### PR TITLE
Do not suspend onboarding workspaces after stripe hook and add cron to delete them after 7 days

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/billing/webhooks/services/billing-webhook-subscription.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/webhooks/services/billing-webhook-subscription.service.ts
@@ -4,8 +4,8 @@ import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import Stripe from 'stripe';
-import { Repository } from 'typeorm';
 import { WorkspaceActivationStatus } from 'twenty-shared/workspace';
+import { Repository } from 'typeorm';
 
 import { BillingCustomer } from 'src/engine/core-modules/billing/entities/billing-customer.entity';
 import { BillingSubscriptionItem } from 'src/engine/core-modules/billing/entities/billing-subscription-item.entity';
@@ -121,6 +121,7 @@ export class BillingWebhookSubscriptionService {
       BILLING_SUBSCRIPTION_STATUS_BY_WORKSPACE_ACTIVATION_STATUS[
         WorkspaceActivationStatus.SUSPENDED
       ].includes(data.object.status as SubscriptionStatus) &&
+      workspace.activationStatus == WorkspaceActivationStatus.ACTIVE &&
       !hasActiveWorkspaceCompatibleSubscription
     ) {
       await this.workspaceRepository.update(workspaceId, {

--- a/packages/twenty-server/src/engine/core-modules/message-queue/jobs.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/message-queue/jobs.module.ts
@@ -19,6 +19,7 @@ import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { WorkspaceModule } from 'src/engine/core-modules/workspace/workspace.module';
 import { DataSourceModule } from 'src/engine/metadata-modules/data-source/data-source.module';
 import { ObjectMetadataModule } from 'src/engine/metadata-modules/object-metadata/object-metadata.module';
+import { CleanOnboardingWorkspacesJob } from 'src/engine/workspace-manager/workspace-cleaner/crons/clean-onboarding-workspaces.job';
 import { CleanSuspendedWorkspacesJob } from 'src/engine/workspace-manager/workspace-cleaner/crons/clean-suspended-workspaces.job';
 import { CleanWorkspaceDeletionWarningUserVarsJob } from 'src/engine/workspace-manager/workspace-cleaner/jobs/clean-workspace-deletion-warning-user-vars.job';
 import { WorkspaceCleanerModule } from 'src/engine/workspace-manager/workspace-cleaner/workspace-cleaner.module';
@@ -60,6 +61,7 @@ import { WorkflowModule } from 'src/modules/workflow/workflow.module';
   ],
   providers: [
     CleanSuspendedWorkspacesJob,
+    CleanOnboardingWorkspacesJob,
     EmailSenderJob,
     UpdateSubscriptionQuantityJob,
     HandleWorkspaceMemberDeletedJob,

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/commands/clean-onboarding-workspaces.command.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/commands/clean-onboarding-workspaces.command.ts
@@ -29,7 +29,7 @@ export class CleanOnboardingWorkspacesCommand extends MigrationCommandRunner {
   @Option({
     flags: '-w, --workspace-id [workspace_id]',
     description:
-      'workspace id. Command runs on all suspended workspaces if not provided',
+      'workspace id. Command runs on all onboarding workspaces if not provided',
     required: false,
   })
   parseWorkspaceId(val: string): string[] {

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/commands/clean-onboarding-workspaces.command.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/commands/clean-onboarding-workspaces.command.ts
@@ -2,7 +2,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 
 import { Command, Option } from 'nest-commander';
 import { WorkspaceActivationStatus } from 'twenty-shared/workspace';
-import { In, Repository } from 'typeorm';
+import { In, LessThan, Repository } from 'typeorm';
 
 import {
   MigrationCommandOptions,
@@ -12,16 +12,16 @@ import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { CleanerWorkspaceService } from 'src/engine/workspace-manager/workspace-cleaner/services/cleaner.workspace-service';
 
 @Command({
-  name: 'workspace:clean',
-  description: 'Clean suspended workspace',
+  name: 'workspace:clean:onboarding',
+  description: 'Clean onboarding workspaces',
 })
-export class CleanSuspendedWorkspacesCommand extends MigrationCommandRunner {
+export class CleanOnboardingWorkspacesCommand extends MigrationCommandRunner {
   private workspaceIds: string[] = [];
 
   constructor(
     private readonly cleanerWorkspaceService: CleanerWorkspaceService,
     @InjectRepository(Workspace, 'core')
-    protected readonly workspaceRepository: Repository<Workspace>,
+    private readonly workspaceRepository: Repository<Workspace>,
   ) {
     super();
   }
@@ -38,16 +38,24 @@ export class CleanSuspendedWorkspacesCommand extends MigrationCommandRunner {
     return this.workspaceIds;
   }
 
-  async fetchSuspendedWorkspaceIds(): Promise<string[]> {
-    const suspendedWorkspaces = await this.workspaceRepository.find({
+  async fetchOnboardingWorkspaceIds(): Promise<string[]> {
+    const sevenDaysAgo = new Date();
+
+    sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+
+    const onboardingWorkspaces = await this.workspaceRepository.find({
       select: ['id'],
       where: {
-        activationStatus: In([WorkspaceActivationStatus.SUSPENDED]),
+        activationStatus: In([
+          WorkspaceActivationStatus.PENDING_CREATION,
+          WorkspaceActivationStatus.ONGOING_CREATION,
+        ]),
+        createdAt: LessThan(sevenDaysAgo),
       },
       withDeleted: true,
     });
 
-    return suspendedWorkspaces.map((workspace) => workspace.id);
+    return onboardingWorkspaces.map((workspace) => workspace.id);
   }
 
   override async runMigrationCommand(
@@ -56,17 +64,17 @@ export class CleanSuspendedWorkspacesCommand extends MigrationCommandRunner {
   ): Promise<void> {
     const { dryRun } = options;
 
-    const suspendedWorkspaceIds =
+    const onboardingWorkspaceIds =
       this.workspaceIds.length > 0
         ? this.workspaceIds
-        : await this.fetchSuspendedWorkspaceIds();
+        : await this.fetchOnboardingWorkspaceIds();
 
     this.logger.log(
-      `${dryRun ? 'DRY RUN - ' : ''}Cleaning ${suspendedWorkspaceIds.length} suspended workspaces`,
+      `${dryRun ? 'DRY RUN - ' : ''}Cleaning ${onboardingWorkspaceIds.length} onboarding workspaces`,
     );
 
-    await this.cleanerWorkspaceService.batchWarnOrCleanSuspendedWorkspaces(
-      suspendedWorkspaceIds,
+    await this.cleanerWorkspaceService.batchCleanOnboardingWorkspaces(
+      onboardingWorkspaceIds,
       dryRun,
     );
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/commands/clean-onboarding-workspaces.cron.command.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/commands/clean-onboarding-workspaces.cron.command.ts
@@ -1,0 +1,30 @@
+import { Command, CommandRunner } from 'nest-commander';
+
+import { InjectMessageQueue } from 'src/engine/core-modules/message-queue/decorators/message-queue.decorator';
+import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
+import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
+import { cleanOnboardingWorkspacesCronPattern } from 'src/engine/workspace-manager/workspace-cleaner/crons/clean-onboarding-workspaces.cron.pattern';
+import { CleanOnboardingWorkspacesJob } from 'src/engine/workspace-manager/workspace-cleaner/crons/clean-onboarding-workspaces.job';
+
+@Command({
+  name: 'cron:clean-onboarding-workspaces',
+  description: 'Starts a cron job to clean onboarding workspaces',
+})
+export class CleanOnboardingWorkspacesCronCommand extends CommandRunner {
+  constructor(
+    @InjectMessageQueue(MessageQueue.cronQueue)
+    private readonly messageQueueService: MessageQueueService,
+  ) {
+    super();
+  }
+
+  async run(): Promise<void> {
+    await this.messageQueueService.addCron<undefined>({
+      jobName: CleanOnboardingWorkspacesJob.name,
+      data: undefined,
+      options: {
+        repeat: { pattern: cleanOnboardingWorkspacesCronPattern },
+      },
+    });
+  }
+}

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/crons/clean-onboarding-workspaces.cron.pattern.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/crons/clean-onboarding-workspaces.cron.pattern.ts
@@ -1,0 +1,1 @@
+export const cleanOnboardingWorkspacesCronPattern = '0 * * * *'; // Every hour at minute 0

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/crons/clean-onboarding-workspaces.job.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/crons/clean-onboarding-workspaces.job.ts
@@ -29,7 +29,7 @@ export class CleanOnboardingWorkspacesJob {
 
     sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
 
-    const suspendedWorkspaceIds = await this.workspaceRepository.find({
+    const onboardingWorkspaces = await this.workspaceRepository.find({
       select: ['id'],
       where: {
         activationStatus: In([
@@ -42,7 +42,7 @@ export class CleanOnboardingWorkspacesJob {
     });
 
     await this.cleanerWorkspaceService.batchCleanOnboardingWorkspaces(
-      suspendedWorkspaceIds.map((workspace) => workspace.id),
+      onboardingWorkspaces.map((workspace) => workspace.id),
     );
   }
 }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/crons/clean-onboarding-workspaces.job.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/crons/clean-onboarding-workspaces.job.ts
@@ -1,0 +1,48 @@
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { WorkspaceActivationStatus } from 'twenty-shared/workspace';
+import { In, LessThan, Repository } from 'typeorm';
+
+import { SentryCronMonitor } from 'src/engine/core-modules/cron/sentry-cron-monitor.decorator';
+import { Process } from 'src/engine/core-modules/message-queue/decorators/process.decorator';
+import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
+import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
+import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
+import { cleanOnboardingWorkspacesCronPattern } from 'src/engine/workspace-manager/workspace-cleaner/crons/clean-onboarding-workspaces.cron.pattern';
+import { CleanerWorkspaceService } from 'src/engine/workspace-manager/workspace-cleaner/services/cleaner.workspace-service';
+
+@Processor(MessageQueue.cronQueue)
+export class CleanOnboardingWorkspacesJob {
+  constructor(
+    private readonly cleanerWorkspaceService: CleanerWorkspaceService,
+    @InjectRepository(Workspace, 'core')
+    private readonly workspaceRepository: Repository<Workspace>,
+  ) {}
+
+  @Process(CleanOnboardingWorkspacesJob.name)
+  @SentryCronMonitor(
+    CleanOnboardingWorkspacesJob.name,
+    cleanOnboardingWorkspacesCronPattern,
+  )
+  async handle(): Promise<void> {
+    const sevenDaysAgo = new Date();
+
+    sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+
+    const suspendedWorkspaceIds = await this.workspaceRepository.find({
+      select: ['id'],
+      where: {
+        activationStatus: In([
+          WorkspaceActivationStatus.PENDING_CREATION,
+          WorkspaceActivationStatus.ONGOING_CREATION,
+        ]),
+        createdAt: LessThan(sevenDaysAgo),
+      },
+      withDeleted: true,
+    });
+
+    await this.cleanerWorkspaceService.batchCleanOnboardingWorkspaces(
+      suspendedWorkspaceIds.map((workspace) => workspace.id),
+    );
+  }
+}

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/services/cleaner.workspace-service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/services/cleaner.workspace-service.ts
@@ -281,10 +281,6 @@ export class CleanerWorkspaceService {
     if (workspaces.length !== 0) {
       if (!dryRun) {
         for (const workspace of workspaces) {
-          await this.workspaceRepository.delete(
-            workspaces.map((workspace) => workspace.id),
-          );
-
           const userWorkspaces = await this.userWorkspaceRepository.find({
             where: {
               workspaceId: workspace.id,
@@ -299,6 +295,8 @@ export class CleanerWorkspaceService {
               false,
             );
           }
+
+          await this.workspaceRepository.delete(workspace.id);
         }
       }
 

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/workspace-cleaner.module.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/workspace-cleaner.module.ts
@@ -4,6 +4,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { BillingModule } from 'src/engine/core-modules/billing/billing.module';
 import { BillingSubscription } from 'src/engine/core-modules/billing/entities/billing-subscription.entity';
 import { EmailModule } from 'src/engine/core-modules/email/email.module';
+import { UserWorkspace } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
 import { UserVarsModule } from 'src/engine/core-modules/user/user-vars/user-vars.module';
 import { UserModule } from 'src/engine/core-modules/user/user.module';
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
@@ -18,7 +19,10 @@ import { CleanerWorkspaceService } from 'src/engine/workspace-manager/workspace-
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Workspace, BillingSubscription], 'core'),
+    TypeOrmModule.forFeature(
+      [Workspace, UserWorkspace, BillingSubscription],
+      'core',
+    ),
     WorkspaceModule,
     DataSourceModule,
     UserVarsModule,

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/workspace-cleaner.module.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/workspace-cleaner.module.ts
@@ -9,6 +9,8 @@ import { UserModule } from 'src/engine/core-modules/user/user.module';
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { WorkspaceModule } from 'src/engine/core-modules/workspace/workspace.module';
 import { DataSourceModule } from 'src/engine/metadata-modules/data-source/data-source.module';
+import { CleanOnboardingWorkspacesCommand } from 'src/engine/workspace-manager/workspace-cleaner/commands/clean-onboarding-workspaces.command';
+import { CleanOnboardingWorkspacesCronCommand } from 'src/engine/workspace-manager/workspace-cleaner/commands/clean-onboarding-workspaces.cron.command';
 import { CleanSuspendedWorkspacesCommand } from 'src/engine/workspace-manager/workspace-cleaner/commands/clean-suspended-workspaces.command';
 import { CleanSuspendedWorkspacesCronCommand } from 'src/engine/workspace-manager/workspace-cleaner/commands/clean-suspended-workspaces.cron.command';
 import { DeleteWorkspacesCommand } from 'src/engine/workspace-manager/workspace-cleaner/commands/delete-workspaces.command';
@@ -28,6 +30,8 @@ import { CleanerWorkspaceService } from 'src/engine/workspace-manager/workspace-
     DeleteWorkspacesCommand,
     CleanSuspendedWorkspacesCommand,
     CleanSuspendedWorkspacesCronCommand,
+    CleanOnboardingWorkspacesCommand,
+    CleanOnboardingWorkspacesCronCommand,
     CleanerWorkspaceService,
   ],
   exports: [CleanerWorkspaceService],


### PR DESCRIPTION
## Context
When a trial ends, we receive a webhook from stripe to switch a workspace from its previous status to SUSPENDED. 
We also have some workspaces in ONGOING_CREATION that started the flow, started the trial but did not finish completely the flow which means the workspace has no data/metadata/schema.
Because of this, we can have workspaces that switch from ONGOING_CREATION to SUSPENDED directly and ONGOING_CREATION workspaces that didn't start the trial can stay in this state forever since they are not cleaned up by the current cleaner.
To solve those 2 issues, I'm adding a new cron that will automatically clean ONGOING_CREATION workspaces that are older than 7 days and I'm updating the stripe webhook to only update the activationStatus to SUSPENDED if it's already ACTIVE (then it will be deleted by the other cron in the other case)