### PR TITLE
Upgrade /front version and display the version in settings navbar

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "private": true,
   "dependencies": {
     "@air/react-drag-to-select": "^5.0.8",

--- a/front/package.json
+++ b/front/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "dependencies": {
     "@air/react-drag-to-select": "^5.0.8",

--- a/front/package.json
+++ b/front/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty",
-  "version": "0.1.3",
+  "version": "0.1.2",
   "private": true,
   "dependencies": {
     "@air/react-drag-to-select": "^5.0.8",

--- a/front/src/modules/settings/components/SettingsNavbar.tsx
+++ b/front/src/modules/settings/components/SettingsNavbar.tsx
@@ -1,7 +1,6 @@
 import { useCallback } from 'react';
 import { useMatch, useNavigate, useResolvedPath } from 'react-router-dom';
 import { useTheme } from '@emotion/react';
-import styled from '@emotion/styled';
 
 import { useAuth } from '@/auth/hooks/useAuth';
 import { AppPath } from '@/types/AppPath';
@@ -16,26 +15,6 @@ import NavItem from '@/ui/navbar/components/NavItem';
 import NavTitle from '@/ui/navbar/components/NavTitle';
 import SubMenuNavbar from '@/ui/navbar/components/SubMenuNavbar';
 
-import packageJson from '../../../../package.json';
-
-const StyledContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  justify-content: space-between;
-  margin-bottom: ${({ theme }) => theme.spacing(2.5)};
-`;
-
-const StyledVersion = styled.div`
-  display: flex;
-  font-size: ${({ theme }) => theme.font.size.sm};
-  font-weight: ${({ theme }) => theme.font.weight.medium};
-  justify-content: center;
-  span {
-    color: ${({ theme }) => theme.font.color.tertiary};
-  }
-`;
-
 export function SettingsNavbar() {
   const theme = useTheme();
   const navigate = useNavigate();
@@ -47,67 +26,60 @@ export function SettingsNavbar() {
     navigate(AppPath.SignIn);
   }, [signOut, navigate]);
 
-  const version = packageJson.version;
-
   return (
-    <StyledContainer>
-      <SubMenuNavbar backButtonTitle="Settings">
-        <NavTitle label="User" />
-        <NavItem
-          label="Profile"
-          to="/settings/profile"
-          icon={<IconUserCircle size={theme.icon.size.md} />}
-          active={
-            !!useMatch({
-              path: useResolvedPath('/settings/profile').pathname,
-              end: true,
-            })
-          }
-        />
-        <NavItem
-          label="Experience"
-          to="/settings/profile/experience"
-          icon={<IconColorSwatch size={theme.icon.size.md} />}
-          active={
-            !!useMatch({
-              path: useResolvedPath('/settings/profile/experience').pathname,
-              end: true,
-            })
-          }
-        />
-        <NavTitle label="Workspace" />
-        <NavItem
-          label="General"
-          to="/settings/workspace"
-          icon={<IconSettings size={theme.icon.size.md} />}
-          active={
-            !!useMatch({
-              path: useResolvedPath('/settings/workspace').pathname,
-              end: true,
-            })
-          }
-        />
-        <NavItem
-          label="Members"
-          to="/settings/workspace-members"
-          icon={<IconUsers size={theme.icon.size.md} />}
-          active={
-            !!useMatch({
-              path: useResolvedPath('/settings/workspace-members').pathname,
-              end: true,
-            })
-          }
-        />
-        <NavTitle label="Other" />
-        <NavItem
-          label="Logout"
-          onClick={handleLogout}
-          icon={<IconLogout size={theme.icon.size.md} />}
-        />
-      </SubMenuNavbar>
-      <StyledVersion>
-        <span>Version {version}</span>
-      </StyledVersion>
-    </StyledContainer>
+    <SubMenuNavbar backButtonTitle="Settings">
+      <NavTitle label="User" />
+      <NavItem
+        label="Profile"
+        to="/settings/profile"
+        icon={<IconUserCircle size={theme.icon.size.md} />}
+        active={
+          !!useMatch({
+            path: useResolvedPath('/settings/profile').pathname,
+            end: true,
+          })
+        }
+      />
+      <NavItem
+        label="Experience"
+        to="/settings/profile/experience"
+        icon={<IconColorSwatch size={theme.icon.size.md} />}
+        active={
+          !!useMatch({
+            path: useResolvedPath('/settings/profile/experience').pathname,
+            end: true,
+          })
+        }
+      />
+      <NavTitle label="Workspace" />
+      <NavItem
+        label="General"
+        to="/settings/workspace"
+        icon={<IconSettings size={theme.icon.size.md} />}
+        active={
+          !!useMatch({
+            path: useResolvedPath('/settings/workspace').pathname,
+            end: true,
+          })
+        }
+      />
+      <NavItem
+        label="Members"
+        to="/settings/workspace-members"
+        icon={<IconUsers size={theme.icon.size.md} />}
+        active={
+          !!useMatch({
+            path: useResolvedPath('/settings/workspace-members').pathname,
+            end: true,
+          })
+        }
+      />
+      <NavTitle label="Other" />
+      <NavItem
+        label="Logout"
+        onClick={handleLogout}
+        icon={<IconLogout size={theme.icon.size.md} />}
+      />
+    </SubMenuNavbar>
   );
 }

--- a/front/src/modules/settings/components/SettingsNavbar.tsx
+++ b/front/src/modules/settings/components/SettingsNavbar.tsx
@@ -27,7 +27,7 @@ export function SettingsNavbar() {
   }, [signOut, navigate]);
 
   return (
-    <SubMenuNavbar backButtonTitle="Settings">
+    <SubMenuNavbar backButtonTitle="Settings" displayVersion={true}>
       <NavTitle label="User" />
       <NavItem
         label="Profile"

--- a/front/src/modules/settings/components/SettingsNavbar.tsx
+++ b/front/src/modules/settings/components/SettingsNavbar.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import { useMatch, useNavigate, useResolvedPath } from 'react-router-dom';
 import { useTheme } from '@emotion/react';
+import styled from '@emotion/styled';
 
 import { useAuth } from '@/auth/hooks/useAuth';
 import { AppPath } from '@/types/AppPath';
@@ -15,6 +16,26 @@ import NavItem from '@/ui/navbar/components/NavItem';
 import NavTitle from '@/ui/navbar/components/NavTitle';
 import SubMenuNavbar from '@/ui/navbar/components/SubMenuNavbar';
 
+import packageJson from '../../../../package.json';
+
+const StyledContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  justify-content: space-between;
+  margin-bottom: ${({ theme }) => theme.spacing(2.5)};
+`;
+
+const StyledVersion = styled.div`
+  display: flex;
+  font-size: ${({ theme }) => theme.font.size.sm};
+  font-weight: ${({ theme }) => theme.font.weight.medium};
+  justify-content: center;
+  span {
+    color: ${({ theme }) => theme.font.color.tertiary};
+  }
+`;
+
 export function SettingsNavbar() {
   const theme = useTheme();
   const navigate = useNavigate();
@@ -26,60 +47,67 @@ export function SettingsNavbar() {
     navigate(AppPath.SignIn);
   }, [signOut, navigate]);
 
+  const version = packageJson.version;
+
   return (
-    <SubMenuNavbar backButtonTitle="Settings">
-      <NavTitle label="User" />
-      <NavItem
-        label="Profile"
-        to="/settings/profile"
-        icon={<IconUserCircle size={theme.icon.size.md} />}
-        active={
-          !!useMatch({
-            path: useResolvedPath('/settings/profile').pathname,
-            end: true,
-          })
-        }
-      />
-      <NavItem
-        label="Experience"
-        to="/settings/profile/experience"
-        icon={<IconColorSwatch size={theme.icon.size.md} />}
-        active={
-          !!useMatch({
-            path: useResolvedPath('/settings/profile/experience').pathname,
-            end: true,
-          })
-        }
-      />
-      <NavTitle label="Workspace" />
-      <NavItem
-        label="General"
-        to="/settings/workspace"
-        icon={<IconSettings size={theme.icon.size.md} />}
-        active={
-          !!useMatch({
-            path: useResolvedPath('/settings/workspace').pathname,
-            end: true,
-          })
-        }
-      />
-      <NavItem
-        label="Members"
-        to="/settings/workspace-members"
-        icon={<IconUsers size={theme.icon.size.md} />}
-        active={
-          !!useMatch({
-            path: useResolvedPath('/settings/workspace-members').pathname,
-            end: true,
-          })
-        }
-      />
-      <NavTitle label="Other" />
-      <NavItem
-        label="Logout"
-        onClick={handleLogout}
-        icon={<IconLogout size={theme.icon.size.md} />}
-      />
-    </SubMenuNavbar>
+    <StyledContainer>
+      <SubMenuNavbar backButtonTitle="Settings">
+        <NavTitle label="User" />
+        <NavItem
+          label="Profile"
+          to="/settings/profile"
+          icon={<IconUserCircle size={theme.icon.size.md} />}
+          active={
+            !!useMatch({
+              path: useResolvedPath('/settings/profile').pathname,
+              end: true,
+            })
+          }
+        />
+        <NavItem
+          label="Experience"
+          to="/settings/profile/experience"
+          icon={<IconColorSwatch size={theme.icon.size.md} />}
+          active={
+            !!useMatch({
+              path: useResolvedPath('/settings/profile/experience').pathname,
+              end: true,
+            })
+          }
+        />
+        <NavTitle label="Workspace" />
+        <NavItem
+          label="General"
+          to="/settings/workspace"
+          icon={<IconSettings size={theme.icon.size.md} />}
+          active={
+            !!useMatch({
+              path: useResolvedPath('/settings/workspace').pathname,
+              end: true,
+            })
+          }
+        />
+        <NavItem
+          label="Members"
+          to="/settings/workspace-members"
+          icon={<IconUsers size={theme.icon.size.md} />}
+          active={
+            !!useMatch({
+              path: useResolvedPath('/settings/workspace-members').pathname,
+              end: true,
+            })
+          }
+        />
+        <NavTitle label="Other" />
+        <NavItem
+          label="Logout"
+          onClick={handleLogout}
+          icon={<IconLogout size={theme.icon.size.md} />}
+        />
+      </SubMenuNavbar>
+      <StyledVersion>
+        <span>Version {version}</span>
+      </StyledVersion>
+    </StyledContainer>
   );
 }

--- a/front/src/modules/ui/icon/index.ts
+++ b/front/src/modules/ui/icon/index.ts
@@ -55,3 +55,4 @@ export { IconHeart } from '@tabler/icons-react';
 export { IconBrandX } from '@tabler/icons-react';
 export { IconTag } from '@tabler/icons-react';
 export { IconHelpCircle } from '@tabler/icons-react';
+export { IconBrandGithub } from '@tabler/icons-react';

--- a/front/src/modules/ui/navbar/components/SubMenuNavbar.tsx
+++ b/front/src/modules/ui/navbar/components/SubMenuNavbar.tsx
@@ -1,3 +1,4 @@
+import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 
 import { IconBrandGithub } from '@/ui/icon';
@@ -15,25 +16,28 @@ type OwnProps = {
   displayVersion?: boolean;
 };
 
-const StyledVersion = styled.div`
+const StyledVersionContainer = styled.div`
   font-size: ${({ theme }) => theme.font.size.sm};
   font-weight: ${({ theme }) => theme.font.weight.medium};
   margin-bottom: ${({ theme }) => theme.spacing(2)};
-  span {
-    color: ${({ theme }) => theme.font.color.light};
-    :hover {
-      color: ${({ theme }) => theme.font.color.tertiary};
-    }
-    padding-left: ${({ theme }) => theme.spacing(1)};
+  padding-left: ${({ theme }) => theme.spacing(1)};
+`;
+
+const StyledVersion = styled.span`
+  color: ${({ theme }) => theme.font.color.light};
+  :hover {
+    color: ${({ theme }) => theme.font.color.tertiary};
   }
-  a {
-    align-items: center;
-    color: ${({ theme }) => theme.font.color.light};
-    display: flex;
-    text-decoration: none;
-    :hover {
-      color: ${({ theme }) => theme.font.color.tertiary};
-    }
+  padding-left: ${({ theme }) => theme.spacing(1)};
+`;
+
+const StyledVersionLink = styled.a`
+  align-items: center;
+  color: ${({ theme }) => theme.font.color.light};
+  display: flex;
+  text-decoration: none;
+  :hover {
+    color: ${({ theme }) => theme.font.color.tertiary};
   }
 `;
 
@@ -53,6 +57,8 @@ export default function SubMenuNavbar({
 }: OwnProps) {
   const version = packageJson.version;
 
+  const theme = useTheme();
+
   return (
     <StyledContainer>
       <div>
@@ -60,12 +66,12 @@ export default function SubMenuNavbar({
         <NavItemsContainer>{children}</NavItemsContainer>
       </div>
       {displayVersion && (
-        <StyledVersion>
-          <a href={githubLink} target="_blank" rel="noreferrer">
-            <IconBrandGithub size={16} />
-            <span>{version}</span>
-          </a>
-        </StyledVersion>
+        <StyledVersionContainer>
+          <StyledVersionLink href={githubLink} target="_blank" rel="noreferrer">
+            <IconBrandGithub size={theme.icon.size.md} />
+            <StyledVersion>{version}</StyledVersion>
+          </StyledVersionLink>
+        </StyledVersionContainer>
       )}
     </StyledContainer>
   );

--- a/front/src/modules/ui/navbar/components/SubMenuNavbar.tsx
+++ b/front/src/modules/ui/navbar/components/SubMenuNavbar.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 
 import { useIsMobile } from '@/ui/utilities/responsive/hooks/useIsMobile';
 
+import packageJson from '../../../../../package.json';
 import { leftNavbarWidth } from '../constants';
 
 import NavBackButton from './NavBackButton';
@@ -12,18 +13,36 @@ type OwnProps = {
   backButtonTitle: string;
 };
 
+const StyledVersion = styled.div`
+  font-size: ${({ theme }) => theme.font.size.sm};
+  font-weight: ${({ theme }) => theme.font.weight.medium};
+  span {
+    color: ${({ theme }) => theme.font.color.tertiary};
+  }
+  margin-bottom: ${({ theme }) => theme.spacing(2)};
+`;
+
 const StyledContainer = styled.div`
   display: flex;
   flex-direction: column;
+  height: 100%;
+  justify-content: space-between;
   padding-top: ${({ theme }) => theme.spacing(9)};
   width: ${() => (useIsMobile() ? '100%' : leftNavbarWidth.desktop)};
 `;
 
 export default function SubMenuNavbar({ children, backButtonTitle }: OwnProps) {
+  const version = packageJson.version;
+
   return (
     <StyledContainer>
-      <NavBackButton title={backButtonTitle} />
-      <NavItemsContainer>{children}</NavItemsContainer>
+      <div>
+        <NavBackButton title={backButtonTitle} />
+        <NavItemsContainer>{children}</NavItemsContainer>
+      </div>
+      <StyledVersion>
+        <span>Version {version}</span>
+      </StyledVersion>
     </StyledContainer>
   );
 }

--- a/front/src/modules/ui/navbar/components/SubMenuNavbar.tsx
+++ b/front/src/modules/ui/navbar/components/SubMenuNavbar.tsx
@@ -1,9 +1,10 @@
 import styled from '@emotion/styled';
 
+import { IconBrandGithub } from '@/ui/icon';
 import { useIsMobile } from '@/ui/utilities/responsive/hooks/useIsMobile';
 
 import packageJson from '../../../../../package.json';
-import { leftNavbarWidth } from '../constants';
+import { githubLink, leftNavbarWidth } from '../constants';
 
 import NavBackButton from './NavBackButton';
 import NavItemsContainer from './NavItemsContainer';
@@ -11,17 +12,29 @@ import NavItemsContainer from './NavItemsContainer';
 type OwnProps = {
   children: React.ReactNode;
   backButtonTitle: string;
+  displayVersion?: boolean;
 };
 
 const StyledVersion = styled.div`
-  display: flex;
   font-size: ${({ theme }) => theme.font.size.sm};
   font-weight: ${({ theme }) => theme.font.weight.medium};
-  justify-content: center;
-  span {
-    color: ${({ theme }) => theme.font.color.tertiary};
-  }
   margin-bottom: ${({ theme }) => theme.spacing(2)};
+  span {
+    color: ${({ theme }) => theme.font.color.light};
+    :hover {
+      color: ${({ theme }) => theme.font.color.tertiary};
+    }
+    padding-left: ${({ theme }) => theme.spacing(1)};
+  }
+  a {
+    align-items: center;
+    color: ${({ theme }) => theme.font.color.light};
+    display: flex;
+    text-decoration: none;
+    :hover {
+      color: ${({ theme }) => theme.font.color.tertiary};
+    }
+  }
 `;
 
 const StyledContainer = styled.div`
@@ -33,7 +46,11 @@ const StyledContainer = styled.div`
   width: ${() => (useIsMobile() ? '100%' : leftNavbarWidth.desktop)};
 `;
 
-export default function SubMenuNavbar({ children, backButtonTitle }: OwnProps) {
+export default function SubMenuNavbar({
+  children,
+  backButtonTitle,
+  displayVersion,
+}: OwnProps) {
   const version = packageJson.version;
 
   return (
@@ -42,9 +59,14 @@ export default function SubMenuNavbar({ children, backButtonTitle }: OwnProps) {
         <NavBackButton title={backButtonTitle} />
         <NavItemsContainer>{children}</NavItemsContainer>
       </div>
-      <StyledVersion>
-        <span>Version {version}</span>
-      </StyledVersion>
+      {displayVersion && (
+        <StyledVersion>
+          <a href={githubLink} target="_blank" rel="noreferrer">
+            <IconBrandGithub size={16} />
+            <span>{version}</span>
+          </a>
+        </StyledVersion>
+      )}
     </StyledContainer>
   );
 }

--- a/front/src/modules/ui/navbar/components/SubMenuNavbar.tsx
+++ b/front/src/modules/ui/navbar/components/SubMenuNavbar.tsx
@@ -14,8 +14,10 @@ type OwnProps = {
 };
 
 const StyledVersion = styled.div`
+  display: flex;
   font-size: ${({ theme }) => theme.font.size.sm};
   font-weight: ${({ theme }) => theme.font.weight.medium};
+  justify-content: center;
   span {
     color: ${({ theme }) => theme.font.color.tertiary};
   }

--- a/front/src/modules/ui/navbar/constants/index.ts
+++ b/front/src/modules/ui/navbar/constants/index.ts
@@ -12,3 +12,5 @@ export const navbarIconSize = {
   mobile: 18,
   desktop: 16,
 };
+
+export const githubLink = 'https://github.com/twentyhq/twenty';


### PR DESCRIPTION
## Context
We missed a few versions, updating the package.json accordingly.
Also the version is now visible in the settings Navbar, this could be useful for people self-hosting.
Not sure if we want to display it on the cloud version though?

https://github.com/twentyhq/twenty/assets/1834158/cec9e729-2591-41ec-bf45-592804815590

