### PR TITLE
Refactor RelationFieldDisplay to eliminate dependency on non-ui components

### DIFF
--- a/front/src/modules/companies/components/CompanyBoardCard.tsx
+++ b/front/src/modules/companies/components/CompanyBoardCard.tsx
@@ -135,6 +135,12 @@ export const CompanyBoardCard = () => {
     </StyledFieldContainer>
   );
 
+  type Toto = {
+    id: string;
+    name: string;
+    domainName: string;
+  };
+
   return (
     <StyledBoardCardWrapper>
       <StyledBoardCard
@@ -170,6 +176,7 @@ export const CompanyBoardCard = () => {
                     type: viewField.type,
                     metadata: viewField.metadata,
                     buttonIcon: viewField.buttonIcon,
+                    entityChipDisplayMapper: viewField.entityChipDisplayMapper,
                   },
                   useUpdateEntityMutation: useUpdateOnePipelineProgressMutation,
                   hotkeyScope: InlineCellHotkeyScope.InlineCell,

--- a/front/src/modules/companies/components/CompanyBoardCard.tsx
+++ b/front/src/modules/companies/components/CompanyBoardCard.tsx
@@ -135,12 +135,6 @@ export const CompanyBoardCard = () => {
     </StyledFieldContainer>
   );
 
-  type Toto = {
-    id: string;
-    name: string;
-    domainName: string;
-  };
-
   return (
     <StyledBoardCardWrapper>
       <StyledBoardCard

--- a/front/src/modules/companies/constants/companiesAvailableColumnDefinitions.tsx
+++ b/front/src/modules/companies/constants/companiesAvailableColumnDefinitions.tsx
@@ -25,6 +25,7 @@ import {
   IconUsers,
 } from '@/ui/icon/index';
 import { Entity } from '@/ui/input/relation-picker/types/EntityTypeForSelect';
+import { User } from '~/generated/graphql';
 
 export const companiesAvailableColumnDefinitions: ColumnDefinition<FieldMetadata>[] =
   [
@@ -76,6 +77,13 @@ export const companiesAvailableColumnDefinitions: ColumnDefinition<FieldMetadata
       isVisible: true,
       infoTooltipContent:
         'Your team member responsible for managing the company account.',
+      entityChipDisplayMapper: (dataObject: User) => {
+        return {
+          name: dataObject?.displayName,
+          pictureUrl: dataObject?.avatarUrl ?? undefined,
+          avatarType: 'rounded',
+        };
+      },
     } satisfies ColumnDefinition<FieldRelationMetadata>,
     {
       key: 'createdAt',

--- a/front/src/modules/people/constants/peopleAvailableColumnDefinitions.tsx
+++ b/front/src/modules/people/constants/peopleAvailableColumnDefinitions.tsx
@@ -23,6 +23,8 @@ import {
   IconUser,
 } from '@/ui/icon/index';
 import { Entity } from '@/ui/input/relation-picker/types/EntityTypeForSelect';
+import { Company } from '~/generated/graphql';
+import { getLogoUrlFromDomainName } from '~/utils';
 
 export const peopleAvailableColumnDefinitions: ColumnDefinition<FieldMetadata>[] =
   [
@@ -71,6 +73,13 @@ export const peopleAvailableColumnDefinitions: ColumnDefinition<FieldMetadata>[]
         relationType: Entity.Company,
       },
       infoTooltipContent: 'Contact’s company.',
+      entityChipDisplayMapper: (dataObject: Company) => {
+        return {
+          name: dataObject?.name,
+          pictureUrl: getLogoUrlFromDomainName(dataObject?.domainName),
+          avatarType: 'squared',
+        };
+      },
     } satisfies ColumnDefinition<FieldRelationMetadata>,
     {
       key: 'phone',

--- a/front/src/modules/pipeline/constants/pipelineAvailableFieldDefinitions.tsx
+++ b/front/src/modules/pipeline/constants/pipelineAvailableFieldDefinitions.tsx
@@ -14,6 +14,7 @@ import {
   IconUser,
 } from '@/ui/icon';
 import { Entity } from '@/ui/input/relation-picker/types/EntityTypeForSelect';
+import { Person } from '~/generated/graphql';
 
 export const pipelineAvailableFieldDefinitions: BoardFieldDefinition<FieldMetadata>[] =
   [
@@ -70,5 +71,12 @@ export const pipelineAvailableFieldDefinitions: BoardFieldDefinition<FieldMetada
       isVisible: true,
       buttonIcon: IconPencil,
       infoTooltipContent: 'Primary contact within the company.',
+      entityChipDisplayMapper: (dataObject: Person) => {
+        return {
+          name: dataObject?.displayName,
+          pictureUrl: dataObject?.avatarUrl ?? undefined,
+          avatarType: 'rounded',
+        };
+      },
     } satisfies BoardFieldDefinition<FieldRelationMetadata>,
   ];

--- a/front/src/modules/ui/field/meta-types/display/components/RelationFieldDisplay.tsx
+++ b/front/src/modules/ui/field/meta-types/display/components/RelationFieldDisplay.tsx
@@ -1,52 +1,24 @@
-import { CompanyChip } from '@/companies/components/CompanyChip';
-import { PersonChip } from '@/people/components/PersonChip';
-import { Entity } from '@/ui/input/relation-picker/types/EntityTypeForSelect';
-import { UserChip } from '@/users/components/UserChip';
-import { getLogoUrlFromDomainName } from '~/utils';
-import { logError } from '~/utils/logError';
+import { EntityChip } from '@/ui/chip/components/EntityChip';
 
 import { useRelationField } from '../../hooks/useRelationField';
 
 export const RelationFieldDisplay = () => {
-  const { fieldDefinition, fieldValue } = useRelationField();
-
-  switch (fieldDefinition.metadata.relationType) {
-    case Entity.Person: {
-      return (
-        <PersonChip
-          id={fieldValue?.id ?? ''}
-          name={fieldValue?.displayName ?? ''}
-          pictureUrl={fieldValue?.avatarUrl ?? ''}
-        />
-      );
-    }
-    case Entity.User: {
-      return (
-        <UserChip
-          id={fieldValue?.id ?? ''}
-          name={fieldValue?.displayName ?? ''}
-          pictureUrl={fieldValue?.avatarUrl ?? ''}
-        />
-      );
-    }
-    case Entity.Company: {
-      return (
-        <CompanyChip
-          id={fieldValue?.id ?? ''}
-          name={fieldValue?.name ?? ''}
-          pictureUrl={
-            fieldValue?.domainName
-              ? getLogoUrlFromDomainName(fieldValue.domainName)
-              : ''
-          }
-        />
-      );
-    }
-    default:
-      logError(
-        `Unknown relation type: "${fieldDefinition.metadata.relationType}"
-          in RelationFieldDisplay`,
-      );
-      return <> </>;
+  const { fieldValue, fieldDefinition } = useRelationField();
+  const { entityChipDisplayMapper } = fieldDefinition;
+  if (!entityChipDisplayMapper) {
+    throw new Error(
+      "Missing entityChipDisplayMapper in FieldContext. Please provide it in the FieldContextProvider's value prop.",
+    );
   }
+  const { name, pictureUrl, avatarType } =
+    entityChipDisplayMapper?.(fieldValue);
+
+  return (
+    <EntityChip
+      entityId={fieldValue?.id}
+      name={name}
+      pictureUrl={pictureUrl}
+      avatarType={avatarType}
+    />
+  );
 };

--- a/front/src/modules/ui/field/types/FieldDefinition.ts
+++ b/front/src/modules/ui/field/types/FieldDefinition.ts
@@ -1,4 +1,5 @@
 import { IconComponent } from '@/ui/icon/types/IconComponent';
+import { AvatarType } from '@/users/components/Avatar';
 
 import { FieldMetadata } from './FieldMetadata';
 import { FieldType } from './FieldType';
@@ -12,4 +13,9 @@ export type FieldDefinition<T extends FieldMetadata> = {
   buttonIcon?: IconComponent;
   basePathToShowPage?: string;
   infoTooltipContent?: string;
+  entityChipDisplayMapper?: (dataObject: any) => {
+    name: string;
+    pictureUrl?: string;
+    avatarType: AvatarType;
+  };
 };

--- a/front/src/modules/ui/field/types/guards/isFieldRelationWithDisplayMapper.ts
+++ b/front/src/modules/ui/field/types/guards/isFieldRelationWithDisplayMapper.ts
@@ -1,0 +1,6 @@
+import { FieldDefinition } from '../FieldDefinition';
+import { FieldMetadata, FieldRelationMetadata } from '../FieldMetadata';
+
+export const isFieldRelation = (
+  field: FieldDefinition<FieldMetadata>,
+): field is FieldDefinition<FieldRelationMetadata> => field.type === 'relation';

--- a/front/src/modules/ui/field/types/guards/isFieldRelationWithDisplayMapper.ts
+++ b/front/src/modules/ui/field/types/guards/isFieldRelationWithDisplayMapper.ts
@@ -1,6 +1,0 @@
-import { FieldDefinition } from '../FieldDefinition';
-import { FieldMetadata, FieldRelationMetadata } from '../FieldMetadata';
-
-export const isFieldRelation = (
-  field: FieldDefinition<FieldMetadata>,
-): field is FieldDefinition<FieldRelationMetadata> => field.type === 'relation';


### PR DESCRIPTION
- Used generic entity chip in RelationFieldDisplay
- Created a custom hard-coded temporary mapper in front/src/modules/companies/constants/companiesAvailableColumnDefinitions.tsx, front/src/modules/people/constants/peopleAvailableColumnDefinitions.tsx and front/src/modules/pipeline/constants/pipelineAvailableFieldDefinitions.tsx
- Added the entityChipDisplayMapper in FieldDefinition type in front/src/modules/ui/field/types/FieldDefinition.ts