### PR TITLE
Fix delete workspace-member avatar

### DIFF
--- a/packages/twenty-front/src/modules/settings/profile/components/ProfilePictureUploader.tsx
+++ b/packages/twenty-front/src/modules/settings/profile/components/ProfilePictureUploader.tsx
@@ -91,7 +91,7 @@ export const ProfilePictureUploader = () => {
       await updateOneRecord({
         idToUpdate: currentWorkspaceMember?.id,
         updateOneRecordInput: {
-          avatarUrl: null,
+          avatarUrl: '',
         },
       });
 

--- a/packages/twenty-front/src/modules/ui/input/components/ImageInput.tsx
+++ b/packages/twenty-front/src/modules/ui/input/components/ImageInput.tsx
@@ -172,7 +172,7 @@ export const ImageInput = ({
           />
         </StyledButtonContainer>
         <StyledText>
-          We support your best PNGs, JPEGs and GIFs portraits under 10MB
+          We support your square PNGs, JPEGs and GIFs under 10MB
         </StyledText>
         {errorMessage && <StyledErrorText>{errorMessage}</StyledErrorText>}
       </StyledContent>


### PR DESCRIPTION
## Context
avatarUrl is a TEXT field type so non nullable, which means if we try to run a mutation with null it will either fail or be ignored. Here this is the second option, done in sanitizeRecordInput where when a fieldMetadata has isNullable=false and the value is null, we return undefined. This caused the mutation to send an empty input and not remove the avatar