### PR TITLE
Webhook Docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@sentry/react": "^7.88.0",
     "@sentry/tracing": "^7.99.0",
     "@sniptt/guards": "^0.2.0",
-    "@stoplight/elements": "^7.16.2",
+    "@stoplight/elements": "^8.0.5",
     "@swc/jest": "^0.2.29",
     "@tabler/icons-react": "^2.44.0",
     "@types/lodash.camelcase": "^4.3.7",

--- a/packages/twenty-server/src/core/open-api/utils/base-schema.utils.ts
+++ b/packages/twenty-server/src/core/open-api/utils/base-schema.utils.ts
@@ -1,8 +1,8 @@
-import { OpenAPIV3 } from 'openapi-types';
+import { OpenAPIV3_1 } from 'openapi-types';
 
 import { computeOpenApiPath } from 'src/core/open-api/utils/path.utils';
 
-export const baseSchema = (): OpenAPIV3.Document => {
+export const baseSchema = (): OpenAPIV3_1.Document => {
   return {
     openapi: '3.0.3',
     info: {

--- a/packages/twenty-server/src/core/open-api/utils/components.utils.ts
+++ b/packages/twenty-server/src/core/open-api/utils/components.utils.ts
@@ -1,4 +1,4 @@
-import { OpenAPIV3 } from 'openapi-types';
+import { OpenAPIV3_1 } from 'openapi-types';
 
 import { ObjectMetadataEntity } from 'src/metadata/object-metadata/object-metadata.entity';
 import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
@@ -12,7 +12,7 @@ import {
   computeOrderByParameters,
 } from 'src/core/open-api/utils/parameters.utils';
 
-type Property = OpenAPIV3.SchemaObject;
+type Property = OpenAPIV3_1.SchemaObject;
 
 type Properties = {
   [name: string]: Property;
@@ -95,12 +95,12 @@ const getRequiredFields = (item: ObjectMetadataEntity): string[] => {
 
 const computeSchemaComponent = (
   item: ObjectMetadataEntity,
-): OpenAPIV3.SchemaObject => {
+): OpenAPIV3_1.SchemaObject => {
   const result = {
     type: 'object',
     properties: getSchemaComponentsProperties(item),
     example: {},
-  } as OpenAPIV3.SchemaObject;
+  } as OpenAPIV3_1.SchemaObject;
 
   const requiredFields = getRequiredFields(item);
 
@@ -121,20 +121,20 @@ const computeSchemaComponent = (
 
 export const computeSchemaComponents = (
   objectMetadataItems: ObjectMetadataEntity[],
-): Record<string, OpenAPIV3.SchemaObject> => {
+): Record<string, OpenAPIV3_1.SchemaObject> => {
   return objectMetadataItems.reduce(
     (schemas, item) => {
       schemas[capitalize(item.nameSingular)] = computeSchemaComponent(item);
 
       return schemas;
     },
-    {} as Record<string, OpenAPIV3.SchemaObject>,
+    {} as Record<string, OpenAPIV3_1.SchemaObject>,
   );
 };
 
 export const computeParameterComponents = (): Record<
   string,
-  OpenAPIV3.ParameterObject
+  OpenAPIV3_1.ParameterObject
 > => {
   return {
     idPath: computeIdPathParameter(),

--- a/packages/twenty-server/src/core/open-api/utils/compute-schema-tags.utils.ts
+++ b/packages/twenty-server/src/core/open-api/utils/compute-schema-tags.utils.ts
@@ -1,11 +1,11 @@
-import { OpenAPIV3 } from 'openapi-types';
+import { OpenAPIV3_1 } from 'openapi-types';
 
 import { ObjectMetadataEntity } from 'src/metadata/object-metadata/object-metadata.entity';
 import { capitalize } from 'src/utils/capitalize';
 
 export const computeSchemaTags = (
   items: ObjectMetadataEntity[],
-): OpenAPIV3.TagObject[] => {
+): OpenAPIV3_1.TagObject[] => {
   const results = [{ name: 'General', description: 'General requests' }];
 
   items.forEach((item) => {

--- a/packages/twenty-server/src/core/open-api/utils/computeWebhooks.utils.ts
+++ b/packages/twenty-server/src/core/open-api/utils/computeWebhooks.utils.ts
@@ -12,7 +12,7 @@ export const computeWebhooks = (
       tags: [item.nameSingular],
       security: [],
       requestBody: {
-        description: `*${type}*.**${item.nameSingular}**, *&#42;*.**${item.nameSingular}**`,
+        description: `*${type}*.**${item.nameSingular}**, *&#42;*.**${item.nameSingular}**, *&#42;*.**&#42;**`,
         content: {
           'application/json': {
             schema: {

--- a/packages/twenty-server/src/core/open-api/utils/computeWebhooks.utils.ts
+++ b/packages/twenty-server/src/core/open-api/utils/computeWebhooks.utils.ts
@@ -1,0 +1,74 @@
+import { OpenAPIV3_1 } from 'openapi-types';
+
+import { ObjectMetadataEntity } from 'src/metadata/object-metadata/object-metadata.entity';
+import { capitalize } from 'src/utils/capitalize';
+
+export const computeWebhooks = (
+  type: 'create' | 'update' | 'delete',
+  item: ObjectMetadataEntity,
+): OpenAPIV3_1.PathItemObject => {
+  return {
+    post: {
+      tags: [item.nameSingular],
+      security: [],
+      requestBody: {
+        description: `*${type}*.**${item.nameSingular}**, *&#42;*.**${item.nameSingular}**`,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                targetUrl: {
+                  type: 'string',
+                  example: 'https://example.com/incomingWebhook',
+                },
+                eventType: {
+                  type: 'string',
+                  enum: [
+                    '*.*',
+                    '*.' + item.nameSingular,
+                    type + '.' + item.nameSingular,
+                  ],
+                },
+                objectMetadata: {
+                  type: 'object',
+                  properties: {
+                    id: {
+                      type: 'string',
+                      example: '370985db-22d8-4463-8e5f-2271d30913bd',
+                    },
+                    nameSingular: {
+                      type: 'string',
+                      enum: [item.nameSingular],
+                    },
+                  },
+                },
+                workspaceId: {
+                  type: 'string',
+                  example: '872cfcf1-c79f-42bc-877d-5829f06eb3f9',
+                },
+                webhookId: {
+                  type: 'string',
+                  example: '90056586-1228-4e03-a507-70140aa85c05',
+                },
+                eventDate: {
+                  type: 'string',
+                  example: '2024-02-14T11:27:01.779Z',
+                },
+                record: {
+                  $ref: `#/components/schemas/${capitalize(item.nameSingular)}`,
+                },
+              },
+            },
+          },
+        },
+      },
+      responses: {
+        '200': {
+          description:
+            'Return a 200 status to indicate that the data was received successfully',
+        },
+      },
+    },
+  } as OpenAPIV3_1.PathItemObject;
+};

--- a/packages/twenty-server/src/core/open-api/utils/get-error-responses.utils.ts
+++ b/packages/twenty-server/src/core/open-api/utils/get-error-responses.utils.ts
@@ -1,8 +1,8 @@
-import { OpenAPIV3 } from 'openapi-types';
+import { OpenAPIV3_1 } from 'openapi-types';
 
 export const getErrorResponses = (
   description: string,
-): OpenAPIV3.ResponseObject => {
+): OpenAPIV3_1.ResponseObject => {
   return {
     description,
     content: {

--- a/packages/twenty-server/src/core/open-api/utils/parameters.utils.ts
+++ b/packages/twenty-server/src/core/open-api/utils/parameters.utils.ts
@@ -1,4 +1,4 @@
-import { OpenAPIV3 } from 'openapi-types';
+import { OpenAPIV3_1 } from 'openapi-types';
 
 import { OrderByDirection } from 'src/workspace/workspace-query-builder/interfaces/record.interface';
 
@@ -7,7 +7,7 @@ import { Conjunctions } from 'src/core/api-rest/api-rest-query-builder/factories
 import { DEFAULT_ORDER_DIRECTION } from 'src/core/api-rest/api-rest-query-builder/factories/input-factories/order-by-input.factory';
 import { DEFAULT_CONJUNCTION } from 'src/core/api-rest/api-rest-query-builder/factories/input-factories/filter-utils/add-default-conjunction.utils';
 
-export const computeLimitParameters = (): OpenAPIV3.ParameterObject => {
+export const computeLimitParameters = (): OpenAPIV3_1.ParameterObject => {
   return {
     name: 'limit',
     in: 'query',
@@ -22,7 +22,7 @@ export const computeLimitParameters = (): OpenAPIV3.ParameterObject => {
   };
 };
 
-export const computeOrderByParameters = (): OpenAPIV3.ParameterObject => {
+export const computeOrderByParameters = (): OpenAPIV3_1.ParameterObject => {
   return {
     name: 'order_by',
     in: 'query',
@@ -49,7 +49,7 @@ export const computeOrderByParameters = (): OpenAPIV3.ParameterObject => {
   };
 };
 
-export const computeDepthParameters = (): OpenAPIV3.ParameterObject => {
+export const computeDepthParameters = (): OpenAPIV3_1.ParameterObject => {
   return {
     name: 'depth',
     in: 'query',
@@ -62,7 +62,7 @@ export const computeDepthParameters = (): OpenAPIV3.ParameterObject => {
   };
 };
 
-export const computeFilterParameters = (): OpenAPIV3.ParameterObject => {
+export const computeFilterParameters = (): OpenAPIV3_1.ParameterObject => {
   return {
     name: 'filter',
     in: 'query',
@@ -95,7 +95,7 @@ export const computeFilterParameters = (): OpenAPIV3.ParameterObject => {
   };
 };
 
-export const computeLastCursorParameters = (): OpenAPIV3.ParameterObject => {
+export const computeLastCursorParameters = (): OpenAPIV3_1.ParameterObject => {
   return {
     name: 'last_cursor',
     in: 'query',
@@ -107,7 +107,7 @@ export const computeLastCursorParameters = (): OpenAPIV3.ParameterObject => {
   };
 };
 
-export const computeIdPathParameter = (): OpenAPIV3.ParameterObject => {
+export const computeIdPathParameter = (): OpenAPIV3_1.ParameterObject => {
   return {
     name: 'id',
     in: 'path',

--- a/packages/twenty-server/src/core/open-api/utils/path.utils.ts
+++ b/packages/twenty-server/src/core/open-api/utils/path.utils.ts
@@ -1,4 +1,4 @@
-import { OpenAPIV3 } from 'openapi-types';
+import { OpenAPIV3_1 } from 'openapi-types';
 
 import { capitalize } from 'src/utils/capitalize';
 import { ObjectMetadataEntity } from 'src/metadata/object-metadata/object-metadata.entity';
@@ -12,7 +12,7 @@ import { getRequestBody } from 'src/core/open-api/utils/request-body.utils';
 
 export const computeManyResultPath = (
   item: ObjectMetadataEntity,
-): OpenAPIV3.PathItemObject => {
+): OpenAPIV3_1.PathItemObject => {
   return {
     get: {
       tags: [item.namePlural],
@@ -44,12 +44,12 @@ export const computeManyResultPath = (
         '401': { $ref: '#/components/responses/401' },
       },
     },
-  } as OpenAPIV3.PathItemObject;
+  } as OpenAPIV3_1.PathItemObject;
 };
 
 export const computeSingleResultPath = (
   item: ObjectMetadataEntity,
-): OpenAPIV3.PathItemObject => {
+): OpenAPIV3_1.PathItemObject => {
   return {
     get: {
       tags: [item.namePlural],
@@ -92,10 +92,10 @@ export const computeSingleResultPath = (
         '401': { $ref: '#/components/responses/401' },
       },
     },
-  } as OpenAPIV3.PathItemObject;
+  } as OpenAPIV3_1.PathItemObject;
 };
 
-export const computeOpenApiPath = (): OpenAPIV3.PathItemObject => {
+export const computeOpenApiPath = (): OpenAPIV3_1.PathItemObject => {
   return {
     get: {
       tags: ['General'],
@@ -105,5 +105,5 @@ export const computeOpenApiPath = (): OpenAPIV3.PathItemObject => {
         '200': getJsonResponse(),
       },
     },
-  } as OpenAPIV3.PathItemObject;
+  } as OpenAPIV3_1.PathItemObject;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -12034,29 +12034,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stoplight/elements-core@npm:~7.16.3":
-  version: 7.16.3
-  resolution: "@stoplight/elements-core@npm:7.16.3"
+"@stoplight/elements-core@npm:~8.0.5":
+  version: 8.0.5
+  resolution: "@stoplight/elements-core@npm:8.0.5"
   dependencies:
-    "@stoplight/http-spec": "npm:^6.0.0"
+    "@stoplight/http-spec": "npm:^7.0.2"
     "@stoplight/json": "npm:^3.18.1"
     "@stoplight/json-schema-ref-parser": "npm:^9.0.5"
     "@stoplight/json-schema-sampler": "npm:0.2.3"
-    "@stoplight/json-schema-tree": "npm:^3.0.0"
-    "@stoplight/json-schema-viewer": "npm:^4.14.1"
+    "@stoplight/json-schema-tree": "npm:^4.0.0"
+    "@stoplight/json-schema-viewer": "npm:^4.14.2"
     "@stoplight/markdown-viewer": "npm:^5.6.0"
-    "@stoplight/mosaic": "npm:^1.46.1"
-    "@stoplight/mosaic-code-editor": "npm:^1.46.1"
-    "@stoplight/mosaic-code-viewer": "npm:^1.46.1"
+    "@stoplight/mosaic": "npm:^1.51.3"
+    "@stoplight/mosaic-code-editor": "npm:^1.51.3"
+    "@stoplight/mosaic-code-viewer": "npm:^1.51.3"
     "@stoplight/path": "npm:^1.3.2"
     "@stoplight/react-error-boundary": "npm:^3.0.0"
-    "@stoplight/types": "npm:^14.0.0"
+    "@stoplight/types": "npm:^14.1.1"
     "@stoplight/yaml": "npm:^4.2.3"
     classnames: "npm:^2.2.6"
     httpsnippet-lite: "npm:^3.0.5"
     jotai: "npm:1.3.9"
     json-schema: "npm:^0.4.0"
-    lodash: "npm:^4.17.19"
+    lodash: "npm:^4.17.21"
     nanoid: "npm:^3.1.32"
     prop-types: "npm:^15.7.2"
     react-query: "npm:^3.34.19"
@@ -12069,51 +12069,49 @@ __metadata:
   peerDependencies:
     react: ">=16.8"
     react-dom: ">=16.8"
-  checksum: 7dac752aa91c9efe2338df26f3a62b3498707756798054d1289472df7837a7428076c3d95e4942f5f2d65d8a8fab3067486c97fb6764b8bf3d03a9ac0bfba4a9
+  checksum: 0dd56fd70b95c497ef17e51f57cb31d632dbeee88241e9884fcb50badabc2bba257058b69ebef5b4b4ca099441b36d565d4bd4f36bc313c24fc250cd45278cb5
   languageName: node
   linkType: hard
 
-"@stoplight/elements@npm:^7.16.2":
-  version: 7.16.3
-  resolution: "@stoplight/elements@npm:7.16.3"
+"@stoplight/elements@npm:^8.0.5":
+  version: 8.0.5
+  resolution: "@stoplight/elements@npm:8.0.5"
   dependencies:
-    "@stoplight/elements-core": "npm:~7.16.3"
-    "@stoplight/http-spec": "npm:^6.0.0"
+    "@stoplight/elements-core": "npm:~8.0.5"
+    "@stoplight/http-spec": "npm:^7.0.2"
     "@stoplight/json": "npm:^3.18.1"
-    "@stoplight/mosaic": "npm:^1.46.1"
-    "@stoplight/types": "npm:^14.0.0"
+    "@stoplight/mosaic": "npm:^1.51.3"
+    "@stoplight/types": "npm:^14.1.1"
     "@stoplight/yaml": "npm:^4.2.3"
     classnames: "npm:^2.2.6"
     file-saver: "npm:^2.0.5"
-    lodash: "npm:^4.17.19"
+    lodash: "npm:^4.17.21"
     react-query: "npm:^3.34.19"
     react-router-dom: "npm:^5.2.0"
   peerDependencies:
     react: ">=16.8"
     react-dom: ">=16.8"
-  checksum: bbc90b219a9b36509ead591d65f5fda842ce1de0217a7ef5f3b0cda22e3e8e28b5f7de80b5d6c9681bec3a17dc7d973e8415093625c6769a06d52774a706ae14
+  checksum: 4e3466ffcce215f33df15dbc33be681f69f18f460171395f7444cf1975c1cf6c9cd9878ff53571677ab48b59ac671c41ca0d073239bb84268bf2877ab4dfa79f
   languageName: node
   linkType: hard
 
-"@stoplight/http-spec@npm:^6.0.0":
-  version: 6.0.3
-  resolution: "@stoplight/http-spec@npm:6.0.3"
+"@stoplight/http-spec@npm:^7.0.2":
+  version: 7.0.2
+  resolution: "@stoplight/http-spec@npm:7.0.2"
   dependencies:
     "@stoplight/json": "npm:^3.18.1"
     "@stoplight/json-schema-generator": "npm:1.0.2"
-    "@stoplight/types": "npm:14.0.0"
+    "@stoplight/types": "npm:14.1.0"
     "@types/json-schema": "npm:7.0.11"
     "@types/swagger-schema-official": "npm:~2.0.22"
     "@types/type-is": "npm:^1.6.3"
     fnv-plus: "npm:^1.3.1"
-    lodash.isequalwith: "npm:^4.4.0"
-    lodash.pick: "npm:^4.4.0"
-    lodash.pickby: "npm:^4.6.0"
+    lodash: "npm:^4.17.21"
     openapi3-ts: "npm:^2.0.2"
     postman-collection: "npm:^4.1.2"
     tslib: "npm:^2.6.2"
     type-is: "npm:^1.6.18"
-  checksum: c00121bd0c3322d78bb9c5aee2259ce05c4e2a7bd32fb5e09c14a173ac0d0c05d7bb62a23a81998dd645d8383a120e906efa8822bc5f78a110ac5ba02123c827
+  checksum: 79a9d810a03ee5da02a3c05f12fdc551af8c1c29d453fa0be92070c8fa4c156fd430aeb28ddfea01f03e9397fb901e6e27b8c70f95572ddae0e0b7a11b2cd407
   languageName: node
   linkType: hard
 
@@ -12168,25 +12166,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stoplight/json-schema-tree@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@stoplight/json-schema-tree@npm:3.0.0"
+"@stoplight/json-schema-tree@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@stoplight/json-schema-tree@npm:4.0.0"
   dependencies:
     "@stoplight/json": "npm:^3.12.0"
     "@stoplight/json-schema-merge-allof": "npm:^0.8.0"
     "@stoplight/lifecycle": "npm:^2.3.2"
     "@types/json-schema": "npm:^7.0.7"
     magic-error: "npm:0.0.1"
-  checksum: fa07eefe61bbcabe12f29324dfa59def4b9565b40fb786953091c9c6dce584bf510c935d38560b926d30a8f5b3e1467329be9d0a224971dfd997e55f1c5e1f0a
+  checksum: 4e75ccadb60b097965cec0152c680f59aad3bf3a95e51480e5dc70c5cb10ed6ee07f81798ece5dd0fde9e4d616e501f8a6d546d8de5f2774f700dc704de991d0
   languageName: node
   linkType: hard
 
-"@stoplight/json-schema-viewer@npm:^4.14.1":
-  version: 4.14.1
-  resolution: "@stoplight/json-schema-viewer@npm:4.14.1"
+"@stoplight/json-schema-viewer@npm:^4.14.2":
+  version: 4.15.1
+  resolution: "@stoplight/json-schema-viewer@npm:4.15.1"
   dependencies:
     "@stoplight/json": "npm:^3.20.1"
-    "@stoplight/json-schema-tree": "npm:^3.0.0"
+    "@stoplight/json-schema-tree": "npm:^4.0.0"
     "@stoplight/react-error-boundary": "npm:^2.0.0"
     "@types/json-schema": "npm:^7.0.7"
     classnames: "npm:^2.2.6"
@@ -12199,7 +12197,7 @@ __metadata:
     "@stoplight/mosaic-code-viewer": ^1.32
     react: ">=16.8"
     react-dom: ">=16.8"
-  checksum: 2a9ff42861420467324bcd6176905da8cfca1fd5be22aa3a6c152b0c1d7ae2cbacebf462c65e288d482f97f189bf5ef8ae842aa42df422d5ae133e48c6cb9875
+  checksum: bc76248d3df3d7acf3b1040c25d0a9dfecdd8f030252d950465679528e23e328d7f0658fb2c8348d61c52665642bccb57854c2c4a10ab5a40d0f475d6ef8afee
   languageName: node
   linkType: hard
 
@@ -12276,9 +12274,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stoplight/mosaic-code-editor@npm:^1.46.1":
-  version: 1.48.4
-  resolution: "@stoplight/mosaic-code-editor@npm:1.48.4"
+"@stoplight/mosaic-code-editor@npm:^1.51.3":
+  version: 1.51.3
+  resolution: "@stoplight/mosaic-code-editor@npm:1.51.3"
   dependencies:
     "@fortawesome/fontawesome-svg-core": "npm:^6.1.1"
     "@fortawesome/react-fontawesome": "npm:^0.2.0"
@@ -12287,8 +12285,8 @@ __metadata:
     "@react-types/radio": "npm:3.1.2"
     "@react-types/shared": "npm:3.9.0"
     "@react-types/switch": "npm:3.1.2"
-    "@stoplight/mosaic": "npm:1.48.4"
-    "@stoplight/mosaic-code-viewer": "npm:1.48.4"
+    "@stoplight/mosaic": "npm:1.51.3"
+    "@stoplight/mosaic-code-viewer": "npm:1.51.3"
     "@stoplight/types": "npm:^13.7.0"
     clsx: "npm:^1.1.1"
     copy-to-clipboard: "npm:^3.3.1"
@@ -12307,13 +12305,13 @@ __metadata:
     zustand: "npm:^3.5.2"
   peerDependencies:
     react: ">= 16.14"
-  checksum: 0f37cec67de896932b096d3608e419943c4177e28607e8fa845c695847525990029fb0f2b1ad6abb066c9983787d81f7d3e8cade1d0f6eff373078201e12e7e4
+  checksum: 0d1cd4a048bcb4d6332523704bc0b1ba46b98dc8e444e76233a2c3c63c1047aa2e64b12a5d89367996db67d53796b317af0948e825765ed2a6cfc5c1e62602a0
   languageName: node
   linkType: hard
 
-"@stoplight/mosaic-code-viewer@npm:1.48.4, @stoplight/mosaic-code-viewer@npm:^1.46.1":
-  version: 1.48.4
-  resolution: "@stoplight/mosaic-code-viewer@npm:1.48.4"
+"@stoplight/mosaic-code-viewer@npm:1.51.3, @stoplight/mosaic-code-viewer@npm:^1.51.3":
+  version: 1.51.3
+  resolution: "@stoplight/mosaic-code-viewer@npm:1.51.3"
   dependencies:
     "@fortawesome/fontawesome-svg-core": "npm:^6.1.1"
     "@fortawesome/react-fontawesome": "npm:^0.2.0"
@@ -12322,7 +12320,7 @@ __metadata:
     "@react-types/radio": "npm:3.1.2"
     "@react-types/shared": "npm:3.9.0"
     "@react-types/switch": "npm:3.1.2"
-    "@stoplight/mosaic": "npm:1.48.4"
+    "@stoplight/mosaic": "npm:1.51.3"
     "@stoplight/types": "npm:^13.7.0"
     clsx: "npm:^1.1.1"
     copy-to-clipboard: "npm:^3.3.1"
@@ -12341,13 +12339,13 @@ __metadata:
     zustand: "npm:^3.5.2"
   peerDependencies:
     react: ">= 16.14"
-  checksum: 2247ec4e08e19edc86931c41071ba840c5df3f289acd4c45854d3666ff4d1ce06836b8506e64f2022fe237b3bf1d73bb9536860d299e83d930426c65faae0e82
+  checksum: a65594884cd50f748436fddf71fb2faa5323156f2f68fd824961db7210fea6a9e3d15d527773babce3b350c1f17321d173d91ec8be0306ef7a0849738022a07f
   languageName: node
   linkType: hard
 
-"@stoplight/mosaic@npm:1.48.4, @stoplight/mosaic@npm:^1.46.1":
-  version: 1.48.4
-  resolution: "@stoplight/mosaic@npm:1.48.4"
+"@stoplight/mosaic@npm:1.51.3, @stoplight/mosaic@npm:^1.51.3":
+  version: 1.51.3
+  resolution: "@stoplight/mosaic@npm:1.51.3"
   dependencies:
     "@fortawesome/fontawesome-svg-core": "npm:^6.1.1"
     "@fortawesome/react-fontawesome": "npm:^0.2.0"
@@ -12376,7 +12374,7 @@ __metadata:
     zustand: "npm:^3.5.2"
   peerDependencies:
     react: ">= 16.14"
-  checksum: 031a02edd6f16d0e05792d29fbef08a86574b93e753d4c02d8c4787f40ee31082599164c33c6d7f456f322a9e1c38c87bd854150977c01a17dc45a86416707c5
+  checksum: b6549ba18187aed374ff0ee3acbd5defa8b22fc04595a472b047026662ae5da899ec9c2b3d67190565a1c039bcddb63dfbb27335fb340355e56ce744fa3098b2
   languageName: node
   linkType: hard
 
@@ -12415,13 +12413,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stoplight/types@npm:14.0.0":
-  version: 14.0.0
-  resolution: "@stoplight/types@npm:14.0.0"
+"@stoplight/types@npm:14.1.0":
+  version: 14.1.0
+  resolution: "@stoplight/types@npm:14.1.0"
   dependencies:
     "@types/json-schema": "npm:^7.0.4"
     utility-types: "npm:^3.10.0"
-  checksum: 81a57ec9362258642f659a6a3818958e83db671d687aeba89fb9ba401b5e6d7f04a1d988c5b47a3b055cf2d5f1474ad04719086528a1f71e7ed8d8c394f64a72
+  checksum: 6b822270d7d59e5d73eb8edf185dd69ffeb681ac4a8af5b15c646b70a440df6c52c9af051fcf8244468d219928f0c62c5dbb77f4ce05ed5b22c99495b7275715
   languageName: node
   linkType: hard
 
@@ -12445,13 +12443,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stoplight/types@npm:^14.0.0":
-  version: 14.1.0
-  resolution: "@stoplight/types@npm:14.1.0"
+"@stoplight/types@npm:^14.1.1":
+  version: 14.1.1
+  resolution: "@stoplight/types@npm:14.1.1"
   dependencies:
     "@types/json-schema": "npm:^7.0.4"
     utility-types: "npm:^3.10.0"
-  checksum: 6b822270d7d59e5d73eb8edf185dd69ffeb681ac4a8af5b15c646b70a440df6c52c9af051fcf8244468d219928f0c62c5dbb77f4ce05ed5b22c99495b7275715
+  checksum: 1573d842fee99a7f1eea1f2b17c28dcbfb1be51b72f2ef794e07d265b2fb8900654b5848f608952cd1e3dedf6c7ec157c82c65d4d95728d6309f4b1722a11450
   languageName: node
   linkType: hard
 
@@ -31317,13 +31315,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash.isequalwith@npm:^4.4.0":
-  version: 4.4.0
-  resolution: "lodash.isequalwith@npm:4.4.0"
-  checksum: edb7f01c6d949fad36c756e7b1af6ee1df8b9663cee62880186a3b241e133a981bc7eed42cf14715a58f939d6d779185c3ead0c3f0d617d1ad59f50b423eb5d5
-  languageName: node
-  linkType: hard
-
 "lodash.isinteger@npm:^4.0.4":
   version: 4.0.4
   resolution: "lodash.isinteger@npm:4.0.4"
@@ -31433,13 +31424,6 @@ __metadata:
   version: 4.4.0
   resolution: "lodash.pick@npm:4.4.0"
   checksum: a04c460b95d1aaa44e9513d1dacf72ea74d838da843e45831de9de64c303f13cdde1859702a6f4dcef417816898ffd47c6ae0614c957ac70245bed2809b8d2e2
-  languageName: node
-  linkType: hard
-
-"lodash.pickby@npm:^4.6.0":
-  version: 4.6.0
-  resolution: "lodash.pickby@npm:4.6.0"
-  checksum: 46befadb64ab0f61159977174b291f87b005cec1c7bd73d1b6949ec4cdff483c1be0e34398df8955b76ce06a3e93a4a5c5a552a4299520390d6993c5420c7ab9
   languageName: node
   linkType: hard
 
@@ -43481,7 +43465,7 @@ __metadata:
     "@sentry/react": "npm:^7.88.0"
     "@sentry/tracing": "npm:^7.99.0"
     "@sniptt/guards": "npm:^0.2.0"
-    "@stoplight/elements": "npm:^7.16.2"
+    "@stoplight/elements": "npm:^8.0.5"
     "@storybook/addon-actions": "npm:^7.6.3"
     "@storybook/addon-coverage": "npm:^1.0.0"
     "@storybook/addon-essentials": "npm:^7.6.7"


### PR DESCRIPTION
closes #3771

Im not really happy with the size as every one of these webhooks has quite a large json object - but I don't think this can be solved via a schema as the record is different each time?

<img width="1460" alt="Bildschirmfoto 2024-02-14 um 14 34 18" src="https://github.com/twentyhq/twenty/assets/48770548/69952dfe-fdc2-489c-ba64-73da49fe656a">
<img width="1470" alt="Bildschirmfoto 2024-02-14 um 14 34 26" src="https://github.com/twentyhq/twenty/assets/48770548/59177a2d-5c5e-4e8e-8e0d-3154b7709689">
<img width="1464" alt="Bildschirmfoto 2024-02-14 um 14 34 33" src="https://github.com/twentyhq/twenty/assets/48770548/a899039c-308b-4a3a-a9ef-aaab61112388">
