### PR TITLE
Add endpoint to create postgres credentials

### DIFF
--- a/packages/twenty-server/src/database/typeorm/core/migrations/1717751631669-addPostgresCredentials.ts
+++ b/packages/twenty-server/src/database/typeorm/core/migrations/1717751631669-addPostgresCredentials.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddPostgresCredentials1717751631669 implements MigrationInterface {
+  name = 'AddPostgresCredentials1717751631669';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "core"."postgresCredentials" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "user" character varying NOT NULL, "passwordHash" character varying NOT NULL, "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP WITH TIME ZONE, "workspaceId" uuid NOT NULL, CONSTRAINT "PK_3f9c4cdf895bfea0a6ea15bdd81" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."postgresCredentials" ADD CONSTRAINT "FK_9494639abc06f9c8c3691bf5d22" FOREIGN KEY ("workspaceId") REFERENCES "core"."workspace"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "core"."postgresCredentials" DROP CONSTRAINT "FK_9494639abc06f9c8c3691bf5d22"`,
+    );
+    await queryRunner.query(`DROP TABLE "core"."postgresCredentials"`);
+  }
+}

--- a/packages/twenty-server/src/database/typeorm/typeorm.service.ts
+++ b/packages/twenty-server/src/database/typeorm/typeorm.service.ts
@@ -12,6 +12,7 @@ import { BillingSubscription } from 'src/engine/core-modules/billing/entities/bi
 import { BillingSubscriptionItem } from 'src/engine/core-modules/billing/entities/billing-subscription-item.entity';
 import { UserWorkspace } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
 import { KeyValuePair } from 'src/engine/core-modules/key-value-pair/key-value-pair.entity';
+import { PostgresCredentials } from 'src/engine/core-modules/postgres-credentials/postgres-credentials.entity';
 
 @Injectable()
 export class TypeORMService implements OnModuleInit, OnModuleDestroy {
@@ -34,6 +35,7 @@ export class TypeORMService implements OnModuleInit, OnModuleDestroy {
         FeatureFlagEntity,
         BillingSubscription,
         BillingSubscriptionItem,
+        PostgresCredentials,
       ],
       ssl: environmentService.get('PG_SSL_ALLOW_SELF_SIGNED')
         ? {

--- a/packages/twenty-server/src/engine/core-modules/core-engine.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/core-engine.module.ts
@@ -11,6 +11,7 @@ import { TimelineCalendarEventModule } from 'src/engine/core-modules/calendar/ti
 import { BillingModule } from 'src/engine/core-modules/billing/billing.module';
 import { HealthModule } from 'src/engine/core-modules/health/health.module';
 import { TwentyORMModule } from 'src/engine/twenty-orm/twenty-orm.module';
+import { PostgresCredentialsModule } from 'src/engine/core-modules/postgres-credentials/postgres-credentials.module';
 
 import { AnalyticsModule } from './analytics/analytics.module';
 import { FileModule } from './file/file.module';
@@ -34,6 +35,7 @@ import { ClientConfigModule } from './client-config/client-config.module';
     TimelineCalendarEventModule,
     UserModule,
     WorkspaceModule,
+    PostgresCredentialsModule,
   ],
   exports: [
     AnalyticsModule,

--- a/packages/twenty-server/src/engine/core-modules/postgres-credentials/dtos/postgres-credentials.dto.ts
+++ b/packages/twenty-server/src/engine/core-modules/postgres-credentials/dtos/postgres-credentials.dto.ts
@@ -1,0 +1,20 @@
+import { ObjectType, Field } from '@nestjs/graphql';
+
+import { IDField } from '@ptc-org/nestjs-query-graphql';
+
+import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
+
+@ObjectType('PostgresCredentials')
+export class PostgresCredentialsDTO {
+  @IDField(() => UUIDScalarType)
+  id: string;
+
+  @Field()
+  user: string;
+
+  @Field()
+  password: string;
+
+  @Field()
+  workspaceId: string;
+}

--- a/packages/twenty-server/src/engine/core-modules/postgres-credentials/postgres-credentials.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/postgres-credentials/postgres-credentials.entity.ts
@@ -1,0 +1,40 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  Relation,
+} from 'typeorm';
+
+import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
+
+@Entity({ name: 'postgresCredentials', schema: 'core' })
+export class PostgresCredentials {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ nullable: false })
+  user: string;
+
+  @Column({ nullable: false })
+  passwordHash: string;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ type: 'timestamptz' })
+  updatedAt: Date;
+
+  @Column({ nullable: true, type: 'timestamptz' })
+  deletedAt: Date;
+
+  @ManyToOne(() => Workspace, (workspace) => workspace.allPostgresCredentials, {
+    onDelete: 'CASCADE',
+  })
+  workspace: Relation<Workspace>;
+
+  @Column({ nullable: false, type: 'uuid' })
+  workspaceId: string;
+}

--- a/packages/twenty-server/src/engine/core-modules/postgres-credentials/postgres-credentials.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/postgres-credentials/postgres-credentials.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { PostgresCredentials } from 'src/engine/core-modules/postgres-credentials/postgres-credentials.entity';
+import { PostgresCredentialsResolver } from 'src/engine/core-modules/postgres-credentials/postgres-credentials.resolver';
+import { PostgresCredentialsService } from 'src/engine/core-modules/postgres-credentials/postgres-credentials.service';
+import { EnvironmentModule } from 'src/engine/integrations/environment/environment.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([PostgresCredentials], 'core'),
+    EnvironmentModule,
+  ],
+  providers: [
+    PostgresCredentialsResolver,
+    PostgresCredentialsService,
+    PostgresCredentials,
+  ],
+})
+export class PostgresCredentialsModule {}

--- a/packages/twenty-server/src/engine/core-modules/postgres-credentials/postgres-credentials.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/postgres-credentials/postgres-credentials.resolver.ts
@@ -1,0 +1,35 @@
+import { UseGuards } from '@nestjs/common';
+import { Resolver, Mutation, Query } from '@nestjs/graphql';
+
+import { PostgresCredentialsDTO } from 'src/engine/core-modules/postgres-credentials/dtos/postgres-credentials.dto';
+import { PostgresCredentialsService } from 'src/engine/core-modules/postgres-credentials/postgres-credentials.service';
+import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
+import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
+import { JwtAuthGuard } from 'src/engine/guards/jwt.auth.guard';
+
+@Resolver(() => PostgresCredentialsDTO)
+export class PostgresCredentialsResolver {
+  constructor(
+    private readonly postgresCredentialsService: PostgresCredentialsService,
+  ) {}
+
+  @UseGuards(JwtAuthGuard)
+  @Mutation(() => PostgresCredentialsDTO)
+  async enablePostgresProxy(@AuthWorkspace() { id: workspaceId }: Workspace) {
+    return this.postgresCredentialsService.enablePostgresProxy(workspaceId);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Mutation(() => PostgresCredentialsDTO)
+  async disablePostgresProxy(@AuthWorkspace() { id: workspaceId }: Workspace) {
+    return this.postgresCredentialsService.disablePostgresProxy(workspaceId);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Query(() => PostgresCredentialsDTO, { nullable: true })
+  async getPostgresCredentials(
+    @AuthWorkspace() { id: workspaceId }: Workspace,
+  ) {
+    return this.postgresCredentialsService.getPostgresCredentials(workspaceId);
+  }
+}

--- a/packages/twenty-server/src/engine/core-modules/postgres-credentials/postgres-credentials.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/postgres-credentials/postgres-credentials.service.ts
@@ -1,4 +1,5 @@
 import { InjectRepository } from '@nestjs/typeorm';
+import { BadRequestException } from '@nestjs/common';
 
 import { randomBytes } from 'crypto';
 
@@ -28,6 +29,19 @@ export class PostgresCredentialsService {
 
     const key = this.environmentService.get('LOGIN_TOKEN_SECRET');
     const passwordHash = encryptText(password, key);
+
+    const existingCredentials =
+      await this.postgresCredentialsRepository.findOne({
+        where: {
+          workspaceId,
+        },
+      });
+
+    if (existingCredentials) {
+      throw new BadRequestException(
+        'Postgres credentials already exist for this workspace',
+      );
+    }
 
     const postgresCredentials = await this.postgresCredentialsRepository.create(
       {

--- a/packages/twenty-server/src/engine/core-modules/postgres-credentials/postgres-credentials.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/postgres-credentials/postgres-credentials.service.ts
@@ -1,0 +1,103 @@
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { randomBytes } from 'crypto';
+
+import { Repository } from 'typeorm';
+
+import {
+  decryptText,
+  encryptText,
+} from 'src/engine/core-modules/auth/auth.util';
+import { EnvironmentService } from 'src/engine/integrations/environment/environment.service';
+import { PostgresCredentials } from 'src/engine/core-modules/postgres-credentials/postgres-credentials.entity';
+import { NotFoundError } from 'src/engine/utils/graphql-errors.util';
+import { PostgresCredentialsDTO } from 'src/engine/core-modules/postgres-credentials/dtos/postgres-credentials.dto';
+
+export class PostgresCredentialsService {
+  constructor(
+    @InjectRepository(PostgresCredentials, 'core')
+    private readonly postgresCredentialsRepository: Repository<PostgresCredentials>,
+    private readonly environmentService: EnvironmentService,
+  ) {}
+
+  async enablePostgresProxy(
+    workspaceId: string,
+  ): Promise<PostgresCredentialsDTO> {
+    const user = `user_${randomBytes(4).toString('hex')}`;
+    const password = randomBytes(16).toString('hex');
+
+    const key = this.environmentService.get('LOGIN_TOKEN_SECRET');
+    const passwordHash = encryptText(password, key);
+
+    const postgresCredentials = await this.postgresCredentialsRepository.create(
+      {
+        user,
+        passwordHash,
+        workspaceId,
+      },
+    );
+
+    await this.postgresCredentialsRepository.save(postgresCredentials);
+
+    return {
+      id: postgresCredentials.id,
+      user,
+      password,
+      workspaceId,
+    };
+  }
+
+  async disablePostgresProxy(
+    workspaceId: string,
+  ): Promise<PostgresCredentialsDTO> {
+    const postgresCredentials =
+      await this.postgresCredentialsRepository.findOne({
+        where: {
+          workspaceId,
+        },
+      });
+
+    if (!postgresCredentials?.id) {
+      throw new NotFoundError(
+        'No valid Postgres credentials not found for this workspace',
+      );
+    }
+
+    await this.postgresCredentialsRepository.delete({
+      id: postgresCredentials.id,
+    });
+
+    const key = this.environmentService.get('LOGIN_TOKEN_SECRET');
+
+    return {
+      id: postgresCredentials.id,
+      user: postgresCredentials.user,
+      password: decryptText(postgresCredentials.passwordHash, key),
+      workspaceId: postgresCredentials.workspaceId,
+    };
+  }
+
+  async getPostgresCredentials(
+    workspaceId: string,
+  ): Promise<PostgresCredentialsDTO | null> {
+    const postgresCredentials =
+      await this.postgresCredentialsRepository.findOne({
+        where: {
+          workspaceId,
+        },
+      });
+
+    if (!postgresCredentials) {
+      return null;
+    }
+
+    const key = this.environmentService.get('LOGIN_TOKEN_SECRET');
+
+    return {
+      id: postgresCredentials.id,
+      user: postgresCredentials.user,
+      password: decryptText(postgresCredentials.passwordHash, key),
+      workspaceId: postgresCredentials.workspaceId,
+    };
+  }
+}

--- a/packages/twenty-server/src/engine/core-modules/workspace/workspace.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/workspace.entity.ts
@@ -19,6 +19,7 @@ import { UserWorkspace } from 'src/engine/core-modules/user-workspace/user-works
 import { AppToken } from 'src/engine/core-modules/app-token/app-token.entity';
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 import { KeyValuePair } from 'src/engine/core-modules/key-value-pair/key-value-pair.entity';
+import { PostgresCredentials } from 'src/engine/core-modules/postgres-credentials/postgres-credentials.entity';
 
 @Entity({ name: 'workspace', schema: 'core' })
 @ObjectType('Workspace')
@@ -99,4 +100,10 @@ export class Workspace {
     (billingSubscription) => billingSubscription.workspace,
   )
   billingSubscriptions: Relation<BillingSubscription[]>;
+
+  @OneToMany(
+    () => PostgresCredentials,
+    (postgresCredentials) => postgresCredentials.workspace,
+  )
+  allPostgresCredentials: Relation<PostgresCredentials[]>;
 }


### PR DESCRIPTION
First step for creating credentials for database proxy.

In next PRs:
- When calling endpoint, create database Postgres on proxy server 
- Setup user on database using postgresCredentials
- Build remote server on DB to access workspace data