### PR TITLE
fix: Restoring record results in blank line in TimelineActivity (#11679)

### DIFF
--- a/packages/twenty-front/src/modules/activities/timeline-activities/rows/components/EventIconDynamicComponent.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/rows/components/EventIconDynamicComponent.tsx
@@ -27,7 +27,7 @@ export const EventIconDynamicComponent = ({
   if (eventAction === 'deleted') {
     return <IconTrash />;
   }
-  if(eventAction === 'restored'){
+  if (eventAction === 'restored'){
     return <IconRestore />;
   }
 

--- a/packages/twenty-front/src/modules/activities/timeline-activities/rows/components/EventIconDynamicComponent.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/rows/components/EventIconDynamicComponent.tsx
@@ -3,6 +3,7 @@ import { ObjectMetadataItem } from '@/object-metadata/types/ObjectMetadataItem';
 import {
   IconCirclePlus,
   IconEditCircle,
+  IconRestore,
   IconTrash,
   useIcons,
 } from 'twenty-ui/display';
@@ -25,6 +26,9 @@ export const EventIconDynamicComponent = ({
   }
   if (eventAction === 'deleted') {
     return <IconTrash />;
+  }
+  if(eventAction === 'restored'){
+    return <IconRestore />;
   }
 
   const IconComponent = getIcon(linkedObjectMetadataItem?.icon);

--- a/packages/twenty-front/src/modules/activities/timeline-activities/rows/components/EventIconDynamicComponent.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/rows/components/EventIconDynamicComponent.tsx
@@ -27,7 +27,7 @@ export const EventIconDynamicComponent = ({
   if (eventAction === 'deleted') {
     return <IconTrash />;
   }
-  if (eventAction === 'restored'){
+  if (eventAction === 'restored') {
     return <IconRestore />;
   }
 

--- a/packages/twenty-front/src/modules/activities/timeline-activities/rows/main-object/components/EventRowMainObject.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/rows/main-object/components/EventRowMainObject.tsx
@@ -5,6 +5,7 @@ import {
 } from '@/activities/timeline-activities/rows/components/EventRowDynamicComponent';
 import { EventRowMainObjectUpdated } from '@/activities/timeline-activities/rows/main-object/components/EventRowMainObjectUpdated';
 import styled from '@emotion/styled';
+import { t } from '@lingui/core/macro';
 import { MOBILE_VIEWPORT } from 'twenty-ui/theme';
 
 type EventRowMainObjectProps = EventRowDynamicComponentProps;
@@ -57,7 +58,7 @@ export const EventRowMainObject = ({
                 {labelIdentifierValue}
               </StyledEventRowItemColumn>
               <StyledEventRowItemAction>
-                was created by
+                {t`was created by`}
               </StyledEventRowItemAction>
               <StyledEventRowItemColumn>
                 {authorFullName}
@@ -88,7 +89,7 @@ export const EventRowMainObject = ({
                 {labelIdentifierValue}
               </StyledEventRowItemColumn>
               <StyledEventRowItemAction>
-                was deleted by
+               {t`was deleted by`}
               </StyledEventRowItemAction>
               <StyledEventRowItemColumn>
                 {authorFullName}
@@ -108,7 +109,7 @@ export const EventRowMainObject = ({
                 {labelIdentifierValue}
               </StyledEventRowItemColumn>
               <StyledEventRowItemAction>
-                was restored by
+               {t`was restored by`}
               </StyledEventRowItemAction>
               <StyledEventRowItemColumn>
                 {authorFullName}

--- a/packages/twenty-front/src/modules/activities/timeline-activities/rows/main-object/components/EventRowMainObject.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/rows/main-object/components/EventRowMainObject.tsx
@@ -89,7 +89,7 @@ export const EventRowMainObject = ({
                 {labelIdentifierValue}
               </StyledEventRowItemColumn>
               <StyledEventRowItemAction>
-               {t`was deleted by`}
+                {t`was deleted by`}
               </StyledEventRowItemAction>
               <StyledEventRowItemColumn>
                 {authorFullName}
@@ -109,7 +109,7 @@ export const EventRowMainObject = ({
                 {labelIdentifierValue}
               </StyledEventRowItemColumn>
               <StyledEventRowItemAction>
-               {t`was restored by`}
+                {t`was restored by`}
               </StyledEventRowItemAction>
               <StyledEventRowItemColumn>
                 {authorFullName}

--- a/packages/twenty-front/src/modules/activities/timeline-activities/rows/main-object/components/EventRowMainObject.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/rows/main-object/components/EventRowMainObject.tsx
@@ -99,6 +99,26 @@ export const EventRowMainObject = ({
         </StyledMainContainer>
       );
     }
+    case 'restored': {
+      return (
+        <StyledMainContainer>
+          <StyledRowContainer>
+            <StyledRow>
+              <StyledEventRowItemColumn>
+                {labelIdentifierValue}
+              </StyledEventRowItemColumn>
+              <StyledEventRowItemAction>
+                was restored by
+              </StyledEventRowItemAction>
+              <StyledEventRowItemColumn>
+                {authorFullName}
+              </StyledEventRowItemColumn>
+            </StyledRow>
+            <StyledItemTitleDate>{createdAt}</StyledItemTitleDate>
+          </StyledRowContainer>
+        </StyledMainContainer>
+      );
+    }
     default:
       return null;
   }


### PR DESCRIPTION
Fixes issue #11679 
There were no case of restored so it was defaulting to null thus showing the blank line

Handled case for restored so it doesn't default to null 

Image shows record restored by the user and restored by other user
![Screenshot 2025-05-03 011257](https://github.com/user-attachments/assets/8b848992-4250-4266-9a3e-1ca89e1a06b8)
