### PR TITLE
[permissions V2] Throw when objectPermissions not found in datasource

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/permissions/permissions.exception.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/permissions/permissions.exception.ts
@@ -30,6 +30,7 @@ export enum PermissionsExceptionCode {
   INVALID_SETTING = 'INVALID_SETTING',
   ROLE_NOT_EDITABLE = 'ROLE_NOT_EDITABLE',
   DEFAULT_ROLE_CANNOT_BE_DELETED = 'DEFAULT_ROLE_CANNOT_BE_DELETED',
+  NO_PERMISSIONS_FOUND_IN_DATASOURCE = 'NO_PERMISSIONS_FOUND_IN_DATASOURCE',
 }
 
 export enum PermissionsExceptionMessage {
@@ -54,4 +55,5 @@ export enum PermissionsExceptionMessage {
   INVALID_SETTING = 'Invalid permission setting (unknown value)',
   ROLE_NOT_EDITABLE = 'Role is not editable',
   DEFAULT_ROLE_CANNOT_BE_DELETED = 'Default role cannot be deleted',
+  NO_PERMISSIONS_FOUND_IN_DATASOURCE = 'No permissions found in datasource',
 }

--- a/packages/twenty-server/src/engine/metadata-modules/permissions/utils/permission-graphql-api-exception-handler.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/permissions/utils/permission-graphql-api-exception-handler.util.ts
@@ -37,6 +37,7 @@ export const permissionGraphqlApiExceptionHandler = (
     case PermissionsExceptionCode.UNKNOWN_OPERATION_NAME:
     case PermissionsExceptionCode.UNKNOWN_REQUIRED_PERMISSION:
     case PermissionsExceptionCode.NO_ROLE_FOUND_FOR_USER_WORKSPACE:
+    case PermissionsExceptionCode.NO_PERMISSIONS_FOUND_IN_DATASOURCE:
       throw error;
     default: {
       const _exhaustiveCheck: never = error.code;

--- a/packages/twenty-server/src/engine/twenty-orm/entity-manager/workspace-entity-manager.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/entity-manager/workspace-entity-manager.ts
@@ -20,7 +20,6 @@ import { FeatureFlagKey } from 'src/engine/core-modules/feature-flag/enums/featu
 import {
   PermissionsException,
   PermissionsExceptionCode,
-  PermissionsExceptionMessage,
 } from 'src/engine/metadata-modules/permissions/permissions.exception';
 import { WorkspaceDataSource } from 'src/engine/twenty-orm/datasource/workspace.datasource';
 import {
@@ -85,7 +84,11 @@ export class WorkspaceEntityManager extends EntityManager {
       if (!isDefined(objectPermissionsByRoleId?.[permissionOptions.roleId])) {
         if (isPermissionsV2Enabled) {
           throw new PermissionsException(
-            PermissionsExceptionMessage.NO_PERMISSIONS_FOUND_IN_DATASOURCE,
+            `No permissions found for role in datasource (missing ${
+              !isDefined(objectPermissionsByRoleId)
+                ? 'objectPermissionsByRoleId object'
+                : `roleId in objectPermissionsByRoleId object (${permissionOptions.roleId})`
+            })`,
             PermissionsExceptionCode.NO_PERMISSIONS_FOUND_IN_DATASOURCE,
           );
         }

--- a/packages/twenty-server/src/engine/twenty-orm/entity-manager/workspace-entity-manager.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/entity-manager/workspace-entity-manager.ts
@@ -88,10 +88,9 @@ export class WorkspaceEntityManager extends EntityManager {
             PermissionsExceptionMessage.NO_PERMISSIONS_FOUND_IN_DATASOURCE,
             PermissionsExceptionCode.NO_PERMISSIONS_FOUND_IN_DATASOURCE,
           );
-        } else {
-          objectPermissions =
-            objectPermissionsByRoleId[permissionOptions.roleId];
         }
+      } else {
+        objectPermissions = objectPermissionsByRoleId[permissionOptions.roleId];
       }
     }
 


### PR DESCRIPTION
I encountered a bug where I was missing permissions while calling searchResolver because the repository from `twentyORMManager.getRepository` was missing permissions itself.
The repository was returned from the cached repositories map using a repository key feature the roleId, the rolesVersion and featureFlagMapVersion. 
I was not able to reproduce but this error should not go unnoticed: we always expect to find objectPermissions for every roleId in the datasource now.
I was not able to understand what happened for now but I think throwing the error will help keeping an eye on it 