### PR TITLE
Fix URL validation on long/internationalized URLs

### DIFF
--- a/front/src/utils/__tests__/is-url.test.ts
+++ b/front/src/utils/__tests__/is-url.test.ts
@@ -44,4 +44,19 @@ describe('isURL', () => {
       ),
     ).toBeTruthy();
   });
+
+  it('should return true if the TLD is long', () => {
+    expect(isURL('https://example.travelinsurance')).toBeTruthy();
+  });
+
+  it('should return true if the TLD is internationalized', () => {
+    // The longest TLD as of now
+    // https://stackoverflow.com/questions/9238640/how-long-can-a-tld-possibly-be
+    // curl -s http://data.iana.org/TLD/tlds-alpha-by-domain.txt \
+    //   | tail -n+2 \
+    //   | awk '{ print length, $0 }' \
+    //   | sort --numeric-sort --reverse \
+    //   | head -n 5
+    expect(isURL('https://example.xn--vermgensberatung-pwb')).toBeTruthy();
+  });
 });

--- a/front/src/utils/is-url.ts
+++ b/front/src/utils/is-url.ts
@@ -4,7 +4,7 @@ export function isURL(url: string | undefined | null) {
   return (
     isDefined(url) &&
     url.match(
-      /^(https?:\/\/)?(www.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-z]{2,4}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)/i,
+      /^(https?:\/\/)?(www.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-z]{2,32}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)/i,
     )
   );
 }

--- a/front/src/utils/is-url.ts
+++ b/front/src/utils/is-url.ts
@@ -4,7 +4,7 @@ export function isURL(url: string | undefined | null) {
   return (
     isDefined(url) &&
     url.match(
-      /^(https?:\/\/)?(www.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-z]{2,32}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)/i,
+      /^(https?:\/\/)?(www.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-z]{2,63}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)/i,
     )
   );
 }


### PR DESCRIPTION
Increases the limit of TLDs to 32. Although the RFC supports TLDs up to 63 octets, I chose 32 because the current longest registered TLD is 24 characters long and just if they end up adding longer ones we have some buffer to account for that.

Also adds tests for both longer TLDs (eg. `.travelinsurance`) and internationalized TLDs (eg. `.xn--vermgensberatung-pwb`).

References:
[RFC 1034: Domain Names](https://www.rfc-editor.org/rfc/rfc1034)
[How long can a TLD possibly be](https://stackoverflow.com/questions/9238640/how-long-can-a-tld-possibly-be)