### PR TITLE
Fix confirmation modal size

### DIFF
--- a/front/src/modules/ui/editable-field/components/EditableFieldDisplayMode.tsx
+++ b/front/src/modules/ui/editable-field/components/EditableFieldDisplayMode.tsx
@@ -71,16 +71,6 @@ type OwnProps = {
   isDisplayModeFixHeight?: boolean;
 };
 
-function displayEmptyIfNothingToShow(
-  children: React.ReactNode,
-  isDisplayModeContentEmpty?: boolean,
-): React.ReactNode {
-  if (isDisplayModeContentEmpty || !children) {
-    return <StyledEmptyField>{'Empty'}</StyledEmptyField>;
-  }
-  return children;
-}
-
 export function EditableFieldDisplayMode({
   children,
   disableClick,
@@ -98,7 +88,11 @@ export function EditableFieldDisplayMode({
       isDisplayModeFixHeight={isDisplayModeFixHeight}
     >
       <StyledEditableFieldNormalModeInnerContainer>
-        {displayEmptyIfNothingToShow(children, isDisplayModeContentEmpty)}
+        {isDisplayModeContentEmpty || !children ? (
+          <StyledEmptyField>{'Empty'}</StyledEmptyField>
+        ) : (
+          children
+        )}
       </StyledEditableFieldNormalModeInnerContainer>
     </StyledEditableFieldNormalModeOuterContainer>
   );

--- a/front/src/modules/ui/modal/components/ConfirmationModal.tsx
+++ b/front/src/modules/ui/modal/components/ConfirmationModal.tsx
@@ -26,6 +26,7 @@ export type ConfirmationModalProps = {
 
 const StyledConfirmationModal = styled(Modal)`
   padding: ${({ theme }) => theme.spacing(4)};
+  width: calc(400px - ${({ theme }) => theme.spacing(10 * 2)});
 `;
 
 const StyledCenteredButton = styled(Button)`


### PR DESCRIPTION
## Context
We recently brought a regression after merging the csv import modal. Padding has been fixed in a recent PR but the size of the confirmation modal is not aligned with the design in Figma https://www.figma.com/file/xt8O9mFeLl46C5InWwoMrN/Twenty?node-id=7825%3A79604&mode=dev

Also I took the occasion to remove an unnecessary function in EditableFieldDisplayMode (cc @emilienchvt)