### PR TITLE
Add "type" to reserved keywords in object metadata validation

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/utils/validate-object-metadata-input.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/utils/validate-object-metadata-input.util.ts
@@ -41,9 +41,10 @@ const reservedKeywords = [
   'address',
   'addresses',
   'type',
+  'types',
+  'object',
+  'objects',
 ];
-
-const METADATA_NAME_VALID_PATTERN = /^[a-zA-Z][a-zA-Z0-9]*$/;
 
 export const validateObjectMetadataInputOrThrow = <
   T extends UpdateObjectPayload | CreateObjectInput,

--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/utils/validate-object-metadata-input.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/utils/validate-object-metadata-input.util.ts
@@ -44,6 +44,9 @@ const reservedKeywords = [
   'types',
   'object',
   'objects',
+  'index',
+  'relation',
+  'relations',
 ];
 
 export const validateObjectMetadataInputOrThrow = <

--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/utils/validate-object-metadata-input.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/utils/validate-object-metadata-input.util.ts
@@ -40,6 +40,7 @@ const reservedKeywords = [
   'fullNames',
   'address',
   'addresses',
+  'type',
 ];
 
 const METADATA_NAME_VALID_PATTERN = /^[a-zA-Z][a-zA-Z0-9]*$/;


### PR DESCRIPTION
This PR adds "type" to the reserved keywords list in validate-object-metadata-input.util.ts. This prevents users from creating objects with "type" as a key, which has caused issues in the past .
issue solved #8543 

1.Updated the RESERVED_KEYWORDS array to include "type"