### PR TITLE
Remove performance logs

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/user/services/user.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/services/user.service.ts
@@ -40,23 +40,17 @@ export class UserService extends TypeOrmQueryService<User> {
       return null;
     }
 
-    console.time('loadWorkspaceMember repo');
     const workspaceMemberRepository =
       await this.twentyORMGlobalManager.getRepositoryForWorkspace<WorkspaceMemberWorkspaceEntity>(
         user.defaultWorkspaceId,
         'workspaceMember',
       );
 
-    console.timeEnd('loadWorkspaceMember repo');
-
-    console.time('loadWorkspaceMember find');
     const workspaceMember = await workspaceMemberRepository.findOne({
       where: {
         userId: user.id,
       },
     });
-
-    console.timeEnd('loadWorkspaceMember find');
 
     return workspaceMember;
   }
@@ -66,20 +60,13 @@ export class UserService extends TypeOrmQueryService<User> {
       return [];
     }
 
-    console.time('loadWorkspaceMembers repo');
     const workspaceMemberRepository =
       await this.twentyORMGlobalManager.getRepositoryForWorkspace<WorkspaceMemberWorkspaceEntity>(
         workspace.id,
         'workspaceMember',
       );
 
-    console.timeEnd('loadWorkspaceMembers repo');
-
-    console.time('loadWorkspaceMembers find');
-
     const workspaceMembers = workspaceMemberRepository.find();
-
-    console.timeEnd('loadWorkspaceMembers find');
 
     return workspaceMembers;
   }

--- a/packages/twenty-server/src/engine/core-modules/user/user.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/user.resolver.ts
@@ -98,7 +98,6 @@ export class UserResolver {
     nullable: true,
   })
   async workspaceMember(@Parent() user: User): Promise<WorkspaceMember | null> {
-    console.time('resolver workspaceMember');
     const workspaceMember = await this.userService.loadWorkspaceMember(user);
 
     if (workspaceMember && workspaceMember.avatarUrl) {
@@ -109,7 +108,6 @@ export class UserResolver {
 
       workspaceMember.avatarUrl = `${workspaceMember.avatarUrl}?token=${avatarUrlToken}`;
     }
-    console.timeEnd('resolver workspaceMember');
 
     // TODO: Fix typing disrepency between Entity and DTO
     return workspaceMember as WorkspaceMember | null;
@@ -119,7 +117,6 @@ export class UserResolver {
     nullable: true,
   })
   async workspaceMembers(@Parent() user: User): Promise<WorkspaceMember[]> {
-    console.time('resolver workspaceMembers');
     const workspaceMembers = await this.userService.loadWorkspaceMembers(
       user.defaultWorkspace,
     );
@@ -134,8 +131,6 @@ export class UserResolver {
         workspaceMember.avatarUrl = `${workspaceMember.avatarUrl}?token=${avatarUrlToken}`;
       }
     }
-
-    console.timeEnd('resolver workspaceMembers');
 
     // TODO: Fix typing disrepency between Entity and DTO
     return workspaceMembers as WorkspaceMember[];

--- a/packages/twenty-server/src/engine/twenty-orm/factories/workspace-datasource.factory.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/factories/workspace-datasource.factory.ts
@@ -55,39 +55,39 @@ export class WorkspaceDatasourceFactory {
       );
     }
 
-    console.time(`fetch in cached metadata ${logId}`);
-    let cachedObjectMetadataCollection =
-      await this.workspaceCacheStorageService.getObjectMetadataCollection(
-        workspaceId,
-      );
-
-    if (!cachedObjectMetadataCollection) {
-      console.log('Fetching fresh object metadata collection...');
-      const freshObjectMetadataCollection =
-        await this.objectMetadataRepository.find({
-          where: { workspaceId },
-          relations: [
-            'fields.object',
-            'fields',
-            'fields.fromRelationMetadata',
-            'fields.toRelationMetadata',
-            'fields.fromRelationMetadata.toObjectMetadata',
-          ],
-        });
-
-      await this.workspaceCacheStorageService.setObjectMetadataCollection(
-        workspaceId,
-        freshObjectMetadataCollection,
-      );
-
-      cachedObjectMetadataCollection = freshObjectMetadataCollection;
-    }
-    console.timeEnd(`fetch in cached metadata ${logId}`);
-
     const workspaceDataSource = await workspaceDataSourceCacheInstance.execute(
       `${workspaceId}-${latestWorkspaceMetadataVersion}`,
       async () => {
         const logId = v4();
+
+        console.time(`fetch in cached metadata ${logId}`);
+        let cachedObjectMetadataCollection =
+          await this.workspaceCacheStorageService.getObjectMetadataCollection(
+            workspaceId,
+          );
+
+        if (!cachedObjectMetadataCollection) {
+          console.log('Fetching fresh object metadata collection...');
+          const freshObjectMetadataCollection =
+            await this.objectMetadataRepository.find({
+              where: { workspaceId },
+              relations: [
+                'fields.object',
+                'fields',
+                'fields.fromRelationMetadata',
+                'fields.toRelationMetadata',
+                'fields.fromRelationMetadata.toObjectMetadata',
+              ],
+            });
+
+          await this.workspaceCacheStorageService.setObjectMetadataCollection(
+            workspaceId,
+            freshObjectMetadataCollection,
+          );
+
+          cachedObjectMetadataCollection = freshObjectMetadataCollection;
+        }
+        console.timeEnd(`fetch in cached metadata ${logId}`);
 
         console.log('Creating workspace fresh data source...' + logId);
         const dataSourceMetadata =

--- a/packages/twenty-server/src/engine/twenty-orm/factories/workspace-datasource.factory.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/factories/workspace-datasource.factory.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { EntitySchema, Repository } from 'typeorm';
-import { v4 } from 'uuid';
 
 import { EnvironmentService } from 'src/engine/integrations/environment/environment.service';
 import { DataSourceService } from 'src/engine/metadata-modules/data-source/data-source.service';
@@ -52,8 +51,6 @@ export class WorkspaceDatasourceFactory {
     const workspaceDataSource = await workspaceDataSourceCacheInstance.execute(
       `${workspaceId}-${latestWorkspaceMetadataVersion}`,
       async () => {
-        const logId = v4();
-
         let cachedObjectMetadataCollection =
           await this.workspaceCacheStorageService.getObjectMetadataCollection(
             workspaceId,

--- a/packages/twenty-server/src/engine/twenty-orm/factories/workspace-datasource.factory.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/factories/workspace-datasource.factory.ts
@@ -55,12 +55,14 @@ export class WorkspaceDatasourceFactory {
       );
     }
 
+    console.time(`fetch in cached metadata ${logId}`);
     let cachedObjectMetadataCollection =
       await this.workspaceCacheStorageService.getObjectMetadataCollection(
         workspaceId,
       );
 
     if (!cachedObjectMetadataCollection) {
+      console.log('Fetching fresh object metadata collection...');
       const freshObjectMetadataCollection =
         await this.objectMetadataRepository.find({
           where: { workspaceId },
@@ -80,6 +82,7 @@ export class WorkspaceDatasourceFactory {
 
       cachedObjectMetadataCollection = freshObjectMetadataCollection;
     }
+    console.timeEnd(`fetch in cached metadata ${logId}`);
 
     const workspaceDataSource = await workspaceDataSourceCacheInstance.execute(
       `${workspaceId}-${latestWorkspaceMetadataVersion}`,

--- a/packages/twenty-server/src/engine/twenty-orm/factories/workspace-datasource.factory.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/factories/workspace-datasource.factory.ts
@@ -29,16 +29,10 @@ export class WorkspaceDatasourceFactory {
     workspaceId: string,
     workspaceMetadataVersion: string | null,
   ): Promise<WorkspaceDataSource> {
-    const logId = v4();
-
-    console.time(`fetch in datasource factory ${logId}`);
-
     const latestWorkspaceMetadataVersion =
       await this.workspaceMetadataVersionService.getMetadataVersion(
         workspaceId,
       );
-
-    console.timeEnd(`fetch in datasource factory ${logId}`);
 
     const desiredWorkspaceMetadataVersion =
       workspaceMetadataVersion ?? latestWorkspaceMetadataVersion;
@@ -60,14 +54,12 @@ export class WorkspaceDatasourceFactory {
       async () => {
         const logId = v4();
 
-        console.time(`fetch in cached metadata ${logId}`);
         let cachedObjectMetadataCollection =
           await this.workspaceCacheStorageService.getObjectMetadataCollection(
             workspaceId,
           );
 
         if (!cachedObjectMetadataCollection) {
-          console.log('Fetching fresh object metadata collection...');
           const freshObjectMetadataCollection =
             await this.objectMetadataRepository.find({
               where: { workspaceId },
@@ -87,9 +79,7 @@ export class WorkspaceDatasourceFactory {
 
           cachedObjectMetadataCollection = freshObjectMetadataCollection;
         }
-        console.timeEnd(`fetch in cached metadata ${logId}`);
 
-        console.log('Creating workspace fresh data source...' + logId);
         const dataSourceMetadata =
           await this.dataSourceService.getLastDataSourceMetadataFromWorkspaceId(
             workspaceId,
@@ -107,7 +97,6 @@ export class WorkspaceDatasourceFactory {
           );
         }
 
-        console.time('create entity schema' + logId);
         const cachedEntitySchemaOptions =
           await this.workspaceCacheStorageService.getORMEntitySchema(
             workspaceId,
@@ -133,9 +122,7 @@ export class WorkspaceDatasourceFactory {
 
           cachedEntitySchemas = entitySchemas;
         }
-        console.timeEnd('create entity schema' + logId);
 
-        console.time('create workspace data source' + logId);
         const workspaceDataSource = new WorkspaceDataSource(
           {
             workspaceId,
@@ -159,11 +146,7 @@ export class WorkspaceDatasourceFactory {
           },
         );
 
-        console.timeEnd('create workspace data source' + logId);
-
-        console.time('initialize workspace data source' + logId);
         await workspaceDataSource.initialize();
-        console.timeEnd('initialize workspace data source' + logId);
 
         return workspaceDataSource;
       },

--- a/packages/twenty-server/src/engine/twenty-orm/storage/cache-manager.storage.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/storage/cache-manager.storage.ts
@@ -1,3 +1,5 @@
+import { v4 } from 'uuid';
+
 type CacheKey = `${string}-${string}`;
 
 type AsyncFactoryCallback<T> = () => Promise<T | null>;
@@ -10,11 +12,20 @@ export class CacheManager<T> {
     factory: AsyncFactoryCallback<T>,
     onDelete?: (value: T) => Promise<void> | void,
   ): Promise<T | null> {
+    const logId = v4();
+
+    console.time(`cacheManager find ${cacheKey} ${logId}`);
     const [workspaceId] = cacheKey.split('-');
 
     if (this.cache.has(cacheKey)) {
-      return this.cache.get(cacheKey)!;
+      const cachedValue = this.cache.get(cacheKey)!;
+
+      console.timeEnd(`cacheManager find ${cacheKey} ${logId}`);
+
+      return cachedValue;
     }
+
+    console.log(`cacheManager miss for ${cacheKey} ${logId}`);
 
     // Remove old entries with the same workspaceId
     for (const key of this.cache.keys()) {
@@ -32,6 +43,8 @@ export class CacheManager<T> {
     }
 
     this.cache.set(cacheKey, value);
+
+    console.timeEnd(`cacheManager find ${cacheKey} ${logId}`);
 
     return value;
   }

--- a/packages/twenty-server/src/engine/twenty-orm/storage/cache-manager.storage.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/storage/cache-manager.storage.ts
@@ -1,5 +1,3 @@
-import { v4 } from 'uuid';
-
 type CacheKey = `${string}-${string}`;
 
 type AsyncFactoryCallback<T> = () => Promise<T | null>;
@@ -12,8 +10,6 @@ export class CacheManager<T> {
     factory: AsyncFactoryCallback<T>,
     onDelete?: (value: T) => Promise<void> | void,
   ): Promise<T | null> {
-    const logId = v4();
-
     const [workspaceId] = cacheKey.split('-');
 
     if (this.cache.has(cacheKey)) {

--- a/packages/twenty-server/src/engine/twenty-orm/storage/cache-manager.storage.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/storage/cache-manager.storage.ts
@@ -14,20 +14,12 @@ export class CacheManager<T> {
   ): Promise<T | null> {
     const logId = v4();
 
-    console.time(`cacheManager find ${cacheKey} ${logId}`);
     const [workspaceId] = cacheKey.split('-');
 
     if (this.cache.has(cacheKey)) {
-      const cachedValue = this.cache.get(cacheKey)!;
-
-      console.timeEnd(`cacheManager find ${cacheKey} ${logId}`);
-
-      return cachedValue;
+      return this.cache.get(cacheKey)!;
     }
 
-    console.log(`cacheManager miss for ${cacheKey} ${logId}`);
-
-    // Remove old entries with the same workspaceId
     for (const key of this.cache.keys()) {
       if (key.startsWith(`${workspaceId}-`)) {
         await onDelete?.(this.cache.get(key)!);
@@ -35,7 +27,6 @@ export class CacheManager<T> {
       }
     }
 
-    // Create a new value using the factory callback
     const value = await factory();
 
     if (!value) {
@@ -43,8 +34,6 @@ export class CacheManager<T> {
     }
 
     this.cache.set(cacheKey, value);
-
-    console.timeEnd(`cacheManager find ${cacheKey} ${logId}`);
 
     return value;
   }

--- a/packages/twenty-server/src/engine/twenty-orm/twenty-orm-global.manager.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/twenty-orm-global.manager.ts
@@ -39,13 +39,10 @@ export class TwentyORMGlobalManager {
 
     const logId = v4();
 
-    console.time(`createDataSource in orm ${logId}`);
     const workspaceDataSource = await this.workspaceDataSourceFactory.create(
       workspaceId,
       null,
     );
-
-    console.timeEnd(`createDataSource in orm ${logId}`);
 
     const repository = workspaceDataSource.getRepository<T>(objectMetadataName);
 

--- a/packages/twenty-server/src/engine/twenty-orm/twenty-orm-global.manager.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/twenty-orm-global.manager.ts
@@ -1,7 +1,6 @@
 import { Injectable, Type } from '@nestjs/common';
 
 import { ObjectLiteral } from 'typeorm';
-import { v4 } from 'uuid';
 
 import { WorkspaceDatasourceFactory } from 'src/engine/twenty-orm/factories/workspace-datasource.factory';
 import { WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace.repository';
@@ -36,8 +35,6 @@ export class TwentyORMGlobalManager {
         workspaceEntityOrobjectMetadataName.name,
       );
     }
-
-    const logId = v4();
 
     const workspaceDataSource = await this.workspaceDataSourceFactory.create(
       workspaceId,


### PR DESCRIPTION
We have found the root cause of the issue:
- when using a datasource (including the cached ones), we are fetching ObjectMetadataCollection from cache (700kB). Datasource usage is happening any time we are using twentyORM, which is everywhere in the jobs and in some resolvers (including the GetCurrentUser one). This is leading to a high load on redis and leading to the performance issues we are seeing.
- we actually don't need to fetch this objectMetadataCollection while using a cached datasource, only when we instantiate a new one