### PR TITLE
Add Keystatic for twenty-website build

### DIFF
--- a/packages/twenty-docker/twenty-website/Dockerfile
+++ b/packages/twenty-docker/twenty-website/Dockerfile
@@ -12,6 +12,11 @@ COPY ./packages/twenty-website/package.json /app/packages/twenty-website/package
 
 RUN yarn
 
+ENV KEYSTATIC_GITHUB_CLIENT_ID="<fake build value>"
+ENV KEYSTATIC_GITHUB_CLIENT_SECRET="<fake build value>"
+ENV KEYSTATIC_SECRET="<fake build value>"
+ENV NEXT_PUBLIC_KEYSTATIC_GITHUB_APP_SLUG="<fake build value>"
+
 COPY ./packages/twenty-website /app/packages/twenty-website
 RUN npx nx build twenty-website
 

--- a/packages/twenty-website/keystatic.config.ts
+++ b/packages/twenty-website/keystatic.config.ts
@@ -1,6 +1,18 @@
 import { collection, config, fields } from '@keystatic/core';
 import { wrapper } from '@keystatic/core/content-components';
 
+console.log({
+  KEYSTATIC_GITHUB_CLIENT_ID: process.env.KEYSTATIC_GITHUB_CLIENT_ID?.slice(
+    0,
+    2,
+  ),
+  KEYSTATIC_GITHUB_CLIENT_SECRET:
+    process.env.KEYSTATIC_GITHUB_CLIENT_SECRET?.slice(0, 2),
+  KEYSTATIC_SECRET: process.env.KEYSTATIC_SECRET?.slice(0, 2),
+  NEXT_PUBLIC_KEYSTATIC_GITHUB_APP_SLUG:
+    process.env.NEXT_PUBLIC_KEYSTATIC_GITHUB_APP_SLUG?.slice(0, 2),
+});
+
 export default config({
   storage: {
     kind: 'github',

--- a/packages/twenty-website/keystatic.config.ts
+++ b/packages/twenty-website/keystatic.config.ts
@@ -1,3 +1,4 @@
+import { global } from '@apollo/client/utilities/globals';
 import { collection, config, fields } from '@keystatic/core';
 import { wrapper } from '@keystatic/core/content-components';
 
@@ -11,6 +12,8 @@ console.log({
   KEYSTATIC_SECRET: process.env.KEYSTATIC_SECRET?.slice(0, 2),
   NEXT_PUBLIC_KEYSTATIC_GITHUB_APP_SLUG:
     process.env.NEXT_PUBLIC_KEYSTATIC_GITHUB_APP_SLUG?.slice(0, 2),
+  GITHUB_TOKEN: global.process.env.GITHUB_TOKEN?.slice(0, 2),
+  GITHUB_TOKEN_2: process.env.GITHUB_TOKEN?.slice(0, 2),
 });
 
 export default config({

--- a/packages/twenty-website/keystatic.config.ts
+++ b/packages/twenty-website/keystatic.config.ts
@@ -1,20 +1,5 @@
-import { global } from '@apollo/client/utilities/globals';
 import { collection, config, fields } from '@keystatic/core';
 import { wrapper } from '@keystatic/core/content-components';
-
-console.log({
-  KEYSTATIC_GITHUB_CLIENT_ID: process.env.KEYSTATIC_GITHUB_CLIENT_ID?.slice(
-    0,
-    2,
-  ),
-  KEYSTATIC_GITHUB_CLIENT_SECRET:
-    process.env.KEYSTATIC_GITHUB_CLIENT_SECRET?.slice(0, 2),
-  KEYSTATIC_SECRET: process.env.KEYSTATIC_SECRET?.slice(0, 2),
-  NEXT_PUBLIC_KEYSTATIC_GITHUB_APP_SLUG:
-    process.env.NEXT_PUBLIC_KEYSTATIC_GITHUB_APP_SLUG?.slice(0, 2),
-  GITHUB_TOKEN: global.process.env.GITHUB_TOKEN?.slice(0, 2),
-  GITHUB_TOKEN_2: process.env.GITHUB_TOKEN?.slice(0, 2),
-});
 
 export default config({
   storage: {


### PR DESCRIPTION
The Keystatic's environment variables must be defined during the build. @prastoin and I identified that the other environment variables aren't defined during the build. We decided to add fake environment variables directly in the Dockerfile to make the build pass. Later, the docker image should be executed with the real environment variables that'll make Keystatic work properly.