### PR TITLE
[messaging] Fix thread cleaner service subqueries

### DIFF
--- a/packages/twenty-server/src/core/auth/services/google-gmail.service.ts
+++ b/packages/twenty-server/src/core/auth/services/google-gmail.service.ts
@@ -79,7 +79,6 @@ export class GoogleGmailService {
         connectedAccountId,
       },
       {
-        id: connectedAccountId,
         retryLimit: 2,
       },
     );

--- a/packages/twenty-server/src/workspace/messaging/jobs/gmail-full-sync.job.ts
+++ b/packages/twenty-server/src/workspace/messaging/jobs/gmail-full-sync.job.ts
@@ -26,10 +26,20 @@ export class GmailFullSyncJob implements MessageQueueJob<GmailFullSyncJobData> {
         data.connectedAccountId
       } ${data.nextPageToken ? `and ${data.nextPageToken} pageToken` : ''}`,
     );
-    await this.gmailRefreshAccessTokenService.refreshAndSaveAccessToken(
-      data.workspaceId,
-      data.connectedAccountId,
-    );
+
+    try {
+      await this.gmailRefreshAccessTokenService.refreshAndSaveAccessToken(
+        data.workspaceId,
+        data.connectedAccountId,
+      );
+    } catch (e) {
+      this.logger.error(
+        `Error refreshing access token for connected account ${data.connectedAccountId} in workspace ${data.workspaceId}`,
+        e,
+      );
+
+      return;
+    }
 
     await this.gmailFullSyncService.fetchConnectedAccountThreads(
       data.workspaceId,

--- a/packages/twenty-server/src/workspace/messaging/jobs/gmail-partial-sync.job.ts
+++ b/packages/twenty-server/src/workspace/messaging/jobs/gmail-partial-sync.job.ts
@@ -25,10 +25,20 @@ export class GmailPartialSyncJob
     this.logger.log(
       `gmail partial-sync for workspace ${data.workspaceId} and account ${data.connectedAccountId}`,
     );
-    await this.gmailRefreshAccessTokenService.refreshAndSaveAccessToken(
-      data.workspaceId,
-      data.connectedAccountId,
-    );
+
+    try {
+      await this.gmailRefreshAccessTokenService.refreshAndSaveAccessToken(
+        data.workspaceId,
+        data.connectedAccountId,
+      );
+    } catch (e) {
+      this.logger.error(
+        `Error refreshing access token for connected account ${data.connectedAccountId} in workspace ${data.workspaceId}`,
+        e,
+      );
+
+      return;
+    }
 
     await this.gmailPartialSyncService.fetchConnectedAccountThreads(
       data.workspaceId,

--- a/packages/twenty-server/src/workspace/messaging/repositories/connected-account/connected-account.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/repositories/connected-account/connected-account.service.ts
@@ -43,11 +43,11 @@ export class ConnectedAccountService {
     );
   }
 
-  public async getByIdOrFail(
+  public async getById(
     connectedAccountId: string,
     workspaceId: string,
     transactionManager?: EntityManager,
-  ): Promise<ObjectRecord<ConnectedAccountObjectMetadata>> {
+  ): Promise<ObjectRecord<ConnectedAccountObjectMetadata> | undefined> {
     const dataSourceSchema =
       this.workspaceDataSourceService.getSchemaName(workspaceId);
 
@@ -59,13 +59,27 @@ export class ConnectedAccountService {
         transactionManager,
       );
 
-    if (!connectedAccounts || connectedAccounts.length === 0) {
+    return connectedAccounts[0];
+  }
+
+  public async getByIdOrFail(
+    connectedAccountId: string,
+    workspaceId: string,
+    transactionManager?: EntityManager,
+  ): Promise<ObjectRecord<ConnectedAccountObjectMetadata>> {
+    const connectedAccount = await this.getById(
+      connectedAccountId,
+      workspaceId,
+      transactionManager,
+    );
+
+    if (!connectedAccount) {
       throw new NotFoundException(
-        `No connected account found for id ${connectedAccountId} in workspace ${workspaceId}`,
+        `Connected account with id ${connectedAccountId} not found in workspace ${workspaceId}`,
       );
     }
 
-    return connectedAccounts[0];
+    return connectedAccount;
   }
 
   public async updateLastSyncHistoryId(

--- a/packages/twenty-server/src/workspace/messaging/repositories/message-channel-message-association/message-channel-message-association.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/repositories/message-channel-message-association/message-channel-message-association.service.ts
@@ -84,18 +84,6 @@ export class MessageChannelMessageAssociationService {
     );
   }
 
-  public async deleteByMessageChannelId(
-    messageChannelId: string,
-    workspaceId: string,
-    transactionManager?: EntityManager,
-  ) {
-    this.deleteByMessageChannelIds(
-      [messageChannelId],
-      workspaceId,
-      transactionManager,
-    );
-  }
-
   public async deleteByMessageChannelIds(
     messageChannelIds: string[],
     workspaceId: string,

--- a/packages/twenty-server/src/workspace/messaging/repositories/message-channel/message-channel.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/repositories/message-channel/message-channel.service.ts
@@ -32,16 +32,28 @@ export class MessageChannelService {
     connectedAccountId: string,
     workspaceId: string,
   ): Promise<ObjectRecord<MessageChannelObjectMetadata>> {
-    const messageChannels = await this.getByConnectedAccountId(
+    const messageChannel = await this.getFirstByConnectedAccountId(
       connectedAccountId,
       workspaceId,
     );
 
-    if (!messageChannels || messageChannels.length === 0) {
+    if (!messageChannel) {
       throw new Error(
-        `No message channel found for connected account ${connectedAccountId} in workspace ${workspaceId}`,
+        `Message channel for connected account ${connectedAccountId} not found in workspace ${workspaceId}`,
       );
     }
+
+    return messageChannel;
+  }
+
+  public async getFirstByConnectedAccountId(
+    connectedAccountId: string,
+    workspaceId: string,
+  ): Promise<ObjectRecord<MessageChannelObjectMetadata> | undefined> {
+    const messageChannels = await this.getByConnectedAccountId(
+      connectedAccountId,
+      workspaceId,
+    );
 
     return messageChannels[0];
   }

--- a/packages/twenty-server/src/workspace/messaging/repositories/message-thread/message-thread.module.ts
+++ b/packages/twenty-server/src/workspace/messaging/repositories/message-thread/message-thread.module.ts
@@ -1,11 +1,16 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 
 import { MessageChannelMessageAssociationModule } from 'src/workspace/messaging/repositories/message-channel-message-association/message-channel-message-assocation.module';
 import { MessageThreadService } from 'src/workspace/messaging/repositories/message-thread/message-thread.service';
+import { MessageModule } from 'src/workspace/messaging/repositories/message/message.module';
 import { WorkspaceDataSourceModule } from 'src/workspace/workspace-datasource/workspace-datasource.module';
 
 @Module({
-  imports: [WorkspaceDataSourceModule, MessageChannelMessageAssociationModule],
+  imports: [
+    WorkspaceDataSourceModule,
+    MessageChannelMessageAssociationModule,
+    forwardRef(() => MessageModule),
+  ],
   providers: [MessageThreadService],
   exports: [MessageThreadService],
 })

--- a/packages/twenty-server/src/workspace/messaging/repositories/message-thread/message-thread.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/repositories/message-thread/message-thread.service.ts
@@ -16,7 +16,7 @@ export class MessageThreadService {
     private readonly workspaceDataSourceService: WorkspaceDataSourceService,
   ) {}
 
-  public async getOrphanThreads(
+  public async getOrphanThreadIds(
     workspaceId: string,
     transactionManager?: EntityManager,
   ): Promise<ObjectRecord<MessageThreadObjectMetadata>[]> {
@@ -24,11 +24,10 @@ export class MessageThreadService {
       this.workspaceDataSourceService.getSchemaName(workspaceId);
 
     return await this.workspaceDataSourceService.executeRawQuery(
-      `SELECT mt.* FROM ${dataSourceSchema}."messageThread" mt
-      WHERE NOT EXISTS (
-          SELECT 1 FROM ${dataSourceSchema}."message" m
-          WHERE m."messageThreadId" = mt.id
-      )`,
+      `SELECT mt.id
+      FROM ${dataSourceSchema}."messageThread" mt
+      LEFT JOIN ${dataSourceSchema}."message" m ON mt.id = m."messageThreadId"
+      WHERE m."messageThreadId" IS NULL`,
       [],
       workspaceId,
       transactionManager,

--- a/packages/twenty-server/src/workspace/messaging/repositories/message/message.module.ts
+++ b/packages/twenty-server/src/workspace/messaging/repositories/message/message.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 
 import { MessageChannelModule } from 'src/workspace/messaging/repositories/message-channel/message-channel.module';
 import { MessageChannelMessageAssociationModule } from 'src/workspace/messaging/repositories/message-channel-message-association/message-channel-message-assocation.module';
@@ -11,7 +11,7 @@ import { CreateCompaniesAndContactsModule } from 'src/workspace/messaging/servic
 @Module({
   imports: [
     WorkspaceDataSourceModule,
-    MessageThreadModule,
+    forwardRef(() => MessageThreadModule),
     MessageParticipantModule,
     MessageChannelMessageAssociationModule,
     MessageChannelModule,

--- a/packages/twenty-server/src/workspace/messaging/repositories/message/message.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/repositories/message/message.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable, forwardRef } from '@nestjs/common';
 
 import { DataSource, EntityManager } from 'typeorm';
 import { v4 } from 'uuid';
@@ -17,6 +17,7 @@ export class MessageService {
   constructor(
     private readonly workspaceDataSourceService: WorkspaceDataSourceService,
     private readonly messageChannelMessageAssociationService: MessageChannelMessageAssociationService,
+    @Inject(forwardRef(() => MessageThreadService))
     private readonly messageThreadService: MessageThreadService,
   ) {}
 
@@ -140,8 +141,10 @@ export class MessageService {
               return;
             }
 
+            // TODO: This does not handle all thread merging use cases and might create orphan threads.
             const savedOrExistingMessageThreadId =
               await this.messageThreadService.saveMessageThreadOrReturnExistingMessageThread(
+                message.headerMessageId,
                 message.messageThreadExternalId,
                 dataSourceMetadata,
                 workspaceId,

--- a/packages/twenty-server/src/workspace/messaging/repositories/message/message.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/repositories/message/message.service.ts
@@ -44,7 +44,7 @@ export class MessageService {
     return nonAssociatedMessages.map(({ id }) => id);
   }
 
-  public async getFirstByHeaderMessageId(
+  public async getFirstOrNullByHeaderMessageId(
     headerMessageId: string,
     workspaceId: string,
     transactionManager?: EntityManager,
@@ -193,7 +193,7 @@ export class MessageService {
     workspaceId: string,
     manager: EntityManager,
   ): Promise<string> {
-    const existingMessage = await this.getFirstByHeaderMessageId(
+    const existingMessage = await this.getFirstOrNullByHeaderMessageId(
       message.headerMessageId,
       workspaceId,
     );

--- a/packages/twenty-server/src/workspace/messaging/services/gmail-full-sync.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/services/gmail-full-sync.service.ts
@@ -46,10 +46,18 @@ export class GmailFullSyncService {
     connectedAccountId: string,
     nextPageToken?: string,
   ): Promise<void> {
-    const connectedAccount = await this.connectedAccountService.getByIdOrFail(
+    const connectedAccount = await this.connectedAccountService.getById(
       connectedAccountId,
       workspaceId,
     );
+
+    if (!connectedAccount) {
+      this.logger.error(
+        `Connected account ${connectedAccountId} not found in workspace ${workspaceId} during full-sync`,
+      );
+
+      return;
+    }
 
     const accessToken = connectedAccount.accessToken;
     const refreshToken = connectedAccount.refreshToken;
@@ -62,10 +70,18 @@ export class GmailFullSyncService {
     }
 
     const gmailMessageChannel =
-      await this.messageChannelService.getFirstByConnectedAccountIdOrFail(
+      await this.messageChannelService.getFirstByConnectedAccountId(
         connectedAccountId,
         workspaceId,
       );
+
+    if (!gmailMessageChannel) {
+      this.logger.error(
+        `No message channel found for connected account ${connectedAccountId} in workspace ${workspaceId} during full-syn`,
+      );
+
+      return;
+    }
 
     const gmailMessageChannelId = gmailMessageChannel.id;
 
@@ -173,7 +189,7 @@ export class GmailFullSyncService {
     );
 
     if (messagesToSave.length > 0) {
-      this.saveMessagesAndCreateContactsService.saveMessagesAndCreateContacts(
+      await this.saveMessagesAndCreateContactsService.saveMessagesAndCreateContacts(
         messagesToSave,
         connectedAccount,
         workspaceId,

--- a/packages/twenty-server/src/workspace/messaging/services/gmail-partial-sync.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/services/gmail-partial-sync.service.ts
@@ -48,10 +48,18 @@ export class GmailPartialSyncService {
     connectedAccountId: string,
     maxResults = 500,
   ): Promise<void> {
-    const connectedAccount = await this.connectedAccountService.getByIdOrFail(
+    const connectedAccount = await this.connectedAccountService.getById(
       connectedAccountId,
       workspaceId,
     );
+
+    if (!connectedAccount) {
+      this.logger.error(
+        `Connected account ${connectedAccountId} not found in workspace ${workspaceId} during partial-sync`,
+      );
+
+      return;
+    }
 
     const lastSyncHistoryId = connectedAccount.lastSyncHistoryId;
 
@@ -135,10 +143,18 @@ export class GmailPartialSyncService {
     }
 
     const gmailMessageChannel =
-      await this.messageChannelService.getFirstByConnectedAccountIdOrFail(
+      await this.messageChannelService.getFirstByConnectedAccountId(
         connectedAccountId,
         workspaceId,
       );
+
+    if (!gmailMessageChannel) {
+      this.logger.error(
+        `No message channel found for connected account ${connectedAccountId} in workspace ${workspaceId} during partial-sync`,
+      );
+
+      return;
+    }
 
     const gmailMessageChannelId = gmailMessageChannel.id;
 

--- a/packages/twenty-server/src/workspace/messaging/services/gmail-refresh-access-token.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/services/gmail-refresh-access-token.service.ts
@@ -16,10 +16,16 @@ export class GmailRefreshAccessTokenService {
     workspaceId: string,
     connectedAccountId: string,
   ): Promise<void> {
-    const connectedAccount = await this.connectedAccountService.getByIdOrFail(
+    const connectedAccount = await this.connectedAccountService.getById(
       connectedAccountId,
       workspaceId,
     );
+
+    if (!connectedAccount) {
+      throw new Error(
+        `No connected account found for ${connectedAccountId} in workspace ${workspaceId}`,
+      );
+    }
 
     const refreshToken = connectedAccount.refreshToken;
 

--- a/packages/twenty-server/src/workspace/messaging/services/save-messages-and-create-contacts.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/services/save-messages-and-create-contacts.service.ts
@@ -42,9 +42,7 @@ export class SaveMessagesAndCreateContactsService {
 
     let startTime = Date.now();
 
-    let messageExternalIdsAndIdsMap = new Map<string, string>();
-
-    messageExternalIdsAndIdsMap = await this.messageService.saveMessages(
+    const messageExternalIdsAndIdsMap = await this.messageService.saveMessages(
       messagesToSave,
       dataSourceMetadata,
       workspaceDataSource,

--- a/packages/twenty-server/src/workspace/messaging/services/thread-cleaner/thread-cleaner.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/services/thread-cleaner/thread-cleaner.service.ts
@@ -25,7 +25,7 @@ export class ThreadCleanerService {
 
     await workspaceDataSource?.transaction(async (transactionManager) => {
       const messagesToDelete =
-        await this.messageService.getNonAssociatedMessages(
+        await this.messageService.getNonAssociatedMessageIds(
           workspaceId,
           transactionManager,
         );
@@ -41,7 +41,7 @@ export class ThreadCleanerService {
       }
 
       const messageThreadsToDelete =
-        await this.messageThreadService.getOrphanThreads(
+        await this.messageThreadService.getOrphanThreadIds(
           workspaceId,
           transactionManager,
         );

--- a/packages/twenty-server/src/workspace/messaging/services/thread-cleaner/thread-cleaner.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/services/thread-cleaner/thread-cleaner.service.ts
@@ -19,15 +19,19 @@ export class ThreadCleanerService {
     await deleteUsingPagination(
       workspaceId,
       500,
-      this.messageService.getNonAssociatedMessageIdsPaginated,
-      this.messageService.deleteByIds,
+      this.messageService.getNonAssociatedMessageIdsPaginated.bind(
+        this.messageService,
+      ),
+      this.messageService.deleteByIds.bind(this.messageService),
     );
 
     await deleteUsingPagination(
       workspaceId,
       500,
-      this.messageThreadService.getOrphanThreadIdsPaginated,
-      this.messageThreadService.deleteByIds,
+      this.messageThreadService.getOrphanThreadIdsPaginated.bind(
+        this.messageThreadService,
+      ),
+      this.messageThreadService.deleteByIds.bind(this.messageThreadService),
     );
   }
 }

--- a/packages/twenty-server/src/workspace/messaging/services/thread-cleaner/thread-cleaner.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/services/thread-cleaner/thread-cleaner.service.ts
@@ -4,6 +4,7 @@ import { TypeORMService } from 'src/database/typeorm/typeorm.service';
 import { DataSourceService } from 'src/metadata/data-source/data-source.service';
 import { MessageThreadService } from 'src/workspace/messaging/repositories/message-thread/message-thread.service';
 import { MessageService } from 'src/workspace/messaging/repositories/message/message.service';
+import { deleteUsingPagination } from 'src/workspace/messaging/services/thread-cleaner/utils/delete-using-pagination.util';
 
 @Injectable()
 export class ThreadCleanerService {
@@ -15,48 +16,18 @@ export class ThreadCleanerService {
   ) {}
 
   public async cleanWorkspaceThreads(workspaceId: string) {
-    const dataSourceMetadata =
-      await this.dataSourceService.getLastDataSourceMetadataFromWorkspaceIdOrFail(
-        workspaceId,
-      );
+    await deleteUsingPagination(
+      workspaceId,
+      500,
+      this.messageService.getNonAssociatedMessageIdsPaginated,
+      this.messageService.deleteByIds,
+    );
 
-    const workspaceDataSource =
-      await this.typeORMService.connectToDataSource(dataSourceMetadata);
-
-    await workspaceDataSource?.transaction(async (transactionManager) => {
-      const messagesToDelete =
-        await this.messageService.getNonAssociatedMessageIds(
-          workspaceId,
-          transactionManager,
-        );
-
-      const messageIdsToDelete = messagesToDelete.map(({ id }) => id);
-
-      if (messageIdsToDelete.length > 0) {
-        await this.messageService.deleteByIds(
-          messageIdsToDelete,
-          workspaceId,
-          transactionManager,
-        );
-      }
-
-      const messageThreadsToDelete =
-        await this.messageThreadService.getOrphanThreadIds(
-          workspaceId,
-          transactionManager,
-        );
-
-      const messageThreadToDeleteIds = messageThreadsToDelete.map(
-        ({ id }) => id,
-      );
-
-      if (messageThreadToDeleteIds.length > 0) {
-        await this.messageThreadService.deleteByIds(
-          messageThreadToDeleteIds,
-          workspaceId,
-          transactionManager,
-        );
-      }
-    });
+    await deleteUsingPagination(
+      workspaceId,
+      500,
+      this.messageThreadService.getOrphanThreadIdsPaginated,
+      this.messageThreadService.deleteByIds,
+    );
   }
 }

--- a/packages/twenty-server/src/workspace/messaging/services/thread-cleaner/utils/delete-using-pagination.util.spec.ts
+++ b/packages/twenty-server/src/workspace/messaging/services/thread-cleaner/utils/delete-using-pagination.util.spec.ts
@@ -1,0 +1,44 @@
+import { deleteUsingPagination } from './delete-using-pagination.util';
+
+describe('deleteUsingPagination', () => {
+  it('should delete items using pagination', async () => {
+    const workspaceId = 'workspace123';
+    const batchSize = 10;
+    const getterPaginated = jest
+      .fn()
+      .mockResolvedValueOnce(['id1', 'id2'])
+      .mockResolvedValueOnce([]);
+    const deleter = jest.fn();
+    const transactionManager = undefined;
+
+    await deleteUsingPagination(
+      workspaceId,
+      batchSize,
+      getterPaginated,
+      deleter,
+      transactionManager,
+    );
+
+    expect(getterPaginated).toHaveBeenNthCalledWith(
+      1,
+      batchSize,
+      0,
+      workspaceId,
+      transactionManager,
+    );
+    expect(getterPaginated).toHaveBeenNthCalledWith(
+      2,
+      batchSize,
+      batchSize,
+      workspaceId,
+      transactionManager,
+    );
+    expect(deleter).toHaveBeenNthCalledWith(
+      1,
+      ['id1', 'id2'],
+      workspaceId,
+      transactionManager,
+    );
+    expect(deleter).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/twenty-server/src/workspace/messaging/services/thread-cleaner/utils/delete-using-pagination.util.ts
+++ b/packages/twenty-server/src/workspace/messaging/services/thread-cleaner/utils/delete-using-pagination.util.ts
@@ -1,0 +1,38 @@
+import { EntityManager } from 'typeorm';
+
+export const deleteUsingPagination = async (
+  workspaceId: string,
+  batchSize: number,
+  getterPaginated: (
+    limit: number,
+    offset: number,
+    workspaceId: string,
+    transactionManager?: EntityManager,
+  ) => Promise<string[]>,
+  deleter: (
+    ids: string[],
+    workspaceId: string,
+    transactionManager?: EntityManager,
+  ) => Promise<void>,
+  transactionManager?: EntityManager,
+) => {
+  let offset = 0;
+  let hasMoreData = true;
+
+  while (hasMoreData) {
+    const idsToDelete = await getterPaginated(
+      batchSize,
+      offset,
+      workspaceId,
+      transactionManager,
+    );
+
+    if (idsToDelete.length > 0) {
+      await deleter(idsToDelete, workspaceId, transactionManager);
+    } else {
+      hasMoreData = false;
+    }
+
+    offset += batchSize;
+  }
+};


### PR DESCRIPTION
## Context
Thread cleaner service is running queries over a whole workspace and can sometimes fetch a lot of messages once a connected account has been deleted.
I've realised we were using sub-optimal queries (500ms for 100 000 rows against 28s before this change...), the next step would be to introduce indexes which is planned for the upcoming release.

Note: We can even go further by introducing pagination. 