### PR TITLE
Fix import twenty-shared

### DIFF
--- a/packages/twenty-chrome-extension/tsconfig.json
+++ b/packages/twenty-chrome-extension/tsconfig.json
@@ -9,8 +9,8 @@
     "skipLibCheck": true,
     "esModuleInterop": true,
     "paths": {
-      "@/*": ["packages/twenty-chrome-extension/src/options/modules/*"],
-      "~/*": ["packages/twenty-chrome-extension/src/*"]
+      "@/*": ["./src/options/modules/*"],
+      "~/*": ["./src/*"]
     },
 
     /* Bundler mode */

--- a/packages/twenty-front/jest.config.ts
+++ b/packages/twenty-front/jest.config.ts
@@ -27,7 +27,9 @@ const jestConfig: JestConfigWithTsJest = {
     '\\.(jpg|jpeg|png|gif|webp|svg|svg\\?react)$':
       '<rootDir>/__mocks__/imageMock.js',
     '\\.css$': '<rootDir>/__mocks__/styleMock.js',
-    ...pathsToModuleNameMapper(tsConfig.compilerOptions.paths),
+    ...pathsToModuleNameMapper(tsConfig.compilerOptions.paths, {
+      prefix: '<rootDir>/',
+    }),
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   extensionsToTreatAsEsm: ['.ts', '.tsx'],

--- a/packages/twenty-front/jest.config.ts
+++ b/packages/twenty-front/jest.config.ts
@@ -28,7 +28,7 @@ const jestConfig: JestConfigWithTsJest = {
       '<rootDir>/__mocks__/imageMock.js',
     '\\.css$': '<rootDir>/__mocks__/styleMock.js',
     ...pathsToModuleNameMapper(tsConfig.compilerOptions.paths, {
-      prefix: '<rootDir>/',
+      prefix: '<rootDir>/../../',
     }),
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],

--- a/packages/twenty-front/jest.config.ts
+++ b/packages/twenty-front/jest.config.ts
@@ -27,7 +27,9 @@ const jestConfig: JestConfigWithTsJest = {
     '\\.(jpg|jpeg|png|gif|webp|svg|svg\\?react)$':
       '<rootDir>/__mocks__/imageMock.js',
     '\\.css$': '<rootDir>/__mocks__/styleMock.js',
-    ...pathsToModuleNameMapper(tsConfig.compilerOptions.paths),
+    ...pathsToModuleNameMapper(tsConfig.compilerOptions.paths, {
+      prefix: '<rootDir>/../..',
+    }),
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   extensionsToTreatAsEsm: ['.ts', '.tsx'],

--- a/packages/twenty-front/jest.config.ts
+++ b/packages/twenty-front/jest.config.ts
@@ -27,9 +27,7 @@ const jestConfig: JestConfigWithTsJest = {
     '\\.(jpg|jpeg|png|gif|webp|svg|svg\\?react)$':
       '<rootDir>/__mocks__/imageMock.js',
     '\\.css$': '<rootDir>/__mocks__/styleMock.js',
-    ...pathsToModuleNameMapper(tsConfig.compilerOptions.paths, {
-      prefix: '<rootDir>/../..',
-    }),
+    ...pathsToModuleNameMapper(tsConfig.compilerOptions.paths),
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   extensionsToTreatAsEsm: ['.ts', '.tsx'],

--- a/packages/twenty-front/package.json
+++ b/packages/twenty-front/package.json
@@ -49,19 +49,9 @@
     "docx": "^9.1.0",
     "file-saver": "^2.0.5",
     "recoil-sync": "^0.2.0",
-    "transliteration": "^2.3.5",
-    "twenty-shared": "workspace:0.41.0-canary"
+    "transliteration": "^2.3.5"
   },
   "devDependencies": {
     "@types/file-saver": "^2"
-  },
-  "workspaces": {
-    "nohoist": [
-      "**twenty-shared/**",
-      "*twenty-shared",
-      "**/twenty-shared",
-      "twenty-shared",
-      "twenty-shared/**"
-    ]
   }
 }

--- a/packages/twenty-front/package.json
+++ b/packages/twenty-front/package.json
@@ -49,9 +49,19 @@
     "docx": "^9.1.0",
     "file-saver": "^2.0.5",
     "recoil-sync": "^0.2.0",
-    "transliteration": "^2.3.5"
+    "transliteration": "^2.3.5",
+    "twenty-shared": "workspace:0.41.0-canary"
   },
   "devDependencies": {
     "@types/file-saver": "^2"
+  },
+  "workspaces": {
+    "nohoist": [
+      "**twenty-shared/**",
+      "*twenty-shared",
+      "**/twenty-shared",
+      "twenty-shared",
+      "twenty-shared/**"
+    ]
   }
 }

--- a/packages/twenty-front/package.json
+++ b/packages/twenty-front/package.json
@@ -49,7 +49,8 @@
     "docx": "^9.1.0",
     "file-saver": "^2.0.5",
     "recoil-sync": "^0.2.0",
-    "transliteration": "^2.3.5"
+    "transliteration": "^2.3.5",
+    "twenty-shared": "workspace:*"
   },
   "devDependencies": {
     "@types/file-saver": "^2"

--- a/packages/twenty-front/src/modules/action-menu/actions/record-actions/workflow-run-record-actions/hooks/useWorkflowRunRecordActions.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-actions/workflow-run-record-actions/hooks/useWorkflowRunRecordActions.tsx
@@ -13,7 +13,6 @@ import { useRunWorkflowVersion } from '@/workflow/hooks/useRunWorkflowVersion';
 import { useRecoilValue } from 'recoil';
 import { capitalize } from 'twenty-shared';
 import { IconSettingsAutomation, isDefined } from 'twenty-ui';
-
 export const useWorkflowRunRecordActions = ({
   objectMetadataItem,
 }: {

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/components/WorkflowStepHeader.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/components/WorkflowStepHeader.tsx
@@ -1,8 +1,8 @@
 import { TextInput } from '@/ui/field/input/components/TextInput';
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
-import { IconComponent } from 'packages/twenty-ui';
 import { useState } from 'react';
+import { IconComponent } from 'twenty-ui';
 import { useDebouncedCallback } from 'use-debounce';
 
 const StyledHeader = styled.div`

--- a/packages/twenty-front/tsconfig.json
+++ b/packages/twenty-front/tsconfig.json
@@ -21,10 +21,10 @@
     "forceConsistentCasingInFileNames": true,
     "outDir": "../../.cache/tsc",
     "paths": {
-      "@/*": ["packages/twenty-front/src/modules/*"],
-      "~/*": ["packages/twenty-front/src/*"],
-      "twenty-ui": ["packages/twenty-ui/src/index.ts"],
-      "@ui/*": ["packages/twenty-ui/src/*"]
+      "@/*": ["./src/modules/*"],
+      "~/*": ["./src/*"],
+      "twenty-ui": ["../twenty-ui/src/index.ts"],
+      "@ui/*": ["../twenty-ui/src/*"]
     }
   },
   "files": [],

--- a/packages/twenty-front/tsconfig.spec.json
+++ b/packages/twenty-front/tsconfig.spec.json
@@ -2,11 +2,13 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "types": ["jest", "node"],
+    "rootDir": "../..",
+    "baseUrl": "../..",
     "paths": {
-     "@/*": ["packages/twenty-front/src/modules/*"],
-      "~/*": ["packages/twenty-front/src/*"],
-      "twenty-ui": ["packages/twenty-ui/src/index.ts"],
-      "@ui/*": ["packages/twenty-ui/src/*"]
+     "@/*": ["./packages/twenty-front/src/modules/*"],
+      "~/*": ["./packages/twenty-front/src/*"],
+      "twenty-ui": ["./packages/twenty-ui/src/index.ts"],
+      "@ui/*": ["./packages/twenty-ui/src/*"]
     }
   },
   "include": [

--- a/packages/twenty-front/tsconfig.spec.json
+++ b/packages/twenty-front/tsconfig.spec.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "types": ["jest", "node"],
-    "rootDir": "../..",
     "baseUrl": "../..",
     "paths": {
      "@/*": ["./packages/twenty-front/src/modules/*"],

--- a/packages/twenty-server/package.json
+++ b/packages/twenty-server/package.json
@@ -74,6 +74,7 @@
     "@types/react": "^18.2.39",
     "@types/unzipper": "^0",
     "rimraf": "^5.0.5",
+    "twenty-shared": "workspace:*",
     "typescript": "5.3.3"
   },
   "engines": {

--- a/packages/twenty-server/package.json
+++ b/packages/twenty-server/package.json
@@ -74,6 +74,7 @@
     "@types/react": "^18.2.39",
     "@types/unzipper": "^0",
     "rimraf": "^5.0.5",
+    "twenty-emails": "workspace:*",
     "twenty-shared": "workspace:*",
     "typescript": "5.3.3"
   },

--- a/packages/twenty-server/tsconfig.json
+++ b/packages/twenty-server/tsconfig.json
@@ -25,9 +25,9 @@
     "resolveJsonModule": true,
     "types": ["jest", "node"],
     "paths": {
-      "src/*": ["packages/twenty-server/src/*"],
-      "test/*": ["packages/twenty-server/test/*"],
-      "twenty-emails": ["packages/twenty-emails/dist"]
+      "src/*": ["./src/*"],
+      "test/*": ["./test/*"],
+      "twenty-emails": ["../twenty-emails/dist"]
     }
   },
   "ts-node": {

--- a/packages/twenty-ui/jest.config.ts
+++ b/packages/twenty-ui/jest.config.ts
@@ -23,7 +23,9 @@ const jestConfig: JestConfigWithTsJest = {
   moduleNameMapper: {
     '\\.(jpg|jpeg|png|gif|webp|svg|svg\\?react)$':
       '<rootDir>/__mocks__/imageMock.js',
-    ...pathsToModuleNameMapper(tsConfig.compilerOptions.paths),
+    ...pathsToModuleNameMapper(tsConfig.compilerOptions.paths, {
+      prefix: '<rootDir>/',
+    }),
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   extensionsToTreatAsEsm: ['.ts', '.tsx'],

--- a/packages/twenty-ui/package.json
+++ b/packages/twenty-ui/package.json
@@ -10,6 +10,9 @@
       "require": "./dist/index.cjs"
     }
   },
+  "dependencies": {
+    "twenty-shared": "workspace:*"
+  },
   "scripts": {
     "build": "npx vite build"
   }

--- a/packages/twenty-ui/project.json
+++ b/packages/twenty-ui/project.json
@@ -15,7 +15,8 @@
       "outputs": ["{projectRoot}/src/index.ts", "{projectRoot}/src/*/index.ts"],
       "options": {
         "command": "node {projectRoot}/scripts/generateBarrels.js"
-      }
+      },
+      "dependsOn": ["^build"]
     },
     "lint": {
       "options": {
@@ -26,7 +27,8 @@
       },
       "configurations": {
         "fix": {}
-      }
+      },
+      "dependsOn": ["^build"]
     },
     "fmt": {
       "options": {
@@ -34,7 +36,8 @@
       },
       "configurations": {
         "fix": {}
-      }
+      },
+      "dependsOn": ["^build"]
     },
     "test": {},
     "typecheck": {},

--- a/packages/twenty-ui/project.json
+++ b/packages/twenty-ui/project.json
@@ -15,8 +15,7 @@
       "outputs": ["{projectRoot}/src/index.ts", "{projectRoot}/src/*/index.ts"],
       "options": {
         "command": "node {projectRoot}/scripts/generateBarrels.js"
-      },
-      "dependsOn": ["^build"]
+      }
     },
     "lint": {
       "options": {
@@ -27,8 +26,7 @@
       },
       "configurations": {
         "fix": {}
-      },
-      "dependsOn": ["^build"]
+      }
     },
     "fmt": {
       "options": {
@@ -36,8 +34,7 @@
       },
       "configurations": {
         "fix": {}
-      },
-      "dependsOn": ["^build"]
+      }
     },
     "test": {},
     "typecheck": {},

--- a/packages/twenty-ui/src/theme/provider/ThemeProvider.tsx
+++ b/packages/twenty-ui/src/theme/provider/ThemeProvider.tsx
@@ -1,5 +1,5 @@
-import { ReactNode } from 'react';
 import { ThemeProvider as EmotionThemeProvider } from '@emotion/react';
+import { ReactNode } from 'react';
 
 import { ThemeContextProvider } from '@ui/theme/provider/ThemeContextProvider';
 

--- a/packages/twenty-ui/tsconfig.json
+++ b/packages/twenty-ui/tsconfig.json
@@ -10,7 +10,7 @@
     "types": ["node"],
     "outDir": "../../.cache/tsc",
     "paths": {
-      "@ui/*": ["packages/twenty-ui/src/*"]
+      "@ui/*": ["./src/*"]
     }
   },
   "files": [],

--- a/packages/twenty-ui/tsconfig.spec.json
+++ b/packages/twenty-ui/tsconfig.spec.json
@@ -2,7 +2,11 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "baseUrl": "../..",
+    "paths": {
+      "@ui/*": ["./packages/twenty-ui/src/*"]
+    }
   },
   "include": [
     "vite.config.ts",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -13,13 +13,7 @@
     "lib": ["es2020", "dom"],
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
-    "resolveJsonModule": true,
-    "baseUrl": ".",
-    "paths": {
-      "twenty-emails": ["packages/twenty-emails/src/index.ts"],
-      "twenty-ui": ["packages/twenty-ui/src/index.ts"],
-      "twenty-shared": ["packages/twenty-shared/dist"]
-    }
+    "resolveJsonModule": true
   },
   "exclude": ["node_modules", "tmp"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -45612,7 +45612,6 @@ __metadata:
     file-saver: "npm:^2.0.5"
     recoil-sync: "npm:^0.2.0"
     transliteration: "npm:^2.3.5"
-    twenty-shared: "workspace:0.41.0-canary"
   languageName: unknown
   linkType: soft
 
@@ -45681,7 +45680,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"twenty-shared@workspace:0.41.0-canary, twenty-shared@workspace:packages/twenty-shared":
+"twenty-shared@workspace:packages/twenty-shared":
   version: 0.0.0-use.local
   resolution: "twenty-shared@workspace:packages/twenty-shared"
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -45581,7 +45581,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"twenty-emails@workspace:packages/twenty-emails":
+"twenty-emails@workspace:*, twenty-emails@workspace:packages/twenty-emails":
   version: 0.0.0-use.local
   resolution: "twenty-emails@workspace:packages/twenty-emails"
   languageName: unknown
@@ -45674,6 +45674,7 @@ __metadata:
     rimraf: "npm:^5.0.5"
     ts-morph: "npm:^24.0.0"
     tsconfig-paths: "npm:^4.2.0"
+    twenty-emails: "workspace:*"
     twenty-shared: "workspace:*"
     typeorm: "patch:typeorm@0.3.20#./patches/typeorm+0.3.20.patch"
     typescript: "npm:5.3.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -45680,7 +45680,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"twenty-shared@workspace:packages/twenty-shared":
+"twenty-shared@workspace:*, twenty-shared@workspace:packages/twenty-shared":
   version: 0.0.0-use.local
   resolution: "twenty-shared@workspace:packages/twenty-shared"
   languageName: unknown
@@ -45689,6 +45689,8 @@ __metadata:
 "twenty-ui@workspace:packages/twenty-ui":
   version: 0.0.0-use.local
   resolution: "twenty-ui@workspace:packages/twenty-ui"
+  dependencies:
+    twenty-shared: "workspace:*"
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -45612,6 +45612,7 @@ __metadata:
     file-saver: "npm:^2.0.5"
     recoil-sync: "npm:^0.2.0"
     transliteration: "npm:^2.3.5"
+    twenty-shared: "workspace:0.41.0-canary"
   languageName: unknown
   linkType: soft
 
@@ -45680,7 +45681,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"twenty-shared@workspace:packages/twenty-shared":
+"twenty-shared@workspace:0.41.0-canary, twenty-shared@workspace:packages/twenty-shared":
   version: 0.0.0-use.local
   resolution: "twenty-shared@workspace:packages/twenty-shared"
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -45612,6 +45612,7 @@ __metadata:
     file-saver: "npm:^2.0.5"
     recoil-sync: "npm:^0.2.0"
     transliteration: "npm:^2.3.5"
+    twenty-shared: "workspace:*"
   languageName: unknown
   linkType: soft
 
@@ -45673,6 +45674,7 @@ __metadata:
     rimraf: "npm:^5.0.5"
     ts-morph: "npm:^24.0.0"
     tsconfig-paths: "npm:^4.2.0"
+    twenty-shared: "workspace:*"
     typeorm: "patch:typeorm@0.3.20#./patches/typeorm+0.3.20.patch"
     typescript: "npm:5.3.3"
     unzipper: "npm:^0.12.3"


### PR DESCRIPTION
In this PR:
- removing rootDir / baseUrl from any tsconfig.json
- we need to keep it in tsconfig.spec.json and also specify rootDir in jest.config.ts moduleMapper because of the way nx jest executor works (automatically moving back to root)
- we need to explictly specify the depencies to twenty-shared / twenty-emails (built packages) in packages package.json to help nx understand dependencies