### PR TITLE
Build arg setter for position

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-board/hooks/internal/useSetRecordBoardRecordIds.ts
+++ b/packages/twenty-front/src/modules/object-record/record-board/hooks/internal/useSetRecordBoardRecordIds.ts
@@ -28,6 +28,7 @@ export const useSetRecordBoardRecordIds = (recordBoardId?: string) => {
 
           const columnRecordIds = records
             .filter((record) => record.stage === column?.value)
+            .sort(sortRecordsByPosition)
             .map((record) => record.id);
 
           if (!isDeeplyEqual(existingColumnRecordIds, columnRecordIds)) {
@@ -42,4 +43,22 @@ export const useSetRecordBoardRecordIds = (recordBoardId?: string) => {
     scopeId,
     setRecordIds,
   };
+};
+
+const sortRecordsByPosition = (
+  record1: ObjectRecord,
+  record2: ObjectRecord,
+) => {
+  if (
+    typeof record1.position == 'number' &&
+    typeof record2.position == 'number'
+  ) {
+    return record1.position - record2.position;
+  } else if (record1.position === 'first' || record2.position === 'last') {
+    return -1;
+  } else if (record2.position === 'first' || record1.position === 'last') {
+    return 1;
+  } else {
+    return 0;
+  }
 };

--- a/packages/twenty-front/src/modules/object-record/record-board/record-board-column/components/RecordBoardColumnNewButton.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/record-board-column/components/RecordBoardColumnNewButton.tsx
@@ -32,6 +32,7 @@ export const RecordBoardColumnNewButton = () => {
   const onNewClick = () => {
     createOneRecord({
       [selectFieldMetadataItem.name]: columnDefinition.value,
+      position: 'last',
     });
   };
 

--- a/packages/twenty-front/src/modules/object-record/record-board/record-board-column/components/RecordBoardColumnNewOpportunityButton.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/record-board-column/components/RecordBoardColumnNewOpportunityButton.tsx
@@ -52,6 +52,7 @@ export const RecordBoardColumnNewOpportunityButton = () => {
     createOneRecord({
       name: company.name,
       companyId: company.id,
+      position: 'last',
       [selectFieldMetadataItem.name]: columnDefinition.value,
     });
   };

--- a/packages/twenty-front/src/pages/object-record/RecordIndexPage.tsx
+++ b/packages/twenty-front/src/pages/object-record/RecordIndexPage.tsx
@@ -37,7 +37,7 @@ export const RecordIndexPage = () => {
 
   const handleAddButtonClick = async () => {
     await createOneObject?.({
-      position: 0,
+      position: 'last',
     });
 
     setSelectedTableCellEditMode(0, 0);

--- a/packages/twenty-front/src/pages/object-record/RecordIndexPage.tsx
+++ b/packages/twenty-front/src/pages/object-record/RecordIndexPage.tsx
@@ -37,7 +37,7 @@ export const RecordIndexPage = () => {
 
   const handleAddButtonClick = async () => {
     await createOneObject?.({
-      position: 'last',
+      position: 'first',
     });
 
     setSelectedTableCellEditMode(0, 0);

--- a/packages/twenty-server/src/workspace/workspace-query-builder/factories/__tests__/record-position-query.factory.spec.ts
+++ b/packages/twenty-server/src/workspace/workspace-query-builder/factories/__tests__/record-position-query.factory.spec.ts
@@ -1,0 +1,48 @@
+import { ObjectMetadataInterface } from 'src/metadata/field-metadata/interfaces/object-metadata.interface';
+
+import { RecordPositionQueryFactory } from 'src/workspace/workspace-query-builder/factories/record-position-query.factory';
+
+describe('RecordPositionQueryFactory', () => {
+  const objectMetadataItem = {
+    isCustom: false,
+    nameSingular: 'company',
+  } as ObjectMetadataInterface;
+  const dataSourceSchema = 'workspace_test';
+  const factory: RecordPositionQueryFactory = new RecordPositionQueryFactory();
+
+  it('should be defined', () => {
+    expect(factory).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should return a string with the position when positionValue is first', async () => {
+      const positionValue = 'first';
+
+      const result = await factory.create(
+        positionValue,
+        objectMetadataItem,
+        dataSourceSchema,
+      );
+
+      expect(result).toEqual(
+        `SELECT position FROM workspace_test."company"
+            WHERE "position" IS NOT NULL ORDER BY "position" ASC LIMIT 1`,
+      );
+    });
+
+    it('should return a string with the position when positionValue is last', async () => {
+      const positionValue = 'last';
+
+      const result = await factory.create(
+        positionValue,
+        objectMetadataItem,
+        dataSourceSchema,
+      );
+
+      expect(result).toEqual(
+        `SELECT position FROM workspace_test."company"
+            WHERE "position" IS NOT NULL ORDER BY "position" DESC LIMIT 1`,
+      );
+    });
+  });
+});

--- a/packages/twenty-server/src/workspace/workspace-query-builder/factories/factories.ts
+++ b/packages/twenty-server/src/workspace/workspace-query-builder/factories/factories.ts
@@ -11,6 +11,7 @@ import { UpdateOneQueryFactory } from './update-one-query.factory';
 import { UpdateManyQueryFactory } from './update-many-query.factory';
 import { DeleteManyQueryFactory } from './delete-many-query.factory';
 import { FindDuplicatesQueryFactory } from './find-duplicates-query.factory';
+import { RecordPositionQueryFactory } from './record-position-query.factory';
 
 export const workspaceQueryBuilderFactories = [
   ArgsAliasFactory,
@@ -23,6 +24,7 @@ export const workspaceQueryBuilderFactories = [
   FindManyQueryFactory,
   FindOneQueryFactory,
   FindDuplicatesQueryFactory,
+  RecordPositionQueryFactory,
   UpdateOneQueryFactory,
   UpdateManyQueryFactory,
   DeleteManyQueryFactory,

--- a/packages/twenty-server/src/workspace/workspace-query-builder/factories/record-position-query.factory.ts
+++ b/packages/twenty-server/src/workspace/workspace-query-builder/factories/record-position-query.factory.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+
+import { ObjectMetadataInterface } from 'src/metadata/field-metadata/interfaces/object-metadata.interface';
+
+@Injectable()
+export class RecordPositionQueryFactory {
+  async create(
+    positionValue: 'first' | 'last',
+    objectMetadataItem: ObjectMetadataInterface,
+    dataSourceSchema: string,
+  ): Promise<string> {
+    const orderByDirection = positionValue === 'first' ? 'ASC' : 'DESC';
+
+    const name =
+      (objectMetadataItem.isCustom ? '_' : '') +
+      objectMetadataItem.nameSingular;
+
+    return `SELECT position FROM ${dataSourceSchema}."${name}"
+            WHERE "position" IS NOT NULL ORDER BY "position" ${orderByDirection} LIMIT 1`;
+  }
+}

--- a/packages/twenty-server/src/workspace/workspace-query-builder/workspace-query-builder.module.ts
+++ b/packages/twenty-server/src/workspace/workspace-query-builder/workspace-query-builder.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 
 import { ObjectMetadataModule } from 'src/metadata/object-metadata/object-metadata.module';
 import { FieldsStringFactory } from 'src/workspace/workspace-query-builder/factories/fields-string.factory';
+import { RecordPositionQueryFactory } from 'src/workspace/workspace-query-builder/factories/record-position-query.factory';
 
 import { WorkspaceQueryBuilderFactory } from './workspace-query-builder.factory';
 
@@ -10,6 +11,10 @@ import { workspaceQueryBuilderFactories } from './factories/factories';
 @Module({
   imports: [ObjectMetadataModule],
   providers: [...workspaceQueryBuilderFactories, WorkspaceQueryBuilderFactory],
-  exports: [WorkspaceQueryBuilderFactory, FieldsStringFactory],
+  exports: [
+    WorkspaceQueryBuilderFactory,
+    FieldsStringFactory,
+    RecordPositionQueryFactory,
+  ],
 })
 export class WorkspaceQueryBuilderModule {}

--- a/packages/twenty-server/src/workspace/workspace-query-runner/factories/__tests__/query-runner-args.factory.spec.ts
+++ b/packages/twenty-server/src/workspace/workspace-query-runner/factories/__tests__/query-runner-args.factory.spec.ts
@@ -1,0 +1,92 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { WorkspaceQueryRunnerOptions } from 'src/workspace/workspace-query-runner/interfaces/query-runner-option.interface';
+import { FieldMetadataInterface } from 'src/metadata/field-metadata/interfaces/field-metadata.interface';
+
+import { WorkspaceDataSourceService } from 'src/workspace/workspace-datasource/workspace-datasource.service';
+import { RecordPositionQueryFactory } from 'src/workspace/workspace-query-builder/factories/record-position-query.factory';
+import { QueryRunnerArgsFactory } from 'src/workspace/workspace-query-runner/factories/query-runner-args.factory';
+import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
+
+describe('QueryRunnerArgsFactory', () => {
+  const workspaceDataSourceService = {
+    getSchemaName: jest.fn().mockResolvedValue('test schema'),
+    executeRawQuery: jest.fn(),
+  };
+  const recordPositionQueryFactory = {
+    create: jest.fn().mockResolvedValue('test query'),
+  };
+  const options = {
+    fieldMetadataCollection: [
+      { name: 'position', type: FieldMetadataType.POSITION },
+    ] as FieldMetadataInterface[],
+  } as WorkspaceQueryRunnerOptions;
+
+  let factory: QueryRunnerArgsFactory;
+
+  beforeEach(async () => {
+    jest.resetAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        QueryRunnerArgsFactory,
+        {
+          provide: RecordPositionQueryFactory,
+          useValue: {
+            create: recordPositionQueryFactory.create,
+          },
+        },
+        {
+          provide: WorkspaceDataSourceService,
+          useValue: workspaceDataSourceService,
+        },
+      ],
+    }).compile();
+
+    factory = module.get<QueryRunnerArgsFactory>(QueryRunnerArgsFactory);
+  });
+
+  it('should be defined', () => {
+    expect(factory).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should return the args when empty', async () => {
+      const args = {};
+      const result = await factory.create(args, options);
+
+      expect(result).toEqual(args);
+    });
+
+    it('should override position when of type string', async () => {
+      const args = {
+        position: 'first',
+      };
+
+      workspaceDataSourceService.executeRawQuery.mockResolvedValue([
+        { position: 2 },
+      ]);
+
+      const result = await factory.create(args, options);
+
+      expect(result).toEqual({
+        position: 1, // Calculates 2 / 2
+      });
+    });
+
+    it('should override args when of type array', async () => {
+      const args = [{ id: 1 }, { position: 'last' }];
+
+      workspaceDataSourceService.executeRawQuery.mockResolvedValue([
+        { position: 1 },
+      ]);
+
+      const result = await factory.create(args, options);
+
+      expect(result).toEqual([
+        { id: 1 },
+        { position: 2 }, // Calculates 1 + 1
+      ]);
+    });
+  });
+});

--- a/packages/twenty-server/src/workspace/workspace-query-runner/factories/arg-setters.factory.ts
+++ b/packages/twenty-server/src/workspace/workspace-query-runner/factories/arg-setters.factory.ts
@@ -1,0 +1,117 @@
+import { Injectable } from '@nestjs/common';
+
+import { FieldMetadataInterface } from 'src/metadata/field-metadata/interfaces/field-metadata.interface';
+import { WorkspaceQueryRunnerOptions } from 'src/workspace/workspace-query-runner/interfaces/query-runner-option.interface';
+import { ObjectMetadataInterface } from 'src/metadata/field-metadata/interfaces/object-metadata.interface';
+
+import { WorkspaceDataSourceService } from 'src/workspace/workspace-datasource/workspace-datasource.service';
+import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
+
+@Injectable()
+export class ArgsSettersFactory {
+  constructor(
+    private readonly workspaceDataSourceService: WorkspaceDataSourceService,
+  ) {}
+
+  async create(
+    args: Record<string, any>,
+    options: WorkspaceQueryRunnerOptions,
+  ) {
+    const fieldMetadataCollection = options.fieldMetadataCollection;
+
+    const fieldMetadataMap = new Map(
+      fieldMetadataCollection.map((fieldMetadata) => [
+        fieldMetadata.name,
+        fieldMetadata,
+      ]),
+    );
+
+    return this.applySettersToArgsRecursive(args, options, fieldMetadataMap);
+  }
+
+  private async applySettersToArgsRecursive(
+    args: Record<string, any>,
+    options: WorkspaceQueryRunnerOptions,
+    fieldMetadataMap: Map<string, FieldMetadataInterface>,
+  ) {
+    // If it's not an object, we don't need to do anything
+    if (typeof args !== 'object' || args === null) {
+      return args;
+    }
+
+    // If it's an array, we need to map all items
+    if (Array.isArray(args)) {
+      return Promise.all(
+        args.map((arg) =>
+          this.applySettersToArgsRecursive(arg, options, fieldMetadataMap),
+        ),
+      );
+    }
+
+    const newArgs = {};
+
+    for (const [key, value] of Object.entries(args)) {
+      const fieldMetadata = fieldMetadataMap.get(key);
+
+      if (!fieldMetadata) {
+        newArgs[key] = await this.applySettersToArgsRecursive(
+          value,
+          options,
+          fieldMetadataMap,
+        );
+        continue;
+      }
+
+      switch (fieldMetadata.type) {
+        case FieldMetadataType.POSITION:
+          newArgs[key] = await this.buildPositionValue(
+            value,
+            options.objectMetadataItem,
+            options.workspaceId,
+          );
+          break;
+        default:
+          newArgs[key] = await this.applySettersToArgsRecursive(
+            value,
+            options,
+            fieldMetadataMap,
+          );
+      }
+    }
+
+    return newArgs;
+  }
+
+  private async buildPositionValue(
+    value: number | 'first' | 'last',
+    objectMetadataItem: ObjectMetadataInterface,
+    workspaceId: string,
+  ) {
+    if (typeof value === 'number') {
+      return value;
+    }
+
+    const orderByDirection = value === 'first' ? 'ASC' : 'DESC';
+
+    const dataSourceSchema =
+      this.workspaceDataSourceService.getSchemaName(workspaceId);
+
+    const name =
+      (objectMetadataItem.isCustom ? '_' : '') +
+      objectMetadataItem.nameSingular;
+
+    const record = await this.workspaceDataSourceService.executeRawQuery(
+      `SELECT position FROM ${dataSourceSchema}."${name}"
+            WHERE "position" IS NOT NULL ORDER BY "position" ${orderByDirection} LIMIT 1`,
+      [],
+      workspaceId,
+      undefined,
+    );
+
+    const position =
+      (value === 'first' ? record[0]?.position / 2 : record[0]?.position + 1) ||
+      1;
+
+    return position;
+  }
+}

--- a/packages/twenty-server/src/workspace/workspace-query-runner/factories/index.ts
+++ b/packages/twenty-server/src/workspace/workspace-query-runner/factories/index.ts
@@ -1,3 +1,3 @@
-import { ArgsSettersFactory } from 'src/workspace/workspace-query-runner/factories/arg-setters.factory';
+import { QueryRunnerArgsFactory } from 'src/workspace/workspace-query-runner/factories/query-runner-args.factory';
 
-export const workspaceQueryRunnerFactories = [ArgsSettersFactory];
+export const workspaceQueryRunnerFactories = [QueryRunnerArgsFactory];

--- a/packages/twenty-server/src/workspace/workspace-query-runner/factories/index.ts
+++ b/packages/twenty-server/src/workspace/workspace-query-runner/factories/index.ts
@@ -1,0 +1,3 @@
+import { ArgsSettersFactory } from 'src/workspace/workspace-query-runner/factories/arg-setters.factory';
+
+export const workspaceQueryRunnerFactories = [ArgsSettersFactory];

--- a/packages/twenty-server/src/workspace/workspace-query-runner/workspace-query-runner.module.ts
+++ b/packages/twenty-server/src/workspace/workspace-query-runner/workspace-query-runner.module.ts
@@ -3,6 +3,7 @@ import { Module } from '@nestjs/common';
 import { WorkspaceQueryBuilderModule } from 'src/workspace/workspace-query-builder/workspace-query-builder.module';
 import { WorkspaceDataSourceModule } from 'src/workspace/workspace-datasource/workspace-datasource.module';
 import { WorkspacePreQueryHookModule } from 'src/workspace/workspace-query-runner/workspace-pre-query-hook/workspace-pre-query-hook.module';
+import { workspaceQueryRunnerFactories } from 'src/workspace/workspace-query-runner/factories';
 
 import { WorkspaceQueryRunnerService } from './workspace-query-runner.service';
 
@@ -12,7 +13,7 @@ import { WorkspaceQueryRunnerService } from './workspace-query-runner.service';
     WorkspaceDataSourceModule,
     WorkspacePreQueryHookModule,
   ],
-  providers: [WorkspaceQueryRunnerService],
+  providers: [WorkspaceQueryRunnerService, ...workspaceQueryRunnerFactories],
   exports: [WorkspaceQueryRunnerService],
 })
 export class WorkspaceQueryRunnerModule {}

--- a/packages/twenty-server/src/workspace/workspace-query-runner/workspace-query-runner.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-query-runner/workspace-query-runner.service.ts
@@ -44,6 +44,7 @@ import { ObjectRecordUpdateEvent } from 'src/integrations/event-emitter/types/ob
 import { WorkspacePreQueryHookService } from 'src/workspace/workspace-query-runner/workspace-pre-query-hook/workspace-pre-query-hook.service';
 import { EnvironmentService } from 'src/integrations/environment/environment.service';
 import { NotFoundError } from 'src/filters/utils/graphql-errors.util';
+import { ArgsSettersFactory } from 'src/workspace/workspace-query-runner/factories/arg-setters.factory';
 
 import { WorkspaceQueryRunnerOptions } from './interfaces/query-runner-option.interface';
 import {
@@ -59,6 +60,7 @@ export class WorkspaceQueryRunnerService {
   constructor(
     private readonly workspaceQueryBuilderFactory: WorkspaceQueryBuilderFactory,
     private readonly workspaceDataSourceService: WorkspaceDataSourceService,
+    private readonly argSettersFactory: ArgsSettersFactory,
     @Inject(MessageQueue.webhookQueue)
     private readonly messageQueueService: MessageQueueService,
     private readonly eventEmitter: EventEmitter2,
@@ -213,8 +215,10 @@ export class WorkspaceQueryRunnerService {
     options: WorkspaceQueryRunnerOptions,
   ): Promise<Record[] | undefined> {
     const { workspaceId, objectMetadataItem } = options;
+    const computedArgs = await this.argSettersFactory.create(args, options);
+
     const query = await this.workspaceQueryBuilderFactory.createMany(
-      args,
+      computedArgs,
       options,
     );
 

--- a/packages/twenty-server/src/workspace/workspace-query-runner/workspace-query-runner.service.ts
+++ b/packages/twenty-server/src/workspace/workspace-query-runner/workspace-query-runner.service.ts
@@ -44,7 +44,7 @@ import { ObjectRecordUpdateEvent } from 'src/integrations/event-emitter/types/ob
 import { WorkspacePreQueryHookService } from 'src/workspace/workspace-query-runner/workspace-pre-query-hook/workspace-pre-query-hook.service';
 import { EnvironmentService } from 'src/integrations/environment/environment.service';
 import { NotFoundError } from 'src/filters/utils/graphql-errors.util';
-import { ArgsSettersFactory } from 'src/workspace/workspace-query-runner/factories/arg-setters.factory';
+import { QueryRunnerArgsFactory } from 'src/workspace/workspace-query-runner/factories/query-runner-args.factory';
 
 import { WorkspaceQueryRunnerOptions } from './interfaces/query-runner-option.interface';
 import {
@@ -60,7 +60,7 @@ export class WorkspaceQueryRunnerService {
   constructor(
     private readonly workspaceQueryBuilderFactory: WorkspaceQueryBuilderFactory,
     private readonly workspaceDataSourceService: WorkspaceDataSourceService,
-    private readonly argSettersFactory: ArgsSettersFactory,
+    private readonly queryRunnerArgsFactory: QueryRunnerArgsFactory,
     @Inject(MessageQueue.webhookQueue)
     private readonly messageQueueService: MessageQueueService,
     private readonly eventEmitter: EventEmitter2,
@@ -215,7 +215,10 @@ export class WorkspaceQueryRunnerService {
     options: WorkspaceQueryRunnerOptions,
   ): Promise<Record[] | undefined> {
     const { workspaceId, objectMetadataItem } = options;
-    const computedArgs = await this.argSettersFactory.create(args, options);
+    const computedArgs = await this.queryRunnerArgsFactory.create(
+      args,
+      options,
+    );
 
     const query = await this.workspaceQueryBuilderFactory.createMany(
       computedArgs,


### PR DESCRIPTION
Position input needs to be of type : `number | first | last`:
- if `number`, returns value
- if `first`, fetch first element ascending and set `position / 2`
- if `last`, fetch first element descending and set `position + 1`

This logic is integrated into a new factory call arg-setters. It iterates recursively on all arguments and override existing ones using setter function.