### PR TITLE
Remove demo from readme as users can create free trial on production

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,9 @@
 
 <br>
 
-# Demo 
+# Installation 
 
-Go to <a href="https://demo.twenty.com/">demo.twenty.com</a> and login with the following credentials:
-
-```
-email: tim@apple.dev
-password: Applecar2025
-```
-
-See also:  
+See:  
 🚀 [Self-hosting](https://twenty.com/developers/section/self-hosting)  
 🖥️ [Local Setup](https://twenty.com/developers/local-setup)  
 

--- a/packages/twenty-e2e-testing/tests/demo/demo_basic.spec.ts
+++ b/packages/twenty-e2e-testing/tests/demo/demo_basic.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from '@playwright/test';
 test('Check if demo account is working properly @demo-only', async ({
   page,
 }) => {
-  await page.goto('https://demo.twenty.com/');
+  await page.goto('https://app.twenty-next.com/');
   await page.getByRole('button', { name: 'Continue With Email' }).click();
   await page.getByRole('button', { name: 'Continue', exact: true }).click();
   await page.getByRole('button', { name: 'Sign in' }).click();

--- a/packages/twenty-e2e-testing/tests/login.setup.ts
+++ b/packages/twenty-e2e-testing/tests/login.setup.ts
@@ -19,7 +19,7 @@ test('Login test', async ({ loginPage, page }) => {
     async () => {
       await page.waitForLoadState('networkidle');
       if (
-        page.url().includes('demo.twenty.com') ||
+        page.url().includes('app.twenty-next.com') ||
         !page.url().includes('app.localhost:3001')
       ) {
         await loginPage.clickLoginWithEmail();

--- a/packages/twenty-website/src/app/_components/playground/token-form.tsx
+++ b/packages/twenty-website/src/app/_components/playground/token-form.tsx
@@ -1,8 +1,8 @@
 'use client';
 
+import { usePathname, useRouter } from 'next/navigation';
 import React, { useEffect, useState } from 'react';
 import { TbApi, TbChevronLeft, TbLink } from 'react-icons/tb';
-import { usePathname, useRouter } from 'next/navigation';
 
 // @ts-expect-error Migration loader as text not passing warnings
 import tokenForm from '!css-loader!./token-form.css';
@@ -71,8 +71,8 @@ const TokenForm = ({
     let url: string;
     if (locationSetting === 'production') {
       url = 'https://api.twenty.com';
-    } else if (locationSetting === 'demo') {
-      url = 'https://api-demo.twenty.com';
+    } else if (locationSetting === 'next') {
+      url = 'https://api.twenty-next.com';
     } else if (locationSetting === 'localhost') {
       url = 'http://localhost:3000';
     } else {

--- a/packages/twenty-website/src/content/user-guide/getting-started/what-is-twenty.mdx
+++ b/packages/twenty-website/src/content/user-guide/getting-started/what-is-twenty.mdx
@@ -44,14 +44,6 @@ Modern web browser (Firefox, Chrome, Safari and Edge on their latest version are
 
 Internet connection (Offline mode isn't yet supported).
 
-## Demo
-
-If you wish to try Twenty before creating your own account, go to demo.twenty.com and login with the following credentials:
-
-
-`email: tim@apple.dev`\
-`password: Applecar2025`
-
 ## Vision
 Creating a good CRM is hard because it's a balancing act.
 For each business, the requirements seem straightforward, yet everyone's needs are distinct.


### PR DESCRIPTION
We have recently introduced the possibility to sign up on Twenty cloud without having to input a credit card which makes the demo.twenty.com useless. Deprecating it!