### PR TITLE
[calendar/messaging] fix google refresh token transaction

### DIFF
--- a/packages/twenty-server/src/modules/messaging/jobs/gmail-full-sync.job.ts
+++ b/packages/twenty-server/src/modules/messaging/jobs/gmail-full-sync.job.ts
@@ -20,7 +20,6 @@ export class GmailFullSyncJob implements MessageQueueJob<GmailFullSyncJobData> {
   ) {}
 
   async handle(data: GmailFullSyncJobData): Promise<void> {
-    console.log(data);
     this.logger.log(
       `gmail full-sync for workspace ${data.workspaceId} and account ${data.connectedAccountId}`,
     );

--- a/packages/twenty-server/src/modules/messaging/jobs/gmail-full-sync.job.ts
+++ b/packages/twenty-server/src/modules/messaging/jobs/gmail-full-sync.job.ts
@@ -20,6 +20,7 @@ export class GmailFullSyncJob implements MessageQueueJob<GmailFullSyncJobData> {
   ) {}
 
   async handle(data: GmailFullSyncJobData): Promise<void> {
+    console.log(data);
     this.logger.log(
       `gmail full-sync for workspace ${data.workspaceId} and account ${data.connectedAccountId}`,
     );


### PR DESCRIPTION
## Context
The full-sync job was enqueued within a transaction, which means it could be executed before the transaction was commit and connected-account was not created yet.
This PR re-arrange the code a bit to avoid this

cc @bosiraphael thx for flagging this!