### PR TITLE
Delay loading support chat

### DIFF
--- a/packages/twenty-front/src/modules/support/components/__stories__/SupportDropdown.stories.tsx
+++ b/packages/twenty-front/src/modules/support/components/__stories__/SupportDropdown.stories.tsx
@@ -53,6 +53,9 @@ export const Default: Story = {
     expect(await canvas.findByText('Support')).toBeInTheDocument();
     await userEvent.click(canvas.getByText('Support'));
 
+    // Add delay to account for the timeout in useSupportChat
+    await new Promise((resolve) => setTimeout(resolve, 600));
+
     expect(await canvas.findByText('Documentation')).toBeInTheDocument();
     expect(await canvas.findByText('Talk to us')).toBeInTheDocument();
   },

--- a/packages/twenty-front/src/modules/support/hooks/useSupportChat.ts
+++ b/packages/twenty-front/src/modules/support/hooks/useSupportChat.ts
@@ -12,15 +12,18 @@ const insertScript = ({
   src,
   innerHTML,
   onLoad,
+  defer = false,
 }: {
   src?: string;
   innerHTML?: string;
   onLoad?: (...args: any[]) => void;
+  defer?: boolean;
 }) => {
   const script = document.createElement('script');
   if (isNonEmptyString(src)) script.src = src;
   if (isNonEmptyString(innerHTML)) script.innerHTML = innerHTML;
   if (isDefined(onLoad)) script.onload = onLoad;
+  script.defer = defer;
   document.body.appendChild(script);
 };
 
@@ -50,6 +53,7 @@ export const useSupportChat = () => {
 
       insertScript({
         src: url,
+        defer: true,
         onLoad: () => {
           window.FrontChat?.('init', {
             chatId,
@@ -82,7 +86,7 @@ export const useSupportChat = () => {
           currentUser,
           currentWorkspaceMember,
         );
-      }, 2000);
+      }, 500);
     }
   }, [
     configureFront,

--- a/packages/twenty-front/src/modules/support/hooks/useSupportChat.ts
+++ b/packages/twenty-front/src/modules/support/hooks/useSupportChat.ts
@@ -76,11 +76,13 @@ export const useSupportChat = () => {
       isDefined(currentWorkspaceMember) &&
       !isFrontChatLoaded
     ) {
-      configureFront(
-        supportChat.supportFrontChatId,
-        currentUser,
-        currentWorkspaceMember,
-      );
+      setTimeout(() => {
+        configureFront(
+          supportChat.supportFrontChatId as string,
+          currentUser,
+          currentWorkspaceMember,
+        );
+      }, 2000);
     }
   }, [
     configureFront,


### PR DESCRIPTION
There are a lot of requests being done in parallel when you load the page, and the support chat is responsible for some of them. I don't think it's critical to have it upon loading so delaying it by 2 seconds