### PR TITLE
Fix display-canvan-options

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/dropdown/components/StyledDropdownMenuSubheader.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/dropdown/components/StyledDropdownMenuSubheader.tsx
@@ -7,5 +7,4 @@ export const StyledDropdownMenuSubheader = styled.div`
   font-weight: ${({ theme }) => theme.font.weight.semiBold};
   padding: ${({ theme }) => `${theme.spacing(1)} ${theme.spacing(2)}`};
   text-transform: uppercase;
-  width: 100%;
 `;

--- a/packages/twenty-front/src/modules/ui/navigation/menu-item/components/MenuItemDraggable.tsx
+++ b/packages/twenty-front/src/modules/ui/navigation/menu-item/components/MenuItemDraggable.tsx
@@ -42,12 +42,7 @@ export const MenuItemDraggable = ({
         text={text}
         showGrip={!isDragDisabled}
       />
-      {showIconButtons && (
-        <LightIconButtonGroup
-          className="hoverable-buttons"
-          iconButtons={iconButtons}
-        />
-      )}
+      {showIconButtons && <LightIconButtonGroup iconButtons={iconButtons} />}
     </StyledHoverableMenuItemBase>
   );
 };


### PR DESCRIPTION
- close #5393 

## Work

Fixed issue #5393.

## Before

<img width="257" alt="image" src="https://github.com/twentyhq/twenty/assets/116232939/0a5e44c0-40f4-41b3-92f3-87a6a21198e7">


## After

<img width="188" alt="image" src="https://github.com/twentyhq/twenty/assets/116232939/23583081-4bef-401e-b70d-1e48f37cdf93">

## Work Detail

I think it would be good to apply truncate in the case of long text because the full name can be shown through the too tip of the hover effect.