### PR TITLE
fix(auth): prevent unintended email validation trigger

### DIFF
--- a/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpWorkspaceScopeFormEffect.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpWorkspaceScopeFormEffect.tsx
@@ -97,6 +97,7 @@ export const SignInUpWorkspaceScopeFormEffect = () => {
     }
 
     if (
+      signInUpStep !== SignInUpStep.Email &&
       isDefined(email) &&
       workspaceAuthProviders.password &&
       loadingStatus === LoadingStatus.Done


### PR DESCRIPTION
Added a condition to skip email validation when the current step is not the email step during the sign-in/sign-up process. This ensures proper flow and avoids unnecessary validation calls.