### PR TITLE
fix(auth): handle error properly in loadCurrentUser

### DIFF
--- a/packages/twenty-front/src/modules/auth/hooks/useAuth.ts
+++ b/packages/twenty-front/src/modules/auth/hooks/useAuth.ts
@@ -177,6 +177,10 @@ export const useAuth = () => {
   const loadCurrentUser = useCallback(async () => {
     const currentUserResult = await getCurrentUser();
 
+    if (isDefined(currentUserResult.error)) {
+      throw new Error(currentUserResult.error.message);
+    }
+
     const user = currentUserResult.data?.currentUser;
 
     if (!user) {


### PR DESCRIPTION
Updated the loadCurrentUser function to throw specific errors when an API error occurs. This improves clarity and error handling, replacing the generic "No current user result" exception.

Fix #9536