### PR TITLE
Use dedicated EditableFieldEntityIdContext for editable fields instead of CardIds

### DIFF
--- a/front/src/generated/graphql.tsx
+++ b/front/src/generated/graphql.tsx
@@ -2404,6 +2404,8 @@ export type DeleteActivityMutationVariables = Exact<{
 
 export type DeleteActivityMutation = { __typename?: 'Mutation', deleteManyActivities: { __typename?: 'AffectedRows', count: number } };
 
+export type ActivityUpdatePartsFragment = { __typename?: 'Activity', id: string, body?: string | null, title?: string | null, type: ActivityType, completedAt?: string | null, dueAt?: string | null, assignee?: { __typename?: 'User', id: string, firstName?: string | null, lastName?: string | null, displayName: string } | null };
+
 export type UpdateActivityMutationVariables = Exact<{
   where: ActivityWhereUniqueInput;
   data: ActivityUpdateInput;
@@ -2831,7 +2833,22 @@ export type DeleteCurrentWorkspaceMutationVariables = Exact<{ [key: string]: nev
 
 export type DeleteCurrentWorkspaceMutation = { __typename?: 'Mutation', deleteCurrentWorkspace: { __typename?: 'Workspace', id: string } };
 
-
+export const ActivityUpdatePartsFragmentDoc = gql`
+    fragment ActivityUpdateParts on Activity {
+  id
+  body
+  title
+  type
+  completedAt
+  dueAt
+  assignee {
+    id
+    firstName
+    lastName
+    displayName
+  }
+}
+    `;
 export const CreateCommentDocument = gql`
     mutation CreateComment($commentId: String!, $commentText: String!, $authorId: String!, $activityId: String!, $createdAt: DateTime!) {
   createOneComment(
@@ -3286,21 +3303,10 @@ export type DeleteActivityMutationOptions = Apollo.BaseMutationOptions<DeleteAct
 export const UpdateActivityDocument = gql`
     mutation UpdateActivity($where: ActivityWhereUniqueInput!, $data: ActivityUpdateInput!) {
   updateOneActivity(where: $where, data: $data) {
-    id
-    body
-    title
-    type
-    completedAt
-    dueAt
-    assignee {
-      id
-      firstName
-      lastName
-      displayName
-    }
+    ...ActivityUpdateParts
   }
 }
-    `;
+    ${ActivityUpdatePartsFragmentDoc}`;
 export type UpdateActivityMutationFn = Apollo.MutationFunction<UpdateActivityMutation, UpdateActivityMutationVariables>;
 
 /**

--- a/front/src/modules/companies/components/CompanyBoardCard.tsx
+++ b/front/src/modules/companies/components/CompanyBoardCard.tsx
@@ -7,6 +7,7 @@ import { fieldsDefinitionsState } from '@/ui/board/states/fieldsDefinitionsState
 import { selectedBoardCardIdsState } from '@/ui/board/states/selectedBoardCardIdsState';
 import { EntityChipVariant } from '@/ui/chip/components/EntityChip';
 import { GenericEditableField } from '@/ui/editable-field/components/GenericEditableField';
+import { EntityIdContext } from '@/ui/editable-field/states/EntityIdContext';
 import {
   Checkbox,
   CheckboxVariant,
@@ -172,7 +173,9 @@ export function CompanyBoardCard() {
             {fieldsDefinitions.map((viewField) => {
               return (
                 <PreventSelectOnClickContainer key={viewField.id}>
-                  <GenericEditableField viewField={viewField} />
+                  <EntityIdContext.Provider value={boardCardId}>
+                    <GenericEditableField viewField={viewField} />
+                  </EntityIdContext.Provider>
                 </PreventSelectOnClickContainer>
               );
             })}

--- a/front/src/modules/companies/components/CompanyBoardCard.tsx
+++ b/front/src/modules/companies/components/CompanyBoardCard.tsx
@@ -7,7 +7,7 @@ import { fieldsDefinitionsState } from '@/ui/board/states/fieldsDefinitionsState
 import { selectedBoardCardIdsState } from '@/ui/board/states/selectedBoardCardIdsState';
 import { EntityChipVariant } from '@/ui/chip/components/EntityChip';
 import { GenericEditableField } from '@/ui/editable-field/components/GenericEditableField';
-import { EntityIdContext } from '@/ui/editable-field/states/EntityIdContext';
+import { EditableFieldEntityIdContext } from '@/ui/editable-field/states/EditableFieldEntityIdContext';
 import {
   Checkbox,
   CheckboxVariant,
@@ -173,9 +173,9 @@ export function CompanyBoardCard() {
             {fieldsDefinitions.map((viewField) => {
               return (
                 <PreventSelectOnClickContainer key={viewField.id}>
-                  <EntityIdContext.Provider value={boardCardId}>
+                  <EditableFieldEntityIdContext.Provider value={boardCardId}>
                     <GenericEditableField viewField={viewField} />
-                  </EntityIdContext.Provider>
+                  </EditableFieldEntityIdContext.Provider>
                 </PreventSelectOnClickContainer>
               );
             })}

--- a/front/src/modules/ui/editable-field/components/GenericEditableDateField.tsx
+++ b/front/src/modules/ui/editable-field/components/GenericEditableDateField.tsx
@@ -9,7 +9,7 @@ import { DateInputDisplay } from '@/ui/input/date/components/DateInputDisplay';
 import { RecoilScope } from '@/ui/utilities/recoil-scope/components/RecoilScope';
 import { parseDate } from '~/utils/date-utils';
 
-import { EntityIdContext } from '../states/EntityIdContext';
+import { EditableFieldEntityIdContext } from '../states/EditableFieldEntityIdContext';
 import { FieldContext } from '../states/FieldContext';
 import { genericEntityFieldFamilySelector } from '../states/genericEntityFieldFamilySelector';
 
@@ -21,11 +21,11 @@ type OwnProps = {
 };
 
 export function GenericEditableDateField({ viewField }: OwnProps) {
-  const currentEntityId = useContext(EntityIdContext);
+  const currentEditableFieldEntityId = useContext(EditableFieldEntityIdContext);
 
   const fieldValue = useRecoilValue<string>(
     genericEntityFieldFamilySelector({
-      entityId: currentEntityId ?? '',
+      entityId: currentEditableFieldEntityId ?? '',
       fieldName: viewField.metadata.fieldName,
     }),
   );

--- a/front/src/modules/ui/editable-field/components/GenericEditableDateField.tsx
+++ b/front/src/modules/ui/editable-field/components/GenericEditableDateField.tsx
@@ -1,7 +1,6 @@
 import { useContext } from 'react';
 import { useRecoilValue } from 'recoil';
 
-import { BoardCardIdContext } from '@/ui/board/states/BoardCardIdContext';
 import {
   ViewFieldDateMetadata,
   ViewFieldDefinition,
@@ -10,6 +9,7 @@ import { DateInputDisplay } from '@/ui/input/date/components/DateInputDisplay';
 import { RecoilScope } from '@/ui/utilities/recoil-scope/components/RecoilScope';
 import { parseDate } from '~/utils/date-utils';
 
+import { EntityIdContext } from '../states/EntityIdContext';
 import { FieldContext } from '../states/FieldContext';
 import { genericEntityFieldFamilySelector } from '../states/genericEntityFieldFamilySelector';
 
@@ -21,7 +21,7 @@ type OwnProps = {
 };
 
 export function GenericEditableDateField({ viewField }: OwnProps) {
-  const currentEntityId = useContext(BoardCardIdContext);
+  const currentEntityId = useContext(EntityIdContext);
 
   const fieldValue = useRecoilValue<string>(
     genericEntityFieldFamilySelector({

--- a/front/src/modules/ui/editable-field/components/GenericEditableDateFieldEditMode.tsx
+++ b/front/src/modules/ui/editable-field/components/GenericEditableDateFieldEditMode.tsx
@@ -1,13 +1,13 @@
 import { useContext } from 'react';
 import { useRecoilState } from 'recoil';
 
-import { BoardCardIdContext } from '@/ui/board/states/BoardCardIdContext';
 import {
   ViewFieldDateMetadata,
   ViewFieldDefinition,
 } from '@/ui/editable-field/types/ViewField';
 
 import { useUpdateGenericEntityField } from '../hooks/useUpdateGenericEntityField';
+import { EntityIdContext } from '../states/EntityIdContext';
 import { genericEntityFieldFamilySelector } from '../states/genericEntityFieldFamilySelector';
 import { EditableFieldEditModeDate } from '../variants/components/EditableFieldEditModeDate';
 
@@ -16,7 +16,7 @@ type OwnProps = {
 };
 
 export function GenericEditableDateFieldEditMode({ viewField }: OwnProps) {
-  const currentEntityId = useContext(BoardCardIdContext);
+  const currentEntityId = useContext(EntityIdContext);
 
   // TODO: we could use a hook that would return the field value with the right type
   const [fieldValue, setFieldValue] = useRecoilState<string>(

--- a/front/src/modules/ui/editable-field/components/GenericEditableDateFieldEditMode.tsx
+++ b/front/src/modules/ui/editable-field/components/GenericEditableDateFieldEditMode.tsx
@@ -7,7 +7,7 @@ import {
 } from '@/ui/editable-field/types/ViewField';
 
 import { useUpdateGenericEntityField } from '../hooks/useUpdateGenericEntityField';
-import { EntityIdContext } from '../states/EntityIdContext';
+import { EditableFieldEntityIdContext } from '../states/EditableFieldEntityIdContext';
 import { genericEntityFieldFamilySelector } from '../states/genericEntityFieldFamilySelector';
 import { EditableFieldEditModeDate } from '../variants/components/EditableFieldEditModeDate';
 
@@ -16,12 +16,12 @@ type OwnProps = {
 };
 
 export function GenericEditableDateFieldEditMode({ viewField }: OwnProps) {
-  const currentEntityId = useContext(EntityIdContext);
+  const currentEditableFieldEntityId = useContext(EditableFieldEntityIdContext);
 
   // TODO: we could use a hook that would return the field value with the right type
   const [fieldValue, setFieldValue] = useRecoilState<string>(
     genericEntityFieldFamilySelector({
-      entityId: currentEntityId ?? '',
+      entityId: currentEditableFieldEntityId ?? '',
       fieldName: viewField.metadata.fieldName,
     }),
   );
@@ -33,8 +33,8 @@ export function GenericEditableDateFieldEditMode({ viewField }: OwnProps) {
 
     setFieldValue(newDateISO);
 
-    if (currentEntityId && updateField && newDateISO) {
-      updateField(currentEntityId, viewField, newDateISO);
+    if (currentEditableFieldEntityId && updateField && newDateISO) {
+      updateField(currentEditableFieldEntityId, viewField, newDateISO);
     }
   }
 

--- a/front/src/modules/ui/editable-field/components/GenericEditableNumberField.tsx
+++ b/front/src/modules/ui/editable-field/components/GenericEditableNumberField.tsx
@@ -7,7 +7,7 @@ import {
 } from '@/ui/editable-field/types/ViewField';
 import { RecoilScope } from '@/ui/utilities/recoil-scope/components/RecoilScope';
 
-import { EntityIdContext } from '../states/EntityIdContext';
+import { EditableFieldEntityIdContext } from '../states/EditableFieldEntityIdContext';
 import { FieldContext } from '../states/FieldContext';
 import { genericEntityFieldFamilySelector } from '../states/genericEntityFieldFamilySelector';
 
@@ -19,11 +19,11 @@ type OwnProps = {
 };
 
 export function GenericEditableNumberField({ viewField }: OwnProps) {
-  const currentEntityId = useContext(EntityIdContext);
+  const currentEditableFieldEntityId = useContext(EditableFieldEntityIdContext);
 
   const fieldValue = useRecoilValue<string>(
     genericEntityFieldFamilySelector({
-      entityId: currentEntityId ?? '',
+      entityId: currentEditableFieldEntityId ?? '',
       fieldName: viewField.metadata.fieldName,
     }),
   );

--- a/front/src/modules/ui/editable-field/components/GenericEditableNumberField.tsx
+++ b/front/src/modules/ui/editable-field/components/GenericEditableNumberField.tsx
@@ -1,13 +1,13 @@
 import { useContext } from 'react';
 import { useRecoilValue } from 'recoil';
 
-import { BoardCardIdContext } from '@/ui/board/states/BoardCardIdContext';
 import {
   ViewFieldDefinition,
   ViewFieldNumberMetadata,
 } from '@/ui/editable-field/types/ViewField';
 import { RecoilScope } from '@/ui/utilities/recoil-scope/components/RecoilScope';
 
+import { EntityIdContext } from '../states/EntityIdContext';
 import { FieldContext } from '../states/FieldContext';
 import { genericEntityFieldFamilySelector } from '../states/genericEntityFieldFamilySelector';
 
@@ -19,7 +19,7 @@ type OwnProps = {
 };
 
 export function GenericEditableNumberField({ viewField }: OwnProps) {
-  const currentEntityId = useContext(BoardCardIdContext);
+  const currentEntityId = useContext(EntityIdContext);
 
   const fieldValue = useRecoilValue<string>(
     genericEntityFieldFamilySelector({

--- a/front/src/modules/ui/editable-field/components/GenericEditableNumberFieldEditMode.tsx
+++ b/front/src/modules/ui/editable-field/components/GenericEditableNumberFieldEditMode.tsx
@@ -13,7 +13,7 @@ import {
 
 import { useRegisterCloseFieldHandlers } from '../hooks/useRegisterCloseFieldHandlers';
 import { useUpdateGenericEntityField } from '../hooks/useUpdateGenericEntityField';
-import { EntityIdContext } from '../states/EntityIdContext';
+import { EditableFieldEntityIdContext } from '../states/EditableFieldEntityIdContext';
 import { genericEntityFieldFamilySelector } from '../states/genericEntityFieldFamilySelector';
 
 type OwnProps = {
@@ -21,12 +21,12 @@ type OwnProps = {
 };
 
 export function GenericEditableNumberFieldEditMode({ viewField }: OwnProps) {
-  const currentEntityId = useContext(EntityIdContext);
+  const currentEditableFieldEntityId = useContext(EditableFieldEntityIdContext);
 
   // TODO: we could use a hook that would return the field value with the right type
   const [fieldValue, setFieldValue] = useRecoilState<number | null>(
     genericEntityFieldFamilySelector({
-      entityId: currentEntityId ?? '',
+      entityId: currentEditableFieldEntityId ?? '',
       fieldName: viewField.metadata.fieldName,
     }),
   );
@@ -44,9 +44,9 @@ export function GenericEditableNumberFieldEditMode({ viewField }: OwnProps) {
 
     setFieldValue(castAsIntegerOrNull(internalValue));
 
-    if (currentEntityId && updateField) {
+    if (currentEditableFieldEntityId && updateField) {
       updateField(
-        currentEntityId,
+        currentEditableFieldEntityId,
         viewField,
         castAsIntegerOrNull(internalValue),
       );

--- a/front/src/modules/ui/editable-field/components/GenericEditableNumberFieldEditMode.tsx
+++ b/front/src/modules/ui/editable-field/components/GenericEditableNumberFieldEditMode.tsx
@@ -1,7 +1,6 @@
 import { useContext, useRef, useState } from 'react';
 import { useRecoilState } from 'recoil';
 
-import { BoardCardIdContext } from '@/ui/board/states/BoardCardIdContext';
 import {
   ViewFieldDefinition,
   ViewFieldNumberMetadata,
@@ -14,6 +13,7 @@ import {
 
 import { useRegisterCloseFieldHandlers } from '../hooks/useRegisterCloseFieldHandlers';
 import { useUpdateGenericEntityField } from '../hooks/useUpdateGenericEntityField';
+import { EntityIdContext } from '../states/EntityIdContext';
 import { genericEntityFieldFamilySelector } from '../states/genericEntityFieldFamilySelector';
 
 type OwnProps = {
@@ -21,7 +21,7 @@ type OwnProps = {
 };
 
 export function GenericEditableNumberFieldEditMode({ viewField }: OwnProps) {
-  const currentEntityId = useContext(BoardCardIdContext);
+  const currentEntityId = useContext(EntityIdContext);
 
   // TODO: we could use a hook that would return the field value with the right type
   const [fieldValue, setFieldValue] = useRecoilState<number | null>(

--- a/front/src/modules/ui/editable-field/components/GenericEditableRelationField.tsx
+++ b/front/src/modules/ui/editable-field/components/GenericEditableRelationField.tsx
@@ -2,7 +2,6 @@ import { useContext } from 'react';
 import { useRecoilValue } from 'recoil';
 
 import { PersonChip } from '@/people/components/PersonChip';
-import { BoardCardIdContext } from '@/ui/board/states/BoardCardIdContext';
 import {
   ViewFieldDefinition,
   ViewFieldRelationMetadata,
@@ -11,6 +10,7 @@ import { Entity } from '@/ui/input/relation-picker/types/EntityTypeForSelect';
 import { RelationPickerHotkeyScope } from '@/ui/input/relation-picker/types/RelationPickerHotkeyScope';
 import { RecoilScope } from '@/ui/utilities/recoil-scope/components/RecoilScope';
 
+import { EntityIdContext } from '../states/EntityIdContext';
 import { FieldContext } from '../states/FieldContext';
 import { genericEntityFieldFamilySelector } from '../states/genericEntityFieldFamilySelector';
 
@@ -47,7 +47,7 @@ function RelationChip({
 }
 
 export function GenericEditableRelationField({ viewField }: OwnProps) {
-  const currentEntityId = useContext(BoardCardIdContext);
+  const currentEntityId = useContext(EntityIdContext);
 
   const fieldValue = useRecoilValue<any | null>(
     genericEntityFieldFamilySelector({

--- a/front/src/modules/ui/editable-field/components/GenericEditableRelationField.tsx
+++ b/front/src/modules/ui/editable-field/components/GenericEditableRelationField.tsx
@@ -10,7 +10,7 @@ import { Entity } from '@/ui/input/relation-picker/types/EntityTypeForSelect';
 import { RelationPickerHotkeyScope } from '@/ui/input/relation-picker/types/RelationPickerHotkeyScope';
 import { RecoilScope } from '@/ui/utilities/recoil-scope/components/RecoilScope';
 
-import { EntityIdContext } from '../states/EntityIdContext';
+import { EditableFieldEntityIdContext } from '../states/EditableFieldEntityIdContext';
 import { FieldContext } from '../states/FieldContext';
 import { genericEntityFieldFamilySelector } from '../states/genericEntityFieldFamilySelector';
 
@@ -47,11 +47,11 @@ function RelationChip({
 }
 
 export function GenericEditableRelationField({ viewField }: OwnProps) {
-  const currentEntityId = useContext(EntityIdContext);
+  const currentEditableFieldEntityId = useContext(EditableFieldEntityIdContext);
 
   const fieldValue = useRecoilValue<any | null>(
     genericEntityFieldFamilySelector({
-      entityId: currentEntityId ?? '',
+      entityId: currentEditableFieldEntityId ?? '',
       fieldName: viewField.metadata.fieldName,
     }),
   );

--- a/front/src/modules/ui/editable-field/components/GenericEditableRelationFieldEditMode.tsx
+++ b/front/src/modules/ui/editable-field/components/GenericEditableRelationFieldEditMode.tsx
@@ -13,7 +13,7 @@ import { Entity } from '@/ui/input/relation-picker/types/EntityTypeForSelect';
 
 import { useEditableField } from '../hooks/useEditableField';
 import { useUpdateGenericEntityField } from '../hooks/useUpdateGenericEntityField';
-import { EntityIdContext } from '../states/EntityIdContext';
+import { EditableFieldEntityIdContext } from '../states/EditableFieldEntityIdContext';
 import { genericEntityFieldFamilySelector } from '../states/genericEntityFieldFamilySelector';
 
 const RelationPickerContainer = styled.div`
@@ -56,12 +56,12 @@ function RelationPicker({
 }
 
 export function GenericEditableRelationFieldEditMode({ viewField }: OwnProps) {
-  const currentEntityId = useContext(EntityIdContext);
+  const currentEditableFieldEntityId = useContext(EditableFieldEntityIdContext);
 
   // TODO: we could use a hook that would return the field value with the right type
   const [fieldValue, setFieldValue] = useRecoilState<any | null>(
     genericEntityFieldFamilySelector({
-      entityId: currentEntityId ?? '',
+      entityId: currentEditableFieldEntityId ?? '',
       fieldName: viewField.metadata.fieldName,
     }),
   );
@@ -78,8 +78,8 @@ export function GenericEditableRelationFieldEditMode({ viewField }: OwnProps) {
       avatarUrl: newRelation?.avatarUrl ?? null,
     });
 
-    if (currentEntityId && updateField) {
-      updateField(currentEntityId, viewField, newRelation);
+    if (currentEditableFieldEntityId && updateField) {
+      updateField(currentEditableFieldEntityId, viewField, newRelation);
     }
 
     closeEditableField();

--- a/front/src/modules/ui/editable-field/components/GenericEditableRelationFieldEditMode.tsx
+++ b/front/src/modules/ui/editable-field/components/GenericEditableRelationFieldEditMode.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 import { useRecoilState } from 'recoil';
 
 import { PeoplePicker } from '@/people/components/PeoplePicker';
-import { BoardCardIdContext } from '@/ui/board/states/BoardCardIdContext';
 import {
   ViewFieldDefinition,
   ViewFieldRelationMetadata,
@@ -14,6 +13,7 @@ import { Entity } from '@/ui/input/relation-picker/types/EntityTypeForSelect';
 
 import { useEditableField } from '../hooks/useEditableField';
 import { useUpdateGenericEntityField } from '../hooks/useUpdateGenericEntityField';
+import { EntityIdContext } from '../states/EntityIdContext';
 import { genericEntityFieldFamilySelector } from '../states/genericEntityFieldFamilySelector';
 
 const RelationPickerContainer = styled.div`
@@ -56,7 +56,7 @@ function RelationPicker({
 }
 
 export function GenericEditableRelationFieldEditMode({ viewField }: OwnProps) {
-  const currentEntityId = useContext(BoardCardIdContext);
+  const currentEntityId = useContext(EntityIdContext);
 
   // TODO: we could use a hook that would return the field value with the right type
   const [fieldValue, setFieldValue] = useRecoilState<any | null>(

--- a/front/src/modules/ui/editable-field/components/ProbabilityEditableFieldEditMode.tsx
+++ b/front/src/modules/ui/editable-field/components/ProbabilityEditableFieldEditMode.tsx
@@ -5,7 +5,7 @@ import { useRecoilState } from 'recoil';
 import { useEditableField } from '@/ui/editable-field/hooks/useEditableField';
 
 import { useUpdateGenericEntityField } from '../hooks/useUpdateGenericEntityField';
-import { EntityIdContext } from '../states/EntityIdContext';
+import { EditableFieldEntityIdContext } from '../states/EditableFieldEntityIdContext';
 import { genericEntityFieldFamilySelector } from '../states/genericEntityFieldFamilySelector';
 import {
   ViewFieldDefinition,
@@ -76,11 +76,11 @@ export function ProbabilityEditableFieldEditMode({ viewField }: OwnProps) {
   const [nextProbabilityIndex, setNextProbabilityIndex] = useState<
     number | null
   >(null);
-  const currentEntityId = useContext(EntityIdContext);
+  const currentEditableFieldEntityId = useContext(EditableFieldEntityIdContext);
 
   const [fieldValue, setFieldValue] = useRecoilState<number>(
     genericEntityFieldFamilySelector({
-      entityId: currentEntityId ?? '',
+      entityId: currentEditableFieldEntityId ?? '',
       fieldName: viewField.metadata.fieldName,
     }),
   );
@@ -92,8 +92,8 @@ export function ProbabilityEditableFieldEditMode({ viewField }: OwnProps) {
 
   function handleChange(newValue: number) {
     setFieldValue(newValue);
-    if (currentEntityId && updateField) {
-      updateField(currentEntityId, viewField, newValue);
+    if (currentEditableFieldEntityId && updateField) {
+      updateField(currentEditableFieldEntityId, viewField, newValue);
     }
     closeEditableField();
   }

--- a/front/src/modules/ui/editable-field/components/ProbabilityEditableFieldEditMode.tsx
+++ b/front/src/modules/ui/editable-field/components/ProbabilityEditableFieldEditMode.tsx
@@ -2,10 +2,10 @@ import { useContext, useState } from 'react';
 import styled from '@emotion/styled';
 import { useRecoilState } from 'recoil';
 
-import { BoardCardIdContext } from '@/ui/board/states/BoardCardIdContext';
 import { useEditableField } from '@/ui/editable-field/hooks/useEditableField';
 
 import { useUpdateGenericEntityField } from '../hooks/useUpdateGenericEntityField';
+import { EntityIdContext } from '../states/EntityIdContext';
 import { genericEntityFieldFamilySelector } from '../states/genericEntityFieldFamilySelector';
 import {
   ViewFieldDefinition,
@@ -76,7 +76,8 @@ export function ProbabilityEditableFieldEditMode({ viewField }: OwnProps) {
   const [nextProbabilityIndex, setNextProbabilityIndex] = useState<
     number | null
   >(null);
-  const currentEntityId = useContext(BoardCardIdContext);
+  const currentEntityId = useContext(EntityIdContext);
+
   const [fieldValue, setFieldValue] = useRecoilState<number>(
     genericEntityFieldFamilySelector({
       entityId: currentEntityId ?? '',

--- a/front/src/modules/ui/editable-field/hooks/useCurrentEntityId.ts
+++ b/front/src/modules/ui/editable-field/hooks/useCurrentEntityId.ts
@@ -1,6 +1,6 @@
 import { useContext } from 'react';
 
-import { EntityIdContext } from '../states/EntityIdContext';
+import { EntityIdContext } from '../states/EditableFieldEntityIdContext';
 
 export function useCurrentEntityId() {
   return useContext(EntityIdContext);

--- a/front/src/modules/ui/editable-field/hooks/useCurrentEntityId.ts
+++ b/front/src/modules/ui/editable-field/hooks/useCurrentEntityId.ts
@@ -1,7 +1,0 @@
-import { useContext } from 'react';
-
-import { EntityIdContext } from '../states/EditableFieldEntityIdContext';
-
-export function useCurrentEntityId() {
-  return useContext(EntityIdContext);
-}

--- a/front/src/modules/ui/editable-field/states/EditableFieldContext.ts
+++ b/front/src/modules/ui/editable-field/states/EditableFieldContext.ts
@@ -1,3 +1,0 @@
-import { createContext } from 'react';
-
-export const EditableFieldContext = createContext<string | null>(null);

--- a/front/src/modules/ui/editable-field/states/EditableFieldEntityIdContext.ts
+++ b/front/src/modules/ui/editable-field/states/EditableFieldEntityIdContext.ts
@@ -1,0 +1,3 @@
+import { createContext } from 'react';
+
+export const EditableFieldEntityIdContext = createContext<string | null>(null);

--- a/front/src/modules/ui/editable-field/states/EntityIdContext.ts
+++ b/front/src/modules/ui/editable-field/states/EntityIdContext.ts
@@ -1,3 +1,0 @@
-import { createContext } from 'react';
-
-export const EntityIdContext = createContext<string | null>(null);


### PR DESCRIPTION
## Context
After the recent refactoring done in https://github.com/twentyhq/twenty/pull/1089, we were using BoardId context to propagate the id later used for the different mutations applied on the editable fields. 
We now want to use the same fields for show pages so it will make more sense to have something with a more generic name.

## Test