### PR TITLE
Selected row background

### DIFF
--- a/front/src/modules/ui/table/components/EntityTableRow.tsx
+++ b/front/src/modules/ui/table/components/EntityTableRow.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import { useRecoilValue } from 'recoil';
 
 import { ViewFieldContext } from '../contexts/ViewFieldContext';
+import { useCurrentRowSelected } from '../hooks/useCurrentRowSelected';
 import { visibleTableColumnsState } from '../states/tableColumnsState';
 
 import { CheckboxCell } from './CheckboxCell';
@@ -9,16 +10,17 @@ import { EntityTableCell } from './EntityTableCell';
 
 const StyledRow = styled.tr<{ selected: boolean }>`
   background: ${(props) =>
-    props.selected ? props.theme.background.secondary : 'none'};
+    props.selected ? props.theme.accent.quaternary : 'none'};
 `;
 
 export function EntityTableRow({ rowId }: { rowId: string }) {
   const columns = useRecoilValue(visibleTableColumnsState);
+  const { currentRowSelected } = useCurrentRowSelected();
 
   return (
     <StyledRow
       data-testid={`row-id-${rowId}`}
-      selected={false}
+      selected={currentRowSelected}
       data-selectable-id={rowId}
     >
       <td>


### PR DESCRIPTION
The selected row background was not set and didn't match figma. 

Now: 

<img width="817" alt="Bildschirmfoto 2023-08-24 um 09 14 12" src="https://github.com/twentyhq/twenty/assets/48770548/bad5b40a-18bf-4eaf-a37f-cb8011c54582">



closes #413 