### PR TITLE
Update total count on record deletion

### DIFF
--- a/packages/twenty-front/src/modules/apollo/optimistic-effect/utils/triggerUpdateRecordOptimisticEffect.ts
+++ b/packages/twenty-front/src/modules/apollo/optimistic-effect/utils/triggerUpdateRecordOptimisticEffect.ts
@@ -120,6 +120,7 @@ export const triggerUpdateRecordOptimisticEffect = ({
         return {
           ...rootQueryConnection,
           edges: rootQueryNextEdges,
+          totalCount: rootQueryNextEdges.length,
         };
       },
     },

--- a/packages/twenty-front/src/modules/apollo/optimistic-effect/utils/triggerUpdateRecordOptimisticEffect.ts
+++ b/packages/twenty-front/src/modules/apollo/optimistic-effect/utils/triggerUpdateRecordOptimisticEffect.ts
@@ -117,10 +117,18 @@ export const triggerUpdateRecordOptimisticEffect = ({
           });
         }
 
+        const totalCount = readField<number | undefined>(
+          'totalCount',
+          rootQueryConnection,
+        );
+
         return {
           ...rootQueryConnection,
           edges: rootQueryNextEdges,
-          totalCount: rootQueryNextEdges.length,
+          totalCount: isDefined(totalCount)
+            ? totalCount -
+              (rootQueryCurrentEdges.length - rootQueryNextEdges.length)
+            : undefined,
         };
       },
     },


### PR DESCRIPTION
Fixes #8228 


1. Summary
    Total counts on record index tables are updated upon record deletion

2. Solution
   The optimistic update logic seemed a bit complicated to me, so I didn't understand everything in there. However, it seems `triggerUpdateRecordOptimisticEffect` should account for deletion as well as update since it's used for both. I ended up updating `totalCount` in Apollo cache along with `nextEdges` to make sure they are always in sync.
I am not quite sure if that's the best way to handle it though. It seems to be solving the problem without impacting other parts of the app in my manual testing. 