### PR TITLE
[Messaging] Fix duplicate messageChannelMessage

### DIFF
--- a/packages/twenty-server/src/core/auth/services/google-gmail.service.ts
+++ b/packages/twenty-server/src/core/auth/services/google-gmail.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { ConflictException, Inject, Injectable } from '@nestjs/common';
 
 import { v4 } from 'uuid';
 
@@ -48,9 +48,7 @@ export class GoogleGmailService {
     );
 
     if (connectedAccount.length > 0) {
-      console.log('This account is already connected to your workspace.');
-
-      return;
+      throw new ConflictException('Connected account already exists');
     }
 
     const connectedAccountId = v4();

--- a/packages/twenty-server/src/workspace/messaging/services/gmail-full-sync.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/services/gmail-full-sync.service.ts
@@ -61,22 +61,25 @@ export class GmailFullSyncService {
       return;
     }
 
-    const existingMessageChannelMessages =
-      await this.utils.getMessageChannelMessages(
+    const existingMessageChannelMessageAssociations =
+      await this.utils.getMessageChannelMessageAssociations(
         messageExternalIds,
         gmailMessageChannelId,
         dataSourceMetadata,
         workspaceDataSource,
       );
 
-    const existingMessageChannelMessagesExternalIds =
-      existingMessageChannelMessages.map(
-        (messageChannelMessage) => messageChannelMessage.messageExternalId,
+    const existingMessageChannelMessageAssociationsExternalIds =
+      existingMessageChannelMessageAssociations.map(
+        (messageChannelMessageAssociation) =>
+          messageChannelMessageAssociation.messageExternalId,
       );
 
     const messagesToFetch = messageExternalIds.filter(
       (messageExternalId) =>
-        !existingMessageChannelMessagesExternalIds.includes(messageExternalId),
+        !existingMessageChannelMessageAssociationsExternalIds.includes(
+          messageExternalId,
+        ),
     );
 
     const messageQueries =

--- a/packages/twenty-server/src/workspace/messaging/services/gmail-partial-sync.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/services/gmail-partial-sync.service.ts
@@ -144,7 +144,7 @@ export class GmailPartialSyncService {
       gmailMessageChannelId,
     );
 
-    await this.utils.deleteMessageChannelMessages(
+    await this.utils.deleteMessageChannelMessageAssociations(
       messagesDeleted,
       gmailMessageChannelId,
       dataSourceMetadata,

--- a/packages/twenty-server/src/workspace/messaging/services/gmail-partial-sync.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/services/gmail-partial-sync.service.ts
@@ -125,7 +125,7 @@ export class GmailPartialSyncService {
     const gmailMessageChannelId = gmailMessageChannel[0].id;
 
     const { messagesAdded, messagesDeleted } =
-      await this.getMessageIdsAndThreadIdsFromHistory(history);
+      await this.getMessageIdsFromHistory(history);
 
     const messageQueries =
       this.utils.createQueriesFromMessageIds(messagesAdded);
@@ -161,7 +161,7 @@ export class GmailPartialSyncService {
     );
   }
 
-  private async getMessageIdsAndThreadIdsFromHistory(
+  private async getMessageIdsFromHistory(
     history: gmail_v1.Schema$ListHistoryResponse,
   ): Promise<{
     messagesAdded: string[];
@@ -193,9 +193,17 @@ export class GmailPartialSyncService {
       { messagesAdded: [], messagesDeleted: [] },
     );
 
+    const uniqueMessagesAdded = messagesAdded.filter(
+      (messageId) => !messagesDeleted.includes(messageId),
+    );
+
+    const uniqueMessagesDeleted = messagesDeleted.filter(
+      (messageId) => !messagesAdded.includes(messageId),
+    );
+
     return {
-      messagesAdded,
-      messagesDeleted,
+      messagesAdded: uniqueMessagesAdded,
+      messagesDeleted: uniqueMessagesDeleted,
     };
   }
 }

--- a/packages/twenty-server/src/workspace/messaging/services/messaging-utils.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/services/messaging-utils.service.ts
@@ -36,13 +36,13 @@ export class MessagingUtilsService {
   ) {
     for (const message of messages) {
       await workspaceDataSource?.transaction(async (manager) => {
-        const existingMessageChannelMessage = await manager.query(
-          `SELECT COUNT(*) FROM ${dataSourceMetadata.schema}."messageChannelMessage"
+        const existingMessageChannelMessageAssociations = await manager.query(
+          `SELECT COUNT(*) FROM ${dataSourceMetadata.schema}."messageChannelMessageAssociation"
           WHERE "messageExternalId" = $1 AND "messageChannelId" = $2`,
           [message.externalId, gmailMessageChannelId],
         );
 
-        if (existingMessageChannelMessage[0]?.count > 0) {
+        if (existingMessageChannelMessageAssociations[0]?.count > 0) {
           return;
         }
 
@@ -63,7 +63,7 @@ export class MessagingUtilsService {
           );
 
         await manager.query(
-          `INSERT INTO ${dataSourceMetadata.schema}."messageChannelMessage" ("messageChannelId", "messageId", "messageExternalId", "messageThreadId", "messageThreadExternalId") VALUES ($1, $2, $3, $4, $5)`,
+          `INSERT INTO ${dataSourceMetadata.schema}."messageChannelMessageAssociation" ("messageChannelId", "messageId", "messageExternalId", "messageThreadId", "messageThreadExternalId") VALUES ($1, $2, $3, $4, $5)`,
           [
             gmailMessageChannelId,
             savedOrExistingMessageId,
@@ -130,7 +130,7 @@ export class MessagingUtilsService {
     workspaceDataSource: DataSource,
   ) {
     const existingMessageThreads = await workspaceDataSource?.query(
-      `SELECT "messageChannelMessage"."messageThreadId" FROM ${dataSourceMetadata.schema}."messageChannelMessage" WHERE "messageThreadExternalId" = $1 LIMIT 1`,
+      `SELECT "messageChannelMessageAssociation"."messageThreadId" FROM ${dataSourceMetadata.schema}."messageChannelMessageAssociation" WHERE "messageThreadExternalId" = $1 LIMIT 1`,
       [messageThreadExternalId],
     );
 
@@ -190,14 +190,14 @@ export class MessagingUtilsService {
     }
   }
 
-  public async deleteMessageChannelMessages(
+  public async deleteMessageChannelMessageAssociations(
     messageExternalIds: string[],
     connectedAccountId: string,
     dataSourceMetadata: DataSourceEntity,
     workspaceDataSource: DataSource,
   ) {
     await workspaceDataSource?.query(
-      `DELETE FROM ${dataSourceMetadata.schema}."messageChannelMessage" WHERE "messageExternalId" = ANY($1) AND "messageChannelId" = $2`,
+      `DELETE FROM ${dataSourceMetadata.schema}."messageChannelMessageAssociation" WHERE "messageExternalId" = ANY($1) AND "messageChannelId" = $2`,
       [messageExternalIds, connectedAccountId],
     );
   }
@@ -276,18 +276,19 @@ export class MessagingUtilsService {
     );
   }
 
-  public async getMessageChannelMessages(
+  public async getMessageChannelMessageAssociations(
     messageExternalIds: string[],
     gmailMessageChannelId: string,
     dataSourceMetadata: DataSourceEntity,
     workspaceDataSource: DataSource,
   ) {
-    const existingMessageChannelMessage = await workspaceDataSource?.query(
-      `SELECT * FROM ${dataSourceMetadata.schema}."messageChannelMessage"
+    const existingMessageChannelMessageAssociation =
+      await workspaceDataSource?.query(
+        `SELECT * FROM ${dataSourceMetadata.schema}."messageChannelMessageAssociation"
       WHERE "messageExternalId" = ANY($1) AND "messageChannelId" = $2`,
-      [messageExternalIds, gmailMessageChannelId],
-    );
+        [messageExternalIds, gmailMessageChannelId],
+      );
 
-    return existingMessageChannelMessage;
+    return existingMessageChannelMessageAssociation;
   }
 }

--- a/packages/twenty-server/src/workspace/messaging/services/messaging-utils.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/services/messaging-utils.service.ts
@@ -275,4 +275,19 @@ export class MessagingUtilsService {
       [historyId, connectedAccountId],
     );
   }
+
+  public async getMessageChannelMessages(
+    messageExternalIds: string[],
+    gmailMessageChannelId: string,
+    dataSourceMetadata: DataSourceEntity,
+    workspaceDataSource: DataSource,
+  ) {
+    const existingMessageChannelMessage = await workspaceDataSource?.query(
+      `SELECT * FROM ${dataSourceMetadata.schema}."messageChannelMessage"
+      WHERE "messageExternalId" = ANY($1) AND "messageChannelId" = $2`,
+      [messageExternalIds, gmailMessageChannelId],
+    );
+
+    return existingMessageChannelMessage;
+  }
 }

--- a/packages/twenty-server/src/workspace/messaging/services/messaging-utils.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/services/messaging-utils.service.ts
@@ -36,6 +36,16 @@ export class MessagingUtilsService {
   ) {
     for (const message of messages) {
       await workspaceDataSource?.transaction(async (manager) => {
+        const existingMessageChannelMessage = await manager.query(
+          `SELECT COUNT(*) FROM ${dataSourceMetadata.schema}."messageChannelMessage"
+          WHERE "messageExternalId" = $1 AND "messageChannelId" = $2`,
+          [message.externalId, gmailMessageChannelId],
+        );
+
+        if (existingMessageChannelMessage[0]?.count > 0) {
+          return;
+        }
+
         const savedOrExistingMessageThreadId =
           await this.saveMessageThreadOrReturnExistingMessageThread(
             message.messageThreadExternalId,

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/index.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/index.ts
@@ -6,7 +6,7 @@ import { CommentObjectMetadata } from 'src/workspace/workspace-sync-metadata/sta
 import { CompanyObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/company.object-metadata';
 import { ConnectedAccountObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/connected-account.object-metadata';
 import { FavoriteObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/favorite.object-metadata';
-import { MessageChannelMessageObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/message-channel-message.object-metadata';
+import { MessageChannelMessageAssociationObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/message-channel-message-association.object-metadata';
 import { MessageChannelObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/message-channel.object-metadata';
 import { MessageParticipantObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/message-participant.object-metadata';
 import { MessageThreadObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/message-thread.object-metadata';
@@ -43,5 +43,5 @@ export const standardObjectMetadata = [
   MessageObjectMetadata,
   MessageChannelObjectMetadata,
   MessageParticipantObjectMetadata,
-  MessageChannelMessageObjectMetadata,
+  MessageChannelMessageAssociationObjectMetadata,
 ];

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/message-channel-message-association.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/message-channel-message-association.object-metadata.ts
@@ -10,9 +10,9 @@ import { MessageThreadObjectMetadata } from 'src/workspace/workspace-sync-metada
 import { MessageObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/message.object-metadata';
 
 @ObjectMetadata({
-  namePlural: 'messageChannelMessages',
-  labelSingular: 'Message Channel Message',
-  labelPlural: 'Message Channel Messages',
+  namePlural: 'messageChannelMessageAssociations',
+  labelSingular: 'Message Channel Message Association',
+  labelPlural: 'Message Channel Message Associations',
   description: 'Message Synced with a Message Channel',
   icon: 'IconMessage',
 })
@@ -20,7 +20,7 @@ import { MessageObjectMetadata } from 'src/workspace/workspace-sync-metadata/sta
   featureFlag: 'IS_MESSAGING_ENABLED',
 })
 @IsSystem()
-export class MessageChannelMessageObjectMetadata extends BaseObjectMetadata {
+export class MessageChannelMessageAssociationObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({
     type: FieldMetadataType.RELATION,
     label: 'Message Channel Id',

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/message-channel.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/message-channel.object-metadata.ts
@@ -8,7 +8,7 @@ import { ObjectMetadata } from 'src/workspace/workspace-sync-metadata/decorators
 import { RelationMetadata } from 'src/workspace/workspace-sync-metadata/decorators/relation-metadata.decorator';
 import { BaseObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/base.object-metadata';
 import { ConnectedAccountObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/connected-account.object-metadata';
-import { MessageChannelMessageObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/message-channel-message.object-metadata';
+import { MessageChannelMessageAssociationObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/message-channel-message-association.object-metadata';
 
 @ObjectMetadata({
   namePlural: 'messageChannels',
@@ -73,14 +73,14 @@ export class MessageChannelObjectMetadata extends BaseObjectMetadata {
 
   @FieldMetadata({
     type: FieldMetadataType.RELATION,
-    label: 'Message Channel Syncs',
+    label: 'Message Channel Association',
     description: 'Messages from the channel.',
     icon: 'IconMessage',
   })
   @RelationMetadata({
     type: RelationMetadataType.ONE_TO_MANY,
-    objectName: 'messageChannelMessage',
+    objectName: 'messageChannelMessageAssociation',
   })
   @IsNullable()
-  messageChannelMessage: MessageChannelMessageObjectMetadata[];
+  messageChannelMessageAssociation: MessageChannelMessageAssociationObjectMetadata[];
 }

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/message-thread.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/message-thread.object-metadata.ts
@@ -7,7 +7,7 @@ import { IsSystem } from 'src/workspace/workspace-sync-metadata/decorators/is-sy
 import { ObjectMetadata } from 'src/workspace/workspace-sync-metadata/decorators/object-metadata.decorator';
 import { RelationMetadata } from 'src/workspace/workspace-sync-metadata/decorators/relation-metadata.decorator';
 import { BaseObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/base.object-metadata';
-import { MessageChannelMessageObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/message-channel-message.object-metadata';
+import { MessageChannelMessageAssociationObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/message-channel-message-association.object-metadata';
 import { MessageObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/message.object-metadata';
 
 @ObjectMetadata({
@@ -37,14 +37,14 @@ export class MessageThreadObjectMetadata extends BaseObjectMetadata {
 
   @FieldMetadata({
     type: FieldMetadataType.RELATION,
-    label: 'Message Channel Syncs',
+    label: 'Message Channel Association',
     description: 'Messages from the channel.',
     icon: 'IconMessage',
   })
   @RelationMetadata({
     type: RelationMetadataType.ONE_TO_MANY,
-    objectName: 'messageChannelMessage',
+    objectName: 'messageChannelMessageAssociation',
   })
   @IsNullable()
-  messageChannelMessage: MessageChannelMessageObjectMetadata[];
+  messageChannelMessageAssociation: MessageChannelMessageAssociationObjectMetadata[];
 }

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/message.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/message.object-metadata.ts
@@ -7,7 +7,7 @@ import { IsSystem } from 'src/workspace/workspace-sync-metadata/decorators/is-sy
 import { ObjectMetadata } from 'src/workspace/workspace-sync-metadata/decorators/object-metadata.decorator';
 import { RelationMetadata } from 'src/workspace/workspace-sync-metadata/decorators/relation-metadata.decorator';
 import { BaseObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/base.object-metadata';
-import { MessageChannelMessageObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/message-channel-message.object-metadata';
+import { MessageChannelMessageAssociationObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/message-channel-message-association.object-metadata';
 import { MessageParticipantObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/message-participant.object-metadata';
 import { MessageThreadObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/message-thread.object-metadata';
 
@@ -103,14 +103,14 @@ export class MessageObjectMetadata extends BaseObjectMetadata {
 
   @FieldMetadata({
     type: FieldMetadataType.RELATION,
-    label: 'Message Channel Syncs',
+    label: 'Message Channel Association',
     description: 'Messages from the channel.',
     icon: 'IconMessage',
   })
   @RelationMetadata({
     type: RelationMetadataType.ONE_TO_MANY,
-    objectName: 'messageChannelMessage',
+    objectName: 'messageChannelMessageAssociation',
   })
   @IsNullable()
-  messageChannelMessage: MessageChannelMessageObjectMetadata[];
+  messageChannelMessageAssociation: MessageChannelMessageAssociationObjectMetadata[];
 }


### PR DESCRIPTION
This PR adds a check before inserting anything if a messageChannelMessage already exists. This should not happen however this part of the code is executed in a job so we want to make sure this part is idempotent in case of retry strategies.
It also adds a check in the partial-sync import, where we don't want to import messages that are in both messageAdded and messageDeleted. This can happen when we do a partial sync after a message has been created (DRAFT or SENT) then deleted, since querying later on with gmail api will result in a 404.