### PR TITLE
Improve QueryFailedError message in sync-metadata

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/workspace-sync-metadata.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/workspace-sync-metadata.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectDataSource } from '@nestjs/typeorm';
 
-import { DataSource } from 'typeorm';
+import { DataSource, QueryFailedError } from 'typeorm';
 
 import { WorkspaceSyncContext } from 'src/engine/workspace-manager/workspace-sync-metadata/interfaces/workspace-sync-context.interface';
 
@@ -150,6 +150,10 @@ export class WorkspaceSyncMetadataService {
       );
     } catch (error) {
       this.logger.error('Sync of standard objects failed with:', error);
+
+      if (error instanceof QueryFailedError && (error as any).detail) {
+        this.logger.error((error as any).detail);
+      }
       await queryRunner.rollbackTransaction();
     } finally {
       await queryRunner.release();


### PR DESCRIPTION
Adding more logs with Typeorm QueryFailedError in sync-metadata command

Example with a unicity constraint violation, to identify which column is affected
<img width="841" alt="Screenshot 2024-08-09 at 14 56 05" src="https://github.com/user-attachments/assets/c47fbb1d-77ee-4d7a-87e7-dbe54a6aa941">

In this case, this should help self-hosting users to know which key is a duplicate during syncs after a version upgrade for example
