### PR TITLE
Fix TEST env not using the correct DB for datasources

### DIFF
--- a/packages/twenty-server/src/database/typeorm/core/core.datasource.ts
+++ b/packages/twenty-server/src/database/typeorm/core/core.datasource.ts
@@ -2,7 +2,10 @@ import { TypeOrmModuleOptions } from '@nestjs/typeorm';
 
 import { config } from 'dotenv';
 import { DataSource, DataSourceOptions } from 'typeorm';
-config({ path: process.env.NODE_ENV === 'test' ? '.env.test' : '.env' });
+config({
+  path: process.env.NODE_ENV === 'test' ? '.env.test' : '.env',
+  override: true,
+});
 
 const isJest = process.argv.some((arg) => arg.includes('jest'));
 

--- a/packages/twenty-server/src/database/typeorm/metadata/metadata.datasource.ts
+++ b/packages/twenty-server/src/database/typeorm/metadata/metadata.datasource.ts
@@ -2,7 +2,10 @@ import { TypeOrmModuleOptions } from '@nestjs/typeorm';
 
 import { config } from 'dotenv';
 import { DataSource, DataSourceOptions } from 'typeorm';
-config({ path: process.env.NODE_ENV === 'test' ? '.env.test' : '.env' });
+config({
+  path: process.env.NODE_ENV === 'test' ? '.env.test' : '.env',
+  override: true,
+});
 
 const isJest = process.argv.some((arg) => arg.includes('jest'));
 

--- a/packages/twenty-server/src/database/typeorm/raw/raw.datasource.ts
+++ b/packages/twenty-server/src/database/typeorm/raw/raw.datasource.ts
@@ -1,6 +1,9 @@
 import { config } from 'dotenv';
 import { DataSource, DataSourceOptions } from 'typeorm';
-config({ path: process.env.NODE_ENV === 'test' ? '.env.test' : '.env' });
+config({
+  path: process.env.NODE_ENV === 'test' ? '.env.test' : '.env',
+  override: true,
+});
 
 const typeORMRawModuleOptions: DataSourceOptions = {
   url: process.env.PG_DATABASE_URL,

--- a/packages/twenty-server/src/utils/generate-front-config.ts
+++ b/packages/twenty-server/src/utils/generate-front-config.ts
@@ -2,7 +2,10 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import { config } from 'dotenv';
-config({ path: process.env.NODE_ENV === 'test' ? '.env.test' : '.env' });
+config({
+  path: process.env.NODE_ENV === 'test' ? '.env.test' : '.env',
+  override: true,
+});
 
 export function generateFrontConfig(): void {
   const configObject = {


### PR DESCRIPTION
## Context
Config was programmatically loaded in our datasources however the default behavior of dotenv is to ignore vars if they are already defined. This means we need to be careful about the order of env injection and sometimes it's done at a higher level (for example db:reset will depend on build). To make things easier I'm using the override flag to properly override the PG_DATABASE_URL if different (and to properly work with the 'test' DB instead of 'default' during testing).