### PR TITLE
Fix command menu keyboard input & refactor group

### DIFF
--- a/front/src/modules/command-menu/components/CommandGroup.tsx
+++ b/front/src/modules/command-menu/components/CommandGroup.tsx
@@ -24,7 +24,7 @@ type OwnProps = {
 };
 
 export const CommandGroup = ({ heading, children }: OwnProps) => {
-  if (!React.Children.count(children)) {
+  if (!children || !React.Children.count(children)) {
     return null;
   }
   return <StyledGroup heading={heading}>{children}</StyledGroup>;

--- a/front/src/modules/command-menu/components/CommandGroup.tsx
+++ b/front/src/modules/command-menu/components/CommandGroup.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { Command } from 'cmdk';
+
+const StyledGroup = styled(Command.Group)`
+  [cmdk-group-heading] {
+    align-items: center;
+    color: ${({ theme }) => theme.font.color.light};
+    display: flex;
+    font-size: ${({ theme }) => theme.font.size.xs};
+    font-weight: ${({ theme }) => theme.font.weight.semiBold};
+    padding-bottom: ${({ theme }) => theme.spacing(2)};
+    padding-left: ${({ theme }) => theme.spacing(2)};
+    padding-right: ${({ theme }) => theme.spacing(1)};
+    padding-top: ${({ theme }) => theme.spacing(2)};
+    text-transform: uppercase;
+    user-select: none;
+  }
+`;
+
+type OwnProps = {
+  heading: string;
+  children: React.ReactNode | React.ReactNode[];
+};
+
+export const CommandGroup = ({ heading, children }: OwnProps) => {
+  if (!React.Children.count(children)) {
+    return null;
+  }
+  return <StyledGroup heading={heading}>{children}</StyledGroup>;
+};

--- a/front/src/modules/command-menu/components/CommandMenu.tsx
+++ b/front/src/modules/command-menu/components/CommandMenu.tsx
@@ -19,11 +19,11 @@ import { commandMenuCommandsState } from '../states/commandMenuCommandsState';
 import { isCommandMenuOpenedState } from '../states/isCommandMenuOpenedState';
 import { Command, CommandType } from '../types/Command';
 
+import { CommandGroup } from './CommandGroup';
 import { CommandMenuItem } from './CommandMenuItem';
 import {
   StyledDialog,
   StyledEmpty,
-  StyledGroup,
   StyledInput,
   StyledList,
 } from './CommandMenuStyles';
@@ -130,87 +130,73 @@ export const CommandMenu = () => {
         onValueChange={setSearch}
       />
       <StyledList>
-        {matchingCreateCommand.length < 1 &&
-          matchingNavigateCommand.length < 1 &&
-          people.length < 1 &&
-          companies.length < 1 &&
-          activities.length < 1 && <StyledEmpty>No results found.</StyledEmpty>}
-        {matchingCreateCommand.length > 0 && (
-          <StyledGroup heading="Create">
-            {matchingCreateCommand.map((cmd) => (
-              <CommandMenuItem
-                to={cmd.to}
-                key={cmd.label}
-                Icon={cmd.Icon}
-                label={cmd.label}
-                onClick={cmd.onCommandClick}
-                shortcuts={cmd.shortcuts || []}
-              />
-            ))}
-          </StyledGroup>
-        )}
-        {matchingNavigateCommand.length > 0 && (
-          <StyledGroup heading="Navigate">
-            {matchingNavigateCommand.map((cmd) => (
-              <CommandMenuItem
-                to={cmd.to}
-                key={cmd.label}
-                label={cmd.label}
-                onClick={cmd.onCommandClick}
-                shortcuts={cmd.shortcuts || []}
-              />
-            ))}
-          </StyledGroup>
-        )}
-        {people.length > 0 && (
-          <StyledGroup heading="People">
-            {people.map((person) => (
-              <CommandMenuItem
-                key={person.id}
-                to={`person/${person.id}`}
-                label={person.displayName}
-                Icon={() => (
-                  <Avatar
-                    type="rounded"
-                    avatarUrl={null}
-                    colorId={person.id}
-                    placeholder={person.displayName}
-                  />
-                )}
-              />
-            ))}
-          </StyledGroup>
-        )}
-        {companies.length > 0 && (
-          <StyledGroup heading="Companies">
-            {companies.map((company) => (
-              <CommandMenuItem
-                key={company.id}
-                label={company.name}
-                to={`companies/${company.id}`}
-                Icon={() => (
-                  <Avatar
-                    colorId={company.id}
-                    placeholder={company.name}
-                    avatarUrl={getLogoUrlFromDomainName(company.domainName)}
-                  />
-                )}
-              />
-            ))}
-          </StyledGroup>
-        )}
-        {activities.length > 0 && (
-          <StyledGroup heading="Notes">
-            {activities.map((activity) => (
-              <CommandMenuItem
-                Icon={IconNotes}
-                key={activity.id}
-                label={activity.title ?? ''}
-                onClick={() => openActivityRightDrawer(activity.id)}
-              />
-            ))}
-          </StyledGroup>
-        )}
+        <StyledEmpty>No results found.</StyledEmpty>
+        <CommandGroup heading="Create">
+          {matchingCreateCommand.map((cmd) => (
+            <CommandMenuItem
+              to={cmd.to}
+              key={cmd.label}
+              Icon={cmd.Icon}
+              label={cmd.label}
+              onClick={cmd.onCommandClick}
+              shortcuts={cmd.shortcuts || []}
+            />
+          ))}
+        </CommandGroup>
+        <CommandGroup heading="Navigate">
+          {matchingNavigateCommand.map((cmd) => (
+            <CommandMenuItem
+              to={cmd.to}
+              key={cmd.label}
+              label={cmd.label}
+              onClick={cmd.onCommandClick}
+              shortcuts={cmd.shortcuts || []}
+            />
+          ))}
+        </CommandGroup>
+        <CommandGroup heading="People">
+          {people.map((person) => (
+            <CommandMenuItem
+              key={person.id}
+              to={`person/${person.id}`}
+              label={person.displayName}
+              Icon={() => (
+                <Avatar
+                  type="rounded"
+                  avatarUrl={null}
+                  colorId={person.id}
+                  placeholder={person.displayName}
+                />
+              )}
+            />
+          ))}
+        </CommandGroup>
+        <CommandGroup heading="Companies">
+          {companies.map((company) => (
+            <CommandMenuItem
+              key={company.id}
+              label={company.name}
+              to={`companies/${company.id}`}
+              Icon={() => (
+                <Avatar
+                  colorId={company.id}
+                  placeholder={company.name}
+                  avatarUrl={getLogoUrlFromDomainName(company.domainName)}
+                />
+              )}
+            />
+          ))}
+        </CommandGroup>
+        <CommandGroup heading="Notes">
+          {activities.map((activity) => (
+            <CommandMenuItem
+              Icon={IconNotes}
+              key={activity.id}
+              label={activity.title ?? ''}
+              onClick={() => openActivityRightDrawer(activity.id)}
+            />
+          ))}
+        </CommandGroup>
       </StyledList>
     </StyledDialog>
   );

--- a/front/src/modules/command-menu/components/CommandMenu.tsx
+++ b/front/src/modules/command-menu/components/CommandMenu.tsx
@@ -132,27 +132,29 @@ export const CommandMenu = () => {
       <StyledList>
         <StyledEmpty>No results found.</StyledEmpty>
         <CommandGroup heading="Create">
-          {matchingCreateCommand.map((cmd) => (
-            <CommandMenuItem
-              to={cmd.to}
-              key={cmd.label}
-              Icon={cmd.Icon}
-              label={cmd.label}
-              onClick={cmd.onCommandClick}
-              shortcuts={cmd.shortcuts || []}
-            />
-          ))}
+          {matchingCreateCommand.length === 1 &&
+            matchingCreateCommand.map((cmd) => (
+              <CommandMenuItem
+                to={cmd.to}
+                key={cmd.label}
+                Icon={cmd.Icon}
+                label={cmd.label}
+                onClick={cmd.onCommandClick}
+                shortcuts={cmd.shortcuts || []}
+              />
+            ))}
         </CommandGroup>
         <CommandGroup heading="Navigate">
-          {matchingNavigateCommand.map((cmd) => (
-            <CommandMenuItem
-              to={cmd.to}
-              key={cmd.label}
-              label={cmd.label}
-              onClick={cmd.onCommandClick}
-              shortcuts={cmd.shortcuts || []}
-            />
-          ))}
+          {matchingNavigateCommand.length === 1 &&
+            matchingNavigateCommand.map((cmd) => (
+              <CommandMenuItem
+                to={cmd.to}
+                key={cmd.label}
+                label={cmd.label}
+                onClick={cmd.onCommandClick}
+                shortcuts={cmd.shortcuts || []}
+              />
+            ))}
         </CommandGroup>
         <CommandGroup heading="People">
           {people.map((person) => (

--- a/front/src/modules/command-menu/components/CommandMenuItem.tsx
+++ b/front/src/modules/command-menu/components/CommandMenuItem.tsx
@@ -1,21 +1,12 @@
-import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useTheme } from '@emotion/react';
 
 import { IconArrowUpRight } from '@/ui/icon';
 import { IconComponent } from '@/ui/icon/types/IconComponent';
+import { MenuItemCommand } from '@/ui/menu-item/components/MenuItemCommand';
 
 import { useCommandMenu } from '../hooks/useCommandMenu';
 
-import {
-  StyledIconAndLabelContainer,
-  StyledIconContainer,
-  StyledMenuItem,
-  StyledShortCut,
-  StyledShortcutsContainer,
-} from './CommandMenuStyles';
-
-export type OwnProps = {
+export type CommandMenuItemProps = {
   label: string;
   to?: string;
   key: string;
@@ -30,10 +21,9 @@ export const CommandMenuItem = ({
   onClick,
   Icon,
   shortcuts,
-}: OwnProps) => {
+}: CommandMenuItemProps) => {
   const navigate = useNavigate();
   const { closeCommandMenu } = useCommandMenu();
-  const theme = useTheme();
 
   if (to && !Icon) {
     Icon = IconArrowUpRight;
@@ -53,25 +43,11 @@ export const CommandMenuItem = ({
   };
 
   return (
-    <StyledMenuItem onSelect={onItemClick}>
-      <StyledIconAndLabelContainer>
-        <StyledIconContainer>
-          {Icon && <Icon size={theme.icon.size.sm} />}
-        </StyledIconContainer>
-        {label}
-      </StyledIconAndLabelContainer>
-      <StyledShortcutsContainer>
-        {shortcuts &&
-          shortcuts.map((shortcut, index) => {
-            const prefix = index > 0 ? 'then' : '';
-            return (
-              <React.Fragment key={index}>
-                {prefix}
-                <StyledShortCut>{shortcut}</StyledShortCut>
-              </React.Fragment>
-            );
-          })}
-      </StyledShortcutsContainer>
-    </StyledMenuItem>
+    <MenuItemCommand
+      LeftIcon={Icon}
+      text={label}
+      command={shortcuts ? shortcuts.join(' then ') : ''}
+      onClick={onItemClick}
+    />
   );
 };

--- a/front/src/modules/command-menu/components/CommandMenuItem.tsx
+++ b/front/src/modules/command-menu/components/CommandMenuItem.tsx
@@ -1,13 +1,21 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useTheme } from '@emotion/react';
 
 import { IconArrowUpRight } from '@/ui/icon';
 import { IconComponent } from '@/ui/icon/types/IconComponent';
-import { MenuItemCommand } from '@/ui/menu-item/components/MenuItemCommand';
 
 import { useCommandMenu } from '../hooks/useCommandMenu';
 
-export type CommandMenuItemProps = {
+import {
+  StyledIconAndLabelContainer,
+  StyledIconContainer,
+  StyledMenuItem,
+  StyledShortCut,
+  StyledShortcutsContainer,
+} from './CommandMenuStyles';
+
+export type OwnProps = {
   label: string;
   to?: string;
   key: string;
@@ -22,9 +30,10 @@ export const CommandMenuItem = ({
   onClick,
   Icon,
   shortcuts,
-}: CommandMenuItemProps) => {
+}: OwnProps) => {
   const navigate = useNavigate();
   const { closeCommandMenu } = useCommandMenu();
+  const theme = useTheme();
 
   if (to && !Icon) {
     Icon = IconArrowUpRight;
@@ -44,11 +53,25 @@ export const CommandMenuItem = ({
   };
 
   return (
-    <MenuItemCommand
-      LeftIcon={Icon}
-      text={label}
-      command={shortcuts ? shortcuts.join(' then ') : ''}
-      onClick={onItemClick}
-    />
+    <StyledMenuItem onSelect={onItemClick}>
+      <StyledIconAndLabelContainer>
+        <StyledIconContainer>
+          {Icon && <Icon size={theme.icon.size.sm} />}
+        </StyledIconContainer>
+        {label}
+      </StyledIconAndLabelContainer>
+      <StyledShortcutsContainer>
+        {shortcuts &&
+          shortcuts.map((shortcut, index) => {
+            const prefix = index > 0 ? 'then' : '';
+            return (
+              <React.Fragment key={index}>
+                {prefix}
+                <StyledShortCut>{shortcut}</StyledShortCut>
+              </React.Fragment>
+            );
+          })}
+      </StyledShortcutsContainer>
+    </StyledMenuItem>
   );
 };

--- a/front/src/modules/command-menu/components/CommandMenuStyles.tsx
+++ b/front/src/modules/command-menu/components/CommandMenuStyles.tsx
@@ -37,48 +37,6 @@ export const StyledInput = styled(Command.Input)`
   }
 `;
 
-export const StyledMenuItem = styled(Command.Item)`
-  align-items: center;
-  border-radius: ${({ theme }) => theme.border.radius.sm};
-  color: ${({ theme }) => theme.font.color.primary};
-  cursor: pointer;
-  display: flex;
-  font-size: ${({ theme }) => theme.font.size.md};
-  gap: ${({ theme }) => theme.spacing(3)};
-  height: 40px;
-  justify-content: space-between;
-  padding: 0 ${({ theme }) => theme.spacing(1)};
-  position: relative;
-  transition: all 150ms ease;
-  transition-property: none;
-  user-select: none;
-  &:hover {
-    background: ${({ theme }) => theme.background.transparent.light};
-  }
-  &[data-selected='true'] {
-    background: ${({ theme }) => theme.background.tertiary};
-    /* Could be nice to add a caret like this for better accessibility in the future
-    But it needs to be consistend with other picker dropdown (e.g. company)
-    &:after {
-      background: ${({ theme }) => theme.background.quaternary};
-      content: '';
-      height: 100%;
-      left: 0;
-      position: absolute;
-      width: 3px;
-      z-index: ${({ theme }) => theme.lastLayerZIndex};
-    } */
-  }
-  &[data-disabled='true'] {
-    color: ${({ theme }) => theme.font.color.light};
-    cursor: not-allowed;
-  }
-  svg {
-    height: 16px;
-    width: 16px;
-  }
-`;
-
 export const StyledList = styled(Command.List)`
   background: ${({ theme }) => theme.background.secondary};
   height: min(300px, var(--cmdk-list-height));
@@ -97,35 +55,4 @@ export const StyledEmpty = styled(Command.Empty)`
   height: 64px;
   justify-content: center;
   white-space: pre-wrap;
-`;
-
-export const StyledSeparator = styled(Command.Separator)``;
-
-export const StyledIconAndLabelContainer = styled.div`
-  align-items: center;
-  display: flex;
-  gap: ${({ theme }) => theme.spacing(2)};
-`;
-export const StyledIconContainer = styled.div`
-  align-items: center;
-  background: ${({ theme }) => theme.background.transparent.light};
-  border-radius: ${({ theme }) => theme.border.radius.sm};
-  color: ${({ theme }) => theme.font.color.secondary};
-  display: flex;
-  padding: ${({ theme }) => theme.spacing(1)};
-`;
-export const StyledShortCut = styled.div`
-  background-color: ${({ theme }) => theme.background.transparent.light};
-  border-radius: ${({ theme }) => theme.border.radius.sm};
-  color: ${({ theme }) => theme.font.color.light};
-  margin-left: ${({ theme }) => theme.spacing(1)};
-  margin-right: ${({ theme }) => theme.spacing(1)};
-  padding: ${({ theme }) => theme.spacing(1)};
-`;
-
-export const StyledShortcutsContainer = styled.div`
-  align-items: center;
-  color: ${({ theme }) => theme.font.color.light};
-  display: flex;
-  font-size: ${({ theme }) => theme.font.size.sm};
 `;

--- a/front/src/modules/command-menu/components/CommandMenuStyles.tsx
+++ b/front/src/modules/command-menu/components/CommandMenuStyles.tsx
@@ -89,22 +89,6 @@ export const StyledList = styled(Command.List)`
   transition-property: height;
 `;
 
-export const StyledGroup = styled(Command.Group)`
-  [cmdk-group-heading] {
-    align-items: center;
-    color: ${({ theme }) => theme.font.color.light};
-    display: flex;
-    font-size: ${({ theme }) => theme.font.size.xs};
-    font-weight: ${({ theme }) => theme.font.weight.semiBold};
-    padding-bottom: ${({ theme }) => theme.spacing(2)};
-    padding-left: ${({ theme }) => theme.spacing(2)};
-    padding-right: ${({ theme }) => theme.spacing(1)};
-    padding-top: ${({ theme }) => theme.spacing(2)};
-    text-transform: uppercase;
-    user-select: none;
-  }
-`;
-
 export const StyledEmpty = styled(Command.Empty)`
   align-items: center;
   color: ${({ theme }) => theme.font.color.light};

--- a/front/src/modules/ui/menu-item/components/MenuItemCommand.tsx
+++ b/front/src/modules/ui/menu-item/components/MenuItemCommand.tsx
@@ -1,10 +1,10 @@
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
+import { Command } from 'cmdk';
 
 import { IconComponent } from '@/ui/icon/types/IconComponent';
 
 import {
-  StyledMenuItemBase,
   StyledMenuItemLabel,
   StyledMenuItemLeftContent,
 } from '../internals/components/StyledMenuItemBase';
@@ -32,8 +32,51 @@ const StyledCommandText = styled.div`
   padding-right: ${({ theme }) => theme.spacing(2)};
 `;
 
-const StyledMenuItemCommandContainer = styled(StyledMenuItemBase)`
+const StyledMenuItemCommandContainer = styled(Command.Item)`
+  --horizontal-padding: ${({ theme }) => theme.spacing(1)};
+  --vertical-padding: ${({ theme }) => theme.spacing(2)};
+  align-items: center;
+  border-radius: ${({ theme }) => theme.border.radius.sm};
+  color: ${({ theme }) => theme.font.color.secondary};
+  cursor: pointer;
+  display: flex;
+  flex-direction: row;
+  font-size: ${({ theme }) => theme.font.size.sm};
+  gap: ${({ theme }) => theme.spacing(2)};
+  height: calc(32px - 2 * var(--vertical-padding));
   height: 24px;
+  justify-content: space-between;
+  padding: var(--vertical-padding) var(--horizontal-padding);
+  position: relative;
+  transition: all 150ms ease;
+  transition-property: none;
+  user-select: none;
+  width: calc(100% - 2 * var(--horizontal-padding));
+  &:hover {
+    background: ${({ theme }) => theme.background.transparent.light};
+  }
+  &[data-selected='true'] {
+    background: ${({ theme }) => theme.background.tertiary};
+    /* Could be nice to add a caret like this for better accessibility in the future
+    But it needs to be consistend with other picker dropdown (e.g. company)
+    &:after {
+      background: ${({ theme }) => theme.background.quaternary};
+      content: '';
+      height: 100%;
+      left: 0;
+      position: absolute;
+      width: 3px;
+      z-index: ${({ theme }) => theme.lastLayerZIndex};
+    } */
+  }
+  &[data-disabled='true'] {
+    color: ${({ theme }) => theme.font.color.light};
+    cursor: not-allowed;
+  }
+  svg {
+    height: 16px;
+    width: 16px;
+  }
 `;
 
 export type MenuItemProps = {
@@ -54,7 +97,7 @@ export const MenuItemCommand = ({
   const theme = useTheme();
 
   return (
-    <StyledMenuItemCommandContainer onClick={onClick} className={className}>
+    <StyledMenuItemCommandContainer onSelect={onClick} className={className}>
       <StyledMenuItemLeftContent>
         {LeftIcon && (
           <StyledBigIconContainer>


### PR DESCRIPTION
It cost me **some** time but now I found the breaking commit: fb737e2 / #1492 

With the icon refactoring some changes where made  to the CommandMenuItem - I'm not sure about their goal ... Maybe you have an Idea why [not only the Icon was refactored](https://github.com/twentyhq/twenty/commit/fb737e20212f0570bcb839714b4f1174e6ce1828#diff-4ecaa2a218b9c9effbcd3db78d8059b88d9c81634e41f8712107a290f0e95fceL54-R52) @charlesBochet ? 

For now I reverted the change and the keyboard input is now working again 🎉 


While I was at the CommandMenu I made the CommandGroups somewhat reasonable to not render if no items are included - improving the developer experience in the CommandMenu files by not needing so many conditional elements. 


We should also write some tests covering this and other keyboard behaviour on the command menu ... maybe in a follow up issue? 

closes #1703  
