### PR TITLE
infra: add make commands for provisioning postgres in macos and linux

### DIFF
--- a/docs/docs/contributor/local-setup/yarn-setup.mdx
+++ b/docs/docs/contributor/local-setup/yarn-setup.mdx
@@ -106,7 +106,7 @@ You need to provision this database with a `twenty` user (password: `twenty`), a
 
 ```bash
 cd twenty
-./infra/dev/scripts/setup-postgres-linux.sh
+make provision-postgres-linux
 ```
 
 <b>Option 2:</b> If you have docker installed:
@@ -114,7 +114,7 @@ cd twenty
 
 ```bash
 cd twenty
-make provision-postgres
+make provision-postgres-docker
 ```
 This will create a Docker container, exposing a PostgresSQL instance at [http://localhost:5432](http://localhost:5432).
 You can access this using `twenty` postgres user (password: `twenty`)
@@ -126,7 +126,7 @@ You can access this using `twenty` postgres user (password: `twenty`)
 
 ```bash
 cd twenty
-./infra/dev/scripts/setup-postgres-macos.sh
+make provision-postgres-macos
 ```
 
 <b>Option 2:</b> If you have docker installed:
@@ -134,7 +134,7 @@ cd twenty
 
 ```bash
 cd twenty
-make provision-postgres
+make provision-postgres-docker
 ```
 This will create a Docker container, exposing a PostgresSQL instance at [http://localhost:5432](http://localhost:5432).
 You can access this using `twenty` postgres user (password: `twenty`)

--- a/infra/dev/Makefile
+++ b/infra/dev/Makefile
@@ -8,11 +8,17 @@ build:
 	@docker volume rm twenty_node_modules_docs > /dev/null 2>&1 || true
 	@docker compose build
 
-provision-postgres:
+provision-postgres-docker:
 	@docker stop twenty_postgres || true
 	@docker rm twenty_postgres || true
 	@docker volume rm twenty_db_data || true
 	@docker compose up --build postgres -d
+
+provision-postgres-macos:
+	sh ./scripts/setup-postgres-macos.sh
+
+provision-postgres-linux:
+	sh ./scripts/setup-postgres-linux.sh
 
 up:
 	@docker compose up -d


### PR DESCRIPTION
Closes #2412 
This adds make commands to provision postgres in macos and linux environment. 
This also renames the existing command for provisioning the same on docker. This makes everything more symmetric.

@charlesBochet Please let me know if this is what you were looking for. If not, please help me by posting a little explanation. I will be happy to do it :)

Thanks in advance.