### PR TITLE
Modify Decimal Fields to be treated as `number` in OpenAPI schema.

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/open-api/utils/__tests__/__snapshots__/components.utils.spec.ts.snap
+++ b/packages/twenty-server/src/engine/core-modules/open-api/utils/__tests__/__snapshots__/components.utils.spec.ts.snap
@@ -1,0 +1,106 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`computeSchemaComponents Float without decimals 1`] = `
+{
+  "ObjectName": {
+    "description": undefined,
+    "properties": {
+      "number2": {
+        "type": "number",
+      },
+    },
+    "required": [
+      "number2",
+    ],
+    "type": "object",
+  },
+  "ObjectName for Response": {
+    "description": undefined,
+    "properties": {
+      "number2": {
+        "type": "number",
+      },
+    },
+    "type": "object",
+  },
+  "ObjectName for Update": {
+    "description": undefined,
+    "properties": {
+      "number2": {
+        "type": "number",
+      },
+    },
+    "type": "object",
+  },
+}
+`;
+
+exports[`computeSchemaComponents Integer dataType with decimals 1`] = `
+{
+  "ObjectName": {
+    "description": undefined,
+    "properties": {
+      "number1": {
+        "type": "number",
+      },
+    },
+    "required": [
+      "number1",
+    ],
+    "type": "object",
+  },
+  "ObjectName for Response": {
+    "description": undefined,
+    "properties": {
+      "number1": {
+        "type": "number",
+      },
+    },
+    "type": "object",
+  },
+  "ObjectName for Update": {
+    "description": undefined,
+    "properties": {
+      "number1": {
+        "type": "number",
+      },
+    },
+    "type": "object",
+  },
+}
+`;
+
+exports[`computeSchemaComponents Integer with a 0 decimals 1`] = `
+{
+  "ObjectName": {
+    "description": undefined,
+    "properties": {
+      "number3": {
+        "type": "integer",
+      },
+    },
+    "required": [
+      "number3",
+    ],
+    "type": "object",
+  },
+  "ObjectName for Response": {
+    "description": undefined,
+    "properties": {
+      "number3": {
+        "type": "integer",
+      },
+    },
+    "type": "object",
+  },
+  "ObjectName for Update": {
+    "description": undefined,
+    "properties": {
+      "number3": {
+        "type": "integer",
+      },
+    },
+    "type": "object",
+  },
+}
+`;

--- a/packages/twenty-server/src/engine/core-modules/open-api/utils/__tests__/components.utils.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/open-api/utils/__tests__/components.utils.spec.ts
@@ -10,659 +10,708 @@ import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadat
 describe('computeSchemaComponents', () => {
   it('should compute schema components', () => {
     expect(
-      computeSchemaComponents([
-        objectMetadataItemMock,
-      ] as ObjectMetadataEntity[]),
-    ).toEqual({
-      ObjectName: {
-        description: undefined,
-        type: 'object',
-        properties: {
-          fieldUuid: {
-            type: 'string',
-            format: 'uuid',
-          },
-          fieldText: {
-            type: 'string',
-          },
-          fieldPhones: {
-            properties: {
-              additionalPhones: {
-                type: 'array',
-                items: {
-                  type: 'string',
-                },
-              },
-              primaryPhoneCountryCode: {
-                type: 'string',
-              },
-              primaryPhoneCallingCode: {
-                type: 'string',
-              },
-              primaryPhoneNumber: {
-                type: 'string',
-              },
-            },
-            type: 'object',
-          },
-          fieldEmails: {
-            type: 'object',
-            properties: {
-              primaryEmail: {
-                type: 'string',
-              },
-              additionalEmails: {
-                type: 'array',
-                items: {
-                  type: 'string',
-                  format: 'email',
-                },
-              },
-            },
-          },
-          fieldDateTime: {
-            type: 'string',
-            format: 'date-time',
-          },
-          fieldDate: {
-            type: 'string',
-            format: 'date',
-          },
-          fieldArray: {
-            items: {
-              type: 'string',
-            },
-            type: 'array',
-          },
-          fieldBoolean: {
-            type: 'boolean',
-          },
-          fieldNumber: {
-            type: 'integer',
-          },
-          fieldNumeric: {
-            type: 'number',
-          },
-          fieldLinks: {
-            type: 'object',
-            properties: {
-              primaryLinkLabel: {
-                type: 'string',
-              },
-              primaryLinkUrl: {
-                type: 'string',
-              },
-              secondaryLinks: {
-                type: 'array',
-                items: {
-                  type: 'object',
-                  description: 'A secondary link',
-                  properties: {
-                    url: {
-                      type: 'string',
-                      format: 'uri',
-                    },
-                    label: {
-                      type: 'string',
-                    },
-                  },
-                },
-              },
-            },
-          },
-          fieldCurrency: {
-            type: 'object',
-            properties: {
-              amountMicros: {
-                type: 'number',
-              },
-              currencyCode: {
-                type: 'string',
-              },
-            },
-          },
-          fieldFullName: {
-            type: 'object',
-            properties: {
-              firstName: {
-                type: 'string',
-              },
-              lastName: {
-                type: 'string',
-              },
-            },
-          },
-          fieldRating: {
-            type: 'string',
-            enum: ['RATING_1', 'RATING_2'],
-          },
-          fieldSelect: {
-            type: 'string',
-            enum: ['OPTION_1', 'OPTION_2'],
-          },
-          fieldMultiSelect: {
-            type: 'array',
-            items: { type: 'string', enum: ['OPTION_1', 'OPTION_2'] },
-          },
-          fieldPosition: {
-            type: 'number',
-          },
-          fieldAddress: {
-            type: 'object',
-            properties: {
-              addressStreet1: {
-                type: 'string',
-              },
-              addressStreet2: {
-                type: 'string',
-              },
-              addressCity: {
-                type: 'string',
-              },
-              addressPostcode: {
-                type: 'string',
-              },
-              addressState: {
-                type: 'string',
-              },
-              addressCountry: {
-                type: 'string',
-              },
-              addressLat: {
-                type: 'number',
-              },
-              addressLng: {
-                type: 'number',
-              },
-            },
-          },
-          fieldRawJson: {
-            type: 'object',
-          },
-          fieldRichText: {
-            type: 'string',
-          },
-          fieldActor: {
-            type: 'object',
-            properties: {
-              source: {
-                type: 'string',
-                enum: [
-                  'EMAIL',
-                  'CALENDAR',
-                  'WORKFLOW',
-                  'API',
-                  'IMPORT',
-                  'MANUAL',
-                  'SYSTEM',
-                  'WEBHOOK',
-                ],
-              },
-            },
+  computeSchemaComponents([
+  objectMetadataItemMock] as
+  ObjectMetadataEntity[])
+).toMatchInlineSnapshot(`
+{
+  "ObjectName": {
+    "description": undefined,
+    "properties": {
+      "fieldActor": {
+        "properties": {
+          "source": {
+            "enum": [
+              "EMAIL",
+              "CALENDAR",
+              "WORKFLOW",
+              "API",
+              "IMPORT",
+              "MANUAL",
+              "SYSTEM",
+              "WEBHOOK",
+            ],
+            "type": "string",
           },
         },
-        required: ['fieldNumber'],
+        "type": "object",
       },
-      'ObjectName for Update': {
-        description: undefined,
-        type: 'object',
-        properties: {
-          fieldUuid: {
-            type: 'string',
-            format: 'uuid',
+      "fieldAddress": {
+        "properties": {
+          "addressCity": {
+            "type": "string",
           },
-          fieldText: {
-            type: 'string',
+          "addressCountry": {
+            "type": "string",
           },
-          fieldPhones: {
-            properties: {
-              additionalPhones: {
-                type: 'array',
-                items: {
-                  type: 'string',
-                },
-              },
-              primaryPhoneCountryCode: {
-                type: 'string',
-              },
-              primaryPhoneCallingCode: {
-                type: 'string',
-              },
-              primaryPhoneNumber: {
-                type: 'string',
-              },
-            },
-            type: 'object',
+          "addressLat": {
+            "type": "number",
           },
-          fieldEmails: {
-            type: 'object',
-            properties: {
-              primaryEmail: {
-                type: 'string',
-              },
-              additionalEmails: {
-                type: 'array',
-                items: {
-                  type: 'string',
-                  format: 'email',
-                },
-              },
-            },
+          "addressLng": {
+            "type": "number",
           },
-          fieldDateTime: {
-            type: 'string',
-            format: 'date-time',
+          "addressPostcode": {
+            "type": "string",
           },
-          fieldDate: {
-            type: 'string',
-            format: 'date',
+          "addressState": {
+            "type": "string",
           },
-          fieldArray: {
-            items: {
-              type: 'string',
-            },
-            type: 'array',
+          "addressStreet1": {
+            "type": "string",
           },
-          fieldBoolean: {
-            type: 'boolean',
-          },
-          fieldNumber: {
-            type: 'integer',
-          },
-          fieldNumeric: {
-            type: 'number',
-          },
-          fieldLinks: {
-            type: 'object',
-            properties: {
-              primaryLinkLabel: {
-                type: 'string',
-              },
-              primaryLinkUrl: {
-                type: 'string',
-              },
-              secondaryLinks: {
-                type: 'array',
-                items: {
-                  type: 'object',
-                  description: 'A secondary link',
-                  properties: {
-                    url: {
-                      type: 'string',
-                      format: 'uri',
-                    },
-                    label: {
-                      type: 'string',
-                    },
-                  },
-                },
-              },
-            },
-          },
-          fieldCurrency: {
-            type: 'object',
-            properties: {
-              amountMicros: {
-                type: 'number',
-              },
-              currencyCode: {
-                type: 'string',
-              },
-            },
-          },
-          fieldFullName: {
-            type: 'object',
-            properties: {
-              firstName: {
-                type: 'string',
-              },
-              lastName: {
-                type: 'string',
-              },
-            },
-          },
-          fieldRating: {
-            type: 'string',
-            enum: ['RATING_1', 'RATING_2'],
-          },
-          fieldSelect: {
-            type: 'string',
-            enum: ['OPTION_1', 'OPTION_2'],
-          },
-          fieldMultiSelect: {
-            type: 'array',
-            items: { type: 'string', enum: ['OPTION_1', 'OPTION_2'] },
-          },
-          fieldPosition: {
-            type: 'number',
-          },
-          fieldAddress: {
-            type: 'object',
-            properties: {
-              addressStreet1: {
-                type: 'string',
-              },
-              addressStreet2: {
-                type: 'string',
-              },
-              addressCity: {
-                type: 'string',
-              },
-              addressPostcode: {
-                type: 'string',
-              },
-              addressState: {
-                type: 'string',
-              },
-              addressCountry: {
-                type: 'string',
-              },
-              addressLat: {
-                type: 'number',
-              },
-              addressLng: {
-                type: 'number',
-              },
-            },
-          },
-          fieldRawJson: {
-            type: 'object',
-          },
-          fieldRichText: {
-            type: 'string',
-          },
-          fieldActor: {
-            type: 'object',
-            properties: {
-              source: {
-                type: 'string',
-                enum: [
-                  'EMAIL',
-                  'CALENDAR',
-                  'WORKFLOW',
-                  'API',
-                  'IMPORT',
-                  'MANUAL',
-                  'SYSTEM',
-                  'WEBHOOK',
-                ],
-              },
-            },
+          "addressStreet2": {
+            "type": "string",
           },
         },
+        "type": "object",
       },
-      'ObjectName for Response': {
-        description: undefined,
-        type: 'object',
-        properties: {
-          fieldUuid: {
-            type: 'string',
-            format: 'uuid',
+      "fieldArray": {
+        "items": {
+          "type": "string",
+        },
+        "type": "array",
+      },
+      "fieldBoolean": {
+        "type": "boolean",
+      },
+      "fieldCurrency": {
+        "properties": {
+          "amountMicros": {
+            "type": "number",
           },
-          fieldText: {
-            type: 'string',
-          },
-          fieldPhones: {
-            properties: {
-              additionalPhones: {
-                type: 'array',
-                items: {
-                  type: 'string',
-                },
-              },
-              primaryPhoneCountryCode: {
-                type: 'string',
-              },
-              primaryPhoneCallingCode: {
-                type: 'string',
-              },
-              primaryPhoneNumber: {
-                type: 'string',
-              },
-            },
-            type: 'object',
-          },
-          fieldEmails: {
-            type: 'object',
-            properties: {
-              primaryEmail: {
-                type: 'string',
-              },
-              additionalEmails: {
-                type: 'array',
-                items: {
-                  type: 'string',
-                  format: 'email',
-                },
-              },
-            },
-          },
-          fieldDateTime: {
-            type: 'string',
-            format: 'date-time',
-          },
-          fieldDate: {
-            type: 'string',
-            format: 'date',
-          },
-          fieldArray: {
-            items: {
-              type: 'string',
-            },
-            type: 'array',
-          },
-          fieldBoolean: {
-            type: 'boolean',
-          },
-          fieldNumber: {
-            type: 'integer',
-          },
-          fieldNumeric: {
-            type: 'number',
-          },
-          fieldLinks: {
-            type: 'object',
-            properties: {
-              primaryLinkLabel: {
-                type: 'string',
-              },
-              primaryLinkUrl: {
-                type: 'string',
-              },
-              secondaryLinks: {
-                type: 'array',
-                items: {
-                  type: 'object',
-                  description: 'A secondary link',
-                  properties: {
-                    url: {
-                      type: 'string',
-                      format: 'uri',
-                    },
-                    label: {
-                      type: 'string',
-                    },
-                  },
-                },
-              },
-            },
-          },
-          fieldCurrency: {
-            type: 'object',
-            properties: {
-              amountMicros: {
-                type: 'number',
-              },
-              currencyCode: {
-                type: 'string',
-              },
-            },
-          },
-          fieldFullName: {
-            type: 'object',
-            properties: {
-              firstName: {
-                type: 'string',
-              },
-              lastName: {
-                type: 'string',
-              },
-            },
-          },
-          fieldRating: {
-            type: 'string',
-            enum: ['RATING_1', 'RATING_2'],
-          },
-          fieldSelect: {
-            type: 'string',
-            enum: ['OPTION_1', 'OPTION_2'],
-          },
-          fieldMultiSelect: {
-            type: 'array',
-            items: { type: 'string', enum: ['OPTION_1', 'OPTION_2'] },
-          },
-          fieldPosition: {
-            type: 'number',
-          },
-          fieldAddress: {
-            type: 'object',
-            properties: {
-              addressStreet1: {
-                type: 'string',
-              },
-              addressStreet2: {
-                type: 'string',
-              },
-              addressCity: {
-                type: 'string',
-              },
-              addressPostcode: {
-                type: 'string',
-              },
-              addressState: {
-                type: 'string',
-              },
-              addressCountry: {
-                type: 'string',
-              },
-              addressLat: {
-                type: 'number',
-              },
-              addressLng: {
-                type: 'number',
-              },
-            },
-          },
-          fieldRawJson: {
-            type: 'object',
-          },
-          fieldRichText: {
-            type: 'string',
-          },
-          fieldActor: {
-            type: 'object',
-            properties: {
-              source: {
-                type: 'string',
-                enum: [
-                  'EMAIL',
-                  'CALENDAR',
-                  'WORKFLOW',
-                  'API',
-                  'IMPORT',
-                  'MANUAL',
-                  'SYSTEM',
-                  'WEBHOOK',
-                ],
-              },
-              workspaceMemberId: {
-                type: 'string',
-                format: 'uuid',
-              },
-              name: {
-                type: 'string',
-              },
-            },
-          },
-          fieldRelation: {
-            type: 'array',
-            items: {
-              $ref: '#/components/schemas/ToObjectMetadataName for Response',
-            },
+          "currencyCode": {
+            "type": "string",
           },
         },
+        "type": "object",
       },
-    });
+      "fieldDate": {
+        "format": "date",
+        "type": "string",
+      },
+      "fieldDateTime": {
+        "format": "date-time",
+        "type": "string",
+      },
+      "fieldEmails": {
+        "properties": {
+          "additionalEmails": {
+            "items": {
+              "format": "email",
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "primaryEmail": {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "fieldFullName": {
+        "properties": {
+          "firstName": {
+            "type": "string",
+          },
+          "lastName": {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "fieldLinks": {
+        "properties": {
+          "primaryLinkLabel": {
+            "type": "string",
+          },
+          "primaryLinkUrl": {
+            "type": "string",
+          },
+          "secondaryLinks": {
+            "items": {
+              "description": "A secondary link",
+              "properties": {
+                "label": {
+                  "type": "string",
+                },
+                "url": {
+                  "format": "uri",
+                  "type": "string",
+                },
+              },
+              "type": "object",
+            },
+            "type": "array",
+          },
+        },
+        "type": "object",
+      },
+      "fieldMultiSelect": {
+        "items": {
+          "enum": [
+            "OPTION_1",
+            "OPTION_2",
+          ],
+          "type": "string",
+        },
+        "type": "array",
+      },
+      "fieldNumber": {
+        "type": "integer",
+      },
+      "fieldNumeric": {
+        "type": "number",
+      },
+      "fieldPhones": {
+        "properties": {
+          "additionalPhones": {
+            "items": {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "primaryPhoneCallingCode": {
+            "type": "string",
+          },
+          "primaryPhoneCountryCode": {
+            "type": "string",
+          },
+          "primaryPhoneNumber": {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "fieldPosition": {
+        "type": "number",
+      },
+      "fieldRating": {
+        "enum": [
+          "RATING_1",
+          "RATING_2",
+        ],
+        "type": "string",
+      },
+      "fieldRawJson": {
+        "type": "object",
+      },
+      "fieldRichText": {
+        "type": "string",
+      },
+      "fieldSelect": {
+        "enum": [
+          "OPTION_1",
+          "OPTION_2",
+        ],
+        "type": "string",
+      },
+      "fieldText": {
+        "type": "string",
+      },
+      "fieldUuid": {
+        "format": "uuid",
+        "type": "string",
+      },
+    },
+    "required": [
+      "fieldNumber",
+    ],
+    "type": "object",
+  },
+  "ObjectName for Response": {
+    "description": undefined,
+    "properties": {
+      "fieldActor": {
+        "properties": {
+          "name": {
+            "type": "string",
+          },
+          "source": {
+            "enum": [
+              "EMAIL",
+              "CALENDAR",
+              "WORKFLOW",
+              "API",
+              "IMPORT",
+              "MANUAL",
+              "SYSTEM",
+              "WEBHOOK",
+            ],
+            "type": "string",
+          },
+          "workspaceMemberId": {
+            "format": "uuid",
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "fieldAddress": {
+        "properties": {
+          "addressCity": {
+            "type": "string",
+          },
+          "addressCountry": {
+            "type": "string",
+          },
+          "addressLat": {
+            "type": "number",
+          },
+          "addressLng": {
+            "type": "number",
+          },
+          "addressPostcode": {
+            "type": "string",
+          },
+          "addressState": {
+            "type": "string",
+          },
+          "addressStreet1": {
+            "type": "string",
+          },
+          "addressStreet2": {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "fieldArray": {
+        "items": {
+          "type": "string",
+        },
+        "type": "array",
+      },
+      "fieldBoolean": {
+        "type": "boolean",
+      },
+      "fieldCurrency": {
+        "properties": {
+          "amountMicros": {
+            "type": "number",
+          },
+          "currencyCode": {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "fieldDate": {
+        "format": "date",
+        "type": "string",
+      },
+      "fieldDateTime": {
+        "format": "date-time",
+        "type": "string",
+      },
+      "fieldEmails": {
+        "properties": {
+          "additionalEmails": {
+            "items": {
+              "format": "email",
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "primaryEmail": {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "fieldFullName": {
+        "properties": {
+          "firstName": {
+            "type": "string",
+          },
+          "lastName": {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "fieldLinks": {
+        "properties": {
+          "primaryLinkLabel": {
+            "type": "string",
+          },
+          "primaryLinkUrl": {
+            "type": "string",
+          },
+          "secondaryLinks": {
+            "items": {
+              "description": "A secondary link",
+              "properties": {
+                "label": {
+                  "type": "string",
+                },
+                "url": {
+                  "format": "uri",
+                  "type": "string",
+                },
+              },
+              "type": "object",
+            },
+            "type": "array",
+          },
+        },
+        "type": "object",
+      },
+      "fieldMultiSelect": {
+        "items": {
+          "enum": [
+            "OPTION_1",
+            "OPTION_2",
+          ],
+          "type": "string",
+        },
+        "type": "array",
+      },
+      "fieldNumber": {
+        "type": "integer",
+      },
+      "fieldNumeric": {
+        "type": "number",
+      },
+      "fieldPhones": {
+        "properties": {
+          "additionalPhones": {
+            "items": {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "primaryPhoneCallingCode": {
+            "type": "string",
+          },
+          "primaryPhoneCountryCode": {
+            "type": "string",
+          },
+          "primaryPhoneNumber": {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "fieldPosition": {
+        "type": "number",
+      },
+      "fieldRating": {
+        "enum": [
+          "RATING_1",
+          "RATING_2",
+        ],
+        "type": "string",
+      },
+      "fieldRawJson": {
+        "type": "object",
+      },
+      "fieldRelation": {
+        "items": {
+          "$ref": "#/components/schemas/ToObjectMetadataName for Response",
+        },
+        "type": "array",
+      },
+      "fieldRichText": {
+        "type": "string",
+      },
+      "fieldSelect": {
+        "enum": [
+          "OPTION_1",
+          "OPTION_2",
+        ],
+        "type": "string",
+      },
+      "fieldText": {
+        "type": "string",
+      },
+      "fieldUuid": {
+        "format": "uuid",
+        "type": "string",
+      },
+    },
+    "type": "object",
+  },
+  "ObjectName for Update": {
+    "description": undefined,
+    "properties": {
+      "fieldActor": {
+        "properties": {
+          "source": {
+            "enum": [
+              "EMAIL",
+              "CALENDAR",
+              "WORKFLOW",
+              "API",
+              "IMPORT",
+              "MANUAL",
+              "SYSTEM",
+              "WEBHOOK",
+            ],
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "fieldAddress": {
+        "properties": {
+          "addressCity": {
+            "type": "string",
+          },
+          "addressCountry": {
+            "type": "string",
+          },
+          "addressLat": {
+            "type": "number",
+          },
+          "addressLng": {
+            "type": "number",
+          },
+          "addressPostcode": {
+            "type": "string",
+          },
+          "addressState": {
+            "type": "string",
+          },
+          "addressStreet1": {
+            "type": "string",
+          },
+          "addressStreet2": {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "fieldArray": {
+        "items": {
+          "type": "string",
+        },
+        "type": "array",
+      },
+      "fieldBoolean": {
+        "type": "boolean",
+      },
+      "fieldCurrency": {
+        "properties": {
+          "amountMicros": {
+            "type": "number",
+          },
+          "currencyCode": {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "fieldDate": {
+        "format": "date",
+        "type": "string",
+      },
+      "fieldDateTime": {
+        "format": "date-time",
+        "type": "string",
+      },
+      "fieldEmails": {
+        "properties": {
+          "additionalEmails": {
+            "items": {
+              "format": "email",
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "primaryEmail": {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "fieldFullName": {
+        "properties": {
+          "firstName": {
+            "type": "string",
+          },
+          "lastName": {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "fieldLinks": {
+        "properties": {
+          "primaryLinkLabel": {
+            "type": "string",
+          },
+          "primaryLinkUrl": {
+            "type": "string",
+          },
+          "secondaryLinks": {
+            "items": {
+              "description": "A secondary link",
+              "properties": {
+                "label": {
+                  "type": "string",
+                },
+                "url": {
+                  "format": "uri",
+                  "type": "string",
+                },
+              },
+              "type": "object",
+            },
+            "type": "array",
+          },
+        },
+        "type": "object",
+      },
+      "fieldMultiSelect": {
+        "items": {
+          "enum": [
+            "OPTION_1",
+            "OPTION_2",
+          ],
+          "type": "string",
+        },
+        "type": "array",
+      },
+      "fieldNumber": {
+        "type": "integer",
+      },
+      "fieldNumeric": {
+        "type": "number",
+      },
+      "fieldPhones": {
+        "properties": {
+          "additionalPhones": {
+            "items": {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "primaryPhoneCallingCode": {
+            "type": "string",
+          },
+          "primaryPhoneCountryCode": {
+            "type": "string",
+          },
+          "primaryPhoneNumber": {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "fieldPosition": {
+        "type": "number",
+      },
+      "fieldRating": {
+        "enum": [
+          "RATING_1",
+          "RATING_2",
+        ],
+        "type": "string",
+      },
+      "fieldRawJson": {
+        "type": "object",
+      },
+      "fieldRichText": {
+        "type": "string",
+      },
+      "fieldSelect": {
+        "enum": [
+          "OPTION_1",
+          "OPTION_2",
+        ],
+        "type": "string",
+      },
+      "fieldText": {
+        "type": "string",
+      },
+      "fieldUuid": {
+        "format": "uuid",
+        "type": "string",
+      },
+    },
+    "type": "object",
+  },
+}
+`);
   });
-});
 
-describe('computeSchemaComponentsForDecimalFields', () => {
   it('should compute schema components', () => {
+    const numberFields = [
+      {
+        id: 'number1',
+        name: 'number1',
+        type: FieldMetadataType.NUMBER,
+        isNullable: false,
+        defaultValue: null,
+        settings: { type: 'number', decimals: 1, dataType: NumberDataType.INT },
+      },
+      {
+        id: 'number2',
+        name: 'number2',
+        type: FieldMetadataType.NUMBER,
+        isNullable: false,
+        defaultValue: null,
+        settings: { type: 'number', dataType: NumberDataType.FLOAT },
+      },
+    ] satisfies Pick<
+      FieldMetadataEntity<FieldMetadataType.NUMBER>,
+      'id' | 'name' | 'type' | 'isNullable' | 'defaultValue' | 'settings'
+    >[];
+
     expect(
-      computeSchemaComponents([
-        {
-          targetTableName: 'testingObject',
-          id: 'mockObjectId',
-          nameSingular: 'objectName',
-          namePlural: 'objectsName',
-          fields: [
-            {
-              id: 'number1',
-              name: 'number1',
-              type: FieldMetadataType.NUMBER,
-              isNullable: false,
-              defaultValue: null,
-              settings: { type: 'number', decimals: 1 },
-            },
-            {
-              id: 'number2',
-              name: 'number2',
-              type: FieldMetadataType.NUMBER,
-              isNullable: false,
-              defaultValue: null,
-              settings: { type: 'number', dataType: NumberDataType.FLOAT },
-            },
-          ] as FieldMetadataEntity<FieldMetadataType.NUMBER>[],
-        },
-      ] as ObjectMetadataEntity[]),
-    ).toEqual({
-      ObjectName: {
-        description: undefined,
-        type: 'object',
-        properties: {
-          number1: {
-            type: 'number',
-          },
-          number2: {
-            type: 'number',
-          },
-        },
-        required: ['number1', 'number2'],
+  computeSchemaComponents([
+  {
+    targetTableName: 'testingObject',
+    id: 'mockObjectId',
+    nameSingular: 'objectName',
+    namePlural: 'objectsName',
+    //@ts-expect-error Passing partial FieldMetadataEntity array
+    fields: numberFields
+  }]
+  )
+).toMatchInlineSnapshot(`
+{
+  "ObjectName": {
+    "description": undefined,
+    "properties": {
+      "number1": {
+        "type": "number",
       },
-      'ObjectName for Response': {
-        description: undefined,
-        properties: {
-          number1: {
-            type: 'number',
-          },
-          number2: {
-            type: 'number',
-          },
-        },
-        type: 'object',
+      "number2": {
+        "type": "number",
       },
-      'ObjectName for Update': {
-        description: undefined,
-        properties: {
-          number1: {
-            type: 'number',
-          },
-          number2: {
-            type: 'number',
-          },
-        },
-        type: 'object',
+    },
+    "required": [
+      "number1",
+      "number2",
+    ],
+    "type": "object",
+  },
+  "ObjectName for Response": {
+    "description": undefined,
+    "properties": {
+      "number1": {
+        "type": "number",
       },
-    });
+      "number2": {
+        "type": "number",
+      },
+    },
+    "type": "object",
+  },
+  "ObjectName for Update": {
+    "description": undefined,
+    "properties": {
+      "number1": {
+        "type": "number",
+      },
+      "number2": {
+        "type": "number",
+      },
+    },
+    "type": "object",
+  },
+}
+`);
   });
 });

--- a/packages/twenty-server/src/engine/core-modules/open-api/utils/__tests__/components.utils.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/open-api/utils/__tests__/components.utils.spec.ts
@@ -10,10 +10,10 @@ import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadat
 describe('computeSchemaComponents', () => {
   it('should compute schema components', () => {
     expect(
-  computeSchemaComponents([
-  objectMetadataItemMock] as
-  ObjectMetadataEntity[])
-).toMatchInlineSnapshot(`
+      computeSchemaComponents([
+        objectMetadataItemMock,
+      ] as ObjectMetadataEntity[]),
+    ).toMatchInlineSnapshot(`
 {
   "ObjectName": {
     "description": undefined,
@@ -659,17 +659,17 @@ describe('computeSchemaComponents', () => {
     >[];
 
     expect(
-  computeSchemaComponents([
-  {
-    targetTableName: 'testingObject',
-    id: 'mockObjectId',
-    nameSingular: 'objectName',
-    namePlural: 'objectsName',
-    //@ts-expect-error Passing partial FieldMetadataEntity array
-    fields: numberFields
-  }]
-  )
-).toMatchInlineSnapshot(`
+      computeSchemaComponents([
+        {
+          targetTableName: 'testingObject',
+          id: 'mockObjectId',
+          nameSingular: 'objectName',
+          namePlural: 'objectsName',
+          //@ts-expect-error Passing partial FieldMetadataEntity array
+          fields: numberFields,
+        },
+      ]),
+    ).toMatchInlineSnapshot(`
 {
   "ObjectName": {
     "description": undefined,

--- a/packages/twenty-server/src/engine/core-modules/open-api/utils/__tests__/components.utils.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/open-api/utils/__tests__/components.utils.spec.ts
@@ -1,9 +1,11 @@
+import { FieldMetadataType } from 'twenty-shared/types';
+
+import { NumberDataType } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata-settings.interface';
+
 import { objectMetadataItemMock } from 'src/engine/api/__mocks__/object-metadata-item.mock';
 import { computeSchemaComponents } from 'src/engine/core-modules/open-api/utils/components.utils';
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
-import { NumberDataType } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata-settings.interface';
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
-import { FieldMetadataType } from 'twenty-shared/types';
 
 describe('computeSchemaComponents', () => {
   it('should compute schema components', () => {
@@ -610,7 +612,7 @@ describe('computeSchemaComponentsForDecimalFields', () => {
               type: FieldMetadataType.NUMBER,
               isNullable: false,
               defaultValue: null,
-              settings: { type: "number", decimals: 1 }
+              settings: { type: 'number', decimals: 1 },
             },
             {
               id: 'number2',
@@ -618,9 +620,9 @@ describe('computeSchemaComponentsForDecimalFields', () => {
               type: FieldMetadataType.NUMBER,
               isNullable: false,
               defaultValue: null,
-              settings: { type: "number", dataType: NumberDataType.FLOAT }
-            }
-          ] as FieldMetadataEntity<FieldMetadataType.NUMBER>[]
+              settings: { type: 'number', dataType: NumberDataType.FLOAT },
+            },
+          ] as FieldMetadataEntity<FieldMetadataType.NUMBER>[],
         },
       ] as ObjectMetadataEntity[]),
     ).toEqual({
@@ -629,40 +631,37 @@ describe('computeSchemaComponentsForDecimalFields', () => {
         type: 'object',
         properties: {
           number1: {
-            type: "number",
+            type: 'number',
           },
           number2: {
-            type: "number",
+            type: 'number',
           },
         },
-        required:[
-          "number1",
-          "number2",
-        ],
+        required: ['number1', 'number2'],
       },
-      "ObjectName for Response": {
+      'ObjectName for Response': {
         description: undefined,
         properties: {
           number1: {
-            type: "number",
+            type: 'number',
           },
           number2: {
-            type: "number",
+            type: 'number',
           },
         },
-        type: "object",
+        type: 'object',
       },
-      "ObjectName for Update": {
+      'ObjectName for Update': {
         description: undefined,
         properties: {
           number1: {
-            type: "number",
+            type: 'number',
           },
           number2: {
-            type: "number",
+            type: 'number',
           },
         },
-        type: "object",
+        type: 'object',
       },
     });
   });

--- a/packages/twenty-server/src/engine/core-modules/open-api/utils/__tests__/components.utils.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/open-api/utils/__tests__/components.utils.spec.ts
@@ -1,4 +1,5 @@
 import { FieldMetadataType } from 'twenty-shared/types';
+import { EachTestingContext } from 'twenty-shared/testing';
 
 import { NumberDataType } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata-settings.interface';
 
@@ -6,7 +7,6 @@ import { objectMetadataItemMock } from 'src/engine/api/__mocks__/object-metadata
 import { computeSchemaComponents } from 'src/engine/core-modules/open-api/utils/components.utils';
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
-import { EachTestingContext } from 'twenty-shared/testing';
 
 describe('computeSchemaComponents', () => {
   it('should compute schema components', () => {

--- a/packages/twenty-server/src/engine/core-modules/open-api/utils/__tests__/components.utils.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/open-api/utils/__tests__/components.utils.spec.ts
@@ -6,6 +6,7 @@ import { objectMetadataItemMock } from 'src/engine/api/__mocks__/object-metadata
 import { computeSchemaComponents } from 'src/engine/core-modules/open-api/utils/components.utils';
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
+import { EachTestingContext } from 'twenty-shared/testing';
 
 describe('computeSchemaComponents', () => {
   it('should compute schema components', () => {
@@ -635,9 +636,15 @@ describe('computeSchemaComponents', () => {
 `);
   });
 
-  it('should compute schema components', () => {
-    const numberFields = [
-      {
+  const testsCases: EachTestingContext<
+    Pick<
+      FieldMetadataEntity<FieldMetadataType.NUMBER>,
+      'id' | 'name' | 'type' | 'isNullable' | 'defaultValue' | 'settings'
+    >
+  >[] = [
+    {
+      title: 'Integer dataType with decimals',
+      context: {
         id: 'number1',
         name: 'number1',
         type: FieldMetadataType.NUMBER,
@@ -645,7 +652,10 @@ describe('computeSchemaComponents', () => {
         defaultValue: null,
         settings: { type: 'number', decimals: 1, dataType: NumberDataType.INT },
       },
-      {
+    },
+    {
+      title: 'Float without decimals',
+      context: {
         id: 'number2',
         name: 'number2',
         type: FieldMetadataType.NUMBER,
@@ -653,11 +663,21 @@ describe('computeSchemaComponents', () => {
         defaultValue: null,
         settings: { type: 'number', dataType: NumberDataType.FLOAT },
       },
-    ] satisfies Pick<
-      FieldMetadataEntity<FieldMetadataType.NUMBER>,
-      'id' | 'name' | 'type' | 'isNullable' | 'defaultValue' | 'settings'
-    >[];
+    },
+    {
+      title: 'Integer with a 0 decimals',
+      context: {
+        id: 'number3',
+        name: 'number3',
+        type: FieldMetadataType.NUMBER,
+        isNullable: false,
+        defaultValue: null,
+        settings: { type: 'number', decimals: 0, dataType: NumberDataType.INT },
+      },
+    },
+  ];
 
+  it.each(testsCases)('$title', ({ context: field }) => {
     expect(
       computeSchemaComponents([
         {
@@ -666,52 +686,9 @@ describe('computeSchemaComponents', () => {
           nameSingular: 'objectName',
           namePlural: 'objectsName',
           //@ts-expect-error Passing partial FieldMetadataEntity array
-          fields: numberFields,
+          fields: [field],
         },
       ]),
-    ).toMatchInlineSnapshot(`
-{
-  "ObjectName": {
-    "description": undefined,
-    "properties": {
-      "number1": {
-        "type": "number",
-      },
-      "number2": {
-        "type": "number",
-      },
-    },
-    "required": [
-      "number1",
-      "number2",
-    ],
-    "type": "object",
-  },
-  "ObjectName for Response": {
-    "description": undefined,
-    "properties": {
-      "number1": {
-        "type": "number",
-      },
-      "number2": {
-        "type": "number",
-      },
-    },
-    "type": "object",
-  },
-  "ObjectName for Update": {
-    "description": undefined,
-    "properties": {
-      "number1": {
-        "type": "number",
-      },
-      "number2": {
-        "type": "number",
-      },
-    },
-    "type": "object",
-  },
-}
-`);
+    ).toMatchSnapshot();
   });
 });

--- a/packages/twenty-server/src/engine/core-modules/open-api/utils/__tests__/components.utils.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/open-api/utils/__tests__/components.utils.spec.ts
@@ -1,6 +1,9 @@
 import { objectMetadataItemMock } from 'src/engine/api/__mocks__/object-metadata-item.mock';
 import { computeSchemaComponents } from 'src/engine/core-modules/open-api/utils/components.utils';
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
+import { NumberDataType } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata-settings.interface';
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
+import { FieldMetadataType } from 'twenty-shared/types';
 
 describe('computeSchemaComponents', () => {
   it('should compute schema components', () => {
@@ -586,6 +589,80 @@ describe('computeSchemaComponents', () => {
             },
           },
         },
+      },
+    });
+  });
+});
+
+describe('computeSchemaComponentsForDecimalFields', () => {
+  it('should compute schema components', () => {
+    expect(
+      computeSchemaComponents([
+        {
+          targetTableName: 'testingObject',
+          id: 'mockObjectId',
+          nameSingular: 'objectName',
+          namePlural: 'objectsName',
+          fields: [
+            {
+              id: 'number1',
+              name: 'number1',
+              type: FieldMetadataType.NUMBER,
+              isNullable: false,
+              defaultValue: null,
+              settings: { type: "number", decimals: 1 }
+            },
+            {
+              id: 'number2',
+              name: 'number2',
+              type: FieldMetadataType.NUMBER,
+              isNullable: false,
+              defaultValue: null,
+              settings: { type: "number", dataType: NumberDataType.FLOAT }
+            }
+          ] as FieldMetadataEntity<FieldMetadataType.NUMBER>[]
+        },
+      ] as ObjectMetadataEntity[]),
+    ).toEqual({
+      ObjectName: {
+        description: undefined,
+        type: 'object',
+        properties: {
+          number1: {
+            type: "number",
+          },
+          number2: {
+            type: "number",
+          },
+        },
+        required:[
+          "number1",
+          "number2",
+        ],
+      },
+      "ObjectName for Response": {
+        description: undefined,
+        properties: {
+          number1: {
+            type: "number",
+          },
+          number2: {
+            type: "number",
+          },
+        },
+        type: "object",
+      },
+      "ObjectName for Update": {
+        description: undefined,
+        properties: {
+          number1: {
+            type: "number",
+          },
+          number2: {
+            type: "number",
+          },
+        },
+        type: "object",
       },
     });
   });

--- a/packages/twenty-server/src/engine/core-modules/open-api/utils/components.utils.ts
+++ b/packages/twenty-server/src/engine/core-modules/open-api/utils/components.utils.ts
@@ -1,6 +1,6 @@
 import { OpenAPIV3_1 } from 'openapi-types';
-import { capitalize } from 'twenty-shared/utils';
 import { FieldMetadataType } from 'twenty-shared/types';
+import { capitalize } from 'twenty-shared/utils';
 
 import {
   computeDepthParameters,
@@ -12,6 +12,7 @@ import {
   computeStartingAfterParameters,
 } from 'src/engine/core-modules/open-api/utils/parameters.utils';
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
+import { NumberDataType } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata-settings.interface';
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 import { RelationMetadataType } from 'src/engine/metadata-modules/relation-metadata/relation-metadata.entity';
 
@@ -36,8 +37,8 @@ const isFieldAvailable = (field: FieldMetadataEntity, forResponse: boolean) => {
   }
 };
 
-const getFieldProperties = (type: FieldMetadataType): Property => {
-  switch (type) {
+const getFieldProperties = (field: FieldMetadataEntity): Property => {
+  switch (field.type) {
     case FieldMetadataType.UUID:
       return { type: 'string', format: 'uuid' };
     case FieldMetadataType.TEXT:
@@ -48,7 +49,8 @@ const getFieldProperties = (type: FieldMetadataType): Property => {
     case FieldMetadataType.DATE:
       return { type: 'string', format: 'date' };
     case FieldMetadataType.NUMBER:
-      return { type: 'integer' };
+      const settings = (field as FieldMetadataEntity<FieldMetadataType.NUMBER>).settings;
+      return { type: settings?.dataType === NumberDataType.FLOAT || (settings?.decimals ?? 0) >= 1 ? 'number' : 'integer' };
     case FieldMetadataType.NUMERIC:
     case FieldMetadataType.POSITION:
       return { type: 'number' };
@@ -282,7 +284,7 @@ const getSchemaComponentsProperties = ({
         };
         break;
       default:
-        itemProperty = getFieldProperties(field.type);
+        itemProperty = getFieldProperties(field);
         break;
     }
 

--- a/packages/twenty-server/src/engine/core-modules/open-api/utils/components.utils.ts
+++ b/packages/twenty-server/src/engine/core-modules/open-api/utils/components.utils.ts
@@ -60,11 +60,14 @@ const getFieldProperties = (field: FieldMetadataEntity): Property => {
       const settings =
         field.settings as FieldMetadataSettings<FieldMetadataType.NUMBER>;
 
-      if (settings?.dataType === NumberDataType.FLOAT || isDefined(settings?.decimals)) {
+      if (
+        settings?.dataType === NumberDataType.FLOAT ||
+        (isDefined(settings?.decimals) && settings.decimals > 0)
+      ) {
         return { type: 'number' };
       }
 
-      return {type: 'integer'};
+      return { type: 'integer' };
     }
     case FieldMetadataType.NUMERIC:
     case FieldMetadataType.POSITION: {

--- a/packages/twenty-server/src/engine/core-modules/open-api/utils/components.utils.ts
+++ b/packages/twenty-server/src/engine/core-modules/open-api/utils/components.utils.ts
@@ -1,6 +1,6 @@
 import { OpenAPIV3_1 } from 'openapi-types';
 import { FieldMetadataType } from 'twenty-shared/types';
-import { capitalize } from 'twenty-shared/utils';
+import { capitalize, isDefined } from 'twenty-shared/utils';
 
 import {
   FieldMetadataSettings,
@@ -60,14 +60,11 @@ const getFieldProperties = (field: FieldMetadataEntity): Property => {
       const settings =
         field.settings as FieldMetadataSettings<FieldMetadataType.NUMBER>;
 
-      switch (settings?.dataType) {
-        case NumberDataType.INT:
-        case NumberDataType.BIGINT:
-          return { type: 'integer' };
-        case NumberDataType.FLOAT:
-        default:
-          return { type: 'number' };
+      if (settings?.dataType === NumberDataType.FLOAT || isDefined(settings?.decimals)) {
+        return { type: 'number' };
       }
+
+      return {type: 'integer'};
     }
     case FieldMetadataType.NUMERIC:
     case FieldMetadataType.POSITION: {

--- a/packages/twenty-server/src/engine/core-modules/open-api/utils/components.utils.ts
+++ b/packages/twenty-server/src/engine/core-modules/open-api/utils/components.utils.ts
@@ -2,6 +2,8 @@ import { OpenAPIV3_1 } from 'openapi-types';
 import { FieldMetadataType } from 'twenty-shared/types';
 import { capitalize } from 'twenty-shared/utils';
 
+import { NumberDataType } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata-settings.interface';
+
 import {
   computeDepthParameters,
   computeEndingBeforeParameters,
@@ -12,7 +14,6 @@ import {
   computeStartingAfterParameters,
 } from 'src/engine/core-modules/open-api/utils/parameters.utils';
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
-import { NumberDataType } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata-settings.interface';
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 import { RelationMetadataType } from 'src/engine/metadata-modules/relation-metadata/relation-metadata.entity';
 
@@ -39,28 +40,44 @@ const isFieldAvailable = (field: FieldMetadataEntity, forResponse: boolean) => {
 
 const getFieldProperties = (field: FieldMetadataEntity): Property => {
   switch (field.type) {
-    case FieldMetadataType.UUID:
+    case FieldMetadataType.UUID: {
       return { type: 'string', format: 'uuid' };
+    }
     case FieldMetadataType.TEXT:
-    case FieldMetadataType.RICH_TEXT:
+    case FieldMetadataType.RICH_TEXT: {
       return { type: 'string' };
-    case FieldMetadataType.DATE_TIME:
+    }
+    case FieldMetadataType.DATE_TIME: {
       return { type: 'string', format: 'date-time' };
-    case FieldMetadataType.DATE:
+    }
+    case FieldMetadataType.DATE: {
       return { type: 'string', format: 'date' };
-    case FieldMetadataType.NUMBER:
-      const settings = (field as FieldMetadataEntity<FieldMetadataType.NUMBER>).settings;
-      return { type: settings?.dataType === NumberDataType.FLOAT || (settings?.decimals ?? 0) >= 1 ? 'number' : 'integer' };
-    case FieldMetadataType.NUMERIC:
-    case FieldMetadataType.POSITION:
-      return { type: 'number' };
-    case FieldMetadataType.BOOLEAN:
-      return { type: 'boolean' };
-    case FieldMetadataType.RAW_JSON:
-      return { type: 'object' };
+    }
+    case FieldMetadataType.NUMBER: {
+      const settings = (field as FieldMetadataEntity<FieldMetadataType.NUMBER>)
+        .settings;
 
-    default:
+      return {
+        type:
+          settings?.dataType === NumberDataType.FLOAT ||
+          (settings?.decimals ?? 0) >= 1
+            ? 'number'
+            : 'integer',
+      };
+    }
+    case FieldMetadataType.NUMERIC:
+    case FieldMetadataType.POSITION: {
+      return { type: 'number' };
+    }
+    case FieldMetadataType.BOOLEAN: {
+      return { type: 'boolean' };
+    }
+    case FieldMetadataType.RAW_JSON: {
+      return { type: 'object' };
+    }
+    default: {
       return { type: 'string' };
+    }
   }
 };
 

--- a/packages/twenty-server/src/engine/core-modules/open-api/utils/components.utils.ts
+++ b/packages/twenty-server/src/engine/core-modules/open-api/utils/components.utils.ts
@@ -2,7 +2,10 @@ import { OpenAPIV3_1 } from 'openapi-types';
 import { FieldMetadataType } from 'twenty-shared/types';
 import { capitalize } from 'twenty-shared/utils';
 
-import { NumberDataType } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata-settings.interface';
+import {
+  FieldMetadataSettings,
+  NumberDataType,
+} from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata-settings.interface';
 
 import {
   computeDepthParameters,
@@ -54,16 +57,17 @@ const getFieldProperties = (field: FieldMetadataEntity): Property => {
       return { type: 'string', format: 'date' };
     }
     case FieldMetadataType.NUMBER: {
-      const settings = (field as FieldMetadataEntity<FieldMetadataType.NUMBER>)
-        .settings;
+      const settings =
+        field.settings as FieldMetadataSettings<FieldMetadataType.NUMBER>;
 
-      return {
-        type:
-          settings?.dataType === NumberDataType.FLOAT ||
-          (settings?.decimals ?? 0) >= 1
-            ? 'number'
-            : 'integer',
-      };
+      switch (settings?.dataType) {
+        case NumberDataType.INT:
+        case NumberDataType.BIGINT:
+          return { type: 'integer' };
+        case NumberDataType.FLOAT:
+        default:
+          return { type: 'number' };
+      }
     }
     case FieldMetadataType.NUMERIC:
     case FieldMetadataType.POSITION: {


### PR DESCRIPTION
Closes https://github.com/twentyhq/twenty/issues/10807

## Description
This PR will Modify Decimal Fields to be treated as `number` in OpenAPI schema.

## Testing
<img width="989" alt="スクリーンショット 2025-05-05 20 49 05" src="https://github.com/user-attachments/assets/2f120317-5860-4c93-91a2-f521a69a1cd5" />
<img width="872" alt="スクリーンショット 2025-05-05 20 49 52" src="https://github.com/user-attachments/assets/0d319785-e30b-4132-be9e-12ed6f3cc46a" />
