### PR TITLE
Use main apollo client for workflows

### DIFF
--- a/packages/twenty-front/src/modules/workflow/hooks/__tests__/useComputeStepOutputSchema.test.ts
+++ b/packages/twenty-front/src/modules/workflow/hooks/__tests__/useComputeStepOutputSchema.test.ts
@@ -6,10 +6,7 @@ import { useComputeStepOutputSchema } from '../useComputeStepOutputSchema';
 jest.mock('@apollo/client', () => ({
   ...jest.requireActual('@apollo/client'),
   useMutation: jest.fn(),
-}));
-
-jest.mock('@/object-metadata/hooks/useApolloMetadataClient', () => ({
-  useApolloMetadataClient: () => ({}),
+  useApolloClient: () => ({}),
 }));
 
 describe('useComputeStepOutputSchema', () => {

--- a/packages/twenty-front/src/modules/workflow/hooks/useActivateWorkflowVersion.ts
+++ b/packages/twenty-front/src/modules/workflow/hooks/useActivateWorkflowVersion.ts
@@ -1,4 +1,3 @@
-import { useApolloMetadataClient } from '@/object-metadata/hooks/useApolloMetadataClient';
 import { useApolloClient, useMutation } from '@apollo/client';
 
 import { triggerUpdateRecordOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerUpdateRecordOptimisticEffect';
@@ -13,13 +12,12 @@ import {
 } from '~/generated/graphql';
 
 export const useActivateWorkflowVersion = () => {
-  const apolloMetadataClient = useApolloMetadataClient();
   const apolloClient = useApolloClient();
   const [mutate] = useMutation<
     ActivateWorkflowVersionMutation,
     ActivateWorkflowVersionMutationVariables
   >(ACTIVATE_WORKFLOW_VERSION, {
-    client: apolloMetadataClient,
+    client: apolloClient,
   });
 
   const { objectMetadataItem: objectMetadataItemWorkflowVersion } =

--- a/packages/twenty-front/src/modules/workflow/hooks/useComputeStepOutputSchema.ts
+++ b/packages/twenty-front/src/modules/workflow/hooks/useComputeStepOutputSchema.ts
@@ -1,6 +1,5 @@
-import { useApolloMetadataClient } from '@/object-metadata/hooks/useApolloMetadataClient';
 import { COMPUTE_STEP_OUTPUT_SCHEMA } from '@/workflow/graphql/mutations/computeStepOutputSchema';
-import { useMutation } from '@apollo/client';
+import { useApolloClient, useMutation } from '@apollo/client';
 import {
   ComputeStepOutputSchemaInput,
   ComputeStepOutputSchemaMutation,
@@ -8,12 +7,12 @@ import {
 } from '~/generated/graphql';
 
 export const useComputeStepOutputSchema = () => {
-  const apolloMetadataClient = useApolloMetadataClient();
+  const apolloClient = useApolloClient();
   const [mutate] = useMutation<
     ComputeStepOutputSchemaMutation,
     ComputeStepOutputSchemaMutationVariables
   >(COMPUTE_STEP_OUTPUT_SCHEMA, {
-    client: apolloMetadataClient,
+    client: apolloClient,
   });
 
   const computeStepOutputSchema = async (

--- a/packages/twenty-front/src/modules/workflow/hooks/useDeactivateWorkflowVersion.ts
+++ b/packages/twenty-front/src/modules/workflow/hooks/useDeactivateWorkflowVersion.ts
@@ -1,4 +1,3 @@
-import { useApolloMetadataClient } from '@/object-metadata/hooks/useApolloMetadataClient';
 import { useApolloClient, useMutation } from '@apollo/client';
 
 import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
@@ -11,13 +10,12 @@ import {
 } from '~/generated/graphql';
 
 export const useDeactivateWorkflowVersion = () => {
-  const apolloMetadataClient = useApolloMetadataClient();
   const apolloClient = useApolloClient();
   const [mutate] = useMutation<
     ActivateWorkflowVersionMutation,
     ActivateWorkflowVersionMutationVariables
   >(DEACTIVATE_WORKFLOW_VERSION, {
-    client: apolloMetadataClient,
+    client: apolloClient,
   });
 
   const { objectMetadataItem: objectMetadataItemWorkflowVersion } =

--- a/packages/twenty-front/src/modules/workflow/hooks/useRunWorkflowVersion.tsx
+++ b/packages/twenty-front/src/modules/workflow/hooks/useRunWorkflowVersion.tsx
@@ -1,8 +1,7 @@
-import { useApolloMetadataClient } from '@/object-metadata/hooks/useApolloMetadataClient';
 import { SnackBarVariant } from '@/ui/feedback/snack-bar-manager/components/SnackBar';
 import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { RUN_WORKFLOW_VERSION } from '@/workflow/graphql/mutations/runWorkflowVersion';
-import { useMutation } from '@apollo/client';
+import { useApolloClient, useMutation } from '@apollo/client';
 import { useTheme } from '@emotion/react';
 import { capitalize } from 'twenty-shared';
 import { IconSettingsAutomation } from 'twenty-ui';
@@ -12,12 +11,12 @@ import {
 } from '~/generated/graphql';
 
 export const useRunWorkflowVersion = () => {
-  const apolloMetadataClient = useApolloMetadataClient();
+  const apolloClient = useApolloClient();
   const [mutate] = useMutation<
     RunWorkflowVersionMutation,
     RunWorkflowVersionMutationVariables
   >(RUN_WORKFLOW_VERSION, {
-    client: apolloMetadataClient,
+    client: apolloClient,
   });
 
   const { enqueueSnackBar } = useSnackBar();


### PR DESCRIPTION
We were using metadata client by legacy. Architecture is not great for Core engine: workflows are available both in data and metadata client. It makes more sense to use the data client since workflows are part of standard objects