### PR TITLE
Fix: Wrong type in env variables front support

### DIFF
--- a/server/src/integrations/environment/environment.validation.ts
+++ b/server/src/integrations/environment/environment.validation.ts
@@ -113,7 +113,7 @@ export class EnvironmentVariables {
 
   @ValidateIf((env) => env.SUPPORT_DRIVER === SupportDriver.Front)
   @IsString()
-  SUPPORT_FRONT_CHAT_ID?: AwsRegion;
+  SUPPORT_FRONT_CHAT_ID?: string;
 
   @ValidateIf((env) => env.SUPPORT_DRIVER === SupportDriver.Front)
   @IsString()


### PR DESCRIPTION
Fixing a typing issue in our server environment variable validator.
Front support channel is working as expected

<img width="1512" alt="image" src="https://github.com/twentyhq/twenty/assets/12035771/28844ad0-661b-4678-9f11-7b669dada048">
