### PR TITLE
fix: ignore enum options sync for now

### DIFF
--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/comparators/workspace-field.comparator.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/comparators/workspace-field.comparator.ts
@@ -18,13 +18,10 @@ const fieldPropertiesToIgnore = [
   'updatedAt',
   'objectMetadataId',
   'isActive',
-] as const;
-
-const fieldPropertiesToStringify = [
-  'targetColumnMap',
-  'defaultValue',
   'options',
 ] as const;
+
+const fieldPropertiesToStringify = ['targetColumnMap', 'defaultValue'] as const;
 
 @Injectable()
 export class WorkspaceFieldComparator {
@@ -55,6 +52,7 @@ export class WorkspaceFieldComparator {
     const standardFieldMetadataMap = transformMetadataForComparison(
       standardObjectMetadata.fields,
       {
+        propertiesToIgnore: ['options'],
         propertiesToStringify: fieldPropertiesToStringify,
         keyFactory(datum) {
           return datum.name;


### PR DESCRIPTION
We've introduced custom option for an enum standard field, this PR is omitting the sync of the `options` to avoid overriding user values.
We'll handle that case later.

Fix #4005 
