### PR TITLE
Ensure the text of select control is aligned on the left

### DIFF
--- a/packages/twenty-front/src/modules/ui/input/components/SelectControl.tsx
+++ b/packages/twenty-front/src/modules/ui/input/components/SelectControl.tsx
@@ -26,6 +26,7 @@ const StyledControlContainer = styled.div<{
   color: ${({ disabled, theme }) =>
     disabled ? theme.font.color.tertiary : theme.font.color.primary};
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
+  text-align: left;
 `;
 
 const StyledIconChevronDown = styled(IconChevronDown)<{


### PR DESCRIPTION
Fixes:

![image](https://github.com/user-attachments/assets/900596ed-1426-49cd-a2f3-4b81eacbb7d0)

The regression is due a recent change I made to the SelectControl component: https://github.com/twentyhq/twenty/pull/8125.

The SelectControls get applied `text-align: center` due to the styles `react-datepicker` applies to the header component. My grid implementation makes the label take all the available width. I could have let it take an `auto` width, but I think it's better to set the `text-align` property and ensure the `SelectControl` component behaves predictably.