### PR TITLE
[FiX] Optimistic cache useUpdateOneRecord

### DIFF
--- a/packages/twenty-front/src/modules/object-record/hooks/useUpdateOneRecord.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useUpdateOneRecord.ts
@@ -130,12 +130,12 @@ export const useUpdateOneRecord = <
         update: (cache, { data }) => {
           const record = data?.[mutationResponseField];
 
-          if (!record || !cachedRecord) return;
+          if (!record || !computedOptimisticRecord) return;
 
           triggerUpdateRecordOptimisticEffect({
             cache,
             objectMetadataItem,
-            currentRecord: cachedRecord,
+            currentRecord: computedOptimisticRecord,
             updatedRecord: record,
             objectMetadataItems,
           });


### PR DESCRIPTION
# Introduction
~~this could be cool for the updateRecordFromCache to return the updated record, so we could consume its return value more explicitly such as `updatedRecordValue`~~

In fact this is nitpick as it would really be the same than returning the received params

## Fixes duplicated optimistic cache upsert
<img src="https://github.com/user-attachments/assets/289f4801-5b67-4e4e-a87b-a512deb5180c" width="300px" height="300px">

We were before comparing the previously `cachedRecord` which is now, not the latest as the optimistic is (should) be working successfully since https://github.com/twentyhq/twenty/pull/9881

## Reproduction
1-  Open any Company
2- Attach an Opportunity it should appears only once
3bis- If you revert the last branch commit it will appear duplicated

Related to #9580 