### PR TITLE
fix demo seed conflicting with dev seed

### DIFF
--- a/packages/twenty-server/src/database/typeorm-seeds/core/demo/users.ts
+++ b/packages/twenty-server/src/database/typeorm-seeds/core/demo/users.ts
@@ -7,7 +7,7 @@ const tableName = 'user';
 export const DEMO_SEED_USER_IDS = {
   NOAH: '20202020-9e3b-46d4-a556-88b9ddc2b035',
   HUGO: '20202020-3957-4908-9c36-2929a23f8358',
-  TIM: '20202020-7169-42cf-bc47-1cfef15264b9',
+  TIM: '20202020-9e3b-46d4-a556-88b9ddc2b034',
 };
 
 export const seedUsers = async (


### PR DESCRIPTION
We have conflicts which prevents us from running demo seed command after a database-reset or/and if dev seed has already been populated. This is because we are trying to create Tim user twice (but due to the insert()...onConflict() in the seed creation, it does not create the second one), for seed-dev and seed-demo .

This PR fixes that by using the same user id, allowing us to use the same Tim apple for both dev/demo seeds

Test
<img width="802" alt="Screenshot 2024-12-16 at 15 36 56" src="https://github.com/user-attachments/assets/72244978-130f-4561-8709-43376453b247" />
<img width="780" alt="Screenshot 2024-12-16 at 15 37 17" src="https://github.com/user-attachments/assets/01ce221b-34f6-4e48-ae30-d84bdf9d3cc2" />
