### PR TITLE
Add sync driver for queue messages

### DIFF
--- a/packages/twenty-server/src/integrations/environment/environment.service.ts
+++ b/packages/twenty-server/src/integrations/environment/environment.service.ts
@@ -148,7 +148,7 @@ export class EnvironmentService {
   getMessageQueueDriverType(): MessageQueueDriverType {
     return (
       this.configService.get<MessageQueueDriverType>('MESSAGE_QUEUE_TYPE') ??
-      MessageQueueDriverType.PgBoss
+      MessageQueueDriverType.Sync
     );
   }
 

--- a/packages/twenty-server/src/integrations/message-queue/drivers/interfaces/message-queue-driver.interface.ts
+++ b/packages/twenty-server/src/integrations/message-queue/drivers/interfaces/message-queue-driver.interface.ts
@@ -1,15 +1,16 @@
 import { QueueJobOptions } from 'src/integrations/message-queue/drivers/interfaces/job-options.interface';
+import { MessageQueueJobData } from 'src/integrations/message-queue/interfaces/message-queue-job.interface';
 
 import { MessageQueue } from 'src/integrations/message-queue/message-queue.constants';
 
 export interface MessageQueueDriver {
-  add<T>(
+  add<T extends MessageQueueJobData>(
     queueName: MessageQueue,
     jobName: string,
     data: T,
     options?: QueueJobOptions,
   ): Promise<void>;
-  work<T>(
+  work<T extends MessageQueueJobData>(
     queueName: MessageQueue,
     handler: ({ data, id }: { data: T; id: string }) => Promise<void> | void,
   );

--- a/packages/twenty-server/src/integrations/message-queue/drivers/sync.driver.ts
+++ b/packages/twenty-server/src/integrations/message-queue/drivers/sync.driver.ts
@@ -1,0 +1,21 @@
+import { ModuleRef } from "@nestjs/core";
+import { QueueJobOptions } from "src/integrations/message-queue/drivers/interfaces/job-options.interface";
+import { MessageQueueDriver } from "src/integrations/message-queue/drivers/interfaces/message-queue-driver.interface";
+import { MessageQueueJob, MessageQueueJobData } from "src/integrations/message-queue/interfaces/message-queue-job.interface";
+import { MessageQueue } from "src/integrations/message-queue/message-queue.constants";
+import { MessageQueueModule } from "src/integrations/message-queue/message-queue.module";
+import { getJobClassName } from "src/integrations/message-queue/utils/get-job-class-name.util";
+import { QueueWorkerModule } from "src/queue-worker.module";
+
+export class SyncDriver implements MessageQueueDriver {
+  constructor(private readonly moduleRef: ModuleRef) {}
+  async add<T extends MessageQueueJobData>(_queueName: MessageQueue, jobName: string, data: T, _options?: QueueJobOptions | undefined): Promise<void> {
+    const jobClassName = getJobClassName(jobName);
+    const job: MessageQueueJob<MessageQueueJobData> = this.moduleRef.get(jobClassName, { strict: true });
+
+    return await job.handle(data);
+  }
+  work<T>(queueName: MessageQueue, handler: ({ data, id }: { data: T; id: string; }) => void | Promise<void>) {
+    return;
+  }
+}

--- a/packages/twenty-server/src/integrations/message-queue/drivers/sync.driver.ts
+++ b/packages/twenty-server/src/integrations/message-queue/drivers/sync.driver.ts
@@ -8,10 +8,10 @@ import { getJobClassName } from "src/integrations/message-queue/utils/get-job-cl
 import { QueueWorkerModule } from "src/queue-worker.module";
 
 export class SyncDriver implements MessageQueueDriver {
-  constructor(private readonly moduleRef: ModuleRef) {}
+  constructor(private readonly jobsModuleRef: ModuleRef) {}
   async add<T extends MessageQueueJobData>(_queueName: MessageQueue, jobName: string, data: T, _options?: QueueJobOptions | undefined): Promise<void> {
     const jobClassName = getJobClassName(jobName);
-    const job: MessageQueueJob<MessageQueueJobData> = this.moduleRef.get(jobClassName, { strict: true });
+    const job: MessageQueueJob<MessageQueueJobData> = this.jobsModuleRef.get(jobClassName, { strict: true });
 
     return await job.handle(data);
   }

--- a/packages/twenty-server/src/integrations/message-queue/interfaces/message-queue.interface.ts
+++ b/packages/twenty-server/src/integrations/message-queue/interfaces/message-queue.interface.ts
@@ -6,6 +6,7 @@ import { PgBossDriverOptions } from 'src/integrations/message-queue/drivers/pg-b
 export enum MessageQueueDriverType {
   PgBoss = 'pg-boss',
   BullMQ = 'bull-mq',
+  Sync = 'sync',
 }
 
 export interface PgBossDriverFactoryOptions {
@@ -18,9 +19,15 @@ export interface BullMQDriverFactoryOptions {
   options: BullMQDriverOptions;
 }
 
+export interface SyncDriverFactoryOptions {
+  type: MessageQueueDriverType.Sync;
+  options: Record<string, any>;
+}
+
 export type MessageQueueModuleOptions =
   | PgBossDriverFactoryOptions
-  | BullMQDriverFactoryOptions;
+  | BullMQDriverFactoryOptions
+  | SyncDriverFactoryOptions;
 
 export type MessageQueueModuleAsyncOptions = {
   useFactory: (

--- a/packages/twenty-server/src/integrations/message-queue/jobs.module.ts
+++ b/packages/twenty-server/src/integrations/message-queue/jobs.module.ts
@@ -1,0 +1,19 @@
+import { Module } from "@nestjs/common";
+import { ModuleRef } from "@nestjs/core";
+import { FetchMessagesJob } from "src/workspace/messaging/jobs/fetch-messages.job";
+
+@Module({
+  providers: [
+    {
+      provide: FetchMessagesJob.name,
+      useClass: FetchMessagesJob,
+    },
+  ],
+})
+export class JobsModule {
+  static moduleRef: ModuleRef;
+
+  constructor(private moduleRef: ModuleRef) {
+    JobsModule.moduleRef = this.moduleRef;
+  }
+}

--- a/packages/twenty-server/src/integrations/message-queue/message-queue.module-factory.ts
+++ b/packages/twenty-server/src/integrations/message-queue/message-queue.module-factory.ts
@@ -15,6 +15,12 @@ export const messageQueueModuleFactory = async (
   const driverType = environmentService.getMessageQueueDriverType();
 
   switch (driverType) {
+    case MessageQueueDriverType.Sync: {
+      return {
+        type: MessageQueueDriverType.Sync,
+        options: {},
+      };
+    }
     case MessageQueueDriverType.PgBoss: {
       const connectionString = environmentService.getPGDatabaseUrl();
 

--- a/packages/twenty-server/src/integrations/message-queue/message-queue.module.ts
+++ b/packages/twenty-server/src/integrations/message-queue/message-queue.module.ts
@@ -35,19 +35,18 @@ export class MessageQueueModule {
         useFactory: async (...args: any[]) => {
           const config = await options.useFactory(...args);
 
-          if (config.type === MessageQueueDriverType.PgBoss) {
-            const boss = new PgBossDriver(config.options);
+          switch (config.type) {
+            case MessageQueueDriverType.PgBoss:
+              const boss = new PgBossDriver(config.options);
+              await boss.init();
+              return boss;
 
-            await boss.init();
+            case MessageQueueDriverType.BullMQ:
+              return new BullMQDriver(config.options);
 
-            return boss;
+            default:
+              return new SyncDriver(JobsModule.moduleRef);
           }
-
-          if (config.type === MessageQueueDriverType.BullMQ) {
-            return new BullMQDriver(config.options);
-          }
-
-          return new SyncDriver(JobsModule.moduleRef);
         },
         inject: options.inject || [],
       },

--- a/packages/twenty-server/src/integrations/message-queue/utils/get-job-class-name.util.ts
+++ b/packages/twenty-server/src/integrations/message-queue/utils/get-job-class-name.util.ts
@@ -1,0 +1,5 @@
+export function getJobClassName(name: string): string {
+  const [, jobName] = name.split('.') ?? [];
+
+  return jobName ?? name;
+}

--- a/packages/twenty-server/src/queue-worker.module.ts
+++ b/packages/twenty-server/src/queue-worker.module.ts
@@ -4,6 +4,7 @@ import { EnvironmentModule } from 'src/integrations/environment/environment.modu
 import { EnvironmentService } from 'src/integrations/environment/environment.service';
 import { LoggerModule } from 'src/integrations/logger/logger.module';
 import { loggerModuleFactory } from 'src/integrations/logger/logger.module-factory';
+import { JobsModule } from 'src/integrations/message-queue/jobs.module';
 import { MessageQueueModule } from 'src/integrations/message-queue/message-queue.module';
 import { messageQueueModuleFactory } from 'src/integrations/message-queue/message-queue.module-factory';
 import { FetchMessagesJob } from 'src/workspace/messaging/jobs/fetch-messages.job';
@@ -19,12 +20,7 @@ import { FetchMessagesJob } from 'src/workspace/messaging/jobs/fetch-messages.jo
       useFactory: messageQueueModuleFactory,
       inject: [EnvironmentService],
     }),
-  ],
-  providers: [
-    {
-      provide: FetchMessagesJob.name,
-      useClass: FetchMessagesJob,
-    },
+    JobsModule,
   ],
 })
 export class QueueWorkerModule {}

--- a/packages/twenty-server/src/queue-worker.ts
+++ b/packages/twenty-server/src/queue-worker.ts
@@ -4,9 +4,11 @@ import {
   MessageQueueJob,
   MessageQueueJobData,
 } from 'src/integrations/message-queue/interfaces/message-queue-job.interface';
+import { JobsModule } from 'src/integrations/message-queue/jobs.module';
 
 import { MessageQueue } from 'src/integrations/message-queue/message-queue.constants';
 import { MessageQueueService } from 'src/integrations/message-queue/services/message-queue.service';
+import { getJobClassName } from 'src/integrations/message-queue/utils/get-job-class-name.util';
 import { QueueWorkerModule } from 'src/queue-worker.module';
 
 async function bootstrap() {
@@ -18,7 +20,7 @@ async function bootstrap() {
     await messageQueueService.work(async (jobData: MessageQueueJobData) => {
       const jobClassName = getJobClassName(jobData.name);
       const job: MessageQueueJob<MessageQueueJobData> = app
-        .select(QueueWorkerModule)
+        .select(JobsModule)
         .get(jobClassName, { strict: true });
 
       await job.handle(jobData.data);
@@ -27,8 +29,3 @@ async function bootstrap() {
 }
 bootstrap();
 
-function getJobClassName(name: string): string {
-  const [, jobName] = name.split('.') ?? [];
-
-  return jobName ?? name;
-}


### PR DESCRIPTION
## Context

We've recently added a worker for our queues however the worker needs to be running in a separated app to execute jobs. To improve the dev experience and because workers are not always meaningful for local development, this PR adds a sync driver which means jobs will be executed directly without going through a queue.

## Test
<img width="990" alt="Screenshot 2023-12-19 at 11 31 39" src="https://github.com/twentyhq/twenty/assets/1834158/af62a385-dd75-4b4f-9800-1fa650748ce5">
