### PR TITLE
Force readonly for deletedAt field

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-show/record-detail-section/components/RecordDetailRelationRecordsListItem.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-show/record-detail-section/components/RecordDetailRelationRecordsListItem.tsx
@@ -151,7 +151,9 @@ export const RecordDetailRelationRecordsListItem = ({
         isFieldCellSupported(fieldMetadataItem, objectMetadataItems) &&
         fieldMetadataItem.id !==
           relationObjectMetadataItem.labelIdentifierFieldMetadataId &&
-        fieldMetadataItem.id !== relationFieldMetadataId,
+        fieldMetadataItem.id !== relationFieldMetadataId &&
+        fieldMetadataItem.name !== 'createdAt' &&
+        fieldMetadataItem.name !== 'deletedAt',
     )
     .sort();
 
@@ -307,8 +309,7 @@ export const RecordDetailRelationRecordsListItem = ({
                     labelWidth: 90,
                   }),
                   useUpdateRecord: useUpdateOneObjectRecordMutation,
-                  isReadOnly:
-                    fieldMetadataItem.name === 'deletedAt' || isFieldReadOnly,
+                  isReadOnly: isFieldReadOnly,
                 }}
               >
                 <RecordFieldComponentInstanceContext.Provider

--- a/packages/twenty-front/src/modules/object-record/record-show/record-detail-section/components/RecordDetailRelationRecordsListItem.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-show/record-detail-section/components/RecordDetailRelationRecordsListItem.tsx
@@ -307,7 +307,8 @@ export const RecordDetailRelationRecordsListItem = ({
                     labelWidth: 90,
                   }),
                   useUpdateRecord: useUpdateOneObjectRecordMutation,
-                  isReadOnly: isFieldReadOnly,
+                  isReadOnly:
+                    fieldMetadataItem.name === 'deletedAt' || isFieldReadOnly,
                 }}
               >
                 <RecordFieldComponentInstanceContext.Provider


### PR DESCRIPTION
Fixes https://github.com/twentyhq/twenty/issues/12839

## Context
We now force readonly mode for deletedAt datepicker as permissions don't handle well this use case. The frontend should call softDelete endpoint in this case. For a user, they should select the record and click on the trash icon instead

<img width="467" alt="Screenshot 2025-06-24 at 17 30 03" src="https://github.com/user-attachments/assets/0a8a0709-305b-440f-91c2-d5e3f23ca213" />