### PR TITLE
Fix IconPicker broken storybook tests

### DIFF
--- a/packages/twenty-front/src/modules/ui/input/components/__stories__/IconPicker.stories.tsx
+++ b/packages/twenty-front/src/modules/ui/input/components/__stories__/IconPicker.stories.tsx
@@ -2,6 +2,7 @@ import { Meta, StoryObj } from '@storybook/react';
 import { expect, userEvent, within } from '@storybook/test';
 
 import { ComponentDecorator } from '~/testing/decorators/ComponentDecorator';
+import { IconsProviderDecorator } from '~/testing/decorators/IconsProviderDecorator';
 import { sleep } from '~/testing/sleep';
 
 import { IconPicker } from '../IconPicker';
@@ -9,7 +10,7 @@ import { IconPicker } from '../IconPicker';
 const meta: Meta<typeof IconPicker> = {
   title: 'UI/Input/IconPicker/IconPicker',
   component: IconPicker,
-  decorators: [ComponentDecorator],
+  decorators: [IconsProviderDecorator, ComponentDecorator],
 };
 
 export default meta;

--- a/packages/twenty-front/src/testing/decorators/IconsProviderDecorator.tsx
+++ b/packages/twenty-front/src/testing/decorators/IconsProviderDecorator.tsx
@@ -1,0 +1,11 @@
+import { Decorator } from '@storybook/react';
+
+import { IconsProvider } from '@/ui/display/icon/components/IconsProvider';
+
+export const IconsProviderDecorator: Decorator = (Story) => {
+  return (
+    <IconsProvider>
+      <Story />
+    </IconsProvider>
+  );
+};


### PR DESCRIPTION
This PR fixes the broken storybook tests on IconPicker ; we were missing IconProvider in storybook decorators