### PR TITLE
fix: Blue Button Secondary Color Issue in Dark Mode

### DIFF
--- a/packages/twenty-front/src/modules/ui/input/button/components/Button.tsx
+++ b/packages/twenty-front/src/modules/ui/input/button/components/Button.tsx
@@ -160,7 +160,7 @@ const StyledButton = styled.button<
               border-color: ${variant === 'secondary'
                 ? focus
                   ? theme.color.blue
-                  : theme.color.blue20
+                  : theme.accent.primary
                 : focus
                   ? theme.color.blue
                   : 'transparent'};


### PR DESCRIPTION
fixes [#5305](https://github.com/twentyhq/twenty/issues/5305#issue-2280997523)

light mode:

<img width="738" alt="Screenshot 2024-05-08 at 2 24 41 AM" src="https://github.com/twentyhq/twenty/assets/60315832/de01bbfa-6b54-4149-9930-b38840483ddf">

<br>
<br>

dark mode

<img width="735" alt="Screenshot 2024-05-08 at 2 24 55 AM" src="https://github.com/twentyhq/twenty/assets/60315832/7c2bbc3e-e999-42ff-a320-8bf84bce8384">
