### PR TITLE
Fix eslintrc in twenty-front

### DIFF
--- a/packages/twenty-front/.eslintrc.cjs
+++ b/packages/twenty-front/.eslintrc.cjs
@@ -24,7 +24,7 @@ module.exports = {
       plugins: ['project-structure'],
       settings: {
         'project-structure/folder-structure-config-path':
-          'packages/twenty-front/folderStructure.json',
+          'folderStructure.json',
       },
       rules: {
         'project-structure/folder-structure': 'error',

--- a/packages/twenty-front/.eslintrc.cjs
+++ b/packages/twenty-front/.eslintrc.cjs
@@ -19,7 +19,7 @@ module.exports = {
     {
       files: ['*.ts', '*.tsx'],
       parserOptions: {
-        project: ['packages/twenty-front/tsconfig.{json,*.json}'],
+        project: ['tsconfig.{json,*.json}'],
       },
       plugins: ['project-structure'],
       settings: {


### PR DESCRIPTION
This PR deletes additional `packages/twenty-front` fixing the ESLint error with missing file `ESLint Error: ENOENT: no such file or directory, open '~/twenty/packages/twenty-front/packages/twenty-front/folderStructure.json'`