### PR TITLE
fix: nested relations not working and relations not prefixed

### DIFF
--- a/server/src/metadata/field-metadata/field-metadata.service.ts
+++ b/server/src/metadata/field-metadata/field-metadata.service.ts
@@ -7,7 +7,7 @@ import {
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { v4 as uuidV4 } from 'uuid';
-import { Repository } from 'typeorm';
+import { FindOneOptions, Repository } from 'typeorm';
 import { TypeOrmQueryService } from '@ptc-org/nestjs-query-typeorm';
 
 import { WorkspaceMigrationRunnerService } from 'src/workspace/workspace-migration-runner/workspace-migration-runner.service';
@@ -47,8 +47,12 @@ export class FieldMetadataService extends TypeOrmQueryService<FieldMetadataEntit
   ): Promise<FieldMetadataEntity> {
     const objectMetadata =
       await this.objectMetadataService.findOneWithinWorkspace(
-        record.objectMetadataId,
         record.workspaceId,
+        {
+          where: {
+            id: record.objectMetadataId,
+          },
+        },
       );
 
     if (!objectMetadata) {
@@ -156,8 +160,12 @@ export class FieldMetadataService extends TypeOrmQueryService<FieldMetadataEntit
 
     const objectMetadata =
       await this.objectMetadataService.findOneWithinWorkspace(
-        existingFieldMetadata?.objectMetadataId,
         record.workspaceId,
+        {
+          where: {
+            id: existingFieldMetadata?.objectMetadataId,
+          },
+        },
       );
 
     if (!objectMetadata) {
@@ -200,11 +208,15 @@ export class FieldMetadataService extends TypeOrmQueryService<FieldMetadataEntit
   }
 
   public async findOneWithinWorkspace(
-    fieldMetadataId: string,
     workspaceId: string,
+    options: FindOneOptions<FieldMetadataEntity>,
   ) {
     return this.fieldMetadataRepository.findOne({
-      where: { id: fieldMetadataId, workspaceId },
+      ...options,
+      where: {
+        ...options.where,
+        workspaceId,
+      },
     });
   }
 

--- a/server/src/metadata/field-metadata/hooks/before-delete-one-field.hook.ts
+++ b/server/src/metadata/field-metadata/hooks/before-delete-one-field.hook.ts
@@ -27,10 +27,11 @@ export class BeforeDeleteOneField implements BeforeDeleteOneHook<any> {
     }
 
     const fieldMetadata =
-      await this.fieldMetadataService.findOneWithinWorkspace(
-        instance.id.toString(),
-        workspaceId,
-      );
+      await this.fieldMetadataService.findOneWithinWorkspace(workspaceId, {
+        where: {
+          id: instance.id.toString(),
+        },
+      });
 
     if (!fieldMetadata) {
       throw new BadRequestException('Field does not exist');

--- a/server/src/metadata/field-metadata/hooks/before-update-one-field.hook.ts
+++ b/server/src/metadata/field-metadata/hooks/before-update-one-field.hook.ts
@@ -31,10 +31,11 @@ export class BeforeUpdateOneField<T extends UpdateFieldInput>
     }
 
     const fieldMetadata =
-      await this.fieldMetadataService.findOneWithinWorkspace(
-        instance.id.toString(),
-        workspaceId,
-      );
+      await this.fieldMetadataService.findOneWithinWorkspace(workspaceId, {
+        where: {
+          id: instance.id.toString(),
+        },
+      });
 
     if (!fieldMetadata) {
       throw new BadRequestException('Field does not exist');

--- a/server/src/metadata/field-metadata/interfaces/field-metadata.interface.ts
+++ b/server/src/metadata/field-metadata/interfaces/field-metadata.interface.ts
@@ -16,6 +16,7 @@ export interface FieldMetadataInterface<
   defaultValue?: FieldMetadataDefaultValue<T>;
   options?: FieldMetadataOptions<T>;
   objectMetadataId: string;
+  workspaceId?: string;
   description?: string;
   isNullable?: boolean;
   fromRelationMetadata?: RelationMetadataEntity;

--- a/server/src/metadata/field-metadata/utils/generate-target-column-map.util.ts
+++ b/server/src/metadata/field-metadata/utils/generate-target-column-map.util.ts
@@ -3,6 +3,7 @@ import { BadRequestException } from '@nestjs/common';
 import { FieldMetadataTargetColumnMap } from 'src/metadata/field-metadata/interfaces/field-metadata-target-column-map.interface';
 
 import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
+import { createCustomColumnName } from 'src/metadata/utils/create-custom-column-name.util';
 
 /**
  * Generate a target column map for a given type, this is used to map the field to the correct column(s) in the database.
@@ -16,7 +17,9 @@ export function generateTargetColumnMap(
   isCustomField: boolean,
   fieldName: string,
 ): FieldMetadataTargetColumnMap {
-  const columnName = isCustomField ? `_${fieldName}` : fieldName;
+  const columnName = isCustomField
+    ? createCustomColumnName(fieldName)
+    : fieldName;
 
   switch (type) {
     case FieldMetadataType.UUID:

--- a/server/src/metadata/object-metadata/hooks/before-delete-one-object.hook.ts
+++ b/server/src/metadata/object-metadata/hooks/before-delete-one-object.hook.ts
@@ -26,10 +26,11 @@ export class BeforeDeleteOneObject implements BeforeDeleteOneHook<any> {
     }
 
     const objectMetadata =
-      await this.objectMetadataService.findOneWithinWorkspace(
-        instance.id.toString(),
-        workspaceId,
-      );
+      await this.objectMetadataService.findOneWithinWorkspace(workspaceId, {
+        where: {
+          id: instance.id.toString(),
+        },
+      });
 
     if (!objectMetadata) {
       throw new BadRequestException('Object does not exist');

--- a/server/src/metadata/object-metadata/hooks/before-update-one-object.hook.ts
+++ b/server/src/metadata/object-metadata/hooks/before-update-one-object.hook.ts
@@ -39,10 +39,11 @@ export class BeforeUpdateOneObject<T extends UpdateObjectInput>
     }
 
     const objectMetadata =
-      await this.objectMetadataService.findOneWithinWorkspace(
-        instance.id.toString(),
-        workspaceId,
-      );
+      await this.objectMetadataService.findOneWithinWorkspace(workspaceId, {
+        where: {
+          id: instance.id.toString(),
+        },
+      });
 
     if (!objectMetadata) {
       throw new BadRequestException('Object does not exist');

--- a/server/src/metadata/object-metadata/object-metadata.service.ts
+++ b/server/src/metadata/object-metadata/object-metadata.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
-import { Equal, In, Repository } from 'typeorm';
+import { FindOneOptions, FindOptionsWhere, Repository } from 'typeorm';
 import { TypeOrmQueryService } from '@ptc-org/nestjs-query-typeorm';
 
 import { WorkspaceMigrationService } from 'src/metadata/workspace-migration/workspace-migration.service';
@@ -298,19 +298,30 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
     return createdObjectMetadata;
   }
 
-  public async getObjectMetadataFromWorkspaceId(workspaceId: string) {
-    return this.objectMetadataRepository.find({
-      where: { workspaceId },
+  public async findOne(
+    options: FindOneOptions<ObjectMetadataEntity>,
+  ): Promise<ObjectMetadataEntity | null> {
+    return this.objectMetadataRepository.findOne({
+      ...options,
       relations: [
         'fields',
         'fields.fromRelationMetadata',
-        'fields.fromRelationMetadata.fromObjectMetadata',
-        'fields.fromRelationMetadata.toObjectMetadata',
-        'fields.fromRelationMetadata.toObjectMetadata.fields',
         'fields.toRelationMetadata',
-        'fields.toRelationMetadata.fromObjectMetadata',
-        'fields.toRelationMetadata.fromObjectMetadata.fields',
-        'fields.toRelationMetadata.toObjectMetadata',
+      ],
+    });
+  }
+
+  public async findMany(
+    where:
+      | FindOptionsWhere<ObjectMetadataEntity>[]
+      | FindOptionsWhere<ObjectMetadataEntity>,
+  ) {
+    return this.objectMetadataRepository.find({
+      where,
+      relations: [
+        'fields',
+        'fields.fromRelationMetadata',
+        'fields.toRelationMetadata',
       ],
     });
   }
@@ -321,16 +332,6 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
   ) {
     return this.objectMetadataRepository.findOne({
       where: { id: objectMetadataId, workspaceId },
-    });
-  }
-
-  public async findManyWithinWorkspace(
-    objectMetadataIds: string[],
-    workspaceId: string,
-  ) {
-    return this.objectMetadataRepository.findBy({
-      id: In(objectMetadataIds),
-      workspaceId: Equal(workspaceId),
     });
   }
 

--- a/server/src/metadata/object-metadata/object-metadata.service.ts
+++ b/server/src/metadata/object-metadata/object-metadata.service.ts
@@ -21,6 +21,7 @@ import {
   RelationMetadataEntity,
   RelationMetadataType,
 } from 'src/metadata/relation-metadata/relation-metadata.entity';
+import { createCustomColumnName } from 'src/metadata/utils/create-custom-column-name.util';
 
 import { ObjectMetadataEntity } from './object-metadata.entity';
 
@@ -63,7 +64,7 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
     const createdObjectMetadata = await super.createOne({
       ...record,
       dataSourceId: lastDataSourceMetadata.id,
-      targetTableName: `_${record.nameSingular}`,
+      targetTableName: createCustomColumnName(record.nameSingular),
       isActive: true,
       isCustom: true,
       isSystem: false,

--- a/server/src/metadata/object-metadata/object-metadata.service.ts
+++ b/server/src/metadata/object-metadata/object-metadata.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
-import { FindOneOptions, FindOptionsWhere, Repository } from 'typeorm';
+import { FindManyOptions, FindOneOptions, Repository } from 'typeorm';
 import { TypeOrmQueryService } from '@ptc-org/nestjs-query-typeorm';
 
 import { WorkspaceMigrationService } from 'src/metadata/workspace-migration/workspace-migration.service';
@@ -299,11 +299,16 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
     return createdObjectMetadata;
   }
 
-  public async findOne(
+  public async findOneWithinWorkspace(
+    workspaceId: string,
     options: FindOneOptions<ObjectMetadataEntity>,
   ): Promise<ObjectMetadataEntity | null> {
     return this.objectMetadataRepository.findOne({
       ...options,
+      where: {
+        ...options.where,
+        workspaceId,
+      },
       relations: [
         'fields',
         'fields.fromRelationMetadata',
@@ -312,27 +317,21 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
     });
   }
 
-  public async findMany(
-    where:
-      | FindOptionsWhere<ObjectMetadataEntity>[]
-      | FindOptionsWhere<ObjectMetadataEntity>,
+  public async findManyWithinWorkspace(
+    workspaceId: string,
+    options?: FindManyOptions<ObjectMetadataEntity>,
   ) {
     return this.objectMetadataRepository.find({
-      where,
+      ...options,
+      where: {
+        ...options?.where,
+        workspaceId,
+      },
       relations: [
         'fields',
         'fields.fromRelationMetadata',
         'fields.toRelationMetadata',
       ],
-    });
-  }
-
-  public async findOneWithinWorkspace(
-    objectMetadataId: string,
-    workspaceId: string,
-  ) {
-    return this.objectMetadataRepository.findOne({
-      where: { id: objectMetadataId, workspaceId },
     });
   }
 

--- a/server/src/metadata/relation-metadata/hooks/before-delete-one-field.hook.ts
+++ b/server/src/metadata/relation-metadata/hooks/before-delete-one-field.hook.ts
@@ -26,10 +26,11 @@ export class BeforeDeleteOneRelation implements BeforeDeleteOneHook<any> {
     }
 
     const relationMetadata =
-      await this.relationMetadataService.findOneWithinWorkspace(
-        instance.id.toString(),
-        workspaceId,
-      );
+      await this.relationMetadataService.findOneWithinWorkspace(workspaceId, {
+        where: {
+          id: instance.id.toString(),
+        },
+      });
 
     if (!relationMetadata) {
       throw new BadRequestException('Relation does not exist');

--- a/server/src/metadata/relation-metadata/relation-metadata.service.ts
+++ b/server/src/metadata/relation-metadata/relation-metadata.service.ts
@@ -110,8 +110,8 @@ export class RelationMetadataService extends TypeOrmQueryService<RelationMetadat
     }
 
     const baseColumnName = `${camelCase(record.toName)}Id`;
-    const toIsCustom = objectMetadataMap[record.toObjectMetadataId].isCustom;
-    const foreignKeyColumnName = toIsCustom
+    const isToCustom = objectMetadataMap[record.toObjectMetadataId].isCustom;
+    const foreignKeyColumnName = isToCustom
       ? createCustomColumnName(baseColumnName)
       : baseColumnName;
 
@@ -136,7 +136,7 @@ export class RelationMetadataService extends TypeOrmQueryService<RelationMetadat
         description: record.toDescription,
         icon: record.toIcon,
         isCustom: true,
-        targetColumnMap: toIsCustom
+        targetColumnMap: isToCustom
           ? {
               value: createCustomColumnName(record.toName),
             }

--- a/server/src/metadata/relation-metadata/relation-metadata.service.ts
+++ b/server/src/metadata/relation-metadata/relation-metadata.service.ts
@@ -105,8 +105,8 @@ export class RelationMetadataService extends TypeOrmQueryService<RelationMetadat
     }
 
     const baseColumnName = `${camelCase(record.toName)}Id`;
-    const foreignKeyColumnName = objectMetadataMap[record.toObjectMetadataId]
-      .isCustom
+    const toIsCustom = objectMetadataMap[record.toObjectMetadataId].isCustom;
+    const foreignKeyColumnName = toIsCustom
       ? createCustomColumnName(baseColumnName)
       : baseColumnName;
 
@@ -131,9 +131,11 @@ export class RelationMetadataService extends TypeOrmQueryService<RelationMetadat
         description: record.toDescription,
         icon: record.toIcon,
         isCustom: true,
-        targetColumnMap: {
-          value: createCustomColumnName(record.toName),
-        },
+        targetColumnMap: toIsCustom
+          ? {
+              value: createCustomColumnName(record.toName),
+            }
+          : {},
         isActive: true,
         type: FieldMetadataType.RELATION,
         objectMetadataId: record.toObjectMetadataId,

--- a/server/src/metadata/relation-metadata/relation-metadata.service.ts
+++ b/server/src/metadata/relation-metadata/relation-metadata.service.ts
@@ -6,7 +6,7 @@ import {
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { TypeOrmQueryService } from '@ptc-org/nestjs-query-typeorm';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 import camelCase from 'lodash.camelcase';
 
 import { ObjectMetadataService } from 'src/metadata/object-metadata/object-metadata.service';
@@ -83,11 +83,10 @@ export class RelationMetadataService extends TypeOrmQueryService<RelationMetadat
      * FROM --- TO (host the id in the TO table)
      */
 
-    const objectMetadataEntries =
-      await this.objectMetadataService.findManyWithinWorkspace(
-        [record.fromObjectMetadataId, record.toObjectMetadataId],
-        record.workspaceId,
-      );
+    const objectMetadataEntries = await this.objectMetadataService.findMany({
+      id: In([record.fromObjectMetadataId, record.toObjectMetadataId]),
+      workspaceId: record.workspaceId,
+    });
 
     const objectMetadataMap = objectMetadataEntries.reduce((acc, curr) => {
       acc[curr.id] = curr;

--- a/server/src/metadata/utils/create-custom-column-name.util.ts
+++ b/server/src/metadata/utils/create-custom-column-name.util.ts
@@ -1,0 +1,3 @@
+export const createCustomColumnName = (name: string) => {
+  return `_${name}`;
+};

--- a/server/src/workspace/workspace-query-builder/factories/create-many-query.factory.ts
+++ b/server/src/workspace/workspace-query-builder/factories/create-many-query.factory.ts
@@ -20,11 +20,11 @@ export class CreateManyQueryFactory {
     private readonly argsAliasFactory: ArgsAliasFactory,
   ) {}
 
-  create<Record extends IRecord = IRecord>(
+  async create<Record extends IRecord = IRecord>(
     args: CreateManyResolverArgs<Record>,
     options: WorkspaceQueryBuilderOptions,
   ) {
-    const fieldsString = this.fieldsStringFactory.create(
+    const fieldsString = await this.fieldsStringFactory.create(
       options.info,
       options.fieldMetadataCollection,
     );

--- a/server/src/workspace/workspace-query-builder/factories/delete-many-query.factory.ts
+++ b/server/src/workspace/workspace-query-builder/factories/delete-many-query.factory.ts
@@ -11,8 +11,11 @@ import { FieldsStringFactory } from './fields-string.factory';
 export class DeleteManyQueryFactory {
   constructor(private readonly fieldsStringFactory: FieldsStringFactory) {}
 
-  create(args: DeleteManyResolverArgs, options: WorkspaceQueryBuilderOptions) {
-    const fieldsString = this.fieldsStringFactory.create(
+  async create(
+    args: DeleteManyResolverArgs,
+    options: WorkspaceQueryBuilderOptions,
+  ) {
+    const fieldsString = await this.fieldsStringFactory.create(
       options.info,
       options.fieldMetadataCollection,
     );

--- a/server/src/workspace/workspace-query-builder/factories/delete-one-query.factory.ts
+++ b/server/src/workspace/workspace-query-builder/factories/delete-one-query.factory.ts
@@ -11,8 +11,11 @@ export class DeleteOneQueryFactory {
 
   constructor(private readonly fieldsStringFactory: FieldsStringFactory) {}
 
-  create(args: DeleteOneResolverArgs, options: WorkspaceQueryBuilderOptions) {
-    const fieldsString = this.fieldsStringFactory.create(
+  async create(
+    args: DeleteOneResolverArgs,
+    options: WorkspaceQueryBuilderOptions,
+  ) {
+    const fieldsString = await this.fieldsStringFactory.create(
       options.info,
       options.fieldMetadataCollection,
     );

--- a/server/src/workspace/workspace-query-builder/factories/fields-string.factory.ts
+++ b/server/src/workspace/workspace-query-builder/factories/fields-string.factory.ts
@@ -23,7 +23,7 @@ export class FieldsStringFactory {
   create(
     info: GraphQLResolveInfo,
     fieldMetadataCollection: FieldMetadataInterface[],
-  ) {
+  ): Promise<string> {
     const selectedFields: Record<string, any> = graphqlFields(info);
 
     return this.createFieldsStringRecursive(
@@ -33,12 +33,12 @@ export class FieldsStringFactory {
     );
   }
 
-  createFieldsStringRecursive(
+  async createFieldsStringRecursive(
     info: GraphQLResolveInfo,
     selectedFields: Record<string, any>,
     fieldMetadataCollection: FieldMetadataInterface[],
     accumulator = '',
-  ): string {
+  ): Promise<string> {
     const fieldMetadataMap = new Map(
       fieldMetadataCollection.map((metadata) => [metadata.name, metadata]),
     );
@@ -54,7 +54,7 @@ export class FieldsStringFactory {
 
         // If the field is a relation field, we need to create a special alias
         if (isRelationFieldMetadataType(fieldMetadata.type)) {
-          const alias = this.relationFieldAliasFactory.create(
+          const alias = await this.relationFieldAliasFactory.create(
             fieldKey,
             fieldValue,
             fieldMetadata,
@@ -80,7 +80,7 @@ export class FieldsStringFactory {
         !isEmpty(fieldValue)
       ) {
         accumulator += `${fieldKey} {\n`;
-        accumulator = this.createFieldsStringRecursive(
+        accumulator = await this.createFieldsStringRecursive(
           info,
           fieldValue,
           fieldMetadataCollection,

--- a/server/src/workspace/workspace-query-builder/factories/find-many-query.factory.ts
+++ b/server/src/workspace/workspace-query-builder/factories/find-many-query.factory.ts
@@ -19,14 +19,14 @@ export class FindManyQueryFactory {
     private readonly argsStringFactory: ArgsStringFactory,
   ) {}
 
-  create<
+  async create<
     Filter extends RecordFilter = RecordFilter,
     OrderBy extends RecordOrderBy = RecordOrderBy,
   >(
     args: FindManyResolverArgs<Filter, OrderBy>,
     options: WorkspaceQueryBuilderOptions,
   ) {
-    const fieldsString = this.fieldsStringFactory.create(
+    const fieldsString = await this.fieldsStringFactory.create(
       options.info,
       options.fieldMetadataCollection,
     );

--- a/server/src/workspace/workspace-query-builder/factories/find-one-query.factory.ts
+++ b/server/src/workspace/workspace-query-builder/factories/find-one-query.factory.ts
@@ -16,11 +16,11 @@ export class FindOneQueryFactory {
     private readonly argsStringFactory: ArgsStringFactory,
   ) {}
 
-  create<Filter extends RecordFilter = RecordFilter>(
+  async create<Filter extends RecordFilter = RecordFilter>(
     args: FindOneResolverArgs<Filter>,
     options: WorkspaceQueryBuilderOptions,
   ) {
-    const fieldsString = this.fieldsStringFactory.create(
+    const fieldsString = await this.fieldsStringFactory.create(
       options.info,
       options.fieldMetadataCollection,
     );

--- a/server/src/workspace/workspace-query-builder/factories/relation-field-alias.factory.ts
+++ b/server/src/workspace/workspace-query-builder/factories/relation-field-alias.factory.ts
@@ -102,7 +102,9 @@ export class RelationFieldAliasFactory {
       }
     `;
     }
-    let relationAlias = fieldKey;
+    let relationAlias = fieldMetadata.isCustom
+      ? `${fieldKey}: ${fieldMetadata.targetColumnMap.value}`
+      : fieldKey;
 
     // For one to one relations, pg_graphql use the targetTableName on the side that is not storing the foreign key
     // so we need to alias it to the field key

--- a/server/src/workspace/workspace-query-builder/factories/relation-field-alias.factory.ts
+++ b/server/src/workspace/workspace-query-builder/factories/relation-field-alias.factory.ts
@@ -91,7 +91,6 @@ export class RelationFieldAliasFactory {
       relationMetadata.relationType === RelationMetadataType.ONE_TO_MANY &&
       relationDirection === RelationDirection.FROM
     ) {
-      console.log('1');
       const args = getFieldArgumentsByKey(info, fieldKey);
       const argsString = this.argsStringFactory.create(
         args,
@@ -122,7 +121,6 @@ export class RelationFieldAliasFactory {
       relationMetadata.relationType === RelationMetadataType.ONE_TO_ONE &&
       relationDirection === RelationDirection.FROM
     ) {
-      console.log('2');
       relationAlias = `${fieldKey}: ${referencedObjectMetadata.targetTableName}`;
     }
     const fieldsString =
@@ -131,8 +129,6 @@ export class RelationFieldAliasFactory {
         fieldValue,
         referencedObjectMetadata.fields ?? [],
       );
-
-    console.log('3');
 
     // Otherwise it means it's a relation destination is of kind ONE
     return `

--- a/server/src/workspace/workspace-query-builder/factories/relation-field-alias.factory.ts
+++ b/server/src/workspace/workspace-query-builder/factories/relation-field-alias.factory.ts
@@ -55,20 +55,30 @@ export class RelationFieldAliasFactory {
       );
     }
 
+    if (!fieldMetadata.workspaceId) {
+      throw new Error(
+        `Workspace id not found for field ${fieldMetadata.name} in object metadata ${fieldMetadata.objectMetadataId}`,
+      );
+    }
+
     const relationDirection = deduceRelationDirection(
       fieldMetadata.objectMetadataId,
       relationMetadata,
     );
     // Retrieve the referenced object metadata based on the relation direction
     // Mandatory to handle n+n relations
-    const referencedObjectMetadata = await this.objectMetadataService.findOne({
-      where: {
-        id:
-          relationDirection == RelationDirection.TO
-            ? relationMetadata.fromObjectMetadataId
-            : relationMetadata.toObjectMetadataId,
-      },
-    });
+    const referencedObjectMetadata =
+      await this.objectMetadataService.findOneWithinWorkspace(
+        fieldMetadata.workspaceId,
+        {
+          where: {
+            id:
+              relationDirection == RelationDirection.TO
+                ? relationMetadata.fromObjectMetadataId
+                : relationMetadata.toObjectMetadataId,
+          },
+        },
+      );
 
     if (!referencedObjectMetadata) {
       throw new Error(

--- a/server/src/workspace/workspace-query-builder/factories/update-many-query.factory.ts
+++ b/server/src/workspace/workspace-query-builder/factories/update-many-query.factory.ts
@@ -18,14 +18,14 @@ export class UpdateManyQueryFactory {
     private readonly argsAliasFactory: ArgsAliasFactory,
   ) {}
 
-  create<
+  async create<
     Record extends IRecord = IRecord,
     Filter extends RecordFilter = RecordFilter,
   >(
     args: UpdateManyResolverArgs<Record, Filter>,
     options: WorkspaceQueryBuilderOptions,
   ) {
-    const fieldsString = this.fieldsStringFactory.create(
+    const fieldsString = await this.fieldsStringFactory.create(
       options.info,
       options.fieldMetadataCollection,
     );

--- a/server/src/workspace/workspace-query-builder/factories/update-one-query.factory.ts
+++ b/server/src/workspace/workspace-query-builder/factories/update-one-query.factory.ts
@@ -18,11 +18,11 @@ export class UpdateOneQueryFactory {
     private readonly argsAliasFactory: ArgsAliasFactory,
   ) {}
 
-  create<Record extends IRecord = IRecord>(
+  async create<Record extends IRecord = IRecord>(
     args: UpdateOneResolverArgs<Record>,
     options: WorkspaceQueryBuilderOptions,
   ) {
-    const fieldsString = this.fieldsStringFactory.create(
+    const fieldsString = await this.fieldsStringFactory.create(
       options.info,
       options.fieldMetadataCollection,
     );

--- a/server/src/workspace/workspace-query-builder/workspace-query-builder.factory.ts
+++ b/server/src/workspace/workspace-query-builder/workspace-query-builder.factory.ts
@@ -44,35 +44,35 @@ export class WorkspaceQueryBuilderFactory {
   >(
     args: FindManyResolverArgs<Filter, OrderBy>,
     options: WorkspaceQueryBuilderOptions,
-  ): string {
+  ): Promise<string> {
     return this.findManyQueryFactory.create<Filter, OrderBy>(args, options);
   }
 
   findOne<Filter extends RecordFilter = RecordFilter>(
     args: FindOneResolverArgs<Filter>,
     options: WorkspaceQueryBuilderOptions,
-  ): string {
+  ): Promise<string> {
     return this.findOneQueryFactory.create<Filter>(args, options);
   }
 
   createMany<Record extends IRecord = IRecord>(
     args: CreateManyResolverArgs<Record>,
     options: WorkspaceQueryBuilderOptions,
-  ): string {
+  ): Promise<string> {
     return this.createManyQueryFactory.create<Record>(args, options);
   }
 
   updateOne<Record extends IRecord = IRecord>(
     initialArgs: UpdateOneResolverArgs<Record>,
     options: WorkspaceQueryBuilderOptions,
-  ): string {
+  ): Promise<string> {
     return this.updateOneQueryFactory.create<Record>(initialArgs, options);
   }
 
   deleteOne(
     args: DeleteOneResolverArgs,
     options: WorkspaceQueryBuilderOptions,
-  ): string {
+  ): Promise<string> {
     return this.deleteOneQueryFactory.create(args, options);
   }
 
@@ -82,14 +82,14 @@ export class WorkspaceQueryBuilderFactory {
   >(
     args: UpdateManyResolverArgs<Record, Filter>,
     options: WorkspaceQueryBuilderOptions,
-  ): string {
+  ): Promise<string> {
     return this.updateManyQueryFactory.create(args, options);
   }
 
   deleteMany<Filter extends RecordFilter = RecordFilter>(
     args: DeleteManyResolverArgs<Filter>,
     options: WorkspaceQueryBuilderOptions,
-  ): string {
+  ): Promise<string> {
     return this.deleteManyQueryFactory.create(args, options);
   }
 }

--- a/server/src/workspace/workspace-query-builder/workspace-query-builder.module.ts
+++ b/server/src/workspace/workspace-query-builder/workspace-query-builder.module.ts
@@ -1,11 +1,13 @@
 import { Module } from '@nestjs/common';
 
+import { ObjectMetadataModule } from 'src/metadata/object-metadata/object-metadata.module';
+
 import { WorkspaceQueryBuilderFactory } from './workspace-query-builder.factory';
 
 import { workspaceQueryBuilderFactories } from './factories/factories';
 
 @Module({
-  imports: [],
+  imports: [ObjectMetadataModule],
   providers: [...workspaceQueryBuilderFactories, WorkspaceQueryBuilderFactory],
   exports: [WorkspaceQueryBuilderFactory],
 })

--- a/server/src/workspace/workspace-query-runner/workspace-query-runner.service.ts
+++ b/server/src/workspace/workspace-query-runner/workspace-query-runner.service.ts
@@ -45,7 +45,10 @@ export class WorkspaceQueryRunnerService {
     options: WorkspaceQueryRunnerOptions,
   ): Promise<IConnection<Record> | undefined> {
     const { workspaceId, targetTableName } = options;
-    const query = this.workspaceQueryBuilderFactory.findMany(args, options);
+    const query = await this.workspaceQueryBuilderFactory.findMany(
+      args,
+      options,
+    );
     const result = await this.execute(query, workspaceId);
 
     return this.parseResult<IConnection<Record>>(result, targetTableName, '');
@@ -62,7 +65,10 @@ export class WorkspaceQueryRunnerService {
       throw new BadRequestException('Missing filter argument');
     }
     const { workspaceId, targetTableName } = options;
-    const query = this.workspaceQueryBuilderFactory.findOne(args, options);
+    const query = await this.workspaceQueryBuilderFactory.findOne(
+      args,
+      options,
+    );
     const result = await this.execute(query, workspaceId);
     const parsedResult = this.parseResult<IConnection<Record>>(
       result,
@@ -78,7 +84,10 @@ export class WorkspaceQueryRunnerService {
     options: WorkspaceQueryRunnerOptions,
   ): Promise<Record[] | undefined> {
     const { workspaceId, targetTableName } = options;
-    const query = this.workspaceQueryBuilderFactory.createMany(args, options);
+    const query = await this.workspaceQueryBuilderFactory.createMany(
+      args,
+      options,
+    );
     const result = await this.execute(query, workspaceId);
 
     return this.parseResult<PGGraphQLMutation<Record>>(
@@ -102,9 +111,10 @@ export class WorkspaceQueryRunnerService {
     options: WorkspaceQueryRunnerOptions,
   ): Promise<Record | undefined> {
     const { workspaceId, targetTableName } = options;
-
-    const query = this.workspaceQueryBuilderFactory.updateOne(args, options);
-
+    const query = await this.workspaceQueryBuilderFactory.updateOne(
+      args,
+      options,
+    );
     const result = await this.execute(query, workspaceId);
 
     return this.parseResult<PGGraphQLMutation<Record>>(
@@ -119,7 +129,10 @@ export class WorkspaceQueryRunnerService {
     options: WorkspaceQueryRunnerOptions,
   ): Promise<Record | undefined> {
     const { workspaceId, targetTableName } = options;
-    const query = this.workspaceQueryBuilderFactory.deleteOne(args, options);
+    const query = await this.workspaceQueryBuilderFactory.deleteOne(
+      args,
+      options,
+    );
     const result = await this.execute(query, workspaceId);
 
     return this.parseResult<PGGraphQLMutation<Record>>(
@@ -134,9 +147,10 @@ export class WorkspaceQueryRunnerService {
     options: WorkspaceQueryRunnerOptions,
   ): Promise<Record[] | undefined> {
     const { workspaceId, targetTableName } = options;
-
-    const query = this.workspaceQueryBuilderFactory.updateMany(args, options);
-
+    const query = await this.workspaceQueryBuilderFactory.updateMany(
+      args,
+      options,
+    );
     const result = await this.execute(query, workspaceId);
 
     return this.parseResult<PGGraphQLMutation<Record>>(
@@ -154,9 +168,10 @@ export class WorkspaceQueryRunnerService {
     options: WorkspaceQueryRunnerOptions,
   ): Promise<Record[] | undefined> {
     const { workspaceId, targetTableName } = options;
-
-    const query = this.workspaceQueryBuilderFactory.deleteMany(args, options);
-
+    const query = await this.workspaceQueryBuilderFactory.deleteMany(
+      args,
+      options,
+    );
     const result = await this.execute(query, workspaceId);
 
     return this.parseResult<PGGraphQLMutation<Record>>(

--- a/server/src/workspace/workspace-schema-builder/factories/args.factory.ts
+++ b/server/src/workspace/workspace-schema-builder/factories/args.factory.ts
@@ -18,7 +18,7 @@ export class ArgsFactory {
   ) {}
 
   public create(
-    { args, objectMetadata }: ArgsMetadata,
+    { args, objectMetadataId }: ArgsMetadata,
     options: WorkspaceBuildSchemaOptions,
   ): GraphQLFieldConfigArgumentMap {
     const fieldConfigMap: GraphQLFieldConfigArgumentMap = {};
@@ -65,21 +65,21 @@ export class ArgsFactory {
       // Argument is an input type
       if (arg.kind) {
         const inputType = this.typeDefinitionsStorage.getInputTypeByKey(
-          objectMetadata.id,
+          objectMetadataId,
           arg.kind,
         );
 
         if (!inputType) {
           this.logger.error(
-            `Could not find a GraphQL input type for ${objectMetadata.id}`,
+            `Could not find a GraphQL input type for ${objectMetadataId}`,
             {
-              objectMetadata,
+              objectMetadataId,
               options,
             },
           );
 
           throw new Error(
-            `Could not find a GraphQL input type for ${objectMetadata.id}`,
+            `Could not find a GraphQL input type for ${objectMetadataId}`,
           );
         }
 

--- a/server/src/workspace/workspace-schema-builder/factories/extend-object-type-definition.factory.ts
+++ b/server/src/workspace/workspace-schema-builder/factories/extend-object-type-definition.factory.ts
@@ -155,7 +155,7 @@ export class ExtendObjectTypeDefinitionFactory {
             argsType = this.argsFactory.create(
               {
                 args,
-                objectMetadata: relationMetadata.toObjectMetadata,
+                objectMetadataId: relationMetadata.toObjectMetadataId,
               },
               options,
             );

--- a/server/src/workspace/workspace-schema-builder/factories/root-type.factory.ts
+++ b/server/src/workspace/workspace-schema-builder/factories/root-type.factory.ts
@@ -81,7 +81,7 @@ export class RootTypeFactory {
         const argsType = this.argsFactory.create(
           {
             args,
-            objectMetadata,
+            objectMetadataId: objectMetadata.id,
           },
           options,
         );

--- a/server/src/workspace/workspace-schema-builder/interfaces/param-metadata.interface.ts
+++ b/server/src/workspace/workspace-schema-builder/interfaces/param-metadata.interface.ts
@@ -1,5 +1,3 @@
-import { ObjectMetadataInterface } from 'src/metadata/field-metadata/interfaces/object-metadata.interface';
-
 import { InputTypeDefinitionKind } from 'src/workspace/workspace-schema-builder/factories/input-type-definition.factory';
 import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
 
@@ -15,5 +13,5 @@ export interface ArgsMetadata {
   args: {
     [key: string]: ArgMetadata;
   };
-  objectMetadata: ObjectMetadataInterface;
+  objectMetadataId: string;
 }

--- a/server/src/workspace/workspace.factory.ts
+++ b/server/src/workspace/workspace.factory.ts
@@ -50,9 +50,8 @@ export class WorkspaceFactory {
 
     // If object metadata is not cached, get it from the database
     if (!objectMetadataCollection) {
-      objectMetadataCollection = await this.objectMetadataService.findMany({
-        workspaceId,
-      });
+      objectMetadataCollection =
+        await this.objectMetadataService.findManyWithinWorkspace(workspaceId);
 
       await this.workspaceSchemaStorageService.setObjectMetadata(
         workspaceId,

--- a/server/src/workspace/workspace.factory.ts
+++ b/server/src/workspace/workspace.factory.ts
@@ -50,10 +50,9 @@ export class WorkspaceFactory {
 
     // If object metadata is not cached, get it from the database
     if (!objectMetadataCollection) {
-      objectMetadataCollection =
-        await this.objectMetadataService.getObjectMetadataFromWorkspaceId(
-          workspaceId,
-        );
+      objectMetadataCollection = await this.objectMetadataService.findMany({
+        workspaceId,
+      });
 
       await this.workspaceSchemaStorageService.setObjectMetadata(
         workspaceId,


### PR DESCRIPTION
This PR fix issue #2446 and also prefix the relations foreign keys when they are applied on a custom object.

We're now able to query n+n levels of object relations, like so:

```graphql
query Documents {
  documents {
    edges {
      node {
        id
        title
        team {
          name
          id
          authors {
            edges {
              node {
                id
                name
              }
            }
          }
        }
      }
    }
  }
}
```

Result:
```json
{
  "data": {
    "documents": {
      "edges": [
        {
          "node": {
            "id": "02acd480-d66c-47f9-90a4-137bc36cc61b",
            "title": "A Document",
            "team": {
              "name": "Big Team",
              "id": "7c068790-3f5e-46bf-8c0e-1b3b549be724",
              "authors": {
                "edges": [
                  {
                    "node": {
                      "id": "57826d24-7e15-4dbf-9447-a47be42316b2",
                      "name": "First Author"
                    }
                  },
                  {
                    "node": {
                      "id": "c7ed9b46-40ac-4a97-b185-d640eca90a1f",
                      "name": "Second Author"
                    }
                  }
                ]
              }
            }
          }
        }
      ]
    }
  }
}
```