### PR TITLE
Fix navbar animation layout shift

### DIFF
--- a/front/src/modules/ui/layout/page/DefaultLayout.tsx
+++ b/front/src/modules/ui/layout/page/DefaultLayout.tsx
@@ -39,16 +39,11 @@ const StyledLayout = styled.div`
   }
 `;
 
-const NAVBAR_WIDTH = '236px';
-
 const StyledMainContainer = styled.div`
   display: flex;
+  flex: 1;
   flex-direction: row;
   overflow: hidden;
-  width: ${() =>
-    useRecoilValue(isNavbarOpenedState)
-      ? `calc(100% - ${NAVBAR_WIDTH})`
-      : '100%'};
   @media (max-width: ${MOBILE_VIEWPORT}px) {
     width: ${() => (useRecoilValue(isNavbarOpenedState) ? '0' : '100%')};
   }

--- a/front/src/modules/ui/navigation/navbar/components/NavCollapseButton.tsx
+++ b/front/src/modules/ui/navigation/navbar/components/NavCollapseButton.tsx
@@ -50,7 +50,7 @@ const NavCollapseButton = ({
   return (
     <>
       <StyledCollapseButton
-        initial={{ opacity: show ? 1 : 0 }}
+        initial={false}
         animate={{
           opacity: show ? 1 : 0,
         }}

--- a/front/src/modules/ui/navigation/navbar/components/NavbarAnimatedContainer.tsx
+++ b/front/src/modules/ui/navigation/navbar/components/NavbarAnimatedContainer.tsx
@@ -48,7 +48,7 @@ export const NavbarAnimatedContainer = ({
       onAnimationComplete={() => {
         setIsNavbarSwitchingSize(false);
       }}
-      initial={{ width: isNavbarOpened ? leftBarWidth : '0' }}
+      initial={false}
       animate={{
         width: isNavbarOpened ? leftBarWidth : '0',
         opacity: isNavbarOpened ? 1 : 0,


### PR DESCRIPTION
Second part of the layout shift problem. Found the problem: it was a conditionally set width which was not animated. 

Also changed the initial values to false for simplicity ... 

closes #1512


https://github.com/twentyhq/twenty/assets/48770548/bd928c80-3355-45be-ad38-b8a35f3ae1cd


