### PR TITLE
Fix/workspace health type

### DIFF
--- a/packages/twenty-server/scripts/truncate-db.ts
+++ b/packages/twenty-server/scripts/truncate-db.ts
@@ -2,31 +2,35 @@ import console from 'console';
 
 import { connectionSource, performQuery } from './utils';
 
-connectionSource
-  .initialize()
-  .then(async () => {
-    await performQuery(
+async function dropSchemasSequentially() {
+  try {
+    await connectionSource.initialize();
+
+    // Fetch all schemas
+    const schemas = await performQuery(
       `
-        CREATE OR REPLACE FUNCTION drop_all() RETURNS VOID AS $$
-          DECLARE schema_item RECORD; 
-          BEGIN
-            FOR schema_item IN
-              SELECT subrequest."name" as schema_name
-              FROM  (SELECT n.nspname AS "name"
-              FROM pg_catalog.pg_namespace n
-              WHERE n.nspname !~ '^pg_' AND n.nspname <> 'information_schema') as subrequest
-            LOOP
-              EXECUTE 'DROP SCHEMA ' || schema_item.schema_name || ' CASCADE'; 
-            END LOOP; 
-            RETURN; 
-          END;
-        $$ LANGUAGE plpgsql;
-     
-        SELECT drop_all ();
-      `,
-      'Dropping all schemas...',
+      SELECT n.nspname AS "schema_name"
+      FROM pg_catalog.pg_namespace n
+      WHERE n.nspname !~ '^pg_' AND n.nspname <> 'information_schema'
+    `,
+      'Fetching schemas...',
     );
-  })
-  .catch((err) => {
-    console.error('Error during Data Source initialization:', err);
-  });
+
+    // Iterate over each schema and drop it
+    // This is to avoid dropping all schemas at once, which would cause an out of shared memory error
+    for (const schema of schemas) {
+      await performQuery(
+        `
+        DROP SCHEMA IF EXISTS "${schema.schema_name}" CASCADE;
+      `,
+        `Dropping schema ${schema.schema_name}...`,
+      );
+    }
+
+    console.log('All schemas dropped successfully.');
+  } catch (err) {
+    console.error('Error during schema dropping:', err);
+  }
+}
+
+dropSchemasSequentially();

--- a/packages/twenty-server/src/metadata/field-metadata/utils/generate-default-value.ts
+++ b/packages/twenty-server/src/metadata/field-metadata/utils/generate-default-value.ts
@@ -17,6 +17,11 @@ export function generateDefaultValue(
         firstName: '',
         lastName: '',
       };
+    case FieldMetadataType.LINK:
+      return {
+        url: '',
+        label: '',
+      };
     default:
       return null;
   }

--- a/packages/twenty-server/src/workspace/workspace-health/services/database-structure.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/services/database-structure.service.ts
@@ -16,6 +16,8 @@ import {
 } from 'src/metadata/field-metadata/field-metadata.entity';
 import { fieldMetadataTypeToColumnType } from 'src/metadata/workspace-migration/utils/field-metadata-type-to-column-type.util';
 import { serializeTypeDefaultValue } from 'src/metadata/field-metadata/utils/serialize-type-default-value.util';
+import { isCompositeFieldMetadataType } from 'src/metadata/field-metadata/utils/is-composite-field-metadata-type.util';
+import { isRelationFieldMetadataType } from 'src/workspace/utils/is-relation-field-metadata-type.util';
 
 @Injectable()
 export class DatabaseStructureService {
@@ -165,8 +167,20 @@ export class DatabaseStructureService {
     postgresDataType: string,
   ): FieldMetadataType | null {
     const mainDataSource = this.typeORMService.getMainDataSource();
+    const types = Object.values(FieldMetadataType).filter((type) => {
+      // We're skipping composite and relation types, as they're not directly mapped to a column type
+      if (isCompositeFieldMetadataType(type)) {
+        return false;
+      }
 
-    for (const type in FieldMetadataType) {
+      if (isRelationFieldMetadataType(type)) {
+        return false;
+      }
+
+      return true;
+    });
+
+    for (const type of types) {
       const typeORMType = fieldMetadataTypeToColumnType(
         FieldMetadataType[type],
       ) as ColumnType;

--- a/packages/twenty-server/src/workspace/workspace-migration-builder/factories/workspace-migration-field.factory.ts
+++ b/packages/twenty-server/src/workspace/workspace-migration-builder/factories/workspace-migration-field.factory.ts
@@ -16,7 +16,7 @@ import { computeObjectTargetTable } from 'src/workspace/utils/compute-object-tar
 import { WorkspaceMigrationFactory } from 'src/metadata/workspace-migration/workspace-migration.factory';
 import { generateMigrationName } from 'src/metadata/workspace-migration/utils/generate-migration-name.util';
 
-interface FieldMetadataUpdate {
+export interface FieldMetadataUpdate {
   current: FieldMetadataEntity;
   altered: FieldMetadataEntity;
 }


### PR DESCRIPTION
In this PR we're fixing the following issues:
- [x] memory issue with the `truncate:db` command when we have a lot of schema
- [x] Cannot convert LINK to column type
- [x] fieldMedataType LINK doesn't have default value
- [x] handle old column type and add a warn to fix them manually
For the last issue, we need to handle them manually as our mapping functions doesn't have anymore the old types, so generated workspaceMigrations doesn't match the actual state of the database, and TypeORM is not migrating anything.

Fix #4006
