### PR TITLE
Fix ExceptionHandler requiring httpAdapter

### DIFF
--- a/packages/twenty-server/src/integrations/exception-handler/exception-handler.module-factory.ts
+++ b/packages/twenty-server/src/integrations/exception-handler/exception-handler.module-factory.ts
@@ -26,7 +26,7 @@ export const exceptionHandlerModuleFactory = async (
         type: ExceptionHandlerDriver.Sentry,
         options: {
           dns: environmentService.getSentryDSN() ?? '',
-          serverInstance: adapterHost.httpAdapter.getInstance(),
+          serverInstance: adapterHost.httpAdapter?.getInstance(),
           debug: environmentService.isDebugMode(),
         },
       };

--- a/packages/twenty-server/src/integrations/exception-handler/interfaces/exception-handler.interface.ts
+++ b/packages/twenty-server/src/integrations/exception-handler/interfaces/exception-handler.interface.ts
@@ -9,7 +9,7 @@ export interface ExceptionHandlerSentryDriverFactoryOptions {
   type: ExceptionHandlerDriver.Sentry;
   options: {
     dns: string;
-    serverInstance: Router;
+    serverInstance?: Router;
     debug?: boolean;
   };
 }


### PR DESCRIPTION
## Context

We have added an Sentry exceptionHandler. This exceptionHandler is using the HttpAdapter to send some request context to Sentry. However, the httpAdapter is not defined when running commands or jobs but was required.

This led to command exception handling being broken.