### PR TITLE
Fix a bug that overwrites currentRecordFilters when using URL filtered view

### DIFF
--- a/packages/twenty-front/src/modules/views/components/QueryParamsFiltersEffect.tsx
+++ b/packages/twenty-front/src/modules/views/components/QueryParamsFiltersEffect.tsx
@@ -2,16 +2,28 @@ import { useEffect } from 'react';
 
 import { useViewFromQueryParams } from '@/views/hooks/internal/useViewFromQueryParams';
 import { useApplyViewFiltersToCurrentRecordFilters } from '@/views/hooks/useApplyViewFiltersToCurrentRecordFilters';
+import { useGetCurrentViewOnly } from '@/views/hooks/useGetCurrentViewOnly';
 
 export const QueryParamsFiltersEffect = () => {
-  const { hasFiltersQueryParams, getFiltersFromQueryParams } =
-    useViewFromQueryParams();
+  const {
+    hasFiltersQueryParams,
+    getFiltersFromQueryParams,
+    objectMetadataItem,
+  } = useViewFromQueryParams();
+
+  const { currentView } = useGetCurrentViewOnly();
 
   const { applyViewFiltersToCurrentRecordFilters } =
     useApplyViewFiltersToCurrentRecordFilters();
 
+  const currentViewObjectMetadataItemIsDifferentFromURLObjectMetadataItem =
+    currentView?.objectMetadataId !== objectMetadataItem.id;
+
   useEffect(() => {
-    if (!hasFiltersQueryParams) {
+    if (
+      !hasFiltersQueryParams ||
+      currentViewObjectMetadataItemIsDifferentFromURLObjectMetadataItem
+    ) {
       return;
     }
 
@@ -21,6 +33,7 @@ export const QueryParamsFiltersEffect = () => {
       }
     });
   }, [
+    currentViewObjectMetadataItemIsDifferentFromURLObjectMetadataItem,
     applyViewFiltersToCurrentRecordFilters,
     getFiltersFromQueryParams,
     hasFiltersQueryParams,

--- a/packages/twenty-front/src/modules/views/hooks/internal/useViewFromQueryParams.ts
+++ b/packages/twenty-front/src/modules/views/hooks/internal/useViewFromQueryParams.ts
@@ -189,5 +189,6 @@ export const useViewFromQueryParams = () => {
     viewIdQueryParam,
     hasFiltersQueryParams,
     getFiltersFromQueryParams,
+    objectMetadataItem,
   };
 };


### PR DESCRIPTION
This PR fixes a bug that happened when navigating to a filtered view from a record show page related record section, clicking on 'All'.

The problem was that the QueryParamsFiltersEffect effect component was overwriting the currentRecordFilter of a different object metadata item than the current view.

Which when we navigated back on the original view, had emptied the filters, while they shouldn't change if we only navigate without refreshing the app.

Fixes https://github.com/twentyhq/core-team-issues/issues/657
