### PR TITLE
feat(button): add accent prop and disable pointer events

### DIFF
--- a/packages/twenty-ui/src/input/button/components/Button/Button.tsx
+++ b/packages/twenty-ui/src/input/button/components/Button/Button.tsx
@@ -404,7 +404,6 @@ const StyledButtonWrapper = styled.div<
     })()};
   `}
 
-  height: 100%;
   max-width: ${({ loading, theme }) =>
     loading ? `calc(100% - ${theme.spacing(8)})` : 'none'};
   position: relative;

--- a/packages/twenty-ui/src/input/button/components/Button/Button.tsx
+++ b/packages/twenty-ui/src/input/button/components/Button/Button.tsx
@@ -441,6 +441,7 @@ export const Button = ({
     <StyledButtonWrapper
       loading={loading}
       variant={variant}
+      accent={accent}
       inverted={inverted}
       disabled={soon || disabled}
     >

--- a/packages/twenty-ui/src/input/button/components/Button/internal/ButtonIcon.tsx
+++ b/packages/twenty-ui/src/input/button/components/Button/internal/ButtonIcon.tsx
@@ -31,6 +31,8 @@ const StyledIconWrapper = styled.div<{ loading?: boolean }>`
   transform: translateY(-50%);
 
   width: ${({ loading }) => (loading ? 0 : '100%')};
+
+  pointer-events: none;
 `;
 
 const StyledLoader = styled.div<{ loading?: boolean }>`


### PR DESCRIPTION
Added an accent prop to the StyledButtonWrapper for additional styling capabilities. Also disabled pointer events on ButtonIcon to prevent interference during loading states.