### PR TITLE
docs(server-commands): fix typo in command to generate migrations

### DIFF
--- a/packages/twenty-website/src/content/developers/backend-development/server-commands.mdx
+++ b/packages/twenty-website/src/content/developers/backend-development/server-commands.mdx
@@ -48,7 +48,7 @@ npx nx run twenty-server:database:reset
 #### For objects in Core/Metadata schemas (TypeORM)
 
 ```bash
-npx nx run twenty-server:typeorm --migration:generate src/database/typeorm/metadata/migrations/nameOfYourMigration -d src/database/typeorm/metadata/metadata.datasource.ts # replace by core data source if necessary
+npx nx run twenty-server:typeorm migration:generate src/database/typeorm/metadata/migrations/nameOfYourMigration -d src/database/typeorm/metadata/metadata.datasource.ts # replace by core data source if necessary
 ```
 
 #### For Workspace objects


### PR DESCRIPTION
- the command had `--migration:generate` instead of `migration:generate` written in the doc
- when copy pasting it we got this error
```
Not enough non-option arguments: got 0, need at least 1
```
- after removing the extra `--` it worked as expected