### PR TITLE
Filter out system object for relation object destination

### DIFF
--- a/packages/twenty-front/src/modules/settings/data-model/components/SettingsObjectFieldRelationForm.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/components/SettingsObjectFieldRelationForm.tsx
@@ -89,11 +89,13 @@ export const SettingsObjectFieldRelationForm = ({
           fullWidth
           disabled={disableRelationEdition}
           value={values.objectMetadataId}
-          options={objectMetadataItems.map((objectMetadataItem) => ({
-            label: objectMetadataItem.labelPlural,
-            value: objectMetadataItem.id,
-            Icon: getIcon(objectMetadataItem.icon),
-          }))}
+          options={objectMetadataItems
+            .filter((objectMetadataItem) => !objectMetadataItem.isSystem)
+            .map((objectMetadataItem) => ({
+              label: objectMetadataItem.labelPlural,
+              value: objectMetadataItem.id,
+              Icon: getIcon(objectMetadataItem.icon),
+            }))}
           onChange={(value) => onChange({ objectMetadataId: value })}
         />
       </StyledSelectsContainer>


### PR DESCRIPTION
## Context

When creating a new relation, we need to define an object destination. However we don't want to allow relation from custom object toward system objects. This should fix the issue
Note: This only fixes the issue on the FE. Since this is not really a security issue but mostly will break the app if done through the API, we can delay the BE check in a later PR cc @charlesBochet 