### PR TITLE
fix: exclude tabler/icons-react from optimizeDeps to avoid crashing  performance CI

### DIFF
--- a/packages/twenty-front/vite.config.ts
+++ b/packages/twenty-front/vite.config.ts
@@ -104,5 +104,8 @@ export default defineConfig(({ command, mode }) => {
         localsConvention: 'camelCaseOnly',
       },
     },
+    optimizeDeps: {
+      exclude: ['@tabler/icons-react'],
+    },
   };
 });


### PR DESCRIPTION
## ISSUE (Warning)

- Fixes #6437 

### Things needed to investigate :

- [x] Can we exclude @tabler-icons from Babel / wyw-in-js / the vite config of Storybook ? 
> Yes we can

- [ ] Is there a reproducible difference between non-Linaria components loading time and Linaria components loading times ?
> Couldn't find anything related to this, yet. but changes fix the problem.