### PR TITLE
fix relation creation bug

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/hooks/useRelationToOneFieldDisplay.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/hooks/useRelationToOneFieldDisplay.ts
@@ -60,9 +60,8 @@ export const useRelationToOneFieldDisplay = () => {
     : (record: ObjectRecord) =>
         generateDefaultRecordChipData({
           record,
-          // @ts-expect-error Above assertions does not infer that fieldDefinition.metadata.objectMetadataNameSingular always defined
           objectNameSingular:
-            fieldDefinition.metadata.objectMetadataNameSingular,
+            fieldDefinition.metadata.relationObjectMetadataNameSingular,
         });
 
   return {


### PR DESCRIPTION
Context : In `RelationToOneFieldDisplay`, the `objectNameSingular` used for the chip calculation was incorrect - it was using the value from the opposite side of the relationship. Then, labelIdentifier based on composite fields were causing errors (People and WorkspaceMembers with name)


<img width="300" alt="Screenshot 2025-05-03 at 08 03 46" src="https://github.com/user-attachments/assets/8d034700-5244-4b1b-978e-f77ae78b6ceb" />


Tested everywhere FieldDisplay is used. 
Tested for each both relation type. 

closes https://github.com/twentyhq/twenty/issues/11826