### PR TITLE
Create command to set stale message sync back to pending

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version/0-30/0-30-set-stale-message-sync-back-to-pending.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-30/0-30-set-stale-message-sync-back-to-pending.ts
@@ -1,0 +1,91 @@
+import { InjectRepository } from '@nestjs/typeorm';
+
+import chalk from 'chalk';
+import { Command } from 'nest-commander';
+import { IsNull, Repository } from 'typeorm';
+
+import {
+  ActiveWorkspacesCommandOptions,
+  ActiveWorkspacesCommandRunner,
+} from 'src/database/commands/active-workspaces.command';
+import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
+import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.manager';
+import {
+  MessageChannelSyncStage,
+  MessageChannelWorkspaceEntity,
+} from 'src/modules/messaging/common/standard-objects/message-channel.workspace-entity';
+@Command({
+  name: 'upgrade-0.30:migrate-email-fields-to-emails',
+  description: 'Migrating fields of deprecated type EMAIL to type EMAILS',
+})
+export class SetStaleMessageSyncBackToPendingCommand extends ActiveWorkspacesCommandRunner {
+  constructor(
+    @InjectRepository(Workspace, 'core')
+    protected readonly workspaceRepository: Repository<Workspace>,
+    private readonly twentyORMGlobalManager: TwentyORMGlobalManager,
+  ) {
+    super(workspaceRepository);
+  }
+
+  async executeActiveWorkspacesCommand(
+    _passedParam: string[],
+    _options: ActiveWorkspacesCommandOptions,
+    workspaceIds: string[],
+  ): Promise<void> {
+    this.logger.log(
+      'Running command to migrate email type fields to emails type',
+    );
+
+    for (const workspaceId of workspaceIds) {
+      this.logger.log(`Running command for workspace ${workspaceId}`);
+
+      try {
+        const dataSource =
+          await this.twentyORMGlobalManager.getDataSourceForWorkspace(
+            workspaceId,
+          );
+
+        const messageChannelRepository =
+          await this.twentyORMGlobalManager.getRepositoryForWorkspace<MessageChannelWorkspaceEntity>(
+            'messageChannel',
+            workspaceId,
+          );
+
+        dataSource.transaction(async (entityManager) => {
+          await messageChannelRepository.update(
+            {
+              syncStage: MessageChannelSyncStage.MESSAGES_IMPORT_ONGOING,
+              syncStageStartedAt: IsNull(),
+            },
+            {
+              syncStage: MessageChannelSyncStage.MESSAGES_IMPORT_PENDING,
+            },
+            entityManager,
+          );
+
+          await messageChannelRepository.update(
+            {
+              syncStage: MessageChannelSyncStage.MESSAGE_LIST_FETCH_ONGOING,
+
+              syncStageStartedAt: IsNull(),
+            },
+            {
+              syncStage:
+                MessageChannelSyncStage.PARTIAL_MESSAGE_LIST_FETCH_PENDING,
+            },
+            entityManager,
+          );
+        });
+      } catch (error) {
+        this.logger.log(
+          chalk.red(
+            `Running command on workspace ${workspaceId} failed with error: ${error}`,
+          ),
+        );
+        continue;
+      }
+
+      this.logger.log(chalk.green(`Command completed!`));
+    }
+  }
+}

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-30/0-30-set-stale-message-sync-back-to-pending.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-30/0-30-set-stale-message-sync-back-to-pending.ts
@@ -15,8 +15,8 @@ import {
   MessageChannelWorkspaceEntity,
 } from 'src/modules/messaging/common/standard-objects/message-channel.workspace-entity';
 @Command({
-  name: 'upgrade-0.30:migrate-email-fields-to-emails',
-  description: 'Migrating fields of deprecated type EMAIL to type EMAILS',
+  name: 'upgrade-0.30:set-stale-message-sync-back-to-pending',
+  description: 'Set stale message sync back to pending',
 })
 export class SetStaleMessageSyncBackToPendingCommand extends ActiveWorkspacesCommandRunner {
   constructor(
@@ -33,7 +33,7 @@ export class SetStaleMessageSyncBackToPendingCommand extends ActiveWorkspacesCom
     workspaceIds: string[],
   ): Promise<void> {
     this.logger.log(
-      'Running command to migrate email type fields to emails type',
+      'Running command to set stale message sync back to pending',
     );
 
     for (const workspaceId of workspaceIds) {
@@ -47,8 +47,8 @@ export class SetStaleMessageSyncBackToPendingCommand extends ActiveWorkspacesCom
 
         const messageChannelRepository =
           await this.twentyORMGlobalManager.getRepositoryForWorkspace<MessageChannelWorkspaceEntity>(
-            'messageChannel',
             workspaceId,
+            'messageChannel',
           );
 
         dataSource.transaction(async (entityManager) => {
@@ -66,7 +66,6 @@ export class SetStaleMessageSyncBackToPendingCommand extends ActiveWorkspacesCom
           await messageChannelRepository.update(
             {
               syncStage: MessageChannelSyncStage.MESSAGE_LIST_FETCH_ONGOING,
-
               syncStageStartedAt: IsNull(),
             },
             {

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-30/0-30-upgrade-version.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-30/0-30-upgrade-version.command.ts
@@ -5,6 +5,7 @@ import { Repository } from 'typeorm';
 
 import { ActiveWorkspacesCommandRunner } from 'src/database/commands/active-workspaces.command';
 import { MigrateEmailFieldsToEmailsCommand } from 'src/database/commands/upgrade-version/0-30/0-30-migrate-email-fields-to-emails.command';
+import { SetStaleMessageSyncBackToPendingCommand } from 'src/database/commands/upgrade-version/0-30/0-30-set-stale-message-sync-back-to-pending';
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { SyncWorkspaceMetadataCommand } from 'src/engine/workspace-manager/workspace-sync-metadata/commands/sync-workspace-metadata.command';
 
@@ -22,6 +23,7 @@ export class UpgradeTo0_30Command extends ActiveWorkspacesCommandRunner {
     protected readonly workspaceRepository: Repository<Workspace>,
     private readonly syncWorkspaceMetadataCommand: SyncWorkspaceMetadataCommand,
     private readonly migrateEmailFieldsToEmails: MigrateEmailFieldsToEmailsCommand,
+    private readonly setStaleMessageSyncBackToPendingCommand: SetStaleMessageSyncBackToPendingCommand,
   ) {
     super(workspaceRepository);
   }
@@ -40,6 +42,11 @@ export class UpgradeTo0_30Command extends ActiveWorkspacesCommandRunner {
       workspaceIds,
     );
     await this.migrateEmailFieldsToEmails.executeActiveWorkspacesCommand(
+      passedParam,
+      options,
+      workspaceIds,
+    );
+    await this.setStaleMessageSyncBackToPendingCommand.executeActiveWorkspacesCommand(
       passedParam,
       options,
       workspaceIds,

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-30/0-30-upgrade-version.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-30/0-30-upgrade-version.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { MigrateEmailFieldsToEmailsCommand } from 'src/database/commands/upgrade-version/0-30/0-30-migrate-email-fields-to-emails.command';
+import { SetStaleMessageSyncBackToPendingCommand } from 'src/database/commands/upgrade-version/0-30/0-30-set-stale-message-sync-back-to-pending';
 import { UpgradeTo0_30Command } from 'src/database/commands/upgrade-version/0-30/0-30-upgrade-version.command';
 import { TypeORMModule } from 'src/database/typeorm/typeorm.module';
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
@@ -27,6 +28,10 @@ import { ViewModule } from 'src/modules/view/view.module';
     TypeORMModule,
     ViewModule,
   ],
-  providers: [UpgradeTo0_30Command, MigrateEmailFieldsToEmailsCommand],
+  providers: [
+    UpgradeTo0_30Command,
+    MigrateEmailFieldsToEmailsCommand,
+    SetStaleMessageSyncBackToPendingCommand,
+  ],
 })
 export class UpgradeTo0_30CommandModule {}


### PR DESCRIPTION
Some message channels are stuck in an ongoing `syncStage` because `syncStartedAt` was not set correctly at the beginning of the sync.
This command resets message channels with an ongoing `syncStage` and `syncStartedAt` set to null.