### PR TITLE
Updated Snackbar as shown in Figma Fixes #5666

### DIFF
--- a/packages/twenty-front/src/modules/ui/feedback/snack-bar-manager/components/SnackBar.tsx
+++ b/packages/twenty-front/src/modules/ui/feedback/snack-bar-manager/components/SnackBar.tsx
@@ -72,7 +72,7 @@ const StyledHeader = styled.div`
   align-items: center;
   color: ${({ theme }) => theme.font.color.primary};
   display: flex;
-  font-weight: ${({ theme }) => theme.font.weight.medium};
+  font-weight: ${({ theme }) => theme.font.weight.semiBold};
   gap: ${({ theme }) => theme.spacing(2)};
   height: ${({ theme }) => theme.spacing(6)};
   margin-bottom: ${({ theme }) => theme.spacing(1)};
@@ -187,9 +187,16 @@ export const SnackBar = ({
         {icon}
         {title}
         <StyledActions>
-          {!!onCancel && <LightButton title="Cancel" onClick={onCancel} />}
+          {!!onCancel && (
+            <LightButton title="Cancel" onClick={onCancel}>
+              Cancel
+            </LightButton>
+          )}
+
           {!!onClose && (
-            <LightIconButton title="Close" Icon={IconX} onClick={onClose} />
+            <LightIconButton title="Close" Icon={IconX} onClick={onClose}>
+              Cancel
+            </LightIconButton>
           )}
         </StyledActions>
       </StyledHeader>

--- a/packages/twenty-front/src/modules/ui/feedback/snack-bar-manager/components/SnackBar.tsx
+++ b/packages/twenty-front/src/modules/ui/feedback/snack-bar-manager/components/SnackBar.tsx
@@ -72,7 +72,7 @@ const StyledHeader = styled.div`
   align-items: center;
   color: ${({ theme }) => theme.font.color.primary};
   display: flex;
-  font-weight: ${({ theme }) => theme.font.weight.semiBold};
+  font-weight: ${({ theme }) => theme.font.weight.medium};
   gap: ${({ theme }) => theme.spacing(2)};
   height: ${({ theme }) => theme.spacing(6)};
   margin-bottom: ${({ theme }) => theme.spacing(1)};
@@ -187,16 +187,10 @@ export const SnackBar = ({
         {icon}
         {title}
         <StyledActions>
-          {!!onCancel && (
-            <LightButton title="Cancel" onClick={onCancel}>
-              Cancel
-            </LightButton>
-          )}
+          {!!onCancel && <LightButton title="Cancel" onClick={onCancel} />}
 
           {!!onClose && (
-            <LightIconButton title="Close" Icon={IconX} onClick={onClose}>
-              Cancel
-            </LightIconButton>
+            <LightIconButton title="Close" Icon={IconX} onClick={onClose} />
           )}
         </StyledActions>
       </StyledHeader>

--- a/packages/twenty-front/src/modules/ui/input/button/components/LightButton.tsx
+++ b/packages/twenty-front/src/modules/ui/input/button/components/LightButton.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent } from 'react';
+import { MouseEvent, ReactNode } from 'react';
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { IconComponent } from 'twenty-ui';
@@ -13,6 +13,7 @@ export type LightButtonProps = {
   active?: boolean;
   disabled?: boolean;
   focus?: boolean;
+  children?: ReactNode;
   onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
 };
 
@@ -82,6 +83,7 @@ export const LightButton = ({
   accent = 'secondary',
   disabled = false,
   focus = false,
+  children,
   onClick,
 }: LightButtonProps) => {
   const theme = useTheme();
@@ -95,7 +97,8 @@ export const LightButton = ({
       className={className}
       active={active}
     >
-      {!!Icon && <Icon size={theme.icon.size.sm} />}
+      {children}
+      {!!Icon && <Icon size={theme.icon.size.md} />}
       {title}
     </StyledButton>
   );

--- a/packages/twenty-front/src/modules/ui/input/button/components/LightButton.tsx
+++ b/packages/twenty-front/src/modules/ui/input/button/components/LightButton.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent, ReactNode } from 'react';
+import { MouseEvent } from 'react';
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { IconComponent } from 'twenty-ui';
@@ -13,7 +13,6 @@ export type LightButtonProps = {
   active?: boolean;
   disabled?: boolean;
   focus?: boolean;
-  children?: ReactNode;
   onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
 };
 
@@ -83,7 +82,6 @@ export const LightButton = ({
   accent = 'secondary',
   disabled = false,
   focus = false,
-  children,
   onClick,
 }: LightButtonProps) => {
   const theme = useTheme();
@@ -97,7 +95,6 @@ export const LightButton = ({
       className={className}
       active={active}
     >
-      {children}
       {!!Icon && <Icon size={theme.icon.size.md} />}
       {title}
     </StyledButton>

--- a/packages/twenty-front/src/modules/ui/input/button/components/LightIconButton.tsx
+++ b/packages/twenty-front/src/modules/ui/input/button/components/LightIconButton.tsx
@@ -1,4 +1,4 @@
-import { ComponentProps, MouseEvent } from 'react';
+import { ComponentProps, MouseEvent, ReactNode } from 'react';
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { IconComponent } from 'twenty-ui';
@@ -16,6 +16,7 @@ export type LightIconButtonProps = {
   active?: boolean;
   disabled?: boolean;
   focus?: boolean;
+  children?: ReactNode;
   onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
 } & Pick<ComponentProps<'button'>, 'aria-label' | 'title'>;
 
@@ -56,13 +57,12 @@ const StyledButton = styled.button<
   gap: ${({ theme }) => theme.spacing(1)};
   height: ${({ size }) => (size === 'small' ? '24px' : '32px')};
   justify-content: center;
-  padding: 0;
+  padding-left: 5px;
+  padding-right: 4px;
   transition: background 0.1s ease;
 
-  white-space: nowrap;
-
-  width: ${({ size }) => (size === 'small' ? '24px' : '32px')};
-  min-width: ${({ size }) => (size === 'small' ? '24px' : '32px')};
+  width: auto;
+  min-width: ${({ size }) => (size === 'small' ? '48px' : '64px')};
 
   &:hover {
     background: ${({ theme, disabled }) =>
@@ -91,6 +91,7 @@ export const LightIconButton = ({
   focus = false,
   onClick,
   title,
+  children,
 }: LightIconButtonProps) => {
   const theme = useTheme();
   return (
@@ -106,6 +107,7 @@ export const LightIconButton = ({
       active={active}
       title={title}
     >
+      {children}
       {Icon && <Icon size={theme.icon.size.sm} stroke={theme.icon.stroke.sm} />}
     </StyledButton>
   );

--- a/packages/twenty-front/src/modules/ui/input/button/components/LightIconButton.tsx
+++ b/packages/twenty-front/src/modules/ui/input/button/components/LightIconButton.tsx
@@ -1,4 +1,4 @@
-import { ComponentProps, MouseEvent, ReactNode } from 'react';
+import { ComponentProps, MouseEvent } from 'react';
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { IconComponent } from 'twenty-ui';
@@ -16,7 +16,6 @@ export type LightIconButtonProps = {
   active?: boolean;
   disabled?: boolean;
   focus?: boolean;
-  children?: ReactNode;
   onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
 } & Pick<ComponentProps<'button'>, 'aria-label' | 'title'>;
 
@@ -57,12 +56,12 @@ const StyledButton = styled.button<
   gap: ${({ theme }) => theme.spacing(1)};
   height: ${({ size }) => (size === 'small' ? '24px' : '32px')};
   justify-content: center;
-  padding-left: 5px;
-  padding-right: 4px;
+  padding: 0;
   transition: background 0.1s ease;
 
-  width: auto;
-  min-width: ${({ size }) => (size === 'small' ? '48px' : '64px')};
+  white-space: nowrap;
+  width: ${({ size }) => (size === 'small' ? '24px' : '32px')};
+  min-width: ${({ size }) => (size === 'small' ? '24px' : '32px')};
 
   &:hover {
     background: ${({ theme, disabled }) =>
@@ -91,7 +90,6 @@ export const LightIconButton = ({
   focus = false,
   onClick,
   title,
-  children,
 }: LightIconButtonProps) => {
   const theme = useTheme();
   return (
@@ -107,7 +105,6 @@ export const LightIconButton = ({
       active={active}
       title={title}
     >
-      {children}
       {Icon && <Icon size={theme.icon.size.sm} stroke={theme.icon.stroke.sm} />}
     </StyledButton>
   );


### PR DESCRIPTION
<img width="282" alt="Screenshot 2024-06-01 at 1 07 16 AM" src="https://github.com/twentyhq/twenty/assets/10000167/0b1cd2f5-9036-4a31-8dfa-b90972ebe1aa">


Updated the font weight and added Cancel label on the left of the icon as shown in figma design.
Also, didn't increased the gap because it's already like the figma design!
Let me know if you want more gap between title and description.

Closes https://github.com/twentyhq/twenty/issues/5666