### PR TITLE
#4976 fix dark mode for multi-select picker in activity target chips

### DIFF
--- a/packages/twenty-front/src/modules/activities/components/ActivityTargetChips.tsx
+++ b/packages/twenty-front/src/modules/activities/components/ActivityTargetChips.tsx
@@ -19,7 +19,7 @@ const StyledContainer = styled.div`
 const StyledRelationsListContainer = styled(StyledContainer)`
   padding: ${({ theme }) => theme.spacing(2)};
   border-radius: ${({ theme }) => theme.spacing(1)};
-  background-color: ${({ theme }) => RGBA(theme.color.gray10, 0.8)};
+  background-color: ${({ theme }) => theme.background.secondary};
   box-shadow: '0px 2px 4px ${({ theme }) =>
     theme.boxShadow.light}, 2px 4px 16px ${({ theme }) =>
     theme.boxShadow.strong}';

--- a/packages/twenty-front/src/modules/activities/components/ActivityTargetChips.tsx
+++ b/packages/twenty-front/src/modules/activities/components/ActivityTargetChips.tsx
@@ -6,7 +6,6 @@ import { v4 } from 'uuid';
 import { ActivityTargetWithTargetRecord } from '@/activities/types/ActivityTargetObject';
 import { RecordChip } from '@/object-record/components/RecordChip';
 import { Dropdown } from '@/ui/layout/dropdown/components/Dropdown';
-import { RGBA } from '@/ui/theme/constants/Rgba';
 
 const MAX_RECORD_CHIPS_DISPLAY = 2;
 


### PR DESCRIPTION
#4976 - Fixed the dark mode for multi-select picker in ActivityTargetChips.

Bug:
![image](https://github.com/twentyhq/twenty/assets/16918891/53f55bba-f692-4dc9-a6b6-440d4ff5b278)

Fix:

https://github.com/twentyhq/twenty/assets/16918891/8e72cd02-0956-468d-b898-a10313448f62

