### PR TITLE
Fix message table plural name

### DIFF
--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/message.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/message.object-metadata.ts
@@ -12,7 +12,7 @@ import { MessageParticipantObjectMetadata } from 'src/workspace/workspace-sync-m
 import { MessageThreadObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/message-thread.object-metadata';
 
 @ObjectMetadata({
-  namePlural: 'message',
+  namePlural: 'messages',
   labelSingular: 'Message',
   labelPlural: 'Messages',
   description: 'Message',


### PR DESCRIPTION
## Context
PluralName of MessageObjectMetadata was not correctly named. Because of this, pluralName and singularName had the same values so the graphql generation skipped the findMany resolver. This PR should fix that.


## Test
<img width="194" alt="Screenshot 2024-01-24 at 14 31 32" src="https://github.com/twentyhq/twenty/assets/1834158/919fa23c-d6fa-409b-9624-2d8e25bf305b">
