### PR TITLE
5581 get httpsapitwentycomrestmetadata relations not working

### DIFF
--- a/packages/twenty-server/src/engine/api/rest/controllers/rest-api-metadata.controller.ts
+++ b/packages/twenty-server/src/engine/api/rest/controllers/rest-api-metadata.controller.ts
@@ -24,28 +24,28 @@ export class RestApiMetadataController {
   async handleApiGet(@Req() request: Request, @Res() res: Response) {
     const result = await this.restApiMetadataService.get(request);
 
-    res.status(200).send(cleanGraphQLResponse(result.data));
+    res.status(200).send(cleanGraphQLResponse(result.data.data));
   }
 
   @Delete()
   async handleApiDelete(@Req() request: Request, @Res() res: Response) {
     const result = await this.restApiMetadataService.delete(request);
 
-    res.status(200).send(cleanGraphQLResponse(result.data));
+    res.status(200).send(cleanGraphQLResponse(result.data.data));
   }
 
   @Post()
   async handleApiPost(@Req() request: Request, @Res() res: Response) {
     const result = await this.restApiMetadataService.create(request);
 
-    res.status(201).send(cleanGraphQLResponse(result.data));
+    res.status(201).send(cleanGraphQLResponse(result.data.data));
   }
 
   @Patch()
   async handleApiPatch(@Req() request: Request, @Res() res: Response) {
     const result = await this.restApiMetadataService.update(request);
 
-    res.status(200).send(cleanGraphQLResponse(result.data));
+    res.status(200).send(cleanGraphQLResponse(result.data.data));
   }
 
   // This endpoint is not documented in the OpenAPI schema.
@@ -55,6 +55,6 @@ export class RestApiMetadataController {
   async handleApiPut(@Req() request: Request, @Res() res: Response) {
     const result = await this.restApiMetadataService.update(request);
 
-    res.status(200).send(cleanGraphQLResponse(result.data));
+    res.status(200).send(cleanGraphQLResponse(result.data.data));
   }
 }

--- a/packages/twenty-server/src/engine/api/rest/services/rest-api-metadata.service.ts
+++ b/packages/twenty-server/src/engine/api/rest/services/rest-api-metadata.service.ts
@@ -113,12 +113,18 @@ export class RestApiMetadataService {
   generateFindManyQuery(objectNameSingular: string, objectNamePlural: string) {
     const fields = this.fetchMetadataFields(objectNamePlural);
 
+    let filterType = '';
+    let filterValue = '';
+
+    if (objectNamePlural !== 'relations') {
+      filterType = `($filter: ${objectNameSingular}Filter)`;
+      filterValue = 'filter: $filter,';
+    }
+
     return `
-      query FindMany${capitalize(objectNamePlural)}(
-        $filter: ${objectNameSingular}Filter,
-        ) {
+      query FindMany${capitalize(objectNamePlural)}${filterType} {
         ${objectNamePlural}(
-        filter: $filter,
+        ${filterValue}
         paging: { first: 1000 }
         ) {
           edges {

--- a/packages/twenty-server/src/engine/core-modules/open-api/open-api.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/open-api/open-api.service.ts
@@ -133,7 +133,10 @@ export class OpenApiService {
         get: {
           tags: [item.namePlural],
           summary: `Find Many ${item.namePlural}`,
-          parameters: [{ $ref: '#/components/parameters/filter' }],
+          parameters:
+            item.namePlural !== 'relations'
+              ? [{ $ref: '#/components/parameters/filter' }]
+              : undefined,
           responses: {
             '200': getFindManyResponse200(item),
             '400': { $ref: '#/components/responses/400' },

--- a/packages/twenty-server/src/engine/core-modules/open-api/utils/components.utils.ts
+++ b/packages/twenty-server/src/engine/core-modules/open-api/utils/components.utils.ts
@@ -240,7 +240,7 @@ export const computeMetadataSchemaComponents = (
     (schemas, item) => {
       switch (item.nameSingular) {
         case 'object': {
-          schemas[`${capitalize(item.nameSingular)}`] = {
+          schemas[`${capitalize(item.nameSingular)} with Relations`] = {
             type: 'object',
             description: `An object`,
             properties: {
@@ -290,7 +290,7 @@ export const computeMetadataSchemaComponents = (
           return schemas;
         }
         case 'field': {
-          schemas[`${capitalize(item.nameSingular)}`] = {
+          schemas[`${capitalize(item.nameSingular)} with Relations`] = {
             type: 'object',
             description: `A field`,
             properties: {
@@ -358,7 +358,7 @@ export const computeMetadataSchemaComponents = (
           return schemas;
         }
         case 'relation': {
-          schemas[`${capitalize(item.nameSingular)}`] = {
+          schemas[`${capitalize(item.nameSingular)} with Relations`] = {
             type: 'object',
             description: 'A relation',
             properties: {


### PR DESCRIPTION
Filtering relations is not allowed (see`packages/twenty-server/src/engine/metadata-modules/relation-metadata/dtos/relation-metadata.dto.ts`) so we remove filtering for find many relation

we also fixed some bug in result structure and metadata open-api schema