### PR TITLE
[flexible-schema] Add reserved keyword check on object creation

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/hooks/before-create-one-object.hook.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/hooks/before-create-one-object.hook.ts
@@ -12,12 +12,24 @@ import {
 import { CreateObjectInput } from 'src/engine/metadata-modules/object-metadata/dtos/create-object.input';
 
 const coreObjectNames = [
-  'featureFlag',
   'appToken',
-  'workspace',
+  'billingSubscription',
+  'billingSubscriptionItem',
+  'featureFlag',
   'user',
+  'userWorkspace',
+  'workspace',
+];
+
+const reservedKeywords = [
+  ...coreObjectNames,
   'event',
   'field',
+  'link',
+  'currency',
+  'fullName',
+  'address',
+  'links',
 ];
 
 @Injectable()
@@ -35,8 +47,8 @@ export class BeforeCreateOneObject<T extends CreateObjectInput>
     }
 
     if (
-      coreObjectNames.includes(instance.input.nameSingular) ||
-      coreObjectNames.includes(instance.input.namePlural)
+      reservedKeywords.includes(instance.input.nameSingular) ||
+      reservedKeywords.includes(instance.input.namePlural)
     ) {
       throw new ForbiddenException(
         'You cannot create an object with this name.',


### PR DESCRIPTION
## Context
Because creating an object in metadata also generates a graphql type and because graphql does not allow 2 types with the same name, we have to manage a list of reserved keywords that can't be used as object names.

Currently we were maintaining a list of the core objects but we also have to introduce composite fields that are also generated as gql types.