### PR TITLE
Enable port to be overridden

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -10,6 +10,7 @@ REFRESH_TOKEN_SECRET=replace_me_with_a_random_string
 SIGN_IN_PREFILLED=true
 
 # ———————— Optional ————————
+# PORT=3000
 # DEBUG_MODE=true
 # ACCESS_TOKEN_EXPIRES_IN=30m
 # LOGIN_TOKEN_EXPIRES_IN=15m

--- a/server/src/integrations/environment/decorators/__tests__/cast-to-positive-number.decorator.spec.ts
+++ b/server/src/integrations/environment/decorators/__tests__/cast-to-positive-number.decorator.spec.ts
@@ -1,0 +1,51 @@
+import { plainToClass } from 'class-transformer';
+
+import { CastToPositiveNumber } from 'src/integrations/environment/decorators/cast-to-positive-number.decorator';
+
+class TestClass {
+  @CastToPositiveNumber()
+  numberProperty?: any;
+}
+
+describe('CastToPositiveNumber Decorator', () => {
+  it('should cast number to number', () => {
+    const transformedClass = plainToClass(TestClass, { numberProperty: 123 });
+    expect(transformedClass.numberProperty).toBe(123);
+  });
+
+  it('should cast string to number', () => {
+    const transformedClass = plainToClass(TestClass, { numberProperty: '123' });
+    expect(transformedClass.numberProperty).toBe(123);
+  });
+
+  it('should cast null to undefined', () => {
+    const transformedClass = plainToClass(TestClass, { numberProperty: null });
+    expect(transformedClass.numberProperty).toBe(undefined);
+  });
+
+  it('should cast negative number to undefined', () => {
+    const transformedClass = plainToClass(TestClass, { numberProperty: -12 });
+    expect(transformedClass.numberProperty).toBe(undefined);
+  });
+
+  it('should cast undefined to undefined', () => {
+    const transformedClass = plainToClass(TestClass, {
+      numberProperty: undefined,
+    });
+    expect(transformedClass.numberProperty).toBe(undefined);
+  });
+
+  it('should cast NaN string to undefined', () => {
+    const transformedClass = plainToClass(TestClass, {
+      numberProperty: 'toto',
+    });
+    expect(transformedClass.numberProperty).toBe(undefined);
+  });
+
+  it('should cast a negative string to undefined', () => {
+    const transformedClass = plainToClass(TestClass, {
+      numberProperty: '-123',
+    });
+    expect(transformedClass.numberProperty).toBe(undefined);
+  });
+});

--- a/server/src/integrations/environment/decorators/cast-to-positive-number.decorator.ts
+++ b/server/src/integrations/environment/decorators/cast-to-positive-number.decorator.ts
@@ -1,0 +1,15 @@
+import { Transform } from 'class-transformer';
+
+export function CastToPositiveNumber() {
+  return Transform(({ value }: { value: string }) => toNumber(value));
+}
+
+const toNumber = (value: any) => {
+  if (typeof value === 'number') {
+    return value >= 0 ? value : undefined;
+  }
+  if (typeof value === 'string') {
+    return isNaN(+value) ? undefined : toNumber(+value);
+  }
+  return undefined;
+};

--- a/server/src/integrations/environment/environment.service.ts
+++ b/server/src/integrations/environment/environment.service.ts
@@ -28,6 +28,10 @@ export class EnvironmentService {
     );
   }
 
+  getPort(): number {
+    return this.configService.get<number>('PORT') ?? 3000;
+  }
+
   getPGDatabaseUrl(): string {
     return this.configService.get<string>('PG_DATABASE_URL')!;
   }

--- a/server/src/integrations/environment/environment.validation.ts
+++ b/server/src/integrations/environment/environment.validation.ts
@@ -7,6 +7,7 @@ import {
   ValidateIf,
   validateSync,
   IsBoolean,
+  IsNumber,
 } from 'class-validator';
 
 import { assert } from 'src/utils/assert';
@@ -17,6 +18,7 @@ import { AwsRegion } from './interfaces/aws-region.interface';
 import { IsAWSRegion } from './decorators/is-aws-region.decorator';
 import { CastToBoolean } from './decorators/cast-to-boolean.decorator';
 import { SupportDriver } from './interfaces/support.interface';
+import { CastToPositiveNumber } from './decorators/cast-to-positive-number.decorator';
 
 export class EnvironmentVariables {
   // Misc
@@ -39,6 +41,11 @@ export class EnvironmentVariables {
   @IsOptional()
   @IsBoolean()
   TELEMETRY_ANONYMIZATION_ENABLED?: boolean;
+
+  @CastToPositiveNumber()
+  @IsNumber()
+  @IsOptional()
+  PORT: number;
 
   // Database
   @IsUrl({ protocols: ['postgres'], require_tld: false })


### PR DESCRIPTION
Following https://github.com/twentyhq/twenty/pull/1465. This PR enables developers to override backend port using .env file.

```
PORT=3000
```

By default, the application will be using port 3000.

I'm also adding a test on class transformation to validate @CastToPositiveNumber decorator