### PR TITLE
8304 - Fix Action Menu Buttons Alignment

### DIFF
--- a/packages/twenty-front/src/modules/action-menu/components/ActionMenuConfirmationModals.tsx
+++ b/packages/twenty-front/src/modules/action-menu/components/ActionMenuConfirmationModals.tsx
@@ -1,5 +1,10 @@
 import { actionMenuEntriesComponentSelector } from '@/action-menu/states/actionMenuEntriesComponentSelector';
 import { useRecoilComponentValueV2 } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValueV2';
+import styled from '@emotion/styled';
+
+const StyledActionMenuConfirmationModals = styled.div`
+  position: absolute;
+`;
 
 export const ActionMenuConfirmationModals = () => {
   const actionMenuEntries = useRecoilComponentValueV2(
@@ -7,12 +12,12 @@ export const ActionMenuConfirmationModals = () => {
   );
 
   return (
-    <div data-select-disable>
+    <StyledActionMenuConfirmationModals data-select-disable>
       {actionMenuEntries.map((actionMenuEntry, index) =>
         actionMenuEntry.ConfirmationModal ? (
           <div key={index}>{actionMenuEntry.ConfirmationModal}</div>
         ) : null,
       )}
-    </div>
+    </StyledActionMenuConfirmationModals>
   );
 };

--- a/packages/twenty-front/src/pages/object-record/RecordShowPage.tsx
+++ b/packages/twenty-front/src/pages/object-record/RecordShowPage.tsx
@@ -65,17 +65,15 @@ export const RecordShowPage = () => {
                     workflowVersionId={objectRecordId}
                   />
                 ) : (
-                  <>
-                    <RecordShowActionMenu
-                      {...{
-                        isFavorite,
-                        handleFavoriteButtonClick,
-                        record,
-                        objectMetadataItem,
-                        objectNameSingular,
-                      }}
-                    />
-                  </>
+                  <RecordShowActionMenu
+                    {...{
+                      isFavorite,
+                      handleFavoriteButtonClick,
+                      record,
+                      objectMetadataItem,
+                      objectNameSingular,
+                    }}
+                  />
                 )}
               </>
             </RecordShowPageHeader>


### PR DESCRIPTION
Closes #8304

The position of the modal container wasn't absolute, so the gap was also applied after the `ShowPageMoreButton`