### PR TITLE
Fix tag border color Relations

### DIFF
--- a/packages/twenty-front/src/modules/settings/data-model/object-details/components/SettingsObjectFieldDataType.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/object-details/components/SettingsObjectFieldDataType.tsx
@@ -35,7 +35,7 @@ const StyledDataType = styled.div<{ value: FieldMetadataType }>`
   ${({ theme, value }) =>
     value === FieldMetadataType.Relation
       ? css`
-          border-color: ${theme.color.purple20};
+          border-color: ${theme.tag.background.purple};
           color: ${theme.color.purple};
         `
       : ''}

--- a/packages/twenty-front/src/modules/ui/theme/constants/tag.ts
+++ b/packages/twenty-front/src/modules/ui/theme/constants/tag.ts
@@ -1,6 +1,6 @@
 import { color } from './colors';
 
-export const tagLight: { [key: string]: { [key: string]: string } } = {
+export const tagLight = {
   text: {
     green: color.green60,
     turquoise: color.turquoise60,


### PR DESCRIPTION
- fix color for tag border
- fix tag theme types

<img width="128" alt="Bildschirmfoto 2023-12-15 um 23 19 32" src="https://github.com/twentyhq/twenty/assets/48770548/16df506e-62c3-4fbf-b6f5-ae36451c95e4">
<img width="124" alt="Bildschirmfoto 2023-12-15 um 23 19 25" src="https://github.com/twentyhq/twenty/assets/48770548/a4b31126-7c00-407c-ad53-d6952eca7331">


closes #3031