### PR TITLE
[Fix] Class validator native `isSemver` does not handle v-prefix

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/environment/decorators/is-twenty-semver.decorator.ts
+++ b/packages/twenty-server/src/engine/core-modules/environment/decorators/is-twenty-semver.decorator.ts
@@ -12,8 +12,9 @@ export class IsTwentySemVerValidator implements ValidatorConstraintInterface {
   validate(version: any) {
     try {
       const parsed = semver.parse(version);
+
       return parsed !== null;
-    } catch(e) {
+    } catch (e) {
       return false;
     }
   }

--- a/packages/twenty-server/src/engine/core-modules/environment/decorators/is-twenty-semver.decorator.ts
+++ b/packages/twenty-server/src/engine/core-modules/environment/decorators/is-twenty-semver.decorator.ts
@@ -1,0 +1,36 @@
+import {
+  registerDecorator,
+  ValidationArguments,
+  ValidationOptions,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+import semver from 'semver';
+
+@ValidatorConstraint({ async: false })
+export class IsTwentySemVerValidator implements ValidatorConstraintInterface {
+  validate(version: any) {
+    try {
+      const parsed = semver.parse(version);
+      return parsed !== null;
+    } catch(e) {
+      return false;
+    }
+  }
+
+  defaultMessage(args: ValidationArguments) {
+    return `${args.property} must be a valid semantic version (e.g., 1.0.0)`;
+  }
+}
+
+export const IsTwentySemVer =
+  (validationOptions?: ValidationOptions) =>
+  (object: object, propertyName: string) => {
+    registerDecorator({
+      target: object.constructor,
+      propertyName: propertyName,
+      options: validationOptions,
+      constraints: [],
+      validator: IsTwentySemVerValidator,
+    });
+  };

--- a/packages/twenty-server/src/engine/core-modules/environment/decorators/is-twenty-semver.decorator.ts
+++ b/packages/twenty-server/src/engine/core-modules/environment/decorators/is-twenty-semver.decorator.ts
@@ -9,14 +9,10 @@ import semver from 'semver';
 
 @ValidatorConstraint({ async: false })
 export class IsTwentySemVerValidator implements ValidatorConstraintInterface {
-  validate(version: any) {
-    try {
-      const parsed = semver.parse(version);
+  validate(version: string) {
+    const parsed = semver.parse(version);
 
-      return parsed !== null;
-    } catch (e) {
-      return false;
-    }
+    return parsed !== null;
   }
 
   defaultMessage(args: ValidationArguments) {

--- a/packages/twenty-server/src/engine/core-modules/environment/environment-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/environment/environment-variables.ts
@@ -7,19 +7,19 @@ import {
   IsEnum,
   IsNumber,
   IsOptional,
-  IsSemVer,
   IsString,
   IsUrl,
   ValidateIf,
+  ValidationError,
   validateSync,
 } from 'class-validator';
-
 import { EmailDriver } from 'src/engine/core-modules/email/interfaces/email.interface';
 import { AwsRegion } from 'src/engine/core-modules/environment/interfaces/aws-region.interface';
 import { NodeEnvironment } from 'src/engine/core-modules/environment/interfaces/node-environment.interface';
 import { SupportDriver } from 'src/engine/core-modules/environment/interfaces/support.interface';
 import { LLMChatModelDriver } from 'src/engine/core-modules/llm-chat-model/interfaces/llm-chat-model.interface';
 import { LLMTracingDriver } from 'src/engine/core-modules/llm-tracing/interfaces/llm-tracing.interface';
+import { isDefined } from "twenty-shared";
 
 import { CaptchaDriverType } from 'src/engine/core-modules/captcha/interfaces';
 import { CastToBoolean } from 'src/engine/core-modules/environment/decorators/cast-to-boolean.decorator';
@@ -30,12 +30,12 @@ import { IsAWSRegion } from 'src/engine/core-modules/environment/decorators/is-a
 import { IsDuration } from 'src/engine/core-modules/environment/decorators/is-duration.decorator';
 import { IsOptionalOrEmptyString } from 'src/engine/core-modules/environment/decorators/is-optional-or-empty-string.decorator';
 import { IsStrictlyLowerThan } from 'src/engine/core-modules/environment/decorators/is-strictly-lower-than.decorator';
+import { IsTwentySemVer } from 'src/engine/core-modules/environment/decorators/is-twenty-semver.decorator';
 import { EnvironmentVariablesGroup } from 'src/engine/core-modules/environment/enums/environment-variables-group.enum';
 import { ExceptionHandlerDriver } from 'src/engine/core-modules/exception-handler/interfaces';
 import { StorageDriverType } from 'src/engine/core-modules/file-storage/interfaces';
 import { LoggerDriverType } from 'src/engine/core-modules/logger/interfaces';
 import { ServerlessDriverType } from 'src/engine/core-modules/serverless/serverless.interface';
-import { assert } from 'src/utils/assert';
 
 export class EnvironmentVariables {
   @EnvironmentVariablesMetadata({
@@ -986,7 +986,7 @@ export class EnvironmentVariables {
     description: 'Twenty server version',
   })
   @IsOptionalOrEmptyString()
-  @IsSemVer()
+  @IsTwentySemVer()
   APP_VERSION?: string;
 }
 
@@ -995,21 +995,29 @@ export const validate = (
 ): EnvironmentVariables => {
   const validatedConfig = plainToClass(EnvironmentVariables, config);
 
-  const errors = validateSync(validatedConfig, { strictGroups: true });
+  const validationErrors = validateSync(validatedConfig, {
+    strictGroups: true,
+  });
 
-  const warnings = validateSync(validatedConfig, { groups: ['warning'] });
-
-  if (warnings.length > 0) {
-    warnings.forEach((warning) => {
-      if (warning.constraints && warning.property) {
-        Object.values(warning.constraints).forEach((message) => {
-          Logger.warn(message);
-        });
+  const validationWarnings = validateSync(validatedConfig, {
+    groups: ['warning'],
+  });
+  const logValidatonErrors = (errorCollection: ValidationError[], type: 'error' | 'warn') =>
+    errorCollection.forEach((error) => {
+      if (!isDefined(error.constraints) || !isDefined(error.property) ) {
+        return
       }
+      Logger[type](Object.values(error.constraints).join('\n'));
     });
+
+  if (validationWarnings.length > 0) {
+    logValidatonErrors(validationWarnings, 'warn');
   }
 
-  assert(!errors.length, errors.toString());
+  if (validationErrors.length > 0) {
+    logValidatonErrors(validationErrors, 'error');
+    throw new Error("Environment variables validation failed")
+  }
 
   return validatedConfig;
 };

--- a/packages/twenty-server/src/engine/core-modules/environment/environment-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/environment/environment-variables.ts
@@ -13,13 +13,14 @@ import {
   ValidationError,
   validateSync,
 } from 'class-validator';
+import { isDefined } from 'twenty-shared';
+
 import { EmailDriver } from 'src/engine/core-modules/email/interfaces/email.interface';
 import { AwsRegion } from 'src/engine/core-modules/environment/interfaces/aws-region.interface';
 import { NodeEnvironment } from 'src/engine/core-modules/environment/interfaces/node-environment.interface';
 import { SupportDriver } from 'src/engine/core-modules/environment/interfaces/support.interface';
 import { LLMChatModelDriver } from 'src/engine/core-modules/llm-chat-model/interfaces/llm-chat-model.interface';
 import { LLMTracingDriver } from 'src/engine/core-modules/llm-tracing/interfaces/llm-tracing.interface';
-import { isDefined } from "twenty-shared";
 
 import { CaptchaDriverType } from 'src/engine/core-modules/captcha/interfaces';
 import { CastToBoolean } from 'src/engine/core-modules/environment/decorators/cast-to-boolean.decorator';
@@ -1002,10 +1003,13 @@ export const validate = (
   const validationWarnings = validateSync(validatedConfig, {
     groups: ['warning'],
   });
-  const logValidatonErrors = (errorCollection: ValidationError[], type: 'error' | 'warn') =>
+  const logValidatonErrors = (
+    errorCollection: ValidationError[],
+    type: 'error' | 'warn',
+  ) =>
     errorCollection.forEach((error) => {
-      if (!isDefined(error.constraints) || !isDefined(error.property) ) {
-        return
+      if (!isDefined(error.constraints) || !isDefined(error.property)) {
+        return;
       }
       Logger[type](Object.values(error.constraints).join('\n'));
     });
@@ -1016,7 +1020,7 @@ export const validate = (
 
   if (validationErrors.length > 0) {
     logValidatonErrors(validationErrors, 'error');
-    throw new Error("Environment variables validation failed")
+    throw new Error('Environment variables validation failed');
   }
 
   return validatedConfig;


### PR DESCRIPTION
# Introduction
Under the hood class-validator isSemver uses https://github.com/validatorjs/validator.js/blob/master/src/lib/isSemVer.js which does not cover all semVer use cases

## Even tho
Had a discussion with @charles was about to store in db ws version as `vx.y.z`. We felt like we wanted it to be stored as `x.y.z`, in my opinion `APP_VERSION` should reflect the tag used to be build the instance and not be updated
But we could extract only `x.y.z` from it at runtime

Also handling the `v` extraction in CD is IMO not the most reliable

## Env var logging refactor
Now not stopping on first error log
```ts
Successfully compiled: 2128 files with swc (185.34ms)
Watching for file changes.
[Nest] 52686  - 03/14/2025, 6:28:33 PM   ERROR PG_DATABASE_URL should not be null or undefined
PG_DATABASE_URL must be a URL address
[Nest] 52686  - 03/14/2025, 6:28:33 PM   ERROR APP_VERSION must be a valid semantic version (e.g., 1.0.0)

/Users/paulrastoin/ws/twenty/packages/twenty-server/src/engine/core-modules/environment/environment-variables.ts:1019
    throw new Error("Environment variables validation failed")
          ^
Error: Environment variables validation failed
    at Object.validate (/Users/paulrastoin/ws/twenty/packages/twenty-server/src/engine/core-modules/environment/environment-variables.ts:1019:11)
    at Function.forRoot (/Users/paulrastoin/ws/twenty/node_modules/@nestjs/config/dist/config.module.js:67:45)
    at Object.<anonymous> (/Users/paulrastoin/ws/twenty/packages/twenty-server/src/engine/core-modules/environment/environment.module.ts:11:18)
    at Module._compile (node:internal/modules/cjs/loader:1256:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1310:10)
    at Module.load (node:internal/modules/cjs/loader:1119:32)
    at Function.Module._load (node:internal/modules/cjs/loader:960:12)
    at Module.require (node:internal/modules/cjs/loader:1143:19)
    at require (node:internal/modules/cjs/helpers:121:18)
    at Object.<anonymous> (/Users/paulrastoin/ws/twenty/packages/twenty-server/dist/src/database/typeorm/typeorm.module.js:14:28)
```