### PR TITLE
feat(auth): enhance workspace handling and error feedback

### DIFF
--- a/packages/twenty-front/src/modules/auth/components/VerifyEffect.tsx
+++ b/packages/twenty-front/src/modules/auth/components/VerifyEffect.tsx
@@ -6,10 +6,16 @@ import { useIsLogged } from '@/auth/hooks/useIsLogged';
 import { isAppWaitingForFreshObjectMetadataState } from '@/object-metadata/states/isAppWaitingForFreshObjectMetadataState';
 import { AppPath } from '@/types/AppPath';
 import { useSetRecoilState } from 'recoil';
+import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
+import { SnackBarVariant } from '@/ui/feedback/snack-bar-manager/components/SnackBar';
+import { isDefined } from 'twenty-ui';
 
 export const VerifyEffect = () => {
   const [searchParams] = useSearchParams();
   const loginToken = searchParams.get('loginToken');
+  const errorMessage = searchParams.get('errorMessage');
+
+  const { enqueueSnackBar } = useSnackBar();
 
   const isLogged = useIsLogged();
   const navigate = useNavigate();
@@ -22,6 +28,11 @@ export const VerifyEffect = () => {
 
   useEffect(() => {
     const getTokens = async () => {
+      if (isDefined(errorMessage)) {
+        enqueueSnackBar(errorMessage, {
+          variant: SnackBarVariant.Error,
+        });
+      }
       if (!loginToken) {
         navigate(AppPath.SignInUp);
       } else {

--- a/packages/twenty-server/src/engine/core-modules/auth/controllers/google-auth.controller.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/controllers/google-auth.controller.ts
@@ -109,7 +109,9 @@ export class GoogleAuthController {
       if (err instanceof AuthException) {
         return res.redirect(
           this.domainManagerService.computeRedirectErrorUrl({
-            subdomain: this.environmentService.get('DEFAULT_SUBDOMAIN'),
+            subdomain:
+              req.user.targetWorkspaceSubdomain ??
+              this.environmentService.get('DEFAULT_SUBDOMAIN'),
             errorMessage: err.message,
           }),
         );

--- a/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.spec.ts
@@ -19,6 +19,7 @@ import {
   Workspace,
   WorkspaceActivationStatus,
 } from 'src/engine/core-modules/workspace/workspace.entity';
+import { UserService } from 'src/engine/core-modules/user/services/user.service';
 
 jest.mock('bcrypt');
 
@@ -34,6 +35,7 @@ const EnvironmentServiceGetMock = jest.fn();
 const WorkspaceCountMock = jest.fn();
 const WorkspaceCreateMock = jest.fn();
 const WorkspaceSaveMock = jest.fn();
+const WorkspaceFindOneMock = jest.fn();
 
 describe('SignInUpService', () => {
   let service: SignInUpService;
@@ -56,6 +58,7 @@ describe('SignInUpService', () => {
             count: WorkspaceCountMock,
             create: WorkspaceCreateMock,
             save: WorkspaceSaveMock,
+            findOne: WorkspaceFindOneMock,
           },
         },
         {
@@ -119,6 +122,12 @@ describe('SignInUpService', () => {
             generateSubdomain: jest.fn().mockReturnValue('testSubDomain'),
           },
         },
+        {
+          provide: UserService,
+          useValue: {
+            saveDefaultWorkspaceIfUserHasAccessOrThrow: jest.fn(),
+          },
+        },
       ],
     }).compile();
 
@@ -170,6 +179,9 @@ describe('SignInUpService', () => {
     workspaceInvitationFindInvitationByWorkspaceSubdomainAndUserEmailMock.mockReturnValueOnce(
       undefined,
     );
+    WorkspaceFindOneMock.mockReturnValueOnce({
+      id: 'another-workspace',
+    });
 
     const result = await service.signInUp({
       email,
@@ -373,6 +385,10 @@ describe('SignInUpService', () => {
     UserFindOneMock.mockReturnValueOnce(existingUser);
 
     EnvironmentServiceGetMock.mockReturnValueOnce(false);
+
+    WorkspaceFindOneMock.mockReturnValueOnce({
+      id: 'another-workspace',
+    });
 
     (bcrypt.compare as jest.Mock).mockReturnValueOnce(true);
 


### PR DESCRIPTION
Add support for setting a user's default workspace during sign-in if a target workspace subdomain exists. Enhance error feedback by displaying authentication error messages using a Snackbar in the front-end and improving redirect logic for workspace-specific errors.