### PR TITLE
Fix exception handler capturing graphql errors

### DIFF
--- a/packages/twenty-server/src/engine/utils/global-exception-handler.util.ts
+++ b/packages/twenty-server/src/engine/utils/global-exception-handler.util.ts
@@ -1,5 +1,7 @@
 import { HttpException } from '@nestjs/common';
 
+import { GraphQLError } from 'graphql';
+
 import { ExceptionHandlerUser } from 'src/engine/integrations/exception-handler/interfaces/exception-handler-user.interface';
 
 import {
@@ -35,6 +37,9 @@ export const handleExceptionAndConvertToGraphQLError = (
 };
 
 export const shouldFilterException = (exception: Error): boolean => {
+  if (exception instanceof GraphQLError) {
+    return true;
+  }
   if (exception instanceof HttpException && exception.getStatus() < 500) {
     return true;
   }

--- a/packages/twenty-server/src/engine/utils/global-exception-handler.util.ts
+++ b/packages/twenty-server/src/engine/utils/global-exception-handler.util.ts
@@ -37,7 +37,10 @@ export const handleExceptionAndConvertToGraphQLError = (
 };
 
 export const shouldFilterException = (exception: Error): boolean => {
-  if (exception instanceof GraphQLError) {
+  if (
+    exception instanceof GraphQLError &&
+    (exception?.extensions?.http?.status ?? 500) < 500
+  ) {
     return true;
   }
   if (exception instanceof HttpException && exception.getStatus() < 500) {


### PR DESCRIPTION
Our exception handler has to filter out some errors/exceptions so they are not caught by the ExceptionHandlerDriver (Logged or Sentry for example). This is done for Http errors in the range of 4xx and also makes sure they are converted back to Graphql validation errors.
However, graphql validation errors that are already managed by Yoga (with Schema validation) should also be filtered out, this PR should fix that behaviour