### PR TITLE
Upgrade infer commands from APP_VERSION

### DIFF
--- a/packages/twenty-server/src/database/commands/command-runners/__tests__/__snapshots__/upgrade.command-runner.spec.ts.snap
+++ b/packages/twenty-server/src/database/commands/command-runners/__tests__/__snapshots__/upgrade.command-runner.spec.ts.snap
@@ -2,13 +2,15 @@
 
 exports[`UpgradeCommandRunner Workspace upgrade should fail when APP_VERSION is not defined 1`] = `[Error: Cannot run upgrade command when APP_VERSION is not defined, please double check your env variables]`;
 
+exports[`UpgradeCommandRunner Workspace upgrade should fail when all commands contains invalid semver keys 1`] = `[Error: No commands found for version 2.0.0. Please check the commands record.]`;
+
 exports[`UpgradeCommandRunner Workspace upgrade should fail when current version commands are not found 1`] = `[Error: No commands found for version 42.0.0. Please check the commands record.]`;
 
 exports[`UpgradeCommandRunner Workspace upgrade should fail when previous version is not found 1`] = `[Error: No previous version found for version 1.0.0. Please check the commands record available 1.0.0, 2.0.0.]`;
 
 exports[`UpgradeCommandRunner Workspace upgrade should fail when workspace version is not defined 1`] = `[Error: WORKSPACE_VERSION_NOT_DEFINED workspace=workspace_0]`;
 
-exports[`UpgradeCommandRunner Workspace upgrade should fail when workspace version is not equal to fromVersion 1`] = `[Error: WORKSPACE_VERSION_MISSMATCH Upgrade for workspace workspace_0 failed as its version is beneath fromWorkspaceVersion=2.0.0]`;
+exports[`UpgradeCommandRunner Workspace upgrade should fail when workspace version is not equal to fromVersion 1`] = `[Error: WORKSPACE_VERSION_MISSMATCH Upgrade for workspace workspace_0 failed as its version is beneath fromWorkspaceVersion=1.0.0]`;
 
 exports[`UpgradeCommandRunner should run upgrade command with failing and successful workspaces 1`] = `[Error: WORKSPACE_VERSION_MISSMATCH Upgrade for workspace outated_version_workspace failed as its version is beneath fromWorkspaceVersion=1.0.0]`;
 

--- a/packages/twenty-server/src/database/commands/command-runners/__tests__/__snapshots__/upgrade.command-runner.spec.ts.snap
+++ b/packages/twenty-server/src/database/commands/command-runners/__tests__/__snapshots__/upgrade.command-runner.spec.ts.snap
@@ -2,6 +2,10 @@
 
 exports[`UpgradeCommandRunner Workspace upgrade should fail when APP_VERSION is not defined 1`] = `[Error: Cannot run upgrade command when APP_VERSION is not defined, please double check your env variables]`;
 
+exports[`UpgradeCommandRunner Workspace upgrade should fail when current version commands are not found 1`] = `[Error: No commands found for version 42.0.0. Please check the commands record.]`;
+
+exports[`UpgradeCommandRunner Workspace upgrade should fail when previous version is not found 1`] = `[Error: No previous version found for version 1.0.0. Please check the commands record available 1.0.0, 2.0.0.]`;
+
 exports[`UpgradeCommandRunner Workspace upgrade should fail when workspace version is not defined 1`] = `[Error: WORKSPACE_VERSION_NOT_DEFINED workspace=workspace_0]`;
 
 exports[`UpgradeCommandRunner Workspace upgrade should fail when workspace version is not equal to fromVersion 1`] = `[Error: WORKSPACE_VERSION_MISSMATCH Upgrade for workspace workspace_0 failed as its version is beneath fromWorkspaceVersion=2.0.0]`;

--- a/packages/twenty-server/src/database/commands/command-runners/__tests__/__snapshots__/upgrade.command-runner.spec.ts.snap
+++ b/packages/twenty-server/src/database/commands/command-runners/__tests__/__snapshots__/upgrade.command-runner.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`UpgradeCommandRunner Workspace upgrade should fail when APP_VERSION is not defined 1`] = `[Error: Cannot run upgrade command when APP_VERSION is not defined, please double check your env variables]`;
 
-exports[`UpgradeCommandRunner Workspace upgrade should fail when all commands contains invalid semver keys 1`] = `[Error: No commands found for version 2.0.0. Please check the commands record.]`;
+exports[`UpgradeCommandRunner Workspace upgrade should fail when all commands contains invalid semver keys 1`] = `[Error: No previous version found for version 2.0.0. Please check the commands record available invalid, 2.0.0.]`;
 
 exports[`UpgradeCommandRunner Workspace upgrade should fail when current version commands are not found 1`] = `[Error: No commands found for version 42.0.0. Please check the commands record.]`;
 

--- a/packages/twenty-server/src/database/commands/command-runners/__tests__/__snapshots__/upgrade.command-runner.spec.ts.snap
+++ b/packages/twenty-server/src/database/commands/command-runners/__tests__/__snapshots__/upgrade.command-runner.spec.ts.snap
@@ -2,11 +2,11 @@
 
 exports[`UpgradeCommandRunner Workspace upgrade should fail when APP_VERSION is not defined 1`] = `[Error: Cannot run upgrade command when APP_VERSION is not defined, please double check your env variables]`;
 
-exports[`UpgradeCommandRunner Workspace upgrade should fail when all commands contains invalid semver keys 1`] = `[Error: No previous version found for version 2.0.0. Please review the "allCommands" record. Available versions are: invalid, 2.0.0.]`;
+exports[`UpgradeCommandRunner Workspace upgrade should fail when all commands contains invalid semver keys 1`] = `[Error: No previous version found for version 2.0.0. Please review the "allCommands" record. Available versions are: invalid, 2.0.0]`;
 
 exports[`UpgradeCommandRunner Workspace upgrade should fail when current version commands are not found 1`] = `[Error: No command found for version 42.0.0. Please check the commands record.]`;
 
-exports[`UpgradeCommandRunner Workspace upgrade should fail when previous version is not found 1`] = `[Error: No previous version found for version 1.0.0. Please review the "allCommands" record. Available versions are: 1.0.0, 2.0.0.]`;
+exports[`UpgradeCommandRunner Workspace upgrade should fail when previous version is not found 1`] = `[Error: No previous version found for version 1.0.0. Please review the "allCommands" record. Available versions are: 1.0.0, 2.0.0]`;
 
 exports[`UpgradeCommandRunner Workspace upgrade should fail when workspace version is not defined 1`] = `[Error: WORKSPACE_VERSION_NOT_DEFINED workspace=workspace_0]`;
 

--- a/packages/twenty-server/src/database/commands/command-runners/__tests__/__snapshots__/upgrade.command-runner.spec.ts.snap
+++ b/packages/twenty-server/src/database/commands/command-runners/__tests__/__snapshots__/upgrade.command-runner.spec.ts.snap
@@ -2,11 +2,11 @@
 
 exports[`UpgradeCommandRunner Workspace upgrade should fail when APP_VERSION is not defined 1`] = `[Error: Cannot run upgrade command when APP_VERSION is not defined, please double check your env variables]`;
 
-exports[`UpgradeCommandRunner Workspace upgrade should fail when all commands contains invalid semver keys 1`] = `[Error: No previous version found for version 2.0.0. Please check the commands record available invalid, 2.0.0.]`;
+exports[`UpgradeCommandRunner Workspace upgrade should fail when all commands contains invalid semver keys 1`] = `[Error: No previous version found for version 2.0.0. Please review the "allCommands" record. Available versions are: invalid, 2.0.0.]`;
 
-exports[`UpgradeCommandRunner Workspace upgrade should fail when current version commands are not found 1`] = `[Error: No commands found for version 42.0.0. Please check the commands record.]`;
+exports[`UpgradeCommandRunner Workspace upgrade should fail when current version commands are not found 1`] = `[Error: No command found for version 42.0.0. Please check the commands record.]`;
 
-exports[`UpgradeCommandRunner Workspace upgrade should fail when previous version is not found 1`] = `[Error: No previous version found for version 1.0.0. Please check the commands record available 1.0.0, 2.0.0.]`;
+exports[`UpgradeCommandRunner Workspace upgrade should fail when previous version is not found 1`] = `[Error: No previous version found for version 1.0.0. Please review the "allCommands" record. Available versions are: 1.0.0, 2.0.0.]`;
 
 exports[`UpgradeCommandRunner Workspace upgrade should fail when workspace version is not defined 1`] = `[Error: WORKSPACE_VERSION_NOT_DEFINED workspace=workspace_0]`;
 

--- a/packages/twenty-server/src/database/commands/command-runners/__tests__/upgrade.command-runner.spec.ts
+++ b/packages/twenty-server/src/database/commands/command-runners/__tests__/upgrade.command-runner.spec.ts
@@ -364,25 +364,28 @@ describe('UpgradeCommandRunner', () => {
       },
     ];
 
-    it.each(successfulTestUseCases)('$title', async ({ context: { input } }) => {
-      await buildModuleAndSetupSpies(input);
+    it.each(successfulTestUseCases)(
+      '$title',
+      async ({ context: { input } }) => {
+        await buildModuleAndSetupSpies(input);
 
-      const passedParams = [];
-      const options = {};
+        const passedParams = [];
+        const options = {};
 
-      await upgradeCommandRunner.run(passedParams, options);
+        await upgradeCommandRunner.run(passedParams, options);
 
-      const { fail: failReport, success: successReport } =
-        upgradeCommandRunner.migrationReport;
+        const { fail: failReport, success: successReport } =
+          upgradeCommandRunner.migrationReport;
 
-      expect(failReport.length).toBe(0);
-      expect(successReport.length).toBe(1);
-      expect(runAfterSyncMetadataSpy).toBeCalledTimes(1);
-      expect(runBeforeSyncMetadataSpy).toBeCalledTimes(1);
-      const { workspaceId } = successReport[0];
+        expect(failReport.length).toBe(0);
+        expect(successReport.length).toBe(1);
+        expect(runAfterSyncMetadataSpy).toBeCalledTimes(1);
+        expect(runBeforeSyncMetadataSpy).toBeCalledTimes(1);
+        const { workspaceId } = successReport[0];
 
-      expect(workspaceId).toBe('workspace_0');
-    });
+        expect(workspaceId).toBe('workspace_0');
+      },
+    );
   });
 
   describe('Workspace upgrade should fail', () => {

--- a/packages/twenty-server/src/database/commands/command-runners/__tests__/upgrade.command-runner.spec.ts
+++ b/packages/twenty-server/src/database/commands/command-runners/__tests__/upgrade.command-runner.spec.ts
@@ -357,7 +357,7 @@ describe('UpgradeCommandRunner', () => {
         title: 'even if workspace version and app version differ in patch',
         context: {
           input: {
-            appVersion: "v2.0.0",
+            appVersion: 'v2.0.0',
             workspaceOverride: {
               version: 'v1.0.12',
             },
@@ -368,7 +368,7 @@ describe('UpgradeCommandRunner', () => {
         title: 'even if workspace version and app version differ in patch',
         context: {
           input: {
-            appVersion: "v2.0.0",
+            appVersion: 'v2.0.0',
             workspaceOverride: {
               version: '1.0.12',
             },
@@ -390,8 +390,8 @@ describe('UpgradeCommandRunner', () => {
 
       expect(failReport.length).toBe(0);
       expect(successReport.length).toBe(1);
-      expect(runAfterSyncMetadataSpy).toBeCalledTimes(1)
-      expect(runBeforeSyncMetadataSpy).toBeCalledTimes(1)
+      expect(runAfterSyncMetadataSpy).toBeCalledTimes(1);
+      expect(runBeforeSyncMetadataSpy).toBeCalledTimes(1);
       const { workspaceId } = successReport[0];
 
       expect(workspaceId).toBe('workspace_0');

--- a/packages/twenty-server/src/database/commands/command-runners/__tests__/upgrade.command-runner.spec.ts
+++ b/packages/twenty-server/src/database/commands/command-runners/__tests__/upgrade.command-runner.spec.ts
@@ -336,7 +336,7 @@ describe('UpgradeCommandRunner', () => {
   });
 
   describe('Workspace upgrade should succeed ', () => {
-    const failingTestUseCases: EachTestingContext<{
+    const successfulTestUseCases: EachTestingContext<{
       input: Omit<BuildModuleAndSetupSpiesArgs, 'numberOfWorkspace'>;
     }>[] = [
       {
@@ -364,7 +364,7 @@ describe('UpgradeCommandRunner', () => {
       },
     ];
 
-    it.each(failingTestUseCases)('$title', async ({ context: { input } }) => {
+    it.each(successfulTestUseCases)('$title', async ({ context: { input } }) => {
       await buildModuleAndSetupSpies(input);
 
       const passedParams = [];

--- a/packages/twenty-server/src/database/commands/command-runners/__tests__/upgrade.command-runner.spec.ts
+++ b/packages/twenty-server/src/database/commands/command-runners/__tests__/upgrade.command-runner.spec.ts
@@ -362,6 +362,17 @@ describe('UpgradeCommandRunner', () => {
           },
         },
       },
+      {
+        title: 'even if app version contains a patch value',
+        context: {
+          input: {
+            appVersion: '2.0.24',
+            workspaceOverride: {
+              version: '1.0.12',
+            },
+          },
+        },
+      },
     ];
 
     it.each(successfulTestUseCases)(

--- a/packages/twenty-server/src/database/commands/command-runners/__tests__/upgrade.command-runner.spec.ts
+++ b/packages/twenty-server/src/database/commands/command-runners/__tests__/upgrade.command-runner.spec.ts
@@ -387,7 +387,7 @@ describe('UpgradeCommandRunner', () => {
         title: 'when current version commands are not found',
         context: {
           input: {
-            appVersion: "42.0.0",
+            appVersion: '42.0.0',
           },
         },
       },
@@ -395,7 +395,7 @@ describe('UpgradeCommandRunner', () => {
         title: 'when previous version is not found',
         context: {
           input: {
-            appVersion: "1.0.0"
+            appVersion: '1.0.0',
           },
         },
       },

--- a/packages/twenty-server/src/database/commands/command-runners/__tests__/upgrade.command-runner.spec.ts
+++ b/packages/twenty-server/src/database/commands/command-runners/__tests__/upgrade.command-runner.spec.ts
@@ -24,7 +24,7 @@ class BasicUpgradeCommandRunner extends UpgradeCommandRunner {
   };
 }
 
-class InvalidVersionUpgradeCommandRunner extends UpgradeCommandRunner {
+class InvalidpgradeCommandRunner extends UpgradeCommandRunner {
   allCommands = {
     '1.0.0': {
       beforeSyncMetadata: [],
@@ -37,23 +37,9 @@ class InvalidVersionUpgradeCommandRunner extends UpgradeCommandRunner {
   };
 }
 
-class TestUpgradeCommandRunnerV2 extends UpgradeCommandRunner {
-  allCommands = {
-    '2.0.0': {
-      beforeSyncMetadata: [],
-      afterSyncMetadata: [],
-    },
-    '3.0.0': {
-      beforeSyncMetadata: [],
-      afterSyncMetadata: [],
-    },
-  };
-}
-
 type CommandRunnerValues =
   | typeof BasicUpgradeCommandRunner
-  | typeof TestUpgradeCommandRunnerV2
-  | typeof InvalidVersionUpgradeCommandRunner;
+  | typeof InvalidpgradeCommandRunner;
 
 const generateMockWorkspace = (overrides?: Partial<Workspace>) =>
   ({
@@ -365,7 +351,8 @@ describe('UpgradeCommandRunner', () => {
         },
       },
       {
-        title: 'even if workspace version and app version differ in patch',
+        title:
+          'even if workspace version and app version differ in patch and semantic',
         context: {
           input: {
             appVersion: 'v2.0.0',
@@ -406,8 +393,7 @@ describe('UpgradeCommandRunner', () => {
         title: 'when workspace version is not equal to fromVersion',
         context: {
           input: {
-            appVersion: '3.0.0',
-            commandRunner: TestUpgradeCommandRunnerV2,
+            appVersion: '2.0.0',
             workspaceOverride: {
               version: '0.1.0',
             },
@@ -445,6 +431,14 @@ describe('UpgradeCommandRunner', () => {
         context: {
           input: {
             appVersion: '1.0.0',
+          },
+        },
+      },
+      {
+        title: 'when all commands contains invalid semver keys',
+        context: {
+          input: {
+            commandRunner: InvalidpgradeCommandRunner,
           },
         },
       },

--- a/packages/twenty-server/src/database/commands/command-runners/__tests__/upgrade.command-runner.spec.ts
+++ b/packages/twenty-server/src/database/commands/command-runners/__tests__/upgrade.command-runner.spec.ts
@@ -349,6 +349,55 @@ describe('UpgradeCommandRunner', () => {
     expect(upgradeCommandRunner.migrationReport.fail.length).toBe(0);
   });
 
+  describe('Workspace upgrade should succeed ', () => {
+    const failingTestUseCases: EachTestingContext<{
+      input: Omit<BuildModuleAndSetupSpiesArgs, 'numberOfWorkspace'>;
+    }>[] = [
+      {
+        title: 'even if workspace version and app version differ in patch',
+        context: {
+          input: {
+            appVersion: "v2.0.0",
+            workspaceOverride: {
+              version: 'v1.0.12',
+            },
+          },
+        },
+      },
+      {
+        title: 'even if workspace version and app version differ in patch',
+        context: {
+          input: {
+            appVersion: "v2.0.0",
+            workspaceOverride: {
+              version: '1.0.12',
+            },
+          },
+        },
+      },
+    ];
+
+    it.each(failingTestUseCases)('$title', async ({ context: { input } }) => {
+      await buildModuleAndSetupSpies(input);
+
+      const passedParams = [];
+      const options = {};
+
+      await upgradeCommandRunner.run(passedParams, options);
+
+      const { fail: failReport, success: successReport } =
+        upgradeCommandRunner.migrationReport;
+
+      expect(failReport.length).toBe(0);
+      expect(successReport.length).toBe(1);
+      expect(runAfterSyncMetadataSpy).toBeCalledTimes(1)
+      expect(runBeforeSyncMetadataSpy).toBeCalledTimes(1)
+      const { workspaceId } = successReport[0];
+
+      expect(workspaceId).toBe('workspace_0');
+    });
+  });
+
   describe('Workspace upgrade should fail', () => {
     const failingTestUseCases: EachTestingContext<{
       input: Omit<BuildModuleAndSetupSpiesArgs, 'numberOfWorkspace'>;

--- a/packages/twenty-server/src/database/commands/command-runners/__tests__/upgrade.command-runner.spec.ts
+++ b/packages/twenty-server/src/database/commands/command-runners/__tests__/upgrade.command-runner.spec.ts
@@ -24,13 +24,13 @@ class BasicUpgradeCommandRunner extends UpgradeCommandRunner {
   };
 }
 
-class InvalidpgradeCommandRunner extends UpgradeCommandRunner {
+class InvalidUpgradeCommandRunner extends UpgradeCommandRunner {
   allCommands = {
-    '1.0.0': {
+    invalid: {
       beforeSyncMetadata: [],
       afterSyncMetadata: [],
     },
-    invalid: {
+    '2.0.0': {
       beforeSyncMetadata: [],
       afterSyncMetadata: [],
     },
@@ -39,7 +39,7 @@ class InvalidpgradeCommandRunner extends UpgradeCommandRunner {
 
 type CommandRunnerValues =
   | typeof BasicUpgradeCommandRunner
-  | typeof InvalidpgradeCommandRunner;
+  | typeof InvalidUpgradeCommandRunner;
 
 const generateMockWorkspace = (overrides?: Partial<Workspace>) =>
   ({
@@ -438,7 +438,7 @@ describe('UpgradeCommandRunner', () => {
         title: 'when all commands contains invalid semver keys',
         context: {
           input: {
-            commandRunner: InvalidpgradeCommandRunner,
+            commandRunner: InvalidUpgradeCommandRunner,
           },
         },
       },

--- a/packages/twenty-server/src/database/commands/command-runners/__tests__/upgrade.command-runner.spec.ts
+++ b/packages/twenty-server/src/database/commands/command-runners/__tests__/upgrade.command-runner.spec.ts
@@ -1,7 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 
-import { SemVer } from 'semver';
 import { EachTestingContext } from 'twenty-shared/testing';
 import { Repository } from 'typeorm';
 
@@ -12,44 +11,47 @@ import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.manager';
 import { SyncWorkspaceMetadataCommand } from 'src/engine/workspace-manager/workspace-sync-metadata/commands/sync-workspace-metadata.command';
 
-class TestUpgradeCommandRunnerV1 extends UpgradeCommandRunner {
-  fromWorkspaceVersion = new SemVer('1.0.0');
-
-  public override async runBeforeSyncMetadata(): Promise<void> {
-    return;
-  }
-
-  public override async runAfterSyncMetadata(): Promise<void> {
-    return;
-  }
+class BasicUpgradeCommandRunner extends UpgradeCommandRunner {
+  allCommands = {
+    '1.0.0': {
+      beforeSyncMetadata: [],
+      afterSyncMetadata: [],
+    },
+    '2.0.0': {
+      beforeSyncMetadata: [],
+      afterSyncMetadata: [],
+    },
+  };
 }
 
 class InvalidVersionUpgradeCommandRunner extends UpgradeCommandRunner {
-  fromWorkspaceVersion = new SemVer('invalid');
-
-  protected async runBeforeSyncMetadata(): Promise<void> {
-    return;
-  }
-
-  protected async runAfterSyncMetadata(): Promise<void> {
-    return;
-  }
+  allCommands = {
+    '1.0.0': {
+      beforeSyncMetadata: [],
+      afterSyncMetadata: [],
+    },
+    invalid: {
+      beforeSyncMetadata: [],
+      afterSyncMetadata: [],
+    },
+  };
 }
 
 class TestUpgradeCommandRunnerV2 extends UpgradeCommandRunner {
-  fromWorkspaceVersion = new SemVer('2.0.0');
-
-  protected async runBeforeSyncMetadata(): Promise<void> {
-    return;
-  }
-
-  protected async runAfterSyncMetadata(): Promise<void> {
-    return;
-  }
+  allCommands = {
+    '2.0.0': {
+      beforeSyncMetadata: [],
+      afterSyncMetadata: [],
+    },
+    '3.0.0': {
+      beforeSyncMetadata: [],
+      afterSyncMetadata: [],
+    },
+  };
 }
 
 type CommandRunnerValues =
-  | typeof TestUpgradeCommandRunnerV1
+  | typeof BasicUpgradeCommandRunner
   | typeof TestUpgradeCommandRunnerV2
   | typeof InvalidVersionUpgradeCommandRunner;
 
@@ -132,7 +134,7 @@ const buildUpgradeCommandModule = async ({
 };
 
 describe('UpgradeCommandRunner', () => {
-  let upgradeCommandRunner: TestUpgradeCommandRunnerV1;
+  let upgradeCommandRunner: BasicUpgradeCommandRunner;
   let workspaceRepository: Repository<Workspace>;
   let syncWorkspaceMetadataCommand: jest.Mocked<SyncWorkspaceMetadataCommand>;
   let runAfterSyncMetadataSpy: jest.SpyInstance;
@@ -150,7 +152,7 @@ describe('UpgradeCommandRunner', () => {
     numberOfWorkspace = 1,
     workspaceOverride,
     workspaces,
-    commandRunner = TestUpgradeCommandRunnerV1,
+    commandRunner = BasicUpgradeCommandRunner,
     appVersion = '2.0.0',
   }: BuildModuleAndSetupSpiesArgs) => {
     const generatedWorkspaces = Array.from(
@@ -381,6 +383,22 @@ describe('UpgradeCommandRunner', () => {
           },
         },
       },
+      {
+        title: 'when current version commands are not found',
+        context: {
+          input: {
+            appVersion: "42.0.0",
+          },
+        },
+      },
+      {
+        title: 'when previous version is not found',
+        context: {
+          input: {
+            appVersion: "1.0.0"
+          },
+        },
+      },
     ];
 
     it.each(failingTestUseCases)('$title', async ({ context: { input } }) => {
@@ -401,13 +419,5 @@ describe('UpgradeCommandRunner', () => {
       expect(workspaceId).toBe('workspace_0');
       expect(error).toMatchSnapshot();
     });
-  });
-
-  it('should throw if upgrade command version is invalid', async () => {
-    await expect(
-      buildModuleAndSetupSpies({
-        commandRunner: InvalidVersionUpgradeCommandRunner,
-      }),
-    ).rejects.toThrowErrorMatchingInlineSnapshot(`"Invalid Version: invalid"`);
   });
 });

--- a/packages/twenty-server/src/database/commands/command-runners/upgrade.command-runner.ts
+++ b/packages/twenty-server/src/database/commands/command-runners/upgrade.command-runner.ts
@@ -48,6 +48,7 @@ export abstract class UpgradeCommandRunner extends ActiveOrSuspendedWorkspacesMi
       this.commands,
       this.fromWorkspaceVersion,
     ].every(isDefined);
+
     if (ugpradeContextAlreadyDefined) {
       return;
     }
@@ -55,6 +56,7 @@ export abstract class UpgradeCommandRunner extends ActiveOrSuspendedWorkspacesMi
     const currentAppVersion = this.retrieveToVersionFromAppVersion();
 
     const currentCommands = this.allCommands[currentAppVersion];
+
     if (!isDefined(currentCommands)) {
       throw new Error(
         `No commands found for version ${currentAppVersion}. Please check the commands record.`,
@@ -81,6 +83,7 @@ export abstract class UpgradeCommandRunner extends ActiveOrSuspendedWorkspacesMi
     this.computeFromToVersionAndCommandsToRunForCurrentAppVersion();
 
     const { workspaceId, index, total, options } = args;
+
     this.logger.log(
       chalk.blue(
         `${options.dryRun ? '(dry run)' : ''} Upgrading workspace ${workspaceId} ${index + 1}/${total}`,

--- a/packages/twenty-server/src/database/commands/command-runners/upgrade.command-runner.ts
+++ b/packages/twenty-server/src/database/commands/command-runners/upgrade.command-runner.ts
@@ -20,7 +20,7 @@ import {
 import { extractVersionMajorMinorPatch } from 'src/utils/version/extract-version-major-minor-patch';
 
 export abstract class UpgradeCommandRunner extends ActiveOrSuspendedWorkspacesMigrationCommandRunner {
-  abstract readonly fromWorkspaceVersion: SemVer;
+  abstract fromWorkspaceVersion: SemVer;
   public readonly VALIDATE_WORKSPACE_VERSION_FEATURE_FLAG?: true;
 
   constructor(

--- a/packages/twenty-server/src/database/commands/command-runners/upgrade.command-runner.ts
+++ b/packages/twenty-server/src/database/commands/command-runners/upgrade.command-runner.ts
@@ -48,6 +48,7 @@ export abstract class UpgradeCommandRunner extends ActiveOrSuspendedWorkspacesMi
       this.commands,
       this.fromWorkspaceVersion,
     ].every(isDefined);
+
     if (ugpradeContextAlreadyDefined) {
       return;
     }

--- a/packages/twenty-server/src/database/commands/command-runners/upgrade.command-runner.ts
+++ b/packages/twenty-server/src/database/commands/command-runners/upgrade.command-runner.ts
@@ -42,36 +42,35 @@ export abstract class UpgradeCommandRunner extends ActiveOrSuspendedWorkspacesMi
     super(workspaceRepository, twentyORMGlobalManager);
   }
 
-  private computeFromToVersionAndCommandsToRunForCurrentAppVersion() {
+  private setUpgradeContextVersionsAndCommandsForCurrentAppVersion() {
     const ugpradeContextAlreadyDefined = [
       this.currentAppVersion,
       this.commands,
       this.fromWorkspaceVersion,
     ].every(isDefined);
-
     if (ugpradeContextAlreadyDefined) {
       return;
     }
 
-    const currentAppVersion = this.retrieveToVersionFromAppVersion();
+    const currentAppVersion = this.retrieveMajorMinorAppVersion();
 
     const currentCommands = this.allCommands[currentAppVersion];
 
     if (!isDefined(currentCommands)) {
       throw new Error(
-        `No commands found for version ${currentAppVersion}. Please check the commands record.`,
+        `No command found for version ${currentAppVersion}. Please check the commands record.`,
       );
     }
 
-    const allCommandsKeys = Object.keys(this.allCommands);
+    const allCommandsVersions = Object.keys(this.allCommands);
     const previousVersion = getPreviousVersion({
       currentVersion: currentAppVersion,
-      versions: allCommandsKeys,
+      versions: allCommandsVersions,
     });
 
     if (!isDefined(previousVersion)) {
       throw new Error(
-        `No previous version found for version ${currentAppVersion}. Please check the commands record available ${allCommandsKeys.join(', ')}.`,
+        `No previous version found for version ${currentAppVersion}. Please review the "allCommands" record. Available versions are: ${allCommandsVersions.join(', ')}.`,
       );
     }
     this.commands = currentCommands;
@@ -89,7 +88,7 @@ export abstract class UpgradeCommandRunner extends ActiveOrSuspendedWorkspacesMi
   }
 
   override async runOnWorkspace(args: RunOnWorkspaceArgs): Promise<void> {
-    this.computeFromToVersionAndCommandsToRunForCurrentAppVersion();
+    this.setUpgradeContextVersionsAndCommandsForCurrentAppVersion();
 
     const { workspaceId, index, total, options } = args;
 
@@ -142,7 +141,7 @@ export abstract class UpgradeCommandRunner extends ActiveOrSuspendedWorkspacesMi
     }
   }
 
-  private retrieveToVersionFromAppVersion() {
+  private retrieveMajorMinorAppVersion() {
     const appVersion = this.twentyConfigService.get('APP_VERSION');
 
     if (!isDefined(appVersion)) {

--- a/packages/twenty-server/src/database/commands/command-runners/upgrade.command-runner.ts
+++ b/packages/twenty-server/src/database/commands/command-runners/upgrade.command-runner.ts
@@ -17,7 +17,6 @@ import {
   CompareVersionMajorAndMinorReturnType,
   compareVersionMajorAndMinor,
 } from 'src/utils/version/compare-version-minor-and-major';
-import { extractVersionMajorMinorPatch } from 'src/utils/version/extract-version-major-minor-patch';
 import { getPreviousVersion } from 'src/utils/version/get-previous-version';
 
 export type VersionCommands = {
@@ -27,7 +26,7 @@ export type VersionCommands = {
 export type AllCommands = Record<string, VersionCommands>;
 export abstract class UpgradeCommandRunner extends ActiveOrSuspendedWorkspacesMigrationCommandRunner {
   private fromWorkspaceVersion: SemVer;
-  private currentAppVersion: string;
+  private currentAppVersion: SemVer;
   public abstract allCommands: AllCommands;
   public commands: VersionCommands;
   public readonly VALIDATE_WORKSPACE_VERSION_FEATURE_FLAG?: true;
@@ -53,9 +52,9 @@ export abstract class UpgradeCommandRunner extends ActiveOrSuspendedWorkspacesMi
       return;
     }
 
-    const currentAppVersion = this.retrieveMajorMinorAppVersion();
-
-    const currentCommands = this.allCommands[currentAppVersion];
+    const currentAppVersion = this.retrieveCurrentAppVersion();
+    const currentVersionMajorMinor = `${currentAppVersion.major}.${currentAppVersion.minor}.0`;
+    const currentCommands = this.allCommands[currentVersionMajorMinor];
 
     if (!isDefined(currentCommands)) {
       throw new Error(
@@ -65,13 +64,13 @@ export abstract class UpgradeCommandRunner extends ActiveOrSuspendedWorkspacesMi
 
     const allCommandsVersions = Object.keys(this.allCommands);
     const previousVersion = getPreviousVersion({
-      currentVersion: currentAppVersion,
+      currentVersion: currentVersionMajorMinor,
       versions: allCommandsVersions,
     });
 
     if (!isDefined(previousVersion)) {
       throw new Error(
-        `No previous version found for version ${currentAppVersion}. Please review the "allCommands" record. Available versions are: ${allCommandsVersions.join(', ')}.`,
+        `No previous version found for version ${currentAppVersion}. Please review the "allCommands" record. Available versions are: ${allCommandsVersions.join(', ')}`,
       );
     }
     this.commands = currentCommands;
@@ -117,7 +116,7 @@ export abstract class UpgradeCommandRunner extends ActiveOrSuspendedWorkspacesMi
 
         await this.workspaceRepository.update(
           { id: workspaceId },
-          { version: this.currentAppVersion },
+          { version: this.currentAppVersion.version },
         );
         this.logger.log(
           chalk.blue(`Upgrade for workspace ${workspaceId} completed.`),
@@ -142,7 +141,7 @@ export abstract class UpgradeCommandRunner extends ActiveOrSuspendedWorkspacesMi
     }
   }
 
-  private retrieveMajorMinorAppVersion() {
+  private retrieveCurrentAppVersion() {
     const appVersion = this.twentyConfigService.get('APP_VERSION');
 
     if (!isDefined(appVersion)) {
@@ -151,15 +150,13 @@ export abstract class UpgradeCommandRunner extends ActiveOrSuspendedWorkspacesMi
       );
     }
 
-    const parsedVersion = extractVersionMajorMinorPatch(appVersion);
-
-    if (!isDefined(parsedVersion)) {
+    try {
+      return new SemVer(appVersion);
+    } catch {
       throw new Error(
-        `Should never occur, APP_VERSION is invalid ${parsedVersion}`,
+        `Should never occur, APP_VERSION is invalid ${appVersion}`,
       );
     }
-
-    return parsedVersion;
   }
 
   private async retrieveWorkspaceVersionAndCompareToWorkspaceFromVersion(

--- a/packages/twenty-server/src/database/commands/command-runners/upgrade.command-runner.ts
+++ b/packages/twenty-server/src/database/commands/command-runners/upgrade.command-runner.ts
@@ -42,13 +42,13 @@ export abstract class UpgradeCommandRunner extends ActiveOrSuspendedWorkspacesMi
   }
 
   private setUpgradeContextVersionsAndCommandsForCurrentAppVersion() {
-    const ugpradeContextAlreadyDefined = [
+    const ugpradeContextIsAlreadyDefined = [
       this.currentAppVersion,
       this.commands,
       this.fromWorkspaceVersion,
     ].every(isDefined);
 
-    if (ugpradeContextAlreadyDefined) {
+    if (ugpradeContextIsAlreadyDefined) {
       return;
     }
 
@@ -141,6 +141,18 @@ export abstract class UpgradeCommandRunner extends ActiveOrSuspendedWorkspacesMi
     }
   }
 
+  public readonly runBeforeSyncMetadata = async (args: RunOnWorkspaceArgs) => {
+    for (const command of this.commands.beforeSyncMetadata) {
+      await command.runOnWorkspace(args);
+    }
+  };
+
+  public readonly runAfterSyncMetadata = async (args: RunOnWorkspaceArgs) => {
+    for (const command of this.commands.afterSyncMetadata) {
+      await command.runOnWorkspace(args);
+    }
+  };
+
   private retrieveCurrentAppVersion() {
     const appVersion = this.twentyConfigService.get('APP_VERSION');
 
@@ -176,16 +188,4 @@ export abstract class UpgradeCommandRunner extends ActiveOrSuspendedWorkspacesMi
       this.fromWorkspaceVersion.version,
     );
   }
-
-  public readonly runBeforeSyncMetadata = async (args: RunOnWorkspaceArgs) => {
-    for (const command of this.commands.beforeSyncMetadata) {
-      await command.runOnWorkspace(args);
-    }
-  };
-
-  public readonly runAfterSyncMetadata = async (args: RunOnWorkspaceArgs) => {
-    for (const command of this.commands.afterSyncMetadata) {
-      await command.runOnWorkspace(args);
-    }
-  };
 }

--- a/packages/twenty-server/src/database/commands/command-runners/upgrade.command-runner.ts
+++ b/packages/twenty-server/src/database/commands/command-runners/upgrade.command-runner.ts
@@ -84,6 +84,7 @@ export abstract class UpgradeCommandRunner extends ActiveOrSuspendedWorkspacesMi
       `- fromWorkspaceVersion: ${previousVersion}`,
       `- ${this.commands.beforeSyncMetadata.length + this.commands.afterSyncMetadata.length} commands`,
     ];
+
     this.logger.log(chalk.blue(message.join('\n   ')));
   }
 

--- a/packages/twenty-server/src/database/commands/command-runners/upgrade.command-runner.ts
+++ b/packages/twenty-server/src/database/commands/command-runners/upgrade.command-runner.ts
@@ -78,9 +78,13 @@ export abstract class UpgradeCommandRunner extends ActiveOrSuspendedWorkspacesMi
     this.fromWorkspaceVersion = previousVersion;
     this.currentAppVersion = currentAppVersion;
 
-    this.logger.log(
-      `Initialized upgrade context with:\n   - currentVersion (migrating to): ${currentAppVersion}\n   - fromVersion: ${previousVersion}\nWith ${this.commands.beforeSyncMetadata.length + this.commands.afterSyncMetadata.length} commands`,
-    );
+    const message = [
+      'Initialized upgrade context with:',
+      `- currentVersion (migrating to): ${currentAppVersion}`,
+      `- fromWorkspaceVersion: ${previousVersion}`,
+      `- ${this.commands.beforeSyncMetadata.length + this.commands.afterSyncMetadata.length} commands`,
+    ];
+    this.logger.log(chalk.blue(message.join('\n   ')));
   }
 
   override async runOnWorkspace(args: RunOnWorkspaceArgs): Promise<void> {
@@ -90,7 +94,7 @@ export abstract class UpgradeCommandRunner extends ActiveOrSuspendedWorkspacesMi
 
     this.logger.log(
       chalk.blue(
-        `${options.dryRun ? '(dry run)' : ''} Upgrading workspace ${workspaceId} from=${this.fromWorkspaceVersion} to=${this.currentAppVersion} ${index + 1}/${total}`,
+        `${options.dryRun ? '(dry run) ' : ''}Upgrading workspace ${workspaceId} from=${this.fromWorkspaceVersion} to=${this.currentAppVersion} ${index + 1}/${total}`,
       ),
     );
 

--- a/packages/twenty-server/src/database/commands/command-runners/upgrade.command-runner.ts
+++ b/packages/twenty-server/src/database/commands/command-runners/upgrade.command-runner.ts
@@ -77,6 +77,10 @@ export abstract class UpgradeCommandRunner extends ActiveOrSuspendedWorkspacesMi
     this.commands = currentCommands;
     this.fromWorkspaceVersion = previousVersion;
     this.currentAppVersion = currentAppVersion;
+
+    this.logger.log(
+      `Initialized upgrade context with:\n   - currentVersion (migrating to): ${currentAppVersion}\n   - fromVersion: ${previousVersion}\nWith ${this.commands.beforeSyncMetadata.length + this.commands.afterSyncMetadata.length} commands`,
+    );
   }
 
   override async runOnWorkspace(args: RunOnWorkspaceArgs): Promise<void> {
@@ -86,7 +90,7 @@ export abstract class UpgradeCommandRunner extends ActiveOrSuspendedWorkspacesMi
 
     this.logger.log(
       chalk.blue(
-        `${options.dryRun ? '(dry run)' : ''} Upgrading workspace ${workspaceId} ${index + 1}/${total}`,
+        `${options.dryRun ? '(dry run)' : ''} Upgrading workspace ${workspaceId} from=${this.fromWorkspaceVersion} to=${this.currentAppVersion} ${index + 1}/${total}`,
       ),
     );
 

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
@@ -1,9 +1,13 @@
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { Repository } from 'typeorm';
-
 import { Command } from 'nest-commander';
-import { AllCommands, UpgradeCommandRunner, VersionCommands } from 'src/database/commands/command-runners/upgrade.command-runner';
+
+import {
+  AllCommands,
+  UpgradeCommandRunner,
+  VersionCommands,
+} from 'src/database/commands/command-runners/upgrade.command-runner';
 import { AddTasksAssignedToMeViewCommand } from 'src/database/commands/upgrade-version-command/0-43/0-43-add-tasks-assigned-to-me-view.command';
 import { MigrateIsSearchableForCustomObjectMetadataCommand } from 'src/database/commands/upgrade-version-command/0-43/0-43-migrate-is-searchable-for-custom-object-metadata.command';
 import { MigrateRichTextContentPatchCommand } from 'src/database/commands/upgrade-version-command/0-43/0-43-migrate-rich-text-content-patch.command';
@@ -63,7 +67,7 @@ export class UpgradeCommand extends UpgradeCommandRunner {
       twentyORMGlobalManager,
       syncWorkspaceMetadataCommand,
     );
-    
+
     const commands_043: VersionCommands = {
       beforeSyncMetadata: [
         this.migrateRichTextContentPatchCommand,
@@ -117,6 +121,6 @@ export class UpgradeCommand extends UpgradeCommandRunner {
       '0.51.0': commands_051,
       '0.52.0': commands_052,
       '0.53.0': commands_053,
-    }
+    };
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/twenty-config.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/twenty-config.service.ts
@@ -275,4 +275,4 @@ export class TwentyConfigService {
 
     return true;
   }
- }
+}

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/twenty-config.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/twenty-config.service.ts
@@ -275,4 +275,4 @@ export class TwentyConfigService {
 
     return true;
   }
-}
+ }

--- a/packages/twenty-server/src/utils/version/__tests__/__snapshots__/compare-version-minor-and-major.spec.ts.snap
+++ b/packages/twenty-server/src/utils/version/__tests__/__snapshots__/compare-version-minor-and-major.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`is-same-major-and-minor-version incomplete version1 1`] = `"Received invalid version: 1.0 1.1.0"`;
+exports[`It should compare two versions with  incomplete version1 1`] = `"Received invalid version: 1.0 1.1.0"`;
 
-exports[`is-same-major-and-minor-version invalid version1 1`] = `"Received invalid version: invalid 1.1.0"`;
+exports[`It should compare two versions with  invalid version1 1`] = `"Received invalid version: invalid 1.1.0"`;
 
-exports[`is-same-major-and-minor-version invalid version2 1`] = `"Received invalid version: 1.0.0 invalid"`;
+exports[`It should compare two versions with  invalid version2 1`] = `"Received invalid version: 1.0.0 invalid"`;

--- a/packages/twenty-server/src/utils/version/__tests__/compare-version-minor-and-major.spec.ts
+++ b/packages/twenty-server/src/utils/version/__tests__/compare-version-minor-and-major.spec.ts
@@ -11,7 +11,7 @@ type IsSameVersionTestCase = EachTestingContext<{
   expected?: CompareVersionMajorAndMinorReturnType;
   expectToThrow?: boolean;
 }>;
-describe('It should compare two versions with ', () => {
+describe('It should compare two versions with', () => {
   const beneathVersionTestCases: IsSameVersionTestCase[] = [
     {
       context: {

--- a/packages/twenty-server/src/utils/version/__tests__/compare-version-minor-and-major.spec.ts
+++ b/packages/twenty-server/src/utils/version/__tests__/compare-version-minor-and-major.spec.ts
@@ -11,7 +11,7 @@ type IsSameVersionTestCase = EachTestingContext<{
   expected?: CompareVersionMajorAndMinorReturnType;
   expectToThrow?: boolean;
 }>;
-describe('is-same-major-and-minor-version', () => {
+describe('It should compare two versions with ', () => {
   const beneathVersionTestCases: IsSameVersionTestCase[] = [
     {
       context: {
@@ -181,7 +181,7 @@ describe('is-same-major-and-minor-version', () => {
     ...beneathVersionTestCases,
     ...aboveVersionTestCases,
   ])(
-    '$title',
+    ' $title',
     ({ context: { version1, version2, expected, expectToThrow = false } }) => {
       if (expectToThrow) {
         expect(() =>

--- a/packages/twenty-server/src/utils/version/__tests__/extract-version-major-minor-patch.spec.ts
+++ b/packages/twenty-server/src/utils/version/__tests__/extract-version-major-minor-patch.spec.ts
@@ -6,7 +6,7 @@ type IsSameVersionTestCase = EachTestingContext<{
   version: string | undefined;
   expected: string | null;
 }>;
-describe('extract-version-major-minor-patch', () => {
+describe('It should extract major.minor.patch values from a', () => {
   const testCase: IsSameVersionTestCase[] = [
     {
       context: {
@@ -101,7 +101,7 @@ describe('extract-version-major-minor-patch', () => {
     },
   ];
 
-  test.each(testCase)('$title', ({ context: { version, expected } }) => {
+  test.each(testCase)(' $title', ({ context: { version, expected } }) => {
     expect(extractVersionMajorMinorPatch(version)).toBe(expected);
   });
 });

--- a/packages/twenty-server/src/utils/version/__tests__/get-previous-version.spec.ts
+++ b/packages/twenty-server/src/utils/version/__tests__/get-previous-version.spec.ts
@@ -8,7 +8,7 @@ type GetPreviousVersionTestCase = EachTestingContext<{
   expected: string | undefined;
 }>;
 
-describe('get-previous-version', () => {
+describe('It should return the previous version from a list of', () => {
   const testCase: GetPreviousVersionTestCase[] = [
     {
       context: {
@@ -93,7 +93,7 @@ describe('get-previous-version', () => {
   ];
 
   test.each(testCase)(
-    '$title',
+    ' $title',
     ({ context: { versions, currentVersion, expected } }) => {
       const result = getPreviousVersion({ versions, currentVersion });
 

--- a/packages/twenty-server/src/utils/version/__tests__/get-previous-version.spec.ts
+++ b/packages/twenty-server/src/utils/version/__tests__/get-previous-version.spec.ts
@@ -1,6 +1,6 @@
-import { getPreviousVersion } from 'src/utils/version/get-previous-version';
 import { EachTestingContext } from 'twenty-shared/testing';
 
+import { getPreviousVersion } from 'src/utils/version/get-previous-version';
 
 type GetPreviousVersionTestCase = EachTestingContext<{
   versions: string[];
@@ -92,8 +92,12 @@ describe('get-previous-version', () => {
     },
   ];
 
-  test.each(testCase)('$title', ({ context: { versions, currentVersion, expected } }) => {
-    const result = getPreviousVersion({versions, currentVersion});
-    expect(result?.format()).toBe(expected);
-  });
-}); 
+  test.each(testCase)(
+    '$title',
+    ({ context: { versions, currentVersion, expected } }) => {
+      const result = getPreviousVersion({ versions, currentVersion });
+
+      expect(result?.format()).toBe(expected);
+    },
+  );
+});

--- a/packages/twenty-server/src/utils/version/__tests__/get-previous-version.spec.ts
+++ b/packages/twenty-server/src/utils/version/__tests__/get-previous-version.spec.ts
@@ -1,0 +1,99 @@
+import { getPreviousVersion } from 'src/utils/version/get-previous-version';
+import { EachTestingContext } from 'twenty-shared/testing';
+
+
+type GetPreviousVersionTestCase = EachTestingContext<{
+  versions: string[];
+  currentVersion: string;
+  expected: string | undefined;
+}>;
+
+describe('get-previous-version', () => {
+  const testCase: GetPreviousVersionTestCase[] = [
+    {
+      context: {
+        versions: ['0.1.0', '0.2.0', '0.3.0'],
+        currentVersion: '0.3.0',
+        expected: '0.2.0',
+      },
+      title: 'Basic version sequence',
+    },
+    {
+      context: {
+        versions: ['1.0.0', '1.1.0', '2.0.0'],
+        currentVersion: '2.0.0',
+        expected: '1.1.0',
+      },
+      title: 'Major version jump',
+    },
+    {
+      context: {
+        versions: ['0.1.0', '0.1.1', '0.1.2'],
+        currentVersion: '0.1.2',
+        expected: '0.1.1',
+      },
+      title: 'Patch version sequence',
+    },
+    {
+      context: {
+        versions: ['1.0.0'],
+        currentVersion: '1.0.0',
+        expected: undefined,
+      },
+      title: 'Single version',
+    },
+    {
+      context: {
+        versions: [],
+        currentVersion: '1.0.0',
+        expected: undefined,
+      },
+      title: 'Empty version array',
+    },
+    {
+      context: {
+        versions: ['0.1.0', '0.2.0', '0.3.0'],
+        currentVersion: '0.1.0',
+        expected: undefined,
+      },
+      title: 'No previous version available',
+    },
+    {
+      context: {
+        versions: ['1.0.0', '2.0.0', '1.5.0'],
+        currentVersion: '2.0.0',
+        expected: '1.5.0',
+      },
+      title: 'Unordered versions',
+    },
+    {
+      context: {
+        versions: ['1.0.0', '1.0.0-alpha', '1.0.0-beta'],
+        currentVersion: '1.0.0',
+        expected: '1.0.0-beta',
+      },
+      title: 'Pre-release versions',
+    },
+    {
+      context: {
+        versions: ['invalid', '1.0.0', '2.0.0'],
+        currentVersion: '2.0.0',
+        expected: undefined,
+      },
+      title: 'Invalid version in array',
+    },
+    {
+      context: {
+        versions: ['1.0.0', '2.0.0'],
+        currentVersion: 'invalid',
+        expected: undefined,
+      },
+      title: 'Invalid current version',
+    },
+  ];
+
+  test.each(testCase)('$title', ({ context: { versions, currentVersion, expected } }) => {
+    const result = getPreviousVersion({versions, currentVersion});
+    expect(result?.format()).toBe(expected);
+  });
+}); 

--- a/packages/twenty-server/src/utils/version/get-previous-version.ts
+++ b/packages/twenty-server/src/utils/version/get-previous-version.ts
@@ -1,0 +1,25 @@
+import { SemVer } from 'semver';
+
+type GetPreviousVersionFromArrayArgs = {
+  versions: string[];
+  currentVersion: string;
+}
+export const getPreviousVersion = (
+  { versions, currentVersion }: GetPreviousVersionFromArrayArgs,
+): SemVer | undefined => {
+  try {
+    const semverVersions = versions
+      .map((version) => new SemVer(version))
+      .sort((a, b) => b.compare(a));
+
+    const currentSemver = new SemVer(currentVersion);
+
+    const previousVersion = semverVersions.find(
+      (version) => version.compare(currentSemver) < 0,
+    );
+
+    return previousVersion;
+  } catch {
+    return undefined;
+  }
+};

--- a/packages/twenty-server/src/utils/version/get-previous-version.ts
+++ b/packages/twenty-server/src/utils/version/get-previous-version.ts
@@ -3,10 +3,11 @@ import { SemVer } from 'semver';
 type GetPreviousVersionFromArrayArgs = {
   versions: string[];
   currentVersion: string;
-}
-export const getPreviousVersion = (
-  { versions, currentVersion }: GetPreviousVersionFromArrayArgs,
-): SemVer | undefined => {
+};
+export const getPreviousVersion = ({
+  versions,
+  currentVersion,
+}: GetPreviousVersionFromArrayArgs): SemVer | undefined => {
   try {
     const semverVersions = versions
       .map((version) => new SemVer(version))


### PR DESCRIPTION
# Introduction
This PR refactors the way we previously manually handled the upgrade command `versionTo` and `versionFrom` values to be replaced by a programmatic inferring using the `APP_VERSION` env variable. It raises new invariant edge cases that are covered by new tests and so on

Please keep in mind that an upgrade will run agnostically of any `patch` semver value as it should be done only when releasing a `major/minor` version update
[Related discord thread](https://discord.com/channels/1130383047699738754/1368953221921505280)

## Testing in local
In order to test in local we have to define an `APP_VERSION` value in `packages/twenty-server/.env` following semver ( or not 🙃 )

## Logs example
```ts
Computing new Datasource for cacheKey: 20202020-1c25-4d02-bf25-6aeccf7ea419-8 out of 0
query: SELECT * FROM current_schema()
query: SELECT version();
[Nest] 37872  - 05/06/2025, 4:07:21 PM     LOG [UpgradeCommand] Initialized upgrade context with:
   - currentVersion (migrating to): 0.53.0
   - fromWorkspaceVersion: 0.52.0
   - 2 commands
[Nest] 37872  - 05/06/2025, 4:07:21 PM     LOG [UpgradeCommand] Upgrading workspace 20202020-1c25-4d02-bf25-6aeccf7ea419 from=0.52.0 to=0.53.0 1/2
[Nest] 37872  - 05/06/2025, 4:07:21 PM     LOG [UpgradeCommand] Upgrade for workspace 20202020-1c25-4d02-bf25-6aeccf7ea419 ignored as is already at a higher version.
[Nest] 37872  - 05/06/2025, 4:07:21 PM     LOG [UpgradeCommand] Running command on workspace 3b8e6458-5fc1-4e63-8563-008ccddaa6db 2/2
Computing new Datasource for cacheKey: 3b8e6458-5fc1-4e63-8563-008ccddaa6db-8 out of 0
query: SELECT * FROM current_schema()
query: SELECT version();
[Nest] 37872  - 05/06/2025, 4:07:21 PM     LOG [UpgradeCommand] Upgrading workspace 3b8e6458-5fc1-4e63-8563-008ccddaa6db from=0.52.0 to=0.53.0 2/2
[Nest] 37872  - 05/06/2025, 4:07:21 PM     LOG [UpgradeCommand] Upgrade for workspace 3b8e6458-5fc1-4e63-8563-008ccddaa6db ignored as is already at a higher version.
[Nest] 37872  - 05/06/2025, 4:07:21 PM     LOG [UpgradeCommand] Command completed!
```

## Misc
Related to https://github.com/twentyhq/twenty/issues/11780