### PR TITLE
fix: update card background to use theme.background.transparent.lighter (#6791)

### DIFF
--- a/packages/twenty-front/src/modules/settings/integrations/components/SettingsIntegrationComponent.tsx
+++ b/packages/twenty-front/src/modules/settings/integrations/components/SettingsIntegrationComponent.tsx
@@ -14,7 +14,7 @@ interface SettingsIntegrationComponentProps {
 
 const StyledContainer = styled.div<{ to?: string }>`
   align-items: center;
-  background: ${({ theme }) => theme.background.secondary};
+  background: ${({ theme }) => theme.background.transparent.lighter};
   border: 1px solid ${({ theme }) => theme.border.color.medium};
   border-radius: ${({ theme }) => theme.border.radius.md};
   font-size: ${({ theme }) => theme.font.size.md};


### PR DESCRIPTION
### Overview
This PR addresses issue #6791, where cards were incorrectly set to use `theme.background.secondary`, which matched the editor's theme background. The cards now use `theme.background.transparent.lighter` for better visibility.

### Changes
- Updated card background styling from `theme.background.secondary` to `theme.background.transparent.lighter`.
- Ensured the new background styling provides better contrast and visibility for card elements.

### Screenshots
**UI: After change**
<img width="1440" alt="Screenshot 2024-08-30 at 12 13 17 AM" src="https://github.com/user-attachments/assets/2e285e56-82c5-44b8-8a92-78c6bbecd2b0">

**Code:After**
<img width="1440" alt="Screenshot 2024-08-30 at 12 21 36 AM" src="https://github.com/user-attachments/assets/a35c681f-a5c0-43af-a21f-f9715aeeca74">


**Code:before**
<img width="1440" alt="Screenshot 2024-08-30 at 12 23 55 AM" src="https://github.com/user-attachments/assets/029700a2-5a41-4f27-b13a-832b1ba0e01f">


### Testing
- Verified that all cards now display the correct background color.
- Ensured that the new background improves readability and aligns with the design specifications.

### Related Issue
Closes #6791

### Additional Notes
- No breaking changes introduced.
- Please review the UI changes to confirm they meet design standards and improve card visibility.
