### PR TITLE
feat: custom objects delete one

### DIFF
--- a/server/src/tenant/entity-resolver/entity-resolver.service.ts
+++ b/server/src/tenant/entity-resolver/entity-resolver.service.ts
@@ -88,4 +88,19 @@ export class EntityResolverService {
 
     return runner.updateOne(args);
   }
+
+  async deleteOne(
+    args: { id: string },
+    context: SchemaBuilderContext,
+    info: GraphQLResolveInfo,
+  ) {
+    const runner = new PGGraphQLQueryRunner(this.dataSourceService, {
+      tableName: context.tableName,
+      workspaceId: context.workspaceId,
+      info,
+      fields: context.fields,
+    });
+
+    return runner.deleteOne(args);
+  }
 }

--- a/server/src/tenant/entity-resolver/pg-graphql/pg-graphql-query-builder.util.ts
+++ b/server/src/tenant/entity-resolver/pg-graphql/pg-graphql-query-builder.util.ts
@@ -19,6 +19,7 @@ type CommandArgs = {
   findOne: { filter?: any };
   createMany: { data: any[] };
   updateOne: { id: string; data: any };
+  deleteOne: { id: string };
 };
 
 export interface PGGraphQLQueryBuilderOptions {
@@ -114,5 +115,21 @@ export class PGGraphQLQueryBuilder {
         }
       }
     `;
+  }
+
+  deleteOne(args: CommandArgs['deleteOne']) {
+    const { tableName } = this.options;
+    const fieldsString = this.getFieldsString();
+
+    return `
+      mutation {
+        deleteFrom${tableName}Collection(filter: { id: { eq: "${args.id}" } }) {
+        affectedCount
+        records {
+          ${fieldsString}
+        }
+      }
+    }
+  `;
   }
 }

--- a/server/src/tenant/entity-resolver/pg-graphql/pg-graphql-query-runner.util.ts
+++ b/server/src/tenant/entity-resolver/pg-graphql/pg-graphql-query-runner.util.ts
@@ -108,6 +108,6 @@ export class PGGraphQLQueryRunner {
     const query = this.queryBuilder.deleteOne(args);
     const result = await this.execute(query, this.options.workspaceId);
 
-    return this.parseResult(result, 'delete')?.records?.[0];
+    return this.parseResult(result, 'deleteFrom')?.records?.[0];
   }
 }

--- a/server/src/tenant/entity-resolver/pg-graphql/pg-graphql-query-runner.util.ts
+++ b/server/src/tenant/entity-resolver/pg-graphql/pg-graphql-query-runner.util.ts
@@ -103,4 +103,11 @@ export class PGGraphQLQueryRunner {
 
     return this.parseResult(result, 'update')?.records?.[0];
   }
+
+  async deleteOne(args: { id: string }): Promise<any> {
+    const query = this.queryBuilder.deleteOne(args);
+    const result = await this.execute(query, this.options.workspaceId);
+
+    return this.parseResult(result, 'delete')?.records?.[0];
+  }
 }

--- a/server/src/tenant/schema-builder/schema-builder.service.ts
+++ b/server/src/tenant/schema-builder/schema-builder.service.ts
@@ -156,6 +156,19 @@ export class SchemaBuilderService {
           );
         },
       },
+      [`deleteOne${upperFirst(entityName.singular)}`]: {
+        type: new GraphQLNonNull(ObjectType),
+        args: {
+          id: { type: new GraphQLNonNull(GraphQLID) },
+        },
+        resolve: (root, args, context, info) => {
+          return this.entityResolverService.deleteOne(
+            args,
+            schemaBuilderContext,
+            info,
+          );
+        },
+      },
     } as GraphQLFieldConfigMap<any, any>;
   }
 


### PR DESCRIPTION
This PR add a new resolver for custom objects called `deleteOne${OBJECT_NAME}`.
For the moment the resolver only accept an id in parameter to delete an object.

<img width="372" alt="Screenshot 2023-10-30 at 12 01 44 PM" src="https://github.com/twentyhq/twenty/assets/3551795/0721af2b-647e-4fea-b02f-a9d1d9dbcdef">
