### PR TITLE
Make workspaceMemberId optional in JWT for workspaces that are not ACTIVE

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/auth/strategies/jwt.auth.strategy.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/strategies/jwt.auth.strategy.ts
@@ -20,7 +20,7 @@ import { ApiKeyWorkspaceEntity } from 'src/modules/api-key/standard-objects/api-
 export type JwtPayload = {
   sub: string;
   workspaceId: string;
-  workspaceMemberId: string;
+  workspaceMemberId?: string;
   jti?: string;
 };
 


### PR DESCRIPTION
WorkspaceMemberId is mandatory in the jwt token generated for a given user on a given workspace.
However, when a user signs up, it does not have a workspaceMemberId yet.