### PR TITLE
[ENH] `APP_VERSION`documentation

### DIFF
--- a/packages/twenty-server/src/database/commands/command-runners/__tests__/__snapshots__/upgrade.command-runner.spec.ts.snap
+++ b/packages/twenty-server/src/database/commands/command-runners/__tests__/__snapshots__/upgrade.command-runner.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`UpgradeCommandRunner Workspace upgrade should fail when APP_VERSION is not defined 1`] = `[Error: Cannot run upgrade command when APP_VERSION is not defined]`;
+exports[`UpgradeCommandRunner Workspace upgrade should fail when APP_VERSION is not defined 1`] = `[Error: Cannot run upgrade command when APP_VERSION is not defined, please double check your env variables]`;
 
 exports[`UpgradeCommandRunner Workspace upgrade should fail when workspace version is not defined 1`] = `[Error: WORKSPACE_VERSION_NOT_DEFINED to=2.0.0]`;
 

--- a/packages/twenty-server/src/database/commands/command-runners/upgrade.command-runner.ts
+++ b/packages/twenty-server/src/database/commands/command-runners/upgrade.command-runner.ts
@@ -97,7 +97,7 @@ export abstract class UpgradeCommandRunner extends ActiveOrSuspendedWorkspacesMi
   }: ValidateWorkspaceVersionEqualsWorkspaceFromVersionOrThrowArgs): Promise<CompareVersionMajorAndMinorReturnType> {
     if (!isDefined(appVersion)) {
       throw new Error(
-        'Cannot run upgrade command when APP_VERSION is not defined',
+        'Cannot run upgrade command when APP_VERSION is not defined, please double check your env variables',
       );
     }
 


### PR DESCRIPTION
# Introduction
In https://github.com/twentyhq/twenty/pull/10751 we decided not to put `APP_VERSION` references in `.env.example` as it's programmatically defined by our CD and should not be override by any manual interaction.

Still, as a dev testing the upgrade command in local, if you do not set the `APP_VERSION` in local you will encounter the following error:
```ts
'Cannot run upgrade command when APP_VERSION is not defined'
```

@guillim currently doing the release legitimately raised that it was not very intuitive

## Levers
- Improve error message such as adding reference to checking env variables
- App local upgrade command dev dedicated documentation ?

## Conclusion
Any suggestions are more than welcomed !