### PR TITLE
Fix typos in website README

### DIFF
--- a/packages/twenty-website/README.md
+++ b/packages/twenty-website/README.md
@@ -1,8 +1,7 @@
+# Twenty-Website
 
-# Twenty-Website 
-This  used for the marketing website (twenty.com).
-This is not related in anyway to the main app, which you can find in twenty-front and twenty-server. 
-
+This is used for the marketing website (twenty.com).
+This is not related in any way to the main app, which you can find in twenty-front and twenty-server.
 
 ## Getting Started
 
@@ -12,17 +11,21 @@ We're using Postgres for the database. Mandatory for the website to work, even l
 1. Copy the .env.example file to .env and fill in the values.
 
 2. Run the migrations:
+
 ```bash
 npx nx run twenty-website:database:migrate
 ```
 
 3. From the root directory:
+
 ```bash
 npx nx run twenty-website:dev
 ```
+
 Then open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 Or to build in prod:
+
 ```bash
 npx nx run twenty-website:build
 npx nx run twenty-website:start


### PR DESCRIPTION
## Summary
- fix typos in `packages/twenty-website/README.md`

## Testing
- `npx nx format:check` *(fails: Could not find Nx modules)*

------
https://chatgpt.com/codex/tasks/task_e_68506cb30dcc832095fbe4b9b360fe8d