### PR TITLE
Fix single note in grid

### DIFF
--- a/front/src/modules/activities/notes/components/NoteCard.tsx
+++ b/front/src/modules/activities/notes/components/NoteCard.tsx
@@ -11,7 +11,7 @@ import {
 } from '@/ui/object/field/contexts/FieldContext';
 import { Activity, ActivityTarget, Comment } from '~/generated/graphql';
 
-const StyledCard = styled.div`
+const StyledCard = styled.div<{ isSingleNote: boolean }>`
   align-items: flex-start;
   background: ${({ theme }) => theme.background.secondary};
   border: 1px solid ${({ theme }) => theme.border.color.medium};
@@ -20,6 +20,7 @@ const StyledCard = styled.div`
   flex-direction: column;
   height: 300px;
   justify-content: space-between;
+  max-width: ${({ isSingleNote }) => (isSingleNote ? '300px' : 'unset')};
 `;
 
 const StyledCardDetailsContainer = styled.div`
@@ -73,6 +74,7 @@ const StyledCommentIcon = styled.div`
 
 export const NoteCard = ({
   note,
+  isSingleNote,
 }: {
   note: Pick<
     Activity,
@@ -81,6 +83,7 @@ export const NoteCard = ({
     activityTargets?: Array<Pick<ActivityTarget, 'id'>> | null;
     comments?: Array<Pick<Comment, 'id'>> | null;
   };
+  isSingleNote: boolean;
 }) => {
   const theme = useTheme();
   const openActivityRightDrawer = useOpenActivityRightDrawer();
@@ -95,7 +98,7 @@ export const NoteCard = ({
 
   return (
     <FieldContext.Provider value={fieldContext as GenericFieldContextType}>
-      <StyledCard>
+      <StyledCard isSingleNote={isSingleNote}>
         <StyledCardDetailsContainer
           onClick={() => openActivityRightDrawer(note.id)}
         >

--- a/front/src/modules/activities/notes/components/NoteList.tsx
+++ b/front/src/modules/activities/notes/components/NoteList.tsx
@@ -59,7 +59,11 @@ export const NoteList = ({ title, notes, button }: NoteListProps) => (
         </StyledTitleBar>
         <StyledNoteContainer>
           {notes.map((note) => (
-            <NoteCard key={note.id} note={note} />
+            <NoteCard
+              key={note.id}
+              note={note}
+              isSingleNote={notes.length == 1}
+            />
           ))}
         </StyledNoteContainer>
       </StyledContainer>


### PR DESCRIPTION
I just fixed the special case in js as I think the css grid doesn't allow us to achieve the desired behavior with multiple cards and just one card. 

<img width="985" alt="Bildschirmfoto 2023-11-11 um 16 35 59" src="https://github.com/twentyhq/twenty/assets/48770548/631db4cc-97d7-4748-8894-67a3e8a9b3f7">

closes #1966