### PR TITLE
[Fix] URL inputs to not submit numeric hostnames and url without domain

### DIFF
--- a/packages/twenty-front/src/utils/validation-schemas/absoluteUrlSchema.ts
+++ b/packages/twenty-front/src/utils/validation-schemas/absoluteUrlSchema.ts
@@ -6,7 +6,18 @@ export const absoluteUrlSchema = z
   .or(
     z
       .string()
-      .transform((value) => `https://${value}`)
+      .transform((value) => {
+        try {
+          const url = `https://${value}`.trim();
+          return isNaN(Number(value.trim())) &&
+            new URL(url) &&
+            /\.[a-z]{2,}$/.test(url)
+            ? url
+            : '';
+        } catch {
+          return '';
+        }
+      })
       .pipe(z.string().url()),
   )
   .or(z.literal(''));


### PR DESCRIPTION
## ISSUE (BUG)

- Fixes #5396

## Description 

- When given a string like **https://300**,  it interprets 300 as the hostname, which it then converts to an IP address, what i did was to check if the entire string (ignoring the protocol ) is number then don't submit it all within zod and it makes sense to do that cause. 

- The range for valid 32-bit unsigned integers is 0 to 4294967295 (which corresponds to 0.0.0.0 to 255.255.255.255) so other than this numbers by default URL objects throws invalid.



https://github.com/user-attachments/assets/1da92aeb-d50c-43a3-87ea-78a059d3fa84

