### PR TITLE
Add updated at column

### DIFF
--- a/packages/twenty-front/src/modules/settings/data-model/fields/preview/utils/getComputedDefaultValue.ts
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/preview/utils/getComputedDefaultValue.ts
@@ -1,0 +1,17 @@
+// Some default value are special keywords such as 'uuid' or 'now'
+// that are mapped to a function that generates a value on the backend.
+// (see serializeFunctionDefaultValue.ts on the server)
+// We need to do a similar mapping on the frontend
+
+import { v4 } from 'uuid';
+
+export const getComputedDefaultValue = (defaultValue?: any) => {
+  switch (defaultValue) {
+    case 'uuid':
+      return v4();
+    case 'now':
+      return new Date().toISOString();
+    default:
+      return null;
+  }
+};

--- a/packages/twenty-front/src/modules/settings/data-model/fields/preview/utils/getFieldPreviewValue.ts
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/preview/utils/getFieldPreviewValue.ts
@@ -1,5 +1,6 @@
 import { FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
 import { isFieldValueEmpty } from '@/object-record/record-field/utils/isFieldValueEmpty';
+import { getComputedDefaultValue } from '@/settings/data-model/fields/preview/utils/getComputedDefaultValue';
 import { getSettingsFieldTypeConfig } from '@/settings/data-model/utils/getSettingsFieldTypeConfig';
 import { isFieldTypeSupportedInSettings } from '@/settings/data-model/utils/isFieldTypeSupportedInSettings';
 import { isDefined } from '~/utils/isDefined';
@@ -17,7 +18,7 @@ export const getFieldPreviewValue = ({
       fieldValue: fieldMetadataItem.defaultValue,
     })
   ) {
-    return fieldMetadataItem.defaultValue;
+    return getComputedDefaultValue(fieldMetadataItem.defaultValue);
   }
 
   const fieldTypeConfig = getSettingsFieldTypeConfig(fieldMetadataItem.type);
@@ -27,7 +28,7 @@ export const getFieldPreviewValue = ({
     'defaultValue' in fieldTypeConfig &&
     isDefined(fieldTypeConfig.defaultValue)
   ) {
-    return fieldTypeConfig.defaultValue;
+    return getComputedDefaultValue(fieldTypeConfig.defaultValue);
   }
 
   return null;

--- a/packages/twenty-server/src/engine/twenty-orm/base.workspace-entity.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/base.workspace-entity.ts
@@ -30,11 +30,10 @@ export abstract class BaseWorkspaceEntity {
   @WorkspaceField({
     standardId: BASE_OBJECT_STANDARD_FIELD_IDS.updatedAt,
     type: FieldMetadataType.DATE_TIME,
-    label: 'Update date',
-    description: 'Update date',
-    icon: 'IconCalendar',
+    label: 'Last update',
+    description: 'Last time the record was changed',
+    icon: 'IconCalendarClock',
     defaultValue: 'now',
   })
-  @WorkspaceIsSystem()
   updatedAt: Date;
 }


### PR DESCRIPTION
Introduced `updatedAt` column. and fix an existing bug where the field edition page was crashing because we were trying to compute Date('now') (param coming from the default value)