### PR TITLE
Make the default view names consistent (#12022)

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/standard-objects-prefill-data/seed-view-with-demo-data.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/standard-objects-prefill-data/seed-view-with-demo-data.ts
@@ -2,7 +2,7 @@ import { ObjectMetadataStandardIdToIdMap } from 'src/engine/metadata-modules/obj
 
 import { WorkspaceEntityManager } from 'src/engine/twenty-orm/entity-manager/workspace-entity-manager';
 import { createWorkspaceViews } from 'src/engine/workspace-manager/standard-objects-prefill-data/create-workspace-views';
-import { seedCompaniesAllView } from 'src/engine/workspace-manager/standard-objects-prefill-data/views/companies-all.view';
+import { companiesAllView } from 'src/engine/workspace-manager/standard-objects-prefill-data/views/companies-all.view';
 import { notesAllView } from 'src/engine/workspace-manager/standard-objects-prefill-data/views/notes-all.view';
 import { opportunitiesAllView } from 'src/engine/workspace-manager/standard-objects-prefill-data/views/opportunities-all.view';
 import { opportunitiesByStageView } from 'src/engine/workspace-manager/standard-objects-prefill-data/views/opportunity-by-stage.view';
@@ -20,7 +20,7 @@ export const seedViewWithDemoData = async (
   objectMetadataStandardIdToIdMap: ObjectMetadataStandardIdToIdMap,
 ) => {
   const viewDefinitions = [
-    seedCompaniesAllView(objectMetadataStandardIdToIdMap),
+    companiesAllView(objectMetadataStandardIdToIdMap),
     peopleAllView(objectMetadataStandardIdToIdMap),
     opportunitiesAllView(objectMetadataStandardIdToIdMap),
     opportunitiesByStageView(objectMetadataStandardIdToIdMap),

--- a/packages/twenty-server/src/engine/workspace-manager/standard-objects-prefill-data/views/companies-all.view.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/standard-objects-prefill-data/views/companies-all.view.ts
@@ -7,11 +7,11 @@ import {
 } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-field-ids';
 import { STANDARD_OBJECT_IDS } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-object-ids';
 
-export const seedCompaniesAllView = (
+export const companiesAllView = (
   objectMetadataStandardIdToIdMap: ObjectMetadataStandardIdToIdMap,
 ) => {
   return {
-    name: 'All',
+    name: 'All Companies',
     objectMetadataId:
       objectMetadataStandardIdToIdMap[STANDARD_OBJECT_IDS.company].id,
     type: 'table',

--- a/packages/twenty-server/src/engine/workspace-manager/standard-objects-prefill-data/views/opportunities-all.view.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/standard-objects-prefill-data/views/opportunities-all.view.ts
@@ -8,7 +8,7 @@ export const opportunitiesAllView = (
   objectMetadataStandardIdToIdMap: ObjectMetadataStandardIdToIdMap,
 ) => {
   return {
-    name: 'All',
+    name: 'All Opportunities',
     objectMetadataId:
       objectMetadataStandardIdToIdMap[STANDARD_OBJECT_IDS.opportunity].id,
     type: 'table',

--- a/packages/twenty-server/src/engine/workspace-manager/standard-objects-prefill-data/views/people-all.view.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/standard-objects-prefill-data/views/people-all.view.ts
@@ -11,7 +11,7 @@ export const peopleAllView = (
   objectMetadataStandardIdToIdMap: ObjectMetadataStandardIdToIdMap,
 ) => {
   return {
-    name: 'All',
+    name: 'All People',
     objectMetadataId:
       objectMetadataStandardIdToIdMap[STANDARD_OBJECT_IDS.person].id,
     type: 'table',


### PR DESCRIPTION
Fixes #12022

## What changed

Now the default names given to views are consistent for People, Companies and Opportunities 

## Before

Some say "All", others say "Some {object name}"

![Image](https://github.com/user-attachments/assets/4233f793-55e1-4566-b9b3-08a6f136dd53)

![Image](https://github.com/user-attachments/assets/29b1af5c-487e-4593-ba40-86163b518ca7)

![Image](https://github.com/user-attachments/assets/81fc1933-0e13-4144-914e-0d99a44db8e4)

![Image](https://github.com/user-attachments/assets/9439fc64-e6e0-4a04-ba28-13c3954a1aa1)

## After

![Image](https://github.com/user-attachments/assets/e88288ac-3a41-4810-bb2a-8e91c937ed6c)

![Image](https://github.com/user-attachments/assets/8fc353e3-5a7c-42ac-88d3-b7014c0fd02c)