### PR TITLE
Cannot delete label identifier associated field

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.service.ts
@@ -463,6 +463,13 @@ export class FieldMetadataService extends TypeOrmQueryService<FieldMetadataEntit
         );
       }
 
+      if (objectMetadata.labelIdentifierFieldMetadataId === fieldMetadata.id) {
+        throw new FieldMetadataException(
+          'Cannot delete, please update the label identifier field first',
+          FieldMetadataExceptionCode.FIELD_MUTATION_NOT_ALLOWED,
+        );
+      }
+
       await fieldMetadataRepository.delete(fieldMetadata.id);
 
       if (isCompositeFieldMetadataType(fieldMetadata.type)) {


### PR DESCRIPTION
## Context
An object should always have a labelIdentifier (would be its primary key at least). If the associated field is deleted by a user, it will break the app. Ideally we should handle that on the DB level but we don't have a FK for this column yet.
In the meantime I'm adding the validation check in the backend, note that this is already handle on the FE side since the "archive/delete" buttons don't appear for such fields so you need to reassign it to another field first which is the desired behaviour.