### PR TITLE
Fix error log on message import

### DIFF
--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/messaging-gmail-messages-import.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/messaging-gmail-messages-import.service.ts
@@ -153,7 +153,9 @@ export class MessagingGmailMessagesImportService {
       );
     } catch (error) {
       this.logger.log(
-        `Messaging import for workspace ${workspaceId} and message channel ${messageChannel.id} failed with error: ${error}`,
+        `Messaging import for workspace ${workspaceId} and connected account ${
+          connectedAccount.id
+        } failed with error: ${JSON.stringify(error)}`,
       );
 
       await this.cacheStorage.setAdd(


### PR DESCRIPTION
Modify #5863 to log the connected account id rather than the message channel id to be consistent with the other logs and stringify the error.