### PR TITLE
Add record chip for sender and add receivers

### DIFF
--- a/packages/twenty-front/src/modules/activities/emails/components/EmailThreadMessage.tsx
+++ b/packages/twenty-front/src/modules/activities/emails/components/EmailThreadMessage.tsx
@@ -3,8 +3,11 @@ import styled from '@emotion/styled';
 
 import { EmailThreadMessageBody } from '@/activities/emails/components/EmailThreadMessageBody';
 import { EmailThreadMessageBodyPreview } from '@/activities/emails/components/EmailThreadMessageBodyPreview';
+import { EmailThreadMessageReceivers } from '@/activities/emails/components/EmailThreadMessageReceivers';
 import { EmailThreadMessageSender } from '@/activities/emails/components/EmailThreadMessageSender';
 import { EmailThreadMessageParticipant } from '@/activities/emails/types/EmailThreadMessageParticipant';
+
+const PARTICIPANT_FROM_ROLE = 'from';
 
 const StyledThreadMessage = styled.div`
   border-bottom: 1px solid ${({ theme }) => theme.border.color.light};
@@ -27,28 +30,6 @@ type EmailThreadMessageProps = {
   participants: EmailThreadMessageParticipant[];
 };
 
-const getDisplayNameFromParticipant = (
-  participant: EmailThreadMessageParticipant,
-) => {
-  if (participant.person) {
-    return `${participant.person?.name?.firstName} ${participant.person?.name?.lastName}`;
-  }
-
-  if (participant.workspaceMember) {
-    return `${participant.workspaceMember?.name?.firstName} ${participant.workspaceMember?.name?.lastName}`;
-  }
-
-  if (participant.displayName) {
-    return participant.displayName;
-  }
-
-  if (participant.handle) {
-    return participant.handle;
-  }
-
-  return 'Unknown';
-};
-
 export const EmailThreadMessage = ({
   body,
   sentAt,
@@ -56,26 +37,22 @@ export const EmailThreadMessage = ({
 }: EmailThreadMessageProps) => {
   const [isOpen, setIsOpen] = useState(false);
 
-  const from = participants.find((participant) => participant.role === 'from');
-  const to = participants.filter((participant) => participant.role === 'to');
+  const from = participants.find(
+    (participant) => participant.role === PARTICIPANT_FROM_ROLE,
+  );
+  const to = participants.filter(
+    (participant) => participant.role !== PARTICIPANT_FROM_ROLE,
+  );
 
   if (!from || to.length === 0) {
     return null;
   }
 
-  const displayName = getDisplayNameFromParticipant(from);
-
-  const avatarUrl =
-    from.person?.avatarUrl ?? from.workspaceMember?.avatarUrl ?? '';
-
   return (
     <StyledThreadMessage onClick={() => setIsOpen(!isOpen)}>
       <StyledThreadMessageHeader>
-        <EmailThreadMessageSender
-          displayName={displayName}
-          avatarUrl={avatarUrl}
-          sentAt={sentAt}
-        />
+        <EmailThreadMessageSender sender={from} sentAt={sentAt} />
+        {isOpen && <EmailThreadMessageReceivers receivers={to} />}
       </StyledThreadMessageHeader>
       {isOpen ? (
         <EmailThreadMessageBody body={body} />

--- a/packages/twenty-front/src/modules/activities/emails/components/EmailThreadMessage.tsx
+++ b/packages/twenty-front/src/modules/activities/emails/components/EmailThreadMessage.tsx
@@ -5,7 +5,6 @@ import { EmailThreadMessageBody } from '@/activities/emails/components/EmailThre
 import { EmailThreadMessageBodyPreview } from '@/activities/emails/components/EmailThreadMessageBodyPreview';
 import { EmailThreadMessageReceivers } from '@/activities/emails/components/EmailThreadMessageReceivers';
 import { EmailThreadMessageSender } from '@/activities/emails/components/EmailThreadMessageSender';
-import { EmailParticipantRole } from '@/activities/emails/types/EmailParticipantRole';
 import { EmailThreadMessageParticipant } from '@/activities/emails/types/EmailThreadMessageParticipant';
 
 const StyledThreadMessage = styled.div`
@@ -36,14 +35,12 @@ export const EmailThreadMessage = ({
 }: EmailThreadMessageProps) => {
   const [isOpen, setIsOpen] = useState(false);
 
-  const from = participants.find(
-    (participant) => participant.role === EmailParticipantRole.FROM,
-  );
-  const to = participants.filter(
-    (participant) => participant.role !== EmailParticipantRole.FROM,
+  const from = participants.find((participant) => participant.role === 'from');
+  const receivers = participants.filter(
+    (participant) => participant.role !== 'from',
   );
 
-  if (!from || to.length === 0) {
+  if (!from || receivers.length === 0) {
     return null;
   }
 
@@ -51,7 +48,7 @@ export const EmailThreadMessage = ({
     <StyledThreadMessage onClick={() => setIsOpen(!isOpen)}>
       <StyledThreadMessageHeader>
         <EmailThreadMessageSender sender={from} sentAt={sentAt} />
-        {isOpen && <EmailThreadMessageReceivers receivers={to} />}
+        {isOpen && <EmailThreadMessageReceivers receivers={receivers} />}
       </StyledThreadMessageHeader>
       {isOpen ? (
         <EmailThreadMessageBody body={body} />

--- a/packages/twenty-front/src/modules/activities/emails/components/EmailThreadMessage.tsx
+++ b/packages/twenty-front/src/modules/activities/emails/components/EmailThreadMessage.tsx
@@ -5,9 +5,8 @@ import { EmailThreadMessageBody } from '@/activities/emails/components/EmailThre
 import { EmailThreadMessageBodyPreview } from '@/activities/emails/components/EmailThreadMessageBodyPreview';
 import { EmailThreadMessageReceivers } from '@/activities/emails/components/EmailThreadMessageReceivers';
 import { EmailThreadMessageSender } from '@/activities/emails/components/EmailThreadMessageSender';
+import { EmailParticipantRole } from '@/activities/emails/types/EmailParticipantRole';
 import { EmailThreadMessageParticipant } from '@/activities/emails/types/EmailThreadMessageParticipant';
-
-const PARTICIPANT_FROM_ROLE = 'from';
 
 const StyledThreadMessage = styled.div`
   border-bottom: 1px solid ${({ theme }) => theme.border.color.light};
@@ -38,10 +37,10 @@ export const EmailThreadMessage = ({
   const [isOpen, setIsOpen] = useState(false);
 
   const from = participants.find(
-    (participant) => participant.role === PARTICIPANT_FROM_ROLE,
+    (participant) => participant.role === EmailParticipantRole.FROM,
   );
   const to = participants.filter(
-    (participant) => participant.role !== PARTICIPANT_FROM_ROLE,
+    (participant) => participant.role !== EmailParticipantRole.FROM,
   );
 
   if (!from || to.length === 0) {

--- a/packages/twenty-front/src/modules/activities/emails/components/EmailThreadMessageReceivers.tsx
+++ b/packages/twenty-front/src/modules/activities/emails/components/EmailThreadMessageReceivers.tsx
@@ -1,0 +1,33 @@
+import styled from '@emotion/styled';
+
+import { EmailThreadMessageParticipant } from '@/activities/emails/types/EmailThreadMessageParticipant';
+import { getDisplayNameFromParticipant } from '@/activities/emails/utils/getDisplayNameFromParticipant';
+import { OverflowingTextWithTooltip } from '@/ui/display/tooltip/OverflowingTextWithTooltip';
+
+type EmailThreadMessageReceiversProps = {
+  receivers: EmailThreadMessageParticipant[];
+};
+
+const StyledThreadMessageReceivers = styled.span`
+  color: ${({ theme }) => theme.font.color.tertiary};
+  display: flex;
+  font-size: ${({ theme }) => theme.font.size.xs};
+  padding: ${({ theme }) => theme.spacing(2, 0, 0, 1)};
+  width: 50%;
+`;
+
+export const EmailThreadMessageReceivers = ({
+  receivers,
+}: EmailThreadMessageReceiversProps) => {
+  const displayedReceivers = receivers
+    .map((receiver) => getDisplayNameFromParticipant({ participant: receiver }))
+    .join(', ');
+
+  const body = `to: ${displayedReceivers}`;
+
+  return (
+    <StyledThreadMessageReceivers>
+      <OverflowingTextWithTooltip text={body} />
+    </StyledThreadMessageReceivers>
+  );
+};

--- a/packages/twenty-front/src/modules/activities/emails/components/EmailThreadMessageSender.tsx
+++ b/packages/twenty-front/src/modules/activities/emails/components/EmailThreadMessageSender.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
+import { EmailThreadMessageParticipant } from '@/activities/emails/types/EmailThreadMessageParticipant';
+import { getDisplayNameFromParticipant } from '@/activities/emails/utils/getDisplayNameFromParticipant';
+import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
+import { RecordChip } from '@/object-record/components/RecordChip';
 import { Avatar } from '@/users/components/Avatar';
 import { beautifyPastDateRelativeToNow } from '~/utils/date-utils';
 
@@ -32,26 +36,42 @@ const StyledThreadMessageSentAt = styled.div`
 `;
 
 type EmailThreadMessageSenderProps = {
-  displayName: string;
-  avatarUrl: string;
+  sender: EmailThreadMessageParticipant;
   sentAt: string;
 };
 
 export const EmailThreadMessageSender = ({
-  displayName,
-  avatarUrl,
+  sender,
   sentAt,
 }: EmailThreadMessageSenderProps) => {
+  const { person, workspaceMember } = sender;
+
+  const displayName = getDisplayNameFromParticipant({
+    participant: sender,
+    shouldUseFullName: true,
+  });
+
+  const avatarUrl = person?.avatarUrl ?? workspaceMember?.avatarUrl ?? '';
+
   return (
     <StyledEmailThreadMessageSender>
       <StyledEmailThreadMessageSenderUser>
-        <StyledAvatar
-          avatarUrl={avatarUrl}
-          type="rounded"
-          placeholder={displayName}
-          size="sm"
-        />
-        <StyledSenderName>{displayName}</StyledSenderName>
+        {person ? (
+          <RecordChip
+            objectNameSingular={CoreObjectNameSingular.Person}
+            record={person}
+          />
+        ) : (
+          <>
+            <StyledAvatar
+              avatarUrl={avatarUrl}
+              type="rounded"
+              placeholder={displayName}
+              size="sm"
+            />
+            <StyledSenderName>{displayName}</StyledSenderName>
+          </>
+        )}
       </StyledEmailThreadMessageSenderUser>
       <StyledThreadMessageSentAt>
         {beautifyPastDateRelativeToNow(sentAt)}

--- a/packages/twenty-front/src/modules/activities/emails/types/EmailParticipantRole.ts
+++ b/packages/twenty-front/src/modules/activities/emails/types/EmailParticipantRole.ts
@@ -1,4 +1,1 @@
-export enum EmailParticipantRole {
-  FROM = 'from',
-  TO = 'to',
-}
+export type EmailParticipantRole = 'from' | 'to' | 'cc' | 'bcc';

--- a/packages/twenty-front/src/modules/activities/emails/types/EmailParticipantRole.ts
+++ b/packages/twenty-front/src/modules/activities/emails/types/EmailParticipantRole.ts
@@ -1,0 +1,4 @@
+export enum EmailParticipantRole {
+  FROM = 'from',
+  TO = 'to',
+}

--- a/packages/twenty-front/src/modules/activities/emails/types/EmailThreadMessageParticipant.ts
+++ b/packages/twenty-front/src/modules/activities/emails/types/EmailThreadMessageParticipant.ts
@@ -1,10 +1,11 @@
+import { EmailParticipantRole } from '@/activities/emails/types/EmailParticipantRole';
 import { Person } from '@/people/types/Person';
 import { WorkspaceMember } from '@/workspace-member/types/WorkspaceMember';
 
 export type EmailThreadMessageParticipant = {
   displayName: string;
   handle: string;
-  role: string;
+  role: EmailParticipantRole;
   person: Person;
   workspaceMember: WorkspaceMember;
 };

--- a/packages/twenty-front/src/modules/activities/emails/utils/getDisplayNameFromParticipant.ts
+++ b/packages/twenty-front/src/modules/activities/emails/utils/getDisplayNameFromParticipant.ts
@@ -1,0 +1,35 @@
+import { EmailThreadMessageParticipant } from '@/activities/emails/types/EmailThreadMessageParticipant';
+
+export const getDisplayNameFromParticipant = ({
+  participant,
+  shouldUseFullName = false,
+}: {
+  participant: EmailThreadMessageParticipant;
+  shouldUseFullName?: boolean;
+}) => {
+  if (participant.person) {
+    return (
+      `${participant.person?.name?.firstName}` +
+      (shouldUseFullName ? ` ${participant.person?.name?.lastName}` : '')
+    );
+  }
+
+  if (participant.workspaceMember) {
+    return (
+      participant.workspaceMember?.name?.firstName +
+      (shouldUseFullName
+        ? ` ${participant.workspaceMember?.name?.lastName}`
+        : '')
+    );
+  }
+
+  if (participant.displayName) {
+    return participant.displayName;
+  }
+
+  if (participant.handle) {
+    return participant.handle;
+  }
+
+  return 'Unknown';
+};


### PR DESCRIPTION
- If sender is a person, display the record chip
- Receivers should be displayed when the message is open. In case of many participants, use an overflow toolkit 

<img width="300" alt="Capture d’écran 2024-01-25 à 17 37 27" src="https://github.com/twentyhq/twenty/assets/22936103/a8525333-c037-42ef-9685-2d15d6cb2081">
<img width="300" alt="Capture d’écran 2024-01-25 à 17 37 44" src="https://github.com/twentyhq/twenty/assets/22936103/d31d0585-7346-42f9-9888-9c2e6645ff40">
<img width="400" alt="Capture d’écran 2024-01-25 à 17 37 56" src="https://github.com/twentyhq/twenty/assets/22936103/92e23793-5848-4cfb-84e8-60efbe9d9a62">
