### PR TITLE
Feat: Allow defining option key also in custom select options

### DIFF
--- a/packages/twenty-front/src/modules/object-metadata/validation-schemas/selectOptionsSchema.ts
+++ b/packages/twenty-front/src/modules/object-metadata/validation-schemas/selectOptionsSchema.ts
@@ -2,7 +2,6 @@ import { themeColorSchema } from 'twenty-ui';
 import { z } from 'zod';
 
 import { FieldMetadataItemOption } from '@/object-metadata/types/FieldMetadataItem';
-import { getOptionValueFromLabel } from '@/settings/data-model/fields/forms/select/utils/getOptionValueFromLabel';
 import { computeOptionValueFromLabelOrThrow } from '~/pages/settings/data-model/utils/compute-option-value-from-label.utils';
 
 const selectOptionSchema = z
@@ -12,9 +11,6 @@ const selectOptionSchema = z
     label: z.string().trim().min(1),
     position: z.number(),
     value: z.string(),
-  })
-  .refine((option) => option.value === getOptionValueFromLabel(option.label), {
-    message: 'Value does not match label',
   })
   .refine(
     (option) => {

--- a/packages/twenty-front/src/modules/settings/data-model/fields/forms/select/components/SettingsDataModelFieldSelectFormOptionRow.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/forms/select/components/SettingsDataModelFieldSelectFormOptionRow.tsx
@@ -107,7 +107,6 @@ export const SettingsDataModelFieldSelectFormOptionRow = ({
         }
         RightIcon={isDefault ? IconCheck : undefined}
         maxLength={OPTION_VALUE_MAXIMUM_LENGTH}
-        onInputEnter={() => {}}
       />
       <Dropdown
         dropdownId={dropdownIds.color}

--- a/packages/twenty-front/src/modules/settings/data-model/fields/forms/select/components/SettingsDataModelFieldSelectFormOptionRow.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/forms/select/components/SettingsDataModelFieldSelectFormOptionRow.tsx
@@ -45,17 +45,19 @@ const StyledRow = styled.div`
 
 const StyledColorSample = styled(ColorSample)`
   cursor: pointer;
-  margin-left: 9px;
-  margin-right: 14px;
+  margin: 0 12px;
 `;
 
 const StyledOptionInput = styled(TextInput)`
   flex: 1 0 auto;
-  margin-right: ${({ theme }) => theme.spacing(2)};
 
   & input {
     height: ${({ theme }) => theme.spacing(6)};
   }
+`;
+
+const StyledOptionsDropdownIcon = styled(LightIconButton)`
+  margin-left: 4px;
 `;
 
 export const SettingsDataModelFieldSelectFormOptionRow = ({
@@ -94,6 +96,18 @@ export const SettingsDataModelFieldSelectFormOptionRow = ({
         size={theme.icon.size.md}
         stroke={theme.icon.stroke.sm}
         color={theme.font.color.extraLight}
+      />
+      <StyledOptionInput
+        value={option.value}
+        onChange={(input) =>
+          onChange({
+            ...option,
+            value: input,
+          })
+        }
+        RightIcon={isDefault ? IconCheck : undefined}
+        maxLength={OPTION_VALUE_MAXIMUM_LENGTH}
+        onInputEnter={() => {}}
       />
       <Dropdown
         dropdownId={dropdownIds.color}
@@ -140,7 +154,9 @@ export const SettingsDataModelFieldSelectFormOptionRow = ({
         dropdownHotkeyScope={{
           scope: dropdownIds.actions,
         }}
-        clickableComponent={<LightIconButton Icon={IconDotsVertical} />}
+        clickableComponent={
+          <StyledOptionsDropdownIcon Icon={IconDotsVertical} />
+        }
         dropdownComponents={
           <DropdownMenu>
             <DropdownMenuItemsContainer>


### PR DESCRIPTION
Closes #6146 

Screenshots:

Single select:
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/0bddefa9-9e0a-4634-a9f1-65d8b95cba87">
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/937ae1e0-aceb-4661-a8f1-2172c453bdeb">

Multi select:
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/81eaaf84-c328-40c2-b3bf-94425e3c0781">

Notes: Current behaviour is such that editing label will also edit value to fit according to the label (as per the old method) to continue suggested values without enforcing them.