### PR TITLE
Added: The support for CZK Currency

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/types/CurrencyCode.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/types/CurrencyCode.ts
@@ -2,6 +2,7 @@ export enum CurrencyCode {
   CAD = 'CAD',
   CHF = 'CHF',
   CNY = 'CNY',
+  CZK = 'CZK',
   EUR = 'EUR',
   GBP = 'GBP',
   HKD = 'HKD',

--- a/packages/twenty-front/src/modules/settings/data-model/constants/SettingsFieldCurrencyCodes.ts
+++ b/packages/twenty-front/src/modules/settings/data-model/constants/SettingsFieldCurrencyCodes.ts
@@ -5,6 +5,7 @@ import {
   IconCurrencyEuro,
   IconCurrencyFrank,
   IconCurrencyKroneSwedish,
+  IconCurrencyKroneCzech,
   IconCurrencyPound,
   IconCurrencyRiyal,
   IconCurrencyYen,
@@ -44,6 +45,10 @@ export const SETTINGS_FIELD_CURRENCY_CODES: Record<
   CNY: {
     label: 'Chinese yuan',
     Icon: IconCurrencyYuan,
+  },
+  CZK: {
+    label: 'Czech koruna',
+    Icon: IconCurrencyKroneCzech,
   },
   HKD: {
     label: 'Hong Kong dollar',

--- a/packages/twenty-ui/src/display/icon/components/TablerIcons.ts
+++ b/packages/twenty-ui/src/display/icon/components/TablerIcons.ts
@@ -57,6 +57,7 @@ export {
   IconCurrencyEuro,
   IconCurrencyFrank,
   IconCurrencyKroneSwedish,
+  IconCurrencyKroneCzech,
   IconCurrencyPound,
   IconCurrencyRiyal,
   IconCurrencyYen,


### PR DESCRIPTION
Added the Czech Koruna currency support.
- Added the CZK to the currency code.
- Set the desired CZK icon to `TablerIcons` to use it within the `twenty-ui` 

fixes: #5530 

![Screenshot (335)](https://github.com/twentyhq/twenty/assets/140178357/a19a60b8-2261-44b3-9ed2-5c35424631a1)
![Screenshot (336)](https://github.com/twentyhq/twenty/assets/140178357/20944e43-901c-4dda-b986-a47763fb5f9b)