### PR TITLE
Allowing to open options for an opportunity on company record.

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-show/record-detail-section/components/RecordDetailRelationRecordsListItem.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-show/record-detail-section/components/RecordDetailRelationRecordsListItem.tsx
@@ -101,13 +101,6 @@ export const RecordDetailRelationRecordsListItem = ({
     await deleteOneRelationRecord(relationRecord.id);
   };
 
-  const isOpportunityCompanyRelation =
-    (objectMetadataNameSingular === CoreObjectNameSingular.Opportunity &&
-      relationObjectMetadataNameSingular === CoreObjectNameSingular.Company) ||
-    (objectMetadataNameSingular === CoreObjectNameSingular.Company &&
-      relationObjectMetadataNameSingular ===
-        CoreObjectNameSingular.Opportunity);
-
   const isAccountOwnerRelation =
     relationObjectMetadataNameSingular ===
     CoreObjectNameSingular.WorkspaceMember;
@@ -118,8 +111,7 @@ export const RecordDetailRelationRecordsListItem = ({
         record={relationRecord}
         objectNameSingular={relationObjectMetadataItem.nameSingular}
       />
-      {/* TODO: temporary to prevent removing a company from an opportunity */}
-      {!isOpportunityCompanyRelation && (
+      {
         <DropdownScope dropdownScopeId={dropdownScopeId}>
           <Dropdown
             dropdownId={dropdownScopeId}
@@ -153,7 +145,7 @@ export const RecordDetailRelationRecordsListItem = ({
             }}
           />
         </DropdownScope>
-      )}
+      }
     </StyledListItem>
   );
 };

--- a/packages/twenty-front/src/modules/object-record/record-show/record-detail-section/components/RecordDetailRelationRecordsListItem.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-show/record-detail-section/components/RecordDetailRelationRecordsListItem.tsx
@@ -53,7 +53,6 @@ export const RecordDetailRelationRecordsListItem = ({
     relationFieldMetadataId,
     relationObjectMetadataNameSingular,
     relationType,
-    objectMetadataNameSingular,
   } = fieldDefinition.metadata as FieldRelationMetadata;
 
   const isToOneObject = relationType === 'TO_ONE_OBJECT';


### PR DESCRIPTION
fixes #4344 

Removed the check `isOpportunityCompanyRelation` to show options for an opportunity.

<img width="1021" alt="Screenshot 2024-03-09 at 11 47 56 AM" src="https://github.com/twentyhq/twenty/assets/82582963/46077461-d1b0-4088-9989-228a4a0260cb">
