### PR TITLE
fix: updated NavigationDrawerItem icon stroke width from sm to md

### DIFF
--- a/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/NavigationDrawerItem.tsx
+++ b/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/NavigationDrawerItem.tsx
@@ -164,7 +164,7 @@ export const NavigationDrawerItem = ({
       danger={danger}
       soon={soon}
     >
-      {Icon && <Icon size={theme.icon.size.md} stroke={theme.icon.stroke.sm} />}
+      {Icon && <Icon size={theme.icon.size.md} stroke={theme.icon.stroke.md} />}
       <StyledItemLabel>{label}</StyledItemLabel>
       {soon && <StyledSoonPill>Soon</StyledSoonPill>}
       {!!count && <StyledItemCount>{count}</StyledItemCount>}


### PR DESCRIPTION
Changed `stroke` prop of `<Icon />` component from sm to md for `<NavigationDrawerItem />`. This PR closes https://github.com/twentyhq/twenty/issues/4321.

Before:
<img width="231" alt="Screenshot 2024-03-06 at 2 58 10 PM" src="https://github.com/twentyhq/twenty/assets/51870531/80deb3fa-5311-4350-bb77-e9a75b69bbff" /> <img width="231" alt="Screenshot 2024-03-06 at 2 57 36 PM" src="https://github.com/twentyhq/twenty/assets/51870531/15e90151-7ed4-41bf-af5c-3aac636f222e" />
After:
<img width="231" alt="Screenshot 2024-03-06 at 2 58 20 PM" src="https://github.com/twentyhq/twenty/assets/51870531/22935e45-3625-4c5d-ab95-2f8349ac6adb" /> <img width="231" alt="Screenshot 2024-03-06 at 2 57 48 PM" src="https://github.com/twentyhq/twenty/assets/51870531/ad942a0a-80e6-45f8-b0d0-1deac2b6fae1" />
