### PR TITLE
fix: update allowed protocols for URL validation in environment variables

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/environment/environment-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/environment/environment-variables.ts
@@ -695,7 +695,7 @@ export class EnvironmentVariables {
   })
   @IsDefined()
   @IsUrl({
-    protocols: ['postgres'],
+    protocols: ['postgres', 'postgresql'],
     require_tld: false,
     allow_underscores: true,
     require_host: false,


### PR DESCRIPTION
When using postgres cloud databse connection string with protocol 'postgresql', it throws error "ERROR PG_DATABASE_URL must be a URL address".

![Screenshot 2025-03-22 at 12 24 25 AM](https://github.com/user-attachments/assets/a5fdcb4e-686c-481a-9f4d-48a65aa44a30)
