### PR TITLE
chore: add sentry captureException for global error logging

### DIFF
--- a/packages/twenty-front/src/modules/error-handler/components/AppErrorBoundary.tsx
+++ b/packages/twenty-front/src/modules/error-handler/components/AppErrorBoundary.tsx
@@ -1,11 +1,15 @@
 import { ErrorInfo, ReactNode } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
+import * as Sentry from '@sentry/react';
 
 import { GenericErrorFallback } from '@/error-handler/components/GenericErrorFallback';
 
 export const AppErrorBoundary = ({ children }: { children: ReactNode }) => {
   const handleError = (_error: Error, _info: ErrorInfo) => {
-    // TODO: log error to Sentry
+    Sentry.captureException(_error, (scope) => {
+      scope.setExtras({ _info });
+      return scope;
+    });
   };
 
   return (


### PR DESCRIPTION
I have added error logging to Sentry using Sentry.captureException. The _info object which includes the componentStack will be sent in extra data along with the exception.