### PR TITLE
fix: table acton row wrong stroke

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-row/components/RecordTableActionRow.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-row/components/RecordTableActionRow.tsx
@@ -64,7 +64,11 @@ export const RecordTableActionRow = ({
     >
       <td aria-hidden />
       <StyledIconContainer>
-        <LeftIcon size={theme.icon.size.sm} color={theme.font.color.tertiary} />
+        <LeftIcon
+          stroke={theme.icon.stroke.sm}
+          size={theme.icon.size.sm}
+          color={theme.font.color.tertiary}
+        />
       </StyledIconContainer>
       <StyledRecordTableTdTextContainer>
         <StyledText>{text}</StyledText>


### PR DESCRIPTION
As requested by @Bonapara the stroke of `RecordTableActionRow` should be in `sm` instead of `md`.