### PR TITLE
Fix table fetchMore flakyness

### DIFF
--- a/packages/twenty-front/src/modules/object-record/hooks/useLazyFindManyRecords.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useLazyFindManyRecords.ts
@@ -65,7 +65,7 @@ export const useLazyFindManyRecords = <T extends ObjectRecord = ObjectRecord>({
         limit,
         orderBy,
       },
-      fetchPolicy: 'network-only',
+      fetchPolicy: 'cache-first',
       onCompleted: handleFindManyRecordsCompleted,
       onError: handleFindManyRecordsError,
     });

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-body/components/RecordTableBodyFetchMoreLoader.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-body/components/RecordTableBodyFetchMoreLoader.tsx
@@ -9,7 +9,6 @@ import { isFetchingMoreRecordsFamilyState } from '@/object-record/states/isFetch
 import { useScrollWrapperElement } from '@/ui/utilities/scroll/hooks/useScrollWrapperElement';
 import { useRecoilComponentValueV2 } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValueV2';
 import { GRAY_SCALE } from 'twenty-ui/theme';
-import { useDebouncedCallback } from 'use-debounce';
 
 const StyledText = styled.div`
   align-items: center;
@@ -38,10 +37,6 @@ export const RecordTableBodyFetchMoreLoader = () => {
   );
 
   const showLoadingMoreRow = !hasRecordTableFetchedAllRecordsComponents;
-  const debouncedFetchMoreRecordsLazy = useDebouncedCallback(
-    fetchMoreRecordsLazy,
-    100,
-  );
 
   const { ref: tbodyRef } = useInView({
     onChange: async (inView) => {
@@ -50,7 +45,7 @@ export const RecordTableBodyFetchMoreLoader = () => {
       }
 
       setIsFetchingMoreRecords(true);
-      await debouncedFetchMoreRecordsLazy();
+      await fetchMoreRecordsLazy();
       setIsFetchingMoreRecords(false);
     },
     delay: 1000,


### PR DESCRIPTION
Remove useless debounce + using cacheFirst for fetchMore as fetchingMore will trigger initial fetch if not already performed