### PR TITLE
fix: sync metadata shouldn't remove non custom fields

### DIFF
--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/comparators/workspace-field.comparator.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/comparators/workspace-field.comparator.ts
@@ -39,8 +39,11 @@ export class WorkspaceFieldComparator {
       string,
       Partial<PartialFieldMetadata>
     > = {};
+    // Double security to only compare non-custom fields
+    const filteredOriginalFieldCollection =
+      originalObjectMetadata.fields.filter((field) => !field.isCustom);
     const originalFieldMetadataMap = transformMetadataForComparison(
-      originalObjectMetadata.fields,
+      filteredOriginalFieldCollection,
       {
         propertiesToIgnore: fieldPropertiesToIgnore,
         propertiesToStringify: fieldPropertiesToStringify,

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/services/workspace-sync-object-metadata.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/services/workspace-sync-object-metadata.service.ts
@@ -43,7 +43,11 @@ export class WorkspaceSyncObjectMetadataService {
     // Retrieve object metadata collection from DB
     const originalObjectMetadataCollection =
       await objectMetadataRepository.find({
-        where: { workspaceId: context.workspaceId, isCustom: false },
+        where: {
+          workspaceId: context.workspaceId,
+          isCustom: false,
+          fields: { isCustom: false },
+        },
         relations: ['dataSource', 'fields'],
       });
 

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/services/workspace-sync-relation-metadata.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/services/workspace-sync-relation-metadata.service.ts
@@ -62,10 +62,12 @@ export class WorkspaceSyncRelationMetadataService {
     );
 
     // Retrieve relation metadata collection from DB
-    // TODO: filter out custom relations once isCustom has been added to relationMetadata table
     const originalRelationMetadataCollection =
       await relationMetadataRepository.find({
-        where: { workspaceId: context.workspaceId },
+        where: {
+          workspaceId: context.workspaceId,
+          fromFieldMetadata: { isCustom: false },
+        },
       });
 
     // Create standard relation metadata collection

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/services/workspace-sync-relation-metadata.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/services/workspace-sync-relation-metadata.service.ts
@@ -44,7 +44,11 @@ export class WorkspaceSyncRelationMetadataService {
     // Retrieve object metadata collection from DB
     const originalObjectMetadataCollection =
       await objectMetadataRepository.find({
-        where: { workspaceId: context.workspaceId, isCustom: false },
+        where: {
+          workspaceId: context.workspaceId,
+          isCustom: false,
+          fields: { isCustom: false },
+        },
         relations: ['dataSource', 'fields'],
       });
 


### PR DESCRIPTION
Sync metadata script must not remove non custom fields.