### PR TITLE
Fix click outside on board

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-board/components/RecordBoard.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/components/RecordBoard.tsx
@@ -86,6 +86,7 @@ export const RecordBoard = () => {
       'action-menu-dropdown',
       'command-menu',
       'modal-backdrop',
+      'page-action-container',
     ],
     listenerId: RECORD_BOARD_CLICK_OUTSIDE_LISTENER_ID,
     refs: [boardRef],


### PR DESCRIPTION
Fixes #9246 
Exclude `page-action-container` from click outside listener