### PR TITLE
Fixed bug with record without activity target

### DIFF
--- a/packages/twenty-front/src/modules/activities/hooks/useActivities.ts
+++ b/packages/twenty-front/src/modules/activities/hooks/useActivities.ts
@@ -51,13 +51,12 @@ export const useActivities = <T extends Task | Note>({
     ),
   ];
 
+  const skipBecauseNoActivityTargetFound = activityIds.length === 0;
+
   const filter: RecordGqlOperationFilter = {
-    id:
-      targetableObjects.length > 0
-        ? {
-            in: activityIds,
-          }
-        : undefined,
+    id: {
+      in: activityIds,
+    },
     ...activitiesFilters,
   };
 
@@ -69,7 +68,7 @@ export const useActivities = <T extends Task | Note>({
 
   const { records: activities, loading: loadingActivities } =
     useFindManyRecords<Task | Note>({
-      skip: skip || loadingActivityTargets,
+      skip: skip || loadingActivityTargets || skipBecauseNoActivityTargetFound,
       objectNameSingular:
         FIND_ACTIVITIES_OPERATION_SIGNATURE.objectNameSingular,
       recordGqlFields: FIND_ACTIVITIES_OPERATION_SIGNATURE.fields,


### PR DESCRIPTION
Fixed bug that was appearing with records without any activity target

The problem may come from the new TwentyORM that doesn't understand the filter like before. 