### PR TITLE
[permissions] allow checkoutSession if workspace is pending_creation

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/billing/billing.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/billing.resolver.ts
@@ -4,6 +4,7 @@ import { UseFilters, UseGuards } from '@nestjs/common';
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
 
 import { isDefined } from 'twenty-shared/utils';
+import { WorkspaceActivationStatus } from 'twenty-shared/workspace';
 
 import { BillingCheckoutSessionInput } from 'src/engine/core-modules/billing/dtos/inputs/billing-checkout-session.input';
 import { BillingSessionInput } from 'src/engine/core-modules/billing/dtos/inputs/billing-session.input';
@@ -86,6 +87,7 @@ export class BillingResolver {
       workspaceId: workspace.id,
       userWorkspaceId,
       isExecutedByApiKey: isDefined(apiKey),
+      workspaceActivationStatus: workspace.activationStatus,
     });
 
     const checkoutSessionParams: BillingPortalCheckoutSessionParameters = {
@@ -169,15 +171,20 @@ export class BillingResolver {
     workspaceId,
     userWorkspaceId,
     isExecutedByApiKey,
+    workspaceActivationStatus,
   }: {
     workspaceId: string;
     userWorkspaceId: string;
     isExecutedByApiKey: boolean;
+    workspaceActivationStatus: WorkspaceActivationStatus;
   }) {
     if (
-      await this.billingService.isSubscriptionIncompleteOnboardingStatus(
+      (await this.billingService.isSubscriptionIncompleteOnboardingStatus(
         workspaceId,
-      )
+      )) ||
+      workspaceActivationStatus ===
+        WorkspaceActivationStatus.PENDING_CREATION ||
+      workspaceActivationStatus === WorkspaceActivationStatus.ONGOING_CREATION
     ) {
       return;
     }


### PR DESCRIPTION
Closes https://github.com/twentyhq/core-team-issues/issues/992

Occasionaly, users can have a subscription created but still have their workspace not activated and therefore not have a role yet, if they did not go through the whole flow the first time. This causes a permission check error while calling checkoutSession, while it shouldn't. 

We detected the error through sentry. Since there has been no occurences for the past three weeks in aggregateCompanies and getCurrentUser transactions (while we have daily errors in checkoutSession), I assume it has been fixed in the meantime. If not it will pop again on sentry anyway ! 
<img width="798" alt="Capture d’écran 2025-06-16 à 18 38 43" src="https://github.com/user-attachments/assets/2067c166-8b19-4c83-9270-6e49ee7ae0f5" />
