### PR TITLE
Fixed dragging with empty orphan favorites

### DIFF
--- a/packages/twenty-front/src/modules/favorites/components/CurrentWorkspaceMemberFavorites.tsx
+++ b/packages/twenty-front/src/modules/favorites/components/CurrentWorkspaceMemberFavorites.tsx
@@ -158,9 +158,6 @@ export const CurrentWorkspaceMemberFavorites = ({
                 ref={provided.innerRef}
                 // eslint-disable-next-line react/jsx-props-no-spreading
                 {...provided.droppableProps}
-                style={{
-                  marginBottom: 15,
-                }}
                 // TODO: (Drag Drop Bug) Adding bottom margin to ensure drag-to-last-position works. Need to find better solution that doesn't affect spacing.
                 // Issue: Without margin, dragging to last position triggers next folder drop area
               >

--- a/packages/twenty-front/src/modules/favorites/components/CurrentWorkspaceMemberOrphanFavorites.tsx
+++ b/packages/twenty-front/src/modules/favorites/components/CurrentWorkspaceMemberOrphanFavorites.tsx
@@ -13,7 +13,6 @@ import { useLocation } from 'react-router-dom';
 import { IconHeartOff } from 'twenty-ui';
 
 const StyledEmptyContainer = styled.div`
-  height: ${({ theme }) => theme.spacing(2.5)};
   width: 100%;
 `;
 
@@ -67,7 +66,7 @@ export const CurrentWorkspaceMemberOrphanFavorites = () => {
           />
         ))
       ) : (
-        <StyledEmptyContainer />
+        <StyledEmptyContainer style={{ height: isDragging ? '24px' : '1px' }} />
       )}
     </FavoritesDroppable>
   );


### PR DESCRIPTION
Created a resizable container tied to dragging state to create suitable droppable zone when there's no orphan favorites.