### PR TITLE
fix: prevent backspace from closing note editor (#12885)

### DIFF
--- a/packages/twenty-front/src/modules/command-menu/hooks/useCommandMenuHotKeys.ts
+++ b/packages/twenty-front/src/modules/command-menu/hooks/useCommandMenuHotKeys.ts
@@ -77,6 +77,11 @@ export const useCommandMenuHotKeys = () => {
         return;
       }
 
+      // Don't handle backspace when editing rich text (notes/tasks)
+      if (commandMenuPage === CommandMenuPages.EditRichText) {
+        return;
+      }
+
       if (
         commandMenuPage === CommandMenuPages.Root &&
         !(


### PR DESCRIPTION
## Summary
- Fixes #12885 - Backspace key no longer unexpectedly closes note cards while editing
- Adds a check to skip backspace navigation handling when in the EditRichText page
- Simple one-line condition that preserves backspace functionality for text editing while maintaining navigation behavior in other contexts

## Fix Details
The issue was caused by the command menu's global hotkey handler intercepting backspace key presses even when editing notes. The fix adds a check to skip the navigation handler when `commandMenuPage === CommandMenuPages.EditRichText`.

## Test Plan
- [x] Tested that backspace works normally when editing notes (doesn't close the card)
- [x] Verified backspace navigation still works on other command menu pages
- [x] No regression in command menu navigation functionality

---

🤖 This fix was implemented using [Claude Code](https://claude.ai/code) by Jez (Jeremy Dawes) and Claude working together\! 

Thanks to the Twenty team for creating such an awesome open-source CRM\! 🚀