### PR TITLE
fix(chip): update padding for transparent variant (#7164)

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellDisplayContainer.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellDisplayContainer.tsx
@@ -8,7 +8,7 @@ const StyledOuterContainer = styled.div<{
   display: flex;
   height: 100%;
   overflow: hidden;
-  padding-left: 6px;
+  padding-left: 8px;
   width: 100%;
 `;
 

--- a/packages/twenty-ui/src/display/chip/components/Chip.tsx
+++ b/packages/twenty-ui/src/display/chip/components/Chip.tsx
@@ -121,7 +121,6 @@ const StyledContainer = withTheme(styled.div<
     variant === ChipVariant.Transparent
       ? theme.spacing(0)
       : 'var(--chip-horizontal-padding)'};
-
 `);
 
 export const Chip = ({

--- a/packages/twenty-ui/src/display/chip/components/Chip.tsx
+++ b/packages/twenty-ui/src/display/chip/components/Chip.tsx
@@ -119,7 +119,7 @@ const StyledContainer = withTheme(styled.div<
 
   padding-left: ${({ variant }) =>
     variant === ChipVariant.Transparent
-      ? '2px !important'
+      ? '0px'
       : 'var(--chip-horizontal-padding)'};
 
 `);

--- a/packages/twenty-ui/src/display/chip/components/Chip.tsx
+++ b/packages/twenty-ui/src/display/chip/components/Chip.tsx
@@ -116,6 +116,12 @@ const StyledContainer = withTheme(styled.div<
   & > svg {
     flex-shrink: 0;
   }
+
+  padding-left: ${({ variant }) =>
+    variant === ChipVariant.Transparent
+      ? '2px !important'
+      : 'var(--chip-horizontal-padding)'};
+
 `);
 
 export const Chip = ({

--- a/packages/twenty-ui/src/display/chip/components/Chip.tsx
+++ b/packages/twenty-ui/src/display/chip/components/Chip.tsx
@@ -117,9 +117,9 @@ const StyledContainer = withTheme(styled.div<
     flex-shrink: 0;
   }
 
-  padding-left: ${({ variant }) =>
+  padding-left: ${({ theme, variant }) =>
     variant === ChipVariant.Transparent
-      ? '0px'
+      ? theme.spacing(0)
       : 'var(--chip-horizontal-padding)'};
 
 `);


### PR DESCRIPTION
This PR addresses the issue described in #7164, where the Chip component's padding for the Transparent variant was not correctly aligned. The following changes have been made:

The padding-left for the Transparent variant is now set to 2px to improve alignment.
Other chip variants retain the default horizontal padding values.

These changes ensure that the Transparent chip variant is rendered consistently with the rest of the design, as described in #7164.

See screenshots below for before and after comparison:
Before:
![image](https://github.com/user-attachments/assets/7749e393-3a9b-4367-a6f9-cb32a9897e7d)
![image](https://github.com/user-attachments/assets/2ad80002-f867-4bf2-b27c-29392b008ed9)

After:
![Screenshot 2024-12-01 at 4 02 08 AM](https://github.com/user-attachments/assets/71fb19a1-00fb-4ea3-989f-185c92221d5e)
![image](https://github.com/user-attachments/assets/7cc93c5e-d42b-4ada-bd27-178836b660b4)

Please review @Bonapara and let me know if you have any feedback or concerns.