### PR TITLE
feat(frontend): New Object Field Step 2 Added Cancel Save Button

### DIFF
--- a/front/src/pages/settings/data-model/SettingsObjectNewField/SettingsObjectNewFieldStep2.tsx
+++ b/front/src/pages/settings/data-model/SettingsObjectNewField/SettingsObjectNewFieldStep2.tsx
@@ -1,6 +1,8 @@
 import { useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
+import { SaveAndCancelButtons } from '@/settings/components/SaveAndCancelButtons/SaveAndCancelButtons';
+import { SettingsHeaderContainer } from '@/settings/components/SettingsHeaderContainer';
 import { SettingsPageContainer } from '@/settings/components/SettingsPageContainer';
 import { activeObjectItems } from '@/settings/data-model/constants/mockObjects';
 import { AppPath } from '@/types/AppPath';
@@ -22,16 +24,25 @@ export const SettingsObjectNewFieldStep2 = () => {
   return (
     <SubMenuTopBarContainer Icon={IconSettings} title="Settings">
       <SettingsPageContainer>
-        <Breadcrumb
-          links={[
-            { children: 'Objects', href: '/settings/objects' },
-            {
-              children: activeObject?.name ?? '',
-              href: `/settings/objects/${pluralObjectName}`,
-            },
-            { children: 'New Field' },
-          ]}
-        />
+        <SettingsHeaderContainer>
+          <Breadcrumb
+            links={[
+              { children: 'Objects', href: '/settings/objects' },
+              {
+                children: activeObject?.name ?? '',
+                href: `/settings/objects/${pluralObjectName}`,
+              },
+              { children: 'New Field' },
+            ]}
+          />
+          <SaveAndCancelButtons
+            isSaveDisabled
+            onCancel={() => {
+              navigate('/settings/objects');
+            }}
+            onSave={() => {}}
+          />
+        </SettingsHeaderContainer>
       </SettingsPageContainer>
     </SubMenuTopBarContainer>
   );


### PR DESCRIPTION
Closes Issue #2006 

Save and Cancel button added 
- Save is disabled
- Cancel navigates to /settings/objects

Below mentioned is the demo

https://github.com/twentyhq/twenty/assets/62852363/a1ece295-1ac3-4b64-8c1d-b5623f4a8b8e

