### PR TITLE
Add select type to field metadata decorator

### DIFF
--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/decorators/field-metadata.decorator.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/decorators/field-metadata.decorator.ts
@@ -42,6 +42,7 @@ export function FieldMetadata<T extends FieldMetadataType>(
                   label: `${restParams.label} id (foreign key)`,
                   description: `${restParams.description} id foreign key`,
                   defaultValue: null,
+                  options: undefined,
                 },
                 joinColumn,
                 isNullable,
@@ -73,7 +74,7 @@ function generateFieldMetadata<T extends FieldMetadataType>(
     isNullable: params.type === FieldMetadataType.RELATION ? true : isNullable,
     isSystem,
     isCustom: false,
-    // TODO: handle options + stringify for the diff.
+    options: params.options ? JSON.stringify(params.options) : null,
     description: params.description,
     icon: params.icon,
     defaultValue: defaultValue ? JSON.stringify(defaultValue) : null,

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/interfaces/reflect-field-metadata.interface.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/interfaces/reflect-field-metadata.interface.ts
@@ -1,5 +1,6 @@
 import { FieldMetadataDefaultValue } from 'src/metadata/field-metadata/interfaces/field-metadata-default-value.interface';
 import { GateDecoratorParams } from 'src/workspace/workspace-sync-metadata/interfaces/gate-decorator.interface';
+import { FieldMetadataOptions } from 'src/metadata/field-metadata/interfaces/field-metadata-options.interface';
 
 import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
 
@@ -12,12 +13,13 @@ export interface FieldMetadataDecoratorParams<
   icon?: string;
   defaultValue?: FieldMetadataDefaultValue<T>;
   joinColumn?: string;
+  options?: FieldMetadataOptions<T>;
 }
 
 export interface ReflectFieldMetadata {
   [key: string]: Omit<
     FieldMetadataDecoratorParams<'default'>,
-    'defaultValue' | 'type'
+    'defaultValue' | 'type' | 'options'
   > & {
     name: string;
     type: FieldMetadataType;
@@ -28,5 +30,6 @@ export interface ReflectFieldMetadata {
     description?: string;
     defaultValue: string | null;
     gate?: GateDecoratorParams;
+    options?: string | null;
   };
 }

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/reflective-metadata.factory.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/reflective-metadata.factory.ts
@@ -43,7 +43,6 @@ export class ReflectiveMetadataFactory {
         ...field,
         workspaceId,
         isSystem: objectMetadata.isSystem || field.isSystem,
-        defaultValue: field.defaultValue,
       })),
     };
   }

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/message-participant.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/message-participant.object-metadata.ts
@@ -31,11 +31,16 @@ export class MessageParticipantObjectMetadata extends BaseObjectMetadata {
   message: MessageObjectMetadata;
 
   @FieldMetadata({
-    // this will be a type select: from, to, cc, bcc
-    type: FieldMetadataType.TEXT,
+    type: FieldMetadataType.SELECT,
     label: 'Role',
     description: 'Role',
     icon: 'IconAt',
+    options: [
+      { value: 'from', label: 'From', position: 0, color: 'green' },
+      { value: 'to', label: 'To', position: 1, color: 'blue' },
+      { value: 'cc', label: 'Cc', position: 2, color: 'orange' },
+      { value: 'bcc', label: 'Bcc', position: 3, color: 'red' },
+    ],
     defaultValue: { value: 'from' },
   })
   role: string;


### PR DESCRIPTION
## Context

We want to add a new standard field with SELECT as a type. However, the fieldMetadataDecorator was not handling option parameter yet, this PR adds the necessary code to do that.

## Test
locally
<img width="927" alt="Screenshot 2024-01-15 at 18 22 07" src="https://github.com/twentyhq/twenty/assets/1834158/409c46ea-5a6a-49c7-bf19-750844e4c729">
<img width="139" alt="Screenshot 2024-01-15 at 18 21 59" src="https://github.com/twentyhq/twenty/assets/1834158/30da2f56-4bcd-4038-8b1a-30a8b5c2ce61">
