### PR TITLE
Fix SimplifySearchVectorExpressionCommand

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version/0-32/0-32-simplify-search-vector-expression.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-32/0-32-simplify-search-vector-expression.ts
@@ -79,11 +79,10 @@ export class SimplifySearchVectorExpressionCommand extends ActiveWorkspacesComma
               fieldsUsedForSearch = SEARCH_FIELDS_FOR_OPPORTUNITY;
               break;
             }
-            default: {
-              throw new Error(
-                `search vector has unexpected standardId: ${searchVectorField.standardId}`,
-              );
-            }
+          }
+
+          if (fieldsUsedForSearch.length === 0) {
+            continue;
           }
 
           await this.searchService.updateSearchVector(


### PR DESCRIPTION
## Context
This command was introduced to simplify searchVector expressions that were added in v0.31.x for existing workspaces.
New search vector columns have been added later during 0.32 development and should not be migrated, this actually breaks the command because we run sync-metadata before the upgrade command.

The fix removes the throw since this is expected and return early if the search vector was not matched with an object that needs migration. 

## Test
checkout v0.31.0
reset:db command
checkout this PR
run typeorm migrations
run upgrade 0-32 command