### PR TITLE
drop foreing key constraint on BillingEntitlements

### DIFF
--- a/packages/twenty-server/src/database/typeorm/core/migrations/billing/1739356522949-dropForeignKeyOnCustomerEntitlement.ts
+++ b/packages/twenty-server/src/database/typeorm/core/migrations/billing/1739356522949-dropForeignKeyOnCustomerEntitlement.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class DropForeignKeyOnCustomerEntitlement1739356522949
+  implements MigrationInterface
+{
+  name = 'DropForeignKeyOnCustomerEntitlement1739356522949';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "core"."billingEntitlement" DROP CONSTRAINT "FK_766a1918aa3dbe0d67d3df62356"`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "core"."billingEntitlement" ADD CONSTRAINT "FK_766a1918aa3dbe0d67d3df62356" FOREIGN KEY ("stripeCustomerId") REFERENCES "core"."billingCustomer"("stripeCustomerId") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+}

--- a/packages/twenty-server/src/engine/core-modules/billing/billing.controller.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/billing.controller.ts
@@ -63,6 +63,8 @@ export class BillingController {
     } catch (error) {
       if (error instanceof BillingException) {
         res.status(404).end();
+      } else {
+        res.status(500).end();
       }
     }
   }

--- a/packages/twenty-server/src/engine/core-modules/billing/entities/billing-entitlement.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/entities/billing-entitlement.entity.ts
@@ -54,6 +54,7 @@ export class BillingEntitlement {
     (billingCustomer) => billingCustomer.billingEntitlements,
     {
       onDelete: 'CASCADE',
+      createForeignKeyConstraints: false,
     },
   )
   @JoinColumn({


### PR DESCRIPTION
**TLDR**
Drop foreign key constraint On BillingEntitlement (one customer has many entitlements) and upgrade error handling in the billing controller.

**Why this?**
Doing the testing in production I realized that when we receive some subscription update events, the data was not updated in our database.

During this stage, I identified some workspaces who had more than one customer, so I eliminated the second one in stripe. However even if I try to update to the new stripe customer id (using stripe events), it doesn't let me update it into the table because of the old customer already has entitlements.

I decided to drop this constraint for the time being, in order to at least have all the customers of all workspaces who are active or suspended and their subscription are not canceled. This way, all the customers can send Billing meter events

Finally I realized that because I only captured the billing Exceptions in the controller and I ignored the rest, stripe  webhook sent a timeout(no response), so the errors went silent. That is why I added the 500 response status.

**In order to test**
1. Have the environment variable IS_BILLING_ENABLED set to true and add the other required environment variables for Billing to work
2. Do a database reset (to ensure that the new feature flag is properly added and that the billing tables are created)
3. Run the command: npx nx run twenty-server:command billing:sync-plans-data (if you don't do that the products and prices will not be present in the database)
4. Run the server , the frontend, the worker, and the stripe listen command (stripe listen --forward-to http://localhost:3000/billing/webhooks)
5. Buy a subscription for the Acme workspace

You can create manually the stripe updated events using the stripe website and updating the subscription metadata. 