### PR TITLE
Add the support of Empty and Non-Empty filter

### DIFF
--- a/packages/twenty-front/src/modules/object-record/graphql/types/RecordGqlOperationFilter.ts
+++ b/packages/twenty-front/src/modules/object-record/graphql/types/RecordGqlOperationFilter.ts
@@ -9,6 +9,11 @@ export type UUIDFilter = {
   is?: IsFilter;
 };
 
+export type RelationFilter = {
+  is?: IsFilter;
+  in?: UUIDFilterValue[];
+};
+
 export type BooleanFilter = {
   eq?: boolean;
   is?: IsFilter;

--- a/packages/twenty-front/src/modules/object-record/object-filter-dropdown/components/MultipleFiltersDropdownContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-filter-dropdown/components/MultipleFiltersDropdownContent.tsx
@@ -37,6 +37,11 @@ export const MultipleFiltersDropdownContent = ({
   const selectedOperandInDropdown = useRecoilValue(
     selectedOperandInDropdownState,
   );
+  const isEmptyOperand =
+    selectedOperandInDropdown &&
+    [ViewFilterOperand.IsEmpty, ViewFilterOperand.IsNotEmpty].includes(
+      selectedOperandInDropdown,
+    );
 
   return (
     <>
@@ -44,10 +49,7 @@ export const MultipleFiltersDropdownContent = ({
         <ObjectFilterDropdownFilterSelect />
       ) : isObjectFilterDropdownOperandSelectUnfolded ? (
         <ObjectFilterDropdownOperandSelect />
-      ) : selectedOperandInDropdown &&
-        [ViewFilterOperand.IsEmpty, ViewFilterOperand.IsNotEmpty].includes(
-          selectedOperandInDropdown,
-        ) ? (
+      ) : isEmptyOperand ? (
         <ObjectFilterDropdownOperandButton />
       ) : (
         selectedOperandInDropdown && (

--- a/packages/twenty-front/src/modules/object-record/object-filter-dropdown/components/MultipleFiltersDropdownContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-filter-dropdown/components/MultipleFiltersDropdownContent.tsx
@@ -3,6 +3,7 @@ import { useRecoilValue } from 'recoil';
 import { ObjectFilterDropdownSearchInput } from '@/object-record/object-filter-dropdown/components/ObjectFilterDropdownSearchInput';
 import { useFilterDropdown } from '@/object-record/object-filter-dropdown/hooks/useFilterDropdown';
 import { DropdownMenuSeparator } from '@/ui/layout/dropdown/components/DropdownMenuSeparator';
+import { ViewFilterOperand } from '@/views/types/ViewFilterOperand';
 
 import { MultipleFiltersDropdownFilterOnFilterChangedEffect } from './MultipleFiltersDropdownFilterOnFilterChangedEffect';
 import { ObjectFilterDropdownDateInput } from './ObjectFilterDropdownDateInput';
@@ -43,6 +44,11 @@ export const MultipleFiltersDropdownContent = ({
         <ObjectFilterDropdownFilterSelect />
       ) : isObjectFilterDropdownOperandSelectUnfolded ? (
         <ObjectFilterDropdownOperandSelect />
+      ) : selectedOperandInDropdown &&
+        [ViewFilterOperand.IsEmpty, ViewFilterOperand.IsNotEmpty].includes(
+          selectedOperandInDropdown,
+        ) ? (
+        <ObjectFilterDropdownOperandButton />
       ) : (
         selectedOperandInDropdown && (
           <>

--- a/packages/twenty-front/src/modules/object-record/object-filter-dropdown/components/ObjectFilterDropdownOperandSelect.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-filter-dropdown/components/ObjectFilterDropdownOperandSelect.tsx
@@ -46,6 +46,7 @@ export const ObjectFilterDropdownOperandSelect = () => {
 
     if (isEmptyOperand) {
       selectFilter?.({
+        id: v4(),
         fieldMetadataId: filterDefinitionUsedInDropdown?.fieldMetadataId ?? '',
         displayValue: '',
         operand: newOperand,

--- a/packages/twenty-front/src/modules/object-record/object-filter-dropdown/components/ObjectFilterDropdownOperandSelect.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-filter-dropdown/components/ObjectFilterDropdownOperandSelect.tsx
@@ -35,7 +35,7 @@ export const ObjectFilterDropdownOperandSelect = () => {
     filterDefinitionUsedInDropdown?.type,
   );
 
-  const handleOperangeChange = (newOperand: ViewFilterOperand) => {
+  const handleOperandChange = (newOperand: ViewFilterOperand) => {
     const isEmptyOperand = [
       ViewFilterOperand.IsEmpty,
       ViewFilterOperand.IsNotEmpty,
@@ -80,7 +80,7 @@ export const ObjectFilterDropdownOperandSelect = () => {
         <MenuItem
           key={`select-filter-operand-${index}`}
           onClick={() => {
-            handleOperangeChange(filterOperand);
+            handleOperandChange(filterOperand);
           }}
           text={getOperandLabel(filterOperand)}
         />

--- a/packages/twenty-front/src/modules/object-record/object-filter-dropdown/components/ObjectFilterDropdownOperandSelect.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-filter-dropdown/components/ObjectFilterDropdownOperandSelect.tsx
@@ -2,6 +2,7 @@ import { useRecoilValue } from 'recoil';
 import { v4 } from 'uuid';
 
 import { useFilterDropdown } from '@/object-record/object-filter-dropdown/hooks/useFilterDropdown';
+import { FilterDefinition } from '@/object-record/object-filter-dropdown/types/FilterDefinition';
 import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/DropdownMenuItemsContainer';
 import { MenuItem } from '@/ui/navigation/menu-item/components/MenuItem';
 import { ViewFilterOperand } from '@/views/types/ViewFilterOperand';
@@ -35,8 +36,24 @@ export const ObjectFilterDropdownOperandSelect = () => {
   );
 
   const handleOperangeChange = (newOperand: ViewFilterOperand) => {
+    const isEmptyOperand = [
+      ViewFilterOperand.IsEmpty,
+      ViewFilterOperand.IsNotEmpty,
+    ].includes(newOperand);
+
     setSelectedOperandInDropdown(newOperand);
     setIsObjectFilterDropdownOperandSelectUnfolded(false);
+
+    if (isEmptyOperand) {
+      selectFilter?.({
+        fieldMetadataId: filterDefinitionUsedInDropdown?.fieldMetadataId ?? '',
+        displayValue: '',
+        operand: newOperand,
+        value: '',
+        definition: filterDefinitionUsedInDropdown as FilterDefinition,
+      });
+      return;
+    }
 
     if (
       isDefined(filterDefinitionUsedInDropdown) &&

--- a/packages/twenty-front/src/modules/object-record/object-filter-dropdown/utils/__tests__/getOperandsForFilterType.test.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-filter-dropdown/utils/__tests__/getOperandsForFilterType.test.tsx
@@ -4,23 +4,37 @@ import { ViewFilterOperand } from '@/views/types/ViewFilterOperand';
 import { getOperandsForFilterType } from '../getOperandsForFilterType';
 
 describe('getOperandsForFilterType', () => {
+  const emptyOperands = [
+    ViewFilterOperand.IsEmpty,
+    ViewFilterOperand.IsNotEmpty,
+  ];
+
+  const containsOperands = [
+    ViewFilterOperand.Contains,
+    ViewFilterOperand.DoesNotContain,
+  ];
+
+  const numberOperands = [
+    ViewFilterOperand.GreaterThan,
+    ViewFilterOperand.LessThan,
+  ];
+
+  const relationOperand = [ViewFilterOperand.Is, ViewFilterOperand.IsNot];
+
   const testCases = [
-    ['TEXT', [ViewFilterOperand.Contains, ViewFilterOperand.DoesNotContain]],
-    ['EMAIL', [ViewFilterOperand.Contains, ViewFilterOperand.DoesNotContain]],
-    [
-      'FULL_NAME',
-      [ViewFilterOperand.Contains, ViewFilterOperand.DoesNotContain],
-    ],
-    ['ADDRESS', [ViewFilterOperand.Contains, ViewFilterOperand.DoesNotContain]],
-    ['LINK', [ViewFilterOperand.Contains, ViewFilterOperand.DoesNotContain]],
-    ['LINKS', [ViewFilterOperand.Contains, ViewFilterOperand.DoesNotContain]],
-    ['CURRENCY', [ViewFilterOperand.GreaterThan, ViewFilterOperand.LessThan]],
-    ['NUMBER', [ViewFilterOperand.GreaterThan, ViewFilterOperand.LessThan]],
-    ['DATE_TIME', [ViewFilterOperand.GreaterThan, ViewFilterOperand.LessThan]],
-    ['RELATION', [ViewFilterOperand.Is, ViewFilterOperand.IsNot]],
-    [undefined, []],
-    [null, []],
-    ['UNKNOWN_TYPE', []],
+    ['TEXT', [...containsOperands, ...emptyOperands]],
+    ['EMAIL', [...containsOperands, ...emptyOperands]],
+    ['FULL_NAME', [...containsOperands, ...emptyOperands]],
+    ['ADDRESS', [...containsOperands, ...emptyOperands]],
+    ['LINK', [...containsOperands, ...emptyOperands]],
+    ['LINKS', [...containsOperands, ...emptyOperands]],
+    ['CURRENCY', [...numberOperands, ...emptyOperands]],
+    ['NUMBER', [...numberOperands, ...emptyOperands]],
+    ['DATE_TIME', [...numberOperands, ...emptyOperands]],
+    ['RELATION', [...relationOperand, ...emptyOperands]],
+    [undefined, [...emptyOperands]],
+    [null, [...emptyOperands]],
+    ['UNKNOWN_TYPE', [...emptyOperands]],
   ];
 
   testCases.forEach(([filterType, expectedOperands]) => {

--- a/packages/twenty-front/src/modules/object-record/object-filter-dropdown/utils/__tests__/getOperandsForFilterType.test.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-filter-dropdown/utils/__tests__/getOperandsForFilterType.test.tsx
@@ -32,9 +32,9 @@ describe('getOperandsForFilterType', () => {
     ['NUMBER', [...numberOperands, ...emptyOperands]],
     ['DATE_TIME', [...numberOperands, ...emptyOperands]],
     ['RELATION', [...relationOperand, ...emptyOperands]],
-    [undefined, [...emptyOperands]],
-    [null, [...emptyOperands]],
-    ['UNKNOWN_TYPE', [...emptyOperands]],
+    [undefined, []],
+    [null, []],
+    ['UNKNOWN_TYPE', []],
   ];
 
   testCases.forEach(([filterType, expectedOperands]) => {

--- a/packages/twenty-front/src/modules/object-record/object-filter-dropdown/utils/getOperandLabel.ts
+++ b/packages/twenty-front/src/modules/object-record/object-filter-dropdown/utils/getOperandLabel.ts
@@ -18,6 +18,10 @@ export const getOperandLabel = (
       return 'Is not';
     case ViewFilterOperand.IsNotNull:
       return 'Is not null';
+    case ViewFilterOperand.IsEmpty:
+      return 'Is empty';
+    case ViewFilterOperand.IsNotEmpty:
+      return 'Is not empty';
     default:
       return '';
   }
@@ -29,11 +33,13 @@ export const getOperandLabelShort = (
   switch (operand) {
     case ViewFilterOperand.Is:
     case ViewFilterOperand.Contains:
+    case ViewFilterOperand.IsEmpty:
       return ': ';
     case ViewFilterOperand.IsNot:
     case ViewFilterOperand.DoesNotContain:
       return ': Not';
     case ViewFilterOperand.IsNotNull:
+    case ViewFilterOperand.IsNotEmpty:
       return ': NotNull';
     case ViewFilterOperand.GreaterThan:
       return '\u00A0> ';

--- a/packages/twenty-front/src/modules/object-record/object-filter-dropdown/utils/getOperandLabel.ts
+++ b/packages/twenty-front/src/modules/object-record/object-filter-dropdown/utils/getOperandLabel.ts
@@ -33,14 +33,16 @@ export const getOperandLabelShort = (
   switch (operand) {
     case ViewFilterOperand.Is:
     case ViewFilterOperand.Contains:
-    case ViewFilterOperand.IsEmpty:
       return ': ';
     case ViewFilterOperand.IsNot:
     case ViewFilterOperand.DoesNotContain:
       return ': Not';
     case ViewFilterOperand.IsNotNull:
-    case ViewFilterOperand.IsNotEmpty:
       return ': NotNull';
+    case ViewFilterOperand.IsNotEmpty:
+      return ': NotEmpty';
+    case ViewFilterOperand.IsEmpty:
+      return ': Empty';
     case ViewFilterOperand.GreaterThan:
       return '\u00A0> ';
     case ViewFilterOperand.LessThan:

--- a/packages/twenty-front/src/modules/object-record/object-filter-dropdown/utils/getOperandsForFilterType.ts
+++ b/packages/twenty-front/src/modules/object-record/object-filter-dropdown/utils/getOperandsForFilterType.ts
@@ -10,6 +10,8 @@ export const getOperandsForFilterType = (
     ViewFilterOperand.IsNotEmpty,
   ];
 
+  const objectOperands = [ViewFilterOperand.Is, ViewFilterOperand.IsNot];
+
   switch (filterType) {
     case 'TEXT':
     case 'EMAIL':
@@ -35,8 +37,9 @@ export const getOperandsForFilterType = (
         ...defaultOperands,
       ];
     case 'RELATION':
+      return [...objectOperands, ...defaultOperands];
     case 'SELECT':
-      return [ViewFilterOperand.Is, ViewFilterOperand.IsNot];
+      return [...objectOperands];
     default:
       return defaultOperands;
   }

--- a/packages/twenty-front/src/modules/object-record/object-filter-dropdown/utils/getOperandsForFilterType.ts
+++ b/packages/twenty-front/src/modules/object-record/object-filter-dropdown/utils/getOperandsForFilterType.ts
@@ -5,6 +5,11 @@ import { FilterType } from '../types/FilterType';
 export const getOperandsForFilterType = (
   filterType: FilterType | null | undefined,
 ): ViewFilterOperand[] => {
+  const defaultOperands = [
+    ViewFilterOperand.IsEmpty,
+    ViewFilterOperand.IsNotEmpty,
+  ];
+
   switch (filterType) {
     case 'TEXT':
     case 'EMAIL':
@@ -12,18 +17,31 @@ export const getOperandsForFilterType = (
     case 'ADDRESS':
     case 'PHONE':
     case 'LINK':
-      return [ViewFilterOperand.Contains, ViewFilterOperand.DoesNotContain];
+      return [
+        ViewFilterOperand.Contains,
+        ViewFilterOperand.DoesNotContain,
+        ...defaultOperands,
+      ];
     case 'LINKS':
       return [ViewFilterOperand.Contains, ViewFilterOperand.DoesNotContain];
+
     case 'CURRENCY':
     case 'NUMBER':
     case 'DATE_TIME':
     case 'DATE':
-      return [ViewFilterOperand.GreaterThan, ViewFilterOperand.LessThan];
+      return [
+        ViewFilterOperand.GreaterThan,
+        ViewFilterOperand.LessThan,
+        ...defaultOperands,
+      ];
     case 'RELATION':
     case 'SELECT':
-      return [ViewFilterOperand.Is, ViewFilterOperand.IsNot];
+      return [
+        ViewFilterOperand.Is,
+        ViewFilterOperand.IsNot,
+        ...defaultOperands,
+      ];
     default:
-      return [];
+      return defaultOperands;
   }
 };

--- a/packages/twenty-front/src/modules/object-record/object-filter-dropdown/utils/getOperandsForFilterType.ts
+++ b/packages/twenty-front/src/modules/object-record/object-filter-dropdown/utils/getOperandsForFilterType.ts
@@ -36,11 +36,7 @@ export const getOperandsForFilterType = (
       ];
     case 'RELATION':
     case 'SELECT':
-      return [
-        ViewFilterOperand.Is,
-        ViewFilterOperand.IsNot,
-        ...defaultOperands,
-      ];
+      return [ViewFilterOperand.Is, ViewFilterOperand.IsNot];
     default:
       return defaultOperands;
   }

--- a/packages/twenty-front/src/modules/object-record/object-filter-dropdown/utils/getOperandsForFilterType.ts
+++ b/packages/twenty-front/src/modules/object-record/object-filter-dropdown/utils/getOperandsForFilterType.ts
@@ -19,13 +19,12 @@ export const getOperandsForFilterType = (
     case 'ADDRESS':
     case 'PHONE':
     case 'LINK':
+    case 'LINKS':
       return [
         ViewFilterOperand.Contains,
         ViewFilterOperand.DoesNotContain,
         ...emptyOperands,
       ];
-    case 'LINKS':
-      return [ViewFilterOperand.Contains, ViewFilterOperand.DoesNotContain];
     case 'CURRENCY':
     case 'NUMBER':
     case 'DATE_TIME':

--- a/packages/twenty-front/src/modules/object-record/object-filter-dropdown/utils/getOperandsForFilterType.ts
+++ b/packages/twenty-front/src/modules/object-record/object-filter-dropdown/utils/getOperandsForFilterType.ts
@@ -37,8 +37,8 @@ export const getOperandsForFilterType = (
     case 'RELATION':
       return [...relationOperands, ...emptyOperands];
     case 'SELECT':
-      return [...relationOperands];
+      return [...relationOperands, ...emptyOperands];
     default:
-      return emptyOperands;
+      return [];
   }
 };

--- a/packages/twenty-front/src/modules/object-record/object-filter-dropdown/utils/getOperandsForFilterType.ts
+++ b/packages/twenty-front/src/modules/object-record/object-filter-dropdown/utils/getOperandsForFilterType.ts
@@ -37,7 +37,7 @@ export const getOperandsForFilterType = (
     case 'RELATION':
       return [...relationOperands, ...emptyOperands];
     case 'SELECT':
-      return [...relationOperands, ...emptyOperands];
+      return [...relationOperands];
     default:
       return [];
   }

--- a/packages/twenty-front/src/modules/object-record/object-filter-dropdown/utils/getOperandsForFilterType.ts
+++ b/packages/twenty-front/src/modules/object-record/object-filter-dropdown/utils/getOperandsForFilterType.ts
@@ -26,7 +26,6 @@ export const getOperandsForFilterType = (
       ];
     case 'LINKS':
       return [ViewFilterOperand.Contains, ViewFilterOperand.DoesNotContain];
-
     case 'CURRENCY':
     case 'NUMBER':
     case 'DATE_TIME':

--- a/packages/twenty-front/src/modules/object-record/object-filter-dropdown/utils/getOperandsForFilterType.ts
+++ b/packages/twenty-front/src/modules/object-record/object-filter-dropdown/utils/getOperandsForFilterType.ts
@@ -5,12 +5,12 @@ import { FilterType } from '../types/FilterType';
 export const getOperandsForFilterType = (
   filterType: FilterType | null | undefined,
 ): ViewFilterOperand[] => {
-  const defaultOperands = [
+  const emptyOperands = [
     ViewFilterOperand.IsEmpty,
     ViewFilterOperand.IsNotEmpty,
   ];
 
-  const objectOperands = [ViewFilterOperand.Is, ViewFilterOperand.IsNot];
+  const relationOperands = [ViewFilterOperand.Is, ViewFilterOperand.IsNot];
 
   switch (filterType) {
     case 'TEXT':
@@ -22,7 +22,7 @@ export const getOperandsForFilterType = (
       return [
         ViewFilterOperand.Contains,
         ViewFilterOperand.DoesNotContain,
-        ...defaultOperands,
+        ...emptyOperands,
       ];
     case 'LINKS':
       return [ViewFilterOperand.Contains, ViewFilterOperand.DoesNotContain];
@@ -34,13 +34,13 @@ export const getOperandsForFilterType = (
       return [
         ViewFilterOperand.GreaterThan,
         ViewFilterOperand.LessThan,
-        ...defaultOperands,
+        ...emptyOperands,
       ];
     case 'RELATION':
-      return [...objectOperands, ...defaultOperands];
+      return [...relationOperands, ...emptyOperands];
     case 'SELECT':
-      return [...objectOperands];
+      return [...relationOperands];
     default:
-      return defaultOperands;
+      return emptyOperands;
   }
 };

--- a/packages/twenty-front/src/modules/object-record/record-filter/utils/turnObjectDropdownFilterIntoQueryFilter.ts
+++ b/packages/twenty-front/src/modules/object-record/record-filter/utils/turnObjectDropdownFilterIntoQueryFilter.ts
@@ -66,6 +66,18 @@ const applyEmptyFilters = (
         ],
       };
       break;
+    case 'LINKS':
+      // eslint-disable-next-line no-case-declarations
+      const linksFilters = generateILikeFiltersForCompositeFields(
+        '',
+        correspondingField.name,
+        ['primaryLinkLabel', 'primaryLinkUrl'],
+        true,
+      );
+      emptyRecordFilter = {
+        or: linksFilters,
+      };
+      break;
     case 'ADDRESS':
       emptyRecordFilter = {
         and: [
@@ -409,6 +421,15 @@ export const turnObjectDropdownFilterIntoQueryFilter = (
                 };
               }),
             });
+            break;
+          case ViewFilterOperand.IsEmpty:
+          case ViewFilterOperand.IsNotEmpty:
+            applyEmptyFilters(
+              rawUIFilter.operand,
+              correspondingField,
+              objectRecordFilters,
+              rawUIFilter.definition.type,
+            );
             break;
           default:
             throw new Error(

--- a/packages/twenty-front/src/modules/object-record/record-filter/utils/turnObjectDropdownFilterIntoQueryFilter.ts
+++ b/packages/twenty-front/src/modules/object-record/record-filter/utils/turnObjectDropdownFilterIntoQueryFilter.ts
@@ -6,6 +6,7 @@ import {
   DateFilter,
   FloatFilter,
   RecordGqlOperationFilter,
+  RelationFilter,
   StringFilter,
   URLFilter,
   UUIDFilter,
@@ -141,7 +142,7 @@ const applyEmptyFilters = (
       break;
     case 'RELATION':
       emptyRecordFilter = {
-        [correspondingField.name + 'Id']: { is: 'NULL' } as UUIDFilter,
+        [correspondingField.name + 'Id']: { is: 'NULL' } as RelationFilter,
       };
       break;
     default:
@@ -302,7 +303,7 @@ export const turnObjectDropdownFilterIntoQueryFilter = (
               objectRecordFilters.push({
                 [correspondingField.name + 'Id']: {
                   in: parsedRecordIds,
-                } as UUIDFilter,
+                } as RelationFilter,
               });
               break;
             case ViewFilterOperand.IsNot:
@@ -311,7 +312,7 @@ export const turnObjectDropdownFilterIntoQueryFilter = (
                   not: {
                     [correspondingField.name + 'Id']: {
                       in: parsedRecordIds,
-                    } as UUIDFilter,
+                    } as RelationFilter,
                   },
                 });
               }

--- a/packages/twenty-front/src/modules/object-record/record-filter/utils/turnObjectDropdownFilterIntoQueryFilter.ts
+++ b/packages/twenty-front/src/modules/object-record/record-filter/utils/turnObjectDropdownFilterIntoQueryFilter.ts
@@ -305,7 +305,7 @@ export const turnObjectDropdownFilterIntoQueryFilter = (
                 rawUIFilter.operand,
                 correspondingField,
                 objectRecordFilters,
-                'Relation',
+                rawUIFilter.definition.type,
               );
               break;
             default:

--- a/packages/twenty-front/src/modules/object-record/record-filter/utils/turnObjectDropdownFilterIntoQueryFilter.ts
+++ b/packages/twenty-front/src/modules/object-record/record-filter/utils/turnObjectDropdownFilterIntoQueryFilter.ts
@@ -88,7 +88,7 @@ const applyEmptyFilters = (
       );
 
       emptyRecordFilter = {
-        or: linksFilters,
+        and: linksFilters,
       };
       break;
     }
@@ -137,6 +137,48 @@ const applyEmptyFilters = (
               },
             ],
           },
+          {
+            or: [
+              {
+                [correspondingField.name]: {
+                  addressState: { ilike: '' },
+                } as AddressFilter,
+              },
+              {
+                [correspondingField.name]: {
+                  addressState: { is: 'NULL' },
+                } as AddressFilter,
+              },
+            ],
+          },
+          {
+            or: [
+              {
+                [correspondingField.name]: {
+                  addressCountry: { ilike: '' },
+                } as AddressFilter,
+              },
+              {
+                [correspondingField.name]: {
+                  addressCountry: { is: 'NULL' },
+                } as AddressFilter,
+              },
+            ],
+          },
+          {
+            or: [
+              {
+                [correspondingField.name]: {
+                  addressPostcode: { ilike: '' },
+                } as AddressFilter,
+              },
+              {
+                [correspondingField.name]: {
+                  addressPostcode: { is: 'NULL' },
+                } as AddressFilter,
+              },
+            ],
+          },
         ],
       };
       break;
@@ -148,6 +190,11 @@ const applyEmptyFilters = (
     case 'DATE_TIME':
       emptyRecordFilter = {
         [correspondingField.name]: { is: 'NULL' } as DateFilter,
+      };
+      break;
+    case 'SELECT':
+      emptyRecordFilter = {
+        [correspondingField.name]: { is: 'NULL' } as UUIDFilter,
       };
       break;
     case 'RELATION':
@@ -459,7 +506,6 @@ export const turnObjectDropdownFilterIntoQueryFilter = (
         }
         break;
       }
-
       case 'FULL_NAME': {
         const fullNameFilters = generateILikeFiltersForCompositeFields(
           rawUIFilter.value,
@@ -523,6 +569,27 @@ export const turnObjectDropdownFilterIntoQueryFilter = (
                     },
                   } as AddressFilter,
                 },
+                {
+                  [correspondingField.name]: {
+                    addressState: {
+                      ilike: `%${rawUIFilter.value}%`,
+                    },
+                  } as AddressFilter,
+                },
+                {
+                  [correspondingField.name]: {
+                    addressCountry: {
+                      ilike: `%${rawUIFilter.value}%`,
+                    },
+                  } as AddressFilter,
+                },
+                {
+                  [correspondingField.name]: {
+                    addressPostcode: {
+                      ilike: `%${rawUIFilter.value}%`,
+                    },
+                  } as AddressFilter,
+                },
               ],
             });
             break;
@@ -575,6 +642,15 @@ export const turnObjectDropdownFilterIntoQueryFilter = (
         }
         break;
       case 'SELECT': {
+        if (isEmptyOperand) {
+          applyEmptyFilters(
+            rawUIFilter.operand,
+            correspondingField,
+            objectRecordFilters,
+            rawUIFilter.definition.type,
+          );
+          break;
+        }
         const stringifiedSelectValues = rawUIFilter.value;
         let parsedOptionValues: string[] = [];
 

--- a/packages/twenty-front/src/modules/object-record/record-filter/utils/turnObjectDropdownFilterIntoQueryFilter.ts
+++ b/packages/twenty-front/src/modules/object-record/record-filter/utils/turnObjectDropdownFilterIntoQueryFilter.ts
@@ -147,10 +147,7 @@ const applyEmptyFilters = (
       break;
     case 'DATE_TIME':
       emptyRecordFilter = {
-        or: [
-          { [correspondingField.name]: { eq: '' } as DateFilter },
-          { [correspondingField.name]: { is: 'NULL' } as DateFilter },
-        ],
+        [correspondingField.name]: { is: 'NULL' } as DateFilter,
       };
       break;
     case 'RELATION':

--- a/packages/twenty-front/src/modules/object-record/record-index/options/hooks/__tests__/useExportTableData.test.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/options/hooks/__tests__/useExportTableData.test.ts
@@ -49,7 +49,7 @@ describe('generateCsv', () => {
       },
     ];
     const csv = generateCsv({ columns, rows });
-    expect(csv).toEqual(`id,Foo,Empty,Nested Foo,Nested Nested,Relation
+    expect(csv).toEqual(`Id,Foo,Empty,Nested Foo,Nested Nested,Relation
 1,some field,,foo,nested,a relation`);
   });
 });

--- a/packages/twenty-front/src/modules/views/types/ViewFilterOperand.ts
+++ b/packages/twenty-front/src/modules/views/types/ViewFilterOperand.ts
@@ -6,4 +6,6 @@ export enum ViewFilterOperand {
   GreaterThan = 'greaterThan',
   Contains = 'contains',
   DoesNotContain = 'doesNotContain',
+  IsEmpty = 'isEmpty',
+  IsNotEmpty = 'isNotEmpty',
 }

--- a/packages/twenty-front/src/utils/array/generateILikeFiltersForCompositeFields.ts
+++ b/packages/twenty-front/src/utils/array/generateILikeFiltersForCompositeFields.ts
@@ -4,7 +4,31 @@ export const generateILikeFiltersForCompositeFields = (
   filterString: string,
   baseFieldName: string,
   subFields: string[],
+  emptyCheck = false,
 ) => {
+  if (emptyCheck) {
+    return subFields.map((subField) => {
+      return {
+        or: [
+          {
+            [baseFieldName]: {
+              [subField]: {
+                is: 'NULL',
+              },
+            },
+          },
+          {
+            [baseFieldName]: {
+              [subField]: {
+                ilike: '',
+              },
+            },
+          },
+        ],
+      };
+    });
+  }
+
   return filterString
     .split(' ')
     .reduce((previousValue: RecordGqlOperationFilter[], currentValue) => {

--- a/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/factories/query-runner-args.factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/factories/query-runner-args.factory.ts
@@ -199,14 +199,20 @@ export class QueryRunnerArgsFactory {
     if (!fieldMetadata) {
       return value;
     }
+
     switch (fieldMetadata.type) {
-      case 'NUMBER':
-        return Object.fromEntries(
-          Object.entries(value).map(([filterKey, filterValue]) => [
-            filterKey,
-            Number(filterValue),
-          ]),
-        );
+      case 'NUMBER': {
+        if (value?.is === 'NULL') {
+          return value;
+        } else {
+          return Object.fromEntries(
+            Object.entries(value).map(([filterKey, filterValue]) => [
+              filterKey,
+              Number(filterValue),
+            ]),
+          );
+        }
+      }
       default:
         return value;
     }


### PR DESCRIPTION
# This PR

- Fix #5216 
- Add the empty filter for fields of type: TEXT, EMAIL, FULL_NAME (composite), DATE_TIME, NUMBER, CURRENCY and LINK

Here is the current behavior:
https://www.loom.com/share/1ae2f5ed73c24c3eae6356532f29bfaa?sid=d58da6e4-d18c-446b-833e-00c6429001c2

@FelixMalfait  please have a look, excited to getting your feedback :) 
Not sure this should be a good first issue though 😃 