### PR TITLE
Add worker run step to server cli

### DIFF
--- a/.github/workflows/ci-server.yaml
+++ b/.github/workflows/ci-server.yaml
@@ -31,5 +31,5 @@ jobs:
         run: yarn nx lint twenty-server
       - name: Server / Run jest tests
         run: yarn nx test twenty-server
-      # - name: Server / Run e2e tests
-      #   run: yarn nx test:e2e twenty-server
+      - name: Worker / Run
+        run: MESSAGE_QUEUE_TYPE=sync yarn nx queue:work twenty-server

--- a/.github/workflows/ci-server.yaml
+++ b/.github/workflows/ci-server.yaml
@@ -33,5 +33,9 @@ jobs:
         run: yarn nx test twenty-server
       - name: Server / Build
         run: yarn nx build twenty-server
+      - name: Server / Write .env
+        run: |
+          cd packages/twenty-server
+          cp .env.example .env
       - name: Worker / Run
         run: MESSAGE_QUEUE_TYPE=sync yarn nx queue:work twenty-server

--- a/.github/workflows/ci-server.yaml
+++ b/.github/workflows/ci-server.yaml
@@ -31,5 +31,7 @@ jobs:
         run: yarn nx lint twenty-server
       - name: Server / Run jest tests
         run: yarn nx test twenty-server
+      - name: Server / Build
+        run: yarn nx build twenty-server
       - name: Worker / Run
         run: MESSAGE_QUEUE_TYPE=sync yarn nx queue:work twenty-server

--- a/packages/twenty-server/src/engine/integrations/message-queue/jobs.module.ts
+++ b/packages/twenty-server/src/engine/integrations/message-queue/jobs.module.ts
@@ -45,6 +45,7 @@ import { ConnectedAccountObjectMetadata } from 'src/modules/connected-account/st
 import { MessageParticipantObjectMetadata } from 'src/modules/messaging/standard-objects/message-participant.object-metadata';
 import { MessageChannelObjectMetadata } from 'src/modules/messaging/standard-objects/message-channel.object-metadata';
 import { SaveEventToDbJob } from 'src/engine/api/graphql/workspace-query-runner/jobs/save-event-to-db.job';
+import { EventObjectMetadata } from 'src/modules/event/standard-objects/event.object-metadata';
 
 @Module({
   imports: [
@@ -74,6 +75,7 @@ import { SaveEventToDbJob } from 'src/engine/api/graphql/workspace-query-runner/
       ConnectedAccountObjectMetadata,
       MessageParticipantObjectMetadata,
       MessageChannelObjectMetadata,
+      EventObjectMetadata,
     ]),
   ],
   providers: [


### PR DESCRIPTION
We recently merged a PR that introduced a regression on the worker, missing some dependencies and the CI was not catching this. We are adding an extra step to simply run the worker to avoid this kind of issue.