### PR TITLE
Fixed avatar url

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-index/hooks/useLoadRecordIndexBoard.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/hooks/useLoadRecordIndexBoard.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
+import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
 import { useFindManyRecords } from '@/object-record/hooks/useFindManyRecords';
 import { turnSortsIntoOrderBy } from '@/object-record/object-sort-dropdown/utils/turnSortsIntoOrderBy';
 import { useRecordBoard } from '@/object-record/record-board/hooks/useRecordBoard';
@@ -54,10 +55,23 @@ export const useLoadRecordIndexBoard = ({
     recordIndexIsCompactModeActiveState,
   );
 
-  const recordGqlFields = useRecordBoardRecordGqlFields({
+  // TODO: improve this by linking it to metadata
+  const visibleFieldsGqlFields = useRecordBoardRecordGqlFields({
     objectMetadataItem,
     recordBoardId,
   });
+
+  const systemGqlFields =
+    objectNameSingular === CoreObjectNameSingular.Person
+      ? {
+          avatarUrl: true,
+        }
+      : {};
+
+  const recordGqlFields = {
+    ...visibleFieldsGqlFields,
+    ...systemGqlFields,
+  };
 
   const {
     records,

--- a/packages/twenty-front/src/modules/object-record/record-index/hooks/useLoadRecordIndexTable.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/hooks/useLoadRecordIndexTable.ts
@@ -2,6 +2,7 @@ import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
+import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
 import { useFindManyRecords } from '@/object-record/hooks/useFindManyRecords';
 import { turnSortsIntoOrderBy } from '@/object-record/object-sort-dropdown/utils/turnSortsIntoOrderBy';
 import { turnObjectDropdownFilterIntoQueryFilter } from '@/object-record/record-filter/utils/turnObjectDropdownFilterIntoQueryFilter';
@@ -42,7 +43,20 @@ export const useLoadRecordIndexTable = (objectNameSingular: string) => {
   const currentWorkspace = useRecoilValue(currentWorkspaceState);
   const params = useFindManyParams(objectNameSingular);
 
-  const recordGqlFields = useRecordTableRecordGqlFields();
+  // TODO: improve this by linking it to metadata
+  const visibleColumnsGqlFields = useRecordTableRecordGqlFields();
+
+  const systemGqlFields =
+    objectNameSingular === CoreObjectNameSingular.Person
+      ? {
+          avatarUrl: true,
+        }
+      : {};
+
+  const recordGqlFields = {
+    ...visibleColumnsGqlFields,
+    ...systemGqlFields,
+  };
 
   const {
     records,

--- a/packages/twenty-front/src/modules/object-record/record-show/components/RecordShowContainer.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-show/components/RecordShowContainer.tsx
@@ -32,6 +32,7 @@ import {
   FileFolder,
   useUploadImageMutation,
 } from '~/generated/graphql';
+import { getImageAbsoluteURIOrBase64 } from '~/utils/image/getImageAbsoluteURIOrBase64';
 import { isDefined } from '~/utils/isDefined';
 import { isUndefinedOrNull } from '~/utils/isUndefinedOrNull';
 
@@ -139,7 +140,11 @@ export const RecordShowContainer = ({
             <>
               <ShowPageSummaryCard
                 id={objectRecordId}
-                logoOrAvatar={recordIdentifier?.avatarUrl ?? ''}
+                logoOrAvatar={
+                  getImageAbsoluteURIOrBase64(
+                    recordIdentifier?.avatarUrl ?? '',
+                  ) ?? ''
+                }
                 avatarPlaceholder={recordIdentifier?.name ?? ''}
                 date={recordFromStore.createdAt ?? ''}
                 loading={isPrefetchLoading || loading || recordLoading}

--- a/packages/twenty-front/src/utils/image/getImageAbsoluteURIOrBase64.ts
+++ b/packages/twenty-front/src/utils/image/getImageAbsoluteURIOrBase64.ts
@@ -1,7 +1,9 @@
+import { isNonEmptyString } from '@sniptt/guards';
+
 import { REACT_APP_SERVER_BASE_URL } from '~/config';
 
 export const getImageAbsoluteURIOrBase64 = (imageUrl?: string | null) => {
-  if (!imageUrl) {
+  if (!isNonEmptyString(imageUrl)) {
     return null;
   }
 


### PR DESCRIPTION
Avatar URL had multiple problems : 
- It wasn't queries due to our new gql fields optimization, has it is not a "visible field", so I fixed it with a dirty hack for person table but we should refactor it later with a clean approach based on metadata (which should be discussed before proceeding) see : `useLoadRecordIndexBoard` and `useLoadRecordIndexTable` 
- The RecordShowContainer component was lacking a call to `getImageAbsoluteURIOrBase64` (which we could maybe find a way to refactor so it's not placed at unclear locations in the code)