### PR TITLE
Fix: Broken "local-setup" link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,5 +134,5 @@ Here’s what you can look forward to:
 
 Dive into Twenty today and experience the power of open-source CRM on your own terms.
 
-🚀 [Get Started with Twenty](https://docs.twenty.com/contributor/local-setup). 
+🚀 [Get Started with Twenty](https://docs.twenty.com/developer/local-setup). 
 


### PR DESCRIPTION
Fixed a broken link to "Local Setup" in the readme.

Before:

![image](https://github.com/twentyhq/twenty/assets/41571384/d6b647b3-1d65-4c3e-8770-b03907fb998a)
