### PR TITLE
Fetch available remote tables

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/auth/auth.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/auth.util.ts
@@ -16,11 +16,11 @@ export const compareHash = async (password: string, passwordHash: string) => {
   return bcrypt.compare(password, passwordHash);
 };
 
-export const encryptText = async (
+export const encryptText = (
   textToEncrypt: string,
   key: string,
   iv: string,
-): Promise<string> => {
+): string => {
   const keyHash = createHash('sha512')
     .update(key)
     .digest('hex')
@@ -35,11 +35,11 @@ export const encryptText = async (
   );
 };
 
-export const decryptText = async (
+export const decryptText = (
   textToDecrypt: string,
   key: string,
   iv: string,
-) => {
+): string => {
   const keyHash = createHash('sha512')
     .update(key)
     .digest('hex')

--- a/packages/twenty-server/src/engine/core-modules/core-engine.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/core-engine.module.ts
@@ -10,7 +10,6 @@ import { TimelineMessagingModule } from 'src/engine/core-modules/messaging/timel
 import { TimelineCalendarEventModule } from 'src/engine/core-modules/calendar/timeline-calendar-event.module';
 import { BillingModule } from 'src/engine/core-modules/billing/billing.module';
 import { HealthModule } from 'src/engine/core-modules/health/health.module';
-import { RemoteServerModule } from 'src/engine/metadata-modules/remote-server/remote-server.module';
 
 import { AnalyticsModule } from './analytics/analytics.module';
 import { FileModule } from './file/file.module';
@@ -31,7 +30,6 @@ import { ClientConfigModule } from './client-config/client-config.module';
     TimelineCalendarEventModule,
     UserModule,
     WorkspaceModule,
-    RemoteServerModule,
   ],
   exports: [
     AnalyticsModule,

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-server.module.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-server.module.ts
@@ -6,17 +6,18 @@ import { ForeignDataWrapperQueryFactory } from 'src/engine/api/graphql/workspace
 import { RemoteServerEntity } from 'src/engine/metadata-modules/remote-server/remote-server.entity';
 import { RemoteServerResolver } from 'src/engine/metadata-modules/remote-server/remote-server.resolver';
 import { RemoteServerService } from 'src/engine/metadata-modules/remote-server/remote-server.service';
+import { RemoteTableModule } from 'src/engine/metadata-modules/remote-server/remote-table/remote-table.module';
 
 @Module({
   imports: [
     TypeORMModule,
     TypeOrmModule.forFeature([RemoteServerEntity], 'metadata'),
+    RemoteTableModule,
   ],
   providers: [
     RemoteServerService,
     RemoteServerResolver,
     ForeignDataWrapperQueryFactory,
   ],
-  exports: [RemoteServerService],
 })
 export class RemoteServerModule {}

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-server.module.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-server.module.ts
@@ -1,7 +1,6 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
-import { TypeORMModule } from 'src/database/typeorm/typeorm.module';
 import { ForeignDataWrapperQueryFactory } from 'src/engine/api/graphql/workspace-query-builder/factories/foreign-data-wrapper-query.factory';
 import { RemoteServerEntity } from 'src/engine/metadata-modules/remote-server/remote-server.entity';
 import { RemoteServerResolver } from 'src/engine/metadata-modules/remote-server/remote-server.resolver';
@@ -10,7 +9,6 @@ import { RemoteTableModule } from 'src/engine/metadata-modules/remote-server/rem
 
 @Module({
   imports: [
-    TypeORMModule,
     TypeOrmModule.forFeature([RemoteServerEntity], 'metadata'),
     RemoteTableModule,
   ],

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/dtos/remote-table.dto.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/dtos/remote-table.dto.ts
@@ -1,0 +1,26 @@
+import { ObjectType, Field, registerEnumType } from '@nestjs/graphql';
+
+import { IsEnum } from 'class-validator';
+
+export enum RemoteTableStatus {
+  SYNCED = 'SYNCED',
+  NOT_SYNCED = 'NOT_SYNCED',
+}
+
+registerEnumType(RemoteTableStatus, {
+  name: 'RemoteTableStatus',
+  description: 'Status of the table',
+});
+
+@ObjectType('RemoteTable')
+export class RemoteTableDTO {
+  @Field(() => String)
+  name: string;
+
+  @IsEnum(RemoteTableStatus)
+  @Field(() => RemoteTableStatus)
+  status: RemoteTableStatus;
+
+  @Field(() => String)
+  schema: string;
+}

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-table.module.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-table.module.ts
@@ -12,6 +12,5 @@ import { WorkspaceDataSourceModule } from 'src/engine/workspace-datasource/works
     WorkspaceDataSourceModule,
   ],
   providers: [RemoteTableService, RemoteTableResolver],
-  exports: [RemoteTableService],
 })
 export class RemoteTableModule {}

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-table.module.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-table.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { RemoteServerEntity } from 'src/engine/metadata-modules/remote-server/remote-server.entity';
+import { RemoteTableResolver } from 'src/engine/metadata-modules/remote-server/remote-table/remote-table.resolver';
+import { RemoteTableService } from 'src/engine/metadata-modules/remote-server/remote-table/remote-table.service';
+import { WorkspaceDataSourceModule } from 'src/engine/workspace-datasource/workspace-datasource.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([RemoteServerEntity], 'metadata'),
+    WorkspaceDataSourceModule,
+  ],
+  providers: [RemoteTableService, RemoteTableResolver],
+  exports: [RemoteTableService],
+})
+export class RemoteTableModule {}

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-table.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-table.resolver.ts
@@ -1,0 +1,26 @@
+import { UseGuards } from '@nestjs/common';
+import { Args, Query, Resolver } from '@nestjs/graphql';
+
+import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
+import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
+import { JwtAuthGuard } from 'src/engine/guards/jwt.auth.guard';
+import { RemoteServerIdInput } from 'src/engine/metadata-modules/remote-server/dtos/remote-server-id.input';
+import { RemoteTableDTO } from 'src/engine/metadata-modules/remote-server/remote-table/dtos/remote-table.dto';
+import { RemoteTableService } from 'src/engine/metadata-modules/remote-server/remote-table/remote-table.service';
+
+@UseGuards(JwtAuthGuard)
+@Resolver(() => RemoteTableDTO)
+export class RemoteTableResolver {
+  constructor(private readonly remoteTableService: RemoteTableService) {}
+
+  @Query(() => [RemoteTableDTO])
+  async findAvailableRemoteTablesByServerId(
+    @Args('input') { id }: RemoteServerIdInput,
+    @AuthWorkspace() { id: workspaceId }: Workspace,
+  ) {
+    return this.remoteTableService.findAvailableRemoteTablesByServerId(
+      id,
+      workspaceId,
+    );
+  }
+}

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-table.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-table.service.ts
@@ -1,0 +1,126 @@
+import { NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { DataSource, Repository } from 'typeorm';
+
+import { decryptText } from 'src/engine/core-modules/auth/auth.util';
+import {
+  RemoteServerType,
+  RemoteServerEntity,
+} from 'src/engine/metadata-modules/remote-server/remote-server.entity';
+import { RemoteTableStatus } from 'src/engine/metadata-modules/remote-server/remote-table/dtos/remote-table.dto';
+import { EnvironmentService } from 'src/engine/integrations/environment/environment.service';
+import { WorkspaceDataSourceService } from 'src/engine/workspace-datasource/workspace-datasource.service';
+import { EXCLUDED_POSTGRES_SCHEMAS } from 'src/engine/metadata-modules/remote-server/remote-table/utils/excluded-postgres-schemas';
+
+export class RemoteTableService {
+  constructor(
+    @InjectRepository(RemoteServerEntity, 'metadata')
+    private readonly remoteServerRepository: Repository<
+      RemoteServerEntity<RemoteServerType>
+    >,
+    private readonly workspaceDataSourceService: WorkspaceDataSourceService,
+    private readonly environmentService: EnvironmentService,
+  ) {}
+
+  public async findAvailableRemoteTablesByServerId(
+    id: string,
+    workspaceId: string,
+  ) {
+    const remoteServer = await this.remoteServerRepository.findOne({
+      where: {
+        id,
+        workspaceId,
+      },
+    });
+
+    if (!remoteServer) {
+      throw new NotFoundException('Remote server does not exist');
+    }
+
+    switch (remoteServer.foreignDataWrapperType) {
+      case RemoteServerType.POSTGRES_FDW:
+        return this.findAvailableRemotePostgresTables(
+          workspaceId,
+          remoteServer,
+        );
+      default:
+        throw new Error('Unsupported foreign data wrapper type');
+    }
+  }
+
+  // TODO: may be moved into a separated postgres table service once we have more use cases
+  private async findAvailableRemotePostgresTables(
+    workspaceId: string,
+    remoteServer: RemoteServerEntity<RemoteServerType>,
+  ) {
+    const remotePostgresTables =
+      await this.fetchTablesFromRemotePostgresSchema(remoteServer);
+
+    const workspaceDataSource =
+      await this.workspaceDataSourceService.connectToWorkspaceDataSource(
+        workspaceId,
+      );
+
+    const currentForeignTableNames = (
+      await workspaceDataSource.query(
+        `SELECT foreign_table_name FROM information_schema.foreign_tables`,
+      )
+    ).map((foreignTable) => foreignTable.foreign_table_name);
+
+    return remotePostgresTables.map((remoteTable) => ({
+      name: remoteTable.table_name,
+      schema: remoteTable.table_schema,
+      status: currentForeignTableNames.includes(remoteTable.table_name)
+        ? RemoteTableStatus.SYNCED
+        : RemoteTableStatus.NOT_SYNCED,
+    }));
+  }
+
+  private async fetchTablesFromRemotePostgresSchema(
+    remoteServer: RemoteServerEntity<RemoteServerType>,
+  ) {
+    const dataSource = new DataSource({
+      url: this.buildPostgresUrl(remoteServer),
+      type: 'postgres',
+      logging: true,
+      schema: 'public',
+    });
+
+    await dataSource.initialize();
+
+    const schemaNames = await dataSource.query(
+      `SELECT schema_name FROM information_schema.schemata where schema_name not in ( ${EXCLUDED_POSTGRES_SCHEMAS.map(
+        (schema) => `'${schema}'`,
+      ).join(', ')} ) order by schema_name limit 1`,
+    );
+
+    const remotePostgresTables = await dataSource.query(
+      `SELECT table_name, table_schema FROM information_schema.tables WHERE table_schema IN (${schemaNames
+        .map((schemaName) => `'${schemaName.schema_name}'`)
+        .join(', ')})`,
+    );
+
+    await dataSource.destroy();
+
+    return remotePostgresTables;
+  }
+
+  private buildPostgresUrl(
+    remoteServer: RemoteServerEntity<RemoteServerType>,
+  ): string {
+    const foreignDataWrapperOptions = remoteServer.foreignDataWrapperOptions;
+    const userMappingOptions = remoteServer.userMappingOptions;
+
+    const secretKey = this.environmentService.get('LOGIN_TOKEN_SECRET');
+    const password = decryptText(
+      userMappingOptions.password,
+      secretKey,
+      secretKey,
+    );
+
+    const url = `postgres://${userMappingOptions.username}:${password}@${foreignDataWrapperOptions.host}:${foreignDataWrapperOptions.port}/${foreignDataWrapperOptions.dbname}`;
+
+    return url;
+  }
+}

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/utils/excluded-postgres-schemas.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/utils/excluded-postgres-schemas.ts
@@ -1,6 +1,0 @@
-export const EXCLUDED_POSTGRES_SCHEMAS = [
-  'information_schema',
-  'pg_catalog',
-  'pg_toast',
-  'public',
-];

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/utils/excluded-postgres-schemas.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/utils/excluded-postgres-schemas.ts
@@ -1,0 +1,6 @@
+export const EXCLUDED_POSTGRES_SCHEMAS = [
+  'information_schema',
+  'pg_catalog',
+  'pg_toast',
+  'public',
+];

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/utils/remote-table-postgres.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/utils/remote-table-postgres.util.ts
@@ -1,0 +1,29 @@
+import { decryptText } from 'src/engine/core-modules/auth/auth.util';
+import {
+  RemoteServerEntity,
+  RemoteServerType,
+} from 'src/engine/metadata-modules/remote-server/remote-server.entity';
+
+export const EXCLUDED_POSTGRES_SCHEMAS = [
+  'information_schema',
+  'pg_catalog',
+  'pg_toast',
+];
+
+export const buildPostgresUrl = (
+  secretKey: string,
+  remoteServer: RemoteServerEntity<RemoteServerType>,
+): string => {
+  const foreignDataWrapperOptions = remoteServer.foreignDataWrapperOptions;
+  const userMappingOptions = remoteServer.userMappingOptions;
+
+  const password = decryptText(
+    userMappingOptions.password,
+    secretKey,
+    secretKey,
+  );
+
+  const url = `postgres://${userMappingOptions.username}:${password}@${foreignDataWrapperOptions.host}:${foreignDataWrapperOptions.port}/${foreignDataWrapperOptions.dbname}`;
+
+  return url;
+};


### PR DESCRIPTION
Once foreign data wrapper and remote server are created, we need to show the user what tables can be imported.
Logic to fetch available remote tables will live into a sub-module of remote server.

It contains:
- a new endpoint 
- a service to connect to the foreign DB using remote server credential and read the tables

For now, until the design evolves, we will only fetch the table of the first interesting schema. It will avoid having to many tables to display.

Also added logic to use transactions during remote server creation.