### PR TITLE
Fix buttons size

### DIFF
--- a/packages/twenty-ui/src/input/button/components/Button/Button.tsx
+++ b/packages/twenty-ui/src/input/button/components/Button/Button.tsx
@@ -2,13 +2,13 @@ import isPropValid from '@emotion/is-prop-valid';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { IconComponent } from '@ui/display/icon/types/IconComponent';
+import { ButtonHotkeys } from '@ui/input/button/components/Button/internal/ButtonHotKeys';
+import { ButtonIcon } from '@ui/input/button/components/Button/internal/ButtonIcon';
+import { ButtonSoon } from '@ui/input/button/components/Button/internal/ButtonSoon';
 import { useIsMobile } from '@ui/utilities';
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { ButtonText } from './internal/ButtonText';
-import { ButtonIcon } from '@ui/input/button/components/Button/internal/ButtonIcon';
-import { ButtonSoon } from '@ui/input/button/components/Button/internal/ButtonSoon';
-import { ButtonHotkeys } from '@ui/input/button/components/Button/internal/ButtonHotKeys';
 
 export type ButtonSize = 'medium' | 'small';
 export type ButtonPosition = 'standalone' | 'left' | 'middle' | 'right';
@@ -466,6 +466,7 @@ export const Button = ({
         loading={loading}
         onFocus={() => setIsFocused(true)}
         onBlur={() => setIsFocused(false)}
+        size={size}
       >
         <ButtonText hasIcon={!!Icon} title={title} loading={loading} />
         {hotkeys && !isMobile && (


### PR DESCRIPTION
The button size attribute was removed accidentally in this PR https://github.com/twentyhq/twenty/pull/10536, I'm putting it back.
All the buttons were 32px instead of 24px for the small ones.