### PR TITLE
fix: Remove /dev/null usage for Windows compatibility

### DIFF
--- a/infra/dev/Makefile
+++ b/infra/dev/Makefile
@@ -3,9 +3,9 @@ build:
 	rm -rf ../../front/node_modules
 	rm -rf ../../server/node_modules
 	rm -rf ../../docs/node_modules
-	@docker volume rm twenty_node_modules_front > /dev/null 2>&1 || true
-	@docker volume rm twenty_node_modules_server > /dev/null 2>&1 || true
-	@docker volume rm twenty_node_modules_docs > /dev/null 2>&1 || true
+	@docker volume rm twenty_node_modules_front || true
+	@docker volume rm twenty_node_modules_server || true
+	@docker volume rm twenty_node_modules_docs || true
 	@docker compose build
 
 provision-postgres:


### PR DESCRIPTION
Removed /dev/null command to make sure script works correctly on Windows