### PR TITLE
fix: invalidate cache when no record inside workspace cache version

### DIFF
--- a/packages/twenty-server/src/metadata/workspace-cache-version/workspace-cache-version.service.ts
+++ b/packages/twenty-server/src/metadata/workspace-cache-version/workspace-cache-version.service.ts
@@ -12,11 +12,12 @@ export class WorkspaceCacheVersionService {
     private readonly workspaceCacheVersionRepository: Repository<WorkspaceCacheVersionEntity>,
   ) {}
 
-  async incrementVersion(workspaceId: string): Promise<void> {
+  async incrementVersion(workspaceId: string): Promise<string> {
     const workspaceCacheVersion =
       (await this.workspaceCacheVersionRepository.findOne({
         where: { workspaceId },
       })) ?? { version: '0' };
+    const newVersion = `${+workspaceCacheVersion.version + 1}`;
 
     await this.workspaceCacheVersionRepository.upsert(
       {
@@ -25,14 +26,16 @@ export class WorkspaceCacheVersionService {
       },
       ['workspaceId'],
     );
+
+    return newVersion;
   }
 
-  async getVersion(workspaceId: string): Promise<string> {
+  async getVersion(workspaceId: string): Promise<string | null> {
     const workspaceCacheVersion =
       await this.workspaceCacheVersionRepository.findOne({
         where: { workspaceId },
       });
 
-    return workspaceCacheVersion?.version ?? '0';
+    return workspaceCacheVersion?.version ?? null;
   }
 }

--- a/packages/twenty-server/src/metadata/workspace-cache-version/workspace-cache-version.service.ts
+++ b/packages/twenty-server/src/metadata/workspace-cache-version/workspace-cache-version.service.ts
@@ -13,10 +13,9 @@ export class WorkspaceCacheVersionService {
   ) {}
 
   async incrementVersion(workspaceId: string): Promise<string> {
-    const workspaceCacheVersion =
-      (await this.workspaceCacheVersionRepository.findOne({
-        where: { workspaceId },
-      })) ?? { version: '0' };
+    const workspaceCacheVersion = (await this.getVersion(workspaceId)) ?? {
+      version: '0',
+    };
     const newVersion = `${+workspaceCacheVersion.version + 1}`;
 
     await this.workspaceCacheVersionRepository.upsert(

--- a/packages/twenty-server/src/workspace/workspace-schema-storage/workspace-schema-storage.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-schema-storage/workspace-schema-storage.service.ts
@@ -28,12 +28,16 @@ export class WorkspaceSchemaStorageService {
       (await this.cacheVersionMemoryStorageService.read({
         key: workspaceId,
       })) ?? '0';
-    const latestVersion =
+    let latestVersion =
       await this.workspaceCacheVersionService.getVersion(workspaceId);
 
-    if (currentVersion !== latestVersion) {
+    if (!latestVersion || currentVersion !== latestVersion) {
       // Invalidate cache if version mismatch is detected
       await this.invalidateCache(workspaceId);
+
+      // If the latest version is not found, increment the version
+      latestVersion ??=
+        await this.workspaceCacheVersionService.incrementVersion(workspaceId);
 
       // Update the cache version after invalidation
       await this.cacheVersionMemoryStorageService.write({


### PR DESCRIPTION
This PR is fixing an issue when we delete the `workspaceCacheVersion` record of a given workspace and fetching it again, the cache was not invalidated (should only happen when version is '0').
Now every time we remove the record from `workspaceCacheVersion` the cache is invalidated and a new record is created.

Fix #2958 
