### PR TITLE
fix(auth): prevent unexpected form effect trigger

### DIFF
--- a/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpWorkspaceScopeFormEffect.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpWorkspaceScopeFormEffect.tsx
@@ -97,6 +97,7 @@ export const SignInUpWorkspaceScopeFormEffect = () => {
     }
 
     if (
+      signInUpStep !== SignInUpStep.Password &&
       signInUpStep !== SignInUpStep.Email &&
       isDefined(email) &&
       workspaceAuthProviders.password &&


### PR DESCRIPTION
Ensure the form effect is not erroneously triggered when the sign-in step is not related to email or password. This resolves potential state inconsistencies during the authentication flow.


Fix #12176 