### PR TITLE
fix: dark-mode for scalar API docs when appearance is system settings

### DIFF
--- a/packages/twenty-front/src/modules/settings/playground/components/RestPlayground.tsx
+++ b/packages/twenty-front/src/modules/settings/playground/components/RestPlayground.tsx
@@ -66,8 +66,9 @@ export const RestPlayground = ({ onError, schema }: RestPlaygroundProps) => {
                   : undefined,
               },
             },
-            baseServerURL: REACT_APP_SERVER_BASE_URL + '/' + schema,
             darkMode: theme.name === 'dark',
+            baseServerURL: REACT_APP_SERVER_BASE_URL + '/' + schema,
+            forceDarkModeState: theme.name === 'dark' ? 'dark' : 'light',
             hideClientButton: true,
             hideDarkModeToggle: true,
             pathRouting: {

--- a/packages/twenty-front/src/modules/settings/playground/components/RestPlayground.tsx
+++ b/packages/twenty-front/src/modules/settings/playground/components/RestPlayground.tsx
@@ -18,6 +18,9 @@ const StyledContainer = styled.div`
 const ApiReferenceReact = lazy(() =>
   import('@scalar/api-reference-react').then((module) => {
     import('@scalar/api-reference-react/style.css');
+    import('@scalar/use-hooks/useColorMode').then((colorMode) =>
+      colorMode.useColorMode(),
+    );
     return {
       default: module.ApiReferenceReact,
     };
@@ -64,7 +67,7 @@ export const RestPlayground = ({ onError, schema }: RestPlaygroundProps) => {
               },
             },
             baseServerURL: REACT_APP_SERVER_BASE_URL + '/' + schema,
-            forceDarkModeState: theme.name === 'dark' ? 'dark' : 'light',
+            darkMode: theme.name === 'dark',
             hideClientButton: true,
             hideDarkModeToggle: true,
             pathRouting: {


### PR DESCRIPTION
# Issue 

- closes #10972

# Demo 

https://github.com/user-attachments/assets/200ec039-0888-4016-b671-34721ee05730

