### PR TITLE
Fix board card glitches

### DIFF
--- a/front/src/modules/pipeline-progress/components/Board.tsx
+++ b/front/src/modules/pipeline-progress/components/Board.tsx
@@ -82,15 +82,13 @@ export function Board({
   const [isInitialBoardLoaded, setIsInitialBoardLoaded] = useState(false);
 
   useEffect(() => {
-    setBoardItems(initialItems);
-  }, [initialItems, setBoardItems, boardItems]);
-
-  useEffect(() => {
-    if (isInitialBoardLoaded) return;
-    setBoard(initialBoard);
-    if (Object.keys(initialItems).length === 0) return;
-    setBoardItems(initialItems);
-    setIsInitialBoardLoaded(true);
+    if (!isInitialBoardLoaded) {
+      setBoard(initialBoard);
+    }
+    if (Object.keys(initialItems).length > 0) {
+      setBoardItems(initialItems);
+      setIsInitialBoardLoaded(true);
+    }
   }, [
     initialBoard,
     setBoard,


### PR DESCRIPTION
This PR cleans the logic for the loading of the board and board items. For some reasons, we had 2 `useContexts` doing similar things under different conditions.