### PR TITLE
Fix next step ids backfill command

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/0-52/0-52-backfill-workflow-next-step-ids.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/0-52/0-52-backfill-workflow-next-step-ids.command.ts
@@ -96,6 +96,9 @@ export class BackfillWorkflowNextStepIdsCommand extends ActiveOrSuspendedWorkspa
           },
           take: batchSize,
           skip: batchIndex * batchSize,
+          order: {
+            id: 'ASC',
+          },
         });
 
         for (const workflowRun of workflowRuns) {
@@ -105,8 +108,12 @@ export class BackfillWorkflowNextStepIdsCommand extends ActiveOrSuspendedWorkspa
             continue;
           }
 
+          const updatedStepsMap = new Map(
+            updatedSteps.map((step) => [step.id, step]),
+          );
+
           const updatedFlow = flow.steps.map((step) => {
-            const updatedStep = updatedSteps.find((s) => s.id === step.id);
+            const updatedStep = updatedStepsMap.get(step.id);
 
             return {
               ...step,


### PR DESCRIPTION
Twenty prod DB has been exported for testing.

Main updates:
- do not process workflow runs with less than 2 steps. Nothing to do.
- update runs by batches of 500. Will avoid java heap space issue
- add more logs