### PR TITLE
Add standardObject seeds

### DIFF
--- a/server/src/metadata/migration-runner/migration-runner.service.ts
+++ b/server/src/metadata/migration-runner/migration-runner.service.ts
@@ -45,9 +45,10 @@ export class MigrationRunnerService {
 
     // Loop over each migration and create or update the table
     // TODO: Should be done in a transaction
-    flattenedPendingMigrations.forEach(async (migration) => {
+
+    for (const migration of flattenedPendingMigrations) {
       await this.handleTableChanges(queryRunner, schemaName, migration);
-    });
+    }
 
     // Update appliedAt date for each migration
     // TODO: Should be done after the migration is successful

--- a/server/src/metadata/tenant-initialisation/standard-objects/companies.seeds.json
+++ b/server/src/metadata/tenant-initialisation/standard-objects/companies.seeds.json
@@ -1,0 +1,32 @@
+[
+  {
+    "name": "Airbnb",
+    "domainName": "airbnb.com",
+    "address": "San Francisco",
+    "employees": 5000
+  },
+  {
+    "name": "Qonto",
+    "domainName": "qonto.com",
+    "address": "San Francisco",
+    "employees": 800
+  },
+  {
+    "name": "Stripe",
+    "domainName": "stripe.com",
+    "address": "San Francisco",
+    "employees": 8000
+  },
+  {
+    "name": "Figma",
+    "domainName": "figma.com",
+    "address": "San Francisco",
+    "employees": 800
+  },
+  {
+    "name": "Notion",
+    "domainName": "notion.com",
+    "address": "San Francisco",
+    "employees": 400
+  }
+]

--- a/server/src/metadata/tenant-initialisation/standard-objects/standard-object-seeds.ts
+++ b/server/src/metadata/tenant-initialisation/standard-objects/standard-object-seeds.ts
@@ -1,0 +1,5 @@
+import companySeeds from './companies.seeds.json';
+
+export const standardObjectsSeeds = {
+  companyV2: companySeeds,
+};

--- a/server/src/metadata/tenant-initialisation/tenant-initialisation.service.ts
+++ b/server/src/metadata/tenant-initialisation/tenant-initialisation.service.ts
@@ -8,8 +8,10 @@ import { ObjectMetadataService } from 'src/metadata/object-metadata/services/obj
 import { DataSourceMetadataService } from 'src/metadata/data-source-metadata/data-source-metadata.service';
 import { FieldMetadata } from 'src/metadata/field-metadata/field-metadata.entity';
 import { ObjectMetadata } from 'src/metadata/object-metadata/object-metadata.entity';
+import { DataSourceMetadata } from 'src/metadata/data-source-metadata/data-source-metadata.entity';
 
 import { standardObjectsMetadata } from './standard-objects/standard-object-metadata';
+import { standardObjectsSeeds } from './standard-objects/standard-object-seeds';
 
 @Injectable()
 export class TenantInitialisationService {
@@ -51,6 +53,11 @@ export class TenantInitialisationService {
       dataSourceMetadata.id,
       workspaceId,
     );
+
+    await this.prefillWorkspaceWithStandardObjects(
+      dataSourceMetadata,
+      workspaceId,
+    );
   }
 
   /**
@@ -89,5 +96,39 @@ export class TenantInitialisationService {
         ),
       ),
     );
+  }
+
+  private async prefillWorkspaceWithStandardObjects(
+    dataSourceMetadata: DataSourceMetadata,
+    workspaceId: string,
+  ) {
+    const objects =
+      await this.objectMetadataService.getObjectMetadataFromDataSourceId(
+        dataSourceMetadata.id,
+      );
+
+    const worksapceDataSource =
+      await this.dataSourceService.connectToWorkspaceDataSource(workspaceId);
+
+    objects.forEach((object) => {
+      const seedData = standardObjectsSeeds[object.nameSingular];
+
+      if (!seedData) {
+        return;
+      }
+
+      const fields = standardObjectsMetadata[object.nameSingular].fields;
+
+      const columns = fields.map((field: FieldMetadata) =>
+        Object.values(field.targetColumnMap),
+      );
+
+      worksapceDataSource
+        ?.createQueryBuilder()
+        .insert()
+        .into(`${dataSourceMetadata.schema}.${object.targetTableName}`, columns)
+        .values(seedData)
+        .execute();
+    });
   }
 }

--- a/server/src/metadata/tenant-initialisation/tenant-initialisation.service.ts
+++ b/server/src/metadata/tenant-initialisation/tenant-initialisation.service.ts
@@ -110,11 +110,11 @@ export class TenantInitialisationService {
     const worksapceDataSource =
       await this.dataSourceService.connectToWorkspaceDataSource(workspaceId);
 
-    objects.forEach((object) => {
+    for (const object of objects) {
       const seedData = standardObjectsSeeds[object.nameSingular];
 
       if (!seedData) {
-        return;
+        continue;
       }
 
       const fields = standardObjectsMetadata[object.nameSingular].fields;
@@ -129,6 +129,6 @@ export class TenantInitialisationService {
         .into(`${dataSourceMetadata.schema}.${object.targetTableName}`, columns)
         .values(seedData)
         .execute();
-    });
+    }
   }
 }


### PR DESCRIPTION
## Context
We recently merged this https://github.com/twentyhq/twenty/pull/2100 which initialises a workspace, including standard objects creation.
We now want to replicate the current behaviour where new users see some example values (for companies for example) so the views don't feel empty.

## Implementation
I'm introducing a new .seeds.json file, I actually reused the same file used today with prisma implementation. This PR only contains seeds for the Company object. 

<img width="1249" alt="Screenshot 2023-10-20 at 10 26 55" src="https://github.com/twentyhq/twenty/assets/1834158/ef1c3f13-c4cd-4b92-9018-71e358906631">
