### PR TITLE
Force 404 on static folder when a file is not found

### DIFF
--- a/infra/prod/front/Dockerfile
+++ b/infra/prod/front/Dockerfile
@@ -13,6 +13,8 @@ COPY ./front .
 RUN yarn install
 RUN yarn build
 
+COPY ./infra/prod/front/serve.json ./build
+
 FROM node:18.16.0-alpine as front
 
 WORKDIR /app/front
@@ -20,4 +22,4 @@ COPY --from=build /app/front/build ./build
 
 RUN yarn global add serve
 
-CMD ["serve", "-s", "build"]
+CMD ["serve", "build"]

--- a/infra/prod/front/serve.json
+++ b/infra/prod/front/serve.json
@@ -1,0 +1,6 @@
+{
+  "rewrites": [
+    { "source": "!static/**", "destination": "/index.html" }
+  ],
+  "directoryListing": false
+}


### PR DESCRIPTION
Right now, on production, when an unexisting static file is requested, we return a 200. That's a problem to handle deployments as not found resources are cached as 200 by Cloudflare

That's because we are using `-s` option of serve to serve build directory.

This PR is removing the use of this option and replacing by rewrite that exclude static folder