### PR TITLE
5x Fix cache performance issues

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/calendar/timeline-calendar-event.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/calendar/timeline-calendar-event.service.ts
@@ -22,6 +22,7 @@ export class TimelineCalendarEventService {
   ): Promise<TimelineCalendarEventsWithTotal> {
     const offset = (page - 1) * pageSize;
 
+    console.time('getCalendarEventsFromPersonIds');
     const calendarEventRepository =
       await this.twentyORMManager.getRepository<CalendarEventWorkspaceEntity>(
         'calendarEvent',

--- a/packages/twenty-server/src/engine/core-modules/calendar/timeline-calendar-event.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/calendar/timeline-calendar-event.service.ts
@@ -22,7 +22,6 @@ export class TimelineCalendarEventService {
   ): Promise<TimelineCalendarEventsWithTotal> {
     const offset = (page - 1) * pageSize;
 
-    console.time('getCalendarEventsFromPersonIds');
     const calendarEventRepository =
       await this.twentyORMManager.getRepository<CalendarEventWorkspaceEntity>(
         'calendarEvent',

--- a/packages/twenty-server/src/engine/twenty-orm/factories/entity-schema-relation.factory.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/factories/entity-schema-relation.factory.ts
@@ -3,8 +3,8 @@ import { Injectable } from '@nestjs/common';
 import { EntitySchemaRelationOptions } from 'typeorm';
 
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
-import { isRelationFieldMetadataType } from 'src/engine/utils/is-relation-field-metadata-type.util';
 import { determineRelationDetails } from 'src/engine/twenty-orm/utils/determine-relation-details.util';
+import { isRelationFieldMetadataType } from 'src/engine/utils/is-relation-field-metadata-type.util';
 import { WorkspaceCacheStorageService } from 'src/engine/workspace-cache-storage/workspace-cache-storage.service';
 
 type EntitySchemaRelationMap = {
@@ -37,11 +37,15 @@ export class EntitySchemaRelationFactory {
         );
       }
 
+      const objectMetadataCollection =
+        await this.workspaceCacheStorageService.getObjectMetadataCollection(
+          workspaceId,
+        );
+
       const relationDetails = await determineRelationDetails(
-        workspaceId,
         fieldMetadata,
         relationMetadata,
-        this.workspaceCacheStorageService,
+        objectMetadataCollection,
       );
 
       entitySchemaRelationMap[fieldMetadata.name] = {

--- a/packages/twenty-server/src/engine/twenty-orm/factories/entity-schema-relation.factory.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/factories/entity-schema-relation.factory.ts
@@ -42,6 +42,10 @@ export class EntitySchemaRelationFactory {
           workspaceId,
         );
 
+      if (!objectMetadataCollection) {
+        throw new Error('Object metadata collection not found');
+      }
+
       const relationDetails = await determineRelationDetails(
         fieldMetadata,
         relationMetadata,

--- a/packages/twenty-server/src/engine/twenty-orm/factories/workspace-datasource.factory.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/factories/workspace-datasource.factory.ts
@@ -94,6 +94,7 @@ export class WorkspaceDatasourceFactory {
           {
             workspaceId,
             workspaceCacheStorage: this.workspaceCacheStorageService,
+            objectMetadataCollection: cachedObjectMetadataCollection,
           },
           {
             url:

--- a/packages/twenty-server/src/engine/twenty-orm/factories/workspace-datasource.factory.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/factories/workspace-datasource.factory.ts
@@ -93,7 +93,6 @@ export class WorkspaceDatasourceFactory {
         const workspaceDataSource = new WorkspaceDataSource(
           {
             workspaceId,
-            workspaceCacheStorage: this.workspaceCacheStorageService,
             objectMetadataCollection: cachedObjectMetadataCollection,
           },
           {

--- a/packages/twenty-server/src/engine/twenty-orm/interfaces/workspace-internal-context.interface.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/interfaces/workspace-internal-context.interface.ts
@@ -1,6 +1,8 @@
+import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 import { WorkspaceCacheStorageService } from 'src/engine/workspace-cache-storage/workspace-cache-storage.service';
 
 export interface WorkspaceInternalContext {
   workspaceId: string;
   workspaceCacheStorage: WorkspaceCacheStorageService;
+  objectMetadataCollection: ObjectMetadataEntity[];
 }

--- a/packages/twenty-server/src/engine/twenty-orm/interfaces/workspace-internal-context.interface.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/interfaces/workspace-internal-context.interface.ts
@@ -1,8 +1,6 @@
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
-import { WorkspaceCacheStorageService } from 'src/engine/workspace-cache-storage/workspace-cache-storage.service';
 
 export interface WorkspaceInternalContext {
   workspaceId: string;
-  workspaceCacheStorage: WorkspaceCacheStorageService;
   objectMetadataCollection: ObjectMetadataEntity[];
 }

--- a/packages/twenty-server/src/engine/twenty-orm/repository/workspace.repository.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/repository/workspace.repository.ts
@@ -69,7 +69,6 @@ export class WorkspaceRepository<
     const manager = entityManager || this.manager;
     const computedOptions = await this.transformOptions({ where });
     const result = await manager.findBy(this.target, computedOptions.where);
-
     const formattedResult = await this.formatResult(result);
 
     return formattedResult;
@@ -82,7 +81,6 @@ export class WorkspaceRepository<
     const manager = entityManager || this.manager;
     const computedOptions = await this.transformOptions(options);
     const result = await manager.findAndCount(this.target, computedOptions);
-
     const formattedResult = await this.formatResult(result);
 
     return formattedResult;
@@ -98,7 +96,6 @@ export class WorkspaceRepository<
       this.target,
       computedOptions.where,
     );
-
     const formattedResult = await this.formatResult(result);
 
     return formattedResult;
@@ -111,7 +108,6 @@ export class WorkspaceRepository<
     const manager = entityManager || this.manager;
     const computedOptions = await this.transformOptions(options);
     const result = await manager.findOne(this.target, computedOptions);
-
     const formattedResult = await this.formatResult(result);
 
     return formattedResult;
@@ -124,7 +120,6 @@ export class WorkspaceRepository<
     const manager = entityManager || this.manager;
     const computedOptions = await this.transformOptions({ where });
     const result = await manager.findOneBy(this.target, computedOptions.where);
-
     const formattedResult = await this.formatResult(result);
 
     return formattedResult;
@@ -137,7 +132,6 @@ export class WorkspaceRepository<
     const manager = entityManager || this.manager;
     const computedOptions = await this.transformOptions(options);
     const result = await manager.findOneOrFail(this.target, computedOptions);
-
     const formattedResult = await this.formatResult(result);
 
     return formattedResult;
@@ -153,7 +147,6 @@ export class WorkspaceRepository<
       this.target,
       computedOptions.where,
     );
-
     const formattedResult = await this.formatResult(result);
 
     return formattedResult;

--- a/packages/twenty-server/src/engine/twenty-orm/utils/determine-relation-details.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/determine-relation-details.util.ts
@@ -4,7 +4,6 @@ import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 import { RelationMetadataEntity } from 'src/engine/metadata-modules/relation-metadata/relation-metadata.entity';
 import { computeRelationType } from 'src/engine/twenty-orm/utils/compute-relation-type.util';
-import { WorkspaceCacheStorageService } from 'src/engine/workspace-cache-storage/workspace-cache-storage.service';
 
 interface RelationDetails {
   relationType: RelationType;
@@ -14,10 +13,9 @@ interface RelationDetails {
 }
 
 export async function determineRelationDetails(
-  workspaceId: string,
   fieldMetadata: FieldMetadataEntity,
   relationMetadata: RelationMetadataEntity,
-  workspaceCacheStorageService: WorkspaceCacheStorageService,
+  objectMetadataCollection?: ObjectMetadataEntity[],
 ): Promise<RelationDetails> {
   const relationType = computeRelationType(fieldMetadata, relationMetadata);
   let fromObjectMetadata: ObjectMetadataEntity | undefined =
@@ -28,8 +26,8 @@ export async function determineRelationDetails(
   // RelationMetadata always store the relation from the perspective of the `from` object, MANY_TO_ONE relations are not stored yet
   if (relationType === 'many-to-one') {
     fromObjectMetadata = fieldMetadata.object;
-    toObjectMetadata = await workspaceCacheStorageService.getObjectMetadata(
-      workspaceId,
+
+    toObjectMetadata = objectMetadataCollection?.find(
       (objectMetadata) =>
         objectMetadata.id === relationMetadata.fromObjectMetadataId,
     );

--- a/packages/twenty-server/src/engine/twenty-orm/utils/determine-relation-details.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/determine-relation-details.util.ts
@@ -15,7 +15,7 @@ interface RelationDetails {
 export async function determineRelationDetails(
   fieldMetadata: FieldMetadataEntity,
   relationMetadata: RelationMetadataEntity,
-  objectMetadataCollection?: ObjectMetadataEntity[],
+  objectMetadataCollection: ObjectMetadataEntity[],
 ): Promise<RelationDetails> {
   const relationType = computeRelationType(fieldMetadata, relationMetadata);
   let fromObjectMetadata: ObjectMetadataEntity | undefined =
@@ -27,7 +27,7 @@ export async function determineRelationDetails(
   if (relationType === 'many-to-one') {
     fromObjectMetadata = fieldMetadata.object;
 
-    toObjectMetadata = objectMetadataCollection?.find(
+    toObjectMetadata = objectMetadataCollection.find(
       (objectMetadata) =>
         objectMetadata.id === relationMetadata.fromObjectMetadataId,
     );

--- a/packages/twenty-server/src/engine/workspace-cache-storage/workspace-cache-storage.service.ts
+++ b/packages/twenty-server/src/engine/workspace-cache-storage/workspace-cache-storage.service.ts
@@ -63,21 +63,6 @@ export class WorkspaceCacheStorageService {
     );
   }
 
-  async getObjectMetadata(
-    workspaceId: string,
-    predicate: (objectMetadata: ObjectMetadataEntity) => boolean,
-  ): Promise<ObjectMetadataEntity | undefined> {
-    const objectMetadataCollection = await this.workspaceSchemaCache.get<
-      ObjectMetadataEntity[]
-    >(`objectMetadataCollection:${workspaceId}`);
-
-    if (!objectMetadataCollection) {
-      return;
-    }
-
-    return objectMetadataCollection.find(predicate);
-  }
-
   setTypeDefs(workspaceId: string, typeDefs: string): Promise<void> {
     return this.workspaceSchemaCache.set<string>(
       `typeDefs:${workspaceId}`,


### PR DESCRIPTION
Calling `getObjectMetadata` from `WorkspaceCacheStorageService` in every query was causing big performance issues. The `objectMetadataCollection` is now part of the `WorkspaceInternalContext` so we only instance it once in the `WorkspaceDatasourceFactory`.
Queries are now much faster, for instance for TimelineCalendar, it went from ~450ms to 80ms.