### PR TITLE
Fix: Long task names overflow the task container UI and are not selectable in multi-select mode

### DIFF
--- a/packages/twenty-ui/src/display/chip/components/AvatarChip.tsx
+++ b/packages/twenty-ui/src/display/chip/components/AvatarChip.tsx
@@ -62,10 +62,10 @@ export const AvatarChip = ({
   size = ChipSize.Small,
 }: AvatarChipProps) => {
   const { theme } = useContext(ThemeContext);
-
+  const name_short = name.length > 10 ? name.substring(0,10).concat("..") : name;
   const chip = (
     <Chip
-      label={name}
+      label={name_short}
       variant={
         isDefined(onClick) || isDefined(to)
           ? variant === AvatarChipVariant.Regular
@@ -97,7 +97,7 @@ export const AvatarChip = ({
           <Avatar
             avatarUrl={avatarUrl}
             placeholderColorSeed={placeholderColorSeed}
-            placeholder={name}
+            placeholder={name_short}
             size="sm"
             type={avatarType}
           />

--- a/packages/twenty-ui/src/display/chip/components/AvatarChip.tsx
+++ b/packages/twenty-ui/src/display/chip/components/AvatarChip.tsx
@@ -62,7 +62,7 @@ export const AvatarChip = ({
   size = ChipSize.Small,
 }: AvatarChipProps) => {
   const { theme } = useContext(ThemeContext);
-  const name_short = name.length > 10 ? name.substring(0,10).concat("..") : name;
+  const name_short = name.length > 10 ? name.substring(0,10).concat('...') : name;
   const chip = (
     <Chip
       label={name_short}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/547848e2-f1c7-453c-af67-a54eedf7967f)
I tried to edit the css but its not working so i truncated the prop value for that component so that the overflow gets diminished for #8803 