### PR TITLE
[reconnect account] Reseting calendar status and stage on reconnect

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/auth/services/microsoft-apis.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/microsoft-apis.service.ts
@@ -20,6 +20,7 @@ import {
   CalendarEventListFetchJobData,
 } from 'src/modules/calendar/calendar-event-import-manager/jobs/calendar-event-list-fetch.job';
 import {
+  CalendarChannelSyncStage,
   CalendarChannelVisibility,
   CalendarChannelWorkspaceEntity,
 } from 'src/modules/calendar/common/standard-objects/calendar-channel.workspace-entity';
@@ -329,6 +330,47 @@ export class MicrosoftAPIsService {
               properties: {
                 before: messageChannel,
                 after: { ...messageChannel, ...messageChannelUpdates.raw[0] },
+              },
+            })),
+            workspaceId,
+          });
+
+          // now for the calendar channels
+          const calendarChannels = await calendarChannelRepository.find({
+            where: { connectedAccountId: newOrExistingConnectedAccountId },
+          });
+
+          const calendarChannelUpdates = await calendarChannelRepository.update(
+            {
+              connectedAccountId: newOrExistingConnectedAccountId,
+            },
+            {
+              syncStage:
+                CalendarChannelSyncStage.FULL_CALENDAR_EVENT_LIST_FETCH_PENDING,
+              syncStatus: null,
+              syncCursor: '',
+              syncStageStartedAt: null,
+            },
+            manager,
+          );
+
+          const calendarChannelMetadata =
+            await this.objectMetadataRepository.findOneOrFail({
+              where: { nameSingular: 'calendarChannel', workspaceId },
+            });
+
+          this.workspaceEventEmitter.emitDatabaseBatchEvent({
+            objectMetadataNameSingular: 'calendarChannel',
+            action: DatabaseEventAction.UPDATED,
+            events: calendarChannels.map((calendarChannel) => ({
+              recordId: calendarChannel.id,
+              objectMetadata: calendarChannelMetadata,
+              properties: {
+                before: calendarChannel,
+                after: {
+                  ...calendarChannel,
+                  ...calendarChannelUpdates.raw[0],
+                },
               },
             })),
             workspaceId,


### PR DESCRIPTION
## Description
When a calendar channel fails, its status is not reset during the reconnect step.

In some cases, resetting is necessary—especially when we’ve deployed a fix and users try to reconnect their accounts after the patch.

## Why reseting to initial state
Our processes are idempotent, so we can safely set the status to null to restart the flow. This approach covers all cases and avoids edge conditions caused by inconsistent statuses.


Fixes : https://github.com/twentyhq/twenty/issues/12026