### PR TITLE
Fix edit button missing in activity editor

### DIFF
--- a/packages/twenty-front/src/modules/activities/inline-cell/components/ActivityTargetsInlineCell.tsx
+++ b/packages/twenty-front/src/modules/activities/inline-cell/components/ActivityTargetsInlineCell.tsx
@@ -6,6 +6,7 @@ import { useActivityTargetObjectRecords } from '@/activities/hooks/useActivityTa
 import { ActivityTargetInlineCellEditMode } from '@/activities/inline-cell/components/ActivityTargetInlineCellEditMode';
 import { Activity } from '@/activities/types/Activity';
 import { ActivityEditorHotkeyScope } from '@/activities/types/ActivityEditorHotkeyScope';
+import { FieldFocusContextProvider } from '@/object-record/record-field/contexts/FieldFocusContextProvider';
 import { RecordFieldInputScope } from '@/object-record/record-field/scopes/RecordFieldInputScope';
 import { RecordInlineCellContainer } from '@/object-record/record-inline-cell/components/RecordInlineCellContainer';
 import { useInlineCell } from '@/object-record/record-inline-cell/hooks/useInlineCell';
@@ -38,29 +39,31 @@ export const ActivityTargetsInlineCell = ({
 
   return (
     <RecordFieldInputScope recordFieldInputScopeId={activity?.id ?? ''}>
-      <RecordInlineCellContainer
-        buttonIcon={IconPencil}
-        customEditHotkeyScope={{
-          scope: ActivityEditorHotkeyScope.ActivityTargets,
-        }}
-        IconLabel={showLabel ? IconArrowUpRight : undefined}
-        showLabel={showLabel}
-        readonly={readonly}
-        editModeContent={
-          <ActivityTargetInlineCellEditMode
-            activity={activity}
-            activityTargetWithTargetRecords={activityTargetObjectRecords}
-          />
-        }
-        label="Relations"
-        displayModeContent={
-          <ActivityTargetChips
-            activityTargetObjectRecords={activityTargetObjectRecords}
-            maxWidth={maxWidth}
-          />
-        }
-        isDisplayModeContentEmpty={activityTargetObjectRecords.length === 0}
-      />
+      <FieldFocusContextProvider>
+        <RecordInlineCellContainer
+          buttonIcon={IconPencil}
+          customEditHotkeyScope={{
+            scope: ActivityEditorHotkeyScope.ActivityTargets,
+          }}
+          IconLabel={showLabel ? IconArrowUpRight : undefined}
+          showLabel={showLabel}
+          readonly={readonly}
+          editModeContent={
+            <ActivityTargetInlineCellEditMode
+              activity={activity}
+              activityTargetWithTargetRecords={activityTargetObjectRecords}
+            />
+          }
+          label="Relations"
+          displayModeContent={
+            <ActivityTargetChips
+              activityTargetObjectRecords={activityTargetObjectRecords}
+              maxWidth={maxWidth}
+            />
+          }
+          isDisplayModeContentEmpty={activityTargetObjectRecords.length === 0}
+        />
+      </FieldFocusContextProvider>
     </RecordFieldInputScope>
   );
 };

--- a/packages/twenty-front/src/modules/object-metadata/utils/getAvatarUrl.ts
+++ b/packages/twenty-front/src/modules/object-metadata/utils/getAvatarUrl.ts
@@ -2,10 +2,10 @@ import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSi
 import { FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
 import { ObjectRecord } from '@/object-record/types/ObjectRecord';
 import { getLogoUrlFromDomainName } from '~/utils';
+import { getImageAbsoluteURIOrBase64 } from '~/utils/image/getImageAbsoluteURIOrBase64';
 import { isDefined } from '~/utils/isDefined';
 
 import { getImageIdentifierFieldValue } from './getImageIdentifierFieldValue';
-import { getImageAbsoluteURIOrBase64 } from '~/utils/image/getImageAbsoluteURIOrBase64';
 
 export const getAvatarUrl = (
   objectNameSingular: string,


### PR DESCRIPTION
## Context
Fixing `setIsFocused is not a function` and the fact that edit buttons were not showing up anymore.
A new FieldFocusContextProvider has been introduced and added to RecordInlineCell but not ActivityTargetsInlineCell. This should fix the issue.

<img width="523" alt="Screenshot 2024-06-05 at 17 42 07" src="https://github.com/twentyhq/twenty/assets/1834158/1c1f919e-3829-4e40-b573-3b1b75b7c16f">
