### PR TITLE
Remove get messages thread id dependancy

### DIFF
--- a/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/calendar-event-find-many.pre-query.hook.ts
+++ b/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/calendar-event-find-many.pre-query.hook.ts
@@ -1,5 +1,7 @@
 import { BadRequestException, NotFoundException, Scope } from '@nestjs/common';
 
+import { isDefined } from 'twenty-shared/utils';
+
 import { WorkspaceQueryHookInstance } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/interfaces/workspace-query-hook.interface';
 import { FindManyResolverArgs } from 'src/engine/api/graphql/workspace-resolver-builder/interfaces/workspace-resolvers-builder.interface';
 
@@ -26,6 +28,12 @@ export class CalendarEventFindManyPreQueryHook
     objectName: string,
     payload: FindManyResolverArgs,
   ): Promise<FindManyResolverArgs> {
+    const isApiContext = isDefined(authContext.apiKey?.id);
+
+    if (isApiContext) {
+      return payload;
+    }
+
     if (!payload?.filter?.id?.eq) {
       throw new BadRequestException('id filter is required');
     }

--- a/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/calendar-event-find-one.pre-query-hook.ts
+++ b/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/calendar-event-find-one.pre-query-hook.ts
@@ -1,5 +1,7 @@
 import { BadRequestException, NotFoundException, Scope } from '@nestjs/common';
 
+import { isDefined } from 'twenty-shared/utils';
+
 import { WorkspaceQueryHookInstance } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/interfaces/workspace-query-hook.interface';
 import { FindOneResolverArgs } from 'src/engine/api/graphql/workspace-resolver-builder/interfaces/workspace-resolvers-builder.interface';
 
@@ -26,6 +28,12 @@ export class CalendarEventFindOnePreQueryHook
     objectName: string,
     payload: FindOneResolverArgs,
   ): Promise<FindOneResolverArgs> {
+    const isApiContext = isDefined(authContext.apiKey?.id);
+
+    if (isApiContext) {
+      return payload;
+    }
+
     if (!payload?.filter?.id?.eq) {
       throw new BadRequestException('id filter is required');
     }

--- a/packages/twenty-server/src/modules/messaging/common/query-hooks/message/message-find-many.pre-query.hook.ts
+++ b/packages/twenty-server/src/modules/messaging/common/query-hooks/message/message-find-many.pre-query.hook.ts
@@ -1,5 +1,7 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 
+import { isDefined } from 'twenty-shared/utils';
+
 import { WorkspaceQueryHookInstance } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/interfaces/workspace-query-hook.interface';
 import { FindManyResolverArgs } from 'src/engine/api/graphql/workspace-resolver-builder/interfaces/workspace-resolvers-builder.interface';
 
@@ -21,6 +23,12 @@ export class MessageFindManyPreQueryHook implements WorkspaceQueryHookInstance {
     objectName: string,
     payload: FindManyResolverArgs,
   ): Promise<FindManyResolverArgs> {
+    const isApiContext = isDefined(authContext.apiKey?.id);
+
+    if (isApiContext) {
+      return payload;
+    }
+
     if (!payload?.filter?.messageThreadId?.eq) {
       throw new BadRequestException('messageThreadId filter is required');
     }

--- a/packages/twenty-server/src/modules/messaging/common/query-hooks/message/message-find-one.pre-query-hook.ts
+++ b/packages/twenty-server/src/modules/messaging/common/query-hooks/message/message-find-one.pre-query-hook.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { NotFoundException } from '@nestjs/common';
 
+import { isDefined } from 'twenty-shared/utils';
+
 import { WorkspaceQueryHookInstance } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/interfaces/workspace-query-hook.interface';
 import { FindOneResolverArgs } from 'src/engine/api/graphql/workspace-resolver-builder/interfaces/workspace-resolvers-builder.interface';
 
@@ -22,6 +24,12 @@ export class MessageFindOnePreQueryHook implements WorkspaceQueryHookInstance {
     objectName: string,
     payload: FindOneResolverArgs,
   ): Promise<FindOneResolverArgs> {
+    const isApiContext = isDefined(authContext.apiKey?.id);
+
+    if (isApiContext) {
+      return payload;
+    }
+
     if (!authContext.user?.id) {
       throw new NotFoundException('User id is required');
     }


### PR DESCRIPTION
https://github.com/twentyhq/twenty/pull/11512 follow up
- remove messageThreadId requirements on messages for requests done with API key (no user, only workspace)
- doing the same for calendarEvents