### PR TITLE
Fix workflow sub objects updates validation

### DIFF
--- a/packages/twenty-server/src/modules/workflow/common/query-hooks/workflow-run-update-one.pre-query.hook.ts
+++ b/packages/twenty-server/src/modules/workflow/common/query-hooks/workflow-run-update-one.pre-query.hook.ts
@@ -2,6 +2,7 @@ import { WorkspacePreQueryHookInstance } from 'src/engine/api/graphql/workspace-
 import { UpdateOneResolverArgs } from 'src/engine/api/graphql/workspace-resolver-builder/interfaces/workspace-resolvers-builder.interface';
 
 import { WorkspaceQueryHook } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/decorators/workspace-query-hook.decorator';
+import { AuthContext } from 'src/engine/core-modules/auth/types/auth-context.type';
 import {
   WorkflowQueryValidationException,
   WorkflowQueryValidationExceptionCode,
@@ -12,7 +13,15 @@ import { WorkflowRunWorkspaceEntity } from 'src/modules/workflow/common/standard
 export class WorkflowRunUpdateOnePreQueryHook
   implements WorkspacePreQueryHookInstance
 {
-  async execute(): Promise<UpdateOneResolverArgs<WorkflowRunWorkspaceEntity>> {
+  async execute(
+    _authContext: AuthContext,
+    _objectName: string,
+    payload: UpdateOneResolverArgs<WorkflowRunWorkspaceEntity>,
+  ): Promise<UpdateOneResolverArgs<WorkflowRunWorkspaceEntity>> {
+    if (Object.keys(payload.data).length === 1 && payload.data.name) {
+      return payload;
+    }
+
     throw new WorkflowQueryValidationException(
       'Method not allowed.',
       WorkflowQueryValidationExceptionCode.FORBIDDEN,

--- a/packages/twenty-server/src/modules/workflow/common/workspace-services/workflow-version-validation.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/common/workspace-services/workflow-version-validation.workspace-service.ts
@@ -71,7 +71,9 @@ export class WorkflowVersionValidationWorkspaceService {
         payload.id,
       );
 
-    if (Object.keys(payload.data).length > 1 || !payload.data.name) {
+    // If the only field updated is the name, we can update the workflow version
+    // Otherwise, we need to assert that the workflow version is a draft
+    if (!(Object.keys(payload.data).length === 1 && payload.data.name)) {
       assertWorkflowVersionIsDraft(workflowVersion);
     }
 

--- a/packages/twenty-server/src/modules/workflow/common/workspace-services/workflow-version-validation.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/common/workspace-services/workflow-version-validation.workspace-service.ts
@@ -71,7 +71,9 @@ export class WorkflowVersionValidationWorkspaceService {
         payload.id,
       );
 
-    assertWorkflowVersionIsDraft(workflowVersion);
+    if (Object.keys(payload.data).length > 1 || !payload.data.name) {
+      assertWorkflowVersionIsDraft(workflowVersion);
+    }
 
     if (payload.data.status && payload.data.status !== workflowVersion.status) {
       throw new WorkflowQueryValidationException(

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-step/workflow-version-step.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-step/workflow-version-step.workspace-service.ts
@@ -18,6 +18,7 @@ import {
 } from 'src/modules/workflow/common/exceptions/workflow-version-step.exception';
 import { StepOutput } from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
 import { WorkflowVersionWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow-version.workspace-entity';
+import { assertWorkflowVersionIsDraft } from 'src/modules/workflow/common/utils/assert-workflow-version-is-draft.util';
 import { WorkflowSchemaWorkspaceService } from 'src/modules/workflow/workflow-builder/workflow-schema/workflow-schema.workspace-service';
 import { insertStep } from 'src/modules/workflow/workflow-builder/workflow-step/utils/insert-step';
 import { removeStep } from 'src/modules/workflow/workflow-builder/workflow-step/utils/remove-step';
@@ -91,6 +92,8 @@ export class WorkflowVersionStepWorkspaceService {
       );
     }
 
+    assertWorkflowVersionIsDraft(workflowVersion);
+
     const existingSteps = workflowVersion.steps || [];
     const updatedSteps = insertStep({
       existingSteps,
@@ -132,6 +135,8 @@ export class WorkflowVersionStepWorkspaceService {
         WorkflowVersionStepExceptionCode.NOT_FOUND,
       );
     }
+
+    assertWorkflowVersionIsDraft(workflowVersion);
 
     if (!isDefined(workflowVersion.steps)) {
       throw new WorkflowVersionStepException(
@@ -186,6 +191,8 @@ export class WorkflowVersionStepWorkspaceService {
         WorkflowVersionStepExceptionCode.NOT_FOUND,
       );
     }
+
+    assertWorkflowVersionIsDraft(workflowVersion);
 
     if (!isDefined(workflowVersion.steps)) {
       throw new WorkflowVersionStepException(


### PR DESCRIPTION
Fixes https://github.com/twentyhq/core-team-issues/issues/983

- Enabling workflow version name update, even if not in draft status
- Assert draft when updating steps
- Enabling workflow run name update