### PR TITLE
Fix unique index email people

### DIFF
--- a/packages/twenty-server/src/modules/person/standard-objects/person.workspace-entity.ts
+++ b/packages/twenty-server/src/modules/person/standard-objects/person.workspace-entity.ts
@@ -22,7 +22,6 @@ import { WorkspaceField } from 'src/engine/twenty-orm/decorators/workspace-field
 import { WorkspaceIsDeprecated } from 'src/engine/twenty-orm/decorators/workspace-is-deprecated.decorator';
 import { WorkspaceIsNullable } from 'src/engine/twenty-orm/decorators/workspace-is-nullable.decorator';
 import { WorkspaceIsSystem } from 'src/engine/twenty-orm/decorators/workspace-is-system.decorator';
-import { WorkspaceIsUnique } from 'src/engine/twenty-orm/decorators/workspace-is-unique.decorator';
 import { WorkspaceJoinColumn } from 'src/engine/twenty-orm/decorators/workspace-join-column.decorator';
 import { WorkspaceRelation } from 'src/engine/twenty-orm/decorators/workspace-relation.decorator';
 import { PERSON_STANDARD_FIELD_IDS } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-field-ids';
@@ -71,7 +70,10 @@ export class PersonWorkspaceEntity extends BaseWorkspaceEntity {
     description: 'Contact’s Emails',
     icon: 'IconMail',
   })
+  /*
+  TODO: add back once we handle TEXT Unique index properly
   @WorkspaceIsUnique()
+  */
   [EMAILS_FIELD_NAME]: EmailsMetadata;
 
   @WorkspaceField({


### PR DESCRIPTION
## Context
WorkspaceIsUnique decorator allows us to create unique indexes on our tables. Here Emails is a composite field containing a TEXT subfield. Due to the fact that TEXT fields are non-nullable and have empty strings as default values, adding a unique index on a TEXT field or any composite containing TEXT as subfields will fail and throw if we try to create more than 1 record that does not specify a value to the TEXT field.

This PR simply removes the index for the time being until we find a solution