### PR TITLE
[poc] standard objects validation handlers

### DIFF
--- a/packages/twenty-server/src/workspace/workspace-query-runner/validation-handler/factories/validation-handler.factory.ts
+++ b/packages/twenty-server/src/workspace/workspace-query-runner/validation-handler/factories/validation-handler.factory.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+
+import { ValidationHandler } from 'src/workspace/workspace-query-runner/validation-handler/interfaces/validation-handler.interface';
+
+import { PersonValidationHandler } from 'src/workspace/workspace-query-runner/validation-handler/handlers/person-validation-handler';
+
+@Injectable()
+export class ValidationHandlerFactory {
+  async create(objectName: string): Promise<ValidationHandler> {
+    switch (objectName) {
+      case 'person':
+        return new PersonValidationHandler();
+      default:
+        return {
+          validate: async () => true,
+        } satisfies ValidationHandler;
+    }
+  }
+}

--- a/packages/twenty-server/src/workspace/workspace-query-runner/validation-handler/handlers/person-validation-handler.ts
+++ b/packages/twenty-server/src/workspace/workspace-query-runner/validation-handler/handlers/person-validation-handler.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common';
+
+import { ValidationHandler } from 'src/workspace/workspace-query-runner/validation-handler/interfaces/validation-handler.interface';
+import { FindManyResolverArgs } from 'src/workspace/workspace-resolver-builder/interfaces/workspace-resolvers-builder.interface';
+import {
+  RecordFilter,
+  RecordOrderBy,
+} from 'src/workspace/workspace-query-builder/interfaces/record.interface';
+
+@Injectable()
+export class PersonValidationHandler implements ValidationHandler {
+  async validate<
+    Filter extends RecordFilter = RecordFilter,
+    OrderBy extends RecordOrderBy = RecordOrderBy,
+  >(
+    args: FindManyResolverArgs<Filter, OrderBy>,
+    workspaceId: string,
+  ): Promise<boolean> {
+    console.log('validating person for workspaceId', workspaceId);
+    console.log('args', JSON.stringify(args, null, 3));
+
+    return true;
+  }
+}

--- a/packages/twenty-server/src/workspace/workspace-query-runner/validation-handler/interfaces/validation-handler.interface.ts
+++ b/packages/twenty-server/src/workspace/workspace-query-runner/validation-handler/interfaces/validation-handler.interface.ts
@@ -1,0 +1,15 @@
+import {
+  RecordFilter,
+  RecordOrderBy,
+} from 'src/workspace/workspace-query-builder/interfaces/record.interface';
+import { FindManyResolverArgs } from 'src/workspace/workspace-resolver-builder/interfaces/workspace-resolvers-builder.interface';
+
+export interface ValidationHandler<
+  Filter extends RecordFilter = RecordFilter,
+  OrderBy extends RecordOrderBy = RecordOrderBy,
+> {
+  validate(
+    args: FindManyResolverArgs<Filter, OrderBy>,
+    workspaceId: string,
+  ): Promise<boolean>;
+}

--- a/packages/twenty-server/src/workspace/workspace-query-runner/validation-handler/validation-handler.module.ts
+++ b/packages/twenty-server/src/workspace/workspace-query-runner/validation-handler/validation-handler.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+
+import { ValidationHandlerFactory } from 'src/workspace/workspace-query-runner/validation-handler/factories/validation-handler.factory';
+import { PersonValidationHandler } from 'src/workspace/workspace-query-runner/validation-handler/handlers/person-validation-handler';
+
+@Module({
+  imports: [],
+  providers: [PersonValidationHandler, ValidationHandlerFactory],
+  exports: [ValidationHandlerFactory],
+})
+export class ValidationHandlerModule {}

--- a/packages/twenty-server/src/workspace/workspace-query-runner/workspace-query-runner.module.ts
+++ b/packages/twenty-server/src/workspace/workspace-query-runner/workspace-query-runner.module.ts
@@ -2,11 +2,16 @@ import { Module } from '@nestjs/common';
 
 import { WorkspaceQueryBuilderModule } from 'src/workspace/workspace-query-builder/workspace-query-builder.module';
 import { WorkspaceDataSourceModule } from 'src/workspace/workspace-datasource/workspace-datasource.module';
+import { ValidationHandlerModule } from 'src/workspace/workspace-query-runner/validation-handler/validation-handler.module';
 
 import { WorkspaceQueryRunnerService } from './workspace-query-runner.service';
 
 @Module({
-  imports: [WorkspaceQueryBuilderModule, WorkspaceDataSourceModule],
+  imports: [
+    WorkspaceQueryBuilderModule,
+    WorkspaceDataSourceModule,
+    ValidationHandlerModule,
+  ],
   providers: [WorkspaceQueryRunnerService],
   exports: [WorkspaceQueryRunnerService],
 })


### PR DESCRIPTION
## Context
We want to execute some logic before querying the DB (and after). 
This is needed for the new messaging module we are introducing since we want to have our first "permission/visibility" feature. For example, some threads should not be accessible and some messages should return limited info, meaning if the frontend sends a filter on a particular threadId we should verify if the user has access to that specific thread. Later on we also want to process the response and filter out from info from the message.

## Test
<img width="600" alt="Screenshot 2024-02-05 at 17 36 40" src="https://github.com/twentyhq/twenty/assets/1834158/de0936b1-e8de-41d8-b273-391ec079cbaf">
