### PR TITLE
Improve record table scroll look

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-row/components/RecordTableRowWrapper.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-row/components/RecordTableRowWrapper.tsx
@@ -37,7 +37,7 @@ export const RecordTableRowWrapper = ({
 
   const { ref: elementRef, inView } = useInView({
     root: scrollWrapperRef.ref.current?.querySelector(
-      '[data-overlayscrollbars-viewport="scrollbarHidden"]',
+      '[data-overlayscrollbars-viewport]',
     ),
     rootMargin: '1000px',
   });


### PR DESCRIPTION
We had a regression on the record table as our inView hook was not able to find the right div to compute its margin. This is because we are identify this div by a hacky css selector as we don't have a direct control on it (it's provided by our scrolling library)