### PR TITLE
Fix ClientConfigProviderEffect infite loop

### DIFF
--- a/packages/twenty-front/src/modules/client-config/hooks/useClientConfig.ts
+++ b/packages/twenty-front/src/modules/client-config/hooks/useClientConfig.ts
@@ -40,6 +40,7 @@ export const useClientConfig = (): UseClientConfigResult => {
       setClientConfigApiStatus((prev) => ({
         ...prev,
         isLoading: false,
+        isLoadedOnce: true,
         isErrored: true,
         error,
       }));


### PR DESCRIPTION
Fixes an infinite loop introduced by #12371

An infinite loop was triggered when there was an error when fetching the client config.
Cause of the bug: `isLoadedOnce` wasn't set to true when catching an error in `useClientConfig`.

This effect then created an infinite loop inside `ClientConfigProviderEffect` because `fetchClientConfig` updated `clientConfigApiStatus.isLoading` but not `isLoadedOnce`.

```typescript
useEffect(() => {
    if (
      !clientConfigApiStatus.isLoadedOnce &&
      !clientConfigApiStatus.isLoading
    ) {
      fetchClientConfig();
    }
  }, [
    clientConfigApiStatus.isLoadedOnce,
    clientConfigApiStatus.isLoading,
    fetchClientConfig,
  ]);
```