### PR TITLE
[MISC] Twenty-shared build `declaration` and `declarationMap` tsconfig

### DIFF
--- a/packages/twenty-shared/tsconfig.lib.json
+++ b/packages/twenty-shared/tsconfig.lib.json
@@ -1,6 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
     "outDir": "../../.cache/tsc",
     "types": [
       "node",


### PR DESCRIPTION
# Motivations
By adding the declaration and declaration mapping this allows a better `go to source` in our IDE
Should also be done for https://github.com/twentyhq/core-team-issues/issues/281

## FROM

https://github.com/user-attachments/assets/5cc307d0-b2dc-46bf-b61f-0731015c4a30


## TO

https://github.com/user-attachments/assets/5ed1d7af-2716-435d-a1b8-6738b5a77956

## Notes
Might be interesting to add global commands for:
- watch mode for `twenty-ui` and `twenty-shared`
- clean, output folders such as `dist` and `node_modules` and so on
