### PR TITLE
FIX: restore database state by nulling invalid entity ids on `PipelineProgress`

### DIFF
--- a/server/src/database/migrations/20230804093724_clean_invalid_pipelineprogressable_ids/migration.sql
+++ b/server/src/database/migrations/20230804093724_clean_invalid_pipelineprogressable_ids/migration.sql
@@ -1,0 +1,16 @@
+-- This is a manually written data migration that ensures that the progressable ids are valid.
+UPDATE "pipeline_progresses" AS pp
+SET "companyId" = NULL
+WHERE "companyId" IS NOT NULL 
+  AND NOT EXISTS (
+    SELECT 1 FROM "companies" AS c
+    WHERE c."id" = pp."companyId"
+);
+
+UPDATE "pipeline_progresses" AS pp
+SET "personId" = NULL
+WHERE "personId" IS NOT NULL 
+  AND NOT EXISTS (
+    SELECT 1 FROM "people" AS p
+    WHERE p."id" = pp."companyId"
+);

--- a/server/src/database/migrations/20230804094134_restore_pipeline_progress_entities/migration.sql
+++ b/server/src/database/migrations/20230804094134_restore_pipeline_progress_entities/migration.sql
@@ -1,0 +1,5 @@
+-- AddForeignKey
+ALTER TABLE "pipeline_progresses" ADD CONSTRAINT "pipeline_progresses_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "companies"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "pipeline_progresses" ADD CONSTRAINT "pipeline_progresses_personId_fkey" FOREIGN KEY ("personId") REFERENCES "people"("id") ON DELETE SET NULL ON UPDATE CASCADE;


### PR DESCRIPTION
### Diagnostic

We merged a set of migrations from this commit https://github.com/twentyhq/twenty/commit/21e3d8fcac84c4ba94743f8588bf47fd85f84beb yesterday that failed in production. As a quick fix we removed the relation in this commit:https://github.com/twentyhq/twenty/commit/057fa0ae04233224391363d61bf69d3f7cc30761.

These errors were due to the a case where a `PipelineProgress` has a `progressableId` set that does not correspond to an existing entry. An example would be: the user creates the `PipelineProgress` from the board view with a valid `Company` and later deletes that `Company`. The `progressableId` remains in the initial table but does not point to a valid company anymore. Here is the error it brings:

```
A migration failed to apply. New migrations cannot be applied before the error is recovered from. Read more about how to resolve migration issues in a production database: https://pris.ly/d/migrate-resolve

Migration name: 20230804094134_restore_pipeline_progress_entities

Database error code: 23503

Database error:
ERROR: insert or update on table "pipeline_progresses" violates foreign key constraint "pipeline_progresses_companyId_fkey"
DETAIL: Key (companyId)=(twenty-118995f3-5d81-46d6-bf83-f7fd33ea6102) is not present in table "companies".
```

### Resolution

I was able to reproduce locally and this PR implements migrations that fix this issue by setting the ivalid ids to `null`.
Note that this problem was solely due to the fact that we were using the previous morph strategy: now that we clearly link to a company, when the company is deleted then the `PipelineProgress.companyId` field is automatically set to `null` and the data remains valid.

### Follow-up

IMO this opens the question of deep deletes: do we want to delete all the `PipelineProgress` linked to a company when deleted ? Or are we OK to leave `PipelineProgress` entries with no progresable ? Note that as of today, we have no constraint on `PipelineProgress` to point to at least one progressable object: an entry with no progressable can exist but would simply not show on the board.
I'd be in favour of deep-deleting, at list for `company.pipelineProgresses`.