### PR TITLE
Fix Messaging sync upsert in messageChannel association

### DIFF
--- a/packages/twenty-server/src/modules/messaging/common/standard-objects/message-channel-message-association.workspace-entity.ts
+++ b/packages/twenty-server/src/modules/messaging/common/standard-objects/message-channel-message-association.workspace-entity.ts
@@ -7,6 +7,7 @@ import { RelationMetadataType } from 'src/engine/metadata-modules/relation-metad
 import { BaseWorkspaceEntity } from 'src/engine/twenty-orm/base.workspace-entity';
 import { WorkspaceEntity } from 'src/engine/twenty-orm/decorators/workspace-entity.decorator';
 import { WorkspaceField } from 'src/engine/twenty-orm/decorators/workspace-field.decorator';
+import { WorkspaceIndex } from 'src/engine/twenty-orm/decorators/workspace-index.decorator';
 import { WorkspaceIsNotAuditLogged } from 'src/engine/twenty-orm/decorators/workspace-is-not-audit-logged.decorator';
 import { WorkspaceIsNullable } from 'src/engine/twenty-orm/decorators/workspace-is-nullable.decorator';
 import { WorkspaceIsSystem } from 'src/engine/twenty-orm/decorators/workspace-is-system.decorator';
@@ -32,6 +33,10 @@ import { MessageWorkspaceEntity } from 'src/modules/messaging/common/standard-ob
 })
 @WorkspaceIsNotAuditLogged()
 @WorkspaceIsSystem()
+@WorkspaceIndex(['messageChannelId', 'messageId'], {
+  isUnique: true,
+  indexWhereClause: '"deletedAt" IS NULL',
+})
 export class MessageChannelMessageAssociationWorkspaceEntity extends BaseWorkspaceEntity {
   @WorkspaceField({
     standardId:

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-message.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-message.service.ts
@@ -65,7 +65,7 @@ export class MessagingMessageService {
             messageExternalId: message.externalId,
             messageThreadExternalId: message.messageThreadExternalId,
           },
-          ['messageChannelId'],
+          ['messageChannelId', 'messageId'],
           transactionManager,
         );
 


### PR DESCRIPTION
We have recently changed an .insert into a .upsert but we forgot to add the unique index on the postgres schema.