### PR TITLE
issue #7712 suggested changes

### DIFF
--- a/packages/twenty-front/src/modules/localization/utils/formatTimeZoneLabel.ts
+++ b/packages/twenty-front/src/modules/localization/utils/formatTimeZoneLabel.ts
@@ -12,12 +12,13 @@ export const formatTimeZoneLabel = (ianaTimeZone: string) => {
     Date.now(),
     ianaTimeZone,
     `(OOOO) zzzz`,
-    { locale: defaultLocale },
-  );
+    { locale: defaultLocale }
+  ).toLowerCase().trim(); // normalize formatting here
+
   const ianaTimeZoneParts = ianaTimeZone.split('/');
   const location =
     ianaTimeZoneParts.length > 1
-      ? ianaTimeZoneParts.slice(-1)[0].replaceAll('_', ' ')
+      ? ianaTimeZoneParts.slice(-1)[0].replaceAll('_', ' ').toLowerCase().trim()
       : undefined;
 
   const timeZoneLabel =


### PR DESCRIPTION
The issue we were facing with findAvailableTimeZoneOption returning undefined could be because:

Mismatch between IANA time zone and label: The formatTimeZoneLabel function transforms the IANA time zone into a more human-readable format (e.g., (GMT+01:00) Central European Time - Paris). If the output of formatTimeZoneLabel(value) doesn't exactly match any keys in AVAILABLE_TIME_ZONE_OPTIONS_BY_LABEL, it will return undefined.