### PR TITLE
Fix github stars endpoint

### DIFF
--- a/packages/twenty-website/src/app/api/github-stars/route.tsx
+++ b/packages/twenty-website/src/app/api/github-stars/route.tsx
@@ -13,11 +13,11 @@ export async function GET() {
       desc(githubStarsModel.timestamp),
     );
 
-    const formattedGithubNumberOfStars = formatNumberOfStars(
+    const githubNumberOfStars = formatNumberOfStars(
       githubStars[0].numberOfStars,
     );
 
-    return Response.json(formattedGithubNumberOfStars);
+    return Response.json({ githubNumberOfStars });
   } catch (error: any) {
     return new Response(`Github stars error: ${error?.message}`, {
       status: 500,

--- a/packages/twenty-website/src/middleware.ts
+++ b/packages/twenty-website/src/middleware.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+
+const allowedOrigins = [
+  'http://localhost:3000',
+  'https://app.twenty.com',
+  'https://twenty.com',
+];
+
+export function middleware(req: any) {
+  const res = NextResponse.next();
+
+  const origin = req.headers.get('origin');
+
+  if (allowedOrigins.includes(origin)) {
+    res.headers.append('Access-Control-Allow-Origin', origin);
+  }
+
+  res.headers.append('Access-Control-Allow-Credentials', 'true');
+  res.headers.append(
+    'Access-Control-Allow-Methods',
+    'GET,DELETE,PATCH,POST,PUT',
+  );
+  res.headers.append(
+    'Access-Control-Allow-Headers',
+    'X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version',
+  );
+
+  return res;
+}
+
+export const config = {
+  matcher: '/api/:path*',
+};

--- a/packages/twenty-website/src/shared-utils/formatNumberOfStars.ts
+++ b/packages/twenty-website/src/shared-utils/formatNumberOfStars.ts
@@ -1,3 +1,3 @@
 export const formatNumberOfStars = (numberOfStars: number) => {
-  return Math.floor(numberOfStars / 100) / 10 + 'k';
+  return Math.ceil(numberOfStars / 100) / 10 + 'k';
 };


### PR DESCRIPTION
- Encapsulated GitHub star response in an object
- Fixed rounding of Github stars to align with Github convention
- Fixed CORS issue so that endpoint can be called from twenty.com and app.twenty.com