### PR TITLE
[CI] `ci-server` reorder `twenty-shared` build after cache restoration

### DIFF
--- a/.github/workflows/ci-server.yaml
+++ b/.github/workflows/ci-server.yaml
@@ -55,13 +55,13 @@ jobs:
           fetch-depth: 0
       - name: Install dependencies
         uses: ./.github/workflows/actions/yarn-install
-      - name: Build twenty-shared
-        run: npx nx build twenty-shared
       - name: Restore server setup
         id: restore-server-setup-cache
         uses: ./.github/workflows/actions/restore-cache
         with:
           key: ${{ env.SERVER_SETUP_CACHE_KEY }}
+      - name: Build twenty-shared
+        run: npx nx build twenty-shared
       - name: Server / Run lint & typecheck
         uses: ./.github/workflows/actions/nx-affected
         with:


### PR DESCRIPTION
# Introduction
Unless I'm mistaken we can win few seconds `~12s` by reordering the `twenty-shared` build step after the cache restoration in order for `nx` to hit it if possible.

[Related run](https://github.com/twentyhq/twenty/actions/runs/12809421832/job/35714544486)
