### PR TITLE
Add tests for `modules/ui/utilities/pointer-event`

### DIFF
--- a/packages/twenty-front/src/modules/ui/utilities/pointer-event/hooks/__tests__/useClickOutsideListener.test.tsx
+++ b/packages/twenty-front/src/modules/ui/utilities/pointer-event/hooks/__tests__/useClickOutsideListener.test.tsx
@@ -1,0 +1,42 @@
+import { act, renderHook } from '@testing-library/react';
+import { RecoilRoot, useRecoilValue } from 'recoil';
+
+import { useClickOustideListenerStates } from '@/ui/utilities/pointer-event/hooks/useClickOustideListenerStates';
+import { useClickOutsideListener } from '@/ui/utilities/pointer-event/hooks/useClickOutsideListener';
+
+const componentId = 'componentId';
+
+describe('useClickOutsideListener', () => {
+  it('should toggle the click outside listener activation state', async () => {
+    const { result } = renderHook(
+      () => {
+        const { getClickOutsideListenerIsActivatedState } =
+          useClickOustideListenerStates(componentId);
+
+        return {
+          useClickOutside: useClickOutsideListener(componentId),
+          isActivated: useRecoilValue(
+            getClickOutsideListenerIsActivatedState(),
+          ),
+        };
+      },
+      {
+        wrapper: RecoilRoot,
+      },
+    );
+
+    const toggle = result.current.useClickOutside.toggleClickOutsideListener;
+
+    act(() => {
+      toggle(true);
+    });
+
+    expect(result.current.isActivated).toBe(true);
+
+    act(() => {
+      toggle(false);
+    });
+
+    expect(result.current.isActivated).toBe(false);
+  });
+});

--- a/packages/twenty-front/src/modules/ui/utilities/pointer-event/hooks/__tests__/useListenClickOutsideV2.test.tsx
+++ b/packages/twenty-front/src/modules/ui/utilities/pointer-event/hooks/__tests__/useListenClickOutsideV2.test.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { fireEvent, renderHook } from '@testing-library/react';
+import { RecoilRoot } from 'recoil';
+
+import {
+  ClickOutsideMode,
+  useListenClickOutsideV2,
+} from '@/ui/utilities/pointer-event/hooks/useListenClickOutsideV2';
+
+const containerRef = React.createRef<HTMLDivElement>();
+const nullRef = React.createRef<HTMLDivElement>();
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <RecoilRoot>
+    <div ref={containerRef}>{children}</div>
+  </RecoilRoot>
+);
+
+const listenerId = 'listenerId';
+describe('useListenClickOutsideV2', () => {
+  it('should trigger the callback when clicking outside the specified refs', () => {
+    const callback = jest.fn();
+
+    renderHook(
+      () =>
+        useListenClickOutsideV2({
+          refs: [containerRef],
+          callback,
+          listenerId,
+        }),
+      { wrapper: Wrapper },
+    );
+
+    act(() => {
+      fireEvent.mouseDown(document);
+      fireEvent.click(document);
+    });
+
+    expect(callback).toHaveBeenCalled();
+  });
+
+  it('should trigger the callback when clicking outside the specified ref with pixel comparison', async () => {
+    const callback = jest.fn();
+
+    renderHook(
+      () =>
+        useListenClickOutsideV2({
+          refs: [nullRef],
+          callback,
+          mode: ClickOutsideMode.comparePixels,
+          listenerId,
+        }),
+      { wrapper: Wrapper },
+    );
+
+    act(() => {
+      fireEvent.mouseDown(document);
+      fireEvent.click(document);
+    });
+
+    expect(callback).toHaveBeenCalled();
+  });
+
+  it('should not call the callback when clicking inside the specified refs using default comparison', () => {
+    const callback = jest.fn();
+
+    renderHook(
+      () =>
+        useListenClickOutsideV2({
+          refs: [containerRef],
+          callback,
+          listenerId,
+        }),
+      { wrapper: Wrapper },
+    );
+
+    act(() => {
+      if (containerRef.current) {
+        fireEvent.mouseDown(containerRef.current);
+        fireEvent.click(containerRef.current);
+      }
+    });
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('should not call the callback when clicking inside the specified refs using pixel comparison', () => {
+    const callback = jest.fn();
+
+    renderHook(
+      () =>
+        useListenClickOutsideV2({
+          refs: [containerRef],
+          callback,
+          mode: ClickOutsideMode.comparePixels,
+          listenerId,
+        }),
+      { wrapper: Wrapper },
+    );
+
+    act(() => {
+      if (containerRef.current) {
+        fireEvent.mouseDown(containerRef.current);
+        fireEvent.click(containerRef.current);
+      }
+    });
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
### Description
This is a child issue of #2992 which addresses increasing test coverage for the front-end. This issue is for the increasing coverage for `modules/ui/utilities/pointer-event`

### Refs
https://github.com/twentyhq/twenty/issues/3550

### Coverage Report
![298176801-ddf520d6-dd0c-4d97-9d6a-1838f049a4ed](https://github.com/twentyhq/twenty/assets/140154534/63e20c31-ea55-452a-aa65-2c36a6cf3e8a)

Fixes #3550

