### PR TITLE
Add simple configuration to ts_query

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-search-resolver.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-search-resolver.service.ts
@@ -88,12 +88,12 @@ export class GraphqlQuerySearchResolverService
           qb.where(
             searchTerms === ''
               ? `"${SEARCH_VECTOR_FIELD.name}" IS NOT NULL`
-              : `"${SEARCH_VECTOR_FIELD.name}" @@ to_tsquery(:searchTerms)`,
+              : `"${SEARCH_VECTOR_FIELD.name}" @@ to_tsquery('simple', :searchTerms)`,
             searchTerms === '' ? {} : { searchTerms },
           ).orWhere(
             searchTermsOr === ''
               ? `"${SEARCH_VECTOR_FIELD.name}" IS NOT NULL`
-              : `"${SEARCH_VECTOR_FIELD.name}" @@ to_tsquery(:searchTermsOr)`,
+              : `"${SEARCH_VECTOR_FIELD.name}" @@ to_tsquery('simple', :searchTermsOr)`,
             searchTermsOr === '' ? {} : { searchTermsOr },
           );
         }),


### PR DESCRIPTION
In the expression of our searchVector fields, we use the "simple" configuration (over the default "english" one), to avoid picking a language that's irrelevant to the user.
I initially forgot to add the same configuration to the query that is being sent using ts_query. 
Adding it will also allow the search to work for a single character, while so far a single letter was most of the time considered a "stop word" (a word with no semantic value, like "a").