### PR TITLE
Fix drag and drop for opportunity board

### DIFF
--- a/front/src/modules/pipeline-progress/components/Board.tsx
+++ b/front/src/modules/pipeline-progress/components/Board.tsx
@@ -77,8 +77,8 @@ export function Board({
   const [isInitialBoardLoaded, setIsInitialBoardLoaded] = useState(false);
 
   useEffect(() => {
+    if (isInitialBoardLoaded) return;
     setBoard(initialBoard);
-    if (Object.keys(initialItems).length === 0 || isInitialBoardLoaded) return;
     setBoardItems(initialItems);
     setIsInitialBoardLoaded(true);
   }, [


### PR DESCRIPTION
This PR fixes the broken drag and drop behaviour on the Opportunity card board: 
![Screen-Recording-2023-07-03-at-1](https://github.com/twentyhq/twenty/assets/18351439/202983ee-024e-4727-b9d0-4eaa29cfa5de)
