### PR TITLE
perf: use Nx cache for Chromatic script

### DIFF
--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -106,7 +106,7 @@ jobs:
           touch .env
           echo "REACT_APP_SERVER_BASE_URL: $REACT_APP_SERVER_BASE_URL" >> .env
       - name: Publish to Chromatic
-        run: npx nx run twenty-front:chromatic:ci
+        run: npx nx chromatic twenty-front --configuration=ci
   front-task:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -106,7 +106,7 @@ jobs:
           touch .env
           echo "REACT_APP_SERVER_BASE_URL: $REACT_APP_SERVER_BASE_URL" >> .env
       - name: Publish to Chromatic
-        run: npx nx chromatic twenty-front --configuration=ci
+        run: npx nx run twenty-front:chromatic:ci
   front-task:
     runs-on: ubuntu-latest
     env:

--- a/nx.json
+++ b/nx.json
@@ -218,8 +218,10 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "{projectRoot}",
-        "command": "cross-var chromatic --project-token=$CHROMATIC_PROJECT_TOKEN --build-script-name={args.targetPackageJsonScript} {args.ci}",
-        "targetPackageJsonScript": "storybook:build:chromatic"
+        "commands": [
+          "nx storybook:build {projectName} --configuration=test",
+          "cross-var chromatic --project-token=$CHROMATIC_PROJECT_TOKEN --storybook-build-dir=storybook-static {args.ci}"
+        ]
       },
       "configurations": {
         "ci": {

--- a/nx.json
+++ b/nx.json
@@ -219,9 +219,13 @@
       "options": {
         "cwd": "{projectRoot}",
         "commands": [
-          "nx storybook:build {projectName} --configuration=test",
+          {
+            "command": "nx storybook:build {projectName} --configuration=test",
+            "forwardAllArgs": false
+          },
           "cross-var chromatic --project-token=$CHROMATIC_PROJECT_TOKEN --storybook-build-dir=storybook-static {args.ci}"
-        ]
+        ],
+        "parallel": false
       },
       "configurations": {
         "ci": {

--- a/packages/twenty-front/package.json
+++ b/packages/twenty-front/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "build": "npx vite build && sh ./scripts/inject-runtime-env.sh",
     "build:sourcemaps": "VITE_BUILD_SOURCEMAP=true NODE_OPTIONS=--max-old-space-size=4096 npx nx build",
-    "storybook:build:chromatic": "nx storybook:build --configuration=test",
     "start:prod": "NODE_ENV=production npx vite --host",
     "tsup": "npx tsup"
   },


### PR DESCRIPTION
Makes sure the `twenty-front:chromatic:ci` task in the CI job `front-chromatic-deployment` reuses the cache of the Storybook built in the CI job `front-sb-build` instead of re-building Storybook so Chromatic is deployed faster in the CI.