### PR TITLE
Fix bug autofill title

### DIFF
--- a/front/src/modules/comments/components/comment-thread/CommentThreadBodyEditor.tsx
+++ b/front/src/modules/comments/components/comment-thread/CommentThreadBodyEditor.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { getOperationName } from '@apollo/client/utilities';
 import { BlockNoteEditor } from '@blocknote/core';
 import { useBlockNote } from '@blocknote/react';
@@ -25,9 +25,17 @@ export function CommentThreadBodyEditor({ commentThread, onChange }: OwnProps) {
   const [updateCommentThreadBodyMutation] =
     useUpdateCommentThreadBodyMutation();
 
+  const [body, setBody] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (body) {
+      onChange?.(body);
+    }
+  }, [body, onChange]);
+
   const debounceOnChange = useMemo(() => {
     function onInternalChange(commentThreadBody: string) {
-      onChange?.(commentThreadBody);
+      setBody(commentThreadBody);
       updateCommentThreadBodyMutation({
         variables: {
           commentThreadId: commentThread.id,
@@ -40,7 +48,7 @@ export function CommentThreadBodyEditor({ commentThread, onChange }: OwnProps) {
     }
 
     return debounce(onInternalChange, 200);
-  }, [commentThread, updateCommentThreadBodyMutation, onChange]);
+  }, [commentThread, updateCommentThreadBodyMutation, setBody]);
 
   const editor: BlockNoteEditor | null = useBlockNote({
     initialContent: commentThread.body

--- a/front/src/modules/comments/components/right-drawer/CommentThread.tsx
+++ b/front/src/modules/comments/components/right-drawer/CommentThread.tsx
@@ -85,11 +85,13 @@ const StyledTopActionsContainer = styled.div`
 type OwnProps = {
   commentThreadId: string;
   showComment?: boolean;
+  autoFillTitle?: boolean;
 };
 
 export function CommentThread({
   commentThreadId,
   showComment = true,
+  autoFillTitle = false,
 }: OwnProps) {
   const { data } = useGetCommentThreadQuery({
     variables: {
@@ -101,6 +103,8 @@ export function CommentThread({
 
   const [title, setTitle] = useState<string | null | undefined>(undefined);
   const [isLoading, setIsLoading] = useState(true);
+  const [hasUserManuallySetTitle, setHasUserManuallySetTitle] =
+    useState<boolean>(false);
 
   const [updateCommentThreadTitleMutation] =
     useUpdateCommentThreadTitleMutation();
@@ -121,10 +125,10 @@ export function CommentThread({
   }, [commentThreadId, updateCommentThreadTitleMutation]);
 
   function updateTitleFromBody(body: string) {
-    const title = JSON.parse(body)[0]?.content[0]?.text;
-    if (!commentThread?.title || commentThread?.title === '') {
-      setTitle(title);
-      debounceUpdateTitle(title);
+    const parsedTitle = JSON.parse(body)[0]?.content[0]?.text;
+    if (!hasUserManuallySetTitle && autoFillTitle) {
+      setTitle(parsedTitle);
+      debounceUpdateTitle(parsedTitle);
     }
   }
 
@@ -152,6 +156,7 @@ export function CommentThread({
           <StyledEditableTitleInput
             placeholder="Note title (optional)"
             onChange={(event) => {
+              setHasUserManuallySetTitle(true);
               setTitle(event.target.value);
               debounceUpdateTitle(event.target.value);
             }}

--- a/front/src/modules/comments/components/right-drawer/CommentThread.tsx
+++ b/front/src/modules/comments/components/right-drawer/CommentThread.tsx
@@ -102,7 +102,6 @@ export function CommentThread({
   const commentThread = data?.findManyCommentThreads[0];
 
   const [title, setTitle] = useState<string | null | undefined>(undefined);
-  const [isLoading, setIsLoading] = useState(true);
   const [hasUserManuallySetTitle, setHasUserManuallySetTitle] =
     useState<boolean>(false);
 
@@ -134,12 +133,9 @@ export function CommentThread({
 
   useEffect(() => {
     if (commentThread) {
-      setIsLoading(false);
-    }
-    if (isLoading) {
       setTitle(commentThread?.title ?? '');
     }
-  }, [commentThread, isLoading]);
+  }, [commentThread]);
 
   if (!commentThread) {
     return <></>;

--- a/front/src/modules/comments/components/right-drawer/create/RightDrawerCreateCommentThread.tsx
+++ b/front/src/modules/comments/components/right-drawer/create/RightDrawerCreateCommentThread.tsx
@@ -30,6 +30,7 @@ export function RightDrawerCreateCommentThread() {
           <CommentThread
             commentThreadId={commentThreadId}
             showComment={false}
+            autoFillTitle={true}
           />
         )}
       </RightDrawerBody>


### PR DESCRIPTION
As Blocknote library is memorizing the onChange callback function, we cannot apply a condition depending on parent state in this function.
I'm introducing an internal state to decouple the internal memorized onChange function from the prop onChange function