### PR TITLE
fix: Updated Menu item font size

### DIFF
--- a/packages/twenty-front/src/modules/ui/navigation/menu-item/internals/components/StyledMenuItemBase.tsx
+++ b/packages/twenty-front/src/modules/ui/navigation/menu-item/internals/components/StyledMenuItemBase.tsx
@@ -69,7 +69,7 @@ export const StyledMenuItemBase = styled.div<MenuItemBaseProps>`
 `;
 
 export const StyledMenuItemLabel = styled.div<{ hasLeftIcon: boolean }>`
-  font-size: ${({ theme }) => theme.font.size.sm};
+  font-size: ${({ theme }) => theme.font.size.md};
   font-weight: ${({ theme }) => theme.font.weight.regular};
 
   overflow: hidden;


### PR DESCRIPTION
## Description

This PR solves the issue #6878. Updated the font size from 12 px to 13 px.

## Before 

<img width="156" alt="Screenshot 2024-09-03 at 11 46 58 PM" src="https://github.com/user-attachments/assets/d4077ecc-0a14-4802-a4d7-9b03c4e419bd">

## After

<img width="154" alt="Screenshot 2024-09-03 at 11 47 33 PM" src="https://github.com/user-attachments/assets/fd6ff0e3-0212-44e3-ba01-864ea9f4c5c6">
