### PR TITLE
Fix:If attachment token expires, it throws a 500 error instead of Unauthenticated

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/graphql/utils/graphql-errors.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/graphql/utils/graphql-errors.util.ts
@@ -191,3 +191,9 @@ export class InternalServerError extends BaseGraphQLError {
     Object.defineProperty(this, 'name', { value: 'InternalServerError' });
   }
 }
+
+export class ExpiredAttachmentTokenError extends BaseGraphQLError {
+  constructor(message = 'The attachment token has expired') {
+    super(message, ErrorCode.UNAUTHENTICATED);
+  }
+}


### PR DESCRIPTION
This fixes this issue by throwing a descriptive error instead of a server error 500