### PR TITLE
Fix mutations with camelCase table names

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-delete-one-resolver.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-delete-one-resolver.service.ts
@@ -35,8 +35,8 @@ export class GraphqlQueryDeleteOneResolverService extends GraphqlQueryBaseResolv
     );
 
     const nonFormattedDeletedObjectRecords = await queryBuilder
-      .where({ id: executionArgs.args.id })
       .softDelete()
+      .where({ id: executionArgs.args.id })
       .returning('*')
       .execute();
 

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-destroy-one-resolver.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-destroy-one-resolver.service.ts
@@ -16,7 +16,6 @@ import {
 import { ObjectRecordsToGraphqlConnectionHelper } from 'src/engine/api/graphql/graphql-query-runner/helpers/object-records-to-graphql-connection.helper';
 import { ProcessNestedRelationsHelper } from 'src/engine/api/graphql/graphql-query-runner/helpers/process-nested-relations.helper';
 import { formatResult } from 'src/engine/twenty-orm/utils/format-result.util';
-import { computeTableName } from 'src/engine/utils/compute-table-name.util';
 
 @Injectable()
 export class GraphqlQueryDestroyOneResolverService extends GraphqlQueryBaseResolverService<
@@ -33,17 +32,9 @@ export class GraphqlQueryDestroyOneResolverService extends GraphqlQueryBaseResol
       objectMetadataItemWithFieldMaps.nameSingular,
     );
 
-    const tableName = computeTableName(
-      objectMetadataItemWithFieldMaps.nameSingular,
-      objectMetadataItemWithFieldMaps.isCustom,
-    );
-
     const nonFormattedDeletedObjectRecords = await queryBuilder
-      .where(`"${tableName}".id = :id`, {
-        id: executionArgs.args.id,
-      })
-      .take(1)
       .delete()
+      .where({ id: executionArgs.args.id })
       .returning('*')
       .execute();
 

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-restore-one-resolver.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-restore-one-resolver.service.ts
@@ -35,8 +35,8 @@ export class GraphqlQueryRestoreOneResolverService extends GraphqlQueryBaseResol
     );
 
     const nonFormattedRestoredObjectRecords = await queryBuilder
-      .where({ id: executionArgs.args.id })
       .restore()
+      .where({ id: executionArgs.args.id })
       .returning('*')
       .execute();
 


### PR DESCRIPTION
## Context
Some mutations are not working properly, workspaceMember soft deletion for example. workspaceMember being a camelCase table name, it's probably not propagated properly to pgql (which needs double quote for the table name to keep it as camelCase)

I didn't have time to dig too much but if the `where` is before `softDelete`, the query is `WHERE workspaceMember.id = $1` while if it's after, the query becomes `WHERE id = $1`.
Probably due to the fact that once you call delete/softDelete/update, the standard builder (SelectQueryBuilder) becomes a DeleteQueryBuilder/etc... and filters are not handled the same way.