### PR TITLE
Use migrations for foreign tables

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-postgres-table/remote-postgres-table.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-postgres-table/remote-postgres-table.service.ts
@@ -14,6 +14,7 @@ import {
 import { EnvironmentService } from 'src/engine/integrations/environment/environment.service';
 import { WorkspaceDataSourceService } from 'src/engine/workspace-datasource/workspace-datasource.service';
 import { RemoteTableColumn } from 'src/engine/metadata-modules/remote-server/remote-table/types/remote-table-column';
+import { getRemoteTableName } from 'src/engine/metadata-modules/remote-server/remote-table/utils/get-remote-table-name.util';
 
 @Injectable()
 export class RemotePostgresTableService {
@@ -43,7 +44,9 @@ export class RemotePostgresTableService {
     return remotePostgresTables.map((remoteTable) => ({
       name: remoteTable.table_name,
       schema: remoteTable.table_schema,
-      status: currentForeignTableNames.includes(remoteTable.table_name)
+      status: currentForeignTableNames.includes(
+        getRemoteTableName(remoteTable.table_name),
+      )
         ? RemoteTableStatus.SYNCED
         : RemoteTableStatus.NOT_SYNCED,
     }));

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-postgres-table/remote-postgres-table.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-postgres-table/remote-postgres-table.service.ts
@@ -13,6 +13,7 @@ import {
 } from 'src/engine/metadata-modules/remote-server/remote-table/remote-postgres-table/utils/remote-postgres-table.util';
 import { EnvironmentService } from 'src/engine/integrations/environment/environment.service';
 import { WorkspaceDataSourceService } from 'src/engine/workspace-datasource/workspace-datasource.service';
+import { RemoteTableColumn } from 'src/engine/metadata-modules/remote-server/remote-table/types/remote-table-column';
 
 @Injectable()
 export class RemotePostgresTableService {
@@ -52,7 +53,7 @@ export class RemotePostgresTableService {
     remoteServer: RemoteServerEntity<RemoteServerType>,
     tableName: string,
     tableSchema: string,
-  ) {
+  ): Promise<RemoteTableColumn[]> {
     const dataSource = new DataSource({
       url: buildPostgresUrl(
         this.environmentService.get('LOGIN_TOKEN_SECRET'),
@@ -70,7 +71,14 @@ export class RemotePostgresTableService {
 
     await dataSource.destroy();
 
-    return columns;
+    return columns.map(
+      (column) =>
+        ({
+          columnName: column.column_name,
+          dataType: column.data_type,
+          udtName: column.udt_name,
+        }) as RemoteTableColumn,
+    );
   }
 
   private async fetchTablesFromRemotePostgresSchema(

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-table.module.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-table.module.ts
@@ -10,18 +10,20 @@ import { RemotePostgresTableModule } from 'src/engine/metadata-modules/remote-se
 import { RemoteTableResolver } from 'src/engine/metadata-modules/remote-server/remote-table/remote-table.resolver';
 import { RemoteTableService } from 'src/engine/metadata-modules/remote-server/remote-table/remote-table.service';
 import { WorkspaceCacheVersionModule } from 'src/engine/metadata-modules/workspace-cache-version/workspace-cache-version.module';
-import { WorkspaceDataSourceModule } from 'src/engine/workspace-datasource/workspace-datasource.module';
+import { WorkspaceMigrationModule } from 'src/engine/metadata-modules/workspace-migration/workspace-migration.module';
+import { WorkspaceMigrationRunnerModule } from 'src/engine/workspace-manager/workspace-migration-runner/workspace-migration-runner.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([RemoteServerEntity], 'metadata'),
     TypeOrmModule.forFeature([FeatureFlagEntity], 'core'),
-    WorkspaceDataSourceModule,
     DataSourceModule,
     ObjectMetadataModule,
     FieldMetadataModule,
     RemotePostgresTableModule,
     WorkspaceCacheVersionModule,
+    WorkspaceMigrationModule,
+    WorkspaceMigrationRunnerModule,
   ],
   providers: [RemoteTableService, RemoteTableResolver],
 })

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-table.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-table.service.ts
@@ -33,6 +33,7 @@ import {
   WorkspaceMigrationForeignTable,
 } from 'src/engine/metadata-modules/workspace-migration/workspace-migration.entity';
 import { RemoteTableColumn } from 'src/engine/metadata-modules/remote-server/remote-table/types/remote-table-column';
+import { getRemoteTableName } from 'src/engine/metadata-modules/remote-server/remote-table/utils/get-remote-table-name.util';
 
 export class RemoteTableService {
   constructor(
@@ -122,13 +123,17 @@ export class RemoteTableService {
     remoteServer: RemoteServerEntity<RemoteServerType>,
     workspaceId: string,
   ) {
+    if (!input.schema) {
+      throw new Error('Schema is required for syncing remote table');
+    }
+
     const remoteTableColumns = await this.fetchTableColumnsSchema(
       remoteServer,
       input.name,
       input.schema,
     );
 
-    const remoteTableName = `${camelCase(input.name)}Remote`;
+    const remoteTableName = getRemoteTableName(input.name);
     const remoteTableLabel = camelToTitleCase(remoteTableName);
 
     // We only support remote tables with an id column for now.
@@ -226,7 +231,7 @@ export class RemoteTableService {
     input: RemoteTableInput,
     workspaceId: string,
   ) {
-    const remoteTableName = `${camelCase(input.name)}Remote`;
+    const remoteTableName = getRemoteTableName(input.name);
 
     const objectMetadata =
       await this.objectMetadataService.findOneWithinWorkspace(workspaceId, {

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-table.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-table.service.ts
@@ -1,14 +1,13 @@
 import { NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
-import { DataSource, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 
 import {
   RemoteServerType,
   RemoteServerEntity,
 } from 'src/engine/metadata-modules/remote-server/remote-server.entity';
 import { RemoteTableStatus } from 'src/engine/metadata-modules/remote-server/remote-table/dtos/remote-table.dto';
-import { WorkspaceDataSourceService } from 'src/engine/workspace-datasource/workspace-datasource.service';
 import {
   isPostgreSQLIntegrationEnabled,
   mapUdtNameToFieldType,
@@ -19,12 +18,21 @@ import { ObjectMetadataService } from 'src/engine/metadata-modules/object-metada
 import { CreateObjectInput } from 'src/engine/metadata-modules/object-metadata/dtos/create-object.input';
 import { FieldMetadataService } from 'src/engine/metadata-modules/field-metadata/field-metadata.service';
 import { CreateFieldInput } from 'src/engine/metadata-modules/field-metadata/dtos/create-field.input';
-import { DataSourceEntity } from 'src/engine/metadata-modules/data-source/data-source.entity';
 import { FeatureFlagEntity } from 'src/engine/core-modules/feature-flag/feature-flag.entity';
 import { RemotePostgresTableService } from 'src/engine/metadata-modules/remote-server/remote-table/remote-postgres-table/remote-postgres-table.service';
 import { WorkspaceCacheVersionService } from 'src/engine/metadata-modules/workspace-cache-version/workspace-cache-version.service';
 import { camelCase } from 'src/utils/camel-case';
 import { camelToTitleCase } from 'src/utils/camel-to-title-case';
+import { WorkspaceMigrationService } from 'src/engine/metadata-modules/workspace-migration/workspace-migration.service';
+import { WorkspaceMigrationRunnerService } from 'src/engine/workspace-manager/workspace-migration-runner/workspace-migration-runner.service';
+import { generateMigrationName } from 'src/engine/metadata-modules/workspace-migration/utils/generate-migration-name.util';
+import {
+  WorkspaceMigrationColumnActionType,
+  WorkspaceMigrationColumnDefinition,
+  WorkspaceMigrationCreateComment,
+  WorkspaceMigrationForeignTable,
+} from 'src/engine/metadata-modules/workspace-migration/workspace-migration.entity';
+import { RemoteTableColumn } from 'src/engine/metadata-modules/remote-server/remote-table/types/remote-table-column';
 
 export class RemoteTableService {
   constructor(
@@ -34,12 +42,13 @@ export class RemoteTableService {
     >,
     @InjectRepository(FeatureFlagEntity, 'core')
     private readonly featureFlagRepository: Repository<FeatureFlagEntity>,
-    private readonly workspaceDataSourceService: WorkspaceDataSourceService,
     private readonly workspaceCacheVersionService: WorkspaceCacheVersionService,
     private readonly dataSourceService: DataSourceService,
     private readonly objectMetadataService: ObjectMetadataService,
     private readonly fieldMetadataService: FieldMetadataService,
     private readonly remotePostgresTableService: RemotePostgresTableService,
+    private readonly workspaceMigrationService: WorkspaceMigrationService,
+    private readonly workspaceMigrationRunnerService: WorkspaceMigrationRunnerService,
   ) {}
 
   public async findAvailableRemoteTablesByServerId(
@@ -88,37 +97,16 @@ export class RemoteTableService {
       throw new NotFoundException('Remote server does not exist');
     }
 
-    const dataSourcesMetatada =
-      await this.dataSourceService.getDataSourcesMetadataFromWorkspaceId(
-        workspaceId,
-      );
-
-    if (!dataSourcesMetatada) {
-      throw new NotFoundException('Workspace data source does not exist');
-    }
-
-    const workspaceDataSource =
-      await this.workspaceDataSourceService.connectToWorkspaceDataSource(
-        workspaceId,
-      );
-
     switch (input.status) {
       case RemoteTableStatus.SYNCED:
         await this.buildForeignTableAndMetadata(
           input,
           remoteServer,
           workspaceId,
-          workspaceDataSource,
-          dataSourcesMetatada[0],
         );
         break;
       case RemoteTableStatus.NOT_SYNCED:
-        await this.removeForeignTableAndMetadata(
-          input,
-          workspaceId,
-          workspaceDataSource,
-          dataSourcesMetatada[0].schema,
-        );
+        await this.removeForeignTableAndMetadata(input, workspaceId);
         break;
       default:
         throw new Error('Unsupported remote table status');
@@ -133,63 +121,92 @@ export class RemoteTableService {
     input: RemoteTableInput,
     remoteServer: RemoteServerEntity<RemoteServerType>,
     workspaceId: string,
-    workspaceDataSource: DataSource,
-    dataSourceMetadata: DataSourceEntity,
   ) {
-    const localSchema = dataSourceMetadata.schema;
-
-    // TODO: Add strong typing for remote table columns. Will be done when we have another use case than Postgres
     const remoteTableColumns = await this.fetchTableColumnsSchema(
       remoteServer,
       input.name,
       input.schema,
     );
 
-    const foreignTableColumns = remoteTableColumns
-      .map((column) => `"${column.column_name}" ${column.data_type}`)
-      .join(', ');
-
     const remoteTableName = `${camelCase(input.name)}Remote`;
     const remoteTableLabel = camelToTitleCase(remoteTableName);
 
     // We only support remote tables with an id column for now.
     const remoteTableIdColumn = remoteTableColumns.filter(
-      (column) => column.column_name === 'id',
+      (column) => column.columnName === 'id',
     )?.[0];
 
     if (!remoteTableIdColumn) {
       throw new Error('Remote table must have an id column');
     }
 
-    await workspaceDataSource.query(
-      `CREATE FOREIGN TABLE ${localSchema}."${remoteTableName}" (${foreignTableColumns}) SERVER "${remoteServer.foreignDataWrapperId}" OPTIONS (schema_name '${input.schema}', table_name '${input.name}')`,
+    const dataSourcesMetatada =
+      await this.dataSourceService.getDataSourcesMetadataFromWorkspaceId(
+        workspaceId,
+      );
+
+    if (!dataSourcesMetatada) {
+      throw new NotFoundException('Workspace data source does not exist');
+    }
+
+    this.workspaceMigrationService.createCustomMigration(
+      generateMigrationName(`create-remote-table-${remoteTableName}`),
+      workspaceId,
+      [
+        {
+          name: remoteTableName,
+          action: 'create_foreign_table',
+          foreignTable: {
+            columns: remoteTableColumns.map(
+              (column) =>
+                ({
+                  columnName: column.columnName,
+                  columnType: column.dataType,
+                }) satisfies WorkspaceMigrationColumnDefinition,
+            ),
+            referencedTableName: input.name,
+            referencedTableSchema: input.schema,
+            foreignDataWrapperId: remoteServer.foreignDataWrapperId,
+          } satisfies WorkspaceMigrationForeignTable,
+        },
+        {
+          name: remoteTableName,
+          action: 'alter',
+          columns: [
+            {
+              action: WorkspaceMigrationColumnActionType.CREATE_COMMENT,
+              comment: `@graphql({"primary_key_columns": ["id"], "totalCount": {"enabled": true}})`,
+              isForeignTable: true,
+            } satisfies WorkspaceMigrationCreateComment,
+          ],
+        },
+      ],
     );
 
-    await workspaceDataSource.query(
-      `COMMENT ON FOREIGN TABLE ${localSchema}."${remoteTableName}" IS e'@graphql({"primary_key_columns": ["id"], "totalCount": {"enabled": true}})'`,
+    await this.workspaceMigrationRunnerService.executeMigrationFromPendingMigrations(
+      workspaceId,
     );
 
-    // Should be done in a transaction. To be discussed
     const objectMetadata = await this.objectMetadataService.createOne({
       nameSingular: remoteTableName,
       namePlural: `${remoteTableName}s`,
       labelSingular: remoteTableLabel,
       labelPlural: `${remoteTableLabel}s`,
       description: 'Remote table',
-      dataSourceId: dataSourceMetadata.id,
+      dataSourceId: dataSourcesMetatada[0].id,
       workspaceId: workspaceId,
       icon: 'IconUser',
       isRemote: true,
-      remoteTablePrimaryKeyColumnType: remoteTableIdColumn.udt_name,
+      remoteTablePrimaryKeyColumnType: remoteTableIdColumn.udtName,
     } as CreateObjectInput);
 
     for (const column of remoteTableColumns) {
       const field = await this.fieldMetadataService.createOne({
-        name: column.column_name,
-        label: camelToTitleCase(camelCase(column.column_name)),
+        name: column.columnName,
+        label: camelToTitleCase(camelCase(column.columnName)),
         description: 'Field of remote',
         // TODO: function should work for other types than Postgres
-        type: mapUdtNameToFieldType(column.udt_name),
+        type: mapUdtNameToFieldType(column.udtName),
         workspaceId: workspaceId,
         objectMetadataId: objectMetadata.id,
         isRemoteCreation: true,
@@ -197,7 +214,7 @@ export class RemoteTableService {
         icon: 'IconUser',
       } as CreateFieldInput);
 
-      if (column.column_name === 'id') {
+      if (column.columnName === 'id') {
         await this.objectMetadataService.updateOne(objectMetadata.id, {
           labelIdentifierFieldMetadataId: field.id,
         });
@@ -208,12 +225,12 @@ export class RemoteTableService {
   private async removeForeignTableAndMetadata(
     input: RemoteTableInput,
     workspaceId: string,
-    workspaceDataSource: DataSource,
-    localSchema: string,
   ) {
+    const remoteTableName = `${camelCase(input.name)}Remote`;
+
     const objectMetadata =
       await this.objectMetadataService.findOneWithinWorkspace(workspaceId, {
-        where: { nameSingular: `${input.name}Remote` },
+        where: { nameSingular: remoteTableName },
       });
 
     if (objectMetadata) {
@@ -223,8 +240,19 @@ export class RemoteTableService {
       );
     }
 
-    await workspaceDataSource.query(
-      `DROP FOREIGN TABLE ${localSchema}."${input.name}Remote"`,
+    this.workspaceMigrationService.createCustomMigration(
+      generateMigrationName(`drop-remote-table-${input.name}`),
+      workspaceId,
+      [
+        {
+          name: remoteTableName,
+          action: 'drop_foreign_table',
+        },
+      ],
+    );
+
+    await this.workspaceMigrationRunnerService.executeMigrationFromPendingMigrations(
+      workspaceId,
     );
   }
 
@@ -232,7 +260,7 @@ export class RemoteTableService {
     remoteServer: RemoteServerEntity<RemoteServerType>,
     tableName: string,
     tableSchema: string,
-  ) {
+  ): Promise<RemoteTableColumn[]> {
     switch (remoteServer.foreignDataWrapperType) {
       case RemoteServerType.POSTGRES_FDW:
         await isPostgreSQLIntegrationEnabled(

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/types/remote-table-column.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/types/remote-table-column.ts
@@ -1,0 +1,6 @@
+// Type will evolve as we add more remote table types
+export type RemoteTableColumn = {
+  columnName: string;
+  dataType: string;
+  udtName: string;
+};

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/utils/get-remote-table-name.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/utils/get-remote-table-name.util.ts
@@ -1,0 +1,4 @@
+import { camelCase } from 'src/utils/camel-case';
+
+export const getRemoteTableName = (distantTableName: string) =>
+  `${camelCase(distantTableName)}Remote`;

--- a/packages/twenty-server/src/engine/metadata-modules/workspace-migration/workspace-migration.entity.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/workspace-migration/workspace-migration.entity.ts
@@ -14,6 +14,7 @@ export enum WorkspaceMigrationColumnActionType {
   DROP_FOREIGN_KEY = 'DROP_FOREIGN_KEY',
   DROP = 'DROP',
   CREATE_COMMENT = 'CREATE_COMMENT',
+  CREATE_FOREIGN_TABLE = 'CREATE_FOREIGN_TABLE',
 }
 
 export type WorkspaceMigrationEnum = string | { from: string; to: string };
@@ -60,6 +61,14 @@ export type WorkspaceMigrationColumnDrop = {
 export type WorkspaceMigrationCreateComment = {
   action: WorkspaceMigrationColumnActionType.CREATE_COMMENT;
   comment: string;
+  isForeignTable?: boolean;
+};
+
+export type WorkspaceMigrationForeignTable = {
+  columns: WorkspaceMigrationColumnDefinition[];
+  referencedTableName: string;
+  referencedTableSchema: string;
+  foreignDataWrapperId: string;
 };
 
 export type WorkspaceMigrationColumnAction = {
@@ -75,8 +84,14 @@ export type WorkspaceMigrationColumnAction = {
 
 export type WorkspaceMigrationTableAction = {
   name: string;
-  action: 'create' | 'alter' | 'drop';
+  action:
+    | 'create'
+    | 'alter'
+    | 'drop'
+    | 'create_foreign_table'
+    | 'drop_foreign_table';
   columns?: WorkspaceMigrationColumnAction[];
+  foreignTable?: WorkspaceMigrationForeignTable;
 };
 
 @Entity('workspaceMigration')

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-runner/workspace-migration-runner.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-runner/workspace-migration-runner.service.ts
@@ -18,6 +18,7 @@ import {
   WorkspaceMigrationColumnCreateRelation,
   WorkspaceMigrationColumnAlter,
   WorkspaceMigrationColumnDropRelation,
+  WorkspaceMigrationForeignTable,
 } from 'src/engine/metadata-modules/workspace-migration/workspace-migration.entity';
 import { WorkspaceCacheVersionService } from 'src/engine/metadata-modules/workspace-cache-version/workspace-cache-version.service';
 import { WorkspaceMigrationEnumService } from 'src/engine/workspace-manager/workspace-migration-runner/services/workspace-migration-enum.service';
@@ -131,6 +132,19 @@ export class WorkspaceMigrationRunnerService {
       case 'drop':
         await queryRunner.dropTable(`${schemaName}.${tableMigration.name}`);
         break;
+      case 'create_foreign_table':
+        await this.createForeignTable(
+          queryRunner,
+          schemaName,
+          tableMigration.name,
+          tableMigration?.foreignTable,
+        );
+        break;
+      case 'drop_foreign_table':
+        await queryRunner.query(
+          `DROP FOREIGN TABLE ${schemaName}."${tableMigration.name}"`,
+        );
+        break;
       default:
         throw new Error(
           `Migration table action ${tableMigration.action} not supported`,
@@ -230,6 +244,7 @@ export class WorkspaceMigrationRunnerService {
             schemaName,
             tableName,
             columnMigration.comment,
+            columnMigration.isForeignTable,
           );
           break;
         default:
@@ -426,9 +441,31 @@ export class WorkspaceMigrationRunnerService {
     schemaName: string,
     tableName: string,
     comment: string,
+    isForeignTable?: boolean,
   ) {
+    const tableType = isForeignTable ? 'FOREIGN TABLE' : 'TABLE';
+
     await queryRunner.query(`
-      COMMENT ON TABLE "${schemaName}"."${tableName}" IS e'${comment}';
+      COMMENT ON ${tableType} "${schemaName}"."${tableName}" IS e'${comment}';
     `);
+  }
+
+  private async createForeignTable(
+    queryRunner: QueryRunner,
+    schemaName: string,
+    name: string,
+    foreignTable: WorkspaceMigrationForeignTable | undefined,
+  ) {
+    if (!foreignTable) {
+      return;
+    }
+
+    const foreignTableColumns = foreignTable.columns
+      .map((column) => `"${column.columnName}" ${column.columnType}`)
+      .join(', ');
+
+    await queryRunner.query(
+      `CREATE FOREIGN TABLE ${schemaName}."${name}" (${foreignTableColumns}) SERVER "${foreignTable.foreignDataWrapperId}" OPTIONS (schema_name '${foreignTable.referencedTableSchema}', table_name '${foreignTable.referencedTableName}')`,
+    );
   }
 }


### PR DESCRIPTION
Adding two new types of migration `create_foreign_table` and `drop_foreign_table `.
Those will be created and triggered instead of using raw queries directly.

Also adapting comment migration for the foreign table use case.