### PR TITLE
Update relation cascade on standard objects favorite, attachment, activityTargets

### DIFF
--- a/packages/twenty-server/src/metadata/field-metadata/utils/generate-default-value.ts
+++ b/packages/twenty-server/src/metadata/field-metadata/utils/generate-default-value.ts
@@ -22,6 +22,11 @@ export function generateDefaultValue(
         url: '',
         label: '',
       };
+    case FieldMetadataType.CURRENCY:
+      return {
+        amountMicros: null,
+        currencyCode: '',
+      };
     default:
       return null;
   }

--- a/packages/twenty-server/src/metadata/object-metadata/object-metadata.service.ts
+++ b/packages/twenty-server/src/metadata/object-metadata/object-metadata.service.ts
@@ -28,6 +28,7 @@ import { DataSourceService } from 'src/metadata/data-source/data-source.service'
 import {
   RelationMetadataEntity,
   RelationMetadataType,
+  RelationOnDeleteAction,
 } from 'src/metadata/relation-metadata/relation-metadata.entity';
 import { computeCustomName } from 'src/workspace/utils/compute-custom-name.util';
 import { computeObjectTargetTable } from 'src/workspace/utils/compute-object-target-table.util';
@@ -355,6 +356,7 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
                 createdObjectMetadata,
               ),
               referencedTableColumnName: 'id',
+              onDelete: RelationOnDeleteAction.CASCADE,
             },
           ],
         },
@@ -386,6 +388,7 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
                 createdObjectMetadata,
               ),
               referencedTableColumnName: 'id',
+              onDelete: RelationOnDeleteAction.CASCADE,
             },
           ],
         },
@@ -611,6 +614,7 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
           activityTargetRelationFieldMetadataMap[
             activityTargetObjectMetadata.id
           ].id,
+        onDeleteAction: RelationOnDeleteAction.CASCADE,
       },
     ]);
 
@@ -699,6 +703,7 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
           favoriteRelationFieldMetadataMap[createdObjectMetadata.id].id,
         toFieldMetadataId:
           favoriteRelationFieldMetadataMap[favoriteObjectMetadata.id].id,
+        onDeleteAction: RelationOnDeleteAction.CASCADE,
       },
     ]);
 

--- a/packages/twenty-server/src/workspace/workspace-migration-runner/services/workspace-migration-enum.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-migration-runner/services/workspace-migration-enum.service.ts
@@ -186,6 +186,6 @@ export class WorkspaceMigrationEnumService {
   }
 
   private getStringifyValue(value: any) {
-    return typeof value === 'string' ? value : `'${value}'`;
+    return `'${value}'`;
   }
 }

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/company.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/company.object-metadata.ts
@@ -1,7 +1,10 @@
 import { CurrencyMetadata } from 'src/metadata/field-metadata/composite-types/currency.composite-type';
 import { LinkMetadata } from 'src/metadata/field-metadata/composite-types/link.composite-type';
 import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
-import { RelationMetadataType } from 'src/metadata/relation-metadata/relation-metadata.entity';
+import {
+  RelationMetadataType,
+  RelationOnDeleteAction,
+} from 'src/metadata/relation-metadata/relation-metadata.entity';
 import { FieldMetadata } from 'src/workspace/workspace-sync-metadata/decorators/field-metadata.decorator';
 import { IsNullable } from 'src/workspace/workspace-sync-metadata/decorators/is-nullable.decorator';
 import { IsSystem } from 'src/workspace/workspace-sync-metadata/decorators/is-system.decorator';
@@ -139,6 +142,7 @@ export class CompanyObjectMetadata extends BaseObjectMetadata {
   @RelationMetadata({
     type: RelationMetadataType.ONE_TO_MANY,
     objectName: 'activityTarget',
+    onDelete: RelationOnDeleteAction.CASCADE,
   })
   @IsNullable()
   activityTargets: ActivityTargetObjectMetadata[];
@@ -165,6 +169,7 @@ export class CompanyObjectMetadata extends BaseObjectMetadata {
   @RelationMetadata({
     type: RelationMetadataType.ONE_TO_MANY,
     objectName: 'favorite',
+    onDelete: RelationOnDeleteAction.CASCADE,
   })
   @IsNullable()
   favorites: FavoriteObjectMetadata[];
@@ -178,6 +183,7 @@ export class CompanyObjectMetadata extends BaseObjectMetadata {
   @RelationMetadata({
     type: RelationMetadataType.ONE_TO_MANY,
     objectName: 'attachment',
+    onDelete: RelationOnDeleteAction.CASCADE,
   })
   @IsNullable()
   attachments: AttachmentObjectMetadata[];

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/opportunity.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/opportunity.object-metadata.ts
@@ -1,6 +1,9 @@
 import { CurrencyMetadata } from 'src/metadata/field-metadata/composite-types/currency.composite-type';
 import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
-import { RelationMetadataType } from 'src/metadata/relation-metadata/relation-metadata.entity';
+import {
+  RelationMetadataType,
+  RelationOnDeleteAction,
+} from 'src/metadata/relation-metadata/relation-metadata.entity';
 import { FieldMetadata } from 'src/workspace/workspace-sync-metadata/decorators/field-metadata.decorator';
 import { IsNullable } from 'src/workspace/workspace-sync-metadata/decorators/is-nullable.decorator';
 import { IsSystem } from 'src/workspace/workspace-sync-metadata/decorators/is-system.decorator';
@@ -128,6 +131,7 @@ export class OpportunityObjectMetadata extends BaseObjectMetadata {
   @RelationMetadata({
     type: RelationMetadataType.ONE_TO_MANY,
     objectName: 'favorite',
+    onDelete: RelationOnDeleteAction.CASCADE,
   })
   @IsNullable()
   favorites: FavoriteObjectMetadata[];
@@ -141,6 +145,7 @@ export class OpportunityObjectMetadata extends BaseObjectMetadata {
   @RelationMetadata({
     type: RelationMetadataType.ONE_TO_MANY,
     objectName: 'activityTarget',
+    onDelete: RelationOnDeleteAction.CASCADE,
   })
   @IsNullable()
   activityTargets: ActivityTargetObjectMetadata[];

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/person.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/person.object-metadata.ts
@@ -1,7 +1,10 @@
 import { FullNameMetadata } from 'src/metadata/field-metadata/composite-types/full-name.composite-type';
 import { LinkMetadata } from 'src/metadata/field-metadata/composite-types/link.composite-type';
 import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
-import { RelationMetadataType } from 'src/metadata/relation-metadata/relation-metadata.entity';
+import {
+  RelationMetadataType,
+  RelationOnDeleteAction,
+} from 'src/metadata/relation-metadata/relation-metadata.entity';
 import { FieldMetadata } from 'src/workspace/workspace-sync-metadata/decorators/field-metadata.decorator';
 import { IsNullable } from 'src/workspace/workspace-sync-metadata/decorators/is-nullable.decorator';
 import { IsSystem } from 'src/workspace/workspace-sync-metadata/decorators/is-system.decorator';
@@ -135,6 +138,7 @@ export class PersonObjectMetadata extends BaseObjectMetadata {
   @RelationMetadata({
     type: RelationMetadataType.ONE_TO_MANY,
     objectName: 'activityTarget',
+    onDelete: RelationOnDeleteAction.CASCADE,
   })
   @IsNullable()
   activityTargets: ActivityTargetObjectMetadata[];
@@ -148,6 +152,7 @@ export class PersonObjectMetadata extends BaseObjectMetadata {
   @RelationMetadata({
     type: RelationMetadataType.ONE_TO_MANY,
     objectName: 'favorite',
+    onDelete: RelationOnDeleteAction.CASCADE,
   })
   @IsNullable()
   favorites: FavoriteObjectMetadata[];
@@ -161,6 +166,7 @@ export class PersonObjectMetadata extends BaseObjectMetadata {
   @RelationMetadata({
     type: RelationMetadataType.ONE_TO_MANY,
     objectName: 'attachment',
+    onDelete: RelationOnDeleteAction.CASCADE,
   })
   @IsNullable()
   attachments: AttachmentObjectMetadata[];

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/workspace-member.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/workspace-member.object-metadata.ts
@@ -1,6 +1,6 @@
 import { FullNameMetadata } from 'src/metadata/field-metadata/composite-types/full-name.composite-type';
 import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
-import { RelationMetadataType } from 'src/metadata/relation-metadata/relation-metadata.entity';
+import { RelationMetadataType, RelationOnDeleteAction } from 'src/metadata/relation-metadata/relation-metadata.entity';
 import { FieldMetadata } from 'src/workspace/workspace-sync-metadata/decorators/field-metadata.decorator';
 import { Gate } from 'src/workspace/workspace-sync-metadata/decorators/gate.decorator';
 import { IsNullable } from 'src/workspace/workspace-sync-metadata/decorators/is-nullable.decorator';
@@ -114,6 +114,7 @@ export class WorkspaceMemberObjectMetadata extends BaseObjectMetadata {
   @RelationMetadata({
     type: RelationMetadataType.ONE_TO_MANY,
     objectName: 'favorite',
+    onDelete: RelationOnDeleteAction.CASCADE,
   })
   @IsNullable()
   favorites: FavoriteObjectMetadata[];


### PR DESCRIPTION
In this PR, I'm re-adding Cascade Deletion on:
- WorkspaceMember deletion => Favorite Deletion
- Person / Company / Opportunity / Custom Object => Favorite / ActivityTarget / Attachment deletion