### PR TITLE
fix(auth, workspace-invitation): enforce required subdomains

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.spec.ts
@@ -498,6 +498,7 @@ describe('SignInUpService', () => {
       email,
       password,
       fromSSO: false,
+      targetWorkspaceSubdomain: 'testSubDomain',
       workspaceInviteHash,
     });
 

--- a/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.ts
@@ -122,19 +122,21 @@ export class SignInUpService {
       }
     }
 
-    const signInUpWithInvitationResult = await this.signInUpWithInvitation({
-      email,
-      workspacePersonalInviteToken,
-      workspaceInviteHash,
-      targetWorkspaceSubdomain,
-      fromSSO,
-      firstName,
-      lastName,
-      picture,
-      authProvider,
-      passwordHash,
-      existingUser,
-    });
+    const signInUpWithInvitationResult = targetWorkspaceSubdomain
+      ? await this.signInUpWithInvitation({
+          email,
+          workspacePersonalInviteToken,
+          workspaceInviteHash,
+          targetWorkspaceSubdomain,
+          fromSSO,
+          firstName,
+          lastName,
+          picture,
+          authProvider,
+          passwordHash,
+          existingUser,
+        })
+      : undefined;
 
     if (isDefined(signInUpWithInvitationResult)) {
       return signInUpWithInvitationResult;
@@ -187,7 +189,7 @@ export class SignInUpService {
     passwordHash?: string;
     existingUser: User | null;
     fromSSO: boolean;
-    targetWorkspaceSubdomain?: string;
+    targetWorkspaceSubdomain: string;
   }) {
     const maybeInvitation =
       fromSSO && !workspacePersonalInviteToken && !workspaceInviteHash

--- a/packages/twenty-server/src/engine/core-modules/workspace-invitation/services/workspace-invitation.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace-invitation/services/workspace-invitation.service.ts
@@ -139,7 +139,7 @@ export class WorkspaceInvitationService {
     subdomain,
     email,
   }: {
-    subdomain?: string;
+    subdomain: string;
     email: string;
   }) {
     const workspace =


### PR DESCRIPTION
Updated the handling of `targetWorkspaceSubdomain` and `subdomain` to enforce them as required fields. This prevents potential issues caused by missing values during sign-in/up and workspace invitation processes.