### PR TITLE
Fix sync metadata default value not being synced

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version/0-40/0-40-record-position-backfill.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-40/0-40-record-position-backfill.command.ts
@@ -9,7 +9,7 @@ import { RecordPositionBackfillService } from 'src/engine/api/graphql/workspace-
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 
 @Command({
-  name: 'migrate-0.40:backfill-record-position',
+  name: 'upgrade-0.40:record-position-backfill',
   description: 'Backfill record position',
 })
 export class RecordPositionBackfillCommand extends ActiveWorkspacesCommandRunner {

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-40/0-40-upgrade-version.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-40/0-40-upgrade-version.command.ts
@@ -38,6 +38,12 @@ export class UpgradeTo0_40Command extends ActiveWorkspacesCommandRunner {
       'Running command to upgrade to 0.40: must start with phone calling code otherwise SyncMetadata will fail',
     );
 
+    await this.recordPositionBackfillCommand.executeActiveWorkspacesCommand(
+      passedParam,
+      options,
+      workspaceIds,
+    );
+
     await this.phoneCallingCodeCreateColumnCommand.executeActiveWorkspacesCommand(
       passedParam,
       options,
@@ -45,12 +51,6 @@ export class UpgradeTo0_40Command extends ActiveWorkspacesCommandRunner {
     );
 
     await this.phoneCallingCodeMigrateDataCommand.executeActiveWorkspacesCommand(
-      passedParam,
-      options,
-      workspaceIds,
-    );
-
-    await this.recordPositionBackfillCommand.executeActiveWorkspacesCommand(
       passedParam,
       options,
       workspaceIds,

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/comparators/workspace-field.comparator.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/comparators/workspace-field.comparator.ts
@@ -26,7 +26,6 @@ const commonFieldPropertiesToIgnore = [
   'gate',
   'asExpression',
   'generatedType',
-  'defaultValue',
   'isLabelSyncedWithName',
 ];
 


### PR DESCRIPTION
## Context
We used to not sync defaultValue and recently introduced a change in https://github.com/twentyhq/twenty/blob/3340f01c312de9d9ca6a4f19f45437d9d850fff0/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/comparators/workspace-field.comparator.ts
with shouldNotOverrideDefaultValue to sync it for specific field metadata type that can't be overwritten by the user. 
This means we should have removed 'defaultValue' from commonFieldPropertiesToIgnore list since it was handled differently.
This PR fixes that

Before
<img width="792" alt="Screenshot 2024-12-20 at 11 04 09" src="https://github.com/user-attachments/assets/1771c5a3-2162-4013-8a08-c54d2619fda3" />

After
<img width="798" alt="Screenshot 2024-12-20 at 11 04 55" src="https://github.com/user-attachments/assets/33e09f16-c615-4a43-950d-d2df955fb196" />
