### PR TITLE
Query dynamic cache key computation 

### DIFF
--- a/packages/twenty-front/src/pages/settings/data-model/SettingsObjectNewField/SettingsObjectNewFieldConfigure.tsx
+++ b/packages/twenty-front/src/pages/settings/data-model/SettingsObjectNewField/SettingsObjectNewFieldConfigure.tsx
@@ -145,13 +145,14 @@ export const SettingsObjectNewFieldConfigure = () => {
         });
       }
 
+      navigate(SettingsPath.ObjectDetail, {
+        objectNamePlural,
+      });
+
       // TODO: fix optimistic update logic
       // Forcing a refetch for now but it's not ideal
       await apolloClient.refetchQueries({
         include: ['FindManyViews', 'CombinedFindManyRecords'],
-      });
-      navigate(SettingsPath.ObjectDetail, {
-        objectNamePlural,
       });
       setIsSaving(false);
     } catch (error) {

--- a/packages/twenty-server/src/engine/api/graphql/graphql-config/hooks/use-cached-metadata.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-config/hooks/use-cached-metadata.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'crypto';
+
 import { isDefined } from 'class-validator';
 import { Plugin } from 'graphql-yoga';
 
@@ -20,8 +22,11 @@ export function useCachedMetadata(config: CacheMetadataPluginConfig): Plugin {
     const localeCacheKey = isDefined(serverContext.req.headers['x-locale'])
       ? `:${locale}`
       : '';
+    const queryHash = createHash('sha256')
+      .update(serverContext.req.body.query)
+      .digest('hex');
 
-    return `graphql:operations:${operationName}:${workspaceId}:${workspaceMetadataVersion}${localeCacheKey}`;
+    return `graphql:operations:${operationName}:${workspaceId}:${workspaceMetadataVersion}${localeCacheKey}:${queryHash}`;
   };
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/twenty-server/src/engine/dataloaders/dataloader.service.ts
+++ b/packages/twenty-server/src/engine/dataloaders/dataloader.service.ts
@@ -142,33 +142,32 @@ export class DataloaderService {
           Object.values(objectMetadataMaps.byId[id].fieldsById).map(
             // TODO: fix this as we should merge FieldMetadataEntity and FieldMetadataInterface
             (fieldMetadata) => {
-              const icon = this.fieldMetadataService.resolveOverridableString(
-                fieldMetadata,
+              const overridesFieldToCompute = [
                 'icon',
-                dataLoaderParams[0].locale,
-              );
-
-              const label = this.fieldMetadataService.resolveOverridableString(
-                fieldMetadata,
                 'label',
-                dataLoaderParams[0].locale,
-              );
+                'description',
+              ] as const satisfies (keyof FieldMetadataInterface)[];
 
-              const description =
-                this.fieldMetadataService.resolveOverridableString(
+              const overrides = overridesFieldToCompute.reduce<
+                Partial<
+                  Record<(typeof overridesFieldToCompute)[number], string>
+                >
+              >((acc, field) => {
+                acc[field] = this.fieldMetadataService.resolveOverridableString(
                   fieldMetadata,
-                  'description',
+                  field,
                   dataLoaderParams[0].locale,
                 );
+
+                return acc;
+              }, {});
 
               return {
                 ...fieldMetadata,
                 createdAt: new Date(fieldMetadata.createdAt),
                 updatedAt: new Date(fieldMetadata.updatedAt),
                 workspaceId: workspaceId,
-                icon,
-                label,
-                description,
+                ...overrides,
               };
             },
           ),

--- a/packages/twenty-server/src/engine/dataloaders/dataloader.service.ts
+++ b/packages/twenty-server/src/engine/dataloaders/dataloader.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
 import DataLoader from 'dataloader';
+import { APP_LOCALES } from 'twenty-shared/translations';
 
 import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
 import { ObjectMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/object-metadata.interface';
@@ -37,6 +38,7 @@ export type RelationLoaderPayload = {
 export type FieldMetadataLoaderPayload = {
   workspaceId: string;
   objectMetadata: Pick<ObjectMetadataInterface, 'id'>;
+  locale?: keyof typeof APP_LOCALES;
 };
 
 export type IndexMetadataLoaderPayload = {
@@ -140,11 +142,33 @@ export class DataloaderService {
           Object.values(objectMetadataMaps.byId[id].fieldsById).map(
             // TODO: fix this as we should merge FieldMetadataEntity and FieldMetadataInterface
             (fieldMetadata) => {
+              const icon = this.fieldMetadataService.resolveOverridableString(
+                fieldMetadata,
+                'icon',
+                dataLoaderParams[0].locale,
+              );
+
+              const label = this.fieldMetadataService.resolveOverridableString(
+                fieldMetadata,
+                'label',
+                dataLoaderParams[0].locale,
+              );
+
+              const description =
+                this.fieldMetadataService.resolveOverridableString(
+                  fieldMetadata,
+                  'description',
+                  dataLoaderParams[0].locale,
+                );
+
               return {
                 ...fieldMetadata,
                 createdAt: new Date(fieldMetadata.createdAt),
                 updatedAt: new Date(fieldMetadata.updatedAt),
                 workspaceId: workspaceId,
+                icon,
+                label,
+                description,
               };
             },
           ),

--- a/packages/twenty-server/src/engine/dataloaders/dataloader.service.ts
+++ b/packages/twenty-server/src/engine/dataloaders/dataloader.service.ts
@@ -152,15 +152,17 @@ export class DataloaderService {
                 Partial<
                   Record<(typeof overridesFieldToCompute)[number], string>
                 >
-              >((acc, field) => {
-                acc[field] = this.fieldMetadataService.resolveOverridableString(
-                  fieldMetadata,
-                  field,
-                  dataLoaderParams[0].locale,
-                );
-
-                return acc;
-              }, {});
+              >(
+                (acc, field) => ({
+                  ...acc,
+                  [field]: this.fieldMetadataService.resolveOverridableString(
+                    fieldMetadata,
+                    field,
+                    dataLoaderParams[0].locale,
+                  ),
+                }),
+                {},
+              );
 
               return {
                 ...fieldMetadata,

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.resolver.ts
@@ -55,30 +55,6 @@ export class FieldMetadataResolver {
     private readonly beforeUpdateOneField: BeforeUpdateOneField<UpdateFieldInput>,
   ) {}
 
-  @ResolveField(() => String, { nullable: true })
-  async label(
-    @Parent() fieldMetadata: FieldMetadataDTO,
-    @Context() context: I18nContext,
-  ): Promise<string> {
-    return this.fieldMetadataService.resolveOverridableString(
-      fieldMetadata,
-      'label',
-      context.req.headers['x-locale'],
-    );
-  }
-
-  @ResolveField(() => String, { nullable: true })
-  async description(
-    @Parent() fieldMetadata: FieldMetadataDTO,
-    @Context() context: I18nContext,
-  ): Promise<string> {
-    return this.fieldMetadataService.resolveOverridableString(
-      fieldMetadata,
-      'description',
-      context.req.headers['x-locale'],
-    );
-  }
-
   @UseGuards(SettingsPermissionsGuard(SettingPermissionType.DATA_MODEL))
   @ResolveField(() => String, { nullable: true })
   async icon(

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.resolver.ts
@@ -56,19 +56,6 @@ export class FieldMetadataResolver {
   ) {}
 
   @UseGuards(SettingsPermissionsGuard(SettingPermissionType.DATA_MODEL))
-  @ResolveField(() => String, { nullable: true })
-  async icon(
-    @Parent() fieldMetadata: FieldMetadataDTO,
-    @Context() context: I18nContext,
-  ): Promise<string> {
-    return this.fieldMetadataService.resolveOverridableString(
-      fieldMetadata,
-      'icon',
-      context.req.headers['x-locale'],
-    );
-  }
-
-  @UseGuards(SettingsPermissionsGuard(SettingPermissionType.DATA_MODEL))
   @Mutation(() => FieldMetadataDTO)
   async createOneField(
     @Args('input') input: CreateOneFieldMetadataInput,

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.service.ts
@@ -4,7 +4,7 @@ import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
 import { i18n } from '@lingui/core';
 import { TypeOrmQueryService } from '@ptc-org/nestjs-query-typeorm';
 import isEmpty from 'lodash.isempty';
-import { APP_LOCALES, SOURCE_LOCALE } from 'twenty-shared/translations';
+import { APP_LOCALES } from 'twenty-shared/translations';
 import { FieldMetadataType } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 import { DataSource, FindOneOptions, In, Repository } from 'typeorm';
@@ -608,23 +608,15 @@ export class FieldMetadataService extends TypeOrmQueryService<FieldMetadataEntit
     return fieldMetadataInput;
   }
 
-  async resolveOverridableString(
-    fieldMetadata: FieldMetadataDTO,
+  resolveOverridableString(
+    fieldMetadata: Pick<
+      FieldMetadataDTO,
+      'label' | 'description' | 'icon' | 'isCustom' | 'standardOverrides'
+    >,
     labelKey: 'label' | 'description' | 'icon',
     locale: keyof typeof APP_LOCALES | undefined,
-  ): Promise<string> {
+  ): string {
     if (fieldMetadata.isCustom) {
-      return fieldMetadata[labelKey] ?? '';
-    }
-
-    if (!locale || locale === SOURCE_LOCALE) {
-      if (
-        fieldMetadata.standardOverrides &&
-        isDefined(fieldMetadata.standardOverrides[labelKey])
-      ) {
-        return fieldMetadata.standardOverrides[labelKey] as string;
-      }
-
       return fieldMetadata[labelKey] ?? '';
     }
 

--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.resolver.ts
@@ -1,4 +1,4 @@
-import { UseFilters, UseGuards } from '@nestjs/common';
+import { UseFilters, UseGuards, UsePipes } from '@nestjs/common';
 import {
   Args,
   Context,
@@ -9,6 +9,7 @@ import {
 } from '@nestjs/graphql';
 
 import { PreventNestToAutoLogGraphqlErrorsFilter } from 'src/engine/core-modules/graphql/filters/prevent-nest-to-auto-log-graphql-errors.filter';
+import { ResolverValidationPipe } from 'src/engine/core-modules/graphql/pipes/resolver-validation.pipe';
 import { I18nContext } from 'src/engine/core-modules/i18n/types/i18n-context.type';
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { IDataloaders } from 'src/engine/dataloaders/dataloader.interface';

--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.resolver.ts
@@ -1,4 +1,4 @@
-import { UseFilters, UseGuards, UsePipes } from '@nestjs/common';
+import { UseFilters, UseGuards } from '@nestjs/common';
 import {
   Args,
   Context,
@@ -9,7 +9,6 @@ import {
 } from '@nestjs/graphql';
 
 import { PreventNestToAutoLogGraphqlErrorsFilter } from 'src/engine/core-modules/graphql/filters/prevent-nest-to-auto-log-graphql-errors.filter';
-import { ResolverValidationPipe } from 'src/engine/core-modules/graphql/pipes/resolver-validation.pipe';
 import { I18nContext } from 'src/engine/core-modules/i18n/types/i18n-context.type';
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { IDataloaders } from 'src/engine/dataloaders/dataloader.interface';
@@ -134,13 +133,14 @@ export class ObjectMetadataResolver {
   async fieldsList(
     @AuthWorkspace() workspace: Workspace,
     @Parent() objectMetadata: ObjectMetadataDTO,
-    @Context() context: { loaders: IDataloaders },
+    @Context() context: { loaders: IDataloaders } & I18nContext,
   ): Promise<FieldMetadataDTO[]> {
     try {
       const fieldMetadataItems = await context.loaders.fieldMetadataLoader.load(
         {
           objectMetadata,
           workspaceId: workspace.id,
+          locale: context.req.headers['x-locale'],
         },
       );
 


### PR DESCRIPTION
In this PR:
- add query hashKey to ObjectMetadataItems query graphql cache to avoid caching outdated queries
- improve performance by removing ResolveField at FieldLevel and adding this at resolver level