### PR TITLE
Fix base graphql error message

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/graphql/utils/generate-graphql-error-from-error.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/graphql/utils/generate-graphql-error-from-error.util.ts
@@ -5,7 +5,7 @@ import {
 
 export const generateGraphQLErrorFromError = (error: Error) => {
   const graphqlError = new BaseGraphQLError(
-    error.name,
+    error.message,
     ErrorCode.INTERNAL_SERVER_ERROR,
   );
 


### PR DESCRIPTION
Display error message instead of name

<img width="762" alt="Capture d’écran 2024-07-30 à 15 51 07" src="https://github.com/user-attachments/assets/a6b49254-a99e-42fc-8704-089f38bf8e7b">
