### PR TITLE
Boost CI

### DIFF
--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -15,12 +15,18 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: "18"
-      - name: Cache node modules
+      - name: Cache front node modules
         uses: actions/cache@v3
         with:
           path: front/node_modules
-          key: node_modules-${{hashFiles('front/yarn.lock')}}
-          restore-keys: node_modules-
+          key: front-node_modules-${{hashFiles('front/yarn.lock')}}
+          restore-keys: front-node_modules-
+      - name: Cache eslint-plugin-twenty node modules
+        uses: actions/cache@v3
+        with:
+          path: packages/eslint-plugin-twenty/node_modules
+          key: eslint-plugin-twenty-node_modules-${{hashFiles('packages/eslint-plugin-twenty/yarn.lock')}}
+          restore-keys: eslint-plugin-twenty-node_modules-
       - name: Front / Install Dependencies
         run: cd front && yarn
   front-lint:
@@ -34,12 +40,18 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: "18"
-      - name: Cache node modules
+      - name: Cache front node modules
         uses: actions/cache@v3
         with:
           path: front/node_modules
-          key: node_modules-${{hashFiles('front/yarn.lock')}}
-          restore-keys: node_modules-
+          key: front-node_modules-${{hashFiles('front/yarn.lock')}}
+          restore-keys: front-node_modules-
+      - name: Cache eslint-plugin-twenty node modules
+        uses: actions/cache@v3
+        with:
+          path: packages/eslint-plugin-twenty/node_modules
+          key: eslint-plugin-twenty-node_modules-${{hashFiles('packages/eslint-plugin-twenty/yarn.lock')}}
+          restore-keys: eslint-plugin-twenty-node_modules-
       - name: Front / Install Dependencies
         run: cd front && yarn
       - name: Front / Run linter
@@ -59,12 +71,18 @@ jobs:
         run: |
           cd front
           cp .env.example .env
-      - name: Cache node modules
+      - name: Cache front node modules
         uses: actions/cache@v3
         with:
           path: front/node_modules
-          key: node_modules-${{hashFiles('front/yarn.lock')}}
-          restore-keys: node_modules-
+          key: front-node_modules-${{hashFiles('front/yarn.lock')}}
+          restore-keys: front-node_modules-
+      - name: Cache eslint-plugin-twenty node modules
+        uses: actions/cache@v3
+        with:
+          path: packages/eslint-plugin-twenty/node_modules
+          key: eslint-plugin-twenty-node_modules-${{hashFiles('packages/eslint-plugin-twenty/yarn.lock')}}
+          restore-keys: eslint-plugin-twenty-node_modules-
       - name: Front / Install Dependencies
         run: cd front && yarn
       - name: Front / Build Storybook
@@ -92,12 +110,18 @@ jobs:
         run: |
           cd front
           cp .env.example .env
-      - name: Cache node modules
+      - name: Cache front node modules
         uses: actions/cache@v3
         with:
           path: front/node_modules
-          key: node_modules-${{hashFiles('front/yarn.lock')}}
-          restore-keys: node_modules-
+          key: front-node_modules-${{hashFiles('front/yarn.lock')}}
+          restore-keys: front-node_modules-
+      - name: Cache eslint-plugin-twenty node modules
+        uses: actions/cache@v3
+        with:
+          path: packages/eslint-plugin-twenty/node_modules
+          key: eslint-plugin-twenty-node_modules-${{hashFiles('packages/eslint-plugin-twenty/yarn.lock')}}
+          restore-keys: eslint-plugin-twenty-node_modules-
       - name: Install dependencies
         run: yarn
       - name: Front / Install Dependencies

--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -28,7 +28,7 @@ jobs:
           key: eslint-plugin-twenty-node_modules-${{hashFiles('packages/eslint-plugin-twenty/yarn.lock')}}
           restore-keys: eslint-plugin-twenty-node_modules-
       - name: Front / Install Dependencies
-        run: cd front && yarn install-ci
+        run: cd front && yarn
   front-lint:
     needs: front-yarn-install
     runs-on: ubuntu-latest
@@ -53,7 +53,7 @@ jobs:
           key: eslint-plugin-twenty-node_modules-${{hashFiles('packages/eslint-plugin-twenty/yarn.lock')}}
           restore-keys: eslint-plugin-twenty-node_modules-
       - name: Front / Install Dependencies
-        run: cd front && yarn install-ci
+        run: cd front && yarn
       - name: Front / Run linter
         run: cd front && yarn lint
   front-modules-test:
@@ -84,7 +84,7 @@ jobs:
           key: eslint-plugin-twenty-node_modules-${{hashFiles('packages/eslint-plugin-twenty/yarn.lock')}}
           restore-keys: eslint-plugin-twenty-node_modules-
       - name: Front / Install Dependencies
-        run: cd front && yarn install-ci
+        run: cd front && yarn
       - name: Front / Build Storybook
         run: cd front && yarn storybook:modules:build --quiet
       - name: Front / Run storybook tests
@@ -125,7 +125,7 @@ jobs:
       - name: Install dependencies
         run: yarn
       - name: Front / Install Dependencies
-        run: cd front && yarn install-ci
+        run: cd front && yarn
       - name: Front / Build Storybook
         run: cd front && yarn storybook:pages:build --quiet
       - name: Front / Run storybook tests

--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -59,8 +59,8 @@ jobs:
           path: front/node_modules
           key: node_modules-${{hashFiles('yarn.lock')}}
           restore-keys: node_modules-
-    - name: Install dependencies
-      run: yarn
+      - name: Install dependencies
+        run: yarn
       - name: Front / Install Dependencies
         run: cd front && yarn
       - name: Front / Run linter

--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -81,7 +81,7 @@ jobs:
           restore-keys: eslint-plugin-twenty-node_modules-
       - name: Front / Install Dependencies
         run: cd front && yarn
-      - name: Front / Run linter
+      - name: Front / Run jest
         run: cd front && yarn test
   front-modules-test:
     needs: front-yarn-install

--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -29,6 +29,84 @@ jobs:
           restore-keys: eslint-plugin-twenty-node_modules-
       - name: Front / Install Dependencies
         run: cd front && yarn
+  front-pages-sb-test:
+    needs: front-yarn-install
+    runs-on: ci-8-cores
+    env:
+      REACT_APP_SERVER_BASE_URL: http://localhost:3000
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+      - name: Front / Write .env
+        run: |
+          cd front
+          cp .env.example .env
+      - name: Cache front node modules
+        uses: actions/cache@v3
+        with:
+          path: front/node_modules
+          key: front-node_modules-${{hashFiles('front/yarn.lock')}}
+          restore-keys: front-node_modules-
+      - name: Cache eslint-plugin-twenty node modules
+        uses: actions/cache@v3
+        with:
+          path: packages/eslint-plugin-twenty/node_modules
+          key: eslint-plugin-twenty-node_modules-${{hashFiles('packages/eslint-plugin-twenty/yarn.lock')}}
+          restore-keys: eslint-plugin-twenty-node_modules-
+      - name: Install dependencies
+        run: yarn
+      - name: Install Dependencies
+        run: cd front && yarn
+      - name: Install Playwright
+        run: cd front && npx playwright install
+      - name: Build Storybook
+        run: cd front && yarn storybook:pages:build --quiet
+      - name: Run storybook tests
+        run: |
+          cd front && npx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
+            "npx http-server storybook-static --silent --port 6006" \
+            "yarn storybook:pages:coverage"
+  front-modules-sb-test:
+    needs: front-yarn-install
+    runs-on: ci-8-cores
+    env:
+      REACT_APP_SERVER_BASE_URL: http://localhost:3000
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+      - name: Front / Write .env
+        run: |
+          cd front
+          cp .env.example .env
+      - name: Cache front node modules
+        uses: actions/cache@v3
+        with:
+          path: front/node_modules
+          key: front-node_modules-${{hashFiles('front/yarn.lock')}}
+          restore-keys: front-node_modules-
+      - name: Cache eslint-plugin-twenty node modules
+        uses: actions/cache@v3
+        with:
+          path: packages/eslint-plugin-twenty/node_modules
+          key: eslint-plugin-twenty-node_modules-${{hashFiles('packages/eslint-plugin-twenty/yarn.lock')}}
+          restore-keys: eslint-plugin-twenty-node_modules-
+      - name: Install Dependencies
+        run: cd front && yarn
+      - name: Install Playwright
+        run: cd front && npx playwright install
+      - name: Build Storybook
+        run: cd front && yarn storybook:modules:build --quiet
+      - name: Run storybook tests
+        run: |
+          cd front && npx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
+            "npx http-server storybook-static --silent --port 6006" \
+            "yarn storybook:modules:coverage"
   front-lint:
     needs: front-yarn-install
     runs-on: ubuntu-latest
@@ -83,81 +161,3 @@ jobs:
         run: cd front && yarn
       - name: Front / Run jest
         run: cd front && yarn test
-  front-modules-test:
-    needs: front-yarn-install
-    runs-on: ci-8-cores
-    env:
-      REACT_APP_SERVER_BASE_URL: http://localhost:3000
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: "18"
-      - name: Front / Write .env
-        run: |
-          cd front
-          cp .env.example .env
-      - name: Cache front node modules
-        uses: actions/cache@v3
-        with:
-          path: front/node_modules
-          key: front-node_modules-${{hashFiles('front/yarn.lock')}}
-          restore-keys: front-node_modules-
-      - name: Cache eslint-plugin-twenty node modules
-        uses: actions/cache@v3
-        with:
-          path: packages/eslint-plugin-twenty/node_modules
-          key: eslint-plugin-twenty-node_modules-${{hashFiles('packages/eslint-plugin-twenty/yarn.lock')}}
-          restore-keys: eslint-plugin-twenty-node_modules-
-      - name: Install Dependencies
-        run: cd front && yarn
-      - name: Install Playwright
-        run: cd front && npx playwright install
-      - name: Build Storybook
-        run: cd front && yarn storybook:modules:build --quiet
-      - name: Run storybook tests
-        run: |
-          cd front && npx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
-            "npx http-server storybook-static --silent --port 6006" \
-            "yarn storybook:modules:coverage"
-  front-pages-test:
-    needs: front-yarn-install
-    runs-on: ci-8-cores
-    env:
-      REACT_APP_SERVER_BASE_URL: http://localhost:3000
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: "18"
-      - name: Front / Write .env
-        run: |
-          cd front
-          cp .env.example .env
-      - name: Cache front node modules
-        uses: actions/cache@v3
-        with:
-          path: front/node_modules
-          key: front-node_modules-${{hashFiles('front/yarn.lock')}}
-          restore-keys: front-node_modules-
-      - name: Cache eslint-plugin-twenty node modules
-        uses: actions/cache@v3
-        with:
-          path: packages/eslint-plugin-twenty/node_modules
-          key: eslint-plugin-twenty-node_modules-${{hashFiles('packages/eslint-plugin-twenty/yarn.lock')}}
-          restore-keys: eslint-plugin-twenty-node_modules-
-      - name: Install dependencies
-        run: yarn
-      - name: Install Dependencies
-        run: cd front && yarn
-      - name: Install Playwright
-        run: cd front && npx playwright install
-      - name: Build Storybook
-        run: cd front && yarn storybook:pages:build --quiet
-      - name: Run storybook tests
-        run: |
-          cd front && npx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
-            "npx http-server storybook-static --silent --port 6006" \
-            "yarn storybook:pages:coverage"

--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -19,6 +19,12 @@ jobs:
         run: |
           cd front
           cp .env.example .env
+      - name: Cache node modules
+        uses: actions/cache@v3
+        with:
+          path: front/node_modules
+          key: node_modules-${{hashFiles('yarn.lock')}}
+          restore-keys: node_modules-
       - name: Front / Install Dependencies
         run: cd front && yarn
       - name: Front / Run linter
@@ -47,6 +53,14 @@ jobs:
         run: |
           cd front
           cp .env.example .env
+      - name: Cache node modules
+        uses: actions/cache@v3
+        with:
+          path: front/node_modules
+          key: node_modules-${{hashFiles('yarn.lock')}}
+          restore-keys: node_modules-
+    - name: Install dependencies
+      run: yarn
       - name: Front / Install Dependencies
         run: cd front && yarn
       - name: Front / Run linter

--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -21,8 +21,6 @@ jobs:
           cp .env.example .env
       - name: Front / Install Dependencies
         run: cd front && yarn
-      - name: Front / Install Playwright
-        run: cd front && npx playwright install --with-deps
       - name: Front / Run linter
         run: cd front && yarn lint
       - name: Front / Build Storybook

--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -28,7 +28,7 @@ jobs:
           key: eslint-plugin-twenty-node_modules-${{hashFiles('packages/eslint-plugin-twenty/yarn.lock')}}
           restore-keys: eslint-plugin-twenty-node_modules-
       - name: Front / Install Dependencies
-        run: cd front && yarn
+        run: cd front && yarn install-ci
   front-lint:
     needs: front-yarn-install
     runs-on: ubuntu-latest
@@ -53,7 +53,7 @@ jobs:
           key: eslint-plugin-twenty-node_modules-${{hashFiles('packages/eslint-plugin-twenty/yarn.lock')}}
           restore-keys: eslint-plugin-twenty-node_modules-
       - name: Front / Install Dependencies
-        run: cd front && yarn
+        run: cd front && yarn install-ci
       - name: Front / Run linter
         run: cd front && yarn lint
   front-modules-test:
@@ -84,7 +84,7 @@ jobs:
           key: eslint-plugin-twenty-node_modules-${{hashFiles('packages/eslint-plugin-twenty/yarn.lock')}}
           restore-keys: eslint-plugin-twenty-node_modules-
       - name: Front / Install Dependencies
-        run: cd front && yarn
+        run: cd front && yarn install-ci
       - name: Front / Build Storybook
         run: cd front && yarn storybook:modules:build --quiet
       - name: Front / Run storybook tests
@@ -125,7 +125,7 @@ jobs:
       - name: Install dependencies
         run: yarn
       - name: Front / Install Dependencies
-        run: cd front && yarn
+        run: cd front && yarn install-ci
       - name: Front / Build Storybook
         run: cd front && yarn storybook:pages:build --quiet
       - name: Front / Run storybook tests

--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -56,6 +56,33 @@ jobs:
         run: cd front && yarn
       - name: Front / Run linter
         run: cd front && yarn lint
+  front-jest:
+    needs: front-yarn-install
+    runs-on: ubuntu-latest
+    env:
+      REACT_APP_SERVER_BASE_URL: http://localhost:3000
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+      - name: Cache front node modules
+        uses: actions/cache@v3
+        with:
+          path: front/node_modules
+          key: front-node_modules-${{hashFiles('front/yarn.lock')}}
+          restore-keys: front-node_modules-
+      - name: Cache eslint-plugin-twenty node modules
+        uses: actions/cache@v3
+        with:
+          path: packages/eslint-plugin-twenty/node_modules
+          key: eslint-plugin-twenty-node_modules-${{hashFiles('packages/eslint-plugin-twenty/yarn.lock')}}
+          restore-keys: eslint-plugin-twenty-node_modules-
+      - name: Front / Install Dependencies
+        run: cd front && yarn
+      - name: Front / Run linter
+        run: cd front && yarn test
   front-modules-test:
     needs: front-yarn-install
     runs-on: ci-8-cores
@@ -94,9 +121,6 @@ jobs:
           cd front && npx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
             "npx http-server storybook-static --silent --port 6006" \
             "yarn storybook:modules:coverage"
-      - name: Front / Run jest tests
-        run: |
-          cd front && yarn test
   front-pages-test:
     needs: front-yarn-install
     runs-on: ci-8-cores
@@ -137,6 +161,3 @@ jobs:
           cd front && npx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
             "npx http-server storybook-static --silent --port 6006" \
             "yarn storybook:pages:coverage"
-      - name: Run jest tests
-        run: |
-          cd front && yarn test

--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -5,7 +5,47 @@ on:
       - main
   pull_request:
 jobs:
+  front-yarn-install:
+    runs-on: ci-8-cores
+    env:
+      REACT_APP_SERVER_BASE_URL: http://localhost:3000
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+      - name: Cache node modules
+        uses: actions/cache@v3
+        with:
+          path: front/node_modules
+          key: node_modules-${{hashFiles('front/yarn.lock')}}
+          restore-keys: node_modules-
+      - name: Front / Install Dependencies
+        run: cd front && yarn
+  front-lint:
+    needs: front-yarn-install
+    runs-on: ubuntu-latest
+    env:
+      REACT_APP_SERVER_BASE_URL: http://localhost:3000
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+      - name: Cache node modules
+        uses: actions/cache@v3
+        with:
+          path: front/node_modules
+          key: node_modules-${{hashFiles('front/yarn.lock')}}
+          restore-keys: node_modules-
+      - name: Front / Install Dependencies
+        run: cd front && yarn
+      - name: Front / Run linter
+        run: cd front && yarn lint
   front-modules-test:
+    needs: front-yarn-install
     runs-on: ci-8-cores
     env:
       REACT_APP_SERVER_BASE_URL: http://localhost:3000
@@ -27,8 +67,6 @@ jobs:
           restore-keys: node_modules-
       - name: Front / Install Dependencies
         run: cd front && yarn
-      - name: Front / Run linter
-        run: cd front && yarn lint
       - name: Front / Build Storybook
         run: cd front && yarn storybook:modules:build --quiet
       - name: Front / Run storybook tests
@@ -40,6 +78,7 @@ jobs:
         run: |
           cd front && yarn test
   front-pages-test:
+    needs: front-yarn-install
     runs-on: ci-8-cores
     env:
       REACT_APP_SERVER_BASE_URL: http://localhost:3000
@@ -63,8 +102,6 @@ jobs:
         run: yarn
       - name: Front / Install Dependencies
         run: cd front && yarn
-      - name: Front / Run linter
-        run: cd front && yarn lint
       - name: Front / Build Storybook
         run: cd front && yarn storybook:pages:build --quiet
       - name: Front / Run storybook tests

--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -83,11 +83,13 @@ jobs:
           path: packages/eslint-plugin-twenty/node_modules
           key: eslint-plugin-twenty-node_modules-${{hashFiles('packages/eslint-plugin-twenty/yarn.lock')}}
           restore-keys: eslint-plugin-twenty-node_modules-
-      - name: Front / Install Dependencies
+      - name: Install Dependencies
         run: cd front && yarn
-      - name: Front / Build Storybook
+      - name: Install Playwright
+        run: cd front && npx playwright install
+      - name: Build Storybook
         run: cd front && yarn storybook:modules:build --quiet
-      - name: Front / Run storybook tests
+      - name: Run storybook tests
         run: |
           cd front && npx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
             "npx http-server storybook-static --silent --port 6006" \
@@ -124,15 +126,17 @@ jobs:
           restore-keys: eslint-plugin-twenty-node_modules-
       - name: Install dependencies
         run: yarn
-      - name: Front / Install Dependencies
+      - name: Install Dependencies
         run: cd front && yarn
-      - name: Front / Build Storybook
+      - name: Install Playwright
+        run: cd front && npx playwright install
+      - name: Build Storybook
         run: cd front && yarn storybook:pages:build --quiet
-      - name: Front / Run storybook tests
+      - name: Run storybook tests
         run: |
           cd front && npx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
             "npx http-server storybook-static --silent --port 6006" \
             "yarn storybook:pages:coverage"
-      - name: Front / Run jest tests
+      - name: Run jest tests
         run: |
           cd front && yarn test

--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: front/node_modules
-          key: node_modules-${{hashFiles('yarn.lock')}}
+          key: node_modules-${{hashFiles('front/yarn.lock')}}
           restore-keys: node_modules-
       - name: Front / Install Dependencies
         run: cd front && yarn
@@ -57,7 +57,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: front/node_modules
-          key: node_modules-${{hashFiles('yarn.lock')}}
+          key: node_modules-${{hashFiles('front/yarn.lock')}}
           restore-keys: node_modules-
       - name: Install dependencies
         run: yarn

--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -5,7 +5,7 @@ on:
       - main
   pull_request:
 jobs:
-  front-test:
+  front-modules-test:
     runs-on: ci-8-cores
     env:
       REACT_APP_SERVER_BASE_URL: http://localhost:3000
@@ -24,12 +24,40 @@ jobs:
       - name: Front / Run linter
         run: cd front && yarn lint
       - name: Front / Build Storybook
-        run: cd front && yarn storybook:build --quiet
+        run: cd front && yarn storybook:modules:build --quiet
       - name: Front / Run storybook tests
         run: |
           cd front && npx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
             "npx http-server storybook-static --silent --port 6006" \
-            "yarn storybook:coverage"
+            "yarn storybook:modules:coverage"
+      - name: Front / Run jest tests
+        run: |
+          cd front && yarn test
+  front-pages-test:
+    runs-on: ci-8-cores
+    env:
+      REACT_APP_SERVER_BASE_URL: http://localhost:3000
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+      - name: Front / Write .env
+        run: |
+          cd front
+          cp .env.example .env
+      - name: Front / Install Dependencies
+        run: cd front && yarn
+      - name: Front / Run linter
+        run: cd front && yarn lint
+      - name: Front / Build Storybook
+        run: cd front && yarn storybook:pages:build --quiet
+      - name: Front / Run storybook tests
+        run: |
+          cd front && npx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
+            "npx http-server storybook-static --silent --port 6006" \
+            "yarn storybook:pages:coverage"
       - name: Front / Run jest tests
         run: |
           cd front && yarn test

--- a/front/.storybook/main.js
+++ b/front/.storybook/main.js
@@ -1,5 +1,18 @@
 const path = require('path');
 
+computeStoriesGlob = () => {
+  if (process.env.STORYBOOK_STORIES_FOLDER === 'pages') {
+    return ['../src/pages/**/*.stories.@(js|jsx|ts|tsx)', '../src/__stories__/*.stories.@(js|jsx|ts|tsx)']
+  }
+
+  if (process.env.STORYBOOK_STORIES_FOLDER === 'modules') {
+    return ['../src/modules/**/*.stories.@(js|jsx|ts|tsx)']
+  }
+
+  return ['../src/**/*.stories.@(js|jsx|ts|tsx)']
+
+};
+
 module.exports = {
   webpackFinal: (config) => {
     config.module.rules.push({
@@ -55,7 +68,7 @@ module.exports = {
     };
     return config;
   },
-  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
+  stories: computeStoriesGlob(),
   addons: [
     '@storybook/addon-links',
     '@storybook/addon-essentials',

--- a/front/.storybook/test-runner-jest.js
+++ b/front/.storybook/test-runner-jest.js
@@ -1,0 +1,13 @@
+const { getJestConfig } = require('@storybook/test-runner');
+
+/**
+ * @type {import('@jest/types').Config.InitialOptions}
+ */
+module.exports = {
+  // The default configuration comes from @storybook/test-runner
+  ...getJestConfig(),
+  /** Add your own overrides below
+   * @see https://jestjs.io/docs/configuration
+   */
+  testTimeout: process.env.STORYBOOK_STORIES_FOLDER === 'pages' ? 30000 : 15000,
+};

--- a/front/nyc.config.js
+++ b/front/nyc.config.js
@@ -1,0 +1,20 @@
+const modulesCoverage = {
+  "statements": 50,
+  "lines": 50,
+  "functions": 50,
+  "include": [
+    "src/modules/**/*",
+  ]
+};
+
+const pagesCoverage = {
+  "statements": 55,
+  "lines": 55,
+  "functions": 55,
+  "exclude": [
+    "src/generated/**/*",
+    "src/modules/**/*",
+  ]
+};
+
+module.exports = process.env.STORYBOOK_STORIES_FOLDER === 'modules' ? modulesCoverage : pagesCoverage;

--- a/front/nyc.config.js
+++ b/front/nyc.config.js
@@ -1,7 +1,7 @@
 const modulesCoverage = {
   "statements": 50,
   "lines": 50,
-  "functions": 50,
+  "functions": 45,
   "include": [
     "src/modules/**/*",
   ]

--- a/front/package.json
+++ b/front/package.json
@@ -75,6 +75,12 @@
     "storybook:test-slow": "test-storybook --maxWorkers=3",
     "storybook:build": "storybook build -s public",
     "storybook:coverage": "test-storybook --coverage --maxWorkers=3 && npx nyc report --reporter=lcov -t coverage/storybook --report-dir coverage/storybook --check-coverage",
+    "storybook:modules:dev": "STORYBOOK_STORIES_FOLDER=modules yarn storybook:dev",
+    "storybook:pages:dev": "STORYBOOK_STORIES_FOLDER=pages yarn storybook:dev",
+    "storybook:modules:build": "STORYBOOK_STORIES_FOLDER=modules yarn storybook:build",
+    "storybook:pages:build": "STORYBOOK_STORIES_FOLDER=pages yarn storybook:build",
+    "storybook:modules:coverage": "STORYBOOK_STORIES_FOLDER=modules yarn storybook:coverage",
+    "storybook:pages:coverage": "STORYBOOK_STORIES_FOLDER=pages yarn storybook:coverage",
     "graphql:generate": "dotenv cross-var graphql-codegen --config codegen.js",
     "chromatic": "dotenv cross-var npx chromatic --project-token=$CHROMATIC_PROJECT_TOKEN",
     "install": "yarn lint:setup"
@@ -185,13 +191,5 @@
   },
   "msw": {
     "workerDirectory": "public"
-  },
-  "nyc": {
-    "statements": 60,
-    "lines": 60,
-    "functions": 60,
-    "exclude": [
-      "src/generated/**/*"
-    ]
   }
 }

--- a/front/package.json
+++ b/front/package.json
@@ -83,7 +83,8 @@
     "storybook:pages:coverage": "STORYBOOK_STORIES_FOLDER=pages yarn storybook:coverage",
     "graphql:generate": "dotenv cross-var graphql-codegen --config codegen.js",
     "chromatic": "dotenv cross-var npx chromatic --project-token=$CHROMATIC_PROJECT_TOKEN",
-    "install": "yarn lint:setup"
+    "install-dev": "yarn && yarn lint:setup",
+    "install-ci": "yarn && cd ../packages/eslint-plugin-twenty/ && yarn && yarn build"
   },
   "eslintConfig": {
     "extends": [

--- a/front/package.json
+++ b/front/package.json
@@ -69,7 +69,8 @@
     "test": "craco test",
     "coverage": "craco test --coverage .",
     "lint": "eslint src --max-warnings=0",
-    "lint:setup": "cd ../packages/eslint-plugin-twenty/ && yarn && yarn build && cd ../../front/ && yarn upgrade eslint-plugin-twenty",
+    "eslint-plugin:upgrade": "yarn eslint-plugin:setup && yarn upgrade eslint-plugin-twenty",
+    "eslint-plugin:setup": "cd ../packages/eslint-plugin-twenty/ && yarn && yarn build && cd ../../front/",
     "storybook:dev": "storybook dev -p 6006 -s ../public",
     "storybook:test": "test-storybook",
     "storybook:test-slow": "test-storybook --maxWorkers=3",
@@ -83,8 +84,7 @@
     "storybook:pages:coverage": "STORYBOOK_STORIES_FOLDER=pages yarn storybook:coverage",
     "graphql:generate": "dotenv cross-var graphql-codegen --config codegen.js",
     "chromatic": "dotenv cross-var npx chromatic --project-token=$CHROMATIC_PROJECT_TOKEN",
-    "install-dev": "yarn && yarn lint:setup",
-    "install-ci": "yarn && cd ../packages/eslint-plugin-twenty/ && yarn && yarn build"
+    "install": "yarn eslint-plugin:setup"
   },
   "eslintConfig": {
     "extends": [

--- a/front/src/__stories__/App.stories.tsx
+++ b/front/src/__stories__/App.stories.tsx
@@ -31,8 +31,6 @@ const meta: Meta<typeof App> = {
   },
 };
 
-jest.setTimeout(30000);
-
 export default meta;
 export type Story = StoryObj<typeof App>;
 

--- a/front/src/__stories__/App.stories.tsx
+++ b/front/src/__stories__/App.stories.tsx
@@ -31,6 +31,8 @@ const meta: Meta<typeof App> = {
   },
 };
 
+jest.setTimeout(30000);
+
 export default meta;
 export type Story = StoryObj<typeof App>;
 


### PR DESCRIPTION
This PRs divides front-ci runtime by 2:

<img width="1512" alt="image" src="https://github.com/twentyhq/twenty/assets/12035771/b961a33f-efc1-4cd8-bb7e-2dcf6473ab51">
vs.
<img width="1512" alt="image" src="https://github.com/twentyhq/twenty/assets/12035771/81ddfe84-147b-4602-977a-49defe29d4e8">

To achieve that, I'm combining multiple techniques:
- parallelizing jobs (jest, lint, storybook)
- cutting the storybook tests in 2 (modules vs pages), this will also allow us to specify different coverage goals for them
- caching node_modules (if you update them, you'll need to wait 1mn20 longer)

I'm also increasing storybook pages timeout to 30 seconds to avoid flaky tests. Pages tests need to render a lot of things and their execution times varies between 5-25seconds
