### PR TITLE
Workflow diagram zoom

### DIFF
--- a/packages/twenty-front/src/modules/workflow/__stories__/Workflow.stories.tsx
+++ b/packages/twenty-front/src/modules/workflow/__stories__/Workflow.stories.tsx
@@ -1,0 +1,94 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { within } from '@storybook/test';
+
+import { GET_CLIENT_CONFIG } from '@/client-config/graphql/queries/getClientConfig';
+import { FIND_MANY_OBJECT_METADATA_ITEMS } from '@/object-metadata/graphql/queries';
+import { GET_CURRENT_USER } from '@/users/graphql/queries/getCurrentUser';
+import { getOperationName } from '@apollo/client/utilities';
+import { graphql, HttpResponse } from 'msw';
+import { OnboardingStatus } from '~/generated/graphql';
+import { PasswordReset } from '~/pages/auth/PasswordReset';
+import { RecordShowPage } from '~/pages/object-record/RecordShowPage';
+import {
+  PageDecorator,
+  PageDecoratorArgs,
+} from '~/testing/decorators/PageDecorator';
+import { graphqlMocks, metadataGraphql } from '~/testing/graphqlMocks';
+import { mockedClientConfig } from '~/testing/mock-data/config';
+import {
+  mockedOnboardingUserData,
+  mockedUserData,
+} from '~/testing/mock-data/users';
+
+const mockedOnboardingUsersData = mockedOnboardingUserData(
+  OnboardingStatus.Completed,
+);
+
+const userMetadataLoaderMocks = {
+  msw: {
+    handlers: [
+      graphql.query(getOperationName(GET_CURRENT_USER) ?? '', () => {
+        return HttpResponse.json({
+          data: {
+            currentUser: mockedUserData,
+          },
+        });
+      }),
+      graphql.query(getOperationName(GET_CLIENT_CONFIG) ?? '', () => {
+        return HttpResponse.json({
+          data: {
+            clientConfig: mockedClientConfig,
+          },
+        });
+      }),
+      metadataGraphql.query(
+        getOperationName(FIND_MANY_OBJECT_METADATA_ITEMS) ?? '',
+        () => {
+          return HttpResponse.json({
+            data: {
+              objects: {
+                // simulate no metadata items
+                edges: [],
+              },
+            },
+          });
+        },
+      ),
+    ],
+  },
+};
+
+const meta: Meta<PageDecoratorArgs> = {
+  title: 'Pages/Workflow',
+  component: RecordShowPage,
+  decorators: [PageDecorator],
+  args: {
+    routePath: '/object/:objectNameSingular/:objectRecordId',
+    routeParams: {
+      ':objectNameSingular': 'workflow',
+      ':objectRecordId': '200c1508-f102-4bb9-af32-eda55239ae61',
+    },
+  },
+  parameters: {
+    msw: {
+      handlers: [
+        graphqlMocks.handlers,
+        ...userMetadataLoaderMocks.msw.handlers,
+      ],
+    },
+  },
+};
+
+export default meta;
+
+export type Story = StoryObj<typeof PasswordReset>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await canvas.findByText('Reset Password', undefined, {
+      timeout: 3000,
+    });
+  },
+};

--- a/packages/twenty-front/src/modules/workflow/components/WorkflowDiagramCanvas.tsx
+++ b/packages/twenty-front/src/modules/workflow/components/WorkflowDiagramCanvas.tsx
@@ -32,6 +32,40 @@ const StyledStatusTagContainer = styled.div`
   padding: ${({ theme }) => theme.spacing(2)};
 `;
 
+const getWorkflowDefinitionPositionRanges = ({
+  nodes,
+}: {
+  nodes: Array<WorkflowDiagramNode>;
+}) => {
+  let minX = 0,
+    maxX = 0,
+    minY = 0,
+    maxY = 0;
+
+  for (const node of nodes) {
+    if (node.position.x < minX) {
+      minX = node.position.x;
+    }
+    if (node.position.x > maxX) {
+      maxX = node.position.x;
+    }
+
+    if (node.position.y < minY) {
+      minY = node.position.y;
+    }
+    if (node.position.y < maxY) {
+      maxY = node.position.y;
+    }
+  }
+
+  return {
+    minX,
+    maxX,
+    minY,
+    maxY,
+  };
+};
+
 export const WorkflowDiagramCanvas = ({
   diagram,
   workflowWithCurrentVersion,
@@ -43,6 +77,8 @@ export const WorkflowDiagramCanvas = ({
     () => getOrganizedDiagram(diagram),
     [diagram],
   );
+
+  const nodesPositionRanges = getWorkflowDefinitionPositionRanges({ nodes });
 
   const setWorkflowDiagram = useSetRecoilState(workflowDiagramState);
 
@@ -89,6 +125,11 @@ export const WorkflowDiagramCanvas = ({
           'empty-trigger': WorkflowDiagramEmptyTrigger,
         }}
         fitView
+        defaultViewport={{
+          x: (nodesPositionRanges.minX + nodesPositionRanges.maxX) / 2,
+          y: (nodesPositionRanges.minY + nodesPositionRanges.maxY) / 2,
+          zoom: 1,
+        }}
         nodes={nodes.map((node) => ({ ...node, draggable: false }))}
         edges={edges}
         onNodesChange={handleNodesChange}

--- a/packages/twenty-front/src/modules/workflow/components/WorkflowDiagramCanvas.tsx
+++ b/packages/twenty-front/src/modules/workflow/components/WorkflowDiagramCanvas.tsx
@@ -17,6 +17,7 @@ import {
   applyNodeChanges,
   Background,
   EdgeChange,
+  FitViewOptions,
   NodeChange,
   ReactFlow,
 } from '@xyflow/react';
@@ -32,38 +33,8 @@ const StyledStatusTagContainer = styled.div`
   padding: ${({ theme }) => theme.spacing(2)};
 `;
 
-const getWorkflowDefinitionPositionRanges = ({
-  nodes,
-}: {
-  nodes: Array<WorkflowDiagramNode>;
-}) => {
-  let minX = 0,
-    maxX = 0,
-    minY = 0,
-    maxY = 0;
-
-  for (const node of nodes) {
-    if (node.position.x < minX) {
-      minX = node.position.x;
-    }
-    if (node.position.x > maxX) {
-      maxX = node.position.x;
-    }
-
-    if (node.position.y < minY) {
-      minY = node.position.y;
-    }
-    if (node.position.y < maxY) {
-      maxY = node.position.y;
-    }
-  }
-
-  return {
-    minX,
-    maxX,
-    minY,
-    maxY,
-  };
+const fitViewOptions: FitViewOptions = {
+  maxZoom: 1.7,
 };
 
 export const WorkflowDiagramCanvas = ({
@@ -77,8 +48,6 @@ export const WorkflowDiagramCanvas = ({
     () => getOrganizedDiagram(diagram),
     [diagram],
   );
-
-  const nodesPositionRanges = getWorkflowDefinitionPositionRanges({ nodes });
 
   const setWorkflowDiagram = useSetRecoilState(workflowDiagramState);
 
@@ -119,16 +88,14 @@ export const WorkflowDiagramCanvas = ({
   return (
     <>
       <ReactFlow
+        key={workflowWithCurrentVersion.currentVersion.id}
+        onInit={({ fitView }) => {
+          fitView(fitViewOptions);
+        }}
         nodeTypes={{
           default: WorkflowDiagramStepNode,
           'create-step': WorkflowDiagramCreateStepNode,
           'empty-trigger': WorkflowDiagramEmptyTrigger,
-        }}
-        fitView
-        defaultViewport={{
-          x: (nodesPositionRanges.minX + nodesPositionRanges.maxX) / 2,
-          y: (nodesPositionRanges.minY + nodesPositionRanges.maxY) / 2,
-          zoom: 1,
         }}
         nodes={nodes.map((node) => ({ ...node, draggable: false }))}
         edges={edges}

--- a/packages/twenty-front/src/modules/workflow/components/WorkflowDiagramCanvas.tsx
+++ b/packages/twenty-front/src/modules/workflow/components/WorkflowDiagramCanvas.tsx
@@ -34,7 +34,8 @@ const StyledStatusTagContainer = styled.div`
 `;
 
 const fitViewOptions: FitViewOptions = {
-  maxZoom: 1.7,
+  minZoom: 1.3,
+  maxZoom: 1.3,
 };
 
 export const WorkflowDiagramCanvas = ({

--- a/packages/twenty-front/src/modules/workflow/components/WorkflowDiagramCreateStepNode.tsx
+++ b/packages/twenty-front/src/modules/workflow/components/WorkflowDiagramCreateStepNode.tsx
@@ -12,7 +12,7 @@ export const WorkflowDiagramCreateStepNode = () => {
     <>
       <StyledTargetHandle type="target" position={Position.Top} />
 
-      <IconButton Icon={IconPlus} />
+      <IconButton Icon={IconPlus} size="small" />
     </>
   );
 };

--- a/packages/twenty-front/src/modules/workflow/types/Workflow.ts
+++ b/packages/twenty-front/src/modules/workflow/types/Workflow.ts
@@ -61,6 +61,7 @@ export type WorkflowVersion = {
   name: string;
   createdAt: string;
   updatedAt: string;
+  deletedAt: string | null;
   workflowId: string;
   trigger: WorkflowTrigger | null;
   steps: Array<WorkflowStep> | null;
@@ -75,6 +76,10 @@ export type Workflow = {
   versions: Array<WorkflowVersion>;
   lastPublishedVersionId: string;
   statuses: Array<WorkflowStatus> | null;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string | null;
+  position: number;
 };
 
 export type WorkflowWithCurrentVersion = Workflow & {

--- a/packages/twenty-front/src/testing/graphqlMocks.ts
+++ b/packages/twenty-front/src/testing/graphqlMocks.ts
@@ -402,6 +402,133 @@ export const graphqlMocks = {
         },
       });
     }),
+    graphql.query('FindManyWorkflows', () => {
+      return HttpResponse.json({
+        data: {
+          workflows: {
+            __typename: 'WorkflowConnection',
+            totalCount: 1,
+            pageInfo: {
+              __typename: 'PageInfo',
+              hasNextPage: false,
+              hasPreviousPage: false,
+              startCursor:
+                'eyJpZCI6IjIwMGMxNTA4LWYxMDItNGJiOS1hZjMyLWVkYTU1MjM5YWU2MSJ9',
+              endCursor:
+                'eyJpZCI6IjIwMGMxNTA4LWYxMDItNGJiOS1hZjMyLWVkYTU1MjM5YWU2MSJ9',
+            },
+            edges: [
+              {
+                __typename: 'WorkflowEdge',
+                cursor:
+                  'eyJpZCI6IjIwMGMxNTA4LWYxMDItNGJiOS1hZjMyLWVkYTU1MjM5YWU2MSJ9',
+                node: {
+                  __typename: 'Workflow',
+                  id: '200c1508-f102-4bb9-af32-eda55239ae61',
+                },
+              },
+            ],
+          },
+        },
+      });
+    }),
+    graphql.query('FindOneWorkflow', () => {
+      return HttpResponse.json({
+        data: {
+          workflow: {
+            __typename: 'Workflow',
+            id: '200c1508-f102-4bb9-af32-eda55239ae61',
+            name: '1231 qqerrt',
+            statuses: null,
+            lastPublishedVersionId: '',
+            deletedAt: null,
+            updatedAt: '2024-09-19T10:10:04.505Z',
+            position: 0,
+            createdAt: '2024-09-19T10:10:04.505Z',
+            favorites: {
+              __typename: 'FavoriteConnection',
+              edges: [],
+            },
+            eventListeners: {
+              __typename: 'WorkflowEventListenerConnection',
+              edges: [],
+            },
+            runs: {
+              __typename: 'WorkflowRunConnection',
+              edges: [],
+            },
+            versions: {
+              __typename: 'WorkflowVersionConnection',
+              edges: [
+                {
+                  __typename: 'WorkflowVersionEdge',
+                  node: {
+                    __typename: 'WorkflowVersion',
+                    updatedAt: '2024-09-19T10:13:12.075Z',
+                    steps: null,
+                    createdAt: '2024-09-19T10:10:04.725Z',
+                    status: 'DRAFT',
+                    name: 'v1',
+                    id: 'f618843a-26be-4a54-a60f-f4ce88a594f0',
+                    trigger: {
+                      type: 'DATABASE_EVENT',
+                      settings: {
+                        eventName: 'note.created',
+                      },
+                    },
+                    deletedAt: null,
+                    workflowId: '200c1508-f102-4bb9-af32-eda55239ae61',
+                  },
+                },
+              ],
+            },
+          },
+        },
+      });
+    }),
+    graphql.query('FindManyWorkflowVersions', () => {
+      return HttpResponse.json({
+        data: {
+          workflowVersions: {
+            __typename: 'WorkflowVersionConnection',
+            totalCount: 1,
+            pageInfo: {
+              __typename: 'PageInfo',
+              hasNextPage: false,
+              hasPreviousPage: false,
+              startCursor:
+                'eyJjcmVhdGVkQXQiOiIyMDI0LTA5LTE5VDEwOjEwOjA0LjcyNVoiLCJpZCI6ImY2MTg4NDNhLTI2YmUtNGE1NC1hNjBmLWY0Y2U4OGE1OTRmMCJ9',
+              endCursor:
+                'eyJjcmVhdGVkQXQiOiIyMDI0LTA5LTE5VDEwOjEwOjA0LjcyNVoiLCJpZCI6ImY2MTg4NDNhLTI2YmUtNGE1NC1hNjBmLWY0Y2U4OGE1OTRmMCJ9',
+            },
+            edges: [
+              {
+                __typename: 'WorkflowVersionEdge',
+                cursor:
+                  'eyJjcmVhdGVkQXQiOiIyMDI0LTA5LTE5VDEwOjEwOjA0LjcyNVoiLCJpZCI6ImY2MTg4NDNhLTI2YmUtNGE1NC1hNjBmLWY0Y2U4OGE1OTRmMCJ9',
+                node: {
+                  __typename: 'WorkflowVersion',
+                  updatedAt: '2024-09-19T10:13:12.075Z',
+                  steps: null,
+                  createdAt: '2024-09-19T10:10:04.725Z',
+                  status: 'DRAFT',
+                  name: 'v1',
+                  id: 'f618843a-26be-4a54-a60f-f4ce88a594f0',
+                  trigger: {
+                    type: 'DATABASE_EVENT',
+                    settings: {
+                      eventName: 'note.created',
+                    },
+                  },
+                  deletedAt: null,
+                  workflowId: '200c1508-f102-4bb9-af32-eda55239ae61',
+                },
+              },
+            ],
+          },
+        },
+      });
+    }),
     graphql.query('GetOneDatabaseConnection', () => {
       return HttpResponse.json({
         data: {

--- a/packages/twenty-front/src/testing/mock-data/users.ts
+++ b/packages/twenty-front/src/testing/mock-data/users.ts
@@ -60,6 +60,12 @@ export const mockDefaultWorkspace: Workspace = {
       value: true,
       workspaceId: '7dfbc3f7-6e5e-4128-957e-8d86808cdf6w',
     },
+    {
+      id: '1492de61-5018-4368-8923-4f1eeaf988c7',
+      key: 'IS_WORKFLOW_ENABLED',
+      value: true,
+      workspaceId: '7dfbc3f7-6e5e-4128-957e-8d86808cdf6w',
+    },
   ],
   createdAt: '2023-04-26T10:23:42.33625+00:00',
   updatedAt: '2023-04-26T10:23:42.33625+00:00',

--- a/packages/twenty-front/src/testing/mock-data/workflow.ts
+++ b/packages/twenty-front/src/testing/mock-data/workflow.ts
@@ -1,0 +1,32 @@
+import { Workflow, WorkflowVersion } from '@/workflow/types/Workflow';
+
+export const mockWorkflowVersion: WorkflowVersion = {
+  __typename: 'WorkflowVersion',
+  updatedAt: '2024-09-19T10:13:12.075Z',
+  steps: null,
+  createdAt: '2024-09-19T10:10:04.725Z',
+  status: 'DRAFT',
+  name: 'v1',
+  id: 'f618843a-26be-4a54-a60f-f4ce88a594f0',
+  trigger: {
+    type: 'DATABASE_EVENT',
+    settings: {
+      eventName: 'note.created',
+    },
+  },
+  deletedAt: null,
+  workflowId: '200c1508-f102-4bb9-af32-eda55239ae61',
+};
+
+export const mockWorkflow: Workflow = {
+  __typename: 'Workflow',
+  id: '200c1508-f102-4bb9-af32-eda55239ae61',
+  name: 'Test Workflow',
+  versions: [mockWorkflowVersion],
+  statuses: ['DRAFT'],
+  lastPublishedVersionId: '',
+  createdAt: '2024-09-19T10:10:04.725Z',
+  updatedAt: '2024-09-19T10:13:12.075Z',
+  deletedAt: null,
+  position: 0,
+};


### PR DESCRIPTION
## What this PR adds

- Set a smaller size to the "+" button to create new steps
- Fit the flow in the view when the flow has been initialized by listening to the `onInit` event.
- Reset the Reactflow component instance when the current workflow version changes. This will re-trigger the `onInit` callback to re-fit the flow in the view.

## Comments

We must call `fitView` in the `onInit` callback instead of relying on the `fitView` property of the `Reactflow` component because we rely on the first render of the nodes to measure their sizes and position the nodes with a layout algorithm, which corrupts the behavior of `fitView`.
The `onInit` callback seems to be called after the dimensions of the nodes have been measured and the nodes correctly positioned, which is the perfect timing to adjust the viewport.

## Result

### New

![CleanShot 2024-09-19 at 15 28 00@2x](https://github.com/user-attachments/assets/6581cb16-a3b7-4ba7-9054-dc5de8d11de4)

![CleanShot 2024-09-19 at 15 28 03@2x](https://github.com/user-attachments/assets/52863d2b-2f7e-4603-98d2-baec3528516c)

### Old

![CleanShot 2024-09-19 at 15 34 52@2x](https://github.com/user-attachments/assets/6f4df54c-6c15-4de3-8ef4-e28e24d244f4)

![CleanShot 2024-09-19 at 15 34 46@2x](https://github.com/user-attachments/assets/8aad0c10-f610-4e51-a2aa-35d0d0765c35)

Closes #7047