### PR TITLE
[fix] Update remote table sync status in cache after schema update

### DIFF
--- a/packages/twenty-front/src/modules/databases/hooks/useSyncRemoteTableSchemaChanges.ts
+++ b/packages/twenty-front/src/modules/databases/hooks/useSyncRemoteTableSchemaChanges.ts
@@ -35,6 +35,7 @@ export const useSyncRemoteTableSchemaChanges = () => {
               fieldModifiers: {
                 schemaPendingUpdates: () =>
                   data.syncRemoteTableSchemaChanges.schemaPendingUpdates || [],
+                status: () => data.syncRemoteTableSchemaChanges.status,
               },
             });
           }

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/distant-table/distant-table.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/distant-table/distant-table.service.ts
@@ -50,7 +50,7 @@ export class DistantTableService {
       tableName,
     );
 
-    return distantTables[tableName] || [];
+    return distantTables[tableName];
   }
 
   private async getDistantTablesFromDynamicSchema(

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-table.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-table.service.ts
@@ -179,6 +179,10 @@ export class RemoteTableService {
         input.name,
       );
 
+    if (!distantTableColumns) {
+      throw new BadRequestException('Table not found');
+    }
+
     // We only support remote tables with an id column for now.
     const distantTableIdColumn = distantTableColumns.find(
       (column) => column.columnName === 'id',
@@ -300,7 +304,7 @@ export class RemoteTableService {
         remoteTable.distantTableName,
       );
 
-    if (isEmpty(distantTableColumns)) {
+    if (!distantTableColumns) {
       await this.unsyncOne(workspaceId, remoteTable, remoteServer);
 
       return {


### PR DESCRIPTION
Upon schema update, sync status can change from synced to non_synced in case the update regards a table that was deleted.  Let's update the sync status too to avoid displaying the table as still synchronized.

https://github.com/twentyhq/twenty/assets/51697796/7ff2342b-ce9f-4179-9b76-940617cf1292

