### PR TITLE
Speed up CI

### DIFF
--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -58,8 +58,6 @@ jobs:
           restore-keys: eslint-plugin-twenty-node_modules-
       - name: Install dependencies
         run: yarn
-      - name: Install Dependencies
-        run: cd front && yarn
       - name: Install Playwright
         run: cd front && npx playwright install
       - name: Build Storybook
@@ -96,8 +94,6 @@ jobs:
           path: packages/eslint-plugin-twenty/node_modules
           key: eslint-plugin-twenty-node_modules-${{hashFiles('packages/eslint-plugin-twenty/yarn.lock')}}
           restore-keys: eslint-plugin-twenty-node_modules-
-      - name: Install Dependencies
-        run: cd front && yarn
       - name: Install Playwright
         run: cd front && npx playwright install
       - name: Build Storybook
@@ -157,7 +153,5 @@ jobs:
           path: packages/eslint-plugin-twenty/node_modules
           key: eslint-plugin-twenty-node_modules-${{hashFiles('packages/eslint-plugin-twenty/yarn.lock')}}
           restore-keys: eslint-plugin-twenty-node_modules-
-      - name: Front / Install Dependencies
-        run: cd front && yarn
       - name: Front / Run jest
         run: cd front && yarn test


### PR DESCRIPTION
Removing yarn from steps as dependencies will be cached by yarn-install job