### PR TITLE
Note link's color contrast fixed in dark mode

### DIFF
--- a/packages/twenty-front/src/modules/ui/input/editor/components/BlockEditor.tsx
+++ b/packages/twenty-front/src/modules/ui/input/editor/components/BlockEditor.tsx
@@ -116,6 +116,10 @@ const StyledEditor = styled.div`
     margin-left: 8px;
   }
 
+  & .bn-inline-content a {
+    color: ${({ theme }) => theme.color.blue};
+  }
+
   & .bn-inline-content code {
     font-family: monospace;
     color: ${({ theme }) => theme.font.color.danger};


### PR DESCRIPTION
# Note link's color contrast fixed in dark mode

## Key changes

This pull request introduces a minor styling update to the `BlockEditor` component in `BlockEditor.tsx`. It adds a new style rule to ensure inline links within the `.bn-inline-content` class are styled with the theme's blue color.

### Styling updates:

* [`packages/twenty-front/src/modules/ui/input/editor/components/BlockEditor.tsx`](diffhunk://#diff-4a66ce7d5588bddc6237ac1a3b2949fe4432182bd357114294e8a79d98afce51R119-R122): Added a CSS rule to style links (`<a>` elements) within `.bn-inline-content` to use the theme's blue color.

## Issue
fixes #11917 

![image](https://github.com/user-attachments/assets/15a15aa4-be46-4d66-9cfa-55b5d961a6ca)