### PR TITLE
Add deleteOneRelation resolver

### DIFF
--- a/server/src/metadata/relation-metadata/relation-metadata.module.ts
+++ b/server/src/metadata/relation-metadata/relation-metadata.module.ts
@@ -42,7 +42,7 @@ import { RelationMetadataDTO } from './dtos/relation-metadata.dto';
           pagingStrategy: PagingStrategies.CURSOR,
           create: { many: { disabled: true } },
           update: { disabled: true },
-          delete: { disabled: true },
+          delete: { many: { disabled: true } },
           guards: [JwtAuthGuard],
         },
       ],


### PR DESCRIPTION
## Context

We need to be able to delete a custom relation that we've created.
2 solutions:
- Delete a fieldMetadata of type relation will fetch its relationMetadata and delete it then delete all other fieldMetadata that were associated to it
- Delete a relationMetadata will fetch all its associated fieldMetadata, will be deleted then we will delete the fieldMetadata.

Solution 2 makes more sense, we have a dedicated endpoint for relations instead of adding edge cases to deleteOneField and the resolver is clear about its purpose.

RelationMetadata does not contain isActive/isCustom so we have to fetch the fields and they all have to comply with the standard check we do in deleteOneField which means all fields of the relation need to be deactivated and custom to be deleted and so the same rule applies to the relation-metadata.

<img width="1060" alt="Screenshot 2023-11-17 at 18 15 31" src="https://github.com/twentyhq/twenty/assets/1834158/9cbb39ee-1de9-4f1d-8393-5e4ceaa8d844">
