### PR TITLE
[CI][FIX] Storybook coverage configuration injection per scope

### DIFF
--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -119,7 +119,7 @@ jobs:
           mkdir -p ${{ env.PATH_TO_COVERAGE }}
           npx nyc merge coverage-artifacts ${{ env.PATH_TO_COVERAGE }}/coverage-storybook.json
       - name: Checking coverage
-        run: npx nx storybook:coverage twenty-front --checkCoverage=true
+        run: npx nx storybook:coverage twenty-front --checkCoverage=true --configuration=${{ matrix.storybook_scope }}
   front-chromatic-deployment:
     timeout-minutes: 30
     if: contains(github.event.pull_request.labels.*.name, 'run-chromatic') || github.event_name == 'push'

--- a/packages/twenty-front/nyc.config.cjs
+++ b/packages/twenty-front/nyc.config.cjs
@@ -39,7 +39,7 @@ const getCoverageConfig = () => {
       return pagesCoverage;
     case 'modules':
       return modulesCoverage;
-    case "performance":
+    case 'performance':
       return performanceCoverage;
     default:
       return globalCoverage;

--- a/packages/twenty-front/nyc.config.cjs
+++ b/packages/twenty-front/nyc.config.cjs
@@ -1,3 +1,4 @@
+// @ts-check
 const globalCoverage = {
   branches: 23,
   statements: 39,
@@ -31,13 +32,18 @@ const performanceCoverage = {
   exclude: ['src/generated/**/*', 'src/modules/**/*', 'src/**/*.ts'],
 };
 
-const storybookStoriesFolders = process.env.STORYBOOK_SCOPE;
+const getCoverageConfig = () => {
+  const storybookStoriesFolders = process.env.STORYBOOK_SCOPE;
+  switch (storybookStoriesFolders) {
+    case 'pages':
+      return pagesCoverage;
+    case 'modules':
+      return modulesCoverage;
+    case "performance":
+      return performanceCoverage;
+    default:
+      return globalCoverage;
+  }
+};
 
-module.exports =
-  storybookStoriesFolders === 'pages'
-    ? pagesCoverage
-    : storybookStoriesFolders === 'modules'
-      ? modulesCoverage
-      : storybookStoriesFolders === 'performance'
-        ? performanceCoverage
-        : globalCoverage;
+module.exports = getCoverageConfig();


### PR DESCRIPTION
# Introduction
Running `storybook` with `configuration=pages` outputs a coverage that is not replicated afterwards by the `storybook:coverage` command.
```sh
npx nx storybook:serve-and-test:static twenty-front --configuration=pages --shard=1/1 --checkCoverage=true
# ...
[TEST] Test Suites: 40 passed, 40 total
[TEST] Tests:       52 passed, 52 total
[TEST] Snapshots:   0 total
[TEST] Time:        84.786 s
[TEST] Ran all test suites.
[TEST] Coverage file (13067196 bytes) written to .nyc_output/coverage.json
[TEST] > nx storybook:coverage twenty-front --coverageDir=coverage/storybook --checkCoverage=true
[TEST] 
[TEST] 
[TEST] > nx run twenty-front:"storybook:coverage" --coverageDir=coverage/storybook --checkCoverage=true
[TEST] 
[TEST] > npx nyc report --reporter=lcov --reporter=text-summary -t coverage/storybook --report-dir coverage/storybook --check-coverage=true --cwd=packages/twenty-front
[TEST] 
[TEST] 
[TEST] =============================== Coverage summary ===============================
[TEST] Statements   : 70.45% ( 775/1100 )
[TEST] Branches     : 45.39% ( 197/434 )
[TEST] Functions    : 63.52% ( 209/329 )
[TEST] Lines        : 71.28% ( 767/1076 )
[TEST] ================================================================================
[TEST] 
```

```sh
> npx nyc report --reporter=lcov --reporter=text-summary -t coverage/storybook --report-dir coverage/storybook --check-coverage=true --cwd=packages/twenty-front


=============================== Coverage summary ===============================
Statements   : 37.4% ( 9326/24931 )
Branches     : 22.99% ( 2314/10063 )
Functions    : 28.27% ( 2189/7741 )
Lines        : 37.81% ( 9261/24488 )
================================================================================
ERROR: Coverage for lines (37.81%) does not meet global threshold (39%)
ERROR: Coverage for branches (22.99%) does not meet global threshold (23%)
ERROR: Coverage for statements (37.4%) does not meet global threshold (39%)
Warning: command "npx nyc report --reporter=lcov --reporter=text-summary -t coverage/storybook --report-dir coverage/storybook --check-coverage=true --cwd=packages/twenty-front" exited with non-zero status code
```

## Fix
Persist configuration scope arg to the `check-coverage` command

## Question
Should we add a step in the `ci-front` what would merge all `performance,modules,pages` coverage and calculate the `global` coverage ? => I think that this has no plus value as we still compute each of them individualy