### PR TITLE
Remove status check when ending workflow

### DIFF
--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run/workflow-run.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run/workflow-run.workspace-service.ts
@@ -113,13 +113,6 @@ export class WorkflowRunWorkspaceService {
       );
     }
 
-    if (workflowRunToUpdate.status !== WorkflowRunStatus.RUNNING) {
-      throw new WorkflowRunException(
-        'Workflow cannot be ended as it is not running',
-        WorkflowRunExceptionCode.INVALID_OPERATION,
-      );
-    }
-
     return workflowRunRepository.update(workflowRunToUpdate.id, {
       status,
       endedAt: new Date().toISOString(),


### PR DESCRIPTION
Should be possible to end workflow, not matter what the current status is.
On failure before the workflow was started, this error prevent the workflow to be marked as failed with the right error message.