### PR TITLE
Fix table click outside

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-body/components/RecordTableBodyFocusClickOutsideEffect.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-body/components/RecordTableBodyFocusClickOutsideEffect.tsx
@@ -1,3 +1,4 @@
+import { RecordIndexHotkeyScope } from '@/object-record/record-index/types/RecordIndexHotkeyScope';
 import { RECORD_TABLE_CLICK_OUTSIDE_LISTENER_ID } from '@/object-record/record-table/constants/RecordTableClickOutsideListenerId';
 import { useRecordTableContextOrThrow } from '@/object-record/record-table/contexts/RecordTableContext';
 import { useLeaveTableFocus } from '@/object-record/record-table/hooks/internal/useLeaveTableFocus';
@@ -29,7 +30,10 @@ export const RecordTableBodyFocusClickOutsideEffect = ({
     listenerId: RECORD_TABLE_CLICK_OUTSIDE_LISTENER_ID,
     refs: [tableBodyRef],
     callback: () => {
-      if (currentHotkeyScope.scope !== TableHotkeyScope.TableFocus) {
+      if (
+        currentHotkeyScope.scope !== TableHotkeyScope.TableFocus &&
+        currentHotkeyScope.scope !== RecordIndexHotkeyScope.RecordIndex
+      ) {
         return;
       }
 


### PR DESCRIPTION
Fixes #12037 
Follow up on #12011

Make `RecordTableBodyFocusClickOutsideEffect` also be available for `RecordIndexHotkeyScope.RecordIndex`