### PR TITLE
Allow use of `paru` in addition to `yay` as aur helper

### DIFF
--- a/packages/twenty-postgres/linux/provision-postgres-linux.sh
+++ b/packages/twenty-postgres/linux/provision-postgres-linux.sh
@@ -98,7 +98,7 @@ elif [ "$PACKAGE_MANAGER" = "pacman" ]; then
     sudo pacman -S postgresql postgresql-libs curl --noconfirm || handle_error "Failed to install PostgreSQL or curl."
 
     echo_header $GREEN "Step [2/4]: Installing GraphQL for PostgreSQL on Arch..."
-    if ! yay -S --noconfirm pg_graphql; then
+    if ! yay -S --noconfirm pg_graphql && ! paru -S --noconfirm pg_graphql; then
         handle_error "Failed to install pg_graphql package from AUR."
     fi
 


### PR DESCRIPTION
Hello Twenty Team,

If this is not an appropriate PR, please feel to close it. I am hoping to make larger contributions down the road. 

I was getting twenty setup locally, and I had a problem with the install script. I noticed that `yay` was named as an AUR helper, but `paru` was not. I use [paru](https://github.com/Morganamilo/paru), and this caused the setup script to fail.

I made a small change in the if statement that checks if `pg-graphql` can be installed with `yay`. I included a check for `paru` on the same line.

Thanks everyone who has made this project what it is.