### PR TITLE
fix: Values field card lacks width in mobile viewports 

### DIFF
--- a/packages/twenty-front/src/modules/settings/data-model/fields/forms/relation/components/SettingsDataModelFieldRelationSettingsFormCard.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/forms/relation/components/SettingsDataModelFieldRelationSettingsFormCard.tsx
@@ -29,11 +29,13 @@ const StyledFieldPreviewCard = styled(SettingsDataModelFieldPreviewCard)`
 
 const StyledPreviewContent = styled.div`
   display: flex;
+  flex-direction: column;
   gap: 6px;
 `;
 
 const StyledRelationImage = styled.img<{ flip?: boolean }>`
-  transform: ${({ flip }) => (flip ? 'scaleX(-1)' : 'none')};
+  transform: ${({ flip }) => (flip ? 'scaleX(-1) rotate(270deg)' : 'none')};
+  margin: auto;
   width: 54px;
 `;
 


### PR DESCRIPTION
## Description

- This PR fixes the issue #7230 

## Current Behaviour
<img width="411" alt="Screenshot 2024-09-24 at 9 51 42 AM" src="https://github.com/user-attachments/assets/65d283b8-24fa-4e25-b3bd-2e35efabf768">

## After

<img width="556" alt="Screenshot 2024-09-25 at 10 38 40 AM" src="https://github.com/user-attachments/assets/97a32497-4230-438f-b048-707bdcd9b674">

<img width="578" alt="Screenshot 2024-09-25 at 10 38 52 AM" src="https://github.com/user-attachments/assets/74e7d055-96fc-4bf4-bddc-e84cf03a6599">
