### PR TITLE
chore: improve password strength in install script (#12878)

### DIFF
--- a/packages/twenty-docker/scripts/install.sh
+++ b/packages/twenty-docker/scripts/install.sh
@@ -94,7 +94,7 @@ echo "# === Randomly generated secret ===" >> .env
 echo "APP_SECRET=$(openssl rand -base64 32)" >> .env
 
 echo "" >> .env
-echo "PG_DATABASE_PASSWORD=$(openssl rand -hex 16)" >> .env
+echo "PG_DATABASE_PASSWORD=$(openssl rand -hex 32)" >> .env
 
 echo -e "\t• .env configuration completed"
 


### PR DESCRIPTION
## Summary
- Fixes #12878 - Increases PostgreSQL password generation from 16 to 32 bytes
- Improves default security for new installations
- Aligns with the password strength recommendation in the manual setup documentation

## Change Details
Changed the password generation in `packages/twenty-docker/scripts/install.sh` from:
```bash
echo "PG_DATABASE_PASSWORD=$(openssl rand -hex 16)" >> .env
```
to:
```bash
echo "PG_DATABASE_PASSWORD=$(openssl rand -hex 32)" >> .env
```

This generates a 64-character hexadecimal password (32 bytes) instead of a 32-character one (16 bytes), providing significantly better security for PostgreSQL database passwords in new installations.

---

🤖 This fix was implemented using [Claude Code](https://claude.ai/code) by Jez (Jeremy Dawes) and Claude working together\! 

Thanks to the Twenty team for maintaining such a great project\! 🚀