### PR TITLE
Fix missing team member images in calendar event

### DIFF
--- a/packages/twenty-front/src/modules/activities/calendar/graphql/operation-signatures/FindOneCalendarEventOperationSignature.ts
+++ b/packages/twenty-front/src/modules/activities/calendar/graphql/operation-signatures/FindOneCalendarEventOperationSignature.ts
@@ -1,0 +1,33 @@
+import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
+import { RecordGqlOperationSignature } from '@/object-record/graphql/types/RecordGqlOperationSignature';
+
+export const FIND_ONE_CALENDAR_EVENT_OPERATION_SIGNATURE: RecordGqlOperationSignature =
+  {
+    objectNameSingular: CoreObjectNameSingular.CalendarEvent,
+    variables: {},
+    fields: {
+      conferenceLink: true,
+      description: true,
+      endsAt: true,
+      externalCreatedAt: true,
+      id: true,
+      isCanceled: true,
+      isFullDay: true,
+      location: true,
+      startsAt: true,
+      title: true,
+      visibility: true,
+      calendarEventParticipants: {
+        id: true,
+        person: true,
+        workspaceMember: true,
+        isOrganizer: true,
+        responseStatus: true,
+        handle: true,
+        createdAt: true,
+        calendarEventId: true,
+        updatedAt: true,
+        displayName: true,
+      },
+    },
+  };

--- a/packages/twenty-front/src/modules/activities/calendar/right-drawer/components/RightDrawerCalendarEvent.tsx
+++ b/packages/twenty-front/src/modules/activities/calendar/right-drawer/components/RightDrawerCalendarEvent.tsx
@@ -6,6 +6,31 @@ import { CalendarEvent } from '@/activities/calendar/types/CalendarEvent';
 import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
 import { useFindOneRecord } from '@/object-record/hooks/useFindOneRecord';
 import { useSetRecordInStore } from '@/object-record/record-store/hooks/useSetRecordInStore';
+const recordGqlFields = {
+  conferenceLink: true,
+  description: true,
+  endsAt: true,
+  externalCreatedAt: true,
+  id: true,
+  isCanceled: true,
+  isFullDay: true,
+  location: true,
+  startsAt: true,
+  title: true,
+  visibility: true,
+  calendarEventParticipants: {
+    id: true,
+    person: true,
+    workspaceMember: true,
+    isOrganizer: true,
+    responseStatus: true,
+    handle: true,
+    createdAt: true,
+    calendarEventId: true,
+    updatedAt: true,
+    displayName: true,
+  },
+};
 
 export const RightDrawerCalendarEvent = () => {
   const { setRecords } = useSetRecordInStore();
@@ -13,6 +38,7 @@ export const RightDrawerCalendarEvent = () => {
   const { record: calendarEvent } = useFindOneRecord<CalendarEvent>({
     objectNameSingular: CoreObjectNameSingular.CalendarEvent,
     objectRecordId: viewableCalendarEventId ?? '',
+    recordGqlFields: recordGqlFields,
     onCompleted: (record) => setRecords([record]),
   });
 

--- a/packages/twenty-front/src/modules/activities/calendar/right-drawer/components/RightDrawerCalendarEvent.tsx
+++ b/packages/twenty-front/src/modules/activities/calendar/right-drawer/components/RightDrawerCalendarEvent.tsx
@@ -1,44 +1,20 @@
 import { useRecoilValue } from 'recoil';
 
 import { CalendarEventDetails } from '@/activities/calendar/components/CalendarEventDetails';
+import { FIND_ONE_CALENDAR_EVENT_OPERATION_SIGNATURE } from '@/activities/calendar/graphql/operation-signatures/FindOneCalendarEventOperationSignature';
 import { viewableCalendarEventIdState } from '@/activities/calendar/states/viewableCalendarEventIdState';
 import { CalendarEvent } from '@/activities/calendar/types/CalendarEvent';
-import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
 import { useFindOneRecord } from '@/object-record/hooks/useFindOneRecord';
 import { useSetRecordInStore } from '@/object-record/record-store/hooks/useSetRecordInStore';
-const recordGqlFields = {
-  conferenceLink: true,
-  description: true,
-  endsAt: true,
-  externalCreatedAt: true,
-  id: true,
-  isCanceled: true,
-  isFullDay: true,
-  location: true,
-  startsAt: true,
-  title: true,
-  visibility: true,
-  calendarEventParticipants: {
-    id: true,
-    person: true,
-    workspaceMember: true,
-    isOrganizer: true,
-    responseStatus: true,
-    handle: true,
-    createdAt: true,
-    calendarEventId: true,
-    updatedAt: true,
-    displayName: true,
-  },
-};
 
 export const RightDrawerCalendarEvent = () => {
   const { setRecords } = useSetRecordInStore();
   const viewableCalendarEventId = useRecoilValue(viewableCalendarEventIdState);
   const { record: calendarEvent } = useFindOneRecord<CalendarEvent>({
-    objectNameSingular: CoreObjectNameSingular.CalendarEvent,
+    objectNameSingular:
+      FIND_ONE_CALENDAR_EVENT_OPERATION_SIGNATURE.objectNameSingular,
     objectRecordId: viewableCalendarEventId ?? '',
-    recordGqlFields: recordGqlFields,
+    recordGqlFields: FIND_ONE_CALENDAR_EVENT_OPERATION_SIGNATURE.fields,
     onCompleted: (record) => setRecords([record]),
   });
 

--- a/packages/twenty-front/src/modules/activities/components/ParticipantChip.tsx
+++ b/packages/twenty-front/src/modules/activities/components/ParticipantChip.tsx
@@ -5,26 +5,6 @@ import { getDisplayNameFromParticipant } from '@/activities/emails/utils/getDisp
 import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
 import { RecordChip } from '@/object-record/components/RecordChip';
 import { getImageAbsoluteURIOrBase64 } from '~/utils/image/getImageAbsoluteURIOrBase64';
-import { gql, useQuery } from '@apollo/client';
-import React from 'react';
-import { UUID } from 'crypto';
-
-var queryPerson = gql`
-query FindOnePerson($objectRecordId: UUID!) {
-  person(filter: { id: { eq: $objectRecordId } }) {
-    __typename
-    avatarUrl
-  }
-}
-`;
-var queryWorkspaceMember = gql`
-query FindOneWorkspaceMember($objectRecordId: UUID!) {
-  workspaceMember(filter: { id: { eq: $objectRecordId } }) {
-    __typename
-    avatarUrl
-  }
-}
-`;
 
 const StyledAvatar = styled(Avatar)`
   margin-right: ${({ theme }) => theme.spacing(1)};
@@ -73,28 +53,6 @@ export const ParticipantChip = ({
   variant?: ParticipantChipVariant;
   className?: string;
 }) => {
-  const [personId, setPersonId] = React.useState<string>('');
-  const [workspaceMemberId, setWorkspaceMemberId] = React.useState<string>('');
-
-  // Trigger the queries when personId or workspaceMemberId changes
-  React.useEffect(() => {
-    setPersonId(participant.personId || '');
-    setWorkspaceMemberId(participant.workspaceMemberId || '');
-  }, [participant.personId, participant.workspaceMemberId]);
-
-  const personData = useQuery(queryPerson, {
-    variables: { objectRecordId: personId as UUID },
-    skip: !personId, 
-  });
-
-  const workspaceMemberData = useQuery(queryWorkspaceMember, {
-    variables: { objectRecordId: workspaceMemberId as UUID},
-    skip: !workspaceMemberId,
-  });
-
-  const dataPerson = personData.data;
-  const dataWorkspaceMember = workspaceMemberData.data;
-
   const { person, workspaceMember } = participant;
 
   const displayName = getDisplayNameFromParticipant({
@@ -102,8 +60,7 @@ export const ParticipantChip = ({
     shouldUseFullName: true,
   });
 
-  const avatarUrl =
-    dataPerson?.person?.avatarUrl ?? dataWorkspaceMember?.workspaceMember?.avatarUrl ?? '';
+  const avatarUrl = person?.avatarUrl ?? workspaceMember?.avatarUrl ?? '';
 
   return (
     <StyledContainer className={className}>

--- a/packages/twenty-front/src/modules/activities/components/ParticipantChip.tsx
+++ b/packages/twenty-front/src/modules/activities/components/ParticipantChip.tsx
@@ -5,6 +5,26 @@ import { getDisplayNameFromParticipant } from '@/activities/emails/utils/getDisp
 import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
 import { RecordChip } from '@/object-record/components/RecordChip';
 import { getImageAbsoluteURIOrBase64 } from '~/utils/image/getImageAbsoluteURIOrBase64';
+import { gql, useQuery } from '@apollo/client';
+import React from 'react';
+import { UUID } from 'crypto';
+
+var queryPerson = gql`
+query FindOnePerson($objectRecordId: UUID!) {
+  person(filter: { id: { eq: $objectRecordId } }) {
+    __typename
+    avatarUrl
+  }
+}
+`;
+var queryWorkspaceMember = gql`
+query FindOneWorkspaceMember($objectRecordId: UUID!) {
+  workspaceMember(filter: { id: { eq: $objectRecordId } }) {
+    __typename
+    avatarUrl
+  }
+}
+`;
 
 const StyledAvatar = styled(Avatar)`
   margin-right: ${({ theme }) => theme.spacing(1)};
@@ -53,6 +73,28 @@ export const ParticipantChip = ({
   variant?: ParticipantChipVariant;
   className?: string;
 }) => {
+  const [personId, setPersonId] = React.useState<string>('');
+  const [workspaceMemberId, setWorkspaceMemberId] = React.useState<string>('');
+
+  // Trigger the queries when personId or workspaceMemberId changes
+  React.useEffect(() => {
+    setPersonId(participant.personId || '');
+    setWorkspaceMemberId(participant.workspaceMemberId || '');
+  }, [participant.personId, participant.workspaceMemberId]);
+
+  const personData = useQuery(queryPerson, {
+    variables: { objectRecordId: personId as UUID },
+    skip: !personId, 
+  });
+
+  const workspaceMemberData = useQuery(queryWorkspaceMember, {
+    variables: { objectRecordId: workspaceMemberId as UUID},
+    skip: !workspaceMemberId,
+  });
+
+  const dataPerson = personData.data;
+  const dataWorkspaceMember = workspaceMemberData.data;
+
   const { person, workspaceMember } = participant;
 
   const displayName = getDisplayNameFromParticipant({
@@ -60,7 +102,8 @@ export const ParticipantChip = ({
     shouldUseFullName: true,
   });
 
-  const avatarUrl = person?.avatarUrl ?? workspaceMember?.avatarUrl ?? '';
+  const avatarUrl =
+    dataPerson?.person?.avatarUrl ?? dataWorkspaceMember?.workspaceMember?.avatarUrl ?? '';
 
   return (
     <StyledContainer className={className}>


### PR DESCRIPTION
### Work
Fixed issue: #5308 
### Before
Team member images are absent from Calendar events participant chips.
![Before](https://github.com/twentyhq/twenty/assets/100703401/bd3408ad-4a07-430e-ba23-83cd0775492a)
### After
<img width="383" alt="Screenshot 2024-05-14 at 10 53 24" src="https://github.com/twentyhq/twenty/assets/100703401/b65efe8a-64de-4214-a60a-ee87d235953a">

### Fix explained
Redefined recordGqlField to fech Person and WorkspaceMember