### PR TITLE
Fix file preview text color in dark mode

### DIFF
--- a/packages/twenty-front/src/modules/activities/files/components/DocumentViewer.tsx
+++ b/packages/twenty-front/src/modules/activities/files/components/DocumentViewer.tsx
@@ -105,7 +105,7 @@ export const DocumentViewer = ({
           },
         ]}
         pluginRenderers={DocViewerRenderers}
-        style={{ height: '100%' }}
+        style={{ height: '100%', color: 'black' }}
         config={{
           header: {
             disableHeader: true,

--- a/packages/twenty-front/src/modules/activities/files/components/DocumentViewer.tsx
+++ b/packages/twenty-front/src/modules/activities/files/components/DocumentViewer.tsx
@@ -105,7 +105,11 @@ export const DocumentViewer = ({
           },
         ]}
         pluginRenderers={DocViewerRenderers}
-        style={{ height: '100%', color: 'black' }}
+        style={{
+          height: '100%',
+          color: theme.font.color.primary,
+          backgroundColor: theme.background.secondary,
+        }}
         config={{
           header: {
             disableHeader: true,

--- a/packages/twenty-front/src/modules/activities/files/components/DocumentViewer.tsx
+++ b/packages/twenty-front/src/modules/activities/files/components/DocumentViewer.tsx
@@ -108,7 +108,7 @@ export const DocumentViewer = ({
         style={{
           height: '100%',
           color: theme.font.color.primary,
-          backgroundColor: theme.background.secondary,
+          backgroundColor: theme.background.primary,
         }}
         config={{
           header: {


### PR DESCRIPTION
This PR fixes an issue where the file preview text was unreadable due to white text on a white background in dark mode.

Dark mode ->
![image](https://github.com/user-attachments/assets/1f8f6fd0-b95b-4b78-ae8c-db51acfefac2)

Light mode ->
![image](https://github.com/user-attachments/assets/82996a31-e000-4f04-b8db-bd35838732ec)

Fixes #10743
