### PR TITLE
Change workflow dispatch permissions

### DIFF
--- a/.github/workflows/preview-env-dispatch.yaml
+++ b/.github/workflows/preview-env-dispatch.yaml
@@ -12,8 +12,9 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
+  contents: write
   actions: write
+  pull-requests: read
 
 jobs:
   changed-files-check:


### PR DESCRIPTION
It seems that content: write is needed so that external contributors can dispatch workflows