### PR TITLE
Feat/workspace health core fix

### DIFF
--- a/packages/twenty-server/src/metadata/workspace-migration/utils/generate-migration-name.util.ts
+++ b/packages/twenty-server/src/metadata/workspace-migration/utils/generate-migration-name.util.ts
@@ -1,6 +1,3 @@
-export function generateMigrationName(
-  name?: string,
-  addMilliseconds: number = 0,
-): string {
-  return `${new Date().getTime() + addMilliseconds}${name ? `-${name}` : ''}`;
+export function generateMigrationName(name?: string): string {
+  return `${new Date().getTime()}${name ? `-${name}` : ''}`;
 }

--- a/packages/twenty-server/src/workspace/workspace-health/commands/workspace-health.command.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/commands/workspace-health.command.ts
@@ -2,6 +2,7 @@ import { Command, CommandRunner, Option } from 'nest-commander';
 import chalk from 'chalk';
 
 import { WorkspaceHealthMode } from 'src/workspace/workspace-health/interfaces/workspace-health-options.interface';
+import { WorkspaceHealthFixKind } from 'src/workspace/workspace-health/interfaces/workspace-health-fix-kind.interface';
 
 import { WorkspaceHealthService } from 'src/workspace/workspace-health/workspace-health.service';
 
@@ -9,6 +10,7 @@ interface WorkspaceHealthCommandOptions {
   workspaceId: string;
   verbose?: boolean;
   mode?: WorkspaceHealthMode;
+  fix?: WorkspaceHealthFixKind;
 }
 
 @Command({
@@ -56,6 +58,19 @@ export class WorkspaceHealthCommand extends CommandRunner {
   }
 
   @Option({
+    flags: '-f, --fix [kind]',
+    description: 'fix issues',
+    required: false,
+  })
+  fix(value: string): WorkspaceHealthFixKind {
+    if (!(value in WorkspaceHealthFixKind)) {
+      throw new Error(`Invalid fix kind ${value}`);
+    }
+
+    return value as WorkspaceHealthFixKind;
+  }
+
+  @Option({
     flags: '-v, --verbose',
     description: 'Detailed output',
     required: false,
@@ -71,6 +86,10 @@ export class WorkspaceHealthCommand extends CommandRunner {
     defaultValue: WorkspaceHealthMode.All,
   })
   parseMode(value: string): WorkspaceHealthMode {
+    if (!(value in WorkspaceHealthMode)) {
+      throw new Error(`Invalid mode ${value}`);
+    }
+
     return value as WorkspaceHealthMode;
   }
 }

--- a/packages/twenty-server/src/workspace/workspace-health/commands/workspace-health.command.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/commands/workspace-health.command.ts
@@ -46,6 +46,14 @@ export class WorkspaceHealthCommand extends CommandRunner {
         console.groupEnd();
       }
     }
+
+    if (options.fix) {
+      await this.workspaceHealthService.fixIssues(
+        options.workspaceId,
+        issues,
+        options.fix,
+      );
+    }
   }
 
   @Option({
@@ -63,7 +71,7 @@ export class WorkspaceHealthCommand extends CommandRunner {
     required: false,
   })
   fix(value: string): WorkspaceHealthFixKind {
-    if (!(value in WorkspaceHealthFixKind)) {
+    if (!Object.values(WorkspaceHealthFixKind).includes(value as any)) {
       throw new Error(`Invalid fix kind ${value}`);
     }
 
@@ -86,7 +94,7 @@ export class WorkspaceHealthCommand extends CommandRunner {
     defaultValue: WorkspaceHealthMode.All,
   })
   parseMode(value: string): WorkspaceHealthMode {
-    if (!(value in WorkspaceHealthMode)) {
+    if (!Object.values(WorkspaceHealthMode).includes(value as any)) {
       throw new Error(`Invalid mode ${value}`);
     }
 

--- a/packages/twenty-server/src/workspace/workspace-health/interfaces/workspace-health-fix-kind.interface.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/interfaces/workspace-health-fix-kind.interface.ts
@@ -1,0 +1,6 @@
+export enum WorkspaceHealthFixKind {
+  Nullable = 'nullable',
+  Type = 'type',
+  DefaultValue = 'default-value',
+  TargetColumnMap = 'target-column-map',
+}

--- a/packages/twenty-server/src/workspace/workspace-health/interfaces/workspace-health-issue.interface.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/interfaces/workspace-health-issue.interface.ts
@@ -31,19 +31,31 @@ export enum WorkspaceHealthIssueType {
   RELATION_TYPE_NOT_VALID = 'RELATION_TYPE_NOT_VALID',
 }
 
-export interface WorkspaceHealthTableIssue {
-  type:
+type ConditionalType<
+  T extends WorkspaceHealthIssueType | null,
+  U,
+> = T extends WorkspaceHealthIssueType ? T : U;
+
+export interface WorkspaceHealthTableIssue<
+  T extends WorkspaceHealthIssueType | null = null,
+> {
+  type: ConditionalType<
+    T,
     | WorkspaceHealthIssueType.MISSING_TABLE
     | WorkspaceHealthIssueType.TABLE_NAME_SHOULD_BE_CUSTOM
     | WorkspaceHealthIssueType.TABLE_TARGET_TABLE_NAME_NOT_VALID
     | WorkspaceHealthIssueType.TABLE_DATA_SOURCE_ID_NOT_VALID
-    | WorkspaceHealthIssueType.TABLE_NAME_NOT_VALID;
+    | WorkspaceHealthIssueType.TABLE_NAME_NOT_VALID
+  >;
   objectMetadata: ObjectMetadataEntity;
   message: string;
 }
 
-export interface WorkspaceHealthColumnIssue {
-  type:
+export interface WorkspaceHealthColumnIssue<
+  T extends WorkspaceHealthIssueType | null = null,
+> {
+  type: ConditionalType<
+    T,
     | WorkspaceHealthIssueType.MISSING_COLUMN
     | WorkspaceHealthIssueType.MISSING_INDEX
     | WorkspaceHealthIssueType.MISSING_FOREIGN_KEY
@@ -57,19 +69,24 @@ export interface WorkspaceHealthColumnIssue {
     | WorkspaceHealthIssueType.COLUMN_NULLABILITY_CONFLICT
     | WorkspaceHealthIssueType.COLUMN_DEFAULT_VALUE_CONFLICT
     | WorkspaceHealthIssueType.COLUMN_DEFAULT_VALUE_NOT_VALID
-    | WorkspaceHealthIssueType.COLUMN_OPTIONS_NOT_VALID;
+    | WorkspaceHealthIssueType.COLUMN_OPTIONS_NOT_VALID
+  >;
   fieldMetadata: FieldMetadataEntity;
   columnStructure?: WorkspaceTableStructure;
   message: string;
 }
 
-export interface WorkspaceHealthRelationIssue {
-  type:
+export interface WorkspaceHealthRelationIssue<
+  T extends WorkspaceHealthIssueType | null = null,
+> {
+  type: ConditionalType<
+    T,
     | WorkspaceHealthIssueType.RELATION_FROM_OR_TO_FIELD_METADATA_NOT_VALID
     | WorkspaceHealthIssueType.RELATION_FOREIGN_KEY_NOT_VALID
     | WorkspaceHealthIssueType.RELATION_NULLABILITY_CONFLICT
     | WorkspaceHealthIssueType.RELATION_FOREIGN_KEY_CONFLICT
-    | WorkspaceHealthIssueType.RELATION_TYPE_NOT_VALID;
+    | WorkspaceHealthIssueType.RELATION_TYPE_NOT_VALID
+  >;
   fromFieldMetadata: FieldMetadataEntity | undefined;
   toFieldMetadata: FieldMetadataEntity | undefined;
   relationMetadata: RelationMetadataEntity;

--- a/packages/twenty-server/src/workspace/workspace-health/services/workspace-fix-nullable.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/services/workspace-fix-nullable.service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@nestjs/common';
+
+import { EntityManager } from 'typeorm';
+
+import {
+  WorkspaceHealthColumnIssue,
+  WorkspaceHealthIssueType,
+  WorkspaceHealthRelationIssue,
+} from 'src/workspace/workspace-health/interfaces/workspace-health-issue.interface';
+
+import { WorkspaceMigrationEntity } from 'src/metadata/workspace-migration/workspace-migration.entity';
+import { ObjectMetadataEntity } from 'src/metadata/object-metadata/object-metadata.entity';
+
+type WorkspaceHealthNullableIssue =
+  | WorkspaceHealthColumnIssue<WorkspaceHealthIssueType.COLUMN_NULLABILITY_CONFLICT>
+  | WorkspaceHealthRelationIssue<WorkspaceHealthIssueType.RELATION_NULLABILITY_CONFLICT>;
+
+@Injectable()
+export class WorkspaceFixNullableService {
+  constructor() {}
+
+  async fix(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    manager: EntityManager,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    objectMetadataCollection: ObjectMetadataEntity[],
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    issues: WorkspaceHealthNullableIssue[],
+  ): Promise<Partial<WorkspaceMigrationEntity>[]> {
+    // TODO: Implement nullable fix
+    return [];
+  }
+}

--- a/packages/twenty-server/src/workspace/workspace-health/services/workspace-fix.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/services/workspace-fix.service.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@nestjs/common';
+
+import { EntityManager } from 'typeorm';
+
+import { WorkspaceHealthFixKind } from 'src/workspace/workspace-health/interfaces/workspace-health-fix-kind.interface';
+import { WorkspaceHealthIssue } from 'src/workspace/workspace-health/interfaces/workspace-health-issue.interface';
+
+import { WorkspaceMigrationEntity } from 'src/metadata/workspace-migration/workspace-migration.entity';
+import { ObjectMetadataEntity } from 'src/metadata/object-metadata/object-metadata.entity';
+import { isWorkspaceHealthNullableIssue } from 'src/workspace/workspace-health/utils/is-workspace-health-issue-type.util';
+
+import { WorkspaceFixNullableService } from './workspace-fix-nullable.service';
+
+@Injectable()
+export class WorkspaceFixService {
+  constructor(
+    private readonly workspaceFixNullableService: WorkspaceFixNullableService,
+  ) {}
+
+  async fix(
+    manager: EntityManager,
+    objectMetadataCollection: ObjectMetadataEntity[],
+    type: WorkspaceHealthFixKind,
+    issues: WorkspaceHealthIssue[],
+  ): Promise<Partial<WorkspaceMigrationEntity>[]> {
+    const services = {
+      [WorkspaceHealthFixKind.Nullable]: {
+        service: this.workspaceFixNullableService,
+        issues: issues.filter((issue) =>
+          isWorkspaceHealthNullableIssue(issue.type),
+        ),
+      },
+    };
+
+    return services[type].service.fix(
+      manager,
+      objectMetadataCollection,
+      services[type].issues,
+    );
+  }
+}

--- a/packages/twenty-server/src/workspace/workspace-health/utils/is-workspace-health-issue-type.util.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/utils/is-workspace-health-issue-type.util.ts
@@ -1,0 +1,12 @@
+import { WorkspaceHealthIssueType } from 'src/workspace/workspace-health/interfaces/workspace-health-issue.interface';
+
+export const isWorkspaceHealthNullableIssue = (
+  type: WorkspaceHealthIssueType,
+): type is
+  | WorkspaceHealthIssueType.COLUMN_NULLABILITY_CONFLICT
+  | WorkspaceHealthIssueType.RELATION_NULLABILITY_CONFLICT => {
+  return type === WorkspaceHealthIssueType.COLUMN_NULLABILITY_CONFLICT ||
+    type === WorkspaceHealthIssueType.RELATION_NULLABILITY_CONFLICT
+    ? true
+    : false;
+};

--- a/packages/twenty-server/src/workspace/workspace-health/workspace-health.module.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/workspace-health.module.ts
@@ -9,6 +9,7 @@ import { FieldMetadataHealthService } from 'src/workspace/workspace-health/servi
 import { ObjectMetadataHealthService } from 'src/workspace/workspace-health/services/object-metadata-health.service';
 import { RelationMetadataHealthService } from 'src/workspace/workspace-health/services/relation-metadata.health.service';
 import { WorkspaceHealthService } from 'src/workspace/workspace-health/workspace-health.service';
+import { WorkspaceMigrationBuilderModule } from 'src/workspace/workspace-migration-builder/workspace-migration-builder.module';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { WorkspaceHealthService } from 'src/workspace/workspace-health/workspace
     TypeORMModule,
     ObjectMetadataModule,
     WorkspaceDataSourceModule,
+    WorkspaceMigrationBuilderModule,
   ],
   providers: [
     WorkspaceHealthService,

--- a/packages/twenty-server/src/workspace/workspace-health/workspace-health.module.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/workspace-health.module.ts
@@ -10,6 +10,10 @@ import { ObjectMetadataHealthService } from 'src/workspace/workspace-health/serv
 import { RelationMetadataHealthService } from 'src/workspace/workspace-health/services/relation-metadata.health.service';
 import { WorkspaceHealthService } from 'src/workspace/workspace-health/workspace-health.service';
 import { WorkspaceMigrationBuilderModule } from 'src/workspace/workspace-migration-builder/workspace-migration-builder.module';
+import { WorkspaceMigrationRunnerModule } from 'src/workspace/workspace-migration-runner/workspace-migration-runner.module';
+
+import { WorkspaceFixService } from './services/workspace-fix.service';
+import { WorkspaceFixNullableService } from './services/workspace-fix-nullable.service';
 
 @Module({
   imports: [
@@ -17,6 +21,7 @@ import { WorkspaceMigrationBuilderModule } from 'src/workspace/workspace-migrati
     TypeORMModule,
     ObjectMetadataModule,
     WorkspaceDataSourceModule,
+    WorkspaceMigrationRunnerModule,
     WorkspaceMigrationBuilderModule,
   ],
   providers: [
@@ -25,6 +30,8 @@ import { WorkspaceMigrationBuilderModule } from 'src/workspace/workspace-migrati
     ObjectMetadataHealthService,
     FieldMetadataHealthService,
     RelationMetadataHealthService,
+    WorkspaceFixNullableService,
+    WorkspaceFixService,
   ],
   exports: [WorkspaceHealthService],
 })

--- a/packages/twenty-server/src/workspace/workspace-health/workspace-health.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/workspace-health.service.ts
@@ -1,10 +1,14 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectDataSource } from '@nestjs/typeorm';
+
+import { DataSource } from 'typeorm';
 
 import { WorkspaceHealthIssue } from 'src/workspace/workspace-health/interfaces/workspace-health-issue.interface';
 import {
   WorkspaceHealthMode,
   WorkspaceHealthOptions,
 } from 'src/workspace/workspace-health/interfaces/workspace-health-options.interface';
+import { WorkspaceHealthFixKind } from 'src/workspace/workspace-health/interfaces/workspace-health-fix-kind.interface';
 
 import { TypeORMService } from 'src/database/typeorm/typeorm.service';
 import { DataSourceService } from 'src/metadata/data-source/data-source.service';
@@ -15,10 +19,14 @@ import { FieldMetadataHealthService } from 'src/workspace/workspace-health/servi
 import { RelationMetadataHealthService } from 'src/workspace/workspace-health/services/relation-metadata.health.service';
 import { DatabaseStructureService } from 'src/workspace/workspace-health/services/database-structure.service';
 import { computeObjectTargetTable } from 'src/workspace/utils/compute-object-target-table.util';
+import { WorkspaceMigrationEntity } from 'src/metadata/workspace-migration/workspace-migration.entity';
+import { WorkspaceMigrationRunnerService } from 'src/workspace/workspace-migration-runner/workspace-migration-runner.service';
 
 @Injectable()
 export class WorkspaceHealthService {
   constructor(
+    @InjectDataSource('metadata')
+    private readonly metadataDataSource: DataSource,
     private readonly dataSourceService: DataSourceService,
     private readonly typeORMService: TypeORMService,
     private readonly objectMetadataService: ObjectMetadataService,
@@ -27,6 +35,7 @@ export class WorkspaceHealthService {
     private readonly objectMetadataHealthService: ObjectMetadataHealthService,
     private readonly fieldMetadataHealthService: FieldMetadataHealthService,
     private readonly relationMetadataHealthService: RelationMetadataHealthService,
+    private readonly workspaceMigrationRunnerService: WorkspaceMigrationRunnerService,
   ) {}
 
   async healthCheck(
@@ -105,5 +114,55 @@ export class WorkspaceHealthService {
     }
 
     return issues;
+  }
+
+  async fixIssues(
+    workspaceId: string,
+    issues: WorkspaceHealthIssue[],
+    type: WorkspaceHealthFixKind,
+  ): Promise<void> {
+    const queryRunner = this.metadataDataSource.createQueryRunner();
+
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+
+    const manager = queryRunner.manager;
+
+    try {
+      const workspaceMigrationRepository = manager.getRepository(
+        WorkspaceMigrationEntity,
+      );
+      const workspaceMigrations: Partial<WorkspaceMigrationEntity>[] = [];
+      // const objectMetadataCollection =
+      //   await this.objectMetadataService.findManyWithinWorkspace(workspaceId);
+
+      switch (type) {
+        case WorkspaceHealthFixKind.Nullable:
+          /**
+           * We should create the migration to fix the nullable issues
+           * For something more readable, we should create a service for each kind of fix
+           */
+          console.log('Fixing nullable issues');
+          break;
+        default:
+          throw new Error(`Invalid fix kind ${type}`);
+      }
+
+      // Save workspace migrations into the database
+      await workspaceMigrationRepository.save(workspaceMigrations);
+
+      // Commit the transaction
+      await queryRunner.commitTransaction();
+
+      // Apply pending migrations
+      await this.workspaceMigrationRunnerService.executeMigrationFromPendingMigrations(
+        workspaceId,
+      );
+    } catch (error) {
+      await queryRunner.rollbackTransaction();
+      console.error('Fix of issues failed with:', error);
+    } finally {
+      await queryRunner.release();
+    }
   }
 }

--- a/packages/twenty-server/src/workspace/workspace-manager/workspace-manager.module.ts
+++ b/packages/twenty-server/src/workspace/workspace-manager/workspace-manager.module.ts
@@ -5,6 +5,7 @@ import { ObjectMetadataModule } from 'src/metadata/object-metadata/object-metada
 import { WorkspaceMigrationModule } from 'src/metadata/workspace-migration/workspace-migration.module';
 import { WorkspaceDataSourceModule } from 'src/workspace/workspace-datasource/workspace-datasource.module';
 import { WorkspaceSyncMetadataModule } from 'src/workspace/workspace-sync-metadata/workspace-sync-metadata.module';
+import { WorkspaceHealthModule } from 'src/workspace/workspace-health/workspace-health.module';
 
 import { WorkspaceManagerService } from './workspace-manager.service';
 
@@ -15,6 +16,7 @@ import { WorkspaceManagerService } from './workspace-manager.service';
     ObjectMetadataModule,
     DataSourceModule,
     WorkspaceSyncMetadataModule,
+    WorkspaceHealthModule,
   ],
   exports: [WorkspaceManagerService],
   providers: [WorkspaceManagerService],

--- a/packages/twenty-server/src/workspace/workspace-migration-builder/factories/index.ts
+++ b/packages/twenty-server/src/workspace/workspace-migration-builder/factories/index.ts
@@ -1,0 +1,9 @@
+import { WorkspaceMigrationObjectFactory } from './workspace-migration-object.factory';
+import { WorkspaceMigrationFieldFactory } from './workspace-migration-field.factory';
+import { WorkspaceMigrationRelationFactory } from './workspace-migration-relation.factory';
+
+export const workspaceMigrationBuilderFactories = [
+  WorkspaceMigrationObjectFactory,
+  WorkspaceMigrationFieldFactory,
+  WorkspaceMigrationRelationFactory,
+];

--- a/packages/twenty-server/src/workspace/workspace-migration-builder/factories/workspace-migration-object.factory.ts
+++ b/packages/twenty-server/src/workspace/workspace-migration-builder/factories/workspace-migration-object.factory.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
+import { WorkspaceMigrationBuilderAction } from 'src/workspace/workspace-migration-builder/interfaces/workspace-migration-builder-action.interface';
+
 import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
 import { ObjectMetadataEntity } from 'src/metadata/object-metadata/object-metadata.entity';
 import {
@@ -12,40 +14,23 @@ import { WorkspaceMigrationFactory } from 'src/metadata/workspace-migration/work
 import { generateMigrationName } from 'src/metadata/workspace-migration/utils/generate-migration-name.util';
 
 @Injectable()
-export class ObjectWorkspaceMigrationFactory {
+export class WorkspaceMigrationObjectFactory {
   constructor(
     private readonly workspaceMigrationFactory: WorkspaceMigrationFactory,
   ) {}
 
   async create(
-    createObjectMetadataCollection: ObjectMetadataEntity[],
-    deleteObjectMetadataCollection: ObjectMetadataEntity[],
+    objectMetadataCollection: ObjectMetadataEntity[],
+    action: WorkspaceMigrationBuilderAction,
   ): Promise<Partial<WorkspaceMigrationEntity>[]> {
-    const workspaceMigrations: Partial<WorkspaceMigrationEntity>[] = [];
-
-    /**
-     * Create object migrations
-     */
-    if (createObjectMetadataCollection.length > 0) {
-      const createObjectWorkspaceMigrations = await this.createObjectMigration(
-        createObjectMetadataCollection,
-      );
-
-      workspaceMigrations.push(...createObjectWorkspaceMigrations);
+    switch (action) {
+      case WorkspaceMigrationBuilderAction.CREATE:
+        return this.createObjectMigration(objectMetadataCollection);
+      case WorkspaceMigrationBuilderAction.DELETE:
+        return this.deleteObjectMigration(objectMetadataCollection);
+      default:
+        return [];
     }
-
-    /**
-     * Delete object migrations
-     */
-    if (deleteObjectMetadataCollection.length > 0) {
-      const deleteObjectWorkspaceMigrations = await this.deleteObjectMigration(
-        deleteObjectMetadataCollection,
-      );
-
-      workspaceMigrations.push(...deleteObjectWorkspaceMigrations);
-    }
-
-    return workspaceMigrations;
   }
 
   private async createObjectMigration(

--- a/packages/twenty-server/src/workspace/workspace-migration-builder/factories/workspace-migration-relation.factory.ts
+++ b/packages/twenty-server/src/workspace/workspace-migration-builder/factories/workspace-migration-relation.factory.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
+import { WorkspaceMigrationBuilderAction } from 'src/workspace/workspace-migration-builder/interfaces/workspace-migration-builder-action.interface';
+
 import { ObjectMetadataEntity } from 'src/metadata/object-metadata/object-metadata.entity';
 import {
   WorkspaceMigrationColumnActionType,
@@ -15,7 +17,7 @@ import { camelCase } from 'src/utils/camel-case';
 import { generateMigrationName } from 'src/metadata/workspace-migration/utils/generate-migration-name.util';
 
 @Injectable()
-export class RelationWorkspaceMigrationFactory {
+export class WorkspaceMigrationRelationFactory {
   constructor() {}
 
   /**
@@ -23,9 +25,9 @@ export class RelationWorkspaceMigrationFactory {
    */
   async create(
     originalObjectMetadataCollection: ObjectMetadataEntity[],
-    createRelationMetadataCollection: RelationMetadataEntity[],
+    relationMetadataCollection: RelationMetadataEntity[],
+    action: WorkspaceMigrationBuilderAction,
   ): Promise<Partial<WorkspaceMigrationEntity>[]> {
-    const workspaceMigrations: Partial<WorkspaceMigrationEntity>[] = [];
     const originalObjectMetadataMap = originalObjectMetadataCollection.reduce(
       (result, currentObject) => {
         result[currentObject.id] = currentObject;
@@ -35,17 +37,15 @@ export class RelationWorkspaceMigrationFactory {
       {} as Record<string, ObjectMetadataEntity>,
     );
 
-    if (createRelationMetadataCollection.length > 0) {
-      const createRelationWorkspaceMigrations =
-        await this.createRelationMigration(
+    switch (action) {
+      case WorkspaceMigrationBuilderAction.CREATE:
+        return this.createRelationMigration(
           originalObjectMetadataMap,
-          createRelationMetadataCollection,
+          relationMetadataCollection,
         );
-
-      workspaceMigrations.push(...createRelationWorkspaceMigrations);
+      default:
+        return [];
     }
-
-    return workspaceMigrations;
   }
 
   private async createRelationMigration(

--- a/packages/twenty-server/src/workspace/workspace-migration-builder/interfaces/workspace-migration-builder-action.interface.ts
+++ b/packages/twenty-server/src/workspace/workspace-migration-builder/interfaces/workspace-migration-builder-action.interface.ts
@@ -1,0 +1,5 @@
+export enum WorkspaceMigrationBuilderAction {
+  CREATE = 'create',
+  UPDATE = 'update',
+  DELETE = 'delete',
+}

--- a/packages/twenty-server/src/workspace/workspace-migration-builder/workspace-migration-builder.module.ts
+++ b/packages/twenty-server/src/workspace/workspace-migration-builder/workspace-migration-builder.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+
+import { WorkspaceMigrationModule } from 'src/metadata/workspace-migration/workspace-migration.module';
+
+import { workspaceMigrationBuilderFactories } from './factories';
+
+@Module({
+  imports: [WorkspaceMigrationModule],
+  providers: [...workspaceMigrationBuilderFactories],
+  exports: [...workspaceMigrationBuilderFactories],
+})
+export class WorkspaceMigrationBuilderModule {}

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/factories/index.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/factories/index.ts
@@ -1,15 +1,9 @@
 import { FeatureFlagFactory } from './feature-flags.factory';
 import { StandardObjectFactory } from './standard-object.factory';
 import { StandardRelationFactory } from './standard-relation.factory';
-import { ObjectWorkspaceMigrationFactory } from './object-workspace-migration.factory';
-import { FieldWorkspaceMigrationFactory } from './field-workspace-migration.factory';
-import { RelationWorkspaceMigrationFactory } from './relation-workspace-migration.factory';
 
 export const workspaceSyncMetadataFactories = [
   FeatureFlagFactory,
   StandardObjectFactory,
   StandardRelationFactory,
-  ObjectWorkspaceMigrationFactory,
-  FieldWorkspaceMigrationFactory,
-  RelationWorkspaceMigrationFactory,
 ];

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/services/workspace-sync-relation-metadata.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/services/workspace-sync-relation-metadata.service.ts
@@ -5,6 +5,7 @@ import { EntityManager } from 'typeorm';
 import { WorkspaceSyncContext } from 'src/workspace/workspace-sync-metadata/interfaces/workspace-sync-context.interface';
 import { FeatureFlagMap } from 'src/core/feature-flag/interfaces/feature-flag-map.interface';
 import { ComparatorAction } from 'src/workspace/workspace-sync-metadata/interfaces/comparator.interface';
+import { WorkspaceMigrationBuilderAction } from 'src/workspace/workspace-migration-builder/interfaces/workspace-migration-builder-action.interface';
 
 import { ObjectMetadataEntity } from 'src/metadata/object-metadata/object-metadata.entity';
 import { RelationMetadataEntity } from 'src/metadata/relation-metadata/relation-metadata.entity';
@@ -14,7 +15,7 @@ import { WorkspaceRelationComparator } from 'src/workspace/workspace-sync-metada
 import { WorkspaceMetadataUpdaterService } from 'src/workspace/workspace-sync-metadata/services/workspace-metadata-updater.service';
 import { WorkspaceMigrationEntity } from 'src/metadata/workspace-migration/workspace-migration.entity';
 import { WorkspaceSyncStorage } from 'src/workspace/workspace-sync-metadata/storage/workspace-sync.storage';
-import { RelationWorkspaceMigrationFactory } from 'src/workspace/workspace-sync-metadata/factories/relation-workspace-migration.factory';
+import { WorkspaceMigrationRelationFactory } from 'src/workspace/workspace-migration-builder/factories/workspace-migration-relation.factory';
 
 @Injectable()
 export class WorkspaceSyncRelationMetadataService {
@@ -26,7 +27,7 @@ export class WorkspaceSyncRelationMetadataService {
     private readonly standardRelationFactory: StandardRelationFactory,
     private readonly workspaceRelationComparator: WorkspaceRelationComparator,
     private readonly workspaceMetadataUpdaterService: WorkspaceMetadataUpdaterService,
-    private readonly relationWorkspaceMigrationFactory: RelationWorkspaceMigrationFactory,
+    private readonly workspaceMigrationRelationFactory: WorkspaceMigrationRelationFactory,
   ) {}
 
   async synchronize(
@@ -95,12 +96,13 @@ export class WorkspaceSyncRelationMetadataService {
       );
 
     // Create migrations
-    const workspaceRelationMigrations =
-      await this.relationWorkspaceMigrationFactory.create(
+    const createRelationWorkspaceMigrations =
+      await this.workspaceMigrationRelationFactory.create(
         originalObjectMetadataCollection,
         metadataRelationUpdaterResult.createdRelationMetadataCollection,
+        WorkspaceMigrationBuilderAction.CREATE,
       );
 
-    return workspaceRelationMigrations;
+    return createRelationWorkspaceMigrations;
   }
 }

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/favorite.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/favorite.object-metadata.ts
@@ -5,7 +5,7 @@ import { IsSystem } from 'src/workspace/workspace-sync-metadata/decorators/is-sy
 import { ObjectMetadata } from 'src/workspace/workspace-sync-metadata/decorators/object-metadata.decorator';
 import { BaseObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/base.object-metadata';
 import { CompanyObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/company.object-metadata';
-// import { OpportunityObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/opportunity.object-metadata';
+import { OpportunityObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/opportunity.object-metadata';
 import { PersonObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/person.object-metadata';
 import { WorkspaceMemberObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/workspace-member.object-metadata';
 
@@ -57,13 +57,13 @@ export class FavoriteObjectMetadata extends BaseObjectMetadata {
   @IsNullable()
   company: CompanyObjectMetadata;
 
-  // @FieldMetadata({
-  //   type: FieldMetadataType.RELATION,
-  //   label: 'Opportunity',
-  //   description: 'Favorite opportunity',
-  //   icon: 'IconTargetArrow',
-  //   joinColumn: 'opportunityId',
-  // })
-  // @IsNullable()
-  // opportunity: OpportunityObjectMetadata;
+  @FieldMetadata({
+    type: FieldMetadataType.RELATION,
+    label: 'Opportunity',
+    description: 'Favorite opportunity',
+    icon: 'IconTargetArrow',
+    joinColumn: 'opportunityId',
+  })
+  @IsNullable()
+  opportunity: OpportunityObjectMetadata;
 }

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/favorite.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/favorite.object-metadata.ts
@@ -5,7 +5,7 @@ import { IsSystem } from 'src/workspace/workspace-sync-metadata/decorators/is-sy
 import { ObjectMetadata } from 'src/workspace/workspace-sync-metadata/decorators/object-metadata.decorator';
 import { BaseObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/base.object-metadata';
 import { CompanyObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/company.object-metadata';
-import { OpportunityObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/opportunity.object-metadata';
+// import { OpportunityObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/opportunity.object-metadata';
 import { PersonObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/person.object-metadata';
 import { WorkspaceMemberObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/workspace-member.object-metadata';
 
@@ -57,13 +57,13 @@ export class FavoriteObjectMetadata extends BaseObjectMetadata {
   @IsNullable()
   company: CompanyObjectMetadata;
 
-  @FieldMetadata({
-    type: FieldMetadataType.RELATION,
-    label: 'Opportunity',
-    description: 'Favorite opportunity',
-    icon: 'IconTargetArrow',
-    joinColumn: 'opportunityId',
-  })
-  @IsNullable()
-  opportunity: OpportunityObjectMetadata;
+  // @FieldMetadata({
+  //   type: FieldMetadataType.RELATION,
+  //   label: 'Opportunity',
+  //   description: 'Favorite opportunity',
+  //   icon: 'IconTargetArrow',
+  //   joinColumn: 'opportunityId',
+  // })
+  // @IsNullable()
+  // opportunity: OpportunityObjectMetadata;
 }

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/opportunity.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/opportunity.object-metadata.ts
@@ -9,7 +9,7 @@ import { RelationMetadata } from 'src/workspace/workspace-sync-metadata/decorato
 import { ActivityTargetObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/activity-target.object-metadata';
 import { BaseObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/base.object-metadata';
 import { CompanyObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/company.object-metadata';
-import { FavoriteObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/favorite.object-metadata';
+// import { FavoriteObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/favorite.object-metadata';
 import { PersonObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/person.object-metadata';
 import { PipelineStepObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/pipeline-step.object-metadata';
 
@@ -118,18 +118,18 @@ export class OpportunityObjectMetadata extends BaseObjectMetadata {
   @IsNullable()
   company: CompanyObjectMetadata;
 
-  @FieldMetadata({
-    type: FieldMetadataType.RELATION,
-    label: 'Favorites',
-    description: 'Favorites linked to the opportunity',
-    icon: 'IconHeart',
-  })
-  @RelationMetadata({
-    type: RelationMetadataType.ONE_TO_MANY,
-    objectName: 'favorite',
-  })
-  @IsNullable()
-  favorites: FavoriteObjectMetadata[];
+  // @FieldMetadata({
+  //   type: FieldMetadataType.RELATION,
+  //   label: 'Favorites',
+  //   description: 'Favorites linked to the opportunity',
+  //   icon: 'IconHeart',
+  // })
+  // @RelationMetadata({
+  //   type: RelationMetadataType.ONE_TO_MANY,
+  //   objectName: 'favorite',
+  // })
+  // @IsNullable()
+  // favorites: FavoriteObjectMetadata[];
 
   @FieldMetadata({
     type: FieldMetadataType.RELATION,

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/opportunity.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/opportunity.object-metadata.ts
@@ -9,7 +9,7 @@ import { RelationMetadata } from 'src/workspace/workspace-sync-metadata/decorato
 import { ActivityTargetObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/activity-target.object-metadata';
 import { BaseObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/base.object-metadata';
 import { CompanyObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/company.object-metadata';
-// import { FavoriteObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/favorite.object-metadata';
+import { FavoriteObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/favorite.object-metadata';
 import { PersonObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/person.object-metadata';
 import { PipelineStepObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/pipeline-step.object-metadata';
 
@@ -118,18 +118,18 @@ export class OpportunityObjectMetadata extends BaseObjectMetadata {
   @IsNullable()
   company: CompanyObjectMetadata;
 
-  // @FieldMetadata({
-  //   type: FieldMetadataType.RELATION,
-  //   label: 'Favorites',
-  //   description: 'Favorites linked to the opportunity',
-  //   icon: 'IconHeart',
-  // })
-  // @RelationMetadata({
-  //   type: RelationMetadataType.ONE_TO_MANY,
-  //   objectName: 'favorite',
-  // })
-  // @IsNullable()
-  // favorites: FavoriteObjectMetadata[];
+  @FieldMetadata({
+    type: FieldMetadataType.RELATION,
+    label: 'Favorites',
+    description: 'Favorites linked to the opportunity',
+    icon: 'IconHeart',
+  })
+  @RelationMetadata({
+    type: RelationMetadataType.ONE_TO_MANY,
+    objectName: 'favorite',
+  })
+  @IsNullable()
+  favorites: FavoriteObjectMetadata[];
 
   @FieldMetadata({
     type: FieldMetadataType.RELATION,

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/workspace-sync-metadata.module.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/workspace-sync-metadata.module.ts
@@ -6,7 +6,6 @@ import { FieldMetadataEntity } from 'src/metadata/field-metadata/field-metadata.
 import { ObjectMetadataEntity } from 'src/metadata/object-metadata/object-metadata.entity';
 import { RelationMetadataEntity } from 'src/metadata/relation-metadata/relation-metadata.entity';
 import { WorkspaceMigrationEntity } from 'src/metadata/workspace-migration/workspace-migration.entity';
-import { WorkspaceMigrationModule } from 'src/metadata/workspace-migration/workspace-migration.module';
 import { WorkspaceMigrationRunnerModule } from 'src/workspace/workspace-migration-runner/workspace-migration-runner.module';
 import { WorkspaceSyncMetadataService } from 'src/workspace/workspace-sync-metadata/workspace-sync-metadata.service';
 import { workspaceSyncMetadataFactories } from 'src/workspace/workspace-sync-metadata/factories';
@@ -15,10 +14,11 @@ import { WorkspaceMetadataUpdaterService } from 'src/workspace/workspace-sync-me
 import { WorkspaceSyncObjectMetadataService } from 'src/workspace/workspace-sync-metadata/services/workspace-sync-object-metadata.service';
 import { WorkspaceSyncRelationMetadataService } from 'src/workspace/workspace-sync-metadata/services/workspace-sync-relation-metadata.service';
 import { WorkspaceLogsService } from 'src/workspace/workspace-sync-metadata/services/workspace-logs.service';
+import { WorkspaceMigrationBuilderModule } from 'src/workspace/workspace-migration-builder/workspace-migration-builder.module';
 
 @Module({
   imports: [
-    WorkspaceMigrationModule,
+    WorkspaceMigrationBuilderModule,
     WorkspaceMigrationRunnerModule,
     TypeOrmModule.forFeature(
       [


### PR DESCRIPTION
In this PR, we're adding the core of `--fix` option for `workspace:health` command, the goal was to reuse the code from sync-metadata command by creating a new module `workspace-migration-builder` that is shared between `sync-metadata` and `health` command.

Depend on #3826 (should be merged before this one)

Fix #3839 