### PR TITLE
fix link validation and matching during csv import

### DIFF
--- a/packages/twenty-front/src/modules/object-record/spreadsheet-import/constants/CompositeFieldImportLabels.ts
+++ b/packages/twenty-front/src/modules/object-record/spreadsheet-import/constants/CompositeFieldImportLabels.ts
@@ -29,8 +29,8 @@ export const COMPOSITE_FIELD_IMPORT_LABELS = {
     addressLngLabel: 'Longitude',
   } satisfies CompositeFieldLabels<FieldAddressValue>,
   [FieldMetadataType.LINKS]: {
+    // primaryLinkLabelLabel excluded from composite field import labels since it's not used in Links input
     primaryLinkUrlLabel: 'Link URL',
-    primaryLinkLabelLabel: 'Link Label',
   } satisfies Partial<CompositeFieldLabels<FieldLinksValue>>,
   [FieldMetadataType.EMAILS]: {
     primaryEmailLabel: 'Email',

--- a/packages/twenty-front/src/modules/object-record/spreadsheet-import/utils/buildRecordFromImportedStructuredRow.ts
+++ b/packages/twenty-front/src/modules/object-record/spreadsheet-import/utils/buildRecordFromImportedStructuredRow.ts
@@ -33,7 +33,7 @@ export const buildRecordFromImportedStructuredRow = (
     },
     CURRENCY: { amountMicrosLabel, currencyCodeLabel },
     FULL_NAME: { firstNameLabel, lastNameLabel },
-    LINKS: { primaryLinkLabelLabel, primaryLinkUrlLabel },
+    LINKS: { primaryLinkUrlLabel },
     EMAILS: { primaryEmailLabel },
     PHONES: { primaryPhoneNumberLabel, primaryPhoneCountryCodeLabel },
   } = COMPOSITE_FIELD_IMPORT_LABELS;
@@ -118,14 +118,11 @@ export const buildRecordFromImportedStructuredRow = (
       case FieldMetadataType.LINKS: {
         if (
           isDefined(
-            importedStructuredRow[`${primaryLinkUrlLabel} (${field.name})`] ||
-              importedStructuredRow[`${primaryLinkLabelLabel} (${field.name})`],
+            importedStructuredRow[`${primaryLinkUrlLabel} (${field.name})`],
           )
         ) {
           recordToBuild[field.name] = {
-            primaryLinkLabel: castToString(
-              importedStructuredRow[`${primaryLinkLabelLabel} (${field.name})`],
-            ),
+            primaryLinkLabel: '',
             primaryLinkUrl: castToString(
               importedStructuredRow[`${primaryLinkUrlLabel} (${field.name})`],
             ),

--- a/packages/twenty-front/src/modules/object-record/spreadsheet-import/utils/getSpreadSheetFieldValidationDefinitions.ts
+++ b/packages/twenty-front/src/modules/object-record/spreadsheet-import/utils/getSpreadSheetFieldValidationDefinitions.ts
@@ -2,6 +2,7 @@ import { FieldValidationDefinition } from '@/spreadsheet-import/types';
 import { isDefined } from 'twenty-ui';
 import { FieldMetadataType } from '~/generated-metadata/graphql';
 import { isValidUuid } from '~/utils/isValidUuid';
+import { absoluteUrlSchema } from '~/utils/validation-schemas/absoluteUrlSchema';
 
 export const getSpreadSheetFieldValidationDefinitions = (
   type: FieldMetadataType,
@@ -44,6 +45,16 @@ export const getSpreadSheetFieldValidationDefinitions = (
         {
           rule: 'function',
           isValid: (value: string) => isValidUuid(value),
+          errorMessage: fieldName + ' is not valid',
+          level: 'error',
+        },
+      ];
+    case FieldMetadataType.LINKS:
+      return [
+        {
+          rule: 'function',
+          isValid: (value: string) =>
+            absoluteUrlSchema.safeParse(value).success,
           errorMessage: fieldName + ' is not valid',
           level: 'error',
         },


### PR DESCRIPTION
### Context
[Issue 9019](https://github.com/twentyhq/twenty/issues/9019) opens by user having domain name not imported while importing through CSV.
@samyakpiya (thank you for your investigation !) has tested various domain imports and has reported issue with its import test. Issues that no longer exist : when I test your import, I get all records imported.

### Solution
- Remove "Link label" (cf screenshot - before fix) composite field in matching options, not used in front that could mislead the user.
<img width="300" alt="Screenshot 2025-01-28 at 15 39 18" src="https://github.com/user-attachments/assets/0ea24d9e-b339-42f3-b8d9-e271b33dbcfd" />

- Check links type fields validity in "Validate data" step


closes #9019 