### PR TITLE
Prevent automatic zoom when focusing inputs on iOS

### DIFF
--- a/packages/twenty-front/index.html
+++ b/packages/twenty-front/index.html
@@ -6,7 +6,6 @@
     <link rel="icon" href="/icons/android/android-launchericon-48-48.png" />
     <link rel="apple-touch-icon" href="/icons/ios/192.png" />
 
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="A modern open-source CRM" />
     <meta
@@ -30,6 +29,22 @@
 
     <title>Twenty</title>
     <script src="/env-config.js"></script>
+
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script type="module">
+      const disableInputAutoZoom = () => {
+        const viewportMetadata = document.querySelector('meta[name=viewport]');
+
+        if (viewportMetadata !== null) {
+          viewportMetadata.setAttribute('content', 'width=device-width, initial-scale=1.0, maximum-scale=1.0');
+        }
+      }
+
+      const isIOS = /iPad|iPhone/.test(navigator.userAgent);
+      if (isIOS) {
+        disableInputAutoZoom();
+      }
+    </script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
This is the result of a long discussion we had here: https://github.com/twentyhq/twenty/issues/8001.

The goal is to stop iOS from automatically zooming when the user focuses on an input whose font size is less than 16px.

The options were:

1. Disable zoom for all devices
2. Disable zoom for devices detected as iOS devices, which doesn't prevent users from zooming manually but fixes the auto-zoom bug
3. Set the font size of the inputs to be equal to or greater than 16px—this change would take a lot of time

To me, the second option is the best, as iOS prevents developers from disabling zoom. They saw that it was overused and chose to restrict this setting. Setting a `maximum-scale` doesn't prevent users from zooming, but it fixes the initial bug we had.

My implementation can be seen as [progressive enhancement](https://developer.mozilla.org/en-US/docs/Glossary/Progressive_Enhancement ): If we can detect that the user uses an iOS device, we'll set the `maximum-scale` viewport property. Relying on the user agent is always unstable, and the check might fail unpredictably. We might not disallow auto-zoom for some iOS devices.

However, I think we can either:

- Invest some time to choose a more reliable user detection pattern if the one I suggest is not sufficient ([we find many different checks on the internet](https://stackoverflow.com/questions/9038625/detect-if-device-is-ios), I'm not sure which one is the best)
- Choose to apply the viewport setting to all devices and remove the JS code. According to my tests, it doesn't prevent zooming on desktops. However, it does on Android phones. I think it's not lovely to disallow zoom, but if the team agrees that we should go this way, I won't disagree.

I know my JavaScript code does not follow a pattern we want to spread in the app. The synchronous script will run as soon as possible to ensure the viewport is correctly set when the website launches. This shouldn't be an example followed by others.

Thanks, @harshit078, for your help in thinking about the best option.

I'm tagging @lucasbordeau and @charlesBochet for a technical review.

I would appreciate if someone could test on a more recent iOS device than mine.

Here is a demonstration of the behavior on iOS:

https://github.com/user-attachments/assets/d49fb65f-dd76-455c-9ac0-d4c002a7fe89