### PR TITLE
Add performance logs to object metadata query

### DIFF
--- a/packages/twenty-server/src/metadata/field-metadata/dtos/default-value.input.ts
+++ b/packages/twenty-server/src/metadata/field-metadata/dtos/default-value.input.ts
@@ -1,4 +1,3 @@
-import { Transform } from 'class-transformer';
 import {
   IsArray,
   IsBoolean,

--- a/packages/twenty-server/src/metadata/object-metadata/object-metadata.service.ts
+++ b/packages/twenty-server/src/metadata/object-metadata/object-metadata.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 
 import { FindManyOptions, FindOneOptions, Repository } from 'typeorm';
 import { TypeOrmQueryService } from '@ptc-org/nestjs-query-typeorm';
+import { Query, QueryOptions } from '@ptc-org/nestjs-query-core';
 
 import { WorkspaceMigrationService } from 'src/metadata/workspace-migration/workspace-migration.service';
 import { WorkspaceMigrationRunnerService } from 'src/workspace/workspace-migration-runner/workspace-migration-runner.service';
@@ -45,6 +46,21 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
     private readonly workspaceMigrationRunnerService: WorkspaceMigrationRunnerService,
   ) {
     super(objectMetadataRepository);
+  }
+
+  override async query(
+    query: Query<ObjectMetadataEntity>,
+    opts?: QueryOptions<ObjectMetadataEntity> | undefined,
+  ): Promise<ObjectMetadataEntity[]> {
+    const start = performance.now();
+
+    const result = super.query(query, opts);
+
+    const end = performance.now();
+
+    console.log(`metadata query time: ${end - start} ms`);
+
+    return result;
   }
 
   override async createOne(

--- a/packages/twenty-server/src/workspace/workspace-query-builder/factories/find-many-query.factory.ts
+++ b/packages/twenty-server/src/workspace/workspace-query-builder/factories/find-many-query.factory.ts
@@ -7,9 +7,10 @@ import {
 } from 'src/workspace/workspace-query-builder/interfaces/record.interface';
 import { FindManyResolverArgs } from 'src/workspace/workspace-resolver-builder/interfaces/workspace-resolvers-builder.interface';
 
+import { computeObjectTargetTable } from 'src/workspace/utils/compute-object-target-table.util';
+
 import { ArgsStringFactory } from './args-string.factory';
 import { FieldsStringFactory } from './fields-string.factory';
-import { computeObjectTargetTable } from 'src/workspace/utils/compute-object-target-table.util';
 
 @Injectable()
 export class FindManyQueryFactory {


### PR DESCRIPTION
## Context
This is temporary as we are trying on identify performances issues on a prod environment.

## Implementation
We are simply overriding the query method of object-metadata TypeOrmQueryService generated by nestjs-query and wrap the call with some logs.