### PR TITLE
Add sort feature for Links type

### DIFF
--- a/packages/twenty-front/src/modules/object-metadata/constants/SortableFieldMetadataTypes.ts
+++ b/packages/twenty-front/src/modules/object-metadata/constants/SortableFieldMetadataTypes.ts
@@ -12,4 +12,5 @@ export const SORTABLE_FIELD_METADATA_TYPES = [
   FieldMetadataType.FullName,
   FieldMetadataType.Rating,
   FieldMetadataType.Currency,
+  FieldMetadataType.Links,
 ];

--- a/packages/twenty-front/src/modules/object-metadata/utils/getOrderByForFieldMetadataType.ts
+++ b/packages/twenty-front/src/modules/object-metadata/utils/getOrderByForFieldMetadataType.ts
@@ -1,6 +1,7 @@
 import { FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
 import { OrderBy } from '@/object-metadata/types/OrderBy';
 import { RecordGqlOperationOrderBy } from '@/object-record/graphql/types/RecordGqlOperationOrderBy';
+import { FieldLinksValue } from '@/object-record/record-field/types/FieldMetadata';
 import { FieldMetadataType } from '~/generated-metadata/graphql';
 
 export const getOrderByForFieldMetadataType = (
@@ -23,6 +24,14 @@ export const getOrderByForFieldMetadataType = (
           [field.name]: {
             amountMicros: direction ?? 'AscNullsLast',
           },
+        },
+      ];
+    case FieldMetadataType.Links:
+      return [
+        {
+          [field.name]: {
+            primaryLinkUrl: direction ?? 'AscNullsLast',
+          } satisfies { [key in keyof FieldLinksValue]?: OrderBy },
         },
       ];
     default:


### PR DESCRIPTION
Closes https://github.com/twentyhq/twenty/issues/5741

Filtering was already working.

I just added the required logic in the frontend to allow sorting by primary link url (because label can be empty)



