### PR TITLE
Fix CalendarOngoingStaleJob being in wrong queue

### DIFF
--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/jobs/calendar-ongoing-stale.job.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/jobs/calendar-ongoing-stale.job.ts
@@ -18,7 +18,7 @@ export type CalendarOngoingStaleJobData = {
 };
 
 @Processor({
-  queueName: MessageQueue.messagingQueue,
+  queueName: MessageQueue.calendarQueue,
   scope: Scope.REQUEST,
 })
 export class CalendarOngoingStaleJob {


### PR DESCRIPTION
Fix CalendarOngoingStaleJob being in the wrong queue (`MessageQueue.messagingQueue` instead of `MessageQueue.calendarQueue`)