### PR TITLE
[E2E][CI] Setup Playwright `webServer`

### DIFF
--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -87,23 +87,6 @@ jobs:
         PGPASSWORD=postgres psql -h localhost -p 5432 -U postgres -d postgres -c 'CREATE DATABASE "default";'
         PGPASSWORD=postgres psql -h localhost -p 5432 -U postgres -d postgres -c 'CREATE DATABASE "test";'
         npx nx run twenty-server:database:reset
-        
-    - name: Start server
-      run: |
-        npx nx start twenty-server &
-        echo "Waiting for server to be ready..."
-        timeout 60 bash -c 'until curl -s http://localhost:3000/health; do sleep 2; done'
-
-    - name: Start frontend
-      run: |
-        npm_config_yes=true npx serve -s packages/twenty-front/build -l 3001 &
-        echo "Waiting for frontend to be ready..."
-        timeout 60 bash -c 'until curl -s http://localhost:3001; do sleep 2; done'
-        
-    - name: Start worker
-      run: |
-        npx nx run twenty-server:worker:ci &
-        echo "Worker started"
 
     - name: Install Playwright Browsers
       run: npx nx setup twenty-e2e-testing

--- a/packages/twenty-e2e-testing/playwright.config.ts
+++ b/packages/twenty-e2e-testing/playwright.config.ts
@@ -35,6 +35,27 @@ export default defineConfig({
       slowMo: 500, // time in milliseconds between each step, better to use it than explicitly define timeout in tests
     },
   },
+  webServer: [
+    // Comment from now as I don't how to get worker's healthcheck
+    // {
+    //   command: 'npx nx worker twenty-server',
+    //   url: 'http://127.0.0.1:3001',
+    //   timeout: 120 * 1000,
+    //   reuseExistingServer: !process.env.CI,
+    // },
+    {
+      command: 'npx nx start twenty-server',
+      url: 'http://localhost:3000/healthz',
+      timeout: 120 * 1000,
+      reuseExistingServer: !process.env.CI,
+    },
+    {
+      command: 'npx nx start twenty-front',
+      url: 'http://localhost:3001',
+      timeout: 120 * 10000,
+      reuseExistingServer: !process.env.CI,
+    }
+  ],
   expect: {
     timeout: 5000,
   },
@@ -60,30 +81,5 @@ export default defineConfig({
       dependencies: ['Login setup'],
       testMatch: /authentication\/.+\.e2e-spec\.ts/, // forces to run login setup before running tests from this project - CASE SENSITIVE
     },
-
-    //{
-    //  name: 'webkit',
-    //  use: { ...devices['Desktop Safari'] },
-    //},
-
-    /* Test against mobile viewports. */
-    // {
-    //   name: 'Mobile Chrome',
-    //   use: { ...devices['Pixel 5'] },
-    // },
-    // {
-    //   name: 'Mobile Safari',
-    //   use: { ...devices['iPhone 12'] },
-    // },
-
-    /* Test against branded browsers. */
-    //{
-    //  name: 'Microsoft Edge',
-    //  use: { ...devices['Desktop Edge'], channel: 'msedge' },
-    //},
-    //{
-    //  name: 'Google Chrome',
-    //  use: { ...devices['Desktop Chrome'], channel: 'chrome' },
-    //},
   ],
 });

--- a/packages/twenty-e2e-testing/project.json
+++ b/packages/twenty-e2e-testing/project.json
@@ -8,7 +8,7 @@
       "options": {
         "cwd": "packages/twenty-e2e-testing",
         "commands": [
-          "yarn playwright install"
+          "npx playwright install --with-deps"
         ]
       }
     },
@@ -17,7 +17,7 @@
       "options": {
         "cwd": "packages/twenty-e2e-testing",
         "commands": [
-          "yarn playwright test"
+          "npx playwright test"
         ]
       }
     },
@@ -26,7 +26,7 @@
       "options": {
         "cwd": "packages/twenty-e2e-testing",
         "commands": [
-          "yarn playwright test --ui"
+          "npx playwright test --ui"
         ]
       }
     },
@@ -35,7 +35,7 @@
       "options": {
         "cwd": "packages/twenty-e2e-testing",
         "commands": [
-          "yarn playwright test --debug"
+          "DEBUG=pw:webserver npx playwright test --debug"
         ]
       }
     },
@@ -44,7 +44,7 @@
       "options": {
         "cwd": "packages/twenty-e2e-testing",
         "commands": [
-          "yarn playwright show-report"
+          "npx playwright show-report"
         ]
       }
     }


### PR DESCRIPTION
WIP

## Worker HealthCheck
We should expose an endpoint on the `twenty-server` that will through redis poll the worker to get its status.
In this way we will gain enough grain to allow adding the worker in the playwright devServers entries