### PR TITLE
Import - Improve phone validation

### DIFF
--- a/packages/twenty-front/src/modules/object-record/spreadsheet-import/utils/__tests__/buildRecordFromImportedStructuredRow.test.ts
+++ b/packages/twenty-front/src/modules/object-record/spreadsheet-import/utils/__tests__/buildRecordFromImportedStructuredRow.test.ts
@@ -405,4 +405,39 @@ describe('buildRecordFromImportedStructuredRow', () => {
       ratingField: '4',
     });
   });
+
+  it('should handle case where user provides only a primaryPhoneNumber without calling code', () => {
+    const importedStructuredRow: ImportedStructuredRow<string> = {
+      'Primary Phone Number (phoneField)': '5550123',
+    };
+
+    const fields: FieldMetadataItem[] = [
+      {
+        id: '13',
+        name: 'phoneField',
+        label: 'Phone Field',
+        type: FieldMetadataType.PHONES,
+        isNullable: true,
+        isActive: true,
+        isCustom: false,
+        isSystem: false,
+        createdAt: '2023-01-01',
+        updatedAt: '2023-01-01',
+        icon: 'IconPhone',
+        description: null,
+      },
+    ];
+
+    const result = buildRecordFromImportedStructuredRow({
+      importedStructuredRow,
+      fields,
+    });
+
+    expect(result).toEqual({
+      phoneField: {
+        primaryPhoneNumber: '5550123',
+        primaryPhoneCallingCode: '+1',
+      },
+    });
+  });
 });

--- a/packages/twenty-front/src/modules/object-record/spreadsheet-import/utils/buildRecordFromImportedStructuredRow.ts
+++ b/packages/twenty-front/src/modules/object-record/spreadsheet-import/utils/buildRecordFromImportedStructuredRow.ts
@@ -233,9 +233,9 @@ export const buildRecordFromImportedStructuredRow = ({
       case FieldMetadataType.CURRENCY:
       case FieldMetadataType.ADDRESS:
       case FieldMetadataType.LINKS:
-      case FieldMetadataType.PHONES:
       case FieldMetadataType.RICH_TEXT_V2:
       case FieldMetadataType.EMAILS:
+      case FieldMetadataType.PHONES:
       case FieldMetadataType.FULL_NAME: {
         const compositeData = buildCompositeFieldRecord(
           field.name,

--- a/packages/twenty-front/src/modules/object-record/spreadsheet-import/utils/buildRecordFromImportedStructuredRow.ts
+++ b/packages/twenty-front/src/modules/object-record/spreadsheet-import/utils/buildRecordFromImportedStructuredRow.ts
@@ -107,12 +107,12 @@ export const buildRecordFromImportedStructuredRow = ({
     },
     [FieldMetadataType.ADDRESS]: {
       addressStreet1: castToString,
+      addressStreet2: castToString,
+      addressCity: castToString,
+      addressPostcode: castToString,
+      addressState: castToString,
+      addressCountry: castToString,
     },
-    addressStreet2: castToString,
-    addressCity: castToString,
-    addressPostcode: castToString,
-    addressState: castToString,
-    addressCountry: castToString,
     [FieldMetadataType.LINKS]: {
       primaryLinkLabel: castToString,
       primaryLinkUrl: castToString,

--- a/packages/twenty-front/src/modules/object-record/spreadsheet-import/utils/buildRecordFromImportedStructuredRow.ts
+++ b/packages/twenty-front/src/modules/object-record/spreadsheet-import/utils/buildRecordFromImportedStructuredRow.ts
@@ -182,22 +182,28 @@ export const buildRecordFromImportedStructuredRow = ({
             getSubFieldOptionKey(field, 'primaryPhoneNumber')
           ];
 
-        if (
-          isDefined(primaryPhoneNumber) &&
-          !isDefined(
+        const hasUserProvidedCallingCode =
+          isDefined(
             importedStructuredRow[
-              getSubFieldOptionKey(field, 'primaryPhoneCountryCode')
+              getSubFieldOptionKey(field, 'primaryPhoneCallingCode')
             ],
-          )
-        ) {
+          ) &&
+          isNonEmptyString(
+            importedStructuredRow[
+              getSubFieldOptionKey(field, 'primaryPhoneCallingCode')
+            ],
+          );
+
+        if (isDefined(primaryPhoneNumber) && !hasUserProvidedCallingCode) {
           try {
             const {
               number: parsedNumber,
               countryCallingCode: parsedCountryCallingCode,
             } = parsePhoneNumberWithError(primaryPhoneNumber as string);
+
             recordToBuild[field.name] = {
               primaryPhoneNumber: parsedNumber,
-              primaryPhoneCountryCode: parsedCountryCallingCode,
+              primaryPhoneCallingCode: parsedCountryCallingCode,
             };
           } catch {
             recordToBuild[field.name] = {

--- a/packages/twenty-server/src/engine/core-modules/record-transformer/utils/transform-phones-value.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-transformer/utils/transform-phones-value.util.ts
@@ -2,13 +2,12 @@ import { t } from '@lingui/core/macro';
 import { isNonEmptyString } from '@sniptt/guards';
 import {
   CountryCallingCode,
-  CountryCode,
-  getCountries,
-  getCountryCallingCode,
   parsePhoneNumberWithError,
 } from 'libphonenumber-js';
 import {
+  getCountryCodesForCallingCode,
   isDefined,
+  isValidCountryCode,
   parseJson,
   removeUndefinedFields,
 } from 'twenty-shared/utils';
@@ -21,8 +20,6 @@ import {
   AdditionalPhoneMetadata,
   PhonesMetadata,
 } from 'src/engine/metadata-modules/field-metadata/composite-types/phones.composite-type';
-
-const ALL_COUNTRIES_CODE = getCountries();
 
 export type PhonesFieldGraphQLInput =
   | Partial<
@@ -37,22 +34,6 @@ type AdditionalPhoneMetadataWithNumber = Partial<AdditionalPhoneMetadata> &
   Required<Pick<AdditionalPhoneMetadata, 'number'>>;
 
 const removePlusFromString = (str: string) => str.replace(/\+/g, '');
-
-const isValidCountryCode = (input: string): input is CountryCode => {
-  return ALL_COUNTRIES_CODE.includes(input as unknown as CountryCode);
-};
-
-const getCountryCodesForCallingCode = (callingCode: string) => {
-  const cleanCallingCode = callingCode.startsWith('+')
-    ? callingCode.slice(1)
-    : callingCode;
-
-  return ALL_COUNTRIES_CODE.filter((country) => {
-    const countryCallingCode = getCountryCallingCode(country);
-
-    return countryCallingCode === cleanCallingCode;
-  });
-};
 
 const validatePrimaryPhoneCountryCodeAndCallingCode = ({
   callingCode,

--- a/packages/twenty-shared/package.json
+++ b/packages/twenty-shared/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@sniptt/guards": "^0.2.0",
+    "libphonenumber-js": "^1.10.26",
     "zod": "3.23.8"
   },
   "preconstruct": {

--- a/packages/twenty-shared/src/utils/index.ts
+++ b/packages/twenty-shared/src/utils/index.ts
@@ -33,3 +33,5 @@ export { isValidLocale } from './validation/isValidLocale';
 export { isValidUuid } from './validation/isValidUuid';
 export { isValidVariable } from './validation/isValidVariable';
 export { normalizeLocale } from './validation/normalizeLocale';
+export { getCountryCodesForCallingCode } from './validation/phones-value/getCountryCodesForCallingCode';
+export { isValidCountryCode } from './validation/phones-value/isValidCountryCode';

--- a/packages/twenty-shared/src/utils/validation/phones-value/getCountryCodesForCallingCode.ts
+++ b/packages/twenty-shared/src/utils/validation/phones-value/getCountryCodesForCallingCode.ts
@@ -1,0 +1,15 @@
+import { getCountries, getCountryCallingCode } from 'libphonenumber-js';
+
+const ALL_COUNTRIES_CODE = getCountries();
+
+export const getCountryCodesForCallingCode = (callingCode: string) => {
+  const cleanCallingCode = callingCode.startsWith('+')
+    ? callingCode.slice(1)
+    : callingCode;
+
+  return ALL_COUNTRIES_CODE.filter((country) => {
+    const countryCallingCode = getCountryCallingCode(country);
+
+    return countryCallingCode === cleanCallingCode;
+  });
+};

--- a/packages/twenty-shared/src/utils/validation/phones-value/index.ts
+++ b/packages/twenty-shared/src/utils/validation/phones-value/index.ts
@@ -1,0 +1,1 @@
+export * from './isValidCountryCode';

--- a/packages/twenty-shared/src/utils/validation/phones-value/isValidCountryCode.ts
+++ b/packages/twenty-shared/src/utils/validation/phones-value/isValidCountryCode.ts
@@ -1,0 +1,7 @@
+import { CountryCode, getCountries } from 'libphonenumber-js';
+
+const ALL_COUNTRIES_CODE = getCountries();
+
+export const isValidCountryCode = (input: string): input is CountryCode => {
+  return ALL_COUNTRIES_CODE.includes(input as unknown as CountryCode);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -56840,6 +56840,7 @@ __metadata:
     "@types/babel__preset-env": "npm:^7"
     babel-plugin-module-resolver: "npm:^5.0.2"
     glob: "npm:^11.0.1"
+    libphonenumber-js: "npm:^1.10.26"
     tsx: "npm:^4.19.3"
     zod: "npm:3.23.8"
   languageName: unknown


### PR DESCRIPTION
Context : 
- Phones import is a bit complex if not all subfields are provided.
- Phones subfield validation are absent or different from BE validation.

Solution : 
- Normalize callingCode and countryCode validation (BE/FE)
- Ease phone import if only phoneNumber is provided