### PR TITLE
Fix action menu padding

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/dropdown/components/DropdownMenuHeader.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/dropdown/components/DropdownMenuHeader.tsx
@@ -15,7 +15,7 @@ const StyledHeader = styled.li`
   border-top-right-radius: ${({ theme }) => theme.border.radius.sm};
   border-bottom: 1px solid ${({ theme }) => theme.border.color.light};
 
-  padding: ${({ theme }) => theme.spacing(1)} 0;
+  padding: ${({ theme }) => theme.spacing(1)};
 
   user-select: none;
   width: inherit;


### PR DESCRIPTION
Before:
<img width="211" alt="Capture d’écran 2024-11-21 à 16 10 29" src="https://github.com/user-attachments/assets/f13be007-e043-4b65-8fb1-b7264f7b37fd">

After:
<img width="218" alt="Capture d’écran 2024-11-21 à 16 10 10" src="https://github.com/user-attachments/assets/3fdf02b1-f932-4e72-8994-7596f6e22164">
