### PR TITLE
Fix filter transform with logic operators

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableWithWrappers.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableWithWrappers.tsx
@@ -81,6 +81,8 @@ export const RecordTableWithWrappers = ({
 
   const objectLabel = foundObjectMetadataItem?.labelSingular;
 
+  const isRemote = foundObjectMetadataItem?.isRemote ?? false;
+
   return (
     <EntityDeleteContext.Provider value={deleteOneRecord}>
       <ScrollWrapper>
@@ -113,25 +115,27 @@ export const RecordTableWithWrappers = ({
                 recordTableId={recordTableId}
                 tableBodyRef={tableBodyRef}
               />
-              {!isRecordTableInitialLoading && numberOfTableRows === 0 && (
-                <AnimatedPlaceholderEmptyContainer>
-                  <AnimatedPlaceholder type="noRecord" />
-                  <AnimatedPlaceholderEmptyTextContainer>
-                    <AnimatedPlaceholderEmptyTitle>
-                      Add your first {objectLabel}
-                    </AnimatedPlaceholderEmptyTitle>
-                    <AnimatedPlaceholderEmptySubTitle>
-                      Use our API or add your first {objectLabel} manually
-                    </AnimatedPlaceholderEmptySubTitle>
-                  </AnimatedPlaceholderEmptyTextContainer>
-                  <Button
-                    Icon={IconPlus}
-                    title={`Add a ${objectLabel}`}
-                    variant={'secondary'}
-                    onClick={createRecord}
-                  />
-                </AnimatedPlaceholderEmptyContainer>
-              )}
+              {!isRecordTableInitialLoading &&
+                numberOfTableRows === 0 &&
+                !isRemote && (
+                  <AnimatedPlaceholderEmptyContainer>
+                    <AnimatedPlaceholder type="noRecord" />
+                    <AnimatedPlaceholderEmptyTextContainer>
+                      <AnimatedPlaceholderEmptyTitle>
+                        Add your first {objectLabel}
+                      </AnimatedPlaceholderEmptyTitle>
+                      <AnimatedPlaceholderEmptySubTitle>
+                        Use our API or add your first {objectLabel} manually
+                      </AnimatedPlaceholderEmptySubTitle>
+                    </AnimatedPlaceholderEmptyTextContainer>
+                    <Button
+                      Icon={IconPlus}
+                      title={`Add a ${objectLabel}`}
+                      variant={'secondary'}
+                      onClick={createRecord}
+                    />
+                  </AnimatedPlaceholderEmptyContainer>
+                )}
             </StyledTableContainer>
           </StyledTableWithHeader>
         </RecordUpdateContext.Provider>

--- a/packages/twenty-front/src/modules/ui/layout/show-page/components/ShowPageSummaryCard.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/show-page/components/ShowPageSummaryCard.tsx
@@ -112,7 +112,11 @@ export const ShowPageSummaryCard = ({
       </StyledAvatarWrapper>
       <StyledInfoContainer>
         <StyledTitle>{title}</StyledTitle>
-        <StyledDate id={dateElementId}>Added {beautifiedCreatedAt}</StyledDate>
+        {beautifiedCreatedAt && (
+          <StyledDate id={dateElementId}>
+            Added {beautifiedCreatedAt}
+          </StyledDate>
+        )}
         <StyledTooltip
           anchorSelect={`#${dateElementId}`}
           content={exactCreatedAt}

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-runner/workspace-migration-runner.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-runner/workspace-migration-runner.service.ts
@@ -495,11 +495,9 @@ export class WorkspaceMigrationRunnerService {
       )
       .join(', ');
 
-    let serverOptions = '';
-
-    Object.entries(foreignTable.referencedTable).forEach(([key, value]) => {
-      serverOptions += ` ${key} '${value}'`;
-    });
+    const serverOptions = Object.entries(foreignTable.referencedTable)
+      .map(([key, value]) => `${key} '${value}'`)
+      .join(', ');
 
     await queryRunner.query(
       `CREATE FOREIGN TABLE ${schemaName}."${name}" (${foreignTableColumns}) SERVER "${foreignTable.foreignDataWrapperId}" OPTIONS (${serverOptions})`,


### PR DESCRIPTION
Various fixes

- Remote objects are read-only for now, we already hide and block most of the write actions but the button that allows you to add a new record in an empty collection was still visible.
- CreatedAt is not mandatory on remote objects (at least for now) so it was breaking the show page, it now checks if createdAt exists and is not null before trying to display the human readable format `Added x days ago`
- The filters are overwritten in query-runner-args.factory.ts to handle NUMBER field type, this was only working with filters like 
```
      {
        "id": {
          "in": [
            1
          ]
        }
```
but not with more depth such as 
```
    "and": [
      {},
      {
        "id": {
          "in": [
            1
          ]
        }
      }
    ]
 ```
- Fixes CREATE FOREIGN TABLE raw query which was missing ",".