### PR TITLE
[Fix] Move save button to top on field edit

### DIFF
--- a/packages/twenty-front/src/pages/settings/data-model/SettingsObjectFieldEdit.tsx
+++ b/packages/twenty-front/src/pages/settings/data-model/SettingsObjectFieldEdit.tsx
@@ -20,7 +20,6 @@ import { isLabelIdentifierField } from '@/object-metadata/utils/isLabelIdentifie
 import { useFindManyRecordsQuery } from '@/object-record/hooks/useFindManyRecordsQuery';
 import { RecordFieldValueSelectorContextProvider } from '@/object-record/record-store/contexts/RecordFieldValueSelectorContext';
 import { SaveAndCancelButtons } from '@/settings/components/SaveAndCancelButtons/SaveAndCancelButtons';
-import { SettingsHeaderContainer } from '@/settings/components/SettingsHeaderContainer';
 import { SettingsPageContainer } from '@/settings/components/SettingsPageContainer';
 import { FIELD_NAME_MAXIMUM_LENGTH } from '@/settings/data-model/constants/FieldNameMaximumLength';
 import { SettingsDataModelFieldAboutForm } from '@/settings/data-model/fields/forms/components/SettingsDataModelFieldAboutForm';
@@ -186,18 +185,18 @@ export const SettingsObjectFieldEdit = () => {
               ]}
             />
           }
+          actionButton={
+            shouldDisplaySaveAndCancel && (
+              <SaveAndCancelButtons
+                isSaveDisabled={!canSave}
+                isCancelDisabled={isSubmitting}
+                onCancel={() => navigate(`/settings/objects/${objectSlug}`)}
+                onSave={formConfig.handleSubmit(handleSave)}
+              />
+            )
+          }
         >
           <SettingsPageContainer>
-            <SettingsHeaderContainer>
-              {shouldDisplaySaveAndCancel && (
-                <SaveAndCancelButtons
-                  isSaveDisabled={!canSave}
-                  isCancelDisabled={isSubmitting}
-                  onCancel={() => navigate(`/settings/objects/${objectSlug}`)}
-                  onSave={formConfig.handleSubmit(handleSave)}
-                />
-              )}
-            </SettingsHeaderContainer>
             <Section>
               <H2Title
                 title="Name and description"


### PR DESCRIPTION
Before
<img width="802" alt="image" src="https://github.com/user-attachments/assets/2a9d9501-6bd4-4dc2-b8d7-98a29816caab">

After
<img width="871" alt="Capture d’écran 2024-08-26 à 12 17 29" src="https://github.com/user-attachments/assets/b6cb688c-fdcd-4b10-8d91-197245f7dd56">

