### PR TITLE
Do not mount the command menu when the user is logged out

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/page/components/DefaultLayout.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/page/components/DefaultLayout.tsx
@@ -88,19 +88,23 @@ export const DefaultLayout = () => {
         `}
       />
       <StyledLayout>
-        <ContextStoreComponentInstanceContext.Provider
-          value={{ instanceId: 'command-menu' }}
-        >
-          <ActionMenuComponentInstanceContext.Provider
-            value={{ instanceId: 'command-menu' }}
-          >
-            <RecordActionMenuEntriesSetter />
-            {isWorkflowEnabled && <RecordAgnosticActionsSetterEffect />}
-            <ActionMenuConfirmationModals />
-            <CommandMenu />
-          </ActionMenuComponentInstanceContext.Provider>
-        </ContextStoreComponentInstanceContext.Provider>
-        <KeyboardShortcutMenu />
+        {!showAuthModal && (
+          <>
+            <ContextStoreComponentInstanceContext.Provider
+              value={{ instanceId: 'command-menu' }}
+            >
+              <ActionMenuComponentInstanceContext.Provider
+                value={{ instanceId: 'command-menu' }}
+              >
+                <RecordActionMenuEntriesSetter />
+                {isWorkflowEnabled && <RecordAgnosticActionsSetterEffect />}
+                <ActionMenuConfirmationModals />
+                <CommandMenu />
+              </ActionMenuComponentInstanceContext.Provider>
+            </ContextStoreComponentInstanceContext.Provider>
+            <KeyboardShortcutMenu />
+          </>
+        )}
 
         <StyledPageContainer
           animate={{


### PR DESCRIPTION
Fixes two bugs:
- The command menu contains hooks which were trying to execute queries even when the user was logged out
- The command menu could be opened with the command + K shortcut even when the user was logged out