### PR TITLE
API rest exception filter

### DIFF
--- a/packages/twenty-server/src/engine/api/rest/core/controllers/rest-api-core.controller.ts
+++ b/packages/twenty-server/src/engine/api/rest/core/controllers/rest-api-core.controller.ts
@@ -29,6 +29,7 @@ export class RestApiCoreController {
   ) {}
 
   @Post('/duplicates')
+  @UseFilters(RestApiExceptionFilter)
   async handleApiFindDuplicates(@Req() request: Request, @Res() res: Response) {
     const result = await this.restApiCoreService.findDuplicates(request);
 
@@ -36,6 +37,7 @@ export class RestApiCoreController {
   }
 
   @Get()
+  @UseFilters(RestApiExceptionFilter)
   async handleApiGet(@Req() request: Request, @Res() res: Response) {
     const result = await this.restApiCoreService.get(request);
 


### PR DESCRIPTION
While troubleshooting with a person self-hosting Twenty (v0.42.2), we figured out that logs were missing on REST findMany, findOne and duplicate endpoints

This PR fixes it