### PR TITLE
TextInput height fix

### DIFF
--- a/packages/twenty-front/src/modules/ui/input/components/TextInput.tsx
+++ b/packages/twenty-front/src/modules/ui/input/components/TextInput.tsx
@@ -60,15 +60,15 @@ const StyledInput = styled.input<Pick<TextInputComponentProps, 'fullWidth'>>`
   border-bottom-left-radius: ${({ theme }) => theme.border.radius.sm};
   border-right: none;
   border-top-left-radius: ${({ theme }) => theme.border.radius.sm};
+  box-sizing: border-box;
   color: ${({ theme }) => theme.font.color.primary};
   display: flex;
   flex-grow: 1;
   font-family: ${({ theme }) => theme.font.family};
-
   font-weight: ${({ theme }) => theme.font.weight.regular};
+  height: 32px;
   outline: none;
   padding: ${({ theme }) => theme.spacing(2)};
-
   width: 100%;
 
   &::placeholder,


### PR DESCRIPTION
Before:
<img width="517" alt="Screenshot 2024-03-05 at 12 05 02 pm" src="https://github.com/twentyhq/twenty/assets/101299667/9b0d940b-ed91-475b-87cc-a8372276bd45">
<img width="677" alt="Screenshot 2024-03-05 at 12 05 50 pm" src="https://github.com/twentyhq/twenty/assets/101299667/b95c68d6-1b51-4ac4-92e5-a369b7a017c7">

After:
- Changed TextInput component to 32px:
<img width="734" alt="Screenshot 2024-03-05 at 11 58 40 am" src="https://github.com/twentyhq/twenty/assets/101299667/b6e8adce-d568-4ad1-b490-b714161d416e">
- Changed box-sizing to `box-sizing: border-box` to prevent overflow and for consistency with button elements
<img width="705" alt="Screenshot 2024-03-05 at 12 02 36 pm" src="https://github.com/twentyhq/twenty/assets/101299667/85f56b79-e18d-49d6-939a-2844cc118790">
