### PR TITLE
fix: grapQL errors are not detailed enough

### DIFF
--- a/packages/twenty-server/src/filters/utils/global-exception-handler.util.ts
+++ b/packages/twenty-server/src/filters/utils/global-exception-handler.util.ts
@@ -52,9 +52,9 @@ export const convertHttpExceptionToGraphql = (exception: HttpException) => {
   let error: BaseGraphQLError;
 
   if (status in graphQLPredefinedExceptions) {
-    error = new graphQLPredefinedExceptions[exception.getStatus()](
-      exception.message,
-    );
+    const message = exception.getResponse()['message'] ?? exception.message;
+
+    error = new graphQLPredefinedExceptions[exception.getStatus()](message);
   } else {
     error = new BaseGraphQLError(
       'Internal Server Error',


### PR DESCRIPTION
This PR is adding more detailed error message for `HttpException`

<img width="426" alt="Screenshot 2024-01-25 at 3 02 09 PM" src="https://github.com/twentyhq/twenty/assets/3551795/33600c5c-e866-41db-92a8-a54d82c1e77e">

Fix #3304 