### PR TITLE
Fix: Manually delete company cache #1214

### DIFF
--- a/front/src/modules/companies/hooks/useDeleteCompanies.ts
+++ b/front/src/modules/companies/hooks/useDeleteCompanies.ts
@@ -33,7 +33,7 @@ export function useDeleteSelectedComapnies() {
           count: rowIdsToDelete.length,
         },
       },
-      update: (cache ) => {
+      update: (cache) => {
         setTableRowIds(
           tableRowIds.filter((id) => !rowIdsToDelete.includes(id)),
         );

--- a/front/src/modules/companies/hooks/useDeleteCompanies.ts
+++ b/front/src/modules/companies/hooks/useDeleteCompanies.ts
@@ -33,10 +33,20 @@ export function useDeleteSelectedComapnies() {
           count: rowIdsToDelete.length,
         },
       },
-      update: () => {
+      update: (cache ) => {
         setTableRowIds(
           tableRowIds.filter((id) => !rowIdsToDelete.includes(id)),
         );
+
+        // Manually update the cache to match the mutations
+        rowIdsToDelete.forEach((companyId) => {
+          cache.evict({
+            id: cache.identify({
+              __typename: 'Company',
+              id: companyId,
+            }),
+          });
+        });
       },
     });
   }


### PR DESCRIPTION
Added cache.evict to delete the selected companies.

```js
// Manually update the cache to match the mutations
  rowIdsToDelete.forEach((companyId) => {
    cache.evict({
      id: cache.identify({
        __typename: 'Company',
        id: companyId,
      }),
    });
  });
```
