### PR TITLE
Fix composite type update migration builder

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version/0-41/0-41-add-context-to-actor-composite-type.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-41/0-41-add-context-to-actor-composite-type.ts
@@ -98,12 +98,6 @@ export class AddContextToActorCompositeTypeCommand extends ActiveWorkspacesComma
         );
 
       if (!dryRun) {
-        await this.workspaceMetadataVersionService.incrementMetadataVersion(
-          workspaceId,
-        );
-      }
-
-      if (!dryRun) {
         const rowsToUpdate = await fieldRepository.update(
           {
             [field.name + 'Source']: In([
@@ -123,6 +117,12 @@ export class AddContextToActorCompositeTypeCommand extends ActiveWorkspacesComma
           `updated ${rowsToUpdate ? rowsToUpdate.affected : 0} rows`,
         );
       }
+    }
+
+    if (!dryRun) {
+      await this.workspaceMetadataVersionService.incrementMetadataVersion(
+        workspaceId,
+      );
     }
   }
 

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/composite-types/actor.composite-type.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/composite-types/actor.composite-type.ts
@@ -1,9 +1,9 @@
 import { ConnectedAccountProvider, FieldMetadataType } from 'twenty-shared';
+import { v4 } from 'uuid';
 
-import {
-  CompositeProperty,
-  CompositeType,
-} from 'src/engine/metadata-modules/field-metadata/interfaces/composite-type.interface';
+import { CompositeType } from 'src/engine/metadata-modules/field-metadata/interfaces/composite-type.interface';
+
+import { FieldMetadataDefaultOption } from 'src/engine/metadata-modules/field-metadata/dtos/options.input';
 
 export enum FieldActorSource {
   EMAIL = 'EMAIL',
@@ -23,12 +23,16 @@ export const actorCompositeType: CompositeType = {
       type: FieldMetadataType.SELECT,
       hidden: false,
       isRequired: true,
-      options: Object.keys(FieldActorSource).map((key, index) => ({
-        label: `${FieldActorSource[key].toLowerCase()}`,
-        value: key,
-        position: index,
-      })),
-    } as CompositeProperty<FieldMetadataType.SELECT>,
+      options: Object.keys(FieldActorSource).map(
+        (key, index) =>
+          ({
+            id: v4(),
+            label: `${FieldActorSource[key].toLowerCase()}`,
+            value: key,
+            position: index,
+          }) satisfies Required<FieldMetadataDefaultOption>,
+      ),
+    },
     {
       name: 'workspaceMemberId',
       type: FieldMetadataType.UUID,


### PR DESCRIPTION
Not providing the id in the options of source property of the ACTOR type was leading to an issue while re-computing changes during sync-metadata