### PR TITLE
Fix filter displayed value from query params

### DIFF
--- a/packages/twenty-front/src/modules/views/hooks/internal/useViewFromQueryParams.ts
+++ b/packages/twenty-front/src/modules/views/hooks/internal/useViewFromQueryParams.ts
@@ -112,12 +112,18 @@ export const useViewFromQueryParams = () => {
                         .getValue()
                     : null;
 
+                const satisfiesRelationFilterSchema =
+                  relationFilterValueSchemaObject.safeParse(
+                    filterValueFromURL,
+                  )?.success;
+
                 const relationRecordNames = [];
 
                 if (
                   isNonEmptyString(relationObjectMetadataNamePlural) &&
                   isDefined(relationObjectMetadataItem) &&
-                  Array.isArray(filterValueFromURL)
+                  (Array.isArray(filterValueFromURL) ||
+                    satisfiesRelationFilterSchema)
                 ) {
                   const queryResult = await apolloClient.query<
                     Record<string, { edges: { node: ObjectRecord }[] }>
@@ -127,7 +133,17 @@ export const useViewFromQueryParams = () => {
                       objectMetadataItems,
                     }),
                     variables: {
-                      filter: { id: { in: filterValueFromURL } },
+                      filter: {
+                        id: {
+                          in: satisfiesRelationFilterSchema
+                            ? (
+                                filterValueFromURL as {
+                                  selectedRecordIds: string[];
+                                }
+                              )?.selectedRecordIds
+                            : filterValueFromURL,
+                        },
+                      },
                     },
                   });
 

--- a/packages/twenty-front/src/modules/workflow/hooks/useDeactivateWorkflowVersion.ts
+++ b/packages/twenty-front/src/modules/workflow/hooks/useDeactivateWorkflowVersion.ts
@@ -6,16 +6,16 @@ import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSi
 import { modifyRecordFromCache } from '@/object-record/cache/utils/modifyRecordFromCache';
 import { DEACTIVATE_WORKFLOW_VERSION } from '@/workflow/graphql/mutations/deactivateWorkflowVersion';
 import {
-  ActivateWorkflowVersionMutation,
-  ActivateWorkflowVersionMutationVariables,
+  DeactivateWorkflowVersionMutation,
+  DeactivateWorkflowVersionMutationVariables,
 } from '~/generated/graphql';
 
 export const useDeactivateWorkflowVersion = () => {
   const apolloMetadataClient = useApolloMetadataClient();
   const apolloClient = useApolloClient();
   const [mutate] = useMutation<
-    ActivateWorkflowVersionMutation,
-    ActivateWorkflowVersionMutationVariables
+    DeactivateWorkflowVersionMutation,
+    DeactivateWorkflowVersionMutationVariables
   >(DEACTIVATE_WORKFLOW_VERSION, {
     client: apolloMetadataClient,
   });


### PR DESCRIPTION
Filter displayed value that use query params was broken. Recently we added a new type of filters using the schema `{ selectedRecordIds: string[] }` while before we were using `string[]` directly.
In that case, when fetching relation record name, we need to fix the findManyRecord query.

Before
<img width="1512" alt="Capture d’écran 2025-01-16 à 16 10 33" src="https://github.com/user-attachments/assets/36dc8c4f-91a4-438f-8480-bc237745a59e" />

After
<img width="1512" alt="Capture d’écran 2025-01-16 à 16 04 43" src="https://github.com/user-attachments/assets/544512a3-0ef9-4d3e-993b-a4416737ab53" />
