### PR TITLE
collapsed navigationDrawerItem width fix

### DIFF
--- a/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/NavigationDrawerItem.tsx
+++ b/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/NavigationDrawerItem.tsx
@@ -90,7 +90,7 @@ const StyledItem = styled('button', {
 
   width: ${(props) =>
     !props.isNavigationDrawerExpanded
-      ? `calc(${NAV_DRAWER_WIDTHS.menu.desktop.collapsed}px - ${props.theme.spacing(6)})`
+      ? `calc(${NAV_DRAWER_WIDTHS.menu.desktop.collapsed}px - ${props.theme.spacing(5.5)})`
       : `calc(100% - ${props.theme.spacing(2)})`};
 
   ${({ isDragging }) =>


### PR DESCRIPTION
Before: 

<img width="81" alt="Screenshot 2024-12-23 at 9 25 25 PM" src="https://github.com/user-attachments/assets/d4c07ed5-0953-422f-aabf-fa2ca10ba7e5" />

After: 

<img width="76" alt="Screenshot 2024-12-23 at 9 25 11 PM" src="https://github.com/user-attachments/assets/1ea6d64e-8c1f-4d0c-9b34-f8dceae9538d" />

