### PR TITLE
Stop forwarding the `active` prop for the `TabButton` component

### DIFF
--- a/packages/twenty-ui/src/input/button/components/TabButton.tsx
+++ b/packages/twenty-ui/src/input/button/components/TabButton.tsx
@@ -1,3 +1,4 @@
+import isPropValid from '@emotion/is-prop-valid';
 import styled from '@emotion/styled';
 import { Pill } from '@ui/components/Pill/Pill';
 import { Avatar, IconComponent } from '@ui/display';
@@ -5,7 +6,9 @@ import { ThemeContext } from '@ui/theme';
 import { ReactElement, useContext } from 'react';
 import { Link } from 'react-router-dom';
 
-const StyledTabButton = styled.button<{
+const StyledTabButton = styled('button', {
+  shouldForwardProp: (prop) => isPropValid(prop) && prop !== 'active',
+})<{
   active?: boolean;
   disabled?: boolean;
   to?: string;


### PR DESCRIPTION
This error was triggered:

![CleanShot 2025-06-09 at 14 49 45@2x](https://github.com/user-attachments/assets/9cc02f99-aead-40ec-aec1-33a6f8a4b81f)
