### PR TITLE
Prevent field with null standardId to be considered as field identifier

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/services/workspace-sync-object-metadata-identifiers.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/services/workspace-sync-object-metadata-identifiers.service.ts
@@ -127,7 +127,8 @@ export class WorkspaceSyncObjectMetadataIdentifiersService {
     const identifierFieldMetadata = objectMetadata.fields.find(
       (field) =>
         field.standardId ===
-        standardObjectMetadataMap[objectStandardId][standardIdFieldName],
+          standardObjectMetadataMap[objectStandardId][standardIdFieldName] &&
+        field.standardId !== null,
     );
 
     if (


### PR DESCRIPTION
Otherwise, any custom field will be considered as image/label identifier by the sync-metadata scripts