### PR TITLE
fix: droppable-placeholder

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-board/record-board-column/components/RecordBoardColumnCardsContainer.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/record-board-column/components/RecordBoardColumnCardsContainer.tsx
@@ -122,6 +122,7 @@ export const RecordBoardColumnCardsContainer = ({
           </div>
         )}
       </Draggable>
+      {droppableProvided?.placeholder}
     </StyledColumnCardsContainer>
   );
 };


### PR DESCRIPTION
Fixes: #7597

This PR fixes the missing placeholder from Droppable component. 