### PR TITLE
[FIX] Kanban field select

### DIFF
--- a/packages/twenty-front/src/modules/ui/input/components/Select.tsx
+++ b/packages/twenty-front/src/modules/ui/input/components/Select.tsx
@@ -91,8 +91,7 @@ export const Select = <Value extends string | number | null>({
   );
 
   const isDisabled =
-    disabledFromProps ||
-    (options.length < 1 && !isDefined(callToActionButton));
+    disabledFromProps || (options.length < 1 && !isDefined(callToActionButton));
 
   const { closeDropdown } = useDropdown(dropdownId);
 

--- a/packages/twenty-front/src/modules/ui/input/components/Select.tsx
+++ b/packages/twenty-front/src/modules/ui/input/components/Select.tsx
@@ -57,7 +57,7 @@ const StyledLabel = styled.span`
 
 export const Select = <Value extends string | number | null>({
   className,
-  disabled: disabledFromProps,
+  disabled: disabledFromProps = false,
   disableBlur = false,
   dropdownId,
   dropdownWidth = 176,
@@ -92,7 +92,7 @@ export const Select = <Value extends string | number | null>({
 
   const isDisabled =
     disabledFromProps ||
-    (options.length <= 1 && !isDefined(callToActionButton));
+    (options.length < 1 && !isDefined(callToActionButton));
 
   const { closeDropdown } = useDropdown(dropdownId);
 


### PR DESCRIPTION
FIX #6048 

This fixes the issue by showing the select field if there's any. However as mentioned in the issue comment it also shows, `No select field` when there are no fields that could be used to create a kanban view. 

Let me know if some updates are needed on my side. 

Thanks!