### PR TITLE
Show email in RecordChip on Email Thread Right Drawer

### DIFF
--- a/packages/twenty-front/src/modules/activities/components/ParticipantChip.tsx
+++ b/packages/twenty-front/src/modules/activities/components/ParticipantChip.tsx
@@ -68,6 +68,7 @@ export const ParticipantChip = ({
         <StyledRecordChip
           objectNameSingular={CoreObjectNameSingular.Person}
           record={person}
+          email={person.email}
           participantChipVariant={variant}
         />
       ) : (

--- a/packages/twenty-front/src/modules/object-record/components/RecordChip.tsx
+++ b/packages/twenty-front/src/modules/object-record/components/RecordChip.tsx
@@ -8,6 +8,7 @@ import { UndecoratedLink } from '@/ui/navigation/link/components/UndecoratedLink
 export type RecordChipProps = {
   objectNameSingular: string;
   record: ObjectRecord;
+  email?: string;
   className?: string;
   variant?: AvatarChipVariant;
 };
@@ -15,6 +16,7 @@ export type RecordChipProps = {
 export const RecordChip = ({
   objectNameSingular,
   record,
+  email,
   className,
   variant,
 }: RecordChipProps) => {
@@ -28,6 +30,7 @@ export const RecordChip = ({
       <AvatarChip
         placeholderColorSeed={record.id}
         name={recordChipData.name}
+        email={email}
         avatarType={recordChipData.avatarType}
         avatarUrl={recordChipData.avatarUrl ?? ''}
         className={className}

--- a/packages/twenty-ui/src/display/chip/components/AvatarChip.tsx
+++ b/packages/twenty-ui/src/display/chip/components/AvatarChip.tsx
@@ -10,6 +10,7 @@ import { MouseEvent, useContext } from 'react';
 
 export type AvatarChipProps = {
   name: string;
+  email?: string;
   avatarUrl?: string;
   avatarType?: Nullable<AvatarType>;
   variant?: AvatarChipVariant;
@@ -37,6 +38,7 @@ const StyledInvertedIconContainer = styled.div<{ backgroundColor: string }>`
 
 export const AvatarChip = ({
   name,
+  email,
   avatarUrl,
   avatarType = 'rounded',
   variant = AvatarChipVariant.Regular,
@@ -50,7 +52,8 @@ export const AvatarChip = ({
 
   return (
     <Chip
-      label={name}
+      maxWidth={email ? 350 : 200}
+      label={email ? `${name} <${email}>` : name}
       variant={
         isDefined(onClick)
           ? variant === AvatarChipVariant.Regular

--- a/packages/twenty-ui/src/display/chip/components/Chip.tsx
+++ b/packages/twenty-ui/src/display/chip/components/Chip.tsx
@@ -123,6 +123,7 @@ export const Chip = ({
   rightComponent,
   accent = ChipAccent.TextPrimary,
   onClick,
+  maxWidth,
 }: ChipProps) => {
   return (
     <StyledContainer
@@ -133,6 +134,7 @@ export const Chip = ({
       size={size}
       variant={variant}
       onClick={onClick}
+      maxWidth={maxWidth}
     >
       {leftComponent}
       <OverflowingTextWithTooltip


### PR DESCRIPTION
Here's a simple PR to add the email to the record chip in the email threads view. This is really just an attempt to get my feet wet with the code base so I don't expect it to be accepted as-is. But wanted to get it looked at. 

I understand there may be considerations about how to display the email. I would prefer a more muted color for the email text, perhaps a bit smaller, similar to how gmail does it. Also this is a simple way to get the email drilled through the many layers not sure if this is the desired method of extending the AvatarChip.

Here's what it looks like, this is a rather simple `it just works` type of commit.

![Screenshot 2024-09-08 at 10 54 08](https://github.com/user-attachments/assets/f9abab1a-75bb-4dcf-a489-7be6c03ab997)

Also note, the Chip is currently not extending the maxWidth property which I had to add to get the email to not be truncated. Seems to work fine otherwise. 

Update: apologies closed the previous, copied here, sorry for the mess, moved to it's own branch, opened as draft.