### PR TITLE
Remove clickhouse check requiring elevated permissions

### DIFF
--- a/packages/twenty-server/src/database/clickHouse/migrations/run-migrations.ts
+++ b/packages/twenty-server/src/database/clickHouse/migrations/run-migrations.ts
@@ -20,19 +20,6 @@ const clickHouseUrl = () => {
   );
 };
 
-async function ensureDatabaseExists() {
-  const [url, database] = clickHouseUrl().split(/\/(?=[^/]*$)/);
-  const client = createClient({
-    url,
-  });
-
-  await client.command({
-    query: `CREATE DATABASE IF NOT EXISTS "${database}"`,
-  });
-
-  await client.close();
-}
-
 async function ensureMigrationTable(client: ClickHouseClient) {
   await client.command({
     query: `
@@ -70,8 +57,6 @@ async function recordMigration(filename: string, client: ClickHouseClient) {
 async function runMigrations() {
   const dir = path.join(__dirname);
   const files = fs.readdirSync(dir).filter((f) => f.endsWith('.sql'));
-
-  await ensureDatabaseExists();
 
   const client = createClient({
     url: clickHouseUrl(),


### PR DESCRIPTION
This check was un-necessary, it will fail after in anycase. Let's leave it to the user to create the DB