### PR TITLE
fix: blockquote icon in slash menu

### DIFF
--- a/packages/twenty-front/src/modules/activities/blocks/utils/getSlashMenu.ts
+++ b/packages/twenty-front/src/modules/activities/blocks/utils/getSlashMenu.ts
@@ -4,6 +4,7 @@ import { SuggestionItem } from '@/ui/input/editor/components/CustomSlashMenu';
 
 import { BLOCK_SCHEMA } from '../constants/Schema';
 import {
+  IconBlockquote,
   IconCode,
   IconComponent,
   IconFile,
@@ -25,6 +26,7 @@ const Icons: Record<string, IconComponent> = {
   'Heading 1': IconH1,
   'Heading 2': IconH2,
   'Heading 3': IconH3,
+  Quote: IconBlockquote,
   'Numbered List': IconListNumbers,
   'Bullet List': IconList,
   'Check List': IconListCheck,

--- a/packages/twenty-ui/src/display/icon/components/TablerIcons.ts
+++ b/packages/twenty-ui/src/display/icon/components/TablerIcons.ts
@@ -19,6 +19,7 @@ export {
   IconAt,
   IconBaselineDensitySmall,
   IconBell,
+  IconBlockquote,
   IconBolt,
   IconBook2,
   IconBookmark,

--- a/packages/twenty-ui/src/display/index.ts
+++ b/packages/twenty-ui/src/display/index.ts
@@ -81,6 +81,7 @@ export {
   IconAt,
   IconBaselineDensitySmall,
   IconBell,
+  IconBlockquote,
   IconBolt,
   IconBook2,
   IconBookmark,


### PR DESCRIPTION
This PR fixes a UI bug where the "Quote" item in the slash command menu was displayed without an icon.


The root cause was that the IconBlockquote component, while available in the icons library, was not being exported from the internal twenty-ui package.

## Before / After

![Before](https://github.com/user-attachments/assets/afd5e848-b6a4-4af9-a01d-15c6128f8535)

![After](https://github.com/user-attachments/assets/2468371f-fdd6-42a0-b04b-61a51d286746)


## Changes:

- Exported IconBlockquote from TablerIcons.ts in the twenty-ui package.
- Updated getSlashMenu.ts in the twenty-front package to import and use the IconBlockquote for the "Quote" menu item.