### PR TITLE
feat(database): add unique constraint on workspace subdomain

### DIFF
--- a/packages/twenty-server/src/database/typeorm/core/migrations/common/1734355945585-add-unique-index-on-subdomain.ts
+++ b/packages/twenty-server/src/database/typeorm/core/migrations/common/1734355945585-add-unique-index-on-subdomain.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddUniqueIndexOnSubdomain1734355945585 implements MigrationInterface {
+    name = 'AddUniqueIndexOnSubdomain1734355945585'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "core"."workspace" ADD CONSTRAINT "UQ_cba6255a24deb1fff07dd7351b8" UNIQUE ("subdomain")`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "core"."workspace" DROP CONSTRAINT "UQ_cba6255a24deb1fff07dd7351b8"`);
+    }
+
+}

--- a/packages/twenty-server/src/database/typeorm/core/migrations/common/1734355945585-add-unique-index-on-subdomain.ts
+++ b/packages/twenty-server/src/database/typeorm/core/migrations/common/1734355945585-add-unique-index-on-subdomain.ts
@@ -1,14 +1,19 @@
-import { MigrationInterface, QueryRunner } from "typeorm";
+import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class AddUniqueIndexOnSubdomain1734355945585 implements MigrationInterface {
-    name = 'AddUniqueIndexOnSubdomain1734355945585'
+export class AddUniqueIndexOnSubdomain1734355945585
+  implements MigrationInterface
+{
+  name = 'AddUniqueIndexOnSubdomain1734355945585';
 
-    public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "core"."workspace" ADD CONSTRAINT "UQ_cba6255a24deb1fff07dd7351b8" UNIQUE ("subdomain")`);
-    }
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "core"."workspace" ADD CONSTRAINT "UQ_cba6255a24deb1fff07dd7351b8" UNIQUE ("subdomain")`,
+    );
+  }
 
-    public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "core"."workspace" DROP CONSTRAINT "UQ_cba6255a24deb1fff07dd7351b8"`);
-    }
-
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "core"."workspace" DROP CONSTRAINT "UQ_cba6255a24deb1fff07dd7351b8"`,
+    );
+  }
 }

--- a/packages/twenty-server/src/engine/core-modules/workspace/workspace.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/workspace.entity.ts
@@ -144,7 +144,7 @@ export class Workspace {
   databaseSchema: string;
 
   @Field()
-  @Column()
+  @Column({ unique: true })
   subdomain: string;
 
   @Field()


### PR DESCRIPTION
Added a unique constraint to the "subdomain" column in the workspace entity to ensure no duplicate subdomains exist in the database. Included a TypeORM migration script to enforce this change at the database level.