### PR TITLE
Fix workflow title cell not opening

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-title-cell/components/RecordTitleCell.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-title-cell/components/RecordTitleCell.tsx
@@ -97,6 +97,7 @@ export const RecordTitleCell = ({
     editModeContentOnly: isFieldInputOnly,
     loading: loading,
     isReadOnly,
+    containerType,
   };
 
   return (

--- a/packages/twenty-front/src/modules/object-record/record-title-cell/components/RecordTitleCellContext.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-title-cell/components/RecordTitleCellContext.tsx
@@ -1,3 +1,4 @@
+import { RecordTitleCellContainerType } from '@/object-record/record-title-cell/types/RecordTitleCellContainerType';
 import { createContext, ReactElement } from 'react';
 
 export type RecordTitleCellContextProps = {
@@ -6,15 +7,8 @@ export type RecordTitleCellContextProps = {
   displayModeContent?: ReactElement;
   loading?: boolean;
   isReadOnly?: boolean;
-};
-
-const defaultRecordTitleCellContextProp: RecordTitleCellContextProps = {
-  editModeContent: undefined,
-  editModeContentOnly: false,
-  displayModeContent: undefined,
-  loading: false,
-  isReadOnly: false,
+  containerType: RecordTitleCellContainerType;
 };
 
 export const RecordTitleCellContext =
-  createContext<RecordTitleCellContextProps>(defaultRecordTitleCellContextProp);
+  createContext<RecordTitleCellContextProps>({} as RecordTitleCellContextProps);

--- a/packages/twenty-front/src/modules/object-record/record-title-cell/components/RecordTitleCellTextFieldDisplay.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-title-cell/components/RecordTitleCellTextFieldDisplay.tsx
@@ -1,7 +1,7 @@
 import { FieldContext } from '@/object-record/record-field/contexts/FieldContext';
 import { recordStoreFamilyState } from '@/object-record/record-store/states/recordStoreFamilyState';
+import { RecordTitleCellContext } from '@/object-record/record-title-cell/components/RecordTitleCellContext';
 import { useRecordTitleCell } from '@/object-record/record-title-cell/hooks/useRecordTitleCell';
-import { RecordTitleCellContainerType } from '@/object-record/record-title-cell/types/RecordTitleCellContainerType';
 import { Theme, withTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useContext } from 'react';
@@ -40,13 +40,15 @@ export const RecordTitleCellSingleTextDisplayMode = () => {
 
   const { openRecordTitleCell } = useRecordTitleCell();
 
+  const { containerType } = useContext(RecordTitleCellContext);
+
   return (
     <StyledDiv
       onClick={() => {
         openRecordTitleCell({
           recordId,
           fieldMetadataId: fieldDefinition.fieldMetadataId,
-          containerType: RecordTitleCellContainerType.ShowPage,
+          containerType,
         });
       }}
     >


### PR DESCRIPTION
This PR fixes a bug that forced all title cell to behave as if they were in a show page, but we have workflow page breadcrumb that is not a show page title.

Fixes https://github.com/twentyhq/twenty/issues/13041