### PR TITLE
feat(ci): use concurrency.group to cancel previous jobs

### DIFF
--- a/.github/workflows/ci-chromatic.yaml
+++ b/.github/workflows/ci-chromatic.yaml
@@ -12,6 +12,10 @@ on:
     paths:
       - 'package.json'
       - 'packages/twenty-front/**'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   chromatic-deployment:
     if: contains(github.event.pull_request.labels.*.name, 'run-chromatic') || github.event_name == 'push'
@@ -20,10 +24,6 @@ jobs:
       REACT_APP_SERVER_BASE_URL: http://127.0.0.1:3000
       CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-            access_token: ${{ github.token }}
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/.github/workflows/ci-chrome-extension.yaml
+++ b/.github/workflows/ci-chrome-extension.yaml
@@ -10,6 +10,10 @@ on:
     paths:
       - 'package.json'
       - 'packages/twenty-chrome-extension/**'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   chrome-extension-yarn-install:
     runs-on: ci-8-cores
@@ -17,10 +21,6 @@ jobs:
       VITE_SERVER_BASE_URL: http://localhost:3000
       VITE_FRONT_BASE_URL: http://localhost:3001
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-            access_token: ${{ github.token }}
       - uses: actions/checkout@v4
       - name: Setup Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -10,14 +10,14 @@ on:
     paths:
       - 'package.json'
       - 'packages/twenty-docs/**'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   docs-build:
     runs-on: ubuntu-latest
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-            access_token: ${{ github.token }}
       - uses: actions/checkout@v4
       - name: Setup Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -10,16 +10,16 @@ on:
     paths:
       - 'package.json'
       - 'packages/twenty-front/**'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   front-yarn-install:
     runs-on: ci-8-cores
     env:
       REACT_APP_SERVER_BASE_URL: http://localhost:3000
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-            access_token: ${{ github.token }}
       - uses: actions/checkout@v4
       - name: Setup Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/ci-server.yaml
+++ b/.github/workflows/ci-server.yaml
@@ -10,6 +10,10 @@ on:
     paths:
       - 'package.json'
       - 'packages/twenty-server/**'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   server-test:
     runs-on: ubuntu-latest
@@ -22,10 +26,6 @@ jobs:
         ports:
           - 5432:5432
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-            access_token: ${{ github.token }}
       - uses: actions/checkout@v4
       - name: Setup Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/ci-utils.yaml
+++ b/.github/workflows/ci-utils.yaml
@@ -2,7 +2,7 @@ name: CI Utils
 on:
   # it's usually not recommended to use pull_request_target
   # but we consider it's safe here if we keep the same steps
-  # see: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/ 
+  # see: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
   # and: https://github.com/facebook/react-native/pull/34370/files
   pull_request_target:
 permissions:
@@ -12,14 +12,14 @@ permissions:
   issues: write
   pull-requests: write
   statuses: write
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   danger-js:
     runs-on: ubuntu-latest
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-            access_token: ${{ github.token }}
       - uses: actions/checkout@v4
       - name: Setup Node.js
         uses: actions/setup-node@v3


### PR DESCRIPTION
As recommended on the repo of the action we were using https://github.com/styfle/cancel-workflow-action, we should use `concurrency.group` rather than a dedicated action.

Here is a PR to use it on all our workflows