### PR TITLE
Fix filter workflow by status

### DIFF
--- a/packages/twenty-server/src/modules/workflow/common/standard-objects/workflow.workspace-entity.ts
+++ b/packages/twenty-server/src/modules/workflow/common/standard-objects/workflow.workspace-entity.ts
@@ -18,9 +18,9 @@ import { STANDARD_OBJECT_ICONS } from 'src/engine/workspace-manager/workspace-sy
 import { STANDARD_OBJECT_IDS } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-object-ids';
 import { FavoriteWorkspaceEntity } from 'src/modules/favorite/standard-objects/favorite.workspace-entity';
 import { TimelineActivityWorkspaceEntity } from 'src/modules/timeline/standard-objects/timeline-activity.workspace-entity';
+import { WorkflowAutomatedTriggerWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow-automated-trigger.workspace-entity';
 import { WorkflowRunWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
 import { WorkflowVersionWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow-version.workspace-entity';
-import { WorkflowAutomatedTriggerWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow-automated-trigger.workspace-entity';
 
 export enum WorkflowStatus {
   DRAFT = 'DRAFT',
@@ -31,18 +31,21 @@ export enum WorkflowStatus {
 const WorkflowStatusOptions: FieldMetadataComplexOption[] = [
   {
     value: WorkflowStatus.DRAFT,
+    id: WorkflowStatus.DRAFT,
     label: 'Draft',
     position: 0,
     color: 'yellow',
   },
   {
     value: WorkflowStatus.ACTIVE,
+    id: WorkflowStatus.ACTIVE,
     label: 'Active',
     position: 1,
     color: 'green',
   },
   {
     value: WorkflowStatus.DEACTIVATED,
+    id: WorkflowStatus.DEACTIVATED,
     label: 'Deactivated',
     position: 2,
     color: 'gray',


### PR DESCRIPTION
Fixes issue #12723 

The frontend is expecting 'id' in the option in 'ObjectFilterDropdownOptionSelect', but actually the option does not contain any 'id', which is why the issue is arising.

I added the 'id' property to the options from the backend. This will solve the problem.

https://github.com/user-attachments/assets/b7395f0f-ba34-40ab-af62-5261fb69c819

