### PR TITLE
Fix keystatic github redirect_uri by relying on x-forwarded-* headers

### DIFF
--- a/packages/twenty-website/src/app/api/keystatic/[...params]/route.ts
+++ b/packages/twenty-website/src/app/api/keystatic/[...params]/route.ts
@@ -1,6 +1,30 @@
 import { makeRouteHandler } from '@keystatic/next/route-handler';
 import config from '../../../../../keystatic.config';
 
-export const { POST, GET } = makeRouteHandler({
-  config,
-});
+const { GET: _GET, POST: _POST } = makeRouteHandler({ config });
+
+function rewriteUrl(request: Request) {
+  const forwardedHost = request.headers.get('x-forwarded-host');
+  const forwardedProto = request.headers.get('x-forwarded-proto');
+  const forwardedPort = request.headers.get('x-forwarded-port');
+
+  if (forwardedHost && forwardedProto) {
+    const url = new URL(request.url);
+
+    url.hostname = forwardedHost;
+    url.protocol = forwardedProto;
+    url.port = forwardedPort ?? '';
+
+    return new Request(url, request);
+  }
+
+  return request;
+}
+
+export function GET(request: Request) {
+  return _GET(rewriteUrl(request));
+}
+
+export function POST(request: Request) {
+  return _POST(rewriteUrl(request));
+}


### PR DESCRIPTION
Fix suggested by https://github.com/Thinkmill/keystatic/issues/1022#issuecomment-2009029315.