### PR TITLE
Fix: Consistent avatars for show pages

### DIFF
--- a/front/src/modules/ui/layout/show-page/components/ShowPageSummaryCard.tsx
+++ b/front/src/modules/ui/layout/show-page/components/ShowPageSummaryCard.tsx
@@ -3,7 +3,7 @@ import { Tooltip } from 'react-tooltip';
 import styled from '@emotion/styled';
 import { v4 as uuidV4 } from 'uuid';
 
-import { Avatar } from '@/users/components/Avatar';
+import { Avatar, AvatarType } from '@/users/components/Avatar';
 import {
   beautifyExactDateTime,
   beautifyPastDateRelativeToNow,
@@ -18,6 +18,7 @@ type OwnProps = {
   date: string;
   renderTitleEditComponent?: () => JSX.Element;
   onUploadPicture?: (file: File) => void;
+  avatarType: AvatarType;
 };
 
 const StyledShowPageSummaryCard = styled.div`
@@ -77,6 +78,7 @@ export const ShowPageSummaryCard = ({
   logoOrAvatar,
   title,
   date,
+  avatarType,
   renderTitleEditComponent,
   onUploadPicture,
 }: OwnProps) => {
@@ -102,7 +104,7 @@ export const ShowPageSummaryCard = ({
           size="xl"
           colorId={id}
           placeholder={title}
-          type="rounded"
+          type={avatarType}
         />
         <StyledFileInput
           ref={inputFileRef}

--- a/front/src/pages/companies/CompanyShow.tsx
+++ b/front/src/pages/companies/CompanyShow.tsx
@@ -90,6 +90,7 @@ export const CompanyShow = () => {
                 renderTitleEditComponent={() => (
                   <CompanyNameEditableField company={company} />
                 )}
+                avatarType="squared"
               />
               <PropertyBox extraPadding={true}>
                 {companyShowFieldDefinition.map((fieldDefinition) => {

--- a/front/src/pages/people/PersonShow.tsx
+++ b/front/src/pages/people/PersonShow.tsx
@@ -116,6 +116,7 @@ export const PersonShow = () => {
                   )
                 }
                 onUploadPicture={onUploadPicture}
+                avatarType="rounded"
               />
               <PropertyBox extraPadding={true}>
                 {personShowFieldDefinition.map((fieldDefinition) => {


### PR DESCRIPTION
Make the avatar for companies on show page squared as for the table view. Otherwise it seems weird having this round avatar when opening it via a squared one ... 


Before:
<img width="322" alt="Bildschirmfoto 2023-09-29 um 23 49 06" src="https://github.com/twentyhq/twenty/assets/48770548/6f54aae9-e0cd-4da0-96d4-cd5d6827b064">


After:
<img width="335" alt="Bildschirmfoto 2023-09-29 um 23 48 41" src="https://github.com/twentyhq/twenty/assets/48770548/761ac6eb-95cb-4a7e-8f2d-3f9351daaaf5">

