### PR TITLE
Fix composite field edition

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellContainer.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellContainer.tsx
@@ -9,7 +9,6 @@ import { getRecordFieldInputId } from '@/object-record/utils/getRecordFieldInput
 
 import { assertFieldMetadata } from '@/object-record/record-field/types/guards/assertFieldMetadata';
 import { isFieldText } from '@/object-record/record-field/types/guards/isFieldText';
-import { useInlineCell } from '@/object-record/record-inline-cell/hooks/useInlineCell';
 import {
   AppTooltip,
   OverflowingTextWithTooltip,
@@ -47,6 +46,7 @@ const StyledValueContainer = styled.div<{ readonly: boolean }>`
   display: flex;
   min-width: 0;
   position: relative;
+  width: 100%;
 
   &:hover {
     ${({ readonly, theme }) =>
@@ -87,14 +87,8 @@ export const StyledSkeletonDiv = styled.div`
 `;
 
 export const RecordInlineCellContainer = () => {
-  const {
-    readonly,
-    IconLabel,
-    label,
-    labelWidth,
-    showLabel,
-    editModeContentOnly,
-  } = useRecordInlineCellContext();
+  const { readonly, IconLabel, label, labelWidth, showLabel } =
+    useRecordInlineCellContext();
 
   const { recordId, fieldDefinition } = useContext(FieldContext);
 
@@ -103,14 +97,6 @@ export const RecordInlineCellContainer = () => {
   }
 
   const { setIsFocused } = useFieldFocus();
-
-  const { openInlineCell } = useInlineCell();
-
-  const handleDisplayModeClick = () => {
-    if (!readonly && !editModeContentOnly) {
-      openInlineCell();
-    }
-  };
 
   const handleContainerMouseEnter = () => {
     if (!readonly) {
@@ -134,7 +120,6 @@ export const RecordInlineCellContainer = () => {
     <StyledInlineCellBaseContainer
       onMouseEnter={handleContainerMouseEnter}
       onMouseLeave={handleContainerMouseLeave}
-      onClick={handleDisplayModeClick}
     >
       {(IconLabel || label) && (
         <StyledLabelAndIconContainer id={labelId}>

--- a/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellContainer.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellContainer.tsx
@@ -9,6 +9,7 @@ import { getRecordFieldInputId } from '@/object-record/utils/getRecordFieldInput
 
 import { assertFieldMetadata } from '@/object-record/record-field/types/guards/assertFieldMetadata';
 import { isFieldText } from '@/object-record/record-field/types/guards/isFieldText';
+import { useInlineCell } from '@/object-record/record-inline-cell/hooks/useInlineCell';
 import {
   AppTooltip,
   OverflowingTextWithTooltip,
@@ -46,7 +47,6 @@ const StyledValueContainer = styled.div<{ readonly: boolean }>`
   display: flex;
   min-width: 0;
   position: relative;
-  width: 100%;
 
   &:hover {
     ${({ readonly, theme }) =>
@@ -87,10 +87,21 @@ export const StyledSkeletonDiv = styled.div`
 `;
 
 export const RecordInlineCellContainer = () => {
-  const { readonly, IconLabel, label, labelWidth, showLabel } =
-    useRecordInlineCellContext();
+  const {
+    readonly,
+    IconLabel,
+    label,
+    labelWidth,
+    showLabel,
+    editModeContentOnly,
+  } = useRecordInlineCellContext();
+
+  const { isInlineCellInEditMode, openInlineCell } = useInlineCell();
 
   const { recordId, fieldDefinition } = useContext(FieldContext);
+
+  const shouldContainerBeClickable =
+    !readonly && !editModeContentOnly && !isInlineCellInEditMode;
 
   if (isFieldText(fieldDefinition)) {
     assertFieldMetadata(FieldMetadataType.TEXT, isFieldText, fieldDefinition);
@@ -120,6 +131,7 @@ export const RecordInlineCellContainer = () => {
     <StyledInlineCellBaseContainer
       onMouseEnter={handleContainerMouseEnter}
       onMouseLeave={handleContainerMouseLeave}
+      onClick={shouldContainerBeClickable ? openInlineCell : undefined}
     >
       {(IconLabel || label) && (
         <StyledLabelAndIconContainer id={labelId}>

--- a/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellContainer.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellContainer.tsx
@@ -43,7 +43,6 @@ const StyledLabelAndIconContainer = styled.div`
 `;
 
 const StyledValueContainer = styled.div<{ readonly: boolean }>`
-  cursor: ${({ readonly }) => (readonly ? 'default' : 'pointer')};
   display: flex;
   min-width: 0;
   position: relative;
@@ -72,7 +71,7 @@ const StyledLabelContainer = styled.div<{ width?: number }>`
   width: ${({ width }) => width}px;
 `;
 
-const StyledInlineCellBaseContainer = styled.div`
+const StyledInlineCellBaseContainer = styled.div<{ readonly: boolean }>`
   box-sizing: border-box;
   width: 100%;
   display: flex;
@@ -80,6 +79,7 @@ const StyledInlineCellBaseContainer = styled.div`
   gap: ${({ theme }) => theme.spacing(1)};
   user-select: none;
   align-items: center;
+  cursor: ${({ readonly }) => (readonly ? 'default' : 'pointer')};
 `;
 
 export const StyledSkeletonDiv = styled.div`
@@ -129,6 +129,7 @@ export const RecordInlineCellContainer = () => {
 
   return (
     <StyledInlineCellBaseContainer
+      readonly={readonly ?? false}
       onMouseEnter={handleContainerMouseEnter}
       onMouseLeave={handleContainerMouseLeave}
       onClick={shouldContainerBeClickable ? openInlineCell : undefined}

--- a/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellValue.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellValue.tsx
@@ -14,6 +14,7 @@ const StyledClickableContainer = styled.div<{
   align-items: center;
   display: flex;
   gap: ${({ theme }) => theme.spacing(1)};
+  width: 100%;
 
   ${({ isCentered }) =>
     isCentered === true &&

--- a/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellValue.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellValue.tsx
@@ -39,7 +39,13 @@ export const RecordInlineCellValue = () => {
     isCentered,
   } = useRecordInlineCellContext();
 
-  const { isInlineCellInEditMode } = useInlineCell();
+  const { isInlineCellInEditMode, openInlineCell } = useInlineCell();
+
+  const handleDisplayModeClick = () => {
+    if (!readonly && !editModeContentOnly) {
+      openInlineCell();
+    }
+  };
 
   if (loading === true) {
     return <RecordInlineCellSkeletonLoader />;
@@ -57,7 +63,11 @@ export const RecordInlineCellValue = () => {
           </RecordInlineCellDisplayMode>
         </StyledClickableContainer>
       ) : (
-        <StyledClickableContainer readonly={readonly} isCentered={isCentered}>
+        <StyledClickableContainer
+          readonly={readonly}
+          isCentered={isCentered}
+          onClick={handleDisplayModeClick}
+        >
           <RecordInlineCellDisplayMode>
             {displayModeContent}
           </RecordInlineCellDisplayMode>

--- a/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellValue.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellValue.tsx
@@ -14,7 +14,6 @@ const StyledClickableContainer = styled.div<{
   align-items: center;
   display: flex;
   gap: ${({ theme }) => theme.spacing(1)};
-  width: 100%;
 
   ${({ isCentered }) =>
     isCentered === true &&
@@ -39,13 +38,7 @@ export const RecordInlineCellValue = () => {
     isCentered,
   } = useRecordInlineCellContext();
 
-  const { isInlineCellInEditMode, openInlineCell } = useInlineCell();
-
-  const handleDisplayModeClick = () => {
-    if (!readonly && !editModeContentOnly) {
-      openInlineCell();
-    }
-  };
+  const { isInlineCellInEditMode } = useInlineCell();
 
   if (loading === true) {
     return <RecordInlineCellSkeletonLoader />;
@@ -56,23 +49,11 @@ export const RecordInlineCellValue = () => {
       {!readonly && isInlineCellInEditMode && (
         <RecordInlineCellEditMode>{editModeContent}</RecordInlineCellEditMode>
       )}
-      {editModeContentOnly ? (
-        <StyledClickableContainer readonly={readonly} isCentered={isCentered}>
-          <RecordInlineCellDisplayMode>
-            {editModeContent}
-          </RecordInlineCellDisplayMode>
-        </StyledClickableContainer>
-      ) : (
-        <StyledClickableContainer
-          readonly={readonly}
-          isCentered={isCentered}
-          onClick={handleDisplayModeClick}
-        >
-          <RecordInlineCellDisplayMode>
-            {displayModeContent}
-          </RecordInlineCellDisplayMode>
-        </StyledClickableContainer>
-      )}
+      <StyledClickableContainer readonly={readonly} isCentered={isCentered}>
+        <RecordInlineCellDisplayMode>
+          {editModeContentOnly ? editModeContent : displayModeContent}
+        </RecordInlineCellDisplayMode>
+      </StyledClickableContainer>
     </>
   );
 };


### PR DESCRIPTION
Fixes https://github.com/twentyhq/twenty/issues/12056

Bug has been introduced by https://github.com/twentyhq/twenty/pull/11983/files

Adding onClick on the container makes it always available. Before it was only when not in edit mode.
It breaks the click outside of the `RecordInlineCell`.

This PR set the onClick only when not in edit mode.


https://github.com/user-attachments/assets/a44337a9-72e6-4de8-afa1-95de6b953459

