### PR TITLE
[messaging] add better logs to messaging sync jobs

### DIFF
--- a/packages/twenty-server/src/workspace/messaging/repositories/connected-account/connected-account.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/repositories/connected-account/connected-account.service.ts
@@ -60,7 +60,9 @@ export class ConnectedAccountService {
       );
 
     if (!connectedAccounts || connectedAccounts.length === 0) {
-      throw new NotFoundException('No connected account found');
+      throw new NotFoundException(
+        `No connected account found for id ${connectedAccountId} in workspace ${workspaceId}`,
+      );
     }
 
     return connectedAccounts[0];

--- a/packages/twenty-server/src/workspace/messaging/repositories/message-channel/message-channel.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/repositories/message-channel/message-channel.service.ts
@@ -38,7 +38,9 @@ export class MessageChannelService {
     );
 
     if (!messageChannels || messageChannels.length === 0) {
-      throw new Error('No message channel found');
+      throw new Error(
+        `No message channel found for connected account ${connectedAccountId} in workspace ${workspaceId}`,
+      );
     }
 
     return messageChannels[0];

--- a/packages/twenty-server/src/workspace/messaging/repositories/workspace-member/workspace-member.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/repositories/workspace-member/workspace-member.service.ts
@@ -44,7 +44,9 @@ export class WorkspaceMemberService {
       );
 
     if (!workspaceMembers || workspaceMembers.length === 0) {
-      throw new NotFoundException('No workspace member found');
+      throw new NotFoundException(
+        `No workspace member found for user ${userId} in workspace ${workspaceId}`,
+      );
     }
 
     return workspaceMembers[0];

--- a/packages/twenty-server/src/workspace/messaging/services/gmail-partial-sync.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/services/gmail-partial-sync.service.ts
@@ -61,7 +61,9 @@ export class GmailPartialSyncService {
     const refreshToken = connectedAccount.refreshToken;
 
     if (!refreshToken) {
-      throw new Error('No refresh token found');
+      throw new Error(
+        `No refresh token found for connected account ${connectedAccountId} in workspace ${workspaceId} during partial-sync`,
+      );
     }
 
     let startTime = Date.now();
@@ -96,7 +98,9 @@ export class GmailPartialSyncService {
     }
 
     if (!historyId) {
-      throw new Error('No history id found');
+      throw new Error(
+        `No historyId found for ${connectedAccountId} in workspace ${workspaceId} during partial-sync`,
+      );
     }
 
     if (historyId === lastSyncHistoryId || !history?.length) {
@@ -173,8 +177,11 @@ export class GmailPartialSyncService {
       );
     }
 
-    if (errors.length) throw new Error('Error fetching messages');
-
+    if (errors.length) {
+      throw new Error(
+        `Error fetching messages for ${connectedAccountId} in workspace ${workspaceId} during partial-sync`,
+      );
+    }
     startTime = Date.now();
 
     await this.connectedAccountService.updateLastSyncHistoryId(

--- a/packages/twenty-server/src/workspace/messaging/services/gmail-refresh-access-token.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/services/gmail-refresh-access-token.service.ts
@@ -24,7 +24,9 @@ export class GmailRefreshAccessTokenService {
     const refreshToken = connectedAccount.refreshToken;
 
     if (!refreshToken) {
-      throw new Error('No refresh token found');
+      throw new Error(
+        `No refresh token found for connected account ${connectedAccountId} in workspace ${workspaceId}`,
+      );
     }
 
     const accessToken = await this.refreshAccessToken(refreshToken);


### PR DESCRIPTION
## Context
Error logs from jobs are harder to debug because we don't have any info from the request context (since there is none), I'm updating the log messages to help us debug better.