### PR TITLE
Fix consistency issuesin relation onDelete behavior while creating a new relation

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/show-page/components/ShowPageRightContainer.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/show-page/components/ShowPageRightContainer.tsx
@@ -9,7 +9,6 @@ import { ObjectTasks } from '@/activities/tasks/components/ObjectTasks';
 import { Timeline } from '@/activities/timeline/components/Timeline';
 import { TimelineQueryEffect } from '@/activities/timeline/components/TimelineQueryEffect';
 import { ActivityTargetableObject } from '@/activities/types/ActivityTargetableEntity';
-import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
 import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
 import {
   IconCalendarEvent,
@@ -65,11 +64,6 @@ export const ShowPageRightContainer = ({
   const { getActiveTabIdState } = useTabList(TAB_LIST_COMPONENT_ID);
   const activeTabId = useRecoilValue(getActiveTabIdState());
 
-  const { objectMetadataItem: targetableObjectMetadataItem } =
-    useObjectMetadataItem({
-      objectNameSingular: targetableObject.targetObjectNameSingular,
-    });
-
   const shouldDisplayCalendarTab = useIsFeatureEnabled('IS_CALENDAR_ENABLED');
   const shouldDisplayEmailsTab =
     (emails &&
@@ -101,7 +95,6 @@ export const ShowPageRightContainer = ({
       title: 'Files',
       Icon: IconPaperclip,
       hide: !notes,
-      disabled: targetableObjectMetadataItem.isCustom,
     },
     {
       id: 'emails',

--- a/packages/twenty-server/src/metadata/object-metadata/object-metadata.service.ts
+++ b/packages/twenty-server/src/metadata/object-metadata/object-metadata.service.ts
@@ -397,6 +397,7 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
                 createdObjectMetadata,
               ),
               referencedTableColumnName: 'id',
+              onDelete: RelationOnDeleteAction.CASCADE,
             },
           ],
         },

--- a/packages/twenty-server/src/metadata/relation-metadata/relation-metadata.service.ts
+++ b/packages/twenty-server/src/metadata/relation-metadata/relation-metadata.service.ts
@@ -26,6 +26,7 @@ import { generateMigrationName } from 'src/metadata/workspace-migration/utils/ge
 import {
   RelationMetadataEntity,
   RelationMetadataType,
+  RelationOnDeleteAction,
 } from './relation-metadata.entity';
 
 @Injectable()
@@ -209,6 +210,7 @@ export class RelationMetadataService extends TypeOrmQueryService<RelationMetadat
               isUnique:
                 relationMetadataInput.relationType ===
                 RelationMetadataType.ONE_TO_ONE,
+              onDelete: RelationOnDeleteAction.SET_NULL,
             },
           ],
         },

--- a/packages/twenty-server/src/workspace/workspace-migration-runner/utils/convert-on-delete-action-to-on-delete.util.ts
+++ b/packages/twenty-server/src/workspace/workspace-migration-runner/utils/convert-on-delete-action-to-on-delete.util.ts
@@ -4,7 +4,7 @@ export const convertOnDeleteActionToOnDelete = (
   onDeleteAction: RelationOnDeleteAction | undefined,
 ): 'CASCADE' | 'SET NULL' | 'RESTRICT' | 'NO ACTION' | undefined => {
   if (!onDeleteAction) {
-    return;
+    return 'SET NULL';
   }
 
   switch (onDeleteAction) {


### PR DESCRIPTION
I have detected consistency issues between the onDelete behavior set in the metadata vs the one applied on postgres schema for:
- custom relations
- attachment relation on any custom object

I'm also enabling Files tab for custom object as the attachment relation is now fixed