### PR TITLE
[REFACTOR] Migrating workflow common types to `twenty-shared`

### DIFF
--- a/packages/twenty-shared/package.json
+++ b/packages/twenty-shared/package.json
@@ -7,6 +7,11 @@
     "build": "npx vite build"
   },
   "exports": {
+    "./workflow": {
+      "types": "./dist/workflow.d.ts",
+      "import": "./dist/workflow.mjs",
+      "require": "./dist/workflow.js"
+    },
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",

--- a/packages/twenty-shared/src/index.ts
+++ b/packages/twenty-shared/src/index.ts
@@ -2,3 +2,5 @@ export * from './constants';
 export * from './types';
 export * from './utils';
 export * from './workspace';
+// export * from './workflow';
+// TODO use barrel.js script to handle and version index.ts files

--- a/packages/twenty-shared/src/index.ts
+++ b/packages/twenty-shared/src/index.ts
@@ -2,5 +2,3 @@ export * from './constants';
 export * from './types';
 export * from './utils';
 export * from './workspace';
-// export * from './workflow';
-// TODO use barrel.js script to handle and version index.ts files

--- a/packages/twenty-shared/src/workflow.ts
+++ b/packages/twenty-shared/src/workflow.ts
@@ -1,0 +1,1 @@
+export * from "./workflow/index";

--- a/packages/twenty-shared/src/workflow.ts
+++ b/packages/twenty-shared/src/workflow.ts
@@ -1,1 +1,4 @@
+// Index required here for correct import suggestion
+// Seems to be specific to workflow, maybe due to folder structure or the fact its a standalone barrel which is not the default main
+// sourcemap still half broken redirects to .d.ts
 export * from "./workflow/index";

--- a/packages/twenty-shared/src/workflow/index.ts
+++ b/packages/twenty-shared/src/workflow/index.ts
@@ -1,0 +1,4 @@
+export * from './toRename';
+export * from './workflow-actions';
+export * from './workflow-builder';
+export * from './workflow-trigger';

--- a/packages/twenty-shared/src/workflow/toRename.ts
+++ b/packages/twenty-shared/src/workflow/toRename.ts
@@ -1,0 +1,62 @@
+import { WorkflowAction } from '@/workflow/workflow-actions';
+import { WorkflowTrigger } from '@/workflow/workflow-trigger';
+
+export type WorkflowStatus = 'DRAFT' | 'ACTIVE' | 'DEACTIVATED';
+
+export type WorkflowVersionStatus =
+  | 'DRAFT'
+  | 'ACTIVE'
+  | 'DEACTIVATED'
+  | 'ARCHIVED';
+
+export type WorkflowStep = WorkflowAction;
+
+export type WorkflowStepType = WorkflowStep['type'];
+
+type StepRunOutput = {
+  id: string;
+  name: string;
+  type: string;
+  outputs: {
+    attemptCount: number;
+    result: object | undefined;
+    error: string | undefined;
+  }[];
+};
+
+export type WorkflowRunOutput = {
+  steps: Record<string, StepRunOutput>;
+  error?: string;
+};
+
+export type WorkflowRun = {
+  __typename: 'WorkflowRun';
+  id: string;
+  workflowVersionId: string;
+  output: WorkflowRunOutput;
+};
+
+export type WorkflowVersion = {
+  id: string;
+  name: string;
+  createdAt: string;
+  updatedAt: string;
+  workflowId: string;
+  trigger: WorkflowTrigger | null;
+  steps: Array<WorkflowStep> | null;
+  status: WorkflowVersionStatus;
+  __typename: 'WorkflowVersion';
+};
+
+export type Workflow = {
+  __typename: 'Workflow';
+  id: string;
+  name: string;
+  versions: Array<WorkflowVersion>;
+  lastPublishedVersionId: string;
+  statuses: Array<WorkflowStatus> | null;
+};
+
+export type WorkflowWithCurrentVersion = Workflow & {
+  currentVersion: WorkflowVersion;
+};

--- a/packages/twenty-shared/src/workflow/workflow-actions/code/index.ts
+++ b/packages/twenty-shared/src/workflow/workflow-actions/code/index.ts
@@ -1,0 +1,3 @@
+export * from './workflow-code-action-input';
+export * from './workflow-code-action-settings';
+

--- a/packages/twenty-shared/src/workflow/workflow-actions/code/workflow-code-action-input.ts
+++ b/packages/twenty-shared/src/workflow/workflow-actions/code/workflow-code-action-input.ts
@@ -1,0 +1,7 @@
+export type WorkflowCodeActionInput = {
+  serverlessFunctionId: string;
+  serverlessFunctionVersion: string;
+  serverlessFunctionInput: {
+    [key: string]: any;
+  };
+};

--- a/packages/twenty-shared/src/workflow/workflow-actions/code/workflow-code-action-settings.ts
+++ b/packages/twenty-shared/src/workflow/workflow-actions/code/workflow-code-action-settings.ts
@@ -1,0 +1,6 @@
+import { WorkflowCodeActionInput } from '@/workflow/workflow-actions/code/workflow-code-action-input';
+import { BaseWorkflowActionSettings } from '@/workflow/workflow-actions/workflow-action-settings';
+
+export type WorkflowCodeActionSettings = BaseWorkflowActionSettings & {
+  input: WorkflowCodeActionInput;
+};

--- a/packages/twenty-shared/src/workflow/workflow-actions/index.ts
+++ b/packages/twenty-shared/src/workflow/workflow-actions/index.ts
@@ -1,0 +1,7 @@
+export * from './code';
+export * from './mail-sender';
+export * from './record-crud';
+export * from './workflow-action';
+export * from './workflow-action-result';
+export * from './workflow-action-settings';
+

--- a/packages/twenty-shared/src/workflow/workflow-actions/mail-sender/index.ts
+++ b/packages/twenty-shared/src/workflow/workflow-actions/mail-sender/index.ts
@@ -1,0 +1,3 @@
+export * from './workflow-send-email-action-input';
+export * from './workflow-send-email-action-settings';
+

--- a/packages/twenty-shared/src/workflow/workflow-actions/mail-sender/workflow-send-email-action-input.ts
+++ b/packages/twenty-shared/src/workflow/workflow-actions/mail-sender/workflow-send-email-action-input.ts
@@ -1,0 +1,6 @@
+export type WorkflowSendEmailActionInput = {
+  connectedAccountId: string;
+  email: string;
+  subject?: string;
+  body?: string;
+};

--- a/packages/twenty-shared/src/workflow/workflow-actions/mail-sender/workflow-send-email-action-settings.ts
+++ b/packages/twenty-shared/src/workflow/workflow-actions/mail-sender/workflow-send-email-action-settings.ts
@@ -1,0 +1,6 @@
+import { WorkflowSendEmailActionInput } from '@/workflow/workflow-actions/mail-sender/workflow-send-email-action-input';
+import { BaseWorkflowActionSettings } from '@/workflow/workflow-actions/workflow-action-settings';
+
+export type WorkflowSendEmailActionSettings = BaseWorkflowActionSettings & {
+  input: WorkflowSendEmailActionInput;
+};

--- a/packages/twenty-shared/src/workflow/workflow-actions/record-crud/index.ts
+++ b/packages/twenty-shared/src/workflow/workflow-actions/record-crud/index.ts
@@ -1,0 +1,3 @@
+export * from './workflow-record-crud-action-input';
+export * from './workflow-record-crud-action-settings';
+

--- a/packages/twenty-shared/src/workflow/workflow-actions/record-crud/workflow-record-crud-action-input.ts
+++ b/packages/twenty-shared/src/workflow/workflow-actions/record-crud/workflow-record-crud-action-input.ts
@@ -1,0 +1,30 @@
+import {
+    ObjectRecordFilter,
+    ObjectRecordOrderBy,
+} from '@/workspace/query-builder/interfaces/object-record.interface';
+
+type ObjectRecord = Record<string, any>;
+
+export type WorkflowCreateRecordActionInput = {
+  objectName: string;
+  objectRecord: ObjectRecord;
+};
+
+export type WorkflowUpdateRecordActionInput = {
+  objectName: string;
+  objectRecord: ObjectRecord;
+  objectRecordId: string;
+  fieldsToUpdate: string[];
+};
+
+export type WorkflowDeleteRecordActionInput = {
+  objectName: string;
+  objectRecordId: string;
+};
+
+export type WorkflowFindRecordsActionInput = {
+  objectName: string;
+  filter?: Partial<ObjectRecordFilter>;
+  orderBy?: Partial<ObjectRecordOrderBy>;
+  limit?: number;
+};

--- a/packages/twenty-shared/src/workflow/workflow-actions/record-crud/workflow-record-crud-action-settings.ts
+++ b/packages/twenty-shared/src/workflow/workflow-actions/record-crud/workflow-record-crud-action-settings.ts
@@ -1,0 +1,23 @@
+import {
+    WorkflowCreateRecordActionInput,
+    WorkflowDeleteRecordActionInput,
+    WorkflowFindRecordsActionInput,
+    WorkflowUpdateRecordActionInput,
+} from '@/workflow/workflow-actions/record-crud/workflow-record-crud-action-input';
+import { BaseWorkflowActionSettings } from '@/workflow/workflow-actions/workflow-action-settings';
+
+export type WorkflowCreateRecordActionSettings = BaseWorkflowActionSettings & {
+  input: WorkflowCreateRecordActionInput;
+};
+
+export type WorkflowUpdateRecordActionSettings = BaseWorkflowActionSettings & {
+  input: WorkflowUpdateRecordActionInput;
+};
+
+export type WorkflowDeleteRecordActionSettings = BaseWorkflowActionSettings & {
+  input: WorkflowDeleteRecordActionInput;
+};
+
+export type WorkflowFindRecordsActionSettings = BaseWorkflowActionSettings & {
+  input: WorkflowFindRecordsActionInput;
+};

--- a/packages/twenty-shared/src/workflow/workflow-actions/workflow-action-result.ts
+++ b/packages/twenty-shared/src/workflow/workflow-actions/workflow-action-result.ts
@@ -1,0 +1,10 @@
+type WorkflowActionError = {
+  errorType: string;
+  errorMessage: string;
+  stackTrace: string;
+};
+
+export type WorkflowActionResult = {
+  result?: object;
+  error?: WorkflowActionError;
+};

--- a/packages/twenty-shared/src/workflow/workflow-actions/workflow-action-settings.ts
+++ b/packages/twenty-shared/src/workflow/workflow-actions/workflow-action-settings.ts
@@ -1,0 +1,30 @@
+import {
+    WorkflowCreateRecordActionSettings,
+    WorkflowDeleteRecordActionSettings,
+    WorkflowFindRecordsActionSettings,
+    WorkflowUpdateRecordActionSettings,
+} from '@/workflow/workflow-actions/record-crud';
+import { OutputSchema } from '../workflow-builder/output-schema';
+import { WorkflowCodeActionSettings } from './code/workflow-code-action-settings';
+import { WorkflowSendEmailActionSettings } from './mail-sender/workflow-send-email-action-settings';
+
+export type BaseWorkflowActionSettings = {
+  input: object;
+  outputSchema: OutputSchema;
+  errorHandlingOptions: {
+    retryOnFailure: {
+      value: boolean;
+    };
+    continueOnFailure: {
+      value: boolean;
+    };
+  };
+};
+
+export type WorkflowActionSettings =
+  | WorkflowSendEmailActionSettings
+  | WorkflowCodeActionSettings
+  | WorkflowCreateRecordActionSettings
+  | WorkflowUpdateRecordActionSettings
+  | WorkflowDeleteRecordActionSettings
+  | WorkflowFindRecordsActionSettings;

--- a/packages/twenty-shared/src/workflow/workflow-actions/workflow-action.ts
+++ b/packages/twenty-shared/src/workflow/workflow-actions/workflow-action.ts
@@ -1,0 +1,64 @@
+import { WorkflowCodeActionSettings } from '@/workflow/workflow-actions/code';
+import { WorkflowSendEmailActionSettings } from '@/workflow/workflow-actions/mail-sender';
+import {
+    WorkflowCreateRecordActionSettings,
+    WorkflowDeleteRecordActionSettings,
+    WorkflowFindRecordsActionSettings,
+    WorkflowUpdateRecordActionSettings,
+} from '@/workflow/workflow-actions/record-crud';
+import { WorkflowActionSettings } from '@/workflow/workflow-actions/workflow-action-settings';
+
+export enum WorkflowActionType {
+  CODE = 'CODE',
+  SEND_EMAIL = 'SEND_EMAIL',
+  CREATE_RECORD = 'CREATE_RECORD',
+  UPDATE_RECORD = 'UPDATE_RECORD',
+  DELETE_RECORD = 'DELETE_RECORD',
+  FIND_RECORDS = 'FIND_RECORDS',
+}
+
+type BaseWorkflowAction = {
+  id: string;
+  name: string;
+  type: WorkflowActionType;
+  settings: WorkflowActionSettings;
+  valid: boolean;
+};
+
+export type WorkflowCodeAction = BaseWorkflowAction & {
+  type: WorkflowActionType.CODE;
+  settings: WorkflowCodeActionSettings;
+};
+
+export type WorkflowSendEmailAction = BaseWorkflowAction & {
+  type: WorkflowActionType.SEND_EMAIL;
+  settings: WorkflowSendEmailActionSettings;
+};
+
+export type WorkflowCreateRecordAction = BaseWorkflowAction & {
+  type: WorkflowActionType.CREATE_RECORD;
+  settings: WorkflowCreateRecordActionSettings;
+};
+
+export type WorkflowUpdateRecordAction = BaseWorkflowAction & {
+  type: WorkflowActionType.UPDATE_RECORD;
+  settings: WorkflowUpdateRecordActionSettings;
+};
+
+export type WorkflowDeleteRecordAction = BaseWorkflowAction & {
+  type: WorkflowActionType.DELETE_RECORD;
+  settings: WorkflowDeleteRecordActionSettings;
+};
+
+export type WorkflowFindRecordsAction = BaseWorkflowAction & {
+  type: WorkflowActionType.FIND_RECORDS;
+  settings: WorkflowFindRecordsActionSettings;
+};
+
+export type WorkflowAction =
+  | WorkflowCodeAction
+  | WorkflowSendEmailAction
+  | WorkflowCreateRecordAction
+  | WorkflowUpdateRecordAction
+  | WorkflowDeleteRecordAction
+  | WorkflowFindRecordsAction;

--- a/packages/twenty-shared/src/workflow/workflow-builder/index.ts
+++ b/packages/twenty-shared/src/workflow/workflow-builder/index.ts
@@ -1,0 +1,3 @@
+export * from './input-schema';
+export * from './output-schema';
+

--- a/packages/twenty-shared/src/workflow/workflow-builder/input-schema.ts
+++ b/packages/twenty-shared/src/workflow/workflow-builder/input-schema.ts
@@ -1,0 +1,23 @@
+import { FieldMetadataType } from "@/types";
+
+export type InputSchemaPropertyType =
+  | 'string'
+  | 'number'
+  | 'boolean'
+  | 'object'
+  | 'array'
+  | 'unknown'
+  | FieldMetadataType;
+
+export type InputSchemaProperty = {
+  type: InputSchemaPropertyType;
+  enum?: string[];
+  items?: InputSchemaProperty; // used to describe array type elements
+  properties?: Properties; // used to describe object type elements
+};
+
+type Properties = {
+  [name: string]: InputSchemaProperty;
+};
+
+export type InputSchema = InputSchemaProperty[];

--- a/packages/twenty-shared/src/workflow/workflow-builder/output-schema.ts
+++ b/packages/twenty-shared/src/workflow/workflow-builder/output-schema.ts
@@ -1,0 +1,41 @@
+import { InputSchemaPropertyType } from '@/workflow/workflow-builder/input-schema';
+
+export type Leaf = {
+  isLeaf: true;
+  type?: InputSchemaPropertyType;
+  icon?: string;
+  label?: string;
+  value: any;
+};
+
+export type Node = {
+  isLeaf: false;
+  icon?: string;
+  label?: string;
+  value: OutputSchema;
+};
+
+type Link = {
+  isLeaf: true;
+  tab?: string;
+  icon?: string;
+  label?: string;
+};
+
+export type BaseOutputSchema = Record<string, Leaf | Node>;
+
+export type RecordOutputSchema = {
+  object: { nameSingular: string; fieldIdName: string } & Leaf;
+  fields: BaseOutputSchema;
+  _outputSchemaType: 'RECORD';
+};
+
+export type LinkOutputSchema = {
+  link: Link;
+  _outputSchemaType: 'LINK';
+};
+
+export type OutputSchema =
+  | BaseOutputSchema
+  | RecordOutputSchema
+  | LinkOutputSchema;

--- a/packages/twenty-shared/src/workflow/workflow-trigger/index.ts
+++ b/packages/twenty-shared/src/workflow/workflow-trigger/index.ts
@@ -1,0 +1,1 @@
+export * from './workflow-trigger';

--- a/packages/twenty-shared/src/workflow/workflow-trigger/workflow-trigger.ts
+++ b/packages/twenty-shared/src/workflow/workflow-trigger/workflow-trigger.ts
@@ -1,0 +1,51 @@
+import { OutputSchema } from '@/workflow/workflow-builder';
+
+export enum WorkflowTriggerType {
+  DATABASE_EVENT = 'DATABASE_EVENT',
+  MANUAL = 'MANUAL',
+  CRON = 'CRON',
+}
+
+type BaseWorkflowTriggerSettings = {
+  input?: object;
+  outputSchema: OutputSchema;
+};
+
+type BaseTrigger = {
+  name: string;
+  type: WorkflowTriggerType;
+  settings: BaseWorkflowTriggerSettings;
+};
+
+export type WorkflowDatabaseEventTrigger = BaseTrigger & {
+  type: WorkflowTriggerType.DATABASE_EVENT;
+  settings: {
+    eventName: string;
+  };
+};
+
+export enum WorkflowManualTriggerAvailability {
+  EVERYWHERE = 'EVERYWHERE',
+  WHEN_RECORD_SELECTED = 'WHEN_RECORD_SELECTED',
+}
+
+export type WorkflowManualTrigger = BaseTrigger & {
+  type: WorkflowTriggerType.MANUAL;
+  settings: {
+    objectType?: string;
+  };
+};
+
+export type WorkflowCronTrigger = BaseTrigger & {
+  type: WorkflowTriggerType.CRON;
+  settings: {
+    pattern: string;
+  };
+};
+
+export type WorkflowManualTriggerSettings = WorkflowManualTrigger['settings'];
+
+export type WorkflowTrigger =
+  | WorkflowDatabaseEventTrigger
+  | WorkflowManualTrigger
+  | WorkflowCronTrigger;

--- a/packages/twenty-shared/src/workspace/index.ts
+++ b/packages/twenty-shared/src/workspace/index.ts
@@ -1,2 +1,3 @@
 export * from './types';
 export * from './utils';
+export * from './query-builder';

--- a/packages/twenty-shared/src/workspace/query-builder/index.ts
+++ b/packages/twenty-shared/src/workspace/query-builder/index.ts
@@ -1,0 +1,1 @@
+export * from './interfaces/object-record.interface';

--- a/packages/twenty-shared/src/workspace/query-builder/interfaces/object-record.interface.ts
+++ b/packages/twenty-shared/src/workspace/query-builder/interfaces/object-record.interface.ts
@@ -1,0 +1,29 @@
+export interface ObjectRecord {
+  id: string;
+  [key: string]: any;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string | null;
+}
+
+export type ObjectRecordFilter = {
+  [Property in keyof ObjectRecord]: any;
+};
+
+export enum OrderByDirection {
+  AscNullsFirst = 'AscNullsFirst',
+  AscNullsLast = 'AscNullsLast',
+  DescNullsFirst = 'DescNullsFirst',
+  DescNullsLast = 'DescNullsLast',
+}
+
+export type ObjectRecordOrderBy = Array<{
+  [Property in keyof ObjectRecord]?:
+    | OrderByDirection
+    | Record<string, OrderByDirection>;
+}>;
+
+export interface ObjectRecordDuplicateCriteria {
+  objectName: string;
+  columnNames: string[];
+}

--- a/packages/twenty-shared/tsconfig.json
+++ b/packages/twenty-shared/tsconfig.json
@@ -5,9 +5,8 @@
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "types": ["vite/client"],
-    "baseUrl": ".",
     "paths": {
-      "twenty-shared": ["packages/twenty-shared/dist"]
+      "@/*": ["./src/*"]
     }
   },
   "files": [],

--- a/packages/twenty-shared/tsconfig.lib.json
+++ b/packages/twenty-shared/tsconfig.lib.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "declarationMap": true,
+    "baseUrl": ".",
     "outDir": "../../.cache/tsc",
     "types": [
       "node",

--- a/packages/twenty-shared/tsconfig.spec.json
+++ b/packages/twenty-shared/tsconfig.spec.json
@@ -1,7 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "commonjs",
     "types": ["jest", "node"]
   },
   "include": [

--- a/packages/twenty-shared/vite.config.ts
+++ b/packages/twenty-shared/vite.config.ts
@@ -2,7 +2,6 @@ import * as path from 'path';
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
 import tsconfigPaths from 'vite-tsconfig-paths';
-import packageJson from "../../package.json";
 
 export default defineConfig({
   root: __dirname,
@@ -32,11 +31,7 @@ export default defineConfig({
       fileName: (format, fileName) => {
         const extension = format === 'cjs' ? 'js' : 'mjs';
         return `${fileName}.${extension}`;
+      },
     },
-    },
-    rollupOptions: {
-        external: Object.keys(packageJson.dependencies || {}),
-      // preserveEntrySignatures: 'strict',
-    }
   },
 });

--- a/packages/twenty-shared/vite.config.ts
+++ b/packages/twenty-shared/vite.config.ts
@@ -25,7 +25,7 @@ export default defineConfig({
       transformMixedEsModules: true,
     },
     lib: {
-      // Centralized and sync with package.json
+      // TODO Centralize and sync with package.json programmatically
       entry: ['src/index.ts', 'src/workflow.ts'],
       name: 'twenty-shared',
       formats: ['es', 'cjs'],

--- a/packages/twenty-shared/vite.config.ts
+++ b/packages/twenty-shared/vite.config.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
 import tsconfigPaths from 'vite-tsconfig-paths';
+import packageJson from "../../package.json";
 
 export default defineConfig({
   root: __dirname,
@@ -24,10 +25,18 @@ export default defineConfig({
       transformMixedEsModules: true,
     },
     lib: {
-      entry: 'src/index.ts',
+      // Centralized and sync with package.json
+      entry: ['src/index.ts', 'src/workflow.ts'],
       name: 'twenty-shared',
-      fileName: 'index',
       formats: ['es', 'cjs'],
+      fileName: (format, fileName) => {
+        const extension = format === 'cjs' ? 'js' : 'mjs';
+        return `${fileName}.${extension}`;
     },
+    },
+    rollupOptions: {
+        external: Object.keys(packageJson.dependencies || {}),
+      // preserveEntrySignatures: 'strict',
+    }
   },
 });


### PR DESCRIPTION
# Introduction
***WIP***

This PR result from a discussion in https://github.com/twentyhq/twenty/pull/10036
This is a refactor of the workflow types extraction to twenty-shared refactor.

In a nutshell instead of importing workflow types like:
```ts
import { SomeWorkflowType } from "twenty-shared";
```
We now expose a scoped barrel as follows:
```ts
import { SomeWorkflowType } from "twenty-shared/workflow";
```

## Vscode import suggestion
From the moment you've added in your vscode project at least one import to a specific barrel which is not your package default entry ( `twenty-shared`). Then vscode will start suggesting imports from this barrel :)
```ts
// @filename some-file.ts
import { SomeWorkflowTypeA } from "twenty-shared/workflow";

// @filename other-file.ts
import { SomeWorkflowTypeA } from "twenty-shared/workflow"; // addMissingImports also auto-importing on save !

const whatever: SomeWorkflowTypeB = 'never' // cmd + esc or ctr + space_bar suggests import from `twenty-shared/worfklow`
```

IMO Several scoped barrel for a better sleep and maintainability ( and enhance tree shaking ? To attest )

## Diff from https://github.com/twentyhq/twenty/pull/10036
- removed `.type` extension file
- renamed a missleading file
- added a `@/` leading to `./src/*` paths within `tsconfig.json` to avoid asserting baseUrl is defined
- updated vite roll-up and package config 

## Dispatching the extract AKA updating imports
Could not find a way to reproduce identication done in #10036, lets discuss this
Also I feel like naming an grouping should be reviewed

## Codegen
We should programmatically handle and maintain or file structure and import along `twenty-ui` and `twenty-shared` such as does the [generateBarrel](https://github.com/twentyhq/twenty/blob/main/packages/twenty-ui/scripts/generateBarrels.js) from `twenty-ui` but with multiple barrel support. I will be working on this on my next slack day.

ps: As a cli and within its own package etc could be smoother