### PR TITLE
Fix filtering on grouped table view

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-filter/utils/__tests__/combineFilters.test.ts
+++ b/packages/twenty-front/src/modules/object-record/record-filter/utils/__tests__/combineFilters.test.ts
@@ -1,0 +1,29 @@
+import { RecordGqlOperationFilter } from '@/object-record/graphql/types/RecordGqlOperationFilter';
+import { combineFilters } from '../combineFilters';
+
+describe('combineFilters', () => {
+  it('should return empty object when all filters are empty', () => {
+    const result = combineFilters([{}, {}, {}]);
+    expect(result).toEqual({});
+  });
+
+  it('should return the single non-empty filter directly', () => {
+    const filter: RecordGqlOperationFilter = { field1: { eq: 'Test' } };
+    const result = combineFilters([{}, filter, {}]);
+    expect(result).toEqual(filter);
+  });
+
+  it('should combine multiple non-empty filters with AND logic', () => {
+    const filter1: RecordGqlOperationFilter = { field1: { eq: 'Test' } };
+    const filter2: RecordGqlOperationFilter = { field2: { eq: 'Active' } };
+    const result = combineFilters([filter1, filter2]);
+    expect(result).toEqual({
+      and: [filter1, filter2],
+    });
+  });
+
+  it('should handle an empty array by returning an empty object', () => {
+    const result = combineFilters([]);
+    expect(result).toEqual({});
+  });
+});

--- a/packages/twenty-front/src/modules/object-record/record-filter/utils/combineFilters.ts
+++ b/packages/twenty-front/src/modules/object-record/record-filter/utils/combineFilters.ts
@@ -1,0 +1,21 @@
+import { RecordGqlOperationFilter } from '@/object-record/graphql/types/RecordGqlOperationFilter';
+
+export const combineFilters = (
+  filters: RecordGqlOperationFilter[],
+): RecordGqlOperationFilter => {
+  const nonEmptyFilters = filters.filter(
+    (filter) => Object.keys(filter).length > 0,
+  );
+
+  if (nonEmptyFilters.length === 0) {
+    return {};
+  }
+
+  if (nonEmptyFilters.length === 1) {
+    return nonEmptyFilters[0];
+  }
+
+  return {
+    and: nonEmptyFilters,
+  };
+};

--- a/packages/twenty-front/src/modules/object-record/record-index/hooks/useFindManyRecordIndexTableParams.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/hooks/useFindManyRecordIndexTableParams.ts
@@ -3,6 +3,7 @@ import { turnSortsIntoOrderBy } from '@/object-record/object-sort-dropdown/utils
 import { currentRecordFilterGroupsComponentState } from '@/object-record/record-filter-group/states/currentRecordFilterGroupsComponentState';
 import { useFilterValueDependencies } from '@/object-record/record-filter/hooks/useFilterValueDependencies';
 import { currentRecordFiltersComponentState } from '@/object-record/record-filter/states/currentRecordFiltersComponentState';
+import { combineFilters } from '@/object-record/record-filter/utils/combineFilters';
 import { computeRecordGqlOperationFilter } from '@/object-record/record-filter/utils/computeRecordGqlOperationFilter';
 import { useCurrentRecordGroupDefinition } from '@/object-record/record-group/hooks/useCurrentRecordGroupDefinition';
 import { useRecordGroupFilter } from '@/object-record/record-group/hooks/useRecordGroupFilter';
@@ -47,10 +48,7 @@ export const useFindManyRecordIndexTableParams = (
 
   return {
     objectNameSingular,
-    filter: {
-      ...stateFilter,
-      ...recordGroupFilter,
-    },
+    filter: combineFilters([stateFilter, recordGroupFilter]),
     orderBy,
     // If we have a current record group definition, we only want to fetch 8 records by page
     ...(currentRecordGroupDefinition ? { limit: 8 } : {}),


### PR DESCRIPTION
# Fix filtering on grouped table view

Fixes #11776 
This PR fixes the filtering issue on the grouped by column in the table.
State filters were overwritten by group filters.

- Implemented a new `combineFilters` utility function that properly merges multiple filter objects using AND logic
- Added tests
- Modified `useFindManyRecordIndexTableParams` to use the new utility instead of directly merging filter objects

## Before

https://github.com/user-attachments/assets/45d51535-ecbc-4cfd-b523-37e72aafc723


## After

https://github.com/user-attachments/assets/70416779-9a9c-4972-82ed-73ad98b0234f

