### PR TITLE
Pin the Node.js version for Volta

### DIFF
--- a/package.json
+++ b/package.json
@@ -374,5 +374,8 @@
       "packages/twenty-shared",
       "tools/eslint-rules"
     ]
+  },
+  "volta": {
+    "node": "22.16.0"
   }
 }

--- a/packages/twenty-emails/package.json
+++ b/packages/twenty-emails/package.json
@@ -36,5 +36,8 @@
     "node": "^22.12.0",
     "npm": "please-use-yarn",
     "yarn": "^4.0.2"
+  },
+  "volta": {
+    "node": "22.16.0"
   }
 }

--- a/packages/twenty-front/package.json
+++ b/packages/twenty-front/package.json
@@ -87,5 +87,8 @@
     "eslint-plugin-unused-imports": "^3.0.0",
     "optionator": "^0.9.1",
     "rollup-plugin-visualizer": "^5.14.0"
+  },
+  "volta": {
+    "node": "22.16.0"
   }
 }

--- a/packages/twenty-server/package.json
+++ b/packages/twenty-server/package.json
@@ -93,5 +93,8 @@
     "node": "^22.12.0",
     "npm": "please-use-yarn",
     "yarn": "^4.0.2"
+  },
+  "volta": {
+    "node": "22.16.0"
   }
 }

--- a/packages/twenty-shared/package.json
+++ b/packages/twenty-shared/package.json
@@ -44,5 +44,8 @@
     "types",
     "utils",
     "workspace"
-  ]
+  ],
+  "volta": {
+    "node": "22.16.0"
+  }
 }

--- a/packages/twenty-zapier/package.json
+++ b/packages/twenty-zapier/package.json
@@ -31,5 +31,8 @@
   },
   "installConfig": {
     "hoistingLimits": "dependencies"
+  },
+  "volta": {
+    "node": "22.16.0"
   }
 }


### PR DESCRIPTION
I use [Volta](https://volta.sh/) to manage my node, npm, and yarn versions for each project. In this PR, I pinned the last LTS version for every package. This will only impact developers using Volta on their computers.