### PR TITLE
GH-3090 Add ability to paste image in activity body editor

### DIFF
--- a/packages/twenty-front/src/modules/activities/components/ActivityBodyEditor.tsx
+++ b/packages/twenty-front/src/modules/activities/components/ActivityBodyEditor.tsx
@@ -84,12 +84,49 @@ export const ActivityBodyEditor = ({
         ? JSON.parse(activity.body)
         : undefined,
     domAttributes: { editor: { class: 'editor' } },
-    onEditorContentChange: (editor) => {
+    onEditorContentChange: (editor: BlockNoteEditor) => {
       debounceOnChange(JSON.stringify(editor.topLevelBlocks) ?? '');
     },
     slashMenuItems,
     uploadFile: imagesActivated ? handleUploadAttachment : undefined,
+    onEditorReady: (editor: BlockNoteEditor) => {
+      editor.domElement.addEventListener('paste', handleImagePaste);
+    },
   });
+
+  const handleImagePaste = async (event: ClipboardEvent) => {
+    const clipboardItems = event.clipboardData?.items;
+
+    if (clipboardItems) {
+      for (let i = 0; i < clipboardItems.length; i++) {
+        if (
+          clipboardItems[i].kind === 'file' &&
+          clipboardItems[i].type.match('^image/')
+        ) {
+          const pastedFile = clipboardItems[i].getAsFile();
+          if (!pastedFile) {
+            return;
+          }
+
+          const imageUrl = await handleUploadAttachment(pastedFile);
+          if (imageUrl) {
+            editor?.insertBlocks(
+              [
+                {
+                  type: 'image',
+                  props: {
+                    url: imageUrl,
+                  },
+                },
+              ],
+              editor?.getTextCursorPosition().block,
+              'after',
+            );
+          }
+        }
+      }
+    }
+  };
 
   return (
     <StyledBlockNoteStyledContainer>


### PR DESCRIPTION
## Description
This PR adds ability to paste image directly in activity body editor.

### Issues
- Closes #3090 

### Screencast

https://github.com/twentyhq/twenty/assets/60139930/08940b34-0ad0-4ef1-a930-f7eb11eb883f
