### PR TITLE
Add missing objectMetadataId column in auditLog

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/constants/standard-field-ids.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/constants/standard-field-ids.ts
@@ -157,6 +157,7 @@ export const AUDIT_LOGS_STANDARD_FIELD_IDS = {
   properties: '20202020-5d36-470e-8fad-d56ea3ab2fd0',
   context: '20202020-b9d1-4058-9a75-7469cab5ca8c',
   objectName: '20202020-76ba-4c47-b7e5-96034005d00a',
+  objectMetadataId: '20202020-127b-409d-9864-0ec44aa9ed98',
   recordId: '20202020-c578-4acf-bf94-eb53b035cea2',
   workspaceMember: '20202020-6e96-4300-b3f5-67a707147385',
 };

--- a/packages/twenty-server/src/modules/timeline/standard-objects/audit-log.workspace-entity.ts
+++ b/packages/twenty-server/src/modules/timeline/standard-objects/audit-log.workspace-entity.ts
@@ -63,7 +63,7 @@ export class AuditLogWorkspaceEntity extends BaseWorkspaceEntity {
   objectName: string;
 
   @WorkspaceField({
-    standardId: AUDIT_LOGS_STANDARD_FIELD_IDS.objectName,
+    standardId: AUDIT_LOGS_STANDARD_FIELD_IDS.objectMetadataId,
     type: FieldMetadataType.TEXT,
     label: 'Object name',
     description: 'If the event is related to a particular object',

--- a/packages/twenty-server/src/modules/timeline/standard-objects/audit-log.workspace-entity.ts
+++ b/packages/twenty-server/src/modules/timeline/standard-objects/audit-log.workspace-entity.ts
@@ -1,17 +1,17 @@
 import { Relation } from 'src/engine/workspace-manager/workspace-sync-metadata/interfaces/relation.interface';
 
 import { FieldMetadataType } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
+import { RelationMetadataType } from 'src/engine/metadata-modules/relation-metadata/relation-metadata.entity';
+import { BaseWorkspaceEntity } from 'src/engine/twenty-orm/base.workspace-entity';
+import { WorkspaceEntity } from 'src/engine/twenty-orm/decorators/workspace-entity.decorator';
+import { WorkspaceField } from 'src/engine/twenty-orm/decorators/workspace-field.decorator';
+import { WorkspaceIsNullable } from 'src/engine/twenty-orm/decorators/workspace-is-nullable.decorator';
+import { WorkspaceIsSystem } from 'src/engine/twenty-orm/decorators/workspace-is-system.decorator';
+import { WorkspaceJoinColumn } from 'src/engine/twenty-orm/decorators/workspace-join-column.decorator';
+import { WorkspaceRelation } from 'src/engine/twenty-orm/decorators/workspace-relation.decorator';
 import { AUDIT_LOGS_STANDARD_FIELD_IDS } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-field-ids';
 import { STANDARD_OBJECT_IDS } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-object-ids';
 import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
-import { BaseWorkspaceEntity } from 'src/engine/twenty-orm/base.workspace-entity';
-import { WorkspaceEntity } from 'src/engine/twenty-orm/decorators/workspace-entity.decorator';
-import { WorkspaceIsSystem } from 'src/engine/twenty-orm/decorators/workspace-is-system.decorator';
-import { WorkspaceField } from 'src/engine/twenty-orm/decorators/workspace-field.decorator';
-import { WorkspaceIsNullable } from 'src/engine/twenty-orm/decorators/workspace-is-nullable.decorator';
-import { WorkspaceRelation } from 'src/engine/twenty-orm/decorators/workspace-relation.decorator';
-import { RelationMetadataType } from 'src/engine/metadata-modules/relation-metadata/relation-metadata.entity';
-import { WorkspaceJoinColumn } from 'src/engine/twenty-orm/decorators/workspace-join-column.decorator';
 
 @WorkspaceEntity({
   standardId: STANDARD_OBJECT_IDS.auditLog,
@@ -57,7 +57,7 @@ export class AuditLogWorkspaceEntity extends BaseWorkspaceEntity {
     standardId: AUDIT_LOGS_STANDARD_FIELD_IDS.objectName,
     type: FieldMetadataType.TEXT,
     label: 'Object name',
-    description: 'If the event is related to a particular object',
+    description: 'Object name',
     icon: 'IconAbc',
   })
   objectName: string;
@@ -65,8 +65,8 @@ export class AuditLogWorkspaceEntity extends BaseWorkspaceEntity {
   @WorkspaceField({
     standardId: AUDIT_LOGS_STANDARD_FIELD_IDS.objectMetadataId,
     type: FieldMetadataType.TEXT,
-    label: 'Object name',
-    description: 'If the event is related to a particular object',
+    label: 'Object metadata id',
+    description: 'Object metadata id',
     icon: 'IconAbc',
   })
   objectMetadataId: string;
@@ -74,8 +74,8 @@ export class AuditLogWorkspaceEntity extends BaseWorkspaceEntity {
   @WorkspaceField({
     standardId: AUDIT_LOGS_STANDARD_FIELD_IDS.recordId,
     type: FieldMetadataType.UUID,
-    label: 'Object id',
-    description: 'Event name/type',
+    label: 'Record id',
+    description: 'Record id',
     icon: 'IconAbc',
   })
   @WorkspaceIsNullable()


### PR DESCRIPTION
Insert inside AuditLog table are all failing due to objectMetadataId column missing.
The FieldMetadata was sharing the same standard-id with another one (objectName) so it was skipped during the comparison step of the sync-metadata.

Running a sync-metadata again should fix this issue. Note that this column is non-nullable so if the table contains existing records, it will fail. However, since the insert was failing I'm assuming the table is empty anyway.