### PR TITLE
Sort active workspaces

### DIFF
--- a/packages/twenty-server/src/database/commands/active-workspaces.command.ts
+++ b/packages/twenty-server/src/database/commands/active-workspaces.command.ts
@@ -40,6 +40,9 @@ export abstract class ActiveWorkspacesCommandRunner extends BaseCommandRunner {
           WorkspaceActivationStatus.SUSPENDED,
         ]),
       },
+      order: {
+        createdAt: 'ASC',
+      },
     });
 
     return activeWorkspaces.map((workspace) => workspace.id);


### PR DESCRIPTION
Adding an order when fetching active workspaces so that when we run command we can better understand the workspaces from the logs. Also, if the command fails, we know we could start from a specific createdAt later on