### PR TITLE
Fixes on rich text editor

### DIFF
--- a/packages/twenty-front/src/modules/ui/input/editor/components/BlockEditor.tsx
+++ b/packages/twenty-front/src/modules/ui/input/editor/components/BlockEditor.tsx
@@ -44,7 +44,7 @@ const StyledEditor = styled.div`
     background: transparent;
   }
   & .bn-editor {
-    padding-inline: 36px;
+    padding-inline: 42px;
   }
   & .bn-container .bn-drag-handle {
     width: 20px;

--- a/packages/twenty-front/src/modules/ui/input/editor/components/BlockEditor.tsx
+++ b/packages/twenty-front/src/modules/ui/input/editor/components/BlockEditor.tsx
@@ -44,7 +44,7 @@ const StyledEditor = styled.div`
     background: transparent;
   }
   & .bn-editor {
-    padding-inline: 42px;
+    padding-inline: 44px;
   }
   & .bn-container .bn-drag-handle {
     width: 20px;

--- a/packages/twenty-front/src/modules/ui/layout/show-page/components/ShowPageActivityContainer.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/show-page/components/ShowPageActivityContainer.tsx
@@ -1,3 +1,4 @@
+import { SKELETON_LOADER_HEIGHT_SIZES } from '@/activities/components/SkeletonLoader';
 import { ActivityTargetableObject } from '@/activities/types/ActivityTargetableEntity';
 import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
 import { recordStoreFamilySelector } from '@/object-record/record-store/states/selectors/recordStoreFamilySelector';
@@ -23,10 +24,8 @@ const StyledShowPageActivityContainer = styled.div`
 const StyledSkeletonContainer = styled.div`
   display: flex;
   flex-direction: column;
-
-  gap: ${({ theme }) => theme.spacing(3)};
   justify-content: center;
-  padding: ${({ theme }) => theme.spacing(4)};
+  padding: ${({ theme }) => theme.spacing(0, 4)};
 `;
 
 const LoadingSkeleton = () => {
@@ -39,9 +38,7 @@ const LoadingSkeleton = () => {
         highlightColor={theme.background.transparent.lighter}
         borderRadius={theme.border.radius.sm}
       >
-        <Skeleton height={24} />
-        <Skeleton height={24} />
-        <Skeleton height={24} />
+        <Skeleton height={SKELETON_LOADER_HEIGHT_SIZES.standard.s} />
       </SkeletonTheme>
     </StyledSkeletonContainer>
   );


### PR DESCRIPTION
- Update skeleton loader padding and make it take only one line
- Update rich text editor padding to align with the fields inside the side panel
<img width="163" alt="Capture d’écran 2025-03-21 à 11 57 00" src="https://github.com/user-attachments/assets/5964404a-3a32-4d7e-b96f-3377949430bf" />
