### PR TITLE
[permissions] fix workflows + remove shouldBypassPermissionChecks for system objects

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/0-54/0-54-clean-not-found-files.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/0-54/0-54-clean-not-found-files.command.ts
@@ -188,6 +188,7 @@ export class CleanNotFoundFilesCommand extends ActiveOrSuspendedWorkspacesMigrat
       await this.twentyORMGlobalManager.getRepositoryForWorkspace<PersonWorkspaceEntity>(
         workspaceId,
         'person',
+        { shouldBypassPermissionChecks: true },
       );
     const people = await personRepository.find({
       where: {

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/0-55/0-55-deduplicate-indexed-fields.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/0-55/0-55-deduplicate-indexed-fields.command.ts
@@ -73,6 +73,7 @@ export class DeduplicateIndexedFieldsCommand extends ActiveOrSuspendedWorkspaces
       await this.twentyORMGlobalManager.getRepositoryForWorkspace(
         workspaceId,
         'company',
+        { shouldBypassPermissionChecks: true },
       );
 
     const duplicates = await companyRepository
@@ -121,6 +122,7 @@ export class DeduplicateIndexedFieldsCommand extends ActiveOrSuspendedWorkspaces
       await this.twentyORMGlobalManager.getRepositoryForWorkspace(
         workspaceId,
         'person',
+        { shouldBypassPermissionChecks: true },
       );
 
     const duplicates = await personRepository

--- a/packages/twenty-server/src/engine/core-modules/auth/strategies/jwt.auth.strategy.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/strategies/jwt.auth.strategy.ts
@@ -76,9 +76,6 @@ export class JwtAuthStrategy extends PassportStrategy(Strategy, 'jwt') {
       await this.twentyORMGlobalManager.getRepositoryForWorkspace<ApiKeyWorkspaceEntity>(
         workspace.id,
         'apiKey',
-        {
-          shouldBypassPermissionChecks: true,
-        },
       );
 
     apiKey = await apiKeyRepository.findOne({

--- a/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.ts
@@ -94,9 +94,6 @@ export class UserWorkspaceService extends TypeOrmQueryService<UserWorkspace> {
       await this.twentyORMGlobalManager.getRepositoryForWorkspace<WorkspaceMemberWorkspaceEntity>(
         workspaceId,
         'workspaceMember',
-        {
-          shouldBypassPermissionChecks: true,
-        },
       );
 
     const userWorkspace = await this.userWorkspaceRepository.findOneOrFail({

--- a/packages/twenty-server/src/engine/core-modules/user/services/user.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/services/user.service.ts
@@ -103,9 +103,6 @@ export class UserService extends TypeOrmQueryService<User> {
       await this.twentyORMGlobalManager.getRepositoryForWorkspace<WorkspaceMemberWorkspaceEntity>(
         workspaceId,
         'workspaceMember',
-        {
-          shouldBypassPermissionChecks: true,
-        },
       );
 
     const workspaceMembers = await workspaceMemberRepository.find();

--- a/packages/twenty-server/src/modules/blocklist/repositories/blocklist.repository.ts
+++ b/packages/twenty-server/src/modules/blocklist/repositories/blocklist.repository.ts
@@ -35,9 +35,6 @@ export class BlocklistRepository {
       await this.twentyORMGlobalManager.getRepositoryForWorkspace(
         workspaceId,
         BlocklistWorkspaceEntity,
-        {
-          shouldBypassPermissionChecks: true,
-        },
       );
 
     return blockListRepository.find({

--- a/packages/twenty-server/src/modules/contact-creation-manager/services/create-company-and-contact.service.ts
+++ b/packages/twenty-server/src/modules/contact-creation-manager/services/create-company-and-contact.service.ts
@@ -61,9 +61,6 @@ export class CreateCompanyAndContactService {
       await this.twentyORMGlobalManager.getRepositoryForWorkspace(
         workspaceId,
         WorkspaceMemberWorkspaceEntity,
-        {
-          shouldBypassPermissionChecks: true,
-        },
       );
 
     const workspaceMembers = await workspaceMemberRepository.find();

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-step/workflow-version-step.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-step/workflow-version-step.workspace-service.ts
@@ -77,6 +77,7 @@ export class WorkflowVersionStepWorkspaceService {
       await this.twentyORMGlobalManager.getRepositoryForWorkspace<WorkflowVersionWorkspaceEntity>(
         workspaceId,
         'workflowVersion',
+        { shouldBypassPermissionChecks: true },
       );
 
     const workflowVersion = await workflowVersionRepository.findOne({
@@ -594,6 +595,7 @@ export class WorkflowVersionStepWorkspaceService {
             await this.twentyORMGlobalManager.getRepositoryForWorkspace(
               workspaceId,
               field.settings.objectName,
+              { shouldBypassPermissionChecks: true },
             );
 
           const record = await repository.findOne({


### PR DESCRIPTION
In this PR 

1. fix workflow step creation by adding forgotten `shouldBypassPermissionChecks` in WorkflowVersionStepWorkspaceService
2. clarify the rule for twentyORMGlobalManager: do not add unnecessary `shouldBypassPermissionChecks` for system objects (there are no object-records permission checks on system objects, they are dealt with at resolver level)