### PR TITLE
Hot fix for currentWorkspaceMember not found error on blocklist page

### DIFF
--- a/packages/twenty-front/src/modules/settings/accounts/components/SettingsAccountsBlocklistSection.tsx
+++ b/packages/twenty-front/src/modules/settings/accounts/components/SettingsAccountsBlocklistSection.tsx
@@ -10,23 +10,23 @@ import { useFindManyRecords } from '@/object-record/hooks/useFindManyRecords';
 import { SettingsAccountsBlocklistInput } from '@/settings/accounts/components/SettingsAccountsBlocklistInput';
 import { SettingsAccountsBlocklistTable } from '@/settings/accounts/components/SettingsAccountsBlocklistTable';
 import { useLingui } from '@lingui/react/macro';
+import { isDefined } from 'twenty-shared/utils';
 
 export const SettingsAccountsBlocklistSection = () => {
   const { t } = useLingui();
 
   const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
 
-  if (!currentWorkspaceMember) {
-    throw new Error('No workspace member found.');
-  }
+  const currentWorkspaceMemberId = currentWorkspaceMember?.id ?? '';
 
   const { records: blocklist } = useFindManyRecords<BlocklistItem>({
     objectNameSingular: CoreObjectNameSingular.Blocklist,
     filter: {
       workspaceMemberId: {
-        in: [currentWorkspaceMember.id],
+        in: [currentWorkspaceMemberId],
       },
     },
+    skip: !isDefined(currentWorkspaceMember),
   });
 
   const { createOneRecord: createBlocklistItem } =


### PR DESCRIPTION
Fixes https://twenty-v7.sentry.io/issues/6504066204/?project=4507072563183616
Introduced by https://github.com/twentyhq/twenty/pull/11325

Called it a hotfix as not sure if missing currentWorkspaceMember is an expected state - maybe it is expected to be temporarily missing ? 
