### PR TITLE
Add South Korean won to currency codes

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/types/CurrencyCode.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/types/CurrencyCode.ts
@@ -14,4 +14,5 @@ export enum CurrencyCode {
   MAD = 'MAD',
   QAR = 'QAR',
   AED = 'AED',
+  KRW = 'KRW',
 }

--- a/packages/twenty-front/src/modules/settings/data-model/constants/SettingsFieldCurrencyCodes.ts
+++ b/packages/twenty-front/src/modules/settings/data-model/constants/SettingsFieldCurrencyCodes.ts
@@ -9,6 +9,7 @@ import {
   IconCurrencyKroneSwedish,
   IconCurrencyPound,
   IconCurrencyRiyal,
+  IconCurrencyWon,
   IconCurrencyYen,
   IconCurrencyYuan,
 } from 'twenty-ui';
@@ -78,5 +79,9 @@ export const SETTINGS_FIELD_CURRENCY_CODES: Record<
   AED: {
     label: 'UAE dirham',
     Icon: IconCurrencyDirham,
+  },
+  KRW: {
+    label: 'South Korean won',
+    Icon: IconCurrencyWon,
   },
 };

--- a/packages/twenty-ui/src/display/icon/components/TablerIcons.ts
+++ b/packages/twenty-ui/src/display/icon/components/TablerIcons.ts
@@ -61,6 +61,7 @@ export {
   IconCurrencyKroneSwedish,
   IconCurrencyPound,
   IconCurrencyRiyal,
+  IconCurrencyWon,
   IconCurrencyYen,
   IconCurrencyYuan,
   IconDatabase,


### PR DESCRIPTION
Greetings from Seoul! I found this amazing project a few days ago, and trying to introduce it to my team. However there is a tiny but significant problem, that South Korean won is not available in twenty. 

So I added `KRW` to the enum `CurrencyCode` and the constant `SETTINGS_FIELD_CURRENCY_CODES`. I tested it locally and apparently works fine.