### PR TITLE
[messaging] fix add messageParticipant not in a transaction

### DIFF
--- a/packages/twenty-server/src/core/auth/services/google-gmail.service.ts
+++ b/packages/twenty-server/src/core/auth/services/google-gmail.service.ts
@@ -67,8 +67,8 @@ export class GoogleGmailService {
       );
 
       await manager.query(
-        `INSERT INTO ${dataSourceMetadata.schema}."messageChannel" ("visibility", "handle", "connectedAccountId", "type", "isContactAutoCreationEnabled") VALUES ($1, $2, $3, $4, $5)`,
-        ['share_everything', handle, connectedAccountId, 'email', true],
+        `INSERT INTO ${dataSourceMetadata.schema}."messageChannel" ("visibility", "handle", "connectedAccountId", "type") VALUES ($1, $2, $3, $4)`,
+        ['share_everything', handle, connectedAccountId, 'email'],
       );
     });
 

--- a/packages/twenty-server/src/workspace/messaging/repositories/message/message.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/repositories/message/message.service.ts
@@ -215,6 +215,7 @@ export class MessageService {
       message.participants,
       newMessageId,
       workspaceId,
+      manager,
     );
 
     return Promise.resolve(newMessageId);


### PR DESCRIPTION
## Context
- isContactAutoCreationEnabled has been recently added however some workspaces don't have this new column, we need to handle that differently. This PR reverts that change so we can still create new contact even without the boolean.
Other places shouldn't fail and return null (false) instead.
- Added a missing instance of transactionManager in the saveParticipants method, because of this, participants were saved before the messages so it was generating an error in DB with FK constraint
<img width="650" alt="Screenshot 2024-02-14 at 19 22 52" src="https://github.com/twentyhq/twenty/assets/1834158/0aa3d6c3-de63-486b-98ed-79760df7bcee">


## Test
tested full import locally