### PR TITLE
fix : composite field parsing in useTimelineActivities hook  #8300

### DIFF
--- a/packages/twenty-front/src/modules/activities/timeline-activities/hooks/useTimelineActivities.ts
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/hooks/useTimelineActivities.ts
@@ -40,20 +40,23 @@ export const useTimelineActivities = (
     fetchPolicy: 'cache-and-network',
   });
 
-  // NEW: Parse composite fields if they are returned as strings (e.g., JSON strings)
-  const parsedTimelineActivities = timelineActivities.map((activity) => {
-    if (
-      activity.compositeField &&
-      typeof activity.compositeField === 'string'
-    ) {
-      try {
-        activity.compositeField = JSON.parse(activity.compositeField);
-      } catch (error) {
-        console.error('Error parsing composite field', error);
-      }
+const parsedTimelineActivities = timelineActivities.map((activity) => {
+
+  const parsedActivity = { ...activity };
+
+  if (
+    parsedActivity.compositeField &&
+    typeof parsedActivity.compositeField === 'string'
+  ) {
+    try {
+      parsedActivity.compositeField = JSON.parse(parsedActivity.compositeField);
+    } catch (error) {
+      console.error('Error parsing composite field', error);
+      parsedActivity.compositeField = [];
     }
-    return activity;
-  });
+  }
+  return parsedActivity;
+});
 
 
   const activityIds = parsedTimelineActivities


### PR DESCRIPTION
### Summary
This PR fixes an issue where composite fields were being returned as strings instead of arrays in the `useTimelineActivities` hook. It parses those string fields (like `compositeField`) and converts them into arrays, ensuring correct behavior.

### Changes
- Added logic to parse composite fields when returned as strings.
- Ensured that activities are filtered and processed correctly after the parsing.

### Related Issue
- Issue #8300