### PR TITLE
Fix infinite loop on table load

### DIFF
--- a/packages/twenty-front/src/modules/object-record/hooks/useLazyFindManyRecords.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useLazyFindManyRecords.ts
@@ -94,8 +94,6 @@ export const useLazyFindManyRecords = <T extends ObjectRecord = ObjectRecord>({
           set(hasNextPageFamilyState(queryIdentifier), false);
           set(cursorFamilyState(queryIdentifier), '');
 
-          onCompleted?.([]);
-
           return {
             data: null,
             loading: false,
@@ -124,7 +122,6 @@ export const useLazyFindManyRecords = <T extends ObjectRecord = ObjectRecord>({
       findManyRecords,
       objectMetadataItem.namePlural,
       queryIdentifier,
-      onCompleted,
     ],
   );
 

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-body/components/RecordTableNoRecordGroupBodyEffect.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-body/components/RecordTableNoRecordGroupBodyEffect.tsx
@@ -140,16 +140,14 @@ export const RecordTableNoRecordGroupBodyEffect = () => {
   ]);
 
   useEffect(() => {
+    setIsRecordTableInitialLoading(false);
+
     if (showAuthModal) {
-      setIsRecordTableInitialLoading(false);
       return;
     }
-  }, [showAuthModal, setIsRecordTableInitialLoading]);
 
-  useEffect(() => {
     findManyRecords();
-    setIsRecordTableInitialLoading(false);
-  }, [findManyRecords, setIsRecordTableInitialLoading]);
+  }, [findManyRecords, setIsRecordTableInitialLoading, showAuthModal]);
 
   return <></>;
 };

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-body/components/RecordTableNoRecordGroupBodyEffect.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-body/components/RecordTableNoRecordGroupBodyEffect.tsx
@@ -148,7 +148,8 @@ export const RecordTableNoRecordGroupBodyEffect = () => {
 
   useEffect(() => {
     findManyRecords();
-  }, [findManyRecords]);
+    setIsRecordTableInitialLoading(false);
+  }, [findManyRecords, setIsRecordTableInitialLoading]);
 
   return <></>;
 };

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-body/components/RecordTableNoRecordGroupBodyEffect.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-body/components/RecordTableNoRecordGroupBodyEffect.tsx
@@ -8,7 +8,6 @@ import { ROW_HEIGHT } from '@/object-record/record-table/constants/RowHeight';
 import { useRecordTableContextOrThrow } from '@/object-record/record-table/contexts/RecordTableContext';
 import { useRecordTable } from '@/object-record/record-table/hooks/useRecordTable';
 import { hasRecordTableFetchedAllRecordsComponentStateV2 } from '@/object-record/record-table/states/hasRecordTableFetchedAllRecordsComponentStateV2';
-import { isRecordTableInitialLoadingComponentState } from '@/object-record/record-table/states/isRecordTableInitialLoadingComponentState';
 import { tableEncounteredUnrecoverableErrorComponentState } from '@/object-record/record-table/states/tableEncounteredUnrecoverableErrorComponentState';
 import { tableLastRowVisibleComponentState } from '@/object-record/record-table/states/tableLastRowVisibleComponentState';
 import { isFetchingMoreRecordsFamilyState } from '@/object-record/states/isFetchingMoreRecordsFamilyState';
@@ -57,10 +56,6 @@ export const RecordTableNoRecordGroupBodyEffect = () => {
 
   const [lastShowPageRecordId, setLastShowPageRecordId] = useRecoilState(
     lastShowPageRecordIdState,
-  );
-
-  const isRecordTableInitialLoading = useRecoilComponentValueV2(
-    isRecordTableInitialLoadingComponentState,
   );
 
   const { scrollToPosition } = useScrollToPosition();
@@ -152,15 +147,8 @@ export const RecordTableNoRecordGroupBodyEffect = () => {
   }, [showAuthModal, setIsRecordTableInitialLoading]);
 
   useEffect(() => {
-    if (!isRecordTableInitialLoading) {
-      setIsRecordTableInitialLoading(false);
-      findManyRecords();
-    }
-  }, [
-    findManyRecords,
-    setIsRecordTableInitialLoading,
-    isRecordTableInitialLoading,
-  ]);
+    findManyRecords();
+  }, [findManyRecords]);
 
   return <></>;
 };

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-body/components/RecordTableNoRecordGroupBodyEffect.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-body/components/RecordTableNoRecordGroupBodyEffect.tsx
@@ -8,6 +8,7 @@ import { ROW_HEIGHT } from '@/object-record/record-table/constants/RowHeight';
 import { useRecordTableContextOrThrow } from '@/object-record/record-table/contexts/RecordTableContext';
 import { useRecordTable } from '@/object-record/record-table/hooks/useRecordTable';
 import { hasRecordTableFetchedAllRecordsComponentStateV2 } from '@/object-record/record-table/states/hasRecordTableFetchedAllRecordsComponentStateV2';
+import { isRecordTableInitialLoadingComponentState } from '@/object-record/record-table/states/isRecordTableInitialLoadingComponentState';
 import { tableEncounteredUnrecoverableErrorComponentState } from '@/object-record/record-table/states/tableEncounteredUnrecoverableErrorComponentState';
 import { tableLastRowVisibleComponentState } from '@/object-record/record-table/states/tableLastRowVisibleComponentState';
 import { isFetchingMoreRecordsFamilyState } from '@/object-record/states/isFetchingMoreRecordsFamilyState';
@@ -58,7 +59,9 @@ export const RecordTableNoRecordGroupBodyEffect = () => {
     lastShowPageRecordIdState,
   );
 
-  const [hasInitialized, setHasInitialized] = useState(false);
+  const isRecordTableInitialLoading = useRecoilComponentValueV2(
+    isRecordTableInitialLoadingComponentState,
+  );
 
   const { scrollToPosition } = useScrollToPosition();
 
@@ -146,16 +149,17 @@ export const RecordTableNoRecordGroupBodyEffect = () => {
       setIsRecordTableInitialLoading(false);
       return;
     }
+  }, [showAuthModal, setIsRecordTableInitialLoading]);
 
-    if (!hasInitialized) {
+  useEffect(() => {
+    if (!isRecordTableInitialLoading) {
+      setIsRecordTableInitialLoading(false);
       findManyRecords();
-      setHasInitialized(true);
     }
   }, [
     findManyRecords,
-    hasInitialized,
     setIsRecordTableInitialLoading,
-    showAuthModal,
+    isRecordTableInitialLoading,
   ]);
 
   return <></>;


### PR DESCRIPTION
This was a tough one:
- we should avoid updating lazy findManyRecords function with onCompleted callback, this is prone to infinite loops