### PR TITLE
Add support for UUID fields in tables

### DIFF
--- a/front/src/modules/ui/object/field/components/FieldDisplay.tsx
+++ b/front/src/modules/ui/object/field/components/FieldDisplay.tsx
@@ -1,6 +1,8 @@
 import { useContext } from 'react';
 
 import { RelationFieldDisplay } from '@/ui/object/field/meta-types/display/components/RelationFieldDisplay';
+import { UuidFieldDisplay } from '@/ui/object/field/meta-types/display/components/UuidFieldDisplay';
+import { isFieldUuid } from '@/ui/object/field/types/guards/isFieldUuid';
 
 import { FieldContext } from '../contexts/FieldContext';
 import { ChipFieldDisplay } from '../meta-types/display/components/ChipFieldDisplay';
@@ -38,6 +40,8 @@ export const FieldDisplay = () => {
         <RelationFieldDisplay />
       ) : isFieldText(fieldDefinition) ? (
         <TextFieldDisplay />
+      ) : isFieldUuid(fieldDefinition) ? (
+        <UuidFieldDisplay />
       ) : isFieldEmail(fieldDefinition) ? (
         <EmailFieldDisplay />
       ) : isFieldDate(fieldDefinition) ? (

--- a/front/src/modules/ui/object/field/meta-types/display/components/UuidFieldDisplay.tsx
+++ b/front/src/modules/ui/object/field/meta-types/display/components/UuidFieldDisplay.tsx
@@ -1,0 +1,8 @@
+import { TextDisplay } from '@/ui/object/field/meta-types/display/content-display/components/TextDisplay';
+import { useUuidField } from '@/ui/object/field/meta-types/hooks/useUuidField';
+
+export const UuidFieldDisplay = () => {
+  const { fieldValue } = useUuidField();
+
+  return <TextDisplay text={fieldValue} />;
+};

--- a/front/src/modules/ui/object/field/meta-types/hooks/useUuidField.ts
+++ b/front/src/modules/ui/object/field/meta-types/hooks/useUuidField.ts
@@ -1,0 +1,40 @@
+import { useContext } from 'react';
+import { useRecoilState } from 'recoil';
+
+import { isFieldUuid } from '@/ui/object/field/types/guards/isFieldUuid';
+
+import { FieldContext } from '../../contexts/FieldContext';
+import { useFieldInitialValue } from '../../hooks/useFieldInitialValue';
+import { entityFieldsFamilySelector } from '../../states/selectors/entityFieldsFamilySelector';
+import { assertFieldMetadata } from '../../types/guards/assertFieldMetadata';
+import { isFieldTextValue } from '../../types/guards/isFieldTextValue';
+
+export const useUuidField = () => {
+  const { entityId, fieldDefinition, hotkeyScope } = useContext(FieldContext);
+
+  assertFieldMetadata('UUID', isFieldUuid, fieldDefinition);
+
+  const fieldName = fieldDefinition.metadata.fieldName;
+
+  const [fieldValue, setFieldValue] = useRecoilState<string>(
+    entityFieldsFamilySelector({
+      entityId: entityId,
+      fieldName: fieldName,
+    }),
+  );
+  const fieldTextValue = isFieldTextValue(fieldValue) ? fieldValue : '';
+
+  const fieldInitialValue = useFieldInitialValue();
+
+  const initialValue = fieldInitialValue?.isEmpty
+    ? ''
+    : fieldInitialValue?.value ?? fieldTextValue;
+
+  return {
+    fieldDefinition,
+    fieldValue: fieldTextValue,
+    initialValue,
+    setFieldValue,
+    hotkeyScope,
+  };
+};

--- a/front/src/modules/ui/object/field/states/selectors/isEntityFieldEmptyFamilySelector.ts
+++ b/front/src/modules/ui/object/field/states/selectors/isEntityFieldEmptyFamilySelector.ts
@@ -1,5 +1,6 @@
 import { selectorFamily } from 'recoil';
 
+import { isFieldUuid } from '@/ui/object/field/types/guards/isFieldUuid';
 import { assertNotNull } from '~/utils/assert';
 
 import { FieldDefinition } from '../../types/FieldDefinition';
@@ -39,6 +40,7 @@ export const isEntityFieldEmptyFamilySelector = selectorFamily({
   }) => {
     return ({ get }) => {
       if (
+        isFieldUuid(fieldDefinition) ||
         isFieldText(fieldDefinition) ||
         isFieldURL(fieldDefinition) ||
         isFieldDate(fieldDefinition) ||

--- a/front/src/modules/ui/object/field/types/FieldMetadata.ts
+++ b/front/src/modules/ui/object/field/types/FieldMetadata.ts
@@ -1,6 +1,11 @@
 import { EntityForSelect } from '@/ui/input/relation-picker/types/EntityForSelect';
 import { Entity } from '@/ui/input/relation-picker/types/EntityTypeForSelect';
 
+export type FieldUuidMetadata = {
+  placeHolder: string;
+  fieldName: string;
+};
+
 export type FieldTextMetadata = {
   placeHolder: string;
   fieldName: string;
@@ -86,6 +91,7 @@ export type FieldBooleanMetadata = {
 };
 
 export type FieldMetadata =
+  | FieldUuidMetadata
   | FieldTextMetadata
   | FieldRelationMetadata
   | FieldChipMetadata
@@ -103,6 +109,7 @@ export type FieldMetadata =
   | FieldBooleanMetadata;
 
 export type FieldTextValue = string;
+export type FieldUUidValue = string;
 
 export type FieldChipValue = string;
 export type FieldDateValue = string | null;

--- a/front/src/modules/ui/object/field/types/FieldType.ts
+++ b/front/src/modules/ui/object/field/types/FieldType.ts
@@ -1,4 +1,5 @@
 export type FieldType =
+  | 'UUID'
   | 'TEXT'
   | 'RELATION'
   | 'CHIP'

--- a/front/src/modules/ui/object/field/types/guards/assertFieldMetadata.ts
+++ b/front/src/modules/ui/object/field/types/guards/assertFieldMetadata.ts
@@ -16,6 +16,7 @@ import {
   FieldTextMetadata,
   FieldURLMetadata,
   FieldURLV2Metadata,
+  FieldUuidMetadata,
 } from '../FieldMetadata';
 import { FieldType } from '../FieldType';
 
@@ -23,6 +24,8 @@ type AssertFieldMetadataFunction = <
   E extends FieldType,
   T extends E extends 'TEXT'
     ? FieldTextMetadata
+    : E extends 'UUID'
+    ? FieldUuidMetadata
     : E extends 'RELATION'
     ? FieldRelationMetadata
     : E extends 'CHIP'

--- a/front/src/modules/ui/object/field/types/guards/isFieldUuid.ts
+++ b/front/src/modules/ui/object/field/types/guards/isFieldUuid.ts
@@ -1,0 +1,6 @@
+import { FieldDefinition } from '../FieldDefinition';
+import { FieldMetadata, FieldUuidMetadata } from '../FieldMetadata';
+
+export const isFieldUuid = (
+  field: FieldDefinition<FieldMetadata>,
+): field is FieldDefinition<FieldUuidMetadata> => field.type === 'UUID';


### PR DESCRIPTION
In our flexible backend, we have introduced a UUID field type. As users could chose to display them in Recordtable, we are also introducing a UUID type in FE.

This is spanning some changes in:
- FieldMetadataType
- FieldType guards and assertions
- FieldDisplay