### PR TITLE
Prevent all workflow node and edge deletions made through the UI

### DIFF
--- a/packages/twenty-e2e-testing/tests/workflow-visualizer.spec.ts
+++ b/packages/twenty-e2e-testing/tests/workflow-visualizer.spec.ts
@@ -184,3 +184,35 @@ test('Replace the trigger of an active version', async ({
     'Create Record',
   ]);
 });
+
+test("Nodes can't be deleted by pressing Backspace or Delete keys", async ({
+  workflowVisualizer,
+  page,
+}) => {
+  await workflowVisualizer.triggerNode.click();
+
+  await page.keyboard.press('Backspace');
+  await page.keyboard.press('Delete');
+
+  await expect(workflowVisualizer.triggerNode).toBeVisible();
+
+  const { createdStepId: firstStepId } =
+    await workflowVisualizer.createStep('create-record');
+  const firstStep = workflowVisualizer.getStepNode(firstStepId);
+
+  await firstStep.click();
+
+  await expect(workflowVisualizer.getDeleteNodeButton(firstStep)).toBeVisible();
+
+  await page.keyboard.press('Backspace');
+  await page.keyboard.press('Delete');
+
+  await expect(firstStep).toBeVisible();
+
+  await workflowVisualizer.addStepButton.click();
+
+  await page.keyboard.press('Backspace');
+  await page.keyboard.press('Delete');
+
+  await expect(workflowVisualizer.addStepButton).toBeVisible();
+});

--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasBase.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasBase.tsx
@@ -225,6 +225,10 @@ export const WorkflowDiagramCanvasBase = ({
         edges={edges}
         onNodesChange={handleNodesChange}
         onEdgesChange={handleEdgesChange}
+        onBeforeDelete={async () => {
+          // Abort all non-programmatic deletions
+          return false;
+        }}
         proOptions={{ hideAttribution: true }}
         multiSelectionKeyCode={null}
         nodesFocusable={false}


### PR DESCRIPTION
## Old

In the demo, I press the `Delete` key multiple times, and it deletes the nodes.

https://github.com/user-attachments/assets/75bf84d3-b182-488c-a781-bbe236985142

## New

https://github.com/user-attachments/assets/4ae4f387-e143-4ce8-8140-6cb2c549f5d2

