### PR TITLE
Backfill position when not input

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/workspace-query-builder/factories/__tests__/record-position-query.factory.spec.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-query-builder/factories/__tests__/record-position-query.factory.spec.ts
@@ -16,74 +16,70 @@ describe('RecordPositionQueryFactory', () => {
   });
 
   describe('create', () => {
-    describe('createForGet', () => {
-      it('should return a string with the position when positionValue is first', async () => {
-        const positionValue = 'first';
-
-        const result = await factory.create(
-          RecordPositionQueryType.GET,
-          positionValue,
-          objectMetadataItem,
-          dataSourceSchema,
-        );
-
-        expect(result).toEqual(
-          `SELECT position FROM workspace_test."company"
-            WHERE "position" IS NOT NULL ORDER BY "position" ASC LIMIT 1`,
-        );
-      });
-
-      it('should return a string with the position when positionValue is last', async () => {
-        const positionValue = 'last';
-
-        const result = await factory.create(
-          RecordPositionQueryType.GET,
-          positionValue,
-          objectMetadataItem,
-          dataSourceSchema,
-        );
-
-        expect(result).toEqual(
-          `SELECT position FROM workspace_test."company"
-            WHERE "position" IS NOT NULL ORDER BY "position" DESC LIMIT 1`,
-        );
-      });
-    });
-
-    it('should return a string with the position when positionValue is a number', async () => {
+    it('should return query and params for FIND_BY_POSITION', async () => {
       const positionValue = 1;
-
-      try {
-        await factory.create(
-          RecordPositionQueryType.GET,
-          positionValue,
-          objectMetadataItem,
-          dataSourceSchema,
-        );
-      } catch (error) {
-        expect(error.message).toEqual(
-          'RecordPositionQueryType.GET requires positionValue to be a number',
-        );
-      }
-    });
-  });
-
-  describe('createForUpdate', () => {
-    it('should return a string when RecordPositionQueryType is UPDATE', async () => {
-      const positionValue = 1;
-
-      const result = await factory.create(
-        RecordPositionQueryType.UPDATE,
-        positionValue,
+      const queryType = RecordPositionQueryType.FIND_BY_POSITION;
+      const [query, params] = await factory.create(
+        { positionValue, recordPositionQueryType: queryType },
         objectMetadataItem,
         dataSourceSchema,
       );
 
-      expect(result).toEqual(
-        `UPDATE workspace_test."company"
+      expect(query).toEqual(
+        `SELECT * FROM ${dataSourceSchema}."${objectMetadataItem.nameSingular}"
+            WHERE "position" = $1`,
+      );
+      expect(params).toEqual([positionValue]);
+    });
+
+    it('should return query and params for FIND_FIRST_RECORD', async () => {
+      const queryType = RecordPositionQueryType.FIND_FIRST_RECORD;
+      const [query, params] = await factory.create(
+        { recordPositionQueryType: queryType },
+        objectMetadataItem,
+        dataSourceSchema,
+      );
+
+      expect(query).toEqual(
+        `SELECT * FROM ${dataSourceSchema}."${objectMetadataItem.nameSingular}"
+            ORDER BY "position" ASC
+            LIMIT 1`,
+      );
+      expect(params).toEqual([]);
+    });
+
+    it('should return query and params for FIND_LAST_RECORD', async () => {
+      const queryType = RecordPositionQueryType.FIND_LAST_RECORD;
+      const [query, params] = await factory.create(
+        { recordPositionQueryType: queryType },
+        objectMetadataItem,
+        dataSourceSchema,
+      );
+
+      expect(query).toEqual(
+        `SELECT * FROM ${dataSourceSchema}."${objectMetadataItem.nameSingular}"
+            ORDER BY "position" DESC
+            LIMIT 1`,
+      );
+      expect(params).toEqual([]);
+    });
+
+    it('should return query and params for UPDATE_POSITION', async () => {
+      const positionValue = 1;
+      const recordId = '1';
+      const queryType = RecordPositionQueryType.UPDATE_POSITION;
+      const [query, params] = await factory.create(
+        { positionValue, recordId, recordPositionQueryType: queryType },
+        objectMetadataItem,
+        dataSourceSchema,
+      );
+
+      expect(query).toEqual(
+        `UPDATE ${dataSourceSchema}."${objectMetadataItem.nameSingular}"
             SET "position" = $1
             WHERE "id" = $2`,
       );
+      expect(params).toEqual([positionValue, recordId]);
     });
   });
 });

--- a/packages/twenty-server/src/engine/api/graphql/workspace-query-builder/factories/__tests__/record-position-query.factory.spec.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-query-builder/factories/__tests__/record-position-query.factory.spec.ts
@@ -32,8 +32,8 @@ describe('RecordPositionQueryFactory', () => {
       expect(params).toEqual([positionValue]);
     });
 
-    it('should return query and params for FIND_FIRST_RECORD', async () => {
-      const queryType = RecordPositionQueryType.FIND_FIRST_RECORD;
+    it('should return query and params for FIND_MIN_POSITION', async () => {
+      const queryType = RecordPositionQueryType.FIND_MIN_POSITION;
       const [query, params] = await factory.create(
         { recordPositionQueryType: queryType },
         objectMetadataItem,
@@ -41,15 +41,13 @@ describe('RecordPositionQueryFactory', () => {
       );
 
       expect(query).toEqual(
-        `SELECT * FROM ${dataSourceSchema}."${objectMetadataItem.nameSingular}"
-            ORDER BY "position" ASC
-            LIMIT 1`,
+        `SELECT MIN(position) as position FROM ${dataSourceSchema}."${objectMetadataItem.nameSingular}`,
       );
       expect(params).toEqual([]);
     });
 
-    it('should return query and params for FIND_LAST_RECORD', async () => {
-      const queryType = RecordPositionQueryType.FIND_LAST_RECORD;
+    it('should return query and params for FIND_MAX_POSITION', async () => {
+      const queryType = RecordPositionQueryType.FIND_MAX_POSITION;
       const [query, params] = await factory.create(
         { recordPositionQueryType: queryType },
         objectMetadataItem,
@@ -57,9 +55,7 @@ describe('RecordPositionQueryFactory', () => {
       );
 
       expect(query).toEqual(
-        `SELECT * FROM ${dataSourceSchema}."${objectMetadataItem.nameSingular}"
-            ORDER BY "position" DESC
-            LIMIT 1`,
+        `SELECT MAX(position) as position FROM ${dataSourceSchema}."${objectMetadataItem.nameSingular}"`,
       );
       expect(params).toEqual([]);
     });

--- a/packages/twenty-server/src/engine/api/graphql/workspace-query-builder/factories/__tests__/record-position-query.factory.spec.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-query-builder/factories/__tests__/record-position-query.factory.spec.ts
@@ -26,7 +26,7 @@ describe('RecordPositionQueryFactory', () => {
       );
 
       expect(query).toEqual(
-        `SELECT * FROM ${dataSourceSchema}."${objectMetadataItem.nameSingular}"
+        `SELECT position FROM ${dataSourceSchema}."${objectMetadataItem.nameSingular}"
             WHERE "position" = $1`,
       );
       expect(params).toEqual([positionValue]);
@@ -41,7 +41,7 @@ describe('RecordPositionQueryFactory', () => {
       );
 
       expect(query).toEqual(
-        `SELECT MIN(position) as position FROM ${dataSourceSchema}."${objectMetadataItem.nameSingular}`,
+        `SELECT MIN(position) as position FROM ${dataSourceSchema}."${objectMetadataItem.nameSingular}"`,
       );
       expect(params).toEqual([]);
     });

--- a/packages/twenty-server/src/engine/api/graphql/workspace-query-builder/factories/record-position-query.factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-query-builder/factories/record-position-query.factory.ts
@@ -53,7 +53,7 @@ export class RecordPositionQueryFactory {
     switch (recordPositionQueryArgs.recordPositionQueryType) {
       case RecordPositionQueryType.FIND_BY_POSITION:
         return this.buildFindByPositionQuery(
-          recordPositionQueryArgs as FindByPositionQueryArgs,
+          recordPositionQueryArgs satisfies FindByPositionQueryArgs,
           name,
           dataSourceSchema,
         );
@@ -63,7 +63,7 @@ export class RecordPositionQueryFactory {
         return this.buildFindMaxPositionQuery(name, dataSourceSchema);
       case RecordPositionQueryType.UPDATE_POSITION:
         return this.buildUpdatePositionQuery(
-          recordPositionQueryArgs as UpdatePositionQueryArgs,
+          recordPositionQueryArgs satisfies UpdatePositionQueryArgs,
           name,
           dataSourceSchema,
         );

--- a/packages/twenty-server/src/engine/api/graphql/workspace-query-builder/factories/record-position-query.factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-query-builder/factories/record-position-query.factory.ts
@@ -39,17 +39,17 @@ export type RecordPositionQueryArgs =
 @Injectable()
 export class RecordPositionQueryFactory {
   create(
-    recordPositonQueryArgs: RecordPositionQueryArgs,
+    recordPositionQueryArgs: RecordPositionQueryArgs,
     objectMetadata: { isCustom: boolean; nameSingular: string },
     dataSourceSchema: string,
   ): [RecordPositionQuery, RecordPositionQueryParams] {
     const name =
       (objectMetadata.isCustom ? '_' : '') + objectMetadata.nameSingular;
 
-    switch (recordPositonQueryArgs.recordPositionQueryType) {
+    switch (recordPositionQueryArgs.recordPositionQueryType) {
       case RecordPositionQueryType.FIND_BY_POSITION:
         return this.buildFindByPositionQuery(
-          recordPositonQueryArgs as FindByPositionQueryArgs,
+          recordPositionQueryArgs as FindByPositionQueryArgs,
           name,
           dataSourceSchema,
         );
@@ -59,7 +59,7 @@ export class RecordPositionQueryFactory {
         return this.buildFindLastRecordQuery(name, dataSourceSchema);
       case RecordPositionQueryType.UPDATE_POSITION:
         return this.buildUpdatePositionQuery(
-          recordPositonQueryArgs as UpdatePositionQueryArgs,
+          recordPositionQueryArgs as UpdatePositionQueryArgs,
           name,
           dataSourceSchema,
         );

--- a/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/factories/__tests__/query-runner-args.factory.spec.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/factories/__tests__/query-runner-args.factory.spec.ts
@@ -12,12 +12,14 @@ describe('QueryRunnerArgsFactory', () => {
   const recordPositionFactory = {
     create: jest.fn().mockResolvedValue(2),
   };
+  const workspaceId = 'workspaceId';
   const options = {
     fieldMetadataCollection: [
       { name: 'position', type: FieldMetadataType.POSITION },
       { name: 'testNumber', type: FieldMetadataType.NUMBER },
     ] as FieldMetadataInterface[],
     objectMetadataItem: { isCustom: true, nameSingular: 'test' },
+    workspaceId,
   } as WorkspaceQueryRunnerOptions;
 
   let factory: QueryRunnerArgsFactory;
@@ -68,6 +70,36 @@ describe('QueryRunnerArgsFactory', () => {
         ResolverArgsType.CreateMany,
       );
 
+      expect(recordPositionFactory.create).toHaveBeenCalledWith(
+        'last',
+        { isCustom: true, nameSingular: 'test' },
+        workspaceId,
+        0,
+      );
+      expect(result).toEqual({
+        id: 'uuid',
+        data: [{ position: 2, testNumber: 1 }],
+      });
+    });
+
+    it('createMany type should override position if not present', async () => {
+      const args = {
+        id: 'uuid',
+        data: [{ testNumber: '1' }],
+      };
+
+      const result = await factory.create(
+        args,
+        options,
+        ResolverArgsType.CreateMany,
+      );
+
+      expect(recordPositionFactory.create).toHaveBeenCalledWith(
+        'first',
+        { isCustom: true, nameSingular: 'test' },
+        workspaceId,
+        0,
+      );
       expect(result).toEqual({
         id: 'uuid',
         data: [{ position: 2, testNumber: 1 }],

--- a/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/factories/__tests__/record-position.factory.spec.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/factories/__tests__/record-position.factory.spec.ts
@@ -9,14 +9,15 @@ describe('RecordPositionFactory', () => {
     create: jest.fn().mockResolvedValue('query'),
   };
 
-  const workspaceDataSourceService = {
-    getSchemaName: jest.fn().mockReturnValue('schemaName'),
-    executeRawQuery: jest.fn().mockResolvedValue([{ position: 1 }]),
-  };
+  let workspaceDataSourceService;
 
   let factory: RecordPositionFactory;
 
   beforeEach(async () => {
+    workspaceDataSourceService = {
+      getSchemaName: jest.fn().mockReturnValue('schemaName'),
+      executeRawQuery: jest.fn().mockResolvedValue([{ position: 1 }]),
+    };
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         RecordPositionFactory,
@@ -44,9 +45,19 @@ describe('RecordPositionFactory', () => {
 
     it('should return the value when value is a number', async () => {
       const value = 1;
+
+      workspaceDataSourceService.executeRawQuery.mockResolvedValue([]);
+
       const result = await factory.create(value, objectMetadata, workspaceId);
 
       expect(result).toEqual(value);
+    });
+    it('should throw an error when position is not unique', async () => {
+      const value = 1;
+
+      await expect(
+        factory.create(value, objectMetadata, workspaceId),
+      ).rejects.toThrow('Position is not unique');
     });
     it('should return the existing position -1 when value is first', async () => {
       const value = 'first';

--- a/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/factories/record-position.factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/factories/record-position.factory.ts
@@ -44,7 +44,7 @@ export class RecordPositionFactory {
     }
 
     if (value === 'first') {
-      const firstRecord = await this.findRecordPosition(
+      const recordWithMinPosition = await this.findRecordPosition(
         {
           recordPositionQueryType: RecordPositionQueryType.FIND_MIN_POSITION,
         },
@@ -53,12 +53,12 @@ export class RecordPositionFactory {
         workspaceId,
       );
 
-      return isDefined(firstRecord?.position)
-        ? firstRecord.position - index - 1
+      return isDefined(recordWithMinPosition?.position)
+        ? recordWithMinPosition.position - index - 1
         : 1;
     }
 
-    const lastRecord = await this.findRecordPosition(
+    const recordWithMaxPosition = await this.findRecordPosition(
       {
         recordPositionQueryType: RecordPositionQueryType.FIND_MAX_POSITION,
       },
@@ -67,8 +67,8 @@ export class RecordPositionFactory {
       workspaceId,
     );
 
-    return isDefined(lastRecord?.position)
-      ? lastRecord.position + index + 1
+    return isDefined(recordWithMaxPosition?.position)
+      ? recordWithMaxPosition.position + index + 1
       : 1;
   }
 

--- a/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/factories/record-position.factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/factories/record-position.factory.ts
@@ -26,7 +26,7 @@ export class RecordPositionFactory {
       this.workspaceDataSourceService.getSchemaName(workspaceId);
 
     if (typeof value === 'number') {
-      const recordWithSamePosition = await this.findRecord(
+      const recordWithSamePosition = await this.findRecordPosition(
         {
           recordPositionQueryType: RecordPositionQueryType.FIND_BY_POSITION,
           positionValue: value,
@@ -44,9 +44,9 @@ export class RecordPositionFactory {
     }
 
     if (value === 'first') {
-      const firstRecord = await this.findRecord(
+      const firstRecord = await this.findRecordPosition(
         {
-          recordPositionQueryType: RecordPositionQueryType.FIND_FIRST_RECORD,
+          recordPositionQueryType: RecordPositionQueryType.FIND_MIN_POSITION,
         },
         objectMetadata,
         dataSourceSchema,
@@ -58,9 +58,9 @@ export class RecordPositionFactory {
         : 1;
     }
 
-    const lastRecord = await this.findRecord(
+    const lastRecord = await this.findRecordPosition(
       {
-        recordPositionQueryType: RecordPositionQueryType.FIND_LAST_RECORD,
+        recordPositionQueryType: RecordPositionQueryType.FIND_MAX_POSITION,
       },
       objectMetadata,
       dataSourceSchema,
@@ -72,7 +72,7 @@ export class RecordPositionFactory {
       : 1;
   }
 
-  private async findRecord(
+  private async findRecordPosition(
     recordPositionQueryArgs: RecordPositionQueryArgs,
     objectMetadata: { isCustom: boolean; nameSingular: string },
     dataSourceSchema: string,

--- a/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/factories/record-position.factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/factories/record-position.factory.ts
@@ -4,6 +4,7 @@ import { isDefined } from 'class-validator';
 
 import { WorkspaceDataSourceService } from 'src/engine/workspace-datasource/workspace-datasource.service';
 import {
+  RecordPositionQueryArgs,
   RecordPositionQueryFactory,
   RecordPositionQueryType,
 } from 'src/engine/api/graphql/workspace-query-builder/factories/record-position-query.factory';
@@ -19,40 +20,76 @@ export class RecordPositionFactory {
     value: number | 'first' | 'last',
     objectMetadata: { isCustom: boolean; nameSingular: string },
     workspaceId: string,
+    index = 0,
   ): Promise<number> {
-    if (typeof value === 'number') {
-      return value;
-    }
-
     const dataSourceSchema =
       this.workspaceDataSourceService.getSchemaName(workspaceId);
 
-    const query = await this.recordPositionQueryFactory.create(
-      RecordPositionQueryType.GET,
-      value,
+    if (typeof value === 'number') {
+      const recordWithSamePosition = await this.findRecord(
+        {
+          recordPositionQueryType: RecordPositionQueryType.FIND_BY_POSITION,
+          positionValue: value,
+        },
+        objectMetadata,
+        dataSourceSchema,
+        workspaceId,
+      );
+
+      if (recordWithSamePosition) {
+        throw new Error('Position is not unique');
+      }
+
+      return value;
+    }
+
+    if (value === 'first') {
+      const firstRecord = await this.findRecord(
+        {
+          recordPositionQueryType: RecordPositionQueryType.FIND_FIRST_RECORD,
+        },
+        objectMetadata,
+        dataSourceSchema,
+        workspaceId,
+      );
+
+      return isDefined(firstRecord?.position)
+        ? firstRecord.position - index - 1
+        : 1;
+    }
+
+    const lastRecord = await this.findRecord(
+      {
+        recordPositionQueryType: RecordPositionQueryType.FIND_LAST_RECORD,
+      },
+      objectMetadata,
+      dataSourceSchema,
+      workspaceId,
+    );
+
+    return isDefined(lastRecord?.position)
+      ? lastRecord.position + index + 1
+      : 1;
+  }
+
+  private async findRecord(
+    recordPositionQueryArgs: RecordPositionQueryArgs,
+    objectMetadata: { isCustom: boolean; nameSingular: string },
+    dataSourceSchema: string,
+    workspaceId: string,
+  ) {
+    const [query, params] = await this.recordPositionQueryFactory.create(
+      recordPositionQueryArgs,
       objectMetadata,
       dataSourceSchema,
     );
 
-    // If the value was 'first', the first record will be the one with the lowest position
-    // If the value was 'last', the first record will be the one with the highest position
     const records = await this.workspaceDataSourceService.executeRawQuery(
       query,
-      [],
+      params,
       workspaceId,
-      undefined,
     );
 
-    if (
-      !isDefined(records) ||
-      records.length === 0 ||
-      !isDefined(records[0]?.position)
-    ) {
-      return 1;
-    }
-
-    return value === 'first'
-      ? records[0].position - 1
-      : records[0].position + 1;
+    return records?.[0];
   }
 }

--- a/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/services/record-position-backfill-service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/services/record-position-backfill-service.ts
@@ -31,16 +31,19 @@ export class RecordPositionBackfillService {
     const dataSourceSchema =
       this.workspaceDataSourceService.getSchemaName(workspaceId);
 
-    const query = await this.recordPositionQueryFactory.create(
-      RecordPositionQueryType.UPDATE,
-      position,
+    const [query, params] = await this.recordPositionQueryFactory.create(
+      {
+        recordPositionQueryType: RecordPositionQueryType.UPDATE_POSITION,
+        recordId,
+        positionValue: position,
+      },
       objectMetadata as ObjectMetadataInterface,
       dataSourceSchema,
     );
 
     this.workspaceDataSourceService.executeRawQuery(
       query,
-      [position, recordId],
+      params,
       workspaceId,
       undefined,
     );


### PR DESCRIPTION
- refactor record position factory and record position query factory
- override position if not present during createMany

To avoid overriding the same positions for all data in createMany, the logic is:
- if inserted last, use last position + arg index + 1
- if inserted first, use first position - arg index - 1