### PR TITLE
fix(wip): tasks navigate to /objects/tasks with viewId

### DIFF
--- a/packages/twenty-front/src/effect-components/GotoHotkeysEffect.tsx
+++ b/packages/twenty-front/src/effect-components/GotoHotkeysEffect.tsx
@@ -5,7 +5,7 @@ export const GotoHotkeysEffect = () => {
   useGoToHotkeys('c', '/objects/companies');
   useGoToHotkeys('o', '/objects/opportunities');
   useGoToHotkeys('s', '/settings/profile');
-  useGoToHotkeys('t', '/tasks');
+  useGoToHotkeys('t', '/objects/tasks');
 
   return <></>;
 };

--- a/packages/twenty-front/src/modules/command-menu/constants/CommandMenuCommands.ts
+++ b/packages/twenty-front/src/modules/command-menu/constants/CommandMenuCommands.ts
@@ -47,7 +47,7 @@ export const COMMAND_MENU_COMMANDS: Command[] = [
   },
   {
     id: 'go-to-tasks',
-    to: '/tasks',
+    to: '/objects/tasks',
     label: 'Go to Tasks',
     type: CommandType.Navigate,
     firstHotKey: 'G',


### PR DESCRIPTION
ISSUE (BUG)

Fixes: #6523 

Description:
- [ ] Should work on Command Menu
- [ ] Should also work on Global Goto Hotkeys
- [ ] Should navigate with viewId, as when we click on Navigationbar it is navigating with viewId. 