### PR TITLE
Handle no concurrency option

### DIFF
--- a/packages/twenty-server/src/engine/integrations/message-queue/drivers/pg-boss.driver.ts
+++ b/packages/twenty-server/src/engine/integrations/message-queue/drivers/pg-boss.driver.ts
@@ -41,9 +41,11 @@ export class PgBossDriver
   ) {
     return this.pgBoss.work<T>(
       `${queueName}.*`,
-      {
-        teamConcurrency: options?.concurrency,
-      },
+      options?.concurrency
+        ? {
+            teamConcurrency: options.concurrency,
+          }
+        : {},
       async (job) => {
         await handler({ data: job.data, id: job.id, name: job.name });
       },


### PR DESCRIPTION
Fix error in local `teamConcurrency must be an integer between 1 and 1000`