### PR TITLE
Fix dropdown overflow

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/dropdown/components/DropdownMenu.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/dropdown/components/DropdownMenu.tsx
@@ -26,8 +26,6 @@ const StyledDropdownMenu = styled.div<{
   z-index: 30;
   width: ${({ width = 200 }) =>
     typeof width === 'number' ? `${width}px` : width};
-
-  overflow: hidden;
 `;
 
 export const DropdownMenu = StyledDropdownMenu;


### PR DESCRIPTION
Fixes:
<img width="267" alt="Capture d’écran 2024-12-03 à 14 59 24" src="https://github.com/user-attachments/assets/73278208-25d2-4225-a632-eb37cc69fcd6">
