### PR TITLE
Set createdAt and updatedAt as readonly on the frontend

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/utils/isFieldValueReadOnly.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/utils/isFieldValueReadOnly.ts
@@ -3,7 +3,6 @@ import { isWorkflowSubObjectMetadata } from '@/object-metadata/utils/isWorkflowS
 import { isWorkflowRunJsonField } from '@/object-record/record-field/meta-types/utils/isWorkflowRunJsonField';
 import { isFieldActor } from '@/object-record/record-field/types/guards/isFieldActor';
 import { isFieldRichText } from '@/object-record/record-field/types/guards/isFieldRichText';
-import { isFieldDateTime } from '@/object-record/record-field/types/guards/isFieldDateTime';
 
 import { isDefined } from 'twenty-shared/utils';
 import { FieldMetadataType } from '~/generated-metadata/graphql';
@@ -66,10 +65,13 @@ export const isFieldValueReadOnly = ({
     return true;
   }
 
-  if (
-    isFieldDateTime({ type: fieldType }) === true &&
-    (fieldName === 'createdAt' || fieldName === 'updatedAt')
-  ) {
+  const isFieldDateOrDateTime =
+    fieldType === FieldMetadataType.DATE ||
+    fieldType === FieldMetadataType.DATE_TIME;
+  const isFieldCreatedAtOrUpdatedAt =
+    fieldName === 'createdAt' || fieldName === 'updatedAt';
+
+  if (isFieldDateOrDateTime && isFieldCreatedAtOrUpdatedAt) {
     return true;
   }
 

--- a/packages/twenty-front/src/modules/object-record/record-field/utils/isFieldValueReadOnly.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/utils/isFieldValueReadOnly.ts
@@ -3,6 +3,7 @@ import { isWorkflowSubObjectMetadata } from '@/object-metadata/utils/isWorkflowS
 import { isWorkflowRunJsonField } from '@/object-record/record-field/meta-types/utils/isWorkflowRunJsonField';
 import { isFieldActor } from '@/object-record/record-field/types/guards/isFieldActor';
 import { isFieldRichText } from '@/object-record/record-field/types/guards/isFieldRichText';
+import { isFieldDateTime } from '@/object-record/record-field/types/guards/isFieldDateTime';
 
 import { isDefined } from 'twenty-shared/utils';
 import { FieldMetadataType } from '~/generated-metadata/graphql';
@@ -61,6 +62,13 @@ export const isFieldValueReadOnly = ({
   if (
     objectNameSingular !== CoreObjectNameSingular.Task &&
     fieldName === 'taskTargets'
+  ) {
+    return true;
+  }
+
+  if (
+    isFieldDateTime({ type: fieldType }) === true &&
+    (fieldName === 'createdAt' || fieldName === 'updatedAt')
   ) {
     return true;
   }


### PR DESCRIPTION
This is not the prettiest fix but it's the 5th time I get the feedback from a user that these fields should be readonly, let's have a special case for them