### PR TITLE
feat: created by calendar email

### DIFF
--- a/packages/twenty-server/src/modules/calendar/calendar-event-participant-manager/jobs/calendar-create-company-and-contact-after-sync.job.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-participant-manager/jobs/calendar-create-company-and-contact-after-sync.job.ts
@@ -9,6 +9,7 @@ import { TwentyORMManager } from 'src/engine/twenty-orm/twenty-orm.manager';
 import { CalendarChannelWorkspaceEntity } from 'src/modules/calendar/common/standard-objects/calendar-channel.workspace-entity';
 import { CalendarEventParticipantWorkspaceEntity } from 'src/modules/calendar/common/standard-objects/calendar-event-participant.workspace-entity';
 import { CreateCompanyAndContactService } from 'src/modules/contact-creation-manager/services/create-company-and-contact.service';
+import { FieldCreatedBySource } from 'src/engine/metadata-modules/field-metadata/composite-types/created-by.composite-type';
 
 export type CalendarCreateCompanyAndContactAfterSyncJobData = {
   workspaceId: string;
@@ -96,6 +97,7 @@ export class CalendarCreateCompanyAndContactAfterSyncJob {
       connectedAccount,
       calendarEventParticipantsWithoutPersonIdAndWorkspaceMemberId,
       workspaceId,
+      FieldCreatedBySource.CALENDAR,
     );
 
     this.logger.log(

--- a/packages/twenty-server/src/modules/contact-creation-manager/contact-creation-manager.module.ts
+++ b/packages/twenty-server/src/modules/contact-creation-manager/contact-creation-manager.module.ts
@@ -12,13 +12,11 @@ import { AutoCompaniesAndContactsCreationMessageChannelListener } from 'src/modu
 import { CreateCompanyAndContactService } from 'src/modules/contact-creation-manager/services/create-company-and-contact.service';
 import { CreateCompanyService } from 'src/modules/contact-creation-manager/services/create-company.service';
 import { CreateContactService } from 'src/modules/contact-creation-manager/services/create-contact.service';
-import { PersonWorkspaceEntity } from 'src/modules/person/standard-objects/person.workspace-entity';
 import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
 
 @Module({
   imports: [
     ObjectMetadataRepositoryModule.forFeature([
-      PersonWorkspaceEntity,
       WorkspaceMemberWorkspaceEntity,
       CompanyWorkspaceEntity,
     ]),

--- a/packages/twenty-server/src/modules/contact-creation-manager/jobs/create-company-and-contact.job.ts
+++ b/packages/twenty-server/src/modules/contact-creation-manager/jobs/create-company-and-contact.job.ts
@@ -1,6 +1,7 @@
 import { Process } from 'src/engine/integrations/message-queue/decorators/process.decorator';
 import { Processor } from 'src/engine/integrations/message-queue/decorators/processor.decorator';
 import { MessageQueue } from 'src/engine/integrations/message-queue/message-queue.constants';
+import { FieldCreatedBySource } from 'src/engine/metadata-modules/field-metadata/composite-types/created-by.composite-type';
 import { ConnectedAccountWorkspaceEntity } from 'src/modules/connected-account/standard-objects/connected-account.workspace-entity';
 import { CreateCompanyAndContactService } from 'src/modules/contact-creation-manager/services/create-company-and-contact.service';
 
@@ -30,6 +31,7 @@ export class CreateCompanyAndContactJob {
         displayName: contact.displayName,
       })),
       workspaceId,
+      FieldCreatedBySource.EMAIL,
     );
   }
 }

--- a/packages/twenty-server/src/modules/contact-creation-manager/services/create-contact.service.ts
+++ b/packages/twenty-server/src/modules/contact-creation-manager/services/create-contact.service.ts
@@ -2,40 +2,33 @@ import { Injectable } from '@nestjs/common';
 
 import { EntityManager } from 'typeorm';
 import { v4 } from 'uuid';
+import camelCase from 'lodash.camelcase';
 
-import { InjectObjectMetadataRepository } from 'src/engine/object-metadata-repository/object-metadata-repository.decorator';
 import { getFirstNameAndLastNameFromHandleAndDisplayName } from 'src/modules/contact-creation-manager/utils/get-first-name-and-last-name-from-handle-and-display-name.util';
-import { PersonRepository } from 'src/modules/person/repositories/person.repository';
 import { PersonWorkspaceEntity } from 'src/modules/person/standard-objects/person.workspace-entity';
+import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.manager';
+import { FieldCreatedBySource } from 'src/engine/metadata-modules/field-metadata/composite-types/created-by.composite-type';
 
 type ContactToCreate = {
   handle: string;
   displayName: string;
   companyId?: string;
-};
-
-type FormattedContactToCreate = {
-  id: string;
-  handle: string;
-  firstName: string;
-  lastName: string;
-  companyId?: string;
+  source: FieldCreatedBySource;
 };
 
 @Injectable()
 export class CreateContactService {
   constructor(
-    @InjectObjectMetadataRepository(PersonWorkspaceEntity)
-    private readonly personRepository: PersonRepository,
+    private readonly twentyORMGlobalManager: TwentyORMGlobalManager,
   ) {}
 
   private formatContacts(
     contactsToCreate: ContactToCreate[],
-  ): FormattedContactToCreate[] {
+  ): DeepPartial<PersonWorkspaceEntity>[] {
     return contactsToCreate.map((contact) => {
       const id = v4();
 
-      const { handle, displayName, companyId } = contact;
+      const { handle, displayName, companyId, source } = contact;
 
       const { firstName, lastName } =
         getFirstNameAndLastNameFromHandleAndDisplayName(handle, displayName);
@@ -43,9 +36,17 @@ export class CreateContactService {
       return {
         id,
         handle,
-        firstName,
-        lastName,
+        name: {
+          firstName,
+          lastName,
+        },
         companyId,
+        // TODO: We need to add workspaceMemberId here, for that a system like loadServiceWithContext
+        // is needed so we can get the user id from the context when this service is called from a job
+        createdBy: {
+          source,
+          name: camelCase(source),
+        },
       };
     });
   }
@@ -54,14 +55,20 @@ export class CreateContactService {
     contactsToCreate: ContactToCreate[],
     workspaceId: string,
     transactionManager?: EntityManager,
-  ): Promise<PersonWorkspaceEntity[]> {
+  ): Promise<DeepPartial<PersonWorkspaceEntity>[]> {
     if (contactsToCreate.length === 0) return [];
+
+    const personRepository =
+      await this.twentyORMGlobalManager.getRepositoryForWorkspace(
+        workspaceId,
+        PersonWorkspaceEntity,
+      );
 
     const formattedContacts = this.formatContacts(contactsToCreate);
 
-    return await this.personRepository.createPeople(
+    return personRepository.save(
       formattedContacts,
-      workspaceId,
+      undefined,
       transactionManager,
     );
   }

--- a/packages/twenty-server/src/modules/messaging/message-participant-manager/jobs/messaging-create-company-and-contact-after-sync.job.ts
+++ b/packages/twenty-server/src/modules/messaging/message-participant-manager/jobs/messaging-create-company-and-contact-after-sync.job.ts
@@ -3,6 +3,7 @@ import { Logger } from '@nestjs/common';
 import { Process } from 'src/engine/integrations/message-queue/decorators/process.decorator';
 import { Processor } from 'src/engine/integrations/message-queue/decorators/processor.decorator';
 import { MessageQueue } from 'src/engine/integrations/message-queue/message-queue.constants';
+import { FieldCreatedBySource } from 'src/engine/metadata-modules/field-metadata/composite-types/created-by.composite-type';
 import { InjectObjectMetadataRepository } from 'src/engine/object-metadata-repository/object-metadata-repository.decorator';
 import { ConnectedAccountRepository } from 'src/modules/connected-account/repositories/connected-account.repository';
 import { ConnectedAccountWorkspaceEntity } from 'src/modules/connected-account/standard-objects/connected-account.workspace-entity';
@@ -84,6 +85,7 @@ export class MessagingCreateCompanyAndContactAfterSyncJob {
       connectedAccount,
       contactsToCreate,
       workspaceId,
+      FieldCreatedBySource.EMAIL,
     );
 
     this.logger.log(


### PR DESCRIPTION
This PR is a followup of #6324 to add support of `EMAIL` and `CALENDAR` source for the `CREATED_BY` composite field.