### PR TITLE
Fix CI: remove import for metadata POC

### DIFF
--- a/server/src/core/core.module.ts
+++ b/server/src/core/core.module.ts
@@ -14,7 +14,6 @@ import { AttachmentModule } from './attachment/attachment.module';
 import { ActivityModule } from './activity/activity.module';
 import { ViewModule } from './view/view.module';
 import { FavoriteModule } from './favorite/favorite.module';
-import { TenantModule } from './tenant/tenant.module';
 
 @Module({
   imports: [
@@ -32,7 +31,6 @@ import { TenantModule } from './tenant/tenant.module';
     ActivityModule,
     ViewModule,
     FavoriteModule,
-    TenantModule,
   ],
   exports: [
     AuthModule,


### PR DESCRIPTION
CI is complaining because TenantModule is trying to init Data sources with a metadata schema that does not exist. This 
should fix the CI until we finish our POC.

Before
<img width="701" alt="Screenshot 2023-09-14 at 19 14 01" src="https://github.com/twentyhq/twenty/assets/1834158/c29dd3fd-a6a5-4674-ab5a-0f00e776b821">


After
<img width="679" alt="Screenshot 2023-09-14 at 19 13 54" src="https://github.com/twentyhq/twenty/assets/1834158/4686076c-6afe-42b7-8f7a-872693fd88f1">

