### PR TITLE
Increased inline relation field hover surface

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellContainer.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellContainer.tsx
@@ -34,7 +34,7 @@ const StyledLabelAndIconContainer = styled.div`
 
 const StyledValueContainer = styled.div`
   display: flex;
-  min-width: 0;
+  min-width: 100%;
 `;
 
 const StyledLabelContainer = styled.div<{ width?: number }>`


### PR DESCRIPTION
I increased the inline relation of the relations fields, now the edit pen is visible when hovering the icon and not only the label.
this aims to fix: #5662