### PR TITLE
Add Approved access domain exception filter

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/approved-access-domain/approved-access-domain-exception-filter.ts
+++ b/packages/twenty-server/src/engine/core-modules/approved-access-domain/approved-access-domain-exception-filter.ts
@@ -1,0 +1,28 @@
+import { Catch, ExceptionFilter } from '@nestjs/common';
+
+import {
+  ApprovedAccessDomainException,
+  ApprovedAccessDomainExceptionCode,
+} from 'src/engine/core-modules/approved-access-domain/approved-access-domain.exception';
+import { ForbiddenError } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
+
+@Catch(ApprovedAccessDomainException)
+export class ApprovedAccessDomainExceptionFilter implements ExceptionFilter {
+  catch(exception: ApprovedAccessDomainException) {
+    switch (exception.code) {
+      case ApprovedAccessDomainExceptionCode.APPROVED_ACCESS_DOMAIN_NOT_FOUND:
+      case ApprovedAccessDomainExceptionCode.APPROVED_ACCESS_DOMAIN_ALREADY_VERIFIED:
+      case ApprovedAccessDomainExceptionCode.APPROVED_ACCESS_DOMAIN_ALREADY_REGISTERED:
+      case ApprovedAccessDomainExceptionCode.APPROVED_ACCESS_DOMAIN_DOES_NOT_MATCH_DOMAIN_EMAIL:
+      case ApprovedAccessDomainExceptionCode.APPROVED_ACCESS_DOMAIN_VALIDATION_TOKEN_INVALID:
+      case ApprovedAccessDomainExceptionCode.APPROVED_ACCESS_DOMAIN_ALREADY_VALIDATED:
+      case ApprovedAccessDomainExceptionCode.APPROVED_ACCESS_DOMAIN_MUST_BE_A_COMPANY_DOMAIN:
+        throw new ForbiddenError(exception.message);
+      default: {
+        const _exhaustiveCheck: never = exception.code;
+
+        throw exception;
+      }
+    }
+  }
+}

--- a/packages/twenty-server/src/engine/core-modules/approved-access-domain/approved-access-domain.exception.ts
+++ b/packages/twenty-server/src/engine/core-modules/approved-access-domain/approved-access-domain.exception.ts
@@ -1,6 +1,7 @@
 import { CustomException } from 'src/utils/custom-exception';
 
 export class ApprovedAccessDomainException extends CustomException {
+  declare code: ApprovedAccessDomainExceptionCode;
   constructor(message: string, code: ApprovedAccessDomainExceptionCode) {
     super(message, code);
   }

--- a/packages/twenty-server/src/engine/core-modules/approved-access-domain/approved-access-domain.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/approved-access-domain/approved-access-domain.resolver.ts
@@ -1,18 +1,20 @@
-import { UseGuards } from '@nestjs/common';
-import { Args, Mutation, Resolver, Query } from '@nestjs/graphql';
+import { UseFilters, UseGuards } from '@nestjs/common';
+import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
 
-import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
-import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
-import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
-import { AuthUser } from 'src/engine/decorators/auth/auth-user.decorator';
-import { User } from 'src/engine/core-modules/user/user.entity';
-import { ApprovedAccessDomainService } from 'src/engine/core-modules/approved-access-domain/services/approved-access-domain.service';
+import { ApprovedAccessDomainExceptionFilter } from 'src/engine/core-modules/approved-access-domain/approved-access-domain-exception-filter';
 import { ApprovedAccessDomain } from 'src/engine/core-modules/approved-access-domain/dtos/approved-access-domain.dto';
 import { CreateApprovedAccessDomainInput } from 'src/engine/core-modules/approved-access-domain/dtos/create-approved-access.domain.input';
 import { DeleteApprovedAccessDomainInput } from 'src/engine/core-modules/approved-access-domain/dtos/delete-approved-access-domain.input';
 import { ValidateApprovedAccessDomainInput } from 'src/engine/core-modules/approved-access-domain/dtos/validate-approved-access-domain.input';
+import { ApprovedAccessDomainService } from 'src/engine/core-modules/approved-access-domain/services/approved-access-domain.service';
+import { User } from 'src/engine/core-modules/user/user.entity';
+import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
+import { AuthUser } from 'src/engine/decorators/auth/auth-user.decorator';
+import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
+import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 
 @UseGuards(WorkspaceAuthGuard)
+@UseFilters(ApprovedAccessDomainExceptionFilter)
 @Resolver()
 export class ApprovedAccessDomainResolver {
   constructor(


### PR DESCRIPTION
We have approvedAccessDomain custom exceptions, but they were never filtered while some of them reflects 4xx errors which we don't want to be captured as 5xx errors