### PR TITLE
Fix confirmation modal style

### DIFF
--- a/front/src/modules/ui/modal/components/ConfirmationModal.tsx
+++ b/front/src/modules/ui/modal/components/ConfirmationModal.tsx
@@ -25,12 +25,17 @@ export type ConfirmationModalProps = {
 };
 
 const StyledConfirmationModal = styled(Modal)`
-  padding: ${({ theme }) => theme.spacing(4)};
-  width: calc(400px - ${({ theme }) => theme.spacing(10 * 2)});
+  border-radius: ${({ theme }) => theme.spacing(1)};
+  padding: ${({ theme }) => theme.spacing(6)};
+  width: calc(400px - ${({ theme }) => theme.spacing(32)});
 `;
 
 const StyledCenteredButton = styled(Button)`
   justify-content: center;
+`;
+
+const StyledCenteredTitle = styled.div`
+  text-align: center;
 `;
 
 export const StyledConfirmationButton = styled(StyledCenteredButton)`
@@ -82,7 +87,9 @@ export function ConfirmationModal({
           }}
           onEnter={onConfirmClick}
         >
-          <H1Title title={title} fontColor={H1TitleFontColor.Primary} />
+          <StyledCenteredTitle>
+            <H1Title title={title} fontColor={H1TitleFontColor.Primary} />
+          </StyledCenteredTitle>
           <Section
             alignment={SectionAlignment.Center}
             fontColor={SectionFontColor.Primary}


### PR DESCRIPTION
Simply aligning the design with figma, border was wrong and title should be aligned at the center
See https://www.figma.com/file/xt8O9mFeLl46C5InWwoMrN/Twenty?node-id=7825%3A79604&mode=dev

## Test
 
<img width="601" alt="Screenshot 2023-08-25 at 17 58 38" src="https://github.com/twentyhq/twenty/assets/1834158/fa138748-3992-4835-86f1-01f1f4e53f0f">
