### PR TITLE
Check if relation before trying to input relation label

### DIFF
--- a/packages/twenty-front/src/modules/settings/data-model/fields/forms/components/SettingsDataModelFieldIconLabelForm.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/forms/components/SettingsDataModelFieldIconLabelForm.tsx
@@ -58,7 +58,7 @@ export const SettingsDataModelFieldIconLabelForm = ({
   const [iconEditedManually, setIconEditedManually] = useState(false);
 
   useEffect(() => {
-    if (labelEditedManually) return;
+    if (labelEditedManually || !relationType) return;
     const label = [
       RelationDefinitionType.ManyToOne,
       RelationDefinitionType.ManyToMany,


### PR DESCRIPTION
Bug introduced by https://github.com/twentyhq/twenty/pull/7363
Input value was not set during edition for field that were not relations

Fixed
<img width="893" alt="Capture d’écran 2024-10-11 à 16 53 56" src="https://github.com/user-attachments/assets/511077c6-5dff-49a1-b058-24a83d998dcf">
