### PR TITLE
Fix duplicate activities

### DIFF
--- a/packages/twenty-front/src/modules/activities/hooks/useOpenCreateActivityDrawer.ts
+++ b/packages/twenty-front/src/modules/activities/hooks/useOpenCreateActivityDrawer.ts
@@ -42,6 +42,7 @@ export const useOpenCreateActivityDrawer = ({
       activityObjectNameSingular === CoreObjectNameSingular.Task
         ? CoreObjectNameSingular.TaskTarget
         : CoreObjectNameSingular.NoteTarget,
+    shouldMatchRootQueryFilter: true,
   });
 
   const setActivityTargetableEntityArray = useSetRecoilState(


### PR DESCRIPTION
Activity creation was duplicating the new activity on already visited records of the same type.

The fix was to activate `shouldMatchRootQueryFilter` on createOne for activity.