### PR TITLE
fix(docker-compose): increase retry for server service

### DIFF
--- a/packages/twenty-docker/docker-compose.yml
+++ b/packages/twenty-docker/docker-compose.yml
@@ -65,7 +65,7 @@ services:
       test: curl --fail http://localhost:3000/healthz
       interval: 5s
       timeout: 5s
-      retries: 10
+      retries: 20
     restart: always
 
   worker:


### PR DESCRIPTION
## Background
I'm trying to self-host twenty using [official 1-Click w/ Docker Compose guide](https://twenty.com/developers/section/self-hosting/docker-compose) on AWS EC2 (using `t3.small` instance type).

## What happened
I used the one-line script but it failed with
```
[skipped]
server-1                | Successfuly migrated DB!
dependency failed to start: container twenty-server-1 is unhealthy
```

Then I tried manual steps, and it failed again with same issue as above. No configuration changed, everything default used.

I re-run manual steps multiple times with `docker compose down -v` and `docker compose up`, everything time it failed with `server` unhealthy as it seems server takes longer than configured health check duration (which is 50 seconds)

Here's the `time` summary running it:
```
[skipped]
server-1                | Successfuly migrated DB!
dependency failed to start: container twenty-server-1 is unhealthy

________________________________________________________
Executed in   58.26 secs      fish           external
   usr time  661.43 millis  362.00 micros  661.07 millis
   sys time  646.10 millis  212.00 micros  645.89 millis

root@ip-10-0-10-43 ~/twenty [1]# 
```

## Why it happend

My hunch (new to twenty, just used it yesterday) is that server service takes much longer to become healthy with DB migration and etc, that configured health check retries is not sufficient.

## What solution worked

Increased the retry for server service from 10 to 20, and it worked and service came up healthy (everytime). The increase wasn't needed for db or worker service, just server service. 

If this all makes sense, please feel free to merge this, so it'll be smoother experience for others new to self-hosting twenty.