### PR TITLE
[fix] Migrated links field should be standard

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version/0-23/0-23-migrate-link-fields-to-links.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-23/0-23-migrate-link-fields-to-links.command.ts
@@ -225,6 +225,7 @@ export class MigrateLinkFieldsToLinksCommand extends CommandRunner {
               id: tmpNewLinksField.id,
               workspaceId: tmpNewLinksField.workspaceId,
               name: `${fieldName}`,
+              isCustom: false,
             });
 
             this.logger.log(

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/commands/sync-workspace-metadata.command.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/commands/sync-workspace-metadata.command.ts
@@ -54,6 +54,7 @@ export class SyncWorkspaceMetadataCommand extends CommandRunner {
     const errorsDuringSync: string[] = [];
 
     for (const workspaceId of workspaceIds) {
+      this.logger.log(`Running workspace sync for workspace: ${workspaceId}`);
       try {
         const issues =
           await this.workspaceHealthService.healthCheck(workspaceId);


### PR DESCRIPTION
Fixing script + ading logs to sync-metadata