### PR TITLE
fix-percentage

### DIFF
--- a/packages/twenty-front/src/modules/settings/data-model/fields/forms/number/components/SettingsDataModelFieldNumberForm.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/forms/number/components/SettingsDataModelFieldNumberForm.tsx
@@ -69,7 +69,7 @@ export const SettingsDataModelFieldNumberForm = ({
             <SettingsOptionCardContentCounter
               Icon={IconDecimal}
               title="Number of decimals"
-              description={`Example: ${(1000).toFixed(count)} ${type === 'percentage' ? '%' : ''}`}
+              description={`Example: ${(type === 'percentage' ? 99 : 1000).toFixed(count)} ${type === 'percentage' ? '%' : ''}`}
               value={count}
               onChange={(value) => onChange({ type: type, decimals: value })}
               disabled={disabled}

--- a/packages/twenty-front/src/modules/settings/data-model/fields/forms/number/components/SettingsDataModelFieldNumberForm.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/forms/number/components/SettingsDataModelFieldNumberForm.tsx
@@ -69,7 +69,7 @@ export const SettingsDataModelFieldNumberForm = ({
             <SettingsOptionCardContentCounter
               Icon={IconDecimal}
               title="Number of decimals"
-              description={`Example: ${(1000).toFixed(count)}`}
+              description={`Example: ${(1000).toFixed(count)} ${type === 'percentage' ? '%' : ''}`}
               value={count}
               onChange={(value) => onChange({ type: type, decimals: value })}
               disabled={disabled}


### PR DESCRIPTION
Following previous release, a suggestion was noticed by @martmull . Here is a suggested fix.

Before :
![image](https://github.com/user-attachments/assets/10a55daa-8c90-42fc-8d1b-e28fc03f1948)

After :
<img width="611" alt="Screenshot 2024-11-22 at 14 56 07" src="https://github.com/user-attachments/assets/67298633-4513-41a4-90aa-5e2366d3cd88">
