### PR TITLE
Fix docker db init / reset for Windows (#1981)

### DIFF
--- a/infra/dev/Makefile
+++ b/infra/dev/Makefile
@@ -6,7 +6,6 @@ build:
 	@docker compose build
 
 provision-postgres:
-	@docker version > /dev/null 2>&1 || (echo "Docker is not running" && exit 1)
 	@docker stop twenty_postgres || true
 	@docker rm twenty_postgres || true
 	@docker volume rm twenty_db_data || true


### PR DESCRIPTION
* removed checking if docker is running with /dev/null