### PR TITLE
Creating a new task is not very smooth

### DIFF
--- a/packages/twenty-front/src/modules/object-record/utils/generateDefaultFieldValue.ts
+++ b/packages/twenty-front/src/modules/object-record/utils/generateDefaultFieldValue.ts
@@ -2,6 +2,7 @@ import { FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
 import { isFieldValueEmpty } from '@/object-record/record-field/utils/isFieldValueEmpty';
 import { generateEmptyFieldValue } from '@/object-record/utils/generateEmptyFieldValue';
 import { v4 } from 'uuid';
+import { stripSimpleQuotesFromString } from '~/utils/string/stripSimpleQuotesFromString';
 
 export const generateDefaultFieldValue = (
   fieldMetadataItem: Pick<FieldMetadataItem, 'defaultValue' | 'type'>,
@@ -11,7 +12,7 @@ export const generateDefaultFieldValue = (
     fieldDefinition: fieldMetadataItem,
   })
     ? generateEmptyFieldValue(fieldMetadataItem)
-    : fieldMetadataItem.defaultValue;
+    : stripSimpleQuotesFromString(fieldMetadataItem.defaultValue);
 
   switch (defaultValue) {
     case 'uuid':


### PR DESCRIPTION
"'TODO'" is the default value from the database and must be escaped in the frontend. The issue was revealed by the "status" field of Tasks but it would have been the same for the others

fix #9210 