### PR TITLE
Fixed reset rating field to "no value" on star re-click

### DIFF
--- a/packages/twenty-front/src/modules/object-record/object-filter-dropdown/components/ObjectFilterDropdownRatingInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-filter-dropdown/components/ObjectFilterDropdownRatingInput.tsx
@@ -7,7 +7,9 @@ import { FieldRatingValue } from '@/object-record/record-field/types/FieldMetada
 import { RatingInput } from '@/ui/field/input/components/RatingInput';
 import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/DropdownMenuItemsContainer';
 
-const convertFieldRatingValueToNumber = (rating: FieldRatingValue): string => {
+const convertFieldRatingValueToNumber = (
+  rating: Exclude<FieldRatingValue, null>,
+): string => {
   return rating.split('_')[1];
 };
 
@@ -51,6 +53,10 @@ export const ObjectFilterDropdownRatingInput = () => {
         <RatingInput
           value={selectedFilter?.value as FieldRatingValue}
           onChange={(newValue: FieldRatingValue) => {
+            if (!newValue) {
+              return;
+            }
+
             selectFilter?.({
               id: selectedFilter?.id ? selectedFilter.id : v4(),
               fieldMetadataId: filterDefinitionUsedInDropdown.fieldMetadataId,

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/hooks/useRatingField.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/hooks/useRatingField.ts
@@ -16,14 +16,14 @@ export const useRatingField = () => {
 
   const fieldName = fieldDefinition.metadata.fieldName;
 
-  const [fieldValue, setFieldValue] = useRecoilState<FieldRatingValue | null>(
+  const [fieldValue, setFieldValue] = useRecoilState<FieldRatingValue>(
     recordStoreFamilySelector({
       recordId: entityId,
       fieldName: fieldName,
     }),
   );
 
-  const rating = fieldValue ?? 'RATING_1';
+  const rating = fieldValue ?? null;
 
   return {
     fieldDefinition,

--- a/packages/twenty-front/src/modules/object-record/record-field/types/FieldMetadata.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/types/FieldMetadata.ts
@@ -185,7 +185,7 @@ export type FieldAddressValue = {
   addressLat: number | null;
   addressLng: number | null;
 };
-export type FieldRatingValue = (typeof RATING_VALUES)[number];
+export type FieldRatingValue = (typeof RATING_VALUES)[number] | null;
 export type FieldSelectValue = string | null;
 export type FieldMultiSelectValue = string[] | null;
 

--- a/packages/twenty-front/src/modules/ui/field/input/components/RatingInput.tsx
+++ b/packages/twenty-front/src/modules/ui/field/input/components/RatingInput.tsx
@@ -1,5 +1,5 @@
 import { styled } from '@linaria/react';
-import { useContext, useEffect, useRef, useState } from 'react';
+import { useContext, useState } from 'react';
 import { IconTwentyStarFilled, THEME_COMMON, ThemeContext } from 'twenty-ui';
 
 import { useClearField } from '@/object-record/record-field/hooks/useClearField';
@@ -16,7 +16,7 @@ const StyledRatingIconContainer = styled.div<{
 }>`
   color: ${({ color }) => color};
   display: inline-flex;
-`;  
+`;
 
 type RatingInputProps = {
   onChange?: (newValue: FieldRatingValue) => void;
@@ -41,18 +41,18 @@ export const RatingInput = ({
 
   const currentValue = hoveredValue ?? value;
 
-  const selectedIndex = currentValue !== null ? RATING_VALUES.indexOf(currentValue) : -1;
+  const selectedIndex =
+    currentValue !== null ? RATING_VALUES.indexOf(currentValue) : -1;
 
-  const previousRating = useRef<FieldRatingValue>(null);
+  const canClick = !readonly;
 
-  const handleClick = (value: FieldRatingValue) => {
-    if (readonly) return;
-    previousRating.current = value;
-    if (previousRating.current === currentValue) {
+  const handleClick = (newValue: FieldRatingValue) => {
+    if (!canClick) return;
+    if (newValue === value) {
       setHoveredValue(null);
       clearField();
     } else {
-      onChange?.(value);
+      onChange?.(newValue);
     }
   };
 

--- a/packages/twenty-front/src/modules/ui/field/input/components/RatingInput.tsx
+++ b/packages/twenty-front/src/modules/ui/field/input/components/RatingInput.tsx
@@ -43,7 +43,7 @@ export const RatingInput = ({
   
   const currentValue = hoveredValue ?? value;
   
-  const selectedIndex = RATING_VALUES.indexOf(currentValue);
+  const selectedIndex = currentValue ? RATING_VALUES.indexOf(currentValue) : -1;
   
   const previousRating = useRef<FieldRatingValue>(null);
 
@@ -67,7 +67,7 @@ export const RatingInput = ({
       aria-label="Rating"
       aria-valuemax={RATING_VALUES.length}
       aria-valuemin={1}
-      aria-valuenow={RATING_VALUES.indexOf(currentValue) + 1}
+      aria-valuenow={selectedIndex + 1}
       tabIndex={0}
     >
       {RATING_VALUES.map((value, index) => {

--- a/packages/twenty-front/src/modules/ui/field/input/components/RatingInput.tsx
+++ b/packages/twenty-front/src/modules/ui/field/input/components/RatingInput.tsx
@@ -47,6 +47,7 @@ export const RatingInput = ({
 
   const handleClick = (value: FieldRatingValue) => {
     if (readonly) return;
+    previousRating.current = value;
     if (previousRating.current === currentValue) {
       setHoveredValue(null);
       clearField();
@@ -54,10 +55,6 @@ export const RatingInput = ({
       onChange?.(value);
     }
   };
-
-  useEffect(() => {
-    previousRating.current = value;
-  }, [value]);
 
   return (
     <StyledContainer

--- a/packages/twenty-front/src/modules/ui/field/input/components/RatingInput.tsx
+++ b/packages/twenty-front/src/modules/ui/field/input/components/RatingInput.tsx
@@ -16,7 +16,7 @@ const StyledRatingIconContainer = styled.div<{
 }>`
   color: ${({ color }) => color};
   display: inline-flex;
-`;
+`;  
 
 type RatingInputProps = {
   onChange?: (newValue: FieldRatingValue) => void;
@@ -41,7 +41,7 @@ export const RatingInput = ({
 
   const currentValue = hoveredValue ?? value;
 
-  const selectedIndex = currentValue ? RATING_VALUES.indexOf(currentValue) : -1;
+  const selectedIndex = currentValue !== null ? RATING_VALUES.indexOf(currentValue) : -1;
 
   const previousRating = useRef<FieldRatingValue>(null);
 

--- a/packages/twenty-front/src/modules/ui/field/input/components/RatingInput.tsx
+++ b/packages/twenty-front/src/modules/ui/field/input/components/RatingInput.tsx
@@ -1,7 +1,8 @@
-import { useContext, useState } from 'react';
 import { styled } from '@linaria/react';
+import { useContext, useEffect, useRef, useState } from 'react';
 import { IconTwentyStarFilled, THEME_COMMON, ThemeContext } from 'twenty-ui';
 
+import { useClearField } from '@/object-record/record-field/hooks/useClearField';
 import { RATING_VALUES } from '@/object-record/record-field/meta-types/constants/RatingValues';
 import { FieldRatingValue } from '@/object-record/record-field/types/FieldMetadata';
 
@@ -31,16 +32,34 @@ export const RatingInput = ({
   readonly,
 }: RatingInputProps) => {
   const { theme } = useContext(ThemeContext);
+  const clearField = useClearField();
 
   const activeColor = theme.font.color.secondary;
   const inactiveColor = theme.background.quaternary;
 
-  const [hoveredValue, setHoveredValue] = useState<FieldRatingValue | null>(
+  const [hoveredValue, setHoveredValue] = useState<FieldRatingValue>(
     null,
   );
+  
   const currentValue = hoveredValue ?? value;
-
+  
   const selectedIndex = RATING_VALUES.indexOf(currentValue);
+  
+  const previousRating = useRef<FieldRatingValue>(null);
+
+  const handleClick = (value: FieldRatingValue) => {
+    if(readonly) return undefined;
+    if(previousRating.current === currentValue) {
+      setHoveredValue(null);
+      clearField();
+    } else {
+      onChange?.(value)
+    }
+  }
+
+   useEffect(() => {
+      previousRating.current = value;
+   },[value])
 
   return (
     <StyledContainer
@@ -58,7 +77,7 @@ export const RatingInput = ({
           <StyledRatingIconContainer
             key={index}
             color={isActive ? activeColor : inactiveColor}
-            onClick={readonly ? undefined : () => onChange?.(value)}
+            onClick={() => handleClick(value)}
             onMouseEnter={readonly ? undefined : () => setHoveredValue(value)}
             onMouseLeave={readonly ? undefined : () => setHoveredValue(null)}
           >

--- a/packages/twenty-front/src/modules/ui/field/input/components/RatingInput.tsx
+++ b/packages/twenty-front/src/modules/ui/field/input/components/RatingInput.tsx
@@ -46,7 +46,7 @@ export const RatingInput = ({
   const previousRating = useRef<FieldRatingValue>(null);
 
   const handleClick = (value: FieldRatingValue) => {
-    if (readonly) return undefined;
+    if (readonly) return;
     if (previousRating.current === currentValue) {
       setHoveredValue(null);
       clearField();

--- a/packages/twenty-front/src/modules/ui/field/input/components/RatingInput.tsx
+++ b/packages/twenty-front/src/modules/ui/field/input/components/RatingInput.tsx
@@ -37,29 +37,27 @@ export const RatingInput = ({
   const activeColor = theme.font.color.secondary;
   const inactiveColor = theme.background.quaternary;
 
-  const [hoveredValue, setHoveredValue] = useState<FieldRatingValue>(
-    null,
-  );
-  
+  const [hoveredValue, setHoveredValue] = useState<FieldRatingValue>(null);
+
   const currentValue = hoveredValue ?? value;
-  
+
   const selectedIndex = currentValue ? RATING_VALUES.indexOf(currentValue) : -1;
-  
+
   const previousRating = useRef<FieldRatingValue>(null);
 
   const handleClick = (value: FieldRatingValue) => {
-    if(readonly) return undefined;
-    if(previousRating.current === currentValue) {
+    if (readonly) return undefined;
+    if (previousRating.current === currentValue) {
       setHoveredValue(null);
       clearField();
     } else {
-      onChange?.(value)
+      onChange?.(value);
     }
-  }
+  };
 
-   useEffect(() => {
-      previousRating.current = value;
-   },[value])
+  useEffect(() => {
+    previousRating.current = value;
+  }, [value]);
 
   return (
     <StyledContainer


### PR DESCRIPTION
### Description
Resolves Issue:  [https://github.com/twentyhq/twenty/issues/6224](#6224)

### Additional Consideration
I have changed the default start rating value from 1 star to no star since clicking on the selected start was reverting the filed to 1 star which didn't seem like the appropriate behaviour. Let me know if this change is fine