### PR TITLE
Fix Continuous Deployment script after adding twenty-emails package

### DIFF
--- a/packages/twenty-docker/prod/twenty-docs/Dockerfile
+++ b/packages/twenty-docker/prod/twenty-docs/Dockerfile
@@ -9,8 +9,8 @@ COPY ./yarn.lock .
 COPY ./.yarnrc.yml .
 COPY ./.yarn/releases /app/.yarn/releases
 COPY ./packages/twenty-docs/package.json /app/packages/twenty-docs/package.json
-COPY ./packages/twenty-docs /app/packages/twenty-docs
-RUN yarn 
+COPY ./packages/twenty-emails /app/packages/twenty-emails
+RUN yarn
 
 COPY ./packages/twenty-docs /app/packages/twenty-docs
 RUN yarn nx build twenty-docs

--- a/packages/twenty-docker/prod/twenty-docs/Dockerfile
+++ b/packages/twenty-docker/prod/twenty-docs/Dockerfile
@@ -9,6 +9,7 @@ COPY ./yarn.lock .
 COPY ./.yarnrc.yml .
 COPY ./.yarn/releases /app/.yarn/releases
 COPY ./packages/twenty-docs/package.json /app/packages/twenty-docs/package.json
+COPY ./packages/twenty-docs /app/packages/twenty-docs
 RUN yarn 
 
 COPY ./packages/twenty-docs /app/packages/twenty-docs

--- a/packages/twenty-docker/prod/twenty-front/Dockerfile
+++ b/packages/twenty-docker/prod/twenty-front/Dockerfile
@@ -1,3 +1,4 @@
+
 FROM node:18.17.1-alpine as twenty-front-build
 
 ARG REACT_APP_SERVER_BASE_URL
@@ -12,6 +13,7 @@ COPY ./.yarnrc.yml .
 COPY ./.yarn/releases /app/.yarn/releases
 COPY ./tools/eslint-rules /app/tools/eslint-rules
 COPY ./packages/twenty-front /app/packages/twenty-front
+COPY ./packages/twenty-emails /app/packages/twenty-emails
 
 RUN yarn
 RUN yarn nx build twenty-front

--- a/packages/twenty-docker/prod/twenty-front/Dockerfile
+++ b/packages/twenty-docker/prod/twenty-front/Dockerfile
@@ -16,9 +16,10 @@ COPY ./packages/twenty-emails /app/packages/twenty-emails
 COPY ./packages/twenty-front/package.json /app/packages/twenty-front/package.json
 
 RUN yarn
-RUN yarn nx build twenty-front
 
 COPY ./packages/twenty-front /app/packages/twenty-front
+RUN yarn nx build twenty-front
+
 
 FROM node:18.17.1-alpine as twenty-front
 

--- a/packages/twenty-docker/prod/twenty-front/Dockerfile
+++ b/packages/twenty-docker/prod/twenty-front/Dockerfile
@@ -12,11 +12,13 @@ COPY ./yarn.lock .
 COPY ./.yarnrc.yml .
 COPY ./.yarn/releases /app/.yarn/releases
 COPY ./tools/eslint-rules /app/tools/eslint-rules
-COPY ./packages/twenty-front /app/packages/twenty-front
 COPY ./packages/twenty-emails /app/packages/twenty-emails
+COPY ./packages/twenty-front/package.json /app/packages/twenty-front/package.json
 
 RUN yarn
 RUN yarn nx build twenty-front
+
+COPY ./packages/twenty-front /app/packages/twenty-front
 
 FROM node:18.17.1-alpine as twenty-front
 

--- a/packages/twenty-docker/prod/twenty-front/Dockerfile
+++ b/packages/twenty-docker/prod/twenty-front/Dockerfile
@@ -1,4 +1,3 @@
-
 FROM node:18.17.1-alpine as twenty-front-build
 
 ARG REACT_APP_SERVER_BASE_URL

--- a/packages/twenty-docker/prod/twenty-server/Dockerfile
+++ b/packages/twenty-docker/prod/twenty-server/Dockerfile
@@ -11,16 +11,14 @@ COPY ./packages/twenty-server/package.json /app/packages/twenty-server/package.j
 COPY ./packages/twenty-server/patches /app/packages/twenty-server/patches
 COPY ./packages/twenty-emails /app/packages/twenty-emails
 
-WORKDIR /app/packages/twenty-server
+WORKDIR /app/packages/twenty-emails
 RUN yarn workspaces focus
-
-WORKDIR /app
-
-COPY ./packages/twenty-server /app/packages/twenty-server
-
-WORKDIR /app/packages/twenty-server
 RUN yarn build
 
+WORKDIR /app/packages/twenty-server
+COPY ./packages/twenty-server /app/packages/twenty-server
+RUN yarn workspaces focus
+RUN yarn build
 
 LABEL org.opencontainers.image.source=https://github.com/twentyhq/twenty
 LABEL org.opencontainers.image.description="This image provides a consistent and reproducible environment for the backend, ensuring it deploys faster and runs the same way regardless of the deployment environment."

--- a/packages/twenty-docker/prod/twenty-server/Dockerfile
+++ b/packages/twenty-docker/prod/twenty-server/Dockerfile
@@ -8,6 +8,7 @@ COPY ./.yarnrc.yml .
 COPY ./.yarn/releases /app/.yarn/releases
 COPY ./tools/eslint-rules /app/tools/eslint-rules
 COPY ./packages/twenty-server/package.json /app/packages/twenty-server/package.json
+COPY ./packages/twenty-server/patches /app/packages/twenty-server/patches
 COPY ./packages/twenty-emails /app/packages/twenty-emails
 
 WORKDIR /app/packages/twenty-server

--- a/packages/twenty-docker/prod/twenty-server/Dockerfile
+++ b/packages/twenty-docker/prod/twenty-server/Dockerfile
@@ -18,9 +18,9 @@ WORKDIR /app
 
 COPY ./packages/twenty-server /app/packages/twenty-server
 
+WORKDIR /app/packages/twenty-server
 RUN yarn build
 
-WORKDIR /app/packages/twenty-server
 
 LABEL org.opencontainers.image.source=https://github.com/twentyhq/twenty
 LABEL org.opencontainers.image.description="This image provides a consistent and reproducible environment for the backend, ensuring it deploys faster and runs the same way regardless of the deployment environment."

--- a/packages/twenty-docker/prod/twenty-server/Dockerfile
+++ b/packages/twenty-docker/prod/twenty-server/Dockerfile
@@ -7,11 +7,15 @@ COPY ./yarn.lock .
 COPY ./.yarnrc.yml .
 COPY ./.yarn/releases /app/.yarn/releases
 COPY ./tools/eslint-rules /app/tools/eslint-rules
-COPY ./packages/twenty-server /app/packages/twenty-server
+COPY ./packages/twenty-server/package.json /app/packages/twenty-server/package.json
 COPY ./packages/twenty-emails /app/packages/twenty-emails
 
 WORKDIR /app/packages/twenty-server
 RUN yarn workspaces focus
+
+WORKDIR /app
+
+COPY ./packages/twenty-server /app/packages/twenty-server
 
 RUN yarn build
 

--- a/packages/twenty-emails/package.json
+++ b/packages/twenty-emails/package.json
@@ -11,10 +11,10 @@
     "build": "tsup"
   },
   "devDependencies": {
-    "tsup": "^8.0.1",
-    "typescript": "^5.3.3",
     "@react-email/components": "0.0.12",
-    "@types/react": "^18.2.39"
+    "@types/react": "^18.2.39",
+    "tsup": "^8.0.1",
+    "typescript": "^5.3.3"
   },
   "engines": {
     "node": "^18.17.1",

--- a/packages/twenty-emails/package.json
+++ b/packages/twenty-emails/package.json
@@ -10,6 +10,12 @@
     "nx": "NX_DEFAULT_PROJECT=twenty-emails node ../../node_modules/nx/bin/nx.js",
     "build": "tsup"
   },
+  "devDependencies": {
+    "tsup": "^8.0.1",
+    "typescript": "^5.3.3",
+    "@react-email/components": "0.0.12",
+    "@types/react": "^18.2.39"
+  },
   "engines": {
     "node": "^18.17.1",
     "npm": "please-use-yarn",

--- a/yarn.lock
+++ b/yarn.lock
@@ -42370,6 +42370,11 @@ __metadata:
 "twenty-emails@workspace:*, twenty-emails@workspace:packages/twenty-emails":
   version: 0.0.0-use.local
   resolution: "twenty-emails@workspace:packages/twenty-emails"
+  dependencies:
+    "@react-email/components": "npm:0.0.12"
+    "@types/react": "npm:^18.2.39"
+    tsup: "npm:^8.0.1"
+    typescript: "npm:^5.3.3"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
1) Re-adding twenty-emails dependencies to its own package.json to enable build without pulling all repo dependencies

2) Adding twenty-emails build to twenty-server Dockerfile

3) Adding twenty-emails to twenty-front and twenty-docs (as we still install all dependencies for front and emails until we take a final decision on nx)

4) Optimizing slightly twenty-front Dockerfile to not re-install node modules if package.json hasn't change