### PR TITLE
Remove graphql twenty orm feature flag

### DIFF
--- a/packages/twenty-front/src/modules/command-menu/components/CommandMenu.tsx
+++ b/packages/twenty-front/src/modules/command-menu/components/CommandMenu.tsx
@@ -167,18 +167,12 @@ export const CommandMenu = () => {
     [closeCommandMenu],
   );
 
-  const isTwentyOrmEnabled = useIsFeatureEnabled(
-    'IS_QUERY_RUNNER_TWENTY_ORM_ENABLED',
-  );
-
   const isWorkspaceMigratedForSearch = useIsFeatureEnabled(
     'IS_WORKSPACE_MIGRATED_FOR_SEARCH',
   );
 
   const isSearchEnabled =
-    useIsFeatureEnabled('IS_SEARCH_ENABLED') &&
-    isTwentyOrmEnabled &&
-    isWorkspaceMigratedForSearch;
+    useIsFeatureEnabled('IS_SEARCH_ENABLED') && isWorkspaceMigratedForSearch;
 
   const { records: peopleFromFindMany } = useFindManyRecords<Person>({
     skip: !isCommandMenuOpened || isSearchEnabled,

--- a/packages/twenty-server/src/database/typeorm-seeds/core/feature-flags.ts
+++ b/packages/twenty-server/src/database/typeorm-seeds/core/feature-flags.ts
@@ -56,11 +56,6 @@ export const seedFeatureFlags = async (
         value: false,
       },
       {
-        key: FeatureFlagKey.IsQueryRunnerTwentyORMEnabled,
-        workspaceId: workspaceId,
-        value: true,
-      },
-      {
         key: FeatureFlagKey.IsSearchEnabled,
         workspaceId: workspaceId,
         value: true,

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-search-resolver.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-search-resolver.service.ts
@@ -107,12 +107,9 @@ export class GraphqlQuerySearchResolverService
         options.authContext.workspace.id,
       );
 
-    const isQueryRunnerTwentyORMEnabled =
-      featureFlagsForWorkspace.IS_QUERY_RUNNER_TWENTY_ORM_ENABLED;
-
     const isSearchEnabled = featureFlagsForWorkspace.IS_SEARCH_ENABLED;
 
-    if (!isQueryRunnerTwentyORMEnabled || !isSearchEnabled) {
+    if (!isSearchEnabled) {
       throw new GraphqlQueryRunnerException(
         'This endpoint is not available yet, please use findMany instead.',
         GraphqlQueryRunnerExceptionCode.INVALID_QUERY_INPUT,

--- a/packages/twenty-server/src/engine/api/graphql/workspace-resolver-builder/factories/create-many-resolver.factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-resolver-builder/factories/create-many-resolver.factory.ts
@@ -10,9 +10,6 @@ import { WorkspaceSchemaBuilderContext } from 'src/engine/api/graphql/workspace-
 
 import { GraphqlQueryRunnerService } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-runner.service';
 import { workspaceQueryRunnerGraphqlApiExceptionHandler } from 'src/engine/api/graphql/workspace-query-runner/utils/workspace-query-runner-graphql-api-exception-handler.util';
-import { WorkspaceQueryRunnerService } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-runner.service';
-import { FeatureFlagKey } from 'src/engine/core-modules/feature-flag/enums/feature-flag-key.enum';
-import { FeatureFlagService } from 'src/engine/core-modules/feature-flag/services/feature-flag.service';
 
 @Injectable()
 export class CreateManyResolverFactory
@@ -21,8 +18,6 @@ export class CreateManyResolverFactory
   public static methodName = 'createMany' as const;
 
   constructor(
-    private readonly workspaceQueryRunnerService: WorkspaceQueryRunnerService,
-    private readonly featureFlagService: FeatureFlagService,
     private readonly graphqlQueryRunnerService: GraphqlQueryRunnerService,
   ) {}
 
@@ -43,17 +38,7 @@ export class CreateManyResolverFactory
           objectMetadataMapItem: internalContext.objectMetadataMapItem,
         };
 
-        const isQueryRunnerTwentyORMEnabled =
-          await this.featureFlagService.isFeatureEnabled(
-            FeatureFlagKey.IsQueryRunnerTwentyORMEnabled,
-            internalContext.authContext.workspace.id,
-          );
-
-        if (isQueryRunnerTwentyORMEnabled) {
-          return await this.graphqlQueryRunnerService.createMany(args, options);
-        }
-
-        return await this.workspaceQueryRunnerService.createMany(args, options);
+        return await this.graphqlQueryRunnerService.createMany(args, options);
       } catch (error) {
         workspaceQueryRunnerGraphqlApiExceptionHandler(error);
       }

--- a/packages/twenty-server/src/engine/api/graphql/workspace-resolver-builder/factories/create-one-resolver.factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-resolver-builder/factories/create-one-resolver.factory.ts
@@ -10,9 +10,6 @@ import { WorkspaceSchemaBuilderContext } from 'src/engine/api/graphql/workspace-
 
 import { GraphqlQueryRunnerService } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-runner.service';
 import { workspaceQueryRunnerGraphqlApiExceptionHandler } from 'src/engine/api/graphql/workspace-query-runner/utils/workspace-query-runner-graphql-api-exception-handler.util';
-import { WorkspaceQueryRunnerService } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-runner.service';
-import { FeatureFlagKey } from 'src/engine/core-modules/feature-flag/enums/feature-flag-key.enum';
-import { FeatureFlagService } from 'src/engine/core-modules/feature-flag/services/feature-flag.service';
 
 @Injectable()
 export class CreateOneResolverFactory
@@ -21,8 +18,6 @@ export class CreateOneResolverFactory
   public static methodName = 'createOne' as const;
 
   constructor(
-    private readonly workspaceQueryRunnerService: WorkspaceQueryRunnerService,
-    private readonly featureFlagService: FeatureFlagService,
     private readonly graphqlQueryRunnerService: GraphqlQueryRunnerService,
   ) {}
 
@@ -43,17 +38,7 @@ export class CreateOneResolverFactory
           objectMetadataMapItem: internalContext.objectMetadataMapItem,
         };
 
-        const isQueryRunnerTwentyORMEnabled =
-          await this.featureFlagService.isFeatureEnabled(
-            FeatureFlagKey.IsQueryRunnerTwentyORMEnabled,
-            internalContext.authContext.workspace.id,
-          );
-
-        if (isQueryRunnerTwentyORMEnabled) {
-          return await this.graphqlQueryRunnerService.createOne(args, options);
-        }
-
-        return await this.workspaceQueryRunnerService.createOne(args, options);
+        return await this.graphqlQueryRunnerService.createOne(args, options);
       } catch (error) {
         workspaceQueryRunnerGraphqlApiExceptionHandler(error);
       }

--- a/packages/twenty-server/src/engine/api/graphql/workspace-resolver-builder/factories/delete-many-resolver.factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-resolver-builder/factories/delete-many-resolver.factory.ts
@@ -10,9 +10,6 @@ import { WorkspaceSchemaBuilderContext } from 'src/engine/api/graphql/workspace-
 
 import { GraphqlQueryRunnerService } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-runner.service';
 import { workspaceQueryRunnerGraphqlApiExceptionHandler } from 'src/engine/api/graphql/workspace-query-runner/utils/workspace-query-runner-graphql-api-exception-handler.util';
-import { WorkspaceQueryRunnerService } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-runner.service';
-import { FeatureFlagKey } from 'src/engine/core-modules/feature-flag/enums/feature-flag-key.enum';
-import { FeatureFlagService } from 'src/engine/core-modules/feature-flag/services/feature-flag.service';
 
 @Injectable()
 export class DeleteManyResolverFactory
@@ -21,8 +18,6 @@ export class DeleteManyResolverFactory
   public static methodName = 'deleteMany' as const;
 
   constructor(
-    private readonly workspaceQueryRunnerService: WorkspaceQueryRunnerService,
-    private readonly featureFlagService: FeatureFlagService,
     private readonly graphqlQueryRunnerService: GraphqlQueryRunnerService,
   ) {}
 
@@ -43,17 +38,7 @@ export class DeleteManyResolverFactory
           objectMetadataMapItem: internalContext.objectMetadataMapItem,
         };
 
-        const isQueryRunnerTwentyORMEnabled =
-          await this.featureFlagService.isFeatureEnabled(
-            FeatureFlagKey.IsQueryRunnerTwentyORMEnabled,
-            internalContext.authContext.workspace.id,
-          );
-
-        if (isQueryRunnerTwentyORMEnabled) {
-          return await this.graphqlQueryRunnerService.deleteMany(args, options);
-        }
-
-        return await this.workspaceQueryRunnerService.deleteMany(args, options);
+        return await this.graphqlQueryRunnerService.deleteMany(args, options);
       } catch (error) {
         workspaceQueryRunnerGraphqlApiExceptionHandler(error);
       }

--- a/packages/twenty-server/src/engine/api/graphql/workspace-resolver-builder/factories/delete-one-resolver.factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-resolver-builder/factories/delete-one-resolver.factory.ts
@@ -10,9 +10,6 @@ import { WorkspaceSchemaBuilderContext } from 'src/engine/api/graphql/workspace-
 
 import { GraphqlQueryRunnerService } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-runner.service';
 import { workspaceQueryRunnerGraphqlApiExceptionHandler } from 'src/engine/api/graphql/workspace-query-runner/utils/workspace-query-runner-graphql-api-exception-handler.util';
-import { WorkspaceQueryRunnerService } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-runner.service';
-import { FeatureFlagKey } from 'src/engine/core-modules/feature-flag/enums/feature-flag-key.enum';
-import { FeatureFlagService } from 'src/engine/core-modules/feature-flag/services/feature-flag.service';
 
 @Injectable()
 export class DeleteOneResolverFactory
@@ -21,8 +18,6 @@ export class DeleteOneResolverFactory
   public static methodName = 'deleteOne' as const;
 
   constructor(
-    private readonly workspaceQueryRunnerService: WorkspaceQueryRunnerService,
-    private readonly featureFlagService: FeatureFlagService,
     private readonly graphqlQueryRunnerService: GraphqlQueryRunnerService,
   ) {}
 
@@ -43,17 +38,7 @@ export class DeleteOneResolverFactory
           objectMetadataMapItem: internalContext.objectMetadataMapItem,
         };
 
-        const isQueryRunnerTwentyORMEnabled =
-          await this.featureFlagService.isFeatureEnabled(
-            FeatureFlagKey.IsQueryRunnerTwentyORMEnabled,
-            internalContext.authContext.workspace.id,
-          );
-
-        if (isQueryRunnerTwentyORMEnabled) {
-          return await this.graphqlQueryRunnerService.deleteOne(args, options);
-        }
-
-        return await this.workspaceQueryRunnerService.deleteOne(args, options);
+        return await this.graphqlQueryRunnerService.deleteOne(args, options);
       } catch (error) {
         workspaceQueryRunnerGraphqlApiExceptionHandler(error);
       }

--- a/packages/twenty-server/src/engine/api/graphql/workspace-resolver-builder/factories/destroy-many-resolver.factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-resolver-builder/factories/destroy-many-resolver.factory.ts
@@ -10,9 +10,6 @@ import { WorkspaceSchemaBuilderContext } from 'src/engine/api/graphql/workspace-
 
 import { GraphqlQueryRunnerService } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-runner.service';
 import { workspaceQueryRunnerGraphqlApiExceptionHandler } from 'src/engine/api/graphql/workspace-query-runner/utils/workspace-query-runner-graphql-api-exception-handler.util';
-import { WorkspaceQueryRunnerService } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-runner.service';
-import { FeatureFlagKey } from 'src/engine/core-modules/feature-flag/enums/feature-flag-key.enum';
-import { FeatureFlagService } from 'src/engine/core-modules/feature-flag/services/feature-flag.service';
 
 @Injectable()
 export class DestroyManyResolverFactory
@@ -21,8 +18,6 @@ export class DestroyManyResolverFactory
   public static methodName = 'destroyMany' as const;
 
   constructor(
-    private readonly workspaceQueryRunnerService: WorkspaceQueryRunnerService,
-    private readonly featureFlagService: FeatureFlagService,
     private readonly graphqlQueryRunnerService: GraphqlQueryRunnerService,
   ) {}
 
@@ -43,23 +38,7 @@ export class DestroyManyResolverFactory
           objectMetadataMapItem: internalContext.objectMetadataMapItem,
         };
 
-        const isQueryRunnerTwentyORMEnabled =
-          await this.featureFlagService.isFeatureEnabled(
-            FeatureFlagKey.IsQueryRunnerTwentyORMEnabled,
-            internalContext.authContext.workspace.id,
-          );
-
-        if (isQueryRunnerTwentyORMEnabled) {
-          return await this.graphqlQueryRunnerService.destroyMany(
-            args,
-            options,
-          );
-        }
-
-        return await this.workspaceQueryRunnerService.destroyMany(
-          args,
-          options,
-        );
+        return await this.graphqlQueryRunnerService.destroyMany(args, options);
       } catch (error) {
         workspaceQueryRunnerGraphqlApiExceptionHandler(error);
       }

--- a/packages/twenty-server/src/engine/api/graphql/workspace-resolver-builder/factories/find-duplicates-resolver.factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-resolver-builder/factories/find-duplicates-resolver.factory.ts
@@ -10,9 +10,6 @@ import { WorkspaceSchemaBuilderContext } from 'src/engine/api/graphql/workspace-
 
 import { GraphqlQueryRunnerService } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-runner.service';
 import { workspaceQueryRunnerGraphqlApiExceptionHandler } from 'src/engine/api/graphql/workspace-query-runner/utils/workspace-query-runner-graphql-api-exception-handler.util';
-import { WorkspaceQueryRunnerService } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-runner.service';
-import { FeatureFlagKey } from 'src/engine/core-modules/feature-flag/enums/feature-flag-key.enum';
-import { FeatureFlagService } from 'src/engine/core-modules/feature-flag/services/feature-flag.service';
 
 @Injectable()
 export class FindDuplicatesResolverFactory
@@ -21,8 +18,6 @@ export class FindDuplicatesResolverFactory
   public static methodName = 'findDuplicates' as const;
 
   constructor(
-    private readonly workspaceQueryRunnerService: WorkspaceQueryRunnerService,
-    private readonly featureFlagService: FeatureFlagService,
     private readonly graphqlQueryRunnerService: GraphqlQueryRunnerService,
   ) {}
 
@@ -43,20 +38,7 @@ export class FindDuplicatesResolverFactory
           objectMetadataMapItem: internalContext.objectMetadataMapItem,
         };
 
-        const isQueryRunnerTwentyORMEnabled =
-          await this.featureFlagService.isFeatureEnabled(
-            FeatureFlagKey.IsQueryRunnerTwentyORMEnabled,
-            internalContext.authContext.workspace.id,
-          );
-
-        if (isQueryRunnerTwentyORMEnabled) {
-          return await this.graphqlQueryRunnerService.findDuplicates(
-            args,
-            options,
-          );
-        }
-
-        return await this.workspaceQueryRunnerService.findDuplicates(
+        return await this.graphqlQueryRunnerService.findDuplicates(
           args,
           options,
         );

--- a/packages/twenty-server/src/engine/api/graphql/workspace-resolver-builder/factories/restore-many-resolver.factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-resolver-builder/factories/restore-many-resolver.factory.ts
@@ -10,9 +10,6 @@ import { WorkspaceSchemaBuilderContext } from 'src/engine/api/graphql/workspace-
 
 import { GraphqlQueryRunnerService } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-runner.service';
 import { workspaceQueryRunnerGraphqlApiExceptionHandler } from 'src/engine/api/graphql/workspace-query-runner/utils/workspace-query-runner-graphql-api-exception-handler.util';
-import { WorkspaceQueryRunnerService } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-runner.service';
-import { FeatureFlagKey } from 'src/engine/core-modules/feature-flag/enums/feature-flag-key.enum';
-import { FeatureFlagService } from 'src/engine/core-modules/feature-flag/services/feature-flag.service';
 
 @Injectable()
 export class RestoreManyResolverFactory
@@ -21,8 +18,6 @@ export class RestoreManyResolverFactory
   public static methodName = 'restoreMany' as const;
 
   constructor(
-    private readonly workspaceQueryRunnerService: WorkspaceQueryRunnerService,
-    private readonly featureFlagService: FeatureFlagService,
     private readonly graphqlQueryRunnerService: GraphqlQueryRunnerService,
   ) {}
 
@@ -43,23 +38,7 @@ export class RestoreManyResolverFactory
           objectMetadataMapItem: internalContext.objectMetadataMapItem,
         };
 
-        const isQueryRunnerTwentyORMEnabled =
-          await this.featureFlagService.isFeatureEnabled(
-            FeatureFlagKey.IsQueryRunnerTwentyORMEnabled,
-            internalContext.authContext.workspace.id,
-          );
-
-        if (isQueryRunnerTwentyORMEnabled) {
-          return await this.graphqlQueryRunnerService.restoreMany(
-            args,
-            options,
-          );
-        }
-
-        return await this.workspaceQueryRunnerService.restoreMany(
-          args,
-          options,
-        );
+        return await this.graphqlQueryRunnerService.restoreMany(args, options);
       } catch (error) {
         workspaceQueryRunnerGraphqlApiExceptionHandler(error);
       }

--- a/packages/twenty-server/src/engine/api/graphql/workspace-resolver-builder/factories/update-many-resolver.factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-resolver-builder/factories/update-many-resolver.factory.ts
@@ -10,9 +10,6 @@ import { WorkspaceSchemaBuilderContext } from 'src/engine/api/graphql/workspace-
 
 import { GraphqlQueryRunnerService } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-runner.service';
 import { workspaceQueryRunnerGraphqlApiExceptionHandler } from 'src/engine/api/graphql/workspace-query-runner/utils/workspace-query-runner-graphql-api-exception-handler.util';
-import { WorkspaceQueryRunnerService } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-runner.service';
-import { FeatureFlagKey } from 'src/engine/core-modules/feature-flag/enums/feature-flag-key.enum';
-import { FeatureFlagService } from 'src/engine/core-modules/feature-flag/services/feature-flag.service';
 
 @Injectable()
 export class UpdateManyResolverFactory
@@ -21,8 +18,6 @@ export class UpdateManyResolverFactory
   public static methodName = 'updateMany' as const;
 
   constructor(
-    private readonly workspaceQueryRunnerService: WorkspaceQueryRunnerService,
-    private readonly featureFlagService: FeatureFlagService,
     private readonly graphqlQueryRunnerService: GraphqlQueryRunnerService,
   ) {}
 
@@ -43,17 +38,7 @@ export class UpdateManyResolverFactory
           objectMetadataMapItem: internalContext.objectMetadataMapItem,
         };
 
-        const isQueryRunnerTwentyORMEnabled =
-          await this.featureFlagService.isFeatureEnabled(
-            FeatureFlagKey.IsQueryRunnerTwentyORMEnabled,
-            internalContext.authContext.workspace.id,
-          );
-
-        if (isQueryRunnerTwentyORMEnabled) {
-          return await this.graphqlQueryRunnerService.updateMany(args, options);
-        }
-
-        return await this.workspaceQueryRunnerService.updateMany(args, options);
+        return await this.graphqlQueryRunnerService.updateMany(args, options);
       } catch (error) {
         workspaceQueryRunnerGraphqlApiExceptionHandler(error);
       }

--- a/packages/twenty-server/src/engine/api/graphql/workspace-resolver-builder/factories/update-one-resolver.factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-resolver-builder/factories/update-one-resolver.factory.ts
@@ -10,9 +10,6 @@ import { WorkspaceSchemaBuilderContext } from 'src/engine/api/graphql/workspace-
 
 import { GraphqlQueryRunnerService } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-runner.service';
 import { workspaceQueryRunnerGraphqlApiExceptionHandler } from 'src/engine/api/graphql/workspace-query-runner/utils/workspace-query-runner-graphql-api-exception-handler.util';
-import { WorkspaceQueryRunnerService } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-runner.service';
-import { FeatureFlagKey } from 'src/engine/core-modules/feature-flag/enums/feature-flag-key.enum';
-import { FeatureFlagService } from 'src/engine/core-modules/feature-flag/services/feature-flag.service';
 
 @Injectable()
 export class UpdateOneResolverFactory
@@ -21,8 +18,6 @@ export class UpdateOneResolverFactory
   public static methodName = 'updateOne' as const;
 
   constructor(
-    private readonly workspaceQueryRunnerService: WorkspaceQueryRunnerService,
-    private readonly featureFlagService: FeatureFlagService,
     private readonly graphqlQueryRunnerService: GraphqlQueryRunnerService,
   ) {}
 
@@ -43,17 +38,7 @@ export class UpdateOneResolverFactory
           objectMetadataMapItem: internalContext.objectMetadataMapItem,
         };
 
-        const isQueryRunnerTwentyORMEnabled =
-          await this.featureFlagService.isFeatureEnabled(
-            FeatureFlagKey.IsQueryRunnerTwentyORMEnabled,
-            internalContext.authContext.workspace.id,
-          );
-
-        if (isQueryRunnerTwentyORMEnabled) {
-          return await this.graphqlQueryRunnerService.updateOne(args, options);
-        }
-
-        return await this.workspaceQueryRunnerService.updateOne(args, options);
+        return await this.graphqlQueryRunnerService.updateOne(args, options);
       } catch (error) {
         workspaceQueryRunnerGraphqlApiExceptionHandler(error);
       }


### PR DESCRIPTION
## Context
IS_QUERY_RUNNER_TWENTY_ORM_ENABLED has been fully launched in 0.31.0, the feature flag can be safely removed.

Note: Waiting for 0.31.1