### PR TITLE
Prevent workflow diagram flickering while computing node dimensions

### DIFF
--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasBase.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasBase.tsx
@@ -1,4 +1,6 @@
 import { useListenRightDrawerClose } from '@/ui/layout/right-drawer/hooks/useListenRightDrawerClose';
+import { WorkflowDiagramCanvasContainer } from '@/workflow/workflow-diagram/components/WorkflowDiagramCanvasContainer';
+import { WorkflowDiagramCanvasStatusTagContainer } from '@/workflow/workflow-diagram/components/WorkflowDiagramCanvasStatusTagContainer';
 import { WorkflowDiagramCustomMarkers } from '@/workflow/workflow-diagram/components/WorkflowDiagramCustomMarkers';
 import { useRightDrawerState } from '@/workflow/workflow-diagram/hooks/useRightDrawerState';
 import { workflowDiagramState } from '@/workflow/workflow-diagram/states/workflowDiagramState';
@@ -11,7 +13,6 @@ import {
 } from '@/workflow/workflow-diagram/types/WorkflowDiagram';
 import { getOrganizedDiagram } from '@/workflow/workflow-diagram/utils/getOrganizedDiagram';
 import { useTheme } from '@emotion/react';
-import styled from '@emotion/styled';
 import {
   Background,
   EdgeChange,
@@ -30,50 +31,6 @@ import { useRecoilCallback, useRecoilValue, useSetRecoilState } from 'recoil';
 import { isDefined } from 'twenty-shared/utils';
 import { Tag, TagColor } from 'twenty-ui/components';
 import { THEME_COMMON } from 'twenty-ui/theme';
-
-const StyledResetReactflowStyles = styled.div`
-  height: 100%;
-  width: 100%;
-  position: relative;
-
-  /* Below we reset the default styling of Reactflow */
-  .react-flow__node-input,
-  .react-flow__node-default,
-  .react-flow__node-output,
-  .react-flow__node-group {
-    padding: 0;
-    width: auto;
-    text-align: start;
-    white-space: nowrap;
-  }
-
-  .react-flow__handle {
-    min-height: 0;
-    min-width: 0;
-  }
-  .react-flow__handle-top {
-    transform: translate(-50%, -50%);
-  }
-  .react-flow__handle-bottom {
-    transform: translate(-50%, 100%);
-  }
-  .react-flow__handle.connectionindicator {
-    cursor: pointer;
-  }
-
-  --xy-node-border-radius: none;
-  --xy-node-border: none;
-  --xy-node-background-color: none;
-  --xy-node-boxshadow-hover: none;
-  --xy-node-boxshadow-selected: none;
-`;
-
-const StyledStatusTagContainer = styled.div`
-  left: 0;
-  top: 0;
-  position: absolute;
-  padding: ${({ theme }) => theme.spacing(4)};
-`;
 
 const defaultFitViewOptions = {
   minZoom: 1,
@@ -218,14 +175,14 @@ export const WorkflowDiagramCanvasBase = ({
     [],
   );
 
-  const handleInit = () => {
+  const handleInit = async () => {
     if (!isDefined(containerRef.current)) {
       return;
     }
 
     const flowBounds = reactflow.getNodesBounds(reactflow.getNodes());
 
-    reactflow.setViewport({
+    await reactflow.setViewport({
       x: containerRef.current.offsetWidth / 2 - flowBounds.width / 2,
       y: 150,
       zoom: defaultFitViewOptions.maxZoom,
@@ -235,7 +192,7 @@ export const WorkflowDiagramCanvasBase = ({
   };
 
   return (
-    <StyledResetReactflowStyles ref={containerRef}>
+    <WorkflowDiagramCanvasContainer ref={containerRef}>
       <WorkflowDiagramCustomMarkers />
 
       <ReactFlow
@@ -267,9 +224,9 @@ export const WorkflowDiagramCanvasBase = ({
         {children}
       </ReactFlow>
 
-      <StyledStatusTagContainer data-testid={tagContainerTestId}>
+      <WorkflowDiagramCanvasStatusTagContainer data-testid={tagContainerTestId}>
         <Tag color={tagColor} text={tagText} />
-      </StyledStatusTagContainer>
-    </StyledResetReactflowStyles>
+      </WorkflowDiagramCanvasStatusTagContainer>
+    </WorkflowDiagramCanvasContainer>
   );
 };

--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasContainer.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasContainer.tsx
@@ -1,0 +1,40 @@
+import styled from '@emotion/styled';
+
+const StyledWorkflowDiagramCanvasContainer = styled.div`
+  height: 100%;
+  width: 100%;
+  position: relative;
+
+  /* Below we reset the default styling of Reactflow */
+  .react-flow__node-input,
+  .react-flow__node-default,
+  .react-flow__node-output,
+  .react-flow__node-group {
+    padding: 0;
+    width: auto;
+    text-align: start;
+    white-space: nowrap;
+  }
+
+  .react-flow__handle {
+    min-height: 0;
+    min-width: 0;
+  }
+  .react-flow__handle-top {
+    transform: translate(-50%, -50%);
+  }
+  .react-flow__handle-bottom {
+    transform: translate(-50%, 100%);
+  }
+  .react-flow__handle.connectionindicator {
+    cursor: pointer;
+  }
+
+  --xy-node-border-radius: none;
+  --xy-node-border: none;
+  --xy-node-background-color: none;
+  --xy-node-boxshadow-hover: none;
+  --xy-node-boxshadow-selected: none;
+`;
+
+export { StyledWorkflowDiagramCanvasContainer as WorkflowDiagramCanvasContainer };

--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasEditable.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasEditable.tsx
@@ -24,6 +24,10 @@ export const WorkflowDiagramCanvasEditable = ({
     workflowDiagramStatusState,
   );
 
+  const handleInit = () => {
+    setWorkflowDiagramStatus('done');
+  };
+
   return (
     <WorkflowDiagramCanvasLoader
       canvasComponent={
@@ -40,9 +44,7 @@ export const WorkflowDiagramCanvasEditable = ({
             tagContainerTestId="workflow-visualizer-status"
             tagColor={tagProps.color}
             tagText={tagProps.text}
-            onInit={() => {
-              setWorkflowDiagramStatus('done');
-            }}
+            onInit={handleInit}
           />
 
           <WorkflowDiagramCanvasEditableEffect />

--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasEditable.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasEditable.tsx
@@ -1,12 +1,15 @@
 import { WorkflowVersionStatus } from '@/workflow/types/Workflow';
 import { WorkflowDiagramCanvasBase } from '@/workflow/workflow-diagram/components/WorkflowDiagramCanvasBase';
 import { WorkflowDiagramCanvasEditableEffect } from '@/workflow/workflow-diagram/components/WorkflowDiagramCanvasEditableEffect';
+import { WorkflowDiagramCanvasLoader } from '@/workflow/workflow-diagram/components/WorkflowDiagramCanvasLoader';
 import { WorkflowDiagramCreateStepNode } from '@/workflow/workflow-diagram/components/WorkflowDiagramCreateStepNode';
 import { WorkflowDiagramDefaultEdge } from '@/workflow/workflow-diagram/components/WorkflowDiagramDefaultEdge';
 import { WorkflowDiagramEmptyTrigger } from '@/workflow/workflow-diagram/components/WorkflowDiagramEmptyTrigger';
 import { WorkflowDiagramStepNodeEditable } from '@/workflow/workflow-diagram/components/WorkflowDiagramStepNodeEditable';
+import { workflowDiagramStatusState } from '@/workflow/workflow-diagram/states/workflowDiagramStatusState';
 import { getWorkflowVersionStatusTagProps } from '@/workflow/workflow-diagram/utils/getWorkflowVersionStatusTagProps';
 import { ReactFlowProvider } from '@xyflow/react';
+import { useSetRecoilState } from 'recoil';
 
 export const WorkflowDiagramCanvasEditable = ({
   versionStatus,
@@ -17,23 +20,36 @@ export const WorkflowDiagramCanvasEditable = ({
     workflowVersionStatus: versionStatus,
   });
 
-  return (
-    <ReactFlowProvider>
-      <WorkflowDiagramCanvasBase
-        nodeTypes={{
-          default: WorkflowDiagramStepNodeEditable,
-          'create-step': WorkflowDiagramCreateStepNode,
-          'empty-trigger': WorkflowDiagramEmptyTrigger,
-        }}
-        edgeTypes={{
-          default: WorkflowDiagramDefaultEdge,
-        }}
-        tagContainerTestId="workflow-visualizer-status"
-        tagColor={tagProps.color}
-        tagText={tagProps.text}
-      />
+  const setWorkflowDiagramStatus = useSetRecoilState(
+    workflowDiagramStatusState,
+  );
 
-      <WorkflowDiagramCanvasEditableEffect />
-    </ReactFlowProvider>
+  return (
+    <WorkflowDiagramCanvasLoader
+      canvasComponent={
+        <ReactFlowProvider>
+          <WorkflowDiagramCanvasBase
+            nodeTypes={{
+              default: WorkflowDiagramStepNodeEditable,
+              'create-step': WorkflowDiagramCreateStepNode,
+              'empty-trigger': WorkflowDiagramEmptyTrigger,
+            }}
+            edgeTypes={{
+              default: WorkflowDiagramDefaultEdge,
+            }}
+            tagContainerTestId="workflow-visualizer-status"
+            tagColor={tagProps.color}
+            tagText={tagProps.text}
+            onInit={() => {
+              setWorkflowDiagramStatus('done');
+            }}
+          />
+
+          <WorkflowDiagramCanvasEditableEffect />
+        </ReactFlowProvider>
+      }
+      skeletonTagColor={tagProps.color}
+      skeletonTagText={tagProps.text}
+    />
   );
 };

--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasLoader.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasLoader.tsx
@@ -1,0 +1,56 @@
+import { WorkflowDiagramCanvasSkeleton } from '@/workflow/workflow-diagram/components/WorkflowDiagramCanvasSkeleton';
+import { workflowDiagramStatusState } from '@/workflow/workflow-diagram/states/workflowDiagramStatusState';
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import { ReactFlowProvider } from '@xyflow/react';
+import { useRecoilValue } from 'recoil';
+import { TagColor } from 'twenty-ui/components';
+
+const StyledContainer = styled.div`
+  display: grid;
+  height: 100%;
+
+  & > * {
+    grid-column: 1;
+    grid-row: 1;
+  }
+`;
+
+const StyledCanvasComponentWrapper = styled.div<{ hide: boolean }>`
+  ${({ hide }) =>
+    hide &&
+    css`
+      opacity: 0;
+    `}
+`;
+
+export const WorkflowDiagramCanvasLoader = ({
+  canvasComponent,
+  skeletonTagColor,
+  skeletonTagText,
+}: {
+  canvasComponent: React.ReactNode;
+  skeletonTagColor: TagColor;
+  skeletonTagText: string;
+}) => {
+  const workflowDiagramStatus = useRecoilValue(workflowDiagramStatusState);
+
+  return (
+    <StyledContainer>
+      <StyledCanvasComponentWrapper hide={workflowDiagramStatus !== 'done'}>
+        {canvasComponent}
+      </StyledCanvasComponentWrapper>
+
+      {workflowDiagramStatus !== 'done' && (
+        <div style={{ height: '100%' }}>
+          <ReactFlowProvider>
+            <WorkflowDiagramCanvasSkeleton
+              tagColor={skeletonTagColor}
+              tagText={skeletonTagText}
+            />
+          </ReactFlowProvider>
+        </div>
+      )}
+    </StyledContainer>
+  );
+};

--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasLoader.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasLoader.tsx
@@ -42,14 +42,12 @@ export const WorkflowDiagramCanvasLoader = ({
       </StyledCanvasComponentWrapper>
 
       {workflowDiagramStatus !== 'done' && (
-        <div style={{ height: '100%' }}>
-          <ReactFlowProvider>
-            <WorkflowDiagramCanvasSkeleton
-              tagColor={skeletonTagColor}
-              tagText={skeletonTagText}
-            />
-          </ReactFlowProvider>
-        </div>
+        <ReactFlowProvider>
+          <WorkflowDiagramCanvasSkeleton
+            tagColor={skeletonTagColor}
+            tagText={skeletonTagText}
+          />
+        </ReactFlowProvider>
       )}
     </StyledContainer>
   );

--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasReadonly.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasReadonly.tsx
@@ -24,6 +24,10 @@ export const WorkflowDiagramCanvasReadonly = ({
     workflowDiagramStatusState,
   );
 
+  const handleInit = () => {
+    setWorkflowDiagramStatus('done');
+  };
+
   return (
     <WorkflowDiagramCanvasLoader
       canvasComponent={
@@ -40,9 +44,7 @@ export const WorkflowDiagramCanvasReadonly = ({
             tagContainerTestId="workflow-visualizer-status"
             tagColor={tagProps.color}
             tagText={tagProps.text}
-            onInit={() => {
-              setWorkflowDiagramStatus('done');
-            }}
+            onInit={handleInit}
           />
 
           <WorkflowDiagramCanvasReadonlyEffect />

--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasReadonly.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasReadonly.tsx
@@ -1,12 +1,15 @@
 import { WorkflowVersionStatus } from '@/workflow/types/Workflow';
 import { WorkflowDiagramCanvasBase } from '@/workflow/workflow-diagram/components/WorkflowDiagramCanvasBase';
+import { WorkflowDiagramCanvasLoader } from '@/workflow/workflow-diagram/components/WorkflowDiagramCanvasLoader';
 import { WorkflowDiagramCanvasReadonlyEffect } from '@/workflow/workflow-diagram/components/WorkflowDiagramCanvasReadonlyEffect';
 import { WorkflowDiagramDefaultEdge } from '@/workflow/workflow-diagram/components/WorkflowDiagramDefaultEdge';
 import { WorkflowDiagramEmptyTrigger } from '@/workflow/workflow-diagram/components/WorkflowDiagramEmptyTrigger';
 import { WorkflowDiagramStepNodeReadonly } from '@/workflow/workflow-diagram/components/WorkflowDiagramStepNodeReadonly';
 import { WorkflowDiagramSuccessEdge } from '@/workflow/workflow-diagram/components/WorkflowDiagramSuccessEdge';
+import { workflowDiagramStatusState } from '@/workflow/workflow-diagram/states/workflowDiagramStatusState';
 import { getWorkflowVersionStatusTagProps } from '@/workflow/workflow-diagram/utils/getWorkflowVersionStatusTagProps';
 import { ReactFlowProvider } from '@xyflow/react';
+import { useSetRecoilState } from 'recoil';
 
 export const WorkflowDiagramCanvasReadonly = ({
   versionStatus,
@@ -17,23 +20,36 @@ export const WorkflowDiagramCanvasReadonly = ({
     workflowVersionStatus: versionStatus,
   });
 
-  return (
-    <ReactFlowProvider>
-      <WorkflowDiagramCanvasBase
-        nodeTypes={{
-          default: WorkflowDiagramStepNodeReadonly,
-          'empty-trigger': WorkflowDiagramEmptyTrigger,
-        }}
-        edgeTypes={{
-          default: WorkflowDiagramDefaultEdge,
-          success: WorkflowDiagramSuccessEdge,
-        }}
-        tagContainerTestId="workflow-visualizer-status"
-        tagColor={tagProps.color}
-        tagText={tagProps.text}
-      />
+  const setWorkflowDiagramStatus = useSetRecoilState(
+    workflowDiagramStatusState,
+  );
 
-      <WorkflowDiagramCanvasReadonlyEffect />
-    </ReactFlowProvider>
+  return (
+    <WorkflowDiagramCanvasLoader
+      canvasComponent={
+        <ReactFlowProvider>
+          <WorkflowDiagramCanvasBase
+            nodeTypes={{
+              default: WorkflowDiagramStepNodeReadonly,
+              'empty-trigger': WorkflowDiagramEmptyTrigger,
+            }}
+            edgeTypes={{
+              default: WorkflowDiagramDefaultEdge,
+              success: WorkflowDiagramSuccessEdge,
+            }}
+            tagContainerTestId="workflow-visualizer-status"
+            tagColor={tagProps.color}
+            tagText={tagProps.text}
+            onInit={() => {
+              setWorkflowDiagramStatus('done');
+            }}
+          />
+
+          <WorkflowDiagramCanvasReadonlyEffect />
+        </ReactFlowProvider>
+      }
+      skeletonTagColor={tagProps.color}
+      skeletonTagText={tagProps.text}
+    />
   );
 };

--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasSkeleton.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasSkeleton.tsx
@@ -1,0 +1,32 @@
+import { WorkflowDiagramCanvasContainer } from '@/workflow/workflow-diagram/components/WorkflowDiagramCanvasContainer';
+import { WorkflowDiagramCanvasStatusTagContainer } from '@/workflow/workflow-diagram/components/WorkflowDiagramCanvasStatusTagContainer';
+import { useTheme } from '@emotion/react';
+import { Background, ReactFlow } from '@xyflow/react';
+import { Tag, TagColor } from 'twenty-ui/components';
+
+export const WorkflowDiagramCanvasSkeleton = ({
+  tagColor,
+  tagText,
+}: {
+  tagColor: TagColor;
+  tagText: string;
+}) => {
+  const theme = useTheme();
+
+  return (
+    <WorkflowDiagramCanvasContainer>
+      <ReactFlow
+        nodes={[]}
+        edges={[]}
+        proOptions={{ hideAttribution: true }}
+        preventScrolling={false}
+      >
+        <Background color={theme.border.color.medium} size={2} />
+      </ReactFlow>
+
+      <WorkflowDiagramCanvasStatusTagContainer>
+        <Tag color={tagColor} text={tagText} />
+      </WorkflowDiagramCanvasStatusTagContainer>
+    </WorkflowDiagramCanvasContainer>
+  );
+};

--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasStatusTagContainer.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasStatusTagContainer.tsx
@@ -1,0 +1,10 @@
+import styled from '@emotion/styled';
+
+const StyledWorkflowDiagramCanvasStatusTagContainer = styled.div`
+  left: 0;
+  top: 0;
+  position: absolute;
+  padding: ${({ theme }) => theme.spacing(4)};
+`;
+
+export { StyledWorkflowDiagramCanvasStatusTagContainer as WorkflowDiagramCanvasStatusTagContainer };

--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowRunDiagramCanvas.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowRunDiagramCanvas.tsx
@@ -1,5 +1,6 @@
 import { WorkflowRunStatus } from '@/workflow/types/Workflow';
 import { WorkflowDiagramCanvasBase } from '@/workflow/workflow-diagram/components/WorkflowDiagramCanvasBase';
+import { WorkflowDiagramCanvasLoader } from '@/workflow/workflow-diagram/components/WorkflowDiagramCanvasLoader';
 import { WorkflowDiagramDefaultEdge } from '@/workflow/workflow-diagram/components/WorkflowDiagramDefaultEdge';
 import { WorkflowDiagramStepNodeReadonly } from '@/workflow/workflow-diagram/components/WorkflowDiagramStepNodeReadonly';
 import { WorkflowDiagramSuccessEdge } from '@/workflow/workflow-diagram/components/WorkflowDiagramSuccessEdge';
@@ -21,22 +22,28 @@ export const WorkflowRunDiagramCanvas = ({
     useHandleWorkflowRunDiagramCanvasInit();
 
   return (
-    <ReactFlowProvider>
-      <WorkflowDiagramCanvasBase
-        nodeTypes={{
-          default: WorkflowDiagramStepNodeReadonly,
-        }}
-        edgeTypes={{
-          default: WorkflowDiagramDefaultEdge,
-          success: WorkflowDiagramSuccessEdge,
-        }}
-        tagContainerTestId="workflow-run-status"
-        tagColor={tagProps.color}
-        tagText={tagProps.text}
-        onInit={handleWorkflowRunDiagramCanvasInit}
-      />
+    <WorkflowDiagramCanvasLoader
+      canvasComponent={
+        <ReactFlowProvider>
+          <WorkflowDiagramCanvasBase
+            nodeTypes={{
+              default: WorkflowDiagramStepNodeReadonly,
+            }}
+            edgeTypes={{
+              default: WorkflowDiagramDefaultEdge,
+              success: WorkflowDiagramSuccessEdge,
+            }}
+            tagContainerTestId="workflow-run-status"
+            tagColor={tagProps.color}
+            tagText={tagProps.text}
+            onInit={handleWorkflowRunDiagramCanvasInit}
+          />
 
-      <WorkflowRunDiagramCanvasEffect />
-    </ReactFlowProvider>
+          <WorkflowRunDiagramCanvasEffect />
+        </ReactFlowProvider>
+      }
+      skeletonTagColor={tagProps.color}
+      skeletonTagText={tagProps.text}
+    />
   );
 };


### PR DESCRIPTION
Explanation video:

https://github.com/user-attachments/assets/153ace59-a32b-4d85-94c6-f56a674f8ca4


> [!WARNING]
>  Please note that the fix doesn't work yet when you click on a Workflow/Workflow Version/Workflow Run `RecordChip`. This will be automatically solved once we migrate to component states everywhere in the workflows. This is because the `workflowDiagramStatusState` will be `done` during the first rendering of the components; it will be set back to `computing-diagram` a few frames later in a useEffect. Using component states will make the default value behave properly.
