### PR TITLE
[Messaging] Delete empty threads after message deletion import

### DIFF
--- a/packages/twenty-server/src/workspace/messaging/message-channel-message-association/message-channel-message-association.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/message-channel-message-association/message-channel-message-association.service.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
+import { EntityManager } from 'typeorm';
+
 import { WorkspaceDataSourceService } from 'src/workspace/workspace-datasource/workspace-datasource.service';
 import { MessageChannelMessageAssociationObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/message-channel-message-association.object-metadata';
 import { ObjectRecord } from 'src/workspace/workspace-sync-metadata/types/object-record';
@@ -14,16 +16,17 @@ export class MessageChannelMessageAssociationService {
     messageExternalIds: string[],
     messageChannelId: string,
     workspaceId: string,
+    transactionManager?: EntityManager,
   ): Promise<ObjectRecord<MessageChannelMessageAssociationObjectMetadata>[]> {
-    const { dataSource: workspaceDataSource, dataSourceMetadata } =
-      await this.workspaceDataSourceService.connectedToWorkspaceDataSourceAndReturnMetadata(
-        workspaceId,
-      );
+    const dataSourceSchema =
+      this.workspaceDataSourceService.getSchemaName(workspaceId);
 
-    return await workspaceDataSource?.query(
-      `SELECT * FROM ${dataSourceMetadata.schema}."messageChannelMessageAssociation"
+    return await this.workspaceDataSourceService.executeRawQuery(
+      `SELECT * FROM ${dataSourceSchema}."messageChannelMessageAssociation"
     WHERE "messageExternalId" = ANY($1) AND "messageChannelId" = $2`,
       [messageExternalIds, messageChannelId],
+      workspaceId,
+      transactionManager,
     );
   }
 
@@ -31,16 +34,17 @@ export class MessageChannelMessageAssociationService {
     messageExternalIds: string[],
     messageChannelId: string,
     workspaceId: string,
+    transactionManager?: EntityManager,
   ): Promise<number> {
-    const { dataSource: workspaceDataSource, dataSourceMetadata } =
-      await this.workspaceDataSourceService.connectedToWorkspaceDataSourceAndReturnMetadata(
-        workspaceId,
-      );
+    const dataSourceSchema =
+      this.workspaceDataSourceService.getSchemaName(workspaceId);
 
-    const result = await workspaceDataSource?.query(
-      `SELECT COUNT(*) FROM ${dataSourceMetadata.schema}."messageChannelMessageAssociation"
+    const result = await this.workspaceDataSourceService.executeRawQuery(
+      `SELECT COUNT(*) FROM ${dataSourceSchema}."messageChannelMessageAssociation"
     WHERE "messageExternalId" = ANY($1) AND "messageChannelId" = $2`,
       [messageExternalIds, messageChannelId],
+      workspaceId,
+      transactionManager,
     );
 
     return result[0]?.count;
@@ -50,54 +54,62 @@ export class MessageChannelMessageAssociationService {
     messageExternalIds: string[],
     messageChannelId: string,
     workspaceId: string,
+    transactionManager?: EntityManager,
   ) {
-    const { dataSource: workspaceDataSource, dataSourceMetadata } =
-      await this.workspaceDataSourceService.connectedToWorkspaceDataSourceAndReturnMetadata(
-        workspaceId,
-      );
+    const dataSourceSchema =
+      this.workspaceDataSourceService.getSchemaName(workspaceId);
 
-    await workspaceDataSource?.query(
-      `DELETE FROM ${dataSourceMetadata.schema}."messageChannelMessageAssociation" WHERE "messageExternalId" = ANY($1) AND "messageChannelId" = $2`,
+    await this.workspaceDataSourceService.executeRawQuery(
+      `DELETE FROM ${dataSourceSchema}."messageChannelMessageAssociation" WHERE "messageExternalId" = ANY($1) AND "messageChannelId" = $2`,
       [messageExternalIds, messageChannelId],
+      workspaceId,
+      transactionManager,
     );
   }
 
-  public async deleteByIds(ids: string[], workspaceId: string) {
-    const { dataSource: workspaceDataSource, dataSourceMetadata } =
-      await this.workspaceDataSourceService.connectedToWorkspaceDataSourceAndReturnMetadata(
-        workspaceId,
-      );
+  public async deleteByIds(
+    ids: string[],
+    workspaceId: string,
+    transactionManager?: EntityManager,
+  ) {
+    const dataSourceSchema =
+      this.workspaceDataSourceService.getSchemaName(workspaceId);
 
-    await workspaceDataSource?.query(
-      `DELETE FROM ${dataSourceMetadata.schema}."messageChannelMessageAssociation" WHERE "id" = ANY($1)`,
+    await this.workspaceDataSourceService.executeRawQuery(
+      `DELETE FROM ${dataSourceSchema}."messageChannelMessageAssociation" WHERE "id" = ANY($1)`,
       [ids],
+      workspaceId,
+      transactionManager,
     );
   }
 
   public async getByMessageThreadExternalIds(
     messageThreadExternalIds: string[],
     workspaceId: string,
+    transactionManager?: EntityManager,
   ): Promise<ObjectRecord<MessageChannelMessageAssociationObjectMetadata>[]> {
-    const { dataSource: workspaceDataSource, dataSourceMetadata } =
-      await this.workspaceDataSourceService.connectedToWorkspaceDataSourceAndReturnMetadata(
-        workspaceId,
-      );
+    const dataSourceSchema =
+      this.workspaceDataSourceService.getSchemaName(workspaceId);
 
-    return await workspaceDataSource?.query(
-      `SELECT * FROM ${dataSourceMetadata.schema}."messageChannelMessageAssociation"
+    return await this.workspaceDataSourceService.executeRawQuery(
+      `SELECT * FROM ${dataSourceSchema}."messageChannelMessageAssociation"
     WHERE "messageThreadExternalId" = ANY($1)`,
       [messageThreadExternalIds],
+      workspaceId,
+      transactionManager,
     );
   }
 
   public async getFirstByMessageThreadExternalId(
     messageThreadExternalId: string,
     workspaceId: string,
+    transactionManager?: EntityManager,
   ): Promise<ObjectRecord<MessageChannelMessageAssociationObjectMetadata> | null> {
     const existingMessageChannelMessageAssociations =
       await this.getByMessageThreadExternalIds(
         [messageThreadExternalId],
         workspaceId,
+        transactionManager,
       );
 
     if (
@@ -113,16 +125,17 @@ export class MessageChannelMessageAssociationService {
   public async getByMessageIds(
     messageIds: string[],
     workspaceId: string,
+    transactionManager?: EntityManager,
   ): Promise<ObjectRecord<MessageChannelMessageAssociationObjectMetadata>[]> {
-    const { dataSource: workspaceDataSource, dataSourceMetadata } =
-      await this.workspaceDataSourceService.connectedToWorkspaceDataSourceAndReturnMetadata(
-        workspaceId,
-      );
+    const dataSourceSchema =
+      this.workspaceDataSourceService.getSchemaName(workspaceId);
 
-    return await workspaceDataSource?.query(
-      `SELECT * FROM ${dataSourceMetadata.schema}."messageChannelMessageAssociation"
+    return await this.workspaceDataSourceService.executeRawQuery(
+      `SELECT * FROM ${dataSourceSchema}."messageChannelMessageAssociation"
     WHERE "messageId" = ANY($1)`,
       [messageIds],
+      workspaceId,
+      transactionManager,
     );
   }
 }

--- a/packages/twenty-server/src/workspace/messaging/message-channel-message-association/message-channel-message-association.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/message-channel-message-association/message-channel-message-association.service.ts
@@ -62,6 +62,18 @@ export class MessageChannelMessageAssociationService {
     );
   }
 
+  public async deleteByIds(ids: string[], workspaceId: string) {
+    const { dataSource: workspaceDataSource, dataSourceMetadata } =
+      await this.workspaceDataSourceService.connectedToWorkspaceDataSourceAndReturnMetadata(
+        workspaceId,
+      );
+
+    await workspaceDataSource?.query(
+      `DELETE FROM ${dataSourceMetadata.schema}."messageChannelMessageAssociation" WHERE "id" = ANY($1)`,
+      [ids],
+    );
+  }
+
   public async getByMessageThreadExternalIds(
     messageThreadExternalIds: string[],
     workspaceId: string,

--- a/packages/twenty-server/src/workspace/messaging/message-thread/message-thread.module.ts
+++ b/packages/twenty-server/src/workspace/messaging/message-thread/message-thread.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+
+import { MessageThreadService } from 'src/workspace/messaging/message-thread/message-thread.service';
+import { WorkspaceDataSourceModule } from 'src/workspace/workspace-datasource/workspace-datasource.module';
+
+@Module({
+  imports: [WorkspaceDataSourceModule],
+  providers: [MessageThreadService],
+  exports: [MessageThreadService],
+})
+export class MessageThreadModule {}

--- a/packages/twenty-server/src/workspace/messaging/message-thread/message-thread.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/message-thread/message-thread.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@nestjs/common';
+
+import { WorkspaceDataSourceService } from 'src/workspace/workspace-datasource/workspace-datasource.service';
+
+@Injectable()
+export class MessageThreadService {
+  constructor(
+    private readonly workspaceDataSourceService: WorkspaceDataSourceService,
+  ) {}
+
+  public async deleteByIds(
+    messageThreadIds: string[],
+    workspaceId: string,
+  ): Promise<void> {
+    const { dataSource: workspaceDataSource, dataSourceMetadata } =
+      await this.workspaceDataSourceService.connectedToWorkspaceDataSourceAndReturnMetadata(
+        workspaceId,
+      );
+
+    await workspaceDataSource?.query(
+      `DELETE FROM ${dataSourceMetadata.schema}."messageThread" WHERE id = ANY($1)`,
+      [messageThreadIds],
+    );
+  }
+}

--- a/packages/twenty-server/src/workspace/messaging/message-thread/message-thread.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/message-thread/message-thread.service.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
+import { EntityManager } from 'typeorm';
+
 import { WorkspaceDataSourceService } from 'src/workspace/workspace-datasource/workspace-datasource.service';
 
 @Injectable()
@@ -11,15 +13,16 @@ export class MessageThreadService {
   public async deleteByIds(
     messageThreadIds: string[],
     workspaceId: string,
+    transactionManager?: EntityManager,
   ): Promise<void> {
-    const { dataSource: workspaceDataSource, dataSourceMetadata } =
-      await this.workspaceDataSourceService.connectedToWorkspaceDataSourceAndReturnMetadata(
-        workspaceId,
-      );
+    const dataSourceSchema =
+      this.workspaceDataSourceService.getSchemaName(workspaceId);
 
-    await workspaceDataSource?.query(
-      `DELETE FROM ${dataSourceMetadata.schema}."messageThread" WHERE id = ANY($1)`,
+    await this.workspaceDataSourceService.executeRawQuery(
+      `DELETE FROM ${dataSourceSchema}."messageThread" WHERE id = ANY($1)`,
       [messageThreadIds],
+      workspaceId,
+      transactionManager,
     );
   }
 }

--- a/packages/twenty-server/src/workspace/messaging/message/message.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/message/message.service.ts
@@ -60,4 +60,19 @@ export class MessageService {
       [messageIds],
     );
   }
+
+  public async getByMessageThreadIds(
+    workspaceId: string,
+    messageThreadIds: string[],
+  ): Promise<ObjectRecord<MessageObjectMetadata>[]> {
+    const { dataSource: workspaceDataSource, dataSourceMetadata } =
+      await this.workspaceDataSourceService.connectedToWorkspaceDataSourceAndReturnMetadata(
+        workspaceId,
+      );
+
+    return await workspaceDataSource?.query(
+      `SELECT * FROM ${dataSourceMetadata.schema}."message" WHERE "messageThreadId" = ANY($1)`,
+      [messageThreadIds],
+    );
+  }
 }

--- a/packages/twenty-server/src/workspace/messaging/message/message.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/message/message.service.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
+import { EntityManager } from 'typeorm';
+
 import { WorkspaceDataSourceService } from 'src/workspace/workspace-datasource/workspace-datasource.service';
 import { MessageObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/message.object-metadata';
 import { ObjectRecord } from 'src/workspace/workspace-sync-metadata/types/object-record';
@@ -11,17 +13,18 @@ export class MessageService {
   ) {}
 
   public async getFirstByHeaderMessageId(
-    workspaceId: string,
     headerMessageId: string,
+    workspaceId: string,
+    transactionManager?: EntityManager,
   ): Promise<ObjectRecord<MessageObjectMetadata> | null> {
-    const { dataSource: workspaceDataSource, dataSourceMetadata } =
-      await this.workspaceDataSourceService.connectedToWorkspaceDataSourceAndReturnMetadata(
-        workspaceId,
-      );
+    const dataSourceSchema =
+      this.workspaceDataSourceService.getSchemaName(workspaceId);
 
-    const messages = await workspaceDataSource?.query(
-      `SELECT * FROM ${dataSourceMetadata.schema}."message" WHERE "headerMessageId" = $1 LIMIT 1`,
+    const messages = await this.workspaceDataSourceService.executeRawQuery(
+      `SELECT * FROM ${dataSourceSchema}."message" WHERE "headerMessageId" = $1 LIMIT 1`,
       [headerMessageId],
+      workspaceId,
+      transactionManager,
     );
 
     if (!messages || messages.length === 0) {
@@ -32,47 +35,50 @@ export class MessageService {
   }
 
   public async getByIds(
-    workspaceId: string,
     messageIds: string[],
+    workspaceId: string,
+    transactionManager?: EntityManager,
   ): Promise<ObjectRecord<MessageObjectMetadata>[]> {
-    const { dataSource: workspaceDataSource, dataSourceMetadata } =
-      await this.workspaceDataSourceService.connectedToWorkspaceDataSourceAndReturnMetadata(
-        workspaceId,
-      );
+    const dataSourceSchema =
+      this.workspaceDataSourceService.getSchemaName(workspaceId);
 
-    return await workspaceDataSource?.query(
-      `SELECT * FROM ${dataSourceMetadata.schema}."message" WHERE "id" = ANY($1)`,
+    return await this.workspaceDataSourceService.executeRawQuery(
+      `SELECT * FROM ${dataSourceSchema}."message" WHERE "id" = ANY($1)`,
       [messageIds],
+      workspaceId,
+      transactionManager,
     );
   }
 
   public async deleteByIds(
-    workspaceId: string,
     messageIds: string[],
+    workspaceId: string,
+    transactionManager?: EntityManager,
   ): Promise<void> {
-    const { dataSource: workspaceDataSource, dataSourceMetadata } =
-      await this.workspaceDataSourceService.connectedToWorkspaceDataSourceAndReturnMetadata(
-        workspaceId,
-      );
+    const dataSourceSchema =
+      this.workspaceDataSourceService.getSchemaName(workspaceId);
 
-    await workspaceDataSource?.query(
-      `DELETE FROM ${dataSourceMetadata.schema}."message" WHERE "id" = ANY($1)`,
+    await this.workspaceDataSourceService.executeRawQuery(
+      `DELETE FROM ${dataSourceSchema}."message" WHERE "id" = ANY($1)`,
       [messageIds],
+      workspaceId,
+      transactionManager,
     );
   }
 
   public async getByMessageThreadIds(
-    workspaceId: string,
     messageThreadIds: string[],
+    workspaceId: string,
+    transactionManager?: EntityManager,
   ): Promise<ObjectRecord<MessageObjectMetadata>[]> {
-    const { dataSource: workspaceDataSource, dataSourceMetadata } =
-      await this.workspaceDataSourceService.connectedToWorkspaceDataSourceAndReturnMetadata(
-        workspaceId,
-      );
+    const dataSourceSchema =
+      this.workspaceDataSourceService.getSchemaName(workspaceId);
 
-    return await workspaceDataSource?.query(
-      `SELECT * FROM ${dataSourceMetadata.schema}."message" WHERE "messageThreadId" = ANY($1)`,
+    return await this.workspaceDataSourceService.executeRawQuery(
+      `SELECT * FROM ${dataSourceSchema}."message" WHERE "messageThreadId" = ANY($1)`,
       [messageThreadIds],
+      workspaceId,
+      transactionManager,
     );
   }
 }

--- a/packages/twenty-server/src/workspace/messaging/services/fetch-workspace-messages.module.ts
+++ b/packages/twenty-server/src/workspace/messaging/services/fetch-workspace-messages.module.ts
@@ -4,6 +4,7 @@ import { EnvironmentModule } from 'src/integrations/environment/environment.modu
 import { ConnectedAccountModule } from 'src/workspace/messaging/connected-account/connected-account.module';
 import { MessageChannelMessageAssociationModule } from 'src/workspace/messaging/message-channel-message-association/message-channel-message-assocation.module';
 import { MessageChannelModule } from 'src/workspace/messaging/message-channel/message-channel.module';
+import { MessageThreadModule } from 'src/workspace/messaging/message-thread/message-thread.module';
 import { MessageModule } from 'src/workspace/messaging/message/message.module';
 import { GmailClientProvider } from 'src/workspace/messaging/providers/gmail/gmail-client.provider';
 import { FetchMessagesByBatchesService } from 'src/workspace/messaging/services/fetch-messages-by-batches.service';
@@ -21,6 +22,7 @@ import { WorkspaceDataSourceModule } from 'src/workspace/workspace-datasource/wo
     MessageChannelModule,
     MessageChannelMessageAssociationModule,
     MessageModule,
+    MessageThreadModule,
   ],
   providers: [
     GmailFullSyncService,

--- a/packages/twenty-server/src/workspace/messaging/services/gmail-full-sync.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/services/gmail-full-sync.service.ts
@@ -52,8 +52,8 @@ export class GmailFullSyncService {
 
     const gmailMessageChannel =
       await this.messageChannelService.getFirstByConnectedAccountIdOrFail(
-        workspaceId,
         connectedAccountId,
+        workspaceId,
       );
 
     const gmailMessageChannelId = gmailMessageChannel.id;
@@ -129,7 +129,7 @@ export class GmailFullSyncService {
 
     if (!historyId) throw new Error('No history id found');
 
-    await this.connectedAccountService.saveLastSyncHistoryId(
+    await this.connectedAccountService.updateLastSyncHistoryId(
       historyId,
       connectedAccount.id,
       workspaceId,

--- a/packages/twenty-server/src/workspace/messaging/services/gmail-partial-sync.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/services/gmail-partial-sync.service.ts
@@ -82,8 +82,8 @@ export class GmailPartialSyncService {
 
     const gmailMessageChannel =
       await this.messageChannelService.getFirstByConnectedAccountIdOrFail(
-        workspaceId,
         connectedAccountId,
+        workspaceId,
       );
 
     const gmailMessageChannelId = gmailMessageChannel.id;
@@ -113,6 +113,7 @@ export class GmailPartialSyncService {
 
     if (messagesDeleted.length !== 0) {
       await this.utils.deleteMessages(
+        workspaceDataSource,
         messagesDeleted,
         gmailMessageChannelId,
         workspaceId,
@@ -121,7 +122,7 @@ export class GmailPartialSyncService {
 
     if (errors.length) throw new Error('Error fetching messages');
 
-    await this.connectedAccountService.saveLastSyncHistoryId(
+    await this.connectedAccountService.updateLastSyncHistoryId(
       newHistoryId,
       connectedAccount.id,
       workspaceId,

--- a/packages/twenty-server/src/workspace/messaging/services/gmail-partial-sync.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/services/gmail-partial-sync.service.ts
@@ -100,20 +100,24 @@ export class GmailPartialSyncService {
         accessToken,
       );
 
-    await this.utils.saveMessages(
-      messagesToSave,
-      dataSourceMetadata,
-      workspaceDataSource,
-      connectedAccount,
-      gmailMessageChannelId,
-      workspaceId,
-    );
+    if (messagesToSave.length !== 0) {
+      await this.utils.saveMessages(
+        messagesToSave,
+        dataSourceMetadata,
+        workspaceDataSource,
+        connectedAccount,
+        gmailMessageChannelId,
+        workspaceId,
+      );
+    }
 
-    await this.utils.deleteMessages(
-      messagesDeleted,
-      gmailMessageChannelId,
-      workspaceId,
-    );
+    if (messagesDeleted.length !== 0) {
+      await this.utils.deleteMessages(
+        messagesDeleted,
+        gmailMessageChannelId,
+        workspaceId,
+      );
+    }
 
     if (errors.length) throw new Error('Error fetching messages');
 


### PR DESCRIPTION
## Context
Follow up on https://github.com/twentyhq/twenty/pull/3701 see for more context

This PR introduces the last check that will make sure to delete empty threads.

If a message is deleted, we fetch all the other messages of the same thread and if there is none we delete the thread.

## Test
tested locally with partial sync after creating an email then deleting it (for gmail, trash then deleted, trash being a label on its own and not considered as deleted) and looking at message, messageThead and messageChannelMessageAssociation COUNT.

`yarn command workspace:gmail-partial-sync -w "20202020-1c25-4d02-bf25-6aeccf7ea419"`