### PR TITLE
Fix sort with pagination and composite fields

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-order/graphql-query-order.parser.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-order/graphql-query-order.parser.ts
@@ -48,7 +48,10 @@ export class GraphqlQueryOrderFieldParser {
             Object.assign(acc, compositeOrder);
           } else {
             acc[`"${objectNameSingular}"."${key}"`] =
-              this.convertOrderByToFindOptionsOrder(value, isForwardPagination);
+              this.convertOrderByToFindOptionsOrder(
+                value as OrderByDirection,
+                isForwardPagination,
+              );
           }
         });
 

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/utils/__tests__/compute-cursor-arg-filter.spec.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/utils/__tests__/compute-cursor-arg-filter.spec.ts
@@ -1,0 +1,141 @@
+import { OrderByDirection } from 'src/engine/api/graphql/workspace-query-builder/interfaces/object-record.interface';
+
+import { GraphqlQueryRunnerException } from 'src/engine/api/graphql/graphql-query-runner/errors/graphql-query-runner.exception';
+import { computeCursorArgFilter } from 'src/engine/api/graphql/graphql-query-runner/utils/compute-cursor-arg-filter';
+import { FieldMetadataType } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
+
+describe('computeCursorArgFilter', () => {
+  const mockFieldMetadataMap = {
+    name: {
+      type: FieldMetadataType.TEXT,
+      id: 'name-id',
+      name: 'name',
+      label: 'Name',
+      objectMetadataId: 'object-id',
+    },
+    age: {
+      type: FieldMetadataType.NUMBER,
+      id: 'age-id',
+      name: 'age',
+      label: 'Age',
+      objectMetadataId: 'object-id',
+    },
+    fullName: {
+      type: FieldMetadataType.FULL_NAME,
+      id: 'fullname-id',
+      name: 'fullName',
+      label: 'Full Name',
+      objectMetadataId: 'object-id',
+    },
+  };
+
+  describe('basic cursor filtering', () => {
+    it('should return empty array when cursor is empty', () => {
+      const result = computeCursorArgFilter({}, [], mockFieldMetadataMap, true);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should compute forward pagination filter for single field', () => {
+      const cursor = { name: 'John' };
+      const orderBy = [{ name: OrderByDirection.AscNullsLast }];
+
+      const result = computeCursorArgFilter(
+        cursor,
+        orderBy,
+        mockFieldMetadataMap,
+        true,
+      );
+
+      expect(result).toEqual([{ name: { gt: 'John' } }]);
+    });
+
+    it('should compute backward pagination filter for single field', () => {
+      const cursor = { name: 'John' };
+      const orderBy = [{ name: OrderByDirection.AscNullsLast }];
+
+      const result = computeCursorArgFilter(
+        cursor,
+        orderBy,
+        mockFieldMetadataMap,
+        false,
+      );
+
+      expect(result).toEqual([{ name: { lt: 'John' } }]);
+    });
+  });
+
+  describe('multiple fields cursor filtering', () => {
+    it('should handle multiple cursor fields with forward pagination', () => {
+      const cursor = { name: 'John', age: 30 };
+      const orderBy = [
+        { name: OrderByDirection.AscNullsLast },
+        { age: OrderByDirection.DescNullsLast },
+      ];
+
+      const result = computeCursorArgFilter(
+        cursor,
+        orderBy,
+        mockFieldMetadataMap,
+        true,
+      );
+
+      expect(result).toEqual([
+        { name: { gt: 'John' } },
+        { name: { eq: 'John' }, age: { lt: 30 } },
+      ]);
+    });
+  });
+
+  describe('composite field handling', () => {
+    it('should handle fullName composite field', () => {
+      const cursor = {
+        fullName: { firstName: 'John', lastName: 'Doe' },
+      };
+      const orderBy = [
+        {
+          fullName: {
+            firstName: OrderByDirection.AscNullsLast,
+            lastName: OrderByDirection.AscNullsLast,
+          },
+        },
+      ];
+
+      const result = computeCursorArgFilter(
+        cursor,
+        orderBy,
+        mockFieldMetadataMap,
+        true,
+      );
+
+      expect(result).toEqual([
+        {
+          fullName: {
+            firstName: { gt: 'John' },
+            lastName: { gt: 'Doe' },
+          },
+        },
+      ]);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should throw error for invalid field metadata', () => {
+      const cursor = { invalidField: 'value' };
+      const orderBy = [{ invalidField: OrderByDirection.AscNullsLast }];
+
+      expect(() =>
+        computeCursorArgFilter(cursor, orderBy, mockFieldMetadataMap, true),
+      ).toThrow(GraphqlQueryRunnerException);
+    });
+
+    it('should throw error for missing orderBy entry', () => {
+      const cursor = { name: 'John' };
+      const orderBy = [{ age: OrderByDirection.AscNullsLast }];
+
+      expect(() =>
+        computeCursorArgFilter(cursor, orderBy, mockFieldMetadataMap, true),
+      ).toThrow(GraphqlQueryRunnerException);
+    });
+  });
+});

--- a/packages/twenty-server/src/engine/api/graphql/workspace-query-builder/interfaces/object-record.interface.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-query-builder/interfaces/object-record.interface.ts
@@ -18,7 +18,9 @@ export enum OrderByDirection {
 }
 
 export type ObjectRecordOrderBy = Array<{
-  [Property in keyof ObjectRecord]?: OrderByDirection;
+  [Property in keyof ObjectRecord]?:
+    | OrderByDirection
+    | Record<string, OrderByDirection>;
 }>;
 
 export interface ObjectRecordDuplicateCriteria {


### PR DESCRIPTION
Fixes https://github.com/twentyhq/twenty/issues/8863

## Description
This PR fixes an issue with cursor-based pagination when dealing with composite fields (like `fullName`). Previously, the pagination direction was incorrectly determined for composite fields because the code wasn't properly handling nested object structures in the `orderBy` parameter.
Refactored the code accordingly.