### PR TITLE
fix: Extend regex in Linkedin Field to support LinkedIn school URL

### DIFF
--- a/packages/twenty-front/src/utils/getDisplayValueByUrlType.ts
+++ b/packages/twenty-front/src/utils/getDisplayValueByUrlType.ts
@@ -11,7 +11,7 @@ export const getDisplayValueByUrlType = ({
 }: getUrlDisplayValueByUrlTypeProps) => {
   if (type === 'linkedin') {
     const matches = href.match(
-      /(?:https?:\/\/)?(?:www.)?linkedin.com\/(?:in|company)\/(.*)/,
+      /(?:https?:\/\/)?(?:www.)?linkedin.com\/(?:in|company|school)\/(.*)/,
     );
     if (matches && matches[1]) {
       return matches[1];


### PR DESCRIPTION
Fixes https://github.com/twentyhq/twenty/issues/4181

The regex does not support Linkedin school URL, so I extended it.

Now school URL works perfectly. 
I tested with `https://www.linkedin.com/school/stanford-university`
![image](https://github.com/twentyhq/twenty/assets/75515229/254b68de-e5a8-4f67-ba22-bc1d65a43375)
![image](https://github.com/twentyhq/twenty/assets/75515229/0d57f5d9-e6bf-4a9c-a400-fadffe00fd8d)
