### PR TITLE
Fix empty trigger on readonly + fix cache apollo on deactivation

### DIFF
--- a/packages/twenty-front/src/modules/workflow/hooks/useDeactivateWorkflowVersion.ts
+++ b/packages/twenty-front/src/modules/workflow/hooks/useDeactivateWorkflowVersion.ts
@@ -44,11 +44,11 @@ export const useDeactivateWorkflowVersion = () => {
         const cacheSnapshot = apolloClient.cache.extract();
         const workflowVersion: WorkflowVersion | undefined = Object.values(
           cacheSnapshot,
-        ).filter(
+        ).find(
           (item) =>
             item.__typename === 'WorkflowVersion' &&
             item.id === workflowVersionId,
-        )?.[0];
+        );
 
         if (!isDefined(workflowVersion)) {
           return;

--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasReadonlyEffect.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasReadonlyEffect.tsx
@@ -3,6 +3,7 @@ import { useRightDrawer } from '@/ui/layout/right-drawer/hooks/useRightDrawer';
 import { RightDrawerHotkeyScope } from '@/ui/layout/right-drawer/types/RightDrawerHotkeyScope';
 import { RightDrawerPages } from '@/ui/layout/right-drawer/types/RightDrawerPages';
 import { useSetHotkeyScope } from '@/ui/utilities/hotkey/hooks/useSetHotkeyScope';
+import { EMPTY_TRIGGER_STEP_ID } from '@/workflow/workflow-diagram/constants/EmptyTriggerStepId';
 import { useTriggerNodeSelection } from '@/workflow/workflow-diagram/hooks/useTriggerNodeSelection';
 import { workflowSelectedNodeState } from '@/workflow/workflow-diagram/states/workflowSelectedNodeState';
 import {
@@ -27,7 +28,7 @@ export const WorkflowDiagramCanvasReadonlyEffect = () => {
       const selectedNode = nodes[0] as WorkflowDiagramNode;
       const isClosingStep = isDefined(selectedNode) === false;
 
-      if (isClosingStep) {
+      if (isClosingStep || selectedNode.type === EMPTY_TRIGGER_STEP_ID) {
         closeRightDrawer();
         closeCommandMenu();
         return;
@@ -37,12 +38,6 @@ export const WorkflowDiagramCanvasReadonlyEffect = () => {
       setHotkeyScope(RightDrawerHotkeyScope.RightDrawer, { goto: false });
 
       const selectedNodeData = selectedNode.data as WorkflowDiagramStepNodeData;
-
-      if (!isDefined(selectedNodeData.name)) {
-        closeRightDrawer();
-        closeCommandMenu();
-        return;
-      }
 
       openRightDrawer(RightDrawerPages.WorkflowStepView, {
         title: selectedNodeData.name,

--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasReadonlyEffect.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasReadonlyEffect.tsx
@@ -37,6 +37,13 @@ export const WorkflowDiagramCanvasReadonlyEffect = () => {
       setHotkeyScope(RightDrawerHotkeyScope.RightDrawer, { goto: false });
 
       const selectedNodeData = selectedNode.data as WorkflowDiagramStepNodeData;
+
+      if (!isDefined(selectedNodeData.name)) {
+        closeRightDrawer();
+        closeCommandMenu();
+        return;
+      }
+
       openRightDrawer(RightDrawerPages.WorkflowStepView, {
         title: selectedNodeData.name,
         Icon: getIcon(getWorkflowNodeIconKey(selectedNodeData)),

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/components/WorkflowStepDetail.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/components/WorkflowStepDetail.tsx
@@ -48,18 +48,12 @@ export const WorkflowStepDetail = ({
     stepId,
     workflowVersion,
   });
-  if (!isDefined(stepDefinition)) {
+  if (!isDefined(stepDefinition) || !isDefined(stepDefinition.definition)) {
     return null;
   }
 
   switch (stepDefinition.type) {
     case 'trigger': {
-      if (!isDefined(stepDefinition.definition)) {
-        throw new Error(
-          'Expected the trigger to be defined at this point. Ensure the trigger has been set with a default value before trying to edit it.',
-        );
-      }
-
       switch (stepDefinition.definition.type) {
         case 'DATABASE_EVENT': {
           return (


### PR DESCRIPTION
- On deactivation, we should not need to refresh so the workflow disappear from cmd+k

https://github.com/user-attachments/assets/826fa4c6-3faa-49d1-b180-ed5d3ed187e5

- When readonly, step empty, we should not see the right drawer

https://github.com/user-attachments/assets/b557ef61-da81-446d-b160-f26c4c7a5191

