### PR TITLE
Fixed avatar font weight and associated story

### DIFF
--- a/packages/twenty-ui/src/display/avatar/components/Avatar.tsx
+++ b/packages/twenty-ui/src/display/avatar/components/Avatar.tsx
@@ -51,6 +51,12 @@ const StyledImage = styled.img`
   width: 100%;
 `;
 
+const StyledPlaceholderChar = styled.span<{
+  fontWeight: number;
+}>`
+  font-weight: ${({ fontWeight }) => fontWeight};
+`;
+
 export type AvatarProps = {
   avatarUrl?: string | null;
   className?: string;
@@ -132,7 +138,9 @@ export const Avatar = ({
           size={theme.icon.size.xl}
         />
       ) : showPlaceholder ? (
-        placeholderChar
+        <StyledPlaceholderChar fontWeight={theme.font.weight.medium}>
+          {placeholderChar}
+        </StyledPlaceholderChar>
       ) : (
         <StyledImage src={avatarImageURI} onError={handleImageError} alt="" />
       )}

--- a/packages/twenty-ui/src/display/avatar/components/__stories__/Avatar.stories.tsx
+++ b/packages/twenty-ui/src/display/avatar/components/__stories__/Avatar.stories.tsx
@@ -15,7 +15,7 @@ const meta: Meta<typeof Avatar> = {
   args: {
     avatarUrl: AVATAR_URL_MOCK,
     size: 'md',
-    placeholder: 'L',
+    placeholder: 'E',
     type: 'rounded',
   },
 };


### PR DESCRIPTION
This PR changes the avatar placeholder letter font-weight to medium.

I also updated the story to use a symmetric letter “E” instead of “L”, so that it is easier to spot alignment problems.

Before : 

<img width="347" alt="Capture d’écran 2025-07-01 à 15 51 57" src="https://github.com/user-attachments/assets/b622083e-b9a8-45a9-9956-a15c0cb3508a" />

After :

<img width="257" alt="Capture d’écran 2025-07-01 à 15 53 29" src="https://github.com/user-attachments/assets/e491af60-cfce-486d-9ee0-6bb4dff0f022" />
