### PR TITLE
fix: set a specifc date to date field input on the story 

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/__stories__/DateFieldInput.stories.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/__stories__/DateFieldInput.stories.tsx
@@ -94,7 +94,14 @@ export default meta;
 
 type Story = StoryObj<typeof DateFieldInputWithContext>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const div = await canvas.findByText('Feb 1, 2022');
+
+    await expect(div.innerText).toContain('Feb 1, 2022');
+  },
+};
 
 export const ClickOutside: Story = {
   play: async ({ canvasElement }) => {

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/__stories__/DateFieldInput.stories.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/__stories__/DateFieldInput.stories.tsx
@@ -8,7 +8,7 @@ import { FieldContextProvider } from '../../../__stories__/FieldContextProvider'
 import { useDateTimeField } from '../../../hooks/useDateTimeField';
 import { DateFieldInput, DateFieldInputProps } from '../DateFieldInput';
 
-const formattedDate = new Date();
+const formattedDate = new Date(2022, 1, 1);
 
 const DateFieldValueSetterEffect = ({ value }: { value: Date }) => {
   const { setFieldValue } = useDateTimeField();

--- a/packages/twenty-front/src/modules/object-record/record-store/states/selectors/recordStoreFamilySelector.ts
+++ b/packages/twenty-front/src/modules/object-record/record-store/states/selectors/recordStoreFamilySelector.ts
@@ -1,6 +1,7 @@
 import { selectorFamily } from 'recoil';
 
 import { recordStoreFamilyState } from '@/object-record/record-store/states/recordStoreFamilyState';
+import { ObjectRecord } from '@/object-record/types/ObjectRecord';
 
 export const recordStoreFamilySelector = selectorFamily({
   key: 'recordStoreFamilySelector',
@@ -12,6 +13,8 @@ export const recordStoreFamilySelector = selectorFamily({
     <T>({ fieldName, recordId }: { fieldName: string; recordId: string }) =>
     ({ set }, newValue: T) =>
       set(recordStoreFamilyState(recordId), (prevState) =>
-        prevState ? { ...prevState, [fieldName]: newValue } : null,
+        prevState
+          ? { ...prevState, [fieldName]: newValue }
+          : ({ [fieldName]: newValue } as ObjectRecord),
       ),
 });


### PR DESCRIPTION
Closes #3797 

I am not so sure about my change on `recordStoreFamilySelector` but I had to set the initial state otherwise `fieldValue` would always be `undefined` and therefore `value: formattedDate` passed to the component is never considered. 

I am happy for any suggestions that would improve the solution.

EDIT: The value is being set some milliseconds after it renders but it will initially set `new Date()` because the `internalValue` on `DateInput` component is getting undefined on the initial render. Unsure if this can cause an issue with the visual testing on Chromatic.