### PR TITLE
Fixed context menu bug with new record filters refactor

### DIFF
--- a/packages/twenty-front/src/modules/object-metadata/hooks/__tests__/useColumnDefinitionsFromFieldMetadata.test.ts
+++ b/packages/twenty-front/src/modules/object-metadata/hooks/__tests__/useColumnDefinitionsFromFieldMetadata.test.ts
@@ -1,5 +1,4 @@
 import { renderHook } from '@testing-library/react';
-import { Nullable } from 'twenty-ui';
 
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { useColumnDefinitionsFromFieldMetadata } from '@/object-metadata/hooks/useColumnDefinitionsFromFieldMetadata';
@@ -49,29 +48,13 @@ const Wrapper = getJestMetadataAndApolloMocksAndActionMenuWrapper({
 });
 
 describe('useColumnDefinitionsFromFieldMetadata', () => {
-  it('should return empty definitions if no object is passed', () => {
-    const { result } = renderHook(
-      (objectMetadataItem?: Nullable<ObjectMetadataItem>) => {
-        return useColumnDefinitionsFromFieldMetadata(objectMetadataItem);
-      },
-      {
-        wrapper: Wrapper,
-      },
-    );
-
-    expect(Array.isArray(result.current.columnDefinitions)).toBe(true);
-    expect(Array.isArray(result.current.sortDefinitions)).toBe(true);
-    expect(result.current.columnDefinitions.length).toBe(0);
-    expect(result.current.sortDefinitions.length).toBe(0);
-  });
-
   it('should return expected definitions', () => {
     const companyObjectMetadata = generatedMockObjectMetadataItems.find(
       (item) => item.nameSingular === 'company',
     );
 
     const { result } = renderHook(
-      (objectMetadataItem?: Nullable<ObjectMetadataItem>) => {
+      (objectMetadataItem: ObjectMetadataItem) => {
         return useColumnDefinitionsFromFieldMetadata(objectMetadataItem);
       },
       {

--- a/packages/twenty-front/src/modules/object-metadata/hooks/useColumnDefinitionsFromFieldMetadata.ts
+++ b/packages/twenty-front/src/modules/object-metadata/hooks/useColumnDefinitionsFromFieldMetadata.ts
@@ -1,17 +1,17 @@
 import { useMemo } from 'react';
-import { Nullable } from 'twenty-ui';
 
 import { ObjectMetadataItem } from '@/object-metadata/types/ObjectMetadataItem';
 import { FieldMetadata } from '@/object-record/record-field/types/FieldMetadata';
 import { ColumnDefinition } from '@/object-record/record-table/types/ColumnDefinition';
 import { filterAvailableTableColumns } from '@/object-record/utils/filterAvailableTableColumns';
 
-import { useFilterableFieldMetadataItemsInRecordIndexContext } from '@/object-record/record-filter/hooks/useFilterableFieldMetadataItemsInRecordIndexContext';
+import { availableFieldMetadataItemsForFilterFamilySelector } from '@/object-metadata/states/availableFieldMetadataItemsForFilterFamilySelector';
+import { useRecoilValue } from 'recoil';
 import { formatFieldMetadataItemAsColumnDefinition } from '../utils/formatFieldMetadataItemAsColumnDefinition';
 import { formatFieldMetadataItemsAsSortDefinitions } from '../utils/formatFieldMetadataItemsAsSortDefinitions';
 
 export const useColumnDefinitionsFromFieldMetadata = (
-  objectMetadataItem?: Nullable<ObjectMetadataItem>,
+  objectMetadataItem: ObjectMetadataItem,
 ) => {
   const activeFieldMetadataItems = useMemo(
     () =>
@@ -23,8 +23,11 @@ export const useColumnDefinitionsFromFieldMetadata = (
     [objectMetadataItem],
   );
 
-  const { filterableFieldMetadataItems } =
-    useFilterableFieldMetadataItemsInRecordIndexContext();
+  const filterableFieldMetadataItems = useRecoilValue(
+    availableFieldMetadataItemsForFilterFamilySelector({
+      objectMetadataItemId: objectMetadataItem.id,
+    }),
+  );
 
   const sortDefinitions = formatFieldMetadataItemsAsSortDefinitions({
     fields: activeFieldMetadataItems,


### PR DESCRIPTION
This PR enforces objectMetadataItem to be passed to hook useColumnDefinitionsFromFieldMetadata, which was never used without an objectMetadataItem passed in parameters (and probably shouldn't anyway)

Removed the associated test that tested for an undefined objectMetadataItem parameter in useColumnDefinitionsFromFieldMetadata.

This allows to remove the need to rely on recordIndexContext to retrieve the filterableFieldMetadataItems.