### PR TITLE
Fix graphql API accepting malformed UUIDs

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/services/type-mapper.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/services/type-mapper.service.ts
@@ -5,7 +5,6 @@ import {
   GraphQLBoolean,
   GraphQLEnumType,
   GraphQLFloat,
-  GraphQLID,
   GraphQLInputObjectType,
   GraphQLInputType,
   GraphQLInt,
@@ -35,7 +34,10 @@ import {
   RawJsonFilterType,
 } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/input';
 import { OrderByDirectionType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/enum';
-import { BigFloatScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
+import {
+  BigFloatScalarType,
+  UUIDScalarType,
+} from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 import { PositionScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars/position.scalar';
 
 export interface TypeOptions<T = any> {
@@ -58,7 +60,7 @@ export class TypeMapperService {
       numberScalarMode === 'float' ? GraphQLFloat : GraphQLInt;
 
     const typeScalarMapping = new Map<FieldMetadataType, GraphQLScalarType>([
-      [FieldMetadataType.UUID, GraphQLID],
+      [FieldMetadataType.UUID, UUIDScalarType],
       [FieldMetadataType.TEXT, GraphQLString],
       [FieldMetadataType.PHONE, GraphQLString],
       [FieldMetadataType.EMAIL, GraphQLString],
@@ -67,7 +69,7 @@ export class TypeMapperService {
       [FieldMetadataType.NUMBER, numberScalar],
       [FieldMetadataType.NUMERIC, BigFloatScalarType],
       [FieldMetadataType.PROBABILITY, GraphQLFloat],
-      [FieldMetadataType.RELATION, GraphQLID],
+      [FieldMetadataType.RELATION, UUIDScalarType],
       [FieldMetadataType.POSITION, PositionScalarType],
       [FieldMetadataType.RAW_JSON, GraphQLJSON],
     ]);

--- a/packages/twenty-server/src/engine/core-modules/user/dtos/workspace-member.dto.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/dtos/workspace-member.dto.ts
@@ -1,6 +1,8 @@
-import { Field, ID, ObjectType } from '@nestjs/graphql';
+import { Field, ObjectType } from '@nestjs/graphql';
 
 import { IDField } from '@ptc-org/nestjs-query-graphql';
+
+import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 
 @ObjectType('FullName')
 export class FullName {
@@ -13,7 +15,7 @@ export class FullName {
 
 @ObjectType('WorkspaceMember')
 export class WorkspaceMember {
-  @IDField(() => ID)
+  @IDField(() => UUIDScalarType)
   id: string;
 
   @Field(() => FullName)


### PR DESCRIPTION
We have discovered that GraphQL inputs for fields of type ids in create / update input where using a more permissive ID type than the type used in FilterInput in queries.

This PRs fixes it and make sure that all Input are using UUID graphql scalar types