### PR TITLE
2795-fix(front): ObjectNamePlural added as Page Header title

### DIFF
--- a/front/src/modules/object-record/components/RecordTablePage.tsx
+++ b/front/src/modules/object-record/components/RecordTablePage.tsx
@@ -54,7 +54,12 @@ export const RecordTablePage = () => {
 
   return (
     <PageContainer>
-      <PageHeader title="Objects" Icon={IconBuildingSkyscraper}>
+      <PageHeader
+        title={
+          objectNamePlural.charAt(0).toUpperCase() + objectNamePlural.slice(1)
+        }
+        Icon={IconBuildingSkyscraper}
+      >
         <PageHotkeysEffect onAddButtonClick={handleAddButtonClick} />
         <PageAddButton onClick={handleAddButtonClick} />
       </PageHeader>

--- a/front/src/modules/object-record/components/RecordTablePage.tsx
+++ b/front/src/modules/object-record/components/RecordTablePage.tsx
@@ -5,9 +5,10 @@ import { isNonEmptyString } from '@sniptt/guards';
 
 import { useOnboardingStatus } from '@/auth/hooks/useOnboardingStatus';
 import { OnboardingStatus } from '@/auth/utils/getOnboardingStatus';
+import { useObjectMetadataItemForSettings } from '@/object-metadata/hooks/useObjectMetadataItemForSettings';
 import { useObjectNameSingularFromPlural } from '@/object-metadata/hooks/useObjectNameSingularFromPlural';
 import { useCreateOneRecord } from '@/object-record/hooks/useCreateOneRecord';
-import { IconBuildingSkyscraper } from '@/ui/display/icon';
+import { useLazyLoadIcons } from '@/ui/input/hooks/useLazyLoadIcons';
 import { PageAddButton } from '@/ui/layout/page/PageAddButton';
 import { PageBody } from '@/ui/layout/page/PageBody';
 import { PageContainer } from '@/ui/layout/page/PageContainer';
@@ -35,6 +36,11 @@ export const RecordTablePage = () => {
 
   const navigate = useNavigate();
 
+  const { icons } = useLazyLoadIcons();
+
+  const { findObjectMetadataItemByNamePlural } =
+    useObjectMetadataItemForSettings();
+
   useEffect(() => {
     if (
       !isNonEmptyString(objectNamePlural) &&
@@ -58,7 +64,12 @@ export const RecordTablePage = () => {
         title={
           objectNamePlural.charAt(0).toUpperCase() + objectNamePlural.slice(1)
         }
-        Icon={IconBuildingSkyscraper}
+        Icon={
+          icons[
+            findObjectMetadataItemByNamePlural(objectNamePlural)!.icon ??
+              'Icon123'
+          ]
+        }
       >
         <PageHotkeysEffect onAddButtonClick={handleAddButtonClick} />
         <PageAddButton onClick={handleAddButtonClick} />

--- a/front/src/modules/spreadsheet-import/steps/components/ValidationStep/ValidationStep.tsx
+++ b/front/src/modules/spreadsheet-import/steps/components/ValidationStep/ValidationStep.tsx
@@ -235,5 +235,4 @@ export const ValidationStep = <T extends string>({
       <ContinueButton onContinue={onContinue} title="Confirm" />
     </>
   );
-
 };

--- a/front/src/modules/ui/navigation/navigation-bar/components/__stories__/NavigationBar.stories.tsx
+++ b/front/src/modules/ui/navigation/navigation-bar/components/__stories__/NavigationBar.stories.tsx
@@ -1,15 +1,15 @@
 import { Meta, StoryObj } from '@storybook/react';
 
+import {
+  IconCheckbox,
+  IconList,
+  IconSearch,
+  IconSettings,
+} from '@/ui/display/icon';
+import { ComponentDecorator } from '~/testing/decorators/ComponentDecorator';
 import { ComponentWithRouterDecorator } from '~/testing/decorators/ComponentWithRouterDecorator';
 
 import { NavigationBar } from '../NavigationBar';
-import { ComponentDecorator } from '~/testing/decorators/ComponentDecorator';
-import {
-  IconList,
-  IconSearch,
-  IconCheckbox,
-  IconSettings,
-} from '@/ui/display/icon';
 
 const meta: Meta<typeof NavigationBar> = {
   title: 'UI/Navigation/NavigationBar/NavigationBar',

--- a/front/src/modules/ui/object/field/meta-types/input/components/__stories__/RatingFieldInput.stories.tsx
+++ b/front/src/modules/ui/object/field/meta-types/input/components/__stories__/RatingFieldInput.stories.tsx
@@ -6,10 +6,10 @@ import { userEvent, within } from '@storybook/testing-library';
 import { useSetHotkeyScope } from '@/ui/utilities/hotkey/hooks/useSetHotkeyScope';
 import { FieldMetadataType } from '~/generated-metadata/graphql';
 
+import { FieldRatingValue } from '../../../../types/FieldMetadata';
 import { FieldContextProvider } from '../../../__stories__/FieldContextProvider';
 import { useRatingField } from '../../../hooks/useRatingField';
 import { RatingFieldInput, RatingFieldInputProps } from '../RatingFieldInput';
-import { FieldRatingValue } from '../../../../types/FieldMetadata';
 
 const RatingFieldValueSetterEffect = ({
   value,

--- a/front/src/utils/cast-as-positive-integer-or-null.ts
+++ b/front/src/utils/cast-as-positive-integer-or-null.ts
@@ -63,4 +63,3 @@ export const castAsPositiveIntegerOrNull = (
 
   return null;
 };
-


### PR DESCRIPTION
Closes #2795 

I have used ObjectMetaData for icons instead of hardcoding. So for new workspaces this approach will work

<img width="1440" alt="Screenshot 2023-12-06 at 8 13 58 PM" src="https://github.com/twentyhq/twenty/assets/62852363/62f8ede4-1cae-476e-b01a-8c799c1c7202">
