### PR TITLE
Set cache metadata version to infinite TTL

### DIFF
--- a/packages/twenty-server/src/engine/workspace-cache-storage/workspace-cache-storage.service.ts
+++ b/packages/twenty-server/src/engine/workspace-cache-storage/workspace-cache-storage.service.ts
@@ -17,6 +17,8 @@ export enum WorkspaceCacheKeys {
   MetadataVersion = 'metadata:workspace-metadata-version',
 }
 
+const TTL_INFINITE = 0;
+
 @Injectable()
 export class WorkspaceCacheStorageService {
   constructor(
@@ -51,6 +53,7 @@ export class WorkspaceCacheStorageService {
     return this.cacheStorageService.set<number>(
       `${WorkspaceCacheKeys.MetadataVersion}:${workspaceId}`,
       metadataVersion,
+      TTL_INFINITE,
     );
   }
 


### PR DESCRIPTION
## Context
To avoid having a corrupt metadata version, we want to remove TTL for that key.

## Test
<img width="592" alt="Screenshot 2024-11-15 at 00 02 05" src="https://github.com/user-attachments/assets/9da0ae33-26a8-4e7b-82d0-dd691135a08f">
