### PR TITLE
Display object name plural instead of object

### DIFF
--- a/packages/twenty-front/src/modules/command-menu/components/CommandMenu.tsx
+++ b/packages/twenty-front/src/modules/command-menu/components/CommandMenu.tsx
@@ -6,6 +6,7 @@ import { useMatchingCommandMenuCommands } from '@/command-menu/hooks/useMatching
 import { commandMenuSearchState } from '@/command-menu/states/commandMenuSearchState';
 import { Command } from '@/command-menu/types/Command';
 import { contextStoreCurrentObjectMetadataIdComponentState } from '@/context-store/states/contextStoreCurrentObjectMetadataIdComponentState';
+import { objectMetadataItemsState } from '@/object-metadata/states/objectMetadataItemsState';
 import { SelectableItem } from '@/ui/layout/selectable-list/components/SelectableItem';
 import { useRecoilComponentValueV2 } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValueV2';
 import { useLingui } from '@lingui/react/macro';
@@ -54,6 +55,15 @@ export const CommandMenu = () => {
     'command-menu-previous',
   );
 
+  const objectMetadataItems = useRecoilValue(objectMetadataItemsState);
+  const currentObjectMetadataId = useRecoilComponentValueV2(
+    contextStoreCurrentObjectMetadataIdComponentState,
+  );
+
+  const currentObjectMetadataItem = objectMetadataItems.find(
+    (objectMetadataItem) => objectMetadataItem.id === currentObjectMetadataId,
+  );
+
   const selectableItemIds = selectableItems.map((item) => item.id);
 
   if (isNonEmptyString(previousContextStoreCurrentObjectMetadataId)) {
@@ -72,7 +82,7 @@ export const CommandMenu = () => {
       ),
     },
     {
-      heading: t`Object`,
+      heading: currentObjectMetadataItem?.labelPlural ?? t`Object`,
       items: matchingStandardActionObjectCommands,
     },
     {


### PR DESCRIPTION
Display object name plural instead of 'Object' inside the command menu section related to the current object.