### PR TITLE
309 have comment relation picker show up above the relation field

### DIFF
--- a/front/src/modules/comments/components/CommentThreadRelationPicker.tsx
+++ b/front/src/modules/comments/components/CommentThreadRelationPicker.tsx
@@ -168,7 +168,13 @@ export function CommentThreadRelationPicker({ commentThread }: OwnProps) {
 
   const { refs, floatingStyles } = useFloating({
     strategy: 'absolute',
-    middleware: [offset(), flip(), size()],
+    middleware: [
+      offset(({ rects }) => {
+        return -rects.reference.height;
+      }),
+      flip(),
+      size(),
+    ],
     whileElementsMounted: autoUpdate,
     open: isMenuOpen,
     placement: 'bottom-start',

--- a/front/src/modules/comments/components/MultipleEntitySelect.tsx
+++ b/front/src/modules/comments/components/MultipleEntitySelect.tsx
@@ -55,7 +55,11 @@ export function MultipleEntitySelect({
 
   return (
     <DropdownMenu>
-      <DropdownMenuSearch value={searchFilter} onChange={handleFilterChange} />
+      <DropdownMenuSearch
+        value={searchFilter}
+        onChange={handleFilterChange}
+        autoFocus
+      />
       <DropdownMenuSeparator />
       <DropdownMenuItemContainer>
         {entitiesInDropdown?.map((entity) => (


### PR DESCRIPTION
- Added a floating ui manual offset to have the dropdown on top of the relation box
- Autofocus on search field on open

Placement : bottom

<img width="335" alt="image" src="https://github.com/twentyhq/twenty/assets/26528466/7c98ca4a-ebf1-40c0-85e6-7ccbc657bb46">

Placement : top 

<img width="325" alt="image" src="https://github.com/twentyhq/twenty/assets/26528466/c0a42554-3d26-4d0d-8ec1-ac468e6ad248">

