### PR TITLE
Update workflow statuses in real time

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-row/components/RecordTableRow.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-row/components/RecordTableRow.tsx
@@ -1,9 +1,11 @@
+import { useRecordIndexContextOrThrow } from '@/object-record/record-index/contexts/RecordIndexContext';
 import { RecordValueSetterEffect } from '@/object-record/record-store/components/RecordValueSetterEffect';
 import { RecordTableCellCheckbox } from '@/object-record/record-table/record-table-cell/components/RecordTableCellCheckbox';
 import { RecordTableCellGrip } from '@/object-record/record-table/record-table-cell/components/RecordTableCellGrip';
 import { RecordTableLastEmptyCell } from '@/object-record/record-table/record-table-cell/components/RecordTableLastEmptyCell';
 import { RecordTableCells } from '@/object-record/record-table/record-table-row/components/RecordTableCells';
 import { RecordTableDraggableTr } from '@/object-record/record-table/record-table-row/components/RecordTableDraggableTr';
+import { ListenRecordUpdatesEffect } from '@/subscription/components/ListenUpdatesEffect';
 
 type RecordTableRowProps = {
   recordId: string;
@@ -16,6 +18,8 @@ export const RecordTableRow = ({
   rowIndexForFocus,
   rowIndexForDrag,
 }: RecordTableRowProps) => {
+  const { objectNameSingular } = useRecordIndexContextOrThrow();
+
   return (
     <RecordTableDraggableTr
       recordId={recordId}
@@ -27,6 +31,13 @@ export const RecordTableRow = ({
       <RecordTableCells />
       <RecordTableLastEmptyCell />
       <RecordValueSetterEffect recordId={recordId} />
+      {objectNameSingular === 'workflow' && (
+        <ListenRecordUpdatesEffect
+          objectNameSingular={objectNameSingular}
+          recordId={recordId}
+          listenedFields={['statuses']}
+        />
+      )}
     </RecordTableDraggableTr>
   );
 };

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-row/components/RecordTableRow.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-row/components/RecordTableRow.tsx
@@ -35,13 +35,11 @@ export const RecordTableRow = ({
       <RecordTableCells />
       <RecordTableLastEmptyCell />
       <RecordValueSetterEffect recordId={recordId} />
-      {listenedFields.length > 0 && (
-        <ListenRecordUpdatesEffect
-          objectNameSingular={objectNameSingular}
-          recordId={recordId}
-          listenedFields={listenedFields}
-        />
-      )}
+      <ListenRecordUpdatesEffect
+        objectNameSingular={objectNameSingular}
+        recordId={recordId}
+        listenedFields={listenedFields}
+      />
     </RecordTableDraggableTr>
   );
 };

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-row/components/RecordTableRow.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-row/components/RecordTableRow.tsx
@@ -6,6 +6,7 @@ import { RecordTableLastEmptyCell } from '@/object-record/record-table/record-ta
 import { RecordTableCells } from '@/object-record/record-table/record-table-row/components/RecordTableCells';
 import { RecordTableDraggableTr } from '@/object-record/record-table/record-table-row/components/RecordTableDraggableTr';
 import { ListenRecordUpdatesEffect } from '@/subscription/components/ListenUpdatesEffect';
+import { getDefaultRecordFieldsToListen } from '@/subscription/utils/getDefaultRecordFieldsToListen.util';
 
 type RecordTableRowProps = {
   recordId: string;
@@ -19,6 +20,9 @@ export const RecordTableRow = ({
   rowIndexForDrag,
 }: RecordTableRowProps) => {
   const { objectNameSingular } = useRecordIndexContextOrThrow();
+  const listenedFields = getDefaultRecordFieldsToListen({
+    objectNameSingular,
+  });
 
   return (
     <RecordTableDraggableTr
@@ -31,11 +35,11 @@ export const RecordTableRow = ({
       <RecordTableCells />
       <RecordTableLastEmptyCell />
       <RecordValueSetterEffect recordId={recordId} />
-      {objectNameSingular === 'workflow' && (
+      {listenedFields.length > 0 && (
         <ListenRecordUpdatesEffect
           objectNameSingular={objectNameSingular}
           recordId={recordId}
-          listenedFields={['statuses']}
+          listenedFields={listenedFields}
         />
       )}
     </RecordTableDraggableTr>

--- a/packages/twenty-front/src/modules/subscription/components/ListenUpdatesEffect.tsx
+++ b/packages/twenty-front/src/modules/subscription/components/ListenUpdatesEffect.tsx
@@ -39,6 +39,7 @@ export const ListenRecordUpdatesEffect = ({
         fields: fieldsUpdater,
       });
     },
+    skip: listenedFields.length === 0,
   });
 
   return null;

--- a/packages/twenty-front/src/modules/subscription/components/ListenUpdatesEffect.tsx
+++ b/packages/twenty-front/src/modules/subscription/components/ListenUpdatesEffect.tsx
@@ -1,7 +1,7 @@
-import { useApolloClient } from '@apollo/client';
 import { useOnDbEvent } from '@/subscription/hooks/useOnDbEvent';
-import { DatabaseEventAction } from '~/generated/graphql';
+import { useApolloClient } from '@apollo/client';
 import { capitalize, isDefined } from 'twenty-shared/utils';
+import { DatabaseEventAction } from '~/generated/graphql';
 
 type ListenRecordUpdatesEffectProps = {
   objectNameSingular: string;

--- a/packages/twenty-front/src/modules/subscription/utils/getDefaultRecordFieldsToListen.util.ts
+++ b/packages/twenty-front/src/modules/subscription/utils/getDefaultRecordFieldsToListen.util.ts
@@ -1,0 +1,14 @@
+import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
+
+export const getDefaultRecordFieldsToListen = ({
+  objectNameSingular,
+}: {
+  objectNameSingular: string;
+}) => {
+  switch (objectNameSingular) {
+    case CoreObjectNameSingular.Workflow:
+      return ['statuses'];
+    default:
+      return [];
+  }
+};

--- a/packages/twenty-server/src/engine/subscriptions/subscriptions.job.ts
+++ b/packages/twenty-server/src/engine/subscriptions/subscriptions.job.ts
@@ -1,13 +1,13 @@
 import { Inject } from '@nestjs/common';
 
-import { isDefined } from 'twenty-shared/utils';
 import { RedisPubSub } from 'graphql-redis-subscriptions';
+import { isDefined } from 'twenty-shared/utils';
 
-import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
-import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
-import { Process } from 'src/engine/core-modules/message-queue/decorators/process.decorator';
-import { WorkspaceEventBatch } from 'src/engine/workspace-event-emitter/types/workspace-event.type';
 import { ObjectRecordEvent } from 'src/engine/core-modules/event-emitter/types/object-record-event.event';
+import { Process } from 'src/engine/core-modules/message-queue/decorators/process.decorator';
+import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
+import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
+import { WorkspaceEventBatch } from 'src/engine/workspace-event-emitter/types/workspace-event.type';
 import { removeSecretFromWebhookRecord } from 'src/utils/remove-secret-from-webhook-record';
 
 @Processor(MessageQueue.subscriptionsQueue)

--- a/packages/twenty-server/src/modules/workflow/workflow-status/jobs/workflow-statuses-update.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-status/jobs/workflow-statuses-update.job.ts
@@ -1,13 +1,19 @@
 import { Logger, Scope } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
 
 import { isDefined } from 'twenty-shared/utils';
+import { Repository } from 'typeorm';
 
+import { DatabaseEventAction } from 'src/engine/api/graphql/graphql-query-runner/enums/database-event-action';
 import { Process } from 'src/engine/core-modules/message-queue/decorators/process.decorator';
 import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
+import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
+import { ServerlessFunctionExceptionCode } from 'src/engine/metadata-modules/serverless-function/serverless-function.exception';
 import { ServerlessFunctionService } from 'src/engine/metadata-modules/serverless-function/serverless-function.service';
 import { WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace.repository';
 import { TwentyORMManager } from 'src/engine/twenty-orm/twenty-orm.manager';
+import { WorkspaceEventEmitter } from 'src/engine/workspace-event-emitter/workspace-event-emitter';
 import {
   WorkflowVersionStatus,
   WorkflowVersionWorkspaceEntity,
@@ -20,7 +26,6 @@ import {
 import { getStatusCombinationFromArray } from 'src/modules/workflow/workflow-status/utils/get-status-combination-from-array.util';
 import { getStatusCombinationFromUpdate } from 'src/modules/workflow/workflow-status/utils/get-status-combination-from-update.util';
 import { getWorkflowStatusesFromCombination } from 'src/modules/workflow/workflow-status/utils/get-statuses-from-combination.util';
-import { ServerlessFunctionExceptionCode } from 'src/engine/metadata-modules/serverless-function/serverless-function.exception';
 
 export enum WorkflowVersionEventType {
   CREATE = 'CREATE',
@@ -66,32 +71,51 @@ export class WorkflowStatusesUpdateJob {
   constructor(
     private readonly twentyORMManager: TwentyORMManager,
     private readonly serverlessFunctionService: ServerlessFunctionService,
+    private readonly workspaceEventEmitter: WorkspaceEventEmitter,
+    @InjectRepository(ObjectMetadataEntity, 'metadata')
+    protected readonly objectMetadataRepository: Repository<ObjectMetadataEntity>,
   ) {}
 
   @Process(WorkflowStatusesUpdateJob.name)
   async handle(event: WorkflowVersionBatchEvent): Promise<void> {
+    const workflowObjectMetadata =
+      await this.objectMetadataRepository.findOneOrFail({
+        where: {
+          nameSingular: 'workflow',
+        },
+      });
+
     switch (event.type) {
       case WorkflowVersionEventType.CREATE:
         await Promise.all(
           event.workflowIds.map((workflowId) =>
-            this.handleWorkflowVersionCreated(workflowId),
+            this.handleWorkflowVersionCreated({
+              workflowId,
+              workflowObjectMetadata,
+              workspaceId: event.workspaceId,
+            }),
           ),
         );
         break;
       case WorkflowVersionEventType.STATUS_UPDATE:
         await Promise.all(
           event.statusUpdates.map((statusUpdate) =>
-            this.handleWorkflowVersionStatusUpdated(
+            this.handleWorkflowVersionStatusUpdated({
               statusUpdate,
-              event.workspaceId,
-            ),
+              workflowObjectMetadata,
+              workspaceId: event.workspaceId,
+            }),
           ),
         );
         break;
       case WorkflowVersionEventType.DELETE:
         await Promise.all(
           event.workflowIds.map((workflowId) =>
-            this.handleWorkflowVersionDeleted(workflowId),
+            this.handleWorkflowVersionDeleted({
+              workflowId,
+              workflowObjectMetadata,
+              workspaceId: event.workspaceId,
+            }),
           ),
         );
         break;
@@ -100,22 +124,28 @@ export class WorkflowStatusesUpdateJob {
     }
   }
 
-  private async handleWorkflowVersionCreated(
-    workflowId: string,
-  ): Promise<void> {
+  private async handleWorkflowVersionCreated({
+    workflowId,
+    workflowObjectMetadata,
+    workspaceId,
+  }: {
+    workflowId: string;
+    workflowObjectMetadata: ObjectMetadataEntity;
+    workspaceId: string;
+  }): Promise<void> {
     const workflowRepository =
       await this.twentyORMManager.getRepository<WorkflowWorkspaceEntity>(
         'workflow',
       );
 
-    const workflow = await workflowRepository.findOneOrFail({
+    const previousWorkflow = await workflowRepository.findOneOrFail({
       where: {
         id: workflowId,
       },
     });
 
     const currentWorkflowStatusCombination = getStatusCombinationFromArray(
-      workflow.statuses || [],
+      previousWorkflow.statuses || [],
     );
 
     const newWorkflowStatusCombination = getStatusCombinationFromUpdate(
@@ -128,16 +158,41 @@ export class WorkflowStatusesUpdateJob {
       return;
     }
 
+    const newWorkflowStatuses = getWorkflowStatusesFromCombination(
+      newWorkflowStatusCombination,
+    );
+
     await workflowRepository.update(
       {
-        id: workflow.id,
+        id: workflowId,
       },
       {
-        statuses: getWorkflowStatusesFromCombination(
-          newWorkflowStatusCombination,
-        ),
+        statuses: newWorkflowStatuses,
       },
     );
+
+    this.workspaceEventEmitter.emitDatabaseBatchEvent({
+      objectMetadataNameSingular: workflowObjectMetadata.nameSingular,
+      action: DatabaseEventAction.UPDATED,
+      events: [
+        {
+          recordId: workflowId,
+          objectMetadata: workflowObjectMetadata,
+          properties: {
+            before: previousWorkflow,
+            after: {
+              ...previousWorkflow,
+              statuses: newWorkflowStatuses,
+            },
+            updatedFields: ['statuses'],
+            diff: {
+              statuses: newWorkflowStatuses,
+            },
+          },
+        },
+      ],
+      workspaceId,
+    });
   }
 
   private async handlePublishServerlessFunction({
@@ -207,10 +262,15 @@ export class WorkflowStatusesUpdateJob {
     }
   }
 
-  private async handleWorkflowVersionStatusUpdated(
-    statusUpdate: WorkflowVersionStatusUpdate,
-    workspaceId: string,
-  ): Promise<void> {
+  private async handleWorkflowVersionStatusUpdated({
+    statusUpdate,
+    workflowObjectMetadata,
+    workspaceId,
+  }: {
+    statusUpdate: WorkflowVersionStatusUpdate;
+    workflowObjectMetadata: ObjectMetadataEntity;
+    workspaceId: string;
+  }): Promise<void> {
     const workflowRepository =
       await this.twentyORMManager.getRepository<WorkflowWorkspaceEntity>(
         'workflow',
@@ -252,21 +312,52 @@ export class WorkflowStatusesUpdateJob {
       return;
     }
 
+    const newWorkflowStatuses = getWorkflowStatusesFromCombination(
+      newWorkflowStatusCombination,
+    );
+
     await workflowRepository.update(
       {
         id: statusUpdate.workflowId,
       },
       {
-        statuses: getWorkflowStatusesFromCombination(
-          newWorkflowStatusCombination,
-        ),
+        statuses: newWorkflowStatuses,
       },
     );
+
+    this.workspaceEventEmitter.emitDatabaseBatchEvent({
+      objectMetadataNameSingular: workflowObjectMetadata.nameSingular,
+      action: DatabaseEventAction.UPDATED,
+      events: [
+        {
+          recordId: statusUpdate.workflowId,
+          objectMetadata: workflowObjectMetadata,
+          properties: {
+            before: workflow,
+            after: {
+              ...workflow,
+              statuses: newWorkflowStatuses,
+            },
+            updatedFields: ['statuses'],
+            diff: {
+              statuses: newWorkflowStatuses,
+            },
+          },
+        },
+      ],
+      workspaceId,
+    });
   }
 
-  private async handleWorkflowVersionDeleted(
-    workflowId: string,
-  ): Promise<void> {
+  private async handleWorkflowVersionDeleted({
+    workflowId,
+    workflowObjectMetadata,
+    workspaceId,
+  }: {
+    workflowId: string;
+    workflowObjectMetadata: ObjectMetadataEntity;
+    workspaceId: string;
+  }): Promise<void> {
     const workflowRepository =
       await this.twentyORMManager.getRepository<WorkflowWorkspaceEntity>(
         'workflow',
@@ -292,15 +383,40 @@ export class WorkflowStatusesUpdateJob {
       return;
     }
 
+    const newWorkflowStatuses = getWorkflowStatusesFromCombination(
+      newWorkflowStatusCombination,
+    );
+
     await workflowRepository.update(
       {
         id: workflowId,
       },
       {
-        statuses: getWorkflowStatusesFromCombination(
-          newWorkflowStatusCombination,
-        ),
+        statuses: newWorkflowStatuses,
       },
     );
+
+    this.workspaceEventEmitter.emitDatabaseBatchEvent({
+      objectMetadataNameSingular: workflowObjectMetadata.nameSingular,
+      action: DatabaseEventAction.UPDATED,
+      events: [
+        {
+          recordId: workflowId,
+          objectMetadata: workflowObjectMetadata,
+          properties: {
+            before: workflow,
+            after: {
+              ...workflow,
+              statuses: newWorkflowStatuses,
+            },
+            updatedFields: ['statuses'],
+            diff: {
+              statuses: newWorkflowStatuses,
+            },
+          },
+        },
+      ],
+      workspaceId,
+    });
   }
 }

--- a/packages/twenty-server/src/modules/workflow/workflow-status/jobs/workflow-statuses-update.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-status/jobs/workflow-statuses-update.job.ts
@@ -18,7 +18,10 @@ import {
   WorkflowVersionStatus,
   WorkflowVersionWorkspaceEntity,
 } from 'src/modules/workflow/common/standard-objects/workflow-version.workspace-entity';
-import { WorkflowWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow.workspace-entity';
+import {
+  WorkflowStatus,
+  WorkflowWorkspaceEntity,
+} from 'src/modules/workflow/common/standard-objects/workflow.workspace-entity';
 import {
   WorkflowAction,
   WorkflowActionType,
@@ -171,26 +174,10 @@ export class WorkflowStatusesUpdateJob {
       },
     );
 
-    this.workspaceEventEmitter.emitDatabaseBatchEvent({
-      objectMetadataNameSingular: workflowObjectMetadata.nameSingular,
-      action: DatabaseEventAction.UPDATED,
-      events: [
-        {
-          recordId: workflowId,
-          objectMetadata: workflowObjectMetadata,
-          properties: {
-            before: previousWorkflow,
-            after: {
-              ...previousWorkflow,
-              statuses: newWorkflowStatuses,
-            },
-            updatedFields: ['statuses'],
-            diff: {
-              statuses: newWorkflowStatuses,
-            },
-          },
-        },
-      ],
+    this.emitWorkflowStatusUpdatedEvent({
+      currentWorkflow: previousWorkflow,
+      workflowObjectMetadata,
+      newWorkflowStatuses,
       workspaceId,
     });
   }
@@ -325,26 +312,10 @@ export class WorkflowStatusesUpdateJob {
       },
     );
 
-    this.workspaceEventEmitter.emitDatabaseBatchEvent({
-      objectMetadataNameSingular: workflowObjectMetadata.nameSingular,
-      action: DatabaseEventAction.UPDATED,
-      events: [
-        {
-          recordId: statusUpdate.workflowId,
-          objectMetadata: workflowObjectMetadata,
-          properties: {
-            before: workflow,
-            after: {
-              ...workflow,
-              statuses: newWorkflowStatuses,
-            },
-            updatedFields: ['statuses'],
-            diff: {
-              statuses: newWorkflowStatuses,
-            },
-          },
-        },
-      ],
+    this.emitWorkflowStatusUpdatedEvent({
+      currentWorkflow: workflow,
+      workflowObjectMetadata,
+      newWorkflowStatuses,
       workspaceId,
     });
   }
@@ -396,17 +367,36 @@ export class WorkflowStatusesUpdateJob {
       },
     );
 
+    this.emitWorkflowStatusUpdatedEvent({
+      currentWorkflow: workflow,
+      workflowObjectMetadata,
+      newWorkflowStatuses,
+      workspaceId,
+    });
+  }
+
+  private emitWorkflowStatusUpdatedEvent({
+    currentWorkflow,
+    workflowObjectMetadata,
+    newWorkflowStatuses,
+    workspaceId,
+  }: {
+    currentWorkflow: WorkflowWorkspaceEntity;
+    workflowObjectMetadata: ObjectMetadataEntity;
+    newWorkflowStatuses: WorkflowStatus[];
+    workspaceId: string;
+  }) {
     this.workspaceEventEmitter.emitDatabaseBatchEvent({
       objectMetadataNameSingular: workflowObjectMetadata.nameSingular,
       action: DatabaseEventAction.UPDATED,
       events: [
         {
-          recordId: workflowId,
+          recordId: currentWorkflow.id,
           objectMetadata: workflowObjectMetadata,
           properties: {
-            before: workflow,
+            before: currentWorkflow,
             after: {
-              ...workflow,
+              ...currentWorkflow,
               statuses: newWorkflowStatuses,
             },
             updatedFields: ['statuses'],

--- a/packages/twenty-server/src/modules/workflow/workflow-status/workflow-status.module.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-status/workflow-status.module.ts
@@ -1,11 +1,18 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
+import { ServerlessFunctionModule } from 'src/engine/metadata-modules/serverless-function/serverless-function.module';
+import { WorkspaceEventEmitterModule } from 'src/engine/workspace-event-emitter/workspace-event-emitter.module';
 import { WorkflowStatusesUpdateJob } from 'src/modules/workflow/workflow-status/jobs/workflow-statuses-update.job';
 import { WorkflowVersionStatusListener } from 'src/modules/workflow/workflow-status/listeners/workflow-version-status.listener';
-import { ServerlessFunctionModule } from 'src/engine/metadata-modules/serverless-function/serverless-function.module';
 
 @Module({
-  imports: [ServerlessFunctionModule],
+  imports: [
+    ServerlessFunctionModule,
+    WorkspaceEventEmitterModule,
+    TypeOrmModule.forFeature([ObjectMetadataEntity], 'metadata'),
+  ],
   providers: [WorkflowStatusesUpdateJob, WorkflowVersionStatusListener],
 })
 export class WorkflowStatusModule {}


### PR DESCRIPTION
Statuses are maintained by an async job. Those are calculations that we would like to avoid using in both frontend and backend. Using push updates are an easier way.


https://github.com/user-attachments/assets/31e44a82-08a8-4100-a38e-c965d5c73ee8

