### PR TITLE
fix(auth): add captcha auto-refresh via ApolloLink

### DIFF
--- a/packages/twenty-front/src/modules/apollo/components/ApolloProvider.tsx
+++ b/packages/twenty-front/src/modules/apollo/components/ApolloProvider.tsx
@@ -1,10 +1,17 @@
 import { ApolloProvider as ApolloProviderBase } from '@apollo/client';
 
 import { useApolloFactory } from '@/apollo/hooks/useApolloFactory';
+import { useRequestFreshCaptchaToken } from '@/captcha/hooks/useRequestFreshCaptchaToken';
+import { createCaptchaRefreshLink } from '@/apollo/utils/captchaRefreshLink';
 
 export const ApolloProvider = ({ children }: React.PropsWithChildren) => {
+  const { requestFreshCaptchaToken } = useRequestFreshCaptchaToken();
+
+  const captchaRefreshLink = createCaptchaRefreshLink(requestFreshCaptchaToken);
+
   const apolloClient = useApolloFactory({
     connectToDevTools: true,
+    extraLinks: [captchaRefreshLink],
   });
 
   // This will attach the right apollo client to Apollo Dev Tools

--- a/packages/twenty-front/src/modules/apollo/utils/captchaRefreshLink.ts
+++ b/packages/twenty-front/src/modules/apollo/utils/captchaRefreshLink.ts
@@ -1,0 +1,19 @@
+import { ApolloLink } from '@apollo/client';
+
+export const createCaptchaRefreshLink = (
+  requestFreshCaptchaToken: () => void
+) => {
+  return new ApolloLink((operation, forward) => {
+    const { variables } = operation;
+
+    const hasCaptchaToken = variables && 'captchaToken' in variables;
+
+    return forward(operation).map((response) => {
+      if (hasCaptchaToken) {
+        requestFreshCaptchaToken();
+      }
+
+      return response;
+    });
+  });
+};

--- a/packages/twenty-front/src/modules/apollo/utils/captchaRefreshLink.ts
+++ b/packages/twenty-front/src/modules/apollo/utils/captchaRefreshLink.ts
@@ -1,7 +1,7 @@
 import { ApolloLink } from '@apollo/client';
 
 export const createCaptchaRefreshLink = (
-  requestFreshCaptchaToken: () => void
+  requestFreshCaptchaToken: () => void,
 ) => {
   return new ApolloLink((operation, forward) => {
     const { variables } = operation;

--- a/packages/twenty-front/src/modules/auth/sign-in-up/hooks/useSignInUp.ts
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/hooks/useSignInUp.ts
@@ -10,7 +10,6 @@ import {
 } from '@/auth/states/signInUpStepState';
 import { SignInUpMode } from '@/auth/types/signInUpMode';
 import { useReadCaptchaToken } from '@/captcha/hooks/useReadCaptchaToken';
-import { useRequestFreshCaptchaToken } from '@/captcha/hooks/useRequestFreshCaptchaToken';
 import { useBuildSearchParamsFromUrlSyncedStates } from '@/domain-manager/hooks/useBuildSearchParamsFromUrlSyncedStates';
 import { AppPath } from '@/types/AppPath';
 import { SnackBarVariant } from '@/ui/feedback/snack-bar-manager/components/SnackBar';
@@ -47,7 +46,6 @@ export const useSignInUp = (form: UseFormReturn<Form>) => {
     checkUserExists: { checkUserExistsQuery },
   } = useAuth();
 
-  const { requestFreshCaptchaToken } = useRequestFreshCaptchaToken();
   const { readCaptchaToken } = useReadCaptchaToken();
 
   const { buildSearchParamsFromUrlSyncedStates } =
@@ -55,7 +53,7 @@ export const useSignInUp = (form: UseFormReturn<Form>) => {
 
   const continueWithEmail = useCallback(() => {
     setSignInUpStep(SignInUpStep.Email);
-  }, [requestFreshCaptchaToken, setSignInUpStep]);
+  }, [setSignInUpStep]);
 
   const continueWithCredentials = useCallback(async () => {
     const token = await readCaptchaToken();
@@ -86,7 +84,6 @@ export const useSignInUp = (form: UseFormReturn<Form>) => {
     form,
     checkUserExistsQuery,
     enqueueSnackBar,
-    requestFreshCaptchaToken,
     setSignInUpStep,
     setSignInUpMode,
   ]);
@@ -165,7 +162,6 @@ export const useSignInUp = (form: UseFormReturn<Form>) => {
       workspaceInviteHash,
       workspacePersonalInviteToken,
       enqueueSnackBar,
-      requestFreshCaptchaToken,
       buildSearchParamsFromUrlSyncedStates,
       isOnAWorkspace,
     ],

--- a/packages/twenty-front/src/modules/auth/sign-in-up/hooks/useSignInUp.ts
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/hooks/useSignInUp.ts
@@ -54,7 +54,6 @@ export const useSignInUp = (form: UseFormReturn<Form>) => {
     useBuildSearchParamsFromUrlSyncedStates();
 
   const continueWithEmail = useCallback(() => {
-    requestFreshCaptchaToken();
     setSignInUpStep(SignInUpStep.Email);
   }, [requestFreshCaptchaToken, setSignInUpStep]);
 
@@ -74,7 +73,6 @@ export const useSignInUp = (form: UseFormReturn<Form>) => {
         });
       },
       onCompleted: (data) => {
-        requestFreshCaptchaToken();
         setSignInUpMode(
           data?.checkUserExists.exists
             ? SignInUpMode.SignIn
@@ -154,8 +152,6 @@ export const useSignInUp = (form: UseFormReturn<Form>) => {
         enqueueSnackBar(err?.message, {
           variant: SnackBarVariant.Error,
         });
-      } finally {
-        requestFreshCaptchaToken();
       }
     },
     [


### PR DESCRIPTION
- Introduced `createCaptchaRefreshLink` to trigger captcha token refresh automatically.
- Removed redundant manual captcha refresh calls and integrated it into Apollo Provider.