### PR TITLE
Fix long text issue on people dropdown picker

### DIFF
--- a/front/src/modules/ui/menu-item/internals/components/StyledMenuItemBase.tsx
+++ b/front/src/modules/ui/menu-item/internals/components/StyledMenuItemBase.tsx
@@ -66,8 +66,12 @@ export const StyledMenuItemBase = styled.li<MenuItemBaseProps>`
 export const StyledMenuItemLabel = styled.div<{ hasLeftIcon: boolean }>`
   font-size: ${({ theme }) => theme.font.size.sm};
   font-weight: ${({ theme }) => theme.font.weight.regular};
+  overflow: hidden;
   padding-left: ${({ theme, hasLeftIcon }) =>
     hasLeftIcon ? '' : theme.spacing(1)};
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 100%;
 `;
 
 export const StyledNoIconFiller = styled.div`
@@ -81,6 +85,7 @@ export const StyledMenuItemLeftContent = styled.div`
   flex-direction: row;
 
   gap: ${({ theme }) => theme.spacing(1)};
+  width: 100%;
 `;
 
 export const StyledMenuItemRightContent = styled.div`

--- a/front/src/modules/ui/menu-item/internals/components/StyledMenuItemBase.tsx
+++ b/front/src/modules/ui/menu-item/internals/components/StyledMenuItemBase.tsx
@@ -71,7 +71,6 @@ export const StyledMenuItemLabel = styled.div<{ hasLeftIcon: boolean }>`
     hasLeftIcon ? '' : theme.spacing(1)};
   text-overflow: ellipsis;
   white-space: nowrap;
-  width: 100%;
 `;
 
 export const StyledNoIconFiller = styled.div`
@@ -86,6 +85,7 @@ export const StyledMenuItemLeftContent = styled.div`
 
   gap: ${({ theme }) => theme.spacing(1)};
   min-width: 0;
+  width: 100%;
 `;
 
 export const StyledMenuItemRightContent = styled.div`

--- a/front/src/modules/ui/menu-item/internals/components/StyledMenuItemBase.tsx
+++ b/front/src/modules/ui/menu-item/internals/components/StyledMenuItemBase.tsx
@@ -86,7 +86,6 @@ export const StyledMenuItemLeftContent = styled.div`
 
   gap: ${({ theme }) => theme.spacing(1)};
   min-width: 0;
-  width: 100%;
 `;
 
 export const StyledMenuItemRightContent = styled.div`

--- a/front/src/modules/ui/menu-item/internals/components/StyledMenuItemBase.tsx
+++ b/front/src/modules/ui/menu-item/internals/components/StyledMenuItemBase.tsx
@@ -85,6 +85,7 @@ export const StyledMenuItemLeftContent = styled.div`
   flex-direction: row;
 
   gap: ${({ theme }) => theme.spacing(1)};
+  min-width: 0;
   width: 100%;
 `;
 


### PR DESCRIPTION
Fix Long text for People Dropdown Picker using CSS properties:-


![dropdown_fix](https://github.com/twentyhq/twenty/assets/57754267/1525a6b7-77a4-4618-b586-263aee305aad)
