### PR TITLE
Update PG_DATABASE_URL to match Service name in k8s manifests

### DIFF
--- a/packages/twenty-docker/k8s/manifests/deployment-server.yaml
+++ b/packages/twenty-docker/k8s/manifests/deployment-server.yaml
@@ -40,7 +40,7 @@ spec:
             - name: FRONT_BASE_URL
               value: "https://crm.example.com:443"
             - name: "PG_DATABASE_URL"
-              value: "postgres://postgres:postgres@twenty-db.twentycrm.svc.cluster.local/default"
+              value: "postgres://postgres:postgres@twentycrm-db.twentycrm.svc.cluster.local/default"
             - name: "REDIS_URL"
               value: "redis://twentycrm-redis.twentycrm.svc.cluster.local:6379"
             - name: ENABLE_DB_MIGRATIONS

--- a/packages/twenty-docker/k8s/manifests/deployment-worker.yaml
+++ b/packages/twenty-docker/k8s/manifests/deployment-worker.yaml
@@ -31,7 +31,7 @@ spec:
             - name: FRONT_BASE_URL
               value: "https://crm.example.com:443"
             - name: PG_DATABASE_URL
-              value: "postgres://postgres:postgres@twenty-db.twentycrm.svc.cluster.local/default"
+              value: "postgres://postgres:postgres@twentycrm-db.twentycrm.svc.cluster.local/default"
             - name: ENABLE_DB_MIGRATIONS
               value: "false" # it already runs on the server
             - name: STORAGE_TYPE


### PR DESCRIPTION
### Issue Summary
The `service` name in the Kubernetes manifest for the PostgreSQL database is defined as `twentycrm-db`. However, the `DSN` configuration in the Server and Worker `deployments` incorrectly references `twenty-db`. This mismatch causes the pods to fail during initialization and crash on boot.

### Fix Description
- Updated the `DSN` values in both the Server and Worker `deployments` to correctly reference `twentycrm-db`, ensuring alignment with the database `service` name.
- Verified the deployments to ensure the pods start without issues after the fix.

### Testing
- Deployed the updated manifests in a development environment.
- Confirmed that both Server and Worker pods initialize correctly and connect to the database service as expected.
