### PR TITLE
Remove serverless functions from settings

### DIFF
--- a/packages/twenty-server/src/database/typeorm-seeds/core/feature-flags.ts
+++ b/packages/twenty-server/src/database/typeorm-seeds/core/feature-flags.ts
@@ -38,7 +38,7 @@ export const seedFeatureFlags = async (
       {
         key: FeatureFlagKey.IsFunctionSettingsEnabled,
         workspaceId: workspaceId,
-        value: true,
+        value: false,
       },
       {
         key: FeatureFlagKey.IsWorkflowEnabled,

--- a/packages/twenty-server/src/engine/metadata-modules/serverless-function/serverless-function.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/serverless-function/serverless-function.resolver.ts
@@ -35,17 +35,16 @@ export class ServerlessFunctionResolver {
   ) {}
 
   async checkFeatureFlag(workspaceId: string) {
-    const isFunctionSettingsEnabled =
-      await this.featureFlagRepository.findOneBy({
-        workspaceId,
-        key: FeatureFlagKey.IsFunctionSettingsEnabled,
-        value: true,
-      });
+    const isWorkflowEnabled = await this.featureFlagRepository.findOneBy({
+      workspaceId,
+      key: FeatureFlagKey.IsWorkflowEnabled,
+      value: true,
+    });
 
-    if (!isFunctionSettingsEnabled) {
+    if (!isWorkflowEnabled) {
       throw new ServerlessFunctionException(
-        `IS_FUNCTION_SETTINGS_ENABLED feature flag is not set to true for this workspace`,
-        ServerlessFunctionExceptionCode.SERVERLESS_FUNCTION_NOT_FOUND,
+        `IS_WORKFLOW_ENABLED feature flag is not set to true for this workspace`,
+        ServerlessFunctionExceptionCode.FEATURE_FLAG_INVALID,
       );
     }
   }


### PR DESCRIPTION
closes https://github.com/twentyhq/twenty/issues/8727

@Bonapara wants to keep the code for now so I ended up by setting the `isFunctionSettingsEnabled` constants to false in the codebase