### PR TITLE
[messaging] rename syncExternalId to syncCursor

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/constants/standard-field-ids.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/constants/standard-field-ids.ts
@@ -170,7 +170,7 @@ export const messageChannelStandardFieldIds = {
   type: '20202020-ae95-42d9-a3f1-797a2ea22122',
   isContactAutoCreationEnabled: '20202020-fabd-4f14-b7c6-3310f6d132c6',
   messageChannelMessageAssociations: '20202020-49b8-4766-88fd-75f1e21b3d5f',
-  syncExternalId: '20202020-79d1-41cf-b738-bcf5ed61e256',
+  syncCursor: '20202020-79d1-41cf-b738-bcf5ed61e256',
   syncedAt: '20202020-263d-4c6b-ad51-137ada56f7d4',
   syncStatus: '20202020-56a1-4f7e-9880-a8493bb899cc',
   ongoingSyncStartedAt: '20202020-8c61-4a42-ae63-73c1c3c52e06',

--- a/packages/twenty-server/src/modules/messaging/repositories/message-channel.repository.ts
+++ b/packages/twenty-server/src/modules/messaging/repositories/message-channel.repository.ts
@@ -123,9 +123,9 @@ export class MessageChannelRepository {
     );
   }
 
-  public async updateLastSyncExternalIdIfHigher(
+  public async updateLastSyncCursorIfHigher(
     id: string,
-    syncExternalId: string,
+    syncCursor: string,
     workspaceId: string,
     transactionManager?: EntityManager,
   ) {
@@ -133,16 +133,16 @@ export class MessageChannelRepository {
       this.workspaceDataSourceService.getSchemaName(workspaceId);
 
     await this.workspaceDataSourceService.executeRawQuery(
-      `UPDATE ${dataSourceSchema}."messageChannel" SET "syncExternalId" = $1
+      `UPDATE ${dataSourceSchema}."messageChannel" SET "syncCursor" = $1
       WHERE "id" = $2
-      AND ("syncExternalId" < $1 OR "syncExternalId" = '')`,
-      [syncExternalId, id],
+      AND ("syncCursor" < $1 OR "syncCursor" = '')`,
+      [syncCursor, id],
       workspaceId,
       transactionManager,
     );
   }
 
-  public async resetSyncExternalId(
+  public async resetSyncCursor(
     id: string,
     workspaceId: string,
     transactionManager?: EntityManager,
@@ -151,7 +151,7 @@ export class MessageChannelRepository {
       this.workspaceDataSourceService.getSchemaName(workspaceId);
 
     await this.workspaceDataSourceService.executeRawQuery(
-      `UPDATE ${dataSourceSchema}."messageChannel" SET "syncExternalId" = ''
+      `UPDATE ${dataSourceSchema}."messageChannel" SET "syncCursor" = ''
       WHERE "id" = $1`,
       [id],
       workspaceId,

--- a/packages/twenty-server/src/modules/messaging/services/gmail-full-sync-v2/gmail-full-sync.v2.service.ts
+++ b/packages/twenty-server/src/modules/messaging/services/gmail-full-sync-v2/gmail-full-sync.v2.service.ts
@@ -223,7 +223,7 @@ export class GmailFullSyncV2Service {
       `Fetched all ${messageIdsToFetch} message ids from Gmail for messageChannel ${messageChannelId} in workspace ${workspaceId} and added to cache for import`,
     );
 
-    await this.updateLastSyncExternalId(
+    await this.updateLastSyncCursor(
       gmailClient,
       messageChannelId,
       firstMessageExternalId,
@@ -256,7 +256,7 @@ export class GmailFullSyncV2Service {
     return blocklist.map((blocklist) => blocklist.handle);
   }
 
-  private async updateLastSyncExternalId(
+  private async updateLastSyncCursor(
     gmailClient: gmail_v1.Gmail,
     messageChannelId: string,
     firstMessageExternalId: string,
@@ -292,7 +292,7 @@ export class GmailFullSyncV2Service {
       `Updating last external id: ${historyId} for workspace ${workspaceId} and account ${messageChannelId} succeeded.`,
     );
 
-    await this.messageChannelRepository.updateLastSyncExternalIdIfHigher(
+    await this.messageChannelRepository.updateLastSyncCursorIfHigher(
       messageChannelId,
       historyId,
       workspaceId,

--- a/packages/twenty-server/src/modules/messaging/services/gmail-partial-sync-v2/gmail-partial-sync-v2.service.ts
+++ b/packages/twenty-server/src/modules/messaging/services/gmail-partial-sync-v2/gmail-partial-sync-v2.service.ts
@@ -102,7 +102,7 @@ export class GmailPartialSyncV2Service {
 
     await workspaceDataSource
       ?.transaction(async (transactionManager: EntityManager) => {
-        const lastSyncHistoryId = gmailMessageChannel.syncExternalId;
+        const lastSyncHistoryId = gmailMessageChannel.syncCursor;
 
         if (!lastSyncHistoryId) {
           this.logger.log(
@@ -134,7 +134,7 @@ export class GmailPartialSyncV2Service {
             `404: Invalid lastSyncHistoryId: ${lastSyncHistoryId} for workspace ${workspaceId} and account ${connectedAccountId}, falling back to full sync.`,
           );
 
-          await this.messageChannelRepository.resetSyncExternalId(
+          await this.messageChannelRepository.resetSyncCursor(
             gmailMessageChannel.id,
             workspaceId,
             transactionManager,
@@ -206,7 +206,7 @@ export class GmailPartialSyncV2Service {
           messagesDeleted,
         );
 
-        await this.messageChannelRepository.updateLastSyncExternalIdIfHigher(
+        await this.messageChannelRepository.updateLastSyncCursorIfHigher(
           gmailMessageChannel.id,
           historyId,
           workspaceId,

--- a/packages/twenty-server/src/modules/messaging/standard-objects/message-channel.object-metadata.ts
+++ b/packages/twenty-server/src/modules/messaging/standard-objects/message-channel.object-metadata.ts
@@ -113,16 +113,16 @@ export class MessageChannelObjectMetadata extends BaseObjectMetadata {
   messageChannelMessageAssociations: MessageChannelMessageAssociationObjectMetadata[];
 
   @FieldMetadata({
-    standardId: messageChannelStandardFieldIds.syncExternalId,
+    standardId: messageChannelStandardFieldIds.syncCursor,
     type: FieldMetadataType.TEXT,
-    label: 'Last sync external ID',
-    description: 'Last sync external ID',
+    label: 'Last sync cursor',
+    description: 'Last sync cursor',
     icon: 'IconHistory',
   })
   @Gate({
     featureFlag: FeatureFlagKeys.IsFullSyncV2Enabled,
   })
-  syncExternalId: string;
+  syncCursor: string;
 
   @FieldMetadata({
     standardId: messageChannelStandardFieldIds.syncedAt,


### PR DESCRIPTION
## Context

SyncExternalId should be renamed because this won't always represent an id. For example, microsoft API does not use ids but dates for their sync. Also we think external is a bit redundant so we are removing it.

Note: this field is not used by the front-end (and will probably never be)