### PR TITLE
1809 new object add cancel and save buttons

### DIFF
--- a/front/src/modules/settings/components/SaveAndCancelButtons/CancelButton.tsx
+++ b/front/src/modules/settings/components/SaveAndCancelButtons/CancelButton.tsx
@@ -1,9 +1,11 @@
 import { Button } from '@/ui/input/button/components/Button';
 
 type CancelButtonProps = {
-  onClick?: () => void;
+  onCancel?: () => void;
 };
 
-export const CancelButton = ({ onClick }: CancelButtonProps) => {
-  return <Button title="Cancel" variant="tertiary" onClick={onClick} />;
+export const CancelButton = ({ onCancel }: CancelButtonProps) => {
+  return (
+    <Button title="Cancel" variant="tertiary" onClick={onCancel} size="small" />
+  );
 };

--- a/front/src/modules/settings/components/SaveAndCancelButtons/CancelButton.tsx
+++ b/front/src/modules/settings/components/SaveAndCancelButtons/CancelButton.tsx
@@ -1,11 +1,9 @@
-import { Button } from '@/ui/input/button/components/Button';
+import { LightButton } from '@/ui/input/button/components/LightButton';
 
 type CancelButtonProps = {
   onCancel?: () => void;
 };
 
 export const CancelButton = ({ onCancel }: CancelButtonProps) => {
-  return (
-    <Button title="Cancel" variant="tertiary" onClick={onCancel} size="small" />
-  );
+  return <LightButton title="Cancel" accent="tertiary" onClick={onCancel} />;
 };

--- a/front/src/modules/settings/components/SaveAndCancelButtons/CancelButton.tsx
+++ b/front/src/modules/settings/components/SaveAndCancelButtons/CancelButton.tsx
@@ -1,0 +1,9 @@
+import { Button } from '@/ui/input/button/components/Button';
+
+type CancelButtonProps = {
+  onClick?: () => void;
+};
+
+export const CancelButton = ({ onClick }: CancelButtonProps) => {
+  return <Button title="Cancel" variant="tertiary" onClick={onClick} />;
+};

--- a/front/src/modules/settings/components/SaveAndCancelButtons/SaveAndCancelButtons.tsx
+++ b/front/src/modules/settings/components/SaveAndCancelButtons/SaveAndCancelButtons.tsx
@@ -12,18 +12,18 @@ const StyledContainer = styled.div`
 type SaveAndCancelButtonsProps = {
   onSave?: () => void;
   onCancel?: () => void;
-  disabled?: boolean;
+  isSaveDisabled?: boolean;
 };
 
 export const SaveAndCancelButtons = ({
   onSave,
   onCancel,
-  disabled,
+  isSaveDisabled,
 }: SaveAndCancelButtonsProps) => {
   return (
     <StyledContainer>
       <CancelButton onCancel={onCancel} />
-      <SaveButton onSave={onSave} disabled={disabled} />
+      <SaveButton onSave={onSave} disabled={isSaveDisabled} />
     </StyledContainer>
   );
 };

--- a/front/src/modules/settings/components/SaveAndCancelButtons/SaveAndCancelButtons.tsx
+++ b/front/src/modules/settings/components/SaveAndCancelButtons/SaveAndCancelButtons.tsx
@@ -1,0 +1,29 @@
+import styled from '@emotion/styled';
+
+import { CancelButton } from './CancelButton';
+import { SaveButton } from './SaveButton';
+
+const StyledContainer = styled.div`
+  align-items: center;
+  display: flex;
+  gap: ${({ theme }) => theme.spacing(1)};
+`;
+
+type SaveAndCancelButtonsProps = {
+  onSave?: () => void;
+  onCancel?: () => void;
+  disabled?: boolean;
+};
+
+export const SaveAndCancelButtons = ({
+  onSave,
+  onCancel,
+  disabled,
+}: SaveAndCancelButtonsProps) => {
+  return (
+    <StyledContainer>
+      <CancelButton onClick={onCancel} />
+      <SaveButton onClick={onSave} disabled={disabled} />
+    </StyledContainer>
+  );
+};

--- a/front/src/modules/settings/components/SaveAndCancelButtons/SaveAndCancelButtons.tsx
+++ b/front/src/modules/settings/components/SaveAndCancelButtons/SaveAndCancelButtons.tsx
@@ -22,8 +22,8 @@ export const SaveAndCancelButtons = ({
 }: SaveAndCancelButtonsProps) => {
   return (
     <StyledContainer>
-      <CancelButton onClick={onCancel} />
-      <SaveButton onClick={onSave} disabled={disabled} />
+      <CancelButton onCancel={onCancel} />
+      <SaveButton onSave={onSave} disabled={disabled} />
     </StyledContainer>
   );
 };

--- a/front/src/modules/settings/components/SaveAndCancelButtons/SaveButton.tsx
+++ b/front/src/modules/settings/components/SaveAndCancelButtons/SaveButton.tsx
@@ -2,18 +2,19 @@ import { Button } from '@/ui/input/button/components/Button';
 import { IconDeviceFloppy } from '@/ui/input/constants/icons';
 
 type SaveButtonProps = {
-  onClick?: () => void;
+  onSave?: () => void;
   disabled?: boolean;
 };
 
-export const SaveButton = ({ onClick, disabled }: SaveButtonProps) => {
+export const SaveButton = ({ onSave, disabled }: SaveButtonProps) => {
   return (
     <Button
       title="Save"
       variant="primary"
+      size="small"
       accent="blue"
       disabled={disabled}
-      onClick={onClick}
+      onClick={onSave}
       Icon={IconDeviceFloppy}
     />
   );

--- a/front/src/modules/settings/components/SaveAndCancelButtons/SaveButton.tsx
+++ b/front/src/modules/settings/components/SaveAndCancelButtons/SaveButton.tsx
@@ -1,0 +1,20 @@
+import { Button } from '@/ui/input/button/components/Button';
+import { IconDeviceFloppy } from '@/ui/input/constants/icons';
+
+type SaveButtonProps = {
+  onClick?: () => void;
+  disabled?: boolean;
+};
+
+export const SaveButton = ({ onClick, disabled }: SaveButtonProps) => {
+  return (
+    <Button
+      title="Save"
+      variant="primary"
+      accent="blue"
+      disabled={disabled}
+      onClick={onClick}
+      Icon={IconDeviceFloppy}
+    />
+  );
+};

--- a/front/src/modules/settings/components/__stories__/CancelButton.stories.tsx
+++ b/front/src/modules/settings/components/__stories__/CancelButton.stories.tsx
@@ -12,9 +12,9 @@ type Story = StoryObj<typeof CancelButton>;
 
 export const Default: Story = {
   argTypes: {
-    onClick: { control: false },
+    onCancel: { control: false },
   },
   args: {
-    onClick: () => {},
+    onCancel: () => {},
   },
 };

--- a/front/src/modules/settings/components/__stories__/CancelButton.stories.tsx
+++ b/front/src/modules/settings/components/__stories__/CancelButton.stories.tsx
@@ -1,0 +1,20 @@
+import { Meta, StoryObj } from '@storybook/react';
+
+import { CancelButton } from '../SaveAndCancelButtons/CancelButton';
+
+const meta: Meta<typeof CancelButton> = {
+  title: 'Modules/Settings/CancelButton',
+  component: CancelButton,
+};
+
+export default meta;
+type Story = StoryObj<typeof CancelButton>;
+
+export const Default: Story = {
+  argTypes: {
+    onClick: { control: false },
+  },
+  args: {
+    onClick: () => {},
+  },
+};

--- a/front/src/modules/settings/components/__stories__/SaveButton.stories.tsx
+++ b/front/src/modules/settings/components/__stories__/SaveButton.stories.tsx
@@ -12,20 +12,20 @@ type Story = StoryObj<typeof SaveButton>;
 
 export const Default: Story = {
   argTypes: {
-    onClick: { control: false },
+    onSave: { control: false },
   },
   args: {
-    onClick: () => {},
+    onSave: () => {},
     disabled: false,
   },
 };
 
 export const Disabled: Story = {
   argTypes: {
-    onClick: { control: false },
+    onSave: { control: false },
   },
   args: {
-    onClick: () => {},
+    onSave: () => {},
     disabled: true,
   },
 };

--- a/front/src/modules/settings/components/__stories__/SaveButton.stories.tsx
+++ b/front/src/modules/settings/components/__stories__/SaveButton.stories.tsx
@@ -1,0 +1,31 @@
+import { Meta, StoryObj } from '@storybook/react';
+
+import { SaveButton } from '../SaveAndCancelButtons/SaveButton';
+
+const meta: Meta<typeof SaveButton> = {
+  title: 'Modules/Settings/SaveButton',
+  component: SaveButton,
+};
+
+export default meta;
+type Story = StoryObj<typeof SaveButton>;
+
+export const Default: Story = {
+  argTypes: {
+    onClick: { control: false },
+  },
+  args: {
+    onClick: () => {},
+    disabled: false,
+  },
+};
+
+export const Disabled: Story = {
+  argTypes: {
+    onClick: { control: false },
+  },
+  args: {
+    onClick: () => {},
+    disabled: true,
+  },
+};

--- a/front/src/pages/settings/data-model/SettingsNewObject.tsx
+++ b/front/src/pages/settings/data-model/SettingsNewObject.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom';
 import styled from '@emotion/styled';
 
 import { SaveAndCancelButtons } from '@/settings/components/SaveAndCancelButtons/SaveAndCancelButtons';
@@ -17,6 +18,7 @@ const StyledContainer = styled.div`
 `;
 
 export const SettingsNewObject = () => {
+  const navigate = useNavigate();
   return (
     <SubMenuTopBarContainer Icon={IconSettings} title="Settings">
       <SettingsPageContainer>
@@ -27,7 +29,13 @@ export const SettingsNewObject = () => {
               { children: 'New' },
             ]}
           />
-          <SaveAndCancelButtons disabled />
+          <SaveAndCancelButtons
+            disabled
+            onCancel={() => {
+              navigate('/settings/objects');
+            }}
+            onSave={() => {}}
+          />
         </StyledContainer>
         <Section>
           <H2Title

--- a/front/src/pages/settings/data-model/SettingsNewObject.tsx
+++ b/front/src/pages/settings/data-model/SettingsNewObject.tsx
@@ -30,7 +30,7 @@ export const SettingsNewObject = () => {
             ]}
           />
           <SaveAndCancelButtons
-            disabled
+            isSaveDisabled
             onCancel={() => {
               navigate('/settings/objects');
             }}

--- a/front/src/pages/settings/data-model/SettingsNewObject.tsx
+++ b/front/src/pages/settings/data-model/SettingsNewObject.tsx
@@ -1,3 +1,6 @@
+import styled from '@emotion/styled';
+
+import { SaveAndCancelButtons } from '@/settings/components/SaveAndCancelButtons/SaveAndCancelButtons';
 import { SettingsPageContainer } from '@/settings/components/SettingsPageContainer';
 import { SettingsNewObjectType } from '@/settings/data-model/new-object/components/SettingsNewObjectType';
 import { IconSettings } from '@/ui/display/icon';
@@ -6,16 +9,26 @@ import { SubMenuTopBarContainer } from '@/ui/layout/page/SubMenuTopBarContainer'
 import { Section } from '@/ui/layout/section/components/Section';
 import { Breadcrumb } from '@/ui/navigation/bread-crumb/components/Breadcrumb';
 
+const StyledContainer = styled.div`
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+`;
+
 export const SettingsNewObject = () => {
   return (
     <SubMenuTopBarContainer Icon={IconSettings} title="Settings">
       <SettingsPageContainer>
-        <Breadcrumb
-          links={[
-            { children: 'Objects', href: '/settings/objects' },
-            { children: 'New' },
-          ]}
-        />
+        <StyledContainer>
+          <Breadcrumb
+            links={[
+              { children: 'Objects', href: '/settings/objects' },
+              { children: 'New' },
+            ]}
+          />
+          <SaveAndCancelButtons disabled />
+        </StyledContainer>
         <Section>
           <H2Title
             title="Object Type"


### PR DESCRIPTION
- Created cancel and save buttons components
- Created the corresponding stories
- Added them in front/src/pages/settings/data-model/SettingsNewObject.tsx with a disabled save button and a cancel button which redirects to the object page