### PR TITLE
Fix selected record id required after closing settings

### DIFF
--- a/packages/twenty-front/src/modules/action-menu/components/RecordShowActionMenu.tsx
+++ b/packages/twenty-front/src/modules/action-menu/components/RecordShowActionMenu.tsx
@@ -5,6 +5,7 @@ import { ActionMenuConfirmationModals } from '@/action-menu/components/ActionMen
 import { RecordShowActionMenuButtons } from '@/action-menu/components/RecordShowActionMenuButtons';
 import { ActionMenuContext } from '@/action-menu/contexts/ActionMenuContext';
 import { contextStoreCurrentObjectMetadataItemIdComponentState } from '@/context-store/states/contextStoreCurrentObjectMetadataItemIdComponentState';
+import { contextStoreTargetedRecordsRuleComponentState } from '@/context-store/states/contextStoreTargetedRecordsRuleComponentState';
 import { useRecoilComponentValueV2 } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValueV2';
 import { useIsFeatureEnabled } from '@/workspace/hooks/useIsFeatureEnabled';
 import { FeatureFlagKey } from '~/generated/graphql';
@@ -14,13 +15,21 @@ export const RecordShowActionMenu = () => {
     contextStoreCurrentObjectMetadataItemIdComponentState,
   );
 
+  const contextStoreTargetedRecordsRule = useRecoilComponentValueV2(
+    contextStoreTargetedRecordsRuleComponentState,
+  );
+
+  const hasSelectedRecord =
+    contextStoreTargetedRecordsRule.mode === 'selection' &&
+    contextStoreTargetedRecordsRule.selectedRecordIds.length === 1;
+
   const isWorkflowEnabled = useIsFeatureEnabled(
     FeatureFlagKey.IsWorkflowEnabled,
   );
 
   return (
     <>
-      {contextStoreCurrentObjectMetadataItemId && (
+      {hasSelectedRecord && contextStoreCurrentObjectMetadataItemId && (
         <ActionMenuContext.Provider
           value={{
             isInRightDrawer: false,


### PR DESCRIPTION
On Show page, let's only load the actionMenu if the objectMetadataItem and the selectedRecord are present in the context store