### PR TITLE
fix : cursor scrolling behaviour

### DIFF
--- a/packages/twenty-front/src/modules/ui/utilities/scroll/components/ScrollWrapper.tsx
+++ b/packages/twenty-front/src/modules/ui/utilities/scroll/components/ScrollWrapper.tsx
@@ -4,8 +4,8 @@ import { useOverlayScrollbars } from 'overlayscrollbars-react';
 import { useEffect, useRef } from 'react';
 
 import {
-  ContextProviderName,
-  getContextByProviderName,
+    ContextProviderName,
+    getContextByProviderName,
 } from '@/ui/utilities/scroll/contexts/ScrollWrapperContexts';
 
 import { ScrollWrapperComponentInstanceContext } from '@/ui/utilities/scroll/states/contexts/ScrollWrapperComponentInstanceContext';
@@ -147,9 +147,11 @@ export const ScrollWrapper = ({
 
         if (scrollbarVertical !== null) {
           scrollbarVertical.track.dataset.selectDisable = 'true';
+          scrollbarVertical.handle.dataset.selectDisable = 'true';
         }
         if (scrollbarHorizontal !== null) {
           scrollbarHorizontal.track.dataset.selectDisable = 'true';
+          scrollbarHorizontal.handle.dataset.selectDisable = 'true';
         }
         setScrollBottom(
           target.scrollHeight - target.clientHeight - target.scrollTop,
@@ -161,6 +163,9 @@ export const ScrollWrapper = ({
         // Hide vertical scrollbar by default
         if (scrollbarVertical !== null) {
           scrollbarVertical.track.style.visibility = 'hidden';
+          // Ensure data-select-disable is set on both track and handle
+          scrollbarVertical.track.dataset.selectDisable = 'true';
+          scrollbarVertical.handle.dataset.selectDisable = 'true';
         }
 
         // Show vertical scrollbar based on scroll direction


### PR DESCRIPTION
fixes : #6773 

## Issue Description
When scrolling through tables with many records (100+), using the scrollbar would inadvertently select table rows. This happened because while the scrollbar track had the data-select-disable="true" attribute, the scrollbar handle (the part users actually drag) did not have this attribute, allowing it to trigger the drag selection functionality.

## Changes Made

Added the data-select-disable="true" attribute to the scrollbar handles (both vertical and horizontal) in the ScrollWrapper component.
Updated both the updated event handler (initial setup) and the scroll event handler to ensure this attribute is consistently applied.
No changes to existing functionality or behavior outside of fixing the scrollbar interaction.

## Technical Details

The issue occurred in the ScrollWrapper component where the data-select-disable="true" attribute was correctly being applied to the scrollbar tracks .

https://github.com/user-attachments/assets/0ec36d8e-fe1f-4a52-a957-33af0ec08536

