### PR TITLE
Removed unnecessary on mouse enter for soft focus

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellContainer.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellContainer.tsx
@@ -66,14 +66,6 @@ export const RecordTableCellContainer = ({
     }
   };
 
-  const handleContainerMouseEnter = () => {
-    if (!hasSoftFocus) {
-      onCellMouseEnter({
-        cellPosition,
-      });
-    }
-  };
-
   const handleContainerMouseLeave = () => {
     setHasSoftFocus(false);
     setIsFocused(false);
@@ -142,7 +134,6 @@ export const RecordTableCellContainer = ({
         value={editHotkeyScope ?? DEFAULT_CELL_SCOPE}
       >
         <div
-          onMouseEnter={handleContainerMouseEnter}
           onMouseLeave={handleContainerMouseLeave}
           onMouseMove={handleContainerMouseMove}
           onClick={handleContainerClick}


### PR DESCRIPTION
In RecordTableCellContainer, I just removed onMouseEnter event handler that was being triggered when we used keyboard soft focus move.

It's not necessary to have it because we already listen on mouse move which is matching our use case where we only want soft focus to move when mouse move and not when the cursor stays on top of a cell.