### PR TITLE
[NITPICK] call `closeDropdown` before `openModal` import spreadsheet

### DIFF
--- a/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownMenuContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownMenuContent.tsx
@@ -166,8 +166,8 @@ export const ObjectOptionsDropdownMenuContent = () => {
             />
             <MenuItem
               onClick={() => {
-                openObjectRecordsSpreasheetImportDialog();
                 closeDropdown();
+                openObjectRecordsSpreasheetImportDialog();
               }}
               LeftIcon={IconFileImport}
               text="Import"


### PR DESCRIPTION
# Introduction
Just a nitpick resulting from https://github.com/twentyhq/twenty/pull/10205
Avoid any possible race condition between competing event handlers by closing dropdown before opening modal 