### PR TITLE
Fix: Allow creating record without requiring select value when grouped #11299

### DIFF
--- a/packages/twenty-docker/.env.example
+++ b/packages/twenty-docker/.env.example
@@ -1,10 +1,11 @@
 TAG=latest
 
-#PG_DATABASE_USER=postgres
-#PG_DATABASE_PASSWORD=replace_me_with_a_strong_password_without_special_characters
-#PG_DATABASE_HOST=db
-#PG_DATABASE_PORT=5432
-#REDIS_URL=redis://redis:6379
+PG_DATABASE_USER=parth_singh
+PG_DATABASE_PASSWORD=parth_singh
+PG_DATABASE_HOST=localhost
+PG_DATABASE_PORT=5432
+REDIS_URL=redis://redis:6379
+DATABASE_URL=postgresql://parth_singh:parth_singh@db:5432/twenty
 
 SERVER_URL=http://localhost:3000
 SIGN_IN_PREFILLED=false
@@ -13,6 +14,7 @@ SIGN_IN_PREFILLED=false
 # APP_SECRET=replace_me_with_a_random_string
 
 STORAGE_TYPE=local
+APP_SECRET=helloworld@xyz
 
 # STORAGE_S3_REGION=eu-west3
 # STORAGE_S3_NAME=my-bucket

--- a/packages/twenty-docker/.env.example
+++ b/packages/twenty-docker/.env.example
@@ -1,11 +1,10 @@
 TAG=latest
 
-PG_DATABASE_USER=parth_singh
-PG_DATABASE_PASSWORD=parth_singh
-PG_DATABASE_HOST=localhost
-PG_DATABASE_PORT=5432
-REDIS_URL=redis://redis:6379
-DATABASE_URL=postgresql://parth_singh:parth_singh@db:5432/twenty
+#PG_DATABASE_USER=postgres
+#PG_DATABASE_PASSWORD=replace_me_with_a_strong_password_without_special_characters
+#PG_DATABASE_HOST=db
+#PG_DATABASE_PORT=5432
+#REDIS_URL=redis://redis:6379
 
 SERVER_URL=http://localhost:3000
 SIGN_IN_PREFILLED=false
@@ -14,7 +13,6 @@ SIGN_IN_PREFILLED=false
 # APP_SECRET=replace_me_with_a_random_string
 
 STORAGE_TYPE=local
-APP_SECRET=helloworld@xyz
 
 # STORAGE_S3_REGION=eu-west3
 # STORAGE_S3_NAME=my-bucket

--- a/packages/twenty-front/src/modules/activities/hooks/useOpenCreateActivityDrawer.ts
+++ b/packages/twenty-front/src/modules/activities/hooks/useOpenCreateActivityDrawer.ts
@@ -62,12 +62,18 @@ export const useOpenCreateActivityDrawer = ({
     setViewableRecordId(null);
     setViewableRecordNameSingular(activityObjectNameSingular);
 
+    const groupByField =
+      targetableObjects.length > 0
+        ? `${targetableObjects[0].targetObjectNameSingular}Id`
+        : null;
+
     const activity = await createOneActivity({
       ...(activityObjectNameSingular === CoreObjectNameSingular.Task
         ? {
             assigneeId: customAssignee?.id,
           }
         : {}),
+      ...(groupByField ? { [groupByField]: targetableObjects[0].id } : {}),
       position: 'last',
     });
 


### PR DESCRIPTION
##  Fix: Allow Creating Record Without Requiring Select Value When Grouped  #11299

###  Issue #11299 

When a "Group By" filter is applied to the view, clicking the **"Create Record"** button prompts the user to select a value before creating a record. This disrupts the workflow, as the expected behavior is to create an empty record immediately in the side panel.  

### Fix  
- Updated the record creation logic to allow an empty record to be created in the side panel without requiring a select value first.  
- Ensured that grouping does not block record creation unnecessarily.  

### Expected Behavior  
- Users can click **"Create Record"** and immediately start editing the new record in the side panel, even when "Group By" is applied.  
- No pop-up requesting a select value before record creation.  

### Testing  
- Applied "Group By" to different views and verified that records can be created without extra steps.  
- Ensured that records are properly assigned to groups after creation.  

### Video 
https://github.com/user-attachments/assets/60c63023-7431-4055-9ee9-679e32badc7b

### Additional Notes  
- Although as far as i have understood this issue

When grouping is applied, the system expects every new record to belong to one of the grouped categories. The UI is prompting the user to choose a value because it does not know which group the new record should belong to.

If I misunderstood anything I will be happy to work on it again.