### PR TITLE
fix: Long File name is not optimised for mobile viewports 

### DIFF
--- a/packages/twenty-front/src/modules/activities/files/components/AttachmentRow.tsx
+++ b/packages/twenty-front/src/modules/activities/files/components/AttachmentRow.tsx
@@ -35,7 +35,7 @@ const StyledLeftContent = styled.div<{ isMobile: boolean }>`
   gap: ${({ theme }) => theme.spacing(2)};
   width: 80%;
   overflow: scroll;
-  scroll-behavior: smooth;
+  -webkit-overflow-scrolling: touch;
   scroll-snap-align: start;
   white-space: pre;
 `;

--- a/packages/twenty-front/src/modules/activities/files/components/AttachmentRow.tsx
+++ b/packages/twenty-front/src/modules/activities/files/components/AttachmentRow.tsx
@@ -14,7 +14,7 @@ import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useMemo, useState } from 'react';
 import { IconCalendar } from 'twenty-ui';
-
+import { useIsMobile } from '@/ui/utilities/responsive/hooks/useIsMobile';
 import { formatToHumanReadableDate } from '~/utils/date-utils';
 import { getFileAbsoluteURI } from '~/utils/file/getFileAbsoluteURI';
 
@@ -29,16 +29,27 @@ const StyledRow = styled.div`
   height: 32px;
 `;
 
-const StyledLeftContent = styled.div`
+const StyledLeftContent = styled.div<{ isMobile: boolean }>`
   align-items: center;
   display: flex;
-  gap: ${({ theme }) => theme.spacing(3)};
+  gap: ${({ theme }) => theme.spacing(2)};
+  width: 80%;
+  overflow: scroll;
+  scroll-behavior: smooth;
+  scroll-snap-align: start;
+  white-space: pre;
 `;
 
 const StyledRightContent = styled.div`
   align-items: center;
   display: flex;
   gap: ${({ theme }) => theme.spacing(0.5)};
+  padding: ${({ theme }) => theme.spacing(0.6)};
+  white-space: pre;
+`;
+
+const StyledAttachment = styled.div<{ isMobile: boolean }>`
+  padding-right: ${({ theme }) => theme.spacing(2)};
 `;
 
 const StyledCalendarIconContainer = styled.div`
@@ -61,7 +72,7 @@ export const AttachmentRow = ({ attachment }: { attachment: Attachment }) => {
   const theme = useTheme();
   const [isEditing, setIsEditing] = useState(false);
   const [attachmentName, setAttachmentName] = useState(attachment.name);
-
+  const isMobile = useIsMobile();
   const fieldContext = useMemo(
     () => ({ recoilScopeId: attachment?.id ?? '' }),
     [attachment?.id],
@@ -98,8 +109,18 @@ export const AttachmentRow = ({ attachment }: { attachment: Attachment }) => {
   return (
     <FieldContext.Provider value={fieldContext as GenericFieldContextType}>
       <StyledRow>
-        <StyledLeftContent>
-          <AttachmentIcon attachmentType={attachment.type} />
+        {isMobile && (
+          <StyledAttachment isMobile={isMobile}>
+            <AttachmentIcon attachmentType={attachment.type} />
+          </StyledAttachment>
+        )}
+
+        <StyledLeftContent isMobile={isMobile}>
+          {!isMobile && (
+            <StyledAttachment isMobile={isMobile}>
+              <AttachmentIcon attachmentType={attachment.type} />
+            </StyledAttachment>
+          )}
           {isEditing ? (
             <TextInput
               value={attachmentName}


### PR DESCRIPTION
## Description

- this PR solves the issue #7330 


## Current behaviour

<img width="435" alt="Screenshot 2024-09-30 at 1 26 25 PM" src="https://github.com/user-attachments/assets/2d418b38-abec-4103-8e54-a9d0b2a07abf">

<img width="361" alt="Screenshot 2024-09-30 at 1 26 43 PM" src="https://github.com/user-attachments/assets/812aadd6-4457-4828-916e-c5610b8c06e6">

## After changes Behaviour

https://github.com/user-attachments/assets/1d6af080-6e92-4e18-9081-35bdd101a3bf



