### PR TITLE
Fix workflow run output empty

### DIFF
--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/mail-sender/exceptions/send-email-action.exception.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/mail-sender/exceptions/send-email-action.exception.ts
@@ -10,4 +10,5 @@ export class SendEmailActionException extends CustomException {
 export enum SendEmailActionExceptionCode {
   PROVIDER_NOT_SUPPORTED = 'PROVIDER_NOT_SUPPORTED',
   CONNECTED_ACCOUNT_NOT_FOUND = 'CONNECTED_ACCOUNT_NOT_FOUND',
+  INVALID_EMAIL = 'INVALID_EMAIL',
 }

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/mail-sender/send-email.workflow-action.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/mail-sender/send-email.workflow-action.ts
@@ -80,47 +80,43 @@ export class SendEmailWorkflowAction implements WorkflowAction {
     );
     const { email, body, subject } = workflowActionInput;
 
-    try {
-      const emailSchema = z.string().trim().email('Invalid email');
+    const emailSchema = z.string().trim().email('Invalid email');
 
-      const result = emailSchema.safeParse(email);
+    const result = emailSchema.safeParse(email);
 
-      if (!result.success) {
-        this.logger.warn(`Email '${email}' invalid`);
+    if (!result.success) {
+      this.logger.warn(`Email '${email}' invalid`);
 
-        return { result: { success: false } };
-      }
-
-      const window = new JSDOM('').window;
-      const purify = DOMPurify(window);
-      const safeBody = purify.sanitize(body || '');
-      const safeSubject = purify.sanitize(subject || '');
-
-      const message = [
-        `To: ${email}`,
-        `Subject: ${safeSubject || ''}`,
-        'MIME-Version: 1.0',
-        'Content-Type: text/plain; charset="UTF-8"',
-        '',
-        safeBody,
-      ].join('\n');
-
-      const encodedMessage = Buffer.from(message).toString('base64');
-
-      await emailProvider.users.messages.send({
-        userId: 'me',
-        requestBody: {
-          raw: encodedMessage,
-        },
-      });
-
-      this.logger.log(`Email sent successfully`);
-
-      return {
-        result: { success: true } satisfies WorkflowSendEmailStepOutputSchema,
-      };
-    } catch (error) {
-      return { error };
+      return { result: { success: false } };
     }
+
+    const window = new JSDOM('').window;
+    const purify = DOMPurify(window);
+    const safeBody = purify.sanitize(body || '');
+    const safeSubject = purify.sanitize(subject || '');
+
+    const message = [
+      `To: ${email}`,
+      `Subject: ${safeSubject || ''}`,
+      'MIME-Version: 1.0',
+      'Content-Type: text/plain; charset="UTF-8"',
+      '',
+      safeBody,
+    ].join('\n');
+
+    const encodedMessage = Buffer.from(message).toString('base64');
+
+    await emailProvider.users.messages.send({
+      userId: 'me',
+      requestBody: {
+        raw: encodedMessage,
+      },
+    });
+
+    this.logger.log(`Email sent successfully`);
+
+    return {
+      result: { success: true } satisfies WorkflowSendEmailStepOutputSchema,
+    };
   }
 }

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/mail-sender/send-email.workflow-action.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/mail-sender/send-email.workflow-action.ts
@@ -85,9 +85,10 @@ export class SendEmailWorkflowAction implements WorkflowAction {
     const result = emailSchema.safeParse(email);
 
     if (!result.success) {
-      this.logger.warn(`Email '${email}' invalid`);
-
-      return { result: { success: false } };
+      throw new SendEmailActionException(
+        `Email '${email}' invalid`,
+        SendEmailActionExceptionCode.INVALID_EMAIL,
+      );
     }
 
     const window = new JSDOM('').window;

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workspace-services/workflow-executor.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workspace-services/workflow-executor.workspace-service.ts
@@ -49,7 +49,6 @@ export class WorkflowExecutorWorkspaceService {
     try {
       result = await workflowAction.execute(actionPayload);
     } catch (error) {
-      this.logger.error(error);
       result = {
         error: {
           errorType: error.name,

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workspace-services/workflow-executor.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workspace-services/workflow-executor.workspace-service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 
 import {
   WorkflowRunOutput,
@@ -6,6 +6,7 @@ import {
 } from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
 import { WorkflowActionFactory } from 'src/modules/workflow/workflow-executor/factories/workflow-action.factory';
 import { resolveInput } from 'src/modules/workflow/workflow-executor/utils/variable-resolver.util';
+import { WorkflowActionResult } from 'src/modules/workflow/workflow-executor/workflow-actions/types/workflow-action-result.type';
 import { WorkflowAction } from 'src/modules/workflow/workflow-executor/workflow-actions/types/workflow-action.type';
 
 const MAX_RETRIES_ON_FAILURE = 3;
@@ -17,6 +18,7 @@ export type WorkflowExecutorOutput = {
 
 @Injectable()
 export class WorkflowExecutorWorkspaceService {
+  private readonly logger = new Logger(WorkflowExecutorWorkspaceService.name);
   constructor(private readonly workflowActionFactory: WorkflowActionFactory) {}
 
   async execute({
@@ -42,7 +44,20 @@ export class WorkflowExecutorWorkspaceService {
 
     const actionPayload = resolveInput(step.settings.input, context);
 
-    const result = await workflowAction.execute(actionPayload);
+    let result: WorkflowActionResult;
+
+    try {
+      result = await workflowAction.execute(actionPayload);
+    } catch (error) {
+      this.logger.error(error);
+      result = {
+        error: {
+          errorType: error.name,
+          errorMessage: error.message,
+          stackTrace: error.stack,
+        },
+      };
+    }
 
     const stepOutput = output.steps[step.id];
 

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/jobs/run-workflow.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/jobs/run-workflow.job.ts
@@ -69,7 +69,6 @@ export class RunWorkflowJob {
         },
       );
     } catch (error) {
-      this.logger.error(`Error running workflow`, error);
       await this.workflowRunWorkspaceService.endWorkflowRun(
         workflowRunId,
         WorkflowRunStatus.FAILED,


### PR DESCRIPTION
- catch error on action execution. We will log the error and return it in the step
- catch error on workflow run
- remove the catch in the action. All actions should simply throw and let the executor do the job

<img width="1512" alt="Capture d’écran 2025-01-14 à 17 35 53" src="https://github.com/user-attachments/assets/dcf79567-a309-45f1-a640-c50b7ac4769b" />
