### PR TITLE
Add Confirmation Modal for Deletion Action and Map All Action Bar Entries

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-action-bar/hooks/useRecordActionBar.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-action-bar/hooks/useRecordActionBar.tsx
@@ -136,7 +136,6 @@ export const useRecordActionBar = ({
               accent: 'danger',
               onClick: () => {
                 setIsDeleteRecordsModalOpen(true);
-                handleDeleteClick();
               },
               ConfirmationModal: (
                 <ConfirmationModal

--- a/packages/twenty-front/src/modules/ui/navigation/shared/components/NavigationModal.tsx
+++ b/packages/twenty-front/src/modules/ui/navigation/shared/components/NavigationModal.tsx
@@ -11,7 +11,11 @@ const SharedNavigationModal = ({
 }: SharedNavigationModalProps) => {
   return (
     <div data-select-disable className={customClassName}>
-      {actionBarEntries[0]?.ConfirmationModal ?? null}
+      {actionBarEntries.map((actionBarEntry, index) =>
+        actionBarEntry.ConfirmationModal ? (
+          <div key={index}>{actionBarEntry.ConfirmationModal}</div>
+        ) : null,
+      )}
     </div>
   );
 };


### PR DESCRIPTION
This pull request addresses an issue where the delete button, placed closely to the export button, could lead to accidental deletions without confirmation. The problem was that the confirmation modal for the delete action, being the second action, was not displayed. The code was updated to map all action bar entries and display their respective confirmation modals correctly.

### Changes Made:
- Updated the rendering of action bar entries to ensure all confirmation modals are shown.
    Changed from displaying only the first action bar entry's confirmation modal to mapping through all entries and displaying each modal if it exists.
- Removed the delete from the onClick because it is present in the onConfirmClick.