### PR TITLE
Re-add constraints

### DIFF
--- a/server/src/database/migrations/20230811193858_add_missing_constraints/migration.sql
+++ b/server/src/database/migrations/20230811193858_add_missing_constraints/migration.sql
@@ -1,0 +1,17 @@
+-- DropForeignKey
+ALTER TABLE "activity_targets" DROP CONSTRAINT "activity_targets_companyId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "activity_targets" DROP CONSTRAINT "activity_targets_personId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "activity_targets" ADD CONSTRAINT "activity_targets_personId_fkey" FOREIGN KEY ("personId") REFERENCES "people"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "activity_targets" ADD CONSTRAINT "activity_targets_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "companies"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "pipeline_progresses" ADD CONSTRAINT "pipeline_progresses_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "companies"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "pipeline_progresses" ADD CONSTRAINT "pipeline_progresses_personId_fkey" FOREIGN KEY ("personId") REFERENCES "people"("id") ON DELETE CASCADE ON UPDATE CASCADE;


### PR DESCRIPTION
In the past weeks, we have been holding on adding these constraints because existing data in production did not allow it. 
Because of legacy logic, we add ActivityTargets and PipelineProgresses pointing on deleted companies/people, which prevents from adding these constraints.
I've cleaned the production database, we are good to go!