### PR TITLE
feat: execute pending migrations command

### DIFF
--- a/packages/twenty-server/src/command.module.ts
+++ b/packages/twenty-server/src/command.module.ts
@@ -10,6 +10,7 @@ import { WorkspaceHealthCommandModule } from 'src/workspace/workspace-health/com
 import { AppModule } from './app.module';
 
 import { WorkspaceSyncMetadataCommandsModule } from './workspace/workspace-sync-metadata/commands/workspace-sync-metadata-commands.module';
+import { WorkspaceMigrationRunnerCommandsModule } from './workspace/workspace-migration-runner/commands/workspace-sync-metadata-commands.module';
 
 @Module({
   imports: [
@@ -21,6 +22,7 @@ import { WorkspaceSyncMetadataCommandsModule } from './workspace/workspace-sync-
     StopCleanInactiveWorkspacesCronCommand,
     CleanInactiveWorkspacesCommand,
     WorkspaceHealthCommandModule,
+    WorkspaceMigrationRunnerCommandsModule,
   ],
 })
 export class CommandModule {}

--- a/packages/twenty-server/src/workspace/workspace-migration-runner/commands/workspace-execute-pending-migrations.command.ts
+++ b/packages/twenty-server/src/workspace/workspace-migration-runner/commands/workspace-execute-pending-migrations.command.ts
@@ -1,0 +1,37 @@
+import { Command, CommandRunner, Option } from 'nest-commander';
+
+import { WorkspaceMigrationRunnerService } from 'src/workspace/workspace-migration-runner/workspace-migration-runner.service';
+
+interface ExecuteWorkspaceMigrationsOptions {
+  workspaceId: string;
+}
+
+@Command({
+  name: 'workspace:apply-pending-migrations',
+  description: 'Apply pending migrations',
+})
+export class WorkspaceExecutePendingMigrationsCommand extends CommandRunner {
+  constructor(
+    private readonly workspaceMigrationRunnerService: WorkspaceMigrationRunnerService,
+  ) {
+    super();
+  }
+
+  async run(
+    _passedParam: string[],
+    options: ExecuteWorkspaceMigrationsOptions,
+  ): Promise<void> {
+    await this.workspaceMigrationRunnerService.executeMigrationFromPendingMigrations(
+      options.workspaceId,
+    );
+  }
+
+  @Option({
+    flags: '-w, --workspace-id [workspace_id]',
+    description: 'workspace id',
+    required: true,
+  })
+  parseWorkspaceId(value: string): string {
+    return value;
+  }
+}

--- a/packages/twenty-server/src/workspace/workspace-migration-runner/commands/workspace-sync-metadata-commands.module.ts
+++ b/packages/twenty-server/src/workspace/workspace-migration-runner/commands/workspace-sync-metadata-commands.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+
+import { WorkspaceMigrationRunnerModule } from 'src/workspace/workspace-migration-runner/workspace-migration-runner.module';
+
+import { WorkspaceExecutePendingMigrationsCommand } from './workspace-execute-pending-migrations.command';
+
+@Module({
+  imports: [WorkspaceMigrationRunnerModule],
+  providers: [WorkspaceExecutePendingMigrationsCommand],
+})
+export class WorkspaceMigrationRunnerCommandsModule {}


### PR DESCRIPTION
This new command `workspace:apply-pending-migrations` allow us to only run the part that is applying the migration to the database from the `workspaceMigration` table.
This is here to retry applying migrations when an error occurred.