### PR TITLE
BugFix: display button title when escaping the "Import" flow

### DIFF
--- a/packages/twenty-front/src/modules/ui/feedback/dialog-manager/components/Dialog.tsx
+++ b/packages/twenty-front/src/modules/ui/feedback/dialog-manager/components/Dialog.tsx
@@ -153,6 +153,7 @@ export const Dialog = ({
             }}
             fullWidth={true}
             variant={variant ?? 'secondary'}
+            title={key}
             {...{ accent, key, role }}
           />
         ))}


### PR DESCRIPTION
Solves #2906 

This PR solves the issue of the text not being displayed inside the buttons on cancellation of the Import Flow.

Here is a visual diff:
![IMG_3025](https://github.com/twentyhq/twenty/assets/68983533/620008b5-1caf-4bf2-90e0-5b1e5e526564)
