### PR TITLE
Add tests for `modules/ui/layout/tab`

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/tab/hooks/__tests__/useTabList.test.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/tab/hooks/__tests__/useTabList.test.tsx
@@ -1,0 +1,35 @@
+import { act } from 'react-dom/test-utils';
+import { renderHook } from '@testing-library/react';
+import { RecoilRoot, useRecoilValue } from 'recoil';
+
+import { useTabList } from '../useTabList';
+
+describe('useTabList', () => {
+  it('Should update the activeTabId state', async () => {
+    const { result } = renderHook(
+      () => {
+        const { getActiveTabIdState, setActiveTabId } =
+          useTabList('TEST_TAB_LIST_ID');
+        const activeTabId = useRecoilValue(getActiveTabIdState());
+
+        return {
+          getActiveTabIdState: getActiveTabIdState,
+          activeTabId,
+          setActiveTabId: setActiveTabId,
+        };
+      },
+      {
+        wrapper: RecoilRoot,
+      },
+    );
+    expect(result.current.getActiveTabIdState).toBeInstanceOf(Function);
+    expect(result.current.setActiveTabId).toBeInstanceOf(Function);
+    expect(result.current.activeTabId).toBeNull();
+
+    act(() => {
+      result.current.setActiveTabId('test-value');
+    });
+
+    expect(result.current.activeTabId).toBe('test-value');
+  });
+});


### PR DESCRIPTION
## Description
This is a child issue of #2992 which addresses increasing test coverage for the front-end. This issue is for the increasing coverage for `modules/ui/layout/tab`

### Ref
#3481

## Coverage Report
![297527570-7b9304c5-ba1c-4029-a721-39daed6760db](https://github.com/twentyhq/twenty/assets/140154534/7968a90a-6b62-4f39-91cf-9bdd5fe82479)


Fixes #3481