### PR TITLE
Add writeLog for relation update sync metadata

### DIFF
--- a/packages/twenty-server/src/workspace/workspace-health/services/relation-metadata.health.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/services/relation-metadata.health.service.ts
@@ -209,7 +209,10 @@ export class RelationMetadataHealthService {
       });
     }
 
-    if (relationMetadata.onDeleteAction !== relationColumn.onDeleteAction) {
+    if (
+      relationMetadata.onDeleteAction?.replace(/_/g, ' ') !==
+      relationColumn.onDeleteAction
+    ) {
       issues.push({
         type: WorkspaceHealthIssueType.RELATION_FOREIGN_KEY_ON_DELETE_ACTION_CONFLICT,
         fromFieldMetadata,

--- a/packages/twenty-server/src/workspace/workspace-health/services/relation-metadata.health.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/services/relation-metadata.health.service.ts
@@ -215,6 +215,7 @@ export class RelationMetadataHealthService {
         fromFieldMetadata,
         toFieldMetadata,
         relationMetadata,
+        columnStructure: relationColumn,
         message: `Relation ${relationMetadata.id} foreign key onDeleteAction is not properly set`,
       });
     }

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/commands/services/sync-workspace-logger.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/commands/services/sync-workspace-logger.service.ts
@@ -64,6 +64,12 @@ export class SyncWorkspaceLoggerService {
       storage.relationMetadataCreateCollection,
     );
 
+    // Save relation metadata update collection
+    await this.commandLogger.writeLog(
+      'relation-metadata-update-collection',
+      storage.relationMetadataUpdateCollection,
+    );
+
     // Save relation metadata delete collection
     await this.commandLogger.writeLog(
       'relation-metadata-delete-collection',


### PR DESCRIPTION
This was missing from my last PR, this should add logs when we are running dry-run for sync-metadata and when relation updates are executed
Also adding columnStructure to health-check command dry-run logs for the RELATION_FOREIGN_KEY_ON_DELETE_ACTION_CONFLICT so we can easily compare between metadata and the table structure