### PR TITLE
Fix workspaceLogo in invite-email

### DIFF
--- a/packages/twenty-emails/src/emails/send-invite-link.email.tsx
+++ b/packages/twenty-emails/src/emails/send-invite-link.email.tsx
@@ -9,6 +9,7 @@ import { MainText } from 'src/components/MainText';
 import { Title } from 'src/components/Title';
 import { WhatIsTwenty } from 'src/components/WhatIsTwenty';
 import { capitalize } from 'src/utils/capitalize';
+import { getImageAbsoluteURIOrBase64 } from 'src/utils/getImageAbsoluteURIOrBase64';
 
 type SendInviteLinkEmailProps = {
   link: string;
@@ -17,13 +18,16 @@ type SendInviteLinkEmailProps = {
     email: string;
     firstName: string;
   };
+  serverUrl?: string;
 };
 
 export const SendInviteLinkEmail = ({
   link,
   workspace,
   sender,
+  serverUrl,
 }: SendInviteLinkEmailProps) => {
+  const workspaceLogo = getImageAbsoluteURIOrBase64(workspace.logo, serverUrl);
   return (
     <BaseEmail width={333}>
       <Title value="Join your team on Twenty" />
@@ -34,7 +38,7 @@ export const SendInviteLinkEmail = ({
         <br />
       </MainText>
       <HighlightedContainer>
-        {workspace.logo && <Img src={workspace.logo} width={40} height={40} />}
+        {workspaceLogo && <Img src={workspaceLogo} width={40} height={40} />}
         {workspace.name && <HighlightedText value={workspace.name} />}
         <CallToAction href={link} value="Accept invite" />
       </HighlightedContainer>

--- a/packages/twenty-emails/src/utils/getImageAbsoluteURIOrBase64.ts
+++ b/packages/twenty-emails/src/utils/getImageAbsoluteURIOrBase64.ts
@@ -1,0 +1,16 @@
+export const getImageAbsoluteURIOrBase64 = (
+  imageUrl?: string | null,
+  serverUrl?: string,
+) => {
+  if (!imageUrl) {
+    return null;
+  }
+
+  if (imageUrl?.startsWith('data:') || imageUrl?.startsWith('https:')) {
+    return imageUrl;
+  }
+
+  return serverUrl?.endsWith('/')
+    ? `${serverUrl.substring(0, serverUrl.length - 1)}/files/${imageUrl}`
+    : `${serverUrl || ''}/files/${imageUrl}`;
+};

--- a/packages/twenty-server/src/engine/core-modules/workspace/services/workspace.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/services/workspace.service.ts
@@ -119,6 +119,7 @@ export class WorkspaceService extends TypeOrmQueryService<Workspace> {
         link: inviteLink,
         workspace: { name: workspace.displayName, logo: workspace.logo },
         sender: { email: sender.email, firstName: sender.firstName },
+        serverUrl: this.environmentService.get('SERVER_URL'),
       };
       const emailTemplate = SendInviteLinkEmail(emailData);
       const html = render(emailTemplate, {


### PR DESCRIPTION
## Fixes wrong image url in email 
![image](https://github.com/twentyhq/twenty/assets/29927851/5fb1524b-874d-4723-8450-0284382bbeb3)

## Done
- duplicates and adapt `getImageAbsoluteURIOrBase64` from `twenty-front` in `twenty-email`
- send `SERVER_URL` to email builder