### PR TITLE
Activate row when clicking on chip

### DIFF
--- a/packages/twenty-front/src/modules/object-record/components/RecordChip.tsx
+++ b/packages/twenty-front/src/modules/object-record/components/RecordChip.tsx
@@ -27,6 +27,7 @@ export type RecordChipProps = {
   size?: ChipSize;
   isLabelHidden?: boolean;
   triggerEvent?: TriggerEventType;
+  onclick?: () => void;
 };
 
 export const RecordChip = ({
@@ -40,6 +41,7 @@ export const RecordChip = ({
   forceDisableClick = false,
   isLabelHidden = false,
   triggerEvent = 'MOUSE_DOWN',
+  onclick,
 }: RecordChipProps) => {
   const { recordChipData } = useRecordChipData({
     objectNameSingular,
@@ -59,6 +61,7 @@ export const RecordChip = ({
           recordId: record.id,
           objectNameSingular,
         });
+        onclick?.();
       }
     : undefined;
 

--- a/packages/twenty-front/src/modules/object-record/components/RecordChip.tsx
+++ b/packages/twenty-front/src/modules/object-record/components/RecordChip.tsx
@@ -3,9 +3,10 @@ import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSi
 import { getLinkToShowPage } from '@/object-metadata/utils/getLinkToShowPage';
 import { useRecordChipData } from '@/object-record/hooks/useRecordChipData';
 import { recordIndexOpenRecordInState } from '@/object-record/record-index/states/recordIndexOpenRecordInState';
+import { RecordTableCellContext } from '@/object-record/record-table/contexts/RecordTableCellContext';
 import { ObjectRecord } from '@/object-record/types/ObjectRecord';
 import { ViewOpenRecordInType } from '@/views/types/ViewOpenRecordInType';
-import { MouseEvent } from 'react';
+import { MouseEvent, useContext } from 'react';
 import { useRecoilValue } from 'recoil';
 import {
   AvatarChip,
@@ -27,7 +28,6 @@ export type RecordChipProps = {
   size?: ChipSize;
   isLabelHidden?: boolean;
   triggerEvent?: TriggerEventType;
-  onclick?: () => void;
 };
 
 export const RecordChip = ({
@@ -41,7 +41,6 @@ export const RecordChip = ({
   forceDisableClick = false,
   isLabelHidden = false,
   triggerEvent = 'MOUSE_DOWN',
-  onclick,
 }: RecordChipProps) => {
   const { recordChipData } = useRecordChipData({
     objectNameSingular,
@@ -51,6 +50,7 @@ export const RecordChip = ({
   const { openRecordInCommandMenu } = useOpenRecordInCommandMenu();
 
   const recordIndexOpenRecordIn = useRecoilValue(recordIndexOpenRecordInState);
+  const { handleActivateRecordTableRow } = useContext(RecordTableCellContext);
 
   const isSidePanelViewOpenRecordInType =
     recordIndexOpenRecordIn === ViewOpenRecordInType.SIDE_PANEL;
@@ -61,7 +61,7 @@ export const RecordChip = ({
           recordId: record.id,
           objectNameSingular,
         });
-        onclick?.();
+        handleActivateRecordTableRow?.();
       }
     : undefined;
 

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/display/components/ChipFieldDisplay.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/display/components/ChipFieldDisplay.tsx
@@ -2,7 +2,6 @@ import { RecordChip } from '@/object-record/components/RecordChip';
 import { useChipFieldDisplay } from '@/object-record/record-field/meta-types/hooks/useChipFieldDisplay';
 import { RecordTableCellContext } from '@/object-record/record-table/contexts/RecordTableCellContext';
 import { useActiveRecordTableRow } from '@/object-record/record-table/hooks/useActiveRecordTableRow';
-import { useFocusedRecordTableRow } from '@/object-record/record-table/hooks/useFocusedRecordTableRow';
 import { useContext } from 'react';
 import { isDefined } from 'twenty-shared/utils';
 import { ChipSize } from 'twenty-ui/components';
@@ -20,10 +19,8 @@ export const ChipFieldDisplay = () => {
   const { cellPosition } = useContext(RecordTableCellContext);
 
   const { activateRecordTableRow } = useActiveRecordTableRow();
-  const { unfocusRecordTableRow } = useFocusedRecordTableRow();
   const onclick = () => {
     activateRecordTableRow(cellPosition.row);
-    unfocusRecordTableRow();
   };
 
   if (!isDefined(recordValue)) {

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/display/components/ChipFieldDisplay.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/display/components/ChipFieldDisplay.tsx
@@ -1,5 +1,10 @@
 import { RecordChip } from '@/object-record/components/RecordChip';
 import { useChipFieldDisplay } from '@/object-record/record-field/meta-types/hooks/useChipFieldDisplay';
+import { RecordTableCellContext } from '@/object-record/record-table/contexts/RecordTableCellContext';
+import { useRecordTableContextOrThrow } from '@/object-record/record-table/contexts/RecordTableContext';
+import { useActiveRecordTableRow } from '@/object-record/record-table/hooks/useActiveRecordTableRow';
+import { useFocusedRecordTableRow } from '@/object-record/record-table/hooks/useFocusedRecordTableRow';
+import { useContext } from 'react';
 import { isDefined } from 'twenty-shared/utils';
 import { ChipSize } from 'twenty-ui/components';
 
@@ -13,6 +18,15 @@ export const ChipFieldDisplay = () => {
     maxWidth,
     triggerEvent,
   } = useChipFieldDisplay();
+  const { recordTableId } = useRecordTableContextOrThrow();
+  const { cellPosition } = useContext(RecordTableCellContext);
+
+  const { activateRecordTableRow } = useActiveRecordTableRow(recordTableId);
+  const { unfocusRecordTableRow } = useFocusedRecordTableRow(recordTableId);
+  const onclick = () => {
+    activateRecordTableRow(cellPosition.row);
+    unfocusRecordTableRow();
+  };
 
   if (!isDefined(recordValue)) {
     return null;
@@ -28,6 +42,7 @@ export const ChipFieldDisplay = () => {
       isLabelHidden={isLabelIdentifierCompact}
       forceDisableClick={disableChipClick}
       triggerEvent={triggerEvent}
+      onclick={onclick}
     />
   );
 };

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/display/components/ChipFieldDisplay.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/display/components/ChipFieldDisplay.tsx
@@ -1,8 +1,5 @@
 import { RecordChip } from '@/object-record/components/RecordChip';
 import { useChipFieldDisplay } from '@/object-record/record-field/meta-types/hooks/useChipFieldDisplay';
-import { RecordTableCellContext } from '@/object-record/record-table/contexts/RecordTableCellContext';
-import { useActiveRecordTableRow } from '@/object-record/record-table/hooks/useActiveRecordTableRow';
-import { useContext } from 'react';
 import { isDefined } from 'twenty-shared/utils';
 import { ChipSize } from 'twenty-ui/components';
 
@@ -16,12 +13,6 @@ export const ChipFieldDisplay = () => {
     maxWidth,
     triggerEvent,
   } = useChipFieldDisplay();
-  const { cellPosition } = useContext(RecordTableCellContext);
-
-  const { activateRecordTableRow } = useActiveRecordTableRow();
-  const onclick = () => {
-    activateRecordTableRow(cellPosition.row);
-  };
 
   if (!isDefined(recordValue)) {
     return null;
@@ -37,7 +28,6 @@ export const ChipFieldDisplay = () => {
       isLabelHidden={isLabelIdentifierCompact}
       forceDisableClick={disableChipClick}
       triggerEvent={triggerEvent}
-      onclick={onclick}
     />
   );
 };

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/display/components/ChipFieldDisplay.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/display/components/ChipFieldDisplay.tsx
@@ -1,7 +1,6 @@
 import { RecordChip } from '@/object-record/components/RecordChip';
 import { useChipFieldDisplay } from '@/object-record/record-field/meta-types/hooks/useChipFieldDisplay';
 import { RecordTableCellContext } from '@/object-record/record-table/contexts/RecordTableCellContext';
-import { useRecordTableContextOrThrow } from '@/object-record/record-table/contexts/RecordTableContext';
 import { useActiveRecordTableRow } from '@/object-record/record-table/hooks/useActiveRecordTableRow';
 import { useFocusedRecordTableRow } from '@/object-record/record-table/hooks/useFocusedRecordTableRow';
 import { useContext } from 'react';
@@ -18,11 +17,10 @@ export const ChipFieldDisplay = () => {
     maxWidth,
     triggerEvent,
   } = useChipFieldDisplay();
-  const { recordTableId } = useRecordTableContextOrThrow();
   const { cellPosition } = useContext(RecordTableCellContext);
 
-  const { activateRecordTableRow } = useActiveRecordTableRow(recordTableId);
-  const { unfocusRecordTableRow } = useFocusedRecordTableRow(recordTableId);
+  const { activateRecordTableRow } = useActiveRecordTableRow();
+  const { unfocusRecordTableRow } = useFocusedRecordTableRow();
   const onclick = () => {
     activateRecordTableRow(cellPosition.row);
     unfocusRecordTableRow();

--- a/packages/twenty-front/src/modules/object-record/record-table/contexts/RecordTableCellContext.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/contexts/RecordTableCellContext.ts
@@ -7,6 +7,7 @@ import { TableCellPosition } from '@/object-record/record-table/types/TableCellP
 export type RecordTableCellContextValue = {
   columnDefinition: ColumnDefinition<FieldMetadata>;
   cellPosition: TableCellPosition;
+  handleActivateRecordTableRow?: () => void;
 };
 
 export const RecordTableCellContext =

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellPortalWrapper.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellPortalWrapper.tsx
@@ -2,7 +2,10 @@ import { useContextStoreObjectMetadataItemOrThrow } from '@/context-store/hooks/
 import { getBasePathToShowPage } from '@/object-metadata/utils/getBasePathToShowPage';
 import { recordIndexAllRecordIdsComponentSelector } from '@/object-record/record-index/states/selectors/recordIndexAllRecordIdsComponentSelector';
 import { RecordTableCellContext } from '@/object-record/record-table/contexts/RecordTableCellContext';
+import { useRecordTableContextOrThrow } from '@/object-record/record-table/contexts/RecordTableContext';
 import { RecordTableRowContextProvider } from '@/object-record/record-table/contexts/RecordTableRowContext';
+import { useActiveRecordTableRow } from '@/object-record/record-table/hooks/useActiveRecordTableRow';
+import { useFocusedRecordTableRow } from '@/object-record/record-table/hooks/useFocusedRecordTableRow';
 import { RecordTableCellFieldContextWrapper } from '@/object-record/record-table/record-table-cell/components/RecordTableCellFieldContextWrapper';
 import { visibleTableColumnsComponentSelector } from '@/object-record/record-table/states/selectors/visibleTableColumnsComponentSelector';
 import { TableCellPosition } from '@/object-record/record-table/types/TableCellPosition';
@@ -35,7 +38,15 @@ export const RecordTableCellPortalWrapper = ({
   if (!isDefined(anchorElement) || !isDefined(recordId)) {
     return null;
   }
+  const { recordTableId } = useRecordTableContextOrThrow();
+  const { unfocusRecordTableRow } = useFocusedRecordTableRow(recordTableId);
 
+  const { activateRecordTableRow } = useActiveRecordTableRow(recordTableId);
+
+  const handleActivateRecordTableRow = () => {
+    activateRecordTableRow(position.row);
+    unfocusRecordTableRow();
+  };
   return ReactDOM.createPortal(
     <RecordTableRowContextProvider
       value={{
@@ -54,6 +65,7 @@ export const RecordTableCellPortalWrapper = ({
         value={{
           columnDefinition: visibleTableColumns[position.column],
           cellPosition: position,
+          handleActivateRecordTableRow: handleActivateRecordTableRow,
         }}
       >
         <RecordTableCellFieldContextWrapper>

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellPortalWrapper.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellPortalWrapper.tsx
@@ -34,19 +34,19 @@ export const RecordTableCellPortalWrapper = ({
     visibleTableColumnsComponentSelector,
   );
 
-  const recordId = allRecordIds.at(position.row);
-  if (!isDefined(anchorElement) || !isDefined(recordId)) {
-    return null;
-  }
   const { recordTableId } = useRecordTableContextOrThrow();
   const { unfocusRecordTableRow } = useFocusedRecordTableRow(recordTableId);
 
   const { activateRecordTableRow } = useActiveRecordTableRow(recordTableId);
-
+  const recordId = allRecordIds.at(position.row);
   const handleActivateRecordTableRow = () => {
     activateRecordTableRow(position.row);
     unfocusRecordTableRow();
   };
+  if (!isDefined(anchorElement) || !isDefined(recordId)) {
+    return null;
+  }
+
   return ReactDOM.createPortal(
     <RecordTableRowContextProvider
       value={{

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellWrapper.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellWrapper.tsx
@@ -1,6 +1,9 @@
 import { FieldMetadata } from '@/object-record/record-field/types/FieldMetadata';
 import { RecordTableCellContext } from '@/object-record/record-table/contexts/RecordTableCellContext';
+import { useRecordTableContextOrThrow } from '@/object-record/record-table/contexts/RecordTableContext';
 import { useRecordTableRowContextOrThrow } from '@/object-record/record-table/contexts/RecordTableRowContext';
+import { useActiveRecordTableRow } from '@/object-record/record-table/hooks/useActiveRecordTableRow';
+import { useFocusedRecordTableRow } from '@/object-record/record-table/hooks/useFocusedRecordTableRow';
 import { RecordTableCellFieldContextWrapper } from '@/object-record/record-table/record-table-cell/components/RecordTableCellFieldContextWrapper';
 import { ColumnDefinition } from '@/object-record/record-table/types/ColumnDefinition';
 import { TableCellPosition } from '@/object-record/record-table/types/TableCellPosition';
@@ -24,12 +27,21 @@ export const RecordTableCellWrapper = ({
     }),
     [columnIndex, rowIndex],
   );
+  const { recordTableId } = useRecordTableContextOrThrow();
+  const { activateRecordTableRow } = useActiveRecordTableRow(recordTableId);
+  const { unfocusRecordTableRow } = useFocusedRecordTableRow(recordTableId);
+
+  const handleActivateRecordTableRow = () => {
+    activateRecordTableRow(rowIndex);
+    unfocusRecordTableRow();
+  };
 
   return (
     <RecordTableCellContext.Provider
       value={{
         columnDefinition: column,
         cellPosition: currentTableCellPosition,
+        handleActivateRecordTableRow: handleActivateRecordTableRow,
       }}
       key={column.fieldMetadataId}
     >


### PR DESCRIPTION
resolve #12223
I added an onClick function in ChipFieldDisplay that calls activateRecordTableRow, and I passed the onClick to the child RecordChip.
Please let me know if this approach is correct or close.
If it is correct, if you want, I can find a way to prevent the focus from being set on the first clicked chip.

https://github.com/user-attachments/assets/544c3c24-0455-4ccb-b444-bed377052e6e

