### PR TITLE
Remove check unique position

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/factories/__tests__/record-position.factory.spec.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/factories/__tests__/record-position.factory.spec.ts
@@ -46,25 +46,18 @@ describe('RecordPositionFactory', () => {
     it('should return the value when value is a number', async () => {
       const value = 1;
 
-      workspaceDataSourceService.executeRawQuery.mockResolvedValue([]);
-
       const result = await factory.create(value, objectMetadata, workspaceId);
 
       expect(result).toEqual(value);
     });
-    it('should throw an error when position is not unique', async () => {
-      const value = 1;
 
-      await expect(
-        factory.create(value, objectMetadata, workspaceId),
-      ).rejects.toThrow('Position is not unique');
-    });
     it('should return the existing position -1 when value is first', async () => {
       const value = 'first';
       const result = await factory.create(value, objectMetadata, workspaceId);
 
       expect(result).toEqual(0);
     });
+
     it('should return the existing position + 1 when value is last', async () => {
       const value = 'last';
       const result = await factory.create(value, objectMetadata, workspaceId);

--- a/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/factories/record-position.factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/factories/record-position.factory.ts
@@ -26,20 +26,6 @@ export class RecordPositionFactory {
       this.workspaceDataSourceService.getSchemaName(workspaceId);
 
     if (typeof value === 'number') {
-      const recordWithSamePosition = await this.findRecordPosition(
-        {
-          recordPositionQueryType: RecordPositionQueryType.FIND_BY_POSITION,
-          positionValue: value,
-        },
-        objectMetadata,
-        dataSourceSchema,
-        workspaceId,
-      );
-
-      if (recordWithSamePosition) {
-        throw new Error('Position is not unique');
-      }
-
       return value;
     }
 


### PR DESCRIPTION
Currently position can be the same for records displayed in a board view. 
Removing unicity check until we find a new startegy.