### PR TITLE
[ENH] Do not fail on missed cache within server commands

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/0-43/0-43-migrate-rich-text-content-patch.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/0-43/0-43-migrate-rich-text-content-patch.command.ts
@@ -230,6 +230,7 @@ export class MigrateRichTextContentPatchCommand extends ActiveOrSuspendedWorkspa
       const workspaceDataSource =
         await this.twentyORMGlobalManager.getDataSourceForWorkspace(
           workspaceId,
+          false,
         );
 
       const rows = await workspaceDataSource.query(

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/0-43/0-43-migrate-rich-text-content-patch.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/0-43/0-43-migrate-rich-text-content-patch.command.ts
@@ -227,10 +227,11 @@ export class MigrateRichTextContentPatchCommand extends ActiveOrSuspendedWorkspa
       const schemaName =
         this.workspaceDataSourceService.getSchemaName(workspaceId);
 
+      const failOnMetadataCacheMiss = false;
       const workspaceDataSource =
         await this.twentyORMGlobalManager.getDataSourceForWorkspace(
           workspaceId,
-          false,
+          failOnMetadataCacheMiss,
         );
 
       const rows = await workspaceDataSource.query(

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/0-43/0-43-update-default-view-record-opening-on-workflow-objects.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/0-43/0-43-update-default-view-record-opening-on-workflow-objects.command.ts
@@ -76,11 +76,12 @@ export class UpdateDefaultViewRecordOpeningOnWorkflowObjectsCommand extends Acti
     workflowObjectMetadataIds: string[],
     workspaceId: string,
   ): Promise<void> {
+    const failOnMetadataCacheMiss = false;
     const viewRepository =
       await this.twentyORMGlobalManager.getRepositoryForWorkspace(
         workspaceId,
         'view',
-        false,
+        failOnMetadataCacheMiss,
       );
 
     await viewRepository.update(

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/0-43/0-43-update-default-view-record-opening-on-workflow-objects.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/0-43/0-43-update-default-view-record-opening-on-workflow-objects.command.ts
@@ -80,6 +80,7 @@ export class UpdateDefaultViewRecordOpeningOnWorkflowObjectsCommand extends Acti
       await this.twentyORMGlobalManager.getRepositoryForWorkspace(
         workspaceId,
         'view',
+        false,
       );
 
     await viewRepository.update(


### PR DESCRIPTION
Avoid critical failure if cache is missed when interacting with the twenty-orm in the upgrade commands