### PR TITLE
Add command to backfill new onboarding user vars

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version/0-23/0-23-backfill-new-onboarding-user-vars.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-23/0-23-backfill-new-onboarding-user-vars.ts
@@ -1,0 +1,100 @@
+import { Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import chalk from 'chalk';
+import { Command, CommandRunner, Option } from 'nest-commander';
+import { Repository } from 'typeorm';
+
+import { UpdateFileFolderStructureCommand } from 'src/database/commands/upgrade-version/0-23/0-23-update-file-folder-structure.command';
+import { OnboardingService } from 'src/engine/core-modules/onboarding/onboarding.service';
+import {
+  Workspace,
+  WorkspaceActivationStatus,
+} from 'src/engine/core-modules/workspace/workspace.entity';
+
+interface BackfillNewOnboardingUserVarsCommandOptions {
+  workspaceId?: string;
+}
+
+@Command({
+  name: 'upgrade-0.23:backfill-new-onboarding-user-vars',
+  description: 'Backfill new onboarding user vars for existing workspaces',
+})
+export class BackfillNewOnboardingUserVarsCommand extends CommandRunner {
+  private readonly logger = new Logger(UpdateFileFolderStructureCommand.name);
+  constructor(
+    @InjectRepository(Workspace, 'core')
+    private readonly workspaceRepository: Repository<Workspace>,
+    private readonly onboardingService: OnboardingService,
+  ) {
+    super();
+  }
+
+  @Option({
+    flags: '-w, --workspace-id [workspace_id]',
+    description: 'workspace id. Command runs on all workspaces if not provided',
+    required: false,
+  })
+  parseWorkspaceId(value: string): string {
+    return value;
+  }
+
+  async run(
+    _passedParam: string[],
+    options: BackfillNewOnboardingUserVarsCommandOptions,
+  ): Promise<void> {
+    let workspaces;
+
+    if (options.workspaceId) {
+      workspaces = await this.workspaceRepository.find({
+        where: {
+          activationStatus: WorkspaceActivationStatus.ACTIVE,
+          id: options.workspaceId,
+        },
+        relations: ['users'],
+      });
+    } else {
+      workspaces = await this.workspaceRepository.find({
+        where: { activationStatus: WorkspaceActivationStatus.ACTIVE },
+        relations: ['users'],
+      });
+    }
+
+    if (!workspaces.length) {
+      this.logger.log(chalk.yellow('No workspace found'));
+
+      return;
+    }
+
+    this.logger.log(
+      chalk.green(`Running command on ${workspaces.length} workspaces`),
+    );
+
+    for (const workspace of workspaces) {
+      this.logger.log(
+        chalk.green(`Running command on workspace ${workspace.id}`),
+      );
+
+      await this.onboardingService.toggleOnboardingInviteTeamCompletion({
+        workspaceId: workspace.id,
+        value: true,
+      });
+
+      for (const user of workspace.users) {
+        await this.onboardingService.toggleOnboardingConnectAccountCompletion({
+          userId: user.id,
+          workspaceId: workspace.id,
+          value: true,
+        });
+
+        await this.onboardingService.toggleOnboardingCreateProfileCompletion({
+          userId: user.id,
+          workspaceId: workspace.id,
+          value: true,
+        });
+      }
+    }
+
+    this.logger.log(chalk.green(`Command completed!`));
+  }
+}

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-23/0-23-migrate-domain-to-links.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-23/0-23-migrate-domain-to-links.command.ts
@@ -25,7 +25,7 @@ interface MigrateDomainNameFromTextToLinksCommandOptions {
 }
 
 @Command({
-  name: 'migrate-0.23:migrate-domain-standard-field-to-links',
+  name: 'upgrade-0.23:migrate-domain-standard-field-to-links',
   description:
     'Migrating field domainName of deprecated type TEXT to type LINKS',
 })

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-23/0-23-migrate-link-fields-to-links.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-23/0-23-migrate-link-fields-to-links.command.ts
@@ -27,7 +27,7 @@ interface MigrateLinkFieldsToLinksCommandOptions {
 }
 
 @Command({
-  name: 'migrate-0.23:migrate-link-fields-to-links',
+  name: 'upgrade-0.23:migrate-link-fields-to-links',
   description: 'Migrating fields of deprecated type LINK to type LINKS',
 })
 export class MigrateLinkFieldsToLinksCommand extends CommandRunner {

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-23/0-23-migrate-message-channel-sync-status-enum.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-23/0-23-migrate-message-channel-sync-status-enum.command.ts
@@ -19,7 +19,7 @@ interface MigrateMessageChannelSyncStatusEnumCommandOptions {
 }
 
 @Command({
-  name: 'migrate-0.23:update-message-channel-sync-status-enum',
+  name: 'upgrade-0.23:update-message-channel-sync-status-enum',
   description: 'Migrate messageChannel syncStatus enum',
 })
 export class MigrateMessageChannelSyncStatusEnumCommand extends CommandRunner {

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-23/0-23-set-workspace-activation-status.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-23/0-23-set-workspace-activation-status.command.ts
@@ -19,7 +19,7 @@ interface SetWorkspaceActivationStatusCommandOptions {
 }
 
 @Command({
-  name: 'migrate-0.23:set-workspace-activation-status',
+  name: 'upgrade-0.23:set-workspace-activation-status',
   description: 'Set workspace activation status',
 })
 export class SetWorkspaceActivationStatusCommand extends CommandRunner {

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-23/0-23-update-activities.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-23/0-23-update-activities.command.ts
@@ -34,7 +34,7 @@ type CoreLogicFunction = (params: {
 }) => Promise<void>;
 
 @Command({
-  name: 'migrate-0.23:update-activities-type',
+  name: 'upgrade-0.23:update-activities-type',
   description: 'Migrate Activity object to Note and Task objects',
 })
 export class UpdateActivitiesCommand extends CommandRunner {

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-23/0-23-upgrade-version.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-23/0-23-upgrade-version.command.ts
@@ -1,5 +1,6 @@
 import { Command, CommandRunner, Option } from 'nest-commander';
 
+import { BackfillNewOnboardingUserVarsCommand } from 'src/database/commands/upgrade-version/0-23/0-23-backfill-new-onboarding-user-vars';
 import { MigrateDomainNameFromTextToLinksCommand } from 'src/database/commands/upgrade-version/0-23/0-23-migrate-domain-to-links.command';
 import { MigrateLinkFieldsToLinksCommand } from 'src/database/commands/upgrade-version/0-23/0-23-migrate-link-fields-to-links.command';
 import { MigrateMessageChannelSyncStatusEnumCommand } from 'src/database/commands/upgrade-version/0-23/0-23-migrate-message-channel-sync-status-enum.command';
@@ -23,6 +24,7 @@ export class UpgradeTo0_23Command extends CommandRunner {
     private readonly migrateMessageChannelSyncStatusEnumCommand: MigrateMessageChannelSyncStatusEnumCommand,
     private readonly setWorkspaceActivationStatusCommand: SetWorkspaceActivationStatusCommand,
     private readonly updateActivitiesCommand: UpdateActivitiesCommand,
+    private readonly backfillNewOnboardingUserVarsCommand: BackfillNewOnboardingUserVarsCommand,
   ) {
     super();
   }
@@ -53,5 +55,6 @@ export class UpgradeTo0_23Command extends CommandRunner {
       options,
     );
     await this.updateActivitiesCommand.run(_passedParam, options);
+    await this.backfillNewOnboardingUserVarsCommand.run(_passedParam, options);
   }
 }

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-23/0-23-upgrade-version.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-23/0-23-upgrade-version.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { BackfillNewOnboardingUserVarsCommand } from 'src/database/commands/upgrade-version/0-23/0-23-backfill-new-onboarding-user-vars';
 import { MigrateDomainNameFromTextToLinksCommand } from 'src/database/commands/upgrade-version/0-23/0-23-migrate-domain-to-links.command';
 import { MigrateLinkFieldsToLinksCommand } from 'src/database/commands/upgrade-version/0-23/0-23-migrate-link-fields-to-links.command';
 import { MigrateMessageChannelSyncStatusEnumCommand } from 'src/database/commands/upgrade-version/0-23/0-23-migrate-message-channel-sync-status-enum.command';
@@ -10,6 +11,7 @@ import { UpdateFileFolderStructureCommand } from 'src/database/commands/upgrade-
 import { UpgradeTo0_23Command } from 'src/database/commands/upgrade-version/0-23/0-23-upgrade-version.command';
 import { TypeORMModule } from 'src/database/typeorm/typeorm.module';
 import { BillingModule } from 'src/engine/core-modules/billing/billing.module';
+import { OnboardingModule } from 'src/engine/core-modules/onboarding/onboarding.module';
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { FileStorageModule } from 'src/engine/integrations/file-storage/file-storage.module';
 import { DataSourceModule } from 'src/engine/metadata-modules/data-source/data-source.module';
@@ -25,6 +27,7 @@ import { ViewModule } from 'src/modules/view/view.module';
   imports: [
     TypeOrmModule.forFeature([Workspace], 'core'),
     FileStorageModule,
+    OnboardingModule,
     TypeORMModule,
     DataSourceModule,
     WorkspaceCacheVersionModule,
@@ -46,6 +49,7 @@ import { ViewModule } from 'src/modules/view/view.module';
     MigrateMessageChannelSyncStatusEnumCommand,
     SetWorkspaceActivationStatusCommand,
     UpdateActivitiesCommand,
+    BackfillNewOnboardingUserVarsCommand,
     UpgradeTo0_23Command,
   ],
 })

--- a/packages/twenty-server/src/database/commands/upgrade-version/upgrade-version.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/upgrade-version.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { DataSeedDemoWorkspaceModule } from 'src/database/commands/data-seed-demo-workspace/data-seed-demo-workspace.module';
+import { BackfillNewOnboardingUserVarsCommand } from 'src/database/commands/upgrade-version/0-23/0-23-backfill-new-onboarding-user-vars';
 import { MigrateDomainNameFromTextToLinksCommand } from 'src/database/commands/upgrade-version/0-23/0-23-migrate-domain-to-links.command';
 import { MigrateLinkFieldsToLinksCommand } from 'src/database/commands/upgrade-version/0-23/0-23-migrate-link-fields-to-links.command';
 import { MigrateMessageChannelSyncStatusEnumCommand } from 'src/database/commands/upgrade-version/0-23/0-23-migrate-message-channel-sync-status-enum.command';
@@ -12,6 +13,7 @@ import { TypeORMModule } from 'src/database/typeorm/typeorm.module';
 import { BillingModule } from 'src/engine/core-modules/billing/billing.module';
 import { BillingSubscription } from 'src/engine/core-modules/billing/entities/billing-subscription.entity';
 import { FeatureFlagEntity } from 'src/engine/core-modules/feature-flag/feature-flag.entity';
+import { OnboardingModule } from 'src/engine/core-modules/onboarding/onboarding.module';
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { WorkspaceModule } from 'src/engine/core-modules/workspace/workspace.module';
 import { DataSourceModule } from 'src/engine/metadata-modules/data-source/data-source.module';
@@ -30,6 +32,7 @@ import { ViewModule } from 'src/modules/view/view.module';
   imports: [
     WorkspaceManagerModule,
     DataSourceModule,
+    OnboardingModule,
     TypeORMModule,
     TypeOrmModule.forFeature(
       [Workspace, BillingSubscription, FeatureFlagEntity],
@@ -57,6 +60,7 @@ import { ViewModule } from 'src/modules/view/view.module';
     MigrateMessageChannelSyncStatusEnumCommand,
     SetWorkspaceActivationStatusCommand,
     UpdateActivitiesCommand,
+    BackfillNewOnboardingUserVarsCommand,
   ],
 })
 export class UpgradeVersionModule {}


### PR DESCRIPTION
As per our guideline to maintain a smooth migration to the new minor versions, this command is backfilling existing workspaces with the 3 userVars used to keep track of user onboarding: 
```
  ONBOARDING_CONNECT_ACCOUNT_COMPLETE = 'ONBOARDING_CONNECT_ACCOUNT_COMPLETE',
  ONBOARDING_INVITE_TEAM_COMPLETE = 'ONBOARDING_INVITE_TEAM_COMPLETE',
  ONBOARDING_CREATE_PROFILE_COMPLETE = 'ONBOARDING_CREATE_PROFILE_COMPLETE',
```