### PR TITLE
Fix calendar page without account

### DIFF
--- a/packages/twenty-front/src/modules/settings/accounts/components/SettingsAccountsCalendarChannelsContainer.tsx
+++ b/packages/twenty-front/src/modules/settings/accounts/components/SettingsAccountsCalendarChannelsContainer.tsx
@@ -45,6 +45,7 @@ export const SettingsAccountsCalendarChannelsContainer = () => {
         in: accounts.map((account) => account.id),
       },
     },
+    skip: !accounts.length,
   });
 
   const tabs = [


### PR DESCRIPTION
More details in this PR https://github.com/twentyhq/twenty/pull/7202

We(I) forgot to fix on the calendar page.