### PR TITLE
Prevent layout shift on page load

### DIFF
--- a/front/src/modules/ui/navigation/navbar/components/NavCollapseButton.tsx
+++ b/front/src/modules/ui/navigation/navbar/components/NavCollapseButton.tsx
@@ -50,6 +50,7 @@ const NavCollapseButton = ({
   return (
     <>
       <StyledCollapseButton
+        initial={{ opacity: show ? 1 : 0 }}
         animate={{
           opacity: show ? 1 : 0,
         }}

--- a/front/src/modules/ui/navigation/navbar/components/NavbarAnimatedContainer.tsx
+++ b/front/src/modules/ui/navigation/navbar/components/NavbarAnimatedContainer.tsx
@@ -48,6 +48,7 @@ export const NavbarAnimatedContainer = ({
       onAnimationComplete={() => {
         setIsNavbarSwitchingSize(false);
       }}
+      initial={{ width: isNavbarOpened ? leftBarWidth : '0' }}
       animate={{
         width: isNavbarOpened ? leftBarWidth : '0',
         opacity: isNavbarOpened ? 1 : 0,


### PR DESCRIPTION
Fixes the layout shift of the page as the navbar is loaded and animated to open. Also fixes the navbar collapse icon flashing.
Sadly this doesn't fix the other layout shift problem described in #1512.


https://github.com/twentyhq/twenty/assets/48770548/87e329ff-b8fc-471d-905a-8cadebe59e70

