### PR TITLE
Prevent webhook trigger from enabling keys with spaces

### DIFF
--- a/packages/twenty-front/src/modules/workflow/workflow-trigger/components/WorkflowEditTriggerWebhookForm.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-trigger/components/WorkflowEditTriggerWebhookForm.tsx
@@ -156,7 +156,15 @@ export const WorkflowEditTriggerWebhookForm = ({
 
               let formattedExpectedBody = {};
               try {
-                formattedExpectedBody = JSON.parse(newExpectedBody || '{}');
+                formattedExpectedBody = JSON.parse(
+                  newExpectedBody || '{}',
+                  (key, value) => {
+                    if (isDefined(key) && key.includes(' ')) {
+                      throw new Error(t`JSON keys cannot contain spaces`);
+                    }
+                    return value;
+                  },
+                );
               } catch (e) {
                 setErrorMessages((prev) => ({
                   ...prev,


### PR DESCRIPTION
Fixes https://github.com/twentyhq/core-team-issues/issues/984

Variables do not support spaces. Preventing those in webhook triggers

<img width="501" alt="Capture d’écran 2025-05-20 à 16 22 19" src="https://github.com/user-attachments/assets/563e4068-583f-4802-9309-a12c00143509" />
