### PR TITLE
fix: Removed autoFocus attribute

### DIFF
--- a/front/src/modules/ui/input/components/DoubleTextInputEdit.tsx
+++ b/front/src/modules/ui/input/components/DoubleTextInputEdit.tsx
@@ -45,7 +45,6 @@ export function DoubleTextInputEdit({
         {(nodeDimensions) => (
           <StyledTextInput
             width={nodeDimensions?.width}
-            autoFocus
             placeholder={firstValuePlaceholder}
             value={firstValue}
             onChange={(event: ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
Hi! I removed the autoFocus attribute from the 'PersonShow'. The attribute was in the 'DoubleTextInput.tsx'.

Closes #1542 

https://github.com/twentyhq/twenty/assets/41576384/e7c12ee7-1ca8-43cb-8d32-51aa1a63c573

