### PR TITLE
Fix custom object renaming

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/services/object-metadata-migration.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/services/object-metadata-migration.service.ts
@@ -165,12 +165,11 @@ export class ObjectMetadataMigrationService {
                 });
 
               if (relatedObject) {
-                // 1. Update to and from relation fieldMetadata)
+                // 1. Update to and from relation fieldMetadata
                 const toFieldRelationFieldMetadataId =
                   await this.fieldMetadataRepository
                     .findOneByOrFail({
                       name: existingObjectMetadata.nameSingular,
-                      label: existingObjectMetadata.labelSingular,
                       objectMetadataId: relatedObject.id,
                       workspaceId: workspaceId,
                     })


### PR DESCRIPTION
Currently when renaming an object, we execute
```
await this.fieldMetadataRepository
                    .findOneByOrFail({
                      name: existingObjectMetadata.nameSingular,
                      label: existingObjectMetadata.labelSingular,
                      objectMetadataId: relatedObject.id,
                      workspaceId: workspaceId,
                    })
```
to find the standard relation fields. 
This would throw an error if the label solely was update beforehand without updating the name too: in that case we will not have migrated the label of the standard relation fields (which is maybe a mistake? @Weiko wdyt?). 
Let's remove it. 