### PR TITLE
fix docker dev

### DIFF
--- a/infra/dev/postgres/Dockerfile
+++ b/infra/dev/postgres/Dockerfile
@@ -4,7 +4,22 @@ FROM postgres:${PG_MAIN_VERSION} as postgres
 
 ARG PG_MAIN_VERSION
 ARG PG_GRAPHQL_VERSION=1.3.0
-ARG TARGETARCH=arm64
+ARG TARGETARCH
+
+RUN set -eux; \
+    ARCH="$(dpkg --print-architecture)"; \
+    case "${ARCH}" in \
+       aarch64|arm64) \
+         TARGETARCH='arm64'; \
+         ;; \
+       amd64|x86_64) \
+         TARGETARCH='amd64'; \
+         ;; \
+       *) \
+         echo "Unsupported arch: ${ARCH}"; \
+         exit 1; \
+         ;; \
+    esac;
 
 RUN apt update && apt install -y curl
 


### PR DESCRIPTION
Lets fix the docker's dev infa for all the possible TARGETARCH.

Before:
```
[+] Building 0.2s (8/9)                                                                                                                              docker:default
 => [postgres internal] load build definition from Dockerfile                                                                                                  0.0s
 => => transferring dockerfile: 915B                                                                                                                           0.0s
 => [postgres internal] load .dockerignore                                                                                                                     0.0s
 => => transferring context: 2B                                                                                                                                0.0s
 => [postgres internal] load metadata for docker.io/library/postgres:14                                                                                        0.0s
 => [postgres 1/5] FROM docker.io/library/postgres:14                                                                                                          0.0s
 => [postgres internal] load build context                                                                                                                     0.0s
 => => transferring context: 30B                                                                                                                               0.0s
 => CACHED [postgres 2/5] RUN apt update && apt install -y curl                                                                                                0.0s
 => CACHED [postgres 3/5] RUN curl -L "https://github.com/supabase/pg_graphql/releases/download/v1.3.0/pg_graphql-v1.3.0-pg14-arm64-linux-gnu.deb" -o pg_grap  0.0s
 => ERROR [postgres 4/5] RUN dpkg --install pg_graphql.deb                                                                                                     0.2s
------
 > [postgres 4/5] RUN dpkg --install pg_graphql.deb:
0.132 dpkg: error processing archive pg_graphql.deb (--install):
0.132  package architecture (arm64) does not match system (amd64)
0.139 Errors were encountered while processing:
0.139  pg_graphql.deb
------
failed to solve: process "/bin/sh -c dpkg --install pg_graphql.deb" did not complete successfully: exit code: 1
make: *** [Makefile:9: provision-postgres] Error 17

```

After:
```
[+] Building 0.1s (11/11) FINISHED                                                                                                                   docker:default
 => [postgres internal] load build definition from Dockerfile                                                                                                  0.0s
 => => transferring dockerfile: 881B                                                                                                                           0.0s 
 => [postgres internal] load .dockerignore                                                                                                                     0.0s 
 => => transferring context: 2B                                                                                                                                0.0s 
 => [postgres internal] load metadata for docker.io/library/postgres:14                                                                                        0.0s 
 => [postgres 1/6] FROM docker.io/library/postgres:14                                                                                                          0.0s 
 => [postgres internal] load build context                                                                                                                     0.0s 
 => => transferring context: 30B                                                                                                                               0.0s 
 => CACHED [postgres 2/6] RUN set -eux;     ARCH="$(dpkg --print-architecture)";     case "${ARCH}" in        aarch64|arm64)          TARGETARCH='arm64';      0.0s 
 => CACHED [postgres 3/6] RUN apt update && apt install -y curl                                                                                                0.0s 
 => CACHED [postgres 4/6] RUN curl -L "https://github.com/supabase/pg_graphql/releases/download/v1.3.0/pg_graphql-v1.3.0-pg14-amd64-linux-gnu.deb" -o pg_grap  0.0s 
 => CACHED [postgres 5/6] RUN dpkg --install pg_graphql.deb                                                                                                    0.0s 
 => CACHED [postgres 6/6] COPY init.sql /docker-entrypoint-initdb.d/                                                                                           0.0s 
 => [postgres] exporting to image                                                                                                                              0.0s 
 => => exporting layers                                                                                                                                        0.0s 
 => => writing image sha256:f4515ef3ad39cffd1d0b573e282ccb5d24b690a8b124c09b0b3158d60ca5e270                                                                   0.0s 
 => => naming to docker.io/library/dev-postgres                                                                                                                0.0s 
[+] Running 2/2
 ✔ Network dev_default       Created                                                                                                                           0.0s 
 ✔ Container dev-postgres-1  Started    
```

OS: Windows10

Client:
-  Cloud integration: v1.0.35-desktop+001     
-  Version:           24.0.5
-  API version:       1.43
-  Go version:        go1.20.6
-  Git commit:        ced0996
-  Built:             Fri Jul 21 20:36:24 2023
-  OS/Arch:           windows/amd64
-  Context:           default

Server: Docker Desktop 4.22.1 (118664)
-  Engine:
-   - Version:          24.0.5
-   - API version:      1.43 (minimum version 1.12)
-   - Go version:       go1.20.6
-   - Git commit:       a61e2b4
-   - Built:            Fri Jul 21 20:35:45 2023
-   - OS/Arch:          linux/amd64
-   - Experimental:     true
-  containerd:
-   - Version:          1.6.21
-   - GitCommit:        3dce8eb055cbb6872793272b4f20ed16117344f8
-  runc:
-   - Version:          1.1.7
-   - GitCommit:        v1.1.7-0-g860f061
-  docker-init:
-   - Version:          0.19.0
-   - GitCommit:        de40ad0