### PR TITLE
Fix frontend test: no need to convert to UTC

### DIFF
--- a/front/src/modules/utils/datetime/__tests__/date-utils.test.ts
+++ b/front/src/modules/utils/datetime/__tests__/date-utils.test.ts
@@ -18,7 +18,6 @@ describe('beautifyExactDate', () => {
     const mockDate = '2023-01-01T12:13:24';
     const actualDate = new Date(mockDate);
     const expected = DateTime.fromJSDate(actualDate)
-      .toUTC()
       .setLocale(DEFAULT_DATE_LOCALE)
       .toFormat('DD · TT');
 


### PR DESCRIPTION
This test failed for me locally because I'm not on UTC.
I don't see why we should convert to UTC?