### PR TITLE
Remove multi select usage

### DIFF
--- a/packages/twenty-front/src/modules/object-metadata/utils/formatFieldMetadataItemsAsFilterDefinitions.ts
+++ b/packages/twenty-front/src/modules/object-metadata/utils/formatFieldMetadataItemsAsFilterDefinitions.ts
@@ -22,7 +22,6 @@ export const formatFieldMetadataItemsAsFilterDefinitions = ({
         FieldMetadataType.Address,
         FieldMetadataType.Relation,
         FieldMetadataType.Select,
-        FieldMetadataType.MultiSelect,
         FieldMetadataType.Currency,
       ].includes(field.type)
     ) {

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-runner/services/workspace-migration-enum.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-runner/services/workspace-migration-enum.service.ts
@@ -49,10 +49,6 @@ export class WorkspaceMigrationEnumService {
         typeof enumValue !== 'string',
     );
 
-    if (!columnDefinition.isNullable && !columnDefinition.defaultValue) {
-      columnDefinition.defaultValue = serializeDefaultValue(enumValues[0]);
-    }
-
     const oldColumnName = `${columnDefinition.columnName}_old_${v4()}`;
 
     // Rename old column


### PR DESCRIPTION
As per title!

Also, I'm removing an incorrect logic in the enum migration runner that takes care of the case where we have no defaultValue but non nullable which is not a valid business case.