### PR TITLE
Remove identifierFieldMetadataId from createObjectInput

### DIFF
--- a/packages/twenty-front/src/generated-metadata/graphql.ts
+++ b/packages/twenty-front/src/generated-metadata/graphql.ts
@@ -199,6 +199,13 @@ export type CreateAppTokenInput = {
   expiresAt: Scalars['DateTime']['input'];
 };
 
+export type CreateDraftFromWorkflowVersionInput = {
+  /** Workflow ID */
+  workflowId: Scalars['String']['input'];
+  /** Workflow version ID */
+  workflowVersionIdToCopy: Scalars['String']['input'];
+};
+
 export type CreateFieldInput = {
   defaultValue?: InputMaybe<Scalars['JSON']['input']>;
   description?: InputMaybe<Scalars['String']['input']>;
@@ -221,10 +228,8 @@ export type CreateFieldInput = {
 export type CreateObjectInput = {
   description?: InputMaybe<Scalars['String']['input']>;
   icon?: InputMaybe<Scalars['String']['input']>;
-  imageIdentifierFieldMetadataId?: InputMaybe<Scalars['String']['input']>;
   isLabelSyncedWithName?: InputMaybe<Scalars['Boolean']['input']>;
   isRemote?: InputMaybe<Scalars['Boolean']['input']>;
-  labelIdentifierFieldMetadataId?: InputMaybe<Scalars['String']['input']>;
   labelPlural: Scalars['String']['input'];
   labelSingular: Scalars['String']['input'];
   namePlural: Scalars['String']['input'];
@@ -579,6 +584,7 @@ export type Mutation = {
   challenge: LoginToken;
   checkoutSession: SessionEntity;
   computeStepOutputSchema: Scalars['JSON']['output'];
+  createDraftFromWorkflowVersion: Scalars['Boolean']['output'];
   createOIDCIdentityProvider: SetupSsoOutput;
   createOneAppToken: AppToken;
   createOneField: Field;
@@ -682,6 +688,11 @@ export type MutationCheckoutSessionArgs = {
 
 export type MutationComputeStepOutputSchemaArgs = {
   input: ComputeStepOutputSchemaInput;
+};
+
+
+export type MutationCreateDraftFromWorkflowVersionArgs = {
+  input: CreateDraftFromWorkflowVersionInput;
 };
 
 

--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/dtos/create-object.input.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/dtos/create-object.input.ts
@@ -1,13 +1,7 @@
 import { Field, HideField, InputType } from '@nestjs/graphql';
 
 import { BeforeCreateOne } from '@ptc-org/nestjs-query-graphql';
-import {
-  IsBoolean,
-  IsNotEmpty,
-  IsOptional,
-  IsString,
-  IsUUID,
-} from 'class-validator';
+import { IsBoolean, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 import GraphQLJSON from 'graphql-type-json';
 
 import { FieldMetadataSettings } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata-settings.interface';
@@ -61,16 +55,6 @@ export class CreateObjectInput {
 
   @HideField()
   workspaceId: string;
-
-  @IsUUID()
-  @IsOptional()
-  @Field({ nullable: true })
-  labelIdentifierFieldMetadataId?: string;
-
-  @IsUUID()
-  @IsOptional()
-  @Field({ nullable: true })
-  imageIdentifierFieldMetadataId?: string;
 
   @IsBoolean()
   @IsOptional()


### PR DESCRIPTION
Removing labelIdentifierFieldMetadataId and imageIdentifierFieldMetadataId that should not be part of createObjectInput as they don't make sense for an object yet to create and will break