### PR TITLE
Fix command for sync stage enum

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version/0-22/0-22-update-message-channel-sync-stage-enum.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-22/0-22-update-message-channel-sync-stage-enum.command.ts
@@ -114,6 +114,10 @@ export class UpdateMessageChannelSyncStageEnumCommand extends CommandRunner {
               );
 
               await queryRunner.query(
+                `ALTER TABLE "${dataSourceMetadata.schema}"."messageChannel" ALTER COLUMN "syncStage" SET DEFAULT 'FULL_MESSAGE_LIST_FETCH_PENDING'`,
+              );
+
+              await queryRunner.query(
                 `DROP TYPE "${dataSourceMetadata.schema}"."messageChannel_syncStage_enum_old"`,
               );
               await queryRunner.commitTransaction();


### PR DESCRIPTION
We were missing the default value for syncStage, while it is expected since indicated in the metadata