### PR TITLE
Fix check identical nameSingular/namePlural

### DIFF
--- a/server/src/metadata/object-metadata/object-metadata.service.ts
+++ b/server/src/metadata/object-metadata/object-metadata.service.ts
@@ -54,9 +54,9 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
         record.workspaceId,
       );
 
-    if (record.labelSingular === record.labelPlural) {
+    if (record.nameSingular.toLowerCase() === record.namePlural.toLowerCase()) {
       throw new Error(
-        'The singular and plural labels cannot be the same for an object',
+        'The singular and plural name cannot be the same for an object',
       );
     }
 


### PR DESCRIPTION
## Context
We've introduced a check in this PR https://github.com/twentyhq/twenty/pull/2685 which was wrongly checking the label instead of the name. 
In practice this is working most of the time because the name is generated from the FE using the label but this is not what we want since we actually use the name for the graphql schema generation.
We are also comparing those strings without case to avoid some edge cases.