### PR TITLE
fix timeline activity pagination overflow

### DIFF
--- a/packages/twenty-front/src/modules/activities/timelineActivities/components/TimelineActivities.tsx
+++ b/packages/twenty-front/src/modules/activities/timelineActivities/components/TimelineActivities.tsx
@@ -23,11 +23,11 @@ const StyledMainContainer = styled.div`
   display: flex;
   flex-direction: column;
   height: 100%;
+  overflow: auto;
 
   justify-content: center;
   padding-top: ${({ theme }) => theme.spacing(6)};
   padding-right: ${({ theme }) => theme.spacing(6)};
-  padding-bottom: ${({ theme }) => theme.spacing(16)};
   padding-left: ${({ theme }) => theme.spacing(6)};
   gap: ${({ theme }) => theme.spacing(4)};
 `;


### PR DESCRIPTION
## Before
<img width="250" alt="Screenshot 2024-06-13 at 18 51 56" src="https://github.com/twentyhq/twenty/assets/1834158/d6c7f5fa-3cc7-48bc-a711-29345e93af92">


## After
<img width="284" alt="Screenshot 2024-06-13 at 18 51 41" src="https://github.com/twentyhq/twenty/assets/1834158/25029e0a-c1b0-4458-b715-dbab217eeee0">
