### PR TITLE
Run queries within queryRunner transaction sequentially

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-runner/services/workspace-migration-enum.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-runner/services/workspace-migration-enum.service.ts
@@ -138,7 +138,7 @@ export class WorkspaceMigrationEnumService {
       `SELECT id, "${oldColumnName}" FROM "${schemaName}"."${tableName}"`,
     );
 
-    values.map(async (value) => {
+    for (const value of values) {
       let val = value[oldColumnName];
 
       if (/^\{.*\}$/.test(val)) {
@@ -159,7 +159,7 @@ export class WorkspaceMigrationEnumService {
         SET "${columnDefinition.columnName}" = ${val}
         WHERE id='${value.id}'
       `);
-    });
+    }
   }
 
   private async dropOldEnumType(


### PR DESCRIPTION
Update - the issue is actually that the whole map operation was not awaited at all. Using for of guarantees the await.

Old
_Within a queryRunner transaction, it is important that migrations are run subsequently and not concurrently: otherwise if an error is thrown by one of the query, it will abort the transaction; any subsequent query running on the same queryRunner will cause the error _current transaction is aborted, commands ignored until end of transaction block_.

Using an async function in a map as below does not guarantee that each query terminates before iterating over the next one, which can be an issue as described above, and which seems to cause [this sentry](https://twenty-v7.sentry.io/issues/5258406553/?environment=prod&project=4507072499810304&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=7d&stream_index=4)._