### PR TITLE
Fix incorrect Scalar CSS import

### DIFF
--- a/packages/twenty-front/.env.example
+++ b/packages/twenty-front/.env.example
@@ -1,6 +1,5 @@
 REACT_APP_SERVER_BASE_URL=http://localhost:3000
-GENERATE_SOURCEMAP=false
-TRANSLATION_IO_API_KEY=xxx
+VITE_BUILD_SOURCEMAP=false
 
 
 # ———————— Optional ————————

--- a/packages/twenty-front/src/modules/settings/playground/components/RestPlayground.tsx
+++ b/packages/twenty-front/src/modules/settings/playground/components/RestPlayground.tsx
@@ -16,9 +16,12 @@ const StyledContainer = styled.div`
 `;
 
 const ApiReferenceReact = lazy(() =>
-  import('@scalar/api-reference-react').then((module) => ({
-    default: module.ApiReferenceReact,
-  })),
+  import('@scalar/api-reference-react').then((module) => {
+    import('@scalar/api-reference-react/style.css');
+    return {
+      default: module.ApiReferenceReact,
+    };
+  }),
 );
 
 type RestPlaygroundProps = {

--- a/packages/twenty-front/src/modules/ui/layout/fullscreen/components/FullScreenContainer.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/fullscreen/components/FullScreenContainer.tsx
@@ -5,7 +5,6 @@ import {
 } from '@/ui/navigation/bread-crumb/components/Breadcrumb';
 import styled from '@emotion/styled';
 import { useLingui } from '@lingui/react/macro';
-import '@scalar/api-reference-react/style.css';
 import { IconButton, IconX, useIsMobile } from 'twenty-ui';
 
 type FullScreenContainerProps = {


### PR DESCRIPTION
CSS was loaded in a global context (full screen which might be re-used for other use cases in the future) instead of a local context.

\+ small update on .env.example