### PR TITLE
fix: update cleanup command to reflect current volume naming

### DIFF
--- a/infra/dev/Makefile
+++ b/infra/dev/Makefile
@@ -3,9 +3,9 @@ build:
 	rm -rf ../../front/node_modules
 	rm -rf ../../server/node_modules
 	rm -rf ../../docs/node_modules
-	@docker volume rm dev_twenty_node_modules_front > /dev/null 2>&1 || true
-	@docker volume rm dev_twenty_node_modules_server > /dev/null 2>&1 || true
-	@docker volume rm dev_twenty_node_modules_docs > /dev/null 2>&1 || true
+	@docker volume rm twenty_node_modules_front > /dev/null 2>&1 || true
+	@docker volume rm twenty_node_modules_server > /dev/null 2>&1 || true
+	@docker volume rm twenty_node_modules_docs > /dev/null 2>&1 || true
 	@docker compose build
 
 provision-postgres:


### PR DESCRIPTION
This pull request updates the cleanup command in our `build/dev/makefile -> build:` scripts to align with our current Docker volume naming conventions. The previous command attempted to remove a volume named `dev_twenty_node_modules_front`, which no longer exists.

