### PR TITLE
[messaging] fix message-channel-message-association field name as dependencies

### DIFF
--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/message-channel.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/message-channel.object-metadata.ts
@@ -82,5 +82,5 @@ export class MessageChannelObjectMetadata extends BaseObjectMetadata {
     objectName: 'messageChannelMessageAssociation',
   })
   @IsNullable()
-  messageChannelMessageAssociation: MessageChannelMessageAssociationObjectMetadata[];
+  messageChannelMessageAssociations: MessageChannelMessageAssociationObjectMetadata[];
 }

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/message-thread.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/message-thread.object-metadata.ts
@@ -46,5 +46,5 @@ export class MessageThreadObjectMetadata extends BaseObjectMetadata {
     objectName: 'messageChannelMessageAssociation',
   })
   @IsNullable()
-  messageChannelMessageAssociation: MessageChannelMessageAssociationObjectMetadata[];
+  messageChannelMessageAssociations: MessageChannelMessageAssociationObjectMetadata[];
 }

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/message.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/message.object-metadata.ts
@@ -112,5 +112,5 @@ export class MessageObjectMetadata extends BaseObjectMetadata {
     objectName: 'messageChannelMessageAssociation',
   })
   @IsNullable()
-  messageChannelMessageAssociation: MessageChannelMessageAssociationObjectMetadata[];
+  messageChannelMessageAssociations: MessageChannelMessageAssociationObjectMetadata[];
 }

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/types/object-record.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/types/object-record.ts
@@ -1,6 +1,5 @@
 import { BaseObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/base.object-metadata';
 
-// Note: This is actually not enterely correct, id field should only be added if the relation is MANY_TO_ONE or ONE_TO_ONE
 export type ObjectRecord<T extends BaseObjectMetadata> = {
   [K in keyof T as T[K] extends BaseObjectMetadata
     ? `${Extract<K, string>}Id`


### PR DESCRIPTION
## Context

Fixing messageChannelMessageAssociations key name as it is a ONE_TO_MANY. This does not impact the DB currently since this is still behind a flag, also for ONE_TO_MANY the property name is not used as we use `objectName` from RelationMetadata decorator

Also removing a comment in object-record.ts, this one is not relevant and has been fixed.