### PR TITLE
Fix workspace schema caching when user is not logged in

### DIFF
--- a/packages/twenty-server/patches/@graphql-yoga-nestjs-npm-2.1.0-cb509e6047.patch
+++ b/packages/twenty-server/patches/@graphql-yoga-nestjs-npm-2.1.0-cb509e6047.patch
@@ -31,8 +31,8 @@ index 16843949d8589a299d8195b0a349ac4dac0bacbf..21e7fe2bbcba36b04a274be9d2219fd3
          const yoga = (0, graphql_yoga_1.createYoga)({
              ...options,
 +            schema: async (request) => {
-+                const workspaceId = request.req.workspace.id
-+                const workspaceCacheVersion = request.req.cacheVersion
++                const workspaceId = request.req.workspace?.id ?? 'anonymous'
++                const workspaceCacheVersion = request.req.cacheVersion ?? '0'
 +                const url = request.req.baseUrl
 +
 +                const cacheKey = `${workspaceId}-${workspaceCacheVersion}-${url}`
@@ -77,8 +77,8 @@ index 16843949d8589a299d8195b0a349ac4dac0bacbf..21e7fe2bbcba36b04a274be9d2219fd3
          const yoga = (0, graphql_yoga_1.createYoga)({
              ...options,
 +            schema: async (request) => {
-+                const workspaceId = request.req.workspace.id
-+                const workspaceCacheVersion = request.req.cacheVersion
++                const workspaceId = request.req.workspace?.id ?? 'anonymous'
++                const workspaceCacheVersion = request.req.cacheVersion ?? '0'
 +                const url = request.req.baseUrl
 +
 +                const cacheKey = `${workspaceId}-${workspaceCacheVersion}-${url}`
@@ -143,8 +143,8 @@ index 7068c519320b379917c46763cd280b1cdd3e48f0..418e1030373fc1e0fb85a932ac8da9b3
          const yoga = createYoga({
              ...options,
 +            schema: async (request) => {
-+                const workspaceId = request.req.workspace.id
-+                const workspaceCacheVersion = request.req.cacheVersion
++                const workspaceId = request.req.workspace?.id ?? 'anonymous'
++                const workspaceCacheVersion = request.req.cacheVersion ?? '0'
 +                const url = request.req.baseUrl
 +
 +                const cacheKey = `${workspaceId}-${workspaceCacheVersion}-${url}`
@@ -189,8 +189,8 @@ index 7068c519320b379917c46763cd280b1cdd3e48f0..418e1030373fc1e0fb85a932ac8da9b3
          const yoga = createYoga({
              ...options,
 +            schema: async (request) => {
-+                const workspaceId = request.req.workspace.id
-+                const workspaceCacheVersion = request.req.cacheVersion
++                const workspaceId = request.req.workspace?.id ?? 'anonymous'
++                const workspaceCacheVersion = request.req.cacheVersion ?? '0'
 +                const url = request.req.baseUrl
 +
 +                const cacheKey = `${workspaceId}-${workspaceCacheVersion}-${url}`

--- a/packages/twenty-server/src/engine/api/graphql/graphql-config/hooks/use-throttler.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-config/hooks/use-throttler.ts
@@ -40,6 +40,10 @@ export const useThrottler = (
       addPlugin(
         useOnResolve(async ({ args, root, context, info }) => {
           if (options.limit && options.ttl) {
+            if (root !== undefined) {
+              return;
+            }
+
             const id = options.identifyFn(context);
 
             const errorMessage = await context.rateLimiterFn(
@@ -47,7 +51,7 @@ export const useThrottler = (
               {
                 max: options?.limit,
                 window: `${options?.ttl}s`,
-                message: interpolate('Too much request.', {
+                message: interpolate('Too many requests.', {
                   id,
                 }),
               },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6830,14 +6830,14 @@ __metadata:
 
 "@graphql-yoga/nestjs@patch:@graphql-yoga/nestjs@2.1.0#./patches/@graphql-yoga-nestjs-npm-2.1.0-cb509e6047.patch::locator=twenty-server%40workspace%3Apackages%2Ftwenty-server":
   version: 2.1.0
-  resolution: "@graphql-yoga/nestjs@patch:@graphql-yoga/nestjs@npm%3A2.1.0#./patches/@graphql-yoga-nestjs-npm-2.1.0-cb509e6047.patch::version=2.1.0&hash=6db821&locator=twenty-server%40workspace%3Apackages%2Ftwenty-server"
+  resolution: "@graphql-yoga/nestjs@patch:@graphql-yoga/nestjs@npm%3A2.1.0#./patches/@graphql-yoga-nestjs-npm-2.1.0-cb509e6047.patch::version=2.1.0&hash=6403da&locator=twenty-server%40workspace%3Apackages%2Ftwenty-server"
   peerDependencies:
     "@nestjs/common": ^10.0.0
     "@nestjs/core": ^10.0.0
     "@nestjs/graphql": ^12.0.0
     graphql: ^15.0.0 || ^16.0.0
     graphql-yoga: ^4.0.4
-  checksum: 512ed39d8a0b9e238b31b0a9fc0a4ee2c8980f7f38f218635beede535bcec9fbf11731ff2f986c0d551a003094c6935748cee721d3a46339b3a6e0467a699e1d
+  checksum: 3f7b8839cb9de4c05b1bae0c3eaa242f70e24c8258d193dedacdd6f06c1d29330ffcd233c6bbb7ff2288f1a55d97a4a333a0538d2ec5da40911d422e1c28e6d6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
In this PR:
- Follow up on #5170 as we did not take into account not logged in users
- only apply throttler on root fields to avoid performance overhead