### PR TITLE
Workspace seeders with version

### DIFF
--- a/packages/twenty-server/src/database/commands/data-seed-demo-workspace/services/data-seed-demo-workspace.service.ts
+++ b/packages/twenty-server/src/database/commands/data-seed-demo-workspace/services/data-seed-demo-workspace.service.ts
@@ -44,6 +44,7 @@ export class DataSeedDemoWorkspaceService {
         }
 
         const appVersion = this.environmentService.get('APP_VERSION');
+
         await seedCoreSchema({
           workspaceDataSource: rawDataSource,
           workspaceId,

--- a/packages/twenty-server/src/database/commands/data-seed-demo-workspace/services/data-seed-demo-workspace.service.ts
+++ b/packages/twenty-server/src/database/commands/data-seed-demo-workspace/services/data-seed-demo-workspace.service.ts
@@ -5,7 +5,7 @@ import { Repository } from 'typeorm';
 
 import {
   deleteCoreSchema,
-  seedCoreSchema,
+  seedDemoCoreSchema,
 } from 'src/database/typeorm-seeds/core/demo';
 import { rawDataSource } from 'src/database/typeorm/raw/raw.datasource';
 import { InjectCacheStorage } from 'src/engine/core-modules/cache-storage/decorators/cache-storage.decorator';
@@ -43,7 +43,7 @@ export class DataSeedDemoWorkspaceService {
           await deleteCoreSchema(rawDataSource, workspaceId);
         }
 
-        await seedCoreSchema(rawDataSource, workspaceId);
+        await seedDemoCoreSchema(rawDataSource, workspaceId);
         await this.workspaceManagerService.initDemo(workspaceId);
       }
     } catch (error) {

--- a/packages/twenty-server/src/database/commands/data-seed-demo-workspace/services/data-seed-demo-workspace.service.ts
+++ b/packages/twenty-server/src/database/commands/data-seed-demo-workspace/services/data-seed-demo-workspace.service.ts
@@ -48,7 +48,8 @@ export class DataSeedDemoWorkspaceService {
           workspaceDataSource: rawDataSource,
           workspaceId,
           appVersion,
-          type: 'demo',
+          seedBilling: false,
+          seedFeatureFlags: false,
         });
         await this.workspaceManagerService.initDemo(workspaceId);
       }

--- a/packages/twenty-server/src/database/commands/data-seed-demo-workspace/services/data-seed-demo-workspace.service.ts
+++ b/packages/twenty-server/src/database/commands/data-seed-demo-workspace/services/data-seed-demo-workspace.service.ts
@@ -3,14 +3,13 @@ import { InjectRepository } from '@nestjs/typeorm';
 
 import { Repository } from 'typeorm';
 
-import {
-  deleteCoreSchema,
-  seedDemoCoreSchema,
-} from 'src/database/typeorm-seeds/core/demo';
+import { seedCoreSchema } from 'src/database/typeorm-seeds/core';
+import { deleteCoreSchema } from 'src/database/typeorm-seeds/core/demo';
 import { rawDataSource } from 'src/database/typeorm/raw/raw.datasource';
 import { InjectCacheStorage } from 'src/engine/core-modules/cache-storage/decorators/cache-storage.decorator';
 import { CacheStorageService } from 'src/engine/core-modules/cache-storage/services/cache-storage.service';
 import { CacheStorageNamespace } from 'src/engine/core-modules/cache-storage/types/cache-storage-namespace.enum';
+import { EnvironmentService } from 'src/engine/core-modules/environment/environment.service';
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { WorkspaceManagerService } from 'src/engine/workspace-manager/workspace-manager.service';
 
@@ -22,6 +21,7 @@ export class DataSeedDemoWorkspaceService {
     protected readonly workspaceRepository: Repository<Workspace>,
     @InjectCacheStorage(CacheStorageNamespace.EngineWorkspace)
     private readonly workspaceSchemaCache: CacheStorageService,
+    private readonly environmentService: EnvironmentService,
   ) {}
 
   async seedDemo(): Promise<void> {
@@ -43,7 +43,13 @@ export class DataSeedDemoWorkspaceService {
           await deleteCoreSchema(rawDataSource, workspaceId);
         }
 
-        await seedDemoCoreSchema(rawDataSource, workspaceId);
+        const appVersion = this.environmentService.get('APP_VERSION');
+        await seedCoreSchema({
+          workspaceDataSource: rawDataSource,
+          workspaceId,
+          appVersion,
+          type: 'demo',
+        });
         await this.workspaceManagerService.initDemo(workspaceId);
       }
     } catch (error) {

--- a/packages/twenty-server/src/database/commands/data-seed-dev-workspace.command.ts
+++ b/packages/twenty-server/src/database/commands/data-seed-dev-workspace.command.ts
@@ -95,12 +95,12 @@ export class DataSeedWorkspaceCommand extends CommandRunner {
     await rawDataSource.initialize();
 
     const isBillingEnabled = this.environmentService.get('IS_BILLING_ENABLED');
-
+    const appVersion = this.environmentService.get('APP_VERSION');
     await seedCoreSchema({
       workspaceDataSource: rawDataSource,
       workspaceId,
       seedBilling: isBillingEnabled,
-      appVersion: this.environmentService.get('APP_VERSION'),
+      appVersion,
     });
 
     await rawDataSource.destroy();

--- a/packages/twenty-server/src/database/commands/data-seed-dev-workspace.command.ts
+++ b/packages/twenty-server/src/database/commands/data-seed-dev-workspace.command.ts
@@ -96,7 +96,12 @@ export class DataSeedWorkspaceCommand extends CommandRunner {
 
     const isBillingEnabled = this.environmentService.get('IS_BILLING_ENABLED');
 
-    await seedCoreSchema(rawDataSource, workspaceId, isBillingEnabled);
+    await seedCoreSchema({
+      workspaceDataSource: rawDataSource,
+      workspaceId,
+      isBillingEnabled,
+      appVersion: this.environmentService.get('APP_VERSION'),
+    });
 
     await rawDataSource.destroy();
 

--- a/packages/twenty-server/src/database/commands/data-seed-dev-workspace.command.ts
+++ b/packages/twenty-server/src/database/commands/data-seed-dev-workspace.command.ts
@@ -96,6 +96,7 @@ export class DataSeedWorkspaceCommand extends CommandRunner {
 
     const isBillingEnabled = this.environmentService.get('IS_BILLING_ENABLED');
     const appVersion = this.environmentService.get('APP_VERSION');
+
     await seedCoreSchema({
       workspaceDataSource: rawDataSource,
       workspaceId,

--- a/packages/twenty-server/src/database/commands/data-seed-dev-workspace.command.ts
+++ b/packages/twenty-server/src/database/commands/data-seed-dev-workspace.command.ts
@@ -99,7 +99,7 @@ export class DataSeedWorkspaceCommand extends CommandRunner {
     await seedCoreSchema({
       workspaceDataSource: rawDataSource,
       workspaceId,
-      isBillingEnabled,
+      seedBilling: isBillingEnabled,
       appVersion: this.environmentService.get('APP_VERSION'),
     });
 

--- a/packages/twenty-server/src/database/typeorm-seeds/core/demo/index.ts
+++ b/packages/twenty-server/src/database/typeorm-seeds/core/demo/index.ts
@@ -1,20 +1,21 @@
 import { DataSource } from 'typeorm';
 
-import {
-  seedUsers,
-  deleteUsersByWorkspace,
-} from 'src/database/typeorm-seeds/core/demo/users';
-import {
-  seedWorkspaces,
-  deleteWorkspaces,
-} from 'src/database/typeorm-seeds/core/demo/workspaces';
 import { deleteFeatureFlags } from 'src/database/typeorm-seeds/core/demo/feature-flags';
 import {
   deleteUserWorkspaces,
   seedUserWorkspaces,
 } from 'src/database/typeorm-seeds/core/demo/user-workspaces';
+import {
+  deleteUsersByWorkspace,
+  seedUsers,
+} from 'src/database/typeorm-seeds/core/demo/users';
+import {
+  deleteWorkspaces,
+  seedWorkspaces,
+} from 'src/database/typeorm-seeds/core/demo/workspaces';
 
-export const seedCoreSchema = async (
+// What is this abstraction ?
+export const seedDemoCoreSchema = async (
   workspaceDataSource: DataSource,
   workspaceId: string,
 ) => {

--- a/packages/twenty-server/src/database/typeorm-seeds/core/demo/index.ts
+++ b/packages/twenty-server/src/database/typeorm-seeds/core/demo/index.ts
@@ -1,30 +1,9 @@
 import { DataSource } from 'typeorm';
 
 import { deleteFeatureFlags } from 'src/database/typeorm-seeds/core/demo/feature-flags';
-import {
-  deleteUserWorkspaces,
-  seedUserWorkspaces,
-} from 'src/database/typeorm-seeds/core/demo/user-workspaces';
-import {
-  deleteUsersByWorkspace,
-  seedUsers,
-} from 'src/database/typeorm-seeds/core/demo/users';
-import {
-  deleteWorkspaces,
-  seedWorkspaces,
-} from 'src/database/typeorm-seeds/core/demo/workspaces';
-
-// What is this abstraction ?
-export const seedDemoCoreSchema = async (
-  workspaceDataSource: DataSource,
-  workspaceId: string,
-) => {
-  const schemaName = 'core';
-
-  await seedWorkspaces(workspaceDataSource, schemaName, workspaceId);
-  await seedUsers(workspaceDataSource, schemaName);
-  await seedUserWorkspaces(workspaceDataSource, schemaName, workspaceId);
-};
+import { deleteUserWorkspaces } from 'src/database/typeorm-seeds/core/demo/user-workspaces';
+import { deleteUsersByWorkspace } from 'src/database/typeorm-seeds/core/demo/users';
+import { deleteWorkspaces } from 'src/database/typeorm-seeds/core/demo/workspaces';
 
 export const deleteCoreSchema = async (
   workspaceDataSource: DataSource,

--- a/packages/twenty-server/src/database/typeorm-seeds/core/index.ts
+++ b/packages/twenty-server/src/database/typeorm-seeds/core/index.ts
@@ -27,7 +27,7 @@ export const seedCoreSchema = async ({
     workspaceDataSource,
     schemaName,
     workspaceId,
-    appVersion: appVersion,
+    appVersion,
   });
   await seedUsers(workspaceDataSource, schemaName);
   await seedUserWorkspaces(workspaceDataSource, schemaName, workspaceId);

--- a/packages/twenty-server/src/database/typeorm-seeds/core/index.ts
+++ b/packages/twenty-server/src/database/typeorm-seeds/core/index.ts
@@ -6,14 +6,22 @@ import { seedUserWorkspaces } from 'src/database/typeorm-seeds/core/user-workspa
 import { seedUsers } from 'src/database/typeorm-seeds/core/users';
 import { seedWorkspaces } from 'src/database/typeorm-seeds/core/workspaces';
 
-export const seedCoreSchema = async (
-  workspaceDataSource: DataSource,
-  workspaceId: string,
-  isBillingEnabled: boolean,
-) => {
+// Test
+type SeedCoreSchemaArgs = {
+  workspaceDataSource: DataSource;
+  workspaceId: string;
+  isBillingEnabled: boolean;
+  appVersion: string | undefined;
+};
+export const seedCoreSchema = async ({
+  isBillingEnabled,
+  appVersion,
+  workspaceDataSource,
+  workspaceId,
+}: SeedCoreSchemaArgs) => {
   const schemaName = 'core';
 
-  await seedWorkspaces(workspaceDataSource, schemaName, workspaceId);
+  await seedWorkspaces({ workspaceDataSource, schemaName, workspaceId });
   await seedUsers(workspaceDataSource, schemaName);
   await seedUserWorkspaces(workspaceDataSource, schemaName, workspaceId);
   await seedFeatureFlags(workspaceDataSource, schemaName, workspaceId);

--- a/packages/twenty-server/src/database/typeorm-seeds/core/index.ts
+++ b/packages/twenty-server/src/database/typeorm-seeds/core/index.ts
@@ -27,7 +27,7 @@ export const seedCoreSchema = async ({
     workspaceDataSource,
     schemaName,
     workspaceId,
-    version: appVersion,
+    appVersion: appVersion,
   });
   await seedUsers(workspaceDataSource, schemaName);
   await seedUserWorkspaces(workspaceDataSource, schemaName, workspaceId);

--- a/packages/twenty-server/src/database/typeorm-seeds/core/index.ts
+++ b/packages/twenty-server/src/database/typeorm-seeds/core/index.ts
@@ -6,29 +6,21 @@ import { seedUserWorkspaces } from 'src/database/typeorm-seeds/core/user-workspa
 import { seedUsers } from 'src/database/typeorm-seeds/core/users';
 import { seedWorkspaces } from 'src/database/typeorm-seeds/core/workspaces';
 
-type SeedCoreSchemaCommonArgs = {
+type SeedCoreSchemaArgs = {
   workspaceDataSource: DataSource;
   workspaceId: string;
   appVersion: string | undefined;
+  seedBilling?: boolean;
+  seedFeatureFlags?: boolean;
 };
 
-type SeedCoreSchemaArgs = SeedCoreSchemaCommonArgs &
-  (
-    | {
-        type: 'dev';
-        isBillingEnabled: boolean;
-      }
-    | {
-        type: 'demo';
-      }
-  );
 export const seedCoreSchema = async ({
   appVersion,
   workspaceDataSource,
   workspaceId,
-  ...rest
+  seedBilling = true,
+  seedFeatureFlags: shouldSeedFeatureFlags = true,
 }: SeedCoreSchemaArgs) => {
-  const { type } = rest;
   const schemaName = 'core';
 
   await seedWorkspaces({
@@ -40,16 +32,15 @@ export const seedCoreSchema = async ({
   await seedUsers(workspaceDataSource, schemaName);
   await seedUserWorkspaces(workspaceDataSource, schemaName, workspaceId);
 
-  if (type === 'dev') {
-    const { isBillingEnabled } = rest;
-
+  if (shouldSeedFeatureFlags) {
     await seedFeatureFlags(workspaceDataSource, schemaName, workspaceId);
-    if (isBillingEnabled) {
-      await seedBillingSubscriptions(
-        workspaceDataSource,
-        schemaName,
-        workspaceId,
-      );
-    }
+  }
+
+  if (seedBilling) {
+    await seedBillingSubscriptions(
+      workspaceDataSource,
+      schemaName,
+      workspaceId,
+    );
   }
 };

--- a/packages/twenty-server/src/database/typeorm-seeds/core/workspaces.ts
+++ b/packages/twenty-server/src/database/typeorm-seeds/core/workspaces.ts
@@ -2,6 +2,7 @@ import { WorkspaceActivationStatus } from 'twenty-shared';
 import { DataSource } from 'typeorm';
 
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
+import { extractVersionMajorMinorPatch } from 'src/utils/version/extract-version-major-minor-patch';
 
 const tableName = 'workspace';
 
@@ -12,14 +13,16 @@ export type SeedWorkspaceArgs = {
   workspaceDataSource: DataSource;
   schemaName: string;
   workspaceId: string;
-  version: string | undefined;
+  appVersion: string | undefined;
 };
 export const seedWorkspaces = async ({
   schemaName,
   workspaceDataSource,
   workspaceId,
-  version,
+  appVersion,
 }: SeedWorkspaceArgs) => {
+  const version = extractVersionMajorMinorPatch(appVersion);
+  console.log({ appVersion, version });
   const workspaces: {
     [key: string]: Pick<
       Workspace,
@@ -39,7 +42,7 @@ export const seedWorkspaces = async ({
       inviteHash: 'apple.dev-invite-hash',
       logo: 'https://twentyhq.github.io/placeholder-images/workspaces/apple-logo.png',
       activationStatus: WorkspaceActivationStatus.ACTIVE,
-      version: version ?? null,
+      version: version,
     },
     [SEED_ACME_WORKSPACE_ID]: {
       id: workspaceId,
@@ -48,7 +51,7 @@ export const seedWorkspaces = async ({
       inviteHash: 'acme.dev-invite-hash',
       logo: 'https://logos-world.net/wp-content/uploads/2022/05/Acme-Logo-700x394.png',
       activationStatus: WorkspaceActivationStatus.ACTIVE,
-      version: version ?? null,
+      version: version,
     },
   };
 
@@ -62,6 +65,7 @@ export const seedWorkspaces = async ({
       'inviteHash',
       'logo',
       'activationStatus',
+      'version',
     ])
     .orIgnore()
     .values(workspaces[workspaceId])

--- a/packages/twenty-server/src/database/typeorm-seeds/core/workspaces.ts
+++ b/packages/twenty-server/src/database/typeorm-seeds/core/workspaces.ts
@@ -12,13 +12,13 @@ export type SeedWorkspaceArgs = {
   workspaceDataSource: DataSource;
   schemaName: string;
   workspaceId: string;
-  version?: string | null;
+  version: string | undefined;
 };
 export const seedWorkspaces = async ({
   schemaName,
   workspaceDataSource,
   workspaceId,
-  version = null,
+  version,
 }: SeedWorkspaceArgs) => {
   const workspaces: {
     [key: string]: Pick<
@@ -39,7 +39,7 @@ export const seedWorkspaces = async ({
       inviteHash: 'apple.dev-invite-hash',
       logo: 'https://twentyhq.github.io/placeholder-images/workspaces/apple-logo.png',
       activationStatus: WorkspaceActivationStatus.ACTIVE,
-      version,
+      version: version ?? null,
     },
     [SEED_ACME_WORKSPACE_ID]: {
       id: workspaceId,
@@ -48,7 +48,7 @@ export const seedWorkspaces = async ({
       inviteHash: 'acme.dev-invite-hash',
       logo: 'https://logos-world.net/wp-content/uploads/2022/05/Acme-Logo-700x394.png',
       activationStatus: WorkspaceActivationStatus.ACTIVE,
-      version,
+      version: version ?? null,
     },
   };
 

--- a/packages/twenty-server/src/database/typeorm-seeds/core/workspaces.ts
+++ b/packages/twenty-server/src/database/typeorm-seeds/core/workspaces.ts
@@ -15,6 +15,22 @@ export type SeedWorkspaceArgs = {
   workspaceId: string;
   appVersion: string | undefined;
 };
+
+const workspaceSeederFields = [
+  'id',
+  'displayName',
+  'subdomain',
+  'inviteHash',
+  'logo',
+  'activationStatus',
+  'version',
+] as const satisfies (keyof Workspace)[];
+
+type WorkspaceSeederFields = Pick<
+  Workspace,
+  (typeof workspaceSeederFields)[number]
+>;
+
 export const seedWorkspaces = async ({
   schemaName,
   workspaceDataSource,
@@ -23,18 +39,7 @@ export const seedWorkspaces = async ({
 }: SeedWorkspaceArgs) => {
   const version = extractVersionMajorMinorPatch(appVersion);
 
-  const workspaces: {
-    [key: string]: Pick<
-      Workspace,
-      | 'version'
-      | 'id'
-      | 'displayName'
-      | 'inviteHash'
-      | 'logo'
-      | 'subdomain'
-      | 'activationStatus'
-    >;
-  } = {
+  const workspaces: Record<string, WorkspaceSeederFields> = {
     [SEED_APPLE_WORKSPACE_ID]: {
       id: workspaceId,
       displayName: 'Apple',
@@ -58,15 +63,7 @@ export const seedWorkspaces = async ({
   await workspaceDataSource
     .createQueryBuilder()
     .insert()
-    .into(`${schemaName}.${tableName}`, [
-      'id',
-      'displayName',
-      'subdomain',
-      'inviteHash',
-      'logo',
-      'activationStatus',
-      'version',
-    ])
+    .into(`${schemaName}.${tableName}`, workspaceSeederFields)
     .orIgnore()
     .values(workspaces[workspaceId])
     .execute();

--- a/packages/twenty-server/src/database/typeorm-seeds/core/workspaces.ts
+++ b/packages/twenty-server/src/database/typeorm-seeds/core/workspaces.ts
@@ -41,7 +41,7 @@ export const seedWorkspaces = async ({
 
   const workspaces: Record<string, WorkspaceSeederFields> = {
     [SEED_APPLE_WORKSPACE_ID]: {
-      id: workspaceId,
+      id: SEED_APPLE_WORKSPACE_ID,
       displayName: 'Apple',
       subdomain: 'apple',
       inviteHash: 'apple.dev-invite-hash',
@@ -50,7 +50,7 @@ export const seedWorkspaces = async ({
       version: version,
     },
     [SEED_ACME_WORKSPACE_ID]: {
-      id: workspaceId,
+      id: SEED_ACME_WORKSPACE_ID,
       displayName: 'Acme',
       subdomain: 'acme',
       inviteHash: 'acme.dev-invite-hash',

--- a/packages/twenty-server/src/database/typeorm-seeds/core/workspaces.ts
+++ b/packages/twenty-server/src/database/typeorm-seeds/core/workspaces.ts
@@ -8,14 +8,22 @@ const tableName = 'workspace';
 export const SEED_APPLE_WORKSPACE_ID = '20202020-1c25-4d02-bf25-6aeccf7ea419';
 export const SEED_ACME_WORKSPACE_ID = '3b8e6458-5fc1-4e63-8563-008ccddaa6db';
 
-export const seedWorkspaces = async (
-  workspaceDataSource: DataSource,
-  schemaName: string,
-  workspaceId: string,
-) => {
+export type SeedWorkspaceArgs = {
+  workspaceDataSource: DataSource;
+  schemaName: string;
+  workspaceId: string;
+  version?: string | null;
+};
+export const seedWorkspaces = async ({
+  schemaName,
+  workspaceDataSource,
+  workspaceId,
+  version = null,
+}: SeedWorkspaceArgs) => {
   const workspaces: {
     [key: string]: Pick<
       Workspace,
+      | 'version'
       | 'id'
       | 'displayName'
       | 'inviteHash'
@@ -31,6 +39,7 @@ export const seedWorkspaces = async (
       inviteHash: 'apple.dev-invite-hash',
       logo: 'https://twentyhq.github.io/placeholder-images/workspaces/apple-logo.png',
       activationStatus: WorkspaceActivationStatus.ACTIVE,
+      version,
     },
     [SEED_ACME_WORKSPACE_ID]: {
       id: workspaceId,
@@ -39,6 +48,7 @@ export const seedWorkspaces = async (
       inviteHash: 'acme.dev-invite-hash',
       logo: 'https://logos-world.net/wp-content/uploads/2022/05/Acme-Logo-700x394.png',
       activationStatus: WorkspaceActivationStatus.ACTIVE,
+      version,
     },
   };
 

--- a/packages/twenty-server/src/database/typeorm-seeds/core/workspaces.ts
+++ b/packages/twenty-server/src/database/typeorm-seeds/core/workspaces.ts
@@ -22,7 +22,7 @@ export const seedWorkspaces = async ({
   appVersion,
 }: SeedWorkspaceArgs) => {
   const version = extractVersionMajorMinorPatch(appVersion);
-  console.log({ appVersion, version });
+
   const workspaces: {
     [key: string]: Pick<
       Workspace,


### PR DESCRIPTION
# Introduction
close https://github.com/twentyhq/core-team-issues/issues/487
Updated the seeders to infer the workspace's version from the `APP_VERSION` env var

To test in local run: `npx nx database:reset twenty-server` with either a defined or not defined `APP_VERSION` in your `.env`
( note that invalid semver values will throw an error and stop the process ) ( valid version ex: `APP_VERSION=1.0.0`)