### PR TITLE
Move the viewport of the workflow visualizer on the show page when side panel is opened

### DIFF
--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasBase.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasBase.tsx
@@ -149,10 +149,6 @@ export const WorkflowDiagramCanvasBase = ({
   const { rightDrawerState } = useRightDrawerState();
   const { isInRightDrawer } = useContext(ActionMenuContext);
 
-  const rightDrawerWidth = Number(
-    THEME_COMMON.rightDrawerWidth.replace('px', ''),
-  );
-
   const setWorkflowDiagram = useSetRecoilComponentStateV2(
     workflowDiagramComponentState,
   );
@@ -185,13 +181,11 @@ export const WorkflowDiagramCanvasBase = ({
   const setFlowViewport = useCallback(
     ({
       rightDrawerState,
-      rightDrawerWidth,
       noAnimation,
       workflowDiagramFlowInitializationStatus,
       isInRightDrawer,
     }: {
       rightDrawerState: CommandMenuAnimationVariant;
-      rightDrawerWidth: number;
       noAnimation?: boolean;
       workflowDiagramFlowInitializationStatus:
         | 'not-initialized'
@@ -210,6 +204,10 @@ export const WorkflowDiagramCanvasBase = ({
 
       let visibleRightDrawerWidth = 0;
       if (rightDrawerState === 'normal' && !isInRightDrawer) {
+        const rightDrawerWidth = Number(
+          THEME_COMMON.rightDrawerWidth.replace('px', ''),
+        );
+
         visibleRightDrawerWidth = rightDrawerWidth;
       }
 
@@ -231,14 +229,12 @@ export const WorkflowDiagramCanvasBase = ({
   useEffect(() => {
     setFlowViewport({
       rightDrawerState,
-      rightDrawerWidth,
       isInRightDrawer,
       workflowDiagramFlowInitializationStatus,
     });
   }, [
     isInRightDrawer,
     rightDrawerState,
-    rightDrawerWidth,
     setFlowViewport,
     workflowDiagramFlowInitializationStatus,
   ]);
@@ -263,7 +259,6 @@ export const WorkflowDiagramCanvasBase = ({
 
     setFlowViewport({
       rightDrawerState,
-      rightDrawerWidth,
       noAnimation: true,
       isInRightDrawer,
       workflowDiagramFlowInitializationStatus: 'initialized',

--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasBase.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasBase.tsx
@@ -219,6 +219,7 @@ export const WorkflowDiagramCanvasBase = ({
         {
           ...currentViewport,
           x: viewportX - visibleRightDrawerWidth,
+          zoom: defaultFitViewOptions.maxZoom,
         },
         { duration: noAnimation ? 0 : 300 },
       );


### PR DESCRIPTION
The viewport was moved before the flow finished initializing. I created a state to prevent moving the viewport before the flow has been initialized, allowing us to compute the bounds of the nodes correctly.

## Before

https://github.com/user-attachments/assets/0f034daf-c29c-4d54-905b-191eb60477a9

## After


https://github.com/user-attachments/assets/1f9018ad-ff97-4cf2-997e-d6b7dadf1f30

## Bonus 🎉 

The viewport is no longer progressively zoomed out, as it was before:


https://github.com/user-attachments/assets/0b985c22-ef06-4226-92a0-e5da569876ff

