### PR TITLE
Remove "When no records are selected" actions on record page ⌘O

### DIFF
--- a/packages/twenty-front/src/modules/action-menu/actions/global-actions/workflow-run-actions/components/WorkflowRunActionEffect.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/global-actions/workflow-run-actions/components/WorkflowRunActionEffect.tsx
@@ -30,6 +30,7 @@ export const WorkflowRunActionEffect = () => {
       addActionMenuEntry({
         type: 'workflow-run',
         key: `workflow-run-${activeWorkflowVersion.id}`,
+        scope: 'global',
         label: capitalize(activeWorkflowVersion.workflow.name),
         position: index,
         Icon: IconSettingsAutomation,

--- a/packages/twenty-front/src/modules/action-menu/actions/record-actions/components/DeleteRecordsActionEffect.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-actions/components/DeleteRecordsActionEffect.tsx
@@ -106,6 +106,7 @@ export const DeleteRecordsActionEffect = ({
     if (canDelete) {
       addActionMenuEntry({
         type: 'standard',
+        scope: 'record-selection',
         key: 'delete',
         label: 'Delete',
         position,

--- a/packages/twenty-front/src/modules/action-menu/actions/record-actions/components/ExportRecordsActionEffect.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-actions/components/ExportRecordsActionEffect.tsx
@@ -32,6 +32,7 @@ export const ExportRecordsActionEffect = ({
   useEffect(() => {
     addActionMenuEntry({
       type: 'standard',
+      scope: 'record-selection',
       key: 'export',
       position,
       label: displayedExportProgress(

--- a/packages/twenty-front/src/modules/action-menu/actions/record-actions/components/ManageFavoritesActionEffect.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-actions/components/ManageFavoritesActionEffect.tsx
@@ -51,6 +51,7 @@ export const ManageFavoritesActionEffect = ({
 
     addActionMenuEntry({
       type: 'standard',
+      scope: 'record-selection',
       key: 'manage-favorites',
       label: isFavorite ? 'Remove from favorites' : 'Add to favorites',
       position,

--- a/packages/twenty-front/src/modules/action-menu/actions/record-actions/workflow-run-record-actions/components/WorkflowRunRecordActionEffect.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-actions/workflow-run-record-actions/components/WorkflowRunRecordActionEffect.tsx
@@ -57,6 +57,7 @@ export const WorkflowRunRecordActionEffect = ({
       addActionMenuEntry({
         type: 'workflow-run',
         key: `workflow-run-${activeWorkflowVersion.id}`,
+        scope: 'record-selection',
         label: capitalize(activeWorkflowVersion.workflow.name),
         position: index,
         Icon: IconSettingsAutomation,

--- a/packages/twenty-front/src/modules/action-menu/components/RightDrawerActionMenuDropdown.tsx
+++ b/packages/twenty-front/src/modules/action-menu/components/RightDrawerActionMenuDropdown.tsx
@@ -65,21 +65,25 @@ export const RightDrawerActionMenuDropdown = () => {
       }}
       dropdownComponents={
         <DropdownMenuItemsContainer>
-          {actionMenuEntries.map((item, index) => (
-            <MenuItem
-              key={index}
-              LeftIcon={item.Icon}
-              onClick={() => {
-                closeDropdown(
-                  getRightDrawerActionMenuDropdownIdFromActionMenuId(
-                    actionMenuId,
-                  ),
-                );
-                item.onClick?.();
-              }}
-              text={item.label}
-            />
-          ))}
+          {actionMenuEntries
+            .filter(
+              (actionMenuEntry) => actionMenuEntry.scope === 'record-selection',
+            )
+            .map((actionMenuEntry, index) => (
+              <MenuItem
+                key={index}
+                LeftIcon={actionMenuEntry.Icon}
+                onClick={() => {
+                  closeDropdown(
+                    getRightDrawerActionMenuDropdownIdFromActionMenuId(
+                      actionMenuId,
+                    ),
+                  );
+                  actionMenuEntry.onClick?.();
+                }}
+                text={actionMenuEntry.label}
+              />
+            ))}
         </DropdownMenuItemsContainer>
       }
     />

--- a/packages/twenty-front/src/modules/action-menu/components/__stories__/RecordIndexActionMenuBar.stories.tsx
+++ b/packages/twenty-front/src/modules/action-menu/components/__stories__/RecordIndexActionMenuBar.stories.tsx
@@ -48,6 +48,7 @@ const meta: Meta<typeof RecordIndexActionMenuBar> = {
 
             map.set('delete', {
               isPinned: true,
+              scope: 'record-selection',
               type: 'standard',
               key: 'delete',
               label: 'Delete',

--- a/packages/twenty-front/src/modules/action-menu/components/__stories__/RecordIndexActionMenuBarEntry.stories.tsx
+++ b/packages/twenty-front/src/modules/action-menu/components/__stories__/RecordIndexActionMenuBarEntry.stories.tsx
@@ -22,6 +22,7 @@ export const Default: Story = {
   args: {
     entry: {
       type: 'standard',
+      scope: 'record-selection',
       key: 'delete',
       label: 'Delete',
       position: 0,
@@ -35,6 +36,7 @@ export const WithDangerAccent: Story = {
   args: {
     entry: {
       type: 'standard',
+      scope: 'record-selection',
       key: 'delete',
       label: 'Delete',
       position: 0,
@@ -49,6 +51,7 @@ export const WithInteraction: Story = {
   args: {
     entry: {
       type: 'standard',
+      scope: 'record-selection',
       key: 'markAsDone',
       label: 'Mark as done',
       position: 0,

--- a/packages/twenty-front/src/modules/action-menu/components/__stories__/RecordIndexActionMenuDropdown.stories.tsx
+++ b/packages/twenty-front/src/modules/action-menu/components/__stories__/RecordIndexActionMenuDropdown.stories.tsx
@@ -42,6 +42,7 @@ const meta: Meta<typeof RecordIndexActionMenuDropdown> = {
 
           map.set('delete', {
             type: 'standard',
+            scope: 'record-selection',
             key: 'delete',
             label: 'Delete',
             position: 0,
@@ -51,6 +52,7 @@ const meta: Meta<typeof RecordIndexActionMenuDropdown> = {
 
           map.set('markAsDone', {
             type: 'standard',
+            scope: 'record-selection',
             key: 'markAsDone',
             label: 'Mark as done',
             position: 1,
@@ -60,6 +62,7 @@ const meta: Meta<typeof RecordIndexActionMenuDropdown> = {
 
           map.set('addToFavorites', {
             type: 'standard',
+            scope: 'record-selection',
             key: 'addToFavorites',
             label: 'Add to favorites',
             position: 2,

--- a/packages/twenty-front/src/modules/action-menu/components/__stories__/RecordShowActionMenuBar.stories.tsx
+++ b/packages/twenty-front/src/modules/action-menu/components/__stories__/RecordShowActionMenuBar.stories.tsx
@@ -55,6 +55,7 @@ const meta: Meta<typeof RightDrawerActionMenuDropdown> = {
 
           map.set('addToFavorites', {
             type: 'standard',
+            scope: 'record-selection',
             key: 'addToFavorites',
             label: 'Add to favorites',
             position: 0,
@@ -64,6 +65,7 @@ const meta: Meta<typeof RightDrawerActionMenuDropdown> = {
 
           map.set('export', {
             type: 'standard',
+            scope: 'record-selection',
             key: 'export',
             label: 'Export',
             position: 1,
@@ -73,6 +75,7 @@ const meta: Meta<typeof RightDrawerActionMenuDropdown> = {
 
           map.set('delete', {
             type: 'standard',
+            scope: 'record-selection',
             key: 'delete',
             label: 'Delete',
             position: 2,

--- a/packages/twenty-front/src/modules/action-menu/types/ActionMenuEntry.ts
+++ b/packages/twenty-front/src/modules/action-menu/types/ActionMenuEntry.ts
@@ -3,6 +3,7 @@ import { IconComponent, MenuItemAccent } from 'twenty-ui';
 
 export type ActionMenuEntry = {
   type: 'standard' | 'workflow-run';
+  scope: 'global' | 'record-selection';
   key: string;
   label: string;
   position: number;


### PR DESCRIPTION
Closes #8566 
- Introduce the concept of scope for an ActionMenuEntry, scope is either `global` or `record-selection`