### PR TITLE
Fix 0.53 upgrade commands

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/0-53/0-53-remove-relation-foreign-key-field-metadata.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/0-53/0-53-remove-relation-foreign-key-field-metadata.command.ts
@@ -9,6 +9,8 @@ import {
   ActiveOrSuspendedWorkspacesMigrationCommandRunner,
   RunOnWorkspaceArgs,
 } from 'src/database/commands/command-runners/active-or-suspended-workspaces-migration.command-runner';
+import { FeatureFlagKey } from 'src/engine/core-modules/feature-flag/enums/feature-flag-key.enum';
+import { FeatureFlagService } from 'src/engine/core-modules/feature-flag/services/feature-flag.service';
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.manager';
@@ -21,6 +23,7 @@ export class RemoveRelationForeignKeyFieldMetadataCommand extends ActiveOrSuspen
   constructor(
     @InjectRepository(Workspace, 'core')
     protected readonly workspaceRepository: Repository<Workspace>,
+    protected readonly featureFlagService: FeatureFlagService,
     @InjectRepository(FieldMetadataEntity, 'metadata')
     private readonly fieldMetadataRepository: Repository<FieldMetadataEntity>,
     protected readonly twentyORMGlobalManager: TwentyORMGlobalManager,
@@ -63,6 +66,10 @@ export class RemoveRelationForeignKeyFieldMetadataCommand extends ActiveOrSuspen
         ),
       );
     } else {
+      await this.featureFlagService.enableFeatureFlags(
+        [FeatureFlagKey.IsNewRelationEnabled],
+        workspaceId,
+      );
       await this.fieldMetadataRepository.delete({
         id: In(
           fieldMetadataCollection.map((fieldMetadata) => fieldMetadata.id),

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/0-53/0-53-upgrade-search-vector-on-person-entity.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/0-53/0-53-upgrade-search-vector-on-person-entity.command.ts
@@ -49,7 +49,7 @@ export class UpgradeSearchVectorOnPersonEntityCommand extends ActiveOrSuspendedW
         select: ['id'],
         where: {
           workspaceId,
-          nameSingular: STANDARD_OBJECT_IDS.person,
+          standardId: STANDARD_OBJECT_IDS.person,
         },
       });
 

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/0-53/0-53-upgrade-version-command.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/0-53/0-53-upgrade-version-command.module.ts
@@ -6,6 +6,7 @@ import { CopyTypeormMigrationsCommand } from 'src/database/commands/upgrade-vers
 import { MigrateWorkflowEventListenersToAutomatedTriggersCommand } from 'src/database/commands/upgrade-version-command/0-53/0-53-migrate-workflow-event-listeners-to-automated-triggers.command';
 import { RemoveRelationForeignKeyFieldMetadataCommand } from 'src/database/commands/upgrade-version-command/0-53/0-53-remove-relation-foreign-key-field-metadata.command';
 import { UpgradeSearchVectorOnPersonEntityCommand } from 'src/database/commands/upgrade-version-command/0-53/0-53-upgrade-search-vector-on-person-entity.command';
+import { FeatureFlagModule } from 'src/engine/core-modules/feature-flag/feature-flag.module';
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
@@ -25,6 +26,7 @@ import { WorkspaceMigrationRunnerModule } from 'src/engine/workspace-manager/wor
     SearchVectorModule,
     WorkspaceMigrationRunnerModule,
     WorkspaceMetadataVersionModule,
+    FeatureFlagModule,
   ],
   providers: [
     MigrateWorkflowEventListenersToAutomatedTriggersCommand,

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
@@ -21,6 +21,7 @@ import { UpgradeDateAndDateTimeFieldsSettingsJsonCommand } from 'src/database/co
 import { BackfillWorkflowNextStepIdsCommand } from 'src/database/commands/upgrade-version-command/0-53/0-53-backfill-workflow-next-step-ids.command';
 import { CopyTypeormMigrationsCommand } from 'src/database/commands/upgrade-version-command/0-53/0-53-copy-typeorm-migrations.command';
 import { MigrateWorkflowEventListenersToAutomatedTriggersCommand } from 'src/database/commands/upgrade-version-command/0-53/0-53-migrate-workflow-event-listeners-to-automated-triggers.command';
+import { RemoveRelationForeignKeyFieldMetadataCommand } from 'src/database/commands/upgrade-version-command/0-53/0-53-remove-relation-foreign-key-field-metadata.command';
 import { UpgradeSearchVectorOnPersonEntityCommand } from 'src/database/commands/upgrade-version-command/0-53/0-53-upgrade-search-vector-on-person-entity.command';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
@@ -64,6 +65,7 @@ export class UpgradeCommand extends UpgradeCommandRunner {
     protected readonly backfillWorkflowNextStepIdsCommand: BackfillWorkflowNextStepIdsCommand,
     protected readonly copyTypeormMigrationsCommand: CopyTypeormMigrationsCommand,
     protected readonly upgradeSearchVectorOnPersonEntityCommand: UpgradeSearchVectorOnPersonEntityCommand,
+    protected readonly removeRelationForeignKeyFieldMetadataCommand: RemoveRelationForeignKeyFieldMetadataCommand,
   ) {
     super(
       workspaceRepository,
@@ -111,7 +113,7 @@ export class UpgradeCommand extends UpgradeCommandRunner {
     };
 
     const commands_053: VersionCommands = {
-      beforeSyncMetadata: [],
+      beforeSyncMetadata: [this.removeRelationForeignKeyFieldMetadataCommand],
       afterSyncMetadata: [
         this.migrateWorkflowEventListenersToAutomatedTriggersCommand,
         this.backfillWorkflowNextStepIdsCommand,

--- a/packages/twenty-server/src/database/typeorm/metadata/migrations/1747062634513-addCascadeDeleteOnFieldMetadataRelationTargetObject.ts
+++ b/packages/twenty-server/src/database/typeorm/metadata/migrations/1747062634513-addCascadeDeleteOnFieldMetadataRelationTargetObject.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddCascadeDeleteOnFieldMetadataRelationTargetObject1747062634513
+  implements MigrationInterface
+{
+  name = 'AddCascadeDeleteOnFieldMetadataRelationTargetObject1747062634513';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "metadata"."fieldMetadata" DROP CONSTRAINT "FK_6f6c87ec32cca956d8be321071c"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "metadata"."fieldMetadata" ADD CONSTRAINT "FK_6f6c87ec32cca956d8be321071c" FOREIGN KEY ("relationTargetObjectMetadataId") REFERENCES "metadata"."objectMetadata"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "metadata"."fieldMetadata" DROP CONSTRAINT "FK_6f6c87ec32cca956d8be321071c"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "metadata"."fieldMetadata" ADD CONSTRAINT "FK_6f6c87ec32cca956d8be321071c" FOREIGN KEY ("relationTargetObjectMetadataId") REFERENCES "metadata"."objectMetadata"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+}

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.entity.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.entity.ts
@@ -124,6 +124,7 @@ export class FieldMetadataEntity<
     () => ObjectMetadataEntity,
     (objectMetadata: ObjectMetadataEntity) =>
       objectMetadata.targetRelationFields,
+    { onDelete: 'CASCADE' },
   )
   @JoinColumn({ name: 'relationTargetObjectMetadataId' })
   relationTargetObjectMetadata: Relation<ObjectMetadataEntity>;


### PR DESCRIPTION
In this PR:
- fixes [0-53-upgrade-search-vector-on-person-entity.command.ts](https://github.com/twentyhq/twenty/pull/11987/files#diff-d97fb2aefe44ac5d849fb7e29b8eaa1ca7c0f109d1b43fbdf87723b05dd22f58) small mistake
- adding Cascade DELETE on fieldMetadata.relationTargetObjectMetadataId (like we have on fieldMetadata.objectMetatadaId)
- enabling IsNewRelationEnabled in 0.53 upgrade