### PR TITLE
Remove debounce on filter search bar

### DIFF
--- a/packages/twenty-front/src/modules/object-record/object-filter-dropdown/components/ObjectFilterDropdownFilterSelect.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-filter-dropdown/components/ObjectFilterDropdownFilterSelect.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react';
 import styled from '@emotion/styled';
 import { useRecoilValue } from 'recoil';
 import { useIcons } from 'twenty-ui';
-import { useDebouncedCallback } from 'use-debounce';
 
 import { useFilterDropdown } from '@/object-record/object-filter-dropdown/hooks/useFilterDropdown';
 import { RelationPickerHotkeyScope } from '@/object-record/relation-picker/types/RelationPickerHotkeyScope';
@@ -55,19 +54,14 @@ export const ObjectFilterDropdownFilterSelect = () => {
 
   const setHotkeyScope = useSetHotkeyScope();
 
-  const debouncedSetSearchFilter = useDebouncedCallback(setSearchText, 100, {
-    leading: true,
-  });
-  const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    debouncedSetSearchFilter(event.target.value);
-  };
-
   return (
     <>
       <StyledInput
         value={searchText}
         placeholder="Search fields"
-        onChange={handleSearchChange}
+        onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+          setSearchText(event.target.value)
+        }
       />
       <DropdownMenuItemsContainer>
         {[...availableFilterDefinitions]

--- a/packages/twenty-front/src/modules/object-record/object-filter-dropdown/components/ObjectFilterDropdownFilterSelect.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-filter-dropdown/components/ObjectFilterDropdownFilterSelect.tsx
@@ -58,6 +58,7 @@ export const ObjectFilterDropdownFilterSelect = () => {
     <>
       <StyledInput
         value={searchText}
+        autoFocus
         placeholder="Search fields"
         onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
           setSearchText(event.target.value)


### PR DESCRIPTION
A search bar has been introduced in the filter dropdown menu however we don't want to apply debounce since the search has no side-effect and is purely FE (it's not querying the DB compared to other search bars). Also adding autofocus on the search bar when the dropdown is open.