### PR TITLE
filter out 500 errors from sentry-captured errors in FE

### DIFF
--- a/packages/twenty-front/src/modules/apollo/services/apollo.factory.ts
+++ b/packages/twenty-front/src/modules/apollo/services/apollo.factory.ts
@@ -137,6 +137,9 @@ export class ApolloFactory<TCacheShape> implements ApolloManager<TCacheShape> {
                 case 'FORBIDDEN': {
                   return;
                 }
+                case 'INTERNAL_SERVER_ERROR': {
+                  return; // already caught in BE
+                }
                 default:
                   if (isDebugMode === true) {
                     logDebug(


### PR DESCRIPTION
Since https://github.com/twentyhq/twenty/pull/12286 we are now capturing in sentry graphql queries errors in the FE.
We want to exclude InternalServerErrors because they are already captured in sentry from the BE. 