### PR TITLE
Add blue focus on text inputs

### DIFF
--- a/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpForm.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpForm.tsx
@@ -204,7 +204,9 @@ export const SignInUpForm = () => {
           </>
         )}
 
-        {signInUpStep !== SignInUpStep.Init && (
+        {signInUpStep !== SignInUpStep.Init && (authProviders.google ||
+          authProviders.microsoft ||
+          authProviders.sso) &&(
           <HorizontalSeparator visible />
         )}
 

--- a/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpForm.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpForm.tsx
@@ -24,6 +24,7 @@ import {
   ActionLink,
   IconGoogle,
   IconKey,
+  IconMail,
   IconMicrosoft,
   Loader,
   MainButton,
@@ -155,6 +156,11 @@ export const SignInUpForm = () => {
               Icon={() => <IconGoogle size={theme.icon.size.lg} />}
               title="Continue with Google"
               onClick={signInWithGoogle}
+              variant={
+                signInUpStep === SignInUpStep.Init
+                  ? undefined
+                  : 'secondary'
+              }
               fullWidth
             />
             <HorizontalSeparator visible={false} />
@@ -167,6 +173,11 @@ export const SignInUpForm = () => {
               Icon={() => <IconMicrosoft size={theme.icon.size.lg} />}
               title="Continue with Microsoft"
               onClick={signInWithMicrosoft}
+              variant={
+                signInUpStep === SignInUpStep.Init
+                  ? undefined
+                  : 'secondary'
+              }
               fullWidth
             />
             <HorizontalSeparator visible={false} />
@@ -176,6 +187,11 @@ export const SignInUpForm = () => {
           <>
             <MainButton
               Icon={() => <IconKey size={theme.icon.size.lg} />}
+              variant={
+                signInUpStep === SignInUpStep.Init
+                  ? undefined
+                  : 'secondary'
+              }
               title={
                 signInUpStep === SignInUpStep.SSOEmail
                   ? 'Continue with email'
@@ -188,9 +204,9 @@ export const SignInUpForm = () => {
           </>
         )}
 
-        {(authProviders.google ||
-          authProviders.microsoft ||
-          authProviders.sso) && <HorizontalSeparator visible />}
+        {signInUpStep !== SignInUpStep.Init && (
+          <HorizontalSeparator visible />
+        )}
 
         {authProviders.password &&
           (signInUpStep === SignInUpStep.Password ||
@@ -282,9 +298,9 @@ export const SignInUpForm = () => {
                 </StyledFullWidthMotionDiv>
               )}
               <MainButton
-                variant="secondary"
                 title={buttonTitle}
                 type="submit"
+                variant="primary"
                 onClick={async () => {
                   if (signInUpStep === SignInUpStep.Init) {
                     continueWithEmail();
@@ -301,7 +317,13 @@ export const SignInUpForm = () => {
                   setShowErrors(true);
                   form.handleSubmit(submitCredentials)();
                 }}
-                Icon={() => form.formState.isSubmitting && <Loader />}
+                Icon={() =>
+                  form.formState.isSubmitting ? (
+                    <Loader />
+                  ) : (
+                    <IconMail size={theme.icon.size.lg} />
+                  )
+                }
                 disabled={isSubmitButtonDisabled}
                 fullWidth
               />

--- a/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpForm.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpForm.tsx
@@ -165,11 +165,7 @@ export const SignInUpForm = () => {
               Icon={() => <IconGoogle size={theme.icon.size.lg} />}
               title="Continue with Google"
               onClick={signInWithGoogle}
-              variant={
-                signInUpStep === SignInUpStep.Init
-                  ? undefined
-                  : 'secondary'
-              }
+              variant="secondary"
               fullWidth
             />
             <HorizontalSeparator visible={false} />
@@ -182,11 +178,7 @@ export const SignInUpForm = () => {
               Icon={() => <IconMicrosoft size={theme.icon.size.lg} />}
               title="Continue with Microsoft"
               onClick={signInWithMicrosoft}
-              variant={
-                signInUpStep === SignInUpStep.Init
-                  ? undefined
-                  : 'secondary'
-              }
+              variant="secondary"
               fullWidth
             />
             <HorizontalSeparator visible={false} />
@@ -196,11 +188,7 @@ export const SignInUpForm = () => {
           <>
             <MainButton
               Icon={() => <IconKey size={theme.icon.size.lg} />}
-              variant={
-                signInUpStep === SignInUpStep.Init
-                  ? undefined
-                  : 'secondary'
-              }
+              variant="secondary"
               title={
                 signInUpStep === SignInUpStep.SSOEmail
                   ? 'Continue with email'
@@ -213,11 +201,10 @@ export const SignInUpForm = () => {
           </>
         )}
 
-        {signInUpStep !== SignInUpStep.Init && (authProviders.google ||
-          authProviders.microsoft ||
-          authProviders.sso) &&(
-          <HorizontalSeparator visible />
-        )}
+        {signInUpStep !== SignInUpStep.Init &&
+          (authProviders.google ||
+            authProviders.microsoft ||
+            authProviders.sso) && <HorizontalSeparator visible />}
 
         {authProviders.password &&
           (signInUpStep === SignInUpStep.Password ||
@@ -311,7 +298,9 @@ export const SignInUpForm = () => {
               <MainButton
                 title={buttonTitle}
                 type="submit"
-                variant="primary"
+                variant={
+                  signInUpStep === SignInUpStep.Init ? 'secondary' : 'primary'
+                }
                 onClick={async () => {
                   if (signInUpStep === SignInUpStep.Init) {
                     continueWithEmail();
@@ -331,9 +320,9 @@ export const SignInUpForm = () => {
                 Icon={() =>
                   form.formState.isSubmitting ? (
                     <Loader />
-                  ) : (
-                    signInUpStep === SignInUpStep.Init ? <IconMail size={theme.icon.size.lg} /> : null
-                  )
+                  ) : signInUpStep === SignInUpStep.Init ? (
+                    <IconMail size={theme.icon.size.lg} />
+                  ) : null
                 }
                 disabled={isSubmitButtonDisabled}
                 fullWidth

--- a/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpForm.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpForm.tsx
@@ -16,7 +16,7 @@ import { TextInput } from '@/ui/input/components/TextInput';
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { motion } from 'framer-motion';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Controller } from 'react-hook-form';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { Key } from 'ts-key-enum';
@@ -73,6 +73,17 @@ export const SignInUpForm = () => {
     submitCredentials,
     submitSSOEmail,
   } = useSignInUp(form);
+
+  useEffect(() => {
+    if (
+      signInUpStep === SignInUpStep.Init &&
+      !authProviders.google &&
+      !authProviders.microsoft &&
+      !authProviders.sso
+    ) {
+      continueWithEmail();
+    }
+  }, [signInUpStep, authProviders, continueWithEmail]);
 
   const toggleSSOMode = () => {
     if (signInUpStep === SignInUpStep.SSOEmail) {
@@ -323,7 +334,7 @@ export const SignInUpForm = () => {
                   form.formState.isSubmitting ? (
                     <Loader />
                   ) : (
-                    <IconMail size={theme.icon.size.lg} />
+                    signInUpStep === SignInUpStep.Init ? <IconMail size={theme.icon.size.lg} /> : null
                   )
                 }
                 disabled={isSubmitButtonDisabled}

--- a/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpForm.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpForm.tsx
@@ -24,11 +24,10 @@ import {
   ActionLink,
   IconGoogle,
   IconKey,
-  IconMail,
   IconMicrosoft,
   Loader,
   MainButton,
-  StyledText,
+  StyledText
 } from 'twenty-ui';
 import { isDefined } from '~/utils/isDefined';
 
@@ -213,7 +212,7 @@ export const SignInUpForm = () => {
           </>
         )}
 
-        {signInUpStep !== SignInUpStep.Init && (authProviders.google ||
+        {(authProviders.google ||
           authProviders.microsoft ||
           authProviders.sso) &&(
           <HorizontalSeparator visible />
@@ -311,7 +310,9 @@ export const SignInUpForm = () => {
               <MainButton
                 title={buttonTitle}
                 type="submit"
-                variant="primary"
+                variant={
+                  signInUpStep === SignInUpStep.Init ? 'secondary' : 'primary'
+                }
                 onClick={async () => {
                   if (signInUpStep === SignInUpStep.Init) {
                     continueWithEmail();
@@ -331,9 +332,7 @@ export const SignInUpForm = () => {
                 Icon={() =>
                   form.formState.isSubmitting ? (
                     <Loader />
-                  ) : (
-                    signInUpStep === SignInUpStep.Init ? <IconMail size={theme.icon.size.lg} /> : null
-                  )
+                  ) : null
                 }
                 disabled={isSubmitButtonDisabled}
                 fullWidth

--- a/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpForm.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpForm.tsx
@@ -165,7 +165,11 @@ export const SignInUpForm = () => {
               Icon={() => <IconGoogle size={theme.icon.size.lg} />}
               title="Continue with Google"
               onClick={signInWithGoogle}
-              variant="secondary"
+              variant={
+                signInUpStep === SignInUpStep.Init
+                  ? undefined
+                  : 'secondary'
+              }
               fullWidth
             />
             <HorizontalSeparator visible={false} />
@@ -178,7 +182,11 @@ export const SignInUpForm = () => {
               Icon={() => <IconMicrosoft size={theme.icon.size.lg} />}
               title="Continue with Microsoft"
               onClick={signInWithMicrosoft}
-              variant="secondary"
+              variant={
+                signInUpStep === SignInUpStep.Init
+                  ? undefined
+                  : 'secondary'
+              }
               fullWidth
             />
             <HorizontalSeparator visible={false} />
@@ -188,7 +196,11 @@ export const SignInUpForm = () => {
           <>
             <MainButton
               Icon={() => <IconKey size={theme.icon.size.lg} />}
-              variant="secondary"
+              variant={
+                signInUpStep === SignInUpStep.Init
+                  ? undefined
+                  : 'secondary'
+              }
               title={
                 signInUpStep === SignInUpStep.SSOEmail
                   ? 'Continue with email'
@@ -201,10 +213,11 @@ export const SignInUpForm = () => {
           </>
         )}
 
-        {signInUpStep !== SignInUpStep.Init &&
-          (authProviders.google ||
-            authProviders.microsoft ||
-            authProviders.sso) && <HorizontalSeparator visible />}
+        {signInUpStep !== SignInUpStep.Init && (authProviders.google ||
+          authProviders.microsoft ||
+          authProviders.sso) &&(
+          <HorizontalSeparator visible />
+        )}
 
         {authProviders.password &&
           (signInUpStep === SignInUpStep.Password ||
@@ -298,9 +311,7 @@ export const SignInUpForm = () => {
               <MainButton
                 title={buttonTitle}
                 type="submit"
-                variant={
-                  signInUpStep === SignInUpStep.Init ? 'secondary' : 'primary'
-                }
+                variant="primary"
                 onClick={async () => {
                   if (signInUpStep === SignInUpStep.Init) {
                     continueWithEmail();
@@ -320,9 +331,9 @@ export const SignInUpForm = () => {
                 Icon={() =>
                   form.formState.isSubmitting ? (
                     <Loader />
-                  ) : signInUpStep === SignInUpStep.Init ? (
-                    <IconMail size={theme.icon.size.lg} />
-                  ) : null
+                  ) : (
+                    signInUpStep === SignInUpStep.Init ? <IconMail size={theme.icon.size.lg} /> : null
+                  )
                 }
                 disabled={isSubmitButtonDisabled}
                 fullWidth

--- a/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpForm.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpForm.tsx
@@ -16,7 +16,7 @@ import { TextInput } from '@/ui/input/components/TextInput';
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { motion } from 'framer-motion';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Controller } from 'react-hook-form';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { Key } from 'ts-key-enum';
@@ -74,16 +74,14 @@ export const SignInUpForm = () => {
     submitSSOEmail,
   } = useSignInUp(form);
 
-  useEffect(() => {
-    if (
-      signInUpStep === SignInUpStep.Init &&
-      !authProviders.google &&
-      !authProviders.microsoft &&
-      !authProviders.sso
-    ) {
-      continueWithEmail();
-    }
-  }, [signInUpStep, authProviders, continueWithEmail]);
+  if (
+    signInUpStep === SignInUpStep.Init &&
+    !authProviders.google &&
+    !authProviders.microsoft &&
+    !authProviders.sso
+  ) {
+    continueWithEmail();
+  }
 
   const toggleSSOMode = () => {
     if (signInUpStep === SignInUpStep.SSOEmail) {

--- a/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpForm.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpForm.tsx
@@ -27,7 +27,7 @@ import {
   IconMicrosoft,
   Loader,
   MainButton,
-  StyledText
+  StyledText,
 } from 'twenty-ui';
 import { isDefined } from '~/utils/isDefined';
 
@@ -165,9 +165,7 @@ export const SignInUpForm = () => {
               title="Continue with Google"
               onClick={signInWithGoogle}
               variant={
-                signInUpStep === SignInUpStep.Init
-                  ? undefined
-                  : 'secondary'
+                signInUpStep === SignInUpStep.Init ? undefined : 'secondary'
               }
               fullWidth
             />
@@ -182,9 +180,7 @@ export const SignInUpForm = () => {
               title="Continue with Microsoft"
               onClick={signInWithMicrosoft}
               variant={
-                signInUpStep === SignInUpStep.Init
-                  ? undefined
-                  : 'secondary'
+                signInUpStep === SignInUpStep.Init ? undefined : 'secondary'
               }
               fullWidth
             />
@@ -196,9 +192,7 @@ export const SignInUpForm = () => {
             <MainButton
               Icon={() => <IconKey size={theme.icon.size.lg} />}
               variant={
-                signInUpStep === SignInUpStep.Init
-                  ? undefined
-                  : 'secondary'
+                signInUpStep === SignInUpStep.Init ? undefined : 'secondary'
               }
               title={
                 signInUpStep === SignInUpStep.SSOEmail
@@ -214,9 +208,7 @@ export const SignInUpForm = () => {
 
         {(authProviders.google ||
           authProviders.microsoft ||
-          authProviders.sso) &&(
-          <HorizontalSeparator visible />
-        )}
+          authProviders.sso) && <HorizontalSeparator visible />}
 
         {authProviders.password &&
           (signInUpStep === SignInUpStep.Password ||
@@ -329,11 +321,7 @@ export const SignInUpForm = () => {
                   setShowErrors(true);
                   form.handleSubmit(submitCredentials)();
                 }}
-                Icon={() =>
-                  form.formState.isSubmitting ? (
-                    <Loader />
-                  ) : null
-                }
+                Icon={() => (form.formState.isSubmitting ? <Loader /> : null)}
                 disabled={isSubmitButtonDisabled}
                 fullWidth
               />

--- a/packages/twenty-front/src/modules/object-record/object-filter-dropdown/components/MultipleFiltersDropdownFilterOnFilterChangedEffect.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-filter-dropdown/components/MultipleFiltersDropdownFilterOnFilterChangedEffect.tsx
@@ -16,7 +16,7 @@ export const MultipleFiltersDropdownFilterOnFilterChangedEffect = ({
         setDropdownWidth(280);
         break;
       default:
-        setDropdownWidth(160);
+        setDropdownWidth(200);
     }
   }, [filterDefinitionUsedInDropdownType, setDropdownWidth]);
 

--- a/packages/twenty-front/src/modules/ui/input/components/TextInputV2.tsx
+++ b/packages/twenty-front/src/modules/ui/input/components/TextInputV2.tsx
@@ -10,7 +10,7 @@ import {
   useRef,
   useState,
 } from 'react';
-import { IconComponent, IconEye, IconEyeOff } from 'twenty-ui';
+import { IconComponent, IconEye, IconEyeOff, RGBA } from 'twenty-ui';
 import { useCombinedRefs } from '~/hooks/useCombinedRefs';
 import { turnIntoEmptyStringIfWhitespacesOnly } from '~/utils/string/turnIntoEmptyStringIfWhitespacesOnly';
 
@@ -33,6 +33,7 @@ const StyledInputContainer = styled.div`
   display: flex;
   flex-direction: row;
   width: 100%;
+  position: relative;
 `;
 
 const StyledInput = styled.input<
@@ -42,11 +43,8 @@ const StyledInput = styled.input<
   border: 1px solid
     ${({ theme, error }) =>
       error ? theme.border.color.danger : theme.border.color.medium};
-  border-bottom-left-radius: ${({ theme, LeftIcon }) =>
-    !LeftIcon && theme.border.radius.sm};
-  border-right: none;
   border-left: ${({ LeftIcon }) => LeftIcon && 'none'};
-  border-top-left-radius: ${({ theme, LeftIcon }) =>
+  border-radius: ${({ theme, LeftIcon }) =>
     !LeftIcon && theme.border.radius.sm};
   box-sizing: border-box;
   color: ${({ theme }) => theme.font.color.primary};
@@ -68,6 +66,13 @@ const StyledInput = styled.input<
 
   &:disabled {
     color: ${({ theme }) => theme.font.color.tertiary};
+  }
+
+  &:focus {
+    ${({ theme }) => {
+      return `box-shadow: 0px 0px 0px 3px ${RGBA(theme.color.blue, 0.1)};
+      border-color: ${theme.color.blue};`;
+    }};
   }
 `;
 
@@ -93,16 +98,14 @@ const StyledTrailingIconContainer = styled.div<
   Pick<TextInputV2ComponentProps, 'error'>
 >`
   align-items: center;
-  background-color: ${({ theme }) => theme.background.transparent.lighter};
-  border: 1px solid
-    ${({ theme, error }) =>
-      error ? theme.border.color.danger : theme.border.color.medium};
-  border-bottom-right-radius: ${({ theme }) => theme.border.radius.sm};
-  border-left: none;
-  border-top-right-radius: ${({ theme }) => theme.border.radius.sm};
   display: flex;
   justify-content: center;
   padding-right: ${({ theme }) => theme.spacing(1)};
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  margin: auto 0;
 `;
 
 const StyledTrailingIcon = styled.div`

--- a/packages/twenty-front/src/modules/ui/input/components/TextInputV2.tsx
+++ b/packages/twenty-front/src/modules/ui/input/components/TextInputV2.tsx
@@ -43,9 +43,7 @@ const StyledInput = styled.input<
   border: 1px solid
     ${({ theme, error }) =>
       error ? theme.border.color.danger : theme.border.color.medium};
-  border-left: ${({ LeftIcon }) => LeftIcon && 'none'};
-  border-radius: ${({ theme, LeftIcon }) =>
-    !LeftIcon && theme.border.radius.sm};
+  border-radius: ${({ theme }) => theme.border.radius.sm};
   box-sizing: border-box;
   color: ${({ theme }) => theme.font.color.primary};
   display: flex;
@@ -55,6 +53,8 @@ const StyledInput = styled.input<
   height: 32px;
   outline: none;
   padding: ${({ theme }) => theme.spacing(2)};
+  padding-left: ${({ theme, LeftIcon }) =>
+    LeftIcon ? `calc(${theme.spacing(4)} + 16px)` : theme.spacing(2)};
   width: 100%;
 
   &::placeholder,
@@ -84,14 +84,13 @@ const StyledErrorHelper = styled.div`
 
 const StyledLeftIconContainer = styled.div`
   align-items: center;
-  background-color: ${({ theme }) => theme.background.transparent.lighter};
-  border: 1px solid ${({ theme }) => theme.border.color.medium};
-  border-bottom-left-radius: ${({ theme }) => theme.border.radius.sm};
-  border-right: none;
-  border-top-left-radius: ${({ theme }) => theme.border.radius.sm};
   display: flex;
   justify-content: center;
   padding-left: ${({ theme }) => theme.spacing(2)};
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  margin: auto 0;
 `;
 
 const StyledTrailingIconContainer = styled.div<

--- a/packages/twenty-front/src/modules/ui/layout/dropdown/components/DropdownMenu.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/dropdown/components/DropdownMenu.tsx
@@ -27,7 +27,7 @@ const StyledDropdownMenu = styled.div<{
 
   flex-direction: column;
   z-index: 30;
-  width: ${({ width = 160 }) =>
+  width: ${({ width = 200 }) =>
     typeof width === 'number' ? `${width}px` : width};
 `;
 

--- a/packages/twenty-front/src/modules/ui/layout/dropdown/hooks/__tests__/useDropdown.test.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/dropdown/hooks/__tests__/useDropdown.test.tsx
@@ -1,6 +1,6 @@
-import { act } from 'react-dom/test-utils';
 import { expect } from '@storybook/test';
 import { renderHook } from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
 import { RecoilRoot } from 'recoil';
 
 import { useDropdown } from '@/ui/layout/dropdown/hooks/useDropdown';
@@ -57,7 +57,7 @@ describe('useDropdown', () => {
       wrapper: Wrapper,
     });
 
-    expect(result.current.dropdownWidth).toBe(160);
+    expect(result.current.dropdownWidth).toBe(200);
 
     await act(async () => {
       result.current.setDropdownWidth(220);

--- a/packages/twenty-front/src/modules/ui/layout/dropdown/states/dropdownWidthComponentState.ts
+++ b/packages/twenty-front/src/modules/ui/layout/dropdown/states/dropdownWidthComponentState.ts
@@ -4,5 +4,5 @@ export const dropdownWidthComponentState = createComponentState<
   number | undefined
 >({
   key: 'dropdownWidthComponentState',
-  defaultValue: 160,
+  defaultValue: 200,
 });

--- a/packages/twenty-front/src/modules/views/view-picker/components/ViewPickerContentCreateMode.tsx
+++ b/packages/twenty-front/src/modules/views/view-picker/components/ViewPickerContentCreateMode.tsx
@@ -4,8 +4,8 @@ import { IconLayoutKanban, IconTable, IconX } from 'twenty-ui';
 
 import { IconPicker } from '@/ui/input/components/IconPicker';
 import { Select } from '@/ui/input/components/Select';
+import { TextInputV2 } from '@/ui/input/components/TextInputV2';
 import { DropdownMenuHeader } from '@/ui/layout/dropdown/components/DropdownMenuHeader';
-import { DropdownMenuInput } from '@/ui/layout/dropdown/components/DropdownMenuInput';
 import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/DropdownMenuItemsContainer';
 import { DropdownMenuSeparator } from '@/ui/layout/dropdown/components/DropdownMenuSeparator';
 import { useScopedHotkeys } from '@/ui/utilities/hotkey/hooks/useScopedHotkeys';
@@ -120,11 +120,11 @@ export const ViewPickerContentCreateMode = () => {
             disableBlur
             onClose={() => setHotkeyScope(ViewsHotkeyScope.ListDropdown)}
           />
-          <DropdownMenuInput
+          <TextInputV2
             value={viewPickerInputName}
-            onChange={(event) => {
+            onChange={(value) => {
               setViewPickerIsDirty(true);
-              setViewPickerInputName(event.target.value);
+              setViewPickerInputName(value);
             }}
             autoFocus
           />

--- a/packages/twenty-front/src/modules/views/view-picker/components/ViewPickerContentEditMode.tsx
+++ b/packages/twenty-front/src/modules/views/view-picker/components/ViewPickerContentEditMode.tsx
@@ -2,8 +2,8 @@ import { Key } from 'ts-key-enum';
 import { IconChevronLeft } from 'twenty-ui';
 
 import { IconPicker } from '@/ui/input/components/IconPicker';
+import { TextInputV2 } from '@/ui/input/components/TextInputV2';
 import { DropdownMenuHeader } from '@/ui/layout/dropdown/components/DropdownMenuHeader';
-import { DropdownMenuInput } from '@/ui/layout/dropdown/components/DropdownMenuInput';
 import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/DropdownMenuItemsContainer';
 import { DropdownMenuSeparator } from '@/ui/layout/dropdown/components/DropdownMenuSeparator';
 import { useScopedHotkeys } from '@/ui/utilities/hotkey/hooks/useScopedHotkeys';
@@ -79,11 +79,11 @@ export const ViewPickerContentEditMode = () => {
             disableBlur
             onClose={() => setHotkeyScope(ViewsHotkeyScope.ListDropdown)}
           />
-          <DropdownMenuInput
+          <TextInputV2
             value={viewPickerInputName}
-            onChange={(event) => {
+            onChange={(value) => {
               setViewPickerIsDirty(true);
-              setViewPickerInputName(event.target.value);
+              setViewPickerInputName(value);
             }}
             autoFocus
           />

--- a/packages/twenty-front/src/pages/auth/SignInUp.tsx
+++ b/packages/twenty-front/src/pages/auth/SignInUp.tsx
@@ -7,10 +7,10 @@ import { SignInUpForm } from '@/auth/sign-in-up/components/SignInUpForm';
 import { SignInUpMode, useSignInUp } from '@/auth/sign-in-up/hooks/useSignInUp';
 import { useSignInUpForm } from '@/auth/sign-in-up/hooks/useSignInUpForm';
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
-import { AnimatedEaseIn } from 'twenty-ui';
-import { isDefined } from '~/utils/isDefined';
 import { SignInUpStep } from '@/auth/states/signInUpStepState';
 import { IconLockCustom } from '@ui/display/icon/components/IconLock';
+import { AnimatedEaseIn } from 'twenty-ui';
+import { isDefined } from '~/utils/isDefined';
 import { SSOWorkspaceSelection } from './SSOWorkspaceSelection';
 
 export const SignInUp = () => {


### PR DESCRIPTION
We removed the blue focus on phone/domain/array/email floating inputs but we want to keep it in the app settings.

<img width="644" alt="Screenshot 2024-11-05 at 15 55 04" src="https://github.com/user-attachments/assets/afcbe6b2-2d6b-4e0d-8397-4268d529127c">
<img width="606" alt="Screenshot 2024-11-05 at 15 55 23" src="https://github.com/user-attachments/assets/004becf8-41e7-45d6-9ad9-9e487b8db8f3">
<img width="351" alt="Screenshot 2024-11-05 at 15 55 33" src="https://github.com/user-attachments/assets/6a4c06e6-04d3-46bf-940b-9fd61ee91995">
<img width="330" alt="Screenshot 2024-11-05 at 15 55 41" src="https://github.com/user-attachments/assets/e6fc8bbd-eca3-47bc-93f1-d6ff8d3d8a13">
<img width="588" alt="Screenshot 2024-11-05 at 15 56 07" src="https://github.com/user-attachments/assets/0d0f5e80-3501-4346-94a1-6ea4b77ee7ba">
<img width="211" alt="Screenshot 2024-11-05 at 15 56 31" src="https://github.com/user-attachments/assets/9cd85f4d-8052-4c6b-a694-84c691c6217d">
