### PR TITLE
Fix bug bypassing verification in confirmation modal when pressing Enter

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/modal/components/ConfirmationModal.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/modal/components/ConfirmationModal.tsx
@@ -93,7 +93,7 @@ export const ConfirmationModal = ({
                 setIsOpen(false);
               }
             }}
-            onEnter={onConfirmClick}
+            onEnter={!isValidValue ? undefined : onConfirmClick}
             isClosable={true}
             padding="large"
           >


### PR DESCRIPTION
# Description
Fix bug bypassing verification in the confirmation modal when pressing Enter

# Demo
Tested for webhook case (similar to other cases):
1. Press Enter when invalid verification => not delete webhook
2. Press Enter when valid verification => delete webhook

https://github.com/user-attachments/assets/81aa0aaa-7361-4584-b7ae-b29525f33664

# Ref
Fixes #6663
