### PR TITLE
fix: create deterministic uuids for standards relation on custom object

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.service.ts
@@ -43,7 +43,10 @@ import {
   eventStandardFieldIds,
   favoriteStandardFieldIds,
 } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-field-ids';
-import { createDeterministicUuid } from 'src/engine/workspace-manager/workspace-sync-metadata/utils/create-deterministic-uuid.util';
+import {
+  createForeignKeyDeterministicUuid,
+  createRelationDeterministicUuid,
+} from 'src/engine/workspace-manager/workspace-sync-metadata/utils/create-deterministic-uuid.util';
 
 import { ObjectMetadataEntity } from './object-metadata.entity';
 
@@ -662,7 +665,10 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
         },
         // TO
         {
-          standardId: activityTargetStandardFieldIds.custom,
+          standardId: createRelationDeterministicUuid({
+            objectId: createdObjectMetadata.id,
+            standardId: activityTargetStandardFieldIds.custom,
+          }),
           objectMetadataId: activityTargetObjectMetadata.id,
           workspaceId: workspaceId,
           isCustom: false,
@@ -677,9 +683,10 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
         },
         // Foreign key
         {
-          standardId: createDeterministicUuid(
-            activityTargetStandardFieldIds.custom,
-          ),
+          standardId: createForeignKeyDeterministicUuid({
+            objectId: createdObjectMetadata.id,
+            standardId: activityTargetStandardFieldIds.custom,
+          }),
           objectMetadataId: activityTargetObjectMetadata.id,
           workspaceId: workspaceId,
           isCustom: false,
@@ -761,7 +768,10 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
         },
         // TO
         {
-          standardId: attachmentStandardFieldIds.custom,
+          standardId: createRelationDeterministicUuid({
+            objectId: createdObjectMetadata.id,
+            standardId: attachmentStandardFieldIds.custom,
+          }),
           objectMetadataId: attachmentObjectMetadata.id,
           workspaceId: workspaceId,
           isCustom: false,
@@ -776,9 +786,10 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
         },
         // Foreign key
         {
-          standardId: createDeterministicUuid(
-            attachmentStandardFieldIds.custom,
-          ),
+          standardId: createForeignKeyDeterministicUuid({
+            objectId: createdObjectMetadata.id,
+            standardId: attachmentStandardFieldIds.custom,
+          }),
           objectMetadataId: attachmentObjectMetadata.id,
           workspaceId: workspaceId,
           isCustom: false,
@@ -857,7 +868,10 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
       },
       // TO
       {
-        standardId: eventStandardFieldIds.custom,
+        standardId: createRelationDeterministicUuid({
+          objectId: createdObjectMetadata.id,
+          standardId: eventStandardFieldIds.custom,
+        }),
         objectMetadataId: eventObjectMetadata.id,
         workspaceId: workspaceId,
         isCustom: false,
@@ -872,7 +886,10 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
       },
       // Foreign key
       {
-        standardId: createDeterministicUuid(eventStandardFieldIds.custom),
+        standardId: createForeignKeyDeterministicUuid({
+          objectId: createdObjectMetadata.id,
+          standardId: eventStandardFieldIds.custom,
+        }),
         objectMetadataId: eventObjectMetadata.id,
         workspaceId: workspaceId,
         isCustom: false,
@@ -952,7 +969,10 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
         },
         // TO
         {
-          standardId: favoriteStandardFieldIds.custom,
+          standardId: createRelationDeterministicUuid({
+            objectId: createdObjectMetadata.id,
+            standardId: favoriteStandardFieldIds.custom,
+          }),
           objectMetadataId: favoriteObjectMetadata.id,
           workspaceId: workspaceId,
           isCustom: false,
@@ -967,7 +987,10 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
         },
         // Foreign key
         {
-          standardId: createDeterministicUuid(favoriteStandardFieldIds.custom),
+          standardId: createForeignKeyDeterministicUuid({
+            objectId: createdObjectMetadata.id,
+            standardId: favoriteStandardFieldIds.custom,
+          }),
           objectMetadataId: favoriteObjectMetadata.id,
           workspaceId: workspaceId,
           isCustom: false,

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/commands/add-standard-id.command.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/commands/add-standard-id.command.ts
@@ -120,10 +120,7 @@ export class AddStandardIdCommand extends CommandRunner {
           customObjectMetadataCollection,
         );
 
-        if (
-          !originalObjectMetadata.isCustom &&
-          !originalObjectMetadata.standardId
-        ) {
+        if (!originalObjectMetadata.isCustom) {
           updateObjectMetadataCollection.push({
             id: originalObjectMetadata.id,
             standardId: computedStandardObjectMetadata.standardId,
@@ -136,7 +133,7 @@ export class AddStandardIdCommand extends CommandRunner {
               (field) => field.name === fieldMetadata.name && !field.isCustom,
             );
 
-          if (!standardFieldMetadata || fieldMetadata.standardId) {
+          if (!standardFieldMetadata) {
             continue;
           }
 

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/utils/compute-standard-object.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/utils/compute-standard-object.util.ts
@@ -7,7 +7,10 @@ import { ComputedPartialFieldMetadata } from 'src/engine/workspace-manager/works
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 import { generateTargetColumnMap } from 'src/engine/metadata-modules/field-metadata/utils/generate-target-column-map.util';
 import { FieldMetadataType } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
-import { createDeterministicUuid } from 'src/engine/workspace-manager/workspace-sync-metadata/utils/create-deterministic-uuid.util';
+import {
+  createForeignKeyDeterministicUuid,
+  createRelationDeterministicUuid,
+} from 'src/engine/workspace-manager/workspace-sync-metadata/utils/create-deterministic-uuid.util';
 
 export const computeStandardObject = (
   standardObjectMetadata: Omit<PartialObjectMetadata, 'standardId'> & {
@@ -24,11 +27,20 @@ export const computeStandardObject = (
       for (const customObjectMetadata of customObjectMetadataCollection) {
         const { paramsFactory, ...rest } = partialFieldMetadata;
         const { joinColumn, ...data } = paramsFactory(customObjectMetadata);
+        const relationStandardId = createRelationDeterministicUuid({
+          objectId: customObjectMetadata.id,
+          standardId: data.standardId,
+        });
+        const foreignKeyStandardId = createForeignKeyDeterministicUuid({
+          objectId: customObjectMetadata.id,
+          standardId: data.standardId,
+        });
 
         // Relation
         fields.push({
           ...data,
           ...rest,
+          standardId: relationStandardId,
           defaultValue: null,
           targetColumnMap: {},
         });
@@ -36,7 +48,7 @@ export const computeStandardObject = (
         // Foreign key
         fields.push({
           ...rest,
-          standardId: createDeterministicUuid(data.standardId),
+          standardId: foreignKeyStandardId,
           name: joinColumn,
           type: FieldMetadataType.UUID,
           label: `${data.label} ID (foreign key)`,

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/utils/create-deterministic-uuid.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/utils/create-deterministic-uuid.util.ts
@@ -1,10 +1,35 @@
 import { createHash } from 'crypto';
 
-export const createDeterministicUuid = (inputUuid: string): string => {
-  const hash = createHash('sha256').update(inputUuid).digest('hex');
+export function createDeterministicUuid(uuid: string): string;
+export function createDeterministicUuid(uuids: string[]): string;
+
+export function createDeterministicUuid(
+  uuidOrUuids: string[] | string,
+): string {
+  const inputForHash = Array.isArray(uuidOrUuids)
+    ? uuidOrUuids.join('-')
+    : uuidOrUuids;
+  const hash = createHash('sha256').update(inputForHash).digest('hex');
 
   return `20202020-${hash.substring(0, 4)}-4${hash.substring(
     4,
     7,
   )}-8${hash.substring(7, 10)}-${hash.substring(10, 22)}`;
+}
+
+type UuidPair = {
+  objectId: string;
+  standardId: string;
+};
+
+export const createRelationDeterministicUuid = (uuidPair: UuidPair): string => {
+  // Chaging the order in the array will result in different UUIDs
+  return createDeterministicUuid([uuidPair.objectId, uuidPair.standardId]);
+};
+
+export const createForeignKeyDeterministicUuid = (
+  uuidPair: UuidPair,
+): string => {
+  // Chaging the order in the array will result in different UUIDs
+  return createDeterministicUuid([uuidPair.standardId, uuidPair.objectId]);
 };


### PR DESCRIPTION
This PR create deterministic uuids for standard relation of custom object, the reuse of the same uuids for custom objects was leading to issues for the `sync` command.