### PR TITLE
Align field values with fixed width for field key. 

### DIFF
--- a/packages/twenty-front/src/modules/activities/components/ActivityEditorFields.tsx
+++ b/packages/twenty-front/src/modules/activities/components/ActivityEditorFields.tsx
@@ -119,6 +119,7 @@ export const ActivityEditorFields = ({
             <ActivityTargetsInlineCell
               activity={activityFromCache}
               maxWidth={340}
+              labelWidth={90}
             />
           </ActivityTargetsContextProvider>
         )}

--- a/packages/twenty-front/src/modules/activities/components/ActivityEditorFields.tsx
+++ b/packages/twenty-front/src/modules/activities/components/ActivityEditorFields.tsx
@@ -119,7 +119,6 @@ export const ActivityEditorFields = ({
             <ActivityTargetsInlineCell
               activity={activityFromCache}
               maxWidth={340}
-              labelWidth={90}
             />
           </ActivityTargetsContextProvider>
         )}

--- a/packages/twenty-front/src/modules/activities/inline-cell/components/ActivityTargetsInlineCell.tsx
+++ b/packages/twenty-front/src/modules/activities/inline-cell/components/ActivityTargetsInlineCell.tsx
@@ -17,6 +17,7 @@ type ActivityTargetsInlineCellProps = {
   showLabel?: boolean;
   maxWidth?: number;
   readonly?: boolean;
+  labelWidth?: number;
 };
 
 export const ActivityTargetsInlineCell = ({
@@ -24,6 +25,7 @@ export const ActivityTargetsInlineCell = ({
   showLabel = true,
   maxWidth,
   readonly,
+  labelWidth,
 }: ActivityTargetsInlineCellProps) => {
   const { activityTargetObjectRecords } =
     useActivityTargetObjectRecords(activity);
@@ -48,6 +50,7 @@ export const ActivityTargetsInlineCell = ({
           IconLabel={showLabel ? IconArrowUpRight : undefined}
           showLabel={showLabel}
           readonly={readonly}
+          labelWidth={labelWidth}
           editModeContent={
             <ActivityTargetInlineCellEditMode
               activity={activity}

--- a/packages/twenty-front/src/modules/activities/inline-cell/components/ActivityTargetsInlineCell.tsx
+++ b/packages/twenty-front/src/modules/activities/inline-cell/components/ActivityTargetsInlineCell.tsx
@@ -1,3 +1,4 @@
+import { useContext } from 'react';
 import { Key } from 'ts-key-enum';
 import { IconArrowUpRight, IconPencil } from 'twenty-ui';
 
@@ -6,6 +7,7 @@ import { useActivityTargetObjectRecords } from '@/activities/hooks/useActivityTa
 import { ActivityTargetInlineCellEditMode } from '@/activities/inline-cell/components/ActivityTargetInlineCellEditMode';
 import { Activity } from '@/activities/types/Activity';
 import { ActivityEditorHotkeyScope } from '@/activities/types/ActivityEditorHotkeyScope';
+import { FieldContext } from '@/object-record/record-field/contexts/FieldContext';
 import { FieldFocusContextProvider } from '@/object-record/record-field/contexts/FieldFocusContextProvider';
 import { RecordFieldInputScope } from '@/object-record/record-field/scopes/RecordFieldInputScope';
 import { RecordInlineCellContainer } from '@/object-record/record-inline-cell/components/RecordInlineCellContainer';
@@ -17,7 +19,6 @@ type ActivityTargetsInlineCellProps = {
   showLabel?: boolean;
   maxWidth?: number;
   readonly?: boolean;
-  labelWidth?: number;
 };
 
 export const ActivityTargetsInlineCell = ({
@@ -25,11 +26,12 @@ export const ActivityTargetsInlineCell = ({
   showLabel = true,
   maxWidth,
   readonly,
-  labelWidth,
 }: ActivityTargetsInlineCellProps) => {
   const { activityTargetObjectRecords } =
     useActivityTargetObjectRecords(activity);
   const { closeInlineCell } = useInlineCell();
+
+  const { fieldDefinition } = useContext(FieldContext);
 
   useScopedHotkeys(
     Key.Escape,
@@ -50,7 +52,7 @@ export const ActivityTargetsInlineCell = ({
           IconLabel={showLabel ? IconArrowUpRight : undefined}
           showLabel={showLabel}
           readonly={readonly}
-          labelWidth={labelWidth}
+          labelWidth={fieldDefinition?.labelWidth}
           editModeContent={
             <ActivityTargetInlineCellEditMode
               activity={activity}

--- a/packages/twenty-front/src/modules/object-record/hooks/useFieldContext.tsx
+++ b/packages/twenty-front/src/modules/object-record/hooks/useFieldContext.tsx
@@ -72,6 +72,7 @@ export const useFieldContext = ({
                 showLabel: true,
                 position: fieldPosition,
                 objectMetadataItem,
+                labelWidth: 90,
               }),
               useUpdateRecord:
                 customUseUpdateOneObjectHook ?? useUpdateOneObjectMutation,


### PR DESCRIPTION
Made the alignment consistent with the field panel. This uses 90px as the key label width.

**Issue:** #5730 

**Changes:**
- Add a label width of 90 to FieldContext Provider in useFieldContext function
- Add a label width of 90 to ActivityTargetsInlineCell component

**Screen recording form local testing:**


https://github.com/twentyhq/twenty/assets/120792086/e150530b-4163-4a69-9bd5-119a2f202d4f


