### PR TITLE
Add deletedAt to foreignKey indexes

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query.parser.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query.parser.ts
@@ -1,5 +1,4 @@
 import {
-  FindOperator,
   FindOptionsOrderValue,
   FindOptionsWhere,
   ObjectLiteral,
@@ -60,19 +59,6 @@ export class GraphqlQueryParser {
 
     for (const [key, value] of Object.entries(filter)) {
       if (key === 'deletedAt') {
-        if (value instanceof FindOperator) {
-          if (value.type === 'isNull') {
-            return true;
-          }
-          if (
-            value.type === 'not' &&
-            value.value instanceof FindOperator &&
-            value.value.type === 'isNull'
-          ) {
-            return true;
-          }
-        }
-
         return true;
       }
 

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-find-many-resolver.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-find-many-resolver.service.ts
@@ -79,7 +79,8 @@ export class GraphqlQueryFindManyResolverService {
       args.orderBy ?? [],
       isForwardPagination,
     );
-    const where = graphqlQueryParser.parseFilter(args.filter ?? ({} as Filter));
+    const { parsedFilters: where, withDeleted } =
+      graphqlQueryParser.parseFilter(args.filter ?? ({} as Filter));
 
     const cursor = this.getCursor(args);
     const limit = args.first ?? args.last ?? QUERY_MAX_RECORDS;
@@ -92,6 +93,7 @@ export class GraphqlQueryFindManyResolverService {
       order,
       select,
       take: limit + 1,
+      withDeleted,
     };
 
     const totalCount = isDefined(selectedFields.totalCount)

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-find-many-resolver.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-find-many-resolver.service.ts
@@ -97,7 +97,7 @@ export class GraphqlQueryFindManyResolverService {
     };
 
     const totalCount = isDefined(selectedFields.totalCount)
-      ? await repository.count({ where })
+      ? await repository.count({ where, withDeleted })
       : 0;
 
     if (cursor) {

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-find-one-resolver.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-find-one-resolver.service.ts
@@ -63,11 +63,13 @@ export class GraphqlQueryFindOneResolverService {
       objectMetadataItem,
       selectedFields,
     );
-    const where = graphqlQueryParser.parseFilter(args.filter ?? ({} as Filter));
+    const { parsedFilters: where, withDeleted } =
+      graphqlQueryParser.parseFilter(args.filter ?? ({} as Filter));
 
     const objectRecord = (await repository.findOne({
       where,
       select,
+      withDeleted,
     })) as ObjectRecord;
 
     const limit = QUERY_MAX_RECORDS;

--- a/packages/twenty-server/src/engine/twenty-orm/decorators/workspace-index.decorator.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/decorators/workspace-index.decorator.ts
@@ -38,9 +38,9 @@ export function WorkspaceIndex(
     metadataArgsStorage.addIndexes({
       name: `IDX_${generateDeterministicIndexName([
         convertClassNameToObjectMetadataName(target.constructor.name),
-        propertyKey.toString(),
+        ...[propertyKey.toString(), 'deletedAt'],
       ])}`,
-      columns: [propertyKey.toString()],
+      columns: [propertyKey.toString(), 'deletedAt'],
       target: target.constructor,
       gate,
     });

--- a/packages/twenty-server/src/engine/twenty-orm/factories/entity-schema-column.factory.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/factories/entity-schema-column.factory.ts
@@ -79,6 +79,7 @@ export class EntitySchemaColumnFactory {
         nullable: fieldMetadata.isNullable,
         createDate: key === 'createdAt',
         updateDate: key === 'updatedAt',
+        deleteDate: key === 'deletedAt',
         array: fieldMetadata.type === FieldMetadataType.MULTI_SELECT,
         default: defaultValue,
       };


### PR DESCRIPTION
We had to remove soft-deletion on default filters due to the missing indexes. We now generate composite indexes with the foreign key containing the deletedAt column as well which should improve performances