### PR TITLE
fix(auth): prevent workspace creation on signup with password with no authorized user + fix 10982

### DIFF
--- a/packages/twenty-front/src/modules/settings/components/SettingsListCard.tsx
+++ b/packages/twenty-front/src/modules/settings/components/SettingsListCard.tsx
@@ -85,7 +85,7 @@ export const SettingsListCard = <
           description={getItemDescription?.(item)}
           rightComponent={<RowRightComponent item={item} />}
           divider={index < items.length - 1}
-          onClick={() => onRowClick?.(item)}
+          onClick={onRowClick ? () => onRowClick?.(item) : undefined}
           to={to?.(item)}
         />
       ))}

--- a/packages/twenty-server/src/engine/core-modules/auth/services/auth.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/auth.service.spec.ts
@@ -423,7 +423,7 @@ describe('AuthService', () => {
       });
 
       expect(result).toBeUndefined();
-      expect(spyWorkspaceRepository).toHaveBeenCalledTimes(0);
+      expect(spyWorkspaceRepository).toHaveBeenCalledTimes(1);
       expect(spyAuthSsoService).toHaveBeenCalledTimes(0);
     });
     it('findWorkspaceForSignInUp - signup password auth with workspaceInviteHash', async () => {

--- a/packages/twenty-server/src/engine/core-modules/auth/services/auth.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/auth.service.ts
@@ -562,7 +562,12 @@ export class AuthService {
       );
     }
 
-    return undefined;
+    return await this.workspaceRepository.findOne({
+      where: {
+        id: params.workspaceId,
+      },
+      relations: ['approvedAccessDomains'],
+    });
   }
 
   formatUserDataPayload(


### PR DESCRIPTION
Updated the method to properly fetch and return workspace data with related approved access domains. This ensures the correct handling of workspace lookup and fixes potential issues with undefined returns.

Fix #10982 