### PR TITLE
feat: order the object metadata items of the API alphabetically

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/open-api/open-api.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/open-api/open-api.service.ts
@@ -62,7 +62,11 @@ export class OpenApiService {
         await this.accessTokenService.validateTokenByRequest(request);
 
       objectMetadataItems =
-        await this.objectMetadataService.findManyWithinWorkspace(workspace.id);
+        await this.objectMetadataService.findManyWithinWorkspace(workspace.id, {
+          order: {
+            namePlural: 'ASC',
+          },
+        });
     } catch (err) {
       return schema;
     }

--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.service.ts
@@ -444,6 +444,9 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
         ...options?.where,
         workspaceId,
       },
+      order: {
+        namePlural: 'ASC',
+      },
     });
   }
 

--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.service.ts
@@ -445,7 +445,7 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
         workspaceId,
       },
       order: {
-        namePlural: 'ASC',
+        ...options?.order,
       },
     });
   }


### PR DESCRIPTION

resolve #12549
This PR updates the `findManyWithinWorkspace` function to order the object metadata items alphabetically by `namePlural` in ascending order.

https://github.com/user-attachments/assets/0be77a37-173f-4cf2-86eb-8f2420d8ff51

