### PR TITLE
[messaging/calendar] cron jobs can run regardless of sub status if billing is disabled

### DIFF
--- a/packages/twenty-server/src/modules/calendar/crons/jobs/google-calendar-sync.cron.job.ts
+++ b/packages/twenty-server/src/modules/calendar/crons/jobs/google-calendar-sync.cron.job.ts
@@ -12,6 +12,7 @@ import {
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { DataSourceEntity } from 'src/engine/metadata-modules/data-source/data-source.entity';
 import { WorkspaceGoogleCalendarSyncService } from 'src/modules/calendar/services/workspace-google-calendar-sync/workspace-google-calendar-sync.service';
+import { EnvironmentService } from 'src/engine/integrations/environment/environment.service';
 
 @Injectable()
 export class GoogleCalendarSyncCronJob implements MessageQueueJob<undefined> {
@@ -23,17 +24,20 @@ export class GoogleCalendarSyncCronJob implements MessageQueueJob<undefined> {
     @InjectRepository(FeatureFlagEntity, 'core')
     private readonly featureFlagRepository: Repository<FeatureFlagEntity>,
     private readonly workspaceGoogleCalendarSyncService: WorkspaceGoogleCalendarSyncService,
+    private readonly environmentService: EnvironmentService,
   ) {}
 
   async handle(): Promise<void> {
-    const workspaceIds = (
-      await this.workspaceRepository.find({
-        where: {
-          subscriptionStatus: In(['active', 'trialing', 'past_due']),
-        },
+    const workspaceIds = await this.workspaceRepository
+      .find({
+        where: this.environmentService.get('IS_BILLING_ENABLED')
+          ? {
+              subscriptionStatus: In(['active', 'trialing', 'past_due']),
+            }
+          : {},
         select: ['id'],
       })
-    ).map((workspace) => workspace.id);
+      .then((workspaces) => workspaces.map((workspace) => workspace.id));
 
     const workspacesWithFeatureFlagActive =
       await this.featureFlagRepository.find({

--- a/packages/twenty-server/src/modules/calendar/crons/jobs/google-calendar-sync.cron.job.ts
+++ b/packages/twenty-server/src/modules/calendar/crons/jobs/google-calendar-sync.cron.job.ts
@@ -28,8 +28,8 @@ export class GoogleCalendarSyncCronJob implements MessageQueueJob<undefined> {
   ) {}
 
   async handle(): Promise<void> {
-    const workspaceIds = await this.workspaceRepository
-      .find({
+    const workspaceIds = (
+      await this.workspaceRepository.find({
         where: this.environmentService.get('IS_BILLING_ENABLED')
           ? {
               subscriptionStatus: In(['active', 'trialing', 'past_due']),
@@ -37,7 +37,7 @@ export class GoogleCalendarSyncCronJob implements MessageQueueJob<undefined> {
           : {},
         select: ['id'],
       })
-      .then((workspaces) => workspaces.map((workspace) => workspace.id));
+    ).map((workspace) => workspace.id);
 
     const workspacesWithFeatureFlagActive =
       await this.featureFlagRepository.find({

--- a/packages/twenty-server/src/modules/messaging/crons/jobs/gmail-fetch-messages-from-cache.cron.job.ts
+++ b/packages/twenty-server/src/modules/messaging/crons/jobs/gmail-fetch-messages-from-cache.cron.job.ts
@@ -11,6 +11,7 @@ import { InjectObjectMetadataRepository } from 'src/engine/object-metadata-repos
 import { MessageChannelRepository } from 'src/modules/messaging/repositories/message-channel.repository';
 import { MessageChannelObjectMetadata } from 'src/modules/messaging/standard-objects/message-channel.object-metadata';
 import { GmailFetchMessageContentFromCacheService } from 'src/modules/messaging/services/gmail-fetch-message-content-from-cache/gmail-fetch-message-content-from-cache.service';
+import { EnvironmentService } from 'src/engine/integrations/environment/environment.service';
 
 @Injectable()
 export class GmailFetchMessagesFromCacheCronJob
@@ -24,17 +25,20 @@ export class GmailFetchMessagesFromCacheCronJob
     @InjectObjectMetadataRepository(MessageChannelObjectMetadata)
     private readonly messageChannelRepository: MessageChannelRepository,
     private readonly gmailFetchMessageContentFromCacheService: GmailFetchMessageContentFromCacheService,
+    private readonly environmentService: EnvironmentService,
   ) {}
 
   async handle(): Promise<void> {
-    const workspaceIds = (
-      await this.workspaceRepository.find({
-        where: {
-          subscriptionStatus: In(['active', 'trialing', 'past_due']),
-        },
+    const workspaceIds = await this.workspaceRepository
+      .find({
+        where: this.environmentService.get('IS_BILLING_ENABLED')
+          ? {
+              subscriptionStatus: In(['active', 'trialing', 'past_due']),
+            }
+          : {},
         select: ['id'],
       })
-    ).map((workspace) => workspace.id);
+      .then((workspaces) => workspaces.map((workspace) => workspace.id));
 
     const dataSources = await this.dataSourceRepository.find({
       where: {

--- a/packages/twenty-server/src/modules/messaging/crons/jobs/gmail-fetch-messages-from-cache.cron.job.ts
+++ b/packages/twenty-server/src/modules/messaging/crons/jobs/gmail-fetch-messages-from-cache.cron.job.ts
@@ -29,8 +29,8 @@ export class GmailFetchMessagesFromCacheCronJob
   ) {}
 
   async handle(): Promise<void> {
-    const workspaceIds = await this.workspaceRepository
-      .find({
+    const workspaceIds = (
+      await this.workspaceRepository.find({
         where: this.environmentService.get('IS_BILLING_ENABLED')
           ? {
               subscriptionStatus: In(['active', 'trialing', 'past_due']),
@@ -38,7 +38,7 @@ export class GmailFetchMessagesFromCacheCronJob
           : {},
         select: ['id'],
       })
-      .then((workspaces) => workspaces.map((workspace) => workspace.id));
+    ).map((workspace) => workspace.id);
 
     const dataSources = await this.dataSourceRepository.find({
       where: {

--- a/packages/twenty-server/src/modules/messaging/crons/jobs/gmail-partial-sync.cron.job.ts
+++ b/packages/twenty-server/src/modules/messaging/crons/jobs/gmail-partial-sync.cron.job.ts
@@ -35,8 +35,8 @@ export class GmailPartialSyncCronJob implements MessageQueueJob<undefined> {
   ) {}
 
   async handle(): Promise<void> {
-    const workspaceIds = await this.workspaceRepository
-      .find({
+    const workspaceIds = (
+      await this.workspaceRepository.find({
         where: this.environmentService.get('IS_BILLING_ENABLED')
           ? {
               subscriptionStatus: In(['active', 'trialing', 'past_due']),
@@ -44,7 +44,7 @@ export class GmailPartialSyncCronJob implements MessageQueueJob<undefined> {
           : {},
         select: ['id'],
       })
-      .then((workspaces) => workspaces.map((workspace) => workspace.id));
+    ).map((workspace) => workspace.id);
 
     const dataSources = await this.dataSourceRepository.find({
       where: {

--- a/packages/twenty-server/src/modules/messaging/crons/jobs/gmail-partial-sync.cron.job.ts
+++ b/packages/twenty-server/src/modules/messaging/crons/jobs/gmail-partial-sync.cron.job.ts
@@ -16,6 +16,7 @@ import { MessageQueueService } from 'src/engine/integrations/message-queue/servi
 import { InjectObjectMetadataRepository } from 'src/engine/object-metadata-repository/object-metadata-repository.decorator';
 import { MessageChannelRepository } from 'src/modules/messaging/repositories/message-channel.repository';
 import { MessageChannelObjectMetadata } from 'src/modules/messaging/standard-objects/message-channel.object-metadata';
+import { EnvironmentService } from 'src/engine/integrations/environment/environment.service';
 
 @Injectable()
 export class GmailPartialSyncCronJob implements MessageQueueJob<undefined> {
@@ -30,17 +31,20 @@ export class GmailPartialSyncCronJob implements MessageQueueJob<undefined> {
     private readonly messageQueueService: MessageQueueService,
     @InjectObjectMetadataRepository(MessageChannelObjectMetadata)
     private readonly messageChannelRepository: MessageChannelRepository,
+    private readonly environmentService: EnvironmentService,
   ) {}
 
   async handle(): Promise<void> {
-    const workspaceIds = (
-      await this.workspaceRepository.find({
-        where: {
-          subscriptionStatus: In(['active', 'trialing', 'past_due']),
-        },
+    const workspaceIds = await this.workspaceRepository
+      .find({
+        where: this.environmentService.get('IS_BILLING_ENABLED')
+          ? {
+              subscriptionStatus: In(['active', 'trialing', 'past_due']),
+            }
+          : {},
         select: ['id'],
       })
-    ).map((workspace) => workspace.id);
+      .then((workspaces) => workspaces.map((workspace) => workspace.id));
 
     const dataSources = await this.dataSourceRepository.find({
       where: {


### PR DESCRIPTION
## Context
Messaging and calendar cron jobs are only working for workspace that have sub status different than incomplete, this is because currently this is the simplest way to know if a user is onboarded. This should not be the source of truth and this will be updated in a later version. In the meantime, to make self-hosting easier, we are adding an extra check on IS_BILLING_ENABLED env var since sub status is not relevant for people not using billing.