### PR TITLE
Stop using labelIdentifier when adding record card

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-board/record-board-card/components/RecordBoardCardHeader.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/record-board-card/components/RecordBoardCardHeader.tsx
@@ -138,20 +138,10 @@ export const RecordBoardCardHeader = ({
               autoFocus
               value={newLabelValue}
               onInputEnter={() =>
-                handleInputEnter(
-                  identifierFieldDefinition.label ?? '',
-                  newLabelValue,
-                  position,
-                  onCreateSuccess,
-                )
+                handleInputEnter(newLabelValue, position, onCreateSuccess)
               }
               onBlur={() =>
-                handleBlur(
-                  identifierFieldDefinition.label ?? '',
-                  newLabelValue,
-                  position,
-                  onCreateSuccess,
-                )
+                handleBlur(newLabelValue, position, onCreateSuccess)
               }
               onChange={(text: string) => setNewLabelValue(text)}
               placeholder={identifierFieldDefinition.label}

--- a/packages/twenty-front/src/modules/object-record/record-board/record-board-column/hooks/useAddNewCard.ts
+++ b/packages/twenty-front/src/modules/object-record/record-board/record-board-column/hooks/useAddNewCard.ts
@@ -73,7 +73,6 @@ export const useAddNewCard = ({
 
   const createRecord = useCallback(
     (
-      labelIdentifier: string,
       labelValue: string,
       position: 'first' | 'last',
       isOpportunity: boolean,
@@ -112,7 +111,7 @@ export const useAddNewCard = ({
           ...(isOpportunity
             ? { companyId: company?.id, name: company?.name }
             : {
-                [labelIdentifier.toLowerCase()]: computedLabelIdentifierValue,
+                [labelIdentifierField.name]: computedLabelIdentifierValue,
               }),
         });
       }
@@ -129,7 +128,6 @@ export const useAddNewCard = ({
   const handleAddNewCardClick = useRecoilCallback(
     ({ set }) =>
       (
-        labelIdentifier: string,
         labelValue: string,
         position: 'first' | 'last',
         isOpportunity: boolean,
@@ -142,7 +140,7 @@ export const useAddNewCard = ({
             SingleRecordPickerHotkeyScope.SingleRecordPicker,
           );
         } else {
-          createRecord(labelIdentifier, labelValue, position, isOpportunity);
+          createRecord(labelValue, position, isOpportunity);
         }
       },
     [
@@ -184,25 +182,17 @@ export const useAddNewCard = ({
   );
 
   const handleCreate = (
-    labelIdentifier: string,
     labelValue: string,
     position: 'first' | 'last',
     onCreateSuccess?: () => void,
   ) => {
     if (labelValue.trim() !== '' && position !== undefined) {
-      handleAddNewCardClick(
-        labelIdentifier,
-        labelValue.trim(),
-        position,
-        false,
-        '',
-      );
+      handleAddNewCardClick(labelValue.trim(), position, false, '');
       onCreateSuccess?.();
     }
   };
 
   const handleBlur = (
-    labelIdentifier: string,
     labelValue: string,
     position: 'first' | 'last',
     onCreateSuccess?: () => void,
@@ -210,17 +200,16 @@ export const useAddNewCard = ({
     if (labelValue.trim() === '') {
       onCreateSuccess?.();
     } else {
-      handleCreate(labelIdentifier, labelValue, position, onCreateSuccess);
+      handleCreate(labelValue, position, onCreateSuccess);
     }
   };
 
   const handleInputEnter = (
-    labelIdentifier: string,
     labelValue: string,
     position: 'first' | 'last',
     onCreateSuccess?: () => void,
   ) => {
-    handleCreate(labelIdentifier, labelValue, position, onCreateSuccess);
+    handleCreate(labelValue, position, onCreateSuccess);
   };
 
   const handleEntitySelect = useCallback(
@@ -230,7 +219,7 @@ export const useAddNewCard = ({
       columnId?: string,
     ) => {
       const columnDefinitionId = getColumnDefinitionId(columnId);
-      createRecord('', '', position, true, company);
+      createRecord('', position, true, company);
       handleCreateSuccess(position, columnDefinitionId, true);
     },
     [createRecord, handleCreateSuccess, getColumnDefinitionId],

--- a/packages/twenty-front/src/modules/object-record/record-board/record-board-column/hooks/useColumnNewCardActions.ts
+++ b/packages/twenty-front/src/modules/object-record/record-board/record-board-column/hooks/useColumnNewCardActions.ts
@@ -1,16 +1,6 @@
 import { useAddNewCard } from '@/object-record/record-board/record-board-column/hooks/useAddNewCard';
-import { recordBoardVisibleFieldDefinitionsComponentSelector } from '@/object-record/record-board/states/selectors/recordBoardVisibleFieldDefinitionsComponentSelector';
-import { useRecoilComponentValueV2 } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValueV2';
 
 export const useColumnNewCardActions = (columnId: string) => {
-  const visibleFieldDefinitions = useRecoilComponentValueV2(
-    recordBoardVisibleFieldDefinitionsComponentSelector,
-  );
-
-  const labelIdentifierField = visibleFieldDefinitions.find(
-    (field) => field.isLabelIdentifier,
-  );
-
   const { handleAddNewCardClick } = useAddNewCard({
     recordPickerComponentInstanceId: `add-new-card-record-picker-column-${columnId}`,
   });
@@ -19,13 +9,7 @@ export const useColumnNewCardActions = (columnId: string) => {
     position: 'first' | 'last',
     isOpportunity: boolean,
   ) => {
-    handleAddNewCardClick(
-      labelIdentifierField?.label ?? '',
-      '',
-      position,
-      isOpportunity,
-      columnId,
-    );
+    handleAddNewCardClick('', position, isOpportunity, columnId);
   };
 
   return {

--- a/packages/twenty-front/src/modules/object-record/record-index/components/RecordIndexPageKanbanAddButton.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-index/components/RecordIndexPageKanbanAddButton.tsx
@@ -1,7 +1,6 @@
 import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
 import { useAddNewCard } from '@/object-record/record-board/record-board-column/hooks/useAddNewCard';
 import { useIsOpportunitiesCompanyFieldDisabled } from '@/object-record/record-board/record-board-column/hooks/useIsOpportunitiesCompanyFieldDisabled';
-import { recordBoardVisibleFieldDefinitionsComponentSelector } from '@/object-record/record-board/states/selectors/recordBoardVisibleFieldDefinitionsComponentSelector';
 import { visibleRecordGroupIdsComponentFamilySelector } from '@/object-record/record-group/states/selectors/visibleRecordGroupIdsComponentFamilySelector';
 import { RecordGroupDefinition } from '@/object-record/record-group/types/RecordGroupDefinition';
 import { RecordIndexPageKanbanAddMenuItem } from '@/object-record/record-index/components/RecordIndexPageKanbanAddMenuItem';
@@ -12,7 +11,6 @@ import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/Drop
 import { useDropdown } from '@/ui/layout/dropdown/hooks/useDropdown';
 import { PageAddButton } from '@/ui/layout/page/components/PageAddButton';
 import { useRecoilComponentFamilyValueV2 } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentFamilyValueV2';
-import { useRecoilComponentValueV2 } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValueV2';
 import { ViewType } from '@/views/types/ViewType';
 import { useCallback } from 'react';
 import { useRecoilValue } from 'recoil';
@@ -20,7 +18,7 @@ import { useRecoilValue } from 'recoil';
 export const RecordIndexPageKanbanAddButton = () => {
   const dropdownId = `record-index-page-add-button-dropdown`;
 
-  const { recordIndexId, objectMetadataItem } = useRecordIndexContextOrThrow();
+  const { objectMetadataItem } = useRecordIndexContextOrThrow();
 
   const visibleRecordGroupIds = useRecoilComponentFamilyValueV2(
     visibleRecordGroupIdsComponentFamilySelector,
@@ -37,15 +35,6 @@ export const RecordIndexPageKanbanAddButton = () => {
   const isOpportunity =
     objectMetadataItem.nameSingular === CoreObjectNameSingular.Opportunity;
 
-  const visibleFieldDefinitions = useRecoilComponentValueV2(
-    recordBoardVisibleFieldDefinitionsComponentSelector,
-    recordIndexId,
-  );
-
-  const labelIdentifierField = visibleFieldDefinitions.find(
-    (field) => field.isLabelIdentifier,
-  );
-
   const { closeDropdown } = useDropdown(dropdownId);
   const { isOpportunitiesCompanyFieldDisabled } =
     useIsOpportunitiesCompanyFieldDisabled();
@@ -58,7 +47,6 @@ export const RecordIndexPageKanbanAddButton = () => {
       const isOpportunityEnabled =
         isOpportunity && !isOpportunitiesCompanyFieldDisabled;
       handleAddNewCardClick(
-        labelIdentifierField?.label ?? '',
         '',
         'first',
         isOpportunityEnabled,
@@ -70,7 +58,6 @@ export const RecordIndexPageKanbanAddButton = () => {
       isOpportunity,
       handleAddNewCardClick,
       closeDropdown,
-      labelIdentifierField,
       isOpportunitiesCompanyFieldDisabled,
     ],
   );


### PR DESCRIPTION
When creating an object from kanban, we are using `labelIdentifier.toLowerCase()` for the labelIdentifier field.
Issue is that labelIdentifier is translated.

Using `labelIdentifierField.name` instead.