### PR TITLE
[tasks] add empty state and new task button

### DIFF
--- a/front/src/generated/graphql.tsx
+++ b/front/src/generated/graphql.tsx
@@ -2313,7 +2313,7 @@ export type CreateActivityMutationVariables = Exact<{
 }>;
 
 
-export type CreateActivityMutation = { __typename?: 'Mutation', createOneActivity: { __typename?: 'Activity', id: string, createdAt: string, updatedAt: string, authorId: string, assigneeId?: string | null, type: ActivityType, activityTargets?: Array<{ __typename?: 'ActivityTarget', id: string, createdAt: string, updatedAt: string, activityId: string, commentableType?: CommentableType | null, commentableId?: string | null }> | null, comments?: Array<{ __typename?: 'Comment', id: string, createdAt: string, updatedAt: string, body: string, author: { __typename?: 'User', id: string } }> | null } };
+export type CreateActivityMutation = { __typename?: 'Mutation', createOneActivity: { __typename?: 'Activity', id: string, createdAt: string, updatedAt: string, authorId: string, type: ActivityType, activityTargets?: Array<{ __typename?: 'ActivityTarget', id: string, createdAt: string, updatedAt: string, activityId: string, commentableType?: CommentableType | null, commentableId?: string | null }> | null, comments?: Array<{ __typename?: 'Comment', id: string, createdAt: string, updatedAt: string, body: string, author: { __typename?: 'User', id: string } }> | null } };
 
 export type GetActivitiesByTargetsQueryVariables = Exact<{
   activityTargetIds: Array<Scalars['String']> | Scalars['String'];
@@ -2819,7 +2819,6 @@ export const CreateActivityDocument = gql`
     createdAt
     updatedAt
     authorId
-    assigneeId
     type
     activityTargets {
       id

--- a/front/src/generated/graphql.tsx
+++ b/front/src/generated/graphql.tsx
@@ -2309,17 +2309,11 @@ export type CreateCommentMutationVariables = Exact<{
 export type CreateCommentMutation = { __typename?: 'Mutation', createOneComment: { __typename?: 'Comment', id: string, createdAt: string, body: string, activityId?: string | null, author: { __typename?: 'User', id: string, displayName: string, firstName?: string | null, lastName?: string | null, avatarUrl?: string | null } } };
 
 export type CreateActivityMutationVariables = Exact<{
-  activityId: Scalars['String'];
-  body?: InputMaybe<Scalars['String']>;
-  title?: InputMaybe<Scalars['String']>;
-  type: ActivityType;
-  authorId: Scalars['String'];
-  createdAt: Scalars['DateTime'];
-  activityTargetArray: Array<ActivityTargetCreateManyActivityInput> | ActivityTargetCreateManyActivityInput;
+  data: ActivityCreateInput;
 }>;
 
 
-export type CreateActivityMutation = { __typename?: 'Mutation', createOneActivity: { __typename?: 'Activity', id: string, createdAt: string, updatedAt: string, authorId: string, type: ActivityType, activityTargets?: Array<{ __typename?: 'ActivityTarget', id: string, createdAt: string, updatedAt: string, activityId: string, commentableType?: CommentableType | null, commentableId?: string | null }> | null, comments?: Array<{ __typename?: 'Comment', id: string, createdAt: string, updatedAt: string, body: string, author: { __typename?: 'User', id: string } }> | null } };
+export type CreateActivityMutation = { __typename?: 'Mutation', createOneActivity: { __typename?: 'Activity', id: string, createdAt: string, updatedAt: string, authorId: string, assigneeId?: string | null, type: ActivityType, activityTargets?: Array<{ __typename?: 'ActivityTarget', id: string, createdAt: string, updatedAt: string, activityId: string, commentableType?: CommentableType | null, commentableId?: string | null }> | null, comments?: Array<{ __typename?: 'Comment', id: string, createdAt: string, updatedAt: string, body: string, author: { __typename?: 'User', id: string } }> | null } };
 
 export type GetActivitiesByTargetsQueryVariables = Exact<{
   activityTargetIds: Array<Scalars['String']> | Scalars['String'];
@@ -2819,14 +2813,13 @@ export type CreateCommentMutationHookResult = ReturnType<typeof useCreateComment
 export type CreateCommentMutationResult = Apollo.MutationResult<CreateCommentMutation>;
 export type CreateCommentMutationOptions = Apollo.BaseMutationOptions<CreateCommentMutation, CreateCommentMutationVariables>;
 export const CreateActivityDocument = gql`
-    mutation CreateActivity($activityId: String!, $body: String, $title: String, $type: ActivityType!, $authorId: String!, $createdAt: DateTime!, $activityTargetArray: [ActivityTargetCreateManyActivityInput!]!) {
-  createOneActivity(
-    data: {id: $activityId, createdAt: $createdAt, updatedAt: $createdAt, author: {connect: {id: $authorId}}, body: $body, title: $title, type: $type, activityTargets: {createMany: {data: $activityTargetArray, skipDuplicates: true}}}
-  ) {
+    mutation CreateActivity($data: ActivityCreateInput!) {
+  createOneActivity(data: $data) {
     id
     createdAt
     updatedAt
     authorId
+    assigneeId
     type
     activityTargets {
       id
@@ -2863,13 +2856,7 @@ export type CreateActivityMutationFn = Apollo.MutationFunction<CreateActivityMut
  * @example
  * const [createActivityMutation, { data, loading, error }] = useCreateActivityMutation({
  *   variables: {
- *      activityId: // value for 'activityId'
- *      body: // value for 'body'
- *      title: // value for 'title'
- *      type: // value for 'type'
- *      authorId: // value for 'authorId'
- *      createdAt: // value for 'createdAt'
- *      activityTargetArray: // value for 'activityTargetArray'
+ *      data: // value for 'data'
  *   },
  * });
  */

--- a/front/src/modules/activities/components/ActivityEditor.tsx
+++ b/front/src/modules/activities/components/ActivityEditor.tsx
@@ -5,10 +5,7 @@ import styled from '@emotion/styled';
 import { ActivityBodyEditor } from '@/activities/components/ActivityBodyEditor';
 import { ActivityComments } from '@/activities/components/ActivityComments';
 import { ActivityTypeDropdown } from '@/activities/components/ActivityTypeDropdown';
-import {
-  GET_ACTIVITIES,
-  GET_ACTIVITIES_BY_TARGETS,
-} from '@/activities/queries';
+import { GET_ACTIVITIES_BY_TARGETS } from '@/activities/queries';
 import { PropertyBox } from '@/ui/editable-field/property-box/components/PropertyBox';
 import { DateEditableField } from '@/ui/editable-field/variants/components/DateEditableField';
 import { IconCalendar } from '@/ui/icon/index';
@@ -178,7 +175,6 @@ export function ActivityEditor({
                           dueAt: newDate,
                         },
                       },
-                      refetchQueries: [getOperationName(GET_ACTIVITIES) ?? ''],
                     });
                   }}
                 />

--- a/front/src/modules/activities/components/ActivityEditor.tsx
+++ b/front/src/modules/activities/components/ActivityEditor.tsx
@@ -5,7 +5,10 @@ import styled from '@emotion/styled';
 import { ActivityBodyEditor } from '@/activities/components/ActivityBodyEditor';
 import { ActivityComments } from '@/activities/components/ActivityComments';
 import { ActivityTypeDropdown } from '@/activities/components/ActivityTypeDropdown';
-import { GET_ACTIVITIES_BY_TARGETS } from '@/activities/queries';
+import {
+  GET_ACTIVITIES,
+  GET_ACTIVITIES_BY_TARGETS,
+} from '@/activities/queries';
 import { PropertyBox } from '@/ui/editable-field/property-box/components/PropertyBox';
 import { DateEditableField } from '@/ui/editable-field/variants/components/DateEditableField';
 import { IconCalendar } from '@/ui/icon/index';
@@ -175,6 +178,7 @@ export function ActivityEditor({
                           dueAt: newDate,
                         },
                       },
+                      refetchQueries: [getOperationName(GET_ACTIVITIES) ?? ''],
                     });
                   }}
                 />

--- a/front/src/modules/activities/components/TaskGroups.tsx
+++ b/front/src/modules/activities/components/TaskGroups.tsx
@@ -16,7 +16,7 @@ const StyledTaskGroupEmptyContainer = styled.div`
   display: flex;
   flex: 1 0 0;
   flex-direction: column;
-  gap: 8px;
+  gap: ${({ theme }) => theme.spacing(2)};
   justify-content: center;
   padding-bottom: ${({ theme }) => theme.spacing(16)};
   padding-left: ${({ theme }) => theme.spacing(4)};
@@ -40,12 +40,16 @@ const StyledEmptyTaskGroupSubTitle = styled.div`
 `;
 
 export function TaskGroups() {
-  const { todayOrPreviousTasks, upcomingTasks } = useTasks();
+  const { todayOrPreviousTasks, upcomingTasks, unscheduledTasks } = useTasks();
   const theme = useTheme();
 
   const openCreateActivity = useOpenCreateActivityDrawer();
 
-  if (todayOrPreviousTasks?.length === 0 && upcomingTasks?.length === 0) {
+  if (
+    todayOrPreviousTasks?.length === 0 &&
+    upcomingTasks?.length === 0 &&
+    unscheduledTasks?.length === 0
+  ) {
     return (
       <StyledTaskGroupEmptyContainer>
         <StyledEmptyTaskGroupTitle>No task yet</StyledEmptyTaskGroupTitle>
@@ -64,6 +68,7 @@ export function TaskGroups() {
     <>
       <TaskList title="Today" tasks={todayOrPreviousTasks ?? []} />
       <TaskList title="Upcoming" tasks={upcomingTasks ?? []} />
+      <TaskList title="Unscheduled" tasks={unscheduledTasks ?? []} />
     </>
   );
 }

--- a/front/src/modules/activities/components/TaskGroups.tsx
+++ b/front/src/modules/activities/components/TaskGroups.tsx
@@ -18,7 +18,10 @@ const StyledTaskGroupEmptyContainer = styled.div`
   flex-direction: column;
   gap: 8px;
   justify-content: center;
-  padding: 12px 16px 64px 16px;
+  padding-bottom: ${({ theme }) => theme.spacing(16)};
+  padding-left: ${({ theme }) => theme.spacing(4)};
+  padding-right: ${({ theme }) => theme.spacing(4)};
+  padding-top: ${({ theme }) => theme.spacing(3)};
 `;
 
 const StyledEmptyTaskGroupTitle = styled.div`

--- a/front/src/modules/activities/components/TaskGroups.tsx
+++ b/front/src/modules/activities/components/TaskGroups.tsx
@@ -1,9 +1,62 @@
+import { useTheme } from '@emotion/react';
+import styled from '@emotion/styled';
+import { IconCheckbox } from '@tabler/icons-react';
+
+import { Button, ButtonVariant } from '@/ui/button/components/Button';
+import { ActivityType } from '~/generated/graphql';
+
+import { useOpenCreateActivityDrawer } from '../hooks/useOpenCreateActivityDrawer';
 import { useTasks } from '../hooks/useTasks';
 
 import { TaskList } from './TaskList';
 
+const StyledTaskGroupEmptyContainer = styled.div`
+  align-items: center;
+  align-self: stretch;
+  display: flex;
+  flex: 1 0 0;
+  flex-direction: column;
+  gap: 8px;
+  justify-content: center;
+  padding: 12px 16px 64px 16px;
+`;
+
+const StyledEmptyTaskGroupTitle = styled.div`
+  color: ${({ theme }) => theme.font.color.secondary};
+  font-size: ${({ theme }) => theme.font.size.xxl};
+  font-weight: ${({ theme }) => theme.font.weight.semiBold};
+  line-height: ${({ theme }) => theme.text.lineHeight.md};
+`;
+
+const StyledEmptyTaskGroupSubTitle = styled.div`
+  color: ${({ theme }) => theme.font.color.extraLight};
+  font-size: ${({ theme }) => theme.font.size.xxl};
+  font-weight: ${({ theme }) => theme.font.weight.semiBold};
+  line-height: ${({ theme }) => theme.text.lineHeight.md};
+  margin-bottom: ${({ theme }) => theme.spacing(2)};
+`;
+
 export function TaskGroups() {
   const { todayOrPreviousTasks, upcomingTasks } = useTasks();
+  const theme = useTheme();
+
+  const openCreateActivity = useOpenCreateActivityDrawer();
+
+  if (todayOrPreviousTasks?.length === 0 && upcomingTasks?.length === 0) {
+    return (
+      <StyledTaskGroupEmptyContainer>
+        <StyledEmptyTaskGroupTitle>No task yet</StyledEmptyTaskGroupTitle>
+        <StyledEmptyTaskGroupSubTitle>Create one:</StyledEmptyTaskGroupSubTitle>
+        <Button
+          icon={<IconCheckbox size={theme.icon.size.sm} />}
+          title="New task"
+          variant={ButtonVariant.Secondary}
+          onClick={() => openCreateActivity(ActivityType.Task)}
+        />
+      </StyledTaskGroupEmptyContainer>
+    );
+  }
+
   return (
     <>
       <TaskList title="Today" tasks={todayOrPreviousTasks ?? []} />

--- a/front/src/modules/activities/hooks/useOpenCreateActivityDrawer.ts
+++ b/front/src/modules/activities/hooks/useOpenCreateActivityDrawer.ts
@@ -35,22 +35,34 @@ export function useOpenCreateActivityDrawer() {
     type: ActivityType,
     entity?: CommentableEntity,
   ) {
-    createActivityMutation({
+    const now = new Date().toISOString();
+
+    return createActivityMutation({
       variables: {
-        authorId: currentUser?.id ?? '',
-        activityId: v4(),
-        createdAt: new Date().toISOString(),
-        type: type,
-        activityTargetArray: entity
-          ? [
-              {
-                commentableId: entity.id,
-                commentableType: entity.type,
-                id: v4(),
-                createdAt: new Date().toISOString(),
-              },
-            ]
-          : [],
+        data: {
+          id: v4(),
+          createdAt: now,
+          updatedAt: now,
+          author: { connect: { id: currentUser?.id ?? '' } },
+          assignee: { connect: { id: currentUser?.id ?? '' } },
+          dueAt: now,
+          type: type,
+          activityTargets: {
+            createMany: {
+              data: entity
+                ? [
+                    {
+                      commentableId: entity.id,
+                      commentableType: entity.type,
+                      id: v4(),
+                      createdAt: now,
+                    },
+                  ]
+                : [],
+              skipDuplicates: true,
+            },
+          },
+        },
       },
       refetchQueries: [
         getOperationName(GET_COMPANIES) ?? '',

--- a/front/src/modules/activities/hooks/useOpenCreateActivityDrawer.ts
+++ b/front/src/modules/activities/hooks/useOpenCreateActivityDrawer.ts
@@ -11,7 +11,11 @@ import { RightDrawerPages } from '@/ui/right-drawer/types/RightDrawerPages';
 import { useSetHotkeyScope } from '@/ui/utilities/hotkey/hooks/useSetHotkeyScope';
 import { ActivityType, useCreateActivityMutation } from '~/generated/graphql';
 
-import { GET_ACTIVITIES_BY_TARGETS, GET_ACTIVITY } from '../queries';
+import {
+  GET_ACTIVITIES,
+  GET_ACTIVITIES_BY_TARGETS,
+  GET_ACTIVITY,
+} from '../queries';
 import { commentableEntityArrayState } from '../states/commentableEntityArrayState';
 import { viewableActivityIdState } from '../states/viewableActivityIdState';
 import { CommentableEntity } from '../types/CommentableEntity';
@@ -53,6 +57,7 @@ export function useOpenCreateActivityDrawer() {
         getOperationName(GET_PEOPLE) ?? '',
         getOperationName(GET_ACTIVITY) ?? '',
         getOperationName(GET_ACTIVITIES_BY_TARGETS) ?? '',
+        getOperationName(GET_ACTIVITIES) ?? '',
       ],
       onCompleted(data) {
         setHotkeyScope(RightDrawerHotkeyScope.RightDrawer, { goto: false });

--- a/front/src/modules/activities/hooks/useOpenCreateActivityDrawer.ts
+++ b/front/src/modules/activities/hooks/useOpenCreateActivityDrawer.ts
@@ -28,8 +28,8 @@ export function useOpenCreateActivityDrawer() {
   const [, setViewableActivityId] = useRecoilState(viewableActivityIdState);
 
   return function openCreateActivityDrawer(
-    entity: CommentableEntity,
     type: ActivityType,
+    entity?: CommentableEntity,
   ) {
     createActivityMutation({
       variables: {
@@ -37,14 +37,16 @@ export function useOpenCreateActivityDrawer() {
         activityId: v4(),
         createdAt: new Date().toISOString(),
         type: type,
-        activityTargetArray: [
-          {
-            commentableId: entity.id,
-            commentableType: entity.type,
-            id: v4(),
-            createdAt: new Date().toISOString(),
-          },
-        ],
+        activityTargetArray: entity
+          ? [
+              {
+                commentableId: entity.id,
+                commentableType: entity.type,
+                id: v4(),
+                createdAt: new Date().toISOString(),
+              },
+            ]
+          : [],
       },
       refetchQueries: [
         getOperationName(GET_COMPANIES) ?? '',
@@ -55,7 +57,7 @@ export function useOpenCreateActivityDrawer() {
       onCompleted(data) {
         setHotkeyScope(RightDrawerHotkeyScope.RightDrawer, { goto: false });
         setViewableActivityId(data.createOneActivity.id);
-        setCommentableEntityArray([entity]);
+        setCommentableEntityArray(entity ? [entity] : []);
         openRightDrawer(RightDrawerPages.CreateActivity);
       },
     });

--- a/front/src/modules/activities/hooks/useOpenCreateActivityDrawer.ts
+++ b/front/src/modules/activities/hooks/useOpenCreateActivityDrawer.ts
@@ -45,7 +45,6 @@ export function useOpenCreateActivityDrawer() {
           updatedAt: now,
           author: { connect: { id: currentUser?.id ?? '' } },
           assignee: { connect: { id: currentUser?.id ?? '' } },
-          dueAt: now,
           type: type,
           activityTargets: {
             createMany: {

--- a/front/src/modules/activities/hooks/useOpenCreateActivityDrawerForSelectedRowIds.ts
+++ b/front/src/modules/activities/hooks/useOpenCreateActivityDrawerForSelectedRowIds.ts
@@ -44,19 +44,28 @@ export function useOpenCreateActivityDrawerForSelectedRowIds() {
         id,
       }),
     );
+    const now = new Date().toISOString();
 
     createActivityMutation({
       variables: {
-        authorId: currentUser?.id ?? '',
-        activityId: v4(),
-        createdAt: new Date().toISOString(),
-        type: ActivityType.Note,
-        activityTargetArray: commentableEntityArray.map((entity) => ({
-          commentableId: entity.id,
-          commentableType: entity.type,
+        data: {
           id: v4(),
-          createdAt: new Date().toISOString(),
-        })),
+          createdAt: now,
+          updatedAt: now,
+          author: { connect: { id: currentUser?.id ?? '' } },
+          type: ActivityType.Note,
+          activityTargets: {
+            createMany: {
+              data: commentableEntityArray.map((entity) => ({
+                commentableId: entity.id,
+                commentableType: entity.type,
+                id: v4(),
+                createdAt: new Date().toISOString(),
+              })),
+              skipDuplicates: true,
+            },
+          },
+        },
       },
       refetchQueries: [
         getOperationName(GET_COMPANIES) ?? '',

--- a/front/src/modules/activities/hooks/useTasks.ts
+++ b/front/src/modules/activities/hooks/useTasks.ts
@@ -96,8 +96,13 @@ export function useTasks() {
     return dueDate > today;
   });
 
+  const unscheduledTasks = tasksData?.findManyActivities.filter((task) => {
+    return !task.dueAt;
+  });
+
   return {
     todayOrPreviousTasks,
     upcomingTasks,
+    unscheduledTasks,
   };
 }

--- a/front/src/modules/activities/queries/create.ts
+++ b/front/src/modules/activities/queries/create.ts
@@ -39,7 +39,6 @@ export const CREATE_ACTIVITY_WITH_COMMENT = gql`
       createdAt
       updatedAt
       authorId
-      assigneeId
       type
       activityTargets {
         id

--- a/front/src/modules/activities/queries/create.ts
+++ b/front/src/modules/activities/queries/create.ts
@@ -33,33 +33,13 @@ export const CREATE_COMMENT = gql`
 `;
 
 export const CREATE_ACTIVITY_WITH_COMMENT = gql`
-  mutation CreateActivity(
-    $activityId: String!
-    $body: String
-    $title: String
-    $type: ActivityType!
-    $authorId: String!
-    $createdAt: DateTime!
-    $activityTargetArray: [ActivityTargetCreateManyActivityInput!]!
-  ) {
-    createOneActivity(
-      data: {
-        id: $activityId
-        createdAt: $createdAt
-        updatedAt: $createdAt
-        author: { connect: { id: $authorId } }
-        body: $body
-        title: $title
-        type: $type
-        activityTargets: {
-          createMany: { data: $activityTargetArray, skipDuplicates: true }
-        }
-      }
-    ) {
+  mutation CreateActivity($data: ActivityCreateInput!) {
+    createOneActivity(data: $data) {
       id
       createdAt
       updatedAt
       authorId
+      assigneeId
       type
       activityTargets {
         id

--- a/front/src/modules/activities/right-drawer/components/ActivityActionBar.tsx
+++ b/front/src/modules/activities/right-drawer/components/ActivityActionBar.tsx
@@ -3,7 +3,10 @@ import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useRecoilState } from 'recoil';
 
-import { GET_ACTIVITIES_BY_TARGETS } from '@/activities/queries';
+import {
+  GET_ACTIVITIES,
+  GET_ACTIVITIES_BY_TARGETS,
+} from '@/activities/queries';
 import { GET_COMPANIES } from '@/companies/queries';
 import { GET_PEOPLE } from '@/people/queries';
 import { IconButton } from '@/ui/button/components/IconButton';
@@ -32,6 +35,7 @@ export function ActivityActionBar({ activityId }: OwnProps) {
         getOperationName(GET_COMPANIES) ?? '',
         getOperationName(GET_PEOPLE) ?? '',
         getOperationName(GET_ACTIVITIES_BY_TARGETS) ?? '',
+        getOperationName(GET_ACTIVITIES) ?? '',
       ],
     });
     setIsRightDrawerOpen(false);

--- a/front/src/modules/activities/right-drawer/components/ActivityActionBar.tsx
+++ b/front/src/modules/activities/right-drawer/components/ActivityActionBar.tsx
@@ -25,11 +25,11 @@ type OwnProps = {
 
 export function ActivityActionBar({ activityId }: OwnProps) {
   const theme = useTheme();
-  const [createCommentMutation] = useDeleteActivityMutation();
+  const [deleteActivityMutation] = useDeleteActivityMutation();
   const [, setIsRightDrawerOpen] = useRecoilState(isRightDrawerOpenState);
 
   function deleteActivity() {
-    createCommentMutation({
+    deleteActivityMutation({
       variables: { activityId },
       refetchQueries: [
         getOperationName(GET_COMPANIES) ?? '',

--- a/front/src/modules/activities/timeline/components/Timeline.tsx
+++ b/front/src/modules/activities/timeline/components/Timeline.tsx
@@ -121,8 +121,8 @@ export function Timeline({ entity }: { entity: CommentableEntity }) {
         <StyledEmptyTimelineTitle>No activity yet</StyledEmptyTimelineTitle>
         <StyledEmptyTimelineSubTitle>Create one:</StyledEmptyTimelineSubTitle>
         <ActivityCreateButton
-          onNoteClick={() => openCreateActivity(entity, ActivityType.Note)}
-          onTaskClick={() => openCreateActivity(entity, ActivityType.Task)}
+          onNoteClick={() => openCreateActivity(ActivityType.Note, entity)}
+          onTaskClick={() => openCreateActivity(ActivityType.Task, entity)}
         />
       </StyledTimelineEmptyContainer>
     );
@@ -132,8 +132,8 @@ export function Timeline({ entity }: { entity: CommentableEntity }) {
     <StyledMainContainer>
       <StyledTopActionBar>
         <ActivityCreateButton
-          onNoteClick={() => openCreateActivity(entity, ActivityType.Note)}
-          onTaskClick={() => openCreateActivity(entity, ActivityType.Task)}
+          onNoteClick={() => openCreateActivity(ActivityType.Note, entity)}
+          onTaskClick={() => openCreateActivity(ActivityType.Task, entity)}
         />
       </StyledTopActionBar>
       <StyledTimelineContainer>


### PR DESCRIPTION
## Context
We are adding an empty state to the task page.
This empty state contains a button allowing us to add a new task. 
This new task will be automatically assigned to the author (connected user) to make sure the task is correctly rendered on the page. Later we will improve the filter section and remove that logic.
We are also now showing a new "Unscheduled tasks" section which shows tasks that have been created without Due date (dueAt)

Note: CreateActivity mutation now accepts a `ActivityCreateInput` instead of the different fields so the caller can use the same request and specify any field for the input.
OpenCreateActivity has been modified to accept an optional entity instead of require. This is because in the task page we don't have any entity to associate the activity with during task creation

## Test
https://github.com/twentyhq/twenty/assets/1834158/e6f859cd-7af9-4e6d-aec4-d1d3ea1aa80e


