### PR TITLE
Add clickhouse prod migration command

### DIFF
--- a/packages/twenty-server/package.json
+++ b/packages/twenty-server/package.json
@@ -11,6 +11,7 @@
     "worker:prod": "node dist/src/queue-worker/queue-worker",
     "database:init:prod": "npx ts-node ./scripts/setup-db.ts && yarn database:migrate:prod",
     "database:migrate:prod": "npx -y typeorm migration:run -d dist/src/database/typeorm/metadata/metadata.datasource && npx -y typeorm migration:run -d dist/src/database/typeorm/core/core.datasource",
+    "clickhouse:migrate:prod": "node dist/src/database/clickhouse/migrations/run-migrations.js",
     "typeorm": "../../node_modules/typeorm/.bin/typeorm"
   },
   "dependencies": {


### PR DESCRIPTION
Add a missing command to launch clickhouse migrations the same way we launch postgres migrations