### PR TITLE
[REFACTOR] remove `isRemote` assertion from `hasFieldPosition` util

### DIFF
--- a/packages/twenty-front/src/modules/object-metadata/utils/hasObjectMetadataItemPositionField.ts
+++ b/packages/twenty-front/src/modules/object-metadata/utils/hasObjectMetadataItemPositionField.ts
@@ -4,7 +4,6 @@ import { FieldMetadataType } from 'twenty-shared';
 export const hasObjectMetadataItemPositionField = (
   objectMetadataItem: ObjectMetadataItem,
 ) =>
-  !objectMetadataItem.isRemote &&
   objectMetadataItem.fields.some(
     (field) => field.type === FieldMetadataType.POSITION,
   );

--- a/packages/twenty-front/src/modules/object-record/object-sort-dropdown/utils/turnSortsIntoOrderBy.ts
+++ b/packages/twenty-front/src/modules/object-record/object-sort-dropdown/utils/turnSortsIntoOrderBy.ts
@@ -35,7 +35,10 @@ export const turnSortsIntoOrderBy = (
     })
     .filter(isDefined);
 
-  if (hasObjectMetadataItemPositionField(objectMetadataItem)) {
+  if (
+    !objectMetadataItem.isRemote &&
+    hasObjectMetadataItemPositionField(objectMetadataItem)
+  ) {
     const positionOrderBy = [
       {
         position: 'AscNullsFirst',


### PR DESCRIPTION
Following this discussion https://github.com/twentyhq/twenty/pull/10510#discussion_r1971845556 with @ijreilly 