### PR TITLE
FIx LeftPanel Skeleton Alignment

### DIFF
--- a/packages/twenty-front/src/loading/components/LeftPanelSkeletonLoader.tsx
+++ b/packages/twenty-front/src/loading/components/LeftPanelSkeletonLoader.tsx
@@ -26,7 +26,7 @@ const StyledItemsContainer = styled.div`
 const StyledSkeletonContainer = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 32px;
+  gap: 12px;
 `;
 
 const StyledSkeletonTitleContainer = styled.div`
@@ -35,6 +35,12 @@ const StyledSkeletonTitleContainer = styled.div`
   gap: 6px;
   margin-left: 12px;
   margin-top: 8px;
+`;
+
+const MainNavigationDrawerContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
 `;
 
 export const LeftPanelSkeletonLoader = () => {
@@ -64,9 +70,11 @@ export const LeftPanelSkeletonLoader = () => {
               <Skeleton width={96} height={16} />
             </SkeletonTheme>
           </StyledSkeletonTitleContainer>
-          <MainNavigationDrawerItemsSkeletonLoader length={4} />
-          <MainNavigationDrawerItemsSkeletonLoader title length={2} />
-          <MainNavigationDrawerItemsSkeletonLoader title length={3} />
+          <MainNavigationDrawerContainer>
+            <MainNavigationDrawerItemsSkeletonLoader length={3} />
+            {/* <MainNavigationDrawerItemsSkeletonLoader title length={2} /> */}
+            <MainNavigationDrawerItemsSkeletonLoader title length={3} />
+          </MainNavigationDrawerContainer>
         </StyledSkeletonContainer>
       </StyledItemsContainer>
     </StyledAnimatedContainer>


### PR DESCRIPTION
fixes [#5664](https://github.com/twentyhq/twenty/issues/5664).

- remove the extra skeletons
- use the exact flex gap structuring as used by the original items.

### Result

https://github.com/twentyhq/twenty/assets/60315832/759ea4e2-05ed-4d82-986c-0612ce81f861

