### PR TITLE
Remove featureFlag on connectedAccount.handleAliases

### DIFF
--- a/packages/twenty-server/src/modules/connected-account/standard-objects/connected-account.workspace-entity.ts
+++ b/packages/twenty-server/src/modules/connected-account/standard-objects/connected-account.workspace-entity.ts
@@ -1,6 +1,5 @@
 import { Relation } from 'src/engine/workspace-manager/workspace-sync-metadata/interfaces/relation.interface';
 
-import { FeatureFlagKeys } from 'src/engine/core-modules/feature-flag/feature-flag.entity';
 import { FieldMetadataType } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import {
   RelationMetadataType,
@@ -9,7 +8,6 @@ import {
 import { BaseWorkspaceEntity } from 'src/engine/twenty-orm/base.workspace-entity';
 import { WorkspaceEntity } from 'src/engine/twenty-orm/decorators/workspace-entity.decorator';
 import { WorkspaceField } from 'src/engine/twenty-orm/decorators/workspace-field.decorator';
-import { WorkspaceGate } from 'src/engine/twenty-orm/decorators/workspace-gate.decorator';
 import { WorkspaceIsNotAuditLogged } from 'src/engine/twenty-orm/decorators/workspace-is-not-audit-logged.decorator';
 import { WorkspaceIsNullable } from 'src/engine/twenty-orm/decorators/workspace-is-nullable.decorator';
 import { WorkspaceIsSystem } from 'src/engine/twenty-orm/decorators/workspace-is-system.decorator';
@@ -97,9 +95,6 @@ export class ConnectedAccountWorkspaceEntity extends BaseWorkspaceEntity {
     label: 'Handle Aliases',
     description: 'Handle Aliases',
     icon: 'IconMail',
-  })
-  @WorkspaceGate({
-    featureFlag: FeatureFlagKeys.IsMessagingAliasFetchingEnabled,
   })
   handleAliases: string;
 


### PR DESCRIPTION
Removing the gating on connectedAccount handleAlias as the feature has been tested for a week