### PR TITLE
[messaging] Fix import message participant uppercase

### DIFF
--- a/packages/twenty-server/src/workspace/messaging/services/fetch-messages-by-batches.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/services/fetch-messages-by-batches.service.ts
@@ -268,7 +268,7 @@ export class FetchMessagesByBatchesService {
 
         return {
           role,
-          handle: address || '',
+          handle: address?.toLowerCase() || '',
           displayName: name || '',
         };
       });


### PR DESCRIPTION
## Context
Participants are sometimes imported like this: John@gmail.com, JOHN@GMAIL.COM. To keep things uniform and handle more easily matching, we are now converting the handle we receive from the API to lowercase