### PR TITLE
Fix secondaryLinks field input

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/LinksFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/LinksFieldInput.tsx
@@ -151,7 +151,7 @@ export const LinksFieldInput = ({ onCancel }: LinksFieldInputProps) => {
           <DropdownMenuSeparator />
         </>
       )}
-      {isInputDisplayed ? (
+      {isInputDisplayed || !links.length ? (
         <DropdownMenuInput
           autoFocus
           placeholder="URL"

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/composite-types/links.composite-type.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/composite-types/links.composite-type.ts
@@ -20,7 +20,7 @@ export const linksCompositeType: CompositeType = {
     {
       name: 'secondaryLinks',
       type: FieldMetadataType.RAW_JSON,
-      hidden: 'input',
+      hidden: false,
       isRequired: false,
     },
   ],


### PR DESCRIPTION
PR https://github.com/twentyhq/twenty/pull/5785/files broke links update.

Also, dropdown "Add link" will be displayed only if a link is already added. Otherwise, it should be a normal input.