### PR TITLE
fix: [#1079] adding max width to menu items and also the tooltip to show full text value

### DIFF
--- a/front/src/modules/ui/dropdown/components/DropdownMenu.tsx
+++ b/front/src/modules/ui/dropdown/components/DropdownMenu.tsx
@@ -16,8 +16,6 @@ export const DropdownMenu = styled.div<{
 
   flex-direction: column;
 
-  max-width: 160px;
-
   overflow: hidden;
 
   width: ${({ width }) => width ?? 160}px;

--- a/front/src/modules/ui/dropdown/components/DropdownMenu.tsx
+++ b/front/src/modules/ui/dropdown/components/DropdownMenu.tsx
@@ -16,6 +16,8 @@ export const DropdownMenu = styled.div<{
 
   flex-direction: column;
 
+  max-width: 160px;
+
   overflow: hidden;
 
   width: ${({ width }) => width ?? 160}px;

--- a/front/src/modules/ui/filter-n-sort/components/SortDropdownButton.tsx
+++ b/front/src/modules/ui/filter-n-sort/components/SortDropdownButton.tsx
@@ -98,6 +98,7 @@ export function SortDropdownButton<SortField>({
                 }}
               >
                 {sort.icon}
+                {/* {sort.label} */}
                 <OverflowingTextWithTooltip text={sort.label} />
               </DropdownMenuSelectableItem>
             ))}

--- a/front/src/modules/ui/filter-n-sort/components/SortDropdownButton.tsx
+++ b/front/src/modules/ui/filter-n-sort/components/SortDropdownButton.tsx
@@ -98,7 +98,6 @@ export function SortDropdownButton<SortField>({
                 }}
               >
                 {sort.icon}
-                {/* {sort.label} */}
                 <OverflowingTextWithTooltip text={sort.label} />
               </DropdownMenuSelectableItem>
             ))}

--- a/front/src/modules/ui/filter-n-sort/components/SortDropdownButton.tsx
+++ b/front/src/modules/ui/filter-n-sort/components/SortDropdownButton.tsx
@@ -6,6 +6,7 @@ import { DropdownMenuHeader } from '@/ui/dropdown/components/DropdownMenuHeader'
 import { DropdownMenuItemsContainer } from '@/ui/dropdown/components/DropdownMenuItemsContainer';
 import { DropdownMenuSelectableItem } from '@/ui/dropdown/components/DropdownMenuSelectableItem';
 import { DropdownMenuSeparator } from '@/ui/dropdown/components/DropdownMenuSeparator';
+import { OverflowingTextWithTooltip } from '@/ui/tooltip/OverflowingTextWithTooltip';
 
 import { FiltersHotkeyScope } from '../types/FiltersHotkeyScope';
 import { SelectedSortType, SortType } from '../types/interface';
@@ -97,7 +98,7 @@ export function SortDropdownButton<SortField>({
                 }}
               >
                 {sort.icon}
-                {sort.label}
+                <OverflowingTextWithTooltip text={sort.label} />
               </DropdownMenuSelectableItem>
             ))}
           </DropdownMenuItemsContainer>

--- a/front/src/pages/companies/__stories__/Companies.sortBy.stories.tsx
+++ b/front/src/pages/companies/__stories__/Companies.sortBy.stories.tsx
@@ -32,7 +32,9 @@ export const SortByName: Story = {
     const sortButton = await canvas.findByText('Sort');
     await userEvent.click(sortButton);
 
-    const nameSortButton = canvas.getByText('Name', { selector: 'li > div' });
+    const nameSortButton = canvas.getByText('Name', {
+      selector: 'li > div > div',
+    });
     await userEvent.click(nameSortButton);
 
     expect(await canvas.getByTestId('remove-icon-name')).toBeInTheDocument();

--- a/front/src/pages/people/__stories__/People.sortBy.stories.tsx
+++ b/front/src/pages/people/__stories__/People.sortBy.stories.tsx
@@ -33,7 +33,9 @@ export const Email: Story = {
     const sortButton = await canvas.findByText('Sort');
     await userEvent.click(sortButton);
 
-    const emailSortButton = canvas.getByText('Email', { selector: 'li > div' });
+    const emailSortButton = canvas.getByText('Email', {
+      selector: 'li > div > div',
+    });
     await userEvent.click(emailSortButton);
 
     expect(await canvas.getByTestId('remove-icon-email')).toBeInTheDocument();
@@ -49,7 +51,9 @@ export const Cancel: Story = {
     const sortButton = await canvas.findByText('Sort');
     await userEvent.click(sortButton);
 
-    const emailSortButton = canvas.getByText('Email', { selector: 'li > div' });
+    const emailSortButton = canvas.getByText('Email', {
+      selector: 'li > div > div',
+    });
     await userEvent.click(emailSortButton);
 
     expect(await canvas.getByTestId('remove-icon-email')).toBeInTheDocument();


### PR DESCRIPTION
<img width="197" alt="Screenshot 2023-08-05 at 12 40 58 PM" src="https://github.com/twentyhq/twenty/assets/52444845/33766790-a341-47fb-9700-5a861abc22e1">
<img width="189" alt="Screenshot 2023-08-05 at 12 41 09 PM" src="https://github.com/twentyhq/twenty/assets/52444845/ba5f1e1e-c38d-4ac2-b3c4-6ed6c97dc103">
