### PR TITLE
Fix settings page container

### DIFF
--- a/packages/twenty-front/src/modules/settings/components/SettingsPageContainer.tsx
+++ b/packages/twenty-front/src/modules/settings/components/SettingsPageContainer.tsx
@@ -23,7 +23,6 @@ const StyledSettingsPageContainer = styled.div<{
     return OBJECT_SETTINGS_WIDTH + 'px';
   }};
   padding-bottom: ${({ theme }) => theme.spacing(20)};
-  height: 100%;
 `;
 
 export const SettingsPageContainer = ({


### PR DESCRIPTION
This was changed in https://github.com/twentyhq/twenty/pull/10556 and was not needed. Reverting to fix the roles page.

## Before

<img width="1155" alt="Screenshot 2025-03-04 at 11 30 30" src="https://github.com/user-attachments/assets/21ae9c02-7c37-46e1-be40-e69ae809ea80" />

## After
<img width="1128" alt="Screenshot 2025-03-04 at 11 30 09" src="https://github.com/user-attachments/assets/956a6222-7925-4aa2-9adb-efd158189368" />

Also checked if security page is still working
<img width="1136" alt="Screenshot 2025-03-04 at 11 30 19" src="https://github.com/user-attachments/assets/0c30101b-51ae-4755-b5a7-d564fb093160" />
