### PR TITLE
Fix/validate access token user not found

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/auth/strategies/jwt.auth.strategy.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/strategies/jwt.auth.strategy.spec.ts
@@ -151,7 +151,7 @@ describe('JwtAuthStrategy', () => {
     );
 
     await expect(strategy.validate(payload as JwtPayload)).rejects.toThrow(
-      new AuthException('User not found', AuthExceptionCode.INVALID_INPUT),
+      new AuthException('User not found', AuthExceptionCode.USER_NOT_FOUND),
     );
   });
 

--- a/packages/twenty-server/src/engine/core-modules/auth/strategies/jwt.auth.strategy.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/strategies/jwt.auth.strategy.spec.ts
@@ -151,8 +151,13 @@ describe('JwtAuthStrategy', () => {
     );
 
     await expect(strategy.validate(payload as JwtPayload)).rejects.toThrow(
-      new AuthException('User not found', AuthExceptionCode.USER_NOT_FOUND),
+      new AuthException('User not found', expect.any(String)),
     );
+    try {
+      await strategy.validate(payload as JwtPayload);
+    } catch (e) {
+      expect(e.code).toBe(AuthExceptionCode.USER_NOT_FOUND);
+    }
   });
 
   it('should be truthy if type is ACCESS, no jti, and user exist', async () => {

--- a/packages/twenty-server/src/engine/core-modules/auth/strategies/jwt.auth.strategy.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/strategies/jwt.auth.strategy.ts
@@ -113,7 +113,7 @@ export class JwtAuthStrategy extends PassportStrategy(Strategy, 'jwt') {
     if (!user) {
       throw new AuthException(
         'User not found',
-        AuthExceptionCode.INVALID_INPUT,
+        AuthExceptionCode.USER_NOT_FOUND,
       );
     }
 


### PR DESCRIPTION
# Description
Closes #7244 

See details about implementation: https://github.com/twentyhq/twenty/issues/7244#issuecomment-2473845859 and https://github.com/twentyhq/twenty/issues/7244#issuecomment-2473905514

# Changes
- return a `USER_NOT_FOUND` error instead of `INVALID_INPUT` error
- tweak unit tests to correctly test `AuthExceptionCode`, as it wasn't properly tested; it was actually a _false positive_. This is because [`toThrow`](https://jestjs.io/docs/expect#tothrowerror) from jest only checks the `message`, and not any other method / attributes from the `Error`. It's a know behaviour and not considered a bug, see https://github.com/jestjs/jest/issues/13232#issuecomment-1252392845