### PR TITLE
Fix rating field not editable if null

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellDisplayMode.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellDisplayMode.tsx
@@ -5,6 +5,7 @@ import styled from '@emotion/styled';
 import { FieldContext } from '@/object-record/record-field/contexts/FieldContext';
 import { useFieldFocus } from '@/object-record/record-field/hooks/useFieldFocus';
 import { useIsFieldEmpty } from '@/object-record/record-field/hooks/useIsFieldEmpty';
+import { isFieldBoolean } from '@/object-record/record-field/types/guards/isFieldBoolean';
 import { isFieldRating } from '@/object-record/record-field/types/guards/isFieldRating';
 import { RecordInlineCellContainerProps } from '@/object-record/record-inline-cell/components/RecordInlineCellContainer';
 import { RecordInlineCellButton } from '@/object-record/record-inline-cell/components/RecordInlineCellEditButton';
@@ -82,7 +83,8 @@ export const RecordInlineCellDisplayMode = ({
     !editModeContentOnly;
 
   const shouldDisplayEditModeOnFocus =
-    isFocused && isFieldRating(fieldDefinition);
+    isFocused &&
+    (isFieldRating(fieldDefinition) || isFieldBoolean(fieldDefinition));
 
   return (
     <>

--- a/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellDisplayMode.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellDisplayMode.tsx
@@ -1,12 +1,9 @@
-import { useContext } from 'react';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
-import { FieldContext } from '@/object-record/record-field/contexts/FieldContext';
 import { useFieldFocus } from '@/object-record/record-field/hooks/useFieldFocus';
 import { useIsFieldEmpty } from '@/object-record/record-field/hooks/useIsFieldEmpty';
-import { isFieldBoolean } from '@/object-record/record-field/types/guards/isFieldBoolean';
-import { isFieldRating } from '@/object-record/record-field/types/guards/isFieldRating';
+import { useIsFieldInputOnly } from '@/object-record/record-field/hooks/useIsFieldInputOnly';
 import { RecordInlineCellContainerProps } from '@/object-record/record-inline-cell/components/RecordInlineCellContainer';
 import { RecordInlineCellButton } from '@/object-record/record-inline-cell/components/RecordInlineCellEditButton';
 
@@ -72,8 +69,6 @@ export const RecordInlineCellDisplayMode = ({
   buttonIcon,
   editModeContentOnly,
 }: React.PropsWithChildren<RecordInlineCellDisplayModeProps>) => {
-  const { fieldDefinition } = useContext(FieldContext);
-
   const { isFocused } = useFieldFocus();
   const isDisplayModeContentEmpty = useIsFieldEmpty();
   const showEditButton =
@@ -82,9 +77,9 @@ export const RecordInlineCellDisplayMode = ({
     !isDisplayModeContentEmpty &&
     !editModeContentOnly;
 
-  const shouldDisplayEditModeOnFocus =
-    isFocused &&
-    (isFieldRating(fieldDefinition) || isFieldBoolean(fieldDefinition));
+  const isFieldInputOnly = useIsFieldInputOnly();
+
+  const shouldDisplayEditModeOnFocus = isFocused && isFieldInputOnly;
 
   return (
     <>

--- a/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellDisplayMode.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellDisplayMode.tsx
@@ -1,8 +1,11 @@
+import { useContext } from 'react';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
+import { FieldContext } from '@/object-record/record-field/contexts/FieldContext';
 import { useFieldFocus } from '@/object-record/record-field/hooks/useFieldFocus';
 import { useIsFieldEmpty } from '@/object-record/record-field/hooks/useIsFieldEmpty';
+import { isFieldRating } from '@/object-record/record-field/types/guards/isFieldRating';
 import { RecordInlineCellContainerProps } from '@/object-record/record-inline-cell/components/RecordInlineCellContainer';
 import { RecordInlineCellButton } from '@/object-record/record-inline-cell/components/RecordInlineCellEditButton';
 
@@ -68,6 +71,8 @@ export const RecordInlineCellDisplayMode = ({
   buttonIcon,
   editModeContentOnly,
 }: React.PropsWithChildren<RecordInlineCellDisplayModeProps>) => {
+  const { fieldDefinition } = useContext(FieldContext);
+
   const { isFocused } = useFieldFocus();
   const isDisplayModeContentEmpty = useIsFieldEmpty();
   const showEditButton =
@@ -75,6 +80,9 @@ export const RecordInlineCellDisplayMode = ({
     isFocused &&
     !isDisplayModeContentEmpty &&
     !editModeContentOnly;
+
+  const shouldDisplayEditModeOnFocus =
+    isFocused && isFieldRating(fieldDefinition);
 
   return (
     <>
@@ -84,7 +92,8 @@ export const RecordInlineCellDisplayMode = ({
         isHovered={isHovered}
       >
         <StyledRecordInlineCellNormalModeInnerContainer>
-          {isDisplayModeContentEmpty || !children ? (
+          {(!shouldDisplayEditModeOnFocus && isDisplayModeContentEmpty) ||
+          !children ? (
             <StyledEmptyField>{emptyPlaceholder}</StyledEmptyField>
           ) : (
             children

--- a/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellDisplayMode.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellDisplayMode.tsx
@@ -89,7 +89,7 @@ export const RecordInlineCellDisplayMode = ({
         isHovered={isHovered}
       >
         <StyledRecordInlineCellNormalModeInnerContainer>
-          {(!shouldDisplayEditModeOnFocus && isDisplayModeContentEmpty) ||
+          {(isDisplayModeContentEmpty && !shouldDisplayEditModeOnFocus) ||
           !children ? (
             <StyledEmptyField>{emptyPlaceholder}</StyledEmptyField>
           ) : (


### PR DESCRIPTION
## Context

Rating fields were not editable on the show page and kanban view when they were null, this is because we don't have a way to leave the empty state for fields that are editModeContentOnly. 
~~This is actually an issue for bool fields (which is the other field type that has editModeContentOnly) as well but they have default values can't go be edited to NULL so it's not visible.~~
Actually let's fix bool, this could happen too

Hovering over "Empty" will now show the RatingField edit mode.
I'm not 100% sure about this solution though, we could also make this behaviour on click? I preferred over since this is the behaviour on the table view 🤔 

## Test

https://github.com/twentyhq/twenty/assets/1834158/6825b5c3-2c62-41f2-8e03-343bc0e895e2

