### PR TITLE
Adding redis server instruction in local setup docs

### DIFF
--- a/packages/twenty-website/src/content/developers/local-setup.mdx
+++ b/packages/twenty-website/src/content/developers/local-setup.mdx
@@ -151,6 +151,11 @@ Twenty requires a redis cache to provide the best performances
     To provision your database locally with `brew`:
     ```bash
     brew install redis
+    brew install redis-server
+    ```
+    To start the redis server, run:
+    ```bash
+    redis-server &
     ```
   </ArticleTab>
   <ArticleTab>


### PR DESCRIPTION
Ran into a small hiccup up while trying to run on local after redis was introduced.
Docs don't mention needing to start a redis-server.