### PR TITLE
added event listener to prevent the dot being created when right clicked (8981)

### DIFF
--- a/package.json
+++ b/package.json
@@ -327,7 +327,7 @@
     "supertest": "^6.1.3",
     "ts-jest": "^29.1.1",
     "ts-loader": "^9.2.3",
-    "ts-node": "10.9.1",
+    "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
     "tsx": "^4.17.0",
     "vite": "^5.4.0",

--- a/packages/twenty-front/src/modules/action-menu/components/RecordIndexActionMenuDropdown.tsx
+++ b/packages/twenty-front/src/modules/action-menu/components/RecordIndexActionMenuDropdown.tsx
@@ -34,6 +34,14 @@ const StyledContainerActionMenuDropdown = styled.div<StyledContainerProps>`
 
   transform: translateX(-50%);
   width: auto;
+
+   /* Remove focus/active visual effects */
+  outline: none;
+  &:focus,
+  &:active {
+    outline: none;
+    box-shadow: none;
+  }
 `;
 
 export const RecordIndexActionMenuDropdown = () => {
@@ -52,6 +60,11 @@ export const RecordIndexActionMenuDropdown = () => {
     ),
   );
 
+   // Prevent focus from being applied to the container
+   const handleMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
+    event.preventDefault();
+  };
+
   //TODO: remove this
   const width = actionMenuEntries.some(
     (actionMenuEntry) => actionMenuEntry.label === 'Remove from favorites',
@@ -63,6 +76,7 @@ export const RecordIndexActionMenuDropdown = () => {
     <StyledContainerActionMenuDropdown
       position={actionMenuDropdownPosition}
       className="action-menu-dropdown"
+      onMouseDown={handleMouseDown}
     >
       <Dropdown
         dropdownId={getActionMenuDropdownIdFromActionMenuId(actionMenuId)}

--- a/yarn.lock
+++ b/yarn.lock
@@ -43958,6 +43958,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ts-node@npm:^10.9.2":
+  version: 10.9.2
+  resolution: "ts-node@npm:10.9.2"
+  dependencies:
+    "@cspotcode/source-map-support": "npm:^0.8.0"
+    "@tsconfig/node10": "npm:^1.0.7"
+    "@tsconfig/node12": "npm:^1.0.7"
+    "@tsconfig/node14": "npm:^1.0.0"
+    "@tsconfig/node16": "npm:^1.0.2"
+    acorn: "npm:^8.4.1"
+    acorn-walk: "npm:^8.1.1"
+    arg: "npm:^4.1.0"
+    create-require: "npm:^1.1.0"
+    diff: "npm:^4.0.1"
+    make-error: "npm:^1.1.1"
+    v8-compile-cache-lib: "npm:^3.0.1"
+    yn: "npm:3.1.1"
+  peerDependencies:
+    "@swc/core": ">=1.2.50"
+    "@swc/wasm": ">=1.2.50"
+    "@types/node": "*"
+    typescript: ">=2.7"
+  peerDependenciesMeta:
+    "@swc/core":
+      optional: true
+    "@swc/wasm":
+      optional: true
+  bin:
+    ts-node: dist/bin.js
+    ts-node-cwd: dist/bin-cwd.js
+    ts-node-esm: dist/bin-esm.js
+    ts-node-script: dist/bin-script.js
+    ts-node-transpile-only: dist/bin-transpile.js
+    ts-script: dist/bin-script-deprecated.js
+  checksum: 10c0/5f29938489f96982a25ba650b64218e83a3357d76f7bede80195c65ab44ad279c8357264639b7abdd5d7e75fc269a83daa0e9c62fd8637a3def67254ecc9ddc2
+  languageName: node
+  linkType: hard
+
 "tsconfck@npm:^3.0.3":
   version: 3.1.1
   resolution: "tsconfck@npm:3.1.1"
@@ -44634,7 +44672,7 @@ __metadata:
     ts-jest: "npm:^29.1.1"
     ts-key-enum: "npm:^2.0.12"
     ts-loader: "npm:^9.2.3"
-    ts-node: "npm:10.9.1"
+    ts-node: "npm:^10.9.2"
     tsconfig-paths: "npm:^4.2.0"
     tslib: "npm:^2.3.0"
     tsup: "npm:^8.2.4"


### PR DESCRIPTION
Addresses Issue #8981

This PR removes the grey dot or focus ring that appears on the dropdown when right-clicking.

Changes Made:
CSS Update:

Added &:focus, &:active { outline: none; box-shadow: none; } to the StyledContainerActionMenuDropdown component to prevent focus and active state visual effects.
Event Handler:

Added an onMouseDown event with event.preventDefault() to stop the default focus behavior when interacting with the dropdown.