### PR TITLE
Use correct env var name in podman-compose

### DIFF
--- a/packages/twenty-docker/podman/podman-compose.yml
+++ b/packages/twenty-docker/podman/podman-compose.yml
@@ -7,7 +7,7 @@ services:
     environment:
       POSTGRES_DB: twenty
       POSTGRES_USER: twenty
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_PASSWORD: ${PG_DATABASE_PASSWORD}
     volumes:
       - twenty-db-data:/var/lib/postgresql/data:Z
 
@@ -24,7 +24,7 @@ services:
     environment:
       NODE_PORT: "3000"
       SERVER_URL: ${SERVER_URL}
-      PG_DATABASE_URL: "postgresql://twenty:${POSTGRES_PASSWORD}@twenty-db:5432/twenty"
+      PG_DATABASE_URL: "postgresql://twenty:${PG_DATABASE_PASSWORD}@twenty-db:5432/twenty"
       REDIS_URL: "redis://twenty-redis:6379"
       APP_SECRET: ${APP_SECRET}
       NODE_ENV: production
@@ -40,7 +40,7 @@ services:
     command: yarn worker:prod
     environment:
       SERVER_URL: ${SERVER_URL}
-      PG_DATABASE_URL: "postgresql://twenty:${POSTGRES_PASSWORD}@twenty-db:5432/twenty"
+      PG_DATABASE_URL: "postgresql://twenty:${PG_DATABASE_PASSWORD}@twenty-db:5432/twenty"
       REDIS_URL: "redis://twenty-redis:6379"
       APP_SECRET: ${APP_SECRET}
       DISABLE_DB_MIGRATIONS: "true"


### PR DESCRIPTION
The example .env file uses `PG_DATABASE_PASSWORD` so this makes it consistent. Currently, the podman-compose directions will fail on first run unless you manually change the env var name.