### PR TITLE
[Improvement] LeftPanel skeleton loader

### DIFF
--- a/packages/twenty-front/src/loading/components/LeftPanelSkeletonLoader.tsx
+++ b/packages/twenty-front/src/loading/components/LeftPanelSkeletonLoader.tsx
@@ -64,8 +64,7 @@ export const LeftPanelSkeletonLoader = () => {
               <Skeleton width={96} height={16} />
             </SkeletonTheme>
           </StyledSkeletonTitleContainer>
-          <MainNavigationDrawerItemsSkeletonLoader length={4} />
-          <MainNavigationDrawerItemsSkeletonLoader title length={2} />
+          <MainNavigationDrawerItemsSkeletonLoader length={3} />
           <MainNavigationDrawerItemsSkeletonLoader title length={3} />
         </StyledSkeletonContainer>
       </StyledItemsContainer>


### PR DESCRIPTION
This change solves #5664 
This modifies the left-side panel skeleton loader in accordance with the default view.
![old-loading-ui](https://github.com/twentyhq/twenty/assets/171416711/83fe8a06-6f49-4581-bb84-00d2a0291f37)
![new-loading-ui](https://github.com/twentyhq/twenty/assets/171416711/4ba45fc0-8932-4ee9-b558-9f810d7891bd)
![default-loaded-view](https://github.com/twentyhq/twenty/assets/171416711/40c301d2-1015-4a2c-9458-0d2fb9d7de75)

