### PR TITLE
Introduce SUSPENDED Activation Status

### DIFF
--- a/packages/twenty-server/src/database/typeorm/core/migrations/common/1736861823893-updateWorkspaceStatusEnum.ts
+++ b/packages/twenty-server/src/database/typeorm/core/migrations/common/1736861823893-updateWorkspaceStatusEnum.ts
@@ -1,0 +1,49 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class UpdateWorkspaceStatusEnum1736861823893
+  implements MigrationInterface
+{
+  name = 'UpdateWorkspaceStatusEnum1736861823893';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TYPE "core"."workspace_activationstatus_enum" RENAME TO "workspace_activationstatus_enum_old"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "core"."workspace_activationStatus_enum" AS ENUM('ONGOING_CREATION', 'PENDING_CREATION', 'ACTIVE', 'INACTIVE', 'SUSPENDED')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."workspace" ALTER COLUMN "activationStatus" DROP DEFAULT`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."workspace" ALTER COLUMN "activationStatus" TYPE "core"."workspace_activationStatus_enum" USING "activationStatus"::"text"::"core"."workspace_activationStatus_enum"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."workspace" ALTER COLUMN "activationStatus" SET DEFAULT 'INACTIVE'`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "core"."workspace_activationstatus_enum_old"`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "core"."workspace_activationstatus_enum_old" AS ENUM('ACTIVE', 'INACTIVE', 'ONGOING_CREATION', 'PENDING_CREATION')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."workspace" ALTER COLUMN "activationStatus" DROP DEFAULT`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."workspace" ALTER COLUMN "activationStatus" TYPE "core"."workspace_activationstatus_enum_old" USING "activationStatus"::"text"::"core"."workspace_activationstatus_enum_old"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."workspace" ALTER COLUMN "activationStatus" SET DEFAULT 'INACTIVE'`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "core"."workspace_activationStatus_enum"`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "core"."workspace_activationstatus_enum_old" RENAME TO "workspace_activationstatus_enum"`,
+    );
+  }
+}

--- a/packages/twenty-server/src/engine/core-modules/workspace/workspace.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/workspace.entity.ts
@@ -36,7 +36,6 @@ registerEnumType(WorkspaceActivationStatus, {
 
 @Entity({ name: 'workspace', schema: 'core' })
 @ObjectType('Workspace')
-@UnPagedRelation('featureFlags', () => FeatureFlagEntity, { nullable: true })
 @UnPagedRelation('billingSubscriptions', () => BillingSubscription, {
   nullable: true,
 })

--- a/packages/twenty-server/src/engine/core-modules/workspace/workspace.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/workspace.entity.ts
@@ -27,6 +27,7 @@ export enum WorkspaceActivationStatus {
   PENDING_CREATION = 'PENDING_CREATION',
   ACTIVE = 'ACTIVE',
   INACTIVE = 'INACTIVE',
+  SUSPENDED = 'SUSPENDED',
 }
 
 registerEnumType(WorkspaceActivationStatus, {
@@ -35,6 +36,7 @@ registerEnumType(WorkspaceActivationStatus, {
 
 @Entity({ name: 'workspace', schema: 'core' })
 @ObjectType('Workspace')
+@UnPagedRelation('featureFlags', () => FeatureFlagEntity, { nullable: true })
 @UnPagedRelation('billingSubscriptions', () => BillingSubscription, {
   nullable: true,
 })
@@ -109,6 +111,7 @@ export class Workspace {
   @Field(() => WorkspaceActivationStatus)
   @Column({
     type: 'enum',
+    enumName: 'workspace_activationStatus_enum',
     enum: WorkspaceActivationStatus,
     default: WorkspaceActivationStatus.INACTIVE,
   })


### PR DESCRIPTION
We are introducing a new workspace activationStatus "SUSPENDED". This status represents a workspace which is SUSPENDED (either manually by the admin or in case if IS_BILLING_ENABLED if the subscription is unpaid | canceled | paused).

We will keep making sure these workspaces are healthy but prevent the user from using it (they will be redirected to the billing page)