### PR TITLE
Run workflow version on multiple records

### DIFF
--- a/packages/twenty-front/src/modules/action-menu/contexts/ActionMenuContextProviderWorkflowsEnabled.tsx
+++ b/packages/twenty-front/src/modules/action-menu/contexts/ActionMenuContextProviderWorkflowsEnabled.tsx
@@ -43,13 +43,13 @@ export const ActionMenuContextProviderWorkflowsEnabled = ({
     contextStoreTargetedRecordsRuleComponentState,
   );
 
-  const isSingleRecordSelection =
+  const isRecordSelection =
     contextStoreTargetedRecordsRule.mode === 'selection' &&
-    contextStoreTargetedRecordsRule.selectedRecordIds.length === 1;
+    contextStoreTargetedRecordsRule.selectedRecordIds.length > 0;
 
   const runWorkflowRecordActions = useRunWorkflowRecordActions({
     objectMetadataItem,
-    skip: !isSingleRecordSelection,
+    skip: !isRecordSelection,
   });
 
   const runWorkflowRecordAgnosticActions =


### PR DESCRIPTION
Fixes https://github.com/twentyhq/core-team-issues/issues/776

Until we have loops implemented, we still allow the user to select multiple records for manual trigger. A workflow run will be triggered for each record selected.

The display of multiple runs in the side panel is not ideal. After discussion with @Bonapara, we will load all runs into the side panel until we have the inbox. Once we have the inbox, we will use the side panel when only one run is triggered.

https://github.com/user-attachments/assets/b563b4f1-0705-45aa-b296-c1b41abf4815

