### PR TITLE
Refactor NavCollapse button

### DIFF
--- a/front/src/modules/ui/layout/components/PageHeader.tsx
+++ b/front/src/modules/ui/layout/components/PageHeader.tsx
@@ -96,7 +96,7 @@ export const PageHeader = ({
       <StyledLeftContainer>
         {!isNavbarOpened && (
           <StyledTopBarButtonContainer>
-            <NavCollapseButton direction="right" hide={true} />
+            <NavCollapseButton direction="right" />
           </StyledTopBarButtonContainer>
         )}
         {hasBackButton && (

--- a/front/src/modules/ui/navbar/components/MainNavbar.tsx
+++ b/front/src/modules/ui/navbar/components/MainNavbar.tsx
@@ -32,7 +32,7 @@ const MainNavbar = ({ children }: OwnProps) => {
   return (
     <StyledContainer>
       <div onMouseEnter={handleHover} onMouseLeave={handleMouseLeave}>
-        <NavWorkspaceButton hideCollapseButton={isHovered} />
+        <NavWorkspaceButton showCollapseButton={isHovered} />
         <NavItemsContainer>{children}</NavItemsContainer>
       </div>
       <SupportChat />

--- a/front/src/modules/ui/navbar/components/NavCollapseButton.tsx
+++ b/front/src/modules/ui/navbar/components/NavCollapseButton.tsx
@@ -1,4 +1,6 @@
+import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
+import { motion } from 'framer-motion';
 import { useRecoilState } from 'recoil';
 
 import { IconButton } from '@/ui/button/components/IconButton';
@@ -8,11 +10,8 @@ import {
 } from '@/ui/icon';
 import { isNavbarOpenedState } from '@/ui/layout/states/isNavbarOpenedState';
 
-const StyledCollapseButton = styled.div<{
-  hide: boolean;
-}>`
+const StyledCollapseButton = styled(motion.div)`
   align-items: center;
-  animation: ${({ hide }) => (hide ? 'fadeIn 150ms' : 'none')};
   background: inherit;
   border: 0;
   &:hover {
@@ -30,58 +29,45 @@ const StyledCollapseButton = styled.div<{
   padding: 0;
 
   user-select: none;
-  visibility: ${({ hide }) => (hide ? 'visible' : 'hidden')};
   width: 24px;
-
-  @keyframes fadeIn {
-    0% {
-      opacity: 0;
-    }
-    100% {
-      opacity: 1;
-    }
-  }
 `;
 
 type CollapseButtonProps = {
   direction?: 'left' | 'right';
-  hide: boolean;
+  show?: boolean;
 };
 
 const NavCollapseButton = ({
   direction = 'left',
-  hide,
+  show = true,
 }: CollapseButtonProps) => {
   const [isNavbarOpened, setIsNavbarOpened] =
     useRecoilState(isNavbarOpenedState);
 
   const iconSize = 'small';
+  const theme = useTheme();
 
   return (
     <>
-      {direction === 'left' ? (
-        <StyledCollapseButton
-          hide={hide}
-          onClick={() => setIsNavbarOpened(!isNavbarOpened)}
-        >
-          <IconButton
-            Icon={IconLayoutSidebarLeftCollapse}
-            variant="tertiary"
-            size={iconSize}
-          />
-        </StyledCollapseButton>
-      ) : (
-        <StyledCollapseButton
-          hide={hide}
-          onClick={() => setIsNavbarOpened(!isNavbarOpened)}
-        >
-          <IconButton
-            Icon={IconLayoutSidebarRightCollapse}
-            variant="tertiary"
-            size={iconSize}
-          />
-        </StyledCollapseButton>
-      )}
+      <StyledCollapseButton
+        animate={{
+          opacity: show ? 1 : 0,
+        }}
+        transition={{
+          duration: theme.animation.duration.normal,
+        }}
+        onClick={() => setIsNavbarOpened(!isNavbarOpened)}
+      >
+        <IconButton
+          Icon={
+            direction === 'left'
+              ? IconLayoutSidebarLeftCollapse
+              : IconLayoutSidebarRightCollapse
+          }
+          variant="tertiary"
+          size={iconSize}
+        />
+      </StyledCollapseButton>
     </>
   );
 };

--- a/front/src/modules/ui/navbar/components/NavWorkspaceButton.tsx
+++ b/front/src/modules/ui/navbar/components/NavWorkspaceButton.tsx
@@ -46,10 +46,10 @@ const StyledName = styled.div`
 `;
 
 type OwnProps = {
-  hideCollapseButton: boolean;
+  showCollapseButton: boolean;
 };
 
-const NavWorkspaceButton = ({ hideCollapseButton }: OwnProps) => {
+const NavWorkspaceButton = ({ showCollapseButton }: OwnProps) => {
   const currentUser = useRecoilValue(currentUserState);
 
   const currentWorkspace = currentUser?.workspaceMember?.workspace;
@@ -68,7 +68,7 @@ const NavWorkspaceButton = ({ hideCollapseButton }: OwnProps) => {
         ></StyledLogo>
         <StyledName>{currentWorkspace?.displayName ?? 'Twenty'}</StyledName>
       </StyledLogoAndNameContainer>
-      <NavCollapseButton direction="left" hide={hideCollapseButton} />
+      <NavCollapseButton direction="left" show={showCollapseButton} />
     </StyledContainer>
   );
 };


### PR DESCRIPTION
I'm refactoring NavCollapse button so simplify the API:
- use show props instead of hide
- use framer to perform the animation
- remove inefficient conditional component display