### PR TITLE
docs: update 'Edit this page' link to fix 404 error

### DIFF
--- a/packages/twenty-docs/docusaurus.config.js
+++ b/packages/twenty-docs/docusaurus.config.js
@@ -44,7 +44,7 @@ const config = {
           sidebarPath: require.resolve("./sidebars.js"),
           sidebarCollapsible: false,
           routeBasePath: "/",
-          editUrl: "https://github.com/twentyhq/twenty/edit/main/docs/",
+          editUrl: "https://github.com/twentyhq/twenty/tree/main/packages/twenty-docs"
         },
         blog: false,
         theme: {


### PR DESCRIPTION
The 'Edit This Page' link was pointing to an outdated GitHub reference,
resulting in a 404 error.

![image](https://github.com/twentyhq/twenty/assets/78979288/804d6c30-327b-4eff-a505-5d8a4226d80f)

This PR updates the link to the correct
location in the updated folder structure, ensuring users can easily
contribute to the documentation.
