### PR TITLE
Remove status tag for workflow runs

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-show/components/CardComponents.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-show/components/CardComponents.tsx
@@ -101,7 +101,7 @@ export const CardComponents: Record<CardType, CardComponentType> = {
     <>
       <WorkflowRunVisualizerEffect workflowRunId={targetableObject.id} />
 
-      <WorkflowRunVisualizer workflowRunId={targetableObject.id} />
+      <WorkflowRunVisualizer />
     </>
   ),
   [CardType.WorkflowRunOutputCard]: ({ targetableObject }) => (

--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasBase.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasBase.tsx
@@ -28,8 +28,8 @@ import '@xyflow/react/dist/style.css';
 import React, { useEffect, useMemo, useRef } from 'react';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { isDefined } from 'twenty-shared/utils';
-import { THEME_COMMON } from 'twenty-ui/theme';
 import { Tag, TagColor } from 'twenty-ui/components';
+import { THEME_COMMON } from 'twenty-ui/theme';
 
 const StyledResetReactflowStyles = styled.div`
   height: 100%;
@@ -84,9 +84,7 @@ export const WorkflowDiagramCanvasBase = ({
   nodeTypes,
   edgeTypes,
   children,
-  tagContainerTestId,
-  tagColor,
-  tagText,
+  statusTagOptions,
 }: {
   nodeTypes: Partial<
     Record<
@@ -111,9 +109,11 @@ export const WorkflowDiagramCanvasBase = ({
     >
   >;
   children?: React.ReactNode;
-  tagContainerTestId: string;
-  tagColor: TagColor;
-  tagText: string;
+  statusTagOptions?: {
+    containerTestId: string;
+    color: TagColor;
+    text: string;
+  };
 }) => {
   const theme = useTheme();
 
@@ -257,9 +257,13 @@ export const WorkflowDiagramCanvasBase = ({
         {children}
       </ReactFlow>
 
-      <StyledStatusTagContainer data-testid={tagContainerTestId}>
-        <Tag color={tagColor} text={tagText} />
-      </StyledStatusTagContainer>
+      {isDefined(statusTagOptions) && (
+        <StyledStatusTagContainer
+          data-testid={statusTagOptions.containerTestId}
+        >
+          <Tag color={statusTagOptions.color} text={statusTagOptions.text} />
+        </StyledStatusTagContainer>
+      )}
     </StyledResetReactflowStyles>
   );
 };

--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasEditable.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasEditable.tsx
@@ -28,9 +28,11 @@ export const WorkflowDiagramCanvasEditable = ({
         edgeTypes={{
           default: WorkflowDiagramDefaultEdge,
         }}
-        tagContainerTestId="workflow-visualizer-status"
-        tagColor={tagProps.color}
-        tagText={tagProps.text}
+        statusTagOptions={{
+          containerTestId: 'workflow-visualizer-status',
+          color: tagProps.color,
+          text: tagProps.text,
+        }}
       />
 
       <WorkflowDiagramCanvasEditableEffect />

--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasReadonly.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasReadonly.tsx
@@ -28,9 +28,11 @@ export const WorkflowDiagramCanvasReadonly = ({
           default: WorkflowDiagramDefaultEdge,
           success: WorkflowDiagramSuccessEdge,
         }}
-        tagContainerTestId="workflow-visualizer-status"
-        tagColor={tagProps.color}
-        tagText={tagProps.text}
+        statusTagOptions={{
+          containerTestId: 'workflow-visualizer-status',
+          color: tagProps.color,
+          text: tagProps.text,
+        }}
       />
 
       <WorkflowDiagramCanvasReadonlyEffect />

--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowRunDiagramCanvas.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowRunDiagramCanvas.tsx
@@ -1,21 +1,11 @@
-import { WorkflowRunStatus } from '@/workflow/types/Workflow';
 import { WorkflowDiagramCanvasBase } from '@/workflow/workflow-diagram/components/WorkflowDiagramCanvasBase';
 import { WorkflowDiagramDefaultEdge } from '@/workflow/workflow-diagram/components/WorkflowDiagramDefaultEdge';
 import { WorkflowDiagramStepNodeReadonly } from '@/workflow/workflow-diagram/components/WorkflowDiagramStepNodeReadonly';
 import { WorkflowDiagramSuccessEdge } from '@/workflow/workflow-diagram/components/WorkflowDiagramSuccessEdge';
 import { WorkflowRunDiagramCanvasEffect } from '@/workflow/workflow-diagram/components/WorkflowRunDiagramCanvasEffect';
-import { getWorkflowRunStatusTagProps } from '@/workflow/workflow-diagram/utils/getWorkflowRunStatusTagProps';
 import { ReactFlowProvider } from '@xyflow/react';
 
-export const WorkflowRunDiagramCanvas = ({
-  workflowRunStatus,
-}: {
-  workflowRunStatus: WorkflowRunStatus;
-}) => {
-  const tagProps = getWorkflowRunStatusTagProps({
-    workflowRunStatus,
-  });
-
+export const WorkflowRunDiagramCanvas = () => {
   return (
     <ReactFlowProvider>
       <WorkflowDiagramCanvasBase
@@ -26,9 +16,6 @@ export const WorkflowRunDiagramCanvas = ({
           default: WorkflowDiagramDefaultEdge,
           success: WorkflowDiagramSuccessEdge,
         }}
-        tagContainerTestId="workflow-run-status"
-        tagColor={tagProps.color}
-        tagText={tagProps.text}
       />
 
       <WorkflowRunDiagramCanvasEffect />

--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowRunVisualizer.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowRunVisualizer.tsx
@@ -1,26 +1,14 @@
-import { useWorkflowRun } from '@/workflow/hooks/useWorkflowRun';
 import { WorkflowRunDiagramCanvas } from '@/workflow/workflow-diagram/components/WorkflowRunDiagramCanvas';
 import styled from '@emotion/styled';
-import { isDefined } from 'twenty-shared/utils';
 
 const StyledContainer = styled.div`
   height: 100%;
 `;
 
-export const WorkflowRunVisualizer = ({
-  workflowRunId,
-}: {
-  workflowRunId: string;
-}) => {
-  const workflowRun = useWorkflowRun({ workflowRunId });
-
-  if (!isDefined(workflowRun)) {
-    return null;
-  }
-
+export const WorkflowRunVisualizer = () => {
   return (
     <StyledContainer>
-      <WorkflowRunDiagramCanvas workflowRunStatus={workflowRun.status} />
+      <WorkflowRunDiagramCanvas />
     </StyledContainer>
   );
 };


### PR DESCRIPTION
The status tag was redundant for workflows runs as there was already a similar tag in the board, displayed on the left of the visualizer.

In this PR:

- Refactor the `WorkflowDiagramCanvasBase` component to make it easier not to provide a status tag; it's easier to type a whole object as optional than three independent properties that must be either all defined or none of them
- Do not display the workflow run's status tag

## Before

![CleanShot 2025-04-11 at 14 09 06@2x](https://github.com/user-attachments/assets/3737739a-0644-492f-a373-d98beb3697c4)

## After

![CleanShot 2025-04-11 at 14 08 56@2x](https://github.com/user-attachments/assets/6129a4aa-3a0c-4313-8fb9-97bf7d2200f1)
