### PR TITLE
Fix empty state not being centered

### DIFF
--- a/packages/twenty-front/src/modules/ui/utilities/scroll/components/ScrollWrapper.tsx
+++ b/packages/twenty-front/src/modules/ui/utilities/scroll/components/ScrollWrapper.tsx
@@ -24,7 +24,7 @@ const StyledScrollWrapper = styled.div`
 `;
 
 const StyledInnerContainer = styled.div`
-  flex: 1;
+  height: 100%;
 `;
 
 export type ScrollWrapperProps = {


### PR DESCRIPTION
Fix empty state not being centered

Before:
<img width="1512" alt="Capture d’écran 2024-11-21 à 15 50 56" src="https://github.com/user-attachments/assets/8ea843b6-dce3-46d9-b2e3-db3be39e0cc1">

After:
<img width="1512" alt="Capture d’écran 2024-11-21 à 15 50 41" src="https://github.com/user-attachments/assets/b18d306a-ccea-489f-941f-086d816d3a79">
