### PR TITLE
fix: schema builder use same type definitions storage across tenant

### DIFF
--- a/server/src/tenant/schema-builder/storages/type-definitions.storage.ts
+++ b/server/src/tenant/schema-builder/storages/type-definitions.storage.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Scope } from '@nestjs/common';
 
 import { GraphQLInputObjectType, GraphQLObjectType } from 'graphql';
 
@@ -12,7 +12,8 @@ import {
   ObjectTypeDefinitionKind,
 } from 'src/tenant/schema-builder/factories/object-type-definition.factory';
 
-@Injectable()
+// Must be scoped on REQUEST level
+@Injectable({ scope: Scope.REQUEST })
 export class TypeDefinitionsStorage {
   private readonly objectTypeDefinitions = new Map<
     string,

--- a/server/src/tenant/tenant.service.ts
+++ b/server/src/tenant/tenant.service.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-empty-function */
 import { Injectable } from '@nestjs/common';
 
 import { GraphQLSchema, printSchema } from 'graphql';


### PR DESCRIPTION
`TypeDefinitionsStorage` was not Scoped on the request level, so between request if the `workspaceId` change, the same storage was used.
This is fixing this issue, by resolving `TenantService` and creating a new `contextId` between each request and manually injecting the request into the scope.