### PR TITLE
Fix: Remove Deleted filter not reflecting issue

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-table/empty-state/components/RecordTableEmptyStateSoftDelete.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/empty-state/components/RecordTableEmptyStateSoftDelete.tsx
@@ -28,7 +28,7 @@ export const RecordTableEmptyStateSoftDelete = () => {
     deleteCombinedViewFilter(
       tableFilters.find(
         (filter) =>
-          filter.definition.label === 'Deleted at' &&
+          filter.definition.label === 'Deleted' &&
           filter.operand === 'isNotEmpty',
       )?.id ?? '',
     );


### PR DESCRIPTION
## PR Summary

This Pull request fixes #7626 

Adding Deleted filter from option will add filter label as "Deleted" in tableFiltersState, But on click of "Remove Deleted filter" "Deleted at" is used for finding tableFilter id, which results in tableFilter id as undefined.