### PR TITLE
[messaging] fix participant handles with trailing spaces

### DIFF
--- a/packages/twenty-server/src/workspace/messaging/services/fetch-messages-by-batches.service.spec.ts
+++ b/packages/twenty-server/src/workspace/messaging/services/fetch-messages-by-batches.service.spec.ts
@@ -1,0 +1,53 @@
+import { AddressObject } from 'mailparser';
+
+import { FetchMessagesByBatchesService } from './fetch-messages-by-batches.service';
+
+describe('FetchMessagesByBatchesService', () => {
+  let service: FetchMessagesByBatchesService;
+
+  beforeEach(() => {
+    service = new FetchMessagesByBatchesService();
+  });
+
+  describe('formatAddressObjectAsParticipants', () => {
+    it('should format address object as participants', () => {
+      const addressObject: AddressObject = {
+        value: [
+          { name: 'John Doe', address: 'john.doe @example.com' },
+          { name: 'Jane Smith', address: 'jane.smith@example.com ' },
+        ],
+        html: '',
+        text: '',
+      };
+
+      const result = service.formatAddressObjectAsParticipants(
+        addressObject,
+        'from',
+      );
+
+      expect(result).toEqual([
+        {
+          role: 'from',
+          handle: 'john.doe@example.com',
+          displayName: 'John Doe',
+        },
+        {
+          role: 'from',
+          handle: 'jane.smith@example.com',
+          displayName: 'Jane Smith',
+        },
+      ]);
+    });
+
+    it('should return an empty array if address object is undefined', () => {
+      const addressObject = undefined;
+
+      const result = service.formatAddressObjectAsParticipants(
+        addressObject,
+        'to',
+      );
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/packages/twenty-server/src/workspace/messaging/services/fetch-messages-by-batches.service.ts
+++ b/packages/twenty-server/src/workspace/messaging/services/fetch-messages-by-batches.service.ts
@@ -282,13 +282,17 @@ export class FetchMessagesByBatchesService {
 
         return {
           role,
-          handle: address?.toLowerCase() || '',
+          handle: address ? this.removeSpacesAndLowerCase(address) : '',
           displayName: name || '',
         };
       });
     });
 
     return participants.flat();
+  }
+
+  private removeSpacesAndLowerCase(email: string): string {
+    return email.replace(/\s/g, '').toLowerCase();
   }
 
   async formatBatchResponsesAsGmailMessages(


### PR DESCRIPTION
## Context
Sanitise the handle of participant email addresses before saving in the DB, this will also simplify the comparisons we do later in the code for contact matching