### PR TITLE
using ref to track the download state change instead of a state variable

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-index/options/hooks/useRecordData.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/options/hooks/useRecordData.ts
@@ -170,7 +170,6 @@ export const useRecordData = ({
     previousRecordCount,
     hiddenKanbanFieldColumn,
     viewType,
-    isDownloadingRef.current,
   ]);
 
   return {


### PR DESCRIPTION
## PR Description

Fix for the issue : #8239 
This issue was not specific to Kanban view, it was happening for me for all the views and all the tables, but only when i fresh login and try to export 

Steps to reproduce 
1. Clear the application data
2. Login
3. go to any table and try to export ( for the first time it will get downloaded twice, but the second time when you click on download its working as expected )


### Issue
This PR addresses a bug where downloads were being triggered twice when the download button was initially clicked. The redundant triggering stemmed from asynchronous state changes (isDownloading, loading, and inflight) that caused the useEffect hook to execute multiple times unintentionally.
noticed that the isDownloading state variable is not setting correctly that was the root cause for the file getting downloaded twice 
line number 122 in useRecordData hook this condition was getting false `if (!isDownloading || inflight || loading)` twice because of the isDownloading state not getting reset correctly in the `complete` function ( possibly its a stale closure )

### Solution
To resolve this, a ref `downloadingRef` was introduced to act as a controller for the download process:

1. Checking downloadingRef.current before initiating a new download, thereby avoiding duplicate downloads.
5. Resetting downloadingRef.current only after the download completes.


#### Thank you for considering this contribution! I look forward to your feedback.