### PR TITLE
Allow `APP_VERSION` to be empty string + dockerFile fix

### DIFF
--- a/packages/twenty-docker/twenty/Dockerfile
+++ b/packages/twenty-docker/twenty/Dockerfile
@@ -67,6 +67,7 @@ ARG SENTRY_RELEASE
 ENV SENTRY_RELEASE $SENTRY_RELEASE
 
 ARG APP_VERSION
+ENV SENTRY_RELEASE $APP_VERSION
 
 # Copy built applications from previous stages
 COPY --chown=1000 --from=twenty-server-build /app /app

--- a/packages/twenty-docker/twenty/Dockerfile
+++ b/packages/twenty-docker/twenty/Dockerfile
@@ -67,7 +67,7 @@ ARG SENTRY_RELEASE
 ENV SENTRY_RELEASE $SENTRY_RELEASE
 
 ARG APP_VERSION
-ENV SENTRY_RELEASE $APP_VERSION
+ENV APP_VERSION $APP_VERSION
 
 # Copy built applications from previous stages
 COPY --chown=1000 --from=twenty-server-build /app /app

--- a/packages/twenty-docker/twenty/entrypoint.sh
+++ b/packages/twenty-docker/twenty/entrypoint.sh
@@ -1,11 +1,6 @@
 #!/bin/sh
 set -e
 
-# Set APP_VERSION only if it has a value
-if [ ! -z "${APP_VERSION}" ]; then
-    export APP_VERSION="${APP_VERSION}"
-fi
-
 # Check if the initialization has already been done and that we enabled automatic migration
 if [ "${DISABLE_DB_MIGRATIONS}" != "true" ] && [ ! -f /app/docker-data/db_status ]; then
     echo "Running database setup and migrations..."

--- a/packages/twenty-server/src/engine/core-modules/environment/decorators/is-optional-or-empty-string.decorator.ts
+++ b/packages/twenty-server/src/engine/core-modules/environment/decorators/is-optional-or-empty-string.decorator.ts
@@ -1,0 +1,7 @@
+import { ValidateIf, ValidationOptions, isDefined } from 'class-validator';
+
+export function IsOptionalOrEmptyString(validationOptions?: ValidationOptions) {
+  return ValidateIf((_obj, value) => {
+    return isDefined(value) && value !== '';
+  }, validationOptions);
+}

--- a/packages/twenty-server/src/engine/core-modules/environment/environment-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/environment/environment-variables.ts
@@ -11,7 +11,6 @@ import {
   IsString,
   IsUrl,
   ValidateIf,
-  isDefined,
   validateSync,
 } from 'class-validator';
 
@@ -29,6 +28,7 @@ import { CastToPositiveNumber } from 'src/engine/core-modules/environment/decora
 import { EnvironmentVariablesMetadata } from 'src/engine/core-modules/environment/decorators/environment-variables-metadata.decorator';
 import { IsAWSRegion } from 'src/engine/core-modules/environment/decorators/is-aws-region.decorator';
 import { IsDuration } from 'src/engine/core-modules/environment/decorators/is-duration.decorator';
+import { IsOptionalOrEmptyString } from 'src/engine/core-modules/environment/decorators/is-optional-or-empty-string.decorator';
 import { IsStrictlyLowerThan } from 'src/engine/core-modules/environment/decorators/is-strictly-lower-than.decorator';
 import { EnvironmentVariablesGroup } from 'src/engine/core-modules/environment/enums/environment-variables-group.enum';
 import { ExceptionHandlerDriver } from 'src/engine/core-modules/exception-handler/interfaces';
@@ -985,7 +985,7 @@ export class EnvironmentVariables {
     group: EnvironmentVariablesGroup.ServerConfig,
     description: 'Twenty server version',
   })
-  @ValidateIf((env) => isDefined(env.APP_VERSION) && env.APP_VERSION != '')
+  @IsOptionalOrEmptyString()
   @IsSemVer()
   APP_VERSION?: string;
 }

--- a/packages/twenty-server/src/engine/core-modules/environment/environment-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/environment/environment-variables.ts
@@ -12,7 +12,7 @@ import {
   IsUrl,
   ValidateIf,
   isDefined,
-  validateSync
+  validateSync,
 } from 'class-validator';
 
 import { EmailDriver } from 'src/engine/core-modules/email/interfaces/email.interface';
@@ -985,7 +985,7 @@ export class EnvironmentVariables {
     group: EnvironmentVariablesGroup.ServerConfig,
     description: 'Twenty server version',
   })
-  @ValidateIf(env => isDefined(env.APP_VERSION) && env.APP_VERSION != '')
+  @ValidateIf((env) => isDefined(env.APP_VERSION) && env.APP_VERSION != '')
   @IsSemVer()
   APP_VERSION?: string;
 }

--- a/packages/twenty-server/src/engine/core-modules/environment/environment-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/environment/environment-variables.ts
@@ -11,7 +11,8 @@ import {
   IsString,
   IsUrl,
   ValidateIf,
-  validateSync,
+  isDefined,
+  validateSync
 } from 'class-validator';
 
 import { EmailDriver } from 'src/engine/core-modules/email/interfaces/email.interface';
@@ -984,7 +985,7 @@ export class EnvironmentVariables {
     group: EnvironmentVariablesGroup.ServerConfig,
     description: 'Twenty server version',
   })
-  @IsOptional()
+  @ValidateIf(env => isDefined(env.APP_VERSION) && env.APP_VERSION != '')
   @IsSemVer()
   APP_VERSION?: string;
 }


### PR DESCRIPTION
# Introduction
No choice but to allow APP_VERSION to be an empty string as it's though to dynamically define dockerfile env vars