### PR TITLE
Fix lessThan operator not applying column case

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-filter/graphql-query-filter-field.parser.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-filter/graphql-query-filter-field.parser.ts
@@ -1,4 +1,4 @@
-import { ObjectLiteral, WhereExpressionBuilder } from 'typeorm';
+import { WhereExpressionBuilder } from 'typeorm';
 
 import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
 
@@ -6,16 +6,12 @@ import {
   GraphqlQueryRunnerException,
   GraphqlQueryRunnerExceptionCode,
 } from 'src/engine/api/graphql/graphql-query-runner/errors/graphql-query-runner.exception';
+import { computeWhereConditionParts } from 'src/engine/api/graphql/graphql-query-runner/utils/compute-where-condition-parts';
 import { compositeTypeDefinitions } from 'src/engine/metadata-modules/field-metadata/composite-types';
 import { isCompositeFieldMetadataType } from 'src/engine/metadata-modules/field-metadata/utils/is-composite-field-metadata-type.util';
 import { FieldMetadataMap } from 'src/engine/metadata-modules/utils/generate-object-metadata-map.util';
 import { CompositeFieldMetadataType } from 'src/engine/metadata-modules/workspace-migration/factories/composite-column-action.factory';
 import { capitalize } from 'src/utils/capitalize';
-
-type WhereConditionParts = {
-  sql: string;
-  params: ObjectLiteral;
-};
 
 export class GraphqlQueryFilterFieldParser {
   private fieldMetadataMap: FieldMetadataMap;
@@ -57,7 +53,7 @@ export class GraphqlQueryFilterFieldParser {
       }
     }
 
-    const { sql, params } = this.computeWhereConditionParts(
+    const { sql, params } = computeWhereConditionParts(
       operator,
       objectNameSingular,
       key,
@@ -68,83 +64,6 @@ export class GraphqlQueryFilterFieldParser {
       queryBuilder.where(sql, params);
     } else {
       queryBuilder.andWhere(sql, params);
-    }
-  }
-
-  private computeWhereConditionParts(
-    operator: string,
-    objectNameSingular: string,
-    key: string,
-    value: any,
-  ): WhereConditionParts {
-    const uuid = Math.random().toString(36).slice(2, 7);
-
-    switch (operator) {
-      case 'eq':
-        return {
-          sql: `"${objectNameSingular}"."${key}" = :${key}${uuid}`,
-          params: { [`${key}${uuid}`]: value },
-        };
-      case 'neq':
-        return {
-          sql: `"${objectNameSingular}"."${key}" != :${key}${uuid}`,
-          params: { [`${key}${uuid}`]: value },
-        };
-      case 'gt':
-        return {
-          sql: `"${objectNameSingular}"."${key}" > :${key}${uuid}`,
-          params: { [`${key}${uuid}`]: value },
-        };
-      case 'gte':
-        return {
-          sql: `"${objectNameSingular}"."${key}" >= :${key}${uuid}`,
-          params: { [`${key}${uuid}`]: value },
-        };
-      case 'lt':
-        return {
-          sql: `"${objectNameSingular}".${key} < :${key}${uuid}`,
-          params: { [`${key}${uuid}`]: value },
-        };
-      case 'lte':
-        return {
-          sql: `"${objectNameSingular}"."${key}" <= :${key}${uuid}`,
-          params: { [`${key}${uuid}`]: value },
-        };
-      case 'in':
-        return {
-          sql: `"${objectNameSingular}"."${key}" IN (:...${key}${uuid})`,
-          params: { [`${key}${uuid}`]: value },
-        };
-      case 'is':
-        return {
-          sql: `"${objectNameSingular}"."${key}" IS ${value === 'NULL' ? 'NULL' : 'NOT NULL'}`,
-          params: {},
-        };
-      case 'like':
-        return {
-          sql: `"${objectNameSingular}"."${key}" LIKE :${key}${uuid}`,
-          params: { [`${key}${uuid}`]: `${value}` },
-        };
-      case 'ilike':
-        return {
-          sql: `"${objectNameSingular}"."${key}" ILIKE :${key}${uuid}`,
-          params: { [`${key}${uuid}`]: `${value}` },
-        };
-      case 'startsWith':
-        return {
-          sql: `"${objectNameSingular}"."${key}" LIKE :${key}${uuid}`,
-          params: { [`${key}${uuid}`]: `${value}` },
-        };
-      case 'endsWith':
-        return {
-          sql: `"${objectNameSingular}"."${key}" LIKE :${key}${uuid}`,
-          params: { [`${key}${uuid}`]: `${value}` },
-        };
-      default:
-        throw new GraphqlQueryRunnerException(
-          `Operator "${operator}" is not supported`,
-          GraphqlQueryRunnerExceptionCode.UNSUPPORTED_OPERATOR,
-        );
     }
   }
 
@@ -182,7 +101,7 @@ export class GraphqlQueryFilterFieldParser {
         subFieldFilter as Record<string, any>,
       );
 
-      const { sql, params } = this.computeWhereConditionParts(
+      const { sql, params } = computeWhereConditionParts(
         operator,
         objectNameSingular,
         fullFieldName,

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/utils/compute-where-condition-parts.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/utils/compute-where-condition-parts.ts
@@ -1,0 +1,88 @@
+import { ObjectLiteral } from 'typeorm';
+
+import {
+  GraphqlQueryRunnerException,
+  GraphqlQueryRunnerExceptionCode,
+} from 'src/engine/api/graphql/graphql-query-runner/errors/graphql-query-runner.exception';
+
+type WhereConditionParts = {
+  sql: string;
+  params: ObjectLiteral;
+};
+
+export const computeWhereConditionParts = (
+  operator: string,
+  objectNameSingular: string,
+  key: string,
+  value: any,
+): WhereConditionParts => {
+  const uuid = Math.random().toString(36).slice(2, 7);
+
+  switch (operator) {
+    case 'eq':
+      return {
+        sql: `"${objectNameSingular}"."${key}" = :${key}${uuid}`,
+        params: { [`${key}${uuid}`]: value },
+      };
+    case 'neq':
+      return {
+        sql: `"${objectNameSingular}"."${key}" != :${key}${uuid}`,
+        params: { [`${key}${uuid}`]: value },
+      };
+    case 'gt':
+      return {
+        sql: `"${objectNameSingular}"."${key}" > :${key}${uuid}`,
+        params: { [`${key}${uuid}`]: value },
+      };
+    case 'gte':
+      return {
+        sql: `"${objectNameSingular}"."${key}" >= :${key}${uuid}`,
+        params: { [`${key}${uuid}`]: value },
+      };
+    case 'lt':
+      return {
+        sql: `"${objectNameSingular}"."${key}" < :${key}${uuid}`,
+        params: { [`${key}${uuid}`]: value },
+      };
+    case 'lte':
+      return {
+        sql: `"${objectNameSingular}"."${key}" <= :${key}${uuid}`,
+        params: { [`${key}${uuid}`]: value },
+      };
+    case 'in':
+      return {
+        sql: `"${objectNameSingular}"."${key}" IN (:...${key}${uuid})`,
+        params: { [`${key}${uuid}`]: value },
+      };
+    case 'is':
+      return {
+        sql: `"${objectNameSingular}"."${key}" IS ${value === 'NULL' ? 'NULL' : 'NOT NULL'}`,
+        params: {},
+      };
+    case 'like':
+      return {
+        sql: `"${objectNameSingular}"."${key}" LIKE :${key}${uuid}`,
+        params: { [`${key}${uuid}`]: `${value}` },
+      };
+    case 'ilike':
+      return {
+        sql: `"${objectNameSingular}"."${key}" ILIKE :${key}${uuid}`,
+        params: { [`${key}${uuid}`]: `${value}` },
+      };
+    case 'startsWith':
+      return {
+        sql: `"${objectNameSingular}"."${key}" LIKE :${key}${uuid}`,
+        params: { [`${key}${uuid}`]: `${value}` },
+      };
+    case 'endsWith':
+      return {
+        sql: `"${objectNameSingular}"."${key}" LIKE :${key}${uuid}`,
+        params: { [`${key}${uuid}`]: `${value}` },
+      };
+    default:
+      throw new GraphqlQueryRunnerException(
+        `Operator "${operator}" is not supported`,
+        GraphqlQueryRunnerExceptionCode.UNSUPPORTED_OPERATOR,
+      );
+  }
+};


### PR DESCRIPTION
Our postgres column naming convention is camelCase ; this forces SQL queries to wrap column names with double quotes.

We previously forgot the quotes in a filter parsing case