### PR TITLE
[FIX] Storybook race condition

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/__stories__/RelationToOneFieldInput.stories.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/__stories__/RelationToOneFieldInput.stories.tsx
@@ -139,10 +139,8 @@ export const Submit: Story = {
       timeout: 3000,
     });
 
-    await waitFor(() => {
-      userEvent.click(item);
-      expect(submitJestFn).toHaveBeenCalledTimes(1);
-    });
+    await userEvent.click(item);
+    await waitFor(() => expect(submitJestFn).toHaveBeenCalledTimes(1));
   },
 };
 


### PR DESCRIPTION
Flaky test can be found [here](https://github.com/twentyhq/twenty/actions/runs/13052735697/job/36416799488)
Action should be outside the waitFor callback

## Context
It seems to occurs since the Charles tooltip perf refactor https://github.com/twentyhq/twenty/commit/ae4bf8d9298ca77cc45f6f4b0c25b66b51ad834f
Maybe the tests render being faster it changed order of execution ? idk still interesting