### PR TITLE
[permissions] Fix redirection at sign-up after configuring billing 

### DIFF
--- a/packages/twenty-front/src/modules/settings/roles/hooks/useHasSettingsPermission.ts
+++ b/packages/twenty-front/src/modules/settings/roles/hooks/useHasSettingsPermission.ts
@@ -1,13 +1,24 @@
 import { currentUserWorkspaceState } from '@/auth/states/currentUserWorkspaceState';
+import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { useRecoilValue } from 'recoil';
+import { WorkspaceActivationStatus } from 'twenty-shared';
 import { SettingsPermissions } from '~/generated/graphql';
 
 export const useHasSettingsPermission = (
   settingsPermission?: SettingsPermissions,
 ) => {
+  const currentWorkspace = useRecoilValue(currentWorkspaceState);
   const currentUserWorkspace = useRecoilValue(currentUserWorkspaceState);
 
   if (!settingsPermission) {
+    return true;
+  }
+
+  if (
+    settingsPermission === SettingsPermissions.WORKSPACE &&
+    currentWorkspace?.activationStatus ===
+      WorkspaceActivationStatus.PENDING_CREATION
+  ) {
     return true;
   }
 


### PR DESCRIPTION
During sign-up, new users setting new workspaces are required to choose a billing plan (30-days or 7 days). They are then redirected to billing.twenty.com to confirm and configure their plan choice. 
Then they are quickly redirected to /settings/billing before being redirected to /create-workspace.

The problem is that even though /create-workspace is not a gated path,  /settings/billing is: it is a path gated by WORKSPACE permission which has not been granted to the user at this stage. therefore the user is not redirected to /create-workspace since they do not reach /settings/billing path but is redirected to the profile page instead. (To see this feature flag must be removed + billing enabled: you can use this branch [from this closed PR](https://github.com/twentyhq/twenty/pull/10570)).

The chosen workaround is to bypass, in the FE, the permission check for WORKSPACE permission if the workspace's activation status is PENDING_CREATION. There is no need for any BE change. 