### PR TITLE
Improve health check command

### DIFF
--- a/packages/twenty-server/src/metadata/object-metadata/object-metadata.service.ts
+++ b/packages/twenty-server/src/metadata/object-metadata/object-metadata.service.ts
@@ -101,7 +101,7 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
             },
             icon: 'Icon123',
             description: 'Id',
-            isNullable: true,
+            isNullable: false,
             isActive: true,
             isCustom: false,
             isSystem: true,
@@ -117,7 +117,7 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
             },
             icon: 'IconAbc',
             description: 'Name',
-            isNullable: true,
+            isNullable: false,
             isActive: true,
             isCustom: false,
             workspaceId: objectMetadataInput.workspaceId,
@@ -132,7 +132,7 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
             },
             icon: 'IconCalendar',
             description: 'Creation date',
-            isNullable: true,
+            isNullable: false,
             isActive: true,
             isCustom: false,
             workspaceId: objectMetadataInput.workspaceId,
@@ -147,7 +147,7 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
             },
             icon: 'IconCalendar',
             description: 'Update date',
-            isNullable: true,
+            isNullable: false,
             isActive: true,
             isCustom: false,
             isSystem: true,
@@ -330,6 +330,7 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
   ) {
     return this.objectMetadataRepository.find({
       relations: [
+        'fields.object',
         'fields',
         'fields.fromRelationMetadata',
         'fields.toRelationMetadata',

--- a/packages/twenty-server/src/metadata/object-metadata/object-metadata.service.ts
+++ b/packages/twenty-server/src/metadata/object-metadata/object-metadata.service.ts
@@ -245,7 +245,7 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
             {
               action: WorkspaceMigrationColumnActionType.CREATE,
               columnName: 'name',
-              columnType: 'varchar',
+              columnType: 'text',
               defaultValue: "'Untitled'",
             } satisfies WorkspaceMigrationColumnCreate,
           ],

--- a/packages/twenty-server/src/metadata/relation-metadata/relation-metadata.service.ts
+++ b/packages/twenty-server/src/metadata/relation-metadata/relation-metadata.service.ts
@@ -20,13 +20,12 @@ import { WorkspaceMigrationColumnActionType } from 'src/metadata/workspace-migra
 import { ObjectMetadataEntity } from 'src/metadata/object-metadata/object-metadata.entity';
 import { createCustomColumnName } from 'src/metadata/utils/create-custom-column-name.util';
 import { computeObjectTargetTable } from 'src/workspace/utils/compute-object-target-table.util';
+import { createRelationForeignKeyColumnName } from 'src/metadata/relation-metadata/utils/create-relation-foreign-key-column-name.util';
 
 import {
   RelationMetadataEntity,
   RelationMetadataType,
 } from './relation-metadata.entity';
-
-import { createRelationMetadataForeignKey } from './utils/create-relation-metadata-foreign-key.util';
 
 @Injectable()
 export class RelationMetadataService extends TypeOrmQueryService<RelationMetadataEntity> {
@@ -56,7 +55,7 @@ export class RelationMetadataService extends TypeOrmQueryService<RelationMetadat
     // NOTE: this logic is called to create relation through metadata graphql endpoint (so only for custom field relations)
     const isCustom = true;
     const baseColumnName = `${camelCase(relationMetadataInput.toName)}Id`;
-    const foreignKeyColumnName = createRelationMetadataForeignKey(
+    const foreignKeyColumnName = createRelationForeignKeyColumnName(
       relationMetadataInput.toName,
       isCustom,
     );

--- a/packages/twenty-server/src/metadata/relation-metadata/utils/create-relation-foreign-key-column-name.util.ts
+++ b/packages/twenty-server/src/metadata/relation-metadata/utils/create-relation-foreign-key-column-name.util.ts
@@ -1,9 +1,9 @@
 import { createCustomColumnName } from 'src/metadata/utils/create-custom-column-name.util';
 import { camelCase } from 'src/utils/camel-case';
 
-export const createRelationMetadataForeignKey = (
+export const createRelationForeignKeyColumnName = (
   name: string,
-  isCustom?: boolean,
+  isCustom: boolean,
 ) => {
   const baseColumnName = `${camelCase(name)}Id`;
 

--- a/packages/twenty-server/src/metadata/relation-metadata/utils/create-relation-foreign-key-field-metadata-name.util.ts
+++ b/packages/twenty-server/src/metadata/relation-metadata/utils/create-relation-foreign-key-field-metadata-name.util.ts
@@ -1,0 +1,5 @@
+import { camelCase } from 'src/utils/camel-case';
+
+export const createRelationForeignKeyFieldMetadataName = (name: string) => {
+  return `${camelCase(name)}Id`;
+};

--- a/packages/twenty-server/src/workspace/workspace-health/services/field-metadata-health.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/services/field-metadata-health.service.ts
@@ -18,7 +18,6 @@ import { compositeDefinitions } from 'src/metadata/field-metadata/composite-type
 import { validateDefaultValueForType } from 'src/metadata/field-metadata/utils/validate-default-value-for-type.util';
 import { isEnumFieldMetadataType } from 'src/metadata/field-metadata/utils/is-enum-field-metadata-type.util';
 import { validateOptionsForType } from 'src/metadata/field-metadata/utils/validate-options-for-type.util';
-import { fieldMetadataTypeToColumnType } from 'src/metadata/workspace-migration/utils/field-metadata-type-to-column-type.util';
 
 @Injectable()
 export class FieldMetadataHealthService {
@@ -133,14 +132,6 @@ export class FieldMetadataHealthService {
     const columnStructure = workspaceTableColumns.find(
       (tableDefinition) => tableDefinition.columnName === columnName,
     );
-
-    console.log(
-      'fieldMetadataType',
-      fieldMetadataTypeToColumnType(fieldMetadata.type),
-    );
-    console.log('expected dataType', dataType);
-
-    console.log('columnStructure type', columnStructure?.dataType);
 
     if (!columnStructure) {
       issues.push({

--- a/packages/twenty-server/src/workspace/workspace-health/services/relation-metadata.health.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/services/relation-metadata.health.service.ts
@@ -142,21 +142,37 @@ export class RelationMetadataHealthService {
       isCustom,
     );
     const relationColumn = workspaceTableColumns.find(
-      (column) =>
-        column.columnName ===
-        createRelationForeignKeyFieldMetadataName(toFieldMetadata.name),
+      (column) => column.columnName === foreignKeyColumnName,
     );
     const relationFieldMetadata = toObjectMetadataFields.find(
-      (fieldMetadata) => fieldMetadata.name === foreignKeyColumnName,
+      (fieldMetadata) =>
+        fieldMetadata.name ===
+        createRelationForeignKeyFieldMetadataName(toFieldMetadata.name),
     );
 
-    if (!relationColumn || !relationFieldMetadata) {
+    if (!relationFieldMetadata) {
       issues.push({
         type: WorkspaceHealthIssueType.RELATION_FOREIGN_KEY_NOT_VALID,
         fromFieldMetadata,
         toFieldMetadata,
         relationMetadata,
-        message: `Relation ${relationMetadata.id} doesn't have a valid foreign key`,
+        message: `Relation ${
+          relationMetadata.id
+        } doesn't have a valid foreign key (expected fieldMetadata.name to be ${createRelationForeignKeyFieldMetadataName(
+          toFieldMetadata.name,
+        )}`,
+      });
+
+      return issues;
+    }
+
+    if (!relationColumn) {
+      issues.push({
+        type: WorkspaceHealthIssueType.RELATION_FOREIGN_KEY_NOT_VALID,
+        fromFieldMetadata,
+        toFieldMetadata,
+        relationMetadata,
+        message: `Relation ${relationMetadata.id} doesn't have a valid foreign key (expected column name to be ${foreignKeyColumnName}`,
       });
 
       return issues;

--- a/packages/twenty-server/src/workspace/workspace-health/services/relation-metadata.health.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/services/relation-metadata.health.service.ts
@@ -18,12 +18,13 @@ import {
   RelationMetadataEntity,
   RelationMetadataType,
 } from 'src/metadata/relation-metadata/relation-metadata.entity';
-import { createRelationMetadataForeignKey } from 'src/metadata/relation-metadata/utils/create-relation-metadata-foreign-key.util';
 import {
   RelationDirection,
   deduceRelationDirection,
 } from 'src/workspace/utils/deduce-relation-direction.util';
 import { ObjectMetadataEntity } from 'src/metadata/object-metadata/object-metadata.entity';
+import { createRelationForeignKeyColumnName } from 'src/metadata/relation-metadata/utils/create-relation-foreign-key-column-name.util';
+import { createRelationForeignKeyFieldMetadataName } from 'src/metadata/relation-metadata/utils/create-relation-foreign-key-field-metadata-name.util';
 
 @Injectable()
 export class RelationMetadataHealthService {
@@ -136,12 +137,14 @@ export class RelationMetadataHealthService {
     }
 
     const isCustom = toFieldMetadata.isCustom ?? false;
-    const foreignKeyColumnName = createRelationMetadataForeignKey(
+    const foreignKeyColumnName = createRelationForeignKeyColumnName(
       toFieldMetadata.name,
       isCustom,
     );
     const relationColumn = workspaceTableColumns.find(
-      (column) => column.columnName === foreignKeyColumnName,
+      (column) =>
+        column.columnName ===
+        createRelationForeignKeyFieldMetadataName(toFieldMetadata.name),
     );
     const relationFieldMetadata = toObjectMetadataFields.find(
       (fieldMetadata) => fieldMetadata.name === foreignKeyColumnName,


### PR DESCRIPTION
This PR fixes two bugs on the health check command:
- enum type support (we should get the complete typename)
- wrong fieldName prefix with _ in case of custom object (fieldName itself should not be prefixed, columnName should be)

Also improving logs on a few exception to ease root cause search