### PR TITLE
[Fix] Remove usage of deprecated FieldMetadata type probability

### DIFF
--- a/packages/twenty-chrome-extension/src/generated/graphql.tsx
+++ b/packages/twenty-chrome-extension/src/generated/graphql.tsx
@@ -1,5 +1,5 @@
-import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
+import { gql } from '@apollo/client';
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
@@ -2528,7 +2528,6 @@ export enum FieldMetadataType {
   Numeric = 'NUMERIC',
   Phone = 'PHONE',
   Position = 'POSITION',
-  Probability = 'PROBABILITY',
   Rating = 'RATING',
   RawJson = 'RAW_JSON',
   Relation = 'RELATION',

--- a/packages/twenty-server/src/engine/api/rest/core/query-builder/utils/map-field-metadata-to-graphql-query.utils.ts
+++ b/packages/twenty-server/src/engine/api/rest/core/query-builder/utils/map-field-metadata-to-graphql-query.utils.ts
@@ -25,7 +25,6 @@ export const mapFieldMetadataToGraphqlQuery = (
     FieldMetadataType.BOOLEAN,
     FieldMetadataType.NUMBER,
     FieldMetadataType.NUMERIC,
-    FieldMetadataType.PROBABILITY,
     FieldMetadataType.RATING,
     FieldMetadataType.SELECT,
     FieldMetadataType.MULTI_SELECT,

--- a/packages/twenty-zapier/src/utils/computeInputFields.ts
+++ b/packages/twenty-zapier/src/utils/computeInputFields.ts
@@ -25,7 +25,6 @@ const getTypeFromFieldMetadataType = (
     case FieldMetadataType.NUMBER:
       return 'integer';
     case FieldMetadataType.NUMERIC:
-    case FieldMetadataType.PROBABILITY:
       return 'number';
     default:
       return undefined;
@@ -183,7 +182,6 @@ export const computeInputFields = (
       case FieldMetadataType.BOOLEAN:
       case FieldMetadataType.NUMBER:
       case FieldMetadataType.NUMERIC:
-      case FieldMetadataType.PROBABILITY:
       case FieldMetadataType.RATING: {
         const nodeFieldType = getTypeFromFieldMetadataType(nodeField.type);
         if (!nodeFieldType) {

--- a/packages/twenty-zapier/src/utils/data.types.ts
+++ b/packages/twenty-zapier/src/utils/data.types.ts
@@ -40,7 +40,6 @@ export enum FieldMetadataType {
   BOOLEAN = 'BOOLEAN',
   NUMBER = 'NUMBER',
   NUMERIC = 'NUMERIC',
-  PROBABILITY = 'PROBABILITY',
   LINK = 'LINK',
   CURRENCY = 'CURRENCY',
   FULL_NAME = 'FULL_NAME',


### PR DESCRIPTION
Bad timing between merge of https://github.com/twentyhq/twenty/commit/364caf0fdf32339004a6d56b4ac8fab7b16ff792 and https://github.com/twentyhq/twenty/commit/c0f6f52669c48e6d0bbe252db51dad74831ac739 a few minutes apart caused issues. Fixing it here ! 