### PR TITLE
Fix `@docker-compose` error

### DIFF
--- a/infra/dev/Makefile
+++ b/infra/dev/Makefile
@@ -6,7 +6,7 @@ build:
 	@docker-compose build
 
 provision-postgres:
-	@docker-compose up postgres -d
+	@docker-compose up -d postgres
 
 up:
 	@docker-compose up -d


### PR DESCRIPTION
```bash
ERROR: No such service: -d
make[1]: *** [Makefile:9: provision-postgres] Error 1
make[1]: Leaving directory /home/tsgo/devel/proj/twenty/infra/dev
make: *** [Makefile:2: provision-postgres] Error 2
```