### PR TITLE
Fix auth modal closing hotkey scopes

### DIFF
--- a/packages/twenty-front/src/modules/auth/components/AuthModalMountEffect.tsx
+++ b/packages/twenty-front/src/modules/auth/components/AuthModalMountEffect.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 
 import { AUTH_MODAL_ID } from '../constants/AuthModalId';
 
+// TODO: Remove this component when we refactor the auth modal to open it directly in the PageChangeEffect
 export const AuthModalMountEffect = () => {
   const { openModal, closeModal } = useModal();
 

--- a/packages/twenty-front/src/modules/auth/components/AuthModalMountEffect.tsx
+++ b/packages/twenty-front/src/modules/auth/components/AuthModalMountEffect.tsx
@@ -4,11 +4,15 @@ import { useEffect } from 'react';
 import { AUTH_MODAL_ID } from '../constants/AuthModalId';
 
 export const AuthModalMountEffect = () => {
-  const { openModal } = useModal();
+  const { openModal, closeModal } = useModal();
 
   useEffect(() => {
     openModal(AUTH_MODAL_ID);
-  }, [openModal]);
+
+    return () => {
+      closeModal(AUTH_MODAL_ID);
+    };
+  }, [openModal, closeModal]);
 
   return null;
 };


### PR DESCRIPTION
The auth modal is a particular modal because it is the only one that is opened in an effect (because its opening depends on the location).

After the hotkey scopes and the modal refactoring, we are now force to call `openModal` and `closeModal` to open and close the modals. Here, the `closeModal` wasn't called, but the modal was simply unmounted. The global hotkeys were then disabled because the modal was still in the focus stack.

Fixes [#1052](https://github.com/twentyhq/core-team-issues/issues/1052#event-17916955590)