### PR TITLE
Fix index renaming

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.module.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.module.ts
@@ -13,6 +13,7 @@ import { FeatureFlagEntity } from 'src/engine/core-modules/feature-flag/feature-
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { DataSourceModule } from 'src/engine/metadata-modules/data-source/data-source.module';
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
+import { IndexMetadataModule } from 'src/engine/metadata-modules/index-metadata/index-metadata.module';
 import { BeforeUpdateOneObject } from 'src/engine/metadata-modules/object-metadata/hooks/before-update-one-object.hook';
 import { ObjectMetadataGraphqlApiExceptionInterceptor } from 'src/engine/metadata-modules/object-metadata/interceptors/object-metadata-graphql-api-exception.interceptor';
 import { ObjectMetadataResolver } from 'src/engine/metadata-modules/object-metadata/object-metadata.resolver';
@@ -49,6 +50,7 @@ import { UpdateObjectPayload } from './dtos/update-object.input';
         WorkspaceMetadataVersionModule,
         RemoteTableRelationsModule,
         SearchModule,
+        IndexMetadataModule,
       ],
       services: [
         ObjectMetadataService,

--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/services/object-metadata-relation.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/services/object-metadata-relation.service.ts
@@ -18,16 +18,26 @@ import {
   RelationMetadataType,
   RelationOnDeleteAction,
 } from 'src/engine/metadata-modules/relation-metadata/relation-metadata.entity';
+import { mapUdtNameToFieldType } from 'src/engine/metadata-modules/remote-server/remote-table/utils/udt-name-mapper.util';
 import {
   CUSTOM_OBJECT_STANDARD_FIELD_IDS,
   STANDARD_OBJECT_FIELD_IDS,
 } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-field-ids';
 import { STANDARD_OBJECT_ICONS } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-object-icons';
+import { STANDARD_OBJECT_IDS } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-object-ids';
 import {
   createForeignKeyDeterministicUuid,
   createRelationDeterministicUuid,
 } from 'src/engine/workspace-manager/workspace-sync-metadata/utils/create-deterministic-uuid.util';
 import { capitalize } from 'src/utils/capitalize';
+
+const DEFAULT_RELATIONS_OBJECTS_STANDARD_IDS = [
+  STANDARD_OBJECT_IDS.timelineActivity,
+  STANDARD_OBJECT_IDS.favorite,
+  STANDARD_OBJECT_IDS.attachment,
+  STANDARD_OBJECT_IDS.noteTarget,
+  STANDARD_OBJECT_IDS.taskTarget,
+];
 
 @Injectable()
 export class ObjectMetadataRelationService {
@@ -40,46 +50,63 @@ export class ObjectMetadataRelationService {
     private readonly relationMetadataRepository: Repository<RelationMetadataEntity>,
   ) {}
 
-  public async createMetadata(
+  public async createRelationsAndForeignKeysMetadata(
+    workspaceId: string,
+    createdObjectMetadata: ObjectMetadataEntity,
+    { primaryKeyFieldMetadataSettings, primaryKeyColumnType },
+  ) {
+    const relatedObjectMetadataCollection = await Promise.all(
+      DEFAULT_RELATIONS_OBJECTS_STANDARD_IDS.map(
+        async (relationObjectMetadataStandardId) =>
+          this.createRelationAndForeignKeyMetadata(
+            workspaceId,
+            createdObjectMetadata,
+            mapUdtNameToFieldType(primaryKeyColumnType ?? 'uuid'),
+            primaryKeyFieldMetadataSettings,
+            relationObjectMetadataStandardId,
+          ),
+      ),
+    );
+
+    return relatedObjectMetadataCollection;
+  }
+
+  private async createRelationAndForeignKeyMetadata(
     workspaceId: string,
     createdObjectMetadata: ObjectMetadataEntity,
     objectPrimaryKeyType: FieldMetadataType,
     objectPrimaryKeyFieldSettings:
       | FieldMetadataSettings<FieldMetadataType | 'default'>
       | undefined,
-    relatedObjectMetadataName: string,
+    relationObjectMetadataStandardId: string,
   ) {
     const relatedObjectMetadata =
       await this.objectMetadataRepository.findOneByOrFail({
-        nameSingular: relatedObjectMetadataName,
+        standardId: relationObjectMetadataStandardId,
         workspaceId: workspaceId,
+        isCustom: false,
       });
 
-    await this.createForeignKeyFieldMetadata(
-      workspaceId,
-      createdObjectMetadata,
-      relatedObjectMetadata,
-      objectPrimaryKeyType,
-      objectPrimaryKeyFieldSettings,
-    );
+    const relationFieldMetadataCollection =
+      await this.createRelationFieldMetadas(
+        workspaceId,
+        createdObjectMetadata,
+        relatedObjectMetadata,
+        objectPrimaryKeyType,
+        objectPrimaryKeyFieldSettings,
+      );
 
-    const relationFieldMetadata = await this.createRelationFields(
+    await this.createRelationMetadataFromFieldMetadatas(
       workspaceId,
       createdObjectMetadata,
       relatedObjectMetadata,
-    );
-
-    await this.createRelationMetadata(
-      workspaceId,
-      createdObjectMetadata,
-      relatedObjectMetadata,
-      relationFieldMetadata,
+      relationFieldMetadataCollection,
     );
 
     return relatedObjectMetadata;
   }
 
-  private async createForeignKeyFieldMetadata(
+  private async createRelationFieldMetadas(
     workspaceId: string,
     createdObjectMetadata: ObjectMetadataEntity,
     relatedObjectMetadata: ObjectMetadataEntity,
@@ -88,99 +115,187 @@ export class ObjectMetadataRelationService {
       | FieldMetadataSettings<FieldMetadataType | 'default'>
       | undefined,
   ) {
-    const customStandardFieldId =
-      STANDARD_OBJECT_FIELD_IDS[relatedObjectMetadata.nameSingular].custom;
-
-    if (!customStandardFieldId) {
-      throw new Error(
-        `Custom standard field ID not found for ${relatedObjectMetadata.nameSingular}`,
-      );
-    }
-
-    const { name, label, description } =
-      buildNameLabelAndDescriptionForForeignKeyFieldMetadata({
-        targetObjectNameSingular: createdObjectMetadata.nameSingular,
-        targetObjectLabelSingular: createdObjectMetadata.labelSingular,
-        relatedObjectLabelSingular: relatedObjectMetadata.labelSingular,
-      });
-
-    await this.fieldMetadataRepository.save({
-      standardId: createForeignKeyDeterministicUuid({
-        objectId: createdObjectMetadata.id,
-        standardId: customStandardFieldId,
-      }),
-      objectMetadataId: relatedObjectMetadata.id,
-      workspaceId: workspaceId,
-      isCustom: false,
-      isActive: true,
-      type: objectPrimaryKeyType,
-      name,
-      label,
-      description,
-      icon: undefined,
-      isNullable: true,
-      isSystem: true,
-      defaultValue: undefined,
-      settings: { ...objectPrimaryKeyFieldSettings, isForeignKey: true },
-    });
-  }
-
-  private async createRelationFields(
-    workspaceId: string,
-    createdObjectMetadata: ObjectMetadataEntity,
-    relatedObjectMetadata: ObjectMetadataEntity,
-  ) {
-    return await this.fieldMetadataRepository.save([
-      this.createFromField(
+    return this.fieldMetadataRepository.save([
+      this.buildFromFieldMetadata(
         workspaceId,
         createdObjectMetadata,
         relatedObjectMetadata,
       ),
-      this.createToField(
+      this.buildToFieldMetadata(
         workspaceId,
         createdObjectMetadata,
         relatedObjectMetadata,
+      ),
+      this.buildForeignKeyFieldMetadata(
+        workspaceId,
+        createdObjectMetadata,
+        relatedObjectMetadata,
+        objectPrimaryKeyType,
+        objectPrimaryKeyFieldSettings,
       ),
     ]);
   }
 
-  private createFromField(
+  public async updateRelationsAndForeignKeysMetadata(
     workspaceId: string,
-    createdObjectMetadata: ObjectMetadataEntity,
+    updatedObjectMetadata: ObjectMetadataEntity,
+  ): Promise<
+    {
+      relatedObjectMetadata: ObjectMetadataEntity;
+      foreignKeyFieldMetadata: FieldMetadataEntity;
+      toFieldMetadata: FieldMetadataEntity;
+      fromFieldMetadata: FieldMetadataEntity;
+    }[]
+  > {
+    return await Promise.all(
+      DEFAULT_RELATIONS_OBJECTS_STANDARD_IDS.map(
+        async (relationObjectMetadataStandardId) =>
+          this.updateRelationAndForeignKeyMetadata(
+            workspaceId,
+            updatedObjectMetadata,
+            relationObjectMetadataStandardId,
+          ),
+      ),
+    );
+  }
+
+  private async updateRelationAndForeignKeyMetadata(
+    workspaceId: string,
+    updatedObjectMetadata: ObjectMetadataEntity,
+    relationObjectMetadataStandardId: string,
+  ) {
+    const relatedObjectMetadata =
+      await this.objectMetadataRepository.findOneByOrFail({
+        standardId: relationObjectMetadataStandardId,
+        workspaceId: workspaceId,
+        isCustom: false,
+      });
+
+    const toFieldMetadataUpdateCriteria = {
+      standardId: createRelationDeterministicUuid({
+        objectId: updatedObjectMetadata.id,
+        standardId:
+          STANDARD_OBJECT_FIELD_IDS[relatedObjectMetadata.nameSingular].custom,
+      }),
+      objectMetadataId: relatedObjectMetadata.id,
+      workspaceId: workspaceId,
+    };
+    const toFieldMetadataUpdateData = this.buildToFieldMetadata(
+      workspaceId,
+      updatedObjectMetadata,
+      relatedObjectMetadata,
+      true,
+    );
+    const toFieldMetadataToUpdate =
+      await this.fieldMetadataRepository.findOneBy(
+        toFieldMetadataUpdateCriteria,
+      );
+    const toFieldMetadata = await this.fieldMetadataRepository.save({
+      ...toFieldMetadataToUpdate,
+      ...toFieldMetadataUpdateData,
+    });
+
+    const fromFieldMetadataUpdateCriteria = {
+      standardId:
+        CUSTOM_OBJECT_STANDARD_FIELD_IDS[relatedObjectMetadata.namePlural],
+      objectMetadataId: updatedObjectMetadata.id,
+      workspaceId: workspaceId,
+    };
+    const fromFieldMetadataUpdateData = this.buildFromFieldMetadata(
+      workspaceId,
+      updatedObjectMetadata,
+      relatedObjectMetadata,
+      true,
+    );
+    const fromFieldMetadataToUpdate =
+      await this.fieldMetadataRepository.findOneBy(
+        fromFieldMetadataUpdateCriteria,
+      );
+    const fromFieldMetadata = await this.fieldMetadataRepository.save({
+      ...fromFieldMetadataToUpdate,
+      ...fromFieldMetadataUpdateData,
+    });
+
+    const foreignKeyFieldMetadataUpdateCriteria = {
+      standardId: createForeignKeyDeterministicUuid({
+        objectId: updatedObjectMetadata.id,
+        standardId:
+          STANDARD_OBJECT_FIELD_IDS[relatedObjectMetadata.nameSingular].custom,
+      }),
+      objectMetadataId: relatedObjectMetadata.id,
+      workspaceId: workspaceId,
+    };
+    const foreignKeyFieldMetadataUpdateData = this.buildForeignKeyFieldMetadata(
+      workspaceId,
+      updatedObjectMetadata,
+      relatedObjectMetadata,
+      FieldMetadataType.UUID,
+      undefined,
+      true,
+    );
+    const foreignKeyFieldMetadataToUpdate =
+      await this.fieldMetadataRepository.findOneBy(
+        foreignKeyFieldMetadataUpdateCriteria,
+      );
+    const foreignKeyFieldMetadata = await this.fieldMetadataRepository.save({
+      ...foreignKeyFieldMetadataToUpdate,
+      ...foreignKeyFieldMetadataUpdateData,
+    });
+
+    return {
+      relatedObjectMetadata,
+      foreignKeyFieldMetadata,
+      toFieldMetadata,
+      fromFieldMetadata,
+    };
+  }
+
+  private buildFromFieldMetadata(
+    workspaceId: string,
+    objectMetadata: ObjectMetadataEntity,
     relatedObjectMetadata: ObjectMetadataEntity,
+    isUpdate = false,
   ) {
     const relationObjectMetadataNamePlural = relatedObjectMetadata.namePlural;
 
     const { description } = buildDescriptionForRelationFieldMetadataOnFromField(
       {
         relationObjectMetadataNamePlural,
-        targetObjectLabelSingular: createdObjectMetadata.labelSingular,
+        targetObjectLabelSingular: objectMetadata.labelSingular,
       },
     );
 
     return {
-      standardId:
-        CUSTOM_OBJECT_STANDARD_FIELD_IDS[relationObjectMetadataNamePlural],
-      objectMetadataId: createdObjectMetadata.id,
-      workspaceId: workspaceId,
-      isCustom: false,
-      isActive: true,
-      isSystem: true,
-      type: FieldMetadataType.RELATION,
-      name: relatedObjectMetadata.namePlural,
-      label: capitalize(relationObjectMetadataNamePlural),
       description,
-      icon:
-        STANDARD_OBJECT_ICONS[relatedObjectMetadata.nameSingular] ||
-        'IconBuildingSkyscraper',
-      isNullable: true,
+      ...(!isUpdate
+        ? {
+            standardId:
+              CUSTOM_OBJECT_STANDARD_FIELD_IDS[
+                relationObjectMetadataNamePlural
+              ],
+            objectMetadataId: objectMetadata.id,
+            workspaceId: workspaceId,
+            isCustom: false,
+            isActive: true,
+            isSystem: true,
+            type: FieldMetadataType.RELATION,
+            name: relatedObjectMetadata.namePlural,
+            label: capitalize(relationObjectMetadataNamePlural),
+            description,
+            icon:
+              STANDARD_OBJECT_ICONS[relatedObjectMetadata.nameSingular] ||
+              'IconBuildingSkyscraper',
+            isNullable: true,
+          }
+        : {}),
     };
   }
 
-  private createToField(
+  private buildToFieldMetadata(
     workspaceId: string,
-    createdObjectMetadata: ObjectMetadataEntity,
+    objectMetadata: ObjectMetadataEntity,
     relatedObjectMetadata: ObjectMetadataEntity,
+    isUpdate = false,
   ) {
     const customStandardFieldId =
       STANDARD_OBJECT_FIELD_IDS[relatedObjectMetadata.nameSingular].custom;
@@ -193,35 +308,96 @@ export class ObjectMetadataRelationService {
 
     const { description } = buildDescriptionForRelationFieldMetadataOnToField({
       relationObjectMetadataNamePlural: relatedObjectMetadata.namePlural,
-      targetObjectLabelSingular: createdObjectMetadata.labelSingular,
+      targetObjectLabelSingular: objectMetadata.labelSingular,
     });
 
     return {
-      standardId: createRelationDeterministicUuid({
-        objectId: createdObjectMetadata.id,
-        standardId: customStandardFieldId,
-      }),
-      objectMetadataId: relatedObjectMetadata.id,
-      workspaceId: workspaceId,
-      isCustom: false,
-      isActive: true,
-      isSystem: true,
-      type: FieldMetadataType.RELATION,
-      name: createdObjectMetadata.nameSingular,
-      label: createdObjectMetadata.labelSingular,
+      name: objectMetadata.nameSingular,
+      label: objectMetadata.labelSingular,
       description,
-      icon: 'IconBuildingSkyscraper',
-      isNullable: true,
+      ...(!isUpdate
+        ? {
+            standardId: createRelationDeterministicUuid({
+              objectId: objectMetadata.id,
+              standardId: customStandardFieldId,
+            }),
+            objectMetadataId: relatedObjectMetadata.id,
+            workspaceId: workspaceId,
+            isCustom: false,
+            isActive: true,
+            isSystem: true,
+            type: FieldMetadataType.RELATION,
+            name: objectMetadata.nameSingular,
+            label: objectMetadata.labelSingular,
+            description,
+            icon: 'IconBuildingSkyscraper',
+            isNullable: true,
+          }
+        : {}),
     };
   }
 
-  private async createRelationMetadata(
+  private buildForeignKeyFieldMetadata(
+    workspaceId: string,
+    objectMetadata: ObjectMetadataEntity,
+    relatedObjectMetadata: ObjectMetadataEntity,
+    objectPrimaryKeyType: FieldMetadataType,
+    objectPrimaryKeyFieldSettings:
+      | FieldMetadataSettings<FieldMetadataType | 'default'>
+      | undefined,
+    isUpdate = false,
+  ) {
+    const customStandardFieldId =
+      STANDARD_OBJECT_FIELD_IDS[relatedObjectMetadata.nameSingular].custom;
+
+    if (!customStandardFieldId) {
+      throw new Error(
+        `Custom standard field ID not found for ${relatedObjectMetadata.nameSingular}`,
+      );
+    }
+
+    const { name, label, description } =
+      buildNameLabelAndDescriptionForForeignKeyFieldMetadata({
+        targetObjectNameSingular: objectMetadata.nameSingular,
+        targetObjectLabelSingular: objectMetadata.labelSingular,
+        relatedObjectLabelSingular: relatedObjectMetadata.labelSingular,
+      });
+
+    return {
+      name,
+      label,
+      description,
+      ...(!isUpdate
+        ? {
+            standardId: createForeignKeyDeterministicUuid({
+              objectId: objectMetadata.id,
+              standardId: customStandardFieldId,
+            }),
+            objectMetadataId: relatedObjectMetadata.id,
+            workspaceId: workspaceId,
+            isCustom: false,
+            isActive: true,
+            type: objectPrimaryKeyType,
+            name,
+            label,
+            description,
+            icon: undefined,
+            isNullable: true,
+            isSystem: true,
+            defaultValue: undefined,
+            settings: { ...objectPrimaryKeyFieldSettings, isForeignKey: true },
+          }
+        : {}),
+    };
+  }
+
+  private async createRelationMetadataFromFieldMetadatas(
     workspaceId: string,
     createdObjectMetadata: ObjectMetadataEntity,
     relatedObjectMetadata: ObjectMetadataEntity,
-    relationFieldMetadata: FieldMetadataEntity[],
+    relationFieldMetadataCollection: FieldMetadataEntity[],
   ) {
-    const relationFieldMetadataMap = relationFieldMetadata.reduce(
+    const relationFieldMetadataMap = relationFieldMetadataCollection.reduce(
       (acc, fieldMetadata: FieldMetadataEntity) => {
         if (fieldMetadata.type === FieldMetadataType.RELATION) {
           acc[fieldMetadata.objectMetadataId] = fieldMetadata;
@@ -247,7 +423,10 @@ export class ObjectMetadataRelationService {
     ]);
   }
 
-  async updateObjectRelationships(objectMetadataId: string, isActive: boolean) {
+  async updateObjectRelationshipsActivationStatus(
+    objectMetadataId: string,
+    isActive: boolean,
+  ) {
     const affectedRelations = await this.relationMetadataRepository.find({
       where: [
         { fromObjectMetadataId: objectMetadataId },


### PR DESCRIPTION
Fixes https://github.com/twentyhq/twenty/issues/8760

## Context
Index names are based on table names and column names, which means renaming an object (or a field) should also trigger a recompute of index names. As of today it raises a bug where you can't create an object with a name that was previously used.

I also took the occasion to refactor a bit the part where we create and update (after renaming) relations. Basically the only relations we want to affect are standard relations so I've aligned the logic with sync-metadata which uses standardId as a source of truth to simplify the code.

Note: We don't create index for custom relations
Next step should be to do that and update that code to update the index name as well. Also note that we need to update the sync-metadata logic for that as well