### PR TITLE
fix: exclude GQL scalar types from the name validation of object and field metadata

### DIFF
--- a/packages/twenty-server/src/metadata/decorators/is-valid-name.decorator.ts
+++ b/packages/twenty-server/src/metadata/decorators/is-valid-name.decorator.ts
@@ -13,7 +13,9 @@ export function IsValidName(validationOptions?: ValidationOptions) {
       options: validationOptions,
       validator: {
         validate(value: any) {
-          return /^(?!(?:not|or|and)$)[^'\"\\;.=*/]+$/.test(value);
+          return /^(?!(?:not|or|and|Int|Float|Boolean|String|ID)$)[^'\"\\;.=*/]+$/.test(
+            value,
+          );
         },
         defaultMessage(args: ValidationArguments) {
           return `${args.property} has failed the name validation check`;


### PR DESCRIPTION
Closes #4443 

I have added the basic scalar types but not sure about `Query`, `Mutation` and `Subscription` because they could conflict when creating an object with such names.