### PR TITLE
Added "Select an option" as default none selector on Workflow Visualizer

### DIFF
--- a/packages/twenty-front/src/modules/workflow/components/WorkflowEditTriggerForm.tsx
+++ b/packages/twenty-front/src/modules/workflow/components/WorkflowEditTriggerForm.tsx
@@ -45,7 +45,7 @@ const StyledTriggerSettings = styled.div`
   row-gap: ${({ theme }) => theme.spacing(4)};
 `;
 
-const SELECT_AN_OPTION = {label:'Select an option',value:''};
+const SELECT_AN_OPTION = { label: 'Select an option', value: '' };
 
 type WorkflowEditTriggerFormProps =
   | {

--- a/packages/twenty-front/src/modules/workflow/components/WorkflowEditTriggerForm.tsx
+++ b/packages/twenty-front/src/modules/workflow/components/WorkflowEditTriggerForm.tsx
@@ -117,7 +117,7 @@ export const WorkflowEditTriggerForm = ({
           value={triggerEvent?.objectType}
           options={[SELECT_AN_OPTION, ...availableMetadata]}
           onChange={(updatedRecordType) => {
-            if (readonly === true || updatedRecordType == '') {
+            if (readonly === true || updatedRecordType === '') {
               return;
             }
 
@@ -147,7 +147,7 @@ export const WorkflowEditTriggerForm = ({
           options={[SELECT_AN_OPTION, ...OBJECT_EVENT_TRIGGERS]}
           disabled={readonly}
           onChange={(updatedEvent) => {
-            if (readonly === true || updatedEvent == '') {
+            if (readonly === true || updatedEvent === '') {
               return;
             }
 

--- a/packages/twenty-front/src/modules/workflow/components/WorkflowEditTriggerForm.tsx
+++ b/packages/twenty-front/src/modules/workflow/components/WorkflowEditTriggerForm.tsx
@@ -45,7 +45,7 @@ const StyledTriggerSettings = styled.div`
   row-gap: ${({ theme }) => theme.spacing(4)};
 `;
 
-const SELECT_AN_OPTION = {label: 'Select an option', value: ''};
+const SELECT_AN_OPTION = {label:'Select an option',value:''};
 
 type WorkflowEditTriggerFormProps =
   | {

--- a/packages/twenty-front/src/modules/workflow/components/WorkflowEditTriggerForm.tsx
+++ b/packages/twenty-front/src/modules/workflow/components/WorkflowEditTriggerForm.tsx
@@ -69,6 +69,7 @@ export const WorkflowEditTriggerForm = ({
   const triggerEvent = isDefined(trigger)
     ? splitWorkflowTriggerEventName(trigger.settings.eventName)
     : undefined;
+
   const availableMetadata: Array<SelectOption<string>> =
     activeObjectMetadataItems.map((item) => ({
       label: item.labelPlural,

--- a/packages/twenty-front/src/modules/workflow/components/WorkflowEditTriggerForm.tsx
+++ b/packages/twenty-front/src/modules/workflow/components/WorkflowEditTriggerForm.tsx
@@ -45,6 +45,8 @@ const StyledTriggerSettings = styled.div`
   row-gap: ${({ theme }) => theme.spacing(4)};
 `;
 
+const SELECT_AN_OPTION = {label: 'Select an option', value: ''};
+
 type WorkflowEditTriggerFormProps =
   | {
       trigger: WorkflowTrigger | undefined;
@@ -69,7 +71,6 @@ export const WorkflowEditTriggerForm = ({
   const triggerEvent = isDefined(trigger)
     ? splitWorkflowTriggerEventName(trigger.settings.eventName)
     : undefined;
-
   const availableMetadata: Array<SelectOption<string>> =
     activeObjectMetadataItems.map((item) => ({
       label: item.labelPlural,
@@ -114,9 +115,9 @@ export const WorkflowEditTriggerForm = ({
           fullWidth
           disabled={readonly}
           value={triggerEvent?.objectType}
-          options={availableMetadata}
+          options={[SELECT_AN_OPTION, ...availableMetadata]}
           onChange={(updatedRecordType) => {
-            if (readonly === true) {
+            if (readonly === true || updatedRecordType == '') {
               return;
             }
 
@@ -143,10 +144,10 @@ export const WorkflowEditTriggerForm = ({
           label="Event type"
           fullWidth
           value={triggerEvent?.event}
-          options={OBJECT_EVENT_TRIGGERS}
+          options={[SELECT_AN_OPTION, ...OBJECT_EVENT_TRIGGERS]}
           disabled={readonly}
           onChange={(updatedEvent) => {
-            if (readonly === true) {
+            if (readonly === true || updatedEvent == '') {
               return;
             }
 

--- a/packages/twenty-front/src/modules/workflow/components/WorkflowEditTriggerForm.tsx
+++ b/packages/twenty-front/src/modules/workflow/components/WorkflowEditTriggerForm.tsx
@@ -45,8 +45,6 @@ const StyledTriggerSettings = styled.div`
   row-gap: ${({ theme }) => theme.spacing(4)};
 `;
 
-const SELECT_AN_OPTION = { label: 'Select an option', value: '' };
-
 type WorkflowEditTriggerFormProps =
   | {
       trigger: WorkflowTrigger | undefined;
@@ -115,7 +113,8 @@ export const WorkflowEditTriggerForm = ({
           fullWidth
           disabled={readonly}
           value={triggerEvent?.objectType}
-          options={[SELECT_AN_OPTION, ...availableMetadata]}
+          emptyOption={{ label: 'Select an option', value: '' }}
+          options={availableMetadata}
           onChange={(updatedRecordType) => {
             if (readonly === true || updatedRecordType === '') {
               return;
@@ -144,7 +143,8 @@ export const WorkflowEditTriggerForm = ({
           label="Event type"
           fullWidth
           value={triggerEvent?.event}
-          options={[SELECT_AN_OPTION, ...OBJECT_EVENT_TRIGGERS]}
+          emptyOption={{ label: 'Select an option', value: '' }}
+          options={OBJECT_EVENT_TRIGGERS}
           disabled={readonly}
           onChange={(updatedEvent) => {
             if (readonly === true || updatedEvent === '') {

--- a/packages/twenty-front/src/modules/workflow/components/WorkflowEditTriggerForm.tsx
+++ b/packages/twenty-front/src/modules/workflow/components/WorkflowEditTriggerForm.tsx
@@ -116,7 +116,7 @@ export const WorkflowEditTriggerForm = ({
           emptyOption={{ label: 'Select an option', value: '' }}
           options={availableMetadata}
           onChange={(updatedRecordType) => {
-            if (readonly === true || updatedRecordType === '') {
+            if (readonly === true) {
               return;
             }
 
@@ -147,7 +147,7 @@ export const WorkflowEditTriggerForm = ({
           options={OBJECT_EVENT_TRIGGERS}
           disabled={readonly}
           onChange={(updatedEvent) => {
-            if (readonly === true || updatedEvent === '') {
+            if (readonly === true) {
               return;
             }
 


### PR DESCRIPTION
## What does this PR do?
Shows "Select an option" as a default selector on the select component for the trigger step in the workflow visualizer

Fixes #7432

<img width="1470" alt="Screenshot 2024-10-20 at 12 48 39 AM" src="https://github.com/user-attachments/assets/189c2a7a-8abd-4411-90b4-d0e1de487fd5">
<img width="1470" alt="Screenshot 2024-10-20 at 12 48 50 AM" src="https://github.com/user-attachments/assets/f451068c-0184-40cb-9cab-f139df400cc6">
