### PR TITLE
Use migrations for remote tables

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/dtos/remote-table-input.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/dtos/remote-table-input.ts
@@ -17,5 +17,5 @@ export class RemoteTableInput {
   status: RemoteTableStatus;
 
   @Field(() => String)
-  schema: string;
+  schema?: string;
 }

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-postgres-table/remote-postgres-table.module.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-postgres-table/remote-postgres-table.module.ts
@@ -1,10 +1,8 @@
 import { Module } from '@nestjs/common';
 
 import { RemotePostgresTableService } from 'src/engine/metadata-modules/remote-server/remote-table/remote-postgres-table/remote-postgres-table.service';
-import { WorkspaceDataSourceModule } from 'src/engine/workspace-datasource/workspace-datasource.module';
 
 @Module({
-  imports: [WorkspaceDataSourceModule],
   providers: [RemotePostgresTableService],
   exports: [RemotePostgresTableService],
 })

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-postgres-table/remote-postgres-table.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-postgres-table/remote-postgres-table.service.ts
@@ -14,6 +14,7 @@ import {
 import { EnvironmentService } from 'src/engine/integrations/environment/environment.service';
 import { WorkspaceDataSourceService } from 'src/engine/workspace-datasource/workspace-datasource.service';
 import { getRemoteTableName } from 'src/engine/metadata-modules/remote-server/remote-table/utils/get-remote-table-name.util';
+import { RemoteTableColumn } from 'src/engine/metadata-modules/remote-server/remote-table/types/remote-table-column';
 
 @Injectable()
 export class RemotePostgresTableService {
@@ -55,7 +56,7 @@ export class RemotePostgresTableService {
     remoteServer: RemoteServerEntity<RemoteServerType>,
     tableName: string,
     tableSchema: string,
-  ) {
+  ): Promise<RemoteTableColumn[]> {
     const dataSource = new DataSource({
       url: buildPostgresUrl(
         this.environmentService.get('LOGIN_TOKEN_SECRET'),
@@ -73,7 +74,14 @@ export class RemotePostgresTableService {
 
     await dataSource.destroy();
 
-    return columns;
+    return columns.map(
+      (column) =>
+        ({
+          columnName: column.column_name,
+          dataType: column.data_type,
+          udtName: column.udt_name,
+        }) as RemoteTableColumn,
+    );
   }
 
   private async fetchTablesFromRemotePostgresSchema(

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-table.module.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-table.module.ts
@@ -10,18 +10,20 @@ import { RemotePostgresTableModule } from 'src/engine/metadata-modules/remote-se
 import { RemoteTableResolver } from 'src/engine/metadata-modules/remote-server/remote-table/remote-table.resolver';
 import { RemoteTableService } from 'src/engine/metadata-modules/remote-server/remote-table/remote-table.service';
 import { WorkspaceCacheVersionModule } from 'src/engine/metadata-modules/workspace-cache-version/workspace-cache-version.module';
-import { WorkspaceDataSourceModule } from 'src/engine/workspace-datasource/workspace-datasource.module';
+import { WorkspaceMigrationModule } from 'src/engine/metadata-modules/workspace-migration/workspace-migration.module';
+import { WorkspaceMigrationRunnerModule } from 'src/engine/workspace-manager/workspace-migration-runner/workspace-migration-runner.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([RemoteServerEntity], 'metadata'),
     TypeOrmModule.forFeature([FeatureFlagEntity], 'core'),
-    WorkspaceDataSourceModule,
     DataSourceModule,
     ObjectMetadataModule,
     FieldMetadataModule,
     RemotePostgresTableModule,
     WorkspaceCacheVersionModule,
+    WorkspaceMigrationModule,
+    WorkspaceMigrationRunnerModule,
   ],
   providers: [RemoteTableService, RemoteTableResolver],
 })

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-table.module.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-table.module.ts
@@ -11,6 +11,7 @@ import { RemoteTableResolver } from 'src/engine/metadata-modules/remote-server/r
 import { RemoteTableService } from 'src/engine/metadata-modules/remote-server/remote-table/remote-table.service';
 import { WorkspaceCacheVersionModule } from 'src/engine/metadata-modules/workspace-cache-version/workspace-cache-version.module';
 import { WorkspaceMigrationModule } from 'src/engine/metadata-modules/workspace-migration/workspace-migration.module';
+import { WorkspaceDataSourceModule } from 'src/engine/workspace-datasource/workspace-datasource.module';
 import { WorkspaceMigrationRunnerModule } from 'src/engine/workspace-manager/workspace-migration-runner/workspace-migration-runner.module';
 
 @Module({
@@ -24,7 +25,9 @@ import { WorkspaceMigrationRunnerModule } from 'src/engine/workspace-manager/wor
     WorkspaceCacheVersionModule,
     WorkspaceMigrationModule,
     WorkspaceMigrationRunnerModule,
+    WorkspaceDataSourceModule,
   ],
   providers: [RemoteTableService, RemoteTableResolver],
+  exports: [RemoteTableService],
 })
 export class RemoteTableModule {}

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-table.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-table.service.ts
@@ -123,6 +123,10 @@ export class RemoteTableService {
     remoteServer: RemoteServerEntity<RemoteServerType>,
     workspaceId: string,
   ) {
+    if (!input.schema) {
+      throw new Error('Schema is required for syncing remote table');
+    }
+
     const remoteTableColumns = await this.fetchTableColumnsSchema(
       remoteServer,
       input.name,

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-table.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-table.service.ts
@@ -102,7 +102,7 @@ export class RemoteTableService {
 
     switch (input.status) {
       case RemoteTableStatus.SYNCED:
-        await this.buildForeignTableAndMetadata(
+        await this.createForeignTableAndMetadata(
           input,
           remoteServer,
           workspaceId,
@@ -120,7 +120,7 @@ export class RemoteTableService {
     return input;
   }
 
-  private async buildForeignTableAndMetadata(
+  private async createForeignTableAndMetadata(
     input: RemoteTableInput,
     remoteServer: RemoteServerEntity<RemoteServerType>,
     workspaceId: string,
@@ -154,14 +154,10 @@ export class RemoteTableService {
       throw new Error('Remote table must have an id column');
     }
 
-    const dataSourcesMetatada =
-      await this.dataSourceService.getDataSourcesMetadataFromWorkspaceId(
+    const dataSourceMetatada =
+      await this.dataSourceService.getLastDataSourceMetadataFromWorkspaceIdOrFail(
         workspaceId,
       );
-
-    if (!dataSourcesMetatada) {
-      throw new NotFoundException('Workspace data source does not exist');
-    }
 
     await this.workspaceMigrationService.createCustomMigration(
       generateMigrationName(`create-foreign-table-${remoteTableName}`),
@@ -196,7 +192,7 @@ export class RemoteTableService {
       labelSingular: remoteTableLabel,
       labelPlural: `${remoteTableLabel}s`,
       description: 'Remote table',
-      dataSourceId: dataSourcesMetatada[0].id,
+      dataSourceId: dataSourceMetatada.id,
       workspaceId: workspaceId,
       icon: 'IconUser',
       isRemote: true,

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/types/remote-table-column.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/types/remote-table-column.ts
@@ -1,0 +1,6 @@
+// Type will evolve as we add more remote table types
+export type RemoteTableColumn = {
+  columnName: string;
+  dataType: string;
+  udtName: string;
+};

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/types/remote-table.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/types/remote-table.ts
@@ -1,0 +1,5 @@
+// Type will evolve as we add more remote table types
+export type RemoteTable = {
+  tableName: string;
+  tableSchema: string;
+};

--- a/packages/twenty-server/src/engine/metadata-modules/workspace-migration/workspace-migration.entity.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/workspace-migration/workspace-migration.entity.ts
@@ -14,6 +14,7 @@ export enum WorkspaceMigrationColumnActionType {
   DROP_FOREIGN_KEY = 'DROP_FOREIGN_KEY',
   DROP = 'DROP',
   CREATE_COMMENT = 'CREATE_COMMENT',
+  CREATE_FOREIGN_TABLE = 'CREATE_FOREIGN_TABLE',
 }
 
 export type WorkspaceMigrationEnum = string | { from: string; to: string };
@@ -60,6 +61,14 @@ export type WorkspaceMigrationColumnDrop = {
 export type WorkspaceMigrationCreateComment = {
   action: WorkspaceMigrationColumnActionType.CREATE_COMMENT;
   comment: string;
+  isForeignTable?: boolean;
+};
+
+export type WorkspaceMigrationForeignTable = {
+  columns: WorkspaceMigrationColumnDefinition[];
+  referencedTableName: string;
+  referencedTableSchema: string;
+  foreignDataWrapperId: string;
 };
 
 export type WorkspaceMigrationColumnAction = {
@@ -75,8 +84,14 @@ export type WorkspaceMigrationColumnAction = {
 
 export type WorkspaceMigrationTableAction = {
   name: string;
-  action: 'create' | 'alter' | 'drop';
+  action:
+    | 'create'
+    | 'alter'
+    | 'drop'
+    | 'create_foreign_table'
+    | 'drop_foreign_table';
   columns?: WorkspaceMigrationColumnAction[];
+  foreignTable?: WorkspaceMigrationForeignTable;
 };
 
 @Entity('workspaceMigration')

--- a/packages/twenty-server/src/engine/metadata-modules/workspace-migration/workspace-migration.entity.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/workspace-migration/workspace-migration.entity.ts
@@ -61,7 +61,6 @@ export type WorkspaceMigrationColumnDrop = {
 export type WorkspaceMigrationCreateComment = {
   action: WorkspaceMigrationColumnActionType.CREATE_COMMENT;
   comment: string;
-  isForeignTable?: boolean;
 };
 
 export type WorkspaceMigrationForeignTable = {

--- a/packages/twenty-server/src/engine/metadata-modules/workspace-migration/workspace-migration.entity.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/workspace-migration/workspace-migration.entity.ts
@@ -14,7 +14,6 @@ export enum WorkspaceMigrationColumnActionType {
   DROP_FOREIGN_KEY = 'DROP_FOREIGN_KEY',
   DROP = 'DROP',
   CREATE_COMMENT = 'CREATE_COMMENT',
-  CREATE_FOREIGN_TABLE = 'CREATE_FOREIGN_TABLE',
 }
 
 export type WorkspaceMigrationEnum = string | { from: string; to: string };

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-runner/workspace-migration-runner.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-runner/workspace-migration-runner.service.ts
@@ -18,6 +18,7 @@ import {
   WorkspaceMigrationColumnCreateRelation,
   WorkspaceMigrationColumnAlter,
   WorkspaceMigrationColumnDropRelation,
+  WorkspaceMigrationForeignTable,
 } from 'src/engine/metadata-modules/workspace-migration/workspace-migration.entity';
 import { WorkspaceCacheVersionService } from 'src/engine/metadata-modules/workspace-cache-version/workspace-cache-version.service';
 import { WorkspaceMigrationEnumService } from 'src/engine/workspace-manager/workspace-migration-runner/services/workspace-migration-enum.service';
@@ -131,6 +132,19 @@ export class WorkspaceMigrationRunnerService {
       case 'drop':
         await queryRunner.dropTable(`${schemaName}.${tableMigration.name}`);
         break;
+      case 'create_foreign_table':
+        await this.createForeignTable(
+          queryRunner,
+          schemaName,
+          tableMigration.name,
+          tableMigration?.foreignTable,
+        );
+        break;
+      case 'drop_foreign_table':
+        await queryRunner.query(
+          `DROP FOREIGN TABLE ${schemaName}."${tableMigration.name}"`,
+        );
+        break;
       default:
         throw new Error(
           `Migration table action ${tableMigration.action} not supported`,
@@ -230,6 +244,7 @@ export class WorkspaceMigrationRunnerService {
             schemaName,
             tableName,
             columnMigration.comment,
+            columnMigration.isForeignTable,
           );
           break;
         default:
@@ -426,9 +441,31 @@ export class WorkspaceMigrationRunnerService {
     schemaName: string,
     tableName: string,
     comment: string,
+    isForeignTable?: boolean,
   ) {
+    const tableType = isForeignTable ? 'FOREIGN TABLE' : 'TABLE';
+
     await queryRunner.query(`
-      COMMENT ON TABLE "${schemaName}"."${tableName}" IS e'${comment}';
+      COMMENT ON ${tableType} "${schemaName}"."${tableName}" IS e'${comment}';
     `);
+  }
+
+  private async createForeignTable(
+    queryRunner: QueryRunner,
+    schemaName: string,
+    name: string,
+    foreignTable: WorkspaceMigrationForeignTable | undefined,
+  ) {
+    if (!foreignTable) {
+      return;
+    }
+
+    const foreignTableColumns = foreignTable.columns
+      .map((column) => `"${column.columnName}" ${column.columnType}`)
+      .join(', ');
+
+    await queryRunner.query(
+      `CREATE FOREIGN TABLE ${schemaName}."${name}" (${foreignTableColumns}) SERVER "${foreignTable.foreignDataWrapperId}" OPTIONS (schema_name '${foreignTable.referencedTableSchema}', table_name '${foreignTable.referencedTableName}')`,
+    );
   }
 }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-runner/workspace-migration-runner.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-runner/workspace-migration-runner.service.ts
@@ -244,7 +244,6 @@ export class WorkspaceMigrationRunnerService {
             schemaName,
             tableName,
             columnMigration.comment,
-            columnMigration.isForeignTable,
           );
           break;
         default:
@@ -441,12 +440,9 @@ export class WorkspaceMigrationRunnerService {
     schemaName: string,
     tableName: string,
     comment: string,
-    isForeignTable?: boolean,
   ) {
-    const tableType = isForeignTable ? 'FOREIGN TABLE' : 'TABLE';
-
     await queryRunner.query(`
-      COMMENT ON ${tableType} "${schemaName}"."${tableName}" IS e'${comment}';
+      COMMENT ON TABLE "${schemaName}"."${tableName}" IS e'${comment}';
     `);
   }
 
@@ -467,5 +463,9 @@ export class WorkspaceMigrationRunnerService {
     await queryRunner.query(
       `CREATE FOREIGN TABLE ${schemaName}."${name}" (${foreignTableColumns}) SERVER "${foreignTable.foreignDataWrapperId}" OPTIONS (schema_name '${foreignTable.referencedTableSchema}', table_name '${foreignTable.referencedTableName}')`,
     );
+
+    await queryRunner.query(`
+      COMMENT ON FOREIGN TABLE "${schemaName}"."${name}" IS '@graphql({"primary_key_columns": ["id"], "totalCount": {"enabled": true}})';
+    `);
   }
 }


### PR DESCRIPTION
Foreign tables should be created using migrations, as we do for standard tables.
Since those are not really generated from the object metadata but from the remote table, those migrations won't live in the object metadata service. 

This PR:
- creates new types of migration : create_foreign_table and drop_foreign_table
- triggers those migrations rather than raw queries directly
- moves the logic to fetch current foreign tables into the remote table service since this is not directly linked to postgres data wrapper
- adds logic to unsync all tables before deleting 