### PR TITLE
Fix cacheData not found after recomputes

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/feature-flag/services/feature-flag.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/feature-flag/services/feature-flag.service.ts
@@ -74,6 +74,7 @@ export class FeatureFlagService {
       await this.workspaceFeatureFlagsMapCacheService.recomputeFeatureFlagsMapCache(
         {
           workspaceId: workspaceId,
+          ignoreLock: true,
         },
       );
     }
@@ -132,7 +133,8 @@ export class FeatureFlagService {
 
     await this.workspaceFeatureFlagsMapCacheService.recomputeFeatureFlagsMapCache(
       {
-        workspaceId: workspaceId,
+        workspaceId,
+        ignoreLock: true,
       },
     );
 

--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.service.ts
@@ -240,6 +240,7 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
 
     await this.workspacePermissionsCacheService.recomputeRolesPermissionsCache({
       workspaceId: objectMetadataInput.workspaceId,
+      ignoreLock: true,
     });
 
     return createdObjectMetadata;
@@ -449,6 +450,7 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
 
     await this.workspacePermissionsCacheService.recomputeRolesPermissionsCache({
       workspaceId,
+      ignoreLock: true,
     });
 
     return objectMetadata;

--- a/packages/twenty-server/src/engine/metadata-modules/object-permission/object-permission.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-permission/object-permission.service.ts
@@ -63,6 +63,7 @@ export class ObjectPermissionService {
         {
           workspaceId,
           roleIds: [input.roleId],
+          ignoreLock: true,
         },
       );
 

--- a/packages/twenty-server/src/engine/metadata-modules/role/role.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/role/role.service.ts
@@ -85,6 +85,7 @@ export class RoleService {
     await this.workspacePermissionsCacheService.recomputeRolesPermissionsCache({
       workspaceId,
       roleIds: [role.id],
+      ignoreLock: true,
     });
 
     return role;
@@ -130,6 +131,7 @@ export class RoleService {
     await this.workspacePermissionsCacheService.recomputeRolesPermissionsCache({
       workspaceId,
       roleIds: [input.id],
+      ignoreLock: true,
     });
 
     return { ...existingRole, ...updatedRole };
@@ -196,6 +198,7 @@ export class RoleService {
 
     await this.workspacePermissionsCacheService.recomputeRolesPermissionsCache({
       workspaceId,
+      ignoreLock: true,
     });
 
     return roleId;

--- a/packages/twenty-server/src/engine/metadata-modules/user-role/user-role.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/user-role/user-role.service.ts
@@ -62,6 +62,7 @@ export class UserRoleService {
     await this.workspacePermissionsCacheService.recomputeUserWorkspaceRoleMapCache(
       {
         workspaceId,
+        ignoreLock: true,
       },
     );
   }

--- a/packages/twenty-server/src/engine/metadata-modules/workspace-feature-flags-map-cache/workspace-feature-flags-map-cache.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/workspace-feature-flags-map-cache/workspace-feature-flags-map-cache.service.ts
@@ -49,6 +49,7 @@ export class WorkspaceFeatureFlagsMapCacheService {
       recomputeCache: (params) => this.recomputeFeatureFlagsMapCache(params),
       cachedEntityName: FEATURE_FLAG_MAP,
       exceptionCode: TwentyORMExceptionCode.FEATURE_FLAG_MAP_VERSION_NOT_FOUND,
+      logger: this.logger,
     });
   }
 
@@ -64,8 +65,18 @@ export class WorkspaceFeatureFlagsMapCacheService {
         workspaceId,
       );
 
-    if (!ignoreLock && isAlreadyCaching) {
-      return;
+    if (isAlreadyCaching) {
+      if (ignoreLock) {
+        this.logger.warn(
+          `Feature flags map cache is already being cached (workspace ${workspaceId}), respecting lock and returning no data`,
+        );
+
+        return;
+      } else {
+        this.logger.warn(
+          `Feature flags map cache is already being cached (workspace ${workspaceId}), ignoring lock`,
+        );
+      }
     }
 
     await this.workspaceCacheStorageService.addFeatureFlagMapOngoingCachingLock(

--- a/packages/twenty-server/src/engine/metadata-modules/workspace-permissions-cache/workspace-permissions-cache-storage.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/workspace-permissions-cache/workspace-permissions-cache-storage.service.ts
@@ -89,10 +89,8 @@ export class WorkspacePermissionsCacheStorageService {
   async setUserWorkspaceRoleMap(
     workspaceId: string,
     userWorkspaceRoleMap: UserWorkspaceRoleMap,
-  ): Promise<{
-    newUserWorkspaceRoleMapVersion: string;
-  }> {
-    const [, newUserWorkspaceRoleMapVersion] = await Promise.all([
+  ): Promise<void> {
+    await Promise.all([
       this.cacheStorageService.set<UserWorkspaceRoleMap>(
         `${WorkspaceCacheKeys.MetadataPermissionsUserWorkspaceRoleMap}:${workspaceId}`,
         userWorkspaceRoleMap,
@@ -100,8 +98,6 @@ export class WorkspacePermissionsCacheStorageService {
       ),
       this.setUserWorkspaceRoleMapVersion(workspaceId),
     ]);
-
-    return { newUserWorkspaceRoleMapVersion };
   }
 
   async setUserWorkspaceRoleMapVersion(workspaceId: string) {
@@ -143,6 +139,12 @@ export class WorkspacePermissionsCacheStorageService {
   removeUserWorkspaceRoleMapOngoingCachingLock(workspaceId: string) {
     return this.cacheStorageService.del(
       `${WorkspaceCacheKeys.MetadataPermissionsUserWorkspaceRoleMapOngoingCachingLock}:${workspaceId}`,
+    );
+  }
+
+  removeUserWorkspaceRoleMap(workspaceId: string) {
+    return this.cacheStorageService.del(
+      `${WorkspaceCacheKeys.MetadataPermissionsUserWorkspaceRoleMap}:${workspaceId}`,
     );
   }
 

--- a/packages/twenty-server/src/engine/metadata-modules/workspace-permissions-cache/workspace-permissions-cache.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/workspace-permissions-cache/workspace-permissions-cache.service.ts
@@ -52,13 +52,21 @@ export class WorkspacePermissionsCacheService {
     ignoreLock?: boolean;
     roleIds?: string[];
   }): Promise<void> {
-    if (!ignoreLock) {
-      const isAlreadyCaching =
-        await this.workspacePermissionsCacheStorageService.getRolesPermissionsOngoingCachingLock(
-          workspaceId,
+    const isAlreadyCaching =
+      await this.workspacePermissionsCacheStorageService.getRolesPermissionsOngoingCachingLock(
+        workspaceId,
+      );
+
+    if (isAlreadyCaching) {
+      if (ignoreLock) {
+        this.logger.warn(
+          `RolesPermissions data is already being cached (workspace ${workspaceId}), ignoring lock`,
+        );
+      } else {
+        this.logger.warn(
+          `RolesPermissions data is already being cached (workspace ${workspaceId}), respecting lock and returning no data`,
         );
 
-      if (isAlreadyCaching) {
         return;
       }
     }
@@ -113,13 +121,21 @@ export class WorkspacePermissionsCacheService {
     ignoreLock?: boolean;
   }): Promise<void> {
     try {
-      if (!ignoreLock) {
-        const isAlreadyCaching =
-          await this.workspacePermissionsCacheStorageService.getUserWorkspaceRoleMapOngoingCachingLock(
-            workspaceId,
+      const isAlreadyCaching =
+        await this.workspacePermissionsCacheStorageService.getUserWorkspaceRoleMapOngoingCachingLock(
+          workspaceId,
+        );
+
+      if (isAlreadyCaching) {
+        if (ignoreLock) {
+          this.logger.warn(
+            `UserWorkspaceRoleMap data is already being cached (workspace ${workspaceId}), ignoring lock`,
+          );
+        } else {
+          this.logger.warn(
+            `UserWorkspaceRoleMap data is already being cached (workspace ${workspaceId}), respecting lock and returning no data`,
           );
 
-        if (isAlreadyCaching) {
           return;
         }
       }
@@ -169,6 +185,7 @@ export class WorkspacePermissionsCacheService {
       recomputeCache: (params) => this.recomputeRolesPermissionsCache(params),
       cachedEntityName: ROLES_PERMISSIONS,
       exceptionCode: TwentyORMExceptionCode.ROLES_PERMISSIONS_VERSION_NOT_FOUND,
+      logger: this.logger,
     });
   }
 
@@ -188,6 +205,7 @@ export class WorkspacePermissionsCacheService {
       cachedEntityName: USER_WORKSPACE_ROLE_MAP,
       exceptionCode:
         TwentyORMExceptionCode.USER_WORKSPACE_ROLE_MAP_VERSION_NOT_FOUND,
+      logger: this.logger,
     });
   }
 

--- a/packages/twenty-server/src/engine/twenty-orm/factories/workspace-datasource.factory.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/factories/workspace-datasource.factory.ts
@@ -233,6 +233,7 @@ export class WorkspaceDatasourceFactory {
         }),
       cachedEntityName: ROLES_PERMISSIONS,
       exceptionCode: TwentyORMExceptionCode.ROLES_PERMISSIONS_VERSION_NOT_FOUND,
+      logger: this.logger,
     });
   }
 

--- a/packages/twenty-server/src/engine/twenty-orm/factories/workspace-datasource.factory.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/factories/workspace-datasource.factory.ts
@@ -230,7 +230,6 @@ export class WorkspaceDatasourceFactory {
       recomputeCache: () =>
         this.workspacePermissionsCacheService.recomputeRolesPermissionsCache({
           workspaceId,
-          ignoreLock: true,
         }),
       cachedEntityName: ROLES_PERMISSIONS,
       exceptionCode: TwentyORMExceptionCode.ROLES_PERMISSIONS_VERSION_NOT_FOUND,


### PR DESCRIPTION
Closes https://github.com/twentyhq/core-team-issues/issues/861

sentries: [User workspace role map not found after recompute](https://twenty-v7.sentry.io/issues/6575092700/events/f9825338a30b470eb2345fe78c1e3479/?project=4507072499810304&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D%20not%20found%20after%20recompute&referrer=next-event&stream_index=0) (64 events in 90d), [Feature flag map not found after recompute](https://twenty-v7.sentry.io/issues/6547696076/?project=4507072499810304&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D%20not%20found%20after%20recompute&referrer=issue-stream&stream_index=1) (23 events in 90d)

We have a structural issue with cached data and our locking mechanism: if a data is missing in cache and queried at the same time by two different entities, the first one will recompute the data and indicate a lock during the operation, while the second one will seek to recompute the data too but be stopped because of the ongoing lock, and be left with no data to use, condemned to throw an error.  In this PR I considered that it was more important to avoid that error and chose to ignoreLock instead when the data is being queried (through getFromCacheWithRecompute), but this is maybe questionnable. 
An important note is that I can't figure out how users that regularly use twenty (as it has been the case since this error occured on our internal workspace) can encounter that error as once computed, **the key should always be present in the workspace**: the corresponding value it is always updated, never deleted (until this PR) and recreated. I was not able understand how this happened

For our data cached without a version to refer to in the database, I also chose to ignore the lock when the recompute is triggered by a data change (eg feature flag enabling or assigning user to a role or adding an objectPermission on a role, etc.), as we never want to imped the recompute in that case to avoid potential stale data. 

