### PR TITLE
Fix Never api key expiration dates

### DIFF
--- a/packages/twenty-front/src/modules/settings/developers/constants/ExpirationDates.ts
+++ b/packages/twenty-front/src/modules/settings/developers/constants/ExpirationDates.ts
@@ -1,3 +1,5 @@
+import { NEVER_EXPIRE_DELTA_IN_YEARS } from '@/settings/developers/constants/NeverExpireDeltaInYears.ts';
+
 export const EXPIRATION_DATES: {
   value: number | null;
   label: string;
@@ -7,5 +9,5 @@ export const EXPIRATION_DATES: {
   { label: '90 days', value: 90 },
   { label: '1 year', value: 365 },
   { label: '2 years', value: 2 * 365 },
-  { label: 'Never', value: null },
+  { label: 'Never', value: NEVER_EXPIRE_DELTA_IN_YEARS * 365 },
 ];

--- a/packages/twenty-front/src/modules/settings/developers/constants/NeverExpireDeltaInYears.ts
+++ b/packages/twenty-front/src/modules/settings/developers/constants/NeverExpireDeltaInYears.ts
@@ -1,0 +1,1 @@
+export const NEVER_EXPIRE_DELTA_IN_YEARS = 100;

--- a/packages/twenty-front/src/modules/settings/developers/utils/__tests__/format-expiration.test.ts
+++ b/packages/twenty-front/src/modules/settings/developers/utils/__tests__/format-expiration.test.ts
@@ -18,17 +18,17 @@ describe('formatExpiration', () => {
     expect(resultWithExpiresMention).toEqual('Expires in 9 days');
   });
   it('should format properly when expiresAt is large', () => {
-    const expiresAt = '2034-01-10T00:00:00.000Z';
+    const expiresAt = '2032-01-10T00:00:00.000Z';
     const result = formatExpiration(expiresAt);
-    expect(result).toEqual('In 10 years');
+    expect(result).toEqual('In 8 years');
     const resultWithExpiresMention = formatExpiration(expiresAt, true);
-    expect(resultWithExpiresMention).toEqual('Expires in 10 years');
+    expect(resultWithExpiresMention).toEqual('Expires in 8 years');
   });
   it('should format properly when expiresAt is large and long version', () => {
-    const expiresAt = '2034-01-10T00:00:00.000Z';
+    const expiresAt = '2032-01-10T00:00:00.000Z';
     const result = formatExpiration(expiresAt, undefined, false);
-    expect(result).toEqual('In 10 years and 9 days');
+    expect(result).toEqual('In 8 years and 9 days');
     const resultWithExpiresMention = formatExpiration(expiresAt, true, false);
-    expect(resultWithExpiresMention).toEqual('Expires in 10 years and 9 days');
+    expect(resultWithExpiresMention).toEqual('Expires in 8 years and 9 days');
   });
 });

--- a/packages/twenty-front/src/modules/settings/developers/utils/__tests__/format-expiration.test.ts
+++ b/packages/twenty-front/src/modules/settings/developers/utils/__tests__/format-expiration.test.ts
@@ -3,6 +3,13 @@ import { formatExpiration } from '@/settings/developers/utils/format-expiration'
 jest.useFakeTimers().setSystemTime(new Date('2024-01-01T00:00:00.000Z'));
 
 describe('formatExpiration', () => {
+  it('should format properly when expiresAt is great', () => {
+    const expiresAt = '2044-01-10T00:00:00.000Z';
+    const result = formatExpiration(expiresAt);
+    expect(result).toEqual('Never');
+    const resultWithExpiresMention = formatExpiration(expiresAt, true);
+    expect(resultWithExpiresMention).toEqual('Never expires');
+  });
   it('should format properly when expiresAt is null', () => {
     const expiresAt = null;
     const result = formatExpiration(expiresAt);

--- a/packages/twenty-front/src/modules/settings/developers/utils/format-expiration.ts
+++ b/packages/twenty-front/src/modules/settings/developers/utils/format-expiration.ts
@@ -11,6 +11,9 @@ export const formatExpiration = (
 ) => {
   if (isNonEmptyString(expiresAt)) {
     const dateDiff = beautifyDateDiff(expiresAt, undefined, short);
+    if (dateDiff === '+∞') {
+      return withExpiresMention ? 'Never expires' : 'Never';
+    }
     if (dateDiff.includes('-')) {
       return 'Expired';
     }

--- a/packages/twenty-front/src/modules/settings/developers/utils/format-expiration.ts
+++ b/packages/twenty-front/src/modules/settings/developers/utils/format-expiration.ts
@@ -1,25 +1,32 @@
 import { isNonEmptyString } from '@sniptt/guards';
+import { DateTime } from 'luxon';
 
+import { NEVER_EXPIRE_DELTA_IN_YEARS } from '@/settings/developers/constants/NeverExpireDeltaInYears.ts';
 import { ApiFieldItem } from '@/settings/developers/types/api-key/ApiFieldItem';
 import { ApiKey } from '@/settings/developers/types/api-key/ApiKey';
 import { beautifyDateDiff } from '~/utils/date-utils';
+
+export const doesNeverExpire = (expiresAt: string) => {
+  const dateDiff = DateTime.fromISO(expiresAt).diff(DateTime.now(), [
+    'years',
+    'days',
+  ]);
+  return dateDiff.years > NEVER_EXPIRE_DELTA_IN_YEARS / 10;
+};
 
 export const formatExpiration = (
   expiresAt: string | null,
   withExpiresMention = false,
   short = true,
 ) => {
-  if (isNonEmptyString(expiresAt)) {
-    const dateDiff = beautifyDateDiff(expiresAt, undefined, short);
-    if (dateDiff === '+∞') {
-      return withExpiresMention ? 'Never expires' : 'Never';
-    }
-    if (dateDiff.includes('-')) {
-      return 'Expired';
-    }
-    return withExpiresMention ? `Expires in ${dateDiff}` : `In ${dateDiff}`;
+  if (!isNonEmptyString(expiresAt) || doesNeverExpire(expiresAt)) {
+    return withExpiresMention ? 'Never expires' : 'Never';
   }
-  return withExpiresMention ? 'Never expires' : 'Never';
+  const dateDiff = beautifyDateDiff(expiresAt, undefined, short);
+  if (dateDiff.includes('-')) {
+    return 'Expired';
+  }
+  return withExpiresMention ? `Expires in ${dateDiff}` : `In ${dateDiff}`;
 };
 
 export const formatExpirations = (

--- a/packages/twenty-front/src/pages/settings/developers/api-keys/SettingsDevelopersApiKeysNew.tsx
+++ b/packages/twenty-front/src/pages/settings/developers/api-keys/SettingsDevelopersApiKeysNew.tsx
@@ -40,6 +40,7 @@ export const SettingsDevelopersApiKeysNew = () => {
     const expiresAt = DateTime.now()
       .plus({ days: formValues.expirationDate ?? 30 })
       .toString();
+
     const newApiKey = await createOneApiKey?.({
       name: formValues.name,
       expiresAt,

--- a/packages/twenty-front/src/utils/__tests__/date-utils.test.ts
+++ b/packages/twenty-front/src/utils/__tests__/date-utils.test.ts
@@ -241,12 +241,6 @@ describe('hasDatePassed', () => {
 });
 
 describe('beautifyDateDiff', () => {
-  it('should return the correct date diff for Never expiration date', () => {
-    const date = '2123-11-05T00:00:00.000Z';
-    const dateToCompareWith = '2023-11-01T00:00:00.000Z';
-    const result = beautifyDateDiff(date, dateToCompareWith);
-    expect(result).toEqual('+∞');
-  });
   it('should return the correct date diff', () => {
     const date = '2023-11-05T00:00:00.000Z';
     const dateToCompareWith = '2023-11-01T00:00:00.000Z';

--- a/packages/twenty-front/src/utils/__tests__/date-utils.test.ts
+++ b/packages/twenty-front/src/utils/__tests__/date-utils.test.ts
@@ -254,10 +254,10 @@ describe('beautifyDateDiff', () => {
     expect(result).toEqual('4 days');
   });
   it('should return the correct date diff for large diff', () => {
-    const date = '2033-11-05T00:00:00.000Z';
+    const date = '2031-11-05T00:00:00.000Z';
     const dateToCompareWith = '2023-11-01T00:00:00.000Z';
     const result = beautifyDateDiff(date, dateToCompareWith);
-    expect(result).toEqual('10 years and 4 days');
+    expect(result).toEqual('8 years and 4 days');
   });
   it('should return the correct date for negative diff', () => {
     const date = '2013-11-05T00:00:00.000Z';
@@ -266,10 +266,10 @@ describe('beautifyDateDiff', () => {
     expect(result).toEqual('-9 years and -361 days');
   });
   it('should return the correct date diff for large diff', () => {
-    const date = '2033-11-01T00:00:00.000Z';
+    const date = '2031-11-01T00:00:00.000Z';
     const dateToCompareWith = '2023-11-01T00:00:00.000Z';
     const result = beautifyDateDiff(date, dateToCompareWith);
-    expect(result).toEqual('10 years');
+    expect(result).toEqual('8 years');
   });
   it('should return the proper english date diff', () => {
     const date = '2024-11-02T00:00:00.000Z';
@@ -289,10 +289,10 @@ describe('beautifyDateDiff', () => {
     expect(result).toEqual('3 years and 9 days');
   });
   it('should return short version', () => {
-    const date = '2033-11-05T00:00:00.000Z';
+    const date = '2031-11-05T00:00:00.000Z';
     const dateToCompareWith = '2023-11-01T00:00:00.000Z';
     const result = beautifyDateDiff(date, dateToCompareWith, true);
-    expect(result).toEqual('10 years');
+    expect(result).toEqual('8 years');
   });
   it('should return short version for short differences', () => {
     const date = '2023-11-05T00:00:00.000Z';

--- a/packages/twenty-front/src/utils/__tests__/date-utils.test.ts
+++ b/packages/twenty-front/src/utils/__tests__/date-utils.test.ts
@@ -241,6 +241,12 @@ describe('hasDatePassed', () => {
 });
 
 describe('beautifyDateDiff', () => {
+  it('should return the correct date diff for Never expiration date', () => {
+    const date = '2123-11-05T00:00:00.000Z';
+    const dateToCompareWith = '2023-11-01T00:00:00.000Z';
+    const result = beautifyDateDiff(date, dateToCompareWith);
+    expect(result).toEqual('+∞');
+  });
   it('should return the correct date diff', () => {
     const date = '2023-11-05T00:00:00.000Z';
     const dateToCompareWith = '2023-11-01T00:00:00.000Z';

--- a/packages/twenty-front/src/utils/date-utils.ts
+++ b/packages/twenty-front/src/utils/date-utils.ts
@@ -3,8 +3,6 @@ import { isDate, isNumber, isString } from '@sniptt/guards';
 import { differenceInCalendarDays, formatDistanceToNow } from 'date-fns';
 import { DateTime } from 'luxon';
 
-import { NEVER_EXPIRE_DELTA_IN_YEARS } from '@/settings/developers/constants/NeverExpireDeltaInYears.ts';
-
 import { logError } from './logError';
 
 export const DEFAULT_DATE_LOCALE = 'en-EN';
@@ -119,15 +117,12 @@ export const beautifyDateDiff = (
   date: string,
   dateToCompareWith?: string,
   short = false,
-  infiniteDiffTriggerInYears = NEVER_EXPIRE_DELTA_IN_YEARS / 10,
 ) => {
   const dateDiff = DateTime.fromISO(date).diff(
     dateToCompareWith ? DateTime.fromISO(dateToCompareWith) : DateTime.now(),
     ['years', 'days'],
   );
   let result = '';
-  if (dateDiff.years && dateDiff.years >= infiniteDiffTriggerInYears)
-    return '+∞';
   if (dateDiff.years) result = result + `${dateDiff.years} year`;
   if (![0, 1].includes(dateDiff.years)) result = result + 's';
   if (short && dateDiff.years) return result;

--- a/packages/twenty-front/src/utils/date-utils.ts
+++ b/packages/twenty-front/src/utils/date-utils.ts
@@ -3,6 +3,8 @@ import { isDate, isNumber, isString } from '@sniptt/guards';
 import { differenceInCalendarDays, formatDistanceToNow } from 'date-fns';
 import { DateTime } from 'luxon';
 
+import { NEVER_EXPIRE_DELTA_IN_YEARS } from '@/settings/developers/constants/NeverExpireDeltaInYears.ts';
+
 import { logError } from './logError';
 
 export const DEFAULT_DATE_LOCALE = 'en-EN';
@@ -117,12 +119,15 @@ export const beautifyDateDiff = (
   date: string,
   dateToCompareWith?: string,
   short = false,
+  infiniteDiffTriggerInYears = NEVER_EXPIRE_DELTA_IN_YEARS / 10,
 ) => {
   const dateDiff = DateTime.fromISO(date).diff(
     dateToCompareWith ? DateTime.fromISO(dateToCompareWith) : DateTime.now(),
     ['years', 'days'],
   );
   let result = '';
+  if (dateDiff.years && dateDiff.years >= infiniteDiffTriggerInYears)
+    return '+∞';
   if (dateDiff.years) result = result + `${dateDiff.years} year`;
   if (![0, 1].includes(dateDiff.years)) result = result + 's';
   if (short && dateDiff.years) return result;


### PR DESCRIPTION
closes #4714 

We cannot set null expiration dates for api keys. So we will set to 100 years instead of null. If apiKey expires in more that 10 years, it is displayed as "Never expires"