### PR TITLE
[messaging] Rename body to text

### DIFF
--- a/packages/twenty-front/src/modules/activities/emails/components/Threads.tsx
+++ b/packages/twenty-front/src/modules/activities/emails/components/Threads.tsx
@@ -5,6 +5,7 @@ import { ThreadPreview } from '@/activities/emails/components/ThreadPreview';
 import { getTimelineThreadsFromCompanyId } from '@/activities/emails/queries/getTimelineThreadsFromCompanyId';
 import { getTimelineThreadsFromPersonId } from '@/activities/emails/queries/getTimelineThreadsFromPersonId';
 import { ActivityTargetableObject } from '@/activities/types/ActivityTargetableEntity';
+import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
 import {
   H1Title,
   H1TitleFontColor,
@@ -31,12 +32,12 @@ const StyledEmailCount = styled.span`
 
 export const Threads = ({ entity }: { entity: ActivityTargetableObject }) => {
   const threadQuery =
-    entity.targetObjectNameSingular === 'person'
+    entity.targetObjectNameSingular === CoreObjectNameSingular.Person
       ? getTimelineThreadsFromPersonId
       : getTimelineThreadsFromCompanyId;
 
   const threadQueryVariables =
-    entity.targetObjectNameSingular === 'person'
+    entity.targetObjectNameSingular === CoreObjectNameSingular.Person
       ? { personId: entity.id }
       : { companyId: entity.id };
 
@@ -50,7 +51,7 @@ export const Threads = ({ entity }: { entity: ActivityTargetableObject }) => {
 
   const timelineThreads: TimelineThread[] =
     threads.data[
-      entity.targetObjectNameSingular === 'person'
+      entity.targetObjectNameSingular === CoreObjectNameSingular.Person
         ? 'getTimelineThreadsFromPersonId'
         : 'getTimelineThreadsFromCompanyId'
     ];

--- a/packages/twenty-front/src/modules/activities/emails/components/Threads.tsx
+++ b/packages/twenty-front/src/modules/activities/emails/components/Threads.tsx
@@ -50,7 +50,7 @@ export const Threads = ({ entity }: { entity: ActivityTargetableObject }) => {
 
   const timelineThreads: TimelineThread[] =
     threads.data[
-      entity.targetObjectNameSingular === 'Person'
+      entity.targetObjectNameSingular === 'person'
         ? 'getTimelineThreadsFromPersonId'
         : 'getTimelineThreadsFromCompanyId'
     ];

--- a/packages/twenty-server/src/core/messaging/timeline-messaging.service.ts
+++ b/packages/twenty-server/src/core/messaging/timeline-messaging.service.ts
@@ -30,7 +30,7 @@ export class TimelineMessagingService {
         subquery.*,
         message_count,
         last_message_subject,
-        last_message_body,
+        last_message_text,
         last_message_received_at,
         last_message_participant_handle,
         last_message_participant_displayName
@@ -39,7 +39,7 @@ export class TimelineMessagingService {
             mt.*,
             COUNT(m."id") OVER (PARTITION BY mt."id") AS message_count,
             FIRST_VALUE(m."subject") OVER (PARTITION BY mt."id" ORDER BY m."receivedAt" DESC) AS last_message_subject,
-            FIRST_VALUE(m."body") OVER (PARTITION BY mt."id" ORDER BY m."receivedAt" DESC) AS last_message_body,
+            FIRST_VALUE(m."text") OVER (PARTITION BY mt."id" ORDER BY m."receivedAt" DESC) AS last_message_text,
             FIRST_VALUE(m."receivedAt") OVER (PARTITION BY mt."id" ORDER BY m."receivedAt" DESC) AS last_message_received_at,
             FIRST_VALUE(mr."handle") OVER (PARTITION BY mt."id" ORDER BY m."receivedAt" DESC) AS last_message_participant_handle,
             FIRST_VALUE(mr."displayName") OVER (PARTITION BY mt."id" ORDER BY m."receivedAt" DESC) AS last_message_participant_displayName,
@@ -69,7 +69,7 @@ export class TimelineMessagingService {
         senderPictureUrl: '',
         numberOfMessagesInThread: messageThread.message_count,
         subject: messageThread.last_message_subject,
-        body: messageThread.last_message_body,
+        body: messageThread.last_message_text,
         receivedAt: messageThread.last_message_received_at,
       };
     });

--- a/packages/twenty-server/src/core/messaging/timeline-messaging.service.ts
+++ b/packages/twenty-server/src/core/messaging/timeline-messaging.service.ts
@@ -62,6 +62,8 @@ export class TimelineMessagingService {
       [personIds],
     );
 
+    console.log(messageThreads);
+
     const formattedMessageThreads = messageThreads.map((messageThread) => {
       return {
         read: true,

--- a/packages/twenty-server/src/core/messaging/timeline-messaging.service.ts
+++ b/packages/twenty-server/src/core/messaging/timeline-messaging.service.ts
@@ -62,8 +62,6 @@ export class TimelineMessagingService {
       [personIds],
     );
 
-    console.log(messageThreads);
-
     const formattedMessageThreads = messageThreads.map((messageThread) => {
       return {
         read: true,

--- a/packages/twenty-server/src/workspace/messaging/services/messaging-utils.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/services/messaging-utils.service.ts
@@ -91,7 +91,7 @@ export class MessagingUtilsService {
     const receivedAt = new Date(parseInt(message.internalDate));
 
     await manager.query(
-      `INSERT INTO ${dataSourceMetadata.schema}."message" ("id", "headerMessageId", "subject", "receivedAt", "direction", "messageThreadId", "body", "html") VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+      `INSERT INTO ${dataSourceMetadata.schema}."message" ("id", "headerMessageId", "subject", "receivedAt", "direction", "messageThreadId", "text", "html") VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
       [
         newMessageId,
         message.headerMessageId,

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/message.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/message.object-metadata.ts
@@ -64,11 +64,11 @@ export class MessageObjectMetadata extends BaseObjectMetadata {
 
   @FieldMetadata({
     type: FieldMetadataType.TEXT,
-    label: 'Body',
-    description: 'Body',
+    label: 'Text',
+    description: 'Text',
     icon: 'IconMessage',
   })
-  body: string;
+  text: string;
 
   @FieldMetadata({
     type: FieldMetadataType.TEXT,


### PR DESCRIPTION
## Context
Last PR introduced an html column. Because of this, the body column was not clear enough so we are renaming it to text.

## Test
<img width="261" alt="Screenshot 2024-01-23 at 19 48 31" src="https://github.com/twentyhq/twenty/assets/1834158/c7d393b0-26c8-4485-932c-bf1d354a147b">
<img width="343" alt="Screenshot 2024-01-23 at 19 48 13" src="https://github.com/twentyhq/twenty/assets/1834158/b0575552-caf2-42b4-9fa2-660febb96325">