### PR TITLE
Fix array enum renaming

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-runner/services/workspace-migration-enum.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-runner/services/workspace-migration-enum.service.ts
@@ -238,7 +238,7 @@ export class WorkspaceMigrationEnumService {
 
     if (!result) {
       throw new WorkspaceMigrationException(
-        `Column ${columnName} not found in table ${tableName} while trying to alter enum`,
+        `Enum type name not found for column ${columnName} in table ${tableName} while trying to alter enum`,
         WorkspaceMigrationExceptionCode.ENUM_TYPE_NAME_NOT_FOUND,
       );
     }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-runner/services/workspace-migration-enum.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-runner/services/workspace-migration-enum.service.ts
@@ -231,19 +231,22 @@ export class WorkspaceMigrationEnumService {
     tableName: string,
     columnName: string,
   ): Promise<string> {
-    const result = await queryRunner.query(
-      `SELECT udt_name FROM information_schema.columns WHERE table_schema = $1 AND table_name = $2 AND column_name = $3`,
+    const [result] = await queryRunner.query(
+      `SELECT udt_name, data_type FROM information_schema.columns WHERE table_schema = $1 AND table_name = $2 AND column_name = $3`,
       [schemaName, tableName, columnName],
     );
 
-    const enumTypeName = result[0]?.udt_name;
-
-    if (!enumTypeName) {
+    if (!result) {
       throw new WorkspaceMigrationException(
-        `Enum type name not found for column ${columnName} in table ${tableName} while trying to alter enum`,
+        `Column ${columnName} not found in table ${tableName} while trying to alter enum`,
         WorkspaceMigrationExceptionCode.ENUM_TYPE_NAME_NOT_FOUND,
       );
     }
+
+    const enumTypeName =
+      result.data_type === 'ARRAY'
+        ? result.udt_name.replace(/^_/, '')
+        : result.udt_name;
 
     return enumTypeName;
   }


### PR DESCRIPTION
When creating an enum type (let's say post_type_enum), postgres will automatically create a array enum type based on this enum and prefix it with an underscore (so _post_type_enum).

Our code was not taking this case into account while dealing with MULTISELECT

Resources:
https://www.postgresql.org/docs/current/sql-createtype.html

<img width="1329" alt="image" src="https://github.com/user-attachments/assets/c41bc90c-9884-4995-8fae-d26869153a1d" />
