### PR TITLE
Consistent Sorting of Workspace Buttons Across Browsers

### DIFF
--- a/packages/twenty-front/src/modules/object-metadata/components/ObjectMetadataNavItems.tsx
+++ b/packages/twenty-front/src/modules/object-metadata/components/ObjectMetadataNavItems.tsx
@@ -17,16 +17,16 @@ export const ObjectMetadataNavItems = () => {
           .filter((item) =>
             ['person', 'company', 'opportunity'].includes(item.nameSingular),
           )
-          .sort((objectMetadataItemA, _) => {
-            if (objectMetadataItemA.nameSingular === 'person') {
-              return -1;
+          .sort((objectMetadataItemA, objectMetadataItemB) => {
+            const order = ['person', 'company', 'opportunity'];
+            const indexA = order.indexOf(objectMetadataItemA.nameSingular);
+            const indexB = order.indexOf(objectMetadataItemB.nameSingular);
+            if (indexA === -1 || indexB === -1) {
+              return objectMetadataItemA.nameSingular.localeCompare(
+                objectMetadataItemB.nameSingular,
+              );
             }
-
-            if (objectMetadataItemA.nameSingular === 'opportunity') {
-              return 1;
-            }
-
-            return 0;
+            return indexA - indexB;
           }),
         ...activeObjectMetadataItems
           .filter(


### PR DESCRIPTION

# Summary
This pull request addresses the issue of inconsistent button order in the workspace across different browsers.

# Problem
* The sorting function returns 0, which leaves the order of equal elements up to the browser's JavaScript engine implementation.

# Solution
* The sorting function always returns a positive or negative number, leading to a consistent order of buttons across all browsers.

# Changes:
1. Updated the sorting function in `ObjectMetadataNavItems.tsx` to handle 'person', 'company', and 'opportunity' explicitly and ensure a consistent order.

# Testing:
1. Open the workspace in different browsers (Chrome, Firefox, Edge).
2. Verify that the order of buttons is consistent and follows the person, company, and opportunity order.

# Screenshots:
## Before

### Chrome
![Before-Chrome](https://github.com/twentyhq/twenty/assets/9837449/873b6c90-0f53-4e69-80e3-b572fc29e5cc)
### Firefox
![Before-Firefox](https://github.com/twentyhq/twenty/assets/9837449/37bd4436-305c-490b-8da6-d81548f68d04)
### Edge
![Before-Edge](https://github.com/twentyhq/twenty/assets/9837449/49006162-f3bb-416b-bb49-af3ffb8590e1)

## After
### Chrome
![After-Chrome](https://github.com/twentyhq/twenty/assets/9837449/14581f45-b79f-478f-b755-a9581e6824e6)
### Firefox
![After-Firefox](https://github.com/twentyhq/twenty/assets/9837449/5721a93e-caf8-4a93-9d08-277e259db477)
### Edge
![After-Edge](https://github.com/twentyhq/twenty/assets/9837449/af6b18b7-0cc7-4280-9813-8aa976f3aee0)

