### PR TITLE
feat: sync metadata can alter and update a field

### DIFF
--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/comparators/workspace-field.comparator.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/comparators/workspace-field.comparator.ts
@@ -55,7 +55,7 @@ export class WorkspaceFieldComparator {
     const standardFieldMetadataMap = transformMetadataForComparison(
       standardObjectMetadata.fields,
       {
-        propertiesToIgnore: fieldPropertiesToStringify,
+        propertiesToStringify: fieldPropertiesToStringify,
         keyFactory(datum) {
           return datum.name;
         },

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/services/workspace-sync-object-metadata.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/services/workspace-sync-object-metadata.service.ts
@@ -160,6 +160,13 @@ export class WorkspaceSyncObjectMetadataService {
         WorkspaceMigrationBuilderAction.CREATE,
       );
 
+    const updateFieldWorkspaceMigrations =
+      await this.workspaceMigrationFieldFactory.create(
+        originalObjectMetadataCollection,
+        metadataFieldUpdaterResult.updatedFieldMetadataCollection,
+        WorkspaceMigrationBuilderAction.UPDATE,
+      );
+
     const deleteFieldWorkspaceMigrations =
       await this.workspaceMigrationFieldFactory.create(
         originalObjectMetadataCollection,
@@ -173,6 +180,7 @@ export class WorkspaceSyncObjectMetadataService {
       ...createObjectWorkspaceMigrations,
       ...deleteObjectWorkspaceMigrations,
       ...createFieldWorkspaceMigrations,
+      ...updateFieldWorkspaceMigrations,
       ...deleteFieldWorkspaceMigrations,
     ];
   }

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/storage/workspace-sync.storage.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/storage/workspace-sync.storage.ts
@@ -15,8 +15,9 @@ export class WorkspaceSyncStorage {
 
   // Field metadata
   private readonly _fieldMetadataCreateCollection: PartialFieldMetadata[] = [];
-  private readonly _fieldMetadataUpdateCollection: Partial<PartialFieldMetadata>[] =
-    [];
+  private readonly _fieldMetadataUpdateCollection: Partial<
+    PartialFieldMetadata & { id: string }
+  >[] = [];
   private readonly _fieldMetadataDeleteCollection: FieldMetadataEntity[] = [];
 
   // Relation metadata


### PR DESCRIPTION
This PR si fixing a missing part in `workspace:sync-metadata` command, updating a field was not implemented.
It also fix an issue that was ignoring some field metadata before comparing them.