### PR TITLE
Refactor sync metadata to handle index creation if already exists

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-runner/workspace-migration-runner.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-runner/workspace-migration-runner.service.ts
@@ -226,7 +226,7 @@ export class WorkspaceMigrationRunnerService {
       if (error.code === '42P07') {
         return;
       }
-
+      // TODO: Remove this once we have re-indexed all our relations
       if (error.message.includes('already exists')) {
         this.logger.error(
           `Allowed error creating index ${index.name} on table ${schemaName}.${tableName}: ${error.message} due to index relations`,

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-runner/workspace-migration-runner.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-runner/workspace-migration-runner.service.ts
@@ -227,9 +227,7 @@ export class WorkspaceMigrationRunnerService {
         return;
       }
 
-      const isv55tov56 = true;
-
-      if (isv55tov56) {
+      if (error.message.includes('already exists')) {
         this.logger.error(
           `Allowed error creating index ${index.name} on table ${schemaName}.${tableName}: ${error.message} due to index relations`,
         );

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-runner/workspace-migration-runner.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-runner/workspace-migration-runner.service.ts
@@ -223,9 +223,8 @@ export class WorkspaceMigrationRunnerService {
       // Ignore error if index already exists
       if (error.code === '42P07') {
         return;
-      } else {
-        throw error;
       }
+      throw error;
     }
   }
 

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-runner/workspace-migration-runner.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-runner/workspace-migration-runner.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 
 import { isDefined } from 'twenty-shared/utils';
-import { QueryRunner, Table, TableColumn, TableIndex } from 'typeorm';
+import { QueryRunner, Table, TableColumn } from 'typeorm';
 
 import { IndexType } from 'src/engine/metadata-modules/index-metadata/index-metadata.entity';
 import {
@@ -208,29 +208,21 @@ export class WorkspaceMigrationRunnerService {
         const quotedColumns = index.columns.map((column) => `"${column}"`);
 
         await queryRunner.query(`
-          CREATE INDEX "${index.name}" ON "${schemaName}"."${tableName}" USING ${index.type} (${quotedColumns.join(', ')})
+          CREATE INDEX IF NOT EXISTS "${index.name}" ON "${schemaName}"."${tableName}" USING ${index.type} (${quotedColumns.join(', ')})
         `);
       } else {
-        await queryRunner.createIndex(
-          `${schemaName}.${tableName}`,
-          new TableIndex({
-            name: index.name,
-            columnNames: index.columns,
-            isUnique: index.isUnique,
-            where: index.where ?? undefined,
-          }),
-        );
+        const quotedColumns = index.columns.map((column) => `"${column}"`);
+        const isUnique = index.isUnique ? 'UNIQUE' : '';
+        const whereClause = index.where ? `WHERE ${index.where}` : '';
+
+        await queryRunner.query(`
+          CREATE ${isUnique} INDEX IF NOT EXISTS "${index.name}" ON "${schemaName}"."${tableName}" (${quotedColumns.join(', ')}) ${whereClause}
+        `);
       }
     } catch (error) {
       // Ignore error if index already exists
       if (error.code === '42P07') {
         return;
-      }
-      // TODO: Remove this once we have re-indexed all our relations
-      if (error.message.includes('already exists')) {
-        this.logger.error(
-          `Allowed error creating index ${index.name} on table ${schemaName}.${tableName}: ${error.message} due to index relations`,
-        );
       } else {
         throw error;
       }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-runner/workspace-migration-runner.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-runner/workspace-migration-runner.service.ts
@@ -226,7 +226,16 @@ export class WorkspaceMigrationRunnerService {
       if (error.code === '42P07') {
         return;
       }
-      throw error;
+
+      const isv55tov56 = true;
+
+      if (isv55tov56) {
+        this.logger.error(
+          `Allowed error creating index ${index.name} on table ${schemaName}.${tableName}: ${error.message} due to index relations`,
+        );
+      } else {
+        throw error;
+      }
     }
   }
 


### PR DESCRIPTION
In order to put back relations on track, we need to allow the preexisting indexes to be created in indexmetadata, but also to avoid failure when the migration runner will try to re-apply a pre-existing index