### PR TITLE
feat: sync standard id

### DIFF
--- a/packages/twenty-server/src/database/typeorm/metadata/migrations/1709894431938-addStandardId.ts
+++ b/packages/twenty-server/src/database/typeorm/metadata/migrations/1709894431938-addStandardId.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddStandardId1709894431938 implements MigrationInterface {
+  name = 'AddStandardId1709894431938';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "metadata"."objectMetadata" ADD "standardId" uuid`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "metadata"."fieldMetadata" ADD "standardId" uuid`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "metadata"."fieldMetadata" DROP COLUMN "standardId"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "metadata"."objectMetadata" DROP COLUMN "standardId"`,
+    );
+  }
+}

--- a/packages/twenty-server/src/metadata/field-metadata/field-metadata.entity.ts
+++ b/packages/twenty-server/src/metadata/field-metadata/field-metadata.entity.ts
@@ -51,6 +51,9 @@ export class FieldMetadataEntity<
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
+  @Column({ nullable: true, type: 'uuid' })
+  standardId: string | null;
+
   @Column({ nullable: false, type: 'uuid' })
   objectMetadataId: string;
 

--- a/packages/twenty-server/src/metadata/object-metadata/object-metadata.entity.ts
+++ b/packages/twenty-server/src/metadata/object-metadata/object-metadata.entity.ts
@@ -25,6 +25,9 @@ export class ObjectMetadataEntity implements ObjectMetadataInterface {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
+  @Column({ nullable: true, type: 'uuid' })
+  standardId: string | null;
+
   @Column({ nullable: false, type: 'uuid' })
   dataSourceId: string;
 

--- a/packages/twenty-server/src/metadata/object-metadata/object-metadata.service.ts
+++ b/packages/twenty-server/src/metadata/object-metadata/object-metadata.service.ts
@@ -35,6 +35,14 @@ import { computeObjectTargetTable } from 'src/workspace/utils/compute-object-tar
 import { DeleteOneObjectInput } from 'src/metadata/object-metadata/dtos/delete-object.input';
 import { RelationToDelete } from 'src/metadata/relation-metadata/types/relation-to-delete';
 import { generateMigrationName } from 'src/metadata/workspace-migration/utils/generate-migration-name.util';
+import {
+  activityTargetStandardFieldIds,
+  attachmentStandardFieldIds,
+  baseObjectStandardFieldIds,
+  customObjectStandardFieldIds,
+  favoriteStandardFieldIds,
+} from 'src/workspace/workspace-sync-metadata/constants/standard-field-ids';
+import { createDeterministicUuid } from 'src/workspace/workspace-sync-metadata/utils/create-deterministic-uuid.util';
 
 import { ObjectMetadataEntity } from './object-metadata.entity';
 
@@ -229,6 +237,7 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
         // created with default values which is not supported yet by workspace migrations.
         [
           {
+            standardId: baseObjectStandardFieldIds.id,
             type: FieldMetadataType.UUID,
             name: 'id',
             label: 'Id',
@@ -245,6 +254,7 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
             defaultValue: { type: 'uuid' },
           },
           {
+            standardId: customObjectStandardFieldIds.name,
             type: FieldMetadataType.TEXT,
             name: 'name',
             label: 'Name',
@@ -260,6 +270,7 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
             defaultValue: { value: 'Untitled' },
           },
           {
+            standardId: baseObjectStandardFieldIds.createdAt,
             type: FieldMetadataType.DATE_TIME,
             name: 'createdAt',
             label: 'Creation date',
@@ -275,6 +286,7 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
             defaultValue: { type: 'now' },
           },
           {
+            standardId: baseObjectStandardFieldIds.updatedAt,
             type: FieldMetadataType.DATE_TIME,
             name: 'updatedAt',
             label: 'Update date',
@@ -291,6 +303,7 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
             defaultValue: { type: 'now' },
           },
           {
+            standardId: customObjectStandardFieldIds.position,
             type: FieldMetadataType.POSITION,
             name: 'position',
             label: 'Position',
@@ -587,6 +600,7 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
       await this.fieldMetadataRepository.save([
         // FROM
         {
+          standardId: customObjectStandardFieldIds.activityTargets,
           objectMetadataId: createdObjectMetadata.id,
           workspaceId: workspaceId,
           isCustom: false,
@@ -601,6 +615,7 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
         },
         // TO
         {
+          standardId: activityTargetStandardFieldIds.custom,
           objectMetadataId: activityTargetObjectMetadata.id,
           workspaceId: workspaceId,
           isCustom: false,
@@ -615,6 +630,9 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
         },
         // Foreign key
         {
+          standardId: createDeterministicUuid(
+            activityTargetStandardFieldIds.custom,
+          ),
           objectMetadataId: activityTargetObjectMetadata.id,
           workspaceId: workspaceId,
           isCustom: false,
@@ -681,6 +699,7 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
       await this.fieldMetadataRepository.save([
         // FROM
         {
+          standardId: customObjectStandardFieldIds.attachments,
           objectMetadataId: createdObjectMetadata.id,
           workspaceId: workspaceId,
           isCustom: false,
@@ -695,6 +714,7 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
         },
         // TO
         {
+          standardId: attachmentStandardFieldIds.custom,
           objectMetadataId: attachmentObjectMetadata.id,
           workspaceId: workspaceId,
           isCustom: false,
@@ -709,6 +729,9 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
         },
         // Foreign key
         {
+          standardId: createDeterministicUuid(
+            attachmentStandardFieldIds.custom,
+          ),
           objectMetadataId: attachmentObjectMetadata.id,
           workspaceId: workspaceId,
           isCustom: false,
@@ -773,6 +796,7 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
       await this.fieldMetadataRepository.save([
         // FROM
         {
+          standardId: customObjectStandardFieldIds.favorites,
           objectMetadataId: createdObjectMetadata.id,
           workspaceId: workspaceId,
           isCustom: false,
@@ -788,6 +812,7 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
         },
         // TO
         {
+          standardId: favoriteStandardFieldIds.custom,
           objectMetadataId: favoriteObjectMetadata.id,
           workspaceId: workspaceId,
           isCustom: false,
@@ -802,6 +827,7 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
         },
         // Foreign key
         {
+          standardId: createDeterministicUuid(favoriteStandardFieldIds.custom),
           objectMetadataId: favoriteObjectMetadata.id,
           workspaceId: workspaceId,
           isCustom: false,

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/commands/add-standard-id.command.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/commands/add-standard-id.command.ts
@@ -1,0 +1,157 @@
+import { Logger } from '@nestjs/common';
+import { InjectDataSource } from '@nestjs/typeorm';
+
+import { Command, CommandRunner } from 'nest-commander';
+import { DataSource } from 'typeorm';
+
+import { ObjectMetadataEntity } from 'src/metadata/object-metadata/object-metadata.entity';
+import { FieldMetadataEntity } from 'src/metadata/field-metadata/field-metadata.entity';
+import { standardObjectMetadataDefinitions } from 'src/workspace/workspace-sync-metadata/standard-objects';
+import { StandardObjectFactory } from 'src/workspace/workspace-sync-metadata/factories/standard-object.factory';
+import { computeStandardObject } from 'src/workspace/workspace-sync-metadata/utils/compute-standard-object.util';
+import { StandardFieldFactory } from 'src/workspace/workspace-sync-metadata/factories/standard-field.factory';
+import { CustomObjectMetadata } from 'src/workspace/workspace-sync-metadata/custom-objects/custom.object-metadata';
+
+@Command({
+  name: 'workspace:add-standard-id',
+  description: 'Add standard id to all metadata objects and fields',
+})
+export class AddStandardIdCommand extends CommandRunner {
+  private readonly logger = new Logger(AddStandardIdCommand.name);
+
+  constructor(
+    @InjectDataSource('metadata')
+    private readonly metadataDataSource: DataSource,
+    private readonly standardObjectFactory: StandardObjectFactory,
+    private readonly standardFieldFactory: StandardFieldFactory,
+  ) {
+    super();
+  }
+
+  async run(): Promise<void> {
+    const queryRunner = this.metadataDataSource.createQueryRunner();
+
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+
+    const manager = queryRunner.manager;
+
+    this.logger.log('Adding standardId to metadata objects and fields');
+
+    try {
+      const standardObjectMetadataCollection =
+        this.standardObjectFactory.create(
+          standardObjectMetadataDefinitions,
+          {
+            // We don't need to provide the workspace id and data source id as we're only adding standardId
+            workspaceId: '',
+            dataSourceId: '',
+          },
+          {
+            IS_BLOCKLIST_ENABLED: true,
+            IS_CALENDAR_ENABLED: true,
+            IS_SELF_BILLING_ENABLED: true,
+          },
+        );
+      const standardFieldMetadataCollection = this.standardFieldFactory.create(
+        CustomObjectMetadata,
+        {
+          workspaceId: '',
+          dataSourceId: '',
+        },
+        {
+          IS_BLOCKLIST_ENABLED: true,
+          IS_CALENDAR_ENABLED: true,
+          IS_SELF_BILLING_ENABLED: true,
+        },
+      );
+
+      const objectMetadataRepository =
+        manager.getRepository(ObjectMetadataEntity);
+      const fieldMetadataRepository =
+        manager.getRepository(FieldMetadataEntity);
+
+      /**
+       * Update all object metadata with standard id
+       */
+      const updateObjectMetadataCollection: Partial<ObjectMetadataEntity>[] =
+        [];
+      const updateFieldMetadataCollection: Partial<FieldMetadataEntity>[] = [];
+      const originalObjectMetadataCollection =
+        await objectMetadataRepository.find({
+          where: {
+            fields: { isCustom: false },
+          },
+          relations: ['fields'],
+        });
+      const customObjectMetadataCollection =
+        originalObjectMetadataCollection.filter(
+          (metadata) => metadata.isCustom,
+        );
+      const standardObjectMetadataMap = new Map(
+        standardObjectMetadataCollection.map((metadata) => [
+          metadata.nameSingular,
+          metadata,
+        ]),
+      );
+
+      for (const originalObjectMetadata of originalObjectMetadataCollection) {
+        const standardObjectMetadata = standardObjectMetadataMap.get(
+          originalObjectMetadata.nameSingular,
+        );
+
+        if (!standardObjectMetadata && !originalObjectMetadata.isCustom) {
+          continue;
+        }
+
+        const computedStandardObjectMetadata = computeStandardObject(
+          !standardObjectMetadata
+            ? {
+                ...originalObjectMetadata,
+                fields: standardFieldMetadataCollection,
+              }
+            : standardObjectMetadata,
+          originalObjectMetadata,
+          customObjectMetadataCollection,
+        );
+
+        if (
+          !originalObjectMetadata.isCustom &&
+          !originalObjectMetadata.standardId
+        ) {
+          updateObjectMetadataCollection.push({
+            id: originalObjectMetadata.id,
+            standardId: computedStandardObjectMetadata.standardId,
+          });
+        }
+
+        for (const fieldMetadata of originalObjectMetadata.fields) {
+          const standardFieldMetadata =
+            computedStandardObjectMetadata.fields.find(
+              (field) => field.name === fieldMetadata.name,
+            );
+
+          if (!standardFieldMetadata || standardFieldMetadata.isCustom) {
+            continue;
+          }
+
+          updateFieldMetadataCollection.push({
+            id: fieldMetadata.id,
+            standardId: standardFieldMetadata.standardId,
+          });
+        }
+      }
+
+      await objectMetadataRepository.save(updateObjectMetadataCollection);
+
+      await fieldMetadataRepository.save(updateFieldMetadataCollection);
+
+      await queryRunner.commitTransaction();
+    } catch (error) {
+      await queryRunner.rollbackTransaction();
+      this.logger.error('Error adding standard id to metadata', error);
+    } finally {
+      await queryRunner.release();
+    }
+  }
+}

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/commands/add-standard-id.command.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/commands/add-standard-id.command.ts
@@ -105,12 +105,10 @@ export class AddStandardIdCommand extends CommandRunner {
         }
 
         const computedStandardObjectMetadata = computeStandardObject(
-          !standardObjectMetadata
-            ? {
-                ...originalObjectMetadata,
-                fields: standardFieldMetadataCollection,
-              }
-            : standardObjectMetadata,
+          standardObjectMetadata ?? {
+            ...originalObjectMetadata,
+            fields: standardFieldMetadataCollection,
+          },
           originalObjectMetadata,
           customObjectMetadataCollection,
         );
@@ -128,10 +126,10 @@ export class AddStandardIdCommand extends CommandRunner {
         for (const fieldMetadata of originalObjectMetadata.fields) {
           const standardFieldMetadata =
             computedStandardObjectMetadata.fields.find(
-              (field) => field.name === fieldMetadata.name,
+              (field) => field.name === fieldMetadata.name && !field.isCustom,
             );
 
-          if (!standardFieldMetadata || standardFieldMetadata.isCustom) {
+          if (!standardFieldMetadata || fieldMetadata.standardId) {
             continue;
           }
 

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/commands/workspace-sync-metadata-commands.module.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/commands/workspace-sync-metadata-commands.module.ts
@@ -4,6 +4,7 @@ import { DataSourceModule } from 'src/metadata/data-source/data-source.module';
 import { WorkspaceSyncMetadataModule } from 'src/workspace/workspace-sync-metadata/workspace-sync-metadata.module';
 import { WorkspaceHealthModule } from 'src/workspace/workspace-health/workspace-health.module';
 import { WorkspaceModule } from 'src/core/workspace/workspace.module';
+import { AddStandardIdCommand } from 'src/workspace/workspace-sync-metadata/commands/add-standard-id.command';
 
 import { SyncWorkspaceMetadataCommand } from './sync-workspace-metadata.command';
 
@@ -16,6 +17,10 @@ import { SyncWorkspaceLoggerService } from './services/sync-workspace-logger.ser
     WorkspaceModule,
     DataSourceModule,
   ],
-  providers: [SyncWorkspaceMetadataCommand, SyncWorkspaceLoggerService],
+  providers: [
+    SyncWorkspaceMetadataCommand,
+    AddStandardIdCommand,
+    SyncWorkspaceLoggerService,
+  ],
 })
 export class WorkspaceSyncMetadataCommandsModule {}

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/comparators/__tests__/workspace-field.comparator.spec.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/comparators/__tests__/workspace-field.comparator.spec.ts
@@ -29,7 +29,12 @@ describe('WorkspaceFieldComparator', () => {
   it('should generate CREATE action for new fields', () => {
     const original = { fields: [] } as any;
     const standard = {
-      fields: [createMockFieldMetadata({ name: 'New Field' })],
+      fields: [
+        createMockFieldMetadata({
+          standardId: 'no-field-1',
+          name: 'New Field',
+        }),
+      ],
     } as any;
 
     const result = comparator.compare(original, standard);
@@ -46,6 +51,7 @@ describe('WorkspaceFieldComparator', () => {
     const original = {
       fields: [
         createMockFieldMetadata({
+          standardId: '1',
           id: '1',
           isNullable: true,
         }),
@@ -54,6 +60,7 @@ describe('WorkspaceFieldComparator', () => {
     const standard = {
       fields: [
         createMockFieldMetadata({
+          standardId: '1',
           isNullable: false,
         }),
       ],
@@ -73,6 +80,7 @@ describe('WorkspaceFieldComparator', () => {
     const original = {
       fields: [
         createMockFieldMetadata({
+          standardId: '1',
           id: '1',
           name: 'Removed Field',
           isActive: true,
@@ -93,10 +101,12 @@ describe('WorkspaceFieldComparator', () => {
 
   it('should not generate any action for identical fields', () => {
     const original = {
-      fields: [createMockFieldMetadata({ id: '1', isActive: true })],
+      fields: [
+        createMockFieldMetadata({ standardId: '1', id: '1', isActive: true }),
+      ],
     } as any;
     const standard = {
-      fields: [createMockFieldMetadata({})],
+      fields: [createMockFieldMetadata({ standardId: '1' })],
     } as any;
 
     const result = comparator.compare(original, standard);

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/comparators/__tests__/workspace-object.comparator.spec.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/comparators/__tests__/workspace-object.comparator.spec.ts
@@ -22,6 +22,7 @@ describe('WorkspaceObjectComparator', () => {
 
   it('should generate CREATE action for new objects', () => {
     const standardObjectMetadata = createMockObjectMetadata({
+      standardId: 'no-object-1',
       description: 'A standard object',
     });
 
@@ -35,10 +36,12 @@ describe('WorkspaceObjectComparator', () => {
 
   it('should generate UPDATE action for objects with differences', () => {
     const originalObjectMetadata = createMockObjectMetadata({
+      standardId: '1',
       id: '1',
       description: 'Original description',
     });
     const standardObjectMetadata = createMockObjectMetadata({
+      standardId: '1',
       description: 'Updated description',
     });
 
@@ -58,10 +61,12 @@ describe('WorkspaceObjectComparator', () => {
 
   it('should generate SKIP action for identical objects', () => {
     const originalObjectMetadata = createMockObjectMetadata({
+      standardId: '1',
       id: '1',
       description: 'Same description',
     });
     const standardObjectMetadata = createMockObjectMetadata({
+      standardId: '1',
       description: 'Same description',
     });
 

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/constants/standard-field-ids.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/constants/standard-field-ids.ts
@@ -1,0 +1,287 @@
+/**
+ * /!\ DO NOT EDIT THE IDS OF THIS FILE /!\
+ * This file contains static ids for standard objects.
+ * These ids are used to identify standard objects in the database and compare them even when renamed.
+ * For readability keys can be edited but the values should not be changed.
+ */
+
+export const activityTargetStandardFieldIds = {
+  activity: '20202020-ca58-478c-a4f5-ae825671c30e',
+  person: '20202020-4afd-4ae7-99c2-de57d795a93f',
+  company: '20202020-7cc0-44a1-8068-f11171fdd02e',
+  opportunity: '20202020-1fc2-4af1-8c91-7901ee0fd38b',
+  custom: '20202020-7f21-442f-94be-32462281b1ca',
+};
+
+export const activityStandardFieldIds = {
+  title: '20202020-24a1-4d94-a071-617f3eeed7b0',
+  body: '20202020-209b-440a-b2a8-043fa36a7d37',
+  type: '20202020-0f2b-4aab-8827-ee5d3f07d993',
+  reminderAt: '20202020-eb06-43e2-ba06-336be0e665a3',
+  dueAt: '20202020-0336-4511-ba79-565b12801bd9',
+  completedAt: '20202020-0f4d-4fca-9f2f-6309d9ecb85f',
+  activityTargets: '20202020-7253-42cb-8586-8cf950e70b79',
+  attachments: '20202020-5547-4197-bc2e-a07dfc4559ca',
+  comments: '20202020-6b2e-4d29-bbd1-ecddb330e71a',
+  author: '20202020-455f-44f2-8e89-1b0ef01cb7fb',
+  assignee: '20202020-4259-48e4-9e77-6b92991906d5',
+};
+
+export const apiKeyStandardFieldIds = {
+  name: '20202020-72e6-4079-815b-436ce8a62f23',
+  expiresAt: '20202020-659b-4241-af59-66515b8e7d40',
+  revokedAt: '20202020-06ab-44b5-8faf-f6e407685001',
+};
+
+export const attachmentStandardFieldIds = {
+  name: '20202020-87a5-48f8-bbf7-ade388825a57',
+  fullPath: '20202020-0d19-453d-8e8d-fbcda8ca3747',
+  type: '20202020-a417-49b8-a40b-f6a7874caa0d',
+  author: '20202020-6501-4ac5-a4ef-b2f8522ef6cd',
+  activity: '20202020-b569-481b-a13f-9b94e47e54fe',
+  person: '20202020-0158-4aa2-965c-5cdafe21ffa2',
+  company: '20202020-ceab-4a28-b546-73b06b4c08d5',
+  opportunity: '20202020-7374-499d-bea3-9354890755b5',
+  custom: '20202020-302d-43b3-9aea-aa4f89282a9f',
+};
+
+export const baseObjectStandardFieldIds = {
+  id: '20202020-eda0-4cee-9577-3eb357e3c22b',
+  createdAt: '20202020-66ac-4502-9975-e4d959c50311',
+  updatedAt: '20202020-d767-4622-bdcf-d8a084834d86',
+};
+
+export const blocklistStandardFieldIds = {
+  handle: '20202020-eef3-44ed-aa32-4641d7fd4a3e',
+  workspaceMember: '20202020-548d-4084-a947-fa20a39f7c06',
+};
+
+export const calendarChannelStandardFieldIds = {
+  connectedAccount: '20202020-95b1-4f44-82dc-61b042ae2414',
+  handle: '20202020-1d08-420a-9aa7-22e0f298232d',
+  visibility: '20202020-1b07-4796-9f01-d626bab7ca4d',
+  isContactAutoCreationEnabled: '20202020-50fb-404b-ba28-369911a3793a',
+  isSyncEnabled: '20202020-fe19-4818-8854-21f7b1b43395',
+  syncCursor: '20202020-bac2-4852-a5cb-7a7898992b70',
+};
+
+export const calendarEventAttendeeStandardFieldIds = {
+  calendarEvent: '20202020-fe3a-401c-b889-af4f4657a861',
+  handle: '20202020-8692-4580-8210-9e09cbd031a7',
+  displayName: '20202020-ee1e-4f9f-8ac1-5c0b2f69691e',
+  isOrganizer: '20202020-66e7-4e00-9e06-d06c92650580',
+  responseStatus: '20202020-cec0-4be8-8fba-c366abc23147',
+  person: '20202020-5761-4842-8186-e1898ef93966',
+  workspaceMember: '20202020-20e4-4591-93ed-aeb17a4dcbd2',
+};
+
+export const calendarEventStandardFieldIds = {
+  title: '20202020-080e-49d1-b21d-9702a7e2525c',
+  isCanceled: '20202020-335b-4e04-b470-43b84b64863c',
+  isFullDay: '20202020-551c-402c-bb6d-dfe9efe86bcb',
+  startsAt: '20202020-2c57-4c75-93c5-2ac950a6ed67',
+  endsAt: '20202020-2554-4ee1-a617-17907f6bab21',
+  externalCreatedAt: '20202020-9f03-4058-a898-346c62181599',
+  externalUpdatedAt: '20202020-b355-4c18-8825-ef42c8a5a755',
+  description: '20202020-52c4-4266-a98f-e90af0b4d271',
+  location: '20202020-641a-4ffe-960d-c3c186d95b17',
+  iCalUID: '20202020-f24b-45f4-b6a3-d2f9fcb98714',
+  conferenceSolution: '20202020-1c3f-4b5a-b526-5411a82179eb',
+  conferenceUri: '20202020-0fc5-490a-871a-2df8a45ab46c',
+  recurringEventExternalId: '20202020-4b96-43d0-8156-4c7a9717635c',
+  eventAttendees: '20202020-e07e-4ccb-88f5-6f3d00458eec',
+};
+
+export const commentStandardFieldIds = {
+  body: '20202020-d5eb-49d2-b3e0-1ed04145ebb7',
+  author: '20202020-2ab1-427e-a981-cf089de3a9bd',
+  activity: '20202020-c8d9-4c30-a35e-dc7f44388070',
+};
+
+export const companyStandardFieldIds = {
+  name: '20202020-4d99-4e2e-a84c-4a27837b1ece',
+  domainName: '20202020-0c28-43d8-8ba5-3659924d3489',
+  address: '20202020-a82a-4ee2-96cc-a18a3259d953',
+  employees: '20202020-8965-464a-8a75-74bafc152a0b',
+  linkedinLink: '20202020-ebeb-4beb-b9ad-6848036fb451',
+  xLink: '20202020-6f64-4fd9-9580-9c1991c7d8c3',
+  annualRecurringRevenue: '20202020-602a-495c-9776-f5d5b11d227b',
+  idealCustomerProfile: '20202020-ba6b-438a-8213-2c5ba28d76a2',
+  position: '20202020-9b4e-462b-991d-a0ee33326454',
+  people: '20202020-3213-4ddf-9494-6422bcff8d7c',
+  accountOwner: '20202020-95b8-4e10-9881-edb5d4765f9d',
+  activityTargets: '20202020-c2a5-4c9b-9d9a-582bcd57fbc8',
+  opportunities: '20202020-add3-4658-8e23-d70dccb6d0ec',
+  favorites: '20202020-4d1d-41ac-b13b-621631298d55',
+  attachments: '20202020-c1b5-4120-b0f0-987ca401ed53',
+};
+
+export const connectedAccountStandardFieldIds = {
+  handle: '20202020-c804-4a50-bb05-b3a9e24f1dec',
+  provider: '20202020-ebb0-4516-befc-a9e95935efd5',
+  accessToken: '20202020-707b-4a0a-8753-2ad42efe1e29',
+  refreshToken: '20202020-532d-48bd-80a5-c4be6e7f6e49',
+  accountOwner: '20202020-3517-4896-afac-b1d0aa362af6',
+  lastSyncHistoryId: '20202020-115c-4a87-b50f-ac4367a971b9',
+  messageChannels: '20202020-24f7-4362-8468-042204d1e445',
+  calendarChannels: '20202020-af4a-47bb-99ec-51911c1d3977',
+};
+
+export const favoriteStandardFieldIds = {
+  position: '20202020-dd26-42c6-8c3c-2a7598c204f6',
+  workspaceMember: '20202020-ce63-49cb-9676-fdc0c45892cd',
+  person: '20202020-c428-4f40-b6f3-86091511c41c',
+  company: '20202020-cff5-4682-8bf9-069169e08279',
+  opportunity: '20202020-dabc-48e1-8318-2781a2b32aa2',
+  custom: '20202020-855a-4bc8-9861-79deef37011f',
+};
+
+export const messageChannelMessageAssociationStandardFieldIds = {
+  messageChannel: '20202020-b658-408f-bd46-3bd2d15d7e52',
+  message: '20202020-da5d-4ac5-8743-342ab0a0336b',
+  messageExternalId: '20202020-37d6-438f-b6fd-6503596c8f34',
+  messageThread: '20202020-fac8-42a8-94dd-44dbc920ae16',
+  messageThreadExternalId: '20202020-35fb-421e-afa0-0b8e8f7f9018',
+};
+
+export const messageChannelStandardFieldIds = {
+  visibility: '20202020-6a6b-4532-9767-cbc61b469453',
+  handle: '20202020-2c96-43c3-93e3-ed6b1acb69bc',
+  connectedAccount: '20202020-49a2-44a4-b470-282c0440d15d',
+  type: '20202020-ae95-42d9-a3f1-797a2ea22122',
+  isContactAutoCreationEnabled: '20202020-fabd-4f14-b7c6-3310f6d132c6',
+  messageChannelMessageAssociations: '20202020-49b8-4766-88fd-75f1e21b3d5f',
+};
+
+export const messageParticipantStandardFieldIds = {
+  message: '20202020-985b-429a-9db9-9e55f4898a2a',
+  role: '20202020-65d1-42f4-8729-c9ec1f52aecd',
+  handle: '20202020-2456-464e-b422-b965a4db4a0b',
+  displayName: '20202020-36dd-4a4f-ac02-228425be9fac',
+  person: '20202020-249d-4e0f-82cd-1b9df5cd3da2',
+  workspaceMember: '20202020-77a7-4845-99ed-1bcbb478be6f',
+};
+
+export const messageThreadStandardFieldIds = {
+  messages: '20202020-3115-404f-aade-e1154b28e35a',
+  messageChannelMessageAssociations: '20202020-314e-40a4-906d-a5d5d6c285f6',
+};
+
+export const messageStandardFieldIds = {
+  headerMessageId: '20202020-72b5-416d-aed8-b55609067d01',
+  messageThread: '20202020-30f2-4ccd-9f5c-e41bb9d26214',
+  direction: '20202020-0203-4118-8e2a-05b9bdae6dab',
+  subject: '20202020-52d1-4036-b9ae-84bd722bb37a',
+  text: '20202020-d2ee-4e7e-89de-9a0a9044a143',
+  receivedAt: '20202020-140a-4a2a-9f86-f13b6a979afc',
+  messageParticipants: '20202020-7cff-4a74-b63c-73228448cbd9',
+  messageChannelMessageAssociations: '20202020-3cef-43a3-82c6-50e7cfbc9ae4',
+};
+
+export const opportunityStandardFieldIds = {
+  name: '20202020-8609-4f65-a2d9-44009eb422b5',
+  amount: '20202020-583e-4642-8533-db761d5fa82f',
+  closeDate: '20202020-527e-44d6-b1ac-c4158d307b97',
+  probability: '20202020-69d4-45f3-9703-690b09fafcf0',
+  stage: '20202020-6f76-477d-8551-28cd65b2b4b9',
+  position: '20202020-806d-493a-bbc6-6313e62958e2',
+  pipelineStep: '20202020-cc8c-4ae7-8d83-25c3addaec5a',
+  pointOfContact: '20202020-8dfb-42fc-92b6-01afb759ed16',
+  company: '20202020-cbac-457e-b565-adece5fc815f',
+  favorites: '20202020-a1c2-4500-aaae-83ba8a0e827a',
+  activityTargets: '20202020-220a-42d6-8261-b2102d6eab35',
+  attachments: '20202020-87c7-4118-83d6-2f4031005209',
+};
+
+export const personStandardFieldIds = {
+  name: '20202020-3875-44d5-8c33-a6239011cab8',
+  email: '20202020-a740-42bb-8849-8980fb3f12e1',
+  linkedinLink: '20202020-f1af-48f7-893b-2007a73dd508',
+  xLink: '20202020-8fc2-487c-b84a-55a99b145cfd',
+  jobTitle: '20202020-b0d0-415a-bef9-640a26dacd9b',
+  phone: '20202020-4564-4b8b-a09f-05445f2e0bce',
+  city: '20202020-5243-4ffb-afc5-2c675da41346',
+  avatarUrl: '20202020-b8a6-40df-961c-373dc5d2ec21',
+  position: '20202020-fcd5-4231-aff5-fff583eaa0b1',
+  company: '20202020-e2f3-448e-b34c-2d625f0025fd',
+  pointOfContactForOpportunities: '20202020-911b-4a7d-b67b-918aa9a5b33a',
+  activityTargets: '20202020-dee7-4b7f-b50a-1f50bd3be452',
+  favorites: '20202020-4073-4117-9cf1-203bcdc91cbd',
+  attachments: '20202020-cd97-451f-87fa-bcb789bdbf3a',
+  messageParticipants: '20202020-498e-4c61-8158-fa04f0638334',
+  calendarEventAttendees: '20202020-52ee-45e9-a702-b64b3753e3a9',
+};
+
+export const pipelineStepStandardFieldIds = {
+  name: '20202020-e10a-4119-9466-97873e86fa47',
+  color: '20202020-4a09-4088-90b8-ce1c72730f43',
+  position: '20202020-44e8-4520-af64-4a3cb37fa0c5',
+  opportunities: '20202020-0442-482a-867f-6d8fd4145ed1',
+};
+
+export const viewFieldStandardFieldIds = {
+  fieldMetadataId: '20202020-135f-4c5b-b361-15f24870473c',
+  isVisible: '20202020-e966-473c-9c18-f00d3347e0ba',
+  size: '20202020-6fab-4bd0-ae72-20f3ee39d581',
+  position: '20202020-19e5-4e4c-8c15-3a96d1fd0650',
+  view: '20202020-e8da-4521-afab-d6d231f9fa18',
+};
+
+export const viewFilterStandardFieldIds = {
+  fieldMetadataId: '20202020-c9aa-4c94-8d0e-9592f5008fb0',
+  operand: '20202020-bd23-48c4-9fab-29d1ffb80310',
+  value: '20202020-1e55-4a1e-a1d2-fefb86a5fce5',
+  displayValue: '20202020-1270-4ebf-9018-c0ec10d5038e',
+  view: '20202020-4f5b-487e-829c-3d881c163611',
+};
+
+export const viewSortStandardFieldIds = {
+  fieldMetadataId: '20202020-8240-4657-aee4-7f0df8e94eca',
+  direction: '20202020-b06e-4eb3-9b58-0a62e5d79836',
+  view: '20202020-bd6c-422b-9167-5c105f2d02c8',
+};
+
+export const viewStandardFieldIds = {
+  name: '20202020-12c6-4f37-b588-c9b9bf57328d',
+  objectMetadataId: '20202020-d6de-4fd5-84dd-47f9e730368b',
+  type: '20202020-dd11-4607-9ec7-c57217262a7f',
+  key: '20202020-298e-49fa-9f4a-7b416b110443',
+  icon: '20202020-1f08-4fd9-929b-cbc07f317166',
+  position: '20202020-e9db-4303-b271-e8250c450172',
+  isCompact: '20202020-674e-4314-994d-05754ea7b22b',
+  viewFields: '20202020-542b-4bdc-b177-b63175d48edf',
+  viewFilters: '20202020-ff23-4154-b63c-21fb36cd0967',
+  viewSorts: '20202020-891b-45c3-9fe1-80a75b4aa043',
+};
+
+export const webhookStandardFieldIds = {
+  targetUrl: '20202020-1229-45a8-8cf4-85c9172aae12',
+  operation: '20202020-15b7-458e-bf30-74770a54410c',
+};
+
+export const workspaceMemberStandardFieldIds = {
+  name: '20202020-e914-43a6-9c26-3603c59065f4',
+  colorScheme: '20202020-66bc-47f2-adac-f2ef7c598b63',
+  locale: '20202020-402e-4695-b169-794fa015afbe',
+  avatarUrl: '20202020-0ced-4c4f-a376-c98a966af3f6',
+  userEmail: '20202020-4c5f-4e09-bebc-9e624e21ecf4',
+  userId: '20202020-75a9-4dfc-bf25-2e4b43e89820',
+  authoredActivities: '20202020-f139-4f13-a82f-a65a8d290a74',
+  assignedActivities: '20202020-5c97-42b6-8ca9-c07622cbb33f',
+  favorites: '20202020-f3c1-4faf-b343-cf7681038757',
+  accountOwnerForCompanies: '20202020-dc29-4bd4-a3c1-29eafa324bee',
+  authoredAttachments: '20202020-000f-4947-917f-1b09851024fe',
+  authoredComments: '20202020-5536-4f59-b837-51c45ef43b05',
+  connectedAccounts: '20202020-e322-4bde-a525-727079b4a100',
+  messageParticipants: '20202020-8f99-48bc-a5eb-edd33dd54188',
+  blocklist: '20202020-6cb2-4161-9f29-a4b7f1283859',
+  calendarEventAttendees: '20202020-0dbc-4841-9ce1-3e793b5b3512',
+};
+
+export const customObjectStandardFieldIds = {
+  name: '20202020-ba07-4ffd-ba63-009491f5749c',
+  position: '20202020-c2bd-4e16-bb9a-c8b0411bf49d',
+  activityTargets: '20202020-7f42-40ae-b96c-c8a61acc83bf',
+  favorites: '20202020-a4a7-4686-b296-1c6c3482ee21',
+  attachments: '20202020-8d59-46ca-b7b2-73d167712134',
+};

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/constants/standard-field-ids.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/constants/standard-field-ids.ts
@@ -56,6 +56,12 @@ export const blocklistStandardFieldIds = {
   workspaceMember: '20202020-548d-4084-a947-fa20a39f7c06',
 };
 
+export const calendarChannelEventAssociationStandardFieldIds = {
+  calendarChannel: '20202020-93ee-4da4-8d58-0282c4a9cb7d',
+  calendarEvent: '20202020-5aa5-437e-bb86-f42d457783e3',
+  eventExternalId: '20202020-9ec8-48bb-b279-21d0734a75a1',
+};
+
 export const calendarChannelStandardFieldIds = {
   connectedAccount: '20202020-95b1-4f44-82dc-61b042ae2414',
   handle: '20202020-1d08-420a-9aa7-22e0f298232d',
@@ -63,6 +69,7 @@ export const calendarChannelStandardFieldIds = {
   isContactAutoCreationEnabled: '20202020-50fb-404b-ba28-369911a3793a',
   isSyncEnabled: '20202020-fe19-4818-8854-21f7b1b43395',
   syncCursor: '20202020-bac2-4852-a5cb-7a7898992b70',
+  calendarChannelEventAssociations: '20202020-afb0-4a9f-979f-2d5087d71d09',
 };
 
 export const calendarEventAttendeeStandardFieldIds = {
@@ -89,6 +96,7 @@ export const calendarEventStandardFieldIds = {
   conferenceSolution: '20202020-1c3f-4b5a-b526-5411a82179eb',
   conferenceUri: '20202020-0fc5-490a-871a-2df8a45ab46c',
   recurringEventExternalId: '20202020-4b96-43d0-8156-4c7a9717635c',
+  calendarChannelEventAssociations: '20202020-bdf8-4572-a2cc-ecbb6bcc3a02',
   eventAttendees: '20202020-e07e-4ccb-88f5-6f3d00458eec',
 };
 

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/constants/standard-object-ids.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/constants/standard-object-ids.ts
@@ -1,0 +1,35 @@
+/**
+ * /!\ DO NOT EDIT THE IDS OF THIS FILE /!\
+ * This file contains static ids for standard objects.
+ * These ids are used to identify standard objects in the database and compare them even when renamed.
+ * For readability keys can be edited but the values should not be changed.
+ */
+
+export const standardObjectIds = {
+  activityTarget: '20202020-2945-440e-8d1a-f84672d33d5e',
+  activity: '20202020-39aa-4a89-843b-eb5f2a8b677f',
+  apiKey: '20202020-4c00-401d-8cda-ec6a4c41cd7d',
+  attachment: '20202020-bd3d-4c60-8dca-571c71d4447a',
+  blocklist: '20202020-0408-4f38-b8a8-4d5e3e26e24d',
+  calendarChannel: '20202020-e8f2-40e1-a39c-c0e0039c5034',
+  calendarEventAttendee: '20202020-a1c3-47a6-9732-27e5b1e8436d',
+  calendarEvent: '20202020-8f1d-4eef-9f85-0d1965e27221',
+  comment: '20202020-435f-4de9-89b5-97e32233bf5f',
+  company: '20202020-b374-4779-a561-80086cb2e17f',
+  connectedAccount: '20202020-977e-46b2-890b-c3002ddfd5c5',
+  favorite: '20202020-ab56-4e05-92a3-e2414a499860',
+  messageChannelMessageAssociation: '20202020-ad1e-4127-bccb-d83ae04d2ccb',
+  messageChannel: '20202020-fe8c-40bc-a681-b80b771449b7',
+  messageParticipant: '20202020-a433-4456-aa2d-fd9cb26b774a',
+  messageThread: '20202020-849a-4c3e-84f5-a25a7d802271',
+  message: '20202020-3f6b-4425-80ab-e468899ab4b2',
+  opportunity: '20202020-9549-49dd-b2b2-883999db8938',
+  person: '20202020-e674-48e5-a542-72570eee7213',
+  pipelineStep: '20202020-f9a3-45f3-82e2-28952a8b19bf',
+  viewField: '20202020-4d19-4655-95bf-b2a04cf206d4',
+  viewFilter: '20202020-6fb6-4631-aded-b7d67e952ec8',
+  viewSort: '20202020-e46a-47a8-939a-e5d911f83531',
+  view: '20202020-722e-4739-8e2c-0c372d661f49',
+  webhook: '20202020-be4d-4e08-811d-0fffcd13ffd4',
+  workspaceMember: '20202020-3319-4234-a34c-82d5c0e881a6',
+};

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/constants/standard-object-ids.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/constants/standard-object-ids.ts
@@ -11,6 +11,7 @@ export const standardObjectIds = {
   apiKey: '20202020-4c00-401d-8cda-ec6a4c41cd7d',
   attachment: '20202020-bd3d-4c60-8dca-571c71d4447a',
   blocklist: '20202020-0408-4f38-b8a8-4d5e3e26e24d',
+  calendarChannelEventAssociation: '20202020-491b-4aaa-9825-afd1bae6ae00',
   calendarChannel: '20202020-e8f2-40e1-a39c-c0e0039c5034',
   calendarEventAttendee: '20202020-a1c3-47a6-9732-27e5b1e8436d',
   calendarEvent: '20202020-8f1d-4eef-9f85-0d1965e27221',

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/custom-objects/custom.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/custom-objects/custom.object-metadata.ts
@@ -12,10 +12,12 @@ import { ActivityTargetObjectMetadata } from 'src/workspace/workspace-sync-metad
 import { RelationMetadata } from 'src/workspace/workspace-sync-metadata/decorators/relation-metadata.decorator';
 import { FavoriteObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/favorite.object-metadata';
 import { AttachmentObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/attachment.object-metadata';
+import { customObjectStandardFieldIds } from 'src/workspace/workspace-sync-metadata/constants/standard-field-ids';
 
 @BaseCustomObjectMetadata()
 export class CustomObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({
+    standardId: customObjectStandardFieldIds.name,
     label: 'Name',
     description: 'Name',
     type: FieldMetadataType.TEXT,
@@ -25,6 +27,7 @@ export class CustomObjectMetadata extends BaseObjectMetadata {
   name: string;
 
   @FieldMetadata({
+    standardId: customObjectStandardFieldIds.position,
     label: 'Position',
     description: 'Position',
     type: FieldMetadataType.POSITION,
@@ -35,6 +38,7 @@ export class CustomObjectMetadata extends BaseObjectMetadata {
   position: number;
 
   @FieldMetadata({
+    standardId: customObjectStandardFieldIds.activityTargets,
     type: FieldMetadataType.RELATION,
     label: 'Activities',
     description: (objectMetadata) =>
@@ -50,6 +54,7 @@ export class CustomObjectMetadata extends BaseObjectMetadata {
   activityTargets: ActivityTargetObjectMetadata[];
 
   @FieldMetadata({
+    standardId: customObjectStandardFieldIds.favorites,
     type: FieldMetadataType.RELATION,
     label: 'Favorites',
     description: (objectMetadata) =>
@@ -66,6 +71,7 @@ export class CustomObjectMetadata extends BaseObjectMetadata {
   favorites: FavoriteObjectMetadata[];
 
   @FieldMetadata({
+    standardId: customObjectStandardFieldIds.attachments,
     type: FieldMetadataType.RELATION,
     label: 'Attachments',
     description: (objectMetadata) =>

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/decorators/field-metadata.decorator.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/decorators/field-metadata.decorator.ts
@@ -9,6 +9,7 @@ import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.en
 import { generateTargetColumnMap } from 'src/metadata/field-metadata/utils/generate-target-column-map.util';
 import { generateDefaultValue } from 'src/metadata/field-metadata/utils/generate-default-value';
 import { TypedReflect } from 'src/utils/typed-reflect';
+import { createDeterministicUuid } from 'src/workspace/workspace-sync-metadata/utils/create-deterministic-uuid.util';
 
 export function FieldMetadata<T extends FieldMetadataType>(
   params: FieldMetadataDecoratorParams<T>,
@@ -21,14 +22,17 @@ export function FieldMetadata<T extends FieldMetadataType>(
     const isSystem =
       TypedReflect.getMetadata('isSystem', target, fieldKey) ?? false;
     const gate = TypedReflect.getMetadata('gate', target, fieldKey);
-    const { joinColumn, ...restParams } = params;
+    const { joinColumn, standardId, ...restParams } = params;
 
     TypedReflect.defineMetadata(
       'fieldMetadataMap',
       {
         ...existingFieldMetadata,
         [fieldKey]: generateFieldMetadata<T>(
-          restParams,
+          {
+            ...restParams,
+            standardId,
+          },
           fieldKey,
           isNullable,
           isSystem,
@@ -39,6 +43,7 @@ export function FieldMetadata<T extends FieldMetadataType>(
               [joinColumn]: generateFieldMetadata<FieldMetadataType.UUID>(
                 {
                   ...restParams,
+                  standardId: createDeterministicUuid(standardId),
                   type: FieldMetadataType.UUID,
                   label: `${restParams.label} id (foreign key)`,
                   description: `${restParams.description} id foreign key`,

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/interfaces/partial-object-metadata.interface.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/interfaces/partial-object-metadata.interface.ts
@@ -14,7 +14,8 @@ export type PartialObjectMetadata = ReflectObjectMetadata & {
 
 export type ComputedPartialObjectMetadata = Omit<
   PartialObjectMetadata,
-  'fields'
+  'standardId' | 'fields'
 > & {
+  standardId: string | null;
   fields: ComputedPartialFieldMetadata[];
 };

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/interfaces/reflect-computed-relation-field-metadata.interface.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/interfaces/reflect-computed-relation-field-metadata.interface.ts
@@ -6,6 +6,7 @@ import { ObjectMetadataEntity } from 'src/metadata/object-metadata/object-metada
 export type DynamicRelationFieldMetadataDecoratorParams = (
   oppositeObjectMetadata: ObjectMetadataEntity,
 ) => {
+  standardId: string;
   name: string;
   label: string;
   joinColumn: string;

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/interfaces/reflect-field-metadata.interface.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/interfaces/reflect-field-metadata.interface.ts
@@ -9,6 +9,7 @@ import { ObjectMetadataEntity } from 'src/metadata/object-metadata/object-metada
 export interface FieldMetadataDecoratorParams<
   T extends FieldMetadataType | 'default',
 > {
+  standardId: string;
   type: T;
   label: string | ((objectMetadata: ObjectMetadataEntity) => string);
   description?: string | ((objectMetadata: ObjectMetadataEntity) => string);

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/interfaces/reflect-object-metadata.interface.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/interfaces/reflect-object-metadata.interface.ts
@@ -1,6 +1,7 @@
 import { GateDecoratorParams } from 'src/workspace/workspace-sync-metadata/interfaces/gate-decorator.interface';
 
 export interface ObjectMetadataDecoratorParams {
+  standardId: string;
   namePlural: string;
   labelSingular: string;
   labelPlural: string;

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/services/workspace-sync-field-metadata.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/services/workspace-sync-field-metadata.service.ts
@@ -63,6 +63,10 @@ export class WorkspaceSyncFieldMetadataService {
 
     // Loop over all standard objects and compare them with the objects in DB
     for (const customObjectMetadata of customObjectMetadataCollection) {
+      if (!customObjectMetadata.standardId) {
+        continue;
+      }
+
       // Also, maybe it's better to refactor a bit and move generation part into a separate module ?
       const standardObjectMetadata = computeStandardObject(
         {

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/services/workspace-sync-field-metadata.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/services/workspace-sync-field-metadata.service.ts
@@ -63,10 +63,6 @@ export class WorkspaceSyncFieldMetadataService {
 
     // Loop over all standard objects and compare them with the objects in DB
     for (const customObjectMetadata of customObjectMetadataCollection) {
-      if (!customObjectMetadata.standardId) {
-        continue;
-      }
-
       // Also, maybe it's better to refactor a bit and move generation part into a separate module ?
       const standardObjectMetadata = computeStandardObject(
         {

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/services/workspace-sync-object-metadata.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/services/workspace-sync-object-metadata.service.ts
@@ -61,7 +61,7 @@ export class WorkspaceSyncObjectMetadataService {
       workspaceFeatureFlagsMap,
     );
 
-    // Create map of original and standard object metadata by unique identifier
+    // Create map of original and standard object metadata by standard ids
     const originalObjectMetadataMap = mapObjectMetadataByUniqueIdentifier(
       originalObjectMetadataCollection,
     );
@@ -75,17 +75,20 @@ export class WorkspaceSyncObjectMetadataService {
     for (const originalObjectMetadata of originalObjectMetadataCollection.filter(
       (object) => !object.isCustom,
     )) {
-      if (!standardObjectMetadataMap[originalObjectMetadata.nameSingular]) {
+      if (
+        originalObjectMetadata.standardId &&
+        !standardObjectMetadataMap[originalObjectMetadata.standardId]
+      ) {
         storage.addDeleteObjectMetadata(originalObjectMetadata);
       }
     }
 
     // Loop over all standard objects and compare them with the objects in DB
-    for (const standardObjectName in standardObjectMetadataMap) {
+    for (const standardObjectId in standardObjectMetadataMap) {
       const originalObjectMetadata =
-        originalObjectMetadataMap[standardObjectName];
+        originalObjectMetadataMap[standardObjectId];
       const standardObjectMetadata = computeStandardObject(
-        standardObjectMetadataMap[standardObjectName],
+        standardObjectMetadataMap[standardObjectId],
         originalObjectMetadata,
         customObjectMetadataCollection,
       );

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/services/workspace-sync-relation-metadata.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/services/workspace-sync-relation-metadata.service.ts
@@ -58,6 +58,8 @@ export class WorkspaceSyncRelationMetadataService {
     // Create map of object metadata & field metadata by unique identifier
     const originalObjectMetadataMap = mapObjectMetadataByUniqueIdentifier(
       originalObjectMetadataCollection,
+      // Relation are based on the singular name
+      (objectMetadata) => objectMetadata.nameSingular,
     );
 
     const relationMetadataRepository = manager.getRepository(

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/activity-target.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/activity-target.object-metadata.ts
@@ -1,4 +1,6 @@
 import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
+import { activityTargetStandardFieldIds } from 'src/workspace/workspace-sync-metadata/constants/standard-field-ids';
+import { standardObjectIds } from 'src/workspace/workspace-sync-metadata/constants/standard-object-ids';
 import { CustomObjectMetadata } from 'src/workspace/workspace-sync-metadata/custom-objects/custom.object-metadata';
 import { DynamicRelationFieldMetadata } from 'src/workspace/workspace-sync-metadata/decorators/dynamic-field-metadata.interface';
 import { FieldMetadata } from 'src/workspace/workspace-sync-metadata/decorators/field-metadata.decorator';
@@ -12,6 +14,7 @@ import { OpportunityObjectMetadata } from 'src/workspace/workspace-sync-metadata
 import { PersonObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/person.object-metadata';
 
 @ObjectMetadata({
+  standardId: standardObjectIds.activityTarget,
   namePlural: 'activityTargets',
   labelSingular: 'Activity Target',
   labelPlural: 'Activity Targets',
@@ -21,6 +24,7 @@ import { PersonObjectMetadata } from 'src/workspace/workspace-sync-metadata/stan
 @IsSystem()
 export class ActivityTargetObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({
+    standardId: activityTargetStandardFieldIds.activity,
     type: FieldMetadataType.RELATION,
     label: 'Activity',
     description: 'ActivityTarget activity',
@@ -31,6 +35,7 @@ export class ActivityTargetObjectMetadata extends BaseObjectMetadata {
   activity: ActivityObjectMetadata;
 
   @FieldMetadata({
+    standardId: activityTargetStandardFieldIds.person,
     type: FieldMetadataType.RELATION,
     label: 'Person',
     description: 'ActivityTarget person',
@@ -41,6 +46,7 @@ export class ActivityTargetObjectMetadata extends BaseObjectMetadata {
   person: PersonObjectMetadata;
 
   @FieldMetadata({
+    standardId: activityTargetStandardFieldIds.company,
     type: FieldMetadataType.RELATION,
     label: 'Company',
     description: 'ActivityTarget company',
@@ -51,6 +57,7 @@ export class ActivityTargetObjectMetadata extends BaseObjectMetadata {
   company: CompanyObjectMetadata;
 
   @FieldMetadata({
+    standardId: activityTargetStandardFieldIds.opportunity,
     type: FieldMetadataType.RELATION,
     label: 'Opportunity',
     description: 'ActivityTarget opportunity',
@@ -61,6 +68,7 @@ export class ActivityTargetObjectMetadata extends BaseObjectMetadata {
   opportunity: OpportunityObjectMetadata;
 
   @DynamicRelationFieldMetadata((oppositeObjectMetadata) => ({
+    standardId: activityTargetStandardFieldIds.custom,
     name: oppositeObjectMetadata.nameSingular,
     label: oppositeObjectMetadata.labelSingular,
     description: `ActivityTarget ${oppositeObjectMetadata.labelSingular}`,

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/activity.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/activity.object-metadata.ts
@@ -1,5 +1,7 @@
 import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
 import { RelationMetadataType } from 'src/metadata/relation-metadata/relation-metadata.entity';
+import { activityStandardFieldIds } from 'src/workspace/workspace-sync-metadata/constants/standard-field-ids';
+import { standardObjectIds } from 'src/workspace/workspace-sync-metadata/constants/standard-object-ids';
 import { FieldMetadata } from 'src/workspace/workspace-sync-metadata/decorators/field-metadata.decorator';
 import { IsNullable } from 'src/workspace/workspace-sync-metadata/decorators/is-nullable.decorator';
 import { IsSystem } from 'src/workspace/workspace-sync-metadata/decorators/is-system.decorator';
@@ -12,6 +14,7 @@ import { CommentObjectMetadata } from 'src/workspace/workspace-sync-metadata/sta
 import { WorkspaceMemberObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/workspace-member.object-metadata';
 
 @ObjectMetadata({
+  standardId: standardObjectIds.activity,
   namePlural: 'activities',
   labelSingular: 'Activity',
   labelPlural: 'Activities',
@@ -21,6 +24,7 @@ import { WorkspaceMemberObjectMetadata } from 'src/workspace/workspace-sync-meta
 @IsSystem()
 export class ActivityObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({
+    standardId: activityStandardFieldIds.title,
     type: FieldMetadataType.TEXT,
     label: 'Title',
     description: 'Activity title',
@@ -29,6 +33,7 @@ export class ActivityObjectMetadata extends BaseObjectMetadata {
   title: string;
 
   @FieldMetadata({
+    standardId: activityStandardFieldIds.body,
     type: FieldMetadataType.TEXT,
     label: 'Body',
     description: 'Activity body',
@@ -37,6 +42,7 @@ export class ActivityObjectMetadata extends BaseObjectMetadata {
   body: string;
 
   @FieldMetadata({
+    standardId: activityStandardFieldIds.type,
     type: FieldMetadataType.TEXT,
     label: 'Type',
     description: 'Activity type',
@@ -46,6 +52,7 @@ export class ActivityObjectMetadata extends BaseObjectMetadata {
   type: string;
 
   @FieldMetadata({
+    standardId: activityStandardFieldIds.reminderAt,
     type: FieldMetadataType.DATE_TIME,
     label: 'Reminder Date',
     description: 'Activity reminder date',
@@ -55,6 +62,7 @@ export class ActivityObjectMetadata extends BaseObjectMetadata {
   reminderAt: Date;
 
   @FieldMetadata({
+    standardId: activityStandardFieldIds.dueAt,
     type: FieldMetadataType.DATE_TIME,
     label: 'Due Date',
     description: 'Activity due date',
@@ -64,6 +72,7 @@ export class ActivityObjectMetadata extends BaseObjectMetadata {
   dueAt: Date;
 
   @FieldMetadata({
+    standardId: activityStandardFieldIds.completedAt,
     type: FieldMetadataType.DATE_TIME,
     label: 'Completion Date',
     description: 'Activity completion date',
@@ -73,6 +82,7 @@ export class ActivityObjectMetadata extends BaseObjectMetadata {
   completedAt: Date;
 
   @FieldMetadata({
+    standardId: activityStandardFieldIds.activityTargets,
     type: FieldMetadataType.RELATION,
     label: 'Targets',
     description: 'Activity targets',
@@ -86,6 +96,7 @@ export class ActivityObjectMetadata extends BaseObjectMetadata {
   activityTargets: ActivityTargetObjectMetadata[];
 
   @FieldMetadata({
+    standardId: activityStandardFieldIds.attachments,
     type: FieldMetadataType.RELATION,
     label: 'Attachments',
     description: 'Activity attachments',
@@ -99,6 +110,7 @@ export class ActivityObjectMetadata extends BaseObjectMetadata {
   attachments: AttachmentObjectMetadata[];
 
   @FieldMetadata({
+    standardId: activityStandardFieldIds.comments,
     type: FieldMetadataType.RELATION,
     label: 'Comments',
     description: 'Activity comments',
@@ -112,6 +124,7 @@ export class ActivityObjectMetadata extends BaseObjectMetadata {
   comments: CommentObjectMetadata[];
 
   @FieldMetadata({
+    standardId: activityStandardFieldIds.author,
     type: FieldMetadataType.RELATION,
     label: 'Author',
     description: 'Activity author',
@@ -121,6 +134,7 @@ export class ActivityObjectMetadata extends BaseObjectMetadata {
   author: WorkspaceMemberObjectMetadata;
 
   @FieldMetadata({
+    standardId: activityStandardFieldIds.assignee,
     type: FieldMetadataType.RELATION,
     label: 'Assignee',
     description: 'Activity assignee',

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/api-key.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/api-key.object-metadata.ts
@@ -1,4 +1,6 @@
 import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
+import { apiKeyStandardFieldIds } from 'src/workspace/workspace-sync-metadata/constants/standard-field-ids';
+import { standardObjectIds } from 'src/workspace/workspace-sync-metadata/constants/standard-object-ids';
 import { FieldMetadata } from 'src/workspace/workspace-sync-metadata/decorators/field-metadata.decorator';
 import { IsNullable } from 'src/workspace/workspace-sync-metadata/decorators/is-nullable.decorator';
 import { IsSystem } from 'src/workspace/workspace-sync-metadata/decorators/is-system.decorator';
@@ -6,6 +8,7 @@ import { ObjectMetadata } from 'src/workspace/workspace-sync-metadata/decorators
 import { BaseObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/base.object-metadata';
 
 @ObjectMetadata({
+  standardId: standardObjectIds.apiKey,
   namePlural: 'apiKeys',
   labelSingular: 'Api Key',
   labelPlural: 'Api Keys',
@@ -15,6 +18,7 @@ import { BaseObjectMetadata } from 'src/workspace/workspace-sync-metadata/standa
 @IsSystem()
 export class ApiKeyObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({
+    standardId: apiKeyStandardFieldIds.name,
     type: FieldMetadataType.TEXT,
     label: 'Name',
     description: 'ApiKey name',
@@ -23,6 +27,7 @@ export class ApiKeyObjectMetadata extends BaseObjectMetadata {
   name: string;
 
   @FieldMetadata({
+    standardId: apiKeyStandardFieldIds.expiresAt,
     type: FieldMetadataType.DATE_TIME,
     label: 'Expiration date',
     description: 'ApiKey expiration date',
@@ -31,6 +36,7 @@ export class ApiKeyObjectMetadata extends BaseObjectMetadata {
   expiresAt: Date;
 
   @FieldMetadata({
+    standardId: apiKeyStandardFieldIds.revokedAt,
     type: FieldMetadataType.DATE_TIME,
     label: 'Revocation date',
     description: 'ApiKey revocation date',

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/attachment.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/attachment.object-metadata.ts
@@ -1,4 +1,6 @@
 import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
+import { attachmentStandardFieldIds } from 'src/workspace/workspace-sync-metadata/constants/standard-field-ids';
+import { standardObjectIds } from 'src/workspace/workspace-sync-metadata/constants/standard-object-ids';
 import { CustomObjectMetadata } from 'src/workspace/workspace-sync-metadata/custom-objects/custom.object-metadata';
 import { DynamicRelationFieldMetadata } from 'src/workspace/workspace-sync-metadata/decorators/dynamic-field-metadata.interface';
 import { FieldMetadata } from 'src/workspace/workspace-sync-metadata/decorators/field-metadata.decorator';
@@ -13,6 +15,7 @@ import { PersonObjectMetadata } from 'src/workspace/workspace-sync-metadata/stan
 import { WorkspaceMemberObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/workspace-member.object-metadata';
 
 @ObjectMetadata({
+  standardId: standardObjectIds.attachment,
   namePlural: 'attachments',
   labelSingular: 'Attachment',
   labelPlural: 'Attachments',
@@ -22,6 +25,7 @@ import { WorkspaceMemberObjectMetadata } from 'src/workspace/workspace-sync-meta
 @IsSystem()
 export class AttachmentObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({
+    standardId: attachmentStandardFieldIds.name,
     type: FieldMetadataType.TEXT,
     label: 'Name',
     description: 'Attachment name',
@@ -30,6 +34,7 @@ export class AttachmentObjectMetadata extends BaseObjectMetadata {
   name: string;
 
   @FieldMetadata({
+    standardId: attachmentStandardFieldIds.fullPath,
     type: FieldMetadataType.TEXT,
     label: 'Full path',
     description: 'Attachment full path',
@@ -38,6 +43,7 @@ export class AttachmentObjectMetadata extends BaseObjectMetadata {
   fullPath: string;
 
   @FieldMetadata({
+    standardId: attachmentStandardFieldIds.type,
     type: FieldMetadataType.TEXT,
     label: 'Type',
     description: 'Attachment type',
@@ -46,6 +52,7 @@ export class AttachmentObjectMetadata extends BaseObjectMetadata {
   type: string;
 
   @FieldMetadata({
+    standardId: attachmentStandardFieldIds.author,
     type: FieldMetadataType.RELATION,
     label: 'Author',
     description: 'Attachment author',
@@ -55,6 +62,7 @@ export class AttachmentObjectMetadata extends BaseObjectMetadata {
   author: WorkspaceMemberObjectMetadata;
 
   @FieldMetadata({
+    standardId: attachmentStandardFieldIds.activity,
     type: FieldMetadataType.RELATION,
     label: 'Activity',
     description: 'Attachment activity',
@@ -65,6 +73,7 @@ export class AttachmentObjectMetadata extends BaseObjectMetadata {
   activity: ActivityObjectMetadata;
 
   @FieldMetadata({
+    standardId: attachmentStandardFieldIds.person,
     type: FieldMetadataType.RELATION,
     label: 'Person',
     description: 'Attachment person',
@@ -75,6 +84,7 @@ export class AttachmentObjectMetadata extends BaseObjectMetadata {
   person: PersonObjectMetadata;
 
   @FieldMetadata({
+    standardId: attachmentStandardFieldIds.company,
     type: FieldMetadataType.RELATION,
     label: 'Company',
     description: 'Attachment company',
@@ -85,6 +95,7 @@ export class AttachmentObjectMetadata extends BaseObjectMetadata {
   company: CompanyObjectMetadata;
 
   @FieldMetadata({
+    standardId: attachmentStandardFieldIds.opportunity,
     type: FieldMetadataType.RELATION,
     label: 'Opportunity',
     description: 'Attachment opportunity',
@@ -95,6 +106,7 @@ export class AttachmentObjectMetadata extends BaseObjectMetadata {
   opportunity: OpportunityObjectMetadata;
 
   @DynamicRelationFieldMetadata((oppositeObjectMetadata) => ({
+    standardId: attachmentStandardFieldIds.custom,
     name: oppositeObjectMetadata.nameSingular,
     label: oppositeObjectMetadata.labelSingular,
     description: `Attachment ${oppositeObjectMetadata.labelSingular}`,

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/base.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/base.object-metadata.ts
@@ -1,9 +1,11 @@
 import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
+import { baseObjectStandardFieldIds } from 'src/workspace/workspace-sync-metadata/constants/standard-field-ids';
 import { FieldMetadata } from 'src/workspace/workspace-sync-metadata/decorators/field-metadata.decorator';
 import { IsSystem } from 'src/workspace/workspace-sync-metadata/decorators/is-system.decorator';
 
 export abstract class BaseObjectMetadata {
   @FieldMetadata({
+    standardId: baseObjectStandardFieldIds.id,
     type: FieldMetadataType.UUID,
     label: 'Id',
     description: 'Id',
@@ -14,6 +16,7 @@ export abstract class BaseObjectMetadata {
   id: string;
 
   @FieldMetadata({
+    standardId: baseObjectStandardFieldIds.createdAt,
     type: FieldMetadataType.DATE_TIME,
     label: 'Creation date',
     description: 'Creation date',
@@ -23,6 +26,7 @@ export abstract class BaseObjectMetadata {
   createdAt: Date;
 
   @FieldMetadata({
+    standardId: baseObjectStandardFieldIds.updatedAt,
     type: FieldMetadataType.DATE_TIME,
     label: 'Update date',
     description: 'Update date',

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/blocklist.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/blocklist.object-metadata.ts
@@ -1,4 +1,6 @@
 import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
+import { blocklistStandardFieldIds } from 'src/workspace/workspace-sync-metadata/constants/standard-field-ids';
+import { standardObjectIds } from 'src/workspace/workspace-sync-metadata/constants/standard-object-ids';
 import { FieldMetadata } from 'src/workspace/workspace-sync-metadata/decorators/field-metadata.decorator';
 import { IsSystem } from 'src/workspace/workspace-sync-metadata/decorators/is-system.decorator';
 import { ObjectMetadata } from 'src/workspace/workspace-sync-metadata/decorators/object-metadata.decorator';
@@ -6,6 +8,7 @@ import { BaseObjectMetadata } from 'src/workspace/workspace-sync-metadata/standa
 import { WorkspaceMemberObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/workspace-member.object-metadata';
 
 @ObjectMetadata({
+  standardId: standardObjectIds.blocklist,
   namePlural: 'blocklists',
   labelSingular: 'Blocklist',
   labelPlural: 'Blocklists',
@@ -15,6 +18,7 @@ import { WorkspaceMemberObjectMetadata } from 'src/workspace/workspace-sync-meta
 @IsSystem()
 export class BlocklistObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({
+    standardId: blocklistStandardFieldIds.handle,
     type: FieldMetadataType.TEXT,
     label: 'Handle',
     description: 'Handle',
@@ -23,6 +27,7 @@ export class BlocklistObjectMetadata extends BaseObjectMetadata {
   handle: string;
 
   @FieldMetadata({
+    standardId: blocklistStandardFieldIds.workspaceMember,
     type: FieldMetadataType.RELATION,
     label: 'WorkspaceMember',
     description: 'WorkspaceMember',

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/calendar-channel-event-association.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/calendar-channel-event-association.object-metadata.ts
@@ -1,5 +1,7 @@
 import { FeatureFlagKeys } from 'src/core/feature-flag/feature-flag.entity';
 import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
+import { calendarChannelEventAssociationStandardFieldIds } from 'src/workspace/workspace-sync-metadata/constants/standard-field-ids';
+import { standardObjectIds } from 'src/workspace/workspace-sync-metadata/constants/standard-object-ids';
 import { FieldMetadata } from 'src/workspace/workspace-sync-metadata/decorators/field-metadata.decorator';
 import { Gate } from 'src/workspace/workspace-sync-metadata/decorators/gate.decorator';
 import { IsSystem } from 'src/workspace/workspace-sync-metadata/decorators/is-system.decorator';
@@ -8,6 +10,7 @@ import { BaseObjectMetadata } from 'src/workspace/workspace-sync-metadata/standa
 import { CalendarEventObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/calendar-event.object-metadata';
 
 @ObjectMetadata({
+  standardId: standardObjectIds.calendarChannelEventAssociation,
   namePlural: 'calendarChannelEventAssociations',
   labelSingular: 'Calendar Channel Event Association',
   labelPlural: 'Calendar Channel Event Associations',
@@ -20,6 +23,7 @@ import { CalendarEventObjectMetadata } from 'src/workspace/workspace-sync-metada
 })
 export class CalendarChannelEventAssociationObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({
+    standardId: calendarChannelEventAssociationStandardFieldIds.calendarChannel,
     type: FieldMetadataType.RELATION,
     label: 'Channel ID',
     description: 'Channel ID',
@@ -29,6 +33,7 @@ export class CalendarChannelEventAssociationObjectMetadata extends BaseObjectMet
   calendarChannel: CalendarEventObjectMetadata;
 
   @FieldMetadata({
+    standardId: calendarChannelEventAssociationStandardFieldIds.calendarEvent,
     type: FieldMetadataType.RELATION,
     label: 'Event ID',
     description: 'Event ID',
@@ -38,6 +43,7 @@ export class CalendarChannelEventAssociationObjectMetadata extends BaseObjectMet
   calendarEvent: CalendarEventObjectMetadata;
 
   @FieldMetadata({
+    standardId: calendarChannelEventAssociationStandardFieldIds.eventExternalId,
     type: FieldMetadataType.TEXT,
     label: 'Event external ID',
     description: 'Event external ID',

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/calendar-channel.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/calendar-channel.object-metadata.ts
@@ -4,6 +4,8 @@ import {
 } from 'src/metadata/relation-metadata/relation-metadata.entity';
 import { FeatureFlagKeys } from 'src/core/feature-flag/feature-flag.entity';
 import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
+import { calendarChannelStandardFieldIds } from 'src/workspace/workspace-sync-metadata/constants/standard-field-ids';
+import { standardObjectIds } from 'src/workspace/workspace-sync-metadata/constants/standard-object-ids';
 import { FieldMetadata } from 'src/workspace/workspace-sync-metadata/decorators/field-metadata.decorator';
 import { Gate } from 'src/workspace/workspace-sync-metadata/decorators/gate.decorator';
 import { IsSystem } from 'src/workspace/workspace-sync-metadata/decorators/is-system.decorator';
@@ -19,6 +21,7 @@ export enum CalendarChannelVisibility {
 }
 
 @ObjectMetadata({
+  standardId: standardObjectIds.calendarChannel,
   namePlural: 'calendarChannels',
   labelSingular: 'Calendar Channel',
   labelPlural: 'Calendar Channels',
@@ -31,6 +34,7 @@ export enum CalendarChannelVisibility {
 })
 export class CalendarChannelObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({
+    standardId: calendarChannelStandardFieldIds.connectedAccount,
     type: FieldMetadataType.RELATION,
     label: 'Connected Account',
     description: 'Connected Account',
@@ -40,6 +44,7 @@ export class CalendarChannelObjectMetadata extends BaseObjectMetadata {
   connectedAccount: ConnectedAccountObjectMetadata;
 
   @FieldMetadata({
+    standardId: calendarChannelStandardFieldIds.handle,
     type: FieldMetadataType.TEXT,
     label: 'Handle',
     description: 'Handle',
@@ -48,6 +53,7 @@ export class CalendarChannelObjectMetadata extends BaseObjectMetadata {
   handle: string;
 
   @FieldMetadata({
+    standardId: calendarChannelStandardFieldIds.visibility,
     type: FieldMetadataType.SELECT,
     label: 'Visibility',
     description: 'Visibility',
@@ -71,6 +77,7 @@ export class CalendarChannelObjectMetadata extends BaseObjectMetadata {
   visibility: string;
 
   @FieldMetadata({
+    standardId: calendarChannelStandardFieldIds.isContactAutoCreationEnabled,
     type: FieldMetadataType.BOOLEAN,
     label: 'Is Contact Auto Creation Enabled',
     description: 'Is Contact Auto Creation Enabled',
@@ -80,6 +87,7 @@ export class CalendarChannelObjectMetadata extends BaseObjectMetadata {
   isContactAutoCreationEnabled: boolean;
 
   @FieldMetadata({
+    standardId: calendarChannelStandardFieldIds.isSyncEnabled,
     type: FieldMetadataType.BOOLEAN,
     label: 'Is Sync Enabled',
     description: 'Is Sync Enabled',
@@ -89,6 +97,7 @@ export class CalendarChannelObjectMetadata extends BaseObjectMetadata {
   isSyncEnabled: boolean;
 
   @FieldMetadata({
+    standardId: calendarChannelStandardFieldIds.syncCursor,
     type: FieldMetadataType.TEXT,
     label: 'Sync Cursor',
     description:

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/calendar-channel.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/calendar-channel.object-metadata.ts
@@ -107,6 +107,8 @@ export class CalendarChannelObjectMetadata extends BaseObjectMetadata {
   syncCursor: string;
 
   @FieldMetadata({
+    standardId:
+      calendarChannelStandardFieldIds.calendarChannelEventAssociations,
     type: FieldMetadataType.RELATION,
     label: 'Calendar Channel Event Associations',
     description: 'Calendar Channel Event Associations',

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/calendar-event-attendee.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/calendar-event-attendee.object-metadata.ts
@@ -1,4 +1,6 @@
 import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
+import { calendarEventAttendeeStandardFieldIds } from 'src/workspace/workspace-sync-metadata/constants/standard-field-ids';
+import { standardObjectIds } from 'src/workspace/workspace-sync-metadata/constants/standard-object-ids';
 import { FieldMetadata } from 'src/workspace/workspace-sync-metadata/decorators/field-metadata.decorator';
 import { Gate } from 'src/workspace/workspace-sync-metadata/decorators/gate.decorator';
 import { IsNullable } from 'src/workspace/workspace-sync-metadata/decorators/is-nullable.decorator';
@@ -17,6 +19,7 @@ export enum CalendarEventAttendeeResponseStatus {
 }
 
 @ObjectMetadata({
+  standardId: standardObjectIds.calendarEventAttendee,
   namePlural: 'calendarEventAttendees',
   labelSingular: 'Calendar event attendee',
   labelPlural: 'Calendar event attendees',
@@ -29,6 +32,7 @@ export enum CalendarEventAttendeeResponseStatus {
 })
 export class CalendarEventAttendeeObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({
+    standardId: calendarEventAttendeeStandardFieldIds.calendarEvent,
     type: FieldMetadataType.RELATION,
     label: 'Event ID',
     description: 'Event ID',
@@ -38,6 +42,7 @@ export class CalendarEventAttendeeObjectMetadata extends BaseObjectMetadata {
   calendarEvent: CalendarEventObjectMetadata;
 
   @FieldMetadata({
+    standardId: calendarEventAttendeeStandardFieldIds.handle,
     type: FieldMetadataType.TEXT,
     label: 'Handle',
     description: 'Handle',
@@ -46,6 +51,7 @@ export class CalendarEventAttendeeObjectMetadata extends BaseObjectMetadata {
   handle: string;
 
   @FieldMetadata({
+    standardId: calendarEventAttendeeStandardFieldIds.displayName,
     type: FieldMetadataType.TEXT,
     label: 'Display Name',
     description: 'Display Name',
@@ -54,6 +60,7 @@ export class CalendarEventAttendeeObjectMetadata extends BaseObjectMetadata {
   displayName: string;
 
   @FieldMetadata({
+    standardId: calendarEventAttendeeStandardFieldIds.isOrganizer,
     type: FieldMetadataType.BOOLEAN,
     label: 'Is Organizer',
     description: 'Is Organizer',
@@ -62,6 +69,7 @@ export class CalendarEventAttendeeObjectMetadata extends BaseObjectMetadata {
   isOrganizer: boolean;
 
   @FieldMetadata({
+    standardId: calendarEventAttendeeStandardFieldIds.responseStatus,
     type: FieldMetadataType.SELECT,
     label: 'Response Status',
     description: 'Response Status',
@@ -97,6 +105,7 @@ export class CalendarEventAttendeeObjectMetadata extends BaseObjectMetadata {
   responseStatus: string;
 
   @FieldMetadata({
+    standardId: calendarEventAttendeeStandardFieldIds.person,
     type: FieldMetadataType.RELATION,
     label: 'Person',
     description: 'Person',
@@ -107,6 +116,7 @@ export class CalendarEventAttendeeObjectMetadata extends BaseObjectMetadata {
   person: PersonObjectMetadata;
 
   @FieldMetadata({
+    standardId: calendarEventAttendeeStandardFieldIds.workspaceMember,
     type: FieldMetadataType.RELATION,
     label: 'Workspace Member',
     description: 'Workspace Member',

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/calendar-event.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/calendar-event.object-metadata.ts
@@ -12,8 +12,11 @@ import { ObjectMetadata } from 'src/workspace/workspace-sync-metadata/decorators
 import { BaseObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/base.object-metadata';
 import { CalendarChannelEventAssociationObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/calendar-channel-event-association.object-metadata';
 import { CalendarEventAttendeeObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/calendar-event-attendee.object-metadata';
+import { standardObjectIds } from 'src/workspace/workspace-sync-metadata/constants/standard-object-ids';
+import { calendarEventStandardFieldIds } from 'src/workspace/workspace-sync-metadata/constants/standard-field-ids';
 
 @ObjectMetadata({
+  standardId: standardObjectIds.calendarEvent,
   namePlural: 'calendarEvents',
   labelSingular: 'Calendar event',
   labelPlural: 'Calendar events',
@@ -26,6 +29,7 @@ import { CalendarEventAttendeeObjectMetadata } from 'src/workspace/workspace-syn
 })
 export class CalendarEventObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({
+    standardId: calendarEventStandardFieldIds.title,
     type: FieldMetadataType.TEXT,
     label: 'Title',
     description: 'Title',
@@ -34,6 +38,7 @@ export class CalendarEventObjectMetadata extends BaseObjectMetadata {
   title: string;
 
   @FieldMetadata({
+    standardId: calendarEventStandardFieldIds.isCanceled,
     type: FieldMetadataType.BOOLEAN,
     label: 'Is canceled',
     description: 'Is canceled',
@@ -42,6 +47,7 @@ export class CalendarEventObjectMetadata extends BaseObjectMetadata {
   isCanceled: boolean;
 
   @FieldMetadata({
+    standardId: calendarEventStandardFieldIds.isFullDay,
     type: FieldMetadataType.BOOLEAN,
     label: 'Is Full Day',
     description: 'Is Full Day',
@@ -50,6 +56,7 @@ export class CalendarEventObjectMetadata extends BaseObjectMetadata {
   isFullDay: boolean;
 
   @FieldMetadata({
+    standardId: calendarEventStandardFieldIds.startsAt,
     type: FieldMetadataType.DATE_TIME,
     label: 'Start DateTime',
     description: 'Start DateTime',
@@ -58,6 +65,7 @@ export class CalendarEventObjectMetadata extends BaseObjectMetadata {
   startsAt: string;
 
   @FieldMetadata({
+    standardId: calendarEventStandardFieldIds.endsAt,
     type: FieldMetadataType.DATE_TIME,
     label: 'End DateTime',
     description: 'End DateTime',
@@ -66,6 +74,7 @@ export class CalendarEventObjectMetadata extends BaseObjectMetadata {
   endsAt: string;
 
   @FieldMetadata({
+    standardId: calendarEventStandardFieldIds.externalCreatedAt,
     type: FieldMetadataType.DATE_TIME,
     label: 'Creation DateTime',
     description: 'Creation DateTime',
@@ -74,6 +83,7 @@ export class CalendarEventObjectMetadata extends BaseObjectMetadata {
   externalCreatedAt: string;
 
   @FieldMetadata({
+    standardId: calendarEventStandardFieldIds.externalUpdatedAt,
     type: FieldMetadataType.DATE_TIME,
     label: 'Update DateTime',
     description: 'Update DateTime',
@@ -82,6 +92,7 @@ export class CalendarEventObjectMetadata extends BaseObjectMetadata {
   externalUpdatedAt: string;
 
   @FieldMetadata({
+    standardId: calendarEventStandardFieldIds.description,
     type: FieldMetadataType.TEXT,
     label: 'Description',
     description: 'Description',
@@ -90,6 +101,7 @@ export class CalendarEventObjectMetadata extends BaseObjectMetadata {
   description: string;
 
   @FieldMetadata({
+    standardId: calendarEventStandardFieldIds.location,
     type: FieldMetadataType.TEXT,
     label: 'Location',
     description: 'Location',
@@ -98,6 +110,7 @@ export class CalendarEventObjectMetadata extends BaseObjectMetadata {
   location: string;
 
   @FieldMetadata({
+    standardId: calendarEventStandardFieldIds.iCalUID,
     type: FieldMetadataType.TEXT,
     label: 'iCal UID',
     description: 'iCal UID',
@@ -106,6 +119,7 @@ export class CalendarEventObjectMetadata extends BaseObjectMetadata {
   iCalUID: string;
 
   @FieldMetadata({
+    standardId: calendarEventStandardFieldIds.conferenceSolution,
     type: FieldMetadataType.TEXT,
     label: 'Conference Solution',
     description: 'Conference Solution',
@@ -114,6 +128,7 @@ export class CalendarEventObjectMetadata extends BaseObjectMetadata {
   conferenceSolution: string;
 
   @FieldMetadata({
+    standardId: calendarEventStandardFieldIds.conferenceUri,
     type: FieldMetadataType.TEXT,
     label: 'Conference URI',
     description: 'Conference URI',
@@ -122,6 +137,7 @@ export class CalendarEventObjectMetadata extends BaseObjectMetadata {
   conferenceUri: string;
 
   @FieldMetadata({
+    standardId: calendarEventStandardFieldIds.recurringEventExternalId,
     type: FieldMetadataType.TEXT,
     label: 'Recurring Event ID',
     description: 'Recurring Event ID',
@@ -130,6 +146,7 @@ export class CalendarEventObjectMetadata extends BaseObjectMetadata {
   recurringEventExternalId: string;
 
   @FieldMetadata({
+    standardId: calendarEventStandardFieldIds.eventAttendees,
     type: FieldMetadataType.RELATION,
     label: 'Calendar Channel Event Associations',
     description: 'Calendar Channel Event Associations',

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/calendar-event.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/calendar-event.object-metadata.ts
@@ -146,7 +146,7 @@ export class CalendarEventObjectMetadata extends BaseObjectMetadata {
   recurringEventExternalId: string;
 
   @FieldMetadata({
-    standardId: calendarEventStandardFieldIds.eventAttendees,
+    standardId: calendarEventStandardFieldIds.calendarChannelEventAssociations,
     type: FieldMetadataType.RELATION,
     label: 'Calendar Channel Event Associations',
     description: 'Calendar Channel Event Associations',
@@ -164,6 +164,7 @@ export class CalendarEventObjectMetadata extends BaseObjectMetadata {
   calendarChannelEventAssociations: CalendarChannelEventAssociationObjectMetadata[];
 
   @FieldMetadata({
+    standardId: calendarEventStandardFieldIds.eventAttendees,
     type: FieldMetadataType.RELATION,
     label: 'Event Attendees',
     description: 'Event Attendees',

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/comment.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/comment.object-metadata.ts
@@ -1,4 +1,6 @@
 import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
+import { commentStandardFieldIds } from 'src/workspace/workspace-sync-metadata/constants/standard-field-ids';
+import { standardObjectIds } from 'src/workspace/workspace-sync-metadata/constants/standard-object-ids';
 import { FieldMetadata } from 'src/workspace/workspace-sync-metadata/decorators/field-metadata.decorator';
 import { IsSystem } from 'src/workspace/workspace-sync-metadata/decorators/is-system.decorator';
 import { ObjectMetadata } from 'src/workspace/workspace-sync-metadata/decorators/object-metadata.decorator';
@@ -7,6 +9,7 @@ import { BaseObjectMetadata } from 'src/workspace/workspace-sync-metadata/standa
 import { WorkspaceMemberObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/workspace-member.object-metadata';
 
 @ObjectMetadata({
+  standardId: standardObjectIds.comment,
   namePlural: 'comments',
   labelSingular: 'Comment',
   labelPlural: 'Comments',
@@ -16,6 +19,7 @@ import { WorkspaceMemberObjectMetadata } from 'src/workspace/workspace-sync-meta
 @IsSystem()
 export class CommentObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({
+    standardId: commentStandardFieldIds.body,
     type: FieldMetadataType.TEXT,
     label: 'Body',
     description: 'Comment body',
@@ -24,6 +28,7 @@ export class CommentObjectMetadata extends BaseObjectMetadata {
   body: string;
 
   @FieldMetadata({
+    standardId: commentStandardFieldIds.author,
     type: FieldMetadataType.RELATION,
     label: 'Author',
     description: 'Comment author',
@@ -33,6 +38,7 @@ export class CommentObjectMetadata extends BaseObjectMetadata {
   author: WorkspaceMemberObjectMetadata;
 
   @FieldMetadata({
+    standardId: commentStandardFieldIds.activity,
     type: FieldMetadataType.RELATION,
     label: 'Activity',
     description: 'Comment activity',

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/company.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/company.object-metadata.ts
@@ -5,6 +5,8 @@ import {
   RelationMetadataType,
   RelationOnDeleteAction,
 } from 'src/metadata/relation-metadata/relation-metadata.entity';
+import { companyStandardFieldIds } from 'src/workspace/workspace-sync-metadata/constants/standard-field-ids';
+import { standardObjectIds } from 'src/workspace/workspace-sync-metadata/constants/standard-object-ids';
 import { FieldMetadata } from 'src/workspace/workspace-sync-metadata/decorators/field-metadata.decorator';
 import { IsNullable } from 'src/workspace/workspace-sync-metadata/decorators/is-nullable.decorator';
 import { IsSystem } from 'src/workspace/workspace-sync-metadata/decorators/is-system.decorator';
@@ -19,6 +21,7 @@ import { PersonObjectMetadata } from 'src/workspace/workspace-sync-metadata/stan
 import { WorkspaceMemberObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/workspace-member.object-metadata';
 
 @ObjectMetadata({
+  standardId: standardObjectIds.company,
   namePlural: 'companies',
   labelSingular: 'Company',
   labelPlural: 'Companies',
@@ -27,6 +30,7 @@ import { WorkspaceMemberObjectMetadata } from 'src/workspace/workspace-sync-meta
 })
 export class CompanyObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({
+    standardId: companyStandardFieldIds.name,
     type: FieldMetadataType.TEXT,
     label: 'Name',
     description: 'The company name',
@@ -35,6 +39,7 @@ export class CompanyObjectMetadata extends BaseObjectMetadata {
   name: string;
 
   @FieldMetadata({
+    standardId: companyStandardFieldIds.domainName,
     type: FieldMetadataType.TEXT,
     label: 'Domain Name',
     description:
@@ -44,6 +49,7 @@ export class CompanyObjectMetadata extends BaseObjectMetadata {
   domainName?: string;
 
   @FieldMetadata({
+    standardId: companyStandardFieldIds.address,
     type: FieldMetadataType.TEXT,
     label: 'Address',
     description: 'The company address',
@@ -52,6 +58,7 @@ export class CompanyObjectMetadata extends BaseObjectMetadata {
   address: string;
 
   @FieldMetadata({
+    standardId: companyStandardFieldIds.employees,
     type: FieldMetadataType.NUMBER,
     label: 'Employees',
     description: 'Number of employees in the company',
@@ -61,6 +68,7 @@ export class CompanyObjectMetadata extends BaseObjectMetadata {
   employees: number;
 
   @FieldMetadata({
+    standardId: companyStandardFieldIds.linkedinLink,
     type: FieldMetadataType.LINK,
     label: 'Linkedin',
     description: 'The company Linkedin account',
@@ -70,6 +78,7 @@ export class CompanyObjectMetadata extends BaseObjectMetadata {
   linkedinLink: LinkMetadata;
 
   @FieldMetadata({
+    standardId: companyStandardFieldIds.xLink,
     type: FieldMetadataType.LINK,
     label: 'X',
     description: 'The company Twitter/X account',
@@ -79,6 +88,7 @@ export class CompanyObjectMetadata extends BaseObjectMetadata {
   xLink: LinkMetadata;
 
   @FieldMetadata({
+    standardId: companyStandardFieldIds.annualRecurringRevenue,
     type: FieldMetadataType.CURRENCY,
     label: 'ARR',
     description:
@@ -89,6 +99,7 @@ export class CompanyObjectMetadata extends BaseObjectMetadata {
   annualRecurringRevenue: CurrencyMetadata;
 
   @FieldMetadata({
+    standardId: companyStandardFieldIds.idealCustomerProfile,
     type: FieldMetadataType.BOOLEAN,
     label: 'ICP',
     description:
@@ -99,6 +110,7 @@ export class CompanyObjectMetadata extends BaseObjectMetadata {
   idealCustomerProfile: boolean;
 
   @FieldMetadata({
+    standardId: companyStandardFieldIds.position,
     type: FieldMetadataType.POSITION,
     label: 'Position',
     description: 'Company record position',
@@ -110,6 +122,7 @@ export class CompanyObjectMetadata extends BaseObjectMetadata {
 
   // Relations
   @FieldMetadata({
+    standardId: companyStandardFieldIds.people,
     type: FieldMetadataType.RELATION,
     label: 'People',
     description: 'People linked to the company.',
@@ -123,6 +136,7 @@ export class CompanyObjectMetadata extends BaseObjectMetadata {
   people: PersonObjectMetadata[];
 
   @FieldMetadata({
+    standardId: companyStandardFieldIds.accountOwner,
     type: FieldMetadataType.RELATION,
     label: 'Account Owner',
     description:
@@ -134,6 +148,7 @@ export class CompanyObjectMetadata extends BaseObjectMetadata {
   accountOwner: WorkspaceMemberObjectMetadata;
 
   @FieldMetadata({
+    standardId: companyStandardFieldIds.activityTargets,
     type: FieldMetadataType.RELATION,
     label: 'Activities',
     description: 'Activities tied to the company',
@@ -148,6 +163,7 @@ export class CompanyObjectMetadata extends BaseObjectMetadata {
   activityTargets: ActivityTargetObjectMetadata[];
 
   @FieldMetadata({
+    standardId: companyStandardFieldIds.opportunities,
     type: FieldMetadataType.RELATION,
     label: 'Opportunities',
     description: 'Opportunities linked to the company.',
@@ -161,6 +177,7 @@ export class CompanyObjectMetadata extends BaseObjectMetadata {
   opportunities: OpportunityObjectMetadata[];
 
   @FieldMetadata({
+    standardId: companyStandardFieldIds.favorites,
     type: FieldMetadataType.RELATION,
     label: 'Favorites',
     description: 'Favorites linked to the company',
@@ -176,6 +193,7 @@ export class CompanyObjectMetadata extends BaseObjectMetadata {
   favorites: FavoriteObjectMetadata[];
 
   @FieldMetadata({
+    standardId: companyStandardFieldIds.attachments,
     type: FieldMetadataType.RELATION,
     label: 'Attachments',
     description: 'Attachments linked to the company.',

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/connected-account.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/connected-account.object-metadata.ts
@@ -4,6 +4,8 @@ import {
   RelationMetadataType,
   RelationOnDeleteAction,
 } from 'src/metadata/relation-metadata/relation-metadata.entity';
+import { connectedAccountStandardFieldIds } from 'src/workspace/workspace-sync-metadata/constants/standard-field-ids';
+import { standardObjectIds } from 'src/workspace/workspace-sync-metadata/constants/standard-object-ids';
 import { FieldMetadata } from 'src/workspace/workspace-sync-metadata/decorators/field-metadata.decorator';
 import { Gate } from 'src/workspace/workspace-sync-metadata/decorators/gate.decorator';
 import { IsSystem } from 'src/workspace/workspace-sync-metadata/decorators/is-system.decorator';
@@ -15,6 +17,7 @@ import { MessageChannelObjectMetadata } from 'src/workspace/workspace-sync-metad
 import { WorkspaceMemberObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/workspace-member.object-metadata';
 
 @ObjectMetadata({
+  standardId: standardObjectIds.connectedAccount,
   namePlural: 'connectedAccounts',
   labelSingular: 'Connected Account',
   labelPlural: 'Connected Accounts',
@@ -24,6 +27,7 @@ import { WorkspaceMemberObjectMetadata } from 'src/workspace/workspace-sync-meta
 @IsSystem()
 export class ConnectedAccountObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({
+    standardId: connectedAccountStandardFieldIds.handle,
     type: FieldMetadataType.TEXT,
     label: 'handle',
     description: 'The account handle (email, username, phone number, etc.)',
@@ -32,6 +36,7 @@ export class ConnectedAccountObjectMetadata extends BaseObjectMetadata {
   handle: string;
 
   @FieldMetadata({
+    standardId: connectedAccountStandardFieldIds.provider,
     type: FieldMetadataType.TEXT,
     label: 'provider',
     description: 'The account provider',
@@ -40,6 +45,7 @@ export class ConnectedAccountObjectMetadata extends BaseObjectMetadata {
   provider: string;
 
   @FieldMetadata({
+    standardId: connectedAccountStandardFieldIds.accessToken,
     type: FieldMetadataType.TEXT,
     label: 'Access Token',
     description: 'Messaging provider access token',
@@ -48,6 +54,7 @@ export class ConnectedAccountObjectMetadata extends BaseObjectMetadata {
   accessToken: string;
 
   @FieldMetadata({
+    standardId: connectedAccountStandardFieldIds.refreshToken,
     type: FieldMetadataType.TEXT,
     label: 'Refresh Token',
     description: 'Messaging provider refresh token',
@@ -56,6 +63,7 @@ export class ConnectedAccountObjectMetadata extends BaseObjectMetadata {
   refreshToken: string;
 
   @FieldMetadata({
+    standardId: connectedAccountStandardFieldIds.accountOwner,
     type: FieldMetadataType.RELATION,
     label: 'Account Owner',
     description: 'Account Owner',
@@ -65,6 +73,7 @@ export class ConnectedAccountObjectMetadata extends BaseObjectMetadata {
   accountOwner: WorkspaceMemberObjectMetadata;
 
   @FieldMetadata({
+    standardId: connectedAccountStandardFieldIds.lastSyncHistoryId,
     type: FieldMetadataType.TEXT,
     label: 'Last sync history ID',
     description: 'Last sync history ID',
@@ -73,6 +82,7 @@ export class ConnectedAccountObjectMetadata extends BaseObjectMetadata {
   lastSyncHistoryId: string;
 
   @FieldMetadata({
+    standardId: connectedAccountStandardFieldIds.messageChannels,
     type: FieldMetadataType.RELATION,
     label: 'Message Channel',
     description: 'Message Channel',
@@ -86,6 +96,7 @@ export class ConnectedAccountObjectMetadata extends BaseObjectMetadata {
   messageChannels: MessageChannelObjectMetadata[];
 
   @FieldMetadata({
+    standardId: connectedAccountStandardFieldIds.calendarChannels,
     type: FieldMetadataType.RELATION,
     label: 'Calendar Channel',
     description: 'Calendar Channel',

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/favorite.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/favorite.object-metadata.ts
@@ -1,4 +1,6 @@
 import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
+import { favoriteStandardFieldIds } from 'src/workspace/workspace-sync-metadata/constants/standard-field-ids';
+import { standardObjectIds } from 'src/workspace/workspace-sync-metadata/constants/standard-object-ids';
 import { CustomObjectMetadata } from 'src/workspace/workspace-sync-metadata/custom-objects/custom.object-metadata';
 import { DynamicRelationFieldMetadata } from 'src/workspace/workspace-sync-metadata/decorators/dynamic-field-metadata.interface';
 import { FieldMetadata } from 'src/workspace/workspace-sync-metadata/decorators/field-metadata.decorator';
@@ -12,6 +14,7 @@ import { PersonObjectMetadata } from 'src/workspace/workspace-sync-metadata/stan
 import { WorkspaceMemberObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/workspace-member.object-metadata';
 
 @ObjectMetadata({
+  standardId: standardObjectIds.favorite,
   namePlural: 'favorites',
   labelSingular: 'Favorite',
   labelPlural: 'Favorites',
@@ -21,6 +24,7 @@ import { WorkspaceMemberObjectMetadata } from 'src/workspace/workspace-sync-meta
 @IsSystem()
 export class FavoriteObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({
+    standardId: favoriteStandardFieldIds.position,
     type: FieldMetadataType.NUMBER,
     label: 'Position',
     description: 'Favorite position',
@@ -31,6 +35,7 @@ export class FavoriteObjectMetadata extends BaseObjectMetadata {
 
   // Relations
   @FieldMetadata({
+    standardId: favoriteStandardFieldIds.workspaceMember,
     type: FieldMetadataType.RELATION,
     label: 'Workspace Member',
     description: 'Favorite workspace member',
@@ -40,6 +45,7 @@ export class FavoriteObjectMetadata extends BaseObjectMetadata {
   workspaceMember: WorkspaceMemberObjectMetadata;
 
   @FieldMetadata({
+    standardId: favoriteStandardFieldIds.person,
     type: FieldMetadataType.RELATION,
     label: 'Person',
     description: 'Favorite person',
@@ -50,6 +56,7 @@ export class FavoriteObjectMetadata extends BaseObjectMetadata {
   person: PersonObjectMetadata;
 
   @FieldMetadata({
+    standardId: favoriteStandardFieldIds.company,
     type: FieldMetadataType.RELATION,
     label: 'Company',
     description: 'Favorite company',
@@ -60,6 +67,7 @@ export class FavoriteObjectMetadata extends BaseObjectMetadata {
   company: CompanyObjectMetadata;
 
   @FieldMetadata({
+    standardId: favoriteStandardFieldIds.opportunity,
     type: FieldMetadataType.RELATION,
     label: 'Opportunity',
     description: 'Favorite opportunity',
@@ -70,6 +78,7 @@ export class FavoriteObjectMetadata extends BaseObjectMetadata {
   opportunity: OpportunityObjectMetadata;
 
   @DynamicRelationFieldMetadata((oppositeObjectMetadata) => ({
+    standardId: favoriteStandardFieldIds.custom,
     name: oppositeObjectMetadata.nameSingular,
     label: oppositeObjectMetadata.labelSingular,
     description: `Favorite ${oppositeObjectMetadata.labelSingular}`,

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/message-channel-message-association.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/message-channel-message-association.object-metadata.ts
@@ -1,4 +1,6 @@
 import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
+import { messageChannelMessageAssociationStandardFieldIds } from 'src/workspace/workspace-sync-metadata/constants/standard-field-ids';
+import { standardObjectIds } from 'src/workspace/workspace-sync-metadata/constants/standard-object-ids';
 import { FieldMetadata } from 'src/workspace/workspace-sync-metadata/decorators/field-metadata.decorator';
 import { IsNullable } from 'src/workspace/workspace-sync-metadata/decorators/is-nullable.decorator';
 import { IsSystem } from 'src/workspace/workspace-sync-metadata/decorators/is-system.decorator';
@@ -9,6 +11,7 @@ import { MessageThreadObjectMetadata } from 'src/workspace/workspace-sync-metada
 import { MessageObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/message.object-metadata';
 
 @ObjectMetadata({
+  standardId: standardObjectIds.messageChannelMessageAssociation,
   namePlural: 'messageChannelMessageAssociations',
   labelSingular: 'Message Channel Message Association',
   labelPlural: 'Message Channel Message Associations',
@@ -18,6 +21,7 @@ import { MessageObjectMetadata } from 'src/workspace/workspace-sync-metadata/sta
 @IsSystem()
 export class MessageChannelMessageAssociationObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({
+    standardId: messageChannelMessageAssociationStandardFieldIds.messageChannel,
     type: FieldMetadataType.RELATION,
     label: 'Message Channel Id',
     description: 'Message Channel Id',
@@ -28,6 +32,7 @@ export class MessageChannelMessageAssociationObjectMetadata extends BaseObjectMe
   messageChannel: MessageChannelObjectMetadata;
 
   @FieldMetadata({
+    standardId: messageChannelMessageAssociationStandardFieldIds.message,
     type: FieldMetadataType.RELATION,
     label: 'Message Id',
     description: 'Message Id',
@@ -38,6 +43,8 @@ export class MessageChannelMessageAssociationObjectMetadata extends BaseObjectMe
   message: MessageObjectMetadata;
 
   @FieldMetadata({
+    standardId:
+      messageChannelMessageAssociationStandardFieldIds.messageExternalId,
     type: FieldMetadataType.TEXT,
     label: 'Message External Id',
     description: 'Message id from the messaging provider',
@@ -47,6 +54,7 @@ export class MessageChannelMessageAssociationObjectMetadata extends BaseObjectMe
   messageExternalId: string;
 
   @FieldMetadata({
+    standardId: messageChannelMessageAssociationStandardFieldIds.messageThread,
     type: FieldMetadataType.RELATION,
     label: 'Message Thread Id',
     description: 'Message Thread Id',
@@ -57,6 +65,8 @@ export class MessageChannelMessageAssociationObjectMetadata extends BaseObjectMe
   messageThread: MessageThreadObjectMetadata;
 
   @FieldMetadata({
+    standardId:
+      messageChannelMessageAssociationStandardFieldIds.messageThreadExternalId,
     type: FieldMetadataType.TEXT,
     label: 'Thread External Id',
     description: 'Thread id from the messaging provider',

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/message-channel.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/message-channel.object-metadata.ts
@@ -3,6 +3,8 @@ import {
   RelationMetadataType,
   RelationOnDeleteAction,
 } from 'src/metadata/relation-metadata/relation-metadata.entity';
+import { messageChannelStandardFieldIds } from 'src/workspace/workspace-sync-metadata/constants/standard-field-ids';
+import { standardObjectIds } from 'src/workspace/workspace-sync-metadata/constants/standard-object-ids';
 import { FieldMetadata } from 'src/workspace/workspace-sync-metadata/decorators/field-metadata.decorator';
 import { IsNullable } from 'src/workspace/workspace-sync-metadata/decorators/is-nullable.decorator';
 import { IsSystem } from 'src/workspace/workspace-sync-metadata/decorators/is-system.decorator';
@@ -13,6 +15,7 @@ import { ConnectedAccountObjectMetadata } from 'src/workspace/workspace-sync-met
 import { MessageChannelMessageAssociationObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/message-channel-message-association.object-metadata';
 
 @ObjectMetadata({
+  standardId: standardObjectIds.messageChannel,
   namePlural: 'messageChannels',
   labelSingular: 'Message Channel',
   labelPlural: 'Message Channels',
@@ -22,6 +25,7 @@ import { MessageChannelMessageAssociationObjectMetadata } from 'src/workspace/wo
 @IsSystem()
 export class MessageChannelObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({
+    standardId: messageChannelStandardFieldIds.visibility,
     type: FieldMetadataType.SELECT,
     label: 'Visibility',
     description: 'Visibility',
@@ -41,6 +45,7 @@ export class MessageChannelObjectMetadata extends BaseObjectMetadata {
   visibility: string;
 
   @FieldMetadata({
+    standardId: messageChannelStandardFieldIds.handle,
     type: FieldMetadataType.TEXT,
     label: 'Handle',
     description: 'Handle',
@@ -49,6 +54,7 @@ export class MessageChannelObjectMetadata extends BaseObjectMetadata {
   handle: string;
 
   @FieldMetadata({
+    standardId: messageChannelStandardFieldIds.connectedAccount,
     type: FieldMetadataType.RELATION,
     label: 'Connected Account',
     description: 'Connected Account',
@@ -58,6 +64,7 @@ export class MessageChannelObjectMetadata extends BaseObjectMetadata {
   connectedAccount: ConnectedAccountObjectMetadata;
 
   @FieldMetadata({
+    standardId: messageChannelStandardFieldIds.type,
     type: FieldMetadataType.SELECT,
     label: 'Type',
     description: 'Channel Type',
@@ -71,6 +78,7 @@ export class MessageChannelObjectMetadata extends BaseObjectMetadata {
   type: string;
 
   @FieldMetadata({
+    standardId: messageChannelStandardFieldIds.isContactAutoCreationEnabled,
     type: FieldMetadataType.BOOLEAN,
     label: 'Is Contact Auto Creation Enabled',
     description: 'Is Contact Auto Creation Enabled',
@@ -80,6 +88,8 @@ export class MessageChannelObjectMetadata extends BaseObjectMetadata {
   isContactAutoCreationEnabled: boolean;
 
   @FieldMetadata({
+    standardId:
+      messageChannelStandardFieldIds.messageChannelMessageAssociations,
     type: FieldMetadataType.RELATION,
     label: 'Message Channel Association',
     description: 'Messages from the channel.',

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/message-participant.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/message-participant.object-metadata.ts
@@ -1,4 +1,6 @@
 import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
+import { messageParticipantStandardFieldIds } from 'src/workspace/workspace-sync-metadata/constants/standard-field-ids';
+import { standardObjectIds } from 'src/workspace/workspace-sync-metadata/constants/standard-object-ids';
 import { FieldMetadata } from 'src/workspace/workspace-sync-metadata/decorators/field-metadata.decorator';
 import { IsNullable } from 'src/workspace/workspace-sync-metadata/decorators/is-nullable.decorator';
 import { IsSystem } from 'src/workspace/workspace-sync-metadata/decorators/is-system.decorator';
@@ -9,6 +11,7 @@ import { PersonObjectMetadata } from 'src/workspace/workspace-sync-metadata/stan
 import { WorkspaceMemberObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/workspace-member.object-metadata';
 
 @ObjectMetadata({
+  standardId: standardObjectIds.messageParticipant,
   namePlural: 'messageParticipants',
   labelSingular: 'Message Participant',
   labelPlural: 'Message Participants',
@@ -18,6 +21,7 @@ import { WorkspaceMemberObjectMetadata } from 'src/workspace/workspace-sync-meta
 @IsSystem()
 export class MessageParticipantObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({
+    standardId: messageParticipantStandardFieldIds.message,
     type: FieldMetadataType.RELATION,
     label: 'Message',
     description: 'Message',
@@ -27,6 +31,7 @@ export class MessageParticipantObjectMetadata extends BaseObjectMetadata {
   message: MessageObjectMetadata;
 
   @FieldMetadata({
+    standardId: messageParticipantStandardFieldIds.role,
     type: FieldMetadataType.SELECT,
     label: 'Role',
     description: 'Role',
@@ -42,6 +47,7 @@ export class MessageParticipantObjectMetadata extends BaseObjectMetadata {
   role: string;
 
   @FieldMetadata({
+    standardId: messageParticipantStandardFieldIds.handle,
     type: FieldMetadataType.TEXT,
     label: 'Handle',
     description: 'Handle',
@@ -50,6 +56,7 @@ export class MessageParticipantObjectMetadata extends BaseObjectMetadata {
   handle: string;
 
   @FieldMetadata({
+    standardId: messageParticipantStandardFieldIds.displayName,
     type: FieldMetadataType.TEXT,
     label: 'Display Name',
     description: 'Display Name',
@@ -58,6 +65,7 @@ export class MessageParticipantObjectMetadata extends BaseObjectMetadata {
   displayName: string;
 
   @FieldMetadata({
+    standardId: messageParticipantStandardFieldIds.person,
     type: FieldMetadataType.RELATION,
     label: 'Person',
     description: 'Person',
@@ -68,6 +76,7 @@ export class MessageParticipantObjectMetadata extends BaseObjectMetadata {
   person: PersonObjectMetadata;
 
   @FieldMetadata({
+    standardId: messageParticipantStandardFieldIds.workspaceMember,
     type: FieldMetadataType.RELATION,
     label: 'Workspace Member',
     description: 'Workspace member',

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/message-thread.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/message-thread.object-metadata.ts
@@ -3,6 +3,8 @@ import {
   RelationMetadataType,
   RelationOnDeleteAction,
 } from 'src/metadata/relation-metadata/relation-metadata.entity';
+import { messageThreadStandardFieldIds } from 'src/workspace/workspace-sync-metadata/constants/standard-field-ids';
+import { standardObjectIds } from 'src/workspace/workspace-sync-metadata/constants/standard-object-ids';
 import { FieldMetadata } from 'src/workspace/workspace-sync-metadata/decorators/field-metadata.decorator';
 import { IsNullable } from 'src/workspace/workspace-sync-metadata/decorators/is-nullable.decorator';
 import { IsSystem } from 'src/workspace/workspace-sync-metadata/decorators/is-system.decorator';
@@ -13,6 +15,7 @@ import { MessageChannelMessageAssociationObjectMetadata } from 'src/workspace/wo
 import { MessageObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/message.object-metadata';
 
 @ObjectMetadata({
+  standardId: standardObjectIds.messageThread,
   namePlural: 'messageThreads',
   labelSingular: 'Message Thread',
   labelPlural: 'Message Threads',
@@ -22,6 +25,7 @@ import { MessageObjectMetadata } from 'src/workspace/workspace-sync-metadata/sta
 @IsSystem()
 export class MessageThreadObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({
+    standardId: messageThreadStandardFieldIds.messages,
     type: FieldMetadataType.RELATION,
     label: 'Messages',
     description: 'Messages from the thread.',
@@ -36,6 +40,7 @@ export class MessageThreadObjectMetadata extends BaseObjectMetadata {
   messages: MessageObjectMetadata[];
 
   @FieldMetadata({
+    standardId: messageThreadStandardFieldIds.messageChannelMessageAssociations,
     type: FieldMetadataType.RELATION,
     label: 'Message Channel Association',
     description: 'Messages from the channel.',

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/message.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/message.object-metadata.ts
@@ -3,6 +3,8 @@ import {
   RelationMetadataType,
   RelationOnDeleteAction,
 } from 'src/metadata/relation-metadata/relation-metadata.entity';
+import { messageStandardFieldIds } from 'src/workspace/workspace-sync-metadata/constants/standard-field-ids';
+import { standardObjectIds } from 'src/workspace/workspace-sync-metadata/constants/standard-object-ids';
 import { FieldMetadata } from 'src/workspace/workspace-sync-metadata/decorators/field-metadata.decorator';
 import { IsNullable } from 'src/workspace/workspace-sync-metadata/decorators/is-nullable.decorator';
 import { IsSystem } from 'src/workspace/workspace-sync-metadata/decorators/is-system.decorator';
@@ -14,6 +16,7 @@ import { MessageParticipantObjectMetadata } from 'src/workspace/workspace-sync-m
 import { MessageThreadObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/message-thread.object-metadata';
 
 @ObjectMetadata({
+  standardId: standardObjectIds.message,
   namePlural: 'messages',
   labelSingular: 'Message',
   labelPlural: 'Messages',
@@ -23,6 +26,7 @@ import { MessageThreadObjectMetadata } from 'src/workspace/workspace-sync-metada
 @IsSystem()
 export class MessageObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({
+    standardId: messageStandardFieldIds.headerMessageId,
     type: FieldMetadataType.TEXT,
     label: 'Header message Id',
     description: 'Message id from the message header',
@@ -31,6 +35,7 @@ export class MessageObjectMetadata extends BaseObjectMetadata {
   headerMessageId: string;
 
   @FieldMetadata({
+    standardId: messageStandardFieldIds.messageThread,
     type: FieldMetadataType.RELATION,
     label: 'Message Thread Id',
     description: 'Message Thread Id',
@@ -41,6 +46,7 @@ export class MessageObjectMetadata extends BaseObjectMetadata {
   messageThread: MessageThreadObjectMetadata;
 
   @FieldMetadata({
+    standardId: messageStandardFieldIds.direction,
     type: FieldMetadataType.SELECT,
     label: 'Direction',
     description: 'Message Direction',
@@ -54,6 +60,7 @@ export class MessageObjectMetadata extends BaseObjectMetadata {
   direction: string;
 
   @FieldMetadata({
+    standardId: messageStandardFieldIds.subject,
     type: FieldMetadataType.TEXT,
     label: 'Subject',
     description: 'Subject',
@@ -62,6 +69,7 @@ export class MessageObjectMetadata extends BaseObjectMetadata {
   subject: string;
 
   @FieldMetadata({
+    standardId: messageStandardFieldIds.text,
     type: FieldMetadataType.TEXT,
     label: 'Text',
     description: 'Text',
@@ -70,6 +78,7 @@ export class MessageObjectMetadata extends BaseObjectMetadata {
   text: string;
 
   @FieldMetadata({
+    standardId: messageStandardFieldIds.receivedAt,
     type: FieldMetadataType.DATE_TIME,
     label: 'Received At',
     description: 'The date the message was received',
@@ -79,6 +88,7 @@ export class MessageObjectMetadata extends BaseObjectMetadata {
   receivedAt: string;
 
   @FieldMetadata({
+    standardId: messageStandardFieldIds.messageParticipants,
     type: FieldMetadataType.RELATION,
     label: 'Message Participants',
     description: 'Message Participants',
@@ -94,6 +104,7 @@ export class MessageObjectMetadata extends BaseObjectMetadata {
   messageParticipants: MessageParticipantObjectMetadata[];
 
   @FieldMetadata({
+    standardId: messageStandardFieldIds.messageChannelMessageAssociations,
     type: FieldMetadataType.RELATION,
     label: 'Message Channel Association',
     description: 'Messages from the channel.',

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/opportunity.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/opportunity.object-metadata.ts
@@ -4,6 +4,8 @@ import {
   RelationMetadataType,
   RelationOnDeleteAction,
 } from 'src/metadata/relation-metadata/relation-metadata.entity';
+import { opportunityStandardFieldIds } from 'src/workspace/workspace-sync-metadata/constants/standard-field-ids';
+import { standardObjectIds } from 'src/workspace/workspace-sync-metadata/constants/standard-object-ids';
 import { FieldMetadata } from 'src/workspace/workspace-sync-metadata/decorators/field-metadata.decorator';
 import { IsNullable } from 'src/workspace/workspace-sync-metadata/decorators/is-nullable.decorator';
 import { IsSystem } from 'src/workspace/workspace-sync-metadata/decorators/is-system.decorator';
@@ -18,6 +20,7 @@ import { PersonObjectMetadata } from 'src/workspace/workspace-sync-metadata/stan
 import { PipelineStepObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/pipeline-step.object-metadata';
 
 @ObjectMetadata({
+  standardId: standardObjectIds.opportunity,
   namePlural: 'opportunities',
   labelSingular: 'Opportunity',
   labelPlural: 'Opportunities',
@@ -26,6 +29,7 @@ import { PipelineStepObjectMetadata } from 'src/workspace/workspace-sync-metadat
 })
 export class OpportunityObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({
+    standardId: opportunityStandardFieldIds.name,
     type: FieldMetadataType.TEXT,
     label: 'Name',
     description: 'The opportunity name',
@@ -34,6 +38,7 @@ export class OpportunityObjectMetadata extends BaseObjectMetadata {
   name: string;
 
   @FieldMetadata({
+    standardId: opportunityStandardFieldIds.amount,
     type: FieldMetadataType.CURRENCY,
     label: 'Amount',
     description: 'Opportunity amount',
@@ -43,6 +48,7 @@ export class OpportunityObjectMetadata extends BaseObjectMetadata {
   amount: CurrencyMetadata;
 
   @FieldMetadata({
+    standardId: opportunityStandardFieldIds.closeDate,
     type: FieldMetadataType.DATE_TIME,
     label: 'Close date',
     description: 'Opportunity close date',
@@ -52,6 +58,7 @@ export class OpportunityObjectMetadata extends BaseObjectMetadata {
   closeDate: Date;
 
   @FieldMetadata({
+    standardId: opportunityStandardFieldIds.probability,
     type: FieldMetadataType.TEXT,
     label: 'Probability',
     description: 'Opportunity probability',
@@ -61,6 +68,7 @@ export class OpportunityObjectMetadata extends BaseObjectMetadata {
   probability: string;
 
   @FieldMetadata({
+    standardId: opportunityStandardFieldIds.stage,
     type: FieldMetadataType.SELECT,
     label: 'Stage',
     description: 'Opportunity stage',
@@ -82,6 +90,7 @@ export class OpportunityObjectMetadata extends BaseObjectMetadata {
   stage: string;
 
   @FieldMetadata({
+    standardId: opportunityStandardFieldIds.position,
     type: FieldMetadataType.POSITION,
     label: 'Position',
     description: 'Opportunity record position',
@@ -93,6 +102,7 @@ export class OpportunityObjectMetadata extends BaseObjectMetadata {
 
   // Relations
   @FieldMetadata({
+    standardId: opportunityStandardFieldIds.pipelineStep,
     type: FieldMetadataType.RELATION,
     label: 'Pipeline Step',
     description: 'Opportunity pipeline step',
@@ -103,6 +113,7 @@ export class OpportunityObjectMetadata extends BaseObjectMetadata {
   pipelineStep: PipelineStepObjectMetadata;
 
   @FieldMetadata({
+    standardId: opportunityStandardFieldIds.pointOfContact,
     type: FieldMetadataType.RELATION,
     label: 'Point of Contact',
     description: 'Opportunity point of contact',
@@ -113,6 +124,7 @@ export class OpportunityObjectMetadata extends BaseObjectMetadata {
   pointOfContact: PersonObjectMetadata;
 
   @FieldMetadata({
+    standardId: opportunityStandardFieldIds.company,
     type: FieldMetadataType.RELATION,
     label: 'Company',
     description: 'Opportunity company',
@@ -123,6 +135,7 @@ export class OpportunityObjectMetadata extends BaseObjectMetadata {
   company: CompanyObjectMetadata;
 
   @FieldMetadata({
+    standardId: opportunityStandardFieldIds.favorites,
     type: FieldMetadataType.RELATION,
     label: 'Favorites',
     description: 'Favorites linked to the opportunity',
@@ -138,6 +151,7 @@ export class OpportunityObjectMetadata extends BaseObjectMetadata {
   favorites: FavoriteObjectMetadata[];
 
   @FieldMetadata({
+    standardId: opportunityStandardFieldIds.activityTargets,
     type: FieldMetadataType.RELATION,
     label: 'Activities',
     description: 'Activities tied to the opportunity',
@@ -152,6 +166,7 @@ export class OpportunityObjectMetadata extends BaseObjectMetadata {
   activityTargets: ActivityTargetObjectMetadata[];
 
   @FieldMetadata({
+    standardId: opportunityStandardFieldIds.attachments,
     type: FieldMetadataType.RELATION,
     label: 'Attachments',
     description: 'Attachments linked to the opportunity.',

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/person.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/person.object-metadata.ts
@@ -5,6 +5,8 @@ import {
   RelationMetadataType,
   RelationOnDeleteAction,
 } from 'src/metadata/relation-metadata/relation-metadata.entity';
+import { personStandardFieldIds } from 'src/workspace/workspace-sync-metadata/constants/standard-field-ids';
+import { standardObjectIds } from 'src/workspace/workspace-sync-metadata/constants/standard-object-ids';
 import { FieldMetadata } from 'src/workspace/workspace-sync-metadata/decorators/field-metadata.decorator';
 import { Gate } from 'src/workspace/workspace-sync-metadata/decorators/gate.decorator';
 import { IsNullable } from 'src/workspace/workspace-sync-metadata/decorators/is-nullable.decorator';
@@ -21,6 +23,7 @@ import { MessageParticipantObjectMetadata } from 'src/workspace/workspace-sync-m
 import { OpportunityObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/opportunity.object-metadata';
 
 @ObjectMetadata({
+  standardId: standardObjectIds.person,
   namePlural: 'people',
   labelSingular: 'Person',
   labelPlural: 'People',
@@ -29,6 +32,7 @@ import { OpportunityObjectMetadata } from 'src/workspace/workspace-sync-metadata
 })
 export class PersonObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({
+    standardId: personStandardFieldIds.name,
     type: FieldMetadataType.FULL_NAME,
     label: 'Name',
     description: 'Contact’s name',
@@ -38,6 +42,7 @@ export class PersonObjectMetadata extends BaseObjectMetadata {
   name: FullNameMetadata;
 
   @FieldMetadata({
+    standardId: personStandardFieldIds.email,
     type: FieldMetadataType.EMAIL,
     label: 'Email',
     description: 'Contact’s Email',
@@ -46,6 +51,7 @@ export class PersonObjectMetadata extends BaseObjectMetadata {
   email: string;
 
   @FieldMetadata({
+    standardId: personStandardFieldIds.linkedinLink,
     type: FieldMetadataType.LINK,
     label: 'Linkedin',
     description: 'Contact’s Linkedin account',
@@ -55,6 +61,7 @@ export class PersonObjectMetadata extends BaseObjectMetadata {
   linkedinLink: LinkMetadata;
 
   @FieldMetadata({
+    standardId: personStandardFieldIds.xLink,
     type: FieldMetadataType.LINK,
     label: 'X',
     description: 'Contact’s X/Twitter account',
@@ -64,6 +71,7 @@ export class PersonObjectMetadata extends BaseObjectMetadata {
   xLink: LinkMetadata;
 
   @FieldMetadata({
+    standardId: personStandardFieldIds.jobTitle,
     type: FieldMetadataType.TEXT,
     label: 'Job Title',
     description: 'Contact’s job title',
@@ -72,6 +80,7 @@ export class PersonObjectMetadata extends BaseObjectMetadata {
   jobTitle: string;
 
   @FieldMetadata({
+    standardId: personStandardFieldIds.phone,
     type: FieldMetadataType.TEXT,
     label: 'Phone',
     description: 'Contact’s phone number',
@@ -80,6 +89,7 @@ export class PersonObjectMetadata extends BaseObjectMetadata {
   phone: string;
 
   @FieldMetadata({
+    standardId: personStandardFieldIds.city,
     type: FieldMetadataType.TEXT,
     label: 'City',
     description: 'Contact’s city',
@@ -88,6 +98,7 @@ export class PersonObjectMetadata extends BaseObjectMetadata {
   city: string;
 
   @FieldMetadata({
+    standardId: personStandardFieldIds.avatarUrl,
     type: FieldMetadataType.TEXT,
     label: 'Avatar',
     description: 'Contact’s avatar',
@@ -97,6 +108,7 @@ export class PersonObjectMetadata extends BaseObjectMetadata {
   avatarUrl: string;
 
   @FieldMetadata({
+    standardId: personStandardFieldIds.position,
     type: FieldMetadataType.POSITION,
     label: 'Position',
     description: 'Person record Position',
@@ -108,6 +120,7 @@ export class PersonObjectMetadata extends BaseObjectMetadata {
 
   // Relations
   @FieldMetadata({
+    standardId: personStandardFieldIds.company,
     type: FieldMetadataType.RELATION,
     label: 'Company',
     description: 'Contact’s company',
@@ -118,6 +131,7 @@ export class PersonObjectMetadata extends BaseObjectMetadata {
   company: CompanyObjectMetadata;
 
   @FieldMetadata({
+    standardId: personStandardFieldIds.pointOfContactForOpportunities,
     type: FieldMetadataType.RELATION,
     label: 'POC for Opportunities',
     description: 'Point of Contact for Opportunities',
@@ -131,6 +145,7 @@ export class PersonObjectMetadata extends BaseObjectMetadata {
   pointOfContactForOpportunities: OpportunityObjectMetadata[];
 
   @FieldMetadata({
+    standardId: personStandardFieldIds.activityTargets,
     type: FieldMetadataType.RELATION,
     label: 'Activities',
     description: 'Activities tied to the contact',
@@ -144,6 +159,7 @@ export class PersonObjectMetadata extends BaseObjectMetadata {
   activityTargets: ActivityTargetObjectMetadata[];
 
   @FieldMetadata({
+    standardId: personStandardFieldIds.favorites,
     type: FieldMetadataType.RELATION,
     label: 'Favorites',
     description: 'Favorites linked to the contact',
@@ -158,6 +174,7 @@ export class PersonObjectMetadata extends BaseObjectMetadata {
   favorites: FavoriteObjectMetadata[];
 
   @FieldMetadata({
+    standardId: personStandardFieldIds.attachments,
     type: FieldMetadataType.RELATION,
     label: 'Attachments',
     description: 'Attachments linked to the contact.',
@@ -171,6 +188,7 @@ export class PersonObjectMetadata extends BaseObjectMetadata {
   attachments: AttachmentObjectMetadata[];
 
   @FieldMetadata({
+    standardId: personStandardFieldIds.messageParticipants,
     type: FieldMetadataType.RELATION,
     label: 'Message Participants',
     description: 'Message Participants',
@@ -185,6 +203,7 @@ export class PersonObjectMetadata extends BaseObjectMetadata {
   messageParticipants: MessageParticipantObjectMetadata[];
 
   @FieldMetadata({
+    standardId: personStandardFieldIds.calendarEventAttendees,
     type: FieldMetadataType.RELATION,
     label: 'Calendar Event Attendees',
     description: 'Calendar Event Attendees',

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/pipeline-step.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/pipeline-step.object-metadata.ts
@@ -1,5 +1,7 @@
 import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
 import { RelationMetadataType } from 'src/metadata/relation-metadata/relation-metadata.entity';
+import { pipelineStepStandardFieldIds } from 'src/workspace/workspace-sync-metadata/constants/standard-field-ids';
+import { standardObjectIds } from 'src/workspace/workspace-sync-metadata/constants/standard-object-ids';
 import { FieldMetadata } from 'src/workspace/workspace-sync-metadata/decorators/field-metadata.decorator';
 import { IsNullable } from 'src/workspace/workspace-sync-metadata/decorators/is-nullable.decorator';
 import { IsSystem } from 'src/workspace/workspace-sync-metadata/decorators/is-system.decorator';
@@ -9,6 +11,7 @@ import { BaseObjectMetadata } from 'src/workspace/workspace-sync-metadata/standa
 import { OpportunityObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/opportunity.object-metadata';
 
 @ObjectMetadata({
+  standardId: standardObjectIds.pipelineStep,
   namePlural: 'pipelineSteps',
   labelSingular: 'Pipeline Step',
   labelPlural: 'Pipeline Steps',
@@ -18,6 +21,7 @@ import { OpportunityObjectMetadata } from 'src/workspace/workspace-sync-metadata
 @IsSystem()
 export class PipelineStepObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({
+    standardId: pipelineStepStandardFieldIds.name,
     type: FieldMetadataType.TEXT,
     label: 'Name',
     description: 'Pipeline Step name',
@@ -26,6 +30,7 @@ export class PipelineStepObjectMetadata extends BaseObjectMetadata {
   name: string;
 
   @FieldMetadata({
+    standardId: pipelineStepStandardFieldIds.color,
     type: FieldMetadataType.TEXT,
     label: 'Color',
     description: 'Pipeline Step color',
@@ -34,6 +39,7 @@ export class PipelineStepObjectMetadata extends BaseObjectMetadata {
   color: string;
 
   @FieldMetadata({
+    standardId: pipelineStepStandardFieldIds.position,
     type: FieldMetadataType.NUMBER,
     label: 'Position',
     description: 'Pipeline Step position',
@@ -45,6 +51,7 @@ export class PipelineStepObjectMetadata extends BaseObjectMetadata {
 
   // Relations
   @FieldMetadata({
+    standardId: pipelineStepStandardFieldIds.opportunities,
     type: FieldMetadataType.RELATION,
     label: 'Opportunities',
     description: 'Opportunities linked to the step.',

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/view-field.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/view-field.object-metadata.ts
@@ -1,4 +1,6 @@
 import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
+import { viewFieldStandardFieldIds } from 'src/workspace/workspace-sync-metadata/constants/standard-field-ids';
+import { standardObjectIds } from 'src/workspace/workspace-sync-metadata/constants/standard-object-ids';
 import { FieldMetadata } from 'src/workspace/workspace-sync-metadata/decorators/field-metadata.decorator';
 import { IsNullable } from 'src/workspace/workspace-sync-metadata/decorators/is-nullable.decorator';
 import { IsSystem } from 'src/workspace/workspace-sync-metadata/decorators/is-system.decorator';
@@ -7,6 +9,7 @@ import { BaseObjectMetadata } from 'src/workspace/workspace-sync-metadata/standa
 import { ViewObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/view.object-metadata';
 
 @ObjectMetadata({
+  standardId: standardObjectIds.viewField,
   namePlural: 'viewFields',
   labelSingular: 'View Field',
   labelPlural: 'View Fields',
@@ -16,6 +19,7 @@ import { ViewObjectMetadata } from 'src/workspace/workspace-sync-metadata/standa
 @IsSystem()
 export class ViewFieldObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({
+    standardId: viewFieldStandardFieldIds.fieldMetadataId,
     type: FieldMetadataType.UUID,
     label: 'Field Metadata Id',
     description: 'View Field target field',
@@ -24,6 +28,7 @@ export class ViewFieldObjectMetadata extends BaseObjectMetadata {
   fieldMetadataId: string;
 
   @FieldMetadata({
+    standardId: viewFieldStandardFieldIds.isVisible,
     type: FieldMetadataType.BOOLEAN,
     label: 'Visible',
     description: 'View Field visibility',
@@ -33,6 +38,7 @@ export class ViewFieldObjectMetadata extends BaseObjectMetadata {
   isVisible: boolean;
 
   @FieldMetadata({
+    standardId: viewFieldStandardFieldIds.size,
     type: FieldMetadataType.NUMBER,
     label: 'Size',
     description: 'View Field size',
@@ -42,6 +48,7 @@ export class ViewFieldObjectMetadata extends BaseObjectMetadata {
   size: number;
 
   @FieldMetadata({
+    standardId: viewFieldStandardFieldIds.position,
     type: FieldMetadataType.NUMBER,
     label: 'Position',
     description: 'View Field position',
@@ -51,6 +58,7 @@ export class ViewFieldObjectMetadata extends BaseObjectMetadata {
   position: number;
 
   @FieldMetadata({
+    standardId: viewFieldStandardFieldIds.view,
     type: FieldMetadataType.RELATION,
     label: 'View',
     description: 'View Field related view',

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/view-filter.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/view-filter.object-metadata.ts
@@ -1,4 +1,6 @@
 import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
+import { viewFilterStandardFieldIds } from 'src/workspace/workspace-sync-metadata/constants/standard-field-ids';
+import { standardObjectIds } from 'src/workspace/workspace-sync-metadata/constants/standard-object-ids';
 import { FieldMetadata } from 'src/workspace/workspace-sync-metadata/decorators/field-metadata.decorator';
 import { IsNullable } from 'src/workspace/workspace-sync-metadata/decorators/is-nullable.decorator';
 import { IsSystem } from 'src/workspace/workspace-sync-metadata/decorators/is-system.decorator';
@@ -7,6 +9,7 @@ import { BaseObjectMetadata } from 'src/workspace/workspace-sync-metadata/standa
 import { ViewObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/view.object-metadata';
 
 @ObjectMetadata({
+  standardId: standardObjectIds.viewFilter,
   namePlural: 'viewFilters',
   labelSingular: 'View Filter',
   labelPlural: 'View Filters',
@@ -16,6 +19,7 @@ import { ViewObjectMetadata } from 'src/workspace/workspace-sync-metadata/standa
 @IsSystem()
 export class ViewFilterObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({
+    standardId: viewFilterStandardFieldIds.fieldMetadataId,
     type: FieldMetadataType.UUID,
     label: 'Field Metadata Id',
     description: 'View Filter target field',
@@ -23,6 +27,7 @@ export class ViewFilterObjectMetadata extends BaseObjectMetadata {
   fieldMetadataId: string;
 
   @FieldMetadata({
+    standardId: viewFilterStandardFieldIds.operand,
     type: FieldMetadataType.TEXT,
     label: 'Operand',
     description: 'View Filter operand',
@@ -31,6 +36,7 @@ export class ViewFilterObjectMetadata extends BaseObjectMetadata {
   operand: string;
 
   @FieldMetadata({
+    standardId: viewFilterStandardFieldIds.value,
     type: FieldMetadataType.TEXT,
     label: 'Value',
     description: 'View Filter value',
@@ -38,6 +44,7 @@ export class ViewFilterObjectMetadata extends BaseObjectMetadata {
   value: string;
 
   @FieldMetadata({
+    standardId: viewFilterStandardFieldIds.displayValue,
     type: FieldMetadataType.TEXT,
     label: 'Display Value',
     description: 'View Filter Display Value',
@@ -45,6 +52,7 @@ export class ViewFilterObjectMetadata extends BaseObjectMetadata {
   displayValue: string;
 
   @FieldMetadata({
+    standardId: viewFilterStandardFieldIds.view,
     type: FieldMetadataType.RELATION,
     label: 'View',
     description: 'View Filter related view',

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/view-sort.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/view-sort.object-metadata.ts
@@ -1,4 +1,6 @@
 import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
+import { viewSortStandardFieldIds } from 'src/workspace/workspace-sync-metadata/constants/standard-field-ids';
+import { standardObjectIds } from 'src/workspace/workspace-sync-metadata/constants/standard-object-ids';
 import { FieldMetadata } from 'src/workspace/workspace-sync-metadata/decorators/field-metadata.decorator';
 import { IsNullable } from 'src/workspace/workspace-sync-metadata/decorators/is-nullable.decorator';
 import { IsSystem } from 'src/workspace/workspace-sync-metadata/decorators/is-system.decorator';
@@ -7,6 +9,7 @@ import { BaseObjectMetadata } from 'src/workspace/workspace-sync-metadata/standa
 import { ViewObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/view.object-metadata';
 
 @ObjectMetadata({
+  standardId: standardObjectIds.viewSort,
   namePlural: 'viewSorts',
   labelSingular: 'View Sort',
   labelPlural: 'View Sorts',
@@ -16,6 +19,7 @@ import { ViewObjectMetadata } from 'src/workspace/workspace-sync-metadata/standa
 @IsSystem()
 export class ViewSortObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({
+    standardId: viewSortStandardFieldIds.fieldMetadataId,
     type: FieldMetadataType.UUID,
     label: 'Field Metadata Id',
     description: 'View Sort target field',
@@ -24,6 +28,7 @@ export class ViewSortObjectMetadata extends BaseObjectMetadata {
   fieldMetadataId: string;
 
   @FieldMetadata({
+    standardId: viewSortStandardFieldIds.direction,
     type: FieldMetadataType.TEXT,
     label: 'Direction',
     description: 'View Sort direction',
@@ -32,6 +37,7 @@ export class ViewSortObjectMetadata extends BaseObjectMetadata {
   direction: string;
 
   @FieldMetadata({
+    standardId: viewSortStandardFieldIds.view,
     type: FieldMetadataType.RELATION,
     label: 'View',
     description: 'View Sort related view',

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/view.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/view.object-metadata.ts
@@ -1,5 +1,7 @@
 import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
 import { RelationMetadataType } from 'src/metadata/relation-metadata/relation-metadata.entity';
+import { viewStandardFieldIds } from 'src/workspace/workspace-sync-metadata/constants/standard-field-ids';
+import { standardObjectIds } from 'src/workspace/workspace-sync-metadata/constants/standard-object-ids';
 import { FieldMetadata } from 'src/workspace/workspace-sync-metadata/decorators/field-metadata.decorator';
 import { IsNullable } from 'src/workspace/workspace-sync-metadata/decorators/is-nullable.decorator';
 import { IsSystem } from 'src/workspace/workspace-sync-metadata/decorators/is-system.decorator';
@@ -11,6 +13,7 @@ import { ViewFilterObjectMetadata } from 'src/workspace/workspace-sync-metadata/
 import { ViewSortObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/view-sort.object-metadata';
 
 @ObjectMetadata({
+  standardId: standardObjectIds.view,
   namePlural: 'views',
   labelSingular: 'View',
   labelPlural: 'Views',
@@ -20,6 +23,7 @@ import { ViewSortObjectMetadata } from 'src/workspace/workspace-sync-metadata/st
 @IsSystem()
 export class ViewObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({
+    standardId: viewStandardFieldIds.name,
     type: FieldMetadataType.TEXT,
     label: 'Name',
     description: 'View name',
@@ -27,6 +31,7 @@ export class ViewObjectMetadata extends BaseObjectMetadata {
   name: string;
 
   @FieldMetadata({
+    standardId: viewStandardFieldIds.objectMetadataId,
     type: FieldMetadataType.UUID,
     label: 'Object Metadata Id',
     description: 'View target object',
@@ -34,6 +39,7 @@ export class ViewObjectMetadata extends BaseObjectMetadata {
   objectMetadataId: string;
 
   @FieldMetadata({
+    standardId: viewStandardFieldIds.type,
     type: FieldMetadataType.TEXT,
     label: 'Type',
     description: 'View type',
@@ -42,6 +48,7 @@ export class ViewObjectMetadata extends BaseObjectMetadata {
   type: string;
 
   @FieldMetadata({
+    standardId: viewStandardFieldIds.key,
     type: FieldMetadataType.SELECT,
     label: 'Key',
     description: 'View key',
@@ -52,6 +59,7 @@ export class ViewObjectMetadata extends BaseObjectMetadata {
   key: string;
 
   @FieldMetadata({
+    standardId: viewStandardFieldIds.icon,
     type: FieldMetadataType.TEXT,
     label: 'Icon',
     description: 'View icon',
@@ -59,6 +67,7 @@ export class ViewObjectMetadata extends BaseObjectMetadata {
   icon: string;
 
   @FieldMetadata({
+    standardId: viewStandardFieldIds.position,
     type: FieldMetadataType.POSITION,
     label: 'Position',
     description: 'View position',
@@ -67,6 +76,7 @@ export class ViewObjectMetadata extends BaseObjectMetadata {
   position: number;
 
   @FieldMetadata({
+    standardId: viewStandardFieldIds.isCompact,
     type: FieldMetadataType.BOOLEAN,
     label: 'Compact View',
     description: 'Describes if the view is in compact mode',
@@ -75,6 +85,7 @@ export class ViewObjectMetadata extends BaseObjectMetadata {
   isCompact: boolean;
 
   @FieldMetadata({
+    standardId: viewStandardFieldIds.viewFields,
     type: FieldMetadataType.RELATION,
     label: 'View Fields',
     description: 'View Fields',
@@ -88,6 +99,7 @@ export class ViewObjectMetadata extends BaseObjectMetadata {
   viewFields: ViewFieldObjectMetadata[];
 
   @FieldMetadata({
+    standardId: viewStandardFieldIds.viewFilters,
     type: FieldMetadataType.RELATION,
     label: 'View Filters',
     description: 'View Filters',
@@ -101,6 +113,7 @@ export class ViewObjectMetadata extends BaseObjectMetadata {
   viewFilters: ViewFilterObjectMetadata[];
 
   @FieldMetadata({
+    standardId: viewStandardFieldIds.viewSorts,
     type: FieldMetadataType.RELATION,
     label: 'View Sorts',
     description: 'View Sorts',

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/webhook.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/webhook.object-metadata.ts
@@ -1,10 +1,13 @@
 import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
+import { webhookStandardFieldIds } from 'src/workspace/workspace-sync-metadata/constants/standard-field-ids';
+import { standardObjectIds } from 'src/workspace/workspace-sync-metadata/constants/standard-object-ids';
 import { FieldMetadata } from 'src/workspace/workspace-sync-metadata/decorators/field-metadata.decorator';
 import { IsSystem } from 'src/workspace/workspace-sync-metadata/decorators/is-system.decorator';
 import { ObjectMetadata } from 'src/workspace/workspace-sync-metadata/decorators/object-metadata.decorator';
 import { BaseObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/base.object-metadata';
 
 @ObjectMetadata({
+  standardId: standardObjectIds.webhook,
   namePlural: 'webhooks',
   labelSingular: 'Webhook',
   labelPlural: 'Webhooks',
@@ -14,6 +17,7 @@ import { BaseObjectMetadata } from 'src/workspace/workspace-sync-metadata/standa
 @IsSystem()
 export class WebhookObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({
+    standardId: webhookStandardFieldIds.targetUrl,
     type: FieldMetadataType.TEXT,
     label: 'Target Url',
     description: 'Webhook target url',
@@ -22,6 +26,7 @@ export class WebhookObjectMetadata extends BaseObjectMetadata {
   targetUrl: string;
 
   @FieldMetadata({
+    standardId: webhookStandardFieldIds.operation,
     type: FieldMetadataType.TEXT,
     label: 'Operation',
     description: 'Webhook operation',

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/workspace-member.object-metadata.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/standard-objects/workspace-member.object-metadata.ts
@@ -4,6 +4,8 @@ import {
   RelationMetadataType,
   RelationOnDeleteAction,
 } from 'src/metadata/relation-metadata/relation-metadata.entity';
+import { workspaceMemberStandardFieldIds } from 'src/workspace/workspace-sync-metadata/constants/standard-field-ids';
+import { standardObjectIds } from 'src/workspace/workspace-sync-metadata/constants/standard-object-ids';
 import { FieldMetadata } from 'src/workspace/workspace-sync-metadata/decorators/field-metadata.decorator';
 import { Gate } from 'src/workspace/workspace-sync-metadata/decorators/gate.decorator';
 import { IsSystem } from 'src/workspace/workspace-sync-metadata/decorators/is-system.decorator';
@@ -21,6 +23,7 @@ import { FavoriteObjectMetadata } from 'src/workspace/workspace-sync-metadata/st
 import { MessageParticipantObjectMetadata } from 'src/workspace/workspace-sync-metadata/standard-objects/message-participant.object-metadata';
 
 @ObjectMetadata({
+  standardId: standardObjectIds.workspaceMember,
   namePlural: 'workspaceMembers',
   labelSingular: 'Workspace Member',
   labelPlural: 'Workspace Members',
@@ -30,6 +33,7 @@ import { MessageParticipantObjectMetadata } from 'src/workspace/workspace-sync-m
 @IsSystem()
 export class WorkspaceMemberObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({
+    standardId: workspaceMemberStandardFieldIds.name,
     type: FieldMetadataType.FULL_NAME,
     label: 'Name',
     description: 'Workspace member name',
@@ -38,6 +42,7 @@ export class WorkspaceMemberObjectMetadata extends BaseObjectMetadata {
   name: FullNameMetadata;
 
   @FieldMetadata({
+    standardId: workspaceMemberStandardFieldIds.colorScheme,
     type: FieldMetadataType.TEXT,
     label: 'Color Scheme',
     description: 'Preferred color scheme',
@@ -47,6 +52,7 @@ export class WorkspaceMemberObjectMetadata extends BaseObjectMetadata {
   colorScheme: string;
 
   @FieldMetadata({
+    standardId: workspaceMemberStandardFieldIds.locale,
     type: FieldMetadataType.TEXT,
     label: 'Language',
     description: 'Preferred language',
@@ -56,6 +62,7 @@ export class WorkspaceMemberObjectMetadata extends BaseObjectMetadata {
   locale: string;
 
   @FieldMetadata({
+    standardId: workspaceMemberStandardFieldIds.avatarUrl,
     type: FieldMetadataType.TEXT,
     label: 'Avatar Url',
     description: 'Workspace member avatar',
@@ -64,6 +71,7 @@ export class WorkspaceMemberObjectMetadata extends BaseObjectMetadata {
   avatarUrl: string;
 
   @FieldMetadata({
+    standardId: workspaceMemberStandardFieldIds.userEmail,
     type: FieldMetadataType.TEXT,
     label: 'User Email',
     description: 'Related user email address',
@@ -72,6 +80,7 @@ export class WorkspaceMemberObjectMetadata extends BaseObjectMetadata {
   userEmail: string;
 
   @FieldMetadata({
+    standardId: workspaceMemberStandardFieldIds.userId,
     type: FieldMetadataType.UUID,
     label: 'User Id',
     description: 'Associated User Id',
@@ -81,6 +90,7 @@ export class WorkspaceMemberObjectMetadata extends BaseObjectMetadata {
 
   // Relations
   @FieldMetadata({
+    standardId: workspaceMemberStandardFieldIds.authoredActivities,
     type: FieldMetadataType.RELATION,
     label: 'Authored activities',
     description: 'Activities created by the workspace member',
@@ -94,6 +104,7 @@ export class WorkspaceMemberObjectMetadata extends BaseObjectMetadata {
   authoredActivities: ActivityObjectMetadata[];
 
   @FieldMetadata({
+    standardId: workspaceMemberStandardFieldIds.assignedActivities,
     type: FieldMetadataType.RELATION,
     label: 'Assigned activities',
     description: 'Activities assigned to the workspace member',
@@ -107,6 +118,7 @@ export class WorkspaceMemberObjectMetadata extends BaseObjectMetadata {
   assignedActivities: ActivityObjectMetadata[];
 
   @FieldMetadata({
+    standardId: workspaceMemberStandardFieldIds.favorites,
     type: FieldMetadataType.RELATION,
     label: 'Favorites',
     description: 'Favorites linked to the workspace member',
@@ -120,6 +132,7 @@ export class WorkspaceMemberObjectMetadata extends BaseObjectMetadata {
   favorites: FavoriteObjectMetadata[];
 
   @FieldMetadata({
+    standardId: workspaceMemberStandardFieldIds.accountOwnerForCompanies,
     type: FieldMetadataType.RELATION,
     label: 'Account Owner For Companies',
     description: 'Account owner for companies',
@@ -133,6 +146,7 @@ export class WorkspaceMemberObjectMetadata extends BaseObjectMetadata {
   accountOwnerForCompanies: CompanyObjectMetadata[];
 
   @FieldMetadata({
+    standardId: workspaceMemberStandardFieldIds.authoredAttachments,
     type: FieldMetadataType.RELATION,
     label: 'Authored attachments',
     description: 'Attachments created by the workspace member',
@@ -146,6 +160,7 @@ export class WorkspaceMemberObjectMetadata extends BaseObjectMetadata {
   authoredAttachments: AttachmentObjectMetadata[];
 
   @FieldMetadata({
+    standardId: workspaceMemberStandardFieldIds.authoredComments,
     type: FieldMetadataType.RELATION,
     label: 'Authored comments',
     description: 'Authored comments',
@@ -159,6 +174,7 @@ export class WorkspaceMemberObjectMetadata extends BaseObjectMetadata {
   authoredComments: CommentObjectMetadata[];
 
   @FieldMetadata({
+    standardId: workspaceMemberStandardFieldIds.connectedAccounts,
     type: FieldMetadataType.RELATION,
     label: 'Connected accounts',
     description: 'Connected accounts',
@@ -172,6 +188,7 @@ export class WorkspaceMemberObjectMetadata extends BaseObjectMetadata {
   connectedAccounts: ConnectedAccountObjectMetadata[];
 
   @FieldMetadata({
+    standardId: workspaceMemberStandardFieldIds.messageParticipants,
     type: FieldMetadataType.RELATION,
     label: 'Message Participants',
     description: 'Message Participants',
@@ -185,6 +202,7 @@ export class WorkspaceMemberObjectMetadata extends BaseObjectMetadata {
   messageParticipants: MessageParticipantObjectMetadata[];
 
   @FieldMetadata({
+    standardId: workspaceMemberStandardFieldIds.blocklist,
     type: FieldMetadataType.RELATION,
     label: 'Blocklist',
     description: 'Blocklisted handles',
@@ -198,6 +216,7 @@ export class WorkspaceMemberObjectMetadata extends BaseObjectMetadata {
   blocklist: BlocklistObjectMetadata[];
 
   @FieldMetadata({
+    standardId: workspaceMemberStandardFieldIds.calendarEventAttendees,
     type: FieldMetadataType.RELATION,
     label: 'Calendar Event Attendees',
     description: 'Calendar Event Attendees',

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/utils/compute-standard-object.util.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/utils/compute-standard-object.util.ts
@@ -7,9 +7,12 @@ import { ComputedPartialFieldMetadata } from 'src/workspace/workspace-sync-metad
 import { ObjectMetadataEntity } from 'src/metadata/object-metadata/object-metadata.entity';
 import { generateTargetColumnMap } from 'src/metadata/field-metadata/utils/generate-target-column-map.util';
 import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
+import { createDeterministicUuid } from 'src/workspace/workspace-sync-metadata/utils/create-deterministic-uuid.util';
 
 export const computeStandardObject = (
-  standardObjectMetadata: PartialObjectMetadata,
+  standardObjectMetadata: Omit<PartialObjectMetadata, 'standardId'> & {
+    standardId: string | null;
+  },
   originalObjectMetadata: ObjectMetadataEntity,
   customObjectMetadataCollection: ObjectMetadataEntity[] = [],
 ): ComputedPartialObjectMetadata => {
@@ -33,6 +36,7 @@ export const computeStandardObject = (
         // Foreign key
         fields.push({
           ...rest,
+          standardId: createDeterministicUuid(data.standardId),
           name: joinColumn,
           type: FieldMetadataType.UUID,
           label: `${data.label} ID (foreign key)`,

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/utils/create-deterministic-uuid.util.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/utils/create-deterministic-uuid.util.ts
@@ -1,0 +1,10 @@
+import { createHash } from 'crypto';
+
+export const createDeterministicUuid = (inputUuid: string): string => {
+  const hash = createHash('sha256').update(inputUuid).digest('hex');
+
+  return `20202020-4${hash.substring(0, 3)}-${hash.substring(
+    3,
+    7,
+  )}-8${hash.substring(7, 10)}-${hash.substring(10, 22)}`;
+};

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/utils/create-deterministic-uuid.util.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/utils/create-deterministic-uuid.util.ts
@@ -3,8 +3,8 @@ import { createHash } from 'crypto';
 export const createDeterministicUuid = (inputUuid: string): string => {
   const hash = createHash('sha256').update(inputUuid).digest('hex');
 
-  return `20202020-4${hash.substring(0, 3)}-${hash.substring(
-    3,
+  return `20202020-${hash.substring(0, 4)}-4${hash.substring(
+    4,
     7,
   )}-8${hash.substring(7, 10)}-${hash.substring(10, 22)}`;
 };

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/utils/sync-metadata.util.spec.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/utils/sync-metadata.util.spec.ts
@@ -7,6 +7,7 @@ describe('mapObjectMetadataByUniqueIdentifier', () => {
   it('should convert an array of ObjectMetadataEntity objects into a map', () => {
     const arr: DeepPartial<ObjectMetadataEntity>[] = [
       {
+        standardId: 'user',
         nameSingular: 'user',
         fields: [
           { name: 'id', type: FieldMetadataType.UUID },
@@ -14,6 +15,7 @@ describe('mapObjectMetadataByUniqueIdentifier', () => {
         ],
       },
       {
+        standardId: 'product',
         nameSingular: 'product',
         fields: [
           { name: 'id', type: FieldMetadataType.UUID },
@@ -29,6 +31,7 @@ describe('mapObjectMetadataByUniqueIdentifier', () => {
 
     expect(mappedObject).toEqual({
       user: {
+        standardId: 'user',
         nameSingular: 'user',
         fields: [
           { name: 'id', type: FieldMetadataType.UUID },
@@ -36,6 +39,7 @@ describe('mapObjectMetadataByUniqueIdentifier', () => {
         ],
       },
       product: {
+        standardId: 'product',
         nameSingular: 'product',
         fields: [
           { name: 'id', type: FieldMetadataType.UUID },

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/utils/sync-metadata.util.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/utils/sync-metadata.util.ts
@@ -7,13 +7,20 @@
  * @returns A map of object metadata, with nameSingular as the key and the object as the value.
  */
 export const mapObjectMetadataByUniqueIdentifier = <
-  T extends { nameSingular: string },
+  T extends { standardId: string | null },
 >(
   arr: T[],
+  keyFactory: (obj: T) => string | null = (obj) => obj.standardId,
 ): Record<string, T> => {
   return arr.reduce(
     (acc, curr) => {
-      acc[curr.nameSingular] = {
+      const key = keyFactory(curr);
+
+      if (!key) {
+        return acc;
+      }
+
+      acc[key] = {
         ...curr,
       };
 

--- a/packages/twenty-server/src/workspace/workspace-sync-metadata/workspace-sync-metadata.module.ts
+++ b/packages/twenty-server/src/workspace/workspace-sync-metadata/workspace-sync-metadata.module.ts
@@ -40,6 +40,6 @@ import { WorkspaceMigrationBuilderModule } from 'src/workspace/workspace-migrati
     WorkspaceSyncFieldMetadataService,
     WorkspaceSyncMetadataService,
   ],
-  exports: [WorkspaceSyncMetadataService],
+  exports: [...workspaceSyncMetadataFactories, WorkspaceSyncMetadataService],
 })
 export class WorkspaceSyncMetadataModule {}


### PR DESCRIPTION
This PR is adding a new property called `standardId` for `FieldMetadata` and `ObjectMetadata`.
The goal of this one is to have a constant id for a standard field or an object that allow to properly renamed them, without dropping all the data.
This property is required for `@ObjectMetadata` and `@FieldMetadata` decorators.
Ids are saved in constant files, the uuid shouldn't be edited to avoid wrong migration.

Fix #3621 