### PR TITLE
2299 fix(frontend): corrected tag spacing in settings object item table row

### DIFF
--- a/front/src/modules/settings/data-model/object-details/components/SettingsObjectItemTableRow.tsx
+++ b/front/src/modules/settings/data-model/object-details/components/SettingsObjectItemTableRow.tsx
@@ -24,15 +24,6 @@ const StyledNameTableCell = styled(TableCell)`
   gap: ${({ theme }) => theme.spacing(2)};
 `;
 
-const StyledTag = styled(Tag)`
-  box-sizing: border-box;
-  height: 16px;
-  padding-bottom: auto;
-  padding-left: 4px;
-  padding-right: 4px;
-  padding-top: auto;
-`;
-
 const StyledActionTableCell = styled(TableCell)`
   justify-content: center;
   padding-right: ${({ theme }) => theme.spacing(1)};
@@ -59,9 +50,9 @@ export const SettingsObjectItemTableRow = ({
       </StyledNameTableCell>
       <TableCell>
         {objectItem.isCustom ? (
-          <StyledTag color="orange" text="Custom" />
+          <Tag color="orange" text="Custom" size="small" />
         ) : (
-          <StyledTag color="blue" text="Standard" />
+          <Tag color="blue" text="Standard" size="small" />
         )}
       </TableCell>
       <TableCell align="right">{objectItem.fields.length}</TableCell>

--- a/front/src/modules/settings/data-model/object-details/components/SettingsObjectItemTableRow.tsx
+++ b/front/src/modules/settings/data-model/object-details/components/SettingsObjectItemTableRow.tsx
@@ -50,9 +50,9 @@ export const SettingsObjectItemTableRow = ({
       </StyledNameTableCell>
       <TableCell>
         {objectItem.isCustom ? (
-          <Tag color="orange" text="Custom" size="small" />
+          <Tag color="orange" text="Custom" />
         ) : (
-          <Tag color="blue" text="Standard" size="small" />
+          <Tag color="blue" text="Standard" />
         )}
       </TableCell>
       <TableCell align="right">{objectItem.fields.length}</TableCell>

--- a/front/src/modules/settings/data-model/object-details/components/SettingsObjectItemTableRow.tsx
+++ b/front/src/modules/settings/data-model/object-details/components/SettingsObjectItemTableRow.tsx
@@ -26,7 +26,11 @@ const StyledNameTableCell = styled(TableCell)`
 
 const StyledTag = styled(Tag)`
   box-sizing: border-box;
-  height: ${({ theme }) => theme.spacing(4)};
+  height: 16px;
+  padding-bottom: auto;
+  padding-left: 4px;
+  padding-right: 4px;
+  padding-top: auto;
 `;
 
 const StyledActionTableCell = styled(TableCell)`

--- a/front/src/modules/ui/display/tag/components/Tag.tsx
+++ b/front/src/modules/ui/display/tag/components/Tag.tsx
@@ -15,14 +15,6 @@ const tagColors = [
   'gray',
 ];
 
-const sizeHeight = {
-  small: 4,
-  medium: 5,
-  large: 6,
-};
-
-type Sizes = 'small' | 'medium' | 'large';
-
 export type TagColor = (typeof tagColors)[number];
 
 export const castToTagColor = (color: string): TagColor =>
@@ -30,7 +22,6 @@ export const castToTagColor = (color: string): TagColor =>
 
 const StyledTag = styled.h3<{
   color: TagColor;
-  size: Sizes;
 }>`
   align-items: center;
   background: ${({ color, theme }) => theme.tag.background[color]};
@@ -42,7 +33,7 @@ const StyledTag = styled.h3<{
   font-style: normal;
   font-weight: ${({ theme }) => theme.font.weight.medium};
   gap: ${({ theme }) => theme.spacing(2)};
-  height: ${({ size, theme }) => theme.spacing(sizeHeight[size])};
+  height: ${({ theme }) => theme.spacing(5)};
   margin: 0;
   padding-left: ${({ theme }) => theme.spacing(2)};
   padding-right: ${({ theme }) => theme.spacing(2)};
@@ -52,22 +43,14 @@ export type TagProps = {
   className?: string;
   color: ThemeColor;
   text: string;
-  size?: Sizes;
   onClick?: () => void;
 };
 
-export const Tag = ({
-  className,
-  color,
-  text,
-  size = 'large',
-  onClick,
-}: TagProps) => (
+export const Tag = ({ className, color, text, onClick }: TagProps) => (
   <StyledTag
     className={className}
     color={castToTagColor(color)}
     onClick={onClick}
-    size={size}
   >
     {text}
   </StyledTag>

--- a/front/src/modules/ui/display/tag/components/Tag.tsx
+++ b/front/src/modules/ui/display/tag/components/Tag.tsx
@@ -15,6 +15,14 @@ const tagColors = [
   'gray',
 ];
 
+const sizeHeight = {
+  small: 4,
+  medium: 5,
+  large: 6,
+};
+
+type Sizes = 'small' | 'medium' | 'large';
+
 export type TagColor = (typeof tagColors)[number];
 
 export const castToTagColor = (color: string): TagColor =>
@@ -22,6 +30,7 @@ export const castToTagColor = (color: string): TagColor =>
 
 const StyledTag = styled.h3<{
   color: TagColor;
+  size: Sizes;
 }>`
   align-items: center;
   background: ${({ color, theme }) => theme.tag.background[color]};
@@ -33,25 +42,32 @@ const StyledTag = styled.h3<{
   font-style: normal;
   font-weight: ${({ theme }) => theme.font.weight.medium};
   gap: ${({ theme }) => theme.spacing(2)};
+  height: ${({ size, theme }) => theme.spacing(sizeHeight[size])};
   margin: 0;
-  padding-bottom: ${({ theme }) => theme.spacing(1)};
   padding-left: ${({ theme }) => theme.spacing(2)};
   padding-right: ${({ theme }) => theme.spacing(2)};
-  padding-top: ${({ theme }) => theme.spacing(1)};
 `;
 
 export type TagProps = {
   className?: string;
   color: ThemeColor;
   text: string;
+  size?: Sizes;
   onClick?: () => void;
 };
 
-export const Tag = ({ className, color, text, onClick }: TagProps) => (
+export const Tag = ({
+  className,
+  color,
+  text,
+  size = 'large',
+  onClick,
+}: TagProps) => (
   <StyledTag
     className={className}
     color={castToTagColor(color)}
     onClick={onClick}
+    size={size}
   >
     {text}
   </StyledTag>


### PR DESCRIPTION
Closes #2299 

Text is now centred and horizontal padding rectified.

<img width="1440" alt="Screenshot 2023-10-31 at 9 34 40 PM" src="https://github.com/twentyhq/twenty/assets/62852363/4f925c78-ad5a-437d-9d9c-68679e2b7f5e">
