### PR TITLE
Add new Dockerfile for postgres

### DIFF
--- a/infra/build/postgres/Dockerfile
+++ b/infra/build/postgres/Dockerfile
@@ -29,6 +29,8 @@ RUN apt update && apt install -y curl
 RUN curl -L "https://github.com/supabase/pg_graphql/releases/download/v${PG_GRAPHQL_VERSION}/pg_graphql-v${PG_GRAPHQL_VERSION}-pg${PG_MAIN_VERSION}-${TARGETARCH}-linux-gnu.deb" -o pg_graphql.deb
 RUN dpkg --install pg_graphql.deb
 
-COPY ./init.sql /docker-entrypoint-initdb.d/
+COPY ./infra/build/postgres/init.sql /docker-entrypoint-initdb.d/
 
 USER 1001
+ENTRYPOINT [ "/opt/bitnami/scripts/postgresql/entrypoint.sh" ]
+CMD [ "/opt/bitnami/scripts/postgresql/run.sh" ]

--- a/infra/build/postgres/Dockerfile
+++ b/infra/build/postgres/Dockerfile
@@ -1,10 +1,12 @@
-ARG PG_MAIN_VERSION=14
+ARG IMAGE_TAG='15.4.0-debian-11-r45'
 
-FROM postgres:${PG_MAIN_VERSION} as postgres
+FROM bitnami/postgresql:${IMAGE_TAG}
 
-ARG PG_MAIN_VERSION
+ARG PG_MAIN_VERSION=15
 ARG PG_GRAPHQL_VERSION=1.3.0
 ARG TARGETARCH
+
+USER root
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
@@ -27,4 +29,6 @@ RUN apt update && apt install -y curl
 RUN curl -L "https://github.com/supabase/pg_graphql/releases/download/v${PG_GRAPHQL_VERSION}/pg_graphql-v${PG_GRAPHQL_VERSION}-pg${PG_MAIN_VERSION}-${TARGETARCH}-linux-gnu.deb" -o pg_graphql.deb
 RUN dpkg --install pg_graphql.deb
 
-COPY ./infra/build/postgres/init.sql /docker-entrypoint-initdb.d/
+COPY ./init.sql /docker-entrypoint-initdb.d/
+
+USER 1001

--- a/infra/release/build-postgres.sh
+++ b/infra/release/build-postgres.sh
@@ -1,0 +1,6 @@
+
+docker buildx build \
+--push \
+--no-cache \
+--platform linux/amd64,linux/arm64 \
+-f ./infra/build/postgres/Dockerfile -t twentycrm/twenty-postgres:0.2.0 -t twentycrm/twenty-postgres:latest .


### PR DESCRIPTION
This PR builds a docker image for twenty postgres. This potsgres image contains postgresql with pg_graphql pre-installed. This is useful to ease setting up Twenty in production (Twenty cloud or Render one-click to deploy)