### PR TITLE
feat: workspace health relation

### DIFF
--- a/packages/twenty-server/src/metadata/relation-metadata/relation-metadata.service.ts
+++ b/packages/twenty-server/src/metadata/relation-metadata/relation-metadata.service.ts
@@ -26,6 +26,8 @@ import {
   RelationMetadataType,
 } from './relation-metadata.entity';
 
+import { createRelationMetadataForeignKey } from './utils/create-relation-metadata-foreign-key.util';
+
 @Injectable()
 export class RelationMetadataService extends TypeOrmQueryService<RelationMetadataEntity> {
   constructor(
@@ -54,10 +56,10 @@ export class RelationMetadataService extends TypeOrmQueryService<RelationMetadat
     // NOTE: this logic is called to create relation through metadata graphql endpoint (so only for custom field relations)
     const isCustom = true;
     const baseColumnName = `${camelCase(relationMetadataInput.toName)}Id`;
-
-    const foreignKeyColumnName = isCustom
-      ? createCustomColumnName(baseColumnName)
-      : baseColumnName;
+    const foreignKeyColumnName = createRelationMetadataForeignKey(
+      relationMetadataInput.toName,
+      isCustom,
+    );
 
     const createdFields = await this.fieldMetadataService.createMany([
       this.createFieldMetadataForRelationMetadata(

--- a/packages/twenty-server/src/metadata/relation-metadata/utils/create-relation-metadata-foreign-key.util.ts
+++ b/packages/twenty-server/src/metadata/relation-metadata/utils/create-relation-metadata-foreign-key.util.ts
@@ -1,0 +1,15 @@
+import { createCustomColumnName } from 'src/metadata/utils/create-custom-column-name.util';
+import { camelCase } from 'src/utils/camel-case';
+
+export const createRelationMetadataForeignKey = (
+  name: string,
+  isCustom?: boolean,
+) => {
+  const baseColumnName = `${camelCase(name)}Id`;
+
+  const foreignKeyColumnName = isCustom
+    ? createCustomColumnName(baseColumnName)
+    : baseColumnName;
+
+  return foreignKeyColumnName;
+};

--- a/packages/twenty-server/src/workspace/workspace-health/interfaces/workspace-health-issue.interface.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/interfaces/workspace-health-issue.interface.ts
@@ -2,6 +2,7 @@ import { WorkspaceTableStructure } from 'src/workspace/workspace-health/interfac
 
 import { FieldMetadataEntity } from 'src/metadata/field-metadata/field-metadata.entity';
 import { ObjectMetadataEntity } from 'src/metadata/object-metadata/object-metadata.entity';
+import { RelationMetadataEntity } from 'src/metadata/relation-metadata/relation-metadata.entity';
 
 export enum WorkspaceHealthIssueType {
   MISSING_TABLE = 'MISSING_TABLE',
@@ -23,6 +24,11 @@ export enum WorkspaceHealthIssueType {
   COLUMN_DEFAULT_VALUE_CONFLICT = 'COLUMN_DEFAULT_VALUE_CONFLICT',
   COLUMN_DEFAULT_VALUE_NOT_VALID = 'COLUMN_DEFAULT_VALUE_NOT_VALID',
   COLUMN_OPTIONS_NOT_VALID = 'COLUMN_OPTIONS_NOT_VALID',
+  RELATION_FROM_OR_TO_FIELD_METADATA_NOT_VALID = 'RELATION_FROM_OR_TO_FIELD_METADATA_NOT_VALID',
+  RELATION_FOREIGN_KEY_NOT_VALID = 'RELATION_FOREIGN_KEY_NOT_VALID',
+  RELATION_NULLABILITY_CONFLICT = 'RELATION_NULLABILITY_CONFLICT',
+  RELATION_FOREIGN_KEY_CONFLICT = 'RELATION_FOREIGN_KEY_CONFLICT',
+  RELATION_TYPE_NOT_VALID = 'RELATION_TYPE_NOT_VALID',
 }
 
 export interface WorkspaceHealthTableIssue {
@@ -57,6 +63,21 @@ export interface WorkspaceHealthColumnIssue {
   message: string;
 }
 
+export interface WorkspaceHealthRelationIssue {
+  type:
+    | WorkspaceHealthIssueType.RELATION_FROM_OR_TO_FIELD_METADATA_NOT_VALID
+    | WorkspaceHealthIssueType.RELATION_FOREIGN_KEY_NOT_VALID
+    | WorkspaceHealthIssueType.RELATION_NULLABILITY_CONFLICT
+    | WorkspaceHealthIssueType.RELATION_FOREIGN_KEY_CONFLICT
+    | WorkspaceHealthIssueType.RELATION_TYPE_NOT_VALID;
+  fromFieldMetadata: FieldMetadataEntity | undefined;
+  toFieldMetadata: FieldMetadataEntity | undefined;
+  relationMetadata: RelationMetadataEntity;
+  columnStructure?: WorkspaceTableStructure;
+  message: string;
+}
+
 export type WorkspaceHealthIssue =
   | WorkspaceHealthTableIssue
-  | WorkspaceHealthColumnIssue;
+  | WorkspaceHealthColumnIssue
+  | WorkspaceHealthRelationIssue;

--- a/packages/twenty-server/src/workspace/workspace-health/interfaces/workspace-table-definition.interface.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/interfaces/workspace-table-definition.interface.ts
@@ -3,7 +3,13 @@ export interface WorkspaceTableStructure {
   tableName: string;
   columnName: string;
   dataType: string;
-  isNullable: string;
   columnDefault: string;
-  isPrimaryKey: string;
+  isNullable: boolean;
+  isPrimaryKey: boolean;
+  isForeignKey: boolean;
+  isUnique: boolean;
 }
+
+export type WorkspaceTableStructureResult = {
+  [P in keyof WorkspaceTableStructure]: string;
+};

--- a/packages/twenty-server/src/workspace/workspace-health/services/field-metadata-health.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/services/field-metadata-health.service.ts
@@ -1,8 +1,4 @@
-import {
-  Injectable,
-  InternalServerErrorException,
-  NotFoundException,
-} from '@nestjs/common';
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
 
 import {
   WorkspaceHealthIssue,
@@ -30,31 +26,19 @@ export class FieldMetadataHealthService {
   ) {}
 
   async healthCheck(
-    schemaName: string,
     tableName: string,
+    workspaceTableColumns: WorkspaceTableStructure[],
     fieldMetadataCollection: FieldMetadataEntity[],
     options: WorkspaceHealthOptions,
   ): Promise<WorkspaceHealthIssue[]> {
     const issues: WorkspaceHealthIssue[] = [];
-    const workspaceTableColumns =
-      await this.databaseStructureService.getWorkspaceTableColumns(
-        schemaName,
-        tableName,
-      );
-
-    if (!workspaceTableColumns) {
-      throw new NotFoundException(
-        `Table ${tableName} not found in schema ${schemaName}`,
-      );
-    }
 
     for (const fieldMetadata of fieldMetadataCollection) {
-      // Ignore relation fields for now
+      // Relation metadata are checked in another service
       if (
         fieldMetadata.fromRelationMetadata ||
         fieldMetadata.toRelationMetadata
       ) {
-        // TODO: Check relation fields
         continue;
       }
 
@@ -140,7 +124,6 @@ export class FieldMetadataHealthService {
       fieldMetadata.type,
       fieldMetadata.defaultValue,
     );
-    const isNullable = fieldMetadata.isNullable ? 'TRUE' : 'FALSE';
     // Check if column exist in database
     const columnStructure = workspaceTableColumns.find(
       (tableDefinition) => tableDefinition.columnName === columnName,
@@ -167,7 +150,7 @@ export class FieldMetadataHealthService {
       });
     }
 
-    if (columnStructure.isNullable !== isNullable) {
+    if (columnStructure.isNullable !== fieldMetadata.isNullable) {
       issues.push({
         type: WorkspaceHealthIssueType.COLUMN_NULLABILITY_CONFLICT,
         fieldMetadata,
@@ -211,7 +194,7 @@ export class FieldMetadataHealthService {
 
     issues.push(...targetColumnMapIssues);
 
-    if (fieldMetadata.isCustom && !columnName.startsWith('_')) {
+    if (fieldMetadata.isCustom && !columnName?.startsWith('_')) {
       issues.push({
         type: WorkspaceHealthIssueType.COLUMN_NAME_SHOULD_BE_CUSTOM,
         fieldMetadata,

--- a/packages/twenty-server/src/workspace/workspace-health/services/relation-metadata.health.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/services/relation-metadata.health.service.ts
@@ -1,0 +1,222 @@
+import { Injectable } from '@nestjs/common';
+
+import { WorkspaceTableStructure } from 'src/workspace/workspace-health/interfaces/workspace-table-definition.interface';
+import {
+  WorkspaceHealthIssue,
+  WorkspaceHealthIssueType,
+} from 'src/workspace/workspace-health/interfaces/workspace-health-issue.interface';
+import {
+  WorkspaceHealthMode,
+  WorkspaceHealthOptions,
+} from 'src/workspace/workspace-health/interfaces/workspace-health-options.interface';
+
+import {
+  FieldMetadataEntity,
+  FieldMetadataType,
+} from 'src/metadata/field-metadata/field-metadata.entity';
+import {
+  RelationMetadataEntity,
+  RelationMetadataType,
+} from 'src/metadata/relation-metadata/relation-metadata.entity';
+import { createRelationMetadataForeignKey } from 'src/metadata/relation-metadata/utils/create-relation-metadata-foreign-key.util';
+import {
+  RelationDirection,
+  deduceRelationDirection,
+} from 'src/workspace/utils/deduce-relation-direction.util';
+import { ObjectMetadataEntity } from 'src/metadata/object-metadata/object-metadata.entity';
+
+@Injectable()
+export class RelationMetadataHealthService {
+  constructor() {}
+
+  public healthCheck(
+    workspaceTableColumns: WorkspaceTableStructure[],
+    objectMetadataCollection: ObjectMetadataEntity[],
+    objectMetadata: ObjectMetadataEntity,
+    options: WorkspaceHealthOptions,
+  ) {
+    const issues: WorkspaceHealthIssue[] = [];
+
+    for (const fieldMetadata of objectMetadata.fields) {
+      // We're only interested in relation fields
+      if (fieldMetadata.type !== FieldMetadataType.RELATION) {
+        continue;
+      }
+
+      const relationMetadata =
+        fieldMetadata.fromRelationMetadata ?? fieldMetadata.toRelationMetadata;
+      const relationDirection = deduceRelationDirection(
+        objectMetadata.id,
+        relationMetadata,
+      );
+
+      // Many to many relations are not supported yet
+      if (relationMetadata.relationType === RelationMetadataType.MANY_TO_MANY) {
+        return [];
+      }
+
+      const fromObjectMetadata = objectMetadataCollection.find(
+        (objectMetadata) =>
+          objectMetadata.id === relationMetadata.fromObjectMetadataId,
+      );
+      const fromFieldMetadata = fromObjectMetadata?.fields.find(
+        (fieldMetadata) =>
+          fieldMetadata.id === relationMetadata.fromFieldMetadataId,
+      );
+      const toObjectMetadata = objectMetadataCollection.find(
+        (objectMetadata) =>
+          objectMetadata.id === relationMetadata.toObjectMetadataId,
+      );
+      const toFieldMetadata = toObjectMetadata?.fields.find(
+        (fieldMetadata) =>
+          fieldMetadata.id === relationMetadata.toFieldMetadataId,
+      );
+
+      if (!fromFieldMetadata || !toFieldMetadata) {
+        issues.push({
+          type: WorkspaceHealthIssueType.RELATION_FROM_OR_TO_FIELD_METADATA_NOT_VALID,
+          fromFieldMetadata,
+          toFieldMetadata,
+          relationMetadata,
+          message: `Relation ${relationMetadata.id} has invalid from or to field metadata`,
+        });
+
+        return issues;
+      }
+
+      if (
+        options.mode === WorkspaceHealthMode.All ||
+        options.mode === WorkspaceHealthMode.Structure
+      ) {
+        // Check relation structure
+        const structureIssues = this.structureRelationCheck(
+          fromFieldMetadata,
+          toFieldMetadata,
+          toObjectMetadata?.fields ?? [],
+          relationDirection,
+          relationMetadata,
+          workspaceTableColumns,
+        );
+
+        issues.push(...structureIssues);
+      }
+
+      if (
+        options.mode === WorkspaceHealthMode.All ||
+        options.mode === WorkspaceHealthMode.Metadata
+      ) {
+        // Check relation metadata
+        const metadataIssues = this.metadataRelationCheck(
+          fromFieldMetadata,
+          toFieldMetadata,
+          relationDirection,
+          relationMetadata,
+        );
+
+        issues.push(...metadataIssues);
+      }
+    }
+
+    return issues;
+  }
+
+  private structureRelationCheck(
+    fromFieldMetadata: FieldMetadataEntity,
+    toFieldMetadata: FieldMetadataEntity,
+    toObjectMetadataFields: FieldMetadataEntity[],
+    relationDirection: RelationDirection,
+    relationMetadata: RelationMetadataEntity,
+    workspaceTableColumns: WorkspaceTableStructure[],
+  ): WorkspaceHealthIssue[] {
+    const issues: WorkspaceHealthIssue[] = [];
+
+    // Nothing to check on the structure
+    if (relationDirection === RelationDirection.FROM) {
+      return [];
+    }
+
+    const isCustom = toFieldMetadata.isCustom ?? false;
+    const foreignKeyColumnName = createRelationMetadataForeignKey(
+      toFieldMetadata.name,
+      isCustom,
+    );
+    const relationColumn = workspaceTableColumns.find(
+      (column) => column.columnName === foreignKeyColumnName,
+    );
+    const relationFieldMetadata = toObjectMetadataFields.find(
+      (fieldMetadata) => fieldMetadata.name === foreignKeyColumnName,
+    );
+
+    if (!relationColumn || !relationFieldMetadata) {
+      issues.push({
+        type: WorkspaceHealthIssueType.RELATION_FOREIGN_KEY_NOT_VALID,
+        fromFieldMetadata,
+        toFieldMetadata,
+        relationMetadata,
+        message: `Relation ${relationMetadata.id} doesn't have a valid foreign key`,
+      });
+
+      return issues;
+    }
+
+    if (!relationColumn.isForeignKey) {
+      issues.push({
+        type: WorkspaceHealthIssueType.RELATION_FOREIGN_KEY_CONFLICT,
+        fromFieldMetadata,
+        toFieldMetadata,
+        relationMetadata,
+        message: `Relation ${relationMetadata.id} foreign key is not properly set`,
+      });
+    }
+
+    if (relationColumn.isNullable !== relationFieldMetadata.isNullable) {
+      issues.push({
+        type: WorkspaceHealthIssueType.RELATION_NULLABILITY_CONFLICT,
+        fromFieldMetadata,
+        toFieldMetadata,
+        relationMetadata,
+        message: `Relation ${relationMetadata.id} foreign key is not properly set`,
+      });
+    }
+
+    if (
+      relationMetadata.relationType === RelationMetadataType.ONE_TO_ONE &&
+      !relationColumn.isUnique
+    ) {
+      issues.push({
+        type: WorkspaceHealthIssueType.RELATION_FOREIGN_KEY_CONFLICT,
+        fromFieldMetadata,
+        toFieldMetadata,
+        relationMetadata,
+        message: `Relation ${relationMetadata.id} foreign key is not marked as unique and relation type is one-to-one`,
+      });
+    }
+
+    return issues;
+  }
+
+  private metadataRelationCheck(
+    fromFieldMetadata: FieldMetadataEntity,
+    toFieldMetadata: FieldMetadataEntity,
+    relationDirection: RelationDirection,
+    relationMetadata: RelationMetadataEntity,
+  ): WorkspaceHealthIssue[] {
+    const issues: WorkspaceHealthIssue[] = [];
+
+    if (
+      !Object.values(RelationMetadataType).includes(
+        relationMetadata.relationType,
+      )
+    ) {
+      issues.push({
+        type: WorkspaceHealthIssueType.RELATION_TYPE_NOT_VALID,
+        fromFieldMetadata,
+        toFieldMetadata,
+        relationMetadata,
+        message: `Relation ${relationMetadata.id} has invalid relation type`,
+      });
+    }
+
+    return issues;
+  }
+}

--- a/packages/twenty-server/src/workspace/workspace-health/workspace-health.module.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/workspace-health.module.ts
@@ -7,6 +7,7 @@ import { WorkspaceDataSourceModule } from 'src/workspace/workspace-datasource/wo
 import { DatabaseStructureService } from 'src/workspace/workspace-health/services/database-structure.service';
 import { FieldMetadataHealthService } from 'src/workspace/workspace-health/services/field-metadata-health.service';
 import { ObjectMetadataHealthService } from 'src/workspace/workspace-health/services/object-metadata-health.service';
+import { RelationMetadataHealthService } from 'src/workspace/workspace-health/services/relation-metadata.health.service';
 import { WorkspaceHealthService } from 'src/workspace/workspace-health/workspace-health.service';
 
 @Module({
@@ -21,6 +22,7 @@ import { WorkspaceHealthService } from 'src/workspace/workspace-health/workspace
     DatabaseStructureService,
     ObjectMetadataHealthService,
     FieldMetadataHealthService,
+    RelationMetadataHealthService,
   ],
   exports: [WorkspaceHealthService],
 })


### PR DESCRIPTION
In this PR, we are enhancing the existing `workspace:health` command by adding the ability to check relations within the specified workspace. The original command focused on assessing the health of a workspace by examining its metadata and database structure and skipping field of kind `RELATION`, and with this enhancement, we are now extending its functionality to ensure the integrity of relations as well.

### Key Features
- **Comprehensive Validation**: With this enhancement, the `workspace:health` command now includes checking for relations to ensure that they are correctly defined and maintained within the workspace.
- **Flexible Modes**: You can still choose from different levels of checking, including structure, metadata, or both, to suit your specific needs.
- **Verbose Output Option**: The command continues to provide detailed issue reporting, including information about detected relation problems, for in-depth analysis.

### How It Works
Run the enhanced command in your terminal as follows:

```sh
$ yarn command workspace:health --workspace-id 20202020-1c25-4d02-bf25-6aeccf7ea419
```

### Customizable Parameters
- **Mode Selection** (`-m, --mode [all | structure | metadata]`):
  - `all`: Checks both structure, metadata, and relations.
  - `structure`: Focuses on the database table structure based on metadata.
  - `metadata`: Concentrates on the validity of metadata.

- **Verbose Output** (`-v, --verbose`):
  - When enabled, displays detailed information about all detected issues within the terminal, including relation-related problems. If not used, only a brief summary message is shown.

Fix #3396 