### PR TITLE
fix: Correct sorting sub-menu font-size #426

### DIFF
--- a/front/src/modules/ui/components/table/table-header/DropdownButton.tsx
+++ b/front/src/modules/ui/components/table/table-header/DropdownButton.tsx
@@ -106,6 +106,7 @@ const StyledDropdownTopOption = styled.li`
   color: ${(props) => props.theme.text80};
   cursor: pointer;
   display: flex;
+  font-size: ${(props) => props.theme.fontSizeSmall};
   font-weight: ${(props) => props.theme.fontWeightMedium};
   justify-content: space-between;
   padding: calc(${(props) => props.theme.spacing(2)})


### PR DESCRIPTION
fixed: issue #426 

By default the font-size was 13px.
I have used **props.theme.fontSizeSmall** to set the font-size to 12px.