### PR TITLE
Fix activity creation

### DIFF
--- a/packages/twenty-server/src/workspace/workspace-query-runner/factories/__tests__/query-runner-args.factory.spec.ts
+++ b/packages/twenty-server/src/workspace/workspace-query-runner/factories/__tests__/query-runner-args.factory.spec.ts
@@ -51,31 +51,13 @@ describe('QueryRunnerArgsFactory', () => {
   });
 
   describe('create', () => {
-    it('should return the args when empty', async () => {
+    it('should simply return the args when data is an empty array', async () => {
       const args = {
         data: [],
       };
       const result = await factory.create(args, options);
 
       expect(result).toEqual(args);
-    });
-
-    it('should override position when of type string', async () => {
-      const args = {
-        data: { position: 'first' },
-      };
-
-      workspaceDataSourceService.executeRawQuery.mockResolvedValue([
-        { position: 2 },
-      ]);
-
-      const result = await factory.create(args, options);
-
-      expect(result).toEqual({
-        data: {
-          position: 1, // Calculates 2 / 2
-        },
-      });
     });
 
     it('should override args when of type array', async () => {

--- a/packages/twenty-server/src/workspace/workspace-query-runner/factories/__tests__/query-runner-args.factory.spec.ts
+++ b/packages/twenty-server/src/workspace/workspace-query-runner/factories/__tests__/query-runner-args.factory.spec.ts
@@ -52,7 +52,9 @@ describe('QueryRunnerArgsFactory', () => {
 
   describe('create', () => {
     it('should return the args when empty', async () => {
-      const args = {};
+      const args = {
+        data: [],
+      };
       const result = await factory.create(args, options);
 
       expect(result).toEqual(args);
@@ -60,7 +62,7 @@ describe('QueryRunnerArgsFactory', () => {
 
     it('should override position when of type string', async () => {
       const args = {
-        position: 'first',
+        data: { position: 'first' },
       };
 
       workspaceDataSourceService.executeRawQuery.mockResolvedValue([
@@ -70,12 +72,14 @@ describe('QueryRunnerArgsFactory', () => {
       const result = await factory.create(args, options);
 
       expect(result).toEqual({
-        position: 1, // Calculates 2 / 2
+        data: {
+          position: 1, // Calculates 2 / 2
+        },
       });
     });
 
     it('should override args when of type array', async () => {
-      const args = [{ id: 1 }, { position: 'last' }];
+      const args = { data: [{ id: 1 }, { position: 'last' }] };
 
       workspaceDataSourceService.executeRawQuery.mockResolvedValue([
         { position: 1 },
@@ -83,10 +87,12 @@ describe('QueryRunnerArgsFactory', () => {
 
       const result = await factory.create(args, options);
 
-      expect(result).toEqual([
-        { id: 1 },
-        { position: 2 }, // Calculates 1 + 1
-      ]);
+      expect(result).toEqual({
+        data: [
+          { id: 1 },
+          { position: 2 }, // Calculates 1 + 1
+        ],
+      });
     });
   });
 });

--- a/packages/twenty-server/src/workspace/workspace-query-runner/factories/query-runner-args.factory.ts
+++ b/packages/twenty-server/src/workspace/workspace-query-runner/factories/query-runner-args.factory.ts
@@ -28,7 +28,13 @@ export class QueryRunnerArgsFactory {
       ]),
     );
 
-    return this.createArgsRecursive(args, options, fieldMetadataMap);
+    return {
+      data: await this.createArgsRecursive(
+        args.data,
+        options,
+        fieldMetadataMap,
+      ),
+    };
   }
 
   private async createArgsRecursive(
@@ -55,10 +61,7 @@ export class QueryRunnerArgsFactory {
         const fieldMetadata = fieldMetadataMap.get(key);
 
         if (!fieldMetadata) {
-          return [
-            key,
-            await this.createArgsRecursive(value, options, fieldMetadataMap),
-          ];
+          return [key, await Promise.resolve(value)];
         }
 
         switch (fieldMetadata.type) {
@@ -72,10 +75,7 @@ export class QueryRunnerArgsFactory {
               ),
             ];
           default:
-            return [
-              key,
-              await this.createArgsRecursive(value, options, fieldMetadataMap),
-            ];
+            return [key, await Promise.resolve(value)];
         }
       },
     );

--- a/packages/twenty-server/src/workspace/workspace-query-runner/factories/query-runner-args.factory.ts
+++ b/packages/twenty-server/src/workspace/workspace-query-runner/factories/query-runner-args.factory.ts
@@ -1,12 +1,12 @@
 import { Injectable } from '@nestjs/common';
 
-import { FieldMetadataInterface } from 'src/metadata/field-metadata/interfaces/field-metadata.interface';
 import { WorkspaceQueryRunnerOptions } from 'src/workspace/workspace-query-runner/interfaces/query-runner-option.interface';
+import { FieldMetadataInterface } from 'src/metadata/field-metadata/interfaces/field-metadata.interface';
 import { ObjectMetadataInterface } from 'src/metadata/field-metadata/interfaces/object-metadata.interface';
 
 import { WorkspaceDataSourceService } from 'src/workspace/workspace-datasource/workspace-datasource.service';
-import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
 import { RecordPositionQueryFactory } from 'src/workspace/workspace-query-builder/factories/record-position-query.factory';
+import { FieldMetadataType } from 'src/metadata/field-metadata/field-metadata.entity';
 
 @Injectable()
 export class QueryRunnerArgsFactory {
@@ -29,34 +29,20 @@ export class QueryRunnerArgsFactory {
     );
 
     return {
-      data: await this.createArgsRecursive(
-        args.data,
-        options,
-        fieldMetadataMap,
+      data: await Promise.all(
+        args.data.map((arg) =>
+          this.overrideArgByFieldMetadata(arg, options, fieldMetadataMap),
+        ),
       ),
     };
   }
 
-  private async createArgsRecursive(
-    args: Record<string, any>,
+  private async overrideArgByFieldMetadata(
+    arg: Record<string, any>,
     options: WorkspaceQueryRunnerOptions,
     fieldMetadataMap: Map<string, FieldMetadataInterface>,
   ) {
-    // If it's not an object, we don't need to do anything
-    if (typeof args !== 'object' || args === null) {
-      return args;
-    }
-
-    // If it's an array, we need to map all items
-    if (Array.isArray(args)) {
-      return Promise.all(
-        args.map((arg) =>
-          this.createArgsRecursive(arg, options, fieldMetadataMap),
-        ),
-      );
-    }
-
-    const createArgPromisesByArgKey = Object.entries(args).map(
+    const createArgPromiseByArgKey = Object.entries(arg).map(
       async ([key, value]) => {
         const fieldMetadata = fieldMetadataMap.get(key);
 
@@ -80,7 +66,7 @@ export class QueryRunnerArgsFactory {
       },
     );
 
-    const newArgEntries = await Promise.all(createArgPromisesByArgKey);
+    const newArgEntries = await Promise.all(createArgPromiseByArgKey);
 
     return Object.fromEntries(newArgEntries);
   }


### PR DESCRIPTION
Activity creation has been broken by the args override.
Data times cannot be computed properly.

New strategy will be:
- Call the recursive function only on the array
- Return if the object is not matched with a field metadata