### PR TITLE
fix: do not report EmailNotVerifiedError to Sentry (#11753)

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/graphql/utils/should-capture-exception.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/graphql/utils/should-capture-exception.util.ts
@@ -12,6 +12,7 @@ export const graphQLErrorCodesToFilterOut = [
   ErrorCode.TIMEOUT,
   ErrorCode.CONFLICT,
   ErrorCode.BAD_USER_INPUT,
+  ErrorCode.EMAIL_NOT_VERIFIED,
 ];
 
 export const shouldCaptureException = (exception: Error): boolean => {


### PR DESCRIPTION
This PR prevents EmailNotVerifiedError from being reported to Sentry, as discussed in issue #11753.

edit:
close #11753 