### PR TITLE
fix attachment upload

### DIFF
--- a/packages/twenty-front/src/modules/activities/files/hooks/__tests__/useUploadAttachmentFile.test.tsx
+++ b/packages/twenty-front/src/modules/activities/files/hooks/__tests__/useUploadAttachmentFile.test.tsx
@@ -1,0 +1,14 @@
+import { computePathWithoutToken } from '../useUploadAttachmentFile';
+
+describe('computePathWithoutToken', () => {
+  it('should remove token from path', () => {
+    const input = 'https://example.com/image.jpg?token=abc123';
+    const expected = 'https://example.com/image.jpg';
+    expect(computePathWithoutToken(input)).toBe(expected);
+  });
+
+  it('should handle path without token', () => {
+    const input = 'https://example.com/image.jpg?size=large';
+    expect(computePathWithoutToken(input)).toBe(input);
+  });
+});

--- a/packages/twenty-front/src/modules/activities/files/hooks/useUploadAttachmentFile.tsx
+++ b/packages/twenty-front/src/modules/activities/files/hooks/useUploadAttachmentFile.tsx
@@ -9,6 +9,11 @@ import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSi
 import { useCreateOneRecord } from '@/object-record/hooks/useCreateOneRecord';
 import { FileFolder, useUploadFileMutation } from '~/generated/graphql';
 
+// Note: This is probably not the right way to do this.
+export const computePathWithoutToken = (attachmentPath: string): string => {
+  return attachmentPath.replace(/\?token=[^&]*$/, '');
+};
+
 export const useUploadAttachmentFile = () => {
   const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
   const [uploadFile] = useUploadFileMutation();
@@ -29,9 +34,9 @@ export const useUploadAttachmentFile = () => {
       },
     });
 
-    const attachmentUrl = result?.data?.uploadFile;
+    const attachmentPath = result?.data?.uploadFile;
 
-    if (!attachmentUrl) {
+    if (!attachmentPath) {
       return;
     }
 
@@ -42,7 +47,7 @@ export const useUploadAttachmentFile = () => {
     const attachmentToCreate = {
       authorId: currentWorkspaceMember?.id,
       name: file.name,
-      fullPath: attachmentUrl,
+      fullPath: computePathWithoutToken(attachmentPath),
       type: getFileType(file.name),
       [targetableObjectFieldIdName]: targetableObject.id,
       createdAt: new Date().toISOString(),


### PR DESCRIPTION
## Context
UploadFile now returns the file token which we don't want when we save the attachment in the DB due to its non-persistence so now the FE removes the token query param before saving the attachment. This is most likely not the right way to do it, we will need to refactor this part before.

Also made sure we don't save the token in the DB for rich_text as well and remove it before saving.