### PR TITLE
Fix invite link sign-up with workspace without subcription and billing not enabled

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.ts
@@ -132,12 +132,18 @@ export class SignInUpService {
   }) {
     const workspace = await this.workspaceRepository.findOneBy({
       inviteHash: workspaceInviteHash,
-      subscriptionStatus: 'active',
     });
 
     assert(
       workspace,
-      'This workspace inviteHash is invalid or the workspace is not active',
+      'This workspace inviteHash is invalid',
+      ForbiddenException,
+    );
+
+    assert(
+      !this.environmentService.get('IS_BILLING_ENABLED') ||
+        workspace.subscriptionStatus === 'active',
+      'Workspace subscription status needs to be active',
       ForbiddenException,
     );
 


### PR DESCRIPTION
## Context

We recently introduced this verification but we didn't take into account self-hosting that might not use billing.

## Test
tested locally with
- new workspace and new account
- existing workspace with new account and billing not enabled and status incomplete => OK
- existing workspace with new account and billing enabled and status incomplete => NOK
- existing workspace with new account and billing enabled and status active => OK