### PR TITLE
feat: Unfocus cells when mouse leaves the table

### DIFF
--- a/front/src/modules/ui/object/record-table/components/RecordTableV1.tsx
+++ b/front/src/modules/ui/object/record-table/components/RecordTableV1.tsx
@@ -90,6 +90,7 @@ export const RecordTableV1 = ({ updateEntityMutation }: RecordTableV1Props) => {
     setRowSelectedState,
     resetTableRowSelection,
     useMapKeyboardToSoftFocus,
+    getIsSomeCellInEditMode,
   } = useRecordTable();
 
   useMapKeyboardToSoftFocus();
@@ -117,11 +118,17 @@ export const RecordTableV1 = ({ updateEntityMutation }: RecordTableV1Props) => {
     },
   });
 
+  const handleMouseLeave = () => {
+    const isSomeCellInEditMode = getIsSomeCellInEditMode();
+    if (isSomeCellInEditMode) return;
+    leaveTableFocus();
+  };
+
   return (
     <EntityUpdateMutationContext.Provider value={updateEntityMutation}>
       <StyledTableWithHeader>
         <StyledTableContainer>
-          <div ref={tableBodyRef} onMouseLeave={leaveTableFocus}>
+          <div ref={tableBodyRef} onMouseLeave={handleMouseLeave}>
             <StyledTable className="entity-table-cell">
               <RecordTableHeader />
               <RecordTableBodyV1 />

--- a/front/src/modules/ui/object/record-table/components/RecordTableV1.tsx
+++ b/front/src/modules/ui/object/record-table/components/RecordTableV1.tsx
@@ -121,7 +121,7 @@ export const RecordTableV1 = ({ updateEntityMutation }: RecordTableV1Props) => {
     <EntityUpdateMutationContext.Provider value={updateEntityMutation}>
       <StyledTableWithHeader>
         <StyledTableContainer>
-          <div ref={tableBodyRef}>
+          <div ref={tableBodyRef} onMouseLeave={leaveTableFocus}>
             <StyledTable className="entity-table-cell">
               <RecordTableHeader />
               <RecordTableBodyV1 />


### PR DESCRIPTION
- Added `leaveTableFocus` as `onMouseLeave` event callback in RecordTableV1

Closes: https://github.com/twentyhq/twenty/issues/2395



https://github.com/twentyhq/twenty/assets/30045115/7dffe40b-92b7-4ca8-8b22-2328eaf8a472

