### PR TITLE
fix: icon visibility on horizontal scroll #6304

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-header/components/RecordTableHeaderDragDropColumn.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-header/components/RecordTableHeaderDragDropColumn.tsx
@@ -1,10 +1,15 @@
 import { styled } from '@linaria/react';
+import { useContext } from 'react';
+import { ThemeContext } from 'twenty-ui';
 
-const StyledTh = styled.th`
+const StyledTh = styled.th<{ backgroundColor: string;}>`
   border-bottom: none;
   border-top: none;
+	background: ${({ backgroundColor }) => backgroundColor};
 `;
 
 export const RecordTableHeaderDragDropColumn = () => {
-  return <StyledTh></StyledTh>;
+	const { theme } = useContext(ThemeContext);
+	
+  return <StyledTh backgroundColor={theme.background.primary}></StyledTh>;
 };


### PR DESCRIPTION

https://github.com/user-attachments/assets/5f8741ad-bdab-4ef3-8741-dacbd2381ea3

fix: When scrolling horizontally, table header goes behind the first frozen column #6304
