### PR TITLE
feat (improvement): update the createOneObjectMetaItem

### DIFF
--- a/packages/twenty-front/src/modules/object-metadata/hooks/useCreateOneObjectMetadataItem.ts
+++ b/packages/twenty-front/src/modules/object-metadata/hooks/useCreateOneObjectMetadataItem.ts
@@ -38,15 +38,18 @@ export const useCreateOneObjectMetadataItem = () => {
       refetchQueries: [getOperationName(FIND_MANY_OBJECT_METADATA_ITEMS) ?? ''],
     });
 
+    return createdObjectMetadata;
+  };
+
+  const findManyRecordsCache = async () => {
     await apolloClient.query({
       query: findManyRecordsQuery,
       fetchPolicy: 'network-only',
     });
-
-    return createdObjectMetadata;
   };
 
   return {
     createOneObjectMetadataItem,
+    findManyRecordsCache,
   };
 };

--- a/packages/twenty-front/src/pages/settings/data-model/SettingsNewObject.tsx
+++ b/packages/twenty-front/src/pages/settings/data-model/SettingsNewObject.tsx
@@ -59,7 +59,6 @@ export const SettingsNewObject = () => {
           : settingsObjectsPagePath,
       );
 
-      // run the findManyRecordsQuery to update the cache - without blocking the UI
       await findManyRecordsCache();
     } catch (error) {
       enqueueSnackBar((error as Error).message, {

--- a/packages/twenty-front/src/pages/settings/data-model/SettingsNewObject.tsx
+++ b/packages/twenty-front/src/pages/settings/data-model/SettingsNewObject.tsx
@@ -30,7 +30,8 @@ export const SettingsNewObject = () => {
   const navigate = useNavigate();
   const { enqueueSnackBar } = useSnackBar();
 
-  const { createOneObjectMetadataItem } = useCreateOneObjectMetadataItem();
+  const { createOneObjectMetadataItem, findManyRecordsCache } =
+    useCreateOneObjectMetadataItem();
 
   const settingsObjectsPagePath = getSettingsPagePath(SettingsPath.Objects);
 
@@ -57,6 +58,9 @@ export const SettingsNewObject = () => {
             )}`
           : settingsObjectsPagePath,
       );
+
+      // run the findManyRecordsQuery to update the cache - without blocking the UI
+      await findManyRecordsCache();
     } catch (error) {
       enqueueSnackBar((error as Error).message, {
         variant: SnackBarVariant.Error,


### PR DESCRIPTION
# This PR

- Fix #5278 
- Updates the implementation of the `createOneObjectMataItem` hook to reduce the number of api calls
- Users can now navigate to the newly created object first and the graphql api calls to cache data are happening in the background - this will improve the user experience and reduce the create object api call time by >2
<img width="1508" alt="Screenshot 2024-05-30 at 12 00 15" src="https://github.com/twentyhq/twenty/assets/61581306/46513fd1-d46e-40bc-a036-07e3acdf2870">

In the issue description, it also suggested to have a loading indicator while creating the object, it seems like on #5352 we adopted to disable it while creating the object - which looks good to me and it works, let me know if we still need the loading indicator instead @Bonapara 

Looking forward to getting your feedback
cc: @charlesBochet 
