### PR TITLE
Fix multiworkspace mode returning inactive workspaces

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/user/user.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/user.resolver.ts
@@ -89,11 +89,6 @@ export class UserResolver {
     const user = await this.userRepository.findOne({
       where: {
         id: userId,
-        workspaces: {
-          workspace: {
-            activationStatus: WorkspaceActivationStatus.ACTIVE,
-          },
-        },
       },
       relations: ['defaultWorkspace', 'workspaces', 'workspaces.workspace'],
     });
@@ -101,6 +96,12 @@ export class UserResolver {
     userValidator.assertIsDefinedOrThrow(
       user,
       new AuthException('User not found', AuthExceptionCode.USER_NOT_FOUND),
+    );
+
+    user.workspaces = user.workspaces.filter(
+      (workspaceMember) =>
+        workspaceMember.workspace.activationStatus ===
+        WorkspaceActivationStatus.ACTIVE,
     );
 
     return user;

--- a/packages/twenty-server/src/engine/core-modules/user/user.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/user.resolver.ts
@@ -20,6 +20,10 @@ import { FileFolder } from 'src/engine/core-modules/file/interfaces/file-folder.
 
 import { AnalyticsService } from 'src/engine/core-modules/analytics/analytics.service';
 import { AnalyticsTinybirdJwtMap } from 'src/engine/core-modules/analytics/entities/analytics-tinybird-jwts.entity';
+import {
+  AuthException,
+  AuthExceptionCode,
+} from 'src/engine/core-modules/auth/auth.exception';
 import { EnvironmentService } from 'src/engine/core-modules/environment/environment.service';
 import { FileUploadService } from 'src/engine/core-modules/file/file-upload/services/file-upload.service';
 import { FileService } from 'src/engine/core-modules/file/services/file.service';
@@ -32,18 +36,17 @@ import { WorkspaceMember } from 'src/engine/core-modules/user/dtos/workspace-mem
 import { UserService } from 'src/engine/core-modules/user/services/user.service';
 import { UserVarsService } from 'src/engine/core-modules/user/user-vars/services/user-vars.service';
 import { User } from 'src/engine/core-modules/user/user.entity';
-import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
+import { userValidator } from 'src/engine/core-modules/user/user.validate';
+import {
+  Workspace,
+  WorkspaceActivationStatus,
+} from 'src/engine/core-modules/workspace/workspace.entity';
 import { AuthUser } from 'src/engine/decorators/auth/auth-user.decorator';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
 import { DemoEnvGuard } from 'src/engine/guards/demo.env.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
-import { streamToBuffer } from 'src/utils/stream-to-buffer';
 import { AccountsToReconnectKeys } from 'src/modules/connected-account/types/accounts-to-reconnect-key-value.type';
-import {
-  AuthException,
-  AuthExceptionCode,
-} from 'src/engine/core-modules/auth/auth.exception';
-import { userValidator } from 'src/engine/core-modules/user/user.validate';
+import { streamToBuffer } from 'src/utils/stream-to-buffer';
 
 const getHMACKey = (email?: string, key?: string | null) => {
   if (!email || !key) return null;
@@ -86,6 +89,11 @@ export class UserResolver {
     const user = await this.userRepository.findOne({
       where: {
         id: userId,
+        workspaces: {
+          workspace: {
+            activationStatus: WorkspaceActivationStatus.ACTIVE,
+          },
+        },
       },
       relations: ['defaultWorkspace', 'workspaces', 'workspaces.workspace'],
     });

--- a/packages/twenty-server/src/engine/core-modules/user/user.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/user.resolver.ts
@@ -100,8 +100,8 @@ export class UserResolver {
 
     user.workspaces = user.workspaces.filter(
       (workspaceMember) =>
-        workspaceMember.workspace.activationStatus ===
-        WorkspaceActivationStatus.ACTIVE,
+        workspaceMember.workspace.activationStatus !==
+        WorkspaceActivationStatus.INACTIVE,
     );
 
     return user;


### PR DESCRIPTION
## Context
Currently we return all the workspaces of a current user, including inactive ones. 
This means when we switch to the other workspace through the UI, we are redirected to a workspace that is possibly in a broken state.

Before (with Toto being an INACTIVE workspace)
<img width="355" alt="Screenshot 2024-12-10 at 17 31 22" src="https://github.com/user-attachments/assets/d7738363-f402-4dfc-88b6-3f2335acd823">

After
<img width="374" alt="Screenshot 2024-12-10 at 17 30 52" src="https://github.com/user-attachments/assets/97053a61-a7c9-4ef5-b7ab-646c52bf64bd">
