### PR TITLE
Fix: Avoid showing confirmation dialog on closing spreadsheet import with no changes

### DIFF
--- a/front/src/modules/spreadsheet-import/components/ModalCloseButton.tsx
+++ b/front/src/modules/spreadsheet-import/components/ModalCloseButton.tsx
@@ -1,10 +1,13 @@
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 
+import { useSpreadsheetImportInitialStep } from '@/spreadsheet-import/hooks/useSpreadsheetImportInitialStep';
+import { useSpreadsheetImportInternal } from '@/spreadsheet-import/hooks/useSpreadsheetImportInternal';
 import { ButtonVariant } from '@/ui/button/components/Button';
 import { IconButton } from '@/ui/button/components/IconButton';
 import { useDialog } from '@/ui/dialog/hooks/useDialog';
 import { IconX } from '@/ui/icon/index';
+import { useStepBar } from '@/ui/step-bar/hooks/useStepBar';
 
 const StyledCloseButtonContainer = styled.div`
   align-items: center;
@@ -24,9 +27,23 @@ type ModalCloseButtonProps = {
 export const ModalCloseButton = ({ onClose }: ModalCloseButtonProps) => {
   const theme = useTheme();
 
+  const { initialStepState } = useSpreadsheetImportInternal();
+
+  const { initialStep } = useSpreadsheetImportInitialStep(
+    initialStepState?.type,
+  );
+
+  const { activeStep } = useStepBar({
+    initialStep,
+  });
+
   const { enqueueDialog } = useDialog();
 
   function handleClose() {
+    if (activeStep === -1) {
+      onClose();
+      return;
+    }
     enqueueDialog({
       title: 'Exit import flow',
       message: 'Are you sure? Your current information will not be saved.',


### PR DESCRIPTION
Was running into this personally using Twenty so here's a fix for skipping showing the confirmation modal if nothing has been changed

#1268 

https://github.com/twentyhq/twenty/assets/32676955/6a529d15-45ad-4684-b77f-409f05133e7e

the whole ModalCloseButton should be refactored as it's obviously very specific to spreadsheet-import (hence I added the checking of steps within it), and the copy on the modal is very specific to just the import flow