### PR TITLE
Fixed overflow scroll bar in dropdowns

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/dropdown/components/DropdownMenuItemsContainer.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/dropdown/components/DropdownMenuItemsContainer.tsx
@@ -27,7 +27,7 @@ const StyledScrollableContainer = styled.div<{ maxHeight?: number }>`
   max-height: ${({ maxHeight }) => (maxHeight ? `${maxHeight}px` : 'none')};
   width: 100%;
 
-  overflow-y: overlay;
+  overflow-y: auto;
 `;
 
 const StyledInternalContainer = styled.div`

--- a/packages/twenty-front/src/modules/ui/layout/dropdown/components/DropdownMenuItemsContainer.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/dropdown/components/DropdownMenuItemsContainer.tsx
@@ -27,7 +27,7 @@ const StyledScrollableContainer = styled.div<{ maxHeight?: number }>`
   max-height: ${({ maxHeight }) => (maxHeight ? `${maxHeight}px` : 'none')};
   width: 100%;
 
-  overflow-y: scroll;
+  overflow-y: overlay;
 `;
 
 const StyledInternalContainer = styled.div`


### PR DESCRIPTION
Following-up PR https://github.com/twentyhq/twenty/pull/12547 which introduced a last minute fix that broke the overflow UI.

Before : 

<img width="261" alt="image" src="https://github.com/user-attachments/assets/e4345d7f-1f4e-4cca-9056-33b5f897ad8c" />

After : 

<img width="276" alt="image" src="https://github.com/user-attachments/assets/ca31b50d-5656-43ca-9819-8d065ec5c005" />
