### PR TITLE
[BUG] Object Settings Model tabs list heigh value `0`

### DIFF
--- a/packages/twenty-front/src/modules/settings/components/SettingsPageContainer.tsx
+++ b/packages/twenty-front/src/modules/settings/components/SettingsPageContainer.tsx
@@ -23,7 +23,6 @@ const StyledSettingsPageContainer = styled.div<{
     return OBJECT_SETTINGS_WIDTH + 'px';
   }};
   padding-bottom: ${({ theme }) => theme.spacing(20)};
-  height: 100%;
 `;
 
 export const SettingsPageContainer = ({
@@ -33,6 +32,7 @@ export const SettingsPageContainer = ({
 }) => (
   <ScrollWrapper
     contextProviderName="settingsPageContainer"
+    heightMode='full'
     componentInstanceId={'scroll-wrapper-settings-page-container'}
   >
     <StyledSettingsPageContainer>{children}</StyledSettingsPageContainer>

--- a/packages/twenty-front/src/modules/settings/components/SettingsPageContainer.tsx
+++ b/packages/twenty-front/src/modules/settings/components/SettingsPageContainer.tsx
@@ -32,7 +32,7 @@ export const SettingsPageContainer = ({
 }) => (
   <ScrollWrapper
     contextProviderName="settingsPageContainer"
-    heightMode='full'
+    heightMode="full"
     componentInstanceId={'scroll-wrapper-settings-page-container'}
   >
     <StyledSettingsPageContainer>{children}</StyledSettingsPageContainer>


### PR DESCRIPTION
# Introduction
While working on https://github.com/twentyhq/core-team-issues/issues/355 encountered a recent regression:
![image](https://github.com/user-attachments/assets/654349a0-fd3d-4e17-a503-b942165f1771)

I honestly cannot explain this regression, should take time to do some commits dichotomy in order to identify the problematic one but it feels overkill

## Remarks
- Modified a common components please while reviewing have a look to other of its invokation too ( others settings page )