### PR TITLE
Standard Object prefill updates

### DIFF
--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/activity.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/activity.object-metadata.ts
@@ -26,7 +26,6 @@ export class ActivityObjectMetadata extends BaseObjectMetadata {
     description: 'Activity title',
     icon: 'IconNotes',
   })
-  @IsNullable()
   title: string;
 
   @FieldMetadata({
@@ -35,7 +34,6 @@ export class ActivityObjectMetadata extends BaseObjectMetadata {
     description: 'Activity body',
     icon: 'IconList',
   })
-  @IsNullable()
   body: string;
 
   @FieldMetadata({

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/api-key.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/api-key.object-metadata.ts
@@ -19,7 +19,6 @@ export class ApiKeyObjectMetadata extends BaseObjectMetadata {
     label: 'Name',
     description: 'ApiKey name',
     icon: 'IconLink',
-    defaultValue: { value: '' },
   })
   name: string;
 

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/comment.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/comment.object-metadata.ts
@@ -20,7 +20,6 @@ export class CommentObjectMetadata extends BaseObjectMetadata {
     label: 'Body',
     description: 'Comment body',
     icon: 'IconLink',
-    defaultValue: { value: '' },
   })
   body: string;
 

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/company.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/company.object-metadata.ts
@@ -37,7 +37,6 @@ export class CompanyObjectMetadata extends BaseObjectMetadata {
       'The company website URL. We use this url to fetch the company icon',
     icon: 'IconLink',
   })
-  @IsNullable()
   domainName?: string;
 
   @FieldMetadata({
@@ -46,7 +45,6 @@ export class CompanyObjectMetadata extends BaseObjectMetadata {
     description: 'The company address',
     icon: 'IconMap',
   })
-  @IsNullable()
   address: string;
 
   @FieldMetadata({

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/connected-account.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/connected-account.object-metadata.ts
@@ -69,7 +69,6 @@ export class ConnectedAccountObjectMetadata extends BaseObjectMetadata {
     description: 'Last sync history ID',
     icon: 'IconHistory',
   })
-  @IsNullable()
   lastSyncHistoryId: string;
 
   @FieldMetadata({

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/message-channel.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/message-channel.object-metadata.ts
@@ -56,7 +56,6 @@ export class MessageChannelObjectMetadata extends BaseObjectMetadata {
     description: 'Type',
     icon: 'IconMessage',
   })
-  @IsNullable()
   type: string;
 
   @FieldMetadata({

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/message-participant.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/message-participant.object-metadata.ts
@@ -59,7 +59,6 @@ export class MessageParticipantObjectMetadata extends BaseObjectMetadata {
     description: 'Display Name',
     icon: 'IconUser',
   })
-  @IsNullable()
   displayName: string;
 
   @FieldMetadata({

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/message-thread.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/message-thread.object-metadata.ts
@@ -29,7 +29,6 @@ export class MessageThreadObjectMetadata extends BaseObjectMetadata {
     description: 'Thread id from the messaging provider',
     icon: 'IconMessage',
   })
-  @IsNullable()
   externalId: string;
 
   @FieldMetadata({
@@ -38,7 +37,6 @@ export class MessageThreadObjectMetadata extends BaseObjectMetadata {
     description: 'Subject',
     icon: 'IconMessage',
   })
-  @IsNullable()
   subject: string;
 
   @FieldMetadata({
@@ -59,7 +57,6 @@ export class MessageThreadObjectMetadata extends BaseObjectMetadata {
     icon: 'IconEyeglass',
     defaultValue: { value: 'default' },
   })
-  @IsNullable()
   visibility: string;
 
   @FieldMetadata({

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/message.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/message.object-metadata.ts
@@ -29,7 +29,6 @@ export class MessageObjectMetadata extends BaseObjectMetadata {
     description: 'Message id from the messaging provider',
     icon: 'IconHash',
   })
-  @IsNullable()
   externalId: string;
 
   @FieldMetadata({
@@ -38,7 +37,6 @@ export class MessageObjectMetadata extends BaseObjectMetadata {
     description: 'Message id from the message header',
     icon: 'IconHash',
   })
-  @IsNullable()
   headerMessageId: string;
 
   @FieldMetadata({
@@ -67,7 +65,6 @@ export class MessageObjectMetadata extends BaseObjectMetadata {
     description: 'Subject',
     icon: 'IconMessage',
   })
-  @IsNullable()
   subject: string;
 
   @FieldMetadata({
@@ -76,7 +73,6 @@ export class MessageObjectMetadata extends BaseObjectMetadata {
     description: 'Body',
     icon: 'IconMessage',
   })
-  @IsNullable()
   body: string;
 
   @FieldMetadata({

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/opportunity.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/opportunity.object-metadata.ts
@@ -53,7 +53,6 @@ export class OpportunityObjectMetadata extends BaseObjectMetadata {
     icon: 'IconProgressCheck',
     defaultValue: { value: '0' },
   })
-  @IsNullable()
   probability: string;
 
   // Relations

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/person.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/person.object-metadata.ts
@@ -39,7 +39,6 @@ export class PersonObjectMetadata extends BaseObjectMetadata {
     description: 'Contact’s Email',
     icon: 'IconMail',
   })
-  @IsNullable()
   email: string;
 
   @FieldMetadata({
@@ -66,7 +65,6 @@ export class PersonObjectMetadata extends BaseObjectMetadata {
     description: 'Contact’s job title',
     icon: 'IconBriefcase',
   })
-  @IsNullable()
   jobTitle: string;
 
   @FieldMetadata({
@@ -75,7 +73,6 @@ export class PersonObjectMetadata extends BaseObjectMetadata {
     description: 'Contact’s phone number',
     icon: 'IconPhone',
   })
-  @IsNullable()
   phone: string;
 
   @FieldMetadata({
@@ -84,7 +81,6 @@ export class PersonObjectMetadata extends BaseObjectMetadata {
     description: 'Contact’s city',
     icon: 'IconMap',
   })
-  @IsNullable()
   city: string;
 
   @FieldMetadata({
@@ -94,7 +90,6 @@ export class PersonObjectMetadata extends BaseObjectMetadata {
     icon: 'IconFileUpload',
   })
   @IsSystem()
-  @IsNullable()
   avatarUrl: string;
 
   // Relations

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/pipeline-step.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/pipeline-step.object-metadata.ts
@@ -23,7 +23,6 @@ export class PipelineStepObjectMetadata extends BaseObjectMetadata {
     description: 'Pipeline Step name',
     icon: 'IconCurrencyDollar',
   })
-  @IsNullable()
   name: string;
 
   @FieldMetadata({
@@ -32,7 +31,6 @@ export class PipelineStepObjectMetadata extends BaseObjectMetadata {
     description: 'Pipeline Step color',
     icon: 'IconColorSwatch',
   })
-  @IsNullable()
   color: string;
 
   @FieldMetadata({

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/view-filter.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/view-filter.object-metadata.ts
@@ -34,7 +34,6 @@ export class ViewFilterObjectMetadata extends BaseObjectMetadata {
     type: FieldMetadataType.TEXT,
     label: 'Value',
     description: 'View Filter value',
-    defaultValue: { value: '' },
   })
   value: string;
 
@@ -42,7 +41,6 @@ export class ViewFilterObjectMetadata extends BaseObjectMetadata {
     type: FieldMetadataType.TEXT,
     label: 'Display Value',
     description: 'View Filter Display Value',
-    defaultValue: { value: '' },
   })
   displayValue: string;
 

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/view.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/view.object-metadata.ts
@@ -23,7 +23,6 @@ export class ViewObjectMetadata extends BaseObjectMetadata {
     type: FieldMetadataType.TEXT,
     label: 'Name',
     description: 'View name',
-    defaultValue: { value: '' },
   })
   name: string;
 


### PR DESCRIPTION
In this PR, I'm changing nullability constraint on prefilled standard objects:
- string (fieldType = TEXT) should always be non nullable
- they should always have a default value. This default value is '' by default in the code, so we don't have to specify it in the field decorator.