### PR TITLE
Fix for Issue 8701

### DIFF
--- a/packages/twenty-website/src/content/developers/local-setup.mdx
+++ b/packages/twenty-website/src/content/developers/local-setup.mdx
@@ -117,10 +117,6 @@ You should run all commands in the following steps from the root of the project.
     ```bash
       make postgres-on-docker
     ```
-    Note: In some cases when using Docker, you may need to manually grant permissions to the `twenty` user.
-    ```bash
-      psql postgres -c "GRANT ALL PRIVILEGES ON DATABASE \"default\" TO twenty;" -c "GRANT ALL PRIVILEGES ON DATABASE \"test\" TO twenty;"
-    ```
   </ArticleTab>
   <ArticleTab>
     <b>Option 1 (preferred):</b> To provision your database locally with `brew`:
@@ -134,10 +130,6 @@ You should run all commands in the following steps from the root of the project.
     <b>Option 2:</b> If you have docker installed:
     ```bash
       make postgres-on-docker
-    ```
-    Note: In some cases when using Docker, you may need to manually grant permissions to the `twenty` user.
-    ```bash
-      psql postgres -c "GRANT ALL PRIVILEGES ON DATABASE \"default\" TO twenty;" -c "GRANT ALL PRIVILEGES ON DATABASE \"test\" TO twenty;"
     ```
   </ArticleTab>
   <ArticleTab>
@@ -156,14 +148,15 @@ You should run all commands in the following steps from the root of the project.
     ```bash
       make postgres-on-docker
     ```
-    Note: In some cases when using Docker, you may need to manually grant permissions to the `twenty` user.
-    ```bash
-      psql postgres -c "GRANT ALL PRIVILEGES ON DATABASE \"default\" TO twenty;" -c "GRANT ALL PRIVILEGES ON DATABASE \"test\" TO twenty;"
-    ```
   </ArticleTab>
 </ArticleTabs>
 
 You can now access the database at [localhost:5432](localhost:5432), with user `postgres` and password `postgres` .
+
+Note: In some cases when using Docker, you may need to manually grant superuser permission to the `postgres` user.
+```bash
+  sudo -u postgres psql postgres -c "ALTER ROLE postgres WITH SUPERUSER"
+```
 
 ## Step 4: Set up a Redis Database (cache)
 Twenty requires a redis cache to provide the best performance

--- a/packages/twenty-website/src/content/developers/local-setup.mdx
+++ b/packages/twenty-website/src/content/developers/local-setup.mdx
@@ -117,6 +117,10 @@ You should run all commands in the following steps from the root of the project.
     ```bash
       make postgres-on-docker
     ```
+    Note: In some cases when using Docker, you may need to manually grant permissions to the `twenty` user.
+    ```bash
+      psql postgres -c "GRANT ALL PRIVILEGES ON DATABASE \"default\" TO twenty;" -c "GRANT ALL PRIVILEGES ON DATABASE \"test\" TO twenty;"
+    ```
   </ArticleTab>
   <ArticleTab>
     <b>Option 1 (preferred):</b> To provision your database locally with `brew`:
@@ -130,6 +134,10 @@ You should run all commands in the following steps from the root of the project.
     <b>Option 2:</b> If you have docker installed:
     ```bash
       make postgres-on-docker
+    ```
+    Note: In some cases when using Docker, you may need to manually grant permissions to the `twenty` user.
+    ```bash
+      psql postgres -c "GRANT ALL PRIVILEGES ON DATABASE \"default\" TO twenty;" -c "GRANT ALL PRIVILEGES ON DATABASE \"test\" TO twenty;"
     ```
   </ArticleTab>
   <ArticleTab>
@@ -147,6 +155,10 @@ You should run all commands in the following steps from the root of the project.
     Only use this option if you are comfortable with the extra steps involved, including turning on [Docker Desktop WSL2](https://docs.docker.com/desktop/wsl).
     ```bash
       make postgres-on-docker
+    ```
+    Note: In some cases when using Docker, you may need to manually grant permissions to the `twenty` user.
+    ```bash
+      psql postgres -c "GRANT ALL PRIVILEGES ON DATABASE \"default\" TO twenty;" -c "GRANT ALL PRIVILEGES ON DATABASE \"test\" TO twenty;"
     ```
   </ArticleTab>
 </ArticleTabs>


### PR DESCRIPTION
We added some basic code that checks if a Twenty user exists in the Postgre database. If the user doesn't exist, we create it and try to give it necessary permissions. If we are unable to give it the necessary permissions, we log that issue to the console and redirect users to the Twenty documentation. We updated the documentation with a command users can run to manually grant permissions to the new Twenty user.

Close #8701