### PR TITLE
Fix update on delete record

### DIFF
--- a/packages/twenty-server/src/workspace/workspace-query-runner/workspace-query-runner.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-query-runner/workspace-query-runner.service.ts
@@ -364,6 +364,10 @@ export class WorkspaceQueryRunnerService {
     const result = graphqlResult?.[0]?.resolve?.data?.[entityKey];
     const errors = graphqlResult?.[0]?.resolve?.errors;
 
+    if (['update', 'deleteFrom'].includes(command) && !result.affectedCount) {
+      throw new BadRequestException('No rows were affected.');
+    }
+
     if (errors && errors.length > 0) {
       const error = computePgGraphQLError(
         command,


### PR DESCRIPTION
## Context
Fixes https://github.com/twentyhq/twenty/issues/3805

When trying to update a deleted record in the DB, pg_graphql will return 0 in affectedCount.
<img width="285" alt="Screenshot 2024-02-15 at 18 40 53" src="https://github.com/twentyhq/twenty/assets/1834158/27ea947b-84bf-4b35-be1d-c3497be8b3fe">
Then fails when trying to resolve the type because it's null.

This PR introduces a fix, however error handling has been improved in @magrinj PR here https://github.com/twentyhq/twenty/pull/3993 so I might wait for this PR

There is a current bug in the FE where this scenario happens, here is now a clearer message and does not generate a 500.
<img width="1286" alt="Screenshot 2024-02-15 at 18 56 54" src="https://github.com/twentyhq/twenty/assets/1834158/9e547c61-0278-412f-a8f3-5186f7d5eb62">

