### PR TITLE
Remove shouldUseEmailsField

### DIFF
--- a/packages/twenty-server/src/modules/contact-creation-manager/services/create-company-and-contact.service.ts
+++ b/packages/twenty-server/src/modules/contact-creation-manager/services/create-company-and-contact.service.ts
@@ -143,11 +143,8 @@ export class CreateCompanyAndContactService {
         createdByWorkspaceMember: connectedAccount.accountOwner,
       }));
 
-    const shouldUseEmailsField = isDefined(emailsFieldMetadata);
-
     return this.createContactService.createPeople(
       formattedContactsToCreate,
-      shouldUseEmailsField,
       workspaceId,
       transactionManager,
     );

--- a/packages/twenty-server/src/modules/contact-creation-manager/services/create-contact.service.ts
+++ b/packages/twenty-server/src/modules/contact-creation-manager/services/create-contact.service.ts
@@ -28,7 +28,6 @@ export class CreateContactService {
   private formatContacts(
     contactsToCreate: ContactToCreate[],
     lastPersonPosition: number,
-    shouldUseEmailsField: boolean,
   ): DeepPartial<PersonWorkspaceEntity>[] {
     return contactsToCreate.map((contact) => {
       const id = v4();
@@ -47,9 +46,7 @@ export class CreateContactService {
 
       return {
         id,
-        ...(shouldUseEmailsField
-          ? { emails: { primaryEmail: handle, additionalEmails: null } }
-          : { email: handle }),
+        emails: { primaryEmail: handle, additionalEmails: null },
         name: {
           firstName,
           lastName,
@@ -67,7 +64,6 @@ export class CreateContactService {
 
   public async createPeople(
     contactsToCreate: ContactToCreate[],
-    shouldUseEmailsField: boolean,
     workspaceId: string,
     transactionManager?: EntityManager,
   ): Promise<DeepPartial<PersonWorkspaceEntity>[]> {
@@ -87,7 +83,6 @@ export class CreateContactService {
     const formattedContacts = this.formatContacts(
       contactsToCreate,
       lastPersonPosition,
-      shouldUseEmailsField,
     );
 
     return personRepository.save(


### PR DESCRIPTION
Remove shouldUseEmailsField. This boolean was used to ensure retro-compatibility with the old email field. It is no longer needed.