### PR TITLE
Fix-6581:Removed isCustom from input Field types

### DIFF
--- a/packages/twenty-front/src/generated-metadata/graphql.ts
+++ b/packages/twenty-front/src/generated-metadata/graphql.ts
@@ -176,7 +176,6 @@ export type CreateFieldInput = {
   description?: InputMaybe<Scalars['String']['input']>;
   icon?: InputMaybe<Scalars['String']['input']>;
   isActive?: InputMaybe<Scalars['Boolean']['input']>;
-  isCustom?: InputMaybe<Scalars['Boolean']['input']>;
   isNullable?: InputMaybe<Scalars['Boolean']['input']>;
   isRemoteCreation?: InputMaybe<Scalars['Boolean']['input']>;
   isSystem?: InputMaybe<Scalars['Boolean']['input']>;
@@ -1276,7 +1275,6 @@ export type UpdateFieldInput = {
   description?: InputMaybe<Scalars['String']['input']>;
   icon?: InputMaybe<Scalars['String']['input']>;
   isActive?: InputMaybe<Scalars['Boolean']['input']>;
-  isCustom?: InputMaybe<Scalars['Boolean']['input']>;
   isNullable?: InputMaybe<Scalars['Boolean']['input']>;
   isSystem?: InputMaybe<Scalars['Boolean']['input']>;
   label?: InputMaybe<Scalars['String']['input']>;

--- a/packages/twenty-front/src/modules/object-metadata/graphql/mutations.ts
+++ b/packages/twenty-front/src/modules/object-metadata/graphql/mutations.ts
@@ -11,7 +11,6 @@ export const CREATE_ONE_OBJECT_METADATA_ITEM = gql`
       labelPlural
       description
       icon
-      isCustom
       isActive
       createdAt
       updatedAt
@@ -69,7 +68,6 @@ export const UPDATE_ONE_FIELD_METADATA_ITEM = gql`
       label
       description
       icon
-      isCustom
       isActive
       isNullable
       createdAt

--- a/packages/twenty-front/src/modules/object-metadata/hooks/useCreateOneFieldMetadataItem.ts
+++ b/packages/twenty-front/src/modules/object-metadata/hooks/useCreateOneFieldMetadataItem.ts
@@ -26,7 +26,10 @@ export const useCreateOneFieldMetadataItem = () => {
     return await mutate({
       variables: {
         input: {
-          field: input,
+          field: {
+            ...input,
+            isCustom:true
+          },
         },
       },
       awaitRefetchQueries: true,

--- a/packages/twenty-front/src/modules/object-metadata/hooks/useUpdateOneFieldMetadataItem.ts
+++ b/packages/twenty-front/src/modules/object-metadata/hooks/useUpdateOneFieldMetadataItem.ts
@@ -42,6 +42,7 @@ export const useUpdateOneFieldMetadataItem = () => {
         idToUpdate: fieldMetadataIdToUpdate,
         updatePayload: {
           ...updatePayload,
+          isCustom:false,
           label: updatePayload.label ?? undefined,
         },
       },


### PR DESCRIPTION
Removed  isCustom from graphql input field type,.
Set isCustom to true when creating a field and false when updating.