### PR TITLE
fix: releases list to have styles according to theme

### DIFF
--- a/packages/twenty-front/src/pages/settings/Releases.tsx
+++ b/packages/twenty-front/src/pages/settings/Releases.tsx
@@ -51,6 +51,14 @@ const StyledReleaseContainer = styled.div`
     margin: ${({ theme }) => theme.spacing(6)} 0px 0px;
     text-align: justify;
   }
+
+  li {
+    color: ${({ theme }) => theme.font.color.secondary};
+  }
+
+  li strong {
+    color: ${({ theme }) => theme.font.color.primary};
+  }
 `;
 
 const StyledReleaseHeader = styled.h2`


### PR DESCRIPTION
### ISSUE (BUG)

- Fixes: #6524

### DESCRIPTION

- List styles wasn't applying based on the theme, reason for applying css to directly to **li** and **li strong** instead of applying to unorderlist-element is that later on we might have **orderlist** in that case if we had apply to **ul** here, this will  issue will be raised again, thus in **list element** 

https://github.com/user-attachments/assets/64f0870e-4f82-4afd-8452-778aa54023fc


