### PR TITLE
[fix] Users with readOnly permissions should not be able to edit richtext fields

### DIFF
--- a/packages/twenty-front/src/modules/activities/components/ActivityRichTextEditor.tsx
+++ b/packages/twenty-front/src/modules/activities/components/ActivityRichTextEditor.tsx
@@ -34,7 +34,6 @@ import '@blocknote/mantine/style.css';
 import { useCreateBlockNote } from '@blocknote/react';
 import '@blocknote/react/style.css';
 import { isArray, isNonEmptyString } from '@sniptt/guards';
-import { FieldMetadataType } from '~/generated-metadata/graphql';
 
 type ActivityRichTextEditorProps = {
   activityId: string;
@@ -65,8 +64,6 @@ export const ActivityRichTextEditor = ({
 
   const isReadOnly = isFieldValueReadOnly({
     objectNameSingular: activityObjectNameSingular,
-    fieldName: 'bodyV2',
-    fieldType: FieldMetadataType.RICH_TEXT_V2,
     hasObjectReadOnlyPermission,
     contextStoreCurrentViewType,
     isRecordDeleted: activityInStore?.deletedAt !== null,

--- a/packages/twenty-front/src/modules/activities/components/ActivityRichTextEditor.tsx
+++ b/packages/twenty-front/src/modules/activities/components/ActivityRichTextEditor.tsx
@@ -8,14 +8,18 @@ import { useUploadAttachmentFile } from '@/activities/files/hooks/useUploadAttac
 import { useUpsertActivity } from '@/activities/hooks/useUpsertActivity';
 import { canCreateActivityState } from '@/activities/states/canCreateActivityState';
 import { ActivityEditorHotkeyScope } from '@/activities/types/ActivityEditorHotkeyScope';
+import { contextStoreCurrentViewTypeComponentState } from '@/context-store/states/contextStoreCurrentViewTypeComponentState';
 import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
 import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
 import { modifyRecordFromCache } from '@/object-record/cache/utils/modifyRecordFromCache';
+import { isFieldValueReadOnly } from '@/object-record/record-field/utils/isFieldValueReadOnly';
 import { recordStoreFamilyState } from '@/object-record/record-store/states/recordStoreFamilyState';
+import { useHasObjectReadOnlyPermission } from '@/settings/roles/hooks/useHasObjectReadOnlyPermission';
 import { usePreviousHotkeyScope } from '@/ui/utilities/hotkey/hooks/usePreviousHotkeyScope';
 import { useScopedHotkeys } from '@/ui/utilities/hotkey/hooks/useScopedHotkeys';
 import { AppHotkeyScope } from '@/ui/utilities/hotkey/types/AppHotkeyScope';
 import { isNonTextWritingKey } from '@/ui/utilities/hotkey/utils/isNonTextWritingKey';
+import { useRecoilComponentValueV2 } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValueV2';
 import { Key } from 'ts-key-enum';
 import { isDefined } from 'twenty-shared';
 import { useDebouncedCallback } from 'use-debounce';
@@ -30,6 +34,7 @@ import '@blocknote/mantine/style.css';
 import { useCreateBlockNote } from '@blocknote/react';
 import '@blocknote/react/style.css';
 import { isArray, isNonEmptyString } from '@sniptt/guards';
+import { FieldMetadataType } from '~/generated-metadata/graphql';
 
 type ActivityRichTextEditorProps = {
   activityId: string;
@@ -52,6 +57,20 @@ export const ActivityRichTextEditor = ({
       objectNameSingular: activityObjectNameSingular,
     });
 
+  const contextStoreCurrentViewType = useRecoilComponentValueV2(
+    contextStoreCurrentViewTypeComponentState,
+  );
+
+  const hasObjectReadOnlyPermission = useHasObjectReadOnlyPermission();
+
+  const isReadOnly = isFieldValueReadOnly({
+    objectNameSingular: activityObjectNameSingular,
+    fieldName: 'bodyV2',
+    fieldType: FieldMetadataType.RICH_TEXT_V2,
+    hasObjectReadOnlyPermission,
+    contextStoreCurrentViewType,
+  });
+
   const {
     goBackToPreviousHotkeyScope,
     setHotkeyScopeAndMemorizePreviousScope,
@@ -62,6 +81,8 @@ export const ActivityRichTextEditor = ({
   });
 
   const persistBodyDebounced = useDebouncedCallback((blocknote: string) => {
+    if (isReadOnly) return;
+
     const input = {
       bodyV2: {
         blocknote,
@@ -301,6 +322,7 @@ export const ActivityRichTextEditor = ({
         onBlur={handlerBlockEditorBlur}
         onChange={handleEditorChange}
         editor={editor}
+        readonly={isReadOnly}
       />
     </>
   );

--- a/packages/twenty-front/src/modules/activities/components/ActivityRichTextEditor.tsx
+++ b/packages/twenty-front/src/modules/activities/components/ActivityRichTextEditor.tsx
@@ -69,6 +69,7 @@ export const ActivityRichTextEditor = ({
     fieldType: FieldMetadataType.RICH_TEXT_V2,
     hasObjectReadOnlyPermission,
     contextStoreCurrentViewType,
+    isRecordDeleted: activityInStore?.deletedAt !== null,
   });
 
   const {

--- a/packages/twenty-front/src/modules/object-record/record-field/utils/isFieldValueReadOnly.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/utils/isFieldValueReadOnly.ts
@@ -65,7 +65,6 @@ export const isFieldValueReadOnly = ({
   }
 
   if (
-    isTableViewOrKanbanView &&
     isDefined(fieldType) &&
     (isFieldActor({ type: fieldType }) ||
       isFieldRichText({ type: fieldType }) ||

--- a/packages/twenty-front/src/modules/object-record/record-field/utils/isFieldValueReadOnly.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/utils/isFieldValueReadOnly.ts
@@ -65,6 +65,7 @@ export const isFieldValueReadOnly = ({
   }
 
   if (
+    isTableViewOrKanbanView &&
     isDefined(fieldType) &&
     (isFieldActor({ type: fieldType }) ||
       isFieldRichText({ type: fieldType }) ||

--- a/packages/twenty-front/src/modules/ui/layout/show-page/components/ShowPageActivityContainer.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/show-page/components/ShowPageActivityContainer.tsx
@@ -51,6 +51,11 @@ export const ShowPageActivityContainer = ({
     isNewViewableRecordLoadingState,
   );
 
+  const activityObjectNameSingular =
+    targetableObject.targetObjectNameSingular as
+      | CoreObjectNameSingular.Note
+      | CoreObjectNameSingular.Task;
+
   return !isNewViewableRecordLoading ? (
     <ScrollWrapper
       contextProviderName="showPageActivityContainer"
@@ -60,11 +65,7 @@ export const ShowPageActivityContainer = ({
         <Suspense fallback={<LoadingSkeleton />}>
           <ActivityRichTextEditor
             activityId={targetableObject.id}
-            activityObjectNameSingular={
-              targetableObject.targetObjectNameSingular as
-                | CoreObjectNameSingular.Note
-                | CoreObjectNameSingular.Task
-            }
+            activityObjectNameSingular={activityObjectNameSingular}
           />
         </Suspense>
       </StyledShowPageActivityContainer>


### PR DESCRIPTION
Before
<img width="1024" alt="Screenshot 2025-03-17 at 17 46 34" src="https://github.com/user-attachments/assets/c754adfb-4197-4be8-95dc-2f2024ed8a5c" />


After
<img width="954" alt="Screenshot 2025-03-17 at 17 46 20" src="https://github.com/user-attachments/assets/e6063990-5d30-416f-9d16-2974d8d1d831" />
