### PR TITLE
fix: no more dashed line

### DIFF
--- a/packages/twenty-ui/src/display/tag/components/Tag.tsx
+++ b/packages/twenty-ui/src/display/tag/components/Tag.tsx
@@ -42,7 +42,7 @@ const StyledTag = styled.h3<{
   padding: 0 ${spacing2};
   border: ${({ variant, theme }) =>
     variant === 'outline' || variant === 'border'
-      ? `1px ${variant === 'border' ? 'solid' : 'dash'} ${theme.border.color.strong}`
+      ? `1px ${variant === 'border' ? 'solid' : 'dashed'} ${theme.border.color.strong}`
       : ''};
 
   gap: ${spacing1};


### PR DESCRIPTION
Fix bug introduced by #8152 where `<Tag />` component doesn't have dashed lines anymore.
<img width="114" alt="Screenshot 2024-10-31 at 3 10 10 PM" src="https://github.com/user-attachments/assets/25c9cb91-7be2-407b-9f07-a3811fb2d082">
<img width="134" alt="Screenshot 2024-10-31 at 3 10 03 PM" src="https://github.com/user-attachments/assets/c44a551f-0e02-4fd4-b779-2076df513b03">
