### PR TITLE
Fix double Run CI

### DIFF
--- a/.github/workflows/ci-chromatic.yaml
+++ b/.github/workflows/ci-chromatic.yaml
@@ -2,6 +2,8 @@ name: 'CI Chromatic'
 
 on:
   push:
+    branches:
+      - main
   pull_request_target:
 jobs:
   chromatic-deployment:

--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -1,6 +1,8 @@
 name: CI Docs
 on:
   push:
+    branches:
+      - main
   pull_request_target:
 jobs:
   docs-build:

--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -1,6 +1,8 @@
 name: CI Front
 on:
   push:
+    branches:
+      - main
   pull_request_target:
 jobs:
   front-test:

--- a/.github/workflows/ci-server.yaml
+++ b/.github/workflows/ci-server.yaml
@@ -1,6 +1,8 @@
 name: CI Server
 on:
   push:
+    branches:
+      - main
   pull_request_target:
 jobs:
   server-test:


### PR DESCRIPTION
Since I have merged https://github.com/twentyhq/twenty/pull/435, the CI was triggered on:
- push on any `twentyhq/twenty` branch
- any PR opened

However, this led to duplicate CI run on opened PRs on `twentyhq/twenty` branches.

This change is restricting the CI to be triggered on:
- push on `twentyhq/twenty/main` branch
- any PR opened