### PR TITLE
Minor refacto and fixes on Remotes updates

### DIFF
--- a/packages/twenty-front/src/generated-metadata/graphql.ts
+++ b/packages/twenty-front/src/generated-metadata/graphql.ts
@@ -338,8 +338,6 @@ export enum FileFolder {
 export type FindManyRemoteTablesInput = {
   /** The id of the remote server. */
   id: Scalars['ID']['input'];
-  /** Indicates if data from distant tables should be refreshed. */
-  shouldFetchPendingSchemaUpdates?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type FullName = {

--- a/packages/twenty-front/src/generated-metadata/graphql.ts
+++ b/packages/twenty-front/src/generated-metadata/graphql.ts
@@ -250,6 +250,14 @@ export type DeleteOneRelationInput = {
   id: Scalars['UUID']['input'];
 };
 
+/** Schema update on a table */
+export enum DistantTableUpdate {
+  ColumnsAdded = 'COLUMNS_ADDED',
+  ColumnsDeleted = 'COLUMNS_DELETED',
+  ColumnsTypeChanged = 'COLUMNS_TYPE_CHANGED',
+  TableDeleted = 'TABLE_DELETED'
+}
+
 export type EmailPasswordResetLink = {
   __typename?: 'EmailPasswordResetLink';
   /** Boolean that confirms query was dispatched */
@@ -331,7 +339,7 @@ export type FindManyRemoteTablesInput = {
   /** The id of the remote server. */
   id: Scalars['ID']['input'];
   /** Indicates if data from distant tables should be refreshed. */
-  refreshData?: InputMaybe<Scalars['Boolean']['input']>;
+  shouldFetchPendingSchemaUpdates?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type FullName = {
@@ -812,7 +820,7 @@ export type RemoteTable = {
   id?: Maybe<Scalars['UUID']['output']>;
   name: Scalars['String']['output'];
   schema?: Maybe<Scalars['String']['output']>;
-  schemaPendingUpdates?: Maybe<Array<TableUpdate>>;
+  schemaPendingUpdates?: Maybe<Array<DistantTableUpdate>>;
   status: RemoteTableStatus;
 };
 
@@ -856,14 +864,6 @@ export type Support = {
   supportDriver: Scalars['String']['output'];
   supportFrontChatId?: Maybe<Scalars['String']['output']>;
 };
-
-/** Schema update on a table */
-export enum TableUpdate {
-  ColumnsAdded = 'COLUMNS_ADDED',
-  ColumnsDeleted = 'COLUMNS_DELETED',
-  ColumnsTypeChanged = 'COLUMNS_TYPE_CHANGED',
-  TableDeleted = 'TABLE_DELETED'
-}
 
 export type Telemetry = {
   __typename?: 'Telemetry';
@@ -1261,7 +1261,7 @@ export type RelationEdge = {
 
 export type RemoteServerFieldsFragment = { __typename?: 'RemoteServer', id: string, createdAt: any, foreignDataWrapperId: string, foreignDataWrapperOptions?: any | null, foreignDataWrapperType: string, updatedAt: any, schema?: string | null, userMappingOptions?: { __typename?: 'UserMappingOptionsUser', user?: string | null } | null };
 
-export type RemoteTableFieldsFragment = { __typename?: 'RemoteTable', id?: any | null, name: string, schema?: string | null, status: RemoteTableStatus, schemaPendingUpdates?: Array<TableUpdate> | null };
+export type RemoteTableFieldsFragment = { __typename?: 'RemoteTable', id?: any | null, name: string, schema?: string | null, status: RemoteTableStatus, schemaPendingUpdates?: Array<DistantTableUpdate> | null };
 
 export type CreateServerMutationVariables = Exact<{
   input: CreateRemoteServerInput;
@@ -1282,14 +1282,14 @@ export type SyncRemoteTableMutationVariables = Exact<{
 }>;
 
 
-export type SyncRemoteTableMutation = { __typename?: 'Mutation', syncRemoteTable: { __typename?: 'RemoteTable', id?: any | null, name: string, schema?: string | null, status: RemoteTableStatus, schemaPendingUpdates?: Array<TableUpdate> | null } };
+export type SyncRemoteTableMutation = { __typename?: 'Mutation', syncRemoteTable: { __typename?: 'RemoteTable', id?: any | null, name: string, schema?: string | null, status: RemoteTableStatus, schemaPendingUpdates?: Array<DistantTableUpdate> | null } };
 
 export type UnsyncRemoteTableMutationVariables = Exact<{
   input: RemoteTableInput;
 }>;
 
 
-export type UnsyncRemoteTableMutation = { __typename?: 'Mutation', unsyncRemoteTable: { __typename?: 'RemoteTable', id?: any | null, name: string, schema?: string | null, status: RemoteTableStatus, schemaPendingUpdates?: Array<TableUpdate> | null } };
+export type UnsyncRemoteTableMutation = { __typename?: 'Mutation', unsyncRemoteTable: { __typename?: 'RemoteTable', id?: any | null, name: string, schema?: string | null, status: RemoteTableStatus, schemaPendingUpdates?: Array<DistantTableUpdate> | null } };
 
 export type UpdateServerMutationVariables = Exact<{
   input: UpdateRemoteServerInput;
@@ -1310,7 +1310,7 @@ export type GetManyRemoteTablesQueryVariables = Exact<{
 }>;
 
 
-export type GetManyRemoteTablesQuery = { __typename?: 'Query', findAvailableRemoteTablesByServerId: Array<{ __typename?: 'RemoteTable', id?: any | null, name: string, schema?: string | null, status: RemoteTableStatus, schemaPendingUpdates?: Array<TableUpdate> | null }> };
+export type GetManyRemoteTablesQuery = { __typename?: 'Query', findAvailableRemoteTablesByServerId: Array<{ __typename?: 'RemoteTable', id?: any | null, name: string, schema?: string | null, status: RemoteTableStatus, schemaPendingUpdates?: Array<DistantTableUpdate> | null }> };
 
 export type GetOneDatabaseConnectionQueryVariables = Exact<{
   input: RemoteServerIdInput;

--- a/packages/twenty-front/src/modules/databases/hooks/useGetDatabaseConnectionTables.ts
+++ b/packages/twenty-front/src/modules/databases/hooks/useGetDatabaseConnectionTables.ts
@@ -10,13 +10,13 @@ import {
 type UseGetDatabaseConnectionTablesParams = {
   connectionId: string;
   skip?: boolean;
-  refreshData?: boolean;
+  shouldFetchPendingSchemaUpdates?: boolean;
 };
 
 export const useGetDatabaseConnectionTables = ({
   connectionId,
   skip,
-  refreshData,
+  shouldFetchPendingSchemaUpdates,
 }: UseGetDatabaseConnectionTablesParams) => {
   const apolloMetadataClient = useApolloMetadataClient();
 
@@ -29,7 +29,7 @@ export const useGetDatabaseConnectionTables = ({
     variables: {
       input: {
         id: connectionId,
-        refreshData: refreshData,
+        shouldFetchPendingSchemaUpdates: shouldFetchPendingSchemaUpdates,
       },
     },
   });

--- a/packages/twenty-front/src/modules/databases/hooks/useGetDatabaseConnectionTables.ts
+++ b/packages/twenty-front/src/modules/databases/hooks/useGetDatabaseConnectionTables.ts
@@ -10,13 +10,11 @@ import {
 type UseGetDatabaseConnectionTablesParams = {
   connectionId: string;
   skip?: boolean;
-  shouldFetchPendingSchemaUpdates?: boolean;
 };
 
 export const useGetDatabaseConnectionTables = ({
   connectionId,
   skip,
-  shouldFetchPendingSchemaUpdates,
 }: UseGetDatabaseConnectionTablesParams) => {
   const apolloMetadataClient = useApolloMetadataClient();
 
@@ -29,7 +27,6 @@ export const useGetDatabaseConnectionTables = ({
     variables: {
       input: {
         id: connectionId,
-        shouldFetchPendingSchemaUpdates,
       },
     },
   });

--- a/packages/twenty-front/src/modules/databases/hooks/useGetDatabaseConnectionTables.ts
+++ b/packages/twenty-front/src/modules/databases/hooks/useGetDatabaseConnectionTables.ts
@@ -29,7 +29,7 @@ export const useGetDatabaseConnectionTables = ({
     variables: {
       input: {
         id: connectionId,
-        shouldFetchPendingSchemaUpdates: shouldFetchPendingSchemaUpdates,
+        shouldFetchPendingSchemaUpdates,
       },
     },
   });

--- a/packages/twenty-front/src/modules/settings/integrations/database-connection/components/SettingsIntegrationDatabaseConnectionSyncStatus.tsx
+++ b/packages/twenty-front/src/modules/settings/integrations/database-connection/components/SettingsIntegrationDatabaseConnectionSyncStatus.tsx
@@ -39,7 +39,9 @@ export const SettingsIntegrationDatabaseConnectionSyncStatus = ({
           ? `1 tracked table${
               updatesAvailable ? ' (with pending schema updates)' : ''
             }`
-          : `${syncedTables.length} tracked tables`
+          : `${syncedTables.length} tracked tables${
+              updatesAvailable ? ' (with pending schema updates)' : ''
+            }`
       }
     />
   );

--- a/packages/twenty-front/src/modules/settings/integrations/database-connection/components/SettingsIntegrationDatabaseConnectionSyncStatus.tsx
+++ b/packages/twenty-front/src/modules/settings/integrations/database-connection/components/SettingsIntegrationDatabaseConnectionSyncStatus.tsx
@@ -15,7 +15,6 @@ export const SettingsIntegrationDatabaseConnectionSyncStatus = ({
   const { tables, error } = useGetDatabaseConnectionTables({
     connectionId,
     skip,
-    shouldFetchPendingSchemaUpdates: true,
   });
 
   if (isDefined(error)) {
@@ -34,7 +33,7 @@ export const SettingsIntegrationDatabaseConnectionSyncStatus = ({
 
   return (
     <Status
-      color="green"
+      color={updatesAvailable ? 'yellow' : 'green'}
       text={
         syncedTables.length === 1
           ? `1 tracked table${

--- a/packages/twenty-front/src/modules/settings/integrations/database-connection/components/SettingsIntegrationDatabaseConnectionSyncStatus.tsx
+++ b/packages/twenty-front/src/modules/settings/integrations/database-connection/components/SettingsIntegrationDatabaseConnectionSyncStatus.tsx
@@ -15,6 +15,7 @@ export const SettingsIntegrationDatabaseConnectionSyncStatus = ({
   const { tables, error } = useGetDatabaseConnectionTables({
     connectionId,
     skip,
+    shouldFetchPendingSchemaUpdates: true,
   });
 
   if (isDefined(error)) {
@@ -25,12 +26,20 @@ export const SettingsIntegrationDatabaseConnectionSyncStatus = ({
     (table) => table.status === RemoteTableStatus.Synced,
   );
 
+  const updatesAvailable = tables.some(
+    (table) =>
+      table.schemaPendingUpdates?.length &&
+      table.schemaPendingUpdates.length > 0,
+  );
+
   return (
     <Status
       color="green"
       text={
         syncedTables.length === 1
-          ? `1 tracked table`
+          ? `1 tracked table${
+              updatesAvailable ? ' (with pending schema updates)' : ''
+            }`
           : `${syncedTables.length} tracked tables`
       }
     />

--- a/packages/twenty-front/src/modules/settings/integrations/database-connection/components/SettingsIntegrationDatabaseTablesListCard.tsx
+++ b/packages/twenty-front/src/modules/settings/integrations/database-connection/components/SettingsIntegrationDatabaseTablesListCard.tsx
@@ -7,9 +7,9 @@ import { useUnsyncRemoteTable } from '@/databases/hooks/useUnsyncRemoteTable';
 import { SettingsListCard } from '@/settings/components/SettingsListCard';
 import { SettingsIntegrationRemoteTableSyncStatusToggle } from '@/settings/integrations/components/SettingsIntegrationRemoteTableSyncStatusToggle';
 import {
+  DistantTableUpdate,
   RemoteTable,
   RemoteTableStatus,
-  TableUpdate,
 } from '~/generated-metadata/graphql';
 import { isDefined } from '~/utils/isDefined';
 
@@ -39,20 +39,22 @@ const StyledText = styled.h3`
   margin: 0;
 `;
 
-const getTableUpdatesText = (schemaPendingUpdates: TableUpdate[]) => {
-  if (schemaPendingUpdates.includes(TableUpdate.TableDeleted)) {
+const getDistantTableUpdatesText = (
+  schemaPendingUpdates: DistantTableUpdate[],
+) => {
+  if (schemaPendingUpdates.includes(DistantTableUpdate.TableDeleted)) {
     return 'Table has been deleted';
   }
   if (
-    schemaPendingUpdates.includes(TableUpdate.ColumnsAdded) &&
-    schemaPendingUpdates.includes(TableUpdate.ColumnsDeleted)
+    schemaPendingUpdates.includes(DistantTableUpdate.ColumnsAdded) &&
+    schemaPendingUpdates.includes(DistantTableUpdate.ColumnsDeleted)
   ) {
     return 'Columns have been added and other deleted';
   }
-  if (schemaPendingUpdates.includes(TableUpdate.ColumnsAdded)) {
+  if (schemaPendingUpdates.includes(DistantTableUpdate.ColumnsAdded)) {
     return 'Columns have been added';
   }
-  if (schemaPendingUpdates.includes(TableUpdate.ColumnsDeleted)) {
+  if (schemaPendingUpdates.includes(DistantTableUpdate.ColumnsDeleted)) {
     return 'Columns have been deleted';
   }
   return null;
@@ -71,7 +73,7 @@ export const SettingsIntegrationDatabaseTablesListCard = ({
       ...table,
       id: table.name,
       updatesText: table.schemaPendingUpdates
-        ? getTableUpdatesText(table.schemaPendingUpdates)
+        ? getDistantTableUpdatesText(table.schemaPendingUpdates)
         : null,
     })),
   );

--- a/packages/twenty-front/src/modules/settings/integrations/database-connection/hooks/useDatabaseConnection.ts
+++ b/packages/twenty-front/src/modules/settings/integrations/database-connection/hooks/useDatabaseConnection.ts
@@ -42,7 +42,6 @@ export const useDatabaseConnection = () => {
   const { tables } = useGetDatabaseConnectionTables({
     connectionId,
     skip: !connection,
-    shouldFetchPendingSchemaUpdates: true,
   });
 
   return { connection, integration, databaseKey, tables };

--- a/packages/twenty-front/src/modules/settings/integrations/database-connection/hooks/useDatabaseConnection.ts
+++ b/packages/twenty-front/src/modules/settings/integrations/database-connection/hooks/useDatabaseConnection.ts
@@ -42,7 +42,7 @@ export const useDatabaseConnection = () => {
   const { tables } = useGetDatabaseConnectionTables({
     connectionId,
     skip: !connection,
-    refreshData: true,
+    shouldFetchPendingSchemaUpdates: true,
   });
 
   return { connection, integration, databaseKey, tables };

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/distant-table/distant-table.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/distant-table/distant-table.service.ts
@@ -39,9 +39,9 @@ export class DistantTableService {
   public async fetchDistantTables(
     remoteServer: RemoteServerEntity<RemoteServerType>,
     workspaceId: string,
-    refreshData?: boolean,
+    shouldFetchPendingSchemaUpdates?: boolean,
   ): Promise<DistantTables> {
-    if (!refreshData && remoteServer.availableTables) {
+    if (!shouldFetchPendingSchemaUpdates && remoteServer.availableTables) {
       return remoteServer.availableTables;
     }
 

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/distant-table/distant-table.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/distant-table/distant-table.service.ts
@@ -39,13 +39,8 @@ export class DistantTableService {
   public async fetchDistantTables(
     remoteServer: RemoteServerEntity<RemoteServerType>,
     workspaceId: string,
-    shouldFetchPendingSchemaUpdates?: boolean,
   ): Promise<DistantTables> {
-    if (!shouldFetchPendingSchemaUpdates && remoteServer.availableTables) {
-      return remoteServer.availableTables;
-    }
-
-    return await this.createAvailableTables(remoteServer, workspaceId);
+    return this.createAvailableTables(remoteServer, workspaceId);
   }
 
   private async createAvailableTables(

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/distant-table/distant-table.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/distant-table/distant-table.service.ts
@@ -9,9 +9,9 @@ import {
   RemoteServerType,
 } from 'src/engine/metadata-modules/remote-server/remote-server.entity';
 import { WorkspaceDataSourceService } from 'src/engine/workspace-datasource/workspace-datasource.service';
-import { DistantTableColumn } from 'src/engine/metadata-modules/remote-server/remote-table/distant-table/types/distant-table-column';
 import { DistantTables } from 'src/engine/metadata-modules/remote-server/remote-table/distant-table/types/distant-table';
 import { STRIPE_DISTANT_TABLES } from 'src/engine/metadata-modules/remote-server/remote-table/distant-table/util/stripe-distant-tables.util';
+import { PostgresTableSchemaColumn } from 'src/engine/metadata-modules/remote-server/types/postgres-table-schema-column';
 
 @Injectable()
 export class DistantTableService {
@@ -26,7 +26,7 @@ export class DistantTableService {
   public getDistantTableColumns(
     remoteServer: RemoteServerEntity<RemoteServerType>,
     tableName: string,
-  ): DistantTableColumn[] {
+  ): PostgresTableSchemaColumn[] {
     if (!remoteServer.availableTables) {
       throw new BadRequestException(
         'Remote server available tables are not defined',

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/distant-table/types/distant-table-column.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/distant-table/types/distant-table-column.ts
@@ -1,6 +1,0 @@
-// Type will evolve as we add more remote table types
-export type DistantTableColumn = {
-  columnName: string;
-  dataType: string;
-  udtName: string;
-};

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/distant-table/types/distant-table.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/distant-table/types/distant-table.ts
@@ -1,5 +1,5 @@
-import { DistantTableColumn } from 'src/engine/metadata-modules/remote-server/remote-table/distant-table/types/distant-table-column';
+import { PostgresTableSchemaColumn } from 'src/engine/metadata-modules/remote-server/types/postgres-table-schema-column';
 
 export type DistantTables = {
-  [tableName: string]: DistantTableColumn[];
+  [tableName: string]: PostgresTableSchemaColumn[];
 };

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/dtos/find-many-remote-tables-input.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/dtos/find-many-remote-tables-input.ts
@@ -1,17 +1,9 @@
-import { InputType, ID, Field } from '@nestjs/graphql';
+import { InputType, ID } from '@nestjs/graphql';
 
 import { IDField } from '@ptc-org/nestjs-query-graphql';
-import { IsOptional } from 'class-validator';
 
 @InputType()
 export class FindManyRemoteTablesInput {
   @IDField(() => ID, { description: 'The id of the remote server.' })
   id!: string;
-
-  @IsOptional()
-  @Field(() => Boolean, {
-    description: 'Indicates if data from distant tables should be refreshed.',
-    nullable: true,
-  })
-  shouldFetchPendingSchemaUpdates?: boolean;
 }

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/dtos/find-many-remote-tables-input.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/dtos/find-many-remote-tables-input.ts
@@ -13,5 +13,5 @@ export class FindManyRemoteTablesInput {
     description: 'Indicates if data from distant tables should be refreshed.',
     nullable: true,
   })
-  refreshData?: boolean;
+  shouldFetchPendingSchemaUpdates?: boolean;
 }

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/dtos/remote-table.dto.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/dtos/remote-table.dto.ts
@@ -10,11 +10,11 @@ export enum RemoteTableStatus {
   NOT_SYNCED = 'NOT_SYNCED',
 }
 
-export enum TableUpdate {
+export enum DistantTableUpdate {
   TABLE_DELETED = 'TABLE_DELETED',
-  COLUMNS_DELETED = 'COLUMN_DELETED',
-  COLUMNS_ADDED = 'COLUMN_ADDED',
-  COLUMNS_TYPE_CHANGED = 'COLUMN_TYPE_CHANGED',
+  COLUMNS_DELETED = 'COLUMNS_DELETED',
+  COLUMNS_ADDED = 'COLUMNS_ADDED',
+  COLUMNS_TYPE_CHANGED = 'COLUMNS_TYPE_CHANGED',
 }
 
 registerEnumType(RemoteTableStatus, {
@@ -22,8 +22,8 @@ registerEnumType(RemoteTableStatus, {
   description: 'Status of the table',
 });
 
-registerEnumType(TableUpdate, {
-  name: 'TableUpdate',
+registerEnumType(DistantTableUpdate, {
+  name: 'DistantTableUpdate',
   description: 'Schema update on a table',
 });
 
@@ -43,6 +43,6 @@ export class RemoteTableDTO {
   schema?: string;
 
   @IsOptional()
-  @Field(() => [TableUpdate], { nullable: true })
-  schemaPendingUpdates?: [TableUpdate];
+  @Field(() => [DistantTableUpdate], { nullable: true })
+  schemaPendingUpdates?: [DistantTableUpdate];
 }

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-table.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-table.resolver.ts
@@ -22,7 +22,7 @@ export class RemoteTableResolver {
     return this.remoteTableService.findDistantTablesByServerId(
       input.id,
       workspaceId,
-      input.refreshData,
+      input.shouldFetchPendingSchemaUpdates,
     );
   }
 

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-table.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-table.resolver.ts
@@ -22,7 +22,6 @@ export class RemoteTableResolver {
     return this.remoteTableService.findDistantTablesByServerId(
       input.id,
       workspaceId,
-      input.shouldFetchPendingSchemaUpdates,
     );
   }
 

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-table.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-table.service.ts
@@ -62,11 +62,7 @@ export class RemoteTableService {
     private readonly workspaceDataSourceService: WorkspaceDataSourceService,
   ) {}
 
-  public async findDistantTablesByServerId(
-    id: string,
-    workspaceId: string,
-    shouldFetchPendingSchemaUpdates?: boolean,
-  ) {
+  public async findDistantTablesByServerId(id: string, workspaceId: string) {
     const remoteServer = await this.remoteServerRepository.findOne({
       where: {
         id,
@@ -90,10 +86,9 @@ export class RemoteTableService {
     const distantTables = await this.distantTableService.fetchDistantTables(
       remoteServer,
       workspaceId,
-      shouldFetchPendingSchemaUpdates,
     );
 
-    if (!shouldFetchPendingSchemaUpdates || currentRemoteTables.length === 0) {
+    if (currentRemoteTables.length === 0) {
       const distantTablesWithStatus = Object.keys(distantTables).map(
         (tableName) => ({
           name: tableName,

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/types/remote-table-schema-column.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/types/remote-table-schema-column.ts
@@ -1,4 +1,0 @@
-export type RemoteTableSchemaColumn = {
-  column_name: string;
-  data_type: string;
-};

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/types/table-schema-column.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/types/table-schema-column.ts
@@ -1,4 +1,0 @@
-export type TableSchemaColumn = {
-  columnName: string;
-  dataType: string;
-};

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/types/table-schema-column.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/types/table-schema-column.ts
@@ -1,0 +1,4 @@
+export type TableSchemaColumn = {
+  columnName: string;
+  dataType: string;
+};

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/utils/get-foreign-table-column-name.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/utils/get-foreign-table-column-name.util.ts
@@ -1,0 +1,5 @@
+import camelCase from 'lodash.camelcase';
+
+export const getForeignTableColumnName = (distantTableColumnName: string) => {
+  return camelCase(distantTableColumnName);
+};

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/types/postgres-table-schema-column.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/types/postgres-table-schema-column.ts
@@ -1,0 +1,5 @@
+export type PostgresTableSchemaColumn = {
+  columnName: string;
+  dataType: string;
+  udtName: string;
+};


### PR DESCRIPTION
In this PR

- Code refactoring
- v0 of adding "updates available" info in Connection sync status
<img width="835" alt="Capture d’écran 2024-05-16 à 17 02 07" src="https://github.com/twentyhq/twenty/assets/51697796/9674d3ca-bed2-4520-a5a6-ba37bc242d06">

- fix distant table columns with not-camel case names are always considered as new