### PR TITLE
Remove usage of toSorted as it is not fully supported

### DIFF
--- a/packages/twenty-front/src/modules/activities/hooks/useActivities.ts
+++ b/packages/twenty-front/src/modules/activities/hooks/useActivities.ts
@@ -41,9 +41,12 @@ export const useActivities = ({
   });
 
   const activityIds = activityTargets
-    ?.map((activityTarget) => activityTarget.activityId)
-    .filter(isNonEmptyString)
-    .toSorted(sortByAscString);
+    ? [
+        ...activityTargets
+          .map((activityTarget) => activityTarget.activityId)
+          .filter(isNonEmptyString),
+      ].sort(sortByAscString)
+    : [];
 
   const activityTargetsFound =
     initializedActivityTargets && isNonEmptyArray(activityTargets);

--- a/packages/twenty-front/src/modules/activities/hooks/useInjectIntoActivitiesQueries.ts
+++ b/packages/twenty-front/src/modules/activities/hooks/useInjectIntoActivitiesQueries.ts
@@ -91,7 +91,7 @@ export const useInjectIntoActivitiesQueries = () => {
       const currentFindManyActivitiesQueryVariables = {
         filter: {
           id: {
-            in: existingActivityIdsFromTargets.toSorted(sortByAscString),
+            in: [...existingActivityIdsFromTargets].sort(sortByAscString),
           },
           ...activitiesFilters,
         },
@@ -110,7 +110,7 @@ export const useInjectIntoActivitiesQueries = () => {
       const nextFindManyActivitiesQueryVariables = {
         filter: {
           id: {
-            in: nextActivityIds.toSorted(sortByAscString),
+            in: [...nextActivityIds].sort(sortByAscString),
           },
           ...activitiesFilters,
         },

--- a/packages/twenty-front/src/modules/activities/hooks/useRemoveFromActivitiesQueries.ts
+++ b/packages/twenty-front/src/modules/activities/hooks/useRemoveFromActivitiesQueries.ts
@@ -72,7 +72,7 @@ export const useRemoveFromActivitiesQueries = () => {
     const currentFindManyActivitiesQueryVariables = {
       filter: {
         id: {
-          in: existingActivityIds.toSorted(sortByAscString),
+          in: [...existingActivityIds].sort(sortByAscString),
         },
         ...activitiesFilters,
       },
@@ -94,7 +94,7 @@ export const useRemoveFromActivitiesQueries = () => {
     const nextFindManyActivitiesQueryVariables = {
       filter: {
         id: {
-          in: activityIdsAfterRemoval.toSorted(sortByAscString),
+          in: [...activityIdsAfterRemoval].sort(sortByAscString),
         },
         ...activitiesFilters,
       },

--- a/packages/twenty-front/src/modules/activities/timeline/components/TimelineQueryEffect.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline/components/TimelineQueryEffect.tsx
@@ -45,17 +45,16 @@ export const TimelineQueryEffect = ({
       return;
     }
 
-    const activitiesForGroup = activities
-      .map((activity) => ({
+    const activitiesForGroup = [
+      ...activities.map((activity) => ({
         id: activity.id,
         createdAt: activity.createdAt,
-      }))
-      .toSorted(sortObjectRecordByDateField('createdAt', 'DescNullsLast'));
+      })),
+    ].sort(sortObjectRecordByDateField('createdAt', 'DescNullsLast'));
 
-    const timelineActivitiesForGroupSorted =
-      timelineActivitiesForGroup.toSorted(
-        sortObjectRecordByDateField('createdAt', 'DescNullsLast'),
-      );
+    const timelineActivitiesForGroupSorted = [
+      ...timelineActivitiesForGroup,
+    ].sort(sortObjectRecordByDateField('createdAt', 'DescNullsLast'));
 
     if (!isDeeplyEqual(activitiesForGroup, timelineActivitiesForGroupSorted)) {
       setTimelineActivitiesForGroup(activitiesForGroup);

--- a/packages/twenty-front/src/modules/activities/timeline/hooks/useTimelineActivities.ts
+++ b/packages/twenty-front/src/modules/activities/timeline/hooks/useTimelineActivities.ts
@@ -45,9 +45,12 @@ export const useTimelineActivities = ({
   const activityIds = Array.from(
     new Set(
       activityTargets
-        ?.map((activityTarget) => activityTarget.activityId)
-        .filter(isNonEmptyString)
-        .toSorted(sortByAscString),
+        ? [
+            ...activityTargets
+              .map((activityTarget) => activityTarget.activityId)
+              .filter(isNonEmptyString),
+          ].sort(sortByAscString)
+        : [],
     ),
   );
 

--- a/packages/twenty-front/src/modules/activities/timeline/utils/makeTimelineActivitiesQueryVariables.ts
+++ b/packages/twenty-front/src/modules/activities/timeline/utils/makeTimelineActivitiesQueryVariables.ts
@@ -9,7 +9,7 @@ export const makeTimelineActivitiesQueryVariables = ({
   return {
     filter: {
       id: {
-        in: activityIds.toSorted(sortByAscString),
+        in: [...activityIds].sort(sortByAscString),
       },
     },
     orderBy: {


### PR DESCRIPTION
I'm removing all usages of toSorted in the codebase as chromatic is using outdated versions of node/ browser and this makes chromatic tests break .
