### PR TITLE
[Opportunities] fix overlapping borders

### DIFF
--- a/front/src/modules/ui/board/components/BoardHeader.tsx
+++ b/front/src/modules/ui/board/components/BoardHeader.tsx
@@ -57,6 +57,7 @@ export function BoardHeader<SortField>({
 
   return (
     <TopBar
+      displayBottomBorder={false}
       leftComponent={
         <>
           <StyledIcon>{viewIcon}</StyledIcon>

--- a/front/src/modules/ui/board/components/StyledBoard.tsx
+++ b/front/src/modules/ui/board/components/StyledBoard.tsx
@@ -6,4 +6,5 @@ export const StyledBoard = styled.div`
   flex: 1;
   flex-direction: row;
   margin-left: ${({ theme }) => theme.spacing(2)};
+  margin-right: ${({ theme }) => theme.spacing(2)};
 `;

--- a/front/src/modules/ui/board/components/StyledBoard.tsx
+++ b/front/src/modules/ui/board/components/StyledBoard.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
 
 export const StyledBoard = styled.div`
-  border-radius: ${({ theme }) => theme.spacing(2)};
+  border-top: 1px solid ${({ theme }) => theme.border.color.light};
   display: flex;
   flex: 1;
   flex-direction: row;
-  padding-left: ${({ theme }) => theme.spacing(2)};
+  margin-left: ${({ theme }) => theme.spacing(2)};
 `;

--- a/front/src/modules/ui/filter-n-sort/components/SortAndFilterBar.tsx
+++ b/front/src/modules/ui/filter-n-sort/components/SortAndFilterBar.tsx
@@ -27,6 +27,7 @@ const StyledBar = styled.div`
   flex-direction: row;
   height: 40px;
   justify-content: space-between;
+  margin-left: ${({ theme }) => theme.spacing(2)};
 `;
 
 const StyledChipcontainer = styled.div`

--- a/front/src/modules/ui/filter-n-sort/components/SortAndFilterBar.tsx
+++ b/front/src/modules/ui/filter-n-sort/components/SortAndFilterBar.tsx
@@ -27,7 +27,6 @@ const StyledBar = styled.div`
   flex-direction: row;
   height: 40px;
   justify-content: space-between;
-  margin-left: ${({ theme }) => theme.spacing(2)};
 `;
 
 const StyledChipcontainer = styled.div`


### PR DESCRIPTION
## Context
When we use a filter, borders are overlapping. We actually want a border-top to the opportunities container and avoid border-bottom in general.
<img width="315" alt="Screenshot 2023-08-05 at 11 12 03" src="https://github.com/twentyhq/twenty/assets/1834158/1851d22b-468b-449c-90c4-d8c3a1d4fe33">

This PR fixes that and also makes sure the border looks similar to Peoples/Companies pages with a correct margin.
<img width="303" alt="Screenshot 2023-08-05 at 11 17 27" src="https://github.com/twentyhq/twenty/assets/1834158/60149454-2899-4e65-a5f1-6d32ba0318ed">
<img width="303" alt="Screenshot 2023-08-05 at 11 17 22" src="https://github.com/twentyhq/twenty/assets/1834158/78eba635-ec3f-470a-a55f-7d26eea45686">

## Test
<img width="303" alt="Screenshot 2023-08-05 at 11 19 02" src="https://github.com/twentyhq/twenty/assets/1834158/b0f5491d-ac4b-4713-af13-25e211cde50b">

<img width="303" alt="Screenshot 2023-08-05 at 11 18 26" src="https://github.com/twentyhq/twenty/assets/1834158/7a3e41ee-e78b-4895-913e-af64ce326108">

