### PR TITLE
803 timebox improve the ux when creating a new step

### DIFF
--- a/packages/twenty-front/src/modules/workflow/workflow-steps/hooks/useCreateStep.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/hooks/useCreateStep.ts
@@ -39,31 +39,36 @@ export const useCreateStep = ({
 
     setIsLoading(true);
 
-    if (!isDefined(workflowInsertStepIds.parentStepId)) {
-      throw new Error(
-        'No parentStepId. Please select a parent step to create from.',
-      );
-    }
+    try {
+      if (!isDefined(workflowInsertStepIds.parentStepId)) {
+        throw new Error(
+          'No parentStepId. Please select a parent step to create from.',
+        );
+      }
 
-    const workflowVersionId = await getUpdatableWorkflowVersion(workflow);
+      const workflowVersionId = await getUpdatableWorkflowVersion(workflow);
 
-    const createdStep = (
-      await createWorkflowVersionStep({
-        workflowVersionId,
-        stepType: newStepType,
-        parentStepId: workflowInsertStepIds.parentStepId,
-        nextStepId: workflowInsertStepIds.nextStepId,
-      })
-    )?.data?.createWorkflowVersionStep;
+      const createdStep = (
+        await createWorkflowVersionStep({
+          workflowVersionId,
+          stepType: newStepType,
+          parentStepId: workflowInsertStepIds.parentStepId,
+          nextStepId: workflowInsertStepIds.nextStepId,
+        })
+      )?.data?.createWorkflowVersionStep;
 
-    if (!createdStep) {
+      if (!createdStep) {
+        return;
+      }
+
+      setWorkflowSelectedNode(createdStep.id);
+      setWorkflowLastCreatedStepId(createdStep.id);
+    } catch (error) {
       setIsLoading(false);
-      return;
+      throw error;
+    } finally {
+      setIsLoading(false);
     }
-
-    setWorkflowSelectedNode(createdStep.id);
-    setWorkflowLastCreatedStepId(createdStep.id);
-    setIsLoading(false);
   };
 
   return {

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/hooks/useCreateStep.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/hooks/useCreateStep.ts
@@ -10,12 +10,14 @@ import { workflowSelectedNodeComponentState } from '@/workflow/workflow-diagram/
 import { useCreateWorkflowVersionStep } from '@/workflow/workflow-steps/hooks/useCreateWorkflowVersionStep';
 import { workflowInsertStepIdsComponentState } from '@/workflow/workflow-steps/states/workflowInsertStepIdsComponentState';
 import { isDefined } from 'twenty-shared/utils';
+import { useState } from 'react';
 
 export const useCreateStep = ({
   workflow,
 }: {
   workflow: WorkflowWithCurrentVersion;
 }) => {
+  const [isLoading, setIsLoading] = useState(false);
   const { createWorkflowVersionStep } = useCreateWorkflowVersionStep();
   const setWorkflowSelectedNode = useSetRecoilComponentStateV2(
     workflowSelectedNodeComponentState,
@@ -31,6 +33,12 @@ export const useCreateStep = ({
   const { getUpdatableWorkflowVersion } = useGetUpdatableWorkflowVersion();
 
   const createStep = async (newStepType: WorkflowStepType) => {
+    if (isLoading === true) {
+      return;
+    }
+
+    setIsLoading(true);
+
     if (!isDefined(workflowInsertStepIds.parentStepId)) {
       throw new Error(
         'No parentStepId. Please select a parent step to create from.',
@@ -49,11 +57,13 @@ export const useCreateStep = ({
     )?.data?.createWorkflowVersionStep;
 
     if (!createdStep) {
+      setIsLoading(false);
       return;
     }
 
     setWorkflowSelectedNode(createdStep.id);
     setWorkflowLastCreatedStepId(createdStep.id);
+    setIsLoading(false);
   };
 
   return {

--- a/packages/twenty-server/src/engine/metadata-modules/serverless-function/serverless-function.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/serverless-function/serverless-function.service.ts
@@ -224,7 +224,8 @@ export class ServerlessFunctionService {
       await this.serverlessFunctionRepository.softDelete({ id });
     } else {
       await this.serverlessFunctionRepository.delete({ id });
-      await this.fileStorageService.delete({
+      // We don't need to await this
+      this.fileStorageService.delete({
         folderPath: getServerlessFolder({
           serverlessFunction: existingServerlessFunction,
         }),


### PR DESCRIPTION
Done:
- improve code step deletion by removing await on serverless function files deletion
- avoid breaking workflow when creating code step mulitple times by disabling `create workflow step` when a step is currently being created

Tested locally with **s3** storage driver and **lambda** serverless drivers
 
## Before

### Code step deletion

https://github.com/user-attachments/assets/609b8fa2-6c25-4606-a164-5674b2869a89

### Code step creation

https://github.com/user-attachments/assets/906e73c4-ee25-4d98-949e-2742a2532893


## After

### Code step deletion

https://github.com/user-attachments/assets/88319647-347b-4640-b5aa-4c5804370095

### Code step creation

https://github.com/user-attachments/assets/c06bdf8f-08ff-476e-90c4-ee00d1914330

