### PR TITLE
Fix zindex contextmenu

### DIFF
--- a/packages/twenty-front/src/modules/ui/navigation/context-menu/components/ContextMenu.tsx
+++ b/packages/twenty-front/src/modules/ui/navigation/context-menu/components/ContextMenu.tsx
@@ -38,7 +38,7 @@ const StyledContainerContextMenu = styled.div<StyledContainerProps>`
 
   transform: translateX(-50%);
   width: auto;
-  z-index: 1;
+  z-index: 2;
 `;
 
 export const ContextMenu = ({ selectedIds }: ContextMenuProps) => {


### PR DESCRIPTION
Fixes: 
<img width="403" alt="Bildschirmfoto 2024-01-15 um 16 18 12" src="https://github.com/twentyhq/twenty/assets/48770548/a119f713-9dee-4e73-8c06-bdaa085da760">
