### PR TITLE
Fix wrong totalCount in groupBy view

### DIFF
--- a/packages/twenty-front/src/modules/views/hooks/internal/useGetRecordIndexTotalCount.ts
+++ b/packages/twenty-front/src/modules/views/hooks/internal/useGetRecordIndexTotalCount.ts
@@ -6,6 +6,7 @@ import { currentRecordFiltersComponentState } from '@/object-record/record-filte
 import { computeRecordGqlOperationFilter } from '@/object-record/record-filter/utils/computeViewRecordGqlOperationFilter';
 import { AGGREGATE_OPERATIONS } from '@/object-record/record-table/constants/AggregateOperations';
 import { useRecoilComponentValueV2 } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValueV2';
+import { useGetViewGroupsFilters } from '@/views/hooks/useGetViewGroupsFilters';
 
 export const useGetRecordIndexTotalCount = () => {
   const { objectMetadataItem } = useContextStoreObjectMetadataItemOrThrow();
@@ -20,9 +21,11 @@ export const useGetRecordIndexTotalCount = () => {
 
   const { filterValueDependencies } = useFilterValueDependencies();
 
+  const recordGroupsVisibilityFilter = useGetViewGroupsFilters();
+
   const filter = computeRecordGqlOperationFilter({
     filterValueDependencies,
-    recordFilters: currentRecordFilters,
+    recordFilters: [...currentRecordFilters, ...recordGroupsVisibilityFilter],
     recordFilterGroups: currentRecordFilterGroups,
     fields: objectMetadataItem.fields,
   });

--- a/packages/twenty-front/src/modules/views/hooks/useGetViewGroupsFilters.ts
+++ b/packages/twenty-front/src/modules/views/hooks/useGetViewGroupsFilters.ts
@@ -1,0 +1,26 @@
+import { useGetCurrentViewOnly } from '@/views/hooks/useGetCurrentViewOnly';
+import { FieldMetadataType, isDefined } from 'twenty-shared';
+import { ViewFilterOperand } from '@/views/types/ViewFilterOperand';
+import { getFilterTypeFromFieldType } from '@/object-metadata/utils/formatFieldMetadataItemsAsFilterDefinitions';
+import { RecordFilter } from '@/object-record/record-filter/types/RecordFilter';
+
+export const useGetViewGroupsFilters = (): RecordFilter[] => {
+  const { currentView } = useGetCurrentViewOnly();
+
+  return (
+    currentView?.viewGroups
+      .filter((recordGroup) => !recordGroup.isVisible)
+      .map((recordGroup) => {
+        return {
+          id: recordGroup.id,
+          fieldMetadataId: recordGroup.fieldMetadataId,
+          value: JSON.stringify([recordGroup.fieldValue]),
+          operand: ViewFilterOperand.IsNot,
+          displayValue: '',
+          type: getFilterTypeFromFieldType(FieldMetadataType.SELECT),
+          label: '',
+        };
+      })
+      .filter(isDefined) || []
+  );
+};


### PR DESCRIPTION
Add filters by visibleRecordGroup to compute totalCount
## Before
see https://github.com/twentyhq/twenty/issues/11067

## After
![image](https://github.com/user-attachments/assets/333e8898-e051-4554-b462-9b1d2f10ec05)

- After hiding `New` and `Meeting` columns:
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/a2ae1728-ea11-4e2d-86e5-02778b3c42c0" />

- With filtering
<img width="1275" alt="image" src="https://github.com/user-attachments/assets/263d8865-9cba-4b46-84a0-e9270b29109b" />

- Works also in groupBy view
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/c1ec171f-6eec-45db-aafc-2bd2d1de8841" />
