### PR TITLE
fix: Api text typo in ApiKeyInput.tsx (#6916)

### DIFF
--- a/packages/twenty-front/src/modules/settings/developers/components/ApiKeyInput.tsx
+++ b/packages/twenty-front/src/modules/settings/developers/components/ApiKeyInput.tsx
@@ -32,7 +32,7 @@ export const ApiKeyInput = ({ apiKey }: ApiKeyInputProps) => {
         Icon={IconCopy}
         title="Copy"
         onClick={() => {
-          enqueueSnackBar('Api Key copied to clipboard', {
+          enqueueSnackBar('API Key copied to clipboard', {
             variant: SnackBarVariant.Success,
             icon: <IconCopy size={theme.icon.size.md} />,
             duration: 2000,


### PR DESCRIPTION
## Issue

Closes (#6916)

There was an `Api` typo with API under Developer section while copying the API Key to clipboard in the status popup which is now corrected to `API`.