### PR TITLE
chore(auth): update SAML strategy configuration

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/auth/strategies/saml.auth.strategy.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/strategies/saml.auth.strategy.ts
@@ -36,9 +36,10 @@ export class SamlAuthStrategy extends PassportStrategy(
                 issuer: this.sSOService.buildIssuerURL(identityProvider),
                 callbackUrl: this.sSOService.buildCallbackUrl(identityProvider),
                 idpCert: identityProvider.certificate,
-                wantAssertionsSigned: false,
                 // TODO: Improve the feature by sign the response
+                wantAssertionsSigned: false,
                 wantAuthnResponseSigned: false,
+                disableRequestedAuthnContext: true,
                 signatureAlgorithm: 'sha256',
               };
 


### PR DESCRIPTION
Added `disableRequestedAuthnContext` flag to SAML auth strategy to align with compatibility requirements. Adjustments ensure seamless integration with certain Identity Providers. No functional impact on existing flows.