### PR TITLE
remove activity fallback record in RelationFromManyFieldDisplay

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/display/components/RelationFromManyFieldDisplay.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/display/components/RelationFromManyFieldDisplay.tsx
@@ -56,7 +56,7 @@ export const RelationFromManyFieldDisplay = () => {
         return {
           ...record,
           [relationFieldName]: {
-            id: 'a7b2c3d4-e5f6-4789-a123-456789abcdef', // fake fallback uuid
+            id: '20202020-e5f6-4789-a123-456789abcdef', // fake fallback uuid
             title: pascalCase(relationFieldName),
           },
         };

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/display/components/RelationFromManyFieldDisplay.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/display/components/RelationFromManyFieldDisplay.tsx
@@ -10,7 +10,6 @@ import { useRelationFromManyFieldDisplay } from '@/object-record/record-field/me
 import { ExpandableList } from '@/ui/layout/expandable-list/components/ExpandableList';
 import { useContext } from 'react';
 import { isDefined } from 'twenty-shared/utils';
-import { pascalCase } from '~/utils/string/pascalCase';
 
 export const RelationFromManyFieldDisplay = () => {
   const { fieldValue, fieldDefinition, generateRecordChipData } =
@@ -51,28 +50,14 @@ export const RelationFromManyFieldDisplay = () => {
         : CoreObjectNameSingular.Task;
 
     const relationFieldName = fieldName === 'noteTargets' ? 'note' : 'task';
-    const formattedRecords = fieldValue.map((record) => {
-      if (!isDefined(record[relationFieldName])) {
-        return {
-          ...record,
-          [relationFieldName]: {
-            id: '20202020-e5f6-4789-a123-456789abcdef', // fake fallback uuid
-            title: pascalCase(relationFieldName),
-          },
-        };
-      }
-
-      return record;
-    });
 
     return (
       <ExpandableList isChipCountDisplayed={isFocused}>
-        {formattedRecords
+        {fieldValue
           .map((record) => {
-            if (!isDefined(record)) {
+            if (!isDefined(record) || !isDefined(record[relationFieldName])) {
               return undefined;
             }
-
             return (
               <RecordChip
                 key={record.id}

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/display/components/RelationFromManyFieldDisplay.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/display/components/RelationFromManyFieldDisplay.tsx
@@ -56,7 +56,7 @@ export const RelationFromManyFieldDisplay = () => {
         return {
           ...record,
           [relationFieldName]: {
-            id: 'fallback-id',
+            id: 'a7b2c3d4-e5f6-4789-a123-456789abcdef', // fake fallback uuid
             title: pascalCase(relationFieldName),
           },
         };

--- a/packages/twenty-front/src/pages/settings/data-model/SettingsObjectFieldEdit.tsx
+++ b/packages/twenty-front/src/pages/settings/data-model/SettingsObjectFieldEdit.tsx
@@ -10,6 +10,7 @@ import { useFieldMetadataItem } from '@/object-metadata/hooks/useFieldMetadataIt
 import { useFilteredObjectMetadataItems } from '@/object-metadata/hooks/useFilteredObjectMetadataItems';
 import { useGetRelationMetadata } from '@/object-metadata/hooks/useGetRelationMetadata';
 import { useUpdateOneFieldMetadataItem } from '@/object-metadata/hooks/useUpdateOneFieldMetadataItem';
+import { CoreObjectNamePlural } from '@/object-metadata/types/CoreObjectNamePlural';
 import { formatFieldMetadataItemInput } from '@/object-metadata/utils/formatFieldMetadataItemInput';
 import { isLabelIdentifierField } from '@/object-metadata/utils/isLabelIdentifierField';
 import { SaveAndCancelButtons } from '@/settings/components/SaveAndCancelButtons/SaveAndCancelButtons';
@@ -212,23 +213,31 @@ export const SettingsObjectFieldEdit = () => {
                 }
               />
             </Section>
-            <Section>
-              {fieldMetadataItem.isUnique ? (
-                <H2Title
-                  title={t`Values`}
-                  description={t`The values of this field must be unique`}
-                />
-              ) : (
-                <H2Title
-                  title={t`Values`}
-                  description={t`The values of this field`}
-                />
-              )}
-              <SettingsDataModelFieldSettingsFormCard
-                fieldMetadataItem={fieldMetadataItem}
-                objectMetadataItem={objectMetadataItem}
-              />
-            </Section>
+            {
+              //patch - awaiting refacto on many to many relations - https://github.com/twentyhq/core-team-issues/issues/186
+              fieldMetadataItem.name !== CoreObjectNamePlural.NoteTarget &&
+                fieldMetadataItem.name !== CoreObjectNamePlural.TaskTarget && (
+                  <>
+                    <Section>
+                      {fieldMetadataItem.isUnique ? (
+                        <H2Title
+                          title={t`Values`}
+                          description={t`The values of this field must be unique`}
+                        />
+                      ) : (
+                        <H2Title
+                          title={t`Values`}
+                          description={t`The values of this field`}
+                        />
+                      )}
+                      <SettingsDataModelFieldSettingsFormCard
+                        fieldMetadataItem={fieldMetadataItem}
+                        objectMetadataItem={objectMetadataItem}
+                      />
+                    </Section>
+                  </>
+                )
+            }
             <Section>
               <H2Title
                 title={t`Description`}
@@ -238,6 +247,7 @@ export const SettingsObjectFieldEdit = () => {
                 fieldMetadataItem={fieldMetadataItem}
               />
             </Section>
+
             {!isLabelIdentifier && (
               <Section>
                 <H2Title


### PR DESCRIPTION
EDITED ⬇️ 

Context
When fixing relation fields preview in this [PR](https://github.com/twentyhq/twenty/pull/11745/files#diff-10073c6310707810d002bceef587936ed5d31dba2ea5babbb4d452a7f1e756b5R31-R35), I've (try to) fixed NoteTarget (and TaskTarget) field preview adding [fallback record](https://github.com/twentyhq/twenty/pull/11745/files#diff-da3ccb70824f1792351457dbee66dd75e48e45ff8e6e0f768f402e35256377bcR54-R61).

It introduces the sentry error (findOneNote/Task with 'fallback-id') : when activity is soft deleted, associated activityTarget is not. In TableView, when displaying Note/Task field in view for a record with a soft deleted ntoe/task, 'fallback-id' record chip is clickable.

Solution - seen with Charles - Remove fallback-id record + Hide NoteTarget and TaskTarget field preview - awaiting ManyToMany relation are updated in few weeks

<img width="1160" alt="Screenshot 2025-05-23 at 11 07 06" src="https://github.com/user-attachments/assets/73b1629a-67a0-43cc-ac2c-ddeea524ed6e" />


Test - RelationFromManyFieldDisplay in Table view & Settings field preview

closes https://github.com/twentyhq/twenty/issues/12218