### PR TITLE
Robust Photo Uploader, handling unsupported file types, upload error, apollo uploader

### DIFF
--- a/front/src/modules/ui/input/image/components/ImageInput.tsx
+++ b/front/src/modules/ui/input/image/components/ImageInput.tsx
@@ -75,6 +75,8 @@ type Props = Omit<React.ComponentProps<'div'>, 'children'> & {
   picture: string | null | undefined;
   onUpload?: (file: File) => void;
   onRemove?: () => void;
+  onAbort?: () => void;
+  error?: Error | null;
   disabled?: boolean;
 };
 
@@ -82,6 +84,8 @@ export function ImageInput({
   picture,
   onUpload,
   onRemove,
+  onAbort,
+  error,
   disabled = false,
   ...restProps
 }: Props) {
@@ -112,6 +116,7 @@ export function ImageInput({
           <StyledHiddenFileInput
             type="file"
             ref={hiddenFileInput}
+            accept="image/jpeg, image/png, image/gif" // to desired specification
             onChange={(event) => {
               if (onUpload) {
                 if (event.target.files) {
@@ -136,10 +141,21 @@ export function ImageInput({
             disabled={!picture || disabled}
             fullWidth
           />
+          {onAbort && (
+            <Button
+              icon={<IconTrash size={theme.icon.size.sm} />}
+              onClick={onAbort}
+              variant="secondary"
+              title="Abort"
+              disabled={!picture || disabled}
+              fullWidth
+            />
+          )}
         </StyledButtonContainer>
         <StyledText>
           We support your best PNGs, JPEGs and GIFs portraits under 10MB
         </StyledText>
+        {error && <StyledText>{error.message}</StyledText>}
       </StyledContent>
     </StyledContainer>
   );


### PR DESCRIPTION
Issue: https://github.com/twentyhq/twenty/issues/978


Currently if you upload an unsupported  file type, our frontend throws a runtime error. 

https://github.com/twentyhq/twenty/assets/38759997/926880f5-57bc-49fa-8f9a-e0ffd304cb28

Notion handles this by disabling unsupported file types in the file editor. And now so does the `ProfilePictureUploader`!

https://github.com/twentyhq/twenty/assets/38759997/c434336f-1851-45d6-8b30-874709a76ed0


I also added error handling.
