### PR TITLE
Fix metadata exception handler #2

### DIFF
--- a/packages/twenty-server/src/filters/utils/global-exception-handler.util.ts
+++ b/packages/twenty-server/src/filters/utils/global-exception-handler.util.ts
@@ -1,7 +1,5 @@
 import { HttpException } from '@nestjs/common';
 
-import { TypeORMError } from 'typeorm';
-
 import {
   AuthenticationError,
   BaseGraphQLError,
@@ -29,12 +27,10 @@ export const handleException = (
   exception: Error,
   exceptionHandlerService: ExceptionHandlerService,
 ): void => {
-  if (
-    exception instanceof TypeORMError ||
-    (exception instanceof HttpException && exception.getStatus() >= 500)
-  ) {
-    exceptionHandlerService.captureException(exception);
+  if (exception instanceof HttpException && exception.getStatus() < 500) {
+    return;
   }
+  exceptionHandlerService.captureException(exception);
 };
 
 export const convertExceptionToGraphQLError = (

--- a/packages/twenty-server/src/integrations/exception-handler/drivers/sentry.driver.ts
+++ b/packages/twenty-server/src/integrations/exception-handler/drivers/sentry.driver.ts
@@ -11,7 +11,7 @@ export class ExceptionHandlerSentryDriver
 {
   constructor(options: ExceptionHandlerSentryDriverFactoryOptions['options']) {
     Sentry.init({
-      dsn: options.dns,
+      dsn: options.dsn,
       integrations: [
         // enable HTTP calls tracing
         new Sentry.Integrations.Http({ tracing: true }),

--- a/packages/twenty-server/src/integrations/exception-handler/exception-handler.module-factory.ts
+++ b/packages/twenty-server/src/integrations/exception-handler/exception-handler.module-factory.ts
@@ -25,7 +25,7 @@ export const exceptionHandlerModuleFactory = async (
       return {
         type: ExceptionHandlerDriver.Sentry,
         options: {
-          dns: environmentService.getSentryDSN() ?? '',
+          dsn: environmentService.getSentryDSN() ?? '',
           serverInstance: adapterHost.httpAdapter?.getInstance(),
           debug: environmentService.isDebugMode(),
         },

--- a/packages/twenty-server/src/integrations/exception-handler/interfaces/exception-handler.interface.ts
+++ b/packages/twenty-server/src/integrations/exception-handler/interfaces/exception-handler.interface.ts
@@ -8,7 +8,7 @@ export enum ExceptionHandlerDriver {
 export interface ExceptionHandlerSentryDriverFactoryOptions {
   type: ExceptionHandlerDriver.Sentry;
   options: {
-    dns: string;
+    dsn: string;
     serverInstance?: Router;
     debug?: boolean;
   };

--- a/packages/twenty-server/src/metadata/field-metadata/field-metadata.resolver.ts
+++ b/packages/twenty-server/src/metadata/field-metadata/field-metadata.resolver.ts
@@ -19,14 +19,10 @@ export class FieldMetadataResolver {
     @Args('input') input: CreateOneFieldMetadataInput,
     @AuthWorkspace() { id: workspaceId }: Workspace,
   ) {
-    try {
-      return this.fieldMetadataService.createOne({
-        ...input.field,
-        workspaceId,
-      });
-    } catch (error) {
-      console.log(error);
-    }
+    return this.fieldMetadataService.createOne({
+      ...input.field,
+      workspaceId,
+    });
   }
 
   @Mutation(() => FieldMetadataDTO)

--- a/packages/twenty-server/src/metadata/field-metadata/field-metadata.service.ts
+++ b/packages/twenty-server/src/metadata/field-metadata/field-metadata.service.ts
@@ -56,7 +56,7 @@ export class FieldMetadataService extends TypeOrmQueryService<FieldMetadataEntit
       );
 
     if (!objectMetadata) {
-      throw new Error('Object does not exist');
+      throw new NotFoundException('Object does not exist');
     }
 
     const fieldAlreadyExists = await this.fieldMetadataRepository.findOne({

--- a/packages/twenty-server/src/metadata/metadata.module-factory.ts
+++ b/packages/twenty-server/src/metadata/metadata.module-factory.ts
@@ -24,9 +24,9 @@ export const metadataModuleFactory = async (
           error.originalError,
           exceptionHandlerService,
         );
-      } else {
-        return maskError(error, message, isDev);
       }
+
+      return maskError(error, message, isDev);
     },
   },
 });

--- a/packages/twenty-server/src/metadata/metadata.module.ts
+++ b/packages/twenty-server/src/metadata/metadata.module.ts
@@ -6,6 +6,7 @@ import { YogaDriverConfig, YogaDriver } from '@graphql-yoga/nestjs';
 import { WorkspaceMigrationRunnerModule } from 'src/workspace/workspace-migration-runner/workspace-migration-runner.module';
 import { WorkspaceMigrationModule } from 'src/metadata/workspace-migration/workspace-migration.module';
 import { metadataModuleFactory } from 'src/metadata/metadata.module-factory';
+import { ExceptionHandlerService } from 'src/integrations/exception-handler/exception-handler.service';
 
 import { DataSourceModule } from './data-source/data-source.module';
 import { FieldMetadataModule } from './field-metadata/field-metadata.module';
@@ -15,7 +16,7 @@ import { RelationMetadataModule } from './relation-metadata/relation-metadata.mo
   imports: [
     GraphQLModule.forRootAsync<YogaDriverConfig>({
       driver: YogaDriver,
-      imports: [],
+      inject: [ExceptionHandlerService],
       useFactory: metadataModuleFactory,
     }),
     DataSourceModule,

--- a/packages/twenty-server/src/metadata/object-metadata/object-metadata.service.ts
+++ b/packages/twenty-server/src/metadata/object-metadata/object-metadata.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { FindManyOptions, FindOneOptions, Repository } from 'typeorm';
@@ -59,7 +59,7 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
       objectMetadataInput.nameSingular.toLowerCase() ===
       objectMetadataInput.namePlural.toLowerCase()
     ) {
-      throw new Error(
+      throw new BadRequestException(
         'The singular and plural name cannot be the same for an object',
       );
     }


### PR DESCRIPTION
## Context
Follow up https://github.com/twentyhq/twenty/pull/3335

The first fix was not working for metadata due to the ExceptionHandlerService not being injected in the module factory. This PR should fix this.
I also fixed a typo in the ExceptionHandlerSentryDriverFactoryOptions interface and changed a bit the logic of the global exception handler to capture all exceptions except httpExceptions with statusCode < 500. This means now not only HttpException >= 500 and typeORM exceptions but anything extending Error or Error itself should be captured.
Due to that change, I've checked metadata module to replace the different "throw new Error" accordingly. 

With our implementation of nestjs-query, all the logic lives inside a service instead of a resolver (which is automatically generated for us), including the validation logic. Ideally we should not throw http-related exceptions to 