### PR TITLE
Auto-run migration script on docker entrypoint

### DIFF
--- a/packages/twenty-docker/twenty/entrypoint.sh
+++ b/packages/twenty-docker/twenty/entrypoint.sh
@@ -17,6 +17,7 @@ if [ "${DISABLE_DB_MIGRATIONS}" != "true" ] && [ ! -f /app/docker-data/db_status
     # Run setup and migration scripts
     NODE_OPTIONS="--max-old-space-size=1500" tsx ./scripts/setup-db.ts
     yarn database:migrate:prod
+    yarn command:prod upgrade
 
     # Mark initialization as done
     echo "Successfuly migrated DB!"

--- a/packages/twenty-website/src/content/developers/self-hosting/upgrade-guide.mdx
+++ b/packages/twenty-website/src/content/developers/self-hosting/upgrade-guide.mdx
@@ -24,7 +24,16 @@ If you used Docker Compose, follow these steps:
 If you want to upgrade your instance by few versions, e.g. from 0.33.0 to 0.35.0, you have to upgrade your instance sequentially, in this example from 0.33.0 to 0.34.0, then from 0.34.0 to 0.35.0.
 
 
+
 ## Version-specific upgrade steps
+{/* 
+### v0.50.0 to v0.51.0
+
+We've now added  `yarn command:prod upgrade` to the entrypoint.sh[https://github.com/twentyhq/twenty/blob/main/packages/twenty-docker/twenty/entrypoint.sh#L19] file.
+This means from now on, you shouldn't have to run any command manually anymore.
+Just make sure to keep upgrading your instance sequentially, without skipping any major version (e.g. 0.43.3 to 0.44.0 is allowed, but 0.43.1 to 0.45.0 is not).
+You can view your instance version in the admin panel (at /settings/admin-panel, accessible if your user has canImpersonate property set to true in the database).
+*/}
 
 ### v0.44.0 to v0.50.0
 


### PR DESCRIPTION
A small PR but a big step towards making Twenty easier to self-host and upgrade!

Now changing the tag and pulling a new version should be the only step to upgrade as migrations script will be ran automatically upon starting the containers. It was already the case for typeorm migrations, but not for standard objects migration and data migration scripts. It is still possible to disable this behavior for the most complex deployments such as our own cloud.