### PR TITLE
Fix api keys

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -26,8 +26,6 @@ services:
       generateValue: true
     - key: LOGIN_TOKEN_SECRET
       generateValue: true
-    - key: API_TOKEN_SECRET
-      generateValue: true
     - key: REFRESH_TOKEN_SECRET
       generateValue: true
     - key: PG_DATABASE_HOST

--- a/server/.env.example
+++ b/server/.env.example
@@ -4,10 +4,10 @@ PG_DATABASE_URL=postgres://twenty:twenty@localhost:5432/default?connection_limit
 # PG_DATABASE_URL=postgres://twenty:twenty@postgres:5432/default?connection_limit=1
 
 FRONT_BASE_URL=http://localhost:3001
-ACCESS_TOKEN_SECRET=replace_me_with_a_random_string
-LOGIN_TOKEN_SECRET=replace_me_with_a_random_string
-API_TOKEN_SECRET=replace_me_with_a_random_string
-REFRESH_TOKEN_SECRET=replace_me_with_a_random_string
+ACCESS_TOKEN_SECRET=replace_me_with_a_random_string_access
+LOGIN_TOKEN_SECRET=replace_me_with_a_random_string_login
+API_TOKEN_SECRET=replace_me_with_a_random_string_api
+REFRESH_TOKEN_SECRET=replace_me_with_a_random_string_refresh
 SIGN_IN_PREFILLED=true
 
 # ———————— Optional ————————

--- a/server/.env.example
+++ b/server/.env.example
@@ -6,7 +6,6 @@ PG_DATABASE_URL=postgres://twenty:twenty@localhost:5432/default?connection_limit
 FRONT_BASE_URL=http://localhost:3001
 ACCESS_TOKEN_SECRET=replace_me_with_a_random_string_access
 LOGIN_TOKEN_SECRET=replace_me_with_a_random_string_login
-API_TOKEN_SECRET=replace_me_with_a_random_string_api
 REFRESH_TOKEN_SECRET=replace_me_with_a_random_string_refresh
 SIGN_IN_PREFILLED=true
 

--- a/server/.env.test
+++ b/server/.env.test
@@ -8,7 +8,6 @@ FRONT_BASE_URL=http://localhost:3001
 # random keys used to generate JWT tokens
 ACCESS_TOKEN_SECRET=secret_jwt
 LOGIN_TOKEN_SECRET=secret_login_tokens
-API_TOKEN_SECRET=secret_api_tokens
 REFRESH_TOKEN_SECRET=secret_refresh_token
 
 

--- a/server/src/core/api-key/api-key.service.ts
+++ b/server/src/core/api-key/api-key.service.ts
@@ -29,7 +29,7 @@ export class ApiKeyService {
     name: string,
     expiresAt?: Date | string,
   ): Promise<AuthToken> {
-    const secret = this.environmentService.getApiTokenSecret();
+    const secret = this.environmentService.getAccessTokenSecret();
     let expiresIn: string | number;
     let expirationDate: Date;
     const now = new Date().getTime();

--- a/server/src/integrations/environment/environment.service.ts
+++ b/server/src/integrations/environment/environment.service.ts
@@ -69,10 +69,6 @@ export class EnvironmentService {
     return this.configService.get<string>('LOGIN_TOKEN_SECRET')!;
   }
 
-  getApiTokenSecret(): string {
-    return this.configService.get<string>('API_TOKEN_SECRET')!;
-  }
-
   getLoginTokenExpiresIn(): string {
     return this.configService.get<string>('LOGIN_TOKEN_EXPIRES_IN') ?? '15m';
   }

--- a/server/src/integrations/environment/environment.validation.ts
+++ b/server/src/integrations/environment/environment.validation.ts
@@ -82,8 +82,6 @@ export class EnvironmentVariables {
 
   @IsString()
   LOGIN_TOKEN_SECRET: string;
-  @IsString()
-  API_TOKEN_SECRET: string;
   @IsDuration()
   @IsOptional()
   LOGIN_TOKEN_EXPIRES_IN: string;


### PR DESCRIPTION
We will finally use the same secret to encode api token and access token. It avoids unnecessary complexity on authJWTGuard