### PR TITLE
fix(domain-manager): prioritize non-seed workspaces in selection

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/domain-manager/service/domain-manager.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/domain-manager/service/domain-manager.service.ts
@@ -12,6 +12,10 @@ import {
 import { getDomainNameByEmail } from 'src/utils/get-domain-name-by-email';
 import { isDefined } from 'src/utils/is-defined';
 import { isWorkEmail } from 'src/utils/is-work-email';
+import {
+  SEED_ACME_WORKSPACE_ID,
+  SEED_APPLE_WORKSPACE_ID,
+} from 'src/database/typeorm-seeds/core/workspaces';
 
 @Injectable()
 export class DomainManagerService {
@@ -153,7 +157,14 @@ export class DomainManagerService {
         );
       }
 
-      return workspaces[0];
+      const nonSeedWorkspace = workspaces.find(
+        (workspace) =>
+          ![SEED_APPLE_WORKSPACE_ID, SEED_ACME_WORKSPACE_ID].includes(
+            workspace.id,
+          ),
+      );
+
+      return nonSeedWorkspace ?? workspaces[workspaces.length - 1];
     }
 
     throw new Error(

--- a/packages/twenty-server/src/engine/core-modules/domain-manager/service/domain-manager.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/domain-manager/service/domain-manager.service.ts
@@ -145,7 +145,7 @@ export class DomainManagerService {
     if (!this.environmentService.get('IS_MULTIWORKSPACE_ENABLED')) {
       const workspaces = await this.workspaceRepository.find({
         order: {
-          createdAt: 'DESC',
+          createdAt: 'ASC',
         },
         relations: ['workspaceSSOIdentityProviders'],
       });
@@ -164,7 +164,7 @@ export class DomainManagerService {
           ),
       );
 
-      return nonSeedWorkspace ?? workspaces[workspaces.length - 1];
+      return nonSeedWorkspace ?? workspaces[0];
     }
 
     throw new Error(


### PR DESCRIPTION
Updated workspace selection logic to prioritize non-seed workspaces. Returns a seed workspace only if no non-seed workspaces are available to improve filtering consistency and avoid unintended behavior.

Fix https://github.com/twentyhq/twenty/issues/9041 https://github.com/twentyhq/twenty/issues/9109