### PR TITLE
[PeoplePicker] fix missing avatar in user search dropdown

### DIFF
--- a/front/src/modules/people/components/PeoplePicker.tsx
+++ b/front/src/modules/people/components/PeoplePicker.tsx
@@ -30,6 +30,7 @@ export function PeoplePicker({ personId, onSubmit, onCancel }: OwnProps) {
       id: person.id,
       name: person.firstName + ' ' + person.lastName,
       avatarType: 'rounded',
+      avatarUrl: person.avatarUrl ?? '',
     }),
     orderByField: 'firstName',
     searchOnFields: ['firstName', 'lastName'],

--- a/front/src/modules/users/components/FilterDropdownUserSearchSelect.tsx
+++ b/front/src/modules/users/components/FilterDropdownUserSearchSelect.tsx
@@ -36,6 +36,7 @@ export function FilterDropdownUserSearchSelect({
       entityType: Entity.User,
       name: `${entity.displayName}`,
       avatarType: 'rounded',
+      avatarUrl: entity.avatarUrl ?? '',
     }),
     searchFilter: filterDropdownSearchInput,
   });


### PR DESCRIPTION
## Context

Avatars were missing in the user picker dropdown. 
`avatarUrl` was not assigned in the `mappingFunction` passed to `useFilteredSearchEntityQuery` for PeoplePicker and FilterDropdownUserSearchSelect components

## Test
Before
<img width="204" alt="Screenshot 2023-08-03 at 15 33 34" src="https://github.com/twentyhq/twenty/assets/1834158/f5f89d95-1108-49b9-9917-0bd6806f7dc9">
After
<img width="203" alt="Screenshot 2023-08-03 at 15 41 34" src="https://github.com/twentyhq/twenty/assets/1834158/4244a905-4cb6-443a-a71f-82482d0b8834">
