### PR TITLE
fix(auth): handle missing workspaceId in auth service

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/auth/services/auth.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/auth.service.ts
@@ -562,12 +562,14 @@ export class AuthService {
       );
     }
 
-    return await this.workspaceRepository.findOne({
-      where: {
-        id: params.workspaceId,
-      },
-      relations: ['approvedAccessDomains'],
-    });
+    return params.workspaceId
+      ? await this.workspaceRepository.findOne({
+          where: {
+            id: params.workspaceId,
+          },
+          relations: ['approvedAccessDomains'],
+        })
+      : undefined;
   }
 
   formatUserDataPayload(


### PR DESCRIPTION
Add a check to return undefined if workspaceId is not provided. Prevents unnecessary execution and potential errors during workspace lookup.