### PR TITLE
[calendar] enabled calendar scope if feature flag enabled

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/auth/guards/google-apis-provider-enabled.guard.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/guards/google-apis-provider-enabled.guard.ts
@@ -1,15 +1,32 @@
-import { Injectable, CanActivate, NotFoundException } from '@nestjs/common';
+import {
+  Injectable,
+  CanActivate,
+  NotFoundException,
+  ExecutionContext,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
 
-import { Observable } from 'rxjs';
+import { Repository } from 'typeorm';
 
+import { TokenService } from 'src/engine/core-modules/auth/services/token.service';
 import { GoogleAPIsStrategy } from 'src/engine/core-modules/auth/strategies/google-apis.auth.strategy';
+import {
+  FeatureFlagEntity,
+  FeatureFlagKeys,
+} from 'src/engine/core-modules/feature-flag/feature-flag.entity';
 import { EnvironmentService } from 'src/engine/integrations/environment/environment.service';
+import { getRequest } from 'src/utils/extract-request';
 
 @Injectable()
 export class GoogleAPIsProviderEnabledGuard implements CanActivate {
-  constructor(private readonly environmentService: EnvironmentService) {}
+  constructor(
+    private readonly environmentService: EnvironmentService,
+    private readonly tokenService: TokenService,
+    @InjectRepository(FeatureFlagEntity, 'core')
+    private readonly featureFlagRepository: Repository<FeatureFlagEntity>,
+  ) {}
 
-  canActivate(): boolean | Promise<boolean> | Observable<boolean> {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
     if (
       !this.environmentService.get('MESSAGING_PROVIDER_GMAIL_ENABLED') &&
       !this.environmentService.get('CALENDAR_PROVIDER_GOOGLE_ENABLED')
@@ -17,7 +34,21 @@ export class GoogleAPIsProviderEnabledGuard implements CanActivate {
       throw new NotFoundException('Google apis auth is not enabled');
     }
 
-    new GoogleAPIsStrategy(this.environmentService);
+    const { workspaceId } = await this.tokenService.verifyTransientToken(
+      getRequest(context)?.query?.transientToken ?? '',
+    );
+
+    const isCalendarEnabledFlag = await this.featureFlagRepository.findOneBy({
+      workspaceId,
+      key: FeatureFlagKeys.IsCalendarEnabled,
+      value: true,
+    });
+
+    const isCalendarEnabled = !!isCalendarEnabledFlag?.value;
+
+    new GoogleAPIsStrategy(this.environmentService, {
+      isCalendarEnabled,
+    });
 
     return true;
   }

--- a/packages/twenty-server/src/engine/core-modules/auth/strategies/google-apis.auth.strategy.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/strategies/google-apis.auth.strategy.ts
@@ -1,8 +1,6 @@
 import { PassportStrategy } from '@nestjs/passport';
 import { Injectable } from '@nestjs/common';
 
-import console from 'console';
-
 import { Strategy, VerifyCallback } from 'passport-google-oauth20';
 import { Request } from 'express';
 
@@ -47,8 +45,6 @@ export class GoogleAPIsStrategy extends PassportStrategy(
     ) {
       scope.push('https://www.googleapis.com/auth/calendar.events');
     }
-
-    console.log(scopeConfig?.isCalendarEnabled);
 
     super({
       clientID: environmentService.get('AUTH_GOOGLE_CLIENT_ID'),

--- a/packages/twenty-server/src/engine/core-modules/auth/strategies/google-apis.auth.strategy.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/strategies/google-apis.auth.strategy.ts
@@ -1,6 +1,8 @@
 import { PassportStrategy } from '@nestjs/passport';
 import { Injectable } from '@nestjs/common';
 
+import console from 'console';
+
 import { Strategy, VerifyCallback } from 'passport-google-oauth20';
 import { Request } from 'express';
 
@@ -27,16 +29,26 @@ export class GoogleAPIsStrategy extends PassportStrategy(
   Strategy,
   'google-apis',
 ) {
-  constructor(environmentService: EnvironmentService) {
+  constructor(
+    environmentService: EnvironmentService,
+    scopeConfig: {
+      isCalendarEnabled?: boolean;
+    },
+  ) {
     const scope = ['email', 'profile'];
 
     if (environmentService.get('MESSAGING_PROVIDER_GMAIL_ENABLED')) {
       scope.push('https://www.googleapis.com/auth/gmail.readonly');
     }
 
-    if (environmentService.get('CALENDAR_PROVIDER_GOOGLE_ENABLED')) {
+    if (
+      environmentService.get('CALENDAR_PROVIDER_GOOGLE_ENABLED') &&
+      scopeConfig?.isCalendarEnabled
+    ) {
       scope.push('https://www.googleapis.com/auth/calendar.events');
     }
+
+    console.log(scopeConfig?.isCalendarEnabled);
 
     super({
       clientID: environmentService.get('AUTH_GOOGLE_CLIENT_ID'),


### PR DESCRIPTION
## Context
Currently the calendar scope is bound to an env variable. We want to rollout this feature to some users so this PR adds a check on the existing IS_CALENDAR_ENABLED flag

