### PR TITLE
[permissions] Fix user is assigned default role after SSO sign-in

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.spec.ts
@@ -419,13 +419,6 @@ describe('SignInUpService', () => {
 
     jest.spyOn(featureFlagService, 'isFeatureEnabled').mockResolvedValue(true);
 
-    jest.spyOn(environmentService, 'get').mockReturnValue(false);
-    jest.spyOn(WorkspaceRepository, 'count').mockResolvedValue(0);
-    jest.spyOn(WorkspaceRepository, 'create').mockReturnValue({} as Workspace);
-    jest.spyOn(WorkspaceRepository, 'save').mockResolvedValue({
-      id: 'newWorkspaceId',
-      activationStatus: WorkspaceActivationStatus.ACTIVE,
-    } as Workspace);
     jest.spyOn(fileUploadService, 'uploadImage').mockResolvedValue({
       id: '',
       mimeType: '',
@@ -433,11 +426,7 @@ describe('SignInUpService', () => {
     });
     jest.spyOn(UserRepository, 'create').mockReturnValue({} as User);
     jest
-      .spyOn(domainManagerService, 'generateSubdomain')
-      .mockResolvedValue('a-subdomain');
-    jest
       .spyOn(UserRepository, 'save')
-
       .mockResolvedValue({ id: 'newUserId' } as User);
     jest.spyOn(userWorkspaceService, 'addUserToWorkspace').mockResolvedValue({
       user: {} as User,

--- a/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.spec.ts
@@ -366,7 +366,7 @@ describe('SignInUpService', () => {
     expect(WorkspaceRepository.save).toHaveBeenCalled();
   });
 
-  it('should assign default role when permissions are enabled', async () => {
+  it('should not assign default role when permissions are enabled and user exists', async () => {
     const params: SignInUpBaseParams &
       ExistingUserOrPartialUserWithPicture &
       AuthProviderWithPasswordType = {
@@ -385,6 +385,60 @@ describe('SignInUpService', () => {
     const mockUserWorkspace = { id: 'userWorkspaceId' };
 
     jest.spyOn(featureFlagService, 'isFeatureEnabled').mockResolvedValue(true);
+    jest.spyOn(userWorkspaceService, 'addUserToWorkspace').mockResolvedValue({
+      user: {} as User,
+      userWorkspace: mockUserWorkspace as UserWorkspace,
+    });
+
+    await service.signInUp(params);
+
+    expect(params.workspace).toBeDefined();
+    expect(userRoleService.assignRoleToUserWorkspace).not.toHaveBeenCalled();
+  });
+
+  it('should assign default role when permissions are enabled and user does not exist', async () => {
+    const params: SignInUpBaseParams &
+      ExistingUserOrPartialUserWithPicture &
+      AuthProviderWithPasswordType = {
+      workspace: {
+        id: 'workspaceId',
+        defaultRoleId: 'defaultRoleId',
+        activationStatus: WorkspaceActivationStatus.ACTIVE,
+      } as Workspace,
+      authParams: { provider: 'password', password: 'validPassword' },
+      userData: {
+        type: 'newUserWithPicture',
+        newUserWithPicture: {
+          email: 'newuser@example.com',
+          picture: 'pictureUrl',
+        },
+      },
+    };
+
+    const mockUserWorkspace = { id: 'userWorkspaceId' };
+
+    jest.spyOn(featureFlagService, 'isFeatureEnabled').mockResolvedValue(true);
+
+    jest.spyOn(environmentService, 'get').mockReturnValue(false);
+    jest.spyOn(WorkspaceRepository, 'count').mockResolvedValue(0);
+    jest.spyOn(WorkspaceRepository, 'create').mockReturnValue({} as Workspace);
+    jest.spyOn(WorkspaceRepository, 'save').mockResolvedValue({
+      id: 'newWorkspaceId',
+      activationStatus: WorkspaceActivationStatus.ACTIVE,
+    } as Workspace);
+    jest.spyOn(fileUploadService, 'uploadImage').mockResolvedValue({
+      id: '',
+      mimeType: '',
+      paths: ['path/to/image'],
+    });
+    jest.spyOn(UserRepository, 'create').mockReturnValue({} as User);
+    jest
+      .spyOn(domainManagerService, 'generateSubdomain')
+      .mockResolvedValue('a-subdomain');
+    jest
+      .spyOn(UserRepository, 'save')
+
+      .mockResolvedValue({ id: 'newUserId' } as User);
     jest.spyOn(userWorkspaceService, 'addUserToWorkspace').mockResolvedValue({
       user: {} as User,
       userWorkspace: mockUserWorkspace as UserWorkspace,

--- a/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/sign-in-up.service.ts
@@ -243,16 +243,18 @@ export class SignInUpService {
 
     const user = Object.assign(currentUser, updatedUser);
 
-    if (params.userData.type === 'newUserWithPicture') {
-      await this.activateOnboardingForUser(user, params.workspace);
-    }
+    const isSignUp = params.userData.type === 'newUserWithPicture';
 
-    if (params.workspace.defaultRoleId) {
-      await this.userRoleService.assignRoleToUserWorkspace({
-        workspaceId: params.workspace.id,
-        userWorkspaceId: userWorkspace.id,
-        roleId: params.workspace.defaultRoleId,
-      });
+    if (isSignUp) {
+      await this.activateOnboardingForUser(user, params.workspace);
+
+      if (params.workspace.defaultRoleId) {
+        await this.userRoleService.assignRoleToUserWorkspace({
+          workspaceId: params.workspace.id,
+          userWorkspaceId: userWorkspace.id,
+          roleId: params.workspace.defaultRoleId,
+        });
+      }
     }
 
     return user;


### PR DESCRIPTION
When logging using a SSO method, we call signInUp service in which we were wrongfully assigning a role to the user even if the user is signing in and not signin up. 

This went unnoticed during our QA as a different sign-in method is called when logging with the credentials.