### PR TITLE
fix:modal appears above dropdown

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/constants/RootStackingContextZIndices.ts
+++ b/packages/twenty-front/src/modules/ui/layout/constants/RootStackingContextZIndices.ts
@@ -17,7 +17,7 @@ export enum RootStackingContextZIndices {
   CommandMenuButton = 22,
   RootModalBackDrop = 39,
   RootModal = 40,
-  DropdownPortal = 50,
+  DropdownPortal = 38,
   Dialog = 9999,
   SnackBar = 10002,
   NotFound = 10001,


### PR DESCRIPTION

resolve #11942 
I just updated the z-index to ensure the modal appears on top of the dropdown.

https://github.com/user-attachments/assets/e8fd36a6-589c-4ae7-bc3c-a12a7fc306e4

