### PR TITLE
Add padding to navigation header

### DIFF
--- a/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/NavigationDrawerHeader.tsx
+++ b/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/NavigationDrawerHeader.tsx
@@ -20,7 +20,7 @@ const StyledContainer = styled.div`
 `;
 const StyledSingleWorkspaceContainer = styled(StyledContainer)`
   gap: ${({ theme }) => theme.spacing(2)};
-  padding: 4px;
+  padding: ${({ theme }) => theme.spacing(1)};
 `;
 
 const StyledLogo = styled.div<{ logo: string }>`

--- a/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/NavigationDrawerHeader.tsx
+++ b/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/NavigationDrawerHeader.tsx
@@ -20,6 +20,7 @@ const StyledContainer = styled.div`
 `;
 const StyledSingleWorkspaceContainer = styled(StyledContainer)`
   gap: ${({ theme }) => theme.spacing(2)};
+  padding: 4px;
 `;
 
 const StyledLogo = styled.div<{ logo: string }>`


### PR DESCRIPTION
This PR adds padding to the header to align the logo with other icons on the sidebar.

## Before

![image](https://github.com/user-attachments/assets/6501bbbf-bf06-4d9f-bff7-2d36c1b63a37)


## After

![image](https://github.com/user-attachments/assets/24610cf8-eab2-49bd-b611-e68a66228fd6)
