### PR TITLE
[CI] Always save cache agnostically of the actions/restore cache-hit output

### DIFF
--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -61,7 +61,7 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         run: npx nx storybook:build twenty-front
       - name: Save storybook build cache
-        if: steps.changed-files.outputs.any_changed == 'true' && steps.restore-storybook-build-cache.outputs.cache-hit != 'true'
+        if: steps.changed-files.outputs.any_changed == 'true'
         uses: ./.github/workflows/actions/save-cache
         with:
           key: ${{ steps.restore-storybook-build-cache.outputs.cache-primary-key }}
@@ -252,7 +252,7 @@ jobs:
           tag: scope:frontend
           tasks: ${{ matrix.task }}
       - name: Save ${{ matrix.task }} cache
-        if: steps.changed-files.outputs.any_changed == 'true' && steps.restore-task-cache.outputs.cache-hit != 'true'
+        if: steps.changed-files.outputs.any_changed == 'true'
         uses: ./.github/workflows/actions/save-cache
         with:
           key: ${{ steps.restore-task-cache.outputs.cache-primary-key }}

--- a/.github/workflows/ci-server.yaml
+++ b/.github/workflows/ci-server.yaml
@@ -108,7 +108,7 @@ jobs:
             exit 1
           fi
       - name: Save server setup
-        if: steps.changed-files.outputs.any_changed == 'true' && steps.restore-server-setup-cache.outputs.cache-hit != 'true'
+        if: steps.changed-files.outputs.any_changed == 'true'
         uses: ./.github/workflows/actions/save-cache
         with:
           key: ${{ steps.restore-server-setup-cache.outputs.cache-primary-key }}


### PR DESCRIPTION
## Motivations
This is not because we've hit the `actions/cache/restore` cache that NX won't be re-building sub commands.
Which means the grain to save or not the cache should be extracted from nx sub commands and not from the `actions/cache` outputs.

We should investigate on the way to retrieve this granularity level

From the moment we will be saving everything, which could result sometimes in duplicating cache instances.
We should keep in mind that our cache occurrences have a ~~1 day retention date~~ default retention date of 14 days from [depot-dev cache](https://depot.dev/docs/cache/overview#cache-retention) docs, is low cost and pretty fast to perform