### PR TITLE
Jotai POC to deprecate recoilsync

### DIFF
--- a/packages/twenty-front/package.json
+++ b/packages/twenty-front/package.json
@@ -54,6 +54,8 @@
     "buffer": "^6.0.3",
     "docx": "^9.1.0",
     "file-saver": "^2.0.5",
+    "jotai": "^2.12.2",
+    "jotai-location": "^0.5.5",
     "recoil-sync": "^0.2.0",
     "transliteration": "^2.3.5",
     "twenty-shared": "workspace:*",

--- a/packages/twenty-front/src/modules/app/components/App.tsx
+++ b/packages/twenty-front/src/modules/app/components/App.tsx
@@ -7,18 +7,18 @@ import { ExceptionHandlerProvider } from '@/error-handler/components/ExceptionHa
 import { SnackBarProviderScope } from '@/ui/feedback/snack-bar-manager/scopes/SnackBarProviderScope';
 import { i18n } from '@lingui/core';
 import { I18nProvider } from '@lingui/react';
+import { Provider } from 'jotai';
 import { HelmetProvider } from 'react-helmet-async';
 import { RecoilRoot } from 'recoil';
-import { RecoilURLSyncJSON } from 'recoil-sync';
-import { initialI18nActivate } from '~/utils/i18n/initialI18nActivate';
 import { IconsProvider } from 'twenty-ui/display';
+import { initialI18nActivate } from '~/utils/i18n/initialI18nActivate';
 
 initialI18nActivate();
 
 export const App = () => {
   return (
     <RecoilRoot>
-      <RecoilURLSyncJSON location={{ part: 'queryParams' }}>
+      <Provider>
         <AppErrorBoundary
           resetOnLocationChange={false}
           FallbackComponent={AppRootErrorFallback}
@@ -37,7 +37,7 @@ export const App = () => {
             </SnackBarProviderScope>
           </I18nProvider>
         </AppErrorBoundary>
-      </RecoilURLSyncJSON>
+      </Provider>
     </RecoilRoot>
   );
 };

--- a/packages/twenty-front/src/modules/auth/sign-in-up/hooks/useSignInWithGoogle.ts
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/hooks/useSignInWithGoogle.ts
@@ -1,18 +1,14 @@
 import { useParams, useSearchParams } from 'react-router-dom';
 
 import { useAuth } from '@/auth/hooks/useAuth';
-import { BillingCheckoutSession } from '@/auth/types/billingCheckoutSession.type';
+import { BILLING_CHECKOUT_SESSION_DEFAULT_VALUE } from '@/billing/constants/BillingCheckoutSessionDefaultValue';
 
 export const useSignInWithGoogle = () => {
   const workspaceInviteHash = useParams().workspaceInviteHash;
   const [searchParams] = useSearchParams();
   const workspacePersonalInviteToken =
     searchParams.get('inviteToken') ?? undefined;
-  const billingCheckoutSession = {
-    plan: 'PRO',
-    interval: 'Month',
-    requirePaymentMethod: true,
-  } as BillingCheckoutSession;
+  const billingCheckoutSession = BILLING_CHECKOUT_SESSION_DEFAULT_VALUE;
 
   const { signInWithGoogle } = useAuth();
   return {

--- a/packages/twenty-front/src/modules/auth/states/__tests__/billingCheckoutSessionAtom.test.tsx
+++ b/packages/twenty-front/src/modules/auth/states/__tests__/billingCheckoutSessionAtom.test.tsx
@@ -1,0 +1,178 @@
+import { renderHook } from '@testing-library/react';
+import { Provider, useAtom } from 'jotai';
+import { act } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { BILLING_CHECKOUT_SESSION_DEFAULT_VALUE } from '@/billing/constants/BillingCheckoutSessionDefaultValue';
+import {
+  BillingPlanKey,
+  SubscriptionInterval,
+} from '~/generated-metadata/graphql';
+import { billingCheckoutSessionAtom } from '../billingCheckoutSessionAtom';
+
+// Mock the window.location and history API
+const mockLocation = {
+  pathname: '/test',
+  search: '',
+};
+
+const mockHistory = {
+  replaceState: jest.fn(),
+};
+
+// Setup the test environment
+const setupTest = () => {
+  // Mock window.location and history
+  Object.defineProperty(window, 'location', {
+    value: mockLocation,
+    writable: true,
+  });
+
+  Object.defineProperty(window, 'history', {
+    value: mockHistory,
+    writable: true,
+  });
+
+  // Reset mocks
+  jest.clearAllMocks();
+};
+
+// Wrapper component for the tests
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <Provider>
+    <MemoryRouter>{children}</MemoryRouter>
+  </Provider>
+);
+
+describe('billingCheckoutSessionAtom', () => {
+  beforeEach(() => {
+    setupTest();
+  });
+
+  it('should initialize with default value when no URL params are present', () => {
+    const { result } = renderHook(() => useAtom(billingCheckoutSessionAtom), {
+      wrapper: Wrapper,
+    });
+
+    expect(result.current[0]).toEqual(BILLING_CHECKOUT_SESSION_DEFAULT_VALUE);
+  });
+
+  it('should read value from URL params when present', () => {
+    // Set up URL with billingCheckoutSession param
+    const customValue = {
+      plan: BillingPlanKey.ENTERPRISE,
+      interval: SubscriptionInterval.Year,
+      requirePaymentMethod: false,
+    };
+
+    Object.defineProperty(window, 'location', {
+      value: {
+        ...mockLocation,
+        search: `?billingCheckoutSession=${encodeURIComponent(JSON.stringify(customValue))}`,
+      },
+      writable: true,
+    });
+
+    const { result } = renderHook(() => useAtom(billingCheckoutSessionAtom), {
+      wrapper: Wrapper,
+    });
+
+    expect(result.current[0]).toEqual(customValue);
+  });
+
+  it('should update URL when state changes', () => {
+    const { result } = renderHook(() => useAtom(billingCheckoutSessionAtom), {
+      wrapper: Wrapper,
+    });
+
+    const newValue = {
+      plan: BillingPlanKey.ENTERPRISE,
+      interval: SubscriptionInterval.Year,
+      requirePaymentMethod: false,
+    };
+
+    act(() => {
+      result.current[1](newValue);
+    });
+
+    // Check that history.replaceState was called with the correct URL
+    expect(mockHistory.replaceState).toHaveBeenCalledWith(
+      {},
+      '',
+      `/test?billingCheckoutSession=${encodeURIComponent(JSON.stringify(newValue))}`,
+    );
+  });
+
+  it('should handle invalid JSON in URL params', () => {
+    // Set up URL with invalid JSON
+    Object.defineProperty(window, 'location', {
+      value: {
+        ...mockLocation,
+        search: '?billingCheckoutSession=invalid-json',
+      },
+      writable: true,
+    });
+
+    const { result } = renderHook(() => useAtom(billingCheckoutSessionAtom), {
+      wrapper: Wrapper,
+    });
+
+    // Should fall back to default value
+    expect(result.current[0]).toEqual(BILLING_CHECKOUT_SESSION_DEFAULT_VALUE);
+  });
+
+  it('should handle JSON with missing required properties', () => {
+    // Set up URL with incomplete JSON
+    const incompleteValue = {
+      plan: BillingPlanKey.ENTERPRISE,
+      // Missing interval and requirePaymentMethod
+    };
+
+    Object.defineProperty(window, 'location', {
+      value: {
+        ...mockLocation,
+        search: `?billingCheckoutSession=${encodeURIComponent(JSON.stringify(incompleteValue))}`,
+      },
+      writable: true,
+    });
+
+    const { result } = renderHook(() => useAtom(billingCheckoutSessionAtom), {
+      wrapper: Wrapper,
+    });
+
+    // Should fall back to default value
+    expect(result.current[0]).toEqual(BILLING_CHECKOUT_SESSION_DEFAULT_VALUE);
+  });
+
+  it('should preserve other URL parameters when updating', () => {
+    // Set up URL with multiple params
+    Object.defineProperty(window, 'location', {
+      value: {
+        ...mockLocation,
+        search: '?otherParam=value&anotherParam=123',
+      },
+      writable: true,
+    });
+
+    const { result } = renderHook(() => useAtom(billingCheckoutSessionAtom), {
+      wrapper: Wrapper,
+    });
+
+    const newValue = {
+      plan: BillingPlanKey.ENTERPRISE,
+      interval: SubscriptionInterval.Year,
+      requirePaymentMethod: false,
+    };
+
+    act(() => {
+      result.current[1](newValue);
+    });
+
+    // Check that other params are preserved
+    expect(mockHistory.replaceState).toHaveBeenCalledWith(
+      {},
+      '',
+      `/test?otherParam=value&anotherParam=123&billingCheckoutSession=${encodeURIComponent(JSON.stringify(newValue))}`,
+    );
+  });
+});

--- a/packages/twenty-front/src/modules/auth/states/__tests__/billingCheckoutSessionAtom.test.tsx
+++ b/packages/twenty-front/src/modules/auth/states/__tests__/billingCheckoutSessionAtom.test.tsx
@@ -10,7 +10,6 @@ import {
 } from '~/generated-metadata/graphql';
 import { billingCheckoutSessionAtom } from '../billingCheckoutSessionAtom';
 
-// Mock the window.location and history API
 const mockLocation = {
   pathname: '/test',
   search: '',
@@ -20,9 +19,7 @@ const mockHistory = {
   replaceState: jest.fn(),
 };
 
-// Setup the test environment
 const setupTest = () => {
-  // Mock window.location and history
   Object.defineProperty(window, 'location', {
     value: mockLocation,
     writable: true,
@@ -33,11 +30,9 @@ const setupTest = () => {
     writable: true,
   });
 
-  // Reset mocks
   jest.clearAllMocks();
 };
 
-// Wrapper component for the tests
 const Wrapper = ({ children }: { children: React.ReactNode }) => (
   <Provider>
     <MemoryRouter>{children}</MemoryRouter>
@@ -58,7 +53,6 @@ describe('billingCheckoutSessionAtom', () => {
   });
 
   it('should read value from URL params when present', () => {
-    // Set up URL with billingCheckoutSession param
     const customValue = {
       plan: BillingPlanKey.ENTERPRISE,
       interval: SubscriptionInterval.Year,
@@ -95,7 +89,6 @@ describe('billingCheckoutSessionAtom', () => {
       result.current[1](newValue);
     });
 
-    // Check that history.replaceState was called with the correct URL
     expect(mockHistory.replaceState).toHaveBeenCalledWith(
       {},
       '',
@@ -104,7 +97,6 @@ describe('billingCheckoutSessionAtom', () => {
   });
 
   it('should handle invalid JSON in URL params', () => {
-    // Set up URL with invalid JSON
     Object.defineProperty(window, 'location', {
       value: {
         ...mockLocation,
@@ -117,15 +109,12 @@ describe('billingCheckoutSessionAtom', () => {
       wrapper: Wrapper,
     });
 
-    // Should fall back to default value
     expect(result.current[0]).toEqual(BILLING_CHECKOUT_SESSION_DEFAULT_VALUE);
   });
 
   it('should handle JSON with missing required properties', () => {
-    // Set up URL with incomplete JSON
     const incompleteValue = {
       plan: BillingPlanKey.ENTERPRISE,
-      // Missing interval and requirePaymentMethod
     };
 
     Object.defineProperty(window, 'location', {
@@ -140,12 +129,10 @@ describe('billingCheckoutSessionAtom', () => {
       wrapper: Wrapper,
     });
 
-    // Should fall back to default value
     expect(result.current[0]).toEqual(BILLING_CHECKOUT_SESSION_DEFAULT_VALUE);
   });
 
   it('should preserve other URL parameters when updating', () => {
-    // Set up URL with multiple params
     Object.defineProperty(window, 'location', {
       value: {
         ...mockLocation,
@@ -168,7 +155,6 @@ describe('billingCheckoutSessionAtom', () => {
       result.current[1](newValue);
     });
 
-    // Check that other params are preserved
     expect(mockHistory.replaceState).toHaveBeenCalledWith(
       {},
       '',

--- a/packages/twenty-front/src/modules/auth/states/billingCheckoutSessionAtom.ts
+++ b/packages/twenty-front/src/modules/auth/states/billingCheckoutSessionAtom.ts
@@ -1,0 +1,45 @@
+import { BillingCheckoutSession } from '@/auth/types/billingCheckoutSession.type';
+import { BILLING_CHECKOUT_SESSION_DEFAULT_VALUE } from '@/billing/constants/BillingCheckoutSessionDefaultValue';
+import { atomWithStorage } from 'jotai/utils';
+
+// Create a Jotai atom that syncs with URL query parameters
+export const billingCheckoutSessionAtom =
+  atomWithStorage<BillingCheckoutSession>(
+    'billingCheckoutSession',
+    BILLING_CHECKOUT_SESSION_DEFAULT_VALUE,
+    {
+      getItem: (key) => {
+        const searchParams = new URLSearchParams(window.location.search);
+        const value = searchParams.get(key);
+        if (!value) return BILLING_CHECKOUT_SESSION_DEFAULT_VALUE;
+
+        try {
+          const parsed = JSON.parse(value);
+          if (
+            typeof parsed === 'object' &&
+            parsed !== null &&
+            'plan' in parsed &&
+            'interval' in parsed &&
+            'requirePaymentMethod' in parsed
+          ) {
+            return parsed as BillingCheckoutSession;
+          }
+          return BILLING_CHECKOUT_SESSION_DEFAULT_VALUE;
+        } catch (e) {
+          return BILLING_CHECKOUT_SESSION_DEFAULT_VALUE;
+        }
+      },
+      setItem: (key, value) => {
+        const searchParams = new URLSearchParams(window.location.search);
+        searchParams.set(key, JSON.stringify(value));
+        const newUrl = `${window.location.pathname}?${searchParams.toString()}`;
+        window.history.replaceState({}, '', newUrl);
+      },
+      removeItem: (key) => {
+        const searchParams = new URLSearchParams(window.location.search);
+        searchParams.delete(key);
+        const newUrl = `${window.location.pathname}?${searchParams.toString()}`;
+        window.history.replaceState({}, '', newUrl);
+      },
+    },
+  );

--- a/packages/twenty-front/src/modules/domain-manager/hooks/useBuildSearchParamsFromUrlSyncedStates.ts
+++ b/packages/twenty-front/src/modules/domain-manager/hooks/useBuildSearchParamsFromUrlSyncedStates.ts
@@ -1,16 +1,16 @@
 import { animateModalState } from '@/auth/states/animateModalState';
-import { billingCheckoutSessionState } from '@/auth/states/billingCheckoutSessionState';
+import { billingCheckoutSessionAtom } from '@/auth/states/billingCheckoutSessionAtom';
 import { BILLING_CHECKOUT_SESSION_DEFAULT_VALUE } from '@/billing/constants/BillingCheckoutSessionDefaultValue';
+import { useAtomValue } from 'jotai';
 import { useRecoilCallback } from 'recoil';
 
 export const useBuildSearchParamsFromUrlSyncedStates = () => {
+  const billingCheckoutSession = useAtomValue(billingCheckoutSessionAtom);
+
   const buildSearchParamsFromUrlSyncedStates = useRecoilCallback(
     ({ snapshot }) =>
       async () => {
         const animateModal = snapshot.getLoadable(animateModalState).getValue();
-        const billingCheckoutSession = snapshot
-          .getLoadable(billingCheckoutSessionState)
-          .getValue();
 
         const output = {
           ...(billingCheckoutSession !== BILLING_CHECKOUT_SESSION_DEFAULT_VALUE
@@ -23,7 +23,7 @@ export const useBuildSearchParamsFromUrlSyncedStates = () => {
 
         return output;
       },
-    [],
+    [billingCheckoutSession],
   );
 
   return {

--- a/packages/twenty-front/src/pages/onboarding/ChooseYourPlan.tsx
+++ b/packages/twenty-front/src/pages/onboarding/ChooseYourPlan.tsx
@@ -1,7 +1,7 @@
 import { SubTitle } from '@/auth/components/SubTitle';
 import { Title } from '@/auth/components/Title';
 import { useAuth } from '@/auth/hooks/useAuth';
-import { billingCheckoutSessionState } from '@/auth/states/billingCheckoutSessionState';
+import { billingCheckoutSessionAtom } from '@/auth/states/billingCheckoutSessionAtom';
 import { SubscriptionBenefit } from '@/billing/components/SubscriptionBenefit';
 import { SubscriptionPrice } from '@/billing/components/SubscriptionPrice';
 import { TrialCard } from '@/billing/components/TrialCard';
@@ -10,7 +10,8 @@ import { isBillingPriceLicensed } from '@/billing/utils/isBillingPriceLicensed';
 import { billingState } from '@/client-config/states/billingState';
 import styled from '@emotion/styled';
 import { Trans, useLingui } from '@lingui/react/macro';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { useAtom } from 'jotai';
+import { useRecoilValue } from 'recoil';
 import { isDefined } from 'twenty-shared/utils';
 import { Loader } from 'twenty-ui/feedback';
 import { CardPicker, MainButton } from 'twenty-ui/input';
@@ -91,8 +92,8 @@ export const ChooseYourPlan = () => {
   const billing = useRecoilValue(billingState);
   const { t } = useLingui();
 
-  const [billingCheckoutSession, setBillingCheckoutSession] = useRecoilState(
-    billingCheckoutSessionState,
+  const [billingCheckoutSession, setBillingCheckoutSession] = useAtom(
+    billingCheckoutSessionAtom,
   );
 
   const { data: plans } = useBillingBaseProductPricesQuery();

--- a/yarn.lock
+++ b/yarn.lock
@@ -40025,6 +40025,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jotai-location@npm:^0.5.5":
+  version: 0.5.5
+  resolution: "jotai-location@npm:0.5.5"
+  peerDependencies:
+    jotai: ">=1.11.0"
+  checksum: 10c0/39e60235187f6ea4336b3d8b0b528f1c9532e2259b5431481e94ed5ea8a75e3e9152965e127870eef6208e81108a150e4292ec7fd7c5d2b2e638b38858cf1ae0
+  languageName: node
+  linkType: hard
+
 "jotai@npm:1.3.9":
   version: 1.3.9
   resolution: "jotai@npm:1.3.9"
@@ -40102,6 +40111,21 @@ __metadata:
     jotai-zustand:
       optional: true
   checksum: 10c0/89143947a868fde093706aa592db550a443ea51721a46e61e5616d6e282d1af76b4e8b918d8648f773085c95dbd011a2523c5ae5ca41a20f8e6b2630ab2eb689
+  languageName: node
+  linkType: hard
+
+"jotai@npm:^2.12.2":
+  version: 2.12.2
+  resolution: "jotai@npm:2.12.2"
+  peerDependencies:
+    "@types/react": ">=17.0.0"
+    react: ">=17.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    react:
+      optional: true
+  checksum: 10c0/df135d8a8c635df5d34bdb30b2e24afa93292c9c0bdac589ed9df31da50cec8c4820f66d04f23fa05f6c0ed0726e86c83b0767ca9c6abae4d281a253526d2db3
   languageName: node
   linkType: hard
 
@@ -55004,6 +55028,8 @@ __metadata:
     eslint-plugin-unicorn: "npm:^51.0.1"
     eslint-plugin-unused-imports: "npm:^3.0.0"
     file-saver: "npm:^2.0.5"
+    jotai: "npm:^2.12.2"
+    jotai-location: "npm:^0.5.5"
     optionator: "npm:^0.9.1"
     recoil-sync: "npm:^0.2.0"
     transliteration: "npm:^2.3.5"


### PR DESCRIPTION
I spent 4 hours trying to find a decent solution to patch the bug in RecoilSync that prevents people from using the development environment on Firefox, but couldn't find a decent solution.

Since recoil is going to be deprecated I think we don't want to over-invest in that direction. Instead, I decided to build a POC with Jotai.

I asked the AI to write scripts migrate the codebase to Jotai and it seems that it will be possible to do so in another PR