### PR TITLE
Fix Docker Volume Persistence Issue (#3364)

### DIFF
--- a/packages/twenty-docker/Makefile
+++ b/packages/twenty-docker/Makefile
@@ -10,6 +10,7 @@ dev-build:
 	@docker compose -f dev/docker-compose.yml build
 
 dev-up:
+	@docker volume create twenty_db_data
 	@docker compose -f dev/docker-compose.yml up -d
 
 dev-down:

--- a/packages/twenty-docker/dev/docker-compose.yml
+++ b/packages/twenty-docker/dev/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - "5432:5432"
 volumes:
   twenty_db_data:
-    name: twenty_db_data
+    external: true
   twenty_dev_node_modules_root:
   twenty_dev_node_modules_docs:
   twenty_dev_node_modules_eslint:


### PR DESCRIPTION
### Issue
Closes #3364 

The current Docker configuration is not persisting the database volume when containers are turned down, leading to the need for repeated database initialization during development. This can be cumbersome for developers.

### Changes Made
Updated the `docker-compose.yaml` file to ensure that the `twenty_db_data` volume persists even when containers are turned down. Additionally, modified the Makefile to include the creation of the volume before running `docker-compose up`. This ensures that the database volume is retained across container restarts, streamlining the development workflow.


This fix addresses the reported issue and enhances the development experience by maintaining the persistence of the database volume.