### PR TITLE
Feat : Change title color of release page in dark mode

### DIFF
--- a/packages/twenty-front/src/pages/settings/Releases.tsx
+++ b/packages/twenty-front/src/pages/settings/Releases.tsx
@@ -35,6 +35,7 @@ const StyledReleaseContainer = styled.div`
   }
 
   h3 {
+    color: ${({ theme }) => theme.font.color.primary};
     margin: ${({ theme }) => theme.spacing(6)} 0px 0px;
   }
   code {
@@ -43,7 +44,7 @@ const StyledReleaseContainer = styled.div`
     border-radius: 4px;
   }
   p {
-    color: #474747;
+    color: ${({ theme }) => theme.font.color.secondary};
     font-family: Inter, sans-serif;
     font-size: ${({ theme }) => theme.font.size.md};
     line-height: 19.5px;
@@ -54,6 +55,7 @@ const StyledReleaseContainer = styled.div`
 `;
 
 const StyledReleaseHeader = styled.h2`
+  color: ${({ theme }) => theme.font.color.primary};
   font-weight: ${({ theme }) => theme.font.weight.medium};
   line-height: 18px;
   font-size: ${({ theme }) => theme.font.size.md};

--- a/packages/twenty-front/src/pages/settings/Releases.tsx
+++ b/packages/twenty-front/src/pages/settings/Releases.tsx
@@ -10,6 +10,8 @@ import { visit } from 'unist-util-visit';
 import { SettingsPageContainer } from '@/settings/components/SettingsPageContainer';
 import { H1Title } from '@/ui/display/typography/components/H1Title';
 import { SubMenuTopBarContainer } from '@/ui/layout/page/SubMenuTopBarContainer';
+import { useColorScheme } from '@/ui/theme/hooks/useColorScheme';
+import { useSystemColorScheme } from '@/ui/theme/hooks/useSystemColorScheme';
 import { ScrollWrapper } from '@/ui/utilities/scroll/components/ScrollWrapper';
 
 const StyledH1Title = styled(H1Title)`
@@ -53,8 +55,10 @@ const StyledReleaseContainer = styled.div`
   }
 `;
 
-const StyledReleaseHeader = styled.h2`
+const StyledReleaseHeader = styled.h2<{ $colorScheme: string }>`
   font-weight: ${({ theme }) => theme.font.weight.medium};
+  color: ${({ $colorScheme, theme }) =>
+    $colorScheme === 'Dark' ? theme.font.color.primary : ''};
   line-height: 18px;
   font-size: ${({ theme }) => theme.font.size.md};
   margin: 0;
@@ -72,8 +76,20 @@ const StyledReleaseDate = styled.span`
   color: ${({ theme }) => theme.font.color.tertiary};
 `;
 
+const StyledHTMLWrapper = styled.div<{ $colorScheme: string }>`
+  h3 {
+    color: ${({ $colorScheme, theme }) =>
+      $colorScheme === 'Dark' ? theme.font.color.secondary : ''};
+  }
+`;
+
 export const Releases = () => {
+  const systemColorScheme = useSystemColorScheme();
+  const { colorScheme } = useColorScheme();
   const [releases, setReleases] = useState<ReleaseNote[]>([]);
+
+  const computedColorScheme =
+    colorScheme === 'System' ? systemColorScheme : colorScheme;
 
   useEffect(() => {
     fetch('https://twenty.com/api/releases').then(async (res) => {
@@ -106,9 +122,14 @@ export const Releases = () => {
           <StyledReleaseContainer>
             {releases.map((release) => (
               <React.Fragment key={release.slug}>
-                <StyledReleaseHeader>{release.release}</StyledReleaseHeader>
+                <StyledReleaseHeader $colorScheme={computedColorScheme}>
+                  {release.release}
+                </StyledReleaseHeader>
                 <StyledReleaseDate>{release.date}</StyledReleaseDate>
-                <div dangerouslySetInnerHTML={{ __html: release.html }}></div>
+                <StyledHTMLWrapper
+                  $colorScheme={computedColorScheme}
+                  dangerouslySetInnerHTML={{ __html: release.html }}
+                />
               </React.Fragment>
             ))}
           </StyledReleaseContainer>

--- a/packages/twenty-front/src/pages/settings/Releases.tsx
+++ b/packages/twenty-front/src/pages/settings/Releases.tsx
@@ -10,8 +10,6 @@ import { visit } from 'unist-util-visit';
 import { SettingsPageContainer } from '@/settings/components/SettingsPageContainer';
 import { H1Title } from '@/ui/display/typography/components/H1Title';
 import { SubMenuTopBarContainer } from '@/ui/layout/page/SubMenuTopBarContainer';
-import { useColorScheme } from '@/ui/theme/hooks/useColorScheme';
-import { useSystemColorScheme } from '@/ui/theme/hooks/useSystemColorScheme';
 import { ScrollWrapper } from '@/ui/utilities/scroll/components/ScrollWrapper';
 
 const StyledH1Title = styled(H1Title)`
@@ -55,10 +53,8 @@ const StyledReleaseContainer = styled.div`
   }
 `;
 
-const StyledReleaseHeader = styled.h2<{ $colorScheme: string }>`
+const StyledReleaseHeader = styled.h2`
   font-weight: ${({ theme }) => theme.font.weight.medium};
-  color: ${({ $colorScheme, theme }) =>
-    $colorScheme === 'Dark' ? theme.font.color.primary : ''};
   line-height: 18px;
   font-size: ${({ theme }) => theme.font.size.md};
   margin: 0;
@@ -76,20 +72,8 @@ const StyledReleaseDate = styled.span`
   color: ${({ theme }) => theme.font.color.tertiary};
 `;
 
-const StyledHTMLWrapper = styled.div<{ $colorScheme: string }>`
-  h3 {
-    color: ${({ $colorScheme, theme }) =>
-      $colorScheme === 'Dark' ? theme.font.color.secondary : ''};
-  }
-`;
-
 export const Releases = () => {
-  const systemColorScheme = useSystemColorScheme();
-  const { colorScheme } = useColorScheme();
   const [releases, setReleases] = useState<ReleaseNote[]>([]);
-
-  const computedColorScheme =
-    colorScheme === 'System' ? systemColorScheme : colorScheme;
 
   useEffect(() => {
     fetch('https://twenty.com/api/releases').then(async (res) => {
@@ -122,14 +106,9 @@ export const Releases = () => {
           <StyledReleaseContainer>
             {releases.map((release) => (
               <React.Fragment key={release.slug}>
-                <StyledReleaseHeader $colorScheme={computedColorScheme}>
-                  {release.release}
-                </StyledReleaseHeader>
+                <StyledReleaseHeader>{release.release}</StyledReleaseHeader>
                 <StyledReleaseDate>{release.date}</StyledReleaseDate>
-                <StyledHTMLWrapper
-                  $colorScheme={computedColorScheme}
-                  dangerouslySetInnerHTML={{ __html: release.html }}
-                />
+                <div dangerouslySetInnerHTML={{ __html: release.html }}></div>
               </React.Fragment>
             ))}
           </StyledReleaseContainer>


### PR DESCRIPTION
## Issue

- close #5459 

## Work Detail

Change title color of release page in dark mode.

I worked using the useColorScheme and useSystemColorSheme hooks, but if there is a better way, please recommend it.

## Before
<img width="606" alt="image" src="https://github.com/twentyhq/twenty/assets/116232939/f5c05360-f1d5-4701-b17d-e3e8a1db65fa">


## After
<img width="565" alt="image" src="https://github.com/twentyhq/twenty/assets/116232939/5f9460d3-db62-461f-b7c2-659a4b687ba9">

