### PR TITLE
Fix total count in show page

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-show/hooks/useRecordShowPagePagination.ts
+++ b/packages/twenty-front/src/modules/object-record/record-show/hooks/useRecordShowPagePagination.ts
@@ -60,7 +60,8 @@ export const useRecordShowPagePagination = (
 
   const cursorFromRequest = currentRecordsPageInfo?.endCursor;
 
-  const [totalCount, setTotalCount] = useState<number>(0);
+  const [totalCountBefore, setTotalCountBefore] = useState<number>(0);
+  const [totalCountAfter, setTotalCountAfter] = useState<number>(0);
 
   const { loading: loadingRecordBefore, records: recordsBefore } =
     useFindManyRecords({
@@ -78,7 +79,7 @@ export const useRecordShowPagePagination = (
       objectNameSingular,
       recordGqlFields,
       onCompleted: (_, pagination) => {
-        setTotalCount(pagination?.totalCount ?? 0);
+        setTotalCountBefore(pagination?.totalCount ?? 0);
       },
     });
 
@@ -98,7 +99,7 @@ export const useRecordShowPagePagination = (
       objectNameSingular,
       recordGqlFields,
       onCompleted: (_, pagination) => {
-        setTotalCount(pagination?.totalCount ?? 0);
+        setTotalCountAfter(pagination?.totalCount ?? 0);
       },
     });
 
@@ -146,6 +147,8 @@ export const useRecordShowPagePagination = (
   const rankFoundInFiew = rankInView > -1;
 
   const objectLabel = capitalize(objectMetadataItem.namePlural);
+
+  const totalCount = Math.max(1, totalCountBefore, totalCountAfter);
 
   const viewNameWithCount = rankFoundInFiew
     ? `${rankInView + 1} of ${totalCount} in ${objectLabel}`


### PR DESCRIPTION
Fixes #6405 

We need to take into account both the totalCount of **before cursor** results and **after cursor** results.