### PR TITLE
Fix events being created for system objects

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/listeners/entity-events-to-db.listener.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/listeners/entity-events-to-db.listener.ts
@@ -49,6 +49,10 @@ export class EntityEventsToDbListener {
     payload: ObjectRecordCreateEvent<any>,
     operation: string,
   ) {
+    if (payload.objectMetadata.isSystem) {
+      return;
+    }
+
     const isEventObjectEnabledFeatureFlag =
       await this.featureFlagRepository.findOneBy({
         workspaceId: payload.workspaceId,
@@ -60,10 +64,6 @@ export class EntityEventsToDbListener {
       !isEventObjectEnabledFeatureFlag ||
       !isEventObjectEnabledFeatureFlag.value
     ) {
-      return;
-    }
-
-    if (payload.objectMetadata.isSystem) {
       return;
     }
 

--- a/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/listeners/entity-events-to-db.listener.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/listeners/entity-events-to-db.listener.ts
@@ -63,6 +63,10 @@ export class EntityEventsToDbListener {
       return;
     }
 
+    if (payload.objectMetadata.isSystem) {
+      return;
+    }
+
     this.messageQueueService.add<SaveEventToDbJobData>(SaveEventToDbJob.name, {
       workspaceId: payload.workspaceId,
       userId: payload.userId,

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.service.ts
@@ -208,6 +208,7 @@ export class FieldMetadataService extends TypeOrmQueryService<FieldMetadataEntit
       view[0].id
     }')`,
         );
+        await workspaceQueryRunner.commitTransaction();
       } catch (error) {
         await workspaceQueryRunner.rollbackTransaction();
         throw error;


### PR DESCRIPTION
Fixes https://github.com/twentyhq/twenty/issues/4675

Events "events" were triggered for system objects which are not part of the events table so the job was failing. Since we don't want to log those, the listener should not trigger the job if the object created/updated is a system object.

Also fixing an issue in the fieldMetadata service where we added a transaction but the transaction was never commit so the viewField was not created 

## Test
Locally