### PR TITLE
feat(settings): add custom domain records and status management

### DIFF
--- a/packages/twenty-front/src/pages/settings/workspace/SettingsCustomDomain.tsx
+++ b/packages/twenty-front/src/pages/settings/workspace/SettingsCustomDomain.tsx
@@ -5,10 +5,15 @@ import { Controller, useFormContext } from 'react-hook-form';
 import { H2Title, Section } from 'twenty-ui';
 import { useGetCustomDomainDetailsQuery } from '~/generated/graphql';
 import { SettingsCustomDomainRecords } from '~/pages/settings/workspace/SettingsCustomDomainRecords';
+import { SettingsCustomDomainRecordsStatus } from '~/pages/settings/workspace/SettingsCustomDomainRecordsStatus';
 
 const StyledDomainFormWrapper = styled.div`
   align-items: center;
   display: flex;
+`;
+
+const StyledRecordsWrapper = styled.div`
+  margin-top: ${({ theme }) => theme.spacing(2)};
 `;
 
 export const SettingsCustomDomain = () => {
@@ -22,7 +27,10 @@ export const SettingsCustomDomain = () => {
 
   return (
     <Section>
-      <H2Title title={t`Domain`} description={t`Set the name of your domain`} />
+      <H2Title
+        title={t`Custom Domain`}
+        description={t`Set the name of your custom domain and configure your DNS records.`}
+      />
       <StyledDomainFormWrapper>
         <Controller
           name="customDomain"
@@ -41,9 +49,18 @@ export const SettingsCustomDomain = () => {
       {getCustomDomainDetailsData?.getCustomDomainDetails &&
         getValues('customDomain') ===
           getCustomDomainDetailsData?.getCustomDomainDetails?.customDomain && (
-          <SettingsCustomDomainRecords
-            records={getCustomDomainDetailsData.getCustomDomainDetails.records}
-          />
+          <StyledRecordsWrapper>
+            <SettingsCustomDomainRecordsStatus
+              records={
+                getCustomDomainDetailsData.getCustomDomainDetails.records
+              }
+            />
+            <SettingsCustomDomainRecords
+              records={
+                getCustomDomainDetailsData.getCustomDomainDetails.records
+              }
+            />
+          </StyledRecordsWrapper>
         )}
     </Section>
   );

--- a/packages/twenty-front/src/pages/settings/workspace/SettingsCustomDomainRecords.tsx
+++ b/packages/twenty-front/src/pages/settings/workspace/SettingsCustomDomainRecords.tsx
@@ -1,75 +1,77 @@
 import { TableRow } from '@/ui/layout/table/components/TableRow';
 import { TableHeader } from '@/ui/layout/table/components/TableHeader';
-import { Separator } from '@/settings/components/Separator';
 import { TableBody } from '@/ui/layout/table/components/TableBody';
 import { TableCell } from '@/ui/layout/table/components/TableCell';
-import { TextInputV2 } from '@/ui/input/components/TextInputV2';
+import { Button } from 'twenty-ui';
 import { Table } from '@/ui/layout/table/components/Table';
 import { CustomDomainDetails } from '~/generated/graphql';
+import styled from '@emotion/styled';
+import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
+import { SnackBarVariant } from '@/ui/feedback/snack-bar-manager/components/SnackBar';
+
+const StyledTable = styled(Table)`
+  border-bottom: 1px solid ${({ theme }) => theme.border.color.light};
+`;
+
+const StyledButton = styled(Button)`
+  background-color: ${({ theme }) => theme.background.transparent.lighter};
+  border: 1px solid ${({ theme }) => theme.border.color.medium};
+  border-radius: ${({ theme }) => theme.border.radius.sm};
+  color: ${({ theme }) => theme.font.color.tertiary};
+  height: ${({ theme }) => theme.spacing(7)};
+  font-family: ${({ theme }) => theme.font.family};
+  font-weight: ${({ theme }) => theme.font.weight.regular};
+  width: 100%;
+  overflow: hidden;
+`;
 
 export const SettingsCustomDomainRecords = ({
   records,
 }: {
   records: CustomDomainDetails['records'];
 }) => {
+  const { enqueueSnackBar } = useSnackBar();
+
+  const copyToClipboard = (value: string) => {
+    navigator.clipboard.writeText(value);
+    enqueueSnackBar('Copied to clipboard!', {
+      variant: SnackBarVariant.Success,
+    });
+  };
+
   return (
-    <Table>
-      <TableRow>
+    <StyledTable>
+      <TableRow gridAutoColumns="35% 16% auto">
         <TableHeader>Name</TableHeader>
-        <TableHeader>Record Type</TableHeader>
+        <TableHeader>Type</TableHeader>
         <TableHeader>Value</TableHeader>
-        <TableHeader>Validation Type</TableHeader>
-        <TableHeader>Status</TableHeader>
       </TableRow>
-      <Separator></Separator>
       <TableBody>
         {records.map((record) => {
           return (
-            <TableRow key={record.key}>
+            <TableRow gridAutoColumns="30% 16% auto" key={record.key}>
               <TableCell>
-                <TextInputV2
-                  value={record.key}
-                  type="text"
-                  disabled
-                  sizeVariant="md"
+                <StyledButton
+                  title={record.key}
+                  onClick={() => copyToClipboard(record.key)}
                 />
               </TableCell>
               <TableCell>
-                <TextInputV2
-                  value={record.type.toUpperCase()}
-                  type="text"
-                  disabled
-                  sizeVariant="md"
+                <StyledButton
+                  title={record.type.toUpperCase()}
+                  onClick={() => copyToClipboard(record.type.toUpperCase())}
                 />
               </TableCell>
               <TableCell>
-                <TextInputV2
-                  value={record.value}
-                  type="text"
-                  disabled
-                  sizeVariant="md"
-                />
-              </TableCell>
-              <TableCell>
-                <TextInputV2
-                  value={record.validationType}
-                  type="text"
-                  disabled
-                  sizeVariant="md"
-                />
-              </TableCell>
-              <TableCell>
-                <TextInputV2
-                  value={record.status}
-                  type="text"
-                  disabled
-                  sizeVariant="md"
+                <StyledButton
+                  title={record.value}
+                  onClick={() => copyToClipboard(record.value)}
                 />
               </TableCell>
             </TableRow>
           );
         })}
       </TableBody>
-    </Table>
+    </StyledTable>
   );
 };

--- a/packages/twenty-front/src/pages/settings/workspace/SettingsCustomDomainRecordsStatus.tsx
+++ b/packages/twenty-front/src/pages/settings/workspace/SettingsCustomDomainRecordsStatus.tsx
@@ -1,0 +1,76 @@
+import { Table } from '@/ui/layout/table/components/Table';
+import { TableRow } from '@/ui/layout/table/components/TableRow';
+import { TableCell } from '@/ui/layout/table/components/TableCell';
+import { Status, ThemeColor } from 'twenty-ui';
+import styled from '@emotion/styled';
+import { CustomDomainDetails } from '~/generated/graphql';
+
+const StyledTable = styled(Table)`
+  background-color: ${({ theme }) => theme.background.transparent.lighter};
+  border-radius: ${({ theme }) => theme.border.radius.sm};
+  border: 1px solid ${({ theme }) => theme.border.color.light};
+`;
+
+const StyledTableRow = styled(TableRow)`
+  display: flex;
+  border-bottom: 1px solid ${({ theme }) => theme.border.color.light};
+  align-items: center;
+  justify-content: space-between;
+  &:last-child {
+    border-bottom: none;
+  }
+`;
+
+export const SettingsCustomDomainRecordsStatus = ({
+  records,
+}: {
+  records: CustomDomainDetails['records'];
+}) => {
+  const rows = records.reduce(
+    (acc, record) => {
+      acc[record.validationType] = {
+        name: acc[record.validationType].name,
+        status: record.status,
+        color:
+          record.status === 'error'
+            ? 'red'
+            : record.status === 'pending'
+              ? 'yellow'
+              : 'green',
+      };
+      return acc;
+    },
+    {
+      ssl: {
+        name: 'SSL',
+        status: 'success',
+        color: 'green',
+      },
+      redirection: {
+        name: 'Redirection',
+        status: 'success',
+        color: 'green',
+      },
+      ownership: {
+        name: 'Ownership',
+        status: 'success',
+        color: 'green',
+      },
+    } as Record<string, { name: string; status: string; color: ThemeColor }>,
+  );
+
+  return (
+    <StyledTable>
+      {Object.values(rows).map((row) => {
+        return (
+          <StyledTableRow>
+            <TableCell>{row.name}</TableCell>
+            <TableCell>
+              <Status color={row.color} text={row.status} />
+            </TableCell>
+          </StyledTableRow>
+        );
+      })}
+    </StyledTable>
+  );
+};

--- a/packages/twenty-front/src/pages/settings/workspace/SettingsDomain.tsx
+++ b/packages/twenty-front/src/pages/settings/workspace/SettingsDomain.tsx
@@ -209,9 +209,7 @@ export const SettingsDomain = () => {
       <SettingsPageContainer>
         {/* eslint-disable-next-line react/jsx-props-no-spreading */}
         <FormProvider {...form}>
-          {(!currentWorkspace?.customDomain || !isCustomDomainEnabled) && (
-            <SettingsSubdomain />
-          )}
+          <SettingsSubdomain />
           {isCustomDomainEnabled && (
             <>
               <SettingsCustomDomainEffect />

--- a/packages/twenty-front/src/pages/settings/workspace/SettingsSubdomain.tsx
+++ b/packages/twenty-front/src/pages/settings/workspace/SettingsSubdomain.tsx
@@ -7,6 +7,7 @@ import { H2Title, Section } from 'twenty-ui';
 import { domainConfigurationState } from '@/domain-manager/states/domainConfigurationState';
 import { useRecoilValue } from 'recoil';
 import { isDefined } from 'twenty-shared';
+import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 
 const StyledDomainFormWrapper = styled.div`
   align-items: center;
@@ -25,6 +26,8 @@ const StyledDomain = styled.h2`
 export const SettingsSubdomain = () => {
   const domainConfiguration = useRecoilValue(domainConfigurationState);
   const { t } = useLingui();
+
+  const currentWorkspace = useRecoilValue(currentWorkspaceState);
 
   const { control } = useFormContext<{
     subdomain: string;
@@ -47,6 +50,7 @@ export const SettingsSubdomain = () => {
                 type="text"
                 onChange={onChange}
                 error={error?.message}
+                disabled={!!currentWorkspace?.customDomain}
                 fullWidth
               />
               {isDefined(domainConfiguration.frontDomain) && (


### PR DESCRIPTION
Introduce status management for custom domain records, displaying validation states with visual feedback. Replace text inputs with styled buttons for easier interaction, including a copy-to-clipboard feature. Adjust subdomain settings to disable input when a custom domain is set.