### PR TITLE
Highlight consumed variables in workflow runs

### DIFF
--- a/packages/twenty-front/src/modules/workflow/components/json-visualizer/components/JsonArrayNode.tsx
+++ b/packages/twenty-front/src/modules/workflow/components/json-visualizer/components/JsonArrayNode.tsx
@@ -7,10 +7,14 @@ export const JsonArrayNode = ({
   label,
   value,
   depth,
+  keyPath,
+  getNodeHighlighting,
 }: {
   label?: string;
   value: JsonArray;
   depth: number;
+  keyPath: string;
+  getNodeHighlighting?: (keyPath: string) => boolean;
 }) => {
   const { t } = useLingui();
 
@@ -26,6 +30,8 @@ export const JsonArrayNode = ({
       Icon={IconBrackets}
       depth={depth}
       emptyElementsText={t`Empty Array`}
+      keyPath={keyPath}
+      getNodeHighlighting={getNodeHighlighting}
     />
   );
 };

--- a/packages/twenty-front/src/modules/workflow/components/json-visualizer/components/JsonArrayNode.tsx
+++ b/packages/twenty-front/src/modules/workflow/components/json-visualizer/components/JsonArrayNode.tsx
@@ -8,13 +8,13 @@ export const JsonArrayNode = ({
   value,
   depth,
   keyPath,
-  getNodeHighlighting,
+  shouldHighlightNode,
 }: {
   label?: string;
   value: JsonArray;
   depth: number;
   keyPath: string;
-  getNodeHighlighting?: (keyPath: string) => boolean;
+  shouldHighlightNode?: (keyPath: string) => boolean;
 }) => {
   const { t } = useLingui();
 
@@ -31,7 +31,7 @@ export const JsonArrayNode = ({
       depth={depth}
       emptyElementsText={t`Empty Array`}
       keyPath={keyPath}
-      getNodeHighlighting={getNodeHighlighting}
+      shouldHighlightNode={shouldHighlightNode}
     />
   );
 };

--- a/packages/twenty-front/src/modules/workflow/components/json-visualizer/components/JsonNestedNode.tsx
+++ b/packages/twenty-front/src/modules/workflow/components/json-visualizer/components/JsonNestedNode.tsx
@@ -35,6 +35,8 @@ export const JsonNestedNode = ({
   renderElementsCount,
   emptyElementsText,
   depth,
+  keyPath,
+  getNodeHighlighting,
 }: {
   label?: string;
   Icon: IconComponent;
@@ -42,6 +44,8 @@ export const JsonNestedNode = ({
   renderElementsCount?: (count: number) => string;
   emptyElementsText: string;
   depth: number;
+  keyPath: string;
+  getNodeHighlighting?: (keyPath: string) => boolean;
 }) => {
   const hideRoot = !isDefined(label);
 
@@ -53,7 +57,14 @@ export const JsonNestedNode = ({
         <StyledEmptyState>{emptyElementsText}</StyledEmptyState>
       ) : (
         elements.map(({ id, label, value }) => (
-          <JsonNode key={id} label={label} value={value} depth={depth + 1} />
+          <JsonNode
+            key={id}
+            label={label}
+            value={value}
+            depth={depth + 1}
+            keyPath={keyPath + '.' + id}
+            getNodeHighlighting={getNodeHighlighting}
+          />
         ))
       )}
     </JsonList>

--- a/packages/twenty-front/src/modules/workflow/components/json-visualizer/components/JsonNestedNode.tsx
+++ b/packages/twenty-front/src/modules/workflow/components/json-visualizer/components/JsonNestedNode.tsx
@@ -37,7 +37,7 @@ export const JsonNestedNode = ({
   emptyElementsText,
   depth,
   keyPath,
-  getNodeHighlighting,
+  shouldHighlightNode,
 }: {
   label?: string;
   Icon: IconComponent;
@@ -46,7 +46,7 @@ export const JsonNestedNode = ({
   emptyElementsText: string;
   depth: number;
   keyPath: string;
-  getNodeHighlighting?: (keyPath: string) => boolean;
+  shouldHighlightNode?: (keyPath: string) => boolean;
 }) => {
   const hideRoot = !isDefined(label);
 
@@ -69,7 +69,7 @@ export const JsonNestedNode = ({
               value={value}
               depth={depth + 1}
               keyPath={nextKeyPath}
-              getNodeHighlighting={getNodeHighlighting}
+              shouldHighlightNode={shouldHighlightNode}
             />
           );
         })

--- a/packages/twenty-front/src/modules/workflow/components/json-visualizer/components/JsonNestedNode.tsx
+++ b/packages/twenty-front/src/modules/workflow/components/json-visualizer/components/JsonNestedNode.tsx
@@ -3,6 +3,7 @@ import { JsonList } from '@/workflow/components/json-visualizer/components/inter
 import { JsonNodeLabel } from '@/workflow/components/json-visualizer/components/internal/JsonNodeLabel';
 import { JsonNode } from '@/workflow/components/json-visualizer/components/JsonNode';
 import styled from '@emotion/styled';
+import { isNonEmptyString } from '@sniptt/guards';
 import { useState } from 'react';
 import { isDefined } from 'twenty-shared';
 import { IconComponent } from 'twenty-ui';
@@ -56,16 +57,22 @@ export const JsonNestedNode = ({
       {elements.length === 0 ? (
         <StyledEmptyState>{emptyElementsText}</StyledEmptyState>
       ) : (
-        elements.map(({ id, label, value }) => (
-          <JsonNode
-            key={id}
-            label={label}
-            value={value}
-            depth={depth + 1}
-            keyPath={keyPath + '.' + id}
-            getNodeHighlighting={getNodeHighlighting}
-          />
-        ))
+        elements.map(({ id, label, value }) => {
+          const nextKeyPath = isNonEmptyString(keyPath)
+            ? `${keyPath}.${id}`
+            : String(id);
+
+          return (
+            <JsonNode
+              key={id}
+              label={label}
+              value={value}
+              depth={depth + 1}
+              keyPath={nextKeyPath}
+              getNodeHighlighting={getNodeHighlighting}
+            />
+          );
+        })
       )}
     </JsonList>
   );

--- a/packages/twenty-front/src/modules/workflow/components/json-visualizer/components/JsonNode.tsx
+++ b/packages/twenty-front/src/modules/workflow/components/json-visualizer/components/JsonNode.tsx
@@ -15,17 +15,26 @@ export const JsonNode = ({
   label,
   value,
   depth,
+  keyPath,
+  getNodeHighlighting,
 }: {
   label?: string;
   value: JsonValue;
   depth: number;
+  keyPath: string;
+  getNodeHighlighting?: (keyPath: string) => boolean;
 }) => {
+  const isHighlighted = getNodeHighlighting?.(keyPath) ?? false;
+
+  console.log({ isHighlighted });
+
   if (isNull(value)) {
     return (
       <JsonValueNode
         label={label}
         valueAsString="[null]"
         Icon={IconCircleOff}
+        isHighlighted={isHighlighted}
       />
     );
   }
@@ -36,6 +45,7 @@ export const JsonNode = ({
         label={label}
         valueAsString={value}
         Icon={IconTypography}
+        isHighlighted={isHighlighted}
       />
     );
   }
@@ -46,6 +56,7 @@ export const JsonNode = ({
         label={label}
         valueAsString={String(value)}
         Icon={IconNumber9}
+        isHighlighted={isHighlighted}
       />
     );
   }
@@ -56,13 +67,30 @@ export const JsonNode = ({
         label={label}
         valueAsString={String(value)}
         Icon={IconCheckbox}
+        isHighlighted={isHighlighted}
       />
     );
   }
 
   if (isArray(value)) {
-    return <JsonArrayNode label={label} value={value} depth={depth} />;
+    return (
+      <JsonArrayNode
+        label={label}
+        value={value}
+        depth={depth}
+        keyPath={keyPath}
+        getNodeHighlighting={getNodeHighlighting}
+      />
+    );
   }
 
-  return <JsonObjectNode label={label} value={value} depth={depth} />;
+  return (
+    <JsonObjectNode
+      label={label}
+      value={value}
+      depth={depth}
+      keyPath={keyPath}
+      getNodeHighlighting={getNodeHighlighting}
+    />
+  );
 };

--- a/packages/twenty-front/src/modules/workflow/components/json-visualizer/components/JsonNode.tsx
+++ b/packages/twenty-front/src/modules/workflow/components/json-visualizer/components/JsonNode.tsx
@@ -16,15 +16,15 @@ export const JsonNode = ({
   value,
   depth,
   keyPath,
-  getNodeHighlighting,
+  shouldHighlightNode,
 }: {
   label?: string;
   value: JsonValue;
   depth: number;
   keyPath: string;
-  getNodeHighlighting?: (keyPath: string) => boolean;
+  shouldHighlightNode?: (keyPath: string) => boolean;
 }) => {
-  const isHighlighted = getNodeHighlighting?.(keyPath) ?? false;
+  const isHighlighted = shouldHighlightNode?.(keyPath) ?? false;
 
   if (isNull(value)) {
     return (
@@ -77,7 +77,7 @@ export const JsonNode = ({
         value={value}
         depth={depth}
         keyPath={keyPath}
-        getNodeHighlighting={getNodeHighlighting}
+        shouldHighlightNode={shouldHighlightNode}
       />
     );
   }
@@ -88,7 +88,7 @@ export const JsonNode = ({
       value={value}
       depth={depth}
       keyPath={keyPath}
-      getNodeHighlighting={getNodeHighlighting}
+      shouldHighlightNode={shouldHighlightNode}
     />
   );
 };

--- a/packages/twenty-front/src/modules/workflow/components/json-visualizer/components/JsonNode.tsx
+++ b/packages/twenty-front/src/modules/workflow/components/json-visualizer/components/JsonNode.tsx
@@ -26,8 +26,6 @@ export const JsonNode = ({
 }) => {
   const isHighlighted = getNodeHighlighting?.(keyPath) ?? false;
 
-  console.log({ isHighlighted });
-
   if (isNull(value)) {
     return (
       <JsonValueNode

--- a/packages/twenty-front/src/modules/workflow/components/json-visualizer/components/JsonObjectNode.tsx
+++ b/packages/twenty-front/src/modules/workflow/components/json-visualizer/components/JsonObjectNode.tsx
@@ -7,10 +7,14 @@ export const JsonObjectNode = ({
   label,
   value,
   depth,
+  keyPath,
+  getNodeHighlighting,
 }: {
   label?: string;
   value: JsonObject;
   depth: number;
+  keyPath: string;
+  getNodeHighlighting?: (keyPath: string) => boolean;
 }) => {
   const { t } = useLingui();
 
@@ -26,6 +30,8 @@ export const JsonObjectNode = ({
       Icon={IconCube}
       depth={depth}
       emptyElementsText={t`Empty Object`}
+      keyPath={keyPath}
+      getNodeHighlighting={getNodeHighlighting}
     />
   );
 };

--- a/packages/twenty-front/src/modules/workflow/components/json-visualizer/components/JsonObjectNode.tsx
+++ b/packages/twenty-front/src/modules/workflow/components/json-visualizer/components/JsonObjectNode.tsx
@@ -8,13 +8,13 @@ export const JsonObjectNode = ({
   value,
   depth,
   keyPath,
-  getNodeHighlighting,
+  shouldHighlightNode,
 }: {
   label?: string;
   value: JsonObject;
   depth: number;
   keyPath: string;
-  getNodeHighlighting?: (keyPath: string) => boolean;
+  shouldHighlightNode?: (keyPath: string) => boolean;
 }) => {
   const { t } = useLingui();
 
@@ -31,7 +31,7 @@ export const JsonObjectNode = ({
       depth={depth}
       emptyElementsText={t`Empty Object`}
       keyPath={keyPath}
-      getNodeHighlighting={getNodeHighlighting}
+      shouldHighlightNode={shouldHighlightNode}
     />
   );
 };

--- a/packages/twenty-front/src/modules/workflow/components/json-visualizer/components/JsonTree.tsx
+++ b/packages/twenty-front/src/modules/workflow/components/json-visualizer/components/JsonTree.tsx
@@ -2,10 +2,21 @@ import { JsonList } from '@/workflow/components/json-visualizer/components/inter
 import { JsonNode } from '@/workflow/components/json-visualizer/components/JsonNode';
 import { JsonValue } from 'type-fest';
 
-export const JsonTree = ({ value }: { value: JsonValue }) => {
+export const JsonTree = ({
+  value,
+  getNodeHighlighting,
+}: {
+  value: JsonValue;
+  getNodeHighlighting?: (keyPath: string) => boolean;
+}) => {
   return (
     <JsonList depth={0}>
-      <JsonNode value={value} depth={0} />
+      <JsonNode
+        value={value}
+        depth={0}
+        keyPath=""
+        getNodeHighlighting={getNodeHighlighting}
+      />
     </JsonList>
   );
 };

--- a/packages/twenty-front/src/modules/workflow/components/json-visualizer/components/JsonTree.tsx
+++ b/packages/twenty-front/src/modules/workflow/components/json-visualizer/components/JsonTree.tsx
@@ -4,10 +4,10 @@ import { JsonValue } from 'type-fest';
 
 export const JsonTree = ({
   value,
-  getNodeHighlighting,
+  shouldHighlightNode,
 }: {
   value: JsonValue;
-  getNodeHighlighting?: (keyPath: string) => boolean;
+  shouldHighlightNode?: (keyPath: string) => boolean;
 }) => {
   return (
     <JsonList depth={0}>
@@ -15,7 +15,7 @@ export const JsonTree = ({
         value={value}
         depth={0}
         keyPath=""
-        getNodeHighlighting={getNodeHighlighting}
+        shouldHighlightNode={shouldHighlightNode}
       />
     </JsonList>
   );

--- a/packages/twenty-front/src/modules/workflow/components/json-visualizer/components/JsonValueNode.tsx
+++ b/packages/twenty-front/src/modules/workflow/components/json-visualizer/components/JsonValueNode.tsx
@@ -10,6 +10,7 @@ const StyledListItem = styled(JsonListItem)`
 
 type JsonValueNodeProps = {
   valueAsString: string;
+  isHighlighted: boolean;
 } & (
   | {
       label: string;
@@ -24,9 +25,18 @@ type JsonValueNodeProps = {
 export const JsonValueNode = (props: JsonValueNodeProps) => {
   return (
     <StyledListItem>
-      {props.label && <JsonNodeLabel label={props.label} Icon={props.Icon} />}
+      {props.label && (
+        <JsonNodeLabel
+          label={props.label}
+          Icon={props.Icon}
+          isHighlighted={props.isHighlighted}
+        />
+      )}
 
-      <JsonNodeValue valueAsString={props.valueAsString} />
+      <JsonNodeValue
+        valueAsString={props.valueAsString}
+        isHighlighted={props.isHighlighted}
+      />
     </StyledListItem>
   );
 };

--- a/packages/twenty-front/src/modules/workflow/components/json-visualizer/components/internal/JsonNodeLabel.tsx
+++ b/packages/twenty-front/src/modules/workflow/components/json-visualizer/components/internal/JsonNodeLabel.tsx
@@ -2,10 +2,12 @@ import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { IconComponent } from 'twenty-ui';
 
-const StyledLabelContainer = styled.span`
+const StyledLabelContainer = styled.span<{ isHighlighted?: boolean }>`
   align-items: center;
   background-color: ${({ theme }) => theme.background.transparent.lighter};
   border-color: ${({ theme }) => theme.border.color.medium};
+  color: ${({ theme, isHighlighted }) =>
+    isHighlighted ? theme.color.blue : theme.font.color.primary};
   border-radius: ${({ theme }) => theme.border.radius.sm};
   border-style: solid;
   border-width: 1px;
@@ -23,15 +25,20 @@ const StyledLabelContainer = styled.span`
 export const JsonNodeLabel = ({
   label,
   Icon,
+  isHighlighted,
 }: {
   label: string;
   Icon: IconComponent;
+  isHighlighted?: boolean;
 }) => {
   const theme = useTheme();
 
   return (
-    <StyledLabelContainer>
-      <Icon size={theme.icon.size.md} color={theme.font.color.tertiary} />
+    <StyledLabelContainer isHighlighted={isHighlighted}>
+      <Icon
+        size={theme.icon.size.md}
+        color={isHighlighted ? theme.color.blue : theme.font.color.tertiary}
+      />
 
       <span>{label}</span>
     </StyledLabelContainer>

--- a/packages/twenty-front/src/modules/workflow/components/json-visualizer/components/internal/JsonNodeValue.tsx
+++ b/packages/twenty-front/src/modules/workflow/components/json-visualizer/components/internal/JsonNodeValue.tsx
@@ -1,9 +1,16 @@
 import styled from '@emotion/styled';
 
-const StyledText = styled.span`
-  color: ${({ theme }) => theme.font.color.tertiary};
+const StyledText = styled.span<{ isHighlighted?: boolean }>`
+  color: ${({ theme, isHighlighted }) =>
+    isHighlighted ? theme.adaptiveColors.blue4 : theme.font.color.tertiary};
 `;
 
-export const JsonNodeValue = ({ valueAsString }: { valueAsString: string }) => {
-  return <StyledText>{valueAsString}</StyledText>;
+export const JsonNodeValue = ({
+  valueAsString,
+  isHighlighted,
+}: {
+  valueAsString: string;
+  isHighlighted?: boolean;
+}) => {
+  return <StyledText isHighlighted={isHighlighted}>{valueAsString}</StyledText>;
 };

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/components/WorkflowRunStepInputDetail.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/components/WorkflowRunStepInputDetail.tsx
@@ -48,6 +48,8 @@ export const WorkflowRunStepInputDetail = ({ stepId }: { stepId: string }) => {
         Icon={IconBrackets}
         emptyElementsText=""
         depth={0}
+        keyPath=""
+        getNodeHighlighting={() => true}
       />
     </StyledContainer>
   );

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/components/WorkflowRunStepInputDetail.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/components/WorkflowRunStepInputDetail.tsx
@@ -1,8 +1,8 @@
 import { JsonNestedNode } from '@/workflow/components/json-visualizer/components/JsonNestedNode';
 import { useWorkflowRun } from '@/workflow/hooks/useWorkflowRun';
 import { useWorkflowRunIdOrThrow } from '@/workflow/hooks/useWorkflowRunIdOrThrow';
-import { getVariablesUsedInStep } from '@/workflow/workflow-steps/utils/getFlowVariablesInUse';
 import { getWorkflowRunStepContext } from '@/workflow/workflow-steps/utils/getWorkflowRunStepContext';
+import { getWorkflowVariablesUsedInStep } from '@/workflow/workflow-steps/utils/getWorkflowVariablesUsedInStep';
 import styled from '@emotion/styled';
 import { isDefined } from 'twenty-shared';
 import { IconBrackets } from 'twenty-ui';
@@ -32,7 +32,7 @@ export const WorkflowRunStepInputDetail = ({ stepId }: { stepId: string }) => {
     return null;
   }
 
-  const variablesInUse = getVariablesUsedInStep({
+  const variablesInUse = getWorkflowVariablesUsedInStep({
     step,
   });
 

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/components/WorkflowRunStepInputDetail.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/components/WorkflowRunStepInputDetail.tsx
@@ -32,7 +32,7 @@ export const WorkflowRunStepInputDetail = ({ stepId }: { stepId: string }) => {
     return null;
   }
 
-  const variablesInUse = getWorkflowVariablesUsedInStep({
+  const variablesUsedInStep = getWorkflowVariablesUsedInStep({
     step,
   });
 
@@ -58,7 +58,7 @@ export const WorkflowRunStepInputDetail = ({ stepId }: { stepId: string }) => {
         emptyElementsText=""
         depth={0}
         keyPath=""
-        getNodeHighlighting={(keyPath) => variablesInUse.has(keyPath)}
+        shouldHighlightNode={(keyPath) => variablesUsedInStep.has(keyPath)}
       />
     </StyledContainer>
   );

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/components/WorkflowRunStepInputDetail.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/components/WorkflowRunStepInputDetail.tsx
@@ -1,6 +1,7 @@
 import { JsonNestedNode } from '@/workflow/components/json-visualizer/components/JsonNestedNode';
 import { useWorkflowRun } from '@/workflow/hooks/useWorkflowRun';
 import { useWorkflowRunIdOrThrow } from '@/workflow/hooks/useWorkflowRunIdOrThrow';
+import { getVariablesUsedInStep } from '@/workflow/workflow-steps/utils/getFlowVariablesInUse';
 import { getWorkflowRunStepContext } from '@/workflow/workflow-steps/utils/getWorkflowRunStepContext';
 import styled from '@emotion/styled';
 import { isDefined } from 'twenty-shared';
@@ -16,16 +17,24 @@ const StyledContainer = styled.div`
 export const WorkflowRunStepInputDetail = ({ stepId }: { stepId: string }) => {
   const workflowRunId = useWorkflowRunIdOrThrow();
   const workflowRun = useWorkflowRun({ workflowRunId });
+  const step = workflowRun?.output?.flow.steps.find(
+    (step) => step.id === stepId,
+  );
 
   if (
     !(
       isDefined(workflowRun) &&
       isDefined(workflowRun.context) &&
-      isDefined(workflowRun.output?.flow)
+      isDefined(workflowRun.output?.flow) &&
+      isDefined(step)
     )
   ) {
     return null;
   }
+
+  const variablesInUse = getVariablesUsedInStep({
+    step,
+  });
 
   const stepContext = getWorkflowRunStepContext({
     context: workflowRun.context,
@@ -49,7 +58,7 @@ export const WorkflowRunStepInputDetail = ({ stepId }: { stepId: string }) => {
         emptyElementsText=""
         depth={0}
         keyPath=""
-        getNodeHighlighting={() => true}
+        getNodeHighlighting={(keyPath) => variablesInUse.has(keyPath)}
       />
     </StyledContainer>
   );

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/utils/__tests__/getWorkflowVariablesUsedInStep.test.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/utils/__tests__/getWorkflowVariablesUsedInStep.test.ts
@@ -1,0 +1,173 @@
+import { WorkflowStep } from '@/workflow/types/Workflow';
+import { getWorkflowVariablesUsedInStep } from '@/workflow/workflow-steps/utils/getWorkflowVariablesUsedInStep';
+
+describe('getWorkflowVariablesUsedInStep', () => {
+  it('returns the variables used in a one-level object', () => {
+    const step: WorkflowStep = {
+      id: '42e8b60e-dd44-417a-875f-823d63f16819',
+      name: 'Code - Serverless Function',
+      type: 'CODE',
+      valid: false,
+      settings: {
+        input: {
+          serverlessFunctionId: '5f7b9b44-bb07-41ba-aef8-ec0eaa5eea2d',
+          serverlessFunctionInput: {
+            a: '{{5f7b9b44-bb07-41ba-aef8-ec0eaa5eea2c.a.b.c.d}}',
+          },
+          serverlessFunctionVersion: 'draft',
+        },
+        outputSchema: {},
+        errorHandlingOptions: {
+          retryOnFailure: {
+            value: false,
+          },
+          continueOnFailure: {
+            value: false,
+          },
+        },
+      },
+    };
+
+    expect(
+      getWorkflowVariablesUsedInStep({
+        step,
+      }),
+    ).toMatchInlineSnapshot(`
+Set {
+  "5f7b9b44-bb07-41ba-aef8-ec0eaa5eea2c.a.b.c.d",
+}
+`);
+  });
+
+  it('returns the variables used in a computed field', () => {
+    const step: WorkflowStep = {
+      id: '42e8b60e-dd44-417a-875f-823d63f16819',
+      name: 'Create Record',
+      type: 'CREATE_RECORD',
+      valid: false,
+      settings: {
+        input: {
+          objectName: 'company',
+          objectRecord: {
+            name: 'Test',
+            address: {
+              addressLat: null,
+              addressLng: null,
+              addressCity: '{{trigger.address.addressCity}}',
+              addressState: '{{trigger.address.addressState}}',
+              addressCountry: '{{trigger.address.addressCountry}}',
+              addressStreet1: '{{trigger.address.addressStreet1}}',
+              addressStreet2: '{{trigger.address.addressStreet2}}',
+              addressPostcode: '{{trigger.address.addressPostcode}}',
+            },
+            domainName: {
+              primaryLinkUrl: '',
+              primaryLinkLabel: '',
+            },
+          },
+        },
+        outputSchema: {},
+        errorHandlingOptions: {
+          retryOnFailure: {
+            value: false,
+          },
+          continueOnFailure: {
+            value: false,
+          },
+        },
+      },
+    };
+
+    expect(
+      getWorkflowVariablesUsedInStep({
+        step,
+      }),
+    ).toMatchInlineSnapshot(`
+Set {
+  "trigger.address.addressCity",
+  "trigger.address.addressState",
+  "trigger.address.addressCountry",
+  "trigger.address.addressStreet1",
+  "trigger.address.addressStreet2",
+  "trigger.address.addressPostcode",
+}
+`);
+  });
+
+  it('returns all the variables used in a single field', () => {
+    const step: WorkflowStep = {
+      id: '42e8b60e-dd44-417a-875f-823d63f16819',
+      name: 'Code - Serverless Function',
+      type: 'CODE',
+      valid: false,
+      settings: {
+        input: {
+          serverlessFunctionId: '5f7b9b44-bb07-41ba-aef8-ec0eaa5eea2d',
+          serverlessFunctionInput: {
+            a: '{{5f7b9b44-bb07-41ba-aef8-ec0eaa5eea2c.a}} {{5f7b9b44-bb07-41ba-aef8-ec0eaa5eea2c.b}} {{5f7b9b44-bb07-41ba-aef8-ec0eaa5eea2c.c}} {{5f7b9b44-bb07-41ba-aef8-ec0eaa5eea2c.d}}',
+          },
+          serverlessFunctionVersion: 'draft',
+        },
+        outputSchema: {},
+        errorHandlingOptions: {
+          retryOnFailure: {
+            value: false,
+          },
+          continueOnFailure: {
+            value: false,
+          },
+        },
+      },
+    };
+
+    expect(
+      getWorkflowVariablesUsedInStep({
+        step,
+      }),
+    ).toMatchInlineSnapshot(`
+Set {
+  "5f7b9b44-bb07-41ba-aef8-ec0eaa5eea2c.a",
+  "5f7b9b44-bb07-41ba-aef8-ec0eaa5eea2c.b",
+  "5f7b9b44-bb07-41ba-aef8-ec0eaa5eea2c.c",
+  "5f7b9b44-bb07-41ba-aef8-ec0eaa5eea2c.d",
+}
+`);
+  });
+
+  it('returns the variables used many times only once', () => {
+    const step: WorkflowStep = {
+      id: '42e8b60e-dd44-417a-875f-823d63f16819',
+      name: 'Code - Serverless Function',
+      type: 'CODE',
+      valid: false,
+      settings: {
+        input: {
+          serverlessFunctionId: '5f7b9b44-bb07-41ba-aef8-ec0eaa5eea2d',
+          serverlessFunctionInput: {
+            a: '{{5f7b9b44-bb07-41ba-aef8-ec0eaa5eea2c.a}} {{5f7b9b44-bb07-41ba-aef8-ec0eaa5eea2c.a}} {{5f7b9b44-bb07-41ba-aef8-ec0eaa5eea2c.a}} {{5f7b9b44-bb07-41ba-aef8-ec0eaa5eea2c.a}}',
+          },
+          serverlessFunctionVersion: 'draft',
+        },
+        outputSchema: {},
+        errorHandlingOptions: {
+          retryOnFailure: {
+            value: false,
+          },
+          continueOnFailure: {
+            value: false,
+          },
+        },
+      },
+    };
+
+    expect(
+      getWorkflowVariablesUsedInStep({
+        step,
+      }),
+    ).toMatchInlineSnapshot(`
+Set {
+  "5f7b9b44-bb07-41ba-aef8-ec0eaa5eea2c.a",
+}
+`);
+  });
+});

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/utils/getFlowVariablesInUse.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/utils/getFlowVariablesInUse.ts
@@ -1,0 +1,32 @@
+import { WorkflowStep } from '@/workflow/types/Workflow';
+import { CAPTURE_ALL_VARIABLE_TAG_INNER_REGEX } from '@/workflow/workflow-variables/constants/CaptureAllVariableTagInnerRegex';
+import { isObject, isString } from '@sniptt/guards';
+import { JsonValue } from 'type-fest';
+
+function* resolveVariables(value: JsonValue): Generator<string> {
+  if (isString(value)) {
+    for (const [, match] of value.matchAll(
+      CAPTURE_ALL_VARIABLE_TAG_INNER_REGEX,
+    )) {
+      yield match;
+    }
+
+    return;
+  }
+
+  if (isObject(value)) {
+    for (const nestedValue of Object.values(value)) {
+      yield* resolveVariables(nestedValue);
+    }
+  }
+}
+
+export const getVariablesUsedInStep = ({ step }: { step: WorkflowStep }) => {
+  const flowVariables = new Set<string>();
+
+  for (const variable of resolveVariables(step.settings.input)) {
+    flowVariables.add(variable);
+  }
+
+  return flowVariables;
+};

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/utils/getWorkflowVariablesUsedInStep.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/utils/getWorkflowVariablesUsedInStep.ts
@@ -21,7 +21,11 @@ function* resolveVariables(value: JsonValue): Generator<string> {
   }
 }
 
-export const getVariablesUsedInStep = ({ step }: { step: WorkflowStep }) => {
+export const getWorkflowVariablesUsedInStep = ({
+  step,
+}: {
+  step: WorkflowStep;
+}) => {
   const flowVariables = new Set<string>();
 
   for (const variable of resolveVariables(step.settings.input)) {

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/utils/getWorkflowVariablesUsedInStep.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/utils/getWorkflowVariablesUsedInStep.ts
@@ -5,10 +5,10 @@ import { JsonValue } from 'type-fest';
 
 function* resolveVariables(value: JsonValue): Generator<string> {
   if (isString(value)) {
-    for (const [, match] of value.matchAll(
+    for (const [, variablePath] of value.matchAll(
       CAPTURE_ALL_VARIABLE_TAG_INNER_REGEX,
     )) {
-      yield match;
+      yield variablePath;
     }
 
     return;
@@ -26,11 +26,11 @@ export const getWorkflowVariablesUsedInStep = ({
 }: {
   step: WorkflowStep;
 }) => {
-  const flowVariables = new Set<string>();
+  const variablesUsedInStep = new Set<string>();
 
   for (const variable of resolveVariables(step.settings.input)) {
-    flowVariables.add(variable);
+    variablesUsedInStep.add(variable);
   }
 
-  return flowVariables;
+  return variablesUsedInStep;
 };


### PR DESCRIPTION
- Create a function to resolve the variables used in the configuration of a step
- Let the JSON tree components take a prop (`getNodeHighlighting`) to determine whether an element must be highlighted
- Compute each element's keyPath recursively; the keyPath is passed as an argument to the `getNodeHighlighting` function

## Demo

https://github.com/user-attachments/assets/8586f43d-53d1-41ba-ab48-08bb8c74e145

Closes https://github.com/twentyhq/core-team-issues/issues/435