### PR TITLE
fix(environment): Make SSL variables optional

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/environment/environment-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/environment/environment-variables.ts
@@ -473,11 +473,11 @@ export class EnvironmentVariables {
 
   // SSL
   @IsString()
-  @ValidateIf((env) => env.SERVER_URL.startsWith('https'))
+  @IsOptional()
   SSL_KEY_PATH: string;
 
   @IsString()
-  @ValidateIf((env) => env.SERVER_URL.startsWith('https'))
+  @IsOptional()
   SSL_CERT_PATH: string;
 }
 


### PR DESCRIPTION
Previously, SSL_KEY_PATH and SSL_CERT_PATH were required if the SERVER_URL started with 'https'. This change makes these variables optional, allowing greater flexibility in dealing with SSL configurations. This update helps in scenarios where SSL paths are managed differently or not needed.