### PR TITLE
1-click install take latest version from docker

### DIFF
--- a/packages/twenty-docker/scripts/install.sh
+++ b/packages/twenty-docker/scripts/install.sh
@@ -44,10 +44,10 @@ function on_exit {
 trap on_exit EXIT
 
 # Use environment variables VERSION and BRANCH, with defaults if not set
-version=${VERSION:-$(curl -s https://api.github.com/repos/twentyhq/twenty/tags | grep '"name":' | head -n 1 | cut -d '"' -f 4)}
-branch=${BRANCH:-$version}
+version=${VERSION:-$(curl -s "https://hub.docker.com/v2/repositories/twentycrm/twenty/tags" | grep -o '"name":"[^"]*"' | grep -v 'latest' | cut -d'"' -f4 | sort -V | tail -n1)}
+branch=${BRANCH:-$(curl -s https://api.github.com/repos/twentyhq/twenty/tags | grep '"name":' | head -n 1 | cut -d '"' -f 4)}
 
-echo "🚀 Using version $version and branch $branch"
+echo "🚀 Using docker version $version and Github branch $branch"
 
 dir_name="twenty"
 function ask_directory {


### PR DESCRIPTION
There was a small issue where if you used the 1-click install script right after it was tagged on Github but before it was built and published to Docker hub, then it would fail