### PR TITLE
refactor: replace useEffect with onCompleted in Apollo query components

### DIFF
--- a/packages/twenty-front/src/modules/command-menu/pages/message-thread/hooks/useEmailThreadInCommandMenu.ts
+++ b/packages/twenty-front/src/modules/command-menu/pages/message-thread/hooks/useEmailThreadInCommandMenu.ts
@@ -115,15 +115,12 @@ export const useEmailThreadInCommandMenu = () => {
         messageExternalId: true,
       },
       skip: !lastMessageId || !isMessagesFetchComplete,
+      onCompleted: (data) => {
+        if (data.length > 0) {
+          setLastMessageChannelId(data[0].messageChannelId);
+        }
+      },
     });
-
-  useEffect(() => {
-    if (messageChannelMessageAssociationData.length > 0) {
-      setLastMessageChannelId(
-        messageChannelMessageAssociationData[0].messageChannelId,
-      );
-    }
-  }, [messageChannelMessageAssociationData]);
 
   const { records: messageChannelData, loading: messageChannelLoading } =
     useFindManyRecords<MessageChannel>({

--- a/packages/twenty-front/src/modules/object-record/record-index/hooks/useLoadRecordIndexBoardColumn.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/hooks/useLoadRecordIndexBoardColumn.ts
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import { useRecoilValue } from 'recoil';
 
 import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
@@ -91,15 +90,11 @@ export const useLoadRecordIndexBoardColumn = ({
       orderBy,
       recordGqlFields,
       limit: 10,
+      onCompleted: (data) => {
+        setRecordIdsForColumn(columnId, data);
+        upsertRecordsInStore(data);
+      },
     });
-
-  useEffect(() => {
-    setRecordIdsForColumn(columnId, records);
-  }, [records, setRecordIdsForColumn, columnId]);
-
-  useEffect(() => {
-    upsertRecordsInStore(records);
-  }, [records, upsertRecordsInStore]);
 
   return {
     records,

--- a/packages/twenty-front/src/modules/object-record/record-show/components/RecordShowEffect.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-show/components/RecordShowEffect.tsx
@@ -4,9 +4,7 @@ import { useFindOneRecord } from '@/object-record/hooks/useFindOneRecord';
 import { buildFindOneRecordForShowPageOperationSignature } from '@/object-record/record-show/graphql/operations/factories/findOneRecordForShowPageOperationSignatureFactory';
 import { recordStoreFamilyState } from '@/object-record/record-store/states/recordStoreFamilyState';
 import { ObjectRecord } from '@/object-record/types/ObjectRecord';
-import { useEffect } from 'react';
 import { useRecoilCallback } from 'recoil';
-import { isDefined } from 'twenty-shared/utils';
 
 type RecordShowEffectProps = {
   objectNameSingular: string;
@@ -26,11 +24,14 @@ export const RecordShowEffect = ({
       objectMetadataItems,
     });
 
-  const { record, loading } = useFindOneRecord({
+  useFindOneRecord({
     objectRecordId: recordId,
     objectNameSingular,
     recordGqlFields: FIND_ONE_RECORD_FOR_SHOW_PAGE_OPERATION_SIGNATURE.fields,
     withSoftDeleted: true,
+    onCompleted: (data) => {
+      setRecordStore(data);
+    },
   });
 
   const setRecordStore = useRecoilCallback(
@@ -46,12 +47,6 @@ export const RecordShowEffect = ({
       },
     [recordId],
   );
-
-  useEffect(() => {
-    if (!loading && isDefined(record)) {
-      setRecordStore(record);
-    }
-  }, [record, setRecordStore, loading]);
 
   return <></>;
 };

--- a/packages/twenty-front/src/modules/object-record/record-show/record-detail-section/components/RecordDetailRelationRecordsListItemEffect.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-show/record-detail-section/components/RecordDetailRelationRecordsListItemEffect.tsx
@@ -1,11 +1,10 @@
-import { useContext, useEffect } from 'react';
+import { useContext } from 'react';
 
 import { useFindOneRecord } from '@/object-record/hooks/useFindOneRecord';
 import { FieldContext } from '@/object-record/record-field/contexts/FieldContext';
 import { FieldRelationMetadata } from '@/object-record/record-field/types/FieldMetadata';
 
 import { useUpsertRecordsInStore } from '@/object-record/record-store/hooks/useUpsertRecordsInStore';
-import { isDefined } from 'twenty-shared/utils';
 
 type RecordDetailRelationRecordsListItemEffectProps = {
   relationRecordId: string;
@@ -19,18 +18,15 @@ export const RecordDetailRelationRecordsListItemEffect = ({
   const { relationObjectMetadataNameSingular } =
     fieldDefinition.metadata as FieldRelationMetadata;
 
-  const { record } = useFindOneRecord({
-    objectNameSingular: relationObjectMetadataNameSingular,
-    objectRecordId: relationRecordId,
-  });
-
   const { upsertRecords } = useUpsertRecordsInStore();
 
-  useEffect(() => {
-    if (isDefined(record)) {
-      upsertRecords([record]);
-    }
-  }, [record, upsertRecords]);
+  useFindOneRecord({
+    objectNameSingular: relationObjectMetadataNameSingular,
+    objectRecordId: relationRecordId,
+    onCompleted: (data) => {
+      upsertRecords([data]);
+    },
+  });
 
   return null;
 };

--- a/packages/twenty-front/src/modules/prefetch/components/PrefetchRunFavoriteQueriesEffect.tsx
+++ b/packages/twenty-front/src/modules/prefetch/components/PrefetchRunFavoriteQueriesEffect.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import { useRecoilCallback, useRecoilValue, useSetRecoilState } from 'recoil';
 
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
@@ -15,7 +14,6 @@ import { prefetchFavoritesState } from '@/prefetch/states/prefetchFavoritesState
 import { prefetchIsLoadedFamilyState } from '@/prefetch/states/prefetchIsLoadedFamilyState';
 import { PrefetchKey } from '@/prefetch/types/PrefetchKey';
 import { useShowAuthModal } from '@/ui/layout/hooks/useShowAuthModal';
-import { isDefined } from 'twenty-shared/utils';
 import { WorkspaceActivationStatus } from 'twenty-shared/workspace';
 import { isDeeplyEqual } from '~/utils/isDeeplyEqual';
 
@@ -50,18 +48,26 @@ export const PrefetchRunFavoriteQueriesEffect = () => {
       ),
     });
 
-  const { records: favorites } = useFindManyRecords({
+  useFindManyRecords({
     objectNameSingular: CoreObjectNameSingular.Favorite,
     filter: findAllFavoritesOperationSignature.variables.filter,
     recordGqlFields: findAllFavoritesOperationSignature.fields,
     skip: showAuthModal || isSettingsPage || !isWorkspaceActive,
+    onCompleted: (data) => {
+      setPrefetchFavoritesState(data as Favorite[]);
+      setIsPrefetchFavoritesLoaded(true);
+    },
   });
 
-  const { records: favoriteFolders } = useFindManyRecords({
+  useFindManyRecords({
     objectNameSingular: CoreObjectNameSingular.FavoriteFolder,
     filter: findAllFavoriteFoldersOperationSignature.variables.filter,
     recordGqlFields: findAllFavoriteFoldersOperationSignature.fields,
     skip: showAuthModal || isSettingsPage || !isWorkspaceActive,
+    onCompleted: (data) => {
+      setPrefetchFavoriteFoldersState(data as FavoriteFolder[]);
+      setIsPrefetchFavoritesFoldersLoaded(true);
+    },
   });
 
   const setPrefetchFavoritesState = useRecoilCallback(
@@ -91,24 +97,6 @@ export const PrefetchRunFavoriteQueriesEffect = () => {
       },
     [],
   );
-
-  useEffect(() => {
-    if (isDefined(favorites)) {
-      setPrefetchFavoritesState(favorites as Favorite[]);
-      setIsPrefetchFavoritesLoaded(true);
-    }
-  }, [favorites, setPrefetchFavoritesState, setIsPrefetchFavoritesLoaded]);
-
-  useEffect(() => {
-    if (isDefined(favoriteFolders)) {
-      setPrefetchFavoriteFoldersState(favoriteFolders as FavoriteFolder[]);
-      setIsPrefetchFavoritesFoldersLoaded(true);
-    }
-  }, [
-    favoriteFolders,
-    setPrefetchFavoriteFoldersState,
-    setIsPrefetchFavoritesFoldersLoaded,
-  ]);
 
   return <></>;
 };

--- a/packages/twenty-front/src/modules/prefetch/components/PrefetchRunViewQueryEffect.tsx
+++ b/packages/twenty-front/src/modules/prefetch/components/PrefetchRunViewQueryEffect.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import { useRecoilCallback, useRecoilValue } from 'recoil';
 
 import { currentUserState } from '@/auth/states/currentUserState';
@@ -11,7 +10,6 @@ import { prefetchViewsState } from '@/prefetch/states/prefetchViewsState';
 import { isPersistingViewFieldsState } from '@/views/states/isPersistingViewFieldsState';
 import { View } from '@/views/types/View';
 import { useIsWorkspaceActivationStatusEqualsTo } from '@/workspace/hooks/useIsWorkspaceActivationStatusEqualsTo';
-import { isDefined } from 'twenty-shared/utils';
 import { WorkspaceActivationStatus } from 'twenty-shared/workspace';
 import { isDeeplyEqual } from '~/utils/isDeeplyEqual';
 
@@ -28,13 +26,6 @@ export const PrefetchRunViewQueryEffect = () => {
     objectMetadataItem: objectMetadataItems.find(
       (item) => item.nameSingular === CoreObjectNameSingular.View,
     ),
-  });
-
-  const { records } = useFindManyRecords({
-    objectNameSingular: CoreObjectNameSingular.View,
-    filter: findAllViewsOperationSignature.variables.filter,
-    recordGqlFields: findAllViewsOperationSignature.fields,
-    skip: !currentUser || !isWorkspaceActive,
   });
 
   const setPrefetchViewsState = useRecoilCallback(
@@ -54,11 +45,17 @@ export const PrefetchRunViewQueryEffect = () => {
 
   const isPersistingViewFields = useRecoilValue(isPersistingViewFieldsState);
 
-  useEffect(() => {
-    if (isDefined(records) && !isPersistingViewFields) {
-      setPrefetchViewsState(records as View[]);
-    }
-  }, [isPersistingViewFields, records, setPrefetchViewsState]);
+  useFindManyRecords({
+    objectNameSingular: CoreObjectNameSingular.View,
+    filter: findAllViewsOperationSignature.variables.filter,
+    recordGqlFields: findAllViewsOperationSignature.fields,
+    skip: !currentUser || !isWorkspaceActive,
+    onCompleted: (data) => {
+      if (!isPersistingViewFields) {
+        setPrefetchViewsState(data as View[]);
+      }
+    },
+  });
 
   return <></>;
 };

--- a/packages/twenty-front/src/modules/settings/roles/components/SettingsRolesQueryEffect.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/components/SettingsRolesQueryEffect.tsx
@@ -3,17 +3,11 @@ import { settingsPersistedRoleFamilyState } from '@/settings/roles/states/settin
 import { settingsRoleIdsState } from '@/settings/roles/states/settingsRoleIdsState';
 import { settingsRolesIsLoadingState } from '@/settings/roles/states/settingsRolesIsLoadingState';
 import { getSnapshotValue } from '@/ui/utilities/recoil-scope/utils/getSnapshotValue';
-import { useEffect } from 'react';
 import { useRecoilCallback, useSetRecoilState } from 'recoil';
-import { isDefined } from 'twenty-shared/utils';
 import { Role, useGetRolesQuery } from '~/generated/graphql';
 import { isDeeplyEqual } from '~/utils/isDeeplyEqual';
 
 export const SettingsRolesQueryEffect = () => {
-  const { data, loading } = useGetRolesQuery({
-    fetchPolicy: 'network-only',
-  });
-
   const setSettingsRolesIsLoading = useSetRecoilState(
     settingsRolesIsLoadingState,
   );
@@ -48,17 +42,17 @@ export const SettingsRolesQueryEffect = () => {
     [],
   );
 
-  useEffect(() => {
-    setSettingsRolesIsLoading(loading);
-    if (!loading) {
+  const { data, loading } = useGetRolesQuery({
+    fetchPolicy: 'network-only',
+    onCompleted: (data) => {
       const roles = data?.getRoles;
-      if (!isDefined(roles)) {
-        return;
+      if (roles) {
+        populateRoles(roles);
       }
+    },
+  });
 
-      populateRoles(roles);
-    }
-  }, [data, loading, populateRoles, setSettingsRolesIsLoading]);
+  setSettingsRolesIsLoading(loading);
 
   return null;
 };


### PR DESCRIPTION
## Summary

  Replace `useEffect` patterns that sync Apollo query data to state with onCompleted callbacks for better performance and cleaner code.

  ## Changes

  - **PrefetchRunViewQueryEffect**: Move data syncing logic to onCompleted callback
  - **PrefetchRunFavoriteQueriesEffect**: Replace dual useEffect calls with onCompleted callbacks
  - **RecordShowEffect**: Use onCompleted instead of useEffect for record store updates
  - **RecordDetailRelationRecordsListItemEffect**: Simplify data flow with onCompleted
  - **useLoadRecordIndexBoardColumn**: Combine two useEffect calls into single onCompleted callback
  - **SettingsRolesQueryEffect**: Move role population logic to onCompleted
  - **useEmailThreadInCommandMenu**: Replace one useEffect with onCompleted (partial refactor)

  ## Files Changed

  - command-menu/pages/message-thread/hooks/useEmailThreadInCommandMenu.ts
  - object-record/record-index/hooks/useLoadRecordIndexBoardColumn.ts
  - object-record/record-show/components/RecordShowEffect.tsx
  - object-record/record-show/record-detail-section/components/RecordDetailRelationRecordsListItemEffect.tsx
  - prefetch/components/PrefetchRunFavoriteQueriesEffect.tsx
  - prefetch/components/PrefetchRunViewQueryEffect.tsx
  - settings/roles/components/SettingsRolesQueryEffect.tsx