### PR TITLE
Update .env.example

### DIFF
--- a/packages/twenty-server/.env.example
+++ b/packages/twenty-server/.env.example
@@ -3,6 +3,9 @@ PG_DATABASE_URL=postgres://twenty:twenty@localhost:5432/default
 # Use this for docker setup
 # PG_DATABASE_URL=postgres://twenty:twenty@postgres:5432/default
 
+# Version of Twenty that you want to run
+TAG=latest
+
 FRONT_BASE_URL=http://localhost:3001
 
 ACCESS_TOKEN_SECRET=replace_me_with_a_random_string_access
@@ -12,7 +15,7 @@ FILE_TOKEN_SECRET=replace_me_with_a_random_string_refresh
 SIGN_IN_PREFILLED=true
 
 # ———————— Optional ————————
-# PORT=3000
+PORT=3001
 # DEBUG_MODE=true
 # DEBUG_PORT=9000
 # ACCESS_TOKEN_EXPIRES_IN=30m


### PR DESCRIPTION
The `TAG` variables is missing from the `.env` file, which makes [the example here](https://docs.twenty.com/start/self-hosting/docker-compose) not work.

Also, all of the documentation assumes port 3001, but port isn't specified, this change does specify it.