### PR TITLE
Fix table mock mode

### DIFF
--- a/front/src/modules/companies/table/components/CompanyTableMockData.tsx
+++ b/front/src/modules/companies/table/components/CompanyTableMockData.tsx
@@ -1,0 +1,11 @@
+import { companyViewFields } from '@/companies/constants/companyViewFields';
+import { useSetEntityTableData } from '@/ui/table/hooks/useSetEntityTableData';
+
+import { mockedCompaniesData } from './companies-mock-data';
+export function CompanyTableMockData() {
+  const setEntityTableData = useSetEntityTableData();
+
+  setEntityTableData(mockedCompaniesData, companyViewFields, []);
+
+  return <></>;
+}

--- a/front/src/modules/companies/table/components/CompanyTableMockMode.tsx
+++ b/front/src/modules/companies/table/components/CompanyTableMockMode.tsx
@@ -3,9 +3,12 @@ import { EntityTable } from '@/ui/table/components/EntityTable';
 import { useUpdateOneCompanyMutation } from '~/generated/graphql';
 import { availableSorts } from '~/pages/companies/companies-sorts';
 
+import { CompanyTableMockData } from './CompanyTableMockData';
+
 export function CompanyTableMockMode() {
   return (
     <>
+      <CompanyTableMockData />
       <EntityTable
         viewName="All Companies"
         viewIcon={<IconList size={16} />}

--- a/front/src/modules/ui/table/components/EntityTable.tsx
+++ b/front/src/modules/ui/table/components/EntityTable.tsx
@@ -127,7 +127,7 @@ export function EntityTable<SortField>({
             onSortsUpdate={onSortsUpdate}
           />
           <StyledTableWrapper>
-            {viewFields.length && (
+            {viewFields.length > 0 && (
               <StyledTable>
                 <EntityTableHeader viewFields={viewFields} />
                 <EntityTableBody />


### PR DESCRIPTION
Putting back mocks behind auth flow. They were temporarily removed during the Table refactoring
<img width="1512" alt="image" src="https://github.com/twentyhq/twenty/assets/12035771/c10f8484-5f40-49b7-88f7-47e82087e77e">
