### PR TITLE
[BUGFIX] `GenerateDefaultRecordChipData` returns `RecordChipData`

### DIFF
--- a/packages/twenty-front/src/modules/object-metadata/contexts/PreComputedChipGeneratorsContext.ts
+++ b/packages/twenty-front/src/modules/object-metadata/contexts/PreComputedChipGeneratorsContext.ts
@@ -8,10 +8,10 @@ export type ChipGeneratorPerObjectNameSingularPerFieldName = Record<
   Record<string, (record: ObjectRecord) => RecordChipData>
 >;
 
-export type IdentifierChipGeneratorPerObject = Record<
+export type IdentifierChipGeneratorPerObject = Partial<Record<
   string,
   (record: ObjectRecord) => RecordChipData
->;
+>>;
 
 export type PreComputedChipGeneratorsContextProps = {
   chipGeneratorPerObjectPerField: ChipGeneratorPerObjectNameSingularPerFieldName;

--- a/packages/twenty-front/src/modules/object-metadata/contexts/PreComputedChipGeneratorsContext.ts
+++ b/packages/twenty-front/src/modules/object-metadata/contexts/PreComputedChipGeneratorsContext.ts
@@ -8,10 +8,9 @@ export type ChipGeneratorPerObjectNameSingularPerFieldName = Record<
   Record<string, (record: ObjectRecord) => RecordChipData>
 >;
 
-export type IdentifierChipGeneratorPerObject = Partial<Record<
-  string,
-  (record: ObjectRecord) => RecordChipData
->>;
+export type IdentifierChipGeneratorPerObject = Partial<
+  Record<string, (record: ObjectRecord) => RecordChipData>
+>;
 
 export type PreComputedChipGeneratorsContextProps = {
   chipGeneratorPerObjectPerField: ChipGeneratorPerObjectNameSingularPerFieldName;

--- a/packages/twenty-front/src/modules/object-metadata/utils/generateDefaultRecordChipData.ts
+++ b/packages/twenty-front/src/modules/object-metadata/utils/generateDefaultRecordChipData.ts
@@ -17,7 +17,7 @@ export const generateDefaultRecordChipData = ({
   return {
     avatarType: 'rounded',
     avatarUrl: name,
-    isLabelIdentifier: false, // idk
+    isLabelIdentifier: false,
     name,
     objectNameSingular,
     recordId: record.id,

--- a/packages/twenty-front/src/modules/object-metadata/utils/generateDefaultRecordChipData.ts
+++ b/packages/twenty-front/src/modules/object-metadata/utils/generateDefaultRecordChipData.ts
@@ -1,20 +1,23 @@
+import { RecordChipData } from '@/object-record/record-field/types/RecordChipData';
 import { isFieldFullNameValue } from '@/object-record/record-field/types/guards/isFieldFullNameValue';
 import { ObjectRecord } from '@/object-record/types/ObjectRecord';
-import { v4 } from 'uuid';
 
-export const generateDefaultRecordChipData = (
-  {__typename, ...record}: ObjectRecord,
-) => {
+type GenerateDefaultRecordChipDataArgs = {
+  record: ObjectRecord,
+  objectNameSingular: string
+}
+export const generateDefaultRecordChipData = ({objectNameSingular, record}: GenerateDefaultRecordChipDataArgs): RecordChipData => {
+  console.log("OUI", { record });
   const name = isFieldFullNameValue(record.name)
     ? `${record.name.firstName} ${record.name.lastName}`
     : (record.name ?? '');
 
   return {
-    __typename,
-    id: v4(),
-    name,
-    avatarUrl: name,
     avatarType: 'rounded',
-    linkToShowPage: false,
-  } satisfies ObjectRecord;
+    avatarUrl: name,
+    isLabelIdentifier: false, // idk
+    name,
+    objectNameSingular,
+    recordId: record.id
+  }
 };

--- a/packages/twenty-front/src/modules/object-metadata/utils/generateDefaultRecordChipData.ts
+++ b/packages/twenty-front/src/modules/object-metadata/utils/generateDefaultRecordChipData.ts
@@ -3,11 +3,14 @@ import { isFieldFullNameValue } from '@/object-record/record-field/types/guards/
 import { ObjectRecord } from '@/object-record/types/ObjectRecord';
 
 type GenerateDefaultRecordChipDataArgs = {
-  record: ObjectRecord,
-  objectNameSingular: string
-}
-export const generateDefaultRecordChipData = ({objectNameSingular, record}: GenerateDefaultRecordChipDataArgs): RecordChipData => {
-  console.log("OUI", { record });
+  record: ObjectRecord;
+  objectNameSingular: string;
+};
+export const generateDefaultRecordChipData = ({
+  objectNameSingular,
+  record,
+}: GenerateDefaultRecordChipDataArgs): RecordChipData => {
+  console.log('OUI', { record });
   const name = isFieldFullNameValue(record.name)
     ? `${record.name.firstName} ${record.name.lastName}`
     : (record.name ?? '');
@@ -18,6 +21,6 @@ export const generateDefaultRecordChipData = ({objectNameSingular, record}: Gene
     isLabelIdentifier: false, // idk
     name,
     objectNameSingular,
-    recordId: record.id
-  }
+    recordId: record.id,
+  };
 };

--- a/packages/twenty-front/src/modules/object-metadata/utils/generateDefaultRecordChipData.ts
+++ b/packages/twenty-front/src/modules/object-metadata/utils/generateDefaultRecordChipData.ts
@@ -10,7 +10,6 @@ export const generateDefaultRecordChipData = ({
   objectNameSingular,
   record,
 }: GenerateDefaultRecordChipDataArgs): RecordChipData => {
-  console.log('OUI', { record });
   const name = isFieldFullNameValue(record.name)
     ? `${record.name.firstName} ${record.name.lastName}`
     : (record.name ?? '');

--- a/packages/twenty-front/src/modules/object-metadata/utils/generateDefaultRecordChipData.ts
+++ b/packages/twenty-front/src/modules/object-metadata/utils/generateDefaultRecordChipData.ts
@@ -1,15 +1,19 @@
 import { isFieldFullNameValue } from '@/object-record/record-field/types/guards/isFieldFullNameValue';
 import { ObjectRecord } from '@/object-record/types/ObjectRecord';
 
-export const generateDefaultRecordChipData = (record: ObjectRecord) => {
+export const generateDefaultRecordChipData = (
+  record: ObjectRecord,
+) => {
   const name = isFieldFullNameValue(record.name)
-    ? record.name.firstName + ' ' + record.name.lastName
+    ? `${record.name.firstName} ${record.name.lastName}`
     : (record.name ?? '');
 
   return {
+    __typename: '',
+    id: '',
     name,
     avatarUrl: name,
     avatarType: 'rounded',
     linkToShowPage: false,
-  };
+  } satisfies ObjectRecord;
 };

--- a/packages/twenty-front/src/modules/object-metadata/utils/generateDefaultRecordChipData.ts
+++ b/packages/twenty-front/src/modules/object-metadata/utils/generateDefaultRecordChipData.ts
@@ -1,16 +1,17 @@
 import { isFieldFullNameValue } from '@/object-record/record-field/types/guards/isFieldFullNameValue';
 import { ObjectRecord } from '@/object-record/types/ObjectRecord';
+import { v4 } from 'uuid';
 
 export const generateDefaultRecordChipData = (
-  record: ObjectRecord,
+  {__typename, ...record}: ObjectRecord,
 ) => {
   const name = isFieldFullNameValue(record.name)
     ? `${record.name.firstName} ${record.name.lastName}`
     : (record.name ?? '');
 
   return {
-    __typename: '',
-    id: '',
+    __typename,
+    id: v4(),
     name,
     avatarUrl: name,
     avatarType: 'rounded',

--- a/packages/twenty-front/src/modules/object-record/hooks/useRecordChipData.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useRecordChipData.ts
@@ -1,24 +1,37 @@
 import { PreComputedChipGeneratorsContext } from '@/object-metadata/contexts/PreComputedChipGeneratorsContext';
 import { generateDefaultRecordChipData } from '@/object-metadata/utils/generateDefaultRecordChipData';
+import { RecordChipData } from '@/object-record/record-field/types/RecordChipData';
 import { ObjectRecord } from '@/object-record/types/ObjectRecord';
 import { useContext } from 'react';
+import { isDefined } from 'twenty-shared';
 
+type UseRecordChipDataArgs = {
+  objectNameSingular: string;
+  record: ObjectRecord;
+};
+type UseRecordChipDataReturnType = {
+  recordChipData: RecordChipData;
+};
 export const useRecordChipData = ({
   objectNameSingular,
   record,
-}: {
-  objectNameSingular: string;
-  record: ObjectRecord;
-}) => {
+}: UseRecordChipDataArgs): UseRecordChipDataReturnType => {
   const { identifierChipGeneratorPerObject } = useContext(
     PreComputedChipGeneratorsContext,
   );
 
-  const generateRecordChipData =
-    identifierChipGeneratorPerObject[objectNameSingular] ??
-    generateDefaultRecordChipData;
+  const generateRecordChipDataFromContext =
+    identifierChipGeneratorPerObject[objectNameSingular];
+  if (isDefined(generateRecordChipDataFromContext)) {
+    return {
+      recordChipData: generateRecordChipDataFromContext(record),
+    };
+  }
 
-  const recordChipData = generateRecordChipData(record);
-
-  return { recordChipData };
+  return {
+    recordChipData: generateDefaultRecordChipData({
+      objectNameSingular,
+      record,
+    }),
+  };
 };

--- a/packages/twenty-front/src/modules/object-record/hooks/useRecordChipData.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useRecordChipData.ts
@@ -20,11 +20,11 @@ export const useRecordChipData = ({
     PreComputedChipGeneratorsContext,
   );
 
-  const generateRecordChipDataFromContext =
+  const identifierChipGenerator =
     identifierChipGeneratorPerObject[objectNameSingular];
-  if (isDefined(generateRecordChipDataFromContext)) {
+  if (isDefined(identifierChipGenerator)) {
     return {
-      recordChipData: generateRecordChipDataFromContext(record),
+      recordChipData: identifierChipGenerator(record),
     };
   }
 

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/display/components/RelationFromManyFieldDisplay.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/display/components/RelationFromManyFieldDisplay.tsx
@@ -6,7 +6,7 @@ import { RecordChip } from '@/object-record/components/RecordChip';
 import { useFieldFocus } from '@/object-record/record-field/hooks/useFieldFocus';
 import { useRelationFromManyFieldDisplay } from '@/object-record/record-field/meta-types/hooks/useRelationFromManyFieldDisplay';
 import { ExpandableList } from '@/ui/layout/expandable-list/components/ExpandableList';
-import { isNull } from '@sniptt/guards';
+import { isDefined } from 'twenty-shared';
 
 export const RelationFromManyFieldDisplay = () => {
   const { fieldValue, fieldDefinition } = useRelationFromManyFieldDisplay();
@@ -49,7 +49,7 @@ export const RelationFromManyFieldDisplay = () => {
     return (
       <ExpandableList isChipCountDisplayed={isFocused}>
         {fieldValue
-          .filter((record) => !isNull(record[relationFieldName]))
+          .filter(isDefined)
           .map((record) => (
             <RecordChip
               key={record.id}
@@ -63,7 +63,7 @@ export const RelationFromManyFieldDisplay = () => {
     return (
       <ExpandableList isChipCountDisplayed={isFocused}>
         {activityTargetObjectRecords
-          .filter((record) => !isNull(record.targetObject))
+          .filter(isDefined)
           .map((record) => (
             <RecordChip
               key={record.targetObject.id}
@@ -77,7 +77,7 @@ export const RelationFromManyFieldDisplay = () => {
     return (
       <ExpandableList isChipCountDisplayed={isFocused}>
         {fieldValue
-          .filter((record) => !isNull(record))
+          .filter(isDefined)
           .map((record) => (
             <RecordChip
               key={record.id}

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/display/components/RelationFromManyFieldDisplay.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/display/components/RelationFromManyFieldDisplay.tsx
@@ -48,43 +48,37 @@ export const RelationFromManyFieldDisplay = () => {
 
     return (
       <ExpandableList isChipCountDisplayed={isFocused}>
-        {fieldValue
-          .filter(isDefined)
-          .map((record) => (
-            <RecordChip
-              key={record.id}
-              objectNameSingular={objectNameSingular}
-              record={record[relationFieldName]}
-            />
-          ))}
+        {fieldValue.filter(isDefined).map((record) => (
+          <RecordChip
+            key={record.id}
+            objectNameSingular={objectNameSingular}
+            record={record[relationFieldName]}
+          />
+        ))}
       </ExpandableList>
     );
   } else if (isRelationFromActivityTargets) {
     return (
       <ExpandableList isChipCountDisplayed={isFocused}>
-        {activityTargetObjectRecords
-          .filter(isDefined)
-          .map((record) => (
-            <RecordChip
-              key={record.targetObject.id}
-              objectNameSingular={record.targetObjectMetadataItem.nameSingular}
-              record={record.targetObject}
-            />
-          ))}
+        {activityTargetObjectRecords.filter(isDefined).map((record) => (
+          <RecordChip
+            key={record.targetObject.id}
+            objectNameSingular={record.targetObjectMetadataItem.nameSingular}
+            record={record.targetObject}
+          />
+        ))}
       </ExpandableList>
     );
   } else {
     return (
       <ExpandableList isChipCountDisplayed={isFocused}>
-        {fieldValue
-          .filter(isDefined)
-          .map((record) => (
-            <RecordChip
-              key={record.id}
-              objectNameSingular={objectNameSingular}
-              record={record}
-            />
-          ))}
+        {fieldValue.filter(isDefined).map((record) => (
+          <RecordChip
+            key={record.id}
+            objectNameSingular={objectNameSingular}
+            record={record}
+          />
+        ))}
       </ExpandableList>
     );
   }

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/hooks/useRelationFromManyFieldDisplay.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/hooks/useRelationFromManyFieldDisplay.ts
@@ -44,14 +44,26 @@ export const useRelationFromManyFieldDisplay = () => {
       ? maxWidth - FIELD_EDIT_BUTTON_WIDTH
       : maxWidth;
 
-  if (!isNonEmptyString(fieldDefinition.metadata.objectMetadataNameSingular)) {
+  if (
+    !isDefined(fieldDefinition.metadata.objectMetadataNameSingular) ||
+    !isNonEmptyString(fieldDefinition.metadata.objectMetadataNameSingular)
+  ) {
     throw new Error('Object metadata name singular is not a non-empty string');
   }
 
-  const generateRecordChipData =
+  const fieldChipGenerator =
     chipGeneratorPerObjectPerField[
       fieldDefinition.metadata.objectMetadataNameSingular
-    ]?.[fieldDefinition.metadata.fieldName] ?? generateDefaultRecordChipData;
+    ]?.[fieldDefinition.metadata.fieldName];
+  const generateRecordChipData = isDefined(fieldChipGenerator)
+    ? fieldChipGenerator
+    : (record: ObjectRecord) =>
+        generateDefaultRecordChipData({
+          record,
+          // @ts-expect-error Above assertions does not infer that fieldDefinition.metadata.objectMetadataNameSingular always defined
+          objectNameSingular:
+            fieldDefinition.metadata.objectMetadataNameSingular,
+        });
 
   return {
     fieldDefinition,

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/hooks/useRelationToOneFieldDisplay.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/hooks/useRelationToOneFieldDisplay.ts
@@ -2,13 +2,13 @@ import { isNonEmptyString } from '@sniptt/guards';
 import { useContext } from 'react';
 
 import { PreComputedChipGeneratorsContext } from '@/object-metadata/contexts/PreComputedChipGeneratorsContext';
-import { generateDefaultRecordChipData } from '@/object-metadata/utils/generateDefaultRecordChipData';
 import { useRecordFieldValue } from '@/object-record/record-store/contexts/RecordFieldValueSelectorContext';
 import { ObjectRecord } from '@/object-record/types/ObjectRecord';
 import { FIELD_EDIT_BUTTON_WIDTH } from '@/ui/field/display/constants/FieldEditButtonWidth';
 import { isDefined } from 'twenty-shared';
 import { FieldMetadataType } from '~/generated-metadata/graphql';
 
+import { generateDefaultRecordChipData } from '@/object-metadata/utils/generateDefaultRecordChipData';
 import { FieldContext } from '../../contexts/FieldContext';
 import { assertFieldMetadata } from '../../types/guards/assertFieldMetadata';
 import { isFieldRelation } from '../../types/guards/isFieldRelation';
@@ -44,14 +44,26 @@ export const useRelationToOneFieldDisplay = () => {
       ? maxWidth - FIELD_EDIT_BUTTON_WIDTH
       : maxWidth;
 
-  if (!isNonEmptyString(fieldDefinition.metadata.objectMetadataNameSingular)) {
+  if (
+    !isDefined(fieldDefinition.metadata.objectMetadataNameSingular) ||
+    !isNonEmptyString(fieldDefinition.metadata.objectMetadataNameSingular)
+  ) {
     throw new Error('Object metadata name singular is not a non-empty string');
   }
 
-  const generateRecordChipData =
+  const fieldChipGenerator =
     chipGeneratorPerObjectPerField[
       fieldDefinition.metadata.objectMetadataNameSingular
-    ]?.[fieldDefinition.metadata.fieldName] ?? generateDefaultRecordChipData;
+    ]?.[fieldDefinition.metadata.fieldName];
+  const generateRecordChipData = isDefined(fieldChipGenerator)
+    ? fieldChipGenerator
+    : (record: ObjectRecord) =>
+        generateDefaultRecordChipData({
+          record,
+          // @ts-expect-error Above assertions does not infer that fieldDefinition.metadata.objectMetadataNameSingular always defined
+          objectNameSingular:
+            fieldDefinition.metadata.objectMetadataNameSingular,
+        });
 
   return {
     fieldDefinition,


### PR DESCRIPTION
# Introduction
closes https://github.com/twentyhq/twenty/issues/11030, might not fix the issue as it seems to be related to the passed record to `identifierChipGeneratorPerObject` about to dig deeper in this generator code => found nothing revelant doubled check each `RecordChip` invocation that could provide undefined record
Fixed wrong default generated `RecordChipData` signature

## Reproducibility
I've only been able to reproduce the bug in production using the very same opportunity than within the issue, but not all the time
https://crm.twenty-internal.com/objects/opportunities?viewId=b709d3d1-2dd2-455d-ba73-784f3ab00883
```json
// Removed timelineActivities to prevent linking ids
{
  "data": {
    "opportunity": {
      "__typename": "Opportunity",
      "closeDate": null,
      "company": null,
      "companyId": null,
      "createdAt": "2024-06-17T09:45:22.357Z",
      "deletedAt": null,
      "id": "006a22dd-6bd6-4247-a24b-42fb164cd48c",
      "name": "test",
      "pointOfContact": null,
      "pointOfContactId": null,
      "position": 0,
      "probability": "0",
      "stage": "NEW_STAGE",
      "updatedAt": "2025-03-20T16:27:51.927Z",
      "amount": {
        "__typename": "Currency",
        "amountMicros": null,
        "currencyCode": "USD"
      },
      "attachments": {
        "__typename": "AttachmentConnection",
        "edges": []
      },
      "createdBy": {
        "__typename": "Actor",
        "source": "MANUAL",
        "workspaceMemberId": null,
        "name": "",
        "context": {}
      },
      "favorites": {
        "__typename": "FavoriteConnection",
        "edges": []
      },
      "taskTargets": {
        "__typename": "TaskTargetConnection",
        "edges": []
      },
      "noteTargets": {
        "__typename": "NoteTargetConnection",
        "edges": [
          {
            "__typename": "NoteTargetEdge",
            "node": {
              "__typename": "NoteTarget",
              "appEventId": null,
              "companyId": null,
              "createdAt": "2025-01-22T17:11:07.801Z",
              "deletedAt": null,
              "feedbackId": null,
              "id": "2e8eca1c-e2c2-425a-93fc-ef2aeb65f410",
              "issueId": null,
              "listingId": null,
              "noteId": "ab586b51-6931-4a4a-9c24-0d16226211b2",
              "opportunityId": "006a22dd-6bd6-4247-a24b-42fb164cd48c",
              "personId": null,
              "somethingId": null,
              "testId": null,
              "updatedAt": "2025-01-22T17:11:07.801Z"
            }
          }
        ]
      },
    }
  }
}
```