### PR TITLE
remove default meter driver

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/environment/environment-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/environment/environment-variables.ts
@@ -593,13 +593,12 @@ export class EnvironmentVariables {
   })
   @CastToMeterDriverArray()
   @IsOptional()
-  METER_DRIVER: MeterDriver[] = [MeterDriver.Console];
+  METER_DRIVER: MeterDriver[] = [];
 
   @EnvironmentVariablesMetadata({
     group: EnvironmentVariablesGroup.Metering,
     description: 'Endpoint URL for the OpenTelemetry collector',
   })
-  @ValidateIf((env) => env.METER_DRIVER.includes(MeterDriver.OpenTelemetry))
   @IsOptional()
   OTLP_COLLECTOR_ENDPOINT_URL: string;
 

--- a/packages/twenty-server/src/instrument.ts
+++ b/packages/twenty-server/src/instrument.ts
@@ -20,7 +20,7 @@ import { parseArrayEnvVar } from 'src/utils/parse-array-env-var';
 const meterDrivers = parseArrayEnvVar(
   process.env.METER_DRIVER,
   Object.values(MeterDriver),
-  [MeterDriver.Console],
+  [],
 );
 
 if (process.env.EXCEPTION_HANDLER_DRIVER === ExceptionHandlerDriver.Sentry) {


### PR DESCRIPTION
Remove default meter driver to prevent metric logs from polluting the console.