### PR TITLE
GH-3153 Enrich Sentry logs with user data on frontend

### DIFF
--- a/packages/twenty-front/src/modules/error-handler/components/SentryInitiEffect.tsx
+++ b/packages/twenty-front/src/modules/error-handler/components/SentryInitiEffect.tsx
@@ -2,11 +2,19 @@ import { useEffect, useState } from 'react';
 import * as Sentry from '@sentry/react';
 import { useRecoilValue } from 'recoil';
 
+import { currentUserState } from '@/auth/states/currentUserState';
+import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
+import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { sentryConfigState } from '@/client-config/states/sentryConfigState';
 import { REACT_APP_SERVER_BASE_URL } from '~/config';
 
 export const SentryInitEffect = () => {
   const sentryConfig = useRecoilValue(sentryConfigState);
+
+  const currentUser = useRecoilValue(currentUserState);
+  const currentWorkspace = useRecoilValue(currentWorkspaceState);
+  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+
   const [isSentryInitialized, setIsSentryInitialized] = useState(false);
 
   useEffect(() => {
@@ -29,6 +37,23 @@ export const SentryInitEffect = () => {
 
       setIsSentryInitialized(true);
     }
-  }, [sentryConfig, isSentryInitialized]);
+
+    if (currentUser) {
+      Sentry.setUser({
+        email: currentUser?.email,
+        id: currentUser?.id,
+        workspaceId: currentWorkspace?.id,
+        workspaceMemberId: currentWorkspaceMember?.id,
+      });
+    } else {
+      Sentry.setUser(null);
+    }
+  }, [
+    sentryConfig,
+    isSentryInitialized,
+    currentUser,
+    currentWorkspace,
+    currentWorkspaceMember,
+  ]);
   return <></>;
 };


### PR DESCRIPTION
## Description
This PR enriches Sentry logs with user data on frontend. Currently, user id, email, workspace id, and workspace member id are tracked as well.

### Issues
- Partially addresses #3153 and #3155 

### Screenshot
<img width="929" alt="image" src="https://github.com/twentyhq/twenty/assets/60139930/64df25d2-2693-4936-95a9-7351933465bd">
