### PR TITLE
Fix sign up broken because of missing workspace schema

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/data-source/data-source.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/data-source/data-source.service.ts
@@ -46,6 +46,15 @@ export class DataSourceService {
     });
   }
 
+  async getLastDataSourceMetadataFromWorkspaceId(
+    workspaceId: string,
+  ): Promise<DataSourceEntity | null> {
+    return this.dataSourceMetadataRepository.findOne({
+      where: { workspaceId },
+      order: { createdAt: 'DESC' },
+    });
+  }
+
   async getLastDataSourceMetadataFromWorkspaceIdOrFail(
     workspaceId: string,
   ): Promise<DataSourceEntity> {

--- a/packages/twenty-server/src/engine/twenty-orm/factories/workspace-datasource.factory.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/factories/workspace-datasource.factory.ts
@@ -14,7 +14,10 @@ export class WorkspaceDatasourceFactory {
     private readonly environmentService: EnvironmentService,
   ) {}
 
-  public async create(entities: EntitySchema[], workspaceId: string) {
+  public async create(
+    entities: EntitySchema[],
+    workspaceId: string,
+  ): Promise<WorkspaceDataSource | null> {
     const storedWorkspaceDataSource =
       DataSourceStorage.getDataSource(workspaceId);
 
@@ -23,9 +26,13 @@ export class WorkspaceDatasourceFactory {
     }
 
     const dataSourceMetadata =
-      await this.dataSourceService.getLastDataSourceMetadataFromWorkspaceIdOrFail(
+      await this.dataSourceService.getLastDataSourceMetadataFromWorkspaceId(
         workspaceId,
       );
+
+    if (!dataSourceMetadata) {
+      return null;
+    }
 
     const workspaceDataSource = new WorkspaceDataSource({
       url:

--- a/packages/twenty-server/src/engine/twenty-orm/twenty-orm.manager.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/twenty-orm.manager.ts
@@ -35,6 +35,11 @@ export class TwentyORMManager {
       entities,
       workspaceId,
     );
+
+    if (!workspaceDataSource) {
+      throw new Error('Workspace data source not found');
+    }
+
     const entitySchema = this.entitySchemaFactory.create(entityClass);
 
     return workspaceDataSource.getRepository<T>(entitySchema);


### PR DESCRIPTION
Allow workspace datasource factory to return null if the workspace schema has not been created yet