### PR TITLE
Add calendar cron command on self-hosting-var.mdx

### DIFF
--- a/packages/twenty-website/src/content/developers/self-hosting/self-hosting-var.mdx
+++ b/packages/twenty-website/src/content/developers/self-hosting/self-hosting-var.mdx
@@ -13,6 +13,7 @@ Twenty offers integrations with Gmail and Google Calendar. To enable these featu
 # from your worker container
 yarn command:prod cron:messaging:messages-import
 yarn command:prod cron:messaging:message-list-fetch
+yarn command:prod cron:calendar:google-calendar-sync
 ```
 
 # Setup Environment Variables


### PR DESCRIPTION
To enable Google Calendar integration, you need to run `yarn command:prod cron:calendar:google-calendar-sync` in the worker container. However, currently, the self-hosting guide does not tell you how to do it. If you just follow the guide, only Gmail integration will be enabled. So I added the command for calendar sync cron on self-hosting-var.mdx.