### PR TITLE
fix update pipelineProgress with 0 probability

### DIFF
--- a/front/src/modules/ui/editable-field/components/ProbabilityEditableFieldEditMode.tsx
+++ b/front/src/modules/ui/editable-field/components/ProbabilityEditableFieldEditMode.tsx
@@ -91,13 +91,11 @@ export function ProbabilityEditableFieldEditMode({ viewField }: OwnProps) {
 
   function handleChange(newValue: number) {
     setFieldValue(newValue);
-    if (currentEntityId && updateField && newValue) {
+    if (currentEntityId && updateField) {
       updateField(currentEntityId, viewField, newValue);
     }
     closeEditableField();
   }
-
-  console.log(probabilityIndex);
 
   return (
     <StyledContainer>


### PR DESCRIPTION
Removing an unnecessary check in the handleChange, we do want to update when newValue is 0 and null check is not needed here.

## Test
<img width="332" alt="Screenshot 2023-08-09 at 10 43 35" src="https://github.com/twentyhq/twenty/assets/1834158/cc5992d1-697d-40c7-b210-cbfb5eef4c63">

Thanks @emilienchvt for flagging this!