### PR TITLE
fix: add logo url response status check when creating workspace

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.ts
@@ -394,7 +394,10 @@ export class SignInUpService {
     const logoUrl = `${TWENTY_ICONS_BASE_URL}/${getDomainNameByEmail(email)}`;
     const isLogoUrlValid = async () => {
       try {
-        return (await this.httpService.axiosRef.get(logoUrl)).status === 200;
+        return (
+          (await this.httpService.axiosRef.get(logoUrl, { timeout: 600 }))
+            .status === 200
+        );
       } catch {
         return false;
       }

--- a/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.ts
@@ -391,9 +391,17 @@ export class SignInUpService {
       }
     }
 
-    const logo = isWorkEmail(email)
-      ? `${TWENTY_ICONS_BASE_URL}/${getDomainNameByEmail(email)}`
-      : undefined;
+    const logoUrl = `${TWENTY_ICONS_BASE_URL}/${getDomainNameByEmail(email)}`;
+    const isLogoUrlValid = async () => {
+      try {
+        return (await this.httpService.axiosRef.get(logoUrl)).status === 200;
+      } catch {
+        return false;
+      }
+    };
+
+    const logo =
+      isWorkEmail(email) && (await isLogoUrlValid()) ? logoUrl : undefined;
 
     const workspaceToCreate = this.workspaceRepository.create({
       subdomain: await this.domainManagerService.generateSubdomain(),


### PR DESCRIPTION
### Context
Workspace logo for work email is generated via twenty favicon service. If twenty favicon can not find user domain favicon, it responds with 404.
### Fix
Check logo url before saving it when creating new workspace

closes #9359 