### PR TITLE
fix: column overlay issue in record table header cells

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-header/components/RecordTableColumnHead.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-header/components/RecordTableColumnHead.tsx
@@ -33,6 +33,7 @@ const StyledTitle = styled.div<{ hideTitle?: boolean }>`
 
 const StyledIcon = styled.div`
   display: flex;
+  flex-shrink: 0;
 
   & > svg {
     height: ${({ theme }) => theme.icon.size.md}px;

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-header/components/RecordTableHeaderCell.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-header/components/RecordTableHeaderCell.tsx
@@ -60,6 +60,9 @@ const StyledColumnHeaderCell = styled.th<{
       }`;
     }
   }};
+  div {
+    overflow: hidden;
+  }
 `;
 
 const StyledResizeHandler = styled.div`


### PR DESCRIPTION
### Issue (BUG)

- Fixes #6604 

### Description

- Now Columns doesn't overlay on header cells, issue was independant of field type.  

#### Before 

https://github.com/user-attachments/assets/0872f07a-83b2-44d8-8f8e-c61c5fac5278

#### After


https://github.com/user-attachments/assets/e2e623f6-6635-4ab6-8ca2-cbd3a296c27d





