### PR TITLE
[messaging] remove partial sync retry and fix missing datasource error

### DIFF
--- a/packages/twenty-server/src/integrations/message-queue/jobs.module.ts
+++ b/packages/twenty-server/src/integrations/message-queue/jobs.module.ts
@@ -33,6 +33,7 @@ import { UserWorkspaceModule } from 'src/core/user-workspace/user-workspace.modu
 import { StripeModule } from 'src/core/billing/stripe/stripe.module';
 import { Workspace } from 'src/core/workspace/workspace.entity';
 import { FeatureFlagEntity } from 'src/core/feature-flag/feature-flag.entity';
+import { DataSourceEntity } from 'src/metadata/data-source/data-source.entity';
 
 @Module({
   imports: [
@@ -51,6 +52,7 @@ import { FeatureFlagEntity } from 'src/core/feature-flag/feature-flag.entity';
     ThreadCleanerModule,
     TypeORMModule,
     TypeOrmModule.forFeature([Workspace, FeatureFlagEntity], 'core'),
+    TypeOrmModule.forFeature([DataSourceEntity], 'metadata'),
     UserModule,
     UserWorkspaceModule,
     WorkspaceDataSourceModule,

--- a/packages/twenty-server/src/workspace/messaging/commands/crons/fetch-all-workspaces-messages.cron.pattern.ts
+++ b/packages/twenty-server/src/workspace/messaging/commands/crons/fetch-all-workspaces-messages.cron.pattern.ts
@@ -1,1 +1,1 @@
-export const fetchAllWorkspacesMessagesCronPattern = '*/10 * * * *';
+export const fetchAllWorkspacesMessagesCronPattern = '*/1 * * * *';

--- a/packages/twenty-server/src/workspace/messaging/commands/crons/fetch-all-workspaces-messages.cron.pattern.ts
+++ b/packages/twenty-server/src/workspace/messaging/commands/crons/fetch-all-workspaces-messages.cron.pattern.ts
@@ -1,1 +1,1 @@
-export const fetchAllWorkspacesMessagesCronPattern = '*/1 * * * *';
+export const fetchAllWorkspacesMessagesCronPattern = '*/10 * * * *';

--- a/packages/twenty-server/src/workspace/messaging/commands/crons/fetch-all-workspaces-messages.job.ts
+++ b/packages/twenty-server/src/workspace/messaging/commands/crons/fetch-all-workspaces-messages.job.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
-import { Repository } from 'typeorm';
+import { Repository, In } from 'typeorm';
 
 import { MessageQueueJob } from 'src/integrations/message-queue/interfaces/message-queue-job.interface';
 
@@ -13,6 +13,7 @@ import {
   GmailPartialSyncJobData,
   GmailPartialSyncJob,
 } from 'src/workspace/messaging/jobs/gmail-partial-sync.job';
+import { DataSourceEntity } from 'src/metadata/data-source/data-source.entity';
 
 @Injectable()
 export class FetchAllWorkspacesMessagesJob
@@ -23,6 +24,8 @@ export class FetchAllWorkspacesMessagesJob
   constructor(
     @InjectRepository(Workspace, 'core')
     private readonly workspaceRepository: Repository<Workspace>,
+    @InjectRepository(DataSourceEntity, 'metadata')
+    private readonly dataSourceRepository: Repository<DataSourceEntity>,
     @Inject(MessageQueue.messagingQueue)
     private readonly messageQueueService: MessageQueueService,
     private readonly connectedAccountService: ConnectedAccountService,
@@ -38,35 +41,33 @@ export class FetchAllWorkspacesMessagesJob
       })
     ).map((workspace) => workspace.id);
 
-    for (const workspaceId of workspaceIds) {
+    const dataSources = await this.dataSourceRepository.find({
+      where: {
+        workspaceId: In(workspaceIds),
+      },
+    });
+
+    const workspaceIdsWithDataSources = new Set(
+      dataSources.map((dataSource) => dataSource.workspaceId),
+    );
+
+    for (const workspaceId of workspaceIdsWithDataSources) {
       await this.fetchWorkspaceMessages(workspaceId);
     }
   }
 
   private async fetchWorkspaceMessages(workspaceId: string): Promise<void> {
-    try {
-      const connectedAccounts =
-        await this.connectedAccountService.getAll(workspaceId);
+    const connectedAccounts =
+      await this.connectedAccountService.getAll(workspaceId);
 
-      for (const connectedAccount of connectedAccounts) {
-        await this.messageQueueService.add<GmailPartialSyncJobData>(
-          GmailPartialSyncJob.name,
-          {
-            workspaceId,
-            connectedAccountId: connectedAccount.id,
-          },
-          {
-            retryLimit: 2,
-          },
-        );
-      }
-    } catch (error) {
-      this.logger.error(
-        `Error while fetching workspace messages for workspace ${workspaceId}`,
+    for (const connectedAccount of connectedAccounts) {
+      await this.messageQueueService.add<GmailPartialSyncJobData>(
+        GmailPartialSyncJob.name,
+        {
+          workspaceId,
+          connectedAccountId: connectedAccount.id,
+        },
       );
-      this.logger.error(error);
-
-      return;
     }
   }
 }

--- a/packages/twenty-server/src/workspace/messaging/commands/crons/fetch-all-workspaces-messages.job.ts
+++ b/packages/twenty-server/src/workspace/messaging/commands/crons/fetch-all-workspaces-messages.job.ts
@@ -57,17 +57,26 @@ export class FetchAllWorkspacesMessagesJob
   }
 
   private async fetchWorkspaceMessages(workspaceId: string): Promise<void> {
-    const connectedAccounts =
-      await this.connectedAccountService.getAll(workspaceId);
+    try {
+      const connectedAccounts =
+        await this.connectedAccountService.getAll(workspaceId);
 
-    for (const connectedAccount of connectedAccounts) {
-      await this.messageQueueService.add<GmailPartialSyncJobData>(
-        GmailPartialSyncJob.name,
-        {
-          workspaceId,
-          connectedAccountId: connectedAccount.id,
-        },
+      for (const connectedAccount of connectedAccounts) {
+        await this.messageQueueService.add<GmailPartialSyncJobData>(
+          GmailPartialSyncJob.name,
+          {
+            workspaceId,
+            connectedAccountId: connectedAccount.id,
+          },
+        );
+      }
+    } catch (error) {
+      this.logger.error(
+        `Error while fetching workspace messages for workspace ${workspaceId}`,
       );
+      this.logger.error(error);
+
+      return;
     }
   }
 }

--- a/packages/twenty-server/src/workspace/messaging/commands/gmail-partial-sync.command.ts
+++ b/packages/twenty-server/src/workspace/messaging/commands/gmail-partial-sync.command.ts
@@ -56,9 +56,6 @@ export class GmailPartialSyncCommand extends CommandRunner {
           workspaceId,
           connectedAccountId: connectedAccount.id,
         },
-        {
-          retryLimit: 2,
-        },
       );
     }
   }

--- a/packages/twenty-server/src/workspace/messaging/services/fetch-messages-by-batches.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/services/fetch-messages-by-batches.service.ts
@@ -187,8 +187,6 @@ export class FetchMessagesByBatchesService {
     const formattedResponse = Promise.all(
       parsedResponses.map(async (message: GmailMessageParsedResponse) => {
         if (message.error) {
-          console.log('Error', message.error);
-
           errors.push(message.error);
 
           return;

--- a/packages/twenty-server/src/workspace/messaging/services/gmail-partial-sync.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/services/gmail-partial-sync.service.ts
@@ -213,6 +213,13 @@ export class GmailPartialSyncService {
     }
 
     if (errors.length) {
+      this.logger.error(
+        `Error fetching messages for ${connectedAccountId} in workspace ${workspaceId} during partial-sync: ${JSON.stringify(
+          errors,
+          null,
+          2,
+        )}`,
+      );
       const errorsCanBeIgnored = errors.every((error) => error.code === 404);
       const errorsShouldBeRetried = errors.some((error) => error.code === 429);
 

--- a/packages/twenty-server/src/workspace/messaging/services/gmail-partial-sync.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/services/gmail-partial-sync.service.ts
@@ -213,7 +213,7 @@ export class GmailPartialSyncService {
     }
 
     if (errors.length) {
-      console.error(
+      this.logger.error(
         `Error fetching messages for ${connectedAccountId} in workspace ${workspaceId} during partial-sync: ${JSON.stringify(
           errors,
           null,

--- a/packages/twenty-server/src/workspace/messaging/services/gmail-partial-sync.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/services/gmail-partial-sync.service.ts
@@ -220,11 +220,11 @@ export class GmailPartialSyncService {
           2,
         )}`,
       );
-      const errorsAreOnly404 = errors.every(
+      const noErrorShouldThrow = errors.every(
         (error) => error.code === 404 || error.code === 429,
       );
 
-      if (errorsAreOnly404) {
+      if (noErrorShouldThrow) {
         return;
       }
 

--- a/packages/twenty-server/src/workspace/messaging/services/gmail-partial-sync.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/services/gmail-partial-sync.service.ts
@@ -220,7 +220,9 @@ export class GmailPartialSyncService {
           2,
         )}`,
       );
-      const errorsAreOnly404 = errors.every((error) => error.code === 404);
+      const errorsAreOnly404 = errors.every(
+        (error) => error.code === 404 || error.code === 429,
+      );
 
       if (errorsAreOnly404) {
         return;

--- a/packages/twenty-server/src/workspace/messaging/services/gmail-partial-sync.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/services/gmail-partial-sync.service.ts
@@ -213,12 +213,21 @@ export class GmailPartialSyncService {
     }
 
     if (errors.length) {
-      throw new Error(
-        `Error fetching messages for ${connectedAccountId} in workspace ${workspaceId} during partial-sync with errors: ${JSON.stringify(
+      console.error(
+        `Error fetching messages for ${connectedAccountId} in workspace ${workspaceId} during partial-sync: ${JSON.stringify(
           errors,
           null,
           2,
         )}`,
+      );
+      const errorsAreOnly404 = errors.every((error) => error.code === 404);
+
+      if (errorsAreOnly404) {
+        return;
+      }
+
+      throw new Error(
+        `Error fetching messages for ${connectedAccountId} in workspace ${workspaceId} during partial-sync`,
       );
     }
     startTime = Date.now();

--- a/packages/twenty-server/src/workspace/messaging/services/gmail-partial-sync.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/services/gmail-partial-sync.service.ts
@@ -213,24 +213,18 @@ export class GmailPartialSyncService {
     }
 
     if (errors.length) {
-      this.logger.error(
-        `Error fetching messages for ${connectedAccountId} in workspace ${workspaceId} during partial-sync: ${JSON.stringify(
-          errors,
-          null,
-          2,
-        )}`,
-      );
-      const noErrorShouldThrow = errors.every(
-        (error) => error.code === 404 || error.code === 429,
-      );
+      const errorsCanBeIgnored = errors.every((error) => error.code === 404);
+      const errorsShouldBeRetried = errors.some((error) => error.code === 429);
 
-      if (noErrorShouldThrow) {
+      if (errorsShouldBeRetried) {
         return;
       }
 
-      throw new Error(
-        `Error fetching messages for ${connectedAccountId} in workspace ${workspaceId} during partial-sync`,
-      );
+      if (!errorsCanBeIgnored) {
+        throw new Error(
+          `Error fetching messages for ${connectedAccountId} in workspace ${workspaceId} during partial-sync`,
+        );
+      }
     }
     startTime = Date.now();
 

--- a/packages/twenty-server/src/workspace/messaging/services/gmail-partial-sync.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/services/gmail-partial-sync.service.ts
@@ -214,7 +214,11 @@ export class GmailPartialSyncService {
 
     if (errors.length) {
       throw new Error(
-        `Error fetching messages for ${connectedAccountId} in workspace ${workspaceId} during partial-sync`,
+        `Error fetching messages for ${connectedAccountId} in workspace ${workspaceId} during partial-sync with errors: ${JSON.stringify(
+          errors,
+          null,
+          2,
+        )}`,
       );
     }
     startTime = Date.now();


### PR DESCRIPTION
## Context
Last PR introduced the wrong fix. Workspaces without Datasources do exist but we should not expect them to have connected accounts.
Also removing the retry on partial sync as this introduces more issues with rate limiting until we handle all the errors properly, this should be fine since this is run inside a cron that is executed fairly often 
<img width="1512" alt="Screenshot 2024-03-08 at 12 55 23" src="https://github.com/twentyhq/twenty/assets/1834158/ef247bff-bdaa-4d9c-9283-4d5c58361227">

