### PR TITLE
Update 1-click install script to use /tags endpoint instead of /release

### DIFF
--- a/packages/twenty-docker/scripts/1-click.sh
+++ b/packages/twenty-docker/scripts/1-click.sh
@@ -1,4 +1,4 @@
-pull_version=${VERSION:-$(curl -s https://api.github.com/repos/twentyhq/twenty/releases/latest | grep '"tag_name":' | cut -d '"' -f 4)}
+pull_version=${VERSION:-$(curl -s https://api.github.com/repos/twentyhq/twenty/tags | grep '"name":' | head -n 1 | cut -d '"' -f 4)}
 pull_branch=${BRANCH:-$pull_version}
 
 version_num=${pull_version#v}

--- a/packages/twenty-docker/scripts/1-click.sh
+++ b/packages/twenty-docker/scripts/1-click.sh
@@ -1,4 +1,9 @@
 pull_version=${VERSION:-$(curl -s https://api.github.com/repos/twentyhq/twenty/tags | grep '"name":' | head -n 1 | cut -d '"' -f 4)}
+
+if [[ -z "$pull_version" ]]; then
+  echo "Error: Unable to fetch the latest version tag. Please check your network connection or the GitHub API response."
+  exit 1
+fi
 pull_branch=${BRANCH:-$pull_version}
 
 version_num=${pull_version#v}


### PR DESCRIPTION
Updated the API endpoint from https://api.github.com/repos/twentyhq/twenty/releases/latest to https://api.github.com/repos/twentyhq/twenty/tags.
Related Issue  #8679 