### PR TITLE
[BUGFIX] Create optimistic cache generate `recordGqlFields` from prefilled record

### DIFF
--- a/packages/twenty-front/src/modules/object-record/cache/hooks/useCreateOneRecordInCache.ts
+++ b/packages/twenty-front/src/modules/object-record/cache/hooks/useCreateOneRecordInCache.ts
@@ -24,9 +24,13 @@ export const useCreateOneRecordInCache = <T extends ObjectRecord>({
   const apolloClient = useApolloClient();
 
   return (record: ObjectRecord) => {
+    const prefilledRecord = prefillRecord({
+      objectMetadataItem,
+      input: record,
+    });
     const recordGqlFields = generateDepthOneRecordGqlFields({
       objectMetadataItem,
-      record,
+      record: prefilledRecord,
     });
     const fragment = gql`
           fragment Create${capitalize(
@@ -40,11 +44,6 @@ export const useCreateOneRecordInCache = <T extends ObjectRecord>({
             recordGqlFields,
           })}
         `;
-
-    const prefilledRecord = prefillRecord({
-      objectMetadataItem,
-      input: record,
-    });
 
     const recordToCreateWithNestedConnections = getRecordNodeFromRecord({
       record: prefilledRecord,

--- a/packages/twenty-front/src/modules/object-record/hooks/useCreateOneRecord.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useCreateOneRecord.ts
@@ -102,6 +102,7 @@ export const useCreateOneRecord = <
       recordInput: {
         ...baseOptimisticRecordInputCreatedBy,
         ...recordInput,
+        position: Number.NEGATIVE_INFINITY,
         id: idForCreation,
       },
     });


### PR DESCRIPTION
# Introduction
The record does not appear in the table because the optimistic record input cached does not fulfill the mutation response fields, which result in it being considered as invalid response
close #10199 
close https://github.com/twentyhq/twenty/issues/10153