### PR TITLE
Add troubleshooting doc

### DIFF
--- a/docs/docs/developer/additional/troubleshooting.mdx
+++ b/docs/docs/developer/additional/troubleshooting.mdx
@@ -1,0 +1,26 @@
+---
+sidebar_position: 2
+sidebar_custom_props:
+  icon: TbExclamationCircle
+---
+
+# Troubleshooting
+
+
+## Windows setup eslint prettier error: `CR` line breaks found
+
+This is due to the linebreak characters of windows and the git configuration. Try running:
+```
+git config --global core.autocrlf false
+```
+
+Then delete the repository and clone it again.
+
+
+## Yarn lock file changed and new files are created (`yarn.lock`, `.yarnrc.yml`, `.yarn`)
+
+Maybe you are using yarn 3? Try installing [yarn classic](https://classic.yarnpkg.com/lang/en/)!
+
+## 
+
+Maybe you are using yarn 3? Try installing [yarn classic](https://classic.yarnpkg.com/lang/en/)!

--- a/docs/docs/developer/additional/troubleshooting.mdx
+++ b/docs/docs/developer/additional/troubleshooting.mdx
@@ -20,7 +20,3 @@ Then delete the repository and clone it again.
 ## Yarn lock file changed and new files are created (`yarn.lock`, `.yarnrc.yml`, `.yarn`)
 
 Maybe you are using yarn 3? Try installing [yarn classic](https://classic.yarnpkg.com/lang/en/)!
-
-## 
-
-Maybe you are using yarn 3? Try installing [yarn classic](https://classic.yarnpkg.com/lang/en/)!

--- a/docs/src/theme/icons.js
+++ b/docs/src/theme/icons.js
@@ -12,6 +12,7 @@ export {
   TbChecklist,
   TbCloud,
   TbDeviceDesktop,
+  TbExclamationCircle,
   TbEyeglass,
   TbFaceIdError,
   TbFolder,


### PR DESCRIPTION
Added Troubleshooting to the docs for:

* The `CR` linebreak problems on windows
* The yarn3 vs yarn classic problem (that was a thing I wondered for so long why the lock files were always changed)

I moved the troubleshooting section to its own page instead of placing it at the Windows setup (I hope that's okay for you ;) )

closes #1842