### PR TITLE
Fix Scalar preload

### DIFF
--- a/packages/twenty-front/vite.config.ts
+++ b/packages/twenty-front/vite.config.ts
@@ -170,6 +170,11 @@ export default defineConfig(({ command, mode }) => {
           },
         },
       },
+      modulePreload: {
+        resolveDependencies: (filename, deps, { hostId }) => {
+          return deps.filter(dep => !dep.includes('scalar'));
+        },
+      },
     },
 
     envPrefix: 'REACT_APP_',


### PR DESCRIPTION
Chrome doesn't really respect preloading and was loading it before other important assets, slowing down the app while in 99% of sessions people don't check the REST API playground