### PR TITLE
[Docs] Update WSL instructions + fix broken links

### DIFF
--- a/docs/docs/developer/additional/windows-wsl-setup.mdx
+++ b/docs/docs/developer/additional/windows-wsl-setup.mdx
@@ -55,8 +55,5 @@ Close and reopen your terminal to start using nvm or run the following to use it
 
 ### Install Twenty project
 
-You are ready to install Twenty project. Follow the [Yarn install guide](/developer/local-setup#yarn-install) instructions. 
+You are ready to install Twenty project. Follow the [Yarn install guide](/developer/local-setup#yarn-install-recommended) instructions.
 We don't recommend to use Docker on WSL as it adds an extra layer of complexity.
-
-
-

--- a/docs/docs/developer/local-setup.mdx
+++ b/docs/docs/developer/local-setup.mdx
@@ -83,7 +83,8 @@ CREATE DATABASE "test";
 Create a `twenty` user with password `twenty`:
 
 ```sql
-CREATE USER twenty PASSWORD ‘twenty’
+CREATE USER twenty PASSWORD 'twenty';
+ALTER USER twenty CREATEDB;
 ```
   </TabItem>
 </Tabs>

--- a/docs/docs/start/getting-started.mdx
+++ b/docs/docs/start/getting-started.mdx
@@ -12,8 +12,8 @@ The easiest way to quickly try the app is to signup on [app.twenty.com](https://
 
 The signup is free.
 
-<ThemedImage sources={{light: "../../img/light-sign-in.png", dark:"../../img/dark-sign-in.png"}} style={{width:'100%', maxWidth:'800px'}}/>
+<ThemedImage sources={{light: "/img/light-sign-in.png", dark:"/img/dark-sign-in.png"}} style={{width:'100%', maxWidth:'800px'}}/>
 
 ## Developer documentation
 
-If you are looking to install the project locally, either to try it or to contribute, check out our [developer guide](../developer/local-setup).
+If you are looking to install the project locally, either to try it or to contribute, check out our [developer guide](/developer/local-setup).


### PR DESCRIPTION
Small PR on docs to:
- grant 'twenty' postgres user database creation rights (this is needed for prisma to compute new migration as it is creating a shadow database: https://www.prisma.io/docs/concepts/components/prisma-migrate/shadow-database
- fix link to Yarn Install on WSL setup page
- fix broken link on getting-started page