### PR TITLE
feat(auth): add workspaceId validation and token expiration

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/auth/token/services/access-token.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/token/services/access-token.service.ts
@@ -100,6 +100,7 @@ export class AccessTokenService {
     return {
       token: this.jwtWrapperService.sign(jwtPayload, {
         secret: this.jwtWrapperService.generateAppSecret('ACCESS', workspaceId),
+        expiresIn,
       }),
       expiresAt,
     };

--- a/packages/twenty-server/src/engine/core-modules/auth/token/services/refresh-token.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/token/services/refresh-token.service.ts
@@ -90,6 +90,7 @@ export class RefreshTokenService {
       );
     }
 
+    // TODO: Delete this useless condition and error after March 31st 2025
     if (!token.workspaceId) {
       throw new AuthException(
         'This refresh token is malformed',

--- a/packages/twenty-server/src/engine/core-modules/auth/token/services/refresh-token.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/token/services/refresh-token.service.ts
@@ -90,6 +90,13 @@ export class RefreshTokenService {
       );
     }
 
+    if (!token.workspaceId) {
+      throw new AuthException(
+        'This refresh token is malformed',
+        AuthExceptionCode.INVALID_INPUT,
+      );
+    }
+
     return { user, token };
   }
 
@@ -115,10 +122,12 @@ export class RefreshTokenService {
     const refreshTokenPayload = {
       userId,
       expiresAt,
+      workspaceId,
       type: AppTokenType.RefreshToken,
     };
     const jwtPayload = {
       sub: userId,
+      workspaceId,
     };
 
     const refreshToken = this.appTokenRepository.create(refreshTokenPayload);


### PR DESCRIPTION
Added validation to ensure refresh tokens include a workspaceId, throwing an exception for malformed tokens. Included workspaceId in payloads and introduced expiration handling for access tokens. This enhances token security and prevents potential misuse.

Close #9126