### PR TITLE
Gracefully close Redis connection when cacheStorageModule is destroyed

### DIFF
--- a/packages/twenty-server/src/engine/integrations/cache-storage/cache-storage.module.ts
+++ b/packages/twenty-server/src/engine/integrations/cache-storage/cache-storage.module.ts
@@ -1,4 +1,4 @@
-import { Module, Global } from '@nestjs/common';
+import { Module, Global, Inject, OnModuleDestroy } from '@nestjs/common';
 import { CacheModule, CACHE_MANAGER, Cache } from '@nestjs/cache-manager';
 import { ConfigModule } from '@nestjs/config';
 
@@ -28,4 +28,12 @@ import { CacheStorageNamespace } from 'src/engine/integrations/cache-storage/typ
   ],
   exports: [...Object.values(CacheStorageNamespace)],
 })
-export class CacheStorageModule {}
+export class CacheStorageModule implements OnModuleDestroy {
+  constructor(@Inject(CACHE_MANAGER) private cacheManager: Cache) {}
+
+  async onModuleDestroy() {
+    if ((this.cacheManager.store as any)?.name === 'redis') {
+      await (this.cacheManager.store as any).client.quit();
+    }
+  }
+}


### PR DESCRIPTION
## Context
When running a command, the process should end normally however it stays hanging due to the open connection with redis client (when CACHE_STORAGE_TYPE=redis)
This PR adds the necessary logic to gracefully close the connection once the module is destroyed. Thanks to that, the command process now properly ends once executed.