### PR TITLE
feat: filter people in CommandMenu via last name, email and phone

### DIFF
--- a/packages/twenty-front/src/modules/command-menu/components/CommandMenu.tsx
+++ b/packages/twenty-front/src/modules/command-menu/components/CommandMenu.tsx
@@ -139,7 +139,9 @@ export const CommandMenu = () => {
     filter: search
       ? makeOrFilterVariables([
           { name: { firstName: { ilike: `%${search}%` } } },
-          { name: { firstName: { ilike: `%${search}%` } } },
+          { name: { lastName: { ilike: `%${search}%` } } },
+          { email: { ilike: `%${search}%` } },
+          { phone: { ilike: `%${search}%` } },
         ])
       : undefined,
     limit: 3,


### PR DESCRIPTION
closes https://github.com/twentyhq/twenty/issues/3878

- fixed what i think was a bug (double search via `firstName`)
- added search via `lastName`, `email` and also `phone` (these props made sense to me to include)

let me know what you think :) looking forward to take on something more difficult if necessary