### PR TITLE
Fix activity target picker click outside not closing the menu

### DIFF
--- a/packages/twenty-front/src/modules/activities/inline-cell/components/ActivityTargetsInlineCell.tsx
+++ b/packages/twenty-front/src/modules/activities/inline-cell/components/ActivityTargetsInlineCell.tsx
@@ -90,7 +90,9 @@ export const ActivityTargetsInlineCell = ({
                 editModeContent: (
                   <MultipleRecordPicker
                     componentInstanceId={multipleRecordPickerInstanceId}
-                    onClickOutside={() => {}}
+                    onClickOutside={() => {
+                      closeInlineCell();
+                    }}
                     onChange={(morphItem) => {
                       updateActivityTargetFromInlineCell({
                         recordPickerInstanceId: multipleRecordPickerInstanceId,


### PR DESCRIPTION
## Context
onClickOutside was not implemented after the refactoring