### PR TITLE
[messaging] delete message channel cache data once deleted

### DIFF
--- a/packages/twenty-server/src/engine/integrations/message-queue/jobs.module.ts
+++ b/packages/twenty-server/src/engine/integrations/message-queue/jobs.module.ts
@@ -61,6 +61,7 @@ import { MessageChannelMessageAssociationObjectMetadata } from 'src/modules/mess
 import { MessageChannelObjectMetadata } from 'src/modules/messaging/standard-objects/message-channel.object-metadata';
 import { BlocklistItemDeleteCalendarEventsJob } from 'src/modules/calendar/jobs/blocklist-item-delete-calendar-events.job';
 import { BlocklistReimportCalendarEventsJob } from 'src/modules/calendar/jobs/blocklist-reimport-calendar-events.job';
+import { DeleteMessageChannelAssociatedDataJob } from 'src/modules/messaging/jobs/delete-message-channel-associated-data.job';
 
 @Module({
   imports: [
@@ -200,6 +201,10 @@ import { BlocklistReimportCalendarEventsJob } from 'src/modules/calendar/jobs/bl
     {
       provide: BlocklistReimportCalendarEventsJob.name,
       useClass: BlocklistReimportCalendarEventsJob,
+    },
+    {
+      provide: DeleteMessageChannelAssociatedDataJob.name,
+      useClass: DeleteMessageChannelAssociatedDataJob,
     },
   ],
 })

--- a/packages/twenty-server/src/modules/messaging/jobs/delete-message-channel-associated-data.job.ts
+++ b/packages/twenty-server/src/modules/messaging/jobs/delete-message-channel-associated-data.job.ts
@@ -1,0 +1,40 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+import { MessageQueueJob } from 'src/engine/integrations/message-queue/interfaces/message-queue-job.interface';
+
+import { CacheStorageService } from 'src/engine/integrations/cache-storage/cache-storage.service';
+import { InjectCacheStorage } from 'src/engine/integrations/cache-storage/decorators/cache-storage.decorator';
+import { CacheStorageNamespace } from 'src/engine/integrations/cache-storage/types/cache-storage-namespace.enum';
+
+export type DeleteMessageChannelAssociatedDataJobData = {
+  workspaceId: string;
+  messageChannelId: string;
+};
+
+@Injectable()
+export class DeleteMessageChannelAssociatedDataJob
+  implements MessageQueueJob<DeleteMessageChannelAssociatedDataJobData>
+{
+  private readonly logger = new Logger(
+    DeleteMessageChannelAssociatedDataJob.name,
+  );
+
+  constructor(
+    @InjectCacheStorage(CacheStorageNamespace.Messaging)
+    private readonly cacheStorage: CacheStorageService,
+  ) {}
+
+  async handle(data: DeleteMessageChannelAssociatedDataJobData): Promise<void> {
+    this.logger.log(
+      `Deleting message channel ${data.messageChannelId} associated data in workspace ${data.workspaceId}`,
+    );
+
+    await this.cacheStorage.del(
+      `messages-to-import:${data.workspaceId}:gmail:${data.messageChannelId}`,
+    );
+
+    this.logger.log(
+      `Deleted message channel ${data.messageChannelId} associated data in workspace ${data.workspaceId}`,
+    );
+  }
+}

--- a/packages/twenty-server/src/modules/messaging/jobs/gmail-partial-sync.job.ts
+++ b/packages/twenty-server/src/modules/messaging/jobs/gmail-partial-sync.job.ts
@@ -3,7 +3,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { MessageQueueJob } from 'src/engine/integrations/message-queue/interfaces/message-queue-job.interface';
 
 import { GoogleAPIRefreshAccessTokenService } from 'src/modules/connected-account/services/google-api-refresh-access-token/google-api-refresh-access-token.service';
-import { GmailPartialSyncV2Service } from 'src/modules/messaging/services/gmail-partial-sync/gmail-partial-sync.service';
+import { GmailPartialSyncService } from 'src/modules/messaging/services/gmail-partial-sync/gmail-partial-sync.service';
 
 export type GmailPartialSyncJobData = {
   workspaceId: string;
@@ -18,7 +18,7 @@ export class GmailPartialSyncJob
 
   constructor(
     private readonly googleAPIsRefreshAccessTokenService: GoogleAPIRefreshAccessTokenService,
-    private readonly gmailPartialSyncV2Service: GmailPartialSyncV2Service,
+    private readonly gmailPartialSyncService: GmailPartialSyncService,
   ) {}
 
   async handle(data: GmailPartialSyncJobData): Promise<void> {
@@ -40,7 +40,7 @@ export class GmailPartialSyncJob
       return;
     }
 
-    await this.gmailPartialSyncV2Service.fetchConnectedAccountThreads(
+    await this.gmailPartialSyncService.fetchConnectedAccountThreads(
       data.workspaceId,
       data.connectedAccountId,
     );

--- a/packages/twenty-server/src/modules/messaging/listeners/messaging-connected-account.listener.ts
+++ b/packages/twenty-server/src/modules/messaging/listeners/messaging-connected-account.listener.ts
@@ -1,8 +1,5 @@
 import { Injectable, Inject } from '@nestjs/common';
 import { OnEvent } from '@nestjs/event-emitter';
-import { InjectRepository } from '@nestjs/typeorm';
-
-import { Repository } from 'typeorm';
 
 import { ObjectRecordDeleteEvent } from 'src/engine/integrations/event-emitter/types/object-record-delete.event';
 import { MessageQueue } from 'src/engine/integrations/message-queue/message-queue.constants';
@@ -16,7 +13,6 @@ import {
   DeleteConnectedAccountAssociatedMessagingDataJob,
 } from 'src/modules/messaging/jobs/delete-connected-account-associated-messaging-data.job';
 import { ConnectedAccountObjectMetadata } from 'src/modules/connected-account/standard-objects/connected-account.object-metadata';
-import { FeatureFlagEntity } from 'src/engine/core-modules/feature-flag/feature-flag.entity';
 
 @Injectable()
 export class MessagingConnectedAccountListener {
@@ -25,8 +21,6 @@ export class MessagingConnectedAccountListener {
     private readonly messageQueueService: MessageQueueService,
     @Inject(MessageQueue.calendarQueue)
     private readonly calendarQueueService: MessageQueueService,
-    @InjectRepository(FeatureFlagEntity, 'core')
-    private readonly featureFlagRepository: Repository<FeatureFlagEntity>,
   ) {}
 
   @OnEvent('connectedAccount.deleted')

--- a/packages/twenty-server/src/modules/messaging/listeners/messaging-message-channel.listener.ts
+++ b/packages/twenty-server/src/modules/messaging/listeners/messaging-message-channel.listener.ts
@@ -6,6 +6,10 @@ import { objectRecordChangedProperties } from 'src/engine/integrations/event-emi
 import { MessageQueue } from 'src/engine/integrations/message-queue/message-queue.constants';
 import { MessageQueueService } from 'src/engine/integrations/message-queue/services/message-queue.service';
 import {
+  DeleteMessageChannelAssociatedDataJobData,
+  DeleteMessageChannelAssociatedDataJob,
+} from 'src/modules/messaging/jobs/delete-message-channel-associated-data.job';
+import {
   MessagingCreateCompanyAndContactAfterSyncJobData,
   MessagingCreateCompanyAndContactAfterSyncJob,
 } from 'src/modules/messaging/jobs/messaging-create-company-and-contact-after-sync.job';
@@ -37,5 +41,18 @@ export class MessagingMessageChannelListener {
         },
       );
     }
+  }
+
+  @OnEvent('messageChannel.deleted')
+  async handleDeletedEvent(
+    payload: ObjectRecordUpdateEvent<MessageChannelObjectMetadata>,
+  ) {
+    await this.messageQueueService.add<DeleteMessageChannelAssociatedDataJobData>(
+      DeleteMessageChannelAssociatedDataJob.name,
+      {
+        workspaceId: payload.workspaceId,
+        messageChannelId: payload.recordId,
+      },
+    );
   }
 }

--- a/packages/twenty-server/src/modules/messaging/services/gmail-partial-sync/gmail-partial-sync.module.ts
+++ b/packages/twenty-server/src/modules/messaging/services/gmail-partial-sync/gmail-partial-sync.module.ts
@@ -7,7 +7,7 @@ import { WorkspaceDataSourceModule } from 'src/engine/workspace-datasource/works
 import { BlocklistObjectMetadata } from 'src/modules/connected-account/standard-objects/blocklist.object-metadata';
 import { ConnectedAccountObjectMetadata } from 'src/modules/connected-account/standard-objects/connected-account.object-metadata';
 import { FetchMessagesByBatchesModule } from 'src/modules/messaging/services/fetch-messages-by-batches/fetch-messages-by-batches.module';
-import { GmailPartialSyncV2Service as GmailPartialSyncService } from 'src/modules/messaging/services/gmail-partial-sync/gmail-partial-sync.service';
+import { GmailPartialSyncService as GmailPartialSyncService } from 'src/modules/messaging/services/gmail-partial-sync/gmail-partial-sync.service';
 import { MessageModule } from 'src/modules/messaging/services/message/message.module';
 import { MessagingProvidersModule } from 'src/modules/messaging/services/providers/messaging-providers.module';
 import { SaveMessageAndEmitContactCreationEventModule } from 'src/modules/messaging/services/save-message-and-emit-contact-creation-event/save-message-and-emit-contact-creation-event.module';

--- a/packages/twenty-server/src/modules/messaging/services/gmail-partial-sync/gmail-partial-sync.service.ts
+++ b/packages/twenty-server/src/modules/messaging/services/gmail-partial-sync/gmail-partial-sync.service.ts
@@ -28,8 +28,8 @@ import { MessageChannelMessageAssociationObjectMetadata } from 'src/modules/mess
 import { MessageChannelMessageAssociationRepository } from 'src/modules/messaging/repositories/message-channel-message-association.repository';
 
 @Injectable()
-export class GmailPartialSyncV2Service {
-  private readonly logger = new Logger(GmailPartialSyncV2Service.name);
+export class GmailPartialSyncService {
+  private readonly logger = new Logger(GmailPartialSyncService.name);
 
   constructor(
     private readonly gmailClientProvider: GmailClientProvider,


### PR DESCRIPTION
## Context
During messaging sync, we first create a cache per channel and store message ids to fetch so it allows us to request them in batch while following gmail limit rate guidelines.
This PR adds a listener to message channel deletion to delete that cache if it's not empty before deletion.