### PR TITLE
Fixed ViewBarDetails unnecessary padding-top

### DIFF
--- a/packages/twenty-front/src/modules/views/components/ViewBarDetails.tsx
+++ b/packages/twenty-front/src/modules/views/components/ViewBarDetails.tsx
@@ -60,7 +60,6 @@ const StyledChipcontainer = styled.div`
   flex-direction: row;
   overflow: scroll;
   gap: ${({ theme }) => theme.spacing(2)};
-  padding-top: ${({ theme }) => theme.spacing(1)};
   z-index: 1;
 `;
 
@@ -68,7 +67,6 @@ const StyledActionButtonContainer = styled.div`
   display: flex;
   flex-direction: row;
   gap: ${({ theme }) => theme.spacing(2)};
-  padding-top: ${({ theme }) => theme.spacing(1)};
 `;
 
 const StyledFilterContainer = styled.div`


### PR DESCRIPTION
This PR fixes a recent change in ViewBarDetails that added an unnecessary padding-top.

Before : 

<img width="876" alt="image" src="https://github.com/user-attachments/assets/f0152f24-da2c-44f7-b299-a98cb559b2d1" />

After : 

<img width="884" alt="image" src="https://github.com/user-attachments/assets/48a0c9d8-1c22-4eb7-abfa-02963facbcd6" />
