### PR TITLE
[messaging]Add temporary capture to gmail refresh token exceptions

### DIFF
--- a/packages/twenty-server/src/modules/connected-account/repositories/connected-account.repository.ts
+++ b/packages/twenty-server/src/modules/connected-account/repositories/connected-account.repository.ts
@@ -144,7 +144,7 @@ export class ConnectedAccountRepository {
       this.workspaceDataSourceService.getSchemaName(workspaceId);
 
     await this.workspaceDataSourceService.executeRawQuery(
-      `UPDATE ${dataSourceSchema}."connectedAccount" SET "accessToken" = $1 WHERE "id" = $2`,
+      `UPDATE ${dataSourceSchema}."connectedAccount" SET "accessToken" = $1, "authFailedAt" = NULL WHERE "id" = $2`,
       [accessToken, connectedAccountId],
       workspaceId,
       transactionManager,

--- a/packages/twenty-server/src/modules/connected-account/services/google-api-refresh-access-token/google-api-refresh-access-token.service.ts
+++ b/packages/twenty-server/src/modules/connected-account/services/google-api-refresh-access-token/google-api-refresh-access-token.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@nestjs/common';
 import axios from 'axios';
 
 import { EnvironmentService } from 'src/engine/integrations/environment/environment.service';
+import { ExceptionHandlerService } from 'src/engine/integrations/exception-handler/exception-handler.service';
 import { InjectObjectMetadataRepository } from 'src/engine/object-metadata-repository/object-metadata-repository.decorator';
 import { ConnectedAccountRepository } from 'src/modules/connected-account/repositories/connected-account.repository';
 import { ConnectedAccountObjectMetadata } from 'src/modules/connected-account/standard-objects/connected-account.object-metadata';
@@ -13,6 +14,7 @@ export class GoogleAPIRefreshAccessTokenService {
     private readonly environmentService: EnvironmentService,
     @InjectObjectMetadataRepository(ConnectedAccountObjectMetadata)
     private readonly connectedAccountRepository: ConnectedAccountRepository,
+    private readonly exceptionHandlerService: ExceptionHandlerService,
   ) {}
 
   async refreshAndSaveAccessToken(
@@ -80,6 +82,11 @@ export class GoogleAPIRefreshAccessTokenService {
         connectedAccountId,
         workspaceId,
       );
+      this.exceptionHandlerService.captureExceptions([error], {
+        user: {
+          workspaceId,
+        },
+      });
       throw new Error(`Error refreshing access token: ${error.message}`);
     }
   }


### PR DESCRIPTION
## Context
This exception is currently caught since this is expected but it seems to be rejected more than it should so we want to have more visibility on it

## Test
<img width="562" alt="Screenshot 2024-04-08 at 11 32 28" src="https://github.com/twentyhq/twenty/assets/1834158/43bb6de9-191a-42d4-911b-6e83c7d8aa18">
