### PR TITLE
fix: correct inverted permission checks for create buttons (fix #12581)

### DIFF
--- a/packages/twenty-front/src/modules/activities/notes/components/Notes.tsx
+++ b/packages/twenty-front/src/modules/activities/notes/components/Notes.tsx
@@ -90,7 +90,7 @@ export const Notes = ({
         title="All"
         notes={notes}
         button={
-          !hasObjectUpdatePermissions && (
+          hasObjectUpdatePermissions && (
             <Button
               Icon={IconPlus}
               size="small"

--- a/packages/twenty-front/src/modules/object-record/record-picker/single-record-picker/components/SingleRecordPickerMenuItemsWithSearch.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-picker/single-record-picker/components/SingleRecordPickerMenuItemsWithSearch.tsx
@@ -81,7 +81,7 @@ export const SingleRecordPickerMenuItemsWithSearch = ({
     <>
       {layoutDirection === 'search-bar-on-bottom' && (
         <>
-          {isDefined(onCreate) && !hasObjectUpdatePermissions && (
+          {isDefined(onCreate) && hasObjectUpdatePermissions && (
             <DropdownMenuItemsContainer scrollable={false}>
               {createNewButton}
             </DropdownMenuItemsContainer>
@@ -125,7 +125,7 @@ export const SingleRecordPickerMenuItemsWithSearch = ({
           {records.recordsToSelect.length > 0 && isDefined(onCreate) && (
             <DropdownMenuSeparator />
           )}
-          {isDefined(onCreate) && !hasObjectUpdatePermissions && (
+          {isDefined(onCreate) && hasObjectUpdatePermissions && (
             <DropdownMenuItemsContainer scrollable={false}>
               {createNewButton}
             </DropdownMenuItemsContainer>


### PR DESCRIPTION
## Summary
This PR fixes inverted permission checks that were preventing authorized users from seeing "Add New" and "Add note" buttons while showing them to unauthorized users.

## Changes
- Fixed permission check in `SingleRecordPickerMenuItemsWithSearch` component (2 locations)
- Fixed permission check in `Notes` component

## Issue
These permission checks were incorrectly using `\!hasObjectUpdatePermissions` (NOT has permissions) when they should have been checking `hasObjectUpdatePermissions` (has permissions).

This is similar to the issue mentioned in PR #12437.

## Test plan
- [ ] Verify that users WITH update permissions can see the "Add New" button in record pickers
- [ ] Verify that users WITHOUT update permissions cannot see the "Add New" button
- [ ] Verify that users WITH update permissions can see the "Add note" button in Notes component
- [ ] Verify that users WITHOUT update permissions cannot see the "Add note" button

🤖 Generated with Claude Code (https://claude.ai/code)