### PR TITLE
Fix authentication with debug mode

### DIFF
--- a/front/src/modules/apollo/hooks/useApolloFactory.ts
+++ b/front/src/modules/apollo/hooks/useApolloFactory.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useMemo, useRef } from 'react';
 import {
   ApolloLink,
   InMemoryCache,
@@ -67,16 +67,11 @@ export function useApolloFactory() {
       },
       extraLinks: isMockMode ? [mockLink] : [],
       isDebugMode,
+      tokenPair,
     });
 
     return apolloRef.current.getClient();
-  }, [isMockMode, setTokenPair, isDebugMode]);
-
-  useEffect(() => {
-    if (apolloRef.current) {
-      apolloRef.current.updateTokenPair(tokenPair);
-    }
-  }, [tokenPair]);
+  }, [isMockMode, setTokenPair, isDebugMode, tokenPair]);
 
   return apolloClient;
 }

--- a/front/src/modules/apollo/services/apollo.factory.ts
+++ b/front/src/modules/apollo/services/apollo.factory.ts
@@ -30,6 +30,7 @@ export interface Options<TCacheShape> extends ApolloClientOptions<TCacheShape> {
   onUnauthenticatedError?: () => void;
   extraLinks?: ApolloLink[];
   isDebugMode?: boolean;
+  tokenPair: AuthTokenPair | null;
 }
 
 export class ApolloFactory<TCacheShape> implements ApolloManager<TCacheShape> {
@@ -45,8 +46,11 @@ export class ApolloFactory<TCacheShape> implements ApolloManager<TCacheShape> {
       onUnauthenticatedError,
       extraLinks,
       isDebugMode,
+      tokenPair,
       ...options
     } = opts;
+
+    this.tokenPair = tokenPair;
 
     const buildApolloLink = (): ApolloLink => {
       const httpLink = createHttpLink({

--- a/front/src/modules/auth/hooks/useFetchClientConfig.ts
+++ b/front/src/modules/auth/hooks/useFetchClientConfig.ts
@@ -1,7 +1,0 @@
-import { useGetClientConfigQuery } from '~/generated/graphql';
-
-export function useFetchClientConfig() {
-  const { data } = useGetClientConfigQuery();
-
-  return data?.clientConfig;
-}


### PR DESCRIPTION
As we added the possibility to load debug mode from backend, this broke apolloFactory.
ApolloFactory is indead reloading once we get the debugMode value from server (as it was listed in useMemo dependency). But the as the tokens where fetched using a useEffect, the reloaded factory was missing tokens.

To fix it, I'm adding tokens to the factory constructor.