### PR TITLE
Fix click outside after mouse down navigation refactoring

### DIFF
--- a/packages/twenty-front/src/modules/command-menu/components/CommandMenuOpenContainer.tsx
+++ b/packages/twenty-front/src/modules/command-menu/components/CommandMenuOpenContainer.tsx
@@ -8,7 +8,7 @@ import { SLASH_MENU_DROPDOWN_CLICK_OUTSIDE_ID } from '@/ui/input/constants/Slash
 import { RootStackingContextZIndices } from '@/ui/layout/constants/RootStackingContextZIndices';
 import { PAGE_HEADER_COMMAND_MENU_BUTTON_CLICK_OUTSIDE_ID } from '@/ui/layout/page-header/constants/PageHeaderCommandMenuButtonClickOutsideId';
 import { currentHotkeyScopeState } from '@/ui/utilities/hotkey/states/internal/currentHotkeyScopeState';
-import { useListenClickOutside } from '@/ui/utilities/pointer-event/hooks/useListenClickOutside';
+import { useListenClickOutsideOnMouseDown } from '@/ui/utilities/pointer-event/hooks/useListenClickOutsideOnMouseDown';
 import { useTheme } from '@emotion/react';
 
 import styled from '@emotion/styled';
@@ -63,7 +63,7 @@ export const CommandMenuOpenContainer = ({
     [closeCommandMenu],
   );
 
-  useListenClickOutside({
+  useListenClickOutsideOnMouseDown({
     refs: [commandMenuRef],
     callback: handleClickOutside,
     listenerId: 'COMMAND_MENU_LISTENER_ID',


### PR DESCRIPTION
The click outside event is triggered on mouse up, but the navigation drawer items were triggered on mouse down. This caused a problem when clicking on the search button, where the opening of the search (on mouse down) would be triggered before the click outside (on mouse up).

This fixes one of the issues in https://github.com/twentyhq/core-team-issues/issues/1093.
I created a new hook `useListenClickOutsideOnMouseDown` and used it in the side panel.
What do you think about this @charlesBochet, @lucasbordeau?

Another fix would be to prevent the closing of the command menu this button.

Before:

https://github.com/user-attachments/assets/aab59be6-33f0-43d5-b8e5-ab3e3cbed846


After:

https://github.com/user-attachments/assets/b98a7b99-e407-4c4c-95c9-6f1492f26e5a

