### PR TITLE
Fix sync metadata script

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -33,6 +33,24 @@
       "internalConsoleOptions": "openOnSessionStart",
       "console": "internalConsole",
       "cwd": "${workspaceFolder}/packages/twenty-server/"
+    },
+    {
+      "name": "twenty-server - command debug example",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "npx",
+      "runtimeVersion": "18",
+      "runtimeArgs": [
+        "nx",
+        "run",
+        "twenty-server:command",
+        "my-command",
+        "--my-parameter value",
+      ],
+      "outputCapture": "std",
+      "internalConsoleOptions": "openOnSessionStart",
+      "console": "internalConsole",
+      "cwd": "${workspaceFolder}/packages/twenty-server/"
     }
   ]
 }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/comparators/workspace-field.comparator.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/comparators/workspace-field.comparator.ts
@@ -23,6 +23,9 @@ const commonFieldPropertiesToIgnore = [
   'objectMetadataId',
   'isActive',
   'options',
+  'settings',
+  'joinColumn',
+  'gate',
 ];
 
 const fieldPropertiesToStringify = ['defaultValue'] as const;
@@ -73,7 +76,7 @@ export class WorkspaceFieldComparator {
       standardObjectMetadata.fields,
       {
         shouldIgnoreProperty: (property, originalMetadata) => {
-          if (['options', 'gate'].includes(property)) {
+          if (commonFieldPropertiesToIgnore.includes(property)) {
             return true;
           }
 


### PR DESCRIPTION
While troubleshooting self-hosting migration, we run into issues with sync-metadata script introduced by recent changes