### PR TITLE
Pass client config during build

### DIFF
--- a/packages/twenty-front/src/generated-metadata/graphql.ts
+++ b/packages/twenty-front/src/generated-metadata/graphql.ts
@@ -106,7 +106,6 @@ export type ApprovedAccessDomain = {
 export type AuthProviders = {
   __typename?: 'AuthProviders';
   google: Scalars['Boolean']['output'];
-  magicLink: Scalars['Boolean']['output'];
   microsoft: Scalars['Boolean']['output'];
   password: Scalars['Boolean']['output'];
   sso: Array<SsoIdentityProvider>;

--- a/packages/twenty-front/src/generated/graphql.tsx
+++ b/packages/twenty-front/src/generated/graphql.tsx
@@ -98,7 +98,6 @@ export type ApprovedAccessDomain = {
 export type AuthProviders = {
   __typename?: 'AuthProviders';
   google: Scalars['Boolean'];
-  magicLink: Scalars['Boolean'];
   microsoft: Scalars['Boolean'];
   password: Scalars['Boolean'];
   sso: Array<SsoIdentityProvider>;
@@ -2697,7 +2696,7 @@ export type GetPublicWorkspaceDataByDomainQueryVariables = Exact<{
 }>;
 
 
-export type GetPublicWorkspaceDataByDomainQuery = { __typename?: 'Query', getPublicWorkspaceDataByDomain: { __typename?: 'PublicWorkspaceDataOutput', id: string, logo?: string | null, displayName?: string | null, workspaceUrls: { __typename?: 'WorkspaceUrls', subdomainUrl: string, customUrl?: string | null }, authProviders: { __typename?: 'AuthProviders', google: boolean, magicLink: boolean, password: boolean, microsoft: boolean, sso: Array<{ __typename?: 'SSOIdentityProvider', id: string, name: string, type: IdentityProviderType, status: SsoIdentityProviderStatus, issuer: string }> } } };
+export type GetPublicWorkspaceDataByDomainQuery = { __typename?: 'Query', getPublicWorkspaceDataByDomain: { __typename?: 'PublicWorkspaceDataOutput', id: string, logo?: string | null, displayName?: string | null, workspaceUrls: { __typename?: 'WorkspaceUrls', subdomainUrl: string, customUrl?: string | null }, authProviders: { __typename?: 'AuthProviders', google: boolean, password: boolean, microsoft: boolean, sso: Array<{ __typename?: 'SSOIdentityProvider', id: string, name: string, type: IdentityProviderType, status: SsoIdentityProviderStatus, issuer: string }> } } };
 
 export type ValidatePasswordResetTokenQueryVariables = Exact<{
   token: Scalars['String'];
@@ -4258,7 +4257,6 @@ export const GetPublicWorkspaceDataByDomainDocument = gql`
         issuer
       }
       google
-      magicLink
       password
       microsoft
     }

--- a/packages/twenty-front/src/modules/auth/graphql/queries/getPublicWorkspaceDataByDomain.ts
+++ b/packages/twenty-front/src/modules/auth/graphql/queries/getPublicWorkspaceDataByDomain.ts
@@ -19,7 +19,6 @@ export const GET_PUBLIC_WORKSPACE_DATA_BY_DOMAIN = gql`
           issuer
         }
         google
-        magicLink
         password
         microsoft
       }

--- a/packages/twenty-front/src/modules/client-config/graphql/queries/getClientConfig.ts
+++ b/packages/twenty-front/src/modules/client-config/graphql/queries/getClientConfig.ts
@@ -1,5 +1,8 @@
 import { gql } from '@apollo/client';
 
+// NOTE: This GraphQL query is now primarily used as fallback for local development
+// For production use, the client config is injected via generateFrontConfig()
+// if the backend serves the frontend, or during the build process for S3-hosted frontends.
 export const GET_CLIENT_CONFIG = gql`
   query GetClientConfig {
     clientConfig {

--- a/packages/twenty-front/src/modules/client-config/states/authProvidersState.ts
+++ b/packages/twenty-front/src/modules/client-config/states/authProvidersState.ts
@@ -1,12 +1,11 @@
-import { AuthProviders } from '~/generated/graphql';
 import { createState } from 'twenty-ui/utilities';
+import { AuthProviders } from '~/generated/graphql';
 
 export const authProvidersState = createState<AuthProviders>({
   key: 'authProvidersState',
   defaultValue: {
-    google: true,
-    magicLink: false,
-    password: true,
+    google: false,
+    password: false,
     microsoft: false,
     sso: [],
   },

--- a/packages/twenty-front/src/modules/client-config/utils/getClientConfigFromWindow.ts
+++ b/packages/twenty-front/src/modules/client-config/utils/getClientConfigFromWindow.ts
@@ -1,0 +1,15 @@
+import { ClientConfig } from '~/generated/graphql';
+
+export const getClientConfigFromWindow = (): ClientConfig | null => {
+  try {
+    const clientConfigString = window._env_?.TWENTY_CLIENT_CONFIG;
+    if (clientConfigString != null && clientConfigString !== '') {
+      return JSON.parse(clientConfigString) as ClientConfig;
+    }
+    return null;
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.warn('Failed to read client config from window object:', error);
+    return null;
+  }
+};

--- a/packages/twenty-front/src/modules/client-config/utils/isClientConfigAvailableFromWindow.ts
+++ b/packages/twenty-front/src/modules/client-config/utils/isClientConfigAvailableFromWindow.ts
@@ -1,0 +1,3 @@
+export const isClientConfigAvailableFromWindow = (): boolean => {
+  return Boolean(window._env_?.TWENTY_CLIENT_CONFIG);
+};

--- a/packages/twenty-front/src/modules/settings/security/components/SettingsSecurityAuthProvidersOptionsList.tsx
+++ b/packages/twenty-front/src/modules/settings/security/components/SettingsSecurityAuthProvidersOptionsList.tsx
@@ -7,17 +7,17 @@ import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import styled from '@emotion/styled';
 import { useLingui } from '@lingui/react/macro';
 import { useRecoilState, useRecoilValue } from 'recoil';
-import { AuthProviders } from '~/generated-metadata/graphql';
-import { useUpdateWorkspaceMutation } from '~/generated/graphql';
-import { capitalize } from 'twenty-shared/utils';
 import { ConnectedAccountProvider } from 'twenty-shared/types';
-import { Card } from 'twenty-ui/layout';
+import { capitalize } from 'twenty-shared/utils';
 import {
   IconGoogle,
   IconLink,
   IconMicrosoft,
   IconPassword,
 } from 'twenty-ui/display';
+import { Card } from 'twenty-ui/layout';
+import { AuthProviders } from '~/generated-metadata/graphql';
+import { useUpdateWorkspaceMutation } from '~/generated/graphql';
 
 const StyledSettingsSecurityOptionsList = styled.div`
   display: flex;
@@ -46,7 +46,7 @@ export const SettingsSecurityAuthProvidersOptionsList = () => {
   };
 
   const toggleAuthMethod = async (
-    authProvider: keyof Omit<AuthProviders, '__typename' | 'magicLink' | 'sso'>,
+    authProvider: keyof Omit<AuthProviders, '__typename' | 'sso'>,
   ) => {
     if (!currentWorkspace?.id) {
       throw new Error(t`User is not logged in`);

--- a/packages/twenty-front/src/testing/graphqlMocks.ts
+++ b/packages/twenty-front/src/testing/graphqlMocks.ts
@@ -7,8 +7,8 @@ import { FIND_MANY_OBJECT_METADATA_ITEMS } from '@/object-metadata/graphql/queri
 import { GET_CURRENT_USER } from '@/users/graphql/queries/getCurrentUser';
 import { REACT_APP_SERVER_BASE_URL } from '~/config';
 import {
-  getCompaniesMock,
-  getCompanyDuplicateMock,
+    getCompaniesMock,
+    getCompanyDuplicateMock,
 } from '~/testing/mock-data/companies';
 import { mockedClientConfig } from '~/testing/mock-data/config';
 import { mockedFavoritesData } from '~/testing/mock-data/favorite';
@@ -27,9 +27,9 @@ import { mockedStandardObjectMetadataQueryResult } from '~/testing/mock-data/gen
 import { getRolesMock } from '~/testing/mock-data/roles';
 import { mockedTasks } from '~/testing/mock-data/tasks';
 import {
-  getWorkflowMock,
-  getWorkflowVersionsMock,
-  workflowQueryResult,
+    getWorkflowMock,
+    getWorkflowVersionsMock,
+    workflowQueryResult,
 } from '~/testing/mock-data/workflow';
 import { oneSucceededWorkflowRunQueryResult } from '~/testing/mock-data/workflow-run';
 import { mockedRemoteServers } from './mock-data/remote-servers';
@@ -100,9 +100,8 @@ export const graphqlMocks = {
               },
               authProviders: {
                 google: true,
-                microsoft: false,
                 password: true,
-                magicLink: false,
+                microsoft: true,
                 sso: [],
               },
             },

--- a/packages/twenty-front/src/testing/graphqlMocks.ts
+++ b/packages/twenty-front/src/testing/graphqlMocks.ts
@@ -7,8 +7,8 @@ import { FIND_MANY_OBJECT_METADATA_ITEMS } from '@/object-metadata/graphql/queri
 import { GET_CURRENT_USER } from '@/users/graphql/queries/getCurrentUser';
 import { REACT_APP_SERVER_BASE_URL } from '~/config';
 import {
-    getCompaniesMock,
-    getCompanyDuplicateMock,
+  getCompaniesMock,
+  getCompanyDuplicateMock,
 } from '~/testing/mock-data/companies';
 import { mockedClientConfig } from '~/testing/mock-data/config';
 import { mockedFavoritesData } from '~/testing/mock-data/favorite';
@@ -27,9 +27,9 @@ import { mockedStandardObjectMetadataQueryResult } from '~/testing/mock-data/gen
 import { getRolesMock } from '~/testing/mock-data/roles';
 import { mockedTasks } from '~/testing/mock-data/tasks';
 import {
-    getWorkflowMock,
-    getWorkflowVersionsMock,
-    workflowQueryResult,
+  getWorkflowMock,
+  getWorkflowVersionsMock,
+  workflowQueryResult,
 } from '~/testing/mock-data/workflow';
 import { oneSucceededWorkflowRunQueryResult } from '~/testing/mock-data/workflow-run';
 import { mockedRemoteServers } from './mock-data/remote-servers';

--- a/packages/twenty-front/src/testing/mock-data/config.ts
+++ b/packages/twenty-front/src/testing/mock-data/config.ts
@@ -6,7 +6,6 @@ export const mockedClientConfig: ClientConfig = {
   isEmailVerificationRequired: false,
   authProviders: {
     google: true,
-    magicLink: false,
     password: true,
     microsoft: false,
     sso: [],

--- a/packages/twenty-front/src/testing/mock-data/publicWorkspaceDataBySubdomain.ts
+++ b/packages/twenty-front/src/testing/mock-data/publicWorkspaceDataBySubdomain.ts
@@ -12,10 +12,9 @@ export const mockedPublicWorkspaceDataBySubdomain: GetPublicWorkspaceDataByDomai
     },
     authProviders: {
       __typename: 'AuthProviders',
-      sso: [],
       google: true,
-      magicLink: false,
       password: true,
       microsoft: false,
+      sso: [],
     },
   };

--- a/packages/twenty-server/src/engine/core-modules/client-config/client-config.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/client-config/client-config.module.ts
@@ -3,9 +3,10 @@ import { Module } from '@nestjs/common';
 import { DomainManagerModule } from 'src/engine/core-modules/domain-manager/domain-manager.module';
 
 import { ClientConfigResolver } from './client-config.resolver';
+import { ClientConfigService } from './client-config.service';
 
 @Module({
   imports: [DomainManagerModule],
-  providers: [ClientConfigResolver],
+  providers: [ClientConfigResolver, ClientConfigService],
 })
 export class ClientConfigModule {}

--- a/packages/twenty-server/src/engine/core-modules/client-config/client-config.resolver.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/client-config/client-config.resolver.spec.ts
@@ -4,6 +4,7 @@ import { DomainManagerService } from 'src/engine/core-modules/domain-manager/ser
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 
 import { ClientConfigResolver } from './client-config.resolver';
+import { ClientConfigService } from './client-config.service';
 
 describe('ClientConfigResolver', () => {
   let resolver: ClientConfigResolver;
@@ -12,6 +13,10 @@ describe('ClientConfigResolver', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ClientConfigResolver,
+        {
+          provide: ClientConfigService,
+          useValue: {},
+        },
         {
           provide: TwentyConfigService,
           useValue: {},

--- a/packages/twenty-server/src/engine/core-modules/client-config/client-config.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/client-config/client-config.resolver.ts
@@ -1,107 +1,14 @@
 import { Query, Resolver } from '@nestjs/graphql';
 
-import { NodeEnvironment } from 'src/engine/core-modules/twenty-config/interfaces/node-environment.interface';
-
-import { DomainManagerService } from 'src/engine/core-modules/domain-manager/services/domain-manager.service';
-import { PUBLIC_FEATURE_FLAGS } from 'src/engine/core-modules/feature-flag/constants/public-feature-flag.const';
-import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
-
 import { ClientConfig } from './client-config.entity';
+import { ClientConfigService } from './client-config.service';
 
 @Resolver()
 export class ClientConfigResolver {
-  constructor(
-    private twentyConfigService: TwentyConfigService,
-    private domainManagerService: DomainManagerService,
-  ) {}
+  constructor(private clientConfigService: ClientConfigService) {}
 
   @Query(() => ClientConfig)
   async clientConfig(): Promise<ClientConfig> {
-    const clientConfig: ClientConfig = {
-      billing: {
-        isBillingEnabled: this.twentyConfigService.get('IS_BILLING_ENABLED'),
-        billingUrl: this.twentyConfigService.get('BILLING_PLAN_REQUIRED_LINK'),
-        trialPeriods: [
-          {
-            duration: this.twentyConfigService.get(
-              'BILLING_FREE_TRIAL_WITH_CREDIT_CARD_DURATION_IN_DAYS',
-            ),
-            isCreditCardRequired: true,
-          },
-          {
-            duration: this.twentyConfigService.get(
-              'BILLING_FREE_TRIAL_WITHOUT_CREDIT_CARD_DURATION_IN_DAYS',
-            ),
-            isCreditCardRequired: false,
-          },
-        ],
-      },
-      authProviders: {
-        google: this.twentyConfigService.get('AUTH_GOOGLE_ENABLED'),
-        magicLink: false,
-        password: this.twentyConfigService.get('AUTH_PASSWORD_ENABLED'),
-        microsoft: this.twentyConfigService.get('AUTH_MICROSOFT_ENABLED'),
-        sso: [],
-      },
-      signInPrefilled: this.twentyConfigService.get('SIGN_IN_PREFILLED'),
-      isMultiWorkspaceEnabled: this.twentyConfigService.get(
-        'IS_MULTIWORKSPACE_ENABLED',
-      ),
-      isEmailVerificationRequired: this.twentyConfigService.get(
-        'IS_EMAIL_VERIFICATION_REQUIRED',
-      ),
-      defaultSubdomain: this.twentyConfigService.get('DEFAULT_SUBDOMAIN'),
-      frontDomain: this.domainManagerService.getFrontUrl().hostname,
-      debugMode:
-        this.twentyConfigService.get('NODE_ENV') ===
-        NodeEnvironment.development,
-      support: {
-        supportDriver: this.twentyConfigService.get('SUPPORT_DRIVER'),
-        supportFrontChatId: this.twentyConfigService.get(
-          'SUPPORT_FRONT_CHAT_ID',
-        ),
-      },
-      sentry: {
-        environment: this.twentyConfigService.get('SENTRY_ENVIRONMENT'),
-        release: this.twentyConfigService.get('APP_VERSION'),
-        dsn: this.twentyConfigService.get('SENTRY_FRONT_DSN'),
-      },
-      captcha: {
-        provider: this.twentyConfigService.get('CAPTCHA_DRIVER'),
-        siteKey: this.twentyConfigService.get('CAPTCHA_SITE_KEY'),
-      },
-      chromeExtensionId: this.twentyConfigService.get('CHROME_EXTENSION_ID'),
-      api: {
-        mutationMaximumAffectedRecords: this.twentyConfigService.get(
-          'MUTATION_MAXIMUM_AFFECTED_RECORDS',
-        ),
-      },
-      isAttachmentPreviewEnabled: this.twentyConfigService.get(
-        'IS_ATTACHMENT_PREVIEW_ENABLED',
-      ),
-      analyticsEnabled: this.twentyConfigService.get('ANALYTICS_ENABLED'),
-      canManageFeatureFlags:
-        this.twentyConfigService.get('NODE_ENV') ===
-          NodeEnvironment.development ||
-        this.twentyConfigService.get('IS_BILLING_ENABLED'),
-      publicFeatureFlags: PUBLIC_FEATURE_FLAGS,
-      isMicrosoftMessagingEnabled: this.twentyConfigService.get(
-        'MESSAGING_PROVIDER_MICROSOFT_ENABLED',
-      ),
-      isMicrosoftCalendarEnabled: this.twentyConfigService.get(
-        'CALENDAR_PROVIDER_MICROSOFT_ENABLED',
-      ),
-      isGoogleMessagingEnabled: this.twentyConfigService.get(
-        'MESSAGING_PROVIDER_GMAIL_ENABLED',
-      ),
-      isGoogleCalendarEnabled: this.twentyConfigService.get(
-        'CALENDAR_PROVIDER_GOOGLE_ENABLED',
-      ),
-      isConfigVariablesInDbEnabled: this.twentyConfigService.get(
-        'IS_CONFIG_VARIABLES_IN_DB_ENABLED',
-      ),
-    };
-
-    return Promise.resolve(clientConfig);
+    return this.clientConfigService.generateClientConfig();
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/client-config/client-config.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/client-config/client-config.service.ts
@@ -1,0 +1,103 @@
+import { Injectable } from '@nestjs/common';
+
+import { NodeEnvironment } from 'src/engine/core-modules/twenty-config/interfaces/node-environment.interface';
+
+import { DomainManagerService } from 'src/engine/core-modules/domain-manager/services/domain-manager.service';
+import { PUBLIC_FEATURE_FLAGS } from 'src/engine/core-modules/feature-flag/constants/public-feature-flag.const';
+import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
+
+import { ClientConfig } from './client-config.entity';
+
+@Injectable()
+export class ClientConfigService {
+  constructor(
+    private twentyConfigService: TwentyConfigService,
+    private domainManagerService: DomainManagerService,
+  ) {}
+
+  generateClientConfig(): ClientConfig {
+    return {
+      billing: {
+        isBillingEnabled: this.twentyConfigService.get('IS_BILLING_ENABLED'),
+        billingUrl: this.twentyConfigService.get('BILLING_PLAN_REQUIRED_LINK'),
+        trialPeriods: [
+          {
+            duration: this.twentyConfigService.get(
+              'BILLING_FREE_TRIAL_WITH_CREDIT_CARD_DURATION_IN_DAYS',
+            ),
+            isCreditCardRequired: true,
+          },
+          {
+            duration: this.twentyConfigService.get(
+              'BILLING_FREE_TRIAL_WITHOUT_CREDIT_CARD_DURATION_IN_DAYS',
+            ),
+            isCreditCardRequired: false,
+          },
+        ],
+      },
+      authProviders: {
+        google: this.twentyConfigService.get('AUTH_GOOGLE_ENABLED'),
+        password: this.twentyConfigService.get('AUTH_PASSWORD_ENABLED'),
+        microsoft: this.twentyConfigService.get('AUTH_MICROSOFT_ENABLED'),
+        sso: [],
+      },
+      signInPrefilled: this.twentyConfigService.get('SIGN_IN_PREFILLED'),
+      isMultiWorkspaceEnabled: this.twentyConfigService.get(
+        'IS_MULTIWORKSPACE_ENABLED',
+      ),
+      isEmailVerificationRequired: this.twentyConfigService.get(
+        'IS_EMAIL_VERIFICATION_REQUIRED',
+      ),
+      defaultSubdomain: this.twentyConfigService.get('DEFAULT_SUBDOMAIN'),
+      frontDomain: this.domainManagerService.getFrontUrl().hostname,
+      debugMode:
+        this.twentyConfigService.get('NODE_ENV') ===
+        NodeEnvironment.development,
+      support: {
+        supportDriver: this.twentyConfigService.get('SUPPORT_DRIVER'),
+        supportFrontChatId: this.twentyConfigService.get(
+          'SUPPORT_FRONT_CHAT_ID',
+        ),
+      },
+      sentry: {
+        environment: this.twentyConfigService.get('SENTRY_ENVIRONMENT'),
+        release: this.twentyConfigService.get('APP_VERSION'),
+        dsn: this.twentyConfigService.get('SENTRY_FRONT_DSN'),
+      },
+      captcha: {
+        provider: this.twentyConfigService.get('CAPTCHA_DRIVER'),
+        siteKey: this.twentyConfigService.get('CAPTCHA_SITE_KEY'),
+      },
+      chromeExtensionId: this.twentyConfigService.get('CHROME_EXTENSION_ID'),
+      api: {
+        mutationMaximumAffectedRecords: this.twentyConfigService.get(
+          'MUTATION_MAXIMUM_AFFECTED_RECORDS',
+        ),
+      },
+      isAttachmentPreviewEnabled: this.twentyConfigService.get(
+        'IS_ATTACHMENT_PREVIEW_ENABLED',
+      ),
+      analyticsEnabled: this.twentyConfigService.get('ANALYTICS_ENABLED'),
+      canManageFeatureFlags:
+        this.twentyConfigService.get('NODE_ENV') ===
+          NodeEnvironment.development ||
+        this.twentyConfigService.get('IS_BILLING_ENABLED'),
+      publicFeatureFlags: PUBLIC_FEATURE_FLAGS,
+      isMicrosoftMessagingEnabled: this.twentyConfigService.get(
+        'MESSAGING_PROVIDER_MICROSOFT_ENABLED',
+      ),
+      isMicrosoftCalendarEnabled: this.twentyConfigService.get(
+        'CALENDAR_PROVIDER_MICROSOFT_ENABLED',
+      ),
+      isGoogleMessagingEnabled: this.twentyConfigService.get(
+        'MESSAGING_PROVIDER_GMAIL_ENABLED',
+      ),
+      isGoogleCalendarEnabled: this.twentyConfigService.get(
+        'CALENDAR_PROVIDER_GOOGLE_ENABLED',
+      ),
+      isConfigVariablesInDbEnabled: this.twentyConfigService.get(
+        'IS_CONFIG_VARIABLES_IN_DB_ENABLED',
+      ),
+    };
+  }
+}

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/twenty-config.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/twenty-config.service.ts
@@ -284,9 +284,12 @@ export class TwentyConfigService {
 
   private regenerateFrontConfig(): void {
     try {
-      const clientConfigService = this.moduleRef.get(ClientConfigService, {
-        strict: false,
-      });
+      const clientConfigService = this.moduleRef.get<ClientConfigService>(
+        'ClientConfigService',
+        {
+          strict: false,
+        },
+      );
 
       if (clientConfigService) {
         generateFrontConfig(clientConfigService);

--- a/packages/twenty-server/src/engine/core-modules/workspace/dtos/public-workspace-data-output.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/dtos/public-workspace-data-output.ts
@@ -1,11 +1,11 @@
-import { ObjectType, Field } from '@nestjs/graphql';
+import { Field, ObjectType } from '@nestjs/graphql';
 
-import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import {
-  IdentityProviderType,
-  SSOIdentityProviderStatus,
+    IdentityProviderType,
+    SSOIdentityProviderStatus,
 } from 'src/engine/core-modules/sso/workspace-sso-identity-provider.entity';
 import { WorkspaceUrls } from 'src/engine/core-modules/workspace/dtos/workspace-urls.dto';
+import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 
 @ObjectType()
 export class SSOIdentityProvider {
@@ -32,9 +32,6 @@ export class AuthProviders {
 
   @Field(() => Boolean)
   google: boolean;
-
-  @Field(() => Boolean)
-  magicLink: boolean;
 
   @Field(() => Boolean)
   password: boolean;

--- a/packages/twenty-server/src/engine/core-modules/workspace/dtos/public-workspace-data-output.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/dtos/public-workspace-data-output.ts
@@ -1,8 +1,8 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 
 import {
-    IdentityProviderType,
-    SSOIdentityProviderStatus,
+  IdentityProviderType,
+  SSOIdentityProviderStatus,
 } from 'src/engine/core-modules/sso/workspace-sso-identity-provider.entity';
 import { WorkspaceUrls } from 'src/engine/core-modules/workspace/dtos/workspace-urls.dto';
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';

--- a/packages/twenty-server/src/engine/core-modules/workspace/utils/__tests__/get-auth-providers-by-workspace.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/utils/__tests__/get-auth-providers-by-workspace.util.spec.ts
@@ -1,10 +1,10 @@
+import {
+    IdentityProviderType,
+    SSOIdentityProviderStatus,
+    WorkspaceSSOIdentityProvider,
+} from 'src/engine/core-modules/sso/workspace-sso-identity-provider.entity';
 import { getAuthProvidersByWorkspace } from 'src/engine/core-modules/workspace/utils/get-auth-providers-by-workspace.util';
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
-import {
-  IdentityProviderType,
-  SSOIdentityProviderStatus,
-  WorkspaceSSOIdentityProvider,
-} from 'src/engine/core-modules/sso/workspace-sso-identity-provider.entity';
 
 describe('getAuthProvidersByWorkspace', () => {
   const mockWorkspace = {
@@ -16,7 +16,6 @@ describe('getAuthProvidersByWorkspace', () => {
         id: 'sso1',
         name: 'SSO Provider 1',
         type: IdentityProviderType.SAML,
-
         status: SSOIdentityProviderStatus.Active,
         issuer: 'sso1.example.com',
       },
@@ -28,7 +27,6 @@ describe('getAuthProvidersByWorkspace', () => {
       workspace: mockWorkspace,
       systemEnabledProviders: {
         google: true,
-        magicLink: false,
         password: true,
         microsoft: true,
         sso: [],
@@ -37,7 +35,6 @@ describe('getAuthProvidersByWorkspace', () => {
 
     expect(result).toEqual({
       google: true,
-      magicLink: false,
       password: true,
       microsoft: false,
       sso: [
@@ -45,7 +42,6 @@ describe('getAuthProvidersByWorkspace', () => {
           id: 'sso1',
           name: 'SSO Provider 1',
           type: IdentityProviderType.SAML,
-
           status: SSOIdentityProviderStatus.Active,
           issuer: 'sso1.example.com',
         },
@@ -58,7 +54,6 @@ describe('getAuthProvidersByWorkspace', () => {
       workspace: { ...mockWorkspace, workspaceSSOIdentityProviders: [] },
       systemEnabledProviders: {
         google: true,
-        magicLink: false,
         password: true,
         microsoft: true,
         sso: [],
@@ -67,7 +62,6 @@ describe('getAuthProvidersByWorkspace', () => {
 
     expect(result).toEqual({
       google: true,
-      magicLink: false,
       password: true,
       microsoft: false,
       sso: [],
@@ -89,7 +83,6 @@ describe('getAuthProvidersByWorkspace', () => {
       },
       systemEnabledProviders: {
         google: true,
-        magicLink: false,
         password: true,
         microsoft: true,
         sso: [],
@@ -98,7 +91,6 @@ describe('getAuthProvidersByWorkspace', () => {
 
     expect(result).toEqual({
       google: true,
-      magicLink: false,
       password: true,
       microsoft: false,
       sso: [],
@@ -110,7 +102,6 @@ describe('getAuthProvidersByWorkspace', () => {
       workspace: { ...mockWorkspace, isMicrosoftAuthEnabled: false },
       systemEnabledProviders: {
         google: true,
-        magicLink: false,
         password: true,
         microsoft: true,
         sso: [],
@@ -119,7 +110,6 @@ describe('getAuthProvidersByWorkspace', () => {
 
     expect(result).toEqual({
       google: true,
-      magicLink: false,
       password: true,
       microsoft: false,
       sso: [
@@ -127,7 +117,6 @@ describe('getAuthProvidersByWorkspace', () => {
           id: 'sso1',
           name: 'SSO Provider 1',
           type: IdentityProviderType.SAML,
-
           status: SSOIdentityProviderStatus.Active,
           issuer: 'sso1.example.com',
         },

--- a/packages/twenty-server/src/engine/core-modules/workspace/utils/__tests__/get-auth-providers-by-workspace.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/utils/__tests__/get-auth-providers-by-workspace.util.spec.ts
@@ -1,7 +1,7 @@
 import {
-    IdentityProviderType,
-    SSOIdentityProviderStatus,
-    WorkspaceSSOIdentityProvider,
+  IdentityProviderType,
+  SSOIdentityProviderStatus,
+  WorkspaceSSOIdentityProvider,
 } from 'src/engine/core-modules/sso/workspace-sso-identity-provider.entity';
 import { getAuthProvidersByWorkspace } from 'src/engine/core-modules/workspace/utils/get-auth-providers-by-workspace.util';
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';

--- a/packages/twenty-server/src/engine/core-modules/workspace/utils/get-auth-providers-by-workspace.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/utils/get-auth-providers-by-workspace.util.ts
@@ -19,7 +19,6 @@ export const getAuthProvidersByWorkspace = ({
 }) => {
   return {
     google: workspace.isGoogleAuthEnabled && systemEnabledProviders.google,
-    magicLink: false,
     password:
       workspace.isPasswordAuthEnabled && systemEnabledProviders.password,
     microsoft:

--- a/packages/twenty-server/src/engine/core-modules/workspace/workspace.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/workspace.resolver.ts
@@ -310,7 +310,6 @@ export class WorkspaceResolver {
 
       const systemEnabledProviders: AuthProviders = {
         google: this.twentyConfigService.get('AUTH_GOOGLE_ENABLED'),
-        magicLink: false,
         password: this.twentyConfigService.get('AUTH_PASSWORD_ENABLED'),
         microsoft: this.twentyConfigService.get('AUTH_MICROSOFT_ENABLED'),
         sso: [],

--- a/packages/twenty-server/src/main.ts
+++ b/packages/twenty-server/src/main.ts
@@ -11,6 +11,7 @@ import { graphqlUploadExpress } from 'graphql-upload';
 
 import { NodeEnvironment } from 'src/engine/core-modules/twenty-config/interfaces/node-environment.interface';
 
+import { ClientConfigService } from 'src/engine/core-modules/client-config/client-config.service';
 import { LoggerService } from 'src/engine/core-modules/logger/logger.service';
 import { getSessionStorageOptions } from 'src/engine/core-modules/session-storage/session-storage.module-factory';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
@@ -39,6 +40,7 @@ const bootstrap = async () => {
   });
   const logger = app.get(LoggerService);
   const twentyConfigService = app.get(TwentyConfigService);
+  const clientConfigService = app.get(ClientConfigService);
 
   app.use(session(getSessionStorageOptions(twentyConfigService)));
 
@@ -85,7 +87,7 @@ const bootstrap = async () => {
   );
 
   // Inject the server url in the frontend page
-  generateFrontConfig();
+  generateFrontConfig(clientConfigService);
 
   await app.listen(twentyConfigService.get('NODE_PORT'));
 };

--- a/packages/twenty-server/src/utils/generate-front-config.ts
+++ b/packages/twenty-server/src/utils/generate-front-config.ts
@@ -7,11 +7,18 @@ config({
   override: true,
 });
 
-export function generateFrontConfig(): void {
+import { ClientConfigService } from 'src/engine/core-modules/client-config/client-config.service';
+
+export function generateFrontConfig(
+  clientConfigService: ClientConfigService,
+): void {
+  const clientConfig = clientConfigService.generateClientConfig();
+
   const configObject = {
     window: {
       _env_: {
         REACT_APP_SERVER_BASE_URL: process.env.SERVER_URL,
+        TWENTY_CLIENT_CONFIG: JSON.stringify(clientConfig),
       },
     },
   };


### PR DESCRIPTION
Introduce a way to pass client config during build.

This can save ~400ms  in "time to first render" for people that are in Australia. The impact will be smaller for closer region (100ms / page load if in EU)


WIP / opening for feedback

TODO:
- re-inject in HTML when env var is modified from admin panel
- twenty-infra script