### PR TITLE
revert logout button to settings menu

### DIFF
--- a/packages/twenty-front/src/modules/settings/components/SettingsNavigationDrawerItems.tsx
+++ b/packages/twenty-front/src/modules/settings/components/SettingsNavigationDrawerItems.tsx
@@ -1,3 +1,4 @@
+import { useAuth } from '@/auth/hooks/useAuth';
 import { AdvancedSettingsWrapper } from '@/settings/components/AdvancedSettingsWrapper';
 import { SettingsNavigationDrawerItem } from '@/settings/components/SettingsNavigationDrawerItem';
 import {
@@ -5,14 +6,20 @@ import {
   SettingsNavigationSection,
   useSettingsNavigationItems,
 } from '@/settings/hooks/useSettingsNavigationItems';
+import { NavigationDrawerItem } from '@/ui/navigation/navigation-drawer/components/NavigationDrawerItem';
 import { NavigationDrawerItemGroup } from '@/ui/navigation/navigation-drawer/components/NavigationDrawerItemGroup';
 import { NavigationDrawerSection } from '@/ui/navigation/navigation-drawer/components/NavigationDrawerSection';
 import { NavigationDrawerSectionTitle } from '@/ui/navigation/navigation-drawer/components/NavigationDrawerSectionTitle';
 import { getNavigationSubItemLeftAdornment } from '@/ui/navigation/navigation-drawer/utils/getNavigationSubItemLeftAdornment';
+import { useLingui } from '@lingui/react/macro';
 import { matchPath, resolvePath, useLocation } from 'react-router-dom';
+import { IconDoorEnter } from 'twenty-ui';
 import { getSettingsPath } from '~/utils/navigation/getSettingsPath';
 
 export const SettingsNavigationDrawerItems = () => {
+  const { signOut } = useAuth();
+  const { t } = useLingui();
+
   const settingsNavigationItems: SettingsNavigationSection[] =
     useSettingsNavigationItems();
 
@@ -109,6 +116,13 @@ export const SettingsNavigationDrawerItems = () => {
           </NavigationDrawerSection>
         );
       })}
+      <NavigationDrawerSection>
+        <NavigationDrawerItem
+          label={t`Logout`}
+          onClick={signOut}
+          Icon={IconDoorEnter}
+        />
+      </NavigationDrawerSection>
     </>
   );
 };


### PR DESCRIPTION
## Context
Reverting back the removal of "Log out" button. While it is now accessible from the workspace picker, suspended workspaces don't have access to that picker and are locked in the settings pages so I'm adding back the log out button in the settings menu

<img width="225" alt="Screenshot 2025-03-21 at 15 52 40" src="https://github.com/user-attachments/assets/d5453868-d043-49e9-9207-2cfdd65838da" />
