### PR TITLE
fix menu-item floating buttons that should only be displayed on hover

### DIFF
--- a/front/src/modules/ui/menu-item/components/MenuItem.tsx
+++ b/front/src/modules/ui/menu-item/components/MenuItem.tsx
@@ -1,4 +1,5 @@
-import type { MouseEvent } from 'react';
+import { type MouseEvent } from 'react';
+import styled from '@emotion/styled';
 
 import { FloatingIconButtonGroup } from '@/ui/button/components/FloatingIconButtonGroup';
 import { IconComponent } from '@/ui/icon/types/IconComponent';
@@ -22,6 +23,17 @@ export type MenuItemProps = {
   onClick?: () => void;
 };
 
+const StyledHoverableMenuItemBase = styled(StyledMenuItemBase)`
+  & .hoverable-buttons {
+    display: none;
+  }
+  &:hover {
+    & .hoverable-buttons {
+      display: block;
+    }
+  }
+`;
+
 export function MenuItem({
   LeftIcon,
   accent = 'default',
@@ -34,14 +46,18 @@ export function MenuItem({
   const showIconButtons = Array.isArray(iconButtons) && iconButtons.length > 0;
 
   return (
-    <StyledMenuItemBase
+    <StyledHoverableMenuItemBase
       data-testid={testId ?? undefined}
       onClick={onClick}
       className={className}
       accent={accent}
     >
       <MenuItemLeftContent LeftIcon={LeftIcon ?? undefined} text={text} />
-      {showIconButtons && <FloatingIconButtonGroup iconButtons={iconButtons} />}
-    </StyledMenuItemBase>
+      <div className="hoverable-buttons">
+        {showIconButtons && (
+          <FloatingIconButtonGroup iconButtons={iconButtons} />
+        )}
+      </div>
+    </StyledHoverableMenuItemBase>
   );
 }


### PR DESCRIPTION
MenuItems floating icons should only be displayed if the menu item is hovered:

<img width="1512" alt="image" src="https://github.com/twentyhq/twenty/assets/12035771/ec60924b-1ebe-4687-893e-93e1d3ec8a7b">

and hovered:
<img width="1512" alt="image" src="https://github.com/twentyhq/twenty/assets/12035771/cf4e1c7d-4535-453d-a8f2-b8bd4c1f5c40">

We have two options to implement it:
1) Cleaner with React, have a [isHovered, setIsHovered] state that will be set onMouseEnter and onMouseLeave on MenuItem and isHovered is used to conditionnally display buttons.
2) Add a customClass on buttons and use nested css to apply menuItem hover display none/block

I've used 2) so we can have it tested in the Storybook, I think it's important for a UI component to be properly tested and as we won't touch this component often, it's OK not going with the cleaner approach IMO
