### PR TITLE
Add a confirmation modal for relation object deletion

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-show/record-detail-section/components/RecordDetailRelationRecordsListItem.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-show/record-detail-section/components/RecordDetailRelationRecordsListItem.tsx
@@ -97,13 +97,12 @@ export const RecordDetailRelationRecordsListItem = ({
 }: RecordDetailRelationRecordsListItemProps) => {
   const { fieldDefinition } = useContext(FieldContext);
 
-  const [isDeleteRelationModalOpen, setIsDeleteRelatinoModalOpen] =
+  const [isDeleteRelationModalOpen, setIsDeleteRelationModalOpen] =
     useState(false);
 
   const {
     relationFieldMetadataId,
     relationObjectMetadataNameSingular,
-    relationObjectMetadataNamePlural,
     relationType,
   } = fieldDefinition.metadata as FieldRelationMetadata;
 
@@ -169,13 +168,13 @@ export const RecordDetailRelationRecordsListItem = ({
   };
 
   const handleDelete = async () => {
-    setIsDeleteRelatinoModalOpen(true);
+    setIsDeleteRelationModalOpen(true);
     closeDropdown();
   };
 
   const handleConfirmDelete = async () => {
     await deleteOneRelationRecord(relationRecord.id);
-    setIsDeleteRelatinoModalOpen(false);
+    setIsDeleteRelationModalOpen(false);
   };
 
   const useUpdateOneObjectRecordMutation: RecordUpdateHook = () => {
@@ -287,7 +286,7 @@ export const RecordDetailRelationRecordsListItem = ({
       {createPortal(
         <ConfirmationModal
           isOpen={isDeleteRelationModalOpen}
-          setIsOpen={setIsDeleteRelatinoModalOpen}
+          setIsOpen={setIsDeleteRelationModalOpen}
           title={`Delete Related ${relationObjectTypeName}`}
           subtitle={
             <>


### PR DESCRIPTION
Fixes #8698 

1. Summary
We decided to add a confirmation modal for the relation object deletion. It's gonna a bit of safety to the user interactions because this action can be disruptive even though it can be restored.

2. Solution
Used `createPortal` function to address the issue where the vertical scrollbar shows over the modal. Added a logic that displays a confirmation modal for deletion in [this file](https://github.com/twentyhq/twenty/blob/d284419d66cf52e418d6622b9635334486b51040/packages/twenty-front/src/modules/object-record/record-show/record-detail-section/components/RecordDetailRelationRecordsListItem.tsx). 
I can update the text(title, description, and CTA) as necessary based on the feedback.

_**However, I observed an issue that the deleted object still shows up under the list until hard-refresh. I figured that can be addressed as a separate issue.**_

3. Recording

https://github.com/user-attachments/assets/1a64b702-a915-49f3-a226-2c2d5af8a1d7


