### PR TITLE
Fix RecordDetailSectionHeader spacing

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-show/record-detail-section/components/RecordDetailSectionHeader.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-show/record-detail-section/components/RecordDetailSectionHeader.tsx
@@ -7,12 +7,11 @@ const StyledHeader = styled.header<{
   areRecordsAvailable?: boolean;
 }>`
   align-items: center;
+  justify-content: space-between;
   display: flex;
   height: 24px;
   margin-bottom: ${({ theme, areRecordsAvailable }) =>
     areRecordsAvailable && theme.spacing(2)};
-
-  gap: ${({ theme }) => theme.spacing(1)};
 `;
 
 const StyledTitle = styled.div`


### PR DESCRIPTION
Before:
<img width="339" alt="Capture d’écran 2024-12-10 à 11 02 30" src="https://github.com/user-attachments/assets/4fd1d598-0efe-4ee9-931e-dd307af21c95">

After:
<img width="345" alt="Capture d’écran 2024-12-10 à 11 02 19" src="https://github.com/user-attachments/assets/fb72a661-ac66-43c7-906c-9020171dbf3b">
