### PR TITLE
Fix turnstile captcha invalid

### DIFF
--- a/packages/twenty-front/project.json
+++ b/packages/twenty-front/project.json
@@ -82,7 +82,7 @@
             "STORYBOOK_SCOPE": "pages"
           }
         },
-        "performance": { 
+        "performance": {
           "env": {
             "NODE_OPTIONS": "--max_old_space_size=5000",
             "STORYBOOK_SCOPE": "performance"
@@ -124,7 +124,6 @@
         "modules": { "env": { "STORYBOOK_SCOPE": "modules" } },
         "pages": { "env": { "STORYBOOK_SCOPE": "pages" } },
         "performance": { "env": { "STORYBOOK_SCOPE": "performance" } }
-
       }
     },
     "storybook:test:nocoverage": {
@@ -133,7 +132,6 @@
         "modules": { "env": { "STORYBOOK_SCOPE": "modules" } },
         "pages": { "env": { "STORYBOOK_SCOPE": "pages" } },
         "performance": { "env": { "STORYBOOK_SCOPE": "performance" } }
-
       }
     },
     "storybook:static:test": {

--- a/packages/twenty-front/src/modules/captcha/hooks/useRequestFreshCaptchaToken.ts
+++ b/packages/twenty-front/src/modules/captcha/hooks/useRequestFreshCaptchaToken.ts
@@ -4,7 +4,6 @@ import { captchaTokenState } from '@/captcha/states/captchaTokenState';
 import { isRequestingCaptchaTokenState } from '@/captcha/states/isRequestingCaptchaTokenState';
 import { captchaProviderState } from '@/client-config/states/captchaProviderState';
 import { CaptchaDriverType } from '~/generated-metadata/graphql';
-import { isDefined } from '~/utils/isDefined';
 import { isUndefinedOrNull } from '~/utils/isUndefinedOrNull';
 
 declare global {
@@ -31,10 +30,6 @@ export const useRequestFreshCaptchaToken = () => {
           return;
         }
 
-        const existingCaptchaToken = snapshot
-          .getLoadable(captchaTokenState)
-          .getValue();
-
         setIsRequestingCaptchaToken(true);
 
         let captchaWidget: any;
@@ -51,12 +46,6 @@ export const useRequestFreshCaptchaToken = () => {
               });
             break;
           case CaptchaDriverType.Turnstile:
-            if (isDefined(existingCaptchaToken)) {
-              // If we already have a token, we don't need to request a new one as turnstile will
-              // automatically refresh the token when the widget is rendered.
-              setIsRequestingCaptchaToken(false);
-              break;
-            }
             // TODO: fix workspace-no-hardcoded-colors rule
             // eslint-disable-next-line @nx/workspace-no-hardcoded-colors
             captchaWidget = window.turnstile.render('#captcha-widget', {


### PR DESCRIPTION
Signing in is a two steps process:
- Checking if the user email is already used
- Checking if the email + password is correct

Those two steps need a captchaToken to be valid. Unfortunately, from Cloudflare Turnstile doc:
`A token can only be validated once and cannot be consumed twice. Once a token has been issued, it can be validated within the next 300 seconds. After 300 seconds, the token is no longer valid and another challenge needs to be solved`

So we need to generate a new token at each step instead of re-using the same