### PR TITLE
Fix multi-dropdown field can't have no options selected

### DIFF
--- a/packages/twenty-server/src/engine/twenty-orm/utils/format-result.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/format-result.util.ts
@@ -148,7 +148,9 @@ function formatFieldMetadataValue(
     (fieldMetadata.type === FieldMetadataType.MULTI_SELECT ||
       fieldMetadata.type === FieldMetadataType.ARRAY)
   ) {
-    return value.replace(/{|}/g, '').split(',');
+    const cleanedValue = value.replace(/{|}/g, '').trim();
+
+    return cleanedValue ? cleanedValue.split(',') : [];
   }
 
   return value;


### PR DESCRIPTION
Fixes: #8224 

1. Summary
All multi-dropdowns across the application don't accept empty options because emptiness is perceived as an invalid state.

2. Solution
The issue came down to the back-end and the specific string utility function that converts a string separated by `,` to an array of options. But the problem with it is that it returns `['']` for an empty string representing an emptiness. And then `['']` fails on the parser because simply `''` is not a valid option the user selected for the dropdown. So I updated the string utility function to return an empty array for cases like `'', '{}', '{ }'`, etc

3. Recording

https://github.com/user-attachments/assets/071fe5d2-2123-4deb-878c-67f62d9b3431


