### PR TITLE
fix: workspace health undefined relation

### DIFF
--- a/packages/twenty-server/src/workspace/workspace-health/interfaces/workspace-health-issue.interface.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/interfaces/workspace-health-issue.interface.ts
@@ -25,6 +25,7 @@ export enum WorkspaceHealthIssueType {
   COLUMN_DEFAULT_VALUE_CONFLICT = 'COLUMN_DEFAULT_VALUE_CONFLICT',
   COLUMN_DEFAULT_VALUE_NOT_VALID = 'COLUMN_DEFAULT_VALUE_NOT_VALID',
   COLUMN_OPTIONS_NOT_VALID = 'COLUMN_OPTIONS_NOT_VALID',
+  RELATION_METADATA_NOT_VALID = 'RELATION_METADATA_NOT_VALID',
   RELATION_FROM_OR_TO_FIELD_METADATA_NOT_VALID = 'RELATION_FROM_OR_TO_FIELD_METADATA_NOT_VALID',
   RELATION_FOREIGN_KEY_NOT_VALID = 'RELATION_FOREIGN_KEY_NOT_VALID',
   RELATION_FOREIGN_KEY_CONFLICT = 'RELATION_FOREIGN_KEY_CONFLICT',
@@ -80,6 +81,7 @@ export interface WorkspaceHealthColumnIssue<
  * Relation issues
  */
 export type WorkspaceRelationIssueTypes =
+  | WorkspaceHealthIssueType.RELATION_METADATA_NOT_VALID
   | WorkspaceHealthIssueType.RELATION_FROM_OR_TO_FIELD_METADATA_NOT_VALID
   | WorkspaceHealthIssueType.RELATION_FOREIGN_KEY_NOT_VALID
   | WorkspaceHealthIssueType.RELATION_FOREIGN_KEY_CONFLICT
@@ -89,9 +91,9 @@ export interface WorkspaceHealthRelationIssue<
   T extends WorkspaceRelationIssueTypes,
 > {
   type: T;
-  fromFieldMetadata: FieldMetadataEntity | undefined;
-  toFieldMetadata: FieldMetadataEntity | undefined;
-  relationMetadata: RelationMetadataEntity;
+  fromFieldMetadata?: FieldMetadataEntity | undefined;
+  toFieldMetadata?: FieldMetadataEntity | undefined;
+  relationMetadata?: RelationMetadataEntity;
   columnStructure?: WorkspaceTableStructure;
   message: string;
 }

--- a/packages/twenty-server/src/workspace/workspace-health/services/field-metadata-health.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/services/field-metadata-health.service.ts
@@ -28,6 +28,7 @@ import { serializeDefaultValue } from 'src/metadata/field-metadata/utils/seriali
 import { computeCompositeFieldMetadata } from 'src/workspace/workspace-health/utils/compute-composite-field-metadata.util';
 import { generateTargetColumnMap } from 'src/metadata/field-metadata/utils/generate-target-column-map.util';
 import { customNamePrefix } from 'src/workspace/utils/compute-custom-name.util';
+import { isRelationFieldMetadataType } from 'src/workspace/utils/is-relation-field-metadata-type.util';
 
 @Injectable()
 export class FieldMetadataHealthService {
@@ -45,10 +46,7 @@ export class FieldMetadataHealthService {
 
     for (const fieldMetadata of fieldMetadataCollection) {
       // Relation metadata are checked in another service
-      if (
-        fieldMetadata.fromRelationMetadata ||
-        fieldMetadata.toRelationMetadata
-      ) {
+      if (isRelationFieldMetadataType(fieldMetadata.type)) {
         continue;
       }
 


### PR DESCRIPTION
Apparently some workspace contains fields of type `RELATION` that are not linked to a `relationMetadata`.
This PR fix the command and add a new error for that case.