### PR TITLE
Fix company creation duplicate on email sync after introducing links type

### DIFF
--- a/packages/twenty-server/src/modules/company/repositories/company.repository.ts
+++ b/packages/twenty-server/src/modules/company/repositories/company.repository.ts
@@ -57,7 +57,7 @@ export class CompanyRepository {
   public async createCompany(
     workspaceId: string,
     companyToCreate: CompanyToCreate,
-    companyDomainNameColumnName,
+    companyDomainNameColumnName: string,
     transactionManager?: EntityManager,
   ): Promise<void> {
     const dataSourceSchema =

--- a/packages/twenty-server/src/modules/contact-creation-manager/services/create-company.service.ts
+++ b/packages/twenty-server/src/modules/contact-creation-manager/services/create-company.service.ts
@@ -7,8 +7,8 @@ import { v4 } from 'uuid';
 import { InjectObjectMetadataRepository } from 'src/engine/object-metadata-repository/object-metadata-repository.decorator';
 import { CompanyRepository } from 'src/modules/company/repositories/company.repository';
 import { CompanyWorkspaceEntity } from 'src/modules/company/standard-objects/company.workspace-entity';
+import { extractDomainFromLink } from 'src/modules/contact-creation-manager/utils/extract-domain-from-link.util';
 import { getCompanyNameFromDomainName } from 'src/modules/contact-creation-manager/utils/get-company-name-from-domain-name.util';
-import { getCompanyDomainName } from 'src/utils/getCompanyDomainName';
 @Injectable()
 export class CreateCompanyService {
   private readonly httpService: AxiosInstance;
@@ -55,7 +55,7 @@ export class CreateCompanyService {
         },
       ) => ({
         ...acc,
-        [company.domainName]: company.id,
+        [extractDomainFromLink(company.domainName)]: company.id,
       }),
       {},
     );
@@ -64,7 +64,7 @@ export class CreateCompanyService {
       (domainName) =>
         !existingCompanies.some(
           (company: { domainName: string }) =>
-            getCompanyDomainName(company) === domainName,
+            extractDomainFromLink(company.domainName) === domainName,
         ),
     );
 

--- a/packages/twenty-server/src/modules/contact-creation-manager/utils/__tests__/extract-domain-from-link.spec.ts
+++ b/packages/twenty-server/src/modules/contact-creation-manager/utils/__tests__/extract-domain-from-link.spec.ts
@@ -1,0 +1,31 @@
+import { extractDomainFromLink } from 'src/modules/contact-creation-manager/utils/extract-domain-from-link.util';
+
+describe('extractDomainFromLink', () => {
+  it('should extract domain from link', () => {
+    const link = 'https://www.twenty.com';
+    const result = extractDomainFromLink(link);
+
+    expect(result).toBe('twenty.com');
+  });
+
+  it('should extract domain from link without www', () => {
+    const link = 'https://twenty.com';
+    const result = extractDomainFromLink(link);
+
+    expect(result).toBe('twenty.com');
+  });
+
+  it('should extract domain from link without protocol', () => {
+    const link = 'twenty.com';
+    const result = extractDomainFromLink(link);
+
+    expect(result).toBe('twenty.com');
+  });
+
+  it('should extract domain from link with path', () => {
+    const link = 'https://twenty.com/about';
+    const result = extractDomainFromLink(link);
+
+    expect(result).toBe('twenty.com');
+  });
+});

--- a/packages/twenty-server/src/modules/contact-creation-manager/utils/extract-domain-from-link.util.ts
+++ b/packages/twenty-server/src/modules/contact-creation-manager/utils/extract-domain-from-link.util.ts
@@ -1,0 +1,5 @@
+export const extractDomainFromLink = (link: string) => {
+  const domain = link.replace(/^(https?:\/\/)?(www\.)?/i, '').split('/')[0];
+
+  return domain;
+};


### PR DESCRIPTION
- Introduce `extractDomainFromLink`
- Use is inside `create-company.service`