### PR TITLE
Allow isActive to be updated for standard objects

### DIFF
--- a/server/src/metadata/field-metadata/hooks/before-update-one-field.hook.ts
+++ b/server/src/metadata/field-metadata/hooks/before-update-one-field.hook.ts
@@ -40,7 +40,12 @@ export class BeforeUpdateOneField<T extends UpdateFieldInput>
     }
 
     if (!fieldMetadata.isCustom) {
-      throw new BadRequestException("Standard Fields can't be updated");
+      return {
+        id: instance.id,
+        update: {
+          isActive: instance.update.isActive,
+        } as T,
+      };
     }
 
     this.checkIfFieldIsEditable(instance.update);

--- a/server/src/metadata/field-metadata/hooks/before-update-one-field.hook.ts
+++ b/server/src/metadata/field-metadata/hooks/before-update-one-field.hook.ts
@@ -40,12 +40,22 @@ export class BeforeUpdateOneField<T extends UpdateFieldInput>
     }
 
     if (!fieldMetadata.isCustom) {
-      return {
-        id: instance.id,
-        update: {
-          isActive: instance.update.isActive,
-        } as T,
-      };
+      if (
+        Object.keys(instance.update).length === 1 &&
+        instance.update.hasOwnProperty('isActive') &&
+        instance.update.isActive !== undefined
+      ) {
+        return {
+          id: instance.id,
+          update: {
+            isActive: instance.update.isActive,
+          } as T,
+        };
+      }
+
+      throw new BadRequestException(
+        'Only isActive field can be updated for standard fields',
+      );
     }
 
     this.checkIfFieldIsEditable(instance.update);

--- a/server/src/metadata/object-metadata/hooks/before-update-one-object.hook.ts
+++ b/server/src/metadata/object-metadata/hooks/before-update-one-object.hook.ts
@@ -48,12 +48,22 @@ export class BeforeUpdateOneObject<T extends UpdateObjectInput>
     }
 
     if (!objectMetadata.isCustom) {
-      return {
-        id: instance.id,
-        update: {
-          isActive: instance.update.isActive,
-        } as T,
-      };
+      if (
+        Object.keys(instance.update).length === 1 &&
+        instance.update.hasOwnProperty('isActive') &&
+        instance.update.isActive !== undefined
+      ) {
+        return {
+          id: instance.id,
+          update: {
+            isActive: instance.update.isActive,
+          } as T,
+        };
+      }
+
+      throw new BadRequestException(
+        'Only isActive field can be updated for standard objects',
+      );
     }
 
     if (

--- a/server/src/metadata/object-metadata/hooks/before-update-one-object.hook.ts
+++ b/server/src/metadata/object-metadata/hooks/before-update-one-object.hook.ts
@@ -48,7 +48,12 @@ export class BeforeUpdateOneObject<T extends UpdateObjectInput>
     }
 
     if (!objectMetadata.isCustom) {
-      throw new BadRequestException("Standard Objects can't be updated");
+      return {
+        id: instance.id,
+        update: {
+          isActive: instance.update.isActive,
+        } as T,
+      };
     }
 
     if (


### PR DESCRIPTION
## Context
A recent PR introduced a few checks in our pre-update hooks and we were rejecting edition on field-metadata and object-metadata. 
However the same endpoint is used to disable an object or a field (through the isActive bool) and we still want to allow users to disable standard objects/fields.

The FE now needs to send only isActive for this to work, I've tested locally and it seems to work