### PR TITLE
[FEAT] Generate barrel export named modules and types

### DIFF
--- a/packages/twenty-shared/scripts/generateBarrels.ts
+++ b/packages/twenty-shared/scripts/generateBarrels.ts
@@ -272,7 +272,9 @@ function getTypeScriptFiles(
   );
 }
 
-const getKind = (node: ts.VariableStatement): Extract<ExportKind, 'const' | 'let' | 'var'>=> {
+const getKind = (
+  node: ts.VariableStatement,
+): Extract<ExportKind, 'const' | 'let' | 'var'> => {
   const isConst = (node.declarationList.flags & ts.NodeFlags.Const) !== 0;
   if (isConst) {
     return 'const';
@@ -410,7 +412,7 @@ const retrieveExportsByBarrel = (barrelDirectories: string[]) => {
     const moduleName = moduleDirectory.split('/').pop();
     if (!moduleName) {
       throw new Error(
-        `Should never occurs moduleName not found ${moduleDirectory}`,
+        `Should never occur moduleName not found ${moduleDirectory}`,
       );
     }
 

--- a/packages/twenty-shared/scripts/generateBarrels.ts
+++ b/packages/twenty-shared/scripts/generateBarrels.ts
@@ -272,7 +272,7 @@ function getTypeScriptFiles(
   );
 }
 
-const getKind = (node: ts.VariableStatement) => {
+const getKind = (node: ts.VariableStatement): Extract<ExportKind, 'const' | 'let' | 'var'>=> {
   const isConst = (node.declarationList.flags & ts.NodeFlags.Const) !== 0;
   if (isConst) {
     return 'const';
@@ -286,7 +286,7 @@ const getKind = (node: ts.VariableStatement) => {
   return 'var';
 };
 
-function extractExports(sourceFile: ts.SourceFile) {
+function extractExportsFromSourceFile(sourceFile: ts.SourceFile) {
   const exports: DeclarationOccurence[] = [];
 
   function visit(node: ts.Node) {
@@ -367,13 +367,13 @@ type ExportKind =
   | 'var'
   | 'class';
 type DeclarationOccurence = { kind: ExportKind; name: string };
-type ExtractedExports = Array<{
+type FileExports = Array<{
   file: string;
   exports: DeclarationOccurence[];
 }>;
 
-function findAllExports(directoryPath: string): ExtractedExports {
-  const results: ExtractedExports = [];
+function findAllExports(directoryPath: string): FileExports {
+  const results: FileExports = [];
 
   const files = getTypeScriptFiles(directoryPath);
 
@@ -385,7 +385,7 @@ function findAllExports(directoryPath: string): ExtractedExports {
       true,
     );
 
-    const exports = extractExports(sourceFile);
+    const exports = extractExportsFromSourceFile(sourceFile);
     if (exports.length > 0) {
       results.push({
         file,
@@ -402,7 +402,7 @@ type ExportByBarrel = {
     moduleName: string;
     moduleDirectory: string;
   };
-  allFileExports: ExtractedExports;
+  allFileExports: FileExports;
 };
 const retrieveExportsByBarrel = (barrelDirectories: string[]) => {
   return barrelDirectories.map<ExportByBarrel>((moduleDirectory) => {

--- a/packages/twenty-shared/src/constants/index.ts
+++ b/packages/twenty-shared/src/constants/index.ts
@@ -7,8 +7,8 @@
  *                              |___/
  */
 
-export * from './FieldForTotalCountAggregateOperation';
-export * from './PermissionsOnAllObjectRecords';
-export * from './StandardObjectRecordsUnderObjectRecordsPermissions';
-export * from './TwentyCompaniesBaseUrl';
-export * from './TwentyIconsBaseUrl';
+export { FIELD_FOR_TOTAL_COUNT_AGGREGATE_OPERATION } from './FieldForTotalCountAggregateOperation';
+export { PermissionsOnAllObjectRecords } from './PermissionsOnAllObjectRecords';
+export { STANDARD_OBJECT_RECORDS_UNDER_OBJECT_RECORDS_PERMISSIONS } from './StandardObjectRecordsUnderObjectRecordsPermissions';
+export { TWENTY_COMPANIES_BASE_URL } from './TwentyCompaniesBaseUrl';
+export { TWENTY_ICONS_BASE_URL } from './TwentyIconsBaseUrl';

--- a/packages/twenty-shared/src/testing/index.ts
+++ b/packages/twenty-shared/src/testing/index.ts
@@ -7,4 +7,4 @@
  *                              |___/
  */
 
-export { EachTestingContext } from './types/EachTestingContext.type';
+export type { EachTestingContext } from './types/EachTestingContext.type';

--- a/packages/twenty-shared/src/testing/index.ts
+++ b/packages/twenty-shared/src/testing/index.ts
@@ -7,4 +7,4 @@
  *                              |___/
  */
 
-export * from './types/EachTestingContext.type';
+export { EachTestingContext } from './types/EachTestingContext.type';

--- a/packages/twenty-shared/src/translations/index.ts
+++ b/packages/twenty-shared/src/translations/index.ts
@@ -7,5 +7,5 @@
  *                              |___/
  */
 
-export * from './constants/AppLocales';
-export * from './constants/SourceLocale';
+export { APP_LOCALES } from './constants/AppLocales';
+export { SOURCE_LOCALE } from './constants/SourceLocale';

--- a/packages/twenty-shared/src/types/index.ts
+++ b/packages/twenty-shared/src/types/index.ts
@@ -9,4 +9,4 @@
 
 export { ConnectedAccountProvider } from './ConnectedAccountProvider';
 export { FieldMetadataType } from './FieldMetadataType';
-export { IsExactly } from './IsExactly';
+export type { IsExactly } from './IsExactly';

--- a/packages/twenty-shared/src/types/index.ts
+++ b/packages/twenty-shared/src/types/index.ts
@@ -7,6 +7,6 @@
  *                              |___/
  */
 
-export * from './ConnectedAccountProvider';
-export * from './FieldMetadataType';
-export * from './IsExactly';
+export { ConnectedAccountProvider } from './ConnectedAccountProvider';
+export { FieldMetadataType } from './FieldMetadataType';
+export { IsExactly } from './IsExactly';

--- a/packages/twenty-shared/src/utils/index.ts
+++ b/packages/twenty-shared/src/utils/index.ts
@@ -7,16 +7,19 @@
  *                              |___/
  */
 
-export * from './assertUnreachable';
-export * from './fieldMetadata/isFieldMetadataDateKind';
-export * from './image/getImageAbsoluteURI';
-export * from './image/getLogoUrlFromDomainName';
-export * from './strings/capitalize';
-export * from './url/absoluteUrlSchema';
-export * from './url/getAbsoluteUrlOrThrow';
-export * from './url/getUrlHostnameOrThrow';
-export * from './url/isValidHostname';
-export * from './url/isValidUrl';
-export * from './validation/isDefined';
-export * from './validation/isValidLocale';
-export * from './validation/isValidUuid';
+export { assertUnreachable } from './assertUnreachable';
+export { isFieldMetadataDateKind } from './fieldMetadata/isFieldMetadataDateKind';
+export { getImageAbsoluteURI } from './image/getImageAbsoluteURI';
+export {
+  sanitizeURL,
+  getLogoUrlFromDomainName,
+} from './image/getLogoUrlFromDomainName';
+export { capitalize } from './strings/capitalize';
+export { absoluteUrlSchema } from './url/absoluteUrlSchema';
+export { getAbsoluteUrlOrThrow } from './url/getAbsoluteUrlOrThrow';
+export { getUrlHostnameOrThrow } from './url/getUrlHostnameOrThrow';
+export { isValidHostname } from './url/isValidHostname';
+export { isValidUrl } from './url/isValidUrl';
+export { isDefined } from './validation/isDefined';
+export { isValidLocale } from './validation/isValidLocale';
+export { isValidUuid } from './validation/isValidUuid';

--- a/packages/twenty-shared/src/workspace/index.ts
+++ b/packages/twenty-shared/src/workspace/index.ts
@@ -7,5 +7,5 @@
  *                              |___/
  */
 
-export * from './types/WorkspaceActivationStatus';
-export * from './utils/isWorkspaceActiveOrSuspended';
+export { WorkspaceActivationStatus } from './types/WorkspaceActivationStatus';
+export { isWorkspaceActiveOrSuspended } from './utils/isWorkspaceActiveOrSuspended';


### PR DESCRIPTION
# Introduction
In this PR using the Ts AST dynamically compute what to export, gathering non-runtime types and interface in an `export type`

[Export type TypeScript documentation](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html)

From
```ts
// index.ts
export * from "submodule"
```
To
```ts
export type { SomeType } from "submodule";
export { SomeFunction, SomeConst } from "submodule";
```


close https://github.com/twentyhq/core-team-issues/issues/644

## Motivations
- Most explicit and maintainable
- Best for tree-shaking
- Clear dependency tracking
- Prevents name collisions

## Important note
Please keep in mind that I will create, very soon, a dedicated `generate-barrel` package in our yarn workspaces in order to:
- Make it reusable for twenty-ui
- Split in several files
- Setup lint + tsconfig
- Add tests

## Conclusion
As usual any suggestions are more than welcomed !