### PR TITLE
Fix hidden copy button on production build for text fields

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/components/LightCopyIconButton.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/components/LightCopyIconButton.tsx
@@ -23,7 +23,6 @@ export const LightCopyIconButton = ({ copyText }: LightCopyIconButtonProps) => {
   return (
     <StyledButtonContainer>
       <LightIconButton
-        className="copy-button"
         Icon={IconCopy}
         onClick={() => {
           enqueueSnackBar(t`Text copied to clipboard`, {

--- a/packages/twenty-front/src/modules/settings/playground/components/RestPlayground.tsx
+++ b/packages/twenty-front/src/modules/settings/playground/components/RestPlayground.tsx
@@ -31,7 +31,7 @@ const StyledContainer = styled.div`
 
 const ApiReferenceReact = lazy(() =>
   import('@scalar/api-reference-react').then((module) => {
-    import('@scalar/api-reference-react/style.css');
+    import('@scalar/api-reference-react/style.css?inline');
     return {
       default: module.ApiReferenceReact,
     };


### PR DESCRIPTION
Fixes #11762

The `copy-button` classname from scalar was overwritting the style of our copy button. It only happened in production build and not with `npx nx run twenty-front:start` so it was quite hard to catch. Thanks @charlesBochet for finding the root cause.

- Removed `copy-button` classname since it was unused
- Added `?inline` when importing scalar css to have inline css

Before:
<img width="210" alt="Capture d’écran 2025-05-16 à 17 43 50" src="https://github.com/user-attachments/assets/7256b5e6-0b61-4590-a4de-d6b28ab2b4ed" />

After:
<img width="230" alt="Capture d’écran 2025-05-16 à 17 43 32" src="https://github.com/user-attachments/assets/a763172b-0566-413d-bbdd-470f28097ae4" />
