### PR TITLE
Filter reset button height fix #11218

### DIFF
--- a/packages/twenty-front/src/modules/views/components/ViewBarDetails.tsx
+++ b/packages/twenty-front/src/modules/views/components/ViewBarDetails.tsx
@@ -71,6 +71,7 @@ const StyledCancelButton = styled.button`
   font-weight: ${({ theme }) => theme.font.weight.medium};
   user-select: none;
   margin-right: ${({ theme }) => theme.spacing(2)};
+  height: 24px;
   &:hover {
     background-color: ${({ theme }) => theme.background.tertiary};
     border-radius: ${({ theme }) => theme.spacing(1)};


### PR DESCRIPTION
[#11218](https://github.com/twentyhq/twenty/issues/11218) Fixed reset filter button height again to 24px  