### PR TITLE
Fix formatDateString test

### DIFF
--- a/packages/twenty-front/src/modules/localization/utils/formatDateISOStringToRelativeDate.ts
+++ b/packages/twenty-front/src/modules/localization/utils/formatDateISOStringToRelativeDate.ts
@@ -9,7 +9,6 @@ export const formatDateISOStringToRelativeDate = (
   isoDate: string,
   isDayMaximumPrecision = false,
 ) => {
-  // test change
   const now = new Date();
   const targetDate = new Date(isoDate);
 

--- a/packages/twenty-front/src/modules/localization/utils/formatDateISOStringToRelativeDate.ts
+++ b/packages/twenty-front/src/modules/localization/utils/formatDateISOStringToRelativeDate.ts
@@ -9,6 +9,7 @@ export const formatDateISOStringToRelativeDate = (
   isoDate: string,
   isDayMaximumPrecision = false,
 ) => {
+  // test change
   const now = new Date();
   const targetDate = new Date(isoDate);
 

--- a/packages/twenty-front/src/utils/string/__tests__/formatDateString.test.ts
+++ b/packages/twenty-front/src/utils/string/__tests__/formatDateString.test.ts
@@ -29,7 +29,7 @@ describe('formatDateString', () => {
 
   it('should format date as relative when displayFormat is set to RELATIVE', () => {
     const mockDate = DateTime.now().minus({ months: 2 }).toISO();
-    const mockRelativeDate = '2 months ago';
+    const mockRelativeDate = 'about 2 months ago';
 
     jest.mock('@/localization/utils/formatDateISOStringToRelativeDate', () => ({
       formatDateISOStringToRelativeDate: jest

--- a/packages/twenty-front/src/utils/string/__tests__/formatDateString.test.ts
+++ b/packages/twenty-front/src/utils/string/__tests__/formatDateString.test.ts
@@ -28,14 +28,8 @@ describe('formatDateString', () => {
   });
 
   it('should format date as relative when displayFormat is set to RELATIVE', () => {
-    const mockDate = DateTime.now().minus({ months: 2 }).toISO();
-    const mockRelativeDate = 'about 2 months ago';
-
-    jest.mock('@/localization/utils/formatDateISOStringToRelativeDate', () => ({
-      formatDateISOStringToRelativeDate: jest
-        .fn()
-        .mockReturnValue(mockRelativeDate),
-    }));
+    const mockDate = DateTime.now().minus({ days: 2 }).toISO();
+    const mockRelativeDate = '2 days ago';
 
     const result = formatDateString({
       ...defaultParams,

--- a/packages/twenty-front/src/utils/string/__tests__/formatDateString.test.ts
+++ b/packages/twenty-front/src/utils/string/__tests__/formatDateString.test.ts
@@ -29,7 +29,7 @@ describe('formatDateString', () => {
 
   it('should format date as relative when displayFormat is set to RELATIVE', () => {
     const mockDate = DateTime.now().minus({ months: 2 }).toISO();
-    const mockRelativeDate = 'about 2 months ago';
+    const mockRelativeDate = '2 months ago';
 
     jest.mock('@/localization/utils/formatDateISOStringToRelativeDate', () => ({
       formatDateISOStringToRelativeDate: jest

--- a/packages/twenty-front/src/utils/string/__tests__/formatDateTimeString.test.ts
+++ b/packages/twenty-front/src/utils/string/__tests__/formatDateTimeString.test.ts
@@ -30,14 +30,8 @@ describe('formatDateTimeString', () => {
   });
 
   it('should format date as relative when displayFormat is RELATIVE', () => {
-    const mockDate = DateTime.now().minus({ months: 2 }).toISO();
-    const mockRelativeDate = 'about 2 months ago';
-
-    jest.mock('@/localization/utils/formatDateISOStringToRelativeDate', () => ({
-      formatDateISOStringToRelativeDate: jest
-        .fn()
-        .mockReturnValue(mockRelativeDate),
-    }));
+    const mockDate = DateTime.now().minus({ days: 2 }).toISO();
+    const mockRelativeDate = '2 days ago';
 
     const result = formatDateTimeString({
       ...defaultParams,


### PR DESCRIPTION
This PR fixes a broken test that makes the CI crash.

This is due to the library `date-fns` which now doesn't use the word "about" in its relative date formatting, if we're not precisely on minus 2 months, which can change for example today the 29th of April, where the 29th of February doesn't exist.

So instead of using months and falling into hard to test cases, we use days instead, which is an easy and predictable relative computation.