### PR TITLE
Fix array field migration

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-runner/utils/internal/typeorm-build-create-column-sql.util.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-runner/utils/internal/typeorm-build-create-column-sql.util.spec.ts
@@ -1,0 +1,95 @@
+import { typeormBuildCreateColumnSql } from './typeorm-build-create-column-sql.util';
+
+describe('typeormBuildCreateColumnSql', () => {
+  const table = { name: 'my_table' };
+
+  it('should generate SQL for a simple text column', () => {
+    const column = {
+      name: 'col1',
+      type: 'text',
+      isArray: false,
+      isNullable: false,
+      default: undefined,
+      generatedType: undefined,
+      asExpression: undefined,
+    };
+    const sql = typeormBuildCreateColumnSql({ table, column });
+
+    expect(sql).toBe('"col1" text NOT NULL');
+  });
+
+  it('should generate SQL for a text[] (array) column', () => {
+    const column = {
+      name: 'col2',
+      type: 'text',
+      isArray: true,
+      isNullable: true,
+      default: undefined,
+      generatedType: undefined,
+      asExpression: undefined,
+    };
+    const sql = typeormBuildCreateColumnSql({ table, column });
+
+    expect(sql).toBe('"col2" text[]');
+  });
+
+  it('should generate SQL for an enum column', () => {
+    const column = {
+      name: 'col3',
+      type: 'enum',
+      isArray: false,
+      isNullable: true,
+      default: undefined,
+      generatedType: undefined,
+      asExpression: undefined,
+    };
+    const sql = typeormBuildCreateColumnSql({ table, column });
+
+    expect(sql).toBe('"col3" "my_table_col3_enum"');
+  });
+
+  it('should generate SQL for an enum[] (array) column', () => {
+    const column = {
+      name: 'col4',
+      type: 'enum',
+      isArray: true,
+      isNullable: false,
+      default: undefined,
+      generatedType: undefined,
+      asExpression: undefined,
+    };
+    const sql = typeormBuildCreateColumnSql({ table, column });
+
+    expect(sql).toBe('"col4" "my_table_col4_enum"[] NOT NULL');
+  });
+
+  it('should include default and nullability', () => {
+    const column = {
+      name: 'col5',
+      type: 'text',
+      isArray: false,
+      isNullable: false,
+      default: "'default'",
+      generatedType: undefined,
+      asExpression: undefined,
+    };
+    const sql = typeormBuildCreateColumnSql({ table, column });
+
+    expect(sql).toBe('"col5" text NOT NULL DEFAULT \'default\'');
+  });
+
+  it('should include generatedType and asExpression', () => {
+    const column = {
+      name: 'col6',
+      type: 'text',
+      isArray: false,
+      isNullable: true,
+      default: undefined,
+      generatedType: 'STORED' as const,
+      asExpression: 'lower(col6)',
+    };
+    const sql = typeormBuildCreateColumnSql({ table, column });
+
+    expect(sql).toBe('"col6" text GENERATED ALWAYS AS (lower(col6)) STORED');
+  });
+});

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-runner/utils/internal/typeorm-build-create-column-sql.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-runner/utils/internal/typeorm-build-create-column-sql.util.ts
@@ -32,7 +32,7 @@ export const typeormBuildCreateColumnSql = ({
     columnSql += ' ' + column.type;
   }
 
-  if (column.isArray) columnSql += ' []';
+  if (column.isArray) columnSql += '[]';
 
   if (column.generatedType === 'STORED' && column.asExpression) {
     columnSql += ` GENERATED ALWAYS AS (${column.asExpression}) STORED`;

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-runner/utils/internal/typeorm-build-create-column-sql.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-runner/utils/internal/typeorm-build-create-column-sql.util.ts
@@ -28,10 +28,11 @@ export const typeormBuildCreateColumnSql = ({
       tableName: table.name,
       columnName: column.name,
     })}"`;
-    if (column.isArray) columnSql += ' array';
   } else {
-    columnSql += ' ' + column.type + (column.isArray ? '[]' : '');
+    columnSql += ' ' + column.type;
   }
+
+  if (column.isArray) columnSql += ' []';
 
   if (column.generatedType === 'STORED' && column.asExpression) {
     columnSql += ` GENERATED ALWAYS AS (${column.asExpression}) STORED`;

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-runner/utils/internal/typeorm-build-create-column-sql.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-runner/utils/internal/typeorm-build-create-column-sql.util.ts
@@ -30,7 +30,7 @@ export const typeormBuildCreateColumnSql = ({
     })}"`;
     if (column.isArray) columnSql += ' array';
   } else {
-    columnSql += ' ' + column.type;
+    columnSql += ' ' + column.type + (column.isArray ? '[]' : '');
   }
 
   if (column.generatedType === 'STORED' && column.asExpression) {


### PR DESCRIPTION
Fixes https://github.com/twentyhq/twenty/issues/12726

## Context
Regression introduced in https://github.com/twentyhq/twenty/pull/12639
We now run raw queries for some migrations (column creations for example) and we created a `typeormBuildCreateColumnSql` util for that.
The issue is that previously we were using typeorm methods which was using isArray from the input to create $type[] (text[], number[]) properly which was not done in the new `typeormBuildCreateColumnSql` util (so the type was text, number, etc...)
Edit: actually this was correctly implemented for Enum types (multi select fields) but not Array type, I've updated the code accordingly