### PR TITLE
Store HTTP request json body as a string

### DIFF
--- a/packages/twenty-front/src/modules/workflow/validation-schemas/workflowSchema.ts
+++ b/packages/twenty-front/src/modules/workflow/validation-schemas/workflowSchema.ts
@@ -126,6 +126,7 @@ export const workflowHttpRequestActionSettingsSchema =
             z.array(z.union([z.string(), z.number(), z.boolean(), z.null()])),
           ]),
         )
+        .or(z.string())
         .optional(),
     }),
   });

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/http-request-action/components/KeyValuePairInput.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/http-request-action/components/KeyValuePairInput.tsx
@@ -39,7 +39,7 @@ export type KeyValuePair = {
 
 export type KeyValuePairInputProps = {
   label?: string;
-  defaultValue?: Record<string, string>;
+  defaultValue?: Record<string, string> | Array<string>;
   onChange: (value: Record<string, string>) => void;
   readonly?: boolean;
   keyPlaceholder?: string;

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/http-request-action/constants/HttpRequest.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/http-request-action/constants/HttpRequest.ts
@@ -21,7 +21,7 @@ export type HttpRequestFormData = {
   url: string;
   method: HttpMethod;
   headers: Record<string, string>;
-  body?: HttpRequestBody;
+  body?: HttpRequestBody | string;
 };
 
 export const DEFAULT_JSON_BODY_PLACEHOLDER =

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/http-request-action/utils/__tests__/hasNonStringValues.test.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/http-request-action/utils/__tests__/hasNonStringValues.test.ts
@@ -2,21 +2,17 @@ import { HttpRequestBody } from '../../constants/HttpRequest';
 import { hasNonStringValues } from '../hasNonStringValues';
 
 describe('hasNonStringValues', () => {
-  it('should return false for undefined input', () => {
-    expect(hasNonStringValues(undefined)).toBe(false);
-  });
-
-  it('should return false for empty object', () => {
-    expect(hasNonStringValues({})).toBe(false);
+  it('should return true for empty object', () => {
+    expect(hasNonStringValues({})).toBe(true);
   });
 
   it('should return false for object with only string values', () => {
     expect(hasNonStringValues({ key1: 'value1', key2: 'value2' })).toBe(false);
   });
 
-  it('should return false for object with null values', () => {
+  it('should return true for object with null values', () => {
     const body: HttpRequestBody = { key1: null, key2: 'value' };
-    expect(hasNonStringValues(body)).toBe(false);
+    expect(hasNonStringValues(body)).toBe(true);
   });
 
   it('should return true for object with number values', () => {

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/http-request-action/utils/hasNonStringValues.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/http-request-action/utils/hasNonStringValues.ts
@@ -1,11 +1,12 @@
-import { HttpRequestBody } from '../constants/HttpRequest';
+import { isString } from '@sniptt/guards';
+import { JsonArray, JsonObject } from 'type-fest';
 
-export const hasNonStringValues = (obj?: HttpRequestBody): boolean => {
-  if (!obj) {
-    return false;
+export const hasNonStringValues = (obj: JsonObject | JsonArray): boolean => {
+  const values = Object.values(obj);
+
+  if (values.length === 0) {
+    return true;
   }
-  return Object.values(obj).some(
-    (value) =>
-      value !== null && value !== undefined && typeof value !== 'string',
-  );
+
+  return !values.every((value) => isString(value));
 };

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/http-request-action/utils/parseHttpJsonBodyWithoutVariablesOrThrow.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/http-request-action/utils/parseHttpJsonBodyWithoutVariablesOrThrow.ts
@@ -1,0 +1,5 @@
+import { removeVariablesFromJson } from '@/workflow/workflow-variables/utils/removeVariablesFromJson';
+
+export const parseHttpJsonBodyWithoutVariablesOrThrow = (value: string) => {
+  return JSON.parse(removeVariablesFromJson(value));
+};

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/http-request-action/utils/shouldDisplayRawJsonByDefault.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/http-request-action/utils/shouldDisplayRawJsonByDefault.ts
@@ -1,0 +1,30 @@
+import { HttpRequestBody } from '@/workflow/workflow-steps/workflow-actions/http-request-action/constants/HttpRequest';
+import { hasNonStringValues } from '@/workflow/workflow-steps/workflow-actions/http-request-action/utils/hasNonStringValues';
+import { removeVariablesFromJson } from '@/workflow/workflow-variables/utils/removeVariablesFromJson';
+import { isObject, isString, isUndefined } from '@sniptt/guards';
+import { parseJson } from 'twenty-shared/utils';
+import { JsonValue } from 'type-fest';
+
+export const shouldDisplayRawJsonByDefault = (
+  defaultValue: string | HttpRequestBody | undefined,
+) => {
+  const defaultValueParsedWithoutVariables: JsonValue | undefined = isString(
+    defaultValue,
+  )
+    ? (parseJson<JsonValue>(removeVariablesFromJson(defaultValue)) ?? {})
+    : defaultValue;
+
+  if (isUndefined(defaultValueParsedWithoutVariables)) {
+    return false;
+  }
+
+  return (
+    ((isObject(defaultValueParsedWithoutVariables) ||
+      Array.isArray(defaultValueParsedWithoutVariables)) &&
+      hasNonStringValues(defaultValueParsedWithoutVariables)) ||
+    !(
+      isObject(defaultValueParsedWithoutVariables) ||
+      Array.isArray(defaultValueParsedWithoutVariables)
+    )
+  );
+};

--- a/packages/twenty-front/src/modules/workflow/workflow-variables/utils/removeVariablesFromJson.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-variables/utils/removeVariablesFromJson.ts
@@ -1,0 +1,5 @@
+import { CAPTURE_ALL_VARIABLE_TAG_INNER_REGEX } from '@/workflow/workflow-variables/constants/CaptureAllVariableTagInnerRegex';
+
+export const removeVariablesFromJson = (json: string): string => {
+  return json.replaceAll(CAPTURE_ALL_VARIABLE_TAG_INNER_REGEX, 'null');
+};

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/http-request/http-request.workflow-action.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/http-request/http-request.workflow-action.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 
+import { isString } from '@sniptt/guards';
 import axios, { AxiosRequestConfig } from 'axios';
 
 import { WorkflowExecutor } from 'src/modules/workflow/workflow-executor/interfaces/workflow-executor.interface';
@@ -52,7 +53,9 @@ export class HttpRequestWorkflowAction implements WorkflowExecutor {
       };
 
       if (['POST', 'PUT', 'PATCH'].includes(method) && body) {
-        axiosConfig.data = body;
+        const parsedBody = isString(body) ? JSON.parse(body) : body;
+
+        axiosConfig.data = parsedBody;
       }
 
       const response = await axios(axiosConfig);

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/http-request/types/workflow-http-request-action-input.type.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/http-request/types/workflow-http-request-action-input.type.ts
@@ -2,13 +2,15 @@ export type WorkflowHttpRequestActionInput = {
   url: string;
   method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
   headers?: Record<string, string>;
-  body?: Record<
-    string,
-    | string
-    | number
-    | boolean
-    | null
-    | undefined
-    | Array<string | number | boolean | null>
-  >;
+  body?:
+    | Record<
+        string,
+        | string
+        | number
+        | boolean
+        | null
+        | undefined
+        | Array<string | number | boolean | null>
+      >
+    | string;
 };


### PR DESCRIPTION
Variables can be used without surrounding quotes.

The formatting is also preserved for raw json.

We would have to do additional work if we want to add other types of bodies, like form data.

## Demo

https://github.com/user-attachments/assets/498dd9c8-6654-4440-9ab0-35bad5e34ca8

Closes https://github.com/twentyhq/core-team-issues/issues/1129

Related to https://github.com/twentyhq/core-team-issues/issues/1117. Doesn't solve the issue for webhooks but does for http body input.