### PR TITLE
Fix bug on relation on custom object

### DIFF
--- a/packages/twenty-server/src/metadata/relation-metadata/relation-metadata.service.ts
+++ b/packages/twenty-server/src/metadata/relation-metadata/relation-metadata.service.ts
@@ -120,9 +120,10 @@ export class RelationMetadataService extends TypeOrmQueryService<RelationMetadat
     }
 
     const baseColumnName = `${camelCase(relationMetadataInput.toName)}Id`;
-    const isToCustom =
-      objectMetadataMap[relationMetadataInput.toObjectMetadataId].isCustom;
-    const foreignKeyColumnName = isToCustom
+
+    // TODO: this logic is called to create relation through metadata graphql endpoint (so only for custom field relations)
+    const isCustom = true;
+    const foreignKeyColumnName = isCustom
       ? createCustomColumnName(baseColumnName)
       : baseColumnName;
 
@@ -149,7 +150,7 @@ export class RelationMetadataService extends TypeOrmQueryService<RelationMetadat
         icon: relationMetadataInput.toIcon,
         isCustom: true,
         targetColumnMap: {
-          value: isToCustom
+          value: isCustom
             ? createCustomColumnName(relationMetadataInput.toName)
             : relationMetadataInput.toName,
         },


### PR DESCRIPTION
This PR fixes a bug on relation creation that is targeting a standard object. 
For some reason, if the "to" side of the relation the relation fields were not prefixed by "_" as needed for custom objects.
