### PR TITLE
Workaround for bug on token conflict with front and storybook

### DIFF
--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -78,7 +78,7 @@ import {
           return conditionalSchema;
         } catch (error) {
           if (error instanceof JsonWebTokenError) {
-            //eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIzNzRmZTNhNS1kZjFlLTQxMTktYWZlMC0yYTYyYTJiYTQ4MWUiLCJ3b3Jrc3BhY2VJZCI6InR3ZW50eS03ZWQ5ZDIxMi0xYzI1LTRkMDItYmYyNS02YWVjY2Y3ZWE0MTkiLCJpYXQiOjE2ODY5OTMxODIsImV4cCI6MTY4Njk5MzQ4Mn0.F_FD6nJ5fssR_47v2XFhtzqjr-wrEQpqaWVq8iIlLJw
+            //mockedUserJWT
             throw new GraphQLError('Unauthenticated', {
               extensions: {
                 code: 'UNAUTHENTICATED',

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -7,7 +7,7 @@ import { YogaDriver, YogaDriverConfig } from '@graphql-yoga/nestjs';
 import GraphQLJSON from 'graphql-type-json';
 import { GraphQLError, GraphQLSchema } from 'graphql';
 import { ExtractJwt } from 'passport-jwt';
-import { TokenExpiredError, verify } from 'jsonwebtoken';
+import { TokenExpiredError, JsonWebTokenError, verify } from 'jsonwebtoken';
 
 import { AppService } from './app.service';
 
@@ -77,6 +77,14 @@ import {
 
           return conditionalSchema;
         } catch (error) {
+          if (error instanceof JsonWebTokenError) {
+            //eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIzNzRmZTNhNS1kZjFlLTQxMTktYWZlMC0yYTYyYTJiYTQ4MWUiLCJ3b3Jrc3BhY2VJZCI6InR3ZW50eS03ZWQ5ZDIxMi0xYzI1LTRkMDItYmYyNS02YWVjY2Y3ZWE0MTkiLCJpYXQiOjE2ODY5OTMxODIsImV4cCI6MTY4Njk5MzQ4Mn0.F_FD6nJ5fssR_47v2XFhtzqjr-wrEQpqaWVq8iIlLJw
+            throw new GraphQLError('Unauthenticated', {
+              extensions: {
+                code: 'UNAUTHENTICATED',
+              },
+            });
+          }
           if (error instanceof TokenExpiredError) {
             throw new GraphQLError('Unauthenticated', {
               extensions: {


### PR DESCRIPTION
When started story book on localhost:6006 and front on localhost:3001, there is an error due to the cookies exchange over all localhost tabs. The old one token taken to preview storybook.
```
 mockedUserJWT =
'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIzNzRmZTNhNS1kZjFlLTQxMTktYWZlMC0yYTYyYTJiYTQ4MWUiLCJ3b3Jrc3BhY2VJZCI6InR3ZW50eS03ZWQ5ZDIxMi0xYzI1LTRkMDItYmYyNS02YWVjY2Y3ZWE0MTkiLCJpYXQiOjE2ODY5OTMxODIsImV4cCI6MTY4Njk5MzQ4Mn0.F_FD6nJ5fssR_47v2XFhtzqjr-wrEQpqaWVq8iIlLJw';
```


After visit storybook and back to front it occurs 500 generic error from server and no way escape from it except clean cookies.

![error](https://github.com/twentyhq/twenty/assets/9631913/52cfb96a-cf51-4b54-8aaf-08add9b19b04)

I add a workaround to mitigate this problem. But it does not solve the issue completely, but redirect to login page at least.