### PR TITLE
Add connection failed status

### DIFF
--- a/packages/twenty-front/src/modules/databases/hooks/useGetDatabaseConnectionTables.ts
+++ b/packages/twenty-front/src/modules/databases/hooks/useGetDatabaseConnectionTables.ts
@@ -18,7 +18,7 @@ export const useGetDatabaseConnectionTables = ({
 }: UseGetDatabaseConnectionTablesParams) => {
   const apolloMetadataClient = useApolloMetadataClient();
 
-  const { data } = useQuery<
+  const { data, error } = useQuery<
     GetManyRemoteTablesQuery,
     GetManyRemoteTablesQueryVariables
   >(GET_MANY_REMOTE_TABLES, {
@@ -33,5 +33,6 @@ export const useGetDatabaseConnectionTables = ({
 
   return {
     tables: data?.findAvailableRemoteTablesByServerId || [],
+    error,
   };
 };

--- a/packages/twenty-front/src/modules/object-record/components/RecordChip.tsx
+++ b/packages/twenty-front/src/modules/object-record/components/RecordChip.tsx
@@ -1,6 +1,8 @@
+import { useContext } from 'react';
 import { EntityChip } from 'twenty-ui';
 
 import { useMapToObjectRecordIdentifier } from '@/object-metadata/hooks/useMapToObjectRecordIdentifier';
+import { RecordTableRowContext } from '@/object-record/record-table/contexts/RecordTableRowContext';
 import { ObjectRecord } from '@/object-record/types/ObjectRecord';
 import { getImageAbsoluteURIOrBase64 } from '~/utils/image/getImageAbsoluteURIOrBase64';
 
@@ -21,7 +23,15 @@ export const RecordChip = ({
     objectNameSingular,
   });
 
+  // Will only exists if the chip is inside a record table.
+  // This is temporary until we have the show page for remote objects.
+  const { isReadOnly } = useContext(RecordTableRowContext);
+
   const objectRecordIdentifier = mapToObjectRecordIdentifier(record);
+
+  const linkToEntity = isReadOnly
+    ? undefined
+    : objectRecordIdentifier.linkToShowPage;
 
   return (
     <EntityChip
@@ -31,7 +41,7 @@ export const RecordChip = ({
       avatarUrl={
         getImageAbsoluteURIOrBase64(objectRecordIdentifier.avatarUrl) || ''
       }
-      linkToEntity={objectRecordIdentifier.linkToShowPage}
+      linkToEntity={linkToEntity}
       maxWidth={maxWidth}
       className={className}
     />

--- a/packages/twenty-front/src/modules/settings/integrations/components/SettingsIntegrationDatabaseConnectionSyncStatus.tsx
+++ b/packages/twenty-front/src/modules/settings/integrations/components/SettingsIntegrationDatabaseConnectionSyncStatus.tsx
@@ -1,6 +1,7 @@
 import { useGetDatabaseConnectionTables } from '@/databases/hooks/useGetDatabaseConnectionTables';
 import { Status } from '@/ui/display/status/components/Status';
 import { RemoteTableStatus } from '~/generated-metadata/graphql';
+import { isDefined } from '~/utils/isDefined';
 
 type SettingsIntegrationDatabaseConnectionSyncStatusProps = {
   connectionId: string;
@@ -11,10 +12,14 @@ export const SettingsIntegrationDatabaseConnectionSyncStatus = ({
   connectionId,
   skip,
 }: SettingsIntegrationDatabaseConnectionSyncStatusProps) => {
-  const { tables } = useGetDatabaseConnectionTables({
+  const { tables, error } = useGetDatabaseConnectionTables({
     connectionId,
     skip,
   });
+
+  if (isDefined(error)) {
+    return <Status color="red" text="Connection failed" />;
+  }
 
   const syncedTables = tables.filter(
     (table) => table.status === RemoteTableStatus.Synced,

--- a/packages/twenty-front/src/pages/object-record/RecordIndexPageHeader.tsx
+++ b/packages/twenty-front/src/pages/object-record/RecordIndexPageHeader.tsx
@@ -35,8 +35,11 @@ export const RecordIndexPageHeader = ({
   const canAddRecord =
     recordIndexViewType === ViewType.Table && !objectMetadataItem?.isRemote;
 
+  const pageHeaderTitle =
+    objectMetadataItem?.labelPlural ?? capitalize(objectNamePlural);
+
   return (
-    <PageHeader title={capitalize(objectNamePlural)} Icon={Icon}>
+    <PageHeader title={pageHeaderTitle} Icon={Icon}>
       <PageHotkeysEffect onAddButtonClick={createRecord} />
       {canAddRecord && <PageAddButton onClick={createRecord} />}
     </PageHeader>

--- a/packages/twenty-front/src/pages/settings/integrations/SettingsIntegrationNewDatabaseConnection.tsx
+++ b/packages/twenty-front/src/pages/settings/integrations/SettingsIntegrationNewDatabaseConnection.tsx
@@ -95,14 +95,18 @@ export const SettingsIntegrationNewDatabaseConnection = () => {
     const formValues = formConfig.getValues();
 
     try {
-      await createOneDatabaseConnection(
+      const createdConnection = await createOneDatabaseConnection(
         createRemoteServerInputSchema.parse({
           ...formValues,
           foreignDataWrapperType: getForeignDataWrapperType(databaseKey),
         }),
       );
 
-      navigate(`${settingsIntegrationsPagePath}/${databaseKey}`);
+      const connectionId = createdConnection.data?.createOneRemoteServer.id;
+
+      navigate(
+        `${settingsIntegrationsPagePath}/${databaseKey}/${connectionId}`,
+      );
     } catch (error) {
       enqueueSnackBar((error as Error).message, {
         variant: 'error',

--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.service.ts
@@ -361,7 +361,7 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
       [
         createdObjectMetadata.id,
         'table',
-        `All ${createdObjectMetadata.namePlural}`,
+        `All ${createdObjectMetadata.labelPlural}`,
         'INDEX',
         createdObjectMetadata.icon,
       ],

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-server.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-server.service.ts
@@ -117,23 +117,32 @@ export class RemoteServerService<T extends RemoteServerType> {
       throw new NotFoundException('Object does not exist');
     }
 
-    const remoteTablesToRemove = (
-      await this.remoteTableService.findAvailableRemoteTablesByServerId(
-        id,
-        workspaceId,
-      )
-    ).filter((remoteTable) => remoteTable.status === RemoteTableStatus.SYNCED);
-
-    if (remoteTablesToRemove.length) {
-      for (const remoteTable of remoteTablesToRemove) {
-        await this.remoteTableService.unsyncRemoteTable(
-          {
-            remoteServerId: id,
-            name: remoteTable.name,
-          },
+    try {
+      const remoteTablesToRemove = (
+        await this.remoteTableService.findAvailableRemoteTablesByServerId(
+          id,
           workspaceId,
-        );
+        )
+      ).filter(
+        (remoteTable) => remoteTable.status === RemoteTableStatus.SYNCED,
+      );
+
+      if (remoteTablesToRemove.length) {
+        for (const remoteTable of remoteTablesToRemove) {
+          await this.remoteTableService.unsyncRemoteTable(
+            {
+              remoteServerId: id,
+              name: remoteTable.name,
+            },
+            workspaceId,
+          );
+        }
       }
+    } catch (error) {
+      console.error(
+        `Failed to retrieve tables while deleting server ${id}`,
+        error,
+      );
     }
 
     return this.metadataDataSource.transaction(

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-server.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-server.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
 
 import { v4 } from 'uuid';
@@ -21,6 +21,8 @@ import { RemoteTableStatus } from 'src/engine/metadata-modules/remote-server/rem
 
 @Injectable()
 export class RemoteServerService<T extends RemoteServerType> {
+  private readonly logger = new Logger(RemoteServerService.name);
+
   constructor(
     @InjectRepository(RemoteServerEntity, 'metadata')
     private readonly remoteServerRepository: Repository<
@@ -139,7 +141,7 @@ export class RemoteServerService<T extends RemoteServerType> {
         }
       }
     } catch (error) {
-      console.error(
+      this.logger.error(
         `Failed to retrieve tables while deleting server ${id}`,
         error,
       );

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/utils/get-remote-table-local-name.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/utils/get-remote-table-local-name.util.ts
@@ -1,4 +1,4 @@
 import { camelCase } from 'src/utils/camel-case';
 
-export const getRemoteTableName = (distantTableName: string) =>
+export const getRemoteTableLocalName = (distantTableName: string) =>
   `${camelCase(distantTableName)}Remote`;

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/utils/validate-remote-server-input.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/utils/validate-remote-server-input.ts
@@ -1,4 +1,4 @@
-const INPUT_REGEX = /^([A-Za-z0-9\-\_\.]+)$/;
+const INPUT_REGEX = /^([A-Za-z0-9\-_.@]+)$/;
 
 export const validateObject = (input: object) => {
   for (const [key, value] of Object.entries(input)) {

--- a/packages/twenty-server/src/engine/metadata-modules/workspace-migration/workspace-migration.entity.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/workspace-migration/workspace-migration.entity.ts
@@ -88,7 +88,7 @@ export enum WorkspaceMigrationTableActionType {
   ALTER = 'alter',
   DROP = 'drop',
   CREATE_FOREIGN_TABLE = 'create_foreign_table',
-  DROP_FOREIGN_TABLE = 'drop_foreign_table'
+  DROP_FOREIGN_TABLE = 'drop_foreign_table',
 }
 
 export type WorkspaceMigrationTableAction = {

--- a/packages/twenty-ui/src/display/chip/components/EntityChip.tsx
+++ b/packages/twenty-ui/src/display/chip/components/EntityChip.tsx
@@ -38,7 +38,6 @@ export const EntityChip = ({
   maxWidth,
 }: EntityChipProps) => {
   const navigate = useNavigate();
-
   const theme = useTheme();
 
   const handleLinkClick = (event: React.MouseEvent<HTMLDivElement>) => {


### PR DESCRIPTION
1/ When the user inputs wrong connection informations, we do not inform him. He will only see that no tables are available.
We will display a connection failed status if an error is raised testing the connection

2/ If the connection fails, it should still be possible to delete the server. Today, since we try first to delete the tables, the connection failure throws an error that will prevent server deletion. Using the foreign tables instead of calling the distant DB.

3/ Redirect to connection show page instead of connection list after creation

4/ Today, foreign tables are fetched without the server name. This is a mistake because we need to know which foreign table is linked with which server. Updating the associated query. 

<img width="632" alt="Capture d’écran 2024-04-12 à 10 52 49" src="https://github.com/twentyhq/twenty/assets/22936103/9e8406b8-75d0-494c-ac1f-5e9fa7100f5c">

