### PR TITLE
Fix state mutation serverless action

### DIFF
--- a/packages/twenty-front/src/modules/settings/serverless-functions/hooks/useGetManyServerlessFunctions.ts
+++ b/packages/twenty-front/src/modules/settings/serverless-functions/hooks/useGetManyServerlessFunctions.ts
@@ -1,6 +1,6 @@
-import { useQuery } from '@apollo/client';
-import { FIND_MANY_SERVERLESS_FUNCTIONS } from '@/settings/serverless-functions/graphql/queries/findManyServerlessFunctions';
 import { useApolloMetadataClient } from '@/object-metadata/hooks/useApolloMetadataClient';
+import { FIND_MANY_SERVERLESS_FUNCTIONS } from '@/settings/serverless-functions/graphql/queries/findManyServerlessFunctions';
+import { useQuery } from '@apollo/client';
 import {
   GetManyServerlessFunctionsQuery,
   GetManyServerlessFunctionsQueryVariables,
@@ -8,13 +8,17 @@ import {
 
 export const useGetManyServerlessFunctions = () => {
   const apolloMetadataClient = useApolloMetadataClient();
-  const { data } = useQuery<
+
+  const { data, loading, error } = useQuery<
     GetManyServerlessFunctionsQuery,
     GetManyServerlessFunctionsQueryVariables
   >(FIND_MANY_SERVERLESS_FUNCTIONS, {
     client: apolloMetadataClient ?? undefined,
   });
+
   return {
     serverlessFunctions: data?.findManyServerlessFunctions || [],
+    loading,
+    error,
   };
 };

--- a/packages/twenty-front/src/modules/workflow/components/WorkflowEditActionFormServerlessFunction.tsx
+++ b/packages/twenty-front/src/modules/workflow/components/WorkflowEditActionFormServerlessFunction.tsx
@@ -1,7 +1,6 @@
 import { useGetManyServerlessFunctions } from '@/settings/serverless-functions/hooks/useGetManyServerlessFunctions';
 import { WorkflowEditActionFormServerlessFunctionInner } from '@/workflow/components/WorkflowEditActionFormServerlessFunctionInner';
 import { WorkflowCodeAction } from '@/workflow/types/Workflow';
-import { isDefined } from 'twenty-ui';
 
 type WorkflowEditActionFormServerlessFunctionProps = {
   action: WorkflowCodeAction;
@@ -19,20 +18,16 @@ export const WorkflowEditActionFormServerlessFunction = ({
   action,
   actionOptions,
 }: WorkflowEditActionFormServerlessFunctionProps) => {
-  const { serverlessFunctions } = useGetManyServerlessFunctions();
+  const { loading: isLoadingServerlessFunctions } =
+    useGetManyServerlessFunctions();
 
-  const selectedServerlessFunction = serverlessFunctions.find(
-    (fn) => fn.id === action.settings.input.serverlessFunctionId,
-  );
-
-  if (!isDefined(selectedServerlessFunction)) {
-    return <div>Could not find the related serverless function.</div>;
+  if (isLoadingServerlessFunctions) {
+    return null;
   }
 
   return (
     <WorkflowEditActionFormServerlessFunctionInner
       action={action}
-      selectedServerlessFunction={selectedServerlessFunction}
       actionOptions={actionOptions}
     />
   );

--- a/packages/twenty-front/src/modules/workflow/components/WorkflowEditActionFormServerlessFunction.tsx
+++ b/packages/twenty-front/src/modules/workflow/components/WorkflowEditActionFormServerlessFunction.tsx
@@ -1,41 +1,7 @@
-import { ReactNode, Fragment } from 'react';
-import styled from '@emotion/styled';
 import { useGetManyServerlessFunctions } from '@/settings/serverless-functions/hooks/useGetManyServerlessFunctions';
-import { Select, SelectOption } from '@/ui/input/components/Select';
-import { WorkflowEditGenericFormBase } from '@/workflow/components/WorkflowEditGenericFormBase';
-import VariableTagInput from '@/workflow/search-variables/components/VariableTagInput';
-import { FunctionInput } from '@/workflow/types/FunctionInput';
+import { WorkflowEditActionFormServerlessFunctionInner } from '@/workflow/components/WorkflowEditActionFormServerlessFunctionInner';
 import { WorkflowCodeAction } from '@/workflow/types/Workflow';
-import { getDefaultFunctionInputFromInputSchema } from '@/workflow/utils/getDefaultFunctionInputFromInputSchema';
-import { mergeDefaultFunctionInputAndFunctionInput } from '@/workflow/utils/mergeDefaultFunctionInputAndFunctionInput';
-import { setNestedValue } from '@/workflow/utils/setNestedValue';
-import { useTheme } from '@emotion/react';
-import { HorizontalSeparator, IconCode, isDefined } from 'twenty-ui';
-import { useDebouncedCallback } from 'use-debounce';
-
-const StyledContainer = styled.div`
-  display: inline-flex;
-  flex-direction: column;
-`;
-
-const StyledLabel = styled.div`
-  color: ${({ theme }) => theme.font.color.light};
-  font-size: ${({ theme }) => theme.font.size.md};
-  font-weight: ${({ theme }) => theme.font.weight.semiBold};
-  margin-top: ${({ theme }) => theme.spacing(2)};
-  margin-bottom: ${({ theme }) => theme.spacing(2)};
-`;
-
-const StyledInputContainer = styled.div`
-  background: ${({ theme }) => theme.background.secondary};
-  border: 1px solid ${({ theme }) => theme.border.color.medium};
-  border-radius: ${({ theme }) => theme.border.radius.md};
-  display: flex;
-  flex-direction: column;
-  gap: ${({ theme }) => theme.spacing(2)};
-  padding: ${({ theme }) => theme.spacing(2)};
-  position: relative;
-`;
+import { isDefined } from 'twenty-ui';
 
 type WorkflowEditActionFormServerlessFunctionProps = {
   action: WorkflowCodeAction;
@@ -53,167 +19,21 @@ export const WorkflowEditActionFormServerlessFunction = ({
   action,
   actionOptions,
 }: WorkflowEditActionFormServerlessFunctionProps) => {
-  const theme = useTheme();
   const { serverlessFunctions } = useGetManyServerlessFunctions();
 
-  const getFunctionInput = (serverlessFunctionId: string) => {
-    if (!serverlessFunctionId) {
-      return {};
-    }
-
-    const serverlessFunction = serverlessFunctions.find(
-      (f) => f.id === serverlessFunctionId,
-    );
-    const inputSchema = serverlessFunction?.latestVersionInputSchema;
-    const defaultFunctionInput =
-      getDefaultFunctionInputFromInputSchema(inputSchema);
-
-    const existingFunctionInput = action.settings.input.serverlessFunctionInput;
-
-    return mergeDefaultFunctionInputAndFunctionInput({
-      defaultFunctionInput,
-      functionInput: existingFunctionInput,
-    });
-  };
-
-  const functionInput = getFunctionInput(
-    action.settings.input.serverlessFunctionId,
+  const selectedServerlessFunction = serverlessFunctions.find(
+    (fn) => fn.id === action.settings.input.serverlessFunctionId,
   );
 
-  const updateFunctionInput = useDebouncedCallback(
-    async (newFunctionInput: object) => {
-      if (actionOptions.readonly === true) {
-        return;
-      }
-
-      actionOptions.onActionUpdate({
-        ...action,
-        settings: {
-          ...action.settings,
-          input: {
-            ...action.settings.input,
-            serverlessFunctionInput: newFunctionInput,
-          },
-        },
-      });
-    },
-    1_000,
-  );
-
-  const handleInputChange = (value: any, path: string[]) => {
-    updateFunctionInput(setNestedValue(functionInput, path, value));
-  };
-
-  const availableFunctions: Array<SelectOption<string>> = [
-    ...serverlessFunctions
-      .filter((serverlessFunction) =>
-        isDefined(serverlessFunction.latestVersion),
-      )
-      .map((serverlessFunction) => ({
-        label: serverlessFunction.name,
-        value: serverlessFunction.id,
-        latestVersionInputSchema: serverlessFunction.latestVersionInputSchema,
-      })),
-  ];
-
-  const handleFunctionChange = (newServerlessFunctionId: string) => {
-    if (actionOptions.readonly === true) {
-      return;
-    }
-
-    const serverlessFunction = serverlessFunctions.find(
-      (f) => f.id === newServerlessFunctionId,
-    );
-
-    const newProps = {
-      ...action,
-      settings: {
-        ...action.settings,
-        input: {
-          serverlessFunctionId: newServerlessFunctionId,
-          serverlessFunctionVersion:
-            serverlessFunction?.latestVersion || 'latest',
-          serverlessFunctionInput: getFunctionInput(newServerlessFunctionId),
-        },
-      },
-    };
-
-    actionOptions.onActionUpdate(newProps);
-  };
-
-  const renderFields = (
-    functionInput: FunctionInput,
-    path: string[] = [],
-    isRoot = true,
-  ): ReactNode[] => {
-    const displaySeparator = (functionInput: FunctionInput) => {
-      const keys = Object.keys(functionInput);
-      if (keys.length > 1) {
-        return true;
-      }
-      if (keys.length === 1) {
-        const subKeys = Object.keys(functionInput[keys[0]]);
-        return subKeys.length > 0;
-      }
-      return false;
-    };
-
-    return Object.entries(functionInput).map(([inputKey, inputValue]) => {
-      const currentPath = [...path, inputKey];
-      const pathKey = currentPath.join('.');
-
-      if (inputValue !== null && typeof inputValue === 'object') {
-        if (isRoot) {
-          return (
-            <Fragment key={pathKey}>
-              {displaySeparator(functionInput) && (
-                <HorizontalSeparator noMargin />
-              )}
-              {renderFields(inputValue, currentPath, false)}
-            </Fragment>
-          );
-        }
-        return (
-          <StyledContainer key={pathKey}>
-            <StyledLabel>{inputKey}</StyledLabel>
-            <StyledInputContainer>
-              {renderFields(inputValue, currentPath, false)}
-            </StyledInputContainer>
-          </StyledContainer>
-        );
-      } else {
-        return (
-          <VariableTagInput
-            key={pathKey}
-            inputId={`input-${inputKey}`}
-            label={inputKey}
-            placeholder="Enter value"
-            value={`${inputValue || ''}`}
-            onChange={(value) => handleInputChange(value, currentPath)}
-            readonly={actionOptions.readonly}
-          />
-        );
-      }
-    });
-  };
+  if (!isDefined(selectedServerlessFunction)) {
+    return <div>Could not find the related serverless function.</div>;
+  }
 
   return (
-    <WorkflowEditGenericFormBase
-      HeaderIcon={<IconCode color={theme.color.orange} />}
-      headerTitle="Code - Serverless Function"
-      headerType="Code"
-    >
-      <Select
-        dropdownId="select-serverless-function-id"
-        label="Function"
-        fullWidth
-        value={action.settings.input.serverlessFunctionId}
-        options={availableFunctions}
-        emptyOption={{ label: 'None', value: '' }}
-        disabled={actionOptions.readonly}
-        onChange={handleFunctionChange}
-      />
-      {renderFields(functionInput)}
-    </WorkflowEditGenericFormBase>
+    <WorkflowEditActionFormServerlessFunctionInner
+      action={action}
+      selectedServerlessFunction={selectedServerlessFunction}
+      actionOptions={actionOptions}
+    />
   );
 };

--- a/packages/twenty-front/src/modules/workflow/components/WorkflowEditActionFormServerlessFunctionInner.tsx
+++ b/packages/twenty-front/src/modules/workflow/components/WorkflowEditActionFormServerlessFunctionInner.tsx
@@ -9,7 +9,7 @@ import { mergeDefaultFunctionInputAndFunctionInput } from '@/workflow/utils/merg
 import { setNestedValue } from '@/workflow/utils/setNestedValue';
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
-import { Fragment, ReactNode, useEffect, useState } from 'react';
+import { Fragment, ReactNode, useState } from 'react';
 import { HorizontalSeparator, IconCode, isDefined } from 'twenty-ui';
 import { useDebouncedCallback } from 'use-debounce';
 
@@ -87,11 +87,6 @@ export const WorkflowEditActionFormServerlessFunctionInner = ({
         functionInput: action.settings.input.serverlessFunctionInput,
       }),
     );
-
-  useEffect(() => {
-    // TODO
-    setSelectedFunctionId(action.settings.input.serverlessFunctionId);
-  }, [action.settings.input.serverlessFunctionId]);
 
   const updateFunctionInput = useDebouncedCallback(
     async (newFunctionInput: object) => {

--- a/packages/twenty-front/src/modules/workflow/components/WorkflowEditActionFormServerlessFunctionInner.tsx
+++ b/packages/twenty-front/src/modules/workflow/components/WorkflowEditActionFormServerlessFunctionInner.tsx
@@ -9,10 +9,9 @@ import { mergeDefaultFunctionInputAndFunctionInput } from '@/workflow/utils/merg
 import { setNestedValue } from '@/workflow/utils/setNestedValue';
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
-import { ReactNode, useEffect, useState } from 'react';
+import { Fragment, ReactNode, useEffect, useState } from 'react';
 import { HorizontalSeparator, IconCode, isDefined } from 'twenty-ui';
 import { useDebouncedCallback } from 'use-debounce';
-import { ServerlessFunction } from '~/generated/graphql';
 
 const StyledContainer = styled.div`
   display: inline-flex;
@@ -40,7 +39,6 @@ const StyledInputContainer = styled.div`
 
 type WorkflowEditActionFormServerlessFunctionInnerProps = {
   action: WorkflowCodeAction;
-  selectedServerlessFunction: ServerlessFunction;
   actionOptions:
     | {
         readonly: true;

--- a/packages/twenty-front/src/modules/workflow/components/WorkflowEditActionFormServerlessFunctionInner.tsx
+++ b/packages/twenty-front/src/modules/workflow/components/WorkflowEditActionFormServerlessFunctionInner.tsx
@@ -1,0 +1,245 @@
+import { useGetManyServerlessFunctions } from '@/settings/serverless-functions/hooks/useGetManyServerlessFunctions';
+import { Select, SelectOption } from '@/ui/input/components/Select';
+import { WorkflowEditGenericFormBase } from '@/workflow/components/WorkflowEditGenericFormBase';
+import VariableTagInput from '@/workflow/search-variables/components/VariableTagInput';
+import { FunctionInput } from '@/workflow/types/FunctionInput';
+import { WorkflowCodeAction } from '@/workflow/types/Workflow';
+import { getDefaultFunctionInputFromInputSchema } from '@/workflow/utils/getDefaultFunctionInputFromInputSchema';
+import { mergeDefaultFunctionInputAndFunctionInput } from '@/workflow/utils/mergeDefaultFunctionInputAndFunctionInput';
+import { setNestedValue } from '@/workflow/utils/setNestedValue';
+import { useTheme } from '@emotion/react';
+import styled from '@emotion/styled';
+import { ReactNode, useEffect, useState } from 'react';
+import { HorizontalSeparator, IconCode, isDefined } from 'twenty-ui';
+import { useDebouncedCallback } from 'use-debounce';
+import { ServerlessFunction } from '~/generated/graphql';
+
+const StyledContainer = styled.div`
+  display: inline-flex;
+  flex-direction: column;
+`;
+
+const StyledLabel = styled.div`
+  color: ${({ theme }) => theme.font.color.light};
+  font-size: ${({ theme }) => theme.font.size.md};
+  font-weight: ${({ theme }) => theme.font.weight.semiBold};
+  margin-top: ${({ theme }) => theme.spacing(2)};
+  margin-bottom: ${({ theme }) => theme.spacing(2)};
+`;
+
+const StyledInputContainer = styled.div`
+  background: ${({ theme }) => theme.background.secondary};
+  border: 1px solid ${({ theme }) => theme.border.color.medium};
+  border-radius: ${({ theme }) => theme.border.radius.md};
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing(2)};
+  padding: ${({ theme }) => theme.spacing(2)};
+  position: relative;
+`;
+
+type WorkflowEditActionFormServerlessFunctionInnerProps = {
+  action: WorkflowCodeAction;
+  selectedServerlessFunction: ServerlessFunction;
+  actionOptions:
+    | {
+        readonly: true;
+      }
+    | {
+        readonly?: false;
+        onActionUpdate: (action: WorkflowCodeAction) => void;
+      };
+};
+
+type ServerlessFunctionInputFormData = {
+  [field: string]: string | ServerlessFunctionInputFormData;
+};
+
+export const WorkflowEditActionFormServerlessFunctionInner = ({
+  action,
+  actionOptions,
+}: WorkflowEditActionFormServerlessFunctionInnerProps) => {
+  const theme = useTheme();
+
+  const { serverlessFunctions } = useGetManyServerlessFunctions();
+
+  const getFunctionInput = (serverlessFunctionId: string) => {
+    if (!serverlessFunctionId) {
+      return {};
+    }
+
+    const serverlessFunction = serverlessFunctions.find(
+      (f) => f.id === serverlessFunctionId,
+    );
+    const inputSchema = serverlessFunction?.latestVersionInputSchema;
+    const defaultFunctionInput =
+      getDefaultFunctionInputFromInputSchema(inputSchema);
+
+    return defaultFunctionInput;
+  };
+
+  const [selectedFunctionId, setSelectedFunctionId] = useState(
+    action.settings.input.serverlessFunctionId,
+  );
+
+  const [functionInput, setFunctionInput] =
+    useState<ServerlessFunctionInputFormData>(
+      mergeDefaultFunctionInputAndFunctionInput({
+        defaultFunctionInput: getFunctionInput(selectedFunctionId),
+        functionInput: action.settings.input.serverlessFunctionInput,
+      }),
+    );
+
+  useEffect(() => {
+    // TODO
+    setSelectedFunctionId(action.settings.input.serverlessFunctionId);
+  }, [action.settings.input.serverlessFunctionId]);
+
+  const updateFunctionInput = useDebouncedCallback(
+    async (newFunctionInput: object) => {
+      if (actionOptions.readonly === true) {
+        return;
+      }
+
+      actionOptions.onActionUpdate({
+        ...action,
+        settings: {
+          ...action.settings,
+          input: {
+            ...action.settings.input,
+            serverlessFunctionInput: newFunctionInput,
+          },
+        },
+      });
+    },
+    1_000,
+  );
+
+  const handleInputChange = (value: any, path: string[]) => {
+    const updatedFunctionInput = setNestedValue(functionInput, path, value);
+
+    setFunctionInput(updatedFunctionInput);
+
+    updateFunctionInput(updatedFunctionInput);
+  };
+
+  const availableFunctions: Array<SelectOption<string>> = [
+    ...serverlessFunctions
+      .filter((serverlessFunction) =>
+        isDefined(serverlessFunction.latestVersion),
+      )
+      .map((serverlessFunction) => ({
+        label: serverlessFunction.name,
+        value: serverlessFunction.id,
+        latestVersionInputSchema: serverlessFunction.latestVersionInputSchema,
+      })),
+  ];
+
+  const handleFunctionChange = (newServerlessFunctionId: string) => {
+    if (actionOptions.readonly === true) {
+      return;
+    }
+
+    updateFunctionInput.cancel();
+
+    setSelectedFunctionId(newServerlessFunctionId);
+
+    const serverlessFunction = serverlessFunctions.find(
+      (f) => f.id === newServerlessFunctionId,
+    );
+
+    const newFunctionInput = getFunctionInput(newServerlessFunctionId);
+
+    const newProps = {
+      ...action,
+      settings: {
+        ...action.settings,
+        input: {
+          serverlessFunctionId: newServerlessFunctionId,
+          serverlessFunctionVersion:
+            serverlessFunction?.latestVersion || 'latest',
+          serverlessFunctionInput: newFunctionInput,
+        },
+      },
+    };
+
+    setFunctionInput(newFunctionInput);
+
+    actionOptions.onActionUpdate(newProps);
+  };
+
+  const renderFields = (
+    functionInput: FunctionInput,
+    path: string[] = [],
+    isRoot = true,
+  ): ReactNode[] => {
+    const displaySeparator = (functionInput: FunctionInput) => {
+      const keys = Object.keys(functionInput);
+      if (keys.length > 1) {
+        return true;
+      }
+      if (keys.length === 1) {
+        const subKeys = Object.keys(functionInput[keys[0]]);
+        return subKeys.length > 0;
+      }
+      return false;
+    };
+
+    return Object.entries(functionInput).map(([inputKey, inputValue]) => {
+      const currentPath = [...path, inputKey];
+      const pathKey = currentPath.join('.');
+
+      if (inputValue !== null && typeof inputValue === 'object') {
+        if (isRoot) {
+          return (
+            <>
+              {displaySeparator(functionInput) && (
+                <HorizontalSeparator noMargin />
+              )}
+              {renderFields(inputValue, currentPath, false)}
+            </>
+          );
+        }
+        return (
+          <StyledContainer key={pathKey}>
+            <StyledLabel>{inputKey}</StyledLabel>
+            <StyledInputContainer>
+              {renderFields(inputValue, currentPath, false)}
+            </StyledInputContainer>
+          </StyledContainer>
+        );
+      } else {
+        return (
+          <VariableTagInput
+            key={pathKey}
+            inputId={`input-${inputKey}`}
+            label={inputKey}
+            placeholder="Enter value (use {{variable}} for dynamic content)"
+            value={`${inputValue || ''}`}
+            onChange={(value) => handleInputChange(value, currentPath)}
+          />
+        );
+      }
+    });
+  };
+
+  return (
+    <WorkflowEditGenericFormBase
+      HeaderIcon={<IconCode color={theme.color.orange} />}
+      headerTitle="Code - Serverless Function"
+      headerType="Code"
+    >
+      <Select
+        dropdownId="select-serverless-function-id"
+        label="Function"
+        fullWidth
+        value={selectedFunctionId}
+        options={availableFunctions}
+        emptyOption={{ label: 'None', value: '' }}
+        disabled={actionOptions.readonly}
+        onChange={handleFunctionChange}
+      />
+      {renderFields(functionInput)}
+    </WorkflowEditGenericFormBase>
+  );
+};

--- a/packages/twenty-front/src/modules/workflow/components/WorkflowEditActionFormServerlessFunctionInner.tsx
+++ b/packages/twenty-front/src/modules/workflow/components/WorkflowEditActionFormServerlessFunctionInner.tsx
@@ -192,12 +192,12 @@ export const WorkflowEditActionFormServerlessFunctionInner = ({
       if (inputValue !== null && typeof inputValue === 'object') {
         if (isRoot) {
           return (
-            <>
+            <Fragment key={pathKey}>
               {displaySeparator(functionInput) && (
                 <HorizontalSeparator noMargin />
               )}
               {renderFields(inputValue, currentPath, false)}
-            </>
+            </Fragment>
           );
         }
         return (

--- a/packages/twenty-front/src/modules/workflow/components/WorkflowEditActionFormServerlessFunctionInner.tsx
+++ b/packages/twenty-front/src/modules/workflow/components/WorkflowEditActionFormServerlessFunctionInner.tsx
@@ -207,7 +207,8 @@ export const WorkflowEditActionFormServerlessFunctionInner = ({
             key={pathKey}
             inputId={`input-${inputKey}`}
             label={inputKey}
-            placeholder="Enter value (use {{variable}} for dynamic content)"
+            placeholder="Enter value"
+            readonly={actionOptions.readonly}
             value={`${inputValue || ''}`}
             onChange={(value) => handleInputChange(value, currentPath)}
           />

--- a/packages/twenty-front/src/modules/workflow/types/FunctionInput.ts
+++ b/packages/twenty-front/src/modules/workflow/types/FunctionInput.ts
@@ -1,5 +1,3 @@
-export type FunctionInput =
-  | {
-      [name: string]: FunctionInput;
-    }
-  | any;
+export type FunctionInput = {
+  [key: string]: FunctionInput | string;
+};

--- a/packages/twenty-front/src/modules/workflow/types/FunctionInput.ts
+++ b/packages/twenty-front/src/modules/workflow/types/FunctionInput.ts
@@ -1,3 +1,5 @@
-export type FunctionInput = {
-  [key: string]: FunctionInput | string;
-};
+export type FunctionInput =
+  | {
+      [name: string]: FunctionInput;
+    }
+  | any;

--- a/packages/twenty-front/src/modules/workflow/utils/__tests__/setNestedValue.test.ts
+++ b/packages/twenty-front/src/modules/workflow/utils/__tests__/setNestedValue.test.ts
@@ -8,4 +8,19 @@ describe('setNestedValue', () => {
     const expectedResult = { a: { b: newValue } };
     expect(setNestedValue(obj, path, newValue)).toEqual(expectedResult);
   });
+
+  it('should not mutate the initial object', () => {
+    const expectedObject = { a: { b: 'b' } };
+
+    const initialObject = structuredClone(expectedObject);
+    const path = ['a', 'b'];
+    const newValue = 'bb';
+
+    const updatedObject = setNestedValue(initialObject, path, newValue);
+
+    expect(initialObject).toEqual(expectedObject);
+
+    expect(updatedObject).not.toBe(initialObject);
+    expect(updatedObject.a).not.toBe(initialObject.a);
+  });
 });

--- a/packages/twenty-front/src/modules/workflow/utils/setNestedValue.ts
+++ b/packages/twenty-front/src/modules/workflow/utils/setNestedValue.ts
@@ -1,5 +1,5 @@
 export const setNestedValue = (obj: any, path: string[], value: any) => {
-  const newObj = { ...obj };
+  const newObj = structuredClone(obj);
   path.reduce((o, key, index) => {
     if (index === path.length - 1) {
       o[key] = value;


### PR DESCRIPTION
In this PR:

- Ensure the `setNestedValue` does a deep copy of the provided object and doesn't mutate it directly.
- Store the form's state in a `useState` instead of relying entirely on the backend's state. This makes the form more resilient to slow network connections.
- Ensure the input settings are reset when selecting another function.
- The Inner component now expects the serverless functions data to be resolved before being mounted, so I split it.

Closes https://github.com/twentyhq/twenty/issues/8523