### PR TITLE
Introduce a new feature flag for contact creation

### DIFF
--- a/packages/twenty-server/src/database/typeorm-seeds/core/feature-flags.ts
+++ b/packages/twenty-server/src/database/typeorm-seeds/core/feature-flags.ts
@@ -50,6 +50,11 @@ export const seedFeatureFlags = async (
         workspaceId: workspaceId,
         value: true,
       },
+      {
+        key: FeatureFlagKeys.IsContactCreationForSentAndReceivedEmailsEnabled,
+        workspaceId: workspaceId,
+        value: true,
+      },
     ])
     .execute();
 };

--- a/packages/twenty-server/src/engine/core-modules/feature-flag/feature-flag.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/feature-flag/feature-flag.entity.ts
@@ -23,6 +23,7 @@ export enum FeatureFlagKeys {
   IsStripeIntegrationEnabled = 'IS_STRIPE_INTEGRATION_ENABLED',
   IsGmailSyncV2Enabled = 'IS_GMAIL_SYNC_V2_ENABLED',
   IsLinksFieldEnabled = 'IS_LINKS_FIELD_ENABLED',
+  IsContactCreationForSentAndReceivedEmailsEnabled = 'IS_CONTACT_CREATION_FOR_SENT_AND_RECEIVED_EMAILS_ENABLED',
 }
 
 @Entity({ name: 'featureFlag', schema: 'core' })

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/commands/add-standard-id.command.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/commands/add-standard-id.command.ts
@@ -60,6 +60,7 @@ export class AddStandardIdCommand extends CommandRunner {
             IS_STRIPE_INTEGRATION_ENABLED: false,
             IS_GMAIL_SYNC_V2_ENABLED: true,
             IS_LINKS_FIELD_ENABLED: true,
+            IS_CONTACT_CREATION_FOR_SENT_AND_RECEIVED_EMAILS_ENABLED: true,
           },
         );
       const standardFieldMetadataCollection = this.standardFieldFactory.create(
@@ -76,6 +77,7 @@ export class AddStandardIdCommand extends CommandRunner {
           IS_STRIPE_INTEGRATION_ENABLED: false,
           IS_GMAIL_SYNC_V2_ENABLED: true,
           IS_LINKS_FIELD_ENABLED: true,
+          IS_CONTACT_CREATION_FOR_SENT_AND_RECEIVED_EMAILS_ENABLED: true,
         },
       );
 

--- a/packages/twenty-server/src/modules/messaging/services/gmail-messages-import/gmail-messages-import.module.ts
+++ b/packages/twenty-server/src/modules/messaging/services/gmail-messages-import/gmail-messages-import.module.ts
@@ -1,5 +1,7 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { FeatureFlagEntity } from 'src/engine/core-modules/feature-flag/feature-flag.entity';
 import { ObjectMetadataRepositoryModule } from 'src/engine/object-metadata-repository/object-metadata-repository.module';
 import { WorkspaceDataSourceModule } from 'src/engine/workspace-datasource/workspace-datasource.module';
 import { ConnectedAccountWorkspaceEntity } from 'src/modules/connected-account/standard-objects/connected-account.workspace-entity';
@@ -24,6 +26,7 @@ import { MessageChannelWorkspaceEntity } from 'src/modules/messaging/standard-ob
     MessageModule,
     MessageParticipantModule,
     SetMessageChannelSyncStatusModule,
+    TypeOrmModule.forFeature([FeatureFlagEntity], 'core'),
   ],
   providers: [
     GmailMessagesImportService,


### PR DESCRIPTION
Introduce new feature flag `IS_CONTACT_CREATION_FOR_SENT_AND_RECEIVED_EMAILS_ENABLED` to allow contacts to be created for sent and received emails.