### PR TITLE
Added eslint config in vite-plugin-checker

### DIFF
--- a/packages/twenty-front/vite.config.ts
+++ b/packages/twenty-front/vite.config.ts
@@ -22,6 +22,9 @@ export default defineConfig(({ mode }) => {
     checker({
       typescript: {
         tsconfigPath: "tsconfig.app.json"
+      },
+      eslint: {
+        lintCommand: "eslint . --report-unused-disable-directives --max-warnings 0 --config .eslintrc.cjs",
       }
     }),
   ]


### PR DESCRIPTION
We generally catch linting errors while editing a file, but like typescript errors, it can go unnoticed and stockpile on main, until someone catches it.

It can also happen when merging main into a branch that linting errors are not catched.

With this activated, ESLint will be run in parallel of vite-plugin-checker and will not impact the build time of vite, but will provide complete linting of the front codebase.