### PR TITLE
Fix command menu list item overflow

### DIFF
--- a/packages/twenty-ui/src/navigation/menu-item/components/MenuItemCommand.tsx
+++ b/packages/twenty-ui/src/navigation/menu-item/components/MenuItemCommand.tsx
@@ -75,7 +75,7 @@ const StyledDescription = styled.span`
 const StyledTextContainer = styled.div`
   display: flex;
   flex-direction: row;
-  width: calc(100% - 2 * var(--horizontal-padding));
+  max-width: calc(100% - 2 * var(--horizontal-padding));
 `;
 
 export type MenuItemCommandProps = {

--- a/packages/twenty-ui/src/navigation/menu-item/components/MenuItemCommand.tsx
+++ b/packages/twenty-ui/src/navigation/menu-item/components/MenuItemCommand.tsx
@@ -75,7 +75,7 @@ const StyledDescription = styled.span`
 const StyledTextContainer = styled.div`
   display: flex;
   flex-direction: row;
-  overflow: hidden;
+  width: calc(100% - 2 * var(--horizontal-padding));
 `;
 
 export type MenuItemCommandProps = {

--- a/packages/twenty-ui/src/navigation/menu-item/components/MenuItemCommand.tsx
+++ b/packages/twenty-ui/src/navigation/menu-item/components/MenuItemCommand.tsx
@@ -6,7 +6,7 @@ import {
   StyledMenuItemLeftContent,
 } from '../internals/components/StyledMenuItemBase';
 
-import { IconComponent } from '@ui/display';
+import { IconComponent, OverflowingTextWithTooltip } from '@ui/display';
 import { useIsMobile } from '@ui/utilities/responsive/hooks/useIsMobile';
 import { ReactNode } from 'react';
 import { MenuItemCommandHotKeys } from './MenuItemCommandHotKeys';
@@ -75,6 +75,7 @@ const StyledDescription = styled.span`
 const StyledTextContainer = styled.div`
   display: flex;
   flex-direction: row;
+  overflow: hidden;
 `;
 
 export type MenuItemCommandProps = {
@@ -114,7 +115,9 @@ export const MenuItemCommand = ({
           </StyledBigIconContainer>
         )}
         <StyledTextContainer>
-          <StyledMenuItemLabelText>{text}</StyledMenuItemLabelText>
+          <StyledMenuItemLabelText>
+            <OverflowingTextWithTooltip text={text} />
+          </StyledMenuItemLabelText>
           {description && <StyledDescription>{description}</StyledDescription>}
         </StyledTextContainer>
         {RightComponent}


### PR DESCRIPTION
Before:
<img width="501" alt="Capture d’écran 2025-02-27 à 12 10 52" src="https://github.com/user-attachments/assets/dd3637b4-cfe4-44b9-8db2-78e14741a415" />

After:
<img width="503" alt="Capture d’écran 2025-02-27 à 12 10 40" src="https://github.com/user-attachments/assets/71ebb02d-cdc8-44e6-82dd-d00b3a45e7c0" />
