### PR TITLE
Change idle connection time

### DIFF
--- a/packages/twenty-server/src/engine/twenty-orm/factories/workspace-datasource.factory.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/factories/workspace-datasource.factory.ts
@@ -36,6 +36,8 @@ type CacheResult<T, U> = {
   data: U;
 };
 
+const ONE_HOUR_IN_MS = 3600_000;
+
 @Injectable()
 export class WorkspaceDatasourceFactory {
   private readonly logger = new Logger(WorkspaceDatasourceFactory.name);
@@ -173,6 +175,11 @@ export class WorkspaceDatasourceFactory {
                     rejectUnauthorized: false,
                   }
                 : undefined,
+              extra: {
+                query_timeout: 10000,
+                idleTimeoutMillis: ONE_HOUR_IN_MS,
+                max: 4,
+              },
             },
             cachedFeatureFlagMapVersion,
             cachedFeatureFlagMap,

--- a/packages/twenty-server/src/engine/twenty-orm/factories/workspace-datasource.factory.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/factories/workspace-datasource.factory.ts
@@ -177,8 +177,13 @@ export class WorkspaceDatasourceFactory {
                 : undefined,
               extra: {
                 query_timeout: 10000,
+                // https://node-postgres.com/apis/pool
+                // TypeORM doesn't allow sharing connection pools bet
+                // So for now we keep a small pool open for longer
+                // for each workspace.
                 idleTimeoutMillis: ONE_HOUR_IN_MS,
                 max: 4,
+                allowExitOnIdle: true,
               },
             },
             cachedFeatureFlagMapVersion,


### PR DESCRIPTION
As discussed with @Weiko

Even though we cache the datasource, the connection expire after 10minutes in TypeORM, that might be the reason why our app is spamming the proxy asking for connections. Also lowering the pool size.