### PR TITLE
Update node image versions. Label docker tag for anedot specific images

### DIFF
--- a/packages/twenty-docker/Makefile
+++ b/packages/twenty-docker/Makefile
@@ -1,5 +1,5 @@
 prod-build:
-	@cd ../.. && docker build -f ./packages/twenty-docker/twenty/Dockerfile --tag twenty . && cd -
+	@cd ../.. && docker build -f ./packages/twenty-docker/twenty/Dockerfile --tag anedot-twenty . && cd -
 
 prod-run:
 	@docker run -d -p 3000:3000 --name twenty twenty

--- a/packages/twenty-docker/twenty/Dockerfile
+++ b/packages/twenty-docker/twenty/Dockerfile
@@ -1,5 +1,5 @@
 # Base image for common dependencies
-FROM node:18.17.1-alpine as common-deps
+FROM node:18.20-alpine as common-deps
 
 WORKDIR /app
 
@@ -48,7 +48,7 @@ RUN npx nx build twenty-front
 
 
 # Final stage: Run the application
-FROM node:18.17.1-alpine as twenty
+FROM node:18.20-alpine as twenty
 
 # Used to run healthcheck in docker
 RUN apk add --no-cache curl jq


### PR DESCRIPTION
Update node alpine to more recent versions. Update makefile docker tags to our internal `anedot-twenty` image tags for ECR. Also rebases on top of latest upstream changes.