### PR TITLE
Use dynamic z indexes + use outline

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-table/components/GripCell.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/components/GripCell.tsx
@@ -6,7 +6,6 @@ const StyledContainer = styled.div`
   cursor: grab;
   width: 16px;
   height: 32px;
-  z-index: 200;
   display: flex;
   &:hover .icon {
     opacity: 1;

--- a/packages/twenty-front/src/modules/object-record/record-table/components/RecordTable.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/components/RecordTable.tsx
@@ -22,9 +22,13 @@ import { useUpsertRecordV2 } from '@/object-record/record-table/record-table-cel
 import { RecordTableScope } from '@/object-record/record-table/scopes/RecordTableScope';
 import { MoveFocusDirection } from '@/object-record/record-table/types/MoveFocusDirection';
 import { TableCellPosition } from '@/object-record/record-table/types/TableCellPosition';
+import { scrollLeftState } from '@/ui/utilities/scroll/states/scrollLeftState';
+import { scrollTopState } from '@/ui/utilities/scroll/states/scrollTopState';
 
 const StyledTable = styled.table<{
   freezeFirstColumns?: boolean;
+  isScrolledLeft?: boolean;
+  isScrolledTop?: boolean;
 }>`
   border-radius: ${({ theme }) => theme.border.radius.sm};
   border-spacing: 0;
@@ -74,13 +78,14 @@ const StyledTable = styled.table<{
   thead th {
     position: sticky;
     top: 0;
-    z-index: 9;
+    z-index: ${({ isScrolledTop }) => (isScrolledTop ? 3 : 1)};
   }
 
   thead th:nth-of-type(1),
   thead th:nth-of-type(2),
   thead th:nth-of-type(3) {
-    z-index: 12;
+    z-index: ${({ isScrolledTop, isScrolledLeft }) =>
+      isScrolledTop ? 4 : isScrolledLeft ? 3 : 2};
     background-color: ${({ theme }) => theme.background.primary};
   }
 
@@ -103,22 +108,19 @@ const StyledTable = styled.table<{
   tbody td:nth-of-type(2),
   tbody td:nth-of-type(3) {
     position: sticky;
-    z-index: 1;
+    z-index: ${({ isScrolledLeft }) => (isScrolledLeft ? 3 : 2)};
   }
 
   tbody td:nth-of-type(1) {
     left: 0;
-    z-index: 7;
   }
 
   tbody td:nth-of-type(2) {
     left: 9px;
-    z-index: 5;
   }
 
   tbody td:nth-of-type(3) {
     left: 39px;
-    z-index: 6;
   }
 
   thead th:nth-of-type(3),
@@ -226,6 +228,12 @@ export const RecordTable = ({
 
   const visibleTableColumns = useRecoilValue(visibleTableColumnsSelector());
 
+  const scrollLeft = useRecoilValue(scrollLeftState);
+  const scrollTop = useRecoilValue(scrollTopState);
+
+  const isScrolledTop = scrollTop > 0;
+  const isScrolledLeft = scrollLeft > 0;
+
   return (
     <RecordTableScope
       recordTableScopeId={scopeId}
@@ -245,7 +253,11 @@ export const RecordTable = ({
             visibleTableColumns,
           }}
         >
-          <StyledTable className="entity-table-cell">
+          <StyledTable
+            className="entity-table-cell"
+            isScrolledLeft={isScrolledLeft}
+            isScrolledTop={isScrolledTop}
+          >
             <RecordTableHeader createRecord={createRecord} />
             <RecordTableBodyEffect objectNameSingular={objectNameSingular} />
             <RecordTableBody

--- a/packages/twenty-front/src/modules/object-record/record-table/components/RecordTable.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/components/RecordTable.tsx
@@ -22,8 +22,6 @@ import { useUpsertRecordV2 } from '@/object-record/record-table/record-table-cel
 import { RecordTableScope } from '@/object-record/record-table/scopes/RecordTableScope';
 import { MoveFocusDirection } from '@/object-record/record-table/types/MoveFocusDirection';
 import { TableCellPosition } from '@/object-record/record-table/types/TableCellPosition';
-import { scrollLeftState } from '@/ui/utilities/scroll/states/scrollLeftState';
-import { scrollTopState } from '@/ui/utilities/scroll/states/scrollTopState';
 
 const StyledTable = styled.table<{
   freezeFirstColumns?: boolean;
@@ -166,8 +164,12 @@ export const RecordTable = ({
   onColumnsChange,
   createRecord,
 }: RecordTableProps) => {
-  const { scopeId, visibleTableColumnsSelector } =
-    useRecordTableStates(recordTableId);
+  const {
+    scopeId,
+    visibleTableColumnsSelector,
+    isScrolledLeftSelector,
+    isScrolledTopSelector,
+  } = useRecordTableStates(recordTableId);
 
   const { objectMetadataItem } = useObjectMetadataItem({
     objectNameSingular,
@@ -228,11 +230,8 @@ export const RecordTable = ({
 
   const visibleTableColumns = useRecoilValue(visibleTableColumnsSelector());
 
-  const scrollLeft = useRecoilValue(scrollLeftState);
-  const scrollTop = useRecoilValue(scrollTopState);
-
-  const isScrolledTop = scrollTop > 0;
-  const isScrolledLeft = scrollLeft > 0;
+  const isScrolledLeft = useRecoilValue(isScrolledLeftSelector());
+  const isScrolledTop = useRecoilValue(isScrolledTopSelector());
 
   return (
     <RecordTableScope

--- a/packages/twenty-front/src/modules/object-record/record-table/components/RecordTable.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/components/RecordTable.tsx
@@ -87,13 +87,6 @@ const StyledTable = styled.table<{
     left: 39px;
   }
 
-  tbody td:nth-of-type(1),
-  tbody td:nth-of-type(2),
-  tbody td:nth-of-type(3) {
-    position: sticky;
-    z-index: ${({ isScrolledLeft }) => (isScrolledLeft ? 3 : 2)};
-  }
-
   tbody td:nth-of-type(1) {
     left: 0;
   }
@@ -149,7 +142,7 @@ export const RecordTable = ({
   onColumnsChange,
   createRecord,
 }: RecordTableProps) => {
-  const { scopeId, visibleTableColumnsSelector, isScrolledLeftSelector } =
+  const { scopeId, visibleTableColumnsSelector } =
     useRecordTableStates(recordTableId);
 
   const { objectMetadataItem } = useObjectMetadataItem({
@@ -211,8 +204,6 @@ export const RecordTable = ({
 
   const visibleTableColumns = useRecoilValue(visibleTableColumnsSelector());
 
-  const isScrolledLeft = useRecoilValue(isScrolledLeftSelector());
-
   return (
     <RecordTableScope
       recordTableScopeId={scopeId}
@@ -232,10 +223,7 @@ export const RecordTable = ({
             visibleTableColumns,
           }}
         >
-          <StyledTable
-            className="entity-table-cell"
-            isScrolledLeft={isScrolledLeft}
-          >
+          <StyledTable className="entity-table-cell">
             <RecordTableHeader createRecord={createRecord} />
             <RecordTableBodyEffect objectNameSingular={objectNameSingular} />
             <RecordTableBody

--- a/packages/twenty-front/src/modules/object-record/record-table/components/RecordTable.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/components/RecordTable.tsx
@@ -26,7 +26,6 @@ import { TableCellPosition } from '@/object-record/record-table/types/TableCellP
 const StyledTable = styled.table<{
   freezeFirstColumns?: boolean;
   isScrolledLeft?: boolean;
-  isScrolledTop?: boolean;
 }>`
   border-radius: ${({ theme }) => theme.border.radius.sm};
   border-spacing: 0;
@@ -71,20 +70,6 @@ const StyledTable = styled.table<{
   th {
     background-color: ${({ theme }) => theme.background.primary};
     border-right: 1px solid ${({ theme }) => theme.border.color.light};
-  }
-
-  thead th {
-    position: sticky;
-    top: 0;
-    z-index: ${({ isScrolledTop }) => (isScrolledTop ? 3 : 1)};
-  }
-
-  thead th:nth-of-type(1),
-  thead th:nth-of-type(2),
-  thead th:nth-of-type(3) {
-    z-index: ${({ isScrolledTop, isScrolledLeft }) =>
-      isScrolledTop ? 4 : isScrolledLeft ? 3 : 2};
-    background-color: ${({ theme }) => theme.background.primary};
   }
 
   thead th:nth-of-type(1) {
@@ -164,12 +149,8 @@ export const RecordTable = ({
   onColumnsChange,
   createRecord,
 }: RecordTableProps) => {
-  const {
-    scopeId,
-    visibleTableColumnsSelector,
-    isScrolledLeftSelector,
-    isScrolledTopSelector,
-  } = useRecordTableStates(recordTableId);
+  const { scopeId, visibleTableColumnsSelector, isScrolledLeftSelector } =
+    useRecordTableStates(recordTableId);
 
   const { objectMetadataItem } = useObjectMetadataItem({
     objectNameSingular,
@@ -231,7 +212,6 @@ export const RecordTable = ({
   const visibleTableColumns = useRecoilValue(visibleTableColumnsSelector());
 
   const isScrolledLeft = useRecoilValue(isScrolledLeftSelector());
-  const isScrolledTop = useRecoilValue(isScrolledTopSelector());
 
   return (
     <RecordTableScope
@@ -255,7 +235,6 @@ export const RecordTable = ({
           <StyledTable
             className="entity-table-cell"
             isScrolledLeft={isScrolledLeft}
-            isScrolledTop={isScrolledTop}
           >
             <RecordTableHeader createRecord={createRecord} />
             <RecordTableBodyEffect objectNameSingular={objectNameSingular} />

--- a/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableHeader.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableHeader.tsx
@@ -33,7 +33,6 @@ const StyledPlusIconHeaderCell = styled.th<{ isTableWiderThanScreen: boolean }>`
     border-right: none !important;
     background-color: ${theme.background.primary};
     `};
-  z-index: 1;
 `;
 
 const StyledPlusIconContainer = styled.div`

--- a/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableHeader.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableHeader.tsx
@@ -11,8 +11,24 @@ import { useScrollWrapperScopedRef } from '@/ui/utilities/scroll/hooks/useScroll
 import { RecordTableHeaderPlusButtonContent } from './RecordTableHeaderPlusButtonContent';
 import { SelectAllCheckbox } from './SelectAllCheckbox';
 
-const StyledTableHead = styled.thead`
+const StyledTableHead = styled.thead<{
+  isScrolledLeft?: boolean;
+  isScrolledTop?: boolean;
+}>`
   cursor: pointer;
+
+  th {
+    position: sticky;
+    top: 0;
+    z-index: ${({ isScrolledTop }) => (isScrolledTop ? 3 : 1)};
+  }
+
+  th:nth-of-type(1),
+  th:nth-of-type(2),
+  th:nth-of-type(3) {
+    z-index: ${({ isScrolledTop, isScrolledLeft }) =>
+      isScrolledTop ? 4 : isScrolledLeft ? 3 : 2};
+  }
 `;
 
 const StyledPlusIconHeaderCell = styled.th<{ isTableWiderThanScreen: boolean }>`
@@ -54,7 +70,11 @@ export const RecordTableHeader = ({
 }: {
   createRecord: () => void;
 }) => {
-  const { visibleTableColumnsSelector } = useRecordTableStates();
+  const {
+    visibleTableColumnsSelector,
+    isScrolledLeftSelector,
+    isScrolledTopSelector,
+  } = useRecordTableStates();
 
   const scrollWrapper = useScrollWrapperScopedRef();
   const isTableWiderThanScreen =
@@ -66,8 +86,14 @@ export const RecordTableHeader = ({
 
   const theme = useTheme();
 
+  const isScrolledLeft = useRecoilValue(isScrolledLeftSelector());
+  const isScrolledTop = useRecoilValue(isScrolledTopSelector());
   return (
-    <StyledTableHead data-select-disable>
+    <StyledTableHead
+      data-select-disable
+      isScrolledLeft={isScrolledLeft}
+      isScrolledTop={isScrolledTop}
+    >
       <tr>
         <th></th>
         <th

--- a/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableHeaderCell.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableHeaderCell.tsx
@@ -63,7 +63,6 @@ const StyledResizeHandler = styled.div`
   right: -9px;
   top: 0;
   width: 3px;
-  z-index: 1;
 `;
 
 const StyledColumnHeadContainer = styled.div`
@@ -71,7 +70,6 @@ const StyledColumnHeadContainer = styled.div`
   flex-direction: row;
   justify-content: space-between;
   position: relative;
-  z-index: 1;
 `;
 
 const StyledHeaderIcon = styled.div`

--- a/packages/twenty-front/src/modules/object-record/record-table/hooks/internal/useRecordTableStates.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/hooks/internal/useRecordTableStates.ts
@@ -27,6 +27,8 @@ import { tableRowIdsComponentState } from '@/object-record/record-table/states/t
 import { tableSortsComponentState } from '@/object-record/record-table/states/tableSortsComponentState';
 import { useAvailableScopeIdOrThrow } from '@/ui/utilities/recoil-scope/scopes-internal/hooks/useAvailableScopeId';
 import { getScopeIdOrUndefinedFromComponentId } from '@/ui/utilities/recoil-scope/utils/getScopeIdOrUndefinedFromComponentId';
+import { isScrolledLeftSelector } from '@/ui/utilities/scroll/states/selectors/isScrolledLeftSelector';
+import { isScrolledTopSelector } from '@/ui/utilities/scroll/states/selectors/isScrolledTopSelector';
 import { extractComponentFamilyState } from '@/ui/utilities/state/component-state/utils/extractComponentFamilyState';
 import { extractComponentReadOnlySelector } from '@/ui/utilities/state/component-state/utils/extractComponentReadOnlySelector';
 import { extractComponentState } from '@/ui/utilities/state/component-state/utils/extractComponentState';
@@ -135,6 +137,14 @@ export const useRecordTableStates = (recordTableId?: string) => {
     ),
     pendingRecordIdState: extractComponentState(
       recordTablePendingRecordIdComponentState,
+      scopeId,
+    ),
+    isScrolledLeftSelector: extractComponentReadOnlySelector(
+      isScrolledLeftSelector,
+      scopeId,
+    ),
+    isScrolledTopSelector: extractComponentReadOnlySelector(
+      isScrolledTopSelector,
       scopeId,
     ),
   };

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellContainer.module.css
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellContainer.module.css
@@ -1,11 +1,3 @@
-.td-in-edit-mode {
-  z-index: 4 !important;
-}
-
-.td-not-in-edit-mode {
-  z-index: 3;
-}
-
 .td-is-selected {
   background: var(--twentycrm-accent-quaternary);
 }
@@ -27,6 +19,6 @@
 .cell-base-container-soft-focus {
   background: var(--twentycrm-background-transparent-secondary);
   border-radius: var(--twentycrm-border-radius-sm);
-  border: 1px solid var(--twentycrm-font-color-extra-light);
+  outline: 1px solid var(--twentycrm-font-color-extra-light);
+  z-index: 2;
 }
-

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellContainer.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellContainer.tsx
@@ -123,8 +123,6 @@ export const RecordTableCellContainer = ({
   return (
     <td
       className={clsx({
-        [styles.tdInEditMode]: isInEditMode,
-        [styles.tdNotInEditMode]: !isInEditMode,
         [styles.tdIsSelected]: isSelected,
         [styles.tdIsNotSelected]: !isSelected,
       })}

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellEditMode.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellEditMode.tsx
@@ -9,7 +9,6 @@ const StyledEditableCellEditModeContainer = styled.div<RecordTableCellEditModePr
   display: flex;
   min-width: 200px;
   width: calc(100% + 2px);
-  z-index: 1;
   height: 100%;
 `;
 
@@ -19,8 +18,6 @@ const StyledTableCellInput = styled.div`
 
   min-height: 32px;
   min-width: 200px;
-
-  z-index: 10;
 `;
 
 export type RecordTableCellEditModeProps = {

--- a/packages/twenty-front/src/modules/ui/layout/draggable-list/components/DraggableTableBody.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/draggable-list/components/DraggableTableBody.tsx
@@ -18,8 +18,14 @@ type DraggableTableBodyProps = {
   recordTableId: string;
 };
 
-const StyledTbody = styled.tbody`
+const StyledTbody = styled.tbody<{ isScrolledLeft?: boolean }>`
   overflow: hidden;
+  td:nth-of-type(1),
+  td:nth-of-type(2),
+  td:nth-of-type(3) {
+    position: sticky;
+    z-index: ${({ isScrolledLeft }) => (isScrolledLeft ? 3 : 2)};
+  }
 `;
 
 export const DraggableTableBody = ({
@@ -29,7 +35,7 @@ export const DraggableTableBody = ({
 }: DraggableTableBodyProps) => {
   const [v4Persistable] = useState(v4());
 
-  const { tableRowIdsState } = useRecordTableStates();
+  const { tableRowIdsState, isScrolledLeftSelector } = useRecordTableStates();
 
   const tableRowIds = useRecoilValue(tableRowIdsState);
 
@@ -67,12 +73,15 @@ export const DraggableTableBody = ({
     });
   };
 
+  const isScrolledLeft = useRecoilValue(isScrolledLeftSelector());
+
   return (
     <DragDropContext onDragEnd={handleDragEnd}>
       <Droppable droppableId={v4Persistable}>
         {(provided) => (
           <StyledTbody
             ref={provided.innerRef}
+            isScrolledLeft={isScrolledLeft}
             // eslint-disable-next-line react/jsx-props-no-spreading
             {...provided.droppableProps}
           >

--- a/packages/twenty-front/src/modules/ui/utilities/scroll/states/selectors/isScrolledLeftSelector.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/scroll/states/selectors/isScrolledLeftSelector.ts
@@ -1,0 +1,11 @@
+import { scrollLeftState } from '@/ui/utilities/scroll/states/scrollLeftState';
+import { createComponentReadOnlySelector } from '@/ui/utilities/state/component-state/utils/createComponentReadOnlySelector';
+
+export const isScrolledLeftSelector = createComponentReadOnlySelector({
+  key: 'isScrolledLeftSelector',
+  get:
+    () =>
+    ({ get }) => {
+      return get(scrollLeftState) > 0;
+    },
+});

--- a/packages/twenty-front/src/modules/ui/utilities/scroll/states/selectors/isScrolledTopSelector.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/scroll/states/selectors/isScrolledTopSelector.ts
@@ -1,0 +1,11 @@
+import { scrollTopState } from '@/ui/utilities/scroll/states/scrollTopState';
+import { createComponentReadOnlySelector } from '@/ui/utilities/state/component-state/utils/createComponentReadOnlySelector';
+
+export const isScrolledTopSelector = createComponentReadOnlySelector({
+  key: 'isScrolledTopSelector',
+  get:
+    () =>
+    ({ get }) => {
+      return get(scrollTopState) > 0;
+    },
+});


### PR DESCRIPTION
- Remove unused z-indexes
- Build dynamic z-indexes based on if the table is scrolled or not
- Use outline rather than border

Fix https://github.com/twentyhq/twenty/issues/5658

https://github.com/twentyhq/twenty/assets/22936103/ad90ab28-d217-4f82-9b59-cfcf0a5102d4

