### PR TITLE
fix: DatePicker cut in DropDownMenu

### DIFF
--- a/front/src/modules/ui/dropdown/components/StyledDropdownMenu.tsx
+++ b/front/src/modules/ui/dropdown/components/StyledDropdownMenu.tsx
@@ -16,7 +16,7 @@ export const StyledDropdownMenu = styled.div<{
 
   flex-direction: column;
 
-  overflow: hidden;
+  min-width: ${({ width }) => (width && width > 160 ? width : 160)}px;
 
-  width: ${({ width }) => (width && width > 160 ? width : 160)}px;
+  overflow: hidden;
 `;

--- a/front/src/modules/ui/dropdown/components/StyledDropdownMenu.tsx
+++ b/front/src/modules/ui/dropdown/components/StyledDropdownMenu.tsx
@@ -16,7 +16,9 @@ export const StyledDropdownMenu = styled.div<{
 
   flex-direction: column;
 
-  min-width: ${({ width }) => (width && width > 160 ? width : 160)}px;
+  min-width: 160px;
 
   overflow: hidden;
+
+  width: ${({ width }) => (width ? `${width}px` : 'auto')};
 `;


### PR DESCRIPTION
<img width="214" alt="Screenshot 2023-09-04 at 4 47 04 PM" src="https://github.com/twentyhq/twenty/assets/3551795/9319cb89-a41f-4786-a37b-46d32d6fc721">
<img width="358" alt="Screenshot 2023-09-04 at 4 46 48 PM" src="https://github.com/twentyhq/twenty/assets/3551795/f773d7a5-2d3f-4da0-9da9-3545b31e92f9">
