### PR TITLE
chore: Unify Label Styles Across App #6389

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ dump.rdb
 /flake.nix
 
 .crowdin.yml
+
+docker-compose.yml

--- a/packages/twenty-front/src/modules/ui/input/components/InputHint.tsx
+++ b/packages/twenty-front/src/modules/ui/input/components/InputHint.tsx
@@ -1,8 +1,7 @@
 import styled from '@emotion/styled';
+import { Label } from 'twenty-ui';
 
-const StyledInputHint = styled.div`
-  color: ${({ theme }) => theme.font.color.light};
-  font-size: ${({ theme }) => theme.font.size.xs};
+const StyledInputHint = styled(Label)`
   font-weight: ${({ theme }) => theme.font.weight.regular};
   margin-top: ${({ theme }) => theme.spacing(0.5)};
 `;

--- a/packages/twenty-front/src/modules/ui/input/components/InputLabel.tsx
+++ b/packages/twenty-front/src/modules/ui/input/components/InputLabel.tsx
@@ -1,10 +1,9 @@
 import styled from '@emotion/styled';
+import { Label } from 'twenty-ui';
 
-const StyledLabel = styled.label`
-  color: ${({ theme }) => theme.font.color.light};
-  font-size: ${({ theme }) => theme.font.size.xs};
-  font-weight: ${({ theme }) => theme.font.weight.semiBold};
+const StyledInputLabel = styled(Label)`
+  display: block;
   margin-bottom: ${({ theme }) => theme.spacing(1)};
 `;
 
-export const InputLabel = StyledLabel;
+export const InputLabel = StyledInputLabel;

--- a/packages/twenty-front/src/modules/ui/layout/dropdown/components/StyledDropdownMenuSubheader.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/dropdown/components/StyledDropdownMenuSubheader.tsx
@@ -1,10 +1,9 @@
 import styled from '@emotion/styled';
+import { Label } from 'twenty-ui';
 
-export const StyledDropdownMenuSubheader = styled.div`
+export const StyledDropdownMenuSubheader = styled(Label)`
   background-color: ${({ theme }) => theme.background.transparent.lighter};
-  color: ${({ theme }) => theme.font.color.light};
   font-size: ${({ theme }) => theme.font.size.xxs};
-  font-weight: ${({ theme }) => theme.font.weight.semiBold};
   padding: ${({ theme }) => `${theme.spacing(1)} ${theme.spacing(2)}`};
   text-transform: uppercase;
   width: 100%;

--- a/packages/twenty-front/src/modules/ui/layout/table/components/TableSection.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/table/components/TableSection.tsx
@@ -1,7 +1,7 @@
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { ReactNode, useState } from 'react';
-import { IconChevronDown, IconChevronUp } from 'twenty-ui';
+import { IconChevronDown, IconChevronUp, Label } from 'twenty-ui';
 import { TableBody } from './TableBody';
 
 type TableSectionProps = {
@@ -14,15 +14,16 @@ const StyledSectionHeader = styled.div<{ isExpanded: boolean }>`
   align-items: center;
   background-color: ${({ theme }) => theme.background.transparent.lighter};
   border-bottom: 1px solid ${({ theme }) => theme.border.color.light};
-  color: ${({ theme }) => theme.font.color.light};
   cursor: pointer;
   display: flex;
-  font-size: ${({ theme }) => theme.font.size.xs};
-  font-weight: ${({ theme }) => theme.font.weight.semiBold};
   height: ${({ theme }) => theme.spacing(6)};
   justify-content: space-between;
   padding: 0 ${({ theme }) => theme.spacing(2)};
   text-align: left;
+  text-transform: uppercase;
+`;
+
+const StyledHeaderLabel = styled(Label)`
   text-transform: uppercase;
 `;
 
@@ -44,23 +45,26 @@ export const TableSection = ({
   isInitiallyExpanded = true,
   title,
 }: TableSectionProps) => {
-  const theme = useTheme();
   const [isExpanded, setIsExpanded] = useState(isInitiallyExpanded);
+  const theme = useTheme();
 
   const handleToggleSection = () =>
     setIsExpanded((previousIsExpanded) => !previousIsExpanded);
 
   return (
     <>
-      <StyledSectionHeader
-        isExpanded={isExpanded}
-        onClick={handleToggleSection}
-      >
-        {title}
+      <StyledSectionHeader isExpanded={isExpanded} onClick={handleToggleSection}>
+        <StyledHeaderLabel>{title}</StyledHeaderLabel>
         {isExpanded ? (
-          <IconChevronUp size={theme.icon.size.sm} />
+          <IconChevronUp
+            size={theme.icon.size.md}
+            stroke={theme.icon.stroke.sm}
+          />
         ) : (
-          <IconChevronDown size={theme.icon.size.sm} />
+          <IconChevronDown
+            size={theme.icon.size.md}
+            stroke={theme.icon.stroke.sm}
+          />
         )}
       </StyledSectionHeader>
       <StyledSection isExpanded={isExpanded}>


### PR DESCRIPTION
chore : #6389 

## Changed
I refactored the InputLabel component to use the standardized Label component from the twenty-ui package instead of creating a custom-styled label element.

## Label used and functionalities remain same 
It still applies the margin-bottom that was in the original component
It keeps the component as a styled component that can be used the same way
I added display: block since we're now extending a div-based component rather than a label element
The light color, font size and font weight styling now comes from the standardized Label component