### PR TITLE
Fix workflow run tab not displaying when navigating from side panel to full page

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/tab-list/components/TabList.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/tab-list/components/TabList.tsx
@@ -71,7 +71,8 @@ export const TabList = ({
   const [containerWidth, setContainerWidth] = useState(0);
   const [moreButtonWidth, setMoreButtonWidth] = useState(0);
 
-  const initialActiveTabId = activeTabId || visibleTabs[0]?.id || '';
+  const activeTabExists = visibleTabs.some((tab) => tab.id === activeTabId);
+  const initialActiveTabId = activeTabExists ? activeTabId : visibleTabs[0]?.id;
 
   const visibleTabCount = useMemo(() => {
     return calculateVisibleTabCount({


### PR DESCRIPTION
closes https://github.com/twentyhq/core-team-issues/issues/1076
## Problem
When opening a workflow run in the side panel and then navigating to the full page view, the workflow visualizer tab wouldn't display until the page was refreshed.

## Root Cause
- In the side panel, tabs are merged into a single "home" tab
- When navigating to full page, the activeTabId state persisted as "home"
- But the full page view only has a "workflowRun"(flow) tab, not "home"
- TabList was trying to display a non-existent tab, resulting in blank content

## Solution
Added validation in TabList to check if activeTabId exists in visibleTabs. If not, it falls back to the first available tab.
