### PR TITLE
Fix undefined state from react-router-dom.

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-show/hooks/useRecordShowPagePagination.ts
+++ b/packages/twenty-front/src/modules/object-record/record-show/hooks/useRecordShowPagePagination.ts
@@ -115,7 +115,7 @@ export const useRecordShowPagePagination = (
 
   const { state } = useLocation();
 
-  const cursorFromIndexPage = state.cursor;
+  const cursorFromIndexPage = state?.cursor;
 
   const { loading: loadingCurrentRecord, pageInfo: currentRecordsPageInfo } =
     useFindManyRecords({


### PR DESCRIPTION
Fix state not well typed from react-router-dom, it can be undefined and we should check for that.