### PR TITLE
Drop await usage for now-synchronous encodeFileToken()

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/factories/query-result-getters/handlers/activity-query-result-getter.handler.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/factories/query-result-getters/handlers/activity-query-result-getter.handler.ts
@@ -53,7 +53,7 @@ export class ActivityQueryResultGetterHandler
 
         imageUrl.searchParams.delete('token');
 
-        const signedPayload = await this.fileService.encodeFileToken({
+        const signedPayload = this.fileService.encodeFileToken({
           noteBlockId: block.id,
           workspaceId: workspaceId,
         });

--- a/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/factories/query-result-getters/handlers/attachment-query-result-getter.handler.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/factories/query-result-getters/handlers/attachment-query-result-getter.handler.ts
@@ -16,7 +16,7 @@ export class AttachmentQueryResultGetterHandler
       return attachment;
     }
 
-    const signedPayload = await this.fileService.encodeFileToken({
+    const signedPayload = this.fileService.encodeFileToken({
       attachmentId: attachment.id,
       workspaceId: workspaceId,
     });

--- a/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/factories/query-result-getters/handlers/person-query-result-getter.handler.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/factories/query-result-getters/handlers/person-query-result-getter.handler.ts
@@ -16,7 +16,7 @@ export class PersonQueryResultGetterHandler
       return person;
     }
 
-    const signedPayload = await this.fileService.encodeFileToken({
+    const signedPayload = this.fileService.encodeFileToken({
       personId: person.id,
       workspaceId: workspaceId,
     });

--- a/packages/twenty-server/src/engine/core-modules/user/user.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/user.resolver.ts
@@ -181,7 +181,7 @@ export class UserResolver {
     );
 
     if (workspaceMember && workspaceMember.avatarUrl) {
-      const avatarUrlToken = await this.fileService.encodeFileToken({
+      const avatarUrlToken = this.fileService.encodeFileToken({
         workspaceMemberId: workspaceMember.id,
         workspaceId: workspace.id,
       });
@@ -233,7 +233,7 @@ export class UserResolver {
 
     for (const workspaceMemberEntity of workspaceMemberEntities) {
       if (workspaceMemberEntity.avatarUrl) {
-        const avatarUrlToken = await this.fileService.encodeFileToken({
+        const avatarUrlToken = this.fileService.encodeFileToken({
           workspaceMemberId: workspaceMemberEntity.id,
           workspaceId: workspace.id,
         });
@@ -318,7 +318,7 @@ export class UserResolver {
       workspaceId,
     });
 
-    const fileToken = await this.fileService.encodeFileToken({
+    const fileToken = this.fileService.encodeFileToken({
       workspaceId: workspaceId,
     });
 

--- a/packages/twenty-server/src/engine/core-modules/workspace-invitation/workspace-invitation.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace-invitation/workspace-invitation.resolver.ts
@@ -69,7 +69,7 @@ export class WorkspaceInvitationResolver {
     let workspaceLogoWithToken = '';
 
     if (workspace.logo) {
-      const workspaceLogoToken = await this.fileService.encodeFileToken({
+      const workspaceLogoToken = this.fileService.encodeFileToken({
         workspaceId: workspace.id,
       });
 

--- a/packages/twenty-server/src/engine/core-modules/workspace/workspace.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/workspace.resolver.ts
@@ -153,7 +153,7 @@ export class WorkspaceResolver {
       logo: paths[0],
     });
 
-    const workspaceLogoToken = await this.fileService.encodeFileToken({
+    const workspaceLogoToken = this.fileService.encodeFileToken({
       workspaceId: id,
     });
 
@@ -235,7 +235,7 @@ export class WorkspaceResolver {
   async logo(@Parent() workspace: Workspace): Promise<string> {
     if (workspace.logo) {
       try {
-        const workspaceLogoToken = await this.fileService.encodeFileToken({
+        const workspaceLogoToken = this.fileService.encodeFileToken({
           workspaceId: workspace.id,
         });
 
@@ -306,7 +306,7 @@ export class WorkspaceResolver {
 
       if (workspace.logo) {
         try {
-          const workspaceLogoToken = await this.fileService.encodeFileToken({
+          const workspaceLogoToken = this.fileService.encodeFileToken({
             workspaceId: workspace.id,
           });
 


### PR DESCRIPTION
###  Remove unnecessary `await` from `encodeFileToken` calls (now synchronous)  #11611 

####  Context

In [PR #11385 – commit 26c17f3](https://github.com/twentyhq/twenty/pull/11385/commits/26c17f3205eb0cf4b93dd37cfec97638596ed263), `FileService.encodeFileToken()` was updated to be a **synchronous** method. However, several places in the codebase were still calling it using `await`.

####  Changes 
This PR cleans up those redundant `await` usages to:
- Improve clarity
- Avoid confusion (no longer awaiting a non-Promise)
- Slightly reduce overhead in affected functions
- Removed `await` from calls to `this.fileService.encodeFileToken(...)`

