### PR TITLE
Update doc & split prisma generate

### DIFF
--- a/docs/docs/dev-docs/getting-started/local-setup.mdx
+++ b/docs/docs/dev-docs/getting-started/local-setup.mdx
@@ -33,6 +33,8 @@ You can run `docker-compose --version` and `docker --version` to check they are 
 ### 3. Setup env variables
 
 `cp ./infra/dev/.env.example ./infra/dev/.env` and fill with values
+`cp ./front/.env.example ./front/.env` and fill with values
+`cp ./server/.env.example ./server/.env` and fill with values
 
 ### 4. Build
 
@@ -51,21 +53,52 @@ make build
 Right now the only way to authenticate yourself is to setup Google Sign-in in `server/.env`
 We will add an easier option soon.
 
-### 6. Start
+### 6. Migrate & seed
 
-Always in the `infra/dev` folder:
+Before running the project, we need to apply database init and migrations and run the seed.
+
+Always in the `infra/dev` folder.
+
+Run the containers:
 ```
 make up
 ```
 
-Once this is completed you should have:
+Generate database init and migrations:
+```
+make server-prisma-migrate
+```
+
+Generate prisma client
+```
+make server-prisma-generate-client
+```
+
+Seed the database:
+```
+make server-prisma-seed
+```
+
+### 7. Start
+
+Once this is completed you can run the project with the following commands:
+
+front:
+```
+make front-start
+```
+
+server:
+```
+make-server start
+```
 
 - front available on: http://localhost:3001
-- server available on: http://localhost:3000/health
+- server available on: http://localhost:3000/healthz
 - postgres: available on http://localhost:5432 that should contain `twenty` database
 
 
-### 6. Development
+### 8. Development
 
 Documented [here](../development/workflows.mdx)
 

--- a/infra/dev/Makefile
+++ b/infra/dev/Makefile
@@ -29,8 +29,11 @@ front-storybook:
 server-start:
 	@docker-compose exec twenty-dev sh -c "cd /app/server && yarn start:dev"
 
-server-prisma-generate:
-	@docker-compose exec twenty-dev sh -c "cd /app/server && yarn prisma:generate"
+server-prisma-generate-client:
+	@docker-compose exec twenty-dev sh -c "cd /app/server && yarn prisma:generate-client"
+
+server-prisma-generate-nest-graphql:
+	@docker-compose exec twenty-dev sh -c "cd /app/server && yarn prisma:generate-nest-graphql"
 
 server-prisma-migrate:
 	@docker-compose exec twenty-dev sh -c "cd /app/server && yarn prisma:migrate"

--- a/server/package.json
+++ b/server/package.json
@@ -19,10 +19,11 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "prisma:generate": "npx prisma generate && eslint \"src/api/@generated/**\" --fix",
+    "prisma:generate-client": "npx prisma generate --generator client",
+    "prisma:generate-nest-graphql": "npx prisma generate --generator nestgraphql && eslint \"src/api/@generated/**\" --fix",
     "prisma:migrate": "npx prisma migrate deploy",
     "prisma:seed": "npx prisma db seed",
-    "prisma:reset": "npm run prisma:generate && npx prisma migrate reset"
+    "prisma:reset": "yarn prisma:generate-client && yarn prisma:generate-nest-grapql && npx prisma migrate reset"
   },
   "dependencies": {
     "@apollo/server": "^4.7.3",


### PR DESCRIPTION
Updating installation docs:
- add instruction to migrate and seed db
- add instruction to start front and server
- separate prisma schema generation into two commands: client and nestjs-graphql