### PR TITLE
Fix missing timeline activity events

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/jobs/workspace-query-runner-job.module.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/jobs/workspace-query-runner-job.module.ts
@@ -1,9 +1,7 @@
-import { HttpModule } from '@nestjs/axios';
 import { Module } from '@nestjs/common';
 
 import { RecordPositionBackfillJob } from 'src/engine/api/graphql/workspace-query-runner/jobs/record-position-backfill.job';
 import { RecordPositionBackfillModule } from 'src/engine/api/graphql/workspace-query-runner/services/record-position-backfill-module';
-import { AnalyticsModule } from 'src/engine/core-modules/analytics/analytics.module';
 import { DataSourceModule } from 'src/engine/metadata-modules/data-source/data-source.module';
 import { WorkspaceDataSourceModule } from 'src/engine/workspace-datasource/workspace-datasource.module';
 


### PR DESCRIPTION
Fixes bug introduced in https://github.com/twentyhq/twenty/pull/8193

Taking into account linked event name `linked-{eventName}` as before issue

## Before
`linked-created` and `linked-updated` activity targets were not created in `timelineActivity` table

## After
`linked-created` and `linked-updated` activity targets are created in `timelineActivity` table