### PR TITLE
fix: handle recoil url sync initialization in Firefox

### DIFF
--- a/packages/twenty-front/src/modules/app/components/App.tsx
+++ b/packages/twenty-front/src/modules/app/components/App.tsx
@@ -2,6 +2,7 @@ import { AppRouter } from '@/app/components/AppRouter';
 import { CaptchaProvider } from '@/captcha/components/CaptchaProvider';
 import { ApolloDevLogEffect } from '@/debug/components/ApolloDevLogEffect';
 import { RecoilDebugObserverEffect } from '@/debug/components/RecoilDebugObserver';
+import { SafeRecoilURLSync } from '@/error-handler/components//SafeRecoilURLSync';
 import { AppErrorBoundary } from '@/error-handler/components/AppErrorBoundary';
 import { ExceptionHandlerProvider } from '@/error-handler/components/ExceptionHandlerProvider';
 import { SnackBarProviderScope } from '@/ui/feedback/snack-bar-manager/scopes/SnackBarProviderScope';
@@ -9,7 +10,6 @@ import { i18n } from '@lingui/core';
 import { I18nProvider } from '@lingui/react';
 import { HelmetProvider } from 'react-helmet-async';
 import { RecoilRoot } from 'recoil';
-import { RecoilURLSyncJSON } from 'recoil-sync';
 import { IconsProvider } from 'twenty-ui';
 import { initialI18nActivate } from '~/utils/i18n/initialI18nActivate';
 
@@ -18,7 +18,7 @@ initialI18nActivate();
 export const App = () => {
   return (
     <RecoilRoot>
-      <RecoilURLSyncJSON location={{ part: 'queryParams' }}>
+      <SafeRecoilURLSync>
         <AppErrorBoundary>
           <I18nProvider i18n={i18n}>
             <CaptchaProvider>
@@ -36,7 +36,7 @@ export const App = () => {
             </CaptchaProvider>
           </I18nProvider>
         </AppErrorBoundary>
-      </RecoilURLSyncJSON>
+      </SafeRecoilURLSync>
     </RecoilRoot>
   );
 };

--- a/packages/twenty-front/src/modules/app/components/App.tsx
+++ b/packages/twenty-front/src/modules/app/components/App.tsx
@@ -2,7 +2,7 @@ import { AppRouter } from '@/app/components/AppRouter';
 import { CaptchaProvider } from '@/captcha/components/CaptchaProvider';
 import { ApolloDevLogEffect } from '@/debug/components/ApolloDevLogEffect';
 import { RecoilDebugObserverEffect } from '@/debug/components/RecoilDebugObserver';
-import { SafeRecoilURLSync } from '@/error-handler/components//SafeRecoilURLSync';
+import { SafeRecoilURLSync } from '@/error-handler/components/SafeRecoilURLSync';
 import { AppErrorBoundary } from '@/error-handler/components/AppErrorBoundary';
 import { ExceptionHandlerProvider } from '@/error-handler/components/ExceptionHandlerProvider';
 import { SnackBarProviderScope } from '@/ui/feedback/snack-bar-manager/scopes/SnackBarProviderScope';

--- a/packages/twenty-front/src/modules/error-handler/components/SafeRecoilURLSync.tsx
+++ b/packages/twenty-front/src/modules/error-handler/components/SafeRecoilURLSync.tsx
@@ -6,7 +6,7 @@ export const SafeRecoilURLSync = ({ children }: { children: ReactNode }) => {
   const [isInitializing, setIsInitializing] = useState(true);
 
   useEffect(() => {
-    const handleError = (event: any) => {
+    const handleError = (event: ErrorEvent) => {
       const hasSnapshotError = Boolean(
         event.error?.message?.includes('Snapshot has already been released'),
       );

--- a/packages/twenty-front/src/modules/error-handler/components/SafeRecoilURLSync.tsx
+++ b/packages/twenty-front/src/modules/error-handler/components/SafeRecoilURLSync.tsx
@@ -1,0 +1,57 @@
+import { ReactNode, useEffect, useState } from 'react';
+import { RecoilURLSyncJSON } from 'recoil-sync';
+
+export const SafeRecoilURLSync = ({ children }: { children: ReactNode }) => {
+  const [hasError, setHasError] = useState(false);
+
+  useEffect(() => {
+    // Clear any existing error state on component mount
+    setHasError(false);
+
+    // Set up error handler
+    const handleError = (event: any) => {
+      const hasSnapshotError = Boolean(
+        event.error?.message?.includes('Snapshot has already been released'),
+      );
+
+      if (hasSnapshotError === true) {
+        event.preventDefault(); // Prevent the error from bubbling up
+        setHasError(true);
+      }
+    };
+
+    window.addEventListener('error', handleError);
+
+    // Firefox-specific delay for initialization
+    const isFirefox = Boolean(
+      navigator.userAgent.toLowerCase().includes('firefox'),
+    );
+
+    if (isFirefox === true) {
+      const initializationTimeout = setTimeout(() => {
+        setHasError(false); // Reset error state after delay
+      }, 300);
+
+      return () => {
+        clearTimeout(initializationTimeout);
+        window.removeEventListener('error', handleError);
+      };
+    }
+
+    return () => {
+      window.removeEventListener('error', handleError);
+    };
+  }, []);
+
+  // If we detected an error, render without RecoilURLSyncJSON
+  if (hasError === true) {
+    return children;
+  }
+
+  // Otherwise use RecoilURLSyncJSON
+  return (
+    <RecoilURLSyncJSON location={{ part: 'queryParams' }}>
+      {children}
+    </RecoilURLSyncJSON>
+  );
+};


### PR DESCRIPTION
fixes #10596

https://github.com/user-attachments/assets/addf213f-1a5b-4a01-af10-b7b92995f131


- Add SafeRecoilURLSync wrapper component to handle Firefox-specific timing issues
- Implement error handling for "Snapshot has already been released" errors
- Add 300ms delay for Firefox Recoil state initialization
- Provide fallback rendering without URL sync when needed
