### PR TITLE
Fixed non advanced filter creation from table header dropdown

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-header/hooks/useOpenRecordFilterChipFromTableHeader.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-header/hooks/useOpenRecordFilterChipFromTableHeader.ts
@@ -37,13 +37,15 @@ export const useOpenRecordFilterChipFromTableHeader = () => {
       );
     }
 
-    const existingRecordFilter = currentRecordFilters.find(
-      (recordFilter) => recordFilter.fieldMetadataId === fieldMetadataItemId,
+    const existingNonAdvancedRecordFilter = currentRecordFilters.find(
+      (recordFilter) =>
+        recordFilter.fieldMetadataId === fieldMetadataItemId &&
+        !isDefined(recordFilter.recordFilterGroupId),
     );
 
-    if (isDefined(existingRecordFilter)) {
-      setEditableFilterChipDropdownStates(existingRecordFilter);
-      openDropdownFromOutside(existingRecordFilter.id);
+    if (isDefined(existingNonAdvancedRecordFilter)) {
+      setEditableFilterChipDropdownStates(existingNonAdvancedRecordFilter);
+      openDropdownFromOutside(existingNonAdvancedRecordFilter.id);
       return;
     }
 


### PR DESCRIPTION
This PR fixes a edge case where the user tries to create a non-advanced filter that already exists in advanced filters, from the table header drodpown.

This was because the hook that handles the creation was checking for duplicate filters but without discerning between advanced and non-advanced, and we want to be able to create non-advanced filters no matter what we have in advanced filters.

Fixes https://github.com/twentyhq/twenty/issues/12316