### PR TITLE
Fix documentation layout broken because of mixed rest api doc styles

### DIFF
--- a/packages/twenty-docs/src/pages/rest-api.tsx
+++ b/packages/twenty-docs/src/pages/rest-api.tsx
@@ -3,7 +3,7 @@ import BrowserOnly from "@docusaurus/BrowserOnly";
 import React, { useEffect, useState } from "react";
 import { API } from '@stoplight/elements';
 import spotlightTheme from '!css-loader!@stoplight/elements/styles.min.css';
-import './rest-api.css'
+import restApiCss from '!css-loader!./rest-api.css';
 import { parseJson } from "nx/src/utils/json";
 import { TbLoader2 } from "react-icons/tb";
 
@@ -23,6 +23,14 @@ const TokenForm = ({onSubmit, isTokenValid, token, isLoading}: TokenFormProps)=>
   useEffect(() => {
     const styleElement = document.createElement('style');
     styleElement.innerHTML = spotlightTheme.toString();
+    document.head.append(styleElement);
+
+    return () => styleElement.remove();
+  }, []);
+
+  useEffect(() => {
+    const styleElement = document.createElement('style');
+    styleElement.innerHTML = restApiCss.toString();
     document.head.append(styleElement);
 
     return () => styleElement.remove();


### PR DESCRIPTION
We have recently merged https://github.com/twentyhq/twenty/pull/3020. However, this PR introduces styles for the rest-api page that are leaking on every pages. To avoid that, we can load css only on the rest-api page. Another technique would be to properly scope the CSS but it looks complicated to do with Docusaurus.

Before:
<img width="1512" alt="image" src="https://github.com/twentyhq/twenty/assets/12035771/3cd5a5c8-b4b1-47f8-a08e-0bff78416e1f">

After:
<img width="1512" alt="image" src="https://github.com/twentyhq/twenty/assets/12035771/10a20995-0fe6-4f21-b9d4-fcbc0190b01b">
