### PR TITLE
Store HTML message

### DIFF
--- a/packages/twenty-server/src/core/messaging/timeline-messaging.service.ts
+++ b/packages/twenty-server/src/core/messaging/timeline-messaging.service.ts
@@ -62,6 +62,8 @@ export class TimelineMessagingService {
       [personIds],
     );
 
+    console.log(messageThreads);
+
     const formattedMessageThreads = messageThreads.map((messageThread) => {
       return {
         read: true,

--- a/packages/twenty-server/src/core/messaging/timeline-messaging.service.ts
+++ b/packages/twenty-server/src/core/messaging/timeline-messaging.service.ts
@@ -62,8 +62,6 @@ export class TimelineMessagingService {
       [personIds],
     );
 
-    console.log(messageThreads);
-
     const formattedMessageThreads = messageThreads.map((messageThread) => {
       return {
         read: true,

--- a/packages/twenty-server/src/workspace/messaging/services/messaging-utils.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/services/messaging-utils.service.ts
@@ -91,7 +91,7 @@ export class MessagingUtilsService {
     const receivedAt = new Date(parseInt(message.internalDate));
 
     await manager.query(
-      `INSERT INTO ${dataSourceMetadata.schema}."message" ("id", "headerMessageId", "subject", "receivedAt", "direction", "messageThreadId", "body") VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+      `INSERT INTO ${dataSourceMetadata.schema}."message" ("id", "headerMessageId", "subject", "receivedAt", "direction", "messageThreadId", "body", "html") VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
       [
         newMessageId,
         message.headerMessageId,
@@ -100,6 +100,7 @@ export class MessagingUtilsService {
         messageDirection,
         messageThreadId,
         message.text,
+        message.html,
       ],
     );
 

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/message.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/message.object-metadata.ts
@@ -71,6 +71,14 @@ export class MessageObjectMetadata extends BaseObjectMetadata {
   body: string;
 
   @FieldMetadata({
+    type: FieldMetadataType.TEXT,
+    label: 'Body',
+    description: 'Body',
+    icon: 'IconMessage',
+  })
+  html: string;
+
+  @FieldMetadata({
     type: FieldMetadataType.DATE_TIME,
     label: 'Received At',
     description: 'The date the message was received',

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/message.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/message.object-metadata.ts
@@ -72,8 +72,8 @@ export class MessageObjectMetadata extends BaseObjectMetadata {
 
   @FieldMetadata({
     type: FieldMetadataType.TEXT,
-    label: 'Body',
-    description: 'Body',
+    label: 'Html',
+    description: 'Html',
     icon: 'IconMessage',
   })
   html: string;


### PR DESCRIPTION
## Context
This PR adds html content to the message table, this will allow us to implement real inbox UI later on.

Note: We will also see if the size won't be an issue in the long run

## Test
<img width="328" alt="Screenshot 2024-01-23 at 19 39 19" src="https://github.com/twentyhq/twenty/assets/1834158/4e2bfaf3-146b-4166-8df1-e0b250468592">

