### PR TITLE
Remove hotkey scope from useListenClickOutside

### DIFF
--- a/packages/twenty-front/src/modules/command-menu/components/CommandMenuContainer.tsx
+++ b/packages/twenty-front/src/modules/command-menu/components/CommandMenuContainer.tsx
@@ -22,7 +22,6 @@ import { RecordFilterGroupsComponentInstanceContext } from '@/object-record/reco
 import { RecordFiltersComponentInstanceContext } from '@/object-record/record-filter/states/context/RecordFiltersComponentInstanceContext';
 import { RecordSortsComponentInstanceContext } from '@/object-record/record-sort/states/context/RecordSortsComponentInstanceContext';
 import { getRecordIndexIdFromObjectNamePluralAndViewId } from '@/object-record/utils/getRecordIndexIdFromObjectNamePluralAndViewId';
-import { AppHotkeyScope } from '@/ui/utilities/hotkey/types/AppHotkeyScope';
 import { useListenClickOutside } from '@/ui/utilities/pointer-event/hooks/useListenClickOutside';
 import { useRecoilComponentValueV2 } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValueV2';
 import { useIsFeatureEnabled } from '@/workspace/hooks/useIsFeatureEnabled';
@@ -70,7 +69,6 @@ export const CommandMenuContainer = ({
     refs: [commandMenuRef],
     callback: closeCommandMenu,
     listenerId: 'COMMAND_MENU_LISTENER_ID',
-    hotkeyScope: AppHotkeyScope.CommandMenuOpen,
     excludeClassNames: ['page-header-command-menu-button'],
   });
 

--- a/packages/twenty-front/src/modules/ui/utilities/pointer-event/hooks/useListenClickOutside.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/pointer-event/hooks/useListenClickOutside.ts
@@ -1,7 +1,6 @@
 import React, { useEffect } from 'react';
 import { useRecoilCallback } from 'recoil';
 
-import { internalHotkeysEnabledScopesState } from '@/ui/utilities/hotkey/states/internal/internalHotkeysEnabledScopesState';
 import { useClickOustideListenerStates } from '@/ui/utilities/pointer-event/hooks/useClickOustideListenerStates';
 
 const CLICK_OUTSIDE_DEBUG_MODE = false;
@@ -17,7 +16,6 @@ export type ClickOutsideListenerProps<T extends Element> = {
   callback: (event: MouseEvent | TouchEvent) => void;
   mode?: ClickOutsideMode;
   listenerId: string;
-  hotkeyScope?: string;
   enabled?: boolean;
 };
 
@@ -27,7 +25,6 @@ export const useListenClickOutside = <T extends Element>({
   callback,
   mode = ClickOutsideMode.compareHTMLRef,
   listenerId,
-  hotkeyScope,
   enabled = true,
 }: ClickOutsideListenerProps<T>) => {
   const {
@@ -45,18 +42,7 @@ export const useListenClickOutside = <T extends Element>({
 
         set(getClickOutsideListenerMouseDownHappenedState, true);
 
-        const currentHotkeyScopes = snapshot
-          .getLoadable(internalHotkeysEnabledScopesState)
-          .getValue();
-
-        const isListeningBasedOnHotkeyScope = hotkeyScope
-          ? currentHotkeyScopes.includes(hotkeyScope)
-          : true;
-
-        const isListening =
-          clickOutsideListenerIsActivated &&
-          enabled &&
-          isListeningBasedOnHotkeyScope;
+        const isListening = clickOutsideListenerIsActivated && enabled;
 
         if (!isListening) {
           return;
@@ -121,7 +107,6 @@ export const useListenClickOutside = <T extends Element>({
     [
       getClickOutsideListenerIsActivatedState,
       getClickOutsideListenerMouseDownHappenedState,
-      hotkeyScope,
       enabled,
       mode,
       refs,
@@ -136,18 +121,7 @@ export const useListenClickOutside = <T extends Element>({
           .getLoadable(getClickOutsideListenerIsActivatedState)
           .getValue();
 
-        const currentHotkeyScopes = snapshot
-          .getLoadable(internalHotkeysEnabledScopesState)
-          .getValue();
-
-        const isListeningBasedOnHotkeyScope = hotkeyScope
-          ? currentHotkeyScopes.includes(hotkeyScope)
-          : true;
-
-        const isListening =
-          clickOutsideListenerIsActivated &&
-          enabled &&
-          isListeningBasedOnHotkeyScope;
+        const isListening = clickOutsideListenerIsActivated && enabled;
 
         const isMouseDownInside = snapshot
           .getLoadable(getClickOutsideListenerIsMouseDownInsideState)
@@ -241,7 +215,6 @@ export const useListenClickOutside = <T extends Element>({
               isListening,
               hasMouseDownHappened,
               isClickedOnExcluded,
-              hotkeyScope,
               enabled,
               event,
             });
@@ -254,7 +227,6 @@ export const useListenClickOutside = <T extends Element>({
       },
     [
       getClickOutsideListenerIsActivatedState,
-      hotkeyScope,
       enabled,
       getClickOutsideListenerIsMouseDownInsideState,
       getClickOutsideListenerMouseDownHappenedState,


### PR DESCRIPTION
The old `useListenClickOutside` API allowed us to pass a hotkeyScope as a parameter, the click outside was triggered only if the current hotkey scope matched the parameter. We don't want this anymore. This fixes a few bugs related to hotkey scopes inside the side panel.