### PR TITLE
Fix field creation

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.service.ts
@@ -182,7 +182,7 @@ export class FieldMetadataService extends TypeOrmQueryService<FieldMetadataEntit
         isCustom: true,
       };
 
-      this.validateFieldMetadataInput<CreateFieldInput>(
+      this.validateFieldMetadata<CreateFieldInput>(
         fieldMetadataForCreate.type,
         fieldMetadataForCreate,
         objectMetadata,
@@ -413,7 +413,7 @@ export class FieldMetadataService extends TypeOrmQueryService<FieldMetadataEntit
           : existingFieldMetadata.defaultValue,
       };
 
-      this.validateFieldMetadataInput<UpdateFieldInput>(
+      this.validateFieldMetadata<UpdateFieldInput>(
         existingFieldMetadata.type,
         fieldMetadataForUpdate,
         objectMetadata,
@@ -708,9 +708,7 @@ export class FieldMetadataService extends TypeOrmQueryService<FieldMetadataEntit
     }
   }
 
-  private validateFieldMetadataInput<
-    T extends UpdateFieldInput | CreateFieldInput,
-  >(
+  private validateFieldMetadata<T extends UpdateFieldInput | CreateFieldInput>(
     fieldMetadataType: FieldMetadataType,
     fieldMetadataInput: T,
     objectMetadata: ObjectMetadataEntity,

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.service.ts
@@ -408,17 +408,9 @@ export class FieldMetadataService extends TypeOrmQueryService<FieldMetadataEntit
 
       const fieldMetadataForUpdate = {
         ...updatableFieldInput,
-        defaultValue:
-          // Todo: we handle default value for all field types.
-          ![
-            FieldMetadataType.SELECT,
-            FieldMetadataType.MULTI_SELECT,
-            FieldMetadataType.BOOLEAN,
-          ].includes(existingFieldMetadata.type)
-            ? existingFieldMetadata.defaultValue
-            : updatableFieldInput.defaultValue !== null
-              ? updatableFieldInput.defaultValue
-              : null,
+        defaultValue: isDefined(updatableFieldInput.defaultValue)
+          ? updatableFieldInput.defaultValue
+          : existingFieldMetadata.defaultValue,
       };
 
       this.validateFieldMetadataInput<UpdateFieldInput>(
@@ -752,7 +744,7 @@ export class FieldMetadataService extends TypeOrmQueryService<FieldMetadataEntit
       }
     }
 
-    if (!fieldMetadataInput.isNullable) {
+    if (fieldMetadataInput.isNullable === false) {
       if (!isDefined(fieldMetadataInput.defaultValue)) {
         throw new FieldMetadataException(
           'Default value is required for non nullable fields',


### PR DESCRIPTION
In [this](https://github.com/twentyhq/twenty/pull/7522) and [this](https://github.com/twentyhq/twenty/pull/7543) PR we introduced the impossibility to save a field that would be non nullable but without a default value. 
The check is actually called on the input while the defaultValue is added by the service on a "built" fieldMetadata to create or save. So far all fields created from the app it currently fails as both isNullable and defaultValue are undefined so falsy at that stage.