### PR TITLE
GH-3105 Fix Object name icon weight is too light

### DIFF
--- a/packages/twenty-front/src/modules/settings/data-model/components/SettingsObjectFieldPreview.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/components/SettingsObjectFieldPreview.tsx
@@ -105,7 +105,7 @@ export const SettingsObjectFieldPreview = ({
             {!!ObjectIcon && (
               <ObjectIcon
                 size={theme.icon.size.sm}
-                stroke={theme.icon.stroke.sm}
+                stroke={theme.icon.stroke.md}
               />
             )}
             {objectMetadataItem?.labelPlural}


### PR DESCRIPTION
## Description
This PR makes the stroke of object name icon to have regular weight (medium).

### Issues
- Closes #3105 

### Screenshot
<img width="592" alt="image" src="https://github.com/twentyhq/twenty/assets/60139930/b67ffcd5-7669-42ac-8e0a-892f6750a076">

<img width="569" alt="image" src="https://github.com/twentyhq/twenty/assets/60139930/13d06776-1d51-429d-acd6-ab51ffd6da36">
