### PR TITLE
Add redis to useMetadataCache yoga plugin

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/graphql-config/hooks/use-cached-metadata.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-config/hooks/use-cached-metadata.ts
@@ -14,12 +14,12 @@ export function useCachedMetadata(config: CacheMetadataPluginConfig): Plugin {
     return `${workspaceId}:${cacheVersion}`;
   };
 
-  const operationName = (serverContext: any) =>
+  const getOperationName = (serverContext: any) =>
     serverContext?.req?.body?.operationName;
 
   return {
     onRequest: async ({ endResponse, serverContext }) => {
-      if (!config.operationsToCache.includes(operationName(serverContext))) {
+      if (!config.operationsToCache.includes(getOperationName(serverContext))) {
         return;
       }
 
@@ -33,6 +33,10 @@ export function useCachedMetadata(config: CacheMetadataPluginConfig): Plugin {
       }
     },
     onResponse: async ({ response, serverContext }) => {
+      if (!config.operationsToCache.includes(getOperationName(serverContext))) {
+        return;
+      }
+
       const cacheKey = computeCacheKey(serverContext);
 
       const cachedResponse = await config.cacheGetter(cacheKey);

--- a/packages/twenty-server/src/engine/api/graphql/graphql-config/hooks/use-cached-metadata.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-config/hooks/use-cached-metadata.ts
@@ -11,8 +11,15 @@ export function useCachedMetadata(
     return `${workspaceId}:${cacheVersion}`;
   };
 
+  const operationName = (serverContext: any) =>
+    serverContext?.req?.body?.operationName;
+
   return {
     onRequest: async ({ endResponse, serverContext }) => {
+      if (operationName(serverContext) !== 'ObjectMetadataItems') {
+        return;
+      }
+
       const cacheKey = computeCacheKey(serverContext);
       const cachedResponse = await cacheGetter(cacheKey);
 

--- a/packages/twenty-server/src/engine/api/graphql/graphql-config/hooks/use-cached-metadata.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-config/hooks/use-cached-metadata.ts
@@ -3,6 +3,7 @@ import { Plugin } from 'graphql-yoga';
 export function useCachedMetadata(
   cacheGetter: (key: string) => any,
   cacheSetter: (key: string, value: any) => void,
+  operationsToCache: string[],
 ): Plugin {
   const computeCacheKey = (serverContext: any) => {
     const workspaceId = serverContext.req.workspace?.id ?? 'anonymous';
@@ -16,7 +17,7 @@ export function useCachedMetadata(
 
   return {
     onRequest: async ({ endResponse, serverContext }) => {
-      if (operationName(serverContext) !== 'ObjectMetadataItems') {
+      if (!operationsToCache.includes(operationName(serverContext))) {
         return;
       }
 

--- a/packages/twenty-server/src/engine/api/graphql/metadata-graphql-api.module.ts
+++ b/packages/twenty-server/src/engine/api/graphql/metadata-graphql-api.module.ts
@@ -12,6 +12,8 @@ import { EnvironmentService } from 'src/engine/integrations/environment/environm
 import { ExceptionHandlerService } from 'src/engine/integrations/exception-handler/exception-handler.service';
 import { DataloaderModule } from 'src/engine/dataloaders/dataloader.module';
 import { DataloaderService } from 'src/engine/dataloaders/dataloader.service';
+import { CacheStorageNamespace } from 'src/engine/integrations/cache-storage/types/cache-storage-namespace.enum';
+import { CacheStorageModule } from 'src/engine/integrations/cache-storage/cache-storage.module';
 
 @Module({
   imports: [
@@ -19,11 +21,17 @@ import { DataloaderService } from 'src/engine/dataloaders/dataloader.service';
       driver: YogaDriver,
       useFactory: metadataModuleFactory,
       imports: [GraphQLConfigModule, DataloaderModule],
-      inject: [EnvironmentService, ExceptionHandlerService, DataloaderService],
+      inject: [
+        EnvironmentService,
+        ExceptionHandlerService,
+        DataloaderService,
+        CacheStorageNamespace.WorkspaceSchema,
+      ],
     }),
     MetadataEngineModule,
     WorkspaceMigrationRunnerModule,
     WorkspaceMigrationModule,
+    CacheStorageModule,
   ],
 })
 export class MetadataGraphQLApiModule {}

--- a/packages/twenty-server/src/engine/api/graphql/metadata.module-factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/metadata.module-factory.ts
@@ -35,11 +35,15 @@ export const metadataModuleFactory = async (
       useExceptionHandler({
         exceptionHandlerService,
       }),
-      useCachedMetadata(
-        workspaceSchemaCacheStorage.get.bind(workspaceSchemaCacheStorage),
-        workspaceSchemaCacheStorage.set.bind(workspaceSchemaCacheStorage),
-        ['ObjectMetadataItems'],
-      ),
+      useCachedMetadata({
+        cacheGetter: workspaceSchemaCacheStorage.get.bind(
+          workspaceSchemaCacheStorage,
+        ),
+        cacheSetter: workspaceSchemaCacheStorage.set.bind(
+          workspaceSchemaCacheStorage,
+        ),
+        operationsToCache: ['ObjectMetadataItems'],
+      }),
     ],
     path: '/metadata',
     context: () => ({

--- a/packages/twenty-server/src/engine/api/graphql/metadata.module-factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/metadata.module-factory.ts
@@ -38,6 +38,7 @@ export const metadataModuleFactory = async (
       useCachedMetadata(
         workspaceSchemaCacheStorage.get.bind(workspaceSchemaCacheStorage),
         workspaceSchemaCacheStorage.set.bind(workspaceSchemaCacheStorage),
+        ['ObjectMetadataItems'],
       ),
     ],
     path: '/metadata',

--- a/packages/twenty-server/src/engine/api/graphql/metadata.module-factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/metadata.module-factory.ts
@@ -9,11 +9,13 @@ import { MetadataGraphQLApiModule } from 'src/engine/api/graphql/metadata-graphq
 import { renderApolloPlayground } from 'src/engine/utils/render-apollo-playground.util';
 import { DataloaderService } from 'src/engine/dataloaders/dataloader.service';
 import { useCachedMetadata } from 'src/engine/api/graphql/graphql-config/hooks/use-cached-metadata';
+import { CacheStorageService } from 'src/engine/integrations/cache-storage/cache-storage.service';
 
 export const metadataModuleFactory = async (
   environmentService: EnvironmentService,
   exceptionHandlerService: ExceptionHandlerService,
   dataloaderService: DataloaderService,
+  workspaceSchemaCacheStorage: CacheStorageService,
 ): Promise<YogaDriverConfig> => {
   const config: YogaDriverConfig = {
     autoSchemaFile: true,
@@ -33,7 +35,10 @@ export const metadataModuleFactory = async (
       useExceptionHandler({
         exceptionHandlerService,
       }),
-      useCachedMetadata(),
+      useCachedMetadata(
+        workspaceSchemaCacheStorage.get.bind(workspaceSchemaCacheStorage),
+        workspaceSchemaCacheStorage.set.bind(workspaceSchemaCacheStorage),
+      ),
     ],
     path: '/metadata',
     context: () => ({


### PR DESCRIPTION
## Context
@lucasbordeau introduced a new Yoga plugin that allows us to cache our requests (👏), see https://github.com/twentyhq/twenty/pull/5189
I'm simply updating the implementation to allow us to use different cache storage types such as redis
Also adding a check so it does not use cache for other operations than ObjectMetadataItems

## Test
locally, first call takes 340ms, 2nd takes 30ms with 'redis' and 13ms with 'memory'