### PR TITLE
Fix missing patches folder to deploy server

### DIFF
--- a/infra/dev/twenty-dev/Dockerfile
+++ b/infra/dev/twenty-dev/Dockerfile
@@ -13,6 +13,7 @@ WORKDIR /app/server
 
 COPY ../../server/package.json .
 COPY ../../server/yarn.lock .
+COPY ../../server/patches ./patches
 RUN yarn install
 
 WORKDIR /app

--- a/infra/prod/server/Dockerfile
+++ b/infra/prod/server/Dockerfile
@@ -7,6 +7,7 @@ COPY ./server/patches ./patches
 
 RUN yarn install
 
+COPY ./server .
 RUN npx prisma generate
 
 RUN yarn build

--- a/infra/prod/server/Dockerfile
+++ b/infra/prod/server/Dockerfile
@@ -3,9 +3,10 @@ FROM node:18.16.0-alpine as server
 WORKDIR /app/server
 COPY ./server/package.json ./
 COPY ./server/yarn.lock ./
+COPY ./server/patches ./patches
+
 RUN yarn install
 
-COPY ./server .
 RUN npx prisma generate
 
 RUN yarn build

--- a/infra/prod/server/Dockerfile
+++ b/infra/prod/server/Dockerfile
@@ -4,7 +4,6 @@ WORKDIR /app/server
 COPY ./server/package.json ./
 COPY ./server/yarn.lock ./
 COPY ./server/patches ./patches
-
 RUN yarn install
 
 COPY ./server .


### PR DESCRIPTION
## Context
CI is failing here https://github.com/twentyhq/twenty-infra/actions/runs/6349606829/job/17248039375
due to a missing implementation of conditionalSchema. In fact, this was added as a patch which should be executed with yarn but seems missing on the CI
```
#10 37.73 [4/4] Building fresh packages...
#10 42.39 $ patch-package
#10 42.65 patch-package 8.0.0
#10 42.65 Applying patches...
#10 42.65 No patch files found
#10 42.68 Done in 42.19s.
```
To do that, we need to make sure our patch exists before running yarn install, which is not the case in our current docker config. I'm adding an instruction to copy it before.

See also https://github.com/ds300/patch-package#docker-and-ci