### PR TITLE
Implicitly start hasura console

### DIFF
--- a/infra/dev/Makefile
+++ b/infra/dev/Makefile
@@ -38,9 +38,3 @@ hasura-logs: ##
 
 hasura-sh: ##
 	@docker-compose exec twenty-hasura sh
-
-hasura-console: ##
-	@docker-compose exec twenty-hasura bash -c " \
-		socat TCP-LISTEN:9695,fork,reuseaddr,bind=twenty-hasura TCP:127.0.0.1:9695 & \
-		socat TCP-LISTEN:9693,fork,reuseaddr,bind=twenty-hasura TCP:127.0.0.1:9693 & \
-		hasura console --log-level DEBUG --address "127.0.0.1" --no-browser || exit 1"

--- a/infra/dev/hasura/entrypoint.sh
+++ b/infra/dev/hasura/entrypoint.sh
@@ -8,4 +8,8 @@ done
 
 hasura deploy
 
+socat TCP-LISTEN:9695,fork,reuseaddr,bind=twenty-hasura TCP:127.0.0.1:9695 &
+socat TCP-LISTEN:9693,fork,reuseaddr,bind=twenty-hasura TCP:127.0.0.1:9693 &
+hasura console --log-level DEBUG --address "127.0.0.1" --no-browser &
+
 wait


### PR DESCRIPTION
### Why

Implicitly starting the developer console in the dev image leads to a better developer experience.

Most of what we do involves needing access to the console anyway, so the overhead of starting it every time seems negligible.

### What

* Add the commands issued in the `hasura-console` make target to the dev hasura image.
* Remove the, now obsolete, make target for explicitly starting the console.