### PR TITLE
[permissions] Fix rest api 

### DIFF
--- a/packages/twenty-server/src/engine/api/rest/core/interfaces/rest-api-base.handler.ts
+++ b/packages/twenty-server/src/engine/api/rest/core/interfaces/rest-api-base.handler.ts
@@ -33,7 +33,7 @@ import { getObjectMetadataMapItemByNameSingular } from 'src/engine/metadata-modu
 import { WorkspacePermissionsCacheService } from 'src/engine/metadata-modules/workspace-permissions-cache/workspace-permissions-cache.service';
 import { WorkspaceSelectQueryBuilder } from 'src/engine/twenty-orm/repository/workspace-select-query-builder';
 import { WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace.repository';
-import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.manager';
+import { TwentyORMManager } from 'src/engine/twenty-orm/twenty-orm.manager';
 import { formatResult as formatGetManyData } from 'src/engine/twenty-orm/utils/format-result.util';
 
 export interface PageInfo {
@@ -72,7 +72,7 @@ export abstract class RestApiBaseHandler {
   @Inject()
   protected readonly coreQueryBuilderFactory: CoreQueryBuilderFactory;
   @Inject()
-  protected readonly twentyORMGlobalManager: TwentyORMGlobalManager;
+  protected readonly twentyORMManager: TwentyORMManager;
   @Inject()
   protected readonly getVariablesFactory: GetVariablesFactory;
   @Inject()
@@ -105,11 +105,7 @@ export abstract class RestApiBaseHandler {
       throw new BadRequestException('Workspace not found');
     }
 
-    const workspaceDataSource =
-      await this.twentyORMGlobalManager.getDataSourceForWorkspace({
-        workspaceId: workspace.id,
-        shouldFailIfMetadataNotFound: false,
-      });
+    const workspaceDataSource = await this.twentyORMManager.getDatasource();
 
     const objectMetadataNameSingular =
       objectMetadata.objectMetadataMapItem.nameSingular;

--- a/packages/twenty-server/src/engine/metadata-modules/workspace-permissions-cache/workspace-permissions-cache.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/workspace-permissions-cache/workspace-permissions-cache.service.ts
@@ -222,11 +222,11 @@ export class WorkspacePermissionsCacheService {
       return;
     }
 
-    const userWorkspaceRoleMap = await this.getUserWorkspaceRoleMapFromCache({
-      workspaceId,
-    });
+    const { data: userWorkspaceRoleMap } =
+      await this.getUserWorkspaceRoleMapFromCache({
+        workspaceId,
+      });
 
-    // @ts-expect-error legacy noImplicitAny
     return userWorkspaceRoleMap[userWorkspaceId];
   }
 

--- a/packages/twenty-server/src/engine/twenty-orm/factories/scoped-workspace-context.factory.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/factories/scoped-workspace-context.factory.ts
@@ -19,7 +19,9 @@ export class ScopedWorkspaceContextFactory {
       // @ts-expect-error legacy noImplicitAny
       this.request?.['req']?.['workspaceId'] ||
       // @ts-expect-error legacy noImplicitAny
-      this.request?.['params']?.['workspaceId'];
+      this.request?.['params']?.['workspaceId'] ||
+      // @ts-expect-error legacy noImplicitAny
+      this.request?.['workspace']?.['id']; // rest api
     const workspaceMetadataVersion: number | undefined =
       // @ts-expect-error legacy noImplicitAny
       this.request?.['req']?.['workspaceMetadataVersion'];
@@ -27,10 +29,18 @@ export class ScopedWorkspaceContextFactory {
     return {
       workspaceId: workspaceId ?? null,
       workspaceMetadataVersion: workspaceMetadataVersion ?? null,
-      // @ts-expect-error legacy noImplicitAny
-      userWorkspaceId: this.request?.['req']?.['userWorkspaceId'] ?? null,
-      // @ts-expect-error legacy noImplicitAny
-      isExecutedByApiKey: !!this.request?.['req']?.['apiKey'],
+      userWorkspaceId:
+        // @ts-expect-error legacy noImplicitAny
+        this.request?.['req']?.['userWorkspaceId'] ??
+        // @ts-expect-error legacy noImplicitAny
+        this.request?.['userWorkspaceId'] ?? // rest api
+        null,
+      isExecutedByApiKey:
+        // @ts-expect-error legacy noImplicitAny
+        !!this.request?.['req']?.['apiKey'] ??
+        // @ts-expect-error legacy noImplicitAny
+        !!this.request?.['apiKey'] ?? // rest api
+        null,
     };
   }
 }

--- a/packages/twenty-server/src/engine/twenty-orm/factories/scoped-workspace-context.factory.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/factories/scoped-workspace-context.factory.ts
@@ -35,12 +35,10 @@ export class ScopedWorkspaceContextFactory {
         // @ts-expect-error legacy noImplicitAny
         this.request?.['userWorkspaceId'] ?? // rest api
         null,
-      isExecutedByApiKey:
+      isExecutedByApiKey: !!(
         // @ts-expect-error legacy noImplicitAny
-        !!this.request?.['req']?.['apiKey'] ??
-        // @ts-expect-error legacy noImplicitAny
-        !!this.request?.['apiKey'] ?? // rest api
-        null,
+        (this.request?.['req']?.['apiKey'] || this.request?.['apiKey'])
+      ),
     };
   }
 }

--- a/packages/twenty-server/test/integration/rest/suites/rest-api-core-create-one.integration-spec.ts
+++ b/packages/twenty-server/test/integration/rest/suites/rest-api-core-create-one.integration-spec.ts
@@ -1,10 +1,10 @@
 import { TEST_COMPANY_1_ID } from 'test/integration/constants/test-company-ids.constants';
 import { TEST_PERSON_1_ID } from 'test/integration/constants/test-person-ids.constants';
 import { TEST_PRIMARY_LINK_URL } from 'test/integration/constants/test-primary-link-url.constant';
+import { TIM_ACCOUNT_ID } from 'test/integration/graphql/integration.constants';
 import { makeRestAPIRequest } from 'test/integration/rest/utils/make-rest-api-request.util';
 import { deleteAllRecords } from 'test/integration/utils/delete-all-records';
 import { generateRecordName } from 'test/integration/utils/generate-record-name';
-import { TIM_ACCOUNT_ID } from 'test/integration/graphql/integration.constants';
 
 import { FieldActorSource } from 'src/engine/metadata-modules/field-metadata/composite-types/actor.composite-type';
 


### PR DESCRIPTION
We need to use twentyORMManager and not twentyORMGlobalManager in rest api base handler, because we don't want to bypass permissions using `shouldBypassPermissions` parameter (which we would have to do to use twentyORMGlobalManager). 

ScopedWorkspaceContextFactory was not adapted to rest api requests which form differs from graphql request. 