### PR TITLE
fix: isIconDisplayedOnHoverOnly marked as required

### DIFF
--- a/packages/twenty-front/src/modules/ui/navigation/menu-item/internals/components/StyledMenuItemBase.tsx
+++ b/packages/twenty-front/src/modules/ui/navigation/menu-item/internals/components/StyledMenuItemBase.tsx
@@ -102,7 +102,7 @@ export const StyledMenuItemRightContent = styled.div`
 
 export const StyledHoverableMenuItemBase = styled(StyledMenuItemBase)<{
   isMenuOpen: boolean;
-  isIconDisplayedOnHoverOnly: boolean;
+  isIconDisplayedOnHoverOnly?: boolean;
 }>`
   & .hoverable-buttons {
     pointer-events: none;


### PR DESCRIPTION
Fix PR #4676, `isIconDisplayedOnHoverOnly` should be provided or not marked as required