### PR TITLE
Fix date dropdown width

### DIFF
--- a/front/src/modules/ui/object/object-filter-dropdown/components/MultipleFiltersDropdownFilterOnFilterChangedEffect.tsx
+++ b/front/src/modules/ui/object/object-filter-dropdown/components/MultipleFiltersDropdownFilterOnFilterChangedEffect.tsx
@@ -11,7 +11,7 @@ export const MultipleFiltersDropdownFilterOnFilterChangedEffect = ({
 
   useEffect(() => {
     switch (filterDefinitionUsedInDropdownType) {
-      case 'date':
+      case 'DATE':
         setDropdownWidth(280);
         break;
       default:


### PR DESCRIPTION
<img width="383" alt="Capture d’écran 2023-11-13 à 18 18 57" src="https://github.com/twentyhq/twenty/assets/71827178/6dbd5c72-8c4a-4680-ba1d-08b357b8823f">
