### PR TITLE
Limit nodes opened by default in the JSON Tree component

### DIFF
--- a/packages/twenty-front/src/modules/command-menu/pages/workflow/step/view-run/components/CommandMenuWorkflowRunViewStep.tsx
+++ b/packages/twenty-front/src/modules/command-menu/pages/workflow/step/view-run/components/CommandMenuWorkflowRunViewStep.tsx
@@ -85,11 +85,17 @@ export const CommandMenuWorkflowRunViewStep = () => {
       ) : null}
 
       {activeTabId === 'input' ? (
-        <WorkflowRunStepInputDetail stepId={workflowSelectedNode} />
+        <WorkflowRunStepInputDetail
+          key={workflowSelectedNode}
+          stepId={workflowSelectedNode}
+        />
       ) : null}
 
       {activeTabId === 'output' ? (
-        <WorkflowRunStepOutputDetail stepId={workflowSelectedNode} />
+        <WorkflowRunStepOutputDetail
+          key={workflowSelectedNode}
+          stepId={workflowSelectedNode}
+        />
       ) : null}
     </WorkflowStepContextProvider>
   );

--- a/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/JsonDataIndicatorHealthStatus.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/JsonDataIndicatorHealthStatus.tsx
@@ -2,7 +2,7 @@ import { SettingsAdminIndicatorHealthContext } from '@/settings/admin-panel/heal
 import styled from '@emotion/styled';
 import { useLingui } from '@lingui/react/macro';
 import { useContext } from 'react';
-import { expandTwoDepths, JsonTree, Section } from 'twenty-ui';
+import { JsonTree, Section } from 'twenty-ui';
 import { AdminPanelHealthServiceStatus } from '~/generated/graphql';
 
 const StyledDetailsContainer = styled.div`
@@ -33,6 +33,8 @@ export const JsonDataIndicatorHealthStatus = () => {
     !indicatorHealth.status ||
     indicatorHealth.status === AdminPanelHealthServiceStatus.OUTAGE;
 
+  const expandEveryNode = (_keyPath: string, _depth: number) => true;
+
   return (
     <Section>
       {isDown && (
@@ -45,7 +47,7 @@ export const JsonDataIndicatorHealthStatus = () => {
         <StyledDetailsContainer>
           <JsonTree
             value={parsedDetails}
-            shouldExpandNodeInitially={expandTwoDepths}
+            shouldExpandNodeInitially={expandEveryNode}
             emptyArrayLabel={t`Empty Array`}
             emptyObjectLabel={t`Empty Object`}
             emptyStringLabel={t`[empty string]`}

--- a/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/JsonDataIndicatorHealthStatus.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/JsonDataIndicatorHealthStatus.tsx
@@ -33,7 +33,7 @@ export const JsonDataIndicatorHealthStatus = () => {
     !indicatorHealth.status ||
     indicatorHealth.status === AdminPanelHealthServiceStatus.OUTAGE;
 
-  const expandEveryNode = (_keyPath: string, _depth: number) => true;
+  const isAnyNode = () => true;
 
   return (
     <Section>
@@ -47,7 +47,7 @@ export const JsonDataIndicatorHealthStatus = () => {
         <StyledDetailsContainer>
           <JsonTree
             value={parsedDetails}
-            shouldExpandNodeInitially={expandEveryNode}
+            shouldExpandNodeInitially={isAnyNode}
             emptyArrayLabel={t`Empty Array`}
             emptyObjectLabel={t`Empty Object`}
             emptyStringLabel={t`[empty string]`}

--- a/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/JsonDataIndicatorHealthStatus.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/JsonDataIndicatorHealthStatus.tsx
@@ -47,6 +47,7 @@ export const JsonDataIndicatorHealthStatus = () => {
             value={parsedDetails}
             emptyArrayLabel={t`Empty Array`}
             emptyObjectLabel={t`Empty Object`}
+            emptyStringLabel={t`[empty string]`}
             arrowButtonCollapsedLabel={t`Expand`}
             arrowButtonExpandedLabel={t`Collapse`}
           />

--- a/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/JsonDataIndicatorHealthStatus.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/JsonDataIndicatorHealthStatus.tsx
@@ -2,7 +2,7 @@ import { SettingsAdminIndicatorHealthContext } from '@/settings/admin-panel/heal
 import styled from '@emotion/styled';
 import { useLingui } from '@lingui/react/macro';
 import { useContext } from 'react';
-import { JsonTree, Section } from 'twenty-ui';
+import { expandTwoDepths, JsonTree, Section } from 'twenty-ui';
 import { AdminPanelHealthServiceStatus } from '~/generated/graphql';
 
 const StyledDetailsContainer = styled.div`
@@ -45,6 +45,7 @@ export const JsonDataIndicatorHealthStatus = () => {
         <StyledDetailsContainer>
           <JsonTree
             value={parsedDetails}
+            shouldExpandNodeInitially={expandTwoDepths}
             emptyArrayLabel={t`Empty Array`}
             emptyObjectLabel={t`Empty Object`}
             emptyStringLabel={t`[empty string]`}

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/components/RightDrawerWorkflowRunViewStep.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/components/RightDrawerWorkflowRunViewStep.tsx
@@ -85,11 +85,17 @@ export const RightDrawerWorkflowRunViewStep = () => {
       ) : null}
 
       {activeTabId === 'input' ? (
-        <WorkflowRunStepInputDetail stepId={workflowSelectedNode} />
+        <WorkflowRunStepInputDetail
+          key={workflowSelectedNode}
+          stepId={workflowSelectedNode}
+        />
       ) : null}
 
       {activeTabId === 'output' ? (
-        <WorkflowRunStepOutputDetail stepId={workflowSelectedNode} />
+        <WorkflowRunStepOutputDetail
+          key={workflowSelectedNode}
+          stepId={workflowSelectedNode}
+        />
       ) : null}
     </WorkflowStepContextProvider>
   );

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/components/WorkflowRunStepInputDetail.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/components/WorkflowRunStepInputDetail.tsx
@@ -6,6 +6,7 @@ import styled from '@emotion/styled';
 import { useLingui } from '@lingui/react/macro';
 import { isDefined } from 'twenty-shared';
 import {
+  expandTwoDepths,
   IconBrackets,
   JsonNestedNode,
   JsonTreeContextProvider,
@@ -62,6 +63,7 @@ export const WorkflowRunStepInputDetail = ({ stepId }: { stepId: string }) => {
           arrowButtonCollapsedLabel: t`Expand`,
           arrowButtonExpandedLabel: t`Collapse`,
           shouldHighlightNode: (keyPath) => variablesUsedInStep.has(keyPath),
+          shouldExpandNodeInitially: expandTwoDepths,
         }}
       >
         <JsonNestedNode

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/components/WorkflowRunStepInputDetail.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/components/WorkflowRunStepInputDetail.tsx
@@ -1,12 +1,12 @@
 import { useWorkflowRun } from '@/workflow/hooks/useWorkflowRun';
 import { useWorkflowRunIdOrThrow } from '@/workflow/hooks/useWorkflowRunIdOrThrow';
+import { getWorkflowPreviousStepId } from '@/workflow/workflow-steps/utils/getWorkflowPreviousStep';
 import { getWorkflowRunStepContext } from '@/workflow/workflow-steps/utils/getWorkflowRunStepContext';
 import { getWorkflowVariablesUsedInStep } from '@/workflow/workflow-steps/utils/getWorkflowVariablesUsedInStep';
 import styled from '@emotion/styled';
 import { useLingui } from '@lingui/react/macro';
 import { isDefined } from 'twenty-shared';
 import {
-  expandTwoDepths,
   IconBrackets,
   JsonNestedNode,
   JsonTreeContextProvider,
@@ -39,6 +39,15 @@ export const WorkflowRunStepInputDetail = ({ stepId }: { stepId: string }) => {
     return null;
   }
 
+  const previousStepId = getWorkflowPreviousStepId({
+    stepId,
+    steps: workflowRun.output.flow.steps,
+  });
+
+  if (previousStepId === undefined) {
+    return null;
+  }
+
   const variablesUsedInStep = getWorkflowVariablesUsedInStep({
     step,
   });
@@ -48,10 +57,12 @@ export const WorkflowRunStepInputDetail = ({ stepId }: { stepId: string }) => {
     flow: workflowRun.output.flow,
     stepId,
   });
-
   if (stepContext.length === 0) {
     throw new Error('The input tab must be rendered with a non-empty context.');
   }
+
+  const expandPreviousStep = (keyPath: string, depth: number) =>
+    keyPath.startsWith(previousStepId) && depth < 2;
 
   return (
     <StyledContainer>
@@ -63,7 +74,7 @@ export const WorkflowRunStepInputDetail = ({ stepId }: { stepId: string }) => {
           arrowButtonCollapsedLabel: t`Expand`,
           arrowButtonExpandedLabel: t`Collapse`,
           shouldHighlightNode: (keyPath) => variablesUsedInStep.has(keyPath),
-          shouldExpandNodeInitially: expandTwoDepths,
+          shouldExpandNodeInitially: expandPreviousStep,
         }}
       >
         <JsonNestedNode

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/components/WorkflowRunStepInputDetail.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/components/WorkflowRunStepInputDetail.tsx
@@ -58,6 +58,7 @@ export const WorkflowRunStepInputDetail = ({ stepId }: { stepId: string }) => {
         value={{
           emptyArrayLabel: t`Empty Array`,
           emptyObjectLabel: t`Empty Object`,
+          emptyStringLabel: t`[empty string]`,
           arrowButtonCollapsedLabel: t`Expand`,
           arrowButtonExpandedLabel: t`Collapse`,
           shouldHighlightNode: (keyPath) => variablesUsedInStep.has(keyPath),

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/components/WorkflowRunStepInputDetail.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/components/WorkflowRunStepInputDetail.tsx
@@ -10,6 +10,7 @@ import {
   IconBrackets,
   JsonNestedNode,
   JsonTreeContextProvider,
+  ShouldExpandNodeInitiallyProps,
 } from 'twenty-ui';
 
 const StyledContainer = styled.div`
@@ -61,7 +62,10 @@ export const WorkflowRunStepInputDetail = ({ stepId }: { stepId: string }) => {
     throw new Error('The input tab must be rendered with a non-empty context.');
   }
 
-  const expandPreviousStep = (keyPath: string, depth: number) =>
+  const isFirstNodeDepthOfPreviousStep = ({
+    keyPath,
+    depth,
+  }: ShouldExpandNodeInitiallyProps) =>
     keyPath.startsWith(previousStepId) && depth < 2;
 
   return (
@@ -74,7 +78,7 @@ export const WorkflowRunStepInputDetail = ({ stepId }: { stepId: string }) => {
           arrowButtonCollapsedLabel: t`Expand`,
           arrowButtonExpandedLabel: t`Collapse`,
           shouldHighlightNode: (keyPath) => variablesUsedInStep.has(keyPath),
-          shouldExpandNodeInitially: expandPreviousStep,
+          shouldExpandNodeInitially: isFirstNodeDepthOfPreviousStep,
         }}
       >
         <JsonNestedNode

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/components/WorkflowRunStepOutputDetail.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/components/WorkflowRunStepOutputDetail.tsx
@@ -3,7 +3,7 @@ import { useWorkflowRunIdOrThrow } from '@/workflow/hooks/useWorkflowRunIdOrThro
 import styled from '@emotion/styled';
 import { useLingui } from '@lingui/react/macro';
 import { isDefined } from 'twenty-shared';
-import { JsonTree } from 'twenty-ui';
+import { expandTwoDepths, JsonTree } from 'twenty-ui';
 
 const StyledContainer = styled.div`
   display: grid;
@@ -28,6 +28,7 @@ export const WorkflowRunStepOutputDetail = ({ stepId }: { stepId: string }) => {
     <StyledContainer>
       <JsonTree
         value={stepOutput}
+        shouldExpandNodeInitially={expandTwoDepths}
         emptyArrayLabel={t`Empty Array`}
         emptyObjectLabel={t`Empty Object`}
         emptyStringLabel={t`[empty string]`}

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/components/WorkflowRunStepOutputDetail.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/components/WorkflowRunStepOutputDetail.tsx
@@ -3,7 +3,7 @@ import { useWorkflowRunIdOrThrow } from '@/workflow/hooks/useWorkflowRunIdOrThro
 import styled from '@emotion/styled';
 import { useLingui } from '@lingui/react/macro';
 import { isDefined } from 'twenty-shared';
-import { expandTwoDepths, JsonTree } from 'twenty-ui';
+import { isTwoFirstDepths, JsonTree } from 'twenty-ui';
 
 const StyledContainer = styled.div`
   display: grid;
@@ -28,7 +28,7 @@ export const WorkflowRunStepOutputDetail = ({ stepId }: { stepId: string }) => {
     <StyledContainer>
       <JsonTree
         value={stepOutput}
-        shouldExpandNodeInitially={expandTwoDepths}
+        shouldExpandNodeInitially={isTwoFirstDepths}
         emptyArrayLabel={t`Empty Array`}
         emptyObjectLabel={t`Empty Object`}
         emptyStringLabel={t`[empty string]`}

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/components/WorkflowRunStepOutputDetail.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/components/WorkflowRunStepOutputDetail.tsx
@@ -30,6 +30,7 @@ export const WorkflowRunStepOutputDetail = ({ stepId }: { stepId: string }) => {
         value={stepOutput}
         emptyArrayLabel={t`Empty Array`}
         emptyObjectLabel={t`Empty Object`}
+        emptyStringLabel={t`[empty string]`}
         arrowButtonCollapsedLabel={t`Expand`}
         arrowButtonExpandedLabel={t`Collapse`}
       />

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/utils/getWorkflowPreviousStep.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/utils/getWorkflowPreviousStep.ts
@@ -1,0 +1,25 @@
+import { WorkflowStep } from '@/workflow/types/Workflow';
+import { TRIGGER_STEP_ID } from '@/workflow/workflow-trigger/constants/TriggerStepId';
+
+export const getWorkflowPreviousStepId = ({
+  stepId,
+  steps,
+}: {
+  stepId: string;
+  steps: Array<WorkflowStep>;
+}) => {
+  if (stepId === TRIGGER_STEP_ID) {
+    return undefined;
+  }
+
+  if (stepId === steps[0].id) {
+    return TRIGGER_STEP_ID;
+  }
+
+  const stepIndex = steps.findIndex((step) => step.id === stepId);
+  if (stepIndex === -1) {
+    throw new Error('Step not found');
+  }
+
+  return steps[stepIndex - 1].id;
+};

--- a/packages/twenty-ui/src/json-visualizer/__stories__/JsonTree.stories.tsx
+++ b/packages/twenty-ui/src/json-visualizer/__stories__/JsonTree.stories.tsx
@@ -13,6 +13,7 @@ const meta: Meta<typeof JsonTree> = {
   args: {
     emptyArrayLabel: 'Empty Array',
     emptyObjectLabel: 'Empty Object',
+    emptyStringLabel: '[empty string]',
     arrowButtonCollapsedLabel: 'Expand',
     arrowButtonExpandedLabel: 'Collapse',
   },

--- a/packages/twenty-ui/src/json-visualizer/__stories__/JsonTree.stories.tsx
+++ b/packages/twenty-ui/src/json-visualizer/__stories__/JsonTree.stories.tsx
@@ -6,11 +6,13 @@ import {
   within,
 } from '@storybook/test';
 import { JsonTree } from '@ui/json-visualizer/components/JsonTree';
+import { expandTwoDepths } from '@ui/json-visualizer/utils/expandTwoDepths';
 
 const meta: Meta<typeof JsonTree> = {
   title: 'UI/JsonVisualizer/JsonTree',
   component: JsonTree,
   args: {
+    shouldExpandNodeInitially: expandTwoDepths,
     emptyArrayLabel: 'Empty Array',
     emptyObjectLabel: 'Empty Object',
     emptyStringLabel: '[empty string]',

--- a/packages/twenty-ui/src/json-visualizer/__stories__/JsonTree.stories.tsx
+++ b/packages/twenty-ui/src/json-visualizer/__stories__/JsonTree.stories.tsx
@@ -6,6 +6,7 @@ import {
   within,
 } from '@storybook/test';
 import { JsonTree } from '@ui/json-visualizer/components/JsonTree';
+import { expandTwoDepths } from '@ui/json-visualizer/utils/expandTwoDepths';
 
 const meta: Meta<typeof JsonTree> = {
   title: 'UI/JsonVisualizer/JsonTree',
@@ -272,6 +273,41 @@ export const ExpandingElementExpandsAllItsDescendants: Story = {
 
       expect(allCollapseButtons).toHaveLength(3);
     }
+  },
+};
+
+export const ExpandTwoFirstDepths: Story = {
+  args: {
+    value: {
+      person: {
+        name: 'John Doe',
+        address: {
+          street: '123 Main St',
+          city: 'New York',
+          country: {
+            name: 'USA',
+            code: 'US',
+          },
+        },
+      },
+      isActive: true,
+    },
+    shouldExpandNodeInitially: expandTwoDepths,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const nameElement = await canvas.findByText('name');
+    expect(nameElement).toBeVisible();
+
+    const addressElement = await canvas.findByText('address');
+    expect(addressElement).toBeVisible();
+
+    const streetElement = canvas.queryByText('street');
+    expect(streetElement).not.toBeInTheDocument();
+
+    const countrCodeElement = canvas.queryByText('code');
+    expect(countrCodeElement).not.toBeInTheDocument();
   },
 };
 

--- a/packages/twenty-ui/src/json-visualizer/__stories__/JsonTree.stories.tsx
+++ b/packages/twenty-ui/src/json-visualizer/__stories__/JsonTree.stories.tsx
@@ -6,7 +6,7 @@ import {
   within,
 } from '@storybook/test';
 import { JsonTree } from '@ui/json-visualizer/components/JsonTree';
-import { expandTwoDepths } from '@ui/json-visualizer/utils/expandTwoDepths';
+import { isTwoFirstDepths } from '@ui/json-visualizer/utils/isTwoFirstDepths';
 
 const meta: Meta<typeof JsonTree> = {
   title: 'UI/JsonVisualizer/JsonTree',
@@ -292,7 +292,7 @@ export const ExpandTwoFirstDepths: Story = {
       },
       isActive: true,
     },
-    shouldExpandNodeInitially: expandTwoDepths,
+    shouldExpandNodeInitially: isTwoFirstDepths,
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/packages/twenty-ui/src/json-visualizer/__stories__/JsonTree.stories.tsx
+++ b/packages/twenty-ui/src/json-visualizer/__stories__/JsonTree.stories.tsx
@@ -6,13 +6,12 @@ import {
   within,
 } from '@storybook/test';
 import { JsonTree } from '@ui/json-visualizer/components/JsonTree';
-import { expandTwoDepths } from '@ui/json-visualizer/utils/expandTwoDepths';
 
 const meta: Meta<typeof JsonTree> = {
   title: 'UI/JsonVisualizer/JsonTree',
   component: JsonTree,
   args: {
-    shouldExpandNodeInitially: expandTwoDepths,
+    shouldExpandNodeInitially: () => true,
     emptyArrayLabel: 'Empty Array',
     emptyObjectLabel: 'Empty Object',
     emptyStringLabel: '[empty string]',

--- a/packages/twenty-ui/src/json-visualizer/components/JsonNestedNode.tsx
+++ b/packages/twenty-ui/src/json-visualizer/components/JsonNestedNode.tsx
@@ -5,6 +5,7 @@ import { JsonArrow } from '@ui/json-visualizer/components/internal/JsonArrow';
 import { JsonList } from '@ui/json-visualizer/components/internal/JsonList';
 import { JsonNodeLabel } from '@ui/json-visualizer/components/internal/JsonNodeLabel';
 import { JsonNode } from '@ui/json-visualizer/components/JsonNode';
+import { useJsonTreeContextOrThrow } from '@ui/json-visualizer/hooks/useJsonTreeContextOrThrow';
 import { ANIMATION } from '@ui/theme';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useState } from 'react';
@@ -49,9 +50,13 @@ export const JsonNestedNode = ({
   depth: number;
   keyPath: string;
 }) => {
+  const { shouldExpandNodeInitially } = useJsonTreeContextOrThrow();
+
   const hideRoot = !isDefined(label);
 
-  const [isOpen, setIsOpen] = useState(true);
+  const [isOpen, setIsOpen] = useState(
+    shouldExpandNodeInitially(keyPath, depth),
+  );
 
   const renderedChildren = (
     <StyledJsonList

--- a/packages/twenty-ui/src/json-visualizer/components/JsonNestedNode.tsx
+++ b/packages/twenty-ui/src/json-visualizer/components/JsonNestedNode.tsx
@@ -55,7 +55,7 @@ export const JsonNestedNode = ({
   const hideRoot = !isDefined(label);
 
   const [isOpen, setIsOpen] = useState(
-    shouldExpandNodeInitially(keyPath, depth),
+    shouldExpandNodeInitially({ keyPath, depth }),
   );
 
   const renderedChildren = (

--- a/packages/twenty-ui/src/json-visualizer/components/JsonNode.tsx
+++ b/packages/twenty-ui/src/json-visualizer/components/JsonNode.tsx
@@ -37,7 +37,7 @@ export const JsonNode = ({
     return (
       <JsonValueNode
         label={label}
-        valueAsString="[null]"
+        valueAsString="null"
         Icon={IconCircleOff}
         isHighlighted={isHighlighted}
       />

--- a/packages/twenty-ui/src/json-visualizer/components/JsonNode.tsx
+++ b/packages/twenty-ui/src/json-visualizer/components/JsonNode.tsx
@@ -1,4 +1,10 @@
-import { isBoolean, isNull, isNumber, isString } from '@sniptt/guards';
+import {
+  isBoolean,
+  isNonEmptyString,
+  isNull,
+  isNumber,
+  isString,
+} from '@sniptt/guards';
 import {
   IconCheckbox,
   IconCircleOff,
@@ -23,7 +29,7 @@ export const JsonNode = ({
   depth: number;
   keyPath: string;
 }) => {
-  const { shouldHighlightNode } = useJsonTreeContextOrThrow();
+  const { shouldHighlightNode, emptyStringLabel } = useJsonTreeContextOrThrow();
 
   const isHighlighted = shouldHighlightNode?.(keyPath) ?? false;
 
@@ -42,7 +48,7 @@ export const JsonNode = ({
     return (
       <JsonValueNode
         label={label}
-        valueAsString={value}
+        valueAsString={isNonEmptyString(value) ? value : emptyStringLabel}
         Icon={IconTypography}
         isHighlighted={isHighlighted}
       />

--- a/packages/twenty-ui/src/json-visualizer/components/JsonTree.tsx
+++ b/packages/twenty-ui/src/json-visualizer/components/JsonTree.tsx
@@ -8,6 +8,7 @@ export const JsonTree = ({
   shouldHighlightNode,
   emptyArrayLabel,
   emptyObjectLabel,
+  emptyStringLabel,
   arrowButtonCollapsedLabel,
   arrowButtonExpandedLabel,
 }: {
@@ -15,6 +16,7 @@ export const JsonTree = ({
   shouldHighlightNode?: (keyPath: string) => boolean;
   emptyArrayLabel: string;
   emptyObjectLabel: string;
+  emptyStringLabel: string;
   arrowButtonCollapsedLabel: string;
   arrowButtonExpandedLabel: string;
 }) => {
@@ -24,6 +26,7 @@ export const JsonTree = ({
         shouldHighlightNode,
         emptyArrayLabel,
         emptyObjectLabel,
+        emptyStringLabel,
         arrowButtonCollapsedLabel,
         arrowButtonExpandedLabel,
       }}

--- a/packages/twenty-ui/src/json-visualizer/components/JsonTree.tsx
+++ b/packages/twenty-ui/src/json-visualizer/components/JsonTree.tsx
@@ -1,6 +1,7 @@
 import { JsonList } from '@ui/json-visualizer/components/internal/JsonList';
 import { JsonNode } from '@ui/json-visualizer/components/JsonNode';
 import { JsonTreeContextProvider } from '@ui/json-visualizer/components/JsonTreeContextProvider';
+import { ShouldExpandNodeInitiallyProps } from '@ui/json-visualizer/contexts/JsonTreeContext';
 import { JsonValue } from 'type-fest';
 
 export const JsonTree = ({
@@ -15,7 +16,9 @@ export const JsonTree = ({
 }: {
   value: JsonValue;
   shouldHighlightNode?: (keyPath: string) => boolean;
-  shouldExpandNodeInitially: (keyPath: string, depth: number) => boolean;
+  shouldExpandNodeInitially: (
+    params: ShouldExpandNodeInitiallyProps,
+  ) => boolean;
   emptyArrayLabel: string;
   emptyObjectLabel: string;
   emptyStringLabel: string;

--- a/packages/twenty-ui/src/json-visualizer/components/JsonTree.tsx
+++ b/packages/twenty-ui/src/json-visualizer/components/JsonTree.tsx
@@ -6,6 +6,7 @@ import { JsonValue } from 'type-fest';
 export const JsonTree = ({
   value,
   shouldHighlightNode,
+  shouldExpandNodeInitially,
   emptyArrayLabel,
   emptyObjectLabel,
   emptyStringLabel,
@@ -14,6 +15,7 @@ export const JsonTree = ({
 }: {
   value: JsonValue;
   shouldHighlightNode?: (keyPath: string) => boolean;
+  shouldExpandNodeInitially: (keyPath: string, depth: number) => boolean;
   emptyArrayLabel: string;
   emptyObjectLabel: string;
   emptyStringLabel: string;
@@ -24,6 +26,7 @@ export const JsonTree = ({
     <JsonTreeContextProvider
       value={{
         shouldHighlightNode,
+        shouldExpandNodeInitially,
         emptyArrayLabel,
         emptyObjectLabel,
         emptyStringLabel,

--- a/packages/twenty-ui/src/json-visualizer/contexts/JsonTreeContext.tsx
+++ b/packages/twenty-ui/src/json-visualizer/contexts/JsonTreeContext.tsx
@@ -2,6 +2,7 @@ import { createContext } from 'react';
 
 export type JsonTreeContextType = {
   shouldHighlightNode?: (keyPath: string) => boolean;
+  shouldExpandNodeInitially: (keyPath: string, depth: number) => boolean;
   emptyStringLabel: string;
   emptyArrayLabel: string;
   emptyObjectLabel: string;

--- a/packages/twenty-ui/src/json-visualizer/contexts/JsonTreeContext.tsx
+++ b/packages/twenty-ui/src/json-visualizer/contexts/JsonTreeContext.tsx
@@ -1,8 +1,12 @@
 import { createContext } from 'react';
 
+export type ShouldExpandNodeInitiallyProps = { keyPath: string; depth: number };
+
 export type JsonTreeContextType = {
   shouldHighlightNode?: (keyPath: string) => boolean;
-  shouldExpandNodeInitially: (keyPath: string, depth: number) => boolean;
+  shouldExpandNodeInitially: (
+    params: ShouldExpandNodeInitiallyProps,
+  ) => boolean;
   emptyStringLabel: string;
   emptyArrayLabel: string;
   emptyObjectLabel: string;

--- a/packages/twenty-ui/src/json-visualizer/contexts/JsonTreeContext.tsx
+++ b/packages/twenty-ui/src/json-visualizer/contexts/JsonTreeContext.tsx
@@ -2,6 +2,7 @@ import { createContext } from 'react';
 
 export type JsonTreeContextType = {
   shouldHighlightNode?: (keyPath: string) => boolean;
+  emptyStringLabel: string;
   emptyArrayLabel: string;
   emptyObjectLabel: string;
   arrowButtonCollapsedLabel: string;

--- a/packages/twenty-ui/src/json-visualizer/index.ts
+++ b/packages/twenty-ui/src/json-visualizer/index.ts
@@ -7,4 +7,6 @@ export * from './components/JsonTreeContextProvider';
 export * from './components/JsonValueNode';
 export * from './contexts/JsonTreeContext';
 export * from './hooks/useJsonTreeContextOrThrow';
+export * from './utils/expandTwoDepths';
 export * from './utils/isArray';
+

--- a/packages/twenty-ui/src/json-visualizer/index.ts
+++ b/packages/twenty-ui/src/json-visualizer/index.ts
@@ -7,6 +7,5 @@ export * from './components/JsonTreeContextProvider';
 export * from './components/JsonValueNode';
 export * from './contexts/JsonTreeContext';
 export * from './hooks/useJsonTreeContextOrThrow';
-export * from './utils/expandTwoDepths';
 export * from './utils/isArray';
-
+export * from './utils/isTwoFirstDepths';

--- a/packages/twenty-ui/src/json-visualizer/utils/expandTwoDepths.ts
+++ b/packages/twenty-ui/src/json-visualizer/utils/expandTwoDepths.ts
@@ -1,1 +1,0 @@
-export const expandTwoDepths = (_keyPath: string, depth: number) => depth <= 1;

--- a/packages/twenty-ui/src/json-visualizer/utils/expandTwoDepths.ts
+++ b/packages/twenty-ui/src/json-visualizer/utils/expandTwoDepths.ts
@@ -1,0 +1,1 @@
+export const expandTwoDepths = (_keyPath: string, depth: number) => depth <= 1;

--- a/packages/twenty-ui/src/json-visualizer/utils/isTwoFirstDepths.ts
+++ b/packages/twenty-ui/src/json-visualizer/utils/isTwoFirstDepths.ts
@@ -1,0 +1,4 @@
+import { ShouldExpandNodeInitiallyProps } from '@ui/json-visualizer/contexts/JsonTreeContext';
+
+export const isTwoFirstDepths = ({ depth }: ShouldExpandNodeInitiallyProps) =>
+  depth <= 1;


### PR DESCRIPTION
- Add a parameter to choose which nodes to open by default
- On the Admin Panel, open all nodes by default
- On the Workflow Run step output, open only the two first depths
- On the Workflow Run step input, open only the previous step first depth
- Display `[empty string]` when a node is an empty string
- Now, display `null` instead of `[null]`

## Demo

https://github.com/user-attachments/assets/99b3078a-da3c-4330-b0ff-ddb2e360d933

Closes https://github.com/twentyhq/core-team-issues/issues/538