### PR TITLE
Treat suspended workspace as workspaces that need to be synced

### DIFF
--- a/packages/twenty-front/jest.config.ts
+++ b/packages/twenty-front/jest.config.ts
@@ -24,7 +24,7 @@ const jestConfig: JestConfigWithTsJest = {
   extensionsToTreatAsEsm: ['.ts', '.tsx'],
   coverageThreshold: {
     global: {
-      statements: 58,
+      statements: 57,
       lines: 55,
       functions: 47,
     },

--- a/packages/twenty-front/src/generated-metadata/graphql.ts
+++ b/packages/twenty-front/src/generated-metadata/graphql.ts
@@ -1784,11 +1784,11 @@ export type WorkspaceBillingSubscriptionsArgs = {
 };
 
 export enum WorkspaceActivationStatus {
-  Active = 'ACTIVE',
-  Inactive = 'INACTIVE',
-  OngoingCreation = 'ONGOING_CREATION',
-  PendingCreation = 'PENDING_CREATION',
-  Suspended = 'SUSPENDED'
+  Active = 'Active',
+  Inactive = 'Inactive',
+  OngoingCreation = 'OngoingCreation',
+  PendingCreation = 'PendingCreation',
+  Suspended = 'Suspended'
 }
 
 export type WorkspaceEdge = {

--- a/packages/twenty-front/src/generated-metadata/graphql.ts
+++ b/packages/twenty-front/src/generated-metadata/graphql.ts
@@ -1784,11 +1784,11 @@ export type WorkspaceBillingSubscriptionsArgs = {
 };
 
 export enum WorkspaceActivationStatus {
-  Active = 'ACTIVE',
-  Inactive = 'INACTIVE',
-  OngoingCreation = 'ONGOING_CREATION',
-  PendingCreation = 'PENDING_CREATION',
-  Suspended = 'SUSPENDED'
+  ACTIVE = 'ACTIVE',
+  INACTIVE = 'INACTIVE',
+  ONGOING_CREATION = 'ONGOING_CREATION',
+  PENDING_CREATION = 'PENDING_CREATION',
+  SUSPENDED = 'SUSPENDED'
 }
 
 export type WorkspaceEdge = {

--- a/packages/twenty-front/src/generated-metadata/graphql.ts
+++ b/packages/twenty-front/src/generated-metadata/graphql.ts
@@ -1784,11 +1784,11 @@ export type WorkspaceBillingSubscriptionsArgs = {
 };
 
 export enum WorkspaceActivationStatus {
-  Active = 'Active',
-  Inactive = 'Inactive',
-  OngoingCreation = 'OngoingCreation',
-  PendingCreation = 'PendingCreation',
-  Suspended = 'Suspended'
+  Active = 'ACTIVE',
+  Inactive = 'INACTIVE',
+  OngoingCreation = 'ONGOING_CREATION',
+  PendingCreation = 'PENDING_CREATION',
+  Suspended = 'SUSPENDED'
 }
 
 export type WorkspaceEdge = {

--- a/packages/twenty-front/src/generated/graphql.tsx
+++ b/packages/twenty-front/src/generated/graphql.tsx
@@ -1,5 +1,5 @@
-import * as Apollo from '@apollo/client';
 import { gql } from '@apollo/client';
+import * as Apollo from '@apollo/client';
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
@@ -1556,11 +1556,11 @@ export type WorkspaceBillingSubscriptionsArgs = {
 };
 
 export enum WorkspaceActivationStatus {
-  Active = 'ACTIVE',
-  Inactive = 'INACTIVE',
-  OngoingCreation = 'ONGOING_CREATION',
-  PendingCreation = 'PENDING_CREATION',
-  Suspended = 'SUSPENDED'
+  Active = 'Active',
+  Inactive = 'Inactive',
+  OngoingCreation = 'OngoingCreation',
+  PendingCreation = 'PendingCreation',
+  Suspended = 'Suspended'
 }
 
 export type WorkspaceEdge = {
@@ -2100,7 +2100,7 @@ export type UpdateBillingSubscriptionMutation = { __typename?: 'Mutation', updat
 export type GetClientConfigQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetClientConfigQuery = { __typename?: 'Query', clientConfig: { __typename?: 'ClientConfig', signInPrefilled: boolean, isMultiWorkspaceEnabled: boolean, defaultSubdomain?: string | null, frontDomain: string, debugMode: boolean, analyticsEnabled: boolean, chromeExtensionId?: string | null, canManageFeatureFlags: boolean, billing: { __typename?: 'Billing', isBillingEnabled: boolean, billingUrl?: string | null, trialPeriods: Array<{ __typename?: 'TrialPeriodDTO', duration: number, isCreditCardRequired: boolean }> }, authProviders: { __typename?: 'AuthProviders', google: boolean, password: boolean, microsoft: boolean, sso: Array<{ __typename?: 'SSOIdentityProvider', id: string, name: string, type: IdentityProviderType, status: SsoIdentityProviderStatus, issuer: string }> }, support: { __typename?: 'Support', supportDriver: string, supportFrontChatId?: string | null }, sentry: { __typename?: 'Sentry', dsn?: string | null, environment?: string | null, release?: string | null }, captcha: { __typename?: 'Captcha', provider?: CaptchaDriverType | null, siteKey?: string | null }, api: { __typename?: 'ApiConfig', mutationMaximumAffectedRecords: number } } };
+export type GetClientConfigQuery = { __typename?: 'Query', clientConfig: { __typename?: 'ClientConfig', signInPrefilled: boolean, isMultiWorkspaceEnabled: boolean, isEmailVerificationRequired: boolean, defaultSubdomain?: string | null, frontDomain: string, debugMode: boolean, analyticsEnabled: boolean, chromeExtensionId?: string | null, canManageFeatureFlags: boolean, billing: { __typename?: 'Billing', isBillingEnabled: boolean, billingUrl?: string | null, trialPeriods: Array<{ __typename?: 'TrialPeriodDTO', duration: number, isCreditCardRequired: boolean }> }, authProviders: { __typename?: 'AuthProviders', google: boolean, password: boolean, microsoft: boolean, sso: Array<{ __typename?: 'SSOIdentityProvider', id: string, name: string, type: IdentityProviderType, status: SsoIdentityProviderStatus, issuer: string }> }, support: { __typename?: 'Support', supportDriver: string, supportFrontChatId?: string | null }, sentry: { __typename?: 'Sentry', dsn?: string | null, environment?: string | null, release?: string | null }, captcha: { __typename?: 'Captcha', provider?: CaptchaDriverType | null, siteKey?: string | null }, api: { __typename?: 'ApiConfig', mutationMaximumAffectedRecords: number } } };
 
 export type SkipSyncEmailOnboardingStepMutationVariables = Exact<{ [key: string]: never; }>;
 

--- a/packages/twenty-front/src/generated/graphql.tsx
+++ b/packages/twenty-front/src/generated/graphql.tsx
@@ -1556,11 +1556,11 @@ export type WorkspaceBillingSubscriptionsArgs = {
 };
 
 export enum WorkspaceActivationStatus {
-  Active = 'Active',
-  Inactive = 'Inactive',
-  OngoingCreation = 'OngoingCreation',
-  PendingCreation = 'PendingCreation',
-  Suspended = 'Suspended'
+  Active = 'ACTIVE',
+  Inactive = 'INACTIVE',
+  OngoingCreation = 'ONGOING_CREATION',
+  PendingCreation = 'PENDING_CREATION',
+  Suspended = 'SUSPENDED'
 }
 
 export type WorkspaceEdge = {

--- a/packages/twenty-front/src/generated/graphql.tsx
+++ b/packages/twenty-front/src/generated/graphql.tsx
@@ -1,5 +1,5 @@
-import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
+import { gql } from '@apollo/client';
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
@@ -1556,11 +1556,11 @@ export type WorkspaceBillingSubscriptionsArgs = {
 };
 
 export enum WorkspaceActivationStatus {
-  Active = 'ACTIVE',
-  Inactive = 'INACTIVE',
-  OngoingCreation = 'ONGOING_CREATION',
-  PendingCreation = 'PENDING_CREATION',
-  Suspended = 'SUSPENDED'
+  ACTIVE = 'ACTIVE',
+  INACTIVE = 'INACTIVE',
+  ONGOING_CREATION = 'ONGOING_CREATION',
+  PENDING_CREATION = 'PENDING_CREATION',
+  SUSPENDED = 'SUSPENDED'
 }
 
 export type WorkspaceEdge = {

--- a/packages/twenty-front/src/hooks/__tests__/usePageChangeEffectNavigateLocation.test.ts
+++ b/packages/twenty-front/src/hooks/__tests__/usePageChangeEffectNavigateLocation.test.ts
@@ -85,6 +85,15 @@ const testCases = [
   { loc: AppPath.ResetPassword, isLoggedIn: true, isWorkspaceSuspended: false, onboardingStatus: OnboardingStatus.InviteTeam, res: undefined },
   { loc: AppPath.ResetPassword, isLoggedIn: true, isWorkspaceSuspended: false, onboardingStatus: OnboardingStatus.Completed, res: undefined },
 
+  { loc: AppPath.VerifyEmail, isLoggedIn: true, isWorkspaceSuspended: false, onboardingStatus: OnboardingStatus.PlanRequired, res: undefined },
+  { loc: AppPath.VerifyEmail, isLoggedIn: true, isWorkspaceSuspended: true, onboardingStatus: OnboardingStatus.Completed, res: undefined },
+  { loc: AppPath.VerifyEmail, isLoggedIn: false, isWorkspaceSuspended: false, onboardingStatus: undefined, res: undefined },
+  { loc: AppPath.VerifyEmail, isLoggedIn: true, isWorkspaceSuspended: false, onboardingStatus: OnboardingStatus.WorkspaceActivation, res: undefined },
+  { loc: AppPath.VerifyEmail, isLoggedIn: true, isWorkspaceSuspended: false, onboardingStatus: OnboardingStatus.ProfileCreation, res: undefined },
+  { loc: AppPath.VerifyEmail, isLoggedIn: true, isWorkspaceSuspended: false, onboardingStatus: OnboardingStatus.SyncEmail, res: undefined },
+  { loc: AppPath.VerifyEmail, isLoggedIn: true, isWorkspaceSuspended: false, onboardingStatus: OnboardingStatus.InviteTeam, res: undefined },
+  { loc: AppPath.VerifyEmail, isLoggedIn: true, isWorkspaceSuspended: false, onboardingStatus: OnboardingStatus.Completed, res: undefined },
+
   { loc: AppPath.CreateWorkspace, isLoggedIn: true, isWorkspaceSuspended: false, onboardingStatus: OnboardingStatus.PlanRequired, res: AppPath.PlanRequired },
   { loc: AppPath.CreateWorkspace, isLoggedIn: true, isWorkspaceSuspended: true, onboardingStatus: OnboardingStatus.Completed, res: '/settings/billing' },
   { loc: AppPath.CreateWorkspace, isLoggedIn: false, isWorkspaceSuspended: false, onboardingStatus: undefined, res: AppPath.SignInUp },

--- a/packages/twenty-front/src/modules/billing/constants/BillingCheckoutSessionDefaultValue.ts
+++ b/packages/twenty-front/src/modules/billing/constants/BillingCheckoutSessionDefaultValue.ts
@@ -1,7 +1,7 @@
 import { BillingCheckoutSession } from '@/auth/types/billingCheckoutSession.type';
 import {
-    BillingPlanKey,
-    SubscriptionInterval,
+  BillingPlanKey,
+  SubscriptionInterval,
 } from '~/generated-metadata/graphql';
 
 export const BILLING_CHECKOUT_SESSION_DEFAULT_VALUE: BillingCheckoutSession = {

--- a/packages/twenty-front/src/modules/object-metadata/components/ObjectMetadataItemsLoadEffect.tsx
+++ b/packages/twenty-front/src/modules/object-metadata/components/ObjectMetadataItemsLoadEffect.tsx
@@ -5,7 +5,7 @@ import { currentUserState } from '@/auth/states/currentUserState';
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { useLoadMockedObjectMetadataItems } from '@/object-metadata/hooks/useLoadMockedObjectMetadataItems';
 import { useRefreshObjectMetadataItems } from '@/object-metadata/hooks/useRefreshObjectMetadataItem';
-import { WorkspaceActivationStatus } from '~/generated/graphql';
+import { isWorkspaceActiveOrSuspended } from 'twenty-shared';
 import { isUndefinedOrNull } from '~/utils/isUndefinedOrNull';
 
 export const ObjectMetadataItemsLoadEffect = () => {
@@ -18,7 +18,7 @@ export const ObjectMetadataItemsLoadEffect = () => {
   useEffect(() => {
     if (
       isUndefinedOrNull(currentUser) ||
-      currentWorkspace?.activationStatus !== WorkspaceActivationStatus.Active
+      !isWorkspaceActiveOrSuspended(currentWorkspace)
     ) {
       loadMockedObjectMetadataItems();
     } else {
@@ -26,7 +26,7 @@ export const ObjectMetadataItemsLoadEffect = () => {
     }
   }, [
     currentUser,
-    currentWorkspace?.activationStatus,
+    currentWorkspace,
     loadMockedObjectMetadataItems,
     refreshObjectMetadataItems,
   ]);

--- a/packages/twenty-front/src/modules/object-metadata/hooks/__tests__/useColumnDefinitionsFromFieldMetadata.test.ts
+++ b/packages/twenty-front/src/modules/object-metadata/hooks/__tests__/useColumnDefinitionsFromFieldMetadata.test.ts
@@ -16,7 +16,7 @@ const Wrapper = getJestMetadataAndApolloMocksWrapper({
       featureFlags: [],
       allowImpersonation: false,
       subdomain: 'test',
-      activationStatus: WorkspaceActivationStatus.Active,
+      activationStatus: WorkspaceActivationStatus.ACTIVE,
       hasValidEntrepriseKey: false,
       metadataVersion: 1,
       isPublicInviteLinkEnabled: false,

--- a/packages/twenty-front/src/modules/object-metadata/hooks/useObjectNamePluralFromSingular.ts
+++ b/packages/twenty-front/src/modules/object-metadata/hooks/useObjectNamePluralFromSingular.ts
@@ -2,7 +2,7 @@ import { useRecoilValue } from 'recoil';
 
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { objectMetadataItemFamilySelector } from '@/object-metadata/states/objectMetadataItemFamilySelector';
-import { WorkspaceActivationStatus } from '~/generated/graphql';
+import { isWorkspaceActiveOrSuspended } from 'twenty-shared';
 import { generatedMockObjectMetadataItems } from '~/testing/mock-data/generatedMockObjectMetadataItems';
 import { isDefined } from '~/utils/isDefined';
 
@@ -20,7 +20,7 @@ export const useObjectNamePluralFromSingular = ({
     }),
   );
 
-  if (currentWorkspace?.activationStatus !== WorkspaceActivationStatus.Active) {
+  if (!isWorkspaceActiveOrSuspended(currentWorkspace)) {
     objectMetadataItem =
       generatedMockObjectMetadataItems.find(
         (objectMetadataItem) =>

--- a/packages/twenty-front/src/modules/object-metadata/hooks/useObjectNameSingularFromPlural.ts
+++ b/packages/twenty-front/src/modules/object-metadata/hooks/useObjectNameSingularFromPlural.ts
@@ -2,7 +2,7 @@ import { useRecoilValue } from 'recoil';
 
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { objectMetadataItemFamilySelector } from '@/object-metadata/states/objectMetadataItemFamilySelector';
-import { WorkspaceActivationStatus } from '~/generated/graphql';
+import { isWorkspaceActiveOrSuspended } from 'twenty-shared';
 import { generatedMockObjectMetadataItems } from '~/testing/mock-data/generatedMockObjectMetadataItems';
 import { isDefined } from '~/utils/isDefined';
 
@@ -20,7 +20,7 @@ export const useObjectNameSingularFromPlural = ({
     }),
   );
 
-  if (currentWorkspace?.activationStatus !== WorkspaceActivationStatus.Active) {
+  if (!isWorkspaceActiveOrSuspended(currentWorkspace)) {
     objectMetadataItem =
       generatedMockObjectMetadataItems.find(
         (objectMetadataItem) =>

--- a/packages/twenty-front/src/modules/object-record/record-index/hooks/useLazyLoadRecordIndexTable.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/hooks/useLazyLoadRecordIndexTable.ts
@@ -7,7 +7,7 @@ import { useFindManyRecordIndexTableParams } from '@/object-record/record-index/
 import { useRecordTableRecordGqlFields } from '@/object-record/record-index/hooks/useRecordTableRecordGqlFields';
 import { useRecordTable } from '@/object-record/record-table/hooks/useRecordTable';
 import { SIGN_IN_BACKGROUND_MOCK_COMPANIES } from '@/sign-in-background-mock/constants/SignInBackgroundMockCompanies';
-import { WorkspaceActivationStatus } from '~/generated/graphql';
+import { isWorkspaceActiveOrSuspended } from 'twenty-shared';
 
 export const useLazyLoadRecordIndexTable = (objectNameSingular: string) => {
   const { objectMetadataItem } = useObjectMetadataItem({
@@ -44,10 +44,9 @@ export const useLazyLoadRecordIndexTable = (objectNameSingular: string) => {
 
   return {
     findManyRecords,
-    records:
-      currentWorkspace?.activationStatus === WorkspaceActivationStatus.Active
-        ? records
-        : SIGN_IN_BACKGROUND_MOCK_COMPANIES,
+    records: isWorkspaceActiveOrSuspended(currentWorkspace)
+      ? records
+      : SIGN_IN_BACKGROUND_MOCK_COMPANIES,
     totalCount: totalCount,
     loading,
     fetchMoreRecords,

--- a/packages/twenty-front/src/modules/workspace/hooks/__tests__/useSubscriptionStatus.test.ts
+++ b/packages/twenty-front/src/modules/workspace/hooks/__tests__/useSubscriptionStatus.test.ts
@@ -4,19 +4,19 @@ import { RecoilRoot, useSetRecoilState } from 'recoil';
 import { v4 } from 'uuid';
 
 import {
-  CurrentWorkspace,
-  currentWorkspaceState,
+    CurrentWorkspace,
+    currentWorkspaceState,
 } from '@/auth/states/currentWorkspaceState';
 import { useSubscriptionStatus } from '@/workspace/hooks/useSubscriptionStatus';
 import {
-  SubscriptionStatus,
-  WorkspaceActivationStatus,
+    SubscriptionStatus,
+    WorkspaceActivationStatus,
 } from '~/generated/graphql';
 
 const currentWorkspace = {
   id: '1',
   currentBillingSubscription: { status: SubscriptionStatus.Incomplete },
-  activationStatus: WorkspaceActivationStatus.Active,
+  activationStatus: WorkspaceActivationStatus.ACTIVE,
   allowImpersonation: true,
 } as CurrentWorkspace;
 

--- a/packages/twenty-front/src/modules/workspace/hooks/__tests__/useSubscriptionStatus.test.ts
+++ b/packages/twenty-front/src/modules/workspace/hooks/__tests__/useSubscriptionStatus.test.ts
@@ -4,13 +4,13 @@ import { RecoilRoot, useSetRecoilState } from 'recoil';
 import { v4 } from 'uuid';
 
 import {
-    CurrentWorkspace,
-    currentWorkspaceState,
+  CurrentWorkspace,
+  currentWorkspaceState,
 } from '@/auth/states/currentWorkspaceState';
 import { useSubscriptionStatus } from '@/workspace/hooks/useSubscriptionStatus';
 import {
-    SubscriptionStatus,
-    WorkspaceActivationStatus,
+  SubscriptionStatus,
+  WorkspaceActivationStatus,
 } from '~/generated/graphql';
 
 const currentWorkspace = {

--- a/packages/twenty-front/src/modules/workspace/hooks/useIsWorkspaceActivationStatusSuspended.ts
+++ b/packages/twenty-front/src/modules/workspace/hooks/useIsWorkspaceActivationStatusSuspended.ts
@@ -6,6 +6,6 @@ import { WorkspaceActivationStatus } from '~/generated/graphql';
 export const useIsWorkspaceActivationStatusSuspended = (): boolean => {
   const currentWorkspace = useRecoilValue(currentWorkspaceState);
   return (
-    currentWorkspace?.activationStatus === WorkspaceActivationStatus.Suspended
+    currentWorkspace?.activationStatus === WorkspaceActivationStatus.SUSPENDED
   );
 };

--- a/packages/twenty-front/src/testing/mock-data/users.ts
+++ b/packages/twenty-front/src/testing/mock-data/users.ts
@@ -1,14 +1,14 @@
 import { WorkspaceMember } from '@/workspace-member/types/WorkspaceMember';
 import {
-    FeatureFlagKey,
-    OnboardingStatus,
-    SubscriptionInterval,
-    SubscriptionStatus,
-    User,
-    Workspace,
-    WorkspaceActivationStatus,
-    WorkspaceMemberDateFormatEnum,
-    WorkspaceMemberTimeFormatEnum,
+  FeatureFlagKey,
+  OnboardingStatus,
+  SubscriptionInterval,
+  SubscriptionStatus,
+  User,
+  Workspace,
+  WorkspaceActivationStatus,
+  WorkspaceMemberDateFormatEnum,
+  WorkspaceMemberTimeFormatEnum,
 } from '~/generated/graphql';
 
 type MockedUser = Pick<

--- a/packages/twenty-front/src/testing/mock-data/users.ts
+++ b/packages/twenty-front/src/testing/mock-data/users.ts
@@ -1,14 +1,14 @@
 import { WorkspaceMember } from '@/workspace-member/types/WorkspaceMember';
 import {
-  FeatureFlagKey,
-  OnboardingStatus,
-  SubscriptionInterval,
-  SubscriptionStatus,
-  User,
-  Workspace,
-  WorkspaceActivationStatus,
-  WorkspaceMemberDateFormatEnum,
-  WorkspaceMemberTimeFormatEnum,
+    FeatureFlagKey,
+    OnboardingStatus,
+    SubscriptionInterval,
+    SubscriptionStatus,
+    User,
+    Workspace,
+    WorkspaceActivationStatus,
+    WorkspaceMemberDateFormatEnum,
+    WorkspaceMemberTimeFormatEnum,
 } from '~/generated/graphql';
 
 type MockedUser = Pick<
@@ -45,7 +45,7 @@ export const mockCurrentWorkspace: Workspace = {
   logo: workspaceLogoUrl,
   isPublicInviteLinkEnabled: true,
   allowImpersonation: true,
-  activationStatus: WorkspaceActivationStatus.Active,
+  activationStatus: WorkspaceActivationStatus.ACTIVE,
   hasValidEntrepriseKey: false,
   isGoogleAuthEnabled: true,
   isPasswordAuthEnabled: true,

--- a/packages/twenty-server/src/database/commands/active-workspaces.command.ts
+++ b/packages/twenty-server/src/database/commands/active-workspaces.command.ts
@@ -1,16 +1,13 @@
 import chalk from 'chalk';
 import { Option } from 'nest-commander';
-import { Repository } from 'typeorm';
+import { WorkspaceActivationStatus } from 'twenty-shared';
+import { In, Repository } from 'typeorm';
 
 import {
   BaseCommandOptions,
   BaseCommandRunner,
 } from 'src/database/commands/base.command';
-import {
-  Workspace,
-  WorkspaceActivationStatus,
-} from 'src/engine/core-modules/workspace/workspace.entity';
-
+import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 export type ActiveWorkspacesCommandOptions = BaseCommandOptions & {
   workspaceId?: string;
 };
@@ -38,7 +35,10 @@ export abstract class ActiveWorkspacesCommandRunner extends BaseCommandRunner {
     const activeWorkspaces = await this.workspaceRepository.find({
       select: ['id'],
       where: {
-        activationStatus: WorkspaceActivationStatus.ACTIVE,
+        activationStatus: In([
+          WorkspaceActivationStatus.Active,
+          WorkspaceActivationStatus.Suspended,
+        ]),
       },
     });
 

--- a/packages/twenty-server/src/database/commands/active-workspaces.command.ts
+++ b/packages/twenty-server/src/database/commands/active-workspaces.command.ts
@@ -36,8 +36,8 @@ export abstract class ActiveWorkspacesCommandRunner extends BaseCommandRunner {
       select: ['id'],
       where: {
         activationStatus: In([
-          WorkspaceActivationStatus.Active,
-          WorkspaceActivationStatus.Suspended,
+          WorkspaceActivationStatus.ACTIVE,
+          WorkspaceActivationStatus.SUSPENDED,
         ]),
       },
     });

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-40/0-40-update-inactive-workspace-status.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-40/0-40-update-inactive-workspace-status.command.ts
@@ -2,6 +2,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 
 import chalk from 'chalk';
 import { Command, Option } from 'nest-commander';
+import { WorkspaceActivationStatus } from 'packages/twenty-shared/dist';
 import { In, Repository } from 'typeorm';
 
 import {
@@ -16,10 +17,7 @@ import { FeatureFlagEntity } from 'src/engine/core-modules/feature-flag/feature-
 import { KeyValuePair } from 'src/engine/core-modules/key-value-pair/key-value-pair.entity';
 import { UserWorkspace } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
 import { User } from 'src/engine/core-modules/user/user.entity';
-import {
-  Workspace,
-  WorkspaceActivationStatus,
-} from 'src/engine/core-modules/workspace/workspace.entity';
+import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { DataSourceEntity } from 'src/engine/metadata-modules/data-source/data-source.entity';
 import { WorkspaceMigrationEntity } from 'src/engine/metadata-modules/workspace-migration/workspace-migration.entity';
 
@@ -68,7 +66,7 @@ export class UpdateInactiveWorkspaceStatusCommand extends BaseCommandRunner {
     options: UpdateInactiveWorkspaceStatusOptions,
   ): Promise<void> {
     const whereCondition: any = {
-      activationStatus: WorkspaceActivationStatus.INACTIVE,
+      activationStatus: WorkspaceActivationStatus.Inactive,
     };
 
     if (options.workspaceIds?.length > 0) {
@@ -179,7 +177,7 @@ export class UpdateInactiveWorkspaceStatusCommand extends BaseCommandRunner {
 
     if (!options.dryRun) {
       await this.workspaceRepository.update(workspace.id, {
-        activationStatus: WorkspaceActivationStatus.SUSPENDED,
+        activationStatus: WorkspaceActivationStatus.Suspended,
       });
 
       await this.workspaceRepository.softRemove({ id: workspace.id });
@@ -200,7 +198,7 @@ export class UpdateInactiveWorkspaceStatusCommand extends BaseCommandRunner {
 
     if (!options.dryRun) {
       await this.workspaceRepository.update(workspace.id, {
-        activationStatus: WorkspaceActivationStatus.SUSPENDED,
+        activationStatus: WorkspaceActivationStatus.Suspended,
       });
 
       await this.workspaceRepository.softRemove({ id: workspace.id });
@@ -243,7 +241,7 @@ export class UpdateInactiveWorkspaceStatusCommand extends BaseCommandRunner {
     this.logger.log(chalk.blue('(!) Marking as suspended'));
     if (!options.dryRun) {
       await this.workspaceRepository.update(workspace.id, {
-        activationStatus: WorkspaceActivationStatus.SUSPENDED,
+        activationStatus: WorkspaceActivationStatus.Suspended,
       });
     }
   }

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-40/0-40-update-inactive-workspace-status.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-40/0-40-update-inactive-workspace-status.command.ts
@@ -2,7 +2,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 
 import chalk from 'chalk';
 import { Command, Option } from 'nest-commander';
-import { WorkspaceActivationStatus } from 'packages/twenty-shared/dist';
+import { WorkspaceActivationStatus } from 'twenty-shared';
 import { In, Repository } from 'typeorm';
 
 import {

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-40/0-40-update-inactive-workspace-status.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-40/0-40-update-inactive-workspace-status.command.ts
@@ -66,7 +66,7 @@ export class UpdateInactiveWorkspaceStatusCommand extends BaseCommandRunner {
     options: UpdateInactiveWorkspaceStatusOptions,
   ): Promise<void> {
     const whereCondition: any = {
-      activationStatus: WorkspaceActivationStatus.Inactive,
+      activationStatus: WorkspaceActivationStatus.INACTIVE,
     };
 
     if (options.workspaceIds?.length > 0) {
@@ -177,7 +177,7 @@ export class UpdateInactiveWorkspaceStatusCommand extends BaseCommandRunner {
 
     if (!options.dryRun) {
       await this.workspaceRepository.update(workspace.id, {
-        activationStatus: WorkspaceActivationStatus.Suspended,
+        activationStatus: WorkspaceActivationStatus.SUSPENDED,
       });
 
       await this.workspaceRepository.softRemove({ id: workspace.id });
@@ -198,7 +198,7 @@ export class UpdateInactiveWorkspaceStatusCommand extends BaseCommandRunner {
 
     if (!options.dryRun) {
       await this.workspaceRepository.update(workspace.id, {
-        activationStatus: WorkspaceActivationStatus.Suspended,
+        activationStatus: WorkspaceActivationStatus.SUSPENDED,
       });
 
       await this.workspaceRepository.softRemove({ id: workspace.id });
@@ -241,7 +241,7 @@ export class UpdateInactiveWorkspaceStatusCommand extends BaseCommandRunner {
     this.logger.log(chalk.blue('(!) Marking as suspended'));
     if (!options.dryRun) {
       await this.workspaceRepository.update(workspace.id, {
-        activationStatus: WorkspaceActivationStatus.Suspended,
+        activationStatus: WorkspaceActivationStatus.SUSPENDED,
       });
     }
   }

--- a/packages/twenty-server/src/database/typeorm-seeds/core/demo/workspaces.ts
+++ b/packages/twenty-server/src/database/typeorm-seeds/core/demo/workspaces.ts
@@ -29,7 +29,7 @@ export const seedWorkspaces = async (
         inviteHash: 'demo.dev-invite-hash',
         logo: 'https://twentyhq.github.io/placeholder-images/workspaces/apple-logo.png',
         subdomain: 'demo',
-        activationStatus: WorkspaceActivationStatus.Active,
+        activationStatus: WorkspaceActivationStatus.ACTIVE,
       },
     ])
     .execute();

--- a/packages/twenty-server/src/database/typeorm-seeds/core/demo/workspaces.ts
+++ b/packages/twenty-server/src/database/typeorm-seeds/core/demo/workspaces.ts
@@ -1,4 +1,4 @@
-import { WorkspaceActivationStatus } from 'packages/twenty-shared/dist';
+import { WorkspaceActivationStatus } from 'twenty-shared';
 import { DataSource } from 'typeorm';
 
 const tableName = 'workspace';

--- a/packages/twenty-server/src/database/typeorm-seeds/core/demo/workspaces.ts
+++ b/packages/twenty-server/src/database/typeorm-seeds/core/demo/workspaces.ts
@@ -1,6 +1,5 @@
+import { WorkspaceActivationStatus } from 'packages/twenty-shared/dist';
 import { DataSource } from 'typeorm';
-
-import { WorkspaceActivationStatus } from 'src/engine/core-modules/workspace/workspace.entity';
 
 const tableName = 'workspace';
 
@@ -30,7 +29,7 @@ export const seedWorkspaces = async (
         inviteHash: 'demo.dev-invite-hash',
         logo: 'https://twentyhq.github.io/placeholder-images/workspaces/apple-logo.png',
         subdomain: 'demo',
-        activationStatus: WorkspaceActivationStatus.ACTIVE,
+        activationStatus: WorkspaceActivationStatus.Active,
       },
     ])
     .execute();

--- a/packages/twenty-server/src/database/typeorm-seeds/core/workspaces.ts
+++ b/packages/twenty-server/src/database/typeorm-seeds/core/workspaces.ts
@@ -1,9 +1,7 @@
+import { WorkspaceActivationStatus } from 'packages/twenty-shared/dist';
 import { DataSource } from 'typeorm';
 
-import {
-  Workspace,
-  WorkspaceActivationStatus,
-} from 'src/engine/core-modules/workspace/workspace.entity';
+import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 
 const tableName = 'workspace';
 
@@ -34,7 +32,7 @@ export const seedWorkspaces = async (
       subdomain: 'apple',
       inviteHash: 'apple.dev-invite-hash',
       logo: 'https://twentyhq.github.io/placeholder-images/workspaces/apple-logo.png',
-      activationStatus: WorkspaceActivationStatus.ACTIVE,
+      activationStatus: WorkspaceActivationStatus.Active,
     },
     [SEED_ACME_WORKSPACE_ID]: {
       id: workspaceId,
@@ -43,7 +41,7 @@ export const seedWorkspaces = async (
       subdomain: 'acme',
       inviteHash: 'acme.dev-invite-hash',
       logo: 'https://logos-world.net/wp-content/uploads/2022/05/Acme-Logo-700x394.png',
-      activationStatus: WorkspaceActivationStatus.ACTIVE,
+      activationStatus: WorkspaceActivationStatus.Active,
     },
   };
 

--- a/packages/twenty-server/src/database/typeorm-seeds/core/workspaces.ts
+++ b/packages/twenty-server/src/database/typeorm-seeds/core/workspaces.ts
@@ -1,4 +1,4 @@
-import { WorkspaceActivationStatus } from 'packages/twenty-shared/dist';
+import { WorkspaceActivationStatus } from 'twenty-shared';
 import { DataSource } from 'typeorm';
 
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';

--- a/packages/twenty-server/src/database/typeorm-seeds/core/workspaces.ts
+++ b/packages/twenty-server/src/database/typeorm-seeds/core/workspaces.ts
@@ -32,7 +32,7 @@ export const seedWorkspaces = async (
       subdomain: 'apple',
       inviteHash: 'apple.dev-invite-hash',
       logo: 'https://twentyhq.github.io/placeholder-images/workspaces/apple-logo.png',
-      activationStatus: WorkspaceActivationStatus.Active,
+      activationStatus: WorkspaceActivationStatus.ACTIVE,
     },
     [SEED_ACME_WORKSPACE_ID]: {
       id: workspaceId,
@@ -41,7 +41,7 @@ export const seedWorkspaces = async (
       subdomain: 'acme',
       inviteHash: 'acme.dev-invite-hash',
       logo: 'https://logos-world.net/wp-content/uploads/2022/05/Acme-Logo-700x394.png',
-      activationStatus: WorkspaceActivationStatus.Active,
+      activationStatus: WorkspaceActivationStatus.ACTIVE,
     },
   };
 

--- a/packages/twenty-server/src/database/typeorm-seeds/workspace/message-channels.ts
+++ b/packages/twenty-server/src/database/typeorm-seeds/workspace/message-channels.ts
@@ -30,6 +30,7 @@ export const seedMessageChannel = async (
       'type',
       'connectedAccountId',
       'handle',
+      'isSyncEnabled',
       'visibility',
       'syncStage',
     ])
@@ -46,7 +47,7 @@ export const seedMessageChannel = async (
         handle: 'tim@apple.dev',
         isSyncEnabled: false,
         visibility: MessageChannelVisibility.SHARE_EVERYTHING,
-        syncSubStatus: MessageChannelSyncStage.FULL_MESSAGE_LIST_FETCH_PENDING,
+        syncStage: MessageChannelSyncStage.FULL_MESSAGE_LIST_FETCH_PENDING,
       },
       {
         id: DEV_SEED_MESSAGE_CHANNEL_IDS.JONY,
@@ -59,7 +60,7 @@ export const seedMessageChannel = async (
         handle: 'jony.ive@apple.dev',
         isSyncEnabled: false,
         visibility: MessageChannelVisibility.SHARE_EVERYTHING,
-        syncSubStatus: MessageChannelSyncStage.FULL_MESSAGE_LIST_FETCH_PENDING,
+        syncStage: MessageChannelSyncStage.FULL_MESSAGE_LIST_FETCH_PENDING,
       },
       {
         id: DEV_SEED_MESSAGE_CHANNEL_IDS.PHIL,
@@ -72,7 +73,7 @@ export const seedMessageChannel = async (
         handle: 'phil.schiler@apple.dev',
         isSyncEnabled: false,
         visibility: MessageChannelVisibility.SHARE_EVERYTHING,
-        syncSubStatus: MessageChannelSyncStage.FULL_MESSAGE_LIST_FETCH_PENDING,
+        syncStage: MessageChannelSyncStage.FULL_MESSAGE_LIST_FETCH_PENDING,
       },
     ])
     .execute();

--- a/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.spec.ts
@@ -135,7 +135,7 @@ describe('SignInUpService', () => {
       invitation: { value: 'invitationToken' } as AppToken,
       workspace: {
         id: 'workspaceId',
-        activationStatus: WorkspaceActivationStatus.Active,
+        activationStatus: WorkspaceActivationStatus.ACTIVE,
       } as Workspace,
       authParams: { provider: 'password', password: 'validPassword' },
       userData: {
@@ -181,7 +181,7 @@ describe('SignInUpService', () => {
       AuthProviderWithPasswordType = {
       workspace: {
         id: 'workspaceId',
-        activationStatus: WorkspaceActivationStatus.Active,
+        activationStatus: WorkspaceActivationStatus.ACTIVE,
       } as Workspace,
       authParams: { provider: 'password', password: 'validPassword' },
       userData: {
@@ -220,7 +220,7 @@ describe('SignInUpService', () => {
     jest.spyOn(WorkspaceRepository, 'create').mockReturnValue({} as Workspace);
     jest.spyOn(WorkspaceRepository, 'save').mockResolvedValue({
       id: 'newWorkspaceId',
-      activationStatus: WorkspaceActivationStatus.Active,
+      activationStatus: WorkspaceActivationStatus.ACTIVE,
     } as Workspace);
     jest.spyOn(fileUploadService, 'uploadImage').mockResolvedValue({
       id: '',

--- a/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.spec.ts
@@ -2,7 +2,7 @@ import { HttpService } from '@nestjs/axios';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 
-import { WorkspaceActivationStatus } from 'packages/twenty-shared/dist';
+import { WorkspaceActivationStatus } from 'twenty-shared';
 import { Repository } from 'typeorm';
 
 import { AppToken } from 'src/engine/core-modules/app-token/app-token.entity';

--- a/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.spec.ts
@@ -1,28 +1,26 @@
-import { Test, TestingModule } from '@nestjs/testing';
 import { HttpService } from '@nestjs/axios';
+import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 
+import { WorkspaceActivationStatus } from 'packages/twenty-shared/dist';
 import { Repository } from 'typeorm';
 
-import { DomainManagerService } from 'src/engine/core-modules/domain-manager/service/domain-manager.service';
-import { EnvironmentService } from 'src/engine/core-modules/environment/environment.service';
+import { AppToken } from 'src/engine/core-modules/app-token/app-token.entity';
 import { SignInUpService } from 'src/engine/core-modules/auth/services/sign-in-up.service';
-import { User } from 'src/engine/core-modules/user/user.entity';
-import { FileUploadService } from 'src/engine/core-modules/file/file-upload/services/file-upload.service';
-import { WorkspaceInvitationService } from 'src/engine/core-modules/workspace-invitation/services/workspace-invitation.service';
-import { UserWorkspaceService } from 'src/engine/core-modules/user-workspace/user-workspace.service';
-import { OnboardingService } from 'src/engine/core-modules/onboarding/onboarding.service';
 import {
   AuthProviderWithPasswordType,
   ExistingUserOrPartialUserWithPicture,
   SignInUpBaseParams,
 } from 'src/engine/core-modules/auth/types/signInUp.type';
-import {
-  Workspace,
-  WorkspaceActivationStatus,
-} from 'src/engine/core-modules/workspace/workspace.entity';
-import { AppToken } from 'src/engine/core-modules/app-token/app-token.entity';
+import { DomainManagerService } from 'src/engine/core-modules/domain-manager/service/domain-manager.service';
+import { EnvironmentService } from 'src/engine/core-modules/environment/environment.service';
+import { FileUploadService } from 'src/engine/core-modules/file/file-upload/services/file-upload.service';
+import { OnboardingService } from 'src/engine/core-modules/onboarding/onboarding.service';
+import { UserWorkspaceService } from 'src/engine/core-modules/user-workspace/user-workspace.service';
 import { UserService } from 'src/engine/core-modules/user/services/user.service';
+import { User } from 'src/engine/core-modules/user/user.entity';
+import { WorkspaceInvitationService } from 'src/engine/core-modules/workspace-invitation/services/workspace-invitation.service';
+import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 
 jest.mock('src/utils/image', () => {
   return {
@@ -137,7 +135,7 @@ describe('SignInUpService', () => {
       invitation: { value: 'invitationToken' } as AppToken,
       workspace: {
         id: 'workspaceId',
-        activationStatus: WorkspaceActivationStatus.ACTIVE,
+        activationStatus: WorkspaceActivationStatus.Active,
       } as Workspace,
       authParams: { provider: 'password', password: 'validPassword' },
       userData: {
@@ -183,7 +181,7 @@ describe('SignInUpService', () => {
       AuthProviderWithPasswordType = {
       workspace: {
         id: 'workspaceId',
-        activationStatus: WorkspaceActivationStatus.ACTIVE,
+        activationStatus: WorkspaceActivationStatus.Active,
       } as Workspace,
       authParams: { provider: 'password', password: 'validPassword' },
       userData: {
@@ -222,7 +220,7 @@ describe('SignInUpService', () => {
     jest.spyOn(WorkspaceRepository, 'create').mockReturnValue({} as Workspace);
     jest.spyOn(WorkspaceRepository, 'save').mockResolvedValue({
       id: 'newWorkspaceId',
-      activationStatus: WorkspaceActivationStatus.ACTIVE,
+      activationStatus: WorkspaceActivationStatus.Active,
     } as Workspace);
     jest.spyOn(fileUploadService, 'uploadImage').mockResolvedValue({
       id: '',

--- a/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.ts
@@ -3,12 +3,16 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import FileType from 'file-type';
-import { TWENTY_ICONS_BASE_URL } from 'twenty-shared';
+import {
+  TWENTY_ICONS_BASE_URL,
+  WorkspaceActivationStatus,
+} from 'twenty-shared';
 import { Repository } from 'typeorm';
 import { v4 } from 'uuid';
 
 import { FileFolder } from 'src/engine/core-modules/file/interfaces/file-folder.interface';
 
+import { AppToken } from 'src/engine/core-modules/app-token/app-token.entity';
 import {
   AuthException,
   AuthExceptionCode,
@@ -18,22 +22,6 @@ import {
   compareHash,
   hashPassword,
 } from 'src/engine/core-modules/auth/auth.util';
-import { DomainManagerService } from 'src/engine/core-modules/domain-manager/service/domain-manager.service';
-import { EnvironmentService } from 'src/engine/core-modules/environment/environment.service';
-import { FileUploadService } from 'src/engine/core-modules/file/file-upload/services/file-upload.service';
-import { OnboardingService } from 'src/engine/core-modules/onboarding/onboarding.service';
-import { UserWorkspaceService } from 'src/engine/core-modules/user-workspace/user-workspace.service';
-import { User } from 'src/engine/core-modules/user/user.entity';
-import { WorkspaceInvitationService } from 'src/engine/core-modules/workspace-invitation/services/workspace-invitation.service';
-import {
-  Workspace,
-  WorkspaceActivationStatus,
-} from 'src/engine/core-modules/workspace/workspace.entity';
-import { workspaceValidator } from 'src/engine/core-modules/workspace/workspace.validate';
-import { getDomainNameByEmail } from 'src/utils/get-domain-name-by-email';
-import { getImageBufferFromUrl } from 'src/utils/image';
-import { isWorkEmail } from 'src/utils/is-work-email';
-import { AppToken } from 'src/engine/core-modules/app-token/app-token.entity';
 import {
   AuthProviderWithPasswordType,
   ExistingUserOrPartialUserWithPicture,
@@ -41,7 +29,19 @@ import {
   SignInUpBaseParams,
   SignInUpNewUserPayload,
 } from 'src/engine/core-modules/auth/types/signInUp.type';
+import { DomainManagerService } from 'src/engine/core-modules/domain-manager/service/domain-manager.service';
+import { EnvironmentService } from 'src/engine/core-modules/environment/environment.service';
+import { FileUploadService } from 'src/engine/core-modules/file/file-upload/services/file-upload.service';
+import { OnboardingService } from 'src/engine/core-modules/onboarding/onboarding.service';
+import { UserWorkspaceService } from 'src/engine/core-modules/user-workspace/user-workspace.service';
 import { UserService } from 'src/engine/core-modules/user/services/user.service';
+import { User } from 'src/engine/core-modules/user/user.entity';
+import { WorkspaceInvitationService } from 'src/engine/core-modules/workspace-invitation/services/workspace-invitation.service';
+import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
+import { workspaceValidator } from 'src/engine/core-modules/workspace/workspace.validate';
+import { getDomainNameByEmail } from 'src/utils/get-domain-name-by-email';
+import { getImageBufferFromUrl } from 'src/utils/image';
+import { isWorkEmail } from 'src/utils/is-work-email';
 
 @Injectable()
 // eslint-disable-next-line @nx/workspace-inject-workspace-repository
@@ -315,7 +315,7 @@ export class SignInUpService {
       displayName: '',
       domainName: '',
       inviteHash: v4(),
-      activationStatus: WorkspaceActivationStatus.PENDING_CREATION,
+      activationStatus: WorkspaceActivationStatus.PendingCreation,
       logo,
     });
 

--- a/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.ts
@@ -315,7 +315,7 @@ export class SignInUpService {
       displayName: '',
       domainName: '',
       inviteHash: v4(),
-      activationStatus: WorkspaceActivationStatus.PendingCreation,
+      activationStatus: WorkspaceActivationStatus.PENDING_CREATION,
       logo,
     });
 

--- a/packages/twenty-server/src/engine/core-modules/auth/token/services/access-token.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/token/services/access-token.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 
 import { Request } from 'express';
+import { WorkspaceActivationStatus } from 'packages/twenty-shared/dist';
 import { Repository } from 'typeorm';
 
 import { AppToken } from 'src/engine/core-modules/app-token/app-token.entity';
@@ -12,10 +13,7 @@ import { EnvironmentService } from 'src/engine/core-modules/environment/environm
 import { JwtWrapperService } from 'src/engine/core-modules/jwt/services/jwt-wrapper.service';
 import { SSOService } from 'src/engine/core-modules/sso/services/sso.service';
 import { User } from 'src/engine/core-modules/user/user.entity';
-import {
-  Workspace,
-  WorkspaceActivationStatus,
-} from 'src/engine/core-modules/workspace/workspace.entity';
+import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.manager';
 
 import { AccessTokenService } from './access-token.service';
@@ -108,7 +106,7 @@ describe('AccessTokenService', () => {
         id: userId,
       };
       const mockWorkspace = {
-        activationStatus: WorkspaceActivationStatus.ACTIVE,
+        activationStatus: WorkspaceActivationStatus.Active,
         id: workspaceId,
       };
       const mockWorkspaceMember = { id: 'workspace-member-id' };

--- a/packages/twenty-server/src/engine/core-modules/auth/token/services/access-token.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/token/services/access-token.service.spec.ts
@@ -2,7 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 
 import { Request } from 'express';
-import { WorkspaceActivationStatus } from 'packages/twenty-shared/dist';
+import { WorkspaceActivationStatus } from 'twenty-shared';
 import { Repository } from 'typeorm';
 
 import { AppToken } from 'src/engine/core-modules/app-token/app-token.entity';

--- a/packages/twenty-server/src/engine/core-modules/auth/token/services/access-token.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/token/services/access-token.service.spec.ts
@@ -106,7 +106,7 @@ describe('AccessTokenService', () => {
         id: userId,
       };
       const mockWorkspace = {
-        activationStatus: WorkspaceActivationStatus.Active,
+        activationStatus: WorkspaceActivationStatus.ACTIVE,
         id: workspaceId,
       };
       const mockWorkspaceMember = { id: 'workspace-member-id' };

--- a/packages/twenty-server/src/engine/core-modules/auth/token/services/access-token.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/token/services/access-token.service.ts
@@ -5,26 +5,24 @@ import { addMilliseconds } from 'date-fns';
 import { Request } from 'express';
 import ms from 'ms';
 import { ExtractJwt } from 'passport-jwt';
+import { isWorkspaceActiveOrSuspended } from 'twenty-shared';
 import { Repository } from 'typeorm';
 
 import {
-    AuthException,
-    AuthExceptionCode,
+  AuthException,
+  AuthExceptionCode,
 } from 'src/engine/core-modules/auth/auth.exception';
 import { AuthToken } from 'src/engine/core-modules/auth/dto/token.entity';
 import { JwtAuthStrategy } from 'src/engine/core-modules/auth/strategies/jwt.auth.strategy';
 import {
-    AuthContext,
-    JwtPayload,
+  AuthContext,
+  JwtPayload,
 } from 'src/engine/core-modules/auth/types/auth-context.type';
 import { EnvironmentService } from 'src/engine/core-modules/environment/environment.service';
 import { JwtWrapperService } from 'src/engine/core-modules/jwt/services/jwt-wrapper.service';
 import { User } from 'src/engine/core-modules/user/user.entity';
 import { userValidator } from 'src/engine/core-modules/user/user.validate';
-import {
-    Workspace,
-    WorkspaceActivationStatus,
-} from 'src/engine/core-modules/workspace/workspace.entity';
+import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { workspaceValidator } from 'src/engine/core-modules/workspace/workspace.validate';
 import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.manager';
 import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
@@ -67,7 +65,7 @@ export class AccessTokenService {
 
     workspaceValidator.assertIsDefinedOrThrow(workspace);
 
-    if (workspace.activationStatus === WorkspaceActivationStatus.ACTIVE) {
+    if (isWorkspaceActiveOrSuspended(workspace)) {
       const workspaceMemberRepository =
         await this.twentyORMGlobalManager.getRepositoryForWorkspace<WorkspaceMemberWorkspaceEntity>(
           workspaceId,

--- a/packages/twenty-server/src/engine/core-modules/auth/token/services/access-token.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/token/services/access-token.service.ts
@@ -20,14 +20,14 @@ import {
 import { EnvironmentService } from 'src/engine/core-modules/environment/environment.service';
 import { JwtWrapperService } from 'src/engine/core-modules/jwt/services/jwt-wrapper.service';
 import { User } from 'src/engine/core-modules/user/user.entity';
+import { userValidator } from 'src/engine/core-modules/user/user.validate';
 import {
   Workspace,
   WorkspaceActivationStatus,
 } from 'src/engine/core-modules/workspace/workspace.entity';
+import { workspaceValidator } from 'src/engine/core-modules/workspace/workspace.validate';
 import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.manager';
 import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
-import { workspaceValidator } from 'src/engine/core-modules/workspace/workspace.validate';
-import { userValidator } from 'src/engine/core-modules/user/user.validate';
 
 @Injectable()
 export class AccessTokenService {
@@ -67,7 +67,7 @@ export class AccessTokenService {
 
     workspaceValidator.assertIsDefinedOrThrow(workspace);
 
-    if (workspace.activationStatus === WorkspaceActivationStatus.ACTIVE) {
+    if (workspace.activationStatus === WorkspaceActivationStatus.Active) {
       const workspaceMemberRepository =
         await this.twentyORMGlobalManager.getRepositoryForWorkspace<WorkspaceMemberWorkspaceEntity>(
           workspaceId,

--- a/packages/twenty-server/src/engine/core-modules/auth/token/services/access-token.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/token/services/access-token.service.ts
@@ -8,22 +8,22 @@ import { ExtractJwt } from 'passport-jwt';
 import { Repository } from 'typeorm';
 
 import {
-  AuthException,
-  AuthExceptionCode,
+    AuthException,
+    AuthExceptionCode,
 } from 'src/engine/core-modules/auth/auth.exception';
 import { AuthToken } from 'src/engine/core-modules/auth/dto/token.entity';
 import { JwtAuthStrategy } from 'src/engine/core-modules/auth/strategies/jwt.auth.strategy';
 import {
-  AuthContext,
-  JwtPayload,
+    AuthContext,
+    JwtPayload,
 } from 'src/engine/core-modules/auth/types/auth-context.type';
 import { EnvironmentService } from 'src/engine/core-modules/environment/environment.service';
 import { JwtWrapperService } from 'src/engine/core-modules/jwt/services/jwt-wrapper.service';
 import { User } from 'src/engine/core-modules/user/user.entity';
 import { userValidator } from 'src/engine/core-modules/user/user.validate';
 import {
-  Workspace,
-  WorkspaceActivationStatus,
+    Workspace,
+    WorkspaceActivationStatus,
 } from 'src/engine/core-modules/workspace/workspace.entity';
 import { workspaceValidator } from 'src/engine/core-modules/workspace/workspace.validate';
 import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.manager';
@@ -67,7 +67,7 @@ export class AccessTokenService {
 
     workspaceValidator.assertIsDefinedOrThrow(workspace);
 
-    if (workspace.activationStatus === WorkspaceActivationStatus.Active) {
+    if (workspace.activationStatus === WorkspaceActivationStatus.ACTIVE) {
       const workspaceMemberRepository =
         await this.twentyORMGlobalManager.getRepositoryForWorkspace<WorkspaceMemberWorkspaceEntity>(
           workspaceId,

--- a/packages/twenty-server/src/engine/core-modules/billing/services/billing-webhook-subscription.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/services/billing-webhook-subscription.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
+import { WorkspaceActivationStatus } from 'packages/twenty-shared/dist';
 import Stripe from 'stripe';
 import { Repository } from 'typeorm';
 
@@ -12,10 +13,7 @@ import { StripeCustomerService } from 'src/engine/core-modules/billing/stripe/se
 import { transformStripeSubscriptionEventToCustomerRepositoryData } from 'src/engine/core-modules/billing/utils/transform-stripe-subscription-event-to-customer-repository-data.util';
 import { transformStripeSubscriptionEventToSubscriptionItemRepositoryData } from 'src/engine/core-modules/billing/utils/transform-stripe-subscription-event-to-subscription-item-repository-data.util';
 import { transformStripeSubscriptionEventToSubscriptionRepositoryData } from 'src/engine/core-modules/billing/utils/transform-stripe-subscription-event-to-subscription-repository-data.util';
-import {
-  Workspace,
-  WorkspaceActivationStatus,
-} from 'src/engine/core-modules/workspace/workspace.entity';
+import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 @Injectable()
 export class BillingWebhookSubscriptionService {
   protected readonly logger = new Logger(
@@ -91,7 +89,7 @@ export class BillingWebhookSubscriptionService {
       data.object.status === SubscriptionStatus.Unpaid
     ) {
       await this.workspaceRepository.update(workspaceId, {
-        activationStatus: WorkspaceActivationStatus.INACTIVE,
+        activationStatus: WorkspaceActivationStatus.Inactive,
       });
     }
 
@@ -99,10 +97,10 @@ export class BillingWebhookSubscriptionService {
       (data.object.status === SubscriptionStatus.Active ||
         data.object.status === SubscriptionStatus.Trialing ||
         data.object.status === SubscriptionStatus.PastDue) &&
-      workspace.activationStatus == WorkspaceActivationStatus.INACTIVE
+      workspace.activationStatus == WorkspaceActivationStatus.Inactive
     ) {
       await this.workspaceRepository.update(workspaceId, {
-        activationStatus: WorkspaceActivationStatus.ACTIVE,
+        activationStatus: WorkspaceActivationStatus.Active,
       });
     }
 

--- a/packages/twenty-server/src/engine/core-modules/billing/services/billing-webhook-subscription.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/services/billing-webhook-subscription.service.ts
@@ -86,10 +86,11 @@ export class BillingWebhookSubscriptionService {
 
     if (
       data.object.status === SubscriptionStatus.Canceled ||
-      data.object.status === SubscriptionStatus.Unpaid
+      data.object.status === SubscriptionStatus.Unpaid ||
+      data.object.status === SubscriptionStatus.Paused
     ) {
       await this.workspaceRepository.update(workspaceId, {
-        activationStatus: WorkspaceActivationStatus.Inactive,
+        activationStatus: WorkspaceActivationStatus.Suspended,
       });
     }
 
@@ -97,7 +98,7 @@ export class BillingWebhookSubscriptionService {
       (data.object.status === SubscriptionStatus.Active ||
         data.object.status === SubscriptionStatus.Trialing ||
         data.object.status === SubscriptionStatus.PastDue) &&
-      workspace.activationStatus == WorkspaceActivationStatus.Inactive
+      workspace.activationStatus == WorkspaceActivationStatus.Suspended
     ) {
       await this.workspaceRepository.update(workspaceId, {
         activationStatus: WorkspaceActivationStatus.Active,

--- a/packages/twenty-server/src/engine/core-modules/billing/services/billing-webhook-subscription.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/services/billing-webhook-subscription.service.ts
@@ -90,7 +90,7 @@ export class BillingWebhookSubscriptionService {
       data.object.status === SubscriptionStatus.Paused
     ) {
       await this.workspaceRepository.update(workspaceId, {
-        activationStatus: WorkspaceActivationStatus.Suspended,
+        activationStatus: WorkspaceActivationStatus.SUSPENDED,
       });
     }
 
@@ -98,10 +98,10 @@ export class BillingWebhookSubscriptionService {
       (data.object.status === SubscriptionStatus.Active ||
         data.object.status === SubscriptionStatus.Trialing ||
         data.object.status === SubscriptionStatus.PastDue) &&
-      workspace.activationStatus == WorkspaceActivationStatus.Suspended
+      workspace.activationStatus == WorkspaceActivationStatus.SUSPENDED
     ) {
       await this.workspaceRepository.update(workspaceId, {
-        activationStatus: WorkspaceActivationStatus.Active,
+        activationStatus: WorkspaceActivationStatus.ACTIVE,
       });
     }
 

--- a/packages/twenty-server/src/engine/core-modules/billing/services/billing-webhook-subscription.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/services/billing-webhook-subscription.service.ts
@@ -1,8 +1,8 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
-import { WorkspaceActivationStatus } from 'packages/twenty-shared/dist';
 import Stripe from 'stripe';
+import { WorkspaceActivationStatus } from 'twenty-shared';
 import { Repository } from 'typeorm';
 
 import { BillingCustomer } from 'src/engine/core-modules/billing/entities/billing-customer.entity';

--- a/packages/twenty-server/src/engine/core-modules/onboarding/onboarding.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/onboarding/onboarding.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 
-import { WorkspaceActivationStatus } from 'packages/twenty-shared/dist';
+import { WorkspaceActivationStatus } from 'twenty-shared';
 
 import { BillingService } from 'src/engine/core-modules/billing/services/billing.service';
 import { OnboardingStatus } from 'src/engine/core-modules/onboarding/enums/onboarding-status.enum';

--- a/packages/twenty-server/src/engine/core-modules/onboarding/onboarding.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/onboarding/onboarding.service.ts
@@ -1,13 +1,12 @@
 import { Injectable } from '@nestjs/common';
 
+import { WorkspaceActivationStatus } from 'packages/twenty-shared/dist';
+
 import { BillingService } from 'src/engine/core-modules/billing/services/billing.service';
 import { OnboardingStatus } from 'src/engine/core-modules/onboarding/enums/onboarding-status.enum';
 import { UserVarsService } from 'src/engine/core-modules/user/user-vars/services/user-vars.service';
 import { User } from 'src/engine/core-modules/user/user.entity';
-import {
-  Workspace,
-  WorkspaceActivationStatus,
-} from 'src/engine/core-modules/workspace/workspace.entity';
+import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 
 export enum OnboardingStepKeys {
   ONBOARDING_CONNECT_ACCOUNT_PENDING = 'ONBOARDING_CONNECT_ACCOUNT_PENDING',
@@ -39,7 +38,7 @@ export class OnboardingService {
 
   private isWorkspaceActivationPending(workspace: Workspace) {
     return (
-      workspace.activationStatus === WorkspaceActivationStatus.PENDING_CREATION
+      workspace.activationStatus === WorkspaceActivationStatus.PendingCreation
     );
   }
 

--- a/packages/twenty-server/src/engine/core-modules/onboarding/onboarding.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/onboarding/onboarding.service.ts
@@ -38,7 +38,7 @@ export class OnboardingService {
 
   private isWorkspaceActivationPending(workspace: Workspace) {
     return (
-      workspace.activationStatus === WorkspaceActivationStatus.PendingCreation
+      workspace.activationStatus === WorkspaceActivationStatus.PENDING_CREATION
     );
   }
 

--- a/packages/twenty-server/src/engine/core-modules/user/services/user.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/services/user.service.ts
@@ -3,7 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import assert from 'assert';
 
 import { TypeOrmQueryService } from '@ptc-org/nestjs-query-typeorm';
-import { isWorkspaceActiveOrSuspended } from 'packages/twenty-shared/dist';
+import { isWorkspaceActiveOrSuspended } from 'twenty-shared';
 import { Repository } from 'typeorm';
 
 import { TypeORMService } from 'src/database/typeorm/typeorm.service';

--- a/packages/twenty-server/src/engine/core-modules/user/services/user.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/services/user.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import assert from 'assert';
 
 import { TypeOrmQueryService } from '@ptc-org/nestjs-query-typeorm';
+import { isWorkspaceActiveOrSuspended } from 'packages/twenty-shared/dist';
 import { Repository } from 'typeorm';
 
 import { TypeORMService } from 'src/database/typeorm/typeorm.service';
@@ -14,10 +15,7 @@ import {
 import { User } from 'src/engine/core-modules/user/user.entity';
 import { userValidator } from 'src/engine/core-modules/user/user.validate';
 import { WorkspaceService } from 'src/engine/core-modules/workspace/services/workspace.service';
-import {
-  Workspace,
-  WorkspaceActivationStatus,
-} from 'src/engine/core-modules/workspace/workspace.entity';
+import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { DataSourceService } from 'src/engine/metadata-modules/data-source/data-source.service';
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.manager';
@@ -41,10 +39,7 @@ export class UserService extends TypeOrmQueryService<User> {
   }
 
   async loadWorkspaceMember(user: User, workspace: Workspace) {
-    if (
-      workspace?.activationStatus !== WorkspaceActivationStatus.ACTIVE &&
-      workspace?.activationStatus !== WorkspaceActivationStatus.SUSPENDED
-    ) {
+    if (!isWorkspaceActiveOrSuspended(workspace)) {
       return null;
     }
 
@@ -62,7 +57,7 @@ export class UserService extends TypeOrmQueryService<User> {
   }
 
   async loadWorkspaceMembers(workspace: Workspace) {
-    if (workspace.activationStatus !== WorkspaceActivationStatus.ACTIVE) {
+    if (!isWorkspaceActiveOrSuspended(workspace)) {
       return [];
     }
 

--- a/packages/twenty-server/src/engine/core-modules/workspace/services/workspace.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/services/workspace.service.ts
@@ -4,7 +4,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import assert from 'assert';
 
 import { TypeOrmQueryService } from '@ptc-org/nestjs-query-typeorm';
-import { WorkspaceActivationStatus } from 'packages/twenty-shared/dist';
+import { WorkspaceActivationStatus } from 'twenty-shared';
 import { Repository } from 'typeorm';
 
 import { BillingSubscriptionService } from 'src/engine/core-modules/billing/services/billing-subscription.service';
@@ -17,8 +17,8 @@ import { User } from 'src/engine/core-modules/user/user.entity';
 import { ActivateWorkspaceInput } from 'src/engine/core-modules/workspace/dtos/activate-workspace-input';
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import {
-  WorkspaceException,
-  WorkspaceExceptionCode,
+    WorkspaceException,
+    WorkspaceExceptionCode,
 } from 'src/engine/core-modules/workspace/workspace.exception';
 import { workspaceValidator } from 'src/engine/core-modules/workspace/workspace.validate';
 import { WorkspaceManagerService } from 'src/engine/workspace-manager/workspace-manager.service';

--- a/packages/twenty-server/src/engine/core-modules/workspace/services/workspace.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/services/workspace.service.ts
@@ -89,19 +89,19 @@ export class WorkspaceService extends TypeOrmQueryService<Workspace> {
     }
 
     if (
-      workspace.activationStatus === WorkspaceActivationStatus.OngoingCreation
+      workspace.activationStatus === WorkspaceActivationStatus.ONGOING_CREATION
     ) {
       throw new Error('Workspace is already being created');
     }
 
     if (
-      workspace.activationStatus !== WorkspaceActivationStatus.PendingCreation
+      workspace.activationStatus !== WorkspaceActivationStatus.PENDING_CREATION
     ) {
       throw new Error('Workspace is not pending creation');
     }
 
     await this.workspaceRepository.update(workspace.id, {
-      activationStatus: WorkspaceActivationStatus.OngoingCreation,
+      activationStatus: WorkspaceActivationStatus.ONGOING_CREATION,
     });
 
     await this.featureFlagService.enableFeatureFlags(
@@ -114,7 +114,7 @@ export class WorkspaceService extends TypeOrmQueryService<Workspace> {
 
     await this.workspaceRepository.update(workspace.id, {
       displayName: data.displayName,
-      activationStatus: WorkspaceActivationStatus.Active,
+      activationStatus: WorkspaceActivationStatus.ACTIVE,
     });
 
     return await this.workspaceRepository.findOneBy({

--- a/packages/twenty-server/src/engine/core-modules/workspace/services/workspace.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/services/workspace.service.ts
@@ -4,6 +4,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import assert from 'assert';
 
 import { TypeOrmQueryService } from '@ptc-org/nestjs-query-typeorm';
+import { WorkspaceActivationStatus } from 'packages/twenty-shared/dist';
 import { Repository } from 'typeorm';
 
 import { BillingSubscriptionService } from 'src/engine/core-modules/billing/services/billing-subscription.service';
@@ -14,10 +15,7 @@ import { UserWorkspace } from 'src/engine/core-modules/user-workspace/user-works
 import { UserWorkspaceService } from 'src/engine/core-modules/user-workspace/user-workspace.service';
 import { User } from 'src/engine/core-modules/user/user.entity';
 import { ActivateWorkspaceInput } from 'src/engine/core-modules/workspace/dtos/activate-workspace-input';
-import {
-  Workspace,
-  WorkspaceActivationStatus,
-} from 'src/engine/core-modules/workspace/workspace.entity';
+import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import {
   WorkspaceException,
   WorkspaceExceptionCode,
@@ -91,19 +89,19 @@ export class WorkspaceService extends TypeOrmQueryService<Workspace> {
     }
 
     if (
-      workspace.activationStatus === WorkspaceActivationStatus.ONGOING_CREATION
+      workspace.activationStatus === WorkspaceActivationStatus.OngoingCreation
     ) {
       throw new Error('Workspace is already being created');
     }
 
     if (
-      workspace.activationStatus !== WorkspaceActivationStatus.PENDING_CREATION
+      workspace.activationStatus !== WorkspaceActivationStatus.PendingCreation
     ) {
       throw new Error('Workspace is not pending creation');
     }
 
     await this.workspaceRepository.update(workspace.id, {
-      activationStatus: WorkspaceActivationStatus.ONGOING_CREATION,
+      activationStatus: WorkspaceActivationStatus.OngoingCreation,
     });
 
     await this.featureFlagService.enableFeatureFlags(
@@ -116,7 +114,7 @@ export class WorkspaceService extends TypeOrmQueryService<Workspace> {
 
     await this.workspaceRepository.update(workspace.id, {
       displayName: data.displayName,
-      activationStatus: WorkspaceActivationStatus.ACTIVE,
+      activationStatus: WorkspaceActivationStatus.Active,
     });
 
     return await this.workspaceRepository.findOneBy({

--- a/packages/twenty-server/src/engine/core-modules/workspace/services/workspace.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/services/workspace.service.ts
@@ -17,8 +17,8 @@ import { User } from 'src/engine/core-modules/user/user.entity';
 import { ActivateWorkspaceInput } from 'src/engine/core-modules/workspace/dtos/activate-workspace-input';
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import {
-    WorkspaceException,
-    WorkspaceExceptionCode,
+  WorkspaceException,
+  WorkspaceExceptionCode,
 } from 'src/engine/core-modules/workspace/workspace.exception';
 import { workspaceValidator } from 'src/engine/core-modules/workspace/workspace.validate';
 import { WorkspaceManagerService } from 'src/engine/workspace-manager/workspace-manager.service';

--- a/packages/twenty-server/src/engine/core-modules/workspace/workspace.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/workspace.entity.ts
@@ -3,14 +3,14 @@ import { Field, ObjectType, registerEnumType } from '@nestjs/graphql';
 import { IDField, UnPagedRelation } from '@ptc-org/nestjs-query-graphql';
 import { WorkspaceActivationStatus } from 'twenty-shared';
 import {
-  Column,
-  CreateDateColumn,
-  DeleteDateColumn,
-  Entity,
-  OneToMany,
-  PrimaryGeneratedColumn,
-  Relation,
-  UpdateDateColumn,
+    Column,
+    CreateDateColumn,
+    DeleteDateColumn,
+    Entity,
+    OneToMany,
+    PrimaryGeneratedColumn,
+    Relation,
+    UpdateDateColumn,
 } from 'typeorm';
 
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
@@ -106,7 +106,7 @@ export class Workspace {
     type: 'enum',
     enumName: 'workspace_activationStatus_enum',
     enum: WorkspaceActivationStatus,
-    default: WorkspaceActivationStatus.Active,
+    default: WorkspaceActivationStatus.ACTIVE,
   })
   activationStatus: WorkspaceActivationStatus;
 

--- a/packages/twenty-server/src/engine/core-modules/workspace/workspace.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/workspace.entity.ts
@@ -3,14 +3,14 @@ import { Field, ObjectType, registerEnumType } from '@nestjs/graphql';
 import { IDField, UnPagedRelation } from '@ptc-org/nestjs-query-graphql';
 import { WorkspaceActivationStatus } from 'twenty-shared';
 import {
-    Column,
-    CreateDateColumn,
-    DeleteDateColumn,
-    Entity,
-    OneToMany,
-    PrimaryGeneratedColumn,
-    Relation,
-    UpdateDateColumn,
+  Column,
+  CreateDateColumn,
+  DeleteDateColumn,
+  Entity,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  Relation,
+  UpdateDateColumn,
 } from 'typeorm';
 
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';

--- a/packages/twenty-server/src/engine/core-modules/workspace/workspace.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/workspace.entity.ts
@@ -1,6 +1,7 @@
 import { Field, ObjectType, registerEnumType } from '@nestjs/graphql';
 
 import { IDField, UnPagedRelation } from '@ptc-org/nestjs-query-graphql';
+import { WorkspaceActivationStatus } from 'twenty-shared';
 import {
   Column,
   CreateDateColumn,
@@ -22,14 +23,6 @@ import { KeyValuePair } from 'src/engine/core-modules/key-value-pair/key-value-p
 import { PostgresCredentials } from 'src/engine/core-modules/postgres-credentials/postgres-credentials.entity';
 import { WorkspaceSSOIdentityProvider } from 'src/engine/core-modules/sso/workspace-sso-identity-provider.entity';
 import { UserWorkspace } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
-
-export enum WorkspaceActivationStatus {
-  ONGOING_CREATION = 'ONGOING_CREATION',
-  PENDING_CREATION = 'PENDING_CREATION',
-  ACTIVE = 'ACTIVE',
-  INACTIVE = 'INACTIVE',
-  SUSPENDED = 'SUSPENDED',
-}
 
 registerEnumType(WorkspaceActivationStatus, {
   name: 'WorkspaceActivationStatus',
@@ -113,7 +106,7 @@ export class Workspace {
     type: 'enum',
     enumName: 'workspace_activationStatus_enum',
     enum: WorkspaceActivationStatus,
-    default: WorkspaceActivationStatus.INACTIVE,
+    default: WorkspaceActivationStatus.Active,
   })
   activationStatus: WorkspaceActivationStatus;
 

--- a/packages/twenty-server/src/engine/core-modules/workspace/workspace.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/workspace.entity.ts
@@ -106,7 +106,7 @@ export class Workspace {
     type: 'enum',
     enumName: 'workspace_activationStatus_enum',
     enum: WorkspaceActivationStatus,
-    default: WorkspaceActivationStatus.ACTIVE,
+    default: WorkspaceActivationStatus.INACTIVE,
   })
   activationStatus: WorkspaceActivationStatus;
 

--- a/packages/twenty-server/src/engine/core-modules/workspace/workspace.validate.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/workspace.validate.ts
@@ -1,17 +1,17 @@
 import {
-  Workspace,
-  WorkspaceActivationStatus,
-} from 'src/engine/core-modules/workspace/workspace.entity';
-import { CustomException } from 'src/utils/custom-exception';
-import {
   AuthException,
   AuthExceptionCode,
 } from 'src/engine/core-modules/auth/auth.exception';
 import { WorkspaceAuthProvider } from 'src/engine/core-modules/workspace/types/workspace.type';
 import {
+  Workspace,
+  WorkspaceActivationStatus,
+} from 'src/engine/core-modules/workspace/workspace.entity';
+import {
   WorkspaceException,
   WorkspaceExceptionCode,
 } from 'src/engine/core-modules/workspace/workspace.exception';
+import { CustomException } from 'src/utils/custom-exception';
 
 const assertIsDefinedOrThrow = (
   workspace: Workspace | undefined | null,
@@ -29,9 +29,9 @@ const assertIsActive = (
   workspace: Workspace,
   exceptionToThrow: CustomException,
 ): asserts workspace is Workspace & {
-  activationStatus: WorkspaceActivationStatus.ACTIVE;
+  activationStatus: WorkspaceActivationStatus.Active;
 } => {
-  if (workspace.activationStatus === WorkspaceActivationStatus.ACTIVE) return;
+  if (workspace.activationStatus === WorkspaceActivationStatus.Active) return;
   throw exceptionToThrow;
 };
 

--- a/packages/twenty-server/src/engine/core-modules/workspace/workspace.validate.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/workspace.validate.ts
@@ -1,15 +1,14 @@
+import { WorkspaceActivationStatus } from 'packages/twenty-shared/dist';
+
 import {
-    AuthException,
-    AuthExceptionCode,
+  AuthException,
+  AuthExceptionCode,
 } from 'src/engine/core-modules/auth/auth.exception';
 import { WorkspaceAuthProvider } from 'src/engine/core-modules/workspace/types/workspace.type';
+import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import {
-    Workspace,
-    WorkspaceActivationStatus,
-} from 'src/engine/core-modules/workspace/workspace.entity';
-import {
-    WorkspaceException,
-    WorkspaceExceptionCode,
+  WorkspaceException,
+  WorkspaceExceptionCode,
 } from 'src/engine/core-modules/workspace/workspace.exception';
 import { CustomException } from 'src/utils/custom-exception';
 

--- a/packages/twenty-server/src/engine/core-modules/workspace/workspace.validate.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/workspace.validate.ts
@@ -1,15 +1,15 @@
 import {
-  AuthException,
-  AuthExceptionCode,
+    AuthException,
+    AuthExceptionCode,
 } from 'src/engine/core-modules/auth/auth.exception';
 import { WorkspaceAuthProvider } from 'src/engine/core-modules/workspace/types/workspace.type';
 import {
-  Workspace,
-  WorkspaceActivationStatus,
+    Workspace,
+    WorkspaceActivationStatus,
 } from 'src/engine/core-modules/workspace/workspace.entity';
 import {
-  WorkspaceException,
-  WorkspaceExceptionCode,
+    WorkspaceException,
+    WorkspaceExceptionCode,
 } from 'src/engine/core-modules/workspace/workspace.exception';
 import { CustomException } from 'src/utils/custom-exception';
 
@@ -29,9 +29,9 @@ const assertIsActive = (
   workspace: Workspace,
   exceptionToThrow: CustomException,
 ): asserts workspace is Workspace & {
-  activationStatus: WorkspaceActivationStatus.Active;
+  activationStatus: WorkspaceActivationStatus.ACTIVE;
 } => {
-  if (workspace.activationStatus === WorkspaceActivationStatus.Active) return;
+  if (workspace.activationStatus === WorkspaceActivationStatus.ACTIVE) return;
   throw exceptionToThrow;
 };
 

--- a/packages/twenty-server/src/engine/core-modules/workspace/workspace.validate.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/workspace.validate.ts
@@ -1,4 +1,4 @@
-import { WorkspaceActivationStatus } from 'packages/twenty-shared/dist';
+import { WorkspaceActivationStatus } from 'twenty-shared';
 
 import {
   AuthException,

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/crons/jobs/calendar-event-list-fetch.cron.job.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/crons/jobs/calendar-event-list-fetch.cron.job.ts
@@ -41,7 +41,7 @@ export class CalendarEventListFetchCronJob {
   async handle(): Promise<void> {
     const activeWorkspaces = await this.workspaceRepository.find({
       where: {
-        activationStatus: WorkspaceActivationStatus.Active,
+        activationStatus: WorkspaceActivationStatus.ACTIVE,
       },
     });
 

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/crons/jobs/calendar-event-list-fetch.cron.job.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/crons/jobs/calendar-event-list-fetch.cron.job.ts
@@ -1,6 +1,6 @@
 import { InjectRepository } from '@nestjs/typeorm';
 
-import { WorkspaceActivationStatus } from 'packages/twenty-shared/dist';
+import { WorkspaceActivationStatus } from 'twenty-shared';
 import { Any, Repository } from 'typeorm';
 
 import { SentryCronMonitor } from 'src/engine/core-modules/cron/sentry-cron-monitor.decorator';
@@ -13,8 +13,8 @@ import { MessageQueueService } from 'src/engine/core-modules/message-queue/servi
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.manager';
 import {
-  CalendarEventListFetchJob,
-  CalendarEventListFetchJobData,
+    CalendarEventListFetchJob,
+    CalendarEventListFetchJobData,
 } from 'src/modules/calendar/calendar-event-import-manager/jobs/calendar-event-list-fetch.job';
 import { CalendarChannelSyncStage } from 'src/modules/calendar/common/standard-objects/calendar-channel.workspace-entity';
 

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/crons/jobs/calendar-event-list-fetch.cron.job.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/crons/jobs/calendar-event-list-fetch.cron.job.ts
@@ -13,8 +13,8 @@ import { MessageQueueService } from 'src/engine/core-modules/message-queue/servi
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.manager';
 import {
-    CalendarEventListFetchJob,
-    CalendarEventListFetchJobData,
+  CalendarEventListFetchJob,
+  CalendarEventListFetchJobData,
 } from 'src/modules/calendar/calendar-event-import-manager/jobs/calendar-event-list-fetch.job';
 import { CalendarChannelSyncStage } from 'src/modules/calendar/common/standard-objects/calendar-channel.workspace-entity';
 

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/crons/jobs/calendar-event-list-fetch.cron.job.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/crons/jobs/calendar-event-list-fetch.cron.job.ts
@@ -1,5 +1,6 @@
 import { InjectRepository } from '@nestjs/typeorm';
 
+import { WorkspaceActivationStatus } from 'packages/twenty-shared/dist';
 import { Any, Repository } from 'typeorm';
 
 import { SentryCronMonitor } from 'src/engine/core-modules/cron/sentry-cron-monitor.decorator';
@@ -9,10 +10,7 @@ import { Process } from 'src/engine/core-modules/message-queue/decorators/proces
 import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
 import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
-import {
-  Workspace,
-  WorkspaceActivationStatus,
-} from 'src/engine/core-modules/workspace/workspace.entity';
+import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.manager';
 import {
   CalendarEventListFetchJob,
@@ -43,7 +41,7 @@ export class CalendarEventListFetchCronJob {
   async handle(): Promise<void> {
     const activeWorkspaces = await this.workspaceRepository.find({
       where: {
-        activationStatus: WorkspaceActivationStatus.ACTIVE,
+        activationStatus: WorkspaceActivationStatus.Active,
       },
     });
 

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/crons/jobs/calendar-events-import.cron.job.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/crons/jobs/calendar-events-import.cron.job.ts
@@ -38,7 +38,7 @@ export class CalendarEventsImportCronJob {
   async handle(): Promise<void> {
     const activeWorkspaces = await this.workspaceRepository.find({
       where: {
-        activationStatus: WorkspaceActivationStatus.Active,
+        activationStatus: WorkspaceActivationStatus.ACTIVE,
       },
     });
 

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/crons/jobs/calendar-events-import.cron.job.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/crons/jobs/calendar-events-import.cron.job.ts
@@ -1,5 +1,6 @@
 import { InjectRepository } from '@nestjs/typeorm';
 
+import { WorkspaceActivationStatus } from 'packages/twenty-shared/dist';
 import { Equal, Repository } from 'typeorm';
 
 import { SentryCronMonitor } from 'src/engine/core-modules/cron/sentry-cron-monitor.decorator';
@@ -9,15 +10,11 @@ import { Process } from 'src/engine/core-modules/message-queue/decorators/proces
 import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
 import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
-import {
-  Workspace,
-  WorkspaceActivationStatus,
-} from 'src/engine/core-modules/workspace/workspace.entity';
+import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.manager';
 import { CalendarEventListFetchJobData } from 'src/modules/calendar/calendar-event-import-manager/jobs/calendar-event-list-fetch.job';
 import { CalendarEventsImportJob } from 'src/modules/calendar/calendar-event-import-manager/jobs/calendar-events-import.job';
 import { CalendarChannelSyncStage } from 'src/modules/calendar/common/standard-objects/calendar-channel.workspace-entity';
-
 export const CALENDAR_EVENTS_IMPORT_CRON_PATTERN = '*/1 * * * *';
 
 @Processor({
@@ -41,7 +38,7 @@ export class CalendarEventsImportCronJob {
   async handle(): Promise<void> {
     const activeWorkspaces = await this.workspaceRepository.find({
       where: {
-        activationStatus: WorkspaceActivationStatus.ACTIVE,
+        activationStatus: WorkspaceActivationStatus.Active,
       },
     });
 

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/crons/jobs/calendar-events-import.cron.job.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/crons/jobs/calendar-events-import.cron.job.ts
@@ -1,6 +1,6 @@
 import { InjectRepository } from '@nestjs/typeorm';
 
-import { WorkspaceActivationStatus } from 'packages/twenty-shared/dist';
+import { WorkspaceActivationStatus } from 'twenty-shared';
 import { Equal, Repository } from 'typeorm';
 
 import { SentryCronMonitor } from 'src/engine/core-modules/cron/sentry-cron-monitor.decorator';

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/crons/jobs/calendar-ongoing-stale.cron.job.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/crons/jobs/calendar-ongoing-stale.cron.job.ts
@@ -1,6 +1,6 @@
 import { InjectRepository } from '@nestjs/typeorm';
 
-import { WorkspaceActivationStatus } from 'packages/twenty-shared/dist';
+import { WorkspaceActivationStatus } from 'twenty-shared';
 import { Repository } from 'typeorm';
 
 import { SentryCronMonitor } from 'src/engine/core-modules/cron/sentry-cron-monitor.decorator';
@@ -12,8 +12,8 @@ import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queu
 import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import {
-  CalendarOngoingStaleJob,
-  CalendarOngoingStaleJobData,
+    CalendarOngoingStaleJob,
+    CalendarOngoingStaleJobData,
 } from 'src/modules/calendar/calendar-event-import-manager/jobs/calendar-ongoing-stale.job';
 export const CALENDAR_ONGOING_STALE_CRON_PATTERN = '0 * * * *';
 

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/crons/jobs/calendar-ongoing-stale.cron.job.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/crons/jobs/calendar-ongoing-stale.cron.job.ts
@@ -1,5 +1,6 @@
 import { InjectRepository } from '@nestjs/typeorm';
 
+import { WorkspaceActivationStatus } from 'packages/twenty-shared/dist';
 import { Repository } from 'typeorm';
 
 import { SentryCronMonitor } from 'src/engine/core-modules/cron/sentry-cron-monitor.decorator';
@@ -9,15 +10,11 @@ import { Process } from 'src/engine/core-modules/message-queue/decorators/proces
 import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
 import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
-import {
-  Workspace,
-  WorkspaceActivationStatus,
-} from 'src/engine/core-modules/workspace/workspace.entity';
+import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import {
   CalendarOngoingStaleJob,
   CalendarOngoingStaleJobData,
 } from 'src/modules/calendar/calendar-event-import-manager/jobs/calendar-ongoing-stale.job';
-
 export const CALENDAR_ONGOING_STALE_CRON_PATTERN = '0 * * * *';
 
 @Processor(MessageQueue.cronQueue)
@@ -38,7 +35,7 @@ export class CalendarOngoingStaleCronJob {
   async handle(): Promise<void> {
     const activeWorkspaces = await this.workspaceRepository.find({
       where: {
-        activationStatus: WorkspaceActivationStatus.ACTIVE,
+        activationStatus: WorkspaceActivationStatus.Active,
       },
     });
 

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/crons/jobs/calendar-ongoing-stale.cron.job.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/crons/jobs/calendar-ongoing-stale.cron.job.ts
@@ -35,7 +35,7 @@ export class CalendarOngoingStaleCronJob {
   async handle(): Promise<void> {
     const activeWorkspaces = await this.workspaceRepository.find({
       where: {
-        activationStatus: WorkspaceActivationStatus.Active,
+        activationStatus: WorkspaceActivationStatus.ACTIVE,
       },
     });
 

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/crons/jobs/calendar-ongoing-stale.cron.job.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/crons/jobs/calendar-ongoing-stale.cron.job.ts
@@ -12,8 +12,8 @@ import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queu
 import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import {
-    CalendarOngoingStaleJob,
-    CalendarOngoingStaleJobData,
+  CalendarOngoingStaleJob,
+  CalendarOngoingStaleJobData,
 } from 'src/modules/calendar/calendar-event-import-manager/jobs/calendar-ongoing-stale.job';
 export const CALENDAR_ONGOING_STALE_CRON_PATTERN = '0 * * * *';
 

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/crons/jobs/messaging-message-list-fetch.cron.job.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/crons/jobs/messaging-message-list-fetch.cron.job.ts
@@ -1,5 +1,6 @@
 import { InjectRepository } from '@nestjs/typeorm';
 
+import { WorkspaceActivationStatus } from 'packages/twenty-shared/dist';
 import { In, Repository } from 'typeorm';
 
 import { SentryCronMonitor } from 'src/engine/core-modules/cron/sentry-cron-monitor.decorator';
@@ -9,10 +10,7 @@ import { Process } from 'src/engine/core-modules/message-queue/decorators/proces
 import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
 import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
-import {
-  Workspace,
-  WorkspaceActivationStatus,
-} from 'src/engine/core-modules/workspace/workspace.entity';
+import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.manager';
 import {
   MessageChannelSyncStage,
@@ -22,7 +20,6 @@ import {
   MessagingMessageListFetchJob,
   MessagingMessageListFetchJobData,
 } from 'src/modules/messaging/message-import-manager/jobs/messaging-message-list-fetch.job';
-
 export const MESSAGING_MESSAGE_LIST_FETCH_CRON_PATTERN = '*/5 * * * *';
 
 @Processor(MessageQueue.cronQueue)
@@ -44,7 +41,7 @@ export class MessagingMessageListFetchCronJob {
   async handle(): Promise<void> {
     const activeWorkspaces = await this.workspaceRepository.find({
       where: {
-        activationStatus: WorkspaceActivationStatus.ACTIVE,
+        activationStatus: WorkspaceActivationStatus.Active,
       },
     });
 

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/crons/jobs/messaging-message-list-fetch.cron.job.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/crons/jobs/messaging-message-list-fetch.cron.job.ts
@@ -41,7 +41,7 @@ export class MessagingMessageListFetchCronJob {
   async handle(): Promise<void> {
     const activeWorkspaces = await this.workspaceRepository.find({
       where: {
-        activationStatus: WorkspaceActivationStatus.Active,
+        activationStatus: WorkspaceActivationStatus.ACTIVE,
       },
     });
 

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/crons/jobs/messaging-message-list-fetch.cron.job.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/crons/jobs/messaging-message-list-fetch.cron.job.ts
@@ -13,12 +13,12 @@ import { MessageQueueService } from 'src/engine/core-modules/message-queue/servi
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.manager';
 import {
-    MessageChannelSyncStage,
-    MessageChannelWorkspaceEntity,
+  MessageChannelSyncStage,
+  MessageChannelWorkspaceEntity,
 } from 'src/modules/messaging/common/standard-objects/message-channel.workspace-entity';
 import {
-    MessagingMessageListFetchJob,
-    MessagingMessageListFetchJobData,
+  MessagingMessageListFetchJob,
+  MessagingMessageListFetchJobData,
 } from 'src/modules/messaging/message-import-manager/jobs/messaging-message-list-fetch.job';
 export const MESSAGING_MESSAGE_LIST_FETCH_CRON_PATTERN = '*/5 * * * *';
 

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/crons/jobs/messaging-message-list-fetch.cron.job.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/crons/jobs/messaging-message-list-fetch.cron.job.ts
@@ -1,6 +1,6 @@
 import { InjectRepository } from '@nestjs/typeorm';
 
-import { WorkspaceActivationStatus } from 'packages/twenty-shared/dist';
+import { WorkspaceActivationStatus } from 'twenty-shared';
 import { In, Repository } from 'typeorm';
 
 import { SentryCronMonitor } from 'src/engine/core-modules/cron/sentry-cron-monitor.decorator';
@@ -13,12 +13,12 @@ import { MessageQueueService } from 'src/engine/core-modules/message-queue/servi
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.manager';
 import {
-  MessageChannelSyncStage,
-  MessageChannelWorkspaceEntity,
+    MessageChannelSyncStage,
+    MessageChannelWorkspaceEntity,
 } from 'src/modules/messaging/common/standard-objects/message-channel.workspace-entity';
 import {
-  MessagingMessageListFetchJob,
-  MessagingMessageListFetchJobData,
+    MessagingMessageListFetchJob,
+    MessagingMessageListFetchJobData,
 } from 'src/modules/messaging/message-import-manager/jobs/messaging-message-list-fetch.job';
 export const MESSAGING_MESSAGE_LIST_FETCH_CRON_PATTERN = '*/5 * * * *';
 

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/crons/jobs/messaging-messages-import.cron.job.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/crons/jobs/messaging-messages-import.cron.job.ts
@@ -13,12 +13,12 @@ import { MessageQueueService } from 'src/engine/core-modules/message-queue/servi
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.manager';
 import {
-    MessageChannelSyncStage,
-    MessageChannelWorkspaceEntity,
+  MessageChannelSyncStage,
+  MessageChannelWorkspaceEntity,
 } from 'src/modules/messaging/common/standard-objects/message-channel.workspace-entity';
 import {
-    MessagingMessagesImportJob,
-    MessagingMessagesImportJobData,
+  MessagingMessagesImportJob,
+  MessagingMessagesImportJobData,
 } from 'src/modules/messaging/message-import-manager/jobs/messaging-messages-import.job';
 
 export const MESSAGING_MESSAGES_IMPORT_CRON_PATTERN = '*/1 * * * *';

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/crons/jobs/messaging-messages-import.cron.job.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/crons/jobs/messaging-messages-import.cron.job.ts
@@ -1,5 +1,6 @@
 import { InjectRepository } from '@nestjs/typeorm';
 
+import { WorkspaceActivationStatus } from 'packages/twenty-shared/dist';
 import { Repository } from 'typeorm';
 
 import { SentryCronMonitor } from 'src/engine/core-modules/cron/sentry-cron-monitor.decorator';
@@ -9,10 +10,7 @@ import { Process } from 'src/engine/core-modules/message-queue/decorators/proces
 import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
 import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
-import {
-  Workspace,
-  WorkspaceActivationStatus,
-} from 'src/engine/core-modules/workspace/workspace.entity';
+import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.manager';
 import {
   MessageChannelSyncStage,
@@ -44,7 +42,7 @@ export class MessagingMessagesImportCronJob {
   async handle(): Promise<void> {
     const activeWorkspaces = await this.workspaceRepository.find({
       where: {
-        activationStatus: WorkspaceActivationStatus.ACTIVE,
+        activationStatus: WorkspaceActivationStatus.Active,
       },
     });
 

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/crons/jobs/messaging-messages-import.cron.job.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/crons/jobs/messaging-messages-import.cron.job.ts
@@ -42,7 +42,7 @@ export class MessagingMessagesImportCronJob {
   async handle(): Promise<void> {
     const activeWorkspaces = await this.workspaceRepository.find({
       where: {
-        activationStatus: WorkspaceActivationStatus.Active,
+        activationStatus: WorkspaceActivationStatus.ACTIVE,
       },
     });
 

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/crons/jobs/messaging-messages-import.cron.job.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/crons/jobs/messaging-messages-import.cron.job.ts
@@ -1,6 +1,6 @@
 import { InjectRepository } from '@nestjs/typeorm';
 
-import { WorkspaceActivationStatus } from 'packages/twenty-shared/dist';
+import { WorkspaceActivationStatus } from 'twenty-shared';
 import { Repository } from 'typeorm';
 
 import { SentryCronMonitor } from 'src/engine/core-modules/cron/sentry-cron-monitor.decorator';
@@ -13,12 +13,12 @@ import { MessageQueueService } from 'src/engine/core-modules/message-queue/servi
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.manager';
 import {
-  MessageChannelSyncStage,
-  MessageChannelWorkspaceEntity,
+    MessageChannelSyncStage,
+    MessageChannelWorkspaceEntity,
 } from 'src/modules/messaging/common/standard-objects/message-channel.workspace-entity';
 import {
-  MessagingMessagesImportJob,
-  MessagingMessagesImportJobData,
+    MessagingMessagesImportJob,
+    MessagingMessagesImportJobData,
 } from 'src/modules/messaging/message-import-manager/jobs/messaging-messages-import.job';
 
 export const MESSAGING_MESSAGES_IMPORT_CRON_PATTERN = '*/1 * * * *';

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/crons/jobs/messaging-ongoing-stale.cron.job.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/crons/jobs/messaging-ongoing-stale.cron.job.ts
@@ -35,7 +35,7 @@ export class MessagingOngoingStaleCronJob {
   async handle(): Promise<void> {
     const activeWorkspaces = await this.workspaceRepository.find({
       where: {
-        activationStatus: WorkspaceActivationStatus.Active,
+        activationStatus: WorkspaceActivationStatus.ACTIVE,
       },
     });
 

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/crons/jobs/messaging-ongoing-stale.cron.job.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/crons/jobs/messaging-ongoing-stale.cron.job.ts
@@ -1,5 +1,6 @@
 import { InjectRepository } from '@nestjs/typeorm';
 
+import { WorkspaceActivationStatus } from 'packages/twenty-shared/dist';
 import { Repository } from 'typeorm';
 
 import { SentryCronMonitor } from 'src/engine/core-modules/cron/sentry-cron-monitor.decorator';
@@ -9,15 +10,11 @@ import { Process } from 'src/engine/core-modules/message-queue/decorators/proces
 import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
 import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
-import {
-  Workspace,
-  WorkspaceActivationStatus,
-} from 'src/engine/core-modules/workspace/workspace.entity';
+import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import {
   MessagingOngoingStaleJob,
   MessagingOngoingStaleJobData,
 } from 'src/modules/messaging/message-import-manager/jobs/messaging-ongoing-stale.job';
-
 export const MESSAGING_ONGOING_STALE_CRON_PATTERN = '0 * * * *';
 
 @Processor(MessageQueue.cronQueue)
@@ -38,7 +35,7 @@ export class MessagingOngoingStaleCronJob {
   async handle(): Promise<void> {
     const activeWorkspaces = await this.workspaceRepository.find({
       where: {
-        activationStatus: WorkspaceActivationStatus.ACTIVE,
+        activationStatus: WorkspaceActivationStatus.Active,
       },
     });
 

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/crons/jobs/messaging-ongoing-stale.cron.job.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/crons/jobs/messaging-ongoing-stale.cron.job.ts
@@ -1,6 +1,6 @@
 import { InjectRepository } from '@nestjs/typeorm';
 
-import { WorkspaceActivationStatus } from 'packages/twenty-shared/dist';
+import { WorkspaceActivationStatus } from 'twenty-shared';
 import { Repository } from 'typeorm';
 
 import { SentryCronMonitor } from 'src/engine/core-modules/cron/sentry-cron-monitor.decorator';

--- a/packages/twenty-server/src/modules/messaging/message-participant-manager/listeners/message-participant-workspace-member.listener.ts
+++ b/packages/twenty-server/src/modules/messaging/message-participant-manager/listeners/message-participant-workspace-member.listener.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
-import { WorkspaceActivationStatus } from 'packages/twenty-shared/dist';
+import { WorkspaceActivationStatus } from 'twenty-shared';
 import { Repository } from 'typeorm';
 
 import { OnDatabaseBatchEvent } from 'src/engine/api/graphql/graphql-query-runner/decorators/on-database-batch-event.decorator';

--- a/packages/twenty-server/src/modules/messaging/message-participant-manager/listeners/message-participant-workspace-member.listener.ts
+++ b/packages/twenty-server/src/modules/messaging/message-participant-manager/listeners/message-participant-workspace-member.listener.ts
@@ -1,18 +1,18 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
+import { WorkspaceActivationStatus } from 'packages/twenty-shared/dist';
 import { Repository } from 'typeorm';
 
-import {
-  Workspace,
-  WorkspaceActivationStatus,
-} from 'src/engine/core-modules/workspace/workspace.entity';
+import { OnDatabaseBatchEvent } from 'src/engine/api/graphql/graphql-query-runner/decorators/on-database-batch-event.decorator';
+import { DatabaseEventAction } from 'src/engine/api/graphql/graphql-query-runner/enums/database-event-action';
 import { ObjectRecordCreateEvent } from 'src/engine/core-modules/event-emitter/types/object-record-create.event';
 import { ObjectRecordUpdateEvent } from 'src/engine/core-modules/event-emitter/types/object-record-update.event';
 import { objectRecordChangedProperties as objectRecordUpdateEventChangedProperties } from 'src/engine/core-modules/event-emitter/utils/object-record-changed-properties.util';
 import { InjectMessageQueue } from 'src/engine/core-modules/message-queue/decorators/message-queue.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
 import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
+import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { WorkspaceEventBatch } from 'src/engine/workspace-event-emitter/types/workspace-event.type';
 import {
   MessageParticipantMatchParticipantJob,
@@ -23,9 +23,6 @@ import {
   MessageParticipantUnmatchParticipantJobData,
 } from 'src/modules/messaging/message-participant-manager/jobs/message-participant-unmatch-participant.job';
 import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
-import { OnDatabaseBatchEvent } from 'src/engine/api/graphql/graphql-query-runner/decorators/on-database-batch-event.decorator';
-import { DatabaseEventAction } from 'src/engine/api/graphql/graphql-query-runner/enums/database-event-action';
-
 @Injectable()
 export class MessageParticipantWorkspaceMemberListener {
   constructor(
@@ -47,7 +44,7 @@ export class MessageParticipantWorkspaceMemberListener {
 
     if (
       !workspace ||
-      workspace.activationStatus !== WorkspaceActivationStatus.ACTIVE
+      workspace.activationStatus !== WorkspaceActivationStatus.Active
     ) {
       return;
     }

--- a/packages/twenty-server/src/modules/messaging/message-participant-manager/listeners/message-participant-workspace-member.listener.ts
+++ b/packages/twenty-server/src/modules/messaging/message-participant-manager/listeners/message-participant-workspace-member.listener.ts
@@ -44,7 +44,7 @@ export class MessageParticipantWorkspaceMemberListener {
 
     if (
       !workspace ||
-      workspace.activationStatus !== WorkspaceActivationStatus.Active
+      workspace.activationStatus !== WorkspaceActivationStatus.ACTIVE
     ) {
       return;
     }

--- a/packages/twenty-server/src/modules/messaging/monitoring/crons/jobs/messaging-message-channel-sync-status-monitoring.cron.job.ts
+++ b/packages/twenty-server/src/modules/messaging/monitoring/crons/jobs/messaging-message-channel-sync-status-monitoring.cron.job.ts
@@ -47,7 +47,7 @@ export class MessagingMessageChannelSyncStatusMonitoringCronJob {
 
     const activeWorkspaces = await this.workspaceRepository.find({
       where: {
-        activationStatus: WorkspaceActivationStatus.Active,
+        activationStatus: WorkspaceActivationStatus.ACTIVE,
       },
     });
 

--- a/packages/twenty-server/src/modules/messaging/monitoring/crons/jobs/messaging-message-channel-sync-status-monitoring.cron.job.ts
+++ b/packages/twenty-server/src/modules/messaging/monitoring/crons/jobs/messaging-message-channel-sync-status-monitoring.cron.job.ts
@@ -2,6 +2,7 @@ import { Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import snakeCase from 'lodash.snakecase';
+import { WorkspaceActivationStatus } from 'twenty-shared';
 import { Repository } from 'typeorm';
 
 import { SentryCronMonitor } from 'src/engine/core-modules/cron/sentry-cron-monitor.decorator';
@@ -9,10 +10,7 @@ import { ExceptionHandlerService } from 'src/engine/core-modules/exception-handl
 import { Process } from 'src/engine/core-modules/message-queue/decorators/process.decorator';
 import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
-import {
-  Workspace,
-  WorkspaceActivationStatus,
-} from 'src/engine/core-modules/workspace/workspace.entity';
+import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.manager';
 import { MessageChannelWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message-channel.workspace-entity';
 import { MessagingTelemetryService } from 'src/modules/messaging/monitoring/services/messaging-telemetry.service';
@@ -49,7 +47,7 @@ export class MessagingMessageChannelSyncStatusMonitoringCronJob {
 
     const activeWorkspaces = await this.workspaceRepository.find({
       where: {
-        activationStatus: WorkspaceActivationStatus.ACTIVE,
+        activationStatus: WorkspaceActivationStatus.Active,
       },
     });
 

--- a/packages/twenty-shared/src/index.ts
+++ b/packages/twenty-shared/src/index.ts
@@ -4,4 +4,4 @@ export * from './types/FieldMetadataType';
 export * from './utils/fieldMetadata/isFieldMetadataDateKind';
 export * from './utils/image/getImageAbsoluteURI';
 export * from './utils/strings';
-
+export * from './workspace';

--- a/packages/twenty-shared/src/workspace/index.ts
+++ b/packages/twenty-shared/src/workspace/index.ts
@@ -1,0 +1,2 @@
+export * from './types/WorkspaceActivationStatus';
+export * from './utils/isWorkspaceActiveOrSuspended';

--- a/packages/twenty-shared/src/workspace/types/WorkspaceActivationStatus.ts
+++ b/packages/twenty-shared/src/workspace/types/WorkspaceActivationStatus.ts
@@ -1,0 +1,7 @@
+export enum WorkspaceActivationStatus {
+  OngoingCreation = 'ONGOING_CREATION',
+  PendingCreation = 'PENDING_CREATION',
+  Active = 'Active',
+  Inactive = 'Inactive',
+  Suspended = 'Suspended',
+}

--- a/packages/twenty-shared/src/workspace/types/WorkspaceActivationStatus.ts
+++ b/packages/twenty-shared/src/workspace/types/WorkspaceActivationStatus.ts
@@ -1,7 +1,7 @@
 export enum WorkspaceActivationStatus {
-  OngoingCreation = 'ONGOING_CREATION',
-  PendingCreation = 'PENDING_CREATION',
-  Active = 'Active',
-  Inactive = 'Inactive',
-  Suspended = 'Suspended',
+  ONGOING_CREATION = 'ONGOING_CREATION',
+  PENDING_CREATION = 'PENDING_CREATION',
+  ACTIVE = 'ACTIVE',
+  INACTIVE = 'INACTIVE',
+  SUSPENDED = 'SUSPENDED',
 }

--- a/packages/twenty-shared/src/workspace/utils/__tests__/isWorkspaceActiveOrSuspended.test.ts
+++ b/packages/twenty-shared/src/workspace/utils/__tests__/isWorkspaceActiveOrSuspended.test.ts
@@ -1,0 +1,52 @@
+import { WorkspaceActivationStatus } from '../../types/WorkspaceActivationStatus';
+import { isWorkspaceActiveOrSuspended } from '../isWorkspaceActiveOrSuspended';
+
+describe('isWorkspaceActiveOrSuspended', () => {
+  it('should return true for Active workspace', () => {
+    const workspace = {
+      activationStatus: WorkspaceActivationStatus.Active,
+    };
+
+    expect(isWorkspaceActiveOrSuspended(workspace)).toBe(true);
+  });
+
+  it('should return true for Suspended workspace', () => {
+    const workspace = {
+      activationStatus: WorkspaceActivationStatus.Suspended,
+    };
+
+    expect(isWorkspaceActiveOrSuspended(workspace)).toBe(true);
+  });
+
+  it('should return false for Inactive workspace', () => {
+    const workspace = {
+      activationStatus: WorkspaceActivationStatus.Inactive,
+    };
+
+    expect(isWorkspaceActiveOrSuspended(workspace)).toBe(false);
+  });
+
+  it('should return false for OngoingCreation workspace', () => {
+    const workspace = {
+      activationStatus: WorkspaceActivationStatus.OngoingCreation,
+    };
+
+    expect(isWorkspaceActiveOrSuspended(workspace)).toBe(false);
+  });
+
+  it('should return false for PendingCreation workspace', () => {
+    const workspace = {
+      activationStatus: WorkspaceActivationStatus.PendingCreation,
+    };
+
+    expect(isWorkspaceActiveOrSuspended(workspace)).toBe(false);
+  });
+
+  it('should return false for undefined workspace', () => {
+    expect(isWorkspaceActiveOrSuspended(undefined)).toBe(false);
+  });
+
+  it('should return false for null workspace', () => {
+    expect(isWorkspaceActiveOrSuspended(null)).toBe(false);
+  });
+});

--- a/packages/twenty-shared/src/workspace/utils/__tests__/isWorkspaceActiveOrSuspended.test.ts
+++ b/packages/twenty-shared/src/workspace/utils/__tests__/isWorkspaceActiveOrSuspended.test.ts
@@ -4,7 +4,7 @@ import { isWorkspaceActiveOrSuspended } from '../isWorkspaceActiveOrSuspended';
 describe('isWorkspaceActiveOrSuspended', () => {
   it('should return true for Active workspace', () => {
     const workspace = {
-      activationStatus: WorkspaceActivationStatus.Active,
+      activationStatus: WorkspaceActivationStatus.ACTIVE,
     };
 
     expect(isWorkspaceActiveOrSuspended(workspace)).toBe(true);
@@ -12,7 +12,7 @@ describe('isWorkspaceActiveOrSuspended', () => {
 
   it('should return true for Suspended workspace', () => {
     const workspace = {
-      activationStatus: WorkspaceActivationStatus.Suspended,
+      activationStatus: WorkspaceActivationStatus.SUSPENDED,
     };
 
     expect(isWorkspaceActiveOrSuspended(workspace)).toBe(true);
@@ -20,7 +20,7 @@ describe('isWorkspaceActiveOrSuspended', () => {
 
   it('should return false for Inactive workspace', () => {
     const workspace = {
-      activationStatus: WorkspaceActivationStatus.Inactive,
+      activationStatus: WorkspaceActivationStatus.INACTIVE,
     };
 
     expect(isWorkspaceActiveOrSuspended(workspace)).toBe(false);
@@ -28,7 +28,7 @@ describe('isWorkspaceActiveOrSuspended', () => {
 
   it('should return false for OngoingCreation workspace', () => {
     const workspace = {
-      activationStatus: WorkspaceActivationStatus.OngoingCreation,
+      activationStatus: WorkspaceActivationStatus.ONGOING_CREATION,
     };
 
     expect(isWorkspaceActiveOrSuspended(workspace)).toBe(false);
@@ -36,7 +36,7 @@ describe('isWorkspaceActiveOrSuspended', () => {
 
   it('should return false for PendingCreation workspace', () => {
     const workspace = {
-      activationStatus: WorkspaceActivationStatus.PendingCreation,
+      activationStatus: WorkspaceActivationStatus.PENDING_CREATION,
     };
 
     expect(isWorkspaceActiveOrSuspended(workspace)).toBe(false);

--- a/packages/twenty-shared/src/workspace/utils/isWorkspaceActiveOrSuspended.ts
+++ b/packages/twenty-shared/src/workspace/utils/isWorkspaceActiveOrSuspended.ts
@@ -1,0 +1,12 @@
+import { WorkspaceActivationStatus } from '../types/WorkspaceActivationStatus';
+
+export const isWorkspaceActiveOrSuspended = (
+  workspace?: {
+    activationStatus: WorkspaceActivationStatus;
+  } | null,
+): boolean => {
+  return (
+    workspace?.activationStatus === WorkspaceActivationStatus.Active ||
+    workspace?.activationStatus === WorkspaceActivationStatus.Suspended
+  );
+};

--- a/packages/twenty-shared/src/workspace/utils/isWorkspaceActiveOrSuspended.ts
+++ b/packages/twenty-shared/src/workspace/utils/isWorkspaceActiveOrSuspended.ts
@@ -6,7 +6,7 @@ export const isWorkspaceActiveOrSuspended = (
   } | null,
 ): boolean => {
   return (
-    workspace?.activationStatus === WorkspaceActivationStatus.Active ||
-    workspace?.activationStatus === WorkspaceActivationStatus.Suspended
+    workspace?.activationStatus === WorkspaceActivationStatus.ACTIVE ||
+    workspace?.activationStatus === WorkspaceActivationStatus.SUSPENDED
   );
 };


### PR DESCRIPTION
In this PR:
- migrate WorkspaceActivationStatus to twenty-shared (and update case to make FE and BE consistent)
- introduce isWorkspaceActiveOrSuspended in twenty-shared
- refactor the code to use it (when we fetch data on the FE, we want to keep SUSPENDED workspace working + when we sync workspaces we want it too)