### PR TITLE
fix(settings): adjust custom domain table cell styling

### DIFF
--- a/packages/twenty-front/src/pages/settings/workspace/SettingsCustomDomainRecords.tsx
+++ b/packages/twenty-front/src/pages/settings/workspace/SettingsCustomDomainRecords.tsx
@@ -18,7 +18,7 @@ const StyledTable = styled(Table)`
 
 const StyledTableCell = styled(TableCell)`
   overflow: hidden;
-
+  display: block;
   padding: 0 ${({ theme }) => theme.spacing(3)} 0 0;
 
   &:first-child {


### PR DESCRIPTION
Set table cell display to block to ensure proper rendering and alignment. This resolves layout issues caused by the previous styling.