### PR TITLE
8130 creating a new company in twenty doesnt activate on zapier

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/jobs/call-webhook-jobs.job.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/jobs/call-webhook-jobs.job.ts
@@ -42,6 +42,9 @@ export class CallWebhookJobsJob {
 
   @Process(CallWebhookJobsJob.name)
   async handle(data: CallWebhookJobsJobData): Promise<void> {
+    // If you change that function, double check it does not break Zapier
+    // trigger in packages/twenty-zapier/src/triggers/trigger_record.ts
+
     const webhookRepository =
       await this.twentyORMGlobalManager.getRepositoryForWorkspace<WebhookWorkspaceEntity>(
         data.workspaceId,

--- a/packages/twenty-zapier/src/triggers/trigger_record.ts
+++ b/packages/twenty-zapier/src/triggers/trigger_record.ts
@@ -21,7 +21,8 @@ export default {
   noun: 'Record',
   display: {
     label: 'Record Trigger',
-    description: 'Triggers when a Record is created, updated or deleted.',
+    description:
+      'Triggers when a Record is created, updated, deleted or destroyed.',
   },
   operation: {
     inputFields: [
@@ -40,6 +41,7 @@ export default {
           [Operation.create]: Operation.create,
           [Operation.update]: Operation.update,
           [Operation.delete]: Operation.delete,
+          [Operation.destroy]: Operation.destroy,
         },
         altersDynamicFields: true,
       },

--- a/packages/twenty-zapier/src/utils/triggers/triggers.utils.ts
+++ b/packages/twenty-zapier/src/utils/triggers/triggers.utils.ts
@@ -19,18 +19,34 @@ export const subscribe = async (
   bundle: Bundle,
   operation: Operation,
 ) => {
-  const data = {
-    targetUrl: bundle.targetUrl,
-    operation: `${bundle.inputData.nameSingular}.${operation}`,
-  };
-  const result = await requestDb(
-    z,
-    bundle,
-    `mutation createWebhook {createWebhook(data:{${handleQueryParams(
-      data,
-    )}}) {id}}`,
-  );
-  return result.data.createWebhook;
+  try {
+    const data = {
+      targetUrl: bundle.targetUrl,
+      operations: [`${bundle.inputData.nameSingular}.${operation}`],
+    };
+    const result = await requestDb(
+      z,
+      bundle,
+      `mutation createWebhook {createWebhook(data:{${handleQueryParams(
+        data,
+      )}}) {id}}`,
+    );
+    return result.data.createWebhook;
+  } catch (e) {
+    // Remove that catch code when operations column exists in all active workspace schemas
+    const data = {
+      targetUrl: bundle.targetUrl,
+      operation: `${bundle.inputData.nameSingular}.${operation}`,
+    };
+    const result = await requestDb(
+      z,
+      bundle,
+      `mutation createWebhook {createWebhook(data:{${handleQueryParams(
+        data,
+      )}}) {id}}`,
+    );
+    return result.data.createWebhook;
+  }
 };
 
 export const performUnsubscribe = async (z: ZObject, bundle: Bundle) => {

--- a/packages/twenty-zapier/src/utils/triggers/triggers.utils.ts
+++ b/packages/twenty-zapier/src/utils/triggers/triggers.utils.ts
@@ -11,6 +11,7 @@ export enum Operation {
   create = 'create',
   update = 'update',
   delete = 'delete',
+  destroy = 'destroy',
 }
 
 export const subscribe = async (
@@ -20,7 +21,7 @@ export const subscribe = async (
 ) => {
   const data = {
     targetUrl: bundle.targetUrl,
-    operation: `${operation}.${bundle.inputData.nameSingular}`,
+    operation: `${bundle.inputData.nameSingular}.${operation}`,
   };
   const result = await requestDb(
     z,

--- a/packages/twenty-zapier/src/utils/triggers/triggers.utils.ts
+++ b/packages/twenty-zapier/src/utils/triggers/triggers.utils.ts
@@ -33,7 +33,9 @@ export const subscribe = async (
     );
     return result.data.createWebhook;
   } catch (e) {
-    // Remove that catch code when operations column exists in all active workspace schemas
+    // Remove that catch code when VERSION 0.32 is deployed
+    // probably removable after 01/11/2024
+    // (ie: when operations column exists in all active workspace schemas)
     const data = {
       targetUrl: bundle.targetUrl,
       operation: `${bundle.inputData.nameSingular}.${operation}`,


### PR DESCRIPTION
- fix webhook.operation format change from august 2024 not spread in twenty-zapier
- added a comment so it does not happen again
- add a fix for the new webhook.operations column that would produce another issue