### PR TITLE
feat: add sourcemap generation for front

### DIFF
--- a/packages/twenty-front/package.json
+++ b/packages/twenty-front/package.json
@@ -8,6 +8,7 @@
     "start": "npx vite --host",
     "start:clean": "yarn start --force",
     "build": "yarn tsc && npx vite build && yarn build:inject-runtime-env",
+    "build:sourcemaps": "VITE_BUILD_SOURCEMAP=true NODE_OPTIONS=--max-old-space-size=3000 yarn build",
     "build:inject-runtime-env": "sh ./scripts/inject-runtime-env.sh",
     "tsc": "npx tsc --project tsconfig.app.json",
     "tsc:ci": "yarn tsc --project tsconfig.json",

--- a/packages/twenty-front/vite.config.ts
+++ b/packages/twenty-front/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig(({ command, mode }) => {
   /*
     Using explicit env variables, there is no need to expose all of them (security).
   */
-  const { REACT_APP_SERVER_BASE_URL, SENTRY_RELEASE, ENVIRONMENT } = env;
+  const { REACT_APP_SERVER_BASE_URL, VITE_BUILD_SOURCEMAP } = env;
 
   const isBuildCommand = command === 'build';
 
@@ -51,6 +51,7 @@ export default defineConfig(({ command, mode }) => {
 
     build: {
       outDir: 'build',
+      sourcemap: VITE_BUILD_SOURCEMAP === 'true',
     },
 
     envPrefix: 'REACT_APP_',
@@ -58,8 +59,6 @@ export default defineConfig(({ command, mode }) => {
     define: {
       'process.env': {
         REACT_APP_SERVER_BASE_URL,
-        SENTRY_RELEASE,
-        ENVIRONMENT,
       },
     },
   };


### PR DESCRIPTION
This PR changes the vite config to enable the generation of sourcemaps with the help of an Env.
It also adds a new script to run the build with the said env as well as more memory (the dafault 2go leads to an OOM)