### PR TITLE
Fix permission check during onboarding

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/permissions/permissions.module.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/permissions/permissions.module.ts
@@ -1,13 +1,11 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
-import { EnvironmentModule } from 'src/engine/core-modules/environment/environment.module';
 import { FeatureFlagModule } from 'src/engine/core-modules/feature-flag/feature-flag.module';
 import { UserWorkspace } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
 import { PermissionsService } from 'src/engine/metadata-modules/permissions/permissions.service';
 import { RoleEntity } from 'src/engine/metadata-modules/role/role.entity';
 import { UserWorkspaceRoleEntity } from 'src/engine/metadata-modules/role/user-workspace-role.entity';
-import { SettingPermissionEntity } from 'src/engine/metadata-modules/setting-permission/setting-permission.entity';
 import { UserRoleModule } from 'src/engine/metadata-modules/user-role/user-role.module';
 
 @Module({
@@ -15,9 +13,7 @@ import { UserRoleModule } from 'src/engine/metadata-modules/user-role/user-role.
     TypeOrmModule.forFeature([RoleEntity, UserWorkspaceRoleEntity], 'metadata'),
     FeatureFlagModule,
     TypeOrmModule.forFeature([UserWorkspace], 'core'),
-    EnvironmentModule,
     UserRoleModule,
-    TypeOrmModule.forFeature([SettingPermissionEntity], 'metadata'),
   ],
   providers: [PermissionsService],
   exports: [PermissionsService],

--- a/packages/twenty-server/src/engine/metadata-modules/permissions/permissions.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/permissions/permissions.service.ts
@@ -1,15 +1,12 @@
 import { Injectable } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
 
 import { PermissionsOnAllObjectRecords } from 'twenty-shared/constants';
 import { isDefined } from 'twenty-shared/utils';
-import { Repository } from 'typeorm';
 
 import {
   AuthException,
   AuthExceptionCode,
 } from 'src/engine/core-modules/auth/auth.exception';
-import { EnvironmentService } from 'src/engine/core-modules/environment/environment.service';
 import { SettingPermissionType } from 'src/engine/metadata-modules/permissions/constants/setting-permission-type.constants';
 import {
   PermissionsException,
@@ -17,17 +14,11 @@ import {
   PermissionsExceptionMessage,
 } from 'src/engine/metadata-modules/permissions/permissions.exception';
 import { RoleEntity } from 'src/engine/metadata-modules/role/role.entity';
-import { SettingPermissionEntity } from 'src/engine/metadata-modules/setting-permission/setting-permission.entity';
 import { UserRoleService } from 'src/engine/metadata-modules/user-role/user-role.service';
 
 @Injectable()
 export class PermissionsService {
-  constructor(
-    private readonly environmentService: EnvironmentService,
-    private readonly userRoleService: UserRoleService,
-    @InjectRepository(SettingPermissionEntity, 'metadata')
-    private readonly settingPermissionRepository: Repository<SettingPermissionEntity>,
-  ) {}
+  constructor(private readonly userRoleService: UserRoleService) {}
 
   public async getUserWorkspacePermissions({
     userWorkspaceId,


### PR DESCRIPTION
## Context
CurrentUser is fetched during onboarding however roles and permissions are not created yet during that stage so an error was thrown. We only want to fetch permissions after the onboarding of the workspace.