### PR TITLE
fix: issue Button-with-'IconChevronDown'-in-'TableUpdateViewGroupButton'-has-incorrect-size

### DIFF
--- a/front/src/modules/ui/data/view-bar/components/UpdateViewButtonGroup.tsx
+++ b/front/src/modules/ui/data/view-bar/components/UpdateViewButtonGroup.tsx
@@ -115,7 +115,7 @@ export const UpdateViewButtonGroup = ({
 
   return (
     <StyledContainer>
-      <ButtonGroup size="small" accent="blue">
+      <ButtonGroup accent="blue">
         <Button title="Update view" onClick={handleViewSubmit} />
         <Button
           size="small"


### PR DESCRIPTION
fixes #1522 

I have checked the buttons in my browser with the Chrome dev tools

I have tested the following sites
- 'People' page
- 'Company' page
- 'Opportunities' page

![Bildschirmfoto vom 2023-10-23 15-53-26](https://github.com/twentyhq/twenty/assets/13363982/0cbc1b63-65a6-4b3e-9f77-0816ec36d6bc)
