### PR TITLE
Fixed: Fields Disappear on Drag and Drop

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-board/record-board-card/components/RecordBoardCard.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/record-board-card/components/RecordBoardCard.tsx
@@ -6,6 +6,7 @@ import { EntityChipVariant, IconEye } from 'twenty-ui';
 
 import { RecordChip } from '@/object-record/components/RecordChip';
 import { RecordBoardContext } from '@/object-record/record-board/contexts/RecordBoardContext';
+import { useDragSelect } from '@/ui/utilities/drag-select/hooks/useDragSelect';
 import { useRecordBoardStates } from '@/object-record/record-board/hooks/internal/useRecordBoardStates';
 import { RecordBoardCardContext } from '@/object-record/record-board/record-board-card/contexts/RecordBoardCardContext';
 import {
@@ -199,6 +200,7 @@ export const RecordBoardCard = () => {
   };
 
   const scrollWrapperRef = useContext(ScrollWrapperContext);
+  const { isDragSelectionStartEnabled } = useDragSelect();
 
   const { ref: cardRef, inView } = useInView({
     root: scrollWrapperRef.current,
@@ -280,8 +282,10 @@ export const RecordBoardCard = () => {
                 >
                   {inView ? (
                     <RecordInlineCell />
-                  ) : (
+                  ) : !isDragSelectionStartEnabled() ? (
                     <StyledRecordInlineCellPlaceholder />
+                  ) : (
+                    <RecordInlineCell />
                   )}
                 </FieldContext.Provider>
               </PreventSelectOnClickContainer>

--- a/packages/twenty-front/src/modules/object-record/record-board/record-board-card/components/RecordBoardCard.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/record-board-card/components/RecordBoardCard.tsx
@@ -280,12 +280,10 @@ export const RecordBoardCard = () => {
                     hotkeyScope: InlineCellHotkeyScope.InlineCell,
                   }}
                 >
-                  {inView ? (
+                  {inView || isDragSelectionStartEnabled() ? (
                     <RecordInlineCell />
-                  ) : !isDragSelectionStartEnabled() ? (
-                    <StyledRecordInlineCellPlaceholder />
                   ) : (
-                    <RecordInlineCell />
+                    <StyledRecordInlineCellPlaceholder />
                   )}
                 </FieldContext.Provider>
               </PreventSelectOnClickContainer>

--- a/packages/twenty-front/src/modules/object-record/record-board/record-board-card/components/RecordBoardCard.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/record-board-card/components/RecordBoardCard.tsx
@@ -6,7 +6,6 @@ import { EntityChipVariant, IconEye } from 'twenty-ui';
 
 import { RecordChip } from '@/object-record/components/RecordChip';
 import { RecordBoardContext } from '@/object-record/record-board/contexts/RecordBoardContext';
-import { useDragSelect } from '@/ui/utilities/drag-select/hooks/useDragSelect';
 import { useRecordBoardStates } from '@/object-record/record-board/hooks/internal/useRecordBoardStates';
 import { RecordBoardCardContext } from '@/object-record/record-board/record-board-card/contexts/RecordBoardCardContext';
 import {
@@ -24,6 +23,7 @@ import { Checkbox, CheckboxVariant } from '@/ui/input/components/Checkbox';
 import { contextMenuIsOpenState } from '@/ui/navigation/context-menu/states/contextMenuIsOpenState';
 import { contextMenuPositionState } from '@/ui/navigation/context-menu/states/contextMenuPositionState';
 import { AnimatedEaseInOut } from '@/ui/utilities/animation/components/AnimatedEaseInOut';
+import { useDragSelect } from '@/ui/utilities/drag-select/hooks/useDragSelect';
 import { ScrollWrapperContext } from '@/ui/utilities/scroll/components/ScrollWrapper';
 
 const StyledBoardCard = styled.div<{ selected: boolean }>`


### PR DESCRIPTION
Now the fields don't disappear on drag and drop.

- After reviewing the codebase, I checked that when `inView` is true the `RecordInlineCell` is rendered otherwise the `StyledRecordInlineCellPlaceholder` will render which causes the fields get disappear.
- So, I added the condition to check if `isDragSelectionStartEnabled` is false then `StyledRecordInlineCellPlaceholder` will be rendered otherwise `RecordInlineCell`.

fixes: #5651 


https://github.com/twentyhq/twenty/assets/140178357/022195ca-fec2-43a7-8808-f4974dbe66cf



