### PR TITLE
5077: fix buggy title input reappearing after delete 

### DIFF
--- a/packages/twenty-front/src/modules/activities/components/ActivityTitle.tsx
+++ b/packages/twenty-front/src/modules/activities/components/ActivityTitle.tsx
@@ -151,7 +151,7 @@ export const ActivityTitle = ({ activityId }: ActivityTitleProps) => {
       cache: cache,
       objectMetadataItem: objectMetadataItemActivity,
     });
-  }, 500);
+  }, 0);
 
   const handleTitleChange = (newTitle: string) => {
     setActivityTitle(newTitle);


### PR DESCRIPTION
Full disclosure this is not a permanent solution. I did spend a lot of time on it and have pinpointed the issue area. It took me some time to get it to run locally properly. Unfortunately I could not get graphql to work, limiting some functionality. For example in the issue video the note automatically renders in the notes list as you are creating the note. Since I could not get the graphql extension to work for some reason I did not have this functionality which can effect result.

However the debounce is more to do with stopping something from triggering too often., so the title state still remains and will show up in both places. It's just the input gets cached and when you delete it, it reappears moments later because of the cashing solution. The fact is trying to create a title and being unable to delete it without some challenge is rather annoying. 

The issue is in the ActivityTitle.tsx file. In the handleTitleChange function.

 const handleTitleChange = (newTitle: string) => {
    setActivityTitle(newTitle);

    setTitleDebounced(newTitle);

    persistTitleDebounced(newTitle);
  };

in the setTitleDebounced function I set the timeout to 0. This allowed me to delete characters by ether pressing delete or holding the delete button, without the whole text reappearing. I did not have to edit the persistTitleDebounced.