### PR TITLE
fix: allow null value for number and date

### DIFF
--- a/front/src/modules/ui/editable-field/types/FieldMetadata.ts
+++ b/front/src/modules/ui/editable-field/types/FieldMetadata.ts
@@ -100,7 +100,7 @@ export type FieldMetadata =
 export type FieldTextValue = string;
 
 export type FieldChipValue = string;
-export type FieldDateValue = string;
+export type FieldDateValue = string | null;
 export type FieldPhoneValue = string;
 export type FieldURLValue = string;
 export type FieldNumberValue = number | null;

--- a/front/src/modules/ui/editable-field/types/guards/isFieldDateValue.ts
+++ b/front/src/modules/ui/editable-field/types/guards/isFieldDateValue.ts
@@ -5,8 +5,7 @@ export function isFieldDateValue(
   fieldValue: unknown,
 ): fieldValue is FieldDateValue {
   return (
-    fieldValue !== null &&
-    fieldValue !== undefined &&
-    typeof fieldValue === 'string'
+    fieldValue === null ||
+    (fieldValue !== undefined && typeof fieldValue === 'string')
   );
 }

--- a/front/src/modules/ui/editable-field/types/guards/isFieldNumberValue.ts
+++ b/front/src/modules/ui/editable-field/types/guards/isFieldNumberValue.ts
@@ -5,8 +5,7 @@ export function isFieldNumberValue(
   fieldValue: unknown,
 ): fieldValue is FieldNumberValue {
   return (
-    fieldValue !== null &&
-    fieldValue !== undefined &&
-    typeof fieldValue === 'number'
+    fieldValue === null ||
+    (fieldValue !== undefined && typeof fieldValue === 'number')
   );
 }


### PR DESCRIPTION
This PR date and number fields typing as these fields can accept null as a valid value.
