### PR TITLE
GH-3028 Update filter key and JSON parse assignee selected filter on tasks page

### DIFF
--- a/packages/twenty-front/src/modules/activities/tasks/hooks/useTasks.ts
+++ b/packages/twenty-front/src/modules/activities/tasks/hooks/useTasks.ts
@@ -46,7 +46,7 @@ export const useTasks = (props?: UseTasksProps) => {
       type: { eq: 'Task' },
       ...(isNonEmptyString(selectedFilter?.value) && {
         assigneeId: {
-          eq: selectedFilter?.value,
+          in: JSON.parse(selectedFilter?.value),
         },
       }),
     },
@@ -70,7 +70,7 @@ export const useTasks = (props?: UseTasksProps) => {
       type: { eq: 'Task' },
       ...(isNonEmptyString(selectedFilter?.value) && {
         assigneeId: {
-          eq: selectedFilter?.value,
+          in: JSON.parse(selectedFilter?.value),
         },
       }),
     },

--- a/packages/twenty-front/src/pages/tasks/TasksEffect.tsx
+++ b/packages/twenty-front/src/pages/tasks/TasksEffect.tsx
@@ -26,7 +26,7 @@ export const TasksEffect = ({ filterDropdownId }: TasksEffectProps) => {
     if (currentWorkspaceMember) {
       setSelectedFilter({
         fieldMetadataId: 'assigneeId',
-        value: currentWorkspaceMember.id,
+        value: JSON.stringify(currentWorkspaceMember.id),
         operand: ViewFilterOperand.Is,
         displayValue:
           currentWorkspaceMember.name?.firstName +


### PR DESCRIPTION
## Description
This PR fixes the multi-select filter on tasks page. After page is loaded, if filter checkbox is selected/de-selected, it didn't behave expectedly and resulted in error.

## Issues
- Closes #3028 

## Screencast

https://github.com/twentyhq/twenty/assets/60139930/63ba7364-e77e-42fc-972e-e6c5f909105b

