### PR TITLE
[test(auth)]: Add unit tests for useSignInUpForm hook

### DIFF
--- a/packages/twenty-front/src/modules/auth/sign-in-up/hooks/__tests__/useSignInUpForm.test.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/hooks/__tests__/useSignInUpForm.test.tsx
@@ -1,0 +1,73 @@
+import { RecoilRoot, useSetRecoilState } from 'recoil';
+import { renderHook } from '@testing-library/react';
+import { useSignInUpForm } from '@/auth/sign-in-up/hooks/useSignInUpForm';
+import { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { isDeveloperDefaultSignInPrefilledState } from '@/client-config/states/isDeveloperDefaultSignInPrefilledState';
+
+describe('useSignInUpForm', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should initialize the form with default values', async () => {
+    const { result } = renderHook(() => useSignInUpForm(), {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <MemoryRouter>
+          <RecoilRoot>{children}</RecoilRoot>
+        </MemoryRouter>
+      ),
+    });
+    expect(result.current.form).toBeDefined();
+  });
+
+  // it('should set prefilled email if available', () => {
+  //   renderHook(() => useSignInUpForm());
+  //   expect(mockSetValue).toHaveBeenCalledWith('email', mockPrefilledEmail);
+  // });
+
+  it('should not prefill sign-in developer defaults when state is false', () => {
+    const { result } = renderHook(() => useSignInUpForm(), {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <MemoryRouter initialEntries={['?email=test@test.com']}>
+          <RecoilRoot>{children}</RecoilRoot>
+        </MemoryRouter>
+      ),
+    });
+
+    expect(result.current.form.getValues()).toEqual({
+      exist: false,
+      email: 'test@test.com',
+      password: '',
+      captchaToken: '',
+    });
+  });
+  //
+  it('should prefill developer defaults when the state is true', () => {
+    const { result } = renderHook(
+      () => {
+        const setIsDeveloperDefaultSignInPrefilledState = useSetRecoilState(
+          isDeveloperDefaultSignInPrefilledState,
+        );
+
+        setIsDeveloperDefaultSignInPrefilledState(true);
+
+        return useSignInUpForm();
+      },
+      {
+        wrapper: ({ children }: { children: ReactNode }) => (
+          <MemoryRouter initialEntries={['?email=test@test.com']}>
+            <RecoilRoot>{children}</RecoilRoot>
+          </MemoryRouter>
+        ),
+      },
+    );
+
+    expect(result.current.form.getValues()).toEqual({
+      exist: false,
+      email: 'test@test.com',
+      password: 'Applecar2025',
+      captchaToken: '',
+    });
+  });
+});

--- a/packages/twenty-front/src/modules/auth/sign-in-up/hooks/__tests__/useSignInUpForm.test.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/hooks/__tests__/useSignInUpForm.test.tsx
@@ -21,11 +21,6 @@ describe('useSignInUpForm', () => {
     expect(result.current.form).toBeDefined();
   });
 
-  // it('should set prefilled email if available', () => {
-  //   renderHook(() => useSignInUpForm());
-  //   expect(mockSetValue).toHaveBeenCalledWith('email', mockPrefilledEmail);
-  // });
-
   it('should not prefill sign-in developer defaults when state is false', () => {
     const { result } = renderHook(() => useSignInUpForm(), {
       wrapper: ({ children }: { children: ReactNode }) => (
@@ -42,7 +37,7 @@ describe('useSignInUpForm', () => {
       captchaToken: '',
     });
   });
-  //
+
   it('should prefill developer defaults when the state is true', () => {
     const { result } = renderHook(
       () => {


### PR DESCRIPTION
Introduce unit tests to validate the behavior of the useSignInUpForm hook. Tests cover default initialization, handling of developer defaults, and prefilled values based on state.