### PR TITLE
docs: add Lingui to the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Below are a few features we have implemented to date:
 - [NestJS](https://nestjs.com/), with [BullMQ](https://bullmq.io/), [PostgreSQL](https://www.postgresql.org/), [Redis](https://redis.io/)
 - [React](https://reactjs.org/), with [Recoil](https://recoiljs.org/) and [Emotion](https://emotion.sh/)
 - [Greptile](https://greptile.com) for code reviews.
-- [TranslationIO](https://translation.io/) for translations.
+- [Lingui](https://lingui.dev/) and [TranslationIO](https://translation.io/) for translations.
 
 
 # Join the Community


### PR DESCRIPTION
This PR adds Lingui to the translation tools in the Stack section of the Readme, based on the suggestion in the comment https://github.com/lingui/js-lingui/issues/2159#issuecomment-2618922147