### PR TITLE
Prevent indexing on docs outside of production

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -11,8 +11,8 @@ const config = {
   tagline: 'Dinosaurs are cool',
   favicon: 'img/logo-square-dark.ico',
 
-  // Prevent search engines from indexing the site if not for production
-  noIndex: process.env.NODE_ENV !== 'production',
+  // Prevent search engines from indexing the doc for selected environments
+  noIndex: process.env.SHOULD_INDEX_DOC === 'false',
 
   // Set the production url of your site here
   url: 'https://docs.twenty.com',

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -5,8 +5,6 @@
 const lightCodeTheme = require('prism-react-renderer/themes/github');
 const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 
-console.log('process.env.SHOULD_INDEX_DOC', process.env.SHOULD_INDEX_DOC)
-
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'Twenty - Documentation',

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -11,6 +11,9 @@ const config = {
   tagline: 'Dinosaurs are cool',
   favicon: 'img/logo-square-dark.ico',
 
+  // Prevent search engines from indexing the site if not for production
+  noIndex: process.env.NODE_ENV !== 'production',
+
   // Set the production url of your site here
   url: 'https://docs.twenty.com',
   // Set the /<baseUrl>/ pathname under which your site is served

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -5,6 +5,8 @@
 const lightCodeTheme = require('prism-react-renderer/themes/github');
 const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 
+console.log('process.env.SHOULD_INDEX_DOC', process.env.SHOULD_INDEX_DOC)
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'Twenty - Documentation',

--- a/infra/dev/twenty-docs/Dockerfile
+++ b/infra/dev/twenty-docs/Dockerfile
@@ -2,14 +2,10 @@ FROM node:18.16-bullseye as docs
 
 WORKDIR /app/docs
 
-ARG SHOULD_INDEX_DOC
-
 COPY ../../docs/package.json .
 COPY ../../docs/yarn.lock .
 RUN yarn
 
 COPY ../../docs .
-
-RUN echo "SHOULD_INDEX_DOC: $SHOULD_INDEX_DOC"
 
 CMD ["yarn", "start"]

--- a/infra/dev/twenty-docs/Dockerfile
+++ b/infra/dev/twenty-docs/Dockerfile
@@ -10,4 +10,6 @@ RUN yarn
 
 COPY ../../docs .
 
+RUN echo "SHOULD_INDEX_DOC: $SHOULD_INDEX_DOC"
+
 CMD ["yarn", "start"]

--- a/infra/dev/twenty-docs/Dockerfile
+++ b/infra/dev/twenty-docs/Dockerfile
@@ -2,6 +2,8 @@ FROM node:18.16-bullseye as docs
 
 WORKDIR /app/docs
 
+ARG NODE_ENV
+
 COPY ../../docs/package.json .
 COPY ../../docs/yarn.lock .
 RUN yarn

--- a/infra/dev/twenty-docs/Dockerfile
+++ b/infra/dev/twenty-docs/Dockerfile
@@ -2,7 +2,7 @@ FROM node:18.16-bullseye as docs
 
 WORKDIR /app/docs
 
-ARG NODE_ENV
+ARG SHOULD_INDEX_DOC
 
 COPY ../../docs/package.json .
 COPY ../../docs/yarn.lock .

--- a/infra/prod/docs/Dockerfile
+++ b/infra/prod/docs/Dockerfile
@@ -2,6 +2,8 @@ FROM node:18.16.0-alpine as docs
 
 WORKDIR /app/docs
 
+ARG SHOULD_INDEX_DOC
+
 COPY ./docs/package.json .
 COPY ./docs/yarn.lock .
 RUN yarn install --prod


### PR DESCRIPTION
This PR closes https://github.com/twentyhq/twenty/issues/550

Following the [google documentation](https://developers.google.com/search/docs/crawling-indexing/robots/intro), robot.txt is not the preferred way to prevent a page from being indexed, instead they recommend using [`noindex` meta tags](https://developers.google.com/search/docs/crawling-indexing/block-indexing).

This is also what docosaurus recommends [from their doc](https://docusaurus.io/fr/docs/next/seo#robots-file). And they have a specific [config item](https://docusaurus.io/fr/docs/next/api/docusaurus-config#noIndex) that can be leveraged to serve our purpose.