### PR TITLE
Fix npx nx run start (twenty:server:worker was not triggered)

### DIFF
--- a/package.json
+++ b/package.json
@@ -350,7 +350,7 @@
   "version": "0.2.1",
   "nx": {},
   "scripts": {
-    "start": "npx nx run-many -t start worker -p twenty-server twenty-front"
+    "start": "npx concurrently --kill-others 'npx nx run-many -t start -p twenty-server twenty-front' 'npx wait-on tcp:3000 && npx nx run twenty-server:worker'"
   },
   "workspaces": {
     "packages": [


### PR DESCRIPTION
twenty:server:worker was not triggered in npx nx run start