### PR TITLE
Fix horizontal line visibility on login page when no SSO providers are available

### DIFF
--- a/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpWorkspaceScopeForm.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpWorkspaceScopeForm.tsx
@@ -9,7 +9,7 @@ import { SignInUpStep } from '@/auth/states/signInUpStepState';
 import { workspaceAuthProvidersState } from '@/workspace/states/workspaceAuthProvidersState';
 import styled from '@emotion/styled';
 import { useRecoilValue } from 'recoil';
-import { ActionLink, HorizontalSeparator } from 'twenty-ui';
+import { ActionLink } from 'twenty-ui';
 
 const StyledContentContainer = styled.div`
   margin-bottom: ${({ theme }) => theme.spacing(8)};
@@ -32,14 +32,7 @@ export const SignInUpWorkspaceScopeForm = () => {
         {workspaceAuthProviders.microsoft && <SignInUpWithMicrosoft />}
 
         {workspaceAuthProviders.sso.length > 0 && <SignInUpWithSSO />}
-
-        {(workspaceAuthProviders.google ||
-          workspaceAuthProviders.microsoft ||
-          workspaceAuthProviders.sso.length > 0) &&
-        workspaceAuthProviders.password ? (
-          <HorizontalSeparator visible />
-        ) : null}
-
+        
         {workspaceAuthProviders.password && <SignInUpWithCredentials />}
       </StyledContentContainer>
       {signInUpStep === SignInUpStep.Password && (


### PR DESCRIPTION
This fixes issue #9094

All components <SignInUpWithGoogle />,<SignInUpWithMicrosoft />, <SignInUpWithSSO /> have their own Horizontal Separator so we don't require extra Horizontal Separator.


Please review @BOHEUS . Let me know if further adjustments are needed.