### PR TITLE
chore: update eslint configuration and clean up index file

### DIFF
--- a/packages/twenty-server/.eslintrc.cjs
+++ b/packages/twenty-server/.eslintrc.cjs
@@ -5,6 +5,7 @@ module.exports = {
     'src/engine/workspace-manager/demo-objects-prefill-data/**',
     'src/engine/seeder/data-seeds/**',
     'src/engine/seeder/metadata-seeds/**',
+    'src/engine/core-modules/serverless/drivers/constants/base-typescript-project/src/index.ts',
   ],
   overrides: [
     {

--- a/packages/twenty-server/src/engine/core-modules/serverless/drivers/constants/base-typescript-project/src/index.ts
+++ b/packages/twenty-server/src/engine/core-modules/serverless/drivers/constants/base-typescript-project/src/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 export const main = async (params: {
   a: string;
   b: number;


### PR DESCRIPTION
Removed eslint disable comment from the index file and updated the eslint ignore list to exclude the serverless driver index file. This ensures the file is skipped during linting without unnecessary inline comments.