### PR TITLE
[FilterDropdownEntitySearchSelect] add missing displayAvatarUrl

### DIFF
--- a/front/src/generated/graphql.tsx
+++ b/front/src/generated/graphql.tsx
@@ -2327,7 +2327,7 @@ export type GetActivitiesByTargetsQueryVariables = Exact<{
 }>;
 
 
-export type GetActivitiesByTargetsQuery = { __typename?: 'Query', findManyActivities: Array<{ __typename?: 'Activity', id: string, createdAt: string, title?: string | null, body?: string | null, type: ActivityType, completedAt?: string | null, dueAt?: string | null, assignee?: { __typename?: 'User', id: string, firstName?: string | null, lastName?: string | null, displayName: string } | null, author: { __typename?: 'User', id: string, firstName?: string | null, lastName?: string | null, displayName: string }, comments?: Array<{ __typename?: 'Comment', id: string, body: string, createdAt: string, updatedAt: string, author: { __typename?: 'User', id: string, displayName: string, firstName?: string | null, lastName?: string | null, avatarUrl?: string | null } }> | null, activityTargets?: Array<{ __typename?: 'ActivityTarget', id: string, commentableType?: CommentableType | null, commentableId?: string | null }> | null }> };
+export type GetActivitiesByTargetsQuery = { __typename?: 'Query', findManyActivities: Array<{ __typename?: 'Activity', id: string, createdAt: string, title?: string | null, body?: string | null, type: ActivityType, completedAt?: string | null, dueAt?: string | null, assignee?: { __typename?: 'User', id: string, firstName?: string | null, lastName?: string | null, displayName: string, avatarUrl?: string | null } | null, author: { __typename?: 'User', id: string, firstName?: string | null, lastName?: string | null, displayName: string }, comments?: Array<{ __typename?: 'Comment', id: string, body: string, createdAt: string, updatedAt: string, author: { __typename?: 'User', id: string, displayName: string, firstName?: string | null, lastName?: string | null, avatarUrl?: string | null } }> | null, activityTargets?: Array<{ __typename?: 'ActivityTarget', id: string, commentableType?: CommentableType | null, commentableId?: string | null }> | null }> };
 
 export type GetActivitiesQueryVariables = Exact<{
   where: ActivityWhereInput;
@@ -2342,7 +2342,7 @@ export type GetActivityQueryVariables = Exact<{
 }>;
 
 
-export type GetActivityQuery = { __typename?: 'Query', findManyActivities: Array<{ __typename?: 'Activity', id: string, createdAt: string, body?: string | null, title?: string | null, type: ActivityType, completedAt?: string | null, dueAt?: string | null, assignee?: { __typename?: 'User', id: string, firstName?: string | null, lastName?: string | null, displayName: string } | null, author: { __typename?: 'User', id: string, firstName?: string | null, lastName?: string | null, displayName: string }, comments?: Array<{ __typename?: 'Comment', id: string, body: string, createdAt: string, updatedAt: string, author: { __typename?: 'User', id: string, displayName: string, firstName?: string | null, lastName?: string | null, avatarUrl?: string | null } }> | null, activityTargets?: Array<{ __typename?: 'ActivityTarget', id: string, commentableType?: CommentableType | null, commentableId?: string | null }> | null }> };
+export type GetActivityQuery = { __typename?: 'Query', findManyActivities: Array<{ __typename?: 'Activity', id: string, createdAt: string, body?: string | null, title?: string | null, type: ActivityType, completedAt?: string | null, dueAt?: string | null, assignee?: { __typename?: 'User', id: string, firstName?: string | null, lastName?: string | null, displayName: string, avatarUrl?: string | null } | null, author: { __typename?: 'User', id: string, firstName?: string | null, lastName?: string | null, displayName: string }, comments?: Array<{ __typename?: 'Comment', id: string, body: string, createdAt: string, updatedAt: string, author: { __typename?: 'User', id: string, displayName: string, firstName?: string | null, lastName?: string | null, avatarUrl?: string | null } }> | null, activityTargets?: Array<{ __typename?: 'ActivityTarget', id: string, commentableType?: CommentableType | null, commentableId?: string | null }> | null }> };
 
 export type AddActivityTargetsOnActivityMutationVariables = Exact<{
   activityId: Scalars['String'];
@@ -2898,6 +2898,7 @@ export const GetActivitiesByTargetsDocument = gql`
       firstName
       lastName
       displayName
+      avatarUrl
     }
     author {
       id
@@ -3033,6 +3034,7 @@ export const GetActivityDocument = gql`
       firstName
       lastName
       displayName
+      avatarUrl
     }
     author {
       id

--- a/front/src/modules/activities/editable-fields/components/ActivityAssigneeEditableField.tsx
+++ b/front/src/modules/activities/editable-fields/components/ActivityAssigneeEditableField.tsx
@@ -15,7 +15,6 @@ type OwnProps = {
 };
 
 export function ActivityAssigneeEditableField({ activity }: OwnProps) {
-  console.log(activity);
   return (
     <RecoilScope SpecificContext={FieldContext}>
       <RecoilScope>

--- a/front/src/modules/activities/editable-fields/components/ActivityAssigneeEditableField.tsx
+++ b/front/src/modules/activities/editable-fields/components/ActivityAssigneeEditableField.tsx
@@ -15,6 +15,7 @@ type OwnProps = {
 };
 
 export function ActivityAssigneeEditableField({ activity }: OwnProps) {
+  console.log(activity);
   return (
     <RecoilScope SpecificContext={FieldContext}>
       <RecoilScope>

--- a/front/src/modules/activities/queries/select.ts
+++ b/front/src/modules/activities/queries/select.ts
@@ -23,6 +23,7 @@ export const GET_ACTIVITIES_BY_TARGETS = gql`
         firstName
         lastName
         displayName
+        avatarUrl
       }
       author {
         id
@@ -105,6 +106,7 @@ export const GET_ACTIVITY = gql`
         firstName
         lastName
         displayName
+        avatarUrl
       }
       author {
         id

--- a/front/src/modules/ui/filter-n-sort/components/FilterDropdownEntitySearchSelect.tsx
+++ b/front/src/modules/ui/filter-n-sort/components/FilterDropdownEntitySearchSelect.tsx
@@ -62,6 +62,7 @@ export function FilterDropdownEntitySearchSelect({
         operand: selectedOperandInDropdown,
         type: filterDefinitionUsedInDropdown.type,
         value: selectedEntity.id,
+        displayAvatarUrl: selectedEntity.avatarUrl,
       });
     }
   }


### PR DESCRIPTION
## Context
Similar to this one https://github.com/twentyhq/twenty/pull/1069
When a user was picked, the avatar was not rendered properly

Similar issue on the activity, this time it was due to the graphql query not fetching the avatar.

## Test
Before
<img width="185" alt="Screenshot 2023-08-03 at 17 33 25" src="https://github.com/twentyhq/twenty/assets/1834158/475306d0-29be-46cf-a83d-388063665937">
<img width="180" alt="Screenshot 2023-08-03 at 17 33 29" src="https://github.com/twentyhq/twenty/assets/1834158/b770b8db-c8cc-48ad-a46a-7dfba527a338">
<img width="788" alt="Screenshot 2023-08-03 at 17 58 06" src="https://github.com/twentyhq/twenty/assets/1834158/0244ae8d-fc7c-4e09-8405-3577832bcac8">

After
<img width="187" alt="Screenshot 2023-08-03 at 17 29 38" src="https://github.com/twentyhq/twenty/assets/1834158/378a98cf-5148-4878-b58b-1fb6b73e516d">
<img width="194" alt="Screenshot 2023-08-03 at 17 29 43" src="https://github.com/twentyhq/twenty/assets/1834158/695f75a1-66b9-4a81-9bf6-fc6099dcde46">
<img width="741" alt="Screenshot 2023-08-03 at 17 55 34" src="https://github.com/twentyhq/twenty/assets/1834158/a8bf538c-1624-4307-919b-9e3f2cad2237">
