### PR TITLE
fix: 802 if no text dont show avatar

### DIFF
--- a/front/src/modules/ui/chip/components/EntityChip.tsx
+++ b/front/src/modules/ui/chip/components/EntityChip.tsx
@@ -83,7 +83,7 @@ export function EntityChip({
     navigate(linkToEntity);
   }
 
-  return clickable && linkToEntity ? (
+  return clickable && linkToEntity && name.trim() ? (
     <StyledContainerLink
       data-testid="entity-chip"
       onClick={handleLinkClick}
@@ -102,13 +102,15 @@ export function EntityChip({
     </StyledContainerLink>
   ) : (
     <StyledContainerReadOnly data-testid="entity-chip">
-      <Avatar
-        avatarUrl={picture}
-        colorId={entityId}
-        placeholder={name}
-        size={14}
-        type={avatarType}
-      />
+      {name.trim() && (
+        <Avatar
+          avatarUrl={picture}
+          colorId={entityId}
+          placeholder={name}
+          size={14}
+          type={avatarType}
+        />
+      )}
       <StyledName>
         <OverflowingTextWithTooltip text={name} />
       </StyledName>

--- a/front/src/modules/ui/chip/components/EntityChip.tsx
+++ b/front/src/modules/ui/chip/components/EntityChip.tsx
@@ -4,6 +4,7 @@ import { Theme } from '@emotion/react';
 import styled from '@emotion/styled';
 
 import { Avatar, AvatarType } from '@/users/components/Avatar';
+import { isNonEmptyString } from '~/utils/isNonEmptyString';
 
 import { OverflowingTextWithTooltip } from '../../tooltip/OverflowingTextWithTooltip';
 
@@ -83,26 +84,28 @@ export function EntityChip({
     navigate(linkToEntity);
   }
 
-  return clickable && linkToEntity && name.trim() ? (
+  return clickable && linkToEntity ? (
     <StyledContainerLink
       data-testid="entity-chip"
       onClick={handleLinkClick}
       variant={variant}
     >
-      <Avatar
-        avatarUrl={picture}
-        colorId={entityId}
-        placeholder={name}
-        size={14}
-        type={avatarType}
-      />
+      {isNonEmptyString(name) && (
+        <Avatar
+          avatarUrl={picture}
+          colorId={entityId}
+          placeholder={name}
+          size={14}
+          type={avatarType}
+        />
+      )}
       <StyledName>
         <OverflowingTextWithTooltip text={name} />
       </StyledName>
     </StyledContainerLink>
   ) : (
     <StyledContainerReadOnly data-testid="entity-chip">
-      {name.trim() && (
+      {isNonEmptyString(name) && (
         <Avatar
           avatarUrl={picture}
           colorId={entityId}


### PR DESCRIPTION
fix for https://github.com/twentyhq/twenty/issues/802.
if text empty or just whitespace, dont show avatar.
![802](https://github.com/twentyhq/twenty/assets/139059022/ef78fa43-afa2-41d0-acc2-ffefec161d7c)
