### PR TITLE
bug: update revokedAt on PKCE flow

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/auth/services/token.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/token.service.ts
@@ -322,13 +322,13 @@ export class TokenService {
       assert(
         authorizationCodeAppToken,
         'Authorization code does not exist',
-        ForbiddenException,
+        NotFoundException,
       );
 
       assert(
         authorizationCodeAppToken.expiresAt.getTime() >= Date.now(),
         'Authorization code expired.',
-        NotFoundException,
+        ForbiddenException,
       );
 
       const codeChallenge = crypto
@@ -355,7 +355,7 @@ export class TokenService {
       assert(
         codeChallengeAppToken.expiresAt.getTime() >= Date.now(),
         'code challenge expired.',
-        NotFoundException,
+        ForbiddenException,
       );
 
       assert(
@@ -363,6 +363,15 @@ export class TokenService {
         'authorization code / code verifier was not created by same client',
         ForbiddenException,
       );
+
+      if (codeChallengeAppToken.revokedAt) {
+        throw new ForbiddenException('Token has been revoked.');
+      }
+
+      await this.appTokenRepository.save({
+        id: codeChallengeAppToken.userId,
+        revokedAt: new Date(),
+      });
 
       userId = codeChallengeAppToken.userId;
     }

--- a/packages/twenty-server/src/engine/core-modules/auth/services/token.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/token.service.ts
@@ -369,7 +369,7 @@ export class TokenService {
       }
 
       await this.appTokenRepository.save({
-        id: codeChallengeAppToken.userId,
+        id: codeChallengeAppToken.id,
         revokedAt: new Date(),
       });
 


### PR DESCRIPTION
The authorization token has an expiry of 5 minutes, we already have checks in place to verify this and throw a Forbidden exception. We need to revoke the token once it's used otherwise it could be used multiple times to gain access to tokens till it expires. 