### PR TITLE
Fixed the Redirect to New Field Page for Kanban Setup

### DIFF
--- a/packages/twenty-front/src/modules/views/view-picker/hooks/useGetAvailableFieldsForKanban.ts
+++ b/packages/twenty-front/src/modules/views/view-picker/hooks/useGetAvailableFieldsForKanban.ts
@@ -24,9 +24,8 @@ export const useGetAvailableFieldsForKanban = () => {
   const navigate = useNavigate();
 
   const navigateToSelectSettings = useCallback(() => {
-    navigate(`/settings/objects/${objectMetadataItem?.namePlural}`);
-  }, [navigate, objectMetadataItem?.namePlural]);
-
+  navigate(`/settings/objects/${objectMetadataItem?.namePlural}/new-field/step-2`);
+}, [navigate, objectMetadataItem?.namePlural]);
   return {
     availableFieldsForKanban,
     navigateToSelectSettings,


### PR DESCRIPTION
This pull request addresses issue #5661 by updating the redirection behavior when users click on the "Redirect to New Field Page for Kanban Setup" link.
Changes Made:

    Updated the link destination from https://app.twenty.com/settings/objects/companies to https://app.twenty.com/settings/objects/companies/new-field/step-2.
    Modified the redirection behavior to direct users to the new field creation page instead of the object settings page.
    Pre-selected the "Select" field on the new field creation page, as requested.