### PR TITLE
Command menu mobile - Prevent overflow on navigation bar

### DIFF
--- a/packages/twenty-front/src/modules/command-menu/components/CommandMenuList.tsx
+++ b/packages/twenty-front/src/modules/command-menu/components/CommandMenuList.tsx
@@ -43,6 +43,10 @@ const StyledInnerList = styled.div`
   }
 `;
 
+const StyledCommandMenuList = styled.div`
+  overflow-y: hidden;
+`;
+
 const StyledEmpty = styled.div`
   align-items: center;
   color: ${({ theme }) => theme.font.color.light};
@@ -68,7 +72,7 @@ export const CommandMenuList = ({
   );
 
   return (
-    <>
+    <StyledCommandMenuList>
       <CommandMenuDefaultSelectionEffect
         selectableItemIds={selectableItemIds}
       />
@@ -104,6 +108,6 @@ export const CommandMenuList = ({
           </SelectableList>
         </StyledInnerList>
       </ScrollWrapper>
-    </>
+    </StyledCommandMenuList>
   );
 };

--- a/packages/twenty-ui/src/navigation/menu-item/components/MenuItemCommand.tsx
+++ b/packages/twenty-ui/src/navigation/menu-item/components/MenuItemCommand.tsx
@@ -78,6 +78,7 @@ const StyledTextContainer = styled.div`
   display: flex;
   flex-direction: row;
   max-width: calc(100% - 2 * var(--horizontal-padding));
+  overflow: hidden;
 `;
 
 export type MenuItemCommandProps = {


### PR DESCRIPTION
Fix https://github.com/twentyhq/twenty/issues/11413