### PR TITLE
Add [from/to]Description to CreateRelationInput

### DIFF
--- a/server/src/metadata/relation-metadata/dtos/create-relation.input.ts
+++ b/server/src/metadata/relation-metadata/dtos/create-relation.input.ts
@@ -62,8 +62,18 @@ export class CreateRelationInput {
 
   @IsString()
   @IsOptional()
-  @Field({ nullable: true })
+  @Field({ nullable: true, deprecationReason: 'Use fromDescription instead' })
   description?: string;
+
+  @IsString()
+  @IsOptional()
+  @Field({ nullable: true })
+  fromDescription?: string;
+
+  @IsString()
+  @IsOptional()
+  @Field({ nullable: true })
+  toDescription?: string;
 
   @HideField()
   workspaceId: string;

--- a/server/src/metadata/relation-metadata/relation-metadata.service.ts
+++ b/server/src/metadata/relation-metadata/relation-metadata.service.ts
@@ -122,7 +122,7 @@ export class RelationMetadataService extends TypeOrmQueryService<RelationMetadat
       {
         name: record.fromName,
         label: record.fromLabel,
-        description: record.description,
+        description: record.fromDescription,
         icon: record.fromIcon,
         isCustom: true,
         targetColumnMap: {},
@@ -135,7 +135,7 @@ export class RelationMetadataService extends TypeOrmQueryService<RelationMetadat
       {
         name: record.toName,
         label: record.toLabel,
-        description: undefined,
+        description: record.toDescription,
         icon: record.toIcon,
         isCustom: true,
         targetColumnMap: {},


### PR DESCRIPTION
## Context

Since we are only storing relations in 1 way in DB, it means creating a MANY_TO_ONE is equivalent to create a ONE_TO_MANY with flipped from/to variables. This is working for all of the fields except for description which was only filled for the "from" side of the relation. 
This PR introduces 2 description fields for each side of the relation.