### PR TITLE
Fix z-index issue on dropdown

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/dropdown/components/DropdownMenu.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/dropdown/components/DropdownMenu.tsx
@@ -24,7 +24,7 @@ const StyledDropdownMenu = styled.div<{
   display: flex;
 
   flex-direction: column;
-  z-index: 1;
+  z-index: 30;
   width: ${({ width = 160 }) =>
     typeof width === 'number' ? `${width}px` : width};
 `;


### PR DESCRIPTION
Recently, we've forced all dropdown menu to be displayed in portal. This loses the z-index hieararchy structure and forces us to specify a higher z-index in order for dropdown menus to be displayed on top