### PR TITLE
Add Name defaultColumn for custom objects

### DIFF
--- a/server/src/metadata/object-metadata/object-metadata.service.ts
+++ b/server/src/metadata/object-metadata/object-metadata.service.ts
@@ -10,7 +10,11 @@ import { TypeOrmQueryService } from '@ptc-org/nestjs-query-typeorm';
 
 import { WorkspaceMigrationService } from 'src/metadata/workspace-migration/workspace-migration.service';
 import { WorkspaceMigrationRunnerService } from 'src/workspace/workspace-migration-runner/workspace-migration-runner.service';
-import { WorkspaceMigrationTableAction } from 'src/metadata/workspace-migration/workspace-migration.entity';
+import {
+  WorkspaceMigrationColumnActionType,
+  WorkspaceMigrationColumnCreate,
+  WorkspaceMigrationTableAction,
+} from 'src/metadata/workspace-migration/workspace-migration.entity';
 import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
 
 import { ObjectMetadataEntity } from './object-metadata.entity';
@@ -77,6 +81,7 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
             isCustom: false,
             isSystem: true,
             workspaceId: record.workspaceId,
+            defaultValue: { type: 'uuid' },
           },
           {
             type: FieldMetadataType.DATE,
@@ -91,6 +96,7 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
             isActive: true,
             isCustom: false,
             workspaceId: record.workspaceId,
+            defaultValue: { type: 'now' },
           },
           {
             type: FieldMetadataType.DATE,
@@ -105,6 +111,22 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
             isActive: true,
             isCustom: false,
             workspaceId: record.workspaceId,
+            defaultValue: { type: 'now' },
+          },
+          {
+            type: FieldMetadataType.TEXT,
+            name: 'name',
+            label: 'Name',
+            targetColumnMap: {
+              value: 'name',
+            },
+            icon: 'IconAbc',
+            description: 'Name',
+            isNullable: true,
+            isActive: true,
+            isCustom: false,
+            workspaceId: record.workspaceId,
+            defaultValue: { value: 'Untitled' },
           },
         ],
     });
@@ -115,6 +137,19 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
         {
           name: createdObjectMetadata.targetTableName,
           action: 'create',
+        } satisfies WorkspaceMigrationTableAction,
+        // This is temporary until we implement mainIdentifier
+        {
+          name: createdObjectMetadata.targetTableName,
+          action: 'alter',
+          columns: [
+            {
+              action: WorkspaceMigrationColumnActionType.CREATE,
+              columnName: 'name',
+              columnType: 'varchar',
+              defaultValue: "'Untitled'",
+            } satisfies WorkspaceMigrationColumnCreate,
+          ],
         } satisfies WorkspaceMigrationTableAction,
       ],
     );


### PR DESCRIPTION
## Context
In preparation for the mainIdentifier work, we want to create a default column "name" once we create custom objects. Later we will be able to specify which column should be the main identifier of the object (which then will be displayed/handled differently on table/show/chip etc)

Note: If a user decides to create a field named "name" it won't collide in the DB because it will be prefixed with a "_" however the schema won't be able to merge those so it will be blocked earlier by the fact that we have a unicity constrain on the name/label of the field-metadata

<img width="870" alt="Screenshot 2023-11-17 at 17 54 44" src="https://github.com/twentyhq/twenty/assets/1834158/e6a7a2cd-939e-4b67-99e8-dbbc085957fd">