### PR TITLE
Feat:multi edit values when selecting several records

### DIFF
--- a/packages/twenty-front/src/modules/object-record/hooks/useUpdateManyRecords.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useUpdateManyRecords.ts
@@ -1,0 +1,270 @@
+import { triggerUpdateRecordOptimisticEffectByBatch } from '@/apollo/optimistic-effect/utils/triggerUpdateRecordOptimisticEffectByBatch';
+import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
+import { apiConfigState } from '@/client-config/states/apiConfigState';
+import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
+import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
+import { useGetRecordFromCache } from '@/object-record/cache/hooks/useGetRecordFromCache';
+import { getObjectTypename } from '@/object-record/cache/utils/getObjectTypename';
+import { getRecordNodeFromRecord } from '@/object-record/cache/utils/getRecordNodeFromRecord';
+import { updateRecordFromCache } from '@/object-record/cache/utils/updateRecordFromCache';
+import { DEFAULT_MUTATION_BATCH_SIZE } from '@/object-record/constants/DefaultMutationBatchSize';
+import { RecordGqlNode } from '@/object-record/graphql/types/RecordGqlNode';
+import { computeDepthOneRecordGqlFieldsFromRecord } from '@/object-record/graphql/utils/computeDepthOneRecordGqlFieldsFromRecord';
+import { generateDepthOneRecordGqlFields } from '@/object-record/graphql/utils/generateDepthOneRecordGqlFields';
+import { useObjectPermissions } from '@/object-record/hooks/useObjectPermissions';
+import { useRefetchAggregateQueries } from '@/object-record/hooks/useRefetchAggregateQueries';
+import { useUpdateManyRecordsMutation } from '@/object-record/hooks/useUpdateManyRecordsMutation';
+import { ObjectRecord } from '@/object-record/types/ObjectRecord';
+import { computeOptimisticRecordFromInput } from '@/object-record/utils/computeOptimisticRecordFromInput';
+import { getUpdateManyRecordsMutationResponseField } from '@/object-record/utils/getUpdateManyRecordsMutationResponseField';
+import { sanitizeRecordInput } from '@/object-record/utils/sanitizeRecordInput';
+import { useApolloClient } from '@apollo/client';
+import { useRecoilValue } from 'recoil';
+import { isDefined } from 'twenty-shared/utils';
+import { buildRecordFromKeysWithSameValue } from '~/utils/array/buildRecordFromKeysWithSameValue';
+import { sleep } from '~/utils/sleep';
+
+type useUpdateManyRecordProps = {
+  objectNameSingular: string;
+  refetchFindManyQuery?: boolean;
+  recordGqlFields?: Record<string, any>;
+};
+
+export type UpdateManyRecordsProps<UpdatedObjectRecord> = {
+  recordIdsToUpdate: string[];
+  skipOptimisticEffect?: boolean;
+  delayInMsBetweenRequests?: number;
+  updateManyRecordsInput: Partial<Omit<UpdatedObjectRecord, 'id'>>;
+  optimisticRecord?: Partial<ObjectRecord>;
+};
+
+export const useUpdateManyRecords = <
+  UpdatedObjectRecord extends ObjectRecord = ObjectRecord,
+>({
+  objectNameSingular,
+  recordGqlFields,
+}: useUpdateManyRecordProps) => {
+  const apiConfig = useRecoilValue(apiConfigState);
+  const mutationPageSize =
+    apiConfig?.mutationMaximumAffectedRecords ?? DEFAULT_MUTATION_BATCH_SIZE;
+  const apolloClient = useApolloClient();
+
+  const { objectMetadataItem } = useObjectMetadataItem({
+    objectNameSingular,
+  });
+  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+  const getRecordFromCache = useGetRecordFromCache({
+    objectNameSingular,
+  });
+
+  const computedRecordGqlFields =
+    recordGqlFields ?? generateDepthOneRecordGqlFields({ objectMetadataItem });
+
+  const { objectMetadataItems } = useObjectMetadataItems();
+  const { objectPermissionsByObjectMetadataId } = useObjectPermissions();
+  const { refetchAggregateQueries } = useRefetchAggregateQueries({
+    objectMetadataNamePlural: objectMetadataItem.namePlural,
+  });
+  const { updateManyRecordsMutation } = useUpdateManyRecordsMutation({
+    objectNameSingular,
+    recordGqlFields: computedRecordGqlFields,
+  });
+  const mutationResponseField = getUpdateManyRecordsMutationResponseField(
+    objectMetadataItem.namePlural,
+  );
+  const updateManyRecords = async ({
+    recordIdsToUpdate,
+    delayInMsBetweenRequests,
+    skipOptimisticEffect = false,
+    updateManyRecordsInput,
+    optimisticRecord,
+  }: UpdateManyRecordsProps<UpdatedObjectRecord>) => {
+    const numberOfBatches = Math.ceil(
+      recordIdsToUpdate.length / mutationPageSize,
+    );
+    const optimisticRecordInput =
+      optimisticRecord ??
+      computeOptimisticRecordFromInput({
+        objectMetadataItem,
+        currentWorkspaceMember: currentWorkspaceMember,
+        recordInput: updateManyRecordsInput,
+        cache: apolloClient.cache,
+        objectMetadataItems,
+        objectPermissionsByObjectMetadataId,
+      });
+    const sanitizedInput = {
+      ...sanitizeRecordInput({
+        objectMetadataItem,
+        recordInput: updateManyRecordsInput,
+      }),
+    };
+    const updatedRecords = [];
+    for (let batchIndex = 0; batchIndex < numberOfBatches; batchIndex++) {
+      const batchIdsToUpdate = recordIdsToUpdate.slice(
+        batchIndex * mutationPageSize,
+        (batchIndex + 1) * mutationPageSize,
+      );
+      const cachedRecords = batchIdsToUpdate
+        .map((idToUpdate) => getRecordFromCache(idToUpdate, apolloClient.cache))
+        .filter(isDefined);
+      const cashedRecordsCopy = [...cachedRecords];
+      if (!skipOptimisticEffect) {
+        const cachedRecordsNode: RecordGqlNode[] = [];
+        const computedOptimisticRecordsNode: RecordGqlNode[] = [];
+        cashedRecordsCopy.forEach((cachedRecord) => {
+          const cachedRecordWithConnection =
+            getRecordNodeFromRecord<ObjectRecord>({
+              record: cachedRecord,
+              objectMetadataItem,
+              objectMetadataItems,
+              recordGqlFields: computedRecordGqlFields,
+              computeReferences: false,
+            });
+          const computedOptimisticRecord = {
+            ...cachedRecord,
+            ...optimisticRecordInput,
+            __typename: getObjectTypename(objectMetadataItem.nameSingular),
+          };
+          const optimisticRecordWithConnection =
+            getRecordNodeFromRecord<ObjectRecord>({
+              record: computedOptimisticRecord,
+              objectMetadataItem,
+              objectMetadataItems,
+              recordGqlFields: computedRecordGqlFields,
+              computeReferences: false,
+            });
+          if (
+            isDefined(optimisticRecordWithConnection) &&
+            isDefined(cachedRecordWithConnection)
+          ) {
+            const recordGqlFields = computeDepthOneRecordGqlFieldsFromRecord({
+              objectMetadataItem,
+              record: optimisticRecordInput,
+            });
+            updateRecordFromCache({
+              objectMetadataItems,
+              objectMetadataItem,
+              cache: apolloClient.cache,
+              record: computedOptimisticRecord,
+              recordGqlFields,
+              objectPermissionsByObjectMetadataId,
+            });
+
+            computedOptimisticRecordsNode.push(optimisticRecordWithConnection);
+            cachedRecordsNode.push(cachedRecordWithConnection);
+          }
+        });
+        triggerUpdateRecordOptimisticEffectByBatch({
+          cache: apolloClient.cache,
+          objectMetadataItem,
+          currentRecords: cachedRecordsNode,
+          updatedRecords: computedOptimisticRecordsNode,
+          objectMetadataItems,
+        });
+      }
+
+      const updatedRecordsResponse = await apolloClient
+        .mutate<Record<string, ObjectRecord[]>>({
+          mutation: updateManyRecordsMutation,
+          variables: {
+            data: sanitizedInput,
+            filter: { id: { in: batchIdsToUpdate } },
+          },
+        })
+        .catch((error: Error) => {
+          if (skipOptimisticEffect) {
+            throw error;
+          }
+
+          const cachedRecordsNode: RecordGqlNode[] = [];
+          const computedOptimisticRecordsNode: RecordGqlNode[] = [];
+
+          cachedRecords.forEach((cachedRecord) => {
+            const cachedRecordKeys = new Set(Object.keys(cachedRecord));
+            const recordKeysAddedByOptimisticCache = Object.keys(
+              optimisticRecordInput,
+            ).filter((diffKey) => !cachedRecordKeys.has(diffKey));
+
+            const recordGqlFields = {
+              ...computeDepthOneRecordGqlFieldsFromRecord({
+                objectMetadataItem,
+                record: cachedRecord,
+              }),
+              ...buildRecordFromKeysWithSameValue(
+                recordKeysAddedByOptimisticCache,
+                true,
+              ),
+            };
+
+            updateRecordFromCache({
+              objectMetadataItems,
+              objectMetadataItem,
+              cache: apolloClient.cache,
+              record: {
+                ...cachedRecord,
+                ...buildRecordFromKeysWithSameValue(
+                  recordKeysAddedByOptimisticCache,
+                  null,
+                ),
+              },
+              recordGqlFields,
+              objectPermissionsByObjectMetadataId,
+            });
+
+            const cachedRecordWithConnection =
+              getRecordNodeFromRecord<ObjectRecord>({
+                record: cachedRecord,
+                objectMetadataItem,
+                objectMetadataItems,
+                computeReferences: false,
+              });
+
+            const computedOptimisticRecord = {
+              ...cachedRecord,
+              ...optimisticRecordInput,
+              __typename: getObjectTypename(objectMetadataItem.nameSingular),
+            };
+
+            const optimisticRecordWithConnection =
+              getRecordNodeFromRecord<ObjectRecord>({
+                record: computedOptimisticRecord,
+                objectMetadataItem,
+                objectMetadataItems,
+                computeReferences: false,
+              });
+
+            if (
+              isDefined(optimisticRecordWithConnection) &&
+              isDefined(cachedRecordWithConnection)
+            ) {
+              cachedRecordsNode.push(cachedRecordWithConnection);
+              computedOptimisticRecordsNode.push(
+                optimisticRecordWithConnection,
+              );
+            }
+          });
+
+          triggerUpdateRecordOptimisticEffectByBatch({
+            cache: apolloClient.cache,
+            objectMetadataItem,
+            currentRecords: computedOptimisticRecordsNode,
+            updatedRecords: cachedRecordsNode,
+            objectMetadataItems,
+          });
+
+          throw error;
+        });
+
+      const updatedRecordsForThisBatch =
+        updatedRecordsResponse.data?.[mutationResponseField] ?? [];
+      updatedRecords.push(...updatedRecordsForThisBatch);
+
+      if (isDefined(delayInMsBetweenRequests)) {
+        await sleep(delayInMsBetweenRequests);
+      }
+    }
+    await refetchAggregateQueries();
+    return updatedRecords;
+  };
+  return { updateManyRecords };
+};

--- a/packages/twenty-front/src/modules/object-record/hooks/useUpdateManyRecords.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useUpdateManyRecords.ts
@@ -107,11 +107,11 @@ export const useUpdateManyRecords = <
       const cachedRecords = batchIdsToUpdate
         .map((idToUpdate) => getRecordFromCache(idToUpdate, apolloClient.cache))
         .filter(isDefined);
-      const cashedRecordsCopy = [...cachedRecords];
+
       if (!skipOptimisticEffect) {
         const cachedRecordsNode: RecordGqlNode[] = [];
         const computedOptimisticRecordsNode: RecordGqlNode[] = [];
-        cashedRecordsCopy.forEach((cachedRecord) => {
+        cachedRecords.forEach((cachedRecord) => {
           const cachedRecordWithConnection =
             getRecordNodeFromRecord<ObjectRecord>({
               record: cachedRecord,

--- a/packages/twenty-front/src/modules/object-record/hooks/useUpdateManyRecordsMutation.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useUpdateManyRecordsMutation.ts
@@ -1,0 +1,65 @@
+import gql from 'graphql-tag';
+import { useRecoilValue } from 'recoil';
+
+import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
+import { objectMetadataItemsState } from '@/object-metadata/states/objectMetadataItemsState';
+import { mapObjectMetadataToGraphQLQuery } from '@/object-metadata/utils/mapObjectMetadataToGraphQLQuery';
+import { EMPTY_MUTATION } from '@/object-record/constants/EmptyMutation';
+import { RecordGqlOperationGqlRecordFields } from '@/object-record/graphql/types/RecordGqlOperationGqlRecordFields';
+import { generateDepthOneRecordGqlFields } from '@/object-record/graphql/utils/generateDepthOneRecordGqlFields';
+import { useObjectPermissions } from '@/object-record/hooks/useObjectPermissions';
+import { getUpdateManyRecordsMutationResponseField } from '@/object-record/utils/getUpdateManyRecordsMutationResponseField';
+import { capitalize } from 'twenty-shared/utils';
+import { isUndefinedOrNull } from '~/utils/isUndefinedOrNull';
+
+export const useUpdateManyRecordsMutation = ({
+  objectNameSingular,
+  recordGqlFields,
+  computeReferences = false,
+}: {
+  objectNameSingular: string;
+  recordGqlFields?: RecordGqlOperationGqlRecordFields;
+  computeReferences?: boolean;
+}) => {
+  const { objectMetadataItem } = useObjectMetadataItem({
+    objectNameSingular,
+  });
+
+  const { objectPermissionsByObjectMetadataId } = useObjectPermissions();
+
+  const objectMetadataItems = useRecoilValue(objectMetadataItemsState);
+
+  if (isUndefinedOrNull(objectMetadataItem)) {
+    return { updateManyRecordsMutation: EMPTY_MUTATION };
+  }
+  const appliedRecordGqlFields =
+    recordGqlFields ??
+    generateDepthOneRecordGqlFields({
+      objectMetadataItem,
+    });
+  const capitalizedSingular = capitalize(objectMetadataItem.nameSingular);
+  const capitalizedPlural = capitalize(objectMetadataItem.namePlural);
+  const mutationResponseField = getUpdateManyRecordsMutationResponseField(
+    objectMetadataItem.namePlural,
+  );
+
+  const updateManyRecordsMutation = gql`
+    mutation UpdateMany${capitalizedPlural}(
+      $filter: ${capitalizedSingular}FilterInput!,
+      $data: ${capitalizedSingular}UpdateInput!
+    ) {
+      ${mutationResponseField}(filter: $filter, data: $data)
+        ${mapObjectMetadataToGraphQLQuery({
+          objectMetadataItems,
+          objectMetadataItem,
+          recordGqlFields: appliedRecordGqlFields,
+          objectPermissionsByObjectMetadataId,
+          computeReferences,
+        })}
+    }
+  `;
+
+  return {
+    updateManyRecordsMutation,
+  };
+};

--- a/packages/twenty-front/src/modules/object-record/record-field/contexts/FieldContext.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/contexts/FieldContext.ts
@@ -20,6 +20,11 @@ export type RecordUpdateHook = () => [
   RecordUpdateHookReturn,
 ];
 
+export type RecordsUpdateHookParams = {
+  recordIdsToUpdate: string[];
+  updateManyRecordsInput: Record<string, unknown>;
+};
+
 export type GenericFieldContextType = {
   fieldDefinition: FieldDefinition<FieldMetadata>;
   useUpdateRecord?: RecordUpdateHook;
@@ -40,6 +45,7 @@ export type GenericFieldContextType = {
   onCloseEditMode?: () => void;
   triggerEvent?: TriggerEventType;
   isForbidden?: boolean;
+  updateMultipleRecords?: (params: RecordsUpdateHookParams) => void;
 };
 
 export const FieldContext = createContext<GenericFieldContextType>(

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellFieldContextGeneric.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellFieldContextGeneric.tsx
@@ -1,6 +1,10 @@
 import { getObjectPermissionsForObject } from '@/object-metadata/utils/getObjectPermissionsForObject';
 import { isLabelIdentifierField } from '@/object-metadata/utils/isLabelIdentifierField';
-import { FieldContext } from '@/object-record/record-field/contexts/FieldContext';
+import { useUpdateManyRecords } from '@/object-record/hooks/useUpdateManyRecords';
+import {
+  FieldContext,
+  RecordsUpdateHookParams,
+} from '@/object-record/record-field/contexts/FieldContext';
 import { useIsFieldValueReadOnly } from '@/object-record/record-field/hooks/useIsFieldValueReadOnly';
 import { isFieldRelationFromManyObjects } from '@/object-record/record-field/types/guards/isFieldRelationFromManyObjects';
 import { isFieldRelationToOneObject } from '@/object-record/record-field/types/guards/isFieldRelationToOneObject';
@@ -54,7 +58,15 @@ export const RecordTableCellFieldContextGeneric = ({
 
     hasObjectReadPermissions = relationObjectPermissions.canReadObjectRecords;
   }
-
+  const { updateManyRecords } = useUpdateManyRecords({
+    objectNameSingular: objectMetadataItem.nameSingular,
+  });
+  const updateMultipleRecords = ({
+    recordIdsToUpdate,
+    updateManyRecordsInput,
+  }: RecordsUpdateHookParams) => {
+    updateManyRecords({ recordIdsToUpdate, updateManyRecordsInput });
+  };
   return (
     <FieldContext.Provider
       value={{
@@ -72,6 +84,7 @@ export const RecordTableCellFieldContextGeneric = ({
         displayedMaxRows: 1,
         isReadOnly: isFieldReadOnly,
         isForbidden: !hasObjectReadPermissions,
+        updateMultipleRecords,
       }}
     >
       {children}

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellFieldContextLabelIdentifier.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellFieldContextLabelIdentifier.tsx
@@ -1,5 +1,9 @@
 import { getObjectPermissionsForObject } from '@/object-metadata/utils/getObjectPermissionsForObject';
-import { FieldContext } from '@/object-record/record-field/contexts/FieldContext';
+import { useUpdateManyRecords } from '@/object-record/hooks/useUpdateManyRecords';
+import {
+  FieldContext,
+  RecordsUpdateHookParams,
+} from '@/object-record/record-field/contexts/FieldContext';
 import { useIsFieldValueReadOnly } from '@/object-record/record-field/hooks/useIsFieldValueReadOnly';
 import { useRecordIndexContextOrThrow } from '@/object-record/record-index/contexts/RecordIndexContext';
 import { useOpenRecordFromIndexView } from '@/object-record/record-index/hooks/useOpenRecordFromIndexView';
@@ -58,7 +62,15 @@ export const RecordTableCellFieldContextLabelIdentifier = ({
     isMobile && !isRecordTableScrolledLeftComponent;
 
   const { openRecordFromIndexView } = useOpenRecordFromIndexView();
-
+  const { updateManyRecords } = useUpdateManyRecords({
+    objectNameSingular: objectMetadataItem.nameSingular,
+  });
+  const updateMultipleRecords = ({
+    recordIdsToUpdate,
+    updateManyRecordsInput,
+  }: RecordsUpdateHookParams) => {
+    updateManyRecords({ recordIdsToUpdate, updateManyRecordsInput });
+  };
   const recordIndexOpenRecordIn = useRecoilValue(recordIndexOpenRecordInState);
   const triggerEvent =
     recordIndexOpenRecordIn === ViewOpenRecordInType.SIDE_PANEL
@@ -84,6 +96,7 @@ export const RecordTableCellFieldContextLabelIdentifier = ({
         },
         isForbidden: !hasObjectReadPermissions,
         triggerEvent,
+        updateMultipleRecords,
       }}
     >
       {children}

--- a/packages/twenty-front/src/modules/object-record/utils/getUpdateManyRecordsMutationResponseField.ts
+++ b/packages/twenty-front/src/modules/object-record/utils/getUpdateManyRecordsMutationResponseField.ts
@@ -1,0 +1,4 @@
+import { capitalize } from 'twenty-shared/utils';
+export const getUpdateManyRecordsMutationResponseField = (
+  objectNamePlural: string,
+) => `update${capitalize(objectNamePlural)}`;


### PR DESCRIPTION
resolve twentyhq/core-team-issues#1254 
This PR enables updating multiple selected records:

- Created a new hook for updating many records.
- Extracted the selected record IDs and invoked the new useUpdateManyRecords hook with the provided update data.
 
Let me know if this approach aligns with the codebase structure. I'll also add tests for the new hooks. Thanks!

https://github.com/user-attachments/assets/f164ee43-2017-4546-bdca-67af4d1bee44

