### PR TITLE
Fix missing feature flag on messaging listeners

### DIFF
--- a/packages/twenty-server/src/workspace/messaging/listeners/messaging-workspace-member.listener.ts
+++ b/packages/twenty-server/src/workspace/messaging/listeners/messaging-workspace-member.listener.ts
@@ -1,6 +1,13 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { OnEvent } from '@nestjs/event-emitter';
+import { InjectRepository } from '@nestjs/typeorm';
 
+import { Repository } from 'typeorm';
+
+import {
+  FeatureFlagEntity,
+  FeatureFlagKeys,
+} from 'src/core/feature-flag/feature-flag.entity';
 import { ObjectRecordCreateEvent } from 'src/integrations/event-emitter/types/object-record-create.event';
 import { ObjectRecordUpdateEvent } from 'src/integrations/event-emitter/types/object-record-update.event';
 import { objectRecordChangedProperties as objectRecordUpdateEventChangedProperties } from 'src/integrations/event-emitter/utils/object-record-changed-properties.util';
@@ -17,13 +24,25 @@ export class MessagingWorkspaceMemberListener {
   constructor(
     @Inject(MessageQueue.messagingQueue)
     private readonly messageQueueService: MessageQueueService,
+    @InjectRepository(FeatureFlagEntity, 'core')
+    private readonly featureFlagRepository: Repository<FeatureFlagEntity>,
   ) {}
 
   @OnEvent('workspaceMember.created')
-  handleCreatedEvent(
+  async handleCreatedEvent(
     payload: ObjectRecordCreateEvent<WorkspaceMemberObjectMetadata>,
   ) {
     if (payload.createdRecord.userEmail === null) {
+      return;
+    }
+
+    const messagingFeatureFlag = await this.featureFlagRepository.findOneBy({
+      key: FeatureFlagKeys.IsMessagingEnabled,
+      value: true,
+      workspaceId: payload.workspaceId,
+    });
+
+    if (!messagingFeatureFlag || !messagingFeatureFlag.value) {
       return;
     }
 
@@ -38,14 +57,24 @@ export class MessagingWorkspaceMemberListener {
   }
 
   @OnEvent('workspaceMember.updated')
-  handleUpdatedEvent(
+  async handleUpdatedEvent(
     payload: ObjectRecordUpdateEvent<WorkspaceMemberObjectMetadata>,
   ) {
+    const messagingFeatureFlag = await this.featureFlagRepository.findOneBy({
+      key: FeatureFlagKeys.IsMessagingEnabled,
+      value: true,
+      workspaceId: payload.workspaceId,
+    });
+
+    const isMessagingEnabled =
+      messagingFeatureFlag && messagingFeatureFlag.value;
+
     if (
       objectRecordUpdateEventChangedProperties(
         payload.previousRecord,
         payload.updatedRecord,
-      ).includes('userEmail')
+      ).includes('userEmail') &&
+      isMessagingEnabled
     ) {
       this.messageQueueService.add<MatchMessageParticipantsJobData>(
         MatchMessageParticipantJob.name,

--- a/packages/twenty-server/src/workspace/messaging/messaging.module.ts
+++ b/packages/twenty-server/src/workspace/messaging/messaging.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { ConnectedAccountModule } from 'src/workspace/messaging/repositories/connected-account/connected-account.module';
 import { MessageChannelMessageAssociationModule } from 'src/workspace/messaging/repositories/message-channel-message-association/message-channel-message-assocation.module';
@@ -20,6 +21,7 @@ import { MessagingWorkspaceMemberListener } from 'src/workspace/messaging/listen
 import { MessagingMessageChannelListener } from 'src/workspace/messaging/listeners/messaging-message-channel.listener';
 import { MessageService } from 'src/workspace/messaging/repositories/message/message.service';
 import { WorkspaceMemberModule } from 'src/workspace/messaging/repositories/workspace-member/workspace-member.module';
+import { FeatureFlagEntity } from 'src/core/feature-flag/feature-flag.entity';
 @Module({
   imports: [
     EnvironmentModule,
@@ -31,6 +33,7 @@ import { WorkspaceMemberModule } from 'src/workspace/messaging/repositories/work
     MessageThreadModule,
     MessageParticipantModule,
     WorkspaceMemberModule,
+    TypeOrmModule.forFeature([FeatureFlagEntity], 'core'),
   ],
   providers: [
     GmailFullSyncService,

--- a/packages/twenty-server/src/workspace/workspace-query-runner/workspace-query-runner.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-query-runner/workspace-query-runner.service.ts
@@ -311,6 +311,9 @@ export class WorkspaceQueryRunnerService {
   private removeNestedProperties<Record extends IRecord = IRecord>(
     record: Record,
   ) {
+    if (!record) {
+      return record;
+    }
     const sanitizedRecord = {};
 
     for (const [key, value] of Object.entries(record)) {

--- a/packages/twenty-server/src/workspace/workspace-query-runner/workspace-query-runner.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-query-runner/workspace-query-runner.service.ts
@@ -312,7 +312,7 @@ export class WorkspaceQueryRunnerService {
     record: Record,
   ) {
     if (!record) {
-      return record;
+      return;
     }
     const sanitizedRecord = {};
 


### PR DESCRIPTION
## Context
Messaging listeners add logic to other objects which means, in our case, updating a person or a workspace member was triggering logic within the messaging module which should only be enabled for workspaces having the IS_MESSAGING_ENABLED featureFlag.
