### PR TITLE
Fix View creation, view fields re-ordering, view filters and view sorts erratic behaviors

### DIFF
--- a/packages/twenty-front/src/modules/views/hooks/useGetViewFromCache.ts
+++ b/packages/twenty-front/src/modules/views/hooks/useGetViewFromCache.ts
@@ -3,9 +3,7 @@ import { useApolloClient } from '@apollo/client';
 
 import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
 import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
-import { ObjectRecordEdge } from '@/object-record/types/ObjectRecordEdge';
-import { GraphQLView } from '@/views/types/GraphQLView';
-import { isUndefinedOrNull } from '~/utils/isUndefinedOrNull';
+import { View } from '@/views/types/View';
 
 export const useGetViewFromCache = () => {
   const client = useApolloClient();
@@ -17,30 +15,7 @@ export const useGetViewFromCache = () => {
 
   const getViewFromCache = useCallback(
     async (viewId: string) => {
-      // Todo Fix typing once we have figured out record connections
-      const viewWithConnections = getRecordFromCache<any>(viewId, cache);
-
-      if (isUndefinedOrNull(viewWithConnections)) {
-        return;
-      }
-
-      const view = {
-        ...viewWithConnections,
-        viewFilters:
-          viewWithConnections.viewFilters?.edges?.map(
-            (edge: ObjectRecordEdge) => edge.node,
-          ) ?? [],
-        viewSorts:
-          viewWithConnections.viewSorts?.edges?.map(
-            (edge: ObjectRecordEdge) => edge.node,
-          ) ?? [],
-        viewFields:
-          viewWithConnections.viewFields?.edges?.map(
-            (edge: ObjectRecordEdge) => edge.node,
-          ) ?? [],
-      } as GraphQLView;
-
-      return view;
+      return getRecordFromCache<View>(viewId, cache);
     },
     [cache, getRecordFromCache],
   );


### PR DESCRIPTION
We used to not type properly the return of getRecordFromCache before the work from last week.
The getViewFromCache function was patching this temporarily in a "dirty" way.

Now that this is cleaner, I'm removing the typescript patch. This fixing several behaviors on viewBar