### PR TITLE
Configure AWS codebuild and add docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:18-alpine as app
+
+WORKDIR /app
+COPY . .
+
+WORKDIR /app/front
+RUN npm install
+RUN npm run build
+
+WORKDIR /app/server
+RUN npm install
+RUN npm run build
+
+CMD ["npm", "run", "start:prod"]

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,24 @@
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+      - echo Logging in to Amazon ECR...
+      - aws ecr get-login-password --region eu-west-3 | docker login --username AWS --password-stdin 255840220362.dkr.ecr.eu-west-3.amazonaws.com
+  build:
+    commands:
+      - echo Build started on `date`
+      - docker build -t twenty-pilot .
+      - docker tag twenty-pilot 255840220362.dkr.ecr.eu-west-3.amazonaws.com/twenty-pilot:latest
+      - cd $CODEBUILD_SRC_DIR
+  post_build:
+    commands:
+      - echo Build completed on `date`
+      - echo Pushing the Docker images...
+      - docker push 255840220362.dkr.ecr.eu-west-3.amazonaws.com/twenty-pilot:latest
+      - echo Writing image definitions file...
+      - printf '{"AWSEBDockerrunVersion":"1","Image":{"Name":"%s","Update":"true"},"Ports":[{"ContainerPort":3000,"HostPort":80}]}' 255840220362.dkr.ecr.eu-west-3.amazonaws.com/twenty-pilot:latest > Dockerrun.aws.json
+      - cat Dockerrun.aws.json
+
+artifacts:
+  files: Dockerrun.aws.json


### PR DESCRIPTION
I'm adding a support for Docker and also adding support for AWS codebuild.

I've also done some configuration in AWS to enable: ECR, CodePipeline (Source, Build, Deploy) and Elastic Beanstalk. This configuration should move to terraform at some point but this is not something that makes sense at this stage given the maturity of the project.
