### PR TITLE
[CI] Add `performance` to merge coverage matrix strategy job

### DIFF
--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -102,7 +102,7 @@ jobs:
       PATH_TO_COVERAGE: packages/twenty-front/coverage/storybook
     strategy:
       matrix:
-        storybook_scope: [modules, pages]
+        storybook_scope: [modules, pages, performance]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
# Introduction
It seems like I've just oversight adding it back while debugging

# Centralization
Please note that we only have access to the following context within a job matrix properties:
```
Available expression contexts: github, inputs, vars, needs
```
We could centralize the `storybook_scope` as a job `outputs` in order to avoid this to re-occurs.