### PR TITLE
Handle relations between same objects

### DIFF
--- a/packages/twenty-server/src/workspace/utils/__tests__/deduce-relation-direction.spec.ts
+++ b/packages/twenty-server/src/workspace/utils/__tests__/deduce-relation-direction.spec.ts
@@ -1,5 +1,7 @@
+import { FieldMetadataInterface } from 'src/metadata/field-metadata/interfaces/field-metadata.interface';
 import { RelationMetadataInterface } from 'src/metadata/field-metadata/interfaces/relation-metadata.interface';
 
+import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
 import { RelationMetadataType } from 'src/metadata/relation-metadata/relation-metadata.entity';
 import {
   deduceRelationDirection,
@@ -8,10 +10,21 @@ import {
 
 describe('deduceRelationDirection', () => {
   it('should return FROM when the current object Metadata ID matches fromObjectMetadataId', () => {
-    const currentObjectId = 'from_object_id';
+    const fieldMetadata: FieldMetadataInterface = {
+      id: 'field_id',
+      objectMetadataId: 'from_object_id',
+      type: FieldMetadataType.RELATION,
+      name: 'field_name',
+      label: 'Field Name',
+      description: 'Field Description',
+      targetColumnMap: {
+        default: 'default_column',
+      },
+    };
+
     const relationMetadata = {
       id: 'relation_id',
-      fromObjectMetadataId: currentObjectId,
+      fromObjectMetadataId: fieldMetadata.objectMetadataId,
       toObjectMetadataId: 'to_object_id',
       fromFieldMetadataId: 'from_field_id',
       toFieldMetadataId: 'to_field_id',
@@ -19,7 +32,7 @@ describe('deduceRelationDirection', () => {
     };
 
     const result = deduceRelationDirection(
-      currentObjectId,
+      fieldMetadata,
       relationMetadata as RelationMetadataInterface,
     );
 
@@ -28,18 +41,91 @@ describe('deduceRelationDirection', () => {
 
   it('should return TO when the current object Metadata ID matches toObjectMetadataId', () => {
     // Arrange
-    const currentObjectId = 'to_object_id';
+    const fieldMetadata: FieldMetadataInterface = {
+      id: 'field_id',
+      objectMetadataId: 'to_object_id',
+      type: FieldMetadataType.RELATION,
+      name: 'field_name',
+      label: 'Field Name',
+      description: 'Field Description',
+      targetColumnMap: {
+        default: 'default_column',
+      },
+    };
+
     const relationMetadata = {
       id: 'relation_id',
       fromObjectMetadataId: 'from_object_id',
-      toObjectMetadataId: currentObjectId,
+      toObjectMetadataId: fieldMetadata.objectMetadataId,
       fromFieldMetadataId: 'from_field_id',
       toFieldMetadataId: 'to_field_id',
       relationType: RelationMetadataType.ONE_TO_ONE,
     };
 
     const result = deduceRelationDirection(
-      currentObjectId,
+      fieldMetadata,
+      relationMetadata as RelationMetadataInterface,
+    );
+
+    expect(result).toBe(RelationDirection.TO);
+  });
+
+  it('when relation between same objects, when object field id matches relation from field id, should return FROM', () => {
+    // Arrange
+    const fieldMetadata: FieldMetadataInterface = {
+      id: 'from_field_id',
+      objectMetadataId: 'object_id',
+      type: FieldMetadataType.RELATION,
+      name: 'field_name',
+      label: 'Field Name',
+      description: 'Field Description',
+      targetColumnMap: {
+        default: 'default_column',
+      },
+    };
+
+    const relationMetadata = {
+      id: 'relation_id',
+      fromObjectMetadataId: fieldMetadata.objectMetadataId,
+      toObjectMetadataId: fieldMetadata.objectMetadataId,
+      fromFieldMetadataId: fieldMetadata.id,
+      toFieldMetadataId: 'to_field_id',
+      relationType: RelationMetadataType.ONE_TO_ONE,
+    };
+
+    const result = deduceRelationDirection(
+      fieldMetadata,
+      relationMetadata as RelationMetadataInterface,
+    );
+
+    expect(result).toBe(RelationDirection.FROM);
+  });
+
+  it('when relation between same objects, when object field id matches relation to field id, should return TO', () => {
+    // Arrange
+    const fieldMetadata: FieldMetadataInterface = {
+      id: 'to_field_id',
+      objectMetadataId: 'object_id',
+      type: FieldMetadataType.RELATION,
+      name: 'field_name',
+      label: 'Field Name',
+      description: 'Field Description',
+      targetColumnMap: {
+        default: 'default_column',
+      },
+    };
+
+    const relationMetadata = {
+      id: 'relation_id',
+      fromObjectMetadataId: fieldMetadata.objectMetadataId,
+      toObjectMetadataId: fieldMetadata.objectMetadataId,
+      fromFieldMetadataId: 'from_field_id',
+      toFieldMetadataId: fieldMetadata.id,
+      relationType: RelationMetadataType.ONE_TO_ONE,
+    };
+
+    const result = deduceRelationDirection(
+      fieldMetadata,
       relationMetadata as RelationMetadataInterface,
     );
 
@@ -47,7 +133,18 @@ describe('deduceRelationDirection', () => {
   });
 
   it('should throw an error when the current object Metadata ID does not match any object metadata ID', () => {
-    const currentObjectId = 'unrelated_object_id';
+    const fieldMetadata: FieldMetadataInterface = {
+      id: 'field_id',
+      objectMetadataId: 'unrelated_object_id',
+      type: FieldMetadataType.RELATION,
+      name: 'field_name',
+      label: 'Field Name',
+      description: 'Field Description',
+      targetColumnMap: {
+        default: 'default_column',
+      },
+    };
+
     const relationMetadata = {
       id: 'relation_id',
       fromObjectMetadataId: 'from_object_id',
@@ -59,11 +156,11 @@ describe('deduceRelationDirection', () => {
 
     expect(() =>
       deduceRelationDirection(
-        currentObjectId,
+        fieldMetadata,
         relationMetadata as RelationMetadataInterface,
       ),
     ).toThrow(
-      `Relation metadata ${relationMetadata.id} is not related to object ${currentObjectId}`,
+      `Relation metadata ${relationMetadata.id} is not related to object ${fieldMetadata.objectMetadataId}`,
     );
   });
 });

--- a/packages/twenty-server/src/workspace/utils/__tests__/deduce-relation-direction.spec.ts
+++ b/packages/twenty-server/src/workspace/utils/__tests__/deduce-relation-direction.spec.ts
@@ -9,7 +9,7 @@ import {
 } from 'src/workspace/utils/deduce-relation-direction.util';
 
 describe('deduceRelationDirection', () => {
-  it('should return FROM when the current object Metadata ID matches fromObjectMetadataId', () => {
+  it('should return FROM when the current object Metadata ID matches fromObjectMetadataId and id matches fromFieldMetadataId', () => {
     const fieldMetadata: FieldMetadataInterface = {
       id: 'field_id',
       objectMetadataId: 'from_object_id',
@@ -26,7 +26,7 @@ describe('deduceRelationDirection', () => {
       id: 'relation_id',
       fromObjectMetadataId: fieldMetadata.objectMetadataId,
       toObjectMetadataId: 'to_object_id',
-      fromFieldMetadataId: 'from_field_id',
+      fromFieldMetadataId: fieldMetadata.id,
       toFieldMetadataId: 'to_field_id',
       relationType: RelationMetadataType.ONE_TO_ONE,
     };
@@ -39,7 +39,7 @@ describe('deduceRelationDirection', () => {
     expect(result).toBe(RelationDirection.FROM);
   });
 
-  it('should return TO when the current object Metadata ID matches toObjectMetadataId', () => {
+  it('should return TO when the current object Metadata ID matches toObjectMetadataId and id matches toFieldMetadataId', () => {
     // Arrange
     const fieldMetadata: FieldMetadataInterface = {
       id: 'field_id',
@@ -56,68 +56,6 @@ describe('deduceRelationDirection', () => {
     const relationMetadata = {
       id: 'relation_id',
       fromObjectMetadataId: 'from_object_id',
-      toObjectMetadataId: fieldMetadata.objectMetadataId,
-      fromFieldMetadataId: 'from_field_id',
-      toFieldMetadataId: 'to_field_id',
-      relationType: RelationMetadataType.ONE_TO_ONE,
-    };
-
-    const result = deduceRelationDirection(
-      fieldMetadata,
-      relationMetadata as RelationMetadataInterface,
-    );
-
-    expect(result).toBe(RelationDirection.TO);
-  });
-
-  it('when relation between same objects, when object field id matches relation from field id, should return FROM', () => {
-    // Arrange
-    const fieldMetadata: FieldMetadataInterface = {
-      id: 'from_field_id',
-      objectMetadataId: 'object_id',
-      type: FieldMetadataType.RELATION,
-      name: 'field_name',
-      label: 'Field Name',
-      description: 'Field Description',
-      targetColumnMap: {
-        default: 'default_column',
-      },
-    };
-
-    const relationMetadata = {
-      id: 'relation_id',
-      fromObjectMetadataId: fieldMetadata.objectMetadataId,
-      toObjectMetadataId: fieldMetadata.objectMetadataId,
-      fromFieldMetadataId: fieldMetadata.id,
-      toFieldMetadataId: 'to_field_id',
-      relationType: RelationMetadataType.ONE_TO_ONE,
-    };
-
-    const result = deduceRelationDirection(
-      fieldMetadata,
-      relationMetadata as RelationMetadataInterface,
-    );
-
-    expect(result).toBe(RelationDirection.FROM);
-  });
-
-  it('when relation between same objects, when object field id matches relation to field id, should return TO', () => {
-    // Arrange
-    const fieldMetadata: FieldMetadataInterface = {
-      id: 'to_field_id',
-      objectMetadataId: 'object_id',
-      type: FieldMetadataType.RELATION,
-      name: 'field_name',
-      label: 'Field Name',
-      description: 'Field Description',
-      targetColumnMap: {
-        default: 'default_column',
-      },
-    };
-
-    const relationMetadata = {
-      id: 'relation_id',
-      fromObjectMetadataId: fieldMetadata.objectMetadataId,
       toObjectMetadataId: fieldMetadata.objectMetadataId,
       fromFieldMetadataId: 'from_field_id',
       toFieldMetadataId: fieldMetadata.id,

--- a/packages/twenty-server/src/workspace/utils/deduce-relation-direction.util.ts
+++ b/packages/twenty-server/src/workspace/utils/deduce-relation-direction.util.ts
@@ -1,3 +1,4 @@
+import { FieldMetadataInterface } from 'src/metadata/field-metadata/interfaces/field-metadata.interface';
 import { RelationMetadataInterface } from 'src/metadata/field-metadata/interfaces/relation-metadata.interface';
 
 export enum RelationDirection {
@@ -6,18 +7,32 @@ export enum RelationDirection {
 }
 
 export const deduceRelationDirection = (
-  currentObjectId: string,
+  fieldMetadata: FieldMetadataInterface,
   relationMetadata: RelationMetadataInterface,
 ): RelationDirection => {
-  if (relationMetadata.fromObjectMetadataId === currentObjectId) {
+  if (
+    relationMetadata.fromObjectMetadataId === fieldMetadata.objectMetadataId
+  ) {
+    if (relationMetadata.fromFieldMetadataId === fieldMetadata.id) {
+      return RelationDirection.FROM;
+    }
+
+    if (relationMetadata.toFieldMetadataId === fieldMetadata.id) {
+      return RelationDirection.TO;
+    }
+  }
+
+  if (
+    relationMetadata.fromObjectMetadataId === fieldMetadata.objectMetadataId
+  ) {
     return RelationDirection.FROM;
   }
 
-  if (relationMetadata.toObjectMetadataId === currentObjectId) {
+  if (relationMetadata.toObjectMetadataId === fieldMetadata.objectMetadataId) {
     return RelationDirection.TO;
   }
 
   throw new Error(
-    `Relation metadata ${relationMetadata.id} is not related to object ${currentObjectId}`,
+    `Relation metadata ${relationMetadata.id} is not related to object ${fieldMetadata.objectMetadataId}`,
   );
 };

--- a/packages/twenty-server/src/workspace/utils/deduce-relation-direction.util.ts
+++ b/packages/twenty-server/src/workspace/utils/deduce-relation-direction.util.ts
@@ -11,24 +11,16 @@ export const deduceRelationDirection = (
   relationMetadata: RelationMetadataInterface,
 ): RelationDirection => {
   if (
-    relationMetadata.fromObjectMetadataId === fieldMetadata.objectMetadataId
-  ) {
-    if (relationMetadata.fromFieldMetadataId === fieldMetadata.id) {
-      return RelationDirection.FROM;
-    }
-
-    if (relationMetadata.toFieldMetadataId === fieldMetadata.id) {
-      return RelationDirection.TO;
-    }
-  }
-
-  if (
-    relationMetadata.fromObjectMetadataId === fieldMetadata.objectMetadataId
+    relationMetadata.fromObjectMetadataId === fieldMetadata.objectMetadataId &&
+    relationMetadata.fromFieldMetadataId === fieldMetadata.id
   ) {
     return RelationDirection.FROM;
   }
 
-  if (relationMetadata.toObjectMetadataId === fieldMetadata.objectMetadataId) {
+  if (
+    relationMetadata.toObjectMetadataId === fieldMetadata.objectMetadataId &&
+    relationMetadata.toFieldMetadataId === fieldMetadata.id
+  ) {
     return RelationDirection.TO;
   }
 

--- a/packages/twenty-server/src/workspace/workspace-health/services/relation-metadata.health.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/services/relation-metadata.health.service.ts
@@ -55,7 +55,7 @@ export class RelationMetadataHealthService {
       }
 
       const relationDirection = deduceRelationDirection(
-        objectMetadata.id,
+        fieldMetadata,
         relationMetadata,
       );
 

--- a/packages/twenty-server/src/workspace/workspace-query-builder/factories/relation-field-alias.factory.ts
+++ b/packages/twenty-server/src/workspace/workspace-query-builder/factories/relation-field-alias.factory.ts
@@ -72,7 +72,7 @@ export class RelationFieldAliasFactory {
     }
 
     const relationDirection = deduceRelationDirection(
-      fieldMetadata.objectMetadataId,
+      fieldMetadata,
       relationMetadata,
     );
     // Retrieve the referenced object metadata based on the relation direction

--- a/packages/twenty-server/src/workspace/workspace-schema-builder/factories/extend-object-type-definition.factory.ts
+++ b/packages/twenty-server/src/workspace/workspace-schema-builder/factories/extend-object-type-definition.factory.ts
@@ -128,7 +128,7 @@ export class ExtendObjectTypeDefinitionFactory {
       }
 
       const relationDirection = deduceRelationDirection(
-        fieldMetadata.objectMetadataId,
+        fieldMetadata,
         relationMetadata,
       );
       const relationType = this.relationTypeFactory.create(


### PR DESCRIPTION
Currently, creating a one to many relation between the same objects fails.
The relation is correctly stored in DB, the issue happens when building the schema from that relation.

Current logic is the following:
- compare object metadata id with the `fromObjectMetadaId` of the relation
- if equals, the direction is `FROM`, the graphql type def is a connection
- else ...
This logic does not work for this case since the object metadata id is the same on both size. So the logic will always return the direction FROM. So it will always create a connection.

This PR:
- checks if both object metadata ids are equals.
- if yes, use the field metadata id instead
- else, keep the same logic