### PR TITLE
Add ability to force picker width

### DIFF
--- a/front/src/modules/companies/components/CompanyPickerCell.tsx
+++ b/front/src/modules/companies/components/CompanyPickerCell.tsx
@@ -12,6 +12,7 @@ export type OwnProps = {
   onSubmit: (newCompany: EntityForSelect | null) => void;
   onCancel?: () => void;
   createModeEnabled?: boolean;
+  width?: number;
 };
 
 export function CompanyPickerCell({
@@ -19,6 +20,7 @@ export function CompanyPickerCell({
   onSubmit,
   onCancel,
   createModeEnabled,
+  width,
 }: OwnProps) {
   const [, setIsCreating] = useRecoilScopedState(isCreateModeScopedState);
 
@@ -46,6 +48,7 @@ export function CompanyPickerCell({
 
   return (
     <SingleEntitySelect
+      width={width}
       onCreate={createModeEnabled ? handleCreate : undefined}
       onCancel={onCancel}
       onEntitySelected={handleEntitySelected}

--- a/front/src/modules/companies/constants/companyViewFields.tsx
+++ b/front/src/modules/companies/constants/companyViewFields.tsx
@@ -32,6 +32,7 @@ export const companyViewFields: ViewFieldDefinition<ViewFieldMetadata>[] = [
       contentFieldName: 'name',
       relationType: Entity.Company,
     },
+    isVisible: true,
   } as ViewFieldDefinition<ViewFieldChipMetadata>,
   {
     id: 'domainName',
@@ -44,6 +45,7 @@ export const companyViewFields: ViewFieldDefinition<ViewFieldMetadata>[] = [
       fieldName: 'domainName',
       placeHolder: 'example.com',
     },
+    isVisible: true,
   } as ViewFieldDefinition<ViewFieldURLMetadata>,
   {
     id: 'accountOwner',
@@ -56,6 +58,7 @@ export const companyViewFields: ViewFieldDefinition<ViewFieldMetadata>[] = [
       fieldName: 'accountOwner',
       relationType: Entity.User,
     },
+    isVisible: true,
   } satisfies ViewFieldDefinition<ViewFieldRelationMetadata>,
   {
     id: 'createdAt',
@@ -67,6 +70,7 @@ export const companyViewFields: ViewFieldDefinition<ViewFieldMetadata>[] = [
       type: 'date',
       fieldName: 'createdAt',
     },
+    isVisible: true,
   } satisfies ViewFieldDefinition<ViewFieldDateMetadata>,
   {
     id: 'employees',
@@ -78,6 +82,7 @@ export const companyViewFields: ViewFieldDefinition<ViewFieldMetadata>[] = [
       type: 'number',
       fieldName: 'employees',
     },
+    isVisible: true,
   } satisfies ViewFieldDefinition<ViewFieldNumberMetadata>,
   {
     id: 'linkedin',
@@ -90,6 +95,7 @@ export const companyViewFields: ViewFieldDefinition<ViewFieldMetadata>[] = [
       fieldName: 'linkedinUrl',
       placeHolder: 'LinkedIn URL',
     },
+    isVisible: true,
   } satisfies ViewFieldDefinition<ViewFieldURLMetadata>,
   {
     id: 'address',
@@ -102,5 +108,6 @@ export const companyViewFields: ViewFieldDefinition<ViewFieldMetadata>[] = [
       fieldName: 'address',
       placeHolder: 'Addre​ss', // Hack: Fake character to prevent password-manager from filling the field
     },
+    isVisible: true,
   } satisfies ViewFieldDefinition<ViewFieldTextMetadata>,
 ];

--- a/front/src/modules/ui/dropdown/components/DropdownMenu.tsx
+++ b/front/src/modules/ui/dropdown/components/DropdownMenu.tsx
@@ -1,6 +1,9 @@
 import styled from '@emotion/styled';
 
-export const DropdownMenu = styled.div<{ disableBlur?: boolean }>`
+export const DropdownMenu = styled.div<{
+  disableBlur?: boolean;
+  width?: number;
+}>`
   backdrop-filter: ${({ disableBlur }) =>
     disableBlur ? 'none' : 'blur(20px)'};
 
@@ -13,7 +16,7 @@ export const DropdownMenu = styled.div<{ disableBlur?: boolean }>`
 
   flex-direction: column;
 
-  min-width: 160px;
-
   overflow: hidden;
+
+  width: ${({ width }) => width ?? 160}px;
 `;

--- a/front/src/modules/ui/input/relation-picker/components/SingleEntitySelect.tsx
+++ b/front/src/modules/ui/input/relation-picker/components/SingleEntitySelect.tsx
@@ -30,6 +30,7 @@ export function SingleEntitySelect<
   onEntitySelected,
   onCreate,
   onCancel,
+  width,
   disableBackgroundBlur = false,
 }: {
   onCancel?: () => void;
@@ -37,6 +38,7 @@ export function SingleEntitySelect<
   entities: EntitiesForSingleEntitySelect<CustomEntityForSelect>;
   onEntitySelected: (entity: CustomEntityForSelect | null | undefined) => void;
   disableBackgroundBlur?: boolean;
+  width?: number;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -58,7 +60,11 @@ export function SingleEntitySelect<
   });
 
   return (
-    <DropdownMenu disableBlur={disableBackgroundBlur} ref={containerRef}>
+    <DropdownMenu
+      disableBlur={disableBackgroundBlur}
+      ref={containerRef}
+      width={width}
+    >
       <DropdownMenuSearch
         value={searchFilter}
         onChange={handleSearchFilterChange}

--- a/front/src/modules/ui/link/components/RawLink.tsx
+++ b/front/src/modules/ui/link/components/RawLink.tsx
@@ -20,8 +20,6 @@ const StyledClickable = styled.div`
 `;
 
 export function RawLink({ className, href, children, onClick }: OwnProps) {
-  console.log(children);
-
   return (
     <div>
       <StyledClickable className={className}>

--- a/front/src/modules/ui/table/editable-cell/type/components/GenericEditableRelationCellEditMode.tsx
+++ b/front/src/modules/ui/table/editable-cell/type/components/GenericEditableRelationCellEditMode.tsx
@@ -54,6 +54,7 @@ export function GenericEditableRelationCellEditMode({ viewField }: OwnProps) {
           companyId={fieldValueEntity?.id ?? null}
           onSubmit={handleEntitySubmit}
           onCancel={handleCancel}
+          width={viewField.columnSize}
         />
       );
     }
@@ -63,6 +64,7 @@ export function GenericEditableRelationCellEditMode({ viewField }: OwnProps) {
           userId={fieldValueEntity?.id ?? null}
           onSubmit={handleEntitySubmit}
           onCancel={handleCancel}
+          width={viewField.columnSize}
         />
       );
     }

--- a/front/src/modules/users/components/UserPicker.tsx
+++ b/front/src/modules/users/components/UserPicker.tsx
@@ -10,13 +10,14 @@ export type OwnProps = {
   userId: string;
   onSubmit: (newUser: EntityForSelect | null) => void;
   onCancel?: () => void;
+  width?: number;
 };
 
 type UserForSelect = EntityForSelect & {
   entityType: Entity.User;
 };
 
-export function UserPicker({ userId, onSubmit, onCancel }: OwnProps) {
+export function UserPicker({ userId, onSubmit, onCancel, width }: OwnProps) {
   const [searchFilter] = useRecoilScopedState(
     relationPickerSearchFilterScopedState,
   );
@@ -44,6 +45,7 @@ export function UserPicker({ userId, onSubmit, onCancel }: OwnProps) {
 
   return (
     <SingleEntitySelect
+      width={width}
       onEntitySelected={handleEntitySelected}
       onCancel={onCancel}
       entities={{


### PR DESCRIPTION
Our Dropdown menu only had a min-width. We actually want to give the possibility to its parent to force a fixed width. This is useful as:
- we sometimes want to have dropdown smaller than its parent, sometime same width
- we want dropdown content to be overflow ellipsis

Also, I'm adding "isVisible: true" to the current default visibleFields for companies as they are used to fuel the non-connected Company view behind Login Modal