### PR TITLE
Allow webhook only on active versions

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/workflow/controllers/workflow-trigger.controller.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/controllers/workflow-trigger.controller.ts
@@ -6,7 +6,10 @@ import { isDefined } from 'twenty-shared/utils';
 import { WorkflowTriggerRestApiExceptionFilter } from 'src/engine/core-modules/workflow/filters/workflow-trigger-rest-api-exception.filter';
 import { FieldActorSource } from 'src/engine/metadata-modules/field-metadata/composite-types/actor.composite-type';
 import { TwentyORMManager } from 'src/engine/twenty-orm/twenty-orm.manager';
-import { WorkflowVersionWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow-version.workspace-entity';
+import {
+  WorkflowVersionStatus,
+  WorkflowVersionWorkspaceEntity,
+} from 'src/modules/workflow/common/standard-objects/workflow-version.workspace-entity';
 import { WorkflowWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow.workspace-entity';
 import {
   WorkflowTriggerException,
@@ -64,7 +67,7 @@ export class WorkflowTriggerController {
       workflow.lastPublishedVersionId === ''
     ) {
       throw new WorkflowTriggerException(
-        'Workflow not activated',
+        'Workflow has not been activated',
         WorkflowTriggerExceptionCode.INVALID_WORKFLOW_STATUS,
       );
     }
@@ -88,6 +91,13 @@ export class WorkflowTriggerController {
       throw new WorkflowTriggerException(
         'Workflow does not have a Webhook trigger',
         WorkflowTriggerExceptionCode.INVALID_WORKFLOW_TRIGGER,
+      );
+    }
+
+    if (workflowVersion.status !== WorkflowVersionStatus.ACTIVE) {
+      throw new WorkflowTriggerException(
+        'Workflow version is not active',
+        WorkflowTriggerExceptionCode.INVALID_WORKFLOW_STATUS,
       );
     }
 

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/jobs/workflow-trigger.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/jobs/workflow-trigger.job.ts
@@ -46,9 +46,16 @@ export class WorkflowTriggerJob {
           'workflow',
         );
 
-      const workflow = await workflowRepository.findOneByOrFail({
+      const workflow = await workflowRepository.findOneBy({
         id: data.workflowId,
       });
+
+      if (!workflow) {
+        throw new WorkflowTriggerException(
+          'Workflow not found',
+          WorkflowTriggerExceptionCode.NOT_FOUND,
+        );
+      }
 
       if (!workflow.lastPublishedVersionId) {
         throw new WorkflowTriggerException(
@@ -62,10 +69,16 @@ export class WorkflowTriggerJob {
           'workflowVersion',
         );
 
-      const workflowVersion = await workflowVersionRepository.findOneByOrFail({
+      const workflowVersion = await workflowVersionRepository.findOneBy({
         id: workflow.lastPublishedVersionId,
       });
 
+      if (!workflowVersion) {
+        throw new WorkflowTriggerException(
+          'Workflow version not found',
+          WorkflowTriggerExceptionCode.NOT_FOUND,
+        );
+      }
       if (workflowVersion.status !== WorkflowVersionStatus.ACTIVE) {
         throw new WorkflowTriggerException(
           'Workflow version is not active',


### PR DESCRIPTION
- webhook call should only be allow on active versions
- fixing exceptions that are wrongly sent to sentry