### PR TITLE
Fixed label transform issues

### DIFF
--- a/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/NavigationDrawerSectionTitle.tsx
+++ b/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/NavigationDrawerSectionTitle.tsx
@@ -11,7 +11,6 @@ const StyledTitle = styled.div`
   font-weight: ${({ theme }) => theme.font.weight.semiBold};
   padding: ${({ theme }) => theme.spacing(1)};
   padding-top: 0;
-  text-transform: uppercase;
 `;
 
 export const NavigationDrawerSectionTitle = ({


### PR DESCRIPTION
Fixes #3970

This pull request addresses an issue where the label in the NavigationDrawerSectionTitle component was transformed into uppercase text. Upon reviewing the code, I found that the text-transform: uppercase; CSS rule was applied in the NavigationDrawerSectionTitle.tsx file, located at packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/NavigationDrawerSectionTitle.tsx.

To resolve this issue, I removed the text-transform: uppercase; line from the CSS, thereby ensuring that the label text is displayed as intended without being automatically converted to uppercase.

![Screenshot from 2024-02-15 12-49-01](https://github.com/twentyhq/twenty/assets/109085921/a5ae988f-3015-4fb1-9d73-ac37f86c126d)


This fix improves the readability and consistency of the component, aligning it with expected behavior and ensuring a more user-friendly experience.

Thank you for considering this pull request.