### PR TITLE
Fix enumMigration not working on long fieldNames

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-runner/services/workspace-migration-enum.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-runner/services/workspace-migration-enum.service.ts
@@ -50,7 +50,7 @@ export class WorkspaceMigrationEnumService {
         typeof enumValue !== 'string',
     );
 
-    const oldColumnName = `${columnDefinition.columnName}_old_${v4()}`;
+    const oldColumnName = `old_${v4()}`;
 
     // Rename old column
     await this.renameColumn(


### PR DESCRIPTION
## Issue

Some users were facing issues while updating SELECT or MULTISELECT options:

```
Error executing migration QueryFailedError: column "undefined" does not exist
    at PostgresQueryRunner.query (/app/node_modules/typeorm/driver/postgres/PostgresQueryRunner.js:219:19)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async WorkspaceMigrationEnumService.migrateEnumValues (/app/packages/twenty-server/dist/src/engine/workspace-manager/workspace-migration-runner/services/workspace-migration-enum.service.js:101:13)
    at async WorkspaceMigrationEnumService.alterEnum (/app/packages/twenty-server/dist/src/engine/workspace-manager/workspace-migration-runner/services/workspace-migration-enum.service.js:54:9)
    at async WorkspaceMigrationRunnerService.alterColumn (/app/packages/twenty-server/dist/src/engine/workspace-manager/workspace-migration-runner/workspace-migration-runner.service.js:254:13)
    at async WorkspaceMigrationRunnerService.handleColumnChanges (/app/packages/twenty-server/dist/src/engine/workspace-manager/workspace-migration-runner/workspace-migration-runner.service.js:202:21)
    at async WorkspaceMigrationRunnerService.handleTableChanges (/app/packages/twenty-server/dist/src/engine/workspace-manager/workspace-migration-runner/workspace-migration-runner.service.js:94:25)
    at async WorkspaceMigrationRunnerService.executeMigrationFromPendingMigrations (/app/packages/twenty-server/dist/src/engine/workspace-manager/workspace-migration-runner/workspace-migration-runner.service.js:60:17)
    at async WorkspaceExecutePendingMigrationsCommand.run (/app/packages/twenty-server/dist/src/engine/workspace-manager/workspace-migration-runner/commands/workspace-execute-pending-migrations.command.js:24:9)
    at async Command.<anonymous> (/app/node_modules/nest-commander/src/command-runner.service.js:162:24) {
  query: '\n' +
    '        UPDATE "workspace_7i7bwawp7keh3gel1g69jropc"."_funnelInProductsRu"\n' +
    '        SET "reasonForStageTransition" = undefined\n' +
    "        WHERE id='2af8db61-5f75-46de-8b1a-97e312937e06'\n" +
    '      ',
  parameters: undefined,
  driverError: error: column "undefined" does not exist
```

## Root cause

Internally, while migrating enum values, we are doing:
```
const values = await queryRunner.query(
      `SELECT id, "${oldColumnName}" FROM "${schemaName}"."${tableName}"`,
    );

 let val = value[oldColumnName];
```

oldColumnName being: `${columnDefinition.columnName}_old_${v4()}`;

However, TypeORM only supports 63 bits identifiers: https://github.com/typeorm/typeorm/issues/3118, but silently truncate the identifer so if oldColumnName gets larger than 63 characters, `value[oldColumnName]` is undefined.

## Fix

We only need a temporary and unique temporary name, no need to take into account the previous columnName here
