### PR TITLE
Refactor sortsOrderBy & filtersWhere on CompanyTable & PeopleTable

### DIFF
--- a/front/src/modules/companies/table/components/CompanyTable.tsx
+++ b/front/src/modules/companies/table/components/CompanyTable.tsx
@@ -9,9 +9,6 @@ import { TableContext } from '@/ui/data/data-table/contexts/TableContext';
 import { useUpsertDataTableItem } from '@/ui/data/data-table/hooks/useUpsertDataTableItem';
 import { TableRecoilScopeContext } from '@/ui/data/data-table/states/recoil-scope-contexts/TableRecoilScopeContext';
 import { ViewBarContext } from '@/ui/data/view-bar/contexts/ViewBarContext';
-import { filtersWhereScopedSelector } from '@/ui/data/view-bar/states/selectors/filtersWhereScopedSelector';
-import { sortsOrderByScopedSelector } from '@/ui/data/view-bar/states/selectors/sortsOrderByScopedSelector';
-import { useRecoilScopedValue } from '@/ui/utilities/recoil-scope/hooks/useRecoilScopedValue';
 import { useTableViews } from '@/views/hooks/useTableViews';
 import {
   UpdateOneCompanyMutationVariables,
@@ -23,15 +20,6 @@ import { companiesFilters } from '~/pages/companies/companies-filters';
 import { companyAvailableSorts } from '~/pages/companies/companies-sorts';
 
 export const CompanyTable = () => {
-  const sortsOrderBy = useRecoilScopedValue(
-    sortsOrderByScopedSelector,
-    TableRecoilScopeContext,
-  );
-  const filtersWhere = useRecoilScopedValue(
-    filtersWhereScopedSelector,
-    TableRecoilScopeContext,
-  );
-
   const [updateEntityMutation] = useUpdateOneCompanyMutation();
   const upsertDataTableItem = useUpsertDataTableItem();
 
@@ -89,8 +77,6 @@ export const CompanyTable = () => {
         getRequestOptimisticEffectDefinition={
           getCompaniesOptimisticEffectDefinition
         }
-        orderBy={sortsOrderBy}
-        whereFilters={filtersWhere}
         filterDefinitionArray={companiesFilters}
         sortDefinitionArray={companyAvailableSorts}
         setContextMenuEntries={setContextMenuEntries}

--- a/front/src/modules/people/table/components/PeopleTable.tsx
+++ b/front/src/modules/people/table/components/PeopleTable.tsx
@@ -9,9 +9,6 @@ import { TableContext } from '@/ui/data/data-table/contexts/TableContext';
 import { useUpsertDataTableItem } from '@/ui/data/data-table/hooks/useUpsertDataTableItem';
 import { TableRecoilScopeContext } from '@/ui/data/data-table/states/recoil-scope-contexts/TableRecoilScopeContext';
 import { ViewBarContext } from '@/ui/data/view-bar/contexts/ViewBarContext';
-import { filtersWhereScopedSelector } from '@/ui/data/view-bar/states/selectors/filtersWhereScopedSelector';
-import { sortsOrderByScopedSelector } from '@/ui/data/view-bar/states/selectors/sortsOrderByScopedSelector';
-import { useRecoilScopedValue } from '@/ui/utilities/recoil-scope/hooks/useRecoilScopedValue';
 import { useTableViews } from '@/views/hooks/useTableViews';
 import {
   UpdateOnePersonMutationVariables,
@@ -22,15 +19,6 @@ import { peopleFilters } from '~/pages/people/people-filters';
 import { peopleAvailableSorts } from '~/pages/people/people-sorts';
 
 export const PeopleTable = () => {
-  const sortsOrderBy = useRecoilScopedValue(
-    sortsOrderByScopedSelector,
-    TableRecoilScopeContext,
-  );
-  const filtersWhere = useRecoilScopedValue(
-    filtersWhereScopedSelector,
-    TableRecoilScopeContext,
-  );
-
   const [updateEntityMutation] = useUpdateOnePersonMutation();
   const upsertDataTableItem = useUpsertDataTableItem();
   const { openPersonSpreadsheetImport } = useSpreadsheetPersonImport();
@@ -61,8 +49,6 @@ export const PeopleTable = () => {
         getRequestOptimisticEffectDefinition={
           getPeopleOptimisticEffectDefinition
         }
-        orderBy={sortsOrderBy}
-        whereFilters={filtersWhere}
         filterDefinitionArray={peopleFilters}
         setContextMenuEntries={setContextMenuEntries}
         setActionBarEntries={setActionBarEntries}


### PR DESCRIPTION
Remove sortsOrderBy and filtersWhere from CompanyTable & PeopleTable
Use sortsOrderBy & filtersWhere as commont hooks in DataTableEffect.