### PR TITLE
fix: Display hidden columns and separator conditionally

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableHeaderPlusButtonContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableHeaderPlusButtonContent.tsx
@@ -38,7 +38,7 @@ export const RecordTableHeaderPlusButtonContent = () => {
 
   return (
     <>
-      {hiddenTableColumns.length > 0 ? (
+      {hiddenTableColumns.length > 0 && (
         <>
           <DropdownMenuItemsContainer>
             {hiddenTableColumns.map((column) => (
@@ -52,7 +52,7 @@ export const RecordTableHeaderPlusButtonContent = () => {
           </DropdownMenuItemsContainer>
           <DropdownMenuSeparator />
         </>
-      ) : null}
+      )}
       <DropdownMenuItemsContainer>
         <StyledMenuItemLink to="/settings/objects">
           <MenuItem LeftIcon={IconSettings} text="Customize fields" />

--- a/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableHeaderPlusButtonContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableHeaderPlusButtonContent.tsx
@@ -38,17 +38,21 @@ export const RecordTableHeaderPlusButtonContent = () => {
 
   return (
     <>
-      <DropdownMenuItemsContainer>
-        {hiddenTableColumns.map((column) => (
-          <MenuItem
-            key={column.fieldMetadataId}
-            onClick={() => handleAddColumn(column)}
-            LeftIcon={getIcon(column.iconName)}
-            text={column.label}
-          />
-        ))}
-      </DropdownMenuItemsContainer>
-      <DropdownMenuSeparator />
+      {hiddenTableColumns.length > 0 ? (
+        <>
+          <DropdownMenuItemsContainer>
+            {hiddenTableColumns.map((column) => (
+              <MenuItem
+                key={column.fieldMetadataId}
+                onClick={() => handleAddColumn(column)}
+                LeftIcon={getIcon(column.iconName)}
+                text={column.label}
+              />
+            ))}
+          </DropdownMenuItemsContainer>
+          <DropdownMenuSeparator />
+        </>
+      ) : null}
       <DropdownMenuItemsContainer>
         <StyledMenuItemLink to="/settings/objects">
           <MenuItem LeftIcon={IconSettings} text="Customize fields" />


### PR DESCRIPTION
Closes #4979 

Hi! `RecordTableHeaderPlusButtonContent.tsx` component displays hidden columns and separator, only if length of `hiddenTableColumns` array is greater than zero.

The top right corner looked good.
![add-field1](https://github.com/twentyhq/twenty/assets/41576384/0b75ce42-d524-42ba-a76d-66c3d15d523e)
![add-field2](https://github.com/twentyhq/twenty/assets/41576384/44cf3910-2f99-4e99-8130-5cafa58c5828)
