### PR TITLE
fix: twentyORM datasource configuration for ssl

### DIFF
--- a/packages/twenty-server/src/engine/twenty-orm/factories/workspace-datasource.factory.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/factories/workspace-datasource.factory.ts
@@ -38,6 +38,11 @@ export class WorkspaceDatasourceFactory {
       logging: 'all',
       schema: dataSourceMetadata.schema,
       entities,
+      ssl: this.environmentService.get('PG_SSL_ALLOW_SELF_SIGNED')
+        ? {
+            rejectUnauthorized: false,
+          }
+        : undefined,
     });
 
     await workspaceDataSource.initialize();


### PR DESCRIPTION
We need to specify ssl configuration for TwentyORM datasources when needed, otherwise connection will be broken.