### PR TITLE
Fix title padding and style on task and attachment

### DIFF
--- a/packages/twenty-front/src/modules/activities/files/components/AttachmentList.tsx
+++ b/packages/twenty-front/src/modules/activities/files/components/AttachmentList.tsx
@@ -1,5 +1,5 @@
-import { ReactElement, useState } from 'react';
 import styled from '@emotion/styled';
+import { ReactElement, useState } from 'react';
 
 import { DropZone } from '@/activities/files/components/DropZone';
 import { useUploadAttachmentFile } from '@/activities/files/hooks/useUploadAttachmentFile';
@@ -34,7 +34,7 @@ const StyledTitleBar = styled.h3`
   width: 100%;
 `;
 
-const StyledTitle = styled.h3`
+const StyledTitle = styled.span`
   color: ${({ theme }) => theme.font.color.primary};
   font-weight: ${({ theme }) => theme.font.weight.semiBold};
 `;

--- a/packages/twenty-front/src/modules/activities/tasks/components/TaskList.tsx
+++ b/packages/twenty-front/src/modules/activities/tasks/components/TaskList.tsx
@@ -28,7 +28,7 @@ const StyledTitleBar = styled.div`
   width: 100%;
 `;
 
-const StyledTitle = styled.h3`
+const StyledTitle = styled.span`
   color: ${({ theme }) => theme.font.color.primary};
   font-weight: ${({ theme }) => theme.font.weight.semiBold};
 `;


### PR DESCRIPTION
Fix https://github.com/twentyhq/twenty/issues/5923

<img width="593" alt="Capture d’écran 2024-08-02 à 12 09 24" src="https://github.com/user-attachments/assets/a1c84060-9b32-4780-beb7-f44b85e49d07">
<img width="593" alt="Capture d’écran 2024-08-02 à 12 09 29" src="https://github.com/user-attachments/assets/641cab31-723c-4253-9c3c-00fef70f2d06">
<img width="593" alt="Capture d’écran 2024-08-02 à 12 09 33" src="https://github.com/user-attachments/assets/ba2adcb6-7651-4288-91f3-304d13c3e7bd">
