### PR TITLE
Add workspace scoping to pipeline progress and expose findManyPipelineeProgress on graphql

### DIFF
--- a/infra/dev/Makefile
+++ b/infra/dev/Makefile
@@ -37,3 +37,6 @@ server-prisma-migrate:
 
 server-prisma-seed:
 	@docker-compose exec twenty-dev sh -c "cd /app/server && yarn prisma:seed"
+
+server-prisma-reset:
+	@docker-compose exec twenty-dev sh -c "cd /app/server && yarn prisma:reset"

--- a/server/package.json
+++ b/server/package.json
@@ -21,7 +21,8 @@
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "prisma:generate": "npx prisma generate && eslint \"src/api/@generated/**\" --fix",
     "prisma:migrate": "npx prisma migrate deploy",
-    "prisma:seed": "npx prisma db seed"
+    "prisma:seed": "npx prisma db seed",
+    "prisma:reset": "npm run prisma:generate && npx prisma migrate reset"
   },
   "dependencies": {
     "@apollo/server": "^4.7.3",

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-count-aggregate.input.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-count-aggregate.input.ts
@@ -1,5 +1,6 @@
 import { Field } from '@nestjs/graphql';
 import { InputType } from '@nestjs/graphql';
+import { HideField } from '@nestjs/graphql';
 
 @InputType()
 export class PipelineProgressCountAggregateInput {
@@ -22,10 +23,13 @@ export class PipelineProgressCountAggregateInput {
   pipelineStageId?: true;
 
   @Field(() => Boolean, { nullable: true })
-  associableType?: true;
+  progressableType?: true;
 
   @Field(() => Boolean, { nullable: true })
-  associableId?: true;
+  progressableId?: true;
+
+  @HideField()
+  workspaceId?: true;
 
   @Field(() => Boolean, { nullable: true })
   _all?: true;

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-count-aggregate.output.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-count-aggregate.output.ts
@@ -1,6 +1,7 @@
 import { Field } from '@nestjs/graphql';
 import { ObjectType } from '@nestjs/graphql';
 import { Int } from '@nestjs/graphql';
+import { HideField } from '@nestjs/graphql';
 
 @ObjectType()
 export class PipelineProgressCountAggregate {
@@ -23,10 +24,13 @@ export class PipelineProgressCountAggregate {
   pipelineStageId!: number;
 
   @Field(() => Int, { nullable: false })
-  associableType!: number;
+  progressableType!: number;
 
   @Field(() => Int, { nullable: false })
-  associableId!: number;
+  progressableId!: number;
+
+  @HideField()
+  workspaceId!: number;
 
   @Field(() => Int, { nullable: false })
   _all!: number;

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-count-order-by-aggregate.input.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-count-order-by-aggregate.input.ts
@@ -1,6 +1,7 @@
 import { Field } from '@nestjs/graphql';
 import { InputType } from '@nestjs/graphql';
 import { SortOrder } from '../prisma/sort-order.enum';
+import { HideField } from '@nestjs/graphql';
 
 @InputType()
 export class PipelineProgressCountOrderByAggregateInput {
@@ -23,8 +24,11 @@ export class PipelineProgressCountOrderByAggregateInput {
   pipelineStageId?: keyof typeof SortOrder;
 
   @Field(() => SortOrder, { nullable: true })
-  associableType?: keyof typeof SortOrder;
+  progressableType?: keyof typeof SortOrder;
 
   @Field(() => SortOrder, { nullable: true })
-  associableId?: keyof typeof SortOrder;
+  progressableId?: keyof typeof SortOrder;
+
+  @HideField()
+  workspaceId?: keyof typeof SortOrder;
 }

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-create-many-pipeline-stage.input.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-create-many-pipeline-stage.input.ts
@@ -1,6 +1,7 @@
 import { Field } from '@nestjs/graphql';
 import { InputType } from '@nestjs/graphql';
 import { PipelineProgressableType } from '../prisma/pipeline-progressable-type.enum';
+import { HideField } from '@nestjs/graphql';
 
 @InputType()
 export class PipelineProgressCreateManyPipelineStageInput {
@@ -20,8 +21,11 @@ export class PipelineProgressCreateManyPipelineStageInput {
   pipelineId!: string;
 
   @Field(() => PipelineProgressableType, { nullable: false })
-  associableType!: keyof typeof PipelineProgressableType;
+  progressableType!: keyof typeof PipelineProgressableType;
 
   @Field(() => String, { nullable: false })
-  associableId!: string;
+  progressableId!: string;
+
+  @HideField()
+  workspaceId!: string;
 }

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-create-many-pipeline.input.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-create-many-pipeline.input.ts
@@ -1,6 +1,7 @@
 import { Field } from '@nestjs/graphql';
 import { InputType } from '@nestjs/graphql';
 import { PipelineProgressableType } from '../prisma/pipeline-progressable-type.enum';
+import { HideField } from '@nestjs/graphql';
 
 @InputType()
 export class PipelineProgressCreateManyPipelineInput {
@@ -20,8 +21,11 @@ export class PipelineProgressCreateManyPipelineInput {
   pipelineStageId!: string;
 
   @Field(() => PipelineProgressableType, { nullable: false })
-  associableType!: keyof typeof PipelineProgressableType;
+  progressableType!: keyof typeof PipelineProgressableType;
 
   @Field(() => String, { nullable: false })
-  associableId!: string;
+  progressableId!: string;
+
+  @HideField()
+  workspaceId!: string;
 }

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-create-many-workspace-input-envelope.input.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-create-many-workspace-input-envelope.input.ts
@@ -1,0 +1,14 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { PipelineProgressCreateManyWorkspaceInput } from './pipeline-progress-create-many-workspace.input';
+import { Type } from 'class-transformer';
+
+@InputType()
+export class PipelineProgressCreateManyWorkspaceInputEnvelope {
+  @Field(() => [PipelineProgressCreateManyWorkspaceInput], { nullable: false })
+  @Type(() => PipelineProgressCreateManyWorkspaceInput)
+  data!: Array<PipelineProgressCreateManyWorkspaceInput>;
+
+  @Field(() => Boolean, { nullable: true })
+  skipDuplicates?: boolean;
+}

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-create-many-workspace.input.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-create-many-workspace.input.ts
@@ -1,0 +1,30 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { PipelineProgressableType } from '../prisma/pipeline-progressable-type.enum';
+
+@InputType()
+export class PipelineProgressCreateManyWorkspaceInput {
+  @Field(() => String, { nullable: false })
+  id!: string;
+
+  @Field(() => Date, { nullable: true })
+  createdAt?: Date | string;
+
+  @Field(() => Date, { nullable: true })
+  updatedAt?: Date | string;
+
+  @Field(() => Date, { nullable: true })
+  deletedAt?: Date | string;
+
+  @Field(() => String, { nullable: false })
+  pipelineId!: string;
+
+  @Field(() => String, { nullable: false })
+  pipelineStageId!: string;
+
+  @Field(() => PipelineProgressableType, { nullable: false })
+  progressableType!: keyof typeof PipelineProgressableType;
+
+  @Field(() => String, { nullable: false })
+  progressableId!: string;
+}

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-create-many.input.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-create-many.input.ts
@@ -1,6 +1,7 @@
 import { Field } from '@nestjs/graphql';
 import { InputType } from '@nestjs/graphql';
 import { PipelineProgressableType } from '../prisma/pipeline-progressable-type.enum';
+import { HideField } from '@nestjs/graphql';
 
 @InputType()
 export class PipelineProgressCreateManyInput {
@@ -23,8 +24,11 @@ export class PipelineProgressCreateManyInput {
   pipelineStageId!: string;
 
   @Field(() => PipelineProgressableType, { nullable: false })
-  associableType!: keyof typeof PipelineProgressableType;
+  progressableType!: keyof typeof PipelineProgressableType;
 
   @Field(() => String, { nullable: false })
-  associableId!: string;
+  progressableId!: string;
+
+  @HideField()
+  workspaceId!: string;
 }

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-create-nested-many-without-workspace.input.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-create-nested-many-without-workspace.input.ts
@@ -1,0 +1,32 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { PipelineProgressCreateWithoutWorkspaceInput } from './pipeline-progress-create-without-workspace.input';
+import { Type } from 'class-transformer';
+import { PipelineProgressCreateOrConnectWithoutWorkspaceInput } from './pipeline-progress-create-or-connect-without-workspace.input';
+import { PipelineProgressCreateManyWorkspaceInputEnvelope } from './pipeline-progress-create-many-workspace-input-envelope.input';
+import { PipelineProgressWhereUniqueInput } from './pipeline-progress-where-unique.input';
+
+@InputType()
+export class PipelineProgressCreateNestedManyWithoutWorkspaceInput {
+  @Field(() => [PipelineProgressCreateWithoutWorkspaceInput], {
+    nullable: true,
+  })
+  @Type(() => PipelineProgressCreateWithoutWorkspaceInput)
+  create?: Array<PipelineProgressCreateWithoutWorkspaceInput>;
+
+  @Field(() => [PipelineProgressCreateOrConnectWithoutWorkspaceInput], {
+    nullable: true,
+  })
+  @Type(() => PipelineProgressCreateOrConnectWithoutWorkspaceInput)
+  connectOrCreate?: Array<PipelineProgressCreateOrConnectWithoutWorkspaceInput>;
+
+  @Field(() => PipelineProgressCreateManyWorkspaceInputEnvelope, {
+    nullable: true,
+  })
+  @Type(() => PipelineProgressCreateManyWorkspaceInputEnvelope)
+  createMany?: PipelineProgressCreateManyWorkspaceInputEnvelope;
+
+  @Field(() => [PipelineProgressWhereUniqueInput], { nullable: true })
+  @Type(() => PipelineProgressWhereUniqueInput)
+  connect?: Array<PipelineProgressWhereUniqueInput>;
+}

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-create-or-connect-without-workspace.input.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-create-or-connect-without-workspace.input.ts
@@ -1,0 +1,16 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { PipelineProgressWhereUniqueInput } from './pipeline-progress-where-unique.input';
+import { Type } from 'class-transformer';
+import { PipelineProgressCreateWithoutWorkspaceInput } from './pipeline-progress-create-without-workspace.input';
+
+@InputType()
+export class PipelineProgressCreateOrConnectWithoutWorkspaceInput {
+  @Field(() => PipelineProgressWhereUniqueInput, { nullable: false })
+  @Type(() => PipelineProgressWhereUniqueInput)
+  where!: PipelineProgressWhereUniqueInput;
+
+  @Field(() => PipelineProgressCreateWithoutWorkspaceInput, { nullable: false })
+  @Type(() => PipelineProgressCreateWithoutWorkspaceInput)
+  create!: PipelineProgressCreateWithoutWorkspaceInput;
+}

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-create-without-pipeline-stage.input.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-create-without-pipeline-stage.input.ts
@@ -2,6 +2,8 @@ import { Field } from '@nestjs/graphql';
 import { InputType } from '@nestjs/graphql';
 import { PipelineProgressableType } from '../prisma/pipeline-progressable-type.enum';
 import { PipelineCreateNestedOneWithoutPipelineProgressesInput } from '../pipeline/pipeline-create-nested-one-without-pipeline-progresses.input';
+import { WorkspaceCreateNestedOneWithoutPipelineProgressesInput } from '../workspace/workspace-create-nested-one-without-pipeline-progresses.input';
+import { HideField } from '@nestjs/graphql';
 
 @InputType()
 export class PipelineProgressCreateWithoutPipelineStageInput {
@@ -18,13 +20,16 @@ export class PipelineProgressCreateWithoutPipelineStageInput {
   deletedAt?: Date | string;
 
   @Field(() => PipelineProgressableType, { nullable: false })
-  associableType!: keyof typeof PipelineProgressableType;
+  progressableType!: keyof typeof PipelineProgressableType;
 
   @Field(() => String, { nullable: false })
-  associableId!: string;
+  progressableId!: string;
 
   @Field(() => PipelineCreateNestedOneWithoutPipelineProgressesInput, {
     nullable: false,
   })
   pipeline!: PipelineCreateNestedOneWithoutPipelineProgressesInput;
+
+  @HideField()
+  workspace!: WorkspaceCreateNestedOneWithoutPipelineProgressesInput;
 }

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-create-without-pipeline.input.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-create-without-pipeline.input.ts
@@ -2,6 +2,8 @@ import { Field } from '@nestjs/graphql';
 import { InputType } from '@nestjs/graphql';
 import { PipelineProgressableType } from '../prisma/pipeline-progressable-type.enum';
 import { PipelineStageCreateNestedOneWithoutPipelineProgressesInput } from '../pipeline-stage/pipeline-stage-create-nested-one-without-pipeline-progresses.input';
+import { WorkspaceCreateNestedOneWithoutPipelineProgressesInput } from '../workspace/workspace-create-nested-one-without-pipeline-progresses.input';
+import { HideField } from '@nestjs/graphql';
 
 @InputType()
 export class PipelineProgressCreateWithoutPipelineInput {
@@ -18,13 +20,16 @@ export class PipelineProgressCreateWithoutPipelineInput {
   deletedAt?: Date | string;
 
   @Field(() => PipelineProgressableType, { nullable: false })
-  associableType!: keyof typeof PipelineProgressableType;
+  progressableType!: keyof typeof PipelineProgressableType;
 
   @Field(() => String, { nullable: false })
-  associableId!: string;
+  progressableId!: string;
 
   @Field(() => PipelineStageCreateNestedOneWithoutPipelineProgressesInput, {
     nullable: false,
   })
   pipelineStage!: PipelineStageCreateNestedOneWithoutPipelineProgressesInput;
+
+  @HideField()
+  workspace!: WorkspaceCreateNestedOneWithoutPipelineProgressesInput;
 }

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-create-without-workspace.input.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-create-without-workspace.input.ts
@@ -1,0 +1,36 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { PipelineProgressableType } from '../prisma/pipeline-progressable-type.enum';
+import { PipelineCreateNestedOneWithoutPipelineProgressesInput } from '../pipeline/pipeline-create-nested-one-without-pipeline-progresses.input';
+import { PipelineStageCreateNestedOneWithoutPipelineProgressesInput } from '../pipeline-stage/pipeline-stage-create-nested-one-without-pipeline-progresses.input';
+
+@InputType()
+export class PipelineProgressCreateWithoutWorkspaceInput {
+  @Field(() => String, { nullable: false })
+  id!: string;
+
+  @Field(() => Date, { nullable: true })
+  createdAt?: Date | string;
+
+  @Field(() => Date, { nullable: true })
+  updatedAt?: Date | string;
+
+  @Field(() => Date, { nullable: true })
+  deletedAt?: Date | string;
+
+  @Field(() => PipelineProgressableType, { nullable: false })
+  progressableType!: keyof typeof PipelineProgressableType;
+
+  @Field(() => String, { nullable: false })
+  progressableId!: string;
+
+  @Field(() => PipelineCreateNestedOneWithoutPipelineProgressesInput, {
+    nullable: false,
+  })
+  pipeline!: PipelineCreateNestedOneWithoutPipelineProgressesInput;
+
+  @Field(() => PipelineStageCreateNestedOneWithoutPipelineProgressesInput, {
+    nullable: false,
+  })
+  pipelineStage!: PipelineStageCreateNestedOneWithoutPipelineProgressesInput;
+}

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-create.input.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-create.input.ts
@@ -3,6 +3,8 @@ import { InputType } from '@nestjs/graphql';
 import { PipelineProgressableType } from '../prisma/pipeline-progressable-type.enum';
 import { PipelineCreateNestedOneWithoutPipelineProgressesInput } from '../pipeline/pipeline-create-nested-one-without-pipeline-progresses.input';
 import { PipelineStageCreateNestedOneWithoutPipelineProgressesInput } from '../pipeline-stage/pipeline-stage-create-nested-one-without-pipeline-progresses.input';
+import { WorkspaceCreateNestedOneWithoutPipelineProgressesInput } from '../workspace/workspace-create-nested-one-without-pipeline-progresses.input';
+import { HideField } from '@nestjs/graphql';
 
 @InputType()
 export class PipelineProgressCreateInput {
@@ -19,10 +21,10 @@ export class PipelineProgressCreateInput {
   deletedAt?: Date | string;
 
   @Field(() => PipelineProgressableType, { nullable: false })
-  associableType!: keyof typeof PipelineProgressableType;
+  progressableType!: keyof typeof PipelineProgressableType;
 
   @Field(() => String, { nullable: false })
-  associableId!: string;
+  progressableId!: string;
 
   @Field(() => PipelineCreateNestedOneWithoutPipelineProgressesInput, {
     nullable: false,
@@ -33,4 +35,7 @@ export class PipelineProgressCreateInput {
     nullable: false,
   })
   pipelineStage!: PipelineStageCreateNestedOneWithoutPipelineProgressesInput;
+
+  @HideField()
+  workspace!: WorkspaceCreateNestedOneWithoutPipelineProgressesInput;
 }

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-group-by.output.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-group-by.output.ts
@@ -1,6 +1,7 @@
 import { Field } from '@nestjs/graphql';
 import { ObjectType } from '@nestjs/graphql';
 import { PipelineProgressableType } from '../prisma/pipeline-progressable-type.enum';
+import { HideField } from '@nestjs/graphql';
 import { PipelineProgressCountAggregate } from './pipeline-progress-count-aggregate.output';
 import { PipelineProgressMinAggregate } from './pipeline-progress-min-aggregate.output';
 import { PipelineProgressMaxAggregate } from './pipeline-progress-max-aggregate.output';
@@ -26,10 +27,13 @@ export class PipelineProgressGroupBy {
   pipelineStageId!: string;
 
   @Field(() => PipelineProgressableType, { nullable: false })
-  associableType!: keyof typeof PipelineProgressableType;
+  progressableType!: keyof typeof PipelineProgressableType;
 
   @Field(() => String, { nullable: false })
-  associableId!: string;
+  progressableId!: string;
+
+  @HideField()
+  workspaceId!: string;
 
   @Field(() => PipelineProgressCountAggregate, { nullable: true })
   _count?: PipelineProgressCountAggregate;

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-max-aggregate.input.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-max-aggregate.input.ts
@@ -1,5 +1,6 @@
 import { Field } from '@nestjs/graphql';
 import { InputType } from '@nestjs/graphql';
+import { HideField } from '@nestjs/graphql';
 
 @InputType()
 export class PipelineProgressMaxAggregateInput {
@@ -22,8 +23,11 @@ export class PipelineProgressMaxAggregateInput {
   pipelineStageId?: true;
 
   @Field(() => Boolean, { nullable: true })
-  associableType?: true;
+  progressableType?: true;
 
   @Field(() => Boolean, { nullable: true })
-  associableId?: true;
+  progressableId?: true;
+
+  @HideField()
+  workspaceId?: true;
 }

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-max-aggregate.output.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-max-aggregate.output.ts
@@ -1,6 +1,7 @@
 import { Field } from '@nestjs/graphql';
 import { ObjectType } from '@nestjs/graphql';
 import { PipelineProgressableType } from '../prisma/pipeline-progressable-type.enum';
+import { HideField } from '@nestjs/graphql';
 
 @ObjectType()
 export class PipelineProgressMaxAggregate {
@@ -23,8 +24,11 @@ export class PipelineProgressMaxAggregate {
   pipelineStageId?: string;
 
   @Field(() => PipelineProgressableType, { nullable: true })
-  associableType?: keyof typeof PipelineProgressableType;
+  progressableType?: keyof typeof PipelineProgressableType;
 
   @Field(() => String, { nullable: true })
-  associableId?: string;
+  progressableId?: string;
+
+  @HideField()
+  workspaceId?: string;
 }

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-max-order-by-aggregate.input.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-max-order-by-aggregate.input.ts
@@ -1,6 +1,7 @@
 import { Field } from '@nestjs/graphql';
 import { InputType } from '@nestjs/graphql';
 import { SortOrder } from '../prisma/sort-order.enum';
+import { HideField } from '@nestjs/graphql';
 
 @InputType()
 export class PipelineProgressMaxOrderByAggregateInput {
@@ -23,8 +24,11 @@ export class PipelineProgressMaxOrderByAggregateInput {
   pipelineStageId?: keyof typeof SortOrder;
 
   @Field(() => SortOrder, { nullable: true })
-  associableType?: keyof typeof SortOrder;
+  progressableType?: keyof typeof SortOrder;
 
   @Field(() => SortOrder, { nullable: true })
-  associableId?: keyof typeof SortOrder;
+  progressableId?: keyof typeof SortOrder;
+
+  @HideField()
+  workspaceId?: keyof typeof SortOrder;
 }

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-min-aggregate.input.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-min-aggregate.input.ts
@@ -1,5 +1,6 @@
 import { Field } from '@nestjs/graphql';
 import { InputType } from '@nestjs/graphql';
+import { HideField } from '@nestjs/graphql';
 
 @InputType()
 export class PipelineProgressMinAggregateInput {
@@ -22,8 +23,11 @@ export class PipelineProgressMinAggregateInput {
   pipelineStageId?: true;
 
   @Field(() => Boolean, { nullable: true })
-  associableType?: true;
+  progressableType?: true;
 
   @Field(() => Boolean, { nullable: true })
-  associableId?: true;
+  progressableId?: true;
+
+  @HideField()
+  workspaceId?: true;
 }

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-min-aggregate.output.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-min-aggregate.output.ts
@@ -1,6 +1,7 @@
 import { Field } from '@nestjs/graphql';
 import { ObjectType } from '@nestjs/graphql';
 import { PipelineProgressableType } from '../prisma/pipeline-progressable-type.enum';
+import { HideField } from '@nestjs/graphql';
 
 @ObjectType()
 export class PipelineProgressMinAggregate {
@@ -23,8 +24,11 @@ export class PipelineProgressMinAggregate {
   pipelineStageId?: string;
 
   @Field(() => PipelineProgressableType, { nullable: true })
-  associableType?: keyof typeof PipelineProgressableType;
+  progressableType?: keyof typeof PipelineProgressableType;
 
   @Field(() => String, { nullable: true })
-  associableId?: string;
+  progressableId?: string;
+
+  @HideField()
+  workspaceId?: string;
 }

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-min-order-by-aggregate.input.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-min-order-by-aggregate.input.ts
@@ -1,6 +1,7 @@
 import { Field } from '@nestjs/graphql';
 import { InputType } from '@nestjs/graphql';
 import { SortOrder } from '../prisma/sort-order.enum';
+import { HideField } from '@nestjs/graphql';
 
 @InputType()
 export class PipelineProgressMinOrderByAggregateInput {
@@ -23,8 +24,11 @@ export class PipelineProgressMinOrderByAggregateInput {
   pipelineStageId?: keyof typeof SortOrder;
 
   @Field(() => SortOrder, { nullable: true })
-  associableType?: keyof typeof SortOrder;
+  progressableType?: keyof typeof SortOrder;
 
   @Field(() => SortOrder, { nullable: true })
-  associableId?: keyof typeof SortOrder;
+  progressableId?: keyof typeof SortOrder;
+
+  @HideField()
+  workspaceId?: keyof typeof SortOrder;
 }

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-order-by-with-aggregation.input.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-order-by-with-aggregation.input.ts
@@ -1,6 +1,7 @@
 import { Field } from '@nestjs/graphql';
 import { InputType } from '@nestjs/graphql';
 import { SortOrder } from '../prisma/sort-order.enum';
+import { HideField } from '@nestjs/graphql';
 import { PipelineProgressCountOrderByAggregateInput } from './pipeline-progress-count-order-by-aggregate.input';
 import { PipelineProgressMaxOrderByAggregateInput } from './pipeline-progress-max-order-by-aggregate.input';
 import { PipelineProgressMinOrderByAggregateInput } from './pipeline-progress-min-order-by-aggregate.input';
@@ -26,10 +27,13 @@ export class PipelineProgressOrderByWithAggregationInput {
   pipelineStageId?: keyof typeof SortOrder;
 
   @Field(() => SortOrder, { nullable: true })
-  associableType?: keyof typeof SortOrder;
+  progressableType?: keyof typeof SortOrder;
 
   @Field(() => SortOrder, { nullable: true })
-  associableId?: keyof typeof SortOrder;
+  progressableId?: keyof typeof SortOrder;
+
+  @HideField()
+  workspaceId?: keyof typeof SortOrder;
 
   @Field(() => PipelineProgressCountOrderByAggregateInput, { nullable: true })
   _count?: PipelineProgressCountOrderByAggregateInput;

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-order-by-with-relation.input.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-order-by-with-relation.input.ts
@@ -1,8 +1,10 @@
 import { Field } from '@nestjs/graphql';
 import { InputType } from '@nestjs/graphql';
 import { SortOrder } from '../prisma/sort-order.enum';
+import { HideField } from '@nestjs/graphql';
 import { PipelineOrderByWithRelationInput } from '../pipeline/pipeline-order-by-with-relation.input';
 import { PipelineStageOrderByWithRelationInput } from '../pipeline-stage/pipeline-stage-order-by-with-relation.input';
+import { WorkspaceOrderByWithRelationInput } from '../workspace/workspace-order-by-with-relation.input';
 
 @InputType()
 export class PipelineProgressOrderByWithRelationInput {
@@ -25,14 +27,20 @@ export class PipelineProgressOrderByWithRelationInput {
   pipelineStageId?: keyof typeof SortOrder;
 
   @Field(() => SortOrder, { nullable: true })
-  associableType?: keyof typeof SortOrder;
+  progressableType?: keyof typeof SortOrder;
 
   @Field(() => SortOrder, { nullable: true })
-  associableId?: keyof typeof SortOrder;
+  progressableId?: keyof typeof SortOrder;
+
+  @HideField()
+  workspaceId?: keyof typeof SortOrder;
 
   @Field(() => PipelineOrderByWithRelationInput, { nullable: true })
   pipeline?: PipelineOrderByWithRelationInput;
 
   @Field(() => PipelineStageOrderByWithRelationInput, { nullable: true })
   pipelineStage?: PipelineStageOrderByWithRelationInput;
+
+  @HideField()
+  workspace?: WorkspaceOrderByWithRelationInput;
 }

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-scalar-field.enum.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-scalar-field.enum.ts
@@ -7,8 +7,9 @@ export enum PipelineProgressScalarFieldEnum {
   deletedAt = 'deletedAt',
   pipelineId = 'pipelineId',
   pipelineStageId = 'pipelineStageId',
-  associableType = 'associableType',
-  associableId = 'associableId',
+  progressableType = 'progressableType',
+  progressableId = 'progressableId',
+  workspaceId = 'workspaceId',
 }
 
 registerEnumType(PipelineProgressScalarFieldEnum, {

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-scalar-where-with-aggregates.input.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-scalar-where-with-aggregates.input.ts
@@ -4,6 +4,7 @@ import { StringWithAggregatesFilter } from '../prisma/string-with-aggregates-fil
 import { DateTimeWithAggregatesFilter } from '../prisma/date-time-with-aggregates-filter.input';
 import { DateTimeNullableWithAggregatesFilter } from '../prisma/date-time-nullable-with-aggregates-filter.input';
 import { EnumPipelineProgressableTypeWithAggregatesFilter } from '../prisma/enum-pipeline-progressable-type-with-aggregates-filter.input';
+import { HideField } from '@nestjs/graphql';
 
 @InputType()
 export class PipelineProgressScalarWhereWithAggregatesInput {
@@ -43,8 +44,11 @@ export class PipelineProgressScalarWhereWithAggregatesInput {
   @Field(() => EnumPipelineProgressableTypeWithAggregatesFilter, {
     nullable: true,
   })
-  associableType?: EnumPipelineProgressableTypeWithAggregatesFilter;
+  progressableType?: EnumPipelineProgressableTypeWithAggregatesFilter;
 
   @Field(() => StringWithAggregatesFilter, { nullable: true })
-  associableId?: StringWithAggregatesFilter;
+  progressableId?: StringWithAggregatesFilter;
+
+  @HideField()
+  workspaceId?: StringWithAggregatesFilter;
 }

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-scalar-where.input.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-scalar-where.input.ts
@@ -4,6 +4,7 @@ import { StringFilter } from '../prisma/string-filter.input';
 import { DateTimeFilter } from '../prisma/date-time-filter.input';
 import { DateTimeNullableFilter } from '../prisma/date-time-nullable-filter.input';
 import { EnumPipelineProgressableTypeFilter } from '../prisma/enum-pipeline-progressable-type-filter.input';
+import { HideField } from '@nestjs/graphql';
 
 @InputType()
 export class PipelineProgressScalarWhereInput {
@@ -35,8 +36,11 @@ export class PipelineProgressScalarWhereInput {
   pipelineStageId?: StringFilter;
 
   @Field(() => EnumPipelineProgressableTypeFilter, { nullable: true })
-  associableType?: EnumPipelineProgressableTypeFilter;
+  progressableType?: EnumPipelineProgressableTypeFilter;
 
   @Field(() => StringFilter, { nullable: true })
-  associableId?: StringFilter;
+  progressableId?: StringFilter;
+
+  @HideField()
+  workspaceId?: StringFilter;
 }

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-unchecked-create-nested-many-without-workspace.input.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-unchecked-create-nested-many-without-workspace.input.ts
@@ -1,0 +1,32 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { PipelineProgressCreateWithoutWorkspaceInput } from './pipeline-progress-create-without-workspace.input';
+import { Type } from 'class-transformer';
+import { PipelineProgressCreateOrConnectWithoutWorkspaceInput } from './pipeline-progress-create-or-connect-without-workspace.input';
+import { PipelineProgressCreateManyWorkspaceInputEnvelope } from './pipeline-progress-create-many-workspace-input-envelope.input';
+import { PipelineProgressWhereUniqueInput } from './pipeline-progress-where-unique.input';
+
+@InputType()
+export class PipelineProgressUncheckedCreateNestedManyWithoutWorkspaceInput {
+  @Field(() => [PipelineProgressCreateWithoutWorkspaceInput], {
+    nullable: true,
+  })
+  @Type(() => PipelineProgressCreateWithoutWorkspaceInput)
+  create?: Array<PipelineProgressCreateWithoutWorkspaceInput>;
+
+  @Field(() => [PipelineProgressCreateOrConnectWithoutWorkspaceInput], {
+    nullable: true,
+  })
+  @Type(() => PipelineProgressCreateOrConnectWithoutWorkspaceInput)
+  connectOrCreate?: Array<PipelineProgressCreateOrConnectWithoutWorkspaceInput>;
+
+  @Field(() => PipelineProgressCreateManyWorkspaceInputEnvelope, {
+    nullable: true,
+  })
+  @Type(() => PipelineProgressCreateManyWorkspaceInputEnvelope)
+  createMany?: PipelineProgressCreateManyWorkspaceInputEnvelope;
+
+  @Field(() => [PipelineProgressWhereUniqueInput], { nullable: true })
+  @Type(() => PipelineProgressWhereUniqueInput)
+  connect?: Array<PipelineProgressWhereUniqueInput>;
+}

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-unchecked-create-without-pipeline-stage.input.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-unchecked-create-without-pipeline-stage.input.ts
@@ -1,6 +1,7 @@
 import { Field } from '@nestjs/graphql';
 import { InputType } from '@nestjs/graphql';
 import { PipelineProgressableType } from '../prisma/pipeline-progressable-type.enum';
+import { HideField } from '@nestjs/graphql';
 
 @InputType()
 export class PipelineProgressUncheckedCreateWithoutPipelineStageInput {
@@ -20,8 +21,11 @@ export class PipelineProgressUncheckedCreateWithoutPipelineStageInput {
   pipelineId!: string;
 
   @Field(() => PipelineProgressableType, { nullable: false })
-  associableType!: keyof typeof PipelineProgressableType;
+  progressableType!: keyof typeof PipelineProgressableType;
 
   @Field(() => String, { nullable: false })
-  associableId!: string;
+  progressableId!: string;
+
+  @HideField()
+  workspaceId!: string;
 }

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-unchecked-create-without-pipeline.input.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-unchecked-create-without-pipeline.input.ts
@@ -1,6 +1,7 @@
 import { Field } from '@nestjs/graphql';
 import { InputType } from '@nestjs/graphql';
 import { PipelineProgressableType } from '../prisma/pipeline-progressable-type.enum';
+import { HideField } from '@nestjs/graphql';
 
 @InputType()
 export class PipelineProgressUncheckedCreateWithoutPipelineInput {
@@ -20,8 +21,11 @@ export class PipelineProgressUncheckedCreateWithoutPipelineInput {
   pipelineStageId!: string;
 
   @Field(() => PipelineProgressableType, { nullable: false })
-  associableType!: keyof typeof PipelineProgressableType;
+  progressableType!: keyof typeof PipelineProgressableType;
 
   @Field(() => String, { nullable: false })
-  associableId!: string;
+  progressableId!: string;
+
+  @HideField()
+  workspaceId!: string;
 }

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-unchecked-create-without-workspace.input.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-unchecked-create-without-workspace.input.ts
@@ -1,0 +1,30 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { PipelineProgressableType } from '../prisma/pipeline-progressable-type.enum';
+
+@InputType()
+export class PipelineProgressUncheckedCreateWithoutWorkspaceInput {
+  @Field(() => String, { nullable: false })
+  id!: string;
+
+  @Field(() => Date, { nullable: true })
+  createdAt?: Date | string;
+
+  @Field(() => Date, { nullable: true })
+  updatedAt?: Date | string;
+
+  @Field(() => Date, { nullable: true })
+  deletedAt?: Date | string;
+
+  @Field(() => String, { nullable: false })
+  pipelineId!: string;
+
+  @Field(() => String, { nullable: false })
+  pipelineStageId!: string;
+
+  @Field(() => PipelineProgressableType, { nullable: false })
+  progressableType!: keyof typeof PipelineProgressableType;
+
+  @Field(() => String, { nullable: false })
+  progressableId!: string;
+}

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-unchecked-create.input.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-unchecked-create.input.ts
@@ -1,6 +1,7 @@
 import { Field } from '@nestjs/graphql';
 import { InputType } from '@nestjs/graphql';
 import { PipelineProgressableType } from '../prisma/pipeline-progressable-type.enum';
+import { HideField } from '@nestjs/graphql';
 
 @InputType()
 export class PipelineProgressUncheckedCreateInput {
@@ -23,8 +24,11 @@ export class PipelineProgressUncheckedCreateInput {
   pipelineStageId!: string;
 
   @Field(() => PipelineProgressableType, { nullable: false })
-  associableType!: keyof typeof PipelineProgressableType;
+  progressableType!: keyof typeof PipelineProgressableType;
 
   @Field(() => String, { nullable: false })
-  associableId!: string;
+  progressableId!: string;
+
+  @HideField()
+  workspaceId!: string;
 }

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-unchecked-update-many-without-pipeline-progresses.input.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-unchecked-update-many-without-pipeline-progresses.input.ts
@@ -20,13 +20,16 @@ export class PipelineProgressUncheckedUpdateManyWithoutPipelineProgressesInput {
   deletedAt?: NullableDateTimeFieldUpdateOperationsInput;
 
   @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
+  pipelineId?: StringFieldUpdateOperationsInput;
+
+  @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
   pipelineStageId?: StringFieldUpdateOperationsInput;
 
   @Field(() => EnumPipelineProgressableTypeFieldUpdateOperationsInput, {
     nullable: true,
   })
-  associableType?: EnumPipelineProgressableTypeFieldUpdateOperationsInput;
+  progressableType?: EnumPipelineProgressableTypeFieldUpdateOperationsInput;
 
   @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
-  associableId?: StringFieldUpdateOperationsInput;
+  progressableId?: StringFieldUpdateOperationsInput;
 }

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-unchecked-update-many-without-workspace-nested.input.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-unchecked-update-many-without-workspace-nested.input.ts
@@ -1,0 +1,70 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { PipelineProgressCreateWithoutWorkspaceInput } from './pipeline-progress-create-without-workspace.input';
+import { Type } from 'class-transformer';
+import { PipelineProgressCreateOrConnectWithoutWorkspaceInput } from './pipeline-progress-create-or-connect-without-workspace.input';
+import { PipelineProgressUpsertWithWhereUniqueWithoutWorkspaceInput } from './pipeline-progress-upsert-with-where-unique-without-workspace.input';
+import { PipelineProgressCreateManyWorkspaceInputEnvelope } from './pipeline-progress-create-many-workspace-input-envelope.input';
+import { PipelineProgressWhereUniqueInput } from './pipeline-progress-where-unique.input';
+import { PipelineProgressUpdateWithWhereUniqueWithoutWorkspaceInput } from './pipeline-progress-update-with-where-unique-without-workspace.input';
+import { PipelineProgressUpdateManyWithWhereWithoutWorkspaceInput } from './pipeline-progress-update-many-with-where-without-workspace.input';
+import { PipelineProgressScalarWhereInput } from './pipeline-progress-scalar-where.input';
+
+@InputType()
+export class PipelineProgressUncheckedUpdateManyWithoutWorkspaceNestedInput {
+  @Field(() => [PipelineProgressCreateWithoutWorkspaceInput], {
+    nullable: true,
+  })
+  @Type(() => PipelineProgressCreateWithoutWorkspaceInput)
+  create?: Array<PipelineProgressCreateWithoutWorkspaceInput>;
+
+  @Field(() => [PipelineProgressCreateOrConnectWithoutWorkspaceInput], {
+    nullable: true,
+  })
+  @Type(() => PipelineProgressCreateOrConnectWithoutWorkspaceInput)
+  connectOrCreate?: Array<PipelineProgressCreateOrConnectWithoutWorkspaceInput>;
+
+  @Field(() => [PipelineProgressUpsertWithWhereUniqueWithoutWorkspaceInput], {
+    nullable: true,
+  })
+  @Type(() => PipelineProgressUpsertWithWhereUniqueWithoutWorkspaceInput)
+  upsert?: Array<PipelineProgressUpsertWithWhereUniqueWithoutWorkspaceInput>;
+
+  @Field(() => PipelineProgressCreateManyWorkspaceInputEnvelope, {
+    nullable: true,
+  })
+  @Type(() => PipelineProgressCreateManyWorkspaceInputEnvelope)
+  createMany?: PipelineProgressCreateManyWorkspaceInputEnvelope;
+
+  @Field(() => [PipelineProgressWhereUniqueInput], { nullable: true })
+  @Type(() => PipelineProgressWhereUniqueInput)
+  set?: Array<PipelineProgressWhereUniqueInput>;
+
+  @Field(() => [PipelineProgressWhereUniqueInput], { nullable: true })
+  @Type(() => PipelineProgressWhereUniqueInput)
+  disconnect?: Array<PipelineProgressWhereUniqueInput>;
+
+  @Field(() => [PipelineProgressWhereUniqueInput], { nullable: true })
+  @Type(() => PipelineProgressWhereUniqueInput)
+  delete?: Array<PipelineProgressWhereUniqueInput>;
+
+  @Field(() => [PipelineProgressWhereUniqueInput], { nullable: true })
+  @Type(() => PipelineProgressWhereUniqueInput)
+  connect?: Array<PipelineProgressWhereUniqueInput>;
+
+  @Field(() => [PipelineProgressUpdateWithWhereUniqueWithoutWorkspaceInput], {
+    nullable: true,
+  })
+  @Type(() => PipelineProgressUpdateWithWhereUniqueWithoutWorkspaceInput)
+  update?: Array<PipelineProgressUpdateWithWhereUniqueWithoutWorkspaceInput>;
+
+  @Field(() => [PipelineProgressUpdateManyWithWhereWithoutWorkspaceInput], {
+    nullable: true,
+  })
+  @Type(() => PipelineProgressUpdateManyWithWhereWithoutWorkspaceInput)
+  updateMany?: Array<PipelineProgressUpdateManyWithWhereWithoutWorkspaceInput>;
+
+  @Field(() => [PipelineProgressScalarWhereInput], { nullable: true })
+  @Type(() => PipelineProgressScalarWhereInput)
+  deleteMany?: Array<PipelineProgressScalarWhereInput>;
+}

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-unchecked-update-many.input.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-unchecked-update-many.input.ts
@@ -4,6 +4,7 @@ import { StringFieldUpdateOperationsInput } from '../prisma/string-field-update-
 import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
 import { NullableDateTimeFieldUpdateOperationsInput } from '../prisma/nullable-date-time-field-update-operations.input';
 import { EnumPipelineProgressableTypeFieldUpdateOperationsInput } from '../prisma/enum-pipeline-progressable-type-field-update-operations.input';
+import { HideField } from '@nestjs/graphql';
 
 @InputType()
 export class PipelineProgressUncheckedUpdateManyInput {
@@ -28,8 +29,11 @@ export class PipelineProgressUncheckedUpdateManyInput {
   @Field(() => EnumPipelineProgressableTypeFieldUpdateOperationsInput, {
     nullable: true,
   })
-  associableType?: EnumPipelineProgressableTypeFieldUpdateOperationsInput;
+  progressableType?: EnumPipelineProgressableTypeFieldUpdateOperationsInput;
 
   @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
-  associableId?: StringFieldUpdateOperationsInput;
+  progressableId?: StringFieldUpdateOperationsInput;
+
+  @HideField()
+  workspaceId?: StringFieldUpdateOperationsInput;
 }

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-unchecked-update-without-pipeline-stage.input.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-unchecked-update-without-pipeline-stage.input.ts
@@ -4,6 +4,7 @@ import { StringFieldUpdateOperationsInput } from '../prisma/string-field-update-
 import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
 import { NullableDateTimeFieldUpdateOperationsInput } from '../prisma/nullable-date-time-field-update-operations.input';
 import { EnumPipelineProgressableTypeFieldUpdateOperationsInput } from '../prisma/enum-pipeline-progressable-type-field-update-operations.input';
+import { HideField } from '@nestjs/graphql';
 
 @InputType()
 export class PipelineProgressUncheckedUpdateWithoutPipelineStageInput {
@@ -25,8 +26,11 @@ export class PipelineProgressUncheckedUpdateWithoutPipelineStageInput {
   @Field(() => EnumPipelineProgressableTypeFieldUpdateOperationsInput, {
     nullable: true,
   })
-  associableType?: EnumPipelineProgressableTypeFieldUpdateOperationsInput;
+  progressableType?: EnumPipelineProgressableTypeFieldUpdateOperationsInput;
 
   @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
-  associableId?: StringFieldUpdateOperationsInput;
+  progressableId?: StringFieldUpdateOperationsInput;
+
+  @HideField()
+  workspaceId?: StringFieldUpdateOperationsInput;
 }

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-unchecked-update-without-pipeline.input.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-unchecked-update-without-pipeline.input.ts
@@ -4,6 +4,7 @@ import { StringFieldUpdateOperationsInput } from '../prisma/string-field-update-
 import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
 import { NullableDateTimeFieldUpdateOperationsInput } from '../prisma/nullable-date-time-field-update-operations.input';
 import { EnumPipelineProgressableTypeFieldUpdateOperationsInput } from '../prisma/enum-pipeline-progressable-type-field-update-operations.input';
+import { HideField } from '@nestjs/graphql';
 
 @InputType()
 export class PipelineProgressUncheckedUpdateWithoutPipelineInput {
@@ -25,8 +26,11 @@ export class PipelineProgressUncheckedUpdateWithoutPipelineInput {
   @Field(() => EnumPipelineProgressableTypeFieldUpdateOperationsInput, {
     nullable: true,
   })
-  associableType?: EnumPipelineProgressableTypeFieldUpdateOperationsInput;
+  progressableType?: EnumPipelineProgressableTypeFieldUpdateOperationsInput;
 
   @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
-  associableId?: StringFieldUpdateOperationsInput;
+  progressableId?: StringFieldUpdateOperationsInput;
+
+  @HideField()
+  workspaceId?: StringFieldUpdateOperationsInput;
 }

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-unchecked-update-without-workspace.input.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-unchecked-update-without-workspace.input.ts
@@ -1,0 +1,35 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { StringFieldUpdateOperationsInput } from '../prisma/string-field-update-operations.input';
+import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
+import { NullableDateTimeFieldUpdateOperationsInput } from '../prisma/nullable-date-time-field-update-operations.input';
+import { EnumPipelineProgressableTypeFieldUpdateOperationsInput } from '../prisma/enum-pipeline-progressable-type-field-update-operations.input';
+
+@InputType()
+export class PipelineProgressUncheckedUpdateWithoutWorkspaceInput {
+  @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
+  id?: StringFieldUpdateOperationsInput;
+
+  @Field(() => DateTimeFieldUpdateOperationsInput, { nullable: true })
+  createdAt?: DateTimeFieldUpdateOperationsInput;
+
+  @Field(() => DateTimeFieldUpdateOperationsInput, { nullable: true })
+  updatedAt?: DateTimeFieldUpdateOperationsInput;
+
+  @Field(() => NullableDateTimeFieldUpdateOperationsInput, { nullable: true })
+  deletedAt?: NullableDateTimeFieldUpdateOperationsInput;
+
+  @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
+  pipelineId?: StringFieldUpdateOperationsInput;
+
+  @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
+  pipelineStageId?: StringFieldUpdateOperationsInput;
+
+  @Field(() => EnumPipelineProgressableTypeFieldUpdateOperationsInput, {
+    nullable: true,
+  })
+  progressableType?: EnumPipelineProgressableTypeFieldUpdateOperationsInput;
+
+  @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
+  progressableId?: StringFieldUpdateOperationsInput;
+}

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-unchecked-update.input.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-unchecked-update.input.ts
@@ -4,6 +4,7 @@ import { StringFieldUpdateOperationsInput } from '../prisma/string-field-update-
 import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
 import { NullableDateTimeFieldUpdateOperationsInput } from '../prisma/nullable-date-time-field-update-operations.input';
 import { EnumPipelineProgressableTypeFieldUpdateOperationsInput } from '../prisma/enum-pipeline-progressable-type-field-update-operations.input';
+import { HideField } from '@nestjs/graphql';
 
 @InputType()
 export class PipelineProgressUncheckedUpdateInput {
@@ -28,8 +29,11 @@ export class PipelineProgressUncheckedUpdateInput {
   @Field(() => EnumPipelineProgressableTypeFieldUpdateOperationsInput, {
     nullable: true,
   })
-  associableType?: EnumPipelineProgressableTypeFieldUpdateOperationsInput;
+  progressableType?: EnumPipelineProgressableTypeFieldUpdateOperationsInput;
 
   @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
-  associableId?: StringFieldUpdateOperationsInput;
+  progressableId?: StringFieldUpdateOperationsInput;
+
+  @HideField()
+  workspaceId?: StringFieldUpdateOperationsInput;
 }

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-update-many-mutation.input.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-update-many-mutation.input.ts
@@ -22,8 +22,8 @@ export class PipelineProgressUpdateManyMutationInput {
   @Field(() => EnumPipelineProgressableTypeFieldUpdateOperationsInput, {
     nullable: true,
   })
-  associableType?: EnumPipelineProgressableTypeFieldUpdateOperationsInput;
+  progressableType?: EnumPipelineProgressableTypeFieldUpdateOperationsInput;
 
   @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
-  associableId?: StringFieldUpdateOperationsInput;
+  progressableId?: StringFieldUpdateOperationsInput;
 }

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-update-many-with-where-without-workspace.input.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-update-many-with-where-without-workspace.input.ts
@@ -1,0 +1,16 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { PipelineProgressScalarWhereInput } from './pipeline-progress-scalar-where.input';
+import { Type } from 'class-transformer';
+import { PipelineProgressUpdateManyMutationInput } from './pipeline-progress-update-many-mutation.input';
+
+@InputType()
+export class PipelineProgressUpdateManyWithWhereWithoutWorkspaceInput {
+  @Field(() => PipelineProgressScalarWhereInput, { nullable: false })
+  @Type(() => PipelineProgressScalarWhereInput)
+  where!: PipelineProgressScalarWhereInput;
+
+  @Field(() => PipelineProgressUpdateManyMutationInput, { nullable: false })
+  @Type(() => PipelineProgressUpdateManyMutationInput)
+  data!: PipelineProgressUpdateManyMutationInput;
+}

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-update-many-without-workspace-nested.input.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-update-many-without-workspace-nested.input.ts
@@ -1,0 +1,70 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { PipelineProgressCreateWithoutWorkspaceInput } from './pipeline-progress-create-without-workspace.input';
+import { Type } from 'class-transformer';
+import { PipelineProgressCreateOrConnectWithoutWorkspaceInput } from './pipeline-progress-create-or-connect-without-workspace.input';
+import { PipelineProgressUpsertWithWhereUniqueWithoutWorkspaceInput } from './pipeline-progress-upsert-with-where-unique-without-workspace.input';
+import { PipelineProgressCreateManyWorkspaceInputEnvelope } from './pipeline-progress-create-many-workspace-input-envelope.input';
+import { PipelineProgressWhereUniqueInput } from './pipeline-progress-where-unique.input';
+import { PipelineProgressUpdateWithWhereUniqueWithoutWorkspaceInput } from './pipeline-progress-update-with-where-unique-without-workspace.input';
+import { PipelineProgressUpdateManyWithWhereWithoutWorkspaceInput } from './pipeline-progress-update-many-with-where-without-workspace.input';
+import { PipelineProgressScalarWhereInput } from './pipeline-progress-scalar-where.input';
+
+@InputType()
+export class PipelineProgressUpdateManyWithoutWorkspaceNestedInput {
+  @Field(() => [PipelineProgressCreateWithoutWorkspaceInput], {
+    nullable: true,
+  })
+  @Type(() => PipelineProgressCreateWithoutWorkspaceInput)
+  create?: Array<PipelineProgressCreateWithoutWorkspaceInput>;
+
+  @Field(() => [PipelineProgressCreateOrConnectWithoutWorkspaceInput], {
+    nullable: true,
+  })
+  @Type(() => PipelineProgressCreateOrConnectWithoutWorkspaceInput)
+  connectOrCreate?: Array<PipelineProgressCreateOrConnectWithoutWorkspaceInput>;
+
+  @Field(() => [PipelineProgressUpsertWithWhereUniqueWithoutWorkspaceInput], {
+    nullable: true,
+  })
+  @Type(() => PipelineProgressUpsertWithWhereUniqueWithoutWorkspaceInput)
+  upsert?: Array<PipelineProgressUpsertWithWhereUniqueWithoutWorkspaceInput>;
+
+  @Field(() => PipelineProgressCreateManyWorkspaceInputEnvelope, {
+    nullable: true,
+  })
+  @Type(() => PipelineProgressCreateManyWorkspaceInputEnvelope)
+  createMany?: PipelineProgressCreateManyWorkspaceInputEnvelope;
+
+  @Field(() => [PipelineProgressWhereUniqueInput], { nullable: true })
+  @Type(() => PipelineProgressWhereUniqueInput)
+  set?: Array<PipelineProgressWhereUniqueInput>;
+
+  @Field(() => [PipelineProgressWhereUniqueInput], { nullable: true })
+  @Type(() => PipelineProgressWhereUniqueInput)
+  disconnect?: Array<PipelineProgressWhereUniqueInput>;
+
+  @Field(() => [PipelineProgressWhereUniqueInput], { nullable: true })
+  @Type(() => PipelineProgressWhereUniqueInput)
+  delete?: Array<PipelineProgressWhereUniqueInput>;
+
+  @Field(() => [PipelineProgressWhereUniqueInput], { nullable: true })
+  @Type(() => PipelineProgressWhereUniqueInput)
+  connect?: Array<PipelineProgressWhereUniqueInput>;
+
+  @Field(() => [PipelineProgressUpdateWithWhereUniqueWithoutWorkspaceInput], {
+    nullable: true,
+  })
+  @Type(() => PipelineProgressUpdateWithWhereUniqueWithoutWorkspaceInput)
+  update?: Array<PipelineProgressUpdateWithWhereUniqueWithoutWorkspaceInput>;
+
+  @Field(() => [PipelineProgressUpdateManyWithWhereWithoutWorkspaceInput], {
+    nullable: true,
+  })
+  @Type(() => PipelineProgressUpdateManyWithWhereWithoutWorkspaceInput)
+  updateMany?: Array<PipelineProgressUpdateManyWithWhereWithoutWorkspaceInput>;
+
+  @Field(() => [PipelineProgressScalarWhereInput], { nullable: true })
+  @Type(() => PipelineProgressScalarWhereInput)
+  deleteMany?: Array<PipelineProgressScalarWhereInput>;
+}

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-update-with-where-unique-without-workspace.input.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-update-with-where-unique-without-workspace.input.ts
@@ -1,0 +1,16 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { PipelineProgressWhereUniqueInput } from './pipeline-progress-where-unique.input';
+import { Type } from 'class-transformer';
+import { PipelineProgressUpdateWithoutWorkspaceInput } from './pipeline-progress-update-without-workspace.input';
+
+@InputType()
+export class PipelineProgressUpdateWithWhereUniqueWithoutWorkspaceInput {
+  @Field(() => PipelineProgressWhereUniqueInput, { nullable: false })
+  @Type(() => PipelineProgressWhereUniqueInput)
+  where!: PipelineProgressWhereUniqueInput;
+
+  @Field(() => PipelineProgressUpdateWithoutWorkspaceInput, { nullable: false })
+  @Type(() => PipelineProgressUpdateWithoutWorkspaceInput)
+  data!: PipelineProgressUpdateWithoutWorkspaceInput;
+}

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-update-without-pipeline-stage.input.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-update-without-pipeline-stage.input.ts
@@ -5,6 +5,8 @@ import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-up
 import { NullableDateTimeFieldUpdateOperationsInput } from '../prisma/nullable-date-time-field-update-operations.input';
 import { EnumPipelineProgressableTypeFieldUpdateOperationsInput } from '../prisma/enum-pipeline-progressable-type-field-update-operations.input';
 import { PipelineUpdateOneRequiredWithoutPipelineProgressesNestedInput } from '../pipeline/pipeline-update-one-required-without-pipeline-progresses-nested.input';
+import { WorkspaceUpdateOneRequiredWithoutPipelineProgressesNestedInput } from '../workspace/workspace-update-one-required-without-pipeline-progresses-nested.input';
+import { HideField } from '@nestjs/graphql';
 
 @InputType()
 export class PipelineProgressUpdateWithoutPipelineStageInput {
@@ -23,13 +25,16 @@ export class PipelineProgressUpdateWithoutPipelineStageInput {
   @Field(() => EnumPipelineProgressableTypeFieldUpdateOperationsInput, {
     nullable: true,
   })
-  associableType?: EnumPipelineProgressableTypeFieldUpdateOperationsInput;
+  progressableType?: EnumPipelineProgressableTypeFieldUpdateOperationsInput;
 
   @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
-  associableId?: StringFieldUpdateOperationsInput;
+  progressableId?: StringFieldUpdateOperationsInput;
 
   @Field(() => PipelineUpdateOneRequiredWithoutPipelineProgressesNestedInput, {
     nullable: true,
   })
   pipeline?: PipelineUpdateOneRequiredWithoutPipelineProgressesNestedInput;
+
+  @HideField()
+  workspace?: WorkspaceUpdateOneRequiredWithoutPipelineProgressesNestedInput;
 }

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-update-without-pipeline.input.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-update-without-pipeline.input.ts
@@ -5,6 +5,8 @@ import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-up
 import { NullableDateTimeFieldUpdateOperationsInput } from '../prisma/nullable-date-time-field-update-operations.input';
 import { EnumPipelineProgressableTypeFieldUpdateOperationsInput } from '../prisma/enum-pipeline-progressable-type-field-update-operations.input';
 import { PipelineStageUpdateOneRequiredWithoutPipelineProgressesNestedInput } from '../pipeline-stage/pipeline-stage-update-one-required-without-pipeline-progresses-nested.input';
+import { WorkspaceUpdateOneRequiredWithoutPipelineProgressesNestedInput } from '../workspace/workspace-update-one-required-without-pipeline-progresses-nested.input';
+import { HideField } from '@nestjs/graphql';
 
 @InputType()
 export class PipelineProgressUpdateWithoutPipelineInput {
@@ -23,14 +25,17 @@ export class PipelineProgressUpdateWithoutPipelineInput {
   @Field(() => EnumPipelineProgressableTypeFieldUpdateOperationsInput, {
     nullable: true,
   })
-  associableType?: EnumPipelineProgressableTypeFieldUpdateOperationsInput;
+  progressableType?: EnumPipelineProgressableTypeFieldUpdateOperationsInput;
 
   @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
-  associableId?: StringFieldUpdateOperationsInput;
+  progressableId?: StringFieldUpdateOperationsInput;
 
   @Field(
     () => PipelineStageUpdateOneRequiredWithoutPipelineProgressesNestedInput,
     { nullable: true },
   )
   pipelineStage?: PipelineStageUpdateOneRequiredWithoutPipelineProgressesNestedInput;
+
+  @HideField()
+  workspace?: WorkspaceUpdateOneRequiredWithoutPipelineProgressesNestedInput;
 }

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-update-without-workspace.input.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-update-without-workspace.input.ts
@@ -1,0 +1,42 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { StringFieldUpdateOperationsInput } from '../prisma/string-field-update-operations.input';
+import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
+import { NullableDateTimeFieldUpdateOperationsInput } from '../prisma/nullable-date-time-field-update-operations.input';
+import { EnumPipelineProgressableTypeFieldUpdateOperationsInput } from '../prisma/enum-pipeline-progressable-type-field-update-operations.input';
+import { PipelineUpdateOneRequiredWithoutPipelineProgressesNestedInput } from '../pipeline/pipeline-update-one-required-without-pipeline-progresses-nested.input';
+import { PipelineStageUpdateOneRequiredWithoutPipelineProgressesNestedInput } from '../pipeline-stage/pipeline-stage-update-one-required-without-pipeline-progresses-nested.input';
+
+@InputType()
+export class PipelineProgressUpdateWithoutWorkspaceInput {
+  @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
+  id?: StringFieldUpdateOperationsInput;
+
+  @Field(() => DateTimeFieldUpdateOperationsInput, { nullable: true })
+  createdAt?: DateTimeFieldUpdateOperationsInput;
+
+  @Field(() => DateTimeFieldUpdateOperationsInput, { nullable: true })
+  updatedAt?: DateTimeFieldUpdateOperationsInput;
+
+  @Field(() => NullableDateTimeFieldUpdateOperationsInput, { nullable: true })
+  deletedAt?: NullableDateTimeFieldUpdateOperationsInput;
+
+  @Field(() => EnumPipelineProgressableTypeFieldUpdateOperationsInput, {
+    nullable: true,
+  })
+  progressableType?: EnumPipelineProgressableTypeFieldUpdateOperationsInput;
+
+  @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
+  progressableId?: StringFieldUpdateOperationsInput;
+
+  @Field(() => PipelineUpdateOneRequiredWithoutPipelineProgressesNestedInput, {
+    nullable: true,
+  })
+  pipeline?: PipelineUpdateOneRequiredWithoutPipelineProgressesNestedInput;
+
+  @Field(
+    () => PipelineStageUpdateOneRequiredWithoutPipelineProgressesNestedInput,
+    { nullable: true },
+  )
+  pipelineStage?: PipelineStageUpdateOneRequiredWithoutPipelineProgressesNestedInput;
+}

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-update.input.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-update.input.ts
@@ -6,6 +6,8 @@ import { NullableDateTimeFieldUpdateOperationsInput } from '../prisma/nullable-d
 import { EnumPipelineProgressableTypeFieldUpdateOperationsInput } from '../prisma/enum-pipeline-progressable-type-field-update-operations.input';
 import { PipelineUpdateOneRequiredWithoutPipelineProgressesNestedInput } from '../pipeline/pipeline-update-one-required-without-pipeline-progresses-nested.input';
 import { PipelineStageUpdateOneRequiredWithoutPipelineProgressesNestedInput } from '../pipeline-stage/pipeline-stage-update-one-required-without-pipeline-progresses-nested.input';
+import { WorkspaceUpdateOneRequiredWithoutPipelineProgressesNestedInput } from '../workspace/workspace-update-one-required-without-pipeline-progresses-nested.input';
+import { HideField } from '@nestjs/graphql';
 
 @InputType()
 export class PipelineProgressUpdateInput {
@@ -24,10 +26,10 @@ export class PipelineProgressUpdateInput {
   @Field(() => EnumPipelineProgressableTypeFieldUpdateOperationsInput, {
     nullable: true,
   })
-  associableType?: EnumPipelineProgressableTypeFieldUpdateOperationsInput;
+  progressableType?: EnumPipelineProgressableTypeFieldUpdateOperationsInput;
 
   @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
-  associableId?: StringFieldUpdateOperationsInput;
+  progressableId?: StringFieldUpdateOperationsInput;
 
   @Field(() => PipelineUpdateOneRequiredWithoutPipelineProgressesNestedInput, {
     nullable: true,
@@ -39,4 +41,7 @@ export class PipelineProgressUpdateInput {
     { nullable: true },
   )
   pipelineStage?: PipelineStageUpdateOneRequiredWithoutPipelineProgressesNestedInput;
+
+  @HideField()
+  workspace?: WorkspaceUpdateOneRequiredWithoutPipelineProgressesNestedInput;
 }

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-upsert-with-where-unique-without-workspace.input.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-upsert-with-where-unique-without-workspace.input.ts
@@ -1,0 +1,21 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { PipelineProgressWhereUniqueInput } from './pipeline-progress-where-unique.input';
+import { Type } from 'class-transformer';
+import { PipelineProgressUpdateWithoutWorkspaceInput } from './pipeline-progress-update-without-workspace.input';
+import { PipelineProgressCreateWithoutWorkspaceInput } from './pipeline-progress-create-without-workspace.input';
+
+@InputType()
+export class PipelineProgressUpsertWithWhereUniqueWithoutWorkspaceInput {
+  @Field(() => PipelineProgressWhereUniqueInput, { nullable: false })
+  @Type(() => PipelineProgressWhereUniqueInput)
+  where!: PipelineProgressWhereUniqueInput;
+
+  @Field(() => PipelineProgressUpdateWithoutWorkspaceInput, { nullable: false })
+  @Type(() => PipelineProgressUpdateWithoutWorkspaceInput)
+  update!: PipelineProgressUpdateWithoutWorkspaceInput;
+
+  @Field(() => PipelineProgressCreateWithoutWorkspaceInput, { nullable: false })
+  @Type(() => PipelineProgressCreateWithoutWorkspaceInput)
+  create!: PipelineProgressCreateWithoutWorkspaceInput;
+}

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress-where.input.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress-where.input.ts
@@ -4,8 +4,10 @@ import { StringFilter } from '../prisma/string-filter.input';
 import { DateTimeFilter } from '../prisma/date-time-filter.input';
 import { DateTimeNullableFilter } from '../prisma/date-time-nullable-filter.input';
 import { EnumPipelineProgressableTypeFilter } from '../prisma/enum-pipeline-progressable-type-filter.input';
+import { HideField } from '@nestjs/graphql';
 import { PipelineRelationFilter } from '../pipeline/pipeline-relation-filter.input';
 import { PipelineStageRelationFilter } from '../pipeline-stage/pipeline-stage-relation-filter.input';
+import { WorkspaceRelationFilter } from '../workspace/workspace-relation-filter.input';
 
 @InputType()
 export class PipelineProgressWhereInput {
@@ -37,14 +39,20 @@ export class PipelineProgressWhereInput {
   pipelineStageId?: StringFilter;
 
   @Field(() => EnumPipelineProgressableTypeFilter, { nullable: true })
-  associableType?: EnumPipelineProgressableTypeFilter;
+  progressableType?: EnumPipelineProgressableTypeFilter;
 
   @Field(() => StringFilter, { nullable: true })
-  associableId?: StringFilter;
+  progressableId?: StringFilter;
+
+  @HideField()
+  workspaceId?: StringFilter;
 
   @Field(() => PipelineRelationFilter, { nullable: true })
   pipeline?: PipelineRelationFilter;
 
   @Field(() => PipelineStageRelationFilter, { nullable: true })
   pipelineStage?: PipelineStageRelationFilter;
+
+  @HideField()
+  workspace?: WorkspaceRelationFilter;
 }

--- a/server/src/api/@generated/pipeline-progress/pipeline-progress.model.ts
+++ b/server/src/api/@generated/pipeline-progress/pipeline-progress.model.ts
@@ -2,8 +2,10 @@ import { Field } from '@nestjs/graphql';
 import { ObjectType } from '@nestjs/graphql';
 import { ID } from '@nestjs/graphql';
 import { PipelineProgressableType } from '../prisma/pipeline-progressable-type.enum';
+import { HideField } from '@nestjs/graphql';
 import { Pipeline } from '../pipeline/pipeline.model';
 import { PipelineStage } from '../pipeline-stage/pipeline-stage.model';
+import { Workspace } from '../workspace/workspace.model';
 
 @ObjectType()
 export class PipelineProgress {
@@ -26,14 +28,20 @@ export class PipelineProgress {
   pipelineStageId!: string;
 
   @Field(() => PipelineProgressableType, { nullable: false })
-  associableType!: keyof typeof PipelineProgressableType;
+  progressableType!: keyof typeof PipelineProgressableType;
 
   @Field(() => String, { nullable: false })
-  associableId!: string;
+  progressableId!: string;
+
+  @HideField()
+  workspaceId!: string;
 
   @Field(() => Pipeline, { nullable: false })
   pipeline?: Pipeline;
 
   @Field(() => PipelineStage, { nullable: false })
   pipelineStage?: PipelineStage;
+
+  @HideField()
+  workspace?: Workspace;
 }

--- a/server/src/api/@generated/workspace/workspace-count.output.ts
+++ b/server/src/api/@generated/workspace/workspace-count.output.ts
@@ -24,4 +24,7 @@ export class WorkspaceCount {
 
   @Field(() => Int, { nullable: false })
   pipelineStages?: number;
+
+  @Field(() => Int, { nullable: false })
+  pipelineProgresses?: number;
 }

--- a/server/src/api/@generated/workspace/workspace-create-nested-one-without-pipeline-progresses.input.ts
+++ b/server/src/api/@generated/workspace/workspace-create-nested-one-without-pipeline-progresses.input.ts
@@ -1,0 +1,25 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { WorkspaceCreateWithoutPipelineProgressesInput } from './workspace-create-without-pipeline-progresses.input';
+import { Type } from 'class-transformer';
+import { WorkspaceCreateOrConnectWithoutPipelineProgressesInput } from './workspace-create-or-connect-without-pipeline-progresses.input';
+import { WorkspaceWhereUniqueInput } from './workspace-where-unique.input';
+
+@InputType()
+export class WorkspaceCreateNestedOneWithoutPipelineProgressesInput {
+  @Field(() => WorkspaceCreateWithoutPipelineProgressesInput, {
+    nullable: true,
+  })
+  @Type(() => WorkspaceCreateWithoutPipelineProgressesInput)
+  create?: WorkspaceCreateWithoutPipelineProgressesInput;
+
+  @Field(() => WorkspaceCreateOrConnectWithoutPipelineProgressesInput, {
+    nullable: true,
+  })
+  @Type(() => WorkspaceCreateOrConnectWithoutPipelineProgressesInput)
+  connectOrCreate?: WorkspaceCreateOrConnectWithoutPipelineProgressesInput;
+
+  @Field(() => WorkspaceWhereUniqueInput, { nullable: true })
+  @Type(() => WorkspaceWhereUniqueInput)
+  connect?: WorkspaceWhereUniqueInput;
+}

--- a/server/src/api/@generated/workspace/workspace-create-or-connect-without-pipeline-progresses.input.ts
+++ b/server/src/api/@generated/workspace/workspace-create-or-connect-without-pipeline-progresses.input.ts
@@ -1,0 +1,18 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { WorkspaceWhereUniqueInput } from './workspace-where-unique.input';
+import { Type } from 'class-transformer';
+import { WorkspaceCreateWithoutPipelineProgressesInput } from './workspace-create-without-pipeline-progresses.input';
+
+@InputType()
+export class WorkspaceCreateOrConnectWithoutPipelineProgressesInput {
+  @Field(() => WorkspaceWhereUniqueInput, { nullable: false })
+  @Type(() => WorkspaceWhereUniqueInput)
+  where!: WorkspaceWhereUniqueInput;
+
+  @Field(() => WorkspaceCreateWithoutPipelineProgressesInput, {
+    nullable: false,
+  })
+  @Type(() => WorkspaceCreateWithoutPipelineProgressesInput)
+  create!: WorkspaceCreateWithoutPipelineProgressesInput;
+}

--- a/server/src/api/@generated/workspace/workspace-create-without-comment-threads.input.ts
+++ b/server/src/api/@generated/workspace/workspace-create-without-comment-threads.input.ts
@@ -6,6 +6,7 @@ import { PersonCreateNestedManyWithoutWorkspaceInput } from '../person/person-cr
 import { CommentCreateNestedManyWithoutWorkspaceInput } from '../comment/comment-create-nested-many-without-workspace.input';
 import { PipelineCreateNestedManyWithoutWorkspaceInput } from '../pipeline/pipeline-create-nested-many-without-workspace.input';
 import { PipelineStageCreateNestedManyWithoutWorkspaceInput } from '../pipeline-stage/pipeline-stage-create-nested-many-without-workspace.input';
+import { PipelineProgressCreateNestedManyWithoutWorkspaceInput } from '../pipeline-progress/pipeline-progress-create-nested-many-without-workspace.input';
 
 @InputType()
 export class WorkspaceCreateWithoutCommentThreadsInput {
@@ -53,4 +54,9 @@ export class WorkspaceCreateWithoutCommentThreadsInput {
     nullable: true,
   })
   pipelineStages?: PipelineStageCreateNestedManyWithoutWorkspaceInput;
+
+  @Field(() => PipelineProgressCreateNestedManyWithoutWorkspaceInput, {
+    nullable: true,
+  })
+  pipelineProgresses?: PipelineProgressCreateNestedManyWithoutWorkspaceInput;
 }

--- a/server/src/api/@generated/workspace/workspace-create-without-comments.input.ts
+++ b/server/src/api/@generated/workspace/workspace-create-without-comments.input.ts
@@ -6,6 +6,7 @@ import { PersonCreateNestedManyWithoutWorkspaceInput } from '../person/person-cr
 import { CommentThreadCreateNestedManyWithoutWorkspaceInput } from '../comment-thread/comment-thread-create-nested-many-without-workspace.input';
 import { PipelineCreateNestedManyWithoutWorkspaceInput } from '../pipeline/pipeline-create-nested-many-without-workspace.input';
 import { PipelineStageCreateNestedManyWithoutWorkspaceInput } from '../pipeline-stage/pipeline-stage-create-nested-many-without-workspace.input';
+import { PipelineProgressCreateNestedManyWithoutWorkspaceInput } from '../pipeline-progress/pipeline-progress-create-nested-many-without-workspace.input';
 
 @InputType()
 export class WorkspaceCreateWithoutCommentsInput {
@@ -55,4 +56,9 @@ export class WorkspaceCreateWithoutCommentsInput {
     nullable: true,
   })
   pipelineStages?: PipelineStageCreateNestedManyWithoutWorkspaceInput;
+
+  @Field(() => PipelineProgressCreateNestedManyWithoutWorkspaceInput, {
+    nullable: true,
+  })
+  pipelineProgresses?: PipelineProgressCreateNestedManyWithoutWorkspaceInput;
 }

--- a/server/src/api/@generated/workspace/workspace-create-without-companies.input.ts
+++ b/server/src/api/@generated/workspace/workspace-create-without-companies.input.ts
@@ -6,6 +6,7 @@ import { CommentThreadCreateNestedManyWithoutWorkspaceInput } from '../comment-t
 import { CommentCreateNestedManyWithoutWorkspaceInput } from '../comment/comment-create-nested-many-without-workspace.input';
 import { PipelineCreateNestedManyWithoutWorkspaceInput } from '../pipeline/pipeline-create-nested-many-without-workspace.input';
 import { PipelineStageCreateNestedManyWithoutWorkspaceInput } from '../pipeline-stage/pipeline-stage-create-nested-many-without-workspace.input';
+import { PipelineProgressCreateNestedManyWithoutWorkspaceInput } from '../pipeline-progress/pipeline-progress-create-nested-many-without-workspace.input';
 
 @InputType()
 export class WorkspaceCreateWithoutCompaniesInput {
@@ -55,4 +56,9 @@ export class WorkspaceCreateWithoutCompaniesInput {
     nullable: true,
   })
   pipelineStages?: PipelineStageCreateNestedManyWithoutWorkspaceInput;
+
+  @Field(() => PipelineProgressCreateNestedManyWithoutWorkspaceInput, {
+    nullable: true,
+  })
+  pipelineProgresses?: PipelineProgressCreateNestedManyWithoutWorkspaceInput;
 }

--- a/server/src/api/@generated/workspace/workspace-create-without-people.input.ts
+++ b/server/src/api/@generated/workspace/workspace-create-without-people.input.ts
@@ -6,6 +6,7 @@ import { CommentThreadCreateNestedManyWithoutWorkspaceInput } from '../comment-t
 import { CommentCreateNestedManyWithoutWorkspaceInput } from '../comment/comment-create-nested-many-without-workspace.input';
 import { PipelineCreateNestedManyWithoutWorkspaceInput } from '../pipeline/pipeline-create-nested-many-without-workspace.input';
 import { PipelineStageCreateNestedManyWithoutWorkspaceInput } from '../pipeline-stage/pipeline-stage-create-nested-many-without-workspace.input';
+import { PipelineProgressCreateNestedManyWithoutWorkspaceInput } from '../pipeline-progress/pipeline-progress-create-nested-many-without-workspace.input';
 
 @InputType()
 export class WorkspaceCreateWithoutPeopleInput {
@@ -55,4 +56,9 @@ export class WorkspaceCreateWithoutPeopleInput {
     nullable: true,
   })
   pipelineStages?: PipelineStageCreateNestedManyWithoutWorkspaceInput;
+
+  @Field(() => PipelineProgressCreateNestedManyWithoutWorkspaceInput, {
+    nullable: true,
+  })
+  pipelineProgresses?: PipelineProgressCreateNestedManyWithoutWorkspaceInput;
 }

--- a/server/src/api/@generated/workspace/workspace-create-without-pipeline-progresses.input.ts
+++ b/server/src/api/@generated/workspace/workspace-create-without-pipeline-progresses.input.ts
@@ -1,0 +1,62 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { WorkspaceMemberCreateNestedManyWithoutWorkspaceInput } from '../workspace-member/workspace-member-create-nested-many-without-workspace.input';
+import { CompanyCreateNestedManyWithoutWorkspaceInput } from '../company/company-create-nested-many-without-workspace.input';
+import { PersonCreateNestedManyWithoutWorkspaceInput } from '../person/person-create-nested-many-without-workspace.input';
+import { CommentThreadCreateNestedManyWithoutWorkspaceInput } from '../comment-thread/comment-thread-create-nested-many-without-workspace.input';
+import { CommentCreateNestedManyWithoutWorkspaceInput } from '../comment/comment-create-nested-many-without-workspace.input';
+import { PipelineCreateNestedManyWithoutWorkspaceInput } from '../pipeline/pipeline-create-nested-many-without-workspace.input';
+import { PipelineStageCreateNestedManyWithoutWorkspaceInput } from '../pipeline-stage/pipeline-stage-create-nested-many-without-workspace.input';
+
+@InputType()
+export class WorkspaceCreateWithoutPipelineProgressesInput {
+  @Field(() => String, { nullable: false })
+  id!: string;
+
+  @Field(() => Date, { nullable: true })
+  createdAt?: Date | string;
+
+  @Field(() => Date, { nullable: true })
+  updatedAt?: Date | string;
+
+  @Field(() => Date, { nullable: true })
+  deletedAt?: Date | string;
+
+  @Field(() => String, { nullable: false })
+  domainName!: string;
+
+  @Field(() => String, { nullable: false })
+  displayName!: string;
+
+  @Field(() => String, { nullable: true })
+  logo?: string;
+
+  @Field(() => WorkspaceMemberCreateNestedManyWithoutWorkspaceInput, {
+    nullable: true,
+  })
+  workspaceMember?: WorkspaceMemberCreateNestedManyWithoutWorkspaceInput;
+
+  @Field(() => CompanyCreateNestedManyWithoutWorkspaceInput, { nullable: true })
+  companies?: CompanyCreateNestedManyWithoutWorkspaceInput;
+
+  @Field(() => PersonCreateNestedManyWithoutWorkspaceInput, { nullable: true })
+  people?: PersonCreateNestedManyWithoutWorkspaceInput;
+
+  @Field(() => CommentThreadCreateNestedManyWithoutWorkspaceInput, {
+    nullable: true,
+  })
+  commentThreads?: CommentThreadCreateNestedManyWithoutWorkspaceInput;
+
+  @Field(() => CommentCreateNestedManyWithoutWorkspaceInput, { nullable: true })
+  comments?: CommentCreateNestedManyWithoutWorkspaceInput;
+
+  @Field(() => PipelineCreateNestedManyWithoutWorkspaceInput, {
+    nullable: true,
+  })
+  pipelines?: PipelineCreateNestedManyWithoutWorkspaceInput;
+
+  @Field(() => PipelineStageCreateNestedManyWithoutWorkspaceInput, {
+    nullable: true,
+  })
+  pipelineStages?: PipelineStageCreateNestedManyWithoutWorkspaceInput;
+}

--- a/server/src/api/@generated/workspace/workspace-create-without-pipeline-stages.input.ts
+++ b/server/src/api/@generated/workspace/workspace-create-without-pipeline-stages.input.ts
@@ -6,6 +6,7 @@ import { PersonCreateNestedManyWithoutWorkspaceInput } from '../person/person-cr
 import { CommentThreadCreateNestedManyWithoutWorkspaceInput } from '../comment-thread/comment-thread-create-nested-many-without-workspace.input';
 import { CommentCreateNestedManyWithoutWorkspaceInput } from '../comment/comment-create-nested-many-without-workspace.input';
 import { PipelineCreateNestedManyWithoutWorkspaceInput } from '../pipeline/pipeline-create-nested-many-without-workspace.input';
+import { PipelineProgressCreateNestedManyWithoutWorkspaceInput } from '../pipeline-progress/pipeline-progress-create-nested-many-without-workspace.input';
 
 @InputType()
 export class WorkspaceCreateWithoutPipelineStagesInput {
@@ -53,4 +54,9 @@ export class WorkspaceCreateWithoutPipelineStagesInput {
     nullable: true,
   })
   pipelines?: PipelineCreateNestedManyWithoutWorkspaceInput;
+
+  @Field(() => PipelineProgressCreateNestedManyWithoutWorkspaceInput, {
+    nullable: true,
+  })
+  pipelineProgresses?: PipelineProgressCreateNestedManyWithoutWorkspaceInput;
 }

--- a/server/src/api/@generated/workspace/workspace-create-without-pipelines.input.ts
+++ b/server/src/api/@generated/workspace/workspace-create-without-pipelines.input.ts
@@ -6,6 +6,7 @@ import { PersonCreateNestedManyWithoutWorkspaceInput } from '../person/person-cr
 import { CommentThreadCreateNestedManyWithoutWorkspaceInput } from '../comment-thread/comment-thread-create-nested-many-without-workspace.input';
 import { CommentCreateNestedManyWithoutWorkspaceInput } from '../comment/comment-create-nested-many-without-workspace.input';
 import { PipelineStageCreateNestedManyWithoutWorkspaceInput } from '../pipeline-stage/pipeline-stage-create-nested-many-without-workspace.input';
+import { PipelineProgressCreateNestedManyWithoutWorkspaceInput } from '../pipeline-progress/pipeline-progress-create-nested-many-without-workspace.input';
 
 @InputType()
 export class WorkspaceCreateWithoutPipelinesInput {
@@ -53,4 +54,9 @@ export class WorkspaceCreateWithoutPipelinesInput {
     nullable: true,
   })
   pipelineStages?: PipelineStageCreateNestedManyWithoutWorkspaceInput;
+
+  @Field(() => PipelineProgressCreateNestedManyWithoutWorkspaceInput, {
+    nullable: true,
+  })
+  pipelineProgresses?: PipelineProgressCreateNestedManyWithoutWorkspaceInput;
 }

--- a/server/src/api/@generated/workspace/workspace-create-without-workspace-member.input.ts
+++ b/server/src/api/@generated/workspace/workspace-create-without-workspace-member.input.ts
@@ -6,6 +6,7 @@ import { CommentThreadCreateNestedManyWithoutWorkspaceInput } from '../comment-t
 import { CommentCreateNestedManyWithoutWorkspaceInput } from '../comment/comment-create-nested-many-without-workspace.input';
 import { PipelineCreateNestedManyWithoutWorkspaceInput } from '../pipeline/pipeline-create-nested-many-without-workspace.input';
 import { PipelineStageCreateNestedManyWithoutWorkspaceInput } from '../pipeline-stage/pipeline-stage-create-nested-many-without-workspace.input';
+import { PipelineProgressCreateNestedManyWithoutWorkspaceInput } from '../pipeline-progress/pipeline-progress-create-nested-many-without-workspace.input';
 
 @InputType()
 export class WorkspaceCreateWithoutWorkspaceMemberInput {
@@ -53,4 +54,9 @@ export class WorkspaceCreateWithoutWorkspaceMemberInput {
     nullable: true,
   })
   pipelineStages?: PipelineStageCreateNestedManyWithoutWorkspaceInput;
+
+  @Field(() => PipelineProgressCreateNestedManyWithoutWorkspaceInput, {
+    nullable: true,
+  })
+  pipelineProgresses?: PipelineProgressCreateNestedManyWithoutWorkspaceInput;
 }

--- a/server/src/api/@generated/workspace/workspace-create.input.ts
+++ b/server/src/api/@generated/workspace/workspace-create.input.ts
@@ -7,6 +7,7 @@ import { CommentThreadCreateNestedManyWithoutWorkspaceInput } from '../comment-t
 import { CommentCreateNestedManyWithoutWorkspaceInput } from '../comment/comment-create-nested-many-without-workspace.input';
 import { PipelineCreateNestedManyWithoutWorkspaceInput } from '../pipeline/pipeline-create-nested-many-without-workspace.input';
 import { PipelineStageCreateNestedManyWithoutWorkspaceInput } from '../pipeline-stage/pipeline-stage-create-nested-many-without-workspace.input';
+import { PipelineProgressCreateNestedManyWithoutWorkspaceInput } from '../pipeline-progress/pipeline-progress-create-nested-many-without-workspace.input';
 
 @InputType()
 export class WorkspaceCreateInput {
@@ -59,4 +60,9 @@ export class WorkspaceCreateInput {
     nullable: true,
   })
   pipelineStages?: PipelineStageCreateNestedManyWithoutWorkspaceInput;
+
+  @Field(() => PipelineProgressCreateNestedManyWithoutWorkspaceInput, {
+    nullable: true,
+  })
+  pipelineProgresses?: PipelineProgressCreateNestedManyWithoutWorkspaceInput;
 }

--- a/server/src/api/@generated/workspace/workspace-order-by-with-relation.input.ts
+++ b/server/src/api/@generated/workspace/workspace-order-by-with-relation.input.ts
@@ -8,6 +8,7 @@ import { CommentThreadOrderByRelationAggregateInput } from '../comment-thread/co
 import { CommentOrderByRelationAggregateInput } from '../comment/comment-order-by-relation-aggregate.input';
 import { PipelineOrderByRelationAggregateInput } from '../pipeline/pipeline-order-by-relation-aggregate.input';
 import { PipelineStageOrderByRelationAggregateInput } from '../pipeline-stage/pipeline-stage-order-by-relation-aggregate.input';
+import { PipelineProgressOrderByRelationAggregateInput } from '../pipeline-progress/pipeline-progress-order-by-relation-aggregate.input';
 
 @InputType()
 export class WorkspaceOrderByWithRelationInput {
@@ -52,4 +53,9 @@ export class WorkspaceOrderByWithRelationInput {
 
   @Field(() => PipelineStageOrderByRelationAggregateInput, { nullable: true })
   pipelineStages?: PipelineStageOrderByRelationAggregateInput;
+
+  @Field(() => PipelineProgressOrderByRelationAggregateInput, {
+    nullable: true,
+  })
+  pipelineProgresses?: PipelineProgressOrderByRelationAggregateInput;
 }

--- a/server/src/api/@generated/workspace/workspace-unchecked-create-without-comment-threads.input.ts
+++ b/server/src/api/@generated/workspace/workspace-unchecked-create-without-comment-threads.input.ts
@@ -6,6 +6,7 @@ import { PersonUncheckedCreateNestedManyWithoutWorkspaceInput } from '../person/
 import { CommentUncheckedCreateNestedManyWithoutWorkspaceInput } from '../comment/comment-unchecked-create-nested-many-without-workspace.input';
 import { PipelineUncheckedCreateNestedManyWithoutWorkspaceInput } from '../pipeline/pipeline-unchecked-create-nested-many-without-workspace.input';
 import { PipelineStageUncheckedCreateNestedManyWithoutWorkspaceInput } from '../pipeline-stage/pipeline-stage-unchecked-create-nested-many-without-workspace.input';
+import { PipelineProgressUncheckedCreateNestedManyWithoutWorkspaceInput } from '../pipeline-progress/pipeline-progress-unchecked-create-nested-many-without-workspace.input';
 
 @InputType()
 export class WorkspaceUncheckedCreateWithoutCommentThreadsInput {
@@ -59,4 +60,9 @@ export class WorkspaceUncheckedCreateWithoutCommentThreadsInput {
     nullable: true,
   })
   pipelineStages?: PipelineStageUncheckedCreateNestedManyWithoutWorkspaceInput;
+
+  @Field(() => PipelineProgressUncheckedCreateNestedManyWithoutWorkspaceInput, {
+    nullable: true,
+  })
+  pipelineProgresses?: PipelineProgressUncheckedCreateNestedManyWithoutWorkspaceInput;
 }

--- a/server/src/api/@generated/workspace/workspace-unchecked-create-without-comments.input.ts
+++ b/server/src/api/@generated/workspace/workspace-unchecked-create-without-comments.input.ts
@@ -6,6 +6,7 @@ import { PersonUncheckedCreateNestedManyWithoutWorkspaceInput } from '../person/
 import { CommentThreadUncheckedCreateNestedManyWithoutWorkspaceInput } from '../comment-thread/comment-thread-unchecked-create-nested-many-without-workspace.input';
 import { PipelineUncheckedCreateNestedManyWithoutWorkspaceInput } from '../pipeline/pipeline-unchecked-create-nested-many-without-workspace.input';
 import { PipelineStageUncheckedCreateNestedManyWithoutWorkspaceInput } from '../pipeline-stage/pipeline-stage-unchecked-create-nested-many-without-workspace.input';
+import { PipelineProgressUncheckedCreateNestedManyWithoutWorkspaceInput } from '../pipeline-progress/pipeline-progress-unchecked-create-nested-many-without-workspace.input';
 
 @InputType()
 export class WorkspaceUncheckedCreateWithoutCommentsInput {
@@ -59,4 +60,9 @@ export class WorkspaceUncheckedCreateWithoutCommentsInput {
     nullable: true,
   })
   pipelineStages?: PipelineStageUncheckedCreateNestedManyWithoutWorkspaceInput;
+
+  @Field(() => PipelineProgressUncheckedCreateNestedManyWithoutWorkspaceInput, {
+    nullable: true,
+  })
+  pipelineProgresses?: PipelineProgressUncheckedCreateNestedManyWithoutWorkspaceInput;
 }

--- a/server/src/api/@generated/workspace/workspace-unchecked-create-without-companies.input.ts
+++ b/server/src/api/@generated/workspace/workspace-unchecked-create-without-companies.input.ts
@@ -6,6 +6,7 @@ import { CommentThreadUncheckedCreateNestedManyWithoutWorkspaceInput } from '../
 import { CommentUncheckedCreateNestedManyWithoutWorkspaceInput } from '../comment/comment-unchecked-create-nested-many-without-workspace.input';
 import { PipelineUncheckedCreateNestedManyWithoutWorkspaceInput } from '../pipeline/pipeline-unchecked-create-nested-many-without-workspace.input';
 import { PipelineStageUncheckedCreateNestedManyWithoutWorkspaceInput } from '../pipeline-stage/pipeline-stage-unchecked-create-nested-many-without-workspace.input';
+import { PipelineProgressUncheckedCreateNestedManyWithoutWorkspaceInput } from '../pipeline-progress/pipeline-progress-unchecked-create-nested-many-without-workspace.input';
 
 @InputType()
 export class WorkspaceUncheckedCreateWithoutCompaniesInput {
@@ -59,4 +60,9 @@ export class WorkspaceUncheckedCreateWithoutCompaniesInput {
     nullable: true,
   })
   pipelineStages?: PipelineStageUncheckedCreateNestedManyWithoutWorkspaceInput;
+
+  @Field(() => PipelineProgressUncheckedCreateNestedManyWithoutWorkspaceInput, {
+    nullable: true,
+  })
+  pipelineProgresses?: PipelineProgressUncheckedCreateNestedManyWithoutWorkspaceInput;
 }

--- a/server/src/api/@generated/workspace/workspace-unchecked-create-without-people.input.ts
+++ b/server/src/api/@generated/workspace/workspace-unchecked-create-without-people.input.ts
@@ -6,6 +6,7 @@ import { CommentThreadUncheckedCreateNestedManyWithoutWorkspaceInput } from '../
 import { CommentUncheckedCreateNestedManyWithoutWorkspaceInput } from '../comment/comment-unchecked-create-nested-many-without-workspace.input';
 import { PipelineUncheckedCreateNestedManyWithoutWorkspaceInput } from '../pipeline/pipeline-unchecked-create-nested-many-without-workspace.input';
 import { PipelineStageUncheckedCreateNestedManyWithoutWorkspaceInput } from '../pipeline-stage/pipeline-stage-unchecked-create-nested-many-without-workspace.input';
+import { PipelineProgressUncheckedCreateNestedManyWithoutWorkspaceInput } from '../pipeline-progress/pipeline-progress-unchecked-create-nested-many-without-workspace.input';
 
 @InputType()
 export class WorkspaceUncheckedCreateWithoutPeopleInput {
@@ -59,4 +60,9 @@ export class WorkspaceUncheckedCreateWithoutPeopleInput {
     nullable: true,
   })
   pipelineStages?: PipelineStageUncheckedCreateNestedManyWithoutWorkspaceInput;
+
+  @Field(() => PipelineProgressUncheckedCreateNestedManyWithoutWorkspaceInput, {
+    nullable: true,
+  })
+  pipelineProgresses?: PipelineProgressUncheckedCreateNestedManyWithoutWorkspaceInput;
 }

--- a/server/src/api/@generated/workspace/workspace-unchecked-create-without-pipeline-progresses.input.ts
+++ b/server/src/api/@generated/workspace/workspace-unchecked-create-without-pipeline-progresses.input.ts
@@ -1,0 +1,68 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { WorkspaceMemberUncheckedCreateNestedManyWithoutWorkspaceInput } from '../workspace-member/workspace-member-unchecked-create-nested-many-without-workspace.input';
+import { CompanyUncheckedCreateNestedManyWithoutWorkspaceInput } from '../company/company-unchecked-create-nested-many-without-workspace.input';
+import { PersonUncheckedCreateNestedManyWithoutWorkspaceInput } from '../person/person-unchecked-create-nested-many-without-workspace.input';
+import { CommentThreadUncheckedCreateNestedManyWithoutWorkspaceInput } from '../comment-thread/comment-thread-unchecked-create-nested-many-without-workspace.input';
+import { CommentUncheckedCreateNestedManyWithoutWorkspaceInput } from '../comment/comment-unchecked-create-nested-many-without-workspace.input';
+import { PipelineUncheckedCreateNestedManyWithoutWorkspaceInput } from '../pipeline/pipeline-unchecked-create-nested-many-without-workspace.input';
+import { PipelineStageUncheckedCreateNestedManyWithoutWorkspaceInput } from '../pipeline-stage/pipeline-stage-unchecked-create-nested-many-without-workspace.input';
+
+@InputType()
+export class WorkspaceUncheckedCreateWithoutPipelineProgressesInput {
+  @Field(() => String, { nullable: false })
+  id!: string;
+
+  @Field(() => Date, { nullable: true })
+  createdAt?: Date | string;
+
+  @Field(() => Date, { nullable: true })
+  updatedAt?: Date | string;
+
+  @Field(() => Date, { nullable: true })
+  deletedAt?: Date | string;
+
+  @Field(() => String, { nullable: false })
+  domainName!: string;
+
+  @Field(() => String, { nullable: false })
+  displayName!: string;
+
+  @Field(() => String, { nullable: true })
+  logo?: string;
+
+  @Field(() => WorkspaceMemberUncheckedCreateNestedManyWithoutWorkspaceInput, {
+    nullable: true,
+  })
+  workspaceMember?: WorkspaceMemberUncheckedCreateNestedManyWithoutWorkspaceInput;
+
+  @Field(() => CompanyUncheckedCreateNestedManyWithoutWorkspaceInput, {
+    nullable: true,
+  })
+  companies?: CompanyUncheckedCreateNestedManyWithoutWorkspaceInput;
+
+  @Field(() => PersonUncheckedCreateNestedManyWithoutWorkspaceInput, {
+    nullable: true,
+  })
+  people?: PersonUncheckedCreateNestedManyWithoutWorkspaceInput;
+
+  @Field(() => CommentThreadUncheckedCreateNestedManyWithoutWorkspaceInput, {
+    nullable: true,
+  })
+  commentThreads?: CommentThreadUncheckedCreateNestedManyWithoutWorkspaceInput;
+
+  @Field(() => CommentUncheckedCreateNestedManyWithoutWorkspaceInput, {
+    nullable: true,
+  })
+  comments?: CommentUncheckedCreateNestedManyWithoutWorkspaceInput;
+
+  @Field(() => PipelineUncheckedCreateNestedManyWithoutWorkspaceInput, {
+    nullable: true,
+  })
+  pipelines?: PipelineUncheckedCreateNestedManyWithoutWorkspaceInput;
+
+  @Field(() => PipelineStageUncheckedCreateNestedManyWithoutWorkspaceInput, {
+    nullable: true,
+  })
+  pipelineStages?: PipelineStageUncheckedCreateNestedManyWithoutWorkspaceInput;
+}

--- a/server/src/api/@generated/workspace/workspace-unchecked-create-without-pipeline-stages.input.ts
+++ b/server/src/api/@generated/workspace/workspace-unchecked-create-without-pipeline-stages.input.ts
@@ -6,6 +6,7 @@ import { PersonUncheckedCreateNestedManyWithoutWorkspaceInput } from '../person/
 import { CommentThreadUncheckedCreateNestedManyWithoutWorkspaceInput } from '../comment-thread/comment-thread-unchecked-create-nested-many-without-workspace.input';
 import { CommentUncheckedCreateNestedManyWithoutWorkspaceInput } from '../comment/comment-unchecked-create-nested-many-without-workspace.input';
 import { PipelineUncheckedCreateNestedManyWithoutWorkspaceInput } from '../pipeline/pipeline-unchecked-create-nested-many-without-workspace.input';
+import { PipelineProgressUncheckedCreateNestedManyWithoutWorkspaceInput } from '../pipeline-progress/pipeline-progress-unchecked-create-nested-many-without-workspace.input';
 
 @InputType()
 export class WorkspaceUncheckedCreateWithoutPipelineStagesInput {
@@ -59,4 +60,9 @@ export class WorkspaceUncheckedCreateWithoutPipelineStagesInput {
     nullable: true,
   })
   pipelines?: PipelineUncheckedCreateNestedManyWithoutWorkspaceInput;
+
+  @Field(() => PipelineProgressUncheckedCreateNestedManyWithoutWorkspaceInput, {
+    nullable: true,
+  })
+  pipelineProgresses?: PipelineProgressUncheckedCreateNestedManyWithoutWorkspaceInput;
 }

--- a/server/src/api/@generated/workspace/workspace-unchecked-create-without-pipelines.input.ts
+++ b/server/src/api/@generated/workspace/workspace-unchecked-create-without-pipelines.input.ts
@@ -6,6 +6,7 @@ import { PersonUncheckedCreateNestedManyWithoutWorkspaceInput } from '../person/
 import { CommentThreadUncheckedCreateNestedManyWithoutWorkspaceInput } from '../comment-thread/comment-thread-unchecked-create-nested-many-without-workspace.input';
 import { CommentUncheckedCreateNestedManyWithoutWorkspaceInput } from '../comment/comment-unchecked-create-nested-many-without-workspace.input';
 import { PipelineStageUncheckedCreateNestedManyWithoutWorkspaceInput } from '../pipeline-stage/pipeline-stage-unchecked-create-nested-many-without-workspace.input';
+import { PipelineProgressUncheckedCreateNestedManyWithoutWorkspaceInput } from '../pipeline-progress/pipeline-progress-unchecked-create-nested-many-without-workspace.input';
 
 @InputType()
 export class WorkspaceUncheckedCreateWithoutPipelinesInput {
@@ -59,4 +60,9 @@ export class WorkspaceUncheckedCreateWithoutPipelinesInput {
     nullable: true,
   })
   pipelineStages?: PipelineStageUncheckedCreateNestedManyWithoutWorkspaceInput;
+
+  @Field(() => PipelineProgressUncheckedCreateNestedManyWithoutWorkspaceInput, {
+    nullable: true,
+  })
+  pipelineProgresses?: PipelineProgressUncheckedCreateNestedManyWithoutWorkspaceInput;
 }

--- a/server/src/api/@generated/workspace/workspace-unchecked-create-without-workspace-member.input.ts
+++ b/server/src/api/@generated/workspace/workspace-unchecked-create-without-workspace-member.input.ts
@@ -6,6 +6,7 @@ import { CommentThreadUncheckedCreateNestedManyWithoutWorkspaceInput } from '../
 import { CommentUncheckedCreateNestedManyWithoutWorkspaceInput } from '../comment/comment-unchecked-create-nested-many-without-workspace.input';
 import { PipelineUncheckedCreateNestedManyWithoutWorkspaceInput } from '../pipeline/pipeline-unchecked-create-nested-many-without-workspace.input';
 import { PipelineStageUncheckedCreateNestedManyWithoutWorkspaceInput } from '../pipeline-stage/pipeline-stage-unchecked-create-nested-many-without-workspace.input';
+import { PipelineProgressUncheckedCreateNestedManyWithoutWorkspaceInput } from '../pipeline-progress/pipeline-progress-unchecked-create-nested-many-without-workspace.input';
 
 @InputType()
 export class WorkspaceUncheckedCreateWithoutWorkspaceMemberInput {
@@ -59,4 +60,9 @@ export class WorkspaceUncheckedCreateWithoutWorkspaceMemberInput {
     nullable: true,
   })
   pipelineStages?: PipelineStageUncheckedCreateNestedManyWithoutWorkspaceInput;
+
+  @Field(() => PipelineProgressUncheckedCreateNestedManyWithoutWorkspaceInput, {
+    nullable: true,
+  })
+  pipelineProgresses?: PipelineProgressUncheckedCreateNestedManyWithoutWorkspaceInput;
 }

--- a/server/src/api/@generated/workspace/workspace-unchecked-create.input.ts
+++ b/server/src/api/@generated/workspace/workspace-unchecked-create.input.ts
@@ -7,6 +7,7 @@ import { CommentThreadUncheckedCreateNestedManyWithoutWorkspaceInput } from '../
 import { CommentUncheckedCreateNestedManyWithoutWorkspaceInput } from '../comment/comment-unchecked-create-nested-many-without-workspace.input';
 import { PipelineUncheckedCreateNestedManyWithoutWorkspaceInput } from '../pipeline/pipeline-unchecked-create-nested-many-without-workspace.input';
 import { PipelineStageUncheckedCreateNestedManyWithoutWorkspaceInput } from '../pipeline-stage/pipeline-stage-unchecked-create-nested-many-without-workspace.input';
+import { PipelineProgressUncheckedCreateNestedManyWithoutWorkspaceInput } from '../pipeline-progress/pipeline-progress-unchecked-create-nested-many-without-workspace.input';
 
 @InputType()
 export class WorkspaceUncheckedCreateInput {
@@ -65,4 +66,9 @@ export class WorkspaceUncheckedCreateInput {
     nullable: true,
   })
   pipelineStages?: PipelineStageUncheckedCreateNestedManyWithoutWorkspaceInput;
+
+  @Field(() => PipelineProgressUncheckedCreateNestedManyWithoutWorkspaceInput, {
+    nullable: true,
+  })
+  pipelineProgresses?: PipelineProgressUncheckedCreateNestedManyWithoutWorkspaceInput;
 }

--- a/server/src/api/@generated/workspace/workspace-unchecked-update-without-comment-threads.input.ts
+++ b/server/src/api/@generated/workspace/workspace-unchecked-update-without-comment-threads.input.ts
@@ -10,6 +10,7 @@ import { PersonUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../person/
 import { CommentUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../comment/comment-unchecked-update-many-without-workspace-nested.input';
 import { PipelineUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../pipeline/pipeline-unchecked-update-many-without-workspace-nested.input';
 import { PipelineStageUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../pipeline-stage/pipeline-stage-unchecked-update-many-without-workspace-nested.input';
+import { PipelineProgressUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../pipeline-progress/pipeline-progress-unchecked-update-many-without-workspace-nested.input';
 
 @InputType()
 export class WorkspaceUncheckedUpdateWithoutCommentThreadsInput {
@@ -63,4 +64,9 @@ export class WorkspaceUncheckedUpdateWithoutCommentThreadsInput {
     nullable: true,
   })
   pipelineStages?: PipelineStageUncheckedUpdateManyWithoutWorkspaceNestedInput;
+
+  @Field(() => PipelineProgressUncheckedUpdateManyWithoutWorkspaceNestedInput, {
+    nullable: true,
+  })
+  pipelineProgresses?: PipelineProgressUncheckedUpdateManyWithoutWorkspaceNestedInput;
 }

--- a/server/src/api/@generated/workspace/workspace-unchecked-update-without-comments.input.ts
+++ b/server/src/api/@generated/workspace/workspace-unchecked-update-without-comments.input.ts
@@ -10,6 +10,7 @@ import { PersonUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../person/
 import { CommentThreadUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../comment-thread/comment-thread-unchecked-update-many-without-workspace-nested.input';
 import { PipelineUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../pipeline/pipeline-unchecked-update-many-without-workspace-nested.input';
 import { PipelineStageUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../pipeline-stage/pipeline-stage-unchecked-update-many-without-workspace-nested.input';
+import { PipelineProgressUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../pipeline-progress/pipeline-progress-unchecked-update-many-without-workspace-nested.input';
 
 @InputType()
 export class WorkspaceUncheckedUpdateWithoutCommentsInput {
@@ -63,4 +64,9 @@ export class WorkspaceUncheckedUpdateWithoutCommentsInput {
     nullable: true,
   })
   pipelineStages?: PipelineStageUncheckedUpdateManyWithoutWorkspaceNestedInput;
+
+  @Field(() => PipelineProgressUncheckedUpdateManyWithoutWorkspaceNestedInput, {
+    nullable: true,
+  })
+  pipelineProgresses?: PipelineProgressUncheckedUpdateManyWithoutWorkspaceNestedInput;
 }

--- a/server/src/api/@generated/workspace/workspace-unchecked-update-without-companies.input.ts
+++ b/server/src/api/@generated/workspace/workspace-unchecked-update-without-companies.input.ts
@@ -10,6 +10,7 @@ import { CommentThreadUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../
 import { CommentUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../comment/comment-unchecked-update-many-without-workspace-nested.input';
 import { PipelineUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../pipeline/pipeline-unchecked-update-many-without-workspace-nested.input';
 import { PipelineStageUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../pipeline-stage/pipeline-stage-unchecked-update-many-without-workspace-nested.input';
+import { PipelineProgressUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../pipeline-progress/pipeline-progress-unchecked-update-many-without-workspace-nested.input';
 
 @InputType()
 export class WorkspaceUncheckedUpdateWithoutCompaniesInput {
@@ -63,4 +64,9 @@ export class WorkspaceUncheckedUpdateWithoutCompaniesInput {
     nullable: true,
   })
   pipelineStages?: PipelineStageUncheckedUpdateManyWithoutWorkspaceNestedInput;
+
+  @Field(() => PipelineProgressUncheckedUpdateManyWithoutWorkspaceNestedInput, {
+    nullable: true,
+  })
+  pipelineProgresses?: PipelineProgressUncheckedUpdateManyWithoutWorkspaceNestedInput;
 }

--- a/server/src/api/@generated/workspace/workspace-unchecked-update-without-people.input.ts
+++ b/server/src/api/@generated/workspace/workspace-unchecked-update-without-people.input.ts
@@ -10,6 +10,7 @@ import { CommentThreadUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../
 import { CommentUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../comment/comment-unchecked-update-many-without-workspace-nested.input';
 import { PipelineUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../pipeline/pipeline-unchecked-update-many-without-workspace-nested.input';
 import { PipelineStageUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../pipeline-stage/pipeline-stage-unchecked-update-many-without-workspace-nested.input';
+import { PipelineProgressUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../pipeline-progress/pipeline-progress-unchecked-update-many-without-workspace-nested.input';
 
 @InputType()
 export class WorkspaceUncheckedUpdateWithoutPeopleInput {
@@ -63,4 +64,9 @@ export class WorkspaceUncheckedUpdateWithoutPeopleInput {
     nullable: true,
   })
   pipelineStages?: PipelineStageUncheckedUpdateManyWithoutWorkspaceNestedInput;
+
+  @Field(() => PipelineProgressUncheckedUpdateManyWithoutWorkspaceNestedInput, {
+    nullable: true,
+  })
+  pipelineProgresses?: PipelineProgressUncheckedUpdateManyWithoutWorkspaceNestedInput;
 }

--- a/server/src/api/@generated/workspace/workspace-unchecked-update-without-pipeline-progresses.input.ts
+++ b/server/src/api/@generated/workspace/workspace-unchecked-update-without-pipeline-progresses.input.ts
@@ -1,0 +1,72 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { StringFieldUpdateOperationsInput } from '../prisma/string-field-update-operations.input';
+import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
+import { NullableDateTimeFieldUpdateOperationsInput } from '../prisma/nullable-date-time-field-update-operations.input';
+import { NullableStringFieldUpdateOperationsInput } from '../prisma/nullable-string-field-update-operations.input';
+import { WorkspaceMemberUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../workspace-member/workspace-member-unchecked-update-many-without-workspace-nested.input';
+import { CompanyUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../company/company-unchecked-update-many-without-workspace-nested.input';
+import { PersonUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../person/person-unchecked-update-many-without-workspace-nested.input';
+import { CommentThreadUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../comment-thread/comment-thread-unchecked-update-many-without-workspace-nested.input';
+import { CommentUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../comment/comment-unchecked-update-many-without-workspace-nested.input';
+import { PipelineUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../pipeline/pipeline-unchecked-update-many-without-workspace-nested.input';
+import { PipelineStageUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../pipeline-stage/pipeline-stage-unchecked-update-many-without-workspace-nested.input';
+
+@InputType()
+export class WorkspaceUncheckedUpdateWithoutPipelineProgressesInput {
+  @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
+  id?: StringFieldUpdateOperationsInput;
+
+  @Field(() => DateTimeFieldUpdateOperationsInput, { nullable: true })
+  createdAt?: DateTimeFieldUpdateOperationsInput;
+
+  @Field(() => DateTimeFieldUpdateOperationsInput, { nullable: true })
+  updatedAt?: DateTimeFieldUpdateOperationsInput;
+
+  @Field(() => NullableDateTimeFieldUpdateOperationsInput, { nullable: true })
+  deletedAt?: NullableDateTimeFieldUpdateOperationsInput;
+
+  @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
+  domainName?: StringFieldUpdateOperationsInput;
+
+  @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
+  displayName?: StringFieldUpdateOperationsInput;
+
+  @Field(() => NullableStringFieldUpdateOperationsInput, { nullable: true })
+  logo?: NullableStringFieldUpdateOperationsInput;
+
+  @Field(() => WorkspaceMemberUncheckedUpdateManyWithoutWorkspaceNestedInput, {
+    nullable: true,
+  })
+  workspaceMember?: WorkspaceMemberUncheckedUpdateManyWithoutWorkspaceNestedInput;
+
+  @Field(() => CompanyUncheckedUpdateManyWithoutWorkspaceNestedInput, {
+    nullable: true,
+  })
+  companies?: CompanyUncheckedUpdateManyWithoutWorkspaceNestedInput;
+
+  @Field(() => PersonUncheckedUpdateManyWithoutWorkspaceNestedInput, {
+    nullable: true,
+  })
+  people?: PersonUncheckedUpdateManyWithoutWorkspaceNestedInput;
+
+  @Field(() => CommentThreadUncheckedUpdateManyWithoutWorkspaceNestedInput, {
+    nullable: true,
+  })
+  commentThreads?: CommentThreadUncheckedUpdateManyWithoutWorkspaceNestedInput;
+
+  @Field(() => CommentUncheckedUpdateManyWithoutWorkspaceNestedInput, {
+    nullable: true,
+  })
+  comments?: CommentUncheckedUpdateManyWithoutWorkspaceNestedInput;
+
+  @Field(() => PipelineUncheckedUpdateManyWithoutWorkspaceNestedInput, {
+    nullable: true,
+  })
+  pipelines?: PipelineUncheckedUpdateManyWithoutWorkspaceNestedInput;
+
+  @Field(() => PipelineStageUncheckedUpdateManyWithoutWorkspaceNestedInput, {
+    nullable: true,
+  })
+  pipelineStages?: PipelineStageUncheckedUpdateManyWithoutWorkspaceNestedInput;
+}

--- a/server/src/api/@generated/workspace/workspace-unchecked-update-without-pipeline-stages.input.ts
+++ b/server/src/api/@generated/workspace/workspace-unchecked-update-without-pipeline-stages.input.ts
@@ -10,6 +10,7 @@ import { PersonUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../person/
 import { CommentThreadUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../comment-thread/comment-thread-unchecked-update-many-without-workspace-nested.input';
 import { CommentUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../comment/comment-unchecked-update-many-without-workspace-nested.input';
 import { PipelineUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../pipeline/pipeline-unchecked-update-many-without-workspace-nested.input';
+import { PipelineProgressUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../pipeline-progress/pipeline-progress-unchecked-update-many-without-workspace-nested.input';
 
 @InputType()
 export class WorkspaceUncheckedUpdateWithoutPipelineStagesInput {
@@ -63,4 +64,9 @@ export class WorkspaceUncheckedUpdateWithoutPipelineStagesInput {
     nullable: true,
   })
   pipelines?: PipelineUncheckedUpdateManyWithoutWorkspaceNestedInput;
+
+  @Field(() => PipelineProgressUncheckedUpdateManyWithoutWorkspaceNestedInput, {
+    nullable: true,
+  })
+  pipelineProgresses?: PipelineProgressUncheckedUpdateManyWithoutWorkspaceNestedInput;
 }

--- a/server/src/api/@generated/workspace/workspace-unchecked-update-without-pipelines.input.ts
+++ b/server/src/api/@generated/workspace/workspace-unchecked-update-without-pipelines.input.ts
@@ -10,6 +10,7 @@ import { PersonUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../person/
 import { CommentThreadUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../comment-thread/comment-thread-unchecked-update-many-without-workspace-nested.input';
 import { CommentUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../comment/comment-unchecked-update-many-without-workspace-nested.input';
 import { PipelineStageUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../pipeline-stage/pipeline-stage-unchecked-update-many-without-workspace-nested.input';
+import { PipelineProgressUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../pipeline-progress/pipeline-progress-unchecked-update-many-without-workspace-nested.input';
 
 @InputType()
 export class WorkspaceUncheckedUpdateWithoutPipelinesInput {
@@ -63,4 +64,9 @@ export class WorkspaceUncheckedUpdateWithoutPipelinesInput {
     nullable: true,
   })
   pipelineStages?: PipelineStageUncheckedUpdateManyWithoutWorkspaceNestedInput;
+
+  @Field(() => PipelineProgressUncheckedUpdateManyWithoutWorkspaceNestedInput, {
+    nullable: true,
+  })
+  pipelineProgresses?: PipelineProgressUncheckedUpdateManyWithoutWorkspaceNestedInput;
 }

--- a/server/src/api/@generated/workspace/workspace-unchecked-update-without-workspace-member.input.ts
+++ b/server/src/api/@generated/workspace/workspace-unchecked-update-without-workspace-member.input.ts
@@ -10,6 +10,7 @@ import { CommentThreadUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../
 import { CommentUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../comment/comment-unchecked-update-many-without-workspace-nested.input';
 import { PipelineUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../pipeline/pipeline-unchecked-update-many-without-workspace-nested.input';
 import { PipelineStageUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../pipeline-stage/pipeline-stage-unchecked-update-many-without-workspace-nested.input';
+import { PipelineProgressUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../pipeline-progress/pipeline-progress-unchecked-update-many-without-workspace-nested.input';
 
 @InputType()
 export class WorkspaceUncheckedUpdateWithoutWorkspaceMemberInput {
@@ -63,4 +64,9 @@ export class WorkspaceUncheckedUpdateWithoutWorkspaceMemberInput {
     nullable: true,
   })
   pipelineStages?: PipelineStageUncheckedUpdateManyWithoutWorkspaceNestedInput;
+
+  @Field(() => PipelineProgressUncheckedUpdateManyWithoutWorkspaceNestedInput, {
+    nullable: true,
+  })
+  pipelineProgresses?: PipelineProgressUncheckedUpdateManyWithoutWorkspaceNestedInput;
 }

--- a/server/src/api/@generated/workspace/workspace-unchecked-update.input.ts
+++ b/server/src/api/@generated/workspace/workspace-unchecked-update.input.ts
@@ -11,6 +11,7 @@ import { CommentThreadUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../
 import { CommentUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../comment/comment-unchecked-update-many-without-workspace-nested.input';
 import { PipelineUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../pipeline/pipeline-unchecked-update-many-without-workspace-nested.input';
 import { PipelineStageUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../pipeline-stage/pipeline-stage-unchecked-update-many-without-workspace-nested.input';
+import { PipelineProgressUncheckedUpdateManyWithoutWorkspaceNestedInput } from '../pipeline-progress/pipeline-progress-unchecked-update-many-without-workspace-nested.input';
 
 @InputType()
 export class WorkspaceUncheckedUpdateInput {
@@ -69,4 +70,9 @@ export class WorkspaceUncheckedUpdateInput {
     nullable: true,
   })
   pipelineStages?: PipelineStageUncheckedUpdateManyWithoutWorkspaceNestedInput;
+
+  @Field(() => PipelineProgressUncheckedUpdateManyWithoutWorkspaceNestedInput, {
+    nullable: true,
+  })
+  pipelineProgresses?: PipelineProgressUncheckedUpdateManyWithoutWorkspaceNestedInput;
 }

--- a/server/src/api/@generated/workspace/workspace-update-one-required-without-pipeline-progresses-nested.input.ts
+++ b/server/src/api/@generated/workspace/workspace-update-one-required-without-pipeline-progresses-nested.input.ts
@@ -1,0 +1,39 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { WorkspaceCreateWithoutPipelineProgressesInput } from './workspace-create-without-pipeline-progresses.input';
+import { Type } from 'class-transformer';
+import { WorkspaceCreateOrConnectWithoutPipelineProgressesInput } from './workspace-create-or-connect-without-pipeline-progresses.input';
+import { WorkspaceUpsertWithoutPipelineProgressesInput } from './workspace-upsert-without-pipeline-progresses.input';
+import { WorkspaceWhereUniqueInput } from './workspace-where-unique.input';
+import { WorkspaceUpdateWithoutPipelineProgressesInput } from './workspace-update-without-pipeline-progresses.input';
+
+@InputType()
+export class WorkspaceUpdateOneRequiredWithoutPipelineProgressesNestedInput {
+  @Field(() => WorkspaceCreateWithoutPipelineProgressesInput, {
+    nullable: true,
+  })
+  @Type(() => WorkspaceCreateWithoutPipelineProgressesInput)
+  create?: WorkspaceCreateWithoutPipelineProgressesInput;
+
+  @Field(() => WorkspaceCreateOrConnectWithoutPipelineProgressesInput, {
+    nullable: true,
+  })
+  @Type(() => WorkspaceCreateOrConnectWithoutPipelineProgressesInput)
+  connectOrCreate?: WorkspaceCreateOrConnectWithoutPipelineProgressesInput;
+
+  @Field(() => WorkspaceUpsertWithoutPipelineProgressesInput, {
+    nullable: true,
+  })
+  @Type(() => WorkspaceUpsertWithoutPipelineProgressesInput)
+  upsert?: WorkspaceUpsertWithoutPipelineProgressesInput;
+
+  @Field(() => WorkspaceWhereUniqueInput, { nullable: true })
+  @Type(() => WorkspaceWhereUniqueInput)
+  connect?: WorkspaceWhereUniqueInput;
+
+  @Field(() => WorkspaceUpdateWithoutPipelineProgressesInput, {
+    nullable: true,
+  })
+  @Type(() => WorkspaceUpdateWithoutPipelineProgressesInput)
+  update?: WorkspaceUpdateWithoutPipelineProgressesInput;
+}

--- a/server/src/api/@generated/workspace/workspace-update-without-comment-threads.input.ts
+++ b/server/src/api/@generated/workspace/workspace-update-without-comment-threads.input.ts
@@ -10,6 +10,7 @@ import { PersonUpdateManyWithoutWorkspaceNestedInput } from '../person/person-up
 import { CommentUpdateManyWithoutWorkspaceNestedInput } from '../comment/comment-update-many-without-workspace-nested.input';
 import { PipelineUpdateManyWithoutWorkspaceNestedInput } from '../pipeline/pipeline-update-many-without-workspace-nested.input';
 import { PipelineStageUpdateManyWithoutWorkspaceNestedInput } from '../pipeline-stage/pipeline-stage-update-many-without-workspace-nested.input';
+import { PipelineProgressUpdateManyWithoutWorkspaceNestedInput } from '../pipeline-progress/pipeline-progress-update-many-without-workspace-nested.input';
 
 @InputType()
 export class WorkspaceUpdateWithoutCommentThreadsInput {
@@ -57,4 +58,9 @@ export class WorkspaceUpdateWithoutCommentThreadsInput {
     nullable: true,
   })
   pipelineStages?: PipelineStageUpdateManyWithoutWorkspaceNestedInput;
+
+  @Field(() => PipelineProgressUpdateManyWithoutWorkspaceNestedInput, {
+    nullable: true,
+  })
+  pipelineProgresses?: PipelineProgressUpdateManyWithoutWorkspaceNestedInput;
 }

--- a/server/src/api/@generated/workspace/workspace-update-without-comments.input.ts
+++ b/server/src/api/@generated/workspace/workspace-update-without-comments.input.ts
@@ -10,6 +10,7 @@ import { PersonUpdateManyWithoutWorkspaceNestedInput } from '../person/person-up
 import { CommentThreadUpdateManyWithoutWorkspaceNestedInput } from '../comment-thread/comment-thread-update-many-without-workspace-nested.input';
 import { PipelineUpdateManyWithoutWorkspaceNestedInput } from '../pipeline/pipeline-update-many-without-workspace-nested.input';
 import { PipelineStageUpdateManyWithoutWorkspaceNestedInput } from '../pipeline-stage/pipeline-stage-update-many-without-workspace-nested.input';
+import { PipelineProgressUpdateManyWithoutWorkspaceNestedInput } from '../pipeline-progress/pipeline-progress-update-many-without-workspace-nested.input';
 
 @InputType()
 export class WorkspaceUpdateWithoutCommentsInput {
@@ -59,4 +60,9 @@ export class WorkspaceUpdateWithoutCommentsInput {
     nullable: true,
   })
   pipelineStages?: PipelineStageUpdateManyWithoutWorkspaceNestedInput;
+
+  @Field(() => PipelineProgressUpdateManyWithoutWorkspaceNestedInput, {
+    nullable: true,
+  })
+  pipelineProgresses?: PipelineProgressUpdateManyWithoutWorkspaceNestedInput;
 }

--- a/server/src/api/@generated/workspace/workspace-update-without-companies.input.ts
+++ b/server/src/api/@generated/workspace/workspace-update-without-companies.input.ts
@@ -10,6 +10,7 @@ import { CommentThreadUpdateManyWithoutWorkspaceNestedInput } from '../comment-t
 import { CommentUpdateManyWithoutWorkspaceNestedInput } from '../comment/comment-update-many-without-workspace-nested.input';
 import { PipelineUpdateManyWithoutWorkspaceNestedInput } from '../pipeline/pipeline-update-many-without-workspace-nested.input';
 import { PipelineStageUpdateManyWithoutWorkspaceNestedInput } from '../pipeline-stage/pipeline-stage-update-many-without-workspace-nested.input';
+import { PipelineProgressUpdateManyWithoutWorkspaceNestedInput } from '../pipeline-progress/pipeline-progress-update-many-without-workspace-nested.input';
 
 @InputType()
 export class WorkspaceUpdateWithoutCompaniesInput {
@@ -59,4 +60,9 @@ export class WorkspaceUpdateWithoutCompaniesInput {
     nullable: true,
   })
   pipelineStages?: PipelineStageUpdateManyWithoutWorkspaceNestedInput;
+
+  @Field(() => PipelineProgressUpdateManyWithoutWorkspaceNestedInput, {
+    nullable: true,
+  })
+  pipelineProgresses?: PipelineProgressUpdateManyWithoutWorkspaceNestedInput;
 }

--- a/server/src/api/@generated/workspace/workspace-update-without-people.input.ts
+++ b/server/src/api/@generated/workspace/workspace-update-without-people.input.ts
@@ -10,6 +10,7 @@ import { CommentThreadUpdateManyWithoutWorkspaceNestedInput } from '../comment-t
 import { CommentUpdateManyWithoutWorkspaceNestedInput } from '../comment/comment-update-many-without-workspace-nested.input';
 import { PipelineUpdateManyWithoutWorkspaceNestedInput } from '../pipeline/pipeline-update-many-without-workspace-nested.input';
 import { PipelineStageUpdateManyWithoutWorkspaceNestedInput } from '../pipeline-stage/pipeline-stage-update-many-without-workspace-nested.input';
+import { PipelineProgressUpdateManyWithoutWorkspaceNestedInput } from '../pipeline-progress/pipeline-progress-update-many-without-workspace-nested.input';
 
 @InputType()
 export class WorkspaceUpdateWithoutPeopleInput {
@@ -59,4 +60,9 @@ export class WorkspaceUpdateWithoutPeopleInput {
     nullable: true,
   })
   pipelineStages?: PipelineStageUpdateManyWithoutWorkspaceNestedInput;
+
+  @Field(() => PipelineProgressUpdateManyWithoutWorkspaceNestedInput, {
+    nullable: true,
+  })
+  pipelineProgresses?: PipelineProgressUpdateManyWithoutWorkspaceNestedInput;
 }

--- a/server/src/api/@generated/workspace/workspace-update-without-pipeline-progresses.input.ts
+++ b/server/src/api/@generated/workspace/workspace-update-without-pipeline-progresses.input.ts
@@ -1,0 +1,66 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { StringFieldUpdateOperationsInput } from '../prisma/string-field-update-operations.input';
+import { DateTimeFieldUpdateOperationsInput } from '../prisma/date-time-field-update-operations.input';
+import { NullableDateTimeFieldUpdateOperationsInput } from '../prisma/nullable-date-time-field-update-operations.input';
+import { NullableStringFieldUpdateOperationsInput } from '../prisma/nullable-string-field-update-operations.input';
+import { WorkspaceMemberUpdateManyWithoutWorkspaceNestedInput } from '../workspace-member/workspace-member-update-many-without-workspace-nested.input';
+import { CompanyUpdateManyWithoutWorkspaceNestedInput } from '../company/company-update-many-without-workspace-nested.input';
+import { PersonUpdateManyWithoutWorkspaceNestedInput } from '../person/person-update-many-without-workspace-nested.input';
+import { CommentThreadUpdateManyWithoutWorkspaceNestedInput } from '../comment-thread/comment-thread-update-many-without-workspace-nested.input';
+import { CommentUpdateManyWithoutWorkspaceNestedInput } from '../comment/comment-update-many-without-workspace-nested.input';
+import { PipelineUpdateManyWithoutWorkspaceNestedInput } from '../pipeline/pipeline-update-many-without-workspace-nested.input';
+import { PipelineStageUpdateManyWithoutWorkspaceNestedInput } from '../pipeline-stage/pipeline-stage-update-many-without-workspace-nested.input';
+
+@InputType()
+export class WorkspaceUpdateWithoutPipelineProgressesInput {
+  @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
+  id?: StringFieldUpdateOperationsInput;
+
+  @Field(() => DateTimeFieldUpdateOperationsInput, { nullable: true })
+  createdAt?: DateTimeFieldUpdateOperationsInput;
+
+  @Field(() => DateTimeFieldUpdateOperationsInput, { nullable: true })
+  updatedAt?: DateTimeFieldUpdateOperationsInput;
+
+  @Field(() => NullableDateTimeFieldUpdateOperationsInput, { nullable: true })
+  deletedAt?: NullableDateTimeFieldUpdateOperationsInput;
+
+  @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
+  domainName?: StringFieldUpdateOperationsInput;
+
+  @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
+  displayName?: StringFieldUpdateOperationsInput;
+
+  @Field(() => NullableStringFieldUpdateOperationsInput, { nullable: true })
+  logo?: NullableStringFieldUpdateOperationsInput;
+
+  @Field(() => WorkspaceMemberUpdateManyWithoutWorkspaceNestedInput, {
+    nullable: true,
+  })
+  workspaceMember?: WorkspaceMemberUpdateManyWithoutWorkspaceNestedInput;
+
+  @Field(() => CompanyUpdateManyWithoutWorkspaceNestedInput, { nullable: true })
+  companies?: CompanyUpdateManyWithoutWorkspaceNestedInput;
+
+  @Field(() => PersonUpdateManyWithoutWorkspaceNestedInput, { nullable: true })
+  people?: PersonUpdateManyWithoutWorkspaceNestedInput;
+
+  @Field(() => CommentThreadUpdateManyWithoutWorkspaceNestedInput, {
+    nullable: true,
+  })
+  commentThreads?: CommentThreadUpdateManyWithoutWorkspaceNestedInput;
+
+  @Field(() => CommentUpdateManyWithoutWorkspaceNestedInput, { nullable: true })
+  comments?: CommentUpdateManyWithoutWorkspaceNestedInput;
+
+  @Field(() => PipelineUpdateManyWithoutWorkspaceNestedInput, {
+    nullable: true,
+  })
+  pipelines?: PipelineUpdateManyWithoutWorkspaceNestedInput;
+
+  @Field(() => PipelineStageUpdateManyWithoutWorkspaceNestedInput, {
+    nullable: true,
+  })
+  pipelineStages?: PipelineStageUpdateManyWithoutWorkspaceNestedInput;
+}

--- a/server/src/api/@generated/workspace/workspace-update-without-pipeline-stages.input.ts
+++ b/server/src/api/@generated/workspace/workspace-update-without-pipeline-stages.input.ts
@@ -10,6 +10,7 @@ import { PersonUpdateManyWithoutWorkspaceNestedInput } from '../person/person-up
 import { CommentThreadUpdateManyWithoutWorkspaceNestedInput } from '../comment-thread/comment-thread-update-many-without-workspace-nested.input';
 import { CommentUpdateManyWithoutWorkspaceNestedInput } from '../comment/comment-update-many-without-workspace-nested.input';
 import { PipelineUpdateManyWithoutWorkspaceNestedInput } from '../pipeline/pipeline-update-many-without-workspace-nested.input';
+import { PipelineProgressUpdateManyWithoutWorkspaceNestedInput } from '../pipeline-progress/pipeline-progress-update-many-without-workspace-nested.input';
 
 @InputType()
 export class WorkspaceUpdateWithoutPipelineStagesInput {
@@ -57,4 +58,9 @@ export class WorkspaceUpdateWithoutPipelineStagesInput {
     nullable: true,
   })
   pipelines?: PipelineUpdateManyWithoutWorkspaceNestedInput;
+
+  @Field(() => PipelineProgressUpdateManyWithoutWorkspaceNestedInput, {
+    nullable: true,
+  })
+  pipelineProgresses?: PipelineProgressUpdateManyWithoutWorkspaceNestedInput;
 }

--- a/server/src/api/@generated/workspace/workspace-update-without-pipelines.input.ts
+++ b/server/src/api/@generated/workspace/workspace-update-without-pipelines.input.ts
@@ -10,6 +10,7 @@ import { PersonUpdateManyWithoutWorkspaceNestedInput } from '../person/person-up
 import { CommentThreadUpdateManyWithoutWorkspaceNestedInput } from '../comment-thread/comment-thread-update-many-without-workspace-nested.input';
 import { CommentUpdateManyWithoutWorkspaceNestedInput } from '../comment/comment-update-many-without-workspace-nested.input';
 import { PipelineStageUpdateManyWithoutWorkspaceNestedInput } from '../pipeline-stage/pipeline-stage-update-many-without-workspace-nested.input';
+import { PipelineProgressUpdateManyWithoutWorkspaceNestedInput } from '../pipeline-progress/pipeline-progress-update-many-without-workspace-nested.input';
 
 @InputType()
 export class WorkspaceUpdateWithoutPipelinesInput {
@@ -57,4 +58,9 @@ export class WorkspaceUpdateWithoutPipelinesInput {
     nullable: true,
   })
   pipelineStages?: PipelineStageUpdateManyWithoutWorkspaceNestedInput;
+
+  @Field(() => PipelineProgressUpdateManyWithoutWorkspaceNestedInput, {
+    nullable: true,
+  })
+  pipelineProgresses?: PipelineProgressUpdateManyWithoutWorkspaceNestedInput;
 }

--- a/server/src/api/@generated/workspace/workspace-update-without-workspace-member.input.ts
+++ b/server/src/api/@generated/workspace/workspace-update-without-workspace-member.input.ts
@@ -10,6 +10,7 @@ import { CommentThreadUpdateManyWithoutWorkspaceNestedInput } from '../comment-t
 import { CommentUpdateManyWithoutWorkspaceNestedInput } from '../comment/comment-update-many-without-workspace-nested.input';
 import { PipelineUpdateManyWithoutWorkspaceNestedInput } from '../pipeline/pipeline-update-many-without-workspace-nested.input';
 import { PipelineStageUpdateManyWithoutWorkspaceNestedInput } from '../pipeline-stage/pipeline-stage-update-many-without-workspace-nested.input';
+import { PipelineProgressUpdateManyWithoutWorkspaceNestedInput } from '../pipeline-progress/pipeline-progress-update-many-without-workspace-nested.input';
 
 @InputType()
 export class WorkspaceUpdateWithoutWorkspaceMemberInput {
@@ -57,4 +58,9 @@ export class WorkspaceUpdateWithoutWorkspaceMemberInput {
     nullable: true,
   })
   pipelineStages?: PipelineStageUpdateManyWithoutWorkspaceNestedInput;
+
+  @Field(() => PipelineProgressUpdateManyWithoutWorkspaceNestedInput, {
+    nullable: true,
+  })
+  pipelineProgresses?: PipelineProgressUpdateManyWithoutWorkspaceNestedInput;
 }

--- a/server/src/api/@generated/workspace/workspace-update.input.ts
+++ b/server/src/api/@generated/workspace/workspace-update.input.ts
@@ -11,6 +11,7 @@ import { CommentThreadUpdateManyWithoutWorkspaceNestedInput } from '../comment-t
 import { CommentUpdateManyWithoutWorkspaceNestedInput } from '../comment/comment-update-many-without-workspace-nested.input';
 import { PipelineUpdateManyWithoutWorkspaceNestedInput } from '../pipeline/pipeline-update-many-without-workspace-nested.input';
 import { PipelineStageUpdateManyWithoutWorkspaceNestedInput } from '../pipeline-stage/pipeline-stage-update-many-without-workspace-nested.input';
+import { PipelineProgressUpdateManyWithoutWorkspaceNestedInput } from '../pipeline-progress/pipeline-progress-update-many-without-workspace-nested.input';
 
 @InputType()
 export class WorkspaceUpdateInput {
@@ -63,4 +64,9 @@ export class WorkspaceUpdateInput {
     nullable: true,
   })
   pipelineStages?: PipelineStageUpdateManyWithoutWorkspaceNestedInput;
+
+  @Field(() => PipelineProgressUpdateManyWithoutWorkspaceNestedInput, {
+    nullable: true,
+  })
+  pipelineProgresses?: PipelineProgressUpdateManyWithoutWorkspaceNestedInput;
 }

--- a/server/src/api/@generated/workspace/workspace-upsert-without-pipeline-progresses.input.ts
+++ b/server/src/api/@generated/workspace/workspace-upsert-without-pipeline-progresses.input.ts
@@ -1,0 +1,20 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { WorkspaceUpdateWithoutPipelineProgressesInput } from './workspace-update-without-pipeline-progresses.input';
+import { Type } from 'class-transformer';
+import { WorkspaceCreateWithoutPipelineProgressesInput } from './workspace-create-without-pipeline-progresses.input';
+
+@InputType()
+export class WorkspaceUpsertWithoutPipelineProgressesInput {
+  @Field(() => WorkspaceUpdateWithoutPipelineProgressesInput, {
+    nullable: false,
+  })
+  @Type(() => WorkspaceUpdateWithoutPipelineProgressesInput)
+  update!: WorkspaceUpdateWithoutPipelineProgressesInput;
+
+  @Field(() => WorkspaceCreateWithoutPipelineProgressesInput, {
+    nullable: false,
+  })
+  @Type(() => WorkspaceCreateWithoutPipelineProgressesInput)
+  create!: WorkspaceCreateWithoutPipelineProgressesInput;
+}

--- a/server/src/api/@generated/workspace/workspace-where.input.ts
+++ b/server/src/api/@generated/workspace/workspace-where.input.ts
@@ -11,6 +11,7 @@ import { CommentThreadListRelationFilter } from '../comment-thread/comment-threa
 import { CommentListRelationFilter } from '../comment/comment-list-relation-filter.input';
 import { PipelineListRelationFilter } from '../pipeline/pipeline-list-relation-filter.input';
 import { PipelineStageListRelationFilter } from '../pipeline-stage/pipeline-stage-list-relation-filter.input';
+import { PipelineProgressListRelationFilter } from '../pipeline-progress/pipeline-progress-list-relation-filter.input';
 
 @InputType()
 export class WorkspaceWhereInput {
@@ -64,4 +65,7 @@ export class WorkspaceWhereInput {
 
   @Field(() => PipelineStageListRelationFilter, { nullable: true })
   pipelineStages?: PipelineStageListRelationFilter;
+
+  @Field(() => PipelineProgressListRelationFilter, { nullable: true })
+  pipelineProgresses?: PipelineProgressListRelationFilter;
 }

--- a/server/src/api/@generated/workspace/workspace.model.ts
+++ b/server/src/api/@generated/workspace/workspace.model.ts
@@ -8,6 +8,7 @@ import { CommentThread } from '../comment-thread/comment-thread.model';
 import { Comment } from '../comment/comment.model';
 import { Pipeline } from '../pipeline/pipeline.model';
 import { PipelineStage } from '../pipeline-stage/pipeline-stage.model';
+import { PipelineProgress } from '../pipeline-progress/pipeline-progress.model';
 import { WorkspaceCount } from './workspace-count.output';
 import { HideField } from '@nestjs/graphql';
 
@@ -54,6 +55,9 @@ export class Workspace {
 
   @Field(() => [PipelineStage], { nullable: true })
   pipelineStages?: Array<PipelineStage>;
+
+  @Field(() => [PipelineProgress], { nullable: true })
+  pipelineProgresses?: Array<PipelineProgress>;
 
   @HideField()
   _count?: WorkspaceCount;

--- a/server/src/api/api.module.ts
+++ b/server/src/api/api.module.ts
@@ -21,9 +21,11 @@ import { WorkspaceMemberRelationsResolver } from './resolvers/relations/workspac
 import { CompanyRelationsResolver } from './resolvers/relations/company-relations.resolver';
 import { CommentThreadRelationsResolver } from './resolvers/relations/comment-thread-relations.resolver';
 import { PipelineRelationsResolver } from './resolvers/relations/pipeline-relations.resolver';
-import { PipelineStageRelationsResolver } from './resolvers/relations/pipeline-stage-relations.resolver';
 import { GraphQLError } from 'graphql';
 import { CommentRelationsResolver } from './resolvers/relations/comment-relations.resolver';
+import { PipelineProgressResolver } from './resolvers/pipeline-progress.resolver';
+import { PipelineStageRelationsResolver } from './resolvers/relations/pipeline-stage-relations.resolver';
+import { PipelineProgressRelationsResolver } from './resolvers/relations/pipeline-progress-relations.resolver';
 
 @Module({
   imports: [
@@ -50,6 +52,7 @@ import { CommentRelationsResolver } from './resolvers/relations/comment-relation
     CommentThreadResolver,
     PipelineResolver,
     PipelineStageResolver,
+    PipelineProgressResolver,
 
     CompanyRelationsResolver,
     CommentRelationsResolver,
@@ -59,6 +62,7 @@ import { CommentRelationsResolver } from './resolvers/relations/comment-relation
     CommentThreadRelationsResolver,
     PipelineRelationsResolver,
     PipelineStageRelationsResolver,
+    PipelineProgressRelationsResolver,
   ],
 })
 export class ApiModule {}

--- a/server/src/api/resolvers/pipeline-progress.resolver.ts
+++ b/server/src/api/resolvers/pipeline-progress.resolver.ts
@@ -1,0 +1,31 @@
+import { Resolver, Args, Query } from '@nestjs/graphql';
+import { UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from 'src/auth/guards/jwt.auth.guard';
+import { PrismaService } from 'src/database/prisma.service';
+import { Workspace } from '../@generated/workspace/workspace.model';
+import { AuthWorkspace } from './decorators/auth-workspace.decorator';
+import { ArgsService } from './services/args.service';
+import { FindManyPipelineProgressArgs } from '../@generated/pipeline-progress/find-many-pipeline-progress.args';
+import { PipelineProgress } from '../@generated/pipeline-progress/pipeline-progress.model';
+
+@UseGuards(JwtAuthGuard)
+@Resolver(() => PipelineProgress)
+export class PipelineProgressResolver {
+  constructor(
+    private readonly prismaService: PrismaService,
+    private readonly argsService: ArgsService,
+  ) {}
+
+  @Query(() => [PipelineProgress])
+  async findManyPipelineProgress(
+    @Args() args: FindManyPipelineProgressArgs,
+    @AuthWorkspace() workspace: Workspace,
+  ) {
+    const preparedArgs =
+      await this.argsService.prepareFindManyArgs<FindManyPipelineProgressArgs>(
+        args,
+        workspace,
+      );
+    return this.prismaService.pipelineProgress.findMany(preparedArgs);
+  }
+}

--- a/server/src/api/resolvers/relations/pipeline-progress-relations.resolver.ts
+++ b/server/src/api/resolvers/relations/pipeline-progress-relations.resolver.ts
@@ -1,0 +1,36 @@
+import * as TypeGraphQL from '@nestjs/graphql';
+import { PipelineProgress } from 'src/api/@generated/pipeline-progress/pipeline-progress.model';
+import { PipelineStage } from 'src/api/@generated/pipeline-stage/pipeline-stage.model';
+import { Pipeline } from 'src/api/@generated/pipeline/pipeline.model';
+import { PrismaService } from 'src/database/prisma.service';
+
+@TypeGraphQL.Resolver(() => PipelineProgress)
+export class PipelineProgressRelationsResolver {
+  constructor(private readonly prismaService: PrismaService) {}
+
+  @TypeGraphQL.ResolveField(() => PipelineStage, {
+    nullable: false,
+  })
+  async pipelineStage(
+    @TypeGraphQL.Root() pipelineStage: PipelineProgress,
+  ): Promise<PipelineStage> {
+    return this.prismaService.pipelineStage.findUniqueOrThrow({
+      where: {
+        id: pipelineStage.pipelineStageId,
+      },
+    });
+  }
+
+  @TypeGraphQL.ResolveField(() => Pipeline, {
+    nullable: false,
+  })
+  async pipeline(
+    @TypeGraphQL.Root() pipelineStage: PipelineProgress,
+  ): Promise<Pipeline> {
+    return this.prismaService.pipeline.findUniqueOrThrow({
+      where: {
+        id: pipelineStage.pipelineId,
+      },
+    });
+  }
+}

--- a/server/src/api/resolvers/relations/pipeline-relations.resolver.ts
+++ b/server/src/api/resolvers/relations/pipeline-relations.resolver.ts
@@ -1,5 +1,4 @@
 import * as TypeGraphQL from '@nestjs/graphql';
-import { Comment } from 'src/api/@generated/comment/comment.model';
 import { PipelineStage } from 'src/api/@generated/pipeline-stage/pipeline-stage.model';
 import { Pipeline } from 'src/api/@generated/pipeline/pipeline.model';
 import { PrismaService } from 'src/database/prisma.service';
@@ -8,7 +7,7 @@ import { PrismaService } from 'src/database/prisma.service';
 export class PipelineRelationsResolver {
   constructor(private readonly prismaService: PrismaService) {}
 
-  @TypeGraphQL.ResolveField(() => [Comment], {
+  @TypeGraphQL.ResolveField(() => [PipelineStage], {
     nullable: false,
   })
   async pipelineStages(

--- a/server/src/api/resolvers/relations/pipeline-stage-relations.resolver.ts
+++ b/server/src/api/resolvers/relations/pipeline-stage-relations.resolver.ts
@@ -1,5 +1,4 @@
 import * as TypeGraphQL from '@nestjs/graphql';
-import { Comment } from 'src/api/@generated/comment/comment.model';
 import { PipelineProgress } from 'src/api/@generated/pipeline-progress/pipeline-progress.model';
 import { PipelineStage } from 'src/api/@generated/pipeline-stage/pipeline-stage.model';
 import { PrismaService } from 'src/database/prisma.service';
@@ -8,7 +7,7 @@ import { PrismaService } from 'src/database/prisma.service';
 export class PipelineStageRelationsResolver {
   constructor(private readonly prismaService: PrismaService) {}
 
-  @TypeGraphQL.ResolveField(() => [Comment], {
+  @TypeGraphQL.ResolveField(() => [PipelineProgress], {
     nullable: false,
   })
   async pipelineProgresses(

--- a/server/src/database/migrations/20230613132410_rename_pipeline_progress_associable/migration.sql
+++ b/server/src/database/migrations/20230613132410_rename_pipeline_progress_associable/migration.sql
@@ -1,0 +1,13 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `associableId` on the `pipeline_progresses` table. All the data in the column will be lost.
+  - You are about to drop the column `associableType` on the `pipeline_progresses` table. All the data in the column will be lost.
+  - Added the required column `progressableId` to the `pipeline_progresses` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `progressableType` to the `pipeline_progresses` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "pipeline_progresses" RENAME "associableId" TO "progressableId";
+ALTER TABLE "pipeline_progresses" RENAME "associableType" TO "progressableType";
+

--- a/server/src/database/migrations/20230614090456_add_workspace_to_pipeline_progress/migration.sql
+++ b/server/src/database/migrations/20230614090456_add_workspace_to_pipeline_progress/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - Added the required column `workspaceId` to the `pipeline_progresses` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "pipeline_progresses" ADD COLUMN     "workspaceId" TEXT NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "pipeline_progresses" ADD CONSTRAINT "pipeline_progresses_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES "workspaces"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/server/src/database/schema.prisma
+++ b/server/src/database/schema.prisma
@@ -113,20 +113,21 @@ model User {
 
 /// @TypeGraphQL.omit(input: true)
 model Workspace {
-  id              String            @id
-  createdAt       DateTime          @default(now())
-  updatedAt       DateTime          @updatedAt
-  deletedAt       DateTime?
-  domainName      String            @unique
-  displayName     String
-  logo            String?
-  workspaceMember WorkspaceMember[]
-  companies       Company[]
-  people          Person[]
-  commentThreads  CommentThread[]
-  comments        Comment[]
-  pipelines       Pipeline[]
-  pipelineStages  PipelineStage[]
+  id                 String            @id
+  createdAt          DateTime          @default(now())
+  updatedAt          DateTime          @updatedAt
+  deletedAt          DateTime?
+  domainName         String            @unique
+  displayName        String
+  logo               String?
+  workspaceMember    WorkspaceMember[]
+  companies          Company[]
+  people             Person[]
+  commentThreads     CommentThread[]
+  comments           Comment[]
+  pipelines          Pipeline[]
+  pipelineStages     PipelineStage[]
+  pipelineProgresses PipelineProgress[]
 
   @@map("workspaces")
 }
@@ -310,8 +311,13 @@ model PipelineProgress {
   pipelineStageId       String
   pipelineStage         PipelineStage @relation(fields: [pipelineStageId], references: [id])
 
-  associableType        PipelineProgressableType
-  associableId          String
+  progressableType      PipelineProgressableType
+  progressableId        String
+
+    /// @TypeGraphQL.omit(input: true, output: true)
+  workspaceId           String
+  /// @TypeGraphQL.omit(input: true, output: true)
+  workspace             Workspace @relation(fields: [workspaceId], references: [id])
 
   @@map("pipeline_progresses")
 }

--- a/server/src/database/seeds/pipelines.ts
+++ b/server/src/database/seeds/pipelines.ts
@@ -83,8 +83,9 @@ export const seedPipelines = async (prisma: PrismaClient) => {
       id: 'twenty-fe256b39-3ec3-4fe7-8998-b76aa0bfb600',
       pipelineId: 'twenty-fe256b39-3ec3-4fe3-8997-b75aa0bfb400',
       pipelineStageId: 'twenty-fe256b39-3ec3-4fe3-8998-b76aa0bfb600',
-      associableType: 'Person',
-      associableId: 'twenty-755035db-623d-41fe-92e7-dd45b7c568e1',
+      progressableType: 'Person',
+      progressableId: 'twenty-755035db-623d-41fe-92e7-dd45b7c568e1',
+      workspaceId: 'twenty-7ed9d212-1c25-4d02-bf25-6aeccf7ea419',
     },
   });
 
@@ -119,8 +120,9 @@ export const seedPipelines = async (prisma: PrismaClient) => {
       id: 'twenty-fe256b39-3ec3-4fe7-8998-b76aa0bfb600',
       pipelineId: 'twenty-fe256b39-3ec3-4fe3-8997-b74aa0bfb400',
       pipelineStageId: 'twenty-fe256b39-3ec3-4fe3-8998-a76aa0bfb600',
-      associableType: 'Person',
-      associableId: 'twenty-755035db-623d-41fe-92e7-dd45b7c568e1',
+      progressableType: 'Person',
+      progressableId: 'twenty-755035db-623d-41fe-92e7-dd45b7c568e1',
+      workspaceId: 'twenty-7ed9d212-1c25-4d02-bf25-6aeccf7ea419',
     },
   });
 
@@ -207,8 +209,9 @@ export const seedPipelines = async (prisma: PrismaClient) => {
       id: 'twenty-dev-fe256b39-3ec3-4fe7-8998-b76aa0bfb600',
       pipelineId: 'twenty-dev-fe256b39-3ec3-4fe3-8997-b75aa0bfb400',
       pipelineStageId: 'twenty-dev-fe256b39-3ec3-4fe3-8998-b76aa0bfb600',
-      associableType: 'Company',
-      associableId: 'twenty-dev-a674fa6c-1455-4c57-afaf-dd5dc086361e',
+      progressableType: 'Company',
+      progressableId: 'twenty-dev-a674fa6c-1455-4c57-afaf-dd5dc086361e',
+      workspaceId: 'twenty-dev-7ed9d212-1c25-4d02-bf25-6aeccf7ea420',
     },
   });
 };


### PR DESCRIPTION
- Adding workspace on PipelineProgress
- renaming PipelineProgress associableType to progressableType

- Introducing findManyPipelineProgress
```
    {
    "operationName": "GetPipelineProgresses",
    "variables": {
        "orderBy": [
            {
                "createdAt": "desc"
            }
        ],
        "where": {}
    },
    "query": "query GetPipelineProgresses($orderBy: [PipelineProgressOrderByWithRelationInput!], $where: PipelineProgressWhereInput, $limit: Int) {\n  pipelineProgresses: findManyPipelineProgress(orderBy: $orderBy, where: $where, take: $limit) {\n    id\n  progressableType\n  progressableId\n    pipelineStage{\n id\n }\n pipeline{\n id\n }\n    __typename\n  }\n}"
}
```

Reponse:
```
{
    "data": {
        "pipelineProgresses": [
            {
                "id": "twenty-fe256b39-3ec3-4fe7-8998-b76aa0bfb600",
                "progressableType": "Person",
                "progressableId": "twenty-755035db-623d-41fe-92e7-dd45b7c568e1",
                "pipelineStage": {
                    "id": "twenty-fe256b39-3ec3-4fe3-8998-b76aa0bfb600"
                },
                "pipeline": {
                    "id": "twenty-fe256b39-3ec3-4fe3-8997-b75aa0bfb400"
                },
                "__typename": "PipelineProgress"
            }
        ]
    }
}
```

- Also adding a new command `prisma:reset` to get a fresh new local database (migrate reset + seeds + prisma generate)
