### PR TITLE
Favorite: computeNewPosition fixed

### DIFF
--- a/front/src/modules/favorites/hooks/useFavorites.ts
+++ b/front/src/modules/favorites/hooks/useFavorites.ts
@@ -104,7 +104,7 @@ export const useFavorites = () => {
     });
   };
 
-  const computeNewPosition = (destIndex: number) => {
+  const computeNewPosition = (destIndex: number, sourceIndex: number) => {
     if (destIndex === 0) {
       return favorites[destIndex].position / 2;
     }
@@ -112,6 +112,13 @@ export const useFavorites = () => {
     if (destIndex === favorites.length - 1) {
       return favorites[destIndex].position + 1;
     }
+
+    if (sourceIndex < destIndex) {
+      return (
+        (favorites[destIndex + 1].position + favorites[destIndex].position) / 2
+      );
+    }
+
     return (
       (favorites[destIndex - 1].position + favorites[destIndex].position) / 2
     );
@@ -121,7 +128,10 @@ export const useFavorites = () => {
     if (!result.destination || !favorites) {
       return;
     }
-    const newPosition = computeNewPosition(result.destination.index);
+    const newPosition = computeNewPosition(
+      result.destination.index,
+      result.source.index,
+    );
 
     const reorderFavorites = Array.from(favorites);
     const [removed] = reorderFavorites.splice(result.source.index, 1);


### PR DESCRIPTION
Currently, it is only working correctly if you scroll from bottom to top, but if you scroll from top position to bottom then it's not working fine
It should also handle one more condition to check if we are scrolling from top to bottom or bottom to top and according to that we need to manage the condition
