### PR TITLE
[CI] Refactor yarn-install composite action

### DIFF
--- a/.github/workflows/actions/yarn-install/action.yaml
+++ b/.github/workflows/actions/yarn-install/action.yaml
@@ -9,10 +9,6 @@ runs:
       run: |
         echo "ACTION_SHELL=bash" >> "${GITHUB_OUTPUT}"
         echo "NODE_VERSION=18" >> "${GITHUB_OUTPUT}"
-    - name: Logs TMP
-      shell: bash
-      run: |
-        echo ${{ toJson(steps.globals.outputs) }}
     - name: Setup Node.js and get yarn cache
       uses: actions/setup-node@v4
       with:

--- a/.github/workflows/actions/yarn-install/action.yaml
+++ b/.github/workflows/actions/yarn-install/action.yaml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Node.js and get yarn cache
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 18
         cache: yarn

--- a/.github/workflows/actions/yarn-install/action.yaml
+++ b/.github/workflows/actions/yarn-install/action.yaml
@@ -25,23 +25,14 @@ runs:
         path: |
           node_modules
           packages/*/node_modules
-    - name: Run logs
-      shell: bash
-      run: |
-        echo ${{ steps.cache-node-modules.outputs.cache-matched-key }}
-        echo ${{ steps.cache-node-modules.outputs.cache-hit }}
-        echo ${{ steps.restore-cache.outputs.cache-hit != 'true' }}
-        echo ${{ steps.restore-cache.outputs.cache-matched-key == '' }}
-        echo WTF${{ steps.restore-cache.outputs.cache-matched-key != '' }}
-        echo ${{ steps.restore-cache.outputs.cache-hit != 'true' && steps.restore-cache.outputs.cache-matched-key == '' }}
-    - name: Install Dependencies
-      if: ${{ steps.restore-cache.outputs.cache-hit != 'true' && steps.restore-cache.outputs.cache-matched-key == '' }}
+    - name: Install Dependencies ${{ steps.cache-node-modules.outputs.cache-hit != 'true' && steps.cache-node-modules.outputs.cache-matched-key == '' }}
+      if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' && steps.cache-node-modules.outputs.cache-matched-key == '' }}
       shell: ${{ steps.globals.outputs.ACTION_SHELL }}
       run: |
         yarn config set enableHardenedMode true
         yarn --immutable --check-cache
     - name: Save cache
-      if: ${{ steps.restore-cache.outputs.cache-hit != 'true' && steps.restore-cache.outputs.cache-matched-key == '' }}
+      if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' && steps.cache-node-modules.outputs.cache-matched-key == '' }}
       uses: actions/cache/save@v4
       with:
         key: ${{ steps.cache-node-modules.outputs.cache-primary-key }}

--- a/.github/workflows/actions/yarn-install/action.yaml
+++ b/.github/workflows/actions/yarn-install/action.yaml
@@ -3,24 +3,54 @@ name: Yarn Install
 runs:
   using: "composite"
   steps:
+    - name: Cache primary key builder
+      id: globals
+      shell: bash
+      run: |
+        echo "ACTION_SHELL=bash" >> "${GITHUB_OUTPUT}"
+        echo "NODE_VERSION=18" >> "${GITHUB_OUTPUT}"
+        {
+          echo 'PATH_TO_CACHE<<EOF'
+          node_modules
+          packages/*/node_modules
+          echo EOF
+        } >> "$GITHUB_OUTPUT"
+    - name: Logs TMP ${{ steps.globals.outputs.PATH_TO_CACHE }}
+      shell: bash
+      run: |
+        echo ${{ steps.globals.outputs.PATH_TO_CACHE }}
+        echo ${{ toJson(steps.globals.outputs) }}
     - name: Setup Node.js and get yarn cache
-      id: setup-node
       uses: actions/setup-node@v4
       with:
-        node-version: 18
-        cache: yarn
-    - name: Log if cache hit ${{ steps.setup-node.outputs.cache-hit }}
-      shell: bash
-      run: echo ${{ steps.setup-node.outputs.cache-hit }}
+        node-version: ${{ steps.globals.outputs.NODE_VERSION }}
+    - name: Restore node_modules
+      id: cache-node-modules
+      uses: actions/cache/restore@v4
+      with:
+        key: node_modules-cache-${{ steps.globals.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
+        path: ${{ steps.globals.outputs.PATH_TO_CACHE }}
+        # restore-keys: root-node_modules- we don't want partial hit but hashfile direct hit
+    - name: Log if cache hit ${{ steps.cache-node-modules.outputs.cache-hit }}
+      shell: ${{ steps.globals.outputs.ACTION_SHELL }}
+      run: echo ${{ steps.cache-node-modules.outputs.cache-hit }}
     - name: Install Dependencies from cache
-      shell: bash
-      if: ${{ steps.setup-node.outputs.cache-hit == 'true' }}
+      shell: ${{ steps.globals.outputs.ACTION_SHELL }}
+      if: ${{ steps.cache-node-modules.outputs.cache-hit == 'true' }}
       run: |
         yarn config set enableHardenedMode false
         yarn --mode=update-lockfile
     - name: Install Dependencies
-      if: ${{ steps.setup-node.outputs.cache-hit == 'false' }}
-      shell: bash
+      if: ${{ steps.cache-node-modules.outputs.cache-hit == 'false' }}
+      shell: ${{ steps.globals.outputs.ACTION_SHELL }}
       run: |
         yarn config set enableHardenedMode true
         yarn --immutable --check-cache
+    - name: Save cache
+      # Only searching for direct hit 
+      if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
+      uses: actions/cache/save@v4
+      with:
+        key: ${{ steps.cache-node-modules.outputs.cache-primary-key }}
+        path: ${{ steps.globals.outputs.PATH_TO_CACHE }}
+      

--- a/.github/workflows/actions/yarn-install/action.yaml
+++ b/.github/workflows/actions/yarn-install/action.yaml
@@ -17,7 +17,7 @@ runs:
       if: ${{ steps.setup-node.outputs.cache-hit == 'true' }}
       run: |
         yarn config set enableHardenedMode false
-        yarn --immutable
+        yarn --mode=update-lockfile
     - name: Install Dependencies
       if: ${{ steps.setup-node.outputs.cache-hit == 'false' }}
       shell: bash

--- a/.github/workflows/actions/yarn-install/action.yaml
+++ b/.github/workflows/actions/yarn-install/action.yaml
@@ -30,7 +30,7 @@ runs:
       shell: ${{ steps.globals.outputs.ACTION_SHELL }}
       run: |
         yarn config set enableHardenedMode true
-        yarn --immutable --check-cache
+        yarn --immutable --immutable-cache --check-cache
     - name: Save cache
       if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' && steps.cache-node-modules.outputs.cache-matched-key == '' }}
       uses: actions/cache/save@v4

--- a/.github/workflows/actions/yarn-install/action.yaml
+++ b/.github/workflows/actions/yarn-install/action.yaml
@@ -4,10 +4,14 @@ runs:
   using: "composite"
   steps:
     - name: Setup Node.js and get yarn cache
+      id: setup-node
       uses: actions/setup-node@v4
       with:
         node-version: 18
         cache: yarn
+    - name: Log if cache hit ${{ steps.setup-node.outputs.cache-hit }}
+      shell: bash
+      run: echo ${{ steps.setup-node.outputs.cache-hit }}
     - name: Install Dependencies
       shell: bash
       run: |

--- a/.github/workflows/actions/yarn-install/action.yaml
+++ b/.github/workflows/actions/yarn-install/action.yaml
@@ -17,7 +17,7 @@ runs:
       if: ${{ steps.setup-node.outputs.cache-hit == 'true' }}
       run: |
         yarn config set enableHardenedMode false
-        yarn --immutable --prefer-offline
+        yarn --immutable
     - name: Install Dependencies
       if: ${{ steps.setup-node.outputs.cache-hit == 'false' }}
       shell: bash

--- a/.github/workflows/actions/yarn-install/action.yaml
+++ b/.github/workflows/actions/yarn-install/action.yaml
@@ -12,8 +12,15 @@ runs:
     - name: Log if cache hit ${{ steps.setup-node.outputs.cache-hit }}
       shell: bash
       run: echo ${{ steps.setup-node.outputs.cache-hit }}
-    - name: Install Dependencies
+    - name: Install Dependencies from cache
       shell: bash
+      if: ${{ steps.setup-node.outputs.cache-hit == 'true' }}
       run: |
         yarn config set enableHardenedMode false
+        yarn --immutable --prefer-offline
+    - name: Install Dependencies
+      if: ${{ steps.setup-node.outputs.cache-hit == 'false' }}
+      shell: bash
+      run: |
+        yarn config set enableHardenedMode true
         yarn --immutable --check-cache

--- a/.github/workflows/actions/yarn-install/action.yaml
+++ b/.github/workflows/actions/yarn-install/action.yaml
@@ -1,4 +1,8 @@
 name: Yarn Install
+inputs:
+  node-version:
+    required: false
+    default: '18'
 
 runs:
   using: "composite"
@@ -7,10 +11,8 @@ runs:
       id: globals
       shell: bash
       run: |
-        local_node_version=18
         echo "ACTION_SHELL=bash" >> "${GITHUB_OUTPUT}"
-        echo "NODE_VERSION=$local_node_version" >> "${GITHUB_OUTPUT}"
-        echo "CACHE_KEY_PREFIX=node_modules-cache-node-$( echo $local_node_version )-${{ hashFiles('yarn.lock') }}"  >> "${GITHUB_OUTPUT}"
+        echo "CACHE_KEY_PREFIX=node_modules-cache-node-${{ inputs.node-version }}-${{ hashFiles('yarn.lock') }}"  >> "${GITHUB_OUTPUT}"
         echo 'PATH_TO_CACHE<<EOF' >> $GITHUB_OUTPUT
         echo "node_modules" >> $GITHUB_OUTPUT
         echo "packages/*/node_modules" >> $GITHUB_OUTPUT
@@ -18,7 +20,7 @@ runs:
     - name: Setup Node.js and get yarn cache
       uses: actions/setup-node@v4
       with:
-        node-version: ${{ steps.globals.outputs.NODE_VERSION }}
+        node-version: ${{ inputs.node-version }}
     - name: Restore node_modules
       id: cache-node-modules
       uses: actions/cache/restore@v4

--- a/.github/workflows/actions/yarn-install/action.yaml
+++ b/.github/workflows/actions/yarn-install/action.yaml
@@ -26,14 +26,13 @@ runs:
           packages/*/node_modules
         restore-keys: ${{ steps.globals.outputs.CACHE_KEY_PREFIX }}-
     - name: Install Dependencies
-      if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
+      if: steps.cache-node-modules.outputs.cache-hit != 'true' && steps.cache-node-modules.outputs.cache-matched-key != ''
       shell: ${{ steps.globals.outputs.ACTION_SHELL }}
       run: |
         yarn config set enableHardenedMode true
         yarn --immutable --check-cache
     - name: Save cache
-      # Only searching for direct hit 
-      if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
+      if: steps.cache-node-modules.outputs.cache-hit != 'true' && steps.cache-node-modules.outputs.cache-matched-key != ''
       uses: actions/cache/save@v4
       with:
         key: ${{ steps.cache-node-modules.outputs.cache-primary-key }}

--- a/.github/workflows/actions/yarn-install/action.yaml
+++ b/.github/workflows/actions/yarn-install/action.yaml
@@ -21,18 +21,27 @@ runs:
       uses: actions/cache/restore@v4
       with:
         key: ${{ steps.globals.outputs.CACHE_KEY_PREFIX }}-${{github.sha}}
+        restore-keys: ${{ steps.globals.outputs.CACHE_KEY_PREFIX }}-
         path: |
           node_modules
           packages/*/node_modules
-        restore-keys: ${{ steps.globals.outputs.CACHE_KEY_PREFIX }}-
+    - name: Run logs
+      shell: bash
+      run: |
+        echo ${{ steps.cache-node-modules.outputs.cache-matched-key }}
+        echo ${{ steps.cache-node-modules.outputs.cache-hit }}
+        echo ${{ steps.restore-cache.outputs.cache-hit != 'true' }}
+        echo ${{ steps.restore-cache.outputs.cache-matched-key == '' }}
+        echo WTF${{ steps.restore-cache.outputs.cache-matched-key != '' }}
+        echo ${{ steps.restore-cache.outputs.cache-hit != 'true' && steps.restore-cache.outputs.cache-matched-key == '' }}
     - name: Install Dependencies
-      if: steps.cache-node-modules.outputs.cache-hit != 'true' && steps.cache-node-modules.outputs.cache-matched-key != ''
+      if: ${{ steps.restore-cache.outputs.cache-hit != 'true' && steps.restore-cache.outputs.cache-matched-key == '' }}
       shell: ${{ steps.globals.outputs.ACTION_SHELL }}
       run: |
         yarn config set enableHardenedMode true
         yarn --immutable --check-cache
     - name: Save cache
-      if: steps.cache-node-modules.outputs.cache-hit != 'true' && steps.cache-node-modules.outputs.cache-matched-key != ''
+      if: ${{ steps.restore-cache.outputs.cache-hit != 'true' && steps.restore-cache.outputs.cache-matched-key == '' }}
       uses: actions/cache/save@v4
       with:
         key: ${{ steps.cache-node-modules.outputs.cache-primary-key }}

--- a/.github/workflows/actions/yarn-install/action.yaml
+++ b/.github/workflows/actions/yarn-install/action.yaml
@@ -10,4 +10,6 @@ runs:
         cache: yarn
     - name: Install Dependencies
       shell: bash
-      run: yarn --immutable --check-cache
+      run: |
+        yarn config set enableHardenedMode false
+        yarn --immutable --check-cache

--- a/.github/workflows/actions/yarn-install/action.yaml
+++ b/.github/workflows/actions/yarn-install/action.yaml
@@ -9,16 +9,9 @@ runs:
       run: |
         echo "ACTION_SHELL=bash" >> "${GITHUB_OUTPUT}"
         echo "NODE_VERSION=18" >> "${GITHUB_OUTPUT}"
-        {
-          echo 'PATH_TO_CACHE<<EOF'
-          echo "node_modules"
-          echo "packages/*/node_modules"
-          echo EOF
-        } >> "$GITHUB_OUTPUT"
-    - name: Logs TMP ${{ steps.globals.outputs.PATH_TO_CACHE }}
+    - name: Logs TMP
       shell: bash
       run: |
-        echo ${{ steps.globals.outputs.PATH_TO_CACHE }}
         echo ${{ toJson(steps.globals.outputs) }}
     - name: Setup Node.js and get yarn cache
       uses: actions/setup-node@v4
@@ -29,7 +22,9 @@ runs:
       uses: actions/cache/restore@v4
       with:
         key: node_modules-cache-${{ steps.globals.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
-        path: ${{ steps.globals.outputs.PATH_TO_CACHE }}
+        path: |
+          node_modules
+          packages/*/node_modules
         # restore-keys: root-node_modules- we don't want partial hit but hashfile direct hit
     - name: Log if cache hit ${{ steps.cache-node-modules.outputs.cache-hit }}
       shell: ${{ steps.globals.outputs.ACTION_SHELL }}
@@ -52,5 +47,7 @@ runs:
       uses: actions/cache/save@v4
       with:
         key: ${{ steps.cache-node-modules.outputs.cache-primary-key }}
-        path: ${{ steps.globals.outputs.PATH_TO_CACHE }}
+        path: |
+          node_modules
+          packages/*/node_modules
       

--- a/.github/workflows/actions/yarn-install/action.yaml
+++ b/.github/workflows/actions/yarn-install/action.yaml
@@ -15,7 +15,6 @@ runs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ steps.globals.outputs.NODE_VERSION }}
-    # Could use changed files to detect updates to package.json and lockfile ?
     - name: Restore node_modules
       id: cache-node-modules
       uses: actions/cache/restore@v4

--- a/.github/workflows/actions/yarn-install/action.yaml
+++ b/.github/workflows/actions/yarn-install/action.yaml
@@ -6,18 +6,8 @@ runs:
     - name: Setup Node.js and get yarn cache
       uses: actions/setup-node@v3
       with:
-        node-version: "18"
+        node-version: 18
         cache: yarn
-    - name: Cache node modules
-      id: node-modules-cache
-      uses: actions/cache@v3
-      with:
-        path: |
-          node_modules
-          packages/*/node_modules
-        key: root-node_modules-${{ hashFiles('yarn.lock') }}
-        restore-keys: root-node_modules-
     - name: Install Dependencies
       shell: bash
       run: yarn --immutable --check-cache
-      if: steps.node-modules-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/actions/yarn-install/action.yaml
+++ b/.github/workflows/actions/yarn-install/action.yaml
@@ -10,7 +10,7 @@ runs:
         local_node_version=18
         echo "ACTION_SHELL=bash" >> "${GITHUB_OUTPUT}"
         echo "NODE_VERSION=$local_node_version" >> "${GITHUB_OUTPUT}"
-        echo "CACHE_KEY_PREFIX=node_modules-cache-node-$local_node_version-${{ hashFiles('yarn.lock') }}"  >> "${GITHUB_OUTPUT}
+        echo "CACHE_KEY_PREFIX=node_modules-cache-node-$( echo $local_node_version )-${{ hashFiles('yarn.lock') }}"  >> "${GITHUB_OUTPUT}"
     - name: Setup Node.js and get yarn cache
       uses: actions/setup-node@v4
       with:

--- a/.github/workflows/actions/yarn-install/action.yaml
+++ b/.github/workflows/actions/yarn-install/action.yaml
@@ -11,8 +11,8 @@ runs:
         echo "NODE_VERSION=18" >> "${GITHUB_OUTPUT}"
         {
           echo 'PATH_TO_CACHE<<EOF'
-          node_modules
-          packages/*/node_modules
+          echo "node_modules"
+          echo "packages/*/node_modules"
           echo EOF
         } >> "$GITHUB_OUTPUT"
     - name: Logs TMP ${{ steps.globals.outputs.PATH_TO_CACHE }}

--- a/.github/workflows/actions/yarn-install/action.yaml
+++ b/.github/workflows/actions/yarn-install/action.yaml
@@ -11,6 +11,10 @@ runs:
         echo "ACTION_SHELL=bash" >> "${GITHUB_OUTPUT}"
         echo "NODE_VERSION=$local_node_version" >> "${GITHUB_OUTPUT}"
         echo "CACHE_KEY_PREFIX=node_modules-cache-node-$( echo $local_node_version )-${{ hashFiles('yarn.lock') }}"  >> "${GITHUB_OUTPUT}"
+        echo 'PATH_TO_CACHE<<EOF' >> $GITHUB_OUTPUT
+        echo "node_modules" >> $GITHUB_OUTPUT
+        echo "packages/*/node_modules" >> $GITHUB_OUTPUT
+        echo 'EOF' >> $GITHUB_OUTPUT
     - name: Setup Node.js and get yarn cache
       uses: actions/setup-node@v4
       with:
@@ -21,9 +25,7 @@ runs:
       with:
         key: ${{ steps.globals.outputs.CACHE_KEY_PREFIX }}-${{github.sha}}
         restore-keys: ${{ steps.globals.outputs.CACHE_KEY_PREFIX }}-
-        path: |
-          node_modules
-          packages/*/node_modules
+        path: ${{ steps.globals.outputs.PATH_TO_CACHE }}
     - name: Install Dependencies ${{ steps.cache-node-modules.outputs.cache-hit != 'true' && steps.cache-node-modules.outputs.cache-matched-key == '' }}
       if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' && steps.cache-node-modules.outputs.cache-matched-key == '' }}
       shell: ${{ steps.globals.outputs.ACTION_SHELL }}
@@ -35,7 +37,5 @@ runs:
       uses: actions/cache/save@v4
       with:
         key: ${{ steps.cache-node-modules.outputs.cache-primary-key }}
-        path: |
-          node_modules
-          packages/*/node_modules
+        path: ${{ steps.globals.outputs.PATH_TO_CACHE }}
       

--- a/.github/workflows/actions/yarn-install/action.yaml
+++ b/.github/workflows/actions/yarn-install/action.yaml
@@ -26,7 +26,7 @@ runs:
         key: ${{ steps.globals.outputs.CACHE_KEY_PREFIX }}-${{github.sha}}
         restore-keys: ${{ steps.globals.outputs.CACHE_KEY_PREFIX }}-
         path: ${{ steps.globals.outputs.PATH_TO_CACHE }}
-    - name: Install Dependencies ${{ steps.cache-node-modules.outputs.cache-hit != 'true' && steps.cache-node-modules.outputs.cache-matched-key == '' }}
+    - name: Install Dependencies
       if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' && steps.cache-node-modules.outputs.cache-matched-key == '' }}
       shell: ${{ steps.globals.outputs.ACTION_SHELL }}
       run: |

--- a/.github/workflows/actions/yarn-install/action.yaml
+++ b/.github/workflows/actions/yarn-install/action.yaml
@@ -13,26 +13,18 @@ runs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ steps.globals.outputs.NODE_VERSION }}
+    # Could use changed files to detect updates to package.json and lockfile ?
     - name: Restore node_modules
       id: cache-node-modules
       uses: actions/cache/restore@v4
       with:
-        key: node_modules-cache-${{ steps.globals.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
+        key: node_modules-cache-node-${{ steps.globals.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
         path: |
           node_modules
           packages/*/node_modules
         # restore-keys: root-node_modules- we don't want partial hit but hashfile direct hit
-    - name: Log if cache hit ${{ steps.cache-node-modules.outputs.cache-hit }}
-      shell: ${{ steps.globals.outputs.ACTION_SHELL }}
-      run: echo ${{ steps.cache-node-modules.outputs.cache-hit }}
-    - name: Install Dependencies from cache
-      shell: ${{ steps.globals.outputs.ACTION_SHELL }}
-      if: ${{ steps.cache-node-modules.outputs.cache-hit == 'true' }}
-      run: |
-        yarn config set enableHardenedMode false
-        yarn --mode=update-lockfile
     - name: Install Dependencies
-      if: ${{ steps.cache-node-modules.outputs.cache-hit == 'false' }}
+      if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
       shell: ${{ steps.globals.outputs.ACTION_SHELL }}
       run: |
         yarn config set enableHardenedMode true

--- a/.github/workflows/actions/yarn-install/action.yaml
+++ b/.github/workflows/actions/yarn-install/action.yaml
@@ -7,8 +7,10 @@ runs:
       id: globals
       shell: bash
       run: |
+        local_node_version=18
         echo "ACTION_SHELL=bash" >> "${GITHUB_OUTPUT}"
-        echo "NODE_VERSION=18" >> "${GITHUB_OUTPUT}"
+        echo "NODE_VERSION=$local_node_version" >> "${GITHUB_OUTPUT}"
+        echo "CACHE_KEY_PREFIX=node_modules-cache-node-$local_node_version-${{ hashFiles('yarn.lock') }}"  >> "${GITHUB_OUTPUT}
     - name: Setup Node.js and get yarn cache
       uses: actions/setup-node@v4
       with:
@@ -18,11 +20,11 @@ runs:
       id: cache-node-modules
       uses: actions/cache/restore@v4
       with:
-        key: node_modules-cache-node-${{ steps.globals.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
+        key: ${{ steps.globals.outputs.CACHE_KEY_PREFIX }}-${{github.sha}}
         path: |
           node_modules
           packages/*/node_modules
-        # restore-keys: root-node_modules- we don't want partial hit but hashfile direct hit
+        restore-keys: ${{ steps.globals.outputs.CACHE_KEY_PREFIX }}-
     - name: Install Dependencies
       if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
       shell: ${{ steps.globals.outputs.ACTION_SHELL }}

--- a/packages/twenty-front/src/index.tsx
+++ b/packages/twenty-front/src/index.tsx
@@ -5,7 +5,7 @@ import '@emotion/react';
 import { App } from '@/app/components/App';
 import 'react-loading-skeleton/dist/skeleton.css';
 import './index.css';
-
+// Trigger ci-front
 const root = ReactDOM.createRoot(
   document.getElementById('root') ?? document.body,
 );

--- a/packages/twenty-front/src/index.tsx
+++ b/packages/twenty-front/src/index.tsx
@@ -5,7 +5,7 @@ import '@emotion/react';
 import { App } from '@/app/components/App';
 import 'react-loading-skeleton/dist/skeleton.css';
 import './index.css';
-// Trigger ci-front
+
 const root = ReactDOM.createRoot(
   document.getElementById('root') ?? document.body,
 );


### PR DESCRIPTION
# Introduction
Unless I'm mistaken in the existing `yarn-install` composite action `dependencies` are cached twice.

## Cached through `setup-node`
As we're providing `yarn` value to cache inputs.
Setup node will cache the global `.yarn`
```yml
    - name: Setup Node.js and get yarn cache
      uses: actions/setup-node@v3
      with:
        node-version: 18
        cache: yarn
```

## Programmatic `node_modules` caching
We even manually still cache `node_modules` folder using:
```yml
    - name: Cache node modules
      id: node-modules-cache
      uses: actions/cache@v3
      with:
        path: |
          node_modules
          packages/*/node_modules
        key: root-node_modules-${{ hashFiles('yarn.lock') }}
        restore-keys: root-node_modules-
```
By the way it seems like that the `yarn.lock` file is useless as the restore-key pattern omits it
This could, unless I'm mistaken, leads to invalid cache restore

## Runtime
The current infra results in the following install deps logs:
```sh
Prepare all required actions
Getting action download info
Download action repository 'actions/setup-node@v3' (SHA:1a444[2](https://github.com/twentyhq/twenty/actions/runs/12770942233/job/35596946506#step:6:2)cacd436585916779262731d5b162bc6ec7)
Download action repository 'actions/cache@v[3](https://github.com/twentyhq/twenty/actions/runs/12770942233/job/35596946506#step:6:3)' (SHA:f4b3439a656ba812b8cb417d2d49f9c810103092)
Run ./.github/workflows/actions/yarn-install
Run actions/setup-node@v3
Found in cache @ /opt/hostedtoolcache/node/18.20.5/x6[4](https://github.com/twentyhq/twenty/actions/runs/12770942233/job/35596946506#step:6:4)
Environment details
/usr/local/bin/yarn --version
4.4.0
/usr/local/bin/yarn config get cacheFolder
/home/runner/.yarn/berry/cache
/usr/local/bin/yarn config get enableGlobalCache
true
Cache Size: ~421 MB (441369819 B)
/usr/bin/tar -xf /home/runner/work/_temp/883eae34-9b21-4684-96[5](https://github.com/twentyhq/twenty/actions/runs/12770942233/job/35596946506#step:6:5)8-cdb937f62965/cache.tzst -P -C /home/runner/work/twenty/twenty --use-compress-program unzstd
Cache restored successfully
Cache restored from key: node-cache-Linux-yarn-a8c18b6600f1bc685e60192f39a0a0c5c51b918829090129d3787302789547fc
Run actions/cache@v3
Cache Size: ~506 MB (530305961 B)
/usr/bin/tar -xf /home/runner/work/_temp/becd3767-ac80-4ca9-8d[21](https://github.com/twentyhq/twenty/actions/runs/12770942233/job/35596946506#step:6:23)-93fa61e3070c/cache.tzst -P -C /home/runner/work/twenty/twenty --use-compress-program unzstd
Cache restored successfully
Cache restored from key: root-node_modules-a8c18b6600f1bc685e60192f39a0a0c5c51b918829090129d378730[27](https://github.com/twentyhq/twenty/actions/runs/12770942233/job/35596946506#step:6:30)89547fc
```
Where we can see in details that a cache is hit twice.
```
Cache Size: ~421 MB (441369819 B)
Cache Size: ~506 MB (530305961 B)
```

## Suggestion
We should stick to only one deps caching mechanism.
Also caching the node_modules folder is not [recommended](https://github.com/actions/cache/blob/611465405cc89ab98caca2c42504d9289fb5f22e/examples.md#node---npm).
That's why I would factorize our caching to the `setup-node` scope only.

## The cache-primary-key crafting
Within the cache-primary-key we will inject the following metrics:
- Node version, as we're caching `node_modules` directly in this way to avoid cache desync in case we upgrade node.
- Hash of the lockfile, in this way if the lockfile comes to mutate we will re-install the deps from scratch, in this way no need to programmatically listen for `changed-files` on the `package.json` and the `lockfile`
- Strict installation with `check-cache` and `enableHardenedMode` to true and obviously the `--immutable` flag ( note adding the `--immutable-cache` by principle even if on paper is overkill as a cache restoration and install should never occurs )