### PR TITLE
fix: soft delete user when removing last userWorkspace

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/workspace/services/workspace.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/services/workspace.service.ts
@@ -159,6 +159,16 @@ export class WorkspaceService extends TypeOrmQueryService<Workspace> {
       userId,
       workspaceId,
     });
+
+    const userWorkspaces = await this.userWorkspaceRepository.find({
+      where: {
+        userId,
+      },
+    });
+
+    if (userWorkspaces.length === 0) {
+      await this.userRepository.softDelete(userId);
+    }
   }
 
   async isSubdomainAvailable(subdomain: string) {


### PR DESCRIPTION
### Context 

User (who has create a workspace and deleted it) can't create new workspace because after deleting his previous workspace, user has not been soft deleted.

There are several cases where user should be soft deleted :
1/ if user delete his account
2/ if a user's workspace is deleted + user has no other workspace
3/ If a workspaceMember is removed + user has no other workspace


### Solution
In `handleRemoveWorkspaceMember` method (logic used in the 3 cases), soft delete user when removing the last userWorkspace


closes #9728 