### PR TITLE
Fix: Profile picture does not appear after signin

### DIFF
--- a/front/src/generated/graphql.tsx
+++ b/front/src/generated/graphql.tsx
@@ -3412,6 +3412,7 @@ export const UserQueryFragmentFragmentDoc = gql`
   lastName
   canImpersonate
   supportUserHash
+  avatarUrl
   workspaceMember {
     id
     allowImpersonation

--- a/front/src/modules/auth/graphql/fragments/userQueryFragment.ts
+++ b/front/src/modules/auth/graphql/fragments/userQueryFragment.ts
@@ -9,6 +9,7 @@ export const USER_QUERY_FRAGMENT = gql`
     lastName
     canImpersonate
     supportUserHash
+    avatarUrl
     workspaceMember {
       id
       allowImpersonation


### PR DESCRIPTION
An attempt to close #1044

- add the missing field `avatarUrl` to `UserQueryFragment` in `front/src/generated/graphql.tsxfront/src/generated/graphql.tsx`

**Before**
[a9c7500e-7033-4d5e-a6a1-862101809640.webm](https://github.com/twentyhq/twenty/assets/18232579/50b4e45c-8c82-4815-9b9c-73498ae22549)

**After**
[e8078109-04d0-4b81-9cd3-8d25a1de3a26.webm](https://github.com/twentyhq/twenty/assets/18232579/efd4ae4a-ca75-467d-9280-a3bd745584a9)

