### PR TITLE
[CI] Migrate to ubuntu 24.04 runners

### DIFF
--- a/.github/workflows/actions/restore-cache/action.yml
+++ b/.github/workflows/actions/restore-cache/action.yml
@@ -20,7 +20,7 @@ runs:
       uses: actions/cache/restore@v4
       id: restore-cache
       with:
-        key: ${{ inputs.key }}-${{ github.ref_name }}-${{ github.sha }}
+        key: ${{ inputs.key }}-${{ runner.name }}-${{ github.ref_name }}-${{ github.sha }}
         restore-keys: ${{ inputs.key }}-${{ github.ref_name }}-
         path: |
           .cache

--- a/.github/workflows/actions/restore-cache/action.yml
+++ b/.github/workflows/actions/restore-cache/action.yml
@@ -16,12 +16,17 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Cache primary key builder
+    id: cache-primary-key-builder
+    shell: bash
+    run: |
+      echo "CACHE_PRIMARY_KEY_PREFIX=${{ inputs.key }}-${{ github.ref_name }}" >> "${GITHUB_OUTPUT}"
     - name: Restore cache
       uses: actions/cache/restore@v4
       id: restore-cache
       with:
-        key: ${{ inputs.key }}-${{ runner.name }}-${{ github.ref_name }}-${{ github.sha }}
-        restore-keys: ${{ inputs.key }}-${{ github.ref_name }}-
+        key:  ${{ steps.cache-primary-key-builder.outputs.CACHE_PRIMARY_KEY_PREFIX }}-${{ github.sha }}
+        restore-keys: ${{ steps.cache-primary-key-builder.outputs.CACHE_PRIMARY_KEY_PREFIX }}-
         path: |
           .cache
           .nx/cache

--- a/.github/workflows/actions/restore-cache/action.yml
+++ b/.github/workflows/actions/restore-cache/action.yml
@@ -17,10 +17,10 @@ runs:
   using: composite
   steps:
     - name: Cache primary key builder
-    id: cache-primary-key-builder
-    shell: bash
-    run: |
-      echo "CACHE_PRIMARY_KEY_PREFIX=${{ inputs.key }}-${{ github.ref_name }}" >> "${GITHUB_OUTPUT}"
+      id: cache-primary-key-builder
+      shell: bash
+      run: |
+        echo "CACHE_PRIMARY_KEY_PREFIX=${{ inputs.key }}-${{ github.ref_name }}" >> "${GITHUB_OUTPUT}"
     - name: Restore cache
       uses: actions/cache/restore@v4
       id: restore-cache

--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -11,12 +11,12 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  STORYBOOK_BUILD_CACHE_KEY: storybook-build-depot-ubuntu-22.04-8-runner
+  STORYBOOK_BUILD_CACHE_KEY: storybook-build-depot-ubuntu-24.04-8-runner
 
 jobs:
   front-sb-build:
     timeout-minutes: 30
-    runs-on: depot-ubuntu-22.04-8
+    runs-on: depot-ubuntu-24.04-8
     env:
       REACT_APP_SERVER_BASE_URL: http://localhost:3000
       NX_REJECT_UNKNOWN_LOCAL_CACHE: 0
@@ -67,7 +67,7 @@ jobs:
           key: ${{ steps.restore-storybook-build-cache.outputs.cache-primary-key }}
   front-sb-test:
     timeout-minutes: 30
-    runs-on: depot-ubuntu-22.04-8
+    runs-on: depot-ubuntu-24.04-8
     needs: front-sb-build
     strategy:
       fail-fast: false
@@ -122,7 +122,7 @@ jobs:
           path: packages/twenty-front/coverage/storybook/coverage-shard-${{matrix.shard}}.json
   merge-reports-and-check-coverage:
     timeout-minutes: 30
-    runs-on: depot-ubuntu-22.04-8
+    runs-on: depot-ubuntu-24.04-8
     needs: front-sb-test
     env:
       PATH_TO_COVERAGE: packages/twenty-front/coverage/storybook
@@ -163,7 +163,7 @@ jobs:
     timeout-minutes: 30
     if: contains(github.event.pull_request.labels.*.name, 'run-chromatic') || github.event_name == 'push'
     needs: front-sb-build
-    runs-on: depot-ubuntu-22.04-8
+    runs-on: depot-ubuntu-24.04-8
     env:
       REACT_APP_SERVER_BASE_URL: http://127.0.0.1:3000
       CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
@@ -203,7 +203,7 @@ jobs:
         run: npx nx run twenty-front:chromatic:ci
   front-task:
     timeout-minutes: 30
-    runs-on: depot-ubuntu-22.04-8
+    runs-on: depot-ubuntu-24.04-8
     env:
       NX_REJECT_UNKNOWN_LOCAL_CACHE: 0
       TASK_CACHE_KEY: front-task-${{ matrix.task }}

--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  STORYBOOK_BUILD_CACHE_KEY: storybook-build
+  STORYBOOK_BUILD_CACHE_KEY: storybook-build-depot-ubuntu-24.04-8-runner
 
 jobs:
   front-sb-build:

--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -21,10 +21,6 @@ jobs:
       REACT_APP_SERVER_BASE_URL: http://localhost:3000
       NX_REJECT_UNKNOWN_LOCAL_CACHE: 0
     steps:
-      - run: echo ${{runner.name}}
-      - run: echo ${{runner.arch}}
-      - run: echo ${{runner.os}}
-      - run: echo ${{runner.temp}}
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.11.0
         with:

--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  STORYBOOK_BUILD_CACHE_KEY: storybook-build-depot-ubuntu-24.04-8-runner
+  STORYBOOK_BUILD_CACHE_KEY: storybook-build
 
 jobs:
   front-sb-build:
@@ -21,6 +21,10 @@ jobs:
       REACT_APP_SERVER_BASE_URL: http://localhost:3000
       NX_REJECT_UNKNOWN_LOCAL_CACHE: 0
     steps:
+      - run: echo ${{runner.name}}
+      - run: echo ${{runner.arch}}
+      - run: echo ${{runner.os}}
+      - run: echo ${{runner.temp}}
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.11.0
         with:

--- a/.github/workflows/ci-server.yaml
+++ b/.github/workflows/ci-server.yaml
@@ -16,7 +16,7 @@ env:
 jobs:
   server-setup:
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-8
     env:
       NX_REJECT_UNKNOWN_LOCAL_CACHE: 0
     services:
@@ -115,7 +115,7 @@ jobs:
 
   server-test:
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-8
     needs: server-setup
     env:
       NX_REJECT_UNKNOWN_LOCAL_CACHE: 0
@@ -152,7 +152,7 @@ jobs:
 
   server-integration-test:
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-8
     needs: server-setup
     services:
       postgres:


### PR DESCRIPTION
## Introduction
Our GitHub Runners provider just [released](https://depot.dev/changelog/2024-07-12-ubuntu-24-04-github-actions-runner-beta) ubuntu-24.04 runners lately 

## Cache primary key factorization
Refactored the calculation of the cache-primary-key prefix to avoid duplication

## Runs
- twenty-front lint https://github.com/twentyhq/twenty/actions/runs/12770312293/job/35595272862
- twenty-server https://github.com/twentyhq/twenty/actions/runs/12770218595