### PR TITLE
Fix flashing title for note

### DIFF
--- a/front/src/modules/activities/right-drawer/components/CommentThread.tsx
+++ b/front/src/modules/activities/right-drawer/components/CommentThread.tsx
@@ -100,7 +100,7 @@ export function CommentThread({
   });
   const commentThread = data?.findManyCommentThreads[0];
 
-  const [title, setTitle] = useState<string | null | undefined>(undefined);
+  const [title, setTitle] = useState<string | null>(null);
   const [hasUserManuallySetTitle, setHasUserManuallySetTitle] =
     useState<boolean>(false);
 
@@ -128,7 +128,7 @@ export function CommentThread({
   }
 
   useEffect(() => {
-    if (commentThread && !title) {
+    if (commentThread && !(title || title === '')) {
       setTitle(commentThread?.title ?? '');
     }
   }, [commentThread, title]);

--- a/front/src/modules/activities/right-drawer/components/CommentThread.tsx
+++ b/front/src/modules/activities/right-drawer/components/CommentThread.tsx
@@ -128,10 +128,10 @@ export function CommentThread({
   }
 
   useEffect(() => {
-    if (commentThread && !(title || title === '')) {
+    if (commentThread) {
       setTitle(commentThread?.title ?? '');
     }
-  }, [commentThread, title]);
+  }, [commentThread]);
 
   if (!commentThread) {
     return <></>;


### PR DESCRIPTION
This PR fixes the following bug:
- When creating a new note with content, the title is updated, but when I delete the content back to an empty one, the previous title is flashing in the card.