### PR TITLE
fix(auth): update error message in sign-in-up service test

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.spec.ts
@@ -302,15 +302,12 @@ describe('SignInUpService', () => {
 
     jest.spyOn(environmentService, 'get').mockReturnValue(false);
     jest
-      .spyOn(userWorkspaceService, 'addUserToWorkspace')
-      .mockResolvedValue({} as User);
-    jest
       .spyOn(userWorkspaceService, 'checkUserWorkspaceExists')
       .mockResolvedValue(null);
 
     await expect(() => service.signInUp(params)).rejects.toThrow(
       new AuthException(
-        'Workspace is not ready to welcome new members',
+        'User is not part of the workspace',
         AuthExceptionCode.FORBIDDEN_EXCEPTION,
       ),
     );


### PR DESCRIPTION
Revised exception message for better clarity when a user is not part of the workspace. Adjusts test expectations to match the updated error output.