### PR TITLE
update refresh token expires in

### DIFF
--- a/packages/twenty-server/src/engine/integrations/environment/environment-variables.ts
+++ b/packages/twenty-server/src/engine/integrations/environment/environment-variables.ts
@@ -130,7 +130,7 @@ export class EnvironmentVariables {
 
   @IsDuration()
   @IsOptional()
-  REFRESH_TOKEN_EXPIRES_IN = '30m';
+  REFRESH_TOKEN_EXPIRES_IN = '60d';
 
   @IsDuration()
   @IsOptional()


### PR DESCRIPTION
Fixes https://github.com/twentyhq/twenty/issues/6598

Updating the refresh token default value to a much more common threshold, this can still be overridden with env variables when needed.

Example of the refresh token mechanism from the fronted side
<img width="679" alt="Screenshot 2024-09-03 at 16 05 12" src="https://github.com/user-attachments/assets/7e618ab1-12b9-48cb-a93e-e27974ad2425">
<img width="673" alt="Screenshot 2024-09-03 at 16 05 22" src="https://github.com/user-attachments/assets/f4d08315-1f5b-4f4a-a86a-a9cd9cdf9b01">
