### PR TITLE
Number display formatting

### DIFF
--- a/front/src/modules/ui/content-display/components/MoneyDisplay.tsx
+++ b/front/src/modules/ui/content-display/components/MoneyDisplay.tsx
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
 
+import { formatNumber } from '~/utils/format/number';
+
 const StyledTextInputDisplay = styled.div`
   overflow: hidden;
   text-overflow: ellipsis;
@@ -14,7 +16,7 @@ type OwnProps = {
 export function MoneyDisplay({ value }: OwnProps) {
   return (
     <StyledTextInputDisplay>
-      {value ? `$${value.toLocaleString()}` : ''}
+      {value ? `$${formatNumber(value)}` : ''}
     </StyledTextInputDisplay>
   );
 }

--- a/front/src/modules/ui/content-display/components/MoneyDisplay.tsx
+++ b/front/src/modules/ui/content-display/components/MoneyDisplay.tsx
@@ -1,7 +1,5 @@
 import styled from '@emotion/styled';
 
-import { formatNumber } from '~/utils/formatNumber';
-
 const StyledTextInputDisplay = styled.div`
   overflow: hidden;
   text-overflow: ellipsis;
@@ -16,7 +14,7 @@ type OwnProps = {
 export function MoneyDisplay({ value }: OwnProps) {
   return (
     <StyledTextInputDisplay>
-      {value ? `$${formatNumber(value)}` : ''}
+      {value ? `$${value.toLocaleString()}` : ''}
     </StyledTextInputDisplay>
   );
 }

--- a/front/src/modules/ui/content-display/components/NumberDisplay.tsx
+++ b/front/src/modules/ui/content-display/components/NumberDisplay.tsx
@@ -1,0 +1,20 @@
+import styled from '@emotion/styled';
+
+const StyledNumberDisplay = styled.div`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 100%;
+`;
+
+type OwnProps = {
+  value: string;
+};
+
+export function NumberDisplay({ value }: OwnProps) {
+  return (
+    <StyledNumberDisplay>
+      {value && Number(value).toLocaleString()}
+    </StyledNumberDisplay>
+  );
+}

--- a/front/src/modules/ui/content-display/components/NumberDisplay.tsx
+++ b/front/src/modules/ui/content-display/components/NumberDisplay.tsx
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
 
+import { formatNumber } from '~/utils/format/number';
+
 const StyledNumberDisplay = styled.div`
   overflow: hidden;
   text-overflow: ellipsis;
@@ -14,7 +16,7 @@ type OwnProps = {
 export function NumberDisplay({ value }: OwnProps) {
   return (
     <StyledNumberDisplay>
-      {value && Number(value).toLocaleString()}
+      {value && formatNumber(Number(value))}
     </StyledNumberDisplay>
   );
 }

--- a/front/src/modules/ui/editable-field/components/GenericEditableNumberField.tsx
+++ b/front/src/modules/ui/editable-field/components/GenericEditableNumberField.tsx
@@ -1,7 +1,7 @@
 import { useContext } from 'react';
 import { useRecoilValue } from 'recoil';
 
-import { TextDisplay } from '@/ui/content-display/components/TextDisplay';
+import { NumberDisplay } from '@/ui/content-display/components/NumberDisplay';
 import { RecoilScope } from '@/ui/utilities/recoil-scope/components/RecoilScope';
 
 import { EditableFieldDefinitionContext } from '../contexts/EditableFieldDefinitionContext';
@@ -34,7 +34,7 @@ export function GenericEditableNumberField() {
       <EditableField
         IconLabel={currentEditableFieldDefinition.Icon}
         editModeContent={<GenericEditableNumberFieldEditMode />}
-        displayModeContent={<TextDisplay text={fieldValue} />}
+        displayModeContent={<NumberDisplay value={fieldValue} />}
         isDisplayModeContentEmpty={!fieldValue}
       />
     </RecoilScope>

--- a/front/src/modules/ui/table/editable-cell/type/components/GenericEditableNumberCell.tsx
+++ b/front/src/modules/ui/table/editable-cell/type/components/GenericEditableNumberCell.tsx
@@ -1,6 +1,6 @@
 import { useRecoilValue } from 'recoil';
 
-import { TextDisplay } from '@/ui/content-display/components/TextDisplay';
+import { NumberDisplay } from '@/ui/content-display/components/NumberDisplay';
 import type { ViewFieldNumberMetadata } from '@/ui/editable-field/types/ViewField';
 import { EditableCell } from '@/ui/table/editable-cell/components/EditableCell';
 import { useCurrentRowEntityId } from '@/ui/table/hooks/useCurrentEntityId';
@@ -36,7 +36,7 @@ export function GenericEditableNumberCell({
           columnDefinition={columnDefinition}
         />
       }
-      nonEditModeContent={<TextDisplay text={fieldValue} />}
+      nonEditModeContent={<NumberDisplay value={fieldValue} />}
     ></EditableCell>
   );
 }

--- a/front/src/utils/format/__tests__/number.test.ts
+++ b/front/src/utils/format/__tests__/number.test.ts
@@ -1,0 +1,17 @@
+import { formatNumber } from '../number';
+
+// This tests the en-US locale by default
+describe('formatNumber', () => {
+  it(`Should format 123 correctly`, () => {
+    expect(formatNumber(123)).toEqual('123');
+  });
+  it(`Should format decimal numbers correctly`, () => {
+    expect(formatNumber(123.92)).toEqual('123.92');
+  });
+  it(`Should format large numbers correctly`, () => {
+    expect(formatNumber(1234567)).toEqual('1,234,567');
+  });
+  it(`Should format large numbers with a decimal point correctly`, () => {
+    expect(formatNumber(7654321.89)).toEqual('7,654,321.89');
+  });
+});

--- a/front/src/utils/format/number.ts
+++ b/front/src/utils/format/number.ts
@@ -1,0 +1,3 @@
+export function formatNumber(value: number): string {
+  return value.toLocaleString();
+}

--- a/front/src/utils/formatNumber.ts
+++ b/front/src/utils/formatNumber.ts
@@ -1,4 +1,0 @@
-export function formatNumber(value: number) {
-  // Formats the value to a string and add commas to it ex: 50,000 | 500,000
-  return value.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
-}


### PR DESCRIPTION
Proposal for using the browsers api for formatting numbers as commented on #1541. This uses the set locale by the user at the moment but also could receive a locale string from a setting later.

If this doesn't match your vision of these displays just discard this pr ...


<img width="873" alt="Bildschirmfoto 2023-09-12 um 22 04 23" src="https://github.com/twentyhq/twenty/assets/48770548/54a149ed-7146-4322-81c2-674719ea2a4d">
