### PR TITLE
Fix relation creation

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -60,6 +60,34 @@
       "cwd": "${workspaceFolder}",
       "internalConsoleOptions": "neverOpen",
       "envFile": "${workspaceFolder}/packages/twenty-e2e-testing/.env"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Integration Test File",
+      "runtimeExecutable": "npx",
+      "runtimeArgs": [
+        "nx",
+        "run",
+        "twenty-server:jest",
+        "--",
+        "--config",
+        "./jest-integration.config.ts",
+        "${relativeFile}"
+      ],
+      "cwd": "${workspaceFolder}/packages/twenty-server",
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "autoAttachChildProcesses": true,
+      "sourceMaps": true,
+      "env": {
+        "NODE_OPTIONS": "--enable-source-maps",
+        "NODE_ENV": "test"
+      },
+      "skipFiles": [
+        "<node_internals>/**",
+        "**/node_modules/**"
+      ]
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -78,16 +78,9 @@
       "cwd": "${workspaceFolder}/packages/twenty-server",
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
-      "autoAttachChildProcesses": true,
-      "sourceMaps": true,
       "env": {
-        "NODE_OPTIONS": "--enable-source-maps",
         "NODE_ENV": "test"
       },
-      "skipFiles": [
-        "<node_internals>/**",
-        "**/node_modules/**"
-      ]
     }
   ]
 }

--- a/packages/twenty-server/jest-integration.config.ts
+++ b/packages/twenty-server/jest-integration.config.ts
@@ -18,6 +18,33 @@ const jestConfig: JestConfigWithTsJest = {
   globalTeardown: '<rootDir>/test/integration/utils/teardown-test.ts',
   testTimeout: 15000,
   maxWorkers: 1,
+  transform: {
+    '^.+\\.(t|j)s$': [
+      '@swc/jest',
+      {
+        jsc: {
+          parser: {
+            syntax: 'typescript',
+            tsx: false,
+            decorators: true,
+          },
+          transform: {
+            decoratorMetadata: true,
+          },
+          experimental: {
+            plugins: [
+              [
+                '@lingui/swc-plugin',
+                {
+                  stripNonEssentialFields: false,
+                },
+              ],
+            ],
+          },
+        },
+      },
+    ],
+  },
   moduleNameMapper: {
     ...pathsToModuleNameMapper(tsConfig.compilerOptions.paths, {
       prefix: '<rootDir>/../..',
@@ -28,9 +55,6 @@ const jestConfig: JestConfigWithTsJest = {
   },
   fakeTimers: {
     enableGlobally: true,
-  },
-  transform: {
-    '^.+\\.(t|j)s$': 'ts-jest',
   },
   globals: {
     APP_PORT: 4000,


### PR DESCRIPTION
## Context
We recently introduced a createMany on the field metadata service to improve seeding performances. This broke relation metadata creation because it was using a method with the same name that was inherited from TypeOrmQueryService.