### PR TITLE
Fast follows on new task/note behaviors

### DIFF
--- a/packages/twenty-front/src/modules/ui/input/editor/utils/getFirstNonEmptyLineOfRichText.ts
+++ b/packages/twenty-front/src/modules/ui/input/editor/utils/getFirstNonEmptyLineOfRichText.ts
@@ -9,15 +9,21 @@ export const getFirstNonEmptyLineOfRichText = (
   }
   for (const node of fieldValue) {
     if (!isUndefinedOrNull(node.content)) {
-      const contentArray = node.content as Array<{ text: string }>;
+      const contentArray = node.content as Array<
+        { text: string } | { link: string }
+      >;
       if (contentArray.length > 0) {
         for (const content of contentArray) {
-          if (content.text?.trim() !== '') {
-            return content.text;
+          if ('link' in content) {
+            return content.link;
+          }
+          if ('text' in content) {
+            return content.text.trim();
           }
         }
       }
     }
   }
+
   return '';
 };

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-23/0-23-update-activities.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-23/0-23-update-activities.command.ts
@@ -170,6 +170,7 @@ export class UpdateActivitiesCommand extends CommandRunner {
             },
             {
               linkedObjectMetadataId: noteObjectMetadataId,
+              name: 'linked-note',
             },
           );
 
@@ -219,6 +220,7 @@ export class UpdateActivitiesCommand extends CommandRunner {
             },
             {
               linkedObjectMetadataId: taskObjectMetadataId,
+              name: 'linked-task',
             },
           );
           await attachmentRepository.update(

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-23/0-23-update-activities.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-23/0-23-update-activities.command.ts
@@ -171,7 +171,7 @@ export class UpdateActivitiesCommand extends CommandRunner {
             },
             {
               linkedObjectMetadataId: noteObjectMetadataId,
-              name: 'linked-note-created',
+              name: 'linked-note.created',
             },
           );
 
@@ -183,7 +183,7 @@ export class UpdateActivitiesCommand extends CommandRunner {
             },
             {
               linkedObjectMetadataId: noteObjectMetadataId,
-              name: 'linked-note-updated',
+              name: 'linked-note.updated',
             },
           );
 
@@ -234,7 +234,7 @@ export class UpdateActivitiesCommand extends CommandRunner {
             },
             {
               linkedObjectMetadataId: taskObjectMetadataId,
-              name: 'linked-task-created',
+              name: 'linked-task.created',
             },
           );
 
@@ -246,7 +246,7 @@ export class UpdateActivitiesCommand extends CommandRunner {
             },
             {
               linkedObjectMetadataId: taskObjectMetadataId,
-              name: 'linked-task-updated',
+              name: 'linked-task.updated',
             },
           );
           await attachmentRepository.update(

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-23/0-23-update-activities.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-23/0-23-update-activities.command.ts
@@ -165,12 +165,25 @@ export class UpdateActivitiesCommand extends CommandRunner {
 
           await timelineActivityRepository.update(
             {
+              name: 'note.created',
               linkedObjectMetadataId: activityObjectMetadataId,
               linkedRecordId: activity.id,
             },
             {
               linkedObjectMetadataId: noteObjectMetadataId,
-              name: 'linked-note',
+              name: 'linked-note-created',
+            },
+          );
+
+          await timelineActivityRepository.update(
+            {
+              name: 'note.updated',
+              linkedObjectMetadataId: activityObjectMetadataId,
+              linkedRecordId: activity.id,
+            },
+            {
+              linkedObjectMetadataId: noteObjectMetadataId,
+              name: 'linked-note-updated',
             },
           );
 
@@ -215,12 +228,25 @@ export class UpdateActivitiesCommand extends CommandRunner {
 
           await timelineActivityRepository.update(
             {
+              name: 'task.created',
               linkedObjectMetadataId: activityObjectMetadataId,
               linkedRecordId: activity.id,
             },
             {
               linkedObjectMetadataId: taskObjectMetadataId,
-              name: 'linked-task',
+              name: 'linked-task-created',
+            },
+          );
+
+          await timelineActivityRepository.update(
+            {
+              name: 'task.updated',
+              linkedObjectMetadataId: activityObjectMetadataId,
+              linkedRecordId: activity.id,
+            },
+            {
+              linkedObjectMetadataId: taskObjectMetadataId,
+              name: 'linked-task-updated',
             },
           );
           await attachmentRepository.update(


### PR DESCRIPTION
In this PR, I'm fixing two issues that we have faced:
- computing a rich text first line in case of the first block content is not a text
- migrating existing timelineActivities tied to tasks / notes to linked-tasks / linked-notes during migration command