### PR TITLE
Revert optimistic rendering on negative response

### DIFF
--- a/packages/twenty-front/src/modules/object-record/hooks/useCreateManyRecords.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useCreateManyRecords.ts
@@ -127,7 +127,7 @@ export const useCreateManyRecords = <
             objectMetadataItems,
             objectMetadataItem,
             cache: apolloClient.cache,
-            recordToDelete: recordToDelete,
+            recordToDelete,
           });
         });
 

--- a/packages/twenty-front/src/modules/object-record/hooks/useCreateManyRecords.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useCreateManyRecords.ts
@@ -2,9 +2,11 @@ import { useApolloClient } from '@apollo/client';
 import { v4 } from 'uuid';
 
 import { triggerCreateRecordsOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerCreateRecordsOptimisticEffect';
+import { triggerDeleteRecordsOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerDeleteRecordsOptimisticEffect';
 import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
 import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
 import { useCreateOneRecordInCache } from '@/object-record/cache/hooks/useCreateOneRecordInCache';
+import { deleteRecordFromCache } from '@/object-record/cache/utils/deleteRecordFromCache';
 import { getObjectTypename } from '@/object-record/cache/utils/getObjectTypename';
 import { RecordGqlOperationGqlRecordFields } from '@/object-record/graphql/types/RecordGqlOperationGqlRecordFields';
 import { generateDepthOneRecordGqlFields } from '@/object-record/graphql/utils/generateDepthOneRecordGqlFields';
@@ -67,7 +69,7 @@ export const useCreateManyRecords = <
       },
     );
 
-    const recordsCreatedInCache = [];
+    const recordsCreatedInCache: ObjectRecord[] = [];
 
     for (const recordToCreate of sanitizedCreateManyRecordsInput) {
       if (recordToCreate.id === null) {
@@ -98,26 +100,46 @@ export const useCreateManyRecords = <
       objectMetadataItem.namePlural,
     );
 
-    const createdObjects = await apolloClient.mutate({
-      mutation: createManyRecordsMutation,
-      variables: {
-        data: sanitizedCreateManyRecordsInput,
-        upsert: upsert,
-      },
-      update: (cache, { data }) => {
-        const records = data?.[mutationResponseField];
+    const createdObjects = await apolloClient
+      .mutate({
+        mutation: createManyRecordsMutation,
+        variables: {
+          data: sanitizedCreateManyRecordsInput,
+          upsert: upsert,
+        },
+        update: (cache, { data }) => {
+          const records = data?.[mutationResponseField];
 
-        if (!records?.length || skipPostOptmisticEffect) return;
+          if (!records?.length || skipPostOptmisticEffect) return;
 
-        triggerCreateRecordsOptimisticEffect({
-          cache,
-          objectMetadataItem,
-          recordsToCreate: records,
-          objectMetadataItems,
-          shouldMatchRootQueryFilter,
+          triggerCreateRecordsOptimisticEffect({
+            cache,
+            objectMetadataItem,
+            recordsToCreate: records,
+            objectMetadataItems,
+            shouldMatchRootQueryFilter,
+          });
+        },
+      })
+      .catch((error: Error) => {
+        recordsCreatedInCache.forEach((recordToDelete) => {
+          deleteRecordFromCache({
+            objectMetadataItems,
+            objectMetadataItem,
+            cache: apolloClient.cache,
+            recordToDelete: recordToDelete,
+          });
         });
-      },
-    });
+
+        triggerDeleteRecordsOptimisticEffect({
+          cache: apolloClient.cache,
+          objectMetadataItem,
+          recordsToDelete: recordsCreatedInCache,
+          objectMetadataItems,
+        });
+
+        throw error;
+      });
 
     return createdObjects.data?.[mutationResponseField] ?? [];
   };

--- a/packages/twenty-front/src/modules/object-record/hooks/useDeleteOneRecord.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useDeleteOneRecord.ts
@@ -1,10 +1,12 @@
 import { useApolloClient } from '@apollo/client';
 import { useCallback } from 'react';
 
+import { triggerCreateRecordsOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerCreateRecordsOptimisticEffect';
 import { triggerDeleteRecordsOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerDeleteRecordsOptimisticEffect';
 import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
 import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
 import { useGetRecordFromCache } from '@/object-record/cache/hooks/useGetRecordFromCache';
+import { updateRecordFromCache } from '@/object-record/cache/utils/updateRecordFromCache';
 import { useDeleteOneRecordMutation } from '@/object-record/hooks/useDeleteOneRecordMutation';
 import { getDeleteOneRecordMutationResponseField } from '@/object-record/utils/getDeleteOneRecordMutationResponseField';
 import { capitalize } from '~/utils/string/capitalize';
@@ -39,35 +41,70 @@ export const useDeleteOneRecord = ({
     async (idToDelete: string) => {
       const currentTimestamp = new Date().toISOString();
 
-      const deletedRecord = await apolloClient.mutate({
-        mutation: deleteOneRecordMutation,
-        variables: {
-          idToDelete: idToDelete,
-        },
-        optimisticResponse: {
-          [mutationResponseField]: {
-            __typename: capitalize(objectNameSingular),
-            id: idToDelete,
-            deletedAt: currentTimestamp,
+      const deletedRecord = await apolloClient
+        .mutate({
+          mutation: deleteOneRecordMutation,
+          variables: {
+            idToDelete: idToDelete,
           },
-        },
-        update: (cache, { data }) => {
-          const record = data?.[mutationResponseField];
+          optimisticResponse: {
+            [mutationResponseField]: {
+              __typename: capitalize(objectNameSingular),
+              id: idToDelete,
+              deletedAt: currentTimestamp,
+            },
+          },
+          update: (cache, { data }) => {
+            const record = data?.[mutationResponseField];
 
-          if (!record) return;
+            if (!record) return;
 
-          const cachedRecord = getRecordFromCache(record.id, cache);
+            const cachedRecord = getRecordFromCache(record.id, cache);
 
-          if (!cachedRecord) return;
+            if (!cachedRecord) return;
 
-          triggerDeleteRecordsOptimisticEffect({
-            cache,
-            objectMetadataItem,
-            recordsToDelete: [cachedRecord],
+            triggerDeleteRecordsOptimisticEffect({
+              cache,
+              objectMetadataItem,
+              recordsToDelete: [cachedRecord],
+              objectMetadataItems,
+            });
+          },
+        })
+        .catch((error: Error) => {
+          const cachedRecord = getRecordFromCache(
+            idToDelete,
+            apolloClient.cache,
+          );
+
+          if (!cachedRecord) {
+            throw error;
+          }
+
+          updateRecordFromCache({
             objectMetadataItems,
+            objectMetadataItem,
+            cache: apolloClient.cache,
+            record: {
+              ...cachedRecord,
+              deletedAt: null,
+            },
           });
-        },
-      });
+
+          triggerCreateRecordsOptimisticEffect({
+            cache: apolloClient.cache,
+            objectMetadataItem,
+            objectMetadataItems,
+            recordsToCreate: [
+              {
+                ...cachedRecord,
+                deletedAt: null,
+              },
+            ],
+          });
+
+          throw error;
+        });
 
       return deletedRecord.data?.[mutationResponseField] ?? null;
     },

--- a/packages/twenty-front/src/modules/object-record/hooks/useDestroyOneRecord.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useDestroyOneRecord.ts
@@ -39,10 +39,13 @@ export const useDestroyOneRecord = ({
   const mutationResponseField =
     getDestroyOneRecordMutationResponseField(objectNameSingular);
 
-  let cachedRecord: ObjectRecord;
-
   const destroyOneRecord = useCallback(
     async (idToDestroy: string) => {
+      const originalRecord: ObjectRecord | null = getRecordFromCache(
+        idToDestroy,
+        apolloClient.cache,
+      );
+
       const deletedRecord = await apolloClient
         .mutate({
           mutation: destroyOneRecordMutation,
@@ -71,11 +74,11 @@ export const useDestroyOneRecord = ({
           },
         })
         .catch((error: Error) => {
-          if (!isUndefinedOrNull(cachedRecord)) {
+          if (!isUndefinedOrNull(originalRecord)) {
             triggerCreateRecordsOptimisticEffect({
               cache: apolloClient.cache,
               objectMetadataItem,
-              recordsToCreate: [cachedRecord],
+              recordsToCreate: [originalRecord],
               objectMetadataItems,
             });
           }

--- a/packages/twenty-front/src/modules/object-record/hooks/useDestroyOneRecord.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useDestroyOneRecord.ts
@@ -1,12 +1,15 @@
 import { useApolloClient } from '@apollo/client';
 import { useCallback } from 'react';
 
+import { triggerCreateRecordsOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerCreateRecordsOptimisticEffect';
 import { triggerDeleteRecordsOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerDeleteRecordsOptimisticEffect';
 import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
 import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
 import { useGetRecordFromCache } from '@/object-record/cache/hooks/useGetRecordFromCache';
 import { useDestroyOneRecordMutation } from '@/object-record/hooks/useDestroyOneRecordMutation';
+import { ObjectRecord } from '@/object-record/types/ObjectRecord';
 import { getDestroyOneRecordMutationResponseField } from '@/object-record/utils/getDestroyOneRecordMutationResponseField';
+import { isUndefinedOrNull } from '~/utils/isUndefinedOrNull';
 import { capitalize } from '~/utils/string/capitalize';
 
 type useDestroyOneRecordProps = {
@@ -36,34 +39,48 @@ export const useDestroyOneRecord = ({
   const mutationResponseField =
     getDestroyOneRecordMutationResponseField(objectNameSingular);
 
+  let cachedRecord: ObjectRecord;
+
   const destroyOneRecord = useCallback(
     async (idToDestroy: string) => {
-      const deletedRecord = await apolloClient.mutate({
-        mutation: destroyOneRecordMutation,
-        variables: { idToDestroy },
-        optimisticResponse: {
-          [mutationResponseField]: {
-            __typename: capitalize(objectNameSingular),
-            id: idToDestroy,
+      const deletedRecord = await apolloClient
+        .mutate({
+          mutation: destroyOneRecordMutation,
+          variables: { idToDestroy },
+          optimisticResponse: {
+            [mutationResponseField]: {
+              __typename: capitalize(objectNameSingular),
+              id: idToDestroy,
+            },
           },
-        },
-        update: (cache, { data }) => {
-          const record = data?.[mutationResponseField];
+          update: (cache, { data }) => {
+            const record = data?.[mutationResponseField];
 
-          if (!record) return;
+            if (!record) return;
 
-          const cachedRecord = getRecordFromCache(record.id, cache);
+            const cachedRecord = getRecordFromCache(record.id, cache);
 
-          if (!cachedRecord) return;
+            if (!cachedRecord) return;
 
-          triggerDeleteRecordsOptimisticEffect({
-            cache,
-            objectMetadataItem,
-            recordsToDelete: [cachedRecord],
-            objectMetadataItems,
-          });
-        },
-      });
+            triggerDeleteRecordsOptimisticEffect({
+              cache,
+              objectMetadataItem,
+              recordsToDelete: [cachedRecord],
+              objectMetadataItems,
+            });
+          },
+        })
+        .catch((error: Error) => {
+          if (!isUndefinedOrNull(cachedRecord)) {
+            triggerCreateRecordsOptimisticEffect({
+              cache: apolloClient.cache,
+              objectMetadataItem,
+              recordsToCreate: [cachedRecord],
+              objectMetadataItems,
+            });
+          }
+          throw error;
+        });
 
       return deletedRecord.data?.[mutationResponseField] ?? null;
     },

--- a/packages/twenty-front/src/modules/object-record/hooks/useRestoreManyRecords.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useRestoreManyRecords.ts
@@ -62,22 +62,27 @@ export const useRestoreManyRecords = ({
         objectMetadataItem.namePlural,
       )}`;
 
-      const restoredRecordsResponse = await apolloClient.mutate({
-        mutation: restoreManyRecordsMutation,
-        refetchQueries: [findOneQueryName, findManyQueryName],
-        variables: {
-          filter: { id: { in: batchIds } },
-        },
-        optimisticResponse: options?.skipOptimisticEffect
-          ? undefined
-          : {
-              [mutationResponseField]: batchIds.map((idToRestore) => ({
-                __typename: capitalize(objectNameSingular),
-                id: idToRestore,
-                deletedAt: null,
-              })),
-            },
-      });
+      const restoredRecordsResponse = await apolloClient
+        .mutate({
+          mutation: restoreManyRecordsMutation,
+          refetchQueries: [findOneQueryName, findManyQueryName],
+          variables: {
+            filter: { id: { in: batchIds } },
+          },
+          optimisticResponse: options?.skipOptimisticEffect
+            ? undefined
+            : {
+                [mutationResponseField]: batchIds.map((idToRestore) => ({
+                  __typename: capitalize(objectNameSingular),
+                  id: idToRestore,
+                  deletedAt: null,
+                })),
+              },
+        })
+        .catch((error: Error) => {
+          // TODO: revert optimistic effect (once optimistic effect is fixed)
+          throw error;
+        });
 
       const restoredRecordsForThisBatch =
         restoredRecordsResponse.data?.[mutationResponseField] ?? [];


### PR DESCRIPTION
Fixes #7299

The changes primarily focus on ensuring that records are correctly handled in the cache and optimistic effects are reverted appropriately when mutations fail.