### PR TITLE
Fix Identifier chips in Timeline Activities are broken

### DIFF
--- a/packages/twenty-front/src/modules/activities/timeline-activities/rows/main-object/components/EventFieldDiffValue.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/rows/main-object/components/EventFieldDiffValue.tsx
@@ -2,7 +2,6 @@ import styled from '@emotion/styled';
 
 import { FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
 import { ObjectMetadataItem } from '@/object-metadata/types/ObjectMetadataItem';
-import { isLabelIdentifierField } from '@/object-metadata/utils/isLabelIdentifierField';
 import { FieldDisplay } from '@/object-record/record-field/components/FieldDisplay';
 import { FieldContext } from '@/object-record/record-field/contexts/FieldContext';
 import { RecordFieldComponentInstanceContext } from '@/object-record/record-field/states/contexts/RecordFieldComponentInstanceContext';
@@ -37,10 +36,7 @@ export const EventFieldDiffValue = ({
         <FieldContext.Provider
           value={{
             recordId: diffArtificialRecordStoreId,
-            isLabelIdentifier: isLabelIdentifierField({
-              fieldMetadataItem,
-              objectMetadataItem: mainObjectMetadataItem,
-            }),
+            isLabelIdentifier: false,
             fieldDefinition: {
               type: fieldMetadataItem.type,
               iconName: fieldMetadataItem?.icon || 'FieldIcon',


### PR DESCRIPTION
Fixes https://github.com/twentyhq/twenty/issues/12114
Fixes https://github.com/twentyhq/core-team-issues/issues/856

Links were in the wrong format. This is because the timeline activity code is re-using FieldDisplay which expects a context with a specific recordId that we can't have (since this is not a true record but simply the result of a diff and each row in the diff needs to be unique)
Today we build the artificial record ID like this `eventId + '--' + fieldMetadataItem.id` to keep it unique.
However, in case the event concerns a labelIdentifier field, it uses the ChipDisplay which creates a link to the record using the artificial ID which results in a 404 when using the link.
We don't really need that link since it points to the record itself (the one that is already opened) so I'm simply removing the isLabelIdentifierField set in [EventFieldDiffValue.tsx](https://github.com/twentyhq/twenty/compare/c--fix-identifier_chips_in_timeline_activities_are_broken?expand=1#diff-af17142141c5334214f43840460a142d531c61be7c3cff55bd8a495eb831bc69) so even if it's one labelIdentifierField, it won't try to display it as such.

Ideally we should refactor this logic and not try to reuse FieldDisplay imho, we probably did that to avoid duplicating logic but that's a lot of "fake" context to get the desired result

Before
<img width="423" alt="Screenshot 2025-05-19 at 15 23 46" src="https://github.com/user-attachments/assets/b9573f4c-e205-4fdb-bdee-65b890da7810" />

After
<img width="428" alt="Screenshot 2025-05-19 at 15 23 33" src="https://github.com/user-attachments/assets/96f29842-b9aa-4230-8125-dd7d1a56baed" />
