### PR TITLE
fix(i18n): Ensure metadata cache is locale-aware

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/workspace-schema.factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-schema.factory.ts
@@ -46,6 +46,7 @@ export class WorkspaceSchemaFactory {
       await this.workspaceMetadataCacheService.getExistingOrRecomputeMetadataMaps(
         {
           workspaceId: authContext.workspace.id,
+          locale: authContext.locale, // Assuming locale is available in authContext
         },
       );
 
@@ -68,11 +69,13 @@ export class WorkspaceSchemaFactory {
     let typeDefs = await this.workspaceCacheStorageService.getGraphQLTypeDefs(
       authContext.workspace.id,
       metadataVersion,
+      authContext.locale, // Added locale
     );
     let usedScalarNames =
       await this.workspaceCacheStorageService.getGraphQLUsedScalarNames(
         authContext.workspace.id,
         metadataVersion,
+        authContext.locale, // Added locale
       );
 
     // If typeDefs are not cached, generate them
@@ -92,11 +95,13 @@ export class WorkspaceSchemaFactory {
         authContext.workspace.id,
         metadataVersion,
         typeDefs,
+        authContext.locale, // Added locale
       );
       await this.workspaceCacheStorageService.setGraphQLUsedScalarNames(
         authContext.workspace.id,
         metadataVersion,
         usedScalarNames,
+        authContext.locale, // Added locale
       );
     }
 

--- a/packages/twenty-server/src/engine/core-modules/auth/types/auth-context.type.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/types/auth-context.type.ts
@@ -10,6 +10,7 @@ export type AuthContext = {
   workspace?: Workspace;
   userWorkspaceId?: string;
   authProvider?: AuthProviderEnum;
+  locale?: string; // Added locale property
 };
 
 export enum JwtTokenTypeEnum {

--- a/packages/twenty-server/src/engine/metadata-modules/workspace-metadata-cache/services/workspace-metadata-cache.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/workspace-metadata-cache/services/workspace-metadata-cache.service.ts
@@ -36,8 +36,10 @@ export class WorkspaceMetadataCacheService {
 
   async getExistingOrRecomputeMetadataMaps({
     workspaceId,
+    locale, // Added locale parameter
   }: {
     workspaceId: string;
+    locale: string; // Added locale parameter
   }): Promise<getExistingOrRecomputeMetadataMapsResult> {
     const currentCacheVersion =
       await this.getMetadataVersionFromCache(workspaceId);
@@ -60,6 +62,7 @@ export class WorkspaceMetadataCacheService {
       await this.workspaceCacheStorageService.getObjectMetadataMaps(
         workspaceId,
         currentDatabaseVersion,
+        locale, // Passed locale to getObjectMetadataMaps
       );
 
     if (isDefined(existingObjectMetadataMaps) && !shouldRecompute) {
@@ -72,6 +75,7 @@ export class WorkspaceMetadataCacheService {
     const { objectMetadataMaps, metadataVersion } =
       await this.recomputeMetadataCache({
         workspaceId,
+        locale, // Passed locale to recomputeMetadataCache
       });
 
     return {
@@ -82,8 +86,10 @@ export class WorkspaceMetadataCacheService {
 
   async recomputeMetadataCache({
     workspaceId,
+    locale, // Added locale parameter
   }: {
     workspaceId: string;
+    locale: string; // Added locale parameter
   }): Promise<getExistingOrRecomputeMetadataMapsResult> {
     const currentDatabaseVersion =
       await this.getMetadataVersionFromDatabase(workspaceId);
@@ -95,7 +101,11 @@ export class WorkspaceMetadataCacheService {
       );
     }
 
-    await this.workspaceCacheStorageService.flushVersionedMetadata(workspaceId);
+    await this.workspaceCacheStorageService.flushVersionedMetadata(
+      workspaceId,
+      currentDatabaseVersion,
+      locale, // Passed locale to flushVersionedMetadata
+    );
 
     const objectMetadataItems = await this.objectMetadataRepository.find({
       where: { workspaceId },
@@ -129,6 +139,7 @@ export class WorkspaceMetadataCacheService {
       workspaceId,
       currentDatabaseVersion,
       freshObjectMetadataMaps,
+      locale, // Passed locale to setObjectMetadataMaps
     );
 
     await this.workspaceCacheStorageService.setMetadataVersion(

--- a/packages/twenty-server/src/engine/middlewares/middleware.service.ts
+++ b/packages/twenty-server/src/engine/middlewares/middleware.service.ts
@@ -108,6 +108,7 @@ export class MiddlewareService {
     if (metadataVersion === undefined && isDefined(data.workspace)) {
       await this.workspaceMetadataCacheService.recomputeMetadataCache({
         workspaceId: data.workspace.id,
+        locale: request.headers['x-locale'] as string, // Added locale
       });
       throw new Error('Metadata cache version not found');
     }
@@ -157,6 +158,8 @@ export class MiddlewareService {
     request.workspaceMemberId = data.workspaceMemberId;
     request.userWorkspaceId = data.userWorkspaceId;
     request.authProvider = data.authProvider;
+    request.locale = request.headers['x-locale'] as string; // Added locale from request headers
+    data.locale = request.headers['x-locale'] as string; // Also add to AuthContext
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/twenty-server/src/engine/workspace-cache-storage/workspace-cache-storage.service.ts
+++ b/packages/twenty-server/src/engine/workspace-cache-storage/workspace-cache-storage.service.ts
@@ -91,9 +91,10 @@ export class WorkspaceCacheStorageService {
     workspaceId: string,
     metadataVersion: number,
     objectMetadataMaps: ObjectMetadataMaps,
+    locale: string, // Added locale parameter
   ) {
     return this.cacheStorageService.set<ObjectMetadataMaps>(
-      `${WorkspaceCacheKeys.MetadataObjectMetadataMaps}:${workspaceId}:${metadataVersion}`,
+      `${WorkspaceCacheKeys.MetadataObjectMetadataMaps}:${workspaceId}:${metadataVersion}:${locale}`, // Added locale to key
       objectMetadataMaps,
       TTL_INFINITE,
     );
@@ -102,9 +103,10 @@ export class WorkspaceCacheStorageService {
   getObjectMetadataMaps(
     workspaceId: string,
     metadataVersion: number,
+    locale: string, // Added locale parameter
   ): Promise<ObjectMetadataMaps | undefined> {
     return this.cacheStorageService.get<ObjectMetadataMaps>(
-      `${WorkspaceCacheKeys.MetadataObjectMetadataMaps}:${workspaceId}:${metadataVersion}`,
+      `${WorkspaceCacheKeys.MetadataObjectMetadataMaps}:${workspaceId}:${metadataVersion}:${locale}`, // Added locale to key
     );
   }
 
@@ -222,25 +224,27 @@ export class WorkspaceCacheStorageService {
   async flushVersionedMetadata(
     workspaceId: string,
     metadataVersion?: number,
+    locale?: string, // Added locale parameter
   ): Promise<void> {
     const metadataVersionSuffix = isDefined(metadataVersion)
       ? `${metadataVersion}`
       : '*';
+    const localeSuffix = isDefined(locale) ? `${locale}` : '*'; // Added locale suffix
 
     await this.cacheStorageService.del(
-      `${WorkspaceCacheKeys.MetadataObjectMetadataMaps}:${workspaceId}:${metadataVersionSuffix}`,
+      `${WorkspaceCacheKeys.MetadataObjectMetadataMaps}:${workspaceId}:${metadataVersionSuffix}:${localeSuffix}`, // Added localeSuffix to key
     );
     await this.cacheStorageService.del(
-      `${WorkspaceCacheKeys.MetadataVersion}:${workspaceId}:${metadataVersionSuffix}`,
+      `${WorkspaceCacheKeys.MetadataVersion}:${workspaceId}:${metadataVersionSuffix}`, // MetadataVersion does not need locale
     );
     await this.cacheStorageService.del(
-      `${WorkspaceCacheKeys.GraphQLTypeDefs}:${workspaceId}:${metadataVersionSuffix}`,
+      `${WorkspaceCacheKeys.GraphQLTypeDefs}:${workspaceId}:${metadataVersionSuffix}:${localeSuffix}`, // Added localeSuffix to key
     );
     await this.cacheStorageService.del(
-      `${WorkspaceCacheKeys.GraphQLUsedScalarNames}:${workspaceId}:${metadataVersionSuffix}`,
+      `${WorkspaceCacheKeys.GraphQLUsedScalarNames}:${workspaceId}:${metadataVersionSuffix}:${localeSuffix}`, // Added localeSuffix to key
     );
     await this.cacheStorageService.del(
-      `${WorkspaceCacheKeys.ORMEntitySchemas}:${workspaceId}:${metadataVersionSuffix}`,
+      `${WorkspaceCacheKeys.ORMEntitySchemas}:${workspaceId}:${metadataVersionSuffix}:${localeSuffix}`, // Added localeSuffix to key
     );
   }
 


### PR DESCRIPTION
This commit addresses a bug where the data model was being served in an incorrect language (e.g., Dutch) despite the workspace preference being set to English. The root cause was that the GraphQL metadata cache was not considering the user's locale when storing and retrieving data.

Changes made:
- Modified `WorkspaceCacheStorageService` to include the `locale` in the cache keys for metadata-related entries (`MetadataObjectMetadataMaps`, `GraphQLTypeDefs`, `GraphQLUsedScalarNames`, `ORMEntitySchemas`).
- Updated `WorkspaceMetadataCacheService` to pass the `locale` to `WorkspaceCacheStorageService` methods when recomputing and retrieving metadata.
- Added a `locale` property to `AuthContext` to carry the user's language preference throughout the request context.
- In `MiddlewareService`, the `locale` is now extracted from the `x-locale` request header and bound to the `AuthContext` and the request object. This ensures the correct `locale` is available when metadata is cached or retrieved.
- Ensured `flushVersionedMetadata` in `WorkspaceCacheStorageService` can clear locale-specific cache entries.

These changes ensure that metadata is cached and retrieved based on the user's selected language, preventing language mismatches.