### PR TITLE
fix: record group issues

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-index/hooks/useHandleRecordGroupField.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/hooks/useHandleRecordGroupField.ts
@@ -73,11 +73,24 @@ export const useHandleRecordGroupField = ({
               }) satisfies ViewGroup,
           );
 
+        const viewGroupsToDelete = view.viewGroups.filter(
+          (group) => group.fieldMetadataId !== fieldMetadataItem.id,
+        );
+
         if (viewGroupsToCreate.length > 0) {
           await createViewGroupRecords(viewGroupsToCreate, view);
         }
+
+        if (viewGroupsToDelete.length > 0) {
+          await deleteViewGroupRecords(viewGroupsToDelete);
+        }
       },
-    [createViewGroupRecords, currentViewIdCallbackState, getViewFromCache],
+    [
+      createViewGroupRecords,
+      deleteViewGroupRecords,
+      currentViewIdCallbackState,
+      getViewFromCache,
+    ],
   );
 
   const resetRecordGroupField = useRecoilCallback(

--- a/packages/twenty-front/src/modules/views/types/GraphQLView.ts
+++ b/packages/twenty-front/src/modules/views/types/GraphQLView.ts
@@ -11,6 +11,9 @@ export type GraphQLView = {
   name: string;
   type: ViewType;
   key: ViewKey | null;
+  /**
+   * @deprecated Use `viewGroups.fieldMetadataId` instead.
+   */
   kanbanFieldMetadataId: string;
   objectMetadataId: string;
   isCompact: boolean;

--- a/packages/twenty-front/src/modules/views/types/View.ts
+++ b/packages/twenty-front/src/modules/views/types/View.ts
@@ -18,6 +18,9 @@ export type View = {
   viewFilters: ViewFilter[];
   viewFilterGroups?: ViewFilterGroup[];
   viewSorts: ViewSort[];
+  /**
+   * @deprecated Use `viewGroups.fieldMetadataId` instead.
+   */
   kanbanFieldMetadataId: string;
   position: number;
   icon: string;

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata-related-records.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata-related-records.service.ts
@@ -49,6 +49,10 @@ export class FieldMetadataRelatedRecordsService {
       );
 
     for (const view of views) {
+      if (view.viewGroups.length === 0) {
+        continue;
+      }
+
       const maxPosition = view.viewGroups.reduce(
         (max, viewGroup) => Math.max(max, viewGroup.position),
         0,

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata-related-records.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata-related-records.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 
-import { In } from 'typeorm';
+import { EntityManager, In } from 'typeorm';
 
 import {
   FieldMetadataComplexOption,
@@ -27,6 +27,7 @@ export class FieldMetadataRelatedRecordsService {
   public async updateRelatedViewGroups(
     oldFieldMetadata: FieldMetadataEntity,
     newFieldMetadata: FieldMetadataEntity,
+    transactionManager?: EntityManager,
   ) {
     if (
       !isSelectFieldMetadataType(newFieldMetadata.type) ||
@@ -68,7 +69,7 @@ export class FieldMetadataRelatedRecordsService {
         }),
       );
 
-      await viewGroupRepository.insert(viewGroupsToCreate);
+      await viewGroupRepository.insert(viewGroupsToCreate, transactionManager);
 
       for (const { old: oldOption, new: newOption } of updated) {
         const viewGroup = view.viewGroups.find(
@@ -86,15 +87,19 @@ export class FieldMetadataRelatedRecordsService {
           {
             fieldValue: newOption.value,
           },
+          transactionManager,
         );
       }
 
       const valuesToDelete = deleted.map((option) => option.value);
 
-      await viewGroupRepository.delete({
-        fieldMetadataId: newFieldMetadata.id,
-        fieldValue: In(valuesToDelete),
-      });
+      await viewGroupRepository.delete(
+        {
+          fieldMetadataId: newFieldMetadata.id,
+          fieldValue: In(valuesToDelete),
+        },
+        transactionManager,
+      );
     }
   }
 
@@ -147,7 +152,9 @@ export class FieldMetadataRelatedRecordsService {
 
     return await viewRepository.find({
       where: {
-        kanbanFieldMetadataId: fieldMetadata.id,
+        viewGroups: {
+          fieldMetadataId: fieldMetadata.id,
+        },
       },
       relations: ['viewGroups'],
     });

--- a/packages/twenty-server/src/modules/view/standard-objects/view.workspace-entity.ts
+++ b/packages/twenty-server/src/modules/view/standard-objects/view.workspace-entity.ts
@@ -84,6 +84,9 @@ export class ViewWorkspaceEntity extends BaseWorkspaceEntity {
     label: 'kanbanfieldMetadataId',
     description: 'View Kanban column field',
   })
+  /**
+   * @deprecated Use `viewGroups.fieldMetadataId` instead
+   */
   kanbanFieldMetadataId: string;
 
   @WorkspaceField({


### PR DESCRIPTION
This PR is fixing the following issues with record groups:

- [x] [Backend] - Only update view groups when a field is edited if this one already has view groups
- [x] [Backend] - Editing a Select field metadata option brake view groups
- [x] [Frontend] - Changing the group by field from one to another brake record group and doesn't remove the previous ones
- [x] [Frontend & Backend] - Mark `kanbanFieldMetadataId` as deprecated in favour of `viewGroups.fieldMetadataId`

Also the following has been checked:

- [x] Properly displayed a table with only one view groups
- [x] Properly displayed a table without view groups