### PR TITLE
mod: entrypoint for docker to setup db even in server with less memory

### DIFF
--- a/packages/twenty-docker/twenty/entrypoint.sh
+++ b/packages/twenty-docker/twenty/entrypoint.sh
@@ -5,7 +5,7 @@ if [ "${ENABLE_DB_MIGRATIONS}" = "true" ] && [ ! -f /app/${STORAGE_LOCAL_PATH:-.
     echo "Running database setup and migrations..."
 
     # Run setup and migration scripts
-    NODE_OPTIONS="--max-old-space-size=8192" npx ts-node ./scripts/setup-db.ts
+    NODE_OPTIONS="--max-old-space-size=1500" npx ts-node ./scripts/setup-db.ts
     yarn database:migrate:prod
 
     # Mark initialization as done

--- a/packages/twenty-docker/twenty/entrypoint.sh
+++ b/packages/twenty-docker/twenty/entrypoint.sh
@@ -5,7 +5,7 @@ if [ "${ENABLE_DB_MIGRATIONS}" = "true" ] && [ ! -f /app/${STORAGE_LOCAL_PATH:-.
     echo "Running database setup and migrations..."
 
     # Run setup and migration scripts
-    npx ts-node ./scripts/setup-db.ts
+    NODE_OPTIONS="--max-old-space-size=8192" npx ts-node ./scripts/setup-db.ts
     yarn database:migrate:prod
 
     # Mark initialization as done

--- a/packages/twenty-website/src/content/developers/self-hosting/docker-compose.mdx
+++ b/packages/twenty-website/src/content/developers/self-hosting/docker-compose.mdx
@@ -31,6 +31,10 @@ FILE_TOKEN_SECRET=replace_me_with_a_random_string_refresh
 5. Run the command `docker-compose up -d`
 6. Go to http://localhost:3000 and see your docker instance.
 
+## System requirements 
+
+Please use an environment with at least 2GB or RAM or one of the processes could crash due to memory issues.
+
 ## Troubleshooting
 
 #### Not able to login


### PR DESCRIPTION
Hello team,

- Modified File: `packages/twenty-docker/twenty/entrypoint.sh`
- Reason: The current `entrypoint.sh` works fine for server with RAM more than 8GB. But the server with less RAM will give error while running `scripts/setup-db.ts`.
![setup-db-failed](https://github.com/twentyhq/twenty/assets/52379037/5e27240a-23ef-4d52-93bb-337e1a004feb)

- My commit: It will set `NODE_OPTIONS="--max-old-space-size=8192"` in docker entrypoint which guarantee to run the script successfully.