### PR TITLE
Side panel tablist fix

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/show-page/components/ShowPageSubContainer.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/show-page/components/ShowPageSubContainer.tsx
@@ -26,10 +26,6 @@ const StyledShowPageRightContainer = styled.div<{ isMobile: boolean }>`
   overflow: auto;
 `;
 
-const StyledTabListContainer = styled.div<{ shouldDisplay: boolean }>`
-  display: ${({ shouldDisplay }) => (shouldDisplay ? 'flex' : 'none')};
-`;
-
 const StyledTabList = styled(TabList)`
   padding-left: ${({ theme }) => theme.spacing(2)};
 `;
@@ -124,7 +120,7 @@ export const ShowPageSubContainer = ({
         </ShowPageLeftContainer>
       )}
       <StyledShowPageRightContainer isMobile={isMobile}>
-        <StyledTabListContainer shouldDisplay={visibleTabs.length > 1}>
+        {visibleTabs.length > 1 && (
           <StyledTabList
             behaveAsLinks={!isInRightDrawer}
             loading={loading || isNewViewableRecordLoading}
@@ -132,7 +128,7 @@ export const ShowPageSubContainer = ({
             tabs={tabs}
             isInRightDrawer={isInRightDrawer}
           />
-        </StyledTabListContainer>
+        )}
         {(isMobile || isInRightDrawer) && summaryCard}
         <StyledContentContainer isInRightDrawer={isInRightDrawer}>
           {renderActiveTabContent()}


### PR DESCRIPTION
followup #10832
whats wrong? -- in "before" screen grabs, the light bottom border doesn't go all the way!

fix -- removed the redundant div :)

(╯°□°）╯︵ ┻━┻

before:
<img width="608" alt="Screenshot 2025-03-14 at 22 26 26" src="https://github.com/user-attachments/assets/4fff92f7-5adc-4816-95dc-7b78ad08cd1c" />
<img width="605" alt="Screenshot 2025-03-14 at 22 26 20" src="https://github.com/user-attachments/assets/e7a796a3-d5ff-4366-bd45-afbe3a219ee5" />
after:
<img width="610" alt="Screenshot 2025-03-14 at 22 24 33" src="https://github.com/user-attachments/assets/c6f744b8-ec8b-4549-a1bb-db1a9fd1fafe" />
<img width="603" alt="Screenshot 2025-03-14 at 22 24 24" src="https://github.com/user-attachments/assets/4758a591-3375-4387-a115-c74d534decb6" />
