### PR TITLE
update example docker-compose to bitnami postgres path

### DIFF
--- a/packages/twenty-docs/docs/start/self-hosting/docker-compose.mdx
+++ b/packages/twenty-docs/docs/start/self-hosting/docker-compose.mdx
@@ -86,7 +86,7 @@ services:
   db:
     image: twentycrm/twenty-postgres:${TAG}
     volumes:
-      - twenty-db-data:/var/lib/postgresql/data
+      - twenty-db-data:/bitnami/postgresql/data
     environment:
       - POSTGRES_PASSWORD=${POSTGRES_ADMIN_PASSWORD}
 volumes:

--- a/packages/twenty-docs/docs/start/self-hosting/docker-compose.mdx
+++ b/packages/twenty-docs/docs/start/self-hosting/docker-compose.mdx
@@ -85,6 +85,10 @@ services:
 
   db:
     image: twentycrm/twenty-postgres:${TAG}
+    volumes:
+      - twenty-db-data:/var/lib/postgresql/data
     environment:
       - POSTGRES_PASSWORD=${POSTGRES_ADMIN_PASSWORD}
+volumes:
+  twenty-db-data:
 ```

--- a/packages/twenty-docs/docs/start/self-hosting/docker-compose.mdx
+++ b/packages/twenty-docs/docs/start/self-hosting/docker-compose.mdx
@@ -35,7 +35,7 @@ Complete step three and four with :
 
 ## Production docker containers
 
-Prebuilt images for both Postgres, frontend, and back-end can be found on [docker hub](https://hub.docker.com/r/twentycrm/).
+Prebuilt images for both Postgres, frontend, and back-end can be found on [docker hub](https://hub.docker.com/r/twentycrm/). Note that the Postgres container will not persist data to a local volume by default. You will probably want to configure it for this.
 
 ## Environment Variables
 
@@ -85,10 +85,6 @@ services:
 
   db:
     image: twentycrm/twenty-postgres:${TAG}
-    volumes:
-      - twenty-db-data:/bitnami/postgresql/data
     environment:
       - POSTGRES_PASSWORD=${POSTGRES_ADMIN_PASSWORD}
-volumes:
-  twenty-db-data:
 ```

--- a/packages/twenty-docs/docs/start/self-hosting/docker-compose.mdx
+++ b/packages/twenty-docs/docs/start/self-hosting/docker-compose.mdx
@@ -35,7 +35,7 @@ Complete step three and four with :
 
 ## Production docker containers
 
-Prebuilt images for both Postgres, frontend, and back-end can be found on [docker hub](https://hub.docker.com/r/twentycrm/). Note that the Postgres container will not persist data to a local volume by default. You will probably want to configure it for this.
+Prebuilt images for both Postgres, frontend, and back-end can be found on [docker hub](https://hub.docker.com/r/twentycrm/). Note that the Postgres container will not persist data if your server is not configured to be stateful (e.g. Heroku). You probably want to configure a special stateful resource for the database.
 
 ## Environment Variables
 


### PR DESCRIPTION
it appears the twenty postgres is based on a bitnami postgres that has a different pgdata dir than the one in the example.

just wanted to update this so that other people are aware!