### PR TITLE
[BUG] Handle optimistic cache deletion operation

### DIFF
--- a/packages/twenty-front/src/modules/action-menu/actions/record-actions/multiple-records/hooks/__tests__/useDeleteMultipleRecordsAction.test.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-actions/multiple-records/hooks/__tests__/useDeleteMultipleRecordsAction.test.tsx
@@ -1,3 +1,4 @@
+import { DeleteManyRecordsProps } from '@/object-record/hooks/useDeleteManyRecords';
 import { recordStoreFamilyState } from '@/object-record/record-store/states/recordStoreFamilyState';
 import { renderHook, waitFor } from '@testing-library/react';
 import { act } from 'react';
@@ -75,13 +76,12 @@ describe('useDeleteMultipleRecordsAction', () => {
       result.current.ConfirmationModal?.props?.onConfirmClick();
     });
 
+    const expectedParams: DeleteManyRecordsProps = {
+      recordIdsToDelete: [peopleMock[0].id, peopleMock[1].id],
+    };
     await waitFor(() => {
       expect(resetTableRowSelectionMock).toHaveBeenCalled();
-
-      expect(deleteManyRecordsMock).toHaveBeenCalledWith([
-        peopleMock[0].id,
-        peopleMock[1].id,
-      ]);
+      expect(deleteManyRecordsMock).toHaveBeenCalledWith(expectedParams);
     });
   });
 });

--- a/packages/twenty-front/src/modules/action-menu/actions/record-actions/multiple-records/hooks/useDeleteMultipleRecordsAction.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-actions/multiple-records/hooks/useDeleteMultipleRecordsAction.tsx
@@ -73,7 +73,9 @@ export const useDeleteMultipleRecordsAction: ActionHookWithObjectMetadataItem =
 
       resetTableRowSelection();
 
-      await deleteManyRecords(recordIdsToDelete);
+      await deleteManyRecords({
+        recordIdsToDelete,
+      });
     }, [deleteManyRecords, fetchAllRecordIds, resetTableRowSelection]);
 
     const isRemoteObject = objectMetadataItem.isRemote;

--- a/packages/twenty-front/src/modules/action-menu/actions/record-actions/single-record/hooks/useDestroySingleRecordAction.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-actions/single-record/hooks/useDestroySingleRecordAction.tsx
@@ -4,11 +4,13 @@ import { ActionMenuContext } from '@/action-menu/contexts/ActionMenuContext';
 import { useDestroyOneRecord } from '@/object-record/hooks/useDestroyOneRecord';
 import { recordStoreFamilyState } from '@/object-record/record-store/states/recordStoreFamilyState';
 import { useRecordTable } from '@/object-record/record-table/hooks/useRecordTable';
+import { AppPath } from '@/types/AppPath';
 import { ConfirmationModal } from '@/ui/layout/modal/components/ConfirmationModal';
 import { useRightDrawer } from '@/ui/layout/right-drawer/hooks/useRightDrawer';
 import { useCallback, useContext, useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import { isDefined } from 'twenty-ui';
+import { useNavigateApp } from '~/hooks/useNavigateApp';
 
 export const useDestroySingleRecordAction: ActionHookWithObjectMetadataItem = ({
   objectMetadataItem,
@@ -17,6 +19,8 @@ export const useDestroySingleRecordAction: ActionHookWithObjectMetadataItem = ({
 
   const [isDestroyRecordsModalOpen, setIsDestroyRecordsModalOpen] =
     useState(false);
+
+  const navigateApp = useNavigateApp();
 
   const { resetTableRowSelection } = useRecordTable({
     recordTableId: objectMetadataItem.namePlural,
@@ -34,7 +38,16 @@ export const useDestroySingleRecordAction: ActionHookWithObjectMetadataItem = ({
     resetTableRowSelection();
 
     await destroyOneRecord(recordId);
-  }, [resetTableRowSelection, destroyOneRecord, recordId]);
+    navigateApp(AppPath.RecordIndexPage, {
+      objectNamePlural: objectMetadataItem.namePlural,
+    });
+  }, [
+    resetTableRowSelection,
+    destroyOneRecord,
+    recordId,
+    navigateApp,
+    objectMetadataItem.namePlural,
+  ]);
 
   const isRemoteObject = objectMetadataItem.isRemote;
 

--- a/packages/twenty-front/src/modules/activities/hooks/useOpenCreateActivityDrawer.ts
+++ b/packages/twenty-front/src/modules/activities/hooks/useOpenCreateActivityDrawer.ts
@@ -92,28 +92,26 @@ export const useOpenCreateActivityDrawer = ({
       const targetableObjectRelationIdName = `${targetableObjects[0].targetObjectNameSingular}Id`;
 
       await createOneActivityTarget({
-        taskId:
-          activityObjectNameSingular === CoreObjectNameSingular.Task
-            ? activity.id
-            : undefined,
-        noteId:
-          activityObjectNameSingular === CoreObjectNameSingular.Note
-            ? activity.id
-            : undefined,
+        ...(activityObjectNameSingular === CoreObjectNameSingular.Task
+          ? {
+              taskId: activity.id,
+            }
+          : {
+              noteId: activity.id,
+            }),
         [targetableObjectRelationIdName]: targetableObjects[0].id,
       });
 
       setActivityTargetableEntityArray(targetableObjects);
     } else {
       await createOneActivityTarget({
-        taskId:
-          activityObjectNameSingular === CoreObjectNameSingular.Task
-            ? activity.id
-            : undefined,
-        noteId:
-          activityObjectNameSingular === CoreObjectNameSingular.Note
-            ? activity.id
-            : undefined,
+        ...(activityObjectNameSingular === CoreObjectNameSingular.Task
+          ? {
+              taskId: activity.id,
+            }
+          : {
+              noteId: activity.id,
+            }),
       });
 
       setActivityTargetableEntityArray([]);

--- a/packages/twenty-front/src/modules/activities/inline-cell/components/ActivityTargetInlineCellEditMode.tsx
+++ b/packages/twenty-front/src/modules/activities/inline-cell/components/ActivityTargetInlineCellEditMode.tsx
@@ -166,7 +166,6 @@ export const ActivityTargetInlineCellEditMode = ({
           );
 
           const newActivityTargetId = v4();
-          const fieldName = record.objectMetadataItem.nameSingular;
           const fieldNameWithIdSuffix = getActivityTargetObjectFieldIdName({
             nameSingular: record.objectMetadataItem.nameSingular,
           });
@@ -179,21 +178,13 @@ export const ActivityTargetInlineCellEditMode = ({
                 activityObjectNameSingular === CoreObjectNameSingular.Task
                   ? activity.id
                   : null,
-              task:
-                activityObjectNameSingular === CoreObjectNameSingular.Task
-                  ? activity
-                  : null,
               noteId:
                 activityObjectNameSingular === CoreObjectNameSingular.Note
                   ? activity.id
                   : null,
-              note:
-                activityObjectNameSingular === CoreObjectNameSingular.Note
-                  ? activity
-                  : null,
+
               createdAt: new Date().toISOString(),
               updatedAt: new Date().toISOString(),
-              [fieldName]: record.record,
               [fieldNameWithIdSuffix]: recordId,
             },
           });

--- a/packages/twenty-front/src/modules/activities/inline-cell/components/ActivityTargetInlineCellEditMode.tsx
+++ b/packages/twenty-front/src/modules/activities/inline-cell/components/ActivityTargetInlineCellEditMode.tsx
@@ -170,23 +170,17 @@ export const ActivityTargetInlineCellEditMode = ({
             nameSingular: record.objectMetadataItem.nameSingular,
           });
 
+          const newActivityTargetInput = {
+            id: newActivityTargetId,
+            ...(activityObjectNameSingular === CoreObjectNameSingular.Task
+              ? { taskId: activity.id }
+              : { noteId: activity.id }),
+            [fieldNameWithIdSuffix]: recordId,
+          };
+
           const newActivityTarget = prefillRecord<NoteTarget | TaskTarget>({
             objectMetadataItem: objectMetadataItemActivityTarget,
-            input: {
-              id: newActivityTargetId,
-              taskId:
-                activityObjectNameSingular === CoreObjectNameSingular.Task
-                  ? activity.id
-                  : null,
-              noteId:
-                activityObjectNameSingular === CoreObjectNameSingular.Note
-                  ? activity.id
-                  : null,
-
-              createdAt: new Date().toISOString(),
-              updatedAt: new Date().toISOString(),
-              [fieldNameWithIdSuffix]: recordId,
-            },
+            input: newActivityTargetInput,
           });
 
           activityTargetsAfterUpdate.push(newActivityTarget);
@@ -204,7 +198,7 @@ export const ActivityTargetInlineCellEditMode = ({
               },
             });
           } else {
-            await createOneActivityTarget(newActivityTarget);
+            await createOneActivityTarget(newActivityTargetInput);
           }
 
           set(activityTargetObjectRecordFamilyState(recordId), {

--- a/packages/twenty-front/src/modules/activities/inline-cell/components/ActivityTargetInlineCellEditMode.tsx
+++ b/packages/twenty-front/src/modules/activities/inline-cell/components/ActivityTargetInlineCellEditMode.tsx
@@ -60,11 +60,9 @@ export const ActivityTargetInlineCellEditMode = ({
     objectNameSingular: getJoinObjectNameSingular(activityObjectNameSingular),
   });
 
-  const { deleteOneRecord: deleteOneActivityTarget } = useDeleteOneRecord(
-    {
-      objectNameSingular: getJoinObjectNameSingular(activityObjectNameSingular),
-    },
-  );
+  const { deleteOneRecord: deleteOneActivityTarget } = useDeleteOneRecord({
+    objectNameSingular: getJoinObjectNameSingular(activityObjectNameSingular),
+  });
 
   const { closeInlineCell: closeEditableField } = useInlineCell();
 

--- a/packages/twenty-front/src/modules/activities/inline-cell/components/ActivityTargetInlineCellEditMode.tsx
+++ b/packages/twenty-front/src/modules/activities/inline-cell/components/ActivityTargetInlineCellEditMode.tsx
@@ -15,7 +15,7 @@ import { getJoinObjectNameSingular } from '@/activities/utils/getJoinObjectNameS
 import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
 import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
 import { useCreateManyRecordsInCache } from '@/object-record/cache/hooks/useCreateManyRecordsInCache';
-import { useCreateManyRecords } from '@/object-record/hooks/useCreateManyRecords';
+import { useCreateOneRecord } from '@/object-record/hooks/useCreateOneRecord';
 import { useDeleteOneRecord } from '@/object-record/hooks/useDeleteOneRecord';
 import { activityTargetObjectRecordFamilyState } from '@/object-record/record-field/states/activityTargetObjectRecordFamilyState';
 import { objectRecordMultiSelectCheckedRecordsIdsComponentState } from '@/object-record/record-field/states/objectRecordMultiSelectCheckedRecordsIdsComponentState';
@@ -54,7 +54,7 @@ export const ActivityTargetInlineCellEditMode = ({
     }),
   );
 
-  const { createManyRecords: createManyActivityTargets } = useCreateManyRecords<
+  const { createOneRecord: createOneActivityTarget } = useCreateOneRecord<
     NoteTarget | TaskTarget
   >({
     objectNameSingular: getJoinObjectNameSingular(activityObjectNameSingular),
@@ -204,7 +204,7 @@ export const ActivityTargetInlineCellEditMode = ({
               },
             });
           } else {
-            await createManyActivityTargets([newActivityTarget]);
+            await createOneActivityTarget(newActivityTarget);
           }
 
           set(activityTargetObjectRecordFamilyState(recordId), {
@@ -252,7 +252,7 @@ export const ActivityTargetInlineCellEditMode = ({
     [
       activity,
       activityTargetWithTargetRecords,
-      createManyActivityTargets,
+      createOneActivityTarget,
       createManyActivityTargetsInCache,
       deleteOneActivityTarget,
       isActivityInCreateMode,

--- a/packages/twenty-front/src/modules/activities/inline-cell/components/ActivityTargetInlineCellEditMode.tsx
+++ b/packages/twenty-front/src/modules/activities/inline-cell/components/ActivityTargetInlineCellEditMode.tsx
@@ -16,7 +16,7 @@ import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadata
 import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
 import { useCreateManyRecordsInCache } from '@/object-record/cache/hooks/useCreateManyRecordsInCache';
 import { useCreateManyRecords } from '@/object-record/hooks/useCreateManyRecords';
-import { useDeleteManyRecords } from '@/object-record/hooks/useDeleteManyRecords';
+import { useDeleteOneRecord } from '@/object-record/hooks/useDeleteOneRecord';
 import { activityTargetObjectRecordFamilyState } from '@/object-record/record-field/states/activityTargetObjectRecordFamilyState';
 import { objectRecordMultiSelectCheckedRecordsIdsComponentState } from '@/object-record/record-field/states/objectRecordMultiSelectCheckedRecordsIdsComponentState';
 import {
@@ -60,7 +60,7 @@ export const ActivityTargetInlineCellEditMode = ({
     objectNameSingular: getJoinObjectNameSingular(activityObjectNameSingular),
   });
 
-  const { deleteManyRecords: deleteManyActivityTargets } = useDeleteManyRecords(
+  const { deleteOneRecord: deleteOneActivityTarget } = useDeleteOneRecord(
     {
       objectNameSingular: getJoinObjectNameSingular(activityObjectNameSingular),
     },
@@ -252,7 +252,7 @@ export const ActivityTargetInlineCellEditMode = ({
               },
             });
           } else {
-            await deleteManyActivityTargets([activityTargetToDeleteId]);
+            await deleteOneActivityTarget(activityTargetToDeleteId);
           }
 
           set(activityTargetObjectRecordFamilyState(recordId), {
@@ -265,7 +265,7 @@ export const ActivityTargetInlineCellEditMode = ({
       activityTargetWithTargetRecords,
       createManyActivityTargets,
       createManyActivityTargetsInCache,
-      deleteManyActivityTargets,
+      deleteOneActivityTarget,
       isActivityInCreateMode,
       objectMetadataItemActivityTarget,
       recordPickerInstanceId,

--- a/packages/twenty-front/src/modules/favorites/hooks/useCreateFavoriteFolder.ts
+++ b/packages/twenty-front/src/modules/favorites/hooks/useCreateFavoriteFolder.ts
@@ -22,7 +22,6 @@ export const useCreateFavoriteFolder = () => {
     );
 
     await createFavoriteFolder({
-      workspaceMemberId: currentWorkspaceMemberId,
       name,
       position: maxPosition + 1,
     });

--- a/packages/twenty-front/src/modules/object-record/hooks/__tests__/useDeleteManyRecords.test.tsx
+++ b/packages/twenty-front/src/modules/object-record/hooks/__tests__/useDeleteManyRecords.test.tsx
@@ -52,7 +52,7 @@ describe('useDeleteManyRecords', () => {
     );
 
     await act(async () => {
-      const res = await result.current.deleteManyRecords(personIds);
+      const res = await result.current.deleteManyRecords({recordIdsToDelete: personIds});
       expect(res).toBeDefined();
       expect(res[0]).toHaveProperty('id');
     });

--- a/packages/twenty-front/src/modules/object-record/hooks/__tests__/useDeleteManyRecords.test.tsx
+++ b/packages/twenty-front/src/modules/object-record/hooks/__tests__/useDeleteManyRecords.test.tsx
@@ -52,7 +52,9 @@ describe('useDeleteManyRecords', () => {
     );
 
     await act(async () => {
-      const res = await result.current.deleteManyRecords({recordIdsToDelete: personIds});
+      const res = await result.current.deleteManyRecords({
+        recordIdsToDelete: personIds,
+      });
       expect(res).toBeDefined();
       expect(res[0]).toHaveProperty('id');
     });

--- a/packages/twenty-front/src/modules/object-record/hooks/useCreateManyRecords.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useCreateManyRecords.ts
@@ -135,7 +135,7 @@ export const useCreateManyRecords = <
         update: (cache, { data }) => {
           const records = data?.[mutationResponseField];
 
-          if (!records?.length || skipPostOptmisticEffect) return;
+          if (!isDefined(records?.length) || skipPostOptmisticEffect) return;
 
           triggerCreateRecordsOptimisticEffect({
             cache,

--- a/packages/twenty-front/src/modules/object-record/hooks/useDeleteManyRecords.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useDeleteManyRecords.ts
@@ -24,7 +24,8 @@ type useDeleteManyRecordProps = {
   refetchFindManyQuery?: boolean;
 };
 
-type DeleteManyRecordsOptions = {
+type DeleteManyRecordsProps = {
+  recordIdsToDelete: string[];
   skipOptimisticEffect?: boolean;
   delayInMsBetweenRequests?: number;
 };
@@ -61,16 +62,16 @@ export const useDeleteManyRecords = ({
     objectMetadataItem.namePlural,
   );
 
-  const deleteManyRecords = async (
-    idsToDelete: string[],
-    options?: DeleteManyRecordsOptions,
-  ) => {
-    const numberOfBatches = Math.ceil(idsToDelete.length / mutationPageSize);
-
+  const deleteManyRecords = async ({
+    recordIdsToDelete,
+    delayInMsBetweenRequests,
+    skipOptimisticEffect = false,
+  }: DeleteManyRecordsProps) => {
+    const numberOfBatches = Math.ceil(recordIdsToDelete.length / mutationPageSize);
     const deletedRecords = [];
 
     for (let batchIndex = 0; batchIndex < numberOfBatches; batchIndex++) {
-      const batchedIdsToDelete = idsToDelete.slice(
+      const batchedIdsToDelete = recordIdsToDelete.slice(
         batchIndex * mutationPageSize,
         (batchIndex + 1) * mutationPageSize,
       );
@@ -81,22 +82,21 @@ export const useDeleteManyRecords = ({
         .map((idToDelete) => getRecordFromCache(idToDelete, apolloClient.cache))
         .filter(isDefined);
 
-      const cachedRecordsWithConnection: RecordGqlNode[] = [];
-      const optimisticRecordsWithConnection: RecordGqlNode[] = [];
+      if (!skipOptimisticEffect) {
+        const cachedRecordsNode: RecordGqlNode[] = [];
+        const computedOptimisticRecordsNode: RecordGqlNode[] = [];
 
-      if (!options?.skipOptimisticEffect) {
         cachedRecords.forEach((cachedRecord) => {
           if (!isDefined(cachedRecord) || !isDefined(cachedRecord.id)) {
             return;
           }
 
-          const cachedRecordWithConnection =
-            getRecordNodeFromRecord<ObjectRecord>({
-              record: cachedRecord,
-              objectMetadataItem,
-              objectMetadataItems,
-              computeReferences: false,
-            });
+          const cachedRecordNode = getRecordNodeFromRecord<ObjectRecord>({
+            record: cachedRecord,
+            objectMetadataItem,
+            objectMetadataItems,
+            computeReferences: false,
+          });
 
           const computedOptimisticRecord = {
             ...cachedRecord,
@@ -104,20 +104,16 @@ export const useDeleteManyRecords = ({
             ...{ __typename: capitalize(objectMetadataItem.nameSingular) },
           };
 
-          const optimisticRecordWithConnection =
-            getRecordNodeFromRecord<ObjectRecord>({
-              record: computedOptimisticRecord,
-              objectMetadataItem,
-              objectMetadataItems,
-              computeReferences: false,
-            });
+          const optimisticRecordNode = getRecordNodeFromRecord<ObjectRecord>({
+            record: computedOptimisticRecord,
+            objectMetadataItem,
+            objectMetadataItems,
+            computeReferences: false,
+          });
 
-          if (!optimisticRecordWithConnection || !cachedRecordWithConnection) {
-            return null;
+          if (!isDefined(optimisticRecordNode) || !isDefined(cachedRecordNode)) {
+            return;
           }
-
-          cachedRecordsWithConnection.push(cachedRecordWithConnection);
-          optimisticRecordsWithConnection.push(optimisticRecordWithConnection);
 
           updateRecordFromCache({
             objectMetadataItems,
@@ -125,13 +121,16 @@ export const useDeleteManyRecords = ({
             cache: apolloClient.cache,
             record: computedOptimisticRecord,
           });
+
+          computedOptimisticRecordsNode.push(optimisticRecordNode);
+          cachedRecordsNode.push(cachedRecordNode);
         });
 
         triggerUpdateRecordOptimisticEffectByBatch({
           cache: apolloClient.cache,
           objectMetadataItem,
-          currentRecords: cachedRecordsWithConnection,
-          updatedRecords: optimisticRecordsWithConnection,
+          currentRecords: cachedRecordsNode,
+          updatedRecords: computedOptimisticRecordsNode,
           objectMetadataItems,
         });
       }
@@ -144,8 +143,8 @@ export const useDeleteManyRecords = ({
           },
         })
         .catch((error: Error) => {
-          const cachedRecordsWithConnection: RecordGqlNode[] = [];
-          const optimisticRecordsWithConnection: RecordGqlNode[] = [];
+          const cachedRecordsNode: RecordGqlNode[] = [];
+          const computedOptimisticRecordsNode: RecordGqlNode[] = [];
 
           cachedRecords.forEach((cachedRecord) => {
             if (isUndefinedOrNull(cachedRecord?.id)) {
@@ -182,23 +181,21 @@ export const useDeleteManyRecords = ({
               });
 
             if (
-              !optimisticRecordWithConnection ||
-              !cachedRecordWithConnection
+              !isDefined(optimisticRecordWithConnection) ||
+              !isDefined(cachedRecordWithConnection)
             ) {
               return;
             }
 
-            cachedRecordsWithConnection.push(cachedRecordWithConnection);
-            optimisticRecordsWithConnection.push(
-              optimisticRecordWithConnection,
-            );
+            cachedRecordsNode.push(cachedRecordWithConnection);
+            computedOptimisticRecordsNode.push(optimisticRecordWithConnection);
           });
 
           triggerUpdateRecordOptimisticEffectByBatch({
             cache: apolloClient.cache,
             objectMetadataItem,
-            currentRecords: optimisticRecordsWithConnection,
-            updatedRecords: cachedRecordsWithConnection,
+            currentRecords: computedOptimisticRecordsNode,
+            updatedRecords: cachedRecordsNode,
             objectMetadataItems,
           });
 
@@ -210,8 +207,8 @@ export const useDeleteManyRecords = ({
 
       deletedRecords.push(...deletedRecordsForThisBatch);
 
-      if (isDefined(options?.delayInMsBetweenRequests)) {
-        await sleep(options.delayInMsBetweenRequests);
+      if (isDefined(delayInMsBetweenRequests)) {
+        await sleep(delayInMsBetweenRequests);
       }
     }
     await refetchAggregateQueries();

--- a/packages/twenty-front/src/modules/object-record/hooks/useDeleteManyRecords.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useDeleteManyRecords.ts
@@ -86,7 +86,7 @@ export const useDeleteManyRecords = ({
 
       if (!options?.skipOptimisticEffect) {
         cachedRecords.forEach((cachedRecord) => {
-          if (!cachedRecord || !cachedRecord.id) {
+          if (!isDefined(cachedRecord) || !isDefined(cachedRecord.id)) {
             return;
           }
 

--- a/packages/twenty-front/src/modules/object-record/hooks/useDeleteManyRecords.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useDeleteManyRecords.ts
@@ -95,7 +95,7 @@ export const useDeleteManyRecords = ({
               record: cachedRecord,
               objectMetadataItem,
               objectMetadataItems,
-              computeReferences: true,
+              computeReferences: false,
             });
 
           const computedOptimisticRecord = {
@@ -109,7 +109,7 @@ export const useDeleteManyRecords = ({
               record: computedOptimisticRecord,
               objectMetadataItem,
               objectMetadataItems,
-              computeReferences: true,
+              computeReferences: false,
             });
 
           if (!optimisticRecordWithConnection || !cachedRecordWithConnection) {

--- a/packages/twenty-front/src/modules/object-record/hooks/useDeleteManyRecords.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useDeleteManyRecords.ts
@@ -67,7 +67,9 @@ export const useDeleteManyRecords = ({
     delayInMsBetweenRequests,
     skipOptimisticEffect = false,
   }: DeleteManyRecordsProps) => {
-    const numberOfBatches = Math.ceil(recordIdsToDelete.length / mutationPageSize);
+    const numberOfBatches = Math.ceil(
+      recordIdsToDelete.length / mutationPageSize,
+    );
     const deletedRecords = [];
 
     for (let batchIndex = 0; batchIndex < numberOfBatches; batchIndex++) {
@@ -111,7 +113,10 @@ export const useDeleteManyRecords = ({
             computeReferences: false,
           });
 
-          if (!isDefined(optimisticRecordNode) || !isDefined(cachedRecordNode)) {
+          if (
+            !isDefined(optimisticRecordNode) ||
+            !isDefined(cachedRecordNode)
+          ) {
             return;
           }
 

--- a/packages/twenty-front/src/modules/object-record/hooks/useDeleteManyRecords.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useDeleteManyRecords.ts
@@ -168,7 +168,7 @@ export const useDeleteManyRecords = ({
                 record: cachedRecord,
                 objectMetadataItem,
                 objectMetadataItems,
-                computeReferences: true,
+                computeReferences: false,
               });
 
             const computedOptimisticRecord = {
@@ -182,7 +182,7 @@ export const useDeleteManyRecords = ({
                 record: computedOptimisticRecord,
                 objectMetadataItem,
                 objectMetadataItems,
-                computeReferences: true,
+                computeReferences: false,
               });
 
             if (

--- a/packages/twenty-front/src/modules/object-record/hooks/useDeleteManyRecords.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useDeleteManyRecords.ts
@@ -24,7 +24,7 @@ type useDeleteManyRecordProps = {
   refetchFindManyQuery?: boolean;
 };
 
-type DeleteManyRecordsProps = {
+export type DeleteManyRecordsProps = {
   recordIdsToDelete: string[];
   skipOptimisticEffect?: boolean;
   delayInMsBetweenRequests?: number;

--- a/packages/twenty-front/src/modules/object-record/hooks/useDeleteOneRecord.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useDeleteOneRecord.ts
@@ -99,12 +99,12 @@ export const useDeleteOneRecord = ({
           update: (cache, { data }) => {
             const record = data?.[mutationResponseField];
 
-            if (!record || !cachedRecord) return;
+            if (!isDefined(record) || !isDefined(computedOptimisticRecord)) return;
 
             triggerUpdateRecordOptimisticEffect({
               cache,
               objectMetadataItem,
-              currentRecord: cachedRecord,
+              currentRecord: computedOptimisticRecord,
               updatedRecord: record,
               objectMetadataItems,
             });

--- a/packages/twenty-front/src/modules/object-record/hooks/useDeleteOneRecord.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useDeleteOneRecord.ts
@@ -63,13 +63,12 @@ export const useDeleteOneRecord = ({
         ...{ __typename: capitalize(objectMetadataItem.nameSingular) },
       };
 
-      const optimisticRecordNode =
-        getRecordNodeFromRecord<ObjectRecord>({
-          record: computedOptimisticRecord,
-          objectMetadataItem,
-          objectMetadataItems,
-          computeReferences: false,
-        });
+      const optimisticRecordNode = getRecordNodeFromRecord<ObjectRecord>({
+        record: computedOptimisticRecord,
+        objectMetadataItem,
+        objectMetadataItems,
+        computeReferences: false,
+      });
 
       if (!isDefined(optimisticRecordNode) || !isDefined(cachedRecordNode)) {
         return null;
@@ -99,7 +98,8 @@ export const useDeleteOneRecord = ({
           update: (cache, { data }) => {
             const record = data?.[mutationResponseField];
 
-            if (!isDefined(record) || !isDefined(computedOptimisticRecord)) return;
+            if (!isDefined(record) || !isDefined(computedOptimisticRecord))
+              return;
 
             triggerUpdateRecordOptimisticEffect({
               cache,

--- a/packages/twenty-front/src/modules/object-record/hooks/useDeleteOneRecord.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useDeleteOneRecord.ts
@@ -49,11 +49,11 @@ export const useDeleteOneRecord = ({
 
       const cachedRecord = getRecordFromCache(idToDelete, apolloClient.cache);
 
-      const cachedRecordWithConnection = getRecordNodeFromRecord<ObjectRecord>({
+      const cachedRecordNode = getRecordNodeFromRecord<ObjectRecord>({
         record: cachedRecord,
         objectMetadataItem,
         objectMetadataItems,
-        computeReferences: true,
+        computeReferences: false,
       });
 
       const computedOptimisticRecord = {
@@ -62,15 +62,15 @@ export const useDeleteOneRecord = ({
         ...{ __typename: capitalize(objectMetadataItem.nameSingular) },
       };
 
-      const optimisticRecordWithConnection =
+      const optimisticRecordNode =
         getRecordNodeFromRecord<ObjectRecord>({
           record: computedOptimisticRecord,
           objectMetadataItem,
           objectMetadataItems,
-          computeReferences: true,
+          computeReferences: false,
         });
 
-      if (!optimisticRecordWithConnection || !cachedRecordWithConnection) {
+      if (!optimisticRecordNode || !cachedRecordNode) {
         return null;
       }
 
@@ -84,8 +84,8 @@ export const useDeleteOneRecord = ({
       triggerUpdateRecordOptimisticEffect({
         cache: apolloClient.cache,
         objectMetadataItem,
-        currentRecord: cachedRecordWithConnection,
-        updatedRecord: optimisticRecordWithConnection,
+        currentRecord: cachedRecordNode,
+        updatedRecord: optimisticRecordNode,
         objectMetadataItems,
       });
 
@@ -123,8 +123,8 @@ export const useDeleteOneRecord = ({
           triggerUpdateRecordOptimisticEffect({
             cache: apolloClient.cache,
             objectMetadataItem,
-            currentRecord: optimisticRecordWithConnection,
-            updatedRecord: cachedRecordWithConnection,
+            currentRecord: optimisticRecordNode,
+            updatedRecord: cachedRecordNode,
             objectMetadataItems,
           });
 

--- a/packages/twenty-front/src/modules/object-record/hooks/useDeleteOneRecord.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useDeleteOneRecord.ts
@@ -12,6 +12,7 @@ import { useRefetchAggregateQueries } from '@/object-record/hooks/useRefetchAggr
 import { ObjectRecord } from '@/object-record/types/ObjectRecord';
 import { getDeleteOneRecordMutationResponseField } from '@/object-record/utils/getDeleteOneRecordMutationResponseField';
 import { capitalize } from 'twenty-shared';
+import { isDefined } from 'twenty-ui';
 
 type useDeleteOneRecordProps = {
   objectNameSingular: string;
@@ -70,7 +71,7 @@ export const useDeleteOneRecord = ({
           computeReferences: false,
         });
 
-      if (!optimisticRecordNode || !cachedRecordNode) {
+      if (!isDefined(optimisticRecordNode) || !isDefined(cachedRecordNode)) {
         return null;
       }
 

--- a/packages/twenty-front/src/modules/object-record/hooks/useUpdateOneRecord.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useUpdateOneRecord.ts
@@ -131,7 +131,8 @@ export const useUpdateOneRecord = <
         update: (cache, { data }) => {
           const record = data?.[mutationResponseField];
 
-          if (!isDefined(record) || !isDefined(computedOptimisticRecord)) return;
+          if (!isDefined(record) || !isDefined(computedOptimisticRecord))
+            return;
 
           triggerUpdateRecordOptimisticEffect({
             cache,

--- a/packages/twenty-front/src/modules/object-record/hooks/useUpdateOneRecord.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useUpdateOneRecord.ts
@@ -14,6 +14,7 @@ import { computeOptimisticRecordFromInput } from '@/object-record/utils/computeO
 import { getUpdateOneRecordMutationResponseField } from '@/object-record/utils/getUpdateOneRecordMutationResponseField';
 import { sanitizeRecordInput } from '@/object-record/utils/sanitizeRecordInput';
 import { capitalize } from 'twenty-shared';
+import { isDefined } from 'twenty-ui';
 import { isUndefinedOrNull } from '~/utils/isUndefinedOrNull';
 
 type useUpdateOneRecordProps = {
@@ -130,7 +131,7 @@ export const useUpdateOneRecord = <
         update: (cache, { data }) => {
           const record = data?.[mutationResponseField];
 
-          if (!record || !computedOptimisticRecord) return;
+          if (!isDefined(record) || !isDefined(computedOptimisticRecord)) return;
 
           triggerUpdateRecordOptimisticEffect({
             cache,

--- a/packages/twenty-front/src/modules/object-record/utils/__tests__/computeOptimisticRecordFromInput.test.ts
+++ b/packages/twenty-front/src/modules/object-record/utils/__tests__/computeOptimisticRecordFromInput.test.ts
@@ -179,4 +179,28 @@ describe('computeOptimisticRecordFromInput', () => {
       `"Should never provide relation mutation through anything else than the fieldId e.g companyId"`,
     );
   });
+
+  it('should throw an error if recordInput contains both the relationFieldId and relationField even if null', () => {
+    const cache = new InMemoryCache();
+    const personObjectMetadataItem = generatedMockObjectMetadataItems.find(
+      (item) => item.nameSingular === 'person',
+    );
+    if (!personObjectMetadataItem) {
+      throw new Error('Person object metadata item not found');
+    }
+
+    expect(() =>
+      computeOptimisticRecordFromInput({
+        objectMetadataItems: generatedMockObjectMetadataItems,
+        objectMetadataItem: personObjectMetadataItem,
+        recordInput: {
+          companyId: '123',
+          company: null,
+        },
+        cache,
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Should never provide relation mutation through anything else than the fieldId e.g companyId"`,
+    );
+  });
 });

--- a/packages/twenty-front/src/modules/object-record/utils/computeOptimisticRecordFromInput.ts
+++ b/packages/twenty-front/src/modules/object-record/utils/computeOptimisticRecordFromInput.ts
@@ -91,7 +91,7 @@ export const computeOptimisticRecordFromInput = ({
       continue;
     }
 
-    if (isDefined(recordInputFieldValue)) {
+    if (!isUndefined(recordInputFieldValue)) {
       throw new Error(
         'Should never provide relation mutation through anything else than the fieldId e.g companyId',
       );

--- a/packages/twenty-front/src/modules/object-record/utils/sanitizeRecordInput.ts
+++ b/packages/twenty-front/src/modules/object-record/utils/sanitizeRecordInput.ts
@@ -34,8 +34,10 @@ export const sanitizeRecordInput = ({
             (field) => field.name === relationIdFieldName,
           );
 
+          const relationIdFieldValue = recordInput[relationIdFieldName];
+
           return relationIdFieldMetadataItem
-            ? [relationIdFieldName, fieldValue?.id ?? null]
+            ? [relationIdFieldName, relationIdFieldValue ?? null]
             : undefined;
         }
 


### PR DESCRIPTION
# Introduction
This PR is highly related to previous optimistic cache refactor: https://github.com/twentyhq/twenty/pull/9881
Here we've added some logic within the `triggerUpdateRelationsOptimisticEffect` which will now run if given recordInput `deletedAt` field is defined.

If deletion, we will iterate over all the fields searching for `RELATION` for which deletion might implies necessity to detach the relation

## Known troubleshooting ( also on main )
![image](https://github.com/user-attachments/assets/10ad59cd-e87b-4f26-89df-0a028fcfa518)
We might have to refactor the `prefillRecord` to spread and overrides`inputValue` over defaultOne as inputValue could be a partial one for more info please a look to 

# Conclusion
Any suggestions are welcomed !
fixes https://github.com/twentyhq/twenty/issues/9580