### PR TITLE
Make the workflow's visualizer layout more stable

### DIFF
--- a/packages/twenty-front/src/modules/workflow/components/WorkflowDiagramCanvasEditable.tsx
+++ b/packages/twenty-front/src/modules/workflow/components/WorkflowDiagramCanvasEditable.tsx
@@ -17,7 +17,6 @@ export const WorkflowDiagramCanvasEditable = ({
   return (
     <ReactFlowProvider>
       <WorkflowDiagramCanvasBase
-        key={workflowWithCurrentVersion.currentVersion.id}
         diagram={diagram}
         status={workflowWithCurrentVersion.currentVersion.status}
         nodeTypes={{

--- a/packages/twenty-front/src/modules/workflow/components/WorkflowDiagramCanvasReadonly.tsx
+++ b/packages/twenty-front/src/modules/workflow/components/WorkflowDiagramCanvasReadonly.tsx
@@ -16,7 +16,6 @@ export const WorkflowDiagramCanvasReadonly = ({
   return (
     <ReactFlowProvider>
       <WorkflowDiagramCanvasBase
-        key={workflowVersion.id}
         diagram={diagram}
         status={workflowVersion.status}
         nodeTypes={{


### PR DESCRIPTION
We no longer reset the state of Reactflow when the selected workflow version changes. The viewport is not reset when discarding a draft version but it looks better that way.

https://github.com/user-attachments/assets/0df9fa52-c44a-4aea-a504-4765542101fa

Fixes https://discord.com/channels/1130383047699738754/1319626151768883300/1319626151768883300