### PR TITLE
Ignore defaultValue update for select fields

### DIFF
--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/comparators/utils/__tests__/transform-metadata-for-comparison.util.spec.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/comparators/utils/__tests__/transform-metadata-for-comparison.util.spec.ts
@@ -21,7 +21,7 @@ describe('transformMetadataForComparison', () => {
       { name: 'Test2', value: { c: 3 }, extra: 'keepMe' },
     ];
     const result = transformMetadataForComparison(input, {
-      propertiesToIgnore: ['ignored'],
+      shouldIgnoreProperty: (property) => ['ignored'].includes(property),
       propertiesToStringify: ['value'],
       keyFactory: (datum) => datum.name,
     });

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/comparators/utils/transform-metadata-for-comparison.util.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/comparators/utils/transform-metadata-for-comparison.util.ts
@@ -8,7 +8,7 @@ type TransformToString<T, Keys extends keyof T> = {
 export function transformMetadataForComparison<T, Keys extends keyof T>(
   fieldMetadataCollection: T[],
   options: {
-    propertiesToIgnore?: readonly Keys[];
+    shouldIgnoreProperty?: (property: string, originalMetadata?: T) => boolean;
     propertiesToStringify?: readonly Keys[];
     keyFactory: (datum: T) => string;
   },
@@ -18,7 +18,7 @@ export function transformMetadataForComparison<T, Keys extends keyof T>(
 export function transformMetadataForComparison<T, Keys extends keyof T>(
   fieldMetadataCollection: T,
   options: {
-    propertiesToIgnore?: readonly Keys[];
+    shouldIgnoreProperty?: (property: string, originalMetadata?: T) => boolean;
     propertiesToStringify?: readonly Keys[];
   },
 ): TransformToString<T, Keys>;
@@ -26,13 +26,11 @@ export function transformMetadataForComparison<T, Keys extends keyof T>(
 export function transformMetadataForComparison<T, Keys extends keyof T>(
   metadata: T[] | T,
   options: {
-    propertiesToIgnore?: readonly Keys[];
+    shouldIgnoreProperty?: (property: string, originalMetadata?: T) => boolean;
     propertiesToStringify?: readonly Keys[];
     keyFactory?: (datum: T) => string;
   },
 ): Record<string, TransformToString<T, Keys>> | TransformToString<T, Keys> {
-  const propertiesToIgnore = (options.propertiesToIgnore ??
-    []) as readonly string[];
   const propertiesToStringify = (options.propertiesToStringify ??
     []) as readonly string[];
 
@@ -40,7 +38,10 @@ export function transformMetadataForComparison<T, Keys extends keyof T>(
     const transformedField = {} as TransformToString<T, Keys>;
 
     for (const property in datum) {
-      if (propertiesToIgnore.includes(property)) {
+      if (
+        options.shouldIgnoreProperty &&
+        options.shouldIgnoreProperty(property, datum)
+      ) {
         continue;
       }
       if (

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/comparators/workspace-object.comparator.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/comparators/workspace-object.comparator.ts
@@ -20,7 +20,7 @@ const objectPropertiesToIgnore = [
   'imageIdentifierFieldMetadataId',
   'isActive',
   'fields',
-] as const;
+];
 
 @Injectable()
 export class WorkspaceObjectComparator {
@@ -44,7 +44,8 @@ export class WorkspaceObjectComparator {
     const partialOriginalObjectMetadata = transformMetadataForComparison(
       originalObjectMetadata,
       {
-        propertiesToIgnore: objectPropertiesToIgnore,
+        shouldIgnoreProperty: (property) =>
+          objectPropertiesToIgnore.includes(property),
       },
     );
 

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/comparators/workspace-relation.comparator.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/comparators/workspace-relation.comparator.ts
@@ -10,7 +10,7 @@ import {
 import { RelationMetadataEntity } from 'src/metadata/relation-metadata/relation-metadata.entity';
 import { transformMetadataForComparison } from 'src/workspace/workspace-sync-metadata/comparators/utils/transform-metadata-for-comparison.util';
 
-const relationPropertiesToIgnore = ['createdAt', 'updatedAt'] as const;
+const relationPropertiesToIgnore = ['createdAt', 'updatedAt'];
 const relationPropertiesToUpdate = ['onDeleteAction'];
 
 @Injectable()
@@ -38,7 +38,8 @@ export class WorkspaceRelationComparator {
     const originalRelationMetadataMap = transformMetadataForComparison(
       originalRelationMetadataCollection,
       {
-        propertiesToIgnore: relationPropertiesToIgnore,
+        shouldIgnoreProperty: (property) =>
+          relationPropertiesToIgnore.includes(property),
         keyFactory(relationMetadata) {
           return `${relationMetadata.fromObjectMetadataId}->${relationMetadata.fromFieldMetadataId}`;
         },


### PR DESCRIPTION
In this PR, I'm introducing the possibility to ignore properties during metadata sync based on (property, originalMetadata). Before it was only based on (property)

This allows us to be more granular and use it to discard defaultValue check for SELECT field type.

@magrinj I think we could introduce a propertyToIgnore(fieldMetadata) factory to encapsulate (and tests!) this business logic which can be quite fragile if edge cases grow
