### PR TITLE
Fix relation between standard objects

### DIFF
--- a/front/src/pages/settings/data-model/SettingsObjectNewField/SettingsObjectNewFieldStep2.tsx
+++ b/front/src/pages/settings/data-model/SettingsObjectNewField/SettingsObjectNewFieldStep2.tsx
@@ -142,7 +142,7 @@ export const SettingsObjectNewFieldStep2 = () => {
 
         objectViews.forEach(async (view) => {
           await createOneViewField?.({
-            view: view.id,
+            viewId: view.id,
             fieldMetadataId:
               validatedFormValues.relation.type === 'MANY_TO_ONE'
                 ? createdRelation.data?.createOneRelation.toFieldMetadataId
@@ -154,7 +154,7 @@ export const SettingsObjectNewFieldStep2 = () => {
         });
         relationObjectViews.forEach(async (view) => {
           await createOneViewField?.({
-            view: view.id,
+            viewId: view.id,
             fieldMetadataId:
               validatedFormValues.relation.type === 'MANY_TO_ONE'
                 ? createdRelation.data?.createOneRelation.fromFieldMetadataId

--- a/server/src/metadata/relation-metadata/relation-metadata.service.ts
+++ b/server/src/metadata/relation-metadata/relation-metadata.service.ts
@@ -137,11 +137,11 @@ export class RelationMetadataService extends TypeOrmQueryService<RelationMetadat
         description: record.toDescription,
         icon: record.toIcon,
         isCustom: true,
-        targetColumnMap: isToCustom
-          ? {
-              value: createCustomColumnName(record.toName),
-            }
-          : {},
+        targetColumnMap: {
+          value: isToCustom
+            ? createCustomColumnName(record.toName)
+            : record.toName,
+        },
         isActive: true,
         type: FieldMetadataType.RELATION,
         objectMetadataId: record.toObjectMetadataId,
@@ -151,7 +151,9 @@ export class RelationMetadataService extends TypeOrmQueryService<RelationMetadat
       {
         name: baseColumnName,
         label: `${record.toLabel} Foreign Key`,
-        description: `${record.toDescription} Foreign Key`,
+        description: record.toDescription
+          ? `${record.toDescription} Foreign Key`
+          : undefined,
         icon: undefined,
         isCustom: true,
         targetColumnMap: {


### PR DESCRIPTION
This PR fixes a few issues
- The FE code was sending a viewId to a view property instead of viewId during viewField creation (after relation creation). Note: this part should be moved to the BE.
- The toDescription field is optional, when a description was missing we were concatenating it to format the relation description and it was containing undefined, now we don't try to create a description if none is provided.
- Fixes the targetColumnMap not defined when we were creating relations to standard objects. In the backend we run the query against pg_graphql with a fieldAlias however if the field is custom and targetColumnMap is empty we query it with undefined like this `bar: undefined` (see RelationFieldAliasFactory). The alias is actually redundant here it seems so maybe there are things we can improve 🤔 (cc @magrinj)