### PR TITLE
Fix linting after prisma generate

### DIFF
--- a/infra/dev/Makefile
+++ b/infra/dev/Makefile
@@ -32,7 +32,7 @@ server-start:
 server-prisma-generate:
 	@docker-compose exec twenty-dev sh -c "cd /app/server && npm run prisma:generate"
 	@echo "Linting generated files..."
-	@docker-compose exec twenty-dev sh -c "cd /app/server && npx eslint src/api/@generated/* --fix"
+	@docker-compose exec twenty-dev sh -c "cd /app/server && npm run prisma:lint"
 
 server-prisma-migrate:
 	@docker-compose exec twenty-dev sh -c "cd /app/server && npm run prisma:migrate"

--- a/infra/dev/Makefile
+++ b/infra/dev/Makefile
@@ -31,6 +31,8 @@ server-start:
 
 server-prisma-generate:
 	@docker-compose exec twenty-dev sh -c "cd /app/server && npm run prisma:generate"
+	@echo "Linting generated files..."
+	@docker-compose exec twenty-dev sh -c "cd /app/server && npx eslint src/api/@generated/* --fix"
 
 server-prisma-migrate:
 	@docker-compose exec twenty-dev sh -c "cd /app/server && npm run prisma:migrate"

--- a/server/package.json
+++ b/server/package.json
@@ -21,7 +21,8 @@
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "prisma:generate": "npx prisma generate",
     "prisma:migrate": "npx prisma migrate deploy",
-    "prisma:seed": "npx prisma db seed"
+    "prisma:seed": "npx prisma db seed",
+    "prisma:lint": "eslint \"src/api/@generated/**\" --fix"
   },
   "dependencies": {
     "@nestjs/apollo": "^11.0.5",


### PR DESCRIPTION
Lint generated prisma file to avoid having hundreds of git changes due to whitespace differences