### PR TITLE
Fix table last column not being displayed

### DIFF
--- a/front/src/modules/ui/object/record-table/components/RecordTable.tsx
+++ b/front/src/modules/ui/object/record-table/components/RecordTable.tsx
@@ -41,9 +41,6 @@ const StyledTable = styled.table`
       border-left-color: transparent;
       border-right-color: transparent;
     }
-    :last-of-type {
-      width: 100%;
-    }
   }
 
   td {


### PR DESCRIPTION
@Kanav-Arora :)
Before:

![image](https://github.com/twentyhq/twenty/assets/12035771/24c3f17c-c6b9-4e4a-ae5d-fea9904d795c)

After:

<img width="1512" alt="image" src="https://github.com/twentyhq/twenty/assets/12035771/df19d3b3-fdf9-4ea5-8793-47b57020bdf1">


<img width="1512" alt="image" src="https://github.com/twentyhq/twenty/assets/12035771/e2522226-2976-4988-85fc-09bf2562103a">

