### PR TITLE
Add output to workflow run

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/constants/standard-field-ids.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/constants/standard-field-ids.ts
@@ -415,6 +415,7 @@ export const WORKFLOW_RUN_STANDARD_FIELD_IDS = {
   endedAt: '20202020-e1c1-4b6b-bbbd-b2beaf2e159e',
   status: '20202020-6b3e-4f9c-8c2b-2e5b8e6d6f3b',
   createdBy: '20202020-6007-401a-8aa5-e6f38581a6f3',
+  output: '20202020-7be4-4db2-8ac6-3ff0d740843d',
 };
 
 export const WORKFLOW_VERSION_STANDARD_FIELD_IDS = {

--- a/packages/twenty-server/src/modules/workflow/common/standard-objects/workflow-run.workspace-entity.ts
+++ b/packages/twenty-server/src/modules/workflow/common/standard-objects/workflow-run.workspace-entity.ts
@@ -29,9 +29,12 @@ export enum WorkflowRunStatus {
 
 export type WorkflowRunOutput = {
   steps: {
+    id: string;
+    name: string;
     type: string;
+    attemptCount: number;
     result: object | undefined;
-    error: object | undefined;
+    error: string | undefined;
   }[];
 };
 

--- a/packages/twenty-server/src/modules/workflow/common/standard-objects/workflow-run.workspace-entity.ts
+++ b/packages/twenty-server/src/modules/workflow/common/standard-objects/workflow-run.workspace-entity.ts
@@ -19,6 +19,7 @@ import { WORKFLOW_RUN_STANDARD_FIELD_IDS } from 'src/engine/workspace-manager/wo
 import { STANDARD_OBJECT_IDS } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-object-ids';
 import { WorkflowVersionWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow-version.workspace-entity';
 import { WorkflowWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow.workspace-entity';
+import { WorkflowExecutionOutput } from 'src/modules/workflow/workflow-executor/workspace-services/workflow-executor.workspace-service';
 
 export enum WorkflowRunStatus {
   NOT_STARTED = 'NOT_STARTED',
@@ -107,6 +108,15 @@ export class WorkflowRunWorkspaceEntity extends BaseWorkspaceEntity {
     },
   })
   createdBy: ActorMetadata;
+
+  @WorkspaceField({
+    standardId: WORKFLOW_RUN_STANDARD_FIELD_IDS.output,
+    type: FieldMetadataType.RAW_JSON,
+    label: 'Output',
+    description: 'Json object to provide output of the workflow run',
+  })
+  @WorkspaceIsNullable()
+  output: WorkflowExecutionOutput | null;
 
   // Relations
   @WorkspaceRelation({

--- a/packages/twenty-server/src/modules/workflow/common/standard-objects/workflow-run.workspace-entity.ts
+++ b/packages/twenty-server/src/modules/workflow/common/standard-objects/workflow-run.workspace-entity.ts
@@ -19,7 +19,6 @@ import { WORKFLOW_RUN_STANDARD_FIELD_IDS } from 'src/engine/workspace-manager/wo
 import { STANDARD_OBJECT_IDS } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-object-ids';
 import { WorkflowVersionWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow-version.workspace-entity';
 import { WorkflowWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow.workspace-entity';
-import { WorkflowExecutionOutput } from 'src/modules/workflow/workflow-executor/workspace-services/workflow-executor.workspace-service';
 
 export enum WorkflowRunStatus {
   NOT_STARTED = 'NOT_STARTED',
@@ -27,6 +26,14 @@ export enum WorkflowRunStatus {
   COMPLETED = 'COMPLETED',
   FAILED = 'FAILED',
 }
+
+export type WorkflowRunOutput = {
+  steps: {
+    type: string;
+    result: object | undefined;
+    error: object | undefined;
+  }[];
+};
 
 @WorkspaceEntity({
   standardId: STANDARD_OBJECT_IDS.workflowRun,
@@ -116,7 +123,7 @@ export class WorkflowRunWorkspaceEntity extends BaseWorkspaceEntity {
     description: 'Json object to provide output of the workflow run',
   })
   @WorkspaceIsNullable()
-  output: WorkflowExecutionOutput | null;
+  output: WorkflowRunOutput | null;
 
   // Relations
   @WorkspaceRelation({

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workspace-services/workflow-executor.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workspace-services/workflow-executor.workspace-service.ts
@@ -15,7 +15,7 @@ export type WorkflowExecutorOutput = {
     result: object | undefined;
     error: object | undefined;
   }[];
-  status?: WorkflowRunStatus;
+  status: WorkflowRunStatus;
 };
 
 @Injectable()

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/jobs/run-workflow.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/jobs/run-workflow.job.ts
@@ -36,8 +36,8 @@ export class RunWorkflowJob {
         workflowVersionId,
       );
 
-    try {
-      const output = await this.workflowExecutorWorkspaceService.execute({
+    const { steps, status } =
+      await this.workflowExecutorWorkspaceService.execute({
         currentStepIndex: 0,
         steps: workflowVersion.steps || [],
         payload,
@@ -46,22 +46,12 @@ export class RunWorkflowJob {
         },
       });
 
-      await this.workflowRunWorkspaceService.endWorkflowRun(
-        workflowRunId,
-        WorkflowRunStatus.COMPLETED,
-        output,
-      );
-    } catch (error) {
-      await this.workflowRunWorkspaceService.endWorkflowRun(
-        workflowRunId,
-        WorkflowRunStatus.FAILED,
-        {
-          steps: [],
-          error,
-        },
-      );
-
-      throw error;
-    }
+    await this.workflowRunWorkspaceService.endWorkflowRun(
+      workflowRunId,
+      status || WorkflowRunStatus.FAILED,
+      {
+        steps,
+      },
+    );
   }
 }

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/jobs/run-workflow.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/jobs/run-workflow.job.ts
@@ -3,8 +3,8 @@ import { Scope } from '@nestjs/common';
 import { Process } from 'src/engine/core-modules/message-queue/decorators/process.decorator';
 import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
-import { WorkflowCommonWorkspaceService } from 'src/modules/workflow/common/workspace-services/workflow-common.workspace-service';
 import { WorkflowRunStatus } from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
+import { WorkflowCommonWorkspaceService } from 'src/modules/workflow/common/workspace-services/workflow-common.workspace-service';
 import { WorkflowExecutorWorkspaceService } from 'src/modules/workflow/workflow-executor/workspace-services/workflow-executor.workspace-service';
 import { WorkflowRunWorkspaceService } from 'src/modules/workflow/workflow-runner/workspace-services/workflow-run.workspace-service';
 
@@ -37,20 +37,28 @@ export class RunWorkflowJob {
       );
 
     try {
-      await this.workflowExecutorWorkspaceService.execute({
+      const output = await this.workflowExecutorWorkspaceService.execute({
         currentStepIndex: 0,
         steps: workflowVersion.steps || [],
         payload,
+        output: {
+          steps: [],
+        },
       });
 
       await this.workflowRunWorkspaceService.endWorkflowRun(
         workflowRunId,
         WorkflowRunStatus.COMPLETED,
+        output,
       );
     } catch (error) {
       await this.workflowRunWorkspaceService.endWorkflowRun(
         workflowRunId,
         WorkflowRunStatus.FAILED,
+        {
+          steps: [],
+          error,
+        },
       );
 
       throw error;

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/jobs/run-workflow.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/jobs/run-workflow.job.ts
@@ -43,12 +43,13 @@ export class RunWorkflowJob {
         payload,
         output: {
           steps: [],
+          status: WorkflowRunStatus.RUNNING,
         },
       });
 
     await this.workflowRunWorkspaceService.endWorkflowRun(
       workflowRunId,
-      status || WorkflowRunStatus.FAILED,
+      status,
       {
         steps,
       },

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workspace-services/workflow-run.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workspace-services/workflow-run.workspace-service.ts
@@ -2,11 +2,12 @@ import { Injectable } from '@nestjs/common';
 
 import { ActorMetadata } from 'src/engine/metadata-modules/field-metadata/composite-types/actor.composite-type';
 import { TwentyORMManager } from 'src/engine/twenty-orm/twenty-orm.manager';
-import { WorkflowCommonWorkspaceService } from 'src/modules/workflow/common/workspace-services/workflow-common.workspace-service';
 import {
   WorkflowRunStatus,
   WorkflowRunWorkspaceEntity,
 } from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
+import { WorkflowCommonWorkspaceService } from 'src/modules/workflow/common/workspace-services/workflow-common.workspace-service';
+import { WorkflowExecutionOutput } from 'src/modules/workflow/workflow-executor/workspace-services/workflow-executor.workspace-service';
 import {
   WorkflowRunException,
   WorkflowRunExceptionCode,
@@ -70,7 +71,11 @@ export class WorkflowRunWorkspaceService {
     });
   }
 
-  async endWorkflowRun(workflowRunId: string, status: WorkflowRunStatus) {
+  async endWorkflowRun(
+    workflowRunId: string,
+    status: WorkflowRunStatus,
+    output: WorkflowExecutionOutput,
+  ) {
     const workflowRunRepository =
       await this.twentyORMManager.getRepository<WorkflowRunWorkspaceEntity>(
         'workflowRun',
@@ -96,6 +101,7 @@ export class WorkflowRunWorkspaceService {
 
     return workflowRunRepository.update(workflowRunToUpdate.id, {
       status,
+      output,
       endedAt: new Date().toISOString(),
     });
   }

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workspace-services/workflow-run.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workspace-services/workflow-run.workspace-service.ts
@@ -3,11 +3,11 @@ import { Injectable } from '@nestjs/common';
 import { ActorMetadata } from 'src/engine/metadata-modules/field-metadata/composite-types/actor.composite-type';
 import { TwentyORMManager } from 'src/engine/twenty-orm/twenty-orm.manager';
 import {
+  WorkflowRunOutput,
   WorkflowRunStatus,
   WorkflowRunWorkspaceEntity,
 } from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
 import { WorkflowCommonWorkspaceService } from 'src/modules/workflow/common/workspace-services/workflow-common.workspace-service';
-import { WorkflowExecutionOutput } from 'src/modules/workflow/workflow-executor/workspace-services/workflow-executor.workspace-service';
 import {
   WorkflowRunException,
   WorkflowRunExceptionCode,
@@ -74,7 +74,7 @@ export class WorkflowRunWorkspaceService {
   async endWorkflowRun(
     workflowRunId: string,
     status: WorkflowRunStatus,
-    output: WorkflowExecutionOutput,
+    output: WorkflowRunOutput,
   ) {
     const workflowRunRepository =
       await this.twentyORMManager.getRepository<WorkflowRunWorkspaceEntity>(


### PR DESCRIPTION
Example of output stored for following workflow:

<img width="244" alt="Capture d’écran 2024-09-27 à 11 18 06" src="https://github.com/user-attachments/assets/722bfa96-2dd1-41f7-ab87-d39584ac9efc">

Output:

```
{"steps": [
  {"type": "CODE", "result": {"email": "test@twenty.com"}}, 
  {"type": "SEND_EMAIL", "result": {"success": true}}
]}
```