### PR TITLE
Fix queryRunnerArgsFactory for updateMany resolver

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/factories/query-runner-args.factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/factories/query-runner-args.factory.ts
@@ -105,18 +105,14 @@ export class QueryRunnerArgsFactory {
             (args as UpdateManyResolverArgs).filter,
             fieldMetadataMapByNameByName,
           ),
-          data: await Promise.all(
-            (args as UpdateManyResolverArgs).data?.map((arg, index) =>
-              this.overrideDataByFieldMetadata(
-                arg,
-                options,
-                fieldMetadataMapByNameByName,
-                {
-                  argIndex: index,
-                  shouldBackfillPosition: false,
-                },
-              ),
-            ) ?? [],
+          data: await this.overrideDataByFieldMetadata(
+            (args as UpdateOneResolverArgs).data,
+            options,
+            fieldMetadataMapByNameByName,
+            {
+              argIndex: 0,
+              shouldBackfillPosition: false,
+            },
           ),
         } satisfies UpdateManyResolverArgs;
       case ResolverArgsType.FindOne:

--- a/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/factories/query-runner-args.factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/factories/query-runner-args.factory.ts
@@ -106,7 +106,7 @@ export class QueryRunnerArgsFactory {
             fieldMetadataMapByNameByName,
           ),
           data: await this.overrideDataByFieldMetadata(
-            (args as UpdateOneResolverArgs).data,
+            (args as UpdateManyResolverArgs).data,
             options,
             fieldMetadataMapByNameByName,
             {


### PR DESCRIPTION
This was updated a few weeks ago and went unnoticed since 1) integration tests were broken + 2) we don't have actionnable updateMany mutations in the product at the moment

It will fix some tests, at least all-people-resolvers.integration-spec.ts for instance