### PR TITLE
fix: vite to allow serve fonts from blocknote and any files from root of workspace

### DIFF
--- a/packages/twenty-front/vite.config.ts
+++ b/packages/twenty-front/vite.config.ts
@@ -1,7 +1,7 @@
 import react from '@vitejs/plugin-react-swc';
 import wyw from '@wyw-in-js/vite';
 import path from 'path';
-import { defineConfig, loadEnv } from 'vite';
+import { defineConfig, loadEnv, searchForWorkspaceRoot } from 'vite';
 import checker from 'vite-plugin-checker';
 import svgr from 'vite-plugin-svgr';
 import tsconfigPaths from 'vite-tsconfig-paths';
@@ -40,6 +40,12 @@ export default defineConfig(({ command, mode }) => {
     server: {
       port: 3001,
       host: 'localhost',
+      fs: {
+        allow: [
+          searchForWorkspaceRoot(process.cwd()),
+          '**/@blocknote/core/src/fonts/**',
+        ],
+      },
     },
 
     plugins: [


### PR DESCRIPTION
## ISSUE

- Fixes #6546 

## Description

- Now we don't get error logs and we are allowing vite to serve from blocknote and root workspace. 