### PR TITLE
[permissions] Override workspaceDatasource.createQueryBuilder

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/helpers/process-nested-relations-v2.helper.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/helpers/process-nested-relations-v2.helper.ts
@@ -37,7 +37,7 @@ export class ProcessNestedRelationsV2Helper {
     aggregate = {},
     limit,
     authContext,
-    dataSource,
+    workspaceDataSource,
     roleId,
     shouldBypassPermissionChecks,
   }: {
@@ -50,7 +50,7 @@ export class ProcessNestedRelationsV2Helper {
     aggregate?: Record<string, AggregationField>;
     limit: number;
     authContext: AuthContext;
-    dataSource: WorkspaceDataSource;
+    workspaceDataSource: WorkspaceDataSource;
     shouldBypassPermissionChecks: boolean;
     roleId?: string;
   }): Promise<void> {
@@ -66,7 +66,7 @@ export class ProcessNestedRelationsV2Helper {
           aggregate,
           limit,
           authContext,
-          dataSource,
+          workspaceDataSource,
           shouldBypassPermissionChecks,
           roleId,
         }),
@@ -85,7 +85,7 @@ export class ProcessNestedRelationsV2Helper {
     aggregate,
     limit,
     authContext,
-    dataSource,
+    workspaceDataSource,
     shouldBypassPermissionChecks,
     roleId,
   }: {
@@ -99,7 +99,7 @@ export class ProcessNestedRelationsV2Helper {
     aggregate: Record<string, AggregationField>;
     limit: number;
     authContext: AuthContext;
-    dataSource: WorkspaceDataSource;
+    workspaceDataSource: WorkspaceDataSource;
     shouldBypassPermissionChecks: boolean;
     roleId?: string;
   }): Promise<void> {
@@ -131,7 +131,7 @@ export class ProcessNestedRelationsV2Helper {
         sourceFieldName,
       });
 
-    const targetObjectRepository = dataSource.getRepository(
+    const targetObjectRepository = workspaceDataSource.getRepository(
       targetObjectMetadata.nameSingular,
       shouldBypassPermissionChecks,
       roleId,
@@ -203,7 +203,7 @@ export class ProcessNestedRelationsV2Helper {
         aggregate,
         limit,
         authContext,
-        dataSource,
+        workspaceDataSource,
         shouldBypassPermissionChecks,
         roleId,
       });

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/helpers/process-nested-relations.helper.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/helpers/process-nested-relations.helper.ts
@@ -4,7 +4,6 @@ import { FindOptionsRelations, ObjectLiteral } from 'typeorm';
 
 import { ObjectRecord } from 'src/engine/api/graphql/workspace-query-builder/interfaces/object-record.interface';
 
-import { ProcessAggregateHelper } from 'src/engine/api/graphql/graphql-query-runner/helpers/process-aggregate.helper';
 import { ProcessNestedRelationsV2Helper } from 'src/engine/api/graphql/graphql-query-runner/helpers/process-nested-relations-v2.helper';
 import { AggregationField } from 'src/engine/api/graphql/workspace-schema-builder/utils/get-available-aggregations-from-object-fields.util';
 import { AuthContext } from 'src/engine/core-modules/auth/types/auth-context.type';
@@ -16,7 +15,6 @@ import { WorkspaceDataSource } from 'src/engine/twenty-orm/datasource/workspace.
 export class ProcessNestedRelationsHelper {
   constructor(
     private readonly processNestedRelationsV2Helper: ProcessNestedRelationsV2Helper,
-    private readonly processAggregateHelper: ProcessAggregateHelper,
   ) {}
 
   public async processNestedRelations<T extends ObjectRecord = ObjectRecord>({
@@ -28,7 +26,7 @@ export class ProcessNestedRelationsHelper {
     aggregate = {},
     limit,
     authContext,
-    dataSource,
+    workspaceDataSource,
     shouldBypassPermissionChecks,
     roleId,
   }: {
@@ -41,7 +39,7 @@ export class ProcessNestedRelationsHelper {
     aggregate?: Record<string, AggregationField>;
     limit: number;
     authContext: AuthContext;
-    dataSource: WorkspaceDataSource;
+    workspaceDataSource: WorkspaceDataSource;
     shouldBypassPermissionChecks: boolean;
     roleId?: string;
   }): Promise<void> {
@@ -54,7 +52,7 @@ export class ProcessNestedRelationsHelper {
       aggregate,
       limit,
       authContext,
-      dataSource,
+      workspaceDataSource,
       shouldBypassPermissionChecks,
       roleId,
     });

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/interfaces/base-resolver-service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/interfaces/base-resolver-service.ts
@@ -41,7 +41,7 @@ import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.
 export type GraphqlQueryResolverExecutionArgs<Input extends ResolverArgs> = {
   args: Input;
   options: WorkspaceQueryRunnerOptions;
-  dataSource: WorkspaceDataSource;
+  workspaceDataSource: WorkspaceDataSource;
   repository: WorkspaceRepository<ObjectLiteral>;
   graphqlQueryParser: GraphqlQueryParser;
   graphqlQuerySelectedFieldsResult: GraphqlQuerySelectedFieldsResult;
@@ -152,7 +152,7 @@ export abstract class GraphqlQueryBaseResolverService<
       const graphqlQueryResolverExecutionArgs = {
         args: computedArgs,
         options,
-        dataSource: workspaceDataSource,
+        workspaceDataSource,
         repository,
         graphqlQueryParser,
         graphqlQuerySelectedFieldsResult,

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-create-many-resolver.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-create-many-resolver.service.ts
@@ -415,7 +415,7 @@ export class GraphqlQueryCreateManyResolverService extends GraphqlQueryBaseResol
       relations: executionArgs.graphqlQuerySelectedFieldsResult.relations,
       limit: QUERY_MAX_RECORDS,
       authContext: executionArgs.options.authContext,
-      dataSource: executionArgs.dataSource,
+      workspaceDataSource: executionArgs.workspaceDataSource,
       roleId,
       shouldBypassPermissionChecks,
     });

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-create-one-resolver.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-create-one-resolver.service.ts
@@ -67,7 +67,7 @@ export class GraphqlQueryCreateOneResolverService extends GraphqlQueryBaseResolv
         relations: executionArgs.graphqlQuerySelectedFieldsResult.relations,
         limit: QUERY_MAX_RECORDS,
         authContext,
-        dataSource: executionArgs.dataSource,
+        workspaceDataSource: executionArgs.workspaceDataSource,
         roleId,
         shouldBypassPermissionChecks: executionArgs.isExecutedByApiKey,
       });

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-delete-many-resolver.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-delete-many-resolver.service.ts
@@ -69,7 +69,7 @@ export class GraphqlQueryDeleteManyResolverService extends GraphqlQueryBaseResol
         relations: executionArgs.graphqlQuerySelectedFieldsResult.relations,
         limit: QUERY_MAX_RECORDS,
         authContext,
-        dataSource: executionArgs.dataSource,
+        workspaceDataSource: executionArgs.workspaceDataSource,
         roleId,
         shouldBypassPermissionChecks: executionArgs.isExecutedByApiKey,
       });

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-delete-one-resolver.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-delete-one-resolver.service.ts
@@ -71,7 +71,7 @@ export class GraphqlQueryDeleteOneResolverService extends GraphqlQueryBaseResolv
         relations: executionArgs.graphqlQuerySelectedFieldsResult.relations,
         limit: QUERY_MAX_RECORDS,
         authContext,
-        dataSource: executionArgs.dataSource,
+        workspaceDataSource: executionArgs.workspaceDataSource,
         roleId,
         shouldBypassPermissionChecks: executionArgs.isExecutedByApiKey,
       });

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-destroy-many-resolver.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-destroy-many-resolver.service.ts
@@ -67,7 +67,7 @@ export class GraphqlQueryDestroyManyResolverService extends GraphqlQueryBaseReso
         relations: executionArgs.graphqlQuerySelectedFieldsResult.relations,
         limit: QUERY_MAX_RECORDS,
         authContext,
-        dataSource: executionArgs.dataSource,
+        workspaceDataSource: executionArgs.workspaceDataSource,
         roleId,
         shouldBypassPermissionChecks: executionArgs.isExecutedByApiKey,
       });

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-destroy-one-resolver.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-destroy-one-resolver.service.ts
@@ -67,7 +67,7 @@ export class GraphqlQueryDestroyOneResolverService extends GraphqlQueryBaseResol
         relations: executionArgs.graphqlQuerySelectedFieldsResult.relations,
         limit: QUERY_MAX_RECORDS,
         authContext,
-        dataSource: executionArgs.dataSource,
+        workspaceDataSource: executionArgs.workspaceDataSource,
         roleId,
         shouldBypassPermissionChecks: executionArgs.isExecutedByApiKey,
       });

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-find-many-resolver.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-find-many-resolver.service.ts
@@ -153,7 +153,7 @@ export class GraphqlQueryFindManyResolverService extends GraphqlQueryBaseResolve
         aggregate: executionArgs.graphqlQuerySelectedFieldsResult.aggregate,
         limit: QUERY_MAX_RECORDS,
         authContext,
-        dataSource: executionArgs.dataSource,
+        workspaceDataSource: executionArgs.workspaceDataSource,
         roleId,
         shouldBypassPermissionChecks: executionArgs.isExecutedByApiKey,
       });

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-find-one-resolver.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-find-one-resolver.service.ts
@@ -77,7 +77,7 @@ export class GraphqlQueryFindOneResolverService extends GraphqlQueryBaseResolver
         relations: executionArgs.graphqlQuerySelectedFieldsResult.relations,
         limit: QUERY_MAX_RECORDS,
         authContext,
-        dataSource: executionArgs.dataSource,
+        workspaceDataSource: executionArgs.workspaceDataSource,
         roleId,
         shouldBypassPermissionChecks: executionArgs.isExecutedByApiKey,
       });

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-restore-many-resolver.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-restore-many-resolver.service.ts
@@ -69,7 +69,7 @@ export class GraphqlQueryRestoreManyResolverService extends GraphqlQueryBaseReso
         relations: executionArgs.graphqlQuerySelectedFieldsResult.relations,
         limit: QUERY_MAX_RECORDS,
         authContext,
-        dataSource: executionArgs.dataSource,
+        workspaceDataSource: executionArgs.workspaceDataSource,
         roleId,
         shouldBypassPermissionChecks: executionArgs.isExecutedByApiKey,
       });

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-restore-one-resolver.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-restore-one-resolver.service.ts
@@ -71,7 +71,7 @@ export class GraphqlQueryRestoreOneResolverService extends GraphqlQueryBaseResol
         relations: executionArgs.graphqlQuerySelectedFieldsResult.relations,
         limit: QUERY_MAX_RECORDS,
         authContext,
-        dataSource: executionArgs.dataSource,
+        workspaceDataSource: executionArgs.workspaceDataSource,
         roleId,
         shouldBypassPermissionChecks: executionArgs.isExecutedByApiKey,
       });

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-update-many-resolver.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-update-many-resolver.service.ts
@@ -108,7 +108,7 @@ export class GraphqlQueryUpdateManyResolverService extends GraphqlQueryBaseResol
         relations: executionArgs.graphqlQuerySelectedFieldsResult.relations,
         limit: QUERY_MAX_RECORDS,
         authContext,
-        dataSource: executionArgs.dataSource,
+        workspaceDataSource: executionArgs.workspaceDataSource,
         roleId,
         shouldBypassPermissionChecks: executionArgs.isExecutedByApiKey,
       });

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-update-one-resolver.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-update-one-resolver.service.ts
@@ -100,7 +100,7 @@ export class GraphqlQueryUpdateOneResolverService extends GraphqlQueryBaseResolv
         relations: executionArgs.graphqlQuerySelectedFieldsResult.relations,
         limit: QUERY_MAX_RECORDS,
         authContext,
-        dataSource: executionArgs.dataSource,
+        workspaceDataSource: executionArgs.workspaceDataSource,
         roleId,
         shouldBypassPermissionChecks: executionArgs.isExecutedByApiKey,
       });

--- a/packages/twenty-server/src/engine/api/rest/core/interfaces/rest-api-base.handler.ts
+++ b/packages/twenty-server/src/engine/api/rest/core/interfaces/rest-api-base.handler.ts
@@ -104,7 +104,7 @@ export abstract class RestApiBaseHandler {
       throw new BadRequestException('Workspace not found');
     }
 
-    const dataSource =
+    const workspaceDataSource =
       await this.twentyORMGlobalManager.getDataSourceForWorkspace({
         workspaceId: workspace.id,
         shouldFailIfMetadataNotFound: false,
@@ -125,7 +125,7 @@ export abstract class RestApiBaseHandler {
       );
     }
 
-    const shouldBypassPermissionChecks = !!apiKey;
+    const shouldBypassPermissionChecks = isDefined(apiKey);
 
     const roleId =
       await this.workspacePermissionsCacheService.getRoleIdFromUserWorkspaceId({
@@ -133,7 +133,7 @@ export abstract class RestApiBaseHandler {
         userWorkspaceId,
       });
 
-    const repository = dataSource.getRepository<ObjectRecord>(
+    const repository = workspaceDataSource.getRepository<ObjectRecord>(
       objectMetadataNameSingular,
       shouldBypassPermissionChecks,
       roleId,
@@ -142,7 +142,7 @@ export abstract class RestApiBaseHandler {
     return {
       objectMetadata,
       repository,
-      dataSource,
+      workspaceDataSource,
       objectMetadataItemWithFieldsMaps,
     };
   }

--- a/packages/twenty-server/src/engine/twenty-orm/datasource/workspace.datasource.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/datasource/workspace.datasource.ts
@@ -13,6 +13,7 @@ import {
 import { FeatureFlagMap } from 'src/engine/core-modules/feature-flag/interfaces/feature-flag-map.interface';
 import { WorkspaceInternalContext } from 'src/engine/twenty-orm/interfaces/workspace-internal-context.interface';
 
+import { FeatureFlagKey } from 'src/engine/core-modules/feature-flag/enums/feature-flag-key.enum';
 import {
   PermissionsException,
   PermissionsExceptionCode,
@@ -112,22 +113,28 @@ export class WorkspaceDataSource extends DataSource {
   ): SelectQueryBuilder<any> {
     let calledByWorkspaceEntityManager;
 
+    const isPermissionsV2Enabled =
+      this.featureFlagMap[FeatureFlagKey.IS_PERMISSIONS_V2_ENABLED];
+
     const isCalledWithEntityTarget =
       isDefined(aliasOrOptions) && typeof aliasOrOptions === 'string';
 
-    if (isCalledWithEntityTarget) {
-      calledByWorkspaceEntityManager = options?.calledByWorkspaceEntityManager;
-    } else {
-      calledByWorkspaceEntityManager = (
-        aliasOrOptions as CreateQueryBuilderOptions
-      )?.calledByWorkspaceEntityManager;
-    }
+    if (isPermissionsV2Enabled) {
+      if (isCalledWithEntityTarget) {
+        calledByWorkspaceEntityManager =
+          options?.calledByWorkspaceEntityManager;
+      } else {
+        calledByWorkspaceEntityManager = (
+          aliasOrOptions as CreateQueryBuilderOptions
+        )?.calledByWorkspaceEntityManager;
+      }
 
-    if (!(calledByWorkspaceEntityManager === true)) {
-      throw new PermissionsException(
-        'Method not allowed because permissions are not implemented at datasource level.',
-        PermissionsExceptionCode.METHOD_NOT_ALLOWED,
-      );
+      if (!(calledByWorkspaceEntityManager === true)) {
+        throw new PermissionsException(
+          'Method not allowed because permissions are not implemented at datasource level.',
+          PermissionsExceptionCode.METHOD_NOT_ALLOWED,
+        );
+      }
     }
 
     if (isCalledWithEntityTarget) {

--- a/packages/twenty-server/src/engine/twenty-orm/entity-manager/workspace-entity-manager.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/entity-manager/workspace-entity-manager.ts
@@ -918,7 +918,10 @@ export class WorkspaceEntityManager extends EntityManager {
       permissionOptions,
     )
       .setFindOptions(options || {})
-      .getExists();
+      .select('1')
+      .limit(1)
+      .getRawOne()
+      .then((result) => isDefined(result));
   }
 
   override existsBy<Entity extends ObjectLiteral>(
@@ -935,7 +938,10 @@ export class WorkspaceEntityManager extends EntityManager {
       permissionOptions,
     )
       .setFindOptions({ where })
-      .getExists();
+      .select('1')
+      .limit(1)
+      .getRawOne()
+      .then((result) => isDefined(result));
   }
 
   override count<Entity extends ObjectLiteral>(

--- a/packages/twenty-server/src/engine/twenty-orm/entity-manager/workspace-entity-manager.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/entity-manager/workspace-entity-manager.ts
@@ -145,14 +145,20 @@ export class WorkspaceEntityManager extends EntityManager {
     let queryBuilder: SelectQueryBuilder<Entity>;
 
     if (alias) {
-      queryBuilder = super.createQueryBuilder(
+      queryBuilder = this.connection.createQueryBuilder(
         entityClassOrQueryRunner as EntityTarget<Entity>,
         alias as string,
         queryRunner as QueryRunner | undefined,
+        {
+          calledByWorkspaceEntityManager: true,
+        },
       );
     } else {
-      queryBuilder = super.createQueryBuilder(
+      queryBuilder = this.connection.createQueryBuilder(
         entityClassOrQueryRunner as QueryRunner,
+        {
+          calledByWorkspaceEntityManager: true,
+        },
       );
     }
 

--- a/packages/twenty-server/src/engine/twenty-orm/repository/workspace-select-query-builder.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/repository/workspace-select-query-builder.ts
@@ -4,6 +4,10 @@ import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity
 
 import { WorkspaceInternalContext } from 'src/engine/twenty-orm/interfaces/workspace-internal-context.interface';
 
+import {
+  PermissionsException,
+  PermissionsExceptionCode,
+} from 'src/engine/metadata-modules/permissions/permissions.exception';
 import { validateQueryIsPermittedOrThrow } from 'src/engine/twenty-orm/repository/permissions.utils';
 import { WorkspaceDeleteQueryBuilder } from 'src/engine/twenty-orm/repository/workspace-delete-query-builder';
 import { WorkspaceSoftDeleteQueryBuilder } from 'src/engine/twenty-orm/repository/workspace-soft-delete-query-builder';
@@ -83,9 +87,10 @@ export class WorkspaceSelectQueryBuilder<
   }
 
   override getExists(): Promise<boolean> {
-    this.validatePermissions();
-
-    return super.getExists();
+    throw new PermissionsException(
+      'getExists is not supported because it calls dataSource.createQueryBuilder()',
+      PermissionsExceptionCode.METHOD_NOT_ALLOWED,
+    );
   }
 
   override getManyAndCount(): Promise<[T[], number]> {
@@ -145,6 +150,13 @@ export class WorkspaceSelectQueryBuilder<
       this.objectRecordsPermissions,
       this.internalContext,
       this.shouldBypassPermissionChecks,
+    );
+  }
+
+  override executeExistsQuery(): Promise<boolean> {
+    throw new PermissionsException(
+      'executeExistsQuery is not supported because it calls dataSource.createQueryBuilder()',
+      PermissionsExceptionCode.METHOD_NOT_ALLOWED,
     );
   }
 


### PR DESCRIPTION
In the frame of https://github.com/twentyhq/core-team-issues/issues/924

- Rename dataSource -> workspaceDataSource when relevant to ease understandability 
- override workspaceDataSource.createQueryBuilder, because we don't want developers to use it directly since it does not run permission checks at this level. Indeed, we cannot do so because 1) datasources are shared between roles so we would need to re-think its implementation to make that possible, while for now we never call workspaceDatasource.createQueryBuilder in our codebase 2) workspaceEntityManager.createQueryBuilder, that we have overriden with permission checks, then performs a call to workspaceDataSource.createQueryBuilder so that would make two permission checks. 