### PR TITLE
Fix 400 yoga errors being sent to exception handlers

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/workspace-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/workspace-query-runner.service.ts
@@ -244,7 +244,7 @@ export class WorkspaceQueryRunnerService {
     assertMutationNotOnRemoteObject(objectMetadataItem);
 
     args.data.forEach((record) => {
-      if (record.id) {
+      if (record?.id) {
         assertIsValidUuid(record.id);
       }
     });

--- a/packages/twenty-server/src/engine/integrations/exception-handler/hooks/use-exception-handler.hook.ts
+++ b/packages/twenty-server/src/engine/integrations/exception-handler/hooks/use-exception-handler.hook.ts
@@ -106,12 +106,11 @@ export const useExceptionHandler = <PluginContext extends GraphQLContext>(
                 ...exceptions.unfiltered,
               ];
               const errors = concatenatedErrors.map((err) => {
-                // Properly convert errors to GraphQLErrors
-                const graphQLError = convertExceptionToGraphQLError(
-                  err.originalError,
-                );
+                if (!err.originalError) {
+                  return err;
+                }
 
-                return graphQLError;
+                return convertExceptionToGraphQLError(err.originalError);
               });
 
               setResult({


### PR DESCRIPTION
## Context
Yoga can catch its own errors and we don't want to convert them again. Moreover those errors don't have an "originalError" property and should be schema related only (400 validation) so we only want to send them back to the API caller without going through the exception handler.

Also fixed an issue in the createMany which was throwing a 500 when id was missing from the creation payload. It seems the FE is always sending an ID but it should actually be optional since the DB can generate one. This is a regression from the new UUID validation introduced a few weeks ago.