### PR TITLE
Add pull request previews

### DIFF
--- a/.ergomake/docker-compose.yml
+++ b/.ergomake/docker-compose.yml
@@ -1,0 +1,44 @@
+version: "3.9"
+services:
+  front:
+    build:
+      context: ..
+      dockerfile: ./infra/prod/front/Dockerfile
+      args:
+        REACT_APP_API_URL: "http://localhost:3000/graphql"
+        REACT_APP_AUTH_URL: "http://localhost:3000/auth"
+        REACT_APP_FILES_URL: "http://localhost:3000/files"
+    ports:
+      - "3001:3000"
+    labels:
+      dev.ergomake.env.replace-arg.REACT_APP_API_URL: "https://{{ services.server.url }}/graphql"
+      dev.ergomake.env.replace-arg.REACT_APP_AUTH_URL: "https://{{ services.server.url }}/auth"
+      dev.ergomake.env.replace-arg.REACT_APP_FILES_URL: "https://{{ services.server.url }}/files"
+  server:
+    build:
+      context: ..
+      dockerfile: ./infra/prod/server/Dockerfile
+    command: sh -c "yarn prisma migrate reset --force && node dist/src/main"
+    ports:
+      - "3000:3000"
+    environment:
+      DEBUG_MODE: false
+      DEMO_MODE: true
+      ACCESS_TOKEN_SECRET: "secret_jwt"
+      ACCESS_TOKEN_EXPIRES_IN: "30m"
+      LOGIN_TOKEN_SECRET: "secret_login_token"
+      LOGIN_TOKEN_EXPIRES_IN: "15m"
+      REFRESH_TOKEN_SECRET: "secret_refresh_token"
+      REFRESH_TOKEN_EXPIRES_IN: "90d"
+      PG_DATABASE_URL: "postgres://postgres:postgrespassword@postgres:5432/default?connection_limit=1"
+      FRONT_AUTH_CALLBACK_URL: "http://localhost:3000/verify"
+      STORAGE_TYPE: "local"
+      STORAGE_LOCAL_PATH: ".local-storage"
+    labels:
+      dev.ergomake.env.replace-env.FRONT_AUTH_CALLBACK_URL: "https://{{ services.server.url }}/verify"
+  postgres:
+    build: ../infra/dev/postgres
+    environment:
+      POSTGRES_PASSWORD: postgrespassword
+    ports:
+      - "5432"


### PR DESCRIPTION
Hey folks — hello from the S23 batch 👋 

Here's the PR implementing the preview links for every pull request at Twenty.

Here's what it will look like after merged:

<img width="917" alt="Screenshot 2023-07-26 at 12 25 28" src="https://github.com/twentyhq/twenty/assets/6868147/23f8717f-d7fc-4f65-8540-ad26d54f30a5">

[You can see a live example on our fork here](https://github.com/ergomake/twenty/pull/1).


# Next steps

1. [Install our GitHub app](https://github.com/apps/ergomake).
2. Merge this pull request
3. Open a new pull request with changes!

_If you want to get a preview at this very pull request, reopen this PR after installing the GitHub app to trigger the integration_.

**I'd also recommend you to set-up a permanent branch on [our dashboard](https://app.ergomake.dev) to use as `staging`.** That way, you can have a `staging` link always deployed.


# How it works

Every time someone opens a PR, the GitHub integration gets triggered. If a compose file exists, we'll use that to spin up infrastructure on our side. Then, we'll post a link here.

Environments that are not active for 1-hour will "go to sleep", meaning they will have to be spun up again "on-demand" when you click the link.