### PR TITLE
fix: Notes not visible in Timeline activities

### DIFF
--- a/packages/twenty-front/src/modules/activities/timelineActivities/components/EventRow.tsx
+++ b/packages/twenty-front/src/modules/activities/timelineActivities/components/EventRow.tsx
@@ -14,6 +14,7 @@ import { beautifyPastDateRelativeToNow } from '~/utils/date-utils';
 import { isUndefinedOrNull } from '~/utils/isUndefinedOrNull';
 
 const StyledTimelineItemContainer = styled.div`
+  color: ${({ theme }) => theme.font.color.primary};
   display: flex;
   gap: ${({ theme }) => theme.spacing(4)};
   height: 'auto';

--- a/packages/twenty-front/src/pages/settings/developers/api-keys/SettingsDevelopersApiKeyDetail.tsx
+++ b/packages/twenty-front/src/pages/settings/developers/api-keys/SettingsDevelopersApiKeyDetail.tsx
@@ -179,7 +179,7 @@ export const SettingsDevelopersApiKeyDetail = () => {
             <Section>
               <H2Title
                 title="Expiration"
-                description="When the key will be diasbled"
+                description="When the key will be disabled"
               />
               <TextInput
                 placeholder="E.g. backoffice integration"


### PR DESCRIPTION
## Description

- This PR solves #6935 #6934 

- fixed the notes color in timeline activities which was not visible in dark mode

- fixed spelling typo

## Before 
<img width="626" alt="Screenshot 2024-09-08 at 12 28 03 PM" src="https://github.com/user-attachments/assets/7c532c6b-af3f-4af6-baa1-be134d2142a6">


<img width="1195" alt="Screenshot 2024-09-08 at 12 20 27 PM" src="https://github.com/user-attachments/assets/2fb868b0-b66c-485f-b574-1beaf83bfb23">


## After
<img width="561" alt="Screenshot 2024-09-08 at 12 27 53 PM" src="https://github.com/user-attachments/assets/937e11ff-77ef-4170-b1ef-dc9cbfa86166">

<img width="1194" alt="Screenshot 2024-09-08 at 12 19 17 PM" src="https://github.com/user-attachments/assets/12455593-051d-490d-bc53-f5c5699f9c97">
