### PR TITLE
Added containers for testing

### DIFF
--- a/packages/twenty-e2e-testing/Makefile
+++ b/packages/twenty-e2e-testing/Makefile
@@ -1,0 +1,22 @@
+# Before running mock-saml, read instructions on how to create public/private pair key and insert it here
+# https://github.com/boxyhq/mock-saml/blob/main/.env.example
+mock-saml:
+	docker run \
+	--name mock_saml \
+  	-p 4000:4000 \
+  	-e APP_URL="http://localhost:4000" \
+  	-e ENTITY_ID="https://saml.example.com/entityid" \
+  	-e PUBLIC_KEY= \
+  	-e PRIVATE_KEY= \
+  	-d boxyhq/mock-saml
+
+smtp4dev:
+	docker run \
+	--name smtp4dev \
+	-p 8090:80 \
+	-p 2525:25 \
+	-p 143:143 \
+	-d rnwood/smtp4dev
+
+webhook:
+	docker compose -f ./containers/webhook.yml up --remove-orphans

--- a/packages/twenty-e2e-testing/containers/webhook.yml
+++ b/packages/twenty-e2e-testing/containers/webhook.yml
@@ -1,0 +1,51 @@
+services:
+  webhook:
+    container_name: "webhook-site"
+    image: "webhooksite/webhook.site"
+    command: php artisan queue:work --daemon --tries=3 --timeout=10
+    ports:
+      - "8084:80"
+    environment:
+      - APP_ENV=dev
+      - APP_DEBUG=true
+      - APP_URL=http://localhost:8084
+      - APP_LOG=errorlog
+      - DB_CONNECTION=sqlite
+      - REDIS_HOST=redis
+      - BROADCAST_DRIVER=redis
+      - CACHE_DRIVER=redis
+      - QUEUE_DRIVER=redis
+      - ECHO_HOST_MODE=path
+    depends_on:
+      - redis
+    networks:
+      - webhook
+
+  redis:
+    container_name: "webhook-redis"
+    image: "redis:alpine"
+    networks:
+      - webhook
+
+  laravel-echo-server:
+    container_name: "laravel-echo-server"
+    image: "webhooksite/laravel-echo-server"
+    environment:
+      - LARAVEL_ECHO_SERVER_AUTH_HOST=http://webhook
+      - LARAVEL_ECHO_SERVER_HOST=0.0.0.0
+      - LARAVEL_ECHO_SERVER_PORT=6001
+      - ECHO_REDIS_PORT=6379
+      - ECHO_REDIS_HOSTNAME=redis
+      - ECHO_PROTOCOL=http
+      - ECHO_ALLOW_CORS=true
+      - ECHO_ALLOW_ORIGIN=*
+      - ECHO_ALLOW_METHODS=*
+      - ECHO_ALLOW_HEADERS=*
+    depends_on:
+      - redis
+    networks:
+      - webhook
+
+networks:
+  webhook:
+    driver: bridge


### PR DESCRIPTION
Related to #8469 and #6641 

Webhook.site container must be in compose file as it requires 3 containers, one of them being Redis which is already used by Twenty. To prevent any problems with running 2 Redis containers simultaneously, network was created to separate both containers.