### PR TITLE
avoid nullable values

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/utils/build-default-fields-for-custom-object.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/utils/build-default-fields-for-custom-object.util.ts
@@ -98,11 +98,11 @@ export const buildDefaultFieldsForCustomObject = (
     label: 'Position',
     icon: 'IconHierarchy2',
     description: 'Position',
-    isNullable: true,
+    isNullable: false,
     isActive: true,
     isCustom: false,
     isSystem: true,
     workspaceId,
-    defaultValue: null,
+    defaultValue: 0,
   },
 ];


### PR DESCRIPTION
Update the default set of system fields for custom objects, to ensure position is not nullabel and has a default value to 0

Steps to reproduce :
create a custom object,
send a POST request with body ```{position:null}```
the record should be created

After the change, 
an error will be thrown
<img width="754" alt="Screenshot 2025-06-13 at 17 16 56" src="https://github.com/user-attachments/assets/d40931f7-16cc-4b68-8dbb-deb0fa292be5" />
