### PR TITLE
Fix record page context store instance id

### DIFF
--- a/packages/twenty-front/src/modules/command-menu/components/CommandMenuContainer.tsx
+++ b/packages/twenty-front/src/modules/command-menu/components/CommandMenuContainer.tsx
@@ -7,6 +7,7 @@ import { ActionMenuConfirmationModals } from '@/action-menu/components/ActionMen
 import { ActionMenuContext } from '@/action-menu/contexts/ActionMenuContext';
 import { ActionMenuComponentInstanceContext } from '@/action-menu/states/contexts/ActionMenuComponentInstanceContext';
 import { COMMAND_MENU_ANIMATION_VARIANTS } from '@/command-menu/constants/CommandMenuAnimationVariants';
+import { COMMAND_MENU_COMPONENT_INSTANCE_ID } from '@/command-menu/constants/CommandMenuComponentInstanceId';
 import { useCommandMenu } from '@/command-menu/hooks/useCommandMenu';
 import { useCommandMenuHotKeys } from '@/command-menu/hooks/useCommandMenuHotKeys';
 import { commandMenuSearchState } from '@/command-menu/states/commandMenuSearchState';
@@ -90,19 +91,19 @@ export const CommandMenuContainer = ({
 
   return (
     <RecordFilterGroupsComponentInstanceContext.Provider
-      value={{ instanceId: 'command-menu' }}
+      value={{ instanceId: COMMAND_MENU_COMPONENT_INSTANCE_ID }}
     >
       <RecordFiltersComponentInstanceContext.Provider
-        value={{ instanceId: 'command-menu' }}
+        value={{ instanceId: COMMAND_MENU_COMPONENT_INSTANCE_ID }}
       >
         <RecordSortsComponentInstanceContext.Provider
-          value={{ instanceId: 'command-menu' }}
+          value={{ instanceId: COMMAND_MENU_COMPONENT_INSTANCE_ID }}
         >
           <ContextStoreComponentInstanceContext.Provider
-            value={{ instanceId: 'command-menu' }}
+            value={{ instanceId: COMMAND_MENU_COMPONENT_INSTANCE_ID }}
           >
             <ActionMenuComponentInstanceContext.Provider
-              value={{ instanceId: 'command-menu' }}
+              value={{ instanceId: COMMAND_MENU_COMPONENT_INSTANCE_ID }}
             >
               <ActionMenuContext.Provider
                 value={{

--- a/packages/twenty-front/src/modules/command-menu/components/__stories__/CommandMenu.stories.tsx
+++ b/packages/twenty-front/src/modules/command-menu/components/__stories__/CommandMenu.stories.tsx
@@ -16,6 +16,7 @@ import { sleep } from '~/utils/sleep';
 
 import { ActionMenuComponentInstanceContext } from '@/action-menu/states/contexts/ActionMenuComponentInstanceContext';
 import { CommandMenuRouter } from '@/command-menu/components/CommandMenuRouter';
+import { COMMAND_MENU_COMPONENT_INSTANCE_ID } from '@/command-menu/constants/CommandMenuComponentInstanceId';
 import { commandMenuNavigationStackState } from '@/command-menu/states/commandMenuNavigationStackState';
 import { isCommandMenuOpenedState } from '@/command-menu/states/isCommandMenuOpenedState';
 import { CommandMenuPages } from '@/command-menu/types/CommandMenuPages';
@@ -49,19 +50,19 @@ const mockWorkspaceWithFeatureFlag = {
 const ContextStoreDecorator: Decorator = (Story) => {
   return (
     <RecordFilterGroupsComponentInstanceContext.Provider
-      value={{ instanceId: 'command-menu' }}
+      value={{ instanceId: COMMAND_MENU_COMPONENT_INSTANCE_ID }}
     >
       <RecordFiltersComponentInstanceContext.Provider
-        value={{ instanceId: 'command-menu' }}
+        value={{ instanceId: COMMAND_MENU_COMPONENT_INSTANCE_ID }}
       >
         <RecordSortsComponentInstanceContext.Provider
-          value={{ instanceId: 'command-menu' }}
+          value={{ instanceId: COMMAND_MENU_COMPONENT_INSTANCE_ID }}
         >
           <ContextStoreComponentInstanceContext.Provider
-            value={{ instanceId: 'command-menu' }}
+            value={{ instanceId: COMMAND_MENU_COMPONENT_INSTANCE_ID }}
           >
             <ActionMenuComponentInstanceContext.Provider
-              value={{ instanceId: 'command-menu' }}
+              value={{ instanceId: COMMAND_MENU_COMPONENT_INSTANCE_ID }}
             >
               <JestContextStoreSetter contextStoreCurrentObjectMetadataNameSingular="company">
                 <Story />

--- a/packages/twenty-front/src/modules/command-menu/constants/CommandMenuComponentInstanceId.ts
+++ b/packages/twenty-front/src/modules/command-menu/constants/CommandMenuComponentInstanceId.ts
@@ -1,0 +1,1 @@
+export const COMMAND_MENU_COMPONENT_INSTANCE_ID = 'command-menu';

--- a/packages/twenty-front/src/modules/command-menu/constants/CommandMenuPreviousComponentInstanceId.ts
+++ b/packages/twenty-front/src/modules/command-menu/constants/CommandMenuPreviousComponentInstanceId.ts
@@ -1,0 +1,2 @@
+export const COMMAND_MENU_PREVIOUS_COMPONENT_INSTANCE_ID =
+  'command-menu-previous';

--- a/packages/twenty-front/src/modules/command-menu/hooks/useCommandMenu.ts
+++ b/packages/twenty-front/src/modules/command-menu/hooks/useCommandMenu.ts
@@ -7,7 +7,9 @@ import { usePreviousHotkeyScope } from '@/ui/utilities/hotkey/hooks/usePreviousH
 import { AppHotkeyScope } from '@/ui/utilities/hotkey/types/AppHotkeyScope';
 import { IconDotsVertical, IconSearch, useIcons } from 'twenty-ui';
 
+import { COMMAND_MENU_COMPONENT_INSTANCE_ID } from '@/command-menu/constants/CommandMenuComponentInstanceId';
 import { COMMAND_MENU_CONTEXT_CHIP_GROUPS_DROPDOWN_ID } from '@/command-menu/constants/CommandMenuContextChipGroupsDropdownId';
+import { COMMAND_MENU_PREVIOUS_COMPONENT_INSTANCE_ID } from '@/command-menu/constants/CommandMenuPreviousComponentInstanceId';
 import { useCopyContextStoreStates } from '@/command-menu/hooks/useCopyContextStoreAndActionMenuStates';
 import { useResetContextStoreStates } from '@/command-menu/hooks/useResetContextStoreStates';
 import {
@@ -61,7 +63,7 @@ export const useCommandMenu = () => {
 
         copyContextStoreStates({
           instanceIdToCopyFrom: MAIN_CONTEXT_STORE_INSTANCE_ID,
-          instanceIdToCopyTo: 'command-menu',
+          instanceIdToCopyTo: COMMAND_MENU_COMPONENT_INSTANCE_ID,
         });
 
         set(isCommandMenuOpenedState, true);
@@ -82,8 +84,8 @@ export const useCommandMenu = () => {
   const onCommandMenuCloseAnimationComplete = useRecoilCallback(
     ({ set }) =>
       () => {
-        resetContextStoreStates('command-menu');
-        resetContextStoreStates('command-menu-previous');
+        resetContextStoreStates(COMMAND_MENU_COMPONENT_INSTANCE_ID);
+        resetContextStoreStates(COMMAND_MENU_PREVIOUS_COMPONENT_INSTANCE_ID);
 
         set(viewableRecordIdState, null);
         set(commandMenuPageState, CommandMenuPages.Root);
@@ -276,13 +278,13 @@ export const useCommandMenu = () => {
     ({ set }) => {
       return () => {
         copyContextStoreStates({
-          instanceIdToCopyFrom: 'command-menu',
-          instanceIdToCopyTo: 'command-menu-previous',
+          instanceIdToCopyFrom: COMMAND_MENU_COMPONENT_INSTANCE_ID,
+          instanceIdToCopyTo: COMMAND_MENU_PREVIOUS_COMPONENT_INSTANCE_ID,
         });
 
         set(
           contextStoreTargetedRecordsRuleComponentState.atomFamily({
-            instanceId: 'command-menu',
+            instanceId: COMMAND_MENU_COMPONENT_INSTANCE_ID,
           }),
           {
             mode: 'selection',
@@ -292,21 +294,21 @@ export const useCommandMenu = () => {
 
         set(
           contextStoreNumberOfSelectedRecordsComponentState.atomFamily({
-            instanceId: 'command-menu',
+            instanceId: COMMAND_MENU_COMPONENT_INSTANCE_ID,
           }),
           0,
         );
 
         set(
           contextStoreFiltersComponentState.atomFamily({
-            instanceId: 'command-menu',
+            instanceId: COMMAND_MENU_COMPONENT_INSTANCE_ID,
           }),
           [],
         );
 
         set(
           contextStoreCurrentViewTypeComponentState.atomFamily({
-            instanceId: 'command-menu',
+            instanceId: COMMAND_MENU_COMPONENT_INSTANCE_ID,
           }),
           ContextStoreViewType.Table,
         );

--- a/packages/twenty-front/src/modules/command-menu/hooks/useCommandMenu.ts
+++ b/packages/twenty-front/src/modules/command-menu/hooks/useCommandMenu.ts
@@ -1,4 +1,4 @@
-import { useRecoilCallback, useRecoilValue } from 'recoil';
+import { useRecoilCallback } from 'recoil';
 
 import { commandMenuSearchState } from '@/command-menu/states/commandMenuSearchState';
 import { objectMetadataItemFamilySelector } from '@/object-metadata/states/objectMetadataItemFamilySelector';
@@ -18,11 +18,11 @@ import { commandMenuPageState } from '@/command-menu/states/commandMenuPageState
 import { commandMenuPageInfoState } from '@/command-menu/states/commandMenuPageTitle';
 import { hasUserSelectedCommandState } from '@/command-menu/states/hasUserSelectedCommandState';
 import { CommandMenuPages } from '@/command-menu/types/CommandMenuPages';
+import { MAIN_CONTEXT_STORE_INSTANCE_ID } from '@/context-store/constants/MainContextStoreInstanceId';
 import { contextStoreCurrentViewTypeComponentState } from '@/context-store/states/contextStoreCurrentViewTypeComponentState';
 import { contextStoreFiltersComponentState } from '@/context-store/states/contextStoreFiltersComponentState';
 import { contextStoreNumberOfSelectedRecordsComponentState } from '@/context-store/states/contextStoreNumberOfSelectedRecordsComponentState';
 import { contextStoreTargetedRecordsRuleComponentState } from '@/context-store/states/contextStoreTargetedRecordsRuleComponentState';
-import { mainContextStoreComponentInstanceIdState } from '@/context-store/states/mainContextStoreComponentInstanceId';
 import { ContextStoreViewType } from '@/context-store/types/ContextStoreViewType';
 import { viewableRecordIdState } from '@/object-record/record-right-drawer/states/viewableRecordIdState';
 import { viewableRecordNameSingularState } from '@/object-record/record-right-drawer/states/viewableRecordNameSingularState';
@@ -40,10 +40,6 @@ export const useCommandMenu = () => {
     goBackToPreviousHotkeyScope,
   } = usePreviousHotkeyScope();
   const { getIcon } = useIcons();
-
-  const mainContextStoreComponentInstanceId = useRecoilValue(
-    mainContextStoreComponentInstanceIdState,
-  );
 
   const { copyContextStoreStates } = useCopyContextStoreStates();
   const { resetContextStoreStates } = useResetContextStoreStates();
@@ -64,18 +60,14 @@ export const useCommandMenu = () => {
         }
 
         copyContextStoreStates({
-          instanceIdToCopyFrom: mainContextStoreComponentInstanceId,
+          instanceIdToCopyFrom: MAIN_CONTEXT_STORE_INSTANCE_ID,
           instanceIdToCopyTo: 'command-menu',
         });
 
         set(isCommandMenuOpenedState, true);
         set(hasUserSelectedCommandState, false);
       },
-    [
-      copyContextStoreStates,
-      mainContextStoreComponentInstanceId,
-      setHotkeyScopeAndMemorizePreviousScope,
-    ],
+    [copyContextStoreStates, setHotkeyScopeAndMemorizePreviousScope],
   );
 
   const closeCommandMenu = useRecoilCallback(

--- a/packages/twenty-front/src/modules/command-menu/hooks/useCommandMenuHotKeys.ts
+++ b/packages/twenty-front/src/modules/command-menu/hooks/useCommandMenuHotKeys.ts
@@ -1,3 +1,4 @@
+import { COMMAND_MENU_COMPONENT_INSTANCE_ID } from '@/command-menu/constants/CommandMenuComponentInstanceId';
 import { useCommandMenu } from '@/command-menu/hooks/useCommandMenu';
 import { commandMenuPageState } from '@/command-menu/states/commandMenuPageState';
 import { commandMenuSearchState } from '@/command-menu/states/commandMenuSearchState';
@@ -27,7 +28,7 @@ export const useCommandMenuHotKeys = () => {
 
   const contextStoreTargetedRecordsRuleComponent = useRecoilComponentValueV2(
     contextStoreTargetedRecordsRuleComponentState,
-    'command-menu',
+    COMMAND_MENU_COMPONENT_INSTANCE_ID,
   );
 
   useScopedHotkeys(

--- a/packages/twenty-front/src/modules/command-menu/hooks/useResetPreviousCommandMenuContext.ts
+++ b/packages/twenty-front/src/modules/command-menu/hooks/useResetPreviousCommandMenuContext.ts
@@ -1,3 +1,5 @@
+import { COMMAND_MENU_COMPONENT_INSTANCE_ID } from '@/command-menu/constants/CommandMenuComponentInstanceId';
+import { COMMAND_MENU_PREVIOUS_COMPONENT_INSTANCE_ID } from '@/command-menu/constants/CommandMenuPreviousComponentInstanceId';
 import { useCopyContextStoreStates } from '@/command-menu/hooks/useCopyContextStoreAndActionMenuStates';
 import { useResetContextStoreStates } from '@/command-menu/hooks/useResetContextStoreStates';
 
@@ -7,10 +9,10 @@ export const useResetPreviousCommandMenuContext = () => {
 
   const resetPreviousCommandMenuContext = () => {
     copyContextStoreStates({
-      instanceIdToCopyFrom: 'command-menu-previous',
-      instanceIdToCopyTo: 'command-menu',
+      instanceIdToCopyFrom: COMMAND_MENU_PREVIOUS_COMPONENT_INSTANCE_ID,
+      instanceIdToCopyTo: COMMAND_MENU_COMPONENT_INSTANCE_ID,
     });
-    resetContextStoreStates('command-menu-previous');
+    resetContextStoreStates(COMMAND_MENU_PREVIOUS_COMPONENT_INSTANCE_ID);
   };
 
   return {

--- a/packages/twenty-front/src/modules/context-store/components/MainContextStoreProvider.tsx
+++ b/packages/twenty-front/src/modules/context-store/components/MainContextStoreProvider.tsx
@@ -1,5 +1,4 @@
 import { MainContextStoreProviderEffect } from '@/context-store/components/MainContextStoreProviderEffect';
-import { MAIN_CONTEXT_STORE_INSTANCE_ID } from '@/context-store/constants/MainContextStoreInstanceId';
 import { useLastVisitedView } from '@/navigation/hooks/useLastVisitedView';
 import { objectMetadataItemsState } from '@/object-metadata/states/objectMetadataItemsState';
 import { prefetchIndexViewIdFromObjectMetadataItemFamilySelector } from '@/prefetch/states/selector/prefetchIndexViewIdFromObjectMetadataItemFamilySelector';
@@ -74,7 +73,6 @@ export const MainContextStoreProvider = () => {
 
   return (
     <MainContextStoreProviderEffect
-      mainContextStoreComponentInstanceIdToSet={MAIN_CONTEXT_STORE_INSTANCE_ID}
       viewId={viewId}
       objectMetadataItem={objectMetadataItem}
       pageName={pageName}

--- a/packages/twenty-front/src/modules/context-store/components/MainContextStoreProvider.tsx
+++ b/packages/twenty-front/src/modules/context-store/components/MainContextStoreProvider.tsx
@@ -1,4 +1,5 @@
 import { MainContextStoreProviderEffect } from '@/context-store/components/MainContextStoreProviderEffect';
+import { MAIN_CONTEXT_STORE_INSTANCE_ID } from '@/context-store/constants/MainContextStoreInstanceId';
 import { useLastVisitedView } from '@/navigation/hooks/useLastVisitedView';
 import { objectMetadataItemsState } from '@/object-metadata/states/objectMetadataItemsState';
 import { prefetchIndexViewIdFromObjectMetadataItemFamilySelector } from '@/prefetch/states/selector/prefetchIndexViewIdFromObjectMetadataItemFamilySelector';
@@ -73,7 +74,7 @@ export const MainContextStoreProvider = () => {
 
   return (
     <MainContextStoreProviderEffect
-      mainContextStoreComponentInstanceIdToSet={'main-context-store'}
+      mainContextStoreComponentInstanceIdToSet={MAIN_CONTEXT_STORE_INSTANCE_ID}
       viewId={viewId}
       objectMetadataItem={objectMetadataItem}
       pageName={pageName}

--- a/packages/twenty-front/src/modules/context-store/components/MainContextStoreProviderEffect.tsx
+++ b/packages/twenty-front/src/modules/context-store/components/MainContextStoreProviderEffect.tsx
@@ -1,7 +1,7 @@
+import { MAIN_CONTEXT_STORE_INSTANCE_ID } from '@/context-store/constants/MainContextStoreInstanceId';
 import { contextStoreCurrentObjectMetadataItemComponentState } from '@/context-store/states/contextStoreCurrentObjectMetadataItemComponentState';
 import { contextStoreCurrentViewIdComponentState } from '@/context-store/states/contextStoreCurrentViewIdComponentState';
 import { contextStoreCurrentViewTypeComponentState } from '@/context-store/states/contextStoreCurrentViewTypeComponentState';
-import { mainContextStoreComponentInstanceIdState } from '@/context-store/states/mainContextStoreComponentInstanceId';
 import { ContextStoreViewType } from '@/context-store/types/ContextStoreViewType';
 import { useSetLastVisitedObjectMetadataId } from '@/navigation/hooks/useSetLastVisitedObjectMetadataId';
 import { useSetLastVisitedViewForObjectMetadataNamePlural } from '@/navigation/hooks/useSetLastVisitedViewForObjectMetadataNamePlural';
@@ -10,24 +10,17 @@ import { prefetchViewFromViewIdFamilySelector } from '@/prefetch/states/selector
 import { useRecoilComponentStateV2 } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentStateV2';
 import { ViewType } from '@/views/types/ViewType';
 import { useEffect } from 'react';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilValue } from 'recoil';
 
 export const MainContextStoreProviderEffect = ({
-  mainContextStoreComponentInstanceIdToSet,
   viewId,
   objectMetadataItem,
   pageName,
 }: {
-  mainContextStoreComponentInstanceIdToSet: string;
   viewId?: string;
   objectMetadataItem: ObjectMetadataItem;
   pageName: string;
 }) => {
-  const [
-    mainContextStoreComponentInstanceId,
-    setMainContextStoreComponentInstanceId,
-  ] = useRecoilState(mainContextStoreComponentInstanceIdState);
-
   const { setLastVisitedViewForObjectMetadataNamePlural } =
     useSetLastVisitedViewForObjectMetadataNamePlural();
 
@@ -37,13 +30,13 @@ export const MainContextStoreProviderEffect = ({
   const [contextStoreCurrentViewId, setContextStoreCurrentViewId] =
     useRecoilComponentStateV2(
       contextStoreCurrentViewIdComponentState,
-      mainContextStoreComponentInstanceId,
+      MAIN_CONTEXT_STORE_INSTANCE_ID,
     );
 
   const [contextStoreCurrentViewType, setContextStoreCurrentViewType] =
     useRecoilComponentStateV2(
       contextStoreCurrentViewTypeComponentState,
-      mainContextStoreComponentInstanceId,
+      MAIN_CONTEXT_STORE_INSTANCE_ID,
     );
 
   const [
@@ -51,7 +44,7 @@ export const MainContextStoreProviderEffect = ({
     setContextStoreCurrentObjectMetadataItem,
   ] = useRecoilComponentStateV2(
     contextStoreCurrentObjectMetadataItemComponentState,
-    mainContextStoreComponentInstanceId,
+    MAIN_CONTEXT_STORE_INSTANCE_ID,
   );
 
   const view = useRecoilValue(
@@ -63,15 +56,6 @@ export const MainContextStoreProviderEffect = ({
   useEffect(() => {
     if (contextStoreCurrentObjectMetadataItem?.id !== objectMetadataItem.id) {
       setContextStoreCurrentObjectMetadataItem(objectMetadataItem);
-    }
-
-    if (
-      mainContextStoreComponentInstanceIdToSet !==
-      mainContextStoreComponentInstanceId
-    ) {
-      setMainContextStoreComponentInstanceId(
-        mainContextStoreComponentInstanceIdToSet,
-      );
     }
 
     setLastVisitedViewForObjectMetadataNamePlural({
@@ -89,15 +73,12 @@ export const MainContextStoreProviderEffect = ({
   }, [
     contextStoreCurrentObjectMetadataItem,
     contextStoreCurrentViewId,
-    mainContextStoreComponentInstanceId,
-    mainContextStoreComponentInstanceIdToSet,
     objectMetadataItem,
     objectMetadataItem.namePlural,
     setContextStoreCurrentObjectMetadataItem,
     setContextStoreCurrentViewId,
     setLastVisitedObjectMetadataId,
     setLastVisitedViewForObjectMetadataNamePlural,
-    setMainContextStoreComponentInstanceId,
     viewId,
   ]);
 

--- a/packages/twenty-front/src/modules/context-store/constants/MainContextStoreInstanceId.tsx
+++ b/packages/twenty-front/src/modules/context-store/constants/MainContextStoreInstanceId.tsx
@@ -1,0 +1,1 @@
+export const MAIN_CONTEXT_STORE_INSTANCE_ID = 'main-context-store';

--- a/packages/twenty-front/src/modules/context-store/states/mainContextStoreComponentInstanceId.ts
+++ b/packages/twenty-front/src/modules/context-store/states/mainContextStoreComponentInstanceId.ts
@@ -1,7 +1,0 @@
-import { CONTEXT_STORE_INSTANCE_ID_DEFAULT_VALUE } from '@/context-store/constants/ContextStoreInstanceIdDefaultValue';
-import { createState } from '@ui/utilities/state/utils/createState';
-
-export const mainContextStoreComponentInstanceIdState = createState<string>({
-  key: 'mainContextStoreComponentInstanceIdState',
-  defaultValue: CONTEXT_STORE_INSTANCE_ID_DEFAULT_VALUE,
-});

--- a/packages/twenty-front/src/modules/object-metadata/components/NavigationDrawerItemForObjectMetadataItem.tsx
+++ b/packages/twenty-front/src/modules/object-metadata/components/NavigationDrawerItemForObjectMetadataItem.tsx
@@ -1,5 +1,5 @@
+import { MAIN_CONTEXT_STORE_INSTANCE_ID } from '@/context-store/constants/MainContextStoreInstanceId';
 import { contextStoreCurrentViewIdComponentState } from '@/context-store/states/contextStoreCurrentViewIdComponentState';
-import { mainContextStoreComponentInstanceIdState } from '@/context-store/states/mainContextStoreComponentInstanceId';
 import { lastVisitedViewPerObjectMetadataItemState } from '@/navigation/states/lastVisitedViewPerObjectMetadataItemState';
 import { ObjectMetadataItem } from '@/object-metadata/types/ObjectMetadataItem';
 import { prefetchViewsFromObjectMetadataItemFamilySelector } from '@/prefetch/states/selector/prefetchViewsFromObjectMetadataItemFamilySelector';
@@ -27,13 +27,9 @@ export const NavigationDrawerItemForObjectMetadataItem = ({
     }),
   );
 
-  const mainContextStoreComponentInstanceId = useRecoilValue(
-    mainContextStoreComponentInstanceIdState,
-  );
-
   const contextStoreCurrentViewId = useRecoilComponentValueV2(
     contextStoreCurrentViewIdComponentState,
-    mainContextStoreComponentInstanceId,
+    MAIN_CONTEXT_STORE_INSTANCE_ID,
   );
 
   const lastVisitedViewPerObjectMetadataItem = useRecoilValue(

--- a/packages/twenty-front/src/modules/object-record/record-group/hooks/useSetRecordGroup.ts
+++ b/packages/twenty-front/src/modules/object-record/record-group/hooks/useSetRecordGroup.ts
@@ -1,3 +1,4 @@
+import { MAIN_CONTEXT_STORE_INSTANCE_ID } from '@/context-store/constants/MainContextStoreInstanceId';
 import { contextStoreCurrentObjectMetadataItemComponentState } from '@/context-store/states/contextStoreCurrentObjectMetadataItemComponentState';
 import { recordGroupDefinitionFamilyState } from '@/object-record/record-group/states/recordGroupDefinitionFamilyState';
 import { recordGroupFieldMetadataComponentState } from '@/object-record/record-group/states/recordGroupFieldMetadataComponentState';
@@ -14,7 +15,7 @@ export const useSetRecordGroup = () => {
         const objectMetadataItem = snapshot
           .getLoadable(
             contextStoreCurrentObjectMetadataItemComponentState.atomFamily({
-              instanceId: 'main-context-store',
+              instanceId: MAIN_CONTEXT_STORE_INSTANCE_ID,
             }),
           )
           .getValue();

--- a/packages/twenty-front/src/modules/object-record/record-index/components/RecordIndexContainerGater.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-index/components/RecordIndexContainerGater.tsx
@@ -2,9 +2,9 @@ import { RecordIndexContextProvider } from '@/object-record/record-index/context
 
 import { ActionMenuComponentInstanceContext } from '@/action-menu/states/contexts/ActionMenuComponentInstanceContext';
 import { getActionMenuIdFromRecordIndexId } from '@/action-menu/utils/getActionMenuIdFromRecordIndexId';
+import { MAIN_CONTEXT_STORE_INSTANCE_ID } from '@/context-store/constants/MainContextStoreInstanceId';
 import { useContextStoreObjectMetadataItemOrThrow } from '@/context-store/hooks/useContextStoreObjectMetadataItemOrThrow';
 import { contextStoreCurrentViewIdComponentState } from '@/context-store/states/contextStoreCurrentViewIdComponentState';
-import { mainContextStoreComponentInstanceIdState } from '@/context-store/states/mainContextStoreComponentInstanceId';
 import { lastShowPageRecordIdState } from '@/object-record/record-field/states/lastShowPageRecordId';
 import { RecordFilterGroupsComponentInstanceContext } from '@/object-record/record-filter-group/states/context/RecordFilterGroupsComponentInstanceContext';
 import { RecordFiltersComponentInstanceContext } from '@/object-record/record-filter/states/context/RecordFiltersComponentInstanceContext';
@@ -19,7 +19,7 @@ import { PageTitle } from '@/ui/utilities/page-title/components/PageTitle';
 import { useRecoilComponentValueV2 } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValueV2';
 import { ViewComponentInstanceContext } from '@/views/states/contexts/ViewComponentInstanceContext';
 import styled from '@emotion/styled';
-import { useRecoilCallback, useRecoilValue } from 'recoil';
+import { useRecoilCallback } from 'recoil';
 import { capitalize } from 'twenty-shared';
 
 const StyledIndexContainer = styled.div`
@@ -29,13 +29,9 @@ const StyledIndexContainer = styled.div`
 `;
 
 export const RecordIndexContainerGater = () => {
-  const mainContextStoreComponentInstanceId = useRecoilValue(
-    mainContextStoreComponentInstanceIdState,
-  );
-
   const contextStoreCurrentViewId = useRecoilComponentValueV2(
     contextStoreCurrentViewIdComponentState,
-    mainContextStoreComponentInstanceId,
+    MAIN_CONTEXT_STORE_INSTANCE_ID,
   );
 
   const { objectMetadataItem } = useContextStoreObjectMetadataItemOrThrow();

--- a/packages/twenty-front/src/modules/sign-in-background-mock/components/SignInBackgroundMockContainer.tsx
+++ b/packages/twenty-front/src/modules/sign-in-background-mock/components/SignInBackgroundMockContainer.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 
 import { ActionMenuComponentInstanceContext } from '@/action-menu/states/contexts/ActionMenuComponentInstanceContext';
+import { MAIN_CONTEXT_STORE_INSTANCE_ID } from '@/context-store/constants/MainContextStoreInstanceId';
 import { contextStoreCurrentObjectMetadataItemComponentState } from '@/context-store/states/contextStoreCurrentObjectMetadataItemComponentState';
 import { ContextStoreComponentInstanceContext } from '@/context-store/states/contexts/ContextStoreComponentInstanceContext';
 import { objectMetadataItemsState } from '@/object-metadata/states/objectMetadataItemsState';
@@ -33,7 +34,7 @@ export const SignInBackgroundMockContainer = () => {
 
   const objectMetadataItem = useRecoilComponentValueV2(
     contextStoreCurrentObjectMetadataItemComponentState,
-    'main-context-store',
+    MAIN_CONTEXT_STORE_INSTANCE_ID,
   );
 
   return (
@@ -62,7 +63,7 @@ export const SignInBackgroundMockContainer = () => {
               >
                 <ContextStoreComponentInstanceContext.Provider
                   value={{
-                    instanceId: 'main-context-store',
+                    instanceId: MAIN_CONTEXT_STORE_INSTANCE_ID,
                   }}
                 >
                   <SignInBackgroundMockContainerEffect

--- a/packages/twenty-front/src/modules/sign-in-background-mock/components/SignInBackgroundMockContainerEffect.tsx
+++ b/packages/twenty-front/src/modules/sign-in-background-mock/components/SignInBackgroundMockContainerEffect.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 
+import { MAIN_CONTEXT_STORE_INSTANCE_ID } from '@/context-store/constants/MainContextStoreInstanceId';
 import { contextStoreCurrentObjectMetadataItemComponentState } from '@/context-store/states/contextStoreCurrentObjectMetadataItemComponentState';
 import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
 import { useObjectNameSingularFromPlural } from '@/object-metadata/hooks/useObjectNameSingularFromPlural';
@@ -25,7 +26,7 @@ export const SignInBackgroundMockContainerEffect = ({
 }: SignInBackgroundMockContainerEffectProps) => {
   const setContextStoreCurrentObjectMetadataItem = useSetRecoilComponentStateV2(
     contextStoreCurrentObjectMetadataItemComponentState,
-    'main-context-store',
+    MAIN_CONTEXT_STORE_INSTANCE_ID,
   );
 
   const { setAvailableTableColumns, setOnEntityCountChange } = useRecordTable({

--- a/packages/twenty-front/src/pages/object-record/RecordIndexPage.tsx
+++ b/packages/twenty-front/src/pages/object-record/RecordIndexPage.tsx
@@ -1,3 +1,4 @@
+import { MAIN_CONTEXT_STORE_INSTANCE_ID } from '@/context-store/constants/MainContextStoreInstanceId';
 import { contextStoreCurrentObjectMetadataItemComponentState } from '@/context-store/states/contextStoreCurrentObjectMetadataItemComponentState';
 import { contextStoreCurrentViewIdComponentState } from '@/context-store/states/contextStoreCurrentViewIdComponentState';
 import { ContextStoreComponentInstanceContext } from '@/context-store/states/contexts/ContextStoreComponentInstanceContext';
@@ -9,12 +10,12 @@ import { isNonEmptyString, isUndefined } from '@sniptt/guards';
 export const RecordIndexPage = () => {
   const contextStoreCurrentViewId = useRecoilComponentValueV2(
     contextStoreCurrentViewIdComponentState,
-    'main-context-store',
+    MAIN_CONTEXT_STORE_INSTANCE_ID,
   );
 
   const objectMetadataItem = useRecoilComponentValueV2(
     contextStoreCurrentObjectMetadataItemComponentState,
-    'main-context-store',
+    MAIN_CONTEXT_STORE_INSTANCE_ID,
   );
 
   if (
@@ -28,7 +29,7 @@ export const RecordIndexPage = () => {
     <PageContainer>
       <ContextStoreComponentInstanceContext.Provider
         value={{
-          instanceId: 'main-context-store',
+          instanceId: MAIN_CONTEXT_STORE_INSTANCE_ID,
         }}
       >
         <RecordIndexContainerGater />

--- a/packages/twenty-front/src/pages/object-record/RecordShowPage.tsx
+++ b/packages/twenty-front/src/pages/object-record/RecordShowPage.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom';
 import { RecordShowActionMenu } from '@/action-menu/components/RecordShowActionMenu';
 import { ActionMenuComponentInstanceContext } from '@/action-menu/states/contexts/ActionMenuComponentInstanceContext';
 import { TimelineActivityContext } from '@/activities/timeline-activities/contexts/TimelineActivityContext';
+import { MAIN_CONTEXT_STORE_INSTANCE_ID } from '@/context-store/constants/MainContextStoreInstanceId';
 import { ContextStoreComponentInstanceContext } from '@/context-store/states/contexts/ContextStoreComponentInstanceContext';
 import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
 import { RecordFilterGroupsComponentInstanceContext } from '@/object-record/record-filter-group/states/context/RecordFilterGroupsComponentInstanceContext';
@@ -59,7 +60,7 @@ export const RecordShowPage = () => {
             value={{ instanceId: `record-show-${objectRecordId}` }}
           >
             <ContextStoreComponentInstanceContext.Provider
-              value={{ instanceId: 'main-context-store' }}
+              value={{ instanceId: MAIN_CONTEXT_STORE_INSTANCE_ID }}
             >
               <ActionMenuComponentInstanceContext.Provider
                 value={{ instanceId: `record-show-${objectRecordId}` }}

--- a/packages/twenty-front/src/pages/object-record/RecordShowPage.tsx
+++ b/packages/twenty-front/src/pages/object-record/RecordShowPage.tsx
@@ -50,19 +50,19 @@ export const RecordShowPage = () => {
   return (
     <RecordFieldValueSelectorContextProvider>
       <RecordFilterGroupsComponentInstanceContext.Provider
-        value={{ instanceId: `record-show-${objectRecordId}` }}
+        value={{ instanceId: 'main-context-store' }}
       >
         <RecordFiltersComponentInstanceContext.Provider
-          value={{ instanceId: `record-show-${objectRecordId}` }}
+          value={{ instanceId: 'main-context-store' }}
         >
           <RecordSortsComponentInstanceContext.Provider
-            value={{ instanceId: `record-show-${objectRecordId}` }}
+            value={{ instanceId: 'main-context-store' }}
           >
             <ContextStoreComponentInstanceContext.Provider
-              value={{ instanceId: `record-show-${objectRecordId}` }}
+              value={{ instanceId: 'main-context-store' }}
             >
               <ActionMenuComponentInstanceContext.Provider
-                value={{ instanceId: `record-show-${objectRecordId}` }}
+                value={{ instanceId: 'main-context-store' }}
               >
                 <RecordValueSetterEffect recordId={objectRecordId} />
                 <PageContainer>

--- a/packages/twenty-front/src/pages/object-record/RecordShowPage.tsx
+++ b/packages/twenty-front/src/pages/object-record/RecordShowPage.tsx
@@ -50,19 +50,19 @@ export const RecordShowPage = () => {
   return (
     <RecordFieldValueSelectorContextProvider>
       <RecordFilterGroupsComponentInstanceContext.Provider
-        value={{ instanceId: 'main-context-store' }}
+        value={{ instanceId: `record-show-${objectRecordId}` }}
       >
         <RecordFiltersComponentInstanceContext.Provider
-          value={{ instanceId: 'main-context-store' }}
+          value={{ instanceId: `record-show-${objectRecordId}` }}
         >
           <RecordSortsComponentInstanceContext.Provider
-            value={{ instanceId: 'main-context-store' }}
+            value={{ instanceId: `record-show-${objectRecordId}` }}
           >
             <ContextStoreComponentInstanceContext.Provider
               value={{ instanceId: 'main-context-store' }}
             >
               <ActionMenuComponentInstanceContext.Provider
-                value={{ instanceId: 'main-context-store' }}
+                value={{ instanceId: `record-show-${objectRecordId}` }}
               >
                 <RecordValueSetterEffect recordId={objectRecordId} />
                 <PageContainer>

--- a/packages/twenty-front/src/testing/decorators/ContextStoreDecorator.tsx
+++ b/packages/twenty-front/src/testing/decorators/ContextStoreDecorator.tsx
@@ -1,6 +1,7 @@
 import { Decorator } from '@storybook/react';
 import { useEffect, useState } from 'react';
 
+import { MAIN_CONTEXT_STORE_INSTANCE_ID } from '@/context-store/constants/MainContextStoreInstanceId';
 import { contextStoreCurrentObjectMetadataItemComponentState } from '@/context-store/states/contextStoreCurrentObjectMetadataItemComponentState';
 import { ContextStoreComponentInstanceContext } from '@/context-store/states/contexts/ContextStoreComponentInstanceContext';
 import { useSetRecoilComponentStateV2 } from '@/ui/utilities/state/component-state/hooks/useSetRecoilComponentStateV2';
@@ -13,7 +14,7 @@ export const ContextStoreDecorator: Decorator = (Story, context) => {
   let componentInstanceId = contextStore?.componentInstanceId;
 
   if (isUndefined(componentInstanceId)) {
-    componentInstanceId = 'main-context-store';
+    componentInstanceId = MAIN_CONTEXT_STORE_INSTANCE_ID;
   }
 
   const setCurrentObjectMetadataItem = useSetRecoilComponentStateV2(


### PR DESCRIPTION
Fixes bug introduced by https://github.com/twentyhq/twenty/pull/10272
- Replace show page context store instance id by 'main-context-store'