### PR TITLE
fix(views): update recoil state on successful api call

### DIFF
--- a/front/src/modules/views/hooks/useTableViews.ts
+++ b/front/src/modules/views/hooks/useTableViews.ts
@@ -101,8 +101,9 @@ export const useTableViews = ({
           viewsById[nextView.id].name !== nextView.name,
       );
       await updateViewFields(viewsToUpdate);
+      setViews(nextViews);
     },
-    [createViews, updateViewFields, viewsById],
+    [createViews, updateViewFields, setViews, viewsById],
   );
 
   return { handleViewsChange };


### PR DESCRIPTION
Vies dropdown in companies table uses, recoil state to show the options, when we update & create a view the later state is not updated and hence showing the inaccurate data on client

**Before:**

https://github.com/twentyhq/twenty/assets/22376783/4a511475-d419-44e4-b7c7-fb1f9ae3a70b

**After:**

https://github.com/twentyhq/twenty/assets/22376783/52575527-3c43-44d2-9b4e-418612f86b9a


