### PR TITLE
unselect all cards using esc key or click

### DIFF
--- a/front/src/modules/ui/board/components/EntityBoard.tsx
+++ b/front/src/modules/ui/board/components/EntityBoard.tsx
@@ -15,7 +15,7 @@ import { SelectedSortType } from '@/ui/filter-n-sort/types/interface';
 import { IconList } from '@/ui/icon';
 import { DragSelect } from '@/ui/utilities/drag-select/components/DragSelect';
 import { useScopedHotkeys } from '@/ui/utilities/hotkey/hooks/useScopedHotkeys';
-import { useListenClickOutside } from '@/ui/utilities/pointer-event/hooks/useListenClickOutside';
+import { useListenClickOutsideByClassName } from '@/ui/utilities/pointer-event/hooks/useListenClickOutside';
 import { RecoilScope } from '@/ui/utilities/recoil-scope/components/RecoilScope';
 import { ScrollWrapper } from '@/ui/utilities/scroll/components/ScrollWrapper';
 import {
@@ -74,6 +74,11 @@ export function EntityBoard({
     [updatePipelineProgressStage],
   );
 
+  useListenClickOutsideByClassName({
+    className: 'entity-board-card',
+    callback: unselectAllActiveCards,
+  });
+
   const updateBoardCardIds = useUpdateBoardCardIds();
 
   const onDragEnd: OnDragEndResponder = useCallback(
@@ -115,11 +120,6 @@ export function EntityBoard({
     unselectAllActiveCards,
     PageHotkeyScope.OpportunitiesPage,
   );
-
-  useListenClickOutside({
-    refs: [boardRef],
-    callback: unselectAllActiveCards,
-  });
 
   return (boardColumns?.length ?? 0) > 0 ? (
     <StyledCustomScrollWrapper>

--- a/front/src/modules/ui/board/components/EntityBoard.tsx
+++ b/front/src/modules/ui/board/components/EntityBoard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useRef } from 'react';
 import { getOperationName } from '@apollo/client/utilities';
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
@@ -7,12 +7,14 @@ import { useRecoilState } from 'recoil';
 
 import { CompanyBoardRecoilScopeContext } from '@/companies/states/recoil-scope-contexts/CompanyBoardRecoilScopeContext';
 import { GET_PIPELINE_PROGRESS } from '@/pipeline/graphql/queries/getPipelineProgress';
+import { PageHotkeyScope } from '@/types/PageHotkeyScope';
 import { BoardHeader } from '@/ui/board/components/BoardHeader';
 import { StyledBoard } from '@/ui/board/components/StyledBoard';
 import { BoardColumnIdContext } from '@/ui/board/contexts/BoardColumnIdContext';
 import { SelectedSortType } from '@/ui/filter-n-sort/types/interface';
 import { IconList } from '@/ui/icon';
 import { DragSelect } from '@/ui/utilities/drag-select/components/DragSelect';
+import { useScopedHotkeys } from '@/ui/utilities/hotkey/hooks/useScopedHotkeys';
 import { useListenClickOutside } from '@/ui/utilities/pointer-event/hooks/useListenClickOutside';
 import { RecoilScope } from '@/ui/utilities/recoil-scope/components/RecoilScope';
 import { ScrollWrapper } from '@/ui/utilities/scroll/components/ScrollWrapper';
@@ -108,17 +110,11 @@ export function EntityBoard({
 
   const boardRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    function handleKeyUp(event: KeyboardEvent) {
-      if (event.key === 'Escape') {
-        unselectAllActiveCards();
-      }
-    }
-    window.addEventListener('keyup', handleKeyUp);
-    return () => {
-      window.removeEventListener('keyup', handleKeyUp);
-    };
-  }, [unselectAllActiveCards]);
+  useScopedHotkeys(
+    'escape',
+    unselectAllActiveCards,
+    PageHotkeyScope.OpportunitiesPage,
+  );
 
   useListenClickOutside({
     refs: [boardRef],

--- a/front/src/modules/ui/board/components/EntityBoard.tsx
+++ b/front/src/modules/ui/board/components/EntityBoard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { getOperationName } from '@apollo/client/utilities';
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
@@ -13,6 +13,7 @@ import { BoardColumnIdContext } from '@/ui/board/contexts/BoardColumnIdContext';
 import { SelectedSortType } from '@/ui/filter-n-sort/types/interface';
 import { IconList } from '@/ui/icon';
 import { DragSelect } from '@/ui/utilities/drag-select/components/DragSelect';
+import { useListenClickOutside } from '@/ui/utilities/pointer-event/hooks/useListenClickOutside';
 import { RecoilScope } from '@/ui/utilities/recoil-scope/components/RecoilScope';
 import { ScrollWrapper } from '@/ui/utilities/scroll/components/ScrollWrapper';
 import {
@@ -22,6 +23,7 @@ import {
   useUpdateOnePipelineProgressStageMutation,
 } from '~/generated/graphql';
 
+import { useCurrentCardSelected } from '../hooks/useCurrentCardSelected';
 import { useSetCardSelected } from '../hooks/useSetCardSelected';
 import { useUpdateBoardCardIds } from '../hooks/useUpdateBoardCardIds';
 import { boardColumnsState } from '../states/boardColumnsState';
@@ -51,6 +53,8 @@ export function EntityBoard({
   const theme = useTheme();
   const [updatePipelineProgressStage] =
     useUpdateOnePipelineProgressStageMutation();
+
+  const { unselectAllActiveCards } = useCurrentCardSelected();
 
   const updatePipelineProgressStageInDB = useCallback(
     async (
@@ -103,6 +107,23 @@ export function EntityBoard({
   });
 
   const boardRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleKeyUp(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        unselectAllActiveCards();
+      }
+    }
+    window.addEventListener('keyup', handleKeyUp);
+    return () => {
+      window.removeEventListener('keyup', handleKeyUp);
+    };
+  }, [unselectAllActiveCards]);
+
+  useListenClickOutside({
+    refs: [boardRef],
+    callback: unselectAllActiveCards,
+  });
 
   return (boardColumns?.length ?? 0) > 0 ? (
     <StyledCustomScrollWrapper>

--- a/front/src/modules/ui/board/components/EntityBoardCard.tsx
+++ b/front/src/modules/ui/board/components/EntityBoardCard.tsx
@@ -38,6 +38,7 @@ export function EntityBoardCard({
           ref={draggableProvided?.innerRef}
           {...draggableProvided?.dragHandleProps}
           {...draggableProvided?.draggableProps}
+          className="entity-board-card"
           data-selectable-id={cardId}
           data-select-disable
           onContextMenu={handleContextMenu}

--- a/front/src/modules/ui/board/hooks/useCurrentCardSelected.ts
+++ b/front/src/modules/ui/board/hooks/useCurrentCardSelected.ts
@@ -47,7 +47,8 @@ export function useCurrentCardSelected() {
           set(isCardSelectedFamilyState(cardId), false);
         });
 
-        setActiveCardIds([]);
+        set(activeCardIdsState, []);
+        set(actionBarOpenState, false);
       },
     [],
   );

--- a/front/src/modules/ui/board/hooks/useCurrentCardSelected.ts
+++ b/front/src/modules/ui/board/hooks/useCurrentCardSelected.ts
@@ -22,7 +22,7 @@ export function useCurrentCardSelected() {
         if (!currentCardId) return;
 
         set(isCardSelectedFamilyState(currentCardId), selected);
-        set(actionBarOpenState, true);
+        set(actionBarOpenState, selected);
 
         if (selected) {
           setActiveCardIds((prevActiveCardIds) => [
@@ -46,6 +46,8 @@ export function useCurrentCardSelected() {
         activeCardIds.forEach((cardId: string) => {
           set(isCardSelectedFamilyState(cardId), false);
         });
+
+        setActiveCardIds([]);
       },
     [],
   );

--- a/front/src/modules/ui/board/hooks/useCurrentCardSelected.ts
+++ b/front/src/modules/ui/board/hooks/useCurrentCardSelected.ts
@@ -25,12 +25,17 @@ export function useCurrentCardSelected() {
         set(actionBarOpenState, true);
 
         if (selected) {
-          setActiveCardIds([...activeCardIds, currentCardId]);
+          setActiveCardIds((prevActiveCardIds) => [
+            ...prevActiveCardIds,
+            currentCardId,
+          ]);
         } else {
-          setActiveCardIds(activeCardIds.filter((id) => id !== currentCardId));
+          setActiveCardIds((prevActiveCardIds) =>
+            prevActiveCardIds.filter((id) => id !== currentCardId),
+          );
         }
       },
-    [currentCardId, activeCardIds, setActiveCardIds],
+    [currentCardId],
   );
 
   const unselectAllActiveCards = useRecoilCallback(

--- a/front/src/modules/ui/board/hooks/useCurrentCardSelected.ts
+++ b/front/src/modules/ui/board/hooks/useCurrentCardSelected.ts
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import { useRecoilCallback, useRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilCallback, useRecoilValue, useSetRecoilState } from 'recoil';
 
 import { actionBarOpenState } from '@/ui/action-bar/states/actionBarIsOpenState';
 
@@ -14,7 +14,7 @@ export function useCurrentCardSelected() {
     isCardSelectedFamilyState(currentCardId ?? ''),
   );
 
-  const [_, setActiveCardIds] = useRecoilState(activeCardIdsState);
+  const setActiveCardIds = useSetRecoilState(activeCardIdsState);
 
   const setCurrentCardSelected = useRecoilCallback(
     ({ set }) =>

--- a/front/src/modules/ui/board/hooks/useCurrentCardSelected.ts
+++ b/front/src/modules/ui/board/hooks/useCurrentCardSelected.ts
@@ -1,10 +1,20 @@
 import { useContext } from 'react';
-import { useRecoilCallback, useRecoilValue } from 'recoil';
+import {
+  atom,
+  useRecoilCallback,
+  useRecoilState,
+  useRecoilValue,
+} from 'recoil';
 
 import { actionBarOpenState } from '@/ui/action-bar/states/actionBarIsOpenState';
 
 import { BoardCardIdContext } from '../contexts/BoardCardIdContext';
 import { isCardSelectedFamilyState } from '../states/isCardSelectedFamilyState';
+
+const activeCardIdsState = atom<string[]>({
+  key: 'activeCardIdsState',
+  default: [],
+});
 
 export function useCurrentCardSelected() {
   const currentCardId = useContext(BoardCardIdContext);
@@ -13,6 +23,8 @@ export function useCurrentCardSelected() {
     isCardSelectedFamilyState(currentCardId ?? ''),
   );
 
+  const [activeCardIds, setActiveCardIds] = useRecoilState(activeCardIdsState);
+
   const setCurrentCardSelected = useRecoilCallback(
     ({ set }) =>
       (selected: boolean) => {
@@ -20,12 +32,31 @@ export function useCurrentCardSelected() {
 
         set(isCardSelectedFamilyState(currentCardId), selected);
         set(actionBarOpenState, true);
+
+        if (selected) {
+          setActiveCardIds([...activeCardIds, currentCardId]);
+        } else {
+          setActiveCardIds(activeCardIds.filter((id) => id !== currentCardId));
+        }
       },
-    [currentCardId],
+    [currentCardId, activeCardIds, setActiveCardIds],
+  );
+
+  const unselectAllActiveCards = useRecoilCallback(
+    ({ set, snapshot }) =>
+      () => {
+        const activeCardIds = snapshot.getLoadable(activeCardIdsState).contents;
+
+        activeCardIds.forEach((cardId: string) => {
+          set(isCardSelectedFamilyState(cardId), false);
+        });
+      },
+    [],
   );
 
   return {
     currentCardSelected: isCardSelected,
     setCurrentCardSelected,
+    unselectAllActiveCards,
   };
 }

--- a/front/src/modules/ui/board/hooks/useCurrentCardSelected.ts
+++ b/front/src/modules/ui/board/hooks/useCurrentCardSelected.ts
@@ -14,7 +14,7 @@ export function useCurrentCardSelected() {
     isCardSelectedFamilyState(currentCardId ?? ''),
   );
 
-  const [activeCardIds, setActiveCardIds] = useRecoilState(activeCardIdsState);
+  const [_, setActiveCardIds] = useRecoilState(activeCardIdsState);
 
   const setCurrentCardSelected = useRecoilCallback(
     ({ set }) =>
@@ -35,7 +35,7 @@ export function useCurrentCardSelected() {
           );
         }
       },
-    [currentCardId],
+    [currentCardId, setActiveCardIds],
   );
 
   const unselectAllActiveCards = useRecoilCallback(

--- a/front/src/modules/ui/board/hooks/useCurrentCardSelected.ts
+++ b/front/src/modules/ui/board/hooks/useCurrentCardSelected.ts
@@ -1,20 +1,11 @@
 import { useContext } from 'react';
-import {
-  atom,
-  useRecoilCallback,
-  useRecoilState,
-  useRecoilValue,
-} from 'recoil';
+import { useRecoilCallback, useRecoilState, useRecoilValue } from 'recoil';
 
 import { actionBarOpenState } from '@/ui/action-bar/states/actionBarIsOpenState';
 
 import { BoardCardIdContext } from '../contexts/BoardCardIdContext';
+import { activeCardIdsState } from '../states/activeCardIdsState';
 import { isCardSelectedFamilyState } from '../states/isCardSelectedFamilyState';
-
-const activeCardIdsState = atom<string[]>({
-  key: 'activeCardIdsState',
-  default: [],
-});
 
 export function useCurrentCardSelected() {
   const currentCardId = useContext(BoardCardIdContext);

--- a/front/src/modules/ui/board/hooks/useSetCardSelected.ts
+++ b/front/src/modules/ui/board/hooks/useSetCardSelected.ts
@@ -2,13 +2,28 @@ import { useRecoilCallback, useSetRecoilState } from 'recoil';
 
 import { actionBarOpenState } from '@/ui/action-bar/states/actionBarIsOpenState';
 
+import { activeCardIdsState } from '../states/activeCardIdsState';
 import { isCardSelectedFamilyState } from '../states/isCardSelectedFamilyState';
 
 export function useSetCardSelected() {
   const setActionBarOpenState = useSetRecoilState(actionBarOpenState);
 
-  return useRecoilCallback(({ set }) => (cardId: string, selected: boolean) => {
-    set(isCardSelectedFamilyState(cardId), selected);
-    setActionBarOpenState(true);
-  });
+  return useRecoilCallback(
+    ({ set, snapshot }) =>
+      (cardId: string, selected: boolean) => {
+        const activeCardIds = snapshot.getLoadable(activeCardIdsState).contents;
+
+        set(isCardSelectedFamilyState(cardId), selected);
+        setActionBarOpenState(selected || activeCardIds.length > 0);
+
+        if (selected) {
+          set(activeCardIdsState, [...activeCardIds, cardId]);
+        } else {
+          set(
+            activeCardIdsState,
+            activeCardIds.filter((id: string) => id !== cardId),
+          );
+        }
+      },
+  );
 }

--- a/front/src/modules/ui/board/states/activeCardIdsState.ts
+++ b/front/src/modules/ui/board/states/activeCardIdsState.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const activeCardIdsState = atom<string[]>({
+  key: 'activeCardIdsState',
+  default: [],
+});

--- a/front/src/modules/ui/utilities/pointer-event/hooks/useListenClickOutside.ts
+++ b/front/src/modules/ui/utilities/pointer-event/hooks/useListenClickOutside.ts
@@ -76,3 +76,38 @@ export function useListenClickOutside<T extends Element>({
     };
   }, [refs, callback, mode]);
 }
+
+export const useListenClickOutsideByClassName = ({
+  className,
+  callback,
+}: {
+  className: string;
+  callback: () => void;
+}) => {
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      const clickedElement = event.target as HTMLElement;
+      let isClickedInside = false;
+      let currentElement: HTMLElement | null = clickedElement;
+
+      // Check if the clicked element or any of its parent elements have the specified class
+      while (currentElement) {
+        if (currentElement.classList.contains(className)) {
+          isClickedInside = true;
+          break;
+        }
+        currentElement = currentElement.parentElement;
+      }
+
+      if (!isClickedInside) {
+        callback();
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [callback, className]);
+};


### PR DESCRIPTION
Ticket: https://github.com/twentyhq/twenty/issues/1264

Working Demo: 
https://github.com/twentyhq/twenty/assets/38759997/de34769c-1bf5-40d4-9bc1-cc5c5d6c83e0


Explanation:
A `boardEntityCard` gets selected in two ways, you can click on the card or drag select with your cursor. 

Card clicking selection logic is stored in `useCurrentCardSelected`
Drag select selection logic is stored in `useSetCardSelected`

`unselectAllActiveCards` is a callback that resets `activeCardIds` and `actionBarOpenState` to false.