### PR TITLE
Fix: Table / Board createView bug

### DIFF
--- a/front/src/modules/ui/board/components/BoardHeader.tsx
+++ b/front/src/modules/ui/board/components/BoardHeader.tsx
@@ -109,7 +109,6 @@ export const BoardHeader = ({ className, onStageAdd }: BoardHeaderProps) => {
           onCurrentViewSubmit: handleCurrentViewSubmit,
           onViewBarReset: handleViewBarReset,
           onViewSelect: handleViewSelect,
-          onViewCreate: (view) => setSearchParams({ view: view.id }),
         }}
       >
         <ViewBar

--- a/front/src/modules/ui/editable-field/components/InlineCell.tsx
+++ b/front/src/modules/ui/editable-field/components/InlineCell.tsx
@@ -54,7 +54,6 @@ export const InlineCell = () => {
     persistField();
     closeInlineCell();
   };
-  console.log(JSON.stringify({ fieldDefinition }));
 
   return (
     <InlineCellContainer

--- a/front/src/modules/ui/table/table-header/components/TableHeader.tsx
+++ b/front/src/modules/ui/table/table-header/components/TableHeader.tsx
@@ -40,7 +40,6 @@ export const TableHeader = () => {
           ...viewBarContextProps,
           onCurrentViewSubmit,
           onViewSelect: handleViewSelect,
-          onViewCreate: (view) => setSearchParams({ view: view.id }),
         }}
       >
         <ViewBar

--- a/front/src/modules/views/hooks/useBoardViews.ts
+++ b/front/src/modules/views/hooks/useBoardViews.ts
@@ -1,3 +1,5 @@
+import { useSearchParams } from 'react-router-dom';
+
 import { RecoilScopeContext } from '@/types/RecoilScopeContext';
 import { useBoardColumns } from '@/ui/board/hooks/useBoardColumns';
 import { boardCardFieldsScopedState } from '@/ui/board/states/boardCardFieldsScopedState';
@@ -29,10 +31,13 @@ export const useBoardViews = ({
   const filters = useRecoilScopedValue(filtersScopedState, RecoilScopeContext);
   const sorts = useRecoilScopedValue(sortsScopedState, RecoilScopeContext);
 
+  const [_, setSearchParams] = useSearchParams();
+
   const handleViewCreate = async (viewId: string) => {
     await createViewFields(boardCardFields, viewId);
     await createViewFilters(filters, viewId);
     await createViewSorts(sorts, viewId);
+    setSearchParams({ view: viewId });
   };
 
   const { createView, deleteView, isFetchingViews, updateView } = useViews({

--- a/front/src/modules/views/hooks/useTableViews.ts
+++ b/front/src/modules/views/hooks/useTableViews.ts
@@ -1,3 +1,5 @@
+import { useSearchParams } from 'react-router-dom';
+
 import { FieldMetadata } from '@/ui/field/types/FieldMetadata';
 import { TableRecoilScopeContext } from '@/ui/table/states/recoil-scope-contexts/TableRecoilScopeContext';
 import { tableColumnsScopedState } from '@/ui/table/states/tableColumnsScopedState';
@@ -29,10 +31,13 @@ export const useTableViews = ({
   );
   const sorts = useRecoilScopedValue(sortsScopedState, TableRecoilScopeContext);
 
+  const [_, setSearchParams] = useSearchParams();
+
   const handleViewCreate = async (viewId: string) => {
     await createViewFields(tableColumns, viewId);
     await createViewFilters(filters, viewId);
     await createViewSorts(sorts, viewId);
+    setSearchParams({ view: viewId });
   };
 
   const { createView, deleteView, isFetchingViews, updateView } = useViews({


### PR DESCRIPTION
## Bug Description

Creating a new view for the table / board causes runtime error. 

https://github.com/twentyhq/twenty/assets/54364088/68181b5d-a70c-4d96-b3ed-6e7dfadb4d08

-  View Create mutation is handled by the onViewCreate function provided to ViewBarContext in the respective table / board page.
- In PR #1710, another onViewCreate function was passed to the child component (TableHeader / BoardHeader) to set the search param. This function, being passed to the same Context, overwrote the original mutation function. Hence only the search param is getting changed and the actual mutation is not getting triggered.
- As the viewId in search params does not exist, it causes a runtime exception.

## Fix
- Moved setSearchParams to useTableViews / useBoardViews hook, where it will be called after view and all relevant fields are created. This fixes the creation of a new view from the dropdown menu.

## To do
When an invalid viewId search param is passed, useGetViewFieldsQuery gets an empty viewFields array and tries to populate it with the default column definition.
https://github.com/twentyhq/twenty/blob/e12e7754e48e0721edb9bfd1bf801a7385d359b7/front/src/modules/views/hooks/useTableViewFields.ts#L122C17-L122C17
As it calls createViewFields mutation with an invalid viewId, we get a foreign key error as seen in the video above.
- viewId from search params needs to be validated.
- also to handle invalid viewId gracefully, we may show Not-found page or clear search params and go to the default page.
