### PR TITLE
Fix(view): `Create` Button is not visible when creating `Kanban` View

### DIFF
--- a/packages/twenty-front/src/modules/views/view-picker/components/ViewPickerDropdown.tsx
+++ b/packages/twenty-front/src/modules/views/view-picker/components/ViewPickerDropdown.tsx
@@ -1,6 +1,6 @@
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 import {
   IconChevronDown,
   IconList,
@@ -19,6 +19,7 @@ import { ViewPickerListContent } from '@/views/view-picker/components/ViewPicker
 import { VIEW_PICKER_DROPDOWN_ID } from '@/views/view-picker/constants/ViewPickerDropdownId';
 import { useViewPickerMode } from '@/views/view-picker/hooks/useViewPickerMode';
 import { useViewPickerPersistView } from '@/views/view-picker/hooks/useViewPickerPersistView';
+import { useViewPickerStates } from '@/views/view-picker/hooks/useViewPickerStates';
 import { isDefined } from '~/utils/isDefined';
 
 import { useViewStates } from '../../hooks/internal/useViewStates';
@@ -52,6 +53,8 @@ export const ViewPickerDropdown = () => {
 
   const { entityCountInCurrentViewState } = useViewStates();
 
+  const { viewPickerIsDirtyState } = useViewPickerStates();
+
   const { currentViewWithCombinedFiltersAndSorts } = useGetCurrentView();
 
   const { handleUpdate } = useViewPickerPersistView();
@@ -59,6 +62,8 @@ export const ViewPickerDropdown = () => {
   const entityCountInCurrentView = useRecoilValue(
     entityCountInCurrentViewState,
   );
+
+  const setViewPickerIsDirty = useSetRecoilState(viewPickerIsDirtyState);
 
   const { isDropdownOpen: isViewsListDropdownOpen } = useDropdown(
     VIEW_PICKER_DROPDOWN_ID,
@@ -70,6 +75,7 @@ export const ViewPickerDropdown = () => {
   const CurrentViewIcon = getIcon(currentViewWithCombinedFiltersAndSorts?.icon);
 
   const handleClickOutside = async () => {
+    setViewPickerIsDirty(false);
     if (isViewsListDropdownOpen && viewPickerMode === 'edit') {
       await handleUpdate();
     }

--- a/packages/twenty-front/src/modules/views/view-picker/hooks/useGetAvailableFieldsForKanban.ts
+++ b/packages/twenty-front/src/modules/views/view-picker/hooks/useGetAvailableFieldsForKanban.ts
@@ -1,8 +1,9 @@
 import { useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 import { objectMetadataItemsState } from '@/object-metadata/states/objectMetadataItemsState';
+import { navigationMemorizedUrlState } from '@/ui/navigation/states/navigationMemorizedUrlState';
 import { useViewStates } from '@/views/hooks/internal/useViewStates';
 import { useViewPickerStates } from '@/views/view-picker/hooks/useViewPickerStates';
 import { FieldMetadataType } from '~/generated-metadata/graphql';
@@ -14,6 +15,10 @@ export const useGetAvailableFieldsForKanban = () => {
   const viewObjectMetadataId = useRecoilValue(viewObjectMetadataIdState);
   const objectMetadataItems = useRecoilValue(objectMetadataItemsState);
   const setViewPickerIsDirty = useSetRecoilState(viewPickerIsDirtyState);
+  const setNavigationMemorizedUrl = useSetRecoilState(
+    navigationMemorizedUrlState,
+  );
+  const location = useLocation();
 
   const objectMetadataItem = objectMetadataItems.find(
     (objectMetadata) => objectMetadata.id === viewObjectMetadataId,
@@ -28,8 +33,17 @@ export const useGetAvailableFieldsForKanban = () => {
 
   const navigateToSelectSettings = useCallback(() => {
     setViewPickerIsDirty(false);
+
+    setNavigationMemorizedUrl(location.pathname + location.search);
+
     navigate(`/settings/objects/${objectMetadataItem?.namePlural}`);
-  }, [navigate, objectMetadataItem?.namePlural, setViewPickerIsDirty]);
+  }, [
+    navigate,
+    objectMetadataItem?.namePlural,
+    setViewPickerIsDirty,
+    setNavigationMemorizedUrl,
+    location,
+  ]);
 
   return {
     availableFieldsForKanban,

--- a/packages/twenty-front/src/modules/views/view-picker/hooks/useGetAvailableFieldsForKanban.ts
+++ b/packages/twenty-front/src/modules/views/view-picker/hooks/useGetAvailableFieldsForKanban.ts
@@ -1,16 +1,19 @@
 import { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 import { objectMetadataItemsState } from '@/object-metadata/states/objectMetadataItemsState';
 import { useViewStates } from '@/views/hooks/internal/useViewStates';
+import { useViewPickerStates } from '@/views/view-picker/hooks/useViewPickerStates';
 import { FieldMetadataType } from '~/generated-metadata/graphql';
 
 export const useGetAvailableFieldsForKanban = () => {
   const { viewObjectMetadataIdState } = useViewStates();
+  const { viewPickerIsDirtyState } = useViewPickerStates();
 
   const viewObjectMetadataId = useRecoilValue(viewObjectMetadataIdState);
   const objectMetadataItems = useRecoilValue(objectMetadataItemsState);
+  const setViewPickerIsDirty = useSetRecoilState(viewPickerIsDirtyState);
 
   const objectMetadataItem = objectMetadataItems.find(
     (objectMetadata) => objectMetadata.id === viewObjectMetadataId,
@@ -24,8 +27,9 @@ export const useGetAvailableFieldsForKanban = () => {
   const navigate = useNavigate();
 
   const navigateToSelectSettings = useCallback(() => {
+    setViewPickerIsDirty(false);
     navigate(`/settings/objects/${objectMetadataItem?.namePlural}`);
-  }, [navigate, objectMetadataItem?.namePlural]);
+  }, [navigate, objectMetadataItem?.namePlural, setViewPickerIsDirty]);
 
   return {
     availableFieldsForKanban,


### PR DESCRIPTION
Closes #5915 

This issue occurs only when there is no select field.

The user then creates a new one in settings and returns back to the view picker.
And the bug arises, it because `viewPickerKanbanFieldMetadataId` is not being set correctly.

When a user navigate to settings, the dirty state should be set to false. As a result, after re-rendering the view picker component, it triggers the effect to set `viewPickerKanbanFieldMetadataId`