### PR TITLE
Fix query runner exceptions not being handled properly

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/workspace-resolver-builder/factories/create-many-resolver.factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-resolver-builder/factories/create-many-resolver.factory.ts
@@ -25,9 +25,9 @@ export class CreateManyResolverFactory
   ): Resolver<CreateManyResolverArgs> {
     const internalContext = context;
 
-    return (_source, args, context, info) => {
+    return async (_source, args, context, info) => {
       try {
-        return this.workspaceQueryRunnerService.createMany(args, {
+        return await this.workspaceQueryRunnerService.createMany(args, {
           authContext: internalContext.authContext,
           objectMetadataItem: internalContext.objectMetadataItem,
           info,

--- a/packages/twenty-server/src/engine/api/graphql/workspace-resolver-builder/factories/create-one-resolver.factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-resolver-builder/factories/create-one-resolver.factory.ts
@@ -25,9 +25,9 @@ export class CreateOneResolverFactory
   ): Resolver<CreateOneResolverArgs> {
     const internalContext = context;
 
-    return (_source, args, context, info) => {
+    return async (_source, args, context, info) => {
       try {
-        return this.workspaceQueryRunnerService.createOne(args, {
+        return await this.workspaceQueryRunnerService.createOne(args, {
           authContext: internalContext.authContext,
           objectMetadataItem: internalContext.objectMetadataItem,
           info,

--- a/packages/twenty-server/src/engine/api/graphql/workspace-resolver-builder/factories/delete-many-resolver.factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-resolver-builder/factories/delete-many-resolver.factory.ts
@@ -25,9 +25,9 @@ export class DeleteManyResolverFactory
   ): Resolver<DeleteManyResolverArgs> {
     const internalContext = context;
 
-    return (_source, args, context, info) => {
+    return async (_source, args, context, info) => {
       try {
-        return this.workspaceQueryRunnerService.deleteMany(args, {
+        return await this.workspaceQueryRunnerService.deleteMany(args, {
           authContext: internalContext.authContext,
           objectMetadataItem: internalContext.objectMetadataItem,
           info,

--- a/packages/twenty-server/src/engine/api/graphql/workspace-resolver-builder/factories/delete-one-resolver.factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-resolver-builder/factories/delete-one-resolver.factory.ts
@@ -25,9 +25,9 @@ export class DeleteOneResolverFactory
   ): Resolver<DeleteOneResolverArgs> {
     const internalContext = context;
 
-    return (_source, args, context, info) => {
+    return async (_source, args, context, info) => {
       try {
-        return this.workspaceQueryRunnerService.deleteOne(args, {
+        return await this.workspaceQueryRunnerService.deleteOne(args, {
           authContext: internalContext.authContext,
           objectMetadataItem: internalContext.objectMetadataItem,
           info,

--- a/packages/twenty-server/src/engine/api/graphql/workspace-resolver-builder/factories/find-duplicates-resolver.factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-resolver-builder/factories/find-duplicates-resolver.factory.ts
@@ -25,9 +25,9 @@ export class FindDuplicatesResolverFactory
   ): Resolver<FindDuplicatesResolverArgs> {
     const internalContext = context;
 
-    return (_source, args, context, info) => {
+    return async (_source, args, context, info) => {
       try {
-        return this.workspaceQueryRunnerService.findDuplicates(args, {
+        return await this.workspaceQueryRunnerService.findDuplicates(args, {
           authContext: internalContext.authContext,
           objectMetadataItem: internalContext.objectMetadataItem,
           info,

--- a/packages/twenty-server/src/engine/api/graphql/workspace-resolver-builder/factories/find-many-resolver.factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-resolver-builder/factories/find-many-resolver.factory.ts
@@ -25,9 +25,9 @@ export class FindManyResolverFactory
   ): Resolver<FindManyResolverArgs> {
     const internalContext = context;
 
-    return (_source, args, context, info) => {
+    return async (_source, args, context, info) => {
       try {
-        return this.workspaceQueryRunnerService.findMany(args, {
+        return await this.workspaceQueryRunnerService.findMany(args, {
           authContext: internalContext.authContext,
           objectMetadataItem: internalContext.objectMetadataItem,
           info,

--- a/packages/twenty-server/src/engine/api/graphql/workspace-resolver-builder/factories/find-one-resolver.factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-resolver-builder/factories/find-one-resolver.factory.ts
@@ -25,9 +25,9 @@ export class FindOneResolverFactory
   ): Resolver<FindOneResolverArgs> {
     const internalContext = context;
 
-    return (_source, args, context, info) => {
+    return async (_source, args, context, info) => {
       try {
-        return this.workspaceQueryRunnerService.findOne(args, {
+        return await this.workspaceQueryRunnerService.findOne(args, {
           authContext: internalContext.authContext,
           objectMetadataItem: internalContext.objectMetadataItem,
           info,

--- a/packages/twenty-server/src/engine/api/graphql/workspace-resolver-builder/factories/update-many-resolver.factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-resolver-builder/factories/update-many-resolver.factory.ts
@@ -25,9 +25,9 @@ export class UpdateManyResolverFactory
   ): Resolver<UpdateManyResolverArgs> {
     const internalContext = context;
 
-    return (_source, args, context, info) => {
+    return async (_source, args, context, info) => {
       try {
-        return this.workspaceQueryRunnerService.updateMany(args, {
+        return await this.workspaceQueryRunnerService.updateMany(args, {
           authContext: internalContext.authContext,
           objectMetadataItem: internalContext.objectMetadataItem,
           info,

--- a/packages/twenty-server/src/engine/api/graphql/workspace-resolver-builder/factories/update-one-resolver.factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-resolver-builder/factories/update-one-resolver.factory.ts
@@ -25,9 +25,9 @@ export class UpdateOneResolverFactory
   ): Resolver<UpdateOneResolverArgs> {
     const internalContext = context;
 
-    return (_source, args, context, info) => {
+    return async (_source, args, context, info) => {
       try {
-        return this.workspaceQueryRunnerService.updateOne(args, {
+        return await this.workspaceQueryRunnerService.updateOne(args, {
           authContext: internalContext.authContext,
           objectMetadataItem: internalContext.objectMetadataItem,
           info,


### PR DESCRIPTION
## Context

We recently introduced a try catch in the different resolvers of the query runner to handle exceptions via workspaceQueryRunnerGraphqlApiExceptionHandler and convert them to proper errors. However this was never called as expected because query runner methods were async. 
This is a regression from https://github.com/twentyhq/twenty/pull/6324

## Before

<img width="938" alt="Screenshot 2024-08-09 at 15 34 02" src="https://github.com/user-attachments/assets/3607c7ed-ea91-4729-a4e4-ede7761347e2">


## After

<img width="905" alt="Screenshot 2024-08-09 at 15 33 46" src="https://github.com/user-attachments/assets/51bcbfa1-9b0b-4c7c-84a2-7c8effeadddd">
