### PR TITLE
[messaging] Removing TO requirement for email import

### DIFF
--- a/packages/twenty-server/src/workspace/messaging/services/fetch-messages-by-batches.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/services/fetch-messages-by-batches.service.ts
@@ -189,7 +189,6 @@ export class FetchMessagesByBatchesService {
           } = parsed;
 
           if (!from) throw new Error('From value is missing');
-          if (!to) throw new Error('To value is missing');
 
           const participants = [
             ...this.formatAddressObjectAsParticipants(from, 'from'),


### PR DESCRIPTION
Fixes #3946

## Context
It seems TO is not a requirement and we had some cases where "TO" was missing but "CC" was not. I'm removing this constraint since it's not affecting the import nor the UI. 