### PR TITLE
Add csv download for tables

### DIFF
--- a/front/src/modules/companies/table/components/CompanyTable.tsx
+++ b/front/src/modules/companies/table/components/CompanyTable.tsx
@@ -6,6 +6,7 @@ import { filtersWhereScopedSelector } from '@/ui/filter-n-sort/states/selectors/
 import { sortsOrderByScopedSelector } from '@/ui/filter-n-sort/states/selectors/sortsOrderByScopedSelector';
 import { EntityTable } from '@/ui/table/components/EntityTable';
 import { GenericEntityTableData } from '@/ui/table/components/GenericEntityTableData';
+import { useExportTableData } from '@/ui/table/hooks/useExportTableData';
 import { useUpsertEntityTableItem } from '@/ui/table/hooks/useUpsertEntityTableItem';
 import { TableRecoilScopeContext } from '@/ui/table/states/recoil-scope-contexts/TableRecoilScopeContext';
 import { useRecoilScopedValue } from '@/ui/utilities/recoil-scope/hooks/useRecoilScopedValue';
@@ -44,6 +45,8 @@ export function CompanyTable() {
   const { setContextMenuEntries } = useCompanyTableContextMenuEntries();
   const { setActionBarEntries } = useCompanyTableActionBarEntries();
 
+  const exportData = useExportTableData();
+
   function handleImport() {
     openCompanySpreadsheetImport();
   }
@@ -65,6 +68,7 @@ export function CompanyTable() {
         onViewsChange={handleViewsChange}
         onViewSubmit={handleViewSubmit}
         onImport={handleImport}
+        onExport={() => exportData('Companies.csv')}
         updateEntityMutation={({
           variables,
         }: {

--- a/front/src/modules/people/table/components/PeopleTable.tsx
+++ b/front/src/modules/people/table/components/PeopleTable.tsx
@@ -6,6 +6,7 @@ import { filtersWhereScopedSelector } from '@/ui/filter-n-sort/states/selectors/
 import { sortsOrderByScopedSelector } from '@/ui/filter-n-sort/states/selectors/sortsOrderByScopedSelector';
 import { EntityTable } from '@/ui/table/components/EntityTable';
 import { GenericEntityTableData } from '@/ui/table/components/GenericEntityTableData';
+import { useExportTableData } from '@/ui/table/hooks/useExportTableData';
 import { useUpsertEntityTableItem } from '@/ui/table/hooks/useUpsertEntityTableItem';
 import { TableRecoilScopeContext } from '@/ui/table/states/recoil-scope-contexts/TableRecoilScopeContext';
 import { useRecoilScopedValue } from '@/ui/utilities/recoil-scope/hooks/useRecoilScopedValue';
@@ -47,6 +48,8 @@ export function PeopleTable() {
     openPersonSpreadsheetImport();
   }
 
+  const exportData = useExportTableData();
+
   return (
     <>
       <GenericEntityTableData
@@ -64,6 +67,7 @@ export function PeopleTable() {
         onViewsChange={handleViewsChange}
         onViewSubmit={handleViewSubmit}
         onImport={handleImport}
+        onExport={() => exportData('People.csv')}
         updateEntityMutation={({
           variables,
         }: {

--- a/front/src/modules/ui/icon/index.ts
+++ b/front/src/modules/ui/icon/index.ts
@@ -31,6 +31,7 @@ export {
   IconCurrencyDollar,
   IconEye,
   IconEyeOff,
+  IconFileDownload,
   IconFileImport,
   IconFileUpload,
   IconForbid,

--- a/front/src/modules/ui/table/components/EntityTable.tsx
+++ b/front/src/modules/ui/table/components/EntityTable.tsx
@@ -91,6 +91,7 @@ type OwnProps<SortField> = {
   onViewsChange?: (views: TableView[]) => void;
   onViewSubmit?: () => void;
   onImport?: () => void;
+  onExport?: () => void;
   updateEntityMutation: any;
 };
 
@@ -100,6 +101,7 @@ export function EntityTable<SortField>({
   onViewsChange,
   onViewSubmit,
   onImport,
+  onExport,
   updateEntityMutation,
 }: OwnProps<SortField>) {
   const tableBodyRef = useRef<HTMLDivElement>(null);
@@ -128,6 +130,7 @@ export function EntityTable<SortField>({
             onViewsChange={onViewsChange}
             onViewSubmit={onViewSubmit}
             onImport={onImport}
+            onExport={onExport}
           />
           <ScrollWrapper>
             <div>

--- a/front/src/modules/ui/table/hooks/useExportTableData.ts
+++ b/front/src/modules/ui/table/hooks/useExportTableData.ts
@@ -1,0 +1,29 @@
+import { useRecoilCallback } from 'recoil';
+
+import { tableEntitiesFamilyState } from '@/ui/table/states/tableEntitiesFamilyState';
+import { tableRowIdsState } from '@/ui/table/states/tableRowIdsState';
+import { downloadBlob } from '~/utils/downloadBlob';
+import { objectArrayToCsv } from '~/utils/objectArrayToCsv';
+
+export function useExportTableData() {
+  return useRecoilCallback(
+    ({ snapshot }) =>
+      (fileName: string) => {
+        const entityIds = snapshot.getLoadable(tableRowIdsState).valueOrThrow();
+        const entities = [];
+        for (const id of entityIds) {
+          entities.push(
+            snapshot.getLoadable(tableEntitiesFamilyState(id)).valueOrThrow(),
+          );
+        }
+        const csv = objectArrayToCsv(entities, (key, value) => {
+          if (typeof value == 'object') {
+            return value?.name;
+          }
+          return value;
+        });
+        downloadBlob(csv, fileName, 'text/csv;charset=utf-8;');
+      },
+    [],
+  );
+}

--- a/front/src/modules/ui/table/options/components/TableOptionsDropdown.tsx
+++ b/front/src/modules/ui/table/options/components/TableOptionsDropdown.tsx
@@ -9,12 +9,14 @@ import { TableOptionsDropdownContent } from './TableOptionsDropdownContent';
 type TableOptionsDropdownProps = {
   onViewsChange?: (views: TableView[]) => void;
   onImport?: () => void;
+  onExport?: () => void;
   customHotkeyScope: HotkeyScope;
 };
 
 export function TableOptionsDropdown({
   onViewsChange,
   onImport,
+  onExport,
   customHotkeyScope,
 }: TableOptionsDropdownProps) {
   return (
@@ -25,6 +27,7 @@ export function TableOptionsDropdown({
       dropdownComponents={
         <TableOptionsDropdownContent
           onImport={onImport}
+          onExport={onExport}
           onViewsChange={onViewsChange}
         />
       }

--- a/front/src/modules/ui/table/options/components/TableOptionsDropdownContent.tsx
+++ b/front/src/modules/ui/table/options/components/TableOptionsDropdownContent.tsx
@@ -27,6 +27,7 @@ import {
   IconPlus,
   IconTag,
 } from '@/ui/icon';
+import { IconFileDownload } from '@/ui/icon';
 import { tableColumnsScopedState } from '@/ui/table/states/tableColumnsScopedState';
 import { useScopedHotkeys } from '@/ui/utilities/hotkey/hooks/useScopedHotkeys';
 import { useContextScopeId } from '@/ui/utilities/recoil-scope/hooks/useContextScopeId';
@@ -51,6 +52,7 @@ import { TableOptionsDropdownSection } from './TableOptionsDropdownSection';
 type TableOptionsDropdownButtonProps = {
   onViewsChange?: (views: TableView[]) => void;
   onImport?: () => void;
+  onExport?: () => void;
 };
 
 enum Option {
@@ -60,6 +62,7 @@ enum Option {
 export function TableOptionsDropdownContent({
   onViewsChange,
   onImport,
+  onExport,
 }: TableOptionsDropdownButtonProps) {
   const theme = useTheme();
 
@@ -259,6 +262,12 @@ export function TableOptionsDropdownContent({
               <DropdownMenuItem onClick={onImport}>
                 <IconFileImport size={theme.icon.size.md} />
                 Import
+              </DropdownMenuItem>
+            )}
+            {onExport && (
+              <DropdownMenuItem onClick={onExport}>
+                <IconFileDownload size={theme.icon.size.md} />
+                Export
               </DropdownMenuItem>
             )}
           </StyledDropdownMenuItemsContainer>

--- a/front/src/modules/ui/table/table-header/components/TableHeader.tsx
+++ b/front/src/modules/ui/table/table-header/components/TableHeader.tsx
@@ -25,6 +25,7 @@ type OwnProps<SortField> = {
   onViewsChange?: (views: TableView[]) => void;
   onViewSubmit?: () => void;
   onImport?: () => void;
+  onExport?: () => void;
 };
 
 export function TableHeader<SortField>({
@@ -33,6 +34,7 @@ export function TableHeader<SortField>({
   onViewsChange,
   onViewSubmit,
   onImport,
+  onExport,
 }: OwnProps<SortField>) {
   const [sorts, setSorts] = useRecoilScopedState<SelectedSortType<SortField>[]>(
     sortsScopedState,
@@ -83,6 +85,7 @@ export function TableHeader<SortField>({
             />
             <TableOptionsDropdown
               onImport={onImport}
+              onExport={onExport}
               onViewsChange={onViewsChange}
               customHotkeyScope={{ scope: TableOptionsHotkeyScope.Dropdown }}
             />

--- a/front/src/utils/downloadBlob.ts
+++ b/front/src/utils/downloadBlob.ts
@@ -1,0 +1,12 @@
+export function downloadBlob(
+  content: string,
+  filename: string,
+  contentType: string,
+) {
+  const blob = new Blob([content], { type: contentType });
+  const url = URL.createObjectURL(blob);
+  const pom = document.createElement('a');
+  pom.href = url;
+  pom.setAttribute('download', filename);
+  pom.click();
+}

--- a/front/src/utils/objectArrayToCsv.ts
+++ b/front/src/utils/objectArrayToCsv.ts
@@ -1,0 +1,24 @@
+export function objectArrayToCsv(
+  arr: any[],
+  mapping?: (key: string, value: any) => string,
+) {
+  const array = [Object.keys(arr[0]).filter((x) => x !== '__typename')].concat(
+    arr,
+  );
+
+  return array
+    .map((row) => {
+      return Object.entries(row)
+        .filter((x) => x[0] !== '__typename')
+        .map(([key, value]) => {
+          value = mapping ? mapping(key, value) : value;
+          if (value == null || value === undefined) {
+            value = '';
+          }
+          value = `"${String(value).replaceAll('"', '""')}"`;
+          return value;
+        })
+        .join(',');
+    })
+    .join('\r\n');
+}


### PR DESCRIPTION
I think it would be awesome to export some filtered list to a csv file.
->  Added a csv download for company/people table

It exports by only using data send to the frontend. Filters and sorts are used, views and column selection not. 


What are your thoughts @charlesBochet?