### PR TITLE
Fix Event core object

### DIFF
--- a/packages/twenty-server/src/metadata/object-metadata/hooks/before-create-one-object.hook.ts
+++ b/packages/twenty-server/src/metadata/object-metadata/hooks/before-create-one-object.hook.ts
@@ -11,7 +11,14 @@ import {
 
 import { CreateObjectInput } from 'src/metadata/object-metadata/dtos/create-object.input';
 
-const coreObjectNames = ['featureFlag', 'refreshToken', 'workspace', 'user'];
+const coreObjectNames = [
+  'featureFlag',
+  'refreshToken',
+  'workspace',
+  'user',
+  'event',
+  'field',
+];
 
 @Injectable()
 export class BeforeCreateOneObject<T extends CreateObjectInput>


### PR DESCRIPTION
## Context
We have a few objects that are not standard objects which means they are not part of the metadata tables (such as user, workspace, refreshToken, etc). However, those objects are defined in the code in their own resolvers and exposed in the same graphql schema shared with standard and custom objects.

## Implementation

ex: "Event" custom object can be created which breaks the generation of the graphql schema because we already defined a createEvent in our analytic resolver.

Because of that, we have introduced a check in the createObject endpoint to reject some names. This PR adds some missing objects that have their own resolvers and could conflict with custom objects