### PR TITLE
Fixed: Select fields now selects on pressing the enter key

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/SelectFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/SelectFieldInput.tsx
@@ -65,10 +65,8 @@ export const SelectFieldInput = ({
   useScopedHotkeys(
     Key.Enter,
     () => {
-      const selectedOption = optionsInDropDown.find(
-        (option) =>
-          option.value !== fieldValue &&
-          option.label.toLowerCase().includes(searchFilter.toLowerCase()),
+      const selectedOption = optionsInDropDown.find((option) =>
+        option.label.toLowerCase().includes(searchFilter.toLowerCase()),
       );
 
       if (isDefined(selectedOption)) {

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/SelectFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/SelectFieldInput.tsx
@@ -1,5 +1,6 @@
 import React, { useRef, useState } from 'react';
 import styled from '@emotion/styled';
+import { Key } from 'ts-key-enum';
 
 import { useSelectField } from '@/object-record/record-field/meta-types/hooks/useSelectField';
 import { FieldInputEvent } from '@/object-record/record-field/types/FieldInputEvent';
@@ -9,6 +10,7 @@ import { DropdownMenuSearchInput } from '@/ui/layout/dropdown/components/Dropdow
 import { DropdownMenuSeparator } from '@/ui/layout/dropdown/components/DropdownMenuSeparator';
 import { MenuItemSelectTag } from '@/ui/navigation/menu-item/components/MenuItemSelectTag';
 import { useListenClickOutside } from '@/ui/utilities/pointer-event/hooks/useListenClickOutside';
+import { useScopedHotkeys } from '@/ui/utilities/hotkey/hooks/useScopedHotkeys';
 import { isDefined } from '~/utils/isDefined';
 
 const StyledRelationPickerContainer = styled.div`
@@ -26,7 +28,8 @@ export const SelectFieldInput = ({
   onSubmit,
   onCancel,
 }: SelectFieldInputProps) => {
-  const { persistField, fieldDefinition, fieldValue } = useSelectField();
+  const { persistField, fieldDefinition, fieldValue, hotkeyScope } =
+    useSelectField();
   const [searchFilter, setSearchFilter] = useState('');
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -59,16 +62,18 @@ export const SelectFieldInput = ({
     },
   });
 
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    if (event.key === 'Enter') {
+  useScopedHotkeys(
+    Key.Enter,
+    () => {
       const selectedOption = optionsInDropDown.find(
         (option) =>
           option.value !== fieldValue &&
           option.label.toLowerCase().includes(searchFilter.toLowerCase()),
       );
       selectedOption && onSubmit?.(() => persistField(selectedOption.value));
-    }
-  };
+    },
+    hotkeyScope,
+  );
 
   return (
     <StyledRelationPickerContainer ref={containerRef}>
@@ -76,7 +81,6 @@ export const SelectFieldInput = ({
         <DropdownMenuSearchInput
           value={searchFilter}
           onChange={(event) => setSearchFilter(event.currentTarget.value)}
-          onKeyDown={handleKeyDown}
           autoFocus
         />
         <DropdownMenuSeparator />

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/SelectFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/SelectFieldInput.tsx
@@ -9,8 +9,8 @@ import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/Drop
 import { DropdownMenuSearchInput } from '@/ui/layout/dropdown/components/DropdownMenuSearchInput';
 import { DropdownMenuSeparator } from '@/ui/layout/dropdown/components/DropdownMenuSeparator';
 import { MenuItemSelectTag } from '@/ui/navigation/menu-item/components/MenuItemSelectTag';
-import { useListenClickOutside } from '@/ui/utilities/pointer-event/hooks/useListenClickOutside';
 import { useScopedHotkeys } from '@/ui/utilities/hotkey/hooks/useScopedHotkeys';
+import { useListenClickOutside } from '@/ui/utilities/pointer-event/hooks/useListenClickOutside';
 import { isDefined } from '~/utils/isDefined';
 
 const StyledRelationPickerContainer = styled.div`

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/SelectFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/SelectFieldInput.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import styled from '@emotion/styled';
 
 import { useSelectField } from '@/object-record/record-field/meta-types/hooks/useSelectField';
@@ -59,12 +59,24 @@ export const SelectFieldInput = ({
     },
   });
 
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      const selectedOption = optionsInDropDown.find(
+        (option) =>
+          option.value !== fieldValue &&
+          option.label.toLowerCase().includes(searchFilter.toLowerCase()),
+      );
+      selectedOption && onSubmit?.(() => persistField(selectedOption.value));
+    }
+  };
+
   return (
     <StyledRelationPickerContainer ref={containerRef}>
       <DropdownMenu data-select-disable>
         <DropdownMenuSearchInput
           value={searchFilter}
           onChange={(event) => setSearchFilter(event.currentTarget.value)}
+          onKeyDown={handleKeyDown}
           autoFocus
         />
         <DropdownMenuSeparator />

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/SelectFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/SelectFieldInput.tsx
@@ -65,8 +65,10 @@ export const SelectFieldInput = ({
   useScopedHotkeys(
     Key.Enter,
     () => {
-      const selectedOption = optionsInDropDown.find((option) =>
-        option.label.toLowerCase().includes(searchFilter.toLowerCase()),
+      const selectedOption = optionsInDropDown.find(
+        (option) =>
+          option.value !== fieldValue &&
+          option.label.toLowerCase().includes(searchFilter.toLowerCase()),
       );
 
       if (isDefined(selectedOption)) {

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/SelectFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/SelectFieldInput.tsx
@@ -65,12 +65,13 @@ export const SelectFieldInput = ({
   useScopedHotkeys(
     Key.Enter,
     () => {
-      const selectedOption = optionsInDropDown.find(
-        (option) =>
-          option.value !== fieldValue &&
-          option.label.toLowerCase().includes(searchFilter.toLowerCase()),
+      const selectedOption = optionsInDropDown.find((option) =>
+        option.label.toLowerCase().includes(searchFilter.toLowerCase()),
       );
-      selectedOption && onSubmit?.(() => persistField(selectedOption.value));
+
+      if (isDefined(selectedOption)) {
+        onSubmit?.(() => persistField(selectedOption.value));
+      }
     },
     hotkeyScope,
   );

--- a/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableCellFieldContextWrapper.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableCellFieldContextWrapper.tsx
@@ -3,6 +3,7 @@ import { useContext } from 'react';
 import { isLabelIdentifierField } from '@/object-metadata/utils/isLabelIdentifierField';
 import { FieldContext } from '@/object-record/record-field/contexts/FieldContext';
 import { isFieldRelation } from '@/object-record/record-field/types/guards/isFieldRelation';
+import { isFieldSelect } from '@/object-record/record-field/types/guards/isFieldSelect';
 import { RecordUpdateContext } from '@/object-record/record-table/contexts/EntityUpdateMutationHookContext';
 import { RecordTableCellContext } from '@/object-record/record-table/contexts/RecordTableCellContext';
 import { RecordTableContext } from '@/object-record/record-table/contexts/RecordTableContext';
@@ -10,9 +11,8 @@ import { RecordTableRowContext } from '@/object-record/record-table/contexts/Rec
 import { RecordTableCell } from '@/object-record/record-table/record-table-cell/components/RecordTableCell';
 import { TableHotkeyScope } from '@/object-record/record-table/types/TableHotkeyScope';
 import { RelationPickerHotkeyScope } from '@/object-record/relation-picker/types/RelationPickerHotkeyScope';
-import { isUndefinedOrNull } from '~/utils/isUndefinedOrNull';
-import { isFieldSelect } from '@/object-record/record-field/types/guards/isFieldSelect';
 import { SelectFieldHotkeyScope } from '@/object-record/select/types/SelectFieldHotkeyScope';
+import { isUndefinedOrNull } from '~/utils/isUndefinedOrNull';
 
 export const RecordTableCellFieldContextWrapper = () => {
   const { objectMetadataItem } = useContext(RecordTableContext);

--- a/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableCellFieldContextWrapper.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableCellFieldContextWrapper.tsx
@@ -11,6 +11,8 @@ import { RecordTableCell } from '@/object-record/record-table/record-table-cell/
 import { TableHotkeyScope } from '@/object-record/record-table/types/TableHotkeyScope';
 import { RelationPickerHotkeyScope } from '@/object-record/relation-picker/types/RelationPickerHotkeyScope';
 import { isUndefinedOrNull } from '~/utils/isUndefinedOrNull';
+import { isFieldSelect } from '@/object-record/record-field/types/guards/isFieldSelect';
+import { SelectFieldHotkeyScope } from '@/object-record/select/types/SelectFieldHotkeyScope';
 
 export const RecordTableCellFieldContextWrapper = () => {
   const { objectMetadataItem } = useContext(RecordTableContext);
@@ -25,7 +27,9 @@ export const RecordTableCellFieldContextWrapper = () => {
 
   const customHotkeyScope = isFieldRelation(columnDefinition)
     ? RelationPickerHotkeyScope.RelationPicker
-    : TableHotkeyScope.CellEditMode;
+    : isFieldSelect(columnDefinition)
+      ? SelectFieldHotkeyScope.SelectField
+      : TableHotkeyScope.CellEditMode;
 
   return (
     <FieldContext.Provider

--- a/packages/twenty-front/src/modules/object-record/select/types/SelectFieldHotkeyScope.tsx
+++ b/packages/twenty-front/src/modules/object-record/select/types/SelectFieldHotkeyScope.tsx
@@ -1,0 +1,3 @@
+export enum SelectFieldHotkeyScope {
+  SelectField = 'select-field',
+}

--- a/packages/twenty-front/src/modules/ui/layout/dropdown/components/DropdownMenuSearchInput.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/dropdown/components/DropdownMenuSearchInput.tsx
@@ -36,12 +36,17 @@ const StyledInput = styled.input`
 export const DropdownMenuSearchInput = forwardRef<
   HTMLInputElement,
   InputHTMLAttributes<HTMLInputElement>
->(({ value, onChange, autoFocus, placeholder = 'Search', type }, ref) => (
-  <StyledDropdownMenuSearchInputContainer>
-    <StyledInput
-      autoComplete="off"
-      {...{ autoFocus, onChange, placeholder, type, value }}
-      ref={ref}
-    />
-  </StyledDropdownMenuSearchInputContainer>
-));
+>(
+  (
+    { value, onChange, onKeyDown, autoFocus, placeholder = 'Search', type },
+    ref,
+  ) => (
+    <StyledDropdownMenuSearchInputContainer>
+      <StyledInput
+        autoComplete="off"
+        {...{ autoFocus, onChange, onKeyDown, placeholder, type, value }}
+        ref={ref}
+      />
+    </StyledDropdownMenuSearchInputContainer>
+  ),
+);

--- a/packages/twenty-front/src/modules/ui/layout/dropdown/components/DropdownMenuSearchInput.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/dropdown/components/DropdownMenuSearchInput.tsx
@@ -36,17 +36,12 @@ const StyledInput = styled.input`
 export const DropdownMenuSearchInput = forwardRef<
   HTMLInputElement,
   InputHTMLAttributes<HTMLInputElement>
->(
-  (
-    { value, onChange, onKeyDown, autoFocus, placeholder = 'Search', type },
-    ref,
-  ) => (
-    <StyledDropdownMenuSearchInputContainer>
-      <StyledInput
-        autoComplete="off"
-        {...{ autoFocus, onChange, onKeyDown, placeholder, type, value }}
-        ref={ref}
-      />
-    </StyledDropdownMenuSearchInputContainer>
-  ),
-);
+>(({ value, onChange, autoFocus, placeholder = 'Search', type }, ref) => (
+  <StyledDropdownMenuSearchInputContainer>
+    <StyledInput
+      autoComplete="off"
+      {...{ autoFocus, onChange, placeholder, type, value }}
+      ref={ref}
+    />
+  </StyledDropdownMenuSearchInputContainer>
+));


### PR DESCRIPTION
Now while pressing the `Enter` button, the select field selects the relevant option.

- Added a `handleKeyDown` function to set the `persistField` with the selected option.
- Added an `onKeyDown` event on `DropdownMenuSearchInput` component, to trigger `handleKeyDown` when `Enter` is pressed.
- Fixes: #5556 