### PR TITLE
Fix activity target picker

### DIFF
--- a/packages/twenty-front/src/modules/activities/inline-cell/components/ActivityTargetInlineCellEditMode.tsx
+++ b/packages/twenty-front/src/modules/activities/inline-cell/components/ActivityTargetInlineCellEditMode.tsx
@@ -98,7 +98,7 @@ export const ActivityTargetInlineCellEditMode = ({
       async () => {
         const activityTargetsAfterUpdate =
           activityTargetWithTargetRecords.filter((activityTarget) => {
-            const record = snapshot
+            const recordSelectedInMultiSelect = snapshot
               .getLoadable(
                 objectRecordMultiSelectComponentFamilyState({
                   scopeId: recordPickerInstanceId,
@@ -107,7 +107,9 @@ export const ActivityTargetInlineCellEditMode = ({
               )
               .getValue() as ObjectRecordAndSelected;
 
-            return record.selected;
+            return recordSelectedInMultiSelect
+              ? recordSelectedInMultiSelect.selected
+              : true;
           });
         setActivityFromStore((currentActivity) => {
           if (isNull(currentActivity)) {


### PR DESCRIPTION
This PR is fixing the Task/Note Target picker.

## Issue

A few weeks ago, we have simplified the recordPicker logic. During this refacto, we stopped making sure the selected records were fetched.
However, the optimistic update of the activity supposed that current activityTargets are present in the selection in the picker in order to filter out the removed items.

## Fix

In case we don't find the record in the picker selection, we don't filter it out (it means the user cannot have removed it)

## Next step

@ijreilly I think we should put it back, as the selected records do not appear on top anymore