### PR TITLE
Fix docker-compose commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 docker-dev-build:
 	make -C packages/twenty-docker dev-build
 
-docker-dev-up:
-	make -C packages/twenty-docker dev-up
+docker-dev-start:
+	make -C packages/twenty-docker dev-start
 
-docker-dev-down:
-	make -C packages/twenty-docker dev-down
+docker-dev-stop:
+	make -C packages/twenty-docker dev-stop
 
 docker-dev-sh:
 	make -C packages/twenty-docker dev-sh

--- a/packages/twenty-docker/Makefile
+++ b/packages/twenty-docker/Makefile
@@ -1,16 +1,12 @@
 dev-build:
-	@docker compose -f dev/docker-compose.yml down
-	@docker volume rm twenty_dev_node_modules_root > /dev/null 2>&1 || true
-	@docker volume rm twenty_dev_node_modules_docs > /dev/null 2>&1 || true
-	@docker volume rm twenty_dev_node_modules_eslint > /dev/null 2>&1 || true
-	@docker volume rm twenty_dev_node_modules_front > /dev/null 2>&1 || true
-	@docker volume rm twenty_dev_node_modules_server > /dev/null 2>&1 || true
-	@docker volume rm twenty_dev_node_modules_website > /dev/null 2>&1 || true
-	@docker volume rm twenty_dev_node_modules_zapier > /dev/null 2>&1 || true
+	@docker compose -f dev/docker-compose.yml down -v
 	@docker compose -f dev/docker-compose.yml build
 
-dev-up:
-	@docker compose -f dev/docker-compose.yml up -d
+dev-start:
+	@docker compose -f dev/docker-compose.yml start
+
+dev-stop:
+	@docker compose -f dev/docker-compose.yml stop
 
 dev-down:
 	@docker compose -f dev/docker-compose.yml down -v

--- a/packages/twenty-docker/dev/docker-compose.yml
+++ b/packages/twenty-docker/dev/docker-compose.yml
@@ -15,7 +15,6 @@ services:
       - twenty_dev_node_modules_front:/app/packages/twenty-front/node_modules
       - twenty_dev_node_modules_server:/app/packages/twenty-server/node_modules
       - twenty_dev_node_modules_website:/app/packages/twenty-website/node_modules
-      - twenty_dev_node_modules_zapier:/app/packages/twenty-zapier/node_modules
     depends_on:
       - postgres
   postgres:
@@ -38,5 +37,4 @@ volumes:
   twenty_dev_node_modules_front:
   twenty_dev_node_modules_server:
   twenty_dev_node_modules_website:
-  twenty_dev_node_modules_zapier:
 

--- a/packages/twenty-docs/docs/contributor/local-setup/docker-setup.mdx
+++ b/packages/twenty-docs/docs/contributor/local-setup/docker-setup.mdx
@@ -86,7 +86,7 @@ Before running the project, you need to initialize the database by running the m
 
 Start the containers:
 ```bash
-make docker-dev-up
+make docker-dev-start
 ```
 
 Setup database, run migrations, and seed:


### PR DESCRIPTION
Several contributors including @i-am-chitti and @Sinister-00 reported that our docker-command setup was deleting docker volumes (including node_modules and database content) when shutting down docker containers.

This is due to the fact that we were doing `docker-compose down -v` in our script, which is actually destroying everything.

We should actually be doing `docker-compose stop` to stop the containers.
Also, replacing `docker-compose up` by `docker-compose start`

Another proposal has been made here: #3376 

Related issue https://github.com/twentyhq/twenty/issues/3364

Stackoverflow post explaining details: https://stackoverflow.com/questions/46428420/docker-compose-up-down-stop-start-difference