### PR TITLE
Fix IN filter with empty array

### DIFF
--- a/packages/twenty-front/src/modules/settings/accounts/components/SettingsAccountsMessageChannelsContainer.tsx
+++ b/packages/twenty-front/src/modules/settings/accounts/components/SettingsAccountsMessageChannelsContainer.tsx
@@ -44,6 +44,7 @@ export const SettingsAccountsMessageChannelsContainer = () => {
         in: accounts.map((account) => account.id),
       },
     },
+    skip: !accounts.length,
   });
 
   const tabs = [

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-filter/graphql-query-filter-field.parser.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-filter/graphql-query-filter-field.parser.ts
@@ -1,4 +1,3 @@
-import { isArray } from 'class-validator';
 import { ObjectLiteral, WhereExpressionBuilder } from 'typeorm';
 
 import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
@@ -49,8 +48,16 @@ export class GraphqlQueryFilterFieldParser {
     }
     const [[operator, value]] = Object.entries(filterValue);
 
-    if (operator === 'in' && (!isArray(value) || value.length === 0)) {
-      return;
+    if (operator === 'in') {
+      if (!Array.isArray(value)) {
+        return;
+      }
+      if (value.length === 0) {
+        throw new GraphqlQueryRunnerException(
+          `Invalid filter value for field ${key}. Expected non-empty array`,
+          GraphqlQueryRunnerExceptionCode.INVALID_QUERY_INPUT,
+        );
+      }
     }
 
     const { sql, params } = this.computeWhereConditionParts(

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-filter/graphql-query-filter-field.parser.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-filter/graphql-query-filter-field.parser.ts
@@ -49,10 +49,7 @@ export class GraphqlQueryFilterFieldParser {
     const [[operator, value]] = Object.entries(filterValue);
 
     if (operator === 'in') {
-      if (!Array.isArray(value)) {
-        return;
-      }
-      if (value.length === 0) {
+      if (!Array.isArray(value) || value.length === 0) {
         throw new GraphqlQueryRunnerException(
           `Invalid filter value for field ${key}. Expected non-empty array`,
           GraphqlQueryRunnerExceptionCode.INVALID_QUERY_INPUT,


### PR DESCRIPTION
## Context
The api currently allows empty array in the IN filter but the expected behaviour is not very clear. Typeorm seems to return all records when it is empty which could lead to undesired result. Instead we decided to throw an error.
I've updated the FE accordingly to skip calls when array is empty.

<img width="696" alt="Screenshot 2024-09-23 at 14 20 28" src="https://github.com/user-attachments/assets/4b641430-ff17-40a6-bbc5-75e9a1d55f50">
