### PR TITLE
fix-right-drawer-bounces-when-opening-a-different-thread

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/right-drawer/components/RightDrawer.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/right-drawer/components/RightDrawer.tsx
@@ -83,14 +83,23 @@ export const RightDrawer = () => {
     return <></>;
   }
 
+  const variants = {
+    fullScreen: {
+      width: '100%',
+    },
+    normal: {
+      width: rightDrawerWidth,
+    },
+    close: {
+      width: 0,
+    },
+  };
+
   return (
     <StyledContainer
-      initial={{
-        width: 0,
-      }}
-      animate={{
-        width: rightDrawerWidth,
-      }}
+      initial="close"
+      animate={isRightDrawerOpen ? 'normal' : 'close'}
+      variants={variants}
       transition={{
         duration: theme.animation.duration.normal,
       }}

--- a/packages/twenty-front/src/modules/ui/layout/right-drawer/components/RightDrawer.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/right-drawer/components/RightDrawer.tsx
@@ -90,15 +90,15 @@ export const RightDrawer = () => {
     normal: {
       width: rightDrawerWidth,
     },
-    close: {
+    closed: {
       width: 0,
     },
   };
 
   return (
     <StyledContainer
-      initial="close"
-      animate={isRightDrawerOpen ? 'normal' : 'close'}
+      initial="closed"
+      animate={isRightDrawerOpen ? 'normal' : 'closed'}
       variants={variants}
       transition={{
         duration: theme.animation.duration.normal,


### PR DESCRIPTION
Fix right drawer bounces when opening a different thread