### PR TITLE
Fix google auth url broken

### DIFF
--- a/front/src/config/index.ts
+++ b/front/src/config/index.ts
@@ -12,9 +12,9 @@ export const REACT_APP_SERVER_BASE_URL =
 export const REACT_APP_SERVER_AUTH_URL =
   window._env_?.REACT_APP_SERVER_AUTH_URL ||
   process.env.REACT_APP_SERVER_AUTH_URL ||
-  'http://localhost:3000';
+  REACT_APP_SERVER_BASE_URL + '/auth';
 
 export const REACT_APP_SERVER_FILES_URL =
   window._env_?.REACT_APP_SERVER_FILES_URL ||
   process.env.REACT_APP_SERVER_FILES_URL ||
-  'http://localhost:3000';
+  REACT_APP_SERVER_BASE_URL + '/files';

--- a/front/src/config/index.ts
+++ b/front/src/config/index.ts
@@ -8,3 +8,13 @@ export const REACT_APP_SERVER_BASE_URL =
   window._env_?.REACT_APP_SERVER_BASE_URL ||
   process.env.REACT_APP_SERVER_BASE_URL ||
   'http://localhost:3000';
+
+export const REACT_APP_SERVER_AUTH_URL =
+  window._env_?.REACT_APP_SERVER_AUTH_URL ||
+  process.env.REACT_APP_SERVER_AUTH_URL ||
+  'http://localhost:3000';
+
+export const REACT_APP_SERVER_FILES_URL =
+  window._env_?.REACT_APP_SERVER_FILES_URL ||
+  process.env.REACT_APP_SERVER_FILES_URL ||
+  'http://localhost:3000';

--- a/front/src/modules/auth/hooks/useAuth.ts
+++ b/front/src/modules/auth/hooks/useAuth.ts
@@ -6,7 +6,7 @@ import {
   useRecoilState,
 } from 'recoil';
 
-import { REACT_APP_SERVER_AUTH_URL, REACT_APP_SERVER_BASE_URL } from '~/config';
+import { REACT_APP_SERVER_AUTH_URL } from '~/config';
 import {
   useChallengeMutation,
   useCheckUserExistsLazyQuery,
@@ -136,8 +136,7 @@ export const useAuth = () => {
   );
 
   const handleGoogleLogin = useCallback((workspaceInviteHash?: string) => {
-    const authServerUrl =
-      REACT_APP_SERVER_AUTH_URL ?? REACT_APP_SERVER_BASE_URL + '/auth';
+    const authServerUrl = REACT_APP_SERVER_AUTH_URL;
     window.location.href =
       `${authServerUrl}/google/${
         workspaceInviteHash ? '?inviteHash=' + workspaceInviteHash : ''

--- a/front/src/modules/auth/hooks/useAuth.ts
+++ b/front/src/modules/auth/hooks/useAuth.ts
@@ -6,7 +6,7 @@ import {
   useRecoilState,
 } from 'recoil';
 
-import { REACT_APP_SERVER_BASE_URL } from '~/config';
+import { REACT_APP_SERVER_AUTH_URL, REACT_APP_SERVER_BASE_URL } from '~/config';
 import {
   useChallengeMutation,
   useCheckUserExistsLazyQuery,
@@ -137,7 +137,7 @@ export const useAuth = () => {
 
   const handleGoogleLogin = useCallback((workspaceInviteHash?: string) => {
     const authServerUrl =
-      REACT_APP_SERVER_BASE_URL ?? REACT_APP_SERVER_BASE_URL + '/auth';
+      REACT_APP_SERVER_AUTH_URL ?? REACT_APP_SERVER_BASE_URL + '/auth';
     window.location.href =
       `${authServerUrl}/google/${
         workspaceInviteHash ? '?inviteHash=' + workspaceInviteHash : ''

--- a/front/src/modules/users/utils/getProfilePictureAbsoluteURI.ts
+++ b/front/src/modules/users/utils/getProfilePictureAbsoluteURI.ts
@@ -1,4 +1,7 @@
-import { REACT_APP_SERVER_BASE_URL } from '~/config';
+import {
+  REACT_APP_SERVER_BASE_URL,
+  REACT_APP_SERVER_FILES_URL,
+} from '~/config';
 
 export const getImageAbsoluteURIOrBase64 = (imageUrl?: string | null) => {
   if (!imageUrl) {
@@ -14,7 +17,7 @@ export const getImageAbsoluteURIOrBase64 = (imageUrl?: string | null) => {
   }
 
   const serverFilesUrl =
-    REACT_APP_SERVER_BASE_URL ?? REACT_APP_SERVER_BASE_URL + '/files';
+    REACT_APP_SERVER_FILES_URL ?? REACT_APP_SERVER_BASE_URL + '/files';
 
   return `${serverFilesUrl}/${imageUrl}`;
 };

--- a/front/src/modules/users/utils/getProfilePictureAbsoluteURI.ts
+++ b/front/src/modules/users/utils/getProfilePictureAbsoluteURI.ts
@@ -1,7 +1,4 @@
-import {
-  REACT_APP_SERVER_BASE_URL,
-  REACT_APP_SERVER_FILES_URL,
-} from '~/config';
+import { REACT_APP_SERVER_FILES_URL } from '~/config';
 
 export const getImageAbsoluteURIOrBase64 = (imageUrl?: string | null) => {
   if (!imageUrl) {
@@ -16,8 +13,7 @@ export const getImageAbsoluteURIOrBase64 = (imageUrl?: string | null) => {
     return imageUrl;
   }
 
-  const serverFilesUrl =
-    REACT_APP_SERVER_FILES_URL ?? REACT_APP_SERVER_BASE_URL + '/files';
+  const serverFilesUrl = REACT_APP_SERVER_FILES_URL;
 
   return `${serverFilesUrl}/${imageUrl}`;
 };


### PR DESCRIPTION
In a Previous PR #2179 , we have added the possibility to provide environment variable at runtime to front container. This allow us to use pre-built docker image.
While doing it, we have introduced regressions regarding the support of custom server url for AUTH and FILES endpoints