### PR TITLE
View picker minor change - favorite fast followups

### DIFF
--- a/packages/twenty-front/src/modules/views/view-picker/components/ViewPickerOptionDropdown.tsx
+++ b/packages/twenty-front/src/modules/views/view-picker/components/ViewPickerOptionDropdown.tsx
@@ -61,9 +61,10 @@ export const ViewPickerOptionDropdown = ({
   const handleAddToFavorites = () => {
     if (!isFavorite) {
       createFavorite(view, 'view');
+    } else {
+      setViewPickerReferenceViewId(view.id);
+      setViewPickerMode('favorite-folders-picker');
     }
-    setViewPickerReferenceViewId(view.id);
-    setViewPickerMode('favorite-folders-picker');
     closeDropdown();
   };
 


### PR DESCRIPTION
Clicking "Add to favorite" should add the record as a favorite. It shouldn't open the menu on the first click; it should only open on the second click when the record is already a favorite.