### PR TITLE
Fix composite field creation

### DIFF
--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/record-crud/create-record.workflow-action.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/record-crud/create-record.workflow-action.ts
@@ -17,11 +17,9 @@ export class CreateRecordWorkflowAction implements WorkflowAction {
       workflowActionInput.objectName,
     );
 
-    const objectRecord = await repository.create(
+    const objectRecord = await repository.save(
       workflowActionInput.objectRecord,
     );
-
-    await repository.save(objectRecord);
 
     return {
       result: objectRecord,


### PR DESCRIPTION
- composite field need to be formatted before being saved
- repository.create() does not do it. So we simply lose the composite fields on the way
- save() does it directly and doing create() before does not change anything