### PR TITLE
Delete cache version when seeding demo

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/workspace-manager.module.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-manager.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 
 import { DataSourceModule } from 'src/engine/metadata-modules/data-source/data-source.module';
 import { ObjectMetadataModule } from 'src/engine/metadata-modules/object-metadata/object-metadata.module';
+import { WorkspaceCacheVersionModule } from 'src/engine/metadata-modules/workspace-cache-version/workspace-cache-version.module';
 import { WorkspaceMigrationModule } from 'src/engine/metadata-modules/workspace-migration/workspace-migration.module';
 import { WorkspaceDataSourceModule } from 'src/engine/workspace-datasource/workspace-datasource.module';
 import { WorkspaceHealthModule } from 'src/engine/workspace-manager/workspace-health/workspace-health.module';
@@ -19,6 +20,7 @@ import { WorkspaceManagerService } from './workspace-manager.service';
     WorkspaceSyncMetadataModule,
     WorkspaceHealthModule,
     WorkspaceStatusModule,
+    WorkspaceCacheVersionModule,
   ],
   exports: [WorkspaceManagerService],
   providers: [WorkspaceManagerService],

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-manager.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-manager.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@nestjs/common';
 import { DataSourceEntity } from 'src/engine/metadata-modules/data-source/data-source.entity';
 import { DataSourceService } from 'src/engine/metadata-modules/data-source/data-source.service';
 import { ObjectMetadataService } from 'src/engine/metadata-modules/object-metadata/object-metadata.service';
+import { WorkspaceCacheVersionService } from 'src/engine/metadata-modules/workspace-cache-version/workspace-cache-version.service';
 import { WorkspaceMigrationService } from 'src/engine/metadata-modules/workspace-migration/workspace-migration.service';
 import { WorkspaceDataSourceService } from 'src/engine/workspace-datasource/workspace-datasource.service';
 import { demoObjectsPrefillData } from 'src/engine/workspace-manager/demo-objects-prefill-data/demo-objects-prefill-data';
@@ -17,6 +18,7 @@ export class WorkspaceManagerService {
     private readonly objectMetadataService: ObjectMetadataService,
     private readonly dataSourceService: DataSourceService,
     private readonly workspaceSyncMetadataService: WorkspaceSyncMetadataService,
+    private readonly workspaceCacheVersionService: WorkspaceCacheVersionService,
   ) {}
 
   /**
@@ -181,6 +183,7 @@ export class WorkspaceManagerService {
     await this.objectMetadataService.deleteObjectsMetadata(workspaceId);
     await this.workspaceMigrationService.deleteAllWithinWorkspace(workspaceId);
     await this.dataSourceService.delete(workspaceId);
+    await this.workspaceCacheVersionService.deleteVersion(workspaceId);
     // Delete schema
     await this.workspaceDataSourceService.deleteWorkspaceDBSchema(workspaceId);
   }


### PR DESCRIPTION
Cache version is not reset when seeding demo. This sometimes leads to issues on next since the cache is not up to date