### PR TITLE
fix stripe subscription deletion

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/billing/billing.controller.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/billing.controller.ts
@@ -114,7 +114,7 @@ export class BillingController {
 
         return await this.billingWebhookSubscriptionService.processStripeEvent(
           workspaceId,
-          event.data,
+          event,
         );
       }
       default:

--- a/packages/twenty-server/src/engine/core-modules/billing/webhooks/services/billing-webhook-subscription.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/webhooks/services/billing-webhook-subscription.service.ts
@@ -71,6 +71,7 @@ export class BillingWebhookSubscriptionService {
   ) {
     const workspace = await this.workspaceRepository.findOne({
       where: { id: workspaceId },
+      withDeleted: true,
     });
 
     if (!workspace) {

--- a/packages/twenty-server/src/engine/core-modules/billing/webhooks/services/billing-webhook-subscription.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/webhooks/services/billing-webhook-subscription.service.ts
@@ -4,6 +4,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import Stripe from 'stripe';
+import { isDefined } from 'twenty-shared/utils';
 import { WorkspaceActivationStatus } from 'twenty-shared/workspace';
 import { Repository } from 'typeorm';
 
@@ -11,6 +12,7 @@ import { BillingCustomer } from 'src/engine/core-modules/billing/entities/billin
 import { BillingSubscriptionItem } from 'src/engine/core-modules/billing/entities/billing-subscription-item.entity';
 import { BillingSubscription } from 'src/engine/core-modules/billing/entities/billing-subscription.entity';
 import { SubscriptionStatus } from 'src/engine/core-modules/billing/enums/billing-subscription-status.enum';
+import { BillingWebhookEvent } from 'src/engine/core-modules/billing/enums/billing-webhook-events.enum';
 import { BillingSubscriptionService } from 'src/engine/core-modules/billing/services/billing-subscription.service';
 import { StripeCustomerService } from 'src/engine/core-modules/billing/stripe/services/stripe-customer.service';
 import { transformStripeSubscriptionEventToDatabaseCustomer } from 'src/engine/core-modules/billing/webhooks/utils/transform-stripe-subscription-event-to-database-customer.util';
@@ -64,17 +66,23 @@ export class BillingWebhookSubscriptionService {
 
   async processStripeEvent(
     workspaceId: string,
-    data:
-      | Stripe.CustomerSubscriptionUpdatedEvent.Data
-      | Stripe.CustomerSubscriptionCreatedEvent.Data
-      | Stripe.CustomerSubscriptionDeletedEvent.Data,
+    event:
+      | Stripe.CustomerSubscriptionUpdatedEvent
+      | Stripe.CustomerSubscriptionCreatedEvent
+      | Stripe.CustomerSubscriptionDeletedEvent,
   ) {
+    const { data, type } = event;
+
     const workspace = await this.workspaceRepository.findOne({
       where: { id: workspaceId },
       withDeleted: true,
     });
 
-    if (!workspace) {
+    if (
+      !workspace ||
+      (isDefined(workspace?.deletedAt) &&
+        type !== BillingWebhookEvent.CUSTOMER_SUBSCRIPTION_DELETED)
+    ) {
       return { noWorkspace: true };
     }
 


### PR DESCRIPTION
when soft deleting workspace, stripe subscription is canceled then workspace is soft deleted before stripe async web hook event is received. This webhook event is needed to update billingSubscription status.