### PR TITLE
Fix object metadata not found for id

### DIFF
--- a/packages/twenty-front/src/modules/action-menu/contexts/ActionMenuContextProvider.tsx
+++ b/packages/twenty-front/src/modules/action-menu/contexts/ActionMenuContextProvider.tsx
@@ -2,7 +2,6 @@ import { ActionMenuContextType } from '@/action-menu/contexts/ActionMenuContext'
 import { ActionMenuContextProviderWorkflowObjects } from '@/action-menu/contexts/ActionMenuContextProviderWorkflowObjects';
 import { ActionMenuContextProviderWorkflowsEnabled } from '@/action-menu/contexts/ActionMenuContextProviderWorkflowsEnabled';
 import { ActionMenuContextProviderWorkflowsNotEnabled } from '@/action-menu/contexts/ActionMenuContextProviderWorkflowsNotEnabled';
-import { MAIN_CONTEXT_STORE_INSTANCE_ID } from '@/context-store/constants/MainContextStoreInstanceId';
 import { contextStoreCurrentObjectMetadataItemIdComponentState } from '@/context-store/states/contextStoreCurrentObjectMetadataItemIdComponentState';
 import { objectMetadataItemsState } from '@/object-metadata/states/objectMetadataItemsState';
 import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
@@ -24,30 +23,16 @@ export const ActionMenuContextProvider = ({
     FeatureFlagKey.IsWorkflowEnabled,
   );
 
-  const localContextStoreCurrentObjectMetadataItemId =
-    useRecoilComponentValueV2(
-      contextStoreCurrentObjectMetadataItemIdComponentState,
-    );
-
-  const mainContextStoreCurrentObjectMetadataItemId = useRecoilComponentValueV2(
+  const contextStoreCurrentObjectMetadataItemId = useRecoilComponentValueV2(
     contextStoreCurrentObjectMetadataItemIdComponentState,
-    MAIN_CONTEXT_STORE_INSTANCE_ID,
   );
 
   const objectMetadataItems = useRecoilValue(objectMetadataItemsState);
 
-  const localContextStoreObjectMetadataItem = objectMetadataItems.find(
+  const objectMetadataItem = objectMetadataItems.find(
     (objectMetadataItem) =>
-      objectMetadataItem.id === localContextStoreCurrentObjectMetadataItemId,
+      objectMetadataItem.id === contextStoreCurrentObjectMetadataItemId,
   );
-
-  const mainContextStoreObjectMetadataItem = objectMetadataItems.find(
-    (objectMetadataItem) =>
-      objectMetadataItem.id === mainContextStoreCurrentObjectMetadataItemId,
-  );
-
-  const objectMetadataItem =
-    localContextStoreObjectMetadataItem ?? mainContextStoreObjectMetadataItem;
 
   const isWorkflowObject =
     objectMetadataItem?.nameSingular === CoreObjectNameSingular.Workflow ||


### PR DESCRIPTION
Fixes https://github.com/twentyhq/twenty/issues/11668

Fixed an error due to falling back to the main context store object metadata when the one in the context store wasn't defined.

When closing the command menu, the `contextStoreCurrentObjectMetadataItemIdComponentState` is reset, but the ActionMenuContextProvider was falling back to the main context store object metadata id, so the action components were mounted. But they still tried to access the `contextStoreCurrentObjectMetadataItemIdComponentState` which is `undefined`, which lead to an error being thrown.

Fix:
- Removed the fallback to the main context store object metadata item