### PR TITLE
fix object metadata renaming

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.service.ts
@@ -320,6 +320,44 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
     return objectMetadata;
   }
 
+  public async findOneWithinWorkspace(
+    workspaceId: string,
+    options: FindOneOptions<ObjectMetadataEntity>,
+  ): Promise<ObjectMetadataEntity | null> {
+    return this.objectMetadataRepository.findOne({
+      relations: [
+        'fields',
+        'fields.fromRelationMetadata',
+        'fields.toRelationMetadata',
+      ],
+      ...options,
+      where: {
+        ...options.where,
+        workspaceId,
+      },
+    });
+  }
+
+  public async findManyWithinWorkspace(
+    workspaceId: string,
+    options?: FindManyOptions<ObjectMetadataEntity>,
+  ) {
+    return this.objectMetadataRepository.find({
+      relations: [
+        'fields.object',
+        'fields',
+        'fields.fromRelationMetadata',
+        'fields.toRelationMetadata',
+        'fields.fromRelationMetadata.toObjectMetadata',
+      ],
+      ...options,
+      where: {
+        ...options?.where,
+        workspaceId,
+      },
+    });
+  }
+
   public async findMany(options?: FindManyOptions<ObjectMetadataEntity>) {
     return this.objectMetadataRepository.find({
       relations: [
@@ -331,26 +369,6 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
       ...options,
       where: {
         ...options?.where,
-      },
-    });
-  }
-
-  public async findOneWithinWorkspace(
-    workspaceId: string,
-    options: FindOneOptions<ObjectMetadataEntity>,
-  ): Promise<ObjectMetadataEntity | null> {
-    return this.findManyWithinWorkspace(workspaceId, options)[0] ?? null;
-  }
-
-  public async findManyWithinWorkspace(
-    workspaceId: string,
-    options?: FindManyOptions<ObjectMetadataEntity>,
-  ) {
-    return this.findMany({
-      ...options,
-      where: {
-        ...options?.where,
-        workspaceId,
       },
     });
   }

--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/services/object-metadata-relation.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/services/object-metadata-relation.service.ts
@@ -139,8 +139,7 @@ export class ObjectMetadataRelationService {
     createdObjectMetadata: ObjectMetadataEntity,
     relatedObjectMetadata: ObjectMetadataEntity,
   ) {
-    const relationObjectMetadataNamePlural =
-      relatedObjectMetadata.nameSingular + 's';
+    const relationObjectMetadataNamePlural = relatedObjectMetadata.namePlural;
 
     return {
       standardId:
@@ -151,7 +150,7 @@ export class ObjectMetadataRelationService {
       isActive: true,
       isSystem: true,
       type: FieldMetadataType.RELATION,
-      name: relationObjectMetadataNamePlural,
+      name: relatedObjectMetadata.namePlural,
       label: capitalize(relationObjectMetadataNamePlural),
       description: `${capitalize(relationObjectMetadataNamePlural)} tied to the ${createdObjectMetadata.labelSingular}`,
       icon:


### PR DESCRIPTION
## Context
Latest refactoring broke the findOneWithinWorkspace method which is called during object update, I'm simply reverting this change.
object-metadata-relation.service was naively computing a namePlural based on the nameSingular while we already had that info in the DB... Should fix some issues with renaming as well because the original field was not computed with the right name.