### PR TITLE
Fix #11075 dropdown reload in LinkAvatarChip

### DIFF
--- a/packages/twenty-front/src/modules/ui/utilities/pointer-event/hooks/useListenClickOutside.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/pointer-event/hooks/useListenClickOutside.ts
@@ -190,6 +190,13 @@ export const useListenClickOutside = <T extends Element>({
           }
 
           if (shouldTrigger) {
+            if (
+              event.target instanceof Element &&
+              event.target.closest('a') != null
+            ) {
+              event.preventDefault();
+              event.stopImmediatePropagation();
+            }
             callback(event);
           }
         }


### PR DESCRIPTION
**Bug:** #11075

When a dropdown was open, clicking any <a> inside the dropdown would immediately trigger navigation (full-page reload), bypassing the “close dropdown first” behavior. This was inconsistent with other UI elements, which always require one click to close the dropdown and a second click to open the side-panel.

**Root Cause:**  
Our click-outside listener would close the dropdown on the first click, but because we never called `event.preventDefault()` on link clicks, the browser still followed the `<a>`’s href immediately.

**Fix:**  
In `useListenClickOutside`, before invoking the outside-click callback, we now check:
```ts
if (event.target instanceof Element && event.target.closest('a')) {
  event.preventDefault();
  event.stopImmediatePropagation();
}