### PR TITLE
Make workflow custom fields editable

### DIFF
--- a/packages/twenty-front/src/modules/activities/components/ActivityRichTextEditor.tsx
+++ b/packages/twenty-front/src/modules/activities/components/ActivityRichTextEditor.tsx
@@ -70,6 +70,7 @@ export const ActivityRichTextEditor = ({
   const isReadOnly = isFieldValueReadOnly({
     objectNameSingular: activityObjectNameSingular,
     isRecordReadOnly,
+    isCustom: objectMetadataItemActivity.isCustom,
   });
 
   const { deleteManyRecords: deleteAttachments } = useDeleteManyRecords({

--- a/packages/twenty-front/src/modules/object-metadata/utils/formatFieldMetadataItemAsFieldDefinition.ts
+++ b/packages/twenty-front/src/modules/object-metadata/utils/formatFieldMetadataItemAsFieldDefinition.ts
@@ -39,6 +39,7 @@ export const formatFieldMetadataItemAsFieldDefinition = ({
     options: field.options,
     settings: field.settings,
     isNullable: field.isNullable,
+    isCustom: field.isCustom ?? false,
   };
 
   return {

--- a/packages/twenty-front/src/modules/object-record/record-board/record-board-card/components/RecordBoardCardBody.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/record-board-card/components/RecordBoardCardBody.tsx
@@ -51,6 +51,7 @@ export const RecordBoardCardBody = ({
                 fieldName: fieldDefinition.metadata.fieldName,
                 fieldType: fieldDefinition.type,
                 isRecordReadOnly,
+                isCustom: fieldDefinition.metadata.isCustom,
               }),
               fieldDefinition: {
                 disableTooltip: false,

--- a/packages/twenty-front/src/modules/object-record/record-field/utils/__tests__/isFieldValueReadOnly.test.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/utils/__tests__/isFieldValueReadOnly.test.ts
@@ -45,6 +45,26 @@ describe('isFieldValueReadOnly', () => {
     expect(result).toBe(false);
   });
 
+  it('should return false if object is a workflow object and field is custom', () => {
+    const result = isFieldValueReadOnly({
+      objectNameSingular: CoreObjectNameSingular.Workflow,
+      fieldName: 'test',
+      isCustom: true,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('should return false if object is a workflow sub object and field is custom', () => {
+    const result = isFieldValueReadOnly({
+      objectNameSingular: CoreObjectNameSingular.WorkflowVersion,
+      fieldName: 'test',
+      isCustom: true,
+    });
+
+    expect(result).toBe(false);
+  });
+
   describe('when checking field types', () => {
     it('should return true if fieldType is RICH_TEXT', () => {
       const result = isFieldValueReadOnly({

--- a/packages/twenty-front/src/modules/object-record/record-field/utils/isFieldValueReadOnly.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/utils/isFieldValueReadOnly.ts
@@ -19,8 +19,8 @@ export const isFieldValueReadOnly = ({
   objectNameSingular,
   fieldName,
   fieldType,
+  isCustom,
   isRecordReadOnly = false,
-  isCustom = false,
 }: isFieldValueReadOnlyParams) => {
   if (isRecordReadOnly) {
     return true;
@@ -35,7 +35,7 @@ export const isFieldValueReadOnly = ({
     return false;
   }
 
-  if (isWorkflowSubObjectMetadata(objectNameSingular)) {
+  if (isWorkflowSubObjectMetadata(objectNameSingular) && !isCustom) {
     return true;
   }
 

--- a/packages/twenty-front/src/modules/object-record/record-index/export/hooks/__tests__/useExportFetchRecords.test.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/export/hooks/__tests__/useExportFetchRecords.test.ts
@@ -223,6 +223,7 @@ describe('useRecordData', () => {
               labelWidth: undefined,
               metadata: {
                 fieldName: 'updatedAt',
+                isCustom: false,
                 isNullable: false,
                 objectMetadataNameSingular: 'person',
                 options: null,

--- a/packages/twenty-front/src/modules/object-record/record-show/components/FieldsCard.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-show/components/FieldsCard.tsx
@@ -122,6 +122,7 @@ export const FieldsCard = ({
                       objectNameSingular,
                       fieldName: fieldMetadataItem.name,
                       fieldType: fieldMetadataItem.type,
+                      isCustom: fieldMetadataItem.isCustom ?? false,
                       isRecordReadOnly,
                     }),
                   }}
@@ -164,6 +165,7 @@ export const FieldsCard = ({
                     objectNameSingular,
                     fieldName: fieldMetadataItem.name,
                     fieldType: fieldMetadataItem.type,
+                    isCustom: fieldMetadataItem.isCustom ?? false,
                     isRecordReadOnly,
                   }),
                 }}


### PR DESCRIPTION
Fixes https://github.com/twentyhq/twenty/issues/11989

<img width="1267" alt="Capture d’écran 2025-05-15 à 14 05 15" src="https://github.com/user-attachments/assets/fbb22f52-2c76-424f-8b8c-fb030fef9fa8" />

`isCustom` was not properly set everywhere because it was not mandatory in `isFieldValueReadOnly`. Removing the default value and adding it to missing places