### PR TITLE
Handle NBSP in tiptap parsing

### DIFF
--- a/packages/twenty-front/src/modules/workflow/search-variables/utils/__tests__/parseEditorContent.test.ts
+++ b/packages/twenty-front/src/modules/workflow/search-variables/utils/__tests__/parseEditorContent.test.ts
@@ -267,4 +267,33 @@ describe('parseEditorContent', () => {
 
     expect(parseEditorContent(input)).toBe('First line\nSecond line');
   });
+
+  it('should handle spaces between variables correctly', () => {
+    const input: JSONContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'variableTag',
+              attrs: { variable: '{{user.firstName}}' },
+            },
+            {
+              type: 'text',
+              text: '\u00A0', // NBSP character
+            },
+            {
+              type: 'variableTag',
+              attrs: { variable: '{{user.lastName}}' },
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(parseEditorContent(input)).toBe(
+      '{{user.firstName}} {{user.lastName}}',
+    );
+  });
 });

--- a/packages/twenty-front/src/modules/workflow/search-variables/utils/parseEditorContent.ts
+++ b/packages/twenty-front/src/modules/workflow/search-variables/utils/parseEditorContent.ts
@@ -11,7 +11,8 @@ export const parseEditorContent = (json: JSONContent): string => {
     }
 
     if (node.type === 'text') {
-      return node.text || '';
+      // Replace &nbsp; with regular space
+      return (node.text || '').replace(/\u00A0/g, ' ');
     }
 
     if (node.type === 'hardBreak') {

--- a/packages/twenty-front/src/modules/workflow/search-variables/utils/parseEditorContent.ts
+++ b/packages/twenty-front/src/modules/workflow/search-variables/utils/parseEditorContent.ts
@@ -12,7 +12,7 @@ export const parseEditorContent = (json: JSONContent): string => {
 
     if (node.type === 'text') {
       // Replace &nbsp; with regular space
-      return (node.text || '').replace(/\u00A0/g, ' ');
+      return node?.text?.replace(/\u00A0/g, ' ') ?? '';
     }
 
     if (node.type === 'hardBreak') {


### PR DESCRIPTION
Tiptap uses non breaking spaces between nodes (like variables). Those html characters are not properly handles in emails. Replacing by regular spaces during parsing.

I tried to fix it in settings but looks like this is only for preserving those nbsp and not for removal (see https://github.com/ueberdosis/tiptap/pull/254) 