### PR TITLE
Add fields to database event settings

### DIFF
--- a/packages/twenty-server/src/modules/workflow/common/standard-objects/workflow-automated-trigger.workspace-entity.ts
+++ b/packages/twenty-server/src/modules/workflow/common/standard-objects/workflow-automated-trigger.workspace-entity.ts
@@ -1,19 +1,19 @@
 import { msg } from '@lingui/core/macro';
-import { Relation } from 'typeorm';
 import { FieldMetadataType } from 'twenty-shared/types';
+import { Relation } from 'typeorm';
 
 import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
 
+import { RelationOnDeleteAction } from 'src/engine/metadata-modules/relation-metadata/relation-metadata.entity';
 import { BaseWorkspaceEntity } from 'src/engine/twenty-orm/base.workspace-entity';
 import { WorkspaceEntity } from 'src/engine/twenty-orm/decorators/workspace-entity.decorator';
+import { WorkspaceField } from 'src/engine/twenty-orm/decorators/workspace-field.decorator';
 import { WorkspaceIsSystem } from 'src/engine/twenty-orm/decorators/workspace-is-system.decorator';
+import { WorkspaceJoinColumn } from 'src/engine/twenty-orm/decorators/workspace-join-column.decorator';
+import { WorkspaceRelation } from 'src/engine/twenty-orm/decorators/workspace-relation.decorator';
+import { WORKFLOW_AUTOMATED_TRIGGER_STANDARD_FIELD_IDS } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-field-ids';
 import { STANDARD_OBJECT_ICONS } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-object-icons';
 import { STANDARD_OBJECT_IDS } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-object-ids';
-import { WORKFLOW_AUTOMATED_TRIGGER_STANDARD_FIELD_IDS } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-field-ids';
-import { WorkspaceRelation } from 'src/engine/twenty-orm/decorators/workspace-relation.decorator';
-import { RelationOnDeleteAction } from 'src/engine/metadata-modules/relation-metadata/relation-metadata.entity';
-import { WorkspaceJoinColumn } from 'src/engine/twenty-orm/decorators/workspace-join-column.decorator';
-import { WorkspaceField } from 'src/engine/twenty-orm/decorators/workspace-field.decorator';
 
 import { WorkflowWorkspaceEntity } from './workflow.workspace-entity';
 
@@ -22,9 +22,17 @@ export enum AutomatedTriggerType {
   CRON = 'CRON',
 }
 
-export type AutomatedTriggerSettings = {
-  pattern?: string;
-  eventName?: string;
+export type AutomatedTriggerSettings =
+  | DatabaseEventTriggerSettings
+  | CronTriggerSettings;
+
+export type DatabaseEventTriggerSettings = {
+  eventName: string;
+  fields?: string[];
+};
+
+export type CronTriggerSettings = {
+  pattern: string;
 };
 
 @WorkspaceEntity({

--- a/packages/twenty-server/src/modules/workflow/common/standard-objects/workflow-automated-trigger.workspace-entity.ts
+++ b/packages/twenty-server/src/modules/workflow/common/standard-objects/workflow-automated-trigger.workspace-entity.ts
@@ -14,6 +14,7 @@ import { WorkspaceRelation } from 'src/engine/twenty-orm/decorators/workspace-re
 import { WORKFLOW_AUTOMATED_TRIGGER_STANDARD_FIELD_IDS } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-field-ids';
 import { STANDARD_OBJECT_ICONS } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-object-icons';
 import { STANDARD_OBJECT_IDS } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-object-ids';
+import { AutomatedTriggerSettings } from 'src/modules/workflow/workflow-trigger/automated-trigger/constants/automated-trigger-settings';
 
 import { WorkflowWorkspaceEntity } from './workflow.workspace-entity';
 
@@ -21,19 +22,6 @@ export enum AutomatedTriggerType {
   DATABASE_EVENT = 'DATABASE_EVENT',
   CRON = 'CRON',
 }
-
-export type AutomatedTriggerSettings =
-  | DatabaseEventTriggerSettings
-  | CronTriggerSettings;
-
-export type DatabaseEventTriggerSettings = {
-  eventName: string;
-  fields?: string[];
-};
-
-export type CronTriggerSettings = {
-  pattern: string;
-};
 
 @WorkspaceEntity({
   standardId: STANDARD_OBJECT_IDS.workflowAutomatedTrigger,

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/automated-trigger.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/automated-trigger.workspace-service.ts
@@ -3,10 +3,10 @@ import { Injectable } from '@nestjs/common';
 import { WorkspaceEntityManager } from 'src/engine/twenty-orm/entity-manager/workspace-entity-manager';
 import { TwentyORMManager } from 'src/engine/twenty-orm/twenty-orm.manager';
 import {
-  AutomatedTriggerSettings,
   AutomatedTriggerType,
   WorkflowAutomatedTriggerWorkspaceEntity,
 } from 'src/modules/workflow/common/standard-objects/workflow-automated-trigger.workspace-entity';
+import { AutomatedTriggerSettings } from 'src/modules/workflow/workflow-trigger/automated-trigger/constants/automated-trigger-settings';
 
 @Injectable()
 export class AutomatedTriggerWorkspaceService {

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/constants/automated-trigger-settings.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/constants/automated-trigger-settings.ts
@@ -1,0 +1,19 @@
+export type BaseDatabaseEventTriggerSettings = {
+  eventName: string;
+};
+
+export type DatabaseEventTriggerSettings =
+  | BaseDatabaseEventTriggerSettings
+  | UpdateEventTriggerSettings;
+
+export type UpdateEventTriggerSettings = BaseDatabaseEventTriggerSettings & {
+  fields: string[];
+};
+
+export type CronTriggerSettings = {
+  pattern: string;
+};
+
+export type AutomatedTriggerSettings =
+  | DatabaseEventTriggerSettings
+  | CronTriggerSettings;

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/crons/jobs/cron-trigger.cron.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/crons/jobs/cron-trigger.cron.job.ts
@@ -14,9 +14,9 @@ import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.manager';
 import {
   AutomatedTriggerType,
-  CronTriggerSettings,
   WorkflowAutomatedTriggerWorkspaceEntity,
 } from 'src/modules/workflow/common/standard-objects/workflow-automated-trigger.workspace-entity';
+import { CronTriggerSettings } from 'src/modules/workflow/workflow-trigger/automated-trigger/constants/automated-trigger-settings';
 import { shouldRunNow } from 'src/modules/workflow/workflow-trigger/automated-trigger/crons/utils/should-run-now.utils';
 import {
   WorkflowTriggerJob,

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/listeners/__tests__/database-event-trigger.listener.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/listeners/__tests__/database-event-trigger.listener.spec.ts
@@ -5,9 +5,8 @@ import { MessageQueueService } from 'src/engine/core-modules/message-queue/servi
 import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.manager';
 import { AutomatedTriggerType } from 'src/modules/workflow/common/standard-objects/workflow-automated-trigger.workspace-entity';
 import { WorkflowCommonWorkspaceService } from 'src/modules/workflow/common/workspace-services/workflow-common.workspace-service';
+import { DatabaseEventTriggerListener } from 'src/modules/workflow/workflow-trigger/automated-trigger/listeners/database-event-trigger.listener';
 import { WorkflowTriggerJob } from 'src/modules/workflow/workflow-trigger/jobs/workflow-trigger.job';
-
-import { DatabaseEventTriggerListener } from './database-event-trigger.listener';
 
 describe('DatabaseEventTriggerListener', () => {
   let listener: DatabaseEventTriggerListener;

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/listeners/database-event-trigger.listener.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/listeners/database-event-trigger.listener.spec.ts
@@ -1,0 +1,226 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { FeatureFlagService } from 'src/engine/core-modules/feature-flag/services/feature-flag.service';
+import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
+import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.manager';
+import { AutomatedTriggerType } from 'src/modules/workflow/common/standard-objects/workflow-automated-trigger.workspace-entity';
+import { WorkflowCommonWorkspaceService } from 'src/modules/workflow/common/workspace-services/workflow-common.workspace-service';
+import { WorkflowTriggerJob } from 'src/modules/workflow/workflow-trigger/jobs/workflow-trigger.job';
+
+import { DatabaseEventTriggerListener } from './database-event-trigger.listener';
+
+describe('DatabaseEventTriggerListener', () => {
+  let listener: DatabaseEventTriggerListener;
+  let twentyORMGlobalManager: jest.Mocked<TwentyORMGlobalManager>;
+  let messageQueueService: jest.Mocked<MessageQueueService>;
+  let featureFlagService: jest.Mocked<FeatureFlagService>;
+
+  const mockRepository = {
+    find: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    twentyORMGlobalManager = {
+      getRepositoryForWorkspace: jest.fn().mockResolvedValue(mockRepository),
+    } as any;
+
+    messageQueueService = {
+      add: jest.fn(),
+    } as any;
+
+    featureFlagService = {
+      isFeatureEnabled: jest.fn().mockResolvedValue(true),
+    } as any;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DatabaseEventTriggerListener,
+        {
+          provide: TwentyORMGlobalManager,
+          useValue: twentyORMGlobalManager,
+        },
+        {
+          provide: MessageQueueService,
+          useValue: messageQueueService,
+        },
+        {
+          provide: FeatureFlagService,
+          useValue: featureFlagService,
+        },
+        {
+          provide: 'MESSAGE_QUEUE_workflow-queue',
+          useValue: messageQueueService,
+        },
+        {
+          provide: WorkflowCommonWorkspaceService,
+          useValue: {
+            getWorkflowById: jest.fn(),
+            getObjectMetadataItemWithFieldsMaps: jest.fn().mockResolvedValue({
+              objectMetadataMaps: {
+                byId: {
+                  'test-object-metadata': {
+                    nameSingular: 'testObject',
+                    namePlural: 'testObjects',
+                  },
+                },
+              },
+              objectMetadataItemWithFieldsMaps: {
+                fieldsByJoinColumnName: {},
+              },
+            }),
+          },
+        },
+      ],
+    }).compile();
+
+    listener = module.get<DatabaseEventTriggerListener>(
+      DatabaseEventTriggerListener,
+    );
+  });
+
+  describe('handleObjectRecordUpdateEvent', () => {
+    const workspaceId = 'test-workspace';
+    const databaseEventName = 'testEvent';
+    const workflowId = 'test-workflow';
+
+    const mockPayload = {
+      workspaceId,
+      name: databaseEventName,
+      events: [
+        {
+          recordId: 'test-record',
+          objectMetadata: {
+            id: 'test-object-metadata',
+            workspaceId,
+            nameSingular: 'testObject',
+            namePlural: 'testObjects',
+            labelSingular: 'Test Object',
+            labelPlural: 'Test Objects',
+            description: 'Test object for testing',
+            targetTableName: 'test_objects',
+            isSystem: false,
+            isCustom: false,
+            isActive: true,
+            isRemote: false,
+            isAuditLogged: true,
+            isSearchable: true,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            fields: [],
+            relationships: [],
+            fromRelations: [],
+            toRelations: [],
+            indexMetadatas: [],
+          },
+          properties: {
+            updatedFields: ['field1', 'field2'],
+            before: { field1: 'old', field2: 'old' },
+            after: { field1: 'new', field2: 'new' },
+          },
+        },
+      ],
+    };
+
+    const mockEventListeners = [
+      {
+        type: AutomatedTriggerType.DATABASE_EVENT,
+        workflowId,
+        settings: {
+          eventName: databaseEventName,
+          fields: ['field1', 'field3'],
+        },
+      },
+    ];
+
+    it('should trigger workflow when fields are specified and match updated fields', async () => {
+      mockRepository.find.mockResolvedValue(mockEventListeners);
+
+      await listener.handleObjectRecordUpdateEvent(mockPayload);
+
+      expect(messageQueueService.add).toHaveBeenCalledWith(
+        WorkflowTriggerJob.name,
+        {
+          workspaceId,
+          workflowId,
+          payload: mockPayload.events[0],
+        },
+        { retryLimit: 3 },
+      );
+    });
+
+    it('should trigger workflow when no fields are specified', async () => {
+      mockRepository.find.mockResolvedValue([
+        {
+          ...mockEventListeners[0],
+          settings: {
+            eventName: databaseEventName,
+            fields: undefined,
+          },
+        },
+      ]);
+
+      await listener.handleObjectRecordUpdateEvent(mockPayload);
+
+      expect(messageQueueService.add).toHaveBeenCalled();
+    });
+
+    it('should trigger workflow when fields array is empty', async () => {
+      mockRepository.find.mockResolvedValue([
+        {
+          ...mockEventListeners[0],
+          settings: {
+            eventName: databaseEventName,
+            fields: [],
+          },
+        },
+      ]);
+
+      await listener.handleObjectRecordUpdateEvent(mockPayload);
+
+      expect(messageQueueService.add).toHaveBeenCalled();
+    });
+
+    it('should not trigger workflow when fields are specified but none match updated fields', async () => {
+      mockRepository.find.mockResolvedValue([
+        {
+          ...mockEventListeners[0],
+          settings: {
+            eventName: databaseEventName,
+            fields: ['field3', 'field4'],
+          },
+        },
+      ]);
+
+      await listener.handleObjectRecordUpdateEvent(mockPayload);
+
+      expect(messageQueueService.add).not.toHaveBeenCalled();
+    });
+
+    it('should filter event listeners by event name', async () => {
+      mockRepository.find.mockResolvedValue([
+        ...mockEventListeners,
+        {
+          type: AutomatedTriggerType.DATABASE_EVENT,
+          workflowId: 'other-workflow',
+          settings: {
+            eventName: 'otherEvent',
+            fields: ['field1'],
+          },
+        },
+      ]);
+
+      await listener.handleObjectRecordUpdateEvent(mockPayload);
+
+      expect(messageQueueService.add).toHaveBeenCalledTimes(1);
+      expect(messageQueueService.add).toHaveBeenCalledWith(
+        WorkflowTriggerJob.name,
+        {
+          workspaceId,
+          workflowId,
+          payload: mockPayload.events[0],
+        },
+        { retryLimit: 3 },
+      );
+    });
+  });
+});

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/listeners/database-event-trigger.listener.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/listeners/database-event-trigger.listener.ts
@@ -261,7 +261,7 @@ export class DatabaseEventTriggerListener {
         type: AutomatedTriggerType.DATABASE_EVENT,
         settings: Raw(
           () =>
-            `${automatedTriggerTableName}."settings"->>'eventName' = :eventName`,
+            `"${automatedTriggerTableName}"."settings"->>'eventName' = :eventName`,
           { eventName: databaseEventName },
         ),
       },

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/listeners/database-event-trigger.listener.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/listeners/database-event-trigger.listener.ts
@@ -18,10 +18,13 @@ import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.
 import { WorkspaceEventBatch } from 'src/engine/workspace-event-emitter/types/workspace-event.type';
 import {
   AutomatedTriggerType,
-  DatabaseEventTriggerSettings,
   WorkflowAutomatedTriggerWorkspaceEntity,
 } from 'src/modules/workflow/common/standard-objects/workflow-automated-trigger.workspace-entity';
 import { WorkflowCommonWorkspaceService } from 'src/modules/workflow/common/workspace-services/workflow-common.workspace-service';
+import {
+  DatabaseEventTriggerSettings,
+  UpdateEventTriggerSettings,
+} from 'src/modules/workflow/workflow-trigger/automated-trigger/constants/automated-trigger-settings';
 import {
   WorkflowTriggerJob,
   WorkflowTriggerJobData,
@@ -88,7 +91,7 @@ export class DatabaseEventTriggerListener {
 
     for (const eventListener of filteredEventListeners) {
       for (const eventPayload of clonedPayload.events) {
-        const settings = eventListener.settings as DatabaseEventTriggerSettings;
+        const settings = eventListener.settings as UpdateEventTriggerSettings;
 
         if (
           !settings.fields ||

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/workspace-services/workflow-trigger.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/workspace-services/workflow-trigger.workspace-service.ts
@@ -11,10 +11,7 @@ import { ScopedWorkspaceContextFactory } from 'src/engine/twenty-orm/factories/s
 import { WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace.repository';
 import { TwentyORMManager } from 'src/engine/twenty-orm/twenty-orm.manager';
 import { WorkspaceEventEmitter } from 'src/engine/workspace-event-emitter/workspace-event-emitter';
-import {
-  AutomatedTriggerType,
-  DatabaseEventTriggerSettings,
-} from 'src/modules/workflow/common/standard-objects/workflow-automated-trigger.workspace-entity';
+import { AutomatedTriggerType } from 'src/modules/workflow/common/standard-objects/workflow-automated-trigger.workspace-entity';
 import {
   WorkflowVersionStatus,
   WorkflowVersionWorkspaceEntity,
@@ -26,6 +23,7 @@ import { WorkflowRunnerWorkspaceService } from 'src/modules/workflow/workflow-ru
 import { WORKFLOW_VERSION_STATUS_UPDATED } from 'src/modules/workflow/workflow-status/constants/workflow-version-status-updated.constants';
 import { WorkflowVersionStatusUpdate } from 'src/modules/workflow/workflow-status/jobs/workflow-statuses-update.job';
 import { AutomatedTriggerWorkspaceService } from 'src/modules/workflow/workflow-trigger/automated-trigger/automated-trigger.workspace-service';
+import { DatabaseEventTriggerSettings } from 'src/modules/workflow/workflow-trigger/automated-trigger/constants/automated-trigger-settings';
 import {
   WorkflowTriggerException,
   WorkflowTriggerExceptionCode,

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/workspace-services/workflow-trigger.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/workspace-services/workflow-trigger.workspace-service.ts
@@ -11,7 +11,10 @@ import { ScopedWorkspaceContextFactory } from 'src/engine/twenty-orm/factories/s
 import { WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace.repository';
 import { TwentyORMManager } from 'src/engine/twenty-orm/twenty-orm.manager';
 import { WorkspaceEventEmitter } from 'src/engine/workspace-event-emitter/workspace-event-emitter';
-import { AutomatedTriggerType } from 'src/modules/workflow/common/standard-objects/workflow-automated-trigger.workspace-entity';
+import {
+  AutomatedTriggerType,
+  DatabaseEventTriggerSettings,
+} from 'src/modules/workflow/common/standard-objects/workflow-automated-trigger.workspace-entity';
 import {
   WorkflowVersionStatus,
   WorkflowVersionWorkspaceEntity,
@@ -329,12 +332,13 @@ export class WorkflowTriggerWorkspaceService {
       case WorkflowTriggerType.WEBHOOK:
         return;
       case WorkflowTriggerType.DATABASE_EVENT: {
-        const eventName = workflowVersion.trigger.settings.eventName;
+        const settings = workflowVersion.trigger
+          .settings as DatabaseEventTriggerSettings;
 
         await this.automatedTriggerWorkspaceService.addAutomatedTrigger({
           workflowId: workflowVersion.workflowId,
           type: AutomatedTriggerType.DATABASE_EVENT,
-          settings: { eventName },
+          settings,
           manager,
         });
 


### PR DESCRIPTION
Backend part of https://github.com/twentyhq/core-team-issues/issues/928

- Add fields to database event settings
- If not set, match all automated triggers with the right event name
- If set, event needs at least one updated field listened to be treated 