### PR TITLE
send pg graphql exception to sentry + fix missing nullable for relations

### DIFF
--- a/packages/twenty-server/src/filters/utils/global-exception-handler.util.ts
+++ b/packages/twenty-server/src/filters/utils/global-exception-handler.util.ts
@@ -49,7 +49,7 @@ export const httpExceptionHandler = (
     );
   } else {
     error = new BaseGraphQLError(
-      exception.message,
+      'Internal Server Error',
       exception.getStatus().toString(),
     );
   }

--- a/packages/twenty-server/src/integrations/message-queue/drivers/sync.driver.ts
+++ b/packages/twenty-server/src/integrations/message-queue/drivers/sync.driver.ts
@@ -1,21 +1,37 @@
-import { ModuleRef } from "@nestjs/core";
-import { QueueJobOptions } from "src/integrations/message-queue/drivers/interfaces/job-options.interface";
-import { MessageQueueDriver } from "src/integrations/message-queue/drivers/interfaces/message-queue-driver.interface";
-import { MessageQueueJob, MessageQueueJobData } from "src/integrations/message-queue/interfaces/message-queue-job.interface";
-import { MessageQueue } from "src/integrations/message-queue/message-queue.constants";
-import { MessageQueueModule } from "src/integrations/message-queue/message-queue.module";
-import { getJobClassName } from "src/integrations/message-queue/utils/get-job-class-name.util";
-import { QueueWorkerModule } from "src/queue-worker.module";
+import { ModuleRef } from '@nestjs/core';
+
+import { QueueJobOptions } from 'src/integrations/message-queue/drivers/interfaces/job-options.interface';
+import { MessageQueueDriver } from 'src/integrations/message-queue/drivers/interfaces/message-queue-driver.interface';
+import {
+  MessageQueueJob,
+  MessageQueueJobData,
+} from 'src/integrations/message-queue/interfaces/message-queue-job.interface';
+
+import { MessageQueue } from 'src/integrations/message-queue/message-queue.constants';
+import { getJobClassName } from 'src/integrations/message-queue/utils/get-job-class-name.util';
 
 export class SyncDriver implements MessageQueueDriver {
   constructor(private readonly jobsModuleRef: ModuleRef) {}
-  async add<T extends MessageQueueJobData>(_queueName: MessageQueue, jobName: string, data: T, _options?: QueueJobOptions | undefined): Promise<void> {
+
+  async add<T extends MessageQueueJobData>(
+    _queueName: MessageQueue,
+    jobName: string,
+    data: T,
+    _options?: QueueJobOptions | undefined,
+  ): Promise<void> {
     const jobClassName = getJobClassName(jobName);
-    const job: MessageQueueJob<MessageQueueJobData> = this.jobsModuleRef.get(jobClassName, { strict: true });
+    const job: MessageQueueJob<MessageQueueJobData> = this.jobsModuleRef.get(
+      jobClassName,
+      { strict: true },
+    );
 
     return await job.handle(data);
   }
-  work<T>(queueName: MessageQueue, handler: ({ data, id }: { data: T; id: string; }) => void | Promise<void>) {
+
+  work<T>(
+    queueName: MessageQueue,
+    handler: ({ data, id }: { data: T; id: string }) => void | Promise<void>,
+  ) {
     return;
   }
 }

--- a/packages/twenty-server/src/metadata/relation-metadata/relation-metadata.service.ts
+++ b/packages/twenty-server/src/metadata/relation-metadata/relation-metadata.service.ts
@@ -202,6 +202,7 @@ export class RelationMetadataService extends TypeOrmQueryService<RelationMetadat
               action: WorkspaceMigrationColumnActionType.CREATE,
               columnName: foreignKeyColumnName,
               columnType: 'uuid',
+              isNullable: true,
             },
           ],
         },

--- a/packages/twenty-server/src/metadata/relation-metadata/relation-metadata.service.ts
+++ b/packages/twenty-server/src/metadata/relation-metadata/relation-metadata.service.ts
@@ -133,6 +133,7 @@ export class RelationMetadataService extends TypeOrmQueryService<RelationMetadat
         isCustom: true,
         targetColumnMap: {},
         isActive: true,
+        isNullable: true,
         type: FieldMetadataType.RELATION,
         objectMetadataId: relationMetadataInput.fromObjectMetadataId,
         workspaceId: relationMetadataInput.workspaceId,
@@ -150,6 +151,7 @@ export class RelationMetadataService extends TypeOrmQueryService<RelationMetadat
             : relationMetadataInput.toName,
         },
         isActive: true,
+        isNullable: true,
         type: FieldMetadataType.RELATION,
         objectMetadataId: relationMetadataInput.toObjectMetadataId,
         workspaceId: relationMetadataInput.workspaceId,
@@ -167,6 +169,7 @@ export class RelationMetadataService extends TypeOrmQueryService<RelationMetadat
           value: foreignKeyColumnName,
         },
         isActive: true,
+        isNullable: true,
         // Should not be visible on the front side
         isSystem: true,
         type: FieldMetadataType.UUID,

--- a/packages/twenty-server/src/workspace/messaging/commands/fetch-workspace-messages.command.ts
+++ b/packages/twenty-server/src/workspace/messaging/commands/fetch-workspace-messages.command.ts
@@ -28,13 +28,13 @@ export class FetchWorkspaceMessagesCommand extends CommandRunner {
       options.workspaceId,
     );
 
-    await this.fetchWorkspaceMessagesService.fetchWorkspaceThreads(
-      options.workspaceId,
-    );
+    // await this.fetchWorkspaceMessagesService.fetchWorkspaceThreads(
+    //   options.workspaceId,
+    // );
 
-    await this.fetchWorkspaceMessagesService.fetchWorkspaceMessages(
-      options.workspaceId,
-    );
+    // await this.fetchWorkspaceMessagesService.fetchWorkspaceMessages(
+    //   options.workspaceId,
+    // );
 
     return;
   }

--- a/packages/twenty-server/src/workspace/messaging/commands/fetch-workspace-messages.command.ts
+++ b/packages/twenty-server/src/workspace/messaging/commands/fetch-workspace-messages.command.ts
@@ -28,13 +28,13 @@ export class FetchWorkspaceMessagesCommand extends CommandRunner {
       options.workspaceId,
     );
 
-    // await this.fetchWorkspaceMessagesService.fetchWorkspaceThreads(
-    //   options.workspaceId,
-    // );
+    await this.fetchWorkspaceMessagesService.fetchWorkspaceThreads(
+      options.workspaceId,
+    );
 
-    // await this.fetchWorkspaceMessagesService.fetchWorkspaceMessages(
-    //   options.workspaceId,
-    // );
+    await this.fetchWorkspaceMessagesService.fetchWorkspaceMessages(
+      options.workspaceId,
+    );
 
     return;
   }

--- a/packages/twenty-server/src/workspace/workspace-query-runner/workspace-query-runner.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-query-runner/workspace-query-runner.service.ts
@@ -1,4 +1,9 @@
-import { BadRequestException, Injectable, Logger } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+} from '@nestjs/common';
 
 import { IConnection } from 'src/utils/pagination/interfaces/connection.interface';
 import {
@@ -219,7 +224,9 @@ export class WorkspaceQueryRunnerService {
     }
 
     if (!result) {
-      throw new BadRequestException('Malformed result from GraphQL query');
+      throw new InternalServerErrorException(
+        'Malformed result from GraphQL query',
+      );
     }
 
     return parseResult(result);

--- a/packages/twenty-server/src/workspace/workspace-query-runner/workspace-query-runner.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-query-runner/workspace-query-runner.service.ts
@@ -23,8 +23,10 @@ import {
 } from 'src/workspace/workspace-resolver-builder/interfaces/workspace-resolvers-builder.interface';
 
 import { WorkspaceQueryBuilderFactory } from 'src/workspace/workspace-query-builder/workspace-query-builder.factory';
-import { parseResult } from 'src/workspace/workspace-query-runner/utils/parse-result.util';
 import { WorkspaceDataSourceService } from 'src/workspace/workspace-datasource/workspace-datasource.service';
+import { parseResult } from 'src/workspace/workspace-query-runner/utils/parse-result.util';
+import { ExceptionHandlerService } from 'src/integrations/exception-handler/exception-handler.service';
+import { globalExceptionHandler } from 'src/filters/utils/global-exception-handler.util';
 
 import { WorkspaceQueryRunnerOptions } from './interfaces/query-runner-optionts.interface';
 import {
@@ -39,6 +41,7 @@ export class WorkspaceQueryRunnerService {
   constructor(
     private readonly workspaceQueryBuilderFactory: WorkspaceQueryBuilderFactory,
     private readonly workspaceDataSourceService: WorkspaceDataSourceService,
+    private readonly exceptionHandlerService: ExceptionHandlerService,
   ) {}
 
   async findMany<
@@ -49,14 +52,18 @@ export class WorkspaceQueryRunnerService {
     args: FindManyResolverArgs<Filter, OrderBy>,
     options: WorkspaceQueryRunnerOptions,
   ): Promise<IConnection<Record> | undefined> {
-    const { workspaceId, targetTableName } = options;
-    const query = await this.workspaceQueryBuilderFactory.findMany(
-      args,
-      options,
-    );
-    const result = await this.execute(query, workspaceId);
+    try {
+      const { workspaceId, targetTableName } = options;
+      const query = await this.workspaceQueryBuilderFactory.findMany(
+        args,
+        options,
+      );
+      const result = await this.execute(query, workspaceId);
 
-    return this.parseResult<IConnection<Record>>(result, targetTableName, '');
+      return this.parseResult<IConnection<Record>>(result, targetTableName, '');
+    } catch (exception) {
+      globalExceptionHandler(exception, this.exceptionHandlerService);
+    }
   }
 
   async findOne<
@@ -66,103 +73,127 @@ export class WorkspaceQueryRunnerService {
     args: FindOneResolverArgs<Filter>,
     options: WorkspaceQueryRunnerOptions,
   ): Promise<Record | undefined> {
-    if (!args.filter || Object.keys(args.filter).length === 0) {
-      throw new BadRequestException('Missing filter argument');
-    }
-    const { workspaceId, targetTableName } = options;
-    const query = await this.workspaceQueryBuilderFactory.findOne(
-      args,
-      options,
-    );
-    const result = await this.execute(query, workspaceId);
-    const parsedResult = this.parseResult<IConnection<Record>>(
-      result,
-      targetTableName,
-      '',
-    );
+    try {
+      if (!args.filter || Object.keys(args.filter).length === 0) {
+        throw new BadRequestException('Missing filter argument');
+      }
+      const { workspaceId, targetTableName } = options;
+      const query = await this.workspaceQueryBuilderFactory.findOne(
+        args,
+        options,
+      );
+      const result = await this.execute(query, workspaceId);
+      const parsedResult = this.parseResult<IConnection<Record>>(
+        result,
+        targetTableName,
+        '',
+      );
 
-    return parsedResult?.edges?.[0]?.node;
+      return parsedResult?.edges?.[0]?.node;
+    } catch (exception) {
+      globalExceptionHandler(exception, this.exceptionHandlerService);
+    }
   }
 
   async createMany<Record extends IRecord = IRecord>(
     args: CreateManyResolverArgs<Record>,
     options: WorkspaceQueryRunnerOptions,
   ): Promise<Record[] | undefined> {
-    const { workspaceId, targetTableName } = options;
-    const query = await this.workspaceQueryBuilderFactory.createMany(
-      args,
-      options,
-    );
-    const result = await this.execute(query, workspaceId);
+    try {
+      const { workspaceId, targetTableName } = options;
+      const query = await this.workspaceQueryBuilderFactory.createMany(
+        args,
+        options,
+      );
+      const result = await this.execute(query, workspaceId);
 
-    return this.parseResult<PGGraphQLMutation<Record>>(
-      result,
-      targetTableName,
-      'insertInto',
-    )?.records;
+      return this.parseResult<PGGraphQLMutation<Record>>(
+        result,
+        targetTableName,
+        'insertInto',
+      )?.records;
+    } catch (exception) {
+      globalExceptionHandler(exception, this.exceptionHandlerService);
+    }
   }
 
   async createOne<Record extends IRecord = IRecord>(
     args: CreateOneResolverArgs<Record>,
     options: WorkspaceQueryRunnerOptions,
   ): Promise<Record | undefined> {
-    const records = await this.createMany({ data: [args.data] }, options);
+    try {
+      const records = await this.createMany({ data: [args.data] }, options);
 
-    return records?.[0];
+      return records?.[0];
+    } catch (exception) {
+      globalExceptionHandler(exception, this.exceptionHandlerService);
+    }
   }
 
   async updateOne<Record extends IRecord = IRecord>(
     args: UpdateOneResolverArgs<Record>,
     options: WorkspaceQueryRunnerOptions,
   ): Promise<Record | undefined> {
-    const { workspaceId, targetTableName } = options;
-    const query = await this.workspaceQueryBuilderFactory.updateOne(
-      args,
-      options,
-    );
-    const result = await this.execute(query, workspaceId);
+    try {
+      const { workspaceId, targetTableName } = options;
+      const query = await this.workspaceQueryBuilderFactory.updateOne(
+        args,
+        options,
+      );
+      const result = await this.execute(query, workspaceId);
 
-    return this.parseResult<PGGraphQLMutation<Record>>(
-      result,
-      targetTableName,
-      'update',
-    )?.records?.[0];
+      return this.parseResult<PGGraphQLMutation<Record>>(
+        result,
+        targetTableName,
+        'update',
+      )?.records?.[0];
+    } catch (exception) {
+      globalExceptionHandler(exception, this.exceptionHandlerService);
+    }
   }
 
   async deleteOne<Record extends IRecord = IRecord>(
     args: DeleteOneResolverArgs,
     options: WorkspaceQueryRunnerOptions,
   ): Promise<Record | undefined> {
-    const { workspaceId, targetTableName } = options;
-    const query = await this.workspaceQueryBuilderFactory.deleteOne(
-      args,
-      options,
-    );
-    const result = await this.execute(query, workspaceId);
+    try {
+      const { workspaceId, targetTableName } = options;
+      const query = await this.workspaceQueryBuilderFactory.deleteOne(
+        args,
+        options,
+      );
+      const result = await this.execute(query, workspaceId);
 
-    return this.parseResult<PGGraphQLMutation<Record>>(
-      result,
-      targetTableName,
-      'deleteFrom',
-    )?.records?.[0];
+      return this.parseResult<PGGraphQLMutation<Record>>(
+        result,
+        targetTableName,
+        'deleteFrom',
+      )?.records?.[0];
+    } catch (exception) {
+      globalExceptionHandler(exception, this.exceptionHandlerService);
+    }
   }
 
   async updateMany<Record extends IRecord = IRecord>(
     args: UpdateManyResolverArgs<Record>,
     options: WorkspaceQueryRunnerOptions,
   ): Promise<Record[] | undefined> {
-    const { workspaceId, targetTableName } = options;
-    const query = await this.workspaceQueryBuilderFactory.updateMany(
-      args,
-      options,
-    );
-    const result = await this.execute(query, workspaceId);
+    try {
+      const { workspaceId, targetTableName } = options;
+      const query = await this.workspaceQueryBuilderFactory.updateMany(
+        args,
+        options,
+      );
+      const result = await this.execute(query, workspaceId);
 
-    return this.parseResult<PGGraphQLMutation<Record>>(
-      result,
-      targetTableName,
-      'update',
-    )?.records;
+      return this.parseResult<PGGraphQLMutation<Record>>(
+        result,
+        targetTableName,
+        'update',
+      )?.records;
+    } catch (exception) {
+      globalExceptionHandler(exception, this.exceptionHandlerService);
+    }
   }
 
   async deleteMany<
@@ -172,18 +203,22 @@ export class WorkspaceQueryRunnerService {
     args: DeleteManyResolverArgs<Filter>,
     options: WorkspaceQueryRunnerOptions,
   ): Promise<Record[] | undefined> {
-    const { workspaceId, targetTableName } = options;
-    const query = await this.workspaceQueryBuilderFactory.deleteMany(
-      args,
-      options,
-    );
-    const result = await this.execute(query, workspaceId);
+    try {
+      const { workspaceId, targetTableName } = options;
+      const query = await this.workspaceQueryBuilderFactory.deleteMany(
+        args,
+        options,
+      );
+      const result = await this.execute(query, workspaceId);
 
-    return this.parseResult<PGGraphQLMutation<Record>>(
-      result,
-      targetTableName,
-      'deleteFrom',
-    )?.records;
+      return this.parseResult<PGGraphQLMutation<Record>>(
+        result,
+        targetTableName,
+        'deleteFrom',
+      )?.records;
+    } catch (exception) {
+      globalExceptionHandler(exception, this.exceptionHandlerService);
+    }
   }
 
   async execute(
@@ -219,13 +254,11 @@ export class WorkspaceQueryRunnerService {
     const result = graphqlResult?.[0]?.resolve?.data?.[entityKey];
     const errors = graphqlResult?.[0]?.resolve?.errors;
 
-    if (Array.isArray(errors) && errors.length > 0) {
-      console.error(`GraphQL errors on ${command}${targetTableName}`, errors);
-    }
-
     if (!result) {
       throw new InternalServerErrorException(
-        `GraphQL errors on ${command}${targetTableName}: ${errors}`,
+        `GraphQL errors on ${command}${targetTableName}: ${JSON.stringify(
+          errors,
+        )}`,
       );
     }
 

--- a/packages/twenty-server/src/workspace/workspace-query-runner/workspace-query-runner.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-query-runner/workspace-query-runner.service.ts
@@ -225,7 +225,7 @@ export class WorkspaceQueryRunnerService {
 
     if (!result) {
       throw new InternalServerErrorException(
-        'Malformed result from GraphQL query',
+        `GraphQL errors on ${command}${targetTableName}: ${errors}`,
       );
     }
 

--- a/packages/twenty-server/src/workspace/workspace-query-runner/workspace-query-runner.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-query-runner/workspace-query-runner.service.ts
@@ -62,7 +62,12 @@ export class WorkspaceQueryRunnerService {
 
       return this.parseResult<IConnection<Record>>(result, targetTableName, '');
     } catch (exception) {
-      globalExceptionHandler(exception, this.exceptionHandlerService);
+      const error = globalExceptionHandler(
+        exception,
+        this.exceptionHandlerService,
+      );
+
+      return Promise.reject(error);
     }
   }
 
@@ -91,7 +96,12 @@ export class WorkspaceQueryRunnerService {
 
       return parsedResult?.edges?.[0]?.node;
     } catch (exception) {
-      globalExceptionHandler(exception, this.exceptionHandlerService);
+      const error = globalExceptionHandler(
+        exception,
+        this.exceptionHandlerService,
+      );
+
+      return Promise.reject(error);
     }
   }
 
@@ -113,7 +123,12 @@ export class WorkspaceQueryRunnerService {
         'insertInto',
       )?.records;
     } catch (exception) {
-      globalExceptionHandler(exception, this.exceptionHandlerService);
+      const error = globalExceptionHandler(
+        exception,
+        this.exceptionHandlerService,
+      );
+
+      return Promise.reject(error);
     }
   }
 
@@ -121,13 +136,9 @@ export class WorkspaceQueryRunnerService {
     args: CreateOneResolverArgs<Record>,
     options: WorkspaceQueryRunnerOptions,
   ): Promise<Record | undefined> {
-    try {
-      const records = await this.createMany({ data: [args.data] }, options);
+    const records = await this.createMany({ data: [args.data] }, options);
 
-      return records?.[0];
-    } catch (exception) {
-      globalExceptionHandler(exception, this.exceptionHandlerService);
-    }
+    return records?.[0];
   }
 
   async updateOne<Record extends IRecord = IRecord>(
@@ -148,7 +159,12 @@ export class WorkspaceQueryRunnerService {
         'update',
       )?.records?.[0];
     } catch (exception) {
-      globalExceptionHandler(exception, this.exceptionHandlerService);
+      const error = globalExceptionHandler(
+        exception,
+        this.exceptionHandlerService,
+      );
+
+      return Promise.reject(error);
     }
   }
 
@@ -170,7 +186,12 @@ export class WorkspaceQueryRunnerService {
         'deleteFrom',
       )?.records?.[0];
     } catch (exception) {
-      globalExceptionHandler(exception, this.exceptionHandlerService);
+      const error = globalExceptionHandler(
+        exception,
+        this.exceptionHandlerService,
+      );
+
+      return Promise.reject(error);
     }
   }
 
@@ -192,7 +213,12 @@ export class WorkspaceQueryRunnerService {
         'update',
       )?.records;
     } catch (exception) {
-      globalExceptionHandler(exception, this.exceptionHandlerService);
+      const error = globalExceptionHandler(
+        exception,
+        this.exceptionHandlerService,
+      );
+
+      return Promise.reject(error);
     }
   }
 
@@ -217,7 +243,12 @@ export class WorkspaceQueryRunnerService {
         'deleteFrom',
       )?.records;
     } catch (exception) {
-      globalExceptionHandler(exception, this.exceptionHandlerService);
+      const error = globalExceptionHandler(
+        exception,
+        this.exceptionHandlerService,
+      );
+
+      return Promise.reject(error);
     }
   }
 


### PR DESCRIPTION
## Context
Fixing an issue where the new isNullable field in WorkspaceMigrationColumAction was missing in the relation metadata service.
Also fixing 500 exceptions not sent to sentry for the flexible backend.