### PR TITLE
removing webhooks failed  logs

### DIFF
--- a/packages/twenty-server/src/modules/webhook/jobs/call-webhook.job.ts
+++ b/packages/twenty-server/src/modules/webhook/jobs/call-webhook.job.ts
@@ -90,9 +90,6 @@ export class CallWebhookJob {
         ...commonPayload,
         ...(err.response && { status: err.response.status }),
       });
-      this.logger.error(
-        `Error calling webhook on targetUrl '${data.targetUrl}': ${err}`,
-      );
     }
   }
 }


### PR DESCRIPTION
As discussed with  @martmull , we remove the logs in order to keep our logs (for cloud users, Grafana) clean.

Comes in the effort of cleaning logs to faster troubleshoot, see below the noise it creates
<img width="1345" alt="Screenshot_2025-06-02_at_13 51 40" src="https://github.com/user-attachments/assets/70ecdb2d-f37e-446b-8df4-a6a8fb165a9a" />

related to [this issue](https://github.com/twentyhq/core-team-issues/issues/1059)
