### PR TITLE
Fixes #7220: Remove primary banner icon when only one value present

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/EmailsFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/EmailsFieldInput.tsx
@@ -29,6 +29,8 @@ export const EmailsFieldInput = ({ onCancel }: EmailsFieldInputProps) => {
     });
   };
 
+  const isPrimaryEmail = (index: number) => index === 0 && emails?.length > 1;
+
   return (
     <MultiItemFieldInput
       items={emails}
@@ -46,7 +48,7 @@ export const EmailsFieldInput = ({ onCancel }: EmailsFieldInputProps) => {
         <EmailsFieldMenuItem
           key={index}
           dropdownId={`${hotkeyScope}-emails-${index}`}
-          isPrimary={index === 0}
+          isPrimary={isPrimaryEmail(index)}
           email={email}
           onEdit={handleEdit}
           onSetAsPrimary={handleSetPrimary}

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/LinksFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/LinksFieldInput.tsx
@@ -42,6 +42,8 @@ export const LinksFieldInput = ({ onCancel }: LinksFieldInputProps) => {
     });
   };
 
+  const isPrimaryLink = (index: number) => index === 0 && links?.length > 1;
+
   return (
     <MultiItemFieldInput
       items={links}
@@ -61,7 +63,7 @@ export const LinksFieldInput = ({ onCancel }: LinksFieldInputProps) => {
         <LinksFieldMenuItem
           key={index}
           dropdownId={`${hotkeyScope}-links-${index}`}
-          isPrimary={index === 0}
+          isPrimary={isPrimaryLink(index)}
           label={link.label}
           onEdit={handleEdit}
           onSetAsPrimary={handleSetPrimary}

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/PhonesFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/PhonesFieldInput.tsx
@@ -78,6 +78,8 @@ export const PhonesFieldInput = ({ onCancel }: PhonesFieldInputProps) => {
     });
   };
 
+  const isPrimaryPhone = (index: number) => index === 0 && phones?.length > 1;
+
   return (
     <MultiItemFieldInput
       items={phones}
@@ -108,7 +110,7 @@ export const PhonesFieldInput = ({ onCancel }: PhonesFieldInputProps) => {
         <PhonesFieldMenuItem
           key={index}
           dropdownId={`${hotkeyScope}-phones-${index}`}
-          isPrimary={index === 0}
+          isPrimary={isPrimaryPhone(index)}
           phone={phone}
           onEdit={handleEdit}
           onSetAsPrimary={handleSetPrimary}


### PR DESCRIPTION
## Changes
- Added a check to make sure that we only indicate an entry is primary if there is more than one value. 

- The banner icon now only displays when there are either **2 or more emails, phone numbers, or domains.**

## Emails
![image](https://github.com/user-attachments/assets/54832aaf-a319-4b70-87bf-3621e05f1637)

![image](https://github.com/user-attachments/assets/44bb8909-9f34-426d-8942-2bb7974e9113)

## Phones
![image](https://github.com/user-attachments/assets/85ca4c36-c148-4d86-89d6-1c02a960f2f4)

![image](https://github.com/user-attachments/assets/f11b5c2e-4376-4bf6-8560-e4c956f2c2e5)

## Domains
![image](https://github.com/user-attachments/assets/ce324714-6bd7-45ac-9a2f-8a2671d080a0)

![image](https://github.com/user-attachments/assets/153883a3-782f-424b-abc4-d882ec969bc2)

## Notes
This is my first time contributing so I am open to any feedback. 