### PR TITLE
Add backup commands to documentation

### DIFF
--- a/packages/twenty-website/src/content/developers/backend-development/feature-flags.mdx
+++ b/packages/twenty-website/src/content/developers/backend-development/feature-flags.mdx
@@ -4,7 +4,7 @@ icon: TbFlag
 image: /images/user-guide/table-views/table.png
 ---
 
-Feature flags are used to hide experimental features. For twenty they are set on workspace level and not on a user level.
+Feature flags are used to hide experimental features. For Twenty, they are set on workspace level and not on a user level.
 
 ## Adding a new feature flag
 

--- a/packages/twenty-website/src/content/developers/backend-development/server-commands.mdx
+++ b/packages/twenty-website/src/content/developers/backend-development/server-commands.mdx
@@ -33,7 +33,7 @@ npx nx run twenty-server:lint # pass --fix to fix lint errors
 npx nx run twenty-server:test:unit          # run unit tests
 npx nx run twenty-server:test:integration   # run integration tests
 ```
-Note : you can run `npx nx run twenty-server:test:integration:with-db-reset` in case you need to reset the database before running the integration tests.
+Note: you can run `npx nx run twenty-server:test:integration:with-db-reset` in case you need to reset the database before running the integration tests.
 
 ### Resetting the database
 

--- a/packages/twenty-website/src/content/developers/backend-development/zapier.mdx
+++ b/packages/twenty-website/src/content/developers/backend-development/zapier.mdx
@@ -8,7 +8,7 @@ Effortlessly sync Twenty with 3000+ apps using [Zapier](https://zapier.com/). Au
 
 ## About Zapier
 
-Zapier is a tool that allows you automate workflows by connecting the apps that your team uses everyday. The fundamental concept of Zapier is automation workflows, called Zaps, and include triggers and actions. 
+Zapier is a tool that allows you to automate workflows by connecting the apps that your team uses every day. The fundamental concept of Zapier is automation workflows, called Zaps, and include triggers and actions.
 
 You can learn more about how Zapier works [here](https://zapier.com/how-it-works).  
 

--- a/packages/twenty-website/src/content/developers/bug-and-requests.mdx
+++ b/packages/twenty-website/src/content/developers/bug-and-requests.mdx
@@ -2,7 +2,7 @@
 title: Bugs and Requests
 icon: TbBug
 image: /images/user-guide/api/api.png
-info: Ask for help on Github or Discord
+info: Ask for help on GitHub or Discord
 ---
 
 ## Reporting Bugs
@@ -12,6 +12,6 @@ You can also ask for help on [Discord](https://discord.gg/cx5n4Jzs57).
 
 ## Feature Requests
 
-If you're not sure it's a bug and you feel it's closer to a feature request, then you should probably [open a discussion instead](https://github.com/twentyhq/twenty/discussions/new).
+If you're not sure if it's a bug, and you feel it's closer to a feature request, then you should probably [open a discussion instead](https://github.com/twentyhq/twenty/discussions/new).
 
 <ArticleEditContent></ArticleEditContent>

--- a/packages/twenty-website/src/content/developers/frontend-development/hotkeys.mdx
+++ b/packages/twenty-website/src/content/developers/frontend-development/hotkeys.mdx
@@ -73,7 +73,7 @@ const PageListeningEnter = () => {
 
 ### Listening to hotkeys in a modal-type component
 
-For this example we'll use a modal component that listens for the Escape key to tell it's parent to close it.
+For this example we'll use a modal component that listens for the Escape key to tell its parent to close it.
 
 Here the user interaction is changing the scope.
 

--- a/packages/twenty-website/src/content/developers/self-hosting/upgrade-guide.mdx
+++ b/packages/twenty-website/src/content/developers/self-hosting/upgrade-guide.mdx
@@ -7,7 +7,11 @@ image: /images/user-guide/notes/notes_header.png
 
 ## General guidelines
 
-Always make sure to back up your database before starting the upgrade process.
+**Always make sure to back up your database before starting the upgrade process** by running `docker exec -it <db_container_name_or_id> pg_dumpall -U <postgres_user> > databases_backup.sql`.
+
+To restore backup, run `cat databases_backup.sql | docker exec -i <db_container_name_or_id> psql -U <postgres_user>`.
+
+If you want to migrate from postgres bitnami container to postgres spilo container, you have to dump the database from the bitnami container and restore it to the spilo container using commands above.
 
 If you used Docker Compose, follow these steps:
 
@@ -55,7 +59,7 @@ The `yarn command:prod upgrade-0.34` takes care of the data migration of all wor
 
 We have updated the way we handle the frontend URL. 
 You can now set the frontend URL using the `FRONT_DOMAIN`, `FRONT_PROTOCOL` and `FRONT_PORT` variables.
-If FRONT_DOMAIN is not set, the frontend URL will fallback to `SERVER_URL`.
+If FRONT_DOMAIN is not set, the frontend URL will fall back to `SERVER_URL`.
 
 ### v0.32.0 to v0.33.0
 

--- a/packages/twenty-website/src/content/user-guide/functions/tasks.mdx
+++ b/packages/twenty-website/src/content/user-guide/functions/tasks.mdx
@@ -108,7 +108,7 @@ This procedure will help keep an updated record of your accomplishments.
 To permanently remove a task:
 
 1. Open the task you want to delete by clicking on its card, either from the `Tasks` page or within a `Record page`.
-2. Click the trash icon located at the top right corner of the task details panel.
+2. Click the trash icon located in the top right corner of the task details panel.
 
 Please note, deleting a task is permanent and can't be undone. Consider marking tasks as `Done` if there is a chance you will need to refer to them again.
 

--- a/packages/twenty-website/src/content/user-guide/other/github.mdx
+++ b/packages/twenty-website/src/content/user-guide/other/github.mdx
@@ -10,7 +10,7 @@ sectionInfo: Discover tips and tricks to optimize your experience.
 
 The Twenty GitHub repository hosts a vast array of resources like source code, documentation, discussions, and issue tracking. This is where you will be able to access the full code behind Twenty.
 
-[Visit Twenty on Github](https://github.com/twentyhq/twenty)
+[Visit Twenty on GitHub](https://github.com/twentyhq/twenty)
 
 ## Contributing
 


### PR DESCRIPTION
In documentation, there's mention to make a backup of database before upgrading Twenty but there are no commands how to do it, so this PR solves this problem by providing commands