### PR TITLE
Added a fallback default record chip generator

### DIFF
--- a/packages/twenty-front/src/modules/object-metadata/utils/generateDefaultRecordChipData.ts
+++ b/packages/twenty-front/src/modules/object-metadata/utils/generateDefaultRecordChipData.ts
@@ -1,0 +1,15 @@
+import { isFieldFullNameValue } from '@/object-record/record-field/types/guards/isFieldFullNameValue';
+import { ObjectRecord } from '@/object-record/types/ObjectRecord';
+
+export const generateDefaultRecordChipData = (record: ObjectRecord) => {
+  const name = isFieldFullNameValue(record.name)
+    ? record.name.firstName + ' ' + record.name.lastName
+    : record.name ?? '';
+
+  return {
+    name,
+    avatarUrl: name,
+    avatarType: 'rounded',
+    linkToShowPage: false,
+  };
+};

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/hooks/useChipFieldDisplay.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/hooks/useChipFieldDisplay.ts
@@ -2,6 +2,7 @@ import { useContext } from 'react';
 import { isNonEmptyString } from '@sniptt/guards';
 
 import { PreComputedChipGeneratorsContext } from '@/object-metadata/context/PreComputedChipGeneratorsContext';
+import { generateDefaultRecordChipData } from '@/object-metadata/utils/generateDefaultRecordChipData';
 import { isFieldFullName } from '@/object-record/record-field/types/guards/isFieldFullName';
 import { isFieldNumber } from '@/object-record/record-field/types/guards/isFieldNumber';
 import { isFieldText } from '@/object-record/record-field/types/guards/isFieldText';
@@ -37,7 +38,7 @@ export const useChipFieldDisplay = () => {
   const generateRecordChipData =
     chipGeneratorPerObjectPerField[
       fieldDefinition.metadata.objectMetadataNameSingular
-    ][fieldDefinition.metadata.fieldName];
+    ]?.[fieldDefinition.metadata.fieldName] ?? generateDefaultRecordChipData;
 
   return {
     objectNameSingular,

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/hooks/useRelationFieldDisplay.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/hooks/useRelationFieldDisplay.ts
@@ -2,6 +2,7 @@ import { useContext } from 'react';
 import { isNonEmptyString } from '@sniptt/guards';
 
 import { PreComputedChipGeneratorsContext } from '@/object-metadata/context/PreComputedChipGeneratorsContext';
+import { generateDefaultRecordChipData } from '@/object-metadata/utils/generateDefaultRecordChipData';
 import { useRecordFieldValue } from '@/object-record/record-store/contexts/RecordFieldValueSelectorContext';
 import { ObjectRecord } from '@/object-record/types/ObjectRecord';
 import { FIELD_EDIT_BUTTON_WIDTH } from '@/ui/field/display/constants/FieldEditButtonWidth';
@@ -50,7 +51,7 @@ export const useRelationFieldDisplay = () => {
   const generateRecordChipData =
     chipGeneratorPerObjectPerField[
       fieldDefinition.metadata.objectMetadataNameSingular
-    ][fieldDefinition.metadata.fieldName];
+    ]?.[fieldDefinition.metadata.fieldName] ?? generateDefaultRecordChipData;
 
   return {
     fieldDefinition,


### PR DESCRIPTION
The record chip generator context was missing a edge were a new field of type relation is created and not yet in the metadata so no chip generator function can be precomputed.

For now I added a fallback default chip generator, to prevent any bug, but we might want to add a new chip generator function while creating the new field ?