### PR TITLE
revert: transform -> marginLeft in DefaultLayout motion div

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/page/components/DefaultLayout.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/page/components/DefaultLayout.tsx
@@ -80,16 +80,14 @@ export const DefaultLayout = () => {
         <AppErrorBoundary FallbackComponent={AppFullScreenErrorFallback}>
           <StyledPageContainer
             animate={{
-              transform:
+              marginLeft:
                 isSettingsPage && !isMobile && !useShowFullScreen
-                  ? `translateX(${
-                      (windowsWidth -
-                        (OBJECT_SETTINGS_WIDTH +
-                          NAV_DRAWER_WIDTHS.menu.desktop.expanded +
-                          76)) /
-                      2
-                    }px)`
-                  : 'translateX(0)',
+                  ? (windowsWidth -
+                      (OBJECT_SETTINGS_WIDTH +
+                        NAV_DRAWER_WIDTHS.menu.desktop.expanded +
+                        76)) /
+                    2
+                  : 0,
             }}
             transition={{
               duration: theme.animation.duration.normal,


### PR DESCRIPTION
This [change](https://github.com/twentyhq/twenty/pull/11345/commits/1020e811190348f06d1ccbf933a6a0ae20f00b04) was done to have smooth transitions between fullscreen and normal screens (with drawer), but caused major regressions on the settings page layout (see video).


https://github.com/user-attachments/assets/7fe41c2f-007b-420f-a230-bcfcd877aded


Reverting to fix the regression and keep marginLeft for now. Transitions can be smoothened in a separate issue, pretty sure not a priority. 