### PR TITLE
Fix zapier validation team request

### DIFF
--- a/packages/twenty-zapier/src/creates/create_company.ts
+++ b/packages/twenty-zapier/src/creates/create_company.ts
@@ -104,7 +104,7 @@ export default {
       },
       {
         key: 'employees',
-        label: 'Employees (number of)',
+        label: 'Number of Employees',
         type: 'number',
         required: false,
         list: false,


### PR DESCRIPTION
closes #2759 
A field label renaming was asked by zapier team. This PR fixes it