### PR TITLE
Fix workflow diagram success edges

### DIFF
--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramSuccessEdge.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramSuccessEdge.tsx
@@ -8,6 +8,7 @@ import {
   getStraightPath,
 } from '@xyflow/react';
 import { Label } from 'twenty-ui/display';
+import { CREATE_STEP_NODE_WIDTH } from '@/workflow/workflow-diagram/constants/CreateStepNodeWidth';
 
 const StyledLabel = styled(Label)`
   color: ${({ theme }) => theme.tag.text.turquoise};
@@ -16,9 +17,7 @@ const StyledLabel = styled(Label)`
 type WorkflowDiagramSuccessEdgeProps = EdgeProps;
 
 export const WorkflowDiagramSuccessEdge = ({
-  sourceX,
   sourceY,
-  targetX,
   targetY,
   markerStart,
   markerEnd,
@@ -27,9 +26,9 @@ export const WorkflowDiagramSuccessEdge = ({
   const theme = useTheme();
 
   const [edgePath, labelX, labelY] = getStraightPath({
-    sourceX,
+    sourceX: CREATE_STEP_NODE_WIDTH,
     sourceY,
-    targetX,
+    targetX: CREATE_STEP_NODE_WIDTH,
     targetY,
   });
 


### PR DESCRIPTION
## Before
<img width="492" alt="image" src="https://github.com/user-attachments/assets/6c85baea-3b58-4196-87ab-dcc7bcb4e5ca" />

## After
<img width="477" alt="image" src="https://github.com/user-attachments/assets/0428f1f0-ef73-4fa1-b778-d1536a8b84e6" />
