### PR TITLE
Set attachment authorId nullable

### DIFF
--- a/packages/twenty-server/src/modules/attachment/standard-objects/attachment.workspace-entity.ts
+++ b/packages/twenty-server/src/modules/attachment/standard-objects/attachment.workspace-entity.ts
@@ -72,10 +72,11 @@ export class AttachmentWorkspaceEntity extends BaseWorkspaceEntity {
     inverseSideTarget: () => WorkspaceMemberWorkspaceEntity,
     inverseSideFieldKey: 'authoredAttachments',
   })
-  author: Relation<WorkspaceMemberWorkspaceEntity>;
+  @WorkspaceIsNullable()
+  author: Relation<WorkspaceMemberWorkspaceEntity> | null;
 
   @WorkspaceJoinColumn('author')
-  authorId: string;
+  authorId: string | null;
 
   @WorkspaceRelation({
     standardId: ATTACHMENT_STANDARD_FIELD_IDS.task,


### PR DESCRIPTION
## Context
This should fix workspaceMember deletion when attachments exist.
Attachment should still be available even if its author leaves the workspace. Currently the author is never displayed in the product.

<img width="936" alt="Screenshot 2025-03-14 at 18 46 49" src="https://github.com/user-attachments/assets/30f85505-11d9-4190-9b9e-2f9a433e5da1" />
<img width="953" alt="Screenshot 2025-03-14 at 18 46 25" src="https://github.com/user-attachments/assets/6a8da47d-70ed-420d-9e18-76f5d901a909" />
