### PR TITLE
Fix overlapping of table footer and picker

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-footer/components/RecordTableAggregateFooter.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-footer/components/RecordTableAggregateFooter.tsx
@@ -16,7 +16,7 @@ const StyledTd = styled.td`
 const StyledTableRow = styled.tr<{
   hasHorizontalOverflow?: boolean;
 }>`
-  z-index: 6;
+  z-index: 5;
   position: sticky;
   border: none;
 


### PR DESCRIPTION
There are some overlapping on footer with date-picker, but decrease 1 z-index seem to fix this.

![CleanShot 2025-05-10 at 05 30 28@2x](https://github.com/user-attachments/assets/f80aa271-bc7f-45c0-af89-893acb00e859)
