### PR TITLE
Feat/add invite link

### DIFF
--- a/front/src/generated/graphql.tsx
+++ b/front/src/generated/graphql.tsx
@@ -3397,7 +3397,7 @@ export type SearchCompanyQuery = { __typename?: 'Query', searchResults: Array<{ 
 export type GetCurrentUserQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetCurrentUserQuery = { __typename?: 'Query', currentUser: { __typename?: 'User', id: string, email: string, displayName: string, firstName?: string | null, lastName?: string | null, avatarUrl?: string | null, workspaceMember?: { __typename?: 'WorkspaceMember', id: string, workspace: { __typename?: 'Workspace', id: string, domainName?: string | null, displayName?: string | null, logo?: string | null } } | null } };
+export type GetCurrentUserQuery = { __typename?: 'Query', currentUser: { __typename?: 'User', id: string, email: string, displayName: string, firstName?: string | null, lastName?: string | null, avatarUrl?: string | null, workspaceMember?: { __typename?: 'WorkspaceMember', id: string, workspace: { __typename?: 'Workspace', id: string, domainName?: string | null, displayName?: string | null, logo?: string | null, inviteHash?: string | null } } | null } };
 
 export type GetUsersQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -5051,6 +5051,7 @@ export const GetCurrentUserDocument = gql`
         domainName
         displayName
         logo
+        inviteHash
       }
     }
   }

--- a/front/src/modules/users/queries/index.ts
+++ b/front/src/modules/users/queries/index.ts
@@ -17,6 +17,7 @@ export const GET_CURRENT_USER = gql`
           domainName
           displayName
           logo
+          inviteHash
         }
       }
     }

--- a/front/src/modules/workspace/components/WorkspaceInviteLink.tsx
+++ b/front/src/modules/workspace/components/WorkspaceInviteLink.tsx
@@ -4,15 +4,15 @@ import styled from '@emotion/styled';
 
 import { Button } from '@/ui/components/buttons/Button';
 import { TextInput } from '@/ui/components/inputs/TextInput';
-import { IconLink } from '@/ui/icons';
+import { IconCheck, IconLink } from '@/ui/icons';
 
-const CopyLinkContainer = styled.div`
+const StyledContainer = styled.div`
   align-items: center;
   display: flex;
   flex-direction: row;
 `;
 
-const LinkContainer = styled.div`
+const StyledLinkContainer = styled.div`
   flex: 1;
   margin-right: ${({ theme }) => theme.spacing(2)};
 `;
@@ -25,20 +25,25 @@ export function WorkspaceInviteLink({ inviteLink }: OwnProps) {
   const theme = useTheme();
   const [isCopied, setIsCopied] = useState(false);
   return (
-    <CopyLinkContainer>
-      <LinkContainer>
+    <StyledContainer>
+      <StyledLinkContainer>
         <TextInput value={inviteLink} disabled fullWidth />
-      </LinkContainer>
+      </StyledLinkContainer>
       <Button
-        icon={<IconLink size={theme.icon.size.md} />}
+        icon={
+          isCopied ? (
+            <IconCheck size={theme.icon.size.md} />
+          ) : (
+            <IconLink size={theme.icon.size.md} />
+          )
+        }
         variant="primary"
         title={isCopied ? 'Copied' : 'Copy link'}
-        disabled={isCopied}
         onClick={() => {
           setIsCopied(true);
           navigator.clipboard.writeText(inviteLink);
         }}
       />
-    </CopyLinkContainer>
+    </StyledContainer>
   );
 }

--- a/front/src/modules/workspace/components/WorkspaceInviteLink.tsx
+++ b/front/src/modules/workspace/components/WorkspaceInviteLink.tsx
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+import { useTheme } from '@emotion/react';
+import styled from '@emotion/styled';
+
+import { Button } from '@/ui/components/buttons/Button';
+import { TextInput } from '@/ui/components/inputs/TextInput';
+import { IconLink } from '@/ui/icons';
+
+const CopyLinkContainer = styled.div`
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+`;
+
+const LinkContainer = styled.div`
+  flex: 1;
+  margin-right: ${({ theme }) => theme.spacing(2)};
+`;
+
+type OwnProps = {
+  inviteLink: string;
+};
+
+export function WorkspaceInviteLink({ inviteLink }: OwnProps) {
+  const theme = useTheme();
+  const [isCopied, setIsCopied] = useState(false);
+  return (
+    <CopyLinkContainer>
+      <LinkContainer>
+        <TextInput value={inviteLink} disabled fullWidth />
+      </LinkContainer>
+      <Button
+        icon={<IconLink size={theme.icon.size.md} />}
+        variant="primary"
+        title={isCopied ? 'Copied' : 'Copy link'}
+        disabled={isCopied}
+        onClick={() => {
+          setIsCopied(true);
+          navigator.clipboard.writeText(inviteLink);
+        }}
+      />
+    </CopyLinkContainer>
+  );
+}

--- a/front/src/pages/settings/SettingsWorkspaceMembers.tsx
+++ b/front/src/pages/settings/SettingsWorkspaceMembers.tsx
@@ -1,15 +1,14 @@
-import { useState } from 'react';
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useRecoilState } from 'recoil';
 
 import { currentUserState } from '@/auth/states/currentUserState';
 import { Button } from '@/ui/components/buttons/Button';
-import { TextInput } from '@/ui/components/inputs/TextInput';
 import { MainSectionTitle } from '@/ui/components/section-titles/MainSectionTitle';
 import { SubSectionTitle } from '@/ui/components/section-titles/SubSectionTitle';
-import { IconLink, IconTrash } from '@/ui/icons';
+import { IconTrash } from '@/ui/icons';
 import { NoTopBarContainer } from '@/ui/layout/containers/NoTopBarContainer';
+import { WorkspaceInviteLink } from '@/workspace/components/WorkspaceInviteLink';
 import { WorkspaceMemberCard } from '@/workspace/components/WorkspaceMemberCard';
 import {
   useGetWorkspaceMembersQuery,
@@ -33,23 +32,10 @@ const ButtonContainer = styled.div`
   margin-left: ${({ theme }) => theme.spacing(3)};
 `;
 
-const CopyLinkContainer = styled.div`
-  align-items: center;
-  display: flex;
-  flex-direction: row;
-`;
-
-const LinkContainer = styled.div`
-  flex: 1;
-  margin-right: ${({ theme }) => theme.spacing(2)};
-`;
-
 export function SettingsWorkspaceMembers() {
   const [currentUser] = useRecoilState(currentUserState);
   const workspace = currentUser?.workspaceMember?.workspace;
-  const [isCopied, setIsCopied] = useState(false);
   const theme = useTheme();
-  const inviteLink = `${window.location.origin}/invite/${workspace?.inviteHash}`;
 
   const { data } = useGetWorkspaceMembersQuery();
 
@@ -98,21 +84,9 @@ export function SettingsWorkspaceMembers() {
               title="Invite"
               description="Send an invitation to use Twenty"
             />
-            <CopyLinkContainer>
-              <LinkContainer>
-                <TextInput value={inviteLink} disabled fullWidth />
-              </LinkContainer>
-              <Button
-                icon={<IconLink size={theme.icon.size.md} />}
-                variant="primary"
-                title={isCopied ? 'Copied' : 'Copy link'}
-                disabled={isCopied}
-                onClick={() => {
-                  setIsCopied(true);
-                  navigator.clipboard.writeText(inviteLink);
-                }}
-              />
-            </CopyLinkContainer>
+            <WorkspaceInviteLink
+              inviteLink={`${window.location.origin}/auth/invite/${workspace?.inviteHash}`}
+            />
           </>
         )}
         <SubSectionTitle

--- a/front/src/pages/settings/SettingsWorkspaceMembers.tsx
+++ b/front/src/pages/settings/SettingsWorkspaceMembers.tsx
@@ -46,8 +46,10 @@ const LinkContainer = styled.div`
 
 export function SettingsWorkspaceMembers() {
   const [currentUser] = useRecoilState(currentUserState);
+  const workspace = currentUser?.workspaceMember?.workspace;
   const [isCopied, setIsCopied] = useState(false);
   const theme = useTheme();
+  const inviteLink = `${window.location.origin}/invite/${workspace?.inviteHash}`;
 
   const { data } = useGetWorkspaceMembersQuery();
 
@@ -90,25 +92,29 @@ export function SettingsWorkspaceMembers() {
     <NoTopBarContainer>
       <StyledContainer>
         <MainSectionTitle>Members</MainSectionTitle>
-        <SubSectionTitle
-          title="Invite"
-          description="Send an invitation to use Twenty"
-        />
-        <CopyLinkContainer>
-          <LinkContainer>
-            <TextInput value={'workspaceHash'} disabled fullWidth />
-          </LinkContainer>
-          <Button
-            icon={<IconLink size={theme.icon.size.md} />}
-            variant="primary"
-            title={isCopied ? 'Copied' : 'Copy link'}
-            disabled={isCopied}
-            onClick={() => {
-              setIsCopied(true);
-              navigator.clipboard.writeText('workspaceHash');
-            }}
-          />
-        </CopyLinkContainer>
+        {workspace?.inviteHash && (
+          <>
+            <SubSectionTitle
+              title="Invite"
+              description="Send an invitation to use Twenty"
+            />
+            <CopyLinkContainer>
+              <LinkContainer>
+                <TextInput value={inviteLink} disabled fullWidth />
+              </LinkContainer>
+              <Button
+                icon={<IconLink size={theme.icon.size.md} />}
+                variant="primary"
+                title={isCopied ? 'Copied' : 'Copy link'}
+                disabled={isCopied}
+                onClick={() => {
+                  setIsCopied(true);
+                  navigator.clipboard.writeText(inviteLink);
+                }}
+              />
+            </CopyLinkContainer>
+          </>
+        )}
         <SubSectionTitle
           title="Members"
           description="Manage the members of your space here"

--- a/front/src/pages/settings/SettingsWorkspaceMembers.tsx
+++ b/front/src/pages/settings/SettingsWorkspaceMembers.tsx
@@ -1,11 +1,14 @@
+import { useState } from 'react';
+import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useRecoilState } from 'recoil';
 
 import { currentUserState } from '@/auth/states/currentUserState';
 import { Button } from '@/ui/components/buttons/Button';
+import { TextInput } from '@/ui/components/inputs/TextInput';
 import { MainSectionTitle } from '@/ui/components/section-titles/MainSectionTitle';
 import { SubSectionTitle } from '@/ui/components/section-titles/SubSectionTitle';
-import { IconTrash } from '@/ui/icons';
+import { IconLink, IconTrash } from '@/ui/icons';
 import { NoTopBarContainer } from '@/ui/layout/containers/NoTopBarContainer';
 import { WorkspaceMemberCard } from '@/workspace/components/WorkspaceMemberCard';
 import {
@@ -30,8 +33,21 @@ const ButtonContainer = styled.div`
   margin-left: ${({ theme }) => theme.spacing(3)};
 `;
 
+const CopyLinkContainer = styled.div`
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+`;
+
+const LinkContainer = styled.div`
+  flex: 1;
+  margin-right: ${({ theme }) => theme.spacing(2)};
+`;
+
 export function SettingsWorkspaceMembers() {
   const [currentUser] = useRecoilState(currentUserState);
+  const [isCopied, setIsCopied] = useState(false);
+  const theme = useTheme();
 
   const { data } = useGetWorkspaceMembersQuery();
 
@@ -75,6 +91,25 @@ export function SettingsWorkspaceMembers() {
       <StyledContainer>
         <MainSectionTitle>Members</MainSectionTitle>
         <SubSectionTitle
+          title="Invite"
+          description="Send an invitation to use Twenty"
+        />
+        <CopyLinkContainer>
+          <LinkContainer>
+            <TextInput value={'workspaceHash'} disabled fullWidth />
+          </LinkContainer>
+          <Button
+            icon={<IconLink size={theme.icon.size.md} />}
+            variant="primary"
+            title={isCopied ? 'Copied' : 'Copy link'}
+            disabled={isCopied}
+            onClick={() => {
+              setIsCopied(true);
+              navigator.clipboard.writeText('workspaceHash');
+            }}
+          />
+        </CopyLinkContainer>
+        <SubSectionTitle
           title="Members"
           description="Manage the members of your space here"
         />
@@ -89,7 +124,7 @@ export function SettingsWorkspaceMembers() {
                     onClick={() => handleRemoveWorkspaceMember(member.user.id)}
                     variant="tertiary"
                     size="small"
-                    icon={<IconTrash size={16} />}
+                    icon={<IconTrash size={theme.icon.size.md} />}
                   />
                 </ButtonContainer>
               )


### PR DESCRIPTION
This PR enables users to copy their workspace invite link to share with team members:
![Screen-Recording-2023-07-11-at-0](https://github.com/twentyhq/twenty/assets/18351439/7518edb2-a171-4939-9a94-dd73080ed8d9)

Storing the workspace information is done through the `GET_CURRENT_USER` query and we may consider doing this in a new `GET_CURRENT_WORSPACE` if the list of properties we get for the workspace keeps on growing.

[figma link](https://www.figma.com/file/xt8O9mFeLl46C5InWwoMrN/Twenty?node-id=3605%3A53526&mode=dev) for reference