### PR TITLE
Add hotkeys to modals

### DIFF
--- a/front/src/modules/ui/layout/show-page/components/ShowPageRightContainer.tsx
+++ b/front/src/modules/ui/layout/show-page/components/ShowPageRightContainer.tsx
@@ -1,9 +1,9 @@
-import { ReactElement } from 'react';
+/* eslint-disable twenty/styled-components-prefixed-with-styled */
 import styled from '@emotion/styled';
 
 import { useIsMobile } from '@/ui/utilities/responsive/hooks/useIsMobile';
 
-export const StyledShowPageRightContainer = styled.div`
+export const ShowPageRightContainer = styled.div`
   display: flex;
   flex: 1 0 0;
   flex-direction: column;
@@ -15,15 +15,3 @@ export const StyledShowPageRightContainer = styled.div`
     return isMobile ? `calc(100% - ${theme.spacing(6)})` : 'auto';
   }};
 `;
-
-export type ShowPageRightContainerProps = {
-  children: ReactElement;
-};
-
-export function ShowPageRightContainer({
-  children,
-}: ShowPageRightContainerProps) {
-  return (
-    <StyledShowPageRightContainer>{children} </StyledShowPageRightContainer>
-  );
-}

--- a/front/src/modules/ui/layout/show-page/components/ShowPageRightContainer.tsx
+++ b/front/src/modules/ui/layout/show-page/components/ShowPageRightContainer.tsx
@@ -1,9 +1,9 @@
-/* eslint-disable twenty/styled-components-prefixed-with-styled */
+import { ReactElement } from 'react';
 import styled from '@emotion/styled';
 
 import { useIsMobile } from '@/ui/utilities/responsive/hooks/useIsMobile';
 
-export const ShowPageRightContainer = styled.div`
+export const StyledShowPageRightContainer = styled.div`
   display: flex;
   flex: 1 0 0;
   flex-direction: column;
@@ -15,3 +15,15 @@ export const ShowPageRightContainer = styled.div`
     return isMobile ? `calc(100% - ${theme.spacing(6)})` : 'auto';
   }};
 `;
+
+export type ShowPageRightContainerProps = {
+  children: ReactElement;
+};
+
+export function ShowPageRightContainer({
+  children,
+}: ShowPageRightContainerProps) {
+  return (
+    <StyledShowPageRightContainer>{children} </StyledShowPageRightContainer>
+  );
+}

--- a/front/src/modules/ui/modal/components/ConfirmationModal.tsx
+++ b/front/src/modules/ui/modal/components/ConfirmationModal.tsx
@@ -2,6 +2,7 @@ import { ReactNode, useState } from 'react';
 import styled from '@emotion/styled';
 import { AnimatePresence, LayoutGroup } from 'framer-motion';
 import debounce from 'lodash.debounce';
+import { Key } from 'ts-key-enum';
 
 import { Button, ButtonVariant } from '@/ui/button/components/Button';
 import { TextInput } from '@/ui/input/text/components/TextInput';
@@ -12,6 +13,9 @@ import {
   SectionFontColor,
 } from '@/ui/section/components/Section';
 import { H1Title, H1TitleFontColor } from '@/ui/typography/components/H1Title';
+import { useScopedHotkeys } from '@/ui/utilities/hotkey/hooks/useScopedHotkeys';
+
+import { ModalHotkeyScope } from './types/ModalHotkeyScope';
 
 export type ConfirmationModalProps = {
   isOpen: boolean;
@@ -60,14 +64,22 @@ export function ConfirmationModal({
 
   const handleInputConfimrationValueChange = (value: string) => {
     setInputConfirmationValue(value);
-    isValueMatchingUserEmail(confirmationValue, value);
+    isValueMatchingInput(confirmationValue, value);
   };
 
-  const isValueMatchingUserEmail = debounce(
+  const isValueMatchingInput = debounce(
     (value?: string, inputValue?: string) => {
       setIsValidValue(Boolean(value && inputValue && value === inputValue));
     },
     250,
+  );
+
+  useScopedHotkeys(
+    [Key.Escape],
+    () => {
+      setIsOpen(false);
+    },
+    ModalHotkeyScope.ConfirmationModal,
   );
 
   return (
@@ -75,11 +87,12 @@ export function ConfirmationModal({
       <LayoutGroup>
         <StyledConfirmationModal
           isOpen={isOpen}
-          onOutsideClick={() => {
+          closeModal={() => {
             if (isOpen) {
               setIsOpen(false);
             }
           }}
+          hotkeyScope={ModalHotkeyScope.ConfirmationModal}
         >
           <H1Title title={title} fontColor={H1TitleFontColor.Primary} />
           <Section
@@ -95,7 +108,7 @@ export function ConfirmationModal({
                 onChange={handleInputConfimrationValueChange}
                 placeholder={confirmationPlaceholder}
                 fullWidth
-                key={'email-' + confirmationValue}
+                key={'input-' + confirmationValue}
               />
             </Section>
           )}

--- a/front/src/modules/ui/modal/components/ConfirmationModal.tsx
+++ b/front/src/modules/ui/modal/components/ConfirmationModal.tsx
@@ -96,6 +96,7 @@ export function ConfirmationModal({
                 placeholder={confirmationPlaceholder}
                 fullWidth
                 key={'input-' + confirmationValue}
+                autoFocus
               />
             </Section>
           )}

--- a/front/src/modules/ui/modal/components/ConfirmationModal.tsx
+++ b/front/src/modules/ui/modal/components/ConfirmationModal.tsx
@@ -80,6 +80,7 @@ export function ConfirmationModal({
               setIsOpen(false);
             }
           }}
+          handleEnter={onConfirmClick}
         >
           <H1Title title={title} fontColor={H1TitleFontColor.Primary} />
           <Section
@@ -96,7 +97,6 @@ export function ConfirmationModal({
                 placeholder={confirmationPlaceholder}
                 fullWidth
                 key={'input-' + confirmationValue}
-                autoFocus
               />
             </Section>
           )}

--- a/front/src/modules/ui/modal/components/ConfirmationModal.tsx
+++ b/front/src/modules/ui/modal/components/ConfirmationModal.tsx
@@ -75,12 +75,12 @@ export function ConfirmationModal({
       <LayoutGroup>
         <StyledConfirmationModal
           isOpen={isOpen}
-          closeModal={() => {
+          onClose={() => {
             if (isOpen) {
               setIsOpen(false);
             }
           }}
-          handleEnter={onConfirmClick}
+          onEnter={onConfirmClick}
         >
           <H1Title title={title} fontColor={H1TitleFontColor.Primary} />
           <Section

--- a/front/src/modules/ui/modal/components/ConfirmationModal.tsx
+++ b/front/src/modules/ui/modal/components/ConfirmationModal.tsx
@@ -2,7 +2,6 @@ import { ReactNode, useState } from 'react';
 import styled from '@emotion/styled';
 import { AnimatePresence, LayoutGroup } from 'framer-motion';
 import debounce from 'lodash.debounce';
-import { Key } from 'ts-key-enum';
 
 import { Button, ButtonVariant } from '@/ui/button/components/Button';
 import { TextInput } from '@/ui/input/text/components/TextInput';
@@ -13,9 +12,6 @@ import {
   SectionFontColor,
 } from '@/ui/section/components/Section';
 import { H1Title, H1TitleFontColor } from '@/ui/typography/components/H1Title';
-import { useScopedHotkeys } from '@/ui/utilities/hotkey/hooks/useScopedHotkeys';
-
-import { ModalHotkeyScope } from './types/ModalHotkeyScope';
 
 export type ConfirmationModalProps = {
   isOpen: boolean;
@@ -74,14 +70,6 @@ export function ConfirmationModal({
     250,
   );
 
-  useScopedHotkeys(
-    [Key.Escape],
-    () => {
-      setIsOpen(false);
-    },
-    ModalHotkeyScope.ConfirmationModal,
-  );
-
   return (
     <AnimatePresence mode="wait">
       <LayoutGroup>
@@ -92,7 +80,6 @@ export function ConfirmationModal({
               setIsOpen(false);
             }
           }}
-          hotkeyScope={ModalHotkeyScope.ConfirmationModal}
         >
           <H1Title title={title} fontColor={H1TitleFontColor.Primary} />
           <Section

--- a/front/src/modules/ui/modal/components/Modal.tsx
+++ b/front/src/modules/ui/modal/components/Modal.tsx
@@ -10,8 +10,6 @@ import {
   useListenClickOutside,
 } from '@/ui/utilities/pointer-event/hooks/useListenClickOutside';
 
-import { ModalHotkeyScope } from './types/ModalHotkeyScope';
-
 const StyledModalDiv = styled(motion.div)`
   display: flex;
   flex-direction: column;
@@ -60,6 +58,10 @@ const StyledBackDrop = styled(motion.div)`
   width: 100%;
   z-index: 9999;
 `;
+
+enum ModalHotkeyScope {
+  Default = 'default',
+}
 
 /**
  * Modal components

--- a/front/src/modules/ui/modal/components/Modal.tsx
+++ b/front/src/modules/ui/modal/components/Modal.tsx
@@ -127,14 +127,6 @@ export function Modal({
     [closeModal],
   );
 
-  useScopedHotkeys(
-    [Key.Enter],
-    () => {
-      return;
-    },
-    hotkeyScope,
-  );
-
   if (isOpen) {
     setHotkeyScopeAndMemorizePreviousScope(hotkeyScope);
   } else {

--- a/front/src/modules/ui/modal/components/Modal.tsx
+++ b/front/src/modules/ui/modal/components/Modal.tsx
@@ -88,9 +88,9 @@ function ModalFooter({ children, ...restProps }: ModalFooterProps) {
 type ModalProps = React.PropsWithChildren &
   React.ComponentProps<'div'> & {
     isOpen?: boolean;
-    closeModal?: () => void;
+    onClose?: () => void;
     hotkeyScope?: ModalHotkeyScope;
-    handleEnter?: () => void;
+    onEnter?: () => void;
   };
 
 const modalVariants = {
@@ -102,16 +102,16 @@ const modalVariants = {
 export function Modal({
   isOpen = false,
   children,
-  closeModal,
+  onClose,
   hotkeyScope = ModalHotkeyScope.Default,
-  handleEnter,
+  onEnter,
   ...restProps
 }: ModalProps) {
   const modalRef = useRef<HTMLDivElement>(null);
 
   useListenClickOutside({
     refs: [modalRef],
-    callback: () => closeModal?.(),
+    callback: () => onClose?.(),
     mode: ClickOutsideMode.absolute,
   });
 
@@ -123,16 +123,16 @@ export function Modal({
   useScopedHotkeys(
     [Key.Escape],
     () => {
-      closeModal?.();
+      onClose?.();
     },
     hotkeyScope,
-    [closeModal],
+    [onClose],
   );
 
   useScopedHotkeys(
     [Key.Enter],
     () => {
-      handleEnter?.();
+      onEnter?.();
     },
     hotkeyScope,
   );

--- a/front/src/modules/ui/modal/components/Modal.tsx
+++ b/front/src/modules/ui/modal/components/Modal.tsx
@@ -10,6 +10,8 @@ import {
   useListenClickOutside,
 } from '@/ui/utilities/pointer-event/hooks/useListenClickOutside';
 
+import { ModalHotkeyScope } from './types/ModalHotkeyScope';
+
 const StyledModalDiv = styled(motion.div)`
   display: flex;
   flex-direction: column;
@@ -58,10 +60,6 @@ const StyledBackDrop = styled(motion.div)`
   width: 100%;
   z-index: 9999;
 `;
-
-enum ModalHotkeyScope {
-  Default = 'default',
-}
 
 /**
  * Modal components

--- a/front/src/modules/ui/modal/components/Modal.tsx
+++ b/front/src/modules/ui/modal/components/Modal.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import styled from '@emotion/styled';
 import { motion } from 'framer-motion';
 import { Key } from 'ts-key-enum';
@@ -90,6 +90,7 @@ type ModalProps = React.PropsWithChildren &
     isOpen?: boolean;
     closeModal?: () => void;
     hotkeyScope?: ModalHotkeyScope;
+    handleEnter?: () => void;
   };
 
 const modalVariants = {
@@ -103,6 +104,7 @@ export function Modal({
   children,
   closeModal,
   hotkeyScope = ModalHotkeyScope.Default,
+  handleEnter,
   ...restProps
 }: ModalProps) {
   const modalRef = useRef<HTMLDivElement>(null);
@@ -127,14 +129,28 @@ export function Modal({
     [closeModal],
   );
 
-  if (isOpen) {
-    setHotkeyScopeAndMemorizePreviousScope(hotkeyScope);
-  } else {
-    goBackToPreviousHotkeyScope();
-    return null;
-  }
+  useScopedHotkeys(
+    [Key.Enter],
+    () => {
+      handleEnter?.();
+    },
+    hotkeyScope,
+  );
 
-  return (
+  useEffect(() => {
+    if (isOpen) {
+      setHotkeyScopeAndMemorizePreviousScope(hotkeyScope);
+    } else {
+      goBackToPreviousHotkeyScope();
+    }
+  }, [
+    goBackToPreviousHotkeyScope,
+    hotkeyScope,
+    isOpen,
+    setHotkeyScopeAndMemorizePreviousScope,
+  ]);
+
+  return isOpen ? (
     <StyledBackDrop>
       <StyledModalDiv
         // framer-motion seems to have typing problems with refs
@@ -151,6 +167,8 @@ export function Modal({
         {children}
       </StyledModalDiv>
     </StyledBackDrop>
+  ) : (
+    <></>
   );
 }
 

--- a/front/src/modules/ui/modal/components/types/ModalHotkeyScope.ts
+++ b/front/src/modules/ui/modal/components/types/ModalHotkeyScope.ts
@@ -1,0 +1,3 @@
+export enum ModalHotkeyScope {
+  Default = 'default',
+}

--- a/front/src/modules/ui/modal/components/types/ModalHotkeyScope.ts
+++ b/front/src/modules/ui/modal/components/types/ModalHotkeyScope.ts
@@ -1,4 +1,0 @@
-export enum ModalHotkeyScope {
-  Default = 'default',
-  ConfirmationModal = 'confirmation-modal',
-}

--- a/front/src/modules/ui/modal/components/types/ModalHotkeyScope.ts
+++ b/front/src/modules/ui/modal/components/types/ModalHotkeyScope.ts
@@ -1,0 +1,4 @@
+export enum ModalHotkeyScope {
+  Default = 'default',
+  ConfirmationModal = 'confirmation-modal',
+}


### PR DESCRIPTION
## Context
Adding hotkeys parameters to modals, for example Esc key will now close the modal

## Test

https://github.com/twentyhq/twenty/assets/1834158/767d3c6b-d2a4-491c-b758-612d8902d924

