### PR TITLE
Fix clickhouse migration not in dist

### DIFF
--- a/packages/twenty-server/nest-cli.json
+++ b/packages/twenty-server/nest-cli.json
@@ -25,6 +25,10 @@
       {
         "include": "**/serverless/drivers/constants/executor/index.mjs",
         "outDir": "dist/assets"
+      },
+      {
+        "include": "**/database/clickhouse/migrations/*.sql",
+        "outDir": "dist"
       }
     ],
     "watchAssets": true

--- a/packages/twenty-server/nest-cli.json
+++ b/packages/twenty-server/nest-cli.json
@@ -28,7 +28,7 @@
       },
       {
         "include": "**/database/clickhouse/migrations/*.sql",
-        "outDir": "dist"
+        "outDir": "dist/src"
       }
     ],
     "watchAssets": true


### PR DESCRIPTION
Clickhouse migrations were not correctly copied to the dist folder (for command yarn clickhouse:migrate:prod)