### PR TITLE
feat: implement user impersonation feature

### DIFF
--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -5,9 +5,11 @@ import { SettingsPath } from '@/types/SettingsPath';
 import { DefaultLayout } from '@/ui/layout/components/DefaultLayout';
 import { CreateProfile } from '~/pages/auth/CreateProfile';
 import { CreateWorkspace } from '~/pages/auth/CreateWorkspace';
+import { SignInUp } from '~/pages/auth/SignInUp';
 import { Verify } from '~/pages/auth/Verify';
 import { Companies } from '~/pages/companies/Companies';
 import { CompanyShow } from '~/pages/companies/CompanyShow';
+import { Impersonate } from '~/pages/impersonate/Impersonate';
 import { Opportunities } from '~/pages/opportunities/Opportunities';
 import { People } from '~/pages/people/People';
 import { PersonShow } from '~/pages/people/PersonShow';
@@ -16,8 +18,6 @@ import { SettingsProfile } from '~/pages/settings/SettingsProfile';
 import { SettingsWorksapce } from '~/pages/settings/SettingsWorkspace';
 import { SettingsWorkspaceMembers } from '~/pages/settings/SettingsWorkspaceMembers';
 import { AppInternalHooks } from '~/sync-hooks/AppInternalHooks';
-
-import { SignInUp } from './pages/auth/SignInUp';
 
 // TEMP FEATURE FLAG FOR VIEW FIELDS
 export const ACTIVATE_VIEW_FIELDS = true;
@@ -39,6 +39,7 @@ export function App() {
           <Route path={AppPath.PersonShowPage} element={<PersonShow />} />
           <Route path={AppPath.CompaniesPage} element={<Companies />} />
           <Route path={AppPath.CompanyShowPage} element={<CompanyShow />} />
+          <Route path={AppPath.Impersonate} element={<Impersonate />} />
 
           <Route path={AppPath.OpportunitiesPage} element={<Opportunities />} />
           <Route

--- a/front/src/generated/graphql.tsx
+++ b/front/src/generated/graphql.tsx
@@ -896,6 +896,7 @@ export type Mutation = {
   deleteManyPipelineProgress: AffectedRows;
   deleteUserAccount: User;
   deleteWorkspaceMember: WorkspaceMember;
+  impersonate: Verify;
   renewToken: AuthTokens;
   signUp: LoginToken;
   updateOneActivity: Activity;
@@ -974,6 +975,11 @@ export type MutationDeleteManyPipelineProgressArgs = {
 
 export type MutationDeleteWorkspaceMemberArgs = {
   where: WorkspaceMemberWhereUniqueInput;
+};
+
+
+export type MutationImpersonateArgs = {
+  userId: Scalars['String'];
 };
 
 
@@ -1835,10 +1841,12 @@ export type Telemetry = {
 
 export type User = {
   __typename?: 'User';
+  allowImpersonation: Scalars['Boolean'];
   assignedActivities?: Maybe<Array<Activity>>;
   authoredActivities?: Maybe<Array<Activity>>;
   authoredAttachments?: Maybe<Array<Attachment>>;
   avatarUrl?: Maybe<Scalars['String']>;
+  canImpersonate: Scalars['Boolean'];
   comments?: Maybe<Array<Comment>>;
   companies?: Maybe<Array<Company>>;
   createdAt: Scalars['DateTime'];
@@ -1881,10 +1889,12 @@ export type UserExists = {
 };
 
 export type UserOrderByWithRelationInput = {
+  allowImpersonation?: InputMaybe<SortOrder>;
   assignedActivities?: InputMaybe<ActivityOrderByRelationAggregateInput>;
   authoredActivities?: InputMaybe<ActivityOrderByRelationAggregateInput>;
   authoredAttachments?: InputMaybe<AttachmentOrderByRelationAggregateInput>;
   avatarUrl?: InputMaybe<SortOrder>;
+  canImpersonate?: InputMaybe<SortOrder>;
   comments?: InputMaybe<CommentOrderByRelationAggregateInput>;
   companies?: InputMaybe<CompanyOrderByRelationAggregateInput>;
   createdAt?: InputMaybe<SortOrder>;
@@ -1909,7 +1919,9 @@ export type UserRelationFilter = {
 };
 
 export enum UserScalarFieldEnum {
+  AllowImpersonation = 'allowImpersonation',
   AvatarUrl = 'avatarUrl',
+  CanImpersonate = 'canImpersonate',
   CreatedAt = 'createdAt',
   DeletedAt = 'deletedAt',
   Disabled = 'disabled',
@@ -1976,10 +1988,12 @@ export type UserSettingsWhereInput = {
 };
 
 export type UserUpdateInput = {
+  allowImpersonation?: InputMaybe<Scalars['Boolean']>;
   assignedActivities?: InputMaybe<ActivityUpdateManyWithoutAssigneeNestedInput>;
   authoredActivities?: InputMaybe<ActivityUpdateManyWithoutAuthorNestedInput>;
   authoredAttachments?: InputMaybe<AttachmentUpdateManyWithoutAuthorNestedInput>;
   avatarUrl?: InputMaybe<Scalars['String']>;
+  canImpersonate?: InputMaybe<Scalars['Boolean']>;
   comments?: InputMaybe<CommentUpdateManyWithoutAuthorNestedInput>;
   companies?: InputMaybe<CompanyUpdateManyWithoutAccountOwnerNestedInput>;
   createdAt?: InputMaybe<Scalars['DateTime']>;
@@ -2015,10 +2029,12 @@ export type UserWhereInput = {
   AND?: InputMaybe<Array<UserWhereInput>>;
   NOT?: InputMaybe<Array<UserWhereInput>>;
   OR?: InputMaybe<Array<UserWhereInput>>;
+  allowImpersonation?: InputMaybe<BoolFilter>;
   assignedActivities?: InputMaybe<ActivityListRelationFilter>;
   authoredActivities?: InputMaybe<ActivityListRelationFilter>;
   authoredAttachments?: InputMaybe<AttachmentListRelationFilter>;
   avatarUrl?: InputMaybe<StringNullableFilter>;
+  canImpersonate?: InputMaybe<BoolFilter>;
   comments?: InputMaybe<CommentListRelationFilter>;
   companies?: InputMaybe<CompanyListRelationFilter>;
   createdAt?: InputMaybe<DateTimeFilter>;
@@ -2321,7 +2337,7 @@ export type VerifyMutationVariables = Exact<{
 }>;
 
 
-export type VerifyMutation = { __typename?: 'Mutation', verify: { __typename?: 'Verify', user: { __typename?: 'User', id: string, email: string, displayName: string, firstName?: string | null, lastName?: string | null, workspaceMember?: { __typename?: 'WorkspaceMember', id: string, workspace: { __typename?: 'Workspace', id: string, domainName?: string | null, displayName?: string | null, logo?: string | null, inviteHash?: string | null } } | null, settings: { __typename?: 'UserSettings', id: string, colorScheme: ColorScheme, locale: string } }, tokens: { __typename?: 'AuthTokenPair', accessToken: { __typename?: 'AuthToken', token: string, expiresAt: string }, refreshToken: { __typename?: 'AuthToken', token: string, expiresAt: string } } } };
+export type VerifyMutation = { __typename?: 'Mutation', verify: { __typename?: 'Verify', user: { __typename?: 'User', id: string, email: string, displayName: string, firstName?: string | null, lastName?: string | null, allowImpersonation: boolean, workspaceMember?: { __typename?: 'WorkspaceMember', id: string, workspace: { __typename?: 'Workspace', id: string, domainName?: string | null, displayName?: string | null, logo?: string | null, inviteHash?: string | null } } | null, settings: { __typename?: 'UserSettings', id: string, colorScheme: ColorScheme, locale: string } }, tokens: { __typename?: 'AuthTokenPair', accessToken: { __typename?: 'AuthToken', token: string, expiresAt: string }, refreshToken: { __typename?: 'AuthToken', token: string, expiresAt: string } } } };
 
 export type RenewTokenMutationVariables = Exact<{
   refreshToken: Scalars['String'];
@@ -2563,7 +2579,7 @@ export type SearchActivityQuery = { __typename?: 'Query', searchResults: Array<{
 export type GetCurrentUserQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetCurrentUserQuery = { __typename?: 'Query', currentUser: { __typename?: 'User', id: string, email: string, displayName: string, firstName?: string | null, lastName?: string | null, avatarUrl?: string | null, workspaceMember?: { __typename?: 'WorkspaceMember', id: string, workspace: { __typename?: 'Workspace', id: string, domainName?: string | null, displayName?: string | null, logo?: string | null, inviteHash?: string | null } } | null, settings: { __typename?: 'UserSettings', id: string, locale: string, colorScheme: ColorScheme } } };
+export type GetCurrentUserQuery = { __typename?: 'Query', currentUser: { __typename?: 'User', id: string, email: string, displayName: string, firstName?: string | null, lastName?: string | null, avatarUrl?: string | null, allowImpersonation: boolean, workspaceMember?: { __typename?: 'WorkspaceMember', id: string, workspace: { __typename?: 'Workspace', id: string, domainName?: string | null, displayName?: string | null, logo?: string | null, inviteHash?: string | null } } | null, settings: { __typename?: 'UserSettings', id: string, locale: string, colorScheme: ColorScheme } } };
 
 export type GetUsersQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -3265,6 +3281,7 @@ export const VerifyDocument = gql`
       displayName
       firstName
       lastName
+      allowImpersonation
       workspaceMember {
         id
         workspace {
@@ -4606,6 +4623,7 @@ export const GetCurrentUserDocument = gql`
     firstName
     lastName
     avatarUrl
+    allowImpersonation
     workspaceMember {
       id
       workspace {

--- a/front/src/generated/graphql.tsx
+++ b/front/src/generated/graphql.tsx
@@ -882,6 +882,7 @@ export type LoginToken = {
 
 export type Mutation = {
   __typename?: 'Mutation';
+  allowImpersonation: WorkspaceMember;
   challenge: LoginToken;
   createEvent: Analytics;
   createOneActivity: Activity;
@@ -913,6 +914,11 @@ export type Mutation = {
   uploadProfilePicture: Scalars['String'];
   uploadWorkspaceLogo: Scalars['String'];
   verify: Verify;
+};
+
+
+export type MutationAllowImpersonationArgs = {
+  allowImpersonation: Scalars['Boolean'];
 };
 
 
@@ -1841,7 +1847,6 @@ export type Telemetry = {
 
 export type User = {
   __typename?: 'User';
-  allowImpersonation: Scalars['Boolean'];
   assignedActivities?: Maybe<Array<Activity>>;
   authoredActivities?: Maybe<Array<Activity>>;
   authoredAttachments?: Maybe<Array<Attachment>>;
@@ -1889,7 +1894,6 @@ export type UserExists = {
 };
 
 export type UserOrderByWithRelationInput = {
-  allowImpersonation?: InputMaybe<SortOrder>;
   assignedActivities?: InputMaybe<ActivityOrderByRelationAggregateInput>;
   authoredActivities?: InputMaybe<ActivityOrderByRelationAggregateInput>;
   authoredAttachments?: InputMaybe<AttachmentOrderByRelationAggregateInput>;
@@ -1919,7 +1923,6 @@ export type UserRelationFilter = {
 };
 
 export enum UserScalarFieldEnum {
-  AllowImpersonation = 'allowImpersonation',
   AvatarUrl = 'avatarUrl',
   CanImpersonate = 'canImpersonate',
   CreatedAt = 'createdAt',
@@ -1988,7 +1991,6 @@ export type UserSettingsWhereInput = {
 };
 
 export type UserUpdateInput = {
-  allowImpersonation?: InputMaybe<Scalars['Boolean']>;
   assignedActivities?: InputMaybe<ActivityUpdateManyWithoutAssigneeNestedInput>;
   authoredActivities?: InputMaybe<ActivityUpdateManyWithoutAuthorNestedInput>;
   authoredAttachments?: InputMaybe<AttachmentUpdateManyWithoutAuthorNestedInput>;
@@ -2029,7 +2031,6 @@ export type UserWhereInput = {
   AND?: InputMaybe<Array<UserWhereInput>>;
   NOT?: InputMaybe<Array<UserWhereInput>>;
   OR?: InputMaybe<Array<UserWhereInput>>;
-  allowImpersonation?: InputMaybe<BoolFilter>;
   assignedActivities?: InputMaybe<ActivityListRelationFilter>;
   authoredActivities?: InputMaybe<ActivityListRelationFilter>;
   authoredAttachments?: InputMaybe<AttachmentListRelationFilter>;
@@ -2154,6 +2155,7 @@ export type WorkspaceInviteHashValid = {
 
 export type WorkspaceMember = {
   __typename?: 'WorkspaceMember';
+  allowImpersonation: Scalars['Boolean'];
   createdAt: Scalars['DateTime'];
   id: Scalars['ID'];
   updatedAt: Scalars['DateTime'];
@@ -2163,6 +2165,7 @@ export type WorkspaceMember = {
 };
 
 export type WorkspaceMemberOrderByWithRelationInput = {
+  allowImpersonation?: InputMaybe<SortOrder>;
   createdAt?: InputMaybe<SortOrder>;
   id?: InputMaybe<SortOrder>;
   updatedAt?: InputMaybe<SortOrder>;
@@ -2171,6 +2174,7 @@ export type WorkspaceMemberOrderByWithRelationInput = {
 };
 
 export enum WorkspaceMemberScalarFieldEnum {
+  AllowImpersonation = 'allowImpersonation',
   CreatedAt = 'createdAt',
   DeletedAt = 'deletedAt',
   Id = 'id',
@@ -2189,6 +2193,7 @@ export type WorkspaceMemberWhereInput = {
   AND?: InputMaybe<Array<WorkspaceMemberWhereInput>>;
   NOT?: InputMaybe<Array<WorkspaceMemberWhereInput>>;
   OR?: InputMaybe<Array<WorkspaceMemberWhereInput>>;
+  allowImpersonation?: InputMaybe<BoolFilter>;
   createdAt?: InputMaybe<DateTimeFilter>;
   id?: InputMaybe<StringFilter>;
   updatedAt?: InputMaybe<DateTimeFilter>;
@@ -2337,7 +2342,7 @@ export type VerifyMutationVariables = Exact<{
 }>;
 
 
-export type VerifyMutation = { __typename?: 'Mutation', verify: { __typename?: 'Verify', user: { __typename?: 'User', id: string, email: string, displayName: string, firstName?: string | null, lastName?: string | null, allowImpersonation: boolean, workspaceMember?: { __typename?: 'WorkspaceMember', id: string, workspace: { __typename?: 'Workspace', id: string, domainName?: string | null, displayName?: string | null, logo?: string | null, inviteHash?: string | null } } | null, settings: { __typename?: 'UserSettings', id: string, colorScheme: ColorScheme, locale: string } }, tokens: { __typename?: 'AuthTokenPair', accessToken: { __typename?: 'AuthToken', token: string, expiresAt: string }, refreshToken: { __typename?: 'AuthToken', token: string, expiresAt: string } } } };
+export type VerifyMutation = { __typename?: 'Mutation', verify: { __typename?: 'Verify', user: { __typename?: 'User', id: string, email: string, displayName: string, firstName?: string | null, lastName?: string | null, canImpersonate: boolean, workspaceMember?: { __typename?: 'WorkspaceMember', id: string, allowImpersonation: boolean, workspace: { __typename?: 'Workspace', id: string, domainName?: string | null, displayName?: string | null, logo?: string | null, inviteHash?: string | null } } | null, settings: { __typename?: 'UserSettings', id: string, colorScheme: ColorScheme, locale: string } }, tokens: { __typename?: 'AuthTokenPair', accessToken: { __typename?: 'AuthToken', token: string, expiresAt: string }, refreshToken: { __typename?: 'AuthToken', token: string, expiresAt: string } } } };
 
 export type RenewTokenMutationVariables = Exact<{
   refreshToken: Scalars['String'];
@@ -2345,6 +2350,13 @@ export type RenewTokenMutationVariables = Exact<{
 
 
 export type RenewTokenMutation = { __typename?: 'Mutation', renewToken: { __typename?: 'AuthTokens', tokens: { __typename?: 'AuthTokenPair', accessToken: { __typename?: 'AuthToken', expiresAt: string, token: string }, refreshToken: { __typename?: 'AuthToken', token: string, expiresAt: string } } } };
+
+export type ImpersonateMutationVariables = Exact<{
+  userId: Scalars['String'];
+}>;
+
+
+export type ImpersonateMutation = { __typename?: 'Mutation', impersonate: { __typename?: 'Verify', user: { __typename?: 'User', id: string, email: string, displayName: string, firstName?: string | null, lastName?: string | null, canImpersonate: boolean, workspaceMember?: { __typename?: 'WorkspaceMember', id: string, allowImpersonation: boolean, workspace: { __typename?: 'Workspace', id: string, domainName?: string | null, displayName?: string | null, logo?: string | null, inviteHash?: string | null } } | null, settings: { __typename?: 'UserSettings', id: string, colorScheme: ColorScheme, locale: string } }, tokens: { __typename?: 'AuthTokenPair', accessToken: { __typename?: 'AuthToken', token: string, expiresAt: string }, refreshToken: { __typename?: 'AuthToken', token: string, expiresAt: string } } } };
 
 export type GetClientConfigQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -2579,7 +2591,7 @@ export type SearchActivityQuery = { __typename?: 'Query', searchResults: Array<{
 export type GetCurrentUserQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetCurrentUserQuery = { __typename?: 'Query', currentUser: { __typename?: 'User', id: string, email: string, displayName: string, firstName?: string | null, lastName?: string | null, avatarUrl?: string | null, allowImpersonation: boolean, workspaceMember?: { __typename?: 'WorkspaceMember', id: string, workspace: { __typename?: 'Workspace', id: string, domainName?: string | null, displayName?: string | null, logo?: string | null, inviteHash?: string | null } } | null, settings: { __typename?: 'UserSettings', id: string, locale: string, colorScheme: ColorScheme } } };
+export type GetCurrentUserQuery = { __typename?: 'Query', currentUser: { __typename?: 'User', id: string, email: string, displayName: string, firstName?: string | null, lastName?: string | null, avatarUrl?: string | null, canImpersonate: boolean, workspaceMember?: { __typename?: 'WorkspaceMember', id: string, allowImpersonation: boolean, workspace: { __typename?: 'Workspace', id: string, domainName?: string | null, displayName?: string | null, logo?: string | null, inviteHash?: string | null } } | null, settings: { __typename?: 'UserSettings', id: string, locale: string, colorScheme: ColorScheme } } };
 
 export type GetUsersQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -2593,6 +2605,13 @@ export type UpdateUserMutationVariables = Exact<{
 
 
 export type UpdateUserMutation = { __typename?: 'Mutation', updateUser: { __typename?: 'User', id: string, email: string, displayName: string, firstName?: string | null, lastName?: string | null, avatarUrl?: string | null, workspaceMember?: { __typename?: 'WorkspaceMember', id: string, workspace: { __typename?: 'Workspace', id: string, domainName?: string | null, displayName?: string | null, logo?: string | null, inviteHash?: string | null } } | null, settings: { __typename?: 'UserSettings', id: string, locale: string, colorScheme: ColorScheme } } };
+
+export type UpdateAllowImpersonationMutationVariables = Exact<{
+  allowImpersonation: Scalars['Boolean'];
+}>;
+
+
+export type UpdateAllowImpersonationMutation = { __typename?: 'Mutation', allowImpersonation: { __typename?: 'WorkspaceMember', id: string, allowImpersonation: boolean } };
 
 export type UploadProfilePictureMutationVariables = Exact<{
   file: Scalars['Upload'];
@@ -3281,9 +3300,10 @@ export const VerifyDocument = gql`
       displayName
       firstName
       lastName
-      allowImpersonation
+      canImpersonate
       workspaceMember {
         id
+        allowImpersonation
         workspace {
           id
           domainName
@@ -3379,6 +3399,72 @@ export function useRenewTokenMutation(baseOptions?: Apollo.MutationHookOptions<R
 export type RenewTokenMutationHookResult = ReturnType<typeof useRenewTokenMutation>;
 export type RenewTokenMutationResult = Apollo.MutationResult<RenewTokenMutation>;
 export type RenewTokenMutationOptions = Apollo.BaseMutationOptions<RenewTokenMutation, RenewTokenMutationVariables>;
+export const ImpersonateDocument = gql`
+    mutation Impersonate($userId: String!) {
+  impersonate(userId: $userId) {
+    user {
+      id
+      email
+      displayName
+      firstName
+      lastName
+      canImpersonate
+      workspaceMember {
+        id
+        allowImpersonation
+        workspace {
+          id
+          domainName
+          displayName
+          logo
+          inviteHash
+        }
+      }
+      settings {
+        id
+        colorScheme
+        locale
+      }
+    }
+    tokens {
+      accessToken {
+        token
+        expiresAt
+      }
+      refreshToken {
+        token
+        expiresAt
+      }
+    }
+  }
+}
+    `;
+export type ImpersonateMutationFn = Apollo.MutationFunction<ImpersonateMutation, ImpersonateMutationVariables>;
+
+/**
+ * __useImpersonateMutation__
+ *
+ * To run a mutation, you first call `useImpersonateMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useImpersonateMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [impersonateMutation, { data, loading, error }] = useImpersonateMutation({
+ *   variables: {
+ *      userId: // value for 'userId'
+ *   },
+ * });
+ */
+export function useImpersonateMutation(baseOptions?: Apollo.MutationHookOptions<ImpersonateMutation, ImpersonateMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<ImpersonateMutation, ImpersonateMutationVariables>(ImpersonateDocument, options);
+      }
+export type ImpersonateMutationHookResult = ReturnType<typeof useImpersonateMutation>;
+export type ImpersonateMutationResult = Apollo.MutationResult<ImpersonateMutation>;
+export type ImpersonateMutationOptions = Apollo.BaseMutationOptions<ImpersonateMutation, ImpersonateMutationVariables>;
 export const GetClientConfigDocument = gql`
     query GetClientConfig {
   clientConfig {
@@ -4623,9 +4709,10 @@ export const GetCurrentUserDocument = gql`
     firstName
     lastName
     avatarUrl
-    allowImpersonation
+    canImpersonate
     workspaceMember {
       id
+      allowImpersonation
       workspace {
         id
         domainName
@@ -4761,6 +4848,40 @@ export function useUpdateUserMutation(baseOptions?: Apollo.MutationHookOptions<U
 export type UpdateUserMutationHookResult = ReturnType<typeof useUpdateUserMutation>;
 export type UpdateUserMutationResult = Apollo.MutationResult<UpdateUserMutation>;
 export type UpdateUserMutationOptions = Apollo.BaseMutationOptions<UpdateUserMutation, UpdateUserMutationVariables>;
+export const UpdateAllowImpersonationDocument = gql`
+    mutation UpdateAllowImpersonation($allowImpersonation: Boolean!) {
+  allowImpersonation(allowImpersonation: $allowImpersonation) {
+    id
+    allowImpersonation
+  }
+}
+    `;
+export type UpdateAllowImpersonationMutationFn = Apollo.MutationFunction<UpdateAllowImpersonationMutation, UpdateAllowImpersonationMutationVariables>;
+
+/**
+ * __useUpdateAllowImpersonationMutation__
+ *
+ * To run a mutation, you first call `useUpdateAllowImpersonationMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdateAllowImpersonationMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [updateAllowImpersonationMutation, { data, loading, error }] = useUpdateAllowImpersonationMutation({
+ *   variables: {
+ *      allowImpersonation: // value for 'allowImpersonation'
+ *   },
+ * });
+ */
+export function useUpdateAllowImpersonationMutation(baseOptions?: Apollo.MutationHookOptions<UpdateAllowImpersonationMutation, UpdateAllowImpersonationMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateAllowImpersonationMutation, UpdateAllowImpersonationMutationVariables>(UpdateAllowImpersonationDocument, options);
+      }
+export type UpdateAllowImpersonationMutationHookResult = ReturnType<typeof useUpdateAllowImpersonationMutation>;
+export type UpdateAllowImpersonationMutationResult = Apollo.MutationResult<UpdateAllowImpersonationMutation>;
+export type UpdateAllowImpersonationMutationOptions = Apollo.BaseMutationOptions<UpdateAllowImpersonationMutation, UpdateAllowImpersonationMutationVariables>;
 export const UploadProfilePictureDocument = gql`
     mutation UploadProfilePicture($file: Upload!) {
   uploadProfilePicture(file: $file)

--- a/front/src/modules/auth/queries/update.ts
+++ b/front/src/modules/auth/queries/update.ts
@@ -39,6 +39,7 @@ export const VERIFY = gql`
         displayName
         firstName
         lastName
+        allowImpersonation
         workspaceMember {
           id
           workspace {

--- a/front/src/modules/auth/queries/update.ts
+++ b/front/src/modules/auth/queries/update.ts
@@ -39,9 +39,10 @@ export const VERIFY = gql`
         displayName
         firstName
         lastName
-        allowImpersonation
+        canImpersonate
         workspaceMember {
           id
+          allowImpersonation
           workspace {
             id
             domainName
@@ -77,6 +78,48 @@ export const RENEW_TOKEN = gql`
         accessToken {
           expiresAt
           token
+        }
+        refreshToken {
+          token
+          expiresAt
+        }
+      }
+    }
+  }
+`;
+
+// TODO: Fragments should be used instead of duplicating the user fields !
+export const IMPERSONATE = gql`
+  mutation Impersonate($userId: String!) {
+    impersonate(userId: $userId) {
+      user {
+        id
+        email
+        displayName
+        firstName
+        lastName
+        canImpersonate
+        workspaceMember {
+          id
+          allowImpersonation
+          workspace {
+            id
+            domainName
+            displayName
+            logo
+            inviteHash
+          }
+        }
+        settings {
+          id
+          colorScheme
+          locale
+        }
+      }
+      tokens {
+        accessToken {
+          token
+          expiresAt
         }
         refreshToken {
           token

--- a/front/src/modules/settings/profile/components/ToggleField.tsx
+++ b/front/src/modules/settings/profile/components/ToggleField.tsx
@@ -1,34 +1,26 @@
-import { getOperationName } from '@apollo/client/utilities';
 import { useRecoilValue } from 'recoil';
 
 import { currentUserState } from '@/auth/states/currentUserState';
 import { Toggle } from '@/ui/input/toggle/components/Toggle';
 import { useSnackBar } from '@/ui/snack-bar/hooks/useSnackBar';
-import { GET_CURRENT_USER } from '@/users/queries';
-import { useUpdateUserMutation } from '~/generated/graphql';
+import { useUpdateAllowImpersonationMutation } from '~/generated/graphql';
 
 export function ToggleField() {
   const { enqueueSnackBar } = useSnackBar();
 
   const currentUser = useRecoilValue(currentUserState);
 
-  const [updateUser] = useUpdateUserMutation();
+  const [updateAllowImpersonation] = useUpdateAllowImpersonationMutation();
 
   async function handleChange(value: boolean) {
     try {
-      const { data, errors } = await updateUser({
+      const { data, errors } = await updateAllowImpersonation({
         variables: {
-          where: {
-            id: currentUser?.id,
-          },
-          data: {
-            allowImpersonation: value,
-          },
+          allowImpersonation: value,
         },
-        refetchQueries: [getOperationName(GET_CURRENT_USER) ?? ''],
       });
 
-      if (errors || !data?.updateUser) {
+      if (errors || !data?.allowImpersonation) {
         throw new Error('Error while updating user');
       }
     } catch (err: any) {
@@ -39,6 +31,9 @@ export function ToggleField() {
   }
 
   return (
-    <Toggle value={currentUser?.allowImpersonation} onChange={handleChange} />
+    <Toggle
+      value={currentUser?.workspaceMember?.allowImpersonation}
+      onChange={handleChange}
+    />
   );
 }

--- a/front/src/modules/settings/profile/components/ToggleField.tsx
+++ b/front/src/modules/settings/profile/components/ToggleField.tsx
@@ -1,0 +1,44 @@
+import { getOperationName } from '@apollo/client/utilities';
+import { useRecoilValue } from 'recoil';
+
+import { currentUserState } from '@/auth/states/currentUserState';
+import { Toggle } from '@/ui/input/toggle/components/Toggle';
+import { useSnackBar } from '@/ui/snack-bar/hooks/useSnackBar';
+import { GET_CURRENT_USER } from '@/users/queries';
+import { useUpdateUserMutation } from '~/generated/graphql';
+
+export function ToggleField() {
+  const { enqueueSnackBar } = useSnackBar();
+
+  const currentUser = useRecoilValue(currentUserState);
+
+  const [updateUser] = useUpdateUserMutation();
+
+  async function handleChange(value: boolean) {
+    try {
+      const { data, errors } = await updateUser({
+        variables: {
+          where: {
+            id: currentUser?.id,
+          },
+          data: {
+            allowImpersonation: value,
+          },
+        },
+        refetchQueries: [getOperationName(GET_CURRENT_USER) ?? ''],
+      });
+
+      if (errors || !data?.updateUser) {
+        throw new Error('Error while updating user');
+      }
+    } catch (err: any) {
+      enqueueSnackBar(err?.message, {
+        variant: 'error',
+      });
+    }
+  }
+
+  return (
+    <Toggle value={currentUser?.allowImpersonation} onChange={handleChange} />
+  );
+}

--- a/front/src/modules/types/AppPath.ts
+++ b/front/src/modules/types/AppPath.ts
@@ -17,4 +17,7 @@ export enum AppPath {
   PersonShowPage = '/person/:personId',
   OpportunitiesPage = '/opportunities',
   SettingsCatchAll = `/settings/*`,
+
+  // Impersonate
+  Impersonate = '/impersonate/:userId',
 }

--- a/front/src/modules/ui/input/toggle/components/Toggle.tsx
+++ b/front/src/modules/ui/input/toggle/components/Toggle.tsx
@@ -1,0 +1,63 @@
+import React, { useEffect, useState } from 'react';
+import styled from '@emotion/styled';
+import { motion } from 'framer-motion';
+
+type ContainerProps = {
+  isOn: boolean;
+  color?: string;
+};
+
+const Container = styled.div<ContainerProps>`
+  align-items: center;
+  background-color: ${({ theme, isOn, color }) =>
+    isOn ? color ?? theme.color.blue : theme.background.quaternary};
+  border-radius: 10px;
+  cursor: pointer;
+  display: flex;
+  height: 20px;
+  transition: background-color 0.3s ease;
+  width: 32px;
+`;
+
+const Circle = styled(motion.div)`
+  background-color: #fff;
+  border-radius: 50%;
+  height: 16px;
+  width: 16px;
+`;
+
+const circleVariants = {
+  on: { x: 14 },
+  off: { x: 2 },
+};
+
+export type ToggleProps = {
+  value?: boolean;
+  onChange?: (value: boolean) => void;
+  color?: string;
+};
+
+export function Toggle({ value, onChange, color }: ToggleProps) {
+  const [isOn, setIsOn] = useState(value ?? false);
+
+  function handleChange() {
+    setIsOn(!isOn);
+
+    if (onChange) {
+      onChange(!isOn);
+    }
+  }
+
+  useEffect(() => {
+    if (value !== isOn) {
+      setIsOn(value ?? false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value]);
+
+  return (
+    <Container onClick={handleChange} isOn={isOn} color={color}>
+      <Circle animate={isOn ? 'on' : 'off'} variants={circleVariants} />
+    </Container>
+  );
+}

--- a/front/src/modules/ui/typography/components/H2Title.tsx
+++ b/front/src/modules/ui/typography/components/H2Title.tsx
@@ -3,12 +3,19 @@ import styled from '@emotion/styled';
 type Props = {
   title: string;
   description?: string;
+  addornment?: React.ReactNode;
 };
 
 const StyledContainer = styled.div`
   display: flex;
   flex-direction: column;
   margin-bottom: ${({ theme }) => theme.spacing(4)};
+`;
+
+const StyledTitleContainer = styled.div`
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
 `;
 
 const StyledTitle = styled.h2`
@@ -26,10 +33,13 @@ const StyledDescription = styled.h3`
   margin-top: ${({ theme }) => theme.spacing(3)};
 `;
 
-export function H2Title({ title, description }: Props) {
+export function H2Title({ title, description, addornment }: Props) {
   return (
     <StyledContainer>
-      <StyledTitle>{title}</StyledTitle>
+      <StyledTitleContainer>
+        <StyledTitle>{title}</StyledTitle>
+        {addornment}
+      </StyledTitleContainer>
       {description && <StyledDescription>{description}</StyledDescription>}
     </StyledContainer>
   );

--- a/front/src/modules/users/queries/index.ts
+++ b/front/src/modules/users/queries/index.ts
@@ -10,6 +10,7 @@ export const GET_CURRENT_USER = gql`
       firstName
       lastName
       avatarUrl
+      allowImpersonation
       workspaceMember {
         id
         workspace {

--- a/front/src/modules/users/queries/index.ts
+++ b/front/src/modules/users/queries/index.ts
@@ -10,9 +10,10 @@ export const GET_CURRENT_USER = gql`
       firstName
       lastName
       avatarUrl
-      allowImpersonation
+      canImpersonate
       workspaceMember {
         id
+        allowImpersonation
         workspace {
           id
           domainName

--- a/front/src/modules/users/queries/update.ts
+++ b/front/src/modules/users/queries/update.ts
@@ -28,6 +28,15 @@ export const UPDATE_USER = gql`
   }
 `;
 
+export const UPDATE_ALLOW_IMPERONATION = gql`
+  mutation UpdateAllowImpersonation($allowImpersonation: Boolean!) {
+    allowImpersonation(allowImpersonation: $allowImpersonation) {
+      id
+      allowImpersonation
+    }
+  }
+`;
+
 export const UPDATE_PROFILE_PICTURE = gql`
   mutation UploadProfilePicture($file: Upload!) {
     uploadProfilePicture(file: $file)

--- a/front/src/pages/impersonate/Impersonate.tsx
+++ b/front/src/pages/impersonate/Impersonate.tsx
@@ -45,7 +45,6 @@ export function Impersonate() {
   }, [userId, impersonate, setCurrentUser, setTokenPair]);
 
   useEffect(() => {
-    console.log('Impersonate effect: ', userId, currentUser, isLogged);
     if (isLogged && currentUser?.canImpersonate && isNonEmptyString(userId)) {
       handleImpersonate();
     } else {

--- a/front/src/pages/impersonate/Impersonate.tsx
+++ b/front/src/pages/impersonate/Impersonate.tsx
@@ -1,0 +1,58 @@
+import { useCallback, useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useRecoilState, useSetRecoilState } from 'recoil';
+
+import { useIsLogged } from '@/auth/hooks/useIsLogged';
+import { currentUserState } from '@/auth/states/currentUserState';
+import { tokenPairState } from '@/auth/states/tokenPairState';
+import { useImpersonateMutation } from '~/generated/graphql';
+
+import { AppPath } from '../../modules/types/AppPath';
+import { isNonEmptyString } from '../../utils/isNonEmptyString';
+
+export function Impersonate() {
+  const navigate = useNavigate();
+  const { userId } = useParams();
+
+  const [currentUser, setCurrentUser] = useRecoilState(currentUserState);
+  const setTokenPair = useSetRecoilState(tokenPairState);
+
+  const [impersonate] = useImpersonateMutation();
+
+  const isLogged = useIsLogged();
+
+  const handleImpersonate = useCallback(async () => {
+    if (!isNonEmptyString(userId)) {
+      return;
+    }
+
+    const impersonateResult = await impersonate({
+      variables: { userId },
+    });
+
+    if (impersonateResult.errors) {
+      throw impersonateResult.errors;
+    }
+
+    if (!impersonateResult.data?.impersonate) {
+      throw new Error('No impersonate result');
+    }
+
+    setCurrentUser(impersonateResult.data?.impersonate.user);
+    setTokenPair(impersonateResult.data?.impersonate.tokens);
+
+    return impersonateResult.data?.impersonate;
+  }, [userId, impersonate, setCurrentUser, setTokenPair]);
+
+  useEffect(() => {
+    console.log('Impersonate effect: ', userId, currentUser, isLogged);
+    if (isLogged && currentUser?.canImpersonate && isNonEmptyString(userId)) {
+      handleImpersonate();
+    } else {
+      // User is not allowed to impersonate or not logged in
+      navigate(AppPath.Index);
+    }
+  }, [userId, currentUser, isLogged, handleImpersonate, navigate]);
+
+  return <></>;
+}

--- a/front/src/pages/settings/SettingsProfile.tsx
+++ b/front/src/pages/settings/SettingsProfile.tsx
@@ -4,6 +4,7 @@ import { DeleteAccount } from '@/settings/profile/components/DeleteAccount';
 import { EmailField } from '@/settings/profile/components/EmailField';
 import { NameFields } from '@/settings/profile/components/NameFields';
 import { ProfilePictureUploader } from '@/settings/profile/components/ProfilePictureUploader';
+import { ToggleField } from '@/settings/profile/components/ToggleField';
 import { IconSettings } from '@/ui/icon';
 import { SubMenuTopBarContainer } from '@/ui/layout/components/SubMenuTopBarContainer';
 import { Section } from '@/ui/section/components/Section';
@@ -43,6 +44,13 @@ export function SettingsProfile() {
               description="The email associated to your account"
             />
             <EmailField />
+          </Section>
+          <Section>
+            <H2Title
+              title="Support"
+              addornment={<ToggleField />}
+              description="Grant Twenty support temporary access to your account so we can troubleshoot problems or recover content on your behalf. You can revoke access at any time."
+            />
           </Section>
           <Section>
             <DeleteAccount />

--- a/front/src/testing/mock-data/users.ts
+++ b/front/src/testing/mock-data/users.ts
@@ -16,6 +16,7 @@ export const mockedUsersData: Array<MockedUser> = [
     firstName: 'Charles',
     lastName: 'Test',
     avatarUrl: null,
+    allowImpersonation: true,
     workspaceMember: {
       __typename: 'WorkspaceMember',
       id: '7dfbc3f7-6e5e-4128-957e-8d86808cdf6b',
@@ -42,6 +43,7 @@ export const mockedUsersData: Array<MockedUser> = [
     displayName: 'Felix Test',
     firstName: 'Felix',
     lastName: 'Test',
+    allowImpersonation: true,
     workspaceMember: {
       __typename: 'WorkspaceMember',
       id: '7dfbc3f7-6e5e-4128-957e-8d86808cdf6b',
@@ -72,6 +74,7 @@ export const mockedOnboardingUsersData: Array<MockedUser> = [
     firstName: '',
     lastName: '',
     avatarUrl: null,
+    allowImpersonation: true,
     workspaceMember: {
       __typename: 'WorkspaceMember',
       id: '7dfbc3f7-6e5e-4128-957e-8d86808cdf6b',
@@ -99,6 +102,7 @@ export const mockedOnboardingUsersData: Array<MockedUser> = [
     firstName: '',
     lastName: '',
     avatarUrl: null,
+    allowImpersonation: true,
     workspaceMember: {
       __typename: 'WorkspaceMember',
       id: '7dfbc3f7-6e5e-4128-957e-8d86808cdf6b',

--- a/front/src/testing/mock-data/users.ts
+++ b/front/src/testing/mock-data/users.ts
@@ -16,10 +16,11 @@ export const mockedUsersData: Array<MockedUser> = [
     firstName: 'Charles',
     lastName: 'Test',
     avatarUrl: null,
-    allowImpersonation: true,
+    canImpersonate: false,
     workspaceMember: {
       __typename: 'WorkspaceMember',
       id: '7dfbc3f7-6e5e-4128-957e-8d86808cdf6b',
+      allowImpersonation: true,
       workspace: {
         __typename: 'Workspace',
         id: '7dfbc3f7-6e5e-4128-957e-8d86808cdf6b',
@@ -43,10 +44,11 @@ export const mockedUsersData: Array<MockedUser> = [
     displayName: 'Felix Test',
     firstName: 'Felix',
     lastName: 'Test',
-    allowImpersonation: true,
+    canImpersonate: false,
     workspaceMember: {
       __typename: 'WorkspaceMember',
       id: '7dfbc3f7-6e5e-4128-957e-8d86808cdf6b',
+      allowImpersonation: true,
       workspace: {
         __typename: 'Workspace',
         id: '7dfbc3f7-6e5e-4128-957e-8d86808cdf6b',
@@ -74,10 +76,11 @@ export const mockedOnboardingUsersData: Array<MockedUser> = [
     firstName: '',
     lastName: '',
     avatarUrl: null,
-    allowImpersonation: true,
+    canImpersonate: false,
     workspaceMember: {
       __typename: 'WorkspaceMember',
       id: '7dfbc3f7-6e5e-4128-957e-8d86808cdf6b',
+      allowImpersonation: true,
       workspace: {
         __typename: 'Workspace',
         id: '7dfbc3f7-6e5e-4128-957e-8d86808cdf6b',
@@ -102,10 +105,11 @@ export const mockedOnboardingUsersData: Array<MockedUser> = [
     firstName: '',
     lastName: '',
     avatarUrl: null,
-    allowImpersonation: true,
+    canImpersonate: false,
     workspaceMember: {
       __typename: 'WorkspaceMember',
       id: '7dfbc3f7-6e5e-4128-957e-8d86808cdf6b',
+      allowImpersonation: true,
       workspace: {
         __typename: 'Workspace',
         id: '7dfbc3f7-6e5e-4128-957e-8d86808cdf6b',

--- a/server/.eslintrc.js
+++ b/server/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
     tsconfigRootDir : __dirname, 
     sourceType: 'module',
   },
-  plugins: ['@typescript-eslint/eslint-plugin', 'import'],
+  plugins: ['@typescript-eslint/eslint-plugin', 'import', 'unused-imports'],
   extends: [
     'plugin:@typescript-eslint/recommended',
     'plugin:prettier/recommended',
@@ -74,5 +74,6 @@ module.exports = {
         pathGroupsExcludedImportTypes: ['@nestjs/**'],
       },
     ],
+    'unused-imports/no-unused-imports': 'warn',
   },
 };

--- a/server/@types/common.d.ts
+++ b/server/@types/common.d.ts
@@ -1,0 +1,5 @@
+type DeepPartial<T> = T extends object
+  ? {
+      [P in keyof T]?: DeepPartial<T[P]>;
+    }
+  : T;

--- a/server/package.json
+++ b/server/package.json
@@ -103,6 +103,7 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-prettier": "^4.0.0",
+    "eslint-plugin-unused-imports": "^3.0.0",
     "jest": "28.1.3",
     "prettier": "^2.3.2",
     "prisma": "4.13.0",

--- a/server/src/ability/handlers/activity-target.ability-handler.ts
+++ b/server/src/ability/handlers/activity-target.ability-handler.ts
@@ -47,9 +47,10 @@ export class UpdateActivityTargetAbilityHandler implements IAbilityHandler {
   async handle(ability: AppAbility, context: ExecutionContext) {
     const gqlContext = GqlExecutionContext.create(context);
     const args = gqlContext.getArgs<ActivityTargetArgs>();
-    const ActivityTarget = await this.prismaService.client.activityTarget.findFirst({
-      where: args.where,
-    });
+    const ActivityTarget =
+      await this.prismaService.client.activityTarget.findFirst({
+        where: args.where,
+      });
     assert(ActivityTarget, '', NotFoundException);
 
     return ability.can(
@@ -66,9 +67,10 @@ export class DeleteActivityTargetAbilityHandler implements IAbilityHandler {
   async handle(ability: AppAbility, context: ExecutionContext) {
     const gqlContext = GqlExecutionContext.create(context);
     const args = gqlContext.getArgs<ActivityTargetArgs>();
-    const ActivityTarget = await this.prismaService.client.activityTarget.findFirst({
-      where: args.where,
-    });
+    const ActivityTarget =
+      await this.prismaService.client.activityTarget.findFirst({
+        where: args.where,
+      });
     assert(ActivityTarget, '', NotFoundException);
 
     return ability.can(

--- a/server/src/core/auth/auth.resolver.ts
+++ b/server/src/core/auth/auth.resolver.ts
@@ -114,7 +114,10 @@ export class AuthResolver {
     @PrismaSelector({
       modelName: 'User',
       defaultFields: {
-        User: { id: true, allowImpersonation: true },
+        User: {
+          id: true,
+          workspaceMember: { select: { allowImpersonation: true } },
+        },
       },
     })
     prismaSelect: PrismaSelect<'User'>,
@@ -123,6 +126,7 @@ export class AuthResolver {
     assert(user.canImpersonate, 'User cannot impersonate', ForbiddenException);
     const select = prismaSelect.valueOf('user') as Prisma.UserSelect & {
       id: true;
+      workspaceMember: { select: { allowImpersonation: true } };
     };
 
     return this.authService.impersonate(impersonateInput.userId, select);

--- a/server/src/core/auth/dto/impersonate.input.ts
+++ b/server/src/core/auth/dto/impersonate.input.ts
@@ -1,0 +1,11 @@
+import { ArgsType, Field } from '@nestjs/graphql';
+
+import { IsNotEmpty, IsString } from 'class-validator';
+
+@ArgsType()
+export class ImpersonateInput {
+  @Field(() => String)
+  @IsNotEmpty()
+  @IsString()
+  userId: string;
+}

--- a/server/src/core/auth/dto/verify.entity.ts
+++ b/server/src/core/auth/dto/verify.entity.ts
@@ -7,5 +7,5 @@ import { AuthTokens } from './token.entity';
 @ObjectType()
 export class Verify extends AuthTokens {
   @Field(() => User)
-  user: Partial<User>;
+  user: DeepPartial<User>;
 }

--- a/server/src/core/auth/services/auth.service.ts
+++ b/server/src/core/auth/services/auth.service.ts
@@ -170,6 +170,11 @@ export class AuthService {
     userId: string,
     select: Prisma.UserSelect & {
       id: true;
+      workspaceMember: {
+        select: {
+          allowImpersonation: true;
+        };
+      };
     },
   ) {
     const user = await this.userService.findUnique({
@@ -181,7 +186,7 @@ export class AuthService {
 
     assert(user, "This user doesn't exist", NotFoundException);
     assert(
-      user.allowImpersonation,
+      user.workspaceMember?.allowImpersonation,
       'Impersonation not allowed',
       ForbiddenException,
     );

--- a/server/src/core/workspace/resolvers/workspace-member.resolver.ts
+++ b/server/src/core/workspace/resolvers/workspace-member.resolver.ts
@@ -9,6 +9,7 @@ import { CheckAbilities } from 'src/decorators/check-abilities.decorator';
 import {
   DeleteWorkspaceMemberAbilityHandler,
   ReadWorkspaceMemberAbilityHandler,
+  UpdateWorkspaceMemberAbilityHandler,
 } from 'src/ability/handlers/workspace-member.ability-handler';
 import { FindManyWorkspaceMemberArgs } from 'src/core/@generated/workspace-member/find-many-workspace-member.args';
 import { UserAbility } from 'src/decorators/user-ability.decorator';
@@ -20,6 +21,8 @@ import {
 import { WorkspaceMemberService } from 'src/core/workspace/services/workspace-member.service';
 import { DeleteOneWorkspaceMemberArgs } from 'src/core/@generated/workspace-member/delete-one-workspace-member.args';
 import { JwtAuthGuard } from 'src/guards/jwt.auth.guard';
+import { AuthUser } from 'src/decorators/auth-user.decorator';
+import { User } from 'src/core/@generated/user/user.model';
 
 @UseGuards(JwtAuthGuard)
 @Resolver(() => WorkspaceMember)
@@ -44,6 +47,24 @@ export class WorkspaceMemberResolver {
             AND: [args.where, accessibleBy(ability).WorkspaceMember],
           }
         : accessibleBy(ability).WorkspaceMember,
+      select: prismaSelect.value,
+    });
+  }
+
+  @Mutation(() => WorkspaceMember)
+  async allowImpersonation(
+    @Args('allowImpersonation') allowImpersonation: boolean,
+    @AuthUser() user: User,
+    @PrismaSelector({ modelName: 'WorkspaceMember' })
+    prismaSelect: PrismaSelect<'WorkspaceMember'>,
+  ): Promise<Partial<WorkspaceMember>> {
+    return this.workspaceMemberService.update({
+      where: {
+        userId: user.id,
+      },
+      data: {
+        allowImpersonation,
+      },
       select: prismaSelect.value,
     });
   }

--- a/server/src/core/workspace/resolvers/workspace-member.resolver.ts
+++ b/server/src/core/workspace/resolvers/workspace-member.resolver.ts
@@ -9,7 +9,6 @@ import { CheckAbilities } from 'src/decorators/check-abilities.decorator';
 import {
   DeleteWorkspaceMemberAbilityHandler,
   ReadWorkspaceMemberAbilityHandler,
-  UpdateWorkspaceMemberAbilityHandler,
 } from 'src/ability/handlers/workspace-member.ability-handler';
 import { FindManyWorkspaceMemberArgs } from 'src/core/@generated/workspace-member/find-many-workspace-member.args';
 import { UserAbility } from 'src/decorators/user-ability.decorator';

--- a/server/src/database/migrations/20230728125137_alter_table_user_add_impersonate/migration.sql
+++ b/server/src/database/migrations/20230728125137_alter_table_user_add_impersonate/migration.sql
@@ -1,3 +1,0 @@
--- AlterTable
-ALTER TABLE "users" ADD COLUMN     "allowImpersonation" BOOLEAN NOT NULL DEFAULT true,
-ADD COLUMN     "canImpersonate" BOOLEAN NOT NULL DEFAULT false;

--- a/server/src/database/migrations/20230728125137_alter_table_user_add_impersonate/migration.sql
+++ b/server/src/database/migrations/20230728125137_alter_table_user_add_impersonate/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "allowImpersonation" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN     "canImpersonate" BOOLEAN NOT NULL DEFAULT false;

--- a/server/src/database/migrations/20230731072336_add_impersonate_ability/migration.sql
+++ b/server/src/database/migrations/20230731072336_add_impersonate_ability/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "canImpersonate" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "workspace_members" ADD COLUMN     "allowImpersonation" BOOLEAN NOT NULL DEFAULT true;

--- a/server/src/database/schema.prisma
+++ b/server/src/database/schema.prisma
@@ -65,39 +65,45 @@ generator nestgraphql {
 model User {
   /// @Validator.IsString()
   /// @Validator.IsOptional()
-  id            String    @id @default(uuid())
+  id                 String    @id @default(uuid())
   /// @Validator.IsString()
   /// @Validator.IsOptional()
-  firstName     String?
+  firstName          String?
   /// @Validator.IsString()
   /// @Validator.IsOptional()
-  lastName      String?
+  lastName           String?
   /// @Validator.IsEmail()
   /// @Validator.IsOptional()
-  email         String    @unique
+  email              String    @unique
   /// @Validator.IsBoolean()
   /// @Validator.IsOptional()
-  emailVerified Boolean   @default(false)
+  emailVerified      Boolean   @default(false)
   /// @Validator.IsString()
   /// @Validator.IsOptional()
-  avatarUrl     String?
+  avatarUrl          String?
   /// @Validator.IsString()
   /// @Validator.IsOptional()
-  locale        String
+  locale             String
   /// @Validator.IsString()
   /// @Validator.IsOptional()
-  phoneNumber   String?
+  phoneNumber        String?
   /// @Validator.IsDate()
   /// @Validator.IsOptional()
-  lastSeen      DateTime?
+  lastSeen           DateTime?
   /// @Validator.IsBoolean()
   /// @Validator.IsOptional()
-  disabled      Boolean   @default(false)
+  disabled           Boolean   @default(false)
   /// @TypeGraphQL.omit(input: true, output: true)
-  passwordHash  String?
+  passwordHash       String?
   /// @Validator.IsJSON()
   /// @Validator.IsOptional()
-  metadata      Json?
+  metadata           Json?
+  /// @Validator.IsBoolean()
+  /// @Validator.IsOptional()
+  canImpersonate     Boolean   @default(false)
+  /// @Validator.IsBoolean()
+  /// @Validator.IsOptional()
+  allowImpersonation Boolean   @default(true)
 
   /// @TypeGraphQL.omit(input: true)
   workspaceMember WorkspaceMember?

--- a/server/src/database/schema.prisma
+++ b/server/src/database/schema.prisma
@@ -65,45 +65,42 @@ generator nestgraphql {
 model User {
   /// @Validator.IsString()
   /// @Validator.IsOptional()
-  id                 String    @id @default(uuid())
+  id             String    @id @default(uuid())
   /// @Validator.IsString()
   /// @Validator.IsOptional()
-  firstName          String?
+  firstName      String?
   /// @Validator.IsString()
   /// @Validator.IsOptional()
-  lastName           String?
+  lastName       String?
   /// @Validator.IsEmail()
   /// @Validator.IsOptional()
-  email              String    @unique
+  email          String    @unique
   /// @Validator.IsBoolean()
   /// @Validator.IsOptional()
-  emailVerified      Boolean   @default(false)
+  emailVerified  Boolean   @default(false)
   /// @Validator.IsString()
   /// @Validator.IsOptional()
-  avatarUrl          String?
+  avatarUrl      String?
   /// @Validator.IsString()
   /// @Validator.IsOptional()
-  locale             String
+  locale         String
   /// @Validator.IsString()
   /// @Validator.IsOptional()
-  phoneNumber        String?
+  phoneNumber    String?
   /// @Validator.IsDate()
   /// @Validator.IsOptional()
-  lastSeen           DateTime?
+  lastSeen       DateTime?
   /// @Validator.IsBoolean()
   /// @Validator.IsOptional()
-  disabled           Boolean   @default(false)
+  disabled       Boolean   @default(false)
   /// @TypeGraphQL.omit(input: true, output: true)
-  passwordHash       String?
+  passwordHash   String?
   /// @Validator.IsJSON()
   /// @Validator.IsOptional()
-  metadata           Json?
+  metadata       Json?
   /// @Validator.IsBoolean()
   /// @Validator.IsOptional()
-  canImpersonate     Boolean   @default(false)
-  /// @Validator.IsBoolean()
-  /// @Validator.IsOptional()
-  allowImpersonation Boolean   @default(true)
+  canImpersonate Boolean   @default(false)
 
   /// @TypeGraphQL.omit(input: true)
   workspaceMember WorkspaceMember?
@@ -112,17 +109,17 @@ model User {
   refreshTokens   RefreshToken[]
   comments        Comment[]
 
-  authoredActivities Activity[]   @relation(name: "authoredActivities")
-  assignedActivities Activity[]   @relation(name: "assignedActivities")
-  settings           UserSettings @relation(fields: [settingsId], references: [id])
-  settingsId         String       @unique
+  authoredActivities  Activity[]   @relation(name: "authoredActivities")
+  assignedActivities  Activity[]   @relation(name: "assignedActivities")
+  authoredAttachments Attachment[] @relation(name: "authoredAttachments")
+  settings            UserSettings @relation(fields: [settingsId], references: [id])
+  settingsId          String       @unique
 
   /// @TypeGraphQL.omit(input: true, output: true)
   deletedAt DateTime?
 
-  createdAt           DateTime     @default(now())
-  updatedAt           DateTime     @updatedAt
-  authoredAttachments Attachment[] @relation(name: "authoredAttachments")
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   @@map("users")
 }
@@ -191,7 +188,10 @@ model Workspace {
 model WorkspaceMember {
   /// @Validator.IsString()
   /// @Validator.IsOptional()
-  id String @id @default(uuid())
+  id                 String  @id @default(uuid())
+  /// @Validator.IsBoolean()
+  /// @Validator.IsOptional()
+  allowImpersonation Boolean @default(true)
 
   user        User      @relation(fields: [userId], references: [id])
   userId      String    @unique

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -21,6 +21,7 @@
     "strictBindCallApply": false,
     "forceConsistentCasingInFileNames": false,
     "noFallthroughCasesInSwitch": false,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "typeRoots": ["@types", "node_modules/@types"]
   }
 }

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -4776,6 +4776,18 @@ eslint-plugin-prettier@^4.0.0:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
+eslint-plugin-unused-imports@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-3.0.0.tgz#d25175b0072ff16a91892c3aa72a09ca3a9e69e7"
+  integrity sha512-sduiswLJfZHeeBJ+MQaG+xYzSWdRXoSw61DpU13mzWumCkR0ufD0HmO4kdNokjrkluMHpj/7PJeN35pgbhW3kw==
+  dependencies:
+    eslint-rule-composer "^0.3.0"
+
+eslint-rule-composer@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz#79320c927b0c5c0d3d3d2b76c8b4a488f25bbaf9"
+  integrity sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==
+
 eslint-scope@5.1.1, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz"


### PR DESCRIPTION
This pull request introduces the new "User Impersonation" feature. It's an important note that this feature can be seen as a security breach; however, it is an intended functionality, designed to allow specific users to log in and act on behalf of other users, subject to their consent.

Key changes in this PR are as follows:

1. **Impersonate Resolver**: A new resolver `impersonate` is added which accepts a `userId` and returns the user details along with the corresponding auth tokens. It's important to note that the impersonate resolver checks for user privileges and authorizations before providing the auth tokens.

2. **Allow Impersonation Mutation**: A new mutation `allowImpersonation` has been added, enabling users to decide if they want to permit other users to impersonate their account.

3. **Frontend Update**: On the frontend, users can toggle impersonation permission from their settings page.

4. **Impersonation URL Access**: Users having 'canImpersonate' privilege can access the URL `impersonate/:userId`, which will log the user into the account of the user specified in the URL.

**Revert to Original User**: The user can revert back to their original account by logging out of the impersonated account and logged in again in his own account.