### PR TITLE
Fix export to pdf

### DIFF
--- a/packages/twenty-front/src/modules/action-menu/actions/record-actions/single-record/utils/exportBlockNoteEditorToPdf.ts
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-actions/single-record/utils/exportBlockNoteEditorToPdf.ts
@@ -3,13 +3,44 @@ import {
   PDFExporter,
   pdfDefaultSchemaMappings,
 } from '@blocknote/xl-pdf-exporter';
-import { pdf } from '@react-pdf/renderer';
+import { Font, pdf } from '@react-pdf/renderer';
 import { saveAs } from 'file-saver';
+
+const registerInterFonts = (() => {
+  let registrationPromise: Promise<void> | null = null;
+
+  return () => {
+    if (!registrationPromise) {
+      registrationPromise = Promise.resolve().then(() => {
+        Font.register({
+          family: 'Inter',
+          fonts: [
+            {
+              src: 'https://fonts.gstatic.com/s/inter/v19/UcCO3FwrK3iLTeHuS_nVMrMxCp50SjIw2boKoduKmMEVuLyfMZg.ttf',
+              fontWeight: 400,
+            },
+            {
+              src: 'https://fonts.gstatic.com/s/inter/v19/UcCO3FwrK3iLTeHuS_nVMrMxCp50SjIw2boKoduKmMEVuI6fMZg.ttf',
+              fontWeight: 500,
+            },
+            {
+              src: 'https://fonts.gstatic.com/s/inter/v19/UcCO3FwrK3iLTeHuS_nVMrMxCp50SjIw2boKoduKmMEVuGKYMZg.ttf',
+              fontWeight: 600,
+            },
+          ],
+        });
+      });
+    }
+    return registrationPromise;
+  };
+})();
 
 export const exportBlockNoteEditorToPdf = async (
   parsedBody: PartialBlock[],
   filename: string,
 ) => {
+  await registerInterFonts();
+
   const editor = BlockNoteEditor.create({
     initialContent: parsedBody,
   });


### PR DESCRIPTION
Export to PDF was throwing an error due to fonts not being registered. Maybe linked to the async loading changes or blocknote upgrades.


I wasn't a fan of hardcoding the fonts here (makes a second source of truth for Inter), but after a few tests this seemed like the best compromise