### PR TITLE
chore: bump Twenty version to 0.1.3 in front/package.json

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "dependencies": {
     "@air/react-drag-to-select": "^5.0.8",


### PR DESCRIPTION
An increment in version number was made in the application's package.json file, from 0.1.2 to 0.1.3. This update was necessary as part of the new release preparation encompassing changes made in the codebase since the last version.