### PR TITLE
Add http status to graphql errors

### DIFF
--- a/packages/twenty-server/src/engine/utils/global-exception-handler.util.ts
+++ b/packages/twenty-server/src/engine/utils/global-exception-handler.util.ts
@@ -43,6 +43,7 @@ export const shouldFilterException = (exception: Error): boolean => {
   ) {
     return true;
   }
+
   if (exception instanceof HttpException && exception.getStatus() < 500) {
     return true;
   }
@@ -50,7 +51,7 @@ export const shouldFilterException = (exception: Error): boolean => {
   return false;
 };
 
-export const handleException = (
+const handleException = (
   exception: Error,
   exceptionHandlerService: ExceptionHandlerService,
   user?: ExceptionHandlerUser,
@@ -72,7 +73,7 @@ export const convertExceptionToGraphQLError = (
   return convertExceptionToGraphql(exception);
 };
 
-export const convertHttpExceptionToGraphql = (exception: HttpException) => {
+const convertHttpExceptionToGraphql = (exception: HttpException) => {
   const status = exception.getStatus();
   let error: BaseGraphQLError;
 

--- a/packages/twenty-server/src/engine/utils/graphql-errors.util.ts
+++ b/packages/twenty-server/src/engine/utils/graphql-errors.util.ts
@@ -15,7 +15,7 @@ declare module 'graphql' {
   }
 }
 
-export class BaseGraphQLError extends Error implements GraphQLError {
+export class BaseGraphQLError extends GraphQLError {
   public extensions: Record<string, any>;
   override readonly name!: string;
   readonly locations: ReadonlyArray<SourceLocation> | undefined;
@@ -84,7 +84,7 @@ export class SyntaxError extends BaseGraphQLError {
 
 export class ValidationError extends BaseGraphQLError {
   constructor(message: string) {
-    super(message, 'GRAPHQL_VALIDATION_FAILED');
+    super(message, 'GRAPHQL_VALIDATION_FAILED', { http: { status: 400 } });
 
     Object.defineProperty(this, 'name', { value: 'ValidationError' });
   }
@@ -92,7 +92,7 @@ export class ValidationError extends BaseGraphQLError {
 
 export class AuthenticationError extends BaseGraphQLError {
   constructor(message: string, extensions?: Record<string, any>) {
-    super(message, 'UNAUTHENTICATED', extensions);
+    super(message, 'UNAUTHENTICATED', { ...extensions, http: { status: 401 } });
 
     Object.defineProperty(this, 'name', { value: 'AuthenticationError' });
   }
@@ -100,7 +100,7 @@ export class AuthenticationError extends BaseGraphQLError {
 
 export class ForbiddenError extends BaseGraphQLError {
   constructor(message: string, extensions?: Record<string, any>) {
-    super(message, 'FORBIDDEN', extensions);
+    super(message, 'FORBIDDEN', { ...extensions, http: { status: 403 } });
 
     Object.defineProperty(this, 'name', { value: 'ForbiddenError' });
   }
@@ -136,7 +136,7 @@ export class UserInputError extends BaseGraphQLError {
 
 export class NotFoundError extends BaseGraphQLError {
   constructor(message: string, extensions?: Record<string, any>) {
-    super(message, 'NOT_FOUND', extensions);
+    super(message, 'NOT_FOUND', { ...extensions, http: { status: 404 } });
 
     Object.defineProperty(this, 'name', { value: 'NotFoundError' });
   }
@@ -144,7 +144,10 @@ export class NotFoundError extends BaseGraphQLError {
 
 export class MethodNotAllowedError extends BaseGraphQLError {
   constructor(message: string, extensions?: Record<string, any>) {
-    super(message, 'METHOD_NOT_ALLOWED', extensions);
+    super(message, 'METHOD_NOT_ALLOWED', {
+      ...extensions,
+      http: { status: 405 },
+    });
 
     Object.defineProperty(this, 'name', { value: 'MethodNotAllowedError' });
   }
@@ -152,7 +155,7 @@ export class MethodNotAllowedError extends BaseGraphQLError {
 
 export class ConflictError extends BaseGraphQLError {
   constructor(message: string, extensions?: Record<string, any>) {
-    super(message, 'CONFLICT', extensions);
+    super(message, 'CONFLICT', { ...extensions, http: { status: 409 } });
 
     Object.defineProperty(this, 'name', { value: 'ConflictError' });
   }
@@ -160,7 +163,7 @@ export class ConflictError extends BaseGraphQLError {
 
 export class TimeoutError extends BaseGraphQLError {
   constructor(message: string, extensions?: Record<string, any>) {
-    super(message, 'TIMEOUT', extensions);
+    super(message, 'TIMEOUT', { ...extensions, http: { status: 408 } });
 
     Object.defineProperty(this, 'name', { value: 'TimeoutError' });
   }

--- a/packages/twenty-server/src/engine/utils/graphql-errors.util.ts
+++ b/packages/twenty-server/src/engine/utils/graphql-errors.util.ts
@@ -15,6 +15,21 @@ declare module 'graphql' {
   }
 }
 
+export enum ErrorCode {
+  GRAPHQL_PARSE_FAILED = 'GRAPHQL_PARSE_FAILED',
+  GRAPHQL_VALIDATION_FAILED = 'GRAPHQL_VALIDATION_FAILED',
+  UNAUTHENTICATED = 'UNAUTHENTICATED',
+  FORBIDDEN = 'FORBIDDEN',
+  PERSISTED_QUERY_NOT_FOUND = 'PERSISTED_QUERY_NOT_FOUND',
+  PERSISTED_QUERY_NOT_SUPPORTED = 'PERSISTED_QUERY_NOT_SUPPORTED',
+  BAD_USER_INPUT = 'BAD_USER_INPUT',
+  NOT_FOUND = 'NOT_FOUND',
+  METHOD_NOT_ALLOWED = 'METHOD_NOT_ALLOWED',
+  CONFLICT = 'CONFLICT',
+  TIMEOUT = 'TIMEOUT',
+  INTERNAL_SERVER_ERROR = 'INTERNAL_SERVER_ERROR',
+}
+
 export class BaseGraphQLError extends GraphQLError {
   public extensions: Record<string, any>;
   override readonly name!: string;
@@ -76,7 +91,7 @@ function toGraphQLError(error: BaseGraphQLError): GraphQLError {
 
 export class SyntaxError extends BaseGraphQLError {
   constructor(message: string) {
-    super(message, 'GRAPHQL_PARSE_FAILED');
+    super(message, ErrorCode.GRAPHQL_PARSE_FAILED);
 
     Object.defineProperty(this, 'name', { value: 'SyntaxError' });
   }
@@ -84,23 +99,23 @@ export class SyntaxError extends BaseGraphQLError {
 
 export class ValidationError extends BaseGraphQLError {
   constructor(message: string) {
-    super(message, 'GRAPHQL_VALIDATION_FAILED', { http: { status: 400 } });
+    super(message, ErrorCode.GRAPHQL_VALIDATION_FAILED);
 
     Object.defineProperty(this, 'name', { value: 'ValidationError' });
   }
 }
 
 export class AuthenticationError extends BaseGraphQLError {
-  constructor(message: string, extensions?: Record<string, any>) {
-    super(message, 'UNAUTHENTICATED', { ...extensions, http: { status: 401 } });
+  constructor(message: string) {
+    super(message, ErrorCode.UNAUTHENTICATED);
 
     Object.defineProperty(this, 'name', { value: 'AuthenticationError' });
   }
 }
 
 export class ForbiddenError extends BaseGraphQLError {
-  constructor(message: string, extensions?: Record<string, any>) {
-    super(message, 'FORBIDDEN', { ...extensions, http: { status: 403 } });
+  constructor(message: string) {
+    super(message, ErrorCode.FORBIDDEN);
 
     Object.defineProperty(this, 'name', { value: 'ForbiddenError' });
   }
@@ -108,7 +123,7 @@ export class ForbiddenError extends BaseGraphQLError {
 
 export class PersistedQueryNotFoundError extends BaseGraphQLError {
   constructor() {
-    super('PersistedQueryNotFound', 'PERSISTED_QUERY_NOT_FOUND');
+    super('PersistedQueryNotFound', ErrorCode.PERSISTED_QUERY_NOT_FOUND);
 
     Object.defineProperty(this, 'name', {
       value: 'PersistedQueryNotFoundError',
@@ -118,7 +133,10 @@ export class PersistedQueryNotFoundError extends BaseGraphQLError {
 
 export class PersistedQueryNotSupportedError extends BaseGraphQLError {
   constructor() {
-    super('PersistedQueryNotSupported', 'PERSISTED_QUERY_NOT_SUPPORTED');
+    super(
+      'PersistedQueryNotSupported',
+      ErrorCode.PERSISTED_QUERY_NOT_SUPPORTED,
+    );
 
     Object.defineProperty(this, 'name', {
       value: 'PersistedQueryNotSupportedError',
@@ -127,43 +145,40 @@ export class PersistedQueryNotSupportedError extends BaseGraphQLError {
 }
 
 export class UserInputError extends BaseGraphQLError {
-  constructor(message: string, extensions?: Record<string, any>) {
-    super(message, 'BAD_USER_INPUT', extensions);
+  constructor(message: string) {
+    super(message, ErrorCode.BAD_USER_INPUT);
 
     Object.defineProperty(this, 'name', { value: 'UserInputError' });
   }
 }
 
 export class NotFoundError extends BaseGraphQLError {
-  constructor(message: string, extensions?: Record<string, any>) {
-    super(message, 'NOT_FOUND', { ...extensions, http: { status: 404 } });
+  constructor(message: string) {
+    super(message, ErrorCode.NOT_FOUND);
 
     Object.defineProperty(this, 'name', { value: 'NotFoundError' });
   }
 }
 
 export class MethodNotAllowedError extends BaseGraphQLError {
-  constructor(message: string, extensions?: Record<string, any>) {
-    super(message, 'METHOD_NOT_ALLOWED', {
-      ...extensions,
-      http: { status: 405 },
-    });
+  constructor(message: string) {
+    super(message, ErrorCode.METHOD_NOT_ALLOWED);
 
     Object.defineProperty(this, 'name', { value: 'MethodNotAllowedError' });
   }
 }
 
 export class ConflictError extends BaseGraphQLError {
-  constructor(message: string, extensions?: Record<string, any>) {
-    super(message, 'CONFLICT', { ...extensions, http: { status: 409 } });
+  constructor(message: string) {
+    super(message, ErrorCode.CONFLICT);
 
     Object.defineProperty(this, 'name', { value: 'ConflictError' });
   }
 }
 
 export class TimeoutError extends BaseGraphQLError {
-  constructor(message: string, extensions?: Record<string, any>) {
-    super(message, 'TIMEOUT', { ...extensions, http: { status: 408 } });
+  constructor(message: string) {
+    super(message, ErrorCode.TIMEOUT);
 
     Object.defineProperty(this, 'name', { value: 'TimeoutError' });
   }


### PR DESCRIPTION
Graphql errors are not properly filtered by our handler. We still receive errors like `NOT_FOUND` in sentry while they should be filtered. Example [here](https://twenty-v7.sentry.io/issues/5490383016/?environment=prod&project=4507072499810304&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=7d&stream_index=6).

We associate statuses with errors in our map `graphQLPredefinedExceptions` but we cannot retrieve the status from the error. 

This PR lists the codes that should be filtered.

To test:
- call `findDuplicates` with an invalid id
- before, server would breaks
- now the error is simply returned

