### PR TITLE
Fix RecordIndexActionMenuDropdown style

### DIFF
--- a/packages/twenty-front/src/modules/action-menu/components/RecordIndexActionMenuDropdown.tsx
+++ b/packages/twenty-front/src/modules/action-menu/components/RecordIndexActionMenuDropdown.tsx
@@ -8,6 +8,7 @@ import { ActionMenuComponentInstanceContext } from '@/action-menu/states/context
 import { recordIndexActionMenuDropdownPositionComponentState } from '@/action-menu/states/recordIndexActionMenuDropdownPositionComponentState';
 import { ActionMenuDropdownHotkeyScope } from '@/action-menu/types/ActionMenuDropdownHotKeyScope';
 import { Dropdown } from '@/ui/layout/dropdown/components/Dropdown';
+import { DropdownMenu } from '@/ui/layout/dropdown/components/DropdownMenu';
 import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/DropdownMenuItemsContainer';
 import { MenuItem } from '@/ui/navigation/menu-item/components/MenuItem';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
@@ -75,17 +76,19 @@ export const RecordIndexActionMenuDropdown = () => {
         data-select-disable
         dropdownMenuWidth={width}
         dropdownComponents={
-          <DropdownMenuItemsContainer>
-            {actionMenuEntries.map((item, index) => (
-              <MenuItem
-                key={index}
-                LeftIcon={item.Icon}
-                onClick={item.onClick}
-                accent={item.accent}
-                text={item.label}
-              />
-            ))}
-          </DropdownMenuItemsContainer>
+          <DropdownMenu>
+            <DropdownMenuItemsContainer>
+              {actionMenuEntries.map((item, index) => (
+                <MenuItem
+                  key={index}
+                  LeftIcon={item.Icon}
+                  onClick={item.onClick}
+                  accent={item.accent}
+                  text={item.label}
+                />
+              ))}
+            </DropdownMenuItemsContainer>
+          </DropdownMenu>
         }
       />
     </StyledContainerActionMenuDropdown>


### PR DESCRIPTION
Fix RecordIndexActionMenuDropdown style. Very subtle change, but added `<DropdownMenu>` around `<DropdownMenuItemsContainer>`.

Before:
<img width="183" alt="Capture d’écran 2024-10-31 à 17 16 54" src="https://github.com/user-attachments/assets/5c9b01b4-2838-47cc-98ef-5e3988a0c318">

After:
<img width="205" alt="Capture d’écran 2024-10-31 à 17 15 49" src="https://github.com/user-attachments/assets/6aac54fd-db03-47a2-966d-e594a6c0aa6a">
