### PR TITLE
fix state management doc link in frontend-commands.mdx

### DIFF
--- a/packages/twenty-website/src/content/developers/frontend-development/frontend-commands.mdx
+++ b/packages/twenty-website/src/content/developers/frontend-development/frontend-commands.mdx
@@ -68,7 +68,7 @@ To avoid unnecessary [re-renders](/contributor/frontend/best-practices#managing-
 
 [Recoil](https://recoiljs.org/docs/introduction/core-concepts) handles state management.
 
-See [best practices](/contributor/frontend/best-practices#state-management) for more information on state management.
+See [best practices](/developers/section/frontend-development/best-practices-front#state-management) for more information on state management.
 
 ## Testing
 


### PR DESCRIPTION
- found dead (assuming old) link in docs