### PR TITLE
[BUGFIX][PROD] RICH_TEXT_V2 command handle `{}` body col value

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-migrate-rich-text-field.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-migrate-rich-text-field.command.ts
@@ -106,7 +106,7 @@ export class MigrateRichTextFieldCommand extends ActiveWorkspacesCommandRunner {
     if (options.force) {
       this.logger.warn('Running in force mode');
     }
-    this.options = { ...options };
+    this.options = options;
     if (isCommandLogger(this.logger)) {
       this.logger.setVerbose(options.verbose ?? false);
     }
@@ -207,13 +207,13 @@ export class MigrateRichTextFieldCommand extends ActiveWorkspacesCommandRunner {
       case richTextField.standardId === NOTE_STANDARD_FIELD_IDS.body: {
         return NOTE_STANDARD_FIELD_IDS.bodyV2;
       }
-      case !richTextField.isCustom: {
+      case richTextField.isCustom: {
+        return null;
+      }
+      default: {
         throw new Error(
           `RICH_TEXT does not belong to a Task or a Note standard objects: ${richTextField.id}`,
         );
-      }
-      default: {
-        return null;
       }
     }
   }

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-migrate-rich-text-field.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-migrate-rich-text-field.command.ts
@@ -54,8 +54,6 @@ type ProcessRichTextFieldsArgs = {
   richTextFields: FieldMetadataEntity[];
   workspaceId: string;
 };
-
-type AsyncMethod<T> = () => Promise<T>;
 @Command({
   name: 'upgrade-0.42:migrate-rich-text-field',
   description: 'Migrate RICH_TEXT fields to new composite structure',
@@ -245,6 +243,7 @@ export class MigrateRichTextFieldCommand extends ActiveWorkspacesCommandRunner {
 
     const shouldForceCreateColumns =
       this.options.force && fieldMetadataAlreadyExisting;
+
     if (shouldForceCreateColumns) {
       this.logger.warn(
         `Force creating V2 columns for workspaceId: ${workspaceId} objectMetadaId: ${objectMetadata.id}`,
@@ -252,6 +251,7 @@ export class MigrateRichTextFieldCommand extends ActiveWorkspacesCommandRunner {
     }
     const shouldCreateColumns =
       !fieldMetadataAlreadyExisting || shouldForceCreateColumns;
+
     if (!this.options.dryRun && shouldCreateColumns) {
       await this.workspaceMigrationService.createCustomMigration(
         generateMigrationName(
@@ -301,6 +301,7 @@ export class MigrateRichTextFieldCommand extends ActiveWorkspacesCommandRunner {
           workspaceId,
         });
       const fieldMetadataAlreadyExisting = isDefined(existingFieldMetadata);
+
       if (fieldMetadataAlreadyExisting) {
         this.logger.warn(
           `FieldMetadata already exists in fieldMetadataRepository name: ${newRichTextField.name} standardId: ${newRichTextField.standardId} type: ${newRichTextField.type} workspaceId: ${workspaceId}`,

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-migrate-rich-text-field.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-migrate-rich-text-field.command.ts
@@ -245,11 +245,11 @@ export class MigrateRichTextFieldCommand extends ActiveWorkspacesCommandRunner {
     ] as const;
 
     const bodyV2FieldExists = objectMetadata.fields.some(
-      (field) => field.name === 'bodyV2',
+      (field) => field.name === `${richTextField.name}V2`,
     );
     if (bodyV2FieldExists) {
       this.logger.warn(
-        `BodyV2 field already exists for workspaceId: ${workspaceId} objectMetadata: ${objectMetadata.id}`,
+        `${richTextField.name}V2 field already exists for workspaceId: ${workspaceId} objectMetadata: ${objectMetadata.id}`,
       );
     }
 

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-migrate-rich-text-field.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-migrate-rich-text-field.command.ts
@@ -313,7 +313,7 @@ export class MigrateRichTextFieldCommand extends ActiveWorkspacesCommandRunner {
 
       if (fieldMetadataAlreadyExists) {
         this.logger.warn(
-          `FieldMetadata already exists in fieldMetadataRepository name: ${newRichTextField.name} standardId: ${newRichTextField.standardId} type: ${newRichTextField.type}`,
+          `FieldMetadata already exists in fieldMetadataRepository name: ${newRichTextField.name} standardId: ${newRichTextField.standardId} type: ${newRichTextField.type} workspaceId: ${workspaceId}`,
         );
       }
 

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-migrate-rich-text-field.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-migrate-rich-text-field.command.ts
@@ -231,11 +231,13 @@ export class MigrateRichTextFieldCommand extends ActiveWorkspacesCommandRunner {
       blocknoteFieldValue !== null &&
       blocknoteFieldValue !== undefined &&
       blocknoteFieldValue !== '{}';
+
     if (!blocknoteFieldValueIsDefined) {
       return null;
     }
 
     const jsonParsedblocknoteFieldValue = JSON.parse(blocknoteFieldValue);
+
     if (!Array.isArray(jsonParsedblocknoteFieldValue)) {
       return null;
     }
@@ -283,6 +285,7 @@ export class MigrateRichTextFieldCommand extends ActiveWorkspacesCommandRunner {
           blocknoteFieldValue,
           serverBlockNoteEditor,
         });
+
         await workspaceDataSource.query(
           `UPDATE "${schemaName}"."${computeTableName(objectMetadata.nameSingular, objectMetadata.isCustom)}" SET "${richTextField.name}V2Blocknote" = $1, "${richTextField.name}V2Markdown" = $2 WHERE id = $3`,
           [blocknoteFieldValue, markdownFieldValue, row.id],

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-migrate-rich-text-field.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-migrate-rich-text-field.command.ts
@@ -6,11 +6,9 @@ import { Command, Option } from 'nest-commander';
 import { FieldMetadataType, isDefined } from 'twenty-shared';
 import { Repository } from 'typeorm';
 
-import {
-  ActiveWorkspacesCommandOptions,
-  ActiveWorkspacesCommandRunner,
-} from 'src/database/commands/active-workspaces.command';
+import { ActiveWorkspacesCommandRunner } from 'src/database/commands/active-workspaces.command';
 import { isCommandLogger } from 'src/database/commands/logger';
+import { Upgrade042CommandOptions } from 'src/database/commands/upgrade-version/0-42/0-42-upgrade-version.command';
 import { FeatureFlagKey } from 'src/engine/core-modules/feature-flag/enums/feature-flag-key.enum';
 import { FeatureFlag } from 'src/engine/core-modules/feature-flag/feature-flag.entity';
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
@@ -44,9 +42,6 @@ type RichTextFieldWithMigrationStatusAndObjectMetadata = {
   hasCreatedColumns: boolean;
   objectMetadata: ObjectMetadataEntity | null;
 };
-type MigrateRichTextFieldCommandOptions = ActiveWorkspacesCommandOptions & {
-  force: boolean;
-};
 type ProcessWorkspaceArgs = {
   workspaceId: string;
   index: number;
@@ -62,7 +57,7 @@ type AsyncMethod<T> = () => Promise<T>;
   description: 'Migrate RICH_TEXT fields to new composite structure',
 })
 export class MigrateRichTextFieldCommand extends ActiveWorkspacesCommandRunner {
-  private options: MigrateRichTextFieldCommandOptions;
+  private options: Upgrade042CommandOptions;
   constructor(
     @InjectRepository(Workspace, 'core')
     protected readonly workspaceRepository: Repository<Workspace>,
@@ -98,7 +93,7 @@ export class MigrateRichTextFieldCommand extends ActiveWorkspacesCommandRunner {
   };
   async executeActiveWorkspacesCommand(
     _passedParam: string[],
-    options: MigrateRichTextFieldCommandOptions,
+    options: Upgrade042CommandOptions,
     workspaceIds: string[],
   ): Promise<void> {
     this.logger.log(

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-migrate-rich-text-field.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-migrate-rich-text-field.command.ts
@@ -299,6 +299,7 @@ export class MigrateRichTextFieldCommand extends ActiveWorkspacesCommandRunner {
         type: FieldMetadataType.RICH_TEXT_V2,
         defaultValue: null,
         standardId,
+        workspaceId,
       };
 
       const existingFieldMetadata =
@@ -306,6 +307,7 @@ export class MigrateRichTextFieldCommand extends ActiveWorkspacesCommandRunner {
           name: newRichTextField.name,
           type: newRichTextField.type,
           standardId: newRichTextField.standardId ?? undefined,
+          workspaceId,
         });
       const fieldMetadataAlreadyExists = isDefined(existingFieldMetadata);
 
@@ -323,7 +325,9 @@ export class MigrateRichTextFieldCommand extends ActiveWorkspacesCommandRunner {
 
       const objectMetadata = await this.objectMetadataRepository.findOne({
         where: { id: richTextField.objectMetadataId },
-        relations: { fields: true },
+        relations: {
+          fields: true,
+        },
       });
 
       if (objectMetadata === null) {
@@ -355,6 +359,7 @@ export class MigrateRichTextFieldCommand extends ActiveWorkspacesCommandRunner {
       richTextFieldsWithHasCreatedColumns.some(
         ({ hasCreatedColumns }) => hasCreatedColumns,
       );
+
     await this.dryRunGuardedOperation(async () => {
       if (hasAtLeastOnePendingMigration) {
         await this.workspaceMigrationRunnerService.executeMigrationFromPendingMigrations(

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-migrate-rich-text-field.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-migrate-rich-text-field.command.ts
@@ -281,7 +281,7 @@ export class MigrateRichTextFieldCommand extends ActiveWorkspacesCommandRunner {
 
       for (const row of rows) {
         const blocknoteFieldValue = row[richTextField.name];
-        const markdownFieldValue = this.getMardownFieldValue({
+        const markdownFieldValue = await this.getMardownFieldValue({
           blocknoteFieldValue,
           serverBlockNoteEditor,
         });

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-migrate-rich-text-field.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-migrate-rich-text-field.command.ts
@@ -243,16 +243,17 @@ export class MigrateRichTextFieldCommand extends ActiveWorkspacesCommandRunner {
         defaultValue: null,
       },
     ] as const;
+
     const bodyV2FieldExists = objectMetadata.fields.some(
       (field) => field.name === 'bodyV2',
     );
-    const shouldForceCreate = bodyV2FieldExists && this.options.force;
-
     if (!bodyV2FieldExists) {
       this.logger.warn(
         `BodyV2 field already exists for workspaceId: ${workspaceId} objectMetadata: ${objectMetadata.id}`,
       );
     }
+
+    const shouldForceCreate = bodyV2FieldExists && this.options.force;
     if (shouldForceCreate) {
       this.logger.warn(
         `Force recreating ${richTextField.name}V2Markdown and ${richTextField.name}V2Blocknote for workspaceId: ${workspaceId} objectMetadata: ${objectMetadata.id}`,
@@ -261,7 +262,7 @@ export class MigrateRichTextFieldCommand extends ActiveWorkspacesCommandRunner {
 
     const shouldCreateColumn = !bodyV2FieldExists || shouldForceCreate;
     await this.dryRunGuardedOperation(async () => {
-      if (!bodyV2FieldExists || shouldForceCreate ) {
+      if (shouldCreateColumn) {
         await this.workspaceMigrationService.createCustomMigration(
           generateMigrationName(
             `migrate-rich-text-field-${objectMetadata.nameSingular}-${richTextField.name}`,

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-migrate-rich-text-field.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-migrate-rich-text-field.command.ts
@@ -161,9 +161,11 @@ export class MigrateRichTextFieldCommand extends ActiveWorkspacesCommandRunner {
 
       await this.enableRichTextV2FeatureFlag(workspaceId);
 
-      await this.workspaceMetadataVersionService.incrementMetadataVersion(
-        workspaceId,
-      );
+      if (!this.options.dryRun) {
+        await this.workspaceMetadataVersionService.incrementMetadataVersion(
+          workspaceId,
+        );
+      }
 
       await this.twentyORMGlobalManager.destroyDataSourceForWorkspace(
         workspaceId,

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-migrate-rich-text-field.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-migrate-rich-text-field.command.ts
@@ -287,6 +287,9 @@ export class MigrateRichTextFieldCommand extends ActiveWorkspacesCommandRunner {
     }
 
     if (!Array.isArray(jsonParsedblocknoteFieldValue)) {
+      this.logger.warn(
+        `blocknoteFieldValue is defined and is not an array got ${blocknoteFieldValue}`,
+      );
       return null;
     }
 

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-migrate-rich-text-field.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-migrate-rich-text-field.command.ts
@@ -220,6 +220,14 @@ export class MigrateRichTextFieldCommand extends ActiveWorkspacesCommandRunner {
     );
   }
 
+  private jsonParseOrSilentlyFail(input: string): null | unknown {
+    try {
+      return JSON.parse(input);
+    } catch (e) {
+      return null;
+    }
+  }
+
   private async getMardownFieldValue({
     blocknoteFieldValue,
     serverBlockNoteEditor,
@@ -236,8 +244,11 @@ export class MigrateRichTextFieldCommand extends ActiveWorkspacesCommandRunner {
       return null;
     }
 
-    const jsonParsedblocknoteFieldValue = JSON.parse(blocknoteFieldValue);
-
+    const jsonParsedblocknoteFieldValue = this.jsonParseOrSilentlyFail(blocknoteFieldValue);
+    if (jsonParsedblocknoteFieldValue === null) {
+      return null
+    }
+    
     if (!Array.isArray(jsonParsedblocknoteFieldValue)) {
       return null;
     }

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-migrate-rich-text-field.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-migrate-rich-text-field.command.ts
@@ -244,11 +244,13 @@ export class MigrateRichTextFieldCommand extends ActiveWorkspacesCommandRunner {
       return null;
     }
 
-    const jsonParsedblocknoteFieldValue = this.jsonParseOrSilentlyFail(blocknoteFieldValue);
+    const jsonParsedblocknoteFieldValue =
+      this.jsonParseOrSilentlyFail(blocknoteFieldValue);
+
     if (jsonParsedblocknoteFieldValue === null) {
-      return null
+      return null;
     }
-    
+
     if (!Array.isArray(jsonParsedblocknoteFieldValue)) {
       return null;
     }

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-migrate-rich-text-field.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-migrate-rich-text-field.command.ts
@@ -243,7 +243,17 @@ export class MigrateRichTextFieldCommand extends ActiveWorkspacesCommandRunner {
       },
     ] as const;
 
-    if (!this.options.dryRun && !fieldMetadataAlreadyExisting) {
+    const shouldForceCreateColumns =
+      this.options.force && fieldMetadataAlreadyExisting;
+    if (shouldForceCreateColumns) {
+      this.logger.warn(
+        `Force creating V2 columns for workspaceId: ${workspaceId} objectMetadaId: ${objectMetadata.id}`,
+      );
+    }
+    if (
+      !this.options.dryRun &&
+      (!fieldMetadataAlreadyExisting || shouldForceCreateColumns)
+    ) {
       await this.workspaceMigrationService.createCustomMigration(
         generateMigrationName(
           `migrate-rich-text-field-${objectMetadata.nameSingular}-${richTextField.name}`,

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-migrate-rich-text-field.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-migrate-rich-text-field.command.ts
@@ -37,20 +37,24 @@ type MigrateRichTextContentArgs = {
   richTextFieldsWithMigrationStatus: RichTextFieldWithMigrationStatusAndObjectMetadata[];
   workspaceId: string;
 };
+
 type RichTextFieldWithMigrationStatusAndObjectMetadata = {
   richTextField: FieldMetadataEntity;
   hasCreatedColumns: boolean;
   objectMetadata: ObjectMetadataEntity | null;
 };
+
 type ProcessWorkspaceArgs = {
   workspaceId: string;
   index: number;
   total: number;
 };
+
 type ProcessRichTextFieldsArgs = {
   richTextFields: FieldMetadataEntity[];
   workspaceId: string;
 };
+
 type AsyncMethod<T> = () => Promise<T>;
 @Command({
   name: 'upgrade-0.42:migrate-rich-text-field',
@@ -208,6 +212,7 @@ export class MigrateRichTextFieldCommand extends ActiveWorkspacesCommandRunner {
       }
     }
   }
+
   private async createMarkdownBlockNoteV2Columns({
     richTextField,
     workspaceId,
@@ -240,6 +245,7 @@ export class MigrateRichTextFieldCommand extends ActiveWorkspacesCommandRunner {
       ),
     );
     const shouldRunMigration = filteredColumnsToCreate.length !== 0;
+
     if (!shouldRunMigration) {
       this.logger.warn(
         `No columns to create for objectMetaData ${objectMetadata.id}`,
@@ -265,6 +271,7 @@ export class MigrateRichTextFieldCommand extends ActiveWorkspacesCommandRunner {
 
     return shouldRunMigration;
   }
+
   private async createIfMissingNewRichTextFieldsColumn({
     richTextFields,
     workspaceId,
@@ -296,6 +303,7 @@ export class MigrateRichTextFieldCommand extends ActiveWorkspacesCommandRunner {
           // standardId: newRichTextField.standardId ?? undefined, //overkill ? or could be counterproductive ?
         });
       const fieldMetadataAlreadyExists = !isDefined(existingFieldMetadata);
+
       if (fieldMetadataAlreadyExists) {
         this.logger.warn(
           `FieldMetadata already exists in fieldMetadataRepository name: ${newRichTextField.name} standardId: ${newRichTextField.standardId} type: ${newRichTextField.type}`,
@@ -382,6 +390,7 @@ export class MigrateRichTextFieldCommand extends ActiveWorkspacesCommandRunner {
       this.logger.warn(
         `blocknoteFieldValue is defined and is not an array got ${blocknoteFieldValue}`,
       );
+
       return null;
     }
 
@@ -431,6 +440,7 @@ export class MigrateRichTextFieldCommand extends ActiveWorkspacesCommandRunner {
 
         const shouldForceUpdate = !hasCreatedColumns && this.options.force;
         const shouldUpdateFieldValue = hasCreatedColumns || shouldForceUpdate;
+
         if (shouldForceUpdate) {
           this.logger.warn(
             `Will force udpate RICH_TEXT_V2 fieldValue for ${richTextField.id} of objectMetada ${objectMetadata.id} even it has already been migrated in the past`,

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-migrate-rich-text-field.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-migrate-rich-text-field.command.ts
@@ -247,7 +247,7 @@ export class MigrateRichTextFieldCommand extends ActiveWorkspacesCommandRunner {
     const bodyV2FieldExists = objectMetadata.fields.some(
       (field) => field.name === 'bodyV2',
     );
-    if (!bodyV2FieldExists) {
+    if (bodyV2FieldExists) {
       this.logger.warn(
         `BodyV2 field already exists for workspaceId: ${workspaceId} objectMetadata: ${objectMetadata.id}`,
       );

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-migrate-rich-text-field.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-migrate-rich-text-field.command.ts
@@ -238,12 +238,13 @@ export class MigrateRichTextFieldCommand extends ActiveWorkspacesCommandRunner {
         defaultValue: null,
       },
     ] as const;
-    const filteredColumnsToCreate = columnsToCreate.filter(({ columnName }) =>
-      objectMetadata.fields.some(
-        ({ name: fieldName }) => fieldName === columnName,
-      ),
+    const filteredColumnsToCreate = columnsToCreate.filter(
+      ({ columnName }) =>
+        !objectMetadata.fields.some(
+          ({ name: fieldName }) => fieldName === columnName,
+        ),
     );
-    const shouldRunMigration = filteredColumnsToCreate.length !== 0;
+    const shouldRunMigration = filteredColumnsToCreate.length > 0;
 
     if (!shouldRunMigration) {
       this.logger.warn(
@@ -301,7 +302,7 @@ export class MigrateRichTextFieldCommand extends ActiveWorkspacesCommandRunner {
           type: newRichTextField.type,
           standardId: newRichTextField.standardId ?? undefined,
         });
-      const fieldMetadataAlreadyExists = !isDefined(existingFieldMetadata);
+      const fieldMetadataAlreadyExists = isDefined(existingFieldMetadata);
 
       if (fieldMetadataAlreadyExists) {
         this.logger.warn(
@@ -317,6 +318,7 @@ export class MigrateRichTextFieldCommand extends ActiveWorkspacesCommandRunner {
 
       const objectMetadata = await this.objectMetadataRepository.findOne({
         where: { id: richTextField.objectMetadataId },
+        relations: { fields: true },
       });
 
       if (objectMetadata === null) {

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-migrate-rich-text-field.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-migrate-rich-text-field.command.ts
@@ -201,14 +201,19 @@ export class MigrateRichTextFieldCommand extends ActiveWorkspacesCommandRunner {
 
   private buildRichTextFieldStandardId(richTextField: FieldMetadataEntity) {
     switch (true) {
-      case richTextField.standardId === TASK_STANDARD_FIELD_IDS.body:
+      case richTextField.standardId === TASK_STANDARD_FIELD_IDS.body: {
         return TASK_STANDARD_FIELD_IDS.bodyV2;
-      case richTextField.standardId === NOTE_STANDARD_FIELD_IDS.body:
+      }
+      case richTextField.standardId === NOTE_STANDARD_FIELD_IDS.body: {
         return NOTE_STANDARD_FIELD_IDS.bodyV2;
-      default: {
+      }
+      case !richTextField.isCustom: {
         throw new Error(
           `RICH_TEXT does not belong to a Task or a Note standard objects: ${richTextField.id}`,
         );
+      }
+      default: {
+        return null;
       }
     }
   }

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-migrate-rich-text-field.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-migrate-rich-text-field.command.ts
@@ -239,12 +239,12 @@ export class MigrateRichTextFieldCommand extends ActiveWorkspacesCommandRunner {
       },
     ] as const;
 
-    const shouldCreateColumn = objectMetadata.fields.some(
+    const shouldCreateColumn = !objectMetadata.fields.some(
       (field) => field.name === `${richTextField.name}V2`,
     );
     if (!shouldCreateColumn) {
       this.logger.warn(
-        `${richTextField.name}V2 field already exists for workspaceId: ${workspaceId} objectMetadata: ${objectMetadata.id}`,
+        `${richTextField.name}V2 field already exists in workspaceId: ${workspaceId} objectMetadata: ${objectMetadata.id}`,
       );
     }
 

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-migrate-rich-text-field.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-migrate-rich-text-field.command.ts
@@ -246,19 +246,16 @@ export class MigrateRichTextFieldCommand extends ActiveWorkspacesCommandRunner {
     const bodyV2AlreadyExists = objectMetadata.fields.some(
       (field) => field.name === 'bodyV2',
     );
-    const shouldForceColumnCreation =
-      !bodyV2AlreadyExists && this.options.force;
-    const shouldCreateColumn =
-      !bodyV2AlreadyExists || shouldForceColumnCreation;
+    const shouldCreateColumn = !bodyV2AlreadyExists || this.options.force;
 
     if (!shouldCreateColumn) {
       this.logger.warn(
         `No columns ${richTextField.name}V2Markdown and ${richTextField.name}V2Blocknote to create for workspaceId: ${workspaceId} objectMetadata: ${objectMetadata.id}`,
       );
     }
-    if (shouldForceColumnCreation) {
+    if (this.options.force && bodyV2AlreadyExists) {
       this.logger.warn(
-        `Force creating ${richTextField.name}V2Markdown and ${richTextField.name}V2Blocknote for workspaceId: ${workspaceId} objectMetadata: ${objectMetadata.id}`,
+        `Force recreating ${richTextField.name}V2Markdown and ${richTextField.name}V2Blocknote for workspaceId: ${workspaceId} objectMetadata: ${objectMetadata.id}`,
       );
     }
     await this.dryRunGuardedOperation(async () => {

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-upgrade-version.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-upgrade-version.command.ts
@@ -1,6 +1,6 @@
 import { InjectRepository } from '@nestjs/typeorm';
 
-import { Command } from 'nest-commander';
+import { Command, Option } from 'nest-commander';
 import { Repository } from 'typeorm';
 
 import { ActiveWorkspacesCommandRunner } from 'src/database/commands/active-workspaces.command';
@@ -11,6 +11,11 @@ import { MigrateRichTextFieldCommand } from 'src/database/commands/upgrade-versi
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { SyncWorkspaceMetadataCommand } from 'src/engine/workspace-manager/workspace-sync-metadata/commands/sync-workspace-metadata.command';
 
+type Upgrade042CommandCustomOptions = {
+  force?: boolean;
+};
+export type Upgrade042CommandOptions = BaseCommandOptions &
+  Upgrade042CommandCustomOptions;
 @Command({
   name: 'upgrade-0.42',
   description: 'Upgrade to 0.42',
@@ -27,9 +32,19 @@ export class UpgradeTo0_42Command extends ActiveWorkspacesCommandRunner {
     super(workspaceRepository);
   }
 
+  @Option({
+    flags: '-f, --force [boolean]',
+    description:
+      'Force RICH_TEXT_FIELD value update even if column migration has already be run',
+    required: false,
+  })
+  parseForceValue(val?: boolean): boolean {
+    return val ?? false;
+  }
+
   async executeActiveWorkspacesCommand(
     passedParam: string[],
-    options: BaseCommandOptions,
+    options: Upgrade042CommandOptions,
     workspaceIds: string[],
   ): Promise<void> {
     this.logger.log('Running command to upgrade to 0.42');

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-upgrade-version.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-upgrade-version.command.ts
@@ -12,7 +12,7 @@ import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { SyncWorkspaceMetadataCommand } from 'src/engine/workspace-manager/workspace-sync-metadata/commands/sync-workspace-metadata.command';
 
 type Upgrade042CommandCustomOptions = {
-  force?: boolean;
+  force: boolean;
 };
 export type Upgrade042CommandOptions = BaseCommandOptions &
   Upgrade042CommandCustomOptions;


### PR DESCRIPTION
# Introduction
Encountered in issue in production where we have a lot of records that has RICH_TEXT_FIELD set to `{}`

```sh
[Nest] 20106  - 02/19/2025, 12:43:08 PM     LOG [MigrateRichTextFieldCommand] Generating markdown for 1 records
[Nest] 20106  - 02/19/2025, 12:43:09 PM     LOG [MigrateRichTextFieldCommand] Error in workspace 3b8e6458-5fc1-4e63-8563-008ccddaa6db: TypeError: o is not iterable
```

## Fix
While reading `fieldValue` definition also strictly check if it's `{}` + checking after JSON parse if it's an iterable to pass to the `serverBlockNoteEditor` in order to be 100 bullet proof for prod migration command

## Refactor Dry run
Implemented dry run

## Refactor to Idempotency
Made the script idempotent in order to avoid issues with re-running commands

## Error repro
- In local checkout on v0.41.5 run `yarn && npx nx reset && npx nx start`
- Create record manually in db that has a RICH_TEXT body to `{}`
- Checkout to main, `yarn && npx nx reset && npx nx build twenty-server && yarn command:prod upgrade-0.42:migrate-rich-text-field -d`