### PR TITLE
Fixed confirmation modal not closing after regenerating API key

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/modal/components/ConfirmationModal.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/modal/components/ConfirmationModal.tsx
@@ -122,7 +122,10 @@ export const ConfirmationModal = ({
             fullWidth
           />
           <StyledCenteredButton
-            onClick={onConfirmClick}
+            onClick={async () => {
+              await onConfirmClick();
+              setIsOpen(false);
+            }}
             variant="secondary"
             accent="danger"
             title={deleteButtonText}


### PR DESCRIPTION
fixes the issue of `ConfirmationModal` not closing after clicking on the regenerate API key
references #3956