### PR TITLE
Reorder company columns

### DIFF
--- a/front/src/modules/companies/table/components/companyColumns.tsx
+++ b/front/src/modules/companies/table/components/companyColumns.tsx
@@ -31,6 +31,20 @@ export const companyColumns: TableColumn[] = [
     cellComponent: <EditableCompanyDomainNameCell />,
   },
   {
+    id: 'accountOwner',
+    title: 'Account owner',
+    icon: <IconUser size={16} />,
+    size: 150,
+    cellComponent: <EditableCompanyAccountOwnerCell />,
+  },
+  {
+    id: 'createdAt',
+    title: 'Creation',
+    icon: <IconCalendarEvent size={16} />,
+    size: 150,
+    cellComponent: <EditableCompanyCreatedAtCell />,
+  },
+  {
     id: 'employees',
     title: 'Employees',
     icon: <IconUsers size={16} />,
@@ -43,19 +57,5 @@ export const companyColumns: TableColumn[] = [
     icon: <IconMap size={16} />,
     size: 170,
     cellComponent: <EditableCompanyAddressCell />,
-  },
-  {
-    id: 'createdAt',
-    title: 'Creation',
-    icon: <IconCalendarEvent size={16} />,
-    size: 150,
-    cellComponent: <EditableCompanyCreatedAtCell />,
-  },
-  {
-    id: 'accountOwner',
-    title: 'Account owner',
-    icon: <IconUser size={16} />,
-    size: 150,
-    cellComponent: <EditableCompanyAccountOwnerCell />,
   },
 ];


### PR DESCRIPTION
This PR re-applies the changes reverted in https://github.com/twentyhq/twenty/pull/645/commits/7ad7969c5ac9342e2f52f1cd1d5eef82298447ea.

Here's the design impact:
<img width="1718" alt="Screenshot 2023-07-13 at 21 29 19" src="https://github.com/twentyhq/twenty/assets/18351439/7b20734d-e9f9-48dd-8ce8-6a46a3fe9def">
