### PR TITLE
Fix firefox recoil snapshot bug

### DIFF
--- a/front/src/modules/debug/components/RecoilDebugObserver.tsx
+++ b/front/src/modules/debug/components/RecoilDebugObserver.tsx
@@ -1,5 +1,4 @@
-import { useEffect } from 'react';
-import { useRecoilSnapshot, useRecoilValue } from 'recoil';
+import { useRecoilTransactionObserver_UNSTABLE, useRecoilValue } from 'recoil';
 
 import { isDebugModeState } from '@/client-config/states/isDebugModeState';
 import { logDebug } from '~/utils/logDebug';
@@ -16,15 +15,12 @@ const formatTitle = (stateName: string) => {
 };
 
 export const RecoilDebugObserverEffect = () => {
-  const snapshot = useRecoilSnapshot();
-
   const isDebugMode = useRecoilValue(isDebugModeState);
 
-  useEffect(() => {
+  useRecoilTransactionObserver_UNSTABLE(({ snapshot }) => {
     if (!isDebugMode) {
       return;
     }
-
     for (const node of Array.from(
       snapshot.getNodes_UNSTABLE({ isModified: true }),
     )) {
@@ -40,7 +36,6 @@ export const RecoilDebugObserverEffect = () => {
 
       console.groupEnd();
     }
-  }, [isDebugMode, snapshot]);
-
+  });
   return null;
 };


### PR DESCRIPTION
Using useRecoilSnapshot() to debug on Firefox creates an error: https://github.com/facebookexperimental/Recoil/issues/1994 .
I used [useRecoilTransactionObserver_UNSTABLE](https://recoiljs.org/docs/api-reference/core/useRecoilTransactionObserver) instead which fixes the issue.