### PR TITLE
fix :update message for permanent record deletion 

### DIFF
--- a/packages/twenty-front/src/modules/action-menu/actions/record-actions/single-record/hooks/useDeleteSingleRecordAction.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-actions/single-record/hooks/useDeleteSingleRecordAction.tsx
@@ -10,6 +10,7 @@ import { useFavorites } from '@/favorites/hooks/useFavorites';
 import { ObjectMetadataItem } from '@/object-metadata/types/ObjectMetadataItem';
 import { useDeleteOneRecord } from '@/object-record/hooks/useDeleteOneRecord';
 import { useRecordTable } from '@/object-record/record-table/hooks/useRecordTable';
+import { isSoftDeleteFilterActiveComponentState } from '@/object-record/record-table/states/isSoftDeleteFilterActiveComponentState';
 import { ConfirmationModal } from '@/ui/layout/modal/components/ConfirmationModal';
 import { useRightDrawer } from '@/ui/layout/right-drawer/hooks/useRightDrawer';
 import { useRecoilComponentValueV2 } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValueV2';
@@ -44,6 +45,10 @@ export const useDeleteSingleRecordAction = ({
   );
 
   const { closeRightDrawer } = useRightDrawer();
+  const isSoftDeleteActive = useRecoilComponentValueV2(
+    isSoftDeleteFilterActiveComponentState,
+    objectMetadataItem.namePlural,
+  );
 
   const recordIdToDelete =
     contextStoreTargetedRecordsRule.mode === 'selection'
@@ -102,7 +107,9 @@ export const useDeleteSingleRecordAction = ({
           setIsOpen={setIsDeleteRecordsModalOpen}
           title={'Delete Record'}
           subtitle={
-            'Are you sure you want to delete this record? It can be recovered from the Options menu.'
+            isSoftDeleteActive
+              ? 'Are you sure to permanently erase this record? You will not be able to recover it.'
+              : 'Are you sure you want to delete this record? It can be recovered from the Options menu.'
           }
           onConfirmClick={() => {
             handleDeleteClick();


### PR DESCRIPTION
Resolves #8690 

Problem:
When permanently deleting records, the message displayed is the same as for general records. This can cause confusion, so we should update the message to reflect the correct context.

Solution:
I tried to extract the value of softDeleteFilterActive. Based on its value:

If true, it means we are on the page of deleted records.
If false, it means we are on the page of general records.

Please feel free to review it and let me know if you have a better approach. This is the only solution that worked for me after trying other approaches, which didn’t work as expected.

![All-Companies-Personal-MicrosoftEdge2024-12-0400-37-01-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/283f3f31-332e-452e-9c1d-6a43254763cd)
