### PR TITLE
Fix missing `ObjectRecordId` param

### DIFF
--- a/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownRecordGroupFieldsContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownRecordGroupFieldsContent.tsx
@@ -11,6 +11,7 @@ import { hiddenRecordGroupIdsComponentSelector } from '@/object-record/record-gr
 import { useHandleRecordGroupField } from '@/object-record/record-index/hooks/useHandleRecordGroupField';
 import { SettingsPath } from '@/types/SettingsPath';
 import { DropdownMenuHeader } from '@/ui/layout/dropdown/components/DropdownMenuHeader/DropdownMenuHeader';
+import { DropdownMenuHeaderLeftComponent } from '@/ui/layout/dropdown/components/DropdownMenuHeader/internal/DropdownMenuHeaderLeftComponent';
 import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/DropdownMenuItemsContainer';
 import { DropdownMenuSeparator } from '@/ui/layout/dropdown/components/DropdownMenuSeparator';
 import { navigationMemorizedUrlState } from '@/ui/navigation/states/navigationMemorizedUrlState';
@@ -19,9 +20,6 @@ import { ViewType } from '@/views/types/ViewType';
 import { useLingui } from '@lingui/react/macro';
 import { useLocation } from 'react-router-dom';
 import { useSetRecoilState } from 'recoil';
-import { FieldMetadataType } from '~/generated-metadata/graphql';
-import { getSettingsPath } from '~/utils/navigation/getSettingsPath';
-import { DropdownMenuHeaderLeftComponent } from '@/ui/layout/dropdown/components/DropdownMenuHeader/internal/DropdownMenuHeaderLeftComponent';
 import { isDefined } from 'twenty-shared/utils';
 import { IconChevronLeft, IconSettings, useIcons } from 'twenty-ui/display';
 import {
@@ -29,6 +27,8 @@ import {
   MenuItemSelect,
   UndecoratedLink,
 } from 'twenty-ui/navigation';
+import { FieldMetadataType } from '~/generated-metadata/graphql';
+import { getSettingsPath } from '~/utils/navigation/getSettingsPath';
 
 export const ObjectOptionsDropdownRecordGroupFieldsContent = () => {
   const { t } = useLingui();
@@ -116,7 +116,7 @@ export const ObjectOptionsDropdownRecordGroupFieldsContent = () => {
           />
         }
       >
-        Group by
+        {t`Group by`}
       </DropdownMenuHeader>
       <StyledInput
         autoFocus

--- a/packages/twenty-front/src/modules/object-record/record-index/hooks/useHandleRecordGroupField.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/hooks/useHandleRecordGroupField.ts
@@ -134,7 +134,7 @@ export const useHandleRecordGroupField = () => {
           return;
         }
 
-        const view = await getViewFromPrefetchState(currentViewId);
+        const view = getViewFromPrefetchState(currentViewId);
 
         if (isUndefinedOrNull(view)) {
           return;

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellPortalWrapper.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellPortalWrapper.tsx
@@ -31,7 +31,7 @@ export const RecordTableCellPortalWrapper = ({
     visibleTableColumnsComponentSelector,
   );
 
-  const recordId = allRecordIds[position.row];
+  const recordId = allRecordIds.at(position.row);
   if (!isDefined(anchorElement) || !isDefined(recordId)) {
     return null;
   }

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellPortalWrapper.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellPortalWrapper.tsx
@@ -8,6 +8,7 @@ import { visibleTableColumnsComponentSelector } from '@/object-record/record-tab
 import { TableCellPosition } from '@/object-record/record-table/types/TableCellPosition';
 import { useRecoilComponentValueV2 } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValueV2';
 import ReactDOM from 'react-dom';
+import { isDefined } from 'twenty-shared/utils';
 
 export const RecordTableCellPortalWrapper = ({
   position,
@@ -16,9 +17,9 @@ export const RecordTableCellPortalWrapper = ({
   position: TableCellPosition;
   children: React.ReactNode;
 }) => {
-  const anchorElement = document.body.querySelector(
+  const anchorElement = document.body.querySelector<HTMLAnchorElement>(
     `#record-table-cell-${position.column}-${position.row}`,
-  ) as HTMLElement;
+  );
 
   const allRecordIds = useRecoilComponentValueV2(
     recordIndexAllRecordIdsComponentSelector,
@@ -30,11 +31,10 @@ export const RecordTableCellPortalWrapper = ({
     visibleTableColumnsComponentSelector,
   );
 
-  if (!anchorElement) {
+  const recordId = allRecordIds[position.row];
+  if (!isDefined(anchorElement) || !isDefined(recordId)) {
     return null;
   }
-
-  const recordId = allRecordIds[position.row];
 
   return ReactDOM.createPortal(
     <RecordTableRowContextProvider


### PR DESCRIPTION
# Introduction
Fixes https://github.com/twentyhq/twenty/issues/11718

From having [noUncheckedIndexedAccess](https://www.typescriptlang.org/tsconfig/#noUncheckedIndexedAccess) set to false we have a flakiness resulting in a such bug right here as the below operation can return `undefined` but not type as it should:
```ts
  const recordId = allRecordIds[position.row];
```

About to create a Tech project about the topic, activating the flag ends in 1500 typescript erros from the style solution compilation ( which means can contains several duplicated errors )