### PR TITLE
Update company board card link to opportunity show page

### DIFF
--- a/packages/twenty-front/src/modules/companies/__stories__/CompanyChip.stories.tsx
+++ b/packages/twenty-front/src/modules/companies/__stories__/CompanyChip.stories.tsx
@@ -15,16 +15,16 @@ type Story = StoryObj<typeof CompanyChip>;
 
 export const SmallName: Story = {
   args: {
-    id: 'airbnb',
-    name: 'Airbnb',
+    opportunityId: 'airbnb',
+    companyName: 'Airbnb',
     avatarUrl: 'https://api.faviconkit.com/airbnb.com/144',
   },
 };
 
 export const BigName: Story = {
   args: {
-    id: 'google',
-    name: 'Google with a real big name to overflow the cell',
+    opportunityId: 'google',
+    companyName: 'Google with a real big name to overflow the cell',
     avatarUrl: 'https://api.faviconkit.com/google.com/144',
   },
 };

--- a/packages/twenty-front/src/modules/companies/components/CompanyBoardCard.tsx
+++ b/packages/twenty-front/src/modules/companies/components/CompanyBoardCard.tsx
@@ -197,8 +197,8 @@ export const CompanyBoardCard = () => {
       >
         <StyledBoardCardHeader showCompactView={showCompactView}>
           <CompanyChip
-            id={company.id}
-            name={company.name}
+            opportunityId={opportunity.id}
+            companyName={company.name}
             avatarUrl={getLogoUrlFromDomainName(company.domainName)}
             variant={EntityChipVariant.Transparent}
           />

--- a/packages/twenty-front/src/modules/companies/components/CompanyChip.tsx
+++ b/packages/twenty-front/src/modules/companies/components/CompanyChip.tsx
@@ -4,22 +4,22 @@ import {
 } from '@/ui/display/chip/components/EntityChip';
 
 type CompanyChipProps = {
-  id: string;
-  name: string;
+  opportunityId: string;
+  companyName: string;
   avatarUrl?: string;
   variant?: EntityChipVariant;
 };
 
 export const CompanyChip = ({
-  id,
-  name,
+  opportunityId,
+  companyName,
   avatarUrl,
   variant = EntityChipVariant.Regular,
 }: CompanyChipProps) => (
   <EntityChip
-    entityId={id}
-    linkToEntity={`/object/company/${id}`}
-    name={name}
+    entityId={opportunityId}
+    linkToEntity={`/object/opportunity/${opportunityId}`}
+    name={companyName}
     avatarType="squared"
     avatarUrl={avatarUrl}
     variant={variant}


### PR DESCRIPTION
- Update board card link so it redirects to the opportunity show page
- Update prop names, since we now send id and name from different entities 
- Do not rename component since this should be deprecated soon to use the Record table

<img width="400" alt="Capture d’écran 2024-01-19 à 16 31 02" src="https://github.com/twentyhq/twenty/assets/22936103/84c6abf1-9f2a-4953-835b-e48a04825b54">
