### PR TITLE
Fix disabled + focus button

### DIFF
--- a/packages/twenty-ui/src/input/button/components/Button.tsx
+++ b/packages/twenty-ui/src/input/button/components/Button.tsx
@@ -60,7 +60,7 @@ const StyledButton = styled('button', {
                 ? theme.background.secondary
                 : theme.background.primary};
               border-color: ${!inverted
-                ? focus
+                ? !disabled && focus
                   ? theme.color.blue
                   : theme.background.transparent.light
                 : theme.background.transparent.light};


### PR DESCRIPTION
Before fix:
<img width="302" alt="Capture d’écran 2024-10-31 à 16 56 03" src="https://github.com/user-attachments/assets/20e219a7-7020-4076-8e8a-bf4892dc0863">
After fix:
<img width="312" alt="Capture d’écran 2024-10-31 à 16 55 54" src="https://github.com/user-attachments/assets/4b759b08-85cb-40ff-aacd-09b078f08033">
