### PR TITLE
Forbid creation of link field type

### DIFF
--- a/packages/twenty-front/src/pages/settings/data-model/SettingsObjectFieldEdit.tsx
+++ b/packages/twenty-front/src/pages/settings/data-model/SettingsObjectFieldEdit.tsx
@@ -213,6 +213,7 @@ export const SettingsObjectFieldEdit = () => {
               <StyledSettingsObjectFieldTypeSelect
                 disabled
                 fieldMetadataItem={activeMetadataField}
+                excludedFieldTypes={[FieldMetadataType.Link]}
               />
               <SettingsDataModelFieldSettingsFormCard
                 disableCurrencyForm

--- a/packages/twenty-front/src/pages/settings/data-model/SettingsObjectNewField/SettingsObjectNewFieldStep2.tsx
+++ b/packages/twenty-front/src/pages/settings/data-model/SettingsObjectNewField/SettingsObjectNewFieldStep2.tsx
@@ -159,7 +159,7 @@ export const SettingsObjectNewFieldStep2 = () => {
     [
       // FieldMetadataType.Email,
       // FieldMetadataType.FullName,
-      // FieldMetadataType.Link,
+      FieldMetadataType.Link,
       FieldMetadataType.Numeric,
       FieldMetadataType.Probability,
       // FieldMetadataType.Uuid,


### PR DESCRIPTION
This is the first step of Link field type deprecation (https://github.com/twentyhq/twenty/issues/5909).
Forbid creation of link field type in product and api. Update to this type is not a concern as we do not allow the update of field type.