### PR TITLE
Complete all standard object migration to the new workspace schema

### DIFF
--- a/server/src/database/typeorm-seeds/metadata/field-metadata/activity.ts
+++ b/server/src/database/typeorm-seeds/metadata/field-metadata/activity.ts
@@ -100,7 +100,7 @@ export const seedActivityFieldMetadata = async (
         isCustom: false,
         workspaceId: SeedWorkspaceId,
         isActive: true,
-        type: 'TEXT',
+        type: 'DATE',
         name: 'reminderAt',
         label: 'Reminder Date',
         targetColumnMap: {
@@ -116,7 +116,7 @@ export const seedActivityFieldMetadata = async (
         isCustom: false,
         workspaceId: SeedWorkspaceId,
         isActive: true,
-        type: 'TEXT',
+        type: 'DATE',
         name: 'dueAt',
         label: 'Due Date',
         targetColumnMap: {
@@ -132,7 +132,7 @@ export const seedActivityFieldMetadata = async (
         isCustom: false,
         workspaceId: SeedWorkspaceId,
         isActive: true,
-        type: 'TEXT',
+        type: 'DATE',
         name: 'completedAt',
         label: 'Completion Date',
         targetColumnMap: {

--- a/server/src/database/typeorm-seeds/metadata/field-metadata/api-key.ts
+++ b/server/src/database/typeorm-seeds/metadata/field-metadata/api-key.ts
@@ -57,7 +57,7 @@ export const seedApiKeyFieldMetadata = async (
         isCustom: false,
         workspaceId: SeedWorkspaceId,
         isActive: true,
-        type: 'TEXT',
+        type: 'DATE',
         name: 'expiresAt',
         label: 'Expiration date',
         targetColumnMap: {
@@ -73,7 +73,7 @@ export const seedApiKeyFieldMetadata = async (
         isCustom: false,
         workspaceId: SeedWorkspaceId,
         isActive: true,
-        type: 'TEXT',
+        type: 'DATE',
         name: 'revokedAt',
         label: 'Revocation date',
         targetColumnMap: {

--- a/server/src/database/typeorm-seeds/metadata/field-metadata/favorite.ts
+++ b/server/src/database/typeorm-seeds/metadata/field-metadata/favorite.ts
@@ -44,7 +44,7 @@ export const seedFavoriteFieldMetadata = async (
         isCustom: false,
         workspaceId: SeedWorkspaceId,
         isActive: true,
-        type: 'TEXT',
+        type: 'NUMBER',
         name: 'position',
         label: 'Position',
         targetColumnMap: {

--- a/server/src/database/typeorm-seeds/metadata/field-metadata/opportunity.ts
+++ b/server/src/database/typeorm-seeds/metadata/field-metadata/opportunity.ts
@@ -46,7 +46,7 @@ export const seedOpportunityFieldMetadata = async (
         isCustom: false,
         workspaceId: SeedWorkspaceId,
         isActive: true,
-        type: 'MONEY',
+        type: 'NUMBER',
         name: 'amount',
         label: 'Amount',
         targetColumnMap: {
@@ -78,7 +78,7 @@ export const seedOpportunityFieldMetadata = async (
         isCustom: false,
         workspaceId: SeedWorkspaceId,
         isActive: true,
-        type: 'PROBABILITY',
+        type: 'TEXT',
         name: 'probability',
         label: 'Probability',
         targetColumnMap: {

--- a/server/src/database/typeorm-seeds/metadata/field-metadata/workspace-member-setting.ts
+++ b/server/src/database/typeorm-seeds/metadata/field-metadata/workspace-member-setting.ts
@@ -5,13 +5,13 @@ import { SeedWorkspaceId } from 'src/database/seeds/metadata';
 
 const fieldMetadataTableName = 'fieldMetadata';
 
-export enum SeedWorkspaceMemberSettingsFieldMetadataIds {
+export enum SeedWorkspaceMemberSettingFieldMetadataIds {
   ColorScheme = '20202020-d7b7-4f2e-bb52-90d3fd78007a',
   Locale = '20202020-10f6-4df9-8d6f-a760b65bd800',
   WorkspaceMember = '20202020-83f2-4c5f-96b0-0c51ecc160e3',
 }
 
-export const seedWorkspaceMemberSettingsFieldMetadata = async (
+export const seedWorkspaceMemberSettingFieldMetadata = async (
   workspaceDataSource: DataSource,
   schemaName: string,
 ) => {
@@ -36,8 +36,8 @@ export const seedWorkspaceMemberSettingsFieldMetadata = async (
     .values([
       // Scalar fields
       {
-        id: SeedWorkspaceMemberSettingsFieldMetadataIds.ColorScheme,
-        objectMetadataId: SeedObjectMetadataIds.WorkspaceMemberSettings,
+        id: SeedWorkspaceMemberSettingFieldMetadataIds.ColorScheme,
+        objectMetadataId: SeedObjectMetadataIds.WorkspaceMemberSetting,
         isCustom: false,
         workspaceId: SeedWorkspaceId,
         isActive: true,
@@ -52,8 +52,8 @@ export const seedWorkspaceMemberSettingsFieldMetadata = async (
         isNullable: false,
       },
       {
-        id: SeedWorkspaceMemberSettingsFieldMetadataIds.Locale,
-        objectMetadataId: SeedObjectMetadataIds.WorkspaceMemberSettings,
+        id: SeedWorkspaceMemberSettingFieldMetadataIds.Locale,
+        objectMetadataId: SeedObjectMetadataIds.WorkspaceMemberSetting,
         isCustom: false,
         workspaceId: SeedWorkspaceId,
         isActive: true,
@@ -61,7 +61,7 @@ export const seedWorkspaceMemberSettingsFieldMetadata = async (
         name: 'locale',
         label: 'Language',
         targetColumnMap: {
-          value: 'colorScheme',
+          value: 'locale',
         },
         description: 'Preferred language',
         icon: 'IconLanguage',
@@ -70,8 +70,8 @@ export const seedWorkspaceMemberSettingsFieldMetadata = async (
 
       // Relationships
       {
-        id: SeedWorkspaceMemberSettingsFieldMetadataIds.WorkspaceMember,
-        objectMetadataId: SeedObjectMetadataIds.WorkspaceMemberSettings,
+        id: SeedWorkspaceMemberSettingFieldMetadataIds.WorkspaceMember,
+        objectMetadataId: SeedObjectMetadataIds.WorkspaceMemberSetting,
         isCustom: false,
         workspaceId: SeedWorkspaceId,
         isActive: true,

--- a/server/src/database/typeorm-seeds/metadata/field-metadata/workspace-member.ts
+++ b/server/src/database/typeorm-seeds/metadata/field-metadata/workspace-member.ts
@@ -6,6 +6,8 @@ import { SeedWorkspaceId } from 'src/database/seeds/metadata';
 const fieldMetadataTableName = 'fieldMetadata';
 
 export enum SeedWorkspaceMemberFieldMetadataIds {
+  FirstName = '20202020-1fa8-4d38-9fa4-0cf696909298',
+  LastName = '20202020-8c37-4163-ba06-1dada334ce3e',
   AllowImpersonation = '20202020-bb19-44a1-8156-8866f87a5f42',
   UserId = '20202020-f2c1-4ca1-9ca5-7b9d5cc87eb0',
   AuthoredActivities = '20202020-37a0-4db4-9c9f-fd3e3f4e47fc',
@@ -41,6 +43,38 @@ export const seedWorkspaceMemberFieldMetadata = async (
     .orIgnore()
     .values([
       // Scalar fields
+      {
+        id: SeedWorkspaceMemberFieldMetadataIds.FirstName,
+        objectMetadataId: SeedObjectMetadataIds.WorkspaceMember,
+        isCustom: false,
+        workspaceId: SeedWorkspaceId,
+        isActive: true,
+        type: 'TEXT',
+        name: 'firstName',
+        label: 'First name',
+        targetColumnMap: {
+          value: 'firstName',
+        },
+        description: 'Workspace member first name',
+        icon: 'IconCircleUser',
+        isNullable: false,
+      },
+      {
+        id: SeedWorkspaceMemberFieldMetadataIds.LastName,
+        objectMetadataId: SeedObjectMetadataIds.WorkspaceMember,
+        isCustom: false,
+        workspaceId: SeedWorkspaceId,
+        isActive: true,
+        type: 'TEXT',
+        name: 'lastName',
+        label: 'Last name',
+        targetColumnMap: {
+          value: 'lastName',
+        },
+        description: 'Workspace member last name',
+        icon: 'IconCircleUser',
+        isNullable: false,
+      },
       {
         id: SeedWorkspaceMemberFieldMetadataIds.UserId,
         objectMetadataId: SeedObjectMetadataIds.WorkspaceMember,
@@ -166,10 +200,10 @@ export const seedWorkspaceMemberFieldMetadata = async (
         workspaceId: SeedWorkspaceId,
         isActive: true,
         type: 'RELATION',
-        name: 'settings',
+        name: 'setting',
         label: 'Settings',
         targetColumnMap: {
-          value: 'settingsId',
+          value: 'settingId',
         },
         description: 'Workspace member settings',
         icon: 'IconSettings',

--- a/server/src/database/typeorm-seeds/metadata/index.ts
+++ b/server/src/database/typeorm-seeds/metadata/index.ts
@@ -17,12 +17,12 @@ import { seedOpportunityFieldMetadata } from 'src/database/typeorm-seeds/metadat
 import { seedPersonFieldMetadata } from 'src/database/typeorm-seeds/metadata/field-metadata/person';
 import { seedPipelineStepFieldMetadata } from 'src/database/typeorm-seeds/metadata/field-metadata/pipeline-step';
 import { seedWorkspaceMemberFieldMetadata } from 'src/database/typeorm-seeds/metadata/field-metadata/workspace-member';
-import { seedWorkspaceMemberSettingsFieldMetadata } from 'src/database/typeorm-seeds/metadata/field-metadata/workspace-member-settings';
 import { seedCompanyRelationMetadata } from 'src/database/typeorm-seeds/metadata/relation-metadata/company';
 import { seedActivityRelationMetadata } from 'src/database/typeorm-seeds/metadata/relation-metadata/activity';
 import { seedPipelineStepRelationMetadata } from 'src/database/typeorm-seeds/metadata/relation-metadata/pipeline-step';
 import { seedPersonRelationMetadata } from 'src/database/typeorm-seeds/metadata/relation-metadata/person';
 import { seedWorkspaceMemberRelationMetadata } from 'src/database/typeorm-seeds/metadata/relation-metadata/workspace-member';
+import { seedWorkspaceMemberSettingFieldMetadata } from 'src/database/typeorm-seeds/metadata/field-metadata/workspace-member-setting';
 
 export const seedMetadataSchema = async (
   workspaceDataSource: DataSource,
@@ -46,7 +46,7 @@ export const seedMetadataSchema = async (
   await seedViewSortFieldMetadata(workspaceDataSource, schemaName);
   await seedViewRelationMetadata(workspaceDataSource, schemaName);
   await seedWorkspaceMemberFieldMetadata(workspaceDataSource, schemaName);
-  await seedWorkspaceMemberSettingsFieldMetadata(
+  await seedWorkspaceMemberSettingFieldMetadata(
     workspaceDataSource,
     schemaName,
   );

--- a/server/src/database/typeorm-seeds/metadata/object-metadata.ts
+++ b/server/src/database/typeorm-seeds/metadata/object-metadata.ts
@@ -10,7 +10,7 @@ export enum SeedObjectMetadataIds {
   Opportunity = '20202020-cae9-4ff4-9579-f7d9fe44c937',
   PipelineStep = '20202020-1029-4661-9e91-83bad932bdcd',
   WorkspaceMember = '20202020-b550-40bb-a96b-9ab54b664753',
-  WorkspaceMemberSettings = '20202020-166d-445c-970f-da1ea43f1dc7',
+  WorkspaceMemberSetting = '20202020-166d-445c-970f-da1ea43f1dc7',
   Webhook = '20202020-ddee-40de-9c9b-5f82a3503360',
   ApiKey = '20202020-d8d0-4c2d-a370-5499b2181d02',
   Activity = '20202020-8ee3-4f67-84ab-1b7a6eb5a448',
@@ -112,7 +112,7 @@ export const seedObjectMetadata = async (
         isActive: true,
       },
       {
-        id: SeedObjectMetadataIds.WorkspaceMemberSettings,
+        id: SeedObjectMetadataIds.WorkspaceMemberSetting,
         nameSingular: 'workspaceMemberSettingV2',
         namePlural: 'workspaceMemberSettingsV2',
         labelSingular: 'WorkspaceMemberSetting',

--- a/server/src/database/typeorm-seeds/metadata/relation-metadata/workspace-member.ts
+++ b/server/src/database/typeorm-seeds/metadata/relation-metadata/workspace-member.ts
@@ -5,11 +5,11 @@ import { SeedObjectMetadataIds } from 'src/database/typeorm-seeds/metadata/objec
 import { SeedWorkspaceId } from 'src/database/seeds/metadata';
 import { SeedCompanyFieldMetadataIds } from 'src/database/typeorm-seeds/metadata/field-metadata/company';
 import { SeedWorkspaceMemberFieldMetadataIds } from 'src/database/typeorm-seeds/metadata/field-metadata/workspace-member';
-import { SeedWorkspaceMemberSettingsFieldMetadataIds } from 'src/database/typeorm-seeds/metadata/field-metadata/workspace-member-settings';
 import { SeedFavoriteFieldMetadataIds } from 'src/database/typeorm-seeds/metadata/field-metadata/favorite';
 import { SeedActivityFieldMetadataIds } from 'src/database/typeorm-seeds/metadata/field-metadata/activity';
 import { SeedCommentFieldMetadataIds } from 'src/database/typeorm-seeds/metadata/field-metadata/comment';
 import { SeedAttachmentFieldMetadataIds } from 'src/database/typeorm-seeds/metadata/field-metadata/attachment';
+import { SeedWorkspaceMemberSettingFieldMetadataIds } from 'src/database/typeorm-seeds/metadata/field-metadata/workspace-member-setting';
 
 const tableName = 'relationMetadata';
 
@@ -42,10 +42,10 @@ export const seedWorkspaceMemberRelationMetadata = async (
       {
         relationType: RelationMetadataType.ONE_TO_ONE,
         fromObjectMetadataId: SeedObjectMetadataIds.WorkspaceMember,
-        toObjectMetadataId: SeedObjectMetadataIds.WorkspaceMemberSettings,
+        toObjectMetadataId: SeedObjectMetadataIds.WorkspaceMemberSetting,
         fromFieldMetadataId: SeedWorkspaceMemberFieldMetadataIds.Settings,
         toFieldMetadataId:
-          SeedWorkspaceMemberSettingsFieldMetadataIds.WorkspaceMember,
+          SeedWorkspaceMemberSettingFieldMetadataIds.WorkspaceMember,
         workspaceId: SeedWorkspaceId,
       },
       {

--- a/server/src/metadata/tenant-migration/migrations/1697618009-addCompanyTable.ts
+++ b/server/src/metadata/tenant-migration/migrations/1697618009-addCompanyTable.ts
@@ -33,11 +33,6 @@ export const addCompanyTable: TenantMigrationTableAction[] = [
         action: TenantMigrationColumnActionType.CREATE,
       },
       {
-        columnName: 'linkedinUrl_link',
-        columnType: 'varchar',
-        action: TenantMigrationColumnActionType.CREATE,
-      },
-      {
         columnName: 'linkedinUrl',
         columnType: 'varchar',
         action: TenantMigrationColumnActionType.CREATE,

--- a/server/src/metadata/tenant-migration/migrations/1697618015-addActivityTargetTable.ts
+++ b/server/src/metadata/tenant-migration/migrations/1697618015-addActivityTargetTable.ts
@@ -17,6 +17,16 @@ export const addActivityTargetTable: TenantMigrationTableAction[] = [
         columnType: 'uuid',
         action: TenantMigrationColumnActionType.CREATE,
       },
+      {
+        columnName: 'activityId',
+        columnType: 'uuid',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
+        columnName: 'personId',
+        columnType: 'uuid',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
     ],
   },
 ];

--- a/server/src/metadata/tenant-migration/migrations/1697618016-addActivityTable.ts
+++ b/server/src/metadata/tenant-migration/migrations/1697618016-addActivityTable.ts
@@ -1,4 +1,7 @@
-import { TenantMigrationTableAction } from 'src/metadata/tenant-migration/tenant-migration.entity';
+import {
+  TenantMigrationColumnActionType,
+  TenantMigrationTableAction,
+} from 'src/metadata/tenant-migration/tenant-migration.entity';
 
 export const addActivityTable: TenantMigrationTableAction[] = [
   {
@@ -8,6 +11,47 @@ export const addActivityTable: TenantMigrationTableAction[] = [
   {
     name: 'activity',
     action: 'alter',
-    columns: [],
+    columns: [
+      {
+        columnName: 'title',
+        columnType: 'varchar',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
+        columnName: 'body',
+        columnType: 'varchar',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
+        columnName: 'type',
+        columnType: 'varchar',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
+        columnName: 'reminderAt',
+        columnType: 'timestamp',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
+        columnName: 'dueAt',
+        columnType: 'timestamp',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
+        columnName: 'completedAt',
+        columnType: 'timestamp',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
+        columnName: 'authorId',
+        columnType: 'uuid',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
+        columnName: 'assigneeId',
+        columnType: 'uuid',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+    ],
   },
 ];

--- a/server/src/metadata/tenant-migration/migrations/1697618017-addApiKeyTable.ts
+++ b/server/src/metadata/tenant-migration/migrations/1697618017-addApiKeyTable.ts
@@ -1,4 +1,7 @@
-import { TenantMigrationTableAction } from 'src/metadata/tenant-migration/tenant-migration.entity';
+import {
+  TenantMigrationColumnActionType,
+  TenantMigrationTableAction,
+} from 'src/metadata/tenant-migration/tenant-migration.entity';
 
 export const addApiKeyTable: TenantMigrationTableAction[] = [
   {
@@ -8,6 +11,22 @@ export const addApiKeyTable: TenantMigrationTableAction[] = [
   {
     name: 'apiKey',
     action: 'alter',
-    columns: [],
+    columns: [
+      {
+        columnName: 'name',
+        columnType: 'varchar',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
+        columnName: 'revokedAt',
+        columnType: 'timestamp',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
+        columnName: 'expiresAt',
+        columnType: 'timestamp',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+    ],
   },
 ];

--- a/server/src/metadata/tenant-migration/migrations/1697618018-addAttachmentTable.ts
+++ b/server/src/metadata/tenant-migration/migrations/1697618018-addAttachmentTable.ts
@@ -13,7 +13,37 @@ export const addAttachmentTable: TenantMigrationTableAction[] = [
     action: 'alter',
     columns: [
       {
+        columnName: 'name',
+        columnType: 'varchar',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
+        columnName: 'fullPath',
+        columnType: 'varchar',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
+        columnName: 'type',
+        columnType: 'varchar',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
         columnName: 'companyId',
+        columnType: 'uuid',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
+        columnName: 'authorId',
+        columnType: 'uuid',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
+        columnName: 'activityId',
+        columnType: 'uuid',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
+        columnName: 'personId',
         columnType: 'uuid',
         action: TenantMigrationColumnActionType.CREATE,
       },

--- a/server/src/metadata/tenant-migration/migrations/1697618019-addCommentTable.ts
+++ b/server/src/metadata/tenant-migration/migrations/1697618019-addCommentTable.ts
@@ -1,4 +1,7 @@
-import { TenantMigrationTableAction } from 'src/metadata/tenant-migration/tenant-migration.entity';
+import {
+  TenantMigrationColumnActionType,
+  TenantMigrationTableAction,
+} from 'src/metadata/tenant-migration/tenant-migration.entity';
 
 export const addCommentTable: TenantMigrationTableAction[] = [
   {
@@ -8,6 +11,22 @@ export const addCommentTable: TenantMigrationTableAction[] = [
   {
     name: 'comment',
     action: 'alter',
-    columns: [],
+    columns: [
+      {
+        columnName: 'body',
+        columnType: 'varchar',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
+        columnName: 'authorId',
+        columnType: 'uuid',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
+        columnName: 'activityId',
+        columnType: 'uuid',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+    ],
   },
 ];

--- a/server/src/metadata/tenant-migration/migrations/1697618020-addFavoriteTable.ts
+++ b/server/src/metadata/tenant-migration/migrations/1697618020-addFavoriteTable.ts
@@ -13,7 +13,22 @@ export const addFavoriteTable: TenantMigrationTableAction[] = [
     action: 'alter',
     columns: [
       {
+        columnName: 'position',
+        columnType: 'float',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
         columnName: 'companyId',
+        columnType: 'uuid',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
+        columnName: 'personId',
+        columnType: 'uuid',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
+        columnName: 'workspaceMemberId',
         columnType: 'uuid',
         action: TenantMigrationColumnActionType.CREATE,
       },

--- a/server/src/metadata/tenant-migration/migrations/1697618021-addOpportunityTable.ts
+++ b/server/src/metadata/tenant-migration/migrations/1697618021-addOpportunityTable.ts
@@ -13,7 +13,37 @@ export const addOpportunityTable: TenantMigrationTableAction[] = [
     action: 'alter',
     columns: [
       {
+        columnName: 'amount',
+        columnType: 'float',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
+        columnName: 'probability',
+        columnType: 'varchar',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
+        columnName: 'closeDate',
+        columnType: 'timestamp',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
         columnName: 'companyId',
+        columnType: 'uuid',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
+        columnName: 'personId',
+        columnType: 'uuid',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
+        columnName: 'pipelineStepId',
+        columnType: 'uuid',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
+        columnName: 'pointOfContactId',
         columnType: 'uuid',
         action: TenantMigrationColumnActionType.CREATE,
       },

--- a/server/src/metadata/tenant-migration/migrations/1697618022-addPersonTable.ts
+++ b/server/src/metadata/tenant-migration/migrations/1697618022-addPersonTable.ts
@@ -13,6 +13,51 @@ export const addPersonTable: TenantMigrationTableAction[] = [
     action: 'alter',
     columns: [
       {
+        columnName: 'firstName',
+        columnType: 'varchar',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
+        columnName: 'lastName',
+        columnType: 'varchar',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
+        columnName: 'email',
+        columnType: 'varchar',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
+        columnName: 'linkedinUrl',
+        columnType: 'varchar',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
+        columnName: 'xUrl',
+        columnType: 'varchar',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
+        columnName: 'jobTitle',
+        columnType: 'varchar',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
+        columnName: 'phone',
+        columnType: 'varchar',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
+        columnName: 'city',
+        columnType: 'varchar',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
+        columnName: 'avatarUrl',
+        columnType: 'varchar',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
         columnName: 'companyId',
         columnType: 'uuid',
         action: TenantMigrationColumnActionType.CREATE,

--- a/server/src/metadata/tenant-migration/migrations/1697618023-addPipelineStepTable.ts
+++ b/server/src/metadata/tenant-migration/migrations/1697618023-addPipelineStepTable.ts
@@ -1,4 +1,7 @@
-import { TenantMigrationTableAction } from 'src/metadata/tenant-migration/tenant-migration.entity';
+import {
+  TenantMigrationColumnActionType,
+  TenantMigrationTableAction,
+} from 'src/metadata/tenant-migration/tenant-migration.entity';
 
 export const addPipelineStepTable: TenantMigrationTableAction[] = [
   {
@@ -8,6 +11,22 @@ export const addPipelineStepTable: TenantMigrationTableAction[] = [
   {
     name: 'pipelineStep',
     action: 'alter',
-    columns: [],
+    columns: [
+      {
+        columnName: 'name',
+        columnType: 'varchar',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
+        columnName: 'color',
+        columnType: 'varchar',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
+        columnName: 'position',
+        columnType: 'float',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+    ],
   },
 ];

--- a/server/src/metadata/tenant-migration/migrations/1697618024-addWebhookTable.ts
+++ b/server/src/metadata/tenant-migration/migrations/1697618024-addWebhookTable.ts
@@ -1,4 +1,7 @@
-import { TenantMigrationTableAction } from 'src/metadata/tenant-migration/tenant-migration.entity';
+import {
+  TenantMigrationColumnActionType,
+  TenantMigrationTableAction,
+} from 'src/metadata/tenant-migration/tenant-migration.entity';
 
 export const addWebhookTable: TenantMigrationTableAction[] = [
   {
@@ -8,6 +11,17 @@ export const addWebhookTable: TenantMigrationTableAction[] = [
   {
     name: 'webhook',
     action: 'alter',
-    columns: [],
+    columns: [
+      {
+        columnName: 'targetUrl',
+        columnType: 'varchar',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
+        columnName: 'operation',
+        columnType: 'varchar',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+    ],
   },
 ];

--- a/server/src/metadata/tenant-migration/migrations/1697618025-addWorkspaceMemberSettingTable.ts
+++ b/server/src/metadata/tenant-migration/migrations/1697618025-addWorkspaceMemberSettingTable.ts
@@ -24,7 +24,7 @@ export const addWorkspaceMemberSettingTable: TenantMigrationTableAction[] = [
       },
       {
         columnName: 'workspaceMemberId',
-        columnType: 'varchar',
+        columnType: 'uuid',
         action: TenantMigrationColumnActionType.CREATE,
       },
     ],

--- a/server/src/metadata/tenant-migration/migrations/1697618025-addWorkspaceMemberSettingTable.ts
+++ b/server/src/metadata/tenant-migration/migrations/1697618025-addWorkspaceMemberSettingTable.ts
@@ -1,4 +1,7 @@
-import { TenantMigrationTableAction } from 'src/metadata/tenant-migration/tenant-migration.entity';
+import {
+  TenantMigrationColumnActionType,
+  TenantMigrationTableAction,
+} from 'src/metadata/tenant-migration/tenant-migration.entity';
 
 export const addWorkspaceMemberSettingTable: TenantMigrationTableAction[] = [
   {
@@ -8,6 +11,22 @@ export const addWorkspaceMemberSettingTable: TenantMigrationTableAction[] = [
   {
     name: 'workspaceMemberSetting',
     action: 'alter',
-    columns: [],
+    columns: [
+      {
+        columnName: 'colorScheme',
+        columnType: 'varchar',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
+        columnName: 'locale',
+        columnType: 'varchar',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
+        columnName: 'workspaceMemberId',
+        columnType: 'varchar',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+    ],
   },
 ];

--- a/server/src/metadata/tenant-migration/migrations/1697618026-addWorspaceMemberTable.ts
+++ b/server/src/metadata/tenant-migration/migrations/1697618026-addWorspaceMemberTable.ts
@@ -1,4 +1,7 @@
-import { TenantMigrationTableAction } from 'src/metadata/tenant-migration/tenant-migration.entity';
+import {
+  TenantMigrationColumnActionType,
+  TenantMigrationTableAction,
+} from 'src/metadata/tenant-migration/tenant-migration.entity';
 
 export const addWorkspaceMemberTable: TenantMigrationTableAction[] = [
   {
@@ -8,6 +11,32 @@ export const addWorkspaceMemberTable: TenantMigrationTableAction[] = [
   {
     name: 'workspaceMember',
     action: 'alter',
-    columns: [],
+    columns: [
+      {
+        columnName: 'firstName',
+        columnType: 'varchar',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
+        columnName: 'lastName',
+        columnType: 'varchar',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
+        columnName: 'allowImpersonation',
+        columnType: 'boolean',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
+        columnName: 'userId',
+        columnType: 'uuid',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+      {
+        columnName: 'settingsId',
+        columnType: 'uuid',
+        action: TenantMigrationColumnActionType.CREATE,
+      },
+    ],
   },
 ];

--- a/server/src/metadata/tenant-migration/migrations/1697618026-addWorspaceMemberTable.ts
+++ b/server/src/metadata/tenant-migration/migrations/1697618026-addWorspaceMemberTable.ts
@@ -33,7 +33,7 @@ export const addWorkspaceMemberTable: TenantMigrationTableAction[] = [
         action: TenantMigrationColumnActionType.CREATE,
       },
       {
-        columnName: 'settingsId',
+        columnName: 'settingId',
         columnType: 'uuid',
         action: TenantMigrationColumnActionType.CREATE,
       },

--- a/server/src/metadata/tenant-migration/migrations/1697618028-addAttachmentRelations.ts
+++ b/server/src/metadata/tenant-migration/migrations/1697618028-addAttachmentRelations.ts
@@ -14,6 +14,24 @@ export const addAttachmentRelations: TenantMigrationTableAction[] = [
         referencedTableColumnName: 'id',
         action: TenantMigrationColumnActionType.RELATION,
       },
+      {
+        columnName: 'personId',
+        referencedTableName: 'person',
+        referencedTableColumnName: 'id',
+        action: TenantMigrationColumnActionType.RELATION,
+      },
+      {
+        columnName: 'activityId',
+        referencedTableName: 'activity',
+        referencedTableColumnName: 'id',
+        action: TenantMigrationColumnActionType.RELATION,
+      },
+      {
+        columnName: 'authorId',
+        referencedTableName: 'workspaceMember',
+        referencedTableColumnName: 'id',
+        action: TenantMigrationColumnActionType.RELATION,
+      },
     ],
   },
 ];

--- a/server/src/metadata/tenant-migration/migrations/1697618031-addOpportunityRelations.ts
+++ b/server/src/metadata/tenant-migration/migrations/1697618031-addOpportunityRelations.ts
@@ -3,9 +3,9 @@ import {
   TenantMigrationTableAction,
 } from 'src/metadata/tenant-migration/tenant-migration.entity';
 
-export const addFavoriteRelations: TenantMigrationTableAction[] = [
+export const addOpportunityRelations: TenantMigrationTableAction[] = [
   {
-    name: 'favorite',
+    name: 'opportunity',
     action: 'alter',
     columns: [
       {
@@ -21,8 +21,14 @@ export const addFavoriteRelations: TenantMigrationTableAction[] = [
         action: TenantMigrationColumnActionType.RELATION,
       },
       {
-        columnName: 'workspaceMemberId',
-        referencedTableName: 'workspaceMember',
+        columnName: 'pointOfContactId',
+        referencedTableName: 'person',
+        referencedTableColumnName: 'id',
+        action: TenantMigrationColumnActionType.RELATION,
+      },
+      {
+        columnName: 'pipelineStepId',
+        referencedTableName: 'pipelineStep',
         referencedTableColumnName: 'id',
         action: TenantMigrationColumnActionType.RELATION,
       },

--- a/server/src/metadata/tenant-migration/migrations/1697618033-addActivityRelations.ts
+++ b/server/src/metadata/tenant-migration/migrations/1697618033-addActivityRelations.ts
@@ -3,25 +3,19 @@ import {
   TenantMigrationTableAction,
 } from 'src/metadata/tenant-migration/tenant-migration.entity';
 
-export const addFavoriteRelations: TenantMigrationTableAction[] = [
+export const addActivityRelations: TenantMigrationTableAction[] = [
   {
-    name: 'favorite',
+    name: 'activity',
     action: 'alter',
     columns: [
       {
-        columnName: 'companyId',
-        referencedTableName: 'company',
+        columnName: 'authorId',
+        referencedTableName: 'workspaceMember',
         referencedTableColumnName: 'id',
         action: TenantMigrationColumnActionType.RELATION,
       },
       {
-        columnName: 'personId',
-        referencedTableName: 'person',
-        referencedTableColumnName: 'id',
-        action: TenantMigrationColumnActionType.RELATION,
-      },
-      {
-        columnName: 'workspaceMemberId',
+        columnName: 'assigneeId',
         referencedTableName: 'workspaceMember',
         referencedTableColumnName: 'id',
         action: TenantMigrationColumnActionType.RELATION,

--- a/server/src/metadata/tenant-migration/migrations/1697618034-addCommentRelations.ts
+++ b/server/src/metadata/tenant-migration/migrations/1697618034-addCommentRelations.ts
@@ -3,20 +3,14 @@ import {
   TenantMigrationTableAction,
 } from 'src/metadata/tenant-migration/tenant-migration.entity';
 
-export const addActivityTargetRelations: TenantMigrationTableAction[] = [
+export const addCommentRelations: TenantMigrationTableAction[] = [
   {
-    name: 'activityTarget',
+    name: 'comment',
     action: 'alter',
     columns: [
       {
-        columnName: 'companyId',
-        referencedTableName: 'company',
-        referencedTableColumnName: 'id',
-        action: TenantMigrationColumnActionType.RELATION,
-      },
-      {
-        columnName: 'personId',
-        referencedTableName: 'person',
+        columnName: 'authorId',
+        referencedTableName: 'workspaceMember',
         referencedTableColumnName: 'id',
         action: TenantMigrationColumnActionType.RELATION,
       },

--- a/server/src/metadata/tenant-migration/migrations/1697618035-addWorkspaceMemberSettingRelations.ts
+++ b/server/src/metadata/tenant-migration/migrations/1697618035-addWorkspaceMemberSettingRelations.ts
@@ -1,0 +1,20 @@
+import {
+  TenantMigrationColumnActionType,
+  TenantMigrationTableAction,
+} from 'src/metadata/tenant-migration/tenant-migration.entity';
+
+export const addWorkspaceMemberSettingRelations: TenantMigrationTableAction[] =
+  [
+    {
+      name: 'workspaceMemberSetting',
+      action: 'alter',
+      columns: [
+        {
+          columnName: 'workspaceMemberId',
+          referencedTableName: 'workspaceMember',
+          referencedTableColumnName: 'id',
+          action: TenantMigrationColumnActionType.RELATION,
+        },
+      ],
+    },
+  ];

--- a/server/src/metadata/tenant-migration/migrations/1697618036-addWorkspaceMemberRelations.ts
+++ b/server/src/metadata/tenant-migration/migrations/1697618036-addWorkspaceMemberRelations.ts
@@ -3,14 +3,14 @@ import {
   TenantMigrationTableAction,
 } from 'src/metadata/tenant-migration/tenant-migration.entity';
 
-export const addOpportunitiesRelations: TenantMigrationTableAction[] = [
+export const addWorkspaceMemberRelations: TenantMigrationTableAction[] = [
   {
-    name: 'opportunity',
+    name: 'workspaceMember',
     action: 'alter',
     columns: [
       {
-        columnName: 'companyId',
-        referencedTableName: 'company',
+        columnName: 'settingId',
+        referencedTableName: 'workspaceMemberSetting',
         referencedTableColumnName: 'id',
         action: TenantMigrationColumnActionType.RELATION,
       },

--- a/server/src/metadata/tenant-migration/standard-migrations.ts
+++ b/server/src/metadata/tenant-migration/standard-migrations.ts
@@ -14,8 +14,11 @@ import { addCompanyRelations } from 'src/metadata/tenant-migration/migrations/16
 import { addAttachmentRelations } from 'src/metadata/tenant-migration/migrations/1697618028-addAttachmentRelations';
 import { addPersonRelations } from 'src/metadata/tenant-migration/migrations/1697618029-addPersonRelations';
 import { addFavoriteRelations } from 'src/metadata/tenant-migration/migrations/1697618030-addFavoriteRelations';
-import { addOpportunitiesRelations } from 'src/metadata/tenant-migration/migrations/1697618031-addOpportunitiesRelations';
 import { addActivityTargetRelations } from 'src/metadata/tenant-migration/migrations/1697618032-addActivityTargetRelations';
+import { addActivityRelations } from 'src/metadata/tenant-migration/migrations/1697618033-addActivityRelations';
+import { addCommentRelations } from 'src/metadata/tenant-migration/migrations/1697618034-addCommentRelations';
+import { addOpportunityRelations } from 'src/metadata/tenant-migration/migrations/1697618031-addOpportunityRelations';
+import { addWorkspaceMemberSettingRelations } from 'src/metadata/tenant-migration/migrations/1697618035-addWorkspaceMemberSettingRelations';
 
 import { addCompanyTable } from './migrations/1697618009-addCompanyTable';
 import { addViewTable } from './migrations/1697618011-addViewTable';
@@ -47,6 +50,10 @@ export const standardMigrations = {
   '1697618028-addAttachmentRelations': addAttachmentRelations,
   '1697618029-addPersonRelations': addPersonRelations,
   '1697618030-addFavoriteRelations': addFavoriteRelations,
-  '1697618031-addOpportunitiesRelations': addOpportunitiesRelations,
+  '1697618031-addOpportunitiesRelations': addOpportunityRelations,
   '1697618032-addActivityTargetRelations': addActivityTargetRelations,
+  '1697618033-addActivityRelations': addActivityRelations,
+  '1697618034-addCommentRelations': addCommentRelations,
+  '1697618035-addWorkspaceMemberSettingRelations':
+    addWorkspaceMemberSettingRelations,
 };

--- a/server/src/metadata/tenant-migration/standard-migrations.ts
+++ b/server/src/metadata/tenant-migration/standard-migrations.ts
@@ -19,6 +19,7 @@ import { addActivityRelations } from 'src/metadata/tenant-migration/migrations/1
 import { addCommentRelations } from 'src/metadata/tenant-migration/migrations/1697618034-addCommentRelations';
 import { addOpportunityRelations } from 'src/metadata/tenant-migration/migrations/1697618031-addOpportunityRelations';
 import { addWorkspaceMemberSettingRelations } from 'src/metadata/tenant-migration/migrations/1697618035-addWorkspaceMemberSettingRelations';
+import { addWorkspaceMemberRelations } from 'src/metadata/tenant-migration/migrations/1697618036-addWorkspaceMemberRelations';
 
 import { addCompanyTable } from './migrations/1697618009-addCompanyTable';
 import { addViewTable } from './migrations/1697618011-addViewTable';
@@ -56,4 +57,5 @@ export const standardMigrations = {
   '1697618034-addCommentRelations': addCommentRelations,
   '1697618035-addWorkspaceMemberSettingRelations':
     addWorkspaceMemberSettingRelations,
+  '1697618036-addWorkspaceMemberRelations': addWorkspaceMemberRelations,
 };


### PR DESCRIPTION
This PR completes the migration of the following standard object from public schema to workspace schema:

- server/src/metadata/tenant-migration/migrations/1697618015-addActivityTargetTable.ts
- server/src/metadata/tenant-migration/migrations/1697618016-addActivityTable.ts
- server/src/metadata/tenant-migration/migrations/1697618017-addApiKeyTable.ts
- server/src/metadata/tenant-migration/migrations/1697618018-addAttachmentTable.ts
- server/src/metadata/tenant-migration/migrations/1697618019-addCommentTable.ts
- server/src/metadata/tenant-migration/migrations/1697618020-addFavoriteTable.ts
- server/src/metadata/tenant-migration/migrations/1697618021-addOpportunityTable.ts
- server/src/metadata/tenant-migration/migrations/1697618022-addPersonTable.ts
- server/src/metadata/tenant-migration/migrations/1697618023-addPipelineStepTable.ts
- server/src/metadata/tenant-migration/migrations/1697618024-addWebhookTable.ts
- server/src/metadata/tenant-migration/migrations/1697618025-addWorkspaceMemberSettingTable.ts
- server/src/metadata/tenant-migration/migrations/1697618026-addWorspaceMemberTable.ts