### PR TITLE
fix: Requests for new captcha token after a wrong password is entered.

### DIFF
--- a/packages/twenty-front/src/modules/auth/sign-in-up/hooks/useSignInUp.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/hooks/useSignInUp.tsx
@@ -118,6 +118,7 @@ export const useSignInUp = (form: UseFormReturn<Form>) => {
         enqueueSnackBar(err?.message, {
           variant: SnackBarVariant.Error,
         });
+        requestFreshCaptchaToken();
       }
     },
     [
@@ -128,6 +129,7 @@ export const useSignInUp = (form: UseFormReturn<Form>) => {
       signUpWithCredentials,
       workspaceInviteHash,
       enqueueSnackBar,
+      requestFreshCaptchaToken,
     ],
   );
 


### PR DESCRIPTION
Fix issue where captcha did not reset after an incorrect password was entered and invalid token error was thrown, ensuring users receive a new captcha token on each attempt.

before:
![Screenshot 2024-05-27 191707](https://github.com/twentyhq/twenty/assets/72244570/7530c569-a3b5-46b9-96aa-b03c21f1e99a)

after: user can try again with a new captcha token and login smoothly without encountering the invalid token error.