### PR TITLE
update subscription interval and quantity for hybrid susbscription

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/billing/billing.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/billing.module.ts
@@ -16,6 +16,7 @@ import { BillingRestApiExceptionFilter } from 'src/engine/core-modules/billing/f
 import { BillingWorkspaceMemberListener } from 'src/engine/core-modules/billing/listeners/billing-workspace-member.listener';
 import { BillingPlanService } from 'src/engine/core-modules/billing/services/billing-plan.service';
 import { BillingPortalWorkspaceService } from 'src/engine/core-modules/billing/services/billing-portal.workspace-service';
+import { BillingProductService } from 'src/engine/core-modules/billing/services/billing-product.service';
 import { BillingSubscriptionService } from 'src/engine/core-modules/billing/services/billing-subscription.service';
 import { BillingService } from 'src/engine/core-modules/billing/services/billing.service';
 import { StripeModule } from 'src/engine/core-modules/billing/stripe/stripe.module';
@@ -56,6 +57,7 @@ import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
     BillingWebhookSubscriptionService,
     BillingWebhookEntitlementService,
     BillingPortalWorkspaceService,
+    BillingProductService,
     BillingResolver,
     BillingPlanService,
     BillingWorkspaceMemberListener,

--- a/packages/twenty-server/src/engine/core-modules/billing/jobs/update-subscription-quantity.job.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/jobs/update-subscription-quantity.job.ts
@@ -37,7 +37,7 @@ export class UpdateSubscriptionQuantityJob {
 
     try {
       const billingBaseProductSubscriptionItem =
-        await this.billingSubscriptionService.getCurrentBaseProductBillingSubscriptionItemOrThrow(
+        await this.billingSubscriptionService.getBaseProductCurrentBillingSubscriptionItemOrThrow(
           data.workspaceId,
         );
 

--- a/packages/twenty-server/src/engine/core-modules/billing/jobs/update-subscription-quantity.job.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/jobs/update-subscription-quantity.job.ts
@@ -36,13 +36,13 @@ export class UpdateSubscriptionQuantityJob {
     }
 
     try {
-      const billingSubscriptionItem =
-        await this.billingSubscriptionService.getCurrentBillingSubscriptionItemOrThrow(
+      const billingBaseProductSubscriptionItem =
+        await this.billingSubscriptionService.getCurrentBaseProductBillingSubscriptionItemOrThrow(
           data.workspaceId,
         );
 
       await this.stripeSubscriptionItemService.updateSubscriptionItem(
-        billingSubscriptionItem.stripeSubscriptionItemId,
+        billingBaseProductSubscriptionItem.stripeSubscriptionItemId,
         workspaceMembersCount,
       );
 

--- a/packages/twenty-server/src/engine/core-modules/billing/services/billing-product.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/services/billing-product.service.ts
@@ -1,0 +1,44 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+import {
+  BillingException,
+  BillingExceptionCode,
+} from 'src/engine/core-modules/billing/billing.exception';
+import { BillingPrice } from 'src/engine/core-modules/billing/entities/billing-price.entity';
+import { BillingProduct } from 'src/engine/core-modules/billing/entities/billing-product.entity';
+import { BillingPlanKey } from 'src/engine/core-modules/billing/enums/billing-plan-key.enum';
+import { SubscriptionInterval } from 'src/engine/core-modules/billing/enums/billing-subscription-interval.enum';
+import { BillingPlanService } from 'src/engine/core-modules/billing/services/billing-plan.service';
+@Injectable()
+export class BillingProductService {
+  protected readonly logger = new Logger(BillingProductService.name);
+  constructor(private readonly billingPlanService: BillingPlanService) {}
+
+  getProductPricesByInterval({
+    interval,
+    billingProductsByPlan,
+  }: {
+    interval: SubscriptionInterval;
+    billingProductsByPlan: BillingProduct[];
+  }): BillingPrice[] {
+    const billingPrices = billingProductsByPlan.flatMap((product) =>
+      product.billingPrices.filter((price) => price.interval === interval),
+    );
+
+    return billingPrices;
+  }
+
+  async getProductsByPlan(planKey: BillingPlanKey): Promise<BillingProduct[]> {
+    const products = await this.billingPlanService.getPlans();
+    const plan = products.find((product) => product.planKey === planKey);
+
+    if (!plan) {
+      throw new BillingException(
+        `Plan ${planKey} not found`,
+        BillingExceptionCode.BILLING_PLAN_NOT_FOUND,
+      );
+    }
+
+    return [plan.baseProduct, ...plan.meteredProducts];
+  }
+}

--- a/packages/twenty-server/src/engine/core-modules/billing/stripe/services/stripe-subscription.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/stripe/services/stripe-subscription.service.ts
@@ -56,4 +56,13 @@ export class StripeSubscriptionService {
     }
     await this.stripe.invoices.pay(latestInvoice.id);
   }
+
+  async updateSubscriptionItems(
+    stripeSubscriptionId: string,
+    billingSubscriptionItems: Stripe.SubscriptionItemUpdateParams[],
+  ) {
+    await this.stripe.subscriptions.update(stripeSubscriptionId, {
+      items: billingSubscriptionItems,
+    });
+  }
 }

--- a/packages/twenty-server/src/engine/core-modules/billing/stripe/services/stripe-subscription.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/stripe/services/stripe-subscription.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 
 import Stripe from 'stripe';
 
+import { BillingSubscriptionItem } from 'src/engine/core-modules/billing/entities/billing-subscription-item.entity';
 import { StripeSDKService } from 'src/engine/core-modules/billing/stripe/stripe-sdk/services/stripe-sdk.service';
 import { EnvironmentService } from 'src/engine/core-modules/environment/environment.service';
 
@@ -59,10 +60,18 @@ export class StripeSubscriptionService {
 
   async updateSubscriptionItems(
     stripeSubscriptionId: string,
-    billingSubscriptionItems: Stripe.SubscriptionItemUpdateParams[],
+    billingSubscriptionItems: BillingSubscriptionItem[],
   ) {
+    const stripeSubscriptionItemsToUpdate = billingSubscriptionItems.map(
+      (item) => ({
+        id: item.stripeSubscriptionItemId,
+        price: item.stripePriceId,
+        quantity: item.quantity === null ? undefined : item.quantity,
+      }),
+    );
+
     await this.stripe.subscriptions.update(stripeSubscriptionId, {
-      items: billingSubscriptionItems,
+      items: stripeSubscriptionItemsToUpdate,
     });
   }
 }


### PR DESCRIPTION
Solves https://github.com/twentyhq/private-issues/issues/253

**TLDR:**

Can update the billing subscription interval for a subscription with a base product and metered product. It also updates correctly as the quantity of base products depending on how many people are in the workspace.

**In order to test:**

1. Have the environment variable IS_BILLING_ENABLED set to true and add the other required environment variables for Billing to work
2. Do a database reset (to ensure that the new feature flag is properly added and that the billing tables are created)
3. Run the command: npx nx run twenty-server:command billing:sync-plans-data (if you don't do that the products and prices will not be present in the database)
4. Run the server , the frontend, the worker, and the stripe listen command (stripe listen --forward-to http://localhost:3000/billing/webhooks)
5. Buy a subscription for the Acme workspace , change the interval in the Billing Settings
6. Add another person to the workspace, you should see all the previous changes reflected in the database

**Doing**
Moving the BillingSubscriptionsService.getUpdatedSubscriptionItems to an util (for a less cluttered service)