### PR TITLE
Fixed default currency code in currency field

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/CurrencyFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/CurrencyFieldInput.tsx
@@ -1,3 +1,5 @@
+import { isNonEmptyString } from '@sniptt/guards';
+
 import { CurrencyCode } from '@/object-record/record-field/types/CurrencyCode';
 import { FieldCurrencyValue } from '@/object-record/record-field/types/FieldMetadata';
 import { CurrencyInput } from '@/ui/field/input/components/CurrencyInput';
@@ -30,13 +32,24 @@ export const CurrencyFieldInput = ({
     defaultValue,
   } = useCurrencyField();
 
-  const currencyCode =
-    draftValue?.currencyCode ??
-    ((defaultValue as FieldCurrencyValue).currencyCode.replace(
-      /'/g,
-      '',
-    ) as CurrencyCode) ??
-    CurrencyCode.USD;
+  const defaultCurrencyCodeWithoutSQLQuotes = (
+    defaultValue as FieldCurrencyValue
+  ).currencyCode.replace(/'/g, '') as CurrencyCode;
+
+  const defaultCurrencyCodeIsNotEmpty = isNonEmptyString(
+    defaultCurrencyCodeWithoutSQLQuotes,
+  );
+
+  const draftCurrencyCode = draftValue?.currencyCode;
+
+  const draftCurrencyCodeIsEmptyIsNotEmpty =
+    isNonEmptyString(draftCurrencyCode);
+
+  const currencyCode = draftCurrencyCodeIsEmptyIsNotEmpty
+    ? draftCurrencyCode
+    : defaultCurrencyCodeIsNotEmpty
+      ? defaultCurrencyCodeWithoutSQLQuotes
+      : CurrencyCode.USD;
 
   const handleEnter = (newValue: string) => {
     onEnter?.(() => {


### PR DESCRIPTION
Default currency logic was not handling a specific case where the default currency is empty in the field metadata. 

I fixed the ternary cascade and made it more explicit, thus also avoiding falling into having an empty currency code being persisted.