### PR TITLE
Object name font-weight in Data Model Settings

### DIFF
--- a/packages/twenty-front/src/modules/settings/data-model/object-details/components/SettingsObjectAboutSection.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/object-details/components/SettingsObjectAboutSection.tsx
@@ -34,9 +34,9 @@ const StyledCardContent = styled(CardContent)`
 const StyledName = styled.div`
   color: ${({ theme }) => theme.font.color.primary};
   display: flex;
+  font-weight: ${({ theme }) => theme.font.weight.medium};
   gap: ${({ theme }) => theme.spacing(2)};
   margin-right: auto;
-  font-weight: ${({ theme }) => theme.font.weight.medium};
 `;
 
 const StyledTag = styled(Tag)`

--- a/packages/twenty-front/src/modules/settings/data-model/object-details/components/SettingsObjectAboutSection.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/object-details/components/SettingsObjectAboutSection.tsx
@@ -36,6 +36,7 @@ const StyledName = styled.div`
   display: flex;
   gap: ${({ theme }) => theme.spacing(2)};
   margin-right: auto;
+  font-weight: ${({ theme }) => theme.font.weight.medium};
 `;
 
 const StyledTag = styled(Tag)`


### PR DESCRIPTION
Fixes #3104
In Data Model Settings, the font-weight of the object name looks to be Regular. The font-weight of the object name should be Medium.

![imagen](https://github.com/twentyhq/twenty/assets/14137213/5a21d728-aa7b-4c46-ae63-2816d6274f91)
