### PR TITLE
Put back object type in settings form

### DIFF
--- a/packages/twenty-front/src/modules/settings/data-model/fields/forms/components/SettingsDataModelFieldSettingsFormCard.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/forms/components/SettingsDataModelFieldSettingsFormCard.tsx
@@ -100,7 +100,6 @@ type SettingsDataModelFieldSettingsFormCardProps = {
 } & Pick<SettingsDataModelFieldPreviewCardProps, 'objectMetadataItem'>;
 
 const StyledFieldPreviewCard = styled(SettingsDataModelFieldPreviewCard)`
-  display: grid;
   flex: 1 1 100%;
 `;
 


### PR DESCRIPTION
Before
<img width="673" alt="Capture d’écran 2024-10-31 à 11 15 27" src="https://github.com/user-attachments/assets/78d81f5b-88c0-40b7-8901-104365ecdd49">


After
<img width="673" alt="Capture d’écran 2024-10-31 à 11 15 07" src="https://github.com/user-attachments/assets/9427da22-a75b-4257-b948-28807b110b26">
