### PR TITLE
Fix ci storybook:build command

### DIFF
--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Front / Write .env
         run: npx nx reset:env twenty-front
       - name: Front / Build storybook
-        run: npx nx storybook:build twenty-front
+        run: node --max-old-space-size=4096 npx nx storybook:build twenty-front
   front-sb-test:
     runs-on: ci-8-cores
     needs: front-sb-build

--- a/packages/twenty-front/src/modules/workflow/components/WorkflowEditActionFormSendEmail.tsx
+++ b/packages/twenty-front/src/modules/workflow/components/WorkflowEditActionFormSendEmail.tsx
@@ -94,6 +94,7 @@ export const WorkflowEditActionFormSendEmail = (
       if (props.readonly === true) {
         return;
       }
+
       props.onActionUpdate({
         ...props.action,
         settings: {
@@ -103,6 +104,7 @@ export const WorkflowEditActionFormSendEmail = (
           body: formData.body,
         },
       });
+
       if (checkScopes === true) {
         await checkConnectedAccountScopes(formData.connectedAccountId);
       }


### PR DESCRIPTION
Increases the node process memory to avoid `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory` errors