### PR TITLE
Fixing BlockNote readability darkMode + fixing impossible to create cards for companies without name or domainName

### DIFF
--- a/front/src/modules/pipeline-progress/components/NewButton.tsx
+++ b/front/src/modules/pipeline-progress/components/NewButton.tsx
@@ -42,7 +42,7 @@ export function NewButton({ pipelineId, columnId }: OwnProps) {
 
   const handleEntitySelect = useCallback(
     async (company: Pick<Company, 'id' | 'name' | 'domainName'>) => {
-      if (!company || !company.name || !company.domainName) return;
+      if (!company) return;
 
       setIsCreatingCard(false);
       goBackToPreviousHotkeysScope();

--- a/front/src/modules/ui/components/editor/BlockEditor.tsx
+++ b/front/src/modules/ui/components/editor/BlockEditor.tsx
@@ -12,6 +12,7 @@ const StyledEditor = styled.div`
   & .editor {
     background: ${({ theme }) => theme.background.primary};
     font-size: 13px;
+    color: ${({ theme }) => theme.font.color.primary};
   }
   & .editor [class^='_inlineContent']:before {
     color: ${({ theme }) => theme.font.color.tertiary};


### PR DESCRIPTION
1) Improving BlockNote readability in dark mode :
<img width="1512" alt="image" src="https://github.com/twentyhq/twenty/assets/12035771/bb472bce-1330-49ca-9a48-a9b929063092">

2) Fixing bug on opportunities board where a unnecessary condition was blocking card creation for companies without name or domainName