### PR TITLE
feat: add resolve absolute path util

### DIFF
--- a/packages/twenty-docker/docker-compose.yml
+++ b/packages/twenty-docker/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       FRONT_BASE_URL: ${FRONT_BASE_URL:-$SERVER_URL}
       MESSAGE_QUEUE_TYPE: ${MESSAGE_QUEUE_TYPE}
 
-      ENABLE_DB_MIGRATIONS: "true"
+      ENABLE_DB_MIGRATIONS: "false" # it already runs on the server
 
       STORAGE_TYPE: ${STORAGE_TYPE}
       STORAGE_S3_REGION: ${STORAGE_S3_REGION}
@@ -60,6 +60,8 @@ services:
       FILE_TOKEN_SECRET: ${FILE_TOKEN_SECRET}
     depends_on:
       db:
+        condition: service_healthy
+      server:
         condition: service_healthy
     restart: always
 

--- a/packages/twenty-docker/docker-compose.yml
+++ b/packages/twenty-docker/docker-compose.yml
@@ -2,6 +2,17 @@ version: "3.9"
 name: twenty
 
 services:
+  change-vol-ownership:
+    image: ubuntu
+    user: root
+    volumes:
+      - server-local-data:/tmp/server-local-data
+      - docker-data:/tmp/docker-data
+    command: >
+      bash -c "
+      chown -R 1000:1000 /tmp/server-local-data
+      && chown -R 1000:1000 /tmp/docker-data"
+
   server:
     image: twentycrm/twenty:${TAG}
     volumes:
@@ -28,6 +39,8 @@ services:
       REFRESH_TOKEN_SECRET: ${REFRESH_TOKEN_SECRET}
       FILE_TOKEN_SECRET: ${FILE_TOKEN_SECRET}
     depends_on:
+      change-vol-ownership:
+        condition: service_completed_successfully
       db:
         condition: service_healthy
     healthcheck:
@@ -39,8 +52,6 @@ services:
 
   worker:
     image: twentycrm/twenty:${TAG}
-    volumes:
-      - worker-local-data:/app/packages/twenty-server/${STORAGE_LOCAL_PATH:-.local-storage}
     command: ["yarn", "worker:prod"]
     environment:
       PG_DATABASE_URL: postgres://twenty:twenty@${PG_DATABASE_HOST}/default
@@ -82,4 +93,3 @@ volumes:
   docker-data:
   db-data:
   server-local-data:
-  worker-local-data:

--- a/packages/twenty-docker/docker-compose.yml
+++ b/packages/twenty-docker/docker-compose.yml
@@ -5,7 +5,8 @@ services:
   server:
     image: twentycrm/twenty:${TAG}
     volumes:
-      - server-local-data:/app/${STORAGE_LOCAL_PATH:-.local-storage}
+      - server-local-data:/app/packages/twenty-server/${STORAGE_LOCAL_PATH:-.local-storage}
+      - docker-data:/app/docker-data
     ports:
       - "3000:3000"
     environment:
@@ -39,7 +40,7 @@ services:
   worker:
     image: twentycrm/twenty:${TAG}
     volumes:
-      - worker-local-data:/app/${STORAGE_LOCAL_PATH:-.local-storage}
+      - worker-local-data:/app/packages/twenty-server/${STORAGE_LOCAL_PATH:-.local-storage}
     command: ["yarn", "worker:prod"]
     environment:
       PG_DATABASE_URL: postgres://twenty:twenty@${PG_DATABASE_HOST}/default
@@ -76,6 +77,7 @@ services:
     restart: always
 
 volumes:
+  docker-data:
   db-data:
   server-local-data:
   worker-local-data:

--- a/packages/twenty-docker/twenty/entrypoint.sh
+++ b/packages/twenty-docker/twenty/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Check if the initialization has already been done and that we enabled automatic migration
-if [ "${ENABLE_DB_MIGRATIONS}" = "true" ] && [ ! -f /app/db_status ]; then
+if [ "${ENABLE_DB_MIGRATIONS}" = "true" ] && [ ! -f /app/docker-data/db_status ]; then
     echo "Running database setup and migrations..."
 
     # Run setup and migration scripts
@@ -10,7 +10,7 @@ if [ "${ENABLE_DB_MIGRATIONS}" = "true" ] && [ ! -f /app/db_status ]; then
 
     # Mark initialization as done
     echo "Successfuly migrated DB!"
-    touch /app/db_status
+    touch /app/docker-data/db_status
 fi
 
 # Continue with the original Docker command

--- a/packages/twenty-docker/twenty/entrypoint.sh
+++ b/packages/twenty-docker/twenty/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Check if the initialization has already been done and that we enabled automatic migration
-if [ "${ENABLE_DB_MIGRATIONS}" = "true" ] && [ ! -f /app/${STORAGE_LOCAL_PATH:-.local-storage}/db_initialized ]; then
+if [ "${ENABLE_DB_MIGRATIONS}" = "true" ] && [ ! -f /app/db_status ]; then
     echo "Running database setup and migrations..."
 
     # Run setup and migration scripts
@@ -10,7 +10,7 @@ if [ "${ENABLE_DB_MIGRATIONS}" = "true" ] && [ ! -f /app/${STORAGE_LOCAL_PATH:-.
 
     # Mark initialization as done
     echo "Successfuly migrated DB!"
-    touch /app/${STORAGE_LOCAL_PATH:-.local-storage}/db_initialized
+    touch /app/db_status
 fi
 
 # Continue with the original Docker command

--- a/packages/twenty-server/src/engine/integrations/file-storage/file-storage.module-factory.ts
+++ b/packages/twenty-server/src/engine/integrations/file-storage/file-storage.module-factory.ts
@@ -5,6 +5,7 @@ import {
   FileStorageModuleOptions,
   StorageDriverType,
 } from 'src/engine/integrations/file-storage/interfaces';
+import { resolveAbsolutePath } from 'src/utils/resolve-absolute-path';
 
 /**
  * FileStorage Module factory
@@ -23,7 +24,7 @@ export const fileStorageModuleFactory = async (
       return {
         type: StorageDriverType.Local,
         options: {
-          storagePath: process.cwd() + '/' + storagePath,
+          storagePath: resolveAbsolutePath(storagePath),
         },
       };
     }

--- a/packages/twenty-server/src/utils/resolve-absolute-path.ts
+++ b/packages/twenty-server/src/utils/resolve-absolute-path.ts
@@ -1,0 +1,3 @@
+export const resolveAbsolutePath = (path: string): string => {
+  return path.startsWith('/') ? path : process.cwd() + '/' + path;
+};


### PR DESCRIPTION
Add a new util called `resolveAbsolutePath` to allow providing absolute path for environment variable like `STORAGE_LOCAL_PATH`.
If the path in the env start with `/` we'll not prefix it with `process.cwd()`.

Also we're using a static path for the old `db_initialized` file now named `db_status` and stop using the env variable for this file as this one shouldn't ne stored in the `STORAGE_LOCAL_PATH`.

Fix #4794 