### PR TITLE
feat: add a docker-compose file for production

### DIFF
--- a/packages/twenty-docker/prod/.env.example
+++ b/packages/twenty-docker/prod/.env.example
@@ -1,0 +1,14 @@
+TAG=latest
+
+POSTGRES_ADMIN_PASSWORD=replace_me_with_a_strong_password
+
+PG_DATABASE_HOST=db:5432
+
+SERVER_URL=http://localhost:3000
+# Uncoment if you are serving your front on another server than the API (eg. bucket)
+# FRONT_BASE_URL=http://localhost:3000
+
+ACCESS_TOKEN_SECRET=replace_me_with_a_random_string_access
+LOGIN_TOKEN_SECRET=replace_me_with_a_random_string_login
+REFRESH_TOKEN_SECRET=replace_me_with_a_random_string_refresh
+SIGN_IN_PREFILLED=true

--- a/packages/twenty-docker/prod/.env.example
+++ b/packages/twenty-docker/prod/.env.example
@@ -8,7 +8,9 @@ SERVER_URL=http://localhost:3000
 # Uncoment if you are serving your front on another server than the API (eg. bucket)
 # FRONT_BASE_URL=http://localhost:3000
 
-ACCESS_TOKEN_SECRET=replace_me_with_a_random_string_access
-LOGIN_TOKEN_SECRET=replace_me_with_a_random_string_login
-REFRESH_TOKEN_SECRET=replace_me_with_a_random_string_refresh
+# Use openssl rand -base64 32 for each secret
+# ACCESS_TOKEN_SECRET=replace_me_with_a_random_string_access
+# LOGIN_TOKEN_SECRET=replace_me_with_a_random_string_login
+# REFRESH_TOKEN_SECRET=replace_me_with_a_random_string_refresh
+
 SIGN_IN_PREFILLED=true

--- a/packages/twenty-docker/prod/docker-compose.yml
+++ b/packages/twenty-docker/prod/docker-compose.yml
@@ -1,0 +1,53 @@
+version: '3.8'
+name: twenty
+
+services:
+  server:
+    image: twentycrm/twenty:${TAG}
+    user: 1000:1000
+    volumes:
+      - server-local-data:/app/.local-storage
+    ports:
+      - "3000:3000"
+    environment:
+      PORT: 3000
+      PG_DATABASE_URL: postgres://twenty:twenty@${PG_DATABASE_HOST}/default
+      SERVER_URL: ${SERVER_URL}
+      FRONT_BASE_URL: ${FRONT_BASE_URL:-$SERVER_URL}
+
+      ENABLE_DB_MIGRATIONS: true
+
+      SIGN_IN_PREFILLED: ${SIGN_IN_PREFILLED}
+      STORAGE_TYPE: local
+      STORAGE_LOCAL_PATH: .local-storage
+      ACCESS_TOKEN_SECRET: ${ACCESS_TOKEN_SECRET}
+      LOGIN_TOKEN_SECRET: ${LOGIN_TOKEN_SECRET}
+      REFRESH_TOKEN_SECRET: ${REFRESH_TOKEN_SECRET}
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl --silent --fail http://localhost:3000/healthz | jq -e '.status == \"ok\"' > /dev/null || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    restart: always
+
+  db:
+    image: twentycrm/twenty-postgres:${TAG}
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_PASSWORD: ${POSTGRES_ADMIN_PASSWORD}
+      #POSTGRES_USER: ${POSTGRES_USER}
+      #POSTGRES_DB: ${POSTGRES_DB}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U twenty -d default"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    restart: always
+
+volumes:
+  db-data:
+  server-local-data:

--- a/packages/twenty-docker/prod/docker-compose.yml
+++ b/packages/twenty-docker/prod/docker-compose.yml
@@ -4,7 +4,6 @@ name: twenty
 services:
   server:
     image: twentycrm/twenty:${TAG}
-    user: 1000:1000
     volumes:
       - server-local-data:/app/.local-storage
     ports:


### PR DESCRIPTION
## Description
**Depends on https://github.com/twentyhq/twenty/pull/4589**

This PR brings a docker-compose config for production use, thanks to the changes made in https://github.com/twentyhq/twenty/pull/4589 we can easily expose the app thanks to automatic DB migrations.

### Testing
Currently we are not building the new Docker image used in here with Github Actions, testing this PR will require small changes
- In `twenty/packages/twenty-docker/prod` make a copy of the .env.example to .env
- In the docker-compose replace
```
    #image: twentycrm/twenty:${TAG}
```
with
```
    build:
      context: ../../..
      dockerfile: ./packages/twenty-docker/prod/twenty/Dockerfile
```

Finally, you should be able to run a `docker compose up --build` and test locally the stack.

### What have been done
- Adding volumes for better flexibility with the DB and local storage
- Support for health checks
- Some tweaks were made in **Depends on https://github.com/twentyhq/twenty/pull/4589** in order to ease the use of the docker-compose

## Points of attention
I've noticed while writing the compose file that we are currently using an hardcoded user and password `twenty` `twenty`. It would be reasonable to harden the security by changing this behavior and by using a generated / user inputted password.
It would require changes in the init script of the database, to correcly set the superuser rights, as well as probably updating the migration script.