### PR TITLE
feat(ci): automate CI tags and pass github context

### DIFF
--- a/.github/workflows/cd-deploy-tag.yaml
+++ b/.github/workflows/cd-deploy-tag.yaml
@@ -1,10 +1,10 @@
 name: CD deploy main
 on:
   push:
-    branches:
-      - main
+    tags:
+      - 'v*'
 jobs:
-  deploy-main:
+  deploy-tag:
     runs-on: ubuntu-latest
     steps:
       - name: Repository Dispatch
@@ -12,5 +12,5 @@ jobs:
         with:
           token: ${{ secrets.TWENTY_INFRA_TOKEN }}
           repository: twentyhq/twenty-infra
-          event-type: auto-deploy-main
+          event-type: auto-deploy-tag
           client-payload: '{"github": ${{ toJson(github) }}}' # Passes the entire github context to the downstream workflow

--- a/.github/workflows/cd-deploy-tag.yaml
+++ b/.github/workflows/cd-deploy-tag.yaml
@@ -1,4 +1,4 @@
-name: CD deploy main
+name: CD deploy tag
 on:
   push:
     tags:


### PR DESCRIPTION
This PR adds a new workflow that triggers on tags v*, it then dispatch an event to an internal repo in order to build Docker images.
I also included in this workflow and the already existing one, the `github` context, in order to be able to have more info on the incoming event.