### PR TITLE
Remove advanced settings wrapper from security page

### DIFF
--- a/packages/twenty-front/src/pages/settings/security/SettingsSecurity.tsx
+++ b/packages/twenty-front/src/pages/settings/security/SettingsSecurity.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { H2Title, IconLock, Section, Tag } from 'twenty-ui';
 
-import { AdvancedSettingsWrapper } from '@/settings/components/AdvancedSettingsWrapper';
+import { isSSOEnabledState } from '@/client-config/states/isSSOEnabledState';
 import { SettingsPageContainer } from '@/settings/components/SettingsPageContainer';
 import { SettingsReadDocumentationButton } from '@/settings/developers/components/SettingsReadDocumentationButton';
 import { SettingsSSOIdentitiesProvidersListCard } from '@/settings/security/components/SettingsSSOIdentitiesProvidersListCard';
@@ -10,7 +10,6 @@ import { getSettingsPagePath } from '@/settings/utils/getSettingsPagePath';
 import { SettingsPath } from '@/types/SettingsPath';
 import { SubMenuTopBarContainer } from '@/ui/layout/page/components/SubMenuTopBarContainer';
 import { useIsFeatureEnabled } from '@/workspace/hooks/useIsFeatureEnabled';
-import { isSSOEnabledState } from '@/client-config/states/isSSOEnabledState';
 import { useRecoilValue } from 'recoil';
 
 const StyledContainer = styled.div`
@@ -65,15 +64,13 @@ export const SettingsSecurity = () => {
             </StyledSSOSection>
           )}
           <Section>
-            <AdvancedSettingsWrapper>
-              <StyledContainer>
-                <H2Title
-                  title="Authentication"
-                  description="Customize your workspace security"
-                />
-                <SettingsSecurityOptionsList />
-              </StyledContainer>
-            </AdvancedSettingsWrapper>
+            <StyledContainer>
+              <H2Title
+                title="Authentication"
+                description="Customize your workspace security"
+              />
+              <SettingsSecurityOptionsList />
+            </StyledContainer>
           </Section>
         </StyledMainContent>
       </SettingsPageContainer>


### PR DESCRIPTION
Before:
Without advanced settings toggled:
<img width="1512" alt="Capture d’écran 2024-12-05 à 19 12 53" src="https://github.com/user-attachments/assets/efe550e2-5b7f-483f-9726-254acefb2872">

With advanced settings toggled:
<img width="1512" alt="Capture d’écran 2024-12-05 à 19 13 01" src="https://github.com/user-attachments/assets/2fab6843-5be1-4d5b-83c4-94c22c85d4d3">

After:
Without advanced settings toggled:
<img width="1512" alt="Capture d’écran 2024-12-05 à 19 12 34" src="https://github.com/user-attachments/assets/72d87281-3822-42d7-816b-403724052678">

With advanced settings toggled:
<img width="1512" alt="Capture d’écran 2024-12-05 à 19 12 26" src="https://github.com/user-attachments/assets/34c87be4-d528-41a8-b269-e274939a75c7">
