### PR TITLE
Emit company created event

### DIFF
--- a/packages/twenty-server/src/modules/contact-creation-manager/services/create-company.service.ts
+++ b/packages/twenty-server/src/modules/contact-creation-manager/services/create-company.service.ts
@@ -1,14 +1,19 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
 
 import axios, { AxiosInstance } from 'axios';
 import uniqBy from 'lodash.uniqby';
 import { TWENTY_COMPANIES_BASE_URL } from 'twenty-shared/constants';
 import { ConnectedAccountProvider } from 'twenty-shared/types';
-import { DeepPartial, ILike } from 'typeorm';
+import { DeepPartial, ILike, Repository } from 'typeorm';
 
+import { DatabaseEventAction } from 'src/engine/api/graphql/graphql-query-runner/enums/database-event-action';
 import { FieldActorSource } from 'src/engine/metadata-modules/field-metadata/composite-types/actor.composite-type';
+import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 import { WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace.repository';
 import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.manager';
+import { WorkspaceEventEmitter } from 'src/engine/workspace-event-emitter/workspace-event-emitter';
+import { STANDARD_OBJECT_IDS } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-object-ids';
 import { CompanyWorkspaceEntity } from 'src/modules/company/standard-objects/company.workspace-entity';
 import { extractDomainFromLink } from 'src/modules/contact-creation-manager/utils/extract-domain-from-link.util';
 import { getCompanyNameFromDomainName } from 'src/modules/contact-creation-manager/utils/get-company-name-from-domain-name.util';
@@ -28,7 +33,12 @@ type CompanyToCreate = {
 export class CreateCompanyService {
   private readonly httpService: AxiosInstance;
 
-  constructor(private readonly twentyORMGlobalManager: TwentyORMGlobalManager) {
+  constructor(
+    private readonly twentyORMGlobalManager: TwentyORMGlobalManager,
+    private readonly workspaceEventEmitter: WorkspaceEventEmitter,
+    @InjectRepository(ObjectMetadataEntity, 'metadata')
+    private readonly objectMetadataRepository: Repository<ObjectMetadataEntity>,
+  ) {
     this.httpService = axios.create({
       baseURL: TWENTY_COMPANIES_BASE_URL,
     });
@@ -42,6 +52,17 @@ export class CreateCompanyService {
   }> {
     if (companies.length === 0) {
       return {};
+    }
+
+    const objectMetadata = await this.objectMetadataRepository.findOne({
+      where: {
+        standardId: STANDARD_OBJECT_IDS.company,
+        workspaceId,
+      },
+    });
+
+    if (!objectMetadata) {
+      throw new Error('Object metadata not found');
     }
 
     const companyRepository =
@@ -93,6 +114,20 @@ export class CreateCompanyService {
 
     // Create new companies
     const createdCompanies = await companyRepository.save(newCompaniesData);
+
+    this.workspaceEventEmitter.emitDatabaseBatchEvent({
+      objectMetadataNameSingular: 'company',
+      action: DatabaseEventAction.CREATED,
+      events: createdCompanies.map((createdCompany) => ({
+        recordId: createdCompany.id,
+        objectMetadata,
+        properties: {
+          after: createdCompany,
+        },
+      })),
+      workspaceId,
+    });
+
     const createdCompanyIdsMap = this.createCompanyMap(createdCompanies);
 
     return {


### PR DESCRIPTION
Fixes https://github.com/twentyhq/twenty/issues/12337

When importing emails, matched companies are added, but no event is triggered. Which means that workflows are not triggered. Adding the event.

To test:
- create a workflow that listens to company creation
- import emails
- make sure workflow has been triggered