### PR TITLE
Add tests for `modules/object-record/object-sort-dropdown`

### DIFF
--- a/packages/twenty-front/src/modules/object-record/object-sort-dropdown/hooks/__tests__/useSortDropdown.test.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-sort-dropdown/hooks/__tests__/useSortDropdown.test.tsx
@@ -1,0 +1,94 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { RecoilRoot } from 'recoil';
+
+import { useSortDropdown } from '@/object-record/object-sort-dropdown/hooks/useSortDropdown';
+import { Sort } from '@/object-record/object-sort-dropdown/types/Sort';
+import { SortDefinition } from '@/object-record/object-sort-dropdown/types/SortDefinition';
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <RecoilRoot>{children}</RecoilRoot>
+);
+
+const sortDropdownId = 'sortDropdownId';
+const renderHookConfig = {
+  wrapper: Wrapper,
+};
+
+const sortDefinitions: SortDefinition[] = [
+  { fieldMetadataId: 'id', label: 'definition label', iconName: 'icon' },
+];
+
+describe('useSortDropdown', () => {
+  it('should set availableSortDefinitions', () => {
+    const { result } = renderHook(
+      () => useSortDropdown({ sortDropdownId }),
+      renderHookConfig,
+    );
+    expect(result.current.availableSortDefinitions).toEqual([]);
+    act(() => {
+      result.current.setAvailableSortDefinitions(sortDefinitions);
+    });
+
+    waitFor(() => {
+      expect(result.current.availableSortDefinitions).toEqual(sortDefinitions);
+    });
+  });
+
+  it('should set isSortSelected', () => {
+    const { result } = renderHook(
+      () => useSortDropdown({ sortDropdownId }),
+      renderHookConfig,
+    );
+
+    expect(result.current.isSortSelected).toBe(false);
+
+    act(() => {
+      result.current.setIsSortSelected(true);
+    });
+
+    waitFor(() => {
+      expect(result.current.isSortSelected).toBe(true);
+    });
+  });
+
+  it('should set onSortSelect', () => {
+    const mockOnSortSelect = jest.fn();
+    const { result } = renderHook(
+      () => useSortDropdown({ sortDropdownId }),
+      renderHookConfig,
+    );
+
+    expect(result.current.onSortSelect).toBeUndefined();
+
+    act(() => {
+      result.current.setOnSortSelect(mockOnSortSelect);
+    });
+
+    waitFor(() => {
+      expect(result.current.onSortSelect).toBe(mockOnSortSelect);
+    });
+  });
+
+  it('should call onSortSelect when a sort option is selected', () => {
+    const mockOnSortSelect = jest.fn();
+    const sort: Sort = {
+      fieldMetadataId: 'id',
+      direction: 'asc',
+      definition: sortDefinitions[0],
+    };
+
+    const { result } = renderHook(
+      () => useSortDropdown({ sortDropdownId }),
+      renderHookConfig,
+    );
+
+    act(() => {
+      result.current.setOnSortSelect(mockOnSortSelect);
+      result.current.onSortSelect?.(sort);
+    });
+
+    waitFor(() => {
+      expect(mockOnSortSelect).toHaveBeenCalledWith(sort);
+    });
+  });
+});

--- a/packages/twenty-front/src/modules/object-record/object-sort-dropdown/utils/__tests__/turnSortsIntoOrderBy.test.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-sort-dropdown/utils/__tests__/turnSortsIntoOrderBy.test.tsx
@@ -1,0 +1,79 @@
+import { Sort } from '@/object-record/object-sort-dropdown/types/Sort';
+import { SortDefinition } from '@/object-record/object-sort-dropdown/types/SortDefinition';
+import { turnSortsIntoOrderBy } from '@/object-record/object-sort-dropdown/utils/turnSortsIntoOrderBy';
+
+const sortDefinition: SortDefinition = {
+  fieldMetadataId: 'id',
+  label: 'definition label',
+  iconName: 'icon',
+};
+
+describe('turnSortsIntoOrderBy', () => {
+  it('should sort by createdAt if no sorts and createdAt field exists', () => {
+    const fields = [{ id: 'field1', name: 'createdAt' }];
+    expect(turnSortsIntoOrderBy([], fields)).toEqual({
+      createdAt: 'DescNullsFirst',
+    });
+  });
+
+  it('should return empty OrderByField if no sorts and no createdAt field', () => {
+    expect(turnSortsIntoOrderBy([], [])).toEqual({});
+  });
+
+  it('should sort by first field if no sorts and createdAt field do not exists', () => {
+    const fields = [{ id: 'field1', name: 'field1' }];
+    expect(turnSortsIntoOrderBy([], fields)).toEqual({
+      field1: 'DescNullsFirst',
+    });
+  });
+
+  it('should create OrderByField with single sort', () => {
+    const sorts: Sort[] = [
+      {
+        fieldMetadataId: 'field1',
+        direction: 'asc',
+        definition: sortDefinition,
+      },
+    ];
+    const fields = [{ id: 'field1', name: 'field1' }];
+    expect(turnSortsIntoOrderBy(sorts, fields)).toEqual({
+      field1: 'AscNullsFirst',
+    });
+  });
+
+  it('should create OrderByField with multiple sorts', () => {
+    const sorts: Sort[] = [
+      {
+        fieldMetadataId: 'field1',
+        direction: 'asc',
+        definition: sortDefinition,
+      },
+      {
+        fieldMetadataId: 'field2',
+        direction: 'desc',
+        definition: sortDefinition,
+      },
+    ];
+    const fields = [
+      { id: 'field1', name: 'field1' },
+      { id: 'field2', name: 'field2' },
+    ];
+    expect(turnSortsIntoOrderBy(sorts, fields)).toEqual({
+      field1: 'AscNullsFirst',
+      field2: 'DescNullsLast',
+    });
+  });
+
+  it('should throw error if field not found', () => {
+    const sorts: Sort[] = [
+      {
+        fieldMetadataId: 'invalidField',
+        direction: 'asc',
+        definition: sortDefinition,
+      },
+    ];
+    expect(() => turnSortsIntoOrderBy(sorts, [])).toThrow(
+      'Could not find field invalidField in metadata object',
+    );
+  });
+});


### PR DESCRIPTION
### COVERAGE RESULTS
![295685151-e916cea7-ebcf-4e09-a0cb-96fcf10fc8d0](https://github.com/twentyhq/twenty/assets/140154534/77fb0b82-6e27-418d-9522-9de496e59d1b)

Fixes #3325

