### PR TITLE
Update danger.js to pull_request_target

### DIFF
--- a/.github/workflows/ci-utils.yaml
+++ b/.github/workflows/ci-utils.yaml
@@ -3,7 +3,18 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  # it's usually not recommended to use pull_request_target
+  # but we consider it's safe here if we keep the same steps
+  # see: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/ 
+  # and: https://github.com/facebook/react-native/pull/34370/files
+  pull_request_target:
+permissions:
+  actions: write
+  checks: write
+  contents: write
+  issues: write
+  pull-requests: write
+  statuses: write
 jobs:
   danger-js:
     runs-on: ubuntu-latest
@@ -19,13 +30,7 @@ jobs:
           node-version: "18"
       - name: Utils / Install Dependencies
         run: cd packages/twenty-utils && yarn
-      - name: Set danger env
-        run: |
-          part1='github_pat_11BCSUEQA0Vd4ajqgGdujc_JJYRUxKfcbMtUn'
-          part2='z89DFTksGNXqOwLnmNv0VwMpQdc47T5BTGG2GOUbm6L8J'
-          echo "DANGER_GITHUB_API_TOKEN=${part1}${part2}" >> $GITHUB_ENV
       - name: Utils / Run Danger.js
-        run: cd packages/twenty-utils && yarn danger ci
+        run: cd packages/twenty-utils && yarn danger ci --use-github-checks --failOnErrors
         env:
-          DANGER_GITHUB_API_TOKEN: ${{ env.DANGER_GITHUB_API_TOKEN }}
-
+          DANGER_GITHUB_API_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Full details on Discord: https://discord.com/channels/1130383047699738754/1176971624013119570

The danger.js CI was broken and we concluded it was acceptable to use pull_request_target instead in that scenario