### PR TITLE
font weight to medium #1208

### DIFF
--- a/front/src/modules/ui/chip/components/Chip.tsx
+++ b/front/src/modules/ui/chip/components/Chip.tsx
@@ -64,6 +64,7 @@ const StyledContainer = styled.div<Partial<OwnProps>>`
       ? 'pointer'
       : 'inherit'};
   display: inline-flex;
+  font-weight: ${({ theme }) => theme.font.weight.medium};
   gap: ${({ theme }) => theme.spacing(1)};
 
   height: ${({ size }) => (size === ChipSize.Large ? '16px' : '12px')};


### PR DESCRIPTION
Addressing #1208

Font weight medium on both icon & text

<img width="112" alt="Screenshot 2023-08-16 at 10 27 25 AM" src="https://github.com/twentyhq/twenty/assets/62022514/5208061b-19fe-4c12-8b50-2c1c53f00bf0">
