### PR TITLE
fixing :     "message" : "Mail service not enabled"

### DIFF
--- a/packages/twenty-server/src/modules/connected-account/refresh-tokens-manager/services/connected-account-refresh-tokens.service.ts
+++ b/packages/twenty-server/src/modules/connected-account/refresh-tokens-manager/services/connected-account-refresh-tokens.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
-import { assertUnreachable } from 'twenty-shared/utils';
 import { ConnectedAccountProvider } from 'twenty-shared/types';
+import { assertUnreachable } from 'twenty-shared/utils';
 
 import { TwentyORMManager } from 'src/engine/twenty-orm/twenty-orm.manager';
 import {
@@ -74,11 +74,11 @@ export class ConnectedAccountRefreshTokensService {
     try {
       switch (connectedAccount.provider) {
         case ConnectedAccountProvider.GOOGLE:
-          return this.googleAPIRefreshAccessTokenService.refreshAccessToken(
+          return await this.googleAPIRefreshAccessTokenService.refreshAccessToken(
             refreshToken,
           );
         case ConnectedAccountProvider.MICROSOFT:
-          return this.microsoftAPIRefreshAccessTokenService.refreshTokens(
+          return await this.microsoftAPIRefreshAccessTokenService.refreshTokens(
             refreshToken,
           );
         default:

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/utils/parse-gmail-message-list-fetch-error.util.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/utils/parse-gmail-message-list-fetch-error.util.ts
@@ -13,7 +13,6 @@ export const parseGmailMessageListFetchError = (error: {
   const { code, errors } = error;
 
   const reason = errors?.[0]?.reason;
-  const originalMessage = errors?.[0]?.message;
   const message = errors?.[0]?.message;
 
   switch (code) {
@@ -25,7 +24,7 @@ export const parseGmailMessageListFetchError = (error: {
         );
       }
       if (reason === 'failedPrecondition') {
-        if (originalMessage.includes('Mail service not enabled')) {
+        if (message.includes('Mail service not enabled')) {
           return new MessageImportDriverException(
             message,
             MessageImportDriverExceptionCode.INSUFFICIENT_PERMISSIONS,

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/utils/parse-gmail-message-list-fetch-error.util.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/utils/parse-gmail-message-list-fetch-error.util.ts
@@ -13,6 +13,7 @@ export const parseGmailMessageListFetchError = (error: {
   const { code, errors } = error;
 
   const reason = errors?.[0]?.reason;
+  const originalMessage = errors?.[0]?.message;
   const message = errors?.[0]?.message;
 
   switch (code) {
@@ -24,6 +25,13 @@ export const parseGmailMessageListFetchError = (error: {
         );
       }
       if (reason === 'failedPrecondition') {
+        if (originalMessage.includes('Mail service not enabled')) {
+          return new MessageImportDriverException(
+            message,
+            MessageImportDriverExceptionCode.INSUFFICIENT_PERMISSIONS,
+          );
+        }
+
         return new MessageImportDriverException(
           message,
           MessageImportDriverExceptionCode.TEMPORARY_ERROR,

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/utils/parse-gmail-messages-import-error.util.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/utils/parse-gmail-messages-import-error.util.ts
@@ -16,6 +16,7 @@ export const parseGmailMessagesImportError = (
   const { code, errors } = error;
 
   const reason = errors?.[0]?.reason;
+  const originalMessage = errors?.[0]?.message;
   const message = `${errors?.[0]?.message} for message with externalId: ${messageExternalId}`;
 
   switch (code) {
@@ -27,6 +28,13 @@ export const parseGmailMessagesImportError = (
         );
       }
       if (reason === 'failedPrecondition') {
+        if (originalMessage.includes('Mail service not enabled')) {
+          return new MessageImportDriverException(
+            message,
+            MessageImportDriverExceptionCode.INSUFFICIENT_PERMISSIONS,
+          );
+        }
+
         return new MessageImportDriverException(
           message,
           MessageImportDriverExceptionCode.TEMPORARY_ERROR,


### PR DESCRIPTION
Fix Gmail API error handling for "Mail service not enabled" scenarios
Add proper await

Improves Gmail API error handling by properly detecting "Mail service not enabled" errors and classifying them as INSUFFICIENT_PERMISSIONS instead of TEMPORARY_ERROR


Fixes https://github.com/twentyhq/twenty/issues/12260
### Refernce :

https://stackoverflow.com/questions/31692720/gmail-api-returning-status-code-400-error-mail-service-not-enabled