### PR TITLE
fix: BUG - Left drawer profile menu item not hovered

### DIFF
--- a/front/src/modules/settings/components/SettingsNavbar.tsx
+++ b/front/src/modules/settings/components/SettingsNavbar.tsx
@@ -34,7 +34,7 @@ export function SettingsNavbar() {
           icon={<IconUser size={theme.icon.size.md} />}
           active={
             !!useMatch({
-              path: useResolvedPath('/people').pathname,
+              path: useResolvedPath('/settings/profile').pathname,
               end: true,
             })
           }


### PR DESCRIPTION
fixes #604 
![image](https://github.com/twentyhq/twenty/assets/32263182/6b7fb3a2-331b-47bd-86e9-b8639dafc86b)
 
 **_changed_**  --> path: useResolvedPath('/people').pathname       to    -->   path: useResolvedPath('/settings/profile').pathname