### PR TITLE
feat: add dry-run option to sync-metadata command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@
 !.yarn/versions
 coverage
 .vercel
+
+**/**/logs/**

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/commands/sync-workspace-metadata.command.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/commands/sync-workspace-metadata.command.ts
@@ -6,6 +6,7 @@ import { WorkspaceSyncMetadataService } from 'src/workspace/workspace-sync-metad
 // TODO: implement dry-run
 interface RunWorkspaceMigrationsOptions {
   workspaceId: string;
+  dryRun?: boolean;
 }
 
 @Command({
@@ -35,6 +36,7 @@ export class SyncWorkspaceMetadataCommand extends CommandRunner {
         workspaceId: options.workspaceId,
         dataSourceId: dataSourceMetadata.id,
       },
+      { dryRun: options.dryRun },
     );
   }
 
@@ -45,5 +47,14 @@ export class SyncWorkspaceMetadataCommand extends CommandRunner {
   })
   parseWorkspaceId(value: string): string {
     return value;
+  }
+
+  @Option({
+    flags: '-d, --dry-run',
+    description: 'Dry run without applying changes',
+    required: false,
+  })
+  dryRun(): boolean {
+    return true;
   }
 }

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/services/workspace-logs.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/services/workspace-logs.service.ts
@@ -1,0 +1,70 @@
+import { Injectable } from '@nestjs/common';
+
+import fs from 'fs/promises';
+
+import { WorkspaceSyncStorage } from 'src/workspace/workspace-sync-metadata/storage/workspace-sync.storage';
+import { WorkspaceMigrationEntity } from 'src/metadata/workspace-migration/workspace-migration.entity';
+
+@Injectable()
+export class WorkspaceLogsService {
+  constructor() {}
+
+  async saveLogs(
+    storage: WorkspaceSyncStorage,
+    workspaceMigrations: WorkspaceMigrationEntity[],
+  ) {
+    // Save workspace migrations
+    await fs.writeFile(
+      './logs/workspace-migrations.json',
+      JSON.stringify(workspaceMigrations, null, 2),
+    );
+
+    // Save object metadata create collection
+    await fs.writeFile(
+      './logs/object-metadata-create-collection.json',
+      JSON.stringify(storage.objectMetadataCreateCollection, null, 2),
+    );
+
+    // Save object metadata update collection
+    await fs.writeFile(
+      './logs/object-metadata-update-collection.json',
+      JSON.stringify(storage.objectMetadataUpdateCollection, null, 2),
+    );
+
+    // Save object metadata delete collection
+    await fs.writeFile(
+      './logs/object-metadata-delete-collection.json',
+      JSON.stringify(storage.objectMetadataDeleteCollection, null, 2),
+    );
+
+    // Save field metadata create collection
+    await fs.writeFile(
+      './logs/field-metadata-create-collection.json',
+      JSON.stringify(storage.fieldMetadataCreateCollection, null, 2),
+    );
+
+    // Save field metadata update collection
+    await fs.writeFile(
+      './logs/field-metadata-update-collection.json',
+      JSON.stringify(storage.fieldMetadataUpdateCollection, null, 2),
+    );
+
+    // Save field metadata delete collection
+    await fs.writeFile(
+      './logs/field-metadata-delete-collection.json',
+      JSON.stringify(storage.fieldMetadataDeleteCollection, null, 2),
+    );
+
+    // Save relation metadata create collection
+    await fs.writeFile(
+      './logs/relation-metadata-create-collection.json',
+      JSON.stringify(storage.relationMetadataCreateCollection, null, 2),
+    );
+
+    // Save relation metadata delete collection
+    await fs.writeFile(
+      './logs/relation-metadata-delete-collection.json',
+      JSON.stringify(storage.relationMetadataDeleteCollection, null, 2),
+    );
+  }
+}

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/services/workspace-sync-object-metadata.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/services/workspace-sync-object-metadata.service.ts
@@ -33,7 +33,7 @@ export class WorkspaceSyncObjectMetadataService {
     manager: EntityManager,
     storage: WorkspaceSyncStorage,
     workspaceFeatureFlagsMap: FeatureFlagMap,
-  ): Promise<void> {
+  ): Promise<WorkspaceMigrationEntity[]> {
     const objectMetadataRepository =
       manager.getRepository(ObjectMetadataEntity);
     const workspaceMigrationRepository = manager.getRepository(
@@ -153,6 +153,10 @@ export class WorkspaceSyncObjectMetadataService {
     this.logger.log('Saving migrations');
 
     // Save migrations into DB
-    await workspaceMigrationRepository.save(workspaceObjectMigrations);
+    const workspaceMigrations = await workspaceMigrationRepository.save(
+      workspaceObjectMigrations,
+    );
+
+    return workspaceMigrations;
   }
 }

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/services/workspace-sync-relation-metadata.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/services/workspace-sync-relation-metadata.service.ts
@@ -34,7 +34,7 @@ export class WorkspaceSyncRelationMetadataService {
     manager: EntityManager,
     storage: WorkspaceSyncStorage,
     workspaceFeatureFlagsMap: FeatureFlagMap,
-  ): Promise<void> {
+  ): Promise<WorkspaceMigrationEntity[]> {
     const objectMetadataRepository =
       manager.getRepository(ObjectMetadataEntity);
     const workspaceMigrationRepository = manager.getRepository(
@@ -106,6 +106,10 @@ export class WorkspaceSyncRelationMetadataService {
       );
 
     // Save migrations into DB
-    await workspaceMigrationRepository.save(workspaceRelationMigrations);
+    const workspaceMigrations = await workspaceMigrationRepository.save(
+      workspaceRelationMigrations,
+    );
+
+    return workspaceMigrations;
   }
 }

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/workspace-sync-metadata.module.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/workspace-sync-metadata.module.ts
@@ -14,6 +14,7 @@ import { workspaceSyncMetadataComparators } from 'src/workspace/workspace-sync-m
 import { WorkspaceMetadataUpdaterService } from 'src/workspace/workspace-sync-metadata/services/workspace-metadata-updater.service';
 import { WorkspaceSyncObjectMetadataService } from 'src/workspace/workspace-sync-metadata/services/workspace-sync-object-metadata.service';
 import { WorkspaceSyncRelationMetadataService } from 'src/workspace/workspace-sync-metadata/services/workspace-sync-relation-metadata.service';
+import { WorkspaceLogsService } from 'src/workspace/workspace-sync-metadata/services/workspace-logs.service';
 
 @Module({
   imports: [
@@ -37,6 +38,7 @@ import { WorkspaceSyncRelationMetadataService } from 'src/workspace/workspace-sy
     WorkspaceSyncObjectMetadataService,
     WorkspaceSyncRelationMetadataService,
     WorkspaceSyncMetadataService,
+    WorkspaceLogsService,
   ],
   exports: [WorkspaceSyncMetadataService],
 })

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/workspace-sync-metadata.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/workspace-sync-metadata.service.ts
@@ -1,8 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectDataSource } from '@nestjs/typeorm';
 
-import fs from 'fs/promises';
-
 import { DataSource } from 'typeorm';
 
 import { WorkspaceSyncContext } from 'src/workspace/workspace-sync-metadata/interfaces/workspace-sync-context.interface';
@@ -12,6 +10,7 @@ import { FeatureFlagFactory } from 'src/workspace/workspace-sync-metadata/factor
 import { WorkspaceSyncObjectMetadataService } from 'src/workspace/workspace-sync-metadata/services/workspace-sync-object-metadata.service';
 import { WorkspaceSyncRelationMetadataService } from 'src/workspace/workspace-sync-metadata/services/workspace-sync-relation-metadata.service';
 import { WorkspaceSyncStorage } from 'src/workspace/workspace-sync-metadata/storage/workspace-sync.storage';
+import { WorkspaceLogsService } from 'src/workspace/workspace-sync-metadata/services/workspace-logs.service';
 
 @Injectable()
 export class WorkspaceSyncMetadataService {
@@ -24,6 +23,7 @@ export class WorkspaceSyncMetadataService {
     private readonly workspaceMigrationRunnerService: WorkspaceMigrationRunnerService,
     private readonly workspaceSyncObjectMetadataService: WorkspaceSyncObjectMetadataService,
     private readonly workspaceSyncRelationMetadataService: WorkspaceSyncRelationMetadataService,
+    private readonly workspaceLogsService: WorkspaceLogsService,
   ) {}
 
   /**
@@ -82,10 +82,7 @@ export class WorkspaceSyncMetadataService {
 
         await queryRunner.rollbackTransaction();
 
-        await fs.writeFile(
-          './logs/workspace-migrations.json',
-          JSON.stringify(workspaceMigrations, null, 2),
-        );
+        await this.workspaceLogsService.saveLogs(storage, workspaceMigrations);
 
         return;
       }


### PR DESCRIPTION
Add a `dry-run` option to the command `workspace:sync-metadata` to avoid applying unwanted changes to the database.