### PR TITLE
Add interceptors for auto-resolvers

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.module.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.module.ts
@@ -1,26 +1,27 @@
 import { Module } from '@nestjs/common';
 
+import { SortDirection } from '@ptc-org/nestjs-query-core';
 import {
   NestjsQueryGraphQLModule,
   PagingStrategies,
 } from '@ptc-org/nestjs-query-graphql';
 import { NestjsQueryTypeOrmModule } from '@ptc-org/nestjs-query-typeorm';
-import { SortDirection } from '@ptc-org/nestjs-query-core';
 
-import { WorkspaceMigrationRunnerModule } from 'src/engine/workspace-manager/workspace-migration-runner/workspace-migration-runner.module';
-import { WorkspaceMigrationModule } from 'src/engine/metadata-modules/workspace-migration/workspace-migration.module';
-import { ObjectMetadataModule } from 'src/engine/metadata-modules/object-metadata/object-metadata.module';
+import { TypeORMModule } from 'src/database/typeorm/typeorm.module';
 import { JwtAuthGuard } from 'src/engine/guards/jwt.auth.guard';
 import { DataSourceModule } from 'src/engine/metadata-modules/data-source/data-source.module';
-import { TypeORMModule } from 'src/database/typeorm/typeorm.module';
-import { IsFieldMetadataDefaultValue } from 'src/engine/metadata-modules/field-metadata/validators/is-field-metadata-default-value.validator';
-import { FieldMetadataResolver } from 'src/engine/metadata-modules/field-metadata/field-metadata.resolver';
 import { FieldMetadataDTO } from 'src/engine/metadata-modules/field-metadata/dtos/field-metadata.dto';
+import { FieldMetadataResolver } from 'src/engine/metadata-modules/field-metadata/field-metadata.resolver';
+import { FieldMetadataGraphqlApiExceptionInterceptor } from 'src/engine/metadata-modules/field-metadata/interceptors/field-metadata-graphql-api-exception.interceptor';
+import { IsFieldMetadataDefaultValue } from 'src/engine/metadata-modules/field-metadata/validators/is-field-metadata-default-value.validator';
 import { IsFieldMetadataOptions } from 'src/engine/metadata-modules/field-metadata/validators/is-field-metadata-options.validator';
+import { ObjectMetadataModule } from 'src/engine/metadata-modules/object-metadata/object-metadata.module';
 import { WorkspaceCacheVersionModule } from 'src/engine/metadata-modules/workspace-cache-version/workspace-cache-version.module';
+import { WorkspaceMigrationModule } from 'src/engine/metadata-modules/workspace-migration/workspace-migration.module';
+import { WorkspaceMigrationRunnerModule } from 'src/engine/workspace-manager/workspace-migration-runner/workspace-migration-runner.module';
 
-import { FieldMetadataService } from './field-metadata.service';
 import { FieldMetadataEntity } from './field-metadata.entity';
+import { FieldMetadataService } from './field-metadata.service';
 
 import { CreateFieldInput } from './dtos/create-field.input';
 import { UpdateFieldInput } from './dtos/update-field.input';
@@ -61,6 +62,7 @@ import { UpdateFieldInput } from './dtos/update-field.input';
           },
           delete: { disabled: true },
           guards: [JwtAuthGuard],
+          interceptors: [FieldMetadataGraphqlApiExceptionInterceptor],
         },
       ],
     }),

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/interceptors/field-metadata-graphql-api-exception.interceptor.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/interceptors/field-metadata-graphql-api-exception.interceptor.ts
@@ -1,0 +1,15 @@
+import { CallHandler, ExecutionContext, NestInterceptor } from '@nestjs/common';
+
+import { Observable, catchError } from 'rxjs';
+
+import { fieldMetadataGraphqlApiExceptionHandler } from 'src/engine/metadata-modules/field-metadata/utils/field-metadata-graphql-api-exception-handler.util';
+
+export class FieldMetadataGraphqlApiExceptionInterceptor
+  implements NestInterceptor
+{
+  intercept(_: ExecutionContext, next: CallHandler): Observable<any> {
+    return next
+      .handle()
+      .pipe(catchError((err) => fieldMetadataGraphqlApiExceptionHandler(err)));
+  }
+}

--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/interceptors/object-metadata-graphql-api-exception.interceptor.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/interceptors/object-metadata-graphql-api-exception.interceptor.ts
@@ -1,0 +1,15 @@
+import { CallHandler, ExecutionContext, NestInterceptor } from '@nestjs/common';
+
+import { Observable, catchError } from 'rxjs';
+
+import { objectMetadataGraphqlApiExceptionHandler } from 'src/engine/metadata-modules/object-metadata/utils/object-metadata-graphql-api-exception-handler.util';
+
+export class ObjectMetadataGraphqlApiExceptionInterceptor
+  implements NestInterceptor
+{
+  intercept(_: ExecutionContext, next: CallHandler): Observable<any> {
+    return next
+      .handle()
+      .pipe(catchError((err) => objectMetadataGraphqlApiExceptionHandler(err)));
+  }
+}

--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.module.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.module.ts
@@ -1,33 +1,34 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { SortDirection } from '@ptc-org/nestjs-query-core';
 import {
   NestjsQueryGraphQLModule,
   PagingStrategies,
 } from '@ptc-org/nestjs-query-graphql';
 import { NestjsQueryTypeOrmModule } from '@ptc-org/nestjs-query-typeorm';
-import { SortDirection } from '@ptc-org/nestjs-query-core';
 
-import { DataSourceModule } from 'src/engine/metadata-modules/data-source/data-source.module';
-import { WorkspaceMigrationRunnerModule } from 'src/engine/workspace-manager/workspace-migration-runner/workspace-migration-runner.module';
-import { WorkspaceMigrationModule } from 'src/engine/metadata-modules/workspace-migration/workspace-migration.module';
-import { JwtAuthGuard } from 'src/engine/guards/jwt.auth.guard';
 import { TypeORMModule } from 'src/database/typeorm/typeorm.module';
-import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
-import { RelationMetadataEntity } from 'src/engine/metadata-modules/relation-metadata/relation-metadata.entity';
-import { ObjectMetadataResolver } from 'src/engine/metadata-modules/object-metadata/object-metadata.resolver';
-import { FeatureFlagModule } from 'src/engine/core-modules/feature-flag/feature-flag.module';
 import { FeatureFlagEntity } from 'src/engine/core-modules/feature-flag/feature-flag.entity';
-import { WorkspaceCacheVersionModule } from 'src/engine/metadata-modules/workspace-cache-version/workspace-cache-version.module';
+import { FeatureFlagModule } from 'src/engine/core-modules/feature-flag/feature-flag.module';
+import { JwtAuthGuard } from 'src/engine/guards/jwt.auth.guard';
+import { DataSourceModule } from 'src/engine/metadata-modules/data-source/data-source.module';
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { BeforeUpdateOneObject } from 'src/engine/metadata-modules/object-metadata/hooks/before-update-one-object.hook';
+import { ObjectMetadataGraphqlApiExceptionInterceptor } from 'src/engine/metadata-modules/object-metadata/interceptors/object-metadata-graphql-api-exception.interceptor';
+import { ObjectMetadataResolver } from 'src/engine/metadata-modules/object-metadata/object-metadata.resolver';
+import { RelationMetadataEntity } from 'src/engine/metadata-modules/relation-metadata/relation-metadata.entity';
 import { RemoteTableRelationsModule } from 'src/engine/metadata-modules/remote-server/remote-table/remote-table-relations/remote-table-relations.module';
+import { WorkspaceCacheVersionModule } from 'src/engine/metadata-modules/workspace-cache-version/workspace-cache-version.module';
+import { WorkspaceMigrationModule } from 'src/engine/metadata-modules/workspace-migration/workspace-migration.module';
+import { WorkspaceMigrationRunnerModule } from 'src/engine/workspace-manager/workspace-migration-runner/workspace-migration-runner.module';
 
-import { ObjectMetadataService } from './object-metadata.service';
 import { ObjectMetadataEntity } from './object-metadata.entity';
+import { ObjectMetadataService } from './object-metadata.service';
 
 import { CreateObjectInput } from './dtos/create-object.input';
-import { UpdateObjectPayload } from './dtos/update-object.input';
 import { ObjectMetadataDTO } from './dtos/object-metadata.dto';
+import { UpdateObjectPayload } from './dtos/update-object.input';
 
 @Module({
   imports: [
@@ -64,6 +65,7 @@ import { ObjectMetadataDTO } from './dtos/object-metadata.dto';
           update: { disabled: true },
           delete: { disabled: true },
           guards: [JwtAuthGuard],
+          interceptors: [ObjectMetadataGraphqlApiExceptionInterceptor],
         },
       ],
     }),

--- a/packages/twenty-server/src/engine/metadata-modules/relation-metadata/interceptors/relation-metadata-graphql-api-exception.interceptor.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/relation-metadata/interceptors/relation-metadata-graphql-api-exception.interceptor.ts
@@ -1,0 +1,17 @@
+import { CallHandler, ExecutionContext, NestInterceptor } from '@nestjs/common';
+
+import { Observable, catchError } from 'rxjs';
+
+import { relationMetadataGraphqlApiExceptionHandler } from 'src/engine/metadata-modules/relation-metadata/utils/relation-metadata-graphql-api-exception-handler.util';
+
+export class RelationMetadataGraphqlApiExceptionInterceptor
+  implements NestInterceptor
+{
+  intercept(_: ExecutionContext, next: CallHandler): Observable<any> {
+    return next
+      .handle()
+      .pipe(
+        catchError((err) => relationMetadataGraphqlApiExceptionHandler(err)),
+      );
+  }
+}

--- a/packages/twenty-server/src/engine/metadata-modules/relation-metadata/relation-metadata.module.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/relation-metadata/relation-metadata.module.ts
@@ -7,16 +7,17 @@ import {
 import { NestjsQueryTypeOrmModule } from '@ptc-org/nestjs-query-typeorm';
 
 import { JwtAuthGuard } from 'src/engine/guards/jwt.auth.guard';
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { FieldMetadataModule } from 'src/engine/metadata-modules/field-metadata/field-metadata.module';
 import { ObjectMetadataModule } from 'src/engine/metadata-modules/object-metadata/object-metadata.module';
+import { RelationMetadataGraphqlApiExceptionInterceptor } from 'src/engine/metadata-modules/relation-metadata/interceptors/relation-metadata-graphql-api-exception.interceptor';
+import { RelationMetadataResolver } from 'src/engine/metadata-modules/relation-metadata/relation-metadata.resolver';
+import { WorkspaceCacheVersionModule } from 'src/engine/metadata-modules/workspace-cache-version/workspace-cache-version.module';
 import { WorkspaceMigrationModule } from 'src/engine/metadata-modules/workspace-migration/workspace-migration.module';
 import { WorkspaceMigrationRunnerModule } from 'src/engine/workspace-manager/workspace-migration-runner/workspace-migration-runner.module';
-import { WorkspaceCacheVersionModule } from 'src/engine/metadata-modules/workspace-cache-version/workspace-cache-version.module';
-import { RelationMetadataResolver } from 'src/engine/metadata-modules/relation-metadata/relation-metadata.resolver';
-import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 
-import { RelationMetadataService } from './relation-metadata.service';
 import { RelationMetadataEntity } from './relation-metadata.entity';
+import { RelationMetadataService } from './relation-metadata.service';
 
 import { CreateRelationInput } from './dtos/create-relation.input';
 import { RelationMetadataDTO } from './dtos/relation-metadata.dto';
@@ -47,6 +48,7 @@ import { RelationMetadataDTO } from './dtos/relation-metadata.dto';
           update: { disabled: true },
           delete: { disabled: true },
           guards: [JwtAuthGuard],
+          interceptors: [RelationMetadataGraphqlApiExceptionInterceptor],
         },
       ],
     }),


### PR DESCRIPTION
Services exceptions are not catch when the endpoint comes from an auto-resolver.
We want to remove auto-resolver but it requires to implement pagination by ourselves.

As a quick fix, here are interceptors that will trigger the exception handler.
I had a hard time making it generic so I finally added one interceptor for each since this is not supposed to stay