### PR TITLE
Sync stripe tables

### DIFF
--- a/packages/twenty-front/src/modules/apollo/optimistic-effect/utils/triggerCreateRecordsOptimisticEffect.ts
+++ b/packages/twenty-front/src/modules/apollo/optimistic-effect/utils/triggerCreateRecordsOptimisticEffect.ts
@@ -62,7 +62,7 @@ export const triggerCreateRecordsOptimisticEffect = ({
           rootQueryCachedObjectRecordConnection,
         );
 
-        const rootQueryCachedRecordTotalCount = readField<number>(
+        const rootQueryCachedRecordTotalCount = readField<number | undefined>(
           'totalCount',
           rootQueryCachedObjectRecordConnection,
         );

--- a/packages/twenty-front/src/modules/apollo/optimistic-effect/utils/triggerCreateRecordsOptimisticEffect.ts
+++ b/packages/twenty-front/src/modules/apollo/optimistic-effect/utils/triggerCreateRecordsOptimisticEffect.ts
@@ -7,6 +7,7 @@ import { RecordGqlRefEdge } from '@/object-record/cache/types/RecordGqlRefEdge';
 import { getEdgeTypename } from '@/object-record/cache/utils/getEdgeTypename';
 import { isObjectRecordConnectionWithRefs } from '@/object-record/cache/utils/isObjectRecordConnectionWithRefs';
 import { RecordGqlNode } from '@/object-record/graphql/types/RecordGqlNode';
+import { isDefined } from '~/utils/isDefined';
 
 /*
   TODO: for now new records are added to all cached record lists, no matter what the variables (filters, orderBy, etc.) are.
@@ -61,11 +62,10 @@ export const triggerCreateRecordsOptimisticEffect = ({
           rootQueryCachedObjectRecordConnection,
         );
 
-        const rootQueryCachedRecordTotalCount =
-          readField<number>(
-            'totalCount',
-            rootQueryCachedObjectRecordConnection,
-          ) || 0;
+        const rootQueryCachedRecordTotalCount = readField<number>(
+          'totalCount',
+          rootQueryCachedObjectRecordConnection,
+        );
 
         const nextRootQueryCachedRecordEdges = rootQueryCachedRecordEdges
           ? [...rootQueryCachedRecordEdges]
@@ -113,7 +113,9 @@ export const triggerCreateRecordsOptimisticEffect = ({
         return {
           ...rootQueryCachedObjectRecordConnection,
           edges: nextRootQueryCachedRecordEdges,
-          totalCount: rootQueryCachedRecordTotalCount + 1,
+          totalCount: isDefined(rootQueryCachedRecordTotalCount)
+            ? rootQueryCachedRecordTotalCount + 1
+            : undefined,
         };
       },
     },

--- a/packages/twenty-front/src/modules/apollo/optimistic-effect/utils/triggerDeleteRecordsOptimisticEffect.ts
+++ b/packages/twenty-front/src/modules/apollo/optimistic-effect/utils/triggerDeleteRecordsOptimisticEffect.ts
@@ -50,11 +50,10 @@ export const triggerDeleteRecordsOptimisticEffect = ({
           rootQueryCachedObjectRecordConnection,
         );
 
-        const totalCount =
-          readField<number>(
-            'totalCount',
-            rootQueryCachedObjectRecordConnection,
-          ) || 0;
+        const totalCount = readField<number | undefined>(
+          'totalCount',
+          rootQueryCachedObjectRecordConnection,
+        );
 
         const nextCachedEdges =
           cachedEdges?.filter((cachedEdge) => {
@@ -77,7 +76,9 @@ export const triggerDeleteRecordsOptimisticEffect = ({
         return {
           ...rootQueryCachedObjectRecordConnection,
           edges: nextCachedEdges,
-          totalCount: totalCount - recordIdsToDelete.length,
+          totalCount: isDefined(totalCount)
+            ? totalCount - recordIdsToDelete.length
+            : undefined,
         };
       },
     },

--- a/packages/twenty-front/src/modules/object-metadata/utils/hasPositionColumn.ts
+++ b/packages/twenty-front/src/modules/object-metadata/utils/hasPositionColumn.ts
@@ -1,0 +1,4 @@
+import { ObjectMetadataItem } from '@/object-metadata/types/ObjectMetadataItem';
+
+export const hasPositionField = (objectMetadataItem: ObjectMetadataItem) =>
+  !objectMetadataItem.isRemote;

--- a/packages/twenty-front/src/modules/object-metadata/utils/isAggregationEnabled.ts
+++ b/packages/twenty-front/src/modules/object-metadata/utils/isAggregationEnabled.ts
@@ -1,0 +1,7 @@
+import { ObjectMetadataItem } from '@/object-metadata/types/ObjectMetadataItem';
+
+export const isAggregationEnabled = (
+  objectMetadataItem: ObjectMetadataItem,
+) => {
+  return !objectMetadataItem.isRemote;
+};

--- a/packages/twenty-front/src/modules/object-metadata/utils/isAggregationEnabled.ts
+++ b/packages/twenty-front/src/modules/object-metadata/utils/isAggregationEnabled.ts
@@ -1,7 +1,4 @@
 import { ObjectMetadataItem } from '@/object-metadata/types/ObjectMetadataItem';
 
-export const isAggregationEnabled = (
-  objectMetadataItem: ObjectMetadataItem,
-) => {
-  return !objectMetadataItem.isRemote;
-};
+export const isAggregationEnabled = (objectMetadataItem: ObjectMetadataItem) =>
+  !objectMetadataItem.isRemote;

--- a/packages/twenty-front/src/modules/object-record/hooks/useFindDuplicateRecords.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useFindDuplicateRecords.ts
@@ -76,7 +76,7 @@ export const useFindDuplicateRecords = <T extends ObjectRecord = ObjectRecord>({
   return {
     objectMetadataItem,
     records,
-    totalCount: objectRecordConnection?.totalCount || 0,
+    totalCount: objectRecordConnection?.totalCount,
     loading,
     error,
     queryStateIdentifier: findDuplicateQueryStateIdentifier,

--- a/packages/twenty-front/src/modules/object-record/hooks/useFindDuplicatesRecordsQuery.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useFindDuplicatesRecordsQuery.ts
@@ -18,6 +18,8 @@ export const useFindDuplicateRecordsQuery = ({
 
   const objectMetadataItems = useRecoilValue(objectMetadataItemsState);
 
+  const shouldQueryCounts = !objectMetadataItem.isRemote;
+
   const findDuplicateRecordsQuery = gql`
     query FindDuplicate${capitalize(
       objectMetadataItem.nameSingular,
@@ -33,11 +35,11 @@ export const useFindDuplicateRecordsQuery = ({
           cursor
         }
         pageInfo {
-          hasNextPage
+          ${shouldQueryCounts ? 'hasNextPage' : ''}
           startCursor
           endCursor
         }
-        totalCount
+        ${shouldQueryCounts ? 'totalCount' : ''}
       }
     }
   `;

--- a/packages/twenty-front/src/modules/object-record/hooks/useFindDuplicatesRecordsQuery.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useFindDuplicatesRecordsQuery.ts
@@ -3,6 +3,7 @@ import { useRecoilValue } from 'recoil';
 
 import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
 import { objectMetadataItemsState } from '@/object-metadata/states/objectMetadataItemsState';
+import { isAggregationEnabled } from '@/object-metadata/utils/isAggregationEnabled';
 import { mapObjectMetadataToGraphQLQuery } from '@/object-metadata/utils/mapObjectMetadataToGraphQLQuery';
 import { getFindDuplicateRecordsQueryResponseField } from '@/object-record/utils/getFindDuplicateRecordsQueryResponseField';
 import { capitalize } from '~/utils/string/capitalize';
@@ -17,8 +18,6 @@ export const useFindDuplicateRecordsQuery = ({
   });
 
   const objectMetadataItems = useRecoilValue(objectMetadataItemsState);
-
-  const shouldQueryCounts = !objectMetadataItem.isRemote;
 
   const findDuplicateRecordsQuery = gql`
     query FindDuplicate${capitalize(
@@ -35,11 +34,11 @@ export const useFindDuplicateRecordsQuery = ({
           cursor
         }
         pageInfo {
-          ${shouldQueryCounts ? 'hasNextPage' : ''}
+          ${isAggregationEnabled(objectMetadataItem) ? 'hasNextPage' : ''}
           startCursor
           endCursor
         }
-        ${shouldQueryCounts ? 'totalCount' : ''}
+        ${isAggregationEnabled(objectMetadataItem) ? 'totalCount' : ''}
       }
     }
   `;

--- a/packages/twenty-front/src/modules/object-record/hooks/useFindManyRecords.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useFindManyRecords.ts
@@ -122,7 +122,8 @@ export const useFindManyRecords = <T extends ObjectRecord = ObjectRecord>({
     });
 
   const fetchMoreRecords = useCallback(async () => {
-    if (hasNextPage) {
+    // Remote objects does not support hasNextPage. We cannot rely on it to fetch more records.
+    if (hasNextPage || objectMetadataItem.isRemote) {
       setIsFetchingMoreObjects(true);
 
       try {
@@ -145,6 +146,10 @@ export const useFindManyRecords = <T extends ObjectRecord = ObjectRecord>({
                 ...(fetchMoreResult?.[objectMetadataItem.namePlural]?.edges ??
                   []),
               ]);
+            }
+
+            if (isNonEmptyArray(previousEdges) && !isNonEmptyArray(nextEdges)) {
+              newEdges = prev?.[objectMetadataItem.namePlural]?.edges ?? [];
             }
 
             const pageInfo =
@@ -199,15 +204,16 @@ export const useFindManyRecords = <T extends ObjectRecord = ObjectRecord>({
     }
   }, [
     hasNextPage,
+    objectMetadataItem.isRemote,
+    objectMetadataItem.namePlural,
+    objectMetadataItem.nameSingular,
     setIsFetchingMoreObjects,
     fetchMore,
     filter,
     orderBy,
     lastCursor,
-    objectMetadataItem.namePlural,
-    objectMetadataItem.nameSingular,
-    onCompleted,
     data,
+    onCompleted,
     setLastCursor,
     setHasNextPage,
     enqueueSnackBar,

--- a/packages/twenty-front/src/modules/object-record/hooks/useFindManyRecords.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useFindManyRecords.ts
@@ -124,7 +124,7 @@ export const useFindManyRecords = <T extends ObjectRecord = ObjectRecord>({
 
   const fetchMoreRecords = useCallback(async () => {
     // Remote objects does not support hasNextPage. We cannot rely on it to fetch more records.
-    if (hasNextPage || !isAggregationEnabled(objectMetadataItem)) {
+    if (hasNextPage || (!isAggregationEnabled(objectMetadataItem) && !error)) {
       setIsFetchingMoreObjects(true);
 
       try {
@@ -202,6 +202,7 @@ export const useFindManyRecords = <T extends ObjectRecord = ObjectRecord>({
   }, [
     hasNextPage,
     objectMetadataItem,
+    error,
     setIsFetchingMoreObjects,
     fetchMore,
     filter,

--- a/packages/twenty-front/src/modules/object-record/hooks/useFindManyRecords.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useFindManyRecords.ts
@@ -214,7 +214,7 @@ export const useFindManyRecords = <T extends ObjectRecord = ObjectRecord>({
     enqueueSnackBar,
   ]);
 
-  const totalCount = data?.[objectMetadataItem.namePlural].totalCount;
+  const totalCount = data?.[objectMetadataItem.namePlural]?.totalCount;
 
   const records = useMemo(
     () =>

--- a/packages/twenty-front/src/modules/object-record/hooks/useFindManyRecords.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useFindManyRecords.ts
@@ -219,7 +219,7 @@ export const useFindManyRecords = <T extends ObjectRecord = ObjectRecord>({
     enqueueSnackBar,
   ]);
 
-  const totalCount = data?.[objectMetadataItem.namePlural].totalCount ?? 0;
+  const totalCount = data?.[objectMetadataItem.namePlural].totalCount;
 
   const records = useMemo(
     () =>

--- a/packages/twenty-front/src/modules/object-record/hooks/useFindManyRecords.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useFindManyRecords.ts
@@ -201,9 +201,7 @@ export const useFindManyRecords = <T extends ObjectRecord = ObjectRecord>({
     }
   }, [
     hasNextPage,
-    objectMetadataItem.isRemote,
-    objectMetadataItem.namePlural,
-    objectMetadataItem.nameSingular,
+    objectMetadataItem,
     setIsFetchingMoreObjects,
     fetchMore,
     filter,

--- a/packages/twenty-front/src/modules/object-record/object-sort-dropdown/utils/__tests__/turnSortsIntoOrderBy.test.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-sort-dropdown/utils/__tests__/turnSortsIntoOrderBy.test.tsx
@@ -1,3 +1,5 @@
+import { FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
+import { ObjectMetadataItem } from '@/object-metadata/types/ObjectMetadataItem';
 import { Sort } from '@/object-record/object-sort-dropdown/types/Sort';
 import { SortDefinition } from '@/object-record/object-sort-dropdown/types/SortDefinition';
 import { turnSortsIntoOrderBy } from '@/object-record/object-sort-dropdown/utils/turnSortsIntoOrderBy';
@@ -8,12 +10,30 @@ const sortDefinition: SortDefinition = {
   iconName: 'icon',
 };
 
+const objectMetadataItem: ObjectMetadataItem = {
+  id: 'object1',
+  fields: [],
+  createdAt: '2021-01-01',
+  updatedAt: '2021-01-01',
+  nameSingular: 'object1',
+  namePlural: 'object1s',
+  icon: 'icon',
+  isActive: true,
+  isSystem: false,
+  isCustom: false,
+  isRemote: false,
+  labelPlural: 'object1s',
+  labelSingular: 'object1',
+};
+
 describe('turnSortsIntoOrderBy', () => {
   it('should sort by recordPosition if no sorts', () => {
-    const fields = [{ id: 'field1', name: 'createdAt' }];
-    expect(turnSortsIntoOrderBy([], fields)).toEqual({
-      position: 'AscNullsFirst',
-    });
+    const fields = [{ id: 'field1', name: 'createdAt' }] as FieldMetadataItem[];
+    expect(turnSortsIntoOrderBy({ ...objectMetadataItem, fields }, [])).toEqual(
+      {
+        position: 'AscNullsFirst',
+      },
+    );
   });
 
   it('should create OrderByField with single sort', () => {
@@ -24,8 +44,10 @@ describe('turnSortsIntoOrderBy', () => {
         definition: sortDefinition,
       },
     ];
-    const fields = [{ id: 'field1', name: 'field1' }];
-    expect(turnSortsIntoOrderBy(sorts, fields)).toEqual({
+    const fields = [{ id: 'field1', name: 'field1' }] as FieldMetadataItem[];
+    expect(
+      turnSortsIntoOrderBy({ ...objectMetadataItem, fields }, sorts),
+    ).toEqual({
       field1: 'AscNullsFirst',
       position: 'AscNullsFirst',
     });
@@ -47,8 +69,10 @@ describe('turnSortsIntoOrderBy', () => {
     const fields = [
       { id: 'field1', name: 'field1' },
       { id: 'field2', name: 'field2' },
-    ];
-    expect(turnSortsIntoOrderBy(sorts, fields)).toEqual({
+    ] as FieldMetadataItem[];
+    expect(
+      turnSortsIntoOrderBy({ ...objectMetadataItem, fields }, sorts),
+    ).toEqual({
       field1: 'AscNullsFirst',
       field2: 'DescNullsLast',
       position: 'AscNullsFirst',
@@ -63,8 +87,21 @@ describe('turnSortsIntoOrderBy', () => {
         definition: sortDefinition,
       },
     ];
-    expect(turnSortsIntoOrderBy(sorts, [])).toEqual({
+    expect(turnSortsIntoOrderBy(objectMetadataItem, sorts)).toEqual({
       position: 'AscNullsFirst',
     });
+  });
+
+  it('should not return position for remotes', () => {
+    const sorts: Sort[] = [
+      {
+        fieldMetadataId: 'invalidField',
+        direction: 'asc',
+        definition: sortDefinition,
+      },
+    ];
+    expect(
+      turnSortsIntoOrderBy({ ...objectMetadataItem, isRemote: true }, sorts),
+    ).toEqual({});
   });
 });

--- a/packages/twenty-front/src/modules/object-record/object-sort-dropdown/utils/turnSortsIntoOrderBy.ts
+++ b/packages/twenty-front/src/modules/object-record/object-sort-dropdown/utils/turnSortsIntoOrderBy.ts
@@ -1,4 +1,6 @@
+import { ObjectMetadataItem } from '@/object-metadata/types/ObjectMetadataItem';
 import { OrderBy } from '@/object-metadata/types/OrderBy';
+import { hasPositionField } from '@/object-metadata/utils/hasPositionColumn';
 import { RecordGqlOperationOrderBy } from '@/object-record/graphql/types/RecordGqlOperationOrderBy';
 import { Field } from '~/generated/graphql';
 import { mapArrayToObject } from '~/utils/array/mapArrayToObject';
@@ -8,9 +10,10 @@ import { isUndefinedOrNull } from '~/utils/isUndefinedOrNull';
 import { Sort } from '../types/Sort';
 
 export const turnSortsIntoOrderBy = (
+  objectMetadataItem: ObjectMetadataItem,
   sorts: Sort[],
-  fields: Pick<Field, 'id' | 'name'>[],
 ): RecordGqlOperationOrderBy => {
+  const fields: Pick<Field, 'id' | 'name'>[] = objectMetadataItem?.fields ?? [];
   const fieldsById = mapArrayToObject(fields, ({ id }) => id);
   const sortsOrderBy = Object.fromEntries(
     sorts
@@ -29,8 +32,12 @@ export const turnSortsIntoOrderBy = (
       .filter(isDefined),
   );
 
-  return {
-    ...sortsOrderBy,
-    position: 'AscNullsFirst',
-  };
+  if (hasPositionField(objectMetadataItem)) {
+    return {
+      ...sortsOrderBy,
+      position: 'AscNullsFirst',
+    };
+  }
+
+  return sortsOrderBy;
 };

--- a/packages/twenty-front/src/modules/object-record/record-action-bar/hooks/useRecordActionBar.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-action-bar/hooks/useRecordActionBar.tsx
@@ -15,7 +15,10 @@ import { useFavorites } from '@/favorites/hooks/useFavorites';
 import { ObjectMetadataItem } from '@/object-metadata/types/ObjectMetadataItem';
 import { useDeleteManyRecords } from '@/object-record/hooks/useDeleteManyRecords';
 import { useExecuteQuickActionOnOneRecord } from '@/object-record/hooks/useExecuteQuickActionOnOneRecord';
-import { useExportTableData } from '@/object-record/record-index/options/hooks/useExportTableData';
+import {
+  displayedExportProgress,
+  useExportTableData,
+} from '@/object-record/record-index/options/hooks/useExportTableData';
 import { recordStoreFamilyState } from '@/object-record/record-store/states/recordStoreFamilyState';
 import { ConfirmationModal } from '@/ui/layout/modal/components/ConfirmationModal';
 import { actionBarEntriesState } from '@/ui/navigation/action-bar/states/actionBarEntriesState';
@@ -111,13 +114,7 @@ export const useRecordActionBar = ({
   const baseActions: ContextMenuEntry[] = useMemo(
     () => [
       {
-        label: `${
-          progress?.count === undefined
-            ? `Export`
-            : `Export (${progress.count}${
-                progress.type === 'percentage' ? '%' : ''
-              })`
-        }`,
+        label: displayedExportProgress(progress),
         Icon: IconFileExport,
         accent: 'default',
         onClick: () => download(),

--- a/packages/twenty-front/src/modules/object-record/record-action-bar/hooks/useRecordActionBar.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-action-bar/hooks/useRecordActionBar.tsx
@@ -111,7 +111,13 @@ export const useRecordActionBar = ({
   const baseActions: ContextMenuEntry[] = useMemo(
     () => [
       {
-        label: `${progress === undefined ? `Export` : `Export (${progress}%)`}`,
+        label: `${
+          progress?.count === undefined
+            ? `Export`
+            : `Export (${progress.count}${
+                progress.type === 'percentage' ? '%' : ''
+              })`
+        }`,
         Icon: IconFileExport,
         accent: 'default',
         onClick: () => download(),

--- a/packages/twenty-front/src/modules/object-record/record-index/hooks/useLoadRecordIndexBoard.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/hooks/useLoadRecordIndexBoard.ts
@@ -48,9 +48,7 @@ export const useLoadRecordIndexBoard = ({
     recordIndexFilters,
     objectMetadataItem?.fields ?? [],
   );
-  const orderBy = !objectMetadataItem.isRemote
-    ? turnSortsIntoOrderBy(recordIndexSorts, objectMetadataItem?.fields ?? [])
-    : undefined;
+  const orderBy = turnSortsIntoOrderBy(objectMetadataItem, recordIndexSorts);
 
   const recordIndexIsCompactModeActive = useRecoilValue(
     recordIndexIsCompactModeActiveState,

--- a/packages/twenty-front/src/modules/object-record/record-index/hooks/useLoadRecordIndexTable.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/hooks/useLoadRecordIndexTable.ts
@@ -71,7 +71,7 @@ export const useLoadRecordIndexTable = (objectNameSingular: string) => {
       currentWorkspace?.activationStatus === 'active'
         ? records
         : SIGN_IN_BACKGROUND_MOCK_COMPANIES,
-    totalCount: totalCount || 0,
+    totalCount: totalCount,
     loading,
     fetchMoreRecords,
     queryStateIdentifier,

--- a/packages/twenty-front/src/modules/object-record/record-index/hooks/useLoadRecordIndexTable.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/hooks/useLoadRecordIndexTable.ts
@@ -29,14 +29,7 @@ export const useFindManyParams = (
     objectMetadataItem?.fields ?? [],
   );
 
-  if (objectMetadataItem?.isRemote) {
-    return { objectNameSingular, filter };
-  }
-
-  const orderBy = turnSortsIntoOrderBy(
-    tableSorts,
-    objectMetadataItem?.fields ?? [],
-  );
+  const orderBy = turnSortsIntoOrderBy(objectMetadataItem, tableSorts);
 
   return { objectNameSingular, filter, orderBy };
 };

--- a/packages/twenty-front/src/modules/object-record/record-index/options/components/RecordIndexOptionsDropdownContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-index/options/components/RecordIndexOptionsDropdownContent.tsx
@@ -9,7 +9,10 @@ import {
 } from 'twenty-ui';
 
 import { RECORD_INDEX_OPTIONS_DROPDOWN_ID } from '@/object-record/record-index/options/constants/RecordIndexOptionsDropdownId';
-import { useExportTableData } from '@/object-record/record-index/options/hooks/useExportTableData';
+import {
+  displayedExportProgress,
+  useExportTableData,
+} from '@/object-record/record-index/options/hooks/useExportTableData';
 import { useRecordIndexOptionsForBoard } from '@/object-record/record-index/options/hooks/useRecordIndexOptionsForBoard';
 import { useRecordIndexOptionsForTable } from '@/object-record/record-index/options/hooks/useRecordIndexOptionsForTable';
 import { TableOptionsHotkeyScope } from '@/object-record/record-table/types/TableOptionsHotkeyScope';
@@ -123,13 +126,7 @@ export const RecordIndexOptionsDropdownContent = ({
           <MenuItem
             onClick={download}
             LeftIcon={IconFileExport}
-            text={
-              progress?.count === undefined
-                ? `Export`
-                : `Export (${progress.count}${
-                    progress.type === 'percentage' ? '%' : ''
-                  })`
-            }
+            text={displayedExportProgress(progress)}
           />
         </DropdownMenuItemsContainer>
       )}

--- a/packages/twenty-front/src/modules/object-record/record-index/options/components/RecordIndexOptionsDropdownContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-index/options/components/RecordIndexOptionsDropdownContent.tsx
@@ -123,7 +123,13 @@ export const RecordIndexOptionsDropdownContent = ({
           <MenuItem
             onClick={download}
             LeftIcon={IconFileExport}
-            text={progress === undefined ? `Export` : `Export (${progress}%)`}
+            text={
+              progress?.count === undefined
+                ? `Export`
+                : `Export (${progress.count}${
+                    progress.type === 'percentage' ? '%' : ''
+                  })`
+            }
           />
         </DropdownMenuItemsContainer>
       )}

--- a/packages/twenty-front/src/modules/object-record/record-index/options/hooks/__tests__/useExportTableData.test.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/options/hooks/__tests__/useExportTableData.test.ts
@@ -3,9 +3,9 @@ import { ColumnDefinition } from '@/object-record/record-table/types/ColumnDefin
 
 import {
   csvDownloader,
+  displayedExportProgress,
   download,
   generateCsv,
-  percentage,
   sleep,
 } from '../useExportTableData';
 
@@ -92,17 +92,24 @@ describe('csvDownloader', () => {
   });
 });
 
-describe('percentage', () => {
+describe('displayedExportProgress', () => {
   it.each([
-    [20, 50, 40],
-    [0, 100, 0],
-    [10, 10, 100],
-    [10, 10, 100],
-    [7, 9, 78],
+    [undefined, undefined, 'percentage', 'Export'],
+    [20, 50, 'percentage', 'Export (40%)'],
+    [0, 100, 'number', 'Export (0)'],
+    [10, 10, 'percentage', 'Export (100%)'],
+    [10, 10, 'number', 'Export (10)'],
+    [7, 9, 'percentage', 'Export (78%)'],
   ])(
-    'calculates the percentage %p/%p = %p',
-    (part, whole, expectedPercentage) => {
-      expect(percentage(part, whole)).toEqual(expectedPercentage);
+    'displays the export progress',
+    (exportedRecordCount, totalRecordCount, displayType, expected) => {
+      expect(
+        displayedExportProgress({
+          exportedRecordCount,
+          totalRecordCount,
+          displayType: displayType as 'percentage' | 'number',
+        }),
+      ).toEqual(expected);
     },
   );
 });

--- a/packages/twenty-front/src/modules/object-record/record-index/options/hooks/useExportTableData.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/options/hooks/useExportTableData.ts
@@ -150,7 +150,9 @@ export const useExportTableData = ({
   });
 
   useEffect(() => {
-    const MAXIMUM_REQUESTS = Math.min(maximumRequests, totalCount / pageSize);
+    const MAXIMUM_REQUESTS = isDefined(totalCount)
+      ? Math.min(maximumRequests, totalCount / pageSize)
+      : maximumRequests;
 
     const downloadCsv = (rows: object[]) => {
       csvDownloader(filename, { rows, columns });

--- a/packages/twenty-front/src/modules/object-record/record-table/hooks/internal/useSetRecordTableData.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/hooks/internal/useSetRecordTableData.ts
@@ -54,7 +54,7 @@ export const useSetRecordTableData = ({
           }
         }
 
-        set(numberOfTableRowsState, totalCount || 0);
+        set(numberOfTableRowsState, totalCount ?? 0);
         onEntityCountChange(totalCount);
       },
     [

--- a/packages/twenty-front/src/modules/object-record/record-table/hooks/internal/useSetRecordTableData.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/hooks/internal/useSetRecordTableData.ts
@@ -8,7 +8,7 @@ import { isDeeplyEqual } from '~/utils/isDeeplyEqual';
 
 type useSetRecordTableDataProps = {
   recordTableId?: string;
-  onEntityCountChange: (entityCount: number) => void;
+  onEntityCountChange: (entityCount: number | undefined) => void;
 };
 
 export const useSetRecordTableData = ({
@@ -24,7 +24,7 @@ export const useSetRecordTableData = ({
 
   return useRecoilCallback(
     ({ set, snapshot }) =>
-      <T extends ObjectRecord>(newEntityArray: T[], totalCount: number) => {
+      <T extends ObjectRecord>(newEntityArray: T[], totalCount?: number) => {
         for (const entity of newEntityArray) {
           // TODO: refactor with scoped state later
           const currentEntity = snapshot

--- a/packages/twenty-front/src/modules/object-record/record-table/hooks/internal/useSetRecordTableData.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/hooks/internal/useSetRecordTableData.ts
@@ -8,7 +8,7 @@ import { isDeeplyEqual } from '~/utils/isDeeplyEqual';
 
 type useSetRecordTableDataProps = {
   recordTableId?: string;
-  onEntityCountChange: (entityCount: number | undefined) => void;
+  onEntityCountChange: (entityCount?: number) => void;
 };
 
 export const useSetRecordTableData = ({
@@ -54,7 +54,7 @@ export const useSetRecordTableData = ({
           }
         }
 
-        set(numberOfTableRowsState, totalCount);
+        set(numberOfTableRowsState, totalCount || 0);
         onEntityCountChange(totalCount);
       },
     [

--- a/packages/twenty-front/src/modules/object-record/record-table/hooks/useRecordTable.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/hooks/useRecordTable.ts
@@ -99,7 +99,7 @@ export const useRecordTable = (props?: useRecordTableProps) => {
 
   const onEntityCountChange = useRecoilCallback(
     ({ snapshot }) =>
-      (count: number) => {
+      (count: number | undefined) => {
         const onEntityCountChange = getSnapshotValue(
           snapshot,
           onEntityCountChangeState,

--- a/packages/twenty-front/src/modules/object-record/record-table/hooks/useRecordTable.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/hooks/useRecordTable.ts
@@ -99,7 +99,7 @@ export const useRecordTable = (props?: useRecordTableProps) => {
 
   const onEntityCountChange = useRecoilCallback(
     ({ snapshot }) =>
-      (count: number | undefined) => {
+      (count?: number) => {
         const onEntityCountChange = getSnapshotValue(
           snapshot,
           onEntityCountChangeState,

--- a/packages/twenty-front/src/modules/object-record/record-table/hooks/useRecordTableMoveFocus.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/hooks/useRecordTableMoveFocus.ts
@@ -3,7 +3,6 @@ import { useRecoilCallback } from 'recoil';
 import { useRecordTableStates } from '@/object-record/record-table/hooks/internal/useRecordTableStates';
 import { MoveFocusDirection } from '@/object-record/record-table/types/MoveFocusDirection';
 import { getSnapshotValue } from '@/ui/utilities/recoil-scope/utils/getSnapshotValue';
-import { isDefined } from '~/utils/isDefined';
 
 import { useSetSoftFocusPosition } from './internal/useSetSoftFocusPosition';
 
@@ -53,10 +52,6 @@ export const useRecordTableMoveFocus = (recordTableId?: string) => {
           numberOfTableRowsState,
         );
 
-        if (!isDefined(numberOfTableRows)) {
-          return;
-        }
-
         let newRowNumber = softFocusPosition.row + 1;
 
         if (newRowNumber >= numberOfTableRows) {
@@ -88,10 +83,6 @@ export const useRecordTableMoveFocus = (recordTableId?: string) => {
           snapshot,
           numberOfTableRowsState,
         );
-
-        if (!isDefined(numberOfTableRows)) {
-          return;
-        }
 
         const currentColumnNumber = softFocusPosition.column;
         const currentRowNumber = softFocusPosition.row;

--- a/packages/twenty-front/src/modules/object-record/record-table/hooks/useRecordTableMoveFocus.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/hooks/useRecordTableMoveFocus.ts
@@ -3,6 +3,7 @@ import { useRecoilCallback } from 'recoil';
 import { useRecordTableStates } from '@/object-record/record-table/hooks/internal/useRecordTableStates';
 import { MoveFocusDirection } from '@/object-record/record-table/types/MoveFocusDirection';
 import { getSnapshotValue } from '@/ui/utilities/recoil-scope/utils/getSnapshotValue';
+import { isDefined } from '~/utils/isDefined';
 
 import { useSetSoftFocusPosition } from './internal/useSetSoftFocusPosition';
 
@@ -52,6 +53,10 @@ export const useRecordTableMoveFocus = (recordTableId?: string) => {
           numberOfTableRowsState,
         );
 
+        if (!isDefined(numberOfTableRows)) {
+          return;
+        }
+
         let newRowNumber = softFocusPosition.row + 1;
 
         if (newRowNumber >= numberOfTableRows) {
@@ -83,6 +88,11 @@ export const useRecordTableMoveFocus = (recordTableId?: string) => {
           snapshot,
           numberOfTableRowsState,
         );
+
+        if (!isDefined(numberOfTableRows)) {
+          return;
+        }
+
         const currentColumnNumber = softFocusPosition.column;
         const currentRowNumber = softFocusPosition.row;
 

--- a/packages/twenty-front/src/modules/object-record/record-table/states/numberOfTableRowsComponentState.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/states/numberOfTableRowsComponentState.ts
@@ -1,8 +1,6 @@
 import { createComponentState } from '@/ui/utilities/state/component-state/utils/createComponentState';
 
-export const numberOfTableRowsComponentState = createComponentState<
-  number | undefined
->({
+export const numberOfTableRowsComponentState = createComponentState<number>({
   key: 'numberOfTableRowsComponentState',
-  defaultValue: undefined,
+  defaultValue: 0,
 });

--- a/packages/twenty-front/src/modules/object-record/record-table/states/numberOfTableRowsComponentState.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/states/numberOfTableRowsComponentState.ts
@@ -1,6 +1,8 @@
 import { createComponentState } from '@/ui/utilities/state/component-state/utils/createComponentState';
 
-export const numberOfTableRowsComponentState = createComponentState<number>({
+export const numberOfTableRowsComponentState = createComponentState<
+  number | undefined
+>({
   key: 'numberOfTableRowsComponentState',
-  defaultValue: 0,
+  defaultValue: undefined,
 });

--- a/packages/twenty-front/src/modules/object-record/record-table/states/onEntityCountChangeComponentState.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/states/onEntityCountChangeComponentState.ts
@@ -1,7 +1,7 @@
 import { createComponentState } from '@/ui/utilities/state/component-state/utils/createComponentState';
 
 export const onEntityCountChangeComponentState = createComponentState<
-  ((entityCount: number) => void) | undefined
+  ((entityCount: number | undefined) => void) | undefined
 >({
   key: 'onEntityCountChangeComponentState',
   defaultValue: undefined,

--- a/packages/twenty-front/src/modules/object-record/record-table/states/onEntityCountChangeComponentState.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/states/onEntityCountChangeComponentState.ts
@@ -1,7 +1,7 @@
 import { createComponentState } from '@/ui/utilities/state/component-state/utils/createComponentState';
 
 export const onEntityCountChangeComponentState = createComponentState<
-  ((entityCount: number | undefined) => void) | undefined
+  ((entityCount?: number) => void) | undefined
 >({
   key: 'onEntityCountChangeComponentState',
   defaultValue: undefined,

--- a/packages/twenty-front/src/modules/object-record/utils/generateFindManyRecordsQuery.ts
+++ b/packages/twenty-front/src/modules/object-record/utils/generateFindManyRecordsQuery.ts
@@ -15,14 +15,17 @@ export const generateFindManyRecordsQuery = ({
   objectMetadataItems: ObjectMetadataItem[];
   recordGqlFields?: RecordGqlOperationGqlRecordFields;
   computeReferences?: boolean;
-}) => gql`
+}) => {
+  const shouldQueryCounts = !objectMetadataItem.isRemote;
+
+  return gql`
 query FindMany${capitalize(
-  objectMetadataItem.namePlural,
-)}($filter: ${capitalize(
-  objectMetadataItem.nameSingular,
-)}FilterInput, $orderBy: ${capitalize(
-  objectMetadataItem.nameSingular,
-)}OrderByInput, $lastCursor: String, $limit: Int) {
+    objectMetadataItem.namePlural,
+  )}($filter: ${capitalize(
+    objectMetadataItem.nameSingular,
+  )}FilterInput, $orderBy: ${capitalize(
+    objectMetadataItem.nameSingular,
+  )}OrderByInput, $lastCursor: String, $limit: Int) {
   ${
     objectMetadataItem.namePlural
   }(filter: $filter, orderBy: $orderBy, first: $limit, after: $lastCursor){
@@ -36,11 +39,12 @@ query FindMany${capitalize(
       cursor
     }
     pageInfo {
-      hasNextPage
+      ${shouldQueryCounts ? 'hasNextPage' : ''}
       startCursor
       endCursor
     }
-    totalCount
+    ${shouldQueryCounts ? 'totalCount' : ''}
   }
 }
 `;
+};

--- a/packages/twenty-front/src/modules/object-record/utils/generateFindManyRecordsQuery.ts
+++ b/packages/twenty-front/src/modules/object-record/utils/generateFindManyRecordsQuery.ts
@@ -1,6 +1,7 @@
 import gql from 'graphql-tag';
 
 import { ObjectMetadataItem } from '@/object-metadata/types/ObjectMetadataItem';
+import { isAggregationEnabled } from '@/object-metadata/utils/isAggregationEnabled';
 import { mapObjectMetadataToGraphQLQuery } from '@/object-metadata/utils/mapObjectMetadataToGraphQLQuery';
 import { RecordGqlOperationGqlRecordFields } from '@/object-record/graphql/types/RecordGqlOperationGqlRecordFields';
 import { capitalize } from '~/utils/string/capitalize';
@@ -15,17 +16,14 @@ export const generateFindManyRecordsQuery = ({
   objectMetadataItems: ObjectMetadataItem[];
   recordGqlFields?: RecordGqlOperationGqlRecordFields;
   computeReferences?: boolean;
-}) => {
-  const shouldQueryCounts = !objectMetadataItem.isRemote;
-
-  return gql`
+}) => gql`
 query FindMany${capitalize(
-    objectMetadataItem.namePlural,
-  )}($filter: ${capitalize(
-    objectMetadataItem.nameSingular,
-  )}FilterInput, $orderBy: ${capitalize(
-    objectMetadataItem.nameSingular,
-  )}OrderByInput, $lastCursor: String, $limit: Int) {
+  objectMetadataItem.namePlural,
+)}($filter: ${capitalize(
+  objectMetadataItem.nameSingular,
+)}FilterInput, $orderBy: ${capitalize(
+  objectMetadataItem.nameSingular,
+)}OrderByInput, $lastCursor: String, $limit: Int) {
   ${
     objectMetadataItem.namePlural
   }(filter: $filter, orderBy: $orderBy, first: $limit, after: $lastCursor){
@@ -39,12 +37,11 @@ query FindMany${capitalize(
       cursor
     }
     pageInfo {
-      ${shouldQueryCounts ? 'hasNextPage' : ''}
+      ${isAggregationEnabled(objectMetadataItem) ? 'hasNextPage' : ''}
       startCursor
       endCursor
     }
-    ${shouldQueryCounts ? 'totalCount' : ''}
+    ${isAggregationEnabled(objectMetadataItem) ? 'totalCount' : ''}
   }
 }
 `;
-};

--- a/packages/twenty-front/src/modules/views/states/entityCountInCurrentViewComponentState.ts
+++ b/packages/twenty-front/src/modules/views/states/entityCountInCurrentViewComponentState.ts
@@ -1,7 +1,8 @@
 import { createComponentState } from '@/ui/utilities/state/component-state/utils/createComponentState';
 
-export const entityCountInCurrentViewComponentState =
-  createComponentState<number>({
-    key: 'entityCountInCurrentViewComponentState',
-    defaultValue: 0,
-  });
+export const entityCountInCurrentViewComponentState = createComponentState<
+  number | undefined
+>({
+  key: 'entityCountInCurrentViewComponentState',
+  defaultValue: undefined,
+});

--- a/packages/twenty-front/src/modules/views/view-picker/components/ViewPickerDropdown.tsx
+++ b/packages/twenty-front/src/modules/views/view-picker/components/ViewPickerDropdown.tsx
@@ -15,9 +15,9 @@ import { ViewPickerListContent } from '@/views/view-picker/components/ViewPicker
 import { VIEW_PICKER_DROPDOWN_ID } from '@/views/view-picker/constants/ViewPickerDropdownId';
 import { useViewPickerMode } from '@/views/view-picker/hooks/useViewPickerMode';
 import { useViewPickerPersistView } from '@/views/view-picker/hooks/useViewPickerPersistView';
+import { isDefined } from '~/utils/isDefined';
 
 import { useViewStates } from '../../hooks/internal/useViewStates';
-import { isDefined } from '~/utils/isDefined';
 
 const StyledDropdownLabelAdornments = styled.span`
   align-items: center;

--- a/packages/twenty-front/src/modules/views/view-picker/components/ViewPickerDropdown.tsx
+++ b/packages/twenty-front/src/modules/views/view-picker/components/ViewPickerDropdown.tsx
@@ -17,6 +17,7 @@ import { useViewPickerMode } from '@/views/view-picker/hooks/useViewPickerMode';
 import { useViewPickerPersistView } from '@/views/view-picker/hooks/useViewPickerPersistView';
 
 import { useViewStates } from '../../hooks/internal/useViewStates';
+import { isDefined } from '~/utils/isDefined';
 
 const StyledDropdownLabelAdornments = styled.span`
   align-items: center;
@@ -89,7 +90,9 @@ export const ViewPickerDropdown = () => {
             {currentViewWithCombinedFiltersAndSorts?.name ?? 'All'}
           </StyledViewName>
           <StyledDropdownLabelAdornments>
-            · {entityCountInCurrentView}{' '}
+            {isDefined(entityCountInCurrentView) && (
+              <>· {entityCountInCurrentView} </>
+            )}
             <IconChevronDown size={theme.icon.size.sm} />
           </StyledDropdownLabelAdornments>
         </StyledDropdownButtonContainer>


### PR DESCRIPTION
Stripe tables do not support `hasNextPage` and `totalCount`. This may be because of stripe wrapper do not properly support `COUNT` request. Waiting on pg_graphql answer [here](https://github.com/supabase/pg_graphql/issues/519).

This PR:
- removes `totalCount` and `hasNextPage` form queries for remote objects. Even if it works for postgres, this may really be inefficient 
- adapt the `fetchMore` functions so it works despite `hasNextPage` missing
- remove `totalCount` display for remotes
- fix `orderBy`