### PR TITLE
fix remove favorite on opportunity delete

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-action-bar/hooks/useRecordActionBar.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-action-bar/hooks/useRecordActionBar.tsx
@@ -90,8 +90,22 @@ export const useRecordActionBar = ({
 
   const handleDeleteClick = useCallback(async () => {
     callback?.();
+    selectedRecordIds.forEach((recordId) => {
+      const foundFavorite = favorites?.find(
+        (favorite) => favorite.recordId === recordId,
+      );
+      if (foundFavorite !== undefined) {
+        deleteFavorite(foundFavorite.id);
+      }
+    });
     await deleteManyRecords(selectedRecordIds);
-  }, [callback, deleteManyRecords, selectedRecordIds]);
+  }, [
+    callback,
+    deleteManyRecords,
+    selectedRecordIds,
+    favorites,
+    deleteFavorite,
+  ]);
 
   const handleExecuteQuickActionOnClick = useCallback(async () => {
     callback?.();


### PR DESCRIPTION
- fix : #5521

When we deleted an opportunity that had been added to the favorites list, the opportunity was removed correctly, but it still remained in the favorites list. The issue was due to not accounting for the removal of the opportunity from the favorites during the deletion process. 

This problem has now been fixed : 


https://github.com/twentyhq/twenty/assets/78202522/3d3cb689-3228-43fc-bf50-e824370582a7


