### PR TITLE
Fix use as draft redirection

### DIFF
--- a/packages/twenty-front/src/modules/action-menu/actions/record-actions/single-record/workflow-version-actions/hooks/useUseAsDraftWorkflowVersionSingleRecordAction.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-actions/single-record/workflow-version-actions/hooks/useUseAsDraftWorkflowVersionSingleRecordAction.tsx
@@ -1,9 +1,12 @@
 import { SingleRecordActionHookWithoutObjectMetadataItem } from '@/action-menu/actions/types/SingleRecordActionHook';
+import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
+import { buildShowPageURL } from '@/object-record/record-show/utils/buildShowPageURL';
 import { OverrideWorkflowDraftConfirmationModal } from '@/workflow/components/OverrideWorkflowDraftConfirmationModal';
 import { useCreateNewWorkflowVersion } from '@/workflow/hooks/useCreateNewWorkflowVersion';
 import { useWorkflowVersion } from '@/workflow/hooks/useWorkflowVersion';
 import { useWorkflowWithCurrentVersion } from '@/workflow/hooks/useWorkflowWithCurrentVersion';
 import { openOverrideWorkflowDraftConfirmationModalState } from '@/workflow/states/openOverrideWorkflowDraftConfirmationModalState';
+import { useNavigate } from 'react-router-dom';
 import { useSetRecoilState } from 'recoil';
 import { isDefined } from 'twenty-ui';
 
@@ -20,6 +23,8 @@ export const useUseAsDraftWorkflowVersionSingleRecordAction: SingleRecordActionH
     const setOpenOverrideWorkflowDraftConfirmationModal = useSetRecoilState(
       openOverrideWorkflowDraftConfirmationModalState,
     );
+
+    const navigate = useNavigate();
 
     const workflowStatuses = workflow?.statuses;
 
@@ -44,6 +49,12 @@ export const useUseAsDraftWorkflowVersionSingleRecordAction: SingleRecordActionH
           trigger: workflowVersion.trigger,
           steps: workflowVersion.steps,
         });
+        navigate(
+          buildShowPageURL(
+            CoreObjectNameSingular.Workflow,
+            workflowVersion.workflow.id,
+          ),
+        );
       }
     };
 

--- a/packages/twenty-front/src/modules/workflow/components/RecordShowPageWorkflowVersionHeader.tsx
+++ b/packages/twenty-front/src/modules/workflow/components/RecordShowPageWorkflowVersionHeader.tsx
@@ -1,6 +1,7 @@
 import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
 import { useFindManyRecords } from '@/object-record/hooks/useFindManyRecords';
 import { useFindOneRecord } from '@/object-record/hooks/useFindOneRecord';
+import { buildShowPageURL } from '@/object-record/record-show/utils/buildShowPageURL';
 import { OverrideWorkflowDraftConfirmationModal } from '@/workflow/components/OverrideWorkflowDraftConfirmationModal';
 import { useActivateWorkflowVersion } from '@/workflow/hooks/useActivateWorkflowVersion';
 import { useCreateNewWorkflowVersion } from '@/workflow/hooks/useCreateNewWorkflowVersion';
@@ -8,6 +9,7 @@ import { useDeactivateWorkflowVersion } from '@/workflow/hooks/useDeactivateWork
 import { useWorkflowVersion } from '@/workflow/hooks/useWorkflowVersion';
 import { openOverrideWorkflowDraftConfirmationModalState } from '@/workflow/states/openOverrideWorkflowDraftConfirmationModalState';
 import { Workflow, WorkflowVersion } from '@/workflow/types/Workflow';
+import { useNavigate } from 'react-router-dom';
 import { useSetRecoilState } from 'recoil';
 import {
   Button,
@@ -78,6 +80,8 @@ export const RecordShowPageWorkflowVersionHeader = ({
     openOverrideWorkflowDraftConfirmationModalState,
   );
 
+  const navigate = useNavigate();
+
   return (
     <>
       {showUseAsDraftButton ? (
@@ -97,6 +101,12 @@ export const RecordShowPageWorkflowVersionHeader = ({
                 trigger: workflowVersion.trigger,
                 steps: workflowVersion.steps,
               });
+              navigate(
+                buildShowPageURL(
+                  CoreObjectNameSingular.Workflow,
+                  workflowVersion.workflow.id,
+                ),
+              );
             }
           }}
         />


### PR DESCRIPTION
When hitting use as draft in workflow version action, redirects to workflow newly created