### PR TITLE
Add mutationMaximumRecordAffected to clientConfig

### DIFF
--- a/packages/twenty-front/src/generated/graphql.tsx
+++ b/packages/twenty-front/src/generated/graphql.tsx
@@ -1235,7 +1235,7 @@ export type UpdateBillingSubscriptionMutation = { __typename?: 'Mutation', updat
 export type GetClientConfigQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetClientConfigQuery = { __typename?: 'Query', clientConfig: { __typename?: 'ClientConfig', signInPrefilled: boolean, signUpDisabled: boolean, debugMode: boolean, chromeExtensionId?: string | null, authProviders: { __typename?: 'AuthProviders', google: boolean, password: boolean, microsoft: boolean }, billing: { __typename?: 'Billing', isBillingEnabled: boolean, billingUrl?: string | null, billingFreeTrialDurationInDays?: number | null }, telemetry: { __typename?: 'Telemetry', enabled: boolean }, support: { __typename?: 'Support', supportDriver: string, supportFrontChatId?: string | null }, sentry: { __typename?: 'Sentry', dsn?: string | null, environment?: string | null, release?: string | null }, captcha: { __typename?: 'Captcha', provider?: CaptchaDriverType | null, siteKey?: string | null } } };
+export type GetClientConfigQuery = { __typename?: 'Query', clientConfig: { __typename?: 'ClientConfig', signInPrefilled: boolean, signUpDisabled: boolean, debugMode: boolean, chromeExtensionId?: string | null, authProviders: { __typename?: 'AuthProviders', google: boolean, password: boolean, microsoft: boolean }, billing: { __typename?: 'Billing', isBillingEnabled: boolean, billingUrl?: string | null, billingFreeTrialDurationInDays?: number | null }, telemetry: { __typename?: 'Telemetry', enabled: boolean }, support: { __typename?: 'Support', supportDriver: string, supportFrontChatId?: string | null }, sentry: { __typename?: 'Sentry', dsn?: string | null, environment?: string | null, release?: string | null }, captcha: { __typename?: 'Captcha', provider?: CaptchaDriverType | null, siteKey?: string | null }, api: { __typename?: 'ApiConfig', mutationMaximumRecordAffected: number } } };
 
 export type SkipSyncEmailOnboardingStepMutationVariables = Exact<{ [key: string]: never; }>;
 
@@ -2360,6 +2360,9 @@ export const GetClientConfigDocument = gql`
     captcha {
       provider
       siteKey
+    }
+    api {
+      mutationMaximumRecordAffected
     }
     chromeExtensionId
   }

--- a/packages/twenty-front/src/generated/graphql.tsx
+++ b/packages/twenty-front/src/generated/graphql.tsx
@@ -30,6 +30,11 @@ export type Analytics = {
   success: Scalars['Boolean'];
 };
 
+export type ApiConfig = {
+  __typename?: 'ApiConfig';
+  mutationMaximumRecordAffected: Scalars['Float'];
+};
+
 export type ApiKeyToken = {
   __typename?: 'ApiKeyToken';
   token: Scalars['String'];
@@ -136,6 +141,7 @@ export enum CaptchaDriverType {
 
 export type ClientConfig = {
   __typename?: 'ClientConfig';
+  api: ApiConfig;
   authProviders: AuthProviders;
   billing: Billing;
   captcha: Captcha;

--- a/packages/twenty-front/src/modules/client-config/graphql/queries/getClientConfig.ts
+++ b/packages/twenty-front/src/modules/client-config/graphql/queries/getClientConfig.ts
@@ -32,6 +32,9 @@ export const GET_CLIENT_CONFIG = gql`
         provider
         siteKey
       }
+      api {
+        mutationMaximumRecordAffected
+      }
       chromeExtensionId
     }
   }

--- a/packages/twenty-server/src/engine/core-modules/client-config/client-config.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/client-config/client-config.entity.ts
@@ -66,6 +66,12 @@ class Captcha {
 }
 
 @ObjectType()
+class ApiConfig {
+  @Field(() => Number, { nullable: false })
+  mutationMaximumRecordAffected: number;
+}
+
+@ObjectType()
 export class ClientConfig {
   @Field(() => AuthProviders, { nullable: false })
   authProviders: AuthProviders;
@@ -96,4 +102,7 @@ export class ClientConfig {
 
   @Field(() => String, { nullable: true })
   chromeExtensionId: string | undefined;
+
+  @Field(() => ApiConfig)
+  api: ApiConfig;
 }

--- a/packages/twenty-server/src/engine/core-modules/client-config/client-config.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/client-config/client-config.resolver.ts
@@ -46,6 +46,11 @@ export class ClientConfigResolver {
         siteKey: this.environmentService.get('CAPTCHA_SITE_KEY'),
       },
       chromeExtensionId: this.environmentService.get('CHROME_EXTENSION_ID'),
+      api: {
+        mutationMaximumRecordAffected: this.environmentService.get(
+          'MUTATION_MAXIMUM_RECORD_AFFECTED',
+        ),
+      },
     };
 
     return Promise.resolve(clientConfig);


### PR DESCRIPTION
We are exposing the server mutationMaximumRecordAffected value via clientConfig so it can be used by the FE.

This is a first step for https://github.com/twentyhq/twenty/issues/6025

<img width="610" alt="Screenshot 2024-06-26 at 14 58 26" src="https://github.com/twentyhq/twenty/assets/1834158/9d192976-fd22-45d2-bdaa-a8ff6bb90ca2">

Note: I think mutationMaximumAffectedRecord is more correct but I wanted to follow the existing env variable name 🤔 