### PR TITLE
Remove relations for remotes

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "graphql-fields": "^2.0.3",
     "graphql-middleware": "^6.1.35",
     "graphql-rate-limit": "^3.3.0",
+    "graphql-scalars": "^1.23.0",
     "graphql-subscriptions": "2.0.0",
     "graphql-tag": "^2.12.6",
     "graphql-type-json": "^0.3.2",

--- a/packages/twenty-front/src/modules/object-record/relation-picker/hooks/useMultiObjectSearchMatchesSearchFilterAndToSelectQuery.ts
+++ b/packages/twenty-front/src/modules/object-record/relation-picker/hooks/useMultiObjectSearchMatchesSearchFilterAndToSelectQuery.ts
@@ -29,19 +29,19 @@ export const useMultiObjectSearchMatchesSearchFilterAndToSelectQuery = ({
 }) => {
   const objectMetadataItems = useRecoilValue(objectMetadataItemsState);
 
-  const nonSystemObjectMetadataItems = objectMetadataItems.filter(
-    ({ isSystem }) => !isSystem,
+  const selectableObjectMetadataItems = objectMetadataItems.filter(
+    ({ isSystem, isRemote }) => !isSystem && !isRemote,
   );
 
   const { searchFilterPerMetadataItemNameSingular } =
     useSearchFilterPerMetadataItem({
-      objectMetadataItems: nonSystemObjectMetadataItems,
+      objectMetadataItems: selectableObjectMetadataItems,
       searchFilterValue,
     });
 
   const objectRecordsToSelectAndMatchesSearchFilterTextFilterPerMetadataItem =
     Object.fromEntries(
-      nonSystemObjectMetadataItems
+      selectableObjectMetadataItems
         .map(({ nameSingular }) => {
           const selectedIds = selectedObjectRecordIds
             .filter(
@@ -74,16 +74,16 @@ export const useMultiObjectSearchMatchesSearchFilterAndToSelectQuery = ({
     );
 
   const { orderByFieldPerMetadataItem } = useOrderByFieldPerMetadataItem({
-    objectMetadataItems: nonSystemObjectMetadataItems,
+    objectMetadataItems: selectableObjectMetadataItems,
   });
 
   const { limitPerMetadataItem } = useLimitPerMetadataItem({
-    objectMetadataItems: nonSystemObjectMetadataItems,
+    objectMetadataItems: selectableObjectMetadataItems,
     limit,
   });
 
   const multiSelectQuery = useGenerateCombinedFindManyRecordsQuery({
-    operationSignatures: nonSystemObjectMetadataItems.map(
+    operationSignatures: selectableObjectMetadataItems.map(
       (objectMetadataItem) => ({
         objectNameSingular: objectMetadataItem.nameSingular,
         variables: {},

--- a/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/graphql-types/input/big-int-filter.input-type.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/graphql-types/input/big-int-filter.input-type.ts
@@ -1,22 +1,18 @@
-import {
-  GraphQLInputObjectType,
-  GraphQLList,
-  GraphQLNonNull,
-  GraphQLInt,
-} from 'graphql';
+import { GraphQLInputObjectType, GraphQLList, GraphQLNonNull } from 'graphql';
+import { GraphQLBigInt } from 'graphql-scalars';
 
 import { FilterIs } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/input/filter-is.input-type';
 
 export const BigIntFilterType = new GraphQLInputObjectType({
   name: 'BigIntFilter',
   fields: {
-    eq: { type: GraphQLInt },
-    gt: { type: GraphQLInt },
-    gte: { type: GraphQLInt },
-    in: { type: new GraphQLList(new GraphQLNonNull(GraphQLInt)) },
-    lt: { type: GraphQLInt },
-    lte: { type: GraphQLInt },
-    neq: { type: GraphQLInt },
+    eq: { type: GraphQLBigInt },
+    gt: { type: GraphQLBigInt },
+    gte: { type: GraphQLBigInt },
+    in: { type: new GraphQLList(new GraphQLNonNull(GraphQLBigInt)) },
+    lt: { type: GraphQLBigInt },
+    lte: { type: GraphQLBigInt },
+    neq: { type: GraphQLBigInt },
     is: { type: FilterIs },
   },
 });

--- a/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/services/type-mapper.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/services/type-mapper.service.ts
@@ -63,7 +63,8 @@ export class TypeMapperService {
       fieldMetadataType === FieldMetadataType.NUMBER &&
       (settings as FieldMetadataSettings<FieldMetadataType.NUMBER>)
         ?.precision === 0
-        ? (settings as FieldMetadataSettings<FieldMetadataType.NUMBER>)?.isBig
+        ? (settings as FieldMetadataSettings<FieldMetadataType.NUMBER>)
+            ?.isBigInt
           ? GraphQLBigInt
           : GraphQLInt
         : GraphQLFloat;
@@ -99,7 +100,8 @@ export class TypeMapperService {
       fieldMetadataType === FieldMetadataType.NUMBER &&
       (settings as FieldMetadataSettings<FieldMetadataType.NUMBER>)
         ?.precision === 0
-        ? (settings as FieldMetadataSettings<FieldMetadataType.NUMBER>)?.isBig
+        ? (settings as FieldMetadataSettings<FieldMetadataType.NUMBER>)
+            ?.isBigInt
           ? BigIntFilterType
           : IntFilterType
         : FloatFilterType;

--- a/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/services/type-mapper.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/services/type-mapper.service.ts
@@ -15,6 +15,7 @@ import {
   GraphQLString,
   GraphQLType,
 } from 'graphql';
+import { GraphQLBigInt } from 'graphql-scalars';
 
 import { FieldMetadataSettings } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata-settings.interface';
 
@@ -27,6 +28,7 @@ import {
   BigFloatFilterType,
   RawJsonFilterType,
   IntFilterType,
+  BigIntFilterType,
 } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/input';
 import { OrderByDirectionType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/enum';
 import {
@@ -61,7 +63,9 @@ export class TypeMapperService {
       fieldMetadataType === FieldMetadataType.NUMBER &&
       (settings as FieldMetadataSettings<FieldMetadataType.NUMBER>)
         ?.precision === 0
-        ? GraphQLInt
+        ? (settings as FieldMetadataSettings<FieldMetadataType.NUMBER>)?.isBig
+          ? GraphQLBigInt
+          : GraphQLInt
         : GraphQLFloat;
 
     const typeScalarMapping = new Map<FieldMetadataType, GraphQLScalarType>([
@@ -95,7 +99,9 @@ export class TypeMapperService {
       fieldMetadataType === FieldMetadataType.NUMBER &&
       (settings as FieldMetadataSettings<FieldMetadataType.NUMBER>)
         ?.precision === 0
-        ? IntFilterType
+        ? (settings as FieldMetadataSettings<FieldMetadataType.NUMBER>)?.isBig
+          ? BigIntFilterType
+          : IntFilterType
         : FloatFilterType;
 
     const typeFilterMapping = new Map<

--- a/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/services/type-mapper.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/services/type-mapper.service.ts
@@ -8,14 +8,12 @@ import {
   GraphQLID,
   GraphQLInputObjectType,
   GraphQLInputType,
-  GraphQLInt,
   GraphQLList,
   GraphQLNonNull,
   GraphQLScalarType,
   GraphQLString,
   GraphQLType,
 } from 'graphql';
-import { GraphQLBigInt } from 'graphql-scalars';
 
 import { FieldMetadataSettings } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata-settings.interface';
 
@@ -27,8 +25,6 @@ import {
   BooleanFilterType,
   BigFloatFilterType,
   RawJsonFilterType,
-  IntFilterType,
-  BigIntFilterType,
 } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/input';
 import { OrderByDirectionType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/enum';
 import {
@@ -38,6 +34,8 @@ import {
 import { PositionScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars/position.scalar';
 import { RawJSONScalar } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars/raw-json.scalar';
 import { IDFilterType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/input/id-filter.input-type';
+import { getNumberFilterType } from 'src/engine/api/graphql/workspace-schema-builder/utils/get-number-filter-type.util';
+import { getNumberScalarType } from 'src/engine/api/graphql/workspace-schema-builder/utils/get-number-scalar-type.util';
 
 export interface TypeOptions<T = any> {
   nullable?: boolean;
@@ -59,16 +57,6 @@ export class TypeMapperService {
       return GraphQLID;
     }
 
-    const numberScalar =
-      fieldMetadataType === FieldMetadataType.NUMBER &&
-      (settings as FieldMetadataSettings<FieldMetadataType.NUMBER>)
-        ?.precision === 0
-        ? (settings as FieldMetadataSettings<FieldMetadataType.NUMBER>)
-            ?.isBigInt
-          ? GraphQLBigInt
-          : GraphQLInt
-        : GraphQLFloat;
-
     const typeScalarMapping = new Map<FieldMetadataType, GraphQLScalarType>([
       [FieldMetadataType.UUID, UUIDScalarType],
       [FieldMetadataType.TEXT, GraphQLString],
@@ -77,7 +65,13 @@ export class TypeMapperService {
       [FieldMetadataType.DATE_TIME, GraphQLISODateTime],
       [FieldMetadataType.DATE, GraphQLISODateTime],
       [FieldMetadataType.BOOLEAN, GraphQLBoolean],
-      [FieldMetadataType.NUMBER, numberScalar],
+      [
+        FieldMetadataType.NUMBER,
+        getNumberScalarType(
+          (settings as FieldMetadataSettings<FieldMetadataType.NUMBER>)
+            ?.dataType,
+        ),
+      ],
       [FieldMetadataType.NUMERIC, BigFloatScalarType],
       [FieldMetadataType.PROBABILITY, GraphQLFloat],
       [FieldMetadataType.POSITION, PositionScalarType],
@@ -96,16 +90,6 @@ export class TypeMapperService {
       return IDFilterType;
     }
 
-    const numberScalar =
-      fieldMetadataType === FieldMetadataType.NUMBER &&
-      (settings as FieldMetadataSettings<FieldMetadataType.NUMBER>)
-        ?.precision === 0
-        ? (settings as FieldMetadataSettings<FieldMetadataType.NUMBER>)
-            ?.isBigInt
-          ? BigIntFilterType
-          : IntFilterType
-        : FloatFilterType;
-
     const typeFilterMapping = new Map<
       FieldMetadataType,
       GraphQLInputObjectType | GraphQLScalarType
@@ -117,7 +101,13 @@ export class TypeMapperService {
       [FieldMetadataType.DATE_TIME, DateFilterType],
       [FieldMetadataType.DATE, DateFilterType],
       [FieldMetadataType.BOOLEAN, BooleanFilterType],
-      [FieldMetadataType.NUMBER, numberScalar],
+      [
+        FieldMetadataType.NUMBER,
+        getNumberFilterType(
+          (settings as FieldMetadataSettings<FieldMetadataType.NUMBER>)
+            ?.dataType,
+        ),
+      ],
       [FieldMetadataType.NUMERIC, BigFloatFilterType],
       [FieldMetadataType.PROBABILITY, FloatFilterType],
       [FieldMetadataType.POSITION, FloatFilterType],

--- a/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/utils/get-number-filter-type.util.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/utils/get-number-filter-type.util.ts
@@ -1,0 +1,24 @@
+import { GraphQLInputObjectType } from 'graphql';
+
+import { NumberDataType } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata-settings.interface';
+
+import {
+  BigIntFilterType,
+  FloatFilterType,
+  IntFilterType,
+} from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/input';
+
+export const getNumberFilterType = (
+  subType: NumberDataType | undefined,
+): GraphQLInputObjectType => {
+  switch (subType) {
+    case NumberDataType.FLOAT:
+      return FloatFilterType;
+    case NumberDataType.BIGINT:
+      return BigIntFilterType;
+    case NumberDataType.INT:
+      return IntFilterType;
+    default:
+      return FloatFilterType;
+  }
+};

--- a/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/utils/get-number-scalar-type.util.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/utils/get-number-scalar-type.util.ts
@@ -1,0 +1,19 @@
+import { GraphQLInt, GraphQLFloat, GraphQLScalarType } from 'graphql';
+import { GraphQLBigInt } from 'graphql-scalars';
+
+import { NumberDataType } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata-settings.interface';
+
+export const getNumberScalarType = (
+  dataType: NumberDataType,
+): GraphQLScalarType => {
+  switch (dataType) {
+    case NumberDataType.FLOAT:
+      return GraphQLFloat;
+    case NumberDataType.BIGINT:
+      return GraphQLBigInt;
+    case NumberDataType.INT:
+      return GraphQLInt;
+    default:
+      return GraphQLFloat;
+  }
+};

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/interfaces/field-metadata-settings.interface.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/interfaces/field-metadata-settings.interface.ts
@@ -6,7 +6,7 @@ type FieldMetadataDefaultSettings = {
 
 type FieldMetadataNumberSettings = {
   precision: number;
-  isBig: boolean;
+  isBigInt: boolean;
 };
 
 type FieldMetadataSettingsMapping = {

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/interfaces/field-metadata-settings.interface.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/interfaces/field-metadata-settings.interface.ts
@@ -6,6 +6,7 @@ type FieldMetadataDefaultSettings = {
 
 type FieldMetadataNumberSettings = {
   precision: number;
+  isBig: boolean;
 };
 
 type FieldMetadataSettingsMapping = {

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/interfaces/field-metadata-settings.interface.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/interfaces/field-metadata-settings.interface.ts
@@ -1,12 +1,17 @@
 import { FieldMetadataType } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 
+export enum NumberDataType {
+  FLOAT = 'float',
+  INT = 'int',
+  BIGINT = 'bigint',
+}
+
 type FieldMetadataDefaultSettings = {
   isForeignKey?: boolean;
 };
 
 type FieldMetadataNumberSettings = {
-  precision: number;
-  isBigInt: boolean;
+  dataType: NumberDataType;
 };
 
 type FieldMetadataSettingsMapping = {

--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/utils/create-migrations-for-custom-object-relations.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/utils/create-migrations-for-custom-object-relations.util.ts
@@ -13,7 +13,7 @@ export const createWorkspaceMigrationsForCustomObjectRelations = (
   createdObjectMetadata: ObjectMetadataEntity,
   activityTargetObjectMetadata: ObjectMetadataEntity,
   attachmentObjectMetadata: ObjectMetadataEntity,
-  eventObjectMetadata: ObjectMetadataEntity,
+  timelineActivityObjectMetadata: ObjectMetadataEntity,
   favoriteObjectMetadata: ObjectMetadataEntity,
 ): WorkspaceMigrationTableAction[] => [
   {
@@ -80,9 +80,9 @@ export const createWorkspaceMigrationsForCustomObjectRelations = (
       },
     ],
   },
-  // Add event relation
+  // Add timeline activity relation
   {
-    name: computeObjectTargetTable(eventObjectMetadata),
+    name: computeObjectTargetTable(timelineActivityObjectMetadata),
     action: WorkspaceMigrationTableActionType.ALTER,
     columns: [
       {
@@ -96,7 +96,7 @@ export const createWorkspaceMigrationsForCustomObjectRelations = (
     ],
   },
   {
-    name: computeObjectTargetTable(eventObjectMetadata),
+    name: computeObjectTargetTable(timelineActivityObjectMetadata),
     action: WorkspaceMigrationTableActionType.ALTER,
     columns: [
       {

--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/utils/create-workspace-migrations-for-remote-object-relations.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/utils/create-workspace-migrations-for-remote-object-relations.util.ts
@@ -1,5 +1,3 @@
-import { DataSource } from 'typeorm';
-
 import { computeColumnName } from 'src/engine/metadata-modules/field-metadata/utils/compute-column-name.util';
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 import {
@@ -10,55 +8,14 @@ import {
 } from 'src/engine/metadata-modules/workspace-migration/workspace-migration.entity';
 import { computeObjectTargetTable } from 'src/engine/utils/compute-object-target-table.util';
 
-const buildCommentForRemoteObjectForeignKey = async (
-  localObjectMetadataName: string,
-  remoteObjectMetadataName: string,
-  schema: string,
-  workspaceDataSource: DataSource | undefined,
-): Promise<string> => {
-  const existingComment = await workspaceDataSource?.query(
-    `SELECT col_description('${schema}."${localObjectMetadataName}"'::regclass, 0)`,
-  );
-
-  if (!existingComment[0]?.col_description) {
-    return `@graphql({"totalCount":{"enabled": true},"foreign_keys":[{"local_name":"${localObjectMetadataName}Collection","local_columns":["${remoteObjectMetadataName}Id"],"foreign_name":"${remoteObjectMetadataName}","foreign_schema":"${schema}","foreign_table":"${remoteObjectMetadataName}","foreign_columns":["id"]}]})`;
-  }
-
-  const commentWithoutGraphQL = existingComment[0].col_description
-    .replace('@graphql(', '')
-    .replace(')', '');
-  const parsedComment = JSON.parse(commentWithoutGraphQL);
-
-  const foreignKey = {
-    local_name: `${localObjectMetadataName}Collection`,
-    local_columns: [`${remoteObjectMetadataName}Id`],
-    foreign_name: `${remoteObjectMetadataName}`,
-    foreign_schema: schema,
-    foreign_table: remoteObjectMetadataName,
-    foreign_columns: ['id'],
-  };
-
-  if (parsedComment.foreign_keys) {
-    parsedComment.foreign_keys.push(foreignKey);
-  } else {
-    parsedComment.foreign_keys = [foreignKey];
-  }
-
-  return `@graphql(${JSON.stringify(parsedComment)})`;
-};
-
 export const createWorkspaceMigrationsForRemoteObjectRelations = async (
   createdObjectMetadata: ObjectMetadataEntity,
   activityTargetObjectMetadata: ObjectMetadataEntity,
   attachmentObjectMetadata: ObjectMetadataEntity,
-  eventObjectMetadata: ObjectMetadataEntity,
+  timelineActivityObjectMetadata: ObjectMetadataEntity,
   favoriteObjectMetadata: ObjectMetadataEntity,
-  schema: string,
   primaryKeyColumnType: string,
-  workspaceDataSource: DataSource | undefined,
 ): Promise<WorkspaceMigrationTableAction[]> => {
-  const createdObjectName = createdObjectMetadata.nameSingular;
-
   return [
     {
       name: computeObjectTargetTable(activityTargetObjectMetadata),
@@ -75,22 +32,6 @@ export const createWorkspaceMigrationsForRemoteObjectRelations = async (
       ],
     },
     {
-      name: computeObjectTargetTable(activityTargetObjectMetadata),
-      action: WorkspaceMigrationTableActionType.ALTER,
-      columns: [
-        {
-          action: WorkspaceMigrationColumnActionType.CREATE_COMMENT,
-          comment: await buildCommentForRemoteObjectForeignKey(
-            activityTargetObjectMetadata.nameSingular,
-            createdObjectName,
-            schema,
-            workspaceDataSource,
-          ),
-        },
-      ],
-    },
-    // Add attachment relation
-    {
       name: computeObjectTargetTable(attachmentObjectMetadata),
       action: WorkspaceMigrationTableActionType.ALTER,
       columns: [
@@ -105,53 +46,7 @@ export const createWorkspaceMigrationsForRemoteObjectRelations = async (
       ],
     },
     {
-      name: computeObjectTargetTable(attachmentObjectMetadata),
-      action: WorkspaceMigrationTableActionType.ALTER,
-      columns: [
-        {
-          action: WorkspaceMigrationColumnActionType.CREATE_COMMENT,
-          comment: await buildCommentForRemoteObjectForeignKey(
-            attachmentObjectMetadata.nameSingular,
-            createdObjectName,
-            schema,
-            workspaceDataSource,
-          ),
-        },
-      ],
-    },
-    // Add event relation
-    {
-      name: computeObjectTargetTable(eventObjectMetadata),
-      action: WorkspaceMigrationTableActionType.ALTER,
-      columns: [
-        {
-          action: WorkspaceMigrationColumnActionType.CREATE,
-          columnName: computeColumnName(createdObjectMetadata.nameSingular, {
-            isForeignKey: true,
-          }),
-          columnType: primaryKeyColumnType,
-          isNullable: true,
-        } satisfies WorkspaceMigrationColumnCreate,
-      ],
-    },
-    {
-      name: computeObjectTargetTable(eventObjectMetadata),
-      action: WorkspaceMigrationTableActionType.ALTER,
-      columns: [
-        {
-          action: WorkspaceMigrationColumnActionType.CREATE_COMMENT,
-          comment: await buildCommentForRemoteObjectForeignKey(
-            eventObjectMetadata.nameSingular,
-            createdObjectName,
-            schema,
-            workspaceDataSource,
-          ),
-        },
-      ],
-    },
-    // Add favorite relation
-    {
-      name: computeObjectTargetTable(favoriteObjectMetadata),
+      name: computeObjectTargetTable(timelineActivityObjectMetadata),
       action: WorkspaceMigrationTableActionType.ALTER,
       columns: [
         {
@@ -169,14 +64,13 @@ export const createWorkspaceMigrationsForRemoteObjectRelations = async (
       action: WorkspaceMigrationTableActionType.ALTER,
       columns: [
         {
-          action: WorkspaceMigrationColumnActionType.CREATE_COMMENT,
-          comment: await buildCommentForRemoteObjectForeignKey(
-            favoriteObjectMetadata.nameSingular,
-            createdObjectName,
-            schema,
-            workspaceDataSource,
-          ),
-        },
+          action: WorkspaceMigrationColumnActionType.CREATE,
+          columnName: computeColumnName(createdObjectMetadata.nameSingular, {
+            isForeignKey: true,
+          }),
+          columnType: primaryKeyColumnType,
+          isNullable: true,
+        } satisfies WorkspaceMigrationColumnCreate,
       ],
     },
   ];

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/utils/udt-name-mapper.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/utils/udt-name-mapper.util.ts
@@ -34,13 +34,13 @@ export const mapUdtNameToFieldSettings = (
     case 'int4':
       return {
         precision: 0,
-        isBig: false,
+        isBigInt: false,
       } satisfies FieldMetadataSettings<FieldMetadataType.NUMBER>;
     case 'int8':
     case 'bigint':
       return {
         precision: 0,
-        isBig: true,
+        isBigInt: true,
       } satisfies FieldMetadataSettings<FieldMetadataType.NUMBER>;
     default:
       return undefined;

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/utils/udt-name-mapper.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/utils/udt-name-mapper.util.ts
@@ -8,8 +8,6 @@ export const mapUdtNameToFieldType = (udtName: string): FieldMetadataType => {
       return FieldMetadataType.UUID;
     case 'varchar':
     case 'text':
-    case 'bigint':
-    case 'int8':
       return FieldMetadataType.TEXT;
     case 'bool':
       return FieldMetadataType.BOOLEAN;
@@ -19,6 +17,8 @@ export const mapUdtNameToFieldType = (udtName: string): FieldMetadataType => {
     case 'integer':
     case 'int2':
     case 'int4':
+    case 'int8':
+    case 'bigint':
       return FieldMetadataType.NUMBER;
     default:
       return FieldMetadataType.TEXT;
@@ -34,6 +34,13 @@ export const mapUdtNameToFieldSettings = (
     case 'int4':
       return {
         precision: 0,
+        isBig: false,
+      } satisfies FieldMetadataSettings<FieldMetadataType.NUMBER>;
+    case 'int8':
+    case 'bigint':
+      return {
+        precision: 0,
+        isBig: true,
       } satisfies FieldMetadataSettings<FieldMetadataType.NUMBER>;
     default:
       return undefined;

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/utils/udt-name-mapper.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/utils/udt-name-mapper.util.ts
@@ -1,4 +1,7 @@
-import { FieldMetadataSettings } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata-settings.interface';
+import {
+  FieldMetadataSettings,
+  NumberDataType,
+} from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata-settings.interface';
 
 import { FieldMetadataType } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 
@@ -33,14 +36,12 @@ export const mapUdtNameToFieldSettings = (
     case 'int2':
     case 'int4':
       return {
-        precision: 0,
-        isBigInt: false,
+        dataType: NumberDataType.INT,
       } satisfies FieldMetadataSettings<FieldMetadataType.NUMBER>;
     case 'int8':
     case 'bigint':
       return {
-        precision: 0,
-        isBigInt: true,
+        dataType: NumberDataType.BIGINT,
       } satisfies FieldMetadataSettings<FieldMetadataType.NUMBER>;
     default:
       return undefined;

--- a/yarn.lock
+++ b/yarn.lock
@@ -28910,6 +28910,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"graphql-scalars@npm:^1.23.0":
+  version: 1.23.0
+  resolution: "graphql-scalars@npm:1.23.0"
+  dependencies:
+    tslib: "npm:^2.5.0"
+  peerDependencies:
+    graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+  checksum: 7666c305b8367528c4fbb583a2731d93d52f36043d71f4957ecc1d2db71d710d268e25535243beb1b2497db921daa94d3cfa83daaf4a3101a667f358ddbf3436
+  languageName: node
+  linkType: hard
+
 "graphql-shield@npm:^7.5.0":
   version: 7.6.5
   resolution: "graphql-shield@npm:7.6.5"
@@ -46585,6 +46596,7 @@ __metadata:
     graphql-fields: "npm:^2.0.3"
     graphql-middleware: "npm:^6.1.35"
     graphql-rate-limit: "npm:^3.3.0"
+    graphql-scalars: "npm:^1.23.0"
     graphql-subscriptions: "npm:2.0.0"
     graphql-tag: "npm:^2.12.6"
     graphql-type-json: "npm:^0.3.2"


### PR DESCRIPTION
For remotes, we will only create the foreign key, without the relation metadata. Expected behavior will be:
- possible to create an activity. But the remote object will not be displayed in the relations of the activity
- the remote objects should not be available in the search for relations

Also switched the number settings to an enum, since we now have to handle `BigInt` case.