### PR TITLE
feat(workspace): delete custom domain on hard workspace delete

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/workspace/services/workspace.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/services/workspace.service.ts
@@ -346,6 +346,13 @@ export class WorkspaceService extends TypeOrmQueryService<Workspace> {
       FileWorkspaceFolderDeletionJob.name,
       { workspaceId: id },
     );
+
+    if (workspace.customDomain) {
+      await this.customDomainService.deleteCustomHostnameByHostnameSilently(
+        workspace.customDomain,
+      );
+    }
+
     await this.workspaceRepository.delete(id);
 
     this.logger.log(`workspace ${id} hard deleted`);


### PR DESCRIPTION
Add logic to remove a workspace's custom domain during hard deletion. Includes tests to verify behavior for both hard and soft deletion cases.

Fix #10351 