### PR TITLE
added light background for better hover visibility on dark theme

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/dropdown/components/StyledDropdownButtonContainer.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/dropdown/components/StyledDropdownButtonContainer.tsx
@@ -7,13 +7,13 @@ type StyledDropdownButtonProps = {
 
 export const StyledDropdownButtonContainer = styled.div<StyledDropdownButtonProps>`
   align-items: center;
-  background: ${({ theme }) => theme.background.primary};
+  background: ${({ theme, isUnfolded }) =>
+    isUnfolded ? theme.background.transparent.light : theme.background.primary};
   border-radius: ${({ theme }) => theme.border.radius.sm};
-  color: ${({ isActive, theme, color }) =>
-    color ?? (isActive ? theme.color.blue : 'none')};
+  color: ${({ isActive, theme }) =>
+    isActive ? theme.color.blue : theme.font.color.secondary};
   cursor: pointer;
   display: flex;
-  filter: ${(props) => (props.isUnfolded ? 'brightness(0.95)' : 'none')};
 
   padding: ${({ theme }) => theme.spacing(1)};
   padding-left: ${({ theme }) => theme.spacing(2)};
@@ -22,7 +22,9 @@ export const StyledDropdownButtonContainer = styled.div<StyledDropdownButtonProp
   user-select: none;
 
   &:hover {
-    filter: brightness(0.95);
-    background:  ${({ theme }) => theme.background.transparent.light};
+    background: ${({ theme, isUnfolded }) =>
+      isUnfolded
+        ? theme.background.transparent.medium
+        : theme.background.transparent.light};
   }
 `;

--- a/packages/twenty-front/src/modules/ui/layout/dropdown/components/StyledDropdownButtonContainer.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/dropdown/components/StyledDropdownButtonContainer.tsx
@@ -23,5 +23,6 @@ export const StyledDropdownButtonContainer = styled.div<StyledDropdownButtonProp
 
   &:hover {
     filter: brightness(0.95);
+    background:  ${({ theme }) => theme.background.transparent.light};
   }
 `;

--- a/packages/twenty-front/src/modules/ui/layout/dropdown/components/StyledHeaderDropdownButton.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/dropdown/components/StyledHeaderDropdownButton.tsx
@@ -25,5 +25,6 @@ export const StyledHeaderDropdownButton = styled.button<StyledDropdownButtonProp
 
   &:hover {
     filter: brightness(0.95);
+     background:  ${({ theme }) => theme.background.transparent.light};
   }
 `;

--- a/packages/twenty-front/src/modules/ui/layout/dropdown/components/StyledHeaderDropdownButton.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/dropdown/components/StyledHeaderDropdownButton.tsx
@@ -8,14 +8,14 @@ type StyledDropdownButtonProps = {
 export const StyledHeaderDropdownButton = styled.button<StyledDropdownButtonProps>`
   font-family: inherit;
   align-items: center;
-  background: ${({ theme }) => theme.background.primary};
+  background: ${({ theme, isUnfolded }) =>
+    isUnfolded ? theme.background.transparent.light : theme.background.primary};
   border: none;
   border-radius: ${({ theme }) => theme.border.radius.sm};
-  color: ${({ isActive, theme, color }) =>
-    color ?? (isActive ? theme.color.blue : theme.font.color.secondary)};
+  color: ${({ isActive, theme }) =>
+    isActive ? theme.color.blue : theme.font.color.secondary};
   cursor: pointer;
   display: flex;
-  filter: ${(props) => (props.isUnfolded ? 'brightness(0.95)' : 'none')};
 
   padding: ${({ theme }) => theme.spacing(1)};
   padding-left: ${({ theme }) => theme.spacing(2)};
@@ -24,7 +24,9 @@ export const StyledHeaderDropdownButton = styled.button<StyledDropdownButtonProp
   user-select: none;
 
   &:hover {
-    filter: brightness(0.95);
-     background:  ${({ theme }) => theme.background.transparent.light};
+    background: ${({ theme, isUnfolded }) =>
+      isUnfolded
+        ? theme.background.transparent.medium
+        : theme.background.transparent.light};
   }
 `;


### PR DESCRIPTION
fixes: #7969 

## What does this PR do?

Apply a lighter background color to enhance the hover effect in dark mode.

![twenty-hover](https://github.com/user-attachments/assets/3d218060-2328-481e-9e66-250abd276dc0)
