### PR TITLE
fix: DataModel page not optimised for mobile viewport

### DIFF
--- a/packages/twenty-front/src/modules/settings/data-model/object-details/components/SettingsObjectFieldItemTableRow.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/object-details/components/SettingsObjectFieldItemTableRow.tsx
@@ -1,7 +1,13 @@
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useMemo } from 'react';
-import { IconMinus, IconPlus, isDefined, useIcons } from 'twenty-ui';
+import {
+  IconMinus,
+  IconPlus,
+  isDefined,
+  useIcons,
+  MOBILE_VIEWPORT,
+} from 'twenty-ui';
 
 import { useGetRelationMetadata } from '@/object-metadata/hooks/useGetRelationMetadata';
 import { FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
@@ -41,6 +47,14 @@ type SettingsObjectFieldItemTableRowProps = {
 
 export const StyledObjectFieldTableRow = styled(TableRow)`
   grid-template-columns: 180px 148px 148px 36px;
+
+  @media (max-width: ${MOBILE_VIEWPORT}px) {
+    grid-template-columns: 120px 90px 100px 16px;
+  }
+
+  @media (min-width: 360px) and (max-width: 390px) {
+    grid-template-columns: 100px 86px 89px 9px;
+  }
 `;
 
 const StyledNameTableCell = styled(TableCell)`


### PR DESCRIPTION
## Description
- this PR solves the issue #7490
- Optimised fields table for all mobile viewports

- [x] Optimised Fields table
- [ ] Optmise Objects table 

## Current behaviour

https://github.com/user-attachments/assets/208e984e-692c-4e54-b5a5-bee59ddfd9cc



<img width="400" alt="Screenshot 2024-10-09 at 4 44 14 PM" src="https://github.com/user-attachments/assets/40e4c3d5-1dec-434d-8b03-ccfae79235e3">

@Bonapara, for Objects table should we align content with start of header to in middle ? As for example, In type items are aligned to start, in fields it is to end and in Instances it is start. If we aligned start for all then we will have a lot of space for left for chevron right icon which will not match the design as you can in Instances.