### PR TITLE
Fixes issue #6267: Hide Navigation Tabs if Single connected Account

### DIFF
--- a/packages/twenty-front/src/modules/settings/accounts/components/SettingsAccountsCalendarChannelsContainer.tsx
+++ b/packages/twenty-front/src/modules/settings/accounts/components/SettingsAccountsCalendarChannelsContainer.tsx
@@ -52,13 +52,16 @@ export const SettingsAccountsCalendarChannelsContainer = () => {
   if (!calendarChannels.length) {
     return <SettingsAccountsListEmptyStateCard />;
   }
+  const hasMultipleAccounts = accounts.length > 1;
 
   return (
     <>
-      <TabList
-        tabListId={SETTINGS_ACCOUNT_CALENDAR_CHANNELS_TAB_LIST_COMPONENT_ID}
-        tabs={tabs}
-      />
+      <div style={{ display: hasMultipleAccounts ? 'block' : 'none' }}>
+        <TabList
+          tabListId={SETTINGS_ACCOUNT_CALENDAR_CHANNELS_TAB_LIST_COMPONENT_ID}
+          tabs={tabs}
+        />
+      </div>
       {calendarChannels.map((calendarChannel) => (
         <React.Fragment key={calendarChannel.id}>
           {calendarChannel.id === activeTabId && (

--- a/packages/twenty-front/src/modules/settings/accounts/components/SettingsAccountsMessageChannelsContainer.tsx
+++ b/packages/twenty-front/src/modules/settings/accounts/components/SettingsAccountsMessageChannelsContainer.tsx
@@ -52,12 +52,15 @@ export const SettingsAccountsMessageChannelsContainer = () => {
     return <SettingsAccountsListEmptyStateCard />;
   }
 
+  const hasMultipleAccounts = accounts.length > 1;
   return (
     <>
-      <TabList
-        tabListId={SETTINGS_ACCOUNT_MESSAGE_CHANNELS_TAB_LIST_COMPONENT_ID}
-        tabs={tabs}
-      />
+      <div style={{ display: hasMultipleAccounts ? 'block' : 'none' }}>
+        <TabList
+          tabListId={SETTINGS_ACCOUNT_MESSAGE_CHANNELS_TAB_LIST_COMPONENT_ID}
+          tabs={tabs}
+        />
+      </div>
       {messageChannels.map((messageChannel) => (
         <React.Fragment key={messageChannel.id}>
           {messageChannel.id === activeTabId && (


### PR DESCRIPTION
I wrapped the TabList with a div and have added conditional display property to make it visible only when we have move than one email address. This fixed the issue. I waiting for the review. :)
![Screenshot from 2024-07-16 18-27-37](https://github.com/user-attachments/assets/9a1c6544-87b7-48c5-baf6-0d89d4ad848a)
![Screenshot from 2024-07-16 18-27-45](https://github.com/user-attachments/assets/47c2a609-50d9-49f4-89a9-f4a38923700c)
