### PR TITLE
fix: workspace migration isNullable

### DIFF
--- a/packages/twenty-server/src/workspace/workspace-migration-runner/workspace-migration-runner.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-migration-runner/workspace-migration-runner.service.ts
@@ -226,7 +226,7 @@ export class WorkspaceMigrationRunnerService {
           (value): value is string => typeof value === 'string',
         ),
         isArray: migrationColumn.isArray,
-        isNullable: true,
+        isNullable: migrationColumn.isNullable,
       }),
     );
   }


### PR DESCRIPTION
Fix #2876 
Seems that all the changes that has been made in the seeds fix the issues we had.
Just putting `isNullable` to the proper variable and reseting the database doesn't seems to brake anything.