### PR TITLE
[server] add cascade delete for workspace->viewFields

### DIFF
--- a/server/src/database/migrations/20230804214457_cascade_delete_workspace_viewfield/migration.sql
+++ b/server/src/database/migrations/20230804214457_cascade_delete_workspace_viewfield/migration.sql
@@ -1,0 +1,11 @@
+-- DropForeignKey
+ALTER TABLE "viewFields" DROP CONSTRAINT "viewFields_workspaceId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "pipeline_progresses" ADD CONSTRAINT "pipeline_progresses_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "companies"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "pipeline_progresses" ADD CONSTRAINT "pipeline_progresses_personId_fkey" FOREIGN KEY ("personId") REFERENCES "people"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "viewFields" ADD CONSTRAINT "viewFields_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES "workspaces"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/server/src/database/schema.prisma
+++ b/server/src/database/schema.prisma
@@ -566,7 +566,7 @@ model ViewField {
   sizeInPx   Int
 
   /// @TypeGraphQL.omit(input: true, output: true)
-  workspace   Workspace @relation(fields: [workspaceId], references: [id])
+  workspace   Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
   /// @TypeGraphQL.omit(input: true, output: true)
   workspaceId String
 


### PR DESCRIPTION
## Context
Users are not able to delete their workspace due to a constraint on the viewField model. 
This PR updates the schema and add an `onDelete: Cascade` in the constraint so viewFields are correctly deleted before workspace deletion while still fulfilling the rest of the existing constraint.

## Test
 Before
<img width="879" alt="Screenshot 2023-08-04 at 14 43 46" src="https://github.com/twentyhq/twenty/assets/1834158/c3f426cd-f6f1-4c55-991f-c06d997d66a8">

After
<img width="1240" alt="Screenshot 2023-08-04 at 14 45 24" src="https://github.com/twentyhq/twenty/assets/1834158/be03bd0b-eb71-4182-9936-6b9571f7f48f">

