### PR TITLE
Fix icon resizing issue for Notes and Tasks

### DIFF
--- a/packages/twenty-ui/src/display/chip/components/Chip.tsx
+++ b/packages/twenty-ui/src/display/chip/components/Chip.tsx
@@ -111,6 +111,10 @@ const StyledContainer = withTheme(styled.div<
 
   border-radius: ${({ theme, variant }) =>
     variant === ChipVariant.Rounded ? '50px' : theme.border.radius.sm};
+
+  & > svg {
+    flex-shrink: 0;
+  }
 `);
 
 export const Chip = ({


### PR DESCRIPTION
This pull request addresses a [resizing issue with the Notes and Tasks icons](https://github.com/twentyhq/twenty/issues/7282). Previously, the icons would change size based on the length of the title or when the column width was adjusted, leading to inconsistent UI behavior. This update ensures that the icons maintain a stable size, enhancing the overall user experience.

Solves Issue : #7282

[twenty-icon-sizing-issue.webm](https://github.com/user-attachments/assets/3ef59592-4dfb-463e-bc7b-a803ee105211)
