### PR TITLE
Validate existing fields on creation

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
@@ -987,7 +987,7 @@ export class ConfigVariables {
     type: ConfigVariableType.NUMBER,
   })
   @CastToPositiveNumber()
-  WORKFLOW_EXEC_THROTTLE_LIMIT = 500;
+  WORKFLOW_EXEC_THROTTLE_LIMIT = 100;
 
   @ConfigVariablesMetadata({
     group: ConfigVariablesGroup.RateLimiting,

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/record-crud/create-record.workflow-action.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/record-crud/create-record.workflow-action.ts
@@ -105,9 +105,15 @@ export class CreateRecordWorkflowAction implements WorkflowExecutor {
         workspaceId,
       );
 
+    const validObjectRecord = Object.fromEntries(
+      Object.entries(workflowActionInput.objectRecord).filter(
+        ([key]) => objectMetadataItemWithFieldsMaps.fieldsByName[key],
+      ),
+    );
+
     const transformedObjectRecord =
       await this.recordInputTransformerService.process({
-        recordInput: workflowActionInput.objectRecord,
+        recordInput: validObjectRecord,
         objectMetadataMapItem: objectMetadataItemWithFieldsMaps,
       });
 


### PR DESCRIPTION
Fixes https://github.com/twentyhq/twenty/issues/12040

When fields are deleted but still used in workflows we do not update create record action settings.
It breaks all following workflow execution and the user cannot update the settings anymore.

This PR fixes the bug by filtering on existing fields.

Next step will be to clean settings on field deletion. Adding it to fast follows.

Also lowering throttle limit because some infinite loops are not catched.