### PR TITLE
fix(workspace): ensure proper handling of updates and errors

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/workspace/workspace.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/workspace.resolver.ts
@@ -99,7 +99,7 @@ export class WorkspaceResolver {
     @AuthWorkspace() workspace: Workspace,
   ) {
     try {
-      return this.workspaceService.updateWorkspaceById({
+      return await this.workspaceService.updateWorkspaceById({
         ...data,
         id: workspace.id,
       });


### PR DESCRIPTION
Added `await` to `updateWorkspaceById` in resolver for proper async handling. Enhanced workspace settings UI with specific error handling for subdomain conflicts and improved feedback for invalid form values.


Fix https://github.com/twentyhq/twenty/issues/9709#issuecomment-2597919251