### PR TITLE
Fix task update sync without refetchQueries

### DIFF
--- a/front/src/modules/activities/hooks/useCompleteTask.ts
+++ b/front/src/modules/activities/hooks/useCompleteTask.ts
@@ -1,13 +1,11 @@
 import { useCallback } from 'react';
 import { useApolloClient } from '@apollo/client';
-import { getOperationName } from '@apollo/client/utilities';
 
 import { Activity, useUpdateActivityMutation } from '~/generated/graphql';
 
 import { ACTIVITY_UPDATE_FRAGMENT } from '../graphql/fragments/activityUpdateFragment';
-import { GET_ACTIVITIES } from '../graphql/queries/getActivities';
 
-type Task = Pick<Activity, 'id' | 'completedAt'>;
+type Task = Pick<Activity, 'id'>;
 
 export function useCompleteTask(task: Task) {
   const [updateActivityMutation] = useUpdateActivityMutation();
@@ -35,7 +33,6 @@ export function useCompleteTask(task: Task) {
             completedAt,
           },
         },
-        refetchQueries: [getOperationName(GET_ACTIVITIES) ?? ''],
       });
     },
     [cachedTask, task.id, updateActivityMutation],

--- a/front/src/modules/activities/hooks/useTasks.ts
+++ b/front/src/modules/activities/hooks/useTasks.ts
@@ -55,30 +55,25 @@ export function useTasks() {
     }),
   );
 
-  const { data: completeTasksData } = useGetActivitiesQuery({
+  const { data: tasks } = useGetActivitiesQuery({
     variables: {
       where: {
         type: { equals: ActivityType.Task },
-        completedAt: { not: { equals: null } },
         ...whereFilters,
       },
     },
   });
 
-  const { data: incompleteTaskData } = useGetActivitiesQuery({
-    variables: {
-      where: {
-        type: { equals: ActivityType.Task },
-        completedAt: { equals: null },
-        ...whereFilters,
-      },
-    },
-  });
+  const completeTasks = tasks?.findManyActivities.filter(
+    (activity) => activity.completedAt,
+  );
+  const incompleteTasks = tasks?.findManyActivities.filter(
+    (activity) => !activity.completedAt,
+  );
 
-  const tasksData =
-    activeTabId === 'done' ? completeTasksData : incompleteTaskData;
+  const tasksData = activeTabId === 'done' ? completeTasks : incompleteTasks;
 
-  const todayOrPreviousTasks = tasksData?.findManyActivities.filter((task) => {
+  const todayOrPreviousTasks = tasksData?.filter((task) => {
     if (!task.dueAt) {
       return false;
     }
@@ -87,7 +82,7 @@ export function useTasks() {
     return dueDate <= today;
   });
 
-  const upcomingTasks = tasksData?.findManyActivities.filter((task) => {
+  const upcomingTasks = tasksData?.filter((task) => {
     if (!task.dueAt) {
       return false;
     }
@@ -96,7 +91,7 @@ export function useTasks() {
     return dueDate > today;
   });
 
-  const unscheduledTasks = tasksData?.findManyActivities.filter((task) => {
+  const unscheduledTasks = tasksData?.filter((task) => {
     return !task.dueAt;
   });
 


### PR DESCRIPTION
## Context
Task status was not reflected when updated (by checking/unchecking the checkbox). 
A first fix has been made with a refetchQueries to force the re-render with fresh data however I think we can avoid the query by simplifying a bit the fetch in useTasks hook. 
Before, we were querying activities twice, once for completed and once for uncompleted tasks. Even if the cache of apollo was updated it was not reflected due to the nature of the request. Now we are simply doing a single request that return all of them then we filter after