### PR TITLE
[metadata] fix soft delete for standard objects missing deletedAt fieldMetadata

### DIFF
--- a/packages/twenty-server/src/database/typeorm-seeds/core/feature-flags.ts
+++ b/packages/twenty-server/src/database/typeorm-seeds/core/feature-flags.ts
@@ -55,6 +55,11 @@ export const seedFeatureFlags = async (
         workspaceId: workspaceId,
         value: false,
       },
+      {
+        key: FeatureFlagKey.IsQueryRunnerTwentyORMEnabled,
+        workspaceId: workspaceId,
+        value: true,
+      },
     ])
     .execute();
 };

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-find-many-resolver.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-find-many-resolver.service.ts
@@ -74,7 +74,7 @@ export class GraphqlQueryFindManyResolverService {
     );
     const where = graphqlQueryParser.parseFilter(
       args.filter ?? ({} as Filter),
-      true,
+      objectMetadataItem.isSoftDeletable ?? false,
     );
 
     const cursor = this.getCursor(args);

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-find-one-resolver.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-find-one-resolver.service.ts
@@ -56,7 +56,10 @@ export class GraphqlQueryFindOneResolverService {
       objectMetadataItem,
       graphqlFields(info),
     );
-    const where = graphqlQueryParser.parseFilter(args.filter ?? ({} as Filter));
+    const where = graphqlQueryParser.parseFilter(
+      args.filter ?? ({} as Filter),
+      objectMetadataItem.isSoftDeletable ?? false,
+    );
 
     const objectRecord = await repository.findOne({ where, select, relations });
 

--- a/packages/twenty-server/src/engine/twenty-orm/decorators/workspace-entity.decorator.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/decorators/workspace-entity.decorator.ts
@@ -48,7 +48,7 @@ export function WorkspaceEntity(
       isAuditLogged,
       isSystem,
       gate,
-      softDelete: options.softDelete,
+      softDelete: options.softDelete ?? true,
     });
   };
 }

--- a/packages/twenty-server/src/engine/twenty-orm/interfaces/workspace-entity-metadata-args.interface.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/interfaces/workspace-entity-metadata-args.interface.ts
@@ -64,5 +64,5 @@ export interface WorkspaceEntityMetadataArgs {
   /**
    * Enable soft delete.
    */
-  readonly softDelete?: boolean;
+  readonly softDelete: boolean;
 }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/factories/standard-object.factory.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/factories/standard-object.factory.ts
@@ -54,7 +54,7 @@ export class StandardObjectFactory {
       isCustom: false,
       isRemote: false,
       isSystem: workspaceEntityMetadataArgs.isSystem ?? false,
-      isSoftDeletable: workspaceEntityMetadataArgs.softDelete ?? true,
+      isSoftDeletable: workspaceEntityMetadataArgs.softDelete,
     };
   }
 }


### PR DESCRIPTION
This https://github.com/twentyhq/twenty/pull/7006 introduced a regression.

The goal was to set "isSoftDeletable" to all standard objects but it was done at the wrong level, meaning it was setting the boolean correctly but not creating the corresponding fieldMetadata.

I took the occasion to update the new graphql query runner to use that boolean and automatically add a filter on soft delete in case it's true.

Also adding **IsQueryRunnerTwentyORMEnabled** by default in the seeds