### PR TITLE
5505 forgot password feature broken

### DIFF
--- a/packages/twenty-front/src/generated/graphql.tsx
+++ b/packages/twenty-front/src/generated/graphql.tsx
@@ -157,6 +157,14 @@ export type DeleteOneObjectInput = {
   id: Scalars['UUID'];
 };
 
+/** Schema update on a table */
+export enum DistantTableUpdate {
+  ColumnsAdded = 'COLUMNS_ADDED',
+  ColumnsDeleted = 'COLUMNS_DELETED',
+  ColumnsTypeChanged = 'COLUMNS_TYPE_CHANGED',
+  TableDeleted = 'TABLE_DELETED'
+}
+
 export type EmailPasswordResetLink = {
   __typename?: 'EmailPasswordResetLink';
   /** Boolean that confirms query was dispatched */
@@ -585,7 +593,7 @@ export type RemoteTable = {
   id?: Maybe<Scalars['UUID']>;
   name: Scalars['String'];
   schema?: Maybe<Scalars['String']>;
-  schemaPendingUpdates?: Maybe<Array<TableUpdate>>;
+  schemaPendingUpdates?: Maybe<Array<DistantTableUpdate>>;
   status: RemoteTableStatus;
 };
 
@@ -624,14 +632,6 @@ export type Support = {
   supportDriver: Scalars['String'];
   supportFrontChatId?: Maybe<Scalars['String']>;
 };
-
-/** Schema update on a table */
-export enum TableUpdate {
-  ColumnsAdded = 'COLUMNS_ADDED',
-  ColumnsDeleted = 'COLUMNS_DELETED',
-  ColumnsTypeChanged = 'COLUMNS_TYPE_CHANGED',
-  TableDeleted = 'TABLE_DELETED'
-}
 
 export type Telemetry = {
   __typename?: 'Telemetry';
@@ -2095,7 +2095,7 @@ export type CheckUserExistsQueryHookResult = ReturnType<typeof useCheckUserExist
 export type CheckUserExistsLazyQueryHookResult = ReturnType<typeof useCheckUserExistsLazyQuery>;
 export type CheckUserExistsQueryResult = Apollo.QueryResult<CheckUserExistsQuery, CheckUserExistsQueryVariables>;
 export const ValidatePasswordResetTokenDocument = gql`
-    query validatePasswordResetToken($token: String!) {
+    query ValidatePasswordResetToken($token: String!) {
   validatePasswordResetToken(passwordResetToken: $token) {
     id
     email

--- a/packages/twenty-front/src/modules/auth/graphql/queries/validatePasswordResetToken.ts
+++ b/packages/twenty-front/src/modules/auth/graphql/queries/validatePasswordResetToken.ts
@@ -1,7 +1,7 @@
 import { gql } from '@apollo/client';
 
 export const VALIDATE_PASSWORD_RESET_TOKEN = gql`
-  query validatePasswordResetToken($token: String!) {
+  query ValidatePasswordResetToken($token: String!) {
     validatePasswordResetToken(passwordResetToken: $token) {
       id
       email

--- a/packages/twenty-front/src/pages/auth/PasswordReset.tsx
+++ b/packages/twenty-front/src/pages/auth/PasswordReset.tsx
@@ -144,6 +144,7 @@ export const PasswordReset = () => {
       }
 
       await signInWithCredentials(email || '', formData.newPassword);
+      navigate(AppPath.Index);
     } catch (err) {
       logError(err);
       enqueueSnackBar(

--- a/packages/twenty-server/src/engine/middlewares/graphql-hydrate-request-from-token.middleware.ts
+++ b/packages/twenty-server/src/engine/middlewares/graphql-hydrate-request-from-token.middleware.ts
@@ -31,6 +31,9 @@ export class GraphQLHydrateRequestFromTokenMiddleware
       'Verify',
       'SignUp',
       'RenewToken',
+      'EmailPasswordResetLink',
+      'ValidatePasswordResetToken',
+      'UpdatePasswordViaResetToken',
       'IntrospectionQuery',
       'ExchangeAuthorizationCode',
     ];


### PR DESCRIPTION
- add missing `excludedOperations` in `packages/twenty-server/src/engine/middlewares/graphql-hydrate-request-from-token.middleware.ts`
- update generated graphql file
- Add missing redirection to index after password update