### PR TITLE
Fix side panel closing after workflow execution

### DIFF
--- a/packages/twenty-front/src/modules/action-menu/actions/record-actions/run-workflow-actions/hooks/useRunWorkflowRecordActions.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-actions/run-workflow-actions/hooks/useRunWorkflowRecordActions.tsx
@@ -68,6 +68,7 @@ export const useRunWorkflowRecordActions = ({
                 payload: selectedRecord,
               });
             }}
+            closeSidePanelOnCommandMenuListActionExecution={false}
           />
         ),
       };

--- a/packages/twenty-front/src/modules/action-menu/actions/record-agnostic-actions/run-workflow-actions/hooks/useRunWorkflowRecordAgnosticActions.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-agnostic-actions/run-workflow-actions/hooks/useRunWorkflowRecordAgnosticActions.tsx
@@ -54,6 +54,7 @@ export const useRunWorkflowRecordAgnosticActions = () => {
                 workflowVersionId: activeWorkflowVersion.id,
               });
             }}
+            closeSidePanelOnCommandMenuListActionExecution={false}
           />
         ),
       };


### PR DESCRIPTION
We introduced a new behavior after a workflow execution where the workflow run would be opened inside the side panel.
But we didn't prevent the side panel form closing. This caused a race condition between the side panel closing and the reopening where sometimes the closing would fire after the reopening.

**Fix**: Since we now always want to open the side panel after the execution, I added `closeSidePanelOnCommandMenuListActionExecution={false}` for workflow actions.