### PR TITLE
Fix permissionAssignment dropdownMenu max height

### DIFF
--- a/packages/twenty-front/src/modules/settings/roles/role-assignment/components/RoleAssignmentWorkspaceMemberPickerDropdown.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/role-assignment/components/RoleAssignmentWorkspaceMemberPickerDropdown.tsx
@@ -41,7 +41,7 @@ export const RoleAssignmentWorkspaceMemberPickerDropdown = ({
         placeholder="Search"
       />
       <DropdownMenuSeparator />
-      <DropdownMenuItemsContainer>
+      <DropdownMenuItemsContainer hasMaxHeight>
         <RoleAssignmentWorkspaceMemberPickerDropdownContent
           loading={loading}
           searchFilter={searchFilter}


### PR DESCRIPTION
HasMaxHeight prop was missing in the dropdown container so the content was not scrollable

Before
<img width="692" alt="Screenshot 2025-03-18 at 15 18 08" src="https://github.com/user-attachments/assets/5ab8fd70-5528-4cf8-a526-38afdae1f502" />

After
<img width="703" alt="Screenshot 2025-03-18 at 15 17 59" src="https://github.com/user-attachments/assets/5bbf4347-c963-4785-948c-8e16272bf067" />
