### PR TITLE
Fix workspace-sync when alter with relation

### DIFF
--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/factories/workspace-sync.factory.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/factories/workspace-sync.factory.ts
@@ -106,6 +106,10 @@ export class WorkspaceSyncFactory {
 
     if (createdFieldMetadataCollection.length > 0) {
       for (const fieldMetadata of createdFieldMetadataCollection) {
+        if (fieldMetadata.type === FieldMetadataType.RELATION) {
+          continue;
+        }
+
         const migrations = [
           {
             name: computeObjectTargetTable(


### PR DESCRIPTION
## Context
Fixing error: "Sync of standard objects failed with: Error: No factory found for type RELATION"
Due to the fact that we are trying to use workspaceMigrationFactory inside createObjectMigration() method to create column actions. 
However we want to skip that logic for relation types because this is already handled inside createRelationMigration() method.
We already filter out relation types in the method above L49 https://github.com/twentyhq/twenty/pull/3721/files#diff-b80c8100118f4f941871b56641f74a36ddaef44099e62aee74f0b21634f9481aR49

## Test
Added a flag on an existing workspace and ran the command to generate new tables that contain relations

<img width="176" alt="Screenshot 2024-01-31 at 15 45 30" src="https://github.com/twentyhq/twenty/assets/1834158/a92d28e5-9764-4655-a27b-adc7a5d86a57">
<img width="418" alt="Screenshot 2024-01-31 at 15 45 22" src="https://github.com/twentyhq/twenty/assets/1834158/696b5449-fa85-4fa2-bec9-278a6e511605">

```

$ yarn command workspace:health -w 4b02d8c0-3c98-41e1-8384-932eb985728f --verbose
Workspace is healthy
```