### PR TITLE
Add prisma metadata seeds

### DIFF
--- a/server/src/database/seeds/index.ts
+++ b/server/src/database/seeds/index.ts
@@ -7,6 +7,7 @@ import { seedComments } from './comments';
 import { seedUsers } from './users';
 import { seedPipelines } from './pipelines';
 import { seedViews } from './views';
+import { seedMetadata } from './metadata';
 
 const seed = async () => {
   const prisma = new PrismaClient();
@@ -17,6 +18,7 @@ const seed = async () => {
   await seedComments(prisma);
   await seedPipelines(prisma);
   await seedViews(prisma);
+  await seedMetadata(prisma);
   await prisma.$disconnect();
 };
 

--- a/server/src/database/seeds/metadata.ts
+++ b/server/src/database/seeds/metadata.ts
@@ -1,0 +1,62 @@
+import { PrismaClient } from '@prisma/client';
+
+export const seedMetadata = async (prisma: PrismaClient) => {
+  await prisma.$queryRawUnsafe(
+    'CREATE SCHEMA IF NOT EXISTS workspace_twenty_7icsva0r6s00mpcp6cwg4w4rd',
+  );
+  await prisma.$queryRawUnsafe(
+    `INSERT INTO metadata.data_source_metadata(
+      id, schema, type, workspace_id
+    ) 
+    VALUES (
+      'b37b2163-7f63-47a9-b1b3-6c7290ca9fb1', 'workspace_twenty_7icsva0r6s00mpcp6cwg4w4rd', 'postgres', 'twenty-7ed9d212-1c25-4d02-bf25-6aeccf7ea419'
+    ) ON CONFLICT DO NOTHING`,
+  );
+
+  await prisma.$queryRawUnsafe(`CREATE TABLE IF NOT EXISTS 
+    workspace_twenty_7icsva0r6s00mpcp6cwg4w4rd.company(
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+      "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+      "deletedAt" TIMESTAMP WITH TIME ZONE,
+      domainName TEXT NOT NULL,
+      address TEXT NOT NULL,
+      employees INTEGER NOT NULL
+    );
+  `);
+  await prisma.$queryRawUnsafe(`INSERT INTO workspace_twenty_7icsva0r6s00mpcp6cwg4w4rd.company(
+    id, name, domainName, address, employees
+  )
+  VALUES (
+    '89bb825c-171e-4bcc-9cf7-43448d6fb278', 'Airbnb', 'airbnb.com', 'San Francisco', 5000
+  ), (
+    '04b2e9f5-0713-40a5-8216-82802401d33e', 'Qonto', 'qonto.com', 'San Francisco', 800
+  ), (
+    '118995f3-5d81-46d6-bf83-f7fd33ea6102', 'Facebook', 'facebook.com', 'San Francisco', 8000
+  ), (
+    '460b6fb1-ed89-413a-b31a-962986e67bb4', 'Microsoft', 'microsoft.com', 'San Francisco', 800
+  ), (
+    'fe256b39-3ec3-4fe3-8997-b76aa0bfa408', 'Linkedin', 'linkedin.com', 'San Francisco', 400
+  ) ON CONFLICT DO NOTHING`);
+
+  await prisma.$queryRawUnsafe(`INSERT INTO metadata.object_metadata(
+    id, name_singular, name_plural, label_singular, label_plural, description, icon, target_table_name, is_custom, is_active, workspace_id, data_source_id
+  )
+  VALUES (
+    'ba391617-ee08-432f-9438-2e17df5ac279', 'companyV2', 'companiesV2', 'Company', 'Companies', 'Companies', 'company', 'company', false, true, 'twenty-7ed9d212-1c25-4d02-bf25-6aeccf7ea419', 'b37b2163-7f63-47a9-b1b3-6c7290ca9fb1'
+  ) ON CONFLICT DO NOTHING`);
+
+  await prisma.$queryRawUnsafe(`INSERT INTO metadata.field_metadata(
+    id, object_id, type, name, label, target_column_map, description, icon, enums, is_custom, is_active, is_nullable, workspace_id
+  )
+  VALUES (
+    '22f5906d-153f-448c-b254-28adce721dcd', 'ba391617-ee08-432f-9438-2e17df5ac279', 'text', 'name', 'Name', '{"value": "name"}', 'Name', 'user', NULL, false, true, false, 'twenty-7ed9d212-1c25-4d02-bf25-6aeccf7ea419'
+  ), (
+    '19bfab29-1cbb-4ce2-9117-8540ac45a0f1', 'ba391617-ee08-432f-9438-2e17df5ac279', 'text', 'domainName', 'Domain Name', '{"value": "domainName"}', 'Domain Name', 'link', NULL, false, true, true, 'twenty-7ed9d212-1c25-4d02-bf25-6aeccf7ea419'
+  ), (
+    '70130f27-9497-4b44-a04c-1a0fb9a4829c', 'ba391617-ee08-432f-9438-2e17df5ac279', 'text', 'address', 'Address', '{"value": "address"}', 'Address', 'location', NULL, false, true, true, 'twenty-7ed9d212-1c25-4d02-bf25-6aeccf7ea419'
+  ), (
+    '2a63c30e-8e80-475b-b5d7-9dda17adc537', 'ba391617-ee08-432f-9438-2e17df5ac279', 'number', 'employees', 'Employees', '{"value": "employees"}', 'Employees', 'people', NULL, false, true, true, 'twenty-7ed9d212-1c25-4d02-bf25-6aeccf7ea419'
+  ) ON CONFLICT DO NOTHING`);
+};

--- a/server/src/database/seeds/workspaces.ts
+++ b/server/src/database/seeds/workspaces.ts
@@ -23,26 +23,4 @@ export const seedWorkspaces = async (prisma: PrismaClient) => {
       logo: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAACXBIWXMAAA7EAAAOxAGVKw4bAAACb0lEQVR4nO2VO4taQRTHr3AblbjxEVlwCwVhg7BoqqCIjy/gAyyFWNlYBOxsfH0KuxgQGwXRUkGuL2S7i1barGAgiwbdW93SnGOc4BonPiKahf3DwXFmuP/fPM4ZlvmlTxAhCBdzHnEQWYiv7Mr4C3NeuVYhQYDPzOUUQgDLBQGcLHNhvQK8DACPx8PTxiqVyvISG43GbyaT6Qfpn06n0m63e/tPAPF4vJ1MJu8kEsnWTCkWi1yr1RKGw+GDRqPBOTfr44vFQvD7/Q/lcpmaaVQAr9fLp1IpO22c47hGOBz+MB6PH+Vy+VYDAL8qlUoGtVotzOfzq4MAgsHgE/6KojiQyWR/bKVSqbSszHFM8Pl8z1YK48JsNltCOBwOnrYLO+8AAIjb+nHbycoTiUQfDJ7tFq4YAHiVSmXBxcD41u8flQU8z7fhzO0r83atVns3Go3u9Xr9x0O/RQXo9/tsIBBg6vX606a52Wz+bZ7P5/WwG29gxSJzhKgA6XTaDoFNF+krFAocmC//4yWEcSf2wTm7mCO19xFgSsKOLI16vV7b7XY7mRNoLwA0JymJ5uQIzgIAuX5PzDElT2m+E8BqtQ4ymcx7Yq7T6a6ZE4sKgOadTucaCwkxp1UzlEKh0GDxIXOwDWHAdi6Xe3swQDQa/Q7mywoolUpvsaptymazDWKxmBHTlWXZm405BFZoNpuGgwEmk4mE2SGtVivii4f1AO7J3ZopkQCQj7Ar1FeRChCJRJzVapX6DKNIfSc1Ax+wtQWQ55h6bH8FWDfYV4fO3wlwDr0C/BcADYiTPCxHqIEA2QsCZAkAKnRGkMbKN/sTX5YHPQ1e7SkAAAAASUVORK5CYII=',
     },
   });
-
-  await prisma.$queryRawUnsafe('CREATE SCHEMA IF NOT EXISTS workspace_twenty');
-  await prisma.$queryRawUnsafe(
-    `INSERT INTO metadata.data_source_metadata(
-      id, schema, type, workspace_id
-    ) 
-    VALUES (
-      '80f5e1e3-574a-4bf9-b5bc-98aedd2b76e6', 'workspace_twenty', 'postgres', 'twenty-dev-7ed9d212-1c25-4d02-bf25-6aeccf7ea420'
-    ) ON CONFLICT DO NOTHING`,
-  );
-
-  await prisma.$queryRawUnsafe(
-    'CREATE SCHEMA IF NOT EXISTS workspace_twenty_7icsva0r6s00mpcp6cwg4w4rd',
-  );
-  await prisma.$queryRawUnsafe(
-    `INSERT INTO metadata.data_source_metadata(
-      id, schema, type, workspace_id
-    ) 
-    VALUES (
-      'b37b2163-7f63-47a9-b1b3-6c7290ca9fb1', 'workspace_twenty_7icsva0r6s00mpcp6cwg4w4rd', 'postgres', 'twenty-7ed9d212-1c25-4d02-bf25-6aeccf7ea419'
-    ) ON CONFLICT DO NOTHING`,
-  );
 };


### PR DESCRIPTION
This is not a long term solution but since we are still using prisma seeds I'm introducing a few metadata/data for the workspace created by our prisma seeds.
This should create a new CompanyV2 metadata object with different fields, the associated table in the workspace schema and a few rows.

Note: This process is already done during new workspace creation however the test workspace coming from the seed command has no access to the TenantInitialisation service.

## Test
tested after deleting docker volumes / prune + make provision-postgres + yarn database:init

<img width="1084" alt="Screenshot 2023-10-27 at 12 49 22" src="https://github.com/twentyhq/twenty/assets/1834158/84f0621f-3282-4c45-a283-e6f27846419e">
<img width="1017" alt="Screenshot 2023-10-27 at 12 49 16" src="https://github.com/twentyhq/twenty/assets/1834158/18219c56-e835-473f-bc27-897ddcc92d14">
