### PR TITLE
Prevent workflows to be opened in side panel

### DIFF
--- a/packages/twenty-front/src/modules/object-record/components/RecordChip.tsx
+++ b/packages/twenty-front/src/modules/object-record/components/RecordChip.tsx
@@ -4,6 +4,7 @@ import { getLinkToShowPage } from '@/object-metadata/utils/getLinkToShowPage';
 import { useRecordChipData } from '@/object-record/hooks/useRecordChipData';
 import { recordIndexOpenRecordInState } from '@/object-record/record-index/states/recordIndexOpenRecordInState';
 import { ObjectRecord } from '@/object-record/types/ObjectRecord';
+import { canOpenObjectInSidePanel } from '@/object-record/utils/canOpenObjectInSidePanel';
 import { ViewOpenRecordInType } from '@/views/types/ViewOpenRecordInType';
 import { MouseEvent } from 'react';
 import { useRecoilValue } from 'recoil';
@@ -52,14 +53,11 @@ export const RecordChip = ({
   const { openRecordInCommandMenu } = useOpenRecordInCommandMenu();
 
   const recordIndexOpenRecordIn = useRecoilValue(recordIndexOpenRecordInState);
-  const canOpenObjectInSidePanel = !(
-    objectNameSingular === 'workflow' ||
-    objectNameSingular === 'workflowVersion'
-  );
+  const canOpenInSidePanel = canOpenObjectInSidePanel(objectNameSingular);
 
   const isSidePanelViewOpenRecordInType =
     recordIndexOpenRecordIn === ViewOpenRecordInType.SIDE_PANEL &&
-    canOpenObjectInSidePanel;
+    canOpenInSidePanel;
 
   const handleCustomClick = isDefined(onClick)
     ? onClick

--- a/packages/twenty-front/src/modules/object-record/components/RecordChip.tsx
+++ b/packages/twenty-front/src/modules/object-record/components/RecordChip.tsx
@@ -52,9 +52,14 @@ export const RecordChip = ({
   const { openRecordInCommandMenu } = useOpenRecordInCommandMenu();
 
   const recordIndexOpenRecordIn = useRecoilValue(recordIndexOpenRecordInState);
+  const canOpenObjectInSidePanel = !(
+    objectNameSingular === 'workflow' ||
+    objectNameSingular === 'workflowVersion'
+  );
 
   const isSidePanelViewOpenRecordInType =
-    recordIndexOpenRecordIn === ViewOpenRecordInType.SIDE_PANEL;
+    recordIndexOpenRecordIn === ViewOpenRecordInType.SIDE_PANEL &&
+    canOpenObjectInSidePanel;
 
   const handleCustomClick = isDefined(onClick)
     ? onClick

--- a/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownLayoutOpenInContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownLayoutOpenInContent.tsx
@@ -3,6 +3,7 @@ import { useOptionsDropdown } from '@/object-record/object-options-dropdown/hook
 import { useUpdateObjectViewOptions } from '@/object-record/object-options-dropdown/hooks/useUpdateObjectViewOptions';
 import { useRecordIndexContextOrThrow } from '@/object-record/record-index/contexts/RecordIndexContext';
 import { recordIndexOpenRecordInState } from '@/object-record/record-index/states/recordIndexOpenRecordInState';
+import { canOpenObjectInSidePanel } from '@/object-record/utils/canOpenObjectInSidePanel';
 import { DropdownContent } from '@/ui/layout/dropdown/components/DropdownContent';
 import { DropdownMenuHeader } from '@/ui/layout/dropdown/components/DropdownMenuHeader/DropdownMenuHeader';
 import { DropdownMenuHeaderLeftComponent } from '@/ui/layout/dropdown/components/DropdownMenuHeader/internal/DropdownMenuHeaderLeftComponent';
@@ -29,9 +30,8 @@ export const ObjectOptionsDropdownLayoutOpenInContent = () => {
   const { currentView } = useGetCurrentViewOnly();
   const { setAndPersistOpenRecordIn } = useUpdateObjectViewOptions();
   const { objectMetadataItem } = useRecordIndexContextOrThrow();
-  const canOpenObjectInSidePanel = !(
-    objectMetadataItem.nameSingular === 'workflow' ||
-    objectMetadataItem.nameSingular === 'workflowVersion'
+  const canOpenInSidePanel = canOpenObjectInSidePanel(
+    objectMetadataItem.nameSingular,
   );
 
   const selectedItemId = useRecoilComponentValueV2(
@@ -66,7 +66,7 @@ export const ObjectOptionsDropdownLayoutOpenInContent = () => {
           <SelectableListItem
             itemId={ViewOpenRecordInType.SIDE_PANEL}
             onEnter={() => {
-              if (!canOpenObjectInSidePanel) {
+              if (!canOpenInSidePanel) {
                 return;
               }
               setAndPersistOpenRecordIn(
@@ -83,7 +83,7 @@ export const ObjectOptionsDropdownLayoutOpenInContent = () => {
               }
               focused={selectedItemId === ViewOpenRecordInType.SIDE_PANEL}
               onClick={() => {
-                if (!canOpenObjectInSidePanel) {
+                if (!canOpenInSidePanel) {
                   return;
                 }
 
@@ -92,7 +92,7 @@ export const ObjectOptionsDropdownLayoutOpenInContent = () => {
                   currentView,
                 );
               }}
-              disabled={!canOpenObjectInSidePanel}
+              disabled={!canOpenInSidePanel}
             />
           </SelectableListItem>
           <SelectableListItem

--- a/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownLayoutOpenInContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownLayoutOpenInContent.tsx
@@ -1,6 +1,7 @@
 import { OBJECT_OPTIONS_DROPDOWN_ID } from '@/object-record/object-options-dropdown/constants/ObjectOptionsDropdownId';
 import { useOptionsDropdown } from '@/object-record/object-options-dropdown/hooks/useOptionsDropdown';
 import { useUpdateObjectViewOptions } from '@/object-record/object-options-dropdown/hooks/useUpdateObjectViewOptions';
+import { useRecordIndexContextOrThrow } from '@/object-record/record-index/contexts/RecordIndexContext';
 import { recordIndexOpenRecordInState } from '@/object-record/record-index/states/recordIndexOpenRecordInState';
 import { DropdownContent } from '@/ui/layout/dropdown/components/DropdownContent';
 import { DropdownMenuHeader } from '@/ui/layout/dropdown/components/DropdownMenuHeader/DropdownMenuHeader';
@@ -27,6 +28,11 @@ export const ObjectOptionsDropdownLayoutOpenInContent = () => {
   const recordIndexOpenRecordIn = useRecoilValue(recordIndexOpenRecordInState);
   const { currentView } = useGetCurrentViewOnly();
   const { setAndPersistOpenRecordIn } = useUpdateObjectViewOptions();
+  const { objectMetadataItem } = useRecordIndexContextOrThrow();
+  const canOpenObjectInSidePanel = !(
+    objectMetadataItem.nameSingular === 'workflow' ||
+    objectMetadataItem.nameSingular === 'workflowVersion'
+  );
 
   const selectedItemId = useRecoilComponentValueV2(
     selectedItemIdComponentState,
@@ -59,12 +65,15 @@ export const ObjectOptionsDropdownLayoutOpenInContent = () => {
         >
           <SelectableListItem
             itemId={ViewOpenRecordInType.SIDE_PANEL}
-            onEnter={() =>
+            onEnter={() => {
+              if (!canOpenObjectInSidePanel) {
+                return;
+              }
               setAndPersistOpenRecordIn(
                 ViewOpenRecordInType.SIDE_PANEL,
                 currentView,
-              )
-            }
+              );
+            }}
           >
             <MenuItemSelect
               LeftIcon={IconLayoutSidebarRight}
@@ -73,12 +82,17 @@ export const ObjectOptionsDropdownLayoutOpenInContent = () => {
                 recordIndexOpenRecordIn === ViewOpenRecordInType.SIDE_PANEL
               }
               focused={selectedItemId === ViewOpenRecordInType.SIDE_PANEL}
-              onClick={() =>
+              onClick={() => {
+                if (!canOpenObjectInSidePanel) {
+                  return;
+                }
+
                 setAndPersistOpenRecordIn(
                   ViewOpenRecordInType.SIDE_PANEL,
                   currentView,
-                )
-              }
+                );
+              }}
+              disabled={!canOpenObjectInSidePanel}
             />
           </SelectableListItem>
           <SelectableListItem

--- a/packages/twenty-front/src/modules/object-record/record-index/hooks/useOpenRecordFromIndexView.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/hooks/useOpenRecordFromIndexView.ts
@@ -6,6 +6,7 @@ import { currentRecordFiltersComponentState } from '@/object-record/record-filte
 import { useRecordIndexContextOrThrow } from '@/object-record/record-index/contexts/RecordIndexContext';
 import { recordIndexOpenRecordInState } from '@/object-record/record-index/states/recordIndexOpenRecordInState';
 import { currentRecordSortsComponentState } from '@/object-record/record-sort/states/currentRecordSortsComponentState';
+import { canOpenObjectInSidePanel } from '@/object-record/utils/canOpenObjectInSidePanel';
 import { AppPath } from '@/types/AppPath';
 import { useRecoilComponentCallbackStateV2 } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentCallbackStateV2';
 import { ViewOpenRecordInType } from '@/views/types/ViewOpenRecordInType';
@@ -67,7 +68,10 @@ export const useOpenRecordFromIndexView = () => {
           },
         );
 
-        if (recordIndexOpenRecordIn === ViewOpenRecordInType.SIDE_PANEL) {
+        if (
+          recordIndexOpenRecordIn === ViewOpenRecordInType.SIDE_PANEL &&
+          canOpenObjectInSidePanel(objectNameSingular)
+        ) {
           openRecordInCommandMenu({
             recordId,
             objectNameSingular,

--- a/packages/twenty-front/src/modules/object-record/record-table/hooks/useCreateNewIndexRecord.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/hooks/useCreateNewIndexRecord.ts
@@ -6,6 +6,7 @@ import { useBuildRecordInputFromFilters } from '@/object-record/record-table/hoo
 import { useRecordTitleCell } from '@/object-record/record-title-cell/hooks/useRecordTitleCell';
 import { RecordTitleCellContainerType } from '@/object-record/record-title-cell/types/RecordTitleCellContainerType';
 import { ObjectRecord } from '@/object-record/types/ObjectRecord';
+import { canOpenObjectInSidePanel } from '@/object-record/utils/canOpenObjectInSidePanel';
 import { AppPath } from '@/types/AppPath';
 import { ViewOpenRecordInType } from '@/views/types/ViewOpenRecordInType';
 import { useRecoilCallback } from 'recoil';
@@ -47,7 +48,10 @@ export const useCreateNewIndexRecord = ({
           ...recordInputFromFilters,
           ...recordInput,
         });
-        if (recordIndexOpenRecordIn === ViewOpenRecordInType.SIDE_PANEL) {
+        if (
+          recordIndexOpenRecordIn === ViewOpenRecordInType.SIDE_PANEL &&
+          canOpenObjectInSidePanel(objectMetadataItem.nameSingular)
+        ) {
           openRecordInCommandMenu({
             recordId,
             objectNameSingular: objectMetadataItem.nameSingular,

--- a/packages/twenty-front/src/modules/object-record/utils/canOpenObjectInSidePanel.ts
+++ b/packages/twenty-front/src/modules/object-record/utils/canOpenObjectInSidePanel.ts
@@ -1,0 +1,5 @@
+export const canOpenObjectInSidePanel = (objectNameSingular: string) =>
+  !(
+    objectNameSingular === 'workflow' ||
+    objectNameSingular === 'workflowVersion'
+  );

--- a/packages/twenty-front/src/modules/views/hooks/useCreateViewFromCurrentView.ts
+++ b/packages/twenty-front/src/modules/views/hooks/useCreateViewFromCurrentView.ts
@@ -125,6 +125,7 @@ export const useCreateViewFromCurrentView = (viewBarComponentId?: string) => {
               : undefined,
           type: type ?? sourceView.type,
           objectMetadataId: sourceView.objectMetadataId,
+          openRecordIn: sourceView.openRecordIn,
         });
 
         if (isUndefinedOrNull(newView)) {


### PR DESCRIPTION
Workflow views and versions are seed being opened by default into record page. Issue is that:
- new views are set by default to side panel. Updated by copying the current opensIn value to the new view
- users can still select side panel into their options. Disabling the button.

<img width="650" alt="Capture d’écran 2025-06-19 à 16 15 34" src="https://github.com/user-attachments/assets/0ddc3284-0fed-404f-9c1d-225c65549fd1" />
