### PR TITLE
Fixed scroll wrapper for settings page container

### DIFF
--- a/packages/twenty-front/src/modules/settings/components/SettingsPageContainer.tsx
+++ b/packages/twenty-front/src/modules/settings/components/SettingsPageContainer.tsx
@@ -20,6 +20,7 @@ const StyledSettingsPageContainer = styled.div<{ width?: number }>`
     }
     return OBJECT_SETTINGS_WIDTH + 'px';
   }};
+  padding-bottom: ${({ theme }) => theme.spacing(20)};
 `;
 
 export const SettingsPageContainer = ({

--- a/packages/twenty-front/src/modules/ui/layout/page/PagePanel.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/page/PagePanel.tsx
@@ -9,7 +9,6 @@ const StyledPanel = styled.div`
   overflow-x: auto;
   overflow-y: hidden;
   width: 100%;
-  padding-bottom: ${({ theme }) => theme.spacing(10)};
 `;
 
 type PagePanelProps = {


### PR DESCRIPTION
Padding was set on global page component while it is needed only for settings page container component.