### PR TITLE
fix: replace defaultProps with default parameters in SpreadsheetImport

### DIFF
--- a/packages/twenty-front/src/modules/spreadsheet-import/provider/components/SpreadsheetImport.tsx
+++ b/packages/twenty-front/src/modules/spreadsheet-import/provider/components/SpreadsheetImport.tsx
@@ -24,13 +24,16 @@ export const defaultSpreadsheetImportProps: Partial<
 export const SpreadsheetImport = <T extends string>(
   props: SpreadsheetImportProps<T>,
 ) => {
+  const mergedProps = {
+    ...defaultSpreadsheetImportProps,
+    ...props,
+  } as SpreadsheetImportProps<T>;
+
   return (
-    <ReactSpreadsheetImportContextProvider values={props}>
-      <ModalWrapper isOpen={props.isOpen} onClose={props.onClose}>
+    <ReactSpreadsheetImportContextProvider values={mergedProps}>
+      <ModalWrapper isOpen={mergedProps.isOpen} onClose={mergedProps.onClose}>
         <SpreadsheetImportStepperContainer />
       </ModalWrapper>
     </ReactSpreadsheetImportContextProvider>
   );
 };
-
-SpreadsheetImport.defaultProps = defaultSpreadsheetImportProps;


### PR DESCRIPTION
This PR addresses https://github.com/twentyhq/twenty/issues/6827

React has deprecated the use of `defaultProps` on function components and will remove support in a future major release. This commit replaces the usage of `defaultProps` in the `SpreadsheetImport` component with default parameters to fix the following warning:

**Changes:**

- Removed `SpreadsheetImport.defaultProps = defaultSpreadsheetImportProps;`
- Merged `defaultSpreadsheetImportProps` with incoming `props` using object spread syntax.
- Adjusted the component to use the merged props (`mergedProps`) instead of `props`.