### PR TITLE
fix(domain-manager): correct domain URL reference and filter logic

### DIFF
--- a/packages/twenty-front/src/pages/settings/workspace/SettingsCustomDomain.tsx
+++ b/packages/twenty-front/src/pages/settings/workspace/SettingsCustomDomain.tsx
@@ -92,18 +92,20 @@ export const SettingsCustomDomain = () => {
             Icon={IconTrash}
             variant="primary"
             onClick={deleteCustomDomain}
-            type="button"
           />
         </StyledButtonGroup>
       </StyledDomainFormWrapper>
       {currentWorkspace?.customDomain && (
         <StyledRecordsWrapper>
           <SettingsCustomDomainRecordsStatus />
-          {customDomainRecords && (
-            <SettingsCustomDomainRecords
-              records={customDomainRecords.records}
-            />
-          )}
+          {customDomainRecords &&
+            customDomainRecords.records.some(
+              (record) => record.status !== 'success',
+            ) && (
+              <SettingsCustomDomainRecords
+                records={customDomainRecords.records}
+              />
+            )}
         </StyledRecordsWrapper>
       )}
     </Section>

--- a/packages/twenty-front/src/pages/settings/workspace/SettingsCustomDomainRecords.tsx
+++ b/packages/twenty-front/src/pages/settings/workspace/SettingsCustomDomainRecords.tsx
@@ -70,7 +70,7 @@ export const SettingsCustomDomainRecords = ({
         <TableHeader>Value</TableHeader>
       </TableRow>
       <TableBody>
-        {records.map((record) => (
+        {records.filter((record) => record.status !== 'success').map((record) => (
           <TableRow gridAutoColumns="30% 16% auto" key={record.key}>
             <StyledTableCell>
               <StyledButton

--- a/packages/twenty-front/src/pages/settings/workspace/SettingsCustomDomainRecords.tsx
+++ b/packages/twenty-front/src/pages/settings/workspace/SettingsCustomDomainRecords.tsx
@@ -70,33 +70,35 @@ export const SettingsCustomDomainRecords = ({
         <TableHeader>Value</TableHeader>
       </TableRow>
       <TableBody>
-        {records.filter((record) => record.status !== 'success').map((record) => (
-          <TableRow gridAutoColumns="30% 16% auto" key={record.key}>
-            <StyledTableCell>
-              <StyledButton
-                title={record.key}
-                onClick={() => copyToClipboardDebounced(record.key)}
-                type="button"
-              />
-            </StyledTableCell>
-            <StyledTableCell>
-              <StyledButton
-                title={record.type.toUpperCase()}
-                onClick={() =>
-                  copyToClipboardDebounced(record.type.toUpperCase())
-                }
-                type="button"
-              />
-            </StyledTableCell>
-            <StyledTableCell>
-              <StyledButton
-                title={record.value}
-                onClick={() => copyToClipboardDebounced(record.value)}
-                type="button"
-              />
-            </StyledTableCell>
-          </TableRow>
-        ))}
+        {records
+          .filter((record) => record.status !== 'success')
+          .map((record) => (
+            <TableRow gridAutoColumns="30% 16% auto" key={record.key}>
+              <StyledTableCell>
+                <StyledButton
+                  title={record.key}
+                  onClick={() => copyToClipboardDebounced(record.key)}
+                  type="button"
+                />
+              </StyledTableCell>
+              <StyledTableCell>
+                <StyledButton
+                  title={record.type.toUpperCase()}
+                  onClick={() =>
+                    copyToClipboardDebounced(record.type.toUpperCase())
+                  }
+                  type="button"
+                />
+              </StyledTableCell>
+              <StyledTableCell>
+                <StyledButton
+                  title={record.value}
+                  onClick={() => copyToClipboardDebounced(record.value)}
+                  type="button"
+                />
+              </StyledTableCell>
+            </TableRow>
+          ))}
       </TableBody>
     </StyledTable>
   );

--- a/packages/twenty-server/src/engine/core-modules/domain-manager/services/custom-domain.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/domain-manager/services/custom-domain.service.spec.ts
@@ -36,7 +36,7 @@ describe('CustomDomainService', () => {
         {
           provide: DomainManagerService,
           useValue: {
-            getFrontUrl: jest.fn(),
+            getBaseUrl: jest.fn(),
           },
         },
       ],
@@ -148,7 +148,7 @@ describe('CustomDomainService', () => {
       jest.spyOn(twentyConfigService, 'get').mockReturnValue('test-zone-id');
 
       jest
-        .spyOn(domainManagerService, 'getFrontUrl')
+        .spyOn(domainManagerService, 'getBaseUrl')
         .mockReturnValue(new URL('https://front.domain'));
       (customDomainService as any).cloudflareClient = cloudflareMock;
 
@@ -185,7 +185,7 @@ describe('CustomDomainService', () => {
 
       jest.spyOn(twentyConfigService, 'get').mockReturnValue('test-zone-id');
       jest
-        .spyOn(domainManagerService, 'getFrontUrl')
+        .spyOn(domainManagerService, 'getBaseUrl')
         .mockReturnValue(new URL('https://front.domain'));
       (customDomainService as any).cloudflareClient = cloudflareMock;
 

--- a/packages/twenty-server/src/engine/core-modules/domain-manager/services/custom-domain.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/domain-manager/services/custom-domain.service.ts
@@ -133,7 +133,7 @@ export class CustomDomainService {
                     ? 'error'
                     : 'success',
               key: response.result[0].hostname,
-              value: this.domainManagerService.getFrontUrl().hostname,
+              value: this.domainManagerService.getBaseUrl().hostname,
             },
           ]),
       };


### PR DESCRIPTION
Updated URL reference from getFrontUrl to getBaseUrl to ensure correct hostname handling. Adjusted record filtering logic to exclude successful records, preventing unnecessary rendering in the UI.

Fix https://github.com/twentyhq/core-team-issues/issues/944