### PR TITLE
Add arrow up/down+enter navigation to select relation

### DIFF
--- a/front/src/modules/ui/components/editable-cell/types/EditableRelation.tsx
+++ b/front/src/modules/ui/components/editable-cell/types/EditableRelation.tsx
@@ -156,7 +156,7 @@ export function EditableRelation<
       setSelectedIndex((prevSelectedIndex) =>
         Math.min(
           prevSelectedIndex + 1,
-          filterSearchResults.results?.length - 1 ?? 0,
+          (filterSearchResults.results?.length ?? 0) - 1,
         ),
       );
     },

--- a/front/src/pages/people/__stories__/People.inputs.stories.tsx
+++ b/front/src/pages/people/__stories__/People.inputs.stories.tsx
@@ -151,3 +151,58 @@ export const EditRelation: Story = {
     ],
   },
 };
+
+export const SelectRelationWithKeys: Story = {
+  render,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const secondRowCompanyCell = await canvas.findByText(
+      mockedPeopleData[1].company.name,
+    );
+
+    await userEvent.click(secondRowCompanyCell);
+
+    const relationInput = await canvas.findByPlaceholderText('Company');
+
+    await userEvent.type(relationInput, 'Air', {
+      delay: 200,
+    });
+
+    await userEvent.type(relationInput, '{arrowdown}');
+    await userEvent.type(relationInput, '{arrowdown}');
+    await userEvent.type(relationInput, '{arrowup}');
+    await userEvent.type(relationInput, '{arrowdown}');
+    await userEvent.type(relationInput, '{enter}');
+
+    const newSecondRowCompanyCell = await canvas.findByText('Aircall');
+    await userEvent.click(newSecondRowCompanyCell);
+  },
+  parameters: {
+    actions: {},
+    msw: [
+      ...graphqlMocks.filter((graphqlMock) => {
+        return graphqlMock.info.operationName !== 'UpdatePeople';
+      }),
+      ...[
+        graphql.mutation('UpdatePeople', (req, res, ctx) => {
+          return res(
+            ctx.data({
+              updateOnePerson: {
+                ...fetchOneFromData(mockedPeopleData, req.variables.id),
+                ...{
+                  company: {
+                    id: req.variables.companyId,
+                    name: 'Aircall',
+                    domainName: 'aircall.io',
+                    __typename: 'Company',
+                  } satisfies GraphqlQueryCompany,
+                },
+              },
+            }),
+          );
+        }),
+      ],
+    ],
+  },
+};

--- a/front/src/pages/people/__stories__/People.inputs.stories.tsx
+++ b/front/src/pages/people/__stories__/People.inputs.stories.tsx
@@ -157,11 +157,11 @@ export const SelectRelationWithKeys: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    const secondRowCompanyCell = await canvas.findByText(
-      mockedPeopleData[1].company.name,
+    const thirdRowCompanyCell = await canvas.findByText(
+      mockedPeopleData[2].company.name,
     );
 
-    await userEvent.click(secondRowCompanyCell);
+    await userEvent.click(thirdRowCompanyCell);
 
     const relationInput = await canvas.findByPlaceholderText('Company');
 
@@ -175,8 +175,8 @@ export const SelectRelationWithKeys: Story = {
     await userEvent.type(relationInput, '{arrowdown}');
     await userEvent.type(relationInput, '{enter}');
 
-    const newSecondRowCompanyCell = await canvas.findByText('Aircall');
-    await userEvent.click(newSecondRowCompanyCell);
+    const newThirdRowCompanyCell = await canvas.findByText('Aircall');
+    await userEvent.click(newThirdRowCompanyCell);
   },
   parameters: {
     actions: {},


### PR DESCRIPTION
It's now possible to use the keyboard to select a company on people view

<img width="197" alt="Screenshot 2023-06-12 at 17 14 49" src="https://github.com/twentyhq/twenty/assets/6399865/5a2b4141-283e-4d91-8bee-7b140613b1b9">
