### PR TITLE
fix: fix Settings field form validation for certain field types

### DIFF
--- a/packages/twenty-front/src/modules/settings/data-model/fields/forms/components/SettingsDataModelFieldSettingsFormCard.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/forms/components/SettingsDataModelFieldSettingsFormCard.tsx
@@ -1,5 +1,6 @@
 import { useFormContext } from 'react-hook-form';
 import styled from '@emotion/styled';
+import omit from 'lodash.omit';
 import { z } from 'zod';
 
 import { useFilteredObjectMetadataItems } from '@/object-metadata/hooks/useFilteredObjectMetadataItems';
@@ -22,6 +23,7 @@ import {
   settingsDataModelFieldSelectFormSchema,
 } from '@/settings/data-model/components/SettingsObjectFieldSelectForm';
 import { RELATION_TYPES } from '@/settings/data-model/constants/RelationTypes';
+import { SETTINGS_FIELD_TYPE_CONFIGS } from '@/settings/data-model/constants/SettingsFieldTypeConfigs';
 import {
   SettingsDataModelFieldPreviewCard,
   SettingsDataModelFieldPreviewCardProps,
@@ -46,6 +48,20 @@ const selectFieldFormSchema = z
   })
   .merge(settingsDataModelFieldSelectFormSchema);
 
+const otherFieldsFormSchema = z.object({
+  type: z.enum(
+    Object.keys(
+      omit(SETTINGS_FIELD_TYPE_CONFIGS, [
+        FieldMetadataType.Boolean,
+        FieldMetadataType.Currency,
+        FieldMetadataType.Relation,
+        FieldMetadataType.Select,
+        FieldMetadataType.MultiSelect,
+      ]),
+    ) as [FieldMetadataType, ...FieldMetadataType[]],
+  ),
+});
+
 export const settingsDataModelFieldSettingsFormSchema = z.discriminatedUnion(
   'type',
   [
@@ -53,6 +69,7 @@ export const settingsDataModelFieldSettingsFormSchema = z.discriminatedUnion(
     currencyFieldFormSchema,
     relationFieldFormSchema,
     selectFieldFormSchema,
+    otherFieldsFormSchema,
   ],
 );
 

--- a/packages/twenty-front/src/modules/settings/data-model/fields/forms/components/SettingsDataModelFieldTypeSelect.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/forms/components/SettingsDataModelFieldTypeSelect.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/settings/data-model/constants/SettingsFieldTypeConfigs';
 import { SettingsSupportedFieldType } from '@/settings/data-model/types/SettingsSupportedFieldType';
 import { Select, SelectOption } from '@/ui/input/components/Select';
+import { FieldMetadataType } from '~/generated-metadata/graphql';
 
 export const settingsDataModelFieldTypeFormSchema = z.object({
   type: z.enum(
@@ -57,7 +58,7 @@ export const SettingsDataModelFieldTypeSelect = ({
       defaultValue={
         fieldMetadataItem && fieldMetadataItem.type in fieldTypeConfigs
           ? (fieldMetadataItem.type as SettingsSupportedFieldType)
-          : undefined
+          : FieldMetadataType.Text
       }
       render={({ field: { onChange, value } }) => (
         <Select

--- a/packages/twenty-front/src/modules/settings/data-model/fields/forms/components/__stories__/SettingsDataModelFieldTypeSelect.stories.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/forms/components/__stories__/SettingsDataModelFieldTypeSelect.stories.tsx
@@ -34,11 +34,11 @@ export const WithOpenSelect: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    const inputField = await canvas.findByText('Unique ID');
+    const inputField = await canvas.findByText('Text');
 
     await userEvent.click(inputField);
 
-    const input = await canvas.findByText('Text');
+    const input = await canvas.findByText('Unique ID');
     await userEvent.click(input);
 
     await userEvent.click(inputField);

--- a/packages/twenty-front/src/pages/settings/data-model/SettingsObjectFieldEdit.tsx
+++ b/packages/twenty-front/src/pages/settings/data-model/SettingsObjectFieldEdit.tsx
@@ -110,8 +110,9 @@ export const SettingsObjectFieldEdit = () => {
     try {
       if (
         formValues.type === FieldMetadataType.Relation &&
-        isNonEmptyString(relationFieldMetadataItem?.id) &&
-        'relation' in dirtyFields
+        'relation' in formValues &&
+        'relation' in dirtyFields &&
+        isNonEmptyString(relationFieldMetadataItem?.id)
       ) {
         await updateOneFieldMetadataItem({
           fieldMetadataIdToUpdate: relationFieldMetadataItem.id,

--- a/packages/twenty-front/src/pages/settings/data-model/SettingsObjectNewField/SettingsObjectNewFieldStep2.tsx
+++ b/packages/twenty-front/src/pages/settings/data-model/SettingsObjectNewField/SettingsObjectNewFieldStep2.tsx
@@ -211,7 +211,8 @@ export const SettingsObjectNewFieldStep2 = () => {
         const createdMetadataField = await createMetadataField({
           ...formValues,
           defaultValue:
-            formValues.type === FieldMetadataType.Currency
+            formValues.type === FieldMetadataType.Currency &&
+            'defaultValue' in formValues
               ? {
                   ...formValues.defaultValue,
                   amountMicros: null,


### PR DESCRIPTION
Related to #4295

Following #5326, field types other than:
- `FieldMetadataType.Boolean`
- `FieldMetadataType.Currency`
- `FieldMetadataType.Relation`
- `FieldMetadataType.Select`
- `FieldMetadataType.MultiSelect`

Cannot be saved as they are not included in the form validation schema.
This PR makes sure they are included and can therefore be created/edited.