### PR TITLE
Allow Card field update and card drag on new record board

### DIFF
--- a/packages/twenty-front/src/modules/activities/utils/__tests__/getActivitySummary.test.ts
+++ b/packages/twenty-front/src/modules/activities/utils/__tests__/getActivitySummary.test.ts
@@ -1,14 +1,14 @@
 import { getActivitySummary } from '../getActivitySummary';
 
 describe('getActivitySummary', () => {
-  it('should work for empty body', () => {
+  it('should work for empty body ""', () => {
     const activityBody = {};
 
     const res = getActivitySummary(JSON.stringify(activityBody));
 
     expect(res).toEqual('');
   });
-  it('should work for empty body', () => {
+  it('should work for empty body {}', () => {
     const activityBody = '';
 
     const res = getActivitySummary(JSON.stringify(activityBody));
@@ -94,6 +94,36 @@ describe('getActivitySummary', () => {
       },
       {
         id: 'd4720499-2a45-4f3b-96cf-a8415c295678',
+        type: 'paragraph',
+        props: {
+          textColor: 'default',
+          backgroundColor: 'default',
+          textAlignment: 'left',
+        },
+        content: [],
+        children: [],
+      },
+    ];
+
+    const res = getActivitySummary(JSON.stringify(activityBody));
+
+    expect(res).toEqual('');
+  });
+
+  it('should work for table as first block', () => {
+    const activityBody = [
+      {
+        id: '591c3aa1-9e51-465d-bb59-611ef60344fb',
+        type: 'table',
+        props: { textColor: 'default', backgroundColor: 'default' },
+        content: {
+          type: 'tableContent',
+          rows: [{ cells: [[], [], []] }, { cells: [[], [], []] }],
+        },
+        children: [],
+      },
+      {
+        id: '1899ab29-0122-4890-bb50-4d7cf2802f98',
         type: 'paragraph',
         props: {
           textColor: 'default',

--- a/packages/twenty-front/src/modules/activities/utils/getActivitySummary.ts
+++ b/packages/twenty-front/src/modules/activities/utils/getActivitySummary.ts
@@ -1,9 +1,25 @@
+import { isArray } from '@sniptt/guards';
+
 export const getActivitySummary = (activityBody: string) => {
   const noteBody = activityBody ? JSON.parse(activityBody) : [];
 
-  return (
-    noteBody[0]?.content?.text ||
-    noteBody[0]?.content?.map((content: any) => content?.text).join(' ') ||
-    ''
-  );
+  if (!noteBody.length) {
+    return '';
+  }
+
+  const firstNoteBlockContent = noteBody[0].content;
+
+  if (!firstNoteBlockContent) {
+    return '';
+  }
+
+  if (firstNoteBlockContent.text) {
+    return noteBody[0].content.text;
+  }
+
+  if (isArray(firstNoteBlockContent)) {
+    return firstNoteBlockContent.map((content: any) => content.text).join(' ');
+  }
+
+  return '';
 };

--- a/packages/twenty-front/src/modules/object-record/record-board/contexts/RecordBoardContext.ts
+++ b/packages/twenty-front/src/modules/object-record/record-board/contexts/RecordBoardContext.ts
@@ -1,0 +1,21 @@
+import { createContext } from 'react';
+
+import { ObjectMetadataItem } from '@/object-metadata/types/ObjectMetadataItem';
+import { ObjectRecord } from '@/object-record/types/ObjectRecord';
+
+type RecordBoardContextProps = {
+  objectMetadataItem: ObjectMetadataItem;
+  createOneRecord: (recordInput: Partial<ObjectRecord>) => void;
+  updateOneRecord: ({
+    idToUpdate,
+    updateOneRecordInput,
+  }: {
+    idToUpdate: string;
+    updateOneRecordInput: Partial<Omit<ObjectRecord, 'id'>>;
+  }) => void;
+  deleteOneRecord: (idToDelete: string) => Promise<unknown>;
+};
+
+export const RecordBoardContext = createContext<RecordBoardContextProps>(
+  {} as RecordBoardContextProps,
+);

--- a/packages/twenty-front/src/modules/object-record/record-board/record-board-card/components/RecordBoardCardDraggableContainer.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/record-board-card/components/RecordBoardCardDraggableContainer.tsx
@@ -1,0 +1,30 @@
+import { Draggable } from '@hello-pangea/dnd';
+
+import { RecordBoardCard } from '@/object-record/record-board/record-board-card/components/RecordBoardCard';
+
+export const RecordBoardCardDraggableContainer = ({
+  recordId,
+  index,
+}: {
+  recordId: string;
+  index: number;
+}) => {
+  return (
+    <Draggable key={recordId} draggableId={recordId} index={index}>
+      {(draggableProvided) => (
+        <div
+          ref={draggableProvided?.innerRef}
+          // eslint-disable-next-line react/jsx-props-no-spreading
+          {...draggableProvided?.dragHandleProps}
+          // eslint-disable-next-line react/jsx-props-no-spreading
+          {...draggableProvided?.draggableProps}
+          className="entity-board-card"
+          data-selectable-id={recordId}
+          data-select-disable
+        >
+          <RecordBoardCard />
+        </div>
+      )}
+    </Draggable>
+  );
+};

--- a/packages/twenty-front/src/modules/object-record/record-board/record-board-column/components/RecordBoardColumn.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/record-board-column/components/RecordBoardColumn.tsx
@@ -3,8 +3,6 @@ import { Droppable } from '@hello-pangea/dnd';
 import { useRecoilValue } from 'recoil';
 
 import { useRecordBoardStates } from '@/object-record/record-board/hooks/internal/useRecordBoardStates';
-import { RecordBoardCard } from '@/object-record/record-board/record-board-card/components/RecordBoardCard';
-import { RecordBoardCardContext } from '@/object-record/record-board/record-board-card/contexts/RecordBoardCardContext';
 import { RecordBoardColumnCardsContainer } from '@/object-record/record-board/record-board-column/components/RecordBoardColumnCardsContainer';
 import { RecordBoardColumnHeader } from '@/object-record/record-board/record-board-column/components/RecordBoardColumnHeader';
 import { RecordBoardColumnContext } from '@/object-record/record-board/record-board-column/contexts/RecordBoardColumnContext';
@@ -52,7 +50,7 @@ export const RecordBoardColumn = ({
     recordBoardRecordIdsByColumnIdFamilyState(recordBoardColumnId),
   );
 
-  if (!columnDefinition || !recordIds) {
+  if (!columnDefinition) {
     return null;
   }
 
@@ -70,16 +68,8 @@ export const RecordBoardColumn = ({
             <RecordBoardColumnHeader />
             <RecordBoardColumnCardsContainer
               droppableProvided={droppableProvided}
-            >
-              {recordIds.map((recordId) => (
-                <RecordBoardCardContext.Provider
-                  value={{ recordId }}
-                  key={recordId}
-                >
-                  <RecordBoardCard />
-                </RecordBoardCardContext.Provider>
-              ))}
-            </RecordBoardColumnCardsContainer>
+              recordIds={recordIds}
+            />
           </StyledColumn>
         )}
       </Droppable>

--- a/packages/twenty-front/src/modules/object-record/record-board/record-board-column/components/RecordBoardColumnCardsContainer.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/record-board-column/components/RecordBoardColumnCardsContainer.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import styled from '@emotion/styled';
 import { DroppableProvided } from '@hello-pangea/dnd';
 
+import { RecordBoardColumnCardsMemo } from '@/object-record/record-board/record-board-column/components/RecordBoardColumnCardsMemo';
+
 const StyledPlaceholder = styled.div`
   min-height: 1px;
 `;
@@ -13,12 +15,12 @@ const StyledColumnCardsContainer = styled.div`
 `;
 
 type RecordBoardColumnCardsContainerProps = {
-  children: React.ReactNode;
+  recordIds: string[];
   droppableProvided: DroppableProvided;
 };
 
 export const RecordBoardColumnCardsContainer = ({
-  children,
+  recordIds,
   droppableProvided,
 }: RecordBoardColumnCardsContainerProps) => {
   return (
@@ -27,7 +29,7 @@ export const RecordBoardColumnCardsContainer = ({
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...droppableProvided?.droppableProps}
     >
-      {children}
+      <RecordBoardColumnCardsMemo recordIds={recordIds} />
       <StyledPlaceholder>{droppableProvided?.placeholder}</StyledPlaceholder>
     </StyledColumnCardsContainer>
   );

--- a/packages/twenty-front/src/modules/object-record/record-board/record-board-column/components/RecordBoardColumnCardsMemo.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/record-board-column/components/RecordBoardColumnCardsMemo.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import { RecordBoardCardDraggableContainer } from '@/object-record/record-board/record-board-card/components/RecordBoardCardDraggableContainer';
+import { RecordBoardCardContext } from '@/object-record/record-board/record-board-card/contexts/RecordBoardCardContext';
+
+type RecordBoardColumnCardsMemoProps = {
+  recordIds: string[];
+};
+
+export const RecordBoardColumnCardsMemo = React.memo(
+  ({ recordIds }: RecordBoardColumnCardsMemoProps) => {
+    return recordIds.map((recordId, index) => (
+      <RecordBoardCardContext.Provider value={{ recordId }} key={recordId}>
+        <RecordBoardCardDraggableContainer recordId={recordId} index={index} />
+      </RecordBoardCardContext.Provider>
+    ));
+  },
+);

--- a/packages/twenty-front/src/modules/object-record/record-index/components/RecordIndexBoardContainer.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-index/components/RecordIndexBoardContainer.tsx
@@ -1,4 +1,9 @@
+import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
+import { useCreateOneRecord } from '@/object-record/hooks/useCreateOneRecord';
+import { useDeleteOneRecord } from '@/object-record/hooks/useDeleteOneRecord';
+import { useUpdateOneRecord } from '@/object-record/hooks/useUpdateOneRecord';
 import { RecordBoard } from '@/object-record/record-board/components/RecordBoard';
+import { RecordBoardContext } from '@/object-record/record-board/contexts/RecordBoardContext';
 
 type RecordIndexBoardContainerProps = {
   recordBoardId: string;
@@ -9,6 +14,24 @@ type RecordIndexBoardContainerProps = {
 
 export const RecordIndexBoardContainer = ({
   recordBoardId,
+  objectNameSingular,
 }: RecordIndexBoardContainerProps) => {
-  return <RecordBoard recordBoardId={recordBoardId} />;
+  const { objectMetadataItem } = useObjectMetadataItem({ objectNameSingular });
+
+  const { deleteOneRecord } = useDeleteOneRecord({ objectNameSingular });
+  const { updateOneRecord } = useUpdateOneRecord({ objectNameSingular });
+  const { createOneRecord } = useCreateOneRecord({ objectNameSingular });
+
+  return (
+    <RecordBoardContext.Provider
+      value={{
+        objectMetadataItem,
+        createOneRecord,
+        updateOneRecord,
+        deleteOneRecord,
+      }}
+    >
+      <RecordBoard recordBoardId={recordBoardId} />
+    </RecordBoardContext.Provider>
+  );
 };


### PR DESCRIPTION
In this PR:
- fixing an unrelated bug on activities body summary: if the first item of the activity body is a table, it was not parsed properly. Also added a unit test
- create a RecordBoardContext to store mutations (update, create, delete)
- re-implemented field update
- re-implemented drag and drop of a card