### PR TITLE
feat: record group insert at bottom when created

### DIFF
--- a/packages/twenty-front/package.json
+++ b/packages/twenty-front/package.json
@@ -40,6 +40,7 @@
     "@tiptap/extension-text-style": "^2.8.0",
     "@tiptap/react": "^2.8.0",
     "@xyflow/react": "^12.0.4",
+    "buffer": "^6.0.3",
     "transliteration": "^2.3.5"
   }
 }

--- a/packages/twenty-front/src/modules/apollo/optimistic-effect/utils/triggerCreateRecordsOptimisticEffect.ts
+++ b/packages/twenty-front/src/modules/apollo/optimistic-effect/utils/triggerCreateRecordsOptimisticEffect.ts
@@ -152,16 +152,24 @@ export const triggerCreateRecordsOptimisticEffect = ({
                   nextRootQueryCachedRecordEdges.push(edge);
                   nextQueryCachedPageInfo.endCursor = cursor;
                 } else if (typeof recordToCreate.position === 'number') {
-                  const deducedIndex = Math.round(
+                  let index = Math.round(
                     nextRootQueryCachedRecordEdges.length *
                       recordToCreate.position,
                   );
-                  const index = Math.max(
+
+                  if (recordToCreate.position < 0) {
+                    index = Math.max(
+                      0,
+                      nextRootQueryCachedRecordEdges.length +
+                        Math.round(recordToCreate.position),
+                    );
+                  } else if (recordToCreate.position > 1) {
+                    index = nextRootQueryCachedRecordEdges.length;
+                  }
+
+                  index = Math.max(
                     0,
-                    Math.min(
-                      deducedIndex,
-                      nextRootQueryCachedRecordEdges.length,
-                    ),
+                    Math.min(index, nextRootQueryCachedRecordEdges.length),
                   );
 
                   nextRootQueryCachedRecordEdges.splice(index, 0, edge);

--- a/packages/twenty-front/src/modules/apollo/optimistic-effect/utils/triggerCreateRecordsOptimisticEffect.ts
+++ b/packages/twenty-front/src/modules/apollo/optimistic-effect/utils/triggerCreateRecordsOptimisticEffect.ts
@@ -116,11 +116,34 @@ export const triggerCreateRecordsOptimisticEffect = ({
               );
 
               if (recordToCreateReference && !recordAlreadyInCache) {
-                nextRootQueryCachedRecordEdges.unshift({
+                const edge = {
                   __typename: getEdgeTypename(objectMetadataItem.nameSingular),
                   node: recordToCreateReference,
                   cursor: '',
-                });
+                };
+
+                if (
+                  !isDefined(recordToCreate.position) ||
+                  recordToCreate.position === 'first'
+                ) {
+                  nextRootQueryCachedRecordEdges.unshift(edge);
+                } else if (recordToCreate.position === 'last') {
+                  nextRootQueryCachedRecordEdges.push(edge);
+                } else if (typeof recordToCreate.position === 'number') {
+                  const deducedIndex = Math.round(
+                    nextRootQueryCachedRecordEdges.length *
+                      recordToCreate.position,
+                  );
+                  const index = Math.max(
+                    0,
+                    Math.min(
+                      deducedIndex,
+                      nextRootQueryCachedRecordEdges.length,
+                    ),
+                  );
+
+                  nextRootQueryCachedRecordEdges.splice(index, 0, edge);
+                }
 
                 return true;
               }

--- a/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableRecordGroupRows.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableRecordGroupRows.tsx
@@ -56,8 +56,8 @@ export const RecordTableRecordGroupRows = () => {
           />
         );
       })}
-      <RecordTableRecordGroupSectionLoadMore />
       <RecordTablePendingRecordGroupRow />
+      <RecordTableRecordGroupSectionLoadMore />
       <RecordTableRecordGroupSectionAddNew />
     </>
   );

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-section/components/RecordTableRecordGroupSectionAddNew.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-section/components/RecordTableRecordGroupSectionAddNew.tsx
@@ -3,21 +3,13 @@ import { recordIndexAllRecordIdsComponentSelector } from '@/object-record/record
 import { useRecordTableContextOrThrow } from '@/object-record/record-table/contexts/RecordTableContext';
 import { useCreateNewTableRecord } from '@/object-record/record-table/hooks/useCreateNewTableRecords';
 import { RecordTableActionRow } from '@/object-record/record-table/record-table-row/components/RecordTableActionRow';
-import { recordTablePendingRecordIdByGroupComponentFamilyState } from '@/object-record/record-table/states/recordTablePendingRecordIdByGroupComponentFamilyState';
-import { useRecoilComponentFamilyValueV2 } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentFamilyValueV2';
 import { useRecoilComponentValueV2 } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValueV2';
 import { IconPlus } from 'twenty-ui';
-import { isDefined } from '~/utils/isDefined';
 
 export const RecordTableRecordGroupSectionAddNew = () => {
   const { recordTableId } = useRecordTableContextOrThrow();
 
   const currentRecordGroupId = useCurrentRecordGroupId();
-
-  const pendingRecordId = useRecoilComponentFamilyValueV2(
-    recordTablePendingRecordIdByGroupComponentFamilyState,
-    currentRecordGroupId,
-  );
 
   const recordIds = useRecoilComponentValueV2(
     recordIndexAllRecordIdsComponentSelector,
@@ -29,8 +21,6 @@ export const RecordTableRecordGroupSectionAddNew = () => {
   const handleAddNewRecord = () => {
     createNewTableRecordInGroup(currentRecordGroupId);
   };
-
-  if (isDefined(pendingRecordId)) return null;
 
   return (
     <RecordTableActionRow

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-create-one-resolver.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-create-one-resolver.service.ts
@@ -83,8 +83,6 @@ export class GraphqlQueryCreateOneResolverService extends GraphqlQueryBaseResolv
     });
   }
 
-  async;
-
   async validate(
     args: CreateOneResolverArgs<Partial<ObjectRecord>>,
     options: WorkspaceQueryRunnerOptions,

--- a/yarn.lock
+++ b/yarn.lock
@@ -43950,6 +43950,7 @@ __metadata:
     "@tiptap/extension-text-style": "npm:^2.8.0"
     "@tiptap/react": "npm:^2.8.0"
     "@xyflow/react": "npm:^12.0.4"
+    buffer: "npm:^6.0.3"
     transliteration: "npm:^2.3.5"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Fix #9050 

When we add a new record in a record group this one should be added at them bottom.