### PR TITLE
fix: added working `launch.json` for VSCode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,10 +15,6 @@
       "outputCapture": "std",
       "internalConsoleOptions": "openOnSessionStart",
       "console": "internalConsole",
-      "env": {
-        "TS_NODE_IGNORE": "false",
-        "TS_NODE_PROJECT": "${workspaceFolder}/packages/twenty-server/tsconfig.json"
-      },
       "cwd": "${workspaceFolder}/packages/twenty-server/"
     }
   ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,21 +1,25 @@
 {
+  "version": "0.2.0",
+  "resolveSourceMapLocations": ["${workspaceFolder}/**", "!**/node_modules/**"],
   "configurations": [
     {
+      "name": "twenty-server - dev debug",
       "type": "node",
       "request": "launch",
-      "name": "Server Debug",
       "runtimeExecutable": "yarn",
-      "cwd": "${workspaceFolder}/server",
       "runtimeArgs": [
-        "start:debug",
-        "--",
-        "--inspect-brk"
+        "nx",
+        "run",
+        "twenty-server:start:dev",
       ],
-      "console": "integratedTerminal",
-      "restart": true,
-      "protocol": "auto",
-      "port": 9229,
-      "autoAttachChildProcesses": true
+      "outputCapture": "std",
+      "internalConsoleOptions": "openOnSessionStart",
+      "console": "internalConsole",
+      "env": {
+        "TS_NODE_IGNORE": "false",
+        "TS_NODE_PROJECT": "${workspaceFolder}/packages/twenty-server/tsconfig.json"
+      },
+      "cwd": "${workspaceFolder}/packages/twenty-server/"
     }
   ]
 }


### PR DESCRIPTION
- previous config was probably unmaintained
- added working command to run `twenty-server` in debug mode
- probably good to mention this somewhere in docs as well?

<img width="1572" alt="image" src="https://github.com/twentyhq/twenty/assets/19856731/ec6d6dca-56fb-4109-a2d9-b3abc31e60d6">
