### PR TITLE
Fix delete trigger node

### DIFF
--- a/packages/twenty-front/src/modules/workflow/hooks/useDeleteOneStep.ts
+++ b/packages/twenty-front/src/modules/workflow/hooks/useDeleteOneStep.ts
@@ -1,5 +1,6 @@
 import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
 import { useUpdateOneRecord } from '@/object-record/hooks/useUpdateOneRecord';
+import { useRightDrawer } from '@/ui/layout/right-drawer/hooks/useRightDrawer';
 import { TRIGGER_STEP_ID } from '@/workflow/constants/TriggerStepId';
 import { useCreateNewWorkflowVersion } from '@/workflow/hooks/useCreateNewWorkflowVersion';
 import {
@@ -15,6 +16,8 @@ export const useDeleteOneStep = ({
   stepId: string;
   workflow: WorkflowWithCurrentVersion;
 }) => {
+  const { closeRightDrawer } = useRightDrawer();
+
   const { updateOneRecord: updateOneWorkflowVersion } =
     useUpdateOneRecord<WorkflowVersion>({
       objectNameSingular: CoreObjectNameSingular.WorkflowVersion,
@@ -23,6 +26,8 @@ export const useDeleteOneStep = ({
   const { createNewWorkflowVersion } = useCreateNewWorkflowVersion();
 
   const deleteOneStep = async () => {
+    closeRightDrawer();
+
     if (workflow.currentVersion.status !== 'DRAFT') {
       const newVersionName = `v${workflow.versions.length + 1}`;
 


### PR DESCRIPTION
Since a recent change, the right drawer was automatically closing when the delete button was clicked. We chose to stop listening to click outside the right drawer and inside the workflow canvas to prevent unwanted closes. See https://github.com/twentyhq/twenty/blob/3c04a191d6f3de176d55d013a95a1a301137bdbe/packages/twenty-front/src/modules/ui/layout/right-drawer/components/RightDrawer.tsx#L111-L135

However, now, when we delete the trigger node, it's removed from Apollo cache before the drawer is closed. The drawer expects to always find a valid step definition, and here, ends ups called with an undefined node.

To fix the issue, I programatically close the drawer before deleting a node.