### PR TITLE
Fix infinite loop in context selector value setter effect

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-store/components/RecordValueSetterEffect.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-store/components/RecordValueSetterEffect.tsx
@@ -6,7 +6,6 @@ import {
   useSetRecordValue,
 } from '@/object-record/record-store/contexts/RecordFieldValueSelectorContext';
 import { recordStoreFamilyState } from '@/object-record/record-store/states/recordStoreFamilyState';
-import { isDeeplyEqual } from '~/utils/isDeeplyEqual';
 
 // TODO: should be optimized and put higher up
 export const RecordValueSetterEffect = ({ recordId }: { recordId: string }) => {
@@ -19,7 +18,10 @@ export const RecordValueSetterEffect = ({ recordId }: { recordId: string }) => {
   );
 
   useEffect(() => {
-    if (!isDeeplyEqual(recordValueFromContextSelector, recordValueFromRecoil)) {
+    if (
+      JSON.stringify(recordValueFromContextSelector) !==
+      JSON.stringify(recordValueFromRecoil)
+    ) {
       setRecordValueInContextSelector(recordId, recordValueFromRecoil);
     }
   }, [


### PR DESCRIPTION
This PR implements the same method as in `useSetRecordTableData`, with a JSON stringified comparison.

Because [deep-equal](https://www.npmjs.com/package/deep-equal) package is unfortunately not doing a deep equal strict comparison and instead of testing with the strict option to true, it's best to use what's already working in our codebase.