### PR TITLE
Fix/enum validation

### DIFF
--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -26,7 +26,6 @@ const bootstrap = async () => {
   // Apply validation pipes globally
   app.useGlobalPipes(
     new ValidationPipe({
-      // whitelist: true,
       transform: true,
     }),
   );

--- a/server/src/metadata/field-metadata/field-metadata.module.ts
+++ b/server/src/metadata/field-metadata/field-metadata.module.ts
@@ -16,6 +16,7 @@ import { TypeORMModule } from 'src/database/typeorm/typeorm.module';
 import { IsFieldMetadataDefaultValue } from 'src/metadata/field-metadata/validators/is-field-metadata-default-value.validator';
 import { FieldMetadataResolver } from 'src/metadata/field-metadata/field-metadata.resolver';
 import { FieldMetadataDTO } from 'src/metadata/field-metadata/dtos/field-metadata.dto';
+import { IsFieldMetadataOptions } from 'src/metadata/field-metadata/validators/is-field-metadata-options.validator';
 
 import { FieldMetadataService } from './field-metadata.service';
 import { FieldMetadataEntity } from './field-metadata.entity';
@@ -65,6 +66,7 @@ import { UpdateFieldInput } from './dtos/update-field.input';
   ],
   providers: [
     IsFieldMetadataDefaultValue,
+    IsFieldMetadataOptions,
     FieldMetadataService,
     FieldMetadataResolver,
   ],

--- a/server/src/metadata/field-metadata/utils/validate-default-value-for-type.util.ts
+++ b/server/src/metadata/field-metadata/utils/validate-default-value-for-type.util.ts
@@ -57,7 +57,13 @@ export const validateDefaultValueForType = (
       FieldMetadataDefaultValue
     >(validator, defaultValue);
 
-    return validateSync(defaultValueInstance).length === 0;
+    return (
+      validateSync(defaultValueInstance, {
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        forbidUnknownValues: true,
+      }).length === 0
+    );
   });
 
   return isValid;

--- a/server/src/metadata/field-metadata/utils/validate-options-for-type.util.ts
+++ b/server/src/metadata/field-metadata/utils/validate-options-for-type.util.ts
@@ -11,7 +11,7 @@ import {
 
 export const optionsValidatorsMap = {
   [FieldMetadataType.RATING]: [FieldMetadataDefaultOptions],
-  [FieldMetadataType.SELECT]: [FieldMetadataDefaultOptions],
+  [FieldMetadataType.SELECT]: [FieldMetadataComplexOptions],
   [FieldMetadataType.MULTI_SELECT]: [FieldMetadataComplexOptions],
 };
 

--- a/server/src/metadata/field-metadata/utils/validate-options-for-type.util.ts
+++ b/server/src/metadata/field-metadata/utils/validate-options-for-type.util.ts
@@ -31,12 +31,18 @@ export const validateOptionsForType = (
 
   const isValid = options.every((option) => {
     return validators.some((validator) => {
-      const optionsInstance = plainToInstance<any, FieldMetadataDefaultOptions>(
-        validator,
-        option,
-      );
+      const optionsInstance = plainToInstance<
+        any,
+        FieldMetadataDefaultOptions | FieldMetadataComplexOptions
+      >(validator, option);
 
-      return validateSync(optionsInstance).length === 0;
+      return (
+        validateSync(optionsInstance, {
+          whitelist: true,
+          forbidNonWhitelisted: true,
+          forbidUnknownValues: true,
+        }).length === 0
+      );
     });
   });
 

--- a/server/src/metadata/field-metadata/validators/is-field-metadata-options.validator.ts
+++ b/server/src/metadata/field-metadata/validators/is-field-metadata-options.validator.ts
@@ -5,7 +5,10 @@ import { ValidationArguments, ValidatorConstraint } from 'class-validator';
 import { FieldMetadataOptions } from 'src/metadata/field-metadata/interfaces/field-metadata-options.interface';
 
 import { FieldMetadataService } from 'src/metadata/field-metadata/field-metadata.service';
-import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
+import {
+  FieldMetadataEntity,
+  FieldMetadataType,
+} from 'src/metadata/field-metadata/field-metadata.entity';
 import { validateOptionsForType } from 'src/metadata/field-metadata/utils/validate-options-for-type.util';
 
 @Injectable()
@@ -28,7 +31,13 @@ export class IsFieldMetadataOptions {
         return false;
       }
 
-      const fieldMetadata = await this.fieldMetadataService.findOneOrFail(id);
+      let fieldMetadata: FieldMetadataEntity;
+
+      try {
+        fieldMetadata = await this.fieldMetadataService.findOneOrFail(id);
+      } catch {
+        return false;
+      }
 
       type = fieldMetadata.type;
     }

--- a/server/src/metadata/workspace-migration/factories/basic-column-action.factory.ts
+++ b/server/src/metadata/workspace-migration/factories/basic-column-action.factory.ts
@@ -47,21 +47,31 @@ export class BasicColumnActionFactory extends ColumnActionAbstractFactory<BasicF
   }
 
   protected handleAlterAction(
-    previousFieldMetadata: FieldMetadataInterface<BasicFieldMetadataType>,
-    nextFieldMetadata: FieldMetadataInterface<BasicFieldMetadataType>,
+    currentFieldMetadata: FieldMetadataInterface<BasicFieldMetadataType>,
+    alteredFieldMetadata: FieldMetadataInterface<BasicFieldMetadataType>,
     options?: WorkspaceColumnActionOptions,
   ): WorkspaceMigrationColumnAlter {
     const defaultValue =
-      this.getDefaultValue(nextFieldMetadata.defaultValue) ??
+      this.getDefaultValue(alteredFieldMetadata.defaultValue) ??
       options?.defaultValue;
     const serializedDefaultValue = serializeDefaultValue(defaultValue);
 
     return {
       action: WorkspaceMigrationColumnActionType.ALTER,
-      columnName: nextFieldMetadata.targetColumnMap.value,
-      columnType: fieldMetadataTypeToColumnType(nextFieldMetadata.type),
-      isNullable: nextFieldMetadata.isNullable,
-      defaultValue: serializedDefaultValue,
+      currentColumnDefinition: {
+        columnName: currentFieldMetadata.targetColumnMap.value,
+        columnType: fieldMetadataTypeToColumnType(currentFieldMetadata.type),
+        isNullable: currentFieldMetadata.isNullable,
+        defaultValue: serializeDefaultValue(
+          this.getDefaultValue(currentFieldMetadata.defaultValue),
+        ),
+      },
+      alteredColumnDefinition: {
+        columnName: alteredFieldMetadata.targetColumnMap.value,
+        columnType: fieldMetadataTypeToColumnType(alteredFieldMetadata.type),
+        isNullable: alteredFieldMetadata.isNullable,
+        defaultValue: serializedDefaultValue,
+      },
     };
   }
 

--- a/server/src/metadata/workspace-migration/factories/column-action-abstract.factory.ts
+++ b/server/src/metadata/workspace-migration/factories/column-action-abstract.factory.ts
@@ -23,21 +23,21 @@ export class ColumnActionAbstractFactory<
     action:
       | WorkspaceMigrationColumnActionType.CREATE
       | WorkspaceMigrationColumnActionType.ALTER,
-    previousFieldMetadata: FieldMetadataInterface<T> | undefined,
-    nextFieldMetadata: FieldMetadataInterface<T>,
+    currentFieldMetadata: FieldMetadataInterface<T> | undefined,
+    alteredFieldMetadata: FieldMetadataInterface<T>,
     options?: WorkspaceColumnActionOptions,
   ): WorkspaceMigrationColumnAction {
     switch (action) {
       case WorkspaceMigrationColumnActionType.CREATE:
-        return this.handleCreateAction(nextFieldMetadata, options);
+        return this.handleCreateAction(alteredFieldMetadata, options);
       case WorkspaceMigrationColumnActionType.ALTER: {
-        if (!previousFieldMetadata) {
-          throw new Error('Previous field metadata is required for alter');
+        if (!currentFieldMetadata) {
+          throw new Error('current field metadata is required for alter');
         }
 
         return this.handleAlterAction(
-          previousFieldMetadata,
-          nextFieldMetadata,
+          currentFieldMetadata,
+          alteredFieldMetadata,
           options,
         );
       }
@@ -57,8 +57,8 @@ export class ColumnActionAbstractFactory<
   }
 
   protected handleAlterAction(
-    _previousFieldMetadata: FieldMetadataInterface<T>,
-    _nextFieldMetadata: FieldMetadataInterface<T>,
+    _currentFieldMetadata: FieldMetadataInterface<T>,
+    _alteredFieldMetadata: FieldMetadataInterface<T>,
     _options?: WorkspaceColumnActionOptions,
   ): WorkspaceMigrationColumnAlter {
     throw new Error('handleAlterAction method not implemented.');

--- a/server/src/metadata/workspace-migration/interfaces/workspace-column-action-factory.interface.ts
+++ b/server/src/metadata/workspace-migration/interfaces/workspace-column-action-factory.interface.ts
@@ -14,8 +14,8 @@ export interface WorkspaceColumnActionFactory<
     action:
       | WorkspaceMigrationColumnActionType.CREATE
       | WorkspaceMigrationColumnActionType.ALTER,
-    previousFieldMetadata: FieldMetadataInterface<T> | undefined,
-    nextFieldMetadata: FieldMetadataInterface<T>,
+    currentFieldMetadata: FieldMetadataInterface<T> | undefined,
+    alteredFieldMetadata: FieldMetadataInterface<T>,
     options?: WorkspaceColumnActionOptions,
   ): WorkspaceMigrationColumnAction;
 }

--- a/server/src/metadata/workspace-migration/workspace-migration.entity.ts
+++ b/server/src/metadata/workspace-migration/workspace-migration.entity.ts
@@ -13,24 +13,24 @@ export enum WorkspaceMigrationColumnActionType {
 
 export type WorkspaceMigrationEnum = string | { from: string; to: string };
 
-export type WorkspaceMigrationColumnCreate = {
-  action: WorkspaceMigrationColumnActionType.CREATE;
+export interface WorkspaceMigrationColumnDefinition {
   columnName: string;
   columnType: string;
   enum?: WorkspaceMigrationEnum[];
   isArray?: boolean;
   isNullable?: boolean;
   defaultValue?: any;
-};
+}
+
+export interface WorkspaceMigrationColumnCreate
+  extends WorkspaceMigrationColumnDefinition {
+  action: WorkspaceMigrationColumnActionType.CREATE;
+}
 
 export type WorkspaceMigrationColumnAlter = {
   action: WorkspaceMigrationColumnActionType.ALTER;
-  columnName: string;
-  columnType: string;
-  enum?: WorkspaceMigrationEnum[];
-  isArray?: boolean;
-  isNullable?: boolean;
-  defaultValue?: any;
+  currentColumnDefinition: WorkspaceMigrationColumnDefinition;
+  alteredColumnDefinition: WorkspaceMigrationColumnDefinition;
 };
 
 export type WorkspaceMigrationColumnRelation = {


### PR DESCRIPTION
Multiple fixes in this PR:

- [x] `color` was not allowed for `SELECT`
- [x] If extra keys are sent to the `options` or `defaultValue`, validator are throwing errors
- [x] Migration of column now store `current` and `altered` version in `workspaceMigration` table in order to apply proper migration with TypeORM
- [x] `findOneOrFail` of undefined, due to a missing Nest.js injection