### PR TITLE
fix(auth): return early in workspace access check

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/auth/services/auth.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/auth.service.ts
@@ -575,13 +575,18 @@ export class AuthService {
     workspaceInviteHash?: string;
   } & ExistingUserOrNewUser &
     SignInUpBaseParams) {
-    if (!invitation && !workspaceInviteHash && workspace) {
-      if (userData.type === 'existingUser') {
-        return await this.userService.hasUserAccessToWorkspaceOrThrow(
-          userData.existingUser.id,
-          workspace.id,
-        );
-      }
+    const hasInvitation = invitation || workspaceInviteHash;
+    const isTargetAnExistingWorkspace = !!workspace;
+    const isAnExistingUser = userData.type === 'existingUser';
+
+    if (!hasInvitation && isTargetAnExistingWorkspace && isAnExistingUser) {
+      return await this.userService.hasUserAccessToWorkspaceOrThrow(
+        userData.existingUser.id,
+        workspace.id,
+      );
+    }
+
+    if (!hasInvitation && isTargetAnExistingWorkspace && !isAnExistingUser) {
       throw new AuthException(
         'User does not have access to this workspace',
         AuthExceptionCode.FORBIDDEN_EXCEPTION,

--- a/packages/twenty-server/src/engine/core-modules/auth/services/auth.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/auth.service.ts
@@ -577,7 +577,7 @@ export class AuthService {
     SignInUpBaseParams) {
     if (!invitation && !workspaceInviteHash && workspace) {
       if (userData.type === 'existingUser') {
-        await this.userService.hasUserAccessToWorkspaceOrThrow(
+        return await this.userService.hasUserAccessToWorkspaceOrThrow(
           userData.existingUser.id,
           workspace.id,
         );


### PR DESCRIPTION
Ensure early return in `hasUserAccessToWorkspaceOrThrow` for existing users during sign-in. This prevents further unnecessary execution when access validation is complete.