### PR TITLE
Hide runs by default on workflow index view

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/standard-objects-prefill-data/views/workflows-all.view.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/standard-objects-prefill-data/views/workflows-all.view.ts
@@ -83,7 +83,7 @@ export const workflowsAllView = (
             (field) => field.standardId === WORKFLOW_STANDARD_FIELD_IDS.runs,
           )?.id ?? '',
         position: 5,
-        isVisible: true,
+        isVisible: false,
         size: 150,
       },
     ],


### PR DESCRIPTION
Too many runs cause perf issues on index page. Let's hide this field until we improve the way we fetch relations