### PR TITLE
fix: adding https in checkurltype

### DIFF
--- a/packages/twenty-front/src/modules/ui/field/display/components/LinkDisplay.tsx
+++ b/packages/twenty-front/src/modules/ui/field/display/components/LinkDisplay.tsx
@@ -18,6 +18,12 @@ export const LinkDisplay = ({ value }: LinkDisplayProps) => {
     return <></>;
   }
 
+  const absoluteUrl = url
+    ? url.startsWith('http')
+      ? url
+      : 'https://' + url
+    : '';
+
   const displayedValue = isNonEmptyString(value?.label)
     ? value?.label
     : url?.replace(/^http[s]?:\/\/(?:[w]+\.)?/gm, '').replace(/^[w]+\./gm, '');
@@ -29,8 +35,8 @@ export const LinkDisplay = ({ value }: LinkDisplayProps) => {
       : LinkType.Url;
 
   if (type === LinkType.LinkedIn || type === LinkType.Twitter) {
-    return <SocialLink href={url} type={type} label={displayedValue} />;
+    return <SocialLink href={absoluteUrl} type={type} label={displayedValue} />;
   }
 
-  return <RoundedLink href={url} label={displayedValue} />;
+  return <RoundedLink href={absoluteUrl} label={displayedValue} />;
 };

--- a/packages/twenty-front/src/utils/checkUrlType.ts
+++ b/packages/twenty-front/src/utils/checkUrlType.ts
@@ -3,9 +3,6 @@ import { LinkType } from '@/ui/navigation/link/components/SocialLink';
 import { isDefined } from './isDefined';
 
 export const checkUrlType = (url: string) => {
-  if (!/^(http|https):\/\//i.test(url)) {
-    url = 'https://' + url;
-  }
   if (
     /^(http|https):\/\/(?:www\.)?linkedin.com(\w+:{0,1}\w*@)?(\S+)(:([0-9])+)?(\/|\/([\w#!:.?+=&%@!\-/]))?/.test(
       url,

--- a/packages/twenty-front/src/utils/checkUrlType.ts
+++ b/packages/twenty-front/src/utils/checkUrlType.ts
@@ -3,6 +3,9 @@ import { LinkType } from '@/ui/navigation/link/components/SocialLink';
 import { isDefined } from './isDefined';
 
 export const checkUrlType = (url: string) => {
+  if (!/^(http|https):\/\//i.test(url)) {
+    url = 'https://' + url;
+  }
   if (
     /^(http|https):\/\/(?:www\.)?linkedin.com(\w+:{0,1}\w*@)?(\S+)(:([0-9])+)?(\/|\/([\w#!:.?+=&%@!\-/]))?/.test(
       url,


### PR DESCRIPTION
# Fix URL handling for LinkedIn and Twitter links

Fixes #6287 

## Solution
Updated `checkUrlType` function to prepend "https://" to URLs if missing, ensuring proper handling of social media links.

## Changes
- Modified `/packages/twenty-front/src/utils/checkUrlType.ts`
- Added a check to prepend "https://" if URL doesn't start with a protocol