### PR TITLE
fix: error thrown when switching between table with/without record group

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-index/hooks/useSetRecordIndexEntityCount.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/hooks/useSetRecordIndexEntityCount.ts
@@ -1,16 +1,10 @@
-import { hasRecordGroupsComponentSelector } from '@/object-record/record-group/states/selectors/hasRecordGroupsComponentSelector';
 import { recordIndexEntityCountByGroupComponentFamilyState } from '@/object-record/record-index/states/recordIndexEntityCountByGroupComponentFamilyState';
 import { recordIndexEntityCountNoGroupComponentFamilyState } from '@/object-record/record-index/states/recordIndexEntityCountNoGroupComponentFamilyState';
 import { useRecoilComponentCallbackStateV2 } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentCallbackStateV2';
-import { useRecoilComponentValueV2 } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValueV2';
 import { useRecoilCallback } from 'recoil';
 import { isDefined } from '~/utils/isDefined';
 
 export const useSetRecordIndexEntityCount = (viewBarComponentId?: string) => {
-  const hasRecordGroup = useRecoilComponentValueV2(
-    hasRecordGroupsComponentSelector,
-  );
-
   const recordIndexEntityCountNoGroupFamilyState =
     useRecoilComponentCallbackStateV2(
       recordIndexEntityCountNoGroupComponentFamilyState,
@@ -26,18 +20,13 @@ export const useSetRecordIndexEntityCount = (viewBarComponentId?: string) => {
   const setRecordIndexEntityCount = useRecoilCallback(
     ({ set }) =>
       (count: number, recordGroupId?: string) => {
-        if (hasRecordGroup) {
-          if (!isDefined(recordGroupId)) {
-            throw new Error('Record group ID is required');
-          }
-
+        if (isDefined(recordGroupId)) {
           set(recordIndexEntityCountByGroupFamilyState(recordGroupId), count);
         } else {
           set(recordIndexEntityCountNoGroupFamilyState, count);
         }
       },
     [
-      hasRecordGroup,
       recordIndexEntityCountByGroupFamilyState,
       recordIndexEntityCountNoGroupFamilyState,
     ],


### PR DESCRIPTION
Fix an error when switching between a table with and without record group.