### PR TITLE
fix: filter out empty strings handlers in participant matching

### DIFF
--- a/packages/twenty-server/src/modules/match-participant/match-participant.service.ts
+++ b/packages/twenty-server/src/modules/match-participant/match-participant.service.ts
@@ -52,7 +52,11 @@ export class MatchParticipantService<
 
     const participantIds = participants.map((participant) => participant.id);
     const uniqueParticipantsHandles = [
-      ...new Set(participants.map((participant) => participant.handle)),
+      ...new Set(
+	      participants
+	      .map((participant) => participant.handle)
+	      .filter((handle) => handle)
+      ),
     ];
 
     const personRepository =


### PR DESCRIPTION
If any mail parsed by twenty has empty fields (for example To: or From:), an empty token is added to the search query for matching people in the CRM. If any entry in the CRM has an empty email field, all the emails with an empty token will be associated to that entry.

This modification filter empty tokens before matching..