### PR TITLE
Update SettingsDevelopersApiKeyDetail.tsx typo

### DIFF
--- a/packages/twenty-front/src/pages/settings/developers/api-keys/SettingsDevelopersApiKeyDetail.tsx
+++ b/packages/twenty-front/src/pages/settings/developers/api-keys/SettingsDevelopersApiKeyDetail.tsx
@@ -179,7 +179,7 @@ export const SettingsDevelopersApiKeyDetail = () => {
             <Section>
               <H2Title
                 title="Expiration"
-                description="When the key will be diasbled"
+                description="When the key will be disabled"
               />
               <TextInput
                 placeholder="E.g. backoffice integration"


### PR DESCRIPTION
Corrected typo error of Expiration description in which it was "diasbled" to "disabled".