### PR TITLE
Fix get available tables

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-postgres-table/remote-postgres-table.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-postgres-table/remote-postgres-table.service.ts
@@ -13,6 +13,7 @@ import {
 } from 'src/engine/metadata-modules/remote-server/remote-table/remote-postgres-table/utils/remote-postgres-table.util';
 import { EnvironmentService } from 'src/engine/integrations/environment/environment.service';
 import { WorkspaceDataSourceService } from 'src/engine/workspace-datasource/workspace-datasource.service';
+import { getRemoteTableName } from 'src/engine/metadata-modules/remote-server/remote-table/utils/get-remote-table-name.util';
 
 @Injectable()
 export class RemotePostgresTableService {
@@ -42,7 +43,9 @@ export class RemotePostgresTableService {
     return remotePostgresTables.map((remoteTable) => ({
       name: remoteTable.table_name,
       schema: remoteTable.table_schema,
-      status: currentForeignTableNames.includes(remoteTable.table_name)
+      status: currentForeignTableNames.includes(
+        getRemoteTableName(remoteTable.table_name),
+      )
         ? RemoteTableStatus.SYNCED
         : RemoteTableStatus.NOT_SYNCED,
     }));

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-table.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-table.service.ts
@@ -25,6 +25,7 @@ import { RemotePostgresTableService } from 'src/engine/metadata-modules/remote-s
 import { WorkspaceCacheVersionService } from 'src/engine/metadata-modules/workspace-cache-version/workspace-cache-version.service';
 import { camelCase } from 'src/utils/camel-case';
 import { camelToTitleCase } from 'src/utils/camel-to-title-case';
+import { getRemoteTableName } from 'src/engine/metadata-modules/remote-server/remote-table/utils/get-remote-table-name.util';
 
 export class RemoteTableService {
   constructor(
@@ -149,7 +150,7 @@ export class RemoteTableService {
       .map((column) => `"${column.column_name}" ${column.data_type}`)
       .join(', ');
 
-    const remoteTableName = `${camelCase(input.name)}Remote`;
+    const remoteTableName = getRemoteTableName(input.name);
     const remoteTableLabel = camelToTitleCase(remoteTableName);
 
     // We only support remote tables with an id column for now.
@@ -211,9 +212,11 @@ export class RemoteTableService {
     workspaceDataSource: DataSource,
     localSchema: string,
   ) {
+    const remoteTableName = getRemoteTableName(input.name);
+
     const objectMetadata =
       await this.objectMetadataService.findOneWithinWorkspace(workspaceId, {
-        where: { nameSingular: `${input.name}Remote` },
+        where: { nameSingular: remoteTableName },
       });
 
     if (objectMetadata) {

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/utils/get-remote-table-name.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/utils/get-remote-table-name.util.ts
@@ -1,0 +1,4 @@
+import { camelCase } from 'src/utils/camel-case';
+
+export const getRemoteTableName = (distantTableName: string) =>
+  `${camelCase(distantTableName)}Remote`;


### PR DESCRIPTION
Endpoint is broken since we now use `Remote` as a suffix for remote table names.

This PR:
- creates a common function to calculate the name of the remote table
- use it in the `findAvailableRemotePostgresTables` to know if a table has been synced or not