### PR TITLE
5161 - fix workspace icon is missing on multi-workspace

### DIFF
--- a/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/MultiWorkspaceDropdownButton.tsx
+++ b/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/MultiWorkspaceDropdownButton.tsx
@@ -14,6 +14,7 @@ import { DEFAULT_WORKSPACE_LOGO } from '@/ui/navigation/navigation-drawer/consta
 import { MULTI_WORKSPACE_DROPDOWN_ID } from '@/ui/navigation/navigation-drawer/constants/MulitWorkspaceDropdownId';
 import { useWorkspaceSwitching } from '@/ui/navigation/navigation-drawer/hooks/useWorkspaceSwitching';
 import { NavigationDrawerHotKeyScope } from '@/ui/navigation/navigation-drawer/types/NavigationDrawerHotKeyScope';
+import { getImageAbsoluteURIOrBase64 } from '~/utils/image/getImageAbsoluteURIOrBase64';
 
 const StyledLogo = styled.div<{ logo: string }>`
   background: url(${({ logo }) => logo});
@@ -86,9 +87,11 @@ export const MultiWorkspaceDropdownButton = ({
         <StyledContainer>
           <StyledLogo
             logo={
-              currentWorkspace?.logo === null
-                ? DEFAULT_WORKSPACE_LOGO
-                : currentWorkspace?.logo ?? ''
+              getImageAbsoluteURIOrBase64(
+                currentWorkspace?.logo === null
+                  ? DEFAULT_WORKSPACE_LOGO
+                  : currentWorkspace?.logo,
+              ) ?? ''
             }
           />
           <StyledLabel>{currentWorkspace?.displayName ?? ''}</StyledLabel>
@@ -107,9 +110,11 @@ export const MultiWorkspaceDropdownButton = ({
               avatar={
                 <StyledLogo
                   logo={
-                    workspace.logo === null
-                      ? DEFAULT_WORKSPACE_LOGO
-                      : workspace.logo ?? ''
+                    getImageAbsoluteURIOrBase64(
+                      workspace.logo === null
+                        ? DEFAULT_WORKSPACE_LOGO
+                        : workspace.logo,
+                    ) ?? ''
                   }
                 />
               }


### PR DESCRIPTION
Fixes #5161

<img width="179" alt="image" src="https://github.com/twentyhq/twenty/assets/68029599/5a7a5b11-c6ec-4f1f-b94d-37be470a7f79">

detail: before this PR, the icon would display as normal for the default data:// icons, but not for uploaded files (`workspace-logo/original/{}.png` for example). This PR fixes this by calling the getImageAbsoluteURIOrBase64 function to resolve the missing path.