### PR TITLE
[FIX] update documentation to install node version before corepack en…

### DIFF
--- a/packages/twenty-website/src/content/developers/local-setup.mdx
+++ b/packages/twenty-website/src/content/developers/local-setup.mdx
@@ -48,15 +48,28 @@ git config --global user.name "Your Name"
 git config --global user.email "youremail@domain.com"
 ```
 
-3. Install Node.js, nvm, yarn
+3. Install nvm, Node.js, yarn
+<ArticleWarning>
+
+Use `nvm` to install the correct `node` version. The `.nvmrc` ensures all contributors use the same version.
+
+</ArticleWarning>
+
 ```bash
 sudo apt-get install curl
 
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash
+```
+Close and reopen your terminal to use nvm. Then run the following commands.
+
+```bash
+
+nvm install # installs recommended node version
+
+nvm use # use recommended node version
 
 corepack enable
 ```
-Close and reopen your terminal to start using nvm. 
 
 </ArticleTab>
 </ArticleTabs>
@@ -105,7 +118,14 @@ You can access the database at [localhost:5432](localhost:5432), with user `twen
 
     <b>Option 2:</b> If you have docker installed:
     ```bash
-      make postgres-on-docker
+      docker run \
+        --name twenty_postgres \
+        -e POSTGRES_USER=postgres \
+        -e POSTGRES_PASSWORD=postgres \
+        -e POSTGRES_DB=default \
+        -v twenty_db_data:/var/lib/postgresql/data \
+        -p 5432:5432 \
+        twentycrm/twenty-postgres:latest
     ```
   </ArticleTab>
   <ArticleTab>
@@ -119,7 +139,14 @@ You can access the database at [localhost:5432](localhost:5432), with user `twen
 
     <b>Option 2:</b> If you have docker installed:
     ```bash
-      make postgres-on-docker
+      docker run \
+        --name twenty_postgres \
+        -e POSTGRES_USER=postgres \
+        -e POSTGRES_PASSWORD=postgres \
+        -e POSTGRES_DB=default \
+        -v twenty_db_data:/var/lib/postgresql/data \
+        -p 5432:5432 \
+        twentycrm/twenty-postgres:latest
     ```
   </ArticleTab>
   <ArticleTab>
@@ -135,7 +162,14 @@ You can access the database at [localhost:5432](localhost:5432), with user `twen
     Running Docker on WSL adds an extra layer of complexity.
     Only use this option if you are comfortable with the extra steps involved, including turning on [Docker Desktop WSL2](https://docs.docker.com/desktop/wsl).
     ```bash
-      make postgres-on-docker
+      docker run \
+        --name twenty_postgres \
+        -e POSTGRES_USER=postgres \
+        -e POSTGRES_PASSWORD=postgres \
+        -e POSTGRES_DB=default \
+        -v twenty_db_data:/var/lib/postgresql/data \
+        -p 5432:5432 \
+        twentycrm/twenty-postgres:latest
     ```
   </ArticleTab>
 </ArticleTabs>
@@ -150,7 +184,7 @@ Twenty requires a redis cache to provide the best performances
 
     <b>Option 2:</b> If you have docker installed:
     ```bash
-      make redis-on-docker
+    docker run -d --name my-redis-stack -p 6379:6379 redis/redis-stack-server:latest
     ```
   </ArticleTab>
   <ArticleTab>
@@ -161,7 +195,7 @@ Twenty requires a redis cache to provide the best performances
 
     <b>Option 2:</b> If you have docker installed:
     ```bash
-      make redis-on-docker
+    docker run -d --name my-redis-stack -p 6379:6379 redis/redis-stack-server:latest
     ```
   </ArticleTab>
   <ArticleTab>
@@ -170,7 +204,7 @@ Twenty requires a redis cache to provide the best performances
 
     <b>Option 2:</b> If you have docker installed:
     ```bash
-      make redis-on-docker
+    docker run -d --name my-redis-stack -p 6379:6379 redis/redis-stack-server:latest
     ```
   </ArticleTab>
 </ArticleTabs>
@@ -187,16 +221,8 @@ cp ./packages/twenty-server/.env.example ./packages/twenty-server/.env
 
 ## Step 6: Installing dependencies
 
-<ArticleWarning>
-
-Use `nvm` to install the correct `node` version. The `.nvmrc` ensures all contributors use the same version.
-
-</ArticleWarning>
-
-To build Twenty server and seed some data into your database, run the following commands:
+To build Twenty server and seed some data into your database, run the following command:
 ```bash
-nvm install # installs recommended node version
-nvm use # use recommended node version
 yarn
 ```
 

--- a/packages/twenty-website/src/content/developers/local-setup.mdx
+++ b/packages/twenty-website/src/content/developers/local-setup.mdx
@@ -48,7 +48,7 @@ git config --global user.name "Your Name"
 git config --global user.email "youremail@domain.com"
 ```
 
-3. Install nvm, Node.js, yarn
+3. Install nvm, node.js and yarn
 <ArticleWarning>
 
 Use `nvm` to install the correct `node` version. The `.nvmrc` ensures all contributors use the same version.
@@ -118,14 +118,7 @@ You can access the database at [localhost:5432](localhost:5432), with user `twen
 
     <b>Option 2:</b> If you have docker installed:
     ```bash
-      docker run \
-        --name twenty_postgres \
-        -e POSTGRES_USER=postgres \
-        -e POSTGRES_PASSWORD=postgres \
-        -e POSTGRES_DB=default \
-        -v twenty_db_data:/var/lib/postgresql/data \
-        -p 5432:5432 \
-        twentycrm/twenty-postgres:latest
+      make postgres-on-docker
     ```
   </ArticleTab>
   <ArticleTab>
@@ -139,14 +132,7 @@ You can access the database at [localhost:5432](localhost:5432), with user `twen
 
     <b>Option 2:</b> If you have docker installed:
     ```bash
-      docker run \
-        --name twenty_postgres \
-        -e POSTGRES_USER=postgres \
-        -e POSTGRES_PASSWORD=postgres \
-        -e POSTGRES_DB=default \
-        -v twenty_db_data:/var/lib/postgresql/data \
-        -p 5432:5432 \
-        twentycrm/twenty-postgres:latest
+      make postgres-on-docker
     ```
   </ArticleTab>
   <ArticleTab>
@@ -162,14 +148,7 @@ You can access the database at [localhost:5432](localhost:5432), with user `twen
     Running Docker on WSL adds an extra layer of complexity.
     Only use this option if you are comfortable with the extra steps involved, including turning on [Docker Desktop WSL2](https://docs.docker.com/desktop/wsl).
     ```bash
-      docker run \
-        --name twenty_postgres \
-        -e POSTGRES_USER=postgres \
-        -e POSTGRES_PASSWORD=postgres \
-        -e POSTGRES_DB=default \
-        -v twenty_db_data:/var/lib/postgresql/data \
-        -p 5432:5432 \
-        twentycrm/twenty-postgres:latest
+      make postgres-on-docker
     ```
   </ArticleTab>
 </ArticleTabs>
@@ -184,7 +163,7 @@ Twenty requires a redis cache to provide the best performances
 
     <b>Option 2:</b> If you have docker installed:
     ```bash
-    docker run -d --name my-redis-stack -p 6379:6379 redis/redis-stack-server:latest
+      make redis-on-docker
     ```
   </ArticleTab>
   <ArticleTab>
@@ -195,7 +174,7 @@ Twenty requires a redis cache to provide the best performances
 
     <b>Option 2:</b> If you have docker installed:
     ```bash
-    docker run -d --name my-redis-stack -p 6379:6379 redis/redis-stack-server:latest
+      make redis-on-docker
     ```
   </ArticleTab>
   <ArticleTab>
@@ -204,7 +183,7 @@ Twenty requires a redis cache to provide the best performances
 
     <b>Option 2:</b> If you have docker installed:
     ```bash
-    docker run -d --name my-redis-stack -p 6379:6379 redis/redis-stack-server:latest
+      make redis-on-docker
     ```
   </ArticleTab>
 </ArticleTabs>
@@ -220,7 +199,6 @@ cp ./packages/twenty-server/.env.example ./packages/twenty-server/.env
 ```
 
 ## Step 6: Installing dependencies
-
 To build Twenty server and seed some data into your database, run the following command:
 ```bash
 yarn


### PR DESCRIPTION
FIX #7696 

This correctly installs the recommended node version before enabling corepack.

![Screenshot 2024-10-14 142628](https://github.com/user-attachments/assets/00643a61-7c1e-4372-8880-f8a7d52a4f35)

Thanks!