### PR TITLE
Unselect users and companies

### DIFF
--- a/front/src/modules/companies/components/CompanyPickerCell.tsx
+++ b/front/src/modules/companies/components/CompanyPickerCell.tsx
@@ -72,7 +72,14 @@ export function CompanyPickerCell({
       });
     setIsCreating(false);
   }
-
+  const noUser: EntityForSelect = {
+    entityType: Entity.Company,
+    id: '',
+    name: 'No Company',
+    avatarType: 'rounded',
+    avatarUrl:
+      'https://raw.githubusercontent.com/tabler/tabler-icons/master/icons/building-skyscraper.svg',
+  };
   return isCreating ? (
     <DoubleTextCellEdit
       firstValue={searchFilter}
@@ -92,6 +99,7 @@ export function CompanyPickerCell({
         selectedEntity: companies.selectedEntities[0],
         loading: companies.loading,
       }}
+      noUser={noUser}
     />
   );
 }

--- a/front/src/modules/ui/input/relation-picker/components/SingleEntitySelect.tsx
+++ b/front/src/modules/ui/input/relation-picker/components/SingleEntitySelect.tsx
@@ -32,6 +32,7 @@ export function SingleEntitySelect<
   onCancel,
   width,
   disableBackgroundBlur = false,
+  noUser,
 }: {
   onCancel?: () => void;
   onCreate?: () => void;
@@ -39,6 +40,7 @@ export function SingleEntitySelect<
   onEntitySelected: (entity: CustomEntityForSelect | null | undefined) => void;
   disableBackgroundBlur?: boolean;
   width?: number;
+  noUser?: CustomEntityForSelect;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -58,7 +60,6 @@ export function SingleEntitySelect<
       onCancel?.();
     },
   });
-
   return (
     <DropdownMenu
       disableBlur={disableBackgroundBlur}
@@ -75,6 +76,7 @@ export function SingleEntitySelect<
         entities={entities}
         onEntitySelected={onEntitySelected}
         onCancel={onCancel}
+        noUser={noUser}
       />
       {showCreateButton && (
         <>

--- a/front/src/modules/ui/input/relation-picker/components/SingleEntitySelectBase.tsx
+++ b/front/src/modules/ui/input/relation-picker/components/SingleEntitySelectBase.tsx
@@ -30,10 +30,12 @@ export function SingleEntitySelectBase<
   entities,
   onEntitySelected,
   onCancel,
+  noUser,
 }: {
   entities: EntitiesForSingleEntitySelect<CustomEntityForSelect>;
   onEntitySelected: (entity: CustomEntityForSelect | null | undefined) => void;
   onCancel?: () => void;
+  noUser?: CustomEntityForSelect;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   let entitiesInDropdown = isDefined(entities.selectedEntity)
@@ -74,6 +76,17 @@ export function SingleEntitySelectBase<
 
   return (
     <DropdownMenuItemsContainer ref={containerRef} hasMaxHeight>
+      {noUser && (
+        <DropdownMenuItem onClick={() => onEntitySelected(noUser)}>
+          <Avatar
+            avatarUrl={noUser.avatarUrl}
+            placeholder={noUser.name}
+            size="md"
+            type={noUser.avatarType}
+          />
+          {noUser.name}
+        </DropdownMenuItem>
+      )}
       {entities.loading ? (
         <DropdownMenuSkeletonItem />
       ) : entitiesInDropdown.length === 0 ? (

--- a/front/src/modules/ui/table/hooks/useUpdateEntityField.ts
+++ b/front/src/modules/ui/table/hooks/useUpdateEntityField.ts
@@ -89,8 +89,7 @@ export function useUpdateEntityField() {
       const newSelectedEntity = newFieldValueUnknown;
 
       const fieldName = viewField.metadata.fieldName;
-
-      if (!newSelectedEntity) {
+      if (!newSelectedEntity || newSelectedEntity.id === '') {
         updateEntity({
           variables: {
             where: { id: currentEntityId },

--- a/front/src/modules/users/components/UserPicker.tsx
+++ b/front/src/modules/users/components/UserPicker.tsx
@@ -42,7 +42,14 @@ export function UserPicker({ userId, onSubmit, onCancel, width }: OwnProps) {
   ) {
     onSubmit(selectedUser ?? null);
   }
-
+  const noUser: UserForSelect = {
+    entityType: Entity.User,
+    id: '',
+    name: 'No Owner',
+    avatarType: 'rounded',
+    avatarUrl:
+      'https://raw.githubusercontent.com/tabler/tabler-icons/master/icons/user-circle.svg',
+  };
   return (
     <SingleEntitySelect
       width={width}
@@ -53,6 +60,7 @@ export function UserPicker({ userId, onSubmit, onCancel, width }: OwnProps) {
         entitiesToSelect: users.entitiesToSelect,
         selectedEntity: users.selectedEntities[0],
       }}
+      noUser={noUser}
     />
   );
 }

--- a/server/src/ability/ability.util.ts
+++ b/server/src/ability/ability.util.ts
@@ -61,6 +61,10 @@ const simpleAbilityCheck: OperationAbilityChecker = async (
 ) => {
   // Extract entity name from model name
   const entity = camelCase(modelName);
+  //TODO: Fix boolean data types so that disconnects are possible
+  if (typeof data === 'boolean') {
+    return true;
+  }
   // Handle all operations cases
   const operations = !Array.isArray(data) ? [data] : data;
   // Handle where case
@@ -135,7 +139,6 @@ export async function relationAbilityChecker(
         // Extract operation name and value
         const operationType = Object.keys(operation)[0] as OperationType;
         const operationValue = operation[operationType];
-
         // Get operation checker for the operation type
         const operationChecker = operationAbilityCheckers[operationType];
 


### PR DESCRIPTION
This resolves #985 of being unable to unset relationships of users and companies. I did have to edit the server ability util as it seemed to fail when data was passed into it as a Boolean when trying to send disconnect. I am unsure of the side affect of having that line.

- [x] Add the ability to have a None option in SingleEntitySelect (pass icon + label as props)
- [x] Use it in UserPicker as optional parameter
- [x] Update GenericEditableRelationCellEditMode to unset the relation