### PR TITLE
Sort Metadata Fields by Custom Status and Creation Date

### DIFF
--- a/packages/twenty-front/src/pages/settings/data-model/SettingsObjectDetail.tsx
+++ b/packages/twenty-front/src/pages/settings/data-model/SettingsObjectDetail.tsx
@@ -25,6 +25,7 @@ import { Table } from '@/ui/layout/table/components/Table';
 import { TableHeader } from '@/ui/layout/table/components/TableHeader';
 import { TableSection } from '@/ui/layout/table/components/TableSection';
 import { Breadcrumb } from '@/ui/navigation/bread-crumb/components/Breadcrumb';
+import { sortFieldMetadataItem } from '~/utils/sortFieldMetadataItem';
 
 const StyledDiv = styled.div`
   display: flex;
@@ -51,27 +52,16 @@ export const SettingsObjectDetail = () => {
 
   if (!activeObjectMetadataItem) return null;
 
-  const sortFields = (a: FieldMetadataItem, b: FieldMetadataItem) => {
-    const customCompare = a.isCustom === b.isCustom ? 0 : a.isCustom ? 1 : -1;
-    if (customCompare !== 0) return customCompare;
-    const dateA = a.createdAt ? new Date(a.createdAt) : null;
-    const dateB = b.createdAt ? new Date(b.createdAt) : null;
-    if (!dateA && !dateB) return 0;
-    if (!dateA) return 1;
-    if (!dateB) return -1;
-    return dateA.getTime() - dateB.getTime();
-  };
-
   const activeMetadataFields = activeObjectMetadataItem.fields
     .filter(
       (metadataField) => metadataField.isActive && !metadataField.isSystem,
     )
-    .sort(sortFields);
+    .sort(sortFieldMetadataItem);
   const disabledMetadataFields = activeObjectMetadataItem.fields
     .filter(
       (metadataField) => !metadataField.isActive && !metadataField.isSystem,
     )
-    .sort(sortFields);
+    .sort(sortFieldMetadataItem);
 
   const handleDisableObject = async () => {
     await disableObjectMetadataItem(activeObjectMetadataItem);

--- a/packages/twenty-front/src/pages/settings/data-model/SettingsObjectDetail.tsx
+++ b/packages/twenty-front/src/pages/settings/data-model/SettingsObjectDetail.tsx
@@ -51,12 +51,27 @@ export const SettingsObjectDetail = () => {
 
   if (!activeObjectMetadataItem) return null;
 
-  const activeMetadataFields = activeObjectMetadataItem.fields.filter(
-    (metadataField) => metadataField.isActive && !metadataField.isSystem,
-  );
-  const disabledMetadataFields = activeObjectMetadataItem.fields.filter(
-    (metadataField) => !metadataField.isActive && !metadataField.isSystem,
-  );
+  const sortFields = (a: FieldMetadataItem, b: FieldMetadataItem) => {
+    const customCompare = a.isCustom === b.isCustom ? 0 : a.isCustom ? 1 : -1;
+    if (customCompare !== 0) return customCompare;
+    const dateA = a.createdAt ? new Date(a.createdAt) : null;
+    const dateB = b.createdAt ? new Date(b.createdAt) : null;
+    if (!dateA && !dateB) return 0;
+    if (!dateA) return 1;
+    if (!dateB) return -1;
+    return dateA.getTime() - dateB.getTime();
+  };
+
+  const activeMetadataFields = activeObjectMetadataItem.fields
+    .filter(
+      (metadataField) => metadataField.isActive && !metadataField.isSystem,
+    )
+    .sort(sortFields);
+  const disabledMetadataFields = activeObjectMetadataItem.fields
+    .filter(
+      (metadataField) => !metadataField.isActive && !metadataField.isSystem,
+    )
+    .sort(sortFields);
 
   const handleDisableObject = async () => {
     await disableObjectMetadataItem(activeObjectMetadataItem);

--- a/packages/twenty-front/src/utils/__tests__/sortFieldMetadataItem.test.ts
+++ b/packages/twenty-front/src/utils/__tests__/sortFieldMetadataItem.test.ts
@@ -1,0 +1,96 @@
+import { FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
+
+import { sortFieldMetadataItem } from '../sortFieldMetadataItem';
+
+describe('sortFieldMetadataItem', () => {
+  it('should return an empty array for an empty array', () => {
+    const items: FieldMetadataItem[] = [];
+    const sortedItems = items.sort(sortFieldMetadataItem);
+    const expectedItems: FieldMetadataItem[] = [];
+    expect(sortedItems).toEqual(expectedItems);
+  });
+
+  it('should return array with a single item for the same array', () => {
+    const item1 = {
+      isCustom: false,
+      createdAt: '2024-01-03T11:41:16.344Z',
+    } as FieldMetadataItem;
+
+    const items: FieldMetadataItem[] = [item1];
+    const sortedItems = items.sort(sortFieldMetadataItem);
+    const expectedItems: FieldMetadataItem[] = [item1];
+    expect(sortedItems).toEqual(expectedItems);
+  });
+
+  it('should correctly sort items based on createdAt', () => {
+    const item1 = {
+      isCustom: false,
+      createdAt: '2024-01-03T11:41:16.344Z',
+    } as FieldMetadataItem;
+
+    const item2 = {
+      isCustom: false,
+      createdAt: '2024-01-02T09:41:16.344Z',
+    } as FieldMetadataItem;
+
+    const item3 = {
+      isCustom: false,
+      createdAt: '2024-01-03T09:41:16.344Z',
+    } as FieldMetadataItem;
+
+    const items = [item1, item2, item3];
+    const sortedItems = items.sort(sortFieldMetadataItem);
+    const expectedItems = [item2, item3, item1];
+
+    expect(sortedItems).toEqual(expectedItems);
+  });
+
+  it('should correctly sort items based on isCustom and createdAt', () => {
+    const item1 = {
+      isCustom: false,
+      createdAt: '2024-01-03T09:41:16.344Z',
+    } as FieldMetadataItem;
+
+    const item2 = {
+      isCustom: true,
+      createdAt: '2024-01-02T09:41:16.344Z',
+    } as FieldMetadataItem;
+
+    const item3 = {
+      isCustom: false,
+      createdAt: '2024-01-01T09:41:16.344Z',
+    } as FieldMetadataItem;
+
+    const item4 = {
+      isCustom: true,
+      createdAt: '2024-01-04T09:41:16.344Z',
+    } as FieldMetadataItem;
+
+    const items = [item1, item2, item3, item4];
+    const sortedItems = items.sort(sortFieldMetadataItem);
+    const expectedItems = [item3, item1, item2, item4];
+
+    expect(sortedItems).toEqual(expectedItems);
+  });
+
+  it('should handle arrays with items missing required properties', () => {
+    const item1 = {
+      isCustom: false,
+      createdAt: '2024-01-03T11:41:16.344Z',
+    } as FieldMetadataItem;
+
+    const item2 = {
+      // Missing createdAt property
+      isCustom: false,
+    } as FieldMetadataItem;
+
+    const item3 = {
+      // Missing isCustom property
+      createdAt: '2024-01-05T11:41:16.344Z',
+    } as FieldMetadataItem;
+
+    const items = [item1, item2, item3];
+    const sortedItems = items.sort(sortFieldMetadataItem);
+    expect(sortedItems).toHaveLength(items.length);
+  });
+});

--- a/packages/twenty-front/src/utils/sortFieldMetadataItem.ts
+++ b/packages/twenty-front/src/utils/sortFieldMetadataItem.ts
@@ -1,6 +1,6 @@
 import { FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
 
-import { parseDate } from '../utils/date-utils'; // adjust the path as needed
+import { parseDate } from '../utils/date-utils';
 
 export const sortFieldMetadataItem = (
   a: FieldMetadataItem,
@@ -16,5 +16,5 @@ export const sortFieldMetadataItem = (
   if (!dateA) return 1;
   if (!dateB) return -1;
 
-  return dateA.diff(dateB);
+  return dateB.diff(dateA).milliseconds > 0 ? -1 : 1;
 };

--- a/packages/twenty-front/src/utils/sortFieldMetadataItem.ts
+++ b/packages/twenty-front/src/utils/sortFieldMetadataItem.ts
@@ -1,0 +1,20 @@
+import { FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
+
+import { parseDate } from '../utils/date-utils'; // adjust the path as needed
+
+export const sortFieldMetadataItem = (
+  a: FieldMetadataItem,
+  b: FieldMetadataItem,
+) => {
+  const customCompare = a.isCustom === b.isCustom ? 0 : a.isCustom ? 1 : -1;
+  if (customCompare !== 0) return customCompare;
+
+  const dateA = a.createdAt ? parseDate(a.createdAt) : null;
+  const dateB = b.createdAt ? parseDate(b.createdAt) : null;
+
+  if (!dateA && !dateB) return 0;
+  if (!dateA) return 1;
+  if (!dateB) return -1;
+
+  return dateA.diff(dateB);
+};


### PR DESCRIPTION
# Summary
This pull request closes #3253 and introduces a change in the way we display metadata fields in objects such as `People`, `Opportunities`, `Companies`. With this change, the fields are sorted first by their `isCustom` status (standard fields first, then custom fields), and then by their `creationDate` (older fields first).

## Changes:
1. Created a new function `sortFieldMetadataItem` in `utils.ts` that takes two fields and returns a sorting score based on the `isCustom` status and `creationDate`.

2. Used the `sortFieldMetadataItem` function to sort `activeMetadataFields` and `disabledMetadataFields` before they are displayed in `SettingsObjectDetails.tsx`
3. Created Jest tests for `sortFieldMetadataItem` utility file.

## Test
1. Navigate to the settings page of an object (http://localhost:3001/settings/objects).
2. Add a new custom field and verify that it appears last in the list of fields.
4. Verify that both of the active and disabled fields are sorted first by `Custom` status (standard first, then custom), and then by `Creation Date` (older first).

## Screenshots
### Before
![image](https://github.com/twentyhq/twenty/assets/9837449/be07f1a4-2ec2-47bd-9db2-52d58dc2b61a)

### After
![image](https://github.com/twentyhq/twenty/assets/9837449/c140ecd4-14f1-44f1-afea-925968d8d62c)


## Checklist

- [x] Extract the sort fucntion to `util.ts`
- [x] Add Jest tests for it
