### PR TITLE
Fix [#7601]: Add a helper for passwords during sign-up

### DIFF
--- a/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpForm.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpForm.tsx
@@ -47,6 +47,13 @@ const StyledInputContainer = styled.div`
   margin-bottom: ${({ theme }) => theme.spacing(3)};
 `;
 
+const StyledHelperText = styled.p`
+  color: ${({ theme }) => theme.color.red};
+  font-size: 0.85rem;
+  padding: 4px;
+  margin: 0;
+`;
+
 export const SignInUpForm = () => {
   const captchaProvider = useRecoilValue(captchaProviderState);
   const isRequestingCaptchaToken = useRecoilValue(
@@ -54,6 +61,7 @@ export const SignInUpForm = () => {
   );
   const [authProviders] = useRecoilState(authProvidersState);
   const [showErrors, setShowErrors] = useState(false);
+  const [password, setPassword] = useState<string | null>(null);
   const { signInWithGoogle } = useSignInWithGoogle();
   const { signInWithMicrosoft } = useSignInWithMicrosoft();
   const { form } = useSignInUpForm();
@@ -221,12 +229,18 @@ export const SignInUpForm = () => {
                         type="password"
                         placeholder="Password"
                         onBlur={onBlur}
-                        onChange={onChange}
+                        onChange={(text:string) => {
+                          onChange(text); 
+                          setPassword(text); 
+                        }}
                         error={showErrors ? error?.message : undefined}
                         fullWidth
                         disableHotkeys
                         onKeyDown={handleKeyDown}
                       />
+                       {password && password.length ! < 8 && !showErrors &&(
+                        <StyledHelperText>At least 8 characters long</StyledHelperText>
+                      )}
                     </StyledInputContainer>
                   )}
                 />

--- a/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpForm.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpForm.tsx
@@ -61,7 +61,7 @@ export const SignInUpForm = () => {
   );
   const [authProviders] = useRecoilState(authProvidersState);
   const [showErrors, setShowErrors] = useState(false);
-  const [password, setPassword] = useState<string | null>(null);
+  const [password, setPassword] = useState<string>('');
   const { signInWithGoogle } = useSignInWithGoogle();
   const { signInWithMicrosoft } = useSignInWithMicrosoft();
   const { form } = useSignInUpForm();


### PR DESCRIPTION
### PR Overview
This PR attempts to solve [Issue #7601](https://github.com/twentyhq/twenty/issues/7601).

### Key Changes and Reason for Change:
1. I have added the text in red color instead of what was suggested in the issue picture. This change was made because when the user types an incorrect password and clicks on "Sign In," the error handler triggers a message while the user is backspacing characters in the password field. The message indicates that the password must be at least 8 characters long (refer to Fig. 1).

### Figures:
- **Fig. 1:**  Password validation error message after signin clicked and password < 8 characters [Existing]
  ![Error message during backspacing](https://github.com/user-attachments/assets/395d8227-a0e7-4f8f-bc89-1d6c19af535a)


- **Fig. 2:** Password validation message before signin clicked[Added]
  ![Sign-in error message](https://github.com/user-attachments/assets/861fdd40-793f-4659-84a9-24082e4111b1)
