### PR TITLE
Fixed the overflow height of the Developers page's table

### DIFF
--- a/packages/twenty-front/src/modules/settings/developers/components/SettingsApiKeysTable.tsx
+++ b/packages/twenty-front/src/modules/settings/developers/components/SettingsApiKeysTable.tsx
@@ -13,6 +13,8 @@ import { TableRow } from '@/ui/layout/table/components/TableRow';
 
 const StyledTableBody = styled(TableBody)`
   border-bottom: 1px solid ${({ theme }) => theme.border.color.light};
+  max-height: 260px;
+  overflow-y: auto;
 `;
 
 const StyledTableRow = styled(TableRow)`

--- a/packages/twenty-front/src/modules/settings/developers/components/SettingsWebhooksTable.tsx
+++ b/packages/twenty-front/src/modules/settings/developers/components/SettingsWebhooksTable.tsx
@@ -11,6 +11,8 @@ import { TableRow } from '@/ui/layout/table/components/TableRow';
 
 const StyledTableBody = styled(TableBody)`
   border-bottom: 1px solid ${({ theme }) => theme.border.color.light};
+  max-height: 260px;
+  overflow-y: auto;
 `;
 
 const StyledTableRow = styled(TableRow)`

--- a/packages/twenty-front/src/modules/ui/layout/table/components/TableBody.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/table/components/TableBody.tsx
@@ -4,6 +4,8 @@ const StyledTableBody = styled.div`
   display: flex;
   flex-direction: column;
   gap: 2px;
+  max-height: 260px;
+  overflow-y: scroll;
   padding: ${({ theme }) => theme.spacing(2)} 0;
 `;
 

--- a/packages/twenty-front/src/modules/ui/layout/table/components/TableBody.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/table/components/TableBody.tsx
@@ -4,8 +4,6 @@ const StyledTableBody = styled.div`
   display: flex;
   flex-direction: column;
   gap: 2px;
-  max-height: 260px;
-  overflow-y: scroll;
   padding: ${({ theme }) => theme.spacing(2)} 0;
 `;
 


### PR DESCRIPTION
Ref: https://github.com/twentyhq/twenty/issues/6962

As of now, if user has more than 20 API keys or webhooks, whole page has scroll, when for the end user (UX) it'd be better if each table had it's own scroll.