### PR TITLE
fix: date-picker flips in records cell even when there is enough space

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-body/components/RecordTableBodyDroppable.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-body/components/RecordTableBodyDroppable.tsx
@@ -8,7 +8,6 @@ import { v4 } from 'uuid';
 const StyledTbody = styled.tbody<{
   theme: Theme;
 }>`
-
   &.first-columns-sticky {
     td:nth-of-type(1) {
       position: sticky;

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-body/components/RecordTableBodyDroppable.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-body/components/RecordTableBodyDroppable.tsx
@@ -8,7 +8,6 @@ import { v4 } from 'uuid';
 const StyledTbody = styled.tbody<{
   theme: Theme;
 }>`
-  overflow: hidden;
 
   &.first-columns-sticky {
     td:nth-of-type(1) {


### PR DESCRIPTION
Fixes: #7897 

This PR fixes the flipping of the date-picker in the record's cell even if there is enough space below the table. 
I attached a screencast to show that it's working fine now. 

With this, it only flips when there is less space to accommodate the date-picker comp. Also, I tested this after adding lots of records to see if the scrolling behaviour is intact or not. And I found no issues, it's working as expected. 

[Screencast from 2024-10-21 13-39-42.webm](https://github.com/user-attachments/assets/615fac80-ae2e-4d26-8f94-55d7ee3f91c2)
