### PR TITLE
Add events on Custom objects

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/jobs/save-event-to-db.job.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/jobs/save-event-to-db.job.ts
@@ -39,14 +39,6 @@ export class SaveEventToDbJob implements MessageQueueJob<SaveEventToDbJobData> {
       workspaceMemberId = workspaceMember.id;
     }
 
-    if (
-      data.objectName != 'person' &&
-      data.objectName != 'company' &&
-      data.objectName != 'opportunity'
-    ) {
-      return;
-    }
-
     if (data.details.diff) {
       // we remove "before" and "after" property for a cleaner/slimmer event payload
       data.details = {

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/constants/standard-field-ids.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/constants/standard-field-ids.ts
@@ -298,4 +298,5 @@ export const customObjectStandardFieldIds = {
   activityTargets: '20202020-7f42-40ae-b96c-c8a61acc83bf',
   favorites: '20202020-a4a7-4686-b296-1c6c3482ee21',
   attachments: '20202020-8d59-46ca-b7b2-73d167712134',
+  events: '20202020-a508-4334-9724-5c2bf1b05998',
 };

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/custom-objects/custom.object-metadata.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/custom-objects/custom.object-metadata.ts
@@ -13,6 +13,7 @@ import { RelationMetadata } from 'src/engine/workspace-manager/workspace-sync-me
 import { FavoriteObjectMetadata } from 'src/modules/favorite/standard-objects/favorite.object-metadata';
 import { AttachmentObjectMetadata } from 'src/modules/attachment/standard-objects/attachment.object-metadata';
 import { customObjectStandardFieldIds } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-field-ids';
+import { EventObjectMetadata } from 'src/modules/event/standard-objects/event.object-metadata';
 
 @BaseCustomObjectMetadata()
 export class CustomObjectMetadata extends BaseObjectMetadata {
@@ -85,4 +86,20 @@ export class CustomObjectMetadata extends BaseObjectMetadata {
   })
   @IsNullable()
   attachments: AttachmentObjectMetadata[];
+
+  @FieldMetadata({
+    standardId: customObjectStandardFieldIds.events,
+    type: FieldMetadataType.RELATION,
+    label: 'Events',
+    description: (objectMetadata) =>
+      `Events tied to the ${objectMetadata.labelSingular}`,
+    icon: 'IconJson',
+  })
+  @RelationMetadata({
+    type: RelationMetadataType.ONE_TO_MANY,
+    inverseSideTarget: () => AttachmentObjectMetadata,
+    onDelete: RelationOnDeleteAction.CASCADE,
+  })
+  @IsNullable()
+  events: EventObjectMetadata[];
 }

--- a/packages/twenty-server/src/modules/company/standard-objects/company.object-metadata.ts
+++ b/packages/twenty-server/src/modules/company/standard-objects/company.object-metadata.ts
@@ -20,7 +20,6 @@ import { OpportunityObjectMetadata } from 'src/modules/opportunity/standard-obje
 import { PersonObjectMetadata } from 'src/modules/person/standard-objects/person.object-metadata';
 import { WorkspaceMemberObjectMetadata } from 'src/modules/workspace-member/standard-objects/workspace-member.object-metadata';
 import { EventObjectMetadata } from 'src/modules/event/standard-objects/event.object-metadata';
-import { Gate } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/gate.decorator';
 
 @ObjectMetadata({
   standardId: standardObjectIds.company,
@@ -222,9 +221,6 @@ export class CompanyObjectMetadata extends BaseObjectMetadata {
     onDelete: RelationOnDeleteAction.CASCADE,
   })
   @IsNullable()
-  @Gate({
-    featureFlag: 'IS_EVENT_OBJECT_ENABLED',
-  })
   @IsSystem()
   events: EventObjectMetadata[];
 }

--- a/packages/twenty-server/src/modules/event/standard-objects/event.object-metadata.ts
+++ b/packages/twenty-server/src/modules/event/standard-objects/event.object-metadata.ts
@@ -1,11 +1,9 @@
 import { FieldMetadataType } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
-import { FeatureFlagKeys } from 'src/engine/core-modules/feature-flag/feature-flag.entity';
 import { eventStandardFieldIds } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-field-ids';
 import { standardObjectIds } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-object-ids';
 import { CustomObjectMetadata } from 'src/engine/workspace-manager/workspace-sync-metadata/custom-objects/custom.object-metadata';
 import { DynamicRelationFieldMetadata } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/dynamic-field-metadata.interface';
 import { FieldMetadata } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/field-metadata.decorator';
-import { Gate } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/gate.decorator';
 import { IsNullable } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/is-nullable.decorator';
 import { IsSystem } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/is-system.decorator';
 import { ObjectMetadata } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/object-metadata.decorator';
@@ -24,9 +22,6 @@ import { WorkspaceMemberObjectMetadata } from 'src/modules/workspace-member/stan
   icon: 'IconJson',
 })
 @IsSystem()
-@Gate({
-  featureFlag: FeatureFlagKeys.IsEventObjectEnabled,
-})
 export class EventObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({
     standardId: eventStandardFieldIds.properties,
@@ -95,7 +90,7 @@ export class EventObjectMetadata extends BaseObjectMetadata {
     standardId: eventStandardFieldIds.custom,
     name: oppositeObjectMetadata.nameSingular,
     label: oppositeObjectMetadata.labelSingular,
-    description: `Favorite ${oppositeObjectMetadata.labelSingular}`,
+    description: `Event ${oppositeObjectMetadata.labelSingular}`,
     joinColumn: `${oppositeObjectMetadata.nameSingular}Id`,
     icon: 'IconBuildingSkyscraper',
   }))

--- a/packages/twenty-server/src/modules/opportunity/standard-objects/opportunity.object-metadata.ts
+++ b/packages/twenty-server/src/modules/opportunity/standard-objects/opportunity.object-metadata.ts
@@ -18,7 +18,6 @@ import { CompanyObjectMetadata } from 'src/modules/company/standard-objects/comp
 import { FavoriteObjectMetadata } from 'src/modules/favorite/standard-objects/favorite.object-metadata';
 import { PersonObjectMetadata } from 'src/modules/person/standard-objects/person.object-metadata';
 import { EventObjectMetadata } from 'src/modules/event/standard-objects/event.object-metadata';
-import { Gate } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/gate.decorator';
 
 @ObjectMetadata({
   standardId: standardObjectIds.opportunity,
@@ -178,9 +177,6 @@ export class OpportunityObjectMetadata extends BaseObjectMetadata {
   @RelationMetadata({
     type: RelationMetadataType.ONE_TO_MANY,
     inverseSideTarget: () => EventObjectMetadata,
-  })
-  @Gate({
-    featureFlag: 'IS_EVENT_OBJECT_ENABLED',
   })
   @IsNullable()
   events: EventObjectMetadata[];

--- a/packages/twenty-server/src/modules/person/standard-objects/person.object-metadata.ts
+++ b/packages/twenty-server/src/modules/person/standard-objects/person.object-metadata.ts
@@ -233,9 +233,6 @@ export class PersonObjectMetadata extends BaseObjectMetadata {
     onDelete: RelationOnDeleteAction.CASCADE,
   })
   @IsNullable()
-  @Gate({
-    featureFlag: 'IS_EVENT_OBJECT_ENABLED',
-  })
   @IsSystem()
   events: EventObjectMetadata[];
 }

--- a/packages/twenty-server/src/modules/workspace-member/standard-objects/workspace-member.object-metadata.ts
+++ b/packages/twenty-server/src/modules/workspace-member/standard-objects/workspace-member.object-metadata.ts
@@ -247,9 +247,6 @@ export class WorkspaceMemberObjectMetadata extends BaseObjectMetadata {
     onDelete: RelationOnDeleteAction.CASCADE,
   })
   @IsNullable()
-  @Gate({
-    featureFlag: 'IS_EVENT_OBJECT_ENABLED',
-  })
   @IsSystem()
   events: EventObjectMetadata[];
 }


### PR DESCRIPTION
In this PR, I'm fixing the relation between events and custom objects so it is rightly provisioned on:
- workspace creation
- sync of existing workspaces

This will allow custom objects to also benefit from logs (beta feature)