### PR TITLE
Fixed sort bug when two select values were null

### DIFF
--- a/packages/twenty-front/src/utils/__tests__/sort.test.ts
+++ b/packages/twenty-front/src/utils/__tests__/sort.test.ts
@@ -3,6 +3,7 @@ import { sortAsc, sortDesc, sortNullsFirst, sortNullsLast } from '../sort';
 describe('sort', () => {
   describe('sortNullsFirst', () => {
     it('should sort nulls first', () => {
+      expect(sortNullsFirst(null, null)).toBe(0);
       expect(sortNullsFirst(null, 'a')).toBe(-1);
       expect(sortNullsFirst('a', null)).toBe(1);
       expect(sortNullsFirst('a', 'a')).toBe(0);
@@ -11,6 +12,7 @@ describe('sort', () => {
 
   describe('sortNullsLast', () => {
     it('should sort nulls last', () => {
+      expect(sortNullsFirst(null, null)).toBe(0);
       expect(sortNullsLast(null, 'a')).toBe(1);
       expect(sortNullsLast('a', null)).toBe(-1);
       expect(sortNullsLast('a', 'a')).toBe(0);

--- a/packages/twenty-front/src/utils/sort.ts
+++ b/packages/twenty-front/src/utils/sort.ts
@@ -3,7 +3,14 @@ import { Maybe } from '~/generated/graphql';
 export const sortNullsFirst = (
   fieldValueA: Maybe<unknown>,
   fieldValueB: Maybe<unknown>,
-) => (fieldValueA === null ? -1 : fieldValueB === null ? 1 : 0);
+) =>
+  fieldValueA === null && fieldValueB === null
+    ? 0
+    : fieldValueA === null
+      ? -1
+      : fieldValueB === null
+        ? 1
+        : 0;
 
 export const sortNullsLast = (
   fieldValueA: Maybe<unknown>,


### PR DESCRIPTION
Fixes https://github.com/twentyhq/twenty/issues/5762

The problem was only happening with a sort on a select type field, also appears with currency type and maybe other types.

This was because NULL values were sorted in a random order because the sort function was comparing two NULL values as not equal, so I just added a case for when A === B === NULL.