### PR TITLE
Add new story for darkmode

### DIFF
--- a/front/.storybook/preview.ts
+++ b/front/.storybook/preview.ts
@@ -4,9 +4,6 @@ import { ThemeProvider } from '@emotion/react';
 import { withThemeFromJSXProvider } from "@storybook/addon-styling";
 import { lightTheme, darkTheme } from '../src/modules/ui/layout/styles/themes';
 
-
-initialize();
-
 const preview: Preview = {
   decorators: [
     mswDecorator,

--- a/front/.storybook/preview.ts
+++ b/front/.storybook/preview.ts
@@ -4,6 +4,8 @@ import { ThemeProvider } from '@emotion/react';
 import { withThemeFromJSXProvider } from "@storybook/addon-styling";
 import { lightTheme, darkTheme } from '../src/modules/ui/layout/styles/themes';
 
+initialize();
+
 const preview: Preview = {
   decorators: [
     mswDecorator,

--- a/front/src/__stories__/App.darkMode.stories.tsx
+++ b/front/src/__stories__/App.darkMode.stories.tsx
@@ -2,6 +2,7 @@ import { Meta } from '@storybook/react';
 
 import { App } from '~/App';
 import { graphqlMocks } from '~/testing/graphqlMocks';
+import { mockedUserJWT } from '~/testing/mock-data/jwt';
 
 import { Story } from './App.stories';
 import { renderWithDarkMode } from './shared';
@@ -15,14 +16,14 @@ export default meta;
 
 export const DarkMode: Story = {
   render: () => renderWithDarkMode(true),
-  play: async ({ canvasElement }) => {
-    /* const canvas = within(canvasElement);
-
-    const someButton = canvas.getByText('Some Button');
-    await userEvent.click(someButton);
-
-    expect(await canvas.findByText('Expected Result')).toBeInTheDocument();*/
-  },
+  loaders: [
+    async () => ({
+      accessTokenStored: window.localStorage.setItem(
+        'accessToken',
+        mockedUserJWT,
+      ),
+    }),
+  ],
   parameters: {
     msw: graphqlMocks,
   },

--- a/front/src/__stories__/App.darkMode.stories.tsx
+++ b/front/src/__stories__/App.darkMode.stories.tsx
@@ -1,0 +1,29 @@
+import { Meta } from '@storybook/react';
+
+import { App } from '~/App';
+import { graphqlMocks } from '~/testing/graphqlMocks';
+
+import { Story } from './App.stories';
+import { renderWithDarkMode } from './shared';
+
+const meta: Meta<typeof App> = {
+  title: 'App/App/DarkMode',
+  component: App,
+};
+
+export default meta;
+
+export const DarkMode: Story = {
+  render: () => renderWithDarkMode(true),
+  play: async ({ canvasElement }) => {
+    /* const canvas = within(canvasElement);
+
+    const someButton = canvas.getByText('Some Button');
+    await userEvent.click(someButton);
+
+    expect(await canvas.findByText('Expected Result')).toBeInTheDocument();*/
+  },
+  parameters: {
+    msw: graphqlMocks,
+  },
+};

--- a/front/src/__stories__/App.mdx
+++ b/front/src/__stories__/App.mdx
@@ -1,0 +1,11 @@
+{ /* App.mdx */ }
+
+import { Canvas, Meta } from '@storybook/blocks';
+
+import * as App from './App.stories';
+
+<Meta of={App} />
+
+# App View
+
+<Canvas of={App.Default} />

--- a/front/src/__stories__/App.stories.tsx
+++ b/front/src/__stories__/App.stories.tsx
@@ -1,14 +1,10 @@
-import { MemoryRouter } from 'react-router-dom';
-import { ApolloProvider } from '@apollo/client';
 import type { Meta, StoryObj } from '@storybook/react';
-import { RecoilRoot } from 'recoil';
 
 import { App } from '~/App';
-import { AuthProvider } from '~/providers/AuthProvider';
-import { FullHeightStorybookLayout } from '~/testing/FullHeightStorybookLayout';
 import { graphqlMocks } from '~/testing/graphqlMocks';
 import { mockedUserJWT } from '~/testing/mock-data/jwt';
-import { mockedClient } from '~/testing/mockedClient';
+
+import { render } from './shared';
 
 const meta: Meta<typeof App> = {
   title: 'App/App',
@@ -16,21 +12,7 @@ const meta: Meta<typeof App> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof App>;
-
-const render = () => (
-  <RecoilRoot>
-    <ApolloProvider client={mockedClient}>
-      <MemoryRouter>
-        <FullHeightStorybookLayout>
-          <AuthProvider>
-            <App />
-          </AuthProvider>
-        </FullHeightStorybookLayout>
-      </MemoryRouter>
-    </ApolloProvider>
-  </RecoilRoot>
-);
+export type Story = StoryObj<typeof App>;
 
 export const Default: Story = {
   render,

--- a/front/src/__stories__/shared.tsx
+++ b/front/src/__stories__/shared.tsx
@@ -1,0 +1,36 @@
+import { MemoryRouter } from 'react-router-dom';
+import { ApolloProvider } from '@apollo/client';
+import { ThemeProvider } from '@emotion/react';
+import { RecoilRoot } from 'recoil';
+
+import { darkTheme } from '@/ui/layout/styles/themes';
+import { App } from '~/App';
+import { AuthProvider } from '~/providers/AuthProvider';
+import { FullHeightStorybookLayout } from '~/testing/FullHeightStorybookLayout';
+import { mockedClient } from '~/testing/mockedClient';
+
+export const render = () => renderWithDarkMode(false);
+
+export const renderWithDarkMode = (forceDarkMode?: boolean) => {
+  const AppInStoryBook = (
+    <FullHeightStorybookLayout>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </FullHeightStorybookLayout>
+  );
+
+  return (
+    <RecoilRoot>
+      <ApolloProvider client={mockedClient}>
+        <MemoryRouter>
+          {forceDarkMode ? (
+            <ThemeProvider theme={darkTheme}>{AppInStoryBook}</ThemeProvider>
+          ) : (
+            AppInStoryBook
+          )}
+        </MemoryRouter>
+      </ApolloProvider>
+    </RecoilRoot>
+  );
+};

--- a/front/src/modules/comments/components/__stories__/CommentChip.stories.tsx
+++ b/front/src/modules/comments/components/__stories__/CommentChip.stories.tsx
@@ -7,7 +7,7 @@ import { CellCommentChip } from '../CellCommentChip';
 import { CommentChip } from '../CommentChip';
 
 const meta: Meta<typeof CellCommentChip> = {
-  title: 'Comments/CellCommentChip',
+  title: 'Modules/Comments/CellCommentChip',
   component: CellCommentChip,
 };
 

--- a/front/src/modules/comments/components/__stories__/CommentHeader.stories.tsx
+++ b/front/src/modules/comments/components/__stories__/CommentHeader.stories.tsx
@@ -9,7 +9,7 @@ import { getRenderWrapperForComponent } from '~/testing/renderWrappers';
 import { CommentHeader } from '../CommentHeader';
 
 const meta: Meta<typeof CommentHeader> = {
-  title: 'Comments/CommentHeader',
+  title: 'Modules/Comments/CommentHeader',
   component: CommentHeader,
 };
 

--- a/front/src/modules/comments/components/__stories__/CommentThreadRelationPicker.stories.tsx
+++ b/front/src/modules/comments/components/__stories__/CommentThreadRelationPicker.stories.tsx
@@ -8,7 +8,7 @@ import { getRenderWrapperForComponent } from '~/testing/renderWrappers';
 import { CommentThreadRelationPicker } from '../CommentThreadRelationPicker';
 
 const meta: Meta<typeof CommentThreadRelationPicker> = {
-  title: 'Comments/CommentThreadRelationPicker',
+  title: 'Modules/Comments/CommentThreadRelationPicker',
   component: CommentThreadRelationPicker,
   parameters: {
     msw: graphqlMocks,

--- a/front/src/modules/search/components/CommandMenuStyles.tsx
+++ b/front/src/modules/search/components/CommandMenuStyles.tsx
@@ -10,7 +10,6 @@ export const StyledDialog = styled(Command.Dialog)`
   max-width: 640px;
   overflow: hidden;
   padding: 0;
-  padding: 25px;
   position: fixed;
   top: 50%;
   transform: translate(-50%, -50%);

--- a/front/src/modules/search/components/__stories__/CommandMenu.stories.tsx
+++ b/front/src/modules/search/components/__stories__/CommandMenu.stories.tsx
@@ -5,7 +5,7 @@ import { getRenderWrapperForPage } from '~/testing/renderWrappers';
 import { CommandMenu } from '../CommandMenu';
 
 const meta: Meta<typeof CommandMenu> = {
-  title: 'Pages/Search/CommandMenu',
+  title: 'Modules/Search/CommandMenu',
   component: CommandMenu,
 };
 

--- a/front/src/modules/ui/components/menu/stories/DropdownMenu.stories.tsx
+++ b/front/src/modules/ui/components/menu/stories/DropdownMenu.stories.tsx
@@ -16,7 +16,7 @@ import { DropdownMenuSelectableItem } from '../DropdownMenuSelectableItem';
 import { DropdownMenuSeparator } from '../DropdownMenuSeparator';
 
 const meta: Meta<typeof DropdownMenu> = {
-  title: 'Components/DropdownMenu',
+  title: 'UI/Menu/DropdownMenu',
   component: DropdownMenu,
 };
 

--- a/front/src/modules/ui/layout/states/isThemeEnabledState.ts
+++ b/front/src/modules/ui/layout/states/isThemeEnabledState.ts
@@ -1,6 +1,0 @@
-import { atom } from 'recoil';
-
-export const isThemeEnabledState = atom<boolean>({
-  key: 'isThemeEnabledState',
-  default: true,
-});

--- a/front/src/modules/users/components/__stories__/Avatar.stories.tsx
+++ b/front/src/modules/users/components/__stories__/Avatar.stories.tsx
@@ -5,7 +5,7 @@ import { getRenderWrapperForComponent } from '~/testing/renderWrappers';
 import { Avatar } from '../Avatar';
 
 const meta: Meta<typeof Avatar> = {
-  title: 'Components/Common/Avatar',
+  title: 'Modules/Users/Avatar',
   component: Avatar,
 };
 

--- a/front/src/pages/settings/__stories__/settings.stories.tsx
+++ b/front/src/pages/settings/__stories__/settings.stories.tsx
@@ -7,7 +7,7 @@ import { SettingsProfile } from '../SettingsProfile';
 import { render } from './shared';
 
 const meta: Meta<typeof SettingsProfile> = {
-  title: 'Pages/SettingsProfile',
+  title: 'Pages/Settings/SettingsProfile',
   component: SettingsProfile,
 };
 


### PR DESCRIPTION
Adding a story that forces dark mode to detect changes that would only affect dark mode in Chromatic

It's the only story for which the theme picker above will not work.

Also reorganizing the story menu, and fixing a small margin issue on the command bar

<img width="1501" alt="Screenshot 2023-06-16 at 14 03 56" src="https://github.com/twentyhq/twenty/assets/6399865/e2bbc668-3c8b-4473-b91c-305d3431f419">
