### PR TITLE
Fix send email connected account

### DIFF
--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/components/WorkflowEditActionSendEmail.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/components/WorkflowEditActionSendEmail.tsx
@@ -171,6 +171,13 @@ export const WorkflowEditActionSendEmail = ({
   const { records: accounts, loading } = useFindManyRecords<ConnectedAccount>({
     objectNameSingular: 'connectedAccount',
     filter,
+    recordGqlFields: {
+      id: true,
+      handle: true,
+      provider: true,
+      scopes: true,
+      accountOwnerId: true,
+    },
   });
 
   let emptyOption: SelectOption<string | null> = { label: 'None', value: null };

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/components/__stories__/WorkflowEditActionSendEmail.stories.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/components/__stories__/WorkflowEditActionSendEmail.stories.tsx
@@ -1,0 +1,104 @@
+import { WorkflowSendEmailAction } from '@/workflow/types/Workflow';
+import { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import { ComponentDecorator, RouterDecorator } from 'twenty-ui/testing';
+import { I18nFrontDecorator } from '~/testing/decorators/I18nFrontDecorator';
+import { ObjectMetadataItemsDecorator } from '~/testing/decorators/ObjectMetadataItemsDecorator';
+import { SnackBarDecorator } from '~/testing/decorators/SnackBarDecorator';
+import { WorkflowStepActionDrawerDecorator } from '~/testing/decorators/WorkflowStepActionDrawerDecorator';
+import { WorkflowStepDecorator } from '~/testing/decorators/WorkflowStepDecorator';
+import { WorkspaceDecorator } from '~/testing/decorators/WorkspaceDecorator';
+import { graphqlMocks } from '~/testing/graphqlMocks';
+import { mockedConnectedAccounts } from '~/testing/mock-data/connected-accounts';
+import { getWorkflowNodeIdMock } from '~/testing/mock-data/workflow';
+import { WorkflowEditActionSendEmail } from '../WorkflowEditActionSendEmail';
+
+const DEFAULT_ACTION: WorkflowSendEmailAction = {
+  id: getWorkflowNodeIdMock(),
+  name: 'Send Email',
+  type: 'SEND_EMAIL',
+  valid: false,
+  settings: {
+    input: {
+      connectedAccountId: '',
+      email: '',
+      subject: '',
+      body: '',
+    },
+    outputSchema: {},
+    errorHandlingOptions: {
+      retryOnFailure: {
+        value: false,
+      },
+      continueOnFailure: {
+        value: false,
+      },
+    },
+  },
+};
+
+const CONFIGURED_ACTION: WorkflowSendEmailAction = {
+  id: getWorkflowNodeIdMock(),
+  name: 'Send Welcome Email',
+  type: 'SEND_EMAIL',
+  valid: true,
+  settings: {
+    input: {
+      connectedAccountId: mockedConnectedAccounts[0].accountOwnerId,
+      email: 'tim@twenty.com',
+      subject: 'Welcome to Twenty!',
+      body: 'Dear Tim,\n\nWelcome to Twenty! We are excited to have you on board.\n\nBest regards,\nThe Team',
+    },
+    outputSchema: {},
+    errorHandlingOptions: {
+      retryOnFailure: {
+        value: true,
+      },
+      continueOnFailure: {
+        value: false,
+      },
+    },
+  },
+};
+
+const meta: Meta<typeof WorkflowEditActionSendEmail> = {
+  title: 'Modules/Workflow/WorkflowEditActionSendEmail',
+  component: WorkflowEditActionSendEmail,
+  parameters: {
+    msw: graphqlMocks,
+  },
+  args: {
+    action: DEFAULT_ACTION,
+  },
+  decorators: [
+    WorkflowStepActionDrawerDecorator,
+    WorkflowStepDecorator,
+    ComponentDecorator,
+    ObjectMetadataItemsDecorator,
+    SnackBarDecorator,
+    RouterDecorator,
+    WorkspaceDecorator,
+    I18nFrontDecorator,
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof WorkflowEditActionSendEmail>;
+
+export const Default: Story = {
+  args: {
+    actionOptions: {
+      onActionUpdate: fn(),
+    },
+  },
+};
+
+export const Configured: Story = {
+  args: {
+    action: CONFIGURED_ACTION,
+    actionOptions: {
+      onActionUpdate: fn(),
+    },
+  },
+};

--- a/packages/twenty-front/src/testing/graphqlMocks.ts
+++ b/packages/twenty-front/src/testing/graphqlMocks.ts
@@ -23,7 +23,6 @@ import { mockWorkspaceMembers } from '~/testing/mock-data/workspace-members';
 import { GET_PUBLIC_WORKSPACE_DATA_BY_DOMAIN } from '@/auth/graphql/queries/getPublicWorkspaceDataByDomain';
 import { GET_ROLES } from '@/settings/roles/graphql/queries/getRolesQuery';
 import { isDefined } from 'twenty-shared/utils';
-import { getMockedConnectedAccount } from '~/testing/mock-data/connected-accounts';
 import { mockedStandardObjectMetadataQueryResult } from '~/testing/mock-data/generated/mock-metadata-query-result';
 import { getRolesMock } from '~/testing/mock-data/roles';
 import { mockedTasks } from '~/testing/mock-data/tasks';
@@ -691,13 +690,6 @@ export const graphqlMocks = {
         `,
         { status: 200 },
       );
-    }),
-    graphql.query('FindManyConnectedAccounts', () => {
-      return HttpResponse.json({
-        data: {
-          connectedAccounts: getMockedConnectedAccount(),
-        },
-      });
     }),
   ],
 };

--- a/packages/twenty-front/src/testing/graphqlMocks.ts
+++ b/packages/twenty-front/src/testing/graphqlMocks.ts
@@ -23,6 +23,7 @@ import { mockWorkspaceMembers } from '~/testing/mock-data/workspace-members';
 import { GET_PUBLIC_WORKSPACE_DATA_BY_DOMAIN } from '@/auth/graphql/queries/getPublicWorkspaceDataByDomain';
 import { GET_ROLES } from '@/settings/roles/graphql/queries/getRolesQuery';
 import { isDefined } from 'twenty-shared/utils';
+import { getMockedConnectedAccount } from '~/testing/mock-data/connected-accounts';
 import { mockedStandardObjectMetadataQueryResult } from '~/testing/mock-data/generated/mock-metadata-query-result';
 import { getRolesMock } from '~/testing/mock-data/roles';
 import { mockedTasks } from '~/testing/mock-data/tasks';
@@ -690,6 +691,13 @@ export const graphqlMocks = {
         `,
         { status: 200 },
       );
+    }),
+    graphql.query('FindManyConnectedAccounts', () => {
+      return HttpResponse.json({
+        data: {
+          connectedAccounts: getMockedConnectedAccount(),
+        },
+      });
     }),
   ],
 };

--- a/packages/twenty-front/src/testing/mock-data/connected-accounts.ts
+++ b/packages/twenty-front/src/testing/mock-data/connected-accounts.ts
@@ -1,0 +1,28 @@
+export const mockedConnectedAccounts = [
+  {
+    id: '8619ace5-1814-4e56-8439-553eab32a5cc',
+    handle: 'tim@twenty.com',
+    provider: 'gmail',
+    scopes: ['https://www.googleapis.com/auth/gmail.readonly'],
+    accountOwnerId: '56561b12-cbad-49db-a6bc-00e6b153ec80',
+  },
+];
+
+export const getMockedConnectedAccount = () => {
+  return {
+    edges: [
+      {
+        node: {
+          ...mockedConnectedAccounts[0],
+        },
+        cursor: null,
+      },
+    ],
+    pageInfo: {
+      hasNextPage: false,
+      hasPreviousPage: false,
+      startCursor: null,
+      endCursor: null,
+    },
+  };
+};


### PR DESCRIPTION
Fixes https://github.com/twentyhq/twenty/issues/12144

Account owner id is not fetched anymore by default in find many connected accounts.
This is coming from the relation migration, since account owner id is not a basic field anymore.

Enforcing the fetch of account owner id + adding tests

<img width="251" alt="Capture d’écran 2025-05-20 à 18 23 44" src="https://github.com/user-attachments/assets/3e3105a0-d3e8-4b5d-87b0-80d3e97ab034" />

