### PR TITLE
Fix infinite scroll issue on table

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-index/hooks/useLoadRecordIndexTable.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/hooks/useLoadRecordIndexTable.ts
@@ -1,4 +1,4 @@
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilValue } from 'recoil';
 
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
@@ -41,8 +41,6 @@ export const useLoadRecordIndexTable = (objectNameSingular: string) => {
 
   const { setRecordTableData, setIsRecordTableInitialLoading } =
     useRecordTable();
-  const { tableLastRowVisibleState } = useRecordTableStates();
-  const setLastRowVisible = useSetRecoilState(tableLastRowVisibleState);
   const currentWorkspace = useRecoilValue(currentWorkspaceState);
   const params = useFindManyParams(objectNameSingular);
 
@@ -58,7 +56,6 @@ export const useLoadRecordIndexTable = (objectNameSingular: string) => {
     ...params,
     recordGqlFields,
     onCompleted: () => {
-      setLastRowVisible(false);
       setIsRecordTableInitialLoading(false);
     },
     onError: () => {

--- a/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableBodyEffect.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableBodyEffect.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useRecoilValue } from 'recoil';
 
 import { useLoadRecordIndexTable } from '@/object-record/record-index/hooks/useLoadRecordIndexTable';
 import { useRecordTableStates } from '@/object-record/record-table/hooks/internal/useRecordTableStates';
+import { isFetchingMoreRecordsFamilyState } from '@/object-record/states/isFetchingMoreRecordsFamilyState';
 import { useScrollRestoration } from '~/hooks/useScrollRestoration';
 
 type RecordTableBodyEffectProps = {
@@ -18,10 +19,12 @@ export const RecordTableBodyEffect = ({
     totalCount,
     setRecordTableData,
     loading,
+    queryStateIdentifier,
   } = useLoadRecordIndexTable(objectNameSingular);
 
-  const [isFetchingMoreObjects, setIsFetchingMoreObjects] =
-    useState<boolean>(false);
+  const isFetchingMoreObjects = useRecoilValue(
+    isFetchingMoreRecordsFamilyState(queryStateIdentifier),
+  );
 
   const { tableLastRowVisibleState } = useRecordTableStates();
 
@@ -39,12 +42,10 @@ export const RecordTableBodyEffect = ({
   }, [records, totalCount, setRecordTableData, loading]);
 
   useEffect(() => {
-    // We are adding a setTimeout here to give the user some room to scroll if they want to
+    // We are adding a setTimeout here to give the user some room to scroll if they want to within this throttle window
     setTimeout(async () => {
       if (!isFetchingMoreObjects && tableLastRowVisible) {
-        setIsFetchingMoreObjects(true);
         await fetchMoreObjects();
-        setIsFetchingMoreObjects(false);
       }
     }, 100);
   }, [fetchMoreObjects, isFetchingMoreObjects, tableLastRowVisible]);

--- a/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableBodyLoading.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableBodyLoading.tsx
@@ -20,6 +20,7 @@ export const RecordTableBodyLoading = () => {
           isDragging={false}
           data-testid={`row-id-${rowIndex}`}
           data-selectable-id={`row-id-${rowIndex}`}
+          key={rowIndex}
         >
           <StyledTd data-select-disable>
             <GripCell isDragging={false} />


### PR DESCRIPTION
We had an issue on infinite scroll on table view.
The fetch more logic was modifying isTableLastRowVisible state (which is wrong, how could it know)? This was done to prevent loading too much data at once. This was causing some race condition on isTableLastRowVisible (as the table itself was also changing it depending on the real visibility of the line)

I have remove this hacky usage of isTableLastRowVisible and replaced it by a setTimeout to let the user some time to scroll and introduce a throttle logic.