### PR TITLE
fix/6759: reduce icon size in note grip menu to 16px and adjust conta…

### DIFF
--- a/packages/twenty-front/src/modules/ui/input/editor/components/BlockEditor.tsx
+++ b/packages/twenty-front/src/modules/ui/input/editor/components/BlockEditor.tsx
@@ -83,8 +83,8 @@ const StyledEditor = styled.div`
     border: 1px solid ${({ theme }) => theme.border.color.light};
   }
   & .bn-side-menu .mantine-UnstyledButton-root:not(.mantine-Menu-item) svg {
-    height: 20px;
-    width: 20px;
+    height: 16px;
+    width: 16px;
   }
 
   & .bn-mantine .bn-side-menu > [draggable='true'] {


### PR DESCRIPTION
### Summary

This pull request addresses issue #6759 by adjusting the icon size and container padding in the note grip menu. The 6-dot icon's size has been reduced from 20px to 16px, while the container size has been kept at 20px to maintain the proper alignment and spacing.

### Changes Made
- **Icon Size**: Reduced the SVG icon size to 16x16px.
- **Container Size**: Ensured the container remains 20x20px to accommodate the icon and maintain visual consistency.

### Screenshots
<img width="1440" alt="Screenshot 2024-08-29 at 3 26 41 AM" src="https://github.com/user-attachments/assets/d8618636-165a-440d-a41e-947b2aa00bdb">


### Related Issue
- [Issue #6759]

### Testing
- Verified that the icon and container sizes are correctly displayed in the note grip menu.
- Ensured no other UI elements were affected by these changes.

Please review the changes and let me know if any additional modifications are required. Thank you!
