### PR TITLE
Add search bar to settings

### DIFF
--- a/packages/twenty-front/src/modules/app/components/SettingsRoutes.tsx
+++ b/packages/twenty-front/src/modules/app/components/SettingsRoutes.tsx
@@ -4,6 +4,7 @@ import { Route, Routes } from 'react-router-dom';
 import { SettingsSkeletonLoader } from '@/settings/components/SettingsSkeletonLoader';
 import { AppPath } from '@/types/AppPath';
 import { SettingsPath } from '@/types/SettingsPath';
+import { CommandMenu } from '@/command-menu/components/CommandMenu';
 
 const SettingsAccountsCalendars = lazy(() =>
   import('~/pages/settings/accounts/SettingsAccountsCalendars').then(
@@ -200,7 +201,8 @@ const SettingsIntegrationShowDatabaseConnection = lazy(() =>
     '~/pages/settings/integrations/SettingsIntegrationShowDatabaseConnection'
   ).then((module) => ({
     default: module.SettingsIntegrationShowDatabaseConnection,
-  })),
+    }),
+  ),
 );
 
 const SettingsObjectNewFieldSelect = lazy(() =>
@@ -262,6 +264,7 @@ export const SettingsRoutes = ({
   isSSOEnabled,
 }: SettingsRoutesProps) => (
   <Suspense fallback={<SettingsSkeletonLoader />}>
+    <CommandMenu />
     <Routes>
       <Route path={SettingsPath.ProfilePage} element={<SettingsProfile />} />
       <Route path={SettingsPath.Appearance} element={<SettingsAppearance />} />

--- a/packages/twenty-front/src/modules/command-menu/components/CommandMenu.tsx
+++ b/packages/twenty-front/src/modules/command-menu/components/CommandMenu.tsx
@@ -550,3 +550,5 @@ export const CommandMenu = () => {
     </>
   );
 };
+
+export { CommandMenu };

--- a/packages/twenty-front/src/modules/navigation/components/MainNavigationDrawerItems.tsx
+++ b/packages/twenty-front/src/modules/navigation/components/MainNavigationDrawerItems.tsx
@@ -37,6 +37,7 @@ export const MainNavigationDrawerItems = () => {
         <NavigationDrawerSection>
           <NavigationDrawerItem
             label="Search"
+            to="/settings/profile"
             Icon={IconSearch}
             onClick={toggleCommandMenu}
             keyboard={['⌘', 'K']}

--- a/packages/twenty-front/src/modules/navigation/components/MobileNavigationBar.tsx
+++ b/packages/twenty-front/src/modules/navigation/components/MobileNavigationBar.tsx
@@ -12,6 +12,7 @@ import {
 } from 'twenty-ui';
 import { useIsSettingsPage } from '../hooks/useIsSettingsPage';
 import { currentMobileNavigationDrawerState } from '../states/currentMobileNavigationDrawerState';
+import { useNavigate } from 'react-router-dom';
 
 type NavigationBarItemName = 'main' | 'search' | 'tasks' | 'settings';
 
@@ -25,6 +26,7 @@ export const MobileNavigationBar = () => {
     useRecoilState(currentMobileNavigationDrawerState);
 
   const { openSettingsMenu } = useOpenSettingsMenu();
+  const navigate = useNavigate();
 
   const activeItemName = isNavigationDrawerExpanded
     ? currentMobileNavigationDrawer
@@ -58,6 +60,7 @@ export const MobileNavigationBar = () => {
           openCommandMenu();
         }
         setIsNavigationDrawerExpanded(false);
+        navigate('/settings/profile');
       },
     },
     {


### PR DESCRIPTION
Fixes twentyhq/core-team-issues#96

Add a search bar to the settings page.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/twentyhq/twenty/issues/8176?shareId=4480ef7e-287f-42f8-81a8-b6bcf28801f1).