### PR TITLE
Fix page change effect being rerun after changes on views

### DIFF
--- a/packages/twenty-front/src/modules/navigation/hooks/__tests__/useDefaultHomePagePath.test.ts
+++ b/packages/twenty-front/src/modules/navigation/hooks/__tests__/useDefaultHomePagePath.test.ts
@@ -6,6 +6,7 @@ import { currentUserWorkspaceState } from '@/auth/states/currentUserWorkspaceSta
 import { useDefaultHomePagePath } from '@/navigation/hooks/useDefaultHomePagePath';
 import { objectMetadataItemsState } from '@/object-metadata/states/objectMetadataItemsState';
 import { AggregateOperations } from '@/object-record/record-table/constants/AggregateOperations';
+import { arePrefetchViewsLoadedState } from '@/prefetch/states/arePrefetchViewsLoaded';
 import { prefetchViewsState } from '@/prefetch/states/prefetchViewsState';
 import { AppPath } from '@/types/AppPath';
 import { ViewOpenRecordInType } from '@/views/types/ViewOpenRecordInType';
@@ -31,8 +32,12 @@ const renderHooks = ({
         objectMetadataItemsState,
       );
       const setPrefetchViews = useSetRecoilState(prefetchViewsState);
+      const setArePrefetchViewsLoaded = useSetRecoilState(
+        arePrefetchViewsLoadedState,
+      );
 
       setObjectMetadataItems(generatedMockObjectMetadataItems);
+      setArePrefetchViewsLoaded(true);
 
       if (withExistingView) {
         setPrefetchViews([
@@ -56,6 +61,8 @@ const renderHooks = ({
             __typename: 'View',
           },
         ]);
+      } else {
+        setPrefetchViews([]);
       }
 
       if (withCurrentUser) {
@@ -70,6 +77,7 @@ const renderHooks = ({
   );
   return { result };
 };
+
 describe('useDefaultHomePagePath', () => {
   it('should return proper path when no currentUser', () => {
     const { result } = renderHooks({

--- a/packages/twenty-front/src/modules/navigation/hooks/useDefaultHomePagePath.ts
+++ b/packages/twenty-front/src/modules/navigation/hooks/useDefaultHomePagePath.ts
@@ -97,7 +97,7 @@ export const useDefaultHomePagePath = () => {
           const view = getFirstView(lastVisitedObjectMetadataItemId);
 
           return {
-            view: view,
+            view,
             objectMetadataItem: lastVisitedObjectMetadataItem,
           };
         }

--- a/packages/twenty-front/src/modules/navigation/hooks/useDefaultHomePagePath.ts
+++ b/packages/twenty-front/src/modules/navigation/hooks/useDefaultHomePagePath.ts
@@ -128,7 +128,7 @@ export const useDefaultHomePagePath = () => {
 
     const defaultObjectPathInfo = getDefaultObjectPathInfo();
 
-    if (!isDefined(defaultObjectPathInfo?.view?.id)) {
+    if (!isDefined(defaultObjectPathInfo?.objectMetadataItem)) {
       return AppPath.NotFound;
     }
 

--- a/packages/twenty-front/src/modules/navigation/hooks/useDefaultHomePagePath.ts
+++ b/packages/twenty-front/src/modules/navigation/hooks/useDefaultHomePagePath.ts
@@ -94,10 +94,8 @@ export const useDefaultHomePagePath = () => {
           );
 
         if (isDefined(lastVisitedObjectMetadataItem)) {
-          const view = getFirstView(lastVisitedObjectMetadataItemId);
-
           return {
-            view,
+            view: getFirstView(lastVisitedObjectMetadataItemId),
             objectMetadataItem: lastVisitedObjectMetadataItem,
           };
         }
@@ -128,7 +126,7 @@ export const useDefaultHomePagePath = () => {
 
     const defaultObjectPathInfo = getDefaultObjectPathInfo();
 
-    if (!isDefined(defaultObjectPathInfo?.objectMetadataItem)) {
+    if (!isDefined(defaultObjectPathInfo)) {
       return AppPath.NotFound;
     }
 

--- a/packages/twenty-front/src/modules/prefetch/components/PrefetchRunViewQueryEffect.tsx
+++ b/packages/twenty-front/src/modules/prefetch/components/PrefetchRunViewQueryEffect.tsx
@@ -6,6 +6,7 @@ import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadat
 import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
 import { useFindManyRecords } from '@/object-record/hooks/useFindManyRecords';
 import { findAllViewsOperationSignatureFactory } from '@/prefetch/graphql/operation-signatures/factories/findAllViewsOperationSignatureFactory';
+import { arePrefetchViewsLoadedState } from '@/prefetch/states/arePrefetchViewsLoaded';
 import { prefetchViewsState } from '@/prefetch/states/prefetchViewsState';
 import { isPersistingViewFieldsState } from '@/views/states/isPersistingViewFieldsState';
 import { View } from '@/views/types/View';
@@ -45,6 +46,7 @@ export const PrefetchRunViewQueryEffect = () => {
 
         if (!isDeeplyEqual(existingViews, views)) {
           set(prefetchViewsState, views);
+          set(arePrefetchViewsLoadedState, true);
         }
       },
     [],

--- a/packages/twenty-front/src/modules/prefetch/states/arePrefetchViewsLoaded.ts
+++ b/packages/twenty-front/src/modules/prefetch/states/arePrefetchViewsLoaded.ts
@@ -1,0 +1,6 @@
+import { createState } from 'twenty-ui/utilities';
+
+export const arePrefetchViewsLoadedState = createState<boolean>({
+  key: 'arePrefetchViewsLoadedState',
+  defaultValue: false,
+});


### PR DESCRIPTION
`useDefaultHomePagePath` was rerendered each time a view was changed, so the PageChangeEffect reran every time a view was updated, but we only want this effect to run on page change.