### PR TITLE
Fix access token refresh

### DIFF
--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/messaging-gmail-messages-import.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/messaging-gmail-messages-import.service.ts
@@ -101,9 +101,8 @@ export class MessagingGmailMessagesImportService {
       const allMessages =
         await this.fetchMessagesByBatchesService.fetchAllMessages(
           messageQueries,
-          connectedAccount.accessToken,
-          workspaceId,
           connectedAccount.id,
+          workspaceId,
         );
 
       const blocklist = await this.blocklistRepository.getByWorkspaceMemberId(


### PR DESCRIPTION
In `messaging-gmail-messages-import.service`, we were refreshing the access token before each query but we were passing the old access token to `fetchAllMessages`.
I modified the function to query the updated connectedAccount with the new access token.
This will solve the 401 errors we were getting in production.