### PR TITLE
Remove user action from waitFor in stories

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/__stories__/AddressFieldInput.stories.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/__stories__/AddressFieldInput.stories.tsx
@@ -146,8 +146,9 @@ export const Enter: Story = {
   play: async () => {
     expect(enterJestFn).toHaveBeenCalledTimes(0);
 
+    userEvent.keyboard('{enter}');
+
     await waitFor(() => {
-      userEvent.keyboard('{enter}');
       expect(enterJestFn).toHaveBeenCalledTimes(1);
     });
   },

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/__stories__/AddressFieldInput.stories.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/__stories__/AddressFieldInput.stories.tsx
@@ -146,7 +146,7 @@ export const Enter: Story = {
   play: async () => {
     expect(enterJestFn).toHaveBeenCalledTimes(0);
 
-    userEvent.keyboard('{enter}');
+    await userEvent.keyboard('{enter}');
 
     await waitFor(() => {
       expect(enterJestFn).toHaveBeenCalledTimes(1);

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/__stories__/NumberFieldInput.stories.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/__stories__/NumberFieldInput.stories.tsx
@@ -139,9 +139,9 @@ export const Default: Story = {};
 export const Enter: Story = {
   play: async () => {
     expect(enterJestFn).toHaveBeenCalledTimes(0);
+    userEvent.keyboard('{enter}');
 
     await waitFor(() => {
-      userEvent.keyboard('{enter}');
       expect(enterJestFn).toHaveBeenCalledTimes(1);
     });
   },
@@ -151,8 +151,9 @@ export const Escape: Story = {
   play: async () => {
     expect(escapeJestfn).toHaveBeenCalledTimes(0);
 
+    userEvent.keyboard('{esc}');
+
     await waitFor(() => {
-      userEvent.keyboard('{esc}');
       expect(escapeJestfn).toHaveBeenCalledTimes(1);
     });
   },
@@ -166,8 +167,9 @@ export const ClickOutside: Story = {
 
     const emptyDiv = canvas.getByTestId('data-field-input-click-outside-div');
 
+    userEvent.click(emptyDiv);
+
     await waitFor(() => {
-      userEvent.click(emptyDiv);
       expect(clickOutsideJestFn).toHaveBeenCalledTimes(1);
     });
   },
@@ -177,8 +179,8 @@ export const Tab: Story = {
   play: async () => {
     expect(tabJestFn).toHaveBeenCalledTimes(0);
 
+    userEvent.keyboard('{tab}');
     await waitFor(() => {
-      userEvent.keyboard('{tab}');
       expect(tabJestFn).toHaveBeenCalledTimes(1);
     });
   },
@@ -188,8 +190,9 @@ export const ShiftTab: Story = {
   play: async () => {
     expect(shiftTabJestFn).toHaveBeenCalledTimes(0);
 
+    userEvent.keyboard('{shift>}{tab}');
+
     await waitFor(() => {
-      userEvent.keyboard('{shift>}{tab}');
       expect(shiftTabJestFn).toHaveBeenCalledTimes(1);
     });
   },

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/__stories__/NumberFieldInput.stories.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/__stories__/NumberFieldInput.stories.tsx
@@ -139,7 +139,7 @@ export const Default: Story = {};
 export const Enter: Story = {
   play: async () => {
     expect(enterJestFn).toHaveBeenCalledTimes(0);
-    userEvent.keyboard('{enter}');
+    await userEvent.keyboard('{enter}');
 
     await waitFor(() => {
       expect(enterJestFn).toHaveBeenCalledTimes(1);
@@ -151,7 +151,7 @@ export const Escape: Story = {
   play: async () => {
     expect(escapeJestfn).toHaveBeenCalledTimes(0);
 
-    userEvent.keyboard('{esc}');
+    await userEvent.keyboard('{esc}');
 
     await waitFor(() => {
       expect(escapeJestfn).toHaveBeenCalledTimes(1);
@@ -167,7 +167,7 @@ export const ClickOutside: Story = {
 
     const emptyDiv = canvas.getByTestId('data-field-input-click-outside-div');
 
-    userEvent.click(emptyDiv);
+    await userEvent.click(emptyDiv);
 
     await waitFor(() => {
       expect(clickOutsideJestFn).toHaveBeenCalledTimes(1);
@@ -179,7 +179,8 @@ export const Tab: Story = {
   play: async () => {
     expect(tabJestFn).toHaveBeenCalledTimes(0);
 
-    userEvent.keyboard('{tab}');
+    await userEvent.keyboard('{tab}');
+
     await waitFor(() => {
       expect(tabJestFn).toHaveBeenCalledTimes(1);
     });
@@ -190,7 +191,7 @@ export const ShiftTab: Story = {
   play: async () => {
     expect(shiftTabJestFn).toHaveBeenCalledTimes(0);
 
-    userEvent.keyboard('{shift>}{tab}');
+    await userEvent.keyboard('{shift>}{tab}');
 
     await waitFor(() => {
       expect(shiftTabJestFn).toHaveBeenCalledTimes(1);

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/__stories__/RatingFieldInput.stories.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/__stories__/RatingFieldInput.stories.tsx
@@ -9,7 +9,6 @@ import { RecordFieldComponentInstanceContext } from '@/object-record/record-fiel
 import { DEFAULT_CELL_SCOPE } from '@/object-record/record-table/record-table-cell/hooks/useOpenRecordTableCellV2';
 import { getRecordFieldInputId } from '@/object-record/utils/getRecordFieldInputId';
 import { FieldMetadataType } from 'twenty-shared/types';
-import { isDefined } from 'twenty-shared/utils';
 import { FieldRatingValue } from '../../../../types/FieldMetadata';
 import { useRatingField } from '../../../hooks/useRatingField';
 import { RatingFieldInput, RatingFieldInputProps } from '../RatingFieldInput';
@@ -118,11 +117,10 @@ export const Submit: Story = {
     const input = canvas.getByRole('slider', { name: 'Rating' });
     const firstStar = input.firstElementChild;
 
+    userEvent.click(firstStar);
+
     await waitFor(() => {
-      if (isDefined(firstStar)) {
-        userEvent.click(firstStar);
-        expect(submitJestFn).toHaveBeenCalledTimes(1);
-      }
+      expect(submitJestFn).toHaveBeenCalledTimes(1);
     });
   },
 };

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/__stories__/RatingFieldInput.stories.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/__stories__/RatingFieldInput.stories.tsx
@@ -117,7 +117,7 @@ export const Submit: Story = {
     const input = canvas.getByRole('slider', { name: 'Rating' });
     const firstStar = input.firstElementChild;
 
-    userEvent.click(firstStar);
+    await userEvent.click(firstStar);
 
     await waitFor(() => {
       expect(submitJestFn).toHaveBeenCalledTimes(1);

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/__stories__/RichTextFieldInput.stories.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/__stories__/RichTextFieldInput.stories.tsx
@@ -111,7 +111,7 @@ export const Escape: Story = {
   play: async () => {
     expect(escapeJestFn).toHaveBeenCalledTimes(0);
 
-    userEvent.keyboard('{esc}');
+    await userEvent.keyboard('{esc}');
 
     await waitFor(() => {
       expect(escapeJestFn).toHaveBeenCalledTimes(1);
@@ -126,7 +126,7 @@ export const ClickOutside: Story = {
 
     const outsideElement = await canvas.findByTestId('click-outside-element');
 
-    userEvent.click(outsideElement);
+    await userEvent.click(outsideElement);
 
     await waitFor(() => {
       expect(clickOutsideJestFn).toHaveBeenCalledTimes(1);

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/__stories__/RichTextFieldInput.stories.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/__stories__/RichTextFieldInput.stories.tsx
@@ -111,8 +111,9 @@ export const Escape: Story = {
   play: async () => {
     expect(escapeJestFn).toHaveBeenCalledTimes(0);
 
+    userEvent.keyboard('{esc}');
+
     await waitFor(() => {
-      userEvent.keyboard('{esc}');
       expect(escapeJestFn).toHaveBeenCalledTimes(1);
     });
   },
@@ -123,9 +124,11 @@ export const ClickOutside: Story = {
     const canvas = within(canvasElement);
     expect(clickOutsideJestFn).toHaveBeenCalledTimes(0);
 
-    await waitFor(async () => {
-      const outsideElement = await canvas.findByTestId('click-outside-element');
-      userEvent.click(outsideElement);
+    const outsideElement = await canvas.findByTestId('click-outside-element');
+
+    userEvent.click(outsideElement);
+
+    await waitFor(() => {
       expect(clickOutsideJestFn).toHaveBeenCalledTimes(1);
     });
   },

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/__stories__/TextFieldInput.stories.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/__stories__/TextFieldInput.stories.tsx
@@ -132,8 +132,9 @@ export const Enter: Story = {
   play: async () => {
     expect(enterJestFn).toHaveBeenCalledTimes(0);
 
+    userEvent.keyboard('{enter}');
+
     await waitFor(() => {
-      userEvent.keyboard('{enter}');
       expect(enterJestFn).toHaveBeenCalledTimes(1);
     });
   },
@@ -143,8 +144,9 @@ export const Escape: Story = {
   play: async () => {
     expect(escapeJestfn).toHaveBeenCalledTimes(0);
 
+    userEvent.keyboard('{esc}');
+
     await waitFor(() => {
-      userEvent.keyboard('{esc}');
       expect(escapeJestfn).toHaveBeenCalledTimes(1);
     });
   },
@@ -158,8 +160,9 @@ export const ClickOutside: Story = {
 
     const emptyDiv = canvas.getByTestId('data-field-input-click-outside-div');
 
+    userEvent.click(emptyDiv);
+
     await waitFor(() => {
-      userEvent.click(emptyDiv);
       expect(clickOutsideJestFn).toHaveBeenCalled();
     });
   },
@@ -169,8 +172,9 @@ export const Tab: Story = {
   play: async () => {
     expect(tabJestFn).toHaveBeenCalledTimes(0);
 
+    userEvent.keyboard('{tab}');
+
     await waitFor(() => {
-      userEvent.keyboard('{tab}');
       expect(tabJestFn).toHaveBeenCalledTimes(1);
     });
   },
@@ -180,8 +184,9 @@ export const ShiftTab: Story = {
   play: async () => {
     expect(shiftTabJestFn).toHaveBeenCalledTimes(0);
 
+    userEvent.keyboard('{shift>}{tab}');
+
     await waitFor(() => {
-      userEvent.keyboard('{shift>}{tab}');
       expect(shiftTabJestFn).toHaveBeenCalledTimes(1);
     });
   },

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/__stories__/TextFieldInput.stories.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/__stories__/TextFieldInput.stories.tsx
@@ -132,7 +132,7 @@ export const Enter: Story = {
   play: async () => {
     expect(enterJestFn).toHaveBeenCalledTimes(0);
 
-    userEvent.keyboard('{enter}');
+    await userEvent.keyboard('{enter}');
 
     await waitFor(() => {
       expect(enterJestFn).toHaveBeenCalledTimes(1);
@@ -144,7 +144,7 @@ export const Escape: Story = {
   play: async () => {
     expect(escapeJestfn).toHaveBeenCalledTimes(0);
 
-    userEvent.keyboard('{esc}');
+    await userEvent.keyboard('{esc}');
 
     await waitFor(() => {
       expect(escapeJestfn).toHaveBeenCalledTimes(1);
@@ -160,7 +160,7 @@ export const ClickOutside: Story = {
 
     const emptyDiv = canvas.getByTestId('data-field-input-click-outside-div');
 
-    userEvent.click(emptyDiv);
+    await userEvent.click(emptyDiv);
 
     await waitFor(() => {
       expect(clickOutsideJestFn).toHaveBeenCalled();
@@ -172,7 +172,7 @@ export const Tab: Story = {
   play: async () => {
     expect(tabJestFn).toHaveBeenCalledTimes(0);
 
-    userEvent.keyboard('{tab}');
+    await userEvent.keyboard('{tab}');
 
     await waitFor(() => {
       expect(tabJestFn).toHaveBeenCalledTimes(1);
@@ -184,7 +184,7 @@ export const ShiftTab: Story = {
   play: async () => {
     expect(shiftTabJestFn).toHaveBeenCalledTimes(0);
 
-    userEvent.keyboard('{shift>}{tab}');
+    await userEvent.keyboard('{shift>}{tab}');
 
     await waitFor(() => {
       expect(shiftTabJestFn).toHaveBeenCalledTimes(1);

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/__stories__/TextFieldInput.stories.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/__stories__/TextFieldInput.stories.tsx
@@ -11,6 +11,7 @@ import { FieldMetadataType } from '~/generated/graphql';
 import { StorybookFieldInputDropdownFocusIdSetterEffect } from '~/testing/components/StorybookFieldInputDropdownFocusIdSetterEffect';
 import { I18nFrontDecorator } from '~/testing/decorators/I18nFrontDecorator';
 import { SnackBarDecorator } from '~/testing/decorators/SnackBarDecorator';
+import { sleep } from '~/utils/sleep';
 import { useTextField } from '../../../hooks/useTextField';
 import { TextFieldInput, TextFieldInputProps } from '../TextFieldInput';
 const TextFieldValueSetterEffect = ({ value }: { value: string }) => {
@@ -131,6 +132,7 @@ export const Default: Story = {};
 export const Enter: Story = {
   play: async () => {
     expect(enterJestFn).toHaveBeenCalledTimes(0);
+    await sleep(100);
 
     await userEvent.keyboard('{enter}');
 
@@ -143,6 +145,7 @@ export const Enter: Story = {
 export const Escape: Story = {
   play: async () => {
     expect(escapeJestfn).toHaveBeenCalledTimes(0);
+    await sleep(100);
 
     await userEvent.keyboard('{esc}');
 
@@ -155,6 +158,7 @@ export const Escape: Story = {
 export const ClickOutside: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    await sleep(100);
 
     expect(clickOutsideJestFn).toHaveBeenCalledTimes(0);
 
@@ -171,6 +175,7 @@ export const ClickOutside: Story = {
 export const Tab: Story = {
   play: async () => {
     expect(tabJestFn).toHaveBeenCalledTimes(0);
+    await sleep(100);
 
     await userEvent.keyboard('{tab}');
 
@@ -183,6 +188,7 @@ export const Tab: Story = {
 export const ShiftTab: Story = {
   play: async () => {
     expect(shiftTabJestFn).toHaveBeenCalledTimes(0);
+    await sleep(100);
 
     await userEvent.keyboard('{shift>}{tab}');
 

--- a/packages/twenty-front/src/modules/object-record/record-index/export/hooks/__tests__/useExportFetchRecords.test.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/export/hooks/__tests__/useExportFetchRecords.test.ts
@@ -206,7 +206,7 @@ describe('useRecordData', () => {
         result.current.tableData.getTableData();
       });
 
-      await waitFor(async () => {
+      await waitFor(() => {
         expect(callback).toHaveBeenCalledWith(
           [mockPerson],
           [
@@ -297,7 +297,7 @@ describe('useRecordData', () => {
         result.current.tableData.getTableData();
       });
 
-      await waitFor(async () => {
+      await waitFor(() => {
         expect(callback).toHaveBeenCalledWith([mockPerson], []);
       });
     });

--- a/packages/twenty-front/src/modules/ui/input/components/__stories__/IconPicker.stories.tsx
+++ b/packages/twenty-front/src/modules/ui/input/components/__stories__/IconPicker.stories.tsx
@@ -5,8 +5,8 @@ import { expect, userEvent, within } from '@storybook/test';
 import { IconsProviderDecorator } from '~/testing/decorators/IconsProviderDecorator';
 import { sleep } from '~/utils/sleep';
 
-import { IconPicker, IconPickerProps } from '../IconPicker';
 import { ComponentDecorator } from 'twenty-ui/testing';
+import { IconPicker, IconPickerProps } from '../IconPicker';
 
 type RenderProps = IconPickerProps;
 const Render = (args: RenderProps) => {
@@ -123,7 +123,7 @@ export const WithSearchAndClose: Story = {
       name: 'Click to select icon (selected: IconBuildingSkyscraper)',
     });
 
-    userEvent.click(iconPickerButton);
+    await userEvent.click(iconPickerButton);
 
     await sleep(500);
 

--- a/packages/twenty-front/src/modules/ui/layout/dropdown/components/__stories__/Dropdown.stories.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/dropdown/components/__stories__/Dropdown.stories.tsx
@@ -95,13 +95,15 @@ export const Empty: Story = {
     await userEvent.click(buttons[0]);
 
     await waitFor(() => {
-      expect(fakeMenu).not.toBeInTheDocument();
+      const fakeMenuBis = canvas.queryByTestId('dropdown-content');
+      expect(fakeMenuBis).not.toBeInTheDocument();
     });
 
     await userEvent.click(buttons[0]);
+    const fakeMenuTer = await canvas.findByTestId('dropdown-content');
 
     await waitFor(() => {
-      expect(fakeMenu).toBeInTheDocument();
+      expect(fakeMenuTer).toBeInTheDocument();
     });
   },
 };

--- a/packages/twenty-front/src/modules/ui/layout/dropdown/components/__stories__/DropdownMenu.stories.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/dropdown/components/__stories__/DropdownMenu.stories.tsx
@@ -84,7 +84,7 @@ export const Empty: Story = {
     const canvas = within(document.body);
 
     const buttons = await canvas.findAllByRole('button');
-    userEvent.click(buttons[0]);
+    await userEvent.click(buttons[0]);
 
     const fakeMenu = await canvas.findByTestId('dropdown-content');
 
@@ -92,13 +92,13 @@ export const Empty: Story = {
       expect(fakeMenu).toBeInTheDocument();
     });
 
-    userEvent.click(buttons[0]);
+    await userEvent.click(buttons[0]);
 
     await waitFor(() => {
       expect(fakeMenu).not.toBeInTheDocument();
     });
 
-    userEvent.click(buttons[0]);
+    await userEvent.click(buttons[0]);
 
     await waitFor(() => {
       expect(fakeMenu).toBeInTheDocument();
@@ -207,7 +207,7 @@ const playInteraction: PlayFunction<any, any> = async () => {
   const canvas = within(document.body);
 
   const buttons = await canvas.findAllByRole('button');
-  userEvent.click(buttons[0]);
+  await userEvent.click(buttons[0]);
 
   await waitFor(() => {
     expect(canvas.getByText('Company A')).toBeInTheDocument();
@@ -265,13 +265,13 @@ export const SearchWithLoadingMenu: Story = {
 
     const buttons = await canvas.findAllByRole('button');
 
-    userEvent.click(buttons[0]);
+    await userEvent.click(buttons[0]);
 
     await waitFor(() => {
       expect(canvas.getByDisplayValue('query')).toBeInTheDocument();
     });
 
-    userEvent.click(buttons[0]);
+    await userEvent.click(buttons[0]);
 
     await waitFor(() => {
       expect(canvas.queryByDisplayValue('query')).not.toBeInTheDocument();

--- a/packages/twenty-front/src/modules/ui/layout/dropdown/components/__stories__/DropdownMenu.stories.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/dropdown/components/__stories__/DropdownMenu.stories.tsx
@@ -6,6 +6,15 @@ import { useState } from 'react';
 
 import { DropdownMenuSkeletonItem } from '@/ui/input/relation-picker/components/skeletons/DropdownMenuSkeletonItem';
 
+import { DropdownMenuHeaderLeftComponent } from '@/ui/layout/dropdown/components/DropdownMenuHeader/internal/DropdownMenuHeaderLeftComponent';
+import { Avatar, IconChevronLeft } from 'twenty-ui/display';
+import { Button } from 'twenty-ui/input';
+import {
+  MenuItem,
+  MenuItemMultiSelectAvatar,
+  MenuItemSelectAvatar,
+} from 'twenty-ui/navigation';
+import { ComponentDecorator } from 'twenty-ui/testing';
 import { Dropdown } from '../Dropdown';
 import { DropdownMenuHeader } from '../DropdownMenuHeader/DropdownMenuHeader';
 import { DropdownMenuInput } from '../DropdownMenuInput';
@@ -13,26 +22,17 @@ import { DropdownMenuItemsContainer } from '../DropdownMenuItemsContainer';
 import { DropdownMenuSearchInput } from '../DropdownMenuSearchInput';
 import { DropdownMenuSeparator } from '../DropdownMenuSeparator';
 import { StyledDropdownMenuSubheader } from '../StyledDropdownMenuSubheader';
-import { DropdownMenuHeaderLeftComponent } from '@/ui/layout/dropdown/components/DropdownMenuHeader/internal/DropdownMenuHeaderLeftComponent';
-import { Avatar, IconChevronLeft } from 'twenty-ui/display';
-import { Button } from 'twenty-ui/input';
-import { ComponentDecorator } from 'twenty-ui/testing';
-import {
-  MenuItem,
-  MenuItemMultiSelectAvatar,
-  MenuItemSelectAvatar,
-} from 'twenty-ui/navigation';
 
 const meta: Meta<typeof Dropdown> = {
   title: 'UI/Layout/Dropdown/Dropdown',
   component: Dropdown,
-
   decorators: [ComponentDecorator, (Story) => <Story />],
   args: {
     clickableComponent: <Button title="Open Dropdown" />,
     dropdownHotkeyScope: { scope: 'testDropdownMenu' },
     dropdownOffset: { x: 0, y: 8 },
     dropdownId: 'test-dropdown-id',
+    dropdownWidth: '200px',
   },
   argTypes: {
     clickableComponent: { control: false },
@@ -86,21 +86,21 @@ export const Empty: Story = {
     const buttons = await canvas.findAllByRole('button');
     userEvent.click(buttons[0]);
 
-    await waitFor(async () => {
-      const fakeMenu = await canvas.findByTestId('dropdown-content');
+    const fakeMenu = await canvas.findByTestId('dropdown-content');
+
+    await waitFor(() => {
       expect(fakeMenu).toBeInTheDocument();
     });
 
     userEvent.click(buttons[0]);
 
-    await waitFor(async () => {
-      const fakeMenu = canvas.queryByTestId('dropdown-content');
+    await waitFor(() => {
       expect(fakeMenu).not.toBeInTheDocument();
     });
 
     userEvent.click(buttons[0]);
-    await waitFor(async () => {
-      const fakeMenu = await canvas.findByTestId('dropdown-content');
+
+    await waitFor(() => {
       expect(fakeMenu).toBeInTheDocument();
     });
   },
@@ -209,7 +209,7 @@ const playInteraction: PlayFunction<any, any> = async () => {
   const buttons = await canvas.findAllByRole('button');
   userEvent.click(buttons[0]);
 
-  await waitFor(async () => {
+  await waitFor(() => {
     expect(canvas.getByText('Company A')).toBeInTheDocument();
   });
 };
@@ -265,13 +265,15 @@ export const SearchWithLoadingMenu: Story = {
 
     const buttons = await canvas.findAllByRole('button');
 
+    userEvent.click(buttons[0]);
+
     await waitFor(() => {
-      userEvent.click(buttons[0]);
       expect(canvas.getByDisplayValue('query')).toBeInTheDocument();
     });
 
+    userEvent.click(buttons[0]);
+
     await waitFor(() => {
-      userEvent.click(buttons[0]);
       expect(canvas.queryByDisplayValue('query')).not.toBeInTheDocument();
     });
   },

--- a/packages/twenty-front/src/pages/settings/__stories__/SettingsExperience.stories.tsx
+++ b/packages/twenty-front/src/pages/settings/__stories__/SettingsExperience.stories.tsx
@@ -46,11 +46,11 @@ export const DateTimeSettingsTimeFormat: Story = {
 
     const timeFormatSelect = await canvas.findByText('24h (08:33)');
 
-    userEvent.click(timeFormatSelect);
+    await userEvent.click(timeFormatSelect);
 
     const timeFormatOptions = await canvas.findByText('12h (8:33 AM)');
 
-    userEvent.click(timeFormatOptions);
+    await userEvent.click(timeFormatOptions);
 
     await canvas.findByText('12h (8:33 AM)');
   },
@@ -66,13 +66,13 @@ export const DateTimeSettingsTimezone: Story = {
       '(GMT-04:00) Eastern Daylight Time - New York',
     );
 
-    userEvent.click(timezoneSelect);
+    await userEvent.click(timezoneSelect);
 
     const systemSettingsOptions = await canvas.findByText(
       '(GMT-11:00) Niue Time',
     );
 
-    userEvent.click(systemSettingsOptions);
+    await userEvent.click(systemSettingsOptions);
 
     await canvas.findByText('(GMT-11:00) Niue Time');
   },
@@ -86,11 +86,11 @@ export const DateTimeSettingsDateFormat: Story = {
 
     const timeFormatSelect = await canvas.findByText('13 Jun, 2022');
 
-    userEvent.click(timeFormatSelect);
+    await userEvent.click(timeFormatSelect);
 
     const timeFormatOptions = await canvas.findByText('Jun 13, 2022');
 
-    userEvent.click(timeFormatOptions);
+    await userEvent.click(timeFormatOptions);
 
     await canvas.findByText('Jun 13, 2022');
   },

--- a/packages/twenty-ui/src/display/tooltip/__stories__/OverflowTextWithTooltip.stories.tsx
+++ b/packages/twenty-ui/src/display/tooltip/__stories__/OverflowTextWithTooltip.stories.tsx
@@ -24,6 +24,6 @@ export const Default: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const tooltip = await canvas.findByTestId('tooltip');
-    userEvent.hover(tooltip);
+    await userEvent.hover(tooltip);
   },
 };


### PR DESCRIPTION
As per title:
- waitFor is a loop that waits for a condition to be filled, it should be use to expect or in rare case to wait for element to be present in the page (in most cases, you can use findByXXX)
- user actions should not be in this loop, otherwise they will be triggered multiple times