### PR TITLE
4809 - disable double signup with mouse click / enter

### DIFF
--- a/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpForm.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpForm.tsx
@@ -71,8 +71,10 @@ export const SignInUpForm = () => {
       } else if (signInUpStep === SignInUpStep.Email) {
         continueWithCredentials();
       } else if (signInUpStep === SignInUpStep.Password) {
-        setShowErrors(true);
-        form.handleSubmit(submitCredentials)();
+        if (!form.formState.isSubmitting) {
+          setShowErrors(true);
+          form.handleSubmit(submitCredentials)();
+        }
       }
     }
   };
@@ -225,7 +227,7 @@ export const SignInUpForm = () => {
             }}
             Icon={() => form.formState.isSubmitting && <Loader />}
             disabled={
-              SignInUpStep.Init
+              signInUpStep === SignInUpStep.Init
                 ? false
                 : signInUpStep === SignInUpStep.Email
                   ? !form.watch('email')


### PR DESCRIPTION
Fixing #4809 

The form has a button with a disabled condition, unfortunately there was an error in checking the condition. 
```
disabled={
       SignInUpStep.Init
                ? false
                ...
```
SignInUpStep.Init is always equal to true, so the first arm was returning false and button was never disabled. Fixing this check fixes the double mouse click bug as expected. 
```
disabled={
              signInUpStep === SignInUpStep.Init
```

Still, the enter keypress is handled a little bit differently. There is a handleKeyDown event that was ignoring if the form is submitting or not. I added the check for that, and now pressing enter multiple times does not result in any errors
              