### PR TITLE
[FIX] Nx project's scope build dependency management

### DIFF
--- a/packages/twenty-chrome-extension/project.json
+++ b/packages/twenty-chrome-extension/project.json
@@ -8,7 +8,8 @@
       "outputs": ["{options.outputPath}"],
       "options": {
         "outputPath": "{projectRoot}/dist"
-      }
+      },
+      "dependsOn": ["^build"]
     },
     "start": {
       "executor": "nx:run-commands",

--- a/packages/twenty-docker/twenty/Dockerfile
+++ b/packages/twenty-docker/twenty/Dockerfile
@@ -26,9 +26,6 @@ COPY ./packages/twenty-emails /app/packages/twenty-emails
 COPY ./packages/twenty-shared /app/packages/twenty-shared
 COPY ./packages/twenty-server /app/packages/twenty-server
 
-RUN npx nx run twenty-shared:build
-RUN npx nx run twenty-emails:build
-
 RUN npx nx run twenty-server:build
 RUN mv /app/packages/twenty-server/dist /app/packages/twenty-server/build
 RUN npx nx run twenty-server:build:packageJson

--- a/packages/twenty-emails/package.json
+++ b/packages/twenty-emails/package.json
@@ -9,6 +9,9 @@
   "scripts": {
     "build": "npx vite build"
   },
+  "dependencies": {
+    "twenty-shared": "workspace:*"
+  },
   "exports": {
     ".": {
       "import": "./dist/index.mjs",

--- a/packages/twenty-emails/project.json
+++ b/packages/twenty-emails/project.json
@@ -8,7 +8,8 @@
       "outputs": ["{options.outputPath}"],
       "options": {
         "outputPath": "{projectRoot}/dist"
-      }
+      },
+      "dependsOn": ["^build"]
     },
     "typecheck": {},
     "lint": {

--- a/packages/twenty-server/project.json
+++ b/packages/twenty-server/project.json
@@ -10,7 +10,8 @@
       "options": {
         "cwd": "packages/twenty-server",
         "commands": ["rimraf dist", "nest build --path ./tsconfig.build.json"]
-      }
+      },
+      "dependsOn": ["^build"]
     },
     "test:integration": {
       "executor": "nx:run-commands",


### PR DESCRIPTION
# Introduction
Defined  `dependsOn` for each nx project's configuration that has a dependency to another local package ( ui, shared ).
As follows:
```json
"dependsOn": ["^build"]
``` 
Where the `^` symbol means "all dependencies of this project"

Now on a fresh repo, no built or install deps after install dependencies you can directly hit `npx nx build PROJECT_NAME`
closes https://github.com/twentyhq/core-team-issues/issues/371

Related what was failing [run](https://github.com/twentyhq/twenty-infra/actions/runs/13141544809/job/36669643182)
Cancelled before deploy, attested build was correct within the publish and digest