### PR TITLE
[opportunities] fix poc being removed after pipeline update

### DIFF
--- a/front/src/generated/graphql.tsx
+++ b/front/src/generated/graphql.tsx
@@ -2655,7 +2655,7 @@ export type UpdateOnePipelineProgressMutationVariables = Exact<{
 }>;
 
 
-export type UpdateOnePipelineProgressMutation = { __typename?: 'Mutation', updateOnePipelineProgress?: { __typename?: 'PipelineProgress', id: string, amount?: number | null, closeDate?: string | null, probability?: number | null } | null };
+export type UpdateOnePipelineProgressMutation = { __typename?: 'Mutation', updateOnePipelineProgress?: { __typename?: 'PipelineProgress', id: string, amount?: number | null, closeDate?: string | null, probability?: number | null, pointOfContact?: { __typename?: 'Person', id: string } | null } | null };
 
 export type UpdateOnePipelineProgressStageMutationVariables = Exact<{
   id?: InputMaybe<Scalars['String']>;
@@ -4685,6 +4685,9 @@ export const UpdateOnePipelineProgressDocument = gql`
     amount
     closeDate
     probability
+    pointOfContact {
+      id
+    }
   }
 }
     `;

--- a/front/src/modules/pipeline/queries/update.ts
+++ b/front/src/modules/pipeline/queries/update.ts
@@ -28,6 +28,9 @@ export const UPDATE_PIPELINE_PROGRESS = gql`
       amount
       closeDate
       probability
+      pointOfContact {
+        id
+      }
     }
   }
 `;

--- a/front/src/modules/ui/editable-field/components/GenericEditableDateFieldEditMode.tsx
+++ b/front/src/modules/ui/editable-field/components/GenericEditableDateFieldEditMode.tsx
@@ -33,7 +33,7 @@ export function GenericEditableDateFieldEditMode({ viewField }: OwnProps) {
 
     setFieldValue(newDateISO);
 
-    if (currentEditableFieldEntityId && updateField && newDateISO) {
+    if (currentEditableFieldEntityId && updateField) {
       updateField(currentEditableFieldEntityId, viewField, newDateISO);
     }
   }


### PR DESCRIPTION
## Issue
updateOnePipelineProgress mutation is performed when we modify fields and all the fields are re-rendered with the value returned by Apollo. When we are modifying PoC then other fields, its value is reverted to the initial value due to the mutation missing the pointOfContact.id from the gql response.

## Test
Before

https://github.com/twentyhq/twenty/assets/1834158/c3457385-5b96-4189-bab7-4ce966b89832


After


https://github.com/twentyhq/twenty/assets/1834158/da70bc13-0062-470b-bb9c-8f951a75bc36

