### PR TITLE
Fixed: Low search accuracy for people

### DIFF
--- a/packages/twenty-front/src/modules/object-record/relation-picker/components/SingleEntitySelectMenuItemsWithSearch.tsx
+++ b/packages/twenty-front/src/modules/object-record/relation-picker/components/SingleEntitySelectMenuItemsWithSearch.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useRecoilValue } from 'recoil';
 
 import { ObjectMetadataItemsRelationPickerEffect } from '@/object-metadata/components/ObjectMetadataItemsRelationPickerEffect';
@@ -70,6 +71,21 @@ export const SingleEntitySelectMenuItemsWithSearch = ({
     objectNameSingular: relationObjectNameSingular,
   });
 
+  const entitiesToSelect = useMemo(() => {
+    const index = entities.entitiesToSelect.findIndex(
+      (person) =>
+        person.name.toLocaleLowerCase() ===
+        relationPickerSearchFilter.toLocaleLowerCase(),
+    );
+
+    return index < 0
+      ? entities.entitiesToSelect
+      : [
+          ...entities.entitiesToSelect.splice(index, 1),
+          ...entities.entitiesToSelect,
+        ];
+  }, [relationPickerSearchFilter, entities.entitiesToSelect]);
+
   let onCreateWithInput = undefined;
 
   if (isDefined(onCreate)) {
@@ -92,7 +108,7 @@ export const SingleEntitySelectMenuItemsWithSearch = ({
       <DropdownMenuSearchInput onChange={handleSearchFilterChange} autoFocus />
       <DropdownMenuSeparator />
       <SingleEntitySelectMenuItems
-        entitiesToSelect={entities.entitiesToSelect}
+        entitiesToSelect={entitiesToSelect}
         loading={entities.loading}
         selectedEntity={
           selectedEntity ??


### PR DESCRIPTION
Now the search is accurate and displays the best match on top.

- Added a logic to put the searched `person` based on the name to the top within `SingleEntitySelectMenuItemsWithSearch`
- Used a `useMemo` with necessary dependencies.

fixes: #5722 

![Screenshot (346)](https://github.com/twentyhq/twenty/assets/140178357/f562ca91-cb22-4d25-bb61-96e9e1de2cdb)
![Screenshot (347)](https://github.com/twentyhq/twenty/assets/140178357/deee75c7-bef7-4c21-9764-747184d7a2ec)


