### PR TITLE
Preview env dispatch using `-paths` syntax

### DIFF
--- a/.github/workflows/preview-env-dispatch.yaml
+++ b/.github/workflows/preview-env-dispatch.yaml
@@ -6,30 +6,24 @@ on:
   # and not checking out or running any code from the external contributor's PR
   pull_request_target:
     types: [opened, synchronize, reopened, labeled]
+    paths:
+      - packages/twenty-docker/**
+      - packages/twenty-server/**
+      - packages/twenty-front/**
+      - .github/workflows/preview-env-dispatch.yaml
+      - .github/workflows/preview-env-keepalive.yaml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  changed-files-check:
-    uses: ./.github/workflows/changed-files.yaml
-    with:
-      files: |
-        .github/workflows/preview-env-dispatch.yaml
-        .github/workflows/preview-env-keepalive.yaml
-        packages/twenty-docker/**
-        docker-compose.yml
-        packages/twenty-server/**
-        packages/twenty-front/**
-
   trigger-preview:
-    needs: changed-files-check
     permissions:
       contents: write
       actions: write
       pull-requests: read
-    if: needs.changed-files-check.outputs.any_changed == 'true' || contains(github.event.pull_request.labels.*.name, 'preview')
+    if: contains(github.event.pull_request.labels.*.name, 'preview')
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
# Introduction
Using changed-files from a forked repo with `pull_request_target` results in invalid checkout issue
Used the native paths GitHub Actions syntax to handle workflow triggering

[Paths syntax](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore)