### PR TITLE
fix: avoid passing invalid to prop to DOM

### DIFF
--- a/packages/twenty-front/src/modules/settings/components/SettingsListItemCardContent.tsx
+++ b/packages/twenty-front/src/modules/settings/components/SettingsListItemCardContent.tsx
@@ -3,10 +3,12 @@ import styled from '@emotion/styled';
 import { ReactNode } from 'react';
 import { Link } from 'react-router-dom';
 import { isDefined } from 'twenty-shared/utils';
-import { CardContent } from 'twenty-ui/layout';
 import { IconChevronRight, IconComponent } from 'twenty-ui/display';
+import { CardContent } from 'twenty-ui/layout';
 
-const StyledRow = styled(CardContent)<{ to?: boolean }>`
+const StyledRow = styled(CardContent, {
+  shouldForwardProp: (prop) => prop !== 'to',
+})<{ to?: boolean }>`
   align-items: center;
   cursor: ${({ onClick, to }) => (onClick || to ? 'pointer' : 'default')};
   display: flex;

--- a/packages/twenty-front/src/modules/settings/components/SettingsListItemCardContent.tsx
+++ b/packages/twenty-front/src/modules/settings/components/SettingsListItemCardContent.tsx
@@ -1,3 +1,4 @@
+import isPropValid from '@emotion/is-prop-valid';
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { ReactNode } from 'react';
@@ -7,7 +8,7 @@ import { IconChevronRight, IconComponent } from 'twenty-ui/display';
 import { CardContent } from 'twenty-ui/layout';
 
 const StyledRow = styled(CardContent, {
-  shouldForwardProp: (prop) => prop !== 'to',
+  shouldForwardProp: (prop) => prop !== 'to' && isPropValid(prop),
 })<{ to?: boolean }>`
   align-items: center;
   cursor: ${({ onClick, to }) => (onClick || to ? 'pointer' : 'default')};


### PR DESCRIPTION
Fixed a React warning caused by the to prop being passed to the DOM when its value was undefined or false. Since to is not a valid HTML attribute, this triggered a console error. The prop is only used for styling logic, so I used Emotion’s shouldForwardProp to prevent it from being passed to the DOM, resolving the issue cleanly.

![Screenshot 2025-05-07 at 10 00 54 PM](https://github.com/user-attachments/assets/0660af7f-df98-46a3-b9f2-2ccc993ac227)

#11850 
