### PR TITLE
Fix undefined read attempt

### DIFF
--- a/packages/twenty-server/src/engine/twenty-orm/utils/format-result.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/format-result.util.ts
@@ -1,8 +1,8 @@
 import { isPlainObject } from '@nestjs/common/utils/shared.utils';
 
 import { isNonEmptyString } from '@sniptt/guards';
-import { isDefined } from 'class-validator';
 import { FieldMetadataType } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
 
 import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
 
@@ -87,7 +87,9 @@ export function formatResult<T>(
   for (const [key, value] of Object.entries(data)) {
     const compositePropertyArgs = compositeFieldMetadataMap.get(key);
 
-    const fieldMetadata = objectMetadataItemWithFieldMaps.fieldsByName[key];
+    const fieldMetadata = objectMetadataItemWithFieldMaps.fieldsByName[key] as
+      | FieldMetadataInterface<FieldMetadataType>
+      | undefined;
 
     const isRelation = fieldMetadata
       ? isFieldMetadataInterfaceOfType(
@@ -151,7 +153,7 @@ export function formatResult<T>(
       }
     } else {
       if (isRelation) {
-        if (!fieldMetadata.relationTargetObjectMetadataId) {
+        if (!isDefined(fieldMetadata?.relationTargetObjectMetadataId)) {
           throw new Error(
             `Relation target object metadata ID is missing for field "${key}"`,
           );


### PR DESCRIPTION
# Introduction
Followup of https://github.com/twentyhq/twenty/pull/11784
Again some propaganda for the [noUncheckedIndexedAccess](https://www.typescriptlang.org/tsconfig/#noUncheckedIndexedAccess) that involved this @charlesBochet 👀 
That's very risky to have this setup to false especially in the backend regarding the twenty-server metadata nature

Also suggested that we do some integration testing ( e2e nestsJs tests ) on a related endpoint that could related we always retrieve the same form result output

We could also do some unit testing of the method but like the idea to ship it through the api itself