### PR TITLE
Enable creating profile by pressing enter

### DIFF
--- a/packages/twenty-front/src/pages/auth/CreateProfile.tsx
+++ b/packages/twenty-front/src/pages/auth/CreateProfile.tsx
@@ -135,6 +135,13 @@ export const CreateProfile = () => {
     [onSubmit],
   );
 
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === Key.Enter && !isSubmitting) {
+      event.preventDefault();
+      handleSubmit(onSubmit)();
+    }
+  };
+
   if (onboardingStatus !== OnboardingStatus.OngoingProfileCreation) {
     return null;
   }
@@ -171,6 +178,7 @@ export const CreateProfile = () => {
                   placeholder="Tim"
                   error={error?.message}
                   fullWidth
+                  onKeyDown={handleKeyDown}
                   disableHotkeys
                 />
               )}
@@ -190,6 +198,7 @@ export const CreateProfile = () => {
                   placeholder="Cook"
                   error={error?.message}
                   fullWidth
+                  onKeyDown={handleKeyDown}
                   disableHotkeys
                 />
               )}


### PR DESCRIPTION
This adds option to press enter to process with profile creation, as requested in #4808 

In the code above my changes there is useScopedHotKeys hook listening to enter keypress, but it's not getting triggered when the fields are focused.

The code I propose here fixes this and enables enter keypress to create new profile. Unfortunately I am not sure what code practice should be followed here, there are mixed approaches.

 - in auth flow there is mostly usage of handleKeyDown attached to input elements. There are no useScopedHotKeys. Which is fine, but enter will only work if the field is focused. Clicking outside of a field disables the enter hotkey (for example here, you cannot press enter to proceed, as input is unfocused:)
 
![image](https://github.com/twentyhq/twenty/assets/4631047/a27e0b05-6234-4eac-acce-7aabf77adc87)

This approach I propose here (leaving useScopedHotKeys and adding handleKeyDown), is allowing user to proceed in both cases with fields focused / unfocused. Please let me know if that's the good approach
