### PR TITLE
Fix useFindManyRecords withSoftDeleterFilter

### DIFF
--- a/packages/twenty-front/src/modules/command-menu/components/ResetContextToSelectionCommandButton.tsx
+++ b/packages/twenty-front/src/modules/command-menu/components/ResetContextToSelectionCommandButton.tsx
@@ -1,5 +1,6 @@
 import { CommandMenuContextRecordsChip } from '@/command-menu/components/CommandMenuContextRecordsChip';
 import { CommandMenuItem } from '@/command-menu/components/CommandMenuItem';
+import { COMMAND_MENU_PREVIOUS_COMPONENT_INSTANCE_ID } from '@/command-menu/constants/CommandMenuPreviousComponentInstanceId';
 import { RESET_CONTEXT_TO_SELECTION } from '@/command-menu/constants/ResetContextToSelection';
 import { useResetPreviousCommandMenuContext } from '@/command-menu/hooks/useResetPreviousCommandMenuContext';
 import { contextStoreCurrentObjectMetadataItemIdComponentState } from '@/context-store/states/contextStoreCurrentObjectMetadataItemIdComponentState';
@@ -48,7 +49,7 @@ export const ResetContextToSelectionCommandButton = () => {
       RightComponent={
         <CommandMenuContextRecordsChip
           objectMetadataItemId={objectMetadataItem.id}
-          instanceId="command-menu-previous"
+          instanceId={COMMAND_MENU_PREVIOUS_COMPONENT_INSTANCE_ID}
         />
       }
       onClick={resetPreviousCommandMenuContext}

--- a/packages/twenty-front/src/modules/object-record/hooks/useFindManyRecords.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useFindManyRecords.ts
@@ -72,15 +72,14 @@ export const useFindManyRecords = <T extends ObjectRecord = ObjectRecord>({
     useQuery<RecordGqlOperationFindManyResult>(findManyRecordsQuery, {
       skip: skip || !objectMetadataItem,
       variables: {
-        filter:
-          filter || withSoftDeleted
-            ? {
-                and: [
-                  ...(filter ? [filter] : []),
-                  ...(withSoftDeleted ? [withSoftDeleterFilter] : []),
-                ],
-              }
-            : undefined,
+        filter: withSoftDeleted
+          ? {
+              and: [
+                ...(filter ? [filter] : []),
+                ...(withSoftDeleted ? [withSoftDeleterFilter] : []),
+              ],
+            }
+          : filter,
         orderBy,
         lastCursor: cursorFilter?.cursor ?? undefined,
         limit,

--- a/packages/twenty-front/src/modules/object-record/hooks/useFindManyRecords.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useFindManyRecords.ts
@@ -72,14 +72,15 @@ export const useFindManyRecords = <T extends ObjectRecord = ObjectRecord>({
     useQuery<RecordGqlOperationFindManyResult>(findManyRecordsQuery, {
       skip: skip || !objectMetadataItem,
       variables: {
-        ...(filter || withSoftDeleted
-          ? {
-              filter: {
-                ...filter,
-                ...(withSoftDeleted ? withSoftDeleterFilter : {}),
-              },
-            }
-          : {}),
+        filter:
+          filter || withSoftDeleted
+            ? {
+                and: [
+                  ...(filter ? [filter] : []),
+                  ...(withSoftDeleted ? [withSoftDeleterFilter] : []),
+                ],
+              }
+            : undefined,
         orderBy,
         lastCursor: cursorFilter?.cursor ?? undefined,
         limit,


### PR DESCRIPTION
Fixes #11038

# Fix useFindManyRecords withSoftDeleterFilter

The error came from a faulty implementation of the `withSoftDeleted` parameter inside `useFindManyRecords` and from the fact that `withSoftDeleted: true` was added to access deleted records actions. However, this parameter was always set in `useFindManyRecordsSelectedInContextStore` instead of considering whether the filter was active or not.

```
const withSoftDeleterFilter = {
  or: [{ deletedAt: { is: 'NULL' } }, { deletedAt: { is: 'NOT_NULL' } }],
};
```

The final filter was incorrectly doing an `or` operation between the base filter and `withSoftDeleterFilter` when it should have been an `and`:

```
filter: {
  ...filter,
  ...(withSoftDeleted ? withSoftDeleterFilter : {}),
}
```

The correct implementation should be:

```
filter:
  filter || withSoftDeleted
    ? {
        and: [
          ...(filter ? [filter] : []),
          ...(withSoftDeleted ? [withSoftDeleterFilter] : []),
        ],
      }
    : undefined,
```

# Fix useFindManyRecordsSelectedInContextStore

- Check if the soft deleted filter is active before using the `withSoftDeleterFilter` parameter