### PR TITLE
Fix upgrade-0-42 command to migrate RICH_TEXT field metadata to RICH_TEXT_V2

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-fix-body-v2-view-field-position.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-fix-body-v2-view-field-position.command.ts
@@ -163,7 +163,7 @@ export class FixBodyV2ViewFieldPositionCommand extends ActiveWorkspacesCommandRu
             aggregateOperation: bodyViewField.aggregateOperation,
           });
 
-          viewFieldRepository.save(viewFieldToCreate);
+          await viewFieldRepository.save(viewFieldToCreate);
 
           await viewFieldRepository.update(
             { id: bodyViewField.id },

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-fix-body-v2-view-field-position.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-fix-body-v2-view-field-position.command.ts
@@ -154,7 +154,7 @@ export class FixBodyV2ViewFieldPositionCommand extends ActiveWorkspacesCommandRu
             (field) => field.name === 'bodyV2',
           )?.id;
 
-          await viewFieldRepository.create({
+          const viewFieldToCreate = viewFieldRepository.create({
             fieldMetadataId: bodyV2FieldMetadataId,
             viewId: view.id,
             position: bodyViewField.position,
@@ -162,6 +162,8 @@ export class FixBodyV2ViewFieldPositionCommand extends ActiveWorkspacesCommandRu
             size: bodyViewField.size,
             aggregateOperation: bodyViewField.aggregateOperation,
           });
+
+          viewFieldRepository.save(viewFieldToCreate);
 
           await viewFieldRepository.update(
             { id: bodyViewField.id },

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/constants/standard-field-ids.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/constants/standard-field-ids.ts
@@ -325,7 +325,7 @@ export const OPPORTUNITY_STANDARD_FIELD_IDS = {
   favorites: '20202020-a1c2-4500-aaae-83ba8a0e827a',
   // TODO: check if activityTargets field can be deleted
   activityTargets: '20202020-220a-42d6-8261-b2102d6eab35',
-  taskTargets: '20202020-59c0-4279-a208-4a255f04a5be',
+  taskTargets: '20202020-59c0-4179-a208-4a255f04a5be',
   noteTargets: '20202020-dd3f-42d5-a382-db58aabf43d3',
   attachments: '20202020-87c7-4118-83d6-2f4031005209',
   timelineActivities: '20202020-30e2-421f-96c7-19c69d1cf631',
@@ -338,7 +338,7 @@ export const PERSON_STANDARD_FIELD_IDS = {
   emails: '20202020-3c51-43fa-8b6e-af39e29368ab',
   linkedinLink: '20202020-f1af-48f7-893b-2007a73dd508',
   xLink: '20202020-8fc2-487c-b84a-55a99b145cfd',
-  jobTitle: '20202020-b0d0-425a-bef9-640a26dacd9b',
+  jobTitle: '20202020-b0d0-415a-bef9-640a26dacd9b',
   phone: '20202020-4564-4b8b-a09f-05445f2e0bce',
   phones: '20202020-0638-448e-8825-439134618022',
   city: '20202020-5243-4ffb-afc5-2c675da41346',
@@ -380,7 +380,7 @@ export const TASK_TARGET_STANDARD_FIELD_IDS = {
   person: '20202020-c8a0-4e85-a016-87e2349cfbec',
   company: '20202020-4703-4a4e-948c-487b0c60a92c',
   opportunity: '20202020-6cb2-4c01-a9a5-aca3dbc11d41',
-  custom: '20202020-42c1-4c9a-8c75-be0971ef89af',
+  custom: '20202020-41c1-4c9a-8c75-be0971ef89af',
 };
 
 export const VIEW_FIELD_STANDARD_FIELD_IDS = {

--- a/packages/twenty-server/src/modules/note/standard-objects/note.workspace-entity.ts
+++ b/packages/twenty-server/src/modules/note/standard-objects/note.workspace-entity.ts
@@ -17,6 +17,7 @@ import { WorkspaceEntity } from 'src/engine/twenty-orm/decorators/workspace-enti
 import { WorkspaceFieldIndex } from 'src/engine/twenty-orm/decorators/workspace-field-index.decorator';
 import { WorkspaceField } from 'src/engine/twenty-orm/decorators/workspace-field.decorator';
 import { WorkspaceGate } from 'src/engine/twenty-orm/decorators/workspace-gate.decorator';
+import { WorkspaceIsDeprecated } from 'src/engine/twenty-orm/decorators/workspace-is-deprecated.decorator';
 import { WorkspaceIsNullable } from 'src/engine/twenty-orm/decorators/workspace-is-nullable.decorator';
 import { WorkspaceIsSystem } from 'src/engine/twenty-orm/decorators/workspace-is-system.decorator';
 import { WorkspaceRelation } from 'src/engine/twenty-orm/decorators/workspace-relation.decorator';
@@ -72,10 +73,11 @@ export class NoteWorkspaceEntity extends BaseWorkspaceEntity {
   @WorkspaceField({
     standardId: NOTE_STANDARD_FIELD_IDS.body,
     type: FieldMetadataType.RICH_TEXT,
-    label: msg`Body`,
+    label: msg`Body (deprecated)`,
     description: msg`Note body`,
     icon: 'IconFilePencil',
   })
+  @WorkspaceIsDeprecated()
   @WorkspaceIsNullable()
   body: string | null;
 

--- a/packages/twenty-server/src/modules/task/standard-objects/task.workspace-entity.ts
+++ b/packages/twenty-server/src/modules/task/standard-objects/task.workspace-entity.ts
@@ -17,6 +17,7 @@ import { WorkspaceEntity } from 'src/engine/twenty-orm/decorators/workspace-enti
 import { WorkspaceFieldIndex } from 'src/engine/twenty-orm/decorators/workspace-field-index.decorator';
 import { WorkspaceField } from 'src/engine/twenty-orm/decorators/workspace-field.decorator';
 import { WorkspaceGate } from 'src/engine/twenty-orm/decorators/workspace-gate.decorator';
+import { WorkspaceIsDeprecated } from 'src/engine/twenty-orm/decorators/workspace-is-deprecated.decorator';
 import { WorkspaceIsNullable } from 'src/engine/twenty-orm/decorators/workspace-is-nullable.decorator';
 import { WorkspaceIsSystem } from 'src/engine/twenty-orm/decorators/workspace-is-system.decorator';
 import { WorkspaceJoinColumn } from 'src/engine/twenty-orm/decorators/workspace-join-column.decorator';
@@ -74,10 +75,11 @@ export class TaskWorkspaceEntity extends BaseWorkspaceEntity {
   @WorkspaceField({
     standardId: TASK_STANDARD_FIELD_IDS.body,
     type: FieldMetadataType.RICH_TEXT,
-    label: msg`Body`,
+    label: msg`Body (deprecated)`,
     description: msg`Task body`,
     icon: 'IconFilePencil',
   })
+  @WorkspaceIsDeprecated()
   @WorkspaceIsNullable()
   body: string | null;
 


### PR DESCRIPTION
While making sure the upgrade-0.42 command was working as expected to upgrade from 0.41 to 0.42, we've detected that the standardId of the new bodyV2 (type RICH_TEXT_V2) was not properly set ; standardId was not correct.

This was forcing the sync-metadata command to try to re-create the field again.