### PR TITLE
Fix queue setup

### DIFF
--- a/packages/twenty-server/src/integrations/message-queue/drivers/bullmq.driver.ts
+++ b/packages/twenty-server/src/integrations/message-queue/drivers/bullmq.driver.ts
@@ -38,9 +38,13 @@ export class BullMQDriver implements MessageQueueDriver {
     queueName: MessageQueue,
     handler: ({ data, id }: { data: T; id: string }) => Promise<void>,
   ) {
-    const worker = new Worker(queueName, async (job) => {
-      await handler(job as { data: T; id: string });
-    });
+    const worker = new Worker(
+      queueName,
+      async (job) => {
+        await handler(job as { data: T; id: string });
+      },
+      this.options,
+    );
 
     this.workerMap[queueName] = worker;
   }

--- a/packages/twenty-server/src/integrations/message-queue/drivers/pg-boss.driver.ts
+++ b/packages/twenty-server/src/integrations/message-queue/drivers/pg-boss.driver.ts
@@ -39,7 +39,12 @@ export class PgBossDriver implements MessageQueueDriver {
     await this.pgBoss.send(
       `${queueName}.${jobName}`,
       data as object,
-      options ?? {},
+      options
+        ? {
+            ...options,
+            singletonKey: options?.id,
+          }
+        : {},
     );
   }
 }

--- a/packages/twenty-server/src/integrations/message-queue/message-queue.module.ts
+++ b/packages/twenty-server/src/integrations/message-queue/message-queue.module.ts
@@ -13,10 +13,7 @@ import {
 import { PgBossDriver } from 'src/integrations/message-queue/drivers/pg-boss.driver';
 import { MessageQueueService } from 'src/integrations/message-queue/services/message-queue.service';
 import { BullMQDriver } from 'src/integrations/message-queue/drivers/bullmq.driver';
-import { FetchMessagesJob } from 'src/workspace/messaging/jobs/fetch-messages.job';
 import { SyncDriver } from 'src/integrations/message-queue/drivers/sync.driver';
-import { ModuleRef } from '@nestjs/core';
-import { AppModule } from 'src/app.module';
 import { JobsModule } from 'src/integrations/message-queue/jobs.module';
 
 @Global()
@@ -38,7 +35,9 @@ export class MessageQueueModule {
           switch (config.type) {
             case MessageQueueDriverType.PgBoss:
               const boss = new PgBossDriver(config.options);
+
               await boss.init();
+
               return boss;
 
             case MessageQueueDriverType.BullMQ:

--- a/packages/twenty-server/src/metadata/data-source/data-source.entity.ts
+++ b/packages/twenty-server/src/metadata/data-source/data-source.entity.ts
@@ -37,7 +37,7 @@ export class DataSourceEntity {
   })
   objects: ObjectMetadataEntity[];
 
-  @Column({ nullable: false })
+  @Column({ nullable: false, type: 'uuid' })
   workspaceId: string;
 
   @CreateDateColumn()

--- a/packages/twenty-server/src/metadata/field-metadata/field-metadata.entity.ts
+++ b/packages/twenty-server/src/metadata/field-metadata/field-metadata.entity.ts
@@ -95,7 +95,7 @@ export class FieldMetadataEntity<
   @Column({ nullable: true, default: true })
   isNullable: boolean;
 
-  @Column({ nullable: false })
+  @Column({ nullable: false, type: 'uuid' })
   workspaceId: string;
 
   @OneToOne(

--- a/packages/twenty-server/src/metadata/object-metadata/object-metadata.entity.ts
+++ b/packages/twenty-server/src/metadata/object-metadata/object-metadata.entity.ts
@@ -64,7 +64,7 @@ export class ObjectMetadataEntity implements ObjectMetadataInterface {
   @Column({ nullable: true })
   imageIdentifierFieldMetadataId?: string;
 
-  @Column({ nullable: false })
+  @Column({ nullable: false, type: 'uuid' })
   workspaceId: string;
 
   @OneToMany(() => FieldMetadataEntity, (field) => field.object, {

--- a/packages/twenty-server/src/metadata/relation-metadata/relation-metadata.entity.ts
+++ b/packages/twenty-server/src/metadata/relation-metadata/relation-metadata.entity.ts
@@ -40,7 +40,7 @@ export class RelationMetadataEntity implements RelationMetadataInterface {
   @Column({ nullable: false, type: 'uuid' })
   toFieldMetadataId: string;
 
-  @Column({ nullable: false })
+  @Column({ nullable: false, type: 'uuid' })
   workspaceId: string;
 
   @ManyToOne(

--- a/packages/twenty-server/src/metadata/workspace-cache-version/workspace-cache-version.entity.ts
+++ b/packages/twenty-server/src/metadata/workspace-cache-version/workspace-cache-version.entity.ts
@@ -11,7 +11,7 @@ export class WorkspaceCacheVersionEntity {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
-  @Column({ unique: true })
+  @Column({ unique: true, nullable: false, type: 'uuid' })
   workspaceId: string;
 
   @Column()

--- a/packages/twenty-server/src/metadata/workspace-migration/workspace-migration.entity.ts
+++ b/packages/twenty-server/src/metadata/workspace-migration/workspace-migration.entity.ts
@@ -79,7 +79,7 @@ export class WorkspaceMigrationEntity {
   @Column({ nullable: true })
   appliedAt?: Date;
 
-  @Column()
+  @Column({ nullable: false, type: 'uuid' })
   workspaceId: string;
 
   @CreateDateColumn()

--- a/packages/twenty-server/src/queue-worker.ts
+++ b/packages/twenty-server/src/queue-worker.ts
@@ -4,8 +4,8 @@ import {
   MessageQueueJob,
   MessageQueueJobData,
 } from 'src/integrations/message-queue/interfaces/message-queue-job.interface';
-import { JobsModule } from 'src/integrations/message-queue/jobs.module';
 
+import { JobsModule } from 'src/integrations/message-queue/jobs.module';
 import { MessageQueue } from 'src/integrations/message-queue/message-queue.constants';
 import { MessageQueueService } from 'src/integrations/message-queue/services/message-queue.service';
 import { getJobClassName } from 'src/integrations/message-queue/utils/get-job-class-name.util';
@@ -28,4 +28,3 @@ async function bootstrap() {
   }
 }
 bootstrap();
-


### PR DESCRIPTION
## Context
- Fixed bull-mq setup: It needs the option parameter for Queues/Workers instantiations, I've added the missing one
- Fixed pg-boss missing singletonKey, it is used a bit differently with pg-boss so I had to adapt the driver accordingly to have an aligned API
- Fixed a few typeorm entities that were not aligned with the DB (and so the previous migrations).
See here that now it matches with the DB when I run a generate after a db:reset
<img width="1332" alt="Screenshot 2023-12-19 at 16 46 36" src="https://github.com/twentyhq/twenty/assets/1834158/261f902b-c5e4-45df-9ec2-645818b22f79">


## Tested 
locally with this redis image `docker run -d --name redis-stack -p 6379:6379 -p 8001:8001 redis/redis-stack:latest` 
<img width="1382" alt="Screenshot 2023-12-19 at 16 45 03" src="https://github.com/twentyhq/twenty/assets/1834158/9a996d10-6b75-42e4-bbe7-b25ac79750fb">
