### PR TITLE
Catching temporary errors in microsft batch calls

### DIFF
--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/microsoft/services/microsoft-get-messages.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/microsoft/services/microsoft-get-messages.service.ts
@@ -143,8 +143,8 @@ export class MicrosoftGetMessagesService {
         return response.body;
       }
 
-      if (!response.body) {
-        this.logger.error(`No body found for response`, response);
+      if (response.status !== 503 && response.status !== 429) {
+        this.logger.error(`Microsoft parseBatchResponse error`, response);
       }
 
       const errorParsed = response?.body?.error

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/microsoft/utils/parse-microsoft-messages-import.util.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/microsoft/utils/parse-microsoft-messages-import.util.ts
@@ -40,7 +40,7 @@ export const parseMicrosoftMessagesImportError = (error: {
     }
   }
 
-  if (error.statusCode === 429) {
+  if (error.statusCode === 429 || error.statusCode === 503) {
     return new MessageImportDriverException(
       `Microsoft Graph API ${error.code} ${error.statusCode} error: ${error.message}`,
       MessageImportDriverExceptionCode.TEMPORARY_ERROR,


### PR DESCRIPTION
# 🐛 Improve Microsoft Graph API Temporary Error Handling on PARSE method

fixes Sentry error
<img width="886" alt="Screenshot 2025-06-02 at 14 39 19" src="https://github.com/user-attachments/assets/117a2601-4bad-48a2-8112-2bb682559b15" />


### What:
Enhances error handling for Microsoft Graph API batch calls 
### How: by treating HTTP 503 (Service Unavailable) as temporary errors alongside existing 429 (Rate Limit) handling. 

### Additional: 
improving logging


Fixes https://github.com/twentyhq/twenty/issues/12257