### PR TITLE
fix-discord-timeline

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/calendar/timeline-calendar-event.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/calendar/timeline-calendar-event.service.ts
@@ -82,17 +82,17 @@ export class TimelineCalendarEventService {
           workspaceMemberId: participant.workspaceMemberId ?? null,
           firstName:
             participant.person?.name?.firstName ||
-            participant.workspaceMember?.name.firstName ||
+            participant.workspaceMember?.name?.firstName ||
             '',
           lastName:
             participant.person?.name?.lastName ||
-            participant.workspaceMember?.name.lastName ||
+            participant.workspaceMember?.name?.lastName ||
             '',
           displayName:
             participant.person?.name?.firstName ||
             participant.person?.name?.lastName ||
-            participant.workspaceMember?.name.firstName ||
-            participant.workspaceMember?.name.lastName ||
+            participant.workspaceMember?.name?.firstName ||
+            participant.workspaceMember?.name?.lastName ||
             participant.displayName ||
             participant.handle ||
             '',

--- a/packages/twenty-server/src/engine/core-modules/calendar/timeline-calendar-event.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/calendar/timeline-calendar-event.service.ts
@@ -82,17 +82,17 @@ export class TimelineCalendarEventService {
           workspaceMemberId: participant.workspaceMemberId ?? null,
           firstName:
             participant.person?.name?.firstName ||
-            participant.workspaceMember?.name?.firstName ||
+            participant.workspaceMember?.name.firstName ||
             '',
           lastName:
             participant.person?.name?.lastName ||
-            participant.workspaceMember?.name?.lastName ||
+            participant.workspaceMember?.name.lastName ||
             '',
           displayName:
             participant.person?.name?.firstName ||
             participant.person?.name?.lastName ||
-            participant.workspaceMember?.name?.firstName ||
-            participant.workspaceMember?.name?.lastName ||
+            participant.workspaceMember?.name.firstName ||
+            participant.workspaceMember?.name.lastName ||
             participant.displayName ||
             participant.handle ||
             '',

--- a/packages/twenty-server/src/engine/twenty-orm/utils/format-result.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/format-result.util.ts
@@ -87,9 +87,7 @@ export function formatResult<T>(
   for (const [key, value] of Object.entries(data)) {
     const compositePropertyArgs = compositeFieldMetadataMap.get(key);
 
-    const fieldMetadata = isNewRelationEnabled
-      ? objectMetadataItemWithFieldMaps.fieldsByName[key]
-      : objectMetadataItemWithFieldMaps.fieldsById[key];
+    const fieldMetadata = objectMetadataItemWithFieldMaps.fieldsByName[key];
 
     const isRelation = fieldMetadata
       ? isFieldMetadataInterfaceOfType(

--- a/packages/twenty-server/src/engine/twenty-orm/utils/format-result.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/format-result.util.ts
@@ -86,7 +86,11 @@ export function formatResult<T>(
 
   for (const [key, value] of Object.entries(data)) {
     const compositePropertyArgs = compositeFieldMetadataMap.get(key);
-    const fieldMetadata = objectMetadataItemWithFieldMaps.fieldsById[key];
+
+    const fieldMetadata = isNewRelationEnabled
+      ? objectMetadataItemWithFieldMaps.fieldsByName[key]
+      : objectMetadataItemWithFieldMaps.fieldsById[key];
+
     const isRelation = fieldMetadata
       ? isFieldMetadataInterfaceOfType(
           fieldMetadata,


### PR DESCRIPTION
In some cases, the person is undefined so we fallback on the workspacemember, and sometimes he is missing the firstname/lastname.

Not sure how this can happen, but one user experiencd such a thing so better to catch this

![image](https://github.com/user-attachments/assets/c91445fe-365e-4fc9-bf14-69f71d344aa7)

fix https://discord.com/channels/1130383047699738754/1366145144838951022

close https://github.com/twentyhq/core-team-issues/issues/918