### PR TITLE
Allow underscores in PG_DATABASE_URL

### DIFF
--- a/packages/twenty-server/src/integrations/environment/environment.validation.ts
+++ b/packages/twenty-server/src/integrations/environment/environment.validation.ts
@@ -64,7 +64,7 @@ export class EnvironmentVariables {
   PORT: number;
 
   // Database
-  @IsUrl({ protocols: ['postgres'], require_tld: false })
+  @IsUrl({ protocols: ['postgres'], require_tld: false, allow_underscores: true })
   PG_DATABASE_URL: string;
 
   // Frontend URL


### PR DESCRIPTION
We are working on a Twenty template for Easypanel.io. We need Twenty to allow underscores in order to be compatible with the generated Postgres database service Easypanel creates.