### PR TITLE
chore: debug Twenty dockerfile failing to build on Github Actions

### DIFF
--- a/packages/twenty-docker/prod/twenty/Dockerfile
+++ b/packages/twenty-docker/prod/twenty/Dockerfile
@@ -24,13 +24,6 @@ FROM common-deps as twenty-server-build
 COPY ./packages/twenty-emails /app/packages/twenty-emails
 COPY ./packages/twenty-server /app/packages/twenty-server
 
-# RUN npx nx run twenty-server:build && \
-#     mv /app/packages/twenty-server/dist /app/packages/twenty-server/build && \
-#     npx nx run twenty-server:build:packageJson && \
-#     mv /app/packages/twenty-server/dist/package.json /app/packages/twenty-server/package.json && \
-#     rm -rf /app/packages/twenty-server/dist && \
-#     mv /app/packages/twenty-server/build /app/packages/twenty-server/dist
-
 RUN npx nx run twenty-server:build
 RUN mv /app/packages/twenty-server/dist /app/packages/twenty-server/build
 RUN npx nx run twenty-server:build:packageJson

--- a/packages/twenty-docker/prod/twenty/Dockerfile
+++ b/packages/twenty-docker/prod/twenty/Dockerfile
@@ -24,12 +24,19 @@ FROM common-deps as twenty-server-build
 COPY ./packages/twenty-emails /app/packages/twenty-emails
 COPY ./packages/twenty-server /app/packages/twenty-server
 
-RUN npx nx run twenty-server:build && \
-    mv /app/packages/twenty-server/dist /app/packages/twenty-server/build && \
-    npx nx run twenty-server:build:packageJson && \
-    mv /app/packages/twenty-server/dist/package.json /app/packages/twenty-server/package.json && \
-    rm -rf /app/packages/twenty-server/dist && \
-    mv /app/packages/twenty-server/build /app/packages/twenty-server/dist
+# RUN npx nx run twenty-server:build && \
+#     mv /app/packages/twenty-server/dist /app/packages/twenty-server/build && \
+#     npx nx run twenty-server:build:packageJson && \
+#     mv /app/packages/twenty-server/dist/package.json /app/packages/twenty-server/package.json && \
+#     rm -rf /app/packages/twenty-server/dist && \
+#     mv /app/packages/twenty-server/build /app/packages/twenty-server/dist
+
+RUN npx nx run twenty-server:build
+RUN mv /app/packages/twenty-server/dist /app/packages/twenty-server/build
+RUN npx nx run twenty-server:build:packageJson
+RUN mv /app/packages/twenty-server/dist/package.json /app/packages/twenty-server/package.json
+RUN rm -rf /app/packages/twenty-server/dist
+RUN mv /app/packages/twenty-server/build /app/packages/twenty-server/dist
 
 RUN yarn workspaces focus --production twenty-emails twenty-server
 


### PR DESCRIPTION
For some reason merging these commands led to synchronization behavior when building the Image with Github Actions (files were not yet present on disk). Using independent RUN did the trick and did not increased the size of the intermediate layer much.