### PR TITLE
force cache refresh for views after new object creation

### DIFF
--- a/packages/twenty-front/src/modules/object-metadata/hooks/useCreateOneObjectMetadataItem.ts
+++ b/packages/twenty-front/src/modules/object-metadata/hooks/useCreateOneObjectMetadataItem.ts
@@ -9,9 +9,12 @@ import {
 import { CREATE_ONE_OBJECT_METADATA_ITEM } from '../graphql/mutations';
 
 import { useRefreshObjectMetadataItems } from '@/object-metadata/hooks/useRefreshObjectMetadataItem';
+import { useRefreshCachedViews } from '@/views/hooks/useRefreshViews';
 import { useApolloMetadataClient } from './useApolloMetadataClient';
 
 export const useCreateOneObjectMetadataItem = () => {
+  const { refreshCachedViews } = useRefreshCachedViews();
+
   const apolloMetadataClient = useApolloMetadataClient();
   const { refreshObjectMetadataItems } =
     useRefreshObjectMetadataItems('network-only');
@@ -31,7 +34,7 @@ export const useCreateOneObjectMetadataItem = () => {
     });
 
     await refreshObjectMetadataItems();
-
+    refreshCachedViews();
     return createdObjectMetadata;
   };
 

--- a/packages/twenty-front/src/modules/views/hooks/useRefreshViews.ts
+++ b/packages/twenty-front/src/modules/views/hooks/useRefreshViews.ts
@@ -1,0 +1,25 @@
+import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
+import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
+import { useLazyFindManyRecords } from '@/object-record/hooks/useLazyFindManyRecords';
+import { findAllViewsOperationSignatureFactory } from '@/prefetch/graphql/operation-signatures/factories/findAllViewsOperationSignatureFactory';
+
+export const useRefreshCachedViews = () => {
+  const { objectMetadataItems } = useObjectMetadataItems();
+
+  const findAllViewsOperationSignature = findAllViewsOperationSignatureFactory({
+    objectMetadataItem: objectMetadataItems.find(
+      (item) => item.nameSingular === CoreObjectNameSingular.View,
+    ),
+  });
+
+  const { findManyRecords: refreshCachedViews } = useLazyFindManyRecords({
+    objectNameSingular: CoreObjectNameSingular.View,
+    filter: findAllViewsOperationSignature.variables.filter,
+    recordGqlFields: findAllViewsOperationSignature.fields,
+    fetchPolicy: 'network-only',
+  });
+
+  return {
+    refreshCachedViews,
+  };
+};


### PR DESCRIPTION
**Context** 
When creating a new object, it creates the "All ...." view associated.
After new object is created, in `PrefetchRunViewQueryEffect`, findManyViews returns cached results WITHOUT the new view.

git bisect - regression introduced with https://github.com/twentyhq/twenty/pull/10272

**Attempt** : Update to 'network-only' fetch policy in  `PrefetchRunViewQueryEffect` -> not working on useQuery apollo hook (🤯) : query is handle by cache and not network

**Solution** 
Based on pattern used for view creation (`useCreateViewFromCurrentView`), refreshing the view cache with a `useLazyFindManyRecords` solves the issue. Then, `prefetchViewsState` is updated in `PrefetchRunViewQueryEffect`


closes : https://github.com/twentyhq/core-team-issues/issues/845