### PR TITLE
Fix billing check for trial sub status

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.ts
@@ -143,7 +143,7 @@ export class SignInUpService {
     assert(
       !this.environmentService.get('IS_BILLING_ENABLED') ||
         workspace.subscriptionStatus !== 'incomplete',
-      'Workspace subscription status needs to be active',
+      'Workspace subscription status is incomplete',
       ForbiddenException,
     );
 

--- a/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.ts
@@ -142,7 +142,7 @@ export class SignInUpService {
 
     assert(
       !this.environmentService.get('IS_BILLING_ENABLED') ||
-        workspace.subscriptionStatus === 'active',
+        workspace.subscriptionStatus !== 'incomplete',
       'Workspace subscription status needs to be active',
       ForbiddenException,
     );


### PR DESCRIPTION
## Context
Sub status is not binary as you can also be in trial mode and still should be able to share invite link. This PR should fix this issue  