### PR TITLE
Update checkbox API

### DIFF
--- a/front/src/modules/companies/components/CompanyBoardCard.tsx
+++ b/front/src/modules/companies/components/CompanyBoardCard.tsx
@@ -132,9 +132,7 @@ export function CompanyBoardCard() {
           />
           <span>{company.name}</span>
           <div style={{ display: 'flex', flex: 1 }} />
-          <div onClick={handleCheckboxChange}>
-            <Checkbox checked={selected} />
-          </div>
+          <Checkbox checked={selected} onChange={handleCheckboxChange} />
         </StyledBoardCardHeader>
         <StyledBoardCardBody>
           <span>

--- a/front/src/modules/ui/board/components/Board.tsx
+++ b/front/src/modules/ui/board/components/Board.tsx
@@ -21,7 +21,6 @@ export function getOptimisticlyUpdatedBoard(
   board: BoardPipelineStageColumn[],
   result: DropResult,
 ) {
-  // TODO: review any types
   const newBoard = JSON.parse(JSON.stringify(board));
   const { destination, source } = result;
   if (!destination) return;

--- a/front/src/modules/ui/components/form/Checkbox.tsx
+++ b/front/src/modules/ui/components/form/Checkbox.tsx
@@ -6,7 +6,7 @@ import { IconCheck } from '@/ui/icons/index';
 type OwnProps = {
   checked: boolean;
   indeterminate?: boolean;
-  onChange?: (newCheckedValue: boolean) => void;
+  onChange: () => void;
 };
 
 const StyledContainer = styled.div`
@@ -65,18 +65,13 @@ export function Checkbox({ checked, onChange, indeterminate }: OwnProps) {
     }
   }, [ref, indeterminate, checked]);
 
-  function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
-    onChange?.(event.target.checked);
-  }
-
   return (
-    <StyledContainer>
+    <StyledContainer onClick={onChange}>
       <input
         ref={ref}
         type="checkbox"
         data-testid="input-checkbox"
         checked={checked}
-        onChange={handleChange}
       />
       {checked && <IconCheck />}
     </StyledContainer>

--- a/front/src/modules/ui/components/menu/DropdownMenuCheckableItem.tsx
+++ b/front/src/modules/ui/components/menu/DropdownMenuCheckableItem.tsx
@@ -42,9 +42,9 @@ export function DropdownMenuCheckableItem({
   }
 
   return (
-    <DropdownMenuCheckableItemContainer onClick={handleClick}>
+    <DropdownMenuCheckableItemContainer>
       <StyledLeftContainer>
-        <Checkbox checked={checked} />
+        <Checkbox checked={checked} onChange={handleClick} />
         <StyledChildrenContainer>{children}</StyledChildrenContainer>
       </StyledLeftContainer>
     </DropdownMenuCheckableItemContainer>

--- a/front/src/modules/ui/components/table/CheckboxCell.tsx
+++ b/front/src/modules/ui/components/table/CheckboxCell.tsx
@@ -33,11 +33,7 @@ export function CheckboxCell() {
 
   return (
     <StyledContainer>
-      <Checkbox
-        checked={currentRowSelected}
-        onChange={handleContainerClick}
-        data-testid="input-checkbox-cell-container"
-      />
+      <Checkbox checked={currentRowSelected} onChange={handleContainerClick} />
     </StyledContainer>
   );
 }

--- a/front/src/modules/ui/components/table/CheckboxCell.tsx
+++ b/front/src/modules/ui/components/table/CheckboxCell.tsx
@@ -10,7 +10,6 @@ import { Checkbox } from '../form/Checkbox';
 const StyledContainer = styled.div`
   align-items: center;
 
-  cursor: pointer;
   display: flex;
   height: 32px;
 
@@ -33,11 +32,12 @@ export function CheckboxCell() {
   }
 
   return (
-    <StyledContainer
-      onClick={handleContainerClick}
-      data-testid="input-checkbox-cell-container"
-    >
-      <Checkbox checked={currentRowSelected} />
+    <StyledContainer>
+      <Checkbox
+        checked={currentRowSelected}
+        onChange={handleContainerClick}
+        data-testid="input-checkbox-cell-container"
+      />
     </StyledContainer>
   );
 }

--- a/front/src/modules/ui/components/table/SelectAllCheckbox.tsx
+++ b/front/src/modules/ui/components/table/SelectAllCheckbox.tsx
@@ -8,7 +8,6 @@ import { Checkbox } from '../form/Checkbox';
 const StyledContainer = styled.div`
   align-items: center;
 
-  cursor: pointer;
   display: flex;
   height: 32px;
 
@@ -26,11 +25,13 @@ export const SelectAllCheckbox = () => {
   const indeterminate = allRowsSelectedStatus === 'some';
 
   return (
-    <StyledContainer
-      onClick={handleContainerClick}
-      data-testid="input-checkbox-cell-container"
-    >
-      <Checkbox checked={checked} indeterminate={indeterminate} />
+    <StyledContainer>
+      <Checkbox
+        checked={checked}
+        onChange={handleContainerClick}
+        data-testid="input-checkbox-cell-container"
+        indeterminate={indeterminate}
+      />
     </StyledContainer>
   );
 };

--- a/front/src/modules/ui/components/table/SelectAllCheckbox.tsx
+++ b/front/src/modules/ui/components/table/SelectAllCheckbox.tsx
@@ -29,7 +29,6 @@ export const SelectAllCheckbox = () => {
       <Checkbox
         checked={checked}
         onChange={handleContainerClick}
-        data-testid="input-checkbox-cell-container"
         indeterminate={indeterminate}
       />
     </StyledContainer>

--- a/front/src/pages/people/__stories__/People.inputs.stories.tsx
+++ b/front/src/pages/people/__stories__/People.inputs.stories.tsx
@@ -81,7 +81,7 @@ export const CheckCheckboxes: Story = {
     await canvas.findByText(mockedPeopleData[0].email);
 
     const inputCheckboxContainers = await canvas.findAllByTestId(
-      'input-checkbox-cell-container',
+      'input-checkbox',
     );
 
     const inputCheckboxes = await canvas.findAllByTestId('input-checkbox');


### PR DESCRIPTION
This PR updates the way we implement `CheckBox` in order to make its `onChange` component mandatory.
The rationale behind is that for most cases, we had to develop a wrapper div around the checkbox to handle clicks, which should be done by the `Checkbox` itself