### PR TITLE
Fix person deletion not reflected on Opportunities POC

### DIFF
--- a/front/src/modules/companies/hooks/useDeleteCompanies.ts
+++ b/front/src/modules/companies/hooks/useDeleteCompanies.ts
@@ -38,14 +38,11 @@ export function useDeleteSelectedComapnies() {
           tableRowIds.filter((id) => !rowIdsToDelete.includes(id)),
         );
 
-        // Manually update the cache to match the mutations
         rowIdsToDelete.forEach((companyId) => {
           cache.evict({
-            id: cache.identify({
-              __typename: 'Company',
-              id: companyId,
-            }),
+            id: cache.identify({ __typename: 'Company', id: companyId }),
           });
+          cache.gc();
         });
       },
     });

--- a/front/src/modules/people/hooks/usePersonTableActionBarEntries.tsx
+++ b/front/src/modules/people/hooks/usePersonTableActionBarEntries.tsx
@@ -52,9 +52,7 @@ export function usePersonTableActionBarEntries() {
           tableRowIds.filter((id) => !rowIdsToDelete.includes(id)),
         );
         rowIdsToDelete.forEach((id) => {
-          const normalizedId = cache.identify({ id, __typename: 'Person' });
-          console.log(normalizedId);
-          cache.evict({ id: normalizedId });
+          cache.evict({ id: cache.identify({ id, __typename: 'Person' }) });
           cache.gc();
         });
       },

--- a/front/src/modules/people/hooks/usePersonTableActionBarEntries.tsx
+++ b/front/src/modules/people/hooks/usePersonTableActionBarEntries.tsx
@@ -47,10 +47,16 @@ export function usePersonTableActionBarEntries() {
           count: rowIdsToDelete.length,
         },
       },
-      update: () => {
+      update: (cache) => {
         setTableRowIds(
           tableRowIds.filter((id) => !rowIdsToDelete.includes(id)),
         );
+        rowIdsToDelete.forEach((id) => {
+          const normalizedId = cache.identify({ id, __typename: 'Person' });
+          console.log(normalizedId);
+          cache.evict({ id: normalizedId });
+          cache.gc();
+        });
       },
     });
   }

--- a/front/src/pages/settings/SettingsWorkspaceMembers.tsx
+++ b/front/src/pages/settings/SettingsWorkspaceMembers.tsx
@@ -64,15 +64,20 @@ export function SettingsWorkspaceMembers() {
           return;
         }
 
-        const normalizedId = cache.identify({
-          id: responseData.deleteWorkspaceMember.id,
-          __typename: 'WorkspaceMember',
+        cache.evict({
+          id: cache.identify({
+            id: responseData.deleteWorkspaceMember.id,
+            __typename: 'WorkspaceMember',
+          }),
         });
 
-        // Evict object from cache
-        cache.evict({ id: normalizedId });
+        cache.evict({
+          id: cache.identify({
+            id: userId,
+            __typename: 'User',
+          }),
+        });
 
-        // Clean up relation to this object
         cache.gc();
       },
     });


### PR DESCRIPTION
Fixing data optimistic update.

There are different cases:
1. An entity is deleted. This entity should be deleted from apollo cache through cache.evict:

```
update: (cache) => {
  companyIdsToDelete.forEach((companyId) => {
    cache.evict({
      id: cache.identify({ __typename: 'Company', id: companyId }),
    });
    cache.gc();
  });
},
```