### PR TITLE
Tag main as 0.31 canary

### DIFF
--- a/packages/twenty-emails/package.json
+++ b/packages/twenty-emails/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty-emails",
-  "version": "0.30.0",
+  "version": "0.31.canary",
   "description": "",
   "author": "",
   "private": true,

--- a/packages/twenty-front/package.json
+++ b/packages/twenty-front/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty-front",
-  "version": "0.30.0",
+  "version": "0.31.canary",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/twenty-server/package.json
+++ b/packages/twenty-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty-server",
-  "version": "0.30.0",
+  "version": "0.31.canary",
   "description": "",
   "author": "",
   "private": true,

--- a/packages/twenty-ui/package.json
+++ b/packages/twenty-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty-ui",
-  "version": "0.30.0",
+  "version": "0.31.canary",
   "type": "module",
   "main": "./src/index.ts",
   "exports": {

--- a/packages/twenty-website/package.json
+++ b/packages/twenty-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty-website",
-  "version": "0.30.0",
+  "version": "0.31.canary",
   "private": true,
   "scripts": {
     "nx": "NX_DEFAULT_PROJECT=twenty-website node ../../node_modules/nx/bin/nx.js",


### PR DESCRIPTION
We are updating our git worklow.

Case 1: **URGENT / PATCH**
If you want to include something URGENT that cannot wait for the next release, you'll need to:
- create a PR from the latest patch (right now v0.30.1)
- create a new patch tag from this PR (would be v0.30.2 right now)
- merge this PR in main so it's in 0.31 too

Case 2: **REGULAR**
- Open a PR from main and merge it into main

I'm tagging main as v0.31.canary to make it clear!