### PR TITLE
Remove danger text from completed passed tasks

### DIFF
--- a/front/src/modules/activities/components/TaskRow.tsx
+++ b/front/src/modules/activities/components/TaskRow.tsx
@@ -101,7 +101,11 @@ export function TaskRow({ task }: { task: TaskForList }) {
       </StyledTaskBody>
       <StyledFieldsContainer>
         <ActivityTargetChips targets={task.activityTargets} />
-        <StyledDueDate isPast={!!task.dueAt && hasDatePassed(task.dueAt)}>
+        <StyledDueDate
+          isPast={
+            !!task.dueAt && hasDatePassed(task.dueAt) && !task.completedAt
+          }
+        >
           <IconCalendar size={theme.icon.size.md} />
           {task.dueAt && beautifyExactDate(task.dueAt)}
         </StyledDueDate>


### PR DESCRIPTION
## Context
Danger text is here to signify that a task has not been completed yet whilst it's Due date has been passed. 
If the task has been completed we don't want to make this kind of task more visible.

## Test
<img width="1269" alt="Screenshot 2023-08-25 at 17 29 45" src="https://github.com/twentyhq/twenty/assets/1834158/0da982ec-a005-44e1-9f5f-fec4475ff492">
<img width="1269" alt="Screenshot 2023-08-25 at 17 29 34" src="https://github.com/twentyhq/twenty/assets/1834158/85bef4e2-fb77-4daf-bf19-6cb65f5934ac">
