### PR TITLE
Fix restore event sent to webhooks

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/workspace-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/workspace-query-runner.service.ts
@@ -776,7 +776,7 @@ export class WorkspaceQueryRunnerService {
 
     await this.triggerWebhooks<Record>(
       parsedResults,
-      CallWebhookJobsJobOperation.delete,
+      CallWebhookJobsJobOperation.create,
       options,
     );
 


### PR DESCRIPTION
We were sending the wrong event when restoring a record (delete instead of create)