### PR TITLE
Place cursor at end when entering cell

### DIFF
--- a/packages/twenty-front/src/modules/ui/field/input/components/TextAreaInput.tsx
+++ b/packages/twenty-front/src/modules/ui/field/input/components/TextAreaInput.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useRef, useState } from 'react';
+import { ChangeEvent, useEffect, useRef, useState } from 'react';
 import TextareaAutosize from 'react-textarea-autosize';
 import styled from '@emotion/styled';
 
@@ -53,6 +53,15 @@ export const TextAreaInput = ({
   };
 
   const wrapperRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (wrapperRef.current) {
+      wrapperRef.current.setSelectionRange(
+        wrapperRef.current.value.length,
+        wrapperRef.current.value.length,
+      );
+    }
+  }, []);
 
   useRegisterInputEvents({
     inputRef: wrapperRef,


### PR DESCRIPTION
Fix: #3723 
Fix: #3724 

[place cursor at the end.webm](https://github.com/twentyhq/twenty/assets/52026385/1241b6bb-0568-4e13-9a7c-1b3f1ba26d31)
