### PR TITLE
[messaging] add defaultValue to isContactAutoCreationEnabled

### DIFF
--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/message-channel.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/message-channel.object-metadata.ts
@@ -76,6 +76,7 @@ export class MessageChannelObjectMetadata extends BaseObjectMetadata {
     label: 'Is Contact Auto Creation Enabled',
     description: 'Is Contact Auto Creation Enabled',
     icon: 'IconUserCircle',
+    defaultValue: { value: true },
   })
   isContactAutoCreationEnabled: boolean;
 


### PR DESCRIPTION
## Context
New column was added as non-nullable without default value, we need to address this for workspaces having existing rows.
In practice, it shouldn't have any effect since the table is not used for workspaces that don't have the messaging flag