### PR TITLE
[CHORE] Enable workspace version validation on upgrade for next release

### DIFF
--- a/packages/twenty-server/src/database/commands/command-runners/__tests__/upgrade.command-runner.spec.ts
+++ b/packages/twenty-server/src/database/commands/command-runners/__tests__/upgrade.command-runner.spec.ts
@@ -2,8 +2,8 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 
 import { SemVer } from 'semver';
-import { Repository } from 'typeorm';
 import { EachTestingContext } from 'twenty-shared/testing';
+import { Repository } from 'typeorm';
 
 import { UpgradeCommandRunner } from 'src/database/commands/command-runners/upgrade.command-runner';
 import { EnvironmentVariables } from 'src/engine/core-modules/environment/environment-variables';
@@ -14,7 +14,6 @@ import { SyncWorkspaceMetadataCommand } from 'src/engine/workspace-manager/works
 
 class TestUpgradeCommandRunnerV1 extends UpgradeCommandRunner {
   fromWorkspaceVersion = new SemVer('1.0.0');
-  VALIDATE_WORKSPACE_VERSION_FEATURE_FLAG = true as const;
 
   public override async runBeforeSyncMetadata(): Promise<void> {
     return;
@@ -27,7 +26,6 @@ class TestUpgradeCommandRunnerV1 extends UpgradeCommandRunner {
 
 class InvalidVersionUpgradeCommandRunner extends UpgradeCommandRunner {
   fromWorkspaceVersion = new SemVer('invalid');
-  VALIDATE_WORKSPACE_VERSION_FEATURE_FLAG = true as const;
 
   protected async runBeforeSyncMetadata(): Promise<void> {
     return;
@@ -40,7 +38,6 @@ class InvalidVersionUpgradeCommandRunner extends UpgradeCommandRunner {
 
 class TestUpgradeCommandRunnerV2 extends UpgradeCommandRunner {
   fromWorkspaceVersion = new SemVer('2.0.0');
-  VALIDATE_WORKSPACE_VERSION_FEATURE_FLAG = true as const;
 
   protected async runBeforeSyncMetadata(): Promise<void> {
     return;

--- a/packages/twenty-server/src/database/commands/command-runners/upgrade.command-runner.ts
+++ b/packages/twenty-server/src/database/commands/command-runners/upgrade.command-runner.ts
@@ -2,8 +2,8 @@ import { InjectRepository } from '@nestjs/typeorm';
 
 import chalk from 'chalk';
 import { SemVer } from 'semver';
-import { Repository } from 'typeorm';
 import { isDefined } from 'twenty-shared/utils';
+import { Repository } from 'typeorm';
 
 import {
   ActiveOrSuspendedWorkspacesMigrationCommandRunner,
@@ -109,15 +109,6 @@ export abstract class UpgradeCommandRunner extends ActiveOrSuspendedWorkspacesMi
   private async retrieveWorkspaceVersionAndCompareToWorkspaceFromVersion(
     workspaceId: string,
   ): Promise<CompareVersionMajorAndMinorReturnType> {
-    // TODO remove after first release has been done using workspace_version
-    if (!isDefined(this.VALIDATE_WORKSPACE_VERSION_FEATURE_FLAG)) {
-      this.logger.warn(
-        'VALIDATE_WORKSPACE_VERSION_FEATURE_FLAG set to true ignoring workspace versions validation step',
-      );
-
-      return 'equal';
-    }
-
     const workspace = await this.workspaceRepository.findOneByOrFail({
       id: workspaceId,
     });

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
@@ -74,7 +74,7 @@ export class UpgradeCommand extends UpgradeCommandRunner {
         this.addTasksAssignedToMeViewCommand,
       ],
     };
-    const commands_044: VersionCommands = {
+    const _commands_044: VersionCommands = {
       beforeSyncMetadata: [
         this.initializePermissionsCommand,
         this.updateViewAggregateOperationsCommand,

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
@@ -31,7 +31,7 @@ type VersionCommands = {
   description: 'Upgrade workspaces to the latest version',
 })
 export class UpgradeCommand extends UpgradeCommandRunner {
-  fromWorkspaceVersion = new SemVer('0.43.0');
+  fromWorkspaceVersion = new SemVer('0.44.0');
   private commands: VersionCommands;
 
   constructor(
@@ -86,7 +86,7 @@ export class UpgradeCommand extends UpgradeCommandRunner {
       afterSyncMetadata: [],
     };
 
-    this.commands = commands_044;
+    this.commands = _commands_050;
   }
 
   override async runBeforeSyncMetadata(args: RunOnWorkspaceArgs) {

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
@@ -81,12 +81,12 @@ export class UpgradeCommand extends UpgradeCommandRunner {
       ],
       afterSyncMetadata: [],
     };
-    const _commands_050: VersionCommands = {
+    const commands_050: VersionCommands = {
       beforeSyncMetadata: [this.migrateRelationsToFieldMetadataCommand],
       afterSyncMetadata: [],
     };
 
-    this.commands = _commands_050;
+    this.commands = commands_050;
   }
 
   override async runBeforeSyncMetadata(args: RunOnWorkspaceArgs) {


### PR DESCRIPTION
# Introduction
- Activate workspace version validation on upgrade command
- Update upgrade command to manager next release starting from `0.44.0`