### PR TITLE
Fix wrong email logo url

### DIFF
--- a/packages/twenty-emails/src/components/Logo.tsx
+++ b/packages/twenty-emails/src/components/Logo.tsx
@@ -7,7 +7,7 @@ const logoStyle = {
 export const Logo = () => {
   return (
     <Img
-      src="https://app.twenty.com/icons/windows11/Square150x150Logo.scale-100.png"
+      src="https://app.twenty.com/images/icons/windows11/Square150x150Logo.scale-100.png"
       alt="Twenty logo"
       width="40"
       height="40"


### PR DESCRIPTION
Fix wrong twenty logo url
It does not fix all the https://github.com/twentyhq/twenty/issues/11744 issue, but this is a small step. The other step is pretty big so I split the ticket in 2 PRs