### PR TITLE
fix: Added isDisplayModeContentEmpty to the showEditButton's check

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellContainer.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellContainer.tsx
@@ -141,7 +141,11 @@ export const RecordInlineCellContainer = ({
   };
 
   const showEditButton =
-    buttonIcon && !isInlineCellInEditMode && isHovered && !editModeContentOnly;
+    buttonIcon &&
+    !isInlineCellInEditMode &&
+    isHovered &&
+    !editModeContentOnly &&
+    !isDisplayModeContentEmpty;
 
   const theme = useTheme();
   const labelId = `label-${entityId}-${fieldDefinition?.metadata?.fieldName}`;


### PR DESCRIPTION
Closes #5011 

Hi! I added isDisplayModeContentEmpty to the showEditButton's check.

https://github.com/twentyhq/twenty/assets/41576384/54a87c16-b58a-4a46-8373-f6c924201113



