### PR TITLE
fix: 906 edit avatar style

### DIFF
--- a/front/src/modules/activities/comment/CommentHeader.tsx
+++ b/front/src/modules/activities/comment/CommentHeader.tsx
@@ -1,5 +1,4 @@
 import { Tooltip } from 'react-tooltip';
-import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 
 import { Avatar } from '@/users/components/Avatar';
@@ -64,7 +63,6 @@ const StyledTooltip = styled(Tooltip)`
 `;
 
 export function CommentHeader({ comment, actionBar }: OwnProps) {
-  const theme = useTheme();
   const beautifiedCreatedAt = beautifyPastDateRelativeToNow(comment.createdAt);
   const exactCreatedAt = beautifyExactDate(comment.createdAt);
   const showDate = beautifiedCreatedAt !== '';

--- a/front/src/modules/activities/comment/CommentHeader.tsx
+++ b/front/src/modules/activities/comment/CommentHeader.tsx
@@ -79,7 +79,7 @@ export function CommentHeader({ comment, actionBar }: OwnProps) {
       <StyledLeftContainer>
         <Avatar
           avatarUrl={avatarUrl}
-          size={theme.icon.size.md}
+          size="md"
           colorId={author.id}
           placeholder={author.displayName}
         />

--- a/front/src/modules/command-menu/components/CommandMenu.tsx
+++ b/front/src/modules/command-menu/components/CommandMenu.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { useTheme } from '@emotion/react';
 import { useRecoilValue } from 'recoil';
 
 import { useFilteredSearchCompanyQuery } from '@/companies/queries';
@@ -81,8 +80,6 @@ export function CommandMenu() {
       />
     </StyledGroup>
   );*/
-
-  const theme = useTheme();
 
   return (
     <StyledDialog

--- a/front/src/modules/command-menu/components/CommandMenu.tsx
+++ b/front/src/modules/command-menu/components/CommandMenu.tsx
@@ -112,7 +112,7 @@ export function CommandMenu() {
                 icon={
                   <Avatar
                     avatarUrl={person.avatarUrl}
-                    size={theme.icon.size.sm}
+                    size="sm"
                     colorId={person.id}
                     placeholder={person.name}
                   />
@@ -131,7 +131,7 @@ export function CommandMenu() {
                 icon={
                   <Avatar
                     avatarUrl={company.avatarUrl}
-                    size={theme.icon.size.sm}
+                    size="sm"
                     colorId={company.id}
                     placeholder={company.name}
                   />

--- a/front/src/modules/ui/chip/components/EntityChip.tsx
+++ b/front/src/modules/ui/chip/components/EntityChip.tsx
@@ -54,7 +54,7 @@ export function EntityChip({
             avatarUrl={pictureUrl}
             colorId={entityId}
             placeholder={name}
-            size={14}
+            size="sm"
             type={avatarType}
           />
         }

--- a/front/src/modules/ui/dropdown/components/__stories__/DropdownMenu.stories.tsx
+++ b/front/src/modules/ui/dropdown/components/__stories__/DropdownMenu.stories.tsx
@@ -118,7 +118,7 @@ const FakeSelectableMenuItemList = ({ hasAvatar }: { hasAvatar?: boolean }) => {
             <Avatar
               placeholder="A"
               avatarUrl={item.avatarUrl}
-              size={16}
+              size="md"
               type="squared"
             />
           )}
@@ -151,7 +151,7 @@ const FakeCheckableMenuItemList = ({ hasAvatar }: { hasAvatar?: boolean }) => {
             <Avatar
               placeholder="A"
               avatarUrl={item.avatarUrl}
-              size={16}
+              size="md"
               type="squared"
             />
           )}

--- a/front/src/modules/ui/layout/show-page/components/ShowPageSummaryCard.tsx
+++ b/front/src/modules/ui/layout/show-page/components/ShowPageSummaryCard.tsx
@@ -1,5 +1,4 @@
 import { Tooltip } from 'react-tooltip';
-import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { v4 as uuidV4 } from 'uuid';
 
@@ -70,18 +69,16 @@ export function ShowPageSummaryCard({
   const beautifiedCreatedAt =
     date !== '' ? beautifyPastDateRelativeToNow(date) : '';
   const exactCreatedAt = date !== '' ? beautifyExactDate(date) : '';
-  const theme = useTheme();
   const dateElementId = `date-id-${uuidV4()}`;
 
   return (
     <StyledShowPageSummaryCard>
       <Avatar
         avatarUrl={logoOrAvatar}
-        size={theme.icon.size.xl}
+        size="xl"
         colorId={id}
         placeholder={title}
         type="rounded"
-        fontSize={theme.font.size.md}
       />
       <StyledInfoContainer>
         <StyledTitle>

--- a/front/src/modules/ui/layout/show-page/components/ShowPageSummaryCard.tsx
+++ b/front/src/modules/ui/layout/show-page/components/ShowPageSummaryCard.tsx
@@ -80,6 +80,8 @@ export function ShowPageSummaryCard({
         size={theme.icon.size.xl}
         colorId={id}
         placeholder={title}
+        type="rounded"
+        fontSize={theme.font.size.md}
       />
       <StyledInfoContainer>
         <StyledTitle>

--- a/front/src/modules/ui/relation-picker/components/MultipleEntitySelect.tsx
+++ b/front/src/modules/ui/relation-picker/components/MultipleEntitySelect.tsx
@@ -74,7 +74,7 @@ export function MultipleEntitySelect<
               avatarUrl={entity.avatarUrl}
               colorId={entity.id}
               placeholder={entity.name}
-              size={16}
+              size="md"
               type={entity.avatarType ?? 'rounded'}
             />
             {entity.name}

--- a/front/src/modules/ui/relation-picker/components/SingleEntitySelectBase.tsx
+++ b/front/src/modules/ui/relation-picker/components/SingleEntitySelectBase.tsx
@@ -86,7 +86,7 @@ export function SingleEntitySelectBase<
               avatarUrl={entity.avatarUrl}
               colorId={entity.id}
               placeholder={entity.name}
-              size={16}
+              size="md"
               type={entity.avatarType ?? 'rounded'}
             />
             <OverflowingTextWithTooltip text={entity.name} />

--- a/front/src/modules/users/components/Avatar.tsx
+++ b/front/src/modules/users/components/Avatar.tsx
@@ -1,3 +1,4 @@
+import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 
 import { isNonEmptyString } from '~/utils/isNonEmptyString';
@@ -13,6 +14,7 @@ type OwnProps = {
   placeholder: string;
   colorId?: string;
   type?: AvatarType;
+  fontSize?: string;
 };
 
 export const StyledAvatar = styled.div<OwnProps & { colorId: string }>`
@@ -27,7 +29,7 @@ export const StyledAvatar = styled.div<OwnProps & { colorId: string }>`
   display: flex;
 
   flex-shrink: 0;
-  font-size: ${({ theme }) => theme.font.size.xs};
+  font-size: ${(props) => props.fontSize};
   font-weight: ${({ theme }) => theme.font.weight.medium};
 
   height: ${(props) => props.size}px;
@@ -41,8 +43,10 @@ export function Avatar({
   placeholder,
   colorId = placeholder,
   type = 'squared',
+  fontSize,
 }: OwnProps) {
   const noAvatarUrl = !isNonEmptyString(avatarUrl);
+  const theme = useTheme();
 
   return (
     <StyledAvatar
@@ -51,6 +55,7 @@ export function Avatar({
       size={size}
       type={type}
       colorId={colorId}
+      fontSize={fontSize || theme.font.size.xs}
     >
       {noAvatarUrl && placeholder[0]?.toLocaleUpperCase()}
     </StyledAvatar>

--- a/front/src/modules/users/components/Avatar.tsx
+++ b/front/src/modules/users/components/Avatar.tsx
@@ -1,4 +1,3 @@
-import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 
 import { isNonEmptyString } from '~/utils/isNonEmptyString';
@@ -7,14 +6,14 @@ import { stringToHslColor } from '~/utils/string-to-hsl';
 import { getImageAbsoluteURIOrBase64 } from '../utils/getProfilePictureAbsoluteURI';
 
 export type AvatarType = 'squared' | 'rounded';
+export type AvatarSize = 'xl' | 'lg' | 'md' | 'sm' | 'xs';
 
 type OwnProps = {
   avatarUrl: string | null | undefined;
-  size: number;
+  size: AvatarSize;
   placeholder: string;
   colorId?: string;
   type?: AvatarType;
-  fontSize?: string;
 };
 
 export const StyledAvatar = styled.div<OwnProps & { colorId: string }>`
@@ -29,12 +28,54 @@ export const StyledAvatar = styled.div<OwnProps & { colorId: string }>`
   display: flex;
 
   flex-shrink: 0;
-  font-size: ${(props) => props.fontSize};
+  font-size: ${({ size }) => {
+    switch (size) {
+      case 'xl':
+        return '16px';
+      case 'lg':
+        return '13px';
+      case 'md':
+      default:
+        return '12px';
+      case 'sm':
+        return '10px';
+      case 'xs':
+        return '8px';
+    }
+  }};
   font-weight: ${({ theme }) => theme.font.weight.medium};
 
-  height: ${(props) => props.size}px;
+  height: ${({ size }) => {
+    switch (size) {
+      case 'xl':
+        return '40px';
+      case 'lg':
+        return '24px';
+      case 'md':
+      default:
+        return '16px';
+      case 'sm':
+        return '14px';
+      case 'xs':
+        return '12px';
+    }
+  }};
   justify-content: center;
-  width: ${(props) => props.size}px;
+  width: ${({ size }) => {
+    switch (size) {
+      case 'xl':
+        return '40px';
+      case 'lg':
+        return '24px';
+      case 'md':
+      default:
+        return '16px';
+      case 'sm':
+        return '14px';
+      case 'xs':
+        return '12px';
+    }
+  }};
 `;
 
 export function Avatar({
@@ -43,10 +84,8 @@ export function Avatar({
   placeholder,
   colorId = placeholder,
   type = 'squared',
-  fontSize,
 }: OwnProps) {
   const noAvatarUrl = !isNonEmptyString(avatarUrl);
-  const theme = useTheme();
 
   return (
     <StyledAvatar
@@ -55,7 +94,6 @@ export function Avatar({
       size={size}
       type={type}
       colorId={colorId}
-      fontSize={fontSize || theme.font.size.xs}
     >
       {noAvatarUrl && placeholder[0]?.toLocaleUpperCase()}
     </StyledAvatar>

--- a/front/src/modules/users/components/__stories__/Avatar.stories.tsx
+++ b/front/src/modules/users/components/__stories__/Avatar.stories.tsx
@@ -9,7 +9,7 @@ const meta: Meta<typeof Avatar> = {
   title: 'Modules/Users/Avatar',
   component: Avatar,
   decorators: [ComponentDecorator],
-  args: { avatarUrl, size: 16, placeholder: 'L', type: 'rounded' },
+  args: { avatarUrl, size: 'md', placeholder: 'L', type: 'rounded' },
 };
 
 export default meta;

--- a/front/src/modules/workspace/components/WorkspaceMemberCard.tsx
+++ b/front/src/modules/workspace/components/WorkspaceMemberCard.tsx
@@ -48,7 +48,7 @@ export function WorkspaceMemberCard({ workspaceMember, accessory }: OwnProps) {
         colorId={workspaceMember.user.id}
         placeholder={workspaceMember.user.firstName || ''}
         type="squared"
-        size={40}
+        size="xl"
       />
       <Content>
         <NameText>{workspaceMember.user.displayName}</NameText>


### PR DESCRIPTION
fix for https://github.com/twentyhq/twenty/issues/906

i added fontsize prop to avatar, and at issue for font size it was 16px medium. i used existing medium font which in rem. also i can add in px?

![906](https://github.com/twentyhq/twenty/assets/139059022/21be55f1-2667-4b21-abc7-028469665a53)
