### PR TITLE
refactor(custom-domain): simplify record mapping logic

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/domain-manager/services/custom-domain.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/domain-manager/services/custom-domain.service.spec.ts
@@ -123,6 +123,36 @@ describe('CustomDomainService', () => {
         hostname: customDomain,
       });
     });
+    it('should return even if no record found', async () => {
+      const customDomain = 'example.com';
+      const mockResult = {
+        id: 'custom-id',
+        hostname: customDomain,
+        ownership_verification: undefined,
+        verification_errors: [],
+      };
+      const cloudflareMock = {
+        customHostnames: {
+          list: jest.fn().mockResolvedValueOnce({ result: [mockResult] }),
+        },
+      };
+
+      jest.spyOn(environmentService, 'get').mockReturnValue('test-zone-id');
+
+      jest
+        .spyOn(domainManagerService, 'getFrontUrl')
+        .mockReturnValue(new URL('https://front.domain'));
+      (customDomainService as any).cloudflareClient = cloudflareMock;
+
+      const result =
+        await customDomainService.getCustomDomainDetails(customDomain);
+
+      expect(result).toEqual({
+        id: 'custom-id',
+        customDomain: customDomain,
+        records: expect.any(Array),
+      });
+    });
 
     it('should return domain details if a single result is found', async () => {
       const customDomain = 'example.com';

--- a/packages/twenty-server/src/engine/core-modules/domain-manager/services/custom-domain.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/domain-manager/services/custom-domain.service.ts
@@ -79,43 +79,43 @@ export class CustomDomainService {
           response.result[0].ownership_verification,
           ...(response.result[0].ssl?.validation_records ?? []),
         ]
-          .map<CustomDomainValidRecords['records'][0] | undefined>(
-            (record: Record<string, string>) => {
-              if (
-                'txt_name' in record &&
-                'txt_value' in record &&
-                record.txt_name &&
-                record.txt_value
-              ) {
-                return {
-                  validationType: 'ssl' as const,
-                  type: 'txt' as const,
-                  status:
-                    !response.result[0].ssl.status ||
-                    response.result[0].ssl.status.startsWith('pending')
-                      ? 'pending'
-                      : response.result[0].ssl.status,
-                  key: record.txt_name,
-                  value: record.txt_value,
-                };
-              }
+          .map<CustomDomainValidRecords['records'][0] | undefined>((record) => {
+            if (!record) return;
 
-              if (
-                'type' in record &&
-                record.type === 'txt' &&
-                record.value &&
-                record.name
-              ) {
-                return {
-                  validationType: 'ownership' as const,
-                  type: 'txt' as const,
-                  status: response.result[0].status ?? 'pending',
-                  key: record.name,
-                  value: record.value,
-                };
-              }
-            },
-          )
+            if (
+              'txt_name' in record &&
+              'txt_value' in record &&
+              record.txt_name &&
+              record.txt_value
+            ) {
+              return {
+                validationType: 'ssl' as const,
+                type: 'txt' as const,
+                status:
+                  !response.result[0].ssl.status ||
+                  response.result[0].ssl.status.startsWith('pending')
+                    ? 'pending'
+                    : response.result[0].ssl.status,
+                key: record.txt_name,
+                value: record.txt_value,
+              };
+            }
+
+            if (
+              'type' in record &&
+              record.type === 'txt' &&
+              record.value &&
+              record.name
+            ) {
+              return {
+                validationType: 'ownership' as const,
+                type: 'txt' as const,
+                status: response.result[0].status ?? 'pending',
+                key: record.name,
+                value: record.value,
+              };
+            }
+          })
           .filter(isDefined)
           .concat([
             {


### PR DESCRIPTION
Refactored the mapping logic in custom-domain.service to improve readability and ensure proper handling of undefined records. This change introduces an early return for nullish records and maintains existing validation behavior.