### PR TITLE
8749 invalid openapi schema

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/open-api/utils/base-schema.utils.ts
+++ b/packages/twenty-server/src/engine/core-modules/open-api/utils/base-schema.utils.ts
@@ -9,17 +9,18 @@ export const baseSchema = (
   serverUrl: string,
 ): OpenAPIV3_1.Document => {
   return {
-    openapi: '3.0.3',
+    openapi: '3.1.1',
     info: {
       title: 'Twenty Api',
-      description: `This is a **Twenty REST/API** playground based on the **OpenAPI 3.0 specification**.`,
-      termsOfService: 'https://github.com/twentyhq/twenty?tab=coc-ov-file',
+      description: `This is a **Twenty REST/API** playground based on the **OpenAPI 3.1 specification**.`,
+      termsOfService:
+        'https://github.com/twentyhq/twenty?tab=coc-ov-file#readme',
       contact: {
         email: 'felix@twenty.com',
       },
       license: {
         name: 'AGPL-3.0',
-        url: 'https://github.com/twentyhq/twenty?tab=AGPL-3.0-1-ov-file#readme',
+        url: 'https://github.com/twentyhq/twenty?tab=License-1-ov-file#readme',
       },
       version: API_Version,
     },


### PR DESCRIPTION
Fixes https://github.com/twentyhq/twenty/issues/8749
Switch openApi schema version from 3.0.1 to 3.1.1
Tested on https://editor-next.swagger.io/ as https://editor.swagger.io/ does not support 3.1
No error
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/41e2b12b-cc5d-49c3-9d4e-9246590e29d4" />
