### PR TITLE
`getLabelIdentifierFieldValue` should always return string

### DIFF
--- a/packages/twenty-front/src/modules/object-metadata/utils/getLabelIdentifierFieldValue.ts
+++ b/packages/twenty-front/src/modules/object-metadata/utils/getLabelIdentifierFieldValue.ts
@@ -20,5 +20,5 @@ export const getLabelIdentifierFieldValue = (
     return `${record[labelIdentifierFieldMetadataItem.name]?.firstName ?? ''} ${record[labelIdentifierFieldMetadataItem.name]?.lastName ?? ''}`;
   }
 
-  return record[labelIdentifierFieldMetadataItem.name] ?? '';
+  return `${record[labelIdentifierFieldMetadataItem.name]}` ?? '';
 };

--- a/packages/twenty-front/src/modules/object-metadata/utils/getLabelIdentifierFieldValue.ts
+++ b/packages/twenty-front/src/modules/object-metadata/utils/getLabelIdentifierFieldValue.ts
@@ -13,12 +13,13 @@ export const getLabelIdentifierFieldValue = (
     return record.id;
   }
 
+  const recordIdentifierValue = record[labelIdentifierFieldMetadataItem.name];
   if (
     objectNameSingular === CoreObjectNameSingular.WorkspaceMember ||
     labelIdentifierFieldMetadataItem.type === FieldMetadataType.FULL_NAME
   ) {
-    return `${record[labelIdentifierFieldMetadataItem.name]?.firstName ?? ''} ${record[labelIdentifierFieldMetadataItem.name]?.lastName ?? ''}`;
+    return `${recordIdentifierValue?.firstName ?? ''} ${recordIdentifierValue?.lastName ?? ''}`;
   }
 
-  return `${record[labelIdentifierFieldMetadataItem.name]}` ?? '';
+  return isDefined(recordIdentifierValue) ? `${recordIdentifierValue}` : '';
 };


### PR DESCRIPTION
## Introduction

For a custom object if the selected identifier field metadata is an number type than it wouldn't get be converted to a string 

#closes https://github.com/twentyhq/twenty/issues/12717

## Concerns
Kinda the same than for https://github.com/twentyhq/twenty/pull/12728

Here ObjectRecord unknown fields are typed as any, we might wanna do a poc in order to migrate to `unknown` usage
```ts
import { BaseObjectRecord } from '@/object-record/types/BaseObjectRecord';

export type ObjectRecord = Record<string, any> & BaseObjectRecord;
```