### PR TITLE
fix: Show Y overflow on Dropdown menus containers

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/dropdown/components/DropdownMenuItemsContainer.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/dropdown/components/DropdownMenuItemsContainer.tsx
@@ -6,17 +6,13 @@ const StyledDropdownMenuItemsExternalContainer = styled.div<{
   hasMaxHeight?: boolean;
 }>`
   --padding: ${({ theme }) => theme.spacing(1)};
-
   align-items: flex-start;
   display: flex;
-
   flex-direction: column;
   gap: 2px;
   max-height: ${({ hasMaxHeight }) => (hasMaxHeight ? '188px' : 'none')};
   overflow-y: auto;
-
-  padding: var(--padding);
-
+  padding: 0px var(--padding) var(--padding) var(--padding);
   width: calc(100% - 2 * var(--padding));
 `;
 
@@ -27,7 +23,7 @@ const StyledScrollWrapper = styled(ScrollWrapper)`
 const StyledDropdownMenuItemsInternalContainer = styled.div`
   align-items: flex-start;
   display: flex;
-
+  padding-top: ${({ theme }) => theme.spacing(1)};
   flex-direction: column;
   gap: 2px;
   height: 100%;


### PR DESCRIPTION
fixes #8170 
![image](https://github.com/user-attachments/assets/2553f346-16d2-403a-a985-b89ce3d6370a)
