### PR TITLE
fix: removing MANY_TO_MANY option from relation type until implemented

### DIFF
--- a/packages/twenty-front/src/modules/settings/data-model/fields/forms/relation/components/SettingsDataModelFieldRelationForm.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/forms/relation/components/SettingsDataModelFieldRelationForm.tsx
@@ -66,7 +66,8 @@ const StyledInputsContainer = styled.div`
 `;
 
 const RELATION_TYPE_OPTIONS = Object.entries(RELATION_TYPES)
-  .filter(([value]) => 'ONE_TO_ONE' !== value)
+  .filter(([key]) => key !== RelationDefinitionType.ManyToMany) // Not supported yet
+  .filter(([key]) => key !== RelationDefinitionType.OneToOne)
   .map(([value, { label, Icon }]) => ({
     label,
     value: value as RelationType,


### PR DESCRIPTION
Fix: #7359 

Simple temporary fix

<img width="589" alt="image" src="https://github.com/user-attachments/assets/a45e2ed6-e7db-462c-b066-b290bf905bf6">
