### PR TITLE
fix error messages margin

### DIFF
--- a/packages/twenty-front/src/modules/auth/sign-in-up/hooks/useSignInUpForm.ts
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/hooks/useSignInUpForm.ts
@@ -22,10 +22,7 @@ const makeValidationSchema = (signInUpStep: SignInUpStep) =>
         signInUpStep === SignInUpStep.Password
           ? z
               .string()
-              .regex(
-                PASSWORD_REGEX,
-                'Password must contain at least 8 characters',
-              )
+              .regex(PASSWORD_REGEX, 'Password must be min. 8 characters')
           : z.string().optional(),
       captchaToken: z.string().default(''),
     })

--- a/packages/twenty-front/src/modules/settings/developers/components/SettingsApiKeysFieldItemTableRow.tsx
+++ b/packages/twenty-front/src/modules/settings/developers/components/SettingsApiKeysFieldItemTableRow.tsx
@@ -4,7 +4,10 @@ import styled from '@emotion/styled';
 import { ApiFieldItem } from '@/settings/developers/types/api-key/ApiFieldItem';
 import { TableCell } from '@/ui/layout/table/components/TableCell';
 import { TableRow } from '@/ui/layout/table/components/TableRow';
-import { IconChevronRight } from 'twenty-ui/display';
+import {
+  IconChevronRight,
+  OverflowingTextWithTooltip,
+} from 'twenty-ui/display';
 import { MOBILE_VIEWPORT } from 'twenty-ui/theme';
 
 export const StyledApisFieldTableRow = styled(TableRow)`
@@ -41,7 +44,9 @@ export const SettingsApiKeysFieldItemTableRow = ({
 
   return (
     <StyledApisFieldTableRow to={to}>
-      <StyledNameTableCell>{fieldItem.name}</StyledNameTableCell>
+      <StyledNameTableCell>
+        <OverflowingTextWithTooltip text={fieldItem.name} />
+      </StyledNameTableCell>
       <TableCell
         color={
           fieldItem.expiration === 'Expired'

--- a/packages/twenty-front/src/modules/settings/playground/components/PlaygroundSetupForm.tsx
+++ b/packages/twenty-front/src/modules/settings/playground/components/PlaygroundSetupForm.tsx
@@ -81,7 +81,7 @@ export const PlaygroundSetupForm = () => {
 
       return true;
     } catch (error) {
-      throw new Error(t`Invalid API key.`);
+      throw new Error(t`Invalid API key`);
     }
   };
 

--- a/packages/twenty-front/src/modules/settings/playground/components/PlaygroundSetupForm.tsx
+++ b/packages/twenty-front/src/modules/settings/playground/components/PlaygroundSetupForm.tsx
@@ -9,16 +9,16 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { useLingui } from '@lingui/react/macro';
 import { Controller, useForm } from 'react-hook-form';
 import { useRecoilState } from 'recoil';
-import { z } from 'zod';
-import { REACT_APP_SERVER_BASE_URL } from '~/config';
-import { useNavigateSettings } from '~/hooks/useNavigateSettings';
-import { Button } from 'twenty-ui/input';
 import {
   IconApi,
   IconBracketsAngle,
   IconBrandGraphql,
   IconFolderRoot,
 } from 'twenty-ui/display';
+import { Button } from 'twenty-ui/input';
+import { z } from 'zod';
+import { REACT_APP_SERVER_BASE_URL } from '~/config';
+import { useNavigateSettings } from '~/hooks/useNavigateSettings';
 
 const playgroundSetupFormSchema = z.object({
   apiKeyForPlayground: z.string(),
@@ -81,9 +81,7 @@ export const PlaygroundSetupForm = () => {
 
       return true;
     } catch (error) {
-      throw new Error(
-        t`Failed to validate API key. Please check your API key and try again.`,
-      );
+      throw new Error(t`Invalid API key.`);
     }
   };
 

--- a/packages/twenty-front/src/modules/ui/input/components/InputErrorHelper.tsx
+++ b/packages/twenty-front/src/modules/ui/input/components/InputErrorHelper.tsx
@@ -4,6 +4,8 @@ import React from 'react';
 const StyledInputErrorHelper = styled.div`
   color: ${({ theme }) => theme.color.red};
   font-size: ${({ theme }) => theme.font.size.xs};
+  position: absolute;
+  margin-top: ${({ theme }) => theme.spacing(0.25)};
 `;
 
 export const InputErrorHelper = ({

--- a/packages/twenty-front/src/pages/auth/PasswordReset.tsx
+++ b/packages/twenty-front/src/pages/auth/PasswordReset.tsx
@@ -36,7 +36,7 @@ const validationSchema = z
     passwordResetToken: z.string(),
     newPassword: z
       .string()
-      .regex(PASSWORD_REGEX, 'Password must contain at least 8 characters'),
+      .regex(PASSWORD_REGEX, 'Password must be min. 8 characters'),
   })
   .required();
 
@@ -69,6 +69,10 @@ const StyledFullWidthMotionDiv = styled(motion.div)`
 
 const StyledInputContainer = styled.div`
   margin-bottom: ${({ theme }) => theme.spacing(3)};
+`;
+
+const StyledMainButton = styled(MainButton)`
+  margin-top: ${({ theme }) => theme.spacing(2)};
 `;
 
 export const PasswordReset = () => {
@@ -237,7 +241,7 @@ export const PasswordReset = () => {
                 />
               </StyledFullWidthMotionDiv>
 
-              <MainButton
+              <StyledMainButton
                 variant="secondary"
                 title={t`Change Password`}
                 type="submit"

--- a/packages/twenty-front/src/pages/settings/developers/api-keys/SettingsApiKeys.tsx
+++ b/packages/twenty-front/src/pages/settings/developers/api-keys/SettingsApiKeys.tsx
@@ -6,11 +6,11 @@ import { SettingsPath } from '@/types/SettingsPath';
 import { SubMenuTopBarContainer } from '@/ui/layout/page/components/SubMenuTopBarContainer';
 import styled from '@emotion/styled';
 import { Trans, useLingui } from '@lingui/react/macro';
-import { getSettingsPath } from '~/utils/navigation/getSettingsPath';
-import { Button } from 'twenty-ui/input';
 import { H2Title, IconPlus } from 'twenty-ui/display';
-import { MOBILE_VIEWPORT } from 'twenty-ui/theme';
+import { Button } from 'twenty-ui/input';
 import { Section } from 'twenty-ui/layout';
+import { MOBILE_VIEWPORT } from 'twenty-ui/theme';
+import { getSettingsPath } from '~/utils/navigation/getSettingsPath';
 
 const StyledButtonContainer = styled.div`
   display: flex;
@@ -24,7 +24,7 @@ const StyledButtonContainer = styled.div`
 const StyledContainer = styled.div`
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  overflow: visible;
   gap: ${({ theme }) => theme.spacing(2)};
 `;
 


### PR DESCRIPTION
## Context
Fixing error messages margin in various places
Reset password
<img width="453" alt="Screenshot 2025-04-10 at 15 17 00" src="https://github.com/user-attachments/assets/7a0fb090-4029-415f-8733-0c9e3aa3c3f2" />
Api key
<img width="543" alt="Screenshot 2025-04-10 at 15 16 21" src="https://github.com/user-attachments/assets/d8f8a348-84d3-44d7-8cea-863c3ddb02fc" />

Also setting overflow on api key label in api keys table
<img width="580" alt="Screenshot 2025-04-10 at 15 16 15" src="https://github.com/user-attachments/assets/207df981-c906-4926-a56d-38167628267f" />
