### PR TITLE
Add relations to form record output

### DIFF
--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-step/workflow-version-step.module.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-step/workflow-version-step.module.ts
@@ -5,6 +5,7 @@ import { NestjsQueryTypeOrmModule } from '@ptc-org/nestjs-query-typeorm';
 import { AgentModule } from 'src/engine/metadata-modules/agent/agent.module';
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 import { ServerlessFunctionModule } from 'src/engine/metadata-modules/serverless-function/serverless-function.module';
+import { WorkflowCommonModule } from 'src/modules/workflow/common/workflow-common.module';
 import { WorkflowSchemaModule } from 'src/modules/workflow/workflow-builder/workflow-schema/workflow-schema.module';
 import { WorkflowVersionStepWorkspaceService } from 'src/modules/workflow/workflow-builder/workflow-step/workflow-version-step.workspace-service';
 import { WorkflowRunModule } from 'src/modules/workflow/workflow-runner/workflow-run/workflow-run.module';
@@ -17,6 +18,7 @@ import { WorkflowRunnerModule } from 'src/modules/workflow/workflow-runner/workf
     ServerlessFunctionModule,
     WorkflowRunnerModule,
     WorkflowRunModule,
+    WorkflowCommonModule,
     NestjsQueryTypeOrmModule.forFeature([ObjectMetadataEntity], 'core'),
   ],
   providers: [WorkflowVersionStepWorkspaceService],

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-step/workflow-version-step.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-step/workflow-version-step.workspace-service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
+import { FieldMetadataType } from 'twenty-shared/types';
 import { isDefined, isValidUuid } from 'twenty-shared/utils';
 import { Repository } from 'typeorm';
 import { v4 } from 'uuid';
@@ -19,9 +20,11 @@ import {
 import { StepOutput } from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
 import { WorkflowVersionWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow-version.workspace-entity';
 import { assertWorkflowVersionIsDraft } from 'src/modules/workflow/common/utils/assert-workflow-version-is-draft.util';
+import { WorkflowCommonWorkspaceService } from 'src/modules/workflow/common/workspace-services/workflow-common.workspace-service';
 import { WorkflowSchemaWorkspaceService } from 'src/modules/workflow/workflow-builder/workflow-schema/workflow-schema.workspace-service';
 import { insertStep } from 'src/modules/workflow/workflow-builder/workflow-step/utils/insert-step';
 import { removeStep } from 'src/modules/workflow/workflow-builder/workflow-step/utils/remove-step';
+import { StepStatus } from 'src/modules/workflow/workflow-executor/types/workflow-run-step-info.type';
 import { BaseWorkflowActionSettings } from 'src/modules/workflow/workflow-executor/workflow-actions/types/workflow-action-settings.type';
 import {
   WorkflowAction,
@@ -30,7 +33,6 @@ import {
 } from 'src/modules/workflow/workflow-executor/workflow-actions/types/workflow-action.type';
 import { WorkflowRunWorkspaceService } from 'src/modules/workflow/workflow-runner/workflow-run/workflow-run.workspace-service';
 import { WorkflowRunnerWorkspaceService } from 'src/modules/workflow/workflow-runner/workspace-services/workflow-runner.workspace-service';
-import { StepStatus } from 'src/modules/workflow/workflow-executor/types/workflow-run-step-info.type';
 
 const TRIGGER_STEP_ID = 'trigger';
 
@@ -57,6 +59,7 @@ export class WorkflowVersionStepWorkspaceService {
     private readonly objectMetadataRepository: Repository<ObjectMetadataEntity>,
     private readonly workflowRunWorkspaceService: WorkflowRunWorkspaceService,
     private readonly workflowRunnerWorkspaceService: WorkflowRunnerWorkspaceService,
+    private readonly workflowCommonWorkspaceService: WorkflowCommonWorkspaceService,
   ) {}
 
   async createWorkflowVersionStep({
@@ -678,6 +681,18 @@ export class WorkflowVersionStepWorkspaceService {
           // @ts-expect-error legacy noImplicitAny
           isValidUuid(response[key].id)
         ) {
+          const objectMetadataInfo =
+            await this.workflowCommonWorkspaceService.getObjectMetadataItemWithFieldsMaps(
+              field.settings.objectName,
+              workspaceId,
+            );
+
+          const relationFieldsNames = Object.values(
+            objectMetadataInfo.objectMetadataItemWithFieldsMaps.fieldsById,
+          )
+            .filter((field) => field.type === FieldMetadataType.RELATION)
+            .map((field) => field.name);
+
           const repository =
             await this.twentyORMGlobalManager.getRepositoryForWorkspace(
               workspaceId,
@@ -688,6 +703,7 @@ export class WorkflowVersionStepWorkspaceService {
           const record = await repository.findOne({
             // @ts-expect-error legacy noImplicitAny
             where: { id: response[key].id },
+            relations: relationFieldsNames,
           });
 
           return { key, value: record };


### PR DESCRIPTION
When we use a record field in a form, record relations are displayed as available variables in following step.
But those are actually empty at execution.

When choosing the record in the form and submitting, we enrich the record id with the full record before starting the workflow again. But we were not adding the relations to that enrichment. 