### PR TITLE
fix: red bar between events is flashing when opening the calendar tab

### DIFF
--- a/packages/twenty-front/src/modules/activities/calendar/components/Calendar.tsx
+++ b/packages/twenty-front/src/modules/activities/calendar/components/Calendar.tsx
@@ -116,7 +116,6 @@ export const Calendar = ({
       value={{
         calendarEventsByDayTime,
         currentCalendarEvent,
-        displayCurrentEventCursor: true,
         getNextCalendarEvent,
         updateCurrentCalendarEvent,
       }}


### PR DESCRIPTION
## ISSUE
- Closes #4692

## DESCRIPTION 

- as when accessing displayCurrentEventCursor, we are making it default -> false if undefined (as shown in attached line of code), we shouldn't make default value right when creating CalendarContext as, its used in  `SettingsAccountsCalendarChannelsGeneral`  component which has no role of cursor.

https://github.com/twentyhq/twenty/blob/d19bc2c224a5e02f9fd325fe2e98ec8116f2f5a0/packages/twenty-front/src/modules/activities/calendar/components/CalendarEventRow.tsx#L111-L114

