### PR TITLE
Fix Rest API id UUID error

### DIFF
--- a/packages/twenty-front/src/modules/object-record/hooks/__tests__/useUpdateOneRecordMutation.test.tsx
+++ b/packages/twenty-front/src/modules/object-record/hooks/__tests__/useUpdateOneRecordMutation.test.tsx
@@ -5,7 +5,7 @@ import { RecoilRoot } from 'recoil';
 import { useUpdateOneRecordMutation } from '@/object-record/hooks/useUpdateOneRecordMutation';
 
 const expectedQueryTemplate = `
-mutation UpdateOnePerson($idToUpdate: UUID!, $input: PersonUpdateInput!) {
+mutation UpdateOnePerson($idToUpdate: ID!, $input: PersonUpdateInput!) {
   updatePerson(id: $idToUpdate, data: $input) {
     __typename
     xLink {
@@ -36,13 +36,11 @@ mutation UpdateOnePerson($idToUpdate: UUID!, $input: PersonUpdateInput!) {
 describe('useUpdateOneRecordMutation', () => {
   it('should return a valid createManyRecordsMutation', () => {
     const objectNameSingular = 'person';
-    const depth = 2;
 
     const { result } = renderHook(
       () =>
         useUpdateOneRecordMutation({
           objectNameSingular,
-          depth,
         }),
       {
         wrapper: RecoilRoot,

--- a/packages/twenty-server/src/engine/api/rest/api-rest-query-builder/factories/delete-query.factory.ts
+++ b/packages/twenty-server/src/engine/api/rest/api-rest-query-builder/factories/delete-query.factory.ts
@@ -8,7 +8,7 @@ export class DeleteQueryFactory {
     const objectNameSingular = capitalize(objectMetadataItem.nameSingular);
 
     return `
-      mutation Delete${objectNameSingular}($id: UUID!) {
+      mutation Delete${objectNameSingular}($id: ID!) {
         delete${objectNameSingular}(id: $id) {
           id
         }

--- a/packages/twenty-server/src/engine/api/rest/api-rest-query-builder/factories/update-query.factory.ts
+++ b/packages/twenty-server/src/engine/api/rest/api-rest-query-builder/factories/update-query.factory.ts
@@ -11,7 +11,7 @@ export class UpdateQueryFactory {
     return `
       mutation Update${capitalize(
         objectNameSingular,
-      )}($id: UUID!, $data: ${capitalize(objectNameSingular)}UpdateInput!) {
+      )}($id: ID!, $data: ${capitalize(objectNameSingular)}UpdateInput!) {
         update${capitalize(objectNameSingular)}(id: $id, data: $data) {
           id
           ${objectMetadata.objectMetadataItem.fields

--- a/packages/twenty-server/src/engine/api/rest/metadata-rest.service.ts
+++ b/packages/twenty-server/src/engine/api/rest/metadata-rest.service.ts
@@ -181,7 +181,7 @@ export class ApiRestMetadataService {
 
     return `
       query FindOne${capitalize(objectNameSingular)}(
-        $id: UUID!,
+        $id: ID!,
         ) {
         ${objectNameSingular}(id: $id) {
           id


### PR DESCRIPTION
A user has reported an issue with REST API.
We have recently migrated the graphql IDs from UUID to ID type. As Rest API is leveraging the graphql API under the hood, the Rest API query builder should be updated accordingly