### PR TITLE
Add fake characters to prevent password managers from filling fields

### DIFF
--- a/front/src/modules/companies/constants/companyViewFields.tsx
+++ b/front/src/modules/companies/constants/companyViewFields.tsx
@@ -99,7 +99,7 @@ export const companyViewFields: ViewFieldDefinition<ViewFieldMetadata>[] = [
     metadata: {
       type: 'text',
       fieldName: 'address',
-      placeHolder: 'Address',
+      placeHolder: 'Addre​ss', // Hack: Fake character to prevent password-manager from filling the field
     },
   } satisfies ViewFieldDefinition<ViewFieldTextMetadata>,
 ];

--- a/front/src/modules/people/constants/peopleViewFields.tsx
+++ b/front/src/modules/people/constants/peopleViewFields.tsx
@@ -31,8 +31,8 @@ export const peopleViewFields: ViewFieldDefinition<ViewFieldMetadata>[] = [
       type: 'double-text-chip',
       firstValueFieldName: 'firstName',
       secondValueFieldName: 'lastName',
-      firstValuePlaceholder: 'First name',
-      secondValuePlaceholder: 'Last name',
+      firstValuePlaceholder: 'F​irst n​ame', // Hack: Fake character to prevent password-manager from filling the field
+      secondValuePlaceholder: 'L​ast n​ame', // Hack: Fake character to prevent password-manager from filling the field
       entityType: Entity.Person,
     },
   } satisfies ViewFieldDefinition<ViewFieldDoubleTextChipMetadata>,
@@ -45,7 +45,7 @@ export const peopleViewFields: ViewFieldDefinition<ViewFieldMetadata>[] = [
     metadata: {
       type: 'text',
       fieldName: 'email',
-      placeHolder: 'Email',
+      placeHolder: 'Ema​il', // Hack: Fake character to prevent password-manager from filling the field
     },
   } satisfies ViewFieldDefinition<ViewFieldTextMetadata>,
   {
@@ -69,7 +69,7 @@ export const peopleViewFields: ViewFieldDefinition<ViewFieldMetadata>[] = [
     metadata: {
       type: 'phone',
       fieldName: 'phone',
-      placeHolder: 'Phone',
+      placeHolder: 'Phon​e', // Hack: Fake character to prevent password-manager from filling the field
     },
   } satisfies ViewFieldDefinition<ViewFieldPhoneMetadata>,
   {
@@ -92,7 +92,7 @@ export const peopleViewFields: ViewFieldDefinition<ViewFieldMetadata>[] = [
     metadata: {
       type: 'text',
       fieldName: 'city',
-      placeHolder: 'City',
+      placeHolder: 'Cit​y', // Hack: Fake character to prevent password-manager from filling the field
     },
   } satisfies ViewFieldDefinition<ViewFieldTextMetadata>,
   {


### PR DESCRIPTION
OK this is not the code I'm most proud of. 
But this works. And I looked up online, dozens of threads, but no-one found any good solution to prevent password managers from showing up. `autocomplete=off` is often ignored. And vendor specific attributes sometimes exist but are not always respected (E.g. lastpass used to provide an `lpignore` attribute but they don't respect it anymore)