### PR TITLE
feat: add australian dollar currency

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/types/CurrencyCode.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/types/CurrencyCode.ts
@@ -16,4 +16,5 @@ export enum CurrencyCode {
   AED = 'AED',
   KRW = 'KRW',
   BRL = 'BRL',
+  AUD = 'AUD',
 }

--- a/packages/twenty-front/src/modules/settings/data-model/constants/SettingsFieldCurrencyCodes.ts
+++ b/packages/twenty-front/src/modules/settings/data-model/constants/SettingsFieldCurrencyCodes.ts
@@ -88,5 +88,9 @@ export const SETTINGS_FIELD_CURRENCY_CODES: Record<
   BRL: {
     label: 'Brazilian real',
     Icon: IconCurrencyReal,
+  },
+  AUD: {
+    label: 'Australian dollar',
+    Icon: IconCurrencyDollar,
   }
 };

--- a/packages/twenty-front/src/modules/settings/data-model/constants/SettingsFieldCurrencyCodes.ts
+++ b/packages/twenty-front/src/modules/settings/data-model/constants/SettingsFieldCurrencyCodes.ts
@@ -92,5 +92,5 @@ export const SETTINGS_FIELD_CURRENCY_CODES: Record<
   AUD: {
     label: 'Australian dollar',
     Icon: IconCurrencyDollar,
-  }
+  },
 };


### PR DESCRIPTION
Hi Twenty team,
I'd love to have Australian dollar as an option in Twenty! Please let me me know if I have missed anything I need to change to enable this.
Thanks for a a great product