### PR TITLE
Fix: Icon position alignment right to left in chip

### DIFF
--- a/packages/twenty-ui/src/display/chip/components/Chip.tsx
+++ b/packages/twenty-ui/src/display/chip/components/Chip.tsx
@@ -51,7 +51,6 @@ const StyledContainer = styled.div<
   cursor: ${({ clickable, disabled }) =>
     clickable ? 'pointer' : disabled ? 'not-allowed' : 'inherit'};
   display: inline-flex;
-  flex-direction: row-reverse;
   justify-content: center;
   gap: ${({ theme }) => theme.spacing(1)};
   height: ${({ theme }) => theme.spacing(3)};


### PR DESCRIPTION
Fixes #5298 

![image](https://github.com/twentyhq/twenty/assets/52026385/6cfcc380-bdd1-4d7b-a0c7-58434d610ace)
