### PR TITLE
fix-dropdown-sort-icons

### DIFF
--- a/front/src/modules/ui/object/object-sort-dropdown/components/ObjectSortDropdownButton.tsx
+++ b/front/src/modules/ui/object/object-sort-dropdown/components/ObjectSortDropdownButton.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react';
 
 import { IconChevronDown } from '@/ui/display/icon';
 import { LightButton } from '@/ui/input/button/components/LightButton';
+import { useLazyLoadIcons } from '@/ui/input/hooks/useLazyLoadIcons';
 import { Dropdown } from '@/ui/layout/dropdown/components/Dropdown';
 import { DropdownMenuHeader } from '@/ui/layout/dropdown/components/DropdownMenuHeader';
 import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/DropdownMenuItemsContainer';
@@ -60,6 +61,8 @@ export const ObjectSortDropdownButton = ({
     resetState();
   };
 
+  const { icons } = useLazyLoadIcons();
+
   return (
     <DropdownScope dropdownScopeId={ObjectSortDropdownId}>
       <Dropdown
@@ -97,15 +100,17 @@ export const ObjectSortDropdownButton = ({
                 </DropdownMenuHeader>
                 <DropdownMenuSeparator />
                 <DropdownMenuItemsContainer>
-                  {availableSortDefinitions.map((availableSort, index) => (
-                    <MenuItem
-                      testId={`select-sort-${index}`}
-                      key={index}
-                      onClick={() => handleAddSort(availableSort)}
-                      LeftIcon={availableSort.Icon}
-                      text={availableSort.label}
-                    />
-                  ))}
+                  {availableSortDefinitions.map(
+                    (availableSortDefinition, index) => (
+                      <MenuItem
+                        testId={`select-sort-${index}`}
+                        key={index}
+                        onClick={() => handleAddSort(availableSortDefinition)}
+                        LeftIcon={icons[availableSortDefinition.iconName]}
+                        text={availableSortDefinition.label}
+                      />
+                    ),
+                  )}
                 </DropdownMenuItemsContainer>
               </>
             )}

--- a/front/src/modules/ui/object/object-sort-dropdown/types/SortDefinition.ts
+++ b/front/src/modules/ui/object/object-sort-dropdown/types/SortDefinition.ts
@@ -1,10 +1,8 @@
-import { IconComponent } from '@/ui/display/icon/types/IconComponent';
-
 import { SortDirection } from './SortDirection';
 
 export type SortDefinition = {
   fieldMetadataId: string;
   label: string;
-  Icon?: IconComponent;
+  iconName: string;
   getOrderByTemplate?: (direction: SortDirection) => any[];
 };

--- a/front/src/pages/opportunities/constants/opportunityBoardSortDefinitions.tsx
+++ b/front/src/pages/opportunities/constants/opportunityBoardSortDefinitions.tsx
@@ -1,20 +1,19 @@
-import { IconCalendarEvent, IconCurrencyDollar } from '@/ui/display/icon/index';
 import { SortDefinition } from '@/ui/object/object-sort-dropdown/types/SortDefinition';
 
 export const opportunityBoardSortDefinitions: SortDefinition[] = [
   {
     fieldMetadataId: 'createdAt',
     label: 'Creation',
-    Icon: IconCalendarEvent,
+    iconName: 'IconCalendarEvent',
   },
   {
     fieldMetadataId: 'amount',
     label: 'Amount',
-    Icon: IconCurrencyDollar,
+    iconName: 'IconCurrencyDollar',
   },
   {
     fieldMetadataId: 'closeDate',
     label: 'Expected close date',
-    Icon: IconCalendarEvent,
+    iconName: 'IconCalendarEvent',
   },
 ];


### PR DESCRIPTION
Dropdown sort icons were not appearing.
This fixes it.

<img width="215" alt="Capture d’écran 2023-11-22 à 18 41 10" src="https://github.com/twentyhq/twenty/assets/71827178/90a1ea6b-0143-44bc-8077-a83f8b33fbcd">
