### PR TITLE
Set missing labelIdentifier to custom objects

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version/0-33/0-33-set-missing-label-identifier-to-custom-objects.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-33/0-33-set-missing-label-identifier-to-custom-objects.command.ts
@@ -76,6 +76,7 @@ export class SetMissingLabelIdentifierToCustomObjectsCommand extends ActiveWorks
       where: {
         workspaceId,
         labelIdentifierFieldMetadataId: IsNull(),
+        isCustom: true,
       },
     });
 

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-33/0-33-set-missing-label-identifier-to-custom-objects.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-33/0-33-set-missing-label-identifier-to-custom-objects.command.ts
@@ -1,0 +1,107 @@
+import { InjectRepository } from '@nestjs/typeorm';
+
+import chalk from 'chalk';
+import { Command } from 'nest-commander';
+import { IsNull, Repository } from 'typeorm';
+
+import {
+  ActiveWorkspacesCommandOptions,
+  ActiveWorkspacesCommandRunner,
+} from 'src/database/commands/active-workspaces.command';
+import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
+import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
+import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.manager';
+import { CUSTOM_OBJECT_STANDARD_FIELD_IDS } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-field-ids';
+
+interface SetMissingLabelIdentifierToCustomObjectsCommandOptions
+  extends ActiveWorkspacesCommandOptions {}
+
+@Command({
+  name: 'upgrade-0.33:set-missing-label-identifier-to-custom-objects',
+  description: 'Set missing labelIdentifier to custom objects',
+})
+export class SetMissingLabelIdentifierToCustomObjectsCommand extends ActiveWorkspacesCommandRunner {
+  constructor(
+    @InjectRepository(Workspace, 'core')
+    protected readonly workspaceRepository: Repository<Workspace>,
+    @InjectRepository(FieldMetadataEntity, 'metadata')
+    private readonly fieldMetadataRepository: Repository<FieldMetadataEntity>,
+    @InjectRepository(ObjectMetadataEntity, 'metadata')
+    private readonly objectMetadataRepository: Repository<ObjectMetadataEntity>,
+    private readonly twentyORMGlobalManager: TwentyORMGlobalManager,
+  ) {
+    super(workspaceRepository);
+  }
+
+  async executeActiveWorkspacesCommand(
+    _passedParam: string[],
+    options: SetMissingLabelIdentifierToCustomObjectsCommandOptions,
+    workspaceIds: string[],
+  ): Promise<void> {
+    this.logger.log(
+      'Running command to set missing labelIdentifier to custom objects',
+    );
+
+    for (const workspaceId of workspaceIds) {
+      this.logger.log(`Running command for workspace ${workspaceId}`);
+
+      try {
+        await this.setMissingLabelIdentifierToCustomObjectsForWorkspace(
+          workspaceId,
+          options,
+        );
+      } catch (error) {
+        this.logger.log(
+          chalk.red(
+            `Running command on workspace ${workspaceId} failed with error: ${error}, ${error.stack}`,
+          ),
+        );
+        continue;
+      } finally {
+        this.logger.log(
+          chalk.green(`Finished running command for workspace ${workspaceId}.`),
+        );
+      }
+    }
+
+    this.logger.log(chalk.green(`Command completed!`));
+  }
+
+  private async setMissingLabelIdentifierToCustomObjectsForWorkspace(
+    workspaceId: string,
+    options: SetMissingLabelIdentifierToCustomObjectsCommandOptions,
+  ): Promise<void> {
+    const customObjects = await this.objectMetadataRepository.find({
+      where: {
+        workspaceId,
+        labelIdentifierFieldMetadataId: IsNull(),
+      },
+    });
+
+    for (const customObject of customObjects) {
+      const labelIdentifierFieldMetadata =
+        await this.fieldMetadataRepository.findOne({
+          where: {
+            workspaceId,
+            objectMetadataId: customObject.id,
+            standardId: CUSTOM_OBJECT_STANDARD_FIELD_IDS.name,
+          },
+        });
+
+      if (labelIdentifierFieldMetadata && !options.dryRun) {
+        await this.objectMetadataRepository.update(customObject.id, {
+          labelIdentifierFieldMetadataId: labelIdentifierFieldMetadata.id,
+        });
+      }
+
+      if (options.verbose) {
+        this.logger.log(
+          chalk.yellow(
+            `Set labelIdentifierFieldMetadataId for custom object ${customObject.nameSingular}`,
+          ),
+        );
+      }
+    }
+  }
+}

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-33/0-33-upgrade-version.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-33/0-33-upgrade-version.command.ts
@@ -6,6 +6,7 @@ import { Repository } from 'typeorm';
 import { ActiveWorkspacesCommandRunner } from 'src/database/commands/active-workspaces.command';
 import { DeleteViewFieldsWithoutViewsCommand } from 'src/database/commands/upgrade-version/0-33/0-33-delete-view-fields-without-views.command';
 import { EnforceUniqueConstraintsCommand } from 'src/database/commands/upgrade-version/0-33/0-33-enforce-unique-constraints.command';
+import { SetMissingLabelIdentifierToCustomObjectsCommand } from 'src/database/commands/upgrade-version/0-33/0-33-set-missing-label-identifier-to-custom-objects.command';
 import { UpdateRichTextSearchVectorCommand } from 'src/database/commands/upgrade-version/0-33/0-33-update-rich-text-search-vector-expression';
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { SyncWorkspaceMetadataCommand } from 'src/engine/workspace-manager/workspace-sync-metadata/commands/sync-workspace-metadata.command';
@@ -26,6 +27,7 @@ export class UpgradeTo0_33Command extends ActiveWorkspacesCommandRunner {
     private readonly enforceUniqueConstraintsCommand: EnforceUniqueConstraintsCommand,
     private readonly deleteViewFieldsWithoutViewsCommand: DeleteViewFieldsWithoutViewsCommand,
     private readonly syncWorkspaceMetadataCommand: SyncWorkspaceMetadataCommand,
+    private readonly setMissingLabelIdentifierToCustomObjectsCommand: SetMissingLabelIdentifierToCustomObjectsCommand,
   ) {
     super(workspaceRepository);
   }
@@ -60,6 +62,11 @@ export class UpgradeTo0_33Command extends ActiveWorkspacesCommandRunner {
       workspaceIds,
     );
     await this.updateRichTextSearchVectorCommand.executeActiveWorkspacesCommand(
+      passedParam,
+      options,
+      workspaceIds,
+    );
+    await this.setMissingLabelIdentifierToCustomObjectsCommand.executeActiveWorkspacesCommand(
       passedParam,
       options,
       workspaceIds,

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-33/0-33-upgrade-version.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-33/0-33-upgrade-version.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { DeleteViewFieldsWithoutViewsCommand } from 'src/database/commands/upgrade-version/0-33/0-33-delete-view-fields-without-views.command';
 import { EnforceUniqueConstraintsCommand } from 'src/database/commands/upgrade-version/0-33/0-33-enforce-unique-constraints.command';
+import { SetMissingLabelIdentifierToCustomObjectsCommand } from 'src/database/commands/upgrade-version/0-33/0-33-set-missing-label-identifier-to-custom-objects.command';
 import { UpdateRichTextSearchVectorCommand } from 'src/database/commands/upgrade-version/0-33/0-33-update-rich-text-search-vector-expression';
 import { UpgradeTo0_33Command } from 'src/database/commands/upgrade-version/0-33/0-33-upgrade-version.command';
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
@@ -28,6 +29,7 @@ import { WorkspaceSyncMetadataCommandsModule } from 'src/engine/workspace-manage
     UpdateRichTextSearchVectorCommand,
     EnforceUniqueConstraintsCommand,
     DeleteViewFieldsWithoutViewsCommand,
+    SetMissingLabelIdentifierToCustomObjectsCommand,
   ],
 })
 export class UpgradeTo0_33CommandModule {}


### PR DESCRIPTION
## Context
Following https://github.com/twentyhq/twenty/pull/8729

This command backfills missing labelIdentifier for custom objects