### PR TITLE
Fix duplicated workspace id in activeOrSuspendedCommandRunner options

### DIFF
--- a/packages/twenty-server/src/database/commands/command-runners/active-or-suspended-workspaces-migration.command-runner.ts
+++ b/packages/twenty-server/src/database/commands/command-runners/active-or-suspended-workspaces-migration.command-runner.ts
@@ -91,7 +91,7 @@ export abstract class ActiveOrSuspendedWorkspacesMigrationCommandRunner<
       'workspace id. Command runs on all active workspaces if not provided.',
     required: false,
   })
-  parseWorkspaceId(val: string): Set<String> {
+  parseWorkspaceId(val: string): Set<string> {
     this.workspaceIds.add(val);
     return this.workspaceIds;
   }

--- a/packages/twenty-server/src/database/commands/command-runners/active-or-suspended-workspaces-migration.command-runner.ts
+++ b/packages/twenty-server/src/database/commands/command-runners/active-or-suspended-workspaces-migration.command-runner.ts
@@ -93,6 +93,7 @@ export abstract class ActiveOrSuspendedWorkspacesMigrationCommandRunner<
   })
   parseWorkspaceId(val: string): Set<string> {
     this.workspaceIds.add(val);
+
     return this.workspaceIds;
   }
 

--- a/packages/twenty-server/src/database/commands/command-runners/active-or-suspended-workspaces-migration.command-runner.ts
+++ b/packages/twenty-server/src/database/commands/command-runners/active-or-suspended-workspaces-migration.command-runner.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { Option } from 'nest-commander';
-import { In, MoreThanOrEqual, Repository } from 'typeorm';
 import { WorkspaceActivationStatus } from 'twenty-shared/workspace';
+import { In, MoreThanOrEqual, Repository } from 'typeorm';
 
 import { MigrationCommandRunner } from 'src/database/commands/command-runners/migration.command-runner';
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
@@ -38,7 +38,7 @@ export abstract class ActiveOrSuspendedWorkspacesMigrationCommandRunner<
   Options extends
     ActiveOrSuspendedWorkspacesMigrationCommandOptions = ActiveOrSuspendedWorkspacesMigrationCommandOptions,
 > extends MigrationCommandRunner {
-  private workspaceIds: string[] = [];
+  private workspaceIds: Set<string> = new Set();
   private startFromWorkspaceId: string | undefined;
   private workspaceCountLimit: number | undefined;
   public migrationReport: WorkspaceMigrationReport = {
@@ -91,9 +91,8 @@ export abstract class ActiveOrSuspendedWorkspacesMigrationCommandRunner<
       'workspace id. Command runs on all active workspaces if not provided.',
     required: false,
   })
-  parseWorkspaceId(val: string): string[] {
-    this.workspaceIds.push(val);
-
+  parseWorkspaceId(val: string): Set<String> {
+    this.workspaceIds.add(val);
     return this.workspaceIds;
   }
 
@@ -123,8 +122,8 @@ export abstract class ActiveOrSuspendedWorkspacesMigrationCommandRunner<
     options: Options,
   ) {
     const activeWorkspaceIds =
-      this.workspaceIds.length > 0
-        ? this.workspaceIds
+      this.workspaceIds.size > 0
+        ? Array.from(this.workspaceIds)
         : await this.fetchActiveWorkspaceIds();
 
     if (options.dryRun) {


### PR DESCRIPTION
# Introduction
From my understand we're kinda hacking through the options parser by defining class properties within them whereas we should be consuming the return type value ? Have no time for this right now

Anw for some reason nestjs-commander enters several time the option parse which result in duplicating the given workspaceId in the array

Added a Set to fix

close https://github.com/twentyhq/twenty/issues/11707