### PR TITLE
Drag to Select for Boards

### DIFF
--- a/front/src/modules/ui/board/components/EntityBoard.tsx
+++ b/front/src/modules/ui/board/components/EntityBoard.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 import { getOperationName } from '@apollo/client/utilities';
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
@@ -12,6 +12,7 @@ import { StyledBoard } from '@/ui/board/components/StyledBoard';
 import { useUpdateBoardCardIds } from '@/ui/board/hooks/useUpdateBoardCardIds';
 import { BoardColumnIdContext } from '@/ui/board/states/BoardColumnIdContext';
 import { SelectedSortType } from '@/ui/filter-n-sort/types/interface';
+import { DragSelect } from '@/ui/utilities/drag-select/components/DragSelect';
 import { RecoilScope } from '@/ui/utilities/recoil-scope/components/RecoilScope';
 import {
   PipelineProgress,
@@ -23,6 +24,7 @@ import {
 import { GET_PIPELINE_PROGRESS } from '../../../pipeline/queries';
 import { BoardColumnContext } from '../states/BoardColumnContext';
 import { boardColumnsState } from '../states/boardColumnsState';
+import { selectedBoardCardIdsState } from '../states/selectedBoardCardIdsState';
 import { BoardOptions } from '../types/BoardOptions';
 
 import { EntityBoardColumn } from './EntityBoardColumn';
@@ -102,6 +104,21 @@ export function EntityBoard({
     return a.index - b.index;
   });
 
+  const boardRef = useRef(null);
+  const [selectedBoardCards, setSelectedBoardCards] = useRecoilState(
+    selectedBoardCardIdsState,
+  );
+
+  function setRowSelectedState(boardCardId: string, selected: boolean) {
+    if (selected && !selectedBoardCards.includes(boardCardId)) {
+      setSelectedBoardCards([...selectedBoardCards, boardCardId ?? '']);
+    } else if (!selected && selectedBoardCards.includes(boardCardId)) {
+      setSelectedBoardCards(
+        selectedBoardCards.filter((id) => id !== boardCardId),
+      );
+    }
+  }
+
   return (boardColumns?.length ?? 0) > 0 ? (
     <StyledBoardWithHeader>
       <BoardHeader
@@ -111,7 +128,7 @@ export function EntityBoard({
         onSortsUpdate={updateSorts}
         context={CompanyBoardContext}
       />
-      <StyledBoard>
+      <StyledBoard ref={boardRef}>
         <DragDropContext onDragEnd={onDragEnd}>
           {sortedBoardColumns.map((column) => (
             <BoardColumnIdContext.Provider value={column.id} key={column.id}>
@@ -127,6 +144,10 @@ export function EntityBoard({
           ))}
         </DragDropContext>
       </StyledBoard>
+      <DragSelect
+        dragSelectable={boardRef}
+        onDragSelectionChange={setRowSelectedState}
+      />
     </StyledBoardWithHeader>
   ) : (
     <></>

--- a/front/src/modules/ui/board/components/EntityBoardCard.tsx
+++ b/front/src/modules/ui/board/components/EntityBoardCard.tsx
@@ -22,6 +22,8 @@ export function EntityBoardCard({
           ref={draggableProvided?.innerRef}
           {...draggableProvided?.dragHandleProps}
           {...draggableProvided?.draggableProps}
+          data-selectable-id={pipelineProgressId}
+          data-select-disable
         >
           {boardOptions.cardComponent}
         </div>

--- a/front/src/modules/ui/utilities/drag-select/components/DragSelect.tsx
+++ b/front/src/modules/ui/utilities/drag-select/components/DragSelect.tsx
@@ -7,7 +7,7 @@ import {
 type OwnProps = {
   dragSelectable: RefObject<HTMLElement>;
   onDragSelectionChange: (id: string, selected: boolean) => void;
-  onDragSelectionStart: () => void;
+  onDragSelectionStart?: () => void;
 };
 
 export function DragSelect({


### PR DESCRIPTION
Second part of the drag selection. 

TODO: Check Performance
Im unsure if this could be done more performant but the current method of adding selections for board cards seems inefficient ?
Current Behaviour: 



https://github.com/twentyhq/twenty/assets/48770548/5cc8355e-0c8b-4371-8a7d-a97bf8309068




