### PR TITLE
fix: Tasks with longer body overflows in Timeline summary

### DIFF
--- a/packages/twenty-front/src/modules/activities/timelineActivities/components/EventRow.tsx
+++ b/packages/twenty-front/src/modules/activities/timelineActivities/components/EventRow.tsx
@@ -60,6 +60,7 @@ const StyledSummary = styled.summary`
   flex: 1;
   flex-direction: row;
   gap: ${({ theme }) => theme.spacing(1)};
+  max-width: calc(50% - ${({ theme }) => theme.spacing(12)});
 `;
 
 const StyledItemContainer = styled.div<{ isMarginBottom?: boolean }>`


### PR DESCRIPTION
> [!Note]
>  This PR addresses the issue  #6977 wherein if summary had a long length then it would make the page overflow

## Current behaviour

<img width="1527" alt="Screenshot 2024-09-11 at 1 22 21 PM" src="https://github.com/user-attachments/assets/3ead52f5-e662-4926-8dd4-87afbef423aa">


https://github.com/user-attachments/assets/992c8b7a-04b2-4550-bcab-1f6e9706bf95

## Expected behavior

<img width="1218" alt="Screenshot 2024-09-11 at 1 21 58 PM" src="https://github.com/user-attachments/assets/ac0cb198-7768-44b7-8b59-5b20577d5263">



