### PR TITLE
Fix broken sync-metadata

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/services/workspace-metadata-updater.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/services/workspace-metadata-updater.service.ts
@@ -140,7 +140,7 @@ export class WorkspaceMetadataUpdaterService {
      */
     const updatedFieldMetadataCollection = await this.updateEntities<
       FieldMetadataEntity<'default'>
-    >(manager, FieldMetadataEntity, storage.objectMetadataUpdateCollection, [
+    >(manager, FieldMetadataEntity, storage.fieldMetadataUpdateCollection, [
       'objectMetadataId',
       'workspaceId',
     ]);
@@ -241,7 +241,7 @@ export class WorkspaceMetadataUpdaterService {
     manager: EntityManager,
     entityClass: EntityTarget<Entity>,
     updateCollection: Array<
-      DeepPartial<Omit<Entity, 'fields'>> & { id: string }
+      DeepPartial<Omit<Entity, 'fields' | 'options'>> & { id: string }
     >,
     keysToOmit: (keyof Entity)[] = [],
   ): Promise<{ current: Entity; altered: Entity }[]> {

--- a/packages/twenty-server/src/modules/calendar/crons/jobs/google-calendar-sync.cron.job.ts
+++ b/packages/twenty-server/src/modules/calendar/crons/jobs/google-calendar-sync.cron.job.ts
@@ -29,7 +29,7 @@ export class GoogleCalendarSyncCronJob implements MessageQueueJob<undefined> {
     const workspaceIds = (
       await this.workspaceRepository.find({
         where: {
-          subscriptionStatus: 'active',
+          subscriptionStatus: In(['active', 'trialing', 'past_due']),
         },
         select: ['id'],
       })

--- a/packages/twenty-server/src/modules/messaging/crons/jobs/gmail-fetch-messages-from-cache.cron.job.ts
+++ b/packages/twenty-server/src/modules/messaging/crons/jobs/gmail-fetch-messages-from-cache.cron.job.ts
@@ -30,7 +30,7 @@ export class GmailFetchMessagesFromCacheCronJob
     const workspaceIds = (
       await this.workspaceRepository.find({
         where: {
-          subscriptionStatus: 'active',
+          subscriptionStatus: In(['active', 'trialing', 'past_due']),
         },
         select: ['id'],
       })

--- a/packages/twenty-server/src/modules/messaging/crons/jobs/gmail-partial-sync.cron.job.ts
+++ b/packages/twenty-server/src/modules/messaging/crons/jobs/gmail-partial-sync.cron.job.ts
@@ -36,7 +36,7 @@ export class GmailPartialSyncCronJob implements MessageQueueJob<undefined> {
     const workspaceIds = (
       await this.workspaceRepository.find({
         where: {
-          subscriptionStatus: 'active',
+          subscriptionStatus: In(['active', 'trialing', 'past_due']),
         },
         select: ['id'],
       })


### PR DESCRIPTION
An error has been recently introduced in the sync of fieldMetadata. This PR fixes it

Additionnally, we are enabling email for trialing and past_due workspaces. There is an ongoing work to introduce a more robust activationStatus on workspace.