### PR TITLE
fix(modal): add padding in confirmation modal

### DIFF
--- a/front/src/modules/ui/modal/components/ConfirmationModal.tsx
+++ b/front/src/modules/ui/modal/components/ConfirmationModal.tsx
@@ -24,6 +24,10 @@ export type ConfirmationModalProps = {
   confirmationValue?: string;
 };
 
+const StyledConfirmationModal = styled(Modal)`
+  padding: ${({ theme }) => theme.spacing(4)};
+`;
+
 const StyledCenteredButton = styled(Button)`
   justify-content: center;
 `;
@@ -68,7 +72,7 @@ export function ConfirmationModal({
   return (
     <AnimatePresence mode="wait">
       <LayoutGroup>
-        <Modal
+        <StyledConfirmationModal
           isOpen={isOpen}
           onOutsideClick={() => {
             if (isOpen) {
@@ -110,7 +114,7 @@ export function ConfirmationModal({
               marginTop: 10,
             }}
           />
-        </Modal>
+        </StyledConfirmationModal>
       </LayoutGroup>
     </AnimatePresence>
   );


### PR DESCRIPTION
Before:
![image](https://github.com/twentyhq/twenty/assets/22376783/acbaadb9-81d5-4ac1-be8c-bdb503ade0f3)


After: 
![image](https://github.com/twentyhq/twenty/assets/22376783/48374edc-b46e-4afc-8e5f-14e9d4ad99bb)
