### PR TITLE
Fix bug hover on table

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-table/hooks/internal/useGetIsSomeCellInEditMode.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/hooks/internal/useGetIsSomeCellInEditMode.ts
@@ -3,7 +3,7 @@ import { useRecoilCallback } from 'recoil';
 import { useRecordTableStates } from '@/object-record/record-table/hooks/internal/useRecordTableStates';
 import { getSnapshotValue } from '@/ui/utilities/recoil-scope/utils/getSnapshotValue';
 
-export const useGetIsSomeCellInEditMode = (recordTableId?: string) => {
+export const useGetIsSomeCellInEditModeState = (recordTableId?: string) => {
   const {
     currentTableCellInEditModePositionState,
     isTableCellInEditModeFamilyState,
@@ -17,11 +17,11 @@ export const useGetIsSomeCellInEditMode = (recordTableId?: string) => {
           currentTableCellInEditModePositionState(),
         );
 
-        const isSomeCellInEditMode = isTableCellInEditModeFamilyState(
+        const isSomeCellInEditModeState = isTableCellInEditModeFamilyState(
           currentTableCellInEditModePosition,
         );
 
-        return isSomeCellInEditMode;
+        return isSomeCellInEditModeState;
       },
     [currentTableCellInEditModePositionState, isTableCellInEditModeFamilyState],
   );

--- a/packages/twenty-front/src/modules/object-record/record-table/hooks/useRecordTable.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/hooks/useRecordTable.ts
@@ -1,7 +1,7 @@
 import { useRecoilCallback, useSetRecoilState } from 'recoil';
 import { Key } from 'ts-key-enum';
 
-import { useGetIsSomeCellInEditMode } from '@/object-record/record-table/hooks/internal/useGetIsSomeCellInEditMode';
+import { useGetIsSomeCellInEditModeState } from '@/object-record/record-table/hooks/internal/useGetIsSomeCellInEditMode';
 import { useRecordTableStates } from '@/object-record/record-table/hooks/internal/useRecordTableStates';
 import { useScopedHotkeys } from '@/ui/utilities/hotkey/hooks/useScopedHotkeys';
 import { useSetHotkeyScope } from '@/ui/utilities/hotkey/hooks/useSetHotkeyScope';
@@ -318,7 +318,8 @@ export const useRecordTable = (props?: useRecordTableProps) => {
 
   const { selectAllRows } = useSelectAllRows(recordTableId);
 
-  const getIsSomeCellInEditMode = useGetIsSomeCellInEditMode(recordTableId);
+  const isSomeCellInEditModeState =
+    useGetIsSomeCellInEditModeState(recordTableId);
 
   return {
     scopeId,
@@ -344,7 +345,7 @@ export const useRecordTable = (props?: useRecordTableProps) => {
     setIsRecordTableInitialLoading,
     setRecordTableLastRowVisible,
     setSoftFocusPosition,
-    getIsSomeCellInEditMode,
+    isSomeCellInEditModeState,
     selectedRowIdsSelector,
   };
 };

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellContainer.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellContainer.tsx
@@ -1,5 +1,6 @@
 import { ReactElement, useContext, useState } from 'react';
 import styled from '@emotion/styled';
+import { useRecoilValue } from 'recoil';
 
 import { useGetButtonIcon } from '@/object-record/field/hooks/useGetButtonIcon';
 import { useIsFieldEmpty } from '@/object-record/field/hooks/useIsFieldEmpty';
@@ -57,7 +58,8 @@ export const TableCellContainer = ({
 }: TableCellContainerProps) => {
   const { isCurrentTableCellInEditMode } = useCurrentTableCellEditMode();
 
-  const { getIsSomeCellInEditMode } = useRecordTable();
+  const { isSomeCellInEditModeState } = useRecordTable();
+  const isSomeCellInEditMode = useRecoilValue(isSomeCellInEditModeState());
 
   const [isHovered, setIsHovered] = useState(false);
 
@@ -76,8 +78,6 @@ export const TableCellContainer = ({
   };
 
   const handleContainerMouseEnter = () => {
-    const isSomeCellInEditMode = getIsSomeCellInEditMode();
-
     if (!isHovered && !isSomeCellInEditMode) {
       setIsHovered(true);
       moveSoftFocusToCurrentCellOnHover();


### PR DESCRIPTION
During the refactoring of the RecordTable with RecoilScope v4, we introduce a regression on RecordTable hover state