### PR TITLE
Fix sort menu padding

### DIFF
--- a/packages/twenty-front/src/modules/object-record/object-sort-dropdown/components/ObjectSortDropdownButton.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-sort-dropdown/components/ObjectSortDropdownButton.tsx
@@ -69,6 +69,11 @@ const StyledSelectedSortDirectionContainer = styled.div`
   z-index: 1000;
 `;
 
+const StyledDropdownMenuItemsContainer = styled.div`
+  padding: 4px;
+  margin-bottom: 0;
+`;
+
 export type ObjectSortDropdownButtonProps = {
   hotkeyScope: HotkeyScope;
 };
@@ -240,7 +245,7 @@ export const ObjectSortDropdownButton = ({
               setObjectSortDropdownSearchInput(event.target.value)
             }
           />
-          <DropdownMenuItemsContainer>
+          <StyledDropdownMenuItemsContainer>
             {visibleFieldMetadataItems.map(
               (visibleFieldMetadataItem, index) => (
                 <MenuItem
@@ -262,7 +267,7 @@ export const ObjectSortDropdownButton = ({
                 text={hiddenFieldMetadataItem.label}
               />
             ))}
-          </DropdownMenuItemsContainer>
+          </StyledDropdownMenuItemsContainer>
         </>
       }
       onClose={handleDropdownButtonClose}


### PR DESCRIPTION
Fixes: [11078](https://github.com/twentyhq/twenty/issues/11078)
Adjusted styles to remove extra space at the bottom of the dropdown menu.


Before:
![Screenshot from 2025-03-21 18-09-59](https://github.com/user-attachments/assets/e3f882c4-1242-4dcc-93e9-774a03638f73)
After:
![Screenshot from 2025-03-21 18-07-14](https://github.com/user-attachments/assets/f1f53594-16c3-40f6-a9ba-b153cc1c1ea8)
