### PR TITLE
Fix: Proper HTTP Status Code Usage for Authentication and Authorization Errors

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/auth/filters/auth-rest-api-exception.filter.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/filters/auth-rest-api-exception.filter.ts
@@ -38,7 +38,7 @@ export class AuthRestApiExceptionFilter implements ExceptionFilter {
         return this.httpExceptionHandlerService.handleError(
           exception,
           response,
-          401,
+          403,
         );
       case AuthExceptionCode.GOOGLE_API_AUTH_DISABLED:
       case AuthExceptionCode.MICROSOFT_API_AUTH_DISABLED:
@@ -46,7 +46,7 @@ export class AuthRestApiExceptionFilter implements ExceptionFilter {
         return this.httpExceptionHandlerService.handleError(
           exception,
           response,
-          403,
+          401,
         );
       case AuthExceptionCode.INTERNAL_SERVER_ERROR:
       default:


### PR DESCRIPTION
This PR ensures the correct usage of HTTP status codes (401 Unauthorized and 403 Forbidden) for authentication and authorization errors, aligning with standard HTTP semantics. The changes impact the handling of AuthException across the application.

Changes Implemented
Updated Exception Handling Logic:

401 Unauthorized: Now used for cases where the user is unauthenticated (e.g., missing JWT, expired JWT, invalid credentials).
403 Forbidden: Used strictly for cases where the user is authenticated but lacks the required permissions.
2. Affected Files:
  before :- 
   
 ![Screenshot 2025-01-04 184617](https://github.com/user-attachments/assets/2d3f1c93-7d08-40d6-81b3-4c99d025a204)
 
  After:- 
  
  ![image](https://github.com/user-attachments/assets/7ca84182-8285-4d28-a4e4-56abefbdc4e2)
 
3.  Frontend Impact:

Verified frontend token renewal and error-handling flows.
Updated logic for handling 401 responses to trigger re-authentication (e.g., token refresh or redirect to login).


4.Issue Resolved:   #9347   