### PR TITLE
Fix workflow run executed by empty

### DIFF
--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workspace-services/workflow-runner.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workspace-services/workflow-runner.workspace-service.ts
@@ -21,12 +21,17 @@ export class WorkflowRunnerWorkspaceService {
     private readonly billingUsageService: BillingUsageService,
   ) {}
 
-  async run(
-    workspaceId: string,
-    workflowVersionId: string,
-    payload: object,
-    source: ActorMetadata,
-  ) {
+  async run({
+    workspaceId,
+    workflowVersionId,
+    payload,
+    source,
+  }: {
+    workspaceId: string;
+    workflowVersionId: string;
+    payload: object;
+    source: ActorMetadata;
+  }) {
     const canFeatureBeUsed =
       await this.billingUsageService.canFeatureBeUsed(workspaceId);
 

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/jobs/workflow-trigger.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/jobs/workflow-trigger.job.ts
@@ -27,6 +27,8 @@ export type WorkflowTriggerJobData = {
   payload: object;
 };
 
+const DEFAULT_WORKFLOW_NAME = 'Workflow';
+
 @Processor({ queueName: MessageQueue.workflowQueue, scope: Scope.REQUEST })
 export class WorkflowTriggerJob {
   constructor(
@@ -80,7 +82,7 @@ export class WorkflowTriggerJob {
           name:
             isDefined(workflow.name) && !isEmpty(workflow.name)
               ? workflow.name
-              : 'Workflow',
+              : DEFAULT_WORKFLOW_NAME,
           context: {},
           workspaceMemberId: null,
         },

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/workspace-services/workflow-trigger.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/workspace-services/workflow-trigger.workspace-service.ts
@@ -7,6 +7,7 @@ import { DatabaseEventAction } from 'src/engine/api/graphql/graphql-query-runner
 import { InjectMessageQueue } from 'src/engine/core-modules/message-queue/decorators/message-queue.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
 import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
+import { ActorMetadata } from 'src/engine/metadata-modules/field-metadata/composite-types/actor.composite-type';
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 import { ScopedWorkspaceContextFactory } from 'src/engine/twenty-orm/factories/scoped-workspace-context.factory';
 import { WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace.repository';
@@ -35,7 +36,6 @@ import { WorkflowTriggerType } from 'src/modules/workflow/workflow-trigger/types
 import { assertVersionCanBeActivated } from 'src/modules/workflow/workflow-trigger/utils/assert-version-can-be-activated.util';
 import { computeCronPatternFromSchedule } from 'src/modules/workflow/workflow-trigger/utils/compute-cron-pattern-from-schedule';
 import { assertNever } from 'src/utils/assert';
-import { ActorMetadata } from 'src/engine/metadata-modules/field-metadata/composite-types/actor.composite-type';
 
 @Injectable()
 export class WorkflowTriggerWorkspaceService {
@@ -78,12 +78,12 @@ export class WorkflowTriggerWorkspaceService {
       workflowVersionId,
     );
 
-    return await this.workflowRunnerWorkspaceService.run(
-      this.getWorkspaceId(),
+    return this.workflowRunnerWorkspaceService.run({
+      workspaceId: this.getWorkspaceId(),
       workflowVersionId,
       payload,
-      createdBy,
-    );
+      source: createdBy,
+    });
   }
 
   async activateWorkflowVersion(workflowVersionId: string) {


### PR DESCRIPTION
Workflow run executed by should not be empty when the workflow is unamed. Adding Workflow as fallback

<img width="1072" alt="Capture d’écran 2025-04-17 à 19 17 12" src="https://github.com/user-attachments/assets/e4cc3360-06e5-47e8-ba05-28a0eafab994" />

