### PR TITLE
Set infinite ttl to all workspace cache keys

### DIFF
--- a/packages/twenty-server/src/engine/workspace-cache-storage/workspace-cache-storage.service.ts
+++ b/packages/twenty-server/src/engine/workspace-cache-storage/workspace-cache-storage.service.ts
@@ -34,6 +34,7 @@ export class WorkspaceCacheStorageService {
     return this.cacheStorageService.set<EntitySchemaOptions<any>[]>(
       `${WorkspaceCacheKeys.ORMEntitySchemas}:${workspaceId}:${metadataVersion}`,
       entitySchemas,
+      TTL_INFINITE,
     );
   }
 
@@ -70,6 +71,7 @@ export class WorkspaceCacheStorageService {
     return this.cacheStorageService.set<boolean>(
       `${WorkspaceCacheKeys.MetadataObjectMetadataOngoingCachingLock}:${workspaceId}:${metadataVersion}`,
       true,
+      TTL_INFINITE,
     );
   }
 
@@ -99,6 +101,7 @@ export class WorkspaceCacheStorageService {
     return this.cacheStorageService.set<ObjectMetadataMaps>(
       `${WorkspaceCacheKeys.MetadataObjectMetadataMaps}:${workspaceId}:${metadataVersion}`,
       objectMetadataMaps,
+      TTL_INFINITE,
     );
   }
 
@@ -119,6 +122,7 @@ export class WorkspaceCacheStorageService {
     return this.cacheStorageService.set<string>(
       `${WorkspaceCacheKeys.GraphQLTypeDefs}:${workspaceId}:${metadataVersion}`,
       typeDefs,
+      TTL_INFINITE,
     );
   }
 
@@ -139,6 +143,7 @@ export class WorkspaceCacheStorageService {
     return this.cacheStorageService.set<string[]>(
       `${WorkspaceCacheKeys.GraphQLUsedScalarNames}:${workspaceId}:${metadataVersion}`,
       usedScalarNames,
+      TTL_INFINITE,
     );
   }
 


### PR DESCRIPTION
## Context
We recently added an infinite ttl to metadata version however other keys such as the object metadata map are also linked to the version so keeping the version in cache without the rest breaks the app. I'm editing all engine related keys with infinite ttl