### PR TITLE
[FEAT] Destroy many Workflow actions

### DIFF
--- a/packages/twenty-front/src/modules/action-menu/actions/record-actions/constants/WorkflowActionsConfig.ts
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-actions/constants/WorkflowActionsConfig.ts
@@ -1,4 +1,5 @@
 import { useDeleteMultipleRecordsAction } from '@/action-menu/actions/record-actions/multiple-records/hooks/useDeleteMultipleRecordsAction';
+import { useDestroyMultipleRecordsAction } from '@/action-menu/actions/record-actions/multiple-records/hooks/useDestroyMultipleRecordsAction';
 import { useExportMultipleRecordsAction } from '@/action-menu/actions/record-actions/multiple-records/hooks/useExportMultipleRecordsAction';
 import { MultipleRecordsActionKeys } from '@/action-menu/actions/record-actions/multiple-records/types/MultipleRecordsActionKeys';
 import { useCreateNewTableRecordNoSelectionRecordAction } from '@/action-menu/actions/record-actions/no-selection/hooks/useCreateNewTableRecordNoSelectionRecordAction';
@@ -192,7 +193,7 @@ export const WORKFLOW_ACTIONS_CONFIG: Record<
     label: msg`Add to favorites`,
     shortLabel: msg`Add to favorites`,
     position: 10,
-    isPinned: false,
+    isPinned: true,
     Icon: IconHeart,
     availableOn: [
       ActionViewType.INDEX_PAGE_SINGLE_RECORD_SELECTION,
@@ -224,7 +225,7 @@ export const WORKFLOW_ACTIONS_CONFIG: Record<
     position: 12,
     Icon: IconTrash,
     accent: 'danger',
-    isPinned: false,
+    isPinned: true,
     availableOn: [
       ActionViewType.INDEX_PAGE_SINGLE_RECORD_SELECTION,
       ActionViewType.SHOW_PAGE,
@@ -253,7 +254,7 @@ export const WORKFLOW_ACTIONS_CONFIG: Record<
     position: 14,
     Icon: IconTrashX,
     accent: 'danger',
-    isPinned: false,
+    isPinned: true,
     availableOn: [
       ActionViewType.INDEX_PAGE_SINGLE_RECORD_SELECTION,
       ActionViewType.SHOW_PAGE,
@@ -285,5 +286,18 @@ export const WORKFLOW_ACTIONS_CONFIG: Record<
     isPinned: false,
     availableOn: [ActionViewType.INDEX_PAGE_NO_SELECTION],
     useAction: useExportMultipleRecordsAction,
+  },
+  destroyMultipleRecords: {
+    type: ActionMenuEntryType.Standard,
+    scope: ActionMenuEntryScope.RecordSelection,
+    key: MultipleRecordsActionKeys.DESTROY,
+    label: msg`Permanently destroy records`,
+    shortLabel: msg`Destroy`,
+    position: 10,
+    Icon: IconTrashX,
+    accent: 'danger',
+    isPinned: true,
+    availableOn: [ActionViewType.INDEX_PAGE_BULK_SELECTION],
+    useAction: useDestroyMultipleRecordsAction,
   },
 };

--- a/packages/twenty-front/src/modules/action-menu/actions/record-actions/constants/WorkflowActionsConfig.ts
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-actions/constants/WorkflowActionsConfig.ts
@@ -293,7 +293,7 @@ export const WORKFLOW_ACTIONS_CONFIG: Record<
     key: MultipleRecordsActionKeys.DESTROY,
     label: msg`Permanently destroy records`,
     shortLabel: msg`Destroy`,
-    position: 10,
+    position: 17,
     Icon: IconTrashX,
     accent: 'danger',
     isPinned: true,


### PR DESCRIPTION
# Introduction
Added destroy many records to the `WorkflowActionConfig`

## Repro:
- Filter by deleted workflow
- Select mulitple rows
- Click on destroy

# Pinned action standardization
After discussion with @Bonapara and @bosiraphael we landed on a standardization of the pinned actions between `DefaultActionsConfigV2` and `WorkflowActionConfig` which means that now are pinned the `DELETE` and `DESTROY` for both `single/multiple` modes for both features

Related to https://github.com/twentyhq/twenty/pull/9991