### PR TITLE
Add soft delete to metadata

### DIFF
--- a/server/src/metadata/field-metadata/dtos/create-field.input.ts
+++ b/server/src/metadata/field-metadata/dtos/create-field.input.ts
@@ -58,9 +58,4 @@ export class CreateFieldInput {
   @IsOptional()
   @Field({ nullable: true })
   icon?: string;
-
-  @IsString()
-  @IsOptional()
-  @Field({ nullable: true })
-  placeholder?: string;
 }

--- a/server/src/metadata/field-metadata/dtos/update-field.input.ts
+++ b/server/src/metadata/field-metadata/dtos/update-field.input.ts
@@ -34,11 +34,6 @@ export class UpdateFieldInput {
   @Field({ nullable: true })
   icon?: string;
 
-  @IsString()
-  @IsOptional()
-  @Field({ nullable: true })
-  placeholder?: string;
-
   @IsBoolean()
   @IsOptional()
   @Field({ nullable: true })

--- a/server/src/metadata/field-metadata/field-metadata.entity.ts
+++ b/server/src/metadata/field-metadata/field-metadata.entity.ts
@@ -3,6 +3,7 @@ import { Field, ID, ObjectType } from '@nestjs/graphql';
 import {
   Column,
   CreateDateColumn,
+  DeleteDateColumn,
   Entity,
   JoinColumn,
   ManyToOne,
@@ -76,8 +77,7 @@ export class FieldMetadata {
   @Column({ nullable: true, name: 'icon' })
   icon: string;
 
-  @Field({ nullable: true })
-  @Column({ nullable: true, name: 'placeholder' })
+  @Field({ nullable: true, deprecationReason: 'Use label name instead' })
   placeholder: string;
 
   @Column('text', { nullable: true, array: true })
@@ -109,4 +109,7 @@ export class FieldMetadata {
   @Field()
   @UpdateDateColumn({ name: 'updated_at' })
   updatedAt: Date;
+
+  @DeleteDateColumn({ name: 'deleted_at' })
+  deletedAt?: Date;
 }

--- a/server/src/metadata/field-metadata/services/field-metadata.service.ts
+++ b/server/src/metadata/field-metadata/services/field-metadata.service.ts
@@ -28,7 +28,7 @@ export class FieldMetadataService extends TypeOrmQueryService<FieldMetadata> {
     private readonly tenantMigrationService: TenantMigrationService,
     private readonly migrationRunnerService: MigrationRunnerService,
   ) {
-    super(fieldMetadataRepository);
+    super(fieldMetadataRepository, { useSoftDelete: true });
   }
 
   override async createOne(record: FieldMetadata): Promise<FieldMetadata> {

--- a/server/src/metadata/metadata.datasource.ts
+++ b/server/src/metadata/metadata.datasource.ts
@@ -8,6 +8,8 @@ import { InitMetadataTables1695214465080 } from './migrations/1695214465080-Init
 import { AlterFieldMetadataTable1695717691800 } from './migrations/1695717691800-alter-field-metadata-table';
 import { AddTargetColumnMap1696409050890 } from './migrations/1696409050890-add-target-column-map';
 import { MetadataNameLabelRefactoring1697126636202 } from './migrations/1697126636202-MetadataNameLabelRefactoring';
+import { RemoveFieldMetadataPlaceholder1697471445015 } from './migrations/1697471445015-removeFieldMetadataPlaceholder';
+import { AddSoftDelete1697474804403 } from './migrations/1697474804403-addSoftDelete';
 
 config();
 
@@ -27,6 +29,8 @@ export const typeORMMetadataModuleOptions: TypeOrmModuleOptions = {
     AlterFieldMetadataTable1695717691800,
     AddTargetColumnMap1696409050890,
     MetadataNameLabelRefactoring1697126636202,
+    RemoveFieldMetadataPlaceholder1697471445015,
+    AddSoftDelete1697474804403,
   ],
 };
 

--- a/server/src/metadata/migrations/1697471445015-removeFieldMetadataPlaceholder.ts
+++ b/server/src/metadata/migrations/1697471445015-removeFieldMetadataPlaceholder.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RemoveFieldMetadataPlaceholder1697471445015
+  implements MigrationInterface
+{
+  name = 'RemoveFieldMetadataPlaceholder1697471445015';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "metadata"."field_metadata" DROP COLUMN "placeholder"`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "metadata"."field_metadata" ADD "placeholder" character varying`,
+    );
+  }
+}

--- a/server/src/metadata/migrations/1697474804403-addSoftDelete.ts
+++ b/server/src/metadata/migrations/1697474804403-addSoftDelete.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddSoftDelete1697474804403 implements MigrationInterface {
+  name = 'AddSoftDelete1697474804403';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "metadata"."object_metadata" ADD "deleted_at" TIMESTAMP`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "metadata"."field_metadata" ADD "deleted_at" TIMESTAMP`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "metadata"."field_metadata" DROP COLUMN "deleted_at"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "metadata"."object_metadata" DROP COLUMN "deleted_at"`,
+    );
+  }
+}

--- a/server/src/metadata/object-metadata/object-metadata.auto-resolver-opts.ts
+++ b/server/src/metadata/object-metadata/object-metadata.auto-resolver-opts.ts
@@ -38,7 +38,6 @@ export const objectMetadataAutoResolverOpts: AutoResolverOpts<
     update: {
       many: { disabled: true },
     },
-    delete: { disabled: true },
     guards: [JwtAuthGuard],
   },
 ];

--- a/server/src/metadata/object-metadata/object-metadata.entity.ts
+++ b/server/src/metadata/object-metadata/object-metadata.entity.ts
@@ -3,6 +3,7 @@ import { ObjectType, ID, Field } from '@nestjs/graphql';
 import {
   Column,
   CreateDateColumn,
+  DeleteDateColumn,
   Entity,
   OneToMany,
   PrimaryGeneratedColumn,
@@ -92,4 +93,7 @@ export class ObjectMetadata {
   @Field()
   @UpdateDateColumn({ name: 'updated_at' })
   updatedAt: Date;
+
+  @DeleteDateColumn({ name: 'deleted_at' })
+  deletedAt?: Date;
 }

--- a/server/src/metadata/object-metadata/services/object-metadata.service.ts
+++ b/server/src/metadata/object-metadata/services/object-metadata.service.ts
@@ -18,7 +18,7 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadata> {
     private readonly tenantMigrationService: TenantMigrationService,
     private readonly migrationRunnerService: MigrationRunnerService,
   ) {
-    super(objectMetadataRepository);
+    super(objectMetadataRepository, { useSoftDelete: true });
   }
 
   override async createOne(record: ObjectMetadata): Promise<ObjectMetadata> {


### PR DESCRIPTION
## Context
In addition to deactivation, we want to be able to delete objects and fields from the UI.
Note: We introduced soft-deletion for now so we can restore when needed, the table and columns associated to the metadata won't be deleted either (but won't be accessible since the gql schema won't generate the corresponding query)

## Technical input
I'm using typeorm soft-deletion so it's quite simple to implement. 
The doc says "All reads from the typeorm repository will add a where clause checking that the column IS NULL", we can introduce a filter later if we want to fetch deleted objects/fields from the UI but we don't have any filter for now in metadata.

Note: I've also deprecated the placeholder field. This is not needed anymore since we decided it was not bringing any value and the frontend should use the label field for that. The column has been deleted through a migration but it's still available in the schema to avoid breaking changes with the FE, we'll be able to remove it from the entity file once its usage has been removed.