### PR TITLE
Fix: Don't sort by column createdAt if it does not exist

### DIFF
--- a/front/src/modules/ui/object/object-sort-dropdown/utils/turnSortsIntoOrderBy.ts
+++ b/front/src/modules/ui/object/object-sort-dropdown/utils/turnSortsIntoOrderBy.ts
@@ -8,8 +8,14 @@ export const turnSortsIntoOrderBy = (
 ) => {
   const sortsObject: Record<string, 'AscNullsFirst' | 'DescNullsLast'> = {};
   if (!sorts.length) {
+    const createdAtField = fields.find((field) => field.name === 'createdAt');
+    if (createdAtField) {
+      return {
+        createdAt: 'DescNullsFirst',
+      };
+    }
     return {
-      createdAt: 'DescNullsFirst',
+      [fields[0].name]: 'DescNullsFirst',
     };
   }
   sorts.forEach((sort) => {


### PR DESCRIPTION
Fixes #2699
We should sort by the first available column if column createdAt does not exist

(This is not enough to make remote objects work but it's a first step)