### PR TITLE
Implemented PHONES sub-field filtering

### DIFF
--- a/packages/twenty-front/src/modules/object-record/advanced-filter/components/AdvancedFilterDropdownFilterInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/advanced-filter/components/AdvancedFilterDropdownFilterInput.tsx
@@ -83,7 +83,7 @@ export const AdvancedFilterDropdownFilterInput = ({
           recordFilter.subFieldName,
         ) ? (
           <>
-            <ObjectFilterDropdownCurrencySelect dropdownWidth={280} />
+            <ObjectFilterDropdownCurrencySelect />
           </>
         ) : (
           <></>

--- a/packages/twenty-front/src/modules/object-record/graphql/types/RecordGqlOperationFilter.ts
+++ b/packages/twenty-front/src/modules/object-record/graphql/types/RecordGqlOperationFilter.ts
@@ -104,6 +104,8 @@ export type EmailsFilter = {
 
 export type PhonesFilter = {
   primaryPhoneNumber?: StringFilter;
+  primaryPhoneCallingCode?: StringFilter;
+  additionalPhones?: RawJsonFilter;
 };
 
 export type SelectFilter = {

--- a/packages/twenty-front/src/modules/object-record/object-filter-dropdown/components/ObjectFilterDropdownCurrencySelect.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-filter-dropdown/components/ObjectFilterDropdownCurrencySelect.tsx
@@ -18,13 +18,7 @@ import { MenuItem, MenuItemMultiSelectAvatar } from 'twenty-ui/navigation';
 export const EMPTY_FILTER_VALUE = '[]';
 export const MAX_ITEMS_TO_DISPLAY = 3;
 
-type ObjectFilterDropdownCurrencySelectProps = {
-  dropdownWidth?: number;
-};
-
-export const ObjectFilterDropdownCurrencySelect = ({
-  dropdownWidth,
-}: ObjectFilterDropdownCurrencySelectProps) => {
+export const ObjectFilterDropdownCurrencySelect = () => {
   const [searchText, setSearchText] = useState('');
 
   const objectFilterDropdownCurrentRecordFilter = useRecoilComponentValueV2(
@@ -112,7 +106,7 @@ export const ObjectFilterDropdownCurrencySelect = ({
         }}
       />
       <DropdownMenuSeparator />
-      <DropdownMenuItemsContainer hasMaxHeight width={dropdownWidth ?? 200}>
+      <DropdownMenuItemsContainer hasMaxHeight width="auto">
         {filteredSelectedItems?.map((item) => {
           return (
             <MenuItemMultiSelectAvatar

--- a/packages/twenty-front/src/modules/object-record/record-filter/utils/__tests__/computeViewRecordGqlOperationFilter.test.ts
+++ b/packages/twenty-front/src/modules/object-record/record-filter/utils/__tests__/computeViewRecordGqlOperationFilter.test.ts
@@ -640,6 +640,20 @@ describe('should work as expected for the different field types', () => {
                 },
               },
             },
+            {
+              phones: {
+                primaryPhoneCallingCode: {
+                  ilike: '%1234567890%',
+                },
+              },
+            },
+            {
+              phones: {
+                additionalPhones: {
+                  like: '%1234567890%',
+                },
+              },
+            },
           ],
         },
         {
@@ -653,6 +667,35 @@ describe('should work as expected for the different field types', () => {
                 },
               },
             },
+            {
+              not: {
+                phones: {
+                  primaryPhoneCallingCode: {
+                    ilike: '%1234567890%',
+                  },
+                },
+              },
+            },
+            {
+              or: [
+                {
+                  not: {
+                    phones: {
+                      additionalPhones: {
+                        like: `%1234567890%`,
+                      },
+                    },
+                  },
+                },
+                {
+                  phones: {
+                    additionalPhones: {
+                      is: 'NULL',
+                    },
+                  },
+                },
+              ],
+            },
           ],
         },
         {
@@ -661,16 +704,40 @@ describe('should work as expected for the different field types', () => {
               or: [
                 {
                   phones: {
-                    primaryPhoneNumber: {
-                      is: 'NULL',
-                    },
+                    primaryPhoneNumber: { is: 'NULL' },
                   },
                 },
                 {
                   phones: {
-                    primaryPhoneNumber: {
-                      ilike: '',
-                    },
+                    primaryPhoneNumber: { ilike: '' },
+                  },
+                },
+              ],
+            },
+            {
+              or: [
+                {
+                  phones: {
+                    primaryPhoneCallingCode: { is: 'NULL' },
+                  },
+                },
+                {
+                  phones: {
+                    primaryPhoneCallingCode: { ilike: '' },
+                  },
+                },
+              ],
+            },
+            {
+              or: [
+                {
+                  phones: {
+                    additionalPhones: { is: 'NULL' },
+                  },
+                },
+                {
+                  phones: {
+                    additionalPhones: { like: '[]' },
                   },
                 },
               ],
@@ -684,16 +751,40 @@ describe('should work as expected for the different field types', () => {
                 or: [
                   {
                     phones: {
-                      primaryPhoneNumber: {
-                        is: 'NULL',
-                      },
+                      primaryPhoneNumber: { is: 'NULL' },
                     },
                   },
                   {
                     phones: {
-                      primaryPhoneNumber: {
-                        ilike: '',
-                      },
+                      primaryPhoneNumber: { ilike: '' },
+                    },
+                  },
+                ],
+              },
+              {
+                or: [
+                  {
+                    phones: {
+                      primaryPhoneCallingCode: { is: 'NULL' },
+                    },
+                  },
+                  {
+                    phones: {
+                      primaryPhoneCallingCode: { ilike: '' },
+                    },
+                  },
+                ],
+              },
+              {
+                or: [
+                  {
+                    phones: {
+                      additionalPhones: { is: 'NULL' },
+                    },
+                  },
+                  {
+                    phones: {
+                      additionalPhones: { like: '[]' },
                     },
                   },
                 ],

--- a/packages/twenty-front/src/modules/object-record/record-filter/utils/areCompositeTypeSubFieldsFilterable.ts
+++ b/packages/twenty-front/src/modules/object-record/record-filter/utils/areCompositeTypeSubFieldsFilterable.ts
@@ -5,6 +5,7 @@ const COMPOSITE_TYPES_FILTERABLE = [
   'FULL_NAME',
   'CURRENCY',
   'ADDRESS',
+  'PHONES',
 ] satisfies FieldType[];
 
 type FilterableCompositeFieldType = (typeof COMPOSITE_TYPES_FILTERABLE)[number];

--- a/packages/twenty-front/src/modules/object-record/record-filter/utils/computeViewRecordGqlOperationFilter.ts
+++ b/packages/twenty-front/src/modules/object-record/record-filter/utils/computeViewRecordGqlOperationFilter.ts
@@ -728,33 +728,6 @@ export const computeFilterRecordGqlOperationFilter = ({
                     },
                   ],
                 },
-                {
-                  not: {
-                    [correspondingField.name]: {
-                      addressState: {
-                        ilike: `%${filter.value}%`,
-                      },
-                    } as AddressFilter,
-                  },
-                },
-                {
-                  not: {
-                    [correspondingField.name]: {
-                      addressCountry: {
-                        ilike: `%${filter.value}%`,
-                      },
-                    } as AddressFilter,
-                  },
-                },
-                {
-                  not: {
-                    [correspondingField.name]: {
-                      addressPostcode: {
-                        ilike: `%${filter.value}%`,
-                      },
-                    } as AddressFilter,
-                  },
-                },
               ],
             };
           } else {

--- a/packages/twenty-front/src/modules/object-record/record-filter/utils/computeViewRecordGqlOperationFilter.ts
+++ b/packages/twenty-front/src/modules/object-record/record-filter/utils/computeViewRecordGqlOperationFilter.ts
@@ -728,6 +728,33 @@ export const computeFilterRecordGqlOperationFilter = ({
                     },
                   ],
                 },
+                {
+                  not: {
+                    [correspondingField.name]: {
+                      addressState: {
+                        ilike: `%${filter.value}%`,
+                      },
+                    } as AddressFilter,
+                  },
+                },
+                {
+                  not: {
+                    [correspondingField.name]: {
+                      addressCountry: {
+                        ilike: `%${filter.value}%`,
+                      },
+                    } as AddressFilter,
+                  },
+                },
+                {
+                  not: {
+                    [correspondingField.name]: {
+                      addressPostcode: {
+                        ilike: `%${filter.value}%`,
+                      },
+                    } as AddressFilter,
+                  },
+                },
               ],
             };
           } else {
@@ -1030,25 +1057,146 @@ export const computeFilterRecordGqlOperationFilter = ({
           );
       }
     case 'PHONES': {
-      const filterValue = filter.value.replace(/[^0-9]/g, '');
+      if (!isSubFieldFilter) {
+        const filterValue = filter.value.replace(/[^0-9]/g, '');
 
-      switch (filter.operand) {
-        case RecordFilterOperand.Contains:
-          return {
-            or: [
-              {
+        if (!isNonEmptyString(filterValue)) {
+          return;
+        }
+
+        switch (filter.operand) {
+          case RecordFilterOperand.Contains:
+            return {
+              or: [
+                {
+                  [correspondingField.name]: {
+                    primaryPhoneNumber: {
+                      ilike: `%${filterValue}%`,
+                    },
+                  } as PhonesFilter,
+                },
+                {
+                  [correspondingField.name]: {
+                    primaryPhoneCallingCode: {
+                      ilike: `%${filterValue}%`,
+                    },
+                  } as PhonesFilter,
+                },
+                {
+                  [correspondingField.name]: {
+                    additionalPhones: {
+                      like: `%${filterValue}%`,
+                    },
+                  } as PhonesFilter,
+                },
+              ],
+            };
+          case RecordFilterOperand.DoesNotContain:
+            return {
+              and: [
+                {
+                  not: {
+                    [correspondingField.name]: {
+                      primaryPhoneNumber: {
+                        ilike: `%${filterValue}%`,
+                      },
+                    } as PhonesFilter,
+                  },
+                },
+                {
+                  not: {
+                    [correspondingField.name]: {
+                      primaryPhoneCallingCode: {
+                        ilike: `%${filterValue}%`,
+                      },
+                    } as PhonesFilter,
+                  },
+                },
+                {
+                  or: [
+                    {
+                      not: {
+                        [correspondingField.name]: {
+                          additionalPhones: {
+                            like: `%${filterValue}%`,
+                          },
+                        } as PhonesFilter,
+                      },
+                    },
+                    {
+                      [correspondingField.name]: {
+                        additionalPhones: {
+                          is: 'NULL',
+                        } as PhonesFilter,
+                      },
+                    },
+                  ],
+                },
+              ],
+            };
+          default:
+            throw new Error(
+              `Unknown operand ${filter.operand} for ${filterType} filter`,
+            );
+        }
+      }
+
+      const filterValue = filter.value;
+
+      switch (subFieldName) {
+        case 'additionalPhones': {
+          switch (filter.operand) {
+            case RecordFilterOperand.Contains:
+              return {
+                or: [
+                  {
+                    [correspondingField.name]: {
+                      additionalPhones: {
+                        like: `%${filterValue}%`,
+                      },
+                    } as PhonesFilter,
+                  },
+                ],
+              };
+            case RecordFilterOperand.DoesNotContain:
+              return {
+                or: [
+                  {
+                    not: {
+                      [correspondingField.name]: {
+                        additionalPhones: {
+                          like: `%${filterValue}%`,
+                        },
+                      } as PhonesFilter,
+                    },
+                  },
+                  {
+                    [correspondingField.name]: {
+                      additionalPhones: {
+                        is: 'NULL',
+                      } as PhonesFilter,
+                    },
+                  },
+                ],
+              };
+            default:
+              throw new Error(
+                `Unknown operand ${filter.operand} for ${filterType} filter`,
+              );
+          }
+        }
+        case 'primaryPhoneNumber': {
+          switch (filter.operand) {
+            case RecordFilterOperand.Contains:
+              return {
                 [correspondingField.name]: {
                   primaryPhoneNumber: {
                     ilike: `%${filterValue}%`,
                   },
                 } as PhonesFilter,
-              },
-            ],
-          };
-        case RecordFilterOperand.DoesNotContain:
-          return {
-            and: [
-              {
+              };
+            case RecordFilterOperand.DoesNotContain:
+              return {
                 not: {
                   [correspondingField.name]: {
                     primaryPhoneNumber: {
@@ -1056,12 +1204,42 @@ export const computeFilterRecordGqlOperationFilter = ({
                     },
                   } as PhonesFilter,
                 },
-              },
-            ],
-          };
+              };
+            default:
+              throw new Error(
+                `Unknown operand ${filter.operand} for ${filterType} filter`,
+              );
+          }
+        }
+        case 'primaryPhoneCallingCode': {
+          switch (filter.operand) {
+            case RecordFilterOperand.Contains:
+              return {
+                [correspondingField.name]: {
+                  primaryPhoneCallingCode: {
+                    ilike: `%${filterValue}%`,
+                  },
+                } as PhonesFilter,
+              };
+            case RecordFilterOperand.DoesNotContain:
+              return {
+                not: {
+                  [correspondingField.name]: {
+                    primaryPhoneCallingCode: {
+                      ilike: `%${filterValue}%`,
+                    },
+                  } as PhonesFilter,
+                },
+              };
+            default:
+              throw new Error(
+                `Unknown operand ${filter.operand} for ${filterType} filter`,
+              );
+          }
+        }
         default:
           throw new Error(
-            `Unknown operand ${filter.operand} for ${filterType} filter`,
+            `Unknown subfield ${subFieldName} for ${filterType} filter`,
           );
       }
     }

--- a/packages/twenty-front/src/modules/settings/data-model/constants/SettingsCompositeFieldTypeConfigs.ts
+++ b/packages/twenty-front/src/modules/settings/data-model/constants/SettingsCompositeFieldTypeConfigs.ts
@@ -102,9 +102,14 @@ export const SETTINGS_COMPOSITE_FIELD_TYPE_CONFIGS = {
     subFields: [
       'primaryPhoneNumber',
       'primaryPhoneCountryCode',
+      'primaryPhoneCallingCode',
       'additionalPhones',
     ],
-    filterableSubFields: ['primaryPhoneNumber', 'primaryPhoneCountryCode'],
+    filterableSubFields: [
+      'primaryPhoneNumber',
+      'primaryPhoneCallingCode',
+      'additionalPhones',
+    ],
     labelBySubField: {
       primaryPhoneNumber: 'Primary Phone Number',
       primaryPhoneCountryCode: 'Primary Phone Country Code',

--- a/packages/twenty-front/src/modules/views/components/ViewBarFilterDropdownFieldSelectMenu.tsx
+++ b/packages/twenty-front/src/modules/views/components/ViewBarFilterDropdownFieldSelectMenu.tsx
@@ -79,7 +79,7 @@ export const ViewBarFilterDropdownFieldSelectMenu = () => {
         selectableItemIdArray={selectableFieldMetadataItemIds}
         selectableListInstanceId={FILTER_FIELD_LIST_ID}
       >
-        <DropdownMenuItemsContainer>
+        <DropdownMenuItemsContainer width="auto">
           {selectableVisibleFieldMetadataItems.map(
             (visibleFieldMetadataItem) => (
               <ViewBarFilterDropdownFieldSelectMenuItem


### PR DESCRIPTION
This PR implements sub-field filtering for the PHONES field type.

What was tricky was to have filtering work correctly on the additionalPhones sub-field, which is an array of objects and is treated as a RawJsonFilter. Now that it works for this sub-field, we can implement the same logic for other similar sub-field like additionalEmails and secondaryLinks.