### PR TITLE
Fixed select field input height

### DIFF
--- a/packages/twenty-front/src/modules/settings/data-model/components/SettingsObjectFieldSelectFormOptionRow.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/components/SettingsObjectFieldSelectFormOptionRow.tsx
@@ -49,7 +49,7 @@ const StyledOptionInput = styled(TextInput)`
   margin-right: ${({ theme }) => theme.spacing(2)};
 
   & input {
-    height: ${({ theme }) => theme.spacing(2)};
+    height: ${({ theme }) => theme.spacing(6)};
   }
 `;
 


### PR DESCRIPTION
Resolves: Issue [4477](https://github.com/twentyhq/twenty/issues/4477)

Fixes height of the input field from 8px to 24px.

I'm a new contributor and it seemed like a small fix. Please let me know if you have any feedback.