### PR TITLE
Fallback `undefined` `recordDataChip` record name to empty string

### DIFF
--- a/packages/twenty-front/src/modules/object-metadata/utils/getLabelIdentifierFieldValue.ts
+++ b/packages/twenty-front/src/modules/object-metadata/utils/getLabelIdentifierFieldValue.ts
@@ -17,7 +17,7 @@ export const getLabelIdentifierFieldValue = (
   }
 
   if (isDefined(labelIdentifierFieldMetadataItem?.name)) {
-    return record[labelIdentifierFieldMetadataItem.name];
+    return record[labelIdentifierFieldMetadataItem.name] ?? '';
   }
 
   return '';


### PR DESCRIPTION
# Introduction
Closes #11682 

This seems to always has been quite flaky but this latest [update](https://github.com/twentyhq/twenty/commit/f0de6d31b7b3b84671c3a5af8fd047ef7432666f#diff-63704155b77d9690a87a1ebd9f364bab7e7bb12afed7cc5a5516561ec3798f29L20) seems to made the name optional.

As previously `undefined` being transpiles to a string results in `"undefined"` which not a good thing neither 🙃 but wouldn't throw before