### PR TITLE
[Enter] key autosave for new API key and webhook

### DIFF
--- a/packages/twenty-front/src/pages/settings/developers/api-keys/SettingsDevelopersApiKeysNew.tsx
+++ b/packages/twenty-front/src/pages/settings/developers/api-keys/SettingsDevelopersApiKeysNew.tsx
@@ -84,7 +84,9 @@ export const SettingsDevelopersApiKeysNew = () => {
             placeholder="E.g. backoffice integration"
             value={formValues.name}
             onKeyDown={(e) => {
-              if (e.key === 'Enter'){handleSave();}
+              if (e.key === 'Enter'){
+                handleSave();
+              }
             }}
             onChange={(value) => {
               setFormValues((prevState) => ({

--- a/packages/twenty-front/src/pages/settings/developers/api-keys/SettingsDevelopersApiKeysNew.tsx
+++ b/packages/twenty-front/src/pages/settings/developers/api-keys/SettingsDevelopersApiKeysNew.tsx
@@ -84,8 +84,7 @@ export const SettingsDevelopersApiKeysNew = () => {
             placeholder="E.g. backoffice integration"
             value={formValues.name}
             onKeyDown={(e) => {
-              if (e.key === 'Enter')
-                  handleSave();
+              if (e.key === 'Enter'){handleSave();}
             }}
             onChange={(value) => {
               setFormValues((prevState) => ({

--- a/packages/twenty-front/src/pages/settings/developers/api-keys/SettingsDevelopersApiKeysNew.tsx
+++ b/packages/twenty-front/src/pages/settings/developers/api-keys/SettingsDevelopersApiKeysNew.tsx
@@ -84,7 +84,7 @@ export const SettingsDevelopersApiKeysNew = () => {
             placeholder="E.g. backoffice integration"
             value={formValues.name}
             onKeyDown={(e) => {
-              if (e.key === 'Enter'){
+              if (e.key === 'Enter') {
                 handleSave();
               }
             }}

--- a/packages/twenty-front/src/pages/settings/developers/api-keys/SettingsDevelopersApiKeysNew.tsx
+++ b/packages/twenty-front/src/pages/settings/developers/api-keys/SettingsDevelopersApiKeysNew.tsx
@@ -83,6 +83,10 @@ export const SettingsDevelopersApiKeysNew = () => {
           <TextInput
             placeholder="E.g. backoffice integration"
             value={formValues.name}
+            onKeyDown={(e) => {
+              if (e.key === "Enter")
+                  handleSave();
+            }}
             onChange={(value) => {
               setFormValues((prevState) => ({
                 ...prevState,

--- a/packages/twenty-front/src/pages/settings/developers/api-keys/SettingsDevelopersApiKeysNew.tsx
+++ b/packages/twenty-front/src/pages/settings/developers/api-keys/SettingsDevelopersApiKeysNew.tsx
@@ -84,7 +84,7 @@ export const SettingsDevelopersApiKeysNew = () => {
             placeholder="E.g. backoffice integration"
             value={formValues.name}
             onKeyDown={(e) => {
-              if (e.key === "Enter")
+              if (e.key === 'Enter')
                   handleSave();
             }}
             onChange={(value) => {

--- a/packages/twenty-front/src/pages/settings/developers/webhooks/SettingsDevelopersWebhooksNew.tsx
+++ b/packages/twenty-front/src/pages/settings/developers/webhooks/SettingsDevelopersWebhooksNew.tsx
@@ -60,6 +60,10 @@ export const SettingsDevelopersWebhooksNew = () => {
           <TextInput
             placeholder="URL"
             value={formValues.targetUrl}
+            onKeyDown={(e) => {
+              if (e.key === "Enter")
+                  handleSave();
+            }}
             onChange={(value) => {
               setFormValues((prevState) => ({
                 ...prevState,

--- a/packages/twenty-front/src/pages/settings/developers/webhooks/SettingsDevelopersWebhooksNew.tsx
+++ b/packages/twenty-front/src/pages/settings/developers/webhooks/SettingsDevelopersWebhooksNew.tsx
@@ -61,7 +61,7 @@ export const SettingsDevelopersWebhooksNew = () => {
             placeholder="URL"
             value={formValues.targetUrl}
             onKeyDown={(e) => {
-              if (e.key === 'Enter'){
+              if (e.key === 'Enter') {
                 handleSave();
               }
             }}

--- a/packages/twenty-front/src/pages/settings/developers/webhooks/SettingsDevelopersWebhooksNew.tsx
+++ b/packages/twenty-front/src/pages/settings/developers/webhooks/SettingsDevelopersWebhooksNew.tsx
@@ -61,8 +61,7 @@ export const SettingsDevelopersWebhooksNew = () => {
             placeholder="URL"
             value={formValues.targetUrl}
             onKeyDown={(e) => {
-              if (e.key === 'Enter')
-                  handleSave();
+              if (e.key === 'Enter'){handleSave();}
             }}
             onChange={(value) => {
               setFormValues((prevState) => ({

--- a/packages/twenty-front/src/pages/settings/developers/webhooks/SettingsDevelopersWebhooksNew.tsx
+++ b/packages/twenty-front/src/pages/settings/developers/webhooks/SettingsDevelopersWebhooksNew.tsx
@@ -61,7 +61,9 @@ export const SettingsDevelopersWebhooksNew = () => {
             placeholder="URL"
             value={formValues.targetUrl}
             onKeyDown={(e) => {
-              if (e.key === 'Enter'){handleSave();}
+              if (e.key === 'Enter'){
+                handleSave();
+              }
             }}
             onChange={(value) => {
               setFormValues((prevState) => ({

--- a/packages/twenty-front/src/pages/settings/developers/webhooks/SettingsDevelopersWebhooksNew.tsx
+++ b/packages/twenty-front/src/pages/settings/developers/webhooks/SettingsDevelopersWebhooksNew.tsx
@@ -61,7 +61,7 @@ export const SettingsDevelopersWebhooksNew = () => {
             placeholder="URL"
             value={formValues.targetUrl}
             onKeyDown={(e) => {
-              if (e.key === "Enter")
+              if (e.key === 'Enter')
                   handleSave();
             }}
             onChange={(value) => {


### PR DESCRIPTION
Added functionality for onKeyDown for new webhook and new API key, to save when the user presses the [Enter] key


Fixes #3928
