### PR TITLE
Update Makefile in local setup to clean postgres instead of pg-spile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 postgres-on-docker:
 	docker run -d \
 	--name twenty_pg \
-	-e PGUSER_SUPERUSER=postgres \
-	-e PGPASSWORD_SUPERUSER=postgres \
+	-e POSTGRES_USER=postgres \
+	-e POSTGRES_PASSWORD=postgres \
 	-e ALLOW_NOSSL=true \
 	-v twenty_db_data:/home/postgres/pgdata \
 	-p 5432:5432 \
-	twentycrm/twenty-postgres-spilo:latest
+	postgres:16
 	@echo "Waiting for PostgreSQL to be ready..."
 	@until docker exec twenty_pg psql -U postgres -d postgres \
 		-c 'SELECT pg_is_in_recovery();' 2>/dev/null | grep -q 'f'; do \

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ postgres-on-docker:
 	-e POSTGRES_USER=postgres \
 	-e POSTGRES_PASSWORD=postgres \
 	-e ALLOW_NOSSL=true \
-	-v twenty_db_data:/home/postgres/pgdata \
+	-v twenty_db_data:/var/lib/postgresql/data \
 	-p 5432:5432 \
 	postgres:16
 	@echo "Waiting for PostgreSQL to be ready..."


### PR DESCRIPTION
In Makefile used for Local dev setup spilo container is still in the use despite deprecating it in 0.43.0