### PR TITLE
Improve docker db init / reset (#1981)

### DIFF
--- a/infra/dev/Makefile
+++ b/infra/dev/Makefile
@@ -6,7 +6,11 @@ build:
 	@docker compose build
 
 provision-postgres:
-	@docker compose up postgres -d
+	@docker version > /dev/null 2>&1 || (echo "Docker is not running" && exit 1)
+	@docker stop twenty_postgres || true
+	@docker rm twenty_postgres || true
+	@docker volume rm twenty_db_data || true
+	@docker compose up --build postgres -d
 
 up:
 	@docker compose up -d

--- a/infra/dev/docker-compose.yml
+++ b/infra/dev/docker-compose.yml
@@ -24,9 +24,10 @@ services:
       - ../../docs:/app/docs
       - twenty_node_modules_docs:/app/docs/node_modules
   postgres:
+    container_name: twenty_postgres
     build: ./postgres
     volumes:
-    - db_data:/var/lib/postgresql/data
+    - twenty_db_data:/var/lib/postgresql/data
     environment:
       - POSTGRES_USER=twenty
       - POSTGRES_PASSWORD=twenty
@@ -34,7 +35,8 @@ services:
     ports:
       - "5432:5432"
 volumes:
-  db_data:
+  twenty_db_data:
+    name: twenty_db_data
   twenty_node_modules_front:
   twenty_node_modules_server:
   twenty_node_modules_docs:


### PR DESCRIPTION
* renamed volume name db_data to twenty_db_data
* named postgres container_name: twenty_postgres

make provision-postgres does:
* checking if docker is running
* stop the container postgres twenty_postgres
* prune the volume twenty_db_data
* rebuild the image every time, use --build