### PR TITLE
Improved note cards design

### DIFF
--- a/packages/twenty-front/src/modules/activities/notes/components/NoteCard.tsx
+++ b/packages/twenty-front/src/modules/activities/notes/components/NoteCard.tsx
@@ -28,8 +28,9 @@ const StyledCardDetailsContainer = styled.div`
   gap: ${({ theme }) => theme.spacing(2)};
   height: calc(100% - 45px);
   justify-content: start;
-  padding: ${({ theme }) => theme.spacing(2)};
-  width: calc(100% - ${({ theme }) => theme.spacing(4)});
+  padding: ${({ theme }) => theme.spacing(4)};
+  width: calc(100% - ${({ theme }) => theme.spacing(8)});
+  box-sizing: border-box;
 `;
 
 const StyledNoteTitle = styled.div`
@@ -41,7 +42,6 @@ const StyledCardContent = styled.div`
   align-self: stretch;
   color: ${({ theme }) => theme.font.color.secondary};
   line-break: anywhere;
-  margin-top: ${({ theme }) => theme.spacing(2)};
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: pre-line;


### PR DESCRIPTION
Fixes #7120

- Removed margin according to design
- Increased card content padding from 8px to 16px

![image](https://github.com/user-attachments/assets/bf1b2be4-7176-4af1-bad0-7e7f159b57c2)
