### PR TITLE
[messaging] fix empty history

### DIFF
--- a/packages/twenty-server/src/workspace/messaging/services/gmail-partial-sync.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/services/gmail-partial-sync.service.ts
@@ -81,7 +81,7 @@ export class GmailPartialSyncService {
       throw new Error('No history id found');
     }
 
-    if (newHistoryId === lastSyncHistoryId) {
+    if (newHistoryId === lastSyncHistoryId || !history?.history?.length) {
       this.logger.log(
         `gmail partial-sync for workspace ${workspaceId} and account ${connectedAccountId} done with nothing to update.`,
       );


### PR DESCRIPTION
Sometimes, the historyId changes without any change inside history. While I don't have a strong idea of why it's happening, I think this still makes sense to stop the job if the history object is empty

Note: There is still an ongoing issue with the partial sync. When we receive history.messageAdded with some message ids, we try to fetch their content with gmail API however sometimes we get a 404 Entity not found from their API. A first fix has been merged a few weeks ago where we compare messageAdded and messageDeleted and skip those ids if they are present in both but this issue still persists.