### PR TITLE
Fix referential_constraints health check

### DIFF
--- a/packages/twenty-server/src/workspace/workspace-health/services/database-structure.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-health/services/database-structure.service.ts
@@ -114,6 +114,7 @@ export class DatabaseStructureService {
         LEFT JOIN
           information_schema.referential_constraints AS rc
           ON rc.constraint_name = fk.constraint_name
+          AND rc.constraint_schema = '${schemaName}'
         WHERE
           c.table_schema = '${schemaName}'
           AND c.table_name = '${tableName}';


### PR DESCRIPTION
## Context
FK names are identical between each schema which broke the recently updated query that fetches constraints and onDelete actions