### PR TITLE
Removed unecessary dropdown container on MultiSelectFieldInput

### DIFF
--- a/packages/twenty-front/src/modules/ui/field/input/components/MultiSelectInput.tsx
+++ b/packages/twenty-front/src/modules/ui/field/input/components/MultiSelectInput.tsx
@@ -1,4 +1,3 @@
-import styled from '@emotion/styled';
 import { useRef, useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import { Key } from 'ts-key-enum';
@@ -18,12 +17,6 @@ import { useListenClickOutside } from '@/ui/utilities/pointer-event/hooks/useLis
 import { MenuItemMultiSelectTag } from 'twenty-ui';
 import { isDefined } from '~/utils/isDefined';
 import { turnIntoEmptyStringIfWhitespacesOnly } from '~/utils/string/turnIntoEmptyStringIfWhitespacesOnly';
-
-const StyledRelationPickerContainer = styled.div`
-  left: -1px;
-  position: absolute;
-  top: -1px;
-`;
 
 type MultiSelectInputProps = {
   values: FieldMultiSelectValue;
@@ -115,36 +108,34 @@ export const MultiSelectInput = ({
         }
       }}
     >
-      <StyledRelationPickerContainer ref={containerRef}>
-        <DropdownMenu data-select-disable>
-          <DropdownMenuSearchInput
-            value={searchFilter}
-            onChange={(event) =>
-              setSearchFilter(
-                turnIntoEmptyStringIfWhitespacesOnly(event.currentTarget.value),
-              )
-            }
-            autoFocus
-          />
-          <DropdownMenuSeparator />
-          <DropdownMenuItemsContainer hasMaxHeight>
-            {filteredOptionsInDropDown.map((option) => {
-              return (
-                <MenuItemMultiSelectTag
-                  key={option.value}
-                  selected={values?.includes(option.value) || false}
-                  text={option.label}
-                  color={option.color ?? 'transparent'}
-                  onClick={() =>
-                    onOptionSelected(formatNewSelectedOptions(option.value))
-                  }
-                  isKeySelected={selectedItemId === option.value}
-                />
-              );
-            })}
-          </DropdownMenuItemsContainer>
-        </DropdownMenu>
-      </StyledRelationPickerContainer>
+      <DropdownMenu data-select-disable ref={containerRef}>
+        <DropdownMenuSearchInput
+          value={searchFilter}
+          onChange={(event) =>
+            setSearchFilter(
+              turnIntoEmptyStringIfWhitespacesOnly(event.currentTarget.value),
+            )
+          }
+          autoFocus
+        />
+        <DropdownMenuSeparator />
+        <DropdownMenuItemsContainer hasMaxHeight>
+          {filteredOptionsInDropDown.map((option) => {
+            return (
+              <MenuItemMultiSelectTag
+                key={option.value}
+                selected={values?.includes(option.value) || false}
+                text={option.label}
+                color={option.color ?? 'transparent'}
+                onClick={() =>
+                  onOptionSelected(formatNewSelectedOptions(option.value))
+                }
+                isKeySelected={selectedItemId === option.value}
+              />
+            );
+          })}
+        </DropdownMenuItemsContainer>
+      </DropdownMenu>
     </SelectableList>
   );
 };


### PR DESCRIPTION
There was an unecessary dropdown menu container div that was conflicting with the recent refactor of dropdowns. The OverlayContainer component is now at the root of the tree of a cell.