### PR TITLE
feat: pagination with total count

### DIFF
--- a/packages/twenty-server/src/database/commands/database-command.module.ts
+++ b/packages/twenty-server/src/database/commands/database-command.module.ts
@@ -10,6 +10,7 @@ import { DataSeedDemoWorkspaceCommand } from 'src/database/commands/data-seed-de
 import { WorkspaceDataSourceModule } from 'src/workspace/workspace-datasource/workspace-datasource.module';
 import { WorkspaceSyncMetadataModule } from 'src/workspace/workspace-sync-metadata/workspace-sync-metadata.module';
 import { ObjectMetadataModule } from 'src/metadata/object-metadata/object-metadata.module';
+import { WorkspaceAddTotalCountCommand } from 'src/database/commands/workspace-add-total-count.command';
 
 @Module({
   imports: [
@@ -24,6 +25,7 @@ import { ObjectMetadataModule } from 'src/metadata/object-metadata/object-metada
   providers: [
     DataSeedWorkspaceCommand,
     DataSeedDemoWorkspaceCommand,
+    WorkspaceAddTotalCountCommand,
     ConfirmationQuestion,
   ],
 })

--- a/packages/twenty-server/src/database/commands/workspace-add-total-count.command.ts
+++ b/packages/twenty-server/src/database/commands/workspace-add-total-count.command.ts
@@ -1,0 +1,49 @@
+import { Command, CommandRunner } from 'nest-commander';
+import chalk from 'chalk';
+
+import { TypeORMService } from 'src/database/typeorm/typeorm.service';
+
+@Command({
+  name: 'workspace:add-total-count',
+  description: 'Add pg_graphql total count directive to all workspace tables',
+})
+export class WorkspaceAddTotalCountCommand extends CommandRunner {
+  constructor(private readonly typeORMService: TypeORMService) {
+    super();
+  }
+
+  async run(): Promise<void> {
+    const mainDataSource = this.typeORMService.getMainDataSource();
+
+    try {
+      await mainDataSource.query(`
+        DO $$
+        DECLARE
+            schema_cursor CURSOR FOR SELECT schema_name FROM information_schema.schemata WHERE schema_name LIKE 'workspace_%';
+            schema_name text;
+            table_rec record;
+        BEGIN
+            OPEN schema_cursor;
+            LOOP
+                FETCH schema_cursor INTO schema_name;
+                EXIT WHEN NOT FOUND;
+                
+                FOR table_rec IN SELECT t.table_name FROM information_schema.tables t WHERE t.table_schema = schema_name
+                LOOP
+                    EXECUTE 'COMMENT ON TABLE ' || quote_ident(schema_name) || '.' || quote_ident(table_rec.table_name) || ' IS e''@graphql({"totalCount": {"enabled": true}})'';';
+                END LOOP;
+            END LOOP;
+            CLOSE schema_cursor;
+        END $$;    
+      `);
+
+      console.log(
+        chalk.green('Total count directive added to all workspace tables'),
+      );
+    } catch (error) {
+      console.log(
+        chalk.red('Error adding total count directive to all workspace tables'),
+      );
+    }
+  }
+}

--- a/packages/twenty-server/src/workspace/workspace-migration-runner/workspace-migration-runner.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-migration-runner/workspace-migration-runner.service.ts
@@ -140,6 +140,11 @@ export class WorkspaceMigrationRunnerService {
       }),
       true,
     );
+
+    // Enable totalCount for the table
+    await queryRunner.query(`
+      COMMENT ON TABLE "${schemaName}"."${tableName}" IS '@graphql({"totalCount": {"enabled": true}})';
+    `);
   }
 
   /**

--- a/packages/twenty-server/src/workspace/workspace-schema-builder/factories/connection-type-definition.factory.ts
+++ b/packages/twenty-server/src/workspace/workspace-schema-builder/factories/connection-type-definition.factory.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 
-import { GraphQLFieldConfigMap, GraphQLObjectType } from 'graphql';
+import { GraphQLFieldConfigMap, GraphQLInt, GraphQLObjectType } from 'graphql';
 
 import { WorkspaceBuildSchemaOptions } from 'src/workspace/workspace-schema-builder/interfaces/workspace-build-schema-optionts.interface';
 import { ObjectMetadataInterface } from 'src/metadata/field-metadata/interfaces/object-metadata.interface';
@@ -69,6 +69,11 @@ export class ConnectionTypeDefinitionFactory {
           nullable: false,
         },
       ),
+    };
+
+    fields.totalCount = {
+      type: GraphQLInt,
+      description: 'Total number of records in the connection',
     };
 
     return fields;


### PR DESCRIPTION
This PR enable `totalCount` on paginated result with `pg_graphql`.
Now `totalCount` can be used on the front side to reflect the correct amount of results.

To make it work we need to apply a `pg_graphql` directive on all tables:

```sql
comment on table "activity" is e'@graphql({"totalCount": {"enabled": true}})';
```

So to fix the production database a command `workspace:add-total-count` has been created and can be executed as follow:

```sh
$ yarn command workspace:add-total-count
```

Fix #2794 