### PR TITLE
fix: section label styling for sort and filter

### DIFF
--- a/packages/twenty-front/src/modules/object-record/advanced-filter/components/AdvancedFilterFieldSelectMenu.tsx
+++ b/packages/twenty-front/src/modules/object-record/advanced-filter/components/AdvancedFilterFieldSelectMenu.tsx
@@ -154,7 +154,7 @@ export const AdvancedFilterFieldSelectMenu = ({
           <>
             <DropdownMenuSectionLabel
               label={t`Visible fields`}
-              isSubsectionLabel={true}
+              isSubsectionLabel
             />
             <DropdownMenuItemsContainer>
               {visibleColumnsFieldMetadataItems.map(
@@ -182,7 +182,7 @@ export const AdvancedFilterFieldSelectMenu = ({
             {visibleColumnsFieldMetadataItems.length > 0 && (
               <DropdownMenuSectionLabel
                 label={t`Hidden fields`}
-                isSubsectionLabel={true}
+                isSubsectionLabel
               />
             )}
             <DropdownMenuItemsContainer>

--- a/packages/twenty-front/src/modules/object-record/advanced-filter/components/AdvancedFilterFieldSelectMenu.tsx
+++ b/packages/twenty-front/src/modules/object-record/advanced-filter/components/AdvancedFilterFieldSelectMenu.tsx
@@ -152,7 +152,10 @@ export const AdvancedFilterFieldSelectMenu = ({
       >
         {shouldShowVisibleFields && (
           <>
-            <DropdownMenuSectionLabel label={t`Visible fields`} />
+            <DropdownMenuSectionLabel
+              label={t`Visible fields`}
+              isSubsectionLabel={true}
+            />
             <DropdownMenuItemsContainer>
               {visibleColumnsFieldMetadataItems.map(
                 (visibleFieldMetadataItem, index) => (
@@ -177,7 +180,10 @@ export const AdvancedFilterFieldSelectMenu = ({
         {shouldShowHiddenFields && (
           <>
             {visibleColumnsFieldMetadataItems.length > 0 && (
-              <DropdownMenuSectionLabel label={t`Hidden fields`} />
+              <DropdownMenuSectionLabel
+                label={t`Hidden fields`}
+                isSubsectionLabel={true}
+              />
             )}
             <DropdownMenuItemsContainer>
               {hiddenColumnsFieldMetadataItems.map(

--- a/packages/twenty-front/src/modules/object-record/object-sort-dropdown/components/ObjectSortDropdownButton.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-sort-dropdown/components/ObjectSortDropdownButton.tsx
@@ -280,7 +280,7 @@ export const ObjectSortDropdownButton = () => {
               <>
                 <DropdownMenuSectionLabel
                   label={t`Visible fields`}
-                  isSubsectionLabel={true}
+                  isSubsectionLabel
                 />
                 <DropdownMenuItemsContainer>
                   {visibleFieldMetadataItems.map(
@@ -312,7 +312,7 @@ export const ObjectSortDropdownButton = () => {
               <>
                 <DropdownMenuSectionLabel
                   label={t`Hidden fields`}
-                  isSubsectionLabel={true}
+                  isSubsectionLabel
                 />
                 <DropdownMenuItemsContainer>
                   {hiddenFieldMetadataItems.map(

--- a/packages/twenty-front/src/modules/object-record/object-sort-dropdown/components/ObjectSortDropdownButton.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-sort-dropdown/components/ObjectSortDropdownButton.tsx
@@ -278,7 +278,10 @@ export const ObjectSortDropdownButton = () => {
             />
             {shouldShowVisibleFields && (
               <>
-                <DropdownMenuSectionLabel label={t`Visible fields`} />
+                <DropdownMenuSectionLabel
+                  label={t`Visible fields`}
+                  isSubsectionLabel={true}
+                />
                 <DropdownMenuItemsContainer>
                   {visibleFieldMetadataItems.map(
                     (visibleFieldMetadataItem, index) => (
@@ -307,7 +310,10 @@ export const ObjectSortDropdownButton = () => {
             {shouldShowSeparator && <DropdownMenuSeparator />}
             {shouldShowHiddenFields && (
               <>
-                <DropdownMenuSectionLabel label={t`Hidden fields`} />
+                <DropdownMenuSectionLabel
+                  label={t`Hidden fields`}
+                  isSubsectionLabel={true}
+                />
                 <DropdownMenuItemsContainer>
                   {hiddenFieldMetadataItems.map(
                     (hiddenFieldMetadataItem, index) => (

--- a/packages/twenty-front/src/modules/ui/layout/dropdown/components/DropdownMenuSectionLabel.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/dropdown/components/DropdownMenuSectionLabel.tsx
@@ -1,11 +1,15 @@
 import styled from '@emotion/styled';
 
-const StyledDropdownMenuSectionLabel = styled.div`
+const StyledDropdownMenuSectionLabel = styled.div<{
+  isSubsectionLabel?: boolean;
+}>`
   background-color: ${({ theme }) => theme.background.transparent.lighter};
-  color: ${({ theme }) => theme.font.color.light};
+  color: ${({ theme, isSubsectionLabel }) =>
+    isSubsectionLabel ? theme.font.color.tertiary : theme.font.color.light};
   min-height: 20px;
   width: auto;
-  font-size: ${({ theme }) => theme.font.size.xxs};
+  font-size: ${({ theme, isSubsectionLabel }) =>
+    isSubsectionLabel ? theme.font.size.xs : theme.font.size.xxs};
   display: flex;
   align-items: center;
   justify-content: flex-start;
@@ -15,12 +19,16 @@ const StyledDropdownMenuSectionLabel = styled.div`
 
 export type DropdownMenuSectionLabelProps = {
   label: string;
+  isSubsectionLabel?: boolean;
 };
 
 export const DropdownMenuSectionLabel = ({
   label,
+  isSubsectionLabel = false,
 }: DropdownMenuSectionLabelProps) => {
   return (
-    <StyledDropdownMenuSectionLabel>{label}</StyledDropdownMenuSectionLabel>
+    <StyledDropdownMenuSectionLabel isSubsectionLabel={isSubsectionLabel}>
+      {label}
+    </StyledDropdownMenuSectionLabel>
   );
 };

--- a/packages/twenty-front/src/modules/views/components/ViewBarFilterDropdownFieldSelectMenu.tsx
+++ b/packages/twenty-front/src/modules/views/components/ViewBarFilterDropdownFieldSelectMenu.tsx
@@ -102,7 +102,7 @@ export const ViewBarFilterDropdownFieldSelectMenu = () => {
           <>
             <DropdownMenuSectionLabel
               label={t`Visible fields`}
-              isSubsectionLabel={true}
+              isSubsectionLabel
             />
             <DropdownMenuItemsContainer>
               {selectableVisibleFieldMetadataItems.map(
@@ -121,7 +121,7 @@ export const ViewBarFilterDropdownFieldSelectMenu = () => {
           <>
             <DropdownMenuSectionLabel
               label={t`Hidden fields`}
-              isSubsectionLabel={true}
+              isSubsectionLabel
             />
             <DropdownMenuItemsContainer>
               {selectableHiddenFieldMetadataItems.map(

--- a/packages/twenty-front/src/modules/views/components/ViewBarFilterDropdownFieldSelectMenu.tsx
+++ b/packages/twenty-front/src/modules/views/components/ViewBarFilterDropdownFieldSelectMenu.tsx
@@ -100,7 +100,10 @@ export const ViewBarFilterDropdownFieldSelectMenu = () => {
       >
         {shouldShowVisibleFields && (
           <>
-            <DropdownMenuSectionLabel label={t`Visible fields`} />
+            <DropdownMenuSectionLabel
+              label={t`Visible fields`}
+              isSubsectionLabel={true}
+            />
             <DropdownMenuItemsContainer>
               {selectableVisibleFieldMetadataItems.map(
                 (visibleFieldMetadataItem) => (
@@ -116,7 +119,10 @@ export const ViewBarFilterDropdownFieldSelectMenu = () => {
         {shouldShowSeparator && <DropdownMenuSeparator />}
         {shouldShowHiddenFields && (
           <>
-            <DropdownMenuSectionLabel label={t`Hidden fields`} />
+            <DropdownMenuSectionLabel
+              label={t`Hidden fields`}
+              isSubsectionLabel={true}
+            />
             <DropdownMenuItemsContainer>
               {selectableHiddenFieldMetadataItems.map(
                 (hiddenFieldMetadataItem) => (


### PR DESCRIPTION

resolve #12744
I changed the section label color to tertiary and increased the font size slightly using a conditional property. The previous styling is still available and can be used again if needed. If the previous styling is not needed, I can remove the conditions. 

https://github.com/user-attachments/assets/8aaa9752-b875-4eef-8acb-c5eca4b627aa


