### PR TITLE
Force workflow step detail re-create

### DIFF
--- a/packages/twenty-front/src/modules/workflow/workflow-steps/components/WorkflowStepDetail.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/components/WorkflowStepDetail.tsx
@@ -90,6 +90,7 @@ export const WorkflowStepDetail = ({
           return (
             <Suspense fallback={<RightDrawerSkeletonLoader />}>
               <WorkflowEditActionFormServerlessFunction
+                key={stepId}
                 action={stepDefinition.definition}
                 actionOptions={props}
               />
@@ -99,6 +100,7 @@ export const WorkflowStepDetail = ({
         case 'SEND_EMAIL': {
           return (
             <WorkflowEditActionFormSendEmail
+              key={stepId}
               action={stepDefinition.definition}
               actionOptions={props}
             />
@@ -107,6 +109,7 @@ export const WorkflowStepDetail = ({
         case 'CREATE_RECORD': {
           return (
             <WorkflowEditActionFormCreateRecord
+              key={stepId}
               action={stepDefinition.definition}
               actionOptions={props}
             />
@@ -116,6 +119,7 @@ export const WorkflowStepDetail = ({
         case 'UPDATE_RECORD': {
           return (
             <WorkflowEditActionFormUpdateRecord
+              key={stepId}
               action={stepDefinition.definition}
               actionOptions={props}
             />
@@ -125,6 +129,7 @@ export const WorkflowStepDetail = ({
         case 'DELETE_RECORD': {
           return (
             <WorkflowEditActionFormDeleteRecord
+              key={stepId}
               action={stepDefinition.definition}
               actionOptions={props}
             />


### PR DESCRIPTION
When switching between the same step detail component, even if the props is updated, component is not re-created.
This is an issue since form fields often keep an internal state. Which means that even if form data are updated, the displayed value may still be the value of the previous step detail.
Adding a key to for re-creation.