### PR TITLE
Fix record filters, sorts and groups

### DIFF
--- a/packages/twenty-front/src/modules/views/components/ViewBarRecordFilterEffect.tsx
+++ b/packages/twenty-front/src/modules/views/components/ViewBarRecordFilterEffect.tsx
@@ -1,8 +1,7 @@
-import { COMMAND_MENU_COMPONENT_INSTANCE_ID } from '@/command-menu/constants/CommandMenuComponentInstanceId';
-import { contextStoreCurrentObjectMetadataItemIdComponentState } from '@/context-store/states/contextStoreCurrentObjectMetadataItemIdComponentState';
 import { contextStoreCurrentViewIdComponentState } from '@/context-store/states/contextStoreCurrentViewIdComponentState';
 import { useFilterableFieldMetadataItems } from '@/object-record/record-filter/hooks/useFilterableFieldMetadataItems';
 import { currentRecordFiltersComponentState } from '@/object-record/record-filter/states/currentRecordFiltersComponentState';
+import { useRecordIndexContextOrThrow } from '@/object-record/record-index/contexts/RecordIndexContext';
 import { prefetchViewFromViewIdFamilySelector } from '@/prefetch/states/selector/prefetchViewFromViewIdFamilySelector';
 import { useRecoilComponentFamilyStateV2 } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentFamilyStateV2';
 import { useRecoilComponentValueV2 } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValueV2';
@@ -18,10 +17,7 @@ export const ViewBarRecordFilterEffect = () => {
     contextStoreCurrentViewIdComponentState,
   );
 
-  const contextStoreCurrentObjectMetadataItemId = useRecoilComponentValueV2(
-    contextStoreCurrentObjectMetadataItemIdComponentState,
-    COMMAND_MENU_COMPONENT_INSTANCE_ID,
-  );
+  const { objectMetadataItem } = useRecordIndexContextOrThrow();
 
   const currentView = useRecoilValue(
     prefetchViewFromViewIdFamilySelector({
@@ -44,16 +40,26 @@ export const ViewBarRecordFilterEffect = () => {
   );
 
   const { filterableFieldMetadataItems } = useFilterableFieldMetadataItems(
-    contextStoreCurrentObjectMetadataItemId ?? '',
+    objectMetadataItem.id,
   );
+
+  console.log({
+    currentView,
+    objectMetadataItem,
+    hasInitializedCurrentRecordFilters,
+  });
 
   useEffect(() => {
     if (isDefined(currentView) && !hasInitializedCurrentRecordFilters) {
-      if (
-        currentView.objectMetadataId !== contextStoreCurrentObjectMetadataItemId
-      ) {
+      console.log({
+        isEqual: currentView.objectMetadataId === objectMetadataItem.id,
+      });
+
+      if (currentView.objectMetadataId !== objectMetadataItem.id) {
         return;
       }
+
+      console.log('currentView', currentView);
 
       if (isDefined(currentView)) {
         setCurrentRecordFilters(
@@ -73,7 +79,7 @@ export const ViewBarRecordFilterEffect = () => {
     hasInitializedCurrentRecordFilters,
     setHasInitializedCurrentRecordFilters,
     currentView,
-    contextStoreCurrentObjectMetadataItemId,
+    objectMetadataItem,
   ]);
 
   return null;

--- a/packages/twenty-front/src/modules/views/components/ViewBarRecordFilterEffect.tsx
+++ b/packages/twenty-front/src/modules/views/components/ViewBarRecordFilterEffect.tsx
@@ -43,23 +43,11 @@ export const ViewBarRecordFilterEffect = () => {
     objectMetadataItem.id,
   );
 
-  console.log({
-    currentView,
-    objectMetadataItem,
-    hasInitializedCurrentRecordFilters,
-  });
-
   useEffect(() => {
     if (isDefined(currentView) && !hasInitializedCurrentRecordFilters) {
-      console.log({
-        isEqual: currentView.objectMetadataId === objectMetadataItem.id,
-      });
-
       if (currentView.objectMetadataId !== objectMetadataItem.id) {
         return;
       }
-
-      console.log('currentView', currentView);
 
       if (isDefined(currentView)) {
         setCurrentRecordFilters(

--- a/packages/twenty-front/src/modules/views/components/ViewBarRecordFilterGroupEffect.tsx
+++ b/packages/twenty-front/src/modules/views/components/ViewBarRecordFilterGroupEffect.tsx
@@ -1,7 +1,6 @@
-import { COMMAND_MENU_COMPONENT_INSTANCE_ID } from '@/command-menu/constants/CommandMenuComponentInstanceId';
-import { contextStoreCurrentObjectMetadataItemIdComponentState } from '@/context-store/states/contextStoreCurrentObjectMetadataItemIdComponentState';
 import { contextStoreCurrentViewIdComponentState } from '@/context-store/states/contextStoreCurrentViewIdComponentState';
 import { currentRecordFilterGroupsComponentState } from '@/object-record/record-filter-group/states/currentRecordFilterGroupsComponentState';
+import { useRecordIndexContextOrThrow } from '@/object-record/record-index/contexts/RecordIndexContext';
 import { prefetchViewFromViewIdFamilySelector } from '@/prefetch/states/selector/prefetchViewFromViewIdFamilySelector';
 import { useRecoilComponentFamilyStateV2 } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentFamilyStateV2';
 import { useRecoilComponentValueV2 } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValueV2';
@@ -17,10 +16,7 @@ export const ViewBarRecordFilterGroupEffect = () => {
     contextStoreCurrentViewIdComponentState,
   );
 
-  const contextStoreCurrentObjectMetadataItemId = useRecoilComponentValueV2(
-    contextStoreCurrentObjectMetadataItemIdComponentState,
-    COMMAND_MENU_COMPONENT_INSTANCE_ID,
-  );
+  const { objectMetadataItem } = useRecordIndexContextOrThrow();
 
   const currentView = useRecoilValue(
     prefetchViewFromViewIdFamilySelector({
@@ -44,9 +40,7 @@ export const ViewBarRecordFilterGroupEffect = () => {
 
   useEffect(() => {
     if (isDefined(currentView) && !hasInitializedCurrentRecordFilterGroups) {
-      if (
-        currentView.objectMetadataId !== contextStoreCurrentObjectMetadataItemId
-      ) {
+      if (currentView.objectMetadataId !== objectMetadataItem.id) {
         return;
       }
 
@@ -65,7 +59,7 @@ export const ViewBarRecordFilterGroupEffect = () => {
     setCurrentRecordFilterGroups,
     hasInitializedCurrentRecordFilterGroups,
     setHasInitializedCurrentRecordFilterGroups,
-    contextStoreCurrentObjectMetadataItemId,
+    objectMetadataItem,
     currentView,
   ]);
 

--- a/packages/twenty-front/src/modules/views/components/ViewBarRecordSortEffect.tsx
+++ b/packages/twenty-front/src/modules/views/components/ViewBarRecordSortEffect.tsx
@@ -1,6 +1,5 @@
-import { COMMAND_MENU_COMPONENT_INSTANCE_ID } from '@/command-menu/constants/CommandMenuComponentInstanceId';
-import { contextStoreCurrentObjectMetadataItemIdComponentState } from '@/context-store/states/contextStoreCurrentObjectMetadataItemIdComponentState';
 import { contextStoreCurrentViewIdComponentState } from '@/context-store/states/contextStoreCurrentViewIdComponentState';
+import { useRecordIndexContextOrThrow } from '@/object-record/record-index/contexts/RecordIndexContext';
 import { currentRecordSortsComponentState } from '@/object-record/record-sort/states/currentRecordSortsComponentState';
 import { prefetchViewFromViewIdFamilySelector } from '@/prefetch/states/selector/prefetchViewFromViewIdFamilySelector';
 import { useRecoilComponentFamilyStateV2 } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentFamilyStateV2';
@@ -17,10 +16,7 @@ export const ViewBarRecordSortEffect = () => {
     contextStoreCurrentViewIdComponentState,
   );
 
-  const contextStoreCurrentObjectMetadataItemId = useRecoilComponentValueV2(
-    contextStoreCurrentObjectMetadataItemIdComponentState,
-    COMMAND_MENU_COMPONENT_INSTANCE_ID,
-  );
+  const { objectMetadataItem } = useRecordIndexContextOrThrow();
 
   const currentView = useRecoilValue(
     prefetchViewFromViewIdFamilySelector({
@@ -44,9 +40,7 @@ export const ViewBarRecordSortEffect = () => {
 
   useEffect(() => {
     if (isDefined(currentView) && !hasInitializedCurrentRecordSorts) {
-      if (
-        currentView.objectMetadataId !== contextStoreCurrentObjectMetadataItemId
-      ) {
+      if (currentView.objectMetadataId !== objectMetadataItem.id) {
         return;
       }
 
@@ -59,7 +53,7 @@ export const ViewBarRecordSortEffect = () => {
     hasInitializedCurrentRecordSorts,
     currentView,
     setCurrentRecordSorts,
-    contextStoreCurrentObjectMetadataItemId,
+    objectMetadataItem,
     setHasInitializedCurrentRecordSorts,
   ]);
 


### PR DESCRIPTION
A recent change made contextStoreCurrentObjectMetadataItemIdComponentState not initialized, while it was being used for intializing currentRecordFilters, currentRecordSorts and currentRecordFilterGroups states.

In this PR we use objectMetadataItem in RecordIndexContext to initialize record filters, sorts and filter groups instead.