### PR TITLE
fix: Use namePlural instead of labelPlural for favorite view URLs

### DIFF
--- a/packages/twenty-front/src/modules/favorites/utils/getObjectMetadataNamePluralFromViewId.ts
+++ b/packages/twenty-front/src/modules/favorites/utils/getObjectMetadataNamePluralFromViewId.ts
@@ -3,11 +3,11 @@ import { View } from '@/views/types/View';
 import { isDefined } from 'twenty-shared/utils';
 
 type ReturnType = {
-  labelPlural: string;
+  namePlural: string;
   view: Pick<View, 'id' | 'name' | 'objectMetadataId'>;
 };
 
-export const getObjectMetadataLabelPluralFromViewId = (
+export const getObjectMetadataNamePluralFromViewId = (
   view: Pick<View, 'id' | 'name' | 'objectMetadataId'>,
   objectMetadataItems: ObjectMetadataItem[],
 ): ReturnType => {
@@ -21,10 +21,10 @@ export const getObjectMetadataLabelPluralFromViewId = (
     );
   }
 
-  const { labelPlural } = objectMetadataItem;
+  const { namePlural } = objectMetadataItem;
 
   return {
-    labelPlural,
+    namePlural,
     view,
   };
 };

--- a/packages/twenty-front/src/modules/favorites/utils/sortFavorites.ts
+++ b/packages/twenty-front/src/modules/favorites/utils/sortFavorites.ts
@@ -54,7 +54,7 @@ export const sortFavorites = (
           labelIdentifier: view?.name,
           link: getAppPath(
             AppPath.RecordIndexPage,
-            { objectNamePlural: namePlural.toLowerCase() },
+            { objectNamePlural: namePlural },
             favorite.viewId ? { viewId: favorite.viewId } : undefined,
           ),
           forWorkspaceMemberId: favorite.forWorkspaceMemberId,

--- a/packages/twenty-front/src/modules/favorites/utils/sortFavorites.ts
+++ b/packages/twenty-front/src/modules/favorites/utils/sortFavorites.ts
@@ -1,13 +1,13 @@
 import { Favorite } from '@/favorites/types/Favorite';
+import { getObjectMetadataNamePluralFromViewId } from '@/favorites/utils/getObjectMetadataNamePluralFromViewId';
 import { FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
 import { ObjectMetadataItem } from '@/object-metadata/types/ObjectMetadataItem';
 import { ObjectRecord } from '@/object-record/types/ObjectRecord';
 import { ObjectRecordIdentifier } from '@/object-record/types/ObjectRecordIdentifier';
 import { AppPath } from '@/types/AppPath';
 import { View } from '@/views/types/View';
-import { getAppPath } from '~/utils/navigation/getAppPath';
-import { getObjectMetadataLabelPluralFromViewId } from './getObjectMetadataLabelPluralFromViewId';
 import { isDefined } from 'twenty-shared/utils';
+import { getAppPath } from '~/utils/navigation/getAppPath';
 
 export type ProcessedFavorite = Favorite & {
   Icon?: string;
@@ -39,7 +39,7 @@ export const sortFavorites = (
           } as ProcessedFavorite;
         }
 
-        const { labelPlural } = getObjectMetadataLabelPluralFromViewId(
+        const { namePlural } = getObjectMetadataNamePluralFromViewId(
           view,
           objectMetadataItems,
         );
@@ -54,7 +54,7 @@ export const sortFavorites = (
           labelIdentifier: view?.name,
           link: getAppPath(
             AppPath.RecordIndexPage,
-            { objectNamePlural: labelPlural.toLowerCase() },
+            { objectNamePlural: namePlural.toLowerCase() },
             favorite.viewId ? { viewId: favorite.viewId } : undefined,
           ),
           forWorkspaceMemberId: favorite.forWorkspaceMemberId,


### PR DESCRIPTION
closes #11404

Used `namePlural` instead of `labelPlural` for generating favorite view URLs to ensure proper routing across all languages.