### PR TITLE
chip-count-black-mode

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/expandable-list/components/ExpandableList.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/expandable-list/components/ExpandableList.tsx
@@ -4,9 +4,9 @@ import { ReactElement, useCallback, useEffect, useRef, useState } from 'react';
 import { ExpandedListDropdown } from '@/ui/layout/expandable-list/components/ExpandedListDropdown';
 import { isFirstOverflowingChildElement } from '@/ui/layout/expandable-list/utils/isFirstOverflowingChildElement';
 import { isDefined } from 'twenty-shared/utils';
-import { AnimatedContainer } from 'twenty-ui/utilities';
 import { ChipSize } from 'twenty-ui/components';
 import { OverflowingTextWithTooltip } from 'twenty-ui/display';
+import { AnimatedContainer } from 'twenty-ui/utilities';
 
 const StyledContainer = styled.div`
   align-items: center;
@@ -37,6 +37,7 @@ const StyledChildContainer = styled.div`
 `;
 
 const StyledUnShrinkableContainer = styled.div`
+  color: ${({ theme }) => theme.font.color.primary};
   flex-shrink: 0;
 `;
 


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/01b4576d-2409-4bf0-8fa7-bd39ad00ded5)

Add chip count display for black mode in participant chips.

Improves visual clarity for participant lists in calendar events.

Fix https://github.com/twentyhq/twenty/issues/12473