### PR TITLE
fix: can't create fields of type UUID

### DIFF
--- a/server/src/metadata/field-metadata/utils/convert-field-metadata-to-column-action.util.ts
+++ b/server/src/metadata/field-metadata/utils/convert-field-metadata-to-column-action.util.ts
@@ -14,6 +14,19 @@ export function convertFieldMetadataToColumnActions(
   fieldMetadata: FieldMetadataEntity,
 ): WorkspaceMigrationColumnAction[] {
   switch (fieldMetadata.type) {
+    case FieldMetadataType.UUID: {
+      const defaultValue =
+        fieldMetadata.defaultValue as FieldMetadataDefaultValue<FieldMetadataType.UUID>;
+
+      return [
+        {
+          action: WorkspaceMigrationColumnActionType.CREATE,
+          columnName: fieldMetadata.targetColumnMap.value,
+          columnType: 'uuid',
+          defaultValue: serializeDefaultValue(defaultValue?.value),
+        },
+      ];
+    }
     case FieldMetadataType.TEXT: {
       const defaultValue =
         fieldMetadata.defaultValue as FieldMetadataDefaultValue<FieldMetadataType.TEXT>;

--- a/server/src/metadata/field-metadata/utils/generate-target-column-map.util.ts
+++ b/server/src/metadata/field-metadata/utils/generate-target-column-map.util.ts
@@ -19,6 +19,7 @@ export function generateTargetColumnMap(
   const columnName = isCustomField ? `_${fieldName}` : fieldName;
 
   switch (type) {
+    case FieldMetadataType.UUID:
     case FieldMetadataType.TEXT:
     case FieldMetadataType.PHONE:
     case FieldMetadataType.EMAIL:


### PR DESCRIPTION
Creating a field metadata type UUID doesn't work and throw this error:

```json
{
    "errors": [
        {
            "message": "Unknown type UUID",
            "locations": [
                {
                    "line": 2,
                    "column": 3
                }
            ],
            "path": [
                "createOneField"
            ]
        }
    ],
    "data": null
}
```

This PR fix the issue