### PR TITLE
Fix pipeline performance issue

### DIFF
--- a/front/src/modules/companies/components/HooksCompanyBoard.tsx
+++ b/front/src/modules/companies/components/HooksCompanyBoard.tsx
@@ -162,10 +162,16 @@ export function HooksCompanyBoard({
   );
 
   const synchronizeCompanyProgresses = useRecoilCallback(
-    ({ set }) =>
+    ({ snapshot, set }) =>
       (companyBoardIndex: { [key: string]: CompanyProgress }) => {
         Object.entries(companyBoardIndex).forEach(([id, companyProgress]) => {
-          set(companyProgressesFamilyState(id), companyProgress);
+          if (
+            JSON.stringify(
+              snapshot.getLoadable(companyProgressesFamilyState(id)).getValue(),
+            ) !== JSON.stringify(companyProgress)
+          ) {
+            set(companyProgressesFamilyState(id), companyProgress);
+          }
         });
       },
     [],


### PR DESCRIPTION
# Context
Users are facing performance issue on Pipeline page as every single card is re-rendered. We are working on a deep refactoring of the pipelines in parallel but this fix should make the life of our users easier until we merge the big work end of the week

# How
CompanyBoardCard component is re-rendered each time the companyProgressesFamilyState is updated. I'm preventing update of these unless there is a change in the new data. This improves the performance of the page drastically