### PR TITLE
Fix sign-in-up sso buttons width

### DIFF
--- a/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpGlobalScopeForm.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpGlobalScopeForm.tsx
@@ -25,15 +25,16 @@ import { authProvidersState } from '@/client-config/states/authProvidersState';
 import { useRedirectToWorkspaceDomain } from '@/domain-manager/hooks/useRedirectToWorkspaceDomain';
 import { SnackBarVariant } from '@/ui/feedback/snack-bar-manager/components/SnackBar';
 import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
-import { getWorkspaceUrl } from '~/utils/getWorkspaceUrl';
 import { isDefined } from 'twenty-shared/utils';
 import { HorizontalSeparator } from 'twenty-ui/display';
 import { Loader } from 'twenty-ui/feedback';
 import { MainButton } from 'twenty-ui/input';
+import { getWorkspaceUrl } from '~/utils/getWorkspaceUrl';
 
 const StyledContentContainer = styled(motion.div)`
   margin-bottom: ${({ theme }) => theme.spacing(8)};
   margin-top: ${({ theme }) => theme.spacing(4)};
+  min-width: 200px;
 `;
 
 const StyledForm = styled.form`

--- a/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpWorkspaceScopeForm.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpWorkspaceScopeForm.tsx
@@ -17,7 +17,7 @@ import { ClickToActionLink } from 'twenty-ui/navigation';
 const StyledContentContainer = styled.div`
   margin-bottom: ${({ theme }) => theme.spacing(8)};
   margin-top: ${({ theme }) => theme.spacing(4)};
-  width: 200px;
+  min-width: 200px;
 `;
 
 export const SignInUpWorkspaceScopeForm = () => {


### PR DESCRIPTION
## Context
An enforced width was introduced recently for error texts but broke Microsoft sso placement due to its longer text.
I've replaced it by a min-width and introduced the missing one in global signin/up.

Before
<img width="456" alt="Screenshot 2025-04-10 at 12 14 51" src="https://github.com/user-attachments/assets/43f29c63-f257-4c1c-9c16-b0170343c43e" />

After
<img width="494" alt="Screenshot 2025-04-10 at 12 14 17" src="https://github.com/user-attachments/assets/17c4362a-1336-4adc-aeb9-76c6dcd059c6" />
