### PR TITLE
Change favicon/company enrichment urls

### DIFF
--- a/packages/twenty-front/src/modules/activities/utils/__tests__/getActivityPreview.test.ts
+++ b/packages/twenty-front/src/modules/activities/utils/__tests__/getActivityPreview.test.ts
@@ -75,7 +75,7 @@ describe('getActivityPreview', () => {
         props: {
           backgroundColor: 'default',
           textAlignment: 'left',
-          url: 'https://favicon.twenty.com/qonto.com',
+          url: 'https://twenty-icons.com/qonto.com',
           caption: '',
           width: 230,
         },

--- a/packages/twenty-front/src/modules/activities/utils/__tests__/getActivitySummary.test.ts
+++ b/packages/twenty-front/src/modules/activities/utils/__tests__/getActivitySummary.test.ts
@@ -75,7 +75,7 @@ describe('getActivitySummary', () => {
         props: {
           backgroundColor: 'default',
           textAlignment: 'left',
-          url: 'https://favicon.twenty.com/qonto.com',
+          url: 'https://twenty-icons.com/qonto.com',
           caption: '',
           width: 230,
         },

--- a/packages/twenty-front/src/modules/object-metadata/hooks/__tests__/useGetObjectRecordIdentifierByNameSingular.test.tsx
+++ b/packages/twenty-front/src/modules/object-metadata/hooks/__tests__/useGetObjectRecordIdentifierByNameSingular.test.tsx
@@ -64,7 +64,7 @@ describe('useGetObjectRecordIdentifierByNameSingular', () => {
 
     expect(result.current.linkToShowPage).toBe('/object/company/recordId');
     expect(result.current.avatarUrl).toBe(
-      'https://favicon.twenty.com/cool-company.com',
+      'https://twenty-icons.com/cool-company.com',
     );
     expect(result.current.avatarType).toBe('squared');
   });

--- a/packages/twenty-front/src/utils/__tests__/utils.test.ts
+++ b/packages/twenty-front/src/utils/__tests__/utils.test.ts
@@ -17,27 +17,27 @@ describe('sanitizeURL', () => {
 describe('getLogoUrlFromDomainName', () => {
   test('should return the correct logo URL for a given domain', () => {
     expect(getLogoUrlFromDomainName('example.com')).toBe(
-      'https://favicon.twenty.com/example.com',
+      'https://twenty-icons.com/example.com',
     );
 
     expect(getLogoUrlFromDomainName('http://example.com/')).toBe(
-      'https://favicon.twenty.com/example.com',
+      'https://twenty-icons.com/example.com',
     );
 
     expect(getLogoUrlFromDomainName('https://www.example.com/')).toBe(
-      'https://favicon.twenty.com/example.com',
+      'https://twenty-icons.com/example.com',
     );
 
     expect(getLogoUrlFromDomainName('www.example.com')).toBe(
-      'https://favicon.twenty.com/example.com',
+      'https://twenty-icons.com/example.com',
     );
 
     expect(getLogoUrlFromDomainName('example.com/')).toBe(
-      'https://favicon.twenty.com/example.com',
+      'https://twenty-icons.com/example.com',
     );
 
     expect(getLogoUrlFromDomainName('apple.com')).toBe(
-      'https://favicon.twenty.com/apple.com',
+      'https://twenty-icons.com/apple.com',
     );
   });
 

--- a/packages/twenty-front/src/utils/index.ts
+++ b/packages/twenty-front/src/utils/index.ts
@@ -9,6 +9,6 @@ export const getLogoUrlFromDomainName = (
 ): string | undefined => {
   const sanitizedDomain = sanitizeURL(domainName);
   return sanitizedDomain
-    ? `https://favicon.twenty.com/${sanitizedDomain}`
+    ? `https://twenty-icons.com/${sanitizedDomain}`
     : undefined;
 };

--- a/packages/twenty-server/src/engine/core-modules/telemetry/telemetry.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/telemetry/telemetry.module.ts
@@ -7,7 +7,7 @@ import { TelemetryService } from './telemetry.service';
   providers: [TelemetryService],
   imports: [
     HttpModule.register({
-      baseURL: 'https://t.twenty.com/api/v2',
+      baseURL: 'https://twenty-telemetry.com/api/v2',
     }),
   ],
   exports: [TelemetryService],

--- a/packages/twenty-server/src/modules/contact-creation-manager/services/create-company.service.ts
+++ b/packages/twenty-server/src/modules/contact-creation-manager/services/create-company.service.ts
@@ -25,7 +25,7 @@ export class CreateCompanyService {
 
   constructor(private readonly twentyORMGlobalManager: TwentyORMGlobalManager) {
     this.httpService = axios.create({
-      baseURL: 'https://companies.twenty.com',
+      baseURL: 'https://twenty-companies.com',
     });
   }
 

--- a/packages/twenty-website/src/app/_components/oss-friends/Card.tsx
+++ b/packages/twenty-website/src/app/_components/oss-friends/Card.tsx
@@ -124,7 +124,7 @@ export const Card = ({ data }: { data: OssData }) => {
   return (
     <Container>
       <StyledContent>
-        <Icon src={`https://favicon.twenty.com/${removeProtocol(data.href)}`} />
+        <Icon src={`https://twenty-icons.com/${removeProtocol(data.href)}`} />
         <Title>{data.name}</Title>
         <Description>{data.description}</Description>
       </StyledContent>


### PR DESCRIPTION
We're moving favicon/telemetry/company enrichment to a separate url for better security/monitoring