### PR TITLE
contact creation was recreating a primaryemail du to casing

### DIFF
--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-event-import-exception-handler.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-event-import-exception-handler.service.ts
@@ -85,7 +85,10 @@ export class CalendarEventImportErrorHandlerService {
         workspaceId,
       );
 
-      return;
+      throw new CalendarEventImportException(
+        `Unknown temporary error occurred while importing calendar events for calendar channel ${calendarChannel.id} in workspace ${workspaceId} with throttleFailureCount${calendarChannel.throttleFailureCount}`,
+        CalendarEventImportExceptionCode.UNKNOWN,
+      );
     }
 
     const calendarChannelRepository =

--- a/packages/twenty-server/src/modules/contact-creation-manager/services/create-company-and-contact.service.ts
+++ b/packages/twenty-server/src/modules/contact-creation-manager/services/create-company-and-contact.service.ts
@@ -84,13 +84,14 @@ export class CreateCompanyAndContactService {
     });
 
     const alreadyCreatedContactEmails: string[] = alreadyCreatedContacts?.map(
-      ({ emails }) => emails?.primaryEmail,
+      ({ emails }) => emails?.primaryEmail?.toLowerCase(),
     );
 
     const filteredContactsToCreate = uniqueContacts.filter(
       (participant) =>
-        !alreadyCreatedContactEmails.includes(participant.handle) &&
-        participant.handle.includes('@'),
+        !alreadyCreatedContactEmails.includes(
+          participant.handle.toLowerCase(),
+        ) && participant.handle.includes('@'),
     );
 
     const filteredContactsToCreateWithCompanyDomainNames =

--- a/packages/twenty-server/src/modules/contact-creation-manager/services/create-contact.service.ts
+++ b/packages/twenty-server/src/modules/contact-creation-manager/services/create-contact.service.ts
@@ -51,7 +51,10 @@ export class CreateContactService {
 
       return {
         id,
-        emails: { primaryEmail: handle, additionalEmails: null },
+        emails: {
+          primaryEmail: handle.toLowerCase(),
+          additionalEmails: null,
+        },
         name: {
           firstName,
           lastName,

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-messages-import.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-messages-import.service.ts
@@ -146,7 +146,7 @@ export class MessagingMessagesImportService {
         blocklist.map((blocklistItem) => blocklistItem.handle),
       );
 
-      await this.saveMessagesAndEnqueueContactCreationService.saveMessagesAndEnqueueContactCreationJob(
+      await this.saveMessagesAndEnqueueContactCreationService.saveMessagesAndEnqueueContactCreation(
         messagesToSave,
         messageChannel,
         connectedAccount,

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-save-messages-and-enqueue-contact-creation.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-save-messages-and-enqueue-contact-creation.service.ts
@@ -36,7 +36,7 @@ export class MessagingSaveMessagesAndEnqueueContactCreationService {
     private readonly twentyORMManager: TwentyORMManager,
   ) {}
 
-  async saveMessagesAndEnqueueContactCreationJob(
+  async saveMessagesAndEnqueueContactCreation(
     messagesToSave: MessageWithParticipants[],
     messageChannel: MessageChannelWorkspaceEntity,
     connectedAccount: ConnectedAccountWorkspaceEntity,


### PR DESCRIPTION
a first step to fix some of the issues i notices in grafana for a client N.

in grafana, we log this error :  
```
error: error: duplicate key value violates unique constraint "IDX_UNIQUE_87914cd3ce963115f8cb943e2ac"

query failed: INSERT INTO "workspace_20fjk7nksxxxxxxxxxxx"."person"("cdrOpportunityId", "siteOpportunityId", "xLinkPrimaryLinkLabel", "xLinkPrimaryLinkUrl", "xLinkSecondaryLinks", "linkedinLinkPrimaryLinkLabel", "linkedinLinkPrimaryLinkUrl", "linkedinLinkSecondaryLinks", "emailsPrimaryEmail", "emailsAdditionalEmails", "companyId", "deletedAt", "position", "phonesPrimaryPhoneNumber", "phonesPrimaryPhoneCountryCode", "phonesPrimaryPhoneCallingCode", "phonesAdditionalPhones", "createdAt", "id", "searchVector", "avatarUrl", "city", "jobTitle", "nameFirstName", "nameLastName", "updatedAt", "createdBySource", "createdByWorkspaceMemberId", "createdByName", "createdByContext") VALUES (DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, $1, $2, $3, DEFAULT, $4, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, $5, DEFAULT, DEFAULT, DEFAULT, DEFAULT, $6, $7, DEFAULT, $8, $9, $10, $11), (DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, $12, $13, $14, DEFAULT, $15, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, $16, DEFAULT, DEFAULT, DEFAULT, DEFAULT, $17, $18, DEFAULT, $19, $20, $21, $22), (DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, $23, $24, $25, DEFAULT, $26, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, $27, DEFAULT, DEFAULT, DEFAULT, DEFAULT, $28, $29, DEFAULT, $30, $31, $32, $33), (DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, $34, $35, $36, DEFAULT, $37, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, $38, DEFAULT, DEFAULT, DEFAULT, DEFAULT, $39, $40, DEFAULT, $41, $42, $43, $44) RETURNING "xLinkPrimaryLinkLabel", "xLinkPrimaryLinkUrl", "xLinkSecondaryLinks", "linkedinLinkPrimaryLinkLabel", "linkedinLinkPrimaryLinkUrl", "linkedinLinkSecondaryLinks", "emailsPrimaryEmail", "emailsAdditionalEmails", "companyId", "deletedAt", "position", "phonesPrimaryPhoneNumber", "phonesPrimaryPhoneCountryCode", "phonesPrimaryPhoneCallingCode", "phonesAdditionalPhones", "createdAt", "id", "searchVector", "avatarUrl", "city", "jobTitle", "nameFirstName", "nameLastName", "updatedAt", "createdBySource", "createdByWorkspaceMemberId", "createdByName", "createdByContext" 
```
The index is related to the People table on the N. workspace schema. When I looked at the email trying to be inserted, it contains captial letters. I looked at the DB and there are existing small caps emails. That's why my guess it that the failure comes from the contact creation service.

Intersting fact, it comes from the CALENDAR source, not the email one. That's why i added a little bit of error logging in case it reproduces itself