### PR TITLE
Fix broken link in README.md for local setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,5 +140,5 @@ Here’s what you can look forward to:
 
 Dive into Twenty today and experience the power of open-source CRM on your own terms.
 
-🚀 [Get Started with Twenty](https://docs.twenty.com/developer/local-setup). 
+🚀 [Get Started with Twenty](https://docs.twenty.com/contributor/local-setup). 
 


### PR DESCRIPTION
### Fix Broken Link in README.md

#### Issue Description:
The link for local env setup in README.md was pointing to a non-existing page.

#### Changes:
- Updated the link to point to the correct `local-setup` page as per the comment by @encg.

#### Fixes:
- Issue #2024

Kindly review the changes and let me know if there are any modifications needed. Thanks!
