### PR TITLE
fix(icon): update Microsoft Outlook icon import

### DIFF
--- a/packages/twenty-ui/src/display/icon/components/IconMicrosoftOutlook.tsx
+++ b/packages/twenty-ui/src/display/icon/components/IconMicrosoftOutlook.tsx
@@ -1,6 +1,6 @@
 import { useTheme } from '@emotion/react';
 
-import IconMicrosoftRaw from '../assets/microsoft.svg?react';
+import IconMicrosoftOutlookRaw from '../assets/microsoft-outlook.svg?react';
 
 interface IconMicrosoftOutlookProps {
   size?: number;
@@ -10,5 +10,5 @@ export const IconMicrosoftOutlook = (props: IconMicrosoftOutlookProps) => {
   const theme = useTheme();
   const size = props.size ?? theme.icon.size.lg;
 
-  return <IconMicrosoftRaw height={size} width={size} />;
+  return <IconMicrosoftOutlookRaw height={size} width={size} />;
 };


### PR DESCRIPTION
Replaced the incorrect Microsoft icon with the correct Microsoft Outlook icon. This ensures the displayed icon matches the intended usage and improves consistency.