### PR TITLE
docs: update admin panel access property name in upgrade guide

### DIFF
--- a/packages/twenty-website/src/content/developers/self-hosting/upgrade-guide.mdx
+++ b/packages/twenty-website/src/content/developers/self-hosting/upgrade-guide.mdx
@@ -34,7 +34,7 @@ Make sure to keep upgrading your instance sequentially, without skipping any maj
 
 To check if a workspace has been correctly migrated you can review its version in database in `core.workspace` table.
 
-It should always be in the range of your current Twenty's instance `major.minor` version, you can view your instance version in the admin panel (at `/settings/admin-panel`, accessible if your user has `canImpersonate` property set to true in the database) or by running `echo $APP_VERSION` in your `twenty-server` container.
+It should always be in the range of your current Twenty's instance `major.minor` version, you can view your instance version in the admin panel (at `/settings/admin-panel`, accessible if your user has `canAccessFullAdminPanel` property set to true in the database) or by running `echo $APP_VERSION` in your `twenty-server` container.
 
 
 To fix a desynchronized workspace version, you will have to upgrade from the corresponding twenty's version following related upgrade guide sequentially and so on until it reaches desired version.


### PR DESCRIPTION
## Changes
- Updated the property name in the upgrade guide to reflect the permission split in Admin Panel:
  - `canImpersonate`: only provides access to impersonate functionality
  - `canAccessFullAdminPanel`: provides access to all other admin panel features
