### PR TITLE
better logging in order to investigate later one on this kind of error

### DIFF
--- a/packages/twenty-front/src/modules/object-record/components/RecordChip.tsx
+++ b/packages/twenty-front/src/modules/object-record/components/RecordChip.tsx
@@ -48,6 +48,7 @@ export const RecordChip = ({
   const recordIndexOpenRecordIn = useRecoilValue(recordIndexOpenRecordInState);
 
   // TODO temporary until we create a record show page for Workspaces members
+
   if (
     forceDisableClick ||
     objectNameSingular === CoreObjectNameSingular.WorkspaceMember
@@ -61,7 +62,7 @@ export const RecordChip = ({
         avatarType={recordChipData.avatarType}
         avatarUrl={recordChipData.avatarUrl ?? ''}
         className={className}
-        variant={ChipVariant.Static}
+        variant={ChipVariant.Transparent}
       />
     );
   }

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/display/components/ActorFieldDisplay.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/display/components/ActorFieldDisplay.tsx
@@ -12,6 +12,7 @@ export const ActorFieldDisplay = () => {
   }
 
   const { fieldValue, name, avatarUrl } = actorFieldDisplay;
+
   return displayActorField ? (
     <ActorDisplay
       name={name}

--- a/packages/twenty-server/src/utils/__test__/get-domain-name-by-email.spec.ts
+++ b/packages/twenty-server/src/utils/__test__/get-domain-name-by-email.spec.ts
@@ -24,4 +24,55 @@ describe('getDomainNameByEmail', () => {
   it('should throw an error if domain part is empty', () => {
     expect(() => getDomainNameByEmail('user@')).toThrow('Invalid email format');
   });
+
+  // Edge cases with weird but potentially valid email formats
+  it('should handle email with plus addressing', () => {
+    expect(getDomainNameByEmail('user+tag@example.com')).toBe('example.com');
+  });
+
+  it('should handle email with dots in local part', () => {
+    expect(getDomainNameByEmail('user.name@example.com')).toBe('example.com');
+  });
+
+  it('should handle email with subdomain', () => {
+    expect(getDomainNameByEmail('user@mail.example.com')).toBe(
+      'mail.example.com',
+    );
+  });
+
+  it('should handle email with numeric domain', () => {
+    expect(getDomainNameByEmail('user@123.456.789.012')).toBe(
+      '123.456.789.012',
+    );
+  });
+
+  it('should handle email with hyphenated domain', () => {
+    expect(getDomainNameByEmail('user@my-domain.com')).toBe('my-domain.com');
+  });
+
+  it('should handle email with international domain (punycode)', () => {
+    expect(getDomainNameByEmail('user@xn--nxasmq6b.com')).toBe(
+      'xn--nxasmq6b.com',
+    );
+  });
+
+  it('should handle email with very long domain', () => {
+    const longDomain = 'a'.repeat(60) + '.com';
+
+    expect(getDomainNameByEmail(`user@${longDomain}`)).toBe(longDomain);
+  });
+
+  it('should handle email with quoted local part containing spaces', () => {
+    expect(getDomainNameByEmail('"user name"@example.com')).toBe('example.com');
+  });
+
+  xit('should handle email with special characters in quoted local part', () => {
+    expect(getDomainNameByEmail('"user@#$%"@example.com')).toBe('example.com');
+  });
+
+  xit('should handle email with quoted local part containing @', () => {
+    expect(getDomainNameByEmail('"user@local"@example.com')).toBe(
+      'example.com',
+    );
+  });
 });

--- a/packages/twenty-server/src/utils/__test__/get-domain-name-by-email.spec.ts
+++ b/packages/twenty-server/src/utils/__test__/get-domain-name-by-email.spec.ts
@@ -41,9 +41,7 @@ describe('getDomainNameByEmail', () => {
   });
 
   it('should handle email with numeric domain', () => {
-    expect(getDomainNameByEmail('user@123.456.789.012')).toBe(
-      '123.456.789.012',
-    );
+    expect(getDomainNameByEmail('user@123.456.1.2')).toBe('123.456.1.2');
   });
 
   it('should handle email with hyphenated domain', () => {
@@ -57,7 +55,7 @@ describe('getDomainNameByEmail', () => {
   });
 
   it('should handle email with very long domain', () => {
-    const longDomain = 'a'.repeat(60) + '.com';
+    const longDomain = 'a'.repeat(160) + '.com';
 
     expect(getDomainNameByEmail(`user@${longDomain}`)).toBe(longDomain);
   });

--- a/packages/twenty-server/src/utils/get-domain-name-by-email.ts
+++ b/packages/twenty-server/src/utils/get-domain-name-by-email.ts
@@ -1,5 +1,5 @@
 export const getDomainNameByEmail = (email: string) => {
-  if (!email) {
+  if (!email || email === '') {
     throw new Error('Email is required');
   }
 

--- a/packages/twenty-server/src/utils/get-domain-name-by-email.ts
+++ b/packages/twenty-server/src/utils/get-domain-name-by-email.ts
@@ -1,7 +1,7 @@
 import { isNonEmptyString } from '@sniptt/guards';
 
 export const getDomainNameByEmail = (email: string) => {
-  if (!email || !isNonEmptyString(email)) {
+  if (!isNonEmptyString(email)) {
     throw new Error('Email is required');
   }
 

--- a/packages/twenty-server/src/utils/get-domain-name-by-email.ts
+++ b/packages/twenty-server/src/utils/get-domain-name-by-email.ts
@@ -6,13 +6,13 @@ export const getDomainNameByEmail = (email: string) => {
   const fields = email.split('@');
 
   if (fields.length !== 2) {
-    throw new Error('Invalid email format');
+    throw new Error(`Invalid email format (${fields.length - 1} @) ${email}`);
   }
 
   const domain = fields[1];
 
   if (!domain) {
-    throw new Error('Invalid email format');
+    throw new Error(`Invalid email format (no domain) ${email}`);
   }
 
   return domain;

--- a/packages/twenty-server/src/utils/get-domain-name-by-email.ts
+++ b/packages/twenty-server/src/utils/get-domain-name-by-email.ts
@@ -1,5 +1,7 @@
+import { isNonEmptyString } from '@sniptt/guards';
+
 export const getDomainNameByEmail = (email: string) => {
-  if (!email || email === '') {
+  if (!email || !isNonEmptyString(email)) {
     throw new Error('Email is required');
   }
 


### PR DESCRIPTION
# extracting domain emails

Added new test cases covering weird but valid email formats (plus addressing, subdomains, international domains, etc.) to identify potential failures in the current implementation. 

Two tests with quoted local parts containing @ symbols or quotes are marked as skipped since they're expected to fail with the current simple string splitting approach. They are too exotic IMO, we should throw errors.

## Next
We will monitor errors related to this and update accordingly later on.


### Note 
technically, quotes are possible in RFC see [here](https://stackoverflow.com/questions/4816424/are-single-quotes-legal-in-the-name-part-of-an-email-address)