### PR TITLE
fix calendar events and messages post hooks

### DIFF
--- a/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/calendar-event-find-many.post-query.hook.ts
+++ b/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/calendar-event-find-many.post-query.hook.ts
@@ -5,7 +5,7 @@ import { WorkspacePostQueryHookInstance } from 'src/engine/api/graphql/workspace
 import { WorkspaceQueryHook } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/decorators/workspace-query-hook.decorator';
 import { WorkspaceQueryHookType } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/types/workspace-query-hook.type';
 import { AuthContext } from 'src/engine/core-modules/auth/types/auth-context.type';
-import { UserInputError } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
+import { ForbiddenError } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
 import { ApplyCalendarEventsVisibilityRestrictionsService } from 'src/modules/calendar/common/query-hooks/calendar-event/services/apply-calendar-events-visibility-restrictions.service';
 import { CalendarEventWorkspaceEntity } from 'src/modules/calendar/common/standard-objects/calendar-event.workspace-entity';
 
@@ -28,7 +28,7 @@ export class CalendarEventFindManyPostQueryHook
     const { user, apiKey } = authContext;
 
     if (!isDefined(user) && !isDefined(apiKey)) {
-      throw new UserInputError('User is required');
+      throw new ForbiddenError('User is required');
     }
 
     await this.applyCalendarEventsVisibilityRestrictionsService.applyCalendarEventsVisibilityRestrictions(

--- a/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/calendar-event-find-many.post-query.hook.ts
+++ b/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/calendar-event-find-many.post-query.hook.ts
@@ -25,14 +25,14 @@ export class CalendarEventFindManyPostQueryHook
     _objectName: string,
     payload: CalendarEventWorkspaceEntity[],
   ): Promise<void> {
-    const user = authContext.user;
+    const { user, apiKey } = authContext;
 
-    if (!isDefined(user)) {
+    if (!isDefined(user) && !isDefined(apiKey)) {
       throw new UserInputError('User is required');
     }
 
     await this.applyCalendarEventsVisibilityRestrictionsService.applyCalendarEventsVisibilityRestrictions(
-      user.id,
+      isDefined(user) ? user.id : undefined,
       payload,
     );
   }

--- a/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/calendar-event-find-many.post-query.hook.ts
+++ b/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/calendar-event-find-many.post-query.hook.ts
@@ -32,8 +32,8 @@ export class CalendarEventFindManyPostQueryHook
     }
 
     await this.applyCalendarEventsVisibilityRestrictionsService.applyCalendarEventsVisibilityRestrictions(
-      isDefined(user) ? user.id : undefined,
       payload,
+      user?.id,
     );
   }
 }

--- a/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/calendar-event-find-many.post-query.hook.ts
+++ b/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/calendar-event-find-many.post-query.hook.ts
@@ -1,3 +1,5 @@
+import { isDefined } from 'twenty-shared/utils';
+
 import { WorkspacePostQueryHookInstance } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/interfaces/workspace-query-hook.interface';
 
 import { WorkspaceQueryHook } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/decorators/workspace-query-hook.decorator';
@@ -23,12 +25,14 @@ export class CalendarEventFindManyPostQueryHook
     _objectName: string,
     payload: CalendarEventWorkspaceEntity[],
   ): Promise<void> {
-    if (!authContext.workspaceMemberId) {
-      throw new UserInputError('Workspace member id is required');
+    const user = authContext.user;
+
+    if (!isDefined(user)) {
+      throw new UserInputError('User is required');
     }
 
     await this.applyCalendarEventsVisibilityRestrictionsService.applyCalendarEventsVisibilityRestrictions(
-      authContext.workspaceMemberId,
+      user.id,
       payload,
     );
   }

--- a/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/calendar-event-find-one.post-query.hook.ts
+++ b/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/calendar-event-find-one.post-query.hook.ts
@@ -32,8 +32,8 @@ export class CalendarEventFindOnePostQueryHook
     }
 
     await this.applyCalendarEventsVisibilityRestrictionsService.applyCalendarEventsVisibilityRestrictions(
-      isDefined(user) ? user.id : undefined,
       payload,
+      user?.id,
     );
   }
 }

--- a/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/calendar-event-find-one.post-query.hook.ts
+++ b/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/calendar-event-find-one.post-query.hook.ts
@@ -1,3 +1,5 @@
+import { isDefined } from 'twenty-shared/utils';
+
 import { WorkspacePostQueryHookInstance } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/interfaces/workspace-query-hook.interface';
 
 import { WorkspaceQueryHook } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/decorators/workspace-query-hook.decorator';
@@ -23,12 +25,14 @@ export class CalendarEventFindOnePostQueryHook
     _objectName: string,
     payload: CalendarEventWorkspaceEntity[],
   ): Promise<void> {
-    if (!authContext.workspaceMemberId) {
-      throw new UserInputError('Workspace member id is required');
+    const user = authContext.user;
+
+    if (!isDefined(user)) {
+      throw new UserInputError('User is required');
     }
 
     await this.applyCalendarEventsVisibilityRestrictionsService.applyCalendarEventsVisibilityRestrictions(
-      authContext.workspaceMemberId,
+      user.id,
       payload,
     );
   }

--- a/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/calendar-event-find-one.post-query.hook.ts
+++ b/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/calendar-event-find-one.post-query.hook.ts
@@ -25,14 +25,14 @@ export class CalendarEventFindOnePostQueryHook
     _objectName: string,
     payload: CalendarEventWorkspaceEntity[],
   ): Promise<void> {
-    const user = authContext.user;
+    const { user, apiKey } = authContext;
 
-    if (!isDefined(user)) {
+    if (!isDefined(user) && !isDefined(apiKey)) {
       throw new UserInputError('User is required');
     }
 
     await this.applyCalendarEventsVisibilityRestrictionsService.applyCalendarEventsVisibilityRestrictions(
-      user.id,
+      isDefined(user) ? user.id : undefined,
       payload,
     );
   }

--- a/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/calendar-event-find-one.post-query.hook.ts
+++ b/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/calendar-event-find-one.post-query.hook.ts
@@ -5,7 +5,7 @@ import { WorkspacePostQueryHookInstance } from 'src/engine/api/graphql/workspace
 import { WorkspaceQueryHook } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/decorators/workspace-query-hook.decorator';
 import { WorkspaceQueryHookType } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/types/workspace-query-hook.type';
 import { AuthContext } from 'src/engine/core-modules/auth/types/auth-context.type';
-import { UserInputError } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
+import { ForbiddenError } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
 import { ApplyCalendarEventsVisibilityRestrictionsService } from 'src/modules/calendar/common/query-hooks/calendar-event/services/apply-calendar-events-visibility-restrictions.service';
 import { CalendarEventWorkspaceEntity } from 'src/modules/calendar/common/standard-objects/calendar-event.workspace-entity';
 
@@ -28,7 +28,7 @@ export class CalendarEventFindOnePostQueryHook
     const { user, apiKey } = authContext;
 
     if (!isDefined(user) && !isDefined(apiKey)) {
-      throw new UserInputError('User is required');
+      throw new ForbiddenError('User is required');
     }
 
     await this.applyCalendarEventsVisibilityRestrictionsService.applyCalendarEventsVisibilityRestrictions(

--- a/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/services/apply-calendar-events-visibility-restrictions.service.spec.ts
+++ b/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/services/apply-calendar-events-visibility-restrictions.service.spec.ts
@@ -48,6 +48,10 @@ describe('ApplyCalendarEventsVisibilityRestrictionsService', () => {
     find: jest.fn(),
   };
 
+  const mockWorkspaceMemberRepository = {
+    findOneByOrFail: jest.fn(),
+  };
+
   const mockTwentyORMManager = {
     getRepository: jest.fn().mockImplementation((name) => {
       if (name === 'calendarChannelEventAssociation') {
@@ -55,6 +59,9 @@ describe('ApplyCalendarEventsVisibilityRestrictionsService', () => {
       }
       if (name === 'connectedAccount') {
         return mockConnectedAccountRepository;
+      }
+      if (name === 'workspaceMember') {
+        return mockWorkspaceMemberRepository;
       }
     }),
   };
@@ -83,6 +90,10 @@ describe('ApplyCalendarEventsVisibilityRestrictionsService', () => {
       createMockCalendarEvent('1', 'Test Event', 'Test Description'),
     ];
 
+    mockWorkspaceMemberRepository.findOneByOrFail.mockResolvedValue({
+      id: 'workspace-member-id',
+    });
+
     mockCalendarEventAssociationRepository.find.mockResolvedValue([
       {
         calendarEventId: '1',
@@ -94,7 +105,7 @@ describe('ApplyCalendarEventsVisibilityRestrictionsService', () => {
     ]);
 
     const result = await service.applyCalendarEventsVisibilityRestrictions(
-      'workspace-member-id',
+      'user-id',
       calendarEvents,
     );
 
@@ -124,10 +135,14 @@ describe('ApplyCalendarEventsVisibilityRestrictionsService', () => {
       },
     ]);
 
+    mockWorkspaceMemberRepository.findOneByOrFail.mockResolvedValue({
+      id: 'workspace-member-id',
+    });
+
     mockConnectedAccountRepository.find.mockResolvedValue([]);
 
     const result = await service.applyCalendarEventsVisibilityRestrictions(
-      'workspace-member-id',
+      'user-id',
       calendarEvents,
     );
 
@@ -155,10 +170,14 @@ describe('ApplyCalendarEventsVisibilityRestrictionsService', () => {
       },
     ]);
 
+    mockWorkspaceMemberRepository.findOneByOrFail.mockResolvedValue({
+      id: 'workspace-member-account-owner-id',
+    });
+
     mockConnectedAccountRepository.find.mockResolvedValue([{ id: '1' }]);
 
     const result = await service.applyCalendarEventsVisibilityRestrictions(
-      'workspace-member-id',
+      'user-id',
       calendarEvents,
     );
 
@@ -186,10 +205,14 @@ describe('ApplyCalendarEventsVisibilityRestrictionsService', () => {
       },
     ]);
 
+    mockWorkspaceMemberRepository.findOneByOrFail.mockResolvedValue({
+      id: 'workspace-member-not-account-owner-id',
+    });
+
     mockConnectedAccountRepository.find.mockResolvedValue([]);
 
     const result = await service.applyCalendarEventsVisibilityRestrictions(
-      'workspace-member-id',
+      'user-id',
       calendarEvents,
     );
 
@@ -202,6 +225,10 @@ describe('ApplyCalendarEventsVisibilityRestrictionsService', () => {
       createMockCalendarEvent('2', 'Event 2', 'Description 2'),
       createMockCalendarEvent('3', 'Event 3', 'Description 3'),
     ];
+
+    mockWorkspaceMemberRepository.findOneByOrFail.mockResolvedValue({
+      id: 'workspace-member-id',
+    });
 
     mockCalendarEventAssociationRepository.find.mockResolvedValue([
       {
@@ -232,7 +259,7 @@ describe('ApplyCalendarEventsVisibilityRestrictionsService', () => {
       .mockResolvedValueOnce([{ id: '1' }]); // request for calendar event 2
 
     const result = await service.applyCalendarEventsVisibilityRestrictions(
-      'workspace-member-id',
+      'user-id',
       calendarEvents,
     );
 

--- a/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/services/apply-calendar-events-visibility-restrictions.service.spec.ts
+++ b/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/services/apply-calendar-events-visibility-restrictions.service.spec.ts
@@ -105,8 +105,8 @@ describe('ApplyCalendarEventsVisibilityRestrictionsService', () => {
     ]);
 
     const result = await service.applyCalendarEventsVisibilityRestrictions(
-      'user-id',
       calendarEvents,
+      'user-id',
     );
 
     expect(result).toEqual(calendarEvents);
@@ -142,8 +142,8 @@ describe('ApplyCalendarEventsVisibilityRestrictionsService', () => {
     mockConnectedAccountRepository.find.mockResolvedValue([]);
 
     const result = await service.applyCalendarEventsVisibilityRestrictions(
-      'user-id',
       calendarEvents,
+      'user-id',
     );
 
     expect(result).toEqual([
@@ -177,8 +177,8 @@ describe('ApplyCalendarEventsVisibilityRestrictionsService', () => {
     mockConnectedAccountRepository.find.mockResolvedValue([{ id: '1' }]);
 
     const result = await service.applyCalendarEventsVisibilityRestrictions(
-      'user-id',
       calendarEvents,
+      'user-id',
     );
 
     expect(result).toEqual(calendarEvents);
@@ -212,8 +212,8 @@ describe('ApplyCalendarEventsVisibilityRestrictionsService', () => {
     mockConnectedAccountRepository.find.mockResolvedValue([]);
 
     const result = await service.applyCalendarEventsVisibilityRestrictions(
-      'user-id',
       calendarEvents,
+      'user-id',
     );
 
     expect(result).toEqual([]);
@@ -259,8 +259,8 @@ describe('ApplyCalendarEventsVisibilityRestrictionsService', () => {
       .mockResolvedValueOnce([{ id: '1' }]); // request for calendar event 2
 
     const result = await service.applyCalendarEventsVisibilityRestrictions(
-      'user-id',
       calendarEvents,
+      'user-id',
     );
 
     expect(result).toEqual([
@@ -314,8 +314,8 @@ describe('ApplyCalendarEventsVisibilityRestrictionsService', () => {
       .mockResolvedValueOnce([{ id: '1' }]); // request for calendar event 2
 
     const result = await service.applyCalendarEventsVisibilityRestrictions(
-      undefined,
       calendarEvents,
+      undefined,
     );
 
     expect(result).toEqual([

--- a/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/services/apply-calendar-events-visibility-restrictions.service.ts
+++ b/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/services/apply-calendar-events-visibility-restrictions.service.ts
@@ -17,8 +17,8 @@ export class ApplyCalendarEventsVisibilityRestrictionsService {
   constructor(private readonly twentyORMManager: TwentyORMManager) {}
 
   public async applyCalendarEventsVisibilityRestrictions(
-    userId: string | undefined, // undefined when request is made with api key
     calendarEvents: CalendarEventWorkspaceEntity[],
+    userId?: string, // undefined when request is made with api key
   ) {
     const calendarChannelEventAssociationRepository =
       await this.twentyORMManager.getRepository<CalendarChannelEventAssociationWorkspaceEntity>(

--- a/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/services/apply-calendar-events-visibility-restrictions.service.ts
+++ b/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/services/apply-calendar-events-visibility-restrictions.service.ts
@@ -9,13 +9,14 @@ import { CalendarChannelEventAssociationWorkspaceEntity } from 'src/modules/cale
 import { CalendarChannelVisibility } from 'src/modules/calendar/common/standard-objects/calendar-channel.workspace-entity';
 import { CalendarEventWorkspaceEntity } from 'src/modules/calendar/common/standard-objects/calendar-event.workspace-entity';
 import { ConnectedAccountWorkspaceEntity } from 'src/modules/connected-account/standard-objects/connected-account.workspace-entity';
+import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
 
 @Injectable()
 export class ApplyCalendarEventsVisibilityRestrictionsService {
   constructor(private readonly twentyORMManager: TwentyORMManager) {}
 
   public async applyCalendarEventsVisibilityRestrictions(
-    workspaceMemberId: string,
+    userId: string,
     calendarEvents: CalendarEventWorkspaceEntity[],
   ) {
     const calendarChannelEventAssociationRepository =
@@ -59,13 +60,22 @@ export class ApplyCalendarEventsVisibilityRestrictionsService {
         continue;
       }
 
+      const workspaceMemberRepository =
+        await this.twentyORMManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+          'workspaceMember',
+        );
+
+      const workspaceMember = await workspaceMemberRepository.findOneByOrFail({
+        userId: userId,
+      });
+
       const connectedAccounts = await connectedAccountRepository.find({
         select: ['id'],
         where: {
           calendarChannels: {
             id: In(calendarChannels.map((channel) => channel.id)),
           },
-          accountOwnerId: workspaceMemberId,
+          accountOwnerId: workspaceMember.id,
         },
       });
 

--- a/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/services/apply-calendar-events-visibility-restrictions.service.ts
+++ b/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/services/apply-calendar-events-visibility-restrictions.service.ts
@@ -37,6 +37,11 @@ export class ApplyCalendarEventsVisibilityRestrictionsService {
         'connectedAccount',
       );
 
+    const workspaceMemberRepository =
+      await this.twentyORMManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+        'workspaceMember',
+      );
+
     for (let i = calendarEvents.length - 1; i >= 0; i--) {
       const calendarChannelCalendarEventAssociations =
         calendarChannelCalendarEventsAssociations.filter(
@@ -59,11 +64,6 @@ export class ApplyCalendarEventsVisibilityRestrictionsService {
       ) {
         continue;
       }
-
-      const workspaceMemberRepository =
-        await this.twentyORMManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-          'workspaceMember',
-        );
 
       const workspaceMember = await workspaceMemberRepository.findOneByOrFail({
         userId: userId,

--- a/packages/twenty-server/src/modules/messaging/common/query-hooks/message/apply-messages-visibility-restrictions.service.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/common/query-hooks/message/apply-messages-visibility-restrictions.service.spec.ts
@@ -90,8 +90,8 @@ describe('ApplyMessagesVisibilityRestrictionsService', () => {
     ]);
 
     const result = await service.applyMessagesVisibilityRestrictions(
-      'user-id',
       messages,
+      'user-id',
     );
 
     expect(result).toEqual(messages);
@@ -126,8 +126,8 @@ describe('ApplyMessagesVisibilityRestrictionsService', () => {
     });
 
     const result = await service.applyMessagesVisibilityRestrictions(
-      'user-id',
       messages,
+      'user-id',
     );
 
     expect(result).toEqual([
@@ -160,8 +160,8 @@ describe('ApplyMessagesVisibilityRestrictionsService', () => {
     });
 
     const result = await service.applyMessagesVisibilityRestrictions(
-      'user-id',
       messages,
+      'user-id',
     );
 
     expect(result).toEqual([
@@ -195,8 +195,8 @@ describe('ApplyMessagesVisibilityRestrictionsService', () => {
     mockConnectedAccountRepository.find.mockResolvedValue([{ id: '1' }]);
 
     const result = await service.applyMessagesVisibilityRestrictions(
-      'user-id',
       messages,
+      'user-id',
     );
 
     expect(result).toEqual(messages);
@@ -229,8 +229,8 @@ describe('ApplyMessagesVisibilityRestrictionsService', () => {
     mockConnectedAccountRepository.find.mockResolvedValue([]);
 
     const result = await service.applyMessagesVisibilityRestrictions(
-      'user-id',
       messages,
+      'user-id',
     );
 
     expect(result).toEqual([]);
@@ -276,8 +276,8 @@ describe('ApplyMessagesVisibilityRestrictionsService', () => {
       .mockResolvedValueOnce([]); // request for message 2
 
     const result = await service.applyMessagesVisibilityRestrictions(
-      'user-id',
       messages,
+      'user-id',
     );
 
     expect(result).toEqual([
@@ -334,8 +334,8 @@ describe('ApplyMessagesVisibilityRestrictionsService', () => {
       .mockResolvedValueOnce([]); // request for message 2
 
     const result = await service.applyMessagesVisibilityRestrictions(
-      undefined,
       messages,
+      undefined,
     );
 
     expect(result).toEqual([

--- a/packages/twenty-server/src/modules/messaging/common/query-hooks/message/apply-messages-visibility-restrictions.service.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/common/query-hooks/message/apply-messages-visibility-restrictions.service.spec.ts
@@ -38,6 +38,10 @@ describe('ApplyMessagesVisibilityRestrictionsService', () => {
     find: jest.fn(),
   };
 
+  const mockWorkspaceMemberRepository = {
+    findOneByOrFail: jest.fn(),
+  };
+
   const mockTwentyORMManager = {
     getRepository: jest.fn().mockImplementation((name) => {
       if (name === 'messageChannelMessageAssociation') {
@@ -45,6 +49,9 @@ describe('ApplyMessagesVisibilityRestrictionsService', () => {
       }
       if (name === 'connectedAccount') {
         return mockConnectedAccountRepository;
+      }
+      if (name === 'workspaceMember') {
+        return mockWorkspaceMemberRepository;
       }
     }),
   };
@@ -83,7 +90,7 @@ describe('ApplyMessagesVisibilityRestrictionsService', () => {
     ]);
 
     const result = await service.applyMessagesVisibilityRestrictions(
-      'workspace-member-id',
+      'user-id',
       messages,
     );
 
@@ -114,8 +121,12 @@ describe('ApplyMessagesVisibilityRestrictionsService', () => {
 
     mockConnectedAccountRepository.find.mockResolvedValue([]);
 
+    mockWorkspaceMemberRepository.findOneByOrFail.mockResolvedValue({
+      id: 'workspace-member-id',
+    });
+
     const result = await service.applyMessagesVisibilityRestrictions(
-      'workspace-member-id',
+      'user-id',
       messages,
     );
 
@@ -144,8 +155,12 @@ describe('ApplyMessagesVisibilityRestrictionsService', () => {
 
     mockConnectedAccountRepository.find.mockResolvedValue([]);
 
+    mockWorkspaceMemberRepository.findOneByOrFail.mockResolvedValue({
+      id: 'workspace-member-id',
+    });
+
     const result = await service.applyMessagesVisibilityRestrictions(
-      'workspace-member-id',
+      'user-id',
       messages,
     );
 
@@ -173,10 +188,14 @@ describe('ApplyMessagesVisibilityRestrictionsService', () => {
       },
     ]);
 
+    mockWorkspaceMemberRepository.findOneByOrFail.mockResolvedValue({
+      id: 'workspace-member-account-owner-id',
+    });
+
     mockConnectedAccountRepository.find.mockResolvedValue([{ id: '1' }]);
 
     const result = await service.applyMessagesVisibilityRestrictions(
-      'workspace-member-id',
+      'user-id',
       messages,
     );
 
@@ -202,6 +221,10 @@ describe('ApplyMessagesVisibilityRestrictionsService', () => {
         },
       },
     ]);
+
+    mockWorkspaceMemberRepository.findOneByOrFail.mockResolvedValue({
+      id: 'workspace-member-not-account-owner-id',
+    });
 
     mockConnectedAccountRepository.find.mockResolvedValue([]);
 
@@ -243,6 +266,10 @@ describe('ApplyMessagesVisibilityRestrictionsService', () => {
         },
       },
     ]);
+
+    mockWorkspaceMemberRepository.findOneByOrFail.mockResolvedValue({
+      id: 'workspace-member-id',
+    });
 
     mockConnectedAccountRepository.find
       .mockResolvedValueOnce([]) // request for message 3

--- a/packages/twenty-server/src/modules/messaging/common/query-hooks/message/apply-messages-visibility-restrictions.service.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/common/query-hooks/message/apply-messages-visibility-restrictions.service.spec.ts
@@ -293,4 +293,62 @@ describe('ApplyMessagesVisibilityRestrictionsService', () => {
       },
     ]);
   });
+
+  it('should return all messages with the right visibility when userId is undefined (api key request)', async () => {
+    const messages = [
+      createMockMessage('1', 'Subject 1', 'Message 1'),
+      createMockMessage('2', 'Subject 2', 'Message 2'),
+      createMockMessage('3', 'Subject 3', 'Message 3'),
+    ];
+
+    mockMessageChannelMessageAssociationRepository.find.mockResolvedValue([
+      {
+        messageId: '1',
+        messageChannel: {
+          id: '1',
+          visibility: MessageChannelVisibility.SHARE_EVERYTHING,
+        },
+      },
+      {
+        messageId: '2',
+        messageChannel: {
+          id: '2',
+          visibility: MessageChannelVisibility.SUBJECT,
+        },
+      },
+      {
+        messageId: '3',
+        messageChannel: {
+          id: '3',
+          visibility: MessageChannelVisibility.METADATA,
+        },
+      },
+    ]);
+
+    mockWorkspaceMemberRepository.findOneByOrFail.mockResolvedValue({
+      id: 'workspace-member-id',
+    });
+
+    mockConnectedAccountRepository.find
+      .mockResolvedValueOnce([]) // request for message 3
+      .mockResolvedValueOnce([]); // request for message 2
+
+    const result = await service.applyMessagesVisibilityRestrictions(
+      undefined,
+      messages,
+    );
+
+    expect(result).toEqual([
+      messages[0],
+      {
+        ...messages[1],
+        text: FIELD_RESTRICTED_ADDITIONAL_PERMISSIONS_REQUIRED,
+      },
+      {
+        ...messages[2],
+        subject: FIELD_RESTRICTED_ADDITIONAL_PERMISSIONS_REQUIRED,
+        text: FIELD_RESTRICTED_ADDITIONAL_PERMISSIONS_REQUIRED,
+      },
+    ]);
+  });
 });

--- a/packages/twenty-server/src/modules/messaging/common/query-hooks/message/apply-messages-visibility-restrictions.service.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/common/query-hooks/message/apply-messages-visibility-restrictions.service.spec.ts
@@ -229,7 +229,7 @@ describe('ApplyMessagesVisibilityRestrictionsService', () => {
     mockConnectedAccountRepository.find.mockResolvedValue([]);
 
     const result = await service.applyMessagesVisibilityRestrictions(
-      'workspace-member-id',
+      'user-id',
       messages,
     );
 
@@ -276,7 +276,7 @@ describe('ApplyMessagesVisibilityRestrictionsService', () => {
       .mockResolvedValueOnce([]); // request for message 2
 
     const result = await service.applyMessagesVisibilityRestrictions(
-      'workspace-member-id',
+      'user-id',
       messages,
     );
 

--- a/packages/twenty-server/src/modules/messaging/common/query-hooks/message/apply-messages-visibility-restrictions.service.ts
+++ b/packages/twenty-server/src/modules/messaging/common/query-hooks/message/apply-messages-visibility-restrictions.service.ts
@@ -10,13 +10,14 @@ import { ConnectedAccountWorkspaceEntity } from 'src/modules/connected-account/s
 import { MessageChannelMessageAssociationWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message-channel-message-association.workspace-entity';
 import { MessageChannelVisibility } from 'src/modules/messaging/common/standard-objects/message-channel.workspace-entity';
 import { MessageWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message.workspace-entity';
+import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
 
 @Injectable()
 export class ApplyMessagesVisibilityRestrictionsService {
   constructor(private readonly twentyORMManager: TwentyORMManager) {}
 
   public async applyMessagesVisibilityRestrictions(
-    workspaceMemberId: string,
+    userId: string,
     messages: MessageWorkspaceEntity[],
   ) {
     const messageChannelMessageAssociationRepository =
@@ -66,13 +67,22 @@ export class ApplyMessagesVisibilityRestrictionsService {
         continue;
       }
 
+      const workspaceMemberRepository =
+        await this.twentyORMManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+          'workspaceMember',
+        );
+
+      const workspaceMember = await workspaceMemberRepository.findOneByOrFail({
+        userId,
+      });
+
       const connectedAccounts = await connectedAccountRepository.find({
         select: ['id'],
         where: {
           messageChannels: {
             id: In(messageChannels.map((channel) => channel.id)),
           },
-          accountOwnerId: workspaceMemberId,
+          accountOwnerId: workspaceMember.id,
         },
       });
 

--- a/packages/twenty-server/src/modules/messaging/common/query-hooks/message/apply-messages-visibility-restrictions.service.ts
+++ b/packages/twenty-server/src/modules/messaging/common/query-hooks/message/apply-messages-visibility-restrictions.service.ts
@@ -38,6 +38,11 @@ export class ApplyMessagesVisibilityRestrictionsService {
         'connectedAccount',
       );
 
+    const workspaceMemberRepository =
+      await this.twentyORMManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+        'workspaceMember',
+      );
+
     for (let i = messages.length - 1; i >= 0; i--) {
       const messageChannelMessageAssociations =
         messageChannelMessagesAssociations.filter(
@@ -66,11 +71,6 @@ export class ApplyMessagesVisibilityRestrictionsService {
       ) {
         continue;
       }
-
-      const workspaceMemberRepository =
-        await this.twentyORMManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-          'workspaceMember',
-        );
 
       const workspaceMember = await workspaceMemberRepository.findOneByOrFail({
         userId,

--- a/packages/twenty-server/src/modules/messaging/common/query-hooks/message/apply-messages-visibility-restrictions.service.ts
+++ b/packages/twenty-server/src/modules/messaging/common/query-hooks/message/apply-messages-visibility-restrictions.service.ts
@@ -18,8 +18,8 @@ export class ApplyMessagesVisibilityRestrictionsService {
   constructor(private readonly twentyORMManager: TwentyORMManager) {}
 
   public async applyMessagesVisibilityRestrictions(
-    userId: string | undefined, // undefined when request is made with api key
     messages: MessageWorkspaceEntity[],
+    userId?: string, // undefined when request is made with api key
   ) {
     const messageChannelMessageAssociationRepository =
       await this.twentyORMManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(

--- a/packages/twenty-server/src/modules/messaging/common/query-hooks/message/message-find-many.post-query.hook.ts
+++ b/packages/twenty-server/src/modules/messaging/common/query-hooks/message/message-find-many.post-query.hook.ts
@@ -25,14 +25,14 @@ export class MessageFindManyPostQueryHook
     _objectName: string,
     payload: MessageWorkspaceEntity[],
   ): Promise<void> {
-    const user = authContext.user;
+    const { user, apiKey } = authContext;
 
-    if (!isDefined(user)) {
+    if (!isDefined(user) && !isDefined(apiKey)) {
       throw new UserInputError('User is required');
     }
 
     await this.applyMessagesVisibilityRestrictionsService.applyMessagesVisibilityRestrictions(
-      user.id,
+      isDefined(user) ? user.id : undefined,
       payload,
     );
   }

--- a/packages/twenty-server/src/modules/messaging/common/query-hooks/message/message-find-many.post-query.hook.ts
+++ b/packages/twenty-server/src/modules/messaging/common/query-hooks/message/message-find-many.post-query.hook.ts
@@ -32,8 +32,8 @@ export class MessageFindManyPostQueryHook
     }
 
     await this.applyMessagesVisibilityRestrictionsService.applyMessagesVisibilityRestrictions(
-      isDefined(user) ? user.id : undefined,
       payload,
+      user?.id,
     );
   }
 }

--- a/packages/twenty-server/src/modules/messaging/common/query-hooks/message/message-find-many.post-query.hook.ts
+++ b/packages/twenty-server/src/modules/messaging/common/query-hooks/message/message-find-many.post-query.hook.ts
@@ -5,7 +5,7 @@ import { WorkspacePostQueryHookInstance } from 'src/engine/api/graphql/workspace
 import { WorkspaceQueryHook } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/decorators/workspace-query-hook.decorator';
 import { WorkspaceQueryHookType } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/types/workspace-query-hook.type';
 import { AuthContext } from 'src/engine/core-modules/auth/types/auth-context.type';
-import { UserInputError } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
+import { ForbiddenError } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
 import { ApplyMessagesVisibilityRestrictionsService } from 'src/modules/messaging/common/query-hooks/message/apply-messages-visibility-restrictions.service';
 import { MessageWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message.workspace-entity';
 
@@ -28,7 +28,7 @@ export class MessageFindManyPostQueryHook
     const { user, apiKey } = authContext;
 
     if (!isDefined(user) && !isDefined(apiKey)) {
-      throw new UserInputError('User is required');
+      throw new ForbiddenError('User is required');
     }
 
     await this.applyMessagesVisibilityRestrictionsService.applyMessagesVisibilityRestrictions(

--- a/packages/twenty-server/src/modules/messaging/common/query-hooks/message/message-find-many.post-query.hook.ts
+++ b/packages/twenty-server/src/modules/messaging/common/query-hooks/message/message-find-many.post-query.hook.ts
@@ -1,3 +1,5 @@
+import { isDefined } from 'twenty-shared/utils';
+
 import { WorkspacePostQueryHookInstance } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/interfaces/workspace-query-hook.interface';
 
 import { WorkspaceQueryHook } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/decorators/workspace-query-hook.decorator';
@@ -23,12 +25,14 @@ export class MessageFindManyPostQueryHook
     _objectName: string,
     payload: MessageWorkspaceEntity[],
   ): Promise<void> {
-    if (!authContext.workspaceMemberId) {
-      throw new UserInputError('Workspace member id is required');
+    const user = authContext.user;
+
+    if (!isDefined(user)) {
+      throw new UserInputError('User is required');
     }
 
     await this.applyMessagesVisibilityRestrictionsService.applyMessagesVisibilityRestrictions(
-      authContext.workspaceMemberId,
+      user.id,
       payload,
     );
   }

--- a/packages/twenty-server/src/modules/messaging/common/query-hooks/message/message-find-one.post-query.hook.ts
+++ b/packages/twenty-server/src/modules/messaging/common/query-hooks/message/message-find-one.post-query.hook.ts
@@ -25,14 +25,14 @@ export class MessageFindOnePostQueryHook
     _objectName: string,
     payload: MessageWorkspaceEntity[],
   ): Promise<void> {
-    const user = authContext.user;
+    const { user, apiKey } = authContext;
 
-    if (!isDefined(user)) {
+    if (!isDefined(user) && !isDefined(apiKey)) {
       throw new UserInputError('User is required');
     }
 
     await this.applyMessagesVisibilityRestrictionsService.applyMessagesVisibilityRestrictions(
-      user.id,
+      isDefined(user) ? user.id : undefined,
       payload,
     );
   }

--- a/packages/twenty-server/src/modules/messaging/common/query-hooks/message/message-find-one.post-query.hook.ts
+++ b/packages/twenty-server/src/modules/messaging/common/query-hooks/message/message-find-one.post-query.hook.ts
@@ -1,3 +1,5 @@
+import { isDefined } from 'twenty-shared/utils';
+
 import { WorkspacePostQueryHookInstance } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/interfaces/workspace-query-hook.interface';
 
 import { WorkspaceQueryHook } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/decorators/workspace-query-hook.decorator';
@@ -23,12 +25,14 @@ export class MessageFindOnePostQueryHook
     _objectName: string,
     payload: MessageWorkspaceEntity[],
   ): Promise<void> {
-    if (!authContext.workspaceMemberId) {
-      throw new UserInputError('Workspace member id is required');
+    const user = authContext.user;
+
+    if (!isDefined(user)) {
+      throw new UserInputError('User is required');
     }
 
     await this.applyMessagesVisibilityRestrictionsService.applyMessagesVisibilityRestrictions(
-      authContext.workspaceMemberId,
+      user.id,
       payload,
     );
   }

--- a/packages/twenty-server/src/modules/messaging/common/query-hooks/message/message-find-one.post-query.hook.ts
+++ b/packages/twenty-server/src/modules/messaging/common/query-hooks/message/message-find-one.post-query.hook.ts
@@ -32,8 +32,8 @@ export class MessageFindOnePostQueryHook
     }
 
     await this.applyMessagesVisibilityRestrictionsService.applyMessagesVisibilityRestrictions(
-      isDefined(user) ? user.id : undefined,
       payload,
+      user?.id,
     );
   }
 }

--- a/packages/twenty-server/src/modules/messaging/common/query-hooks/message/message-find-one.post-query.hook.ts
+++ b/packages/twenty-server/src/modules/messaging/common/query-hooks/message/message-find-one.post-query.hook.ts
@@ -5,7 +5,7 @@ import { WorkspacePostQueryHookInstance } from 'src/engine/api/graphql/workspace
 import { WorkspaceQueryHook } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/decorators/workspace-query-hook.decorator';
 import { WorkspaceQueryHookType } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/types/workspace-query-hook.type';
 import { AuthContext } from 'src/engine/core-modules/auth/types/auth-context.type';
-import { UserInputError } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
+import { ForbiddenError } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
 import { ApplyMessagesVisibilityRestrictionsService } from 'src/modules/messaging/common/query-hooks/message/apply-messages-visibility-restrictions.service';
 import { MessageWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message.workspace-entity';
 
@@ -28,7 +28,7 @@ export class MessageFindOnePostQueryHook
     const { user, apiKey } = authContext;
 
     if (!isDefined(user) && !isDefined(apiKey)) {
-      throw new UserInputError('User is required');
+      throw new ForbiddenError('User is required');
     }
 
     await this.applyMessagesVisibilityRestrictionsService.applyMessagesVisibilityRestrictions(


### PR DESCRIPTION
Context
workspaceMemberId is not always present in AuthContext. Solution implemented here is to fetch workspaceMemberId via userId.

QRQC coming ... 

Tested
- FindManyCalendarEvents / FindOneCalendarEvent
- FindManyMessages / FindOneMessage

closes https://github.com/twentyhq/twenty/issues/12027