### PR TITLE
Fixed_Auth_Documentation

### DIFF
--- a/packages/twenty-website/src/content/developers/self-hosting/self-hosting-var.mdx
+++ b/packages/twenty-website/src/content/developers/self-hosting/self-hosting-var.mdx
@@ -75,7 +75,7 @@ yarn command:prod cron:calendar:calendar-event-list-fetch
     ['AUTH_MICROSOFT_TENANT_ID', '', 'Microsoft tenant ID'],
     ['AUTH_MICROSOFT_CLIENT_SECRET', '', 'Microsoft client secret'],
     ['AUTH_MICROSOFT_CALLBACK_URL', 'http://[YourDomain]/auth/microsoft/redirect', 'Microsoft auth callback'],
-    ['AUTH_GOOGLE_APIS_CALLBACK_URL', 'http://[YourDomain]/auth/microsoft-apis/get-access-token', 'Microsoft APIs auth callback'],
+    ['AUTH_MICROSOFT_APIS_CALLBACK_URL', 'http://[YourDomain]/auth/microsoft-apis/get-access-token', 'Microsoft APIs auth callback'],
     ['FRONT_AUTH_CALLBACK_URL', 'http://localhost:3001/verify ', 'Callback used for Login page'],
     ['IS_SIGN_UP_DISABLED', 'false', 'Disable sign-up'],
     ['PASSWORD_RESET_TOKEN_EXPIRES_IN', '5m', 'Password reset token expiration time'],


### PR DESCRIPTION
Fixes #8525 

Fixed a small documentation API change:

AUTH_GOOGLE_APIS_CALLBACK_URL changed to AUTH_MICROSOFT_APIS_CALLBACK_URL

