### PR TITLE
fix fields appear

### DIFF
--- a/front/src/modules/ui/view-bar/components/ViewFieldsVisibilityDropdownSection.tsx
+++ b/front/src/modules/ui/view-bar/components/ViewFieldsVisibilityDropdownSection.tsx
@@ -47,17 +47,7 @@ export const ViewFieldsVisibilityDropdownSection = ({
   };
 
   const getIconButtons = (index: number, field: ViewFieldForVisibility) => {
-    const isFirstColumn = isDraggable && index === 0;
-    if (isFirstColumn && field.infoTooltipContent) {
-      return [
-        {
-          Icon: IconInfoCircle,
-          onClick: () => handleInfoButtonClick(index),
-          isActive: openToolTipIndex === index,
-        },
-      ];
-    }
-    if (!isFirstColumn && field.infoTooltipContent) {
+    if (field.infoTooltipContent) {
       return [
         {
           Icon: IconInfoCircle,
@@ -70,7 +60,7 @@ export const ViewFieldsVisibilityDropdownSection = ({
         },
       ];
     }
-    if (!isFirstColumn && !field.infoTooltipContent) {
+    if (!field.infoTooltipContent) {
       return [
         {
           Icon: field.isVisible ? IconMinus : IconPlus,
@@ -98,25 +88,27 @@ export const ViewFieldsVisibilityDropdownSection = ({
             onDragEnd={handleOnDrag}
             draggableItems={
               <>
-                {fields.map((field, index) => (
-                  <DraggableItem
-                    key={field.key}
-                    draggableId={field.key}
-                    index={index}
-                    isDragDisabled={index === 0}
-                    itemComponent={
-                      <MenuItemDraggable
-                        key={field.key}
-                        LeftIcon={field.Icon}
-                        iconButtons={getIconButtons(index, field)}
-                        isTooltipOpen={openToolTipIndex === index}
-                        text={field.name}
-                        isDragDisabled={index === 0}
-                        className={`${title}-draggable-item-tooltip-anchor-${index}`}
-                      />
-                    }
-                  />
-                ))}
+                {fields
+                  .filter(({ index, size }) => index !== 0 || !size)
+                  .map((field, index) => (
+                    <DraggableItem
+                      key={field.key}
+                      draggableId={field.key}
+                      index={index + 1}
+                      itemComponent={
+                        <MenuItemDraggable
+                          key={field.key}
+                          LeftIcon={field.Icon}
+                          iconButtons={getIconButtons(index + 1, field)}
+                          isTooltipOpen={openToolTipIndex === index + 1}
+                          text={field.name}
+                          className={`${title}-draggable-item-tooltip-anchor-${
+                            index + 1
+                          }`}
+                        />
+                      }
+                    />
+                  ))}
               </>
             }
           />

--- a/front/src/modules/ui/view-bar/types/ViewFieldForVisibility.ts
+++ b/front/src/modules/ui/view-bar/types/ViewFieldForVisibility.ts
@@ -7,4 +7,5 @@ export type ViewFieldForVisibility = Pick<
 > & {
   isVisible?: boolean;
   index: number;
+  size?: number | undefined;
 };


### PR DESCRIPTION
Fix https://github.com/twentyhq/twenty/issues/1886
Fix Fields appears depending on index and size.
So we exclude every field with index eq. 0 or the size is  not set.
Becouse board's fields do not have size.

P.S. For real its should be backend solution with adding field "sticky" into viewFiels table.