### PR TITLE
361 create a navigation stack for the command menu

### DIFF
--- a/packages/twenty-front/src/modules/action-menu/actions/record-agnostic-actions/hooks/useSearchRecordsRecordAgnosticAction.ts
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-agnostic-actions/hooks/useSearchRecordsRecordAgnosticAction.ts
@@ -1,25 +1,17 @@
 import { useCommandMenu } from '@/command-menu/hooks/useCommandMenu';
-import { commandMenuPageState } from '@/command-menu/states/commandMenuPageState';
-import { commandMenuPageInfoState } from '@/command-menu/states/commandMenuPageTitle';
 import { CommandMenuPages } from '@/command-menu/types/CommandMenuPages';
-import { useRecoilCallback } from 'recoil';
 import { IconSearch } from 'twenty-ui';
 
 export const useSearchRecordsRecordAgnosticAction = () => {
-  const { openCommandMenu } = useCommandMenu();
+  const { navigateCommandMenu } = useCommandMenu();
 
-  const onClick = useRecoilCallback(
-    ({ set }) =>
-      () => {
-        set(commandMenuPageState, CommandMenuPages.SearchRecords);
-        set(commandMenuPageInfoState, {
-          title: 'Search',
-          Icon: IconSearch,
-        });
-        openCommandMenu();
-      },
-    [openCommandMenu],
-  );
+  const onClick = () => {
+    navigateCommandMenu({
+      page: CommandMenuPages.SearchRecords,
+      pageTitle: 'Search',
+      pageIcon: IconSearch,
+    });
+  };
 
   return {
     onClick,

--- a/packages/twenty-front/src/modules/command-menu/hooks/__tests__/useCommandMenu.test.tsx
+++ b/packages/twenty-front/src/modules/command-menu/hooks/__tests__/useCommandMenu.test.tsx
@@ -191,7 +191,7 @@ describe('useCommandMenu', () => {
     });
 
     expect(result.current.commandMenuNavigationStack).toEqual([]);
-    expect(result.current.commandMenuPage).toBe(undefined);
+    expect(result.current.commandMenuPage).toBe(CommandMenuPages.Root);
     expect(result.current.commandMenuPageInfo).toEqual({
       title: undefined,
       Icon: undefined,

--- a/packages/twenty-front/src/modules/command-menu/hooks/__tests__/useCommandMenu.test.tsx
+++ b/packages/twenty-front/src/modules/command-menu/hooks/__tests__/useCommandMenu.test.tsx
@@ -138,4 +138,64 @@ describe('useCommandMenu', () => {
       Icon: undefined,
     });
   });
+
+  it('should go back from a page', () => {
+    const { result } = renderHooks();
+
+    act(() => {
+      result.current.commandMenu.navigateCommandMenu({
+        page: CommandMenuPages.SearchRecords,
+        pageTitle: 'Search',
+        pageIcon: IconSearch,
+      });
+    });
+
+    act(() => {
+      result.current.commandMenu.navigateCommandMenu({
+        page: CommandMenuPages.ViewRecord,
+        pageTitle: 'View Record',
+      });
+    });
+
+    expect(result.current.commandMenuNavigationStack).toEqual([
+      {
+        page: CommandMenuPages.SearchRecords,
+        pageTitle: 'Search',
+        pageIcon: IconSearch,
+      },
+      {
+        page: CommandMenuPages.ViewRecord,
+        pageTitle: 'View Record',
+      },
+    ]);
+
+    act(() => {
+      result.current.commandMenu.goBackFromCommandMenu();
+    });
+
+    expect(result.current.commandMenuNavigationStack).toEqual([
+      {
+        page: CommandMenuPages.SearchRecords,
+        pageTitle: 'Search',
+        pageIcon: IconSearch,
+      },
+    ]);
+    expect(result.current.commandMenuPage).toBe(CommandMenuPages.SearchRecords);
+    expect(result.current.commandMenuPageInfo).toEqual({
+      title: 'Search',
+      Icon: IconSearch,
+    });
+
+    act(() => {
+      result.current.commandMenu.goBackFromCommandMenu();
+    });
+
+    expect(result.current.commandMenuNavigationStack).toEqual([]);
+    expect(result.current.commandMenuPage).toBe(undefined);
+    expect(result.current.commandMenuPageInfo).toEqual({
+      title: undefined,
+      Icon: undefined,
+    });
+    expect(result.current.isCommandMenuOpened).toBe(false);
+  });
 });

--- a/packages/twenty-front/src/modules/command-menu/hooks/__tests__/useCommandMenu.test.tsx
+++ b/packages/twenty-front/src/modules/command-menu/hooks/__tests__/useCommandMenu.test.tsx
@@ -198,4 +198,26 @@ describe('useCommandMenu', () => {
     });
     expect(result.current.isCommandMenuOpened).toBe(false);
   });
+
+  it('should navigate to a page in history', () => {
+    const { result } = renderHooks();
+
+    act(() => {
+      result.current.commandMenu.navigateCommandMenu({
+        page: CommandMenuPages.SearchRecords,
+        pageTitle: 'Search',
+        pageIcon: IconSearch,
+      });
+    });
+
+    act(() => {
+      result.current.commandMenu.navigateCommandMenuHistory(0);
+    });
+
+    expect(result.current.commandMenuPage).toBe(CommandMenuPages.SearchRecords);
+    expect(result.current.commandMenuPageInfo).toEqual({
+      title: 'Search',
+      Icon: IconSearch,
+    });
+  });
 });

--- a/packages/twenty-front/src/modules/command-menu/hooks/__tests__/useCommandMenu.test.tsx
+++ b/packages/twenty-front/src/modules/command-menu/hooks/__tests__/useCommandMenu.test.tsx
@@ -4,7 +4,12 @@ import { MemoryRouter } from 'react-router-dom';
 import { RecoilRoot, useRecoilValue } from 'recoil';
 
 import { useCommandMenu } from '@/command-menu/hooks/useCommandMenu';
+import { commandMenuNavigationStackState } from '@/command-menu/states/commandMenuNavigationStackState';
+import { commandMenuPageState } from '@/command-menu/states/commandMenuPageState';
+import { commandMenuPageInfoState } from '@/command-menu/states/commandMenuPageTitle';
 import { isCommandMenuOpenedState } from '@/command-menu/states/isCommandMenuOpenedState';
+import { CommandMenuPages } from '@/command-menu/types/CommandMenuPages';
+import { IconSearch } from 'twenty-ui';
 
 const Wrapper = ({ children }: { children: React.ReactNode }) => (
   <RecoilRoot>
@@ -22,10 +27,18 @@ const renderHooks = () => {
     () => {
       const commandMenu = useCommandMenu();
       const isCommandMenuOpened = useRecoilValue(isCommandMenuOpenedState);
+      const commandMenuNavigationStack = useRecoilValue(
+        commandMenuNavigationStackState,
+      );
+      const commandMenuPage = useRecoilValue(commandMenuPageState);
+      const commandMenuPageInfo = useRecoilValue(commandMenuPageInfoState);
 
       return {
         commandMenu,
         isCommandMenuOpened,
+        commandMenuNavigationStack,
+        commandMenuPage,
+        commandMenuPageInfo,
       };
     },
     {
@@ -68,5 +81,61 @@ describe('useCommandMenu', () => {
     });
 
     expect(result.current.isCommandMenuOpened).toBe(false);
+  });
+
+  it('should navigate to a page', () => {
+    const { result } = renderHooks();
+
+    expect(result.current.commandMenuNavigationStack).toEqual([]);
+    expect(result.current.commandMenuPage).toBe(CommandMenuPages.Root);
+    expect(result.current.commandMenuPageInfo).toEqual({
+      title: undefined,
+      Icon: undefined,
+    });
+
+    act(() => {
+      result.current.commandMenu.navigateCommandMenu({
+        page: CommandMenuPages.SearchRecords,
+        pageTitle: 'Search',
+        pageIcon: IconSearch,
+      });
+    });
+
+    expect(result.current.commandMenuNavigationStack).toEqual([
+      {
+        page: CommandMenuPages.SearchRecords,
+        pageTitle: 'Search',
+        pageIcon: IconSearch,
+      },
+    ]);
+    expect(result.current.commandMenuPage).toBe(CommandMenuPages.SearchRecords);
+    expect(result.current.commandMenuPageInfo).toEqual({
+      title: 'Search',
+      Icon: IconSearch,
+    });
+
+    act(() => {
+      result.current.commandMenu.navigateCommandMenu({
+        page: CommandMenuPages.ViewRecord,
+        pageTitle: 'View Record',
+      });
+    });
+
+    expect(result.current.commandMenuNavigationStack).toEqual([
+      {
+        page: CommandMenuPages.SearchRecords,
+        pageTitle: 'Search',
+        pageIcon: IconSearch,
+      },
+      {
+        page: CommandMenuPages.ViewRecord,
+        pageTitle: 'View Record',
+      },
+    ]);
+    expect(result.current.commandMenuPage).toBe(CommandMenuPages.ViewRecord);
+    expect(result.current.commandMenuPageInfo).toEqual({
+      title: 'View Record',
+      Icon: undefined,
+    });
   });
 });

--- a/packages/twenty-front/src/modules/command-menu/hooks/useCommandMenu.ts
+++ b/packages/twenty-front/src/modules/command-menu/hooks/useCommandMenu.ts
@@ -143,10 +143,7 @@ export const useCommandMenu = () => {
         const newNavigationStack = currentNavigationStack.slice(0, -1);
         const lastNavigationStackItem = newNavigationStack.at(-1);
 
-        if (
-          newNavigationStack.length === 0 ||
-          !isDefined(lastNavigationStackItem)
-        ) {
+        if (!isDefined(lastNavigationStackItem)) {
           closeCommandMenu();
           return;
         }
@@ -174,14 +171,13 @@ export const useCommandMenu = () => {
 
       set(commandMenuNavigationStackState, newNavigationStack);
 
-      if (newNavigationStack.length === 0) {
+      const newNavigationStackItem = newNavigationStack.at(-1);
+
+      if (!isDefined(newNavigationStackItem)) {
         throw new Error(
           `No command menu navigation stack item found for index ${pageIndex}`,
         );
       }
-
-      const newNavigationStackItem =
-        newNavigationStack[newNavigationStack.length - 1];
 
       set(commandMenuPageState, newNavigationStackItem?.page);
       set(commandMenuPageInfoState, {

--- a/packages/twenty-front/src/modules/command-menu/hooks/useCommandMenu.ts
+++ b/packages/twenty-front/src/modules/command-menu/hooks/useCommandMenu.ts
@@ -169,7 +169,7 @@ export const useCommandMenu = () => {
         .getLoadable(commandMenuNavigationStackState)
         .getValue();
 
-      const newNavigationStack = currentNavigationStack.slice(0, pageIndex);
+      const newNavigationStack = currentNavigationStack.slice(0, pageIndex + 1);
 
       set(commandMenuNavigationStackState, newNavigationStack);
 

--- a/packages/twenty-front/src/modules/command-menu/hooks/useCommandMenu.ts
+++ b/packages/twenty-front/src/modules/command-menu/hooks/useCommandMenu.ts
@@ -77,9 +77,7 @@ export const useCommandMenu = () => {
           });
           set(isCommandMenuOpenedState, false);
           set(commandMenuSearchState, '');
-          set(commandMenuNavigationStackState, [
-            { page: CommandMenuPages.Root },
-          ]);
+          set(commandMenuNavigationStackState, []);
           resetSelectedItem();
           goBackToPreviousHotkeyScope();
 
@@ -145,16 +143,17 @@ export const useCommandMenu = () => {
 
         if (newNavigationStack.length === 0) {
           closeCommandMenu();
+          return;
         }
 
         const lastNavigationStackItem =
           newNavigationStack[newNavigationStack.length - 1];
 
-        set(commandMenuPageState, lastNavigationStackItem?.page);
+        set(commandMenuPageState, lastNavigationStackItem.page);
 
         set(commandMenuPageInfoState, {
-          title: lastNavigationStackItem?.pageTitle,
-          Icon: lastNavigationStackItem?.pageIcon,
+          title: lastNavigationStackItem.pageTitle,
+          Icon: lastNavigationStackItem.pageIcon,
         });
 
         set(commandMenuNavigationStackState, newNavigationStack);

--- a/packages/twenty-front/src/modules/command-menu/hooks/useCommandMenu.ts
+++ b/packages/twenty-front/src/modules/command-menu/hooks/useCommandMenu.ts
@@ -23,6 +23,7 @@ import { ContextStoreViewType } from '@/context-store/types/ContextStoreViewType
 import { viewableRecordIdState } from '@/object-record/record-right-drawer/states/viewableRecordIdState';
 import { viewableRecordNameSingularState } from '@/object-record/record-right-drawer/states/viewableRecordNameSingularState';
 import { emitRightDrawerCloseEvent } from '@/ui/layout/right-drawer/utils/emitRightDrawerCloseEvent';
+import { isDefined } from 'twenty-shared';
 import { IconSearch } from 'twenty-ui';
 import { isCommandMenuOpenedState } from '../states/isCommandMenuOpenedState';
 
@@ -140,14 +141,15 @@ export const useCommandMenu = () => {
           .getValue();
 
         const newNavigationStack = currentNavigationStack.slice(0, -1);
+        const lastNavigationStackItem = newNavigationStack.at(-1);
 
-        if (newNavigationStack.length === 0) {
+        if (
+          newNavigationStack.length === 0 ||
+          !isDefined(lastNavigationStackItem)
+        ) {
           closeCommandMenu();
           return;
         }
-
-        const lastNavigationStackItem =
-          newNavigationStack[newNavigationStack.length - 1];
 
         set(commandMenuPageState, lastNavigationStackItem.page);
 

--- a/packages/twenty-front/src/modules/command-menu/hooks/useCommandMenu.ts
+++ b/packages/twenty-front/src/modules/command-menu/hooks/useCommandMenu.ts
@@ -163,6 +163,33 @@ export const useCommandMenu = () => {
     [closeCommandMenu],
   );
 
+  const navigateCommandMenuHistory = useRecoilCallback(({ snapshot, set }) => {
+    return (pageIndex: number) => {
+      const currentNavigationStack = snapshot
+        .getLoadable(commandMenuNavigationStackState)
+        .getValue();
+
+      const newNavigationStack = currentNavigationStack.slice(0, pageIndex);
+
+      set(commandMenuNavigationStackState, newNavigationStack);
+
+      if (newNavigationStack.length === 0) {
+        throw new Error(
+          `No command menu navigation stack item found for index ${pageIndex}`,
+        );
+      }
+
+      const newNavigationStackItem =
+        newNavigationStack[newNavigationStack.length - 1];
+
+      set(commandMenuPageState, newNavigationStackItem?.page);
+      set(commandMenuPageInfoState, {
+        title: newNavigationStackItem?.pageTitle,
+        Icon: newNavigationStackItem?.pageIcon,
+      });
+    };
+  }, []);
+
   const openRecordInCommandMenu = useRecoilCallback(
     ({ set }) => {
       return (recordId: string, objectNameSingular: string) => {
@@ -238,6 +265,7 @@ export const useCommandMenu = () => {
     openCommandMenu,
     closeCommandMenu,
     navigateCommandMenu,
+    navigateCommandMenuHistory,
     goBackFromCommandMenu,
     openRecordsSearchPage,
     openRecordInCommandMenu,

--- a/packages/twenty-front/src/modules/command-menu/hooks/useCommandMenu.ts
+++ b/packages/twenty-front/src/modules/command-menu/hooks/useCommandMenu.ts
@@ -206,7 +206,7 @@ export const useCommandMenu = () => {
   const openRecordsSearchPage = () => {
     navigateCommandMenu({
       page: CommandMenuPages.SearchRecords,
-      pageTitle: 'Search records',
+      pageTitle: 'Search',
       pageIcon: IconSearch,
     });
   };

--- a/packages/twenty-front/src/modules/command-menu/hooks/useCommandMenu.ts
+++ b/packages/twenty-front/src/modules/command-menu/hooks/useCommandMenu.ts
@@ -203,15 +203,13 @@ export const useCommandMenu = () => {
     [navigateCommandMenu],
   );
 
-  const openRecordsSearchPage = useRecoilCallback(() => {
-    return () => {
-      navigateCommandMenu({
-        page: CommandMenuPages.SearchRecords,
-        pageTitle: 'Search records',
-        pageIcon: IconSearch,
-      });
-    };
-  }, [navigateCommandMenu]);
+  const openRecordsSearchPage = () => {
+    navigateCommandMenu({
+      page: CommandMenuPages.SearchRecords,
+      pageTitle: 'Search records',
+      pageIcon: IconSearch,
+    });
+  };
 
   const setGlobalCommandMenuContext = useRecoilCallback(
     ({ set }) => {

--- a/packages/twenty-front/src/modules/command-menu/hooks/useCommandMenu.ts
+++ b/packages/twenty-front/src/modules/command-menu/hooks/useCommandMenu.ts
@@ -7,6 +7,10 @@ import { AppHotkeyScope } from '@/ui/utilities/hotkey/types/AppHotkeyScope';
 
 import { useCopyContextStoreStates } from '@/command-menu/hooks/useCopyContextStoreAndActionMenuStates';
 import { useResetContextStoreStates } from '@/command-menu/hooks/useResetContextStoreStates';
+import {
+  CommandMenuNavigationStackItem,
+  commandMenuNavigationStackState,
+} from '@/command-menu/states/commandMenuNavigationStackState';
 import { commandMenuPageState } from '@/command-menu/states/commandMenuPageState';
 import { commandMenuPageInfoState } from '@/command-menu/states/commandMenuPageTitle';
 import { CommandMenuPages } from '@/command-menu/types/CommandMenuPages';
@@ -73,6 +77,9 @@ export const useCommandMenu = () => {
           });
           set(isCommandMenuOpenedState, false);
           set(commandMenuSearchState, '');
+          set(commandMenuNavigationStackState, [
+            { page: CommandMenuPages.Root },
+          ]);
           resetSelectedItem();
           goBackToPreviousHotkeyScope();
 
@@ -100,31 +107,77 @@ export const useCommandMenu = () => {
     [closeCommandMenu, openCommandMenu],
   );
 
-  const openRecordInCommandMenu = useRecoilCallback(
-    ({ set }) => {
-      return (recordId: string, objectNameSingular: string) => {
+  const navigateCommandMenu = useRecoilCallback(
+    ({ snapshot, set }) => {
+      return ({
+        page,
+        pageTitle,
+        pageIcon,
+      }: CommandMenuNavigationStackItem) => {
+        set(commandMenuPageState, page);
+        set(commandMenuPageInfoState, {
+          title: pageTitle,
+          Icon: pageIcon,
+        });
+
+        const currentNavigationStack = snapshot
+          .getLoadable(commandMenuNavigationStackState)
+          .getValue();
+
+        set(commandMenuNavigationStackState, [
+          ...currentNavigationStack,
+          { page, pageTitle, pageIcon },
+        ]);
         openCommandMenu();
-        set(commandMenuPageState, CommandMenuPages.ViewRecord);
-        set(viewableRecordNameSingularState, objectNameSingular);
-        set(viewableRecordIdState, recordId);
       };
     },
     [openCommandMenu],
   );
 
-  const openRecordsSearchPage = useRecoilCallback(
+  const goBackFromCommandMenu = useRecoilCallback(({ snapshot, set }) => {
+    return () => {
+      const currentNavigationStack = snapshot
+        .getLoadable(commandMenuNavigationStackState)
+        .getValue();
+
+      const newNavigationStack = currentNavigationStack.slice(0, -1);
+
+      const lastNavigationStackItem =
+        newNavigationStack[newNavigationStack.length - 1];
+
+      set(commandMenuPageState, lastNavigationStackItem.page);
+
+      set(commandMenuPageInfoState, {
+        title: lastNavigationStackItem.pageTitle,
+        Icon: lastNavigationStackItem.pageIcon,
+      });
+
+      set(commandMenuNavigationStackState, newNavigationStack);
+    };
+  }, []);
+
+  const openRecordInCommandMenu = useRecoilCallback(
     ({ set }) => {
-      return () => {
-        set(commandMenuPageState, CommandMenuPages.SearchRecords);
-        set(commandMenuPageInfoState, {
-          title: 'Search',
-          Icon: IconSearch,
+      return (recordId: string, objectNameSingular: string) => {
+        set(viewableRecordNameSingularState, objectNameSingular);
+        set(viewableRecordIdState, recordId);
+        navigateCommandMenu({
+          page: CommandMenuPages.ViewRecord,
         });
-        openCommandMenu();
       };
     },
-    [openCommandMenu],
+    [navigateCommandMenu],
   );
+
+  const openRecordsSearchPage = useRecoilCallback(() => {
+    return () => {
+      navigateCommandMenu({
+        page: CommandMenuPages.SearchRecords,
+        pageTitle: 'Search records',
+        pageIcon: IconSearch,
+      });
+    };
+  }, [navigateCommandMenu]);
 
   const setGlobalCommandMenuContext = useRecoilCallback(
     ({ set }) => {
@@ -177,6 +230,8 @@ export const useCommandMenu = () => {
   return {
     openCommandMenu,
     closeCommandMenu,
+    navigateCommandMenu,
+    goBackFromCommandMenu,
     openRecordsSearchPage,
     openRecordInCommandMenu,
     toggleCommandMenu,

--- a/packages/twenty-front/src/modules/command-menu/hooks/useCommandMenu.ts
+++ b/packages/twenty-front/src/modules/command-menu/hooks/useCommandMenu.ts
@@ -142,14 +142,18 @@ export const useCommandMenu = () => {
 
       const newNavigationStack = currentNavigationStack.slice(0, -1);
 
+      if (newNavigationStack.length === 0) {
+        closeCommandMenu();
+      }
+
       const lastNavigationStackItem =
         newNavigationStack[newNavigationStack.length - 1];
 
-      set(commandMenuPageState, lastNavigationStackItem.page);
+      set(commandMenuPageState, lastNavigationStackItem?.page);
 
       set(commandMenuPageInfoState, {
-        title: lastNavigationStackItem.pageTitle,
-        Icon: lastNavigationStackItem.pageIcon,
+        title: lastNavigationStackItem?.pageTitle,
+        Icon: lastNavigationStackItem?.pageIcon,
       });
 
       set(commandMenuNavigationStackState, newNavigationStack);

--- a/packages/twenty-front/src/modules/command-menu/hooks/useCommandMenu.ts
+++ b/packages/twenty-front/src/modules/command-menu/hooks/useCommandMenu.ts
@@ -134,31 +134,34 @@ export const useCommandMenu = () => {
     [openCommandMenu],
   );
 
-  const goBackFromCommandMenu = useRecoilCallback(({ snapshot, set }) => {
-    return () => {
-      const currentNavigationStack = snapshot
-        .getLoadable(commandMenuNavigationStackState)
-        .getValue();
+  const goBackFromCommandMenu = useRecoilCallback(
+    ({ snapshot, set }) => {
+      return () => {
+        const currentNavigationStack = snapshot
+          .getLoadable(commandMenuNavigationStackState)
+          .getValue();
 
-      const newNavigationStack = currentNavigationStack.slice(0, -1);
+        const newNavigationStack = currentNavigationStack.slice(0, -1);
 
-      if (newNavigationStack.length === 0) {
-        closeCommandMenu();
-      }
+        if (newNavigationStack.length === 0) {
+          closeCommandMenu();
+        }
 
-      const lastNavigationStackItem =
-        newNavigationStack[newNavigationStack.length - 1];
+        const lastNavigationStackItem =
+          newNavigationStack[newNavigationStack.length - 1];
 
-      set(commandMenuPageState, lastNavigationStackItem?.page);
+        set(commandMenuPageState, lastNavigationStackItem?.page);
 
-      set(commandMenuPageInfoState, {
-        title: lastNavigationStackItem?.pageTitle,
-        Icon: lastNavigationStackItem?.pageIcon,
-      });
+        set(commandMenuPageInfoState, {
+          title: lastNavigationStackItem?.pageTitle,
+          Icon: lastNavigationStackItem?.pageIcon,
+        });
 
-      set(commandMenuNavigationStackState, newNavigationStack);
-    };
-  }, []);
+        set(commandMenuNavigationStackState, newNavigationStack);
+      };
+    },
+    [closeCommandMenu],
+  );
 
   const openRecordInCommandMenu = useRecoilCallback(
     ({ set }) => {

--- a/packages/twenty-front/src/modules/command-menu/states/commandMenuNavigationStackState.ts
+++ b/packages/twenty-front/src/modules/command-menu/states/commandMenuNavigationStackState.ts
@@ -1,0 +1,19 @@
+import { CommandMenuPages } from '@/command-menu/types/CommandMenuPages';
+import { IconComponent, createState } from 'twenty-ui';
+
+type CommandMenuNavigationStackItem = {
+  page: CommandMenuPages;
+  pageTitle?: string;
+  pageIcon?: IconComponent;
+};
+
+export const commandMenuNavigationStackState = createState<
+  CommandMenuNavigationStackItem[]
+>({
+  key: 'command-menu/commandMenuNavigationStackState',
+  defaultValue: [
+    {
+      page: CommandMenuPages.Root,
+    },
+  ],
+});

--- a/packages/twenty-front/src/modules/command-menu/states/commandMenuNavigationStackState.ts
+++ b/packages/twenty-front/src/modules/command-menu/states/commandMenuNavigationStackState.ts
@@ -11,9 +11,5 @@ export const commandMenuNavigationStackState = createState<
   CommandMenuNavigationStackItem[]
 >({
   key: 'command-menu/commandMenuNavigationStackState',
-  defaultValue: [
-    {
-      page: CommandMenuPages.Root,
-    },
-  ],
+  defaultValue: [],
 });

--- a/packages/twenty-front/src/modules/command-menu/states/commandMenuNavigationStackState.ts
+++ b/packages/twenty-front/src/modules/command-menu/states/commandMenuNavigationStackState.ts
@@ -1,7 +1,7 @@
 import { CommandMenuPages } from '@/command-menu/types/CommandMenuPages';
 import { IconComponent, createState } from 'twenty-ui';
 
-type CommandMenuNavigationStackItem = {
+export type CommandMenuNavigationStackItem = {
   page: CommandMenuPages;
   pageTitle?: string;
   pageIcon?: IconComponent;

--- a/packages/twenty-front/src/modules/ui/layout/right-drawer/hooks/useRightDrawer.ts
+++ b/packages/twenty-front/src/modules/ui/layout/right-drawer/hooks/useRightDrawer.ts
@@ -4,8 +4,6 @@ import { isRightDrawerMinimizedState } from '@/ui/layout/right-drawer/states/isR
 import { rightDrawerCloseEventState } from '@/ui/layout/right-drawer/states/rightDrawerCloseEventsState';
 
 import { useCommandMenu } from '@/command-menu/hooks/useCommandMenu';
-import { commandMenuPageState } from '@/command-menu/states/commandMenuPageState';
-import { commandMenuPageInfoState } from '@/command-menu/states/commandMenuPageTitle';
 import { emitRightDrawerCloseEvent } from '@/ui/layout/right-drawer/utils/emitRightDrawerCloseEvent';
 import { mapRightDrawerPageToCommandMenuPage } from '@/ui/layout/right-drawer/utils/mapRightDrawerPageToCommandMenuPage';
 import { useIsFeatureEnabled } from '@/workspace/hooks/useIsFeatureEnabled';
@@ -25,7 +23,7 @@ export const useRightDrawer = () => {
     FeatureFlagKey.IsCommandMenuV2Enabled,
   );
 
-  const { openCommandMenu } = useCommandMenu();
+  const { navigateCommandMenu } = useCommandMenu();
 
   const openRightDrawer = useRecoilCallback(
     ({ set }) =>
@@ -40,12 +38,12 @@ export const useRightDrawer = () => {
           const commandMenuPage =
             mapRightDrawerPageToCommandMenuPage(rightDrawerPage);
 
-          set(commandMenuPageState, commandMenuPage);
-          set(commandMenuPageInfoState, {
-            title: commandMenuPageInfo?.title,
-            Icon: commandMenuPageInfo?.Icon,
+          navigateCommandMenu({
+            page: commandMenuPage,
+            pageTitle: commandMenuPageInfo?.title,
+            pageIcon: commandMenuPageInfo?.Icon,
           });
-          openCommandMenu();
+
           return;
         }
 
@@ -53,7 +51,7 @@ export const useRightDrawer = () => {
         set(isRightDrawerOpenState, true);
         set(isRightDrawerMinimizedState, false);
       },
-    [isCommandMenuV2Enabled, openCommandMenu],
+    [isCommandMenuV2Enabled, navigateCommandMenu],
   );
 
   const closeRightDrawer = useRecoilCallback(


### PR DESCRIPTION
Closes https://github.com/twentyhq/core-team-issues/issues/361

- Created navigation stack state
- Created navigation functions inside the `useCommandMenu` hook
- Added tests