### PR TITLE
Add PageHeaderOpenCommandMenuButton on Record index page header for command menu v1

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-index/components/RecordIndexPageHeader.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-index/components/RecordIndexPageHeader.tsx
@@ -67,11 +67,10 @@ export const RecordIndexPageHeader = () => {
         ))}
 
       {isCommandMenuV2Enabled && (
-        <>
-          <RecordIndexActionMenu indexId={recordIndexId} />
-          <PageHeaderOpenCommandMenuButton />
-        </>
+        <RecordIndexActionMenu indexId={recordIndexId} />
       )}
+
+      <PageHeaderOpenCommandMenuButton />
     </PageHeader>
   );
 };

--- a/packages/twenty-front/src/modules/ui/layout/page-header/components/PageHeaderOpenCommandMenuButton.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/page-header/components/PageHeaderOpenCommandMenuButton.tsx
@@ -2,6 +2,7 @@ import {
   AnimatedButton,
   IconButton,
   IconDotsVertical,
+  IconX,
   getOsControlSymbol,
   useIsMobile,
 } from 'twenty-ui';
@@ -144,7 +145,7 @@ export const PageHeaderOpenCommandMenuButton = () => {
         />
       ) : (
         <IconButton
-          Icon={IconDotsVertical}
+          Icon={isCommandMenuOpened ? IconX : IconDotsVertical}
           size="medium"
           dataTestId="more-showpage-button"
           accent="default"


### PR DESCRIPTION
The only way to open the command menu in v1 on the index page was through the shortcut, but since important actions (export and see deleted records) have been moved to the command menu, we want an easy way to open it on v1.

https://github.com/user-attachments/assets/b446f385-da69-4dcc-af9d-74d36b52e94f

