### PR TITLE
feat(auth, settings): allow to impersonate on mono workspace mode

### DIFF
--- a/packages/twenty-front/src/modules/auth/components/VerifyEffect.tsx
+++ b/packages/twenty-front/src/modules/auth/components/VerifyEffect.tsx
@@ -27,22 +27,17 @@ export const VerifyEffect = () => {
   );
 
   useEffect(() => {
-    const getTokens = async () => {
-      if (isDefined(errorMessage)) {
-        enqueueSnackBar(errorMessage, {
-          variant: SnackBarVariant.Error,
-        });
-      }
-      if (!loginToken) {
-        navigate(AppPath.SignInUp);
-      } else {
-        setIsAppWaitingForFreshObjectMetadata(true);
-        await verify(loginToken);
-      }
-    };
+    if (isDefined(errorMessage)) {
+      enqueueSnackBar(errorMessage, {
+        variant: SnackBarVariant.Error,
+      });
+    }
 
-    if (!isLogged) {
-      getTokens();
+    if (isDefined(loginToken)) {
+      setIsAppWaitingForFreshObjectMetadata(true);
+      verify(loginToken);
+    } else if (!isLogged) {
+      navigate(AppPath.SignInUp);
     }
     // Verify only needs to run once at mount
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/twenty-front/src/modules/auth/hooks/__tests__/useAuth.test.tsx
+++ b/packages/twenty-front/src/modules/auth/hooks/__tests__/useAuth.test.tsx
@@ -141,10 +141,7 @@ describe('useAuth', () => {
     const { result } = renderHooks();
 
     await act(async () => {
-      const res = await result.current.signUpWithCredentials(email, password);
-      expect(res).toHaveProperty('user');
-      expect(res).toHaveProperty('workspaceMember');
-      expect(res).toHaveProperty('workspace');
+      await result.current.signUpWithCredentials(email, password);
     });
 
     expect(mocks[2].result).toHaveBeenCalled();

--- a/packages/twenty-front/src/modules/auth/hooks/useAuth.ts
+++ b/packages/twenty-front/src/modules/auth/hooks/useAuth.ts
@@ -268,6 +268,8 @@ export const useAuth = () => {
 
   const handleVerify = useCallback(
     async (loginToken: string) => {
+      setIsVerifyPendingState(true);
+
       const verifyResult = await verify({
         variables: { loginToken },
       });
@@ -282,16 +284,11 @@ export const useAuth = () => {
 
       setTokenPair(verifyResult.data?.verify.tokens);
 
-      const { user, workspaceMember, workspace } = await loadCurrentUser();
+      await loadCurrentUser();
 
-      return {
-        user,
-        workspaceMember,
-        workspace,
-        tokens: verifyResult.data?.verify.tokens,
-      };
+      setIsVerifyPendingState(false);
     },
-    [verify, setTokenPair, loadCurrentUser],
+    [setIsVerifyPendingState, verify, setTokenPair, loadCurrentUser],
   );
 
   const handleCrendentialsSignIn = useCallback(
@@ -301,21 +298,9 @@ export const useAuth = () => {
         password,
         captchaToken,
       );
-      setIsVerifyPendingState(true);
-
-      const { user, workspaceMember, workspace } = await handleVerify(
-        loginToken.token,
-      );
-
-      setIsVerifyPendingState(false);
-
-      return {
-        user,
-        workspaceMember,
-        workspace,
-      };
+      await handleVerify(loginToken.token);
     },
-    [handleChallenge, handleVerify, setIsVerifyPendingState],
+    [handleChallenge, handleVerify],
   );
 
   const handleSignOut = useCallback(async () => {
@@ -360,13 +345,7 @@ export const useAuth = () => {
         );
       }
 
-      const { user, workspace, workspaceMember } = await handleVerify(
-        signUpResult.data?.signUp.loginToken.token,
-      );
-
-      setIsVerifyPendingState(false);
-
-      return { user, workspaceMember, workspace };
+      await handleVerify(signUpResult.data?.signUp.loginToken.token);
     },
     [
       setIsVerifyPendingState,


### PR DESCRIPTION
Added support for multi-workspace checks during impersonation and streamlined token verification flows. Adjusted session clearing and navigation logic to improve user transition between workspaces.