### PR TITLE
Fix contact creation when calendar is not enabled

### DIFF
--- a/packages/twenty-server/src/modules/connected-account/auto-companies-and-contacts-creation/auto-companies-and-contacts-creation.module.ts
+++ b/packages/twenty-server/src/modules/connected-account/auto-companies-and-contacts-creation/auto-companies-and-contacts-creation.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { CreateCompanyAndContactService } from 'src/modules/connected-account/auto-companies-and-contacts-creation/services/create-company-and-contact.service';
 import { CreateCompanyModule } from 'src/modules/connected-account/auto-companies-and-contacts-creation/create-company/create-company.module';
@@ -11,6 +12,7 @@ import { WorkspaceDataSourceModule } from 'src/engine/workspace-datasource/works
 import { CreateCompanyAndContactListener } from 'src/modules/connected-account/auto-companies-and-contacts-creation/listeners/create-company-and-contact.listener';
 import { CalendarEventParticipantObjectMetadata } from 'src/modules/calendar/standard-objects/calendar-event-participant.object-metadata';
 import { CalendarEventParticipantModule } from 'src/modules/calendar/services/calendar-event-participant/calendar-event-participant.module';
+import { FeatureFlagEntity } from 'src/engine/core-modules/feature-flag/feature-flag.entity';
 
 @Module({
   imports: [
@@ -24,6 +26,7 @@ import { CalendarEventParticipantModule } from 'src/modules/calendar/services/ca
     MessageParticipantModule,
     WorkspaceDataSourceModule,
     CalendarEventParticipantModule,
+    TypeOrmModule.forFeature([FeatureFlagEntity], 'core'),
   ],
   providers: [CreateCompanyAndContactService, CreateCompanyAndContactListener],
   exports: [CreateCompanyAndContactService],


### PR DESCRIPTION
## Context
Calendar tables are behind a featureFlag, they do not exist if the feature flag is off which means we should not use them for the same reason. I'm adding a check on the featureFlag before calling the repository.

```
Error executing raw query for workspace 20202020-1c25-4d02-bf25-6aeccf7ea419: relation "workspace_1wgvd1injqtife6y4rvfbu3h5.calendarEventParticipant" does not exist
```
## Test
locally with and without featureflag