### PR TITLE
Fix token expiration error loop (#6731)

### DIFF
--- a/packages/twenty-front/src/modules/object-record/hooks/useFetchMoreRecordsWithPagination.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useFetchMoreRecordsWithPagination.ts
@@ -188,6 +188,7 @@ export const useFetchMoreRecordsWithPagination = <
             };
           } catch (error) {
             handleFindManyRecordsError(error as ApolloError);
+            return { error };
           } finally {
             setIsFetchingMoreObjects(false);
           }

--- a/packages/twenty-front/src/modules/object-record/hooks/useFetchMoreRecordsWithPagination.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useFetchMoreRecordsWithPagination.ts
@@ -188,7 +188,7 @@ export const useFetchMoreRecordsWithPagination = <
             };
           } catch (error) {
             handleFindManyRecordsError(error as ApolloError);
-            return { error };
+            return { error: error as ApolloError };
           } finally {
             setIsFetchingMoreObjects(false);
           }

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-body/components/RecordTableNoRecordGroupBodyEffect.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-body/components/RecordTableNoRecordGroupBodyEffect.tsx
@@ -97,7 +97,15 @@ export const RecordTableNoRecordGroupBodyEffect = () => {
 
   useEffect(() => {
     (async () => {
+      // NOW: tableLastRowVisible and hasNextPage
+      // TODO: and latest fetch succeeded and reset on component remount.
       if (!isFetchingMoreObjects && tableLastRowVisible && hasNextPage) {
+        console.log(
+          'RecordTableNoRecordGroupBodyEffect useEffect',
+          isFetchingMoreObjects,
+          tableLastRowVisible,
+          hasNextPage,
+        );
         await fetchMoreDebouncedIfRequested();
       }
     })();

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-body/components/RecordTableNoRecordGroupBodyEffect.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-body/components/RecordTableNoRecordGroupBodyEffect.tsx
@@ -128,6 +128,8 @@ export const RecordTableNoRecordGroupBodyEffect = () => {
     fetchMoreDebouncedIfRequested,
     isFetchingMoreObjects,
     tableLastRowVisible,
+    encounteredUnrecoverableError,
+    setEncounteredUnrecoverableError,
   ]);
 
   return <></>;

--- a/packages/twenty-front/src/modules/object-record/record-table/states/tableEncounteredUnrecoverableErrorComponentState.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/states/tableEncounteredUnrecoverableErrorComponentState.ts
@@ -1,9 +1,9 @@
 import { RecordTableComponentInstanceContext } from '@/object-record/record-table/states/context/RecordTableComponentInstanceContext';
 import { createComponentStateV2 } from '@/ui/utilities/state/component-state/utils/createComponentStateV2';
 
-export const tableLastFetchFailedComponentState =
+export const tableEncounteredUnrecoverableErrorComponentState =
   createComponentStateV2<boolean>({
-    key: 'tableLastFetchFailedComponentState',
+    key: 'tableEncounteredUnrecoverableErrorComponentState',
     defaultValue: false,
     componentInstanceContext: RecordTableComponentInstanceContext,
   });

--- a/packages/twenty-front/src/modules/object-record/record-table/states/tableLastFetchFailedComponentState.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/states/tableLastFetchFailedComponentState.ts
@@ -1,0 +1,9 @@
+import { RecordTableComponentInstanceContext } from '@/object-record/record-table/states/context/RecordTableComponentInstanceContext';
+import { createComponentStateV2 } from '@/ui/utilities/state/component-state/utils/createComponentStateV2';
+
+export const tableLastFetchFailedComponentState =
+  createComponentStateV2<boolean>({
+    key: 'tableLastFetchFailedComponentState',
+    defaultValue: false,
+    componentInstanceContext: RecordTableComponentInstanceContext,
+  });


### PR DESCRIPTION
Fixes issue https://github.com/twentyhq/twenty/issues/6731

**Problem:** After access token token expires, scrolling down the `RecordTable` component will put it to an infinite loop of trying to fetch records and printing errors on every iteration.

**Solution:** Disable fetching until component remount if a `FORBIDDEN` error is encountered.