### PR TITLE
Fix SingleRecordSelectMenuItemsWithSearch

### DIFF
--- a/packages/twenty-front/src/modules/object-record/relation-picker/components/SingleRecordSelectMenuItemsWithSearch.tsx
+++ b/packages/twenty-front/src/modules/object-record/relation-picker/components/SingleRecordSelectMenuItemsWithSearch.tsx
@@ -59,6 +59,9 @@ export const SingleRecordSelectMenuItemsWithSearch = ({
     />
   );
 
+  const shouldDisplayDropdownMenuItems =
+    records.recordsToSelect.length + records.selectedRecords?.length > 0;
+
   return (
     <>
       {dropdownPlacement?.includes('end') && (
@@ -67,15 +70,11 @@ export const SingleRecordSelectMenuItemsWithSearch = ({
             {createNewButton}
           </DropdownMenuItemsContainer>
           {records.recordsToSelect.length > 0 && <DropdownMenuSeparator />}
-          {records.recordsToSelect.length > 0 && (
+          {shouldDisplayDropdownMenuItems && (
             <SingleRecordSelectMenuItems
               recordsToSelect={records.recordsToSelect}
               loading={records.loading}
-              selectedRecord={
-                records.recordsToSelect.length === 1
-                  ? records.recordsToSelect[0]
-                  : undefined
-              }
+              selectedRecord={records.selectedRecords?.[0]}
               shouldSelectEmptyOption={selectedRecordIds?.length === 0}
               hotkeyScope={recordPickerInstanceId}
               isFiltered={!!recordPickerSearchFilter}
@@ -95,15 +94,11 @@ export const SingleRecordSelectMenuItemsWithSearch = ({
         isUndefinedOrNull(dropdownPlacement)) && (
         <>
           <DropdownMenuSeparator />
-          {records.recordsToSelect.length > 0 && (
+          {shouldDisplayDropdownMenuItems && (
             <SingleRecordSelectMenuItems
               recordsToSelect={records.recordsToSelect}
               loading={records.loading}
-              selectedRecord={
-                records.recordsToSelect.length === 1
-                  ? records.recordsToSelect[0]
-                  : undefined
-              }
+              selectedRecord={records.selectedRecords?.[0]}
               shouldSelectEmptyOption={selectedRecordIds?.length === 0}
               hotkeyScope={recordPickerInstanceId}
               isFiltered={!!recordPickerSearchFilter}


### PR DESCRIPTION
- Fix all fields being selected when opening dropdown
- Fix not being able to set back to no selection when a record is selected and there is only one record to select

Before:


https://github.com/user-attachments/assets/31185a05-7e1a-4550-aa2a-591683934224


After:

https://github.com/user-attachments/assets/e3cd388b-44de-42e2-970b-b4d4f31253bc

