### PR TITLE
Fix version creation / update when opening an action

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/form-types/hooks/useTextVariableEditor.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/form-types/hooks/useTextVariableEditor.ts
@@ -6,6 +6,7 @@ import Paragraph from '@tiptap/extension-paragraph';
 import { default as Placeholder } from '@tiptap/extension-placeholder';
 import Text from '@tiptap/extension-text';
 import { Editor, useEditor } from '@tiptap/react';
+import { useState } from 'react';
 import { isDefined } from 'twenty-ui';
 
 type UseTextVariableEditorProps = {
@@ -23,6 +24,8 @@ export const useTextVariableEditor = ({
   defaultValue,
   onUpdate,
 }: UseTextVariableEditorProps) => {
+  const [isInitializing, setIsInitializing] = useState(true);
+
   const editor = useEditor({
     extensions: [
       Document,
@@ -45,8 +48,12 @@ export const useTextVariableEditor = ({
       if (isDefined(defaultValue)) {
         initializeEditorContent(editor, defaultValue);
       }
+      setIsInitializing(false);
     },
     onUpdate: ({ editor }) => {
+      if (isInitializing) {
+        return;
+      }
       onUpdate(editor);
     },
     editorProps: {
@@ -54,11 +61,10 @@ export const useTextVariableEditor = ({
         if (event.key === 'Enter' && !event.shiftKey) {
           event.preventDefault();
 
-          const { state } = view;
-          const { tr } = state;
-
           // Insert hard break using the view's state and dispatch
           if (multiline === true) {
+            const { state } = view;
+            const { tr } = state;
             const transaction = tr.replaceSelectionWith(
               state.schema.nodes.hardBreak.create(),
             );


### PR DESCRIPTION
Actions using tiptap trigger updates when called.

Flow is following:
- component using tiptap receive default value
- we separate the default value because we need to add specific attributes to the editor when inserting breaks or variables
- editor performs an update for each value

It means that initialize our editor performs several updates. We need to avoid persisting until the init finished.