### PR TITLE
Fix ORM

### DIFF
--- a/packages/twenty-server/src/engine/twenty-orm/factories/entity-schema.factory.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/factories/entity-schema.factory.ts
@@ -7,14 +7,12 @@ import { EntitySchemaColumnFactory } from 'src/engine/twenty-orm/factories/entit
 import { EntitySchemaRelationFactory } from 'src/engine/twenty-orm/factories/entity-schema-relation.factory';
 import { WorkspaceEntitiesStorage } from 'src/engine/twenty-orm/storage/workspace-entities.storage';
 import { computeTableName } from 'src/engine/utils/compute-table-name.util';
-import { WorkspaceCacheStorageService } from 'src/engine/workspace-cache-storage/workspace-cache-storage.service';
 
 @Injectable()
 export class EntitySchemaFactory {
   constructor(
     private readonly entitySchemaColumnFactory: EntitySchemaColumnFactory,
     private readonly entitySchemaRelationFactory: EntitySchemaRelationFactory,
-    private readonly workspaceCacheStorageService: WorkspaceCacheStorageService,
   ) {}
 
   async create(

--- a/packages/twenty-server/src/engine/twenty-orm/repository/workspace.repository.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/repository/workspace.repository.ts
@@ -16,19 +16,19 @@ import {
   SaveOptions,
   UpdateResult,
 } from 'typeorm';
+import { PickKeysByType } from 'typeorm/common/PickKeysByType';
 import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 import { UpsertOptions } from 'typeorm/repository/UpsertOptions';
-import { PickKeysByType } from 'typeorm/common/PickKeysByType';
 
 import { WorkspaceInternalContext } from 'src/engine/twenty-orm/interfaces/workspace-internal-context.interface';
 
-import { WorkspaceEntitiesStorage } from 'src/engine/twenty-orm/storage/workspace-entities.storage';
-import { isCompositeFieldMetadataType } from 'src/engine/metadata-modules/field-metadata/utils/is-composite-field-metadata-type.util';
 import { compositeTypeDefintions } from 'src/engine/metadata-modules/field-metadata/composite-types';
 import { computeCompositeColumnName } from 'src/engine/metadata-modules/field-metadata/utils/compute-column-name.util';
-import { isPlainObject } from 'src/utils/is-plain-object';
-import { isRelationFieldMetadataType } from 'src/engine/utils/is-relation-field-metadata-type.util';
+import { isCompositeFieldMetadataType } from 'src/engine/metadata-modules/field-metadata/utils/is-composite-field-metadata-type.util';
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
+import { WorkspaceEntitiesStorage } from 'src/engine/twenty-orm/storage/workspace-entities.storage';
+import { isRelationFieldMetadataType } from 'src/engine/utils/is-relation-field-metadata-type.util';
+import { isPlainObject } from 'src/utils/is-plain-object';
 
 export class WorkspaceRepository<
   Entity extends ObjectLiteral,
@@ -607,10 +607,13 @@ export class WorkspaceRepository<
    * PRIVATE METHODS
    */
   private async getObjectMetadataFromTarget() {
-    const objectMetadataName = WorkspaceEntitiesStorage.getObjectMetadataName(
-      this.internalContext.workspaceId,
-      this.target as EntitySchema,
-    );
+    const objectMetadataName =
+      typeof this.target === 'string'
+        ? this.target
+        : WorkspaceEntitiesStorage.getObjectMetadataName(
+            this.internalContext.workspaceId,
+            this.target as EntitySchema,
+          );
 
     if (!objectMetadataName) {
       throw new Error('Object metadata name is missing');

--- a/packages/twenty-server/src/engine/twenty-orm/utils/determine-relation-details.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/determine-relation-details.util.ts
@@ -1,10 +1,10 @@
 import { RelationType } from 'typeorm/metadata/types/RelationTypes';
 
-import { RelationMetadataEntity } from 'src/engine/metadata-modules/relation-metadata/relation-metadata.entity';
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
-import { WorkspaceCacheStorageService } from 'src/engine/workspace-cache-storage/workspace-cache-storage.service';
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
+import { RelationMetadataEntity } from 'src/engine/metadata-modules/relation-metadata/relation-metadata.entity';
 import { computeRelationType } from 'src/engine/twenty-orm/utils/compute-relation-type.util';
+import { WorkspaceCacheStorageService } from 'src/engine/workspace-cache-storage/workspace-cache-storage.service';
 
 interface RelationDetails {
   relationType: RelationType;
@@ -31,7 +31,7 @@ export async function determineRelationDetails(
     toObjectMetadata = await workspaceCacheStorageService.getObjectMetadata(
       workspaceId,
       (objectMetadata) =>
-        objectMetadata.id === relationMetadata.toObjectMetadataId,
+        objectMetadata.id === relationMetadata.fromObjectMetadataId,
     );
   }
 

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-save-events.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-save-events.service.ts
@@ -119,7 +119,10 @@ export class CalendarSaveEventsService {
     const savedCalendarEventParticipantsToEmit: CalendarEventParticipantWorkspaceEntity[] =
       [];
 
-    await this.workspaceDataSource?.transaction(async (transactionManager) => {
+    const workspaceDataSource =
+      await this.twentyORMManager.getWorkspaceDatasource();
+
+    await workspaceDataSource?.transaction(async (transactionManager) => {
       await calendarEventRepository.save(eventsToSave, {}, transactionManager);
 
       await calendarEventRepository.save(

--- a/packages/twenty-server/src/modules/calendar/calendar-event-participant-manager/calendar-event-participant-manager.module.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-participant-manager/calendar-event-participant-manager.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { WorkspaceModule } from 'src/engine/core-modules/workspace/workspace.module';
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 import { ObjectMetadataRepositoryModule } from 'src/engine/object-metadata-repository/object-metadata-repository.module';
@@ -22,6 +23,7 @@ import { PersonWorkspaceEntity } from 'src/modules/person/standard-objects/perso
 @Module({
   imports: [
     WorkspaceDataSourceModule,
+    WorkspaceModule,
     TwentyORMModule.forFeature([CalendarEventParticipantWorkspaceEntity]),
     ObjectMetadataRepositoryModule.forFeature([PersonWorkspaceEntity]),
     TypeOrmModule.forFeature(

--- a/packages/twenty-server/src/modules/calendar/calendar-event-participant-manager/jobs/calendar-event-participant-match-participant.job.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-participant-manager/jobs/calendar-event-participant-match-participant.job.ts
@@ -1,5 +1,6 @@
 import { Scope } from '@nestjs/common';
 
+import { WorkspaceService } from 'src/engine/core-modules/workspace/services/workspace.service';
 import { Process } from 'src/engine/integrations/message-queue/decorators/process.decorator';
 import { Processor } from 'src/engine/integrations/message-queue/decorators/processor.decorator';
 import { MessageQueue } from 'src/engine/integrations/message-queue/message-queue.constants';
@@ -19,6 +20,7 @@ export type CalendarEventParticipantMatchParticipantJobData = {
 export class CalendarEventParticipantMatchParticipantJob {
   constructor(
     private readonly calendarEventParticipantService: CalendarEventParticipantService,
+    private readonly workspaceService: WorkspaceService,
   ) {}
 
   @Process(CalendarEventParticipantMatchParticipantJob.name)
@@ -26,6 +28,10 @@ export class CalendarEventParticipantMatchParticipantJob {
     data: CalendarEventParticipantMatchParticipantJobData,
   ): Promise<void> {
     const { workspaceId, email, personId, workspaceMemberId } = data;
+
+    if (!this.workspaceService.isWorkspaceActivated(workspaceId)) {
+      return;
+    }
 
     await this.calendarEventParticipantService.matchCalendarEventParticipants(
       workspaceId,


### PR DESCRIPTION
This PR fixes a few bugs on TwentyORM:
- fix many to one relations that were not properly queries
- fix many to one relations that were not properly parsed
- compute datasource (or use from cache) at run-time and do not use injected one that could be outdated

We still need to refactor it to simplify, I feel the API are too complex and we have too many cache layers. Also the relation computation part is very complex and bug prone