### PR TITLE
Remove actions when record deleted

### DIFF
--- a/packages/twenty-front/src/modules/action-menu/actions/record-actions/constants/DefaultRecordActionsConfig.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-actions/constants/DefaultRecordActionsConfig.tsx
@@ -66,8 +66,8 @@ export const DEFAULT_RECORD_ACTIONS_CONFIG: Record<
     position: 0,
     isPinned: true,
     Icon: IconPlus,
-    shouldBeRegistered: ({ objectPermissions }) =>
-      objectPermissions.canUpdateObjectRecords,
+    shouldBeRegistered: ({ objectPermissions, isSoftDeleteFilterActive }) =>
+      objectPermissions.canUpdateObjectRecords && !isSoftDeleteFilterActive,
     availableOn: [ActionViewType.INDEX_PAGE_NO_SELECTION],
     component: <CreateNewTableRecordNoSelectionRecordAction />,
   },
@@ -96,8 +96,15 @@ export const DEFAULT_RECORD_ACTIONS_CONFIG: Record<
     position: 2,
     isPinned: true,
     Icon: IconHeart,
-    shouldBeRegistered: ({ selectedRecord, isFavorite }) =>
-      !selectedRecord?.isRemote && !isFavorite,
+    shouldBeRegistered: ({
+      selectedRecord,
+      isFavorite,
+      isSoftDeleteFilterActive,
+    }) =>
+      !selectedRecord?.isRemote &&
+      !isFavorite &&
+      !isDefined(selectedRecord?.deletedAt) &&
+      !isSoftDeleteFilterActive,
     availableOn: [
       ActionViewType.INDEX_PAGE_SINGLE_RECORD_SELECTION,
       ActionViewType.SHOW_PAGE,
@@ -113,11 +120,17 @@ export const DEFAULT_RECORD_ACTIONS_CONFIG: Record<
     isPinned: true,
     position: 3,
     Icon: IconHeartOff,
-    shouldBeRegistered: ({ selectedRecord, isFavorite }) =>
+    shouldBeRegistered: ({
+      selectedRecord,
+      isFavorite,
+      isSoftDeleteFilterActive,
+    }) =>
       isDefined(selectedRecord) &&
       !selectedRecord?.isRemote &&
       isDefined(isFavorite) &&
-      isFavorite,
+      isFavorite &&
+      !isDefined(selectedRecord?.deletedAt) &&
+      !isSoftDeleteFilterActive,
     availableOn: [
       ActionViewType.INDEX_PAGE_SINGLE_RECORD_SELECTION,
       ActionViewType.SHOW_PAGE,
@@ -166,7 +179,8 @@ export const DEFAULT_RECORD_ACTIONS_CONFIG: Record<
     Icon: IconFileImport,
     accent: 'default',
     isPinned: false,
-    shouldBeRegistered: () => true,
+    shouldBeRegistered: ({ isSoftDeleteFilterActive }) =>
+      !isSoftDeleteFilterActive,
     availableOn: [ActionViewType.INDEX_PAGE_NO_SELECTION],
     component: <ImportRecordsNoSelectionRecordAction />,
   },
@@ -202,7 +216,8 @@ export const DEFAULT_RECORD_ACTIONS_CONFIG: Record<
       isDefined(selectedRecord) &&
       !selectedRecord.isRemote &&
       !isSoftDeleteFilterActive &&
-      objectPermissions.canSoftDeleteObjectRecords,
+      objectPermissions.canSoftDeleteObjectRecords &&
+      !isDefined(selectedRecord?.deletedAt),
     availableOn: [
       ActionViewType.INDEX_PAGE_SINGLE_RECORD_SELECTION,
       ActionViewType.SHOW_PAGE,

--- a/packages/twenty-front/src/modules/action-menu/actions/record-actions/constants/WorkflowActionsConfig.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-actions/constants/WorkflowActionsConfig.tsx
@@ -39,14 +39,15 @@ export const WORKFLOW_ACTIONS_CONFIG = inheritActionsFromDefaultConfig({
       Icon: IconPower,
       type: ActionType.Standard,
       scope: ActionScope.RecordSelection,
-      shouldBeRegistered: ({ workflowWithCurrentVersion }) =>
+      shouldBeRegistered: ({ selectedRecord, workflowWithCurrentVersion }) =>
         isDefined(workflowWithCurrentVersion?.currentVersion?.trigger) &&
         isDefined(workflowWithCurrentVersion.currentVersion?.steps) &&
         workflowWithCurrentVersion.currentVersion.steps.length > 0 &&
         (workflowWithCurrentVersion.currentVersion.status === 'DRAFT' ||
           !workflowWithCurrentVersion.versions?.some(
             (version) => version.status === 'ACTIVE',
-          )),
+          )) &&
+        !isDefined(selectedRecord?.deletedAt),
       availableOn: [
         ActionViewType.SHOW_PAGE,
         ActionViewType.INDEX_PAGE_SINGLE_RECORD_SELECTION,
@@ -62,9 +63,10 @@ export const WORKFLOW_ACTIONS_CONFIG = inheritActionsFromDefaultConfig({
       Icon: IconPlayerPause,
       type: ActionType.Standard,
       scope: ActionScope.RecordSelection,
-      shouldBeRegistered: ({ workflowWithCurrentVersion }) =>
+      shouldBeRegistered: ({ selectedRecord, workflowWithCurrentVersion }) =>
         isDefined(workflowWithCurrentVersion) &&
-        workflowWithCurrentVersion.currentVersion.status === 'ACTIVE',
+        workflowWithCurrentVersion.currentVersion.status === 'ACTIVE' &&
+        !isDefined(selectedRecord?.deletedAt),
       availableOn: [
         ActionViewType.SHOW_PAGE,
         ActionViewType.INDEX_PAGE_SINGLE_RECORD_SELECTION,
@@ -80,10 +82,11 @@ export const WORKFLOW_ACTIONS_CONFIG = inheritActionsFromDefaultConfig({
       Icon: IconNoteOff,
       type: ActionType.Standard,
       scope: ActionScope.RecordSelection,
-      shouldBeRegistered: ({ workflowWithCurrentVersion }) =>
+      shouldBeRegistered: ({ selectedRecord, workflowWithCurrentVersion }) =>
         isDefined(workflowWithCurrentVersion) &&
         workflowWithCurrentVersion.versions.length > 1 &&
-        workflowWithCurrentVersion.currentVersion.status === 'DRAFT',
+        workflowWithCurrentVersion.currentVersion.status === 'DRAFT' &&
+        !isDefined(selectedRecord?.deletedAt),
       availableOn: [
         ActionViewType.SHOW_PAGE,
         ActionViewType.INDEX_PAGE_SINGLE_RECORD_SELECTION,
@@ -99,9 +102,10 @@ export const WORKFLOW_ACTIONS_CONFIG = inheritActionsFromDefaultConfig({
       Icon: IconVersions,
       type: ActionType.Standard,
       scope: ActionScope.RecordSelection,
-      shouldBeRegistered: ({ workflowWithCurrentVersion }) =>
+      shouldBeRegistered: ({ workflowWithCurrentVersion, selectedRecord }) =>
         (workflowWithCurrentVersion?.statuses?.includes('ACTIVE') || false) &&
-        (workflowWithCurrentVersion?.statuses?.includes('DRAFT') || false),
+        (workflowWithCurrentVersion?.statuses?.includes('DRAFT') || false) &&
+        !isDefined(selectedRecord?.deletedAt),
       availableOn: [
         ActionViewType.SHOW_PAGE,
         ActionViewType.INDEX_PAGE_SINGLE_RECORD_SELECTION,
@@ -117,8 +121,9 @@ export const WORKFLOW_ACTIONS_CONFIG = inheritActionsFromDefaultConfig({
       Icon: IconHistoryToggle,
       type: ActionType.Standard,
       scope: ActionScope.RecordSelection,
-      shouldBeRegistered: ({ workflowWithCurrentVersion }) =>
-        isDefined(workflowWithCurrentVersion),
+      shouldBeRegistered: ({ selectedRecord, workflowWithCurrentVersion }) =>
+        isDefined(workflowWithCurrentVersion) &&
+        !isDefined(selectedRecord?.deletedAt),
       availableOn: [
         ActionViewType.SHOW_PAGE,
         ActionViewType.INDEX_PAGE_SINGLE_RECORD_SELECTION,
@@ -134,8 +139,9 @@ export const WORKFLOW_ACTIONS_CONFIG = inheritActionsFromDefaultConfig({
       Icon: IconVersions,
       type: ActionType.Standard,
       scope: ActionScope.RecordSelection,
-      shouldBeRegistered: ({ workflowWithCurrentVersion }) =>
-        isDefined(workflowWithCurrentVersion),
+      shouldBeRegistered: ({ selectedRecord, workflowWithCurrentVersion }) =>
+        isDefined(workflowWithCurrentVersion) &&
+        !isDefined(selectedRecord?.deletedAt),
       availableOn: [
         ActionViewType.SHOW_PAGE,
         ActionViewType.INDEX_PAGE_SINGLE_RECORD_SELECTION,
@@ -151,14 +157,16 @@ export const WORKFLOW_ACTIONS_CONFIG = inheritActionsFromDefaultConfig({
       Icon: IconPlayerPlay,
       type: ActionType.Standard,
       scope: ActionScope.RecordSelection,
-      shouldBeRegistered: ({ workflowWithCurrentVersion }) =>
+      shouldBeRegistered: ({ selectedRecord, workflowWithCurrentVersion }) =>
         isDefined(workflowWithCurrentVersion?.currentVersion?.trigger) &&
         ((workflowWithCurrentVersion.currentVersion.trigger.type === 'MANUAL' &&
           !isDefined(
             workflowWithCurrentVersion.currentVersion.trigger.settings
               .objectType,
           )) ||
-          workflowWithCurrentVersion.currentVersion.trigger.type === 'WEBHOOK'),
+          workflowWithCurrentVersion.currentVersion.trigger.type ===
+            'WEBHOOK') &&
+        !isDefined(selectedRecord?.deletedAt),
       availableOn: [
         ActionViewType.SHOW_PAGE,
         ActionViewType.INDEX_PAGE_SINGLE_RECORD_SELECTION,
@@ -175,7 +183,8 @@ export const WORKFLOW_ACTIONS_CONFIG = inheritActionsFromDefaultConfig({
       Icon: IconHistoryToggle,
       accent: 'default',
       isPinned: true,
-      shouldBeRegistered: () => true,
+      shouldBeRegistered: ({ isSoftDeleteFilterActive }) =>
+        !isSoftDeleteFilterActive,
       availableOn: [ActionViewType.INDEX_PAGE_NO_SELECTION],
       component: (
         <ActionLink
@@ -234,6 +243,8 @@ export const WORKFLOW_ACTIONS_CONFIG = inheritActionsFromDefaultConfig({
     [SingleRecordActionKeys.EXPORT]: {
       position: 13,
       label: msg`Export workflow`,
+      shouldBeRegistered: ({ selectedRecord }) =>
+        !isDefined(selectedRecord?.deletedAt),
     },
     [MultipleRecordsActionKeys.EXPORT]: {
       position: 14,


### PR DESCRIPTION
## All Objects
Remove from deleted records view for all object:
- NoSelectionRecordActionKeys.CREATE_NEW_RECORD
- NoSelectionRecordActionKeys.IMPORT_RECORDS
- SingleRecordActionKeys.ADD_TO_FAVORITES
- SingleRecordActionKeys.REMOVE_FROM_FAVORITES

Remove from index view for deleted record:
- DELETE
- ADD_TO_FAVORITES
- REMOVE_FROM_FAVORITES

## Workflows
Remove from deleted workflows view:
- NoSelectionWorkflowRecordActionKeys.GO_TO_RUNS
- SingleRecordActionKeys.EXPORT

Remove from index view for deleted workflow:
- ACTIVATE
- DEACTIVATE
- DISCARD_DRAFT
- SEE_ACTIVE_VERSION
- SEE_RUNS
- SEE_VERSIONS
- TEST

