### PR TITLE
FIX: Corrected button border color for danger button

### DIFF
--- a/front/src/modules/ui/input/button/components/Button.tsx
+++ b/front/src/modules/ui/input/button/components/Button.tsx
@@ -208,7 +208,7 @@ const StyledButton = styled.button<
                 variant === 'secondary'
                   ? focus
                     ? theme.color.red
-                    : theme.color.red20
+                    : theme.border.color.danger
                   : focus
                   ? theme.color.red
                   : 'transparent'

--- a/front/src/modules/ui/layout/modal/components/ConfirmationModal.tsx
+++ b/front/src/modules/ui/layout/modal/components/ConfirmationModal.tsx
@@ -43,7 +43,7 @@ const StyledCenteredTitle = styled.div`
 `;
 
 export const StyledConfirmationButton = styled(StyledCenteredButton)`
-  border-color: ${({ theme }) => theme.color.red20};
+  border-color: ${({ theme }) => theme.border.color.danger};
   box-shadow: none;
   color: ${({ theme }) => theme.color.red};
   font-size: ${({ theme }) => theme.font.size.md};


### PR DESCRIPTION
fix for incorrect danger button border color in dark mode https://github.com/twentyhq/twenty/issues/2396
 - Changed styles to use Border/Danger border color as recommended in the issue
 
<img width="468" alt="Screenshot 2023-11-08 at 21 51 13" src="https://github.com/uwem-RH/twenty/assets/30045115/ad8ad417-8e3b-45ad-8d7c-47115d78c47d">
<img width="468" alt="Screenshot 2023-11-08 at 21 51 28" src="https://github.com/uwem-RH/twenty/assets/30045115/60aa8acf-5c07-4aa6-babb-f8bb434f5082">
