### PR TITLE
[Messaging logs] Better logging AggregateError

### DIFF
--- a/packages/twenty-server/src/modules/connected-account/refresh-tokens-manager/services/connected-account-refresh-tokens.service.ts
+++ b/packages/twenty-server/src/modules/connected-account/refresh-tokens-manager/services/connected-account-refresh-tokens.service.ts
@@ -92,7 +92,13 @@ export class ConnectedAccountRefreshTokensService {
           );
       }
     } catch (error) {
-      this.logger.log(error);
+      if (error?.name === 'AggregateError') {
+        this.logger.log(error.message);
+        this.logger.log(error.name);
+        this.logger.log(error?.errors);
+      } else {
+        this.logger.log(error);
+      }
       throw new ConnectedAccountRefreshAccessTokenException(
         `Error refreshing tokens for connected account ${connectedAccount.id.slice(0, 7)} in workspace ${workspaceId.slice(0, 7)}: ${error.message} ${error?.response?.data?.error_description}`,
         ConnectedAccountRefreshAccessTokenExceptionCode.REFRESH_ACCESS_TOKEN_FAILED,


### PR DESCRIPTION
"An AggregateError in NestJS usually indicates that multiple errors were thrown or collected together and then re-thrown as a single error."

Since we have this in logs, we cannot debug properly the error https://github.com/twentyhq/twenty/issues/12589
<img width="911" alt="Screenshot 2025-06-23 at 18 39 16" src="https://github.com/user-attachments/assets/888d620f-8d1a-4b59-93b6-2d716a4ab77c" />

That is why we will better log this errors in order to tackle them ASAP

Note: sentry errors match our Grafan logs agggregate errors as you can see

<img width="298" alt="Screenshot 2025-06-23 at 18 39 58" src="https://github.com/user-attachments/assets/fc412153-4f91-4eea-a9db-8e72c67f8ffc" />
<img width="973" alt="Screenshot 2025-06-23 at 18 40 46" src="https://github.com/user-attachments/assets/2bf01947-bb6e-4f48-b94b-777acfd83012" />

