### PR TITLE
Fix query runner throwing 500 when pg_graphql detects unique constraint

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/workspace-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/workspace-query-runner.service.ts
@@ -599,13 +599,6 @@ export class WorkspaceQueryRunnerService {
     const result = graphqlResult?.[0]?.resolve?.data?.[entityKey];
     const errors = graphqlResult?.[0]?.resolve?.errors;
 
-    if (!result) {
-      this.logger.log(
-        `No result found for ${entityKey}, graphqlResult: ` +
-          JSON.stringify(graphqlResult, null, 3),
-      );
-    }
-
     if (
       result &&
       ['update', 'deleteFrom'].includes(command) &&


### PR DESCRIPTION
## Context
Since pg_graphql does not return specific error/exception, we have to map the error message and throw validation errors when needed
This PR adds a check on unicity constraint error returned by pg_graphql when we are trying to insert duplicate records and returns a 400 instead of being handled by the exceptionHandler as a 500.