### PR TITLE
Let pass a Nodemailer SMTP config string for advanced options

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/email/drivers/smtp.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/email/drivers/smtp.driver.ts
@@ -1,6 +1,6 @@
 import { Logger } from '@nestjs/common';
 
-import { createTransport, Transporter, SendMailOptions } from 'nodemailer';
+import { createTransport, SendMailOptions, Transporter } from 'nodemailer';
 import SMTPConnection from 'nodemailer/lib/smtp-connection';
 
 import { EmailDriver } from 'src/engine/core-modules/email/drivers/interfaces/email-driver.interface';
@@ -9,7 +9,7 @@ export class SmtpDriver implements EmailDriver {
   private readonly logger = new Logger(SmtpDriver.name);
   private transport: Transporter;
 
-  constructor(options: SMTPConnection.Options) {
+  constructor(options: SMTPConnection.Options | string) {
     this.transport = createTransport(options);
   }
 

--- a/packages/twenty-server/src/engine/core-modules/email/email.module-factory.ts
+++ b/packages/twenty-server/src/engine/core-modules/email/email.module-factory.ts
@@ -15,6 +15,10 @@ export const emailModuleFactory = (
       return;
     }
     case EmailDriver.Smtp: {
+      const smtpConfigString = environmentService.get('EMAIL_SMTP');
+      if (smtpConfigString) {
+        return smtpConfigString;
+      }
       const host = environmentService.get('EMAIL_SMTP_HOST');
       const port = environmentService.get('EMAIL_SMTP_PORT');
       const user = environmentService.get('EMAIL_SMTP_USER');

--- a/packages/twenty-server/src/engine/core-modules/email/interfaces/email.interface.ts
+++ b/packages/twenty-server/src/engine/core-modules/email/interfaces/email.interface.ts
@@ -7,7 +7,7 @@ export enum EmailDriver {
   Smtp = 'smtp',
 }
 
-export type EmailModuleOptions = SMTPConnection.Options | undefined;
+export type EmailModuleOptions = SMTPConnection.Options | string | undefined;
 
 export type EmailModuleAsyncOptions = {
   useFactory: (...args: any[]) => EmailModuleOptions;

--- a/packages/twenty-server/src/engine/core-modules/environment/environment-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/environment/environment-variables.ts
@@ -285,6 +285,12 @@ export class EnvironmentVariables {
 
   @EnvironmentVariablesMetadata({
     group: EnvironmentVariablesGroup.EmailSettings,
+    description: 'SMTP config string for sending emails',
+  })
+  EMAIL_SMTP: string;
+
+  @EnvironmentVariablesMetadata({
+    group: EnvironmentVariablesGroup.EmailSettings,
     description: 'SMTP host for sending emails',
   })
   EMAIL_SMTP_HOST: string;


### PR DESCRIPTION
Hi,

For my self-hosting, I need to pass advanced options (`secure=false` and `ignoreTLS=true`) for my mail sending to work.

Is it possible to allow to pass a configuration string as env variable (in my PR named `EMAIL_SMTP`)?

Calcom [does that](https://github.com/calcom/cal.com/blob/d38b35b6262e95a70326f2c78e33d493eff7fca7/packages/lib/serverConfig.ts#L23) with Nodemailer, and it is handy for self-hosters.

I'm sorry I was not able to test the change in dev, as I don't have time to setup a local dev env atm.

Thanks for the great tool.