### PR TITLE
Fix cursor generation buffer dependency in front

### DIFF
--- a/packages/twenty-front/src/modules/apollo/utils/__tests__/encodeCursor.test.ts
+++ b/packages/twenty-front/src/modules/apollo/utils/__tests__/encodeCursor.test.ts
@@ -1,5 +1,6 @@
 import { encodeCursor } from '@/apollo/utils/encodeCursor';
 import { ObjectRecord } from '@/object-record/types/ObjectRecord';
+import { Buffer } from 'buffer';
 
 describe('encodeCursor', () => {
   it('should create a cursor with id only', () => {

--- a/packages/twenty-front/src/modules/apollo/utils/encodeCursor.ts
+++ b/packages/twenty-front/src/modules/apollo/utils/encodeCursor.ts
@@ -1,6 +1,8 @@
 import { ObjectRecord } from '@/object-record/types/ObjectRecord';
 import { isDefined } from '~/utils/isDefined';
 
+import { Buffer } from 'buffer';
+
 export const encodeCursor = (record: ObjectRecord) => {
   if (!('id' in record) || !isDefined(record.id)) {
     throw new Error('Record does not have an id');


### PR DESCRIPTION
Buffer is part of nodejs API and is not recognized by front js runner. buffer library (already installed) is providing a polyfill for that