### PR TITLE
fix: fixed overflowing text on record show page

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellContainer.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellContainer.tsx
@@ -36,6 +36,7 @@ const StyledLabelAndIconContainer = styled.div`
 
 const StyledValueContainer = styled.div`
   display: flex;
+  overflow: hidden;
 `;
 
 const StyledLabel = styled.div<

--- a/packages/twenty-front/src/modules/object-record/record-inline-cell/property-box/components/PropertyBox.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-inline-cell/property-box/components/PropertyBox.tsx
@@ -9,6 +9,7 @@ const StyledPropertyBoxContainer = styled.div`
   flex-direction: column;
   gap: ${({ theme }) => theme.spacing(2)};
   padding: ${({ theme }) => theme.spacing(3)};
+  overflow: hidden;
 `;
 
 interface PropertyBoxProps {


### PR DESCRIPTION
fixed overflowing text on record show page closes #3300 
![Screenshot from 2024-01-11 18-20-15](https://github.com/twentyhq/twenty/assets/70434968/e475b542-8028-4256-a745-e76824b1bd0d)
