### PR TITLE
Import messages after connected-account creation

### DIFF
--- a/packages/twenty-server/src/core/auth/controllers/google-gmail-auth.controller.ts
+++ b/packages/twenty-server/src/core/auth/controllers/google-gmail-auth.controller.ts
@@ -35,7 +35,7 @@ export class GoogleGmailAuthController {
     const { workspaceMemberId, workspaceId } =
       await this.tokenService.verifyTransientToken(transientToken);
 
-    this.googleGmailService.saveConnectedAccount({
+    await this.googleGmailService.saveConnectedAccount({
       handle: email,
       workspaceMemberId: workspaceMemberId,
       workspaceId: workspaceId,


### PR DESCRIPTION
## Context

This is a first naive non-event based approach to trigger our messages fetching job after connectedAccount creation.

Note: Sync mode can take a long time to run, might even timeout. 

## Test
tested on sync mode and with pg-boss