### PR TITLE
Enable workflow to run on fork pull requests

### DIFF
--- a/.github/workflows/ci-chromatic.yaml
+++ b/.github/workflows/ci-chromatic.yaml
@@ -2,6 +2,7 @@ name: 'CI Chromatic'
 
 on:
   push:
+  pull_request_target:
 jobs:
   chromatic-deployment:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -1,6 +1,7 @@
 name: CI Docs
 on:
   push:
+  pull_request_target:
 jobs:
   docs-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -1,6 +1,7 @@
 name: CI Front
 on:
   push:
+  pull_request_target:
 jobs:
   front-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-server.yaml
+++ b/.github/workflows/ci-server.yaml
@@ -1,6 +1,7 @@
 name: CI Server
 on:
   push:
+  pull_request_target:
 jobs:
   server-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We have our first external contributor PR: https://github.com/twentyhq/twenty/pull/430

But CIs are not run because github actions are not listening to fork PR event