### PR TITLE
update path for copying pg backup file to docker host folder

### DIFF
--- a/packages/twenty-website/src/content/developers/self-hosting/upgrade-guide.mdx
+++ b/packages/twenty-website/src/content/developers/self-hosting/upgrade-guide.mdx
@@ -51,7 +51,7 @@ If you want to migrate your database to the new postgres:16 image, please follow
 docker exec -it twenty-db-1 sh 
 pg_dump -U {YOUR_POSTGRES_USER} -d {YOUR_POSTGRES_DB} > databases_backup.sql
 exit
-docker cp twenty-db-1:/databases_backup.sql .
+docker cp twenty-db-1:/home/postgres/databases_backup.sql .
 ```
 
 Make sure your dump file is not empty.


### PR DESCRIPTION
### Update of path for copying postgres dumpfile to docker host folder.

The original path stated in the upgrade guide for self hosted docker.
(Option 2) Database migration, contains a wrong path to be able to copy the backup file. The command results in a "there is no such file"
I replaced the  line 
**docker cp twenty-db-1:/databases_backup.sql .**   
with 
**docker cp twenty-db-1:/home/postgres/databases_backup.sql .**  
and it worked as it should.

So this is the edit of the correct path on the user guide on the webpage