### PR TITLE
refactor: refactor Optimistic Effect registration

### DIFF
--- a/packages/twenty-front/src/modules/apollo/optimistic-effect/types/OptimisticEffectDefinition.ts
+++ b/packages/twenty-front/src/modules/apollo/optimistic-effect/types/OptimisticEffectDefinition.ts
@@ -1,11 +1,8 @@
-import { DocumentNode } from 'graphql';
-
 import { ObjectMetadataItem } from '@/object-metadata/types/ObjectMetadataItem';
 
 import { OptimisticEffectResolver } from './OptimisticEffectResolver';
 
 export type OptimisticEffectDefinition = {
-  query?: DocumentNode;
   typename: string;
   resolver: OptimisticEffectResolver;
   objectMetadataItem?: ObjectMetadataItem;

--- a/packages/twenty-front/src/modules/apollo/optimistic-effect/types/internal/OptimisticEffect.ts
+++ b/packages/twenty-front/src/modules/apollo/optimistic-effect/types/internal/OptimisticEffect.ts
@@ -1,30 +1,6 @@
-import { ApolloCache, DocumentNode } from '@apollo/client';
-
-import { ObjectMetadataItem } from '@/object-metadata/types/ObjectMetadataItem';
+import { OptimisticEffectDefinition } from '@/apollo/optimistic-effect/types/OptimisticEffectDefinition';
 import { ObjectRecordQueryVariables } from '@/object-record/types/ObjectRecordQueryVariables';
 
-export type OptimisticEffectWriter = ({
-  cache,
-  query,
-  createdRecords,
-  updatedRecords,
-  deletedRecordIds,
-  variables,
-  objectMetadataItem,
-}: {
-  cache: ApolloCache<any>;
-  query?: DocumentNode;
-  createdRecords?: Record<string, unknown>[];
-  updatedRecords?: Record<string, unknown>[];
-  deletedRecordIds?: string[];
+export type OptimisticEffect = OptimisticEffectDefinition & {
   variables: ObjectRecordQueryVariables;
-  objectMetadataItem: ObjectMetadataItem;
-}) => void;
-
-export type OptimisticEffect = {
-  query?: DocumentNode;
-  typename: string;
-  variables: ObjectRecordQueryVariables;
-  writer: OptimisticEffectWriter;
-  objectMetadataItem: ObjectMetadataItem;
 };

--- a/packages/twenty-front/src/modules/object-metadata/hooks/useRecordOptimisticEffect.ts
+++ b/packages/twenty-front/src/modules/object-metadata/hooks/useRecordOptimisticEffect.ts
@@ -23,35 +23,20 @@ export const useRecordOptimisticEffect = ({
     });
 
   useEffect(() => {
-    registerOptimisticEffect({
-      definition: getRecordOptimisticEffectDefinition({
-        objectMetadataItem,
-      }),
-      variables: {
-        filter,
-        orderBy,
-        limit,
-      },
+    const definition = getRecordOptimisticEffectDefinition({
+      objectMetadataItem,
     });
+    const variables = { filter, orderBy, limit };
 
-    return () => {
-      unregisterOptimisticEffect({
-        definition: getRecordOptimisticEffectDefinition({
-          objectMetadataItem,
-        }),
-        variables: {
-          filter,
-          orderBy,
-          limit,
-        },
-      });
-    };
+    registerOptimisticEffect({ definition, variables });
+
+    return () => unregisterOptimisticEffect({ definition, variables });
   }, [
-    registerOptimisticEffect,
     filter,
-    orderBy,
     limit,
     objectMetadataItem,
+    orderBy,
+    registerOptimisticEffect,
     unregisterOptimisticEffect,
   ]);
 };

--- a/packages/twenty-front/src/modules/object-record/graphql/optimistic-effect-definition/getRecordOptimisticEffectDefinition.ts
+++ b/packages/twenty-front/src/modules/object-record/graphql/optimistic-effect-definition/getRecordOptimisticEffectDefinition.ts
@@ -24,9 +24,9 @@ export const getRecordOptimisticEffectDefinition = ({
     const newRecordPaginatedCacheField = produce<
       PaginatedRecordTypeResults<any>
     >(currentData as PaginatedRecordTypeResults<any>, (draft) => {
-      const existingDataIsEmpty = !draft || !draft.edges || !draft.edges[0];
-
       if (isNonEmptyArray(createdRecords)) {
+        const existingDataIsEmpty = !draft?.edges?.[0];
+
         if (existingDataIsEmpty) {
           return {
             __typename: `${capitalize(objectMetadataItem.nameSingular)}Edge`,
@@ -41,23 +41,23 @@ export const getRecordOptimisticEffectDefinition = ({
               startCursor: '',
             },
           };
-        } else {
-          for (const createdRecord of createdRecords) {
-            const existingRecord = draft.edges.find(
-              (edge) => edge.node.id === createdRecord.id,
-            );
+        }
 
-            if (existingRecord) {
-              existingRecord.node = createdRecord;
-              continue;
-            }
+        for (const createdRecord of createdRecords) {
+          const existingRecord = draft.edges.find(
+            (edge) => edge.node.id === createdRecord.id,
+          );
 
-            draft.edges.unshift({
-              node: createdRecord,
-              cursor: '',
-              __typename: `${capitalize(objectMetadataItem.nameSingular)}Edge`,
-            });
+          if (existingRecord) {
+            existingRecord.node = createdRecord;
+            continue;
           }
+
+          draft.edges.unshift({
+            node: createdRecord,
+            cursor: '',
+            __typename: `${capitalize(objectMetadataItem.nameSingular)}Edge`,
+          });
         }
       }
 


### PR DESCRIPTION
This PR is a suggestion to simplify some aspects of optimistic effect registration.

`optimisticEffectWriter` always does the same thing:
- read data from Apollo cache
- compute updated data with a resolver
- update data in Apollo cache

Instead of wrapping the `resolver` with a `writer` and saving the `writer` in the Recoil State, this saves the `resolver` directly in the Recoil state and the "read data/update data in cache" logic is moved to `triggerOptimisticEffects`.

I also removed the `query` from the optimistic effect as right now we only use the optimistic effects with `findManyRecordsQuery`, but it can be added back if needed.