### PR TITLE
Change default behavior of ENABLE DB MIGRATION

### DIFF
--- a/packages/twenty-docker/.env.example
+++ b/packages/twenty-docker/.env.example
@@ -2,20 +2,13 @@ TAG=latest
 
 #PGUSER_SUPERUSER=postgres
 #PGPASSWORD_SUPERUSER=replace_me_with_a_strong_password
-
-PG_DATABASE_HOST=db
-
-REDIS_URL=redis://redis:6379
+#PG_DATABASE_HOST=db
+#REDIS_URL=redis://redis:6379
 
 SERVER_URL=http://localhost:3000
-FRONT_DOMAIN=localhost
-FRONT_PORT=3000
-FRONT_PROTOCOL=http
 
 # Use openssl rand -base64 32 for each secret
 # APP_SECRET=replace_me_with_a_random_string
-
-SIGN_IN_PREFILLED=false
 
 STORAGE_TYPE=local
 

--- a/packages/twenty-docker/.env.example
+++ b/packages/twenty-docker/.env.example
@@ -3,7 +3,8 @@ TAG=latest
 #PGUSER_SUPERUSER=postgres
 #PGPASSWORD_SUPERUSER=replace_me_with_a_strong_password
 
-PG_DATABASE_HOST=db:5432
+PG_DATABASE_HOST=db
+
 REDIS_URL=redis://redis:6379
 
 SERVER_URL=http://localhost:3000
@@ -14,7 +15,7 @@ FRONT_PROTOCOL=http
 # Use openssl rand -base64 32 for each secret
 # APP_SECRET=replace_me_with_a_random_string
 
-SIGN_IN_PREFILLED=true
+SIGN_IN_PREFILLED=false
 
 STORAGE_TYPE=local
 

--- a/packages/twenty-docker/docker-compose.yml
+++ b/packages/twenty-docker/docker-compose.yml
@@ -26,8 +26,6 @@ services:
       SERVER_URL: ${SERVER_URL}
       REDIS_URL: ${REDIS_URL:-redis://redis:6379}
 
-      ENABLE_DB_MIGRATIONS: "true"
-
       SIGN_IN_PREFILLED: ${SIGN_IN_PREFILLED}
       STORAGE_TYPE: ${STORAGE_TYPE}
       STORAGE_S3_REGION: ${STORAGE_S3_REGION}
@@ -54,7 +52,7 @@ services:
       PG_DATABASE_URL: postgres://${PGUSER_SUPERUSER:-postgres}:${PGPASSWORD_SUPERUSER:-postgres}@${PG_DATABASE_HOST:-db:5432}/default
       SERVER_URL: ${SERVER_URL}
       REDIS_URL: ${REDIS_URL:-redis://redis:6379}
-      ENABLE_DB_MIGRATIONS: "false" # it already runs on the server
+      DISABLE_DB_MIGRATIONS: "true" # it already runs on the server
 
       STORAGE_TYPE: ${STORAGE_TYPE}
       STORAGE_S3_REGION: ${STORAGE_S3_REGION}

--- a/packages/twenty-docker/k8s/manifests/deployment-server.yaml
+++ b/packages/twenty-docker/k8s/manifests/deployment-server.yaml
@@ -41,10 +41,8 @@ spec:
               value: "postgres://postgres:postgres@twentycrm-db.twentycrm.svc.cluster.local/default"
             - name: "REDIS_URL"
               value: "redis://twentycrm-redis.twentycrm.svc.cluster.local:6379"
-            - name: ENABLE_DB_MIGRATIONS
-              value: "true"
             - name: SIGN_IN_PREFILLED
-              value: "true"
+              value: "false"
             - name: STORAGE_TYPE
               value: "local"
             - name: "MESSAGE_QUEUE_TYPE"

--- a/packages/twenty-docker/k8s/manifests/deployment-worker.yaml
+++ b/packages/twenty-docker/k8s/manifests/deployment-worker.yaml
@@ -30,7 +30,7 @@ spec:
               value: "https://crm.example.com:443"
             - name: PG_DATABASE_URL
               value: "postgres://postgres:postgres@twentycrm-db.twentycrm.svc.cluster.local/default"
-            - name: ENABLE_DB_MIGRATIONS
+            - name: DISABLE_DB_MIGRATIONS
               value: "false" # it already runs on the server
             - name: STORAGE_TYPE
               value: "local"

--- a/packages/twenty-docker/k8s/terraform/deployment-server.tf
+++ b/packages/twenty-docker/k8s/terraform/deployment-server.tf
@@ -60,13 +60,8 @@ resource "kubernetes_deployment" "twentycrm_server" {
             value = "redis://${kubernetes_service.twentycrm_redis.metadata.0.name}.${kubernetes_namespace.twentycrm.metadata.0.name}.svc.cluster.local:6379"
           }
           env {
-            name  = "ENABLE_DB_MIGRATIONS"
-            value = "true"
-          }
-
-          env {
-            name  = "SIGN_IN_PREFILLED"
-            value = "true"
+            name  = "DISABLE_DB_MIGRATIONS"
+            value = "false"
           }
 
           env {

--- a/packages/twenty-docker/k8s/terraform/deployment-worker.tf
+++ b/packages/twenty-docker/k8s/terraform/deployment-worker.tf
@@ -59,8 +59,8 @@ resource "kubernetes_deployment" "twentycrm_worker" {
           }
 
           env {
-            name  = "ENABLE_DB_MIGRATIONS"
-            value = "false" #it already runs on the server
+            name  = "DISABLE_DB_MIGRATIONS"
+            value = "true" #it already runs on the server
           }
 
           env {

--- a/packages/twenty-docker/twenty/entrypoint.sh
+++ b/packages/twenty-docker/twenty/entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Check if the initialization has already been done and that we enabled automatic migration
-if [ "${DISABLE_DB_MIGRATIONS}" = "true" ] && [ ! -f /app/docker-data/db_status ]; then
+if [ "${DISABLE_DB_MIGRATIONS}" != "true" ] && [ ! -f /app/docker-data/db_status ]; then
     echo "Running database setup and migrations..."
 
     # Creating the database if it doesn't exist

--- a/packages/twenty-docker/twenty/entrypoint.sh
+++ b/packages/twenty-docker/twenty/entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Check if the initialization has already been done and that we enabled automatic migration
-if [ "${ENABLE_DB_MIGRATIONS}" != "false" ] && [ ! -f /app/docker-data/db_status ]; then
+if [ "${DISABLE_DB_MIGRATIONS}" = "true" ] && [ ! -f /app/docker-data/db_status ]; then
     echo "Running database setup and migrations..."
 
     # Creating the database if it doesn't exist

--- a/packages/twenty-docker/twenty/entrypoint.sh
+++ b/packages/twenty-docker/twenty/entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Check if the initialization has already been done and that we enabled automatic migration
-if [ "${ENABLE_DB_MIGRATIONS}" = "true" ] && [ ! -f /app/docker-data/db_status ]; then
+if [ "${ENABLE_DB_MIGRATIONS}" != "false" ] && [ ! -f /app/docker-data/db_status ]; then
     echo "Running database setup and migrations..."
 
     # Creating the database if it doesn't exist

--- a/packages/twenty-website/src/content/developers/self-hosting/upgrade-guide.mdx
+++ b/packages/twenty-website/src/content/developers/self-hosting/upgrade-guide.mdx
@@ -20,6 +20,12 @@ If you used Docker Compose, follow these steps:
 
 ## Version-specific upgrade steps
 
+### v0.34.0 to v0.35.0
+
+- We replaced `ENABLE_DB_MIGRATIONS` with `DISABLE_DB_MIGRATIONS` (default value is now `true`)
+
+
+
 ### v0.33.0 to v0.34.0
 
 Upgrade your Twenty instance to use v0.34.0 image

--- a/packages/twenty-website/src/content/developers/self-hosting/upgrade-guide.mdx
+++ b/packages/twenty-website/src/content/developers/self-hosting/upgrade-guide.mdx
@@ -20,7 +20,7 @@ If you used Docker Compose, follow these steps:
 
 ## Version-specific upgrade steps
 
-### v0.34.0 to v0.35.0
+### v0.34.0 to v0.40.0
 
 - We replaced `ENABLE_DB_MIGRATIONS` with `DISABLE_DB_MIGRATIONS` (default value is now `true`)
 

--- a/packages/twenty-website/src/content/developers/self-hosting/upgrade-guide.mdx
+++ b/packages/twenty-website/src/content/developers/self-hosting/upgrade-guide.mdx
@@ -22,7 +22,7 @@ If you used Docker Compose, follow these steps:
 
 ### v0.34.0 to v0.40.0
 
-- We replaced `ENABLE_DB_MIGRATIONS` with `DISABLE_DB_MIGRATIONS` (default value is now `true`)
+- We replaced `ENABLE_DB_MIGRATIONS` with `DISABLE_DB_MIGRATIONS` (default value is now `false`, you probably don't have to set anything)
 
 
 


### PR DESCRIPTION
See: https://github.com/twentyhq/twenty/issues/9031#issuecomment-2542015975

I think it would be easier if the default behavior for the container was to run the migration, and setting the environment variable would be used to disable it (e.g. on the worker).

Long-term goal is for the default setup to work out of the box with ~2 env variables only (database url, redis url)

I don't think there's a big risk if people forget to turn it off on the worker?