### PR TITLE
Add crud actions

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query.parser.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query.parser.ts
@@ -54,7 +54,7 @@ export class GraphqlQueryParser {
 
   public applyDeletedAtToBuilder(
     queryBuilder: SelectQueryBuilder<any>,
-    recordFilter: ObjectRecordFilter,
+    recordFilter: Partial<ObjectRecordFilter>,
   ): SelectQueryBuilder<any> {
     if (this.checkForDeletedAtFilter(recordFilter)) {
       queryBuilder.withDeleted();

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-builder.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-builder.workspace-service.ts
@@ -10,6 +10,7 @@ import { checkStringIsDatabaseEventAction } from 'src/engine/api/graphql/graphql
 import { INDEX_FILE_NAME } from 'src/engine/core-modules/serverless/drivers/constants/index-file-name';
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 import { ServerlessFunctionService } from 'src/engine/metadata-modules/serverless-function/serverless-function.service';
+import { generateFakeValue } from 'src/engine/utils/generate-fake-value';
 import { CodeIntrospectionService } from 'src/modules/code-introspection/code-introspection.service';
 import { generateFakeObjectRecord } from 'src/modules/workflow/workflow-builder/utils/generate-fake-object-record';
 import { generateFakeObjectRecordEvent } from 'src/modules/workflow/workflow-builder/utils/generate-fake-object-record-event';
@@ -141,10 +142,11 @@ export class WorkflowBuilderWorkspaceService {
       objectMetadataRepository,
     });
 
-    if (operationType === WorkflowRecordCRUDType.FIND) {
+    if (operationType === WorkflowRecordCRUDType.READ) {
       return {
         first: recordOutputSchema,
         last: recordOutputSchema,
+        totalCount: generateFakeValue('number'),
       };
     }
 

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-builder.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-builder.workspace-service.ts
@@ -14,6 +14,7 @@ import { CodeIntrospectionService } from 'src/modules/code-introspection/code-in
 import { generateFakeObjectRecord } from 'src/modules/workflow/workflow-builder/utils/generate-fake-object-record';
 import { generateFakeObjectRecordEvent } from 'src/modules/workflow/workflow-builder/utils/generate-fake-object-record-event';
 import { WorkflowSendEmailStepOutputSchema } from 'src/modules/workflow/workflow-executor/workflow-actions/mail-sender/send-email.workflow-action';
+import { WorkflowRecordCRUDType } from 'src/modules/workflow/workflow-executor/workflow-actions/record-crud/types/workflow-record-crud-action-input.type';
 import {
   WorkflowAction,
   WorkflowActionType,
@@ -44,7 +45,7 @@ export class WorkflowBuilderWorkspaceService {
 
     switch (stepType) {
       case WorkflowTriggerType.DATABASE_EVENT: {
-        return await this.computeDatabaseEventTriggerOutputSchema({
+        return this.computeDatabaseEventTriggerOutputSchema({
           eventName: step.settings.eventName,
           workspaceId,
           objectMetadataRepository: this.objectMetadataRepository,
@@ -57,7 +58,7 @@ export class WorkflowBuilderWorkspaceService {
           return {};
         }
 
-        return await this.computeRecordOutputSchema({
+        return this.computeRecordOutputSchema({
           objectType,
           workspaceId,
           objectMetadataRepository: this.objectMetadataRepository,
@@ -70,7 +71,7 @@ export class WorkflowBuilderWorkspaceService {
         const { serverlessFunctionId, serverlessFunctionVersion } =
           step.settings.input;
 
-        return await this.computeCodeActionOutputSchema({
+        return this.computeCodeActionOutputSchema({
           serverlessFunctionId,
           serverlessFunctionVersion,
           workspaceId,
@@ -79,8 +80,9 @@ export class WorkflowBuilderWorkspaceService {
         });
       }
       case WorkflowActionType.RECORD_CRUD:
-        return await this.computeRecordOutputSchema({
+        return this.computeRecordCrudOutputSchema({
           objectType: step.settings.input.objectName,
+          operationType: step.settings.input.type,
           workspaceId,
           objectMetadataRepository: this.objectMetadataRepository,
         });
@@ -120,6 +122,33 @@ export class WorkflowBuilderWorkspaceService {
       objectMetadata,
       action as DatabaseEventAction,
     );
+  }
+
+  private async computeRecordCrudOutputSchema<Entity>({
+    objectType,
+    operationType,
+    workspaceId,
+    objectMetadataRepository,
+  }: {
+    objectType: string;
+    operationType: string;
+    workspaceId: string;
+    objectMetadataRepository: Repository<ObjectMetadataEntity>;
+  }) {
+    const recordOutputSchema = await this.computeRecordOutputSchema<Entity>({
+      objectType,
+      workspaceId,
+      objectMetadataRepository,
+    });
+
+    if (operationType === WorkflowRecordCRUDType.FIND) {
+      return {
+        first: recordOutputSchema,
+        last: recordOutputSchema,
+      };
+    }
+
+    return recordOutputSchema;
   }
 
   private async computeRecordOutputSchema<Entity>({

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/record-crud/exceptions/record-crud-action.exception.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/record-crud/exceptions/record-crud-action.exception.ts
@@ -1,0 +1,13 @@
+import { CustomException } from 'src/utils/custom-exception';
+
+export class RecordCRUDActionException extends CustomException {
+  code: RecordCRUDActionExceptionCode;
+  constructor(message: string, code: RecordCRUDActionExceptionCode) {
+    super(message, code);
+  }
+}
+
+export enum RecordCRUDActionExceptionCode {
+  INVALID_REQUEST = 'INVALID_REQUEST',
+  RECORD_NOT_FOUND = 'RECORD_NOT_FOUND',
+}

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/record-crud/record-crud-action.module.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/record-crud/record-crud-action.module.ts
@@ -1,9 +1,12 @@
 import { Module } from '@nestjs/common';
 
+import { ScopedWorkspaceContextFactory } from 'src/engine/twenty-orm/factories/scoped-workspace-context.factory';
+import { WorkspaceCacheStorageModule } from 'src/engine/workspace-cache-storage/workspace-cache-storage.module';
 import { RecordCRUDWorkflowAction } from 'src/modules/workflow/workflow-executor/workflow-actions/record-crud/record-crud.workflow-action';
 
 @Module({
-  providers: [RecordCRUDWorkflowAction],
+  imports: [WorkspaceCacheStorageModule],
+  providers: [RecordCRUDWorkflowAction, ScopedWorkspaceContextFactory],
   exports: [RecordCRUDWorkflowAction],
 })
 export class RecordCRUDActionModule {}

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/record-crud/record-crud.workflow-action.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/record-crud/record-crud.workflow-action.ts
@@ -1,18 +1,34 @@
 import { Injectable } from '@nestjs/common';
 
+import {
+  OrderByDirection,
+  RecordFilter,
+  RecordOrderBy,
+} from 'src/engine/api/graphql/workspace-query-builder/interfaces/record.interface';
 import { WorkflowAction } from 'src/modules/workflow/workflow-executor/interfaces/workflow-action.interface';
 
+import { GraphqlQueryParser } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query.parser';
+import { ScopedWorkspaceContextFactory } from 'src/engine/twenty-orm/factories/scoped-workspace-context.factory';
 import { TwentyORMManager } from 'src/engine/twenty-orm/twenty-orm.manager';
+import { formatResult } from 'src/engine/twenty-orm/utils/format-result.util';
+import { WorkspaceCacheStorageService } from 'src/engine/workspace-cache-storage/workspace-cache-storage.service';
 import {
   WorkflowCreateRecordActionInput,
+  WorkflowDeleteRecordActionInput,
+  WorkflowFindRecordActionInput,
   WorkflowRecordCRUDActionInput,
   WorkflowRecordCRUDType,
+  WorkflowUpdateRecordActionInput,
 } from 'src/modules/workflow/workflow-executor/workflow-actions/record-crud/types/workflow-record-crud-action-input.type';
 import { WorkflowActionResult } from 'src/modules/workflow/workflow-executor/workflow-actions/types/workflow-action-result.type';
 
 @Injectable()
 export class RecordCRUDWorkflowAction implements WorkflowAction {
-  constructor(private readonly twentyORMManager: TwentyORMManager) {}
+  constructor(
+    private readonly twentyORMManager: TwentyORMManager,
+    private readonly workspaceCacheStorageService: WorkspaceCacheStorageService,
+    private readonly scopedWorkspaceContextFactory: ScopedWorkspaceContextFactory,
+  ) {}
 
   async execute(
     workflowActionInput: WorkflowRecordCRUDActionInput,
@@ -20,10 +36,14 @@ export class RecordCRUDWorkflowAction implements WorkflowAction {
     switch (workflowActionInput.type) {
       case WorkflowRecordCRUDType.CREATE:
         return this.createRecord(workflowActionInput);
+      case WorkflowRecordCRUDType.DELETE:
+        return this.deleteRecord(workflowActionInput);
+      case WorkflowRecordCRUDType.UPDATE:
+        return this.updateRecord(workflowActionInput);
+      case WorkflowRecordCRUDType.FIND:
+        return this.findRecord(workflowActionInput);
       default:
-        throw new Error(
-          `Unknown record operation type: ${workflowActionInput.type}`,
-        );
+        throw new Error(`Unknown record operation type`);
     }
   }
 
@@ -41,5 +61,133 @@ export class RecordCRUDWorkflowAction implements WorkflowAction {
     const createdObjectRecord = await repository.save(objectRecord);
 
     return { result: createdObjectRecord };
+  }
+
+  private async deleteRecord(
+    workflowActionInput: WorkflowDeleteRecordActionInput,
+  ): Promise<WorkflowActionResult> {
+    const repository = await this.twentyORMManager.getRepository(
+      workflowActionInput.objectName,
+    );
+
+    const objectRecord = await repository.findOne({
+      where: {
+        id: workflowActionInput.objectRecordId,
+      },
+    });
+
+    if (!objectRecord) {
+      throw new Error(
+        `Record ${workflowActionInput.objectName} with id ${workflowActionInput.objectRecordId} not found`,
+      );
+    }
+
+    const deletedObjectRecord = await repository.remove(objectRecord);
+
+    return { result: deletedObjectRecord };
+  }
+
+  private async updateRecord(
+    workflowActionInput: WorkflowUpdateRecordActionInput,
+  ): Promise<WorkflowActionResult> {
+    const repository = await this.twentyORMManager.getRepository(
+      workflowActionInput.objectName,
+    );
+
+    const objectRecord = await repository.findOne({
+      where: {
+        id: workflowActionInput.objectRecordId,
+      },
+    });
+
+    if (!objectRecord) {
+      throw new Error(
+        `Record ${workflowActionInput.objectName} with id ${workflowActionInput.objectRecordId} not found`,
+      );
+    }
+
+    const updatedObjectRecord = await repository.save({
+      ...objectRecord,
+      ...workflowActionInput.objectRecord,
+    });
+
+    return { result: updatedObjectRecord };
+  }
+
+  private async findRecord(
+    workflowActionInput: WorkflowFindRecordActionInput,
+  ): Promise<WorkflowActionResult> {
+    const repository = await this.twentyORMManager.getRepository(
+      workflowActionInput.objectName,
+    );
+    const workspaceId = this.scopedWorkspaceContextFactory.create().workspaceId;
+
+    if (!workspaceId) {
+      throw new Error('Workspace ID is required');
+    }
+
+    const currentCacheVersion =
+      await this.workspaceCacheStorageService.getMetadataVersion(workspaceId);
+
+    if (currentCacheVersion === undefined) {
+      throw new Error('Metadata cache version not found');
+    }
+
+    const objectMetadataMap =
+      await this.workspaceCacheStorageService.getObjectMetadataMap(
+        workspaceId,
+        currentCacheVersion,
+      );
+
+    if (!objectMetadataMap) {
+      throw new Error('Object metadata collection not found');
+    }
+
+    const objectMetadataMapItem =
+      objectMetadataMap[workflowActionInput.objectName];
+
+    const queryBuilder = repository.createQueryBuilder(
+      workflowActionInput.objectName,
+    );
+
+    const graphqlQueryParser = new GraphqlQueryParser(
+      objectMetadataMapItem.fields,
+      objectMetadataMap,
+    );
+
+    const withFilterQueryBuilder = graphqlQueryParser.applyFilterToBuilder(
+      queryBuilder,
+      workflowActionInput.objectName,
+      workflowActionInput.filter ?? ({} as RecordFilter),
+    );
+
+    const orderByWithIdCondition = [
+      ...(workflowActionInput.orderBy ?? []),
+      { id: OrderByDirection.AscNullsFirst },
+    ] as RecordOrderBy;
+
+    const withOrderByQueryBuilder = graphqlQueryParser.applyOrderToBuilder(
+      withFilterQueryBuilder,
+      orderByWithIdCondition,
+      objectMetadataMapItem.nameSingular,
+      false,
+    );
+
+    const nonFormattedObjectRecords = await withOrderByQueryBuilder
+      .take(workflowActionInput.limit ?? 1)
+      .getMany();
+
+    const objectRecords = formatResult(
+      nonFormattedObjectRecords,
+      objectMetadataMapItem,
+      objectMetadataMap,
+    );
+
+    return {
+      result: {
+        first: objectRecords[0],
+        last: objectRecords[objectRecords.length - 1],
+      },
+    };
   }
 }

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/record-crud/record-crud.workflow-action.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/record-crud/record-crud.workflow-action.ts
@@ -92,10 +92,12 @@ export class RecordCRUDWorkflowAction implements WorkflowAction {
       );
     }
 
-    const updatedObjectRecord = await repository.save({
-      ...objectRecord,
-      ...workflowActionInput.objectRecord,
-    });
+    const updatedObjectRecord = await repository.update(
+      workflowActionInput.objectRecordId,
+      {
+        ...workflowActionInput.objectRecord,
+      },
+    );
 
     return {
       result: updatedObjectRecord,
@@ -170,6 +172,13 @@ export class RecordCRUDWorkflowAction implements WorkflowAction {
     const objectMetadataMapItem =
       objectMetadataMap[workflowActionInput.objectName];
 
+    if (!objectMetadataMapItem) {
+      throw new RecordCRUDActionException(
+        `Object ${workflowActionInput.objectName} not found`,
+        RecordCRUDActionExceptionCode.INVALID_REQUEST,
+      );
+    }
+
     const queryBuilder = repository.createQueryBuilder(
       workflowActionInput.objectName,
     );
@@ -198,7 +207,11 @@ export class RecordCRUDWorkflowAction implements WorkflowAction {
     );
 
     const nonFormattedObjectRecords = await withOrderByQueryBuilder
-      .take(workflowActionInput.limit ?? 1)
+      .take(
+        workflowActionInput.limit && workflowActionInput.limit > 0
+          ? workflowActionInput.limit
+          : 1,
+      )
       .getMany();
 
     const objectRecords = formatResult(

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/record-crud/types/workflow-record-crud-action-input.type.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/record-crud/types/workflow-record-crud-action-input.type.ts
@@ -9,7 +9,7 @@ export enum WorkflowRecordCRUDType {
   CREATE = 'create',
   UPDATE = 'update',
   DELETE = 'delete',
-  FIND = 'find',
+  READ = 'read',
 }
 
 export type WorkflowCreateRecordActionInput = {
@@ -31,8 +31,8 @@ export type WorkflowDeleteRecordActionInput = {
   objectRecordId: string;
 };
 
-export type WorkflowFindRecordActionInput = {
-  type: WorkflowRecordCRUDType.FIND;
+export type WorkflowReadRecordActionInput = {
+  type: WorkflowRecordCRUDType.READ;
   objectName: string;
   filter?: Partial<RecordFilter>;
   orderBy?: Partial<RecordOrderBy>;
@@ -43,4 +43,4 @@ export type WorkflowRecordCRUDActionInput =
   | WorkflowCreateRecordActionInput
   | WorkflowUpdateRecordActionInput
   | WorkflowDeleteRecordActionInput
-  | WorkflowFindRecordActionInput;
+  | WorkflowReadRecordActionInput;

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/record-crud/types/workflow-record-crud-action-input.type.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/record-crud/types/workflow-record-crud-action-input.type.ts
@@ -1,7 +1,7 @@
 import {
-  RecordFilter,
-  RecordOrderBy,
-} from 'src/engine/api/graphql/workspace-query-builder/interfaces/record.interface';
+  ObjectRecordFilter,
+  ObjectRecordOrderBy,
+} from 'src/engine/api/graphql/workspace-query-builder/interfaces/object-record.interface';
 
 type ObjectRecord = Record<string, any>;
 
@@ -34,8 +34,8 @@ export type WorkflowDeleteRecordActionInput = {
 export type WorkflowReadRecordActionInput = {
   type: WorkflowRecordCRUDType.READ;
   objectName: string;
-  filter?: Partial<RecordFilter>;
-  orderBy?: Partial<RecordOrderBy>;
+  filter?: Partial<ObjectRecordFilter>;
+  orderBy?: Partial<ObjectRecordOrderBy>;
   limit?: number;
 };
 

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/record-crud/types/workflow-record-crud-action-input.type.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/record-crud/types/workflow-record-crud-action-input.type.ts
@@ -1,4 +1,7 @@
-import { RecordFilter } from 'src/engine/api/graphql/workspace-query-builder/interfaces/record.interface';
+import {
+  RecordFilter,
+  RecordOrderBy,
+} from 'src/engine/api/graphql/workspace-query-builder/interfaces/record.interface';
 
 type ObjectRecord = Record<string, any>;
 
@@ -32,7 +35,7 @@ export type WorkflowFindRecordActionInput = {
   type: WorkflowRecordCRUDType.FIND;
   objectName: string;
   filter?: Partial<RecordFilter>;
-  orderBy?: string;
+  orderBy?: Partial<RecordOrderBy>;
   limit?: number;
 };
 

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/record-crud/types/workflow-record-crud-action-input.type.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/record-crud/types/workflow-record-crud-action-input.type.ts
@@ -1,9 +1,12 @@
+import { RecordFilter } from 'src/engine/api/graphql/workspace-query-builder/interfaces/record.interface';
+
 type ObjectRecord = Record<string, any>;
 
 export enum WorkflowRecordCRUDType {
   CREATE = 'create',
   UPDATE = 'update',
   DELETE = 'delete',
+  FIND = 'find',
 }
 
 export type WorkflowCreateRecordActionInput = {
@@ -25,7 +28,16 @@ export type WorkflowDeleteRecordActionInput = {
   objectRecordId: string;
 };
 
+export type WorkflowFindRecordActionInput = {
+  type: WorkflowRecordCRUDType.FIND;
+  objectName: string;
+  filter?: Partial<RecordFilter>;
+  orderBy?: string;
+  limit?: number;
+};
+
 export type WorkflowRecordCRUDActionInput =
   | WorkflowCreateRecordActionInput
   | WorkflowUpdateRecordActionInput
-  | WorkflowDeleteRecordActionInput;
+  | WorkflowDeleteRecordActionInput
+  | WorkflowFindRecordActionInput;


### PR DESCRIPTION
Adding update / delete / find actions

Update and delete are not really different than creation.

Find uses the same logique as for graphql filters.
Expected formats are:

Filter
```
{
  "and": [
    {
      "name": {
        "eq": "salut"
      }
    },
    {
      "employees": {
        "eq": "0"
      }
    }
  ]
}
```

Order
`[ { "name": 'AscNullsFirst' } ]`