### PR TITLE
better label for toggle input that will improve UX

### DIFF
--- a/packages/twenty-ui/src/navigation/link/components/AdvancedSettingsToggle.tsx
+++ b/packages/twenty-ui/src/navigation/link/components/AdvancedSettingsToggle.tsx
@@ -12,7 +12,7 @@ const StyledContainer = styled.div`
   position: relative;
 `;
 
-const StyledLabel = styled.label`
+const StyledLabel = styled.div`
   color: ${({ theme }) => theme.font.color.secondary};
   font-size: ${({ theme }) => theme.font.size.sm};
   font-weight: ${({ theme }) => theme.font.weight.medium};
@@ -25,7 +25,7 @@ const StyledIconContainer = styled.div`
   left: ${({ theme }) => theme.spacing(-3)};
 `;
 
-const StyledToggleContainer = styled.div`
+const StyledToggleContainer = styled.label`
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -59,8 +59,8 @@ export const AdvancedSettingsToggle = ({
           fill={MAIN_COLORS.yellow}
         />
       </StyledIconContainer>
-      <StyledToggleContainer>
-        <StyledLabel htmlFor={inputId}>Advanced:</StyledLabel>
+      <StyledToggleContainer htmlFor={inputId}>
+        <StyledLabel>Advanced:</StyledLabel>
 
         <Toggle
           id={inputId}

--- a/packages/twenty-ui/src/navigation/link/components/AdvancedSettingsToggle.tsx
+++ b/packages/twenty-ui/src/navigation/link/components/AdvancedSettingsToggle.tsx
@@ -12,7 +12,7 @@ const StyledContainer = styled.div`
   position: relative;
 `;
 
-const StyledLabel = styled.div`
+const StyledText = styled.div`
   color: ${({ theme }) => theme.font.color.secondary};
   font-size: ${({ theme }) => theme.font.size.sm};
   font-weight: ${({ theme }) => theme.font.weight.medium};
@@ -26,8 +26,9 @@ const StyledIconContainer = styled.div`
 `;
 
 const StyledToggleContainer = styled.label`
-  display: flex;
   align-items: center;
+  cursor: pointer;
+  display: flex;
   justify-content: space-between;
   width: 100%;
 `;
@@ -60,7 +61,7 @@ export const AdvancedSettingsToggle = ({
         />
       </StyledIconContainer>
       <StyledToggleContainer htmlFor={inputId}>
-        <StyledLabel>Advanced:</StyledLabel>
+        <StyledText>Advanced:</StyledText>
 
         <Toggle
           id={inputId}

--- a/packages/twenty-ui/src/navigation/menu-item/components/MenuItemToggle.tsx
+++ b/packages/twenty-ui/src/navigation/menu-item/components/MenuItemToggle.tsx
@@ -1,10 +1,19 @@
+import styled from '@emotion/styled';
 import { IconComponent } from '@ui/display';
 import { Toggle, ToggleSize } from '@ui/input';
+import { useId } from 'react';
 import { MenuItemLeftContent } from '../internals/components/MenuItemLeftContent';
 import {
   StyledMenuItemBase,
   StyledMenuItemRightContent,
 } from '../internals/components/StyledMenuItemBase';
+
+const StyledToggleContainer = styled.label`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+`;
 
 type MenuItemToggleProps = {
   LeftIcon?: IconComponent;
@@ -23,16 +32,20 @@ export const MenuItemToggle = ({
   onToggleChange,
   toggleSize,
 }: MenuItemToggleProps) => {
+  const inputId = useId();
   return (
     <StyledMenuItemBase className={className}>
-      <MenuItemLeftContent LeftIcon={LeftIcon} text={text} />
-      <StyledMenuItemRightContent>
-        <Toggle
-          value={toggled}
-          onChange={onToggleChange}
-          toggleSize={toggleSize}
-        />
-      </StyledMenuItemRightContent>
+      <StyledToggleContainer htmlFor={inputId}>
+        <MenuItemLeftContent LeftIcon={LeftIcon} text={text} />
+        <StyledMenuItemRightContent>
+          <Toggle
+            id={inputId}
+            value={toggled}
+            onChange={onToggleChange}
+            toggleSize={toggleSize}
+          />
+        </StyledMenuItemRightContent>
+      </StyledToggleContainer>
     </StyledMenuItemBase>
   );
 };

--- a/packages/twenty-ui/src/navigation/menu-item/components/MenuItemToggle.tsx
+++ b/packages/twenty-ui/src/navigation/menu-item/components/MenuItemToggle.tsx
@@ -9,8 +9,9 @@ import {
 } from '../internals/components/StyledMenuItemBase';
 
 const StyledToggleContainer = styled.label`
-  display: flex;
   align-items: center;
+  cursor: pointer;
+  display: flex;
   justify-content: space-between;
   width: 100%;
 `;


### PR DESCRIPTION
Answering the ticket : Increase the clickable area of toggles to parent container

# Change in Labels

In order to solve this ticket, we change the way we handle the labels VS the inputs. The use of `htmlFor` and setting up the appropriate id for the toggle solves the "blank click"
<img width="239" alt="Screenshot 2024-12-09 at 17 43 53" src="https://github.com/user-attachments/assets/19eab5fc-8393-496d-b713-57e51c620bf1">

fix #8953 