### PR TITLE
Fix contact creation

### DIFF
--- a/packages/twenty-server/src/modules/contact-creation-manager/utils/filter-out-contacts-from-company-or-workspace.util.ts
+++ b/packages/twenty-server/src/modules/contact-creation-manager/utils/filter-out-contacts-from-company-or-workspace.util.ts
@@ -11,7 +11,7 @@ export function filterOutSelfAndContactsFromCompanyOrWorkspace(
 ): Contact[] {
   const selfDomainName = getDomainNameFromHandle(connectedAccount.handle);
 
-  const handleAliases = [
+  const allHandles = [
     connectedAccount.handle,
     ...(connectedAccount.handleAliases?.split(',') || []),
   ];
@@ -33,6 +33,6 @@ export function filterOutSelfAndContactsFromCompanyOrWorkspace(
       (isDifferentDomain(contact, selfDomainName) ||
         !isWorkDomain(selfDomainName)) &&
       !workspaceMembersMap[contact.handle] &&
-      !handleAliases.includes(contact.handle),
+      !allHandles.includes(contact.handle),
   );
 }

--- a/packages/twenty-server/src/modules/contact-creation-manager/utils/filter-out-contacts-from-company-or-workspace.util.ts
+++ b/packages/twenty-server/src/modules/contact-creation-manager/utils/filter-out-contacts-from-company-or-workspace.util.ts
@@ -11,7 +11,10 @@ export function filterOutSelfAndContactsFromCompanyOrWorkspace(
 ): Contact[] {
   const selfDomainName = getDomainNameFromHandle(connectedAccount.handle);
 
-  const handleAliases = connectedAccount.handleAliases?.split(',') || [];
+  const handleAliases = [
+    connectedAccount.handle,
+    ...(connectedAccount.handleAliases?.split(',') || []),
+  ];
 
   const workspaceMembersMap = workspaceMembers.reduce(
     (map, workspaceMember) => {


### PR DESCRIPTION
Fixes the following bug:
When I connect an account, a contact is created for that email if the domain name differs from the workspace domain name.
