### PR TITLE
Update Attachment Table on RICH_TEXT Field Edits (#6565) 

### DIFF
--- a/packages/twenty-front/src/generated/graphql.tsx
+++ b/packages/twenty-front/src/generated/graphql.tsx
@@ -1301,6 +1301,21 @@ export type RelationEdge = {
   node: Relation;
 };
 
+export type AddAttachmentMutation = {
+  addAttachment: {
+    id: string;
+    fileName: string;
+    fileUrl: string;
+  };
+};
+
+export type AddAttachmentMutationVariables = {
+  fileId: string;
+  fileName: string;
+  fileUrl: string;
+};
+
+
 export type TimelineCalendarEventFragmentFragment = { __typename?: 'TimelineCalendarEvent', id: any, title: string, description: string, location: string, startsAt: string, endsAt: string, isFullDay: boolean, visibility: CalendarChannelVisibility, participants: Array<{ __typename?: 'TimelineCalendarEventParticipant', personId?: any | null, workspaceMemberId?: any | null, firstName: string, lastName: string, displayName: string, avatarUrl: string, handle: string }> };
 
 export type TimelineCalendarEventParticipantFragmentFragment = { __typename?: 'TimelineCalendarEventParticipant', personId?: any | null, workspaceMemberId?: any | null, firstName: string, lastName: string, displayName: string, avatarUrl: string, handle: string };
@@ -3341,3 +3356,30 @@ export function useGetWorkspaceFromInviteHashLazyQuery(baseOptions?: Apollo.Lazy
 export type GetWorkspaceFromInviteHashQueryHookResult = ReturnType<typeof useGetWorkspaceFromInviteHashQuery>;
 export type GetWorkspaceFromInviteHashLazyQueryHookResult = ReturnType<typeof useGetWorkspaceFromInviteHashLazyQuery>;
 export type GetWorkspaceFromInviteHashQueryResult = Apollo.QueryResult<GetWorkspaceFromInviteHashQuery, GetWorkspaceFromInviteHashQueryVariables>;
+
+export const AddAttachmentDocument = gql`
+  mutation AddAttachment($fileId: ID!, $fileName: String!, $fileUrl: String!) {
+    addAttachment(fileId: $fileId, fileName: $fileName, fileUrl: $fileUrl) {
+      id
+      fileName
+      fileUrl
+    }
+  }
+`;
+
+export function useAddAttachmentMutation(
+  baseOptions?: Apollo.MutationHookOptions<AddAttachmentMutation, AddAttachmentMutationVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<AddAttachmentMutation, AddAttachmentMutationVariables>(
+    AddAttachmentDocument,
+    options
+  );
+}
+
+export type AddAttachmentMutationHookResult = ReturnType<typeof useAddAttachmentMutation>;
+export type AddAttachmentMutationResult = Apollo.MutationResult<AddAttachmentMutation>;
+export type AddAttachmentMutationOptions = Apollo.BaseMutationOptions<
+  AddAttachmentMutation,
+  AddAttachmentMutationVariables
+>;

--- a/packages/twenty-front/src/modules/activities/components/RichTextEditor.tsx
+++ b/packages/twenty-front/src/modules/activities/components/RichTextEditor.tsx
@@ -138,10 +138,6 @@ export const RichTextEditor = ({
     });
     const uploadedFileData = result?.data?.uploadFile;
 
-  if (!uploadedFileData) {
-    throw new Error("Couldn't upload Image");
-  }
-
   if (!result?.data?.uploadFile) {
     throw new Error("Couldn't upload Image");
   }
@@ -151,7 +147,7 @@ export const RichTextEditor = ({
   // Step 2: Update attachment table with file metadata
   await addAttachmentMutation({
     variables: {
-      fileId: result.data.uploadFile, // Assuming file ID is returned from the upload
+      fileId: result.data.uploadFile.id, // Assuming file ID is returned from the upload
       fileName: file.name,
       fileUrl: uploadedFileUrl,
     },

--- a/packages/twenty-front/src/modules/attachments/graphql/queries/uploadFile.ts
+++ b/packages/twenty-front/src/modules/attachments/graphql/queries/uploadFile.ts
@@ -2,6 +2,19 @@ import { gql } from '@apollo/client';
 
 export const UPLOAD_FILE = gql`
   mutation uploadFile($file: Upload!, $fileFolder: FileFolder) {
-    uploadFile(file: $file, fileFolder: $fileFolder)
+    uploadFile(file: $file, fileFolder: $fileFolder){
+    id
+    url
+  }
+  }
+`;
+
+export const ADD_ATTACHMENT = gql`
+  mutation AddAttachment($fileId: ID!, $fileName: String!, $fileUrl: String!) {
+    addAttachment(fileId: $fileId, fileName: $fileName, fileUrl: $fileUrl) {
+      id
+      fileName
+      fileUrl
+    }
   }
 `;


### PR DESCRIPTION
i implements a feature that ensures the attachment table is updated whenever new images are added to a RICH_TEXT field. This enhancement improves the data consistency and integrity of our application's file management system, ensuring that all relevant attachments are correctly linked to their respective entries.

Changes Made:
Image Handling Logic :-
Modified the existing functionality for handling image uploads within the RICH_TEXT field.
Implemented a mechanism to detect when new images are added to the RICH_TEXT content.
Attachment Table Update :-
Added a function that updates the attachment table with the details of newly added images.
Each image upload will now trigger an insert operation in the attachment table, including fields such as fileId, fileName, and fileUrl.
Integration with GraphQL :--
Updated the relevant GraphQL mutations to support the addition of attachments in conjunction with RICH_TEXT field edits.
Ensured proper error handling and logging for failed uploads or attachment inserts.