### PR TITLE
[server] set local setup as default in .env.example

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -1,5 +1,9 @@
-PG_DATABASE_URL=postgres://postgres:postgrespassword@postgres:5432/default?connection_limit=1
-FRONT_BASE_URL=http://localhost:3000
+# Use this for local setup
+PG_DATABASE_URL=postgres://postgres:postgrespassword@localhost:5432/default?connection_limit=1
+# Use this for docker setup
+# PG_DATABASE_URL=postgres://postgres:postgrespassword@postgres:5432/default?connection_limit=1
+
+FRONT_BASE_URL=http://localhost:3001
 ACCESS_TOKEN_SECRET=replace_me_with_a_random_string
 LOGIN_TOKEN_SECRET=replace_me_with_a_random_string
 REFRESH_TOKEN_SECRET=replace_me_with_a_random_string


### PR DESCRIPTION
## Context
This PR set the local setup as default and updates the server .env.example with the correct values for local setup.
For docker setup, we can simply uncomment the corresponding line.

This also updates the FRONT_BASE_URL to 3001 port to match with the front config

## Test
Before
<img width="599" alt="before" src="https://github.com/twentyhq/twenty/assets/1834158/16e1beeb-7fd8-4d00-b357-84edb690032b">
After
<img width="591" alt="after" src="https://github.com/twentyhq/twenty/assets/1834158/bd41b807-4018-451a-9477-39b6b5601922">

## Reviewers
@charlesBochet @emilienchvt 