### PR TITLE
Gmail temporary error

### DIFF
--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/utils/parse-gmail-messages-import-error.util.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/utils/parse-gmail-messages-import-error.util.ts
@@ -75,7 +75,17 @@ export const parseGmailMessagesImportError = (
       );
 
     case 500:
+    case 502:
+    case 503:
+    case 504:
       if (reason === 'backendError') {
+        return new MessageImportDriverException(
+          message,
+          MessageImportDriverExceptionCode.TEMPORARY_ERROR,
+        );
+      }
+
+      if (errors?.[0]?.message.includes(`Authentication backend unavailable`)) {
         return new MessageImportDriverException(
           message,
           MessageImportDriverExceptionCode.TEMPORARY_ERROR,

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/utils/parse-gmail-messages-import-error.util.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/utils/parse-gmail-messages-import-error.util.ts
@@ -87,7 +87,7 @@ export const parseGmailMessagesImportError = (
 
       if (errors?.[0]?.message.includes(`Authentication backend unavailable`)) {
         return new MessageImportDriverException(
-          message,
+          `${code} - ${reason} - ${message}`,
           MessageImportDriverExceptionCode.TEMPORARY_ERROR,
         );
       }


### PR DESCRIPTION
# Handling Google error

This bug is hard to reproduce so the resolution is based only on the Sentry logs. There is not definite error code 
 for this error message. in the documentation. https://developers.google.com/workspace/gmail/api/guides

This is why i added more 5xx code types in order to be sure we catch this. In order to refine this later, i added the error code to the message.

Fixes https://github.com/twentyhq/twenty/issues/12025