### PR TITLE
fix: message cleaner find operator

### DIFF
--- a/packages/twenty-server/src/modules/messaging/message-cleaner/services/messaging-message-cleaner.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-cleaner/services/messaging-message-cleaner.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 
-import { EntityManager, IsNull } from 'typeorm';
+import { EntityManager } from 'typeorm';
 
 import { InjectWorkspaceRepository } from 'src/engine/twenty-orm/decorators/inject-workspace-repository.decorator';
 import { WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace.repository';
@@ -30,10 +30,11 @@ export class MessagingMessageCleanerService {
         const nonAssociatedMessages = await this.messageRepository.find(
           {
             where: {
-              messageChannelMessageAssociations: IsNull(),
+              messageChannelMessageAssociations: [],
             },
             take: limit,
             skip: offset,
+            relations: ['messageChannelMessageAssociations'],
           },
           transactionManager,
         );
@@ -61,7 +62,7 @@ export class MessagingMessageCleanerService {
         const orphanThreads = await this.messageThreadRepository.find(
           {
             where: {
-              messages: IsNull(),
+              messages: [],
             },
             take: limit,
             skip: offset,


### PR DESCRIPTION
This PR fix an issue with the `IsNull()` find operator applied on one-to-many relation, this one is not supported by TypeORM.
We can instead filter by an empty array to retrieve object with empty relations.