### PR TITLE
Improving empty filter chip UI

### DIFF
--- a/packages/twenty-front/src/modules/views/components/EditableFilterChip.tsx
+++ b/packages/twenty-front/src/modules/views/components/EditableFilterChip.tsx
@@ -2,6 +2,7 @@ import { useFieldMetadataItemById } from '@/object-metadata/hooks/useFieldMetada
 import { getOperandLabelShort } from '@/object-record/object-filter-dropdown/utils/getOperandLabel';
 import { RecordFilter } from '@/object-record/record-filter/types/RecordFilter';
 import { SortOrFilterChip } from '@/views/components/SortOrFilterChip';
+import { isNonEmptyString } from '@sniptt/guards';
 import { useIcons } from 'twenty-ui/display';
 
 type EditableFilterChipProps = {
@@ -21,11 +22,15 @@ export const EditableFilterChip = ({
 
   const FieldMetadataItemIcon = getIcon(fieldMetadataItem.icon);
 
+  const operandLabelShort = getOperandLabelShort(viewFilter.operand);
+
+  const labelKey = `${viewFilter.label}${isNonEmptyString(viewFilter.value) ? operandLabelShort : ''}`;
+
   return (
     <SortOrFilterChip
       key={viewFilter.id}
       testId={viewFilter.id}
-      labelKey={`${viewFilter.label}${getOperandLabelShort(viewFilter.operand)}`}
+      labelKey={labelKey}
       labelValue={viewFilter.displayValue}
       Icon={FieldMetadataItemIcon}
       onRemove={onRemove}


### PR DESCRIPTION
This PR is simply removing the : character on the filter chip when the filter value is empty.

The issue originally was about removing the filter chip when closing the filter value dropdown with an empty value but it is already the default behavior.

Fixes https://github.com/twentyhq/core-team-issues/issues/658