### PR TITLE
[Docs] Update 'self-hosting options' link on getting-started.mdx

### DIFF
--- a/docs/docs/start/getting-started.mdx
+++ b/docs/docs/start/getting-started.mdx
@@ -21,7 +21,7 @@ The signup is free.
 If you're a developer and would like to experiment or contribute to the app, you can install Twenty on your local environment. Follow our [local setup](/contributor/local-setup) guide to get started.  
 
 ### 3. Self-hosting
-We provide [self-hosting options](self-hosting) if you want greater control over your data and want to run the app on your own server. Right now, Docker containers are the only hosting option we support. However we are actively working on providing simple options to self-host Twenty.
+We provide [self-hosting options](/start/self-hosting) if you want greater control over your data and want to run the app on your own server. Right now, Docker containers are the only hosting option we support. However we are actively working on providing simple options to self-host Twenty.
 
 
 ___


### PR DESCRIPTION
When browsing from: 
https://docs.twenty.com/start/getting-started/

The link with text "self-hosting options" lands on a 404 page with this address: https://docs.twenty.com/start/getting-started/self-hosting

Adding '/start/' to the beginning of the URL fixes this. 

Note: if your browser automatically redirects from: https://docs.twenty.com/start/getting-started/
to:
https://docs.twenty.com/start/getting-started

Then the relative document URL will work as expected. When adding the trailing slash, the link breaks.