### PR TITLE
Fix infinite loop critical bug

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-store/components/RecordValueSetterEffect.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-store/components/RecordValueSetterEffect.tsx
@@ -6,7 +6,6 @@ import {
   useSetRecordValue,
 } from '@/object-record/record-store/contexts/RecordFieldValueSelectorContext';
 import { recordStoreFamilyState } from '@/object-record/record-store/states/recordStoreFamilyState';
-import { isDeeplyEqual } from '~/utils/isDeeplyEqual';
 
 // TODO: should be optimized and put higher up
 export const RecordValueSetterEffect = ({ recordId }: { recordId: string }) => {
@@ -19,9 +18,9 @@ export const RecordValueSetterEffect = ({ recordId }: { recordId: string }) => {
   );
 
   useEffect(() => {
-    if (!isDeeplyEqual(recordValueFromContextSelector, recordValueFromRecoil)) {
+    //if (!isDeeplyEqual(recordValueFromContextSelector, recordValueFromRecoil)) {
       setRecordValueInContextSelector(recordId, recordValueFromRecoil);
-    }
+    //}
   }, [
     setRecordValueInContextSelector,
     recordValueFromRecoil,

--- a/packages/twenty-front/src/modules/object-record/record-store/components/RecordValueSetterEffect.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-store/components/RecordValueSetterEffect.tsx
@@ -6,6 +6,7 @@ import {
   useSetRecordValue,
 } from '@/object-record/record-store/contexts/RecordFieldValueSelectorContext';
 import { recordStoreFamilyState } from '@/object-record/record-store/states/recordStoreFamilyState';
+import { isDeeplyEqual } from '~/utils/isDeeplyEqual';
 
 // TODO: should be optimized and put higher up
 export const RecordValueSetterEffect = ({ recordId }: { recordId: string }) => {
@@ -18,9 +19,9 @@ export const RecordValueSetterEffect = ({ recordId }: { recordId: string }) => {
   );
 
   useEffect(() => {
-    //if (!isDeeplyEqual(recordValueFromContextSelector, recordValueFromRecoil)) {
+    if (!isDeeplyEqual(recordValueFromContextSelector, recordValueFromRecoil)) {
       setRecordValueInContextSelector(recordId, recordValueFromRecoil);
-    //}
+    }
   }, [
     setRecordValueInContextSelector,
     recordValueFromRecoil,

--- a/packages/twenty-front/src/modules/object-record/record-store/components/RecordValueSetterEffect.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-store/components/RecordValueSetterEffect.tsx
@@ -1,18 +1,33 @@
 import { useEffect } from 'react';
 import { useRecoilValue } from 'recoil';
 
-import { useSetRecordValue } from '@/object-record/record-store/contexts/RecordFieldValueSelectorContext';
+import {
+  useRecordValue,
+  useSetRecordValue,
+} from '@/object-record/record-store/contexts/RecordFieldValueSelectorContext';
 import { recordStoreFamilyState } from '@/object-record/record-store/states/recordStoreFamilyState';
+import { isDeeplyEqual } from '~/utils/isDeeplyEqual';
 
 // TODO: should be optimized and put higher up
 export const RecordValueSetterEffect = ({ recordId }: { recordId: string }) => {
-  const setRecordValue = useSetRecordValue();
+  const setRecordValueInContextSelector = useSetRecordValue();
 
-  const recordValue = useRecoilValue(recordStoreFamilyState(recordId));
+  const recordValueFromContextSelector = useRecordValue(recordId);
+
+  const recordValueFromRecoil = useRecoilValue(
+    recordStoreFamilyState(recordId),
+  );
 
   useEffect(() => {
-    setRecordValue(recordId, recordValue);
-  }, [setRecordValue, recordValue, recordId]);
+    if (!isDeeplyEqual(recordValueFromContextSelector, recordValueFromRecoil)) {
+      setRecordValueInContextSelector(recordId, recordValueFromRecoil);
+    }
+  }, [
+    setRecordValueInContextSelector,
+    recordValueFromRecoil,
+    recordId,
+    recordValueFromContextSelector,
+  ]);
 
   return null;
 };


### PR DESCRIPTION
This PR fixes an infinite loop than happens due to a useEffect in a non deterministic manner.

The fix is to put a `isDeeplyEqual()` to avoid re-rendering the useEffect if the value is the same.

Fixes : https://github.com/twentyhq/core-team-issues/issues/957