### PR TITLE
Fix enum defaultValue broken

### DIFF
--- a/packages/twenty-front/src/modules/object-metadata/types/FieldMetadataItem.ts
+++ b/packages/twenty-front/src/modules/object-metadata/types/FieldMetadataItem.ts
@@ -26,7 +26,7 @@ export type FieldMetadataItem = Omit<
         >;
       })
     | null;
-  defaultValue?: unknown;
+  defaultValue?: any;
   options?: {
     color: ThemeColor;
     id: string;

--- a/packages/twenty-front/src/modules/object-metadata/types/FieldMetadataItem.ts
+++ b/packages/twenty-front/src/modules/object-metadata/types/FieldMetadataItem.ts
@@ -26,7 +26,7 @@ export type FieldMetadataItem = Omit<
         >;
       })
     | null;
-  defaultValue?: { value: string };
+  defaultValue?: unknown;
   options?: {
     color: ThemeColor;
     id: string;

--- a/packages/twenty-front/src/modules/object-metadata/types/FieldMetadataItem.ts
+++ b/packages/twenty-front/src/modules/object-metadata/types/FieldMetadataItem.ts
@@ -26,7 +26,7 @@ export type FieldMetadataItem = Omit<
         >;
       })
     | null;
-  defaultValue?: unknown;
+  defaultValue?: { value: string };
   options?: {
     color: ThemeColor;
     id: string;

--- a/packages/twenty-front/src/pages/settings/data-model/SettingsObjectFieldEdit.tsx
+++ b/packages/twenty-front/src/pages/settings/data-model/SettingsObjectFieldEdit.tsx
@@ -105,7 +105,7 @@ export const SettingsObjectFieldEdit = () => {
 
     const selectOptions = activeMetadataField.options?.map((option) => ({
       ...option,
-      isDefault: defaultValue === option.value,
+      isDefault: defaultValue?.value === option.value,
     }));
     selectOptions?.sort(
       (optionA, optionB) => optionA.position - optionB.position,

--- a/packages/twenty-server/src/metadata/field-metadata/field-metadata.service.ts
+++ b/packages/twenty-server/src/metadata/field-metadata/field-metadata.service.ts
@@ -235,6 +235,10 @@ export class FieldMetadataService extends TypeOrmQueryService<FieldMetadataEntit
 
     const updatedFieldMetadata = await super.updateOne(id, {
       ...updatableFieldInput,
+      defaultValue: updatableFieldInput.defaultValue
+        ? // Todo: we need to rework DefaultValue typing and format to be simpler, there is no need to have this complexity
+          { value: updatableFieldInput.defaultValue as unknown as string }
+        : null,
       // If the name is updated, the targetColumnMap should be updated as well
       targetColumnMap: updatableFieldInput.name
         ? generateTargetColumnMap(

--- a/packages/twenty-server/src/metadata/workspace-migration/factories/enum-column-action.factory.ts
+++ b/packages/twenty-server/src/metadata/workspace-migration/factories/enum-column-action.factory.ts
@@ -52,6 +52,7 @@ export class EnumColumnActionFactory extends ColumnActionAbstractFactory<EnumFie
     const defaultValue =
       alteredFieldMetadata.defaultValue?.value ?? options?.defaultValue;
     const serializedDefaultValue = serializeDefaultValue(defaultValue);
+
     const enumOptions = alteredFieldMetadata.options
       ? [
           ...alteredFieldMetadata.options.map((option) => {

--- a/packages/twenty-server/src/workspace/workspace-migration-runner/services/workspace-migration-enum.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-migration-runner/services/workspace-migration-enum.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@nestjs/common';
 import { QueryRunner } from 'typeorm';
 
 import { WorkspaceMigrationColumnAlter } from 'src/metadata/workspace-migration/workspace-migration.entity';
+import { serializeDefaultValue } from 'src/metadata/field-metadata/utils/serialize-default-value';
 
 @Injectable()
 export class WorkspaceMigrationEnumService {
@@ -25,7 +26,7 @@ export class WorkspaceMigrationEnumService {
       }) ?? [];
 
     if (!columnDefinition.isNullable && !columnDefinition.defaultValue) {
-      columnDefinition.defaultValue = columnDefinition.enum?.[0];
+      columnDefinition.defaultValue = serializeDefaultValue(enumValues[0]);
     }
 
     // Create new enum type with new values
@@ -66,6 +67,7 @@ export class WorkspaceMigrationEnumService {
       tableName,
       columnDefinition.columnName,
       newEnumTypeName,
+      columnDefinition.defaultValue,
     );
 
     // Drop old enum type
@@ -138,7 +140,7 @@ export class WorkspaceMigrationEnumService {
           .map((e) => `'${e}'`)
           .join(', ')}]`;
       } else {
-        defaultValue = this.getStringifyValue(columnDefinition.defaultValue);
+        defaultValue = columnDefinition.defaultValue;
       }
     }
 
@@ -157,9 +159,12 @@ export class WorkspaceMigrationEnumService {
     tableName: string,
     columnName: string,
     newEnumTypeName: string,
+    newDefaultValue: string,
   ) {
     await queryRunner.query(
-      `ALTER TABLE "${schemaName}"."${tableName}" ALTER COLUMN "${columnName}" DROP DEFAULT, ALTER COLUMN "${columnName}" TYPE "${schemaName}"."${newEnumTypeName}" USING ("${columnName}"::text::"${schemaName}"."${newEnumTypeName}")`,
+      `ALTER TABLE "${schemaName}"."${tableName}" ALTER COLUMN "${columnName}" DROP DEFAULT,
+      ALTER COLUMN "${columnName}" TYPE "${schemaName}"."${newEnumTypeName}" USING ("${columnName}"::text::"${schemaName}"."${newEnumTypeName}"),
+      ALTER COLUMN "${columnName}" SET DEFAULT ${newDefaultValue}`,
     );
   }
 
@@ -183,9 +188,5 @@ export class WorkspaceMigrationEnumService {
       ALTER TYPE "${schemaName}"."${newEnumTypeName}"
       RENAME TO "${oldEnumTypeName}"
     `);
-  }
-
-  private getStringifyValue(value: any) {
-    return `'${value}'`;
   }
 }


### PR DESCRIPTION
In this PR, I'm fixing defaultValue behavior for enum.

However this need to be reworked:
- defaultValue typing is too complex ; the graphQL API does not match what it is stored in database ; migration format does not match metadata. I think we can heavily simplify this
- Also, defaultValue backup to first enum options should not be addressed in migration but at metadata stage