### PR TITLE
3970-label fix

### DIFF
--- a/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/NavigationDrawerSectionTitle.tsx
+++ b/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/NavigationDrawerSectionTitle.tsx
@@ -11,7 +11,6 @@ const StyledTitle = styled.div`
   font-weight: ${({ theme }) => theme.font.weight.semiBold};
   padding: ${({ theme }) => theme.spacing(1)};
   padding-top: 0;
-  text-transform: uppercase;
 `;
 
 export const NavigationDrawerSectionTitle = ({


### PR DESCRIPTION
Closes #3970 

<img width="1440" alt="Screenshot 2024-02-14 at 8 12 19 PM" src="https://github.com/twentyhq/twenty/assets/62852363/695333c4-fd12-47ec-8a65-62e0dac5fbe7">
