### PR TITLE
Add viewFields delete in Workspace delete resolver

### DIFF
--- a/server/src/core/workspace/services/workspace.service.ts
+++ b/server/src/core/workspace/services/workspace.service.ts
@@ -111,6 +111,7 @@ export class WorkspaceService {
       comment,
       activityTarget,
       activity,
+      viewField,
     } = this.prismaService.client;
 
     const activitys = await activity.findMany({
@@ -148,6 +149,9 @@ export class WorkspaceService {
         }),
       ),
       activity.deleteMany({
+        where,
+      }),
+      viewField.deleteMany({
         where,
       }),
       refreshToken.deleteMany({


### PR DESCRIPTION
## Context
Users are not able to delete their workspace due to a constraint on the viewField model. 
This PR updates the Workspace resolver to now delete all associated viewFields before deleting the Workspace.

## Test
 Before
<img width="879" alt="Screenshot 2023-08-04 at 14 43 46" src="https://github.com/twentyhq/twenty/assets/1834158/c3f426cd-f6f1-4c55-991f-c06d997d66a8">

After
<img width="1240" alt="Screenshot 2023-08-04 at 14 45 24" src="https://github.com/twentyhq/twenty/assets/1834158/be03bd0b-eb71-4182-9936-6b9571f7f48f">

