### PR TITLE
Fix nullable being set to null for text field

### DIFF
--- a/packages/twenty-server/src/metadata/field-metadata/field-metadata.service.ts
+++ b/packages/twenty-server/src/metadata/field-metadata/field-metadata.service.ts
@@ -25,6 +25,7 @@ import { UpdateFieldInput } from 'src/metadata/field-metadata/dtos/update-field.
 import { WorkspaceMigrationFactory } from 'src/metadata/workspace-migration/workspace-migration.factory';
 import { computeObjectTargetTable } from 'src/workspace/utils/compute-object-target-table.util';
 import { generateMigrationName } from 'src/metadata/workspace-migration/utils/generate-migration-name.util';
+import { generateNullable } from 'src/metadata/field-metadata/utils/generate-nullable';
 
 import {
   FieldMetadataEntity,
@@ -101,6 +102,10 @@ export class FieldMetadataService extends TypeOrmQueryService<FieldMetadataEntit
         fieldMetadataInput.type,
         true,
         fieldMetadataInput.name,
+      ),
+      isNullable: generateNullable(
+        fieldMetadataInput.type,
+        fieldMetadataInput.isNullable,
       ),
       defaultValue:
         fieldMetadataInput.defaultValue ??

--- a/packages/twenty-server/src/metadata/field-metadata/utils/__tests__/generate-nullable.spec.ts
+++ b/packages/twenty-server/src/metadata/field-metadata/utils/__tests__/generate-nullable.spec.ts
@@ -1,0 +1,27 @@
+import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
+import { generateNullable } from 'src/metadata/field-metadata/utils/generate-nullable';
+
+describe('generateNullable', () => {
+  it('should generate a nullable value false for TEXT, EMAIL, PHONE no matter what the input is', () => {
+    expect(generateNullable(FieldMetadataType.TEXT, false)).toEqual(false);
+    expect(generateNullable(FieldMetadataType.PHONE, false)).toEqual(false);
+    expect(generateNullable(FieldMetadataType.EMAIL, false)).toEqual(false);
+
+    expect(generateNullable(FieldMetadataType.TEXT, true)).toEqual(false);
+    expect(generateNullable(FieldMetadataType.PHONE, true)).toEqual(false);
+    expect(generateNullable(FieldMetadataType.EMAIL, true)).toEqual(false);
+
+    expect(generateNullable(FieldMetadataType.TEXT)).toEqual(false);
+    expect(generateNullable(FieldMetadataType.PHONE)).toEqual(false);
+    expect(generateNullable(FieldMetadataType.EMAIL)).toEqual(false);
+  });
+
+  it('should should return true if no input is given', () => {
+    expect(generateNullable(FieldMetadataType.DATE_TIME)).toEqual(true);
+  });
+
+  it('should should return the input value if the input value is given', () => {
+    expect(generateNullable(FieldMetadataType.DATE_TIME, true)).toEqual(true);
+    expect(generateNullable(FieldMetadataType.DATE_TIME, false)).toEqual(false);
+  });
+});

--- a/packages/twenty-server/src/metadata/field-metadata/utils/generate-nullable.ts
+++ b/packages/twenty-server/src/metadata/field-metadata/utils/generate-nullable.ts
@@ -1,0 +1,15 @@
+import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
+
+export function generateNullable(
+  type: FieldMetadataType,
+  inputNullableValue?: boolean,
+): boolean {
+  switch (type) {
+    case FieldMetadataType.TEXT:
+    case FieldMetadataType.PHONE:
+    case FieldMetadataType.EMAIL:
+      return false;
+    default:
+      return inputNullableValue ?? true;
+  }
+}


### PR DESCRIPTION
## Issue

Custom fields of type `TEXT` were created with `isNullable: true`. This is not correct as TEXT field should always be `isNullable: false` because the `null` state of a text field is actually an empty string ('')

This means that the backend should compute his own nullable value based on field type and the nullable value provided by the frontend

## How

I'm introducing a generateNullable, following the pattern of generateDefaultValue