### PR TITLE
Fix text color issue in CustomSlashMenu for dark mode

### DIFF
--- a/packages/twenty-front/src/modules/ui/input/editor/components/CustomSlashMenu.tsx
+++ b/packages/twenty-front/src/modules/ui/input/editor/components/CustomSlashMenu.tsx
@@ -23,6 +23,7 @@ const StyledContainer = styled.div`
 `;
 
 const StyledInnerContainer = styled.div`
+  color: ${({ theme }) => theme.font.color.secondary};
   height: 250px;
   width: 100%;
 `;


### PR DESCRIPTION
fixes #9265 

#### Summary
The menu options appear in black color in dark mode, making text hard to read because there is very little contrast between text and background.

#### Solution
Added `color: ${({ theme }) => theme.font.color.secondary};` to the dropdown menu container, so the menu options inherit the correct text color from their containers.

### Screenshots
![CleanShot 2024-12-30 at 09 37 26](https://github.com/user-attachments/assets/a709b785-75a4-408d-9517-d3cab2c1fee6)
