### PR TITLE
Fix discard workflow draft 

### DIFF
--- a/packages/twenty-front/src/modules/workflow/hooks/useWorkflowWithCurrentVersion.ts
+++ b/packages/twenty-front/src/modules/workflow/hooks/useWorkflowWithCurrentVersion.ts
@@ -18,7 +18,17 @@ export const useWorkflowWithCurrentVersion = (
       name: true,
       statuses: true,
       lastPublishedVersionId: true,
-      versions: true,
+      versions: {
+        id: true,
+        status: true,
+        name: true,
+        steps: true,
+        trigger: true,
+        workflowId: true,
+        deletedAt: true,
+        createdAt: true,
+        updatedAt: true,
+      },
     },
     skip: !isDefined(workflowId),
   });


### PR DESCRIPTION
Fixes https://github.com/twentyhq/core-team-issues/issues/997

Fetch workflow id in workflow version is not done by default since the refacto of relations. So we delete the version from cache once discarded by we cannot clean the workflow using the workflow id in the version.

This PR adds the workflow id to the query.

Before

https://github.com/user-attachments/assets/03663bba-6c9e-4357-9326-0fb33c707fe6

After

https://github.com/user-attachments/assets/e6bb910b-2d9f-412f-a349-cd4b076aca65
