### PR TITLE
fix: 3 first columns should be sticky view group

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-body/components/RecordTableBodyDroppable.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-body/components/RecordTableBodyDroppable.tsx
@@ -23,7 +23,7 @@ export const RecordTableBodyDroppable = ({
     >
       {(provided) => (
         <RecordTableBody
-          id={`record-table-body${recordGroupId ? `-${recordGroupId}` : ''}`}
+          id="record-table-body"
           ref={provided.innerRef}
           // eslint-disable-next-line react/jsx-props-no-spreading
           {...provided.droppableProps}

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-row/components/RecordTableActionRow.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-row/components/RecordTableActionRow.tsx
@@ -65,9 +65,10 @@ export const RecordTableActionRow = ({
       <StyledIconContainer>
         <LeftIcon size={theme.icon.size.sm} color={theme.font.color.tertiary} />
       </StyledIconContainer>
-      <StyledRecordTableTdTextContainer colSpan={visibleTableColumns.length}>
+      <StyledRecordTableTdTextContainer>
         <StyledText>{text}</StyledText>
       </StyledRecordTableTdTextContainer>
+      <StyledEmptyTd colSpan={visibleTableColumns.length - 1} />
       <StyledEmptyTd />
       <StyledEmptyTd />
     </StyledRecordTableDraggableTr>

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-section/components/RecordTableRecordGroupSection.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-section/components/RecordTableRecordGroupSection.tsx
@@ -91,7 +91,7 @@ export const RecordTableRecordGroupSection = () => {
           <IconChevronUp size={theme.icon.size.md} />
         </motion.span>
       </StyledChevronContainer>
-      <StyledRecordGroupSection colSpan={visibleColumns.length}>
+      <StyledRecordGroupSection>
         <Tag
           variant={
             recordGroup.type !== RecordGroupDefinitionType.NoValue
@@ -108,6 +108,7 @@ export const RecordTableRecordGroupSection = () => {
         />
         <StyledTotalRow>{recordIdsByGroup.length}</StyledTotalRow>
       </StyledRecordGroupSection>
+      <StyledEmptyTd colSpan={visibleColumns.length - 1} />
       <StyledEmptyTd />
       <StyledEmptyTd />
     </StyledTrContainer>


### PR DESCRIPTION
Fix #9113 

<img width="591" alt="Screenshot 2024-12-18 at 3 33 05 PM" src="https://github.com/user-attachments/assets/df55eff3-7b0d-4cf0-881b-167e1bf2f97b" />

<img width="543" alt="Screenshot 2024-12-18 at 3 34 37 PM" src="https://github.com/user-attachments/assets/76fe06e1-0a46-4130-921d-1d480306bda2" />
