### PR TITLE
Use refetch instead of cache modify when activating/deactivating a workflow

### DIFF
--- a/packages/twenty-front/src/modules/workflow/hooks/useActivateWorkflowVersion.ts
+++ b/packages/twenty-front/src/modules/workflow/hooks/useActivateWorkflowVersion.ts
@@ -1,11 +1,8 @@
 import { useApolloClient, useMutation } from '@apollo/client';
 
-import { triggerUpdateRecordOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerUpdateRecordOptimisticEffect';
-import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
 import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
-import { modifyRecordFromCache } from '@/object-record/cache/utils/modifyRecordFromCache';
+import { useFindManyRecordsQuery } from '@/object-record/hooks/useFindManyRecordsQuery';
 import { ACTIVATE_WORKFLOW_VERSION } from '@/workflow/graphql/mutations/activateWorkflowVersion';
-import { WorkflowVersion } from '@/workflow/types/Workflow';
 import {
   ActivateWorkflowVersionMutation,
   ActivateWorkflowVersionMutationVariables,
@@ -20,8 +17,8 @@ export const useActivateWorkflowVersion = () => {
     client: apolloClient,
   });
 
-  const { objectMetadataItem: objectMetadataItemWorkflowVersion } =
-    useObjectMetadataItem({
+  const { findManyRecordsQuery: findManyWorkflowVersionsQuery } =
+    useFindManyRecordsQuery({
       objectNameSingular: CoreObjectNameSingular.WorkflowVersion,
     });
 
@@ -36,55 +33,14 @@ export const useActivateWorkflowVersion = () => {
       variables: {
         workflowVersionId,
       },
-      update: () => {
-        modifyRecordFromCache({
-          cache: apolloClient.cache,
-          recordId: workflowVersionId,
-          objectMetadataItem: objectMetadataItemWorkflowVersion,
-          fieldModifiers: {
-            status: () => 'ACTIVE',
+      refetchQueries: [
+        {
+          query: findManyWorkflowVersionsQuery,
+          variables: {
+            id: workflowId,
           },
-        });
-
-        const cacheSnapshot = apolloClient.cache.extract();
-        const allWorkflowVersions: Array<WorkflowVersion> = Object.values(
-          cacheSnapshot,
-        ).filter(
-          (item) =>
-            item.__typename === 'WorkflowVersion' &&
-            item.workflowId === workflowId,
-        );
-
-        const previousActiveWorkflowVersions = allWorkflowVersions.filter(
-          (version) =>
-            version.status === 'ACTIVE' && version.id !== workflowVersionId,
-        );
-
-        for (const workflowVersion of previousActiveWorkflowVersions) {
-          apolloClient.cache.modify({
-            id: apolloClient.cache.identify(workflowVersion),
-            fields: {
-              status: () => {
-                return workflowVersion.id !== workflowVersionId &&
-                  workflowVersion.status === 'ACTIVE'
-                  ? 'ARCHIVED'
-                  : workflowVersion.status;
-              },
-            },
-          });
-
-          triggerUpdateRecordOptimisticEffect({
-            cache: apolloClient.cache,
-            objectMetadataItem: objectMetadataItemWorkflowVersion,
-            currentRecord: workflowVersion,
-            updatedRecord: {
-              ...workflowVersion,
-              status: 'ARCHIVED',
-            },
-            objectMetadataItems: [objectMetadataItemWorkflowVersion],
-          });
-        }
-      },
+        },
+      ],
     });
   };
 

--- a/packages/twenty-front/src/modules/workflow/hooks/useDeactivateWorkflowVersion.ts
+++ b/packages/twenty-front/src/modules/workflow/hooks/useDeactivateWorkflowVersion.ts
@@ -1,12 +1,8 @@
 import { useApolloClient, useMutation } from '@apollo/client';
 
-import { triggerUpdateRecordOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerUpdateRecordOptimisticEffect';
-import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
 import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
-import { modifyRecordFromCache } from '@/object-record/cache/utils/modifyRecordFromCache';
+import { useFindManyRecordsQuery } from '@/object-record/hooks/useFindManyRecordsQuery';
 import { DEACTIVATE_WORKFLOW_VERSION } from '@/workflow/graphql/mutations/deactivateWorkflowVersion';
-import { WorkflowVersion } from '@/workflow/types/Workflow';
-import { isDefined } from 'twenty-ui';
 import {
   DeactivateWorkflowVersionMutation,
   DeactivateWorkflowVersionMutationVariables,
@@ -21,8 +17,8 @@ export const useDeactivateWorkflowVersion = () => {
     client: apolloClient,
   });
 
-  const { objectMetadataItem: objectMetadataItemWorkflowVersion } =
-    useObjectMetadataItem({
+  const { findManyRecordsQuery: findManyWorkflowVersionsQuery } =
+    useFindManyRecordsQuery({
       objectNameSingular: CoreObjectNameSingular.WorkflowVersion,
     });
 
@@ -31,40 +27,14 @@ export const useDeactivateWorkflowVersion = () => {
       variables: {
         workflowVersionId,
       },
-      update: () => {
-        modifyRecordFromCache({
-          cache: apolloClient.cache,
-          recordId: workflowVersionId,
-          objectMetadataItem: objectMetadataItemWorkflowVersion,
-          fieldModifiers: {
-            status: () => 'DEACTIVATED',
+      refetchQueries: [
+        {
+          query: findManyWorkflowVersionsQuery,
+          variables: {
+            id: workflowVersionId,
           },
-        });
-
-        const cacheSnapshot = apolloClient.cache.extract();
-        const workflowVersion: WorkflowVersion | undefined = Object.values(
-          cacheSnapshot,
-        ).find(
-          (item) =>
-            item.__typename === 'WorkflowVersion' &&
-            item.id === workflowVersionId,
-        );
-
-        if (!isDefined(workflowVersion)) {
-          return;
-        }
-
-        triggerUpdateRecordOptimisticEffect({
-          cache: apolloClient.cache,
-          objectMetadataItem: objectMetadataItemWorkflowVersion,
-          currentRecord: workflowVersion,
-          updatedRecord: {
-            ...workflowVersion,
-            status: 'DEACTIVATED',
-          },
-          objectMetadataItems: [objectMetadataItemWorkflowVersion],
-        });
-      },
+        },
+      ],
     });
   };
 


### PR DESCRIPTION
Workflow version statuses are too complex to handle in cache. You always need to:
- modify entity in cache
- modify queries in cache
- do the same for all other version statuses that should also be updated

This complex behavior leads to bugs because of a cache wrongly updated.

Let's simply do a refetch versions on status update.