### PR TITLE
Fix select field options update

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-runner/services/workspace-migration-enum.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-runner/services/workspace-migration-enum.service.ts
@@ -158,7 +158,7 @@ export class WorkspaceMigrationEnumService {
             .map((v: string) =>
               this.migrateEnumValue(v, renamedEnumValues, enumValues),
             )
-            .filter((v: string) => enumValues.includes(v)),
+            .filter((v: string | null) => isDefined(v)),
         );
       } else if (typeof val === 'string') {
         const migratedValue = this.migrateEnumValue(

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-runner/services/workspace-migration-enum.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-runner/services/workspace-migration-enum.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 import { QueryRunner, TableColumn } from 'typeorm';
 import { v4 } from 'uuid';
+import { isDefined } from 'class-validator';
 
 import {
   WorkspaceMigrationColumnAlter,
@@ -117,10 +118,17 @@ export class WorkspaceMigrationEnumService {
   private migrateEnumValue(
     value: string,
     renamedEnumValues?: WorkspaceMigrationRenamedEnum[],
+    allEnumValues?: string[],
   ) {
-    return (
-      renamedEnumValues?.find((enumVal) => enumVal?.from === value)?.to || value
-    );
+    if (renamedEnumValues?.find((enumVal) => enumVal?.from === value)?.to) {
+      return renamedEnumValues?.find((enumVal) => enumVal?.from === value)?.to;
+    }
+
+    if (allEnumValues?.includes(value)) {
+      return value;
+    }
+
+    return null;
   }
 
   private async migrateEnumValues(
@@ -147,11 +155,19 @@ export class WorkspaceMigrationEnumService {
             .slice(1, -1)
             .split(',')
             .map((v: string) => v.trim())
-            .map((v: string) => this.migrateEnumValue(v, renamedEnumValues))
+            .map((v: string) =>
+              this.migrateEnumValue(v, renamedEnumValues, enumValues),
+            )
             .filter((v: string) => enumValues.includes(v)),
         );
       } else if (typeof val === 'string') {
-        val = `'${this.migrateEnumValue(val, renamedEnumValues)}'`;
+        const migratedValue = this.migrateEnumValue(
+          val,
+          renamedEnumValues,
+          enumValues,
+        );
+
+        val = isDefined(migratedValue) ? `'${migratedValue}'` : null;
       }
 
       await queryRunner.query(`


### PR DESCRIPTION
Update of select fields options was failing if we deleted an option that was used for at least one row: former code would not update the value to null but leave it to the no-longer-allowed value.