### PR TITLE
Redis max memory limit and eviction policy

### DIFF
--- a/packages/twenty-docker/docker-compose.yml
+++ b/packages/twenty-docker/docker-compose.yml
@@ -134,6 +134,7 @@ services:
   redis:
     image: redis
     restart: always
+    command: ["--maxmemory-policy", "noeviction"]
 
 volumes:
   docker-data:

--- a/packages/twenty-docker/k8s/manifests/deployment-redis.yaml
+++ b/packages/twenty-docker/k8s/manifests/deployment-redis.yaml
@@ -25,7 +25,7 @@ spec:
         - name: redis
           image: redis/redis-stack-server:latest
           imagePullPolicy: Always
-          args: ["--maxmemory", "1800mb", "--maxmemory-policy", "noeviction"]
+          args: ["--maxmemory-policy", "noeviction"]
           env:
             - name: PORT
               value: "6379"

--- a/packages/twenty-docker/k8s/manifests/deployment-redis.yaml
+++ b/packages/twenty-docker/k8s/manifests/deployment-redis.yaml
@@ -25,9 +25,10 @@ spec:
         - name: redis
           image: redis/redis-stack-server:latest
           imagePullPolicy: Always
+          args: ["--maxmemory", "1800mb", "--maxmemory-policy", "noeviction"]
           env:
             - name: PORT
-              value: 6379
+              value: "6379"
           ports:
             - containerPort: 6379
               name: redis

--- a/packages/twenty-docker/podman/podman-compose.yml
+++ b/packages/twenty-docker/podman/podman-compose.yml
@@ -14,6 +14,7 @@ services:
   redis:
     container_name: twenty-redis
     image: redis:latest
+    command: ["--maxmemory-policy", "noeviction"]
     volumes:
       - twenty-redis-data:/data:Z
 


### PR DESCRIPTION
# Introduction
Redis [eviction policy](https://redis.io/docs/latest/operate/rs/databases/memory-performance/eviction-policy/) and [Key eviction](https://redis.io/docs/latest/develop/reference/eviction/)
[Bullmq eviction recommendations](https://docs.bullmq.io/guide/going-to-production#max-memory-policy)


We might need a dedicated bullmq redis instance, as sharing engine/metadata keys and bull will someday become problematic

close https://github.com/twentyhq/core-team-issues/issues/452

About to open a PR for our internal IaC

Ps: Did not set a `--maxmemory` that could be leading to undetermined OOOM errors at runtime. Should be user provided or should define a default value ?