### PR TITLE
fix: Cropped company logos on the Companies Kanban

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-board/record-board-card/components/RecordBoardCard.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/record-board-card/components/RecordBoardCard.tsx
@@ -83,7 +83,6 @@ export const StyledBoardCardHeader = styled.div<{
 
   img {
     height: ${({ theme }) => theme.icon.size.md}px;
-    margin-right: ${({ theme }) => theme.spacing(2)};
     object-fit: cover;
     width: ${({ theme }) => theme.icon.size.md}px;
   }


### PR DESCRIPTION
> [!Note]
> This PR addresses the issue #7161 
> Removed margin right which made images crop.

## Before 

<img width="236" alt="Screenshot 2024-09-20 at 1 35 55 AM" src="https://github.com/user-attachments/assets/21e56f6e-2860-4a85-a866-4b619b42b659">


## After

<img width="205" alt="Screenshot 2024-09-20 at 1 35 34 AM" src="https://github.com/user-attachments/assets/8fdc2999-9f26-42e6-bbc5-e339a23db823">
