### PR TITLE
feat: default pipeline provisioning at workspace creation

### DIFF
--- a/server/src/core/pipeline/seed-data/pipeline-stages.json
+++ b/server/src/core/pipeline/seed-data/pipeline-stages.json
@@ -1,0 +1,33 @@
+[
+    {
+      "name": "New",
+      "color": "#B76796",
+      "index": 0,
+      "type": "open"
+    },
+    {
+      "name": "Screening",
+      "color": "#CB912F",
+      "index": 1,
+      "type": "ongoing"
+    },
+    {
+      "name": "Meeting",
+      "color": "#9065B0",
+      "index": 2,
+      "type": "ongoing"
+    },
+    {
+      "name": "Proposal",
+      "color": "#337EA9",
+      "index": 3,
+      "type": "ongoing"
+    },
+    {
+      "name": "Customer",
+      "color": "#079039",
+      "index": 4,
+      "type": "won"
+    }
+  ]
+  

--- a/server/src/core/pipeline/seed-data/sales-pipeline.json
+++ b/server/src/core/pipeline/seed-data/sales-pipeline.json
@@ -1,0 +1,6 @@
+{
+  "name": "Sales pipeline",
+  "icon": "💰",
+  "pipelineProgressableType": "Company"
+}
+

--- a/server/src/core/pipeline/services/pipeline-stage.service.ts
+++ b/server/src/core/pipeline/services/pipeline-stage.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
-import { Prisma } from '@prisma/client';
 import { PrismaService } from 'src/database/prisma.service';
+import seedPipelineStages from '../seed-data/pipeline-stages.json';
 
 @Injectable()
 export class PipelineStageService {
@@ -45,49 +45,13 @@ export class PipelineStageService {
     workspaceId: string;
     pipelineId: string;
   }) {
+    const pipelineStages = seedPipelineStages.map((pipelineStage) => ({
+      ...pipelineStage,
+      workspaceId,
+      pipelineId,
+    }));
     return this.createMany({
-      data: [
-        {
-          name: 'New',
-          color: '#B76796',
-          index: 0,
-          type: 'open',
-          pipelineId,
-          workspaceId,
-        },
-        {
-          name: 'Screening',
-          color: '#CB912F',
-          index: 1,
-          type: 'ongoing',
-          pipelineId,
-          workspaceId,
-        },
-        {
-          name: 'Meeting',
-          color: '#9065B0',
-          index: 2,
-          type: 'ongoing',
-          pipelineId,
-          workspaceId,
-        },
-        {
-          name: 'Proposal',
-          color: '#337EA9',
-          index: 3,
-          type: 'ongoing',
-          pipelineId,
-          workspaceId,
-        },
-        {
-          name: 'Customer',
-          color: '#079039',
-          index: 4,
-          type: 'won',
-          pipelineId,
-          workspaceId,
-        },
-      ],
+      data: pipelineStages,
     });
   }
 }

--- a/server/src/core/pipeline/services/pipeline-stage.service.ts
+++ b/server/src/core/pipeline/services/pipeline-stage.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from 'src/database/prisma.service';
 
 @Injectable()
@@ -35,4 +36,58 @@ export class PipelineStageService {
 
   // GroupBy
   groupBy = this.prismaService.pipelineStage.groupBy;
+
+  // Customs
+  async createDefaultPipelineStages({
+    workspaceId,
+    pipelineId,
+  }: {
+    workspaceId: string;
+    pipelineId: string;
+  }) {
+    return this.createMany({
+      data: [
+        {
+          name: 'New',
+          color: '#B76796',
+          index: 0,
+          type: 'open',
+          pipelineId,
+          workspaceId,
+        },
+        {
+          name: 'Screening',
+          color: '#CB912F',
+          index: 1,
+          type: 'ongoing',
+          pipelineId,
+          workspaceId,
+        },
+        {
+          name: 'Meeting',
+          color: '#9065B0',
+          index: 2,
+          type: 'ongoing',
+          pipelineId,
+          workspaceId,
+        },
+        {
+          name: 'Proposal',
+          color: '#337EA9',
+          index: 3,
+          type: 'ongoing',
+          pipelineId,
+          workspaceId,
+        },
+        {
+          name: 'Customer',
+          color: '#079039',
+          index: 4,
+          type: 'won',
+          pipelineId,
+          workspaceId,
+        },
+      ],
+    });
+  }
 }

--- a/server/src/core/pipeline/services/pipeline.service.ts
+++ b/server/src/core/pipeline/services/pipeline.service.ts
@@ -35,4 +35,16 @@ export class PipelineService {
 
   // GroupBy
   groupBy = this.prismaService.pipeline.groupBy;
+
+  // Customs
+  async createDefaultPipeline({ workspaceId }: { workspaceId: string }) {
+    return this.create({
+      data: {
+        name: 'Sales pipeline',
+        icon: '💰',
+        pipelineProgressableType: 'Company',
+        workspaceId,
+      },
+    });
+  }
 }

--- a/server/src/core/pipeline/services/pipeline.service.ts
+++ b/server/src/core/pipeline/services/pipeline.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from 'src/database/prisma.service';
-import salesPipeline from '../seed-data/sales-pipeline.json';
+import seedSalesPipeline from '../seed-data/sales-pipeline.json';
 import { PipelineProgressableType } from '@prisma/client';
 
 @Injectable()
@@ -41,9 +41,9 @@ export class PipelineService {
   // Customs
   async createDefaultPipeline({ workspaceId }: { workspaceId: string }) {
     const pipeline = {
-      ...salesPipeline,
+      ...seedSalesPipeline,
       pipelineProgressableType:
-        salesPipeline.pipelineProgressableType as PipelineProgressableType,
+        seedSalesPipeline.pipelineProgressableType as PipelineProgressableType,
       workspaceId,
     };
 

--- a/server/src/core/pipeline/services/pipeline.service.ts
+++ b/server/src/core/pipeline/services/pipeline.service.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from 'src/database/prisma.service';
+import salesPipeline from '../seed-data/sales-pipeline.json';
+import { PipelineProgressableType } from '@prisma/client';
 
 @Injectable()
 export class PipelineService {
@@ -38,13 +40,15 @@ export class PipelineService {
 
   // Customs
   async createDefaultPipeline({ workspaceId }: { workspaceId: string }) {
+    const pipeline = {
+      ...salesPipeline,
+      pipelineProgressableType:
+        salesPipeline.pipelineProgressableType as PipelineProgressableType,
+      workspaceId,
+    };
+
     return this.create({
-      data: {
-        name: 'Sales pipeline',
-        icon: '💰',
-        pipelineProgressableType: 'Company',
-        workspaceId,
-      },
+      data: pipeline,
     });
   }
 }

--- a/server/src/core/user/user.module.ts
+++ b/server/src/core/user/user.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { UserService } from './user.service';
 import { UserResolver } from './user.resolver';
 import { FileModule } from '../file/file.module';
+import { WorkspaceModule } from '../workspace/workspace.module';
 
 @Module({
-  imports: [FileModule],
+  imports: [FileModule, WorkspaceModule],
   providers: [UserService, UserResolver],
   exports: [UserService],
 })

--- a/server/src/core/user/user.service.spec.ts
+++ b/server/src/core/user/user.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { UserService } from './user.service';
 import { PrismaService } from 'src/database/prisma.service';
 import { prismaMock } from 'src/database/client-mock/jest-prisma-singleton';
+import { WorkspaceService } from '../workspace/services/workspace.service';
 
 describe('UserService', () => {
   let service: UserService;
@@ -13,6 +14,10 @@ describe('UserService', () => {
         {
           provide: PrismaService,
           useValue: prismaMock,
+        },
+        {
+          provide: WorkspaceService,
+          useValue: {},
         },
       ],
     }).compile();

--- a/server/src/core/user/user.service.ts
+++ b/server/src/core/user/user.service.ts
@@ -2,6 +2,7 @@ import { BadRequestException, Injectable } from '@nestjs/common';
 import { PrismaService } from 'src/database/prisma.service';
 import { Prisma } from '@prisma/client';
 import { assert } from 'src/utils/assert';
+import { WorkspaceService } from '../workspace/services/workspace.service';
 
 export type UserPayload = {
   displayName: string | undefined | null;
@@ -10,7 +11,10 @@ export type UserPayload = {
 
 @Injectable()
 export class UserService {
-  constructor(private readonly prismaService: PrismaService) {}
+  constructor(
+    private readonly prismaService: PrismaService,
+    private readonly workspaceSerice: WorkspaceService,
+  ) {}
 
   // Find
   findFirst = this.prismaService.user.findFirst;
@@ -50,6 +54,18 @@ export class UserService {
   ): Promise<Prisma.UserGetPayload<T>> {
     assert(args.data.email, 'email is missing', BadRequestException);
 
+    // Create workspace if not exists
+    const workspace = workspaceId
+      ? await this.workspaceSerice.findUnique({
+          where: {
+            id: workspaceId,
+          },
+        })
+      : await this.workspaceSerice.createDefaultWorkspace();
+
+    assert(workspace, 'workspace is missing', BadRequestException);
+
+    // Create user
     const user = await this.prismaService.user.upsert({
       where: {
         email: args.data.email,
@@ -57,22 +73,13 @@ export class UserService {
       create: {
         ...(args.data as Prisma.UserCreateInput),
 
-        workspaceMember: workspaceId
-          ? {
-              create: {
-                workspace: {
-                  connect: { id: workspaceId },
-                },
-              },
-            }
-          : // Assign the user to a new workspace by default
-            {
-              create: {
-                workspace: {
-                  create: {},
-                },
-              },
+        workspaceMember: {
+          create: {
+            workspace: {
+              connect: { id: workspace.id },
             },
+          },
+        },
         locale: 'en',
       },
       update: {},

--- a/server/src/core/user/user.service.ts
+++ b/server/src/core/user/user.service.ts
@@ -13,7 +13,7 @@ export type UserPayload = {
 export class UserService {
   constructor(
     private readonly prismaService: PrismaService,
-    private readonly workspaceSerice: WorkspaceService,
+    private readonly workspaceService: WorkspaceService,
   ) {}
 
   // Find
@@ -56,12 +56,12 @@ export class UserService {
 
     // Create workspace if not exists
     const workspace = workspaceId
-      ? await this.workspaceSerice.findUnique({
+      ? await this.workspaceService.findUnique({
           where: {
             id: workspaceId,
           },
         })
-      : await this.workspaceSerice.createDefaultWorkspace();
+      : await this.workspaceService.createDefaultWorkspace();
 
     assert(workspace, 'workspace is missing', BadRequestException);
 

--- a/server/src/core/workspace/services/workspace.service.spec.ts
+++ b/server/src/core/workspace/services/workspace.service.spec.ts
@@ -2,6 +2,8 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { WorkspaceService } from './workspace.service';
 import { PrismaService } from 'src/database/prisma.service';
 import { prismaMock } from 'src/database/client-mock/jest-prisma-singleton';
+import { PipelineService } from 'src/core/pipeline/services/pipeline.service';
+import { PipelineStageService } from 'src/core/pipeline/services/pipeline-stage.service';
 
 describe('WorkspaceService', () => {
   let service: WorkspaceService;
@@ -13,6 +15,14 @@ describe('WorkspaceService', () => {
         {
           provide: PrismaService,
           useValue: prismaMock,
+        },
+        {
+          provide: PipelineService,
+          useValue: {},
+        },
+        {
+          provide: PipelineStageService,
+          useValue: {},
         },
       ],
     }).compile();

--- a/server/src/core/workspace/services/workspace.service.ts
+++ b/server/src/core/workspace/services/workspace.service.ts
@@ -1,9 +1,15 @@
 import { Injectable } from '@nestjs/common';
+import { PipelineStageService } from 'src/core/pipeline/services/pipeline-stage.service';
+import { PipelineService } from 'src/core/pipeline/services/pipeline.service';
 import { PrismaService } from 'src/database/prisma.service';
 
 @Injectable()
 export class WorkspaceService {
-  constructor(private readonly prismaService: PrismaService) {}
+  constructor(
+    private readonly prismaService: PrismaService,
+    private readonly pipelineService: PipelineService,
+    private readonly pipelineStageService: PipelineStageService,
+  ) {}
 
   // Find
   findFirst = this.prismaService.workspace.findFirst;
@@ -35,4 +41,22 @@ export class WorkspaceService {
 
   // GroupBy
   groupBy = this.prismaService.workspace.groupBy;
+
+  // Customs
+  async createDefaultWorkspace() {
+    const workspace = await this.create({ data: {} });
+
+    // Create default pipeline
+    const pipeline = await this.pipelineService.createDefaultPipeline({
+      workspaceId: workspace.id,
+    });
+
+    // Create default stages
+    await this.pipelineStageService.createDefaultPipelineStages({
+      pipelineId: pipeline.id,
+      workspaceId: workspace.id,
+    });
+
+    return workspace;
+  }
 }

--- a/server/src/core/workspace/workspace.module.ts
+++ b/server/src/core/workspace/workspace.module.ts
@@ -4,8 +4,10 @@ import { WorkspaceMemberService } from './services/workspace-member.service';
 import { WorkspaceMemberResolver } from './resolvers/workspace-member.resolver';
 import { WorkspaceResolver } from './resolvers/workspace.resolver';
 import { FileUploadService } from '../file/services/file-upload.service';
+import { PipelineModule } from '../pipeline/pipeline.module';
 
 @Module({
+  imports: [PipelineModule],
   providers: [
     WorkspaceService,
     FileUploadService,


### PR DESCRIPTION
This Pull Request introduces the automatic provisioning of default pipelines when a new workspace is created. This feature simplifies the onboarding process by providing users with a set of standard pipeline stages to start with, which can be further customized as needed.

Key features introduced are:

1. **Default Pipeline Creation**: When a new workspace is created, a default sales pipeline named `Sales pipeline` is also created automatically. The pipeline is associated with the 'Company' `pipelineProgressableType` and is represented with a '💰' icon.

2. **Default Pipeline Stages**: Alongside the creation of the default pipeline, a set of default pipeline stages is also created. These stages, named 'New', 'Screening', 'Meeting', 'Proposal', and 'Customer', represent the typical sales process stages. 
