### PR TITLE
[BUGFIX] Call and await `destroyDataSourceForWorkspace` to avoid killing poor pod

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version/0-41/0-41-add-context-to-actor-composite-type.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-41/0-41-add-context-to-actor-composite-type.ts
@@ -125,7 +125,9 @@ export class AddContextToActorCompositeTypeCommand extends ActiveWorkspacesComma
       );
     }
 
-    await this.twentyORMGlobalManager.destroyDataSourceForWorkspace(workspaceId);
+    await this.twentyORMGlobalManager.destroyDataSourceForWorkspace(
+      workspaceId,
+    );
   }
 
   private async addContextColumn(

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-41/0-41-add-context-to-actor-composite-type.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-41/0-41-add-context-to-actor-composite-type.ts
@@ -125,7 +125,7 @@ export class AddContextToActorCompositeTypeCommand extends ActiveWorkspacesComma
       );
     }
 
-    this.twentyORMGlobalManager.destroyDataSourceForWorkspace(workspaceId);
+    await this.twentyORMGlobalManager.destroyDataSourceForWorkspace(workspaceId);
   }
 
   private async addContextColumn(

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-41/0-41-remove-duplicate-mcmas.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-41/0-41-remove-duplicate-mcmas.ts
@@ -91,6 +91,8 @@ export class RemoveDuplicateMcmasCommand extends ActiveWorkspacesCommandRunner {
       }
     }
 
-    await this.twentyORMGlobalManager.destroyDataSourceForWorkspace(workspaceId);
+    await this.twentyORMGlobalManager.destroyDataSourceForWorkspace(
+      workspaceId,
+    );
   }
 }

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-41/0-41-remove-duplicate-mcmas.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-41/0-41-remove-duplicate-mcmas.ts
@@ -91,6 +91,6 @@ export class RemoveDuplicateMcmasCommand extends ActiveWorkspacesCommandRunner {
       }
     }
 
-    this.twentyORMGlobalManager.destroyDataSourceForWorkspace(workspaceId);
+    await this.twentyORMGlobalManager.destroyDataSourceForWorkspace(workspaceId);
   }
 }

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-41/0-41-seed-workflow-views.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-41/0-41-seed-workflow-views.command.ts
@@ -78,7 +78,7 @@ export class SeedWorkflowViewsCommand extends ActiveWorkspacesCommandRunner {
       dryRun,
     );
 
-    this.twentyORMGlobalManager.destroyDataSourceForWorkspace(workspaceId);
+    await this.twentyORMGlobalManager.destroyDataSourceForWorkspace(workspaceId);
   }
 
   private async seedWorkflowViews(

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-41/0-41-seed-workflow-views.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-41/0-41-seed-workflow-views.command.ts
@@ -78,7 +78,9 @@ export class SeedWorkflowViewsCommand extends ActiveWorkspacesCommandRunner {
       dryRun,
     );
 
-    await this.twentyORMGlobalManager.destroyDataSourceForWorkspace(workspaceId);
+    await this.twentyORMGlobalManager.destroyDataSourceForWorkspace(
+      workspaceId,
+    );
   }
 
   private async seedWorkflowViews(

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-fix-body-v2-view-field-position.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-fix-body-v2-view-field-position.command.ts
@@ -185,5 +185,9 @@ export class FixBodyV2ViewFieldPositionCommand extends ActiveWorkspacesCommandRu
     } catch (error) {
       this.logger.log(chalk.red(`Error in workspace ${workspaceId}`));
     }
+
+    await this.twentyORMGlobalManager.destroyDataSourceForWorkspace(
+      workspaceId,
+    );
   }
 }

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-limit-amount-of-view-field.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-limit-amount-of-view-field.ts
@@ -87,11 +87,11 @@ export class LimitAmountOfViewFieldCommand extends ActiveWorkspacesCommandRunner
         error,
       );
       throw error;
+    } finally {
+      await this.twentyORMGlobalManager.destroyDataSourceForWorkspace(
+        workspaceId,
+      );
     }
-
-    await this.twentyORMGlobalManager.destroyDataSourceForWorkspace(
-      workspaceId,
-    );
   }
 
   async executeActiveWorkspacesCommand(

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-limit-amount-of-view-field.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-limit-amount-of-view-field.ts
@@ -88,6 +88,10 @@ export class LimitAmountOfViewFieldCommand extends ActiveWorkspacesCommandRunner
       );
       throw error;
     }
+
+    await this.twentyORMGlobalManager.destroyDataSourceForWorkspace(
+      workspaceId,
+    );
   }
 
   async executeActiveWorkspacesCommand(

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-standardization-of-actor-composite-context-type.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-standardization-of-actor-composite-context-type.ts
@@ -109,6 +109,8 @@ export class StandardizationOfActorCompositeContextTypeCommand extends ActiveWor
       );
     }
 
-    await this.twentyORMGlobalManager.destroyDataSourceForWorkspace(workspaceId);
+    await this.twentyORMGlobalManager.destroyDataSourceForWorkspace(
+      workspaceId,
+    );
   }
 }

--- a/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-standardization-of-actor-composite-context-type.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version/0-42/0-42-standardization-of-actor-composite-context-type.ts
@@ -109,6 +109,6 @@ export class StandardizationOfActorCompositeContextTypeCommand extends ActiveWor
       );
     }
 
-    this.twentyORMGlobalManager.destroyDataSourceForWorkspace(workspaceId);
+    await this.twentyORMGlobalManager.destroyDataSourceForWorkspace(workspaceId);
   }
 }


### PR DESCRIPTION
# Motivations
Upgrade migration is not possible atm in production because running over all workspaces cause cpu raise leading to pod termination