### PR TITLE
Update Jest configuration for frontend

### DIFF
--- a/packages/twenty-front/jest.config.js
+++ b/packages/twenty-front/jest.config.js
@@ -10,8 +10,30 @@ export default {
     '@testing/(.+)': "<rootDir>/src/testing/$1",
   },
   extensionsToTreatAsEsm: ['.ts', '.tsx'],
-  // collectCoverage: true,
-  // collectCoverageFrom: ['<rootDir>/src/**/*.{ts,tsx}'],
-  // coveragePathIgnorePatterns: ['(tests/.*.mock).(jsx?|tsx?)$', '(.*).d.ts$'],
+  coverageThreshold: {
+    global: {
+      statements: 10,
+      lines: 10,
+      functions: 10,
+    },
+  },
+  collectCoverage: true,
+  collectCoverageFrom: ['<rootDir>/src/**/*.ts'],
+  coveragePathIgnorePatterns: [
+    'states/.+State.ts$',
+    'contexts/.+Context.ts',
+    'testing/*',
+    'tests/*',
+    'config/*',
+    'graphql/queries/*',
+    'graphql/mutations/*',
+    'graphql/fragments/*',
+    'types/*',
+    'constants/*',
+    'generated-metadata/*',
+    'generated/*',
+    '__stories__/*',
+
+  ],
   // coverageDirectory: '<rootDir>/coverage/',
 }


### PR DESCRIPTION
Related to #2992 

We have never set up jest config correctly in the past. Jest tests should be setup to tests all .ts files (excluding the one not containing any logic or the one that are tied to testing themselves). Mainly, the goals is to cover `utils`, `hooks` and `selectors`.
`.tsx` components are covered through storybook.

So, I'm excluding:
```
'states/.+State.ts$',
'contexts/.+Context.ts',
'testing/*',
'tests/*',
'config/*',
'graphql/queries/*',
'graphql/mutations/*',
'graphql/fragments/*',
'types/*',
'constants/*',
'generated-metadata/*',
'generated/*',
'__stories__/*',
```