### PR TITLE
Only display record actions inside the RecordIndexActionMenuDropdown

### DIFF
--- a/packages/twenty-front/src/modules/action-menu/components/RecordIndexActionMenuDropdown.tsx
+++ b/packages/twenty-front/src/modules/action-menu/components/RecordIndexActionMenuDropdown.tsx
@@ -2,6 +2,10 @@ import { actionMenuEntriesComponentSelector } from '@/action-menu/states/actionM
 import { ActionMenuComponentInstanceContext } from '@/action-menu/states/contexts/ActionMenuComponentInstanceContext';
 import { recordIndexActionMenuDropdownPositionComponentState } from '@/action-menu/states/recordIndexActionMenuDropdownPositionComponentState';
 import { ActionMenuDropdownHotkeyScope } from '@/action-menu/types/ActionMenuDropdownHotKeyScope';
+import {
+  ActionMenuEntryScope,
+  ActionMenuEntryType,
+} from '@/action-menu/types/ActionMenuEntry';
 import { getActionMenuDropdownIdFromActionMenuId } from '@/action-menu/utils/getActionMenuDropdownIdFromActionMenuId';
 import { Dropdown } from '@/ui/layout/dropdown/components/Dropdown';
 import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/DropdownMenuItemsContainer';
@@ -29,6 +33,12 @@ export const RecordIndexActionMenuDropdown = () => {
     actionMenuEntriesComponentSelector,
   );
 
+  const recordIndexActions = actionMenuEntries.filter(
+    (actionMenuEntry) =>
+      actionMenuEntry.type === ActionMenuEntryType.Standard &&
+      actionMenuEntry.scope === ActionMenuEntryScope.RecordSelection,
+  );
+
   const actionMenuId = useAvailableComponentInstanceIdOrThrow(
     ActionMenuComponentInstanceContext,
   );
@@ -44,7 +54,7 @@ export const RecordIndexActionMenuDropdown = () => {
   );
 
   //TODO: remove this
-  const width = actionMenuEntries.some(
+  const width = recordIndexActions.some(
     (actionMenuEntry) =>
       i18n._(actionMenuEntry.label) === 'Remove from favorites',
   )
@@ -68,7 +78,7 @@ export const RecordIndexActionMenuDropdown = () => {
       dropdownComponents={
         <StyledDropdownMenuContainer className="action-menu-dropdown">
           <DropdownMenuItemsContainer>
-            {actionMenuEntries.map((item) => (
+            {recordIndexActions.map((item) => (
               <MenuItem
                 key={item.key}
                 LeftIcon={item.Icon}


### PR DESCRIPTION
In the action menu dropdown, we only want to display the actions for the selected records, so we need to filter available actions according to their type and scope.
Note: the `Search record` action was appearing twice because one is a standard action and one is a fallback action and both are registered in the available actions. We don't want to display this action because it isn't related to the selected records, it is a global action. 

Before:
<img width="226" alt="Capture d’écran 2025-02-21 à 12 12 53" src="https://github.com/user-attachments/assets/0a4f9b8c-4e30-4697-9861-559e76dc288f" />

After:
<img width="241" alt="Capture d’écran 2025-02-21 à 12 10 34" src="https://github.com/user-attachments/assets/0a98c9d5-432d-4018-a4d3-bf3a6d0c49be" />
