### PR TITLE
Timeline log displays empty when field value deleted

### DIFF
--- a/packages/twenty-front/src/modules/activities/timelineActivities/rows/main-object/components/EventFieldDiff.tsx
+++ b/packages/twenty-front/src/modules/activities/timelineActivities/rows/main-object/components/EventFieldDiff.tsx
@@ -37,14 +37,17 @@ export const EventFieldDiff = ({
     throw new Error('fieldMetadataItem is required');
   }
 
-  const isValueEmpty = (value: any) =>
+  const isValueEmpty = (value: unknown): boolean =>
     value === null || value === undefined || value === '';
+
+  const isObjectEmpty = (obj: Record<string, unknown>): boolean =>
+    Object.values(obj).every(isValueEmpty);
 
   const isUpdatedToEmpty =
     isValueEmpty(diffRecord) ||
     (typeof diffRecord === 'object' &&
       diffRecord !== null &&
-      Object.values(diffRecord).every(isValueEmpty));
+      isObjectEmpty(diffRecord));
 
   return (
     <RecordFieldValueSelectorContextProvider>

--- a/packages/twenty-front/src/modules/activities/timelineActivities/rows/main-object/components/EventFieldDiff.tsx
+++ b/packages/twenty-front/src/modules/activities/timelineActivities/rows/main-object/components/EventFieldDiff.tsx
@@ -23,6 +23,10 @@ const StyledEventFieldDiffContainer = styled.div`
   width: 380px;
 `;
 
+const StyledEmptyValue = styled.div`
+  color: ${({ theme }) => theme.font.color.tertiary};
+`;
+
 export const EventFieldDiff = ({
   diffRecord,
   mainObjectMetadataItem,
@@ -33,21 +37,31 @@ export const EventFieldDiff = ({
     throw new Error('fieldMetadataItem is required');
   }
 
+  const isUpdatedToEmpty = Object.values(diffRecord).every(
+    (value) => value === null || value === undefined || value === '',
+  );
+
   return (
     <RecordFieldValueSelectorContextProvider>
       <StyledEventFieldDiffContainer>
         <EventFieldDiffLabel fieldMetadataItem={fieldMetadataItem} />→
-        <EventFieldDiffValueEffect
-          diffArtificialRecordStoreId={diffArtificialRecordStoreId}
-          mainObjectMetadataItem={mainObjectMetadataItem}
-          fieldMetadataItem={fieldMetadataItem}
-          diffRecord={diffRecord}
-        />
-        <EventFieldDiffValue
-          diffArtificialRecordStoreId={diffArtificialRecordStoreId}
-          mainObjectMetadataItem={mainObjectMetadataItem}
-          fieldMetadataItem={fieldMetadataItem}
-        />
+        {isUpdatedToEmpty ? (
+          <StyledEmptyValue>Empty</StyledEmptyValue>
+        ) : (
+          <>
+            <EventFieldDiffValueEffect
+              diffArtificialRecordStoreId={diffArtificialRecordStoreId}
+              mainObjectMetadataItem={mainObjectMetadataItem}
+              fieldMetadataItem={fieldMetadataItem}
+              diffRecord={diffRecord}
+            />
+            <EventFieldDiffValue
+              diffArtificialRecordStoreId={diffArtificialRecordStoreId}
+              mainObjectMetadataItem={mainObjectMetadataItem}
+              fieldMetadataItem={fieldMetadataItem}
+            />
+          </>
+        )}
       </StyledEventFieldDiffContainer>
     </RecordFieldValueSelectorContextProvider>
   );

--- a/packages/twenty-front/src/modules/activities/timelineActivities/rows/main-object/components/EventFieldDiff.tsx
+++ b/packages/twenty-front/src/modules/activities/timelineActivities/rows/main-object/components/EventFieldDiff.tsx
@@ -37,9 +37,13 @@ export const EventFieldDiff = ({
     throw new Error('fieldMetadataItem is required');
   }
 
-  const isUpdatedToEmpty = Object.values(diffRecord).every(
-    (value) => value === null || value === undefined || value === '',
-  );
+  const isValueEmpty = (value: any) =>
+    value === null || value === undefined || value === '';
+
+  const isUpdatedToEmpty =
+    isValueEmpty(diffRecord) ||
+    (typeof diffRecord === 'object' &&
+      Object.values(diffRecord).every(isValueEmpty));
 
   return (
     <RecordFieldValueSelectorContextProvider>

--- a/packages/twenty-front/src/modules/activities/timelineActivities/rows/main-object/components/EventFieldDiff.tsx
+++ b/packages/twenty-front/src/modules/activities/timelineActivities/rows/main-object/components/EventFieldDiff.tsx
@@ -43,6 +43,7 @@ export const EventFieldDiff = ({
   const isUpdatedToEmpty =
     isValueEmpty(diffRecord) ||
     (typeof diffRecord === 'object' &&
+      diffRecord !== null &&
       Object.values(diffRecord).every(isValueEmpty));
 
   return (


### PR DESCRIPTION
Fixes https://github.com/twentyhq/twenty/issues/6288

## Before
<img width="1282" alt="Screenshot 2024-08-05 at 13 22 13" src="https://github.com/user-attachments/assets/27bf3343-7d6a-440f-905b-e55fdde918d7">

## After
<img width="1251" alt="Screenshot 2024-08-05 at 13 22 05" src="https://github.com/user-attachments/assets/25404bff-9d90-4631-af09-fe18b6df43f5">
