### PR TITLE
Fix/1734/selecting and releasing mouse

### DIFF
--- a/front/src/modules/ui/input/components/TextInput.tsx
+++ b/front/src/modules/ui/input/components/TextInput.tsx
@@ -37,6 +37,7 @@ export const TextInput = ({
   const [internalText, setInternalText] = useState(value);
 
   const wrapperRef = useRef(null);
+  const isSelectingTextInInput = useRef<boolean>(false);
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     setInternalText(event.target.value);
@@ -46,12 +47,22 @@ export const TextInput = ({
     setInternalText(value);
   }, [value]);
 
+  const onClickOutsideNew = (
+    event: MouseEvent | TouchEvent,
+    inputValue: string,
+  ) => {
+    if (!isSelectingTextInInput.current) {
+      onClickOutside(event, inputValue);
+    }
+    isSelectingTextInInput.current = false;
+  };
+
   useRegisterInputEvents({
     inputRef: wrapperRef,
     inputValue: internalText,
     onEnter,
     onEscape,
-    onClickOutside,
+    onClickOutside: onClickOutsideNew,
     onTab,
     onShiftTab,
     hotkeyScope,
@@ -65,6 +76,12 @@ export const TextInput = ({
       onChange={handleChange}
       autoFocus={autoFocus}
       value={internalText}
+      onMouseDown={() => {
+        isSelectingTextInInput.current = true;
+      }}
+      onMouseUp={() => {
+        isSelectingTextInInput.current = false;
+      }}
     />
   );
 };

--- a/front/src/modules/ui/input/components/TextInput.tsx
+++ b/front/src/modules/ui/input/components/TextInput.tsx
@@ -37,7 +37,7 @@ export const TextInput = ({
   const [internalText, setInternalText] = useState(value);
 
   const wrapperRef = useRef(null);
-  const isSelectingTextInInput = useRef<boolean>(false);
+  const isOutsideMouseReleased = useRef<boolean>(false);
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     setInternalText(event.target.value);
@@ -47,14 +47,14 @@ export const TextInput = ({
     setInternalText(value);
   }, [value]);
 
-  const onClickOutsideNew = (
+  const onClickOutsideWithConditions = (
     event: MouseEvent | TouchEvent,
     inputValue: string,
   ) => {
-    if (!isSelectingTextInInput.current) {
+    if (!isOutsideMouseReleased.current) {
       onClickOutside(event, inputValue);
     }
-    isSelectingTextInInput.current = false;
+    isOutsideMouseReleased.current = false;
   };
 
   useRegisterInputEvents({
@@ -62,7 +62,7 @@ export const TextInput = ({
     inputValue: internalText,
     onEnter,
     onEscape,
-    onClickOutside: onClickOutsideNew,
+    onClickOutside: onClickOutsideWithConditions,
     onTab,
     onShiftTab,
     hotkeyScope,
@@ -77,10 +77,10 @@ export const TextInput = ({
       autoFocus={autoFocus}
       value={internalText}
       onMouseDown={() => {
-        isSelectingTextInInput.current = true;
+        isOutsideMouseReleased.current = true;
       }}
       onMouseUp={() => {
-        isSelectingTextInInput.current = false;
+        isOutsideMouseReleased.current = false;
       }}
     />
   );


### PR DESCRIPTION
Fixed #1734 

## Selecting and releasing the mouse outside of an edit cell will not close that cell

## OnMouseDown and onMouseUp Flow:
- When we click on any input box (cell ) then onMouseDown is called
- And then if we leave the mouse in that input box then onMouseUp is called
- but if we leave the mouse outside the input box then onMouseUp is not called

## How i fixed:
- Setting `isOutsideMouseReleased.current` true in onMouseDown and then setting false it in onMouseUp
- it means if the user leaves the mouse outside the input box then `isOutsideMouseReleased.current` will be true
- then based on this we are calling the outsideclick function (whether it is clicked outside or not)
- then after that, we are again setting `isOutsideMouseReleased.current` false

 
[Screencast from 09-10-23 02:31:35 AM CDT.webm](https://github.com/twentyhq/twenty/assets/76877003/76ebc75a-1223-4de8-a47c-ccf5afd40519)
