### PR TITLE
docs: fix instructions to start projects in the docker setup flow

### DIFF
--- a/docs/docs/developer/local-setup.mdx
+++ b/docs/docs/developer/local-setup.mdx
@@ -157,16 +157,14 @@ make server-prisma-reset
 
 ### 6. Start Twenty
 
-Run the project with the following commands:
+Run the project with the following commands from `root folder`:
 
-In `/front`:
-```bash
-make front-start
-```
-
-In `/server`:
 ```bash
 make server-start
+```
+
+```bash
+make front-start
 ```
 
 You should now have:


### PR DESCRIPTION
closes #994 

Updated the documentation with working instructions.