### PR TITLE
Fix bull-mq retry option and exceptions not being captured for jobs

### DIFF
--- a/packages/twenty-server/src/integrations/message-queue/drivers/bullmq.driver.ts
+++ b/packages/twenty-server/src/integrations/message-queue/drivers/bullmq.driver.ts
@@ -93,7 +93,11 @@ export class BullMQDriver implements MessageQueueDriver {
         `Queue ${queueName} is not registered, make sure you have added it as a queue provider`,
       );
     }
-    const queueOptions = { jobId: options?.id, priority: options?.priority };
+    const queueOptions = {
+      jobId: options?.id,
+      priority: options?.priority,
+      attempts: 1 + (options?.retryLimit || 0),
+    };
 
     await this.queueMap[queueName].add(jobName, data, queueOptions);
   }

--- a/packages/twenty-server/src/queue-worker.ts
+++ b/packages/twenty-server/src/queue-worker.ts
@@ -42,12 +42,7 @@ async function bootstrap() {
         try {
           await job.handle(jobData.data);
         } catch (err) {
-          if (
-            !jobData?.opts?.attempts ||
-            jobData.attemptsMade >= jobData.opts.attempts
-          ) {
-            exceptionHandlerService?.captureExceptions([err]);
-          }
+          exceptionHandlerService?.captureExceptions([err]);
           throw err;
         }
       });

--- a/packages/twenty-server/src/queue-worker.ts
+++ b/packages/twenty-server/src/queue-worker.ts
@@ -39,7 +39,17 @@ async function bootstrap() {
           .select(JobsModule)
           .get(jobClassName, { strict: true });
 
-        await job.handle(jobData.data);
+        try {
+          await job.handle(jobData.data);
+        } catch (err) {
+          if (
+            !jobData?.opts?.attempts ||
+            jobData.attemptsMade >= jobData.opts.attempts
+          ) {
+            exceptionHandlerService?.captureExceptions([err]);
+          }
+          throw err;
+        }
       });
     }
   } catch (err) {

--- a/packages/twenty-server/src/workspace/messaging/commands/gmail-full-sync.command.ts
+++ b/packages/twenty-server/src/workspace/messaging/commands/gmail-full-sync.command.ts
@@ -75,7 +75,6 @@ export class GmailFullSyncCommand extends CommandRunner {
           connectedAccountId: connectedAccount.id,
         },
         {
-          id: `${workspaceId}-${connectedAccount.id}`,
           retryLimit: 2,
         },
       );

--- a/packages/twenty-server/src/workspace/messaging/commands/gmail-partial-sync.command.ts
+++ b/packages/twenty-server/src/workspace/messaging/commands/gmail-partial-sync.command.ts
@@ -75,7 +75,6 @@ export class GmailPartialSyncCommand extends CommandRunner {
           connectedAccountId: connectedAccount.id,
         },
         {
-          id: `${workspaceId}-${connectedAccount.id}`,
           retryLimit: 2,
         },
       );

--- a/packages/twenty-server/src/workspace/messaging/listeners/messaging-person.listener.ts
+++ b/packages/twenty-server/src/workspace/messaging/listeners/messaging-person.listener.ts
@@ -37,13 +37,6 @@ export class MessagingPersonListener {
 
   @OnEvent('person.updated')
   handleUpdatedEvent(payload: ObjectRecordUpdateEvent<PersonObjectMetadata>) {
-    console.log(
-      objectRecordUpdateEventChangedProperties(
-        payload.previousRecord,
-        payload.updatedRecord,
-      ),
-    );
-
     if (
       objectRecordUpdateEventChangedProperties(
         payload.previousRecord,

--- a/packages/twenty-server/src/workspace/messaging/services/gmail-full-sync.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/services/gmail-full-sync.service.ts
@@ -109,6 +109,10 @@ export class GmailFullSyncService {
       );
 
     if (messagesToSave.length === 0) {
+      this.logger.log(
+        `gmail full-sync for workspace ${workspaceId} and account ${connectedAccountId} done with nothing to import.`,
+      );
+
       return;
     }
 


### PR DESCRIPTION
## Context
Bull-mq driver is working a bit differently than pg-boss from my testings so I'm trying to arrange that, also retry was not working properly and exceptions were not sent to sentry.

## Implementation
It seems pg-boss ignores job ids if they are processed but bull-mq does not and will not enqueue another job if the same id exists, which means they have to be unique. To avoid this issue I'm removing the id option for the few jobs that we were enqueuing and that had non unique ids (repeatable jobs with the same generated id) and let the driver generate the id for us.
Also, I'm adding the retry option to bull-mq since it was missing and not used. Failed jobs should now retry based on the retryLimit value similarly to pg-boss.

Finally, I'm adding a try catch inside the work method to capture exceptions when jobs fail and send it to our exception driver (sentry). This is because the work method has its own exception handler that swallows exceptions and stores the error inside the job which is not always easily accessible (for redis for example, even more true if we decide to shard this part in the future). For bull-mq, the exception is only thrown if the number of retries specified in the job option has been reached, this will avoid jobs that retry from spamming Sentry or the console. For pg-boss, however, I couldn't do the same because the jobData in the callback function of the work method does not contain the current retry count.