### PR TITLE
Fix docker setup with bcrypt

### DIFF
--- a/infra/dev/Makefile
+++ b/infra/dev/Makefile
@@ -12,7 +12,7 @@ up:
 	@docker-compose up -d
 
 down:
-	@docker-compose down
+	@docker-compose down -v
 
 sh:
 	@docker-compose exec twenty-dev sh

--- a/infra/dev/docker-compose.yml
+++ b/infra/dev/docker-compose.yml
@@ -10,8 +10,8 @@ services:
       - "6006:6006"
     volumes:
       - ../..:/app
-      - twenty_node_modules_front:/app/front/node_modules
-      - twenty_node_modules_server:/app/server/node_modules
+      - /app/front/node_modules
+      - /app/server/node_modules
     depends_on:
       - postgres
   twenty-docs:


### PR DESCRIPTION
## Context
Apparently our docker setup was broken due to our dependency to bcrypt lib.

See error here
<img width="750" alt="Screenshot 2023-10-01 at 18 50 52" src="https://github.com/twentyhq/twenty/assets/1834158/82a7d915-d791-4658-afe5-65f6b9c7d6b6">

## Fix
See suggestion and explanation detailed here https://www.richardkotze.com/top-tips/install-bcrypt-docker-image-exclude-host-node-modules
Let me know if you find a better solution, in the meantime, using anonymous volumes seems to fix the problem.

After
<img width="835" alt="Screenshot 2023-10-01 at 18 54 29" src="https://github.com/twentyhq/twenty/assets/1834158/cc5cbc37-9ba7-4aa2-b767-9e1d1d541e22">
