### PR TITLE
Typed updateRecord hook in generic field logic

### DIFF
--- a/packages/twenty-front/src/modules/activities/components/ActivityBodyEditor.tsx
+++ b/packages/twenty-front/src/modules/activities/components/ActivityBodyEditor.tsx
@@ -42,7 +42,7 @@ export const ActivityBodyEditor = ({
       setBody(activityBody);
       updateOneRecord?.({
         idToUpdate: activity.id,
-        input: {
+        newRecord: {
           body: activityBody,
         },
       });

--- a/packages/twenty-front/src/modules/activities/components/ActivityBodyEditor.tsx
+++ b/packages/twenty-front/src/modules/activities/components/ActivityBodyEditor.tsx
@@ -42,7 +42,7 @@ export const ActivityBodyEditor = ({
       setBody(activityBody);
       updateOneRecord?.({
         idToUpdate: activity.id,
-        newRecord: {
+        updateOneRecordInput: {
           body: activityBody,
         },
       });

--- a/packages/twenty-front/src/modules/activities/components/ActivityEditor.tsx
+++ b/packages/twenty-front/src/modules/activities/components/ActivityEditor.tsx
@@ -104,7 +104,7 @@ export const ActivityEditor = ({
     (newTitle: string) => {
       updateOneActivity?.({
         idToUpdate: activity.id,
-        newRecord: {
+        updateOneRecordInput: {
           title: newTitle ?? '',
         },
       });
@@ -115,7 +115,7 @@ export const ActivityEditor = ({
     (value: boolean) => {
       updateOneActivity?.({
         idToUpdate: activity.id,
-        newRecord: {
+        updateOneRecordInput: {
           completedAt: value ? new Date().toISOString() : null,
         },
       });

--- a/packages/twenty-front/src/modules/activities/components/ActivityEditor.tsx
+++ b/packages/twenty-front/src/modules/activities/components/ActivityEditor.tsx
@@ -90,7 +90,6 @@ export const ActivityEditor = ({
     objectRecordId: activity.id,
     fieldMetadataName: 'dueAt',
     fieldPosition: 0,
-    forceRefetch: true,
   });
 
   const { FieldContextProvider: AssigneeFieldContextProvider } =
@@ -99,14 +98,13 @@ export const ActivityEditor = ({
       objectRecordId: activity.id,
       fieldMetadataName: 'assignee',
       fieldPosition: 1,
-      forceRefetch: true,
     });
 
   const updateTitle = useCallback(
     (newTitle: string) => {
       updateOneActivity?.({
         idToUpdate: activity.id,
-        input: {
+        newRecord: {
           title: newTitle ?? '',
         },
       });
@@ -117,10 +115,9 @@ export const ActivityEditor = ({
     (value: boolean) => {
       updateOneActivity?.({
         idToUpdate: activity.id,
-        input: {
+        newRecord: {
           completedAt: value ? new Date().toISOString() : null,
         },
-        forceRefetch: true,
       });
     },
     [activity.id, updateOneActivity],

--- a/packages/twenty-front/src/modules/activities/tasks/hooks/useCompleteTask.ts
+++ b/packages/twenty-front/src/modules/activities/tasks/hooks/useCompleteTask.ts
@@ -15,7 +15,7 @@ export const useCompleteTask = (task: Task) => {
       const completedAt = value ? new Date().toISOString() : null;
       await updateOneActivity?.({
         idToUpdate: task.id,
-        newRecord: {
+        updateOneRecordInput: {
           completedAt,
         },
       });

--- a/packages/twenty-front/src/modules/activities/tasks/hooks/useCompleteTask.ts
+++ b/packages/twenty-front/src/modules/activities/tasks/hooks/useCompleteTask.ts
@@ -15,7 +15,7 @@ export const useCompleteTask = (task: Task) => {
       const completedAt = value ? new Date().toISOString() : null;
       await updateOneActivity?.({
         idToUpdate: task.id,
-        input: {
+        newRecord: {
           completedAt,
         },
       });

--- a/packages/twenty-front/src/modules/companies/components/CompanyBoardCard.tsx
+++ b/packages/twenty-front/src/modules/companies/components/CompanyBoardCard.tsx
@@ -2,7 +2,11 @@ import { ReactNode, useContext } from 'react';
 import styled from '@emotion/styled';
 import { useRecoilState, useRecoilValue } from 'recoil';
 
-import { FieldContext } from '@/object-record/field/contexts/FieldContext';
+import {
+  FieldContext,
+  RecordUpdateHook,
+  RecordUpdateHookParams,
+} from '@/object-record/field/contexts/FieldContext';
 import { useUpdateOneRecord } from '@/object-record/hooks/useUpdateOneRecord';
 import { BoardCardIdContext } from '@/object-record/record-board/contexts/BoardCardIdContext';
 import { useCurrentRecordBoardCardSelectedInternal } from '@/object-record/record-board/hooks/internal/useCurrentRecordBoardCardSelectedInternal';
@@ -145,24 +149,15 @@ export const CompanyBoardCard = () => {
 
   const visibleBoardCardFields = useRecoilValue(visibleBoardCardFieldsSelector);
 
-  const useUpdateOneRecordMutation: () => [(params: any) => any, any] = () => {
+  const useUpdateOneRecordMutation: RecordUpdateHook = () => {
     const { updateOneRecord: updateOneOpportunity } = useUpdateOneRecord({
       objectNameSingular: 'opportunity',
     });
 
-    const updateEntity = ({
-      variables,
-    }: {
-      variables: {
-        where: { id: string };
-        data: {
-          [fieldName: string]: any;
-        };
-      };
-    }) => {
+    const updateEntity = ({ variables }: RecordUpdateHookParams) => {
       updateOneOpportunity?.({
-        idToUpdate: variables.where.id,
-        input: variables.data,
+        idToUpdate: variables.where.id as string,
+        newRecord: variables.newRecord,
       });
     };
 
@@ -242,7 +237,7 @@ export const CompanyBoardCard = () => {
                       type: viewField.type,
                       metadata: viewField.metadata,
                     },
-                    useUpdateEntityMutation: useUpdateOneRecordMutation,
+                    useUpdateRecord: useUpdateOneRecordMutation,
                     hotkeyScope: InlineCellHotkeyScope.InlineCell,
                   }}
                 >

--- a/packages/twenty-front/src/modules/companies/components/CompanyBoardCard.tsx
+++ b/packages/twenty-front/src/modules/companies/components/CompanyBoardCard.tsx
@@ -157,7 +157,7 @@ export const CompanyBoardCard = () => {
     const updateEntity = ({ variables }: RecordUpdateHookParams) => {
       updateOneOpportunity?.({
         idToUpdate: variables.where.id as string,
-        newRecord: variables.newRecord,
+        updateOneRecordInput: variables.updateOneRecordInput,
       });
     };
 

--- a/packages/twenty-front/src/modules/object-record/components/RecordShowPage.tsx
+++ b/packages/twenty-front/src/modules/object-record/components/RecordShowPage.tsx
@@ -90,7 +90,7 @@ export const RecordShowPage = () => {
     const updateEntity = ({ variables }: RecordUpdateHookParams) => {
       updateOneRecord?.({
         idToUpdate: variables.where.id as string,
-        newRecord: variables.newRecord,
+        updateOneRecordInput: variables.updateOneRecordInput,
       });
     };
 
@@ -164,7 +164,7 @@ export const RecordShowPage = () => {
 
     await updateOneRecord({
       idToUpdate: record.id,
-      newRecord: {
+      updateOneRecordInput: {
         avatarUrl,
       },
     });

--- a/packages/twenty-front/src/modules/object-record/components/RecordShowPage.tsx
+++ b/packages/twenty-front/src/modules/object-record/components/RecordShowPage.tsx
@@ -6,7 +6,11 @@ import { useFavorites } from '@/favorites/hooks/useFavorites';
 import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
 import { formatFieldMetadataItemAsColumnDefinition } from '@/object-metadata/utils/formatFieldMetadataItemAsColumnDefinition';
 import { parseFieldType } from '@/object-metadata/utils/parseFieldType';
-import { FieldContext } from '@/object-record/field/contexts/FieldContext';
+import {
+  FieldContext,
+  RecordUpdateHook,
+  RecordUpdateHookParams,
+} from '@/object-record/field/contexts/FieldContext';
 import { entityFieldsFamilyState } from '@/object-record/field/states/entityFieldsFamilyState';
 import { RecordInlineCell } from '@/object-record/record-inline-cell/components/RecordInlineCell';
 import { PropertyBox } from '@/object-record/record-inline-cell/property-box/components/PropertyBox';
@@ -82,23 +86,11 @@ export const RecordShowPage = () => {
         ? 'Person'
         : 'Custom';
 
-  const useUpdateOneObjectRecordMutation: () => [
-    (params: any) => any,
-    any,
-  ] = () => {
-    const updateEntity = ({
-      variables,
-    }: {
-      variables: {
-        where: { id: string };
-        data: {
-          [fieldName: string]: any;
-        };
-      };
-    }) => {
+  const useUpdateOneObjectRecordMutation: RecordUpdateHook = () => {
+    const updateEntity = ({ variables }: RecordUpdateHookParams) => {
       updateOneRecord?.({
-        idToUpdate: variables.where.id,
-        input: variables.data,
+        idToUpdate: variables.where.id as string,
+        newRecord: variables.newRecord,
       });
     };
 
@@ -172,7 +164,7 @@ export const RecordShowPage = () => {
 
     await updateOneRecord({
       idToUpdate: record.id,
-      input: {
+      newRecord: {
         avatarUrl,
       },
     });
@@ -249,8 +241,7 @@ export const RecordShowPage = () => {
                                 labelIdentifierFieldMetadata?.name || '',
                             },
                           },
-                          useUpdateEntityMutation:
-                            useUpdateOneObjectRecordMutation,
+                          useUpdateRecord: useUpdateOneObjectRecordMutation,
                           hotkeyScope: InlineCellHotkeyScope.InlineCell,
                         }}
                       >
@@ -279,8 +270,7 @@ export const RecordShowPage = () => {
                                 position: index,
                                 objectMetadataItem,
                               }),
-                            useUpdateEntityMutation:
-                              useUpdateOneObjectRecordMutation,
+                            useUpdateRecord: useUpdateOneObjectRecordMutation,
                             hotkeyScope: InlineCellHotkeyScope.InlineCell,
                           }}
                         >

--- a/packages/twenty-front/src/modules/object-record/components/RecordTableContainer.tsx
+++ b/packages/twenty-front/src/modules/object-record/components/RecordTableContainer.tsx
@@ -61,8 +61,7 @@ export const RecordTableContainer = ({
   const updateEntity = ({ variables }: RecordUpdateHookParams) => {
     updateOneRecord?.({
       idToUpdate: variables.where.id as string,
-      newRecord: variables.newRecord,
-      optimisticRecord: variables.optimisticRecord,
+      updateOneRecordInput: variables.updateOneRecordInput,
     });
   };
 

--- a/packages/twenty-front/src/modules/object-record/components/RecordTableContainer.tsx
+++ b/packages/twenty-front/src/modules/object-record/components/RecordTableContainer.tsx
@@ -4,6 +4,7 @@ import { useSpreadsheetCompanyImport } from '@/companies/hooks/useSpreadsheetCom
 import { useColumnDefinitionsFromFieldMetadata } from '@/object-metadata/hooks/useColumnDefinitionsFromFieldMetadata';
 import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
 import { useObjectNameSingularFromPlural } from '@/object-metadata/hooks/useObjectNameSingularFromPlural';
+import { RecordUpdateHookParams } from '@/object-record/field/contexts/FieldContext';
 import { useUpdateOneRecord } from '@/object-record/hooks/useUpdateOneRecord';
 import { RecordTable } from '@/object-record/record-table/components/RecordTable';
 import { TableOptionsDropdownId } from '@/object-record/record-table/constants/TableOptionsDropdownId';
@@ -57,19 +58,11 @@ export const RecordTableContainer = ({
     recordTableScopeId: recordTableId,
   });
 
-  const updateEntity = ({
-    variables,
-  }: {
-    variables: {
-      where: { id: string };
-      data: {
-        [fieldName: string]: any;
-      };
-    };
-  }) => {
+  const updateEntity = ({ variables }: RecordUpdateHookParams) => {
     updateOneRecord?.({
-      idToUpdate: variables.where.id,
-      input: variables.data,
+      idToUpdate: variables.where.id as string,
+      newRecord: variables.newRecord,
+      optimisticRecord: variables.optimisticRecord,
     });
   };
 
@@ -111,14 +104,12 @@ export const RecordTableContainer = ({
         />
       </SpreadsheetImportProvider>
       <RecordTableEffect recordTableId={recordTableId} viewBarId={viewBarId} />
-      {
-        <RecordTable
-          recordTableId={recordTableId}
-          viewBarId={viewBarId}
-          updateRecordMutation={updateEntity}
-          createRecord={createRecord}
-        />
-      }
+      <RecordTable
+        recordTableId={recordTableId}
+        viewBarId={viewBarId}
+        updateRecordMutation={updateEntity}
+        createRecord={createRecord}
+      />
     </StyledContainer>
   );
 };

--- a/packages/twenty-front/src/modules/object-record/field/contexts/FieldContext.ts
+++ b/packages/twenty-front/src/modules/object-record/field/contexts/FieldContext.ts
@@ -3,10 +3,26 @@ import { createContext } from 'react';
 import { FieldDefinition } from '../types/FieldDefinition';
 import { FieldMetadata } from '../types/FieldMetadata';
 
+export type RecordUpdateHookParams = {
+  variables: {
+    where: Record<string, unknown>;
+    newRecord: Record<string, unknown>;
+    optimisticRecord?: Record<string, unknown>;
+  };
+};
+
+export type RecordUpdateHookReturn = {
+  loading?: boolean;
+};
+
+export type RecordUpdateHook = () => [
+  (params: RecordUpdateHookParams) => void,
+  RecordUpdateHookReturn,
+];
+
 export type GenericFieldContextType = {
   fieldDefinition: FieldDefinition<FieldMetadata>;
-  // TODO: add better typing for mutation web-hook
-  useUpdateEntityMutation?: () => [(params: any) => void, any];
+  useUpdateRecord?: RecordUpdateHook;
   entityId: string;
   recoilScopeId?: string;
   hotkeyScope: string;

--- a/packages/twenty-front/src/modules/object-record/field/contexts/FieldContext.ts
+++ b/packages/twenty-front/src/modules/object-record/field/contexts/FieldContext.ts
@@ -6,8 +6,7 @@ import { FieldMetadata } from '../types/FieldMetadata';
 export type RecordUpdateHookParams = {
   variables: {
     where: Record<string, unknown>;
-    newRecord: Record<string, unknown>;
-    optimisticRecord?: Record<string, unknown>;
+    updateOneRecordInput: Record<string, unknown>;
   };
 };
 

--- a/packages/twenty-front/src/modules/object-record/field/hooks/usePersistField.ts
+++ b/packages/twenty-front/src/modules/object-record/field/hooks/usePersistField.ts
@@ -88,10 +88,7 @@ export const usePersistField = () => {
           updateRecord?.({
             variables: {
               where: { id: entityId },
-              newRecord: {
-                [`${fieldName}Id`]: valueToPersist?.id ?? null,
-              },
-              optimisticRecord: {
+              updateOneRecordInput: {
                 [`${fieldName}Id`]: valueToPersist?.id ?? null,
                 [`${fieldName}`]: valueToPersist ?? null,
               },
@@ -118,7 +115,7 @@ export const usePersistField = () => {
           updateRecord?.({
             variables: {
               where: { id: entityId },
-              newRecord: {
+              updateOneRecordInput: {
                 [fieldName]: valueToPersist,
               },
             },

--- a/packages/twenty-front/src/modules/object-record/field/hooks/usePersistField.ts
+++ b/packages/twenty-front/src/modules/object-record/field/hooks/usePersistField.ts
@@ -31,10 +31,10 @@ export const usePersistField = () => {
   const {
     entityId,
     fieldDefinition,
-    useUpdateEntityMutation = () => [],
+    useUpdateRecord = () => [],
   } = useContext(FieldContext);
 
-  const [updateEntity] = useUpdateEntityMutation();
+  const [updateRecord] = useUpdateRecord();
 
   const persistField = useRecoilCallback(
     ({ set }) =>
@@ -85,13 +85,15 @@ export const usePersistField = () => {
             valueToPersist,
           );
 
-          updateEntity?.({
+          updateRecord?.({
             variables: {
               where: { id: entityId },
-              data: {
-                // TODO: find a more elegant way to do this ?
-                // Maybe have a link between the RELATION field and the UUID field ?
+              newRecord: {
                 [`${fieldName}Id`]: valueToPersist?.id ?? null,
+              },
+              optimisticRecord: {
+                [`${fieldName}Id`]: valueToPersist?.id ?? null,
+                [`${fieldName}`]: valueToPersist ?? null,
               },
             },
           });
@@ -113,10 +115,10 @@ export const usePersistField = () => {
             valueToPersist,
           );
 
-          updateEntity?.({
+          updateRecord?.({
             variables: {
               where: { id: entityId },
-              data: {
+              newRecord: {
                 [fieldName]: valueToPersist,
               },
             },
@@ -131,7 +133,7 @@ export const usePersistField = () => {
           );
         }
       },
-    [entityId, fieldDefinition, updateEntity],
+    [entityId, fieldDefinition, updateRecord],
   );
 
   return persistField;

--- a/packages/twenty-front/src/modules/object-record/field/hooks/useToggleEditOnlyInput.ts
+++ b/packages/twenty-front/src/modules/object-record/field/hooks/useToggleEditOnlyInput.ts
@@ -33,7 +33,7 @@ export const useToggleEditOnlyInput = () => {
           updateRecord?.({
             variables: {
               where: { id: entityId },
-              newRecord: {
+              updateOneRecordInput: {
                 [fieldName]: valueToPersist,
               },
             },

--- a/packages/twenty-front/src/modules/object-record/field/hooks/useToggleEditOnlyInput.ts
+++ b/packages/twenty-front/src/modules/object-record/field/hooks/useToggleEditOnlyInput.ts
@@ -9,10 +9,10 @@ export const useToggleEditOnlyInput = () => {
   const {
     entityId,
     fieldDefinition,
-    useUpdateEntityMutation = () => [],
+    useUpdateRecord = () => [],
   } = useContext(FieldContext);
 
-  const [updateEntity] = useUpdateEntityMutation();
+  const [updateRecord] = useUpdateRecord();
 
   const toggleField = useRecoilCallback(
     ({ set, snapshot }) =>
@@ -30,10 +30,10 @@ export const useToggleEditOnlyInput = () => {
             valueToPersist,
           );
 
-          updateEntity?.({
+          updateRecord?.({
             variables: {
               where: { id: entityId },
-              data: {
+              newRecord: {
                 [fieldName]: valueToPersist,
               },
             },
@@ -44,7 +44,7 @@ export const useToggleEditOnlyInput = () => {
           );
         }
       },
-    [entityId, fieldDefinition, updateEntity],
+    [entityId, fieldDefinition, updateRecord],
   );
 
   return toggleField;

--- a/packages/twenty-front/src/modules/object-record/field/meta-types/__stories__/FieldContextProvider.tsx
+++ b/packages/twenty-front/src/modules/object-record/field/meta-types/__stories__/FieldContextProvider.tsx
@@ -22,7 +22,7 @@ export const FieldContextProvider = ({
         recoilScopeId: '1',
         hotkeyScope: 'hotkey-scope',
         fieldDefinition,
-        useUpdateEntityMutation: () => [() => undefined, {}],
+        useUpdateRecord: () => [() => undefined, {}],
       }}
     >
       {children}

--- a/packages/twenty-front/src/modules/object-record/field/meta-types/display/components/__stories__/NumberFieldDisplay.stories.tsx
+++ b/packages/twenty-front/src/modules/object-record/field/meta-types/display/components/__stories__/NumberFieldDisplay.stories.tsx
@@ -37,7 +37,7 @@ const meta: Meta = {
             },
           },
           hotkeyScope: 'hotkey-scope',
-          useUpdateEntityMutation: () => [() => undefined, undefined],
+          useUpdateRecord: () => [() => undefined, {}],
         }}
       >
         <NumberFieldValueSetterEffect value={args.value} />

--- a/packages/twenty-front/src/modules/object-record/field/meta-types/display/components/__stories__/PhoneFieldDisplay.stories.tsx
+++ b/packages/twenty-front/src/modules/object-record/field/meta-types/display/components/__stories__/PhoneFieldDisplay.stories.tsx
@@ -38,7 +38,7 @@ const meta: Meta = {
             },
           },
           hotkeyScope: 'hotkey-scope',
-          useUpdateEntityMutation: () => [() => undefined, undefined],
+          useUpdateRecord: () => [() => undefined, {}],
         }}
       >
         <MemoryRouter>

--- a/packages/twenty-front/src/modules/object-record/field/meta-types/input/components/RelationFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/field/meta-types/input/components/RelationFieldInput.tsx
@@ -44,22 +44,6 @@ export const RelationFieldInput = ({
         onCancel={onCancel}
         initialSearchFilter={initialSearchValue}
       />
-      {/* {fieldDefinition.metadata.fieldName === 'person' ? (
-        <PeoplePicker
-          personId={initialValue?.id ?? ''}
-          companyId={initialValue?.companyId ?? ''}
-          onSubmit={handleSubmit}
-          onCancel={onCancel}
-          initialSearchFilter={initialSearchValue}
-        />
-      ) : fieldDefinition.metadata.fieldName === 'company' ? (
-        <CompanyPicker
-          companyId={initialValue?.id ?? ''}
-          onSubmit={handleSubmit}
-          onCancel={onCancel}
-          initialSearchFilter={initialSearchValue}
-        />
-      ) : null} */}
     </StyledRelationPickerContainer>
   );
 };

--- a/packages/twenty-front/src/modules/object-record/hooks/useFieldContext.tsx
+++ b/packages/twenty-front/src/modules/object-record/hooks/useFieldContext.tsx
@@ -2,7 +2,11 @@ import { ReactNode } from 'react';
 
 import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
 import { formatFieldMetadataItemAsColumnDefinition } from '@/object-metadata/utils/formatFieldMetadataItemAsColumnDefinition';
-import { FieldContext } from '@/object-record/field/contexts/FieldContext';
+import {
+  FieldContext,
+  RecordUpdateHook,
+  RecordUpdateHookParams,
+} from '@/object-record/field/contexts/FieldContext';
 import { useUpdateOneRecord } from '@/object-record/hooks/useUpdateOneRecord';
 import { InlineCellHotkeyScope } from '@/object-record/record-inline-cell/types/InlineCellHotkeyScope';
 
@@ -11,13 +15,11 @@ export const useFieldContext = ({
   fieldMetadataName,
   objectRecordId,
   fieldPosition,
-  forceRefetch,
 }: {
   objectNameSingular: string;
   objectRecordId: string;
   fieldMetadataName: string;
   fieldPosition: number;
-  forceRefetch?: boolean;
 }) => {
   const { objectMetadataItem } = useObjectMetadataItem({
     objectNameSingular,
@@ -27,25 +29,16 @@ export const useFieldContext = ({
     (field) => field.name === fieldMetadataName,
   );
 
-  const useUpdateOneObjectMutation: () => [(params: any) => any, any] = () => {
+  const useUpdateOneObjectMutation: RecordUpdateHook = () => {
     const { updateOneRecord } = useUpdateOneRecord({
       objectNameSingular,
     });
 
-    const updateEntity = ({
-      variables,
-    }: {
-      variables: {
-        where: { id: string };
-        data: {
-          [fieldName: string]: any;
-        };
-      };
-    }) => {
+    const updateEntity = ({ variables }: RecordUpdateHookParams) => {
       updateOneRecord?.({
-        idToUpdate: variables.where.id,
-        input: variables.data,
-        forceRefetch,
+        idToUpdate: variables.where.id as string,
+        newRecord: variables.newRecord,
+        optimisticRecord: variables.optimisticRecord,
       });
     };
 
@@ -66,7 +59,7 @@ export const useFieldContext = ({
                 position: fieldPosition,
                 objectMetadataItem,
               }),
-              useUpdateEntityMutation: useUpdateOneObjectMutation,
+              useUpdateRecord: useUpdateOneObjectMutation,
               hotkeyScope: InlineCellHotkeyScope.InlineCell,
             }}
           >

--- a/packages/twenty-front/src/modules/object-record/hooks/useFieldContext.tsx
+++ b/packages/twenty-front/src/modules/object-record/hooks/useFieldContext.tsx
@@ -37,8 +37,7 @@ export const useFieldContext = ({
     const updateEntity = ({ variables }: RecordUpdateHookParams) => {
       updateOneRecord?.({
         idToUpdate: variables.where.id as string,
-        newRecord: variables.newRecord,
-        optimisticRecord: variables.optimisticRecord,
+        updateOneRecordInput: variables.updateOneRecordInput,
       });
     };
 

--- a/packages/twenty-front/src/modules/object-record/record-board/components/RecordBoard.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/components/RecordBoard.tsx
@@ -83,7 +83,7 @@ export const RecordBoard = ({
     async (pipelineProgressId: string, pipelineStepId: string) => {
       await updateOneOpportunity?.({
         idToUpdate: pipelineProgressId,
-        newRecord: {
+        updateOneRecordInput: {
           pipelineStepId: pipelineStepId,
         },
       });

--- a/packages/twenty-front/src/modules/object-record/record-board/components/RecordBoard.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/components/RecordBoard.tsx
@@ -83,7 +83,7 @@ export const RecordBoard = ({
     async (pipelineProgressId: string, pipelineStepId: string) => {
       await updateOneOpportunity?.({
         idToUpdate: pipelineProgressId,
-        input: {
+        newRecord: {
           pipelineStepId: pipelineStepId,
         },
       });

--- a/packages/twenty-front/src/modules/object-record/record-board/hooks/internal/useRecordBoardColumnsInternal.ts
+++ b/packages/twenty-front/src/modules/object-record/record-board/hooks/internal/useRecordBoardColumnsInternal.ts
@@ -26,7 +26,7 @@ export const useBoardColumnsInternal = () => {
         (stage) =>
           updateOnePipelineStep?.({
             idToUpdate: stage.id,
-            newRecord: {
+            updateOneRecordInput: {
               position: stage.position,
             },
           }),

--- a/packages/twenty-front/src/modules/object-record/record-board/hooks/internal/useRecordBoardColumnsInternal.ts
+++ b/packages/twenty-front/src/modules/object-record/record-board/hooks/internal/useRecordBoardColumnsInternal.ts
@@ -26,7 +26,7 @@ export const useBoardColumnsInternal = () => {
         (stage) =>
           updateOnePipelineStep?.({
             idToUpdate: stage.id,
-            input: {
+            newRecord: {
               position: stage.position,
             },
           }),

--- a/packages/twenty-front/src/modules/object-record/record-table/components/RecordTable.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/components/RecordTable.tsx
@@ -12,7 +12,7 @@ import { ScrollWrapper } from '@/ui/utilities/scroll/components/ScrollWrapper';
 import { useViewFields } from '@/views/hooks/internal/useViewFields';
 import { mapColumnDefinitionsToViewFields } from '@/views/utils/mapColumnDefinitionToViewField';
 
-import { EntityUpdateMutationContext } from '../contexts/EntityUpdateMutationHookContext';
+import { RecordUpdateContext } from '../contexts/EntityUpdateMutationHookContext';
 import { useRecordTable } from '../hooks/useRecordTable';
 import { RecordTableScope } from '../scopes/RecordTableScope';
 import { numberOfTableRowsState } from '../states/numberOfTableRowsState';
@@ -159,7 +159,7 @@ export const RecordTable = ({
       })}
     >
       <ScrollWrapper>
-        <EntityUpdateMutationContext.Provider value={updateRecordMutation}>
+        <RecordUpdateContext.Provider value={updateRecordMutation}>
           <StyledTableWithHeader>
             <StyledTableContainer>
               <div ref={tableBodyRef}>
@@ -193,7 +193,7 @@ export const RecordTable = ({
               )}
             </StyledTableContainer>
           </StyledTableWithHeader>
-        </EntityUpdateMutationContext.Provider>
+        </RecordUpdateContext.Provider>
       </ScrollWrapper>
     </RecordTableScope>
   );

--- a/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableCell.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableCell.tsx
@@ -11,7 +11,7 @@ import { FieldContext } from '../../field/contexts/FieldContext';
 import { isFieldRelation } from '../../field/types/guards/isFieldRelation';
 import { ColumnContext } from '../contexts/ColumnContext';
 import { ColumnIndexContext } from '../contexts/ColumnIndexContext';
-import { EntityUpdateMutationContext } from '../contexts/EntityUpdateMutationHookContext';
+import { RecordUpdateContext } from '../contexts/EntityUpdateMutationHookContext';
 import { RowIdContext } from '../contexts/RowIdContext';
 import { TableCell } from '../record-table-cell/components/RecordTableCell';
 import { useCurrentRowSelected } from '../record-table-row/hooks/useCurrentRowSelected';
@@ -39,7 +39,7 @@ export const RecordTableCell = ({ cellIndex }: { cellIndex: number }) => {
 
   const columnDefinition = useContext(ColumnContext);
 
-  const updateEntityMutation = useContext(EntityUpdateMutationContext);
+  const updateRecord = useContext(RecordUpdateContext);
 
   if (!columnDefinition || !currentRowId) {
     return null;
@@ -58,7 +58,7 @@ export const RecordTableCell = ({ cellIndex }: { cellIndex: number }) => {
               recoilScopeId: currentRowId + columnDefinition.label,
               entityId: currentRowId,
               fieldDefinition: columnDefinition,
-              useUpdateEntityMutation: () => [updateEntityMutation, {}],
+              useUpdateRecord: () => [updateRecord, {}],
               hotkeyScope: customHotkeyScope,
               basePathToShowPage: objectMetadataConfig?.basePathToShowPage,
               isLabelIdentifier:

--- a/packages/twenty-front/src/modules/object-record/record-table/contexts/EntityUpdateMutationHookContext.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/contexts/EntityUpdateMutationHookContext.ts
@@ -1,5 +1,7 @@
 import { createContext } from 'react';
 
-export const EntityUpdateMutationContext = createContext<(params: any) => void>(
-  {} as any,
-);
+import { RecordUpdateHookParams } from '@/object-record/field/contexts/FieldContext';
+
+export const RecordUpdateContext = createContext<
+  (params: RecordUpdateHookParams) => void
+>({} as any);

--- a/packages/twenty-front/src/modules/settings/profile/components/NameFields.tsx
+++ b/packages/twenty-front/src/modules/settings/profile/components/NameFields.tsx
@@ -60,7 +60,7 @@ export const NameFields = ({
       if (autoSave) {
         await updateOneRecord({
           idToUpdate: currentWorkspaceMember?.id,
-          newRecord: {
+          updateOneRecordInput: {
             name: {
               firstName: firstName,
               lastName: lastName,

--- a/packages/twenty-front/src/modules/settings/profile/components/NameFields.tsx
+++ b/packages/twenty-front/src/modules/settings/profile/components/NameFields.tsx
@@ -60,7 +60,7 @@ export const NameFields = ({
       if (autoSave) {
         await updateOneRecord({
           idToUpdate: currentWorkspaceMember?.id,
-          input: {
+          newRecord: {
             name: {
               firstName: firstName,
               lastName: lastName,

--- a/packages/twenty-front/src/modules/settings/profile/components/ProfilePictureUploader.tsx
+++ b/packages/twenty-front/src/modules/settings/profile/components/ProfilePictureUploader.tsx
@@ -57,7 +57,7 @@ export const ProfilePictureUploader = () => {
 
       await updateOneRecord({
         idToUpdate: currentWorkspaceMember?.id,
-        input: {
+        newRecord: {
           avatarUrl,
         },
       });
@@ -84,7 +84,7 @@ export const ProfilePictureUploader = () => {
 
     await updateOneRecord({
       idToUpdate: currentWorkspaceMember?.id,
-      input: {
+      newRecord: {
         avatarUrl: null,
       },
     });

--- a/packages/twenty-front/src/modules/settings/profile/components/ProfilePictureUploader.tsx
+++ b/packages/twenty-front/src/modules/settings/profile/components/ProfilePictureUploader.tsx
@@ -57,7 +57,7 @@ export const ProfilePictureUploader = () => {
 
       await updateOneRecord({
         idToUpdate: currentWorkspaceMember?.id,
-        newRecord: {
+        updateOneRecordInput: {
           avatarUrl,
         },
       });
@@ -84,7 +84,7 @@ export const ProfilePictureUploader = () => {
 
     await updateOneRecord({
       idToUpdate: currentWorkspaceMember?.id,
-      newRecord: {
+      updateOneRecordInput: {
         avatarUrl: null,
       },
     });

--- a/packages/twenty-front/src/modules/ui/theme/hooks/useColorScheme.ts
+++ b/packages/twenty-front/src/modules/ui/theme/hooks/useColorScheme.ts
@@ -32,7 +32,7 @@ export const useColorScheme = () => {
       });
       await updateOneWorkspaceMember?.({
         idToUpdate: currentWorkspaceMember?.id,
-        newRecord: {
+        updateOneRecordInput: {
           colorScheme: value,
         },
       });

--- a/packages/twenty-front/src/modules/ui/theme/hooks/useColorScheme.ts
+++ b/packages/twenty-front/src/modules/ui/theme/hooks/useColorScheme.ts
@@ -32,7 +32,7 @@ export const useColorScheme = () => {
       });
       await updateOneWorkspaceMember?.({
         idToUpdate: currentWorkspaceMember?.id,
-        input: {
+        newRecord: {
           colorScheme: value,
         },
       });

--- a/packages/twenty-front/src/pages/auth/CreateProfile.tsx
+++ b/packages/twenty-front/src/pages/auth/CreateProfile.tsx
@@ -93,7 +93,7 @@ export const CreateProfile = () => {
 
         await updateOneRecord({
           idToUpdate: currentWorkspaceMember?.id,
-          newRecord: {
+          updateOneRecordInput: {
             name: {
               firstName: data.firstName,
               lastName: data.lastName,

--- a/packages/twenty-front/src/pages/auth/CreateProfile.tsx
+++ b/packages/twenty-front/src/pages/auth/CreateProfile.tsx
@@ -93,7 +93,7 @@ export const CreateProfile = () => {
 
         await updateOneRecord({
           idToUpdate: currentWorkspaceMember?.id,
-          input: {
+          newRecord: {
             name: {
               firstName: data.firstName,
               lastName: data.lastName,

--- a/packages/twenty-front/src/pages/opportunities/Opportunities.tsx
+++ b/packages/twenty-front/src/pages/opportunities/Opportunities.tsx
@@ -36,7 +36,7 @@ export const Opportunities = () => {
   }) => {
     updateOnePipelineStep?.({
       idToUpdate: columnId,
-      input: { name: title, color },
+      newRecord: { name: title, color },
     });
   };
 

--- a/packages/twenty-front/src/pages/opportunities/Opportunities.tsx
+++ b/packages/twenty-front/src/pages/opportunities/Opportunities.tsx
@@ -36,7 +36,7 @@ export const Opportunities = () => {
   }) => {
     updateOnePipelineStep?.({
       idToUpdate: columnId,
-      newRecord: { name: title, color },
+      updateOneRecordInput: { name: title, color },
     });
   };
 

--- a/packages/twenty-front/src/pages/settings/developers/api-keys/SettingsDevelopersApiKeyDetail.tsx
+++ b/packages/twenty-front/src/pages/settings/developers/api-keys/SettingsDevelopersApiKeyDetail.tsx
@@ -65,7 +65,7 @@ export const SettingsDevelopersApiKeyDetail = () => {
   const deleteIntegration = async (redirect = true) => {
     await updateApiKey?.({
       idToUpdate: apiKeyId,
-      input: { revokedAt: DateTime.now().toString() },
+      newRecord: { revokedAt: DateTime.now().toString() },
     });
     performOptimisticEvict('ApiKey', 'id', apiKeyId);
     if (redirect) {

--- a/packages/twenty-front/src/pages/settings/developers/api-keys/SettingsDevelopersApiKeyDetail.tsx
+++ b/packages/twenty-front/src/pages/settings/developers/api-keys/SettingsDevelopersApiKeyDetail.tsx
@@ -65,7 +65,7 @@ export const SettingsDevelopersApiKeyDetail = () => {
   const deleteIntegration = async (redirect = true) => {
     await updateApiKey?.({
       idToUpdate: apiKeyId,
-      newRecord: { revokedAt: DateTime.now().toString() },
+      updateOneRecordInput: { revokedAt: DateTime.now().toString() },
     });
     performOptimisticEvict('ApiKey', 'id', apiKeyId);
     if (redirect) {


### PR DESCRIPTION
- Typed updateRecordHook that is used from context 
- Added an optional optimisticRecord parameter to pass a record that should only be used for optimistic rendering and not as an input for the API.