### PR TITLE
Fix token validation on graphql IntrospectionQuery

### DIFF
--- a/packages/twenty-server/src/engine/middlewares/user-workspace.middleware.ts
+++ b/packages/twenty-server/src/engine/middlewares/user-workspace.middleware.ts
@@ -14,6 +14,7 @@ export class UserWorkspaceMiddleware implements NestMiddleware {
 
   async use(req: Request, res: Response, next: NextFunction) {
     const body = req.body;
+
     const excludedOperations = [
       'GetClientConfig',
       'GetCurrentUser',
@@ -24,12 +25,12 @@ export class UserWorkspaceMiddleware implements NestMiddleware {
       'Verify',
       'SignUp',
       'RenewToken',
+      'IntrospectionQuery',
     ];
 
     if (
-      body &&
-      body.operationName &&
-      excludedOperations.includes(body.operationName)
+      !this.tokenService.isTokenPresent(req) &&
+      (!body?.operationName || excludedOperations.includes(body.operationName))
     ) {
       return next();
     }


### PR DESCRIPTION
## Context
We recently introduced a change that now throws a 401 if the token is invalid or expired. 
The first implementation is using an allow list and 'IntrospectionQuery' was missing so the playground was broken.

The check has been updated and we now only check the excludedOperations list if a token is not present. This is because some operations can be both used as loggedIn and loggedOut so we want to validate the token for those sometimes (and set the workspace, user, cache version, etc). Still not a very clean solution imho.