### PR TITLE
fix: record board column border spans the available screen height

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-board/components/RecordBoard.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/components/RecordBoard.tsx
@@ -26,6 +26,7 @@ const StyledContainer = styled.div`
   display: flex;
   flex: 1;
   flex-direction: row;
+  height: 100%;
 `;
 
 const StyledWrapper = styled.div`


### PR DESCRIPTION
Resolves #5273