### PR TITLE
block invite link if workspace subscription is not active

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.ts
@@ -132,11 +132,12 @@ export class SignInUpService {
   }) {
     const workspace = await this.workspaceRepository.findOneBy({
       inviteHash: workspaceInviteHash,
+      subscriptionStatus: 'active',
     });
 
     assert(
       workspace,
-      'This workspace inviteHash is invalid',
+      'This workspace inviteHash is invalid or the workspace is not active',
       ForbiddenException,
     );
 


### PR DESCRIPTION
Fixes https://github.com/twentyhq/twenty/issues/4980

## Test
tested locally with incomplete and active