### PR TITLE
Disable audit log on system objects

### DIFF
--- a/packages/twenty-server/src/modules/activity/standard-objects/activity-target.object-metadata.ts
+++ b/packages/twenty-server/src/modules/activity/standard-objects/activity-target.object-metadata.ts
@@ -14,6 +14,7 @@ import { BaseObjectMetadata } from 'src/engine/workspace-manager/workspace-sync-
 import { CompanyObjectMetadata } from 'src/modules/company/standard-objects/company.object-metadata';
 import { OpportunityObjectMetadata } from 'src/modules/opportunity/standard-objects/opportunity.object-metadata';
 import { PersonObjectMetadata } from 'src/modules/person/standard-objects/person.object-metadata';
+import { IsNotAuditLogged } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/is-not-audit-logged.decorator';
 
 @ObjectMetadata({
   standardId: standardObjectIds.activityTarget,
@@ -24,6 +25,7 @@ import { PersonObjectMetadata } from 'src/modules/person/standard-objects/person
   icon: 'IconCheckbox',
 })
 @IsSystem()
+@IsNotAuditLogged()
 export class ActivityTargetObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({
     standardId: activityTargetStandardFieldIds.activity,

--- a/packages/twenty-server/src/modules/activity/standard-objects/activity.object-metadata.ts
+++ b/packages/twenty-server/src/modules/activity/standard-objects/activity.object-metadata.ts
@@ -17,6 +17,7 @@ import { AttachmentObjectMetadata } from 'src/modules/attachment/standard-object
 import { BaseObjectMetadata } from 'src/engine/workspace-manager/workspace-sync-metadata/standard-objects/base.object-metadata';
 import { CommentObjectMetadata } from 'src/modules/activity/standard-objects/comment.object-metadata';
 import { WorkspaceMemberObjectMetadata } from 'src/modules/workspace-member/standard-objects/workspace-member.object-metadata';
+import { IsNotAuditLogged } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/is-not-audit-logged.decorator';
 
 @ObjectMetadata({
   standardId: standardObjectIds.activity,
@@ -26,6 +27,7 @@ import { WorkspaceMemberObjectMetadata } from 'src/modules/workspace-member/stan
   description: 'An activity',
   icon: 'IconCheckbox',
 })
+@IsNotAuditLogged()
 @IsSystem()
 export class ActivityObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({

--- a/packages/twenty-server/src/modules/activity/standard-objects/comment.object-metadata.ts
+++ b/packages/twenty-server/src/modules/activity/standard-objects/comment.object-metadata.ts
@@ -9,6 +9,7 @@ import { ObjectMetadata } from 'src/engine/workspace-manager/workspace-sync-meta
 import { ActivityObjectMetadata } from 'src/modules/activity/standard-objects/activity.object-metadata';
 import { BaseObjectMetadata } from 'src/engine/workspace-manager/workspace-sync-metadata/standard-objects/base.object-metadata';
 import { WorkspaceMemberObjectMetadata } from 'src/modules/workspace-member/standard-objects/workspace-member.object-metadata';
+import { IsNotAuditLogged } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/is-not-audit-logged.decorator';
 
 @ObjectMetadata({
   standardId: standardObjectIds.comment,
@@ -19,6 +20,7 @@ import { WorkspaceMemberObjectMetadata } from 'src/modules/workspace-member/stan
   icon: 'IconMessageCircle',
 })
 @IsSystem()
+@IsNotAuditLogged()
 export class CommentObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({
     standardId: commentStandardFieldIds.body,

--- a/packages/twenty-server/src/modules/api-key/standard-objects/api-key.object-metadata.ts
+++ b/packages/twenty-server/src/modules/api-key/standard-objects/api-key.object-metadata.ts
@@ -2,6 +2,7 @@ import { FieldMetadataType } from 'src/engine/metadata-modules/field-metadata/fi
 import { apiKeyStandardFieldIds } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-field-ids';
 import { standardObjectIds } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-object-ids';
 import { FieldMetadata } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/field-metadata.decorator';
+import { IsNotAuditLogged } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/is-not-audit-logged.decorator';
 import { IsNullable } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/is-nullable.decorator';
 import { IsSystem } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/is-system.decorator';
 import { ObjectMetadata } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/object-metadata.decorator';
@@ -16,6 +17,7 @@ import { BaseObjectMetadata } from 'src/engine/workspace-manager/workspace-sync-
   icon: 'IconRobot',
 })
 @IsSystem()
+@IsNotAuditLogged()
 export class ApiKeyObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({
     standardId: apiKeyStandardFieldIds.name,

--- a/packages/twenty-server/src/modules/attachment/standard-objects/attachment.object-metadata.ts
+++ b/packages/twenty-server/src/modules/attachment/standard-objects/attachment.object-metadata.ts
@@ -15,6 +15,7 @@ import { CompanyObjectMetadata } from 'src/modules/company/standard-objects/comp
 import { OpportunityObjectMetadata } from 'src/modules/opportunity/standard-objects/opportunity.object-metadata';
 import { PersonObjectMetadata } from 'src/modules/person/standard-objects/person.object-metadata';
 import { WorkspaceMemberObjectMetadata } from 'src/modules/workspace-member/standard-objects/workspace-member.object-metadata';
+import { IsNotAuditLogged } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/is-not-audit-logged.decorator';
 
 @ObjectMetadata({
   standardId: standardObjectIds.attachment,
@@ -25,6 +26,7 @@ import { WorkspaceMemberObjectMetadata } from 'src/modules/workspace-member/stan
   icon: 'IconFileImport',
 })
 @IsSystem()
+@IsNotAuditLogged()
 export class AttachmentObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({
     standardId: attachmentStandardFieldIds.name,

--- a/packages/twenty-server/src/modules/calendar/standard-objects/calendar-channel-event-association.object-metadata.ts
+++ b/packages/twenty-server/src/modules/calendar/standard-objects/calendar-channel-event-association.object-metadata.ts
@@ -10,6 +10,7 @@ import { IsSystem } from 'src/engine/workspace-manager/workspace-sync-metadata/d
 import { ObjectMetadata } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/object-metadata.decorator';
 import { BaseObjectMetadata } from 'src/engine/workspace-manager/workspace-sync-metadata/standard-objects/base.object-metadata';
 import { CalendarEventObjectMetadata } from 'src/modules/calendar/standard-objects/calendar-event.object-metadata';
+import { IsNotAuditLogged } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/is-not-audit-logged.decorator';
 
 @ObjectMetadata({
   standardId: standardObjectIds.calendarChannelEventAssociation,
@@ -20,6 +21,7 @@ import { CalendarEventObjectMetadata } from 'src/modules/calendar/standard-objec
   icon: 'IconCalendar',
 })
 @IsSystem()
+@IsNotAuditLogged()
 @Gate({
   featureFlag: FeatureFlagKeys.IsCalendarEnabled,
 })

--- a/packages/twenty-server/src/modules/calendar/standard-objects/calendar-channel.object-metadata.ts
+++ b/packages/twenty-server/src/modules/calendar/standard-objects/calendar-channel.object-metadata.ts
@@ -16,6 +16,7 @@ import { BaseObjectMetadata } from 'src/engine/workspace-manager/workspace-sync-
 import { ConnectedAccountObjectMetadata } from 'src/modules/connected-account/standard-objects/connected-account.object-metadata';
 import { CalendarChannelEventAssociationObjectMetadata } from 'src/modules/calendar/standard-objects/calendar-channel-event-association.object-metadata';
 import { RelationMetadata } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/relation-metadata.decorator';
+import { IsNotAuditLogged } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/is-not-audit-logged.decorator';
 
 export enum CalendarChannelVisibility {
   METADATA = 'METADATA',
@@ -31,6 +32,7 @@ export enum CalendarChannelVisibility {
   icon: 'IconCalendar',
 })
 @IsSystem()
+@IsNotAuditLogged()
 @Gate({
   featureFlag: FeatureFlagKeys.IsCalendarEnabled,
 })

--- a/packages/twenty-server/src/modules/calendar/standard-objects/calendar-event-participant.object-metadata.ts
+++ b/packages/twenty-server/src/modules/calendar/standard-objects/calendar-event-participant.object-metadata.ts
@@ -12,6 +12,7 @@ import { BaseObjectMetadata } from 'src/engine/workspace-manager/workspace-sync-
 import { CalendarEventObjectMetadata } from 'src/modules/calendar/standard-objects/calendar-event.object-metadata';
 import { PersonObjectMetadata } from 'src/modules/person/standard-objects/person.object-metadata';
 import { WorkspaceMemberObjectMetadata } from 'src/modules/workspace-member/standard-objects/workspace-member.object-metadata';
+import { IsNotAuditLogged } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/is-not-audit-logged.decorator';
 
 export enum CalendarEventParticipantResponseStatus {
   NEEDS_ACTION = 'NEEDS_ACTION',
@@ -29,6 +30,7 @@ export enum CalendarEventParticipantResponseStatus {
   icon: 'IconCalendar',
 })
 @IsSystem()
+@IsNotAuditLogged()
 @Gate({
   featureFlag: 'IS_CALENDAR_ENABLED',
 })

--- a/packages/twenty-server/src/modules/calendar/standard-objects/calendar-event.object-metadata.ts
+++ b/packages/twenty-server/src/modules/calendar/standard-objects/calendar-event.object-metadata.ts
@@ -18,6 +18,7 @@ import { IsNullable } from 'src/engine/workspace-manager/workspace-sync-metadata
 import { standardObjectIds } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-object-ids';
 import { calendarEventStandardFieldIds } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-field-ids';
 import { LinkMetadata } from 'src/engine/metadata-modules/field-metadata/composite-types/link.composite-type';
+import { IsNotAuditLogged } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/is-not-audit-logged.decorator';
 
 @ObjectMetadata({
   standardId: standardObjectIds.calendarEvent,
@@ -28,6 +29,7 @@ import { LinkMetadata } from 'src/engine/metadata-modules/field-metadata/composi
   icon: 'IconCalendar',
 })
 @IsSystem()
+@IsNotAuditLogged()
 @Gate({
   featureFlag: FeatureFlagKeys.IsCalendarEnabled,
 })

--- a/packages/twenty-server/src/modules/connected-account/standard-objects/blocklist.object-metadata.ts
+++ b/packages/twenty-server/src/modules/connected-account/standard-objects/blocklist.object-metadata.ts
@@ -8,6 +8,7 @@ import { IsSystem } from 'src/engine/workspace-manager/workspace-sync-metadata/d
 import { ObjectMetadata } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/object-metadata.decorator';
 import { BaseObjectMetadata } from 'src/engine/workspace-manager/workspace-sync-metadata/standard-objects/base.object-metadata';
 import { WorkspaceMemberObjectMetadata } from 'src/modules/workspace-member/standard-objects/workspace-member.object-metadata';
+import { IsNotAuditLogged } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/is-not-audit-logged.decorator';
 
 @ObjectMetadata({
   standardId: standardObjectIds.blocklist,
@@ -18,6 +19,7 @@ import { WorkspaceMemberObjectMetadata } from 'src/modules/workspace-member/stan
   icon: 'IconForbid2',
 })
 @IsSystem()
+@IsNotAuditLogged()
 export class BlocklistObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({
     standardId: blocklistStandardFieldIds.handle,

--- a/packages/twenty-server/src/modules/connected-account/standard-objects/connected-account.object-metadata.ts
+++ b/packages/twenty-server/src/modules/connected-account/standard-objects/connected-account.object-metadata.ts
@@ -18,6 +18,7 @@ import { BaseObjectMetadata } from 'src/engine/workspace-manager/workspace-sync-
 import { CalendarChannelObjectMetadata } from 'src/modules/calendar/standard-objects/calendar-channel.object-metadata';
 import { MessageChannelObjectMetadata } from 'src/modules/messaging/standard-objects/message-channel.object-metadata';
 import { WorkspaceMemberObjectMetadata } from 'src/modules/workspace-member/standard-objects/workspace-member.object-metadata';
+import { IsNotAuditLogged } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/is-not-audit-logged.decorator';
 
 export enum ConnectedAccountProvider {
   GOOGLE = 'google',
@@ -32,6 +33,7 @@ export enum ConnectedAccountProvider {
   icon: 'IconAt',
 })
 @IsSystem()
+@IsNotAuditLogged()
 export class ConnectedAccountObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({
     standardId: connectedAccountStandardFieldIds.handle,

--- a/packages/twenty-server/src/modules/favorite/standard-objects/favorite.object-metadata.ts
+++ b/packages/twenty-server/src/modules/favorite/standard-objects/favorite.object-metadata.ts
@@ -14,6 +14,7 @@ import { CompanyObjectMetadata } from 'src/modules/company/standard-objects/comp
 import { OpportunityObjectMetadata } from 'src/modules/opportunity/standard-objects/opportunity.object-metadata';
 import { PersonObjectMetadata } from 'src/modules/person/standard-objects/person.object-metadata';
 import { WorkspaceMemberObjectMetadata } from 'src/modules/workspace-member/standard-objects/workspace-member.object-metadata';
+import { IsNotAuditLogged } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/is-not-audit-logged.decorator';
 
 @ObjectMetadata({
   standardId: standardObjectIds.favorite,
@@ -23,6 +24,7 @@ import { WorkspaceMemberObjectMetadata } from 'src/modules/workspace-member/stan
   description: 'A favorite',
   icon: 'IconHeart',
 })
+@IsNotAuditLogged()
 @IsSystem()
 export class FavoriteObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({

--- a/packages/twenty-server/src/modules/messaging/standard-objects/message-channel-message-association.object-metadata.ts
+++ b/packages/twenty-server/src/modules/messaging/standard-objects/message-channel-message-association.object-metadata.ts
@@ -11,6 +11,7 @@ import { BaseObjectMetadata } from 'src/engine/workspace-manager/workspace-sync-
 import { MessageChannelObjectMetadata } from 'src/modules/messaging/standard-objects/message-channel.object-metadata';
 import { MessageThreadObjectMetadata } from 'src/modules/messaging/standard-objects/message-thread.object-metadata';
 import { MessageObjectMetadata } from 'src/modules/messaging/standard-objects/message.object-metadata';
+import { IsNotAuditLogged } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/is-not-audit-logged.decorator';
 
 @ObjectMetadata({
   standardId: standardObjectIds.messageChannelMessageAssociation,
@@ -20,6 +21,7 @@ import { MessageObjectMetadata } from 'src/modules/messaging/standard-objects/me
   description: 'Message Synced with a Message Channel',
   icon: 'IconMessage',
 })
+@IsNotAuditLogged()
 @IsSystem()
 export class MessageChannelMessageAssociationObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({

--- a/packages/twenty-server/src/modules/messaging/standard-objects/message-channel.object-metadata.ts
+++ b/packages/twenty-server/src/modules/messaging/standard-objects/message-channel.object-metadata.ts
@@ -15,6 +15,7 @@ import { RelationMetadata } from 'src/engine/workspace-manager/workspace-sync-me
 import { BaseObjectMetadata } from 'src/engine/workspace-manager/workspace-sync-metadata/standard-objects/base.object-metadata';
 import { ConnectedAccountObjectMetadata } from 'src/modules/connected-account/standard-objects/connected-account.object-metadata';
 import { MessageChannelMessageAssociationObjectMetadata } from 'src/modules/messaging/standard-objects/message-channel-message-association.object-metadata';
+import { IsNotAuditLogged } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/is-not-audit-logged.decorator';
 
 export enum MessageChannelSyncStatus {
   PENDING = 'PENDING',
@@ -42,6 +43,7 @@ export enum MessageChannelType {
   description: 'Message Channels',
   icon: 'IconMessage',
 })
+@IsNotAuditLogged()
 @IsSystem()
 export class MessageChannelObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({

--- a/packages/twenty-server/src/modules/messaging/standard-objects/message-participant.object-metadata.ts
+++ b/packages/twenty-server/src/modules/messaging/standard-objects/message-participant.object-metadata.ts
@@ -11,6 +11,7 @@ import { BaseObjectMetadata } from 'src/engine/workspace-manager/workspace-sync-
 import { MessageObjectMetadata } from 'src/modules/messaging/standard-objects/message.object-metadata';
 import { PersonObjectMetadata } from 'src/modules/person/standard-objects/person.object-metadata';
 import { WorkspaceMemberObjectMetadata } from 'src/modules/workspace-member/standard-objects/workspace-member.object-metadata';
+import { IsNotAuditLogged } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/is-not-audit-logged.decorator';
 
 @ObjectMetadata({
   standardId: standardObjectIds.messageParticipant,
@@ -20,6 +21,7 @@ import { WorkspaceMemberObjectMetadata } from 'src/modules/workspace-member/stan
   description: 'Message Participants',
   icon: 'IconUserCircle',
 })
+@IsNotAuditLogged()
 @IsSystem()
 export class MessageParticipantObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({

--- a/packages/twenty-server/src/modules/messaging/standard-objects/message-thread.object-metadata.ts
+++ b/packages/twenty-server/src/modules/messaging/standard-objects/message-thread.object-metadata.ts
@@ -15,6 +15,7 @@ import { RelationMetadata } from 'src/engine/workspace-manager/workspace-sync-me
 import { BaseObjectMetadata } from 'src/engine/workspace-manager/workspace-sync-metadata/standard-objects/base.object-metadata';
 import { MessageChannelMessageAssociationObjectMetadata } from 'src/modules/messaging/standard-objects/message-channel-message-association.object-metadata';
 import { MessageObjectMetadata } from 'src/modules/messaging/standard-objects/message.object-metadata';
+import { IsNotAuditLogged } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/is-not-audit-logged.decorator';
 
 @ObjectMetadata({
   standardId: standardObjectIds.messageThread,
@@ -24,6 +25,7 @@ import { MessageObjectMetadata } from 'src/modules/messaging/standard-objects/me
   description: 'Message Thread',
   icon: 'IconMessage',
 })
+@IsNotAuditLogged()
 @IsSystem()
 export class MessageThreadObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({

--- a/packages/twenty-server/src/modules/messaging/standard-objects/message.object-metadata.ts
+++ b/packages/twenty-server/src/modules/messaging/standard-objects/message.object-metadata.ts
@@ -16,6 +16,7 @@ import { BaseObjectMetadata } from 'src/engine/workspace-manager/workspace-sync-
 import { MessageChannelMessageAssociationObjectMetadata } from 'src/modules/messaging/standard-objects/message-channel-message-association.object-metadata';
 import { MessageParticipantObjectMetadata } from 'src/modules/messaging/standard-objects/message-participant.object-metadata';
 import { MessageThreadObjectMetadata } from 'src/modules/messaging/standard-objects/message-thread.object-metadata';
+import { IsNotAuditLogged } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/is-not-audit-logged.decorator';
 
 @ObjectMetadata({
   standardId: standardObjectIds.message,
@@ -25,6 +26,7 @@ import { MessageThreadObjectMetadata } from 'src/modules/messaging/standard-obje
   description: 'Message',
   icon: 'IconMessage',
 })
+@IsNotAuditLogged()
 @IsSystem()
 export class MessageObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({

--- a/packages/twenty-server/src/modules/opportunity/standard-objects/opportunity.object-metadata.ts
+++ b/packages/twenty-server/src/modules/opportunity/standard-objects/opportunity.object-metadata.ts
@@ -20,6 +20,7 @@ import { CompanyObjectMetadata } from 'src/modules/company/standard-objects/comp
 import { FavoriteObjectMetadata } from 'src/modules/favorite/standard-objects/favorite.object-metadata';
 import { PersonObjectMetadata } from 'src/modules/person/standard-objects/person.object-metadata';
 import { EventObjectMetadata } from 'src/modules/event/standard-objects/event.object-metadata';
+import { IsNotAuditLogged } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/is-not-audit-logged.decorator';
 
 @ObjectMetadata({
   standardId: standardObjectIds.opportunity,
@@ -29,6 +30,7 @@ import { EventObjectMetadata } from 'src/modules/event/standard-objects/event.ob
   description: 'An opportunity',
   icon: 'IconTargetArrow',
 })
+@IsNotAuditLogged()
 export class OpportunityObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({
     standardId: opportunityStandardFieldIds.name,

--- a/packages/twenty-server/src/modules/view/standard-objects/view-field.object-metadata.ts
+++ b/packages/twenty-server/src/modules/view/standard-objects/view-field.object-metadata.ts
@@ -2,6 +2,7 @@ import { FieldMetadataType } from 'src/engine/metadata-modules/field-metadata/fi
 import { viewFieldStandardFieldIds } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-field-ids';
 import { standardObjectIds } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-object-ids';
 import { FieldMetadata } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/field-metadata.decorator';
+import { IsNotAuditLogged } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/is-not-audit-logged.decorator';
 import { IsNullable } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/is-nullable.decorator';
 import { IsSystem } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/is-system.decorator';
 import { ObjectMetadata } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/object-metadata.decorator';
@@ -16,6 +17,7 @@ import { ViewObjectMetadata } from 'src/modules/view/standard-objects/view.objec
   description: '(System) View Fields',
   icon: 'IconTag',
 })
+@IsNotAuditLogged()
 @IsSystem()
 export class ViewFieldObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({

--- a/packages/twenty-server/src/modules/view/standard-objects/view-filter.object-metadata.ts
+++ b/packages/twenty-server/src/modules/view/standard-objects/view-filter.object-metadata.ts
@@ -9,6 +9,7 @@ import { IsSystem } from 'src/engine/workspace-manager/workspace-sync-metadata/d
 import { ObjectMetadata } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/object-metadata.decorator';
 import { BaseObjectMetadata } from 'src/engine/workspace-manager/workspace-sync-metadata/standard-objects/base.object-metadata';
 import { ViewObjectMetadata } from 'src/modules/view/standard-objects/view.object-metadata';
+import { IsNotAuditLogged } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/is-not-audit-logged.decorator';
 
 @ObjectMetadata({
   standardId: standardObjectIds.viewFilter,
@@ -18,6 +19,7 @@ import { ViewObjectMetadata } from 'src/modules/view/standard-objects/view.objec
   description: '(System) View Filters',
   icon: 'IconFilterBolt',
 })
+@IsNotAuditLogged()
 @IsSystem()
 export class ViewFilterObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({

--- a/packages/twenty-server/src/modules/view/standard-objects/view-sort.object-metadata.ts
+++ b/packages/twenty-server/src/modules/view/standard-objects/view-sort.object-metadata.ts
@@ -9,6 +9,7 @@ import { IsSystem } from 'src/engine/workspace-manager/workspace-sync-metadata/d
 import { ObjectMetadata } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/object-metadata.decorator';
 import { BaseObjectMetadata } from 'src/engine/workspace-manager/workspace-sync-metadata/standard-objects/base.object-metadata';
 import { ViewObjectMetadata } from 'src/modules/view/standard-objects/view.object-metadata';
+import { IsNotAuditLogged } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/is-not-audit-logged.decorator';
 
 @ObjectMetadata({
   standardId: standardObjectIds.viewSort,
@@ -18,6 +19,7 @@ import { ViewObjectMetadata } from 'src/modules/view/standard-objects/view.objec
   description: '(System) View Sorts',
   icon: 'IconArrowsSort',
 })
+@IsNotAuditLogged()
 @IsSystem()
 export class ViewSortObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({

--- a/packages/twenty-server/src/modules/view/standard-objects/view.object-metadata.ts
+++ b/packages/twenty-server/src/modules/view/standard-objects/view.object-metadata.ts
@@ -16,6 +16,7 @@ import { BaseObjectMetadata } from 'src/engine/workspace-manager/workspace-sync-
 import { ViewFieldObjectMetadata } from 'src/modules/view/standard-objects/view-field.object-metadata';
 import { ViewFilterObjectMetadata } from 'src/modules/view/standard-objects/view-filter.object-metadata';
 import { ViewSortObjectMetadata } from 'src/modules/view/standard-objects/view-sort.object-metadata';
+import { IsNotAuditLogged } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/is-not-audit-logged.decorator';
 
 @ObjectMetadata({
   standardId: standardObjectIds.view,
@@ -25,6 +26,7 @@ import { ViewSortObjectMetadata } from 'src/modules/view/standard-objects/view-s
   description: '(System) Views',
   icon: 'IconLayoutCollage',
 })
+@IsNotAuditLogged()
 @IsSystem()
 export class ViewObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({

--- a/packages/twenty-server/src/modules/webhook/standard-objects/webhook.object-metadata.ts
+++ b/packages/twenty-server/src/modules/webhook/standard-objects/webhook.object-metadata.ts
@@ -2,6 +2,7 @@ import { FieldMetadataType } from 'src/engine/metadata-modules/field-metadata/fi
 import { webhookStandardFieldIds } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-field-ids';
 import { standardObjectIds } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-object-ids';
 import { FieldMetadata } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/field-metadata.decorator';
+import { IsNotAuditLogged } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/is-not-audit-logged.decorator';
 import { IsSystem } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/is-system.decorator';
 import { ObjectMetadata } from 'src/engine/workspace-manager/workspace-sync-metadata/decorators/object-metadata.decorator';
 import { BaseObjectMetadata } from 'src/engine/workspace-manager/workspace-sync-metadata/standard-objects/base.object-metadata';
@@ -14,6 +15,7 @@ import { BaseObjectMetadata } from 'src/engine/workspace-manager/workspace-sync-
   description: 'A webhook',
   icon: 'IconRobot',
 })
+@IsNotAuditLogged()
 @IsSystem()
 export class WebhookObjectMetadata extends BaseObjectMetadata {
   @FieldMetadata({


### PR DESCRIPTION
## Context

We have recently added an event listener to create audit logs on objects update. However, we have only created the structure (relations on event standard objects) for Company, Person, Opportunity and custom objects. There is a larger effort in #4936 to refactor this.
For now, we are disabling log auditing on all other objects

## How
Add @IsNotAuditLogged() annotation on all standard objects except Company, Person, Opportunity