### PR TITLE
fix: move icon state update to useEffect in ObjectOptionsDropdownMenu…

### DIFF
--- a/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownMenuViewName.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownMenuViewName.tsx
@@ -16,7 +16,7 @@ import { viewPickerIsPersistingComponentState } from '@/views/view-picker/states
 import { viewPickerSelectedIconComponentState } from '@/views/view-picker/states/viewPickerSelectedIconComponentState';
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { OverflowingTextWithTooltip, useIcons } from 'twenty-ui/display';
 import { useDebouncedCallback } from 'use-debounce';
 
@@ -62,8 +62,6 @@ export const ObjectOptionsDropdownMenuViewName = ({
   const [viewPickerSelectedIcon, setViewPickerSelectedIcon] =
     useRecoilComponentStateV2(viewPickerSelectedIconComponentState);
 
-  setViewPickerSelectedIcon(currentView.icon);
-
   const viewPickerIsPersisting = useRecoilComponentValueV2(
     viewPickerIsPersistingComponentState,
   );
@@ -94,9 +92,15 @@ export const ObjectOptionsDropdownMenuViewName = ({
     setViewPickerSelectedIcon(iconKey);
     setAndPersistViewIcon(iconKey, currentView);
   };
+
   const handleViewNameChange = useDebouncedCallback((value: string) => {
     setAndPersistViewName(value, currentView);
   }, 500);
+
+  useEffect(() => {
+    setViewPickerSelectedIcon(currentView.icon);
+  }, [currentView.icon, setViewPickerSelectedIcon]);
+
   const theme = useTheme();
   const { getIcon } = useIcons();
   const MainIcon = getIcon(currentView?.icon);


### PR DESCRIPTION
Fixed a React state update issue in the ObjectOptionsDropdownMenuViewName component where the icon state was being updated during render, causing a React warning.

### What was the issue?
- The code was updating the view's icon state (`setViewPickerSelectedIcon`) on component mount
- This triggered React's warning: "Cannot update a component while rendering a different component"

### How was it fixed?
- Moved the state update into a `useEffect` hook
- The icon state now updates properly after component render
- Added proper dependencies to the `useEffect` hook (`currentView.icon` and `setViewPickerSelectedIcon`)


https://github.com/user-attachments/assets/b3b6b3ba-16cd-4d9a-83db-eea96dc51bd6


fix #11852 