### PR TITLE
improve matching filter error message

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-filter/utils/isRecordMatchingFilter.ts
+++ b/packages/twenty-front/src/modules/object-record/record-filter/utils/isRecordMatchingFilter.ts
@@ -290,7 +290,9 @@ export const isRecordMatchingFilter = ({
         );
       }
       default: {
-        throw new Error('Not implemented yet');
+        throw new Error(
+          `Not implemented yet for field type "${objectMetadataField.type}"`,
+        );
       }
     }
   });


### PR DESCRIPTION
## Context
This can be thrown when a type is not properly supported by isRecordMatchingFilter. This should not happen but for some workspaces with legacy types this should help debugging.