### PR TITLE
Display system objects in Workflow triggers

### DIFF
--- a/packages/twenty-front/src/modules/workflow/workflow-trigger/components/WorkflowEditTriggerDatabaseEventForm.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-trigger/components/WorkflowEditTriggerDatabaseEventForm.tsx
@@ -46,10 +46,15 @@ const filterOptionsBySearch = <T extends { label: string }>(
 
 type WorkflowEditTriggerDatabaseEventFormProps = {
   trigger: WorkflowDatabaseEventTrigger;
-  triggerOptions: {
-    readonly?: boolean;
-    onTriggerUpdate: (trigger: WorkflowDatabaseEventTrigger) => void;
-  };
+  triggerOptions:
+    | {
+        readonly: true;
+        onTriggerUpdate?: undefined;
+      }
+    | {
+        readonly?: false;
+        onTriggerUpdate: (trigger: WorkflowDatabaseEventTrigger) => void;
+      };
 };
 
 export const WorkflowEditTriggerDatabaseEventForm = ({


### PR DESCRIPTION
Fixes #11310

Note:
- I changed "system to advanced" because I think we will link that to the Advanced Mode in the future
- Not sure when to use useCallback / useMemo, AI added some useCallbacks which I removed but I left some useMemo... Not sure what should be the rule
- It had to use MenuItem because this sub-menu behavior wasn't available in the Standard select component. We should probably rename the "MenuItem" elements to something more generic. I didn't do it in this PR because I'm not sure about the strategy and it would change a lot of files. 