### PR TITLE
Fix: Ensure First Click on Spreadsheet Import 'Select File' Button Triggers File picker

### DIFF
--- a/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownMenuContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownMenuContent.tsx
@@ -165,7 +165,10 @@ export const ObjectOptionsDropdownMenuContent = () => {
               text={displayedExportProgress(progress)}
             />
             <MenuItem
-              onClick={() => openObjectRecordsSpreasheetImportDialog()}
+              onClick={() => {
+                openObjectRecordsSpreasheetImportDialog();
+                closeDropdown();
+              }}
               LeftIcon={IconFileImport}
               text="Import"
             />


### PR DESCRIPTION
Fixes #10154 

### What was happening:
1. Click "Import" in dropdown -> Dropdown stays open
2. Click "Select file" button -> Two events occur:
   - Button tries to open file dialog
   - Click event bubbles up, reaches dropdown, dropdown tries to close
3. These competing actions cause the first click to fail

### Fix
By closing the dropdown immediately when clicking "Import":

No competing event handlers are active
The dropdown is fully closed before any file selector interactions
The open() function from useDropzone can work without interference
