### PR TITLE
Add workspace constraint on defaultRoleId and activationStatus

### DIFF
--- a/packages/twenty-server/src/database/typeorm/core/migrations/common/1742998832316-addWorkspaceConstraint.ts
+++ b/packages/twenty-server/src/database/typeorm/core/migrations/common/1742998832316-addWorkspaceConstraint.ts
@@ -5,13 +5,13 @@ export class AddWorkspaceConstraint1742998832316 implements MigrationInterface {
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `ALTER TABLE "core"."workspace" ADD CONSTRAINT "workspace_active_requires_default_role" CHECK ("activationStatus" IN ('PENDING_CREATION', 'ONGOING_CREATION') OR "defaultRoleId" IS NOT NULL)`,
+      `ALTER TABLE "core"."workspace" ADD CONSTRAINT "onboarded_workspace_requires_default_role" CHECK ("activationStatus" IN ('PENDING_CREATION', 'ONGOING_CREATION') OR "defaultRoleId" IS NOT NULL)`,
     );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `ALTER TABLE "core"."workspace" DROP CONSTRAINT "workspace_active_requires_default_role"`,
+      `ALTER TABLE "core"."workspace" DROP CONSTRAINT "onboarded_workspace_requires_default_role"`,
     );
   }
 }

--- a/packages/twenty-server/src/database/typeorm/core/migrations/common/1742998832316-addWorkspaceConstraint.ts
+++ b/packages/twenty-server/src/database/typeorm/core/migrations/common/1742998832316-addWorkspaceConstraint.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddWorkspaceConstraint1742998832316 implements MigrationInterface {
+  name = 'AddWorkspaceConstraint1742998832316';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "core"."workspace" ADD CONSTRAINT "workspace_active_requires_default_role" CHECK ("activationStatus" IN ('PENDING_CREATION', 'ONGOING_CREATION') OR "defaultRoleId" IS NOT NULL)`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "core"."workspace" DROP CONSTRAINT "workspace_active_requires_default_role"`,
+    );
+  }
+}

--- a/packages/twenty-server/src/engine/core-modules/workspace/workspace.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/workspace.entity.ts
@@ -29,7 +29,7 @@ registerEnumType(WorkspaceActivationStatus, {
 });
 
 @Check(
-  'workspace_active_requires_default_role',
+  'onboarded_workspace_requires_default_role',
   `"activationStatus" IN ('PENDING_CREATION', 'ONGOING_CREATION') OR "defaultRoleId" IS NOT NULL`,
 )
 @Entity({ name: 'workspace', schema: 'core' })

--- a/packages/twenty-server/src/engine/core-modules/workspace/workspace.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/workspace.entity.ts
@@ -3,6 +3,7 @@ import { Field, ObjectType, registerEnumType } from '@nestjs/graphql';
 import { IDField } from '@ptc-org/nestjs-query-graphql';
 import { WorkspaceActivationStatus } from 'twenty-shared/workspace';
 import {
+  Check,
   Column,
   CreateDateColumn,
   DeleteDateColumn,
@@ -27,6 +28,10 @@ registerEnumType(WorkspaceActivationStatus, {
   name: 'WorkspaceActivationStatus',
 });
 
+@Check(
+  'workspace_active_requires_default_role',
+  `"activationStatus" IN ('PENDING_CREATION', 'ONGOING_CREATION') OR "defaultRoleId" IS NOT NULL`,
+)
 @Entity({ name: 'workspace', schema: 'core' })
 @ObjectType()
 export class Workspace {


### PR DESCRIPTION
Part of https://github.com/twentyhq/core-team-issues/issues/526

An active workspace's defaultRoleId should never be null.
We can't rely on a simple postgres NOT NULL constraint as defaultRoleId will always be initially null when the workspace is first created since the roles do not exist at that time.
Since a suspended workspace can be active again, we should maintain that rule during the workspace suspension. The only moment defaultRoleId can have a null value is during the onboarding. this pr enforces that 