### PR TITLE
Use builtin number validation

### DIFF
--- a/packages/twenty-front/src/modules/object-record/spreadsheet-import/utils/getSpreadSheetFieldValidationDefinitions.ts
+++ b/packages/twenty-front/src/modules/object-record/spreadsheet-import/utils/getSpreadSheetFieldValidationDefinitions.ts
@@ -33,9 +33,9 @@ export const getSpreadSheetFieldValidationDefinitions = (
     case FieldMetadataType.Number:
       return [
         {
-          rule: 'regex',
-          value: '^\\d+$',
-          errorMessage: fieldName + ' must be a number',
+          rule: 'function',
+          isValid: (value: string) => !isNaN(+value),
+          errorMessage: fieldName + ' is not valid',
           level: 'error',
         },
       ];


### PR DESCRIPTION
The regex approach doesn't work great for the many different number formats. Even a simple decimal failed e.g. '1.1' was considered invalid. I've switched this over to use javascripts builtin conversion and validation. This now supports other formats e.g. '-1.0e15' would now be considered valid.

Closes: #8820