### PR TITLE
fix: Removed autofocus

### DIFF
--- a/front/src/modules/companies/editable-field/components/CompanyNameEditableField.tsx
+++ b/front/src/modules/companies/editable-field/components/CompanyNameEditableField.tsx
@@ -63,7 +63,6 @@ export function CompanyNameEditableField({ company }: OwnProps) {
     <RecoilScope SpecificContext={FieldRecoilScopeContext}>
       <StyledEditableTitleInput
         autoComplete="off"
-        autoFocus
         onChange={(event) => handleChange(event.target.value)}
         onBlur={handleSubmit}
         value={internalValue}


### PR DESCRIPTION
Hi! I removed autoFocus attribute from 'CompanyNameEditableField.tsx'. 

Closes #1542 

https://github.com/twentyhq/twenty/assets/41576384/cc25f5b8-1126-40c4-b42b-2c203ad249c5

