### PR TITLE
Fix missing isNullable for object creation activity target

### DIFF
--- a/packages/twenty-server/src/metadata/object-metadata/object-metadata.service.ts
+++ b/packages/twenty-server/src/metadata/object-metadata/object-metadata.service.ts
@@ -240,6 +240,7 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
               action: WorkspaceMigrationColumnActionType.CREATE,
               columnName: `${createdObjectMetadata.targetTableName}Id`,
               columnType: 'uuid',
+              isNullable: true,
             } satisfies WorkspaceMigrationColumnCreate,
           ],
         },


### PR DESCRIPTION
Fix: QueryFailedError: column "_investorId" of relation "activityTarget" contains null values
