### PR TITLE
Feature/add flexibility to docker image makefile

### DIFF
--- a/packages/twenty-docker/Makefile
+++ b/packages/twenty-docker/Makefile
@@ -1,14 +1,27 @@
+# Makefile for building Twenty CRM docker images.
+# Set the tag and/or target build platform using make command-line variables assignments.
+#
+# Optional make variables:
+# PLATFORM - defaults to 'linux/amd64'
+# TAG      - defaults to 'latest'
+#
+# Example: make
+# Example: make PLATFORM=linux/aarch64 TAG=my-tag
+
+PLATFORM ?= linux/amd64
+TAG ?= latest
+
 prod-build:
-	@cd ../.. && docker build -f ./packages/twenty-docker/twenty/Dockerfile --tag twenty . && cd -
+	@cd ../.. && docker build -f ./packages/twenty-docker/twenty/Dockerfile --platform $(PLATFORM) --tag twenty:$(TAG) . && cd -
 
 prod-run:
-	@docker run -d -p 3000:3000 --name twenty twenty
+	@docker run -d -p 3001:3000 --name twenty twenty:$(TAG)
 
 prod-postgres-run:
 	@docker run -d -p 5432:5432 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres --name twenty-postgres twenty-postgres
 
 prod-website-build:
-	@cd ../.. && docker build -f ./packages/twenty-docker/twenty-website/Dockerfile --tag twenty-website . && cd -
+	@cd ../.. && docker build -f ./packages/twenty-docker/twenty-website/Dockerfile --platform $(PLATFORM) --tag twenty-website:$(TAG) . && cd -
 
 prod-website-run:
-	@docker run -d -p 3000:3000 --name twenty-website twenty-website
+	@docker run -d -p 3001:3000 --name twenty-website twenty-website:$(TAG)

--- a/packages/twenty-docker/Makefile
+++ b/packages/twenty-docker/Makefile
@@ -15,7 +15,7 @@ prod-build:
 	@cd ../.. && docker build -f ./packages/twenty-docker/twenty/Dockerfile --platform $(PLATFORM) --tag twenty:$(TAG) . && cd -
 
 prod-run:
-	@docker run -d -p 3001:3000 --name twenty twenty:$(TAG)
+	@docker run -d -p 3000:3000 --name twenty twenty:$(TAG)
 
 prod-postgres-run:
 	@docker run -d -p 5432:5432 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres --name twenty-postgres twenty-postgres:$(TAG)
@@ -24,4 +24,4 @@ prod-website-build:
 	@cd ../.. && docker build -f ./packages/twenty-docker/twenty-website/Dockerfile --platform $(PLATFORM) --tag twenty-website:$(TAG) . && cd -
 
 prod-website-run:
-	@docker run -d -p 3001:3000 --name twenty-website twenty-website:$(TAG)
+	@docker run -d -p 3000:3000 --name twenty-website twenty-website:$(TAG)

--- a/packages/twenty-docker/Makefile
+++ b/packages/twenty-docker/Makefile
@@ -18,7 +18,7 @@ prod-run:
 	@docker run -d -p 3001:3000 --name twenty twenty:$(TAG)
 
 prod-postgres-run:
-	@docker run -d -p 5432:5432 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres --name twenty-postgres twenty-postgres
+	@docker run -d -p 5432:5432 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres --name twenty-postgres twenty-postgres:$(TAG)
 
 prod-website-build:
 	@cd ../.. && docker build -f ./packages/twenty-docker/twenty-website/Dockerfile --platform $(PLATFORM) --tag twenty-website:$(TAG) . && cd -


### PR DESCRIPTION
Trying to build the images for different build platforms using the Makefile isn't possible without changing the code.

This change exposes the PLATFORM and TAG variables to enable the user to build and tag the images with greater flexibility.

The same TAG variable can be used on the prod-*-run targets too.

Postgres is not built in the same way but is run in the Makefile too, so the TAG variable applied here too, but not the platform.