### PR TITLE
Fix graphql conflict between role custom object and role dto

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/utils/validate-object-metadata-input.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/utils/validate-object-metadata-input.util.ts
@@ -12,18 +12,41 @@ import { validateMetadataNameValidityOrThrow } from 'src/engine/metadata-modules
 import { camelCase } from 'src/utils/camel-case';
 
 const coreObjectNames = [
+  'approvedAccessDomain',
+  'approvedAccessDomains',
   'appToken',
+  'appTokens',
+  'billingCustomer',
+  'billingCustomers',
+  'billingEntitlement',
+  'billingEntitlements',
+  'billingMeter',
+  'billingMeters',
+  'billingProduct',
+  'billingProducts',
   'billingSubscription',
   'billingSubscriptions',
   'billingSubscriptionItem',
   'billingSubscriptionItems',
   'featureFlag',
+  'featureFlags',
+  'keyValuePair',
+  'keyValuePairs',
+  'postgresCredential',
+  'postgresCredentials',
+  'twoFactorMethod',
+  'twoFactorMethods',
   'user',
   'users',
   'userWorkspace',
   'userWorkspaces',
   'workspace',
   'workspaces',
+
+  'role',
+  'roles',
+  'userWorkspaceRole',
+  'userWorkspaceRoles',
 ];
 
 const reservedKeywords = [


### PR DESCRIPTION
## Context
Following the strategy where we want to block custom object creation when the type is reserved by core objects. The issue happened again with the recently introduced role table.