### PR TITLE
Fix wrong domainName for redirect url

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/billing/billing.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/billing.resolver.ts
@@ -45,7 +45,7 @@ export class BillingResolver {
   ) {
     return {
       url: await this.billingPortalWorkspaceService.computeBillingPortalSessionURLOrThrow(
-        workspace.id,
+        workspace,
         returnUrlPath,
       ),
     };

--- a/packages/twenty-server/src/engine/core-modules/billing/services/billing-portal.workspace-service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/services/billing-portal.workspace-service.ts
@@ -36,9 +36,9 @@ export class BillingPortalWorkspaceService {
     plan?: BillingPlanKey,
     requirePaymentMethod?: boolean,
   ): Promise<string> {
-    const frontBaseUrl = this.domainManagerService.getBaseUrl(
-      workspace.subdomain,
-    );
+    const frontBaseUrl = this.domainManagerService.buildWorkspaceURL({
+      subdomain: workspace.subdomain,
+    });
     const cancelUrl = frontBaseUrl.toString();
 
     if (successUrlPath) {
@@ -94,9 +94,9 @@ export class BillingPortalWorkspaceService {
       throw new Error('Error: missing stripeCustomerId');
     }
 
-    const frontBaseUrl = this.domainManagerService.getBaseUrl(
-      workspace.subdomain,
-    );
+    const frontBaseUrl = this.domainManagerService.buildWorkspaceURL({
+      subdomain: workspace.subdomain,
+    });
 
     if (returnUrlPath) {
       frontBaseUrl.pathname = returnUrlPath;

--- a/packages/twenty-server/src/engine/core-modules/billing/services/billing-portal.workspace-service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/services/billing-portal.workspace-service.ts
@@ -36,7 +36,9 @@ export class BillingPortalWorkspaceService {
     plan?: BillingPlanKey,
     requirePaymentMethod?: boolean,
   ): Promise<string> {
-    const frontBaseUrl = this.domainManagerService.getBaseUrl();
+    const frontBaseUrl = this.domainManagerService.getBaseUrl(
+      workspace.subdomain,
+    );
     const cancelUrl = frontBaseUrl.toString();
 
     if (successUrlPath) {

--- a/packages/twenty-server/src/engine/core-modules/billing/services/billing-portal.workspace-service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/services/billing-portal.workspace-service.ts
@@ -74,13 +74,13 @@ export class BillingPortalWorkspaceService {
   }
 
   async computeBillingPortalSessionURLOrThrow(
-    workspaceId: string,
+    workspace: Workspace,
     returnUrlPath?: string,
   ) {
     const currentSubscription =
       await this.billingSubscriptionService.getCurrentBillingSubscriptionOrThrow(
         {
-          workspaceId,
+          workspaceId: workspace.id,
         },
       );
 
@@ -94,7 +94,9 @@ export class BillingPortalWorkspaceService {
       throw new Error('Error: missing stripeCustomerId');
     }
 
-    const frontBaseUrl = this.domainManagerService.getBaseUrl();
+    const frontBaseUrl = this.domainManagerService.getBaseUrl(
+      workspace.subdomain,
+    );
 
     if (returnUrlPath) {
       frontBaseUrl.pathname = returnUrlPath;

--- a/packages/twenty-server/src/engine/core-modules/domain-manager/service/domain-manager.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/domain-manager/service/domain-manager.service.ts
@@ -46,13 +46,14 @@ export class DomainManagerService {
     return baseUrl;
   }
 
-  getBaseUrl(
-    subdomain = this.environmentService.get('DEFAULT_SUBDOMAIN'),
-  ): URL {
+  getBaseUrl(): URL {
     const baseUrl = this.getFrontUrl();
 
-    if (this.environmentService.get('IS_MULTIWORKSPACE_ENABLED') && subdomain) {
-      baseUrl.hostname = `${subdomain}.${baseUrl.hostname}`;
+    if (
+      this.environmentService.get('IS_MULTIWORKSPACE_ENABLED') &&
+      this.environmentService.get('DEFAULT_SUBDOMAIN')
+    ) {
+      baseUrl.hostname = `${this.environmentService.get('DEFAULT_SUBDOMAIN')}.${baseUrl.hostname}`;
     }
 
     return baseUrl;

--- a/packages/twenty-server/src/engine/core-modules/domain-manager/service/domain-manager.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/domain-manager/service/domain-manager.service.ts
@@ -46,14 +46,13 @@ export class DomainManagerService {
     return baseUrl;
   }
 
-  getBaseUrl(): URL {
+  getBaseUrl(
+    subdomain = this.environmentService.get('DEFAULT_SUBDOMAIN'),
+  ): URL {
     const baseUrl = this.getFrontUrl();
 
-    if (
-      this.environmentService.get('IS_MULTIWORKSPACE_ENABLED') &&
-      this.environmentService.get('DEFAULT_SUBDOMAIN')
-    ) {
-      baseUrl.hostname = `${this.environmentService.get('DEFAULT_SUBDOMAIN')}.${baseUrl.hostname}`;
+    if (this.environmentService.get('IS_MULTIWORKSPACE_ENABLED') && subdomain) {
+      baseUrl.hostname = `${subdomain}.${baseUrl.hostname}`;
     }
 
     return baseUrl;


### PR DESCRIPTION
Closes https://github.com/twentyhq/twenty/issues/9097

Fixes the redirect url of stripe `checkout` and `billingPortal` sessions

## Before

https://github.com/user-attachments/assets/4ccab325-41e1-494e-854a-9d9a72e534f1

## After

https://github.com/user-attachments/assets/740b07f4-84b0-4670-a5b6-2684fde640c8

