### PR TITLE
fix search active hit styling #4719

### DIFF
--- a/packages/twenty-docs/src/css/custom.css
+++ b/packages/twenty-docs/src/css/custom.css
@@ -43,7 +43,13 @@
   --category-icon-background-color: #ebebeb;
   --category-icon-border-color: #d6d6d6;
   --level-1-color: #B3B3B3;
-  
+
+  --dark-docsearch-hit-title-color: #444950;
+  --dark-docsearch-hit-mark-color: #11181c;
+  --dark-docsearch-hit-general-color: #969faf;
+  --light-docsearch-hit-title-color: #bec3c9;
+  --light-docsearch-hit-mark-color: #ffffff;
+  --light-docsearch-hit-general-color: #7f8497;
 }
 
 .markdown > h1 {
@@ -193,6 +199,38 @@ li.coming-soon a::after {
   color: white;
 }
 
+[data-theme='dark'] ul > .DocSearch-Hit[aria-selected='true'] .DocSearch-Hit-title {
+  color: var(--dark-docsearch-hit-title-color) !important;
+}
+
+[data-theme='dark'] ul > .DocSearch-Hit[aria-selected='true'] mark {
+  color: var(--dark-docsearch-hit-mark-color) !important;
+}
+
+[data-theme='dark'] ul > .DocSearch-Hit[aria-selected='true'] .DocSearch-Hit-action,
+[data-theme='dark'] ul > .DocSearch-Hit[aria-selected='true'] .DocSearch-Hit-icon,
+[data-theme='dark'] ul > .DocSearch-Hit[aria-selected='true'] .DocSearch-Hit-path,
+[data-theme='dark'] ul > .DocSearch-Hit[aria-selected='true'] .DocSearch-Hit-text,
+[data-theme='dark'] ul > .DocSearch-Hit[aria-selected='true'] .DocSearch-Hit-Tree {
+  color: var(--dark-docsearch-hit-general-color) !important;
+}
+
+
+[data-theme='light'] ul > .DocSearch-Hit[aria-selected='true'] .DocSearch-Hit-title {
+  color: var(--light-docsearch-hit-title-color) !important;
+}
+
+[data-theme='light'] ul > .DocSearch-Hit[aria-selected='true'] mark {
+  color: var(--light-docsearch-hit-mark-color) !important;
+}
+
+[data-theme='light'] ul > .DocSearch-Hit[aria-selected='true'] .DocSearch-Hit-action,
+[data-theme='light'] ul > .DocSearch-Hit[aria-selected='true'] .DocSearch-Hit-icon,
+[data-theme='light'] ul > .DocSearch-Hit[aria-selected='true'] .DocSearch-Hit-path,
+[data-theme='light'] ul > .DocSearch-Hit[aria-selected='true'] .DocSearch-Hit-text,
+[data-theme='light'] ul > .DocSearch-Hit[aria-selected='true'] .DocSearch-Hit-Tree {
+  color: var(--light-docsearch-hit-general-color) !important;
+}
 
 [data-theme='light'] .menu__list-item--level1 > .menu__link--active > .icon-and-text {
   color: initial;


### PR DESCRIPTION
The issue addressed in this patch was related to the visibility and styling inconsistency of the active hit search in different modes. In Dark Mode, the active hit search was not visible against the background, while in Light Mode, it exhibited a different styling compared to other search hits (for example, in Light mode, the part of the result that matches the search string was not highlighted). 

To resolve this bug, the following changes were implemented: 
- Adjusted CSS classes for the active hit search to ensure proper visibility against the background in Dark Mode.
<img src="https://github.com/twentyhq/twenty/assets/26422084/c4c767d1-437a-44a7-bf00-7145a547b795" alt="darkmodefixed" width="500"/>

- Aligned the styling of the active hit search with other search hits in Light Mode for consistency across themes.
<img src="https://github.com/twentyhq/twenty/assets/26422084/5f9283d4-4ca2-44e0-adc3-e9b55cb7d17b" alt="lightmodefixed" width="500"/>