### PR TITLE
Fix typo in default member's last name

### DIFF
--- a/packages/twenty-server/src/database/typeorm-seeds/workspace/workspace-members.ts
+++ b/packages/twenty-server/src/database/typeorm-seeds/workspace/workspace-members.ts
@@ -55,7 +55,7 @@ export const seedWorkspaceMember = async (
       {
         id: DEV_SEED_WORKSPACE_MEMBER_IDS.PHIL,
         nameFirstName: 'Phil',
-        nameLastName: 'Shiler',
+        nameLastName: 'Schiler',
         locale: 'en',
         colorScheme: 'Light',
         userEmail: 'phil.schiler@apple.dev',


### PR DESCRIPTION
Fixes #8290

Correct the last name of the default member "Phil Shiler" to "Phil Schiler" in the `packages/twenty-server/src/database/typeorm-seeds/workspace/workspace-members.ts` file.

* Change the last name from "Shiler" to "Schiler" for the user with the email `phil.schiler@apple.dev`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/twentyhq/twenty/issues/8290?shareId=13cc0610-8aaf-45f9-9e96-2a723ed60218).