### PR TITLE
Fix 0.32

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version/0-32/0-32-enforce-unique-constraints.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-32/0-32-enforce-unique-constraints.command.ts
@@ -107,11 +107,10 @@ export class EnforceUniqueConstraintsCommand extends ActiveWorkspacesCommandRunn
     dryRun: boolean,
     options: EnforceUniqueConstraintsCommandOptions,
   ): Promise<void> {
+    await this.enforceUniquePersonEmail(workspaceId, dryRun);
+
     if (options.company) {
       await this.enforceUniqueCompanyDomainName(workspaceId, dryRun);
-    }
-    if (options.person) {
-      await this.enforceUniquePersonEmail(workspaceId, dryRun);
     }
     if (options.viewField) {
       await this.enforceUniqueViewField(workspaceId, dryRun);

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-runner/workspace-migration-runner.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-runner/workspace-migration-runner.service.ts
@@ -522,6 +522,10 @@ export class WorkspaceMigrationRunnerService {
     );
 
     if (!foreignKeyName) {
+      // Todo: Remove this temporary hack tied to 0.32 upgrade
+      if (migrationColumn.columnName === 'activityId') {
+        return;
+      }
       throw new Error(
         `Foreign key not found for column ${migrationColumn.columnName}`,
       );

--- a/packages/twenty-server/src/modules/person/standard-objects/person.workspace-entity.ts
+++ b/packages/twenty-server/src/modules/person/standard-objects/person.workspace-entity.ts
@@ -22,7 +22,6 @@ import { WorkspaceField } from 'src/engine/twenty-orm/decorators/workspace-field
 import { WorkspaceIsDeprecated } from 'src/engine/twenty-orm/decorators/workspace-is-deprecated.decorator';
 import { WorkspaceIsNullable } from 'src/engine/twenty-orm/decorators/workspace-is-nullable.decorator';
 import { WorkspaceIsSystem } from 'src/engine/twenty-orm/decorators/workspace-is-system.decorator';
-import { WorkspaceIsUnique } from 'src/engine/twenty-orm/decorators/workspace-is-unique.decorator';
 import { WorkspaceJoinColumn } from 'src/engine/twenty-orm/decorators/workspace-join-column.decorator';
 import { WorkspaceRelation } from 'src/engine/twenty-orm/decorators/workspace-relation.decorator';
 import { PERSON_STANDARD_FIELD_IDS } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-field-ids';
@@ -81,7 +80,7 @@ export class PersonWorkspaceEntity extends BaseWorkspaceEntity {
     description: 'Contact’s Emails',
     icon: 'IconMail',
   })
-  @WorkspaceIsUnique()
+  // @WorkspaceIsUnique()
   [EMAILS_FIELD_NAME]: EmailsMetadata;
 
   @WorkspaceField({


### PR DESCRIPTION
- Removing unique constraint creation in 0.32 as we have a dependency on sync-metadata and sync-metadata has a dependency on it if we keep it.
- sync-metadata does not support well the deletion of activity + activityTarget, silently swallow the exception for now