### PR TITLE
feat: workspace health

### DIFF
--- a/packages/twenty-server/src/command.module.ts
+++ b/packages/twenty-server/src/command.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 
 import { DatabaseCommandModule } from 'src/database/commands/database-command.module';
 import { FetchWorkspaceMessagesCommandsModule } from 'src/workspace/messaging/commands/fetch-workspace-messages-commands.module';
+import { WorkspaceHealthCommandModule } from 'src/workspace/workspace-health/commands/workspace-health-command.module';
 
 import { AppModule } from './app.module';
 
@@ -13,6 +14,7 @@ import { WorkspaceSyncMetadataCommandsModule } from './workspace/workspace-sync-
     WorkspaceSyncMetadataCommandsModule,
     DatabaseCommandModule,
     FetchWorkspaceMessagesCommandsModule,
+    WorkspaceHealthCommandModule,
   ],
 })
 export class CommandModule {}

--- a/packages/twenty-server/src/core/auth/controllers/google-auth.controller.ts
+++ b/packages/twenty-server/src/core/auth/controllers/google-auth.controller.ts
@@ -39,7 +39,7 @@ export class GoogleAuthController {
     const { firstName, lastName, email, picture, workspaceInviteHash } =
       req.user;
 
-    const mainDataSource = await this.typeORMService.getMainDataSource();
+    const mainDataSource = this.typeORMService.getMainDataSource();
 
     const existingUser = await mainDataSource
       .getRepository(User)

--- a/packages/twenty-server/src/database/typeorm/typeorm.service.ts
+++ b/packages/twenty-server/src/database/typeorm/typeorm.service.ts
@@ -25,7 +25,7 @@ export class TypeORMService implements OnModuleInit, OnModuleDestroy {
     });
   }
 
-  public async getMainDataSource(): Promise<DataSource> {
+  public getMainDataSource(): DataSource {
     return this.mainDataSource;
   }
 

--- a/packages/twenty-server/src/metadata/field-metadata/composite-types/currency.composite-type.ts
+++ b/packages/twenty-server/src/metadata/field-metadata/composite-types/currency.composite-type.ts
@@ -7,11 +7,14 @@ import { generateTargetColumnMap } from 'src/metadata/field-metadata/utils/gener
 export const currencyFields = (
   fieldMetadata?: FieldMetadataInterface,
 ): FieldMetadataInterface[] => {
-  const targetColumnMap = fieldMetadata
+  const inferedFieldMetadata = fieldMetadata as
+    | FieldMetadataInterface<FieldMetadataType.CURRENCY>
+    | undefined;
+  const targetColumnMap = inferedFieldMetadata
     ? generateTargetColumnMap(
-        fieldMetadata.type,
-        fieldMetadata.isCustom ?? false,
-        fieldMetadata.name,
+        inferedFieldMetadata.type,
+        inferedFieldMetadata.isCustom ?? false,
+        inferedFieldMetadata.name,
       )
     : {
         amountMicros: 'amountMicros',
@@ -29,7 +32,14 @@ export const currencyFields = (
         value: targetColumnMap.amountMicros,
       },
       isNullable: true,
-    } satisfies FieldMetadataInterface,
+      ...(inferedFieldMetadata
+        ? {
+            defaultValue: {
+              value: inferedFieldMetadata.defaultValue?.amountMicros ?? null,
+            },
+          }
+        : {}),
+    } satisfies FieldMetadataInterface<FieldMetadataType.NUMERIC>,
     {
       id: 'currencyCode',
       type: FieldMetadataType.TEXT,
@@ -40,7 +50,14 @@ export const currencyFields = (
         value: targetColumnMap.currencyCode,
       },
       isNullable: true,
-    } satisfies FieldMetadataInterface,
+      ...(inferedFieldMetadata
+        ? {
+            defaultValue: {
+              value: inferedFieldMetadata.defaultValue?.currencyCode ?? null,
+            },
+          }
+        : {}),
+    } satisfies FieldMetadataInterface<FieldMetadataType.TEXT>,
   ];
 };
 

--- a/packages/twenty-server/src/metadata/field-metadata/composite-types/currency.composite-type.ts
+++ b/packages/twenty-server/src/metadata/field-metadata/composite-types/currency.composite-type.ts
@@ -7,14 +7,14 @@ import { generateTargetColumnMap } from 'src/metadata/field-metadata/utils/gener
 export const currencyFields = (
   fieldMetadata?: FieldMetadataInterface,
 ): FieldMetadataInterface[] => {
-  const inferedFieldMetadata = fieldMetadata as
+  const inferredFieldMetadata = fieldMetadata as
     | FieldMetadataInterface<FieldMetadataType.CURRENCY>
     | undefined;
-  const targetColumnMap = inferedFieldMetadata
+  const targetColumnMap = inferredFieldMetadata
     ? generateTargetColumnMap(
-        inferedFieldMetadata.type,
-        inferedFieldMetadata.isCustom ?? false,
-        inferedFieldMetadata.name,
+        inferredFieldMetadata.type,
+        inferredFieldMetadata.isCustom ?? false,
+        inferredFieldMetadata.name,
       )
     : {
         amountMicros: 'amountMicros',
@@ -32,10 +32,10 @@ export const currencyFields = (
         value: targetColumnMap.amountMicros,
       },
       isNullable: true,
-      ...(inferedFieldMetadata
+      ...(inferredFieldMetadata
         ? {
             defaultValue: {
-              value: inferedFieldMetadata.defaultValue?.amountMicros ?? null,
+              value: inferredFieldMetadata.defaultValue?.amountMicros ?? null,
             },
           }
         : {}),
@@ -50,10 +50,10 @@ export const currencyFields = (
         value: targetColumnMap.currencyCode,
       },
       isNullable: true,
-      ...(inferedFieldMetadata
+      ...(inferredFieldMetadata
         ? {
             defaultValue: {
-              value: inferedFieldMetadata.defaultValue?.currencyCode ?? null,
+              value: inferredFieldMetadata.defaultValue?.currencyCode ?? null,
             },
           }
         : {}),

--- a/packages/twenty-server/src/metadata/field-metadata/composite-types/full-name.composite-type.ts
+++ b/packages/twenty-server/src/metadata/field-metadata/composite-types/full-name.composite-type.ts
@@ -7,14 +7,14 @@ import { generateTargetColumnMap } from 'src/metadata/field-metadata/utils/gener
 export const fullNameFields = (
   fieldMetadata?: FieldMetadataInterface,
 ): FieldMetadataInterface[] => {
-  const inferedFieldMetadata = fieldMetadata as
+  const inferredFieldMetadata = fieldMetadata as
     | FieldMetadataInterface<FieldMetadataType.FULL_NAME>
     | undefined;
-  const targetColumnMap = inferedFieldMetadata
+  const targetColumnMap = inferredFieldMetadata
     ? generateTargetColumnMap(
-        inferedFieldMetadata.type,
-        inferedFieldMetadata.isCustom ?? false,
-        inferedFieldMetadata.name,
+        inferredFieldMetadata.type,
+        inferredFieldMetadata.isCustom ?? false,
+        inferredFieldMetadata.name,
       )
     : {
         firstName: 'firstName',
@@ -32,10 +32,10 @@ export const fullNameFields = (
         value: targetColumnMap.firstName,
       },
       isNullable: true,
-      ...(inferedFieldMetadata
+      ...(inferredFieldMetadata
         ? {
             defaultValue: {
-              value: inferedFieldMetadata.defaultValue?.firstName ?? null,
+              value: inferredFieldMetadata.defaultValue?.firstName ?? null,
             },
           }
         : {}),
@@ -50,10 +50,10 @@ export const fullNameFields = (
         value: targetColumnMap.lastName,
       },
       isNullable: true,
-      ...(inferedFieldMetadata
+      ...(inferredFieldMetadata
         ? {
             defaultValue: {
-              value: inferedFieldMetadata.defaultValue?.lastName ?? null,
+              value: inferredFieldMetadata.defaultValue?.lastName ?? null,
             },
           }
         : {}),

--- a/packages/twenty-server/src/metadata/field-metadata/composite-types/full-name.composite-type.ts
+++ b/packages/twenty-server/src/metadata/field-metadata/composite-types/full-name.composite-type.ts
@@ -7,11 +7,14 @@ import { generateTargetColumnMap } from 'src/metadata/field-metadata/utils/gener
 export const fullNameFields = (
   fieldMetadata?: FieldMetadataInterface,
 ): FieldMetadataInterface[] => {
-  const targetColumnMap = fieldMetadata
+  const inferedFieldMetadata = fieldMetadata as
+    | FieldMetadataInterface<FieldMetadataType.FULL_NAME>
+    | undefined;
+  const targetColumnMap = inferedFieldMetadata
     ? generateTargetColumnMap(
-        fieldMetadata.type,
-        fieldMetadata.isCustom ?? false,
-        fieldMetadata.name,
+        inferedFieldMetadata.type,
+        inferedFieldMetadata.isCustom ?? false,
+        inferedFieldMetadata.name,
       )
     : {
         firstName: 'firstName',
@@ -29,7 +32,14 @@ export const fullNameFields = (
         value: targetColumnMap.firstName,
       },
       isNullable: true,
-    } satisfies FieldMetadataInterface,
+      ...(inferedFieldMetadata
+        ? {
+            defaultValue: {
+              value: inferedFieldMetadata.defaultValue?.firstName ?? null,
+            },
+          }
+        : {}),
+    } satisfies FieldMetadataInterface<FieldMetadataType.TEXT>,
     {
       id: 'lastName',
       type: FieldMetadataType.TEXT,
@@ -40,7 +50,14 @@ export const fullNameFields = (
         value: targetColumnMap.lastName,
       },
       isNullable: true,
-    } satisfies FieldMetadataInterface,
+      ...(inferedFieldMetadata
+        ? {
+            defaultValue: {
+              value: inferedFieldMetadata.defaultValue?.lastName ?? null,
+            },
+          }
+        : {}),
+    } satisfies FieldMetadataInterface<FieldMetadataType.TEXT>,
   ];
 };
 

--- a/packages/twenty-server/src/metadata/field-metadata/composite-types/index.ts
+++ b/packages/twenty-server/src/metadata/field-metadata/composite-types/index.ts
@@ -1,0 +1,19 @@
+import { FieldMetadataInterface } from 'src/metadata/field-metadata/interfaces/field-metadata.interface';
+
+import { currencyFields } from 'src/metadata/field-metadata/composite-types/currency.composite-type';
+import { fullNameFields } from 'src/metadata/field-metadata/composite-types/full-name.composite-type';
+import { linkFields } from 'src/metadata/field-metadata/composite-types/link.composite-type';
+import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
+
+export type CompositeFieldsDefinitionFunction = (
+  fieldMetadata: FieldMetadataInterface,
+) => FieldMetadataInterface[];
+
+export const compositeDefinitions = new Map<
+  string,
+  CompositeFieldsDefinitionFunction
+>([
+  [FieldMetadataType.LINK, linkFields],
+  [FieldMetadataType.CURRENCY, currencyFields],
+  [FieldMetadataType.FULL_NAME, fullNameFields],
+]);

--- a/packages/twenty-server/src/metadata/field-metadata/composite-types/index.ts
+++ b/packages/twenty-server/src/metadata/field-metadata/composite-types/index.ts
@@ -6,7 +6,7 @@ import { linkFields } from 'src/metadata/field-metadata/composite-types/link.com
 import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
 
 export type CompositeFieldsDefinitionFunction = (
-  fieldMetadata: FieldMetadataInterface,
+  fieldMetadata?: FieldMetadataInterface,
 ) => FieldMetadataInterface[];
 
 export const compositeDefinitions = new Map<

--- a/packages/twenty-server/src/metadata/field-metadata/composite-types/link.composite-type.ts
+++ b/packages/twenty-server/src/metadata/field-metadata/composite-types/link.composite-type.ts
@@ -7,14 +7,14 @@ import { generateTargetColumnMap } from 'src/metadata/field-metadata/utils/gener
 export const linkFields = (
   fieldMetadata?: FieldMetadataInterface,
 ): FieldMetadataInterface[] => {
-  const inferedFieldMetadata = fieldMetadata as
+  const inferredFieldMetadata = fieldMetadata as
     | FieldMetadataInterface<FieldMetadataType.LINK>
     | undefined;
-  const targetColumnMap = inferedFieldMetadata
+  const targetColumnMap = inferredFieldMetadata
     ? generateTargetColumnMap(
-        inferedFieldMetadata.type,
-        inferedFieldMetadata.isCustom ?? false,
-        inferedFieldMetadata.name,
+        inferredFieldMetadata.type,
+        inferredFieldMetadata.isCustom ?? false,
+        inferredFieldMetadata.name,
       )
     : {
         label: 'label',
@@ -32,10 +32,10 @@ export const linkFields = (
         value: targetColumnMap.label,
       },
       isNullable: true,
-      ...(inferedFieldMetadata
+      ...(inferredFieldMetadata
         ? {
             defaultValue: {
-              value: inferedFieldMetadata.defaultValue?.label ?? null,
+              value: inferredFieldMetadata.defaultValue?.label ?? null,
             },
           }
         : {}),
@@ -50,10 +50,10 @@ export const linkFields = (
         value: targetColumnMap.url,
       },
       isNullable: true,
-      ...(inferedFieldMetadata
+      ...(inferredFieldMetadata
         ? {
             defaultValue: {
-              value: inferedFieldMetadata.defaultValue?.url ?? null,
+              value: inferredFieldMetadata.defaultValue?.url ?? null,
             },
           }
         : {}),

--- a/packages/twenty-server/src/metadata/field-metadata/composite-types/link.composite-type.ts
+++ b/packages/twenty-server/src/metadata/field-metadata/composite-types/link.composite-type.ts
@@ -7,11 +7,14 @@ import { generateTargetColumnMap } from 'src/metadata/field-metadata/utils/gener
 export const linkFields = (
   fieldMetadata?: FieldMetadataInterface,
 ): FieldMetadataInterface[] => {
-  const targetColumnMap = fieldMetadata
+  const inferedFieldMetadata = fieldMetadata as
+    | FieldMetadataInterface<FieldMetadataType.LINK>
+    | undefined;
+  const targetColumnMap = inferedFieldMetadata
     ? generateTargetColumnMap(
-        fieldMetadata.type,
-        fieldMetadata.isCustom ?? false,
-        fieldMetadata.name,
+        inferedFieldMetadata.type,
+        inferedFieldMetadata.isCustom ?? false,
+        inferedFieldMetadata.name,
       )
     : {
         label: 'label',
@@ -29,7 +32,14 @@ export const linkFields = (
         value: targetColumnMap.label,
       },
       isNullable: true,
-    } satisfies FieldMetadataInterface,
+      ...(inferedFieldMetadata
+        ? {
+            defaultValue: {
+              value: inferedFieldMetadata.defaultValue?.label ?? null,
+            },
+          }
+        : {}),
+    } satisfies FieldMetadataInterface<FieldMetadataType.TEXT>,
     {
       id: 'url',
       type: FieldMetadataType.TEXT,
@@ -40,7 +50,14 @@ export const linkFields = (
         value: targetColumnMap.url,
       },
       isNullable: true,
-    } satisfies FieldMetadataInterface,
+      ...(inferedFieldMetadata
+        ? {
+            defaultValue: {
+              value: inferedFieldMetadata.defaultValue?.url ?? null,
+            },
+          }
+        : {}),
+    } satisfies FieldMetadataInterface<FieldMetadataType.TEXT>,
   ];
 };
 

--- a/packages/twenty-server/src/metadata/field-metadata/dtos/default-value.input.ts
+++ b/packages/twenty-server/src/metadata/field-metadata/dtos/default-value.input.ts
@@ -1,3 +1,4 @@
+import { Transform } from 'class-transformer';
 import {
   IsArray,
   IsBoolean,
@@ -53,7 +54,10 @@ export class FieldMetadataDefaultValueLink {
 export class FieldMetadataDefaultValueCurrency {
   @ValidateIf((_object, value) => value !== null)
   @IsNumber()
-  amountMicros: number | null;
+  @Transform(({ value }) => {
+    return value.toString();
+  })
+  amountMicros: string | null;
 
   @ValidateIf((_object, value) => value !== null)
   @IsString()

--- a/packages/twenty-server/src/metadata/field-metadata/dtos/default-value.input.ts
+++ b/packages/twenty-server/src/metadata/field-metadata/dtos/default-value.input.ts
@@ -5,6 +5,7 @@ import {
   IsDate,
   IsNotEmpty,
   IsNumber,
+  IsNumberString,
   IsString,
   Matches,
   ValidateIf,
@@ -53,10 +54,7 @@ export class FieldMetadataDefaultValueLink {
 
 export class FieldMetadataDefaultValueCurrency {
   @ValidateIf((_object, value) => value !== null)
-  @IsNumber()
-  @Transform(({ value }) => {
-    return value.toString();
-  })
+  @IsNumberString()
   amountMicros: string | null;
 
   @ValidateIf((_object, value) => value !== null)

--- a/packages/twenty-server/src/metadata/field-metadata/utils/__tests__/validate-default-value-based-on-type.spec.ts
+++ b/packages/twenty-server/src/metadata/field-metadata/utils/__tests__/validate-default-value-based-on-type.spec.ts
@@ -133,7 +133,7 @@ describe('validateDefaultValueForType', () => {
   it('should validate CURRENCY default value', () => {
     expect(
       validateDefaultValueForType(FieldMetadataType.CURRENCY, {
-        amountMicros: 100,
+        amountMicros: '100',
         currencyCode: 'USD',
       }),
     ).toBe(true);
@@ -144,7 +144,7 @@ describe('validateDefaultValueForType', () => {
       validateDefaultValueForType(
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-expect-error Just for testing purposes
-        { amountMicros: '100', currencyCode: 'USD' },
+        { amountMicros: 100, currencyCode: 'USD' },
         FieldMetadataType.CURRENCY,
       ),
     ).toBe(false);

--- a/packages/twenty-server/src/metadata/field-metadata/utils/serialize-default-value.ts
+++ b/packages/twenty-server/src/metadata/field-metadata/utils/serialize-default-value.ts
@@ -2,6 +2,8 @@ import { BadRequestException } from '@nestjs/common';
 
 import { FieldMetadataDefaultSerializableValue } from 'src/metadata/field-metadata/interfaces/field-metadata-default-value.interface';
 
+import { serializeTypeDefaultValue } from 'src/metadata/field-metadata/utils/serialize-type-default-value.util';
+
 export const serializeDefaultValue = (
   defaultValue?: FieldMetadataDefaultSerializableValue,
 ) => {
@@ -15,14 +17,7 @@ export const serializeDefaultValue = (
     typeof defaultValue === 'object' &&
     'type' in defaultValue
   ) {
-    switch (defaultValue.type) {
-      case 'uuid':
-        return 'public.uuid_generate_v4()';
-      case 'now':
-        return 'now()';
-      default:
-        throw new BadRequestException('Invalid dynamic default value type');
-    }
+    return serializeTypeDefaultValue(defaultValue);
   }
 
   // Static default values

--- a/packages/twenty-server/src/metadata/field-metadata/utils/serialize-default-value.ts
+++ b/packages/twenty-server/src/metadata/field-metadata/utils/serialize-default-value.ts
@@ -17,7 +17,13 @@ export const serializeDefaultValue = (
     typeof defaultValue === 'object' &&
     'type' in defaultValue
   ) {
-    return serializeTypeDefaultValue(defaultValue);
+    const serializedTypeDefaultValue = serializeTypeDefaultValue(defaultValue);
+
+    if (!serializedTypeDefaultValue) {
+      throw new BadRequestException('Invalid default value');
+    }
+
+    return serializedTypeDefaultValue;
   }
 
   // Static default values

--- a/packages/twenty-server/src/metadata/field-metadata/utils/serialize-type-default-value.util.ts
+++ b/packages/twenty-server/src/metadata/field-metadata/utils/serialize-type-default-value.util.ts
@@ -1,0 +1,18 @@
+import { FieldMetadataDynamicDefaultValue } from 'src/metadata/field-metadata/interfaces/field-metadata-default-value.interface';
+
+export const serializeTypeDefaultValue = (
+  defaultValue?: FieldMetadataDynamicDefaultValue,
+) => {
+  if (!defaultValue?.type) {
+    return null;
+  }
+
+  switch (defaultValue.type) {
+    case 'uuid':
+      return 'public.uuid_generate_v4()';
+    case 'now':
+      return 'now()';
+    default:
+      return null;
+  }
+};

--- a/packages/twenty-server/src/metadata/workspace-migration/workspace-migration.factory.ts
+++ b/packages/twenty-server/src/metadata/workspace-migration/workspace-migration.factory.ts
@@ -12,13 +12,7 @@ import {
   WorkspaceMigrationColumnActionType,
 } from 'src/metadata/workspace-migration/workspace-migration.entity';
 import { isCompositeFieldMetadataType } from 'src/metadata/field-metadata/utils/is-composite-field-metadata-type.util';
-import { fullNameFields } from 'src/metadata/field-metadata/composite-types/full-name.composite-type';
-import { currencyFields } from 'src/metadata/field-metadata/composite-types/currency.composite-type';
-import { linkFields } from 'src/metadata/field-metadata/composite-types/link.composite-type';
-
-type CompositeFieldsDefinitionFunction = (
-  fieldMetadata: FieldMetadataInterface,
-) => FieldMetadataInterface[];
+import { compositeDefinitions } from 'src/metadata/field-metadata/composite-types';
 
 @Injectable()
 export class WorkspaceMigrationFactory {
@@ -30,10 +24,6 @@ export class WorkspaceMigrationFactory {
       options?: WorkspaceColumnActionOptions;
     }
   >;
-  private compositeDefinitions = new Map<
-    string,
-    CompositeFieldsDefinitionFunction
-  >();
 
   constructor(
     private readonly basicColumnActionFactory: BasicColumnActionFactory,
@@ -89,15 +79,6 @@ export class WorkspaceMigrationFactory {
         { factory: this.enumColumnActionFactory },
       ],
     ]);
-
-    this.compositeDefinitions = new Map<
-      string,
-      CompositeFieldsDefinitionFunction
-    >([
-      [FieldMetadataType.LINK, linkFields],
-      [FieldMetadataType.CURRENCY, currencyFields],
-      [FieldMetadataType.FULL_NAME, fullNameFields],
-    ]);
   }
 
   createColumnActions(
@@ -138,7 +119,7 @@ export class WorkspaceMigrationFactory {
 
     // If it's a composite field type, we need to create a column action for each of the fields
     if (isCompositeFieldMetadataType(alteredFieldMetadata.type)) {
-      const fieldMetadataSplitterFunction = this.compositeDefinitions.get(
+      const fieldMetadataSplitterFunction = compositeDefinitions.get(
         alteredFieldMetadata.type,
       );
 

--- a/packages/twenty-server/src/workspace/workspace-health/commands/workspace-health-command.module.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/commands/workspace-health-command.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+
+import { WorkspaceHealthCommand } from 'src/workspace/workspace-health/commands/workspace-health.command';
+import { WorkspaceHealthModule } from 'src/workspace/workspace-health/workspace-health.module';
+
+@Module({
+  imports: [WorkspaceHealthModule],
+  providers: [WorkspaceHealthCommand],
+})
+export class WorkspaceHealthCommandModule {}

--- a/packages/twenty-server/src/workspace/workspace-health/commands/workspace-health.command.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/commands/workspace-health.command.ts
@@ -1,0 +1,33 @@
+import { Command, CommandRunner, Option } from 'nest-commander';
+
+import { WorkspaceHealthService } from 'src/workspace/workspace-health/workspace-health.service';
+
+interface WorkspaceHealthCommandOptions {
+  workspaceId: string;
+}
+
+@Command({
+  name: 'workspace:health',
+  description: 'Check health of the given workspace.',
+})
+export class WorkspaceHealthCommand extends CommandRunner {
+  constructor(private readonly workspaceHealthService: WorkspaceHealthService) {
+    super();
+  }
+
+  async run(
+    _passedParam: string[],
+    options: WorkspaceHealthCommandOptions,
+  ): Promise<void> {
+    await this.workspaceHealthService.healthCheck(options.workspaceId);
+  }
+
+  @Option({
+    flags: '-w, --workspace-id [workspace_id]',
+    description: 'workspace id',
+    required: true,
+  })
+  parseWorkspaceId(value: string): string {
+    return value;
+  }
+}

--- a/packages/twenty-server/src/workspace/workspace-health/commands/workspace-health.command.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/commands/workspace-health.command.ts
@@ -1,9 +1,14 @@
 import { Command, CommandRunner, Option } from 'nest-commander';
+import chalk from 'chalk';
+
+import { WorkspaceHealthMode } from 'src/workspace/workspace-health/interfaces/workspace-health-options.interface';
 
 import { WorkspaceHealthService } from 'src/workspace/workspace-health/workspace-health.service';
 
 interface WorkspaceHealthCommandOptions {
   workspaceId: string;
+  verbose?: boolean;
+  mode?: WorkspaceHealthMode;
 }
 
 @Command({
@@ -19,7 +24,26 @@ export class WorkspaceHealthCommand extends CommandRunner {
     _passedParam: string[],
     options: WorkspaceHealthCommandOptions,
   ): Promise<void> {
-    await this.workspaceHealthService.healthCheck(options.workspaceId);
+    const issues = await this.workspaceHealthService.healthCheck(
+      options.workspaceId,
+      {
+        mode: options.mode ?? WorkspaceHealthMode.All,
+      },
+    );
+
+    if (issues.length === 0) {
+      console.log(chalk.green('Workspace is healthy'));
+    } else {
+      console.log(chalk.red('Workspace is not healthy'));
+
+      if (options.verbose) {
+        console.group(chalk.red('Issues'));
+        issues.forEach((issue) => {
+          console.log(chalk.yellow(JSON.stringify(issue, null, 2)));
+        });
+        console.groupEnd();
+      }
+    }
   }
 
   @Option({
@@ -29,5 +53,25 @@ export class WorkspaceHealthCommand extends CommandRunner {
   })
   parseWorkspaceId(value: string): string {
     return value;
+  }
+
+  @Option({
+    flags: '-v, --verbose',
+    description: 'Detailed output',
+    required: false,
+    defaultValue: 'true',
+  })
+  parseVerbose(value: string): boolean {
+    return value === 'true';
+  }
+
+  @Option({
+    flags: '-m, --mode [mode]',
+    description: 'Mode of the health check [structure, metadata, all]',
+    required: false,
+    defaultValue: WorkspaceHealthMode.All,
+  })
+  parseMode(value: string): WorkspaceHealthMode {
+    return value as WorkspaceHealthMode;
   }
 }

--- a/packages/twenty-server/src/workspace/workspace-health/commands/workspace-health.command.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/commands/workspace-health.command.ts
@@ -36,6 +36,7 @@ export class WorkspaceHealthCommand extends CommandRunner {
     } else {
       console.log(chalk.red('Workspace is not healthy'));
 
+      console.log('options', options);
       if (options.verbose) {
         console.group(chalk.red('Issues'));
         issues.forEach((issue) => {
@@ -59,10 +60,9 @@ export class WorkspaceHealthCommand extends CommandRunner {
     flags: '-v, --verbose',
     description: 'Detailed output',
     required: false,
-    defaultValue: 'true',
   })
-  parseVerbose(value: string): boolean {
-    return value === 'true';
+  parseVerbose(): boolean {
+    return true;
   }
 
   @Option({

--- a/packages/twenty-server/src/workspace/workspace-health/commands/workspace-health.command.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/commands/workspace-health.command.ts
@@ -36,7 +36,6 @@ export class WorkspaceHealthCommand extends CommandRunner {
     } else {
       console.log(chalk.red('Workspace is not healthy'));
 
-      console.log('options', options);
       if (options.verbose) {
         console.group(chalk.red('Issues'));
         issues.forEach((issue) => {

--- a/packages/twenty-server/src/workspace/workspace-health/interfaces/workspace-health-issue.interface.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/interfaces/workspace-health-issue.interface.ts
@@ -20,6 +20,7 @@ export enum WorkspaceHealthIssueType {
   COLUMN_TYPE_NOT_VALID = 'COLUMN_TYPE_NOT_VALID',
   COLUMN_DATA_TYPE_CONFLICT = 'COLUMN_DATA_TYPE_CONFLICT',
   COLUMN_NULLABILITY_CONFLICT = 'COLUMN_NULLABILITY_CONFLICT',
+  COLUMN_DEFAULT_VALUE_CONFLICT = 'COLUMN_DEFAULT_VALUE_CONFLICT',
 }
 
 export interface WorkspaceHealthTableIssue {
@@ -45,7 +46,8 @@ export interface WorkspaceHealthColumnIssue {
     | WorkspaceHealthIssueType.COLUMN_NAME_NOT_VALID
     | WorkspaceHealthIssueType.COLUMN_TYPE_NOT_VALID
     | WorkspaceHealthIssueType.COLUMN_DATA_TYPE_CONFLICT
-    | WorkspaceHealthIssueType.COLUMN_NULLABILITY_CONFLICT;
+    | WorkspaceHealthIssueType.COLUMN_NULLABILITY_CONFLICT
+    | WorkspaceHealthIssueType.COLUMN_DEFAULT_VALUE_CONFLICT;
   fieldMetadata: FieldMetadataEntity;
   columnStructure?: WorkspaceTableStructure;
   message: string;

--- a/packages/twenty-server/src/workspace/workspace-health/interfaces/workspace-health-issue.interface.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/interfaces/workspace-health-issue.interface.ts
@@ -5,18 +5,30 @@ import { ObjectMetadataEntity } from 'src/metadata/object-metadata/object-metada
 
 export enum WorkspaceHealthIssueType {
   MISSING_TABLE = 'MISSING_TABLE',
-  TABLE_CONFLICT = 'TABLE_CONFLICT',
+  TABLE_NAME_SHOULD_BE_CUSTOM = 'TABLE_NAME_SHOULD_BE_CUSTOM',
+  TABLE_TARGET_TABLE_NAME_NOT_VALID = 'TABLE_TARGET_TABLE_NAME_NOT_VALID',
+  TABLE_DATA_SOURCE_ID_NOT_VALID = 'TABLE_DATA_SOURCE_ID_NOT_VALID',
+  TABLE_NAME_NOT_VALID = 'TABLE_NAME_NOT_VALID',
   MISSING_COLUMN = 'MISSING_COLUMN',
   MISSING_INDEX = 'MISSING_INDEX',
   MISSING_FOREIGN_KEY = 'MISSING_FOREIGN_KEY',
   MISSING_COMPOSITE_TYPE = 'MISSING_COMPOSITE_TYPE',
-  COLUMN_CONFLICT = 'COLUMN_CONFLICT',
+  COLUMN_TARGET_COLUMN_MAP_NOT_VALID = 'COLUMN_TARGET_COLUMN_MAP_NOT_VALID',
+  COLUMN_NAME_SHOULD_BE_CUSTOM = 'COLUMN_NAME_SHOULD_BE_CUSTOM',
+  COLUMN_OBJECT_REFERENCE_INVALID = 'COLUMN_OBJECT_REFERENCE_INVALID',
+  COLUMN_NAME_NOT_VALID = 'COLUMN_NAME_NOT_VALID',
+  COLUMN_TYPE_NOT_VALID = 'COLUMN_TYPE_NOT_VALID',
+  COLUMN_DATA_TYPE_CONFLICT = 'COLUMN_DATA_TYPE_CONFLICT',
+  COLUMN_NULLABILITY_CONFLICT = 'COLUMN_NULLABILITY_CONFLICT',
 }
 
 export interface WorkspaceHealthTableIssue {
   type:
     | WorkspaceHealthIssueType.MISSING_TABLE
-    | WorkspaceHealthIssueType.TABLE_CONFLICT;
+    | WorkspaceHealthIssueType.TABLE_NAME_SHOULD_BE_CUSTOM
+    | WorkspaceHealthIssueType.TABLE_TARGET_TABLE_NAME_NOT_VALID
+    | WorkspaceHealthIssueType.TABLE_DATA_SOURCE_ID_NOT_VALID
+    | WorkspaceHealthIssueType.TABLE_NAME_NOT_VALID;
   objectMetadata: ObjectMetadataEntity;
   message: string;
 }
@@ -27,7 +39,13 @@ export interface WorkspaceHealthColumnIssue {
     | WorkspaceHealthIssueType.MISSING_INDEX
     | WorkspaceHealthIssueType.MISSING_FOREIGN_KEY
     | WorkspaceHealthIssueType.MISSING_COMPOSITE_TYPE
-    | WorkspaceHealthIssueType.COLUMN_CONFLICT;
+    | WorkspaceHealthIssueType.COLUMN_TARGET_COLUMN_MAP_NOT_VALID
+    | WorkspaceHealthIssueType.COLUMN_NAME_SHOULD_BE_CUSTOM
+    | WorkspaceHealthIssueType.COLUMN_OBJECT_REFERENCE_INVALID
+    | WorkspaceHealthIssueType.COLUMN_NAME_NOT_VALID
+    | WorkspaceHealthIssueType.COLUMN_TYPE_NOT_VALID
+    | WorkspaceHealthIssueType.COLUMN_DATA_TYPE_CONFLICT
+    | WorkspaceHealthIssueType.COLUMN_NULLABILITY_CONFLICT;
   fieldMetadata: FieldMetadataEntity;
   columnStructure?: WorkspaceTableStructure;
   message: string;

--- a/packages/twenty-server/src/workspace/workspace-health/interfaces/workspace-health-issue.interface.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/interfaces/workspace-health-issue.interface.ts
@@ -1,0 +1,38 @@
+import { WorkspaceTableStructure } from 'src/workspace/workspace-health/interfaces/workspace-table-definition.interface';
+
+import { FieldMetadataEntity } from 'src/metadata/field-metadata/field-metadata.entity';
+import { ObjectMetadataEntity } from 'src/metadata/object-metadata/object-metadata.entity';
+
+export enum WorkspaceHealthIssueType {
+  MISSING_TABLE = 'MISSING_TABLE',
+  TABLE_CONFLICT = 'TABLE_CONFLICT',
+  MISSING_COLUMN = 'MISSING_COLUMN',
+  MISSING_INDEX = 'MISSING_INDEX',
+  MISSING_FOREIGN_KEY = 'MISSING_FOREIGN_KEY',
+  MISSING_COMPOSITE_TYPE = 'MISSING_COMPOSITE_TYPE',
+  COLUMN_CONFLICT = 'COLUMN_CONFLICT',
+}
+
+export interface WorkspaceHealthTableIssue {
+  type:
+    | WorkspaceHealthIssueType.MISSING_TABLE
+    | WorkspaceHealthIssueType.TABLE_CONFLICT;
+  objectMetadata: ObjectMetadataEntity;
+  message: string;
+}
+
+export interface WorkspaceHealthColumnIssue {
+  type:
+    | WorkspaceHealthIssueType.MISSING_COLUMN
+    | WorkspaceHealthIssueType.MISSING_INDEX
+    | WorkspaceHealthIssueType.MISSING_FOREIGN_KEY
+    | WorkspaceHealthIssueType.MISSING_COMPOSITE_TYPE
+    | WorkspaceHealthIssueType.COLUMN_CONFLICT;
+  fieldMetadata: FieldMetadataEntity;
+  columnStructure?: WorkspaceTableStructure;
+  message: string;
+}
+
+export type WorkspaceHealthIssue =
+  | WorkspaceHealthTableIssue
+  | WorkspaceHealthColumnIssue;

--- a/packages/twenty-server/src/workspace/workspace-health/interfaces/workspace-health-issue.interface.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/interfaces/workspace-health-issue.interface.ts
@@ -22,6 +22,7 @@ export enum WorkspaceHealthIssueType {
   COLUMN_NULLABILITY_CONFLICT = 'COLUMN_NULLABILITY_CONFLICT',
   COLUMN_DEFAULT_VALUE_CONFLICT = 'COLUMN_DEFAULT_VALUE_CONFLICT',
   COLUMN_DEFAULT_VALUE_NOT_VALID = 'COLUMN_DEFAULT_VALUE_NOT_VALID',
+  COLUMN_OPTIONS_NOT_VALID = 'COLUMN_OPTIONS_NOT_VALID',
 }
 
 export interface WorkspaceHealthTableIssue {
@@ -49,7 +50,8 @@ export interface WorkspaceHealthColumnIssue {
     | WorkspaceHealthIssueType.COLUMN_DATA_TYPE_CONFLICT
     | WorkspaceHealthIssueType.COLUMN_NULLABILITY_CONFLICT
     | WorkspaceHealthIssueType.COLUMN_DEFAULT_VALUE_CONFLICT
-    | WorkspaceHealthIssueType.COLUMN_DEFAULT_VALUE_NOT_VALID;
+    | WorkspaceHealthIssueType.COLUMN_DEFAULT_VALUE_NOT_VALID
+    | WorkspaceHealthIssueType.COLUMN_OPTIONS_NOT_VALID;
   fieldMetadata: FieldMetadataEntity;
   columnStructure?: WorkspaceTableStructure;
   message: string;

--- a/packages/twenty-server/src/workspace/workspace-health/interfaces/workspace-health-issue.interface.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/interfaces/workspace-health-issue.interface.ts
@@ -21,6 +21,7 @@ export enum WorkspaceHealthIssueType {
   COLUMN_DATA_TYPE_CONFLICT = 'COLUMN_DATA_TYPE_CONFLICT',
   COLUMN_NULLABILITY_CONFLICT = 'COLUMN_NULLABILITY_CONFLICT',
   COLUMN_DEFAULT_VALUE_CONFLICT = 'COLUMN_DEFAULT_VALUE_CONFLICT',
+  COLUMN_DEFAULT_VALUE_NOT_VALID = 'COLUMN_DEFAULT_VALUE_NOT_VALID',
 }
 
 export interface WorkspaceHealthTableIssue {
@@ -47,7 +48,8 @@ export interface WorkspaceHealthColumnIssue {
     | WorkspaceHealthIssueType.COLUMN_TYPE_NOT_VALID
     | WorkspaceHealthIssueType.COLUMN_DATA_TYPE_CONFLICT
     | WorkspaceHealthIssueType.COLUMN_NULLABILITY_CONFLICT
-    | WorkspaceHealthIssueType.COLUMN_DEFAULT_VALUE_CONFLICT;
+    | WorkspaceHealthIssueType.COLUMN_DEFAULT_VALUE_CONFLICT
+    | WorkspaceHealthIssueType.COLUMN_DEFAULT_VALUE_NOT_VALID;
   fieldMetadata: FieldMetadataEntity;
   columnStructure?: WorkspaceTableStructure;
   message: string;

--- a/packages/twenty-server/src/workspace/workspace-health/interfaces/workspace-health-options.interface.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/interfaces/workspace-health-options.interface.ts
@@ -1,0 +1,9 @@
+export enum WorkspaceHealthMode {
+  Structure = 'structure',
+  Metadata = 'metadata',
+  All = 'all',
+}
+
+export interface WorkspaceHealthOptions {
+  mode: WorkspaceHealthMode;
+}

--- a/packages/twenty-server/src/workspace/workspace-health/interfaces/workspace-table-definition.interface.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/interfaces/workspace-table-definition.interface.ts
@@ -1,0 +1,11 @@
+export interface WorkspaceTableStructure {
+  table_schema: string;
+  table_name: string;
+  column_name: string;
+  data_type: string;
+  character_maximum_length: number;
+  numeric_precision: number;
+  is_nullable: string;
+  column_default: string;
+  is_primary_key: string;
+}

--- a/packages/twenty-server/src/workspace/workspace-health/interfaces/workspace-table-definition.interface.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/interfaces/workspace-table-definition.interface.ts
@@ -1,11 +1,9 @@
 export interface WorkspaceTableStructure {
-  table_schema: string;
-  table_name: string;
-  column_name: string;
-  data_type: string;
-  character_maximum_length: number;
-  numeric_precision: number;
-  is_nullable: string;
-  column_default: string;
-  is_primary_key: string;
+  tableSchema: string;
+  tableName: string;
+  columnName: string;
+  dataType: string;
+  isNullable: string;
+  columnDefault: string;
+  isPrimaryKey: string;
 }

--- a/packages/twenty-server/src/workspace/workspace-health/services/database-structure.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/services/database-structure.service.ts
@@ -1,0 +1,61 @@
+import { Injectable } from '@nestjs/common';
+
+import { TableColumn } from 'typeorm';
+
+import { WorkspaceTableStructure } from 'src/workspace/workspace-health/interfaces/workspace-table-definition.interface';
+
+import { TypeORMService } from 'src/database/typeorm/typeorm.service';
+import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
+import { fieldMetadataTypeToColumnType } from 'src/metadata/workspace-migration/utils/field-metadata-type-to-column-type.util';
+
+@Injectable()
+export class DatabaseStructureService {
+  constructor(private readonly typeORMService: TypeORMService) {}
+
+  async getWorkspaceTableColumns(
+    schemaName: string,
+    tableName: string,
+  ): Promise<WorkspaceTableStructure[]> {
+    const mainDataSource = this.typeORMService.getMainDataSource();
+
+    return mainDataSource.query<WorkspaceTableStructure[]>(`
+      SELECT
+        c.table_schema,
+        c.table_name,
+        c.column_name,
+        c.data_type,
+        c.character_maximum_length,
+        c.numeric_precision,
+        c.is_nullable,
+        pg_get_expr(d.adbin, d.adrelid) as column_default,
+        CASE
+            WHEN pk.constraint_type = 'PRIMARY KEY' THEN 'YES'
+            ELSE 'NO'
+        END as is_primary_key
+      FROM
+          information_schema.columns c
+      LEFT JOIN
+          information_schema.constraint_column_usage as ccu ON c.column_name = ccu.column_name AND c.table_name = ccu.table_name
+      LEFT JOIN
+          information_schema.table_constraints as pk ON pk.constraint_name = ccu.constraint_name AND pk.constraint_type = 'PRIMARY KEY'
+      LEFT JOIN
+          pg_attrdef as d ON d.adrelid = (SELECT oid FROM pg_class WHERE relname = c.table_name) AND d.adnum = c.ordinal_position
+      WHERE
+          c.table_schema = '${schemaName}'
+          AND c.table_name = '${tableName}';
+    `);
+  }
+
+  getPostgresDataType(fieldMedataType: FieldMetadataType): string {
+    const typeORMType = fieldMetadataTypeToColumnType(fieldMedataType);
+    const mainDataSource = this.typeORMService.getMainDataSource();
+
+    // Workaround to get the postgres data type from a field metadata type
+    const tempColumn = new TableColumn({
+      name: 'tempColumn',
+      type: typeORMType,
+    });
+
+    return mainDataSource.driver.normalizeType(tempColumn);
+  }
+}

--- a/packages/twenty-server/src/workspace/workspace-health/services/database-structure.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/services/database-structure.service.ts
@@ -55,10 +55,12 @@ export class DatabaseStructureService {
   }
 
   getPostgresDefault(
-    type: FieldMetadataType,
+    fieldMetadataType: FieldMetadataType,
     defaultValue: FieldMetadataDefaultValue | null,
   ): string | null | undefined {
-    const typeORMType = fieldMetadataTypeToColumnType(type) as ColumnType;
+    const typeORMType = fieldMetadataTypeToColumnType(
+      fieldMetadataType,
+    ) as ColumnType;
     const mainDataSource = this.typeORMService.getMainDataSource();
 
     if (defaultValue && 'type' in defaultValue) {

--- a/packages/twenty-server/src/workspace/workspace-health/services/database-structure.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/services/database-structure.service.ts
@@ -30,8 +30,8 @@ export class DatabaseStructureService {
         c.is_nullable as "isNullable",
         c.column_default as "columnDefault",
         CASE
-            WHEN pk.constraint_type = 'PRIMARY KEY' THEN 'YES'
-            ELSE 'NO'
+            WHEN pk.constraint_type = 'PRIMARY KEY' THEN 'TRUE'
+            ELSE 'FALSE'
         END as "isPrimaryKey"
       FROM
           information_schema.columns c

--- a/packages/twenty-server/src/workspace/workspace-health/services/database-structure.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/services/database-structure.service.ts
@@ -4,12 +4,10 @@ import { ColumnType } from 'typeorm';
 import { ColumnMetadata } from 'typeorm/metadata/ColumnMetadata';
 
 import { WorkspaceTableStructure } from 'src/workspace/workspace-health/interfaces/workspace-table-definition.interface';
+import { FieldMetadataDefaultValue } from 'src/metadata/field-metadata/interfaces/field-metadata-default-value.interface';
 
 import { TypeORMService } from 'src/database/typeorm/typeorm.service';
-import {
-  FieldMetadataEntity,
-  FieldMetadataType,
-} from 'src/metadata/field-metadata/field-metadata.entity';
+import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
 import { fieldMetadataTypeToColumnType } from 'src/metadata/workspace-migration/utils/field-metadata-type-to-column-type.util';
 import { serializeTypeDefaultValue } from 'src/metadata/field-metadata/utils/serialize-type-default-value.util';
 
@@ -57,17 +55,14 @@ export class DatabaseStructureService {
   }
 
   getPostgresDefault(
-    fieldMetadata: FieldMetadataEntity,
+    type: FieldMetadataType,
+    defaultValue: FieldMetadataDefaultValue | null,
   ): string | null | undefined {
-    const typeORMType = fieldMetadataTypeToColumnType(
-      fieldMetadata.type,
-    ) as ColumnType;
+    const typeORMType = fieldMetadataTypeToColumnType(type) as ColumnType;
     const mainDataSource = this.typeORMService.getMainDataSource();
 
-    if (fieldMetadata.defaultValue && 'type' in fieldMetadata.defaultValue) {
-      const serializedDefaultValue = serializeTypeDefaultValue(
-        fieldMetadata.defaultValue,
-      );
+    if (defaultValue && 'type' in defaultValue) {
+      const serializedDefaultValue = serializeTypeDefaultValue(defaultValue);
 
       // Special case for uuid_generate_v4() default value
       if (serializedDefaultValue === 'public.uuid_generate_v4()') {
@@ -78,9 +73,7 @@ export class DatabaseStructureService {
     }
 
     const value =
-      fieldMetadata.defaultValue && 'value' in fieldMetadata.defaultValue
-        ? fieldMetadata.defaultValue.value
-        : null;
+      defaultValue && 'value' in defaultValue ? defaultValue.value : null;
 
     if (typeof value === 'number') {
       return value.toString();

--- a/packages/twenty-server/src/workspace/workspace-health/services/field-metadata-health.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/services/field-metadata-health.service.ts
@@ -1,0 +1,180 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+
+import {
+  WorkspaceHealthIssue,
+  WorkspaceHealthIssueType,
+} from 'src/workspace/workspace-health/interfaces/workspace-health-issue.interface';
+import { WorkspaceTableStructure } from 'src/workspace/workspace-health/interfaces/workspace-table-definition.interface';
+
+import { currencyFields } from 'src/metadata/field-metadata/composite-types/currency.composite-type';
+import { fullNameFields } from 'src/metadata/field-metadata/composite-types/full-name.composite-type';
+import { linkFields } from 'src/metadata/field-metadata/composite-types/link.composite-type';
+import {
+  FieldMetadataEntity,
+  FieldMetadataType,
+} from 'src/metadata/field-metadata/field-metadata.entity';
+import { isCompositeFieldMetadataType } from 'src/metadata/field-metadata/utils/is-composite-field-metadata-type.util';
+import { DatabaseStructureService } from 'src/workspace/workspace-health/services/database-structure.service';
+import { validName } from 'src/workspace/workspace-health/utils/valid-name.util';
+
+@Injectable()
+export class FieldMetadataHealthService {
+  private issues: WorkspaceHealthIssue[] = [];
+
+  constructor(
+    private readonly databaseStructureService: DatabaseStructureService,
+  ) {}
+
+  async healthCheckFields(
+    schemaName: string,
+    tableName: string,
+    fieldMetadataCollection: FieldMetadataEntity[],
+  ): Promise<WorkspaceHealthIssue[]> {
+    const workspaceTableColumns =
+      await this.databaseStructureService.getWorkspaceTableColumns(
+        schemaName,
+        tableName,
+      );
+
+    if (!workspaceTableColumns) {
+      throw new NotFoundException(
+        `Table ${tableName} not found in schema ${schemaName}`,
+      );
+    }
+
+    for (const fieldMetadata of fieldMetadataCollection) {
+      // Ignore relation fields for now
+      if (
+        fieldMetadata.fromRelationMetadata ||
+        fieldMetadata.toRelationMetadata
+      ) {
+        // TODO: Check relation fields
+        continue;
+      }
+
+      if (isCompositeFieldMetadataType(fieldMetadata.type)) {
+        const compositeFieldMetadataMap = {
+          [FieldMetadataType.CURRENCY]: currencyFields(fieldMetadata),
+          [FieldMetadataType.FULL_NAME]: fullNameFields(fieldMetadata),
+          [FieldMetadataType.LINK]: linkFields(fieldMetadata),
+        };
+
+        const compositeFieldMetadataCollection =
+          compositeFieldMetadataMap[fieldMetadata.type];
+
+        for (const compositeFieldMetadata of compositeFieldMetadataCollection) {
+          await this.healthCheckField(
+            tableName,
+            workspaceTableColumns,
+            compositeFieldMetadata as FieldMetadataEntity,
+          );
+        }
+      } else {
+        await this.healthCheckField(
+          tableName,
+          workspaceTableColumns,
+          fieldMetadata,
+        );
+      }
+    }
+
+    return this.issues;
+  }
+
+  private async healthCheckField(
+    tableName: string,
+    workspaceTableColumns: WorkspaceTableStructure[],
+    fieldMetadata: FieldMetadataEntity,
+  ): Promise<void> {
+    const columnName = fieldMetadata.targetColumnMap.value;
+    const dataType = this.databaseStructureService.getPostgresDataType(
+      fieldMetadata.type,
+    );
+    const isNullable = fieldMetadata.isNullable ? 'YES' : 'NO';
+    // Check if column exist in database
+    const columnStructure = workspaceTableColumns.find(
+      (tableDefinition) => tableDefinition.column_name === columnName,
+    );
+
+    if (Object.keys(fieldMetadata.targetColumnMap).length !== 1) {
+      this.issues.push({
+        type: WorkspaceHealthIssueType.COLUMN_CONFLICT,
+        fieldMetadata,
+        columnStructure,
+        message: `Column ${columnName} has more than one target column map, it should only contains "value"`,
+      });
+    }
+
+    if (fieldMetadata.isCustom && !columnName.startsWith('_')) {
+      this.issues.push({
+        type: WorkspaceHealthIssueType.MISSING_COLUMN,
+        fieldMetadata,
+        columnStructure,
+        message: `Column ${columnName} is marked as custom in table ${tableName} but doesn't start with "_"`,
+      });
+
+      return;
+    }
+
+    if (!columnStructure) {
+      this.issues.push({
+        type: WorkspaceHealthIssueType.MISSING_COLUMN,
+        fieldMetadata,
+        columnStructure,
+        message: `Column ${columnName} not found in table ${tableName}`,
+      });
+
+      return;
+    }
+
+    if (!fieldMetadata.objectMetadataId) {
+      this.issues.push({
+        type: WorkspaceHealthIssueType.COLUMN_CONFLICT,
+        fieldMetadata,
+        columnStructure,
+        message: `Column ${columnName} doesn't have a valid object metadata id`,
+      });
+    }
+
+    if (!Object.values(FieldMetadataType).includes(fieldMetadata.type)) {
+      this.issues.push({
+        type: WorkspaceHealthIssueType.COLUMN_CONFLICT,
+        fieldMetadata,
+        columnStructure,
+        message: `Column ${columnName} doesn't have a valid field metadata type`,
+      });
+    }
+
+    if (
+      !fieldMetadata.name ||
+      !validName(fieldMetadata.name) ||
+      !fieldMetadata.label
+    ) {
+      this.issues.push({
+        type: WorkspaceHealthIssueType.COLUMN_CONFLICT,
+        fieldMetadata,
+        columnStructure,
+        message: `Column ${columnName} doesn't have a valid name or label`,
+      });
+    }
+
+    // Check if column data type is the same
+    if (columnStructure.data_type !== dataType) {
+      this.issues.push({
+        type: WorkspaceHealthIssueType.COLUMN_CONFLICT,
+        fieldMetadata,
+        columnStructure,
+        message: `Column ${columnName} type is not the same as the field metadata type "${columnStructure.data_type}" !== "${dataType}"`,
+      });
+    }
+
+    if (columnStructure.is_nullable !== isNullable) {
+      this.issues.push({
+        type: WorkspaceHealthIssueType.COLUMN_CONFLICT,
+        fieldMetadata,
+        columnStructure,
+        message: `Column ${columnName} is not nullable as expected`,
+      });
+    }
+  }
+}

--- a/packages/twenty-server/src/workspace/workspace-health/services/field-metadata-health.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/services/field-metadata-health.service.ts
@@ -140,7 +140,7 @@ export class FieldMetadataHealthService {
       fieldMetadata.type,
       fieldMetadata.defaultValue,
     );
-    const isNullable = fieldMetadata.isNullable ? 'YES' : 'NO';
+    const isNullable = fieldMetadata.isNullable ? 'TRUE' : 'FALSE';
     // Check if column exist in database
     const columnStructure = workspaceTableColumns.find(
       (tableDefinition) => tableDefinition.columnName === columnName,

--- a/packages/twenty-server/src/workspace/workspace-health/services/field-metadata-health.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/services/field-metadata-health.service.ts
@@ -329,10 +329,10 @@ export class FieldMetadataHealthService {
   }
 
   private isCompositeObjectWellStructured(
-    type: FieldMetadataType,
+    fieldMetadataType: FieldMetadataType,
     object: any,
   ): boolean {
-    const subFields = compositeDefinitions.get(type)?.() ?? [];
+    const subFields = compositeDefinitions.get(fieldMetadataType)?.() ?? [];
 
     if (!object) {
       return true;
@@ -340,7 +340,7 @@ export class FieldMetadataHealthService {
 
     if (subFields.length === 0) {
       throw new InternalServerErrorException(
-        `The composite field type ${type} doesn't have any sub fields, it seems this one is not implemented in the composite definitions map`,
+        `The composite field type ${fieldMetadataType} doesn't have any sub fields, it seems this one is not implemented in the composite definitions map`,
       );
     }
 

--- a/packages/twenty-server/src/workspace/workspace-health/services/object-metadata-health.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/services/object-metadata-health.service.ts
@@ -4,6 +4,7 @@ import {
   WorkspaceHealthIssue,
   WorkspaceHealthIssueType,
 } from 'src/workspace/workspace-health/interfaces/workspace-health-issue.interface';
+import { WorkspaceHealthOptions } from 'src/workspace/workspace-health/interfaces/workspace-health-options.interface';
 
 import { ObjectMetadataEntity } from 'src/metadata/object-metadata/object-metadata.entity';
 import { validName } from 'src/workspace/workspace-health/utils/valid-name.util';
@@ -13,7 +14,38 @@ import { TypeORMService } from 'src/database/typeorm/typeorm.service';
 export class ObjectMetadataHealthService {
   constructor(private readonly typeORMService: TypeORMService) {}
 
-  async heathCheck(
+  async healthCheck(
+    schemaName: string,
+    objectMetadata: ObjectMetadataEntity,
+    options: WorkspaceHealthOptions,
+  ): Promise<WorkspaceHealthIssue[]> {
+    const issues: WorkspaceHealthIssue[] = [];
+
+    if (options.mode === 'structure' || options.mode === 'all') {
+      const structureIssues = await this.structureObjectCheck(
+        schemaName,
+        objectMetadata,
+      );
+
+      issues.push(...structureIssues);
+    }
+
+    if (options.mode === 'metadata' || options.mode === 'all') {
+      const metadataIssues = await this.metadataObjectCheck(objectMetadata);
+
+      issues.push(...metadataIssues);
+    }
+
+    return issues;
+  }
+
+  /**
+   * Check the structure health of the table based on metadata
+   * @param schemaName
+   * @param objectMetadata
+   * @returns WorkspaceHealthIssue[]
+   */
+  private async structureObjectCheck(
     schemaName: string,
     objectMetadata: ObjectMetadataEntity,
   ): Promise<WorkspaceHealthIssue[]> {
@@ -25,19 +57,6 @@ export class ObjectMetadataHealthService {
       `SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_schema = '${schemaName}' AND table_name = '${objectMetadata.targetTableName}')`,
     );
 
-    if (
-      objectMetadata.isCustom &&
-      !objectMetadata.targetTableName.startsWith('_')
-    ) {
-      issues.push({
-        type: WorkspaceHealthIssueType.MISSING_TABLE,
-        objectMetadata,
-        message: `Table ${objectMetadata.targetTableName} is marked as custom but doesn't start with "_"`,
-      });
-
-      return issues;
-    }
-
     if (!tableExist) {
       issues.push({
         type: WorkspaceHealthIssueType.MISSING_TABLE,
@@ -48,9 +67,33 @@ export class ObjectMetadataHealthService {
       return issues;
     }
 
+    return issues;
+  }
+
+  /**
+   * Check ObjectMetadata health
+   * @param objectMetadata
+   * @returns WorkspaceHealthIssue[]
+   */
+  private async metadataObjectCheck(
+    objectMetadata: ObjectMetadataEntity,
+  ): Promise<WorkspaceHealthIssue[]> {
+    const issues: WorkspaceHealthIssue[] = [];
+
+    if (
+      objectMetadata.isCustom &&
+      !objectMetadata.targetTableName.startsWith('_')
+    ) {
+      issues.push({
+        type: WorkspaceHealthIssueType.TABLE_NAME_SHOULD_BE_CUSTOM,
+        objectMetadata,
+        message: `Table ${objectMetadata.targetTableName} is marked as custom but doesn't start with "_"`,
+      });
+    }
+
     if (!objectMetadata.targetTableName) {
       issues.push({
-        type: WorkspaceHealthIssueType.TABLE_CONFLICT,
+        type: WorkspaceHealthIssueType.TABLE_TARGET_TABLE_NAME_NOT_VALID,
         objectMetadata,
         message: `Table ${objectMetadata.targetTableName} doesn't have a valid target table name`,
       });
@@ -58,7 +101,7 @@ export class ObjectMetadataHealthService {
 
     if (!objectMetadata.dataSourceId) {
       issues.push({
-        type: WorkspaceHealthIssueType.TABLE_CONFLICT,
+        type: WorkspaceHealthIssueType.TABLE_DATA_SOURCE_ID_NOT_VALID,
         objectMetadata,
         message: `Table ${objectMetadata.targetTableName} doesn't have a data source`,
       });
@@ -73,7 +116,7 @@ export class ObjectMetadataHealthService {
       !objectMetadata.labelPlural
     ) {
       issues.push({
-        type: WorkspaceHealthIssueType.TABLE_CONFLICT,
+        type: WorkspaceHealthIssueType.TABLE_NAME_NOT_VALID,
         objectMetadata,
         message: `Table ${objectMetadata.targetTableName} doesn't have a valid name or label`,
       });

--- a/packages/twenty-server/src/workspace/workspace-health/services/object-metadata-health.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/services/object-metadata-health.service.ts
@@ -1,0 +1,84 @@
+import { Injectable } from '@nestjs/common';
+
+import {
+  WorkspaceHealthIssue,
+  WorkspaceHealthIssueType,
+} from 'src/workspace/workspace-health/interfaces/workspace-health-issue.interface';
+
+import { ObjectMetadataEntity } from 'src/metadata/object-metadata/object-metadata.entity';
+import { validName } from 'src/workspace/workspace-health/utils/valid-name.util';
+import { TypeORMService } from 'src/database/typeorm/typeorm.service';
+
+@Injectable()
+export class ObjectMetadataHealthService {
+  constructor(private readonly typeORMService: TypeORMService) {}
+
+  async heathCheck(
+    schemaName: string,
+    objectMetadata: ObjectMetadataEntity,
+  ): Promise<WorkspaceHealthIssue[]> {
+    const mainDataSource = this.typeORMService.getMainDataSource();
+    const issues: WorkspaceHealthIssue[] = [];
+
+    // Check if the table exist in database
+    const tableExist = await mainDataSource.query(
+      `SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_schema = '${schemaName}' AND table_name = '${objectMetadata.targetTableName}')`,
+    );
+
+    if (
+      objectMetadata.isCustom &&
+      !objectMetadata.targetTableName.startsWith('_')
+    ) {
+      issues.push({
+        type: WorkspaceHealthIssueType.MISSING_TABLE,
+        objectMetadata,
+        message: `Table ${objectMetadata.targetTableName} is marked as custom but doesn't start with "_"`,
+      });
+
+      return issues;
+    }
+
+    if (!tableExist) {
+      issues.push({
+        type: WorkspaceHealthIssueType.MISSING_TABLE,
+        objectMetadata,
+        message: `Table ${objectMetadata.targetTableName} not found in schema ${schemaName}`,
+      });
+
+      return issues;
+    }
+
+    if (!objectMetadata.targetTableName) {
+      issues.push({
+        type: WorkspaceHealthIssueType.TABLE_CONFLICT,
+        objectMetadata,
+        message: `Table ${objectMetadata.targetTableName} doesn't have a valid target table name`,
+      });
+    }
+
+    if (!objectMetadata.dataSourceId) {
+      issues.push({
+        type: WorkspaceHealthIssueType.TABLE_CONFLICT,
+        objectMetadata,
+        message: `Table ${objectMetadata.targetTableName} doesn't have a data source`,
+      });
+    }
+
+    if (
+      !objectMetadata.nameSingular ||
+      !objectMetadata.namePlural ||
+      !validName(objectMetadata.nameSingular) ||
+      !validName(objectMetadata.namePlural) ||
+      !objectMetadata.labelSingular ||
+      !objectMetadata.labelPlural
+    ) {
+      issues.push({
+        type: WorkspaceHealthIssueType.TABLE_CONFLICT,
+        objectMetadata,
+        message: `Table ${objectMetadata.targetTableName} doesn't have a valid name or label`,
+      });
+    }
+
+    return issues;
+  }
+}

--- a/packages/twenty-server/src/workspace/workspace-health/services/object-metadata-health.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/services/object-metadata-health.service.ts
@@ -31,7 +31,7 @@ export class ObjectMetadataHealthService {
     }
 
     if (options.mode === 'metadata' || options.mode === 'all') {
-      const metadataIssues = await this.metadataObjectCheck(objectMetadata);
+      const metadataIssues = this.metadataObjectCheck(objectMetadata);
 
       issues.push(...metadataIssues);
     }
@@ -75,9 +75,9 @@ export class ObjectMetadataHealthService {
    * @param objectMetadata
    * @returns WorkspaceHealthIssue[]
    */
-  private async metadataObjectCheck(
+  private metadataObjectCheck(
     objectMetadata: ObjectMetadataEntity,
-  ): Promise<WorkspaceHealthIssue[]> {
+  ): WorkspaceHealthIssue[] {
     const issues: WorkspaceHealthIssue[] = [];
 
     if (

--- a/packages/twenty-server/src/workspace/workspace-health/utils/map-field-metadata-type-to-data-type.util.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/utils/map-field-metadata-type-to-data-type.util.ts
@@ -1,0 +1,34 @@
+import { ConflictException } from '@nestjs/common';
+
+import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
+
+export const mapFieldMetadataTypeToDataType = (
+  fieldMetadataType: FieldMetadataType,
+): string => {
+  switch (fieldMetadataType) {
+    case FieldMetadataType.UUID:
+      return 'uuid';
+    case FieldMetadataType.TEXT:
+      return 'text';
+    case FieldMetadataType.PHONE:
+    case FieldMetadataType.EMAIL:
+      return 'varchar';
+    case FieldMetadataType.NUMERIC:
+      return 'numeric';
+    case FieldMetadataType.NUMBER:
+    case FieldMetadataType.PROBABILITY:
+      return 'double precision';
+    case FieldMetadataType.BOOLEAN:
+      return 'boolean';
+    case FieldMetadataType.DATE_TIME:
+      return 'timestamp';
+    case FieldMetadataType.RATING:
+    case FieldMetadataType.SELECT:
+    case FieldMetadataType.MULTI_SELECT:
+      return 'enum';
+    default:
+      throw new ConflictException(
+        `Cannot convert ${fieldMetadataType} to data type.`,
+      );
+  }
+};

--- a/packages/twenty-server/src/workspace/workspace-health/utils/valid-name.util.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/utils/valid-name.util.ts
@@ -1,0 +1,3 @@
+export const validName = (name: string): boolean => {
+  return /^[a-zA-Z0-9_]+$/.test(name);
+};

--- a/packages/twenty-server/src/workspace/workspace-health/workspace-health.module.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/workspace-health.module.ts
@@ -1,0 +1,27 @@
+import { Module } from '@nestjs/common';
+
+import { TypeORMModule } from 'src/database/typeorm/typeorm.module';
+import { DataSourceModule } from 'src/metadata/data-source/data-source.module';
+import { ObjectMetadataModule } from 'src/metadata/object-metadata/object-metadata.module';
+import { WorkspaceDataSourceModule } from 'src/workspace/workspace-datasource/workspace-datasource.module';
+import { DatabaseStructureService } from 'src/workspace/workspace-health/services/database-structure.service';
+import { FieldMetadataHealthService } from 'src/workspace/workspace-health/services/field-metadata-health.service';
+import { ObjectMetadataHealthService } from 'src/workspace/workspace-health/services/object-metadata-health.service';
+import { WorkspaceHealthService } from 'src/workspace/workspace-health/workspace-health.service';
+
+@Module({
+  imports: [
+    DataSourceModule,
+    TypeORMModule,
+    ObjectMetadataModule,
+    WorkspaceDataSourceModule,
+  ],
+  providers: [
+    WorkspaceHealthService,
+    DatabaseStructureService,
+    ObjectMetadataHealthService,
+    FieldMetadataHealthService,
+  ],
+  exports: [WorkspaceHealthService],
+})
+export class WorkspaceHealthModule {}

--- a/packages/twenty-server/src/workspace/workspace-health/workspace-health.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/workspace-health.service.ts
@@ -1,0 +1,75 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+
+import { WorkspaceHealthIssue } from 'src/workspace/workspace-health/interfaces/workspace-health-issue.interface';
+
+import { TypeORMService } from 'src/database/typeorm/typeorm.service';
+import { DataSourceService } from 'src/metadata/data-source/data-source.service';
+import { ObjectMetadataService } from 'src/metadata/object-metadata/object-metadata.service';
+import { WorkspaceDataSourceService } from 'src/workspace/workspace-datasource/workspace-datasource.service';
+import { ObjectMetadataHealthService } from 'src/workspace/workspace-health/services/object-metadata-health.service';
+import { FieldMetadataHealthService } from 'src/workspace/workspace-health/services/field-metadata-health.service';
+
+@Injectable()
+export class WorkspaceHealthService {
+  constructor(
+    private readonly dataSourceService: DataSourceService,
+    private readonly typeORMService: TypeORMService,
+    private readonly objectMetadataService: ObjectMetadataService,
+    private readonly workspaceDataSourceService: WorkspaceDataSourceService,
+    private readonly objectMetadataHealthService: ObjectMetadataHealthService,
+    private readonly fieldMetadataHealthService: FieldMetadataHealthService,
+  ) {}
+
+  async healthCheck(workspaceId: string): Promise<void> {
+    const schemaName =
+      this.workspaceDataSourceService.getSchemaName(workspaceId);
+    const issues: WorkspaceHealthIssue[] = [];
+
+    const dataSourceMetadata =
+      await this.dataSourceService.getLastDataSourceMetadataFromWorkspaceIdOrFail(
+        workspaceId,
+      );
+
+    // Check if a data source exists for this workspace
+    if (!dataSourceMetadata) {
+      throw new NotFoundException(
+        `Datasource for workspace id ${workspaceId} not found`,
+      );
+    }
+
+    // Try to connect to the data source
+    await this.typeORMService.connectToDataSource(dataSourceMetadata);
+
+    const objectMetadataCollection =
+      await this.objectMetadataService.findManyWithinWorkspace(workspaceId);
+
+    // Check if object metadata exists for this workspace
+    if (!objectMetadataCollection || objectMetadataCollection.length === 0) {
+      throw new NotFoundException(`Workspace with id ${workspaceId} not found`);
+    }
+
+    for (const objectMetadata of objectMetadataCollection) {
+      // Check health of the object
+      const objectIssues = await this.objectMetadataHealthService.heathCheck(
+        schemaName,
+        objectMetadata,
+      );
+
+      issues.push(...objectIssues);
+
+      // Check health of the fields
+      const fieldIssues =
+        await this.fieldMetadataHealthService.healthCheckFields(
+          schemaName,
+          objectMetadata.targetTableName,
+          objectMetadata.fields,
+        );
+
+      issues.push(...fieldIssues);
+    }
+
+    console.log('ISSUES: ', JSON.stringify(issues, null, 2));
+
+    return;
+  }
+}


### PR DESCRIPTION
**Introducing the `workspace:health` Command**

In this PR, we're introducing a new command: `workspace:health`. This command is designed to assess the health of a specified workspace by examining its metadata and database structure. 

### Key Features
- **Comprehensive Validation**: Ensures each object corresponds to a table, each field aligns with a database column, and all metadata are valid based on their types.
- **Flexible Modes**: Offers different levels of checking, including structure, metadata, or both.
- **Verbose Output Option**: Provides detailed issue reporting for in-depth analysis.

### How It Works
Run this command in your terminal as follows:

```sh
$ yarn command workspace:health --workspace-id 20202020-1c25-4d02-bf25-6aeccf7ea419
```

### Customizable Parameters
- **Mode Selection** (`-m, --mode [all | structure | metadata]`):
  - `all`: Checks both structure and metadata.
  - `structure`: Focuses on the database table structure based on metadata.
  - `metadata`: Concentrates on the validity of metadata.

- **Verbose Output** (`-v, --verbose`):
  - When enabled, displays detailed information about all detected issues within the terminal. If not used, only a brief summary message is shown.

### Warning

**Relations are not yet checked**