### PR TITLE
Fix boolean default value update not updating psql default value when false

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.service.ts
@@ -255,9 +255,9 @@ export class FieldMetadataService extends TypeOrmQueryService<FieldMetadataEntit
       }
 
       if (
-        fieldMetadataInput.name ||
-        updatableFieldInput.options ||
-        updatableFieldInput.defaultValue
+        isDefined(fieldMetadataInput.name) ||
+        isDefined(updatableFieldInput.options) ||
+        isDefined(updatableFieldInput.defaultValue)
       ) {
         await this.workspaceMigrationService.createCustomMigration(
           generateMigrationName(`update-${updatedFieldMetadata.name}`),


### PR DESCRIPTION
Fixes https://github.com/twentyhq/twenty/issues/11471

## Context
When sending false as a new defaultValue, this was not going through the migration creation code due to this condition
```typescript
if (updatableFieldInput.defaultValue)
```
