### PR TITLE
fix/updated useFindManyRecords for if messageChannels is null it returns null

### DIFF
--- a/packages/twenty-server/src/modules/messaging/common/query-hooks/message/can-access-message-thread.service.ts
+++ b/packages/twenty-server/src/modules/messaging/common/query-hooks/message/can-access-message-thread.service.ts
@@ -54,6 +54,7 @@ export class CanAccessMessageThreadService {
         'connectedAccount',
       );
 
+if(messageChannels.length===0) return []
     const connectedAccounts = await connectedAccountRepository.find({
       select: ['id'],
       where: {
@@ -65,7 +66,7 @@ export class CanAccessMessageThreadService {
     if (connectedAccounts.length > 0) {
       return;
     }
-
+  
     throw new ForbiddenException();
   }
 }


### PR DESCRIPTION
Fixed #7830

Include a check of `if(messageChannels.length===0) return []`
that if the messageChannels is coming as null then just return and don't perform any further operation, it will allow to go forward only if messageChannels.length>0