### PR TITLE
refactor(entities): centralize base entity fields

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/app-token/app-token.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/app-token/app-token.entity.ts
@@ -1,21 +1,12 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 
-import { BeforeCreateOne, IDField } from '@ptc-org/nestjs-query-graphql';
-import {
-  Column,
-  CreateDateColumn,
-  Entity,
-  JoinColumn,
-  ManyToOne,
-  PrimaryGeneratedColumn,
-  Relation,
-  UpdateDateColumn,
-} from 'typeorm';
+import { BeforeCreateOne } from '@ptc-org/nestjs-query-graphql';
+import { Column, Entity, JoinColumn, ManyToOne, Relation } from 'typeorm';
 
-import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 import { BeforeCreateOneAppToken } from 'src/engine/core-modules/app-token/hooks/before-create-one-app-token.hook';
 import { User } from 'src/engine/core-modules/user/user.entity';
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
+import { BaseSoftDeleteEntity } from 'src/engine/utils/base-entities-fields';
 
 export enum AppTokenType {
   RefreshToken = 'REFRESH_TOKEN',
@@ -30,11 +21,7 @@ export enum AppTokenType {
 @Entity({ name: 'appToken', schema: 'core' })
 @ObjectType()
 @BeforeCreateOne(BeforeCreateOneAppToken)
-export class AppToken {
-  @IDField(() => UUIDScalarType)
-  @PrimaryGeneratedColumn('uuid')
-  id: string;
-
+export class AppToken extends BaseSoftDeleteEntity {
   @ManyToOne(() => User, (user) => user.appTokens, {
     onDelete: 'CASCADE',
   })
@@ -65,18 +52,7 @@ export class AppToken {
   expiresAt: Date;
 
   @Column({ nullable: true, type: 'timestamptz' })
-  deletedAt: Date | null;
-
-  @Column({ nullable: true, type: 'timestamptz' })
   revokedAt: Date | null;
-
-  @Field()
-  @CreateDateColumn({ type: 'timestamptz' })
-  createdAt: Date;
-
-  @Field()
-  @UpdateDateColumn({ type: 'timestamptz' })
-  updatedAt: Date;
 
   @Column({ nullable: true, type: 'jsonb' })
   context: { email: string } | null;

--- a/packages/twenty-server/src/engine/core-modules/sso/workspace-sso-identity-provider.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/sso/workspace-sso-identity-provider.entity.ts
@@ -2,20 +2,10 @@
 
 import { ObjectType, registerEnumType } from '@nestjs/graphql';
 
-import { IDField } from '@ptc-org/nestjs-query-graphql';
-import {
-  Column,
-  CreateDateColumn,
-  Entity,
-  JoinColumn,
-  ManyToOne,
-  PrimaryGeneratedColumn,
-  Relation,
-  UpdateDateColumn,
-} from 'typeorm';
+import { Column, Entity, JoinColumn, ManyToOne, Relation } from 'typeorm';
 
-import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
+import { BaseEntity } from 'src/engine/utils/base-entities-fields';
 
 export enum IdentityProviderType {
   OIDC = 'OIDC',
@@ -46,12 +36,7 @@ registerEnumType(SSOIdentityProviderStatus, {
 
 @Entity({ name: 'workspaceSSOIdentityProvider', schema: 'core' })
 @ObjectType()
-export class WorkspaceSSOIdentityProvider {
-  // COMMON
-  @IDField(() => UUIDScalarType)
-  @PrimaryGeneratedColumn('uuid')
-  id: string;
-
+export class WorkspaceSSOIdentityProvider extends BaseEntity {
   @Column()
   name: string;
 
@@ -74,12 +59,6 @@ export class WorkspaceSSOIdentityProvider {
 
   @Column()
   workspaceId: string;
-
-  @CreateDateColumn({ type: 'timestamptz' })
-  createdAt: Date;
-
-  @UpdateDateColumn({ type: 'timestamptz' })
-  updatedAt: Date;
 
   @Column({
     type: 'enum',

--- a/packages/twenty-server/src/engine/core-modules/user/user.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/user.entity.ts
@@ -1,25 +1,14 @@
 import { Field, ObjectType, registerEnumType } from '@nestjs/graphql';
 
-import { IDField } from '@ptc-org/nestjs-query-graphql';
-import {
-  Column,
-  CreateDateColumn,
-  DeleteDateColumn,
-  Entity,
-  Index,
-  OneToMany,
-  PrimaryGeneratedColumn,
-  Relation,
-  UpdateDateColumn,
-} from 'typeorm';
+import { Column, Entity, Index, OneToMany, Relation } from 'typeorm';
 
-import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 import { AppToken } from 'src/engine/core-modules/app-token/app-token.entity';
 import { KeyValuePair } from 'src/engine/core-modules/key-value-pair/key-value-pair.entity';
 import { OnboardingStatus } from 'src/engine/core-modules/onboarding/enums/onboarding-status.enum';
 import { UserWorkspace } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
 import { WorkspaceMember } from 'src/engine/core-modules/user/dtos/workspace-member.dto';
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
+import { BaseSoftDeleteEntity } from 'src/engine/utils/base-entities-fields';
 
 registerEnumType(OnboardingStatus, {
   name: 'OnboardingStatus',
@@ -32,11 +21,7 @@ registerEnumType(OnboardingStatus, {
   unique: true,
   where: '"deletedAt" IS NULL',
 })
-export class User {
-  @IDField(() => UUIDScalarType)
-  @PrimaryGeneratedColumn('uuid')
-  id: string;
-
+export class User extends BaseSoftDeleteEntity {
   @Field()
   @Column({ default: '' })
   firstName: string;
@@ -68,18 +53,6 @@ export class User {
   @Field()
   @Column({ default: false })
   canImpersonate: boolean;
-
-  @Field()
-  @CreateDateColumn({ type: 'timestamptz' })
-  createdAt: Date;
-
-  @Field()
-  @UpdateDateColumn({ type: 'timestamptz' })
-  updatedAt: Date;
-
-  @Field({ nullable: true })
-  @DeleteDateColumn({ type: 'timestamptz' })
-  deletedAt: Date;
 
   @Field(() => String, { nullable: false })
   @Column({ nullable: false, default: 'en' })

--- a/packages/twenty-server/src/engine/core-modules/workspace/workspace.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/workspace.entity.ts
@@ -1,25 +1,15 @@
 import { Field, ObjectType, registerEnumType } from '@nestjs/graphql';
 
-import { IDField } from '@ptc-org/nestjs-query-graphql';
 import { WorkspaceActivationStatus } from 'twenty-shared';
-import {
-  Column,
-  CreateDateColumn,
-  DeleteDateColumn,
-  Entity,
-  OneToMany,
-  PrimaryGeneratedColumn,
-  Relation,
-  UpdateDateColumn,
-} from 'typeorm';
+import { Column, Entity, OneToMany, Relation } from 'typeorm';
 
-import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 import { AppToken } from 'src/engine/core-modules/app-token/app-token.entity';
 import { FeatureFlag } from 'src/engine/core-modules/feature-flag/feature-flag.entity';
 import { KeyValuePair } from 'src/engine/core-modules/key-value-pair/key-value-pair.entity';
 import { PostgresCredentials } from 'src/engine/core-modules/postgres-credentials/postgres-credentials.entity';
 import { WorkspaceSSOIdentityProvider } from 'src/engine/core-modules/sso/workspace-sso-identity-provider.entity';
 import { UserWorkspace } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
+import { BaseSoftDeleteEntity } from 'src/engine/utils/base-entities-fields';
 
 registerEnumType(WorkspaceActivationStatus, {
   name: 'WorkspaceActivationStatus',
@@ -27,11 +17,7 @@ registerEnumType(WorkspaceActivationStatus, {
 
 @Entity({ name: 'workspace', schema: 'core' })
 @ObjectType()
-export class Workspace {
-  @IDField(() => UUIDScalarType)
-  @PrimaryGeneratedColumn('uuid')
-  id: string;
-
+export class Workspace extends BaseSoftDeleteEntity {
   @Field({ nullable: true })
   @Column({ nullable: true })
   displayName?: string;
@@ -43,18 +29,6 @@ export class Workspace {
   @Field({ nullable: true })
   @Column({ nullable: true })
   inviteHash?: string;
-
-  @Field({ nullable: true })
-  @DeleteDateColumn({ type: 'timestamptz' })
-  deletedAt?: Date;
-
-  @Field()
-  @CreateDateColumn({ type: 'timestamptz' })
-  createdAt: Date;
-
-  @Field()
-  @UpdateDateColumn({ type: 'timestamptz' })
-  updatedAt: Date;
 
   @OneToMany(() => AppToken, (appToken) => appToken.workspace, {
     cascade: true,

--- a/packages/twenty-server/src/engine/utils/base-entities-fields.ts
+++ b/packages/twenty-server/src/engine/utils/base-entities-fields.ts
@@ -1,0 +1,33 @@
+import { Field, ObjectType } from '@nestjs/graphql';
+
+import {
+  CreateDateColumn,
+  DeleteDateColumn,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { IDField } from '@ptc-org/nestjs-query-graphql';
+
+import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
+
+@ObjectType()
+export abstract class BaseEntity {
+  @IDField(() => UUIDScalarType)
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Field()
+  @CreateDateColumn({ name: 'createdAt', type: 'timestamptz' })
+  createdAt: Date;
+
+  @Field()
+  @UpdateDateColumn({ name: 'updatedAt', type: 'timestamptz' })
+  updatedAt: Date;
+}
+
+@ObjectType()
+export abstract class BaseSoftDeleteEntity extends BaseEntity {
+  @Field({ nullable: true })
+  @DeleteDateColumn({ name: 'deletedAt', type: 'timestamptz' })
+  deletedAt: Date;
+}


### PR DESCRIPTION
Extracted common fields (id, createdAt, updatedAt, deletedAt) into abstract base classes BaseEntity and BaseSoftDeleteEntity. Updated various entities to inherit from these classes, reducing redundancy and improving maintainability.