### PR TITLE
refactor(auth): integrate react-hook-form context

### DIFF
--- a/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpEmailField.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpEmailField.tsx
@@ -2,7 +2,6 @@ import { TextInput } from '@/ui/input/components/TextInput';
 import { Controller, useFormContext } from 'react-hook-form';
 import styled from '@emotion/styled';
 import { motion } from 'framer-motion';
-import { isDefined } from '~/utils/isDefined';
 import { Form } from '@/auth/sign-in-up/hooks/useSignInUpForm';
 
 const StyledFullWidthMotionDiv = styled(motion.div)`
@@ -13,13 +12,7 @@ const StyledInputContainer = styled.div`
   margin-bottom: ${({ theme }) => theme.spacing(3)};
 `;
 
-export const SignInUpEmailField = ({
-  showErrors,
-  onChange: onChangeFromProps,
-}: {
-  showErrors: boolean;
-  onChange?: (value: string) => void;
-}) => {
+export const SignInUpEmailField = ({ showErrors }: { showErrors: boolean }) => {
   const form = useFormContext<Form>();
 
   return (
@@ -45,10 +38,7 @@ export const SignInUpEmailField = ({
               value={value}
               placeholder="Email"
               onBlur={onBlur}
-              onChange={(value: string) => {
-                onChange(value);
-                if (isDefined(onChangeFromProps)) onChangeFromProps(value);
-              }}
+              onChange={onChange}
               error={showErrors ? error?.message : undefined}
               fullWidth
             />

--- a/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpWorkspaceScopeForm.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpWorkspaceScopeForm.tsx
@@ -8,6 +8,7 @@ import { useSignInUpForm } from '@/auth/sign-in-up/hooks/useSignInUpForm';
 import { SignInUpStep } from '@/auth/states/signInUpStepState';
 import { workspaceAuthProvidersState } from '@/workspace/states/workspaceAuthProvidersState';
 import styled from '@emotion/styled';
+import { FormProvider } from 'react-hook-form';
 import { useRecoilValue } from 'recoil';
 import { ActionLink, HorizontalSeparator } from 'twenty-ui';
 
@@ -20,6 +21,7 @@ export const SignInUpWorkspaceScopeForm = () => {
   const workspaceAuthProviders = useRecoilValue(workspaceAuthProvidersState);
 
   const { form } = useSignInUpForm();
+
   const { handleResetPassword } = useHandleResetPassword();
 
   const { signInUpStep } = useSignInUp(form);
@@ -39,8 +41,12 @@ export const SignInUpWorkspaceScopeForm = () => {
         workspaceAuthProviders.password ? (
           <HorizontalSeparator />
         ) : null}
-
-        {workspaceAuthProviders.password && <SignInUpWithCredentials />}
+        {workspaceAuthProviders.password && (
+          // eslint-disable-next-line react/jsx-props-no-spreading
+          <FormProvider {...form}>
+            <SignInUpWithCredentials />
+          </FormProvider>
+        )}
       </StyledContentContainer>
       {signInUpStep === SignInUpStep.Password && (
         <ActionLink onClick={handleResetPassword(form.getValues('email'))}>

--- a/packages/twenty-front/src/modules/auth/sign-in-up/hooks/useSignInUpForm.ts
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/hooks/useSignInUpForm.ts
@@ -70,5 +70,5 @@ export const useSignInUpForm = () => {
     prefilledEmail,
     location.search,
   ]);
-  return { form: form, validationSchema };
+  return { form: form };
 };


### PR DESCRIPTION
Remove redundant validation logic and streamline form handling by leveraging react-hook-form's context. Simplify component props and enhance consistency across the sign-in/up flow.

Fix https://github.com/twentyhq/twenty/issues/9380