### PR TITLE
Add post hooks for workflow deletion

### DIFF
--- a/packages/twenty-server/src/modules/workflow/common/query-hooks/workflow-delete-many.post-query.hook.ts
+++ b/packages/twenty-server/src/modules/workflow/common/query-hooks/workflow-delete-many.post-query.hook.ts
@@ -1,0 +1,29 @@
+import { WorkspaceQueryPostHookInstance } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/interfaces/workspace-query-hook.interface';
+
+import { WorkspaceQueryHook } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/decorators/workspace-query-hook.decorator';
+import { WorkspaceQueryHookType } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/types/workspace-query-hook.type';
+import { AuthContext } from 'src/engine/core-modules/auth/types/auth-context.type';
+import { WorkflowWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow.workspace-entity';
+import { WorkflowCommonWorkspaceService } from 'src/modules/workflow/common/workspace-services/workflow-common.workspace-service';
+
+@WorkspaceQueryHook({
+  key: `workflow.deleteMany`,
+  type: WorkspaceQueryHookType.PostHook,
+})
+export class WorkflowDeleteManyPostQueryHook
+  implements WorkspaceQueryPostHookInstance
+{
+  constructor(
+    private readonly workflowCommonWorkspaceService: WorkflowCommonWorkspaceService,
+  ) {}
+
+  async execute(
+    _authContext: AuthContext,
+    _objectName: string,
+    payload: WorkflowWorkspaceEntity[],
+  ): Promise<void> {
+    this.workflowCommonWorkspaceService.cleanWorkflowsSubEntities(
+      payload.map((workflow) => workflow.id),
+    );
+  }
+}

--- a/packages/twenty-server/src/modules/workflow/common/query-hooks/workflow-delete-one.post-query.hook.ts
+++ b/packages/twenty-server/src/modules/workflow/common/query-hooks/workflow-delete-one.post-query.hook.ts
@@ -1,0 +1,29 @@
+import { WorkspaceQueryPostHookInstance } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/interfaces/workspace-query-hook.interface';
+
+import { WorkspaceQueryHook } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/decorators/workspace-query-hook.decorator';
+import { WorkspaceQueryHookType } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/types/workspace-query-hook.type';
+import { AuthContext } from 'src/engine/core-modules/auth/types/auth-context.type';
+import { WorkflowWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow.workspace-entity';
+import { WorkflowCommonWorkspaceService } from 'src/modules/workflow/common/workspace-services/workflow-common.workspace-service';
+
+@WorkspaceQueryHook({
+  key: `workflow.deleteOne`,
+  type: WorkspaceQueryHookType.PostHook,
+})
+export class WorkflowDeleteOnePostQueryHook
+  implements WorkspaceQueryPostHookInstance
+{
+  constructor(
+    private readonly workflowCommonWorkspaceService: WorkflowCommonWorkspaceService,
+  ) {}
+
+  async execute(
+    _authContext: AuthContext,
+    _objectName: string,
+    payload: WorkflowWorkspaceEntity[],
+  ): Promise<void> {
+    this.workflowCommonWorkspaceService.cleanWorkflowsSubEntities(
+      payload.map((workflow) => workflow.id),
+    );
+  }
+}

--- a/packages/twenty-server/src/modules/workflow/common/query-hooks/workflow-query-hook.module.ts
+++ b/packages/twenty-server/src/modules/workflow/common/query-hooks/workflow-query-hook.module.ts
@@ -7,6 +7,8 @@ import { WorkflowCreateManyPostQueryHook } from 'src/modules/workflow/common/que
 import { WorkflowCreateManyPreQueryHook } from 'src/modules/workflow/common/query-hooks/workflow-create-many.pre-query.hook';
 import { WorkflowCreateOnePostQueryHook } from 'src/modules/workflow/common/query-hooks/workflow-create-one.post-query.hook';
 import { WorkflowCreateOnePreQueryHook } from 'src/modules/workflow/common/query-hooks/workflow-create-one.pre-query.hook';
+import { WorkflowDeleteManyPostQueryHook } from 'src/modules/workflow/common/query-hooks/workflow-delete-many.post-query.hook';
+import { WorkflowDeleteOnePostQueryHook } from 'src/modules/workflow/common/query-hooks/workflow-delete-one.post-query.hook';
 import { WorkflowRunCreateManyPreQueryHook } from 'src/modules/workflow/common/query-hooks/workflow-run-create-many.pre-query.hook';
 import { WorkflowRunCreateOnePreQueryHook } from 'src/modules/workflow/common/query-hooks/workflow-run-create-one.pre-query.hook';
 import { WorkflowRunDeleteManyPreQueryHook } from 'src/modules/workflow/common/query-hooks/workflow-run-delete-many.pre-query.hook';
@@ -49,6 +51,8 @@ import { WorkflowVersionValidationWorkspaceService } from 'src/modules/workflow/
     WorkflowCreateManyPostQueryHook,
     WorkflowVersionValidationWorkspaceService,
     WorkflowCommonWorkspaceService,
+    WorkflowDeleteManyPostQueryHook,
+    WorkflowDeleteOnePostQueryHook,
   ],
 })
 export class WorkflowQueryHookModule {}

--- a/packages/twenty-server/src/modules/workflow/common/workspace-services/workflow-common.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/common/workspace-services/workflow-common.workspace-service.ts
@@ -74,18 +74,20 @@ export class WorkflowCommonWorkspaceService {
         'workflowEventListener',
       );
 
-    workflowIds.map(async (workflowId) => {
-      workflowEventListenerRepository.softDelete({
-        workflowId,
-      });
+    Promise.all(
+      workflowIds.map((workflowId) => {
+        workflowEventListenerRepository.softDelete({
+          workflowId,
+        });
 
-      workflowRunRepository.softDelete({
-        workflowId,
-      });
+        workflowRunRepository.softDelete({
+          workflowId,
+        });
 
-      workflowVersionRepository.softDelete({
-        workflowId,
-      });
-    });
+        workflowVersionRepository.softDelete({
+          workflowId,
+        });
+      }),
+    );
   }
 }

--- a/packages/twenty-server/src/modules/workflow/common/workspace-services/workflow-common.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/common/workspace-services/workflow-common.workspace-service.ts
@@ -1,6 +1,8 @@
 import { Injectable } from '@nestjs/common';
 
 import { TwentyORMManager } from 'src/engine/twenty-orm/twenty-orm.manager';
+import { WorkflowEventListenerWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow-event-listener.workspace-entity';
+import { WorkflowRunWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
 import { WorkflowVersionWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow-version.workspace-entity';
 import {
   WorkflowTriggerException,
@@ -63,12 +65,12 @@ export class WorkflowCommonWorkspaceService {
       );
 
     const workflowRunRepository =
-      await this.twentyORMManager.getRepository<WorkflowVersionWorkspaceEntity>(
+      await this.twentyORMManager.getRepository<WorkflowRunWorkspaceEntity>(
         'workflowRun',
       );
 
     const workflowEventListenerRepository =
-      await this.twentyORMManager.getRepository<WorkflowVersionWorkspaceEntity>(
+      await this.twentyORMManager.getRepository<WorkflowEventListenerWorkspaceEntity>(
         'workflowEventListener',
       );
 

--- a/packages/twenty-server/src/modules/workflow/common/workspace-services/workflow-common.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/common/workspace-services/workflow-common.workspace-service.ts
@@ -55,4 +55,35 @@ export class WorkflowCommonWorkspaceService {
 
     return { ...workflowVersion, trigger: workflowVersion.trigger };
   }
+
+  async cleanWorkflowsSubEntities(workflowIds: string[]): Promise<void> {
+    const workflowVersionRepository =
+      await this.twentyORMManager.getRepository<WorkflowVersionWorkspaceEntity>(
+        'workflowVersion',
+      );
+
+    const workflowRunRepository =
+      await this.twentyORMManager.getRepository<WorkflowVersionWorkspaceEntity>(
+        'workflowRun',
+      );
+
+    const workflowEventListenerRepository =
+      await this.twentyORMManager.getRepository<WorkflowVersionWorkspaceEntity>(
+        'workflowEventListener',
+      );
+
+    workflowIds.map(async (workflowId) => {
+      workflowEventListenerRepository.softDelete({
+        workflowId,
+      });
+
+      workflowRunRepository.softDelete({
+        workflowId,
+      });
+
+      workflowVersionRepository.softDelete({
+        workflowId,
+      });
+    });
+  }
 }


### PR DESCRIPTION
Delete all workflow sub objects when workflow is deleted. Other sub objects cannot be deleted otherwise.

We do not listen to deletion events so I am not adding them. Those post hooks should be deleted Q1 once we properly handle cascade for soft deletion