### PR TITLE
Compute any new `Workspace` version from `APP_VERSION`

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.ts
@@ -344,12 +344,14 @@ export class SignInUpService {
     const logo =
       isWorkEmail(user.email) && (await isLogoUrlValid()) ? logoUrl : undefined;
 
+    const appVersion = this.environmentService.get("APP_VERSION");
     const workspaceToCreate = this.workspaceRepository.create({
       subdomain: await this.domainManagerService.generateSubdomain(),
       displayName: '',
       inviteHash: v4(),
       activationStatus: WorkspaceActivationStatus.PENDING_CREATION,
       logo,
+      version: appVersion
     });
 
     const workspace = await this.workspaceRepository.save(workspaceToCreate);

--- a/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.ts
@@ -344,14 +344,12 @@ export class SignInUpService {
     const logo =
       isWorkEmail(user.email) && (await isLogoUrlValid()) ? logoUrl : undefined;
 
-    const appVersion = this.environmentService.get("APP_VERSION");
     const workspaceToCreate = this.workspaceRepository.create({
       subdomain: await this.domainManagerService.generateSubdomain(),
       displayName: '',
       inviteHash: v4(),
       activationStatus: WorkspaceActivationStatus.PENDING_CREATION,
       logo,
-      version: appVersion
     });
 
     const workspace = await this.workspaceRepository.save(workspaceToCreate);

--- a/packages/twenty-server/src/engine/core-modules/workspace/services/workspace.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/services/workspace.service.ts
@@ -271,9 +271,14 @@ export class WorkspaceService extends TypeOrmQueryService<Workspace> {
     });
     await this.userWorkspaceService.createWorkspaceMember(workspace.id, user);
 
+    const appVersion = this.environmentService.get("APP_VERSION") ?? null;
+    if (!isDefined(appVersion)) {
+      // do sentry warning
+    }
     await this.workspaceRepository.update(workspace.id, {
       displayName: data.displayName,
       activationStatus: WorkspaceActivationStatus.ACTIVE,
+      version: appVersion
     });
 
     return await this.workspaceRepository.findOneBy({

--- a/packages/twenty-server/src/engine/core-modules/workspace/services/workspace.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/services/workspace.service.ts
@@ -272,9 +272,6 @@ export class WorkspaceService extends TypeOrmQueryService<Workspace> {
     await this.userWorkspaceService.createWorkspaceMember(workspace.id, user);
 
     const appVersion = this.environmentService.get("APP_VERSION") ?? null;
-    if (!isDefined(appVersion)) {
-      // do sentry warning
-    }
     await this.workspaceRepository.update(workspace.id, {
       displayName: data.displayName,
       activationStatus: WorkspaceActivationStatus.ACTIVE,

--- a/packages/twenty-server/src/engine/core-modules/workspace/services/workspace.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/services/workspace.service.ts
@@ -271,11 +271,12 @@ export class WorkspaceService extends TypeOrmQueryService<Workspace> {
     });
     await this.userWorkspaceService.createWorkspaceMember(workspace.id, user);
 
-    const appVersion = this.environmentService.get("APP_VERSION") ?? null;
+    const appVersion = this.environmentService.get('APP_VERSION') ?? null;
+
     await this.workspaceRepository.update(workspace.id, {
       displayName: data.displayName,
       activationStatus: WorkspaceActivationStatus.ACTIVE,
-      version: appVersion
+      version: appVersion,
     });
 
     return await this.workspaceRepository.findOneBy({


### PR DESCRIPTION
# Introduction
We want any new activated workspace to be filled with a version equal to the current `APP_VERSION`
Please note that in a workspace lifecycle this operation will be run only once, discussed with @charlesBochet in front of `3 fois plus de piments`

Going straightforward in this PR in order to release asap
Started et will continue to implem new integrations regarding `SignUp` and `ActivateWorkspace` happy and expections path in https://github.com/twentyhq/twenty/tree/prastoin-new-workspace-has-version-integrations-tests