### PR TITLE
Fix explicit boolean predicates rule not working with boolean constants

### DIFF
--- a/packages/twenty-front/src/modules/ui/utilities/hotkey/hooks/usePreviousHotkeyScope.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/hotkey/hooks/usePreviousHotkeyScope.ts
@@ -23,7 +23,6 @@ export const usePreviousHotkeyScope = () => {
           return;
         }
 
-        // eslint-disable-next-line @nx/workspace-explicit-boolean-predicates-in-if
         if (DEBUG_HOTKEY_SCOPE) {
           logDebug('DEBUG: goBackToPreviousHotkeyScope', previousHotkeyScope);
         }
@@ -45,7 +44,6 @@ export const usePreviousHotkeyScope = () => {
           .getLoadable(currentHotkeyScopeState)
           .getValue();
 
-        // eslint-disable-next-line @nx/workspace-explicit-boolean-predicates-in-if
         if (DEBUG_HOTKEY_SCOPE) {
           logDebug('DEBUG: setHotkeyScopeAndMemorizePreviousScope', {
             currentHotkeyScope,

--- a/packages/twenty-front/src/modules/ui/utilities/hotkey/hooks/useScopedHotkeyCallback.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/hotkey/hooks/useScopedHotkeyCallback.ts
@@ -28,7 +28,6 @@ export const useScopedHotkeyCallback = () =>
           .getValue();
 
         if (!currentHotkeyScopes.includes(scope)) {
-          // eslint-disable-next-line @nx/workspace-explicit-boolean-predicates-in-if
           if (DEBUG_HOTKEY_SCOPE) {
             logDebug(
               `DEBUG: %cI can't call hotkey (${
@@ -43,7 +42,6 @@ export const useScopedHotkeyCallback = () =>
           return;
         }
 
-        // eslint-disable-next-line @nx/workspace-explicit-boolean-predicates-in-if
         if (DEBUG_HOTKEY_SCOPE) {
           logDebug(
             `DEBUG: %cI can call hotkey (${

--- a/packages/twenty-front/src/modules/ui/utilities/hotkey/hooks/useSetHotkeyScope.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/hotkey/hooks/useSetHotkeyScope.ts
@@ -79,9 +79,6 @@ export const useSetHotkeyScope = () =>
 
         scopesToSet.push(newHotkeyScope.scope);
 
-        // TODO: fix eslint rule not understanding a boolean constant
-        //    See issue https://github.com/twentyhq/twenty/issues/4881
-        // eslint-disable-next-line @nx/workspace-explicit-boolean-predicates-in-if
         if (DEBUG_HOTKEY_SCOPE) {
           logDebug('DEBUG: set new hotkey scope', {
             scopesToSet,

--- a/packages/twenty-front/src/utils/cast-as-integer-or-null.ts
+++ b/packages/twenty-front/src/utils/cast-as-integer-or-null.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @nx/workspace-explicit-boolean-predicates-in-if */
 import { isNull, isNumber, isString } from '@sniptt/guards';
 
 import { logError } from './logError';

--- a/tools/eslint-rules/rules/explicit-boolean-predicates-in-if.ts
+++ b/tools/eslint-rules/rules/explicit-boolean-predicates-in-if.ts
@@ -1,6 +1,12 @@
 import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils';
+import ts from 'typescript';
 
 export const RULE_NAME = 'explicit-boolean-predicates-in-if';
+
+const isBooleanType = (type: ts.Type) => {
+  // check if boolean flag(s) is set on the type (e.g. boolean, true, false, etc.)
+  return type && (type.flags & ts.TypeFlags.BooleanLike) !== 0;
+};
 
 export const rule = ESLintUtils.RuleCreator(() => __filename)({
   name: RULE_NAME,
@@ -27,9 +33,8 @@ export const rule = ESLintUtils.RuleCreator(() => __filename)({
         const tsNode = parserServices.esTreeNodeToTSNodeMap.get(node.test);
         const type = typeChecker.getTypeAtLocation(tsNode);
 
-        if (typeChecker.typeToString(type) !== 'boolean') {
+        if (!isBooleanType(type)) {
           const { test } = node;
-
           context.report({
             node: test,
             messageId: 'nonExplicitPredicate',


### PR DESCRIPTION
### Description
Fix explicit boolean predicates rule not working with boolean constants

### Refs
#4881

### Demo

Fixes #4881