### PR TITLE
[permissions] Prepare for roll-out

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/0-44/0-44-initialize-permissions.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/0-44/0-44-initialize-permissions.command.ts
@@ -215,6 +215,7 @@ export class InitializePermissionsCommand extends ActiveOrSuspendedWorkspacesMig
       if (options.dryRun) {
         return;
       }
+
       await this.userRoleService.assignRoleToUserWorkspace({
         roleId: adminRoleId,
         userWorkspaceId: userWorkspace.id,

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/0-44/0-44-initialize-permissions.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/0-44/0-44-initialize-permissions.command.ts
@@ -162,7 +162,7 @@ export class InitializePermissionsCommand extends ActiveOrSuspendedWorkspacesMig
 
     this.logger.log(
       chalk.green(
-        `Setting member role as default role ${options.dryRun ? '(dry run)' : ''}`,
+        `Setting admin role as default role ${options.dryRun ? '(dry run)' : ''}`,
       ),
     );
 

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/0-44/0-44-initialize-permissions.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/0-44/0-44-initialize-permissions.command.ts
@@ -219,7 +219,7 @@ export class InitializePermissionsCommand extends ActiveOrSuspendedWorkspacesMig
       );
 
       if (options.dryRun) {
-        return;
+        continue;
       }
 
       await this.userRoleService.assignRoleToUserWorkspace({

--- a/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.ts
@@ -31,7 +31,6 @@ import {
 } from 'src/engine/core-modules/auth/types/signInUp.type';
 import { DomainManagerService } from 'src/engine/core-modules/domain-manager/services/domain-manager.service';
 import { EnvironmentService } from 'src/engine/core-modules/environment/environment.service';
-import { FeatureFlagKey } from 'src/engine/core-modules/feature-flag/enums/feature-flag-key.enum';
 import { FeatureFlagService } from 'src/engine/core-modules/feature-flag/services/feature-flag.service';
 import { FileUploadService } from 'src/engine/core-modules/file/file-upload/services/file-upload.service';
 import { OnboardingService } from 'src/engine/core-modules/onboarding/onboarding.service';
@@ -273,12 +272,7 @@ export class SignInUpService {
       await this.activateOnboardingForUser(user, params.workspace);
     }
 
-    const isPermissionsEnabled = await this.featureFlagService.isFeatureEnabled(
-      FeatureFlagKey.IsPermissionsEnabled,
-      params.workspace.id,
-    );
-
-    if (isPermissionsEnabled && params.workspace.defaultRoleId) {
+    if (params.workspace.defaultRoleId) {
       await this.userRoleService.assignRoleToUserWorkspace({
         workspaceId: params.workspace.id,
         userWorkspaceId: userWorkspace.id,

--- a/packages/twenty-server/src/engine/core-modules/environment/environment-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/environment/environment-variables.ts
@@ -863,16 +863,6 @@ export class EnvironmentVariables {
   @EnvironmentVariablesMetadata({
     group: EnvironmentVariablesGroup.Other,
     description:
-      'Use as a feature flag for the new permission feature we are working on.',
-  })
-  @CastToBoolean()
-  @IsOptional()
-  @IsBoolean()
-  PERMISSIONS_ENABLED = false;
-
-  @EnvironmentVariablesMetadata({
-    group: EnvironmentVariablesGroup.Other,
-    description:
       'Number of inactive days before sending a deletion warning for workspaces. Used in the workspace deletion cron job to determine when to send warning emails.',
   })
   @CastToPositiveNumber()

--- a/packages/twenty-server/src/engine/metadata-modules/permissions/permissions.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/permissions/permissions.service.ts
@@ -145,10 +145,6 @@ export class PermissionsService {
     return roleOfUserWorkspace?.[roleColumn] === true;
   }
 
-  public async isPermissionsEnabled(): Promise<boolean> {
-    return this.environmentService.get('PERMISSIONS_ENABLED') === true;
-  }
-
   private getRoleColumnForRequiredPermission(
     requiredPermission: PermissionsOnAllObjectRecords,
   ): keyof RoleEntity {

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-manager.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-manager.service.ts
@@ -99,12 +99,8 @@ export class WorkspaceManagerService {
     );
 
     const permissionsEnabledStart = performance.now();
-    const permissionsEnabled =
-      await this.permissionsService.isPermissionsEnabled();
 
-    if (permissionsEnabled === true) {
-      await this.initPermissions({ workspaceId, userId });
-    }
+    await this.initPermissions({ workspaceId, userId });
 
     const permissionsEnabledEnd = performance.now();
 
@@ -168,12 +164,7 @@ export class WorkspaceManagerService {
       dataSourceId: dataSourceMetadata.id,
     });
 
-    const permissionsEnabled =
-      await this.permissionsService.isPermissionsEnabled();
-
-    if (permissionsEnabled === true) {
-      await this.initPermissionsDev(workspaceId);
-    }
+    await this.initPermissionsDev(workspaceId);
   }
 
   /**

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-manager.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-manager.service.ts
@@ -287,12 +287,13 @@ export class WorkspaceManagerService {
       roleId: adminRole.id,
     });
 
-    const memberRole = await this.roleService.createMemberRole({
+    await this.roleService.createMemberRole({
       workspaceId,
     });
 
+    // Temporary - after permissions are rolled-out we will set member role as the default role
     await this.workspaceRepository.update(workspaceId, {
-      defaultRoleId: memberRole.id,
+      defaultRoleId: adminRole.id,
     });
   }
 


### PR DESCRIPTION
Closes https://github.com/twentyhq/core-team-issues/issues/469 and https://github.com/twentyhq/core-team-issues/issues/500

In this PR
1. stop conditioning permission initialization for a workspace to env variable value. Instead we want to create and assign permissions and roles in all new workspaces. For now that will be totally silent. 
2. temporarily, the default role is set to the admin role for new workspaces. it will also be the case for existing workspaces through the backfill command. Member role is still being created though. (when we will do the final roll-out we will update this so that future workspaces have the member role as default role. our goal here is not to break any current behaviour for users, that today have all have the equivalent of admin rights).