### PR TITLE
[REG/FEAT] Sync metadata after upgrade

### DIFF
--- a/packages/twenty-server/src/database/commands/migration-command/create-upgrade-all-command.factory.ts
+++ b/packages/twenty-server/src/database/commands/migration-command/create-upgrade-all-command.factory.ts
@@ -1,11 +1,18 @@
 import { Inject } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
 
 import { Command } from 'nest-commander';
 
 import { MigrationCommandInterface } from 'src/database/commands/migration-command/interfaces/migration-command.interface';
+import { MaintainedWorkspacesMigrationCommandRunner } from 'src/database/commands/migration-command/maintained-workspaces-migration-command.runner';
 
 import { MIGRATION_COMMAND_INJECTION_TOKEN } from 'src/database/commands/migration-command/migration-command.constants';
 import { MigrationCommandRunner } from 'src/database/commands/migration-command/migration-command.runner';
+import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
+import { DataSourceService } from 'src/engine/metadata-modules/data-source/data-source.service';
+import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.manager';
+import { WorkspaceSyncMetadataService } from 'src/engine/workspace-manager/workspace-sync-metadata/workspace-sync-metadata.service';
+import { Repository } from 'typeorm';
 
 export function createUpgradeAllCommand(
   version: string,
@@ -14,23 +21,78 @@ export function createUpgradeAllCommand(
     name: `upgrade-${version}`,
     description: `Upgrade to version ${version}`,
   })
-  class UpgradeCommand extends MigrationCommandRunner {
+  class UpgradeCommand extends MaintainedWorkspacesMigrationCommandRunner {
     constructor(
+      @InjectRepository(Workspace, 'core')
+      protected readonly workspaceRepository: Repository<Workspace>,
+      protected readonly twentyORMGlobalManager: TwentyORMGlobalManager,
       @Inject(MIGRATION_COMMAND_INJECTION_TOKEN)
       private readonly subCommands: MigrationCommandInterface[],
+      private readonly dataSourceService: DataSourceService,
+      private readonly workspaceSyncMetadataService: WorkspaceSyncMetadataService,
     ) {
-      super();
+      super(workspaceRepository, twentyORMGlobalManager);
     }
 
-    async runMigrationCommand(
+    private async synchronizeWorkspaceMetadata({
+      workspaceIds,
+      options,
+    }: {
+      workspaceIds: string[];
+      options: Record<string, unknown>;
+    }) {
+      this.logger.log(`Attempting to sync ${workspaceIds.length} workspaces.`);
+      let errorsDuringSync: string[] = [];
+      for (const [index, workspaceId] of workspaceIds.entries()) {
+        try {
+          this.logger.log(
+            `Running workspace sync for workspace: ${workspaceId} (${index + 1} out of ${workspaceIds.length})`,
+          );
+          const dataSourceMetadata =
+            await this.dataSourceService.getLastDataSourceMetadataFromWorkspaceIdOrFail(
+              workspaceId,
+            );
+
+          await this.workspaceSyncMetadataService.synchronize(
+            {
+              workspaceId,
+              dataSourceId: dataSourceMetadata.id,
+            },
+            { applyChanges: !options.dryRun },
+          );
+          // TODO save logs
+        } catch (error) {
+          const errorMessage = `Failed to synchronize workspace ${workspaceId}: ${error.message}`;
+          this.logger.error(errorMessage);
+          errorsDuringSync.push(errorMessage);
+
+          continue;
+        }
+      }
+      this.logger.log(
+        `Finished synchronizing all active workspaces (${
+          workspaceIds.length
+        } workspaces). ${
+          errorsDuringSync.length > 0
+            ? 'Errors during sync:\n' + errorsDuringSync.join('.\n')
+            : ''
+        }`,
+      );
+    }
+
+    async runMigrationCommandOnMaintainedWorkspaces(
       passedParams: string[],
       options: Record<string, unknown>,
+      workspaceIds: string[],
     ): Promise<void> {
+      console.log(passedParams, options, workspaceIds);
       this.logger.log(`Running upgrade command for version ${version}`);
 
       for (const command of this.subCommands) {
         await command.runMigrationCommand(passedParams, options);
       }
+
+      await this.synchronizeWorkspaceMetadata({ options, workspaceIds });
 
       this.logger.log(`Upgrade ${version} command completed!`);
     }

--- a/packages/twenty-server/src/database/commands/migration-command/create-upgrade-all-command.factory.ts
+++ b/packages/twenty-server/src/database/commands/migration-command/create-upgrade-all-command.factory.ts
@@ -36,6 +36,7 @@ export function createUpgradeAllCommand(
       super(workspaceRepository, twentyORMGlobalManager);
     }
 
+    // TODO Remove and avoid duplicated synchronize logic with SyncWorkspaceMetadataCommand after command refactoring
     private async synchronizeWorkspaceMetadata({
       workspaceIds,
       options,
@@ -43,7 +44,6 @@ export function createUpgradeAllCommand(
       workspaceIds: string[];
       options: Record<string, unknown>;
     }) {
-      // TODO Remove and avoid duplicated synchronize logic with SyncWorkspaceMetadataCommand after command refactoring
       this.logger.log(`Attempting to sync ${workspaceIds.length} workspaces.`);
       const errorsDuringSync: string[] = [];
 

--- a/packages/twenty-server/src/database/commands/migration-command/migration-command.module.ts
+++ b/packages/twenty-server/src/database/commands/migration-command/migration-command.module.ts
@@ -5,6 +5,9 @@ import { MigrationCommandInterface } from 'src/database/commands/migration-comma
 import { createUpgradeAllCommand } from 'src/database/commands/migration-command/create-upgrade-all-command.factory';
 import { getMigrationCommandsForVersion } from 'src/database/commands/migration-command/decorators/migration-command.decorator';
 import { MIGRATION_COMMAND_INJECTION_TOKEN } from 'src/database/commands/migration-command/migration-command.constants';
+import { DataSourceModule } from 'src/engine/metadata-modules/data-source/data-source.module';
+import { WorkspaceSyncMetadataCommandsModule } from 'src/engine/workspace-manager/workspace-sync-metadata/commands/workspace-sync-metadata-commands.module';
+import { WorkspaceSyncMetadataModule } from 'src/engine/workspace-manager/workspace-sync-metadata/workspace-sync-metadata.module';
 
 @Module({})
 export class MigrationCommandModule {
@@ -17,7 +20,12 @@ export class MigrationCommandModule {
 
     return {
       module: MigrationCommandModule,
-      imports: moduleMetadata.imports,
+      imports: [
+        ...(moduleMetadata.imports ?? []),
+        WorkspaceSyncMetadataModule,
+        DataSourceModule,
+        WorkspaceSyncMetadataCommandsModule,
+      ],
       providers: [
         ...(moduleMetadata.providers ?? []),
         ...commandClasses,

--- a/packages/twenty-server/src/database/commands/migration-command/migration-command.module.ts
+++ b/packages/twenty-server/src/database/commands/migration-command/migration-command.module.ts
@@ -6,7 +6,7 @@ import { createUpgradeAllCommand } from 'src/database/commands/migration-command
 import { getMigrationCommandsForVersion } from 'src/database/commands/migration-command/decorators/migration-command.decorator';
 import { MIGRATION_COMMAND_INJECTION_TOKEN } from 'src/database/commands/migration-command/migration-command.constants';
 import { DataSourceModule } from 'src/engine/metadata-modules/data-source/data-source.module';
-import { WorkspaceSyncMetadataCommandsModule } from 'src/engine/workspace-manager/workspace-sync-metadata/commands/workspace-sync-metadata-commands.module';
+import { SyncWorkspaceLoggerModule } from 'src/engine/workspace-manager/workspace-sync-metadata/commands/services/sync-workspace-logger.module';
 import { WorkspaceSyncMetadataModule } from 'src/engine/workspace-manager/workspace-sync-metadata/workspace-sync-metadata.module';
 
 @Module({})
@@ -21,10 +21,10 @@ export class MigrationCommandModule {
     return {
       module: MigrationCommandModule,
       imports: [
+        SyncWorkspaceLoggerModule,
         ...(moduleMetadata.imports ?? []),
         WorkspaceSyncMetadataModule,
         DataSourceModule,
-        WorkspaceSyncMetadataCommandsModule,
       ],
       providers: [
         ...(moduleMetadata.providers ?? []),

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/commands/services/sync-workspace-logger.module.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/commands/services/sync-workspace-logger.module.ts
@@ -1,0 +1,9 @@
+import { Module } from "@nestjs/common";
+import { SyncWorkspaceLoggerService } from "src/engine/workspace-manager/workspace-sync-metadata/commands/services/sync-workspace-logger.service";
+
+@Module({
+    providers: [SyncWorkspaceLoggerService],
+    exports: [SyncWorkspaceLoggerService]
+  })
+  export class SyncWorkspaceLoggerModule {}
+  

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/commands/services/sync-workspace-logger.module.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/commands/services/sync-workspace-logger.module.ts
@@ -1,9 +1,9 @@
-import { Module } from "@nestjs/common";
-import { SyncWorkspaceLoggerService } from "src/engine/workspace-manager/workspace-sync-metadata/commands/services/sync-workspace-logger.service";
+import { Module } from '@nestjs/common';
+
+import { SyncWorkspaceLoggerService } from 'src/engine/workspace-manager/workspace-sync-metadata/commands/services/sync-workspace-logger.service';
 
 @Module({
-    providers: [SyncWorkspaceLoggerService],
-    exports: [SyncWorkspaceLoggerService]
-  })
-  export class SyncWorkspaceLoggerModule {}
-  
+  providers: [SyncWorkspaceLoggerService],
+  exports: [SyncWorkspaceLoggerService],
+})
+export class SyncWorkspaceLoggerModule {}

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/commands/services/sync-workspace-logger.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/commands/services/sync-workspace-logger.service.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@nestjs/common';
 
-import { WorkspaceSyncStorage } from 'src/engine/workspace-manager/workspace-sync-metadata/storage/workspace-sync.storage';
-import { WorkspaceMigrationEntity } from 'src/engine/metadata-modules/workspace-migration/workspace-migration.entity';
 import { CommandLogger } from 'src/command/command-logger';
+import { WorkspaceMigrationEntity } from 'src/engine/metadata-modules/workspace-migration/workspace-migration.entity';
+import { WorkspaceSyncStorage } from 'src/engine/workspace-manager/workspace-sync-metadata/storage/workspace-sync.storage';
 
 @Injectable()
 export class SyncWorkspaceLoggerService {

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/commands/workspace-sync-metadata-commands.module.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/commands/workspace-sync-metadata-commands.module.ts
@@ -8,10 +8,9 @@ import { WorkspaceDataSourceModule } from 'src/engine/workspace-datasource/works
 import { WorkspaceHealthModule } from 'src/engine/workspace-manager/workspace-health/workspace-health.module';
 import { ConvertRecordPositionsToIntegers } from 'src/engine/workspace-manager/workspace-sync-metadata/commands/convert-record-positions-to-integers.command';
 import { WorkspaceSyncMetadataModule } from 'src/engine/workspace-manager/workspace-sync-metadata/workspace-sync-metadata.module';
-
 import { SyncWorkspaceLoggerModule } from 'src/engine/workspace-manager/workspace-sync-metadata/commands/services/sync-workspace-logger.module';
-import { SyncWorkspaceMetadataCommand } from './sync-workspace-metadata.command';
 
+import { SyncWorkspaceMetadataCommand } from './sync-workspace-metadata.command';
 
 @Module({
   imports: [
@@ -21,12 +20,9 @@ import { SyncWorkspaceMetadataCommand } from './sync-workspace-metadata.command'
     DataSourceModule,
     WorkspaceDataSourceModule,
     TypeOrmModule.forFeature([Workspace], 'core'),
-    SyncWorkspaceLoggerModule
+    SyncWorkspaceLoggerModule,
   ],
-  providers: [
-    SyncWorkspaceMetadataCommand,
-    ConvertRecordPositionsToIntegers,
-  ],
+  providers: [SyncWorkspaceMetadataCommand, ConvertRecordPositionsToIntegers],
   exports: [SyncWorkspaceMetadataCommand],
 })
 export class WorkspaceSyncMetadataCommandsModule {}

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/commands/workspace-sync-metadata-commands.module.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/commands/workspace-sync-metadata-commands.module.ts
@@ -9,9 +9,9 @@ import { WorkspaceHealthModule } from 'src/engine/workspace-manager/workspace-he
 import { ConvertRecordPositionsToIntegers } from 'src/engine/workspace-manager/workspace-sync-metadata/commands/convert-record-positions-to-integers.command';
 import { WorkspaceSyncMetadataModule } from 'src/engine/workspace-manager/workspace-sync-metadata/workspace-sync-metadata.module';
 
+import { SyncWorkspaceLoggerModule } from 'src/engine/workspace-manager/workspace-sync-metadata/commands/services/sync-workspace-logger.module';
 import { SyncWorkspaceMetadataCommand } from './sync-workspace-metadata.command';
 
-import { SyncWorkspaceLoggerService } from './services/sync-workspace-logger.service';
 
 @Module({
   imports: [
@@ -21,11 +21,11 @@ import { SyncWorkspaceLoggerService } from './services/sync-workspace-logger.ser
     DataSourceModule,
     WorkspaceDataSourceModule,
     TypeOrmModule.forFeature([Workspace], 'core'),
+    SyncWorkspaceLoggerModule
   ],
   providers: [
     SyncWorkspaceMetadataCommand,
     ConvertRecordPositionsToIntegers,
-    SyncWorkspaceLoggerService,
   ],
   exports: [SyncWorkspaceMetadataCommand],
 })


### PR DESCRIPTION
# Introduction
Historically we've been programmatically running sync metadata just after all upgrade command's migration.
Adding back this behavior as default to the new dynamic modules

Duplicated already existing synchronize metadata logic as a quick fix as we're about to iterate over commands next sprint