### PR TITLE
refactor(settings): nest support section within workspace

### DIFF
--- a/packages/twenty-front/src/pages/settings/SettingsWorkspace.tsx
+++ b/packages/twenty-front/src/pages/settings/SettingsWorkspace.tsx
@@ -42,24 +42,25 @@ export const SettingsWorkspace = () => {
           <NameField />
         </Section>
         {isMultiWorkspaceEnabled && (
-          <Section>
-            <H2Title
-              title="Domain"
-              description="Edit your subdomain name or set a custom domain."
-            />
-            <UndecoratedLink to={getSettingsPagePath(SettingsPath.Domain)}>
-              <SettingsCard title="Customize Domain" Icon={<IconWorld />} />
-            </UndecoratedLink>
-          </Section>
+          <>
+            <Section>
+              <H2Title
+                title="Domain"
+                description="Edit your subdomain name or set a custom domain."
+              />
+              <UndecoratedLink to={getSettingsPagePath(SettingsPath.Domain)}>
+                <SettingsCard title="Customize Domain" Icon={<IconWorld />} />
+              </UndecoratedLink>
+            </Section>
+            <Section>
+              <H2Title
+                title="Support"
+                adornment={<ToggleImpersonate />}
+                description="Grant Twenty support temporary access to your workspace so we can troubleshoot problems or recover content on your behalf. You can revoke access at any time."
+              />
+            </Section>
+          </>
         )}
-
-        <Section>
-          <H2Title
-            title="Support"
-            adornment={<ToggleImpersonate />}
-            description="Grant Twenty support temporary access to your workspace so we can troubleshoot problems or recover content on your behalf. You can revoke access at any time."
-          />
-        </Section>
         <Section>
           <DeleteWorkspace />
         </Section>


### PR DESCRIPTION
Refactor the settings structure to include the support section within the workspace feature when multi-workspace is enabled. This update provides a more consistent user interface by grouping related settings, thereby enhancing the manageability of workspace-specific actions.

Fix #8914