### PR TITLE
Close command menu after destroy

### DIFF
--- a/packages/twenty-front/src/modules/action-menu/actions/components/Action.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/components/Action.tsx
@@ -5,17 +5,19 @@ import { useContext } from 'react';
 
 export const Action = ({
   onClick,
-  sidePanelOptions,
+  closeSidePanelOnShowPageOptionsActionExecution = false,
+  closeSidePanelOnCommandMenuListActionExecution = true,
 }: {
   onClick: () => void;
-  sidePanelOptions?: {
-    closeOnShowPageOptionsActionExecution?: boolean;
-    closeOnCommandMenuListActionExecution?: boolean;
-  };
+  closeSidePanelOnShowPageOptionsActionExecution?: boolean;
+  closeSidePanelOnCommandMenuListActionExecution?: boolean;
 }) => {
   const actionConfig = useContext(ActionConfigContext);
 
-  const { closeActionMenu } = useCloseActionMenu({ sidePanelOptions });
+  const { closeActionMenu } = useCloseActionMenu({
+    closeSidePanelOnShowPageOptionsActionExecution,
+    closeSidePanelOnCommandMenuListActionExecution,
+  });
 
   if (!actionConfig) {
     return null;

--- a/packages/twenty-front/src/modules/action-menu/actions/components/Action.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/components/Action.tsx
@@ -5,14 +5,17 @@ import { useContext } from 'react';
 
 export const Action = ({
   onClick,
-  preventCommandMenuClosing,
+  sidePanelOptions,
 }: {
   onClick: () => void;
-  preventCommandMenuClosing?: boolean;
+  sidePanelOptions?: {
+    closeOnShowPageOptionsActionExecution?: boolean;
+    closeOnCommandMenuListActionExecution?: boolean;
+  };
 }) => {
   const actionConfig = useContext(ActionConfigContext);
 
-  const { closeActionMenu } = useCloseActionMenu({ preventCommandMenuClosing });
+  const { closeActionMenu } = useCloseActionMenu({ sidePanelOptions });
 
   if (!actionConfig) {
     return null;

--- a/packages/twenty-front/src/modules/action-menu/actions/components/Action.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/components/Action.tsx
@@ -12,7 +12,7 @@ export const Action = ({
 }) => {
   const actionConfig = useContext(ActionConfigContext);
 
-  const { closeActionMenu } = useCloseActionMenu(preventCommandMenuClosing);
+  const { closeActionMenu } = useCloseActionMenu({ preventCommandMenuClosing });
 
   if (!actionConfig) {
     return null;

--- a/packages/twenty-front/src/modules/action-menu/actions/components/ActionModal.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/components/ActionModal.tsx
@@ -18,7 +18,7 @@ export type ActionModalProps = {
   confirmButtonText?: string;
   confirmButtonAccent?: ButtonAccent;
   isLoading?: boolean;
-  forceCommandMenuClosing?: boolean;
+  closeCommandMenuFromShowPageOptionsMenu?: boolean;
 };
 
 export const ActionModal = ({
@@ -28,12 +28,12 @@ export const ActionModal = ({
   confirmButtonText = 'Confirm',
   confirmButtonAccent = 'danger',
   isLoading = false,
-  forceCommandMenuClosing = false,
+  closeCommandMenuFromShowPageOptionsMenu = false,
 }: ActionModalProps) => {
   const { openModal } = useModal();
 
   const { closeActionMenu } = useCloseActionMenu({
-    forceCommandMenuClosing,
+    closeCommandMenuFromShowPageOptionsMenu,
   });
 
   const handleConfirmClick = () => {

--- a/packages/twenty-front/src/modules/action-menu/actions/components/ActionModal.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/components/ActionModal.tsx
@@ -18,6 +18,7 @@ export type ActionModalProps = {
   confirmButtonText?: string;
   confirmButtonAccent?: ButtonAccent;
   isLoading?: boolean;
+  forceCommandMenuClosing?: boolean;
 };
 
 export const ActionModal = ({
@@ -27,10 +28,13 @@ export const ActionModal = ({
   confirmButtonText = 'Confirm',
   confirmButtonAccent = 'danger',
   isLoading = false,
+  forceCommandMenuClosing = false,
 }: ActionModalProps) => {
   const { openModal } = useModal();
 
-  const { closeActionMenu } = useCloseActionMenu();
+  const { closeActionMenu } = useCloseActionMenu({
+    forceCommandMenuClosing,
+  });
 
   const handleConfirmClick = () => {
     onConfirmClick();

--- a/packages/twenty-front/src/modules/action-menu/actions/components/ActionModal.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/components/ActionModal.tsx
@@ -18,7 +18,10 @@ export type ActionModalProps = {
   confirmButtonText?: string;
   confirmButtonAccent?: ButtonAccent;
   isLoading?: boolean;
-  closeCommandMenuFromShowPageOptionsMenu?: boolean;
+  sidePanelOptions?: {
+    closeOnShowPageOptionsActionExecution: false;
+    closeOnCommandMenuListActionExecution: true;
+  };
 };
 
 export const ActionModal = ({
@@ -28,12 +31,12 @@ export const ActionModal = ({
   confirmButtonText = 'Confirm',
   confirmButtonAccent = 'danger',
   isLoading = false,
-  closeCommandMenuFromShowPageOptionsMenu = false,
+  sidePanelOptions,
 }: ActionModalProps) => {
   const { openModal } = useModal();
 
   const { closeActionMenu } = useCloseActionMenu({
-    closeCommandMenuFromShowPageOptionsMenu,
+    sidePanelOptions,
   });
 
   const handleConfirmClick = () => {

--- a/packages/twenty-front/src/modules/action-menu/actions/components/ActionModal.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/components/ActionModal.tsx
@@ -18,10 +18,8 @@ export type ActionModalProps = {
   confirmButtonText?: string;
   confirmButtonAccent?: ButtonAccent;
   isLoading?: boolean;
-  sidePanelOptions?: {
-    closeOnShowPageOptionsActionExecution: false;
-    closeOnCommandMenuListActionExecution: true;
-  };
+  closeSidePanelOnShowPageOptionsActionExecution?: boolean;
+  closeSidePanelOnCommandMenuListActionExecution?: boolean;
 };
 
 export const ActionModal = ({
@@ -31,12 +29,14 @@ export const ActionModal = ({
   confirmButtonText = 'Confirm',
   confirmButtonAccent = 'danger',
   isLoading = false,
-  sidePanelOptions,
+  closeSidePanelOnShowPageOptionsActionExecution,
+  closeSidePanelOnCommandMenuListActionExecution,
 }: ActionModalProps) => {
   const { openModal } = useModal();
 
   const { closeActionMenu } = useCloseActionMenu({
-    sidePanelOptions,
+    closeSidePanelOnShowPageOptionsActionExecution,
+    closeSidePanelOnCommandMenuListActionExecution,
   });
 
   const handleConfirmClick = () => {

--- a/packages/twenty-front/src/modules/action-menu/actions/record-actions/multiple-records/components/DestroyMultipleRecordsAction.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-actions/multiple-records/components/DestroyMultipleRecordsAction.tsx
@@ -80,7 +80,7 @@ export const DestroyMultipleRecordsAction = () => {
       subtitle="Are you sure you want to destroy these records? They won't be recoverable anymore."
       onConfirmClick={handleDestroyClick}
       confirmButtonText="Destroy Records"
-      forceCommandMenuClosing={true}
+      closeCommandMenuFromShowPageOptionsMenu={true}
     />
   );
 };

--- a/packages/twenty-front/src/modules/action-menu/actions/record-actions/multiple-records/components/DestroyMultipleRecordsAction.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-actions/multiple-records/components/DestroyMultipleRecordsAction.tsx
@@ -80,6 +80,7 @@ export const DestroyMultipleRecordsAction = () => {
       subtitle="Are you sure you want to destroy these records? They won't be recoverable anymore."
       onConfirmClick={handleDestroyClick}
       confirmButtonText="Destroy Records"
+      forceCommandMenuClosing={true}
     />
   );
 };

--- a/packages/twenty-front/src/modules/action-menu/actions/record-actions/multiple-records/components/DestroyMultipleRecordsAction.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-actions/multiple-records/components/DestroyMultipleRecordsAction.tsx
@@ -80,7 +80,6 @@ export const DestroyMultipleRecordsAction = () => {
       subtitle="Are you sure you want to destroy these records? They won't be recoverable anymore."
       onConfirmClick={handleDestroyClick}
       confirmButtonText="Destroy Records"
-      closeCommandMenuFromShowPageOptionsMenu={true}
     />
   );
 };

--- a/packages/twenty-front/src/modules/action-menu/actions/record-actions/no-selection/components/CreateNewTableRecordNoSelectionRecordAction.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-actions/no-selection/components/CreateNewTableRecordNoSelectionRecordAction.tsx
@@ -10,6 +10,9 @@ export const CreateNewTableRecordNoSelectionRecordAction = () => {
   });
 
   return (
-    <Action onClick={() => createNewIndexRecord()} preventCommandMenuClosing />
+    <Action
+      onClick={() => createNewIndexRecord()}
+      closeSidePanelOnCommandMenuListActionExecution={false}
+    />
   );
 };

--- a/packages/twenty-front/src/modules/action-menu/actions/record-actions/single-record/components/DestroySingleRecordAction.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-actions/single-record/components/DestroySingleRecordAction.tsx
@@ -36,7 +36,7 @@ export const DestroySingleRecordAction = () => {
       subtitle="Are you sure you want to destroy this record? It cannot be recovered anymore."
       onConfirmClick={handleDeleteClick}
       confirmButtonText="Permanently Destroy Record"
-      forceCommandMenuClosing={true}
+      closeCommandMenuFromShowPageOptionsMenu={true}
     />
   );
 };

--- a/packages/twenty-front/src/modules/action-menu/actions/record-actions/single-record/components/DestroySingleRecordAction.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-actions/single-record/components/DestroySingleRecordAction.tsx
@@ -36,6 +36,7 @@ export const DestroySingleRecordAction = () => {
       subtitle="Are you sure you want to destroy this record? It cannot be recovered anymore."
       onConfirmClick={handleDeleteClick}
       confirmButtonText="Permanently Destroy Record"
+      forceCommandMenuClosing={true}
     />
   );
 };

--- a/packages/twenty-front/src/modules/action-menu/actions/record-actions/single-record/components/DestroySingleRecordAction.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-actions/single-record/components/DestroySingleRecordAction.tsx
@@ -36,7 +36,7 @@ export const DestroySingleRecordAction = () => {
       subtitle="Are you sure you want to destroy this record? It cannot be recovered anymore."
       onConfirmClick={handleDeleteClick}
       confirmButtonText="Permanently Destroy Record"
-      closeCommandMenuFromShowPageOptionsMenu={true}
+      closeSidePanelOnShowPageOptionsActionExecution={true}
     />
   );
 };

--- a/packages/twenty-front/src/modules/action-menu/hooks/useCloseActionMenu.ts
+++ b/packages/twenty-front/src/modules/action-menu/hooks/useCloseActionMenu.ts
@@ -8,7 +8,13 @@ import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/com
 import { useContext } from 'react';
 import { isDefined } from 'twenty-shared/utils';
 
-export const useCloseActionMenu = (preventCommandMenuClosing?: boolean) => {
+export const useCloseActionMenu = ({
+  preventCommandMenuClosing = false,
+  forceCommandMenuClosing = false,
+}: {
+  preventCommandMenuClosing?: boolean;
+  forceCommandMenuClosing?: boolean;
+} = {}) => {
   const { actionMenuType, isInRightDrawer } = useContext(ActionMenuContext);
 
   const { closeCommandMenu } = useCommandMenu();
@@ -36,6 +42,14 @@ export const useCloseActionMenu = (preventCommandMenuClosing?: boolean) => {
       actionMenuType === 'command-menu-show-page-action-menu-dropdown'
     ) {
       closeDropdown(dropdownId);
+    }
+
+    if (
+      actionMenuType === 'command-menu-show-page-action-menu-dropdown' &&
+      isDefined(forceCommandMenuClosing) &&
+      forceCommandMenuClosing
+    ) {
+      closeCommandMenu();
     }
   };
 

--- a/packages/twenty-front/src/modules/action-menu/hooks/useCloseActionMenu.ts
+++ b/packages/twenty-front/src/modules/action-menu/hooks/useCloseActionMenu.ts
@@ -10,10 +10,10 @@ import { isDefined } from 'twenty-shared/utils';
 
 export const useCloseActionMenu = ({
   preventCommandMenuClosing = false,
-  forceCommandMenuClosing = false,
+  closeCommandMenuFromShowPageOptionsMenu = false,
 }: {
   preventCommandMenuClosing?: boolean;
-  forceCommandMenuClosing?: boolean;
+  closeCommandMenuFromShowPageOptionsMenu?: boolean;
 } = {}) => {
   const { actionMenuType, isInRightDrawer } = useContext(ActionMenuContext);
 
@@ -46,8 +46,8 @@ export const useCloseActionMenu = ({
 
     if (
       actionMenuType === 'command-menu-show-page-action-menu-dropdown' &&
-      isDefined(forceCommandMenuClosing) &&
-      forceCommandMenuClosing
+      isDefined(closeCommandMenuFromShowPageOptionsMenu) &&
+      closeCommandMenuFromShowPageOptionsMenu
     ) {
       closeCommandMenu();
     }

--- a/packages/twenty-front/src/modules/action-menu/hooks/useCloseActionMenu.ts
+++ b/packages/twenty-front/src/modules/action-menu/hooks/useCloseActionMenu.ts
@@ -9,15 +9,11 @@ import { useContext } from 'react';
 import { isDefined } from 'twenty-shared/utils';
 
 export const useCloseActionMenu = ({
-  sidePanelOptions = {
-    closeOnShowPageOptionsActionExecution: false,
-    closeOnCommandMenuListActionExecution: true,
-  },
+  closeSidePanelOnShowPageOptionsActionExecution = false,
+  closeSidePanelOnCommandMenuListActionExecution = true,
 }: {
-  sidePanelOptions?: {
-    closeOnShowPageOptionsActionExecution?: boolean;
-    closeOnCommandMenuListActionExecution?: boolean;
-  };
+  closeSidePanelOnShowPageOptionsActionExecution?: boolean;
+  closeSidePanelOnCommandMenuListActionExecution?: boolean;
 } = {}) => {
   const { actionMenuType, isInRightDrawer } = useContext(ActionMenuContext);
 
@@ -36,8 +32,8 @@ export const useCloseActionMenu = ({
   const closeActionMenu = () => {
     if (actionMenuType === 'command-menu') {
       if (
-        isDefined(sidePanelOptions.closeOnCommandMenuListActionExecution) &&
-        !sidePanelOptions.closeOnCommandMenuListActionExecution
+        isDefined(closeSidePanelOnCommandMenuListActionExecution) &&
+        !closeSidePanelOnCommandMenuListActionExecution
       ) {
         return;
       }
@@ -53,8 +49,8 @@ export const useCloseActionMenu = ({
 
     if (
       actionMenuType === 'command-menu-show-page-action-menu-dropdown' &&
-      isDefined(sidePanelOptions.closeOnShowPageOptionsActionExecution) &&
-      sidePanelOptions.closeOnShowPageOptionsActionExecution
+      isDefined(closeSidePanelOnShowPageOptionsActionExecution) &&
+      closeSidePanelOnShowPageOptionsActionExecution
     ) {
       closeCommandMenu();
     }

--- a/packages/twenty-front/src/modules/action-menu/hooks/useCloseActionMenu.ts
+++ b/packages/twenty-front/src/modules/action-menu/hooks/useCloseActionMenu.ts
@@ -9,11 +9,15 @@ import { useContext } from 'react';
 import { isDefined } from 'twenty-shared/utils';
 
 export const useCloseActionMenu = ({
-  preventCommandMenuClosing = false,
-  closeCommandMenuFromShowPageOptionsMenu = false,
+  sidePanelOptions = {
+    closeOnShowPageOptionsActionExecution: false,
+    closeOnCommandMenuListActionExecution: true,
+  },
 }: {
-  preventCommandMenuClosing?: boolean;
-  closeCommandMenuFromShowPageOptionsMenu?: boolean;
+  sidePanelOptions?: {
+    closeOnShowPageOptionsActionExecution?: boolean;
+    closeOnCommandMenuListActionExecution?: boolean;
+  };
 } = {}) => {
   const { actionMenuType, isInRightDrawer } = useContext(ActionMenuContext);
 
@@ -31,7 +35,10 @@ export const useCloseActionMenu = ({
 
   const closeActionMenu = () => {
     if (actionMenuType === 'command-menu') {
-      if (isDefined(preventCommandMenuClosing) && preventCommandMenuClosing) {
+      if (
+        isDefined(sidePanelOptions.closeOnCommandMenuListActionExecution) &&
+        !sidePanelOptions.closeOnCommandMenuListActionExecution
+      ) {
         return;
       }
       closeCommandMenu();
@@ -46,8 +53,8 @@ export const useCloseActionMenu = ({
 
     if (
       actionMenuType === 'command-menu-show-page-action-menu-dropdown' &&
-      isDefined(closeCommandMenuFromShowPageOptionsMenu) &&
-      closeCommandMenuFromShowPageOptionsMenu
+      isDefined(sidePanelOptions.closeOnShowPageOptionsActionExecution) &&
+      sidePanelOptions.closeOnShowPageOptionsActionExecution
     ) {
       closeCommandMenu();
     }

--- a/packages/twenty-front/src/modules/command-menu/hooks/useCommandMenuSearchRecords.tsx
+++ b/packages/twenty-front/src/modules/command-menu/hooks/useCommandMenuSearchRecords.tsx
@@ -76,7 +76,7 @@ export const useCommandMenuSearchRecords = () => {
                         objectNameSingular: CoreObjectNameSingular.Note,
                       });
                 }}
-                preventCommandMenuClosing
+                closeSidePanelOnCommandMenuListActionExecution={false}
               />
             ),
           };


### PR DESCRIPTION
Added an argument `closeCommandMenuFromShowPageOptionsMenu` which allows us to not only close the parent action menu if the action is located inside the record page action menu dropdown, but to also close the command menu after, which is the behavior we want for the destroy action.