### PR TITLE
Add fail on metadata cache miss

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/workspace-schema.factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-schema.factory.ts
@@ -47,9 +47,9 @@ export class WorkspaceSchemaFactory {
       );
 
     if (currentCacheVersion === undefined) {
-      await this.workspaceMetadataCacheService.recomputeMetadataCache(
-        authContext.workspace.id,
-      );
+      await this.workspaceMetadataCacheService.recomputeMetadataCache({
+        workspaceId: authContext.workspace.id,
+      });
       throw new GraphqlQueryRunnerException(
         'Metadata cache version not found',
         GraphqlQueryRunnerExceptionCode.METADATA_CACHE_VERSION_NOT_FOUND,
@@ -63,9 +63,9 @@ export class WorkspaceSchemaFactory {
       );
 
     if (!objectMetadataMap) {
-      await this.workspaceMetadataCacheService.recomputeMetadataCache(
-        authContext.workspace.id,
-      );
+      await this.workspaceMetadataCacheService.recomputeMetadataCache({
+        workspaceId: authContext.workspace.id,
+      });
       throw new GraphqlQueryRunnerException(
         'Object metadata collection not found',
         GraphqlQueryRunnerExceptionCode.METADATA_CACHE_VERSION_NOT_FOUND,

--- a/packages/twenty-server/src/engine/metadata-modules/workspace-metadata-cache/services/workspace-metadata-cache.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/workspace-metadata-cache/services/workspace-metadata-cache.service.ts
@@ -26,10 +26,13 @@ export class WorkspaceMetadataCacheService {
   ) {}
 
   @LogExecutionTime()
-  async recomputeMetadataCache(
-    workspaceId: string,
-    force = false,
-  ): Promise<void> {
+  async recomputeMetadataCache({
+    workspaceId,
+    ignoreLock = false,
+  }: {
+    workspaceId: string;
+    ignoreLock?: boolean;
+  }): Promise<void> {
     const currentCacheVersion =
       await this.getMetadataVersionFromCache(workspaceId);
 
@@ -43,17 +46,13 @@ export class WorkspaceMetadataCacheService {
       );
     }
 
-    if (!force && currentCacheVersion === currentDatabaseVersion) {
-      return;
-    }
-
     const isAlreadyCaching =
       await this.workspaceCacheStorageService.getObjectMetadataOngoingCachingLock(
         workspaceId,
         currentDatabaseVersion,
       );
 
-    if (isAlreadyCaching) {
+    if (!ignoreLock && isAlreadyCaching) {
       return;
     }
 

--- a/packages/twenty-server/src/engine/metadata-modules/workspace-metadata-version/services/workspace-metadata-version.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/workspace-metadata-version/services/workspace-metadata-version.service.ts
@@ -45,8 +45,8 @@ export class WorkspaceMetadataVersionService {
       { metadataVersion: newMetadataVersion },
     );
 
-    await this.workspaceMetadataCacheService.recomputeMetadataCache(
+    await this.workspaceMetadataCacheService.recomputeMetadataCache({
       workspaceId,
-    );
+    });
   }
 }

--- a/packages/twenty-server/src/engine/twenty-orm/twenty-orm-global.manager.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/twenty-orm-global.manager.ts
@@ -15,16 +15,19 @@ export class TwentyORMGlobalManager {
   async getRepositoryForWorkspace<T extends ObjectLiteral>(
     workspaceId: string,
     workspaceEntity: Type<T>,
+    failOnMetadataCacheMiss?: boolean,
   ): Promise<WorkspaceRepository<T>>;
 
   async getRepositoryForWorkspace<T extends ObjectLiteral>(
     workspaceId: string,
     objectMetadataName: string,
+    failOnMetadataCacheMiss?: boolean,
   ): Promise<WorkspaceRepository<T>>;
 
   async getRepositoryForWorkspace<T extends ObjectLiteral>(
     workspaceId: string,
     workspaceEntityOrobjectMetadataName: Type<T> | string,
+    failOnMetadataCacheMiss = true,
   ): Promise<WorkspaceRepository<T>> {
     let objectMetadataName: string;
 
@@ -39,6 +42,7 @@ export class TwentyORMGlobalManager {
     const workspaceDataSource = await this.workspaceDataSourceFactory.create(
       workspaceId,
       null,
+      failOnMetadataCacheMiss,
     );
 
     const repository = workspaceDataSource.getRepository<T>(objectMetadataName);
@@ -50,11 +54,7 @@ export class TwentyORMGlobalManager {
     return await this.workspaceDataSourceFactory.create(workspaceId, null);
   }
 
-  async loadDataSourceForWorkspace(workspaceId: string) {
-    await this.workspaceDataSourceFactory.create(workspaceId, null);
-  }
-
   async destroyDataSourceForWorkspace(workspaceId: string) {
-    await this.workspaceDataSourceFactory.destroy(workspaceId, null);
+    await this.workspaceDataSourceFactory.destroy(workspaceId);
   }
 }


### PR DESCRIPTION
- avoid failing when missing cache (used for command)
- remove unused load cache function. Cache will be always re-created when trying to fetch if not existing