### PR TITLE
fix enum default value update when option deleted

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/open-api/utils/parameters.utils.ts
+++ b/packages/twenty-server/src/engine/core-modules/open-api/utils/parameters.utils.ts
@@ -84,8 +84,7 @@ export const computeFilterParameters = (): OpenAPIV3_1.ParameterObject => {
     ).join('**, **')}**.  
     Default root conjunction is **${DEFAULT_CONJUNCTION}**.  
     To filter **null** values use **field[is]:NULL** or **field[is]:NOT_NULL**  
-    To filter using **boolean** values use **field[eq]:true** or **field[eq]:false**
-    `,
+    To filter using **boolean** values use **field[eq]:true** or **field[eq]:false**`,
 
     required: false,
     schema: {

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.service.ts
@@ -394,9 +394,15 @@ export class FieldMetadataService extends TypeOrmQueryService<FieldMetadataEntit
 
       const fieldMetadataForUpdate = {
         ...updatableFieldInput,
-        defaultValue: isDefined(updatableFieldInput.defaultValue)
-          ? updatableFieldInput.defaultValue
-          : existingFieldMetadata.defaultValue,
+        defaultValue: ![
+          FieldMetadataType.SELECT,
+          FieldMetadataType.MULTI_SELECT,
+          FieldMetadataType.BOOLEAN,
+        ].includes(existingFieldMetadata.type)
+          ? existingFieldMetadata.defaultValue
+          : updatableFieldInput.defaultValue !== null
+            ? updatableFieldInput.defaultValue
+            : null,
       };
 
       this.validateFieldMetadata<UpdateFieldInput>(

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.service.ts
@@ -394,13 +394,10 @@ export class FieldMetadataService extends TypeOrmQueryService<FieldMetadataEntit
 
       const fieldMetadataForUpdate = {
         ...updatableFieldInput,
-        defaultValue: ![
-          FieldMetadataType.SELECT,
-          FieldMetadataType.MULTI_SELECT,
-          FieldMetadataType.BOOLEAN,
-        ].includes(existingFieldMetadata.type)
-          ? existingFieldMetadata.defaultValue
-          : updatableFieldInput.defaultValue,
+        defaultValue:
+          updatableFieldInput.defaultValue !== undefined
+            ? updatableFieldInput.defaultValue
+            : existingFieldMetadata.defaultValue,
       };
 
       this.validateFieldMetadata<UpdateFieldInput>(

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.service.ts
@@ -400,9 +400,7 @@ export class FieldMetadataService extends TypeOrmQueryService<FieldMetadataEntit
           FieldMetadataType.BOOLEAN,
         ].includes(existingFieldMetadata.type)
           ? existingFieldMetadata.defaultValue
-          : updatableFieldInput.defaultValue !== null
-            ? updatableFieldInput.defaultValue
-            : null,
+          : updatableFieldInput.defaultValue,
       };
 
       this.validateFieldMetadata<UpdateFieldInput>(


### PR DESCRIPTION
Fix as isDefined also returns false if value is null and we still want to allow users to set defaultValue back to null