### PR TITLE
[CI]: Increase status check timeout

### DIFF
--- a/.github/workflows/ci-chrome-extension.yaml
+++ b/.github/workflows/ci-chrome-extension.yaml
@@ -39,7 +39,7 @@ jobs:
         run: npx nx build twenty-chrome-extension
   ci-chrome-extension-status-check:
     if: always() && !cancelled()
-    timeout-minutes: 1
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     needs: [changed-files-check, chrome-extension-build]
     steps:

--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -124,7 +124,7 @@ jobs:
         retention-days: 30
   ci-e2e-status-check:
       if: always() && !cancelled()
-      timeout-minutes: 1
+      timeout-minutes: 5
       runs-on: ubuntu-latest
       needs: [changed-files-check, test]
       steps:

--- a/.github/workflows/ci-emails.yaml
+++ b/.github/workflows/ci-emails.yaml
@@ -53,7 +53,7 @@ jobs:
           kill $SERVER_PID
   ci-emails-status-check:
     if: always() && !cancelled()
-    timeout-minutes: 1
+    timeout-minutes: 5
     runs-on: depot-ubuntu-24.04-8
     needs: [changed-files-check, emails-test]
     steps:

--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -189,7 +189,7 @@ jobs:
           key: ${{ steps.restore-task-cache.outputs.cache-primary-key }}
   ci-front-status-check:
     if: always() && !cancelled()
-    timeout-minutes: 1
+    timeout-minutes: 5
     runs-on: depot-ubuntu-24.04-8
     needs:
       [

--- a/.github/workflows/ci-server.yaml
+++ b/.github/workflows/ci-server.yaml
@@ -232,7 +232,7 @@ jobs:
           path: reset-logs.log
   ci-server-status-check:
     if: always() && !cancelled()
-    timeout-minutes: 1
+    timeout-minutes: 5
     runs-on: depot-ubuntu-24.04-8
     needs: [changed-files-check, server-setup, server-test, server-integration-test]
     steps:

--- a/.github/workflows/ci-shared.yaml
+++ b/.github/workflows/ci-shared.yaml
@@ -44,7 +44,7 @@ jobs:
           tasks: ${{ matrix.task }}
   ci-shared-status-check:
     if: always() && !cancelled()
-    timeout-minutes: 1
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     needs: [changed-files-check, shared-test]
     steps:

--- a/.github/workflows/ci-test-docker-compose.yaml
+++ b/.github/workflows/ci-test-docker-compose.yaml
@@ -84,7 +84,7 @@ jobs:
         working-directory: ./packages/twenty-docker/
   ci-test-docker-compose-status-check:
     if: always() && !cancelled()
-    timeout-minutes: 1
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     needs: [changed-files-check, test]
     steps:

--- a/.github/workflows/ci-website.yaml
+++ b/.github/workflows/ci-website.yaml
@@ -62,7 +62,7 @@ jobs:
           NEXT_PUBLIC_KEYSTATIC_GITHUB_APP_SLUG: xxx
   ci-website-status-check:
     if: always() && !cancelled()
-    timeout-minutes: 10
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     needs: [changed-files-check, website-build]
     steps:


### PR DESCRIPTION
# Introduction
Some jobs start to fail because they exceed the timeout
Such as this job https://github.com/twentyhq/twenty/actions/runs/14862320942/job/41730200276?pr=11881