### PR TITLE
docs: console.log invaluable typo

### DIFF
--- a/packages/twenty-website/src/content/developers/frontend-development/best-practices-front.mdx
+++ b/packages/twenty-website/src/content/developers/frontend-development/best-practices-front.mdx
@@ -151,7 +151,7 @@ They are often not necessary and will make the code harder to read and maintain 
 
 `console.log` statements are valuable during development, offering real-time insights into variable values and code flow. But, leaving them in production code can lead to several issues: 
 
-1. **Performance**: Excessive logging can affect the runtime performance, specially on client-side applications.
+1. **Performance**: Excessive logging can affect the runtime performance, especially on client-side applications.
   
 2. **Security**: Logging sensitive data can expose critical information to anyone who inspects the browser's console.
 

--- a/packages/twenty-website/src/content/developers/frontend-development/best-practices-front.mdx
+++ b/packages/twenty-website/src/content/developers/frontend-development/best-practices-front.mdx
@@ -149,7 +149,7 @@ They are often not necessary and will make the code harder to read and maintain 
 
 ## Console.logs
 
-`console.log` statements are invaluable during development, offering real-time insights into variable values and code flow. But, leaving them in production code can lead to several issues: 
+`console.log` statements are valuable during development, offering real-time insights into variable values and code flow. But, leaving them in production code can lead to several issues: 
 
 1. **Performance**: Excessive logging can affect the runtime performance, specially on client-side applications.
   


### PR DESCRIPTION
Console.logs are valuable in development so changed `invaluable` to `valuable`