### PR TITLE
Fixed I shouldn't be able to remove myself from a workspace #3330

### DIFF
--- a/packages/twenty-front/src/pages/settings/SettingsWorkspaceMembers.tsx
+++ b/packages/twenty-front/src/pages/settings/SettingsWorkspaceMembers.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import styled from '@emotion/styled';
 import { useRecoilValue } from 'recoil';
 
+import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
 import { useDeleteOneRecord } from '@/object-record/hooks/useDeleteOneRecord';
@@ -17,7 +18,6 @@ import { Section } from '@/ui/layout/section/components/Section';
 import { WorkspaceInviteLink } from '@/workspace/components/WorkspaceInviteLink';
 import { WorkspaceMemberCard } from '@/workspace/components/WorkspaceMemberCard';
 import { WorkspaceMember } from '@/workspace-member/types/WorkspaceMember';
-import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
 
 const StyledH1Title = styled(H1Title)`
   margin-bottom: 0;
@@ -45,7 +45,6 @@ export const SettingsWorkspaceMembers = () => {
     });
   const currentWorkspace = useRecoilValue(currentWorkspaceState);
   const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
-
 
   const handleRemoveWorkspaceMember = async (workspaceMemberId: string) => {
     await deleteOneWorkspaceMember?.(workspaceMemberId);

--- a/packages/twenty-front/src/pages/settings/SettingsWorkspaceMembers.tsx
+++ b/packages/twenty-front/src/pages/settings/SettingsWorkspaceMembers.tsx
@@ -17,6 +17,7 @@ import { Section } from '@/ui/layout/section/components/Section';
 import { WorkspaceInviteLink } from '@/workspace/components/WorkspaceInviteLink';
 import { WorkspaceMemberCard } from '@/workspace/components/WorkspaceMemberCard';
 import { WorkspaceMember } from '@/workspace-member/types/WorkspaceMember';
+import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
 
 const StyledH1Title = styled(H1Title)`
   margin-bottom: 0;
@@ -43,6 +44,8 @@ export const SettingsWorkspaceMembers = () => {
       objectNameSingular: CoreObjectNameSingular.WorkspaceMember,
     });
   const currentWorkspace = useRecoilValue(currentWorkspaceState);
+  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+
 
   const handleRemoveWorkspaceMember = async (workspaceMemberId: string) => {
     await deleteOneWorkspaceMember?.(workspaceMemberId);
@@ -74,7 +77,7 @@ export const SettingsWorkspaceMembers = () => {
               key={member.id}
               workspaceMember={member as WorkspaceMember}
               accessory={
-                currentWorkspace?.id !== member.id && (
+                currentWorkspaceMember?.id !== member.id && (
                   <StyledButtonContainer>
                     <IconButton
                       onClick={() => {


### PR DESCRIPTION
Addresses issue 3330

- Correct the conditional rendering of the delete user button. 

- Hides the button (trash icon) if the currentWorkspaceUser ID matches the listed member ID in the WorkspaceMemberCard