### PR TITLE
Fix CSV import upsert

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-create-many-resolver.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-create-many-resolver.service.ts
@@ -266,18 +266,20 @@ export class GraphqlQueryCreateManyResolverService extends GraphqlQueryBaseResol
     for (const record of recordsToUpdate) {
       const recordId = record.id as string;
 
+      // we should not update an existing record's createdBy value
+      const recordWithoutCreatedByUpdate = this.getRecordWithoutCreatedBy(
+        record,
+        objectMetadataItemWithFieldMaps,
+      );
+
+      const formattedRecord = formatData(
+        recordWithoutCreatedByUpdate,
+        objectMetadataItemWithFieldMaps,
+      );
+
       // TODO: we should align update and insert
       // For insert, formating is done in the server
       // While for update, formatting is done at the resolver level
-
-      const shouldNotEraseCreatedByField = true;
-
-      const formattedRecord = formatData(
-        record,
-        objectMetadataItemWithFieldMaps,
-        shouldNotEraseCreatedByField,
-      );
-
       await repository.update(recordId, formattedRecord);
       result.identifiers.push({ id: recordId });
       result.generatedMaps.push({ id: recordId });
@@ -363,6 +365,25 @@ export class GraphqlQueryCreateManyResolverService extends GraphqlQueryBaseResol
         totalCount: 1,
       }),
     );
+  }
+
+  private getRecordWithoutCreatedBy(
+    record: Partial<ObjectRecord>,
+    objectMetadataItemWithFieldMaps: ObjectMetadataItemWithFieldMaps,
+  ) {
+    let recordWithoutCreatedByUpdate = record;
+
+    if (
+      'createdBy' in record &&
+      objectMetadataItemWithFieldMaps.fieldsByName['createdBy']?.isCustom ===
+        false
+    ) {
+      const { createdBy: _createdBy, ...recordWithoutCreatedBy } = record;
+
+      recordWithoutCreatedByUpdate = recordWithoutCreatedBy;
+    }
+
+    return recordWithoutCreatedByUpdate;
   }
 
   async validate<T extends ObjectRecord>(

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-create-many-resolver.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-create-many-resolver.service.ts
@@ -270,9 +270,12 @@ export class GraphqlQueryCreateManyResolverService extends GraphqlQueryBaseResol
       // For insert, formating is done in the server
       // While for update, formatting is done at the resolver level
 
+      const shouldNotEraseCreatedByField = true;
+
       const formattedRecord = formatData(
         record,
         objectMetadataItemWithFieldMaps,
+        shouldNotEraseCreatedByField,
       );
 
       await repository.update(recordId, formattedRecord);

--- a/packages/twenty-server/src/engine/twenty-orm/utils/format-data.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/format-data.util.ts
@@ -1,5 +1,5 @@
-import { capitalize } from 'twenty-shared/utils';
 import { FieldMetadataType } from 'twenty-shared/types';
+import { capitalize } from 'twenty-shared/utils';
 
 import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
 
@@ -12,6 +12,7 @@ import { isFieldMetadataInterfaceOfType } from 'src/engine/utils/is-field-metada
 export function formatData<T>(
   data: T,
   objectMetadataItemWithFieldMaps: ObjectMetadataItemWithFieldMaps,
+  shouldNotEraseCreatedByField = false,
 ): T {
   if (!data) {
     return data;
@@ -46,6 +47,15 @@ export function formatData<T>(
     const fieldMetadata =
       objectMetadataItemWithFieldMaps.fieldsByName[key] ||
       fieldMetadataByJoinColumnName.get(key);
+
+    if (
+      fieldMetadata?.name === 'createdBy' &&
+      fieldMetadata.isCustom === false
+    ) {
+      if (shouldNotEraseCreatedByField) {
+        continue;
+      }
+    }
 
     if (!fieldMetadata) {
       throw new Error(

--- a/packages/twenty-server/src/engine/twenty-orm/utils/format-data.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/format-data.util.ts
@@ -48,19 +48,19 @@ export function formatData<T>(
       objectMetadataItemWithFieldMaps.fieldsByName[key] ||
       fieldMetadataByJoinColumnName.get(key);
 
+    if (!fieldMetadata) {
+      throw new Error(
+        `Field metadata for field "${key}" is missing in object metadata`,
+      );
+    }
+
     if (
-      fieldMetadata?.name === 'createdBy' &&
+      fieldMetadata.name === 'createdBy' &&
       fieldMetadata.isCustom === false
     ) {
       if (shouldNotEraseCreatedByField) {
         continue;
       }
-    }
-
-    if (!fieldMetadata) {
-      throw new Error(
-        `Field metadata for field "${key}" is missing in object metadata`,
-      );
     }
 
     if (isCompositeFieldMetadataType(fieldMetadata.type)) {

--- a/packages/twenty-server/src/engine/twenty-orm/utils/format-data.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/format-data.util.ts
@@ -12,7 +12,6 @@ import { isFieldMetadataInterfaceOfType } from 'src/engine/utils/is-field-metada
 export function formatData<T>(
   data: T,
   objectMetadataItemWithFieldMaps: ObjectMetadataItemWithFieldMaps,
-  shouldNotEraseCreatedByField = false,
 ): T {
   if (!data) {
     return data;
@@ -52,15 +51,6 @@ export function formatData<T>(
       throw new Error(
         `Field metadata for field "${key}" is missing in object metadata`,
       );
-    }
-
-    if (
-      fieldMetadata.name === 'createdBy' &&
-      fieldMetadata.isCustom === false
-    ) {
-      if (shouldNotEraseCreatedByField) {
-        continue;
-      }
     }
 
     if (isCompositeFieldMetadataType(fieldMetadata.type)) {


### PR DESCRIPTION
Fixes https://github.com/twentyhq/twenty/issues/11864 and https://github.com/twentyhq/core-team-issues/issues/908

We should not send `createManyXXX` mutations with FE-forged ids in the payload if we want to do an upsert, because that 1) prevents records from being merged 2) triggers optimistic rendering while we can't know before-hand which records will actually be created and which records will only be updated

Also noticed createdBy was being overriden even for records we are updating and not creating, which did not seem right, so fixed that too 