### PR TITLE
Fix custom exceptions not propagating error code

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/errors/graphql-query-runner.exception.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/errors/graphql-query-runner.exception.ts
@@ -1,7 +1,6 @@
 import { CustomException } from 'src/utils/custom-exception';
 
 export class GraphqlQueryRunnerException extends CustomException {
-  code: GraphqlQueryRunnerExceptionCode;
   constructor(message: string, code: GraphqlQueryRunnerExceptionCode) {
     super(message, code);
   }

--- a/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/workspace-query-runner.exception.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/workspace-query-runner.exception.ts
@@ -1,7 +1,6 @@
 import { CustomException } from 'src/utils/custom-exception';
 
 export class WorkspaceQueryRunnerException extends CustomException {
-  code: WorkspaceQueryRunnerExceptionCode;
   constructor(message: string, code: WorkspaceQueryRunnerExceptionCode) {
     super(message, code);
   }

--- a/packages/twenty-server/src/engine/core-modules/billing/billing.exception.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/billing.exception.ts
@@ -3,7 +3,6 @@
 import { CustomException } from 'src/utils/custom-exception';
 
 export class BillingException extends CustomException {
-  code: BillingExceptionCode;
   constructor(message: string, code: BillingExceptionCode) {
     super(message, code);
   }

--- a/packages/twenty-server/src/engine/core-modules/feature-flag/feature-flag.exception.ts
+++ b/packages/twenty-server/src/engine/core-modules/feature-flag/feature-flag.exception.ts
@@ -1,7 +1,6 @@
 import { CustomException } from 'src/utils/custom-exception';
 
 export class FeatureFlagException extends CustomException {
-  code: FeatureFlagExceptionCode;
   constructor(message: string, code: FeatureFlagExceptionCode) {
     super(message, code);
   }

--- a/packages/twenty-server/src/engine/core-modules/file-storage/interfaces/file-storage-exception.ts
+++ b/packages/twenty-server/src/engine/core-modules/file-storage/interfaces/file-storage-exception.ts
@@ -1,7 +1,6 @@
 import { CustomException } from 'src/utils/custom-exception';
 
 export class FileStorageException extends CustomException {
-  code: FileStorageExceptionCode;
   constructor(message: string, code: FileStorageExceptionCode) {
     super(message, code);
   }

--- a/packages/twenty-server/src/engine/core-modules/file/file.exception.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/file.exception.ts
@@ -7,7 +7,6 @@ export enum FileExceptionCode {
 }
 
 export class FileException extends CustomException {
-  code: FileExceptionCode;
   constructor(message: string, code: FileExceptionCode) {
     super(message, code);
   }

--- a/packages/twenty-server/src/engine/core-modules/sso/sso.exception.ts
+++ b/packages/twenty-server/src/engine/core-modules/sso/sso.exception.ts
@@ -3,7 +3,6 @@
 import { CustomException } from 'src/utils/custom-exception';
 
 export class SSOException extends CustomException {
-  code: SSOExceptionCode;
   constructor(message: string, code: SSOExceptionCode) {
     super(message, code);
   }

--- a/packages/twenty-server/src/engine/core-modules/throttler/throttler.exception.ts
+++ b/packages/twenty-server/src/engine/core-modules/throttler/throttler.exception.ts
@@ -1,7 +1,6 @@
 import { CustomException } from 'src/utils/custom-exception';
 
 export class ThrottlerException extends CustomException {
-  code: ThrottlerExceptionCode;
   constructor(message: string, code: ThrottlerExceptionCode) {
     super(message, code);
   }

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.exception.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.exception.ts
@@ -1,7 +1,6 @@
 import { CustomException } from 'src/utils/custom-exception';
 
 export class FieldMetadataException extends CustomException {
-  code: FieldMetadataExceptionCode;
   constructor(message: string, code: FieldMetadataExceptionCode) {
     super(message, code);
   }

--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.exception.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.exception.ts
@@ -1,7 +1,6 @@
 import { CustomException } from 'src/utils/custom-exception';
 
 export class ObjectMetadataException extends CustomException {
-  code: ObjectMetadataExceptionCode;
   constructor(message: string, code: ObjectMetadataExceptionCode) {
     super(message, code);
   }

--- a/packages/twenty-server/src/engine/metadata-modules/permissions/permissions.exception.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/permissions/permissions.exception.ts
@@ -1,7 +1,6 @@
 import { CustomException } from 'src/utils/custom-exception';
 
 export class PermissionsException extends CustomException {
-  code: PermissionsExceptionCode;
   constructor(message: string, code: PermissionsExceptionCode) {
     super(message, code);
   }

--- a/packages/twenty-server/src/engine/metadata-modules/relation-metadata/relation-metadata.exception.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/relation-metadata/relation-metadata.exception.ts
@@ -1,7 +1,6 @@
 import { CustomException } from 'src/utils/custom-exception';
 
 export class RelationMetadataException extends CustomException {
-  code: RelationMetadataExceptionCode;
   constructor(message: string, code: RelationMetadataExceptionCode) {
     super(message, code);
   }

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-server.exception.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-server.exception.ts
@@ -1,7 +1,6 @@
 import { CustomException } from 'src/utils/custom-exception';
 
 export class RemoteServerException extends CustomException {
-  code: RemoteServerExceptionCode;
   constructor(message: string, code: RemoteServerExceptionCode) {
     super(message, code);
   }

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/distant-table/distant-table.exception.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/distant-table/distant-table.exception.ts
@@ -1,7 +1,6 @@
 import { CustomException } from 'src/utils/custom-exception';
 
 export class DistantTableException extends CustomException {
-  code: DistantTableExceptionCode;
   constructor(message: string, code: DistantTableExceptionCode) {
     super(message, code);
   }

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/foreign-table/foreign-table.exception.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/foreign-table/foreign-table.exception.ts
@@ -1,7 +1,6 @@
 import { CustomException } from 'src/utils/custom-exception';
 
 export class ForeignTableException extends CustomException {
-  code: ForeignTableExceptionCode;
   constructor(message: string, code: ForeignTableExceptionCode) {
     super(message, code);
   }

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-table.exception.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-table.exception.ts
@@ -1,7 +1,6 @@
 import { CustomException } from 'src/utils/custom-exception';
 
 export class RemoteTableException extends CustomException {
-  code: RemoteTableExceptionCode;
   constructor(message: string, code: RemoteTableExceptionCode) {
     super(message, code);
   }

--- a/packages/twenty-server/src/engine/metadata-modules/serverless-function/serverless-function.exception.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/serverless-function/serverless-function.exception.ts
@@ -1,7 +1,6 @@
 import { CustomException } from 'src/utils/custom-exception';
 
 export class ServerlessFunctionException extends CustomException {
-  code: ServerlessFunctionExceptionCode;
   constructor(message: string, code: ServerlessFunctionExceptionCode) {
     super(message, code);
   }

--- a/packages/twenty-server/src/engine/metadata-modules/workspace-metadata-cache/exceptions/workspace-metadata-cache.exception.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/workspace-metadata-cache/exceptions/workspace-metadata-cache.exception.ts
@@ -1,7 +1,6 @@
 import { CustomException } from 'src/utils/custom-exception';
 
 export class WorkspaceMetadataCacheException extends CustomException {
-  code: WorkspaceMetadataCacheExceptionCode;
   constructor(message: string, code: WorkspaceMetadataCacheExceptionCode) {
     super(message, code);
   }

--- a/packages/twenty-server/src/engine/metadata-modules/workspace-metadata-version/exceptions/workspace-metadata-version.exception.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/workspace-metadata-version/exceptions/workspace-metadata-version.exception.ts
@@ -1,7 +1,6 @@
 import { CustomException } from 'src/utils/custom-exception';
 
 export class WorkspaceMetadataVersionException extends CustomException {
-  code: WorkspaceMetadataVersionExceptionCode;
   constructor(message: string, code: WorkspaceMetadataVersionExceptionCode) {
     super(message, code);
   }

--- a/packages/twenty-server/src/engine/metadata-modules/workspace-migration/workspace-migration.exception.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/workspace-migration/workspace-migration.exception.ts
@@ -1,7 +1,6 @@
 import { CustomException } from 'src/utils/custom-exception';
 
 export class WorkspaceMigrationException extends CustomException {
-  code: WorkspaceMigrationExceptionCode;
   constructor(message: string, code: WorkspaceMigrationExceptionCode) {
     super(message, code);
   }

--- a/packages/twenty-server/src/engine/twenty-orm/exceptions/twenty-orm.exception.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/exceptions/twenty-orm.exception.ts
@@ -1,7 +1,6 @@
 import { CustomException } from 'src/utils/custom-exception';
 
 export class TwentyORMException extends CustomException {
-  code: TwentyORMExceptionCode;
   constructor(message: string, code: TwentyORMExceptionCode) {
     super(message, code);
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/exceptions/workspace-cleaner.exception.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/exceptions/workspace-cleaner.exception.ts
@@ -1,7 +1,6 @@
 import { CustomException } from 'src/utils/custom-exception';
 
 export class WorkspaceCleanerException extends CustomException {
-  code: WorkspaceCleanerExceptionCode;
   constructor(message: string, code: WorkspaceCleanerExceptionCode) {
     super(message, code);
   }

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/exceptions/calendar-event-import-driver.exception.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/exceptions/calendar-event-import-driver.exception.ts
@@ -1,7 +1,6 @@
 import { CustomException } from 'src/utils/custom-exception';
 
 export class CalendarEventImportDriverException extends CustomException {
-  code: CalendarEventImportDriverExceptionCode;
   constructor(message: string, code: CalendarEventImportDriverExceptionCode) {
     super(message, code);
   }

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/exceptions/calendar-event-import.exception.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/exceptions/calendar-event-import.exception.ts
@@ -1,7 +1,6 @@
 import { CustomException } from 'src/utils/custom-exception';
 
 export class CalendarEventImportException extends CustomException {
-  code: CalendarEventImportExceptionCode;
   constructor(message: string, code: CalendarEventImportExceptionCode) {
     super(message, code);
   }

--- a/packages/twenty-server/src/modules/connected-account/refresh-access-token-manager/exceptions/refresh-access-token.exception.ts
+++ b/packages/twenty-server/src/modules/connected-account/refresh-access-token-manager/exceptions/refresh-access-token.exception.ts
@@ -1,7 +1,6 @@
 import { CustomException } from 'src/utils/custom-exception';
 
 export class RefreshAccessTokenException extends CustomException {
-  code: RefreshAccessTokenExceptionCode;
   constructor(message: string, code: RefreshAccessTokenExceptionCode) {
     super(message, code);
   }

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/exceptions/message-import-driver.exception.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/exceptions/message-import-driver.exception.ts
@@ -1,11 +1,8 @@
 import { CustomException } from 'src/utils/custom-exception';
 
 export class MessageImportDriverException extends CustomException {
-  code: MessageImportDriverExceptionCode;
-
   constructor(message: string, code: MessageImportDriverExceptionCode) {
     super(message, code);
-    this.code = code;
   }
 }
 

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/exceptions/message-import.exception.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/exceptions/message-import.exception.ts
@@ -1,7 +1,6 @@
 import { CustomException } from 'src/utils/custom-exception';
 
 export class MessageImportException extends CustomException {
-  code: MessageImportExceptionCode;
   constructor(message: string, code: MessageImportExceptionCode) {
     super(message, code);
   }

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/exceptions/workflow-step-executor.exception.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/exceptions/workflow-step-executor.exception.ts
@@ -1,7 +1,6 @@
 import { CustomException } from 'src/utils/custom-exception';
 
 export class WorkflowStepExecutorException extends CustomException {
-  code: WorkflowStepExecutorExceptionCode;
   constructor(message: string, code: WorkflowStepExecutorExceptionCode) {
     super(message, code);
   }

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/mail-sender/exceptions/send-email-action.exception.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/mail-sender/exceptions/send-email-action.exception.ts
@@ -1,7 +1,6 @@
 import { CustomException } from 'src/utils/custom-exception';
 
 export class SendEmailActionException extends CustomException {
-  code: SendEmailActionExceptionCode;
   constructor(message: string, code: SendEmailActionExceptionCode) {
     super(message, code);
   }

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/record-crud/exceptions/record-crud-action.exception.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/record-crud/exceptions/record-crud-action.exception.ts
@@ -1,7 +1,6 @@
 import { CustomException } from 'src/utils/custom-exception';
 
 export class RecordCRUDActionException extends CustomException {
-  code: RecordCRUDActionExceptionCode;
   constructor(message: string, code: RecordCRUDActionExceptionCode) {
     super(message, code);
   }

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/exceptions/workflow-run.exception.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/exceptions/workflow-run.exception.ts
@@ -1,7 +1,6 @@
 import { CustomException } from 'src/utils/custom-exception';
 
 export class WorkflowRunException extends CustomException {
-  code: WorkflowRunExceptionCode;
   constructor(message: string, code: WorkflowRunExceptionCode) {
     super(message, code);
   }

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/exceptions/workflow-trigger.exception.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/exceptions/workflow-trigger.exception.ts
@@ -1,7 +1,6 @@
 import { CustomException } from 'src/utils/custom-exception';
 
 export class WorkflowTriggerException extends CustomException {
-  code: WorkflowTriggerExceptionCode;
   constructor(message: string, code: WorkflowTriggerExceptionCode) {
     super(message, code);
   }


### PR DESCRIPTION
## Context
In some CustomException exceptions, we were instantiating a code without initializing it which was overriding the parent code and it was then lost when retrieving it in filters.
Removing them to make sure we don't reproduce this pattern