### PR TITLE
Fix Storybook Build running out of memory

### DIFF
--- a/packages/twenty-front/project.json
+++ b/packages/twenty-front/project.json
@@ -67,7 +67,7 @@
     "test": {},
     "storybook:build": {
       "options": {
-        "env": { "NODE_OPTIONS": "--max_old_space_size=6000" }
+        "env": { "NODE_OPTIONS": "--max_old_space_size=8000" }
       }
     },
     "storybook:serve:dev": {

--- a/packages/twenty-front/project.json
+++ b/packages/twenty-front/project.json
@@ -67,7 +67,7 @@
     "test": {},
     "storybook:build": {
       "options": {
-        "env": { "NODE_OPTIONS": "--max_old_space_size=8000" }
+        "env": { "NODE_OPTIONS": "--max_old_space_size=6500" }
       }
     },
     "storybook:serve:dev": {

--- a/packages/twenty-front/src/modules/workflow/components/WorkflowEditActionFormSendEmail.tsx
+++ b/packages/twenty-front/src/modules/workflow/components/WorkflowEditActionFormSendEmail.tsx
@@ -94,6 +94,7 @@ export const WorkflowEditActionFormSendEmail = (
       if (props.readonly === true) {
         return;
       }
+
       props.onActionUpdate({
         ...props.action,
         settings: {
@@ -103,6 +104,7 @@ export const WorkflowEditActionFormSendEmail = (
           body: formData.body,
         },
       });
+
       if (checkScopes === true) {
         await checkConnectedAccountScopes(formData.connectedAccountId);
       }


### PR DESCRIPTION
Increases the node process memory to avoid `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory` errors