### PR TITLE
Fix convertRecordPositionsToIntegers command for camelCase tables

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/commands/convert-record-positions-to-integers.command.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/commands/convert-record-positions-to-integers.command.ts
@@ -105,12 +105,12 @@ export class ConvertRecordPositionsToIntegers extends CommandRunner {
     transactionManager: any,
   ): Promise<void> {
     await this.workspaceDataSourceService.executeRawQuery(
-      `UPDATE ${dataSourceSchema}.${tableName} SET position = subquery.position
+      `UPDATE ${dataSourceSchema}."${tableName}" SET position = subquery.position
       FROM (
         SELECT id, ROW_NUMBER() OVER (ORDER BY position) as position
-        FROM ${dataSourceSchema}.${tableName}
+        FROM ${dataSourceSchema}."${tableName}"
       ) as subquery
-      WHERE ${dataSourceSchema}.${tableName}.id = subquery.id`,
+      WHERE ${dataSourceSchema}."${tableName}".id = subquery.id`,
       [],
       workspaceId,
       transactionManager,


### PR DESCRIPTION
## Context
Per title, postgresql will use lowercase if not surrounded by quotes