### PR TITLE
Fix: broken link to server .env.example

### DIFF
--- a/packages/twenty-docs/docs/start/self-hosting/self-hosting.mdx
+++ b/packages/twenty-docs/docs/start/self-hosting/self-hosting.mdx
@@ -11,7 +11,7 @@ Feel free to open issues on [GitHub](https://github.com/twentyhq/twenty/issues/n
 
 Prebuilt images for both front and back-end can be found on [docker hub](https://hub.docker.com/r/twentycrm/).
 
-For correct operation your will need to set [environment variables](enviroment-variables), a example configuration can be found [here](https://github.com/twentyhq/twenty/blob/main/server/.env.example).
+For correct operation your will need to set [environment variables](enviroment-variables), a example configuration can be found [here](https://github.com/twentyhq/twenty/blob/main/packages/twenty-server/.env.example).
 
 
 ## Render


### PR DESCRIPTION
Correct URL is https://github.com/twentyhq/twenty/blob/main/packages/twenty-server/.env.example