### PR TITLE
fix: Auto Reset Opportunity Creation Search Field

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-board/record-board-column/components/RecordBoardColumnNewOpportunityButton.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/record-board-column/components/RecordBoardColumnNewOpportunityButton.tsx
@@ -7,6 +7,7 @@ import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSi
 import { RecordBoardContext } from '@/object-record/record-board/contexts/RecordBoardContext';
 import { RecordBoardColumnContext } from '@/object-record/record-board/record-board-column/contexts/RecordBoardColumnContext';
 import { SingleEntitySelect } from '@/object-record/relation-picker/components/SingleEntitySelect';
+import { useEntitySelectSearch } from '@/object-record/relation-picker/hooks/useEntitySelectSearch';
 import { EntityForSelect } from '@/object-record/relation-picker/types/EntityForSelect';
 import { RelationPickerHotkeyScope } from '@/object-record/relation-picker/types/RelationPickerHotkeyScope';
 import { usePreviousHotkeyScope } from '@/ui/utilities/hotkey/hooks/usePreviousHotkeyScope';
@@ -41,9 +42,14 @@ export const RecordBoardColumnNewOpportunityButton = () => {
     setHotkeyScopeAndMemorizePreviousScope,
   } = usePreviousHotkeyScope();
 
+  const { resetSearchFilterChange } = useEntitySelectSearch({
+    relationPickerScopeId: 'relation-picker',
+  });
+
   const handleEntitySelect = (company?: EntityForSelect) => {
     setIsCreatingCard(false);
     goBackToPreviousHotkeyScope();
+    resetSearchFilterChange();
 
     if (!company) {
       return;
@@ -65,6 +71,7 @@ export const RecordBoardColumnNewOpportunityButton = () => {
   }, [setIsCreatingCard, setHotkeyScopeAndMemorizePreviousScope]);
 
   const handleCancel = () => {
+    resetSearchFilterChange();
     goBackToPreviousHotkeyScope();
     setIsCreatingCard(false);
   };
@@ -79,7 +86,6 @@ export const RecordBoardColumnNewOpportunityButton = () => {
           relationObjectNameSingular={CoreObjectNameSingular.Company}
           relationPickerScopeId="relation-picker"
           selectedRelationRecordIds={[]}
-          clearOnOpen={true}
         />
       ) : (
         <StyledButton onClick={handleNewClick}>

--- a/packages/twenty-front/src/modules/object-record/record-board/record-board-column/components/RecordBoardColumnNewOpportunityButton.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/record-board-column/components/RecordBoardColumnNewOpportunityButton.tsx
@@ -42,14 +42,14 @@ export const RecordBoardColumnNewOpportunityButton = () => {
     setHotkeyScopeAndMemorizePreviousScope,
   } = usePreviousHotkeyScope();
 
-  const { resetSearchFilterChange } = useEntitySelectSearch({
+  const { resetSearchFilter } = useEntitySelectSearch({
     relationPickerScopeId: 'relation-picker',
   });
 
   const handleEntitySelect = (company?: EntityForSelect) => {
     setIsCreatingCard(false);
     goBackToPreviousHotkeyScope();
-    resetSearchFilterChange();
+    resetSearchFilter();
 
     if (!company) {
       return;
@@ -71,7 +71,7 @@ export const RecordBoardColumnNewOpportunityButton = () => {
   }, [setIsCreatingCard, setHotkeyScopeAndMemorizePreviousScope]);
 
   const handleCancel = () => {
-    resetSearchFilterChange();
+    resetSearchFilter();
     goBackToPreviousHotkeyScope();
     setIsCreatingCard(false);
   };

--- a/packages/twenty-front/src/modules/object-record/record-board/record-board-column/components/RecordBoardColumnNewOpportunityButton.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/record-board-column/components/RecordBoardColumnNewOpportunityButton.tsx
@@ -79,6 +79,7 @@ export const RecordBoardColumnNewOpportunityButton = () => {
           relationObjectNameSingular={CoreObjectNameSingular.Company}
           relationPickerScopeId="relation-picker"
           selectedRelationRecordIds={[]}
+          clearOnOpen={true}
         />
       ) : (
         <StyledButton onClick={handleNewClick}>

--- a/packages/twenty-front/src/modules/object-record/relation-picker/components/SingleEntitySelect.tsx
+++ b/packages/twenty-front/src/modules/object-record/relation-picker/components/SingleEntitySelect.tsx
@@ -26,6 +26,7 @@ export const SingleEntitySelect = ({
   selectedEntity,
   selectedRelationRecordIds,
   width = 200,
+  clearOnOpen,
 }: SingleEntitySelectProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -63,6 +64,7 @@ export const SingleEntitySelect = ({
           relationPickerScopeId,
           selectedEntity,
           selectedRelationRecordIds,
+          clearOnOpen,
         }}
       />
     </DropdownMenu>

--- a/packages/twenty-front/src/modules/object-record/relation-picker/components/SingleEntitySelect.tsx
+++ b/packages/twenty-front/src/modules/object-record/relation-picker/components/SingleEntitySelect.tsx
@@ -26,7 +26,6 @@ export const SingleEntitySelect = ({
   selectedEntity,
   selectedRelationRecordIds,
   width = 200,
-  clearOnOpen,
 }: SingleEntitySelectProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -64,7 +63,6 @@ export const SingleEntitySelect = ({
           relationPickerScopeId,
           selectedEntity,
           selectedRelationRecordIds,
-          clearOnOpen,
         }}
       />
     </DropdownMenu>

--- a/packages/twenty-front/src/modules/object-record/relation-picker/components/SingleEntitySelectMenuItemsWithSearch.tsx
+++ b/packages/twenty-front/src/modules/object-record/relation-picker/components/SingleEntitySelectMenuItemsWithSearch.tsx
@@ -1,8 +1,11 @@
+import { useRecoilValue } from 'recoil';
+
 import { ObjectMetadataItemsRelationPickerEffect } from '@/object-metadata/components/ObjectMetadataItemsRelationPickerEffect';
 import {
   SingleEntitySelectMenuItems,
   SingleEntitySelectMenuItemsProps,
 } from '@/object-record/relation-picker/components/SingleEntitySelectMenuItems';
+import { useRelationPickerScopedStates } from '@/object-record/relation-picker/hooks/internal/useRelationPickerScopedStates';
 import { useFilteredSearchEntityQuery } from '@/search/hooks/useFilteredSearchEntityQuery';
 import { DropdownMenuSearchInput } from '@/ui/layout/dropdown/components/DropdownMenuSearchInput';
 import { DropdownMenuSeparator } from '@/ui/layout/dropdown/components/DropdownMenuSeparator';
@@ -37,19 +40,29 @@ export const SingleEntitySelectMenuItemsWithSearch = ({
   selectedEntity,
   selectedRelationRecordIds,
 }: SingleEntitySelectMenuItemsWithSearchProps) => {
-  const { searchFilter, searchQuery, handleSearchFilterChange } =
-    useEntitySelectSearch({
-      relationPickerScopeId,
+  const { handleSearchFilterChange } = useEntitySelectSearch({
+    relationPickerScopeId,
+  });
+
+  const { searchQueryState, relationPickerSearchFilterState } =
+    useRelationPickerScopedStates({
+      relationPickerScopedId: relationPickerScopeId,
     });
 
-  const showCreateButton = isDefined(onCreate) && searchFilter !== '';
+  const searchQuery = useRecoilValue(searchQueryState);
+  const relationPickerSearchFilter = useRecoilValue(
+    relationPickerSearchFilterState,
+  );
+
+  const showCreateButton =
+    isDefined(onCreate) && relationPickerSearchFilter !== '';
 
   const entities = useFilteredSearchEntityQuery({
     filters: [
       {
         fieldNames:
           searchQuery?.computeFilterFields?.(relationObjectNameSingular) ?? [],
-        filter: searchFilter,
+        filter: relationPickerSearchFilter,
       },
     ],
     orderByField: 'createdAt',
@@ -63,11 +76,7 @@ export const SingleEntitySelectMenuItemsWithSearch = ({
       <ObjectMetadataItemsRelationPickerEffect
         relationPickerScopeId={relationPickerScopeId}
       />
-      <DropdownMenuSearchInput
-        value={searchFilter}
-        onChange={handleSearchFilterChange}
-        autoFocus
-      />
+      <DropdownMenuSearchInput onChange={handleSearchFilterChange} autoFocus />
       <DropdownMenuSeparator />
       <SingleEntitySelectMenuItems
         entitiesToSelect={entities.entitiesToSelect}

--- a/packages/twenty-front/src/modules/object-record/relation-picker/components/SingleEntitySelectMenuItemsWithSearch.tsx
+++ b/packages/twenty-front/src/modules/object-record/relation-picker/components/SingleEntitySelectMenuItemsWithSearch.tsx
@@ -1,5 +1,3 @@
-import { useEffect } from 'react';
-
 import { ObjectMetadataItemsRelationPickerEffect } from '@/object-metadata/components/ObjectMetadataItemsRelationPickerEffect';
 import {
   SingleEntitySelectMenuItems,
@@ -18,7 +16,6 @@ export type SingleEntitySelectMenuItemsWithSearchProps = {
   relationObjectNameSingular: string;
   relationPickerScopeId?: string;
   selectedRelationRecordIds: string[];
-  clearOnOpen?: boolean;
 } & Pick<
   SingleEntitySelectMenuItemsProps,
   | 'EmptyIcon'
@@ -39,24 +36,11 @@ export const SingleEntitySelectMenuItemsWithSearch = ({
   relationPickerScopeId = 'relation-picker',
   selectedEntity,
   selectedRelationRecordIds,
-  clearOnOpen = false,
 }: SingleEntitySelectMenuItemsWithSearchProps) => {
-  const {
-    searchFilter,
-    searchQuery,
-    handleSearchFilterChange,
-    resetSearchFilterChange,
-  } = useEntitySelectSearch({
-    relationPickerScopeId,
-  });
-
-  useEffect(() => {
-    if (clearOnOpen) {
-      resetSearchFilterChange();
-    }
-    // We only want to clear the search filter when the dropdown is opened
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  const { searchFilter, searchQuery, handleSearchFilterChange } =
+    useEntitySelectSearch({
+      relationPickerScopeId,
+    });
 
   const showCreateButton = isDefined(onCreate) && searchFilter !== '';
 

--- a/packages/twenty-front/src/modules/object-record/relation-picker/components/SingleEntitySelectMenuItemsWithSearch.tsx
+++ b/packages/twenty-front/src/modules/object-record/relation-picker/components/SingleEntitySelectMenuItemsWithSearch.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+
 import { ObjectMetadataItemsRelationPickerEffect } from '@/object-metadata/components/ObjectMetadataItemsRelationPickerEffect';
 import {
   SingleEntitySelectMenuItems,
@@ -16,6 +18,7 @@ export type SingleEntitySelectMenuItemsWithSearchProps = {
   relationObjectNameSingular: string;
   relationPickerScopeId?: string;
   selectedRelationRecordIds: string[];
+  clearOnOpen?: boolean;
 } & Pick<
   SingleEntitySelectMenuItemsProps,
   | 'EmptyIcon'
@@ -36,11 +39,24 @@ export const SingleEntitySelectMenuItemsWithSearch = ({
   relationPickerScopeId = 'relation-picker',
   selectedEntity,
   selectedRelationRecordIds,
+  clearOnOpen = false,
 }: SingleEntitySelectMenuItemsWithSearchProps) => {
-  const { searchFilter, searchQuery, handleSearchFilterChange } =
-    useEntitySelectSearch({
-      relationPickerScopeId,
-    });
+  const {
+    searchFilter,
+    searchQuery,
+    handleSearchFilterChange,
+    resetSearchFilterChange,
+  } = useEntitySelectSearch({
+    relationPickerScopeId,
+  });
+
+  useEffect(() => {
+    if (clearOnOpen) {
+      resetSearchFilterChange();
+    }
+    // We only want to clear the search filter when the dropdown is opened
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const showCreateButton = isDefined(onCreate) && searchFilter !== '';
 

--- a/packages/twenty-front/src/modules/object-record/relation-picker/hooks/useEntitySelectSearch.ts
+++ b/packages/twenty-front/src/modules/object-record/relation-picker/hooks/useEntitySelectSearch.ts
@@ -7,12 +7,8 @@ export const useEntitySelectSearch = ({
 }: {
   relationPickerScopeId?: string;
 } = {}) => {
-  const {
-    relationPickerSearchFilter,
-    searchQuery,
-    setRelationPickerPreselectedId,
-    setRelationPickerSearchFilter,
-  } = useRelationPicker({ relationPickerScopeId });
+  const { setRelationPickerSearchFilter, setRelationPickerPreselectedId } =
+    useRelationPicker({ relationPickerScopeId });
 
   const debouncedSetSearchFilter = useDebouncedCallback(
     setRelationPickerSearchFilter,
@@ -22,7 +18,7 @@ export const useEntitySelectSearch = ({
     },
   );
 
-  const resetSearchFilterChange = () => {
+  const resetSearchFilter = () => {
     debouncedSetSearchFilter('');
     setRelationPickerPreselectedId('');
   };
@@ -35,9 +31,7 @@ export const useEntitySelectSearch = ({
   };
 
   return {
-    searchFilter: relationPickerSearchFilter,
-    searchQuery,
     handleSearchFilterChange,
-    resetSearchFilterChange,
+    resetSearchFilter,
   };
 };

--- a/packages/twenty-front/src/modules/object-record/relation-picker/hooks/useEntitySelectSearch.ts
+++ b/packages/twenty-front/src/modules/object-record/relation-picker/hooks/useEntitySelectSearch.ts
@@ -22,6 +22,11 @@ export const useEntitySelectSearch = ({
     },
   );
 
+  const resetSearchFilterChange = () => {
+    debouncedSetSearchFilter('');
+    setRelationPickerPreselectedId('');
+  };
+
   const handleSearchFilterChange = (
     event: React.ChangeEvent<HTMLInputElement>,
   ) => {
@@ -33,5 +38,6 @@ export const useEntitySelectSearch = ({
     searchFilter: relationPickerSearchFilter,
     searchQuery,
     handleSearchFilterChange,
+    resetSearchFilterChange,
   };
 };

--- a/packages/twenty-front/src/modules/object-record/relation-picker/hooks/useRelationPicker.ts
+++ b/packages/twenty-front/src/modules/object-record/relation-picker/hooks/useRelationPicker.ts
@@ -1,4 +1,4 @@
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useSetRecoilState } from 'recoil';
 
 import { useRelationPickerScopedStates } from '@/object-record/relation-picker/hooks/internal/useRelationPickerScopedStates';
 import { RelationPickerScopeInternalContext } from '@/object-record/relation-picker/scopes/scope-internal-context/RelationPickerScopeInternalContext';
@@ -22,19 +22,18 @@ export const useRelationPicker = (props?: useRelationPickeProps) => {
     relationPickerScopedId: scopeId,
   });
 
-  const [searchQuery, setSearchQuery] = useRecoilState(searchQueryState);
+  const setSearchQuery = useSetRecoilState(searchQueryState);
 
-  const [relationPickerSearchFilter, setRelationPickerSearchFilter] =
-    useRecoilState(relationPickerSearchFilterState);
+  const setRelationPickerSearchFilter = useSetRecoilState(
+    relationPickerSearchFilterState,
+  );
 
   const [relationPickerPreselectedId, setRelationPickerPreselectedId] =
     useRecoilState(relationPickerPreselectedIdState);
 
   return {
     scopeId,
-    searchQuery,
     setSearchQuery,
-    relationPickerSearchFilter,
     setRelationPickerSearchFilter,
     relationPickerPreselectedId,
     setRelationPickerPreselectedId,


### PR DESCRIPTION
## Description

In the previous implementation, we saved the user's search field input. However, I have introduced a new prop called `clearOnOpen`, which allows us to reset the search field upon loading.

Closes: #4923 


https://github.com/twentyhq/twenty/assets/95065270/dd2cab30-ea47-444e-b356-d5c98087bcc6
