### PR TITLE
Removed React Provider Layer in Spreadsheet Import

### DIFF
--- a/front/src/modules/spreadsheet-import/hooks/useSpreadsheetImport.tsx
+++ b/front/src/modules/spreadsheet-import/hooks/useSpreadsheetImport.tsx
@@ -9,11 +9,27 @@ export function useSpreadsheetImport<T extends string>() {
   const openSpreadsheetImport = (
     options: Omit<SpreadsheetOptions<T>, 'isOpen' | 'onClose'>,
   ) => {
-    setSpreadSheetImport({
+    setSpreadSheetImport((prevState) => ({
+      ...prevState,
       isOpen: true,
-      options,
-    });
+      options: {
+        ...options,
+        onClose: () => {
+          setSpreadSheetImport((prevState) => ({
+            ...prevState,
+            isOpen: false,
+          }));
+        },
+      },
+    }));
   };
 
-  return { openSpreadsheetImport };
+  const closeSpreadsheetImport = () => {
+    setSpreadSheetImport((prevState) => ({
+      ...prevState,
+      isOpen: false,
+    }));
+  };
+
+  return { openSpreadsheetImport, closeSpreadsheetImport };
 }

--- a/front/src/modules/spreadsheet-import/provider/components/SpreadsheetImport.tsx
+++ b/front/src/modules/spreadsheet-import/provider/components/SpreadsheetImport.tsx
@@ -1,5 +1,8 @@
+import { useRecoilValue } from 'recoil';
+
 import { ModalWrapper } from '@/spreadsheet-import/components/ModalWrapper';
-import { Providers } from '@/spreadsheet-import/components/Providers';
+import { useSpreadsheetImport } from '@/spreadsheet-import/hooks/useSpreadsheetImport';
+import { spreadsheetImportState } from '@/spreadsheet-import/states/spreadsheetImportState';
 import { Steps } from '@/spreadsheet-import/steps/components/Steps';
 import type { SpreadsheetOptions } from '@/spreadsheet-import/types';
 
@@ -14,15 +17,14 @@ export const defaultSpreadsheetImportProps: Partial<SpreadsheetOptions<any>> = {
   parseRaw: true,
 } as const;
 
-export const SpreadsheetImport = <T extends string>(
-  props: SpreadsheetOptions<T>,
-) => {
+export const SpreadsheetImport = () => {
+  const { isOpen } = useRecoilValue(spreadsheetImportState);
+  const { closeSpreadsheetImport } = useSpreadsheetImport();
+
   return (
-    <Providers values={props}>
-      <ModalWrapper isOpen={props.isOpen} onClose={props.onClose}>
-        <Steps />
-      </ModalWrapper>
-    </Providers>
+    <ModalWrapper isOpen={isOpen} onClose={closeSpreadsheetImport}>
+      <Steps />
+    </ModalWrapper>
   );
 };
 


### PR DESCRIPTION
Ticket: https://github.com/twentyhq/twenty/issues/1401


Removed the provider layer within SpreadsheetImport.tsx
Wrote closeSpreadsheetImport to handle closing functionality in Recoil