### PR TITLE
Fix typo in branch name

### DIFF
--- a/packages/twenty-emails/package.json
+++ b/packages/twenty-emails/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty-emails",
-  "version": "0.33.0-canaray",
+  "version": "0.33.0-canary",
   "description": "",
   "author": "",
   "private": true,

--- a/packages/twenty-front/package.json
+++ b/packages/twenty-front/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty-front",
-  "version": "0.33.0-canaray",
+  "version": "0.33.0-canary",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/twenty-server/package.json
+++ b/packages/twenty-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty-server",
-  "version": "0.33.0-canaray",
+  "version": "0.33.0-canary",
   "description": "",
   "author": "",
   "private": true,

--- a/packages/twenty-ui/package.json
+++ b/packages/twenty-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty-ui",
-  "version": "0.33.0-canaray",
+  "version": "0.33.0-canary",
   "type": "module",
   "main": "./src/index.ts",
   "exports": {

--- a/packages/twenty-website/package.json
+++ b/packages/twenty-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty-website",
-  "version": "0.33.0-canaray",
+  "version": "0.33.0-canary",
   "private": true,
   "scripts": {
     "nx": "NX_DEFAULT_PROJECT=twenty-website node ../../node_modules/nx/bin/nx.js",


### PR DESCRIPTION
Fixes #8471 

Updated `0.33.0-canaray` -> `0.33.0-canary`

![CleanShot 2024-11-13 at 09 45 36](https://github.com/user-attachments/assets/6a365542-9b4d-4279-9ef4-966d22863eba)
