### PR TITLE
[messaging] reorder messages desc to asc

### DIFF
--- a/packages/twenty-front/src/modules/activities/emails/right-drawer/components/RightDrawerEmailThread.tsx
+++ b/packages/twenty-front/src/modules/activities/emails/right-drawer/components/RightDrawerEmailThread.tsx
@@ -37,7 +37,7 @@ export const RightDrawerEmailThread = () => {
     },
     objectNameSingular: CoreObjectNameSingular.Message,
     orderBy: {
-      receivedAt: 'DescNullsLast',
+      receivedAt: 'AscNullsLast',
     },
     skip: !viewableEmailThread,
     useRecordsWithoutConnection: true,

--- a/packages/twenty-server/src/workspace/messaging/services/fetch-messages-by-batches.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/services/fetch-messages-by-batches.service.ts
@@ -82,8 +82,6 @@ export class FetchMessagesByBatchesService {
       },
     );
 
-    console.log('responseFromGmailQuery', response);
-
     return response;
   }
 

--- a/packages/twenty-server/src/workspace/messaging/services/gmail-full-sync.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/services/gmail-full-sync.service.ts
@@ -67,8 +67,6 @@ export class GmailFullSyncService {
       pageToken: nextPageToken,
     });
 
-    console.log('messageList query result from gmail', messages);
-
     const messagesData = messages.data.messages;
 
     const messageExternalIds = messagesData
@@ -86,11 +84,6 @@ export class GmailFullSyncService {
         workspaceId,
       );
 
-    console.log(
-      'existingMessagesInDB',
-      existingMessageChannelMessageAssociations,
-    );
-
     const existingMessageChannelMessageAssociationsExternalIds =
       existingMessageChannelMessageAssociations.map(
         (messageChannelMessageAssociation) =>
@@ -104,8 +97,6 @@ export class GmailFullSyncService {
         ),
     );
 
-    console.log('newMessagesToFetch', messagesToFetch);
-
     const messageQueries =
       this.utils.createQueriesFromMessageIds(messagesToFetch);
 
@@ -114,8 +105,6 @@ export class GmailFullSyncService {
         messageQueries,
         accessToken,
       );
-
-    console.log('messagesToSave', messagesToSave);
 
     if (messagesToSave.length === 0) {
       return;
@@ -149,7 +138,7 @@ export class GmailFullSyncService {
     console.log(
       `gmail full-sync for workspace ${workspaceId} and account ${connectedAccountId} ${
         nextPageToken ? `and ${nextPageToken} pageToken` : ''
-      } done.`,
+      }done.`,
     );
 
     if (messages.data.nextPageToken) {


### PR DESCRIPTION
## Context
To match with the figma and also because it's usually more conventional in an email client to see mails in that order, this PR aims to change the order from DESC to ASC on the receivedAt field.

Note: Also removing a few logs we left yesterday when we were testing integration.

## Test
Before (last message at the top)
<img width="457" alt="Screenshot 2024-02-01 at 15 18 38" src="https://github.com/twentyhq/twenty/assets/1834158/251b0eb2-7ff9-4110-accb-660e2129c717">

After (last message at the bottom)
<img width="444" alt="Screenshot 2024-02-01 at 15 19 11" src="https://github.com/twentyhq/twenty/assets/1834158/e13cbd05-872d-4497-a032-855d994383a2">