### PR TITLE
Fixed single record picker missing dropdown separator

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-picker/single-record-picker/components/SingleRecordPickerMenuItemsWithSearch.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-picker/single-record-picker/components/SingleRecordPickerMenuItemsWithSearch.tsx
@@ -82,11 +82,13 @@ export const SingleRecordPickerMenuItemsWithSearch = ({
       {layoutDirection === 'search-bar-on-bottom' && (
         <>
           {isDefined(onCreate) && hasObjectUpdatePermissions && (
-            <DropdownMenuItemsContainer scrollable={false}>
-              {createNewButton}
-            </DropdownMenuItemsContainer>
+            <>
+              <DropdownMenuItemsContainer scrollable={false}>
+                {createNewButton}
+              </DropdownMenuItemsContainer>
+              <DropdownMenuSeparator />
+            </>
           )}
-          {records.recordsToSelect.length > 0 && <DropdownMenuSeparator />}
           <SingleRecordPickerMenuItems
             recordsToSelect={records.recordsToSelect}
             loading={records.loading}

--- a/packages/twenty-front/src/modules/object-record/record-picker/single-record-picker/components/SingleRecordPickerMenuItemsWithSearch.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-picker/single-record-picker/components/SingleRecordPickerMenuItemsWithSearch.tsx
@@ -122,11 +122,13 @@ export const SingleRecordPickerMenuItemsWithSearch = ({
               onRecordSelected,
             }}
           />
-          {isDefined(onCreate) && <DropdownMenuSeparator />}
           {isDefined(onCreate) && hasObjectUpdatePermissions && (
-            <DropdownMenuItemsContainer scrollable={false}>
-              {createNewButton}
-            </DropdownMenuItemsContainer>
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItemsContainer scrollable={false}>
+                {createNewButton}
+              </DropdownMenuItemsContainer>
+            </>
           )}
         </>
       )}

--- a/packages/twenty-front/src/modules/object-record/record-picker/single-record-picker/components/SingleRecordPickerMenuItemsWithSearch.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-picker/single-record-picker/components/SingleRecordPickerMenuItemsWithSearch.tsx
@@ -122,9 +122,7 @@ export const SingleRecordPickerMenuItemsWithSearch = ({
               onRecordSelected,
             }}
           />
-          {records.recordsToSelect.length > 0 && isDefined(onCreate) && (
-            <DropdownMenuSeparator />
-          )}
+          {isDefined(onCreate) && <DropdownMenuSeparator />}
           {isDefined(onCreate) && hasObjectUpdatePermissions && (
             <DropdownMenuItemsContainer scrollable={false}>
               {createNewButton}


### PR DESCRIPTION
This PR fixes a missing dropdown menu separator when no result found in a single record picker.

Before : 

![image](https://github.com/user-attachments/assets/77ea2275-cace-443b-b691-bab52dd8cfc0) 

After : 

<img width="233" alt="image" src="https://github.com/user-attachments/assets/73919d63-3126-4b56-b335-34d3c9d6ac15" />

Fixes https://github.com/twentyhq/twenty/issues/12665
