### PR TITLE
Bug Fix: Set the padding of parent div to 4px

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/dropdown/components/DropdownMenuItemsContainer.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/dropdown/components/DropdownMenuItemsContainer.tsx
@@ -15,7 +15,7 @@ const StyledDropdownMenuItemsExternalContainer = styled.div<{
   max-height: ${({ hasMaxHeight }) => (hasMaxHeight ? '188px' : 'none')};
   overflow-y: auto;
 
-  padding: var(--padding);
+  padding: 4px;
 
   width: calc(100% - 2 * var(--padding));
 `;


### PR DESCRIPTION
##What does this PR do?
we set the padding of the div element 4px as without padding it not looking good.

Fixes #7915

https://github.com/user-attachments/assets/b4d2f893-3e0c-495a-bf6a-12ded6aae9a9

## How should this be tested?

1-> right click on record menu 
2-> hover the options

