### PR TITLE
fix: hide UUID from field type options in field creation form

### DIFF
--- a/front/src/pages/settings/data-model/SettingsObjectNewField/SettingsObjectNewFieldStep2.tsx
+++ b/front/src/pages/settings/data-model/SettingsObjectNewField/SettingsObjectNewFieldStep2.tsx
@@ -206,6 +206,7 @@ export const SettingsObjectNewFieldStep2 = () => {
           excludedFieldTypes={[
             FieldMetadataType.Enum,
             FieldMetadataType.Relation,
+            FieldMetadataType.Uuid,
           ]}
           fieldMetadata={{
             icon: formValues.icon,


### PR DESCRIPTION
Fixes #2644