### PR TITLE
Fixed position in query fields

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-index/hooks/useRecordTableQueryFields.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/hooks/useRecordTableQueryFields.ts
@@ -12,6 +12,7 @@ export const useRecordTableQueryFields = () => {
     ...Object.fromEntries(
       visibleTableColumns.map((column) => [column.metadata.fieldName, true]),
     ),
+    position: true,
   };
 
   return queryFields;


### PR DESCRIPTION
Position was not passed to the request query fields so it changed every time we updated a field.