### PR TITLE
Fixed open table cell triggering

### DIFF
--- a/packages/twenty-front/src/modules/ui/field/input/components/DoubleTextInput.tsx
+++ b/packages/twenty-front/src/modules/ui/field/input/components/DoubleTextInput.tsx
@@ -172,6 +172,13 @@ export const DoubleTextInput = ({
     onPaste?.({ firstValue: splittedName[0], secondValue: splittedName[1] });
   };
 
+  const handleClickToPreventParentClickEvents = (
+    event: React.MouseEvent<HTMLInputElement>,
+  ) => {
+    event.stopPropagation();
+    event.preventDefault();
+  };
+
   return (
     <StyledContainer ref={containerRef}>
       <StyledTextInput
@@ -187,6 +194,7 @@ export const DoubleTextInput = ({
         onPaste={(event: ClipboardEvent<HTMLInputElement>) =>
           handleOnPaste(event)
         }
+        onClick={handleClickToPreventParentClickEvents}
       />
       <StyledTextInput
         autoComplete="off"
@@ -197,6 +205,7 @@ export const DoubleTextInput = ({
         onChange={(event: ChangeEvent<HTMLInputElement>) => {
           handleChange(firstInternalValue, event.target.value);
         }}
+        onClick={handleClickToPreventParentClickEvents}
       />
     </StyledContainer>
   );


### PR DESCRIPTION
Open table cell was triggered by a click on a field input.

This is a temporary solution.

I fixed it for DoubleTextInput but it might be problematic for other field types as well, we should implement a kind of bubbling shield to make sure that no click event can bubble up to trigger things like open table cell in the above components that shouldn't listen.

See https://github.com/twentyhq/core-team-issues/issues/164