### PR TITLE
Fix entity tasks filter scopeid bug

### DIFF
--- a/front/src/modules/activities/tasks/components/EntityTasks.tsx
+++ b/front/src/modules/activities/tasks/components/EntityTasks.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import { TasksRecoilScopeContext } from '@/activities/states/recoil-scope-contexts/TasksRecoilScopeContext';
 import { TaskGroups } from '@/activities/tasks/components/TaskGroups';
 import { ActivityTargetableEntity } from '@/activities/types/ActivityTargetableEntity';
+import { ObjectFilterDropdownScope } from '@/ui/object/object-filter-dropdown/scopes/ObjectFilterDropdownScope';
 import { RecoilScope } from '@/ui/utilities/recoil-scope/components/RecoilScope';
 
 const StyledContainer = styled.div`
@@ -21,7 +22,9 @@ export const EntityTasks = ({
   return (
     <StyledContainer>
       <RecoilScope CustomRecoilScopeContext={TasksRecoilScopeContext}>
-        <TaskGroups entity={entity} showAddButton />
+        <ObjectFilterDropdownScope filterScopeId="entity-tasks-filter-scope">
+          <TaskGroups entity={entity} showAddButton />
+        </ObjectFilterDropdownScope>
       </RecoilScope>
     </StyledContainer>
   );


### PR DESCRIPTION
EntityTasks uses useTask() which calls useFilter() even if there is no filter here. useFilter() needs a filter scope id to work, which was not provided. We have to think about the decoupling between Tasks and EntityTasks in the future.