### PR TITLE
[Messaging] Fix gmail connected account creation redirect url

### DIFF
--- a/packages/twenty-server/src/core/auth/controllers/google-gmail-auth.controller.ts
+++ b/packages/twenty-server/src/core/auth/controllers/google-gmail-auth.controller.ts
@@ -7,12 +7,14 @@ import { GoogleGmailOauthGuard } from 'src/core/auth/guards/google-gmail-oauth.g
 import { GoogleGmailRequest } from 'src/core/auth/strategies/google-gmail.auth.strategy';
 import { GoogleGmailService } from 'src/core/auth/services/google-gmail.service';
 import { TokenService } from 'src/core/auth/services/token.service';
+import { EnvironmentService } from 'src/integrations/environment/environment.service';
 
 @Controller('auth/google-gmail')
 export class GoogleGmailAuthController {
   constructor(
     private readonly googleGmailService: GoogleGmailService,
     private readonly tokenService: TokenService,
+    private readonly environmentService: EnvironmentService,
   ) {}
 
   @Get()
@@ -44,6 +46,8 @@ export class GoogleGmailAuthController {
       refreshToken,
     });
 
-    return res.redirect('http://localhost:3001/settings/accounts');
+    return res.redirect(
+      `${this.environmentService.getFrontBaseUrl()}/settings/accounts`,
+    );
   }
 }


### PR DESCRIPTION
## Context
This part of the code was not properly using the base URL from the env. This PR should fix that so we can use it on other envs.

## Test
Tested locally 