### PR TITLE
feat(frontend): Export Notes to PDF/Word

### DIFF
--- a/packages/twenty-front/src/modules/action-menu/actions/record-actions/components/RecordActionMenuEntriesSetter.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-actions/components/RecordActionMenuEntriesSetter.tsx
@@ -1,5 +1,6 @@
 import { MultipleRecordsActionMenuEntrySetterEffect } from '@/action-menu/actions/record-actions/multiple-records/components/MultipleRecordsActionMenuEntrySetterEffect';
 import { NoSelectionActionMenuEntrySetterEffect } from '@/action-menu/actions/record-actions/no-selection/components/NoSelectionActionMenuEntrySetterEffect';
+import { RightDrawerActionMenuEntriesSetterEffect } from '@/action-menu/actions/record-actions/right-drawer/components/RightDrawerActionMenuEntriesSetterEffect';
 import { ShowPageSingleRecordActionMenuEntrySetterEffect } from '@/action-menu/actions/record-actions/single-record/components/ShowPageSingleRecordActionMenuEntrySetterEffect';
 import { SingleRecordActionMenuEntrySetterEffect } from '@/action-menu/actions/record-actions/single-record/components/SingleRecordActionMenuEntrySetterEffect';
 import { WorkflowRunRecordActionMenuEntrySetterEffect } from '@/action-menu/actions/record-actions/workflow-run-record-actions/components/WorkflowRunRecordActionMenuEntrySetter';
@@ -9,6 +10,7 @@ import { contextStoreTargetedRecordsRuleComponentState } from '@/context-store/s
 import { ContextStoreViewType } from '@/context-store/types/ContextStoreViewType';
 import { useObjectMetadataItemById } from '@/object-metadata/hooks/useObjectMetadataItemById';
 import { objectMetadataItemsState } from '@/object-metadata/states/objectMetadataItemsState';
+import { isRightDrawerOpenState } from '@/ui/layout/right-drawer/states/isRightDrawerOpenState';
 import { useRecoilComponentValueV2 } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValueV2';
 import { useIsFeatureEnabled } from '@/workspace/hooks/useIsFeatureEnabled';
 import { useRecoilValue } from 'recoil';
@@ -54,6 +56,7 @@ const ActionEffects = ({
   );
 
   const isWorkflowEnabled = useIsFeatureEnabled('IS_WORKFLOW_ENABLED');
+  const isRightDrawerOpen = useRecoilValue(isRightDrawerOpenState);
 
   return (
     <>
@@ -87,6 +90,11 @@ const ActionEffects = ({
       {(contextStoreTargetedRecordsRule.mode === 'exclusion' ||
         contextStoreTargetedRecordsRule.selectedRecordIds.length > 1) && (
         <MultipleRecordsActionMenuEntrySetterEffect
+          objectMetadataItem={objectMetadataItem}
+        />
+      )}
+      {isRightDrawerOpen && (
+        <RightDrawerActionMenuEntriesSetterEffect
           objectMetadataItem={objectMetadataItem}
         />
       )}

--- a/packages/twenty-front/src/modules/action-menu/actions/record-actions/right-drawer/components/RightDrawerActionMenuEntriesSetterEffect.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-actions/right-drawer/components/RightDrawerActionMenuEntriesSetterEffect.tsx
@@ -1,0 +1,33 @@
+import { useExportNoteToPdfAction } from '@/action-menu/actions/record-actions/right-drawer/hooks/useExportNoteToPdfAction';
+import { ObjectMetadataItem } from '@/object-metadata/types/ObjectMetadataItem';
+import { useRightDrawer } from '@/ui/layout/right-drawer/hooks/useRightDrawer';
+import { useEffect } from 'react';
+import { isDefined } from 'twenty-ui';
+
+export const RightDrawerActionMenuEntriesSetterEffect = ({
+  objectMetadataItem,
+}: {
+  objectMetadataItem: ObjectMetadataItem;
+}) => {
+  const { isRightDrawerOpen } = useRightDrawer();
+
+  const { registerExportToPdfAction, unregisterExportToPdfAction } =
+    useExportNoteToPdfAction();
+
+  useEffect(() => {
+    if (isRightDrawerOpen && isDefined(objectMetadataItem)) {
+      registerExportToPdfAction({ position: 1 });
+
+      return () => {
+        unregisterExportToPdfAction();
+      };
+    }
+  }, [
+    isRightDrawerOpen,
+    objectMetadataItem,
+    registerExportToPdfAction,
+    unregisterExportToPdfAction,
+  ]);
+
+  return null;
+};

--- a/packages/twenty-front/src/modules/action-menu/actions/record-actions/right-drawer/hooks/useExportNoteToPdfAction.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-actions/right-drawer/hooks/useExportNoteToPdfAction.tsx
@@ -1,0 +1,51 @@
+import { useContext } from 'react';
+
+import { RightDrawerActionKeys } from '@/action-menu/actions/record-actions/right-drawer/types/RightDrawerActionKeys';
+import { ActionMenuContext } from '@/action-menu/contexts/ActionMenuContext';
+import { useActionMenuEntries } from '@/action-menu/hooks/useActionMenuEntries';
+import {
+  ActionMenuEntryScope,
+  ActionMenuEntryType,
+} from '@/action-menu/types/ActionMenuEntry';
+import { IconFileExport } from 'twenty-ui';
+
+export const useExportNoteToPdfAction = () => {
+  const { addActionMenuEntry, removeActionMenuEntry } = useActionMenuEntries();
+
+  const exportToPdf = async () => {
+    // [Issue 8439] TODO: Implement PDF export
+  };
+
+  const { onActionStartedCallback, onActionExecutedCallback } =
+    useContext(ActionMenuContext);
+
+  const registerExportToPdfAction = ({ position }: { position: number }) => {
+    addActionMenuEntry({
+      key: RightDrawerActionKeys.EXPORT_NOTE_TO_PDF,
+      label: 'Export to PDF',
+      shortLabel: 'Export PDF',
+      Icon: IconFileExport,
+      onClick: async () => {
+        await onActionStartedCallback?.({
+          key: RightDrawerActionKeys.EXPORT_NOTE_TO_PDF,
+        });
+        await exportToPdf();
+        await onActionExecutedCallback?.({
+          key: RightDrawerActionKeys.EXPORT_NOTE_TO_PDF,
+        });
+      },
+      type: ActionMenuEntryType.Standard,
+      scope: ActionMenuEntryScope.RightDrawer,
+      position,
+    });
+  };
+
+  const unregisterExportToPdfAction = () => {
+    removeActionMenuEntry(RightDrawerActionKeys.EXPORT_NOTE_TO_PDF);
+  };
+
+  return {
+    registerExportToPdfAction,
+    unregisterExportToPdfAction,
+  };
+};

--- a/packages/twenty-front/src/modules/action-menu/actions/record-actions/right-drawer/types/RightDrawerActionKeys.ts
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-actions/right-drawer/types/RightDrawerActionKeys.ts
@@ -1,0 +1,3 @@
+export enum RightDrawerActionKeys {
+  EXPORT_NOTE_TO_PDF = 'export-note-to-pdf',
+}

--- a/packages/twenty-front/src/modules/action-menu/components/RightDrawerActionMenuDropdown.tsx
+++ b/packages/twenty-front/src/modules/action-menu/components/RightDrawerActionMenuDropdown.tsx
@@ -69,7 +69,7 @@ export const RightDrawerActionMenuDropdown = () => {
           {actionMenuEntries
             .filter(
               (actionMenuEntry) =>
-                actionMenuEntry.scope === ActionMenuEntryScope.RecordSelection,
+                actionMenuEntry.scope === ActionMenuEntryScope.RightDrawer,
             )
             .map((actionMenuEntry, index) => (
               <MenuItem

--- a/packages/twenty-front/src/modules/action-menu/types/ActionMenuEntry.ts
+++ b/packages/twenty-front/src/modules/action-menu/types/ActionMenuEntry.ts
@@ -11,6 +11,7 @@ export enum ActionMenuEntryType {
 export enum ActionMenuEntryScope {
   Global = 'Global',
   RecordSelection = 'RecordSelection',
+  RightDrawer = 'RightDrawer',
 }
 
 export type ActionMenuEntry = {

--- a/packages/twenty-front/src/modules/activities/components/ActivityRichTextEditor.tsx
+++ b/packages/twenty-front/src/modules/activities/components/ActivityRichTextEditor.tsx
@@ -178,6 +178,8 @@ export const ActivityRichTextEditor = ({
     uploadFile: handleEditorBuiltInUploadFile,
   });
 
+  // [Issue 8439] TODO: Make the editor instance available to useExportNoteToPdfAction
+
   useScopedHotkeys(
     Key.Escape,
     () => {


### PR DESCRIPTION
## Summary

Implements part of the “Export to PDF” feature by adding a new right-drawer directory to record-actions and introducing a dedicated ActionMenu scope for the RightDrawer. This lays the groundwork for displaying the export button in the RightDrawerActionMenuDropdown.

## Status
This PR addresses issue #8439 but does not resolve it completely yet. Feel free to take over and complete the remaining tasks.

## Changes
- Created a new `right-drawer` directory under `action-menu/actions`, containing relevant components, hooks, and type definitions
- Added `RightDrawer` scope to the `ActionMenuEntryScope` enum
- Integrated a `RightDrawerActionMenuEntriesSetterEffect` component
- Updated `RightDrawerActionMenuDropdown` to filter entries by `RightDrawer` scope
- Added `[Issue 8439] TODO` comments for remaining tasks that might be helpful for others looking to work on the issue

## Notes
- This PR only covers showing the export action in the RightDrawer. Handling the actual PDF export (and reconciling schema/type issues for BlockNote) remains a TODO.
- Upgrading BlockNote to the latest version introduces additional type errors, so some refactoring will be needed for the “file” block and custom schema fields.
- Further steps are noted in the issue and in the TODO comments for anyone who wants to continue this work.
