### PR TITLE
Fix RICH_TEXT display on cell

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/display/components/TextFieldDisplay.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/display/components/TextFieldDisplay.tsx
@@ -1,13 +1,13 @@
 import { useTextFieldDisplay } from '@/object-record/record-field/meta-types/hooks/useTextFieldDisplay';
+import { isFieldText } from '@/object-record/record-field/types/guards/isFieldText';
 import { TextDisplay } from '@/ui/field/display/components/TextDisplay';
 
 export const TextFieldDisplay = () => {
   const { fieldValue, fieldDefinition } = useTextFieldDisplay();
 
-  return (
-    <TextDisplay
-      text={fieldValue}
-      displayedMaxRows={fieldDefinition.metadata?.settings?.displayedMaxRows}
-    />
-  );
+  const displayedMaxRows = isFieldText(fieldDefinition)
+    ? fieldDefinition.metadata?.settings?.displayedMaxRows
+    : 1;
+
+  return <TextDisplay text={fieldValue} displayedMaxRows={displayedMaxRows} />;
 };

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/hooks/useTextFieldDisplay.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/hooks/useTextFieldDisplay.ts
@@ -2,15 +2,11 @@ import { useContext } from 'react';
 
 import { useRecordFieldValue } from '@/object-record/record-store/contexts/RecordFieldValueSelectorContext';
 
-import { assertFieldMetadata } from '@/object-record/record-field/types/guards/assertFieldMetadata';
-import { isFieldText } from '@/object-record/record-field/types/guards/isFieldText';
-import { FieldMetadataType } from '~/generated-metadata/graphql';
 import { FieldContext } from '../../contexts/FieldContext';
 
 export const useTextFieldDisplay = () => {
   const { recordId, fieldDefinition, hotkeyScope } = useContext(FieldContext);
 
-  assertFieldMetadata(FieldMetadataType.Text, isFieldText, fieldDefinition);
   const fieldName = fieldDefinition.metadata.fieldName;
 
   const fieldValue =


### PR DESCRIPTION
## Context
We added a check of the field type in [useTextFieldDisplay.ts](https://github.com/twentyhq/twenty/compare/c--fix-rich-text-display?expand=1#diff-8e53a2496b9faa67ac9aad3f7016efed19147557904da1bc44e895688513330d) however this hook is also used for RICH_TEXT fields so it fails.
I'm removing this check since I don't think this is necessary, the caller should already know its a TEXT or RICH_TEXT