### PR TITLE
Add missing CopyWebhookOperationIntoOperationsCommand to 0.32 upgrade global command

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version/0-32/0-32-copy-webhook-operation-into-operations-command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-32/0-32-copy-webhook-operation-into-operations-command.ts
@@ -1,14 +1,13 @@
 import { InjectRepository } from '@nestjs/typeorm';
 
-import { Command } from 'nest-commander';
-import { ObjectLiteral, Repository } from 'typeorm';
 import chalk from 'chalk';
+import { Command } from 'nest-commander';
+import { Repository } from 'typeorm';
 
 import { ActiveWorkspacesCommandRunner } from 'src/database/commands/active-workspaces.command';
+import { BaseCommandOptions } from 'src/database/commands/base.command';
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.manager';
-import { BaseCommandOptions } from 'src/database/commands/base.command';
-import { WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace.repository';
 
 @Command({
   name: 'upgrade-0.32:copy-webhook-operation-into-operations',

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-32/0-32-upgrade-version.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-32/0-32-upgrade-version.command.ts
@@ -4,6 +4,7 @@ import { Command } from 'nest-commander';
 import { Repository } from 'typeorm';
 
 import { ActiveWorkspacesCommandRunner } from 'src/database/commands/active-workspaces.command';
+import { CopyWebhookOperationIntoOperationsCommand } from 'src/database/commands/upgrade-version/0-32/0-32-copy-webhook-operation-into-operations-command';
 import { SimplifySearchVectorExpressionCommand } from 'src/database/commands/upgrade-version/0-32/0-32-simplify-search-vector-expression';
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { SyncWorkspaceMetadataCommand } from 'src/engine/workspace-manager/workspace-sync-metadata/commands/sync-workspace-metadata.command';
@@ -25,6 +26,7 @@ export class UpgradeTo0_32Command extends ActiveWorkspacesCommandRunner {
     private readonly syncWorkspaceMetadataCommand: SyncWorkspaceMetadataCommand,
     private readonly enforceUniqueConstraintsCommand: EnforceUniqueConstraintsCommand,
     private readonly simplifySearchVectorExpressionCommand: SimplifySearchVectorExpressionCommand,
+    private readonly copyWebhookOperationIntoOperationsCommand: CopyWebhookOperationIntoOperationsCommand,
   ) {
     super(workspaceRepository);
   }
@@ -50,6 +52,12 @@ export class UpgradeTo0_32Command extends ActiveWorkspacesCommandRunner {
     );
 
     await this.enforceUniqueConstraintsCommand.executeActiveWorkspacesCommand(
+      passedParam,
+      options,
+      workspaceIds,
+    );
+
+    await this.copyWebhookOperationIntoOperationsCommand.executeActiveWorkspacesCommand(
       passedParam,
       options,
       workspaceIds,


### PR DESCRIPTION
## Context
This command was missing in the global upgrade command, this PR simply adds it.