### PR TITLE
[calendar] change api scope

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/auth/controllers/google-apis-auth.controller.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/controllers/google-apis-auth.controller.ts
@@ -1,4 +1,11 @@
-import { Controller, Get, Req, Res, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Req,
+  Res,
+  UnauthorizedException,
+  UseGuards,
+} from '@nestjs/common';
 
 import { Response } from 'express';
 
@@ -40,7 +47,9 @@ export class GoogleAPIsAuthController {
     const demoWorkspaceIds = this.environmentService.get('DEMO_WORKSPACE_IDS');
 
     if (demoWorkspaceIds.includes(workspaceId)) {
-      throw new Error('Cannot connect Google account to demo workspace');
+      throw new UnauthorizedException(
+        'Cannot connect Google account to demo workspace',
+      );
     }
 
     if (!workspaceId) {

--- a/packages/twenty-server/src/engine/core-modules/auth/strategies/google-apis.auth.strategy.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/strategies/google-apis.auth.strategy.ts
@@ -35,7 +35,7 @@ export class GoogleAPIsStrategy extends PassportStrategy(
     }
 
     if (environmentService.get('CALENDAR_PROVIDER_GOOGLE_ENABLED')) {
-      scope.push('https://www.googleapis.com/auth/calendar');
+      scope.push('https://www.googleapis.com/auth/calendar.events');
     }
 
     super({


### PR DESCRIPTION
## Context
Calendar scope was too broad, this PR updates it to events only.
Also changing "Cannot connect Google account to demo workspace" error to a 404 to avoid having a 500 for something expected