### PR TITLE
Fix REST API when metadata cache not found

### DIFF
--- a/packages/twenty-server/src/engine/api/rest/core/query-builder/core-query-builder.module.ts
+++ b/packages/twenty-server/src/engine/api/rest/core/query-builder/core-query-builder.module.ts
@@ -4,10 +4,16 @@ import { CoreQueryBuilderFactory } from 'src/engine/api/rest/core/query-builder/
 import { coreQueryBuilderFactories } from 'src/engine/api/rest/core/query-builder/factories/factories';
 import { AuthModule } from 'src/engine/core-modules/auth/auth.module';
 import { DomainManagerModule } from 'src/engine/core-modules/domain-manager/domain-manager.module';
+import { WorkspaceMetadataCacheModule } from 'src/engine/metadata-modules/workspace-metadata-cache/workspace-metadata-cache.module';
 import { WorkspaceCacheStorageModule } from 'src/engine/workspace-cache-storage/workspace-cache-storage.module';
 
 @Module({
-  imports: [AuthModule, DomainManagerModule, WorkspaceCacheStorageModule],
+  imports: [
+    AuthModule,
+    DomainManagerModule,
+    WorkspaceCacheStorageModule,
+    WorkspaceMetadataCacheModule,
+  ],
   providers: [...coreQueryBuilderFactories, CoreQueryBuilderFactory],
   exports: [CoreQueryBuilderFactory],
 })


### PR DESCRIPTION
## Context
When REST API calls fail due to metadata cache version not found, we throw an exception without trying to recover.
In Graphql implementation, the exception is thrown after recomputing the cache. This PR implements the same logic for REST for users only user the REST API.