### PR TITLE
feat: restrict field types in field creation form

### DIFF
--- a/front/src/pages/settings/data-model/SettingsObjectNewField/SettingsObjectNewFieldStep2.tsx
+++ b/front/src/pages/settings/data-model/SettingsObjectNewField/SettingsObjectNewFieldStep2.tsx
@@ -204,7 +204,13 @@ export const SettingsObjectNewFieldStep2 = () => {
         />
         <SettingsObjectFieldTypeSelectSection
           excludedFieldTypes={[
+            FieldMetadataType.Currency,
+            FieldMetadataType.Email,
             FieldMetadataType.Enum,
+            FieldMetadataType.FullName,
+            FieldMetadataType.Link,
+            FieldMetadataType.Phone,
+            FieldMetadataType.Probability,
             FieldMetadataType.Relation,
             FieldMetadataType.Uuid,
           ]}


### PR DESCRIPTION
This PR restricts the types we can pick while creating a new field. We will release the new field types progressively once they are bullet proof