### PR TITLE
Fix 2 small bugs following tasks migration

### DIFF
--- a/packages/twenty-front/src/modules/navigation/components/MobileNavigationBar.tsx
+++ b/packages/twenty-front/src/modules/navigation/components/MobileNavigationBar.tsx
@@ -1,4 +1,3 @@
-import { useNavigate } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 import { IconComponent, IconList, IconSearch, IconSettings } from 'twenty-ui';
 
@@ -16,7 +15,6 @@ export const MobileNavigationBar = () => {
   const [isCommandMenuOpened] = useRecoilState(isCommandMenuOpenedState);
   const { closeCommandMenu, openCommandMenu } = useCommandMenu();
   const isSettingsPage = useIsSettingsPage();
-  const navigate = useNavigate();
   const [isNavigationDrawerOpen, setIsNavigationDrawerOpen] = useRecoilState(
     isNavigationDrawerOpenState,
   );

--- a/packages/twenty-front/src/modules/navigation/components/MobileNavigationBar.tsx
+++ b/packages/twenty-front/src/modules/navigation/components/MobileNavigationBar.tsx
@@ -1,21 +1,13 @@
 import { useNavigate } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
-import {
-  IconCheckbox,
-  IconComponent,
-  IconList,
-  IconSearch,
-  IconSettings,
-} from 'twenty-ui';
+import { IconComponent, IconList, IconSearch, IconSettings } from 'twenty-ui';
 
 import { useCommandMenu } from '@/command-menu/hooks/useCommandMenu';
 import { isCommandMenuOpenedState } from '@/command-menu/states/isCommandMenuOpenedState';
-import { AppPath } from '@/types/AppPath';
 import { NavigationBar } from '@/ui/navigation/navigation-bar/components/NavigationBar';
 import { isNavigationDrawerOpenState } from '@/ui/navigation/states/isNavigationDrawerOpenState';
 
 import { useIsSettingsPage } from '../hooks/useIsSettingsPage';
-import { useIsTasksPage } from '../hooks/useIsTasksPage';
 import { currentMobileNavigationDrawerState } from '../states/currentMobileNavigationDrawerState';
 
 type NavigationBarItemName = 'main' | 'search' | 'tasks' | 'settings';
@@ -23,7 +15,6 @@ type NavigationBarItemName = 'main' | 'search' | 'tasks' | 'settings';
 export const MobileNavigationBar = () => {
   const [isCommandMenuOpened] = useRecoilState(isCommandMenuOpenedState);
   const { closeCommandMenu, openCommandMenu } = useCommandMenu();
-  const isTasksPage = useIsTasksPage();
   const isSettingsPage = useIsSettingsPage();
   const navigate = useNavigate();
   const [isNavigationDrawerOpen, setIsNavigationDrawerOpen] = useRecoilState(
@@ -36,11 +27,9 @@ export const MobileNavigationBar = () => {
     ? currentMobileNavigationDrawer
     : isCommandMenuOpened
       ? 'search'
-      : isTasksPage
-        ? 'tasks'
-        : isSettingsPage
-          ? 'settings'
-          : 'main';
+      : isSettingsPage
+        ? 'settings'
+        : 'main';
 
   const items: {
     name: NavigationBarItemName;
@@ -66,15 +55,6 @@ export const MobileNavigationBar = () => {
           openCommandMenu();
         }
         setIsNavigationDrawerOpen(false);
-      },
-    },
-    {
-      name: 'tasks',
-      Icon: IconCheckbox,
-      onClick: () => {
-        closeCommandMenu();
-        setIsNavigationDrawerOpen(false);
-        navigate(AppPath.TasksPage);
       },
     },
     {

--- a/packages/twenty-front/src/modules/object-record/record-index/hooks/useRecordBoardRecordGqlFields.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/hooks/useRecordBoardRecordGqlFields.ts
@@ -44,6 +44,18 @@ export const useRecordBoardRecordGqlFields = ({
     ),
     ...(hasPositionField(objectMetadataItem) ? { position: true } : undefined),
     ...identifierQueryFields,
+    noteTargets: {
+      note: {
+        id: true,
+        title: true,
+      },
+    },
+    taskTargets: {
+      task: {
+        id: true,
+        title: true,
+      },
+    },
   };
 
   if (isDefined(kanbanFieldMetadataName)) {


### PR DESCRIPTION
This PR fixes two bugs:
- A broken link to the task page that had been left on the mobile version
- On Kanban cards, the badge for notes/tasks wasn't properly displayed because the title wasn't loaded from the backend