### PR TITLE
Fix docker install to have all projects

### DIFF
--- a/packages/twenty-docker/Makefile
+++ b/packages/twenty-docker/Makefile
@@ -1,13 +1,12 @@
 dev-build:
 	@docker compose -f dev/docker-compose.yml down
-	rm -rf ../twenty-front/node_modules
-	rm -rf ../twenty-server/node_modules
-	rm -rf ../twenty-docs/node_modules
+	@docker volume rm twenty_dev_node_modules_root > /dev/null 2>&1 || true
+	@docker volume rm twenty_dev_node_modules_docs > /dev/null 2>&1 || true
+	@docker volume rm twenty_dev_node_modules_eslint > /dev/null 2>&1 || true
 	@docker volume rm twenty_dev_node_modules_front > /dev/null 2>&1 || true
 	@docker volume rm twenty_dev_node_modules_server > /dev/null 2>&1 || true
-	@docker volume rm twenty_dev_node_modules_docs > /dev/null 2>&1 || true
-	@docker volume rm twenty_dev_node_modules_root > /dev/null 2>&1 || true
-	@docker volume rm twenty_dev_node_modules_yarn > /dev/null 2>&1 || true
+	@docker volume rm twenty_dev_node_modules_website > /dev/null 2>&1 || true
+	@docker volume rm twenty_dev_node_modules_zapier > /dev/null 2>&1 || true
 	@docker compose -f dev/docker-compose.yml build
 
 dev-up:

--- a/packages/twenty-docker/dev/docker-compose.yml
+++ b/packages/twenty-docker/dev/docker-compose.yml
@@ -11,7 +11,6 @@ services:
     volumes:
       - ../../..:/app
       - twenty_dev_node_modules_root:/app/node_modules
-      - twenty_dev_node_modules_yarn:/app/.yarn
       - twenty_dev_node_modules_docs:/app/packages/twenty-docs/node_modules
       - twenty_dev_node_modules_eslint:/app/packages/eslint-plugin-twenty/node_modules
       - twenty_dev_node_modules_front:/app/packages/twenty-front/node_modules
@@ -35,7 +34,6 @@ volumes:
   twenty_db_data:
     name: twenty_db_data
   twenty_dev_node_modules_root:
-  twenty_dev_node_modules_yarn:
   twenty_dev_node_modules_docs:
   twenty_dev_node_modules_eslint:
   twenty_dev_node_modules_front:

--- a/packages/twenty-docker/dev/docker-compose.yml
+++ b/packages/twenty-docker/dev/docker-compose.yml
@@ -9,13 +9,15 @@ services:
       - "3001:3001"
       - "6006:6006"
     volumes:
-      - ../../../packages/twenty-front:/app/packages/twenty-front
-      - ../../../packages/twenty-server:/app/packages/twenty-server
-      - ../../../packages/eslint-plugin-twenty:/app/packages/eslint-plugin-twenty
+      - ../../..:/app
       - twenty_dev_node_modules_root:/app/node_modules
       - twenty_dev_node_modules_yarn:/app/.yarn
+      - twenty_dev_node_modules_docs:/app/packages/twenty-docs/node_modules
+      - twenty_dev_node_modules_eslint:/app/packages/eslint-plugin-twenty/node_modules
       - twenty_dev_node_modules_front:/app/packages/twenty-front/node_modules
       - twenty_dev_node_modules_server:/app/packages/twenty-server/node_modules
+      - twenty_dev_node_modules_website:/app/packages/twenty-website/node_modules
+      - twenty_dev_node_modules_zapier:/app/packages/twenty-zapier/node_modules
     depends_on:
       - postgres
   postgres:
@@ -34,6 +36,10 @@ volumes:
     name: twenty_db_data
   twenty_dev_node_modules_root:
   twenty_dev_node_modules_yarn:
+  twenty_dev_node_modules_docs:
+  twenty_dev_node_modules_eslint:
   twenty_dev_node_modules_front:
   twenty_dev_node_modules_server:
-  twenty_dev_node_modules_docs:
+  twenty_dev_node_modules_website:
+  twenty_dev_node_modules_zapier:
+

--- a/packages/twenty-docker/dev/twenty-dev/Dockerfile
+++ b/packages/twenty-docker/dev/twenty-dev/Dockerfile
@@ -1,14 +1,6 @@
 FROM node:18.16-bullseye as twenty-dev
 
 WORKDIR /app
-COPY ./package.json .
-COPY ./yarn.lock .
-COPY ./.yarnrc.yml .
-COPY ./.yarn/releases /app/.yarn/releases
-COPY ./packages/twenty-front/package.json /app/packages/twenty-front/package.json
-COPY ./packages/twenty-server/package.json /app/packages/twenty-server/package.json
-COPY ./packages/twenty-server/patches /app/packages/twenty-server/patches
-COPY ./packages/eslint-plugin-twenty/package.json /app/packages/eslint-plugin-twenty/package.json
 
 RUN npx playwright install-deps 
 

--- a/packages/twenty-docs/docs/contributor/local-setup/docker-setup.mdx
+++ b/packages/twenty-docs/docs/contributor/local-setup/docker-setup.mdx
@@ -118,6 +118,10 @@ You should now have:
 
 Sign in using a seeded demo account `tim@apple.dev` (password: `Applecar2025`) to start using Twenty.
 
+## Step 6: Configure your IDE
+
+As you are executing the project inside a Docker container, you need to configure your IDE to use the same environment.
+You can find the instructions for your IDE in our [IDE setup](/contributor/local-setup/ide-setup) guide.
 
 ### Troubleshooting
 


### PR DESCRIPTION
In this PR, we are updating the docker-compose dev configuration to share the whole root folder with Docker. This is simplifying the setup.

As an output, the dev docker image is 1.5GB and a volume is created for each node_module instance (so node_modules built in docker are not visible on the host file system).

I have also made a direct link to the IDE setup dock in the Docker setup doc to make sure contributors are also following it