### PR TITLE
Add field create and delete migration to metadata sync

### DIFF
--- a/packages/twenty-server/src/metadata/workspace-migration/workspace-migration.entity.ts
+++ b/packages/twenty-server/src/metadata/workspace-migration/workspace-migration.entity.ts
@@ -9,6 +9,7 @@ export enum WorkspaceMigrationColumnActionType {
   CREATE = 'CREATE',
   ALTER = 'ALTER',
   RELATION = 'RELATION',
+  DROP = 'DROP',
 }
 
 export type WorkspaceMigrationEnum = string | { from: string; to: string };
@@ -41,12 +42,18 @@ export type WorkspaceMigrationColumnRelation = {
   isUnique?: boolean;
 };
 
+export type WorkspaceMigrationColumnDrop = {
+  action: WorkspaceMigrationColumnActionType.DROP;
+  columnName: string;
+};
+
 export type WorkspaceMigrationColumnAction = {
   action: WorkspaceMigrationColumnActionType;
 } & (
   | WorkspaceMigrationColumnCreate
   | WorkspaceMigrationColumnAlter
   | WorkspaceMigrationColumnRelation
+  | WorkspaceMigrationColumnDrop
 );
 
 export type WorkspaceMigrationTableAction = {

--- a/packages/twenty-server/src/workspace/workspace-migration-runner/workspace-migration-runner.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-migration-runner/workspace-migration-runner.service.ts
@@ -187,6 +187,12 @@ export class WorkspaceMigrationRunnerService {
             columnMigration,
           );
           break;
+        case WorkspaceMigrationColumnActionType.DROP:
+          await queryRunner.dropColumn(
+            `${schemaName}.${tableName}`,
+            columnMigration.columnName,
+          );
+          break;
         default:
           throw new Error(`Migration column action not supported`);
       }

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/decorators/metadata.decorator.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/decorators/metadata.decorator.ts
@@ -144,7 +144,8 @@ function generateFieldMetadata<T extends FieldMetadataType>(
     name: fieldKey,
     ...metadata,
     targetColumnMap: targetColumnMap,
-    isNullable: metadata.type === FieldMetadataType.RELATION ? true : isNullable,
+    isNullable:
+      metadata.type === FieldMetadataType.RELATION ? true : isNullable,
     isSystem,
     isCustom: false,
     options: null, // TODO: handle options + stringify for the diff.


### PR DESCRIPTION
## Context
The new sync-metadata service does not handle field creation nor deletion on existing objects.
This should now be possible. I had to update the migration runner to handle DROP actions on columns.

Note: Object deletion is a bit more tricky because sometimes we have relations between objects so we need to delete the joinColumn before deleting the object if it exists, it can be done in another PR.