### PR TITLE
Fix inject-runtime-env.sh in frontend docker file

### DIFF
--- a/packages/twenty-docker/prod/twenty-front/Dockerfile
+++ b/packages/twenty-docker/prod/twenty-front/Dockerfile
@@ -28,4 +28,4 @@ RUN yarn global add serve
 LABEL org.opencontainers.image.source=https://github.com/twentyhq/twenty
 LABEL org.opencontainers.image.description="This image provides a consistent and reproducible environment for the frontend."
 
-CMD ["/bin/sh", "-c", "./scripts/inject-runtime-env.sh && serve build"]
+CMD ["/bin/sh", "-c", "/app/packages/twenty-front/scripts/inject-runtime-env.sh && serve build"]


### PR DESCRIPTION
The cmd couldn't find the the file path in the current dir, that's why had to use whole path to reference the file
[Issue](https://github.com/twentyhq/twenty/issues/3036)