### PR TITLE
Change Apollo cache policy

### DIFF
--- a/packages/twenty-front/src/modules/apollo/hooks/useApolloFactory.ts
+++ b/packages/twenty-front/src/modules/apollo/hooks/useApolloFactory.ts
@@ -54,8 +54,8 @@ export const useApolloFactory = (options: Partial<Options<any>> = {}) => {
         }),
       },
       defaultOptions: {
-        query: {
-          fetchPolicy: 'cache-first',
+        watchQuery: {
+          fetchPolicy: 'cache-and-network',
         },
       },
       connectToDevTools: isDebugMode,


### PR DESCRIPTION
Set the default cache policy to 'cache-and-network' to make sure user get more fresh data without refreshing the browser. Better for workspace with several users working at the same time.

It will put more load on the server...

Note: I don't think the previous setting was taken into account
<img width="829" alt="Screenshot 2024-12-31 at 10 59 56" src="https://github.com/user-attachments/assets/30ea74be-0907-422f-8e84-6c352d379337" />
