### PR TITLE
In Activities (Tasks / Notes) right drawer, while editing the body and displaying the styling bar, the bar should styling not be larger than the right drawer

### DIFF
--- a/front/src/modules/ui/editor/components/BlockEditor.tsx
+++ b/front/src/modules/ui/editor/components/BlockEditor.tsx
@@ -18,6 +18,9 @@ const StyledEditor = styled.div`
     color: ${({ theme }) => theme.font.color.tertiary};
     font-style: normal !important;
   }
+  .tippy-box:has(.mantine-Toolbar-root) {
+    transform: translateX(-13%);
+  }
 `;
 
 export function BlockEditor({ editor }: BlockEditorProps) {


### PR DESCRIPTION
## Video/Screenshot Demo
 ##### Before:

![265006027-40be1141-5271-4969-b1e4-a3b86abc7f51](https://github.com/twentyhq/twenty/assets/140154534/50dee87a-bd93-4560-aa16-2b4dcb7389cf)

 ##### Fix:

![265005988-ee84353d-a77b-43c7-992a-7ebfc8c6660c](https://github.com/twentyhq/twenty/assets/140154534/4f51f50c-7b4f-41d6-b522-be0c48f8090d)



Fixes #1347