### PR TITLE
Fix teleporting board cards on drag drop

### DIFF
--- a/front/src/modules/ui/board/components/EntityBoard.tsx
+++ b/front/src/modules/ui/board/components/EntityBoard.tsx
@@ -72,6 +72,24 @@ export const EntityBoard = ({
           id: pipelineProgressId,
           pipelineStageId,
         },
+        optimisticResponse: {
+          __typename: 'Mutation',
+          updateOnePipelineProgress: {
+            __typename: 'PipelineProgress',
+            id: pipelineProgressId,
+          },
+        },
+        update: (cache) => {
+          cache.modify({
+            id: cache.identify({
+              id: pipelineProgressId,
+              __typename: 'PipelineProgress',
+            }),
+            fields: {
+              pipelineStageId: () => pipelineStageId,
+            },
+          });
+        },
         refetchQueries: [getOperationName(GET_PIPELINE_PROGRESS) ?? ''],
       });
     },


### PR DESCRIPTION
There's still something about the behavior not completely right but this at leasts prevents the teleporting ... 


https://github.com/twentyhq/twenty/assets/48770548/81f5f59f-373e-46a0-928b-df1e374376b6



closes #1488