### PR TITLE
fix: composite type migrations not well formatted

### DIFF
--- a/packages/twenty-server/src/metadata/field-metadata/composite-types/currency.composite-type.ts
+++ b/packages/twenty-server/src/metadata/field-metadata/composite-types/currency.composite-type.ts
@@ -2,10 +2,22 @@ import { ObjectMetadataInterface } from 'src/metadata/field-metadata/interfaces/
 import { FieldMetadataInterface } from 'src/metadata/field-metadata/interfaces/field-metadata.interface';
 
 import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
+import { generateTargetColumnMap } from 'src/metadata/field-metadata/utils/generate-target-column-map.util';
 
 export const currencyFields = (
   fieldMetadata?: FieldMetadataInterface,
 ): FieldMetadataInterface[] => {
+  const targetColumnMap = fieldMetadata
+    ? generateTargetColumnMap(
+        fieldMetadata.type,
+        fieldMetadata.isCustom ?? false,
+        fieldMetadata.name,
+      )
+    : {
+        amountMicros: 'amountMicros',
+        currencyCode: 'currencyCode',
+      };
+
   return [
     {
       id: 'amountMicros',
@@ -14,9 +26,7 @@ export const currencyFields = (
       name: 'amountMicros',
       label: 'AmountMicros',
       targetColumnMap: {
-        value: fieldMetadata
-          ? `${fieldMetadata.name}AmountMicros`
-          : 'amountMicros',
+        value: targetColumnMap.amountMicros,
       },
       isNullable: true,
     } satisfies FieldMetadataInterface,
@@ -27,9 +37,7 @@ export const currencyFields = (
       name: 'currencyCode',
       label: 'Currency Code',
       targetColumnMap: {
-        value: fieldMetadata
-          ? `${fieldMetadata.name}CurrencyCode`
-          : 'currencyCode',
+        value: targetColumnMap.currencyCode,
       },
       isNullable: true,
     } satisfies FieldMetadataInterface,

--- a/packages/twenty-server/src/metadata/field-metadata/composite-types/full-name.composite-type.ts
+++ b/packages/twenty-server/src/metadata/field-metadata/composite-types/full-name.composite-type.ts
@@ -2,10 +2,22 @@ import { ObjectMetadataInterface } from 'src/metadata/field-metadata/interfaces/
 import { FieldMetadataInterface } from 'src/metadata/field-metadata/interfaces/field-metadata.interface';
 
 import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
+import { generateTargetColumnMap } from 'src/metadata/field-metadata/utils/generate-target-column-map.util';
 
 export const fullNameFields = (
   fieldMetadata?: FieldMetadataInterface,
 ): FieldMetadataInterface[] => {
+  const targetColumnMap = fieldMetadata
+    ? generateTargetColumnMap(
+        fieldMetadata.type,
+        fieldMetadata.isCustom ?? false,
+        fieldMetadata.name,
+      )
+    : {
+        firstName: 'firstName',
+        lastName: 'lastName',
+      };
+
   return [
     {
       id: 'firstName',
@@ -14,7 +26,7 @@ export const fullNameFields = (
       name: 'firstName',
       label: 'First Name',
       targetColumnMap: {
-        value: fieldMetadata ? `${fieldMetadata.name}FirstName` : 'firstName',
+        value: targetColumnMap.firstName,
       },
       isNullable: true,
     } satisfies FieldMetadataInterface,
@@ -25,7 +37,7 @@ export const fullNameFields = (
       name: 'lastName',
       label: 'Last Name',
       targetColumnMap: {
-        value: fieldMetadata ? `${fieldMetadata.name}LastName` : 'lastName',
+        value: targetColumnMap.lastName,
       },
       isNullable: true,
     } satisfies FieldMetadataInterface,

--- a/packages/twenty-server/src/metadata/field-metadata/composite-types/link.composite-type.ts
+++ b/packages/twenty-server/src/metadata/field-metadata/composite-types/link.composite-type.ts
@@ -2,10 +2,22 @@ import { ObjectMetadataInterface } from 'src/metadata/field-metadata/interfaces/
 import { FieldMetadataInterface } from 'src/metadata/field-metadata/interfaces/field-metadata.interface';
 
 import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
+import { generateTargetColumnMap } from 'src/metadata/field-metadata/utils/generate-target-column-map.util';
 
 export const linkFields = (
   fieldMetadata?: FieldMetadataInterface,
 ): FieldMetadataInterface[] => {
+  const targetColumnMap = fieldMetadata
+    ? generateTargetColumnMap(
+        fieldMetadata.type,
+        fieldMetadata.isCustom ?? false,
+        fieldMetadata.name,
+      )
+    : {
+        label: 'label',
+        url: 'url',
+      };
+
   return [
     {
       id: 'label',
@@ -14,7 +26,7 @@ export const linkFields = (
       name: 'label',
       label: 'Label',
       targetColumnMap: {
-        value: fieldMetadata ? `${fieldMetadata.name}Label` : 'label',
+        value: targetColumnMap.label,
       },
       isNullable: true,
     } satisfies FieldMetadataInterface,
@@ -25,7 +37,7 @@ export const linkFields = (
       name: 'url',
       label: 'Url',
       targetColumnMap: {
-        value: fieldMetadata ? `${fieldMetadata.name}Url` : 'url',
+        value: targetColumnMap.url,
       },
       isNullable: true,
     } satisfies FieldMetadataInterface,


### PR DESCRIPTION
When using custom fields inside standards or custom objects, the generated `targetColumnMap` was not generated with the custom prefix `_`.
So we got an error during the query, because we're trying to retrieve column that doesn't exist.
This PR fix the issue.

Fix #3002 
