### PR TITLE
Add optimistic rendering for tasks

### DIFF
--- a/front/src/modules/activities/components/ActivityEditor.tsx
+++ b/front/src/modules/activities/components/ActivityEditor.tsx
@@ -6,10 +6,7 @@ import styled from '@emotion/styled';
 import { ActivityBodyEditor } from '@/activities/components/ActivityBodyEditor';
 import { ActivityComments } from '@/activities/components/ActivityComments';
 import { ActivityTypeDropdown } from '@/activities/components/ActivityTypeDropdown';
-import {
-  GET_ACTIVITIES,
-  GET_ACTIVITIES_BY_TARGETS,
-} from '@/activities/queries';
+import { GET_ACTIVITIES } from '@/activities/queries';
 import { PropertyBox } from '@/ui/editable-field/property-box/components/PropertyBox';
 import { DateEditableField } from '@/ui/editable-field/variants/components/DateEditableField';
 import { IconCalendar } from '@/ui/icon/index';
@@ -139,11 +136,19 @@ export function ActivityEditor({
             completedAt: value ? new Date().toISOString() : null,
           },
         },
-        refetchQueries: [getOperationName(GET_ACTIVITIES_BY_TARGETS) ?? ''],
+        optimisticResponse: {
+          __typename: 'Mutation',
+          updateOneActivity: {
+            __typename: 'Activity',
+            ...cachedActivity,
+            completedAt: value ? new Date().toISOString() : null,
+          },
+        },
+        refetchQueries: [getOperationName(GET_ACTIVITIES) ?? ''],
       });
       setCompletedAt(value ? new Date().toISOString() : null);
     },
-    [activity, updateActivityMutation],
+    [activity.id, cachedActivity, updateActivityMutation],
   );
 
   const debouncedUpdateTitle = debounce(updateTitle, 200);

--- a/front/src/modules/activities/hooks/useCompleteTask.ts
+++ b/front/src/modules/activities/hooks/useCompleteTask.ts
@@ -1,32 +1,43 @@
 import { useCallback } from 'react';
-import { getOperationName } from '@apollo/client/utilities';
+import { useApolloClient } from '@apollo/client';
 
-import {
-  GET_ACTIVITIES,
-  GET_ACTIVITIES_BY_TARGETS,
-} from '@/activities/queries';
 import { Activity, useUpdateActivityMutation } from '~/generated/graphql';
+
+import { ACTIVITY_UPDATE_FRAGMENT } from '../queries/update';
 
 type Task = Pick<Activity, 'id'>;
 
 export function useCompleteTask(task: Task) {
   const [updateActivityMutation] = useUpdateActivityMutation();
+
+  const client = useApolloClient();
+  const cachedTask = client.readFragment({
+    id: `Activity:${task.id}`,
+    fragment: ACTIVITY_UPDATE_FRAGMENT,
+  });
+
+  console.log('cachedTask', cachedTask);
+
   const completeTask = useCallback(
     (value: boolean) => {
+      const completedAt = value ? new Date().toISOString() : null;
       updateActivityMutation({
         variables: {
           where: { id: task.id },
           data: {
-            completedAt: value ? new Date().toISOString() : null,
+            completedAt,
           },
         },
-        refetchQueries: [
-          getOperationName(GET_ACTIVITIES_BY_TARGETS) ?? '',
-          getOperationName(GET_ACTIVITIES) ?? '',
-        ],
+        optimisticResponse: {
+          __typename: 'Mutation',
+          updateOneActivity: {
+            ...cachedTask,
+            completedAt,
+          },
+        },
       });
     },
-    [task, updateActivityMutation],
+    [cachedTask, task.id, updateActivityMutation],
   );
 
   return {

--- a/front/src/modules/activities/queries/update.ts
+++ b/front/src/modules/activities/queries/update.ts
@@ -60,24 +60,30 @@ export const DELETE_ACTIVITY = gql`
   }
 `;
 
+export const ACTIVITY_UPDATE_FRAGMENT = gql`
+  fragment ActivityUpdateParts on Activity {
+    id
+    body
+    title
+    type
+    completedAt
+    dueAt
+    assignee {
+      id
+      firstName
+      lastName
+      displayName
+    }
+  }
+`;
+
 export const UPDATE_ACTIVITY = gql`
   mutation UpdateActivity(
     $where: ActivityWhereUniqueInput!
     $data: ActivityUpdateInput!
   ) {
     updateOneActivity(where: $where, data: $data) {
-      id
-      body
-      title
-      type
-      completedAt
-      dueAt
-      assignee {
-        id
-        firstName
-        lastName
-        displayName
-      }
+      ...ActivityUpdateParts
     }
   }
 `;


### PR DESCRIPTION
Closes https://github.com/twentyhq/twenty/issues/1138.

The implementation is a bit painful due to the fact that we have to specify every field returned by the mutation in order to implement optimistic rendering, so we need to get it from the cache. This is not ideal. See this issue on apollo: https://github.com/apollographql/apollo-feature-requests/issues/104