### PR TITLE
Fix calendar import cron job

### DIFF
--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/crons/jobs/calendar-events-import.cron.job.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/crons/jobs/calendar-events-import.cron.job.ts
@@ -64,7 +64,7 @@ export class CalendarEventsImportCronJob {
           CalendarEventsImportJob.name,
           {
             workspaceId,
-            connectedAccountId: calendarChannel.connectedAccount.id,
+            connectedAccountId: calendarChannel.connectedAccountId,
           },
         );
       }

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/crons/jobs/calendar-events-import.cron.job.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/crons/jobs/calendar-events-import.cron.job.ts
@@ -7,16 +7,15 @@ import { DataSourceEntity } from 'src/engine/metadata-modules/data-source/data-s
 import { MessageQueue } from 'src/engine/integrations/message-queue/message-queue.constants';
 import { Processor } from 'src/engine/integrations/message-queue/decorators/processor.decorator';
 import { Process } from 'src/engine/integrations/message-queue/decorators/process.decorator';
+import { InjectMessageQueue } from 'src/engine/integrations/message-queue/decorators/message-queue.decorator';
+import { MessageQueueService } from 'src/engine/integrations/message-queue/services/message-queue.service';
+import { BillingService } from 'src/engine/core-modules/billing/billing.service';
+import { TwentyORMManager } from 'src/engine/twenty-orm/twenty-orm.manager';
+import { CalendarChannelWorkspaceEntity } from 'src/modules/calendar/common/standard-objects/calendar-channel.workspace-entity';
 import {
   CalendarEventsImportJobData,
   CalendarEventsImportJob,
 } from 'src/modules/calendar/calendar-event-import-manager/jobs/calendar-events-import.job';
-import { InjectMessageQueue } from 'src/engine/integrations/message-queue/decorators/message-queue.decorator';
-import { MessageQueueService } from 'src/engine/integrations/message-queue/services/message-queue.service';
-import { InjectWorkspaceRepository } from 'src/engine/twenty-orm/decorators/inject-workspace-repository.decorator';
-import { WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace.repository';
-import { BillingService } from 'src/engine/core-modules/billing/billing.service';
-import { CalendarChannelWorkspaceEntity } from 'src/modules/calendar/common/standard-objects/calendar-channel.workspace-entity';
 
 @Processor({
   queueName: MessageQueue.cronQueue,
@@ -26,11 +25,10 @@ export class CalendarEventsImportCronJob {
   constructor(
     @InjectRepository(DataSourceEntity, 'metadata')
     private readonly dataSourceRepository: Repository<DataSourceEntity>,
-    @InjectWorkspaceRepository(CalendarChannelWorkspaceEntity)
-    private readonly calendarChannelRepository: WorkspaceRepository<CalendarChannelWorkspaceEntity>,
     @InjectMessageQueue(MessageQueue.calendarQueue)
     private readonly messageQueueService: MessageQueueService,
     private readonly billingService: BillingService,
+    private readonly twentyORMManager: TwentyORMManager,
   ) {}
 
   @Process(CalendarEventsImportCronJob.name)
@@ -49,7 +47,13 @@ export class CalendarEventsImportCronJob {
     );
 
     for (const workspaceId of workspaceIdsWithDataSources) {
-      const calendarChannels = await this.calendarChannelRepository.find({});
+      const calendarChannelRepository =
+        await this.twentyORMManager.getRepositoryForWorkspace(
+          workspaceId,
+          CalendarChannelWorkspaceEntity,
+        );
+
+      const calendarChannels = await calendarChannelRepository.find({});
 
       for (const calendarChannel of calendarChannels) {
         if (!calendarChannel?.isSyncEnabled) {
@@ -61,9 +65,6 @@ export class CalendarEventsImportCronJob {
           {
             workspaceId,
             connectedAccountId: calendarChannel.connectedAccount.id,
-          },
-          {
-            retryLimit: 2,
           },
         );
       }

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/jobs/calendar-events-import.job.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/jobs/calendar-events-import.job.ts
@@ -33,32 +33,6 @@ export class CalendarEventsImportJob {
     this.logger.log(
       `google calendar sync for workspace ${data.workspaceId} and account ${data.connectedAccountId}`,
     );
-    try {
-      const { connectedAccountId, workspaceId } = data;
-
-      const connectedAccount = await this.connectedAccountRepository.getById(
-        connectedAccountId,
-        workspaceId,
-      );
-
-      if (!connectedAccount) {
-        throw new Error(
-          `No connected account found for ${connectedAccountId} in workspace ${workspaceId}`,
-        );
-      }
-
-      await this.googleAPIsRefreshAccessTokenService.refreshAndSaveAccessToken(
-        connectedAccount,
-        workspaceId,
-      );
-    } catch (e) {
-      this.logger.error(
-        `Error refreshing access token for connected account ${data.connectedAccountId} in workspace ${data.workspaceId}`,
-        e,
-      );
-
-      return;
-    }
 
     await this.googleCalendarSyncService.processCalendarEventsImport(
       data.workspaceId,

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/jobs/calendar-events-import.job.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/jobs/calendar-events-import.job.ts
@@ -1,9 +1,5 @@
 import { Logger, Scope } from '@nestjs/common';
 
-import { GoogleAPIRefreshAccessTokenService } from 'src/modules/connected-account/services/google-api-refresh-access-token/google-api-refresh-access-token.service';
-import { InjectObjectMetadataRepository } from 'src/engine/object-metadata-repository/object-metadata-repository.decorator';
-import { ConnectedAccountRepository } from 'src/modules/connected-account/repositories/connected-account.repository';
-import { ConnectedAccountWorkspaceEntity } from 'src/modules/connected-account/standard-objects/connected-account.workspace-entity';
 import { Processor } from 'src/engine/integrations/message-queue/decorators/processor.decorator';
 import { MessageQueue } from 'src/engine/integrations/message-queue/message-queue.constants';
 import { Process } from 'src/engine/integrations/message-queue/decorators/process.decorator';
@@ -22,10 +18,7 @@ export class CalendarEventsImportJob {
   private readonly logger = new Logger(CalendarEventsImportJob.name);
 
   constructor(
-    private readonly googleAPIsRefreshAccessTokenService: GoogleAPIRefreshAccessTokenService,
     private readonly googleCalendarSyncService: CalendarEventsImportService,
-    @InjectObjectMetadataRepository(ConnectedAccountWorkspaceEntity)
-    private readonly connectedAccountRepository: ConnectedAccountRepository,
   ) {}
 
   @Process(CalendarEventsImportJob.name)


### PR DESCRIPTION
An error was introduced in the calendar cron job because we tried to inject the workspace context inside the calendarChannelRepository where we didn't have access to that context.