### PR TITLE
refactor: make search case-insensitive

### DIFF
--- a/packages/twenty-front/src/modules/command-menu/components/CommandMenu.tsx
+++ b/packages/twenty-front/src/modules/command-menu/components/CommandMenu.tsx
@@ -157,8 +157,8 @@ export const CommandMenu = () => {
     objectNameSingular: CoreObjectNameSingular.Activity,
     filter: {
       or: [
-        { title: { like: `%${search}%` } },
-        { body: { like: `%${search}%` } },
+        { title: { ilike: `%${search}%` } },
+        { body: { ilike: `%${search}%` } },
       ],
     },
     limit: 3,


### PR DESCRIPTION
fixes #3385 

Used `ilike` instead of `like` to make search case-insensitive.