### PR TITLE
Throw error if attempting to open RecordPage without recordId

### DIFF
--- a/packages/twenty-front/src/modules/command-menu/pages/record-page/components/CommandMenuRecordPage.tsx
+++ b/packages/twenty-front/src/modules/command-menu/pages/record-page/components/CommandMenuRecordPage.tsx
@@ -34,12 +34,16 @@ export const CommandMenuRecordPage = () => {
   );
 
   if (!viewableRecordNameSingular) {
-    throw new Error(`Object name is not defined`);
+    throw new Error(`Object name or is not defined`);
+  }
+
+  if (!viewableRecordId) {
+    throw new Error(`Record id is not defined`);
   }
 
   const { objectNameSingular, objectRecordId } = useRecordShowPage(
-    viewableRecordNameSingular ?? '',
-    viewableRecordId ?? '',
+    viewableRecordNameSingular,
+    viewableRecordId,
   );
 
   const commandMenuPageInstanceId = useComponentInstanceStateContext(

--- a/packages/twenty-front/src/modules/command-menu/pages/record-page/components/CommandMenuRecordPage.tsx
+++ b/packages/twenty-front/src/modules/command-menu/pages/record-page/components/CommandMenuRecordPage.tsx
@@ -34,7 +34,7 @@ export const CommandMenuRecordPage = () => {
   );
 
   if (!viewableRecordNameSingular) {
-    throw new Error(`Object name or is not defined`);
+    throw new Error(`Object name is not defined`);
   }
 
   if (!viewableRecordId) {


### PR DESCRIPTION
Closes https://github.com/twentyhq/core-team-issues/issues/857

The issue was caused by the fact that the preview chip was accidentally made clickable while not linked to any record id: 
<img width="763" alt="Capture d’écran 2025-04-28 à 15 17 32" src="https://github.com/user-attachments/assets/c1d9bf61-edcb-442f-a914-eccc627ee190" />
this was fixed by [this PR](https://github.com/twentyhq/twenty/pull/11745) (@etiennejouan)

It was causing the side panel to open while the record id was empty, while this recordId is used in query filters (as it should be to fetch record data), leading the queries to fail. 
Let's early return with an error instead as it does not make sense to open the record page with an empty recordId. 

