### PR TITLE
0.60.0 upgrade commands

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
@@ -167,14 +167,14 @@ export class UpgradeCommand extends UpgradeCommandRunner {
 
     const commands_060: VersionCommands = {
       afterSyncMetadata: [],
-      beforeSyncMetadata: []
-    }
+      beforeSyncMetadata: [],
+    };
 
     this.allCommands = {
       '0.53.0': commands_053,
       '0.54.0': commands_054,
       '0.55.0': commands_055,
-      '0.60.0': commands_060
+      '0.60.0': commands_060,
     };
   }
 

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
@@ -165,10 +165,16 @@ export class UpgradeCommand extends UpgradeCommandRunner {
       afterSyncMetadata: [],
     };
 
+    const commands_060: VersionCommands = {
+      afterSyncMetadata: [],
+      beforeSyncMetadata: []
+    }
+
     this.allCommands = {
       '0.53.0': commands_053,
       '0.54.0': commands_054,
       '0.55.0': commands_055,
+      '0.60.0': commands_060
     };
   }
 


### PR DESCRIPTION
# Introduction
Even tho there's no commands we need to add the `0.60.0` entry within the records