### PR TITLE
Fix developers url and remove webhook url error

### DIFF
--- a/packages/twenty-front/src/App.tsx
+++ b/packages/twenty-front/src/App.tsx
@@ -133,13 +133,13 @@ export const App = () => {
                   element={<SettingsNewObject />}
                 />
                 <Route
+                  path={SettingsPath.Developers}
+                  element={<SettingsDevelopers />}
+                />
+                <Route
                   path={AppPath.DevelopersCatchAll}
                   element={
                     <Routes>
-                      <Route
-                        path={SettingsPath.Developers}
-                        element={<SettingsDevelopers />}
-                      />
                       <Route
                         path={SettingsPath.DevelopersNewApiKey}
                         element={<SettingsDevelopersApiKeysNew />}

--- a/packages/twenty-server/src/workspace/workspace-query-runner/jobs/call-webhook.job.ts
+++ b/packages/twenty-server/src/workspace/workspace-query-runner/jobs/call-webhook.job.ts
@@ -26,7 +26,7 @@ export class CallWebhookJob implements MessageQueueJob<CallWebhookJobData> {
         `CallWebhookJob successfully called on targetUrl '${data.targetUrl}'`,
       );
     } catch (err) {
-      throw new Error(
+      this.logger.error(
         `Error calling webhook on targetUrl '${data.targetUrl}': ${err}`,
       );
     }


### PR DESCRIPTION
This PR fixes two issues:

- setting a wrong webhook url breaks the server because it throws an error in the async job. This will simply log the error since this is not a critical one. We will implement a better solution as a follow-up

- [developers url](http://localhost:3001/settings/developers) has been broken by [this commit](https://github.com/twentyhq/twenty/commit/11581ca9c336162c997dcff31a81dcb2ff7d6f76). I moved the route out of the prefix `/developers/` to make it work again

<img width="400" alt="Capture d’écran 2024-02-21 à 15 18 55" src="https://github.com/twentyhq/twenty/assets/22936103/77c4b5d6-0b7a-4c5e-8c3b-c4023b0b7d38">