### PR TITLE
Fix boolean field in table view

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/components/FieldDisplay.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/components/FieldDisplay.tsx
@@ -1,6 +1,8 @@
 import { useContext } from 'react';
 
+import { BooleanFieldDisplay } from '@/object-record/record-field/meta-types/display/components/BooleanFieldDisplay';
 import { LinksFieldDisplay } from '@/object-record/record-field/meta-types/display/components/LinksFieldDisplay';
+import { isFieldBoolean } from '@/object-record/record-field/types/guards/isFieldBoolean';
 import { isFieldDisplayedAsPhone } from '@/object-record/record-field/types/guards/isFieldDisplayedAsPhone';
 import { isFieldLinks } from '@/object-record/record-field/types/guards/isFieldLinks';
 
@@ -81,5 +83,7 @@ export const FieldDisplay = () => {
     <AddressFieldDisplay />
   ) : isFieldRawJson(fieldDefinition) ? (
     <JsonFieldDisplay />
+  ) : isFieldBoolean(fieldDefinition) ? (
+    <BooleanFieldDisplay />
   ) : null;
 };

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/display/components/BooleanFieldDisplay.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/display/components/BooleanFieldDisplay.tsx
@@ -1,0 +1,8 @@
+import { useBooleanField } from '@/object-record/record-field/meta-types/hooks/useBooleanField';
+import { BooleanDisplay } from '@/ui/field/display/components/BooleanDisplay';
+
+export const BooleanFieldDisplay = () => {
+  const { fieldValue } = useBooleanField();
+
+  return <BooleanDisplay value={fieldValue} />;
+};

--- a/packages/twenty-front/src/modules/ui/field/display/components/BooleanDisplay.tsx
+++ b/packages/twenty-front/src/modules/ui/field/display/components/BooleanDisplay.tsx
@@ -15,7 +15,6 @@ export const BooleanDisplay = ({ value }: BooleanDisplayProps) => {
 
   return (
     <>
-      {' '}
       {value ? (
         <IconCheck size={theme.icon.size.sm} />
       ) : (

--- a/packages/twenty-front/src/modules/ui/field/display/components/BooleanDisplay.tsx
+++ b/packages/twenty-front/src/modules/ui/field/display/components/BooleanDisplay.tsx
@@ -2,6 +2,8 @@ import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { IconCheck, IconX } from 'twenty-ui';
 
+import { isDefined } from '~/utils/isDefined';
+
 const StyledBooleanFieldValue = styled.div`
   margin-left: ${({ theme }) => theme.spacing(1)};
 `;
@@ -15,14 +17,20 @@ export const BooleanDisplay = ({ value }: BooleanDisplayProps) => {
 
   return (
     <>
-      {value ? (
-        <IconCheck size={theme.icon.size.sm} />
+      {isDefined(value) ? (
+        <>
+          {value ? (
+            <IconCheck size={theme.icon.size.sm} />
+          ) : (
+            <IconX size={theme.icon.size.sm} />
+          )}
+          <StyledBooleanFieldValue>
+            {value ? 'True' : 'False'}
+          </StyledBooleanFieldValue>
+        </>
       ) : (
-        <IconX size={theme.icon.size.sm} />
+        <></>
       )}
-      <StyledBooleanFieldValue>
-        {value ? 'True' : 'False'}
-      </StyledBooleanFieldValue>
     </>
   );
 };

--- a/packages/twenty-front/src/modules/ui/field/display/components/BooleanDisplay.tsx
+++ b/packages/twenty-front/src/modules/ui/field/display/components/BooleanDisplay.tsx
@@ -1,0 +1,29 @@
+import { useTheme } from '@emotion/react';
+import styled from '@emotion/styled';
+import { IconCheck, IconX } from 'twenty-ui';
+
+const StyledBooleanFieldValue = styled.div`
+  margin-left: ${({ theme }) => theme.spacing(1)};
+`;
+
+type BooleanDisplayProps = {
+  value: boolean | null;
+};
+
+export const BooleanDisplay = ({ value }: BooleanDisplayProps) => {
+  const theme = useTheme();
+
+  return (
+    <>
+      {' '}
+      {value ? (
+        <IconCheck size={theme.icon.size.sm} />
+      ) : (
+        <IconX size={theme.icon.size.sm} />
+      )}
+      <StyledBooleanFieldValue>
+        {value ? 'True' : 'False'}
+      </StyledBooleanFieldValue>
+    </>
+  );
+};

--- a/packages/twenty-front/src/modules/ui/field/input/components/BooleanInput.tsx
+++ b/packages/twenty-front/src/modules/ui/field/input/components/BooleanInput.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
-import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
-import { IconCheck, IconX } from 'twenty-ui';
+
+import { BooleanDisplay } from '@/ui/field/display/components/BooleanDisplay';
 
 const StyledEditableBooleanFieldContainer = styled.div`
   align-items: center;
@@ -10,10 +10,6 @@ const StyledEditableBooleanFieldContainer = styled.div`
 
   height: 100%;
   width: 100%;
-`;
-
-const StyledEditableBooleanFieldValue = styled.div`
-  margin-left: ${({ theme }) => theme.spacing(1)};
 `;
 
 type BooleanInputProps = {
@@ -40,21 +36,12 @@ export const BooleanInput = ({
     onToggle?.(!internalValue);
   };
 
-  const theme = useTheme();
-
   return (
     <StyledEditableBooleanFieldContainer
       onClick={readonly ? undefined : handleClick}
       data-testid={testId}
     >
-      {internalValue ? (
-        <IconCheck size={theme.icon.size.sm} />
-      ) : (
-        <IconX size={theme.icon.size.sm} />
-      )}
-      <StyledEditableBooleanFieldValue>
-        {internalValue ? 'True' : 'False'}
-      </StyledEditableBooleanFieldValue>
+      <BooleanDisplay value={internalValue} />
     </StyledEditableBooleanFieldContainer>
   );
 };


### PR DESCRIPTION
Boolean field was not working in display (unfocused) mode.

Before fix
<img width="269" alt="Capture d’écran 2024-06-04 à 11 50 55" src="https://github.com/twentyhq/twenty/assets/51697796/9140f71c-41e4-44b4-9514-933edab33dd6">
https://github.com/twentyhq/twenty/assets/51697796/831c34a7-b91c-4df9-81d8-ced01cc7b9b6

After fix
<img width="284" alt="Capture d’écran 2024-06-04 à 11 51 01" src="https://github.com/twentyhq/twenty/assets/51697796/7e4a089d-0c55-4624-a5d3-44c00681c6ca">
https://github.com/twentyhq/twenty/assets/51697796/b5103f39-64c1-4ace-ab32-353aba364471



