### PR TITLE
Fix option text deletion in select fields by removing error for empty values

### DIFF
--- a/packages/twenty-front/src/modules/settings/components/AdvancedSettingsWrapper.tsx
+++ b/packages/twenty-front/src/modules/settings/components/AdvancedSettingsWrapper.tsx
@@ -48,13 +48,14 @@ export const AdvancedSettingsWrapper = ({
   children,
   hideDot = false,
   dotPosition = 'centered',
+  animationDimension = 'height',
 }: AdvancedSettingsWrapperProps) => {
   const isAdvancedModeEnabled = useRecoilValue(isAdvancedModeEnabledState);
 
   return (
     <AnimatedExpandableContainer
       isExpanded={isAdvancedModeEnabled}
-      dimension="height"
+      dimension={animationDimension}
       animationDurations={ADVANCED_SETTINGS_ANIMATION_DURATION}
       mode="scroll-height"
       containAnimation={false}

--- a/packages/twenty-front/src/pages/settings/data-model/utils/compute-option-value-from-label.utils.ts
+++ b/packages/twenty-front/src/pages/settings/data-model/utils/compute-option-value-from-label.utils.ts
@@ -9,9 +9,5 @@ export const computeOptionValueFromLabel = (label: string): string => {
     allowedChars: 'a-zA-Z0-9_',
   });
 
-  if (formattedString === '') {
-    throw new Error('Invalid label');
-  }
-
   return formattedString.toUpperCase();
 };


### PR DESCRIPTION
closes #11013
Fixes the issue where users couldn't delete all text in select field options. Removed the error throw for empty strings in the computeOptionValueFromLabel function, allowing proper text deletion. This error handling was redundant since the form validation already prevents submission with empty values.