### PR TITLE
Fix Metadata GQL server hook

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/graphql-config/hooks/use-cached-metadata.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-config/hooks/use-cached-metadata.ts
@@ -10,8 +10,9 @@ export function useCachedMetadata(config: CacheMetadataPluginConfig): Plugin {
   const computeCacheKey = (serverContext: any) => {
     const workspaceId = serverContext.req.workspace?.id ?? 'anonymous';
     const cacheVersion = serverContext.req.cacheVersion ?? '0';
+    const operationName = getOperationName(serverContext);
 
-    return `${workspaceId}:${cacheVersion}`;
+    return `cachedOperations:${operationName}:${workspaceId}:${cacheVersion}`;
   };
 
   const getOperationName = (serverContext: any) =>
@@ -43,6 +44,10 @@ export function useCachedMetadata(config: CacheMetadataPluginConfig): Plugin {
 
       if (!cachedResponse) {
         const responseBody = await response.json();
+
+        if (responseBody.errors) {
+          return;
+        }
 
         config.cacheSetter(cacheKey, responseBody);
       }


### PR DESCRIPTION
## Context
We've created a yoga (gql server) hook that catches requests and cache them when needed. In practice we use it on the "objects" query because this is often queried on the FE and it should never return something different unless the schema has been intentionally changed by the user when editing their data model (updating objects, fields, etc).

The issue here is we always cache the response regardless of its result, even when it fails. This PR fixes that behaviour by only caching the query response if it is successful.

I'm also fixing the cache key because the signature let users put multiple operations and the cache key was not taking this into account (we always use it on only one operation but we might have issues in the future because another operation response could have erased the cached response of another). Now the cache key contains the name of the operation as well.

## Test
tested locally by manually throwing an error in the JWT auth guard 