### PR TITLE
[9382][FRONT]: Compute highlighted object view using raw name plural

### DIFF
--- a/packages/twenty-front/src/modules/navigation/hooks/useLastVisitedView.ts
+++ b/packages/twenty-front/src/modules/navigation/hooks/useLastVisitedView.ts
@@ -29,7 +29,7 @@ export const useLastVisitedView = () => {
     setLastVisitedViewPerObjectMetadataItem,
   ] = useRecoilState(lastVisitedViewPerObjectMetadataItemState);
 
-  const { findActiveObjectMetadataItemBySlug } =
+  const { findActiveObjectMetadataItemByNamePlural } =
     useFilteredObjectMetadataItems();
 
   const setFallbackForLastVisitedView = (objectMetadataItemId: string) => {
@@ -49,7 +49,7 @@ export const useLastVisitedView = () => {
     viewId: string;
   }) => {
     const fallbackObjectMetadataItem =
-      findActiveObjectMetadataItemBySlug(objectNamePlural);
+    findActiveObjectMetadataItemByNamePlural(objectNamePlural);
 
     if (isDefined(fallbackObjectMetadataItem)) {
       /* when both are equal meaning there was change in view else 
@@ -72,7 +72,7 @@ export const useLastVisitedView = () => {
     objectNamePlural: string,
   ) => {
     const objectMetadataItemId: string | undefined =
-      findActiveObjectMetadataItemBySlug(objectNamePlural)?.id;
+    findActiveObjectMetadataItemByNamePlural(objectNamePlural)?.id;
     return objectMetadataItemId
       ? lastVisitedViewPerObjectMetadataItem?.[objectMetadataItemId]
       : undefined;

--- a/packages/twenty-front/src/modules/navigation/hooks/useLastVisitedView.ts
+++ b/packages/twenty-front/src/modules/navigation/hooks/useLastVisitedView.ts
@@ -49,7 +49,7 @@ export const useLastVisitedView = () => {
     viewId: string;
   }) => {
     const fallbackObjectMetadataItem =
-    findActiveObjectMetadataItemByNamePlural(objectNamePlural);
+      findActiveObjectMetadataItemByNamePlural(objectNamePlural);
 
     if (isDefined(fallbackObjectMetadataItem)) {
       /* when both are equal meaning there was change in view else 
@@ -72,7 +72,7 @@ export const useLastVisitedView = () => {
     objectNamePlural: string,
   ) => {
     const objectMetadataItemId: string | undefined =
-    findActiveObjectMetadataItemByNamePlural(objectNamePlural)?.id;
+      findActiveObjectMetadataItemByNamePlural(objectNamePlural)?.id;
     return objectMetadataItemId
       ? lastVisitedViewPerObjectMetadataItem?.[objectMetadataItemId]
       : undefined;

--- a/packages/twenty-front/src/modules/object-metadata/hooks/useFilteredObjectMetadataItems.ts
+++ b/packages/twenty-front/src/modules/object-metadata/hooks/useFilteredObjectMetadataItems.ts
@@ -38,6 +38,12 @@ export const useFilteredObjectMetadataItems = () => {
         getObjectSlug(activeObjectMetadataItem) === slug,
     );
 
+  const findActiveObjectMetadataItemByNamePlural = (namePlural: string) =>
+    activeObjectMetadataItems.find(
+      (activeObjectMetadataItem) =>
+        activeObjectMetadataItem.namePlural === namePlural,
+    );
+
   const findObjectMetadataItemById = (id: string) =>
     objectMetadataItems.find(
       (objectMetadataItem) => objectMetadataItem.id === id,
@@ -53,6 +59,7 @@ export const useFilteredObjectMetadataItems = () => {
     findActiveObjectMetadataItemBySlug,
     findObjectMetadataItemById,
     findObjectMetadataItemByNamePlural,
+    findActiveObjectMetadataItemByNamePlural,
     inactiveObjectMetadataItems,
     objectMetadataItems,
     findObjectMetadataItemBySlug,


### PR DESCRIPTION
# Introduction
Please find related ticket here #9382
To fix the issue the solution seems to be to stop searching for last viewed `objectMetadata` using their slugged version `namePlural`

## Upcoming cleanup
After discussing with @charlesBochet it seems like a bad practice to slug the `objectMetadata`, in this way in a following PR we will suggest a cleanup of the remaining method that does within the `useFilteredObjectMetadataItems.ts`

## Conclusion
As always any suggestions are welcomed !
Please let me know

closes #9382