### PR TITLE
feat: health check enum

### DIFF
--- a/packages/twenty-server/src/metadata/field-metadata/utils/is-enum-field-metadata-type.util.ts
+++ b/packages/twenty-server/src/metadata/field-metadata/utils/is-enum-field-metadata-type.util.ts
@@ -1,11 +1,13 @@
 import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
 
-export const isEnumFieldMetadataType = (
-  type: FieldMetadataType,
-): type is
+export type EnumFieldMetadataUnionType =
   | FieldMetadataType.RATING
   | FieldMetadataType.SELECT
-  | FieldMetadataType.MULTI_SELECT => {
+  | FieldMetadataType.MULTI_SELECT;
+
+export const isEnumFieldMetadataType = (
+  type: FieldMetadataType,
+): type is EnumFieldMetadataUnionType => {
   return (
     type === FieldMetadataType.RATING ||
     type === FieldMetadataType.SELECT ||

--- a/packages/twenty-server/src/workspace/workspace-health/services/database-structure.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/services/database-structure.service.ts
@@ -10,7 +10,10 @@ import {
 import { FieldMetadataDefaultValue } from 'src/metadata/field-metadata/interfaces/field-metadata-default-value.interface';
 
 import { TypeORMService } from 'src/database/typeorm/typeorm.service';
-import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
+import {
+  FieldMetadataEntity,
+  FieldMetadataType,
+} from 'src/metadata/field-metadata/field-metadata.entity';
 import { fieldMetadataTypeToColumnType } from 'src/metadata/workspace-migration/utils/field-metadata-type-to-column-type.util';
 import { serializeTypeDefaultValue } from 'src/metadata/field-metadata/utils/serialize-type-default-value.util';
 
@@ -122,17 +125,17 @@ export class DatabaseStructureService {
     }));
   }
 
-  getPostgresDataType(
-    fieldMetadataType: FieldMetadataType,
-    fieldMetadataName: string,
-    objectMetadataNameSingular: string,
-  ): string {
-    const typeORMType = fieldMetadataTypeToColumnType(fieldMetadataType);
+  getPostgresDataType(fieldMetadata: FieldMetadataEntity): string {
+    const typeORMType = fieldMetadataTypeToColumnType(fieldMetadata.type);
     const mainDataSource = this.typeORMService.getMainDataSource();
 
-    // TODO: remove special case for enum type, should we include this to fieldMetadataTypeToColumnType?
+    // Compute enum name to compare data type properly
     if (typeORMType === 'enum') {
-      return `${objectMetadataNameSingular}_${fieldMetadataName}_enum`;
+      const objectName = fieldMetadata.object?.nameSingular;
+      const prefix = fieldMetadata.isCustom ? '_' : '';
+      const fieldName = fieldMetadata.name;
+
+      return `${objectName}_${prefix}${fieldName}_enum`;
     }
 
     return mainDataSource.driver.normalizeType({

--- a/packages/twenty-server/src/workspace/workspace-health/services/field-metadata-health.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/services/field-metadata-health.service.ts
@@ -146,7 +146,7 @@ export class FieldMetadataHealthService {
       return issues;
     }
 
-    const columnDefault = columnStructure.columnDefault?.split('::')?.[0];
+    const columnDefaultValue = columnStructure.columnDefault?.split('::')?.[0];
 
     // Check if column data type is the same
     if (columnStructure.dataType !== dataType) {
@@ -169,28 +169,36 @@ export class FieldMetadataHealthService {
       });
     }
 
-    if (defaultValue && columnDefault) {
-      if (isEnumFieldMetadataType(fieldMetadata.type)) {
-        const enumValues = fieldMetadata.options?.map((option) =>
-          serializeDefaultValue(option.value),
-        );
+    if (
+      defaultValue &&
+      columnDefaultValue &&
+      isEnumFieldMetadataType(fieldMetadata.type)
+    ) {
+      const enumValues = fieldMetadata.options?.map((option) =>
+        serializeDefaultValue(option.value),
+      );
 
-        if (!enumValues.includes(columnDefault)) {
-          issues.push({
-            type: WorkspaceHealthIssueType.COLUMN_DEFAULT_VALUE_NOT_VALID,
-            fieldMetadata,
-            columnStructure,
-            message: `Column ${columnName} default value is not in the enum values "${columnDefault}" NOT IN "${enumValues}"`,
-          });
-        }
-      } else if (columnDefault !== defaultValue) {
+      if (!enumValues.includes(columnDefaultValue)) {
         issues.push({
-          type: WorkspaceHealthIssueType.COLUMN_DEFAULT_VALUE_CONFLICT,
+          type: WorkspaceHealthIssueType.COLUMN_DEFAULT_VALUE_NOT_VALID,
           fieldMetadata,
           columnStructure,
-          message: `Column ${columnName} default value is not the same as the field metadata default value "${columnStructure.columnDefault}" !== "${defaultValue}"`,
+          message: `Column ${columnName} default value is not in the enum values "${columnDefaultValue}" NOT IN "${enumValues}"`,
         });
       }
+    }
+
+    if (
+      defaultValue &&
+      columnDefaultValue &&
+      columnDefaultValue !== defaultValue
+    ) {
+      issues.push({
+        type: WorkspaceHealthIssueType.COLUMN_DEFAULT_VALUE_CONFLICT,
+        fieldMetadata,
+        columnStructure,
+        message: `Column ${columnName} default value is not the same as the field metadata default value "${columnStructure.columnDefault}" !== "${defaultValue}"`,
+      });
     }
 
     return issues;
@@ -334,15 +342,15 @@ export class FieldMetadataHealthService {
       fieldMetadata.defaultValue
     ) {
       const enumValues = fieldMetadata.options?.map((option) => option.value);
-      const defaultValue = (
+      const metadataDefaultValue = (
         fieldMetadata.defaultValue as FieldMetadataDefaultValue<EnumFieldMetadataUnionType>
       )?.value;
 
-      if (defaultValue && !enumValues.includes(defaultValue)) {
+      if (metadataDefaultValue && !enumValues.includes(metadataDefaultValue)) {
         issues.push({
           type: WorkspaceHealthIssueType.COLUMN_DEFAULT_VALUE_NOT_VALID,
           fieldMetadata,
-          message: `Column default value is not in the enum values "${defaultValue}" NOT IN "${enumValues}"`,
+          message: `Column default value is not in the enum values "${metadataDefaultValue}" NOT IN "${enumValues}"`,
         });
       }
     }


### PR DESCRIPTION
This PR is adding some health check on enum types, the goal is to verify that `defaultValue` is matching with one of the provided options.
