### PR TITLE
Display "Untitled" in MultipleRecordPicker

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-picker/multiple-record-picker/components/MultipleRecordPickerMenuItemContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-picker/multiple-record-picker/components/MultipleRecordPickerMenuItemContent.tsx
@@ -10,6 +10,7 @@ import { SelectableListItem } from '@/ui/layout/selectable-list/components/Selec
 import { isSelectedItemIdComponentFamilySelector } from '@/ui/layout/selectable-list/states/selectors/isSelectedItemIdComponentFamilySelector';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useRecoilComponentFamilyValueV2 } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentFamilyValueV2';
+import { capitalize } from 'twenty-shared/utils';
 import { Avatar } from 'twenty-ui/display';
 import { MenuItemMultiSelectAvatar } from 'twenty-ui/navigation';
 import { SearchRecord } from '~/generated-metadata/graphql';
@@ -58,6 +59,10 @@ export const MultipleRecordPickerMenuItemContent = ({
     });
   };
 
+  const displayText =
+    searchRecord.label?.trim() ||
+    `Untitled ${capitalize(objectMetadataItem.nameSingular)}`;
+
   return (
     <StyledSelectableItem
       itemId={searchRecord.recordId}
@@ -72,12 +77,12 @@ export const MultipleRecordPickerMenuItemContent = ({
           <Avatar
             avatarUrl={searchRecord.imageUrl}
             placeholderColorSeed={searchRecord.recordId}
-            placeholder={searchRecord.label}
+            placeholder={displayText}
             size="md"
             type={getAvatarType(objectMetadataItem.nameSingular) ?? 'rounded'}
           />
         }
-        text={searchRecord.label}
+        text={displayText}
       />
     </StyledSelectableItem>
   );


### PR DESCRIPTION
Fixes #11940 

Display untitled with the object name for untitled records in `MultipleRecordPicker`:

![CleanShot 2025-05-23 at 11 29 20@2x](https://github.com/user-attachments/assets/062df33c-5c7a-4170-a973-8a1fc1b04729)
