### PR TITLE
4366-feat(front): Clickable Ascending/Descending menu

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/dropdown/components/DropdownMenuHeader.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/dropdown/components/DropdownMenuHeader.tsx
@@ -29,16 +29,6 @@ const StyledLightIconButton = styled(LightIconButton)`
   display: inline-flex;
   margin-left: auto;
   margin-right: 0;
-
-  &:hover {
-    background: transparent;
-  }
-`;
-
-const StyledLightStartIconButton = styled(LightIconButton)`
-  &:hover {
-    background: transparent;
-  }
 `;
 
 type DropdownMenuHeaderProps = ComponentProps<'li'> & {
@@ -58,7 +48,7 @@ export const DropdownMenuHeader = ({
   return (
     <StyledHeader data-testid={testId} onClick={onClick}>
       {StartIcon && (
-        <StyledLightStartIconButton
+        <LightIconButton
           testId="dropdown-menu-header-end-icon"
           Icon={StartIcon}
           accent="tertiary"

--- a/packages/twenty-front/src/modules/ui/layout/dropdown/components/DropdownMenuHeader.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/dropdown/components/DropdownMenuHeader.tsx
@@ -7,6 +7,7 @@ import { LightIconButton } from '@/ui/input/button/components/LightIconButton';
 const StyledHeader = styled.li`
   align-items: center;
   color: ${({ theme }) => theme.font.color.primary};
+  cursor: pointer;
   display: flex;
   font-size: ${({ theme }) => theme.font.size.sm};
   font-weight: ${({ theme }) => theme.font.weight.medium};
@@ -14,6 +15,10 @@ const StyledHeader = styled.li`
   padding: ${({ theme }) => theme.spacing(1)};
 
   user-select: none;
+
+  &:hover {
+    background: ${({ theme }) => theme.background.transparent.light};
+  }
 `;
 
 const StyledChildrenWrapper = styled.span`
@@ -24,6 +29,16 @@ const StyledLightIconButton = styled(LightIconButton)`
   display: inline-flex;
   margin-left: auto;
   margin-right: 0;
+
+  &:hover {
+    background: transparent;
+  }
+`;
+
+const StyledLightStartIconButton = styled(LightIconButton)`
+  &:hover {
+    background: transparent;
+  }
 `;
 
 type DropdownMenuHeaderProps = ComponentProps<'li'> & {
@@ -41,12 +56,11 @@ export const DropdownMenuHeader = ({
   testId,
 }: DropdownMenuHeaderProps) => {
   return (
-    <StyledHeader data-testid={testId}>
+    <StyledHeader data-testid={testId} onClick={onClick}>
       {StartIcon && (
-        <LightIconButton
+        <StyledLightStartIconButton
           testId="dropdown-menu-header-end-icon"
           Icon={StartIcon}
-          onClick={onClick}
           accent="tertiary"
           size="small"
         />
@@ -56,7 +70,6 @@ export const DropdownMenuHeader = ({
         <StyledLightIconButton
           testId="dropdown-menu-header-end-icon"
           Icon={EndIcon}
-          onClick={onClick}
           accent="tertiary"
           size="small"
         />


### PR DESCRIPTION
Closes #4366 

Changes:
- Made Header Menu clickable.
- Added Hover effect on the Menu.


https://github.com/twentyhq/twenty/assets/22574091/2c4a1df9-208e-4233-809e-5d399e95ff79

