### PR TITLE
fix: auth user decorator cannot destruct property of undefined

### DIFF
--- a/packages/twenty-server/src/core/analytics/analytics.resolver.ts
+++ b/packages/twenty-server/src/core/analytics/analytics.resolver.ts
@@ -21,7 +21,7 @@ export class AnalyticsResolver {
   createEvent(
     @Args() createEventInput: CreateAnalyticsInput,
     @AuthWorkspace() workspace: Workspace | undefined,
-    @AuthUser({ required: false }) user: User | undefined,
+    @AuthUser({ allowUndefined: true }) user: User | undefined,
   ) {
     return this.analyticsService.create(createEventInput, user, workspace);
   }

--- a/packages/twenty-server/src/core/analytics/analytics.resolver.ts
+++ b/packages/twenty-server/src/core/analytics/analytics.resolver.ts
@@ -21,7 +21,7 @@ export class AnalyticsResolver {
   createEvent(
     @Args() createEventInput: CreateAnalyticsInput,
     @AuthWorkspace() workspace: Workspace | undefined,
-    @AuthUser() user: User | undefined,
+    @AuthUser({ required: false }) user: User | undefined,
   ) {
     return this.analyticsService.create(createEventInput, user, workspace);
   }

--- a/packages/twenty-server/src/decorators/auth-user.decorator.ts
+++ b/packages/twenty-server/src/decorators/auth-user.decorator.ts
@@ -1,10 +1,22 @@
-import { ExecutionContext, createParamDecorator } from '@nestjs/common';
+import {
+  ExecutionContext,
+  ForbiddenException,
+  createParamDecorator,
+} from '@nestjs/common';
 
 import { getRequest } from 'src/utils/extract-request';
 
+interface DecoratorOptions {
+  required?: boolean;
+}
+
 export const AuthUser = createParamDecorator(
-  (_: unknown, ctx: ExecutionContext) => {
+  (options: DecoratorOptions = { required: true }, ctx: ExecutionContext) => {
     const request = getRequest(ctx);
+
+    if (options.required && (!request.user || !request.user.user)) {
+      throw new ForbiddenException("You're not authorized to do this");
+    }
 
     return request.user ? request.user.user : undefined;
   },

--- a/packages/twenty-server/src/decorators/auth-user.decorator.ts
+++ b/packages/twenty-server/src/decorators/auth-user.decorator.ts
@@ -7,14 +7,14 @@ import {
 import { getRequest } from 'src/utils/extract-request';
 
 interface DecoratorOptions {
-  required?: boolean;
+  allowUndefined?: boolean;
 }
 
 export const AuthUser = createParamDecorator(
-  (options: DecoratorOptions = { required: true }, ctx: ExecutionContext) => {
+  (options: DecoratorOptions | undefined, ctx: ExecutionContext) => {
     const request = getRequest(ctx);
 
-    if (options.required && (!request.user || !request.user.user)) {
+    if (!options?.allowUndefined && (!request.user || !request.user.user)) {
       throw new ForbiddenException("You're not authorized to do this");
     }
 


### PR DESCRIPTION
This PR fix errors with `@AuthUser` decorator, when someone use an ApiKey to retrieve data related to a user.
As ApiKey token only contain a workspace, and not any data about a user.
To avoid this being sent to Sentry, a proper exception has been set by adding some options to the `@AuthUser` decorator.

Inside the options the new property is `required` (`true` | `false`).
By default it's set to `true`.
If it's `true` a check will be made to verify if `user` is defined.
if it's `false` it's working like before and can return an undefined user.

Fix #3144 
