### PR TITLE
Remove company avatar show page hover effect

### DIFF
--- a/front/src/modules/ui/layout/show-page/components/ShowPageSummaryCard.tsx
+++ b/front/src/modules/ui/layout/show-page/components/ShowPageSummaryCard.tsx
@@ -92,7 +92,7 @@ export const ShowPageSummaryCard = ({
     if (e.target.files) onUploadPicture?.(e.target.files[0]);
   };
   const handleAvatarClick = () => {
-    if (onUploadPicture) inputFileRef?.current?.click?.();
+    inputFileRef?.current?.click?.();
   };
 
   return (
@@ -100,7 +100,7 @@ export const ShowPageSummaryCard = ({
       <StyledAvatarWrapper>
         <Avatar
           avatarUrl={logoOrAvatar}
-          onClick={handleAvatarClick}
+          onClick={onUploadPicture ? handleAvatarClick : undefined}
           size="xl"
           colorId={id}
           placeholder={title}

--- a/front/src/modules/users/components/Avatar.tsx
+++ b/front/src/modules/users/components/Avatar.tsx
@@ -83,7 +83,8 @@ const StyledAvatar = styled.div<AvatarProps & { colorId: string }>`
   }};
 
   &:hover {
-    box-shadow: 0 0 0 4px ${({ theme }) => theme.background.transparent.light};
+    box-shadow: ${({ theme, onClick }) =>
+      onClick ? '0 0 0 4px ' + theme.background.transparent.light : 'unset'};
   }
 `;
 


### PR DESCRIPTION
As we cannot upload an image for companies and instead fetch them from the URL, there shouldn't be any effect to indicate a click on the company avatar. 

Before:


https://github.com/twentyhq/twenty/assets/48770548/d8046961-5ff9-4eb1-874f-48022830014a



Suggestion:


https://github.com/twentyhq/twenty/assets/48770548/60e6be36-23e2-4122-8736-e5461ddf91a6



@Bonapara What are your thoughts on this?