### PR TITLE
Skip front config generation if index isn't writable

### DIFF
--- a/packages/twenty-server/src/utils/generate-front-config.ts
+++ b/packages/twenty-server/src/utils/generate-front-config.ts
@@ -25,21 +25,19 @@ export function generateFrontConfig(): void {
   const distPath = path.join(__dirname, '../..', 'front');
   const indexPath = path.join(distPath, 'index.html');
 
-  if (!fs.existsSync(indexPath)) {
-    // eslint-disable-next-line no-console
-    console.log(
-      'Frontend build not found, assuming it is served independently',
+  try {
+    let indexContent = fs.readFileSync(indexPath, 'utf8');
+
+    indexContent = indexContent.replace(
+      /<!-- BEGIN: Twenty Config -->[\s\S]*?<!-- END: Twenty Config -->/,
+      configString,
     );
 
-    return;
+    fs.writeFileSync(indexPath, indexContent, 'utf8');
+  } catch {
+    // eslint-disable-next-line no-console
+    console.log(
+      'Frontend build not found or not writable, assuming it is served independently',
+    );
   }
-
-  let indexContent = fs.readFileSync(indexPath, 'utf8');
-
-  indexContent = indexContent.replace(
-    /<!-- BEGIN: Twenty Config -->[\s\S]*?<!-- END: Twenty Config -->/,
-    configString,
-  );
-
-  fs.writeFileSync(indexPath, indexContent, 'utf8');
 }


### PR DESCRIPTION
In certain scenarios, the front directory may not be writable.
When this is the case, writing the patched `index.html` should be skipped just like when the file does not exist.
For brevity, I have replaced the `existsSync` check with a try-catch that catches any errors occuring during read
or write of the index file.
The alternative would be `fs.accessSync` with `W_OK`, but that would still throw an error if the file is not writable so I think it is reasonable to skip it altogether and go straight for the read and write attempts.

A specific scenario where the front directory is immutable is NixOS, where the directory may be located in the read-only nix store.

