### PR TITLE
Add mcp.json to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ dump.rdb
 
 .crowdin.yml
 .react-email/
+
+mcp.json


### PR DESCRIPTION
# Introduction
In order to avoid pushing secrets within an project scoped mcp.json configuration
[Related docs](https://docs.cursor.com/context/model-context-protocol#configuration-locations)