### PR TITLE
Fix token cookie not being peristed on browser reboot

### DIFF
--- a/front/src/utils/recoil-effects.ts
+++ b/front/src/utils/recoil-effects.ts
@@ -32,6 +32,8 @@ export const cookieStorageEffect =
       }
       isReset
         ? cookieStorage.removeItem(key)
-        : cookieStorage.setItem(key, JSON.stringify(newValue));
+        : cookieStorage.setItem(key, JSON.stringify(newValue), {
+            expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 7),
+          });
     });
   };

--- a/server/src/core/auth/services/auth.service.ts
+++ b/server/src/core/auth/services/auth.service.ts
@@ -169,8 +169,6 @@ export class AuthService {
     user.passwordHash = '';
     user.workspaceMember = await this.userService.loadWorkspaceMember(user);
 
-    console.log(user.workspaceMember);
-
     const accessToken = await this.tokenService.generateAccessToken(user.id);
     const refreshToken = await this.tokenService.generateRefreshToken(user.id);
 


### PR DESCRIPTION
If your browser is configured to start a new browsing session on browser launch, the twenty token cookie is not persisted as it was a "Session" cookie. I'm adding an expiration date in 1 week by default when we write to the cookie storage