### PR TITLE
Fix wrong getAll keyValue method

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.ts
@@ -209,12 +209,10 @@ export class SignInUpService {
         )
       : await this.userWorkspaceService.addUserToWorkspace(user, workspace);
 
-    if (isNewUser) {
-      await this.activateOnboardingForNewUser(user, workspace, {
-        firstName,
-        lastName,
-      });
-    }
+    await this.activateOnboardingForUser(user, workspace, {
+      firstName,
+      lastName,
+    });
 
     return Object.assign(user, updatedUser);
   }
@@ -266,7 +264,7 @@ export class SignInUpService {
     return workspace;
   }
 
-  private async activateOnboardingForNewUser(
+  private async activateOnboardingForUser(
     user: User,
     workspace: Workspace,
     { firstName, lastName }: { firstName: string; lastName: string },
@@ -331,19 +329,10 @@ export class SignInUpService {
 
     await this.userWorkspaceService.create(user.id, workspace.id);
 
-    await this.onboardingService.setOnboardingConnectAccountPending({
-      userId: user.id,
-      workspaceId: workspace.id,
-      value: true,
+    await this.activateOnboardingForUser(user, workspace, {
+      firstName,
+      lastName,
     });
-
-    if (firstName === '' && lastName === '') {
-      await this.onboardingService.setOnboardingCreateProfilePending({
-        userId: user.id,
-        workspaceId: workspace.id,
-        value: true,
-      });
-    }
 
     await this.onboardingService.setOnboardingInviteTeamPending({
       workspaceId: workspace.id,

--- a/packages/twenty-server/src/engine/core-modules/onboarding/onboarding.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/onboarding/onboarding.service.ts
@@ -50,7 +50,10 @@ export class OnboardingService {
       return OnboardingStatus.WORKSPACE_ACTIVATION;
     }
 
-    const userVars = await this.userVarsService.getAll(user);
+    const userVars = await this.userVarsService.getAll({
+      userId: user.id,
+      workspaceId: user.defaultWorkspaceId,
+    });
 
     const isProfileCreationPending =
       userVars.get(OnboardingStepKeys.ONBOARDING_CREATE_PROFILE_PENDING) ===

--- a/packages/twenty-server/src/engine/core-modules/onboarding/onboarding.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/onboarding/onboarding.service.ts
@@ -50,10 +50,7 @@ export class OnboardingService {
       return OnboardingStatus.WORKSPACE_ACTIVATION;
     }
 
-    const userVars = await this.userVarsService.getAll({
-      userId: user.id,
-      workspaceId: user.defaultWorkspaceId,
-    });
+    const userVars = await this.userVarsService.getAll(user);
 
     const isProfileCreationPending =
       userVars.get(OnboardingStepKeys.ONBOARDING_CREATE_PROFILE_PENDING) ===

--- a/packages/twenty-server/src/engine/core-modules/user/user-vars/services/user-vars.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/user-vars/services/user-vars.service.ts
@@ -3,7 +3,6 @@ import { Injectable } from '@nestjs/common';
 import { KeyValuePairType } from 'src/engine/core-modules/key-value-pair/key-value-pair.entity';
 import { KeyValuePairService } from 'src/engine/core-modules/key-value-pair/key-value-pair.service';
 import { mergeUserVars } from 'src/engine/core-modules/user/user-vars/utils/merge-user-vars.util';
-import { User } from 'src/engine/core-modules/user/user.entity';
 
 @Injectable()
 export class UserVarsService<
@@ -76,27 +75,44 @@ export class UserVarsService<
     ]).get(key) as KeyValueTypesMap[K];
   }
 
-  public async getAll(
-    user: User,
-  ): Promise<Map<Extract<keyof KeyValueTypesMap, string>, any>> {
-    let result = await this.keyValuePairService.get({
-      type: KeyValuePairType.USER_VAR,
-      userId: user.id,
-      workspaceId: null,
-    });
+  public async getAll({
+    userId,
+    workspaceId,
+  }: {
+    userId?: string;
+    workspaceId?: string;
+  }): Promise<Map<Extract<keyof KeyValueTypesMap, string>, any>> {
+    let result: any[] = [];
 
-    if (user.defaultWorkspaceId) {
+    if (userId) {
+      result = [
+        ...result,
+        ...(await this.keyValuePairService.get({
+          type: KeyValuePairType.USER_VAR,
+          userId,
+          workspaceId: null,
+        })),
+      ];
+    }
+
+    if (workspaceId) {
       result = [
         ...result,
         ...(await this.keyValuePairService.get({
           type: KeyValuePairType.USER_VAR,
           userId: null,
-          workspaceId: user.defaultWorkspaceId,
+          workspaceId,
         })),
+      ];
+    }
+
+    if (workspaceId && userId) {
+      result = [
+        ...result,
         ...(await this.keyValuePairService.get({
           type: KeyValuePairType.USER_VAR,
-          userId: user.id,
-          workspaceId: user.defaultWorkspaceId,
+          userId,
+          workspaceId,
         })),
       ];
     }

--- a/packages/twenty-server/src/engine/core-modules/user/user.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/user.resolver.ts
@@ -79,13 +79,10 @@ export class UserResolver {
   }
 
   @ResolveField(() => GraphQLJSONObject)
-  async userVars(
-    @Parent() user: User,
-    @AuthWorkspace() workspace: Workspace,
-  ): Promise<Record<string, any>> {
+  async userVars(@Parent() user: User): Promise<Record<string, any>> {
     const userVars = await this.userVarService.getAll({
       userId: user.id,
-      workspaceId: workspace.id,
+      workspaceId: user.defaultWorkspaceId,
     });
 
     const userVarAllowList = [

--- a/packages/twenty-server/src/engine/core-modules/user/user.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/user.resolver.ts
@@ -25,7 +25,10 @@ import { EnvironmentService } from 'src/engine/core-modules/environment/environm
 import { FileUploadService } from 'src/engine/core-modules/file/file-upload/services/file-upload.service';
 import { FileService } from 'src/engine/core-modules/file/services/file.service';
 import { OnboardingStatus } from 'src/engine/core-modules/onboarding/enums/onboarding-status.enum';
-import { OnboardingService } from 'src/engine/core-modules/onboarding/onboarding.service';
+import {
+  OnboardingService,
+  OnboardingStepKeys,
+} from 'src/engine/core-modules/onboarding/onboarding.service';
 import { WorkspaceMember } from 'src/engine/core-modules/user/dtos/workspace-member.dto';
 import { UserService } from 'src/engine/core-modules/user/services/user.service';
 import { UserVarsService } from 'src/engine/core-modules/user/user-vars/services/user-vars.service';
@@ -36,6 +39,7 @@ import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorat
 import { DemoEnvGuard } from 'src/engine/guards/demo.env.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { streamToBuffer } from 'src/utils/stream-to-buffer';
+import { AccountsToReconnectKeys } from 'src/modules/connected-account/types/accounts-to-reconnect-key-value.type';
 
 const getHMACKey = (email?: string, key?: string | null) => {
   if (!email || !key) return null;
@@ -75,20 +79,14 @@ export class UserResolver {
   }
 
   @ResolveField(() => GraphQLJSONObject)
-  async userVars(
-    @Parent() user: User,
-    @AuthWorkspace() workspace: Workspace,
-  ): Promise<Record<string, any>> {
-    const userVars = await this.userVarService.getAll({
-      userId: user.id,
-      workspaceId: workspace?.id ?? user.defaultWorkspaceId,
-    });
+  async userVars(@Parent() user: User): Promise<Record<string, any>> {
+    const userVars = await this.userVarService.getAll(user);
 
     const userVarAllowList = [
-      'SYNC_EMAIL_ONBOARDING_STEP',
-      'ACCOUNTS_TO_RECONNECT_INSUFFICIENT_PERMISSIONS',
-      'ACCOUNTS_TO_RECONNECT_EMAIL_ALIASES',
-    ];
+      OnboardingStepKeys.ONBOARDING_CONNECT_ACCOUNT_PENDING,
+      AccountsToReconnectKeys.ACCOUNTS_TO_RECONNECT_INSUFFICIENT_PERMISSIONS,
+      AccountsToReconnectKeys.ACCOUNTS_TO_RECONNECT_EMAIL_ALIASES,
+    ] as string[];
 
     const filteredMap = new Map(
       [...userVars].filter(([key]) => userVarAllowList.includes(key)),

--- a/packages/twenty-server/src/engine/core-modules/user/user.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/user.resolver.ts
@@ -79,8 +79,14 @@ export class UserResolver {
   }
 
   @ResolveField(() => GraphQLJSONObject)
-  async userVars(@Parent() user: User): Promise<Record<string, any>> {
-    const userVars = await this.userVarService.getAll(user);
+  async userVars(
+    @Parent() user: User,
+    @AuthWorkspace() workspace: Workspace,
+  ): Promise<Record<string, any>> {
+    const userVars = await this.userVarService.getAll({
+      userId: user.id,
+      workspaceId: workspace.id,
+    });
 
     const userVarAllowList = [
       OnboardingStepKeys.ONBOARDING_CONNECT_ACCOUNT_PENDING,


### PR DESCRIPTION
Fixes https://github.com/twentyhq/twenty/issues/8520#issuecomment-2485913500

- Fix the getAll key-value pairs method, as it returns incorrect results. The keyVar values were being affected by keyValues from other workspaces.
- Fix missing Sync Email step for existing users joining existing workspace
  
Before, this method returned keyValues that verifies:
- workspaceId = user.defaultWorkspaceId
- userId = user.id

This method now returns:
- userId = null && workspaceId = user.defaultWorkspaceId
- userId = user.id && workspaceId = null
- userId = user.id && workspaceId = user.defaultWorkspaceId

## Result

https://github.com/user-attachments/assets/b7563db6-a6a8-4e09-a0c6-c372d7e2b712

