### PR TITLE
Fix DateTimeSettingsTimeZoneSelect

### DIFF
--- a/packages/twenty-front/src/pages/settings/profile/appearance/components/DateTimeSettingsTimeZoneSelect.tsx
+++ b/packages/twenty-front/src/pages/settings/profile/appearance/components/DateTimeSettingsTimeZoneSelect.tsx
@@ -2,6 +2,7 @@ import { detectTimeZone } from '@/localization/utils/detectTimeZone';
 import { findAvailableTimeZoneOption } from '@/localization/utils/findAvailableTimeZoneOption';
 import { AVAILABLE_TIMEZONE_OPTIONS } from '@/settings/accounts/constants/AvailableTimezoneOptions';
 import { Select } from '@/ui/input/components/Select';
+import { isDefined } from '~/utils/isDefined';
 
 type DateTimeSettingsTimeZoneSelectProps = {
   value?: string;
@@ -25,7 +26,9 @@ export const DateTimeSettingsTimeZoneSelect = ({
       value={value}
       options={[
         {
-          label: `System settings - ${systemTimeZoneOption.label}`,
+          label: isDefined(systemTimeZoneOption)
+            ? `System settings - ${systemTimeZoneOption.label}`
+            : 'System settings',
           value: 'system',
         },
         ...AVAILABLE_TIMEZONE_OPTIONS,


### PR DESCRIPTION
Fixing [sentry](https://twenty-v7.sentry.io/issues/5990711011/?alert_rule_id=15135099&alert_type=issue&notification_uuid=06fea945-1c24-4ee6-94f6-99f1d7f94010&project=4507072563183616&referrer=discord) _Cannot read properties of undefined (reading 'label')_