### PR TITLE
5180 - does not call debounced update for invalid names

### DIFF
--- a/packages/twenty-front/src/modules/settings/profile/components/NameFields.tsx
+++ b/packages/twenty-front/src/modules/settings/profile/components/NameFields.tsx
@@ -84,9 +84,13 @@ export const NameFields = ({
       return;
     }
 
+    const { firstName: newFirstName, lastName: newLastName } =
+      currentWorkspaceMember.name;
+
     if (
-      currentWorkspaceMember.name?.firstName !== firstName ||
-      currentWorkspaceMember.name?.lastName !== lastName
+      (newFirstName !== firstName || newLastName !== lastName) &&
+      firstName !== '' &&
+      lastName !== ''
     ) {
       debouncedUpdate();
     }

--- a/packages/twenty-front/src/modules/settings/profile/components/NameFields.tsx
+++ b/packages/twenty-front/src/modules/settings/profile/components/NameFields.tsx
@@ -84,11 +84,11 @@ export const NameFields = ({
       return;
     }
 
-    const { firstName: newFirstName, lastName: newLastName } =
+    const { firstName: currentFirstName, lastName: currentLastName } =
       currentWorkspaceMember.name;
 
     if (
-      (newFirstName !== firstName || newLastName !== lastName) &&
+      (currentFirstName !== firstName || currentLastName !== lastName) &&
       firstName !== '' &&
       lastName !== ''
     ) {


### PR DESCRIPTION
fix: #5180 

Previously, clearing your name would kick you to the profile creation page.

https://github.com/twentyhq/twenty/assets/68029599/8c0087da-6b03-4b6e-b202-eabe8ebcee18


Fixed so it checks your name is valid before calling the debounced update

https://github.com/twentyhq/twenty/assets/68029599/4bc71d8f-e4f4-49ae-9cb8-497bd971be94



