### PR TITLE
Fix display of boolean fields in timeline activities

### DIFF
--- a/packages/twenty-front/src/modules/activities/timelineActivities/rows/main-object/components/EventFieldDiffValueEffect.tsx
+++ b/packages/twenty-front/src/modules/activities/timelineActivities/rows/main-object/components/EventFieldDiffValueEffect.tsx
@@ -5,6 +5,7 @@ import { FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
 import { ObjectMetadataItem } from '@/object-metadata/types/ObjectMetadataItem';
 import { useSetRecordValue } from '@/object-record/record-store/contexts/RecordFieldValueSelectorContext';
 import { recordStoreFamilyState } from '@/object-record/record-store/states/recordStoreFamilyState';
+import { isDefined } from 'twenty-ui';
 
 export const EventFieldDiffValueEffect = ({
   diffArtificialRecordStoreId,
@@ -23,7 +24,7 @@ export const EventFieldDiffValueEffect = ({
   const setRecordValue = useSetRecordValue();
 
   useEffect(() => {
-    if (!diffRecord) return;
+    if (!isDefined(diffRecord)) return;
 
     const forgedObjectRecord = {
       __typename: mainObjectMetadataItem.nameSingular,


### PR DESCRIPTION
before
<img width="556" alt="Capture d’écran 2024-07-22 à 11 29 59" src="https://github.com/user-attachments/assets/c3f76698-77f8-411f-8488-c3b119184f91">

after
<img width="963" alt="Capture d’écran 2024-07-22 à 11 31 07" src="https://github.com/user-attachments/assets/29248677-16c6-49f5-8a86-cfe8aa677d86">
