### PR TITLE
[CI][NITPICK]: Rename `prerequisites` jobs to `changed-files-check`

### DIFF
--- a/.github/workflows/ci-chrome-extension.yaml
+++ b/.github/workflows/ci-chrome-extension.yaml
@@ -11,15 +11,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  prerequisites:
+  changed-files-check:
     uses: ./.github/workflows/changed-files.yaml
     with:
       files: |
         package.json
         packages/twenty-chrome-extension/**
   chrome-extension-build:
-    needs: prerequisites
-    if: needs.prerequisites.outputs.any_changed == 'true'
+    needs: changed-files-check
+    if: needs.changed-files-check.outputs.any_changed == 'true'
     timeout-minutes: 15
     runs-on: ubuntu-latest
     env:
@@ -41,7 +41,7 @@ jobs:
     if: always() && !cancelled()
     timeout-minutes: 1
     runs-on: ubuntu-latest
-    needs: [prerequisites, chrome-extension-build]
+    needs: [changed-files-check, chrome-extension-build]
     steps:
       - name: Fail job if any needs failed
         if: contains(needs.*.result, 'failure')

--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  prerequisites:
+  changed-files-check:
     uses: ./.github/workflows/changed-files.yaml
     with:
       files: |
@@ -20,8 +20,8 @@ jobs:
           .github/workflows/ci-e2e.yaml
   test:
     runs-on: ubuntu-latest
-    needs: prerequisites
-    if: needs.prerequisites.outputs.any_changed == 'true' && ( github.event_name == 'push' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-e2e')))
+    needs: changed-files-check
+    if: needs.changed-files-check.outputs.any_changed == 'true' && ( github.event_name == 'push' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-e2e')))
     timeout-minutes: 30
     env:
       NX_REJECT_UNKNOWN_LOCAL_CACHE: 0
@@ -128,7 +128,7 @@ jobs:
       if: always() && !cancelled()
       timeout-minutes: 1
       runs-on: ubuntu-latest
-      needs: [prerequisites, test]
+      needs: [changed-files-check, test]
       steps:
         - name: Fail job if any needs failed
           if: contains(needs.*.result, 'failure')

--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -14,7 +14,7 @@ env:
   STORYBOOK_BUILD_CACHE_KEY: storybook-build-depot-ubuntu-24.04-8-runner
 
 jobs:
-  prerequisites:
+  changed-files-check:
     uses: ./.github/workflows/changed-files.yaml
     with:
       files: |
@@ -23,8 +23,8 @@ jobs:
         packages/twenty-ui/**
         packages/twenty-shared/**
   front-sb-build:
-    needs: [prerequisites]
-    if: needs.prerequisites.outputs.any_changed == 'true'
+    needs: [changed-files-check]
+    if: needs.changed-files-check.outputs.any_changed == 'true'
     timeout-minutes: 30
     runs-on: depot-ubuntu-24.04-8
     env:
@@ -147,8 +147,8 @@ jobs:
       - name: Publish to Chromatic
         run: npx nx run twenty-front:chromatic:ci
   front-task:
-    needs: prerequisites
-    if: needs.prerequisites.outputs.any_changed == 'true'
+    needs: changed-files-check
+    if: needs.changed-files-check.outputs.any_changed == 'true'
     timeout-minutes: 30
     runs-on: depot-ubuntu-24.04-8
     env:
@@ -193,7 +193,7 @@ jobs:
     runs-on: depot-ubuntu-24.04-8
     needs:
       [
-        prerequisites,
+        changed-files-check,
         front-task,
         front-chromatic-deployment,
         merge-reports-and-check-coverage,

--- a/.github/workflows/ci-server.yaml
+++ b/.github/workflows/ci-server.yaml
@@ -14,7 +14,7 @@ env:
   SERVER_SETUP_CACHE_KEY: server-setup
 
 jobs:
-  prerequisites:
+  changed-files-check:
     uses: ./.github/workflows/changed-files.yaml
     with:
       files: |
@@ -23,8 +23,8 @@ jobs:
         packages/twenty-emails/**
         packages/twenty-shared/**
   server-setup:
-    needs: prerequisites
-    if: needs.prerequisites.outputs.any_changed == 'true'
+    needs: changed-files-check
+    if: needs.changed-files-check.outputs.any_changed == 'true'
     timeout-minutes: 30
     runs-on: depot-ubuntu-24.04-8
     env:
@@ -182,7 +182,7 @@ jobs:
     if: always() && !cancelled()
     timeout-minutes: 1
     runs-on: depot-ubuntu-24.04-8
-    needs: [prerequisites, server-setup, server-test, server-integration-test]
+    needs: [changed-files-check, server-setup, server-test, server-integration-test]
     steps:
       - name: Fail job if any needs failed 
         if: contains(needs.*.result, 'failure')

--- a/.github/workflows/ci-shared.yaml
+++ b/.github/workflows/ci-shared.yaml
@@ -11,14 +11,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  prerequisites:
+  changed-files-check:
     uses: ./.github/workflows/changed-files.yaml
     with:
       files: |
         packages/twenty-shared/**
   shared-test:
-    needs: prerequisites
-    if: needs.prerequisites.outputs.any_changed == 'true'
+    needs: changed-files-check
+    if: needs.changed-files-check.outputs.any_changed == 'true'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
@@ -46,7 +46,7 @@ jobs:
     if: always() && !cancelled()
     timeout-minutes: 1
     runs-on: ubuntu-latest
-    needs: [prerequisites, shared-test]
+    needs: [changed-files-check, shared-test]
     steps:
       - name: Fail job if any needs failed
         if: contains(needs.*.result, 'failure')

--- a/.github/workflows/ci-test-docker-compose.yaml
+++ b/.github/workflows/ci-test-docker-compose.yaml
@@ -7,15 +7,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  prerequisites:
+  changed-files-check:
     uses: ./.github/workflows/changed-files.yaml
     with:
       files: |
         packages/twenty-docker/**
         docker-compose.yml
   test:
-    needs: prerequisites
-    if: needs.prerequisites.outputs.any_changed == 'true'
+    needs: changed-files-check
+    if: needs.changed-files-check.outputs.any_changed == 'true'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
@@ -90,7 +90,7 @@ jobs:
     if: always() && !cancelled()
     timeout-minutes: 1
     runs-on: ubuntu-latest
-    needs: [prerequisites, test]
+    needs: [changed-files-check, test]
     steps:
       - name: Fail job if any needs failed
         if: contains(needs.*.result, 'failure')

--- a/.github/workflows/ci-website.yaml
+++ b/.github/workflows/ci-website.yaml
@@ -11,15 +11,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  prerequisites:
+  changed-files-check:
     uses: ./.github/workflows/changed-files.yaml
     with:
       files: |
         package.json
         packages/twenty-website/**
   website-build:
-    needs: prerequisites
-    if: needs.prerequisites.outputs.any_changed == 'true'
+    needs: changed-files-check
+    if: needs.changed-files-check.outputs.any_changed == 'true'
     timeout-minutes: 3
     runs-on: ubuntu-latest
     services:
@@ -60,7 +60,7 @@ jobs:
     if: always() && !cancelled()
     timeout-minutes: 1
     runs-on: ubuntu-latest
-    needs: [prerequisites, website-build]
+    needs: [changed-files-check, website-build]
     steps:
       - name: Fail job if any needs failed
         if: contains(needs.*.result, 'failure')


### PR DESCRIPTION
Related to https://github.com/twentyhq/twenty/pull/9643

Renaming `prerequisites` jobs to a more accurate `changed-files-check`