### PR TITLE
Fix vite build config

### DIFF
--- a/packages/twenty-front/.eslintrc.cjs
+++ b/packages/twenty-front/.eslintrc.cjs
@@ -16,7 +16,6 @@ module.exports = {
     'mockServiceWorker.js',
     '**/generated*/*',
     '*config.*',
-    '**/*config.*',
     'build',
     'coverage',
     'storybook-static',

--- a/packages/twenty-front/.eslintrc.cjs
+++ b/packages/twenty-front/.eslintrc.cjs
@@ -1,4 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
+// eslint-disable-next-line
 const path = require('path');
 
 module.exports = {
@@ -16,6 +16,10 @@ module.exports = {
     'mockServiceWorker.js',
     '**/generated*/*',
     '*config.*',
+    '**/*config.*',
+    'build',
+    'coverage',
+    'storybook-static',
     '**/*config.js',
     'codegen*',
     'tsup.ui.index.tsx',

--- a/packages/twenty-front/.eslintrc.cjs
+++ b/packages/twenty-front/.eslintrc.cjs
@@ -15,6 +15,7 @@ module.exports = {
     'node_modules',
     'mockServiceWorker.js',
     '**/generated*/*',
+    'tsup.config.ts',
     'build',
     'coverage',
     'storybook-static',

--- a/packages/twenty-front/.eslintrc.cjs
+++ b/packages/twenty-front/.eslintrc.cjs
@@ -15,7 +15,6 @@ module.exports = {
     'node_modules',
     'mockServiceWorker.js',
     '**/generated*/*',
-    '*config.*',
     'build',
     'coverage',
     'storybook-static',

--- a/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableColumnDropdownMenu.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableColumnDropdownMenu.tsx
@@ -1,5 +1,4 @@
 import { FieldMetadata } from '@/object-record/field/types/FieldMetadata';
-import { BoardOptionsDropdownId } from '@/object-record/record-board/constants/BoardOptionsDropdownId';
 import { IconArrowLeft, IconArrowRight, IconEyeOff } from '@/ui/display/icon';
 import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/DropdownMenuItemsContainer';
 import { useDropdown } from '@/ui/layout/dropdown/hooks/useDropdown';
@@ -24,7 +23,7 @@ export const RecordTableColumnDropdownMenu = ({
   const { handleColumnVisibilityChange, handleMoveTableColumn } =
     useTableColumns();
 
-  const { closeDropdown } = useDropdown(BoardOptionsDropdownId);
+  const { closeDropdown } = useDropdown(column.fieldMetadataId + '-header');
 
   const handleColumnMoveLeft = () => {
     closeDropdown();

--- a/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableColumnDropdownMenu.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableColumnDropdownMenu.tsx
@@ -1,4 +1,5 @@
 import { FieldMetadata } from '@/object-record/field/types/FieldMetadata';
+import { BoardOptionsDropdownId } from '@/object-record/record-board/constants/BoardOptionsDropdownId';
 import { IconArrowLeft, IconArrowRight, IconEyeOff } from '@/ui/display/icon';
 import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/DropdownMenuItemsContainer';
 import { useDropdown } from '@/ui/layout/dropdown/hooks/useDropdown';
@@ -23,7 +24,7 @@ export const RecordTableColumnDropdownMenu = ({
   const { handleColumnVisibilityChange, handleMoveTableColumn } =
     useTableColumns();
 
-  const { closeDropdown } = useDropdown();
+  const { closeDropdown } = useDropdown(BoardOptionsDropdownId);
 
   const handleColumnMoveLeft = () => {
     closeDropdown();

--- a/packages/twenty-front/tsconfig.app.json
+++ b/packages/twenty-front/tsconfig.app.json
@@ -9,7 +9,6 @@
     "**/*.spec.tsx",
     "**/*.test.tsx",
     "jest.config.ts",
-    "vite.config.ts",
     "tsup.config.ts"
   ],
   "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]

--- a/packages/twenty-front/tsconfig.app.json
+++ b/packages/twenty-front/tsconfig.app.json
@@ -9,6 +9,7 @@
     "**/*.spec.tsx",
     "**/*.test.tsx",
     "jest.config.ts",
+    "vite.config.ts",
     "tsup.config.ts"
   ],
   "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]

--- a/packages/twenty-front/vite.config.ts
+++ b/packages/twenty-front/vite.config.ts
@@ -3,7 +3,6 @@ import react from '@vitejs/plugin-react-swc';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import svgr from 'vite-plugin-svgr';
 import checker from 'vite-plugin-checker'
-import { plugins } from '@swc/core';
 
 // https://vitejs.dev/config/
 export default defineConfig(({ command, mode }) => {

--- a/packages/twenty-front/vite.config.ts
+++ b/packages/twenty-front/vite.config.ts
@@ -4,6 +4,15 @@ import tsconfigPaths from 'vite-tsconfig-paths';
 import svgr from 'vite-plugin-svgr';
 import checker from 'vite-plugin-checker'
 
+type Checkers = {
+  typescript: {
+    tsconfigPath: string
+  },
+  eslint?: {
+    lintCommand: string
+  }
+}
+
 // https://vitejs.dev/config/
 export default defineConfig(({ command, mode }) => {
   const env = loadEnv(mode, process.cwd(), '')
@@ -15,16 +24,16 @@ export default defineConfig(({ command, mode }) => {
     REACT_APP_SERVER_BASE_URL,
   } = env;
 
-  let checkers = {};
+  let checkers = {
+    typescript: {
+      tsconfigPath: "tsconfig.app.json"
+    },
+  }
+
   if (command === 'serve') {
-    checkers = {
-      typescript: {
-        tsconfigPath: "tsconfig.app.json"
-      },
-      eslint: {
-        lintCommand:
-          "eslint . --report-unused-disable-directives --max-warnings 0 --config .eslintrc.cjs"
-      }
+    checkers['eslint']= {
+      lintCommand:
+        "eslint . --report-unused-disable-directives --max-warnings 0 --config .eslintrc.cjs"
     }
   }
 

--- a/packages/twenty-front/vite.config.ts
+++ b/packages/twenty-front/vite.config.ts
@@ -3,9 +3,10 @@ import react from '@vitejs/plugin-react-swc';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import svgr from 'vite-plugin-svgr';
 import checker from 'vite-plugin-checker'
+import { plugins } from '@swc/core';
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode }) => {
+export default defineConfig(({ command, mode }) => {
   const env = loadEnv(mode, process.cwd(), '')
 
   /*
@@ -15,18 +16,24 @@ export default defineConfig(({ mode }) => {
     REACT_APP_SERVER_BASE_URL,
   } = env;
 
+  let checkers = {
+    typescript: {
+      tsconfigPath: "tsconfig.app.json"
+    },
+  }
+
+  if (command === 'serve') {
+    checkers['eslint'] = {
+      lintCommand: 
+        "eslint . --report-unused-disable-directives --max-warnings 0 --config .eslintrc.cjs"
+    }
+  }
+
   const plugins = [
     react({ jsxImportSource: "@emotion/react" }),
     tsconfigPaths(),
     svgr(),
-    checker({
-      typescript: {
-        tsconfigPath: "tsconfig.app.json"
-      },
-      eslint: {
-        lintCommand: "eslint . --report-unused-disable-directives --max-warnings 0 --config .eslintrc.cjs",
-      }
-    }),
+    checker(checkers),
   ]
 
   return {

--- a/packages/twenty-front/vite.config.ts
+++ b/packages/twenty-front/vite.config.ts
@@ -16,16 +16,16 @@ export default defineConfig(({ command, mode }) => {
     REACT_APP_SERVER_BASE_URL,
   } = env;
 
-  let checkers = {
-    typescript: {
-      tsconfigPath: "tsconfig.app.json"
-    },
-  }
-
+  let checkers;
   if (command === 'serve') {
-    checkers['eslint'] = {
-      lintCommand: 
-        "eslint . --report-unused-disable-directives --max-warnings 0 --config .eslintrc.cjs"
+    checkers = {
+      typescript: {
+        tsconfigPath: "tsconfig.app.json"
+      },
+      eslint: {
+        lintCommand:
+          "eslint . --report-unused-disable-directives --max-warnings 0 --config .eslintrc.cjs"
+      }
     }
   }
 

--- a/packages/twenty-front/vite.config.ts
+++ b/packages/twenty-front/vite.config.ts
@@ -24,7 +24,7 @@ export default defineConfig(({ command, mode }) => {
     REACT_APP_SERVER_BASE_URL,
   } = env;
 
-  let checkers = {
+  let checkers: Checkers = {
     typescript: {
       tsconfigPath: "tsconfig.app.json"
     },

--- a/packages/twenty-front/vite.config.ts
+++ b/packages/twenty-front/vite.config.ts
@@ -1,64 +1,64 @@
-import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react-swc';
-import tsconfigPaths from 'vite-tsconfig-paths';
+import { defineConfig, loadEnv } from 'vite';
+import checker from 'vite-plugin-checker';
 import svgr from 'vite-plugin-svgr';
-import checker from 'vite-plugin-checker'
+import tsconfigPaths from 'vite-tsconfig-paths';
 
 type Checkers = {
   typescript: {
-    tsconfigPath: string
-  },
+    tsconfigPath: string;
+  };
   eslint?: {
-    lintCommand: string
-  }
-}
+    lintCommand: string;
+  };
+};
 
 // https://vitejs.dev/config/
 export default defineConfig(({ command, mode }) => {
-  const env = loadEnv(mode, process.cwd(), '')
+  const env = loadEnv(mode, process.cwd(), '');
 
   /*
     Using explicit env variables, there is no need to expose all of them (security).
   */
-  const {
-    REACT_APP_SERVER_BASE_URL,
-  } = env;
+  const { REACT_APP_SERVER_BASE_URL } = env;
 
-  let checkers: Checkers = {
+  const isBuildCommand = command === 'build';
+
+  const checkers: Checkers = {
     typescript: {
-      tsconfigPath: "tsconfig.app.json"
+      tsconfigPath: 'tsconfig.app.json',
     },
-  }
+  };
 
-  if (command === 'serve') {
-    checkers['eslint']= {
+  if (!isBuildCommand) {
+    checkers['eslint'] = {
       lintCommand:
-        "eslint . --report-unused-disable-directives --max-warnings 0 --config .eslintrc.cjs"
-    }
+        'eslint . --report-unused-disable-directives --max-warnings 0 --config .eslintrc.cjs',
+    };
   }
 
   const plugins = [
-    react({ jsxImportSource: "@emotion/react" }),
+    react({ jsxImportSource: '@emotion/react' }),
     tsconfigPaths(),
     svgr(),
     checker(checkers),
-  ]
+  ];
 
   return {
     // base: ,
     envPrefix: 'REACT_APP_',
     build: {
       outDir: 'build',
-    },      
+    },
     plugins,
     server: {
       // open: true,
       port: 3001,
     },
     define: {
-      "process.env": {
+      'process.env': {
         REACT_APP_SERVER_BASE_URL,
-      }
-    },  
-  }
+      },
+    },
+  };
 });

--- a/packages/twenty-front/vite.config.ts
+++ b/packages/twenty-front/vite.config.ts
@@ -4,14 +4,7 @@ import checker from 'vite-plugin-checker';
 import svgr from 'vite-plugin-svgr';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
-type Checkers = {
-  typescript: {
-    tsconfigPath: string;
-  };
-  eslint?: {
-    lintCommand: string;
-  };
-};
+type Checkers = Parameters<typeof checker>[0];
 
 // https://vitejs.dev/config/
 export default defineConfig(({ command, mode }) => {

--- a/packages/twenty-front/vite.config.ts
+++ b/packages/twenty-front/vite.config.ts
@@ -15,7 +15,7 @@ export default defineConfig(({ command, mode }) => {
     REACT_APP_SERVER_BASE_URL,
   } = env;
 
-  let checkers;
+  let checkers = {};
   if (command === 'serve') {
     checkers = {
       typescript: {


### PR DESCRIPTION
This PR fixes vite config that was breaking vite build. The following PR: #3289 added lint check on vite run. However, this lint run is hanging which is not suitable for build mode.

Dev mode (serve):
<img width="895" alt="image" src="https://github.com/twentyhq/twenty/assets/12035771/ef28e489-dc53-4bf1-9c31-99da2e07f92a">
