### PR TITLE
feat: add brazilian real currency

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/types/CurrencyCode.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/types/CurrencyCode.ts
@@ -15,4 +15,5 @@ export enum CurrencyCode {
   QAR = 'QAR',
   AED = 'AED',
   KRW = 'KRW',
+  BRL = 'BRL',
 }

--- a/packages/twenty-front/src/modules/settings/data-model/constants/SettingsFieldCurrencyCodes.ts
+++ b/packages/twenty-front/src/modules/settings/data-model/constants/SettingsFieldCurrencyCodes.ts
@@ -8,6 +8,7 @@ import {
   IconCurrencyKroneCzech,
   IconCurrencyKroneSwedish,
   IconCurrencyPound,
+  IconCurrencyReal,
   IconCurrencyRiyal,
   IconCurrencyWon,
   IconCurrencyYen,
@@ -84,4 +85,8 @@ export const SETTINGS_FIELD_CURRENCY_CODES: Record<
     label: 'South Korean won',
     Icon: IconCurrencyWon,
   },
+  BRL: {
+    label: 'Brazilian real',
+    Icon: IconCurrencyReal,
+  }
 };

--- a/packages/twenty-ui/src/display/icon/components/TablerIcons.ts
+++ b/packages/twenty-ui/src/display/icon/components/TablerIcons.ts
@@ -60,6 +60,7 @@ export {
   IconCurrencyKroneCzech,
   IconCurrencyKroneSwedish,
   IconCurrencyPound,
+  IconCurrencyReal,
   IconCurrencyRiyal,
   IconCurrencyWon,
   IconCurrencyYen,


### PR DESCRIPTION
Added support to Brazilian Real currency code, added the new code on `CurrencyCode.ts` and on `SETTINGS_FIELD_CURRENCY_CODES`