### PR TITLE
Added aggregate operations for boolean fields

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-board/record-board-column/utils/getAggregateOperationLabel.ts
+++ b/packages/twenty-front/src/modules/object-record/record-board/record-board-column/utils/getAggregateOperationLabel.ts
@@ -27,6 +27,10 @@ export const getAggregateOperationLabel = (
       return t`Percent empty`;
     case AGGREGATE_OPERATIONS.percentageNotEmpty:
       return t`Percent not empty`;
+    case AGGREGATE_OPERATIONS.countTrue:
+      return t`Count true`;
+    case AGGREGATE_OPERATIONS.countFalse:
+      return t`Count false`;
     case DATE_AGGREGATE_OPERATIONS.earliest:
       return t`Earliest date`;
     case DATE_AGGREGATE_OPERATIONS.latest:

--- a/packages/twenty-front/src/modules/object-record/record-board/record-board-column/utils/getAggregateOperationShortLabel.ts
+++ b/packages/twenty-front/src/modules/object-record/record-board/record-board-column/utils/getAggregateOperationShortLabel.ts
@@ -25,6 +25,10 @@ export const getAggregateOperationShortLabel = (
       return msg`Not empty`;
     case AGGREGATE_OPERATIONS.countUniqueValues:
       return msg`Unique`;
+    case AGGREGATE_OPERATIONS.countTrue:
+      return msg`True`;
+    case AGGREGATE_OPERATIONS.countFalse:
+      return msg`False`;
     case DATE_AGGREGATE_OPERATIONS.earliest:
       return msg`Earliest`;
     case DATE_AGGREGATE_OPERATIONS.latest:

--- a/packages/twenty-front/src/modules/object-record/record-table/constants/AggregateOperations.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/constants/AggregateOperations.ts
@@ -9,4 +9,6 @@ export enum AGGREGATE_OPERATIONS {
   countUniqueValues = 'COUNT_UNIQUE_VALUES',
   percentageEmpty = 'PERCENTAGE_EMPTY',
   percentageNotEmpty = 'PERCENTAGE_NOT_EMPTY',
+  countTrue = 'COUNT_TRUE',
+  countFalse = 'COUNT_FALSE',
 }

--- a/packages/twenty-front/src/modules/object-record/record-table/constants/FieldTypesAvailableForNonStandardAggregateOperation.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/constants/FieldTypesAvailableForNonStandardAggregateOperation.ts
@@ -27,4 +27,10 @@ export const FIELD_TYPES_AVAILABLE_FOR_NON_STANDARD_AGGREGATE_OPERATION = {
     FieldMetadataType.DATE_TIME,
     FieldMetadataType.DATE,
   ],
+  [AGGREGATE_OPERATIONS.countTrue]: [
+    FieldMetadataType.BOOLEAN,
+  ],
+  [AGGREGATE_OPERATIONS.countFalse]: [
+    FieldMetadataType.BOOLEAN,
+  ],
 };

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-footer/components/RecordTableColumnAggregateFooterDropdownContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-footer/components/RecordTableColumnAggregateFooterDropdownContent.tsx
@@ -27,7 +27,7 @@ export const RecordTableColumnAggregateFooterDropdownContent = () => {
   switch (currentContentId) {
     case 'moreAggregateOperationOptions': {
       const aggregateOperations = availableAggregateOperations.filter(
-        (aggregateOperation) =>
+        (aggregateOperation): aggregateOperation is AGGREGATE_OPERATIONS =>
           !STANDARD_AGGREGATE_OPERATION_OPTIONS.includes(
             aggregateOperation as AGGREGATE_OPERATIONS,
           ),
@@ -42,7 +42,7 @@ export const RecordTableColumnAggregateFooterDropdownContent = () => {
     }
     case 'countAggregateOperationsOptions': {
       const aggregateOperations = availableAggregateOperations.filter(
-        (aggregateOperation) =>
+        (aggregateOperation): aggregateOperation is AGGREGATE_OPERATIONS =>
           COUNT_AGGREGATE_OPERATION_OPTIONS.includes(
             aggregateOperation as AGGREGATE_OPERATIONS,
           ),
@@ -56,7 +56,7 @@ export const RecordTableColumnAggregateFooterDropdownContent = () => {
     }
     case 'percentAggregateOperationsOptions': {
       const aggregateOperations = availableAggregateOperations.filter(
-        (aggregateOperation) =>
+        (aggregateOperation): aggregateOperation is AGGREGATE_OPERATIONS =>
           PERCENT_AGGREGATE_OPERATION_OPTIONS.includes(
             aggregateOperation as AGGREGATE_OPERATIONS,
           ),
@@ -70,7 +70,7 @@ export const RecordTableColumnAggregateFooterDropdownContent = () => {
     }
     case 'booleanAggregateOperationsOptions': {
       const aggregateOperations = availableAggregateOperations.filter(
-        (aggregateOperation) =>
+        (aggregateOperation): aggregateOperation is AGGREGATE_OPERATIONS =>
           BOOLEAN_AGGREGATE_OPERATION_OPTIONS.includes(
             aggregateOperation as AGGREGATE_OPERATIONS,
           ),
@@ -84,7 +84,7 @@ export const RecordTableColumnAggregateFooterDropdownContent = () => {
     }
     case 'datesAggregateOperationsOptions': {
       const aggregateOperations = availableAggregateOperations.filter(
-        (aggregateOperation) =>
+        (aggregateOperation): aggregateOperation is DATE_AGGREGATE_OPERATIONS =>
           DATE_AGGREGATE_OPERATION_OPTIONS.includes(
             aggregateOperation as DATE_AGGREGATE_OPERATIONS,
           ),

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-footer/components/RecordTableColumnAggregateFooterDropdownContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-footer/components/RecordTableColumnAggregateFooterDropdownContent.tsx
@@ -4,6 +4,7 @@ import { DATE_AGGREGATE_OPERATIONS } from '@/object-record/record-table/constant
 import { RecordTableColumnAggregateFooterDropdownSubmenuContent } from '@/object-record/record-table/record-table-footer/components/RecordTableColumnAggregateDropdownSubmenuContent';
 import { RecordTableColumnAggregateFooterDropdownContext } from '@/object-record/record-table/record-table-footer/components/RecordTableColumnAggregateFooterDropdownContext';
 import { RecordTableColumnAggregateFooterMenuContent } from '@/object-record/record-table/record-table-footer/components/RecordTableColumnAggregateFooterMenuContent';
+import { BOOLEAN_AGGREGATE_OPERATION_OPTIONS } from '@/object-record/record-table/record-table-footer/constants/booleanAggregateOperationOptions';
 import { COUNT_AGGREGATE_OPERATION_OPTIONS } from '@/object-record/record-table/record-table-footer/constants/countAggregateOperationOptions';
 import { DATE_AGGREGATE_OPERATION_OPTIONS } from '@/object-record/record-table/record-table-footer/constants/dateAggregateOperationOptions';
 import { PERCENT_AGGREGATE_OPERATION_OPTIONS } from '@/object-record/record-table/record-table-footer/constants/percentAggregateOperationOptions';
@@ -64,6 +65,20 @@ export const RecordTableColumnAggregateFooterDropdownContent = () => {
         <RecordTableColumnAggregateFooterDropdownSubmenuContent
           aggregateOperations={aggregateOperations}
           title={t`Percent`}
+        />
+      );
+    }
+    case 'booleanAggregateOperationsOptions': {
+      const aggregateOperations = availableAggregateOperations.filter(
+        (aggregateOperation) =>
+          BOOLEAN_AGGREGATE_OPERATION_OPTIONS.includes(
+            aggregateOperation as AGGREGATE_OPERATIONS,
+          ),
+      );
+      return (
+        <RecordTableColumnAggregateFooterDropdownSubmenuContent
+          aggregateOperations={aggregateOperations}
+          title={t`Boolean`}
         />
       );
     }

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-footer/components/RecordTableColumnAggregateFooterMenuContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-footer/components/RecordTableColumnAggregateFooterMenuContent.tsx
@@ -45,6 +45,7 @@ export const RecordTableColumnAggregateFooterMenuContent = () => {
   );
 
   const fieldIsDateKind = isFieldMetadataDateKind(fieldMetadataType);
+  const fieldIsBoolean = fieldMetadataType === FieldMetadataType.BOOLEAN;
 
   const nonStandardAvailableAggregateOperation =
     availableAggregateOperation.filter((aggregateOperation) =>
@@ -87,6 +88,15 @@ export const RecordTableColumnAggregateFooterMenuContent = () => {
               onContentChange('datesAggregateOperationsOptions');
             }}
             text={t`Date`}
+            hasSubMenu
+          />
+        )}
+        {fieldIsBoolean && (
+          <MenuItem
+            onClick={() => {
+              onContentChange('booleanAggregateOperationsOptions');
+            }}
+            text={t`Boolean`}
             hasSubMenu
           />
         )}

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-footer/constants/booleanAggregateOperationOptions.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-footer/constants/booleanAggregateOperationOptions.ts
@@ -1,0 +1,6 @@
+import { AGGREGATE_OPERATIONS } from '@/object-record/record-table/constants/AggregateOperations';
+
+export const BOOLEAN_AGGREGATE_OPERATION_OPTIONS = [
+  AGGREGATE_OPERATIONS.countTrue,
+  AGGREGATE_OPERATIONS.countFalse,
+]; 

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-footer/constants/booleanAggregateOperationOptions.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-footer/constants/booleanAggregateOperationOptions.ts
@@ -3,4 +3,4 @@ import { AGGREGATE_OPERATIONS } from '@/object-record/record-table/constants/Agg
 export const BOOLEAN_AGGREGATE_OPERATION_OPTIONS = [
   AGGREGATE_OPERATIONS.countTrue,
   AGGREGATE_OPERATIONS.countFalse,
-]; 
+];

--- a/packages/twenty-front/src/modules/object-record/types/AggregateOperationsOmittingStandardOperations.ts
+++ b/packages/twenty-front/src/modules/object-record/types/AggregateOperationsOmittingStandardOperations.ts
@@ -8,4 +8,6 @@ export type AggregateOperationsOmittingStandardOperations = Exclude<
   | AGGREGATE_OPERATIONS.countUniqueValues
   | AGGREGATE_OPERATIONS.percentageEmpty
   | AGGREGATE_OPERATIONS.percentageNotEmpty
+  | AGGREGATE_OPERATIONS.countTrue
+  | AGGREGATE_OPERATIONS.countFalse
 >;

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/constants/aggregate-operations.constant.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/constants/aggregate-operations.constant.ts
@@ -9,4 +9,6 @@ export enum AGGREGATE_OPERATIONS {
   countNotEmpty = 'COUNT_NOT_EMPTY',
   percentageEmpty = 'PERCENTAGE_EMPTY',
   percentageNotEmpty = 'PERCENTAGE_NOT_EMPTY',
+  countTrue = 'COUNT_TRUE',
+  countFalse = 'COUNT_FALSE',
 }

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/helpers/process-aggregate.helper.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/helpers/process-aggregate.helper.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
-import { SelectQueryBuilder } from 'typeorm';
 import { isDefined } from 'twenty-shared';
+import { SelectQueryBuilder } from 'typeorm';
 
 import { AGGREGATE_OPERATIONS } from 'src/engine/api/graphql/graphql-query-runner/constants/aggregate-operations.constant';
 import { AggregationField } from 'src/engine/api/graphql/workspace-schema-builder/utils/get-available-aggregations-from-object-fields.util';
@@ -84,6 +84,18 @@ export class ProcessAggregateHelper {
         case AGGREGATE_OPERATIONS.percentageNotEmpty:
           queryBuilder.addSelect(
             `CASE WHEN COUNT(*) = 0 THEN NULL ELSE CAST((COUNT(${columnExpression})::decimal / COUNT(*)) AS DECIMAL) END`,
+            `${aggregatedFieldName}`,
+          );
+          break;
+        case AGGREGATE_OPERATIONS.countTrue:
+          queryBuilder.addSelect(
+            `CASE WHEN COUNT(*) = 0 THEN NULL ELSE COUNT(CASE WHEN "${columnNameForNumericOperation}" = true THEN 1 END) END`,
+            `${aggregatedFieldName}`,
+          );
+          break;
+        case AGGREGATE_OPERATIONS.countFalse:
+          queryBuilder.addSelect(
+            `CASE WHEN COUNT(*) = 0 THEN NULL ELSE COUNT(CASE WHEN "${columnNameForNumericOperation}" = false THEN 1 END) END`,
             `${aggregatedFieldName}`,
           );
           break;

--- a/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/utils/get-available-aggregations-from-object-fields.util.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/utils/get-available-aggregations-from-object-fields.util.ts
@@ -2,10 +2,10 @@ import { GraphQLISODateTime } from '@nestjs/graphql';
 
 import { GraphQLFloat, GraphQLInt, GraphQLScalarType } from 'graphql';
 import {
-  capitalize,
-  FIELD_FOR_TOTAL_COUNT_AGGREGATE_OPERATION,
-  FieldMetadataType,
-  isFieldMetadataDateKind,
+    capitalize,
+    FIELD_FOR_TOTAL_COUNT_AGGREGATE_OPERATION,
+    FieldMetadataType,
+    isFieldMetadataDateKind,
 } from 'twenty-shared';
 
 import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
@@ -94,6 +94,26 @@ export const getAvailableAggregationsFromObjectFields = (
           fromField: field.name,
           fromFieldType: field.type,
           aggregateOperation: AGGREGATE_OPERATIONS.max,
+        };
+      }
+
+      if (field.type === FieldMetadataType.BOOLEAN) {
+        acc[`countTrue${capitalize(field.name)}`] = {
+          type: GraphQLInt,
+          description: `Number of true values for ${field.name}`,
+          fromField: field.name,
+          fromFieldType: field.type,
+          fromSubFields,
+          aggregateOperation: AGGREGATE_OPERATIONS.countTrue,
+        };
+
+        acc[`countFalse${capitalize(field.name)}`] = {
+          type: GraphQLInt,
+          description: `Number of false values for ${field.name}`,
+          fromField: field.name,
+          fromFieldType: field.type,
+          fromSubFields,
+          aggregateOperation: AGGREGATE_OPERATIONS.countFalse,
         };
       }
 


### PR DESCRIPTION
Fixes: #10603 

## Problem
Previously, boolean fields could only be aggregated using the standard counting operations ("Count All", "Count Empty" etc.), which didn't distinguish between true and false values. Both were treated as "non-empty" making the count operations less useful for boolean fields.

## Solution
Added two new aggregate operations specifically for boolean fields:
Count True - counts only records where the boolean field is true
Count False - counts only records where the boolean field is false

## Implementation Details
Added new aggregate operations countTrue and countFalse to constants
Added SQL query logic to correctly count true/false values
Updated the UI to show a "Boolean" submenu with these options when a boolean field is selected
Added appropriate labels and translations
