### PR TITLE
fix: redis url to not be optional anymore

### DIFF
--- a/packages/twenty-server/.env.example
+++ b/packages/twenty-server/.env.example
@@ -8,6 +8,8 @@ LOGIN_TOKEN_SECRET=replace_me_with_a_random_string_login
 REFRESH_TOKEN_SECRET=replace_me_with_a_random_string_refresh
 FILE_TOKEN_SECRET=replace_me_with_a_random_string_refresh
 SIGN_IN_PREFILLED=true
+REDIS_URL=redis://localhost:6379
+
 
 # ———————— Optional ————————
 # PORT=3000
@@ -50,7 +52,6 @@ SIGN_IN_PREFILLED=true
 # SENTRY_FRONT_DSN=https://xxx@xxx.ingest.sentry.io/xxx
 # LOG_LEVELS=error,warn
 # MESSAGE_QUEUE_TYPE=pg-boss
-# REDIS_URL=redis://localhost:6379
 # DEMO_WORKSPACE_IDS=REPLACE_ME_WITH_A_RANDOM_UUID
 # SERVER_URL=http://localhost:3000
 # WORKSPACE_INACTIVE_DAYS_BEFORE_NOTIFICATION=30


### PR DESCRIPTION
## Description

- `REDIS_URL` is required 

<img width="1903" alt="Redis Required" src="https://github.com/user-attachments/assets/5b53a4a6-29f4-4473-b7e4-52489f75204e">

---- 

- Closes #7849

- Might be related #7768

--- 

- Wasn't gracefully reseting database

``` 
   npx nx database:reset twenty-server
```


