### PR TITLE
Fix Internal Server Error when removing profile picture (#4257)

### DIFF
--- a/packages/twenty-front/src/modules/settings/profile/components/ProfilePictureUploader.tsx
+++ b/packages/twenty-front/src/modules/settings/profile/components/ProfilePictureUploader.tsx
@@ -79,18 +79,22 @@ export const ProfilePictureUploader = () => {
   };
 
   const handleRemove = async () => {
-    if (!currentWorkspaceMember?.id) {
-      throw new Error('User is not logged in');
+    try {
+      if (!currentWorkspaceMember?.id) {
+        throw new Error('User is not logged in');
+      }
+
+      await updateOneRecord({
+        idToUpdate: currentWorkspaceMember?.id,
+        updateOneRecordInput: {
+          avatarUrl: null,
+        },
+      });
+
+      setCurrentWorkspaceMember({ ...currentWorkspaceMember, avatarUrl: null });
+    } catch (error) {
+      setErrorMessage('An error occured while removing the picture.');
     }
-
-    await updateOneRecord({
-      idToUpdate: currentWorkspaceMember?.id,
-      updateOneRecordInput: {
-        avatarUrl: null,
-      },
-    });
-
-    setCurrentWorkspaceMember({ ...currentWorkspaceMember, avatarUrl: null });
   };
 
   return (

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/workspace-member.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/workspace-member.object-metadata.ts
@@ -60,6 +60,7 @@ export class WorkspaceMemberObjectMetadata extends BaseObjectMetadata {
     description: 'Workspace member avatar',
     icon: 'IconFileUpload',
   })
+  @IsNullable()
   avatarUrl: string;
 
   @FieldMetadata({

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/workspace-member.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/workspace-member.object-metadata.ts
@@ -60,7 +60,6 @@ export class WorkspaceMemberObjectMetadata extends BaseObjectMetadata {
     description: 'Workspace member avatar',
     icon: 'IconFileUpload',
   })
-  @IsNullable()
   avatarUrl: string;
 
   @FieldMetadata({


### PR DESCRIPTION
# Context

This PR addresses the solving of the issue where attempting to remove a profile picture resulted in an Internal Server Error.
This shall improve user experience when editing his profile settings.

(Fixes #4257)


# Cause

Violation of not-null contraint for "avatarUrl" column in workspace-meber relationship by setting an avatarUrl field to _null_ in _updateOneRecordInput()_. 

_Screen Capture from local setup server's console:_

![Captura de ecrã 2024-03-03 171605](https://github.com/twentyhq/twenty/assets/126079162/37709cec-2125-4470-9490-89ccdac3fb23)

This object was missing nullable property when defining its metadata, which was conflicting with what was defined in the correspondig DTO.


_Screen Capture from  twenty-server/src/core/user/dtos/workspace-member.dto.ts:_

![image](https://github.com/twentyhq/twenty/assets/126079162/ed5855f6-b8ac-4f7a-b618-5512ec230341)


# Implementation & Outcome

- Adding isNullable() to workspace-member object FieldMetadata "Avatar Url":
  - Now, there will be no problems when addressing null value to this field, or errors appearing in the console.

- Implementing exception handling, to handle errors during avatar removal: 
  - In case of an error, it is going to be handled, and will smoothly show up a message telling the user the profile picture removal was not succesfull.

_Video adressing succesfull removal:_

https://github.com/twentyhq/twenty/assets/126079162/bed00a15-6f0a-4e88-b9df-dd3fc6631164



