### PR TITLE
Fix CombinedFindManyRecords with permissions

### DIFF
--- a/packages/twenty-front/src/modules/object-record/multiple-objects/hooks/useGenerateCombinedFindManyRecordsQuery.ts
+++ b/packages/twenty-front/src/modules/object-record/multiple-objects/hooks/useGenerateCombinedFindManyRecordsQuery.ts
@@ -3,6 +3,7 @@ import { isUndefined } from '@sniptt/guards';
 import { useRecoilValue } from 'recoil';
 
 import { objectMetadataItemsState } from '@/object-metadata/states/objectMetadataItemsState';
+import { getObjectPermissionsForObject } from '@/object-metadata/utils/getObjectPermissionsForObject';
 import { mapObjectMetadataToGraphQLQuery } from '@/object-metadata/utils/mapObjectMetadataToGraphQLQuery';
 import { RecordGqlOperationSignature } from '@/object-record/graphql/types/RecordGqlOperationSignature';
 import { generateDepthOneRecordGqlFields } from '@/object-record/graphql/utils/generateDepthOneRecordGqlFields';
@@ -41,8 +42,10 @@ export const useGenerateCombinedFindManyRecordsQuery = ({
     })
     .filter(
       ({ objectMetadataItem }) =>
-        objectPermissionsByObjectMetadataId[objectMetadataItem.id]
-          ?.canReadObjectRecords,
+        getObjectPermissionsForObject(
+          objectPermissionsByObjectMetadataId,
+          objectMetadataItem.id,
+        )?.canReadObjectRecords,
     );
 
   const filterPerMetadataItemArray =

--- a/packages/twenty-front/src/modules/object-record/multiple-objects/hooks/useGenerateCombinedFindManyRecordsQuery.ts
+++ b/packages/twenty-front/src/modules/object-record/multiple-objects/hooks/useGenerateCombinedFindManyRecordsQuery.ts
@@ -23,40 +23,8 @@ export const useGenerateCombinedFindManyRecordsQuery = ({
     return null;
   }
 
-  const filterPerMetadataItemArray = operationSignatures
-    .map(
-      ({ objectNameSingular }) =>
-        `$filter${capitalize(objectNameSingular)}: ${capitalize(
-          objectNameSingular,
-        )}FilterInput`,
-    )
-    .join(', ');
-
-  const orderByPerMetadataItemArray = operationSignatures
-    .map(
-      ({ objectNameSingular }) =>
-        `$orderBy${capitalize(objectNameSingular)}: [${capitalize(
-          objectNameSingular,
-        )}OrderByInput]`,
-    )
-    .join(', ');
-
-  const cursorFilteringPerMetadataItemArray = operationSignatures
-    .map(
-      ({ objectNameSingular }) =>
-        `$after${capitalize(objectNameSingular)}: String, $before${capitalize(objectNameSingular)}: String, $first${capitalize(objectNameSingular)}: Int, $last${capitalize(objectNameSingular)}: Int`,
-    )
-    .join(', ');
-
-  const limitPerMetadataItemArray = operationSignatures
-    .map(
-      ({ objectNameSingular }) =>
-        `$limit${capitalize(objectNameSingular)}: Int`,
-    )
-    .join(', ');
-
-  const queryOperationSignatureWithObjectMetadataItemArray =
-    operationSignatures.map((operationSignature) => {
+  const queryOperationSignatureWithObjectMetadataItemArray = operationSignatures
+    .map((operationSignature) => {
       const objectMetadataItem = objectMetadataItems.find(
         (objectMetadataItem) =>
           objectMetadataItem.nameSingular ===
@@ -70,7 +38,48 @@ export const useGenerateCombinedFindManyRecordsQuery = ({
       }
 
       return { operationSignature, objectMetadataItem };
-    });
+    })
+    .filter(
+      ({ objectMetadataItem }) =>
+        objectPermissionsByObjectMetadataId[objectMetadataItem.id]
+          ?.canReadObjectRecords,
+    );
+
+  const filterPerMetadataItemArray =
+    queryOperationSignatureWithObjectMetadataItemArray
+      .map(
+        ({ objectMetadataItem }) =>
+          `$filter${capitalize(objectMetadataItem.nameSingular)}: ${capitalize(
+            objectMetadataItem.nameSingular,
+          )}FilterInput`,
+      )
+      .join(', ');
+
+  const orderByPerMetadataItemArray =
+    queryOperationSignatureWithObjectMetadataItemArray
+      .map(
+        ({ objectMetadataItem }) =>
+          `$orderBy${capitalize(objectMetadataItem.nameSingular)}: [${capitalize(
+            objectMetadataItem.nameSingular,
+          )}OrderByInput]`,
+      )
+      .join(', ');
+
+  const cursorFilteringPerMetadataItemArray =
+    queryOperationSignatureWithObjectMetadataItemArray
+      .map(
+        ({ objectMetadataItem }) =>
+          `$after${capitalize(objectMetadataItem.nameSingular)}: String, $before${capitalize(objectMetadataItem.nameSingular)}: String, $first${capitalize(objectMetadataItem.nameSingular)}: Int, $last${capitalize(objectMetadataItem.nameSingular)}: Int`,
+      )
+      .join(', ');
+
+  const limitPerMetadataItemArray =
+    queryOperationSignatureWithObjectMetadataItemArray
+      .map(
+        ({ objectMetadataItem }) =>
+          `$limit${capitalize(objectMetadataItem.nameSingular)}: Int`,
+      )
+      .join(', ');
 
   return gql`
     query CombinedFindManyRecords(


### PR DESCRIPTION
## Context
This was already for relations but not the root object. This caused issues with pages where we query multiple objects with the CombinedFindManyRecords such as the data model

In the example below, we don't have access to rockets so we don't see the real number of instances (now displays 0) and the FE shouldn't query it. 
<img width="557" alt="Screenshot 2025-06-23 at 19 23 51" src="https://github.com/user-attachments/assets/2ee769b6-c108-466e-93ef-a17a6b092fcc" />

Diff
<img width="1232" alt="Screenshot 2025-06-23 at 19 39 05" src="https://github.com/user-attachments/assets/6c841d4f-2a64-4908-8423-dc040893dfac" />
<img width="1224" alt="Screenshot 2025-06-23 at 19 38 57" src="https://github.com/user-attachments/assets/bb3ff3bc-e9e4-40a6-b72f-18b4dc109df9" />
