### PR TITLE
Add People API upgrade instruction to upgrade guide

### DIFF
--- a/packages/twenty-website/src/content/developers/self-hosting/upgrade-guide.mdx
+++ b/packages/twenty-website/src/content/developers/self-hosting/upgrade-guide.mdx
@@ -126,12 +126,11 @@ We have also simplifed the way we handle the JWT tokens.
 - Removed: `ACCESS_TOKEN_SECRET`, `LOGIN_TOKEN_SECRET`, `REFRESH_TOKEN_SECRET`, `FILE_TOKEN_SECRET`
 - Added: `APP_SECRET`
 
-*Note*: Keep the `ACCESS_TOKEN_SECRET` variables if you want to keep the backward compatibility with the previous API tokens.
-
 Update your `.env` file to use the new `APP_SECRET` variable instead of the individual tokens secrets (you can use the same secret as before or generate a new random string)
+*Note*: Keep the `ACCESS_TOKEN_SECRET` variable to keep the backward compatibility with the previous API tokens.
 
-### Connected Accounts
+### Connected Account
 
-If you are using connected account (messaging & calendar sync) feature on Google APIs, you will need to activate the [People API](https://developers.google.com/people) on your Google Admin console.
+If you are using connected account to synchronize your Google emails and calendars, you will need to activate the [People API](https://developers.google.com/people) on your Google Admin console.
 
 <ArticleEditContent></ArticleEditContent>

--- a/packages/twenty-website/src/content/developers/self-hosting/upgrade-guide.mdx
+++ b/packages/twenty-website/src/content/developers/self-hosting/upgrade-guide.mdx
@@ -126,6 +126,12 @@ We have also simplifed the way we handle the JWT tokens.
 - Removed: `ACCESS_TOKEN_SECRET`, `LOGIN_TOKEN_SECRET`, `REFRESH_TOKEN_SECRET`, `FILE_TOKEN_SECRET`
 - Added: `APP_SECRET`
 
+*Note*: Keep the `ACCESS_TOKEN_SECRET` variables if you want to keep the backward compatibility with the previous API tokens.
+
 Update your `.env` file to use the new `APP_SECRET` variable instead of the individual tokens secrets (you can use the same secret as before or generate a new random string)
+
+### Connected Accounts
+
+If you are using connected account (messaging & calendar sync) feature on Google APIs, you will need to activate the [People API](https://developers.google.com/people) on your Google Admin console.
 
 <ArticleEditContent></ArticleEditContent>


### PR DESCRIPTION
I'm updating the docs as we now require the People API to be available to use messaging sync. This has been reported by a user self-hosting the app on discord.