### PR TITLE
fix:  redirecting of companies while disable

### DIFF
--- a/packages/twenty-front/src/modules/navigation/hooks/useDefaultHomePagePath.ts
+++ b/packages/twenty-front/src/modules/navigation/hooks/useDefaultHomePagePath.ts
@@ -36,9 +36,13 @@ export const useDefaultHomePagePath = () => {
   );
 
   const firstObjectPathInfo = useMemo<ObjectPathInfo | null>(() => {
+    if (alphaSortedActiveObjectMetadataItems.length === 0) {
+      return null;
+    }
+
     const [firstObjectMetadataItem] = alphaSortedActiveObjectMetadataItems;
 
-    if (!isDefined(firstObjectMetadataItem)) {
+    if (!isDefined(firstObjectMetadataItem) || !firstObjectMetadataItem.isActive) {
       return null;
     }
 
@@ -76,8 +80,8 @@ export const useDefaultHomePagePath = () => {
       return AppPath.SignInUp;
     }
 
-    if (!isDefined(defaultObjectPathInfo)) {
-      return AppPath.NotFound;
+    if (!isDefined(defaultObjectPathInfo) || !isDefined(defaultObjectPathInfo.objectMetadataItem)) {
+      return `${AppPath.SettingsCatchAll.replace('/*', '')}/objects`;
     }
 
     const namePlural = defaultObjectPathInfo.objectMetadataItem?.namePlural;


### PR DESCRIPTION
Fixes : #10064 

## Problem
When a user disables an object (such as the Companies object) in the system they should not be redirected to that object's index page when navigating to the root URL (/). However the current implementation incorrectly redirects users to the index page of disabled objects when they are still the first alphabetically sorted item.


## Solution

This PR modifies the default homepage selection logic to correctly handle disabled objects. Now when a user disables all objects or the alphabetically first object (like Companies) the system will:

1. Properly check if there are any active objects at all before attempting to redirect
2. Double check that the selected object is truly active before redirecting
3. Redirect to the settings/objects page when no active objects are available instead of showing a "Not Found" page

## Changes

1. Enhanced the useDefaultHomePagePath hook to add additional validation for active objects
2. Added an initial check for empty alphaSortedActiveObjectMetadataItems array
3. Improved validation for the first object to ensure it's definitely active
4. Modified the fallback behavior to redirect to the settings objects page when no active objects are available