### PR TITLE
Fix empty option selected in single entity select

### DIFF
--- a/packages/twenty-front/src/modules/object-record/relation-picker/components/SingleEntitySelect.tsx
+++ b/packages/twenty-front/src/modules/object-record/relation-picker/components/SingleEntitySelect.tsx
@@ -23,7 +23,6 @@ export const SingleEntitySelect = ({
   onEntitySelected,
   relationObjectNameSingular,
   relationPickerScopeId,
-  selectedEntity,
   selectedRelationRecordIds,
   width = 200,
 }: SingleEntitySelectProps) => {
@@ -61,7 +60,6 @@ export const SingleEntitySelect = ({
           onEntitySelected,
           relationObjectNameSingular,
           relationPickerScopeId,
-          selectedEntity,
           selectedRelationRecordIds,
         }}
       />

--- a/packages/twenty-front/src/modules/object-record/relation-picker/components/SingleEntitySelectMenuItems.tsx
+++ b/packages/twenty-front/src/modules/object-record/relation-picker/components/SingleEntitySelectMenuItems.tsx
@@ -183,7 +183,7 @@ export const SingleEntitySelectMenuItems = ({
                         onClick={() => onEntitySelected()}
                         LeftIcon={EmptyIcon}
                         text={emptyLabel}
-                        selected={shouldSelectEmptyOption || false}
+                        selected={shouldSelectEmptyOption === true}
                         hovered={isSelectedSelectNoneButton}
                       />
                     )

--- a/packages/twenty-front/src/modules/object-record/relation-picker/components/SingleEntitySelectMenuItems.tsx
+++ b/packages/twenty-front/src/modules/object-record/relation-picker/components/SingleEntitySelectMenuItems.tsx
@@ -37,6 +37,7 @@ export type SingleEntitySelectMenuItemsProps = {
   onAllEntitySelected?: () => void;
   hotkeyScope?: string;
   isFiltered: boolean;
+  shouldSelectEmptyOption?: boolean;
 };
 
 export const SingleEntitySelectMenuItems = ({
@@ -56,6 +57,7 @@ export const SingleEntitySelectMenuItems = ({
   onAllEntitySelected,
   hotkeyScope = RelationPickerHotkeyScope.RelationPicker,
   isFiltered,
+  shouldSelectEmptyOption,
 }: SingleEntitySelectMenuItemsProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -181,7 +183,7 @@ export const SingleEntitySelectMenuItems = ({
                         onClick={() => onEntitySelected()}
                         LeftIcon={EmptyIcon}
                         text={emptyLabel}
-                        selected={!selectedEntity}
+                        selected={shouldSelectEmptyOption || false}
                         hovered={isSelectedSelectNoneButton}
                       />
                     )

--- a/packages/twenty-front/src/modules/object-record/relation-picker/components/SingleEntitySelectMenuItemsWithSearch.tsx
+++ b/packages/twenty-front/src/modules/object-record/relation-picker/components/SingleEntitySelectMenuItemsWithSearch.tsx
@@ -35,7 +35,6 @@ export const SingleEntitySelectMenuItemsWithSearch = ({
   onEntitySelected,
   relationObjectNameSingular,
   relationPickerScopeId = 'relation-picker',
-  selectedEntity,
   selectedRelationRecordIds,
   dropdownPlacement,
 }: SingleEntitySelectMenuItemsWithSearchProps) => {
@@ -71,11 +70,11 @@ export const SingleEntitySelectMenuItemsWithSearch = ({
       entitiesToSelect={entities.entitiesToSelect}
       loading={entities.loading}
       selectedEntity={
-        selectedEntity ??
-        (entities.selectedEntities.length === 1
+        entities.selectedEntities.length === 1
           ? entities.selectedEntities[0]
-          : undefined)
+          : undefined
       }
+      shouldSelectEmptyOption={selectedRelationRecordIds?.length === 0}
       hotkeyScope={relationPickerScopeId}
       onCreate={onCreateWithInput}
       isFiltered={!!relationPickerSearchFilter}


### PR DESCRIPTION
SingleEntitySelect was wrongfully showing the empty option (eg "No company") as selected if the selected option was not showing in the list, because of a search filter for instance (eg selected option is "Linkedin" but search filter is "a").

Fixing this and removing misleading prop selectedEntity from components where it is never passed.