### PR TITLE
fix: Boolean editable field not align properly

### DIFF
--- a/front/src/modules/ui/editable-field/components/GenericEditableBooleanFieldDisplayMode.tsx
+++ b/front/src/modules/ui/editable-field/components/GenericEditableBooleanFieldDisplayMode.tsx
@@ -13,10 +13,11 @@ import { FieldDefinition } from '../types/FieldDefinition';
 import { FieldBooleanMetadata } from '../types/FieldMetadata';
 
 const StyledEditableBooleanFieldContainer = styled.div`
+  align-items: center;
   cursor: pointer;
   display: flex;
 `;
-const StyledBooleanFieldIcon = styled.div``;
+
 const StyledEditableBooleanFieldValue = styled.div`
   margin-left: ${({ theme }) => theme.spacing(1)};
 `;
@@ -54,13 +55,11 @@ export function GenericEditableBooleanFieldDisplayMode() {
 
   return (
     <StyledEditableBooleanFieldContainer onClick={toggleValue}>
-      <StyledBooleanFieldIcon>
-        {fieldValue ? (
-          <IconCheck size={theme.icon.size.sm} />
-        ) : (
-          <IconX size={theme.icon.size.sm} />
-        )}
-      </StyledBooleanFieldIcon>
+      {fieldValue ? (
+        <IconCheck size={theme.icon.size.sm} />
+      ) : (
+        <IconX size={theme.icon.size.sm} />
+      )}
       <StyledEditableBooleanFieldValue>
         {fieldValue ? 'True' : 'False'}
       </StyledEditableBooleanFieldValue>


### PR DESCRIPTION
<img width="250" alt="Screenshot 2023-09-05 at 9 01 53 AM" src="https://github.com/twentyhq/twenty/assets/3551795/dfc02454-b962-4654-9003-64e2fb45ec67">
