### PR TITLE
Refactor messaging refresh access token

### DIFF
--- a/packages/twenty-server/src/modules/connected-account/services/google-api-refresh-access-token/google-api-refresh-access-token.service.ts
+++ b/packages/twenty-server/src/modules/connected-account/services/google-api-refresh-access-token/google-api-refresh-access-token.service.ts
@@ -6,10 +6,6 @@ import { EnvironmentService } from 'src/engine/integrations/environment/environm
 import { InjectObjectMetadataRepository } from 'src/engine/object-metadata-repository/object-metadata-repository.decorator';
 import { ConnectedAccountRepository } from 'src/modules/connected-account/repositories/connected-account.repository';
 import { ConnectedAccountWorkspaceEntity } from 'src/modules/connected-account/standard-objects/connected-account.workspace-entity';
-import { MessageChannelRepository } from 'src/modules/messaging/common/repositories/message-channel.repository';
-import { MessagingTelemetryService } from 'src/modules/messaging/common/services/messaging-telemetry.service';
-import { MessageChannelWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message-channel.workspace-entity';
-import { MessagingChannelSyncStatusService } from 'src/modules/messaging/common/services/messaging-channel-sync-status.service';
 
 @Injectable()
 export class GoogleAPIRefreshAccessTokenService {
@@ -17,10 +13,6 @@ export class GoogleAPIRefreshAccessTokenService {
     private readonly environmentService: EnvironmentService,
     @InjectObjectMetadataRepository(ConnectedAccountWorkspaceEntity)
     private readonly connectedAccountRepository: ConnectedAccountRepository,
-    @InjectObjectMetadataRepository(MessageChannelWorkspaceEntity)
-    private readonly messageChannelRepository: MessageChannelRepository,
-    private readonly messagingTelemetryService: MessagingTelemetryService,
-    private readonly messagingChannelSyncStatusService: MessagingChannelSyncStatusService,
   ) {}
 
   async refreshAndSaveAccessToken(
@@ -46,51 +38,13 @@ export class GoogleAPIRefreshAccessTokenService {
       );
     }
 
-    try {
-      const accessToken = await this.refreshAccessToken(refreshToken);
+    const accessToken = await this.refreshAccessToken(refreshToken);
 
-      await this.connectedAccountRepository.updateAccessToken(
-        accessToken,
-        connectedAccountId,
-        workspaceId,
-      );
-    } catch (error) {
-      const messageChannel =
-        await this.messageChannelRepository.getFirstByConnectedAccountId(
-          connectedAccountId,
-          workspaceId,
-        );
-
-      if (!messageChannel) {
-        throw new Error(
-          `No message channel found for connected account ${connectedAccountId} in workspace ${workspaceId}`,
-        );
-      }
-
-      await this.messagingTelemetryService.track({
-        eventName: `refresh_token.error.insufficient_permissions`,
-        workspaceId,
-        connectedAccountId: messageChannel.connectedAccountId,
-        messageChannelId: messageChannel.id,
-        message: `${error.code}: ${error.reason}`,
-      });
-
-      await this.messagingChannelSyncStatusService.markAsFailedInsufficientPermissionsAndFlushMessagesToImport(
-        messageChannel.id,
-        workspaceId,
-      );
-
-      if (!messageChannel.connectedAccountId) {
-        throw new Error(
-          `No connected account ID found for message channel ${messageChannel.id} in workspace ${workspaceId}`,
-        );
-      }
-
-      await this.connectedAccountRepository.updateAuthFailedAt(
-        messageChannel.connectedAccountId,
-        workspaceId,
-      );
-    }
+    await this.connectedAccountRepository.updateAccessToken(
+      accessToken,
+      connectedAccountId,
+      workspaceId,
+    );
   }
 
   async refreshAccessToken(refreshToken: string): Promise<string> {

--- a/packages/twenty-server/src/modules/connected-account/services/google-api-refresh-access-token/google-api-refresh-access-token.service.ts
+++ b/packages/twenty-server/src/modules/connected-account/services/google-api-refresh-access-token/google-api-refresh-access-token.service.ts
@@ -18,7 +18,7 @@ export class GoogleAPIRefreshAccessTokenService {
   async refreshAndSaveAccessToken(
     workspaceId: string,
     connectedAccountId: string,
-  ): Promise<void> {
+  ): Promise<string> {
     const connectedAccount = await this.connectedAccountRepository.getById(
       connectedAccountId,
       workspaceId,
@@ -45,6 +45,8 @@ export class GoogleAPIRefreshAccessTokenService {
       connectedAccountId,
       workspaceId,
     );
+
+    return accessToken;
   }
 
   async refreshAccessToken(refreshToken: string): Promise<string> {

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/messaging-gmail-fetch-messages-by-batches.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/messaging-gmail-fetch-messages-by-batches.service.ts
@@ -9,9 +9,6 @@ import { assert, assertNotNull } from 'src/utils/assert';
 import { GmailMessage } from 'src/modules/messaging/message-import-manager/drivers/gmail/types/gmail-message';
 import { formatAddressObjectAsParticipants } from 'src/modules/messaging/message-import-manager/utils/format-address-object-as-participants.util';
 import { MessagingFetchByBatchesService } from 'src/modules/messaging/common/services/messaging-fetch-by-batch.service';
-import { InjectObjectMetadataRepository } from 'src/engine/object-metadata-repository/object-metadata-repository.decorator';
-import { ConnectedAccountRepository } from 'src/modules/connected-account/repositories/connected-account.repository';
-import { ConnectedAccountWorkspaceEntity } from 'src/modules/connected-account/standard-objects/connected-account.workspace-entity';
 
 @Injectable()
 export class MessagingGmailFetchMessagesByBatchesService {
@@ -21,29 +18,15 @@ export class MessagingGmailFetchMessagesByBatchesService {
 
   constructor(
     private readonly fetchByBatchesService: MessagingFetchByBatchesService,
-    @InjectObjectMetadataRepository(ConnectedAccountWorkspaceEntity)
-    private readonly connectedAccountRepository: ConnectedAccountRepository,
   ) {}
 
   async fetchAllMessages(
     messageIds: string[],
+    accessToken: string,
     connectedAccountId: string,
     workspaceId: string,
   ): Promise<GmailMessage[]> {
     let startTime = Date.now();
-
-    const connectedAccount = await this.connectedAccountRepository.getById(
-      connectedAccountId,
-      workspaceId,
-    );
-
-    if (!connectedAccount) {
-      throw new Error(
-        `Connected account ${connectedAccountId} not found in workspace ${workspaceId}`,
-      );
-    }
-
-    const accessToken = connectedAccount.accessToken;
 
     const { messageIdsByBatch, batchResponses } =
       await this.fetchByBatchesService.fetchAllByBatches(

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/messaging-gmail-full-message-list-fetch.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/messaging-gmail-full-message-list-fetch.service.ts
@@ -23,9 +23,6 @@ import { MessagingChannelSyncStatusService } from 'src/modules/messaging/common/
 import { MessagingGmailClientProvider } from 'src/modules/messaging/message-import-manager/drivers/gmail/providers/messaging-gmail-client.provider';
 import { MESSAGING_GMAIL_USERS_MESSAGES_LIST_MAX_RESULT } from 'src/modules/messaging/message-import-manager/drivers/gmail/constants/messaging-gmail-users-messages-list-max-result.constant';
 import { MESSAGING_GMAIL_EXCLUDED_CATEGORIES } from 'src/modules/messaging/message-import-manager/drivers/gmail/constants/messaging-gmail-excluded-categories';
-import { GoogleAPIRefreshAccessTokenService } from 'src/modules/connected-account/services/google-api-refresh-access-token/google-api-refresh-access-token.service';
-import { ConnectedAccountRepository } from 'src/modules/connected-account/repositories/connected-account.repository';
-import { MessagingTelemetryService } from 'src/modules/messaging/common/services/messaging-telemetry.service';
 
 @Injectable()
 export class MessagingGmailFullMessageListFetchService {
@@ -43,12 +40,8 @@ export class MessagingGmailFullMessageListFetchService {
       MessageChannelMessageAssociationWorkspaceEntity,
     )
     private readonly messageChannelMessageAssociationRepository: MessageChannelMessageAssociationRepository,
-    @InjectObjectMetadataRepository(ConnectedAccountWorkspaceEntity)
-    private readonly connectedAccountRepository: ConnectedAccountRepository,
     private readonly messagingChannelSyncStatusService: MessagingChannelSyncStatusService,
     private readonly gmailErrorHandlingService: MessagingErrorHandlingService,
-    private readonly googleAPIsRefreshAccessTokenService: GoogleAPIRefreshAccessTokenService,
-    private readonly messagingTelemetryService: MessagingTelemetryService,
   ) {}
 
   public async processMessageListFetch(
@@ -61,46 +54,9 @@ export class MessagingGmailFullMessageListFetchService {
       workspaceId,
     );
 
-    try {
-      await this.googleAPIsRefreshAccessTokenService.refreshAndSaveAccessToken(
-        workspaceId,
-        connectedAccount.id,
-      );
-    } catch (error) {
-      await this.messagingTelemetryService.track({
-        eventName: `refresh_token.error.insufficient_permissions`,
-        workspaceId,
-        connectedAccountId: messageChannel.connectedAccountId,
-        messageChannelId: messageChannel.id,
-        message: `${error.code}: ${error.reason}`,
-      });
-
-      await this.messagingChannelSyncStatusService.markAsFailedInsufficientPermissionsAndFlushMessagesToImport(
-        messageChannel.id,
-        workspaceId,
-      );
-
-      await this.connectedAccountRepository.updateAuthFailedAt(
-        messageChannel.connectedAccountId,
-        workspaceId,
-      );
-    }
-
-    const refreshedConnectedAccount =
-      await this.connectedAccountRepository.getById(
-        connectedAccount.id,
-        workspaceId,
-      );
-
-    if (!refreshedConnectedAccount) {
-      throw new Error(
-        `Connected account ${connectedAccount.id} not found in workspace ${workspaceId}`,
-      );
-    }
-
     const gmailClient: gmail_v1.Gmail =
       await this.gmailClientProvider.getGmailClient(
-        refreshedConnectedAccount.refreshToken,
+        connectedAccount.refreshToken,
       );
 
     const { error: gmailError } =

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/messaging-gmail-messages-import.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/messaging-gmail-messages-import.service.ts
@@ -21,6 +21,7 @@ import { MessagingGmailFetchMessagesByBatchesService } from 'src/modules/messagi
 import { MessagingErrorHandlingService } from 'src/modules/messaging/common/services/messaging-error-handling.service';
 import { MessagingSaveMessagesAndEnqueueContactCreationService } from 'src/modules/messaging/common/services/messaging-save-messages-and-enqueue-contact-creation.service';
 import { MessageChannelRepository } from 'src/modules/messaging/common/repositories/message-channel.repository';
+import { ConnectedAccountRepository } from 'src/modules/connected-account/repositories/connected-account.repository';
 
 @Injectable()
 export class MessagingGmailMessagesImportService {
@@ -41,6 +42,8 @@ export class MessagingGmailMessagesImportService {
     private readonly blocklistRepository: BlocklistRepository,
     @InjectObjectMetadataRepository(MessageChannelWorkspaceEntity)
     private readonly messageChannelRepository: MessageChannelRepository,
+    @InjectObjectMetadataRepository(ConnectedAccountWorkspaceEntity)
+    private readonly connectedAccountRepository: ConnectedAccountRepository,
   ) {}
 
   async processMessageBatchImport(
@@ -70,11 +73,30 @@ export class MessagingGmailMessagesImportService {
       messageChannel.id,
       workspaceId,
     );
+    try {
+      await this.googleAPIsRefreshAccessTokenService.refreshAndSaveAccessToken(
+        workspaceId,
+        connectedAccount.id,
+      );
+    } catch (error) {
+      await this.messagingTelemetryService.track({
+        eventName: `refresh_token.error.insufficient_permissions`,
+        workspaceId,
+        connectedAccountId: messageChannel.connectedAccountId,
+        messageChannelId: messageChannel.id,
+        message: `${error.code}: ${error.reason}`,
+      });
 
-    await this.googleAPIsRefreshAccessTokenService.refreshAndSaveAccessToken(
-      workspaceId,
-      connectedAccount.id,
-    );
+      await this.messagingChannelSyncStatusService.markAsFailedInsufficientPermissionsAndFlushMessagesToImport(
+        messageChannel.id,
+        workspaceId,
+      );
+
+      await this.connectedAccountRepository.updateAuthFailedAt(
+        messageChannel.connectedAccountId,
+        workspaceId,
+      );
+    }
 
     const messageIdsToFetch =
       (await this.cacheStorage.setPop(

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/messaging-gmail-messages-import.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/messaging-gmail-messages-import.service.ts
@@ -73,11 +73,15 @@ export class MessagingGmailMessagesImportService {
       messageChannel.id,
       workspaceId,
     );
+
+    let accessToken: string;
+
     try {
-      await this.googleAPIsRefreshAccessTokenService.refreshAndSaveAccessToken(
-        workspaceId,
-        connectedAccount.id,
-      );
+      accessToken =
+        await this.googleAPIsRefreshAccessTokenService.refreshAndSaveAccessToken(
+          workspaceId,
+          connectedAccount.id,
+        );
     } catch (error) {
       await this.messagingTelemetryService.track({
         eventName: `refresh_token.error.insufficient_permissions`,
@@ -96,6 +100,8 @@ export class MessagingGmailMessagesImportService {
         messageChannel.connectedAccountId,
         workspaceId,
       );
+
+      return;
     }
 
     const messageIdsToFetch =
@@ -120,6 +126,7 @@ export class MessagingGmailMessagesImportService {
       const allMessages =
         await this.fetchMessagesByBatchesService.fetchAllMessages(
           messageIdsToFetch,
+          accessToken,
           connectedAccount.id,
           workspaceId,
         );


### PR DESCRIPTION
- Put error handling outside of `refreshAndSaveAccessToken`
- return after failing to refresh access token in `processMessageBatchImport`
- remove unnecessary token refresh in `processMessageListFetch`