### PR TITLE
Update docker-compose to use postgres container

### DIFF
--- a/packages/twenty-docker/docker-compose.yml
+++ b/packages/twenty-docker/docker-compose.yml
@@ -66,14 +66,12 @@ services:
     restart: always
 
   db:
-    image: twentycrm/twenty-postgres-spilo:${TAG:-latest}
+    image: postgres:16
     volumes:
-      - db-data:/home/postgres/pgdata
+      - db-data:/var/lib/postgresql/data
     environment:
-      PGUSER_SUPERUSER: ${PG_DATABASE_USER:-postgres}
-      PGPASSWORD_SUPERUSER: ${PG_DATABASE_PASSWORD:-postgres}
-      ALLOW_NOSSL: "true"
-      SPILO_PROVIDER: "local"
+      POSTGRES_USER: ${PG_DATABASE_USER:-postgres}
+      POSTGRES_PASSWORD: ${PG_DATABASE_PASSWORD:-postgres}
     healthcheck:
       test: pg_isready -U ${PG_DATABASE_USER:-postgres} -h localhost -d postgres
       interval: 5s

--- a/packages/twenty-server/scripts/setup-db.ts
+++ b/packages/twenty-server/scripts/setup-db.ts
@@ -8,11 +8,6 @@ rawDataSource
   .initialize()
   .then(async () => {
     await performQuery(
-      'CREATE EXTENSION IF NOT EXISTS "vector"',
-      'create extension "vector (pgvector)"',
-    );
-
-    await performQuery(
       'CREATE SCHEMA IF NOT EXISTS "public"',
       'create schema "public"',
     );

--- a/packages/twenty-website/src/content/developers/self-hosting/upgrade-guide.mdx
+++ b/packages/twenty-website/src/content/developers/self-hosting/upgrade-guide.mdx
@@ -35,6 +35,38 @@ yarn database:migrate:prod
 yarn command:prod upgrade
 ```
 
+In this version, we have also switched to postgres:16 image in docker-compose.yml.
+
+#### (Option 1) Database migration
+
+Keeping the existing postgres-spilo image is fine, but you will have to freeze the version in your docker-compose.yml to be 0.43.0.
+
+#### (Option 2) Database migration
+
+If you want to migrate your database to the new postgres:16 image, please follow these steps:
+
+1. Dump your database from the old postgres-spilo container
+
+```
+docker exec -it twenty-db-1 sh 
+pg_dump -U {YOUR_POSTGRES_USER} -d {YOUR_POSTGRES_DB} > databases_backup.sql
+exit
+docker cp twenty-db-1:/databases_backup.sql .
+```
+
+Make sure your dump file is not empty.
+
+2. Upgrade your docker-compose.yml to use postgres:16 image as in the [docker-compose.yml](https://raw.githubusercontent.com/twentyhq/twenty/main/packages/twenty-docker/docker-compose.yml) file.
+
+3. Restore the database to the new postgres:16 container
+
+```
+docker cp databases_backup.sql twenty-db-1:/databases_backup.sql
+docker exec -it twenty-db-1 sh
+psql -U {YOUR_POSTGRES_USER} -d {YOUR_POSTGRES_DB} -f databases_backup.sql
+exit
+```
+
 ### v0.41.0 to v0.42.0
 
 Upgrade your Twenty instance to use v0.42.0 image


### PR DESCRIPTION
There is no reason to use a custom image for postgres anymore as we have migrated out pg_graphql postgres extension