### PR TITLE
Fix array edit option

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/MultiItemFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/MultiItemFieldInput.tsx
@@ -117,6 +117,10 @@ export const MultiItemFieldInput = <T,>({
         item = items[index] as string;
         setInputValue(item);
         break;
+      case FieldMetadataType.Array:
+        item = items[index] as string;
+        setInputValue(item);
+        break;
       default:
         throw new Error(`Unsupported field type: ${fieldMetadataType}`);
     }


### PR DESCRIPTION
Closes #8578 
There was no case to handle a FieldMetadataType.Array and thus an error was thrown every time the edit button was clicked on an Array type.
It has been added now with an explicit break statement.