### PR TITLE
Add type guard library to front-end

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -15,6 +15,7 @@
     "@floating-ui/react": "^0.24.3",
     "@hello-pangea/dnd": "^16.2.0",
     "@hookform/resolvers": "^3.1.1",
+    "@sniptt/guards": "^0.2.0",
     "@tabler/icons-react": "^2.30.0",
     "@tanstack/react-virtual": "^3.0.0-alpha.0",
     "@types/node": "^16.18.4",


### PR DESCRIPTION
Closes #1888 
Since suggested library covers all basic type guards , it was installed to the project without re implementing basic type guards as utils . 