### PR TITLE
minor env tab description font color fix

### DIFF
--- a/packages/twenty-front/src/modules/settings/admin-panel/components/SettingsAdminEnvVariables.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/components/SettingsAdminEnvVariables.tsx
@@ -36,8 +36,6 @@ const StyledShowMoreButton = styled(Button)<{ isSelected?: boolean }>`
   `}
 `;
 
-const StyledEnvVariablesDescription = styled.div``;
-
 export const SettingsAdminEnvVariables = () => {
   const { data: environmentVariables } = useGetEnvironmentVariablesGroupedQuery(
     {
@@ -68,11 +66,11 @@ export const SettingsAdminEnvVariables = () => {
 
   return (
     <>
-      <StyledEnvVariablesDescription>
+      <Section>
         These are only the server values. Ensure your worker environment has the
         same variables and values, this is required for asynchronous tasks like
         email sync.
-      </StyledEnvVariablesDescription>
+      </Section>
       <Section>
         {visibleGroups.map((group) => (
           <StyledGroupContainer key={group.name}>


### PR DESCRIPTION
Before: 

<img width="630" alt="Screenshot 2025-02-12 at 00 48 14" src="https://github.com/user-attachments/assets/0df50cc6-be0c-4286-9883-2a9d23f4f9d9" />

After:

<img width="628" alt="Screenshot 2025-02-12 at 00 47 54" src="https://github.com/user-attachments/assets/cb02c127-fb01-493f-8183-e558449c0193" />
