### PR TITLE
Collapsible menu

### DIFF
--- a/packages/twenty-front/src/modules/favorites/components/Favorites.tsx
+++ b/packages/twenty-front/src/modules/favorites/components/Favorites.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { useRecoilValue } from 'recoil';
 import { Avatar } from 'twenty-ui';
 
 import { FavoritesSkeletonLoader } from '@/favorites/components/FavoritesSkeletonLoader';
@@ -8,6 +9,7 @@ import { DraggableList } from '@/ui/layout/draggable-list/components/DraggableLi
 import { NavigationDrawerItem } from '@/ui/navigation/navigation-drawer/components/NavigationDrawerItem';
 import { NavigationDrawerSection } from '@/ui/navigation/navigation-drawer/components/NavigationDrawerSection';
 import { NavigationDrawerSectionTitle } from '@/ui/navigation/navigation-drawer/components/NavigationDrawerSectionTitle';
+import { useNavigationSection } from '@/ui/navigation/navigation-drawer/hooks/useNavigationSection';
 import { getImageAbsoluteURIOrBase64 } from '~/utils/image/getImageAbsoluteURIOrBase64';
 
 import { useFavorites } from '../hooks/useFavorites';
@@ -36,6 +38,10 @@ export const Favorites = () => {
   const { favorites, handleReorderFavorite } = useFavorites();
   const loading = useIsPrefetchLoading();
 
+  const { toggleNavigationSection, isNavigationSectionOpenState } =
+    useNavigationSection('Favorites');
+  const isNavigationSectionOpen = useRecoilValue(isNavigationSectionOpenState);
+
   if (loading) {
     return <FavoritesSkeletonLoader />;
   }
@@ -44,48 +50,53 @@ export const Favorites = () => {
 
   return (
     <StyledContainer>
-      <NavigationDrawerSectionTitle label="Favorites" />
-      <DraggableList
-        onDragEnd={handleReorderFavorite}
-        draggableItems={
-          <>
-            {favorites.map((favorite, index) => {
-              const {
-                id,
-                labelIdentifier,
-                avatarUrl,
-                avatarType,
-                link,
-                recordId,
-              } = favorite;
-
-              return (
-                <DraggableItem
-                  key={id}
-                  draggableId={id}
-                  index={index}
-                  itemComponent={
-                    <StyledNavigationDrawerItem
-                      key={id}
-                      label={labelIdentifier}
-                      Icon={() => (
-                        <StyledAvatar
-                          entityId={recordId}
-                          avatarUrl={getImageAbsoluteURIOrBase64(avatarUrl)}
-                          type={avatarType}
-                          placeholder={labelIdentifier}
-                          className="fav-avatar"
-                        />
-                      )}
-                      to={link}
-                    />
-                  }
-                />
-              );
-            })}
-          </>
-        }
+      <NavigationDrawerSectionTitle
+        label="Favorites"
+        onClick={() => toggleNavigationSection()}
       />
+      {isNavigationSectionOpen && (
+        <DraggableList
+          onDragEnd={handleReorderFavorite}
+          draggableItems={
+            <>
+              {favorites.map((favorite, index) => {
+                const {
+                  id,
+                  labelIdentifier,
+                  avatarUrl,
+                  avatarType,
+                  link,
+                  recordId,
+                } = favorite;
+
+                return (
+                  <DraggableItem
+                    key={id}
+                    draggableId={id}
+                    index={index}
+                    itemComponent={
+                      <StyledNavigationDrawerItem
+                        key={id}
+                        label={labelIdentifier}
+                        Icon={() => (
+                          <StyledAvatar
+                            entityId={recordId}
+                            avatarUrl={getImageAbsoluteURIOrBase64(avatarUrl)}
+                            type={avatarType}
+                            placeholder={labelIdentifier}
+                            className="fav-avatar"
+                          />
+                        )}
+                        to={link}
+                      />
+                    }
+                  />
+                );
+              })}
+            </>
+          }
+        />
+      )}
     </StyledContainer>
   );
 };

--- a/packages/twenty-front/src/modules/navigation/components/MainNavigationDrawerItems.tsx
+++ b/packages/twenty-front/src/modules/navigation/components/MainNavigationDrawerItems.tsx
@@ -9,7 +9,6 @@ import { Favorites } from '@/favorites/components/Favorites';
 import { ObjectMetadataNavItems } from '@/object-metadata/components/ObjectMetadataNavItems';
 import { NavigationDrawerItem } from '@/ui/navigation/navigation-drawer/components/NavigationDrawerItem';
 import { NavigationDrawerSection } from '@/ui/navigation/navigation-drawer/components/NavigationDrawerSection';
-import { NavigationDrawerSectionTitle } from '@/ui/navigation/navigation-drawer/components/NavigationDrawerSectionTitle';
 import { navigationMemorizedUrlState } from '@/ui/navigation/states/navigationMemorizedUrlState';
 import { useIsMobile } from '@/ui/utilities/responsive/hooks/useIsMobile';
 
@@ -56,10 +55,8 @@ export const MainNavigationDrawerItems = () => {
 
       <Favorites />
 
-      <NavigationDrawerSection>
-        <NavigationDrawerSectionTitle label="Workspace" />
-        <ObjectMetadataNavItems />
-      </NavigationDrawerSection>
+      <ObjectMetadataNavItems isRemote={false} />
+      <ObjectMetadataNavItems isRemote={true} />
     </>
   );
 };

--- a/packages/twenty-front/src/modules/object-metadata/components/ObjectMetadataNavItems.tsx
+++ b/packages/twenty-front/src/modules/object-metadata/components/ObjectMetadataNavItems.tsx
@@ -16,13 +16,8 @@ import { getObjectMetadataItemViews } from '@/views/utils/getObjectMetadataItemV
 
 export const ObjectMetadataNavItems = ({ isRemote }: { isRemote: boolean }) => {
   const { toggleNavigationSection, isNavigationSectionOpenState } =
-    useNavigationSection();
-  const isNavigationSectionOpen = useRecoilValue(
-    isNavigationSectionOpenState(
-      'objects-' + (isRemote ? 'remote' : 'workspace'),
-    ),
-  );
-  console.log('isNavigationSectionOpen', isNavigationSectionOpen);
+    useNavigationSection('Objects' + (isRemote ? 'Remote' : 'Workspace'));
+  const isNavigationSectionOpen = useRecoilValue(isNavigationSectionOpenState);
 
   const { activeObjectMetadataItems } = useFilteredObjectMetadataItems();
   const filteredActiveObjectMetadataItems = activeObjectMetadataItems.filter(
@@ -43,11 +38,7 @@ export const ObjectMetadataNavItems = ({ isRemote }: { isRemote: boolean }) => {
       <NavigationDrawerSection>
         <NavigationDrawerSectionTitle
           label={isRemote ? 'Remote' : 'Workspace'}
-          onClick={() =>
-            toggleNavigationSection(
-              'objects-' + (isRemote ? 'remote' : 'workspace'),
-            )
-          }
+          onClick={() => toggleNavigationSection()}
         />
 
         {isNavigationSectionOpen &&

--- a/packages/twenty-front/src/modules/object-metadata/components/ObjectMetadataNavItems.tsx
+++ b/packages/twenty-front/src/modules/object-metadata/components/ObjectMetadataNavItems.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
 import { useLocation } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
 import { useIcons } from 'twenty-ui';
 
 import { ObjectMetadataNavItemsSkeletonLoader } from '@/object-metadata/components/ObjectMetadataNavItemsSkeletonLoader';
@@ -10,11 +10,19 @@ import { PrefetchKey } from '@/prefetch/types/PrefetchKey';
 import { NavigationDrawerItem } from '@/ui/navigation/navigation-drawer/components/NavigationDrawerItem';
 import { NavigationDrawerSection } from '@/ui/navigation/navigation-drawer/components/NavigationDrawerSection';
 import { NavigationDrawerSectionTitle } from '@/ui/navigation/navigation-drawer/components/NavigationDrawerSectionTitle';
+import { useNavigationSection } from '@/ui/navigation/navigation-drawer/hooks/useNavigationSection';
 import { View } from '@/views/types/View';
 import { getObjectMetadataItemViews } from '@/views/utils/getObjectMetadataItemViews';
 
 export const ObjectMetadataNavItems = ({ isRemote }: { isRemote: boolean }) => {
-  const [collapsed, setCollapsed] = useState(false);
+  const { toggleNavigationSection, isNavigationSectionOpenState } =
+    useNavigationSection();
+  const isNavigationSectionOpen = useRecoilValue(
+    isNavigationSectionOpenState(
+      'objects-' + (isRemote ? 'remote' : 'workspace'),
+    ),
+  );
+  console.log('isNavigationSectionOpen', isNavigationSectionOpen);
 
   const { activeObjectMetadataItems } = useFilteredObjectMetadataItems();
   const filteredActiveObjectMetadataItems = activeObjectMetadataItems.filter(
@@ -35,10 +43,14 @@ export const ObjectMetadataNavItems = ({ isRemote }: { isRemote: boolean }) => {
       <NavigationDrawerSection>
         <NavigationDrawerSectionTitle
           label={isRemote ? 'Remote' : 'Workspace'}
-          onClick={() => setCollapsed((collapsed) => !collapsed)}
+          onClick={() =>
+            toggleNavigationSection(
+              'objects-' + (isRemote ? 'remote' : 'workspace'),
+            )
+          }
         />
 
-        {!collapsed &&
+        {isNavigationSectionOpen &&
           [
             ...filteredActiveObjectMetadataItems
               .filter((item) =>

--- a/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/NavigationDrawerSectionTitle.tsx
+++ b/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/NavigationDrawerSectionTitle.tsx
@@ -14,11 +14,11 @@ const StyledTitle = styled.div`
   font-size: ${({ theme }) => theme.font.size.xs};
   font-weight: ${({ theme }) => theme.font.weight.semiBold};
   padding: ${({ theme }) => theme.spacing(1)};
-  padding-top: 0;
+  height: ${({ theme }) => theme.spacing(4)};
 
   &:hover {
     cursor: pointer;
-    background-color: ${({ theme }) => theme.background.tertiary};
+    background-color: ${({ theme }) => theme.background.transparent.light};
   }
 `;
 

--- a/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/NavigationDrawerSectionTitle.tsx
+++ b/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/NavigationDrawerSectionTitle.tsx
@@ -4,6 +4,7 @@ import { useIsPrefetchLoading } from '@/prefetch/hooks/useIsPrefetchLoading';
 import { NavigationDrawerSectionTitleSkeletonLoader } from '@/ui/navigation/navigation-drawer/components/NavigationDrawerSectionTitleSkeletonLoader';
 
 type NavigationDrawerSectionTitleProps = {
+  onClick: () => void;
   label: string;
 };
 
@@ -14,9 +15,15 @@ const StyledTitle = styled.div`
   font-weight: ${({ theme }) => theme.font.weight.semiBold};
   padding: ${({ theme }) => theme.spacing(1)};
   padding-top: 0;
+
+  &:hover {
+    cursor: pointer;
+    background-color: ${({ theme }) => theme.background.tertiary};
+  }
 `;
 
 export const NavigationDrawerSectionTitle = ({
+  onClick,
   label,
 }: NavigationDrawerSectionTitleProps) => {
   const loading = useIsPrefetchLoading();
@@ -24,5 +31,5 @@ export const NavigationDrawerSectionTitle = ({
   if (loading) {
     return <NavigationDrawerSectionTitleSkeletonLoader />;
   }
-  return <StyledTitle>{label}</StyledTitle>;
+  return <StyledTitle onClick={onClick}>{label}</StyledTitle>;
 };

--- a/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/NavigationDrawerSectionTitle.tsx
+++ b/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/NavigationDrawerSectionTitle.tsx
@@ -2,13 +2,14 @@ import styled from '@emotion/styled';
 
 import { useIsPrefetchLoading } from '@/prefetch/hooks/useIsPrefetchLoading';
 import { NavigationDrawerSectionTitleSkeletonLoader } from '@/ui/navigation/navigation-drawer/components/NavigationDrawerSectionTitleSkeletonLoader';
+import { isUndefinedOrNull } from '~/utils/isUndefinedOrNull';
 
 type NavigationDrawerSectionTitleProps = {
-  onClick: () => void;
+  onClick?: () => void;
   label: string;
 };
 
-const StyledTitle = styled.div`
+const StyledTitle = styled.div<{ onClick?: () => void }>`
   color: ${({ theme }) => theme.font.color.light};
   display: flex;
   font-size: ${({ theme }) => theme.font.size.xs};
@@ -16,10 +17,13 @@ const StyledTitle = styled.div`
   padding: ${({ theme }) => theme.spacing(1)};
   height: ${({ theme }) => theme.spacing(4)};
 
-  &:hover {
-    cursor: pointer;
-    background-color: ${({ theme }) => theme.background.transparent.light};
-  }
+  ${({ onClick, theme }) =>
+    !isUndefinedOrNull(onClick)
+      ? `&:hover {
+          cursor: pointer;
+          background-color:${theme.background.transparent.light};
+        }`
+      : ''}
 `;
 
 export const NavigationDrawerSectionTitle = ({

--- a/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/NavigationDrawerSectionTitle.tsx
+++ b/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/NavigationDrawerSectionTitle.tsx
@@ -10,12 +10,14 @@ type NavigationDrawerSectionTitleProps = {
 };
 
 const StyledTitle = styled.div<{ onClick?: () => void }>`
+  align-items: center;
+  border-radius: ${({ theme }) => theme.border.radius.sm};
   color: ${({ theme }) => theme.font.color.light};
   display: flex;
   font-size: ${({ theme }) => theme.font.size.xs};
   font-weight: ${({ theme }) => theme.font.weight.semiBold};
-  padding: ${({ theme }) => theme.spacing(1)};
   height: ${({ theme }) => theme.spacing(4)};
+  padding: ${({ theme }) => theme.spacing(1)};
 
   ${({ onClick, theme }) =>
     !isUndefinedOrNull(onClick)

--- a/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/hooks/useNavigationSection.ts
+++ b/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/hooks/useNavigationSection.ts
@@ -1,0 +1,61 @@
+import { useRecoilCallback } from 'recoil';
+
+import { isNavigationSectionOpenComponentState } from '@/ui/navigation/navigation-drawer/states/isNavigationSectionOpenComponentState';
+import { extractComponentState } from '@/ui/utilities/state/component-state/utils/extractComponentState';
+
+export const useNavigationSection = () => {
+  const closeNavigationSection = useRecoilCallback(
+    ({ set }) =>
+      (componentId: string) => {
+        set(
+          isNavigationSectionOpenComponentState({
+            scopeId: componentId,
+          }),
+          false,
+        );
+      },
+    [],
+  );
+
+  const openNavigationSection = useRecoilCallback(
+    ({ set }) =>
+      (componentId: string) => {
+        set(
+          isNavigationSectionOpenComponentState({
+            scopeId: componentId,
+          }),
+          true,
+        );
+      },
+    [],
+  );
+
+  const toggleNavigationSection = useRecoilCallback(
+    ({ snapshot }) =>
+      (componentId: string) => {
+        console.log('componentId', componentId);
+        const isNavigationSectionOpen = snapshot
+          .getLoadable(
+            isNavigationSectionOpenComponentState({ scopeId: componentId }),
+          )
+          .getValue();
+
+        console.log(isNavigationSectionOpen);
+
+        if (isNavigationSectionOpen) {
+          closeNavigationSection(componentId);
+        } else {
+          openNavigationSection(componentId);
+        }
+      },
+    [closeNavigationSection, openNavigationSection],
+  );
+
+  return {
+    isNavigationSectionOpenState: (scopeId: string) =>
+      extractComponentState(isNavigationSectionOpenComponentState, scopeId),
+    closeNavigationSection,
+    openNavigationSection,
+    toggleNavigationSection,
+  };
+};

--- a/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/hooks/useNavigationSection.ts
+++ b/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/hooks/useNavigationSection.ts
@@ -3,57 +3,56 @@ import { useRecoilCallback } from 'recoil';
 import { isNavigationSectionOpenComponentState } from '@/ui/navigation/navigation-drawer/states/isNavigationSectionOpenComponentState';
 import { extractComponentState } from '@/ui/utilities/state/component-state/utils/extractComponentState';
 
-export const useNavigationSection = () => {
+export const useNavigationSection = (scopeId: string) => {
   const closeNavigationSection = useRecoilCallback(
     ({ set }) =>
-      (componentId: string) => {
+      () => {
         set(
           isNavigationSectionOpenComponentState({
-            scopeId: componentId,
+            scopeId,
           }),
           false,
         );
       },
-    [],
+    [scopeId],
   );
 
   const openNavigationSection = useRecoilCallback(
     ({ set }) =>
-      (componentId: string) => {
+      () => {
         set(
           isNavigationSectionOpenComponentState({
-            scopeId: componentId,
+            scopeId,
           }),
           true,
         );
       },
-    [],
+    [scopeId],
   );
 
   const toggleNavigationSection = useRecoilCallback(
     ({ snapshot }) =>
-      (componentId: string) => {
-        console.log('componentId', componentId);
+      () => {
         const isNavigationSectionOpen = snapshot
-          .getLoadable(
-            isNavigationSectionOpenComponentState({ scopeId: componentId }),
-          )
+          .getLoadable(isNavigationSectionOpenComponentState({ scopeId }))
           .getValue();
 
-        console.log(isNavigationSectionOpen);
-
         if (isNavigationSectionOpen) {
-          closeNavigationSection(componentId);
+          closeNavigationSection();
         } else {
-          openNavigationSection(componentId);
+          openNavigationSection();
         }
       },
-    [closeNavigationSection, openNavigationSection],
+    [closeNavigationSection, openNavigationSection, scopeId],
+  );
+
+  const isNavigationSectionOpenState = extractComponentState(
+    isNavigationSectionOpenComponentState,
+    scopeId,
   );
 
   return {
-    isNavigationSectionOpenState: (scopeId: string) =>
-      extractComponentState(isNavigationSectionOpenComponentState, scopeId),
+    isNavigationSectionOpenState,
     closeNavigationSection,
     openNavigationSection,
     toggleNavigationSection,

--- a/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/states/isNavigationSectionOpenComponentState.ts
+++ b/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/states/isNavigationSectionOpenComponentState.ts
@@ -1,15 +1,9 @@
-import { ComponentStateKey } from '@/ui/utilities/state/component-state/types/ComponentStateKey';
 import { createComponentState } from '@/ui/utilities/state/component-state/utils/createComponentState';
 import { localStorageEffect } from '~/utils/recoil-effects';
 
-export const isNavigationSectionOpenComponentState = ({
-  scopeId,
-}: ComponentStateKey) => {
-  return createComponentState<boolean>({
+export const isNavigationSectionOpenComponentState =
+  createComponentState<boolean>({
     key: 'isNavigationSectionOpenComponentState',
     defaultValue: true,
-    effects: [
-      localStorageEffect('isNavigationSectionOpenComponentState' + scopeId),
-    ],
-  })({ scopeId });
-};
+    effects: [localStorageEffect()],
+  });

--- a/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/states/isNavigationSectionOpenComponentState.ts
+++ b/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/states/isNavigationSectionOpenComponentState.ts
@@ -1,0 +1,7 @@
+import { createComponentState } from '@/ui/utilities/state/component-state/utils/createComponentState';
+
+export const isNavigationSectionOpenComponentState =
+  createComponentState<boolean>({
+    key: 'isNavigationSectionOpenComponentState',
+    defaultValue: true,
+  });

--- a/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/states/isNavigationSectionOpenComponentState.ts
+++ b/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/states/isNavigationSectionOpenComponentState.ts
@@ -1,7 +1,15 @@
+import { ComponentStateKey } from '@/ui/utilities/state/component-state/types/ComponentStateKey';
 import { createComponentState } from '@/ui/utilities/state/component-state/utils/createComponentState';
+import { localStorageEffect } from '~/utils/recoil-effects';
 
-export const isNavigationSectionOpenComponentState =
-  createComponentState<boolean>({
+export const isNavigationSectionOpenComponentState = ({
+  scopeId,
+}: ComponentStateKey) => {
+  return createComponentState<boolean>({
     key: 'isNavigationSectionOpenComponentState',
     defaultValue: true,
-  });
+    effects: [
+      localStorageEffect('isNavigationSectionOpenComponentState' + scopeId),
+    ],
+  })({ scopeId });
+};

--- a/packages/twenty-front/src/modules/ui/utilities/state/component-state/utils/createComponentState.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/state/component-state/utils/createComponentState.ts
@@ -1,16 +1,19 @@
-import { atomFamily } from 'recoil';
+import { AtomEffect, atomFamily } from 'recoil';
 
 import { ComponentStateKey } from '@/ui/utilities/state/component-state/types/ComponentStateKey';
 
 export const createComponentState = <ValueType>({
   key,
   defaultValue,
+  effects,
 }: {
   key: string;
   defaultValue: ValueType;
+  effects?: AtomEffect<ValueType>[];
 }) => {
   return atomFamily<ValueType, ComponentStateKey>({
     key,
     default: defaultValue,
+    effects: effects,
   });
 };

--- a/packages/twenty-front/src/utils/recoil-effects.ts
+++ b/packages/twenty-front/src/utils/recoil-effects.ts
@@ -5,17 +5,17 @@ import { cookieStorage } from '~/utils/cookie-storage';
 import { isDefined } from './isDefined';
 
 export const localStorageEffect =
-  <T>(key: string): AtomEffect<T> =>
-  ({ setSelf, onSet }) => {
-    const savedValue = localStorage.getItem(key);
+  <T>(key?: string): AtomEffect<T> =>
+  ({ setSelf, onSet, node }) => {
+    const savedValue = localStorage.getItem(key ?? node.key);
     if (savedValue != null) {
       setSelf(JSON.parse(savedValue));
     }
 
     onSet((newValue, _, isReset) => {
       isReset
-        ? localStorage.removeItem(key)
-        : localStorage.setItem(key, JSON.stringify(newValue));
+        ? localStorage.removeItem(key ?? node.key)
+        : localStorage.setItem(key ?? node.key, JSON.stringify(newValue));
     });
   };
 


### PR DESCRIPTION
A mini PR to discuss with @Bonapara tomorrow

Separating remote objects from others and making the menu collapsible (style to be changed)
<img width="225" alt="Screenshot 2024-06-12 at 23 25 59" src="https://github.com/twentyhq/twenty/assets/6399865/b4b69d36-6770-43a2-a5e8-bfcdf0a629ea">

Biggest issue is we don't use local storage today so the collapsed state gets lost.
I see we have localStorageEffect with recoil. Maybe store it there? Seems easy but don't want to introduce a bad pattern.


Todo:
- style update
- collapsible favorites
- persistent storage

