### PR TITLE
fix(front): move "Add to favorites" btn to start of action menu

### DIFF
--- a/packages/twenty-front/src/modules/action-menu/actions/record-actions/components/SingleRecordActionMenuEntriesSetter.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-actions/components/SingleRecordActionMenuEntriesSetter.tsx
@@ -4,9 +4,9 @@ import { ManageFavoritesActionEffect } from '@/action-menu/actions/record-action
 
 export const SingleRecordActionMenuEntriesSetter = () => {
   const actionEffects = [
+    ManageFavoritesActionEffect,
     ExportRecordsActionEffect,
     DeleteRecordsActionEffect,
-    ManageFavoritesActionEffect,
   ];
   return (
     <>


### PR DESCRIPTION
### What does this PR do?

Moves the "Add to favourites" action button to the beginning of the action menu, thus moving the "Delete" button to its right edge. 

Fixes #7780.

<img width="1494" alt="image" src="https://github.com/user-attachments/assets/52498fce-278c-4f04-a5ce-26920f9ffd5a">
