### PR TITLE
[messaging] Remove ids from enqueued jobs

### DIFF
--- a/packages/twenty-server/src/workspace/messaging/crons/fetch-all-workspaces-messages.job.ts
+++ b/packages/twenty-server/src/workspace/messaging/crons/fetch-all-workspaces-messages.job.ts
@@ -57,7 +57,6 @@ export class FetchAllWorkspacesMessagesJob
           connectedAccountId: connectedAccount.id,
         },
         {
-          id: `${workspaceId}-${connectedAccount.id}`,
           retryLimit: 2,
         },
       );

--- a/packages/twenty-server/src/workspace/messaging/services/fetch-messages-by-batches.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/services/fetch-messages-by-batches.service.ts
@@ -268,7 +268,7 @@ export class FetchMessagesByBatchesService {
 
         return {
           role,
-          handle: address || '',
+          handle: address?.toLowerCase() || '',
           displayName: name || '',
         };
       });

--- a/packages/twenty-server/src/workspace/messaging/services/gmail-full-sync.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/services/gmail-full-sync.service.ts
@@ -160,7 +160,6 @@ export class GmailFullSyncService {
           nextPageToken: messages.data.nextPageToken,
         },
         {
-          id: `${workspaceId}-${connectedAccountId}`,
           retryLimit: 2,
         },
       );

--- a/packages/twenty-server/src/workspace/messaging/services/gmail-partial-sync.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/services/gmail-partial-sync.service.ts
@@ -228,7 +228,6 @@ export class GmailPartialSyncService {
       GmailFullSyncJob.name,
       { workspaceId, connectedAccountId },
       {
-        id: `${workspaceId}-${connectedAccountId}`,
         retryLimit: 2,
       },
     );


### PR DESCRIPTION
## Context
bullmq use those ids as unique identifiers to not enqueue the same job twice. However in this case we were not using unique values so I'm fixing that by removing them. Bull-mq will handle this part and generate ids for us.