### PR TITLE
fix: sync and health

### DIFF
--- a/packages/twenty-server/src/metadata/workspace-migration/factories/basic-column-action.factory.ts
+++ b/packages/twenty-server/src/metadata/workspace-migration/factories/basic-column-action.factory.ts
@@ -55,11 +55,22 @@ export class BasicColumnActionFactory extends ColumnActionAbstractFactory<BasicF
       this.getDefaultValue(alteredFieldMetadata.defaultValue) ??
       options?.defaultValue;
     const serializedDefaultValue = serializeDefaultValue(defaultValue);
+    const currentColumnName = currentFieldMetadata.targetColumnMap.value;
+    const alteredColumnName = alteredFieldMetadata.targetColumnMap.value;
+
+    if (!currentColumnName || !alteredColumnName) {
+      this.logger.error(
+        `Column name not found for current or altered field metadata, can be due to a missing or an invalid target column map. Current column name: ${currentColumnName}, Altered column name: ${alteredColumnName}.`,
+      );
+      throw new Error(
+        `Column name not found for current or altered field metadata`,
+      );
+    }
 
     return {
       action: WorkspaceMigrationColumnActionType.ALTER,
       currentColumnDefinition: {
-        columnName: currentFieldMetadata.targetColumnMap.value,
+        columnName: currentColumnName,
         columnType: fieldMetadataTypeToColumnType(currentFieldMetadata.type),
         isNullable: currentFieldMetadata.isNullable,
         defaultValue: serializeDefaultValue(
@@ -67,7 +78,7 @@ export class BasicColumnActionFactory extends ColumnActionAbstractFactory<BasicF
         ),
       },
       alteredColumnDefinition: {
-        columnName: alteredFieldMetadata.targetColumnMap.value,
+        columnName: alteredColumnName,
         columnType: fieldMetadataTypeToColumnType(alteredFieldMetadata.type),
         isNullable: alteredFieldMetadata.isNullable,
         defaultValue: serializedDefaultValue,

--- a/packages/twenty-server/src/metadata/workspace-migration/factories/enum-column-action.factory.ts
+++ b/packages/twenty-server/src/metadata/workspace-migration/factories/enum-column-action.factory.ts
@@ -71,11 +71,22 @@ export class EnumColumnActionFactory extends ColumnActionAbstractFactory<EnumFie
           }),
         ]
       : undefined;
+    const currentColumnName = currentFieldMetadata.targetColumnMap.value;
+    const alteredColumnName = alteredFieldMetadata.targetColumnMap.value;
+
+    if (!currentColumnName || !alteredColumnName) {
+      this.logger.error(
+        `Column name not found for current or altered field metadata, can be due to a missing or an invalid target column map. Current column name: ${currentColumnName}, Altered column name: ${alteredColumnName}.`,
+      );
+      throw new Error(
+        `Column name not found for current or altered field metadata`,
+      );
+    }
 
     return {
       action: WorkspaceMigrationColumnActionType.ALTER,
       currentColumnDefinition: {
-        columnName: currentFieldMetadata.targetColumnMap.value,
+        columnName: currentColumnName,
         columnType: fieldMetadataTypeToColumnType(currentFieldMetadata.type),
         enum: currentFieldMetadata.options
           ? [...currentFieldMetadata.options.map((option) => option.value)]
@@ -87,7 +98,7 @@ export class EnumColumnActionFactory extends ColumnActionAbstractFactory<EnumFie
         ),
       },
       alteredColumnDefinition: {
-        columnName: alteredFieldMetadata.targetColumnMap.value,
+        columnName: alteredColumnName,
         columnType: fieldMetadataTypeToColumnType(alteredFieldMetadata.type),
         enum: enumOptions,
         isArray: alteredFieldMetadata.type === FieldMetadataType.MULTI_SELECT,

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/storage/workspace-sync.storage.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/storage/workspace-sync.storage.ts
@@ -15,9 +15,9 @@ export class WorkspaceSyncStorage {
 
   // Field metadata
   private readonly _fieldMetadataCreateCollection: PartialFieldMetadata[] = [];
-  private readonly _fieldMetadataUpdateCollection: Partial<
-    PartialFieldMetadata & { id: string }
-  >[] = [];
+  private readonly _fieldMetadataUpdateCollection: (Partial<PartialFieldMetadata> & {
+    id: string;
+  })[] = [];
   private readonly _fieldMetadataDeleteCollection: FieldMetadataEntity[] = [];
 
   // Relation metadata
@@ -76,7 +76,9 @@ export class WorkspaceSyncStorage {
     this._fieldMetadataCreateCollection.push(field);
   }
 
-  addUpdateFieldMetadata(field: Partial<PartialFieldMetadata>) {
+  addUpdateFieldMetadata(
+    field: Partial<PartialFieldMetadata> & { id: string },
+  ) {
     this._fieldMetadataUpdateCollection.push(field);
   }
 


### PR DESCRIPTION
This PR addresses the following issues:

### The `columnName` attribute is absent in the `workspace-migrations`.
This occurs when the `targetColumnMap` is either empty or not correctly defined for a specific field. To resolve this issue within the `workspace:sync-metadata` command, execute `workspace:health --fix=target-column-map`. This action will rectify any discrepancies in the `targetColumnMap`, ensuring the command's functionality is restored. To further enhance error handling, an exception is now thrown if an attempt is made to create a `workspace-migration` without specifying a `columnName`.

### The `defaultValue` is inadvertently replaced with a `null` value.
This behavior stems from the operational characteristics of the TypeORM's `save` function. Specifically, when a partial entity is submitted through the save operation without including the original values of properties that have a `defaultValue` set, TypeORM defaults to overriding these properties with the `defaultValue`, irrespective of existing data within the database for those properties. Furthermore, when a partial entity is provided, the save method does not return the complete entity in the result, leading to incomplete data representation.

TypeORM issue for reference: https://github.com/typeorm/typeorm/issues/3490