### PR TITLE
Fail entrypoint if migration fails

### DIFF
--- a/packages/twenty-docker/twenty/entrypoint.sh
+++ b/packages/twenty-docker/twenty/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 # Check if the initialization has already been done and that we enabled automatic migration
 if [ "${ENABLE_DB_MIGRATIONS}" = "true" ] && [ ! -f /app/docker-data/db_status ]; then


### PR DESCRIPTION
If migration fails for some reason, the script runs anyway and creates the file which indicates that migration is complete. This is obviously not cool. If database is not available for some reason and migrations fail, the container should exit, not continue. 

Relevant stack overflow: https://stackoverflow.com/a/2871034