### PR TITLE
Added oss-gg hackathon issue opening template

### DIFF
--- a/.github/ISSUE_TEMPLATE/oss-gg-hack-submission.yml
+++ b/.github/ISSUE_TEMPLATE/oss-gg-hack-submission.yml
@@ -1,0 +1,33 @@
+name: oss.gg hack submission 🕹️
+description: "Submit your contribution for the for the oss.gg hackathon"
+title: "[🕹️]"
+labels: 🕹️ oss.gg, player submission, hacktoberfest
+assignees: []
+body:
+  - type: textarea
+    id: contribution-name
+    attributes:
+      label: What side quest or challenge are you solving?
+      description: Add the name of the side quest or challenge.
+    validations:
+      required: true
+  - type: textarea
+    id: points
+    attributes:
+      label: Points
+      description: How many points are assigned to this contribution?
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What's the task your performed?
+    validations:
+  - type: textarea
+    id: proof
+    attributes:
+      label: Provide proof that you've completed the task
+      description: Screenshots, loom recordings, links to the content you shared or interacted with.
+    validations:
+      required: true


### PR DESCRIPTION
## Added [oss.gg](https://oss.gg/) hackathon issue opening template 

### This is issue template is consistent in other oss-gg participating repos. So this helps the participant to open the issue with proof of work and makes it easy for the maintainer to award points on the simple side quests.

### If any changes needed lmk

### {can I get some Brownie Point for this template addition}?

### Thank You :slightly_smiling_face: 

#### DEMO
![image](https://github.com/user-attachments/assets/864b2c9e-c147-4e67-bdd7-e90eb481ba44)
![image](https://github.com/user-attachments/assets/799edbab-0039-435d-8608-1a809ddb7533)
