### PR TITLE
fix: allow arrow key navigation in record table inputs (#12847)

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/hooks/useRecordTableCellFocusHotkeys.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/hooks/useRecordTableCellFocusHotkeys.ts
@@ -1,5 +1,7 @@
 import { useRecordTableContextOrThrow } from '@/object-record/record-table/contexts/RecordTableContext';
 import { useRecordTableMoveFocusedCell } from '@/object-record/record-table/hooks/useRecordTableMoveFocusedCell';
+import { recordTableCellEditModePositionComponentState } from '@/object-record/record-table/states/recordTableCellEditModePositionComponentState';
+import { useRecoilComponentValueV2 } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValueV2';
 import { useHotkeysOnFocusedElement } from '@/ui/utilities/hotkey/hooks/useHotkeysOnFocusedElement';
 import { Key } from 'ts-key-enum';
 
@@ -14,43 +16,63 @@ export const useRecordTableCellFocusHotkeys = ({
 
   const { moveFocus } = useRecordTableMoveFocusedCell(recordTableId);
 
+  const currentTableCellInEditModePosition = useRecoilComponentValueV2(
+    recordTableCellEditModePositionComponentState,
+  );
+
   useHotkeysOnFocusedElement({
     keys: [Key.ArrowUp],
     callback: () => {
+      // Don't handle arrow keys when a cell is in edit mode
+      if (currentTableCellInEditModePosition) {
+        return;
+      }
       moveFocus('up');
     },
     focusId,
     scope: hotkeyScope,
-    dependencies: [moveFocus],
+    dependencies: [moveFocus, currentTableCellInEditModePosition],
   });
 
   useHotkeysOnFocusedElement({
     keys: [Key.ArrowDown],
     callback: () => {
+      // Don't handle arrow keys when a cell is in edit mode
+      if (currentTableCellInEditModePosition) {
+        return;
+      }
       moveFocus('down');
     },
     focusId,
     scope: hotkeyScope,
-    dependencies: [moveFocus],
+    dependencies: [moveFocus, currentTableCellInEditModePosition],
   });
 
   useHotkeysOnFocusedElement({
     keys: [Key.ArrowLeft],
     callback: () => {
+      // Don't handle arrow keys when a cell is in edit mode
+      if (currentTableCellInEditModePosition) {
+        return;
+      }
       moveFocus('left');
     },
     focusId,
     scope: hotkeyScope,
-    dependencies: [moveFocus],
+    dependencies: [moveFocus, currentTableCellInEditModePosition],
   });
 
   useHotkeysOnFocusedElement({
     keys: [Key.ArrowRight],
     callback: () => {
+      // Don't handle arrow keys when a cell is in edit mode
+      if (currentTableCellInEditModePosition) {
+        return;
+      }
       moveFocus('right');
     },
     focusId,
     scope: hotkeyScope,
-    dependencies: [moveFocus],
+    dependencies: [moveFocus, currentTableCellInEditModePosition],
   });
 };


### PR DESCRIPTION
## Summary
- Fixes #12847 - Arrow keys now work properly for cursor navigation when editing table cells
- Prevents arrow key hotkeys from intercepting cursor movement in input fields
- Simple fix that checks if a cell is in edit mode before handling arrow key navigation

## Fix Details
The issue was caused by the table's arrow key navigation hotkeys being active even during cell editing. The fix adds a check for `currentTableCellInEditModePosition` in the `useRecordTableCellFocusHotkeys` hook, which skips arrow key handling when any cell is being edited.

## Test Plan
- [x] Tested that arrow keys move the cursor within text when editing cells
- [x] Verified arrow key navigation between cells still works when not editing
- [x] Confirmed no regression in table navigation functionality
- [x] Works with all input types in the record table

## Demo
Before: Arrow keys would navigate to adjacent cells even when trying to move cursor within text
After: Arrow keys properly move the text cursor when editing, and navigate cells when not editing

---

🤖 This fix was implemented using [Claude Code](https://claude.ai/code) by Jez (Jeremy Dawes) and Claude working together\! 

Thanks again to the Twenty team for building such a great open-source CRM\! 🚀