### PR TITLE
Remove ID field + fix relations + remove runs

### DIFF
--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/components/WorkflowEditActionUpdateRecord.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/components/WorkflowEditActionUpdateRecord.tsx
@@ -7,20 +7,20 @@ import { formatFieldMetadataItemAsFieldDefinition } from '@/object-metadata/util
 import { FormFieldInput } from '@/object-record/record-field/components/FormFieldInput';
 import { FormSingleRecordPicker } from '@/object-record/record-field/form-types/components/FormSingleRecordPicker';
 import { isFieldRelation } from '@/object-record/record-field/types/guards/isFieldRelation';
+import { GenericDropdownContentWidth } from '@/ui/layout/dropdown/constants/GenericDropdownContentWidth';
 import { WorkflowFieldsMultiSelect } from '@/workflow/components/WorkflowEditUpdateEventFieldsMultiSelect';
 import { WorkflowStepBody } from '@/workflow/workflow-steps/components/WorkflowStepBody';
 import { WorkflowStepHeader } from '@/workflow/workflow-steps/components/WorkflowStepHeader';
 import { useWorkflowActionHeader } from '@/workflow/workflow-steps/workflow-actions/hooks/useWorkflowActionHeader';
 import { shouldDisplayFormField } from '@/workflow/workflow-steps/workflow-actions/utils/shouldDisplayFormField';
 import { WorkflowVariablePicker } from '@/workflow/workflow-variables/components/WorkflowVariablePicker';
+import { useTheme } from '@emotion/react';
 import { isDefined } from 'twenty-shared/utils';
 import { HorizontalSeparator, useIcons } from 'twenty-ui/display';
 import { SelectOption } from 'twenty-ui/input';
 import { JsonValue } from 'type-fest';
 import { useDebouncedCallback } from 'use-debounce';
 import { RelationType } from '~/generated-metadata/graphql';
-import { useTheme } from '@emotion/react';
-import { GenericDropdownContentWidth } from '@/ui/layout/dropdown/constants/GenericDropdownContentWidth';
 
 type WorkflowEditActionUpdateRecordProps = {
   action: WorkflowUpdateRecordAction;
@@ -65,6 +65,7 @@ export const WorkflowEditActionUpdateRecord = ({
     fieldsToUpdate: action.settings.input.fieldsToUpdate ?? [],
     ...action.settings.input.objectRecord,
   });
+
   const isFormDisabled = actionOptions.readonly;
 
   const handleFieldChange = (

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/utils/shouldDisplayFormField.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/utils/shouldDisplayFormField.ts
@@ -41,24 +41,30 @@ export const shouldDisplayFormField = ({
       isTypeAllowedForAction =
         fieldMetadataItem.type !== FieldMetadataType.RELATION ||
         fieldMetadataItem.settings?.['relationType'] === 'MANY_TO_ONE';
-      break;
+      return (
+        isTypeAllowedForAction &&
+        !fieldMetadataItem.isSystem &&
+        fieldMetadataItem.isActive
+      );
     case 'UPDATE_RECORD':
       isTypeAllowedForAction =
         COMMON_DISPLAYABLE_FIELD_TYPES.includes(fieldMetadataItem.type) ||
         fieldMetadataItem.settings?.['relationType'] === 'MANY_TO_ONE';
-      break;
+      return (
+        isTypeAllowedForAction &&
+        !fieldMetadataItem.isSystem &&
+        fieldMetadataItem.isActive
+      );
     case 'FIND_RECORDS':
       isTypeAllowedForAction = FIND_RECORDS_DISPLAYABLE_FIELD_TYPES.includes(
         fieldMetadataItem.type,
       );
-      break;
+      return (
+        isTypeAllowedForAction &&
+        (!fieldMetadataItem.isSystem || isIdField) &&
+        fieldMetadataItem.isActive
+      );
     default:
       throw new Error(`Action "${actionType}" is not supported`);
   }
-
-  return (
-    isTypeAllowedForAction &&
-    (!fieldMetadataItem.isSystem || isIdField) &&
-    fieldMetadataItem.isActive
-  );
 };

--- a/packages/twenty-server/src/engine/workspace-manager/standard-objects-prefill-data/views/workflow-versions-all.view.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/standard-objects-prefill-data/views/workflow-versions-all.view.ts
@@ -75,7 +75,7 @@ export const workflowVersionsAllView = (
               field.standardId === WORKFLOW_VERSION_STANDARD_FIELD_IDS.runs,
           )?.id ?? '',
         position: 4,
-        isVisible: true,
+        isVisible: false,
         size: 150,
       },
     ],


### PR DESCRIPTION
- id field should only be available for search records action
- create record action does not work for relations. Requires to send `accountOwner: { id: string }` instead of `accountOwner: string`
- hidding `runs` for version views as we did for workflows