### PR TITLE
bug fix webhook response not sending data to tinybird

### DIFF
--- a/packages/twenty-front/src/modules/settings/developers/webhook/utils/__tests__/fetchGraphDataOrThrow.test.js
+++ b/packages/twenty-front/src/modules/settings/developers/webhook/utils/__tests__/fetchGraphDataOrThrow.test.js
@@ -7,6 +7,7 @@ global.fetch = jest.fn();
 describe('fetchGraphDataOrThrow', () => {
   const mockWebhookId = 'test-webhook-id';
   const mockWindowLength = '7D';
+  const mockTinybirdJwt = 'test-jwt';
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -27,6 +28,7 @@ describe('fetchGraphDataOrThrow', () => {
     const result = await fetchGraphDataOrThrow({
       webhookId: mockWebhookId,
       windowLength: mockWindowLength,
+      tinybirdJwt: mockTinybirdJwt,
     });
 
     expect(global.fetch).toHaveBeenCalledWith(
@@ -71,6 +73,7 @@ describe('fetchGraphDataOrThrow', () => {
       fetchGraphDataOrThrow({
         webhookId: mockWebhookId,
         windowLength: mockWindowLength,
+        tinybirdJwt: mockTinybirdJwt,
       }),
     ).rejects.toThrow('Something went wrong while fetching webhook usage');
   });
@@ -85,13 +88,14 @@ describe('fetchGraphDataOrThrow', () => {
     await fetchGraphDataOrThrow({
       webhookId: mockWebhookId,
       windowLength: '1D',
+      tinybirdJwt: mockTinybirdJwt,
     });
 
     expect(global.fetch).toHaveBeenCalledWith(
       expect.stringContaining(
         new URLSearchParams({
           ...WEBHOOK_GRAPH_API_OPTIONS_MAP['1D'],
-          webhookIdRequest: mockWebhookId,
+          webhookId: mockWebhookId,
         }).toString(),
       ),
       expect.any(Object),

--- a/packages/twenty-front/src/modules/settings/developers/webhook/utils/fetchGraphDataOrThrow.ts
+++ b/packages/twenty-front/src/modules/settings/developers/webhook/utils/fetchGraphDataOrThrow.ts
@@ -14,7 +14,7 @@ export const fetchGraphDataOrThrow = async ({
 }: fetchGraphDataOrThrowProps) => {
   const queryString = new URLSearchParams({
     ...WEBHOOK_GRAPH_API_OPTIONS_MAP[windowLength],
-    webhookIdRequest: webhookId,
+    webhookId: webhookId,
   }).toString();
 
   const response = await fetch(

--- a/packages/twenty-front/src/modules/settings/developers/webhook/utils/fetchGraphDataOrThrow.ts
+++ b/packages/twenty-front/src/modules/settings/developers/webhook/utils/fetchGraphDataOrThrow.ts
@@ -14,7 +14,7 @@ export const fetchGraphDataOrThrow = async ({
 }: fetchGraphDataOrThrowProps) => {
   const queryString = new URLSearchParams({
     ...WEBHOOK_GRAPH_API_OPTIONS_MAP[windowLength],
-    webhookId: webhookId,
+    webhookId,
   }).toString();
 
   const response = await fetch(

--- a/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/jobs/call-webhook.job.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/jobs/call-webhook.job.ts
@@ -35,6 +35,7 @@ export class CallWebhookJob {
         action: 'webhook.response',
         payload: {
           status: response.status,
+          success: true,
           url: data.targetUrl,
           webhookId: data.webhookId,
           eventName: data.eventName,
@@ -46,10 +47,11 @@ export class CallWebhookJob {
       const eventInput = {
         action: 'webhook.response',
         payload: {
-          status: err.response.status,
           url: data.targetUrl,
           webhookId: data.webhookId,
           eventName: data.eventName,
+          success: false,
+          ...(err.response && { status: err.response.status }),
         },
       };
 

--- a/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/jobs/call-webhook.job.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/jobs/call-webhook.job.ts
@@ -26,19 +26,24 @@ export class CallWebhookJob {
 
   @Process(CallWebhookJob.name)
   async handle(data: CallWebhookJobData): Promise<void> {
+    const commonPayload = {
+      url: data.targetUrl,
+      webhookId: data.webhookId,
+      eventName: data.eventName,
+    };
+
     try {
       const response = await this.httpService.axiosRef.post(
         data.targetUrl,
         data,
       );
+      const success = response.status >= 200 && response.status < 300;
       const eventInput = {
         action: 'webhook.response',
         payload: {
           status: response.status,
-          success: true,
-          url: data.targetUrl,
-          webhookId: data.webhookId,
-          eventName: data.eventName,
+          success,
+          ...commonPayload,
         },
       };
 
@@ -47,10 +52,8 @@ export class CallWebhookJob {
       const eventInput = {
         action: 'webhook.response',
         payload: {
-          url: data.targetUrl,
-          webhookId: data.webhookId,
-          eventName: data.eventName,
           success: false,
+          ...commonPayload,
           ...(err.response && { status: err.response.status }),
         },
       };


### PR DESCRIPTION
Solves https://github.com/twentyhq/private-issues/issues/118

**TLDR**

Fix webhook response not sending data to tinybird when the url is not a link.

**Changes in Tinybird:**

- Add column Success to webhook payload (boolean)
-  Changed the parameter WebhookIdRequest to WebhookId in the getWebhooksResponse api point.
-  Those changes can be seen in the tinybird workspace twenty_analytics_playground

**In order to test**

1. Set ANALYTICS_ENABLED to true
2. Set TINYBIRD_INGEST_TOKEN to your token from the workspace twenty_analytics_playground
3. Set TINYBIRD_GENERATE_JWT_TOKEN to the admin kwt token from the workspace twenty_analytics_playground
4. Set TINYBIRD_WORKSPACE_UUID to the UUID of twenty_analytics_playground
5. Create a Webhook in twenty and set wich events it needs to track
6. Run twenty-worker in order to make the webhooks work.
7. Do your tasks in order to populate the data
8.  Look at your webhooks in settings>api and webhooks> your webhook and the statistics should be displayed