### PR TITLE
Fixed: Inconsistent Field Label Display on Task Side Panel

### DIFF
--- a/packages/twenty-front/src/modules/activities/components/ActivityEditorFields.tsx
+++ b/packages/twenty-front/src/modules/activities/components/ActivityEditorFields.tsx
@@ -57,6 +57,16 @@ export const ActivityEditorFields = ({
     return [upsertActivityMutation, { loading: false }];
   };
 
+  const { FieldContextProvider: ReminderAtFieldContextProvider } =
+    useFieldContext({
+      objectNameSingular: CoreObjectNameSingular.Activity,
+      objectRecordId: activityId,
+      fieldMetadataName: 'reminderAt',
+      fieldPosition: 0,
+      clearable: true,
+      customUseUpdateOneObjectHook: useUpsertOneActivityMutation,
+    });
+
   const { FieldContextProvider: DueAtFieldContextProvider } = useFieldContext({
     objectNameSingular: CoreObjectNameSingular.Activity,
     objectRecordId: activityId,
@@ -87,9 +97,13 @@ export const ActivityEditorFields = ({
   return (
     <StyledPropertyBox>
       {activity.type === 'Task' &&
+        ReminderAtFieldContextProvider &&
         DueAtFieldContextProvider &&
         AssigneeFieldContextProvider && (
           <>
+            <ReminderAtFieldContextProvider>
+              <RecordInlineCell />
+            </ReminderAtFieldContextProvider>
             <DueAtFieldContextProvider>
               <RecordInlineCell />
             </DueAtFieldContextProvider>

--- a/packages/twenty-front/src/modules/activities/components/ActivityEditorFields.tsx
+++ b/packages/twenty-front/src/modules/activities/components/ActivityEditorFields.tsx
@@ -71,7 +71,7 @@ export const ActivityEditorFields = ({
     objectNameSingular: CoreObjectNameSingular.Activity,
     objectRecordId: activityId,
     fieldMetadataName: 'dueAt',
-    fieldPosition: 0,
+    fieldPosition: 1,
     clearable: true,
     customUseUpdateOneObjectHook: useUpsertOneActivityMutation,
   });
@@ -81,7 +81,7 @@ export const ActivityEditorFields = ({
       objectNameSingular: CoreObjectNameSingular.Activity,
       objectRecordId: activityId,
       fieldMetadataName: 'assignee',
-      fieldPosition: 1,
+      fieldPosition: 2,
       clearable: true,
       customUseUpdateOneObjectHook: useUpsertOneActivityMutation,
     });
@@ -91,7 +91,7 @@ export const ActivityEditorFields = ({
       objectNameSingular: CoreObjectNameSingular.Activity,
       objectRecordId: activityId,
       fieldMetadataName: 'activityTargets',
-      fieldPosition: 2,
+      fieldPosition: 3,
     });
 
   return (

--- a/packages/twenty-front/src/modules/object-record/hooks/useFieldContext.tsx
+++ b/packages/twenty-front/src/modules/object-record/hooks/useFieldContext.tsx
@@ -69,6 +69,7 @@ export const useFieldContext = ({
               isLabelIdentifier,
               fieldDefinition: formatFieldMetadataItemAsColumnDefinition({
                 field: fieldMetadataItem,
+                showLabel: true,
                 position: fieldPosition,
                 objectMetadataItem,
               }),


### PR DESCRIPTION
Now all the required fields are displayed with the respective labels.

- Added a `FieldContextProvider` for the field `Reminder` in the `ActivityEditorFields`.
- Fixed the missing label values, by adding a missed optional `showLabel` within the `fieldDefinition` in the `useFieldContext`.

fixes: #5667 

![Screenshot (342)](https://github.com/twentyhq/twenty/assets/140178357/adf9563a-6cab-4809-8616-1c256abab717)
