### PR TITLE
fix: Exit Settings link remains stuck after shortcut navigation (#12235)

### DIFF
--- a/packages/twenty-front/src/modules/app/effect-components/GotoHotkeysEffectsProvider.tsx
+++ b/packages/twenty-front/src/modules/app/effect-components/GotoHotkeysEffectsProvider.tsx
@@ -20,9 +20,7 @@ export const GotoHotkeysEffectsProvider = () => {
         () => {
           set(isNavigationDrawerExpandedState, true);
           set(navigationDrawerExpandedMemorizedState, true);
-          // set(navigationMemorizedUrlState, location.pathname + location.search);
         },
-      [location.pathname, location.search],
     ),
   });
 

--- a/packages/twenty-front/src/modules/app/effect-components/GotoHotkeysEffectsProvider.tsx
+++ b/packages/twenty-front/src/modules/app/effect-components/GotoHotkeysEffectsProvider.tsx
@@ -2,7 +2,6 @@ import { GoToHotkeyItemEffect } from '@/app/effect-components/GoToHotkeyItemEffe
 import { useNonSystemActiveObjectMetadataItems } from '@/object-metadata/hooks/useNonSystemActiveObjectMetadataItems';
 import { isNavigationDrawerExpandedState } from '@/ui/navigation/states/isNavigationDrawerExpanded';
 import { navigationDrawerExpandedMemorizedState } from '@/ui/navigation/states/navigationDrawerExpandedMemorizedState';
-import { navigationMemorizedUrlState } from '@/ui/navigation/states/navigationMemorizedUrlState';
 import { useGoToHotkeys } from '@/ui/utilities/hotkey/hooks/useGoToHotkeys';
 import { useLocation } from 'react-router-dom';
 import { useRecoilCallback } from 'recoil';
@@ -21,7 +20,7 @@ export const GotoHotkeysEffectsProvider = () => {
         () => {
           set(isNavigationDrawerExpandedState, true);
           set(navigationDrawerExpandedMemorizedState, true);
-          set(navigationMemorizedUrlState, location.pathname + location.search);
+          // set(navigationMemorizedUrlState, location.pathname + location.search);
         },
       [location.pathname, location.search],
     ),


### PR DESCRIPTION
## 🛠️ What this PR fixes
Fixes #12235

The "Exit Settings" link was stuck after navigating with a keyboard shortcut.
This PR ensures the Exit Settings button works correctly.

## 🎥 Demo
Attached video shows the issue fixed and the link behaving as expected.

https://github.com/user-attachments/assets/47b986cf-10d9-4afa-a797-822221c84e24

