### PR TITLE
fix(packages): shell command built from environment values

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/serverless/commands/add-packages.command.ts
+++ b/packages/twenty-server/src/engine/core-modules/serverless/commands/add-packages.command.ts
@@ -1,9 +1,9 @@
 import { Logger } from '@nestjs/common';
 
+import { execFile } from 'child_process';
 import * as fs from 'fs/promises';
 import { resolve } from 'path';
 import { promisify } from 'util';
-import { execFile } from 'child_process';
 
 import { Command, CommandRunner, Option } from 'nest-commander';
 
@@ -40,7 +40,6 @@ export class AddPackagesCommand extends CommandRunner {
     );
 
     const currentVersion = await this.getLastLayerVersion();
-
     const newVersion = currentVersion + 1;
 
     const currentVersionFolder = `${layersFolder}/${currentVersion}`;
@@ -71,7 +70,6 @@ export class AddPackagesCommand extends CommandRunner {
 
   private getAbsoluteFilePath(path: string) {
     const rootPath = process.cwd();
-
     return resolve(rootPath, path);
   }
 
@@ -95,7 +93,7 @@ export class AddPackagesCommand extends CommandRunner {
       for (const packageName of packages) {
         this.logger.log(`- adding '${packageName}'...`);
         try {
-          await execPromise(`yarn add ${packageName}`, {
+          await execFilePromise('yarn', ['add', packageName], {
             cwd: folderPath,
           });
         } catch (error) {

--- a/packages/twenty-server/src/engine/core-modules/serverless/commands/add-packages.command.ts
+++ b/packages/twenty-server/src/engine/core-modules/serverless/commands/add-packages.command.ts
@@ -3,11 +3,11 @@ import { Logger } from '@nestjs/common';
 import * as fs from 'fs/promises';
 import { resolve } from 'path';
 import { promisify } from 'util';
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 
 import { Command, CommandRunner, Option } from 'nest-commander';
 
-const execPromise = promisify(exec);
+const execFilePromise = promisify(execFile);
 
 @Command({
   name: 'serverless:add-packages',
@@ -76,7 +76,7 @@ export class AddPackagesCommand extends CommandRunner {
   }
 
   private async addToGit(folderPath: string) {
-    await execPromise(`git add ${folderPath}`);
+    await execFilePromise('git', ['add', folderPath]);
   }
 
   private async cleanPackageInstallation(folderPath: string) {


### PR DESCRIPTION
https://github.com/twentyhq/twenty/blob/b7473371b3fda51de96241533dc7d56856134f72/packages/twenty-server/src/engine/core-modules/serverless/commands/add-packages.command.ts#L6-L6

https://github.com/twentyhq/twenty/blob/b7473371b3fda51de96241533dc7d56856134f72/packages/twenty-server/src/engine/core-modules/serverless/commands/add-packages.command.ts#L10-L10

https://github.com/twentyhq/twenty/blob/b7473371b3fda51de96241533dc7d56856134f72/packages/twenty-server/src/engine/core-modules/serverless/commands/add-packages.command.ts#L79-L79

Fix the issue should avoid dynamically constructing the shell command. Instead, we can use `execFile` or `execFileSync`, which allows us to pass arguments as an array, avoiding shell interpretation of special characters. This ensures that the `folderPath` is treated as a literal argument and not subject to command injection.

Specifically:
1. Replace the use of `execPromise` with `execFilePromise` (a promisified version of `execFile`).
2. Modify the `addToGit` method to pass the `folderPath` as an argument to `git add` instead of interpolating it into the command string.



---


