### PR TITLE
Do not hard code PORT

### DIFF
--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -33,7 +33,7 @@ async function bootstrap() {
     }),
   );
 
-  await app.listen(3000);
+  await app.listen(process.env.PORT || 3000);
 }
 
 bootstrap();


### PR DESCRIPTION
It is better practice not to hard-code the port on which a server is running but rather read it from the environment. It is a requirement for some PaaS services.
The PR should not change current behavior as it will default to 3000 when the environment variable is missing. 
The PORT environment variable is the quasi-standard for that ...