### PR TITLE
fix(auth): update onboarding activation for specific users

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.ts
@@ -98,7 +98,6 @@ export class SignInUpService {
       };
     }
 
-    // with global invitation flow
     if (params.workspace) {
       const updatedUser = await this.signInUpOnExistingWorkspace({
         workspace: params.workspace,
@@ -246,7 +245,9 @@ export class SignInUpService {
 
     const user = Object.assign(currentUser, updatedUser);
 
-    await this.activateOnboardingForUser(user, params.workspace);
+    if (params.userData.type === 'newUserWithPicture') {
+      await this.activateOnboardingForUser(user, params.workspace);
+    }
 
     return user;
   }


### PR DESCRIPTION
Adjust onboarding activation to trigger only for new users with pictures. This prevents unnecessary activation steps for other user types, streamlining the flow.