### PR TITLE
[SERVER] Typecheck the `twenty-server`

### DIFF
--- a/packages/twenty-server/project.json
+++ b/packages/twenty-server/project.json
@@ -39,6 +39,7 @@
         "updateBuildableProjectDepsInPackageJson": true
       }
     },
+    "typecheck": {},
     "start": {
       "executor": "nx:run-commands",
       "dependsOn": ["typecheck", "build"],


### PR DESCRIPTION
# Introduction
It seems like that within the `twenty-server` `nx-project` there's no entry for the `typecheck` command. It also seems to silently fail along the `start` command even if it depends on it.
Looking at this [run](https://github.com/twentyhq/twenty/actions/runs/12865329787/job/35865644811?pr=9736) we can see that even when containing following diff it still does not fail
```ts
// twenty-server/main.ts
// @ts-expected-error: Manually triggering TSC error should be deleted afterwards
const bootstrap = async () => {
```

By adding the `typecheck` entry in the project the same run will now [fails](https://github.com/twentyhq/twenty/actions/runs/12865516249/job/35866224325)
![image](https://github.com/user-attachments/assets/e7d29307-05d0-4614-8e0f-b395129c3602)


# Notes
- There're no existing TSC errors even if wasn't guarded by the CI rn 😎 
- The ci will take dozen of more seconds to run, should keep an eye on // with nx implem checking if it works as expected

