### PR TITLE
Handle multiple orderBy sorting

### DIFF
--- a/packages/twenty-server/src/workspace/workspace-query-builder/factories/__tests__/args-string.factory.spec.ts
+++ b/packages/twenty-server/src/workspace/workspace-query-builder/factories/__tests__/args-string.factory.spec.ts
@@ -1,0 +1,86 @@
+import { TestingModule, Test } from '@nestjs/testing';
+
+import { ArgsAliasFactory } from 'src/workspace/workspace-query-builder/factories/args-alias.factory';
+import { ArgsStringFactory } from 'src/workspace/workspace-query-builder/factories/args-string.factory';
+
+describe('ArgsStringFactory', () => {
+  let service: ArgsStringFactory;
+  const argsAliasCreate = jest.fn();
+
+  beforeEach(async () => {
+    jest.resetAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ArgsStringFactory,
+        {
+          provide: ArgsAliasFactory,
+          useValue: {
+            create: argsAliasCreate,
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<ArgsStringFactory>(ArgsStringFactory);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should return null when args are missing', () => {
+      const args = undefined;
+
+      const result = service.create(args, []);
+
+      expect(result).toBeNull();
+    });
+
+    it('should return a string with the args when args are present', () => {
+      const args = {
+        id: '1',
+        name: 'field_name',
+      };
+
+      argsAliasCreate.mockReturnValue(args);
+
+      const result = service.create(args, []);
+
+      expect(result).toEqual('id: "1", name: "field_name"');
+    });
+
+    it('should return a string with the args when args are present and the value is an object', () => {
+      const args = {
+        id: '1',
+        name: {
+          firstName: 'test',
+        },
+      };
+
+      argsAliasCreate.mockReturnValue(args);
+
+      const result = service.create(args, []);
+
+      expect(result).toEqual('id: "1", name: {firstName:"test"}');
+    });
+
+    it('when orderBy is present, should return an array of objects', () => {
+      const args = {
+        orderBy: {
+          id: 'AscNullsFirst',
+          name: 'AscNullsFirst',
+        },
+      };
+
+      argsAliasCreate.mockReturnValue(args);
+
+      const result = service.create(args, []);
+
+      expect(result).toEqual(
+        'orderBy: [{id: AscNullsFirst}, {name: AscNullsFirst}]',
+      );
+    });
+  });
+});

--- a/packages/twenty-server/src/workspace/workspace-query-builder/factories/args-string.factory.ts
+++ b/packages/twenty-server/src/workspace/workspace-query-builder/factories/args-string.factory.ts
@@ -37,7 +37,8 @@ export class ArgsStringFactory {
         computedArgs[key] !== null
       ) {
         // If it's an object (and not null), stringify it
-        argsString += `${key}: ${stringifyWithoutKeyQuote(
+        argsString += `${key}: ${this.buildStringifiedObject(
+          key,
           computedArgs[key],
         )}, `;
       } else {
@@ -52,5 +53,21 @@ export class ArgsStringFactory {
     }
 
     return argsString;
+  }
+
+  private buildStringifiedObject(
+    key: string,
+    obj: Record<string, any>,
+  ): string {
+    // PgGraphql is expecting the orderBy argument to be an array of objects
+    if (key === 'orderBy') {
+      const orderByString = Object.keys(obj)
+        .map((orderByKey) => `{${orderByKey}: ${obj[orderByKey]}}`)
+        .join(', ');
+
+      return `[${orderByString}]`;
+    }
+
+    return stringifyWithoutKeyQuote(obj);
   }
 }


### PR DESCRIPTION
Pg graphql expects an array of simple objects when receiving an order by. Today we send an unique object.

This PR:
- checks if the arg is orderBY
- if not, stringify as a normal object
- if yes, build an array with all key - value pairs in that object