### PR TITLE
[#12744] UI Fix: Filter Section Separator Needs to Be Darker

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/dropdown/components/DropdownMenuSectionLabel.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/dropdown/components/DropdownMenuSectionLabel.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 
 const StyledDropdownMenuSectionLabel = styled.div`
   background-color: ${({ theme }) => theme.background.transparent.lighter};
-  color: ${({ theme }) => theme.font.color.light};
+  color: ${({ theme }) => theme.font.color.tertiary};
   min-height: 20px;
   width: auto;
   font-size: ${({ theme }) => theme.font.size.xxs};


### PR DESCRIPTION
[#12744] UI Fix: Change text color in Filter Section Separator from light to tertiary.

Before
<img width="316" alt="Screenshot 2025-06-29 at 6 10 50 PM" src="https://github.com/user-attachments/assets/09c21571-24a2-4459-bf0f-4d7e7b4dcf04" />


After
<img width="322" alt="Screenshot 2025-06-29 at 6 11 15 PM" src="https://github.com/user-attachments/assets/a4c486c9-34ae-4f10-83cb-918b15582dec" />
