### PR TITLE
Fix inline cell height issue and allow field settings update

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellContainer.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellContainer.tsx
@@ -70,14 +70,8 @@ export const StyledSkeletonDiv = styled.div`
 `;
 
 export const RecordInlineCellContainer = () => {
-  const {
-    readonly,
-    IconLabel,
-    label,
-    labelWidth,
-    showLabel,
-    isDisplayModeFixHeight,
-  } = useRecordInlineCellContext();
+  const { readonly, IconLabel, label, labelWidth, showLabel } =
+    useRecordInlineCellContext();
 
   const { recordId, fieldDefinition } = useContext(FieldContext);
 

--- a/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellContainer.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellContainer.tsx
@@ -38,6 +38,7 @@ const StyledLabelAndIconContainer = styled.div`
   display: flex;
   gap: ${({ theme }) => theme.spacing(1)};
   height: 18px;
+  padding-top: 3px;
 `;
 
 const StyledValueContainer = styled.div`
@@ -53,16 +54,11 @@ const StyledLabelContainer = styled.div<{ width?: number }>`
   width: ${({ width }) => width}px;
 `;
 
-const StyledInlineCellBaseContainer = styled.div<{
-  isDisplayModeFixHeight?: boolean;
-}>`
+const StyledInlineCellBaseContainer = styled.div`
   box-sizing: border-box;
   width: 100%;
   display: flex;
-  line-height: ${({ isDisplayModeFixHeight }) =>
-    isDisplayModeFixHeight ? `24px` : `18px`};
-  height: ${({ isDisplayModeFixHeight }) =>
-    isDisplayModeFixHeight ? `24px` : `18px`};
+  height: fit-content;
   gap: ${({ theme }) => theme.spacing(1)};
   user-select: none;
   align-items: center;
@@ -111,7 +107,6 @@ export const RecordInlineCellContainer = () => {
 
   return (
     <StyledInlineCellBaseContainer
-      isDisplayModeFixHeight={isDisplayModeFixHeight}
       onMouseEnter={handleContainerMouseEnter}
       onMouseLeave={handleContainerMouseLeave}
     >

--- a/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellDisplayMode.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellDisplayMode.tsx
@@ -44,6 +44,8 @@ const StyledRecordInlineCellNormalModeInnerContainer = styled.div`
   align-items: center;
   color: ${({ theme }) => theme.font.color.primary};
   height: fit-content;
+  padding-top: 3px;
+  padding-bottom: 3px;
 
   overflow: hidden;
   text-overflow: ellipsis;

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/hooks/before-update-one-field.hook.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/hooks/before-update-one-field.hook.ts
@@ -75,7 +75,12 @@ export class BeforeUpdateOneField<T extends UpdateFieldInput>
     locale?: keyof typeof APP_LOCALES,
   ): UpdateOneInputType<T> {
     const update: StandardFieldUpdate = {};
-    const updatableFields = ['isActive', 'isLabelSyncedWithName', 'options'];
+    const updatableFields = [
+      'isActive',
+      'isLabelSyncedWithName',
+      'options',
+      'settings',
+    ];
     const overridableFields = ['label', 'icon', 'description'];
 
     const nonUpdatableFields = Object.keys(instance.update).filter(
@@ -110,6 +115,7 @@ export class BeforeUpdateOneField<T extends UpdateFieldInput>
     this.handleLabelSyncedWithNameField(instance, update);
     this.handleStandardOverrides(instance, fieldMetadata, update, locale);
     this.handleOptionsField(instance, update);
+    this.handleSettingsField(instance, update);
 
     return {
       id: instance.id,
@@ -126,6 +132,17 @@ export class BeforeUpdateOneField<T extends UpdateFieldInput>
     }
 
     update.options = instance.update.options;
+  }
+
+  private handleSettingsField(
+    instance: UpdateOneInputType<T>,
+    update: StandardFieldUpdate,
+  ): void {
+    if (!isDefined(instance.update.settings)) {
+      return;
+    }
+
+    update.settings = instance.update.settings;
   }
 
   private handleActiveField(


### PR DESCRIPTION
In this PR:
- allow to update settings on fields metadata (regression introduced by a recent refactoring of fields-metadata update)
- revert changes introduced by https://github.com/twentyhq/twenty/pull/11221