### PR TITLE
chore: enable no-console eslint rule for tests and stories

### DIFF
--- a/packages/twenty-chrome-extension/.eslintrc-ci.cjs
+++ b/packages/twenty-chrome-extension/.eslintrc-ci.cjs
@@ -3,17 +3,4 @@ module.exports = {
   rules: {
     'no-console': 'error',
   },
-  overrides: [
-    {
-      files: [
-        '.storybook/**/*',
-        '**/*.stories.tsx',
-        '**/*.test.ts',
-        '**/*.test.tsx',
-      ],
-      rules: {
-        'no-console': 'off',
-      },
-    },
-  ],
 };

--- a/packages/twenty-front/.eslintrc-ci.cjs
+++ b/packages/twenty-front/.eslintrc-ci.cjs
@@ -3,17 +3,4 @@ module.exports = {
   rules: {
     'no-console': 'error',
   },
-  overrides: [
-    {
-      files: [
-        '.storybook/**/*',
-        '**/*.stories.tsx',
-        '**/*.test.ts',
-        '**/*.test.tsx',
-      ],
-      rules: {
-        'no-console': 'off',
-      },
-    },
-  ],
 };

--- a/packages/twenty-front/src/modules/command-menu/components/__stories__/CommandMenu.stories.tsx
+++ b/packages/twenty-front/src/modules/command-menu/components/__stories__/CommandMenu.stories.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { action } from '@storybook/addon-actions';
 import { Meta, StoryObj } from '@storybook/react';
 import { expect, userEvent, within } from '@storybook/test';
 import { useSetRecoilState } from 'recoil';
@@ -46,8 +47,7 @@ const meta: Meta<typeof CommandMenu> = {
             label: 'Create Task',
             type: CommandType.Create,
             Icon: IconCheckbox,
-            // eslint-disable-next-line no-console
-            onCommandClick: () => console.log('create task click'),
+            onCommandClick: action('create task click'),
           },
           {
             id: 'create-note',
@@ -55,8 +55,7 @@ const meta: Meta<typeof CommandMenu> = {
             label: 'Create Note',
             type: CommandType.Create,
             Icon: IconNotes,
-            // eslint-disable-next-line no-console
-            onCommandClick: () => console.log('create note click'),
+            onCommandClick: action('create note click'),
           },
         ]);
         openCommandMenu();

--- a/packages/twenty-front/src/modules/favorites/hooks/__tests__/useFavorites.test.tsx
+++ b/packages/twenty-front/src/modules/favorites/hooks/__tests__/useFavorites.test.tsx
@@ -146,8 +146,7 @@ describe('useFavorites', () => {
       };
 
       const responderProvided: ResponderProvided = {
-        // eslint-disable-next-line no-console
-        announce: (message: string) => console.log(message),
+        announce: () => {},
       };
 
       result.current.handleReorderFavorite(

--- a/packages/twenty-front/src/modules/object-record/object-filter-dropdown/hooks/__tests__/useFilterDropdown.test.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-filter-dropdown/hooks/__tests__/useFilterDropdown.test.tsx
@@ -351,8 +351,7 @@ describe('useFilterDropdown', () => {
   });
 
   it('should handle scopeId undefined on initial values', () => {
-    // eslint-disable-next-line no-console
-    console.error = jest.fn();
+    global.console.error = jest.fn();
 
     const renderFunction = () => {
       renderHook(() => useFilterDropdown(), renderHookConfig);

--- a/packages/twenty-front/src/modules/ui/layout/draggable-list/__stories__/DraggableList.stories.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/draggable-list/__stories__/DraggableList.stories.tsx
@@ -1,3 +1,4 @@
+import { action } from '@storybook/addon-actions';
 import { Meta, StoryObj } from '@storybook/react';
 import { IconBell } from 'twenty-ui';
 
@@ -12,8 +13,7 @@ const meta: Meta<typeof DraggableList> = {
   component: DraggableList,
   decorators: [ComponentDecorator],
   parameters: {
-    // eslint-disable-next-line no-console
-    onDragEnd: () => console.log('dragged'),
+    onDragEnd: action('dragged'),
   },
   argTypes: {
     draggableItems: { control: false },

--- a/packages/twenty-front/src/modules/ui/navigation/menu-item/components/__stories__/MenuItem.stories.tsx
+++ b/packages/twenty-front/src/modules/ui/navigation/menu-item/components/__stories__/MenuItem.stories.tsx
@@ -1,3 +1,4 @@
+import { action } from '@storybook/addon-actions';
 import { Meta, StoryObj } from '@storybook/react';
 import { IconBell } from 'twenty-ui';
 
@@ -23,10 +24,8 @@ export const Default: Story = {
     LeftIcon: IconBell,
     accent: 'default',
     iconButtons: [
-      // eslint-disable-next-line no-console
-      { Icon: IconBell, onClick: () => console.log('Clicked') },
-      // eslint-disable-next-line no-console
-      { Icon: IconBell, onClick: () => console.log('Clicked') },
+      { Icon: IconBell, onClick: action('Clicked') },
+      { Icon: IconBell, onClick: action('Clicked') },
     ],
   },
   decorators: [ComponentDecorator],
@@ -86,15 +85,11 @@ export const Catalog: CatalogStory<Story, typeof MenuItem> = {
                   iconButtons: [
                     {
                       Icon: IconBell,
-                      onClick: () =>
-                        // eslint-disable-next-line no-console
-                        console.log('Clicked on first icon button'),
+                      onClick: action('Clicked on first icon button'),
                     },
                     {
                       Icon: IconBell,
-                      onClick: () =>
-                        // eslint-disable-next-line no-console
-                        console.log('Clicked on second icon button'),
+                      onClick: action('Clicked on second icon button'),
                     },
                   ],
                 };

--- a/packages/twenty-front/src/modules/ui/navigation/menu-item/components/__stories__/MenuItemDraggable.stories.tsx
+++ b/packages/twenty-front/src/modules/ui/navigation/menu-item/components/__stories__/MenuItemDraggable.stories.tsx
@@ -1,3 +1,4 @@
+import { action } from '@storybook/addon-actions';
 import { Meta, StoryObj } from '@storybook/react';
 import { IconBell, IconMinus } from 'twenty-ui';
 
@@ -24,10 +25,8 @@ export const Default: Story = {
   args: {
     LeftIcon: IconBell,
     accent: 'default',
-    // eslint-disable-next-line no-console
-    iconButtons: [{ Icon: IconMinus, onClick: () => console.log('Clicked') }],
-    // eslint-disable-next-line no-console
-    onClick: () => console.log('Clicked'),
+    iconButtons: [{ Icon: IconMinus, onClick: action('Clicked') }],
+    onClick: action('Clicked'),
     text: 'Menu item draggable',
     isDragDisabled: false,
   },
@@ -87,9 +86,7 @@ export const Catalog: Story = {
                   iconButtons: [
                     {
                       Icon: IconMinus,
-                      onClick: () =>
-                        // eslint-disable-next-line no-console
-                        console.log('Clicked on minus icon button'),
+                      onClick: action('Clicked on minus icon button'),
                     },
                   ],
                 };

--- a/packages/twenty-front/src/modules/ui/utilities/recoil-scope/scopes-internal/hooks/__tests__/useAvailableScopeId.test.tsx
+++ b/packages/twenty-front/src/modules/ui/utilities/recoil-scope/scopes-internal/hooks/__tests__/useAvailableScopeId.test.tsx
@@ -52,8 +52,7 @@ describe('useAvailableScopeIdOrThrow', () => {
   });
 
   it('should throw an error if no scopeId is provided and scopeId is undefined in the context', () => {
-    // eslint-disable-next-line no-console
-    console.error = jest.fn();
+    global.console.error = jest.fn();
 
     const renderFunction = () =>
       renderHook(() => ({


### PR DESCRIPTION
Re-enables no-console eslint rule in stories and tests files:
- In stories, use `action` from '@storybook/addon-actions' or `fn` from '@storybook/test' instead of console.
- In tests, console methods can be mocked like this: `global.console.error = jest.fn()`.