### PR TITLE
[FIX][CI] cache-hit incorrectly computed

### DIFF
--- a/.github/workflows/actions/restore-cache/action.yml
+++ b/.github/workflows/actions/restore-cache/action.yml
@@ -11,7 +11,7 @@ outputs:
     value: ${{ steps.restore-cache.outputs.cache-primary-key }}
   cache-hit:
     description: String bool indicating whether cache has been directly or indirectly hit
-    value: ${{ steps.restore-cache.outputs.cache-hit != 'false' || steps.restore-cache.outputs.cache-matched-key != '' }}
+    value: ${{ steps.restore-cache.outputs.cache-hit == 'true' || steps.restore-cache.outputs.cache-matched-key != '' }}
 
 runs:
   using: composite
@@ -20,11 +20,11 @@ runs:
       uses: actions/cache/restore@v4
       id: restore-cache
       with:
+        key: ${{ inputs.key }}-${{ github.ref_name }}-${{ github.sha }}
+        restore-keys: ${{ inputs.key }}-${{ github.ref_name }}-
         path: |
           .cache
           .nx/cache
           node_modules/.cache
           packages/*/node_modules/.cache
           ${{ inputs.additional-paths }}
-        key: ${{ inputs.key }}-${{ github.ref_name }}-${{ github.sha }}
-        restore-keys: ${{ inputs.key }}-${{ github.ref_name }}-


### PR DESCRIPTION
## Introduction
The `cache-hit` value should be a string boolean, but it seems like not to always be the case ?

## Related runs
- twenty-server first attempt saves cache second retrieves it https://github.com/twentyhq/twenty/actions/runs/12768260350
- twenty-front https://github.com/twentyhq/twenty/actions/runs/12767064201