### PR TITLE
Fix sync token is no longer valid in calendar sync

### DIFF
--- a/packages/twenty-server/src/modules/calendar/repositories/calendar-channel.repository.ts
+++ b/packages/twenty-server/src/modules/calendar/repositories/calendar-channel.repository.ts
@@ -127,7 +127,7 @@ export class CalendarChannelRepository {
 
     await this.workspaceDataSourceService.executeRawQuery(
       `UPDATE ${dataSourceSchema}."calendarChannel" SET "syncCursor" = $1 WHERE "id" = $2`,
-      [syncCursor, calendarChannelId],
+      [syncCursor || '', calendarChannelId],
       workspaceId,
       transactionManager,
     );

--- a/packages/twenty-server/src/modules/calendar/repositories/calendar-channel.repository.ts
+++ b/packages/twenty-server/src/modules/calendar/repositories/calendar-channel.repository.ts
@@ -117,7 +117,7 @@ export class CalendarChannelRepository {
   }
 
   public async updateSyncCursor(
-    syncCursor: string,
+    syncCursor: string | null,
     calendarChannelId: string,
     workspaceId: string,
     transactionManager?: EntityManager,

--- a/packages/twenty-server/src/modules/calendar/services/google-calendar-sync/google-calendar-sync.service.ts
+++ b/packages/twenty-server/src/modules/calendar/services/google-calendar-sync/google-calendar-sync.service.ts
@@ -341,9 +341,17 @@ export class GoogleCalendarSyncService {
             workspaceId,
           );
 
-          throw new Error(
-            `Sync token no longer valid for connected account ${connectedAccountId} in workspace ${workspaceId}, resetting sync cursor.`,
+          this.logger.log(
+            `Sync token is no longer valid for connected account ${connectedAccountId} in workspace ${workspaceId}, resetting sync cursor.`,
           );
+
+          return {
+            data: {
+              items: [],
+              nextSyncToken: undefined,
+              nextPageToken: undefined,
+            },
+          };
         });
 
       nextSyncToken = googleCalendarEvents.data.nextSyncToken;

--- a/packages/twenty-server/src/modules/calendar/services/google-calendar-sync/google-calendar-sync.service.ts
+++ b/packages/twenty-server/src/modules/calendar/services/google-calendar-sync/google-calendar-sync.service.ts
@@ -330,12 +330,20 @@ export class GoogleCalendarSyncService {
           q: emailOrDomainToReimport,
           showDeleted: true,
         })
-        .catch((error: GaxiosError) => {
+        .catch(async (error: GaxiosError) => {
           if (error.response?.status !== 410) {
             throw error;
           }
 
-          return;
+          await this.calendarChannelRepository.updateSyncCursor(
+            null,
+            connectedAccountId,
+            workspaceId,
+          );
+
+          throw new Error(
+            `Sync token no longer valid for connected account ${connectedAccountId} in workspace ${workspaceId}, resetting sync cursor.`,
+          );
         });
 
       nextSyncToken = googleCalendarEvents.data.nextSyncToken;

--- a/packages/twenty-server/src/modules/calendar/services/google-calendar-sync/google-calendar-sync.service.ts
+++ b/packages/twenty-server/src/modules/calendar/services/google-calendar-sync/google-calendar-sync.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 
 import { Repository } from 'typeorm';
 import { calendar_v3 as calendarV3 } from 'googleapis';
+import { GaxiosError } from 'gaxios';
 
 import { ConnectedAccountRepository } from 'src/modules/connected-account/repositories/connected-account.repository';
 import { BlocklistRepository } from 'src/modules/connected-account/repositories/blocklist.repository';
@@ -320,14 +321,22 @@ export class GoogleCalendarSyncService {
     let hasMoreEvents = true;
 
     while (hasMoreEvents) {
-      const googleCalendarEvents = await googleCalendarClient.events.list({
-        calendarId: 'primary',
-        maxResults: 500,
-        syncToken: emailOrDomainToReimport ? undefined : syncToken,
-        pageToken: nextPageToken,
-        q: emailOrDomainToReimport,
-        showDeleted: true,
-      });
+      const googleCalendarEvents = await googleCalendarClient.events
+        .list({
+          calendarId: 'primary',
+          maxResults: 500,
+          syncToken: emailOrDomainToReimport ? undefined : syncToken,
+          pageToken: nextPageToken,
+          q: emailOrDomainToReimport,
+          showDeleted: true,
+        })
+        .catch((error: GaxiosError) => {
+          if (error.response?.status !== 410) {
+            throw error;
+          }
+
+          return;
+        });
 
       nextSyncToken = googleCalendarEvents.data.nextSyncToken;
       nextPageToken = googleCalendarEvents.data.nextPageToken || undefined;


### PR DESCRIPTION
Fix sync token is no longer valid in calendar sync.

https://developers.google.com/apps-script/add-ons/calendar/conferencing/sync-calendar-changes#implement_a_sync_trigger_function
_Caution: Occasionally sync tokens are invalidated by the server, resulting in a Sync token is no longer valid error. When this happens, your code should conduct a full sync and replace any stored sync tokens you have._