### PR TITLE
chore(ci): extend timeout for Danger JS job

### DIFF
--- a/.github/workflows/ci-utils.yaml
+++ b/.github/workflows/ci-utils.yaml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   danger-js:
-    timeout-minutes: 3
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     if: github.event.action != 'closed'
     steps:


### PR DESCRIPTION
Increased the timeout for the Danger JS job from 3 to 5 minutes to prevent premature failures on slower runs. This ensures more reliable execution of the workflow.

To unlock https://github.com/twentyhq/twenty/pull/11339