### PR TITLE
Fix api keys refresh

### DIFF
--- a/front/src/modules/apollo/optimistic-effect/hooks/useOptimisticEffect.ts
+++ b/front/src/modules/apollo/optimistic-effect/hooks/useOptimisticEffect.ts
@@ -121,11 +121,16 @@ export const useOptimisticEffect = () => {
           .getValue();
 
         Object.values(optimisticEffects).forEach((optimisticEffect) => {
+          // We need to update the typename when createObject type differs from listObject types
+          // It is the case for apiKey, where the creation route returns an ApiKeyToken type
+          const formattedNewData = newData.map((data) => {
+            return { ...data, __typename: typename };
+          });
           if (optimisticEffect.typename === typename) {
             optimisticEffect.writer({
               cache: apolloClient.cache,
               query: optimisticEffect.query,
-              newData,
+              newData: formattedNewData,
               variables: optimisticEffect.variables,
             });
           }


### PR DESCRIPTION
- Fix is in [this commit](https://github.com/twentyhq/twenty/pull/2283/commits/eee3914002b595f98c1618ab94528159a18107aa), the other one is just code style modif
- as `insertOneApiKey` returns an `ApiKeyToken` __typename object and `getApiKeys` returns a list of `ApiKey` __typename objects, evicting `ApiKey` __typename from the apollo cache is not enough, we should remove also the `ApiKeyToken` __typename. To make everything more simple, we just format the `ApiKeyToken` __typename into `ApiKey` when writing on the apollo cache