### PR TITLE
Improve performances of metadata endpoint

### DIFF
--- a/packages/twenty-front/src/modules/object-metadata/graphql/queries.ts
+++ b/packages/twenty-front/src/modules/object-metadata/graphql/queries.ts
@@ -72,7 +72,6 @@ export const FIND_MANY_OBJECT_METADATA_ITEMS = gql`
               startCursor
               endCursor
             }
-            totalCount
           }
         }
       }
@@ -82,7 +81,6 @@ export const FIND_MANY_OBJECT_METADATA_ITEMS = gql`
         startCursor
         endCursor
       }
-      totalCount
     }
   }
 `;

--- a/packages/twenty-front/src/modules/object-metadata/hooks/__mocks__/useFindManyObjectMetadataItems.ts
+++ b/packages/twenty-front/src/modules/object-metadata/hooks/__mocks__/useFindManyObjectMetadataItems.ts
@@ -72,7 +72,6 @@ export const query = gql`
               startCursor
               endCursor
             }
-            totalCount
           }
         }
       }
@@ -82,7 +81,6 @@ export const query = gql`
         startCursor
         endCursor
       }
-      totalCount
     }
   }
 `;

--- a/packages/twenty-server/src/metadata/field-metadata/field-metadata.module.ts
+++ b/packages/twenty-server/src/metadata/field-metadata/field-metadata.module.ts
@@ -43,7 +43,6 @@ import { UpdateFieldInput } from './dtos/update-field.input';
           CreateDTOClass: CreateFieldInput,
           UpdateDTOClass: UpdateFieldInput,
           ServiceClass: FieldMetadataService,
-          enableTotalCount: true,
           pagingStrategy: PagingStrategies.CURSOR,
           read: {
             defaultSort: [{ field: 'id', direction: SortDirection.DESC }],

--- a/packages/twenty-server/src/metadata/object-metadata/object-metadata.module.ts
+++ b/packages/twenty-server/src/metadata/object-metadata/object-metadata.module.ts
@@ -44,7 +44,6 @@ import { ObjectMetadataDTO } from './dtos/object-metadata.dto';
           CreateDTOClass: CreateObjectInput,
           UpdateDTOClass: UpdateObjectInput,
           ServiceClass: ObjectMetadataService,
-          enableTotalCount: true,
           pagingStrategy: PagingStrategies.CURSOR,
           read: {
             defaultSort: [{ field: 'id', direction: SortDirection.DESC }],

--- a/packages/twenty-server/src/metadata/relation-metadata/relation-metadata.module.ts
+++ b/packages/twenty-server/src/metadata/relation-metadata/relation-metadata.module.ts
@@ -38,7 +38,6 @@ import { RelationMetadataDTO } from './dtos/relation-metadata.dto';
           DTOClass: RelationMetadataDTO,
           ServiceClass: RelationMetadataService,
           CreateDTOClass: CreateRelationInput,
-          enableTotalCount: true,
           pagingStrategy: PagingStrategies.CURSOR,
           create: { many: { disabled: true } },
           update: { disabled: true },


### PR DESCRIPTION
I have investigated the performances of /metadata endpoint which is used to load all metadata:
1) we are missing indexes, I have added them directly on production database and created the following ticket ticket here with follow ups (good first issue): https://github.com/twentyhq/twenty/issues/4346
2) totalCount feature is forcing a lot of count requests (one by field, one by object), even with index each requests takes 10ms. This is ~500ms and we don't actually use it in the front
