### PR TITLE
Fixed ACTOR advanced filter recent regressions

### DIFF
--- a/packages/twenty-front/src/modules/object-record/advanced-filter/components/AdvancedFilterDropdownFilterInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/advanced-filter/components/AdvancedFilterDropdownFilterInput.tsx
@@ -32,7 +32,6 @@ export const AdvancedFilterDropdownFilterInput = ({
 }: AdvancedFilterDropdownFilterInputProps) => {
   const subFieldNameUsedInDropdown = useRecoilComponentValueV2(
     subFieldNameUsedInDropdownComponentState,
-    filterDropdownId,
   );
 
   const filterType = recordFilter.type;

--- a/packages/twenty-front/src/modules/object-record/advanced-filter/components/AdvancedFilterSubFieldSelectMenu.tsx
+++ b/packages/twenty-front/src/modules/object-record/advanced-filter/components/AdvancedFilterSubFieldSelectMenu.tsx
@@ -94,7 +94,9 @@ export const AdvancedFilterSubFieldSelectMenu = ({
 
   const subFieldNames = SETTINGS_COMPOSITE_FIELD_TYPE_CONFIGS[
     objectFilterDropdownSubMenuFieldType
-  ].subFields.map((subField) => subField.subFieldName);
+  ].subFields
+    .filter((subField) => subField.isFilterable === true)
+    .map((subField) => subField.subFieldName);
 
   const subFieldsAreFilterable =
     isDefined(fieldMetadataItemUsedInDropdown) &&


### PR DESCRIPTION
This PR fixes recent regressions on advanced filters for the ACTOR field type.

- The new `isFilterable` props on `SETTINGS_COMPOSITE_FIELD_TYPE_CONFIGS` wasn't taken into account for sub field picker in advanced filter.
- A wrong component instance id was passed to `subFieldNameUsedInDropdownComponentState`