### PR TITLE
Standardize `isDefined` usage for metadata version assertions

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/relation/field-metadata-relation.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/relation/field-metadata-relation.service.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
+import { isDefined } from 'twenty-shared/utils';
+
 import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
 
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
@@ -10,7 +12,6 @@ import {
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 import { removeFieldMapsFromObjectMetadata } from 'src/engine/metadata-modules/utils/remove-field-maps-from-object-metadata.util';
 import { WorkspaceCacheStorageService } from 'src/engine/workspace-cache-storage/workspace-cache-storage.service';
-import { isDefined } from 'twenty-shared/utils';
 
 @Injectable()
 export class FieldMetadataRelationService {

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/relation/field-metadata-relation.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/relation/field-metadata-relation.service.ts
@@ -10,6 +10,7 @@ import {
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 import { removeFieldMapsFromObjectMetadata } from 'src/engine/metadata-modules/utils/remove-field-maps-from-object-metadata.util';
 import { WorkspaceCacheStorageService } from 'src/engine/workspace-cache-storage/workspace-cache-storage.service';
+import { isDefined } from 'twenty-shared/utils';
 
 @Injectable()
 export class FieldMetadataRelationService {
@@ -40,7 +41,7 @@ export class FieldMetadataRelationService {
     const metadataVersion =
       await this.workspaceCacheStorageService.getMetadataVersion(workspaceId);
 
-    if (!metadataVersion) {
+    if (!isDefined(metadataVersion)) {
       throw new FieldMetadataException(
         `Metadata version not found for workspace ${workspaceId}`,
         FieldMetadataExceptionCode.INTERNAL_SERVER_ERROR,

--- a/packages/twenty-server/src/engine/metadata-modules/relation-metadata/relation-metadata.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/relation-metadata/relation-metadata.service.ts
@@ -537,7 +537,7 @@ export class RelationMetadataService extends TypeOrmQueryService<RelationMetadat
     const metadataVersion =
       await this.workspaceCacheStorageService.getMetadataVersion(workspaceId);
 
-    if (!metadataVersion) {
+    if (!isDefined(metadataVersion)) {
       throw new NotFoundException(
         `Metadata version not found for workspace ${workspaceId}`,
       );

--- a/packages/twenty-server/src/engine/metadata-modules/workspace-metadata-cache/services/workspace-metadata-cache.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/workspace-metadata-cache/services/workspace-metadata-cache.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { Repository } from 'typeorm';
+import { isDefined } from 'twenty-shared/utils';
 
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
@@ -12,7 +13,6 @@ import {
   WorkspaceMetadataCacheExceptionCode,
 } from 'src/engine/metadata-modules/workspace-metadata-cache/exceptions/workspace-metadata-cache.exception';
 import { WorkspaceCacheStorageService } from 'src/engine/workspace-cache-storage/workspace-cache-storage.service';
-import { isDefined } from 'twenty-shared/utils';
 
 @Injectable()
 export class WorkspaceMetadataCacheService {

--- a/packages/twenty-server/src/engine/metadata-modules/workspace-metadata-cache/services/workspace-metadata-cache.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/workspace-metadata-cache/services/workspace-metadata-cache.service.ts
@@ -12,6 +12,7 @@ import {
   WorkspaceMetadataCacheExceptionCode,
 } from 'src/engine/metadata-modules/workspace-metadata-cache/exceptions/workspace-metadata-cache.exception';
 import { WorkspaceCacheStorageService } from 'src/engine/workspace-cache-storage/workspace-cache-storage.service';
+import { isDefined } from 'twenty-shared/utils';
 
 @Injectable()
 export class WorkspaceMetadataCacheService {
@@ -44,7 +45,7 @@ export class WorkspaceMetadataCacheService {
     const currentDatabaseVersion =
       await this.getMetadataVersionFromDatabase(workspaceId);
 
-    if (currentDatabaseVersion === undefined) {
+    if (!isDefined(currentDatabaseVersion)) {
       throw new WorkspaceMetadataCacheException(
         'Metadata version not found in the database',
         WorkspaceMetadataCacheExceptionCode.METADATA_VERSION_NOT_FOUND,

--- a/packages/twenty-server/src/engine/metadata-modules/workspace-metadata-version/services/workspace-metadata-version.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/workspace-metadata-version/services/workspace-metadata-version.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { Repository } from 'typeorm';
+import { isDefined } from 'twenty-shared/utils';
 
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { WorkspaceMetadataCacheService } from 'src/engine/metadata-modules/workspace-metadata-cache/services/workspace-metadata-cache.service';
@@ -9,7 +10,6 @@ import {
   WorkspaceMetadataVersionException,
   WorkspaceMetadataVersionExceptionCode,
 } from 'src/engine/metadata-modules/workspace-metadata-version/exceptions/workspace-metadata-version.exception';
-import { isDefined } from 'twenty-shared/utils';
 
 @Injectable()
 export class WorkspaceMetadataVersionService {

--- a/packages/twenty-server/src/engine/metadata-modules/workspace-metadata-version/services/workspace-metadata-version.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/workspace-metadata-version/services/workspace-metadata-version.service.ts
@@ -9,6 +9,7 @@ import {
   WorkspaceMetadataVersionException,
   WorkspaceMetadataVersionExceptionCode,
 } from 'src/engine/metadata-modules/workspace-metadata-version/exceptions/workspace-metadata-version.exception';
+import { isDefined } from 'twenty-shared/utils';
 
 @Injectable()
 export class WorkspaceMetadataVersionService {
@@ -27,7 +28,7 @@ export class WorkspaceMetadataVersionService {
 
     const metadataVersion = workspace?.metadataVersion;
 
-    if (metadataVersion === undefined) {
+    if (!isDefined(metadataVersion)) {
       throw new WorkspaceMetadataVersionException(
         'Metadata version not found',
         WorkspaceMetadataVersionExceptionCode.METADATA_VERSION_NOT_FOUND,

--- a/packages/twenty-server/src/engine/twenty-orm/factories/workspace-datasource.factory.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/factories/workspace-datasource.factory.ts
@@ -307,7 +307,7 @@ export class WorkspaceDatasourceFactory {
     let latestWorkspaceMetadataVersion =
       await this.workspaceCacheStorageService.getMetadataVersion(workspaceId);
 
-    if (latestWorkspaceMetadataVersion === undefined) {
+    if (!isDefined(latestWorkspaceMetadataVersion)) {
       if (shouldFailIfMetadataNotFound) {
         throw new TwentyORMException(
           `Metadata version not found for workspace ${workspaceId}`,
@@ -325,7 +325,7 @@ export class WorkspaceDatasourceFactory {
       }
     }
 
-    if (!latestWorkspaceMetadataVersion) {
+    if (!isDefined(latestWorkspaceMetadataVersion)) {
       throw new TwentyORMException(
         `Metadata version not found after recompute for workspace ${workspaceId}`,
         TwentyORMExceptionCode.METADATA_VERSION_NOT_FOUND,


### PR DESCRIPTION
# Introduction
`!value` is risky as `!falsy` would return `true`