### PR TITLE
Fix Chip font-weight

### DIFF
--- a/front/src/modules/ui/chip/components/Chip.tsx
+++ b/front/src/modules/ui/chip/components/Chip.tsx
@@ -65,7 +65,7 @@ const StyledContainer = styled.div<Partial<OwnProps>>`
       : 'inherit'};
   display: inline-flex;
   font-weight: ${({ theme, accent }) =>
-    accent == ChipAccent.TextSecondary ? theme.font.weight.medium : 'inherit'};
+    accent === ChipAccent.TextSecondary ? theme.font.weight.medium : 'inherit'};
   gap: ${({ theme }) => theme.spacing(1)};
 
   height: ${({ size }) => (size === ChipSize.Large ? '16px' : '12px')};

--- a/front/src/modules/ui/chip/components/Chip.tsx
+++ b/front/src/modules/ui/chip/components/Chip.tsx
@@ -64,7 +64,8 @@ const StyledContainer = styled.div<Partial<OwnProps>>`
       ? 'pointer'
       : 'inherit'};
   display: inline-flex;
-  font-weight: ${({ theme }) => theme.font.weight.medium};
+  font-weight: ${({ theme, accent }) =>
+    accent == ChipAccent.TextSecondary ? theme.font.weight.medium : 'inherit'};
   gap: ${({ theme }) => theme.spacing(1)};
 
   height: ${({ size }) => (size === ChipSize.Large ? '16px' : '12px')};


### PR DESCRIPTION
## Context
Chip font-weight was updated everywhere instead of just the ActivityTypeDropdown, this PR should fix that by adding this change to the TextSecondary accent only (which is only used in ActivityTypeDropdown)

Before
<img width="498" alt="Screenshot 2023-08-16 at 15 57 31" src="https://github.com/twentyhq/twenty/assets/1834158/e387f16b-0355-4ad0-bb3c-36b054293712">

After
<img width="496" alt="Screenshot 2023-08-16 at 15 57 47" src="https://github.com/twentyhq/twenty/assets/1834158/7e3ea0fe-f306-4059-b133-58d0661305f0">
