### PR TITLE
Improve upsert for spreadsheet import

### DIFF
--- a/packages/twenty-front/src/modules/spreadsheet-import/components/MatchColumnSelect.tsx
+++ b/packages/twenty-front/src/modules/spreadsheet-import/components/MatchColumnSelect.tsx
@@ -7,7 +7,7 @@ import {
   size,
   useFloating,
 } from '@floating-ui/react';
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useId, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { AppTooltip, MenuItem, MenuItemSelect, SelectOption } from 'twenty-ui';
 import { ReadonlyDeep } from 'type-fest';
@@ -20,7 +20,6 @@ import { DropdownMenuSeparator } from '@/ui/layout/dropdown/components/DropdownM
 import { OverlayContainer } from '@/ui/layout/overlay/components/OverlayContainer';
 import { useListenClickOutside } from '@/ui/utilities/pointer-event/hooks/useListenClickOutside';
 import { useLingui } from '@lingui/react/macro';
-import { v4 as uuidV4 } from 'uuid';
 import { useUpdateEffect } from '~/hooks/useUpdateEffect';
 
 const StyledFloatingDropdown = styled.div`
@@ -42,6 +41,7 @@ export const MatchColumnSelect = ({
   placeholder,
 }: MatchColumnSelectProps) => {
   const theme = useTheme();
+  const idPrefix = useId();
 
   const dropdownContainerRef = useRef<HTMLDivElement>(null);
 
@@ -138,8 +138,8 @@ export const MatchColumnSelect = ({
                 />
                 <DropdownMenuSeparator />
                 <DropdownMenuItemsContainer hasMaxHeight>
-                  {options?.map((option) => {
-                    const id = `${uuidV4()}`;
+                  {options?.map((option, index) => {
+                    const id = `${idPrefix}-option-${index}`;
                     return (
                       <React.Fragment key={id}>
                         <div id={id}>

--- a/packages/twenty-front/src/modules/spreadsheet-import/components/MatchColumnSelect.tsx
+++ b/packages/twenty-front/src/modules/spreadsheet-import/components/MatchColumnSelect.tsx
@@ -139,7 +139,7 @@ export const MatchColumnSelect = ({
                 <DropdownMenuSeparator />
                 <DropdownMenuItemsContainer hasMaxHeight>
                   {options?.map((option) => {
-                    const id = `${uuidV4()}-${option.value}`;
+                    const id = `${uuidV4()}`;
                     return (
                       <React.Fragment key={id}>
                         <div id={id}>

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-create-many-resolver.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-create-many-resolver.service.ts
@@ -227,33 +227,24 @@ export class GraphqlQueryCreateManyResolverService extends GraphqlQueryBaseResol
 
       for (const field of conflictingFields) {
         let requestFieldValue;
-
         const pathParts = field.fullPath.split('.');
 
         if (pathParts.length === 1) {
           requestFieldValue = record[field.fullPath];
-          const existingRec = existingRecords.find(
-            (existingRecord) =>
-              existingRecord[field.column] === requestFieldValue,
-          );
-
-          if (existingRec) {
-            existingRecord = { ...record, id: existingRec.id };
-            break;
-          }
         } else {
           const [parentField, childField] = pathParts;
 
           requestFieldValue = record[parentField]?.[childField];
-          const existingRec = existingRecords.find(
-            (existingRecord) =>
-              existingRecord[field.column] === requestFieldValue,
-          );
+        }
 
-          if (existingRec) {
-            existingRecord = { ...record, id: existingRec.id };
-            break;
-          }
+        const existingRec = existingRecords.find(
+          (existingRecord) =>
+            existingRecord[field.column] === requestFieldValue,
+        );
+
+        if (existingRec) {
+          existingRecord = { ...record, id: existingRec.id };
+          break;
         }
       }
 

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-create-many-resolver.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-create-many-resolver.service.ts
@@ -18,6 +18,7 @@ import { FeatureFlagKey } from 'src/engine/core-modules/feature-flag/enums/featu
 import { compositeTypeDefinitions } from 'src/engine/metadata-modules/field-metadata/composite-types';
 import { assertMutationNotOnRemoteObject } from 'src/engine/metadata-modules/object-metadata/utils/assert-mutation-not-on-remote-object.util';
 import { ObjectMetadataItemWithFieldMaps } from 'src/engine/metadata-modules/types/object-metadata-item-with-field-maps';
+import { ObjectMetadataMaps } from 'src/engine/metadata-modules/types/object-metadata-maps';
 import { WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace.repository';
 import { formatData } from 'src/engine/twenty-orm/utils/format-data.util';
 import { formatResult } from 'src/engine/twenty-orm/utils/format-result.util';
@@ -299,8 +300,8 @@ export class GraphqlQueryCreateManyResolverService extends GraphqlQueryBaseResol
   private async fetchUpsertedRecords(
     executionArgs: GraphqlQueryResolverExecutionArgs<CreateManyResolverArgs>,
     objectRecords: InsertResult,
-    objectMetadataItemWithFieldMaps: any,
-    objectMetadataMaps: any,
+    objectMetadataItemWithFieldMaps: ObjectMetadataItemWithFieldMaps,
+    objectMetadataMaps: ObjectMetadataMaps,
   ): Promise<ObjectRecord[]> {
     const queryBuilder = executionArgs.repository.createQueryBuilder(
       objectMetadataItemWithFieldMaps.nameSingular,
@@ -323,8 +324,8 @@ export class GraphqlQueryCreateManyResolverService extends GraphqlQueryBaseResol
   private async processNestedRelationsIfNeeded(
     executionArgs: GraphqlQueryResolverExecutionArgs<CreateManyResolverArgs>,
     upsertedRecords: ObjectRecord[],
-    objectMetadataItemWithFieldMaps: any,
-    objectMetadataMaps: any,
+    objectMetadataItemWithFieldMaps: ObjectMetadataItemWithFieldMaps,
+    objectMetadataMaps: ObjectMetadataMaps,
     featureFlagsMap: Record<FeatureFlagKey, boolean>,
   ): Promise<void> {
     if (!executionArgs.graphqlQuerySelectedFieldsResult.relations) {
@@ -346,8 +347,8 @@ export class GraphqlQueryCreateManyResolverService extends GraphqlQueryBaseResol
 
   private formatRecordsForResponse(
     upsertedRecords: ObjectRecord[],
-    objectMetadataItemWithFieldMaps: any,
-    objectMetadataMaps: any,
+    objectMetadataItemWithFieldMaps: ObjectMetadataItemWithFieldMaps,
+    objectMetadataMaps: ObjectMetadataMaps,
     featureFlagsMap: Record<FeatureFlagKey, boolean>,
   ): ObjectRecord[] {
     const typeORMObjectRecordsParser =

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-create-many-resolver.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-create-many-resolver.service.ts
@@ -171,7 +171,7 @@ export class GraphqlQueryCreateManyResolverService extends GraphqlQueryBaseResol
       conflictingFields,
     );
 
-    return queryBuilder.where(whereConditions).getMany();
+    return queryBuilder.orWhere(whereConditions).getMany();
   }
 
   private buildWhereConditions(


### PR DESCRIPTION
Refactor query runner to improve the import method for upserts, we now take into account any unique field and prevent any conflict upfront. Previously, we would only update if an `id` was passed.


https://github.com/user-attachments/assets/8087b864-ba42-4b6e-abf2-b9ea66e6c467


This is only a first step, there are other things to fix on the frontend for this to work.