### PR TITLE
Fix show page navbar issue

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-show/hooks/useRecordIdsForShowPageNavigation.ts
+++ b/packages/twenty-front/src/modules/object-record/record-show/hooks/useRecordIdsForShowPageNavigation.ts
@@ -1,0 +1,37 @@
+import { useFindManyRecords } from '@/object-record/hooks/useFindManyRecords';
+import { useRecordIdsFromFindManyCacheRootQuery } from '@/object-record/record-show/hooks/useRecordIdsFromFindManyCacheRootQuery';
+import isEmpty from 'lodash.isempty';
+
+export const useRecordIdsForShowPageNavigation = ({
+  objectNameSingular,
+  objectNamePlural,
+  fieldVariables,
+}: {
+  objectNameSingular: string;
+  objectNamePlural: string;
+  fieldVariables: {
+    filter: any;
+    orderBy: any;
+  };
+}) => {
+  let recordIds: string[] = [];
+  const { recordIdsInCache } = useRecordIdsFromFindManyCacheRootQuery({
+    objectNamePlural: objectNamePlural,
+    fieldVariables,
+  });
+  recordIds = recordIdsInCache;
+
+  const { records, loading } = useFindManyRecords({
+    filter: fieldVariables.filter,
+    orderBy: fieldVariables.orderBy,
+    objectNameSingular,
+    recordGqlFields: { id: true },
+    skip: !isEmpty(recordIdsInCache),
+  });
+
+  if (isEmpty(recordIdsInCache)) {
+    recordIds = records.map((record) => record.id);
+  }
+
+  return { recordIds, loading };
+};

--- a/packages/twenty-front/src/modules/object-record/record-show/hooks/useRecordShowPagePagination.ts
+++ b/packages/twenty-front/src/modules/object-record/record-show/hooks/useRecordShowPagePagination.ts
@@ -1,12 +1,11 @@
 import { isNonEmptyString } from '@sniptt/guards';
-import { useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { useSetRecoilState } from 'recoil';
 
 import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
 import { useFindManyRecords } from '@/object-record/hooks/useFindManyRecords';
 import { lastShowPageRecordIdState } from '@/object-record/record-field/states/lastShowPageRecordId';
-import { useRecordIdsFromFindManyCacheRootQuery } from '@/object-record/record-show/hooks/useRecordIdsFromFindManyCacheRootQuery';
+import { useRecordIdsForShowPageNavigation } from '@/object-record/record-show/hooks/useRecordIdsForShowPageNavigation';
 import { buildShowPageURL } from '@/object-record/record-show/utils/buildShowPageURL';
 import { buildIndexTablePageURL } from '@/object-record/record-table/utils/buildIndexTableURL';
 import { useQueryVariablesFromActiveFieldsOfViewOrDefaultView } from '@/views/hooks/useQueryVariablesFromActiveFieldsOfViewOrDefaultView';
@@ -55,9 +54,6 @@ export const useRecordShowPagePagination = (
 
   const cursorFromRequest = currentRecordsPageInfo?.endCursor;
 
-  const [totalCountBefore, setTotalCountBefore] = useState<number>(0);
-  const [totalCountAfter, setTotalCountAfter] = useState<number>(0);
-
   const { loading: loadingRecordBefore, records: recordsBefore } =
     useFindManyRecords({
       skip: loadingCursor,
@@ -76,9 +72,6 @@ export const useRecordShowPagePagination = (
         : undefined,
       objectNameSingular,
       recordGqlFields: { id: true },
-      onCompleted: (_, pagination) => {
-        setTotalCountBefore(pagination?.totalCount ?? 0);
-      },
     });
 
   const { loading: loadingRecordAfter, records: recordsAfter } =
@@ -99,23 +92,26 @@ export const useRecordShowPagePagination = (
         : undefined,
       objectNameSingular,
       recordGqlFields: { id: true },
-      onCompleted: (_, pagination) => {
-        setTotalCountAfter(pagination?.totalCount ?? 0);
-      },
     });
-
-  const loading = loadingRecordAfter || loadingRecordBefore || loadingCursor;
 
   const recordBefore = recordsBefore[0];
   const recordAfter = recordsAfter[0];
 
-  const { recordIdsInCache } = useRecordIdsFromFindManyCacheRootQuery({
-    objectNamePlural: objectMetadataItem.namePlural,
-    fieldVariables: {
-      filter,
-      orderBy,
-    },
-  });
+  const { recordIds, loading: loadingRecordIds } =
+    useRecordIdsForShowPageNavigation({
+      objectNameSingular: objectMetadataItem.nameSingular,
+      objectNamePlural: objectMetadataItem.namePlural,
+      fieldVariables: {
+        filter,
+        orderBy,
+      },
+    });
+
+  const loading =
+    loadingRecordAfter ||
+    loadingRecordBefore ||
+    loadingCursor ||
+    loadingRecordIds;
 
   const navigateToPreviousRecord = () => {
     if (isDefined(recordBefore)) {
@@ -124,7 +120,7 @@ export const useRecordShowPagePagination = (
       );
     }
     if (!loadingRecordBefore && !isDefined(recordBefore)) {
-      const firstRecordId = recordIdsInCache[recordIdsInCache.length - 1];
+      const firstRecordId = recordIds[recordIds.length - 1];
       navigate(
         buildShowPageURL(objectNameSingular, firstRecordId, viewIdQueryParam),
       );
@@ -138,7 +134,7 @@ export const useRecordShowPagePagination = (
       );
     }
     if (!loadingRecordAfter && !isDefined(recordAfter)) {
-      const lastRecordId = recordIdsInCache[0];
+      const lastRecordId = recordIds[0];
       navigate(
         buildShowPageURL(objectNameSingular, lastRecordId, viewIdQueryParam),
       );
@@ -156,13 +152,13 @@ export const useRecordShowPagePagination = (
     navigate(indexTableURL);
   };
 
-  const rankInView = recordIdsInCache.findIndex((id) => id === objectRecordId);
+  const rankInView = recordIds.findIndex((id) => id === objectRecordId);
 
   const rankFoundInView = rankInView > -1;
 
   const objectLabel = capitalize(objectMetadataItem.labelPlural);
 
-  const totalCount = Math.max(1, totalCountBefore, totalCountAfter);
+  const totalCount = recordIds.length;
 
   const viewNameWithCount = rankFoundInView
     ? `${rankInView + 1} of ${totalCount} in ${objectLabel}`


### PR DESCRIPTION
Fixing https://discord.com/channels/1130383047699738754/1319674733796659251/1319674733796659251

Issues were
1. cache is empty is page has been refresh, therefore recordsInCache[0] is undefined, creating issue with navigation to next or last record. I created a new hook to re-launch the query if cache is empty
2. totalCount did not make sense, being either equal to recordsBeforeCount or recordsAfterCount, who were both equal to all records length minus 1 