### PR TITLE
Fix tab icon alignment issue

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/tab/components/Tab.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/tab/components/Tab.tsx
@@ -4,8 +4,8 @@ import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { ReactElement } from 'react';
 import { Link } from 'react-router-dom';
-import { Avatar, IconComponent } from 'twenty-ui/display';
 import { Pill } from 'twenty-ui/components';
+import { Avatar, IconComponent } from 'twenty-ui/display';
 
 type TabProps = {
   id: string;
@@ -69,6 +69,9 @@ const StyledHover = styled.span`
 
 const StyledIconContainer = styled.div`
   flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 `;
 
 export const Tab = ({
@@ -101,7 +104,7 @@ export const Tab = ({
       to={to}
     >
       <StyledHover>
-        <StyledIconContainer>
+        <StyledIconContainer className="awdawdqwd">
           {logo && (
             <Avatar
               avatarUrl={logo}

--- a/packages/twenty-front/src/modules/ui/layout/tab/components/Tab.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/tab/components/Tab.tsx
@@ -104,7 +104,7 @@ export const Tab = ({
       to={to}
     >
       <StyledHover>
-        <StyledIconContainer className="awdawdqwd">
+        <StyledIconContainer>
           {logo && (
             <Avatar
               avatarUrl={logo}


### PR DESCRIPTION
before:
![Screenshot 2025-04-17 at 13 40 00](https://github.com/user-attachments/assets/b29b3e6b-0185-4289-950c-37a24b63cb65)

after:
![Screenshot 2025-04-17 at 13 39 49](https://github.com/user-attachments/assets/af2efe6f-3908-40d6-acde-d2839a5a8ba2)

