### PR TITLE
Mime encode names in email headers

### DIFF
--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-send-message.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-send-message.service.ts
@@ -42,17 +42,22 @@ export class MessagingSendMessageService {
 
         const fromName = data.name;
 
-        const message = [
-          isDefined(fromName)
-            ? `From: "${mimeEncode(fromName)}" <${fromEmail}>`
-            : '',
+        const headers: string[] = [];
+
+        if (isDefined(fromName)) {
+          headers.push(`From: "${mimeEncode(fromName)}" <${fromEmail}>`);
+        }
+
+        headers.push(
           `To: ${sendMessageInput.to}`,
           `Subject: ${sendMessageInput.subject}`,
           'MIME-Version: 1.0',
           'Content-Type: text/plain; charset="UTF-8"',
           '',
           sendMessageInput.body,
-        ].join('\n');
+        );
+
+        const message = headers.join('\n');
 
         const encodedMessage = Buffer.from(message).toString('base64');
 

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-send-message.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-send-message.service.ts
@@ -1,13 +1,14 @@
 import { Injectable } from '@nestjs/common';
 
 import { z } from 'zod';
-import { assertUnreachable } from 'twenty-shared/utils';
+import { assertUnreachable, isDefined } from 'twenty-shared/utils';
 import { ConnectedAccountProvider } from 'twenty-shared/types';
 
 import { ConnectedAccountWorkspaceEntity } from 'src/modules/connected-account/standard-objects/connected-account.workspace-entity';
 import { GmailClientProvider } from 'src/modules/messaging/message-import-manager/drivers/gmail/providers/gmail-client.provider';
 import { MicrosoftClientProvider } from 'src/modules/messaging/message-import-manager/drivers/microsoft/providers/microsoft-client.provider';
 import { OAuth2ClientProvider } from 'src/modules/messaging/message-import-manager/drivers/gmail/providers/oauth2-client.provider';
+import { mimeEncode } from 'src/modules/messaging/message-import-manager/utils/mime-encode.util';
 
 interface SendMessageInput {
   body: string;
@@ -42,7 +43,9 @@ export class MessagingSendMessageService {
         const fromName = data.name;
 
         const message = [
-          `From: "${fromName}" <${fromEmail}>`,
+          isDefined(fromName)
+            ? `From: "${mimeEncode(fromName)}" <${fromEmail}>`
+            : '',
           `To: ${sendMessageInput.to}`,
           `Subject: ${sendMessageInput.subject}`,
           'MIME-Version: 1.0',

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-send-message.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-send-message.service.ts
@@ -50,7 +50,7 @@ export class MessagingSendMessageService {
 
         headers.push(
           `To: ${sendMessageInput.to}`,
-          `Subject: ${sendMessageInput.subject}`,
+          `Subject: ${mimeEncode(sendMessageInput.subject)}`,
           'MIME-Version: 1.0',
           'Content-Type: text/plain; charset="UTF-8"',
           '',

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/utils/__tests__/mime-encode.util.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/utils/__tests__/mime-encode.util.spec.ts
@@ -1,0 +1,9 @@
+import { mimeEncode } from 'src/modules/messaging/message-import-manager/utils/mime-encode.util';
+
+describe('mimeEncode', () => {
+  it('should encode properly', () => {
+    expect(mimeEncode('test-accents-é-è-ê-ë')).toBe(
+      '=?UTF-8?B?dGVzdC1hY2NlbnRzLcOpLcOoLcOqLcOr?=',
+    );
+  });
+});

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/utils/mime-encode.util.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/utils/mime-encode.util.ts
@@ -1,0 +1,3 @@
+export const mimeEncode = (raw: string) => {
+  return `=?UTF-8?B?${Buffer.from(raw).toString('base64')}?=`;
+};


### PR DESCRIPTION
# Before
<img width="618" alt="image" src="https://github.com/user-attachments/assets/e6d7c0ac-10f8-4d2e-abe4-05bf86a2ea9e" />

# After
<img width="504" alt="image" src="https://github.com/user-attachments/assets/db147cb9-be19-4d08-b357-cb554dc2a4ae" />

Fixes also Emojis encoding in Subject ->
<img width="540" alt="image" src="https://github.com/user-attachments/assets/8c27743f-3a50-46eb-b0f3-492219bbd646" />

 Works with microsoft accounts
<img width="360" alt="image" src="https://github.com/user-attachments/assets/d924440f-c107-4c1c-ad4d-b4b27016f102" />


Fixes https://github.com/twentyhq/twenty/issues/9194