### PR TITLE
Fix restApi should not use TS_VECTOR fields as mutation inputs

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/open-api/utils/components.utils.ts
+++ b/packages/twenty-server/src/engine/core-modules/open-api/utils/components.utils.ts
@@ -109,7 +109,8 @@ const getSchemaComponentsProperties = ({
   return item.fields.reduce((node, field) => {
     if (
       !isFieldAvailable(field, forResponse) ||
-      field.type === FieldMetadataType.RELATION
+      field.type === FieldMetadataType.RELATION ||
+      field.type === FieldMetadataType.TS_VECTOR
     ) {
       return node;
     }


### PR DESCRIPTION
## Context
<img width="398" alt="Screenshot 2024-10-08 at 11 10 59" src="https://github.com/user-attachments/assets/03ee0305-527c-42ed-a8a1-0ccea8176357">
<img width="489" alt="Screenshot 2024-10-08 at 11 10 50" src="https://github.com/user-attachments/assets/1403876b-40b6-490e-8557-d8280c439d57">

Tested with https://twenty.com/developers/rest-api/core#/operations/createOnePerson