### PR TITLE
docker compose db pull issue fixed

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -45,6 +45,7 @@ trap on_exit EXIT
 
 # Use environment variables VERSION and BRANCH, with defaults if not set
 version=${VERSION:-$(curl -s https://api.github.com/repos/twentyhq/twenty/releases/latest | grep '"tag_name":' | cut -d '"' -f 4)}
+pg_version=$(echo $version | sed 's/^v//')
 branch=${BRANCH:-main}
 
 echo "🚀 Using version $version and branch $branch"
@@ -84,9 +85,11 @@ curl -sLo .env https://raw.githubusercontent.com/twentyhq/twenty/$branch/package
 if [[ $(uname) == "Darwin" ]]; then
   # Running on macOS
   sed -i '' "s/TAG=latest/TAG=$version/g" .env
+  sed -i '' "s/PG_TAG=latest/PG_TAG=$pg_version/g" .env
 else
   # Assuming Linux
   sed -i'' "s/TAG=latest/TAG=$version/g" .env
+  sed -i'' "s/PG_TAG=latest/PG_TAG=$pg_version/g" .env
 fi
 
 # Generate random strings for secrets

--- a/packages/twenty-docker/docker-compose.yml
+++ b/packages/twenty-docker/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     restart: always
 
   db:
-    image: twentycrm/twenty-postgres:${TAG}
+    image: twentycrm/twenty-postgres:${PG_TAG}
     volumes:
       - db-data:/bitnami/postgresql
     environment:


### PR DESCRIPTION
Hi,

When encountering an error with docker-compose up stating that it cannot pull twentycrm/twenty-postgres from Docker Hub, the issue likely stems from difficulties in pulling a specific tag due to inconsistencies in tag naming conventions.

 1) **Inconsistent Tag Prefix:**  The Twenty CRM repository consistently uses v0.4.0 as a tag format, indicating that tags customarily begin with a "V". This pattern suggests that all version tags for this repository are prefixed with a letter "V", making it a standard practice for version tagging in this context.

![screenshot-hub docker com-2024 04 08-11_11_51](https://github.com/twentyhq/twenty/assets/44894135/5ddab334-e359-4151-a988-5e255e713319)

  2)  Variation in Tagging Conventions: For twentycrm/twenty-postgres, there has been a shift in tagging conventions. Previously, tags included the "V" prefix, aligning with the overall tagging approach of Twenty CRM. However, the current release has omitted the "V" from the tag. This change introduces inconsistency and may lead to difficulties in pulling the correct image, as the expected tag format does not match the actual tag.

![screenshot-hub docker com-2024 04 08-11_12_14](https://github.com/twentyhq/twenty/assets/44894135/3a2d89f1-4d9c-4f46-bdda-95cbcb2773fb)

3) To resolve this discrepancy and avoid similar errors, employing separate environment variables for tag management proved to be an effective solution. By defining distinct environment variables for tags, it becomes possible to accommodate variations in tagging conventions (whether they include the "V" prefix or not) without manual intervention or error. This approach enhances flexibility and ensures that the correct Docker images can be pulled from Docker Hub, regardless of inconsistencies in tag naming conventions.

So fixed with separate tag env variables handle the issue .