### PR TITLE
Use transformer in workflows

### DIFF
--- a/packages/twenty-server/src/modules/workflow/common/exceptions/workflow-common.exception.ts
+++ b/packages/twenty-server/src/modules/workflow/common/exceptions/workflow-common.exception.ts
@@ -1,0 +1,12 @@
+import { CustomException } from 'src/utils/custom-exception';
+
+export class WorkflowCommonException extends CustomException {
+  constructor(message: string, code: WorkflowCommonExceptionCode) {
+    super(message, code);
+  }
+}
+
+export enum WorkflowCommonExceptionCode {
+  OBJECT_METADATA_NOT_FOUND = 'OBJECT_METADATA_NOT_FOUND',
+  INVALID_CACHE_VERSION = 'INVALID_CACHE_VERSION',
+}

--- a/packages/twenty-server/src/modules/workflow/common/query-hooks/workflow-query-hook.module.ts
+++ b/packages/twenty-server/src/modules/workflow/common/query-hooks/workflow-query-hook.module.ts
@@ -5,6 +5,7 @@ import { NestjsQueryTypeOrmModule } from '@ptc-org/nestjs-query-typeorm';
 import { RecordPositionModule } from 'src/engine/core-modules/record-position/record-position.module';
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 import { ServerlessFunctionModule } from 'src/engine/metadata-modules/serverless-function/serverless-function.module';
+import { WorkspaceCacheStorageModule } from 'src/engine/workspace-cache-storage/workspace-cache-storage.module';
 import { WorkflowCreateManyPostQueryHook } from 'src/modules/workflow/common/query-hooks/workflow-create-many.post-query.hook';
 import { WorkflowCreateManyPreQueryHook } from 'src/modules/workflow/common/query-hooks/workflow-create-many.pre-query.hook';
 import { WorkflowCreateOnePostQueryHook } from 'src/modules/workflow/common/query-hooks/workflow-create-one.post-query.hook';
@@ -33,6 +34,7 @@ import { WorkflowVersionValidationWorkspaceService } from 'src/modules/workflow/
     NestjsQueryTypeOrmModule.forFeature([ObjectMetadataEntity], 'metadata'),
     ServerlessFunctionModule,
     RecordPositionModule,
+    WorkspaceCacheStorageModule,
   ],
   providers: [
     WorkflowCreateOnePreQueryHook,

--- a/packages/twenty-server/src/modules/workflow/common/workflow-common.module.ts
+++ b/packages/twenty-server/src/modules/workflow/common/workflow-common.module.ts
@@ -1,11 +1,16 @@
 import { Module } from '@nestjs/common';
 
 import { ServerlessFunctionModule } from 'src/engine/metadata-modules/serverless-function/serverless-function.module';
+import { WorkspaceCacheStorageModule } from 'src/engine/workspace-cache-storage/workspace-cache-storage.module';
 import { WorkflowQueryHookModule } from 'src/modules/workflow/common/query-hooks/workflow-query-hook.module';
 import { WorkflowCommonWorkspaceService } from 'src/modules/workflow/common/workspace-services/workflow-common.workspace-service';
 
 @Module({
-  imports: [WorkflowQueryHookModule, ServerlessFunctionModule],
+  imports: [
+    WorkflowQueryHookModule,
+    ServerlessFunctionModule,
+    WorkspaceCacheStorageModule,
+  ],
   providers: [WorkflowCommonWorkspaceService],
   exports: [WorkflowCommonWorkspaceService],
 })

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/record-crud/record-crud-action.module.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/record-crud/record-crud-action.module.ts
@@ -4,9 +4,11 @@ import { NestjsQueryTypeOrmModule } from '@ptc-org/nestjs-query-typeorm';
 
 import { FeatureFlagModule } from 'src/engine/core-modules/feature-flag/feature-flag.module';
 import { RecordPositionModule } from 'src/engine/core-modules/record-position/record-position.module';
+import { RecordTransformerModule } from 'src/engine/core-modules/record-transformer/record-transformer.module';
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 import { ScopedWorkspaceContextFactory } from 'src/engine/twenty-orm/factories/scoped-workspace-context.factory';
 import { WorkspaceCacheStorageModule } from 'src/engine/workspace-cache-storage/workspace-cache-storage.module';
+import { WorkflowCommonModule } from 'src/modules/workflow/common/workflow-common.module';
 import { CreateRecordWorkflowAction } from 'src/modules/workflow/workflow-executor/workflow-actions/record-crud/create-record.workflow-action';
 import { DeleteRecordWorkflowAction } from 'src/modules/workflow/workflow-executor/workflow-actions/record-crud/delete-record.workflow-action';
 import { FindRecordsWorkflowAction } from 'src/modules/workflow/workflow-executor/workflow-actions/record-crud/find-records.workflow-action';
@@ -18,6 +20,8 @@ import { UpdateRecordWorkflowAction } from 'src/modules/workflow/workflow-execut
     NestjsQueryTypeOrmModule.forFeature([ObjectMetadataEntity], 'metadata'),
     FeatureFlagModule,
     RecordPositionModule,
+    RecordTransformerModule,
+    WorkflowCommonModule,
   ],
   providers: [
     ScopedWorkspaceContextFactory,

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/record-crud/update-record.workflow-action.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/record-crud/update-record.workflow-action.ts
@@ -1,19 +1,19 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
-import { Repository } from 'typeorm';
 import deepEqual from 'deep-equal';
+import { Repository } from 'typeorm';
 
 import { WorkflowExecutor } from 'src/modules/workflow/workflow-executor/interfaces/workflow-executor.interface';
 
 import { DatabaseEventAction } from 'src/engine/api/graphql/graphql-query-runner/enums/database-event-action';
+import { RecordInputTransformerService } from 'src/engine/core-modules/record-transformer/services/record-input-transformer.service';
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
-import { getObjectMetadataMapItemByNameSingular } from 'src/engine/metadata-modules/utils/get-object-metadata-map-item-by-name-singular.util';
 import { ScopedWorkspaceContextFactory } from 'src/engine/twenty-orm/factories/scoped-workspace-context.factory';
 import { TwentyORMManager } from 'src/engine/twenty-orm/twenty-orm.manager';
 import { formatData } from 'src/engine/twenty-orm/utils/format-data.util';
-import { WorkspaceCacheStorageService } from 'src/engine/workspace-cache-storage/workspace-cache-storage.service';
 import { WorkspaceEventEmitter } from 'src/engine/workspace-event-emitter/workspace-event-emitter';
+import { WorkflowCommonWorkspaceService } from 'src/modules/workflow/common/workspace-services/workflow-common.workspace-service';
 import {
   WorkflowStepExecutorException,
   WorkflowStepExecutorExceptionCode,
@@ -32,11 +32,12 @@ import { WorkflowUpdateRecordActionInput } from 'src/modules/workflow/workflow-e
 export class UpdateRecordWorkflowAction implements WorkflowExecutor {
   constructor(
     private readonly twentyORMManager: TwentyORMManager,
-    private readonly workspaceCacheStorageService: WorkspaceCacheStorageService,
     private readonly scopedWorkspaceContextFactory: ScopedWorkspaceContextFactory,
     @InjectRepository(ObjectMetadataEntity, 'metadata')
     private readonly objectMetadataRepository: Repository<ObjectMetadataEntity>,
     private readonly workspaceEventEmitter: WorkspaceEventEmitter,
+    private readonly workflowCommonWorkspaceService: WorkflowCommonWorkspaceService,
+    private readonly recordInputTransformerService: RecordInputTransformerService,
   ) {}
 
   async execute({
@@ -97,50 +98,26 @@ export class UpdateRecordWorkflowAction implements WorkflowExecutor {
       );
     }
 
-    const currentCacheVersion =
-      await this.workspaceCacheStorageService.getMetadataVersion(workspaceId);
-
-    if (currentCacheVersion === undefined) {
-      throw new RecordCRUDActionException(
-        'Failed to read: Metadata cache version not found',
-        RecordCRUDActionExceptionCode.INVALID_REQUEST,
-      );
-    }
-
-    const objectMetadataMaps =
-      await this.workspaceCacheStorageService.getObjectMetadataMaps(
-        workspaceId,
-        currentCacheVersion,
-      );
-
-    if (!objectMetadataMaps) {
-      throw new RecordCRUDActionException(
-        'Failed to read: Object metadata collection not found',
-        RecordCRUDActionExceptionCode.INVALID_REQUEST,
-      );
-    }
-
-    const objectMetadataItemWithFieldsMaps =
-      getObjectMetadataMapItemByNameSingular(
-        objectMetadataMaps,
-        workflowActionInput.objectName,
-      );
-
-    if (!objectMetadataItemWithFieldsMaps) {
-      throw new RecordCRUDActionException(
-        `Failed to read: Object ${workflowActionInput.objectName} not found`,
-        RecordCRUDActionExceptionCode.INVALID_REQUEST,
-      );
-    }
-
     if (workflowActionInput.fieldsToUpdate.length === 0) {
       return {
         result: previousObjectRecord,
       };
     }
 
+    const { objectMetadataItemWithFieldsMaps } =
+      await this.workflowCommonWorkspaceService.getObjectMetadataItemWithFieldsMaps(
+        workflowActionInput.objectName,
+        workspaceId,
+      );
+
+    const transformedObjectRecord =
+      await this.recordInputTransformerService.process({
+        recordInput: workflowActionInput.objectRecord,
+        objectMetadataMapItem: objectMetadataItemWithFieldsMaps,
+      });
+
     const objectRecordWithFilteredFields = Object.keys(
-      workflowActionInput.objectRecord,
+      transformedObjectRecord,
     ).reduce((acc, key) => {
       if (workflowActionInput.fieldsToUpdate.includes(key)) {
         return {

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/record-crud/update-record.workflow-action.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/record-crud/update-record.workflow-action.ts
@@ -110,14 +110,8 @@ export class UpdateRecordWorkflowAction implements WorkflowExecutor {
         workspaceId,
       );
 
-    const transformedObjectRecord =
-      await this.recordInputTransformerService.process({
-        recordInput: workflowActionInput.objectRecord,
-        objectMetadataMapItem: objectMetadataItemWithFieldsMaps,
-      });
-
     const objectRecordWithFilteredFields = Object.keys(
-      transformedObjectRecord,
+      workflowActionInput.objectRecord,
     ).reduce((acc, key) => {
       if (workflowActionInput.fieldsToUpdate.includes(key)) {
         return {
@@ -129,8 +123,14 @@ export class UpdateRecordWorkflowAction implements WorkflowExecutor {
       return acc;
     }, {});
 
+    const transformedObjectRecord =
+      await this.recordInputTransformerService.process({
+        recordInput: objectRecordWithFilteredFields,
+        objectMetadataMapItem: objectMetadataItemWithFieldsMaps,
+      });
+
     const objectRecordFormatted = formatData(
-      objectRecordWithFilteredFields,
+      transformedObjectRecord,
       objectMetadataItemWithFieldsMaps,
     );
 


### PR DESCRIPTION
We do not manage rich text properly in workflows. This is because API has a layer called transformer service. Looks a bit as a duplicate of format data, but this api layer was already there for position anyway. Using it in workflow record actions.

I hope at some point we merged formatData util and transformer.