### PR TITLE
Order users by first name

### DIFF
--- a/front/src/modules/companies/components/CompanyAccountOwnerPicker.tsx
+++ b/front/src/modules/companies/components/CompanyAccountOwnerPicker.tsx
@@ -40,7 +40,7 @@ export function CompanyAccountOwnerPicker({ company }: OwnProps) {
       name: user.displayName,
       avatarType: 'rounded',
     }),
-    orderByField: 'displayName',
+    orderByField: 'firstName',
     searchOnFields: ['firstName', 'lastName'],
   });
 


### PR DESCRIPTION
This PR fixes the company owner picker: the sorting was done on a field that is now computed which is not valid.

<img width="1726" alt="Screenshot 2023-07-08 at 17 08 31" src="https://github.com/twentyhq/twenty/assets/18351439/5d77a412-08d9-4b51-9fe5-7202347ad417">

Related issue: https://github.com/prisma/prisma/issues/3394