### PR TITLE
Fix duplicate imports by VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -39,12 +39,6 @@
     "twentyhq"
   ],
   "typescript.preferences.importModuleSpecifier": "non-relative",
-  "[javascript][typescript][typescriptreact]": {
-    "editor.codeActionsOnSave": {
-      "source.fixAll.eslint": "explicit",
-      "source.addMissingImports": "always"
-    }
-  },
   "search.exclude": {
     "**/.yarn": true,
   },


### PR DESCRIPTION
Fixes  #3819
This was annoying. 
It was caused by a duplicate rule in VS Code config.