### PR TITLE
Fix throw on mounting action in right drawer

### DIFF
--- a/packages/twenty-front/src/modules/action-menu/actions/record-actions/components/RecordActionMenuEntriesSetter.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-actions/components/RecordActionMenuEntriesSetter.tsx
@@ -1,4 +1,5 @@
 import { RegisterRecordActionEffect } from '@/action-menu/actions/record-actions/components/RegisterRecordActionEffect';
+import { useFirstSelectedRecordId } from '@/action-menu/actions/record-actions/single-record/hooks/useFirstSelectedRecordId';
 import { WorkflowRunRecordActionMenuEntrySetterEffect } from '@/action-menu/actions/record-actions/workflow-run-record-actions/components/WorkflowRunRecordActionMenuEntrySetter';
 import { getActionConfig } from '@/action-menu/actions/utils/getActionConfig';
 import { getActionViewType } from '@/action-menu/actions/utils/getActionViewType';
@@ -22,6 +23,8 @@ export const RecordActionMenuEntriesSetter = () => {
   const contextStoreCurrentViewType = useRecoilComponentValueV2(
     contextStoreCurrentViewTypeComponentState,
   );
+
+  const selectedRecordId = useFirstSelectedRecordId();
 
   const isWorkflowEnabled = useIsFeatureEnabled(
     FeatureFlagKey.IsWorkflowEnabled,
@@ -51,15 +54,18 @@ export const RecordActionMenuEntriesSetter = () => {
       )
     : [];
 
+  const shouldRegisterActions = isDefined(selectedRecordId);
+
   return (
     <>
-      {actionsToRegister.map((action) => (
-        <RegisterRecordActionEffect
-          key={action.key}
-          action={action}
-          objectMetadataItem={contextStoreCurrentObjectMetadataItem}
-        />
-      ))}
+      {shouldRegisterActions &&
+        actionsToRegister.map((action) => (
+          <RegisterRecordActionEffect
+            key={action.key}
+            action={action}
+            objectMetadataItem={contextStoreCurrentObjectMetadataItem}
+          />
+        ))}
 
       {isWorkflowEnabled &&
         contextStoreTargetedRecordsRule?.mode === 'selection' &&

--- a/packages/twenty-front/src/modules/action-menu/actions/record-actions/single-record/hooks/useFirstSelectedRecordId.ts
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-actions/single-record/hooks/useFirstSelectedRecordId.ts
@@ -1,0 +1,18 @@
+import { contextStoreTargetedRecordsRuleComponentState } from '@/context-store/states/contextStoreTargetedRecordsRuleComponentState';
+import { useRecoilComponentValueV2 } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValueV2';
+
+export const useFirstSelectedRecordId = () => {
+  const contextStoreTargetedRecordsRule = useRecoilComponentValueV2(
+    contextStoreTargetedRecordsRuleComponentState,
+  );
+
+  if (
+    contextStoreTargetedRecordsRule.mode === 'exclusion' ||
+    (contextStoreTargetedRecordsRule.mode === 'selection' &&
+      contextStoreTargetedRecordsRule.selectedRecordIds.length === 0)
+  ) {
+    return null;
+  }
+
+  return contextStoreTargetedRecordsRule.selectedRecordIds[0];
+};

--- a/packages/twenty-front/src/modules/action-menu/actions/record-actions/single-record/hooks/useFirstSelectedRecordIdInContextStore.ts
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-actions/single-record/hooks/useFirstSelectedRecordIdInContextStore.ts
@@ -1,7 +1,7 @@
 import { contextStoreTargetedRecordsRuleComponentState } from '@/context-store/states/contextStoreTargetedRecordsRuleComponentState';
 import { useRecoilComponentValueV2 } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValueV2';
 
-export const useFirstSelectedRecordId = () => {
+export const useFirstSelectedRecordIdInContextStore = () => {
   const contextStoreTargetedRecordsRule = useRecoilComponentValueV2(
     contextStoreTargetedRecordsRuleComponentState,
   );

--- a/packages/twenty-front/src/modules/action-menu/actions/utils/isActionOnSelectedRecord.ts
+++ b/packages/twenty-front/src/modules/action-menu/actions/utils/isActionOnSelectedRecord.ts
@@ -1,0 +1,24 @@
+import { MultipleRecordsActionKeys } from '@/action-menu/actions/record-actions/multiple-records/types/MultipleRecordsActionKeys';
+import { NoSelectionRecordActionKeys } from '@/action-menu/actions/record-actions/no-selection/types/NoSelectionRecordActionsKey';
+import { RecordAgnosticActionsKey } from '@/action-menu/actions/record-agnostic-actions/types/RecordAgnosticActionsKey';
+import { ActionHook } from '@/action-menu/actions/types/ActionHook';
+import { ActionMenuEntry } from '@/action-menu/types/ActionMenuEntry';
+
+const ACTION_KEYS_WITHOUT_SELECTED_RECORD = [
+  NoSelectionRecordActionKeys.EXPORT_VIEW,
+  NoSelectionRecordActionKeys.CREATE_NEW_RECORD,
+  MultipleRecordsActionKeys.DESTROY,
+  MultipleRecordsActionKeys.EXPORT,
+  MultipleRecordsActionKeys.DELETE,
+  RecordAgnosticActionsKey.SEARCH_RECORDS,
+  RecordAgnosticActionsKey.SEARCH_RECORDS_FALLBACK,
+] as string[];
+
+// TODO: this is a temporary solution, we need to refactor shouldBeRegistered
+export const isActionOnSelectedRecord = (
+  action: ActionMenuEntry & {
+    useAction: ActionHook;
+  },
+) => {
+  return !ACTION_KEYS_WITHOUT_SELECTED_RECORD.includes(action.key);
+};


### PR DESCRIPTION
This PR fixes a bug where actions where mounted and throwing because nothing was selected when opening workflow right drawer, which is normal.

We should avoid throwing in hooks and they should be resilient to non defined values.