### PR TITLE
Fix permissions V1's guest role

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/components/FieldContextProvider.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/components/FieldContextProvider.tsx
@@ -1,5 +1,6 @@
 import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
 import { formatFieldMetadataItemAsColumnDefinition } from '@/object-metadata/utils/formatFieldMetadataItemAsColumnDefinition';
+import { useObjectPermissionsForObject } from '@/object-record/hooks/useObjectPermissionsForObject';
 import { useUpdateOneRecord } from '@/object-record/hooks/useUpdateOneRecord';
 import {
   FieldContext,
@@ -33,7 +34,11 @@ export const FieldContextProvider = ({
     objectNameSingular,
   });
 
-  const fieldMetadataItem = objectMetadataItem?.fields.find(
+  const objectPermissions = useObjectPermissionsForObject(
+    objectMetadataItem.id,
+  );
+
+  const fieldMetadataItem = objectMetadataItem.fields.find(
     (field) => field.name === fieldMetadataName,
   );
 
@@ -73,7 +78,11 @@ export const FieldContextProvider = ({
           customUseUpdateOneObjectHook ?? useUpdateOneObjectMutation,
         clearable,
         overridenIsFieldEmpty,
-        isReadOnly: false,
+        isReadOnly:
+          objectPermissions.canReadObjectRecords === true &&
+          objectPermissions.canUpdateObjectRecords === false &&
+          objectPermissions.canDestroyObjectRecords === false &&
+          objectPermissions.canSoftDeleteObjectRecords === false,
       }}
     >
       {children}

--- a/packages/twenty-server/src/engine/core-modules/user/user.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/user.resolver.ts
@@ -147,13 +147,22 @@ export class UserResolver {
         objectRecordsPermissions = permissions.objectRecordsPermissions;
       } else {
         const permissions =
-          await this.permissionsService.getUserWorkspacePermissions({
+          await this.permissionsService.getUserWorkspacePermissionsV1({
             userWorkspaceId: currentUserWorkspace.id,
             workspaceId: workspace.id,
           });
 
         settingsPermissions = permissions.settingsPermissions;
         objectRecordsPermissions = permissions.objectRecordsPermissions;
+        objectPermissions = Object.entries(permissions.objectPermissions).map(
+          ([objectMetadataId, permissions]) => ({
+            objectMetadataId,
+            canReadObjectRecords: permissions.canRead,
+            canUpdateObjectRecords: permissions.canUpdate,
+            canSoftDeleteObjectRecords: permissions.canSoftDelete,
+            canDestroyObjectRecords: permissions.canDestroy,
+          }),
+        );
       }
     }
 

--- a/packages/twenty-server/src/engine/metadata-modules/permissions/permissions.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/permissions/permissions.service.ts
@@ -100,7 +100,7 @@ export class PermissionsService {
     };
   }
 
-  public async getUserWorkspacePermissions({
+  public async getUserWorkspacePermissionsV1({
     userWorkspaceId,
     workspaceId,
   }: {
@@ -109,6 +109,7 @@ export class PermissionsService {
   }): Promise<{
     settingsPermissions: Record<SettingPermissionType, boolean>;
     objectRecordsPermissions: Record<PermissionsOnAllObjectRecords, boolean>;
+    objectPermissions: ObjectRecordsPermissions;
   }> {
     const [roleOfUserWorkspace] = await this.userRoleService
       .getRolesByUserWorkspaces({
@@ -158,9 +159,17 @@ export class PermissionsService {
         roleOfUserWorkspace.canDestroyAllObjectRecords ?? false,
     };
 
+    const { data: rolesPermissions } =
+      await this.workspacePermissionsCacheService.getRolesPermissionsFromCache({
+        workspaceId,
+      });
+
+    const objectPermissions = rolesPermissions[roleOfUserWorkspace.id] ?? {};
+
     return {
       settingsPermissions: settingsPermissionsMap,
       objectRecordsPermissions: objectRecordsPermissionsMap,
+      objectPermissions,
     };
   }
 

--- a/packages/twenty-server/src/engine/metadata-modules/workspace-permissions-cache/workspace-permissions-cache.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/workspace-permissions-cache/workspace-permissions-cache.service.ts
@@ -258,10 +258,12 @@ export class WorkspacePermissionsCacheService {
       for (const objectMetadata of workspaceObjectMetadataCollection) {
         const { id: objectMetadataId, isSystem } = objectMetadata;
 
-        let canRead = role.canReadAllObjectRecords;
-        let canUpdate = role.canUpdateAllObjectRecords;
-        let canSoftDelete = role.canSoftDeleteAllObjectRecords;
-        let canDestroy = role.canDestroyAllObjectRecords;
+        let canRead = isSystem ? true : role.canReadAllObjectRecords;
+        let canUpdate = isSystem ? true : role.canUpdateAllObjectRecords;
+        let canSoftDelete = isSystem
+          ? true
+          : role.canSoftDeleteAllObjectRecords;
+        let canDestroy = isSystem ? true : role.canDestroyAllObjectRecords;
 
         if (isPermissionsV2Enabled) {
           const objectRecordPermissionsOverride = role.objectPermissions.find(


### PR DESCRIPTION
In the FE we have started relying on currentUser.objectPermissions instead of currentUser.objectRecordsPermissions, but we do not populate currentUser.objectPermissions for permissions V1 and fallback to `true` for the permissions on object records.
As a consequence, workspaces with seeded guest role (a role which has read but not update, etc. permissions) do not offer the right UI for guest users who see and interact with everything as if they have update permissions which they don't, so they can try to update something and it will fail. 

This PR 
- populates objectPermissions for permission V1 
- reads that value to compute FieldContextProvider's isReadOnly value. This is a quick mitigation, it does not solve all the cases where we currently do not have the right read-only value (from the side panel it is still possible to try to edit values despite not having update permissions). Also I see a lot of isReadOnly in the code while read only will not make sense with permissions V2, I don't know if it is planned to replace all of them? @Weiko 