### PR TITLE
Update docker entry point parsing to handle postgres query paramaters

### DIFF
--- a/packages/twenty-docker/twenty/entrypoint.sh
+++ b/packages/twenty-docker/twenty/entrypoint.sh
@@ -12,7 +12,7 @@ setup_and_migrate_db() {
     PGPASS=$(echo $PG_DATABASE_URL | awk -F ':' '{print $3}' | awk -F '@' '{print $1}')
     PGHOST=$(echo $PG_DATABASE_URL | awk -F '@' '{print $2}' | awk -F ':' '{print $1}')
     PGPORT=$(echo $PG_DATABASE_URL | awk -F ':' '{print $4}' | awk -F '/' '{print $1}')
-    PGDATABASE=$(echo $PG_DATABASE_URL | awk -F ':' '{print $4}' | awk -F '/' '{print $2}')
+    PGDATABASE=$(echo $PG_DATABASE_URL | awk -F '/' '{print $NF}' | cut -d'?' -f1)
 
     # Creating the database if it doesn't exist
     db_count=$(PGPASSWORD=${PGPASS} psql -h ${PGHOST} -p ${PGPORT} -U ${PGUSER} -d postgres -tAc "SELECT COUNT(*) FROM pg_database WHERE datname = '${PGDATABASE}'")


### PR DESCRIPTION
This PR fixes the database name check to ignore query params.
This is useful for situations where you need to force sslmode, like ?sslmode=require. Yarn seems to handle this, but this db creation check fails.

My environment enforces ssl for all PG connections, so I need twenty to handle this check for me to test it locally. 