### PR TITLE
Add indexes to custom relations

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/index-metadata/index-metadata.module.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/index-metadata/index-metadata.module.ts
@@ -2,10 +2,15 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { IndexMetadataEntity } from 'src/engine/metadata-modules/index-metadata/index-metadata.entity';
+import { IndexMetadataService } from 'src/engine/metadata-modules/index-metadata/index-metadata.service';
+import { WorkspaceMigrationModule } from 'src/engine/metadata-modules/workspace-migration/workspace-migration.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([IndexMetadataEntity], 'metadata')],
-  providers: [],
-  exports: [],
+  imports: [
+    TypeOrmModule.forFeature([IndexMetadataEntity], 'metadata'),
+    WorkspaceMigrationModule,
+  ],
+  providers: [IndexMetadataService],
+  exports: [IndexMetadataService],
 })
 export class IndexMetadataModule {}

--- a/packages/twenty-server/src/engine/metadata-modules/index-metadata/index-metadata.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/index-metadata/index-metadata.service.ts
@@ -27,11 +27,11 @@ export class IndexMetadataService {
   async createIndex(
     workspaceId: string,
     objectMetadata: ObjectMetadataEntity,
-    fieldMetadataToIndexSet: Partial<FieldMetadataEntity>[],
+    fieldMetadataToIndex: Partial<FieldMetadataEntity>[],
   ) {
     const tableName = computeObjectTargetTable(objectMetadata);
 
-    const columnNames: string[] = Array.from(fieldMetadataToIndexSet).map(
+    const columnNames: string[] = fieldMetadataToIndex.map(
       (fieldMetadata) => fieldMetadata.name as string,
     );
 
@@ -43,7 +43,7 @@ export class IndexMetadataService {
       savedIndexMetadata = await this.indexMetadataRepository.save({
         name: indexName,
         tableName,
-        indexFieldMetadatas: fieldMetadataToIndexSet.map(
+        indexFieldMetadatas: fieldMetadataToIndex.map(
           (fieldMetadata, index) => {
             return {
               fieldMetadataId: fieldMetadata.id,

--- a/packages/twenty-server/src/engine/metadata-modules/index-metadata/index-metadata.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/index-metadata/index-metadata.service.ts
@@ -1,0 +1,87 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { Repository } from 'typeorm';
+
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
+import { IndexMetadataEntity } from 'src/engine/metadata-modules/index-metadata/index-metadata.entity';
+import { generateDeterministicIndexName } from 'src/engine/metadata-modules/index-metadata/utils/generate-deterministic-index-name';
+import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
+import { generateMigrationName } from 'src/engine/metadata-modules/workspace-migration/utils/generate-migration-name.util';
+import {
+  WorkspaceMigrationIndexActionType,
+  WorkspaceMigrationTableAction,
+  WorkspaceMigrationTableActionType,
+} from 'src/engine/metadata-modules/workspace-migration/workspace-migration.entity';
+import { WorkspaceMigrationService } from 'src/engine/metadata-modules/workspace-migration/workspace-migration.service';
+import { computeObjectTargetTable } from 'src/engine/utils/compute-object-target-table.util';
+
+@Injectable()
+export class IndexMetadataService {
+  constructor(
+    @InjectRepository(IndexMetadataEntity, 'metadata')
+    private readonly indexMetadataRepository: Repository<IndexMetadataEntity>,
+    private readonly workspaceMigrationService: WorkspaceMigrationService,
+  ) {}
+
+  async createIndex(
+    workspaceId: string,
+    objectMetadata: ObjectMetadataEntity,
+    fieldMetadataToIndexSet: Partial<FieldMetadataEntity>[],
+  ) {
+    const tableName = computeObjectTargetTable(objectMetadata);
+
+    const columnNames: string[] = Array.from(fieldMetadataToIndexSet).map(
+      (fieldMetadata) => fieldMetadata.name as string,
+    );
+
+    const indexName = `IDX_${generateDeterministicIndexName([tableName, ...columnNames])}`;
+
+    let savedIndexMetadata: IndexMetadataEntity;
+
+    try {
+      savedIndexMetadata = await this.indexMetadataRepository.save({
+        name: indexName,
+        tableName,
+        indexFieldMetadatas: fieldMetadataToIndexSet.map(
+          (fieldMetadata, index) => {
+            return {
+              fieldMetadataId: fieldMetadata.id,
+              order: index,
+            };
+          },
+        ),
+        workspaceId,
+        objectMetadataId: objectMetadata.id,
+      });
+    } catch (error) {
+      throw new Error(
+        `Failed to create index ${indexName} on object metadata ${objectMetadata.nameSingular}`,
+      );
+    }
+
+    if (!savedIndexMetadata) {
+      throw new Error(
+        `Failed to return saved index ${indexName} on object metadata ${objectMetadata.nameSingular}`,
+      );
+    }
+
+    const migration = {
+      name: tableName,
+      action: WorkspaceMigrationTableActionType.ALTER_INDEXES,
+      indexes: [
+        {
+          action: WorkspaceMigrationIndexActionType.CREATE,
+          columns: columnNames,
+          name: indexName,
+        },
+      ],
+    } satisfies WorkspaceMigrationTableAction;
+
+    await this.workspaceMigrationService.createCustomMigration(
+      generateMigrationName(`create-${objectMetadata.nameSingular}-index`),
+      workspaceId,
+      [migration],
+    );
+  }
+}

--- a/packages/twenty-server/src/engine/metadata-modules/relation-metadata/relation-metadata.module.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/relation-metadata/relation-metadata.module.ts
@@ -9,6 +9,7 @@ import { NestjsQueryTypeOrmModule } from '@ptc-org/nestjs-query-typeorm';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { FieldMetadataModule } from 'src/engine/metadata-modules/field-metadata/field-metadata.module';
+import { IndexMetadataModule } from 'src/engine/metadata-modules/index-metadata/index-metadata.module';
 import { ObjectMetadataModule } from 'src/engine/metadata-modules/object-metadata/object-metadata.module';
 import { RelationMetadataGraphqlApiExceptionInterceptor } from 'src/engine/metadata-modules/relation-metadata/interceptors/relation-metadata-graphql-api-exception.interceptor';
 import { RelationMetadataResolver } from 'src/engine/metadata-modules/relation-metadata/relation-metadata.resolver';
@@ -33,6 +34,7 @@ import { RelationMetadataDTO } from './dtos/relation-metadata.dto';
         ),
         ObjectMetadataModule,
         FieldMetadataModule,
+        IndexMetadataModule,
         WorkspaceMigrationRunnerModule,
         WorkspaceMigrationModule,
         WorkspaceCacheStorageModule,


### PR DESCRIPTION
TODO: command to retro-actively create indexes to existing custom objects