### PR TITLE
fix: Removed margin-top on Member page

### DIFF
--- a/front/src/pages/settings/SettingsWorkspaceMembers.tsx
+++ b/front/src/pages/settings/SettingsWorkspaceMembers.tsx
@@ -20,7 +20,6 @@ import {
 const StyledContainer = styled.div`
   display: flex;
   flex-direction: column;
-  margin-top: ${({ theme }) => theme.spacing(8)};
   padding: ${({ theme }) => theme.spacing(8)};
   width: 350px;
 `;


### PR DESCRIPTION
Hi! I removed `margin-top` on the `Member` page. All pages look the same.

https://github.com/twentyhq/twenty/assets/41576384/0a2fd1ad-d830-412c-8122-1562f126afdc

Closes: #1586 