### PR TITLE
refactor: rest APIs to use twenty orm

### DIFF
--- a/packages/twenty-server/src/app.module.ts
+++ b/packages/twenty-server/src/app.module.ts
@@ -26,6 +26,9 @@ import { TwentyORMModule } from 'src/engine/twenty-orm/twenty-orm.module';
 import { WorkspaceCacheStorageModule } from 'src/engine/workspace-cache-storage/workspace-cache-storage.module';
 import { ModulesModule } from 'src/modules/modules.module';
 
+import { DataSourceModule } from 'src/engine/metadata-modules/data-source/data-source.module';
+import { WorkspaceMetadataCacheModule } from 'src/engine/metadata-modules/workspace-metadata-cache/workspace-metadata-cache.module';
+import { RestMetadataMiddleware } from 'src/engine/middlewares/rest-metadata.middleware';
 import { CoreEngineModule } from './engine/core-modules/core-engine.module';
 
 @Module({
@@ -53,6 +56,9 @@ import { CoreEngineModule } from './engine/core-modules/core-engine.module';
     RestApiModule,
     // Conditional modules
     ...AppModule.getConditionalModules(),
+
+    DataSourceModule,
+    WorkspaceMetadataCacheModule,
   ],
 })
 export class AppModule {
@@ -86,5 +92,9 @@ export class AppModule {
     consumer
       .apply(GraphQLHydrateRequestFromTokenMiddleware)
       .forRoutes({ path: 'metadata', method: RequestMethod.ALL });
+
+    consumer
+      .apply(RestMetadataMiddleware)
+      .forRoutes({ path: 'rest/batch/*', method: RequestMethod.ALL });
   }
 }

--- a/packages/twenty-server/src/engine/api/rest/core/controllers/rest-api-core-batch.controller.ts
+++ b/packages/twenty-server/src/engine/api/rest/core/controllers/rest-api-core-batch.controller.ts
@@ -3,7 +3,6 @@ import { Controller, Post, Req, Res, UseGuards } from '@nestjs/common';
 import { Request, Response } from 'express';
 
 import { RestApiCoreService } from 'src/engine/api/rest/core/rest-api-core.service';
-import { cleanGraphQLResponse } from 'src/engine/api/rest/utils/clean-graphql-response.utils';
 import { JwtAuthGuard } from 'src/engine/guards/jwt-auth.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 
@@ -16,6 +15,6 @@ export class RestApiCoreBatchController {
   async handleApiPost(@Req() request: Request, @Res() res: Response) {
     const result = await this.restApiCoreService.createMany(request);
 
-    res.status(201).send(cleanGraphQLResponse(result.data));
+    res.status(201).send(result);
   }
 }

--- a/packages/twenty-server/src/engine/api/rest/core/query-builder/core-query-builder.factory.ts
+++ b/packages/twenty-server/src/engine/api/rest/core/query-builder/core-query-builder.factory.ts
@@ -2,6 +2,9 @@ import { BadRequestException, Injectable } from '@nestjs/common';
 
 import { Request } from 'express';
 
+// TODO: have this within the rest folder
+import { QUERY_MAX_RECORDS } from 'src/engine/api/graphql/graphql-query-runner/constants/query-max-records.constant';
+
 import { CreateManyQueryFactory } from 'src/engine/api/rest/core/query-builder/factories/create-many-query.factory';
 import { CreateOneQueryFactory } from 'src/engine/api/rest/core/query-builder/factories/create-one-query.factory';
 import { CreateVariablesFactory } from 'src/engine/api/rest/core/query-builder/factories/create-variables.factory';
@@ -17,11 +20,20 @@ import { UpdateVariablesFactory } from 'src/engine/api/rest/core/query-builder/f
 import { computeDepth } from 'src/engine/api/rest/core/query-builder/utils/compute-depth.utils';
 import { parseCoreBatchPath } from 'src/engine/api/rest/core/query-builder/utils/path-parsers/parse-core-batch-path.utils';
 import { parseCorePath } from 'src/engine/api/rest/core/query-builder/utils/path-parsers/parse-core-path.utils';
+import { QueryVariables } from 'src/engine/api/rest/core/types/query-variables.type';
 import { Query } from 'src/engine/api/rest/core/types/query.type';
 import { TokenService } from 'src/engine/core-modules/auth/token/services/token.service';
+import { AuthContext } from 'src/engine/core-modules/auth/types/auth-context.type';
 import { EnvironmentService } from 'src/engine/core-modules/environment/environment.service';
+import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 import { ObjectMetadataService } from 'src/engine/metadata-modules/object-metadata/object-metadata.service';
+import { WorkspaceMetadataCacheService } from 'src/engine/metadata-modules/workspace-metadata-cache/services/workspace-metadata-cache.service';
+import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.manager';
+import { formatResult } from 'src/engine/twenty-orm/utils/format-result.util';
+import { WorkspaceCacheStorageService } from 'src/engine/workspace-cache-storage/workspace-cache-storage.service';
+import { capitalize } from 'src/utils/capitalize';
+import { In, InsertResult } from 'typeorm';
 
 @Injectable()
 export class CoreQueryBuilderFactory {
@@ -41,6 +53,9 @@ export class CoreQueryBuilderFactory {
     private readonly objectMetadataService: ObjectMetadataService,
     private readonly tokenService: TokenService,
     private readonly environmentService: EnvironmentService,
+    private readonly workspaceStorageCacheService: WorkspaceCacheStorageService,
+    private readonly workspaceMetadataCacheService: WorkspaceMetadataCacheService,
+    private readonly twentyORMGlobalManager: TwentyORMGlobalManager,
   ) {}
 
   async getObjectMetadata(
@@ -119,15 +134,69 @@ export class CoreQueryBuilderFactory {
     };
   }
 
-  async createMany(request: Request): Promise<Query> {
+  async createMany(request: Request): Promise<QueryVariables> {
     const { object: parsedObject } = parseCoreBatchPath(request);
     const objectMetadata = await this.getObjectMetadata(request, parsedObject);
     const depth = computeDepth(request);
 
-    return {
-      query: this.createManyQueryFactory.create(objectMetadata, depth),
-      variables: this.createVariablesFactory.create(request),
+    const context: AuthContext = {
+      user: request.user,
+      apiKey: request.apiKey,
+      workspaceMemberId: request.workspaceMemberId,
+      workspace: request.workspace as Workspace,
     };
+
+    const objectMetadataMap =
+      await this.workspaceStorageCacheService.getObjectMetadataMap(
+        context.workspace.id,
+        request.workspaceMetadataVersion as number,
+      );
+
+    if (!objectMetadataMap) {
+      await this.workspaceMetadataCacheService.recomputeMetadataCache({
+        workspaceId: context.workspace.id,
+      });
+      throw new Error('Object metadata collection not found');
+    }
+
+    const objectMetadataMapItem =
+      objectMetadataMap[objectMetadata.objectMetadataItem.nameSingular];
+
+    const dataSource =
+      await this.twentyORMGlobalManager.getDataSourceForWorkspace(
+        context.workspace.id,
+      );
+
+    const repository = dataSource.getRepository(
+      objectMetadataMapItem.nameSingular,
+    );
+
+    const objectRecords: InsertResult = !request.body.upsert
+      ? await repository.insert(request.body)
+      : await repository.upsert(request.body, {
+          conflictPaths: ['id'],
+          skipUpdateIfNoValuesChanged: true,
+        });
+
+    const queryBuilder = repository.createQueryBuilder(
+      objectMetadataMapItem.nameSingular,
+    );
+
+    const nonFormattedUpsertedRecords = await queryBuilder
+      .where({
+        id: In(objectRecords.generatedMaps.map((record) => record.id)),
+      })
+      .take(QUERY_MAX_RECORDS)
+      .getMany();
+
+    const upsertedRecords = formatResult(
+      nonFormattedUpsertedRecords,
+      objectMetadataMapItem,
+      objectMetadataMap,
+    );
+    // TODO: send the relation fields which were sent earlier
+
+    return { data: { [`create${capitalize(parsedObject)}`]: upsertedRecords } };
   }
 
   async update(request: Request): Promise<Query> {

--- a/packages/twenty-server/src/engine/api/rest/core/query-builder/core-query-builder.module.ts
+++ b/packages/twenty-server/src/engine/api/rest/core/query-builder/core-query-builder.module.ts
@@ -2,11 +2,18 @@ import { Module } from '@nestjs/common';
 
 import { CoreQueryBuilderFactory } from 'src/engine/api/rest/core/query-builder/core-query-builder.factory';
 import { coreQueryBuilderFactories } from 'src/engine/api/rest/core/query-builder/factories/factories';
-import { ObjectMetadataModule } from 'src/engine/metadata-modules/object-metadata/object-metadata.module';
 import { AuthModule } from 'src/engine/core-modules/auth/auth.module';
+import { ObjectMetadataModule } from 'src/engine/metadata-modules/object-metadata/object-metadata.module';
+import { WorkspaceMetadataCacheModule } from 'src/engine/metadata-modules/workspace-metadata-cache/workspace-metadata-cache.module';
+import { WorkspaceCacheStorageModule } from 'src/engine/workspace-cache-storage/workspace-cache-storage.module';
 
 @Module({
-  imports: [ObjectMetadataModule, AuthModule],
+  imports: [
+    ObjectMetadataModule,
+    AuthModule,
+    WorkspaceCacheStorageModule,
+    WorkspaceMetadataCacheModule,
+  ],
   providers: [...coreQueryBuilderFactories, CoreQueryBuilderFactory],
   exports: [CoreQueryBuilderFactory],
 })

--- a/packages/twenty-server/src/engine/api/rest/core/rest-api-core.service.ts
+++ b/packages/twenty-server/src/engine/api/rest/core/rest-api-core.service.ts
@@ -7,6 +7,7 @@ import {
   GraphqlApiType,
   RestApiService,
 } from 'src/engine/api/rest/rest-api.service';
+import { LogExecutionTime } from 'src/engine/decorators/observability/log-execution-time.decorator';
 
 @Injectable()
 export class RestApiCoreService {
@@ -33,10 +34,14 @@ export class RestApiCoreService {
     return await this.restApiService.call(GraphqlApiType.CORE, request, data);
   }
 
+  @LogExecutionTime()
   async createMany(request: Request) {
+    //TODO : write this within try catch?
+
     const data = await this.coreQueryBuilderFactory.createMany(request);
 
-    return await this.restApiService.call(GraphqlApiType.CORE, request, data);
+    // TODO: emit create event
+    return data;
   }
 
   async update(request: Request) {

--- a/packages/twenty-server/src/engine/middlewares/rest-metadata.middleware.ts
+++ b/packages/twenty-server/src/engine/middlewares/rest-metadata.middleware.ts
@@ -1,0 +1,97 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+
+import { NextFunction, Request, Response } from 'express';
+
+import { TokenService } from 'src/engine/core-modules/auth/token/services/token.service';
+import { AuthContext } from 'src/engine/core-modules/auth/types/auth-context.type';
+import { ExceptionHandlerService } from 'src/engine/core-modules/exception-handler/exception-handler.service';
+import { DataSourceService } from 'src/engine/metadata-modules/data-source/data-source.service';
+import { WorkspaceMetadataCacheService } from 'src/engine/metadata-modules/workspace-metadata-cache/services/workspace-metadata-cache.service';
+import { handleException } from 'src/engine/utils/global-exception-handler.util';
+import { WorkspaceCacheStorageService } from 'src/engine/workspace-cache-storage/workspace-cache-storage.service';
+
+@Injectable()
+export class RestMetadataMiddleware implements NestMiddleware {
+  constructor(
+    private readonly tokenService: TokenService,
+    private readonly workspaceStorageCacheService: WorkspaceCacheStorageService,
+    private readonly exceptionHandlerService: ExceptionHandlerService,
+    private readonly dataSourceService: DataSourceService,
+    private readonly workspaceMetadataCacheService: WorkspaceMetadataCacheService,
+  ) {}
+
+  async use(req: Request, res: Response, next: NextFunction) {
+    const body = req.body;
+
+    const excludedOperations = [
+      'GetClientConfig',
+      'GetCurrentUser',
+      'GetWorkspaceFromInviteHash',
+      'Track',
+      'CheckUserExists',
+      'Challenge',
+      'Verify',
+      'SignUp',
+      'RenewToken',
+      'EmailPasswordResetLink',
+      'ValidatePasswordResetToken',
+      'UpdatePasswordViaResetToken',
+      'IntrospectionQuery',
+      'ExchangeAuthorizationCode',
+      'GetAuthorizationUrl',
+      'FindAvailableSSOIdentityProviders',
+    ];
+
+    if (
+      !this.tokenService.isTokenPresent(req) &&
+      (!body?.operationName || excludedOperations.includes(body.operationName))
+    ) {
+      return next();
+    }
+
+    let data: AuthContext;
+
+    try {
+      data = await this.tokenService.validateToken(req);
+      const metadataVersion =
+        await this.workspaceStorageCacheService.getMetadataVersion(
+          data.workspace.id,
+        );
+
+      if (metadataVersion === undefined) {
+        await this.workspaceMetadataCacheService.recomputeMetadataCache({
+          workspaceId: data.workspace.id,
+        });
+        throw new Error('Metadata cache version not found');
+      }
+
+      const dataSourcesMetadata =
+        await this.dataSourceService.getDataSourcesMetadataFromWorkspaceId(
+          data.workspace.id,
+        );
+
+      if (!dataSourcesMetadata || dataSourcesMetadata.length === 0) {
+        throw new Error('No data sources found');
+      }
+
+      req.user = data.user;
+      req.apiKey = data.apiKey;
+      req.workspace = data.workspace;
+      req.workspaceId = data.workspace.id;
+      req.workspaceMetadataVersion = metadataVersion;
+      req.workspaceMemberId = data.workspaceMemberId;
+    } catch (error) {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.write(
+        JSON.stringify({
+          errors: [handleException(error, this.exceptionHandlerService)],
+        }),
+      );
+      res.end();
+
+      return;
+    }
+
+    next();
+  }
+}

--- a/packages/twenty-server/src/engine/utils/global-exception-handler.util.ts
+++ b/packages/twenty-server/src/engine/utils/global-exception-handler.util.ts
@@ -70,7 +70,7 @@ export const shouldFilterException = (exception: Error): boolean => {
   return false;
 };
 
-const handleException = (
+export const handleException = (
   exception: Error,
   exceptionHandlerService: ExceptionHandlerService,
   user?: ExceptionHandlerUser,


### PR DESCRIPTION
fixes #3644

This isn't the whole refactoring yet. I tried to refactor the `rest/batch/...` endpoint first. I added comments too for the part that might have to be included which were in `GraphqlQueryRunnerService`. Please let me know if I am moving in the right direction and If there is anything that I might have missed. 

Note: I will split the code in well scoped functionalities after knowing that I am moving in the right direction. Please excuse me until then.