### PR TITLE
Fix default value fixer script

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/workspace-health/services/field-metadata-health.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-health/services/field-metadata-health.service.ts
@@ -276,7 +276,7 @@ export class FieldMetadataHealthService {
       !validateDefaultValueForType(
         fieldMetadata.type,
         fieldMetadata.defaultValue,
-      )
+      ).isValid
     ) {
       issues.push({
         type: WorkspaceHealthIssueType.COLUMN_DEFAULT_VALUE_NOT_VALID,


### PR DESCRIPTION
While trying to migrate a workspace from 0.3.3 to 0.10.0, we've faced an issue with the script to migrate default-values format.
This PR fixes it.

We really need to add tests on this part ;)