### PR TITLE
Fix command menu selectable items ordering

### DIFF
--- a/packages/twenty-front/src/modules/command-menu/components/CommandMenu.tsx
+++ b/packages/twenty-front/src/modules/command-menu/components/CommandMenu.tsx
@@ -73,9 +73,9 @@ export const CommandMenu = () => {
     },
   ];
 
-  const selectableItems: Command[] = commandGroups
-    .flatMap((group) => group.items ?? [])
-    .filter(isDefined);
+  const selectableItems: Command[] = commandGroups.flatMap(
+    (group) => group.items ?? [],
+  );
 
   const selectableItemIds = selectableItems.map((item) => item.id);
 

--- a/packages/twenty-front/src/modules/command-menu/components/CommandMenu.tsx
+++ b/packages/twenty-front/src/modules/command-menu/components/CommandMenu.tsx
@@ -36,18 +36,6 @@ export const CommandMenu = () => {
     commandMenuSearch,
   });
 
-  const selectableItems: Command[] = copilotCommands
-    .concat(
-      matchingStandardActionRecordSelectionCommands,
-      matchingStandardActionObjectCommands,
-      matchingWorkflowRunRecordSelectionCommands,
-      matchingStandardActionGlobalCommands,
-      matchingWorkflowRunGlobalCommands,
-      matchingNavigateCommands,
-      fallbackCommands,
-    )
-    .filter(isDefined);
-
   const previousContextStoreCurrentObjectMetadataItem =
     useRecoilComponentValueV2(
       contextStoreCurrentObjectMetadataItemComponentState,
@@ -57,12 +45,6 @@ export const CommandMenu = () => {
   const currentObjectMetadataItem = useRecoilComponentValueV2(
     contextStoreCurrentObjectMetadataItemComponentState,
   );
-
-  const selectableItemIds = selectableItems.map((item) => item.id);
-
-  if (isDefined(previousContextStoreCurrentObjectMetadataItem)) {
-    selectableItemIds.unshift(RESET_CONTEXT_TO_SELECTION);
-  }
 
   const commandGroups: CommandGroupConfig[] = [
     {
@@ -90,6 +72,16 @@ export const CommandMenu = () => {
       items: fallbackCommands,
     },
   ];
+
+  const selectableItems: Command[] = commandGroups
+    .flatMap((group) => group.items ?? [])
+    .filter(isDefined);
+
+  const selectableItemIds = selectableItems.map((item) => item.id);
+
+  if (isDefined(previousContextStoreCurrentObjectMetadataItem)) {
+    selectableItemIds.unshift(RESET_CONTEXT_TO_SELECTION);
+  }
 
   return (
     <CommandMenuList


### PR DESCRIPTION
The order of the selectableItems was not the same as the command groups so the navigation with arrow keys inside the command menu was broken.

Before:

https://github.com/user-attachments/assets/a3487b58-9c26-4522-9e7b-584d30396a21


After:

https://github.com/user-attachments/assets/bd60263b-b4e2-4d41-bad1-eef9115caec6

