### PR TITLE
11312 rest api cant filter enum type columns by null value

### DIFF
--- a/packages/twenty-server/@types/express.d.ts
+++ b/packages/twenty-server/@types/express.d.ts
@@ -7,7 +7,7 @@ declare module 'express-serve-static-core' {
     user?: User | null;
     apiKey?: ApiKeyWorkspaceEntity | null;
     workspace: Workspace;
-    workspaceId?: string;
+    workspaceId: string;
     workspaceMetadataVersion?: number;
     workspaceMemberId?: string;
     userWorkspaceId?: string;

--- a/packages/twenty-server/src/engine/api/rest/core/query-builder/utils/filter-utils/__tests__/check-filter-enum-values.spec.ts
+++ b/packages/twenty-server/src/engine/api/rest/core/query-builder/utils/filter-utils/__tests__/check-filter-enum-values.spec.ts
@@ -56,4 +56,24 @@ describe('checkFilterEnumValues', () => {
       `'filter' enum value 'MISSING_OPTION' not available in '${fieldSelectMock.name}' enum. Available enum values are ['OPTION_1', 'OPTION_2']`,
     );
   });
+
+  it('should allow filter by NULL or NOT_NULL values', () => {
+    expect(() =>
+      checkFilterEnumValues(
+        FieldMetadataType.SELECT,
+        fieldSelectMock.name,
+        'NULL',
+        mockObjectMetadataWithFieldMaps,
+      ),
+    ).not.toThrow();
+
+    expect(() =>
+      checkFilterEnumValues(
+        FieldMetadataType.SELECT,
+        fieldSelectMock.name,
+        'NOT_NULL',
+        mockObjectMetadataWithFieldMaps,
+      ),
+    ).not.toThrow();
+  });
 });

--- a/packages/twenty-server/src/engine/api/rest/core/query-builder/utils/filter-utils/check-filter-enum-values.ts
+++ b/packages/twenty-server/src/engine/api/rest/core/query-builder/utils/filter-utils/check-filter-enum-values.ts
@@ -28,8 +28,10 @@ export const checkFilterEnumValues = (
   if (!enumValues) {
     return;
   }
+  const allowedEnumValues = ['NULL', 'NOT_NULL', ...enumValues];
+
   values.forEach((val) => {
-    if (!enumValues.includes(val)) {
+    if (!allowedEnumValues.includes(val)) {
       throw new BadRequestException(
         `'filter' enum value '${val}' not available in '${fieldName}' enum. Available enum values are ['${enumValues.join(
           "', '",

--- a/packages/twenty-server/src/engine/api/rest/core/rest-api-core-v2.service.ts
+++ b/packages/twenty-server/src/engine/api/rest/core/rest-api-core-v2.service.ts
@@ -68,7 +68,7 @@ export class RestApiCoreServiceV2 {
 
     await repository.delete(recordId);
 
-    this.apiEventEmitterService.emitDeletedEvents(
+    this.apiEventEmitterService.emitDestroyEvents(
       [recordToDelete],
       this.getAuthContextFromRequest(request),
       objectMetadata.objectMetadataMapItem,

--- a/packages/twenty-server/src/modules/webhook/jobs/call-webhook-jobs.job.ts
+++ b/packages/twenty-server/src/modules/webhook/jobs/call-webhook-jobs.job.ts
@@ -1,6 +1,7 @@
 import { Logger } from '@nestjs/common';
 
 import { ArrayContains } from 'typeorm';
+import { isDefined } from 'twenty-shared/utils';
 
 import { ObjectRecordEvent } from 'src/engine/core-modules/event-emitter/types/object-record-event.event';
 import { InjectMessageQueue } from 'src/engine/core-modules/message-queue/decorators/message-queue.decorator';
@@ -61,9 +62,10 @@ export class CallWebhookJobsJob {
       };
       const workspaceId = workspaceEventBatch.workspaceId;
       const record =
-        'after' in eventData.properties
+        'after' in eventData.properties && isDefined(eventData.properties.after)
           ? eventData.properties.after
-          : 'before' in eventData.properties
+          : 'before' in eventData.properties &&
+              isDefined(eventData.properties.before)
             ? eventData.properties.before
             : {};
       const updatedFields =


### PR DESCRIPTION
- Fixes https://github.com/twentyhq/twenty/issues/11312
- Fixes record undefined on webhook deleted events
- Emit destroy event when deleting record via the rest api