### PR TITLE
Fix assignee not displayed on tasks

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-show/components/FieldsCard.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-show/components/FieldsCard.tsx
@@ -77,10 +77,10 @@ export const FieldsCard = ({
 
   const boxedRelationFieldMetadataItems = relationFieldMetadataItems?.filter(
     (fieldMetadataItem) =>
-      objectNameSingular !== CoreObjectNameSingular.Note &&
-      fieldMetadataItem.name !== 'noteTargets' &&
-      objectNameSingular !== CoreObjectNameSingular.Task &&
-      fieldMetadataItem.name !== 'taskTargets',
+      !((objectNameSingular === CoreObjectNameSingular.Note &&
+        fieldMetadataItem.name === 'noteTargets') ||
+      (objectNameSingular === CoreObjectNameSingular.Task &&
+        fieldMetadataItem.name === 'taskTargets')),
   );
   const isReadOnly = objectMetadataItem.isRemote;
 


### PR DESCRIPTION
Fix an issue where the assignee of a task wasn't displayed on the task record's show page