### PR TITLE
Implemented useListenClickOutside V2

### DIFF
--- a/packages/twenty-front/src/modules/object-record/relation-picker/components/MultipleObjectRecordOnClickOutsideEffect.tsx
+++ b/packages/twenty-front/src/modules/object-record/relation-picker/components/MultipleObjectRecordOnClickOutsideEffect.tsx
@@ -1,4 +1,8 @@
-import { useListenClickOutsideV2 } from '@/ui/utilities/pointer-event/hooks/useListenClickOutsideV2';
+import { useEffect } from 'react';
+
+import { MULTI_OBJECT_RECORD_CLICK_OUTSIDE_LISTENER_ID } from '@/object-record/relation-picker/constants/MultiObjectRecordClickOutsideListenerId';
+import { RIGHT_DRAWER_CLICK_OUTSIDE_LISTENER_ID } from '@/ui/layout/right-drawer/constants/RightDrawerClickOutsideListener';
+import { useClickOutsideListener } from '@/ui/utilities/pointer-event/hooks/useClickOutsideListener';
 
 export const MultipleObjectRecordOnClickOutsideEffect = ({
   containerRef,
@@ -7,7 +11,22 @@ export const MultipleObjectRecordOnClickOutsideEffect = ({
   containerRef: React.RefObject<HTMLDivElement>;
   onClickOutside: () => void;
 }) => {
-  useListenClickOutsideV2({
+  const { useListenClickOutside } = useClickOutsideListener(
+    MULTI_OBJECT_RECORD_CLICK_OUTSIDE_LISTENER_ID,
+  );
+
+  const { toggleClickOutsideListener: toggleRightDrawerClickOustideListener } =
+    useClickOutsideListener(RIGHT_DRAWER_CLICK_OUTSIDE_LISTENER_ID);
+
+  useEffect(() => {
+    toggleRightDrawerClickOustideListener(false);
+
+    return () => {
+      toggleRightDrawerClickOustideListener(true);
+    };
+  }, [toggleRightDrawerClickOustideListener]);
+
+  useListenClickOutside({
     refs: [containerRef],
     callback: (event) => {
       event.stopImmediatePropagation();
@@ -16,8 +35,6 @@ export const MultipleObjectRecordOnClickOutsideEffect = ({
 
       onClickOutside();
     },
-    listenerId: 'multiple-object-record',
-    isLocking: true,
   });
 
   return <></>;

--- a/packages/twenty-front/src/modules/object-record/relation-picker/components/MultipleObjectRecordOnClickOutsideEffect.tsx
+++ b/packages/twenty-front/src/modules/object-record/relation-picker/components/MultipleObjectRecordOnClickOutsideEffect.tsx
@@ -1,4 +1,4 @@
-import { useListenClickOutside } from '@/ui/utilities/pointer-event/hooks/useListenClickOutside';
+import { useListenClickOutsideV2 } from '@/ui/utilities/pointer-event/hooks/useListenClickOutsideV2';
 
 export const MultipleObjectRecordOnClickOutsideEffect = ({
   containerRef,
@@ -7,7 +7,7 @@ export const MultipleObjectRecordOnClickOutsideEffect = ({
   containerRef: React.RefObject<HTMLDivElement>;
   onClickOutside: () => void;
 }) => {
-  useListenClickOutside({
+  useListenClickOutsideV2({
     refs: [containerRef],
     callback: (event) => {
       event.stopImmediatePropagation();
@@ -16,6 +16,8 @@ export const MultipleObjectRecordOnClickOutsideEffect = ({
 
       onClickOutside();
     },
+    listenerId: 'multiple-object-record',
+    isLocking: true,
   });
 
   return <></>;

--- a/packages/twenty-front/src/modules/object-record/relation-picker/constants/MultiObjectRecordClickOutsideListenerId.ts
+++ b/packages/twenty-front/src/modules/object-record/relation-picker/constants/MultiObjectRecordClickOutsideListenerId.ts
@@ -1,0 +1,2 @@
+export const MULTI_OBJECT_RECORD_CLICK_OUTSIDE_LISTENER_ID =
+  'multi-object-record-click-outside-listener';

--- a/packages/twenty-front/src/modules/ui/layout/right-drawer/components/RightDrawer.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/right-drawer/components/RightDrawer.tsx
@@ -6,10 +6,8 @@ import { useRecoilState } from 'recoil';
 import { Key } from 'ts-key-enum';
 
 import { useScopedHotkeys } from '@/ui/utilities/hotkey/hooks/useScopedHotkeys';
-import {
-  ClickOutsideMode,
-  useListenClickOutside,
-} from '@/ui/utilities/pointer-event/hooks/useListenClickOutside';
+import { ClickOutsideMode } from '@/ui/utilities/pointer-event/hooks/useListenClickOutside';
+import { useListenClickOutsideV2 } from '@/ui/utilities/pointer-event/hooks/useListenClickOutsideV2';
 import { useIsMobile } from '@/ui/utilities/responsive/hooks/useIsMobile';
 import { isDefined } from '~/utils/isDefined';
 
@@ -53,10 +51,11 @@ export const RightDrawer = () => {
 
   const rightDrawerRef = useRef<HTMLDivElement>(null);
 
-  useListenClickOutside({
+  useListenClickOutsideV2({
     refs: [rightDrawerRef],
     callback: () => closeRightDrawer(),
     mode: ClickOutsideMode.comparePixels,
+    listenerId: 'right-drawer',
   });
 
   const theme = useTheme();

--- a/packages/twenty-front/src/modules/ui/layout/right-drawer/components/RightDrawer.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/right-drawer/components/RightDrawer.tsx
@@ -5,9 +5,10 @@ import { motion } from 'framer-motion';
 import { useRecoilState } from 'recoil';
 import { Key } from 'ts-key-enum';
 
+import { RIGHT_DRAWER_CLICK_OUTSIDE_LISTENER_ID } from '@/ui/layout/right-drawer/constants/RightDrawerClickOutsideListener';
 import { useScopedHotkeys } from '@/ui/utilities/hotkey/hooks/useScopedHotkeys';
+import { useClickOutsideListener } from '@/ui/utilities/pointer-event/hooks/useClickOutsideListener';
 import { ClickOutsideMode } from '@/ui/utilities/pointer-event/hooks/useListenClickOutside';
-import { useListenClickOutsideV2 } from '@/ui/utilities/pointer-event/hooks/useListenClickOutsideV2';
 import { useIsMobile } from '@/ui/utilities/responsive/hooks/useIsMobile';
 import { isDefined } from '~/utils/isDefined';
 
@@ -51,11 +52,14 @@ export const RightDrawer = () => {
 
   const rightDrawerRef = useRef<HTMLDivElement>(null);
 
-  useListenClickOutsideV2({
+  const { useListenClickOutside } = useClickOutsideListener(
+    RIGHT_DRAWER_CLICK_OUTSIDE_LISTENER_ID,
+  );
+
+  useListenClickOutside({
     refs: [rightDrawerRef],
     callback: () => closeRightDrawer(),
     mode: ClickOutsideMode.comparePixels,
-    listenerId: 'right-drawer',
   });
 
   const theme = useTheme();

--- a/packages/twenty-front/src/modules/ui/layout/right-drawer/constants/RightDrawerClickOutsideListener.ts
+++ b/packages/twenty-front/src/modules/ui/layout/right-drawer/constants/RightDrawerClickOutsideListener.ts
@@ -1,0 +1,2 @@
+export const RIGHT_DRAWER_CLICK_OUTSIDE_LISTENER_ID =
+  'right-drawer-click-outside-listener';

--- a/packages/twenty-front/src/modules/ui/utilities/pointer-event/hooks/useClickOustideListenerStates.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/pointer-event/hooks/useClickOustideListenerStates.ts
@@ -1,0 +1,25 @@
+import { clickOutsideListenerIsEnabledStateScopeMap } from '@/ui/utilities/pointer-event/states/clickOutsideListenerIsEnabledStateScopeMap';
+import { clickOutsideListenerIsMouseDownInsideStateScopeMap } from '@/ui/utilities/pointer-event/states/clickOutsideListenerIsMouseDownInsideStateScopeMap';
+import { lockedListenerIdState } from '@/ui/utilities/pointer-event/states/lockedListenerIdState';
+import { getState } from '@/ui/utilities/recoil-scope/utils/getState';
+
+export const useClickOustideListenerStates = ({
+  listenerId,
+}: {
+  listenerId: string;
+}) => {
+  const scopeId = `listener-${listenerId}-scope`;
+
+  return {
+    scopeId,
+    getClickOutsideListenerIsMouseDownInsideState: getState(
+      clickOutsideListenerIsMouseDownInsideStateScopeMap,
+      scopeId,
+    ),
+    getClickOutsideListenerIsEnabledState: getState(
+      clickOutsideListenerIsEnabledStateScopeMap,
+      scopeId,
+    ),
+    lockedListenerIdState,
+  };
+};

--- a/packages/twenty-front/src/modules/ui/utilities/pointer-event/hooks/useClickOustideListenerStates.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/pointer-event/hooks/useClickOustideListenerStates.ts
@@ -1,14 +1,12 @@
-import { clickOutsideListenerIsEnabledStateScopeMap } from '@/ui/utilities/pointer-event/states/clickOutsideListenerIsEnabledStateScopeMap';
+import { clickOutsideListenerIsActivatedStateScopeMap } from '@/ui/utilities/pointer-event/states/clickOutsideListenerIsActivatedStateScopeMap';
 import { clickOutsideListenerIsMouseDownInsideStateScopeMap } from '@/ui/utilities/pointer-event/states/clickOutsideListenerIsMouseDownInsideStateScopeMap';
 import { lockedListenerIdState } from '@/ui/utilities/pointer-event/states/lockedListenerIdState';
+import { getScopeIdFromComponentId } from '@/ui/utilities/recoil-scope/utils/getScopeIdFromComponentId';
 import { getState } from '@/ui/utilities/recoil-scope/utils/getState';
 
-export const useClickOustideListenerStates = ({
-  listenerId,
-}: {
-  listenerId: string;
-}) => {
-  const scopeId = `listener-${listenerId}-scope`;
+export const useClickOustideListenerStates = (componentId: string) => {
+  // TODO: improve typing
+  const scopeId = getScopeIdFromComponentId(componentId) ?? '';
 
   return {
     scopeId,
@@ -16,8 +14,8 @@ export const useClickOustideListenerStates = ({
       clickOutsideListenerIsMouseDownInsideStateScopeMap,
       scopeId,
     ),
-    getClickOutsideListenerIsEnabledState: getState(
-      clickOutsideListenerIsEnabledStateScopeMap,
+    getClickOutsideListenerIsActivatedState: getState(
+      clickOutsideListenerIsActivatedStateScopeMap,
       scopeId,
     ),
     lockedListenerIdState,

--- a/packages/twenty-front/src/modules/ui/utilities/pointer-event/hooks/useClickOutsideListener.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/pointer-event/hooks/useClickOutsideListener.ts
@@ -1,0 +1,45 @@
+import { useRecoilCallback } from 'recoil';
+
+import { useClickOustideListenerStates } from '@/ui/utilities/pointer-event/hooks/useClickOustideListenerStates';
+import {
+  ClickOutsideListenerProps,
+  useListenClickOutsideV2,
+} from '@/ui/utilities/pointer-event/hooks/useListenClickOutsideV2';
+import { getScopeIdFromComponentId } from '@/ui/utilities/recoil-scope/utils/getScopeIdFromComponentId';
+
+export const useClickOutsideListener = (componentId: string) => {
+  // TODO: improve typing
+  const scopeId = getScopeIdFromComponentId(componentId) ?? '';
+
+  const { getClickOutsideListenerIsActivatedState } =
+    useClickOustideListenerStates(componentId);
+
+  const useListenClickOutside = <T extends Element>({
+    callback,
+    refs,
+    enabled,
+    mode,
+  }: Omit<ClickOutsideListenerProps<T>, 'listenerId'>) => {
+    return useListenClickOutsideV2({
+      listenerId: componentId,
+      refs,
+      callback,
+      enabled,
+      mode,
+    });
+  };
+
+  const toggleClickOutsideListener = useRecoilCallback(
+    ({ set }) =>
+      (activated: boolean) => {
+        set(getClickOutsideListenerIsActivatedState(), activated);
+      },
+    [getClickOutsideListenerIsActivatedState],
+  );
+
+  return {
+    scopeId,
+    useListenClickOutside,
+    toggleClickOutsideListener,
+  };
+};

--- a/packages/twenty-front/src/modules/ui/utilities/pointer-event/hooks/useListenClickOutsideV2.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/pointer-event/hooks/useListenClickOutsideV2.ts
@@ -1,0 +1,203 @@
+import React, { useEffect } from 'react';
+import { useRecoilCallback, useRecoilState, useRecoilValue } from 'recoil';
+
+import { useClickOustideListenerStates } from '@/ui/utilities/pointer-event/hooks/useClickOustideListenerStates';
+
+export enum ClickOutsideMode {
+  comparePixels = 'comparePixels',
+  compareHTMLRef = 'compareHTMLRef',
+}
+
+export const useListenClickOutsideV2 = <T extends Element>({
+  refs,
+  callback,
+  mode = ClickOutsideMode.compareHTMLRef,
+  listenerId,
+  isLocking,
+}: {
+  refs: Array<React.RefObject<T>>;
+  callback: (event: MouseEvent | TouchEvent) => void;
+  mode?: ClickOutsideMode;
+  listenerId: string;
+  isLocking?: boolean;
+}) => {
+  const {
+    getClickOutsideListenerIsMouseDownInsideState,
+    getClickOutsideListenerIsEnabledState,
+    lockedListenerIdState,
+  } = useClickOustideListenerStates({
+    listenerId,
+  });
+
+  const [lockedListenerId, setLockedListenerId] = useRecoilState(
+    lockedListenerIdState,
+  );
+
+  useEffect(() => {
+    if (isLocking && lockedListenerId === null) {
+      setLockedListenerId(listenerId);
+    }
+
+    return () => {
+      if (isLocking && lockedListenerId === listenerId) {
+        setLockedListenerId(null);
+      }
+    };
+  }, [isLocking, listenerId, lockedListenerId, setLockedListenerId]);
+
+  const handleMouseDown = useRecoilCallback(
+    ({ set }) =>
+      (event: MouseEvent | TouchEvent) => {
+        if (mode === ClickOutsideMode.compareHTMLRef) {
+          const clickedOnAtLeastOneRef = refs
+            .filter((ref) => !!ref.current)
+            .some((ref) => ref.current?.contains(event.target as Node));
+
+          set(
+            getClickOutsideListenerIsMouseDownInsideState(),
+            clickedOnAtLeastOneRef,
+          );
+        }
+
+        if (mode === ClickOutsideMode.comparePixels) {
+          const clickedOnAtLeastOneRef = refs
+            .filter((ref) => !!ref.current)
+            .some((ref) => {
+              if (!ref.current) {
+                return false;
+              }
+
+              const { x, y, width, height } =
+                ref.current.getBoundingClientRect();
+
+              const clientX =
+                'clientX' in event
+                  ? event.clientX
+                  : event.changedTouches[0].clientX;
+              const clientY =
+                'clientY' in event
+                  ? event.clientY
+                  : event.changedTouches[0].clientY;
+
+              if (
+                clientX < x ||
+                clientX > x + width ||
+                clientY < y ||
+                clientY > y + height
+              ) {
+                return false;
+              }
+              return true;
+            });
+
+          set(
+            getClickOutsideListenerIsMouseDownInsideState(),
+            clickedOnAtLeastOneRef,
+          );
+        }
+      },
+    [mode, refs, getClickOutsideListenerIsMouseDownInsideState],
+  );
+
+  const handleClickOutside = useRecoilCallback(
+    ({ snapshot }) =>
+      (event: MouseEvent | TouchEvent) => {
+        const isMouseDownInside = snapshot
+          .getLoadable(getClickOutsideListenerIsMouseDownInsideState())
+          .getValue();
+
+        if (mode === ClickOutsideMode.compareHTMLRef) {
+          const clickedOnAtLeastOneRef = refs
+            .filter((ref) => !!ref.current)
+            .some((ref) => ref.current?.contains(event.target as Node));
+
+          if (!clickedOnAtLeastOneRef && !isMouseDownInside) {
+            callback(event);
+          }
+        }
+
+        if (mode === ClickOutsideMode.comparePixels) {
+          const clickedOnAtLeastOneRef = refs
+            .filter((ref) => !!ref.current)
+            .some((ref) => {
+              if (!ref.current) {
+                return false;
+              }
+
+              const { x, y, width, height } =
+                ref.current.getBoundingClientRect();
+
+              const clientX =
+                'clientX' in event
+                  ? event.clientX
+                  : event.changedTouches[0].clientX;
+              const clientY =
+                'clientY' in event
+                  ? event.clientY
+                  : event.changedTouches[0].clientY;
+
+              if (
+                clientX < x ||
+                clientX > x + width ||
+                clientY < y ||
+                clientY > y + height
+              ) {
+                return false;
+              }
+              return true;
+            });
+
+          if (!clickedOnAtLeastOneRef && !isMouseDownInside) {
+            callback(event);
+          }
+        }
+      },
+    [mode, refs, callback, getClickOutsideListenerIsMouseDownInsideState],
+  );
+
+  const isEnabled = useRecoilValue(getClickOutsideListenerIsEnabledState());
+
+  const noListenerIsLocked = lockedListenerId === null;
+
+  const thisListenerIsLocked = lockedListenerId === listenerId;
+
+  const thisListenerMustListen =
+    isEnabled && (thisListenerIsLocked || noListenerIsLocked);
+
+  useEffect(() => {
+    if (thisListenerMustListen) {
+      document.addEventListener('mousedown', handleMouseDown, {
+        capture: true,
+      });
+      document.addEventListener('click', handleClickOutside, { capture: true });
+      document.addEventListener('touchstart', handleMouseDown, {
+        capture: true,
+      });
+      document.addEventListener('touchend', handleClickOutside, {
+        capture: true,
+      });
+
+      return () => {
+        document.removeEventListener('mousedown', handleMouseDown, {
+          capture: true,
+        });
+        document.removeEventListener('click', handleClickOutside, {
+          capture: true,
+        });
+        document.removeEventListener('touchstart', handleMouseDown, {
+          capture: true,
+        });
+        document.removeEventListener('touchend', handleClickOutside, {
+          capture: true,
+        });
+      };
+    }
+  }, [
+    refs,
+    callback,
+    mode,
+    thisListenerMustListen,
+    handleClickOutside,
+    handleMouseDown,
+  ]);
+};

--- a/packages/twenty-front/src/modules/ui/utilities/pointer-event/states/clickOutsideListenerIsActivatedStateScopeMap.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/pointer-event/states/clickOutsideListenerIsActivatedStateScopeMap.ts
@@ -1,7 +1,7 @@
 import { createStateScopeMap } from '@/ui/utilities/recoil-scope/utils/createStateScopeMap';
 
-export const clickOutsideListenerIsEnabledStateScopeMap =
+export const clickOutsideListenerIsActivatedStateScopeMap =
   createStateScopeMap<boolean>({
-    key: 'clickOutsideListenerIsEnabledStateScopeMap',
+    key: 'clickOutsideListenerIsActivatedStateScopeMap',
     defaultValue: true,
   });

--- a/packages/twenty-front/src/modules/ui/utilities/pointer-event/states/clickOutsideListenerIsEnabledStateScopeMap.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/pointer-event/states/clickOutsideListenerIsEnabledStateScopeMap.ts
@@ -1,0 +1,7 @@
+import { createStateScopeMap } from '@/ui/utilities/recoil-scope/utils/createStateScopeMap';
+
+export const clickOutsideListenerIsEnabledStateScopeMap =
+  createStateScopeMap<boolean>({
+    key: 'clickOutsideListenerIsEnabledStateScopeMap',
+    defaultValue: true,
+  });

--- a/packages/twenty-front/src/modules/ui/utilities/pointer-event/states/clickOutsideListenerIsMouseDownInsideStateScopeMap.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/pointer-event/states/clickOutsideListenerIsMouseDownInsideStateScopeMap.ts
@@ -1,0 +1,7 @@
+import { createStateScopeMap } from '@/ui/utilities/recoil-scope/utils/createStateScopeMap';
+
+export const clickOutsideListenerIsMouseDownInsideStateScopeMap =
+  createStateScopeMap<boolean>({
+    key: 'clickOutsideListenerIsMouseDownInsideStateScopeMap',
+    defaultValue: false,
+  });

--- a/packages/twenty-front/src/modules/ui/utilities/pointer-event/states/lockedListenerIdState.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/pointer-event/states/lockedListenerIdState.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const lockedListenerIdState = atom<string | null>({
+  key: 'lockedListenerIdState',
+  default: null,
+});


### PR DESCRIPTION
Closes #3416, closes #3412 

- Created scoped states for useListenClickOutside
- Created a module hook `useClickOutsideListener`
- listenerActivated is a scoped state that can be changed from anywhere
- isMouseDownInside is now a scoped state that fix various bugs and re-renders.
- click handlers are now recoil callbacks.