### PR TITLE
Fix select all

### DIFF
--- a/packages/twenty-front/src/modules/action-menu/actions/record-actions/components/RecordActionMenuEntriesSetter.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-actions/components/RecordActionMenuEntriesSetter.tsx
@@ -73,10 +73,8 @@ export const RecordActionMenuEntriesSetter = () => {
       ))}
 
       {isWorkflowEnabled &&
-        !(
-          contextStoreTargetedRecordsRule?.mode === 'selection' &&
-          contextStoreTargetedRecordsRule?.selectedRecordIds.length === 0
-        ) && (
+        contextStoreTargetedRecordsRule?.mode === 'selection' &&
+        contextStoreTargetedRecordsRule?.selectedRecordIds.length === 1 && (
           <WorkflowRunRecordActionMenuEntrySetterEffect
             objectMetadataItem={objectMetadataItem}
           />


### PR DESCRIPTION
There was a bug when selecting all records on the index page.
This was due to the fact that `WorkflowRunRecordActionMenuEntrySetterEffect` was mounted when it shouldn't have been.