### PR TITLE
Animate the opening and exiting states of the JSON visualizer

### DIFF
--- a/packages/twenty-ui/src/json-visualizer/components/JsonNestedNode.tsx
+++ b/packages/twenty-ui/src/json-visualizer/components/JsonNestedNode.tsx
@@ -1,18 +1,19 @@
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { isNonEmptyString } from '@sniptt/guards';
 import { IconComponent } from '@ui/display';
 import { JsonArrow } from '@ui/json-visualizer/components/internal/JsonArrow';
-import { JsonList } from '@ui/json-visualizer/components/internal/JsonList';
 import { JsonNodeLabel } from '@ui/json-visualizer/components/internal/JsonNodeLabel';
 import { JsonNode } from '@ui/json-visualizer/components/JsonNode';
+import { ANIMATION } from '@ui/theme';
+import { AnimatePresence, motion } from 'framer-motion';
 import { useState } from 'react';
 import { isDefined } from 'twenty-shared';
 import { JsonValue } from 'type-fest';
 
 const StyledContainer = styled.li`
-  list-style-type: none;
   display: grid;
-  row-gap: ${({ theme }) => theme.spacing(2)};
+  list-style-type: none;
 `;
 
 const StyledLabelContainer = styled.div`
@@ -27,6 +28,25 @@ const StyledElementsCount = styled.span`
 
 const StyledEmptyState = styled.div`
   color: ${({ theme }) => theme.font.color.tertiary};
+`;
+
+const StyledJsonList = styled(motion.ul)<{ depth: number }>`
+  position: relative;
+  margin: 0;
+  padding: 0;
+
+  display: grid;
+  row-gap: ${({ theme }) => theme.spacing(2)};
+
+  ${({ theme, depth }) =>
+    depth > 0 &&
+    css`
+      padding-left: ${theme.spacing(8)};
+
+      > :first-child {
+        margin-top: ${theme.spacing(2)};
+      }
+    `}
 `;
 
 export const JsonNestedNode = ({
@@ -51,8 +71,14 @@ export const JsonNestedNode = ({
   const [isOpen, setIsOpen] = useState(true);
 
   const renderedChildren = (
-    <JsonList depth={depth}>
-      {elements.length === 0 ? (
+    <StyledJsonList
+      initial={{ height: 0, overflow: 'hidden' }}
+      animate={{ height: 'auto', overflow: 'hidden' }}
+      exit={{ height: 0, opacity: 0 }}
+      transition={{ duration: ANIMATION.duration.normal }}
+      depth={depth}
+    >
+      {!isOpen ? null : elements.length === 0 ? (
         <StyledEmptyState>{emptyElementsText}</StyledEmptyState>
       ) : (
         elements.map(({ id, label, value }) => {
@@ -71,7 +97,7 @@ export const JsonNestedNode = ({
           );
         })
       )}
-    </JsonList>
+    </StyledJsonList>
   );
 
   const handleArrowClick = () => {
@@ -79,7 +105,11 @@ export const JsonNestedNode = ({
   };
 
   if (hideRoot) {
-    return <StyledContainer>{renderedChildren}</StyledContainer>;
+    return (
+      <StyledContainer>
+        <AnimatePresence initial={false}>{renderedChildren}</AnimatePresence>
+      </StyledContainer>
+    );
   }
 
   return (
@@ -96,7 +126,9 @@ export const JsonNestedNode = ({
         )}
       </StyledLabelContainer>
 
-      {isOpen && renderedChildren}
+      <AnimatePresence initial={false}>
+        {isOpen && renderedChildren}
+      </AnimatePresence>
     </StyledContainer>
   );
 };

--- a/packages/twenty-ui/src/json-visualizer/components/JsonNestedNode.tsx
+++ b/packages/twenty-ui/src/json-visualizer/components/JsonNestedNode.tsx
@@ -78,7 +78,7 @@ export const JsonNestedNode = ({
       transition={{ duration: ANIMATION.duration.normal }}
       depth={depth}
     >
-      {!isOpen ? null : elements.length === 0 ? (
+      {elements.length === 0 ? (
         <StyledEmptyState>{emptyElementsText}</StyledEmptyState>
       ) : (
         elements.map(({ id, label, value }) => {

--- a/packages/twenty-ui/src/json-visualizer/components/JsonNestedNode.tsx
+++ b/packages/twenty-ui/src/json-visualizer/components/JsonNestedNode.tsx
@@ -1,8 +1,8 @@
-import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { isNonEmptyString } from '@sniptt/guards';
 import { IconComponent } from '@ui/display';
 import { JsonArrow } from '@ui/json-visualizer/components/internal/JsonArrow';
+import { JsonList } from '@ui/json-visualizer/components/internal/JsonList';
 import { JsonNodeLabel } from '@ui/json-visualizer/components/internal/JsonNodeLabel';
 import { JsonNode } from '@ui/json-visualizer/components/JsonNode';
 import { ANIMATION } from '@ui/theme';
@@ -30,24 +30,7 @@ const StyledEmptyState = styled.div`
   color: ${({ theme }) => theme.font.color.tertiary};
 `;
 
-const StyledJsonList = styled(motion.ul)<{ depth: number }>`
-  position: relative;
-  margin: 0;
-  padding: 0;
-
-  display: grid;
-  row-gap: ${({ theme }) => theme.spacing(2)};
-
-  ${({ theme, depth }) =>
-    depth > 0 &&
-    css`
-      padding-left: ${theme.spacing(8)};
-
-      > :first-child {
-        margin-top: ${theme.spacing(2)};
-      }
-    `}
-`;
+const StyledJsonList = styled(JsonList)``.withComponent(motion.ul);
 
 export const JsonNestedNode = ({
   label,
@@ -72,9 +55,21 @@ export const JsonNestedNode = ({
 
   const renderedChildren = (
     <StyledJsonList
-      initial={{ height: 0, overflow: 'hidden' }}
-      animate={{ height: 'auto', overflow: 'hidden' }}
-      exit={{ height: 0, opacity: 0 }}
+      initial={{
+        height: 0,
+        opacity: 0,
+        overflowY: 'clip',
+      }}
+      animate={{
+        height: 'auto',
+        opacity: 1,
+        overflowY: 'clip',
+      }}
+      exit={{
+        height: 0,
+        opacity: 0,
+        overflowY: 'clip',
+      }}
       transition={{ duration: ANIMATION.duration.normal }}
       depth={depth}
     >

--- a/packages/twenty-ui/src/json-visualizer/components/internal/JsonArrow.tsx
+++ b/packages/twenty-ui/src/json-visualizer/components/internal/JsonArrow.tsx
@@ -46,7 +46,7 @@ export const JsonArrow = ({
         size={theme.icon.size.md}
         color={theme.font.color.secondary}
         initial={false}
-        animate={{ rotate: isOpen ? -180 : 0 }}
+        animate={{ rotate: isOpen ? 0 : -90 }}
         transition={{ duration: ANIMATION.duration.normal }}
       />
     </StyledButton>

--- a/packages/twenty-ui/src/json-visualizer/components/internal/JsonArrow.tsx
+++ b/packages/twenty-ui/src/json-visualizer/components/internal/JsonArrow.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import { VisibilityHidden } from '@ui/accessibility';
 import { IconChevronDown } from '@ui/display';
 import { useJsonTreeContextOrThrow } from '@ui/json-visualizer/hooks/useJsonTreeContextOrThrow';
+import { ANIMATION } from '@ui/theme';
 import { motion } from 'framer-motion';
 
 const StyledButton = styled(motion.button)`
@@ -46,6 +47,7 @@ export const JsonArrow = ({
         color={theme.font.color.secondary}
         initial={false}
         animate={{ rotate: isOpen ? -180 : 0 }}
+        transition={{ duration: ANIMATION.duration.normal }}
       />
     </StyledButton>
   );

--- a/packages/twenty-ui/src/json-visualizer/components/internal/JsonList.tsx
+++ b/packages/twenty-ui/src/json-visualizer/components/internal/JsonList.tsx
@@ -12,6 +12,10 @@ const StyledList = styled.ul<{ depth: number }>`
     depth > 0 &&
     css`
       padding-left: ${theme.spacing(8)};
+
+      > :first-child {
+        margin-top: ${theme.spacing(2)};
+      }
     `}
 `;
 

--- a/packages/twenty-ui/src/json-visualizer/components/internal/JsonList.tsx
+++ b/packages/twenty-ui/src/json-visualizer/components/internal/JsonList.tsx
@@ -13,7 +13,7 @@ const StyledList = styled.ul<{ depth: number }>`
     css`
       padding-left: ${theme.spacing(8)};
 
-      > :first-child {
+      > :first-of-type {
         margin-top: ${theme.spacing(2)};
       }
     `}


### PR DESCRIPTION
I used `overflow-y: clip` instead of `overflow-y: hidden` because of this behavior:

> Setting overflow to visible in one direction (i.e. overflow-x or overflow-y) when it isn't set to visible or clip in the other direction results in the visible value behaving as auto.


## Demo

https://github.com/user-attachments/assets/b7975c99-58cc-4b63-b420-a54b27752188

Closes https://github.com/twentyhq/core-team-issues/issues/562