### PR TITLE
[CI][NITPICK] Remove input `types` invalid syntax

### DIFF
--- a/.github/workflows/actions/nx-affected/action.yaml
+++ b/.github/workflows/actions/nx-affected/action.yaml
@@ -2,14 +2,11 @@ name: Nx Affected CI
 inputs:
   parallel:
     required: false
-    types: [number]
-    default: 3
+    default: '3'
   tag:
     required: false
-    types: [string]
   tasks:
     required: true
-    types: [string]
 
 runs:
   using: "composite"

--- a/.github/workflows/actions/restore-cache/action.yml
+++ b/.github/workflows/actions/restore-cache/action.yml
@@ -3,10 +3,8 @@ inputs:
   key:
     required: true
     description: Prefix to the cache key
-    type: string
   additional-paths:
     required: false
-    type: string
 outputs:
   cache-primary-key:
     description: actions/cache/restore cache-primary-key outputs proxy

--- a/.github/workflows/actions/save-cache/action.yml
+++ b/.github/workflows/actions/save-cache/action.yml
@@ -3,10 +3,8 @@ inputs:
   key:
     required: true
     description: Primary key to the cache, should be retrieved from `cache-restore` composite action outputs.
-    type: string
   additional-paths:
     required: false
-    type: string
 
 runs:
   using: "composite"


### PR DESCRIPTION
## Introduction
Unless I'm mistaken neither the `inputs.type` or `inputs.type` syntax exists for `composite actions`.
By default it seems like any `Composite action` inputs are considered as `string`.
```yml
name: Nx Affected CI
inputs:
  parallel:
    required: false
    types: [number]
    default: 3
  tag:
    required: false
    types: [string]
  tasks:
    required: true
    types: [string]
```

## Suggestion
To avoid misunderstanding of our composite actions inputs signature I would recommend removing any `type` props but also default any inputs as `strings`

## Misc
- Please find related GitHub community discussion https://github.com/orgs/community/discussions/65588