### PR TITLE
Fix password too short issue

### DIFF
--- a/packages/twenty-front/src/modules/auth/sign-in-up/hooks/useSignInUp.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/hooks/useSignInUp.tsx
@@ -146,7 +146,13 @@ export const useSignInUp = (form: UseFormReturn<Form>) => {
       }
     },
     PageHotkeyScope.SignInUp,
-    [continueWithEmail],
+    [
+      continueWithEmail,
+      signInUpStep,
+      continueWithCredentials,
+      form,
+      submitCredentials,
+    ],
   );
 
   return {


### PR DESCRIPTION
See issue https://github.com/orgs/twentyhq/projects/1/views/3?pane=issue&itemId=53814124

Dependencies are missing in the hotscope function. This is built only once, so the signup step is still set to initial in there. This is why only the email is display when pressing enter. It goes from init to email step.

Adding missing dependencies.