### PR TITLE
Update bullmq queue option for job failure strategy

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/message-queue/drivers/bullmq.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/message-queue/drivers/bullmq.driver.ts
@@ -82,8 +82,8 @@ export class BullMQDriver implements MessageQueueDriver, OnModuleDestroy {
       jobId: options?.id,
       priority: options?.priority,
       repeat: options?.repeat,
-      removeOnComplete: 100,
-      removeOnFail: 500,
+      removeOnComplete: true,
+      removeOnFail: 100,
     };
 
     await this.queueMap[queueName].add(jobName, data, queueOptions);
@@ -128,8 +128,8 @@ export class BullMQDriver implements MessageQueueDriver, OnModuleDestroy {
       jobId: options?.id ? `${options.id}-${v4()}` : undefined, // We add V4() to id to make sure ids are uniques so we can add a waiting job when a job related with the same option.id is running
       priority: options?.priority,
       attempts: 1 + (options?.retryLimit || 0),
-      removeOnComplete: 100,
-      removeOnFail: 500,
+      removeOnComplete: true,
+      removeOnFail: 100,
     };
 
     await this.queueMap[queueName].add(jobName, data, queueOptions);


### PR DESCRIPTION
## Context
This config tells bullmq what to do with jobs once they have been processed.
We used to retain 100 completed jobs and 500 failed jobs. We never really needed that much retention and keeping succeeded job is not useful either in our case. I'm updating the strategy so all completed jobs are removed from the queue and we now keep 100 failed jobs in case we need to debug. (Although we should have good monitoring with ExceptionHandler driver)