### PR TITLE
fix: big view name is not handled

### DIFF
--- a/front/src/modules/ui/table/options/components/TableViewsDropdownButton.tsx
+++ b/front/src/modules/ui/table/options/components/TableViewsDropdownButton.tsx
@@ -27,6 +27,7 @@ import {
   tableViewEditModeState,
   tableViewsState,
 } from '@/ui/table/states/tableViewsState';
+import { MOBILE_VIEWPORT } from '@/ui/theme/constants/theme';
 import { usePreviousHotkeyScope } from '@/ui/utilities/hotkey/hooks/usePreviousHotkeyScope';
 import { useContextScopeId } from '@/ui/utilities/recoil-scope/hooks/useContextScopeId';
 import { useRecoilScopedState } from '@/ui/utilities/recoil-scope/hooks/useRecoilScopedState';
@@ -54,6 +55,21 @@ const StyledDropdownLabelAdornments = styled.span`
 
 const StyledViewIcon = styled(IconList)`
   margin-right: ${({ theme }) => theme.spacing(1)};
+`;
+
+const StyledViewName = styled.span`
+  display: inline-block;
+  max-width: 300px;
+  @media (max-width: 375px) {
+    max-width: 90px;
+  }
+  @media (min-width: 376px) and (max-width: ${MOBILE_VIEWPORT}px) {
+    max-width: 110px;
+  }
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: middle;
+  white-space: nowrap;
 `;
 
 type TableViewsDropdownButtonProps = {
@@ -164,7 +180,9 @@ export const TableViewsDropdownButton = ({
       label={
         <>
           <StyledViewIcon size={theme.icon.size.md} />
-          {currentView?.name || defaultViewName}{' '}
+          <StyledViewName>
+            {currentView?.name || defaultViewName}{' '}
+          </StyledViewName>
           <StyledDropdownLabelAdornments>
             · {views.length} <IconChevronDown size={theme.icon.size.sm} />
           </StyledDropdownLabelAdornments>
@@ -199,7 +217,7 @@ export const TableViewsDropdownButton = ({
             onClick={() => handleViewSelect(view.id)}
           >
             <IconList size={theme.icon.size.md} />
-            {view.name}
+            <StyledViewName>{view.name}</StyledViewName>
           </DropdownMenuItem>
         ))}
       </StyledDropdownMenuItemsContainer>

--- a/front/src/modules/ui/table/options/components/TableViewsDropdownButton.tsx
+++ b/front/src/modules/ui/table/options/components/TableViewsDropdownButton.tsx
@@ -59,7 +59,7 @@ const StyledViewIcon = styled(IconList)`
 
 const StyledViewName = styled.span`
   display: inline-block;
-  max-width: 300px;
+  max-width: 200px;
   @media (max-width: 375px) {
     max-width: 90px;
   }


### PR DESCRIPTION
<img width="437" alt="Screenshot 2023-09-04 at 5 44 15 PM" src="https://github.com/twentyhq/twenty/assets/3551795/9d41e192-85d4-4aa6-ab81-af3af52ad3d9">

Mobile case are also handled