### PR TITLE
additionaldata-message-exception

### DIFF
--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-import-exception-handler.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-import-exception-handler.service.ts
@@ -197,6 +197,7 @@ export class MessageImportExceptionHandlerService {
 
     this.exceptionHandlerService.captureExceptions([messageImportException], {
       additionalData: {
+        exception,
         messageChannelId: messageChannel.id,
       },
       workspace: { id: workspaceId },


### PR DESCRIPTION
better loging exceptions by keeping the orginal error (otherwise it's swallowed and hard to debug precisely)