### PR TITLE
Fix pg pool implementation

### DIFF
--- a/packages/twenty-server/src/engine/twenty-orm/pg-shared-pool/pg-shared-pool.service.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/pg-shared-pool/pg-shared-pool.service.ts
@@ -20,11 +20,7 @@ interface PoolWithEndTracker extends Pool {
 }
 
 interface ExtendedPoolConfig extends PoolConfig {
-  extra?: {
-    allowExitOnIdle?: boolean;
-    idleTimeoutMillis?: number;
-    [key: string]: unknown;
-  };
+  allowExitOnIdle?: boolean;
 }
 
 interface PoolInternalStats {
@@ -367,10 +363,9 @@ export class PgPoolSharedService {
         poolConfig.idleTimeoutMillis = idleTimeoutMs;
       }
 
-      if (!poolConfig.extra) {
-        poolConfig.extra = {};
+      if (allowExitOnIdle) {
+        poolConfig.allowExitOnIdle = allowExitOnIdle;
       }
-      poolConfig.extra.allowExitOnIdle = allowExitOnIdle;
 
       const key = buildPoolKey(poolConfig);
       const existing = poolsMap.get(key);


### PR DESCRIPTION
Fix the following error: 
Cannot use a pool after calling end on a pool

<img width="917" alt="Screenshot 2025-05-17 at 14 56 18" src="https://github.com/user-attachments/assets/63081831-9a7e-4633-8274-de9f8a48dbae" />

The problem was that the datasource manager was destroying the connections when a datasource cache expired.