### PR TITLE
Add authentication optional api url parameter

### DIFF
--- a/packages/twenty-zapier/package.json
+++ b/packages/twenty-zapier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty-zapier",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Effortlessly sync Twenty with 3000+ apps. Automate tasks, boost productivity, and supercharge your customer relationships!",
   "main": "src/index.ts",
   "scripts": {
@@ -10,6 +10,7 @@
     "build": "yarn clean && tsc",
     "deploy": "yarn build && zapier push",
     "validate": "yarn build && zapier validate",
+    "versions": "yarn build && zapier versions",
     "clean": "rimraf ./lib ./build",
     "watch": "yarn clean && tsc --watch",
     "_zapier-build": "yarn build"

--- a/packages/twenty-zapier/src/authentication.ts
+++ b/packages/twenty-zapier/src/authentication.ts
@@ -23,6 +23,15 @@ export default {
       helpText:
         'Create an API key in [your twenty workspace](https://app.twenty.com/settings/developers)',
     },
+    {
+      computed: false,
+      key: 'apiUrl',
+      required: false,
+      label: 'Api Url',
+      type: 'string',
+      helpText:
+        'Leave blank if you use app.twenty.com. If you self-host Twenty, please set your Twenty server url (same as variable REACT_APP_SERVER_BASE_URL in https://docs.twenty.com/start/self-hosting/).',
+    },
   ],
   connectionLabel: '{{data.currentWorkspace.displayName}}',
   customConfig: {},

--- a/packages/twenty-zapier/src/authentication.ts
+++ b/packages/twenty-zapier/src/authentication.ts
@@ -29,8 +29,9 @@ export default {
       required: false,
       label: 'Api Url',
       type: 'string',
+      placeholder: 'https://api.twenty.com',
       helpText:
-        'Leave blank if you use app.twenty.com. If you self-host Twenty, please set your Twenty server url (same as variable REACT_APP_SERVER_BASE_URL in https://docs.twenty.com/start/self-hosting/).',
+        'Set this only if you self-host Twenty. Use the same value as `REACT_APP_SERVER_BASE_URL` in https://docs.twenty.com/start/self-hosting/',
     },
   ],
   connectionLabel: '{{data.currentWorkspace.displayName}}',

--- a/packages/twenty-zapier/src/test/authentication.test.ts
+++ b/packages/twenty-zapier/src/test/authentication.test.ts
@@ -37,6 +37,35 @@ describe('custom auth', () => {
     expect(response.data.currentWorkspace).toHaveProperty('displayName');
   });
 
+  it('passes authentication with api url and returns json', async () => {
+    const bundle = getBundle();
+    const bundleWithApiUrl = {
+      ...bundle,
+      authData: { ...bundle.authData, apiUrl: 'http://localhost:3000' },
+    };
+    const response = await appTester(App.authentication.test, bundleWithApiUrl);
+    expect(response.data).toHaveProperty('currentWorkspace');
+    expect(response.data.currentWorkspace).toHaveProperty('displayName');
+  });
+
+  it('fail authentication with bad api url', async () => {
+    const bundle = getBundle();
+    const bundleWithApiUrl = {
+      ...bundle,
+      authData: { ...bundle.authData, apiUrl: 'http://invalid' },
+    };
+    try {
+      const response = await appTester(
+        App.authentication.test,
+        bundleWithApiUrl,
+      );
+      expect(response.data).toHaveProperty('currentWorkspace');
+      expect(response.data.currentWorkspace).toHaveProperty('displayName');
+    } catch (error: any) {
+      expect(error.message).toContain('ENOTFOUND');
+    }
+  });
+
   it('fails on bad auth token format', async () => {
     const bundle = getBundle();
     bundle.authData.apiKey = 'bad';
@@ -44,7 +73,7 @@ describe('custom auth', () => {
     try {
       await appTester(App.authentication.test, bundle);
     } catch (error: any) {
-      expect(error.message).toContain('Unauthenticated');
+      expect(error.message).toContain('UNAUTHENTICATED');
       return;
     }
     throw new Error('appTester should have thrown');
@@ -71,7 +100,7 @@ describe('custom auth', () => {
     try {
       await appTester(App.authentication.test, bundleWithExpiredApiKey);
     } catch (error: any) {
-      expect(error.message).toContain('Unauthenticated');
+      expect(error.message).toContain('UNAUTHENTICATED');
       return;
     }
     throw new Error('appTester should have thrown');

--- a/packages/twenty-zapier/src/utils/requestDb.ts
+++ b/packages/twenty-zapier/src/utils/requestDb.ts
@@ -40,7 +40,7 @@ const requestDb = async (
   endpoint = 'graphql',
 ) => {
   const options = {
-    url: `${process.env.SERVER_BASE_URL}/${endpoint}`,
+    url: `${bundle.authData.apiUrl || process.env.SERVER_BASE_URL}/${endpoint}`,
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -81,7 +81,9 @@ export const requestDbViaRestApi = (
   objectNamePlural: string,
 ) => {
   const options = {
-    url: `${process.env.SERVER_BASE_URL}/rest/${objectNamePlural}?limit:3`,
+    url: `${
+      bundle.authData.apiUrl || process.env.SERVER_BASE_URL
+    }/rest/${objectNamePlural}?limit:3`,
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',


### PR DESCRIPTION
Added an authentication optional api url parameter to create Zaps on self host instances

New Zapier authentication form:
![image](https://github.com/twentyhq/twenty/assets/29927851/7a6e36c5-6162-4869-ad2a-3e38834f68e3)
