### PR TITLE
fix: options value can't contain special characters

### DIFF
--- a/packages/twenty-front/src/modules/object-metadata/utils/__tests__/formatFieldMetadataItemInput.test.ts
+++ b/packages/twenty-front/src/modules/object-metadata/utils/__tests__/formatFieldMetadataItemInput.test.ts
@@ -38,35 +38,34 @@ describe('formatFieldMetadataItemInput', () => {
       label: 'Example Label',
       icon: 'example-icon',
       description: 'Example description',
-      defaultValue: 'example-default-value',
       options: [
-        { id: '1', label: 'Option 1', color: 'red' as const },
+        { id: '1', label: 'Option 1', color: 'red' as const, isDefault: true },
         { id: '2', label: 'Option 2', color: 'blue' as const },
       ],
     };
 
     const expected = {
-      defaultValue: 'EXAMPLE_DEFAULT_VALUE',
       description: 'Example description',
       icon: 'example-icon',
       label: 'Example Label',
       name: 'exampleLabel',
       options: [
         {
-          id: 1,
+          id: '1',
           label: 'Option 1',
           color: 'red',
           position: 0,
           value: 'OPTION_1',
         },
         {
-          id: 2,
+          id: '2',
           label: 'Option 2',
           color: 'blue',
           position: 1,
           value: 'OPTION_2',
         },
       ],
+      defaultValue: 'OPTION_1',
     };
 
     const result = formatFieldMetadataItemInput(input);
@@ -79,16 +78,15 @@ describe('formatFieldMetadataItemInput', () => {
       label: 'Example Label',
       icon: 'example-icon',
       description: 'Example description',
-      defaultValue: 'example-default-value',
     };
 
     const expected = {
-      defaultValue: 'EXAMPLE_DEFAULT_VALUE',
       description: 'Example description',
       icon: 'example-icon',
       label: 'Example Label',
       name: 'exampleLabel',
       options: undefined,
+      defaultValue: undefined,
     };
 
     const result = formatFieldMetadataItemInput(input);

--- a/packages/twenty-front/src/modules/object-metadata/utils/__tests__/formatFieldMetadataItemInput.test.ts
+++ b/packages/twenty-front/src/modules/object-metadata/utils/__tests__/formatFieldMetadataItemInput.test.ts
@@ -30,6 +30,15 @@ describe('getOptionValueFromLabel', () => {
 
     expect(result).toEqual(expected);
   });
+
+  it('should handle labels with emojis', () => {
+    const label = '📱 Example Label';
+    const expected = 'EXAMPLE_LABEL';
+
+    const result = getOptionValueFromLabel(label);
+
+    expect(result).toEqual(expected);
+  });
 });
 
 describe('formatFieldMetadataItemInput', () => {

--- a/packages/twenty-front/src/modules/object-metadata/utils/__tests__/formatFieldMetadataItemInput.test.ts
+++ b/packages/twenty-front/src/modules/object-metadata/utils/__tests__/formatFieldMetadataItemInput.test.ts
@@ -1,0 +1,98 @@
+import {
+  formatFieldMetadataItemInput,
+  getOptionValueFromLabel,
+} from '../formatFieldMetadataItemInput';
+
+describe('getOptionValueFromLabel', () => {
+  it('should return the option value from the label', () => {
+    const label = 'Example Label';
+    const expected = 'EXAMPLE_LABEL';
+
+    const result = getOptionValueFromLabel(label);
+
+    expect(result).toEqual(expected);
+  });
+
+  it('should handle labels with accents', () => {
+    const label = 'Éxàmplè Làbèl';
+    const expected = 'EXAMPLE_LABEL';
+
+    const result = getOptionValueFromLabel(label);
+
+    expect(result).toEqual(expected);
+  });
+
+  it('should handle labels with special characters', () => {
+    const label = 'Example!@#$%^&*() Label';
+    const expected = 'EXAMPLE_LABEL';
+
+    const result = getOptionValueFromLabel(label);
+
+    expect(result).toEqual(expected);
+  });
+});
+
+describe('formatFieldMetadataItemInput', () => {
+  it('should format the field metadata item input correctly', () => {
+    const input = {
+      label: 'Example Label',
+      icon: 'example-icon',
+      description: 'Example description',
+      defaultValue: 'example-default-value',
+      options: [
+        { id: '1', label: 'Option 1', color: 'red' as const },
+        { id: '2', label: 'Option 2', color: 'blue' as const },
+      ],
+    };
+
+    const expected = {
+      defaultValue: 'EXAMPLE_DEFAULT_VALUE',
+      description: 'Example description',
+      icon: 'example-icon',
+      label: 'Example Label',
+      name: 'exampleLabel',
+      options: [
+        {
+          id: 1,
+          label: 'Option 1',
+          color: 'red',
+          position: 0,
+          value: 'OPTION_1',
+        },
+        {
+          id: 2,
+          label: 'Option 2',
+          color: 'blue',
+          position: 1,
+          value: 'OPTION_2',
+        },
+      ],
+    };
+
+    const result = formatFieldMetadataItemInput(input);
+
+    expect(result).toEqual(expected);
+  });
+
+  it('should handle input without options', () => {
+    const input = {
+      label: 'Example Label',
+      icon: 'example-icon',
+      description: 'Example description',
+      defaultValue: 'example-default-value',
+    };
+
+    const expected = {
+      defaultValue: 'EXAMPLE_DEFAULT_VALUE',
+      description: 'Example description',
+      icon: 'example-icon',
+      label: 'Example Label',
+      name: 'exampleLabel',
+      options: undefined,
+    };
+
+    const result = formatFieldMetadataItemInput(input);
+
+    expect(result).toEqual(expected);
+  });
+});

--- a/packages/twenty-front/src/modules/object-metadata/utils/formatFieldMetadataItemInput.ts
+++ b/packages/twenty-front/src/modules/object-metadata/utils/formatFieldMetadataItemInput.ts
@@ -5,7 +5,7 @@ import { Field } from '~/generated-metadata/graphql';
 
 import { FieldMetadataOption } from '../types/FieldMetadataOption';
 
-const getOptionValueFromLabel = (label: string) => {
+export const getOptionValueFromLabel = (label: string) => {
   // Remove accents
   const unaccentedLabel = label
     .normalize('NFD')

--- a/packages/twenty-front/src/modules/object-metadata/utils/formatFieldMetadataItemInput.ts
+++ b/packages/twenty-front/src/modules/object-metadata/utils/formatFieldMetadataItemInput.ts
@@ -5,8 +5,19 @@ import { Field } from '~/generated-metadata/graphql';
 
 import { FieldMetadataOption } from '../types/FieldMetadataOption';
 
-const getOptionValueFromLabel = (label: string) =>
-  toSnakeCase(label.trim()).toUpperCase();
+const getOptionValueFromLabel = (label: string) => {
+  // Remove accents
+  const unaccentedLabel = label
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '');
+  // Remove special characters
+  const noSpecialCharactersLabel = unaccentedLabel.replace(
+    /[^a-zA-Z0-9 ]/g,
+    '',
+  );
+
+  return toSnakeCase(noSpecialCharactersLabel).toUpperCase();
+};
 
 export const formatFieldMetadataItemInput = (
   input: Pick<Field, 'label' | 'icon' | 'description' | 'defaultValue'> & {


### PR DESCRIPTION
When we put special characters like emoji inside options, the value generated by the front-end should strip the special characters and accents.

Fix #3296 