### PR TITLE
Flush cache when reset db

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/workspace-schema-storage/workspace-schema-storage.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-schema-storage/workspace-schema-storage.service.ts
@@ -86,6 +86,7 @@ export class WorkspaceSchemaStorageService {
   }
 
   async invalidateCache(workspaceId: string): Promise<void> {
+    await this.workspaceSchemaCache.del(`*`);
     await this.workspaceSchemaCache.del(
       `objectMetadataCollection:${workspaceId}`,
     );

--- a/packages/twenty-server/src/engine/api/graphql/workspace-schema-storage/workspace-schema-storage.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-schema-storage/workspace-schema-storage.service.ts
@@ -86,7 +86,6 @@ export class WorkspaceSchemaStorageService {
   }
 
   async invalidateCache(workspaceId: string): Promise<void> {
-    await this.workspaceSchemaCache.del(`*`);
     await this.workspaceSchemaCache.del(
       `objectMetadataCollection:${workspaceId}`,
     );

--- a/packages/twenty-server/src/engine/integrations/cache-storage/cache-storage.service.ts
+++ b/packages/twenty-server/src/engine/integrations/cache-storage/cache-storage.service.ts
@@ -63,6 +63,10 @@ export class CacheStorageService {
     });
   }
 
+  async flush() {
+    return this.cache.reset();
+  }
+
   private isRedisCache() {
     return (this.cache.store as any)?.name === 'redis';
   }


### PR DESCRIPTION
Now that we have persistent cache for schemas, we want to be able to reset its state when users run the database:reset db otherwise schemas won't be synced with the new DB state.

Note: In an upcoming PR, we want to be able to invalidate the cache on a workspace level when we change the metadata schema through twenty version upgrade