### PR TITLE
fix: prevent updating isCustom on object and field metadata

### DIFF
--- a/packages/twenty-front/src/generated/graphql.tsx
+++ b/packages/twenty-front/src/generated/graphql.tsx
@@ -1604,7 +1604,6 @@ export type UpdateFieldInput = {
   description?: InputMaybe<Scalars['String']>;
   icon?: InputMaybe<Scalars['String']>;
   isActive?: InputMaybe<Scalars['Boolean']>;
-  isCustom?: InputMaybe<Scalars['Boolean']>;
   isLabelSyncedWithName?: InputMaybe<Scalars['Boolean']>;
   isNullable?: InputMaybe<Scalars['Boolean']>;
   isSystem?: InputMaybe<Scalars['Boolean']>;

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/dtos/update-field.input.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/dtos/update-field.input.ts
@@ -15,7 +15,7 @@ import { FieldMetadataDTO } from 'src/engine/metadata-modules/field-metadata/dto
 @InputType()
 export class UpdateFieldInput extends OmitType(
   PartialType(FieldMetadataDTO, InputType),
-  ['id', 'type', 'createdAt', 'updatedAt'] as const,
+  ['id', 'type', 'createdAt', 'updatedAt', 'isCustom'] as const,
 ) {
   @HideField()
   id: string;


### PR DESCRIPTION
This PR prevents updating isCustom on object and field metadata.

Example graphql mutation now cannot be used to modify existing field's isCustom property as expected.

```
mutation UpdateOneFieldMetadataItem(
    $idToUpdate: UUID!
    $updatePayload: UpdateFieldInput!
  ) {
    updateOneField(input: { id: $idToUpdate, update: $updatePayload }) {
      id
     isCustom
    }
  }
```

Example payload is not allowed now and it will return error in response. 

```
{
  "idToUpdate": "80c6c8df-f719-42d2-985a-353468a3ed00",
  "updatePayload": {
    "isCustom": true
  }
}
```

fixes- #6581