### PR TITLE
fix: update docker-compose database volumes

### DIFF
--- a/packages/twenty-docker/dev/docker-compose.yml
+++ b/packages/twenty-docker/dev/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   twenty-dev:
-    build: 
+    build:
       context: ../../..
       dockerfile: ./packages/twenty-docker/dev/twenty-dev/Dockerfile
     ports:
@@ -21,7 +21,7 @@ services:
     container_name: twenty_postgres
     image: twentycrm/twenty-postgres:latest
     volumes:
-    - twenty_db_data:/var/lib/postgresql/data
+    - twenty_db_data:/bitnami/postgresql
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
@@ -37,4 +37,3 @@ volumes:
   twenty_dev_node_modules_front:
   twenty_dev_node_modules_server:
   twenty_dev_node_modules_website:
-

--- a/packages/twenty-docker/prod/docker-compose.yml
+++ b/packages/twenty-docker/prod/docker-compose.yml
@@ -36,7 +36,7 @@ services:
   db:
     image: twentycrm/twenty-postgres:${TAG}
     volumes:
-      - db-data:/var/lib/postgresql/data
+      - db-data:/bitnami/postgresql
     environment:
       POSTGRES_PASSWORD: ${POSTGRES_ADMIN_PASSWORD}
       #POSTGRES_USER: ${POSTGRES_USER}

--- a/packages/twenty-docs/docs/start/self-hosting/docker-compose.mdx
+++ b/packages/twenty-docs/docs/start/self-hosting/docker-compose.mdx
@@ -86,7 +86,7 @@ services:
   db:
     image: twentycrm/twenty-postgres:${TAG}
     volumes:
-      - twenty-db-data:/var/lib/postgresql/data
+      - twenty-db-data:/bitnami/postgresql
     environment:
       - POSTGRES_PASSWORD=${POSTGRES_ADMIN_PASSWORD}
 volumes:


### PR DESCRIPTION
It appears that the example in documentation and docker-compose were referencing default postgres volume path. It should have been bitnami's one instead.

Thanks @thilles for catching this one!