### PR TITLE
Fix add-subdomain-to-workspace command

### DIFF
--- a/packages/twenty-server/src/database/commands/database-command.module.ts
+++ b/packages/twenty-server/src/database/commands/database-command.module.ts
@@ -9,6 +9,7 @@ import { DataSeedWorkspaceCommand } from 'src/database/commands/data-seed-dev-wo
 import { ConfirmationQuestion } from 'src/database/commands/questions/confirmation.question';
 import { UpgradeTo0_32CommandModule } from 'src/database/commands/upgrade-version/0-32/0-32-upgrade-version.module';
 import { UpgradeTo0_33CommandModule } from 'src/database/commands/upgrade-version/0-33/0-33-upgrade-version.module';
+import { UpgradeTo0_34CommandModule } from 'src/database/commands/upgrade-version/0-34/0-34-upgrade-version.module';
 import { TypeORMModule } from 'src/database/typeorm/typeorm.module';
 import { BillingSubscription } from 'src/engine/core-modules/billing/entities/billing-subscription.entity';
 import { FeatureFlagEntity } from 'src/engine/core-modules/feature-flag/feature-flag.entity';
@@ -49,6 +50,7 @@ import { WorkspaceSyncMetadataModule } from 'src/engine/workspace-manager/worksp
     WorkspaceMetadataVersionModule,
     UpgradeTo0_32CommandModule,
     UpgradeTo0_33CommandModule,
+    UpgradeTo0_34CommandModule,
     FeatureFlagModule,
   ],
   providers: [

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-34/0-34-upgrade-version.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-34/0-34-upgrade-version.module.ts
@@ -1,13 +1,14 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { GenerateDefaultSubdomainCommand } from 'src/database/commands/upgrade-version/0-34/0-34-generate-subdomain.command';
+import { UpgradeTo0_34Command } from 'src/database/commands/upgrade-version/0-34/0-34-upgrade-version.command';
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 import { SearchModule } from 'src/engine/metadata-modules/search/search.module';
 import { WorkspaceMigrationRunnerModule } from 'src/engine/workspace-manager/workspace-migration-runner/workspace-migration-runner.module';
 import { WorkspaceSyncMetadataCommandsModule } from 'src/engine/workspace-manager/workspace-sync-metadata/commands/workspace-sync-metadata-commands.module';
-import { UpgradeTo0_34Command } from 'src/database/commands/upgrade-version/0-34/0-34-upgrade-version.command';
 
 @Module({
   imports: [
@@ -20,6 +21,6 @@ import { UpgradeTo0_34Command } from 'src/database/commands/upgrade-version/0-34
     SearchModule,
     WorkspaceMigrationRunnerModule,
   ],
-  providers: [UpgradeTo0_34Command],
+  providers: [UpgradeTo0_34Command, GenerateDefaultSubdomainCommand],
 })
-export class UpgradeTo0_33CommandModule {}
+export class UpgradeTo0_34CommandModule {}


### PR DESCRIPTION
## Context
Fix add-subdomain-to-workspace command not included in global module also fixing the command regex logic that was not generating subdomain properly