### PR TITLE
Add viewField creation to fieldMetadata creation service

### DIFF
--- a/front/src/pages/settings/data-model/SettingsObjectNewField/SettingsObjectNewFieldStep2.tsx
+++ b/front/src/pages/settings/data-model/SettingsObjectNewField/SettingsObjectNewFieldStep2.tsx
@@ -155,21 +155,12 @@ export const SettingsObjectNewFieldStep2 = () => {
         });
       });
     } else {
-      const createdField = await createMetadataField({
+      await createMetadataField({
         description: validatedFormValues.description,
         icon: validatedFormValues.icon,
         label: validatedFormValues.label,
         objectMetadataId: activeObjectMetadataItem.id,
         type: validatedFormValues.type,
-      });
-      objectViews.forEach(async (view) => {
-        await createOneViewField?.({
-          view: view.id,
-          fieldMetadataId: createdField.data?.createOneField.id,
-          position: activeObjectMetadataItem.fields.length,
-          isVisible: true,
-          size: 100,
-        });
       });
     }
 

--- a/server/src/metadata/field-metadata/field-metadata.module.ts
+++ b/server/src/metadata/field-metadata/field-metadata.module.ts
@@ -11,6 +11,8 @@ import { WorkspaceMigrationRunnerModule } from 'src/workspace/workspace-migratio
 import { WorkspaceMigrationModule } from 'src/metadata/workspace-migration/workspace-migration.module';
 import { ObjectMetadataModule } from 'src/metadata/object-metadata/object-metadata.module';
 import { JwtAuthGuard } from 'src/guards/jwt.auth.guard';
+import { DataSourceModule } from 'src/metadata/data-source/data-source.module';
+import { TypeORMModule } from 'src/database/typeorm/typeorm.module';
 
 import { FieldMetadataService } from './field-metadata.service';
 import { FieldMetadataEntity } from './field-metadata.entity';
@@ -27,6 +29,8 @@ import { UpdateFieldInput } from './dtos/update-field.input';
         WorkspaceMigrationModule,
         WorkspaceMigrationRunnerModule,
         ObjectMetadataModule,
+        DataSourceModule,
+        TypeORMModule,
       ],
       services: [FieldMetadataService],
       resolvers: [

--- a/server/src/metadata/field-metadata/field-metadata.service.ts
+++ b/server/src/metadata/field-metadata/field-metadata.service.ts
@@ -103,15 +103,14 @@ export class FieldMetadataService extends TypeOrmQueryService<FieldMetadataEntit
       WHERE "viewId" = '${view[0].id}'`,
     );
 
-    const lastPosition =
-      existingViewFields
-        .map((viewField) => viewField.position)
-        .reduce((acc, position) => {
-          if (position > acc) {
-            return position;
-          }
-          return acc;
-        }) ?? -1;
+    const lastPosition = existingViewFields
+      .map((viewField) => viewField.position)
+      .reduce((acc, position) => {
+        if (position > acc) {
+          return position;
+        }
+        return acc;
+      }, -1);
 
     await workspaceDataSource?.query(
       `INSERT INTO ${dataSourceMetadata.schema}."viewField"

--- a/server/src/metadata/field-metadata/field-metadata.service.ts
+++ b/server/src/metadata/field-metadata/field-metadata.service.ts
@@ -15,6 +15,8 @@ import { CreateFieldInput } from 'src/metadata/field-metadata/dtos/create-field.
 import { WorkspaceMigrationTableAction } from 'src/metadata/workspace-migration/workspace-migration.entity';
 import { generateTargetColumnMap } from 'src/metadata/field-metadata/utils/generate-target-column-map.util';
 import { convertFieldMetadataToColumnActions } from 'src/metadata/field-metadata/utils/convert-field-metadata-to-column-action.util';
+import { TypeORMService } from 'src/database/typeorm/typeorm.service';
+import { DataSourceService } from 'src/metadata/data-source/data-source.service';
 
 import { FieldMetadataEntity } from './field-metadata.entity';
 
@@ -27,6 +29,8 @@ export class FieldMetadataService extends TypeOrmQueryService<FieldMetadataEntit
     private readonly objectMetadataService: ObjectMetadataService,
     private readonly workspaceMigrationService: WorkspaceMigrationService,
     private readonly workspaceMigrationRunnerService: WorkspaceMigrationRunnerService,
+    private readonly dataSourceService: DataSourceService,
+    private readonly typeORMService: TypeORMService,
   ) {
     super(fieldMetadataRepository);
   }
@@ -56,10 +60,6 @@ export class FieldMetadataService extends TypeOrmQueryService<FieldMetadataEntit
       throw new ConflictException('Field already exists');
     }
 
-    if (record.name == record.label) {
-      throw new ConflictException('Field name and label cannot be the same');
-    }
-
     const createdFieldMetadata = await super.createOne({
       ...record,
       targetColumnMap: generateTargetColumnMap(record.type, true, record.name),
@@ -80,6 +80,45 @@ export class FieldMetadataService extends TypeOrmQueryService<FieldMetadataEntit
 
     await this.workspaceMigrationRunnerService.executeMigrationFromPendingMigrations(
       record.workspaceId,
+    );
+
+    // TODO: Move viewField creation to a cdc scheduler
+    const dataSourceMetadata =
+      await this.dataSourceService.getLastDataSourceMetadataFromWorkspaceIdOrFail(
+        record.workspaceId,
+      );
+
+    const workspaceDataSource = await this.typeORMService.connectToDataSource(
+      dataSourceMetadata,
+    );
+
+    // TODO: use typeorm repository
+    const view = await workspaceDataSource?.query(
+      `SELECT id FROM ${dataSourceMetadata.schema}."view"
+      WHERE "objectMetadataId" = '${createdFieldMetadata.objectMetadataId}'`,
+    );
+
+    const existingViewFields = await workspaceDataSource?.query(
+      `SELECT * FROM ${dataSourceMetadata.schema}."viewField"
+      WHERE "viewId" = '${view[0].id}'`,
+    );
+
+    const lastPosition =
+      existingViewFields
+        .map((viewField) => viewField.position)
+        .reduce((acc, position) => {
+          if (position > acc) {
+            return position;
+          }
+          return acc;
+        }) ?? -1;
+
+    await workspaceDataSource?.query(
+      `INSERT INTO ${dataSourceMetadata.schema}."viewField"
+    ("fieldMetadataId", "position", "isVisible", "size", "viewId")
+    VALUES ('${createdFieldMetadata.id}', '${lastPosition + 1}', true, 180, '${
+        view[0].id
+      }')`,
     );
 
     return createdFieldMetadata;

--- a/server/src/metadata/object-metadata/object-metadata.service.ts
+++ b/server/src/metadata/object-metadata/object-metadata.service.ts
@@ -54,6 +54,12 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
         record.workspaceId,
       );
 
+    if (record.labelSingular === record.labelPlural) {
+      throw new Error(
+        'The singular and plural labels cannot be the same for an object',
+      );
+    }
+
     const createdObjectMetadata = await super.createOne({
       ...record,
       dataSourceId: lastDataSourceMetadata.id,


### PR DESCRIPTION
## Context
When we add a new field we want to create an associated viewField to the global "All ${ObjectName}" table view so it's automatically displayed the next time you load the table.
This logic currently lives in the FE and we want to move it to the BE, we did something similar with object creation this week.

I'm also adding a check in the object creation because we should not be able to create an object with the same name.singular and name.plural (however label is fine). This is because we use those values to generate the dynamic graphql schema will try to generate duplicate resolvers and fail. We might need to find a better solution in the future, to handle words that don't have plural forms.