### PR TITLE
Fixed the box-shadow of the first column

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-table/components/RecordTable.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/components/RecordTable.tsx
@@ -5,7 +5,6 @@ import { RecordTableBody } from '@/object-record/record-table/components/RecordT
 import { RecordTableBodyEffect } from '@/object-record/record-table/components/RecordTableBodyEffect';
 import { RecordTableHeader } from '@/object-record/record-table/components/RecordTableHeader';
 import { RecordTableRefContext } from '@/object-record/record-table/contexts/RecordTableRefContext';
-import { rgba } from '@/ui/theme/constants/colors';
 
 const StyledTable = styled.table`
   border-radius: ${({ theme }) => theme.border.radius.sm};
@@ -56,7 +55,6 @@ const StyledTable = styled.table`
   tbody td:nth-of-type(-n + 2) {
     position: sticky;
     z-index: 2;
-    border-right: none;
   }
 
   thead th:nth-of-type(1),
@@ -65,32 +63,22 @@ const StyledTable = styled.table`
   }
   thead th:nth-of-type(2),
   tbody td:nth-of-type(2) {
-    left: calc(${({ theme }) => theme.table.checkboxColumnWidth} - 2px);
+    left: calc(${({ theme }) => theme.table.checkboxColumnWidth} - 1px);
   }
 
-  tbody td:nth-of-type(2)::after,
-  thead th:nth-of-type(2)::after {
+  &.freeze-first-columns-shadow thead th:nth-of-type(2),
+  &.freeze-first-columns-shadow tbody td:nth-of-type(2) {
+    box-shadow: ${({ theme }) => theme.boxShadow.strong};
+    clip-path: inset(0px -14px 0px 0px);
+  }
+
+  &.freeze-first-columns-shadow thead th:nth-of-type(2)::before,
+  &.freeze-first-columns-shadow tbody td:nth-of-type(2)::before {
     content: '';
     height: calc(100% + 1px);
     position: absolute;
     top: 0;
-    width: 4px;
-    right: -4px;
-  }
-
-  &.freeze-first-columns-shadow thead th:nth-of-type(2)::after,
-  &.freeze-first-columns-shadow tbody td:nth-of-type(2)::after {
-    box-shadow: ${({ theme }) =>
-      `4px 0px 4px -4px ${
-        theme.name === 'dark'
-          ? rgba(theme.grayScale.gray50, 0.8)
-          : rgba(theme.grayScale.gray100, 0.25)
-      } inset`};
-  }
-
-  thead th:nth-of-type(3),
-  tbody td:nth-of-type(3) {
-    border-left: 1px solid ${({ theme }) => theme.border.color.light};
+    width: 2px;
   }
 `;
 


### PR DESCRIPTION
# Summary
This pull request closes #3241 and introduces changes to the `RecordTable.tsx` file to adapt the visual appearance of table cells based on Figma ([Link](https://www.figma.com/file/xt8O9mFeLl46C5InWwoMrN/Twenty?type=design&node-id=15958-80931&mode=design&t=BFCEpNNScuH0kXRo-11)).

## Changes
1. Deleted `rgba` import
2. Used `theme.boxShadow.strong` for `box-shadow` 
3. Used `clip-path` to only show the right side
4. Replaced `::after` to `::before` to compensate the gap between the first column (checkbox) and the second column (name)

## Screenshots
### Before
**Light mode**
![image](https://github.com/twentyhq/twenty/assets/9837449/a12671f5-2874-47d3-8e15-cc1f811a7357)

**Dark mode**
![image](https://github.com/twentyhq/twenty/assets/9837449/b674cace-70d1-4ac8-a556-5c1a3ae5e32d)
### After
**Light mode**
![Screenshot 2024-01-05 195835](https://github.com/twentyhq/twenty/assets/9837449/d35e2f4b-c265-43d9-bac0-818f72a4855d)
**Dark mode**
![Screenshot 2024-01-05 195911](https://github.com/twentyhq/twenty/assets/9837449/b2667d82-ffe5-4183-964d-7b0655828c7c)


## Checklist

- [x] Change the box shadow to strong instead of light.
- [x] We need to keep the right border of the cells on the right in addition to the box shadow.
- [x] The box shadow should stay dark even in dark mode
- [ ] Change the individual box-shadow to a single one