### PR TITLE
Fix record page navigation cause unncessary skeleton loading

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-show/hooks/useRecordShowPagePagination.ts
+++ b/packages/twenty-front/src/modules/object-record/record-show/hooks/useRecordShowPagePagination.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @nx/workspace-no-navigate-prefer-link */
 import { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { useSetRecoilState } from 'recoil';

--- a/packages/twenty-front/src/pages/object-record/RecordShowPage.tsx
+++ b/packages/twenty-front/src/pages/object-record/RecordShowPage.tsx
@@ -64,7 +64,7 @@ export const RecordShowPage = () => {
           hasNextRecord={hasNextRecord}
           navigateToNextRecord={navigateToNextRecord}
           Icon={headerIcon}
-          loading={loading || isLoadingPagination}
+          loading={isLoadingPagination}
         >
           <>
             <PageFavoriteButton


### PR DESCRIPTION
Issue #6325 
- skeleton is only displayed when the total number changes.

[Screencast from 2024-07-23 06-36-21.webm](https://github.com/user-attachments/assets/668c2b11-85b7-440f-939b-ab9286a2a835)
[Screencast from 2024-07-23 06-35-50.webm](https://github.com/user-attachments/assets/d9333216-1e10-4090-8f7d-5bb7391dc0ec)
