### PR TITLE
fix: Update Currency Filter Dropdown UI

### DIFF
--- a/packages/twenty-front/src/modules/object-record/object-filter-dropdown/components/ObjectFilterDropdownFilterSelectCompositeFieldSubMenu.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-filter-dropdown/components/ObjectFilterDropdownFilterSelectCompositeFieldSubMenu.tsx
@@ -13,7 +13,7 @@ import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/Drop
 import { MenuItem } from '@/ui/navigation/menu-item/components/MenuItem';
 import { useRecoilComponentStateV2 } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentStateV2';
 import { useState } from 'react';
-import { IconApps, IconChevronLeft, isDefined, useIcons } from 'twenty-ui';
+import { IconChevronLeft, isDefined, useIcons } from 'twenty-ui';
 
 export const ObjectFilterDropdownFilterSelectCompositeFieldSubMenu = () => {
   const [searchText, setSearchText] = useState('');
@@ -96,15 +96,6 @@ export const ObjectFilterDropdownFilterSelectCompositeFieldSubMenu = () => {
         }
       />
       <DropdownMenuItemsContainer>
-        <MenuItem
-          key={`select-filter-${-1}`}
-          testId={`select-filter-${-1}`}
-          onClick={() => {
-            handleSelectFilter(objectFilterDropdownFirstLevelFilterDefinition);
-          }}
-          LeftIcon={IconApps}
-          text={`Any ${getFilterableFieldTypeLabel(objectFilterDropdownSubMenuFieldType)} field`}
-        />
         {options.map((subFieldName, index) => (
           <MenuItem
             key={`select-filter-${index}`}


### PR DESCRIPTION
Fixes #7558 

Removed the "Any Currency field" option from the Currency filter dropdown as it is redundant and unnecessary.

<img width="241" alt="image" src="https://github.com/user-attachments/assets/4468a858-d94b-4031-b951-47cbe16a9e2c">
