### PR TITLE
refactor(auth): simplify continueWithEmail and remove useCallback

### DIFF
--- a/packages/twenty-front/src/hooks/useIsMatchingLocation.ts
+++ b/packages/twenty-front/src/hooks/useIsMatchingLocation.ts
@@ -3,36 +3,26 @@ import { matchPath, useLocation } from 'react-router-dom';
 import { AppBasePath } from '@/types/AppBasePath';
 import { isNonEmptyString } from '@sniptt/guards';
 import { isDefined } from 'twenty-shared';
-import { useCallback } from 'react';
 
 export const useIsMatchingLocation = () => {
   const location = useLocation();
 
-  // Infinite loop issue caused by `checkUserExistsQuery` in `useSignInUp`.
-  // Without executing this query, there is no infinite loop.
-  // I also noticed that in `isMatchingLocation` inside `continueWithEmail`, no loop occurs.
-  // Both functions are called within the `useEffect` of `SignInUpWorkspaceScopeFormEffect`.
-  // This led me to conclude that the issue comes from `useIsMatchingLocation`.
-  // Using `useCallback` prevent the loop.
-  const isMatchingLocation = useCallback(
-    (path: string, basePath?: AppBasePath) => {
-      const addTrailingSlash = (path: string) =>
-        path.endsWith('/') ? path : path + '/';
+  const addTrailingSlash = (path: string) =>
+    path.endsWith('/') ? path : path + '/';
 
-      const getConstructedPath = (path: string, basePath?: AppBasePath) => {
-        if (!isNonEmptyString(basePath)) return path;
+  const getConstructedPath = (path: string, basePath?: AppBasePath) => {
+    if (!isNonEmptyString(basePath)) return path;
 
-        return addTrailingSlash(basePath) + path;
-      };
+    return addTrailingSlash(basePath) + path;
+  };
 
-      const match = matchPath(
-        getConstructedPath(path, basePath),
-        location.pathname,
-      );
-      return isDefined(match);
-    },
-    [location.pathname],
-  );
+  const isMatchingLocation = (path: string, basePath?: AppBasePath) => {
+    const match = matchPath(
+      getConstructedPath(path, basePath),
+      location.pathname,
+    );
+    return isDefined(match);
+  };
 
   return {
     isMatchingLocation,

--- a/packages/twenty-front/src/modules/auth/sign-in-up/hooks/useSignInUp.ts
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/hooks/useSignInUp.ts
@@ -45,17 +45,7 @@ export const useSignInUp = (form: UseFormReturn<Form>) => {
   const continueWithEmail = useCallback(() => {
     requestFreshCaptchaToken();
     setSignInUpStep(SignInUpStep.Email);
-    setSignInUpMode(
-      isMatchingLocation(AppPath.SignInUp)
-        ? SignInUpMode.SignIn
-        : SignInUpMode.SignUp,
-    );
-  }, [
-    isMatchingLocation,
-    requestFreshCaptchaToken,
-    setSignInUpMode,
-    setSignInUpStep,
-  ]);
+  }, [requestFreshCaptchaToken, setSignInUpStep]);
 
   const continueWithCredentials = useCallback(async () => {
     const token = await readCaptchaToken();


### PR DESCRIPTION
Refactored continueWithEmail to remove unnecessary dependencies and simplified the useIsMatchingLocation hook by eliminating useCallback. This reduces complexity and addresses potential infinite loop issues.