### PR TITLE
Fix error when workflows aren't enabled

### DIFF
--- a/packages/twenty-front/src/modules/action-menu/actions/record-actions/components/RecordActionMenuEntriesSetter.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-actions/components/RecordActionMenuEntriesSetter.tsx
@@ -1,9 +1,11 @@
 import { RegisterRecordActionEffects } from '@/action-menu/actions/record-actions/components/RegisterRecordActionEffects';
+import { RegisterWorkflowRecordActionEffects } from '@/action-menu/actions/record-actions/components/RegisterWorkflowRecordActionEffects';
 import { WorkflowRunRecordActionMenuEntrySetterEffect } from '@/action-menu/actions/record-actions/workflow-run-record-actions/components/WorkflowRunRecordActionMenuEntrySetter';
 import { MAIN_CONTEXT_STORE_INSTANCE_ID } from '@/context-store/constants/MainContextStoreInstanceId';
 import { contextStoreCurrentObjectMetadataItemIdComponentState } from '@/context-store/states/contextStoreCurrentObjectMetadataItemIdComponentState';
 import { contextStoreTargetedRecordsRuleComponentState } from '@/context-store/states/contextStoreTargetedRecordsRuleComponentState';
 import { objectMetadataItemsState } from '@/object-metadata/states/objectMetadataItemsState';
+import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
 import { useRecoilComponentValueV2 } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValueV2';
 import { useIsFeatureEnabled } from '@/workspace/hooks/useIsFeatureEnabled';
 import { useRecoilValue } from 'recoil';
@@ -48,9 +50,20 @@ export const RecordActionMenuEntriesSetter = () => {
     return null;
   }
 
+  const isWorkflowObject =
+    objectMetadataItem.nameSingular === CoreObjectNameSingular.Workflow ||
+    objectMetadataItem.nameSingular === CoreObjectNameSingular.WorkflowRun ||
+    objectMetadataItem.nameSingular === CoreObjectNameSingular.WorkflowVersion;
+
   return (
     <>
-      <RegisterRecordActionEffects objectMetadataItem={objectMetadataItem} />
+      {isWorkflowObject ? (
+        <RegisterWorkflowRecordActionEffects
+          objectMetadataItem={objectMetadataItem}
+        />
+      ) : (
+        <RegisterRecordActionEffects objectMetadataItem={objectMetadataItem} />
+      )}
 
       {isWorkflowEnabled &&
         contextStoreTargetedRecordsRule?.mode === 'selection' &&

--- a/packages/twenty-front/src/modules/action-menu/actions/record-actions/components/RegisterRecordActionEffects.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-actions/components/RegisterRecordActionEffects.tsx
@@ -1,5 +1,6 @@
 import { RegisterRecordActionEffect } from '@/action-menu/actions/record-actions/components/RegisterRecordActionEffect';
 import { useRegisteredRecordActions } from '@/action-menu/hooks/useRegisteredRecordActions';
+import { useShouldActionBeRegisteredParams } from '@/action-menu/hooks/useShouldActionBeRegisteredParams';
 import { ObjectMetadataItem } from '@/object-metadata/types/ObjectMetadataItem';
 
 type RegisterRecordActionEffectsProps = {
@@ -9,8 +10,13 @@ type RegisterRecordActionEffectsProps = {
 export const RegisterRecordActionEffects = ({
   objectMetadataItem,
 }: RegisterRecordActionEffectsProps) => {
+  const shouldBeRegisteredParams = useShouldActionBeRegisteredParams({
+    objectMetadataItem,
+  });
+
   const actionsToRegister = useRegisteredRecordActions({
     objectMetadataItem,
+    shouldBeRegisteredParams,
   });
 
   return (

--- a/packages/twenty-front/src/modules/action-menu/actions/record-actions/components/RegisterWorkflowRecordActionEffects.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-actions/components/RegisterWorkflowRecordActionEffects.tsx
@@ -1,0 +1,50 @@
+import { RegisterRecordActionEffect } from '@/action-menu/actions/record-actions/components/RegisterRecordActionEffect';
+import { useRegisteredRecordActions } from '@/action-menu/hooks/useRegisteredRecordActions';
+import { useShouldActionBeRegisteredParams } from '@/action-menu/hooks/useShouldActionBeRegisteredParams';
+import { contextStoreTargetedRecordsRuleComponentState } from '@/context-store/states/contextStoreTargetedRecordsRuleComponentState';
+import { ObjectMetadataItem } from '@/object-metadata/types/ObjectMetadataItem';
+import { useRecoilComponentValueV2 } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValueV2';
+import { useWorkflowWithCurrentVersion } from '@/workflow/hooks/useWorkflowWithCurrentVersion';
+
+type RegisterWorkflowRecordActionEffectsProps = {
+  objectMetadataItem: ObjectMetadataItem;
+};
+
+export const RegisterWorkflowRecordActionEffects = ({
+  objectMetadataItem,
+}: RegisterWorkflowRecordActionEffectsProps) => {
+  const shouldBeRegisteredParams = useShouldActionBeRegisteredParams({
+    objectMetadataItem,
+  });
+
+  const contextStoreTargetedRecordsRule = useRecoilComponentValueV2(
+    contextStoreTargetedRecordsRuleComponentState,
+  );
+
+  const recordId =
+    contextStoreTargetedRecordsRule.mode === 'selection'
+      ? contextStoreTargetedRecordsRule.selectedRecordIds[0]
+      : undefined;
+
+  const workflowWithCurrentVersion = useWorkflowWithCurrentVersion(recordId);
+
+  const actionsToRegister = useRegisteredRecordActions({
+    objectMetadataItem,
+    shouldBeRegisteredParams: {
+      ...shouldBeRegisteredParams,
+      workflowWithCurrentVersion,
+    },
+  });
+
+  return (
+    <>
+      {actionsToRegister.map((action) => (
+        <RegisterRecordActionEffect
+          key={action.key}
+          action={action}
+          objectMetadataItem={objectMetadataItem}
+        />
+      ))}
+    </>
+  );
+};

--- a/packages/twenty-front/src/modules/action-menu/hooks/useRegisteredRecordActions.ts
+++ b/packages/twenty-front/src/modules/action-menu/hooks/useRegisteredRecordActions.ts
@@ -1,7 +1,7 @@
 import { ActionViewType } from '@/action-menu/actions/types/ActionViewType';
+import { ShouldBeRegisteredFunctionParams } from '@/action-menu/actions/types/ShouldBeRegisteredFunctionParams';
 import { getActionConfig } from '@/action-menu/actions/utils/getActionConfig';
 import { getActionViewType } from '@/action-menu/actions/utils/getActionViewType';
-import { useShouldActionBeRegisteredParams } from '@/action-menu/hooks/useShouldActionBeRegisteredParams';
 import { contextStoreCurrentViewTypeComponentState } from '@/context-store/states/contextStoreCurrentViewTypeComponentState';
 import { contextStoreTargetedRecordsRuleComponentState } from '@/context-store/states/contextStoreTargetedRecordsRuleComponentState';
 import { ObjectMetadataItem } from '@/object-metadata/types/ObjectMetadataItem';
@@ -10,13 +10,11 @@ import { isDefined } from 'twenty-shared/utils';
 
 export const useRegisteredRecordActions = ({
   objectMetadataItem,
+  shouldBeRegisteredParams,
 }: {
   objectMetadataItem: ObjectMetadataItem;
+  shouldBeRegisteredParams: ShouldBeRegisteredFunctionParams;
 }) => {
-  const params = useShouldActionBeRegisteredParams({
-    objectMetadataItem,
-  });
-
   const contextStoreTargetedRecordsRule = useRecoilComponentValueV2(
     contextStoreTargetedRecordsRuleComponentState,
   );
@@ -41,7 +39,7 @@ export const useRegisteredRecordActions = ({
     : [];
 
   const actions = actionsToRegister.filter((action) =>
-    action.shouldBeRegistered(params),
+    action.shouldBeRegistered(shouldBeRegisteredParams),
   );
 
   return actions;

--- a/packages/twenty-front/src/modules/action-menu/hooks/useShouldActionBeRegisteredParams.ts
+++ b/packages/twenty-front/src/modules/action-menu/hooks/useShouldActionBeRegisteredParams.ts
@@ -10,7 +10,6 @@ import { recordStoreFamilyState } from '@/object-record/record-store/states/reco
 import { isSoftDeleteFilterActiveComponentState } from '@/object-record/record-table/states/isSoftDeleteFilterActiveComponentState';
 import { useHasObjectReadOnlyPermission } from '@/settings/roles/hooks/useHasObjectReadOnlyPermission';
 import { useRecoilComponentValueV2 } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValueV2';
-import { useWorkflowWithCurrentVersion } from '@/workflow/hooks/useWorkflowWithCurrentVersion';
 import { useIsFeatureEnabled } from '@/workspace/hooks/useIsFeatureEnabled';
 import { useContext } from 'react';
 import { useRecoilValue } from 'recoil';
@@ -67,11 +66,6 @@ export const useShouldActionBeRegisteredParams = ({
     contextStoreNumberOfSelectedRecordsComponentState,
   );
 
-  const workflowWithCurrentVersion = useWorkflowWithCurrentVersion(
-    recordId,
-    objectMetadataItem.nameSingular !== CoreObjectNameSingular.Workflow,
-  );
-
   return {
     isFavorite,
     isRemoteObject,
@@ -83,6 +77,5 @@ export const useShouldActionBeRegisteredParams = ({
     selectedRecord,
     isWorkflowsEnabled,
     numberOfSelectedRecords,
-    workflowWithCurrentVersion,
   };
 };

--- a/packages/twenty-front/src/modules/workflow/hooks/useWorkflowWithCurrentVersion.ts
+++ b/packages/twenty-front/src/modules/workflow/hooks/useWorkflowWithCurrentVersion.ts
@@ -9,7 +9,6 @@ import { isDefined } from 'twenty-shared/utils';
 
 export const useWorkflowWithCurrentVersion = (
   workflowId: string | undefined,
-  skip = false,
 ): WorkflowWithCurrentVersion | undefined => {
   const { record: workflow } = useFindOneRecord<Workflow>({
     objectNameSingular: CoreObjectNameSingular.Workflow,
@@ -21,7 +20,7 @@ export const useWorkflowWithCurrentVersion = (
       lastPublishedVersionId: true,
       versions: true,
     },
-    skip: !isDefined(workflowId) || skip,
+    skip: !isDefined(workflowId),
   });
 
   return useMemo(() => {


### PR DESCRIPTION
Fix Uncaught Error: Workflow is not enabled. If you want to use it, please enable it in the lab.
<img width="505" alt="erroractionmenu" src="https://github.com/user-attachments/assets/66e60219-20fb-4b00-90e4-d6bd640be774" />

This error was due to using the hook `useWorkflowWithCurrentVersion` outside of a workflow object. Adding a skip parameter wasn't enough because the `useFindOneRecord` uses `useObjectMetadataItem` which throws if workflows aren't enabled.