### PR TITLE
fix-on-dropdown-menu-width

### DIFF
--- a/front/src/modules/ui/dropdown/components/DropdownMenu.tsx
+++ b/front/src/modules/ui/dropdown/components/DropdownMenu.tsx
@@ -18,5 +18,5 @@ export const DropdownMenu = styled.div<{
 
   overflow: hidden;
 
-  width: ${({ width }) => width ?? 160}px;
+  width: ${({ width }) => (width && width > 160 ? width : 160)}px;
 `;

--- a/front/src/modules/ui/table/components/EntityTable.tsx
+++ b/front/src/modules/ui/table/components/EntityTable.tsx
@@ -28,6 +28,8 @@ const StyledTable = styled.table`
   margin-right: ${({ theme }) => theme.table.horizontalCellMargin};
   table-layout: fixed;
 
+  width: calc(100% - ${({ theme }) => theme.table.horizontalCellMargin} * 2);
+
   th {
     border: 1px solid ${({ theme }) => theme.border.color.light};
     border-collapse: collapse;

--- a/front/src/modules/ui/tooltip/OverflowingTextWithTooltip.tsx
+++ b/front/src/modules/ui/tooltip/OverflowingTextWithTooltip.tsx
@@ -47,11 +47,6 @@ export function OverflowingTextWithTooltip({
     event.preventDefault();
   }
 
-  function handleTooltipMouseUp(event: React.MouseEvent<HTMLDivElement>) {
-    event.stopPropagation();
-    event.preventDefault();
-  }
-
   return (
     <>
       <StyledOverflowingText
@@ -64,12 +59,11 @@ export function OverflowingTextWithTooltip({
       </StyledOverflowingText>
       {isTitleOverflowing &&
         createPortal(
-          <div onMouseUp={handleTooltipMouseUp} onClick={handleTooltipClick}>
+          <div onClick={handleTooltipClick}>
             <AppTooltip
               anchorSelect={`#${textElementId}`}
               content={text ?? ''}
-              clickable
-              delayHide={100}
+              delayHide={0}
               offset={5}
               noArrow
               place="bottom"


### PR DESCRIPTION
In this PR:
- Disable Tooltip clickable: this was annoying, especially in dropdown where the tooltip was on top of the next dropdown item and preventing the user from selecting it
- Make table have a width (other wise, th and td width is not taken into account below minimum content width)
- Make dropdown min-width 160px per discussion with design team