### PR TITLE
Refetch query on draft creation

### DIFF
--- a/packages/twenty-front/src/generated/graphql.tsx
+++ b/packages/twenty-front/src/generated/graphql.tsx
@@ -1,5 +1,5 @@
-import * as Apollo from '@apollo/client';
 import { gql } from '@apollo/client';
+import * as Apollo from '@apollo/client';
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
@@ -1532,7 +1532,8 @@ export enum WorkspaceActivationStatus {
   Active = 'ACTIVE',
   Inactive = 'INACTIVE',
   OngoingCreation = 'ONGOING_CREATION',
-  PendingCreation = 'PENDING_CREATION'
+  PendingCreation = 'PENDING_CREATION',
+  Suspended = 'SUSPENDED'
 }
 
 export type WorkspaceEdge = {

--- a/packages/twenty-front/src/modules/workflow/hooks/useCreateDraftFromWorkflowVersion.ts
+++ b/packages/twenty-front/src/modules/workflow/hooks/useCreateDraftFromWorkflowVersion.ts
@@ -1,3 +1,5 @@
+import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
+import { useFindManyRecordsQuery } from '@/object-record/hooks/useFindManyRecordsQuery';
 import { useApolloClient } from '@apollo/client';
 import {
   CreateDraftFromWorkflowVersionInput,
@@ -11,10 +13,33 @@ export const useCreateDraftFromWorkflowVersion = () => {
     client: apolloClient,
   });
 
+  const { findManyRecordsQuery: findManyWorkflowsQuery } =
+    useFindManyRecordsQuery({
+      objectNameSingular: CoreObjectNameSingular.Workflow,
+      recordGqlFields: {
+        id: true,
+        name: true,
+        statuses: true,
+        lastPublishedVersionId: true,
+        versions: true,
+      },
+    });
+
   const createDraftFromWorkflowVersion = async (
     input: CreateDraftFromWorkflowVersionInput,
   ) => {
-    await mutate({ variables: { input } });
+    await mutate({
+      variables: { input },
+      awaitRefetchQueries: true,
+      refetchQueries: [
+        {
+          query: findManyWorkflowsQuery,
+          variables: {
+            id: input.workflowId,
+          },
+        },
+      ],
+    });
   };
 
   return {


### PR DESCRIPTION
After hitting use as draft, we redirect the user to the workflow page. If the user already accessed that page, the workflow and its current version will be stored in cache. So we also need to update that cache.

I tried to update it manually but it was more complex than expected. Steps and trigger are not fully defined objects.

I ended with a simple refetch query that I wanted to avoid but that is at least fully working with minimum logic.