### PR TITLE
Patch messaging import crons not running

### DIFF
--- a/packages/twenty-server/src/modules/messaging/message-import-manager/crons/jobs/messaging-message-list-fetch.cron.job.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/crons/jobs/messaging-message-list-fetch.cron.job.ts
@@ -46,9 +46,7 @@ export class MessagingMessageListFetchCronJob {
           'messageChannel',
         );
 
-      const messageChannels = await messageChannelRepository.find({
-        select: ['id'],
-      });
+      const messageChannels = await messageChannelRepository.find();
 
       for (const messageChannel of messageChannels) {
         if (

--- a/packages/twenty-server/src/modules/messaging/monitoring/crons/jobs/messaging-message-channel-sync-status-monitoring.cron.ts
+++ b/packages/twenty-server/src/modules/messaging/monitoring/crons/jobs/messaging-message-channel-sync-status-monitoring.cron.ts
@@ -46,8 +46,8 @@ export class MessagingMessageChannelSyncStatusMonitoringCronJob {
     for (const activeWorkspace of activeWorkspaces) {
       const messageChannelRepository =
         await this.twentyORMGlobalManager.getRepositoryForWorkspace<MessageChannelWorkspaceEntity>(
-          'messageChannel',
           activeWorkspace.id,
+          'messageChannel',
         );
       const messageChannels = await messageChannelRepository.find({
         select: ['id', 'syncStatus', 'connectedAccountId'],


### PR DESCRIPTION
In 0.23.1, we have introduced a regression by migrating to TwentyORM ; messageChannels were not considered as syncable anymore.

I'm also using this PR to fix the channelStatus monitoring script