### PR TITLE
Update Relation Field Label 

### DIFF
--- a/packages/twenty-front/src/modules/settings/data-model/fields/forms/relation/components/SettingsDataModelFieldRelationForm.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/forms/relation/components/SettingsDataModelFieldRelationForm.tsx
@@ -15,6 +15,7 @@ import { IconPicker } from '@/ui/input/components/IconPicker';
 import { Select } from '@/ui/input/components/Select';
 import { TextInput } from '@/ui/input/components/TextInput';
 import { useIsMobile } from '@/ui/utilities/responsive/hooks/useIsMobile';
+import { useEffect, useState } from 'react';
 import { RelationDefinitionType } from '~/generated-metadata/graphql';
 
 export const settingsDataModelFieldRelationFormSchema = z.object({
@@ -94,9 +95,15 @@ export const SettingsDataModelFieldRelationForm = ({
     initialRelationType,
   } = useRelationSettingsFormInitialValues({ fieldMetadataItem });
 
-  const selectedObjectMetadataItem = findObjectMetadataItemById(
-    watchFormValue('relation.objectMetadataId'),
-  );
+  
+  const [selectedObjectMetadataItem, setSelectedObjectMetadataItem] =useState(initialRelationObjectMetadataItem);
+  const objectMetadataId = watchFormValue('relation.objectMetadataId');
+  useEffect(() => {
+    if (objectMetadataId !== undefined) {
+      setSelectedObjectMetadataItem(findObjectMetadataItemById(objectMetadataId));
+    }
+  }, [objectMetadataId]);
+  
 
   const isMobile = useIsMobile();
 
@@ -143,7 +150,7 @@ export const SettingsDataModelFieldRelationForm = ({
         />
       </StyledSelectsContainer>
       <StyledInputsLabel>
-        Field on {selectedObjectMetadataItem?.labelPlural}
+        Field on  {selectedObjectMetadataItem?.labelPlural || 'Select an object'}
       </StyledInputsLabel>
       <StyledInputsContainer>
         <Controller


### PR DESCRIPTION
This PR fixes an issue #7082  where the Field on Other Object Name label appears empty initially when creating a relation field on an object. The fix involves initializing the label with a default value or placeholder text and updating the UI to display the correct field name when the object relation switch is toggled.

Changes Made
1. Updated the UI to initialize the "Field on Other Object Name" label with a default value or placeholder text.
2. Added logic to update the label with the correct field name when the object relation switch is toggled.