### PR TITLE
docs: enhance localhost documentation with REST API URL

### DIFF
--- a/packages/twenty-website/src/content/developers/local-setup.mdx
+++ b/packages/twenty-website/src/content/developers/local-setup.mdx
@@ -186,8 +186,9 @@ Alternatively, you can start both applications at once:
 npx nx start
 ```
 
-Twenty's server will be up and running at [http://localhost:3000/graphql](http://localhost:3000/graphql).
-Twenty's frontend will be running at [http://localhost:3001](http://localhost:3001). Just login using the seeded demo account: `tim@apple.dev` (password: `Applecar2025`) to start using Twenty.
+Twenty's server will be up and running at [http://localhost:3000](http://localhost:3000). The GraphQL API can be accessed at [http://localhost:3000/graphql](http://localhost:3000/graphql), and the REST API can be reached at [http://localhost:3000/rest](http://localhost:3000/rest).
+
+Twenty's frontend will be running at [http://localhost:3001](http://localhost:3001). Just log in using the seeded demo account: `tim@apple.dev` (password: `Applecar2025`) to start using Twenty.
 
 
 ## Troubleshooting


### PR DESCRIPTION
- Add callout for local REST API URL alongside the GraphQL API URL.
- This change aims to reduce confusion and complexity for the self-hosted community.

**Associated Issue - "(Docs) Enhance local hosting docs with reference to the REST API URL as well as the Graphql API URL [#7316]"**