### PR TITLE
Fix optimistic effect deletedAt

### DIFF
--- a/packages/twenty-front/src/modules/apollo/optimistic-effect/utils/triggerDestroyRecordsOptimisticEffect.ts
+++ b/packages/twenty-front/src/modules/apollo/optimistic-effect/utils/triggerDestroyRecordsOptimisticEffect.ts
@@ -7,7 +7,7 @@ import { isObjectRecordConnectionWithRefs } from '@/object-record/cache/utils/is
 import { RecordGqlNode } from '@/object-record/graphql/types/RecordGqlNode';
 import { isDefined } from '~/utils/isDefined';
 
-export const triggerDeleteRecordsOptimisticEffect = ({
+export const triggerDestroyRecordsOptimisticEffect = ({
   cache,
   objectMetadataItem,
   recordsToDelete,
@@ -78,11 +78,6 @@ export const triggerDeleteRecordsOptimisticEffect = ({
       objectMetadataItems,
     });
 
-    cache.modify({
-      id: cache.identify(recordToDelete),
-      fields: {
-        deletedAt: () => recordToDelete.deletedAt,
-      },
-    });
+    cache.evict({ id: cache.identify(recordToDelete) });
   });
 };

--- a/packages/twenty-front/src/modules/apollo/optimistic-effect/utils/triggerDestroyRecordsOptimisticEffect.ts
+++ b/packages/twenty-front/src/modules/apollo/optimistic-effect/utils/triggerDestroyRecordsOptimisticEffect.ts
@@ -10,12 +10,12 @@ import { isDefined } from '~/utils/isDefined';
 export const triggerDestroyRecordsOptimisticEffect = ({
   cache,
   objectMetadataItem,
-  recordsToDelete,
+  recordsToDestroy,
   objectMetadataItems,
 }: {
   cache: ApolloCache<unknown>;
   objectMetadataItem: ObjectMetadataItem;
-  recordsToDelete: RecordGqlNode[];
+  recordsToDestroy: RecordGqlNode[];
   objectMetadataItems: ObjectMetadataItem[];
 }) => {
   cache.modify<StoreObject>({
@@ -36,7 +36,7 @@ export const triggerDestroyRecordsOptimisticEffect = ({
 
         const rootQueryCachedObjectRecordConnection = rootQueryCachedResponse;
 
-        const recordIdsToDelete = recordsToDelete.map(({ id }) => id);
+        const recordIdsToDelete = recordsToDestroy.map(({ id }) => id);
 
         const cachedEdges = readField<RecordGqlRefEdge[]>(
           'edges',
@@ -69,15 +69,15 @@ export const triggerDestroyRecordsOptimisticEffect = ({
     },
   });
 
-  recordsToDelete.forEach((recordToDelete) => {
+  recordsToDestroy.forEach((recordToDestroy) => {
     triggerUpdateRelationsOptimisticEffect({
       cache,
       sourceObjectMetadataItem: objectMetadataItem,
-      currentSourceRecord: recordToDelete,
+      currentSourceRecord: recordToDestroy,
       updatedSourceRecord: null,
       objectMetadataItems,
     });
 
-    cache.evict({ id: cache.identify(recordToDelete) });
+    cache.evict({ id: cache.identify(recordToDestroy) });
   });
 };

--- a/packages/twenty-front/src/modules/apollo/optimistic-effect/utils/triggerUpdateRelationsOptimisticEffect.ts
+++ b/packages/twenty-front/src/modules/apollo/optimistic-effect/utils/triggerUpdateRelationsOptimisticEffect.ts
@@ -125,7 +125,7 @@ export const triggerUpdateRelationsOptimisticEffect = ({
           triggerDestroyRecordsOptimisticEffect({
             cache,
             objectMetadataItem: fullTargetObjectMetadataItem,
-            recordsToDelete: targetRecordsToDetachFrom,
+            recordsToDestroy: targetRecordsToDetachFrom,
             objectMetadataItems,
           });
         } else {

--- a/packages/twenty-front/src/modules/apollo/optimistic-effect/utils/triggerUpdateRelationsOptimisticEffect.ts
+++ b/packages/twenty-front/src/modules/apollo/optimistic-effect/utils/triggerUpdateRelationsOptimisticEffect.ts
@@ -1,7 +1,7 @@
 import { ApolloCache } from '@apollo/client';
 
 import { triggerAttachRelationOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerAttachRelationOptimisticEffect';
-import { triggerDeleteRecordsOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerDeleteRecordsOptimisticEffect';
+import { triggerDestroyRecordsOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerDestroyRecordsOptimisticEffect';
 import { triggerDetachRelationOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerDetachRelationOptimisticEffect';
 import { CORE_OBJECT_NAMES_TO_DELETE_ON_TRIGGER_RELATION_DETACH } from '@/apollo/types/coreObjectNamesToDeleteOnRelationDetach';
 import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
@@ -122,7 +122,7 @@ export const triggerUpdateRelationsOptimisticEffect = ({
           );
 
         if (shouldCascadeDeleteTargetRecords) {
-          triggerDeleteRecordsOptimisticEffect({
+          triggerDestroyRecordsOptimisticEffect({
             cache,
             objectMetadataItem: fullTargetObjectMetadataItem,
             recordsToDelete: targetRecordsToDetachFrom,

--- a/packages/twenty-front/src/modules/object-record/cache/hooks/useDeleteRecordFromCache.ts
+++ b/packages/twenty-front/src/modules/object-record/cache/hooks/useDeleteRecordFromCache.ts
@@ -18,11 +18,11 @@ export const useDeleteRecordFromCache = ({
 
   const { objectMetadataItems } = useObjectMetadataItems();
 
-  return (recordToDelete: ObjectRecord) => {
+  return (recordToDestroy: ObjectRecord) => {
     deleteRecordFromCache({
       objectMetadataItem,
       objectMetadataItems,
-      recordToDelete,
+      recordToDestroy,
       cache: apolloClient.cache,
     });
   };

--- a/packages/twenty-front/src/modules/object-record/cache/utils/deleteRecordFromCache.ts
+++ b/packages/twenty-front/src/modules/object-record/cache/utils/deleteRecordFromCache.ts
@@ -8,21 +8,21 @@ import { ObjectRecord } from '@/object-record/types/ObjectRecord';
 export const deleteRecordFromCache = ({
   objectMetadataItem,
   objectMetadataItems,
-  recordToDelete,
+  recordToDestroy,
   cache,
 }: {
   objectMetadataItem: ObjectMetadataItem;
   objectMetadataItems: ObjectMetadataItem[];
-  recordToDelete: ObjectRecord;
+  recordToDestroy: ObjectRecord;
   cache: ApolloCache<object>;
 }) => {
   triggerDestroyRecordsOptimisticEffect({
     cache,
     objectMetadataItem,
     objectMetadataItems,
-    recordsToDelete: [
+    recordsToDestroy: [
       {
-        ...recordToDelete,
+        ...recordToDestroy,
         __typename: getObjectTypename(objectMetadataItem.nameSingular),
       },
     ],

--- a/packages/twenty-front/src/modules/object-record/cache/utils/deleteRecordFromCache.ts
+++ b/packages/twenty-front/src/modules/object-record/cache/utils/deleteRecordFromCache.ts
@@ -1,6 +1,6 @@
 import { ApolloCache } from '@apollo/client';
 
-import { triggerDeleteRecordsOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerDeleteRecordsOptimisticEffect';
+import { triggerDestroyRecordsOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerDestroyRecordsOptimisticEffect';
 import { ObjectMetadataItem } from '@/object-metadata/types/ObjectMetadataItem';
 import { getObjectTypename } from '@/object-record/cache/utils/getObjectTypename';
 import { ObjectRecord } from '@/object-record/types/ObjectRecord';
@@ -16,7 +16,7 @@ export const deleteRecordFromCache = ({
   recordToDelete: ObjectRecord;
   cache: ApolloCache<object>;
 }) => {
-  triggerDeleteRecordsOptimisticEffect({
+  triggerDestroyRecordsOptimisticEffect({
     cache,
     objectMetadataItem,
     objectMetadataItems,

--- a/packages/twenty-front/src/modules/object-record/hooks/__tests__/useDeleteManyRecords.test.tsx
+++ b/packages/twenty-front/src/modules/object-record/hooks/__tests__/useDeleteManyRecords.test.tsx
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 
 import {
   query,
@@ -6,9 +6,10 @@ import {
   variables,
 } from '@/object-record/hooks/__mocks__/useDeleteManyRecords';
 import { useDeleteManyRecords } from '@/object-record/hooks/useDeleteManyRecords';
+import { act } from 'react';
 import { getJestMetadataAndApolloMocksWrapper } from '~/testing/jest/getJestMetadataAndApolloMocksWrapper';
 
-const people = [
+const personIds = [
   'a7286b9a-c039-4a89-9567-2dfa7953cda9',
   '37faabcd-cb39-4a0a-8618-7e3fda9afca0',
 ];
@@ -41,7 +42,7 @@ describe('useDeleteManyRecords', () => {
     );
 
     await act(async () => {
-      const res = await result.current.deleteManyRecords(people);
+      const res = await result.current.deleteManyRecords(personIds);
       expect(res).toBeDefined();
       expect(res[0]).toHaveProperty('id');
     });

--- a/packages/twenty-front/src/modules/object-record/hooks/useCreateManyRecords.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useCreateManyRecords.ts
@@ -2,7 +2,7 @@ import { useApolloClient } from '@apollo/client';
 import { v4 } from 'uuid';
 
 import { triggerCreateRecordsOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerCreateRecordsOptimisticEffect';
-import { triggerDeleteRecordsOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerDeleteRecordsOptimisticEffect';
+import { triggerDestroyRecordsOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerDestroyRecordsOptimisticEffect';
 import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
 import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
 import { useCreateOneRecordInCache } from '@/object-record/cache/hooks/useCreateOneRecordInCache';
@@ -131,7 +131,7 @@ export const useCreateManyRecords = <
           });
         });
 
-        triggerDeleteRecordsOptimisticEffect({
+        triggerDestroyRecordsOptimisticEffect({
           cache: apolloClient.cache,
           objectMetadataItem,
           recordsToDelete: recordsCreatedInCache,

--- a/packages/twenty-front/src/modules/object-record/hooks/useCreateManyRecords.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useCreateManyRecords.ts
@@ -122,19 +122,19 @@ export const useCreateManyRecords = <
         },
       })
       .catch((error: Error) => {
-        recordsCreatedInCache.forEach((recordToDelete) => {
+        recordsCreatedInCache.forEach((recordToDestroy) => {
           deleteRecordFromCache({
             objectMetadataItems,
             objectMetadataItem,
             cache: apolloClient.cache,
-            recordToDelete,
+            recordToDestroy,
           });
         });
 
         triggerDestroyRecordsOptimisticEffect({
           cache: apolloClient.cache,
           objectMetadataItem,
-          recordsToDelete: recordsCreatedInCache,
+          recordsToDestroy: recordsCreatedInCache,
           objectMetadataItems,
         });
 

--- a/packages/twenty-front/src/modules/object-record/hooks/useCreateOneRecord.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useCreateOneRecord.ts
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { v4 } from 'uuid';
 
 import { triggerCreateRecordsOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerCreateRecordsOptimisticEffect';
-import { triggerDeleteRecordsOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerDeleteRecordsOptimisticEffect';
+import { triggerDestroyRecordsOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerDestroyRecordsOptimisticEffect';
 import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
 import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
 import { useCreateOneRecordInCache } from '@/object-record/cache/hooks/useCreateOneRecordInCache';
@@ -121,7 +121,7 @@ export const useCreateOneRecord = <
           recordToDelete: recordCreatedInCache,
         });
 
-        triggerDeleteRecordsOptimisticEffect({
+        triggerDestroyRecordsOptimisticEffect({
           cache: apolloClient.cache,
           objectMetadataItem,
           recordsToDelete: [recordCreatedInCache],

--- a/packages/twenty-front/src/modules/object-record/hooks/useCreateOneRecord.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useCreateOneRecord.ts
@@ -118,13 +118,13 @@ export const useCreateOneRecord = <
           objectMetadataItems,
           objectMetadataItem,
           cache: apolloClient.cache,
-          recordToDelete: recordCreatedInCache,
+          recordToDestroy: recordCreatedInCache,
         });
 
         triggerDestroyRecordsOptimisticEffect({
           cache: apolloClient.cache,
           objectMetadataItem,
-          recordsToDelete: [recordCreatedInCache],
+          recordsToDestroy: [recordCreatedInCache],
           objectMetadataItems,
         });
 

--- a/packages/twenty-front/src/modules/object-record/hooks/useDeleteManyRecords.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useDeleteManyRecords.ts
@@ -1,14 +1,15 @@
 import { useApolloClient } from '@apollo/client';
 
-import { triggerCreateRecordsOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerCreateRecordsOptimisticEffect';
-import { triggerDeleteRecordsOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerDeleteRecordsOptimisticEffect';
+import { triggerUpdateRecordOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerUpdateRecordOptimisticEffect';
 import { apiConfigState } from '@/client-config/states/apiConfigState';
 import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
 import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
 import { useGetRecordFromCache } from '@/object-record/cache/hooks/useGetRecordFromCache';
+import { getRecordNodeFromRecord } from '@/object-record/cache/utils/getRecordNodeFromRecord';
 import { updateRecordFromCache } from '@/object-record/cache/utils/updateRecordFromCache';
 import { DEFAULT_MUTATION_BATCH_SIZE } from '@/object-record/constants/DefaultMutationBatchSize';
 import { useDeleteManyRecordsMutation } from '@/object-record/hooks/useDeleteManyRecordsMutation';
+import { ObjectRecord } from '@/object-record/types/ObjectRecord';
 import { getDeleteManyRecordsMutationResponseField } from '@/object-record/utils/getDeleteManyRecordsMutationResponseField';
 import { useRecoilValue } from 'recoil';
 import { isDefined } from '~/utils/isDefined';
@@ -67,44 +68,69 @@ export const useDeleteManyRecords = ({
         (batchIndex + 1) * mutationPageSize,
       );
 
+      const currentTimestamp = new Date().toISOString();
+
+      const cachedRecords = idsToDelete.map((idToDelete) =>
+        getRecordFromCache(idToDelete, apolloClient.cache),
+      );
+
+      if (!options?.skipOptimisticEffect) {
+        cachedRecords.forEach((cachedRecord) => {
+          if (!cachedRecord) {
+            return;
+          }
+
+          const cachedRecordWithConnection =
+            getRecordNodeFromRecord<ObjectRecord>({
+              record: cachedRecord,
+              objectMetadataItem,
+              objectMetadataItems,
+              computeReferences: true,
+            });
+
+          const computedOptimisticRecord = {
+            ...cachedRecord,
+            ...{ id: cachedRecord.id, deletedAt: currentTimestamp },
+            ...{ __typename: capitalize(objectMetadataItem.nameSingular) },
+          };
+
+          const optimisticRecordWithConnection =
+            getRecordNodeFromRecord<ObjectRecord>({
+              record: computedOptimisticRecord,
+              objectMetadataItem,
+              objectMetadataItems,
+              computeReferences: true,
+            });
+
+          if (!optimisticRecordWithConnection || !cachedRecordWithConnection) {
+            return null;
+          }
+
+          updateRecordFromCache({
+            objectMetadataItems,
+            objectMetadataItem,
+            cache: apolloClient.cache,
+            record: computedOptimisticRecord,
+          });
+
+          triggerUpdateRecordOptimisticEffect({
+            cache: apolloClient.cache,
+            objectMetadataItem,
+            currentRecord: cachedRecordWithConnection,
+            updatedRecord: optimisticRecordWithConnection,
+            objectMetadataItems,
+          });
+        });
+      }
+
       const deletedRecordsResponse = await apolloClient
         .mutate({
           mutation: deleteManyRecordsMutation,
           variables: {
             filter: { id: { in: batchIds } },
           },
-          optimisticResponse: options?.skipOptimisticEffect
-            ? undefined
-            : {
-                [mutationResponseField]: batchIds.map((idToDelete) => ({
-                  __typename: capitalize(objectNameSingular),
-                  id: idToDelete,
-                })),
-              },
-          update: options?.skipOptimisticEffect
-            ? undefined
-            : (cache, { data }) => {
-                const records = data?.[mutationResponseField];
-
-                if (!records?.length) return;
-
-                const cachedRecords = records
-                  .map((record) => getRecordFromCache(record.id, cache))
-                  .filter(isDefined);
-
-                triggerDeleteRecordsOptimisticEffect({
-                  cache,
-                  objectMetadataItem,
-                  recordsToDelete: cachedRecords,
-                  objectMetadataItems,
-                });
-              },
         })
         .catch((error: Error) => {
-          const cachedRecords = batchIds.map((idToDelete) =>
-            getRecordFromCache(idToDelete, apolloClient.cache),
-          );
-
           cachedRecords.forEach((cachedRecord) => {
             if (!cachedRecord) {
               return;
@@ -114,23 +140,45 @@ export const useDeleteManyRecords = ({
               objectMetadataItems,
               objectMetadataItem,
               cache: apolloClient.cache,
-              record: {
-                ...cachedRecord,
-                deletedAt: null,
-              },
+              record: cachedRecord,
             });
-          });
 
-          triggerCreateRecordsOptimisticEffect({
-            cache: apolloClient.cache,
-            objectMetadataItem,
-            objectMetadataItems,
-            recordsToCreate: cachedRecords
-              .filter(isDefined)
-              .map((cachedRecord) => ({
-                ...cachedRecord,
-                deletedAt: null,
-              })),
+            const cachedRecordWithConnection =
+              getRecordNodeFromRecord<ObjectRecord>({
+                record: cachedRecord,
+                objectMetadataItem,
+                objectMetadataItems,
+                computeReferences: true,
+              });
+
+            const computedOptimisticRecord = {
+              ...cachedRecord,
+              ...{ id: cachedRecord.id, deletedAt: currentTimestamp },
+              ...{ __typename: capitalize(objectMetadataItem.nameSingular) },
+            };
+
+            const optimisticRecordWithConnection =
+              getRecordNodeFromRecord<ObjectRecord>({
+                record: computedOptimisticRecord,
+                objectMetadataItem,
+                objectMetadataItems,
+                computeReferences: true,
+              });
+
+            if (
+              !optimisticRecordWithConnection ||
+              !cachedRecordWithConnection
+            ) {
+              return null;
+            }
+
+            triggerUpdateRecordOptimisticEffect({
+              cache: apolloClient.cache,
+              objectMetadataItem,
+              currentRecord: optimisticRecordWithConnection,
+              updatedRecord: cachedRecordWithConnection,
+              objectMetadataItems,
+            });
           });
 
           throw error;

--- a/packages/twenty-front/src/modules/object-record/hooks/useDeleteManyRecords.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useDeleteManyRecords.ts
@@ -76,7 +76,6 @@ export const useDeleteManyRecords = ({
 
       if (!options?.skipOptimisticEffect) {
         cachedRecords.forEach((cachedRecord) => {
-          console.log('cachedRecord', cachedRecord);
           if (!cachedRecord || !cachedRecord.id) {
             return;
           }

--- a/packages/twenty-front/src/modules/object-record/hooks/useDestroyManyRecords.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useDestroyManyRecords.ts
@@ -98,7 +98,7 @@ export const useDestroyManyRecords = ({
                 triggerDestroyRecordsOptimisticEffect({
                   cache,
                   objectMetadataItem,
-                  recordsToDelete: cachedRecords,
+                  recordsToDestroy: cachedRecords,
                   objectMetadataItems,
                 });
               },

--- a/packages/twenty-front/src/modules/object-record/hooks/useDestroyManyRecords.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useDestroyManyRecords.ts
@@ -1,7 +1,7 @@
 import { useApolloClient } from '@apollo/client';
 
 import { triggerCreateRecordsOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerCreateRecordsOptimisticEffect';
-import { triggerDeleteRecordsOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerDeleteRecordsOptimisticEffect';
+import { triggerDestroyRecordsOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerDestroyRecordsOptimisticEffect';
 import { apiConfigState } from '@/client-config/states/apiConfigState';
 import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
 import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
@@ -95,7 +95,7 @@ export const useDestroyManyRecords = ({
                   .map((record) => getRecordFromCache(record.id, cache))
                   .filter(isDefined);
 
-                triggerDeleteRecordsOptimisticEffect({
+                triggerDestroyRecordsOptimisticEffect({
                   cache,
                   objectMetadataItem,
                   recordsToDelete: cachedRecords,

--- a/packages/twenty-front/src/modules/object-record/hooks/useDestroyManyRecords.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useDestroyManyRecords.ts
@@ -61,12 +61,12 @@ export const useDestroyManyRecords = ({
     const destroyedRecords = [];
 
     for (let batchIndex = 0; batchIndex < numberOfBatches; batchIndex++) {
-      const batchIds = idsToDestroy.slice(
+      const batchedIdToDestroy = idsToDestroy.slice(
         batchIndex * mutationPageSize,
         (batchIndex + 1) * mutationPageSize,
       );
 
-      const originalRecords = idsToDestroy
+      const originalRecords = batchedIdToDestroy
         .map((recordId) => getRecordFromCache(recordId, apolloClient.cache))
         .filter(isDefined);
 
@@ -74,15 +74,17 @@ export const useDestroyManyRecords = ({
         .mutate({
           mutation: destroyManyRecordsMutation,
           variables: {
-            filter: { id: { in: batchIds } },
+            filter: { id: { in: batchedIdToDestroy } },
           },
           optimisticResponse: options?.skipOptimisticEffect
             ? undefined
             : {
-                [mutationResponseField]: batchIds.map((idToDestroy) => ({
-                  __typename: capitalize(objectNameSingular),
-                  id: idToDestroy,
-                })),
+                [mutationResponseField]: batchedIdToDestroy.map(
+                  (idToDestroy) => ({
+                    __typename: capitalize(objectNameSingular),
+                    id: idToDestroy,
+                  }),
+                ),
               },
           update: options?.skipOptimisticEffect
             ? undefined

--- a/packages/twenty-front/src/modules/object-record/hooks/useDestroyOneRecord.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useDestroyOneRecord.ts
@@ -68,7 +68,7 @@ export const useDestroyOneRecord = ({
             triggerDestroyRecordsOptimisticEffect({
               cache,
               objectMetadataItem,
-              recordsToDelete: [cachedRecord],
+              recordsToDestroy: [cachedRecord],
               objectMetadataItems,
             });
           },

--- a/packages/twenty-front/src/modules/object-record/hooks/useDestroyOneRecord.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useDestroyOneRecord.ts
@@ -2,7 +2,7 @@ import { useApolloClient } from '@apollo/client';
 import { useCallback } from 'react';
 
 import { triggerCreateRecordsOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerCreateRecordsOptimisticEffect';
-import { triggerDeleteRecordsOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerDeleteRecordsOptimisticEffect';
+import { triggerDestroyRecordsOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerDestroyRecordsOptimisticEffect';
 import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
 import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
 import { useGetRecordFromCache } from '@/object-record/cache/hooks/useGetRecordFromCache';
@@ -65,7 +65,7 @@ export const useDestroyOneRecord = ({
 
             if (!cachedRecord) return;
 
-            triggerDeleteRecordsOptimisticEffect({
+            triggerDestroyRecordsOptimisticEffect({
               cache,
               objectMetadataItem,
               recordsToDelete: [cachedRecord],

--- a/packages/twenty-front/src/modules/object-record/hooks/useRestoreManyRecords.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useRestoreManyRecords.ts
@@ -1,9 +1,15 @@
 import { useApolloClient } from '@apollo/client';
 
+import { triggerUpdateRecordOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerUpdateRecordOptimisticEffect';
 import { apiConfigState } from '@/client-config/states/apiConfigState';
 import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
+import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
+import { useGetRecordFromCache } from '@/object-record/cache/hooks/useGetRecordFromCache';
+import { getRecordNodeFromRecord } from '@/object-record/cache/utils/getRecordNodeFromRecord';
+import { updateRecordFromCache } from '@/object-record/cache/utils/updateRecordFromCache';
 import { DEFAULT_MUTATION_BATCH_SIZE } from '@/object-record/constants/DefaultMutationBatchSize';
 import { useRestoreManyRecordsMutation } from '@/object-record/hooks/useRestoreManyRecordsMutation';
+import { ObjectRecord } from '@/object-record/types/ObjectRecord';
 import { getRestoreManyRecordsMutationResponseField } from '@/object-record/utils/getRestoreManyRecordsMutationResponseField';
 import { useRecoilValue } from 'recoil';
 import { isDefined } from '~/utils/isDefined';
@@ -34,9 +40,15 @@ export const useRestoreManyRecords = ({
     objectNameSingular,
   });
 
+  const getRecordFromCache = useGetRecordFromCache({
+    objectNameSingular,
+  });
+
   const { restoreManyRecordsMutation } = useRestoreManyRecordsMutation({
     objectNameSingular,
   });
+
+  const { objectMetadataItems } = useObjectMetadataItems();
 
   const mutationResponseField = getRestoreManyRecordsMutationResponseField(
     objectMetadataItem.namePlural,
@@ -56,31 +68,117 @@ export const useRestoreManyRecords = ({
         (batchIndex + 1) * mutationPageSize,
       );
 
-      // TODO: fix optimistic effect
-      const findOneQueryName = `FindOne${capitalize(objectNameSingular)}`;
-      const findManyQueryName = `FindMany${capitalize(
-        objectMetadataItem.namePlural,
-      )}`;
+      const cachedRecords = idsToRestore.map((idToRestore) =>
+        getRecordFromCache(idToRestore, apolloClient.cache),
+      );
+
+      if (!options?.skipOptimisticEffect) {
+        cachedRecords.forEach((cachedRecord) => {
+          if (!cachedRecord) {
+            return;
+          }
+
+          const cachedRecordWithConnection =
+            getRecordNodeFromRecord<ObjectRecord>({
+              record: cachedRecord,
+              objectMetadataItem,
+              objectMetadataItems,
+              computeReferences: true,
+            });
+
+          const computedOptimisticRecord = {
+            ...cachedRecord,
+            ...{ id: cachedRecord.id, deletedAt: null },
+            ...{ __typename: capitalize(objectMetadataItem.nameSingular) },
+          };
+
+          const optimisticRecordWithConnection =
+            getRecordNodeFromRecord<ObjectRecord>({
+              record: computedOptimisticRecord,
+              objectMetadataItem,
+              objectMetadataItems,
+              computeReferences: true,
+            });
+
+          if (!optimisticRecordWithConnection || !cachedRecordWithConnection) {
+            return null;
+          }
+
+          updateRecordFromCache({
+            objectMetadataItems,
+            objectMetadataItem,
+            cache: apolloClient.cache,
+            record: computedOptimisticRecord,
+          });
+
+          triggerUpdateRecordOptimisticEffect({
+            cache: apolloClient.cache,
+            objectMetadataItem,
+            currentRecord: cachedRecordWithConnection,
+            updatedRecord: optimisticRecordWithConnection,
+            objectMetadataItems,
+          });
+        });
+      }
 
       const restoredRecordsResponse = await apolloClient
         .mutate({
           mutation: restoreManyRecordsMutation,
-          refetchQueries: [findOneQueryName, findManyQueryName],
           variables: {
             filter: { id: { in: batchIds } },
           },
-          optimisticResponse: options?.skipOptimisticEffect
-            ? undefined
-            : {
-                [mutationResponseField]: batchIds.map((idToRestore) => ({
-                  __typename: capitalize(objectNameSingular),
-                  id: idToRestore,
-                  deletedAt: null,
-                })),
-              },
         })
         .catch((error: Error) => {
-          // TODO: revert optimistic effect (once optimistic effect is fixed)
+          cachedRecords.forEach((cachedRecord) => {
+            if (!cachedRecord) {
+              return;
+            }
+
+            updateRecordFromCache({
+              objectMetadataItems,
+              objectMetadataItem,
+              cache: apolloClient.cache,
+              record: cachedRecord,
+            });
+
+            const cachedRecordWithConnection =
+              getRecordNodeFromRecord<ObjectRecord>({
+                record: cachedRecord,
+                objectMetadataItem,
+                objectMetadataItems,
+                computeReferences: true,
+              });
+
+            const computedOptimisticRecord = {
+              ...cachedRecord,
+              ...{ id: cachedRecord.id, deletedAt: null },
+              ...{ __typename: capitalize(objectMetadataItem.nameSingular) },
+            };
+
+            const optimisticRecordWithConnection =
+              getRecordNodeFromRecord<ObjectRecord>({
+                record: computedOptimisticRecord,
+                objectMetadataItem,
+                objectMetadataItems,
+                computeReferences: true,
+              });
+
+            if (
+              !optimisticRecordWithConnection ||
+              !cachedRecordWithConnection
+            ) {
+              return null;
+            }
+
+            triggerUpdateRecordOptimisticEffect({
+              cache: apolloClient.cache,
+              objectMetadataItem,
+              currentRecord: optimisticRecordWithConnection,
+              updatedRecord: cachedRecordWithConnection,
+              objectMetadataItems,
+            });
+          });
+
           throw error;
         });
 

--- a/packages/twenty-front/src/modules/object-record/record-filter/utils/isRecordMatchingFilter.ts
+++ b/packages/twenty-front/src/modules/object-record/record-filter/utils/isRecordMatchingFilter.ts
@@ -128,7 +128,7 @@ export const isRecordMatchingFilter = ({
   }
 
   if (isLeafFilter(filter)) {
-    if (record.deletedAt !== null && filter.deletedAt === undefined) {
+    if (isDefined(record.deletedAt) && filter.deletedAt === undefined) {
       return false;
     }
   }

--- a/packages/twenty-front/src/modules/object-record/record-filter/utils/isRecordMatchingFilter.ts
+++ b/packages/twenty-front/src/modules/object-record/record-filter/utils/isRecordMatchingFilter.ts
@@ -11,6 +11,7 @@ import {
   EmailsFilter,
   FloatFilter,
   FullNameFilter,
+  LeafObjectRecordFilter,
   LinksFilter,
   NotObjectRecordFilter,
   OrObjectRecordFilter,
@@ -28,6 +29,12 @@ import { isMatchingUUIDFilter } from '@/object-record/record-filter/utils/isMatc
 import { FieldMetadataType } from '~/generated-metadata/graphql';
 import { isDefined } from '~/utils/isDefined';
 import { isEmptyObject } from '~/utils/isEmptyObject';
+
+const isLeafFilter = (
+  filter: RecordGqlOperationFilter,
+): filter is LeafObjectRecordFilter => {
+  return !isAndFilter(filter) && !isOrFilter(filter) && !isNotFilter(filter);
+};
 
 const isAndFilter = (
   filter: RecordGqlOperationFilter,
@@ -50,7 +57,7 @@ export const isRecordMatchingFilter = ({
   filter: RecordGqlOperationFilter;
   objectMetadataItem: ObjectMetadataItem;
 }): boolean => {
-  if (Object.keys(filter).length === 0) {
+  if (Object.keys(filter).length === 0 && record.deletedAt === null) {
     return true;
   }
 
@@ -118,6 +125,12 @@ export const isRecordMatchingFilter = ({
         objectMetadataItem,
       })
     );
+  }
+
+  if (isLeafFilter(filter)) {
+    if (record.deletedAt !== null && filter.deletedAt === undefined) {
+      return false;
+    }
   }
 
   return Object.entries(filter).every(([filterKey, filterValue]) => {

--- a/packages/twenty-front/src/modules/object-record/record-index/options/hooks/useDeleteTableData.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/options/hooks/useDeleteTableData.ts
@@ -1,11 +1,7 @@
 import { useFavorites } from '@/favorites/hooks/useFavorites';
 import { useDeleteManyRecords } from '@/object-record/hooks/useDeleteManyRecords';
-import { useFetchAllRecordIds } from '@/object-record/hooks/useFetchAllRecordIds';
 import { UseTableDataOptions } from '@/object-record/record-index/options/hooks/useTableData';
 import { useRecordTable } from '@/object-record/record-table/hooks/useRecordTable';
-import { tableRowIdsComponentState } from '@/object-record/record-table/states/tableRowIdsComponentState';
-import { getScopeIdFromComponentId } from '@/ui/utilities/recoil-scope/utils/getScopeIdFromComponentId';
-import { useRecoilValue } from 'recoil';
 
 type UseDeleteTableDataOptions = Pick<
   UseTableDataOptions,
@@ -16,20 +12,9 @@ export const useDeleteTableData = ({
   objectNameSingular,
   recordIndexId,
 }: UseDeleteTableDataOptions) => {
-  const { fetchAllRecordIds } = useFetchAllRecordIds({
-    objectNameSingular,
+  const { resetTableRowSelection } = useRecordTable({
+    recordTableId: recordIndexId,
   });
-
-  const { resetTableRowSelection, hasUserSelectedAllRowsState } =
-    useRecordTable({
-      recordTableId: recordIndexId,
-    });
-
-  const tableRowIds = useRecoilValue(
-    tableRowIdsComponentState({
-      scopeId: getScopeIdFromComponentId(recordIndexId),
-    }),
-  );
 
   const { deleteManyRecords } = useDeleteManyRecords({
     objectNameSingular,

--- a/packages/twenty-front/src/modules/object-record/record-index/options/hooks/useDeleteTableData.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/options/hooks/useDeleteTableData.ts
@@ -36,21 +36,7 @@ export const useDeleteTableData = ({
   });
   const { favorites, deleteFavorite } = useFavorites();
 
-  const hasUserSelectedAllRows = useRecoilValue(hasUserSelectedAllRowsState);
-
   const deleteRecords = async (recordIdsToDelete: string[]) => {
-    if (hasUserSelectedAllRows) {
-      const allRecordIds = await fetchAllRecordIds();
-
-      const unselectedRecordIds = tableRowIds.filter(
-        (recordId) => !recordIdsToDelete.includes(recordId),
-      );
-
-      recordIdsToDelete = allRecordIds.filter(
-        (recordId) => !unselectedRecordIds.includes(recordId),
-      );
-    }
-
     resetTableRowSelection();
 
     for (const recordIdToDelete of recordIdsToDelete) {

--- a/packages/twenty-front/src/modules/ui/layout/show-page/components/ShowPageMoreButton.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/show-page/components/ShowPageMoreButton.tsx
@@ -11,7 +11,7 @@ import { useDropdown } from '@/ui/layout/dropdown/hooks/useDropdown';
 import { MenuItem } from '@/ui/navigation/menu-item/components/MenuItem';
 import { navigationMemorizedUrlState } from '@/ui/navigation/states/navigationMemorizedUrlState';
 
-import { useDestroyManyRecords } from '@/object-record/hooks/useDestroyManyRecords';
+import { useDestroyOneRecord } from '@/object-record/hooks/useDestroyOneRecord';
 import { useRestoreManyRecords } from '@/object-record/hooks/useRestoreManyRecords';
 import { recordStoreFamilyState } from '@/object-record/record-store/states/recordStoreFamilyState';
 import { Dropdown } from '../../dropdown/components/Dropdown';
@@ -35,7 +35,7 @@ export const ShowPageMoreButton = ({
   const { deleteOneRecord } = useDeleteOneRecord({
     objectNameSingular,
   });
-  const { destroyManyRecords } = useDestroyManyRecords({
+  const { destroyOneRecord } = useDestroyOneRecord({
     objectNameSingular,
   });
   const { restoreManyRecords } = useRestoreManyRecords({
@@ -48,7 +48,7 @@ export const ShowPageMoreButton = ({
   };
 
   const handleDestroy = () => {
-    destroyManyRecords([recordId]);
+    destroyOneRecord(recordId);
     closeDropdown();
     navigate(navigationMemorizedUrl, { replace: true });
   };

--- a/packages/twenty-front/src/modules/views/hooks/internal/usePersistViewFilterRecords.ts
+++ b/packages/twenty-front/src/modules/views/hooks/internal/usePersistViewFilterRecords.ts
@@ -134,7 +134,7 @@ export const usePersistViewFilterRecords = () => {
               idToDestroy: viewFilterId,
             },
             update: (cache, { data }) => {
-              const record = data?.['deleteViewFilter'];
+              const record = data?.['destroyViewFilter'];
 
               if (!record) return;
 
@@ -145,7 +145,7 @@ export const usePersistViewFilterRecords = () => {
               triggerDestroyRecordsOptimisticEffect({
                 cache,
                 objectMetadataItem,
-                recordsToDelete: [cachedRecord],
+                recordsToDestroy: [cachedRecord],
                 objectMetadataItems,
               });
             },

--- a/packages/twenty-front/src/modules/views/hooks/internal/usePersistViewFilterRecords.ts
+++ b/packages/twenty-front/src/modules/views/hooks/internal/usePersistViewFilterRecords.ts
@@ -1,15 +1,15 @@
-import { useCallback } from 'react';
 import { useApolloClient } from '@apollo/client';
+import { useCallback } from 'react';
 
 import { triggerCreateRecordsOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerCreateRecordsOptimisticEffect';
-import { triggerDeleteRecordsOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerDeleteRecordsOptimisticEffect';
+import { triggerDestroyRecordsOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerDestroyRecordsOptimisticEffect';
 import { triggerUpdateRecordOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerUpdateRecordOptimisticEffect';
 import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
 import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
 import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
 import { useGetRecordFromCache } from '@/object-record/cache/hooks/useGetRecordFromCache';
 import { useCreateOneRecordMutation } from '@/object-record/hooks/useCreateOneRecordMutation';
-import { useDeleteOneRecordMutation } from '@/object-record/hooks/useDeleteOneRecordMutation';
+import { useDestroyOneRecordMutation } from '@/object-record/hooks/useDestroyOneRecordMutation';
 import { useUpdateOneRecordMutation } from '@/object-record/hooks/useUpdateOneRecordMutation';
 import { ObjectRecord } from '@/object-record/types/ObjectRecord';
 import { GraphQLView } from '@/views/types/GraphQLView';
@@ -24,7 +24,7 @@ export const usePersistViewFilterRecords = () => {
     objectNameSingular: CoreObjectNameSingular.ViewFilter,
   });
 
-  const { deleteOneRecordMutation } = useDeleteOneRecordMutation({
+  const { destroyOneRecordMutation } = useDestroyOneRecordMutation({
     objectNameSingular: CoreObjectNameSingular.ViewFilter,
   });
 
@@ -129,9 +129,9 @@ export const usePersistViewFilterRecords = () => {
       return Promise.all(
         viewFilterIdsToDelete.map((viewFilterId) =>
           apolloClient.mutate({
-            mutation: deleteOneRecordMutation,
+            mutation: destroyOneRecordMutation,
             variables: {
-              idToDelete: viewFilterId,
+              idToDestroy: viewFilterId,
             },
             update: (cache, { data }) => {
               const record = data?.['deleteViewFilter'];
@@ -142,7 +142,7 @@ export const usePersistViewFilterRecords = () => {
 
               if (!cachedRecord) return;
 
-              triggerDeleteRecordsOptimisticEffect({
+              triggerDestroyRecordsOptimisticEffect({
                 cache,
                 objectMetadataItem,
                 recordsToDelete: [cachedRecord],
@@ -155,7 +155,7 @@ export const usePersistViewFilterRecords = () => {
     },
     [
       apolloClient,
-      deleteOneRecordMutation,
+      destroyOneRecordMutation,
       getRecordFromCache,
       objectMetadataItem,
       objectMetadataItems,

--- a/packages/twenty-front/src/modules/views/hooks/internal/usePersistViewSortRecords.ts
+++ b/packages/twenty-front/src/modules/views/hooks/internal/usePersistViewSortRecords.ts
@@ -1,15 +1,15 @@
-import { useCallback } from 'react';
 import { useApolloClient } from '@apollo/client';
+import { useCallback } from 'react';
 
 import { triggerCreateRecordsOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerCreateRecordsOptimisticEffect';
-import { triggerDeleteRecordsOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerDeleteRecordsOptimisticEffect';
+import { triggerDestroyRecordsOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerDestroyRecordsOptimisticEffect';
 import { triggerUpdateRecordOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerUpdateRecordOptimisticEffect';
 import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
 import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
 import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
 import { useGetRecordFromCache } from '@/object-record/cache/hooks/useGetRecordFromCache';
 import { useCreateOneRecordMutation } from '@/object-record/hooks/useCreateOneRecordMutation';
-import { useDeleteOneRecordMutation } from '@/object-record/hooks/useDeleteOneRecordMutation';
+import { useDestroyOneRecordMutation } from '@/object-record/hooks/useDestroyOneRecordMutation';
 import { useUpdateOneRecordMutation } from '@/object-record/hooks/useUpdateOneRecordMutation';
 import { ObjectRecord } from '@/object-record/types/ObjectRecord';
 import { GraphQLView } from '@/views/types/GraphQLView';
@@ -24,7 +24,7 @@ export const usePersistViewSortRecords = () => {
     objectNameSingular: CoreObjectNameSingular.ViewSort,
   });
 
-  const { deleteOneRecordMutation } = useDeleteOneRecordMutation({
+  const { destroyOneRecordMutation } = useDestroyOneRecordMutation({
     objectNameSingular: CoreObjectNameSingular.ViewSort,
   });
 
@@ -124,9 +124,9 @@ export const usePersistViewSortRecords = () => {
       return Promise.all(
         viewSortIdsToDelete.map((viewSortId) =>
           apolloClient.mutate({
-            mutation: deleteOneRecordMutation,
+            mutation: destroyOneRecordMutation,
             variables: {
-              idToDelete: viewSortId,
+              idToDestroy: viewSortId,
             },
             update: (cache, { data }) => {
               const record = data?.['deleteViewSort'];
@@ -137,7 +137,7 @@ export const usePersistViewSortRecords = () => {
 
               if (!cachedRecord) return;
 
-              triggerDeleteRecordsOptimisticEffect({
+              triggerDestroyRecordsOptimisticEffect({
                 cache,
                 objectMetadataItem,
                 recordsToDelete: [cachedRecord],
@@ -150,7 +150,7 @@ export const usePersistViewSortRecords = () => {
     },
     [
       apolloClient,
-      deleteOneRecordMutation,
+      destroyOneRecordMutation,
       getRecordFromCache,
       objectMetadataItem,
       objectMetadataItems,

--- a/packages/twenty-front/src/modules/views/hooks/internal/usePersistViewSortRecords.ts
+++ b/packages/twenty-front/src/modules/views/hooks/internal/usePersistViewSortRecords.ts
@@ -129,7 +129,7 @@ export const usePersistViewSortRecords = () => {
               idToDestroy: viewSortId,
             },
             update: (cache, { data }) => {
-              const record = data?.['deleteViewSort'];
+              const record = data?.['destroyViewSort'];
 
               if (!record) return;
 
@@ -140,7 +140,7 @@ export const usePersistViewSortRecords = () => {
               triggerDestroyRecordsOptimisticEffect({
                 cache,
                 objectMetadataItem,
-                recordsToDelete: [cachedRecord],
+                recordsToDestroy: [cachedRecord],
                 objectMetadataItems,
               });
             },

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-filter/graphql-query-filter-field.parser.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-filter/graphql-query-filter-field.parser.ts
@@ -82,62 +82,62 @@ export class GraphqlQueryFilterFieldParser {
     switch (operator) {
       case 'eq':
         return {
-          sql: `${objectNameSingular}.${key} = :${key}${uuid}`,
+          sql: `"${objectNameSingular}"."${key}" = :${key}${uuid}`,
           params: { [`${key}${uuid}`]: value },
         };
       case 'neq':
         return {
-          sql: `${objectNameSingular}.${key} != :${key}${uuid}`,
+          sql: `"${objectNameSingular}"."${key}" != :${key}${uuid}`,
           params: { [`${key}${uuid}`]: value },
         };
       case 'gt':
         return {
-          sql: `${objectNameSingular}.${key} > :${key}${uuid}`,
+          sql: `"${objectNameSingular}"."${key}" > :${key}${uuid}`,
           params: { [`${key}${uuid}`]: value },
         };
       case 'gte':
         return {
-          sql: `${objectNameSingular}.${key} >= :${key}${uuid}`,
+          sql: `"${objectNameSingular}"."${key}" >= :${key}${uuid}`,
           params: { [`${key}${uuid}`]: value },
         };
       case 'lt':
         return {
-          sql: `${objectNameSingular}.${key} < :${key}${uuid}`,
+          sql: `"${objectNameSingular}".${key} < :${key}${uuid}`,
           params: { [`${key}${uuid}`]: value },
         };
       case 'lte':
         return {
-          sql: `${objectNameSingular}.${key} <= :${key}${uuid}`,
+          sql: `"${objectNameSingular}"."${key}" <= :${key}${uuid}`,
           params: { [`${key}${uuid}`]: value },
         };
       case 'in':
         return {
-          sql: `${objectNameSingular}.${key} IN (:...${key}${uuid})`,
+          sql: `"${objectNameSingular}"."${key}" IN (:...${key}${uuid})`,
           params: { [`${key}${uuid}`]: value },
         };
       case 'is':
         return {
-          sql: `${objectNameSingular}.${key} IS ${value === 'NULL' ? 'NULL' : 'NOT NULL'}`,
+          sql: `"${objectNameSingular}"."${key}" IS ${value === 'NULL' ? 'NULL' : 'NOT NULL'}`,
           params: {},
         };
       case 'like':
         return {
-          sql: `${objectNameSingular}.${key} LIKE :${key}${uuid}`,
+          sql: `"${objectNameSingular}"."${key}" LIKE :${key}${uuid}`,
           params: { [`${key}${uuid}`]: `${value}` },
         };
       case 'ilike':
         return {
-          sql: `${objectNameSingular}.${key} ILIKE :${key}${uuid}`,
+          sql: `"${objectNameSingular}"."${key}" ILIKE :${key}${uuid}`,
           params: { [`${key}${uuid}`]: `${value}` },
         };
       case 'startsWith':
         return {
-          sql: `${objectNameSingular}.${key} LIKE :${key}${uuid}`,
+          sql: `"${objectNameSingular}"."${key}" LIKE :${key}${uuid}`,
           params: { [`${key}${uuid}`]: `${value}` },
         };
       case 'endsWith':
         return {
-          sql: `${objectNameSingular}.${key} LIKE :${key}${uuid}`,
+          sql: `"${objectNameSingular}"."${key}" LIKE :${key}${uuid}`,
           params: { [`${key}${uuid}`]: `${value}` },
         };
       default:

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-destroy-one-resolver.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-destroy-one-resolver.service.ts
@@ -58,7 +58,7 @@ export class GraphqlQueryDestroyOneResolverService
     );
 
     const nonFormattedDeletedObjectRecords = await queryBuilder
-      .where({
+      .where(`"${objectMetadataMapItem.nameSingular}".id = :id`, {
         id: args.id,
       })
       .take(1)

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-update-many-resolver.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-update-many-resolver.service.ts
@@ -16,6 +16,7 @@ import { assertMutationNotOnRemoteObject } from 'src/engine/metadata-modules/obj
 import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.manager';
 import { formatData } from 'src/engine/twenty-orm/utils/format-data.util';
 import { formatResult } from 'src/engine/twenty-orm/utils/format-result.util';
+import { computeTableName } from 'src/engine/utils/compute-table-name.util';
 
 @Injectable()
 export class GraphqlQueryUpdateManyResolverService
@@ -57,9 +58,14 @@ export class GraphqlQueryUpdateManyResolverService
       objectMetadataMapItem.nameSingular,
     );
 
+    const tableName = computeTableName(
+      objectMetadataMapItem.nameSingular,
+      objectMetadataMapItem.isCustom,
+    );
+
     const withFilterQueryBuilder = graphqlQueryParser.applyFilterToBuilder(
       queryBuilder,
-      objectMetadataMapItem.nameSingular,
+      tableName,
       args.filter,
     );
 

--- a/packages/twenty-server/src/engine/core-modules/open-api/utils/parameters.utils.ts
+++ b/packages/twenty-server/src/engine/core-modules/open-api/utils/parameters.utils.ts
@@ -84,8 +84,7 @@ export const computeFilterParameters = (): OpenAPIV3_1.ParameterObject => {
     ).join('**, **')}**.  
     Default root conjunction is **${DEFAULT_CONJUNCTION}**.  
     To filter **null** values use **field[is]:NULL** or **field[is]:NOT_NULL**  
-    To filter using **boolean** values use **field[eq]:true** or **field[eq]:false**
-    `,
+    To filter using **boolean** values use **field[eq]:true** or **field[eq]:false**`,
 
     required: false,
     schema: {


### PR DESCRIPTION
In this PR, I'm fixing part of the impact of soft deletion on optimistic rendering.

## Backend Vision

1) Backend endpoints will not return soft deleted records (having deletedAt set) by default. To get the softDeleted records, we will pass a { withSoftDelete: true } additional param in the query.
2) Record relations will NEVER contain softDeleted relations

## Backend current state

Right now, we have the following behavior:
- if the query filters do not mention deletedAt, we don't return softDeletedRecords
- if the query filters mention deletedAt, we take it into consideration. Meaning that if we want to have the softDeleted records in any way we need to do { or: [ deletedAt: NULL, deletedAt: NOT_NULL] }

## Optimistic rendering strategy

1) useDestroyOne/Many is triggering destroyOptimisticEffects (previously deleteOptimisticEffects)
2) UseDeleteOne/Many and useRestoreOne/Many are actually triggering updateOptimisticEffects (as they only update deletedAt field) AND we need updateOptimisticEffects to take into account deletedAt (future withSoftDelete: true) filter.

