### PR TITLE
fixed view switcher by changing zindex of TopBar

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/top-bar/TopBar.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/top-bar/TopBar.tsx
@@ -27,7 +27,7 @@ const StyledTopBar = styled.div<{ displayBottomBorder: boolean }>`
   justify-content: space-between;
   padding-left: ${({ theme }) => theme.spacing(2)};
   padding-right: ${({ theme }) => theme.spacing(2)};
-  z-index: 5;
+  z-index: 7;
 `;
 
 const StyledLeftSection = styled.div`


### PR DESCRIPTION
Fixed the issue of View switcher is hidden behind the table header
(https://github.com/twentyhq/twenty/issues/4681#top)

Changed the value of z-index from 5 to 7. The z index of the dropdown element is 6, so have to increase it more than 6 to make it visible.

<img width="1169" alt="Screenshot 2024-03-28 at 01 06 37" src="https://github.com/twentyhq/twenty/assets/16238974/3653cd8c-f2bd-4625-b705-0179c38964a9">

Working well now. 