### PR TITLE
1801 objects settings add activate option to disabled menu

### DIFF
--- a/front/src/modules/settings/data-model/objects/SettingsObjectDisabledMenuDropDown.tsx
+++ b/front/src/modules/settings/data-model/objects/SettingsObjectDisabledMenuDropDown.tsx
@@ -1,0 +1,35 @@
+import { IconDotsVertical, IconTrash } from '@/ui/display/icon';
+import { LightIconButton } from '@/ui/input/button/components/LightIconButton';
+import { IconArchiveOff } from '@/ui/input/constants/icons';
+import { DropdownMenu } from '@/ui/layout/dropdown/components/DropdownMenu';
+import { DropdownScope } from '@/ui/layout/dropdown/scopes/DropdownScope';
+import { MenuItem } from '@/ui/navigation/menu-item/components/MenuItem';
+
+type SettingsObjectDisabledMenuDropDownProps = {
+  scopeKey: string;
+};
+
+export const SettingsObjectDisabledMenuDropDown = ({
+  scopeKey,
+}: SettingsObjectDisabledMenuDropDownProps) => {
+  return (
+    <DropdownScope
+      dropdownScopeId={scopeKey + '-settings-object-disabled-menu-dropdown'}
+    >
+      <DropdownMenu
+        clickableComponent={
+          <LightIconButton Icon={IconDotsVertical} accent="tertiary" />
+        }
+        dropdownComponents={
+          <>
+            <MenuItem text="Edit" LeftIcon={IconArchiveOff} />
+            <MenuItem text="Erase" LeftIcon={IconTrash} />
+          </>
+        }
+        dropdownHotkeyScope={{
+          scope: scopeKey + '-settings-object-disabled-menu-dropdown',
+        }}
+      />
+    </DropdownScope>
+  );
+};

--- a/front/src/modules/settings/data-model/objects/SettingsObjectDisabledMenuDropDown.tsx
+++ b/front/src/modules/settings/data-model/objects/SettingsObjectDisabledMenuDropDown.tsx
@@ -1,3 +1,5 @@
+import styled from '@emotion/styled';
+
 import { IconDotsVertical, IconTrash } from '@/ui/display/icon';
 import { LightIconButton } from '@/ui/input/button/components/LightIconButton';
 import { IconArchiveOff } from '@/ui/input/constants/icons';
@@ -8,6 +10,21 @@ import { MenuItem } from '@/ui/navigation/menu-item/components/MenuItem';
 type SettingsObjectDisabledMenuDropDownProps = {
   scopeKey: string;
 };
+
+const StyledDropdownMenuItemsContainer = styled.div`
+  align-items: flex-start;
+  backdrop-filter: blur(20px);
+  background: ${({ theme }) => theme.background.primary};
+  border: 1px solid ${({ theme }) => theme.border.color.medium};
+  border-radius: ${({ theme }) => theme.border.radius.md};
+
+  box-shadow: ${({ theme }) => theme.boxShadow.strong};
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: ${({ theme }) => theme.spacing(1)};
+  width: 160px;
+`;
 
 export const SettingsObjectDisabledMenuDropDown = ({
   scopeKey,
@@ -21,10 +38,10 @@ export const SettingsObjectDisabledMenuDropDown = ({
           <LightIconButton Icon={IconDotsVertical} accent="tertiary" />
         }
         dropdownComponents={
-          <>
+          <StyledDropdownMenuItemsContainer>
             <MenuItem text="Edit" LeftIcon={IconArchiveOff} />
-            <MenuItem text="Erase" LeftIcon={IconTrash} />
-          </>
+            <MenuItem text="Erase" LeftIcon={IconTrash} accent="danger" />
+          </StyledDropdownMenuItemsContainer>
         }
         dropdownHotkeyScope={{
           scope: scopeKey + '-settings-object-disabled-menu-dropdown',

--- a/front/src/modules/settings/data-model/objects/SettingsObjectDisabledMenuDropDown.tsx
+++ b/front/src/modules/settings/data-model/objects/SettingsObjectDisabledMenuDropDown.tsx
@@ -39,7 +39,7 @@ export const SettingsObjectDisabledMenuDropDown = ({
         }
         dropdownComponents={
           <StyledDropdownMenuItemsContainer>
-            <MenuItem text="Edit" LeftIcon={IconArchiveOff} />
+            <MenuItem text="Activate" LeftIcon={IconArchiveOff} />
             <MenuItem text="Erase" LeftIcon={IconTrash} accent="danger" />
           </StyledDropdownMenuItemsContainer>
         }

--- a/front/src/modules/settings/data-model/objects/SettingsObjectDisabledMenuDropDown.tsx
+++ b/front/src/modules/settings/data-model/objects/SettingsObjectDisabledMenuDropDown.tsx
@@ -9,6 +9,8 @@ import { MenuItem } from '@/ui/navigation/menu-item/components/MenuItem';
 
 type SettingsObjectDisabledMenuDropDownProps = {
   scopeKey: string;
+  handleActivate: () => void;
+  handleErase: () => void;
 };
 
 const StyledDropdownMenuItemsContainer = styled.div`
@@ -28,6 +30,8 @@ const StyledDropdownMenuItemsContainer = styled.div`
 
 export const SettingsObjectDisabledMenuDropDown = ({
   scopeKey,
+  handleActivate,
+  handleErase,
 }: SettingsObjectDisabledMenuDropDownProps) => {
   return (
     <DropdownScope
@@ -39,8 +43,17 @@ export const SettingsObjectDisabledMenuDropDown = ({
         }
         dropdownComponents={
           <StyledDropdownMenuItemsContainer>
-            <MenuItem text="Activate" LeftIcon={IconArchiveOff} />
-            <MenuItem text="Erase" LeftIcon={IconTrash} accent="danger" />
+            <MenuItem
+              text="Activate"
+              LeftIcon={IconArchiveOff}
+              onClick={handleActivate}
+            />
+            <MenuItem
+              text="Erase"
+              LeftIcon={IconTrash}
+              accent="danger"
+              onClick={handleErase}
+            />
           </StyledDropdownMenuItemsContainer>
         }
         dropdownHotkeyScope={{

--- a/front/src/modules/settings/data-model/objects/SettingsObjectDisabledMenuDropDown.tsx
+++ b/front/src/modules/settings/data-model/objects/SettingsObjectDisabledMenuDropDown.tsx
@@ -1,9 +1,9 @@
-import styled from '@emotion/styled';
-
 import { IconDotsVertical, IconTrash } from '@/ui/display/icon';
 import { LightIconButton } from '@/ui/input/button/components/LightIconButton';
 import { IconArchiveOff } from '@/ui/input/constants/icons';
 import { DropdownMenu } from '@/ui/layout/dropdown/components/DropdownMenu';
+import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/DropdownMenuItemsContainer';
+import { StyledDropdownMenu } from '@/ui/layout/dropdown/components/StyledDropdownMenu';
 import { DropdownScope } from '@/ui/layout/dropdown/scopes/DropdownScope';
 import { MenuItem } from '@/ui/navigation/menu-item/components/MenuItem';
 
@@ -12,21 +12,6 @@ type SettingsObjectDisabledMenuDropDownProps = {
   handleActivate: () => void;
   handleErase: () => void;
 };
-
-const StyledDropdownMenuItemsContainer = styled.div`
-  align-items: flex-start;
-  backdrop-filter: blur(20px);
-  background: ${({ theme }) => theme.background.primary};
-  border: 1px solid ${({ theme }) => theme.border.color.medium};
-  border-radius: ${({ theme }) => theme.border.radius.md};
-
-  box-shadow: ${({ theme }) => theme.boxShadow.strong};
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  padding: ${({ theme }) => theme.spacing(1)};
-  width: 160px;
-`;
 
 export const SettingsObjectDisabledMenuDropDown = ({
   scopeKey,
@@ -42,19 +27,21 @@ export const SettingsObjectDisabledMenuDropDown = ({
           <LightIconButton Icon={IconDotsVertical} accent="tertiary" />
         }
         dropdownComponents={
-          <StyledDropdownMenuItemsContainer>
-            <MenuItem
-              text="Activate"
-              LeftIcon={IconArchiveOff}
-              onClick={handleActivate}
-            />
-            <MenuItem
-              text="Erase"
-              LeftIcon={IconTrash}
-              accent="danger"
-              onClick={handleErase}
-            />
-          </StyledDropdownMenuItemsContainer>
+          <StyledDropdownMenu width="160px">
+            <DropdownMenuItemsContainer>
+              <MenuItem
+                text="Activate"
+                LeftIcon={IconArchiveOff}
+                onClick={handleActivate}
+              />
+              <MenuItem
+                text="Erase"
+                LeftIcon={IconTrash}
+                accent="danger"
+                onClick={handleErase}
+              />
+            </DropdownMenuItemsContainer>
+          </StyledDropdownMenu>
         }
         dropdownHotkeyScope={{
           scope: scopeKey + '-settings-object-disabled-menu-dropdown',

--- a/front/src/modules/settings/data-model/objects/__stories__/SettingsObjectDisabledMenuDropDown.stories.tsx
+++ b/front/src/modules/settings/data-model/objects/__stories__/SettingsObjectDisabledMenuDropDown.stories.tsx
@@ -1,0 +1,84 @@
+import { expect } from '@storybook/jest';
+import { jest } from '@storybook/jest';
+import { Decorator, Meta, StoryObj } from '@storybook/react';
+import { userEvent, within } from '@storybook/testing-library';
+
+import { ComponentDecorator } from '~/testing/decorators/ComponentDecorator';
+
+import { SettingsObjectDisabledMenuDropDown } from '../SettingsObjectDisabledMenuDropDown';
+
+const handleActivateMockFunction = jest.fn();
+const handleEraseMockFunction = jest.fn();
+
+const ClearMocksDecorator: Decorator = (Story, context) => {
+  if (context.parameters.clearMocks) {
+    handleActivateMockFunction.mockClear();
+    handleEraseMockFunction.mockClear();
+  }
+  return <Story />;
+};
+
+const meta: Meta<typeof SettingsObjectDisabledMenuDropDown> = {
+  title: 'Modules/Settings/DataModel/SettingsObjectDisabledMenuDropDown',
+  component: SettingsObjectDisabledMenuDropDown,
+  args: {
+    scopeKey: 'settings-object-disabled-menu-dropdown',
+    handleActivate: handleActivateMockFunction,
+    handleErase: handleEraseMockFunction,
+  },
+  decorators: [ComponentDecorator, ClearMocksDecorator],
+  parameters: {
+    clearMocks: true,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof SettingsObjectDisabledMenuDropDown>;
+
+export const Default: Story = {};
+
+export const WithOpen: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const dropdownButton = await canvas.findByRole('button');
+
+    await userEvent.click(dropdownButton);
+  },
+};
+
+export const WithActivate: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const dropdownButton = await canvas.findByRole('button');
+
+    await userEvent.click(dropdownButton);
+
+    await expect(handleActivateMockFunction).toHaveBeenCalledTimes(0);
+
+    const activateMenuItem = await canvas.findByText('Activate');
+
+    await userEvent.click(activateMenuItem);
+
+    await expect(handleActivateMockFunction).toHaveBeenCalledTimes(1);
+  },
+};
+
+export const WithErase: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const dropdownButton = await canvas.findByRole('button');
+
+    await userEvent.click(dropdownButton);
+
+    await expect(handleEraseMockFunction).toHaveBeenCalledTimes(0);
+
+    const eraseMenuItem = await canvas.findByText('Erase');
+
+    await userEvent.click(eraseMenuItem);
+
+    await expect(handleEraseMockFunction).toHaveBeenCalledTimes(1);
+  },
+};

--- a/front/src/modules/ui/navigation/menu-item/internals/components/StyledMenuItemBase.tsx
+++ b/front/src/modules/ui/navigation/menu-item/internals/components/StyledMenuItemBase.tsx
@@ -82,7 +82,7 @@ export const StyledMenuItemLeftContent = styled.div`
 
   flex-direction: row;
 
-  gap: ${({ theme }) => theme.spacing(1)};
+  gap: ${({ theme }) => theme.spacing(2)};
   min-width: 0;
   width: 100%;
 `;

--- a/front/src/pages/settings/data-model/SettingsObjects.tsx
+++ b/front/src/pages/settings/data-model/SettingsObjects.tsx
@@ -9,6 +9,7 @@ import {
   disabledObjectItems,
 } from '@/settings/data-model/constants/mockObjects';
 import { SettingsObjectCoverImage } from '@/settings/data-model/objects/SettingsObjectCoverImage';
+import { SettingsObjectDisabledMenuDropDown } from '@/settings/data-model/objects/SettingsObjectDisabledMenuDropDown';
 import {
   IconChevronRight,
   IconDotsVertical,
@@ -141,9 +142,12 @@ export const SettingsObjects = () => {
                         {objectItem.instances}
                       </TableCell>
                       <StyledIconTableCell>
-                        <StyledIconDotsVertical
+                        {/* <StyledIconDotsVertical
                           size={theme.icon.size.md}
                           stroke={theme.icon.stroke.sm}
+                        /> */}
+                        <SettingsObjectDisabledMenuDropDown
+                          scopeKey={objectItem.name}
                         />
                       </StyledIconTableCell>
                     </StyledTableRow>

--- a/front/src/pages/settings/data-model/SettingsObjects.tsx
+++ b/front/src/pages/settings/data-model/SettingsObjects.tsx
@@ -10,12 +10,7 @@ import {
 } from '@/settings/data-model/constants/mockObjects';
 import { SettingsObjectCoverImage } from '@/settings/data-model/objects/SettingsObjectCoverImage';
 import { SettingsObjectDisabledMenuDropDown } from '@/settings/data-model/objects/SettingsObjectDisabledMenuDropDown';
-import {
-  IconChevronRight,
-  IconDotsVertical,
-  IconPlus,
-  IconSettings,
-} from '@/ui/display/icon';
+import { IconChevronRight, IconPlus, IconSettings } from '@/ui/display/icon';
 import { Tag } from '@/ui/display/tag/components/Tag';
 import { H1Title } from '@/ui/display/typography/components/H1Title';
 import { H2Title } from '@/ui/display/typography/components/H2Title';
@@ -48,10 +43,6 @@ const StyledIconTableCell = styled(TableCell)`
 `;
 
 const StyledIconChevronRight = styled(IconChevronRight)`
-  color: ${({ theme }) => theme.font.color.tertiary};
-`;
-
-const StyledIconDotsVertical = styled(IconDotsVertical)`
   color: ${({ theme }) => theme.font.color.tertiary};
 `;
 

--- a/front/src/pages/settings/data-model/SettingsObjects.tsx
+++ b/front/src/pages/settings/data-model/SettingsObjects.tsx
@@ -142,10 +142,6 @@ export const SettingsObjects = () => {
                         {objectItem.instances}
                       </TableCell>
                       <StyledIconTableCell>
-                        {/* <StyledIconDotsVertical
-                          size={theme.icon.size.md}
-                          stroke={theme.icon.stroke.sm}
-                        /> */}
                         <SettingsObjectDisabledMenuDropDown
                           scopeKey={objectItem.name}
                         />

--- a/front/src/pages/settings/data-model/SettingsObjects.tsx
+++ b/front/src/pages/settings/data-model/SettingsObjects.tsx
@@ -144,6 +144,8 @@ export const SettingsObjects = () => {
                       <StyledIconTableCell>
                         <SettingsObjectDisabledMenuDropDown
                           scopeKey={objectItem.name}
+                          handleActivate={() => {}}
+                          handleErase={() => {}}
                         />
                       </StyledIconTableCell>
                     </StyledTableRow>


### PR DESCRIPTION
- Created a dropdown menu with two menu item components : Activate and Erase
- The dropdown menu takes handleActivate and handleErase as props, but since this part is not yet connected to the backend, these functions will be implemented later
- Added stories : Default, WithOpen, WithActivate, WithErase