### PR TITLE
Fix custom index creation missing indexFieldMetadatas

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/relation-metadata/relation-metadata.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/relation-metadata/relation-metadata.service.ts
@@ -149,7 +149,7 @@ export class RelationMetadataService extends TypeOrmQueryService<RelationMetadat
       );
     }
 
-    await this.indexMetadataService.createIndex(
+    await this.indexMetadataService.createIndexMetadata(
       relationMetadataInput.workspaceId,
       toObjectMetadata,
       [foreignKeyFieldMetadata, deletedFieldMetadata],

--- a/packages/twenty-server/src/engine/metadata-modules/search/search.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/search/search.service.ts
@@ -105,7 +105,7 @@ export class SearchService {
       ],
     );
 
-    await this.indexMetadataService.createIndex(
+    await this.indexMetadataService.createIndexMetadata(
       objectMetadataInput.workspaceId,
       createdObjectMetadata,
       [searchVectorFieldMetadata],
@@ -157,7 +157,7 @@ export class SearchService {
     );
 
     // index needs to be recreated as typeorm deletes then recreates searchVector column at alter
-    await this.indexMetadataService.createIndex(
+    await this.indexMetadataService.createIndexCreationMigration(
       workspaceId,
       objectMetadata,
       [existingSearchVectorFieldMetadata],


### PR DESCRIPTION
## Context
Regression on custom index creation where indexFieldMetadatas were not saved properly in the DB. This is because we recently changed save() to upsert() in the indexMetadataService and upsert does not handle nesting insert properly.
I'm suggesting another fix where we separate indexMetadata creation and index migration creation in 2 different functions. Since the goal was to be able to recreate the index after being deleted when we changed the tsvector expression and indexMetadata was actually not deleted, we didn't need to recreate that part (hence the upsert) and only needed to run a migration to create the actual index in the workspace schema.
I've updated the different services and now only call createIndexMigration when we update a search vector expression.

Note: this is also fixing the sync-metadata command when running on a workspace with a custom object (including the seeded workspace which has the 'rocket' custom object), failing due to the missing 'searchVector' indexFieldMetadata 