### PR TITLE
13058 workflow with code fail to run

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/serverless-function/serverless-function.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/serverless-function/serverless-function.resolver.ts
@@ -163,7 +163,7 @@ export class ServerlessFunctionResolver {
     try {
       const { id } = input;
 
-      return await this.serverlessFunctionService.publishOneServerlessFunction(
+      return await this.serverlessFunctionService.publishOneServerlessFunctionOrFail(
         id,
         workspaceId,
       );

--- a/packages/twenty-server/src/modules/workflow/workflow-status/jobs/__tests__/workflow-statuses-update.job.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-status/jobs/__tests__/workflow-statuses-update.job.spec.ts
@@ -50,7 +50,7 @@ describe('WorkflowStatusesUpdate', () => {
   };
 
   const mockServerlessFunctionService = {
-    publishOneServerlessFunction: jest.fn(),
+    publishOneServerlessFunctionOrFail: jest.fn(),
     findOneOrFail: jest.fn(),
   };
 
@@ -256,6 +256,9 @@ describe('WorkflowStatusesUpdate', () => {
         mockServerlessFunctionService.findOneOrFail.mockResolvedValue(
           mockServerlessFunction,
         );
+        mockServerlessFunctionService.publishOneServerlessFunctionOrFail.mockResolvedValue(
+          mockServerlessFunction,
+        );
 
         await job.handle(event);
 
@@ -264,7 +267,7 @@ describe('WorkflowStatusesUpdate', () => {
           mockWorkflowVersionRepository.findOneOrFail,
         ).toHaveBeenCalledTimes(1);
         expect(
-          mockServerlessFunctionService.publishOneServerlessFunction,
+          mockServerlessFunctionService.publishOneServerlessFunctionOrFail,
         ).toHaveBeenCalledWith('serverless-1', '1');
         expect(mockWorkflowVersionRepository.update).toHaveBeenCalledWith('1', {
           steps: [

--- a/packages/twenty-website/src/content/developers/self-hosting/upgrade-guide.mdx
+++ b/packages/twenty-website/src/content/developers/self-hosting/upgrade-guide.mdx
@@ -123,11 +123,6 @@ yarn command:prod upgrade
 
 This version includes a `docker-compose.yml` mutation to give `worker` service access to the `server-local-data` volume.
 Please update your local `docker-compose.yml` with [v0.50.0 docker-compose.yml](https://github.com/twentyhq/twenty/blob/v0.50.0/packages/twenty-docker/docker-compose.yml)
-Then run:
-
-```
-docker compose up -d worker
-```
 
 ### v0.43.0 to v0.44.0
 

--- a/packages/twenty-website/src/content/developers/self-hosting/upgrade-guide.mdx
+++ b/packages/twenty-website/src/content/developers/self-hosting/upgrade-guide.mdx
@@ -119,6 +119,16 @@ yarn database:migrate:prod
 yarn command:prod upgrade
 ```
 
+#### Docker-compose.yml mutation
+
+This version includes a `docker-compose.yml` mutation to give `worker` service access to the `server-local-data` volume.
+Please update your local `docker-compose.yml` with [v0.50.0 docker-compose.yml](https://github.com/twentyhq/twenty/blob/v0.50.0/packages/twenty-docker/docker-compose.yml)
+Then run:
+
+```
+docker compose up -d worker
+```
+
 ### v0.43.0 to v0.44.0
 
 Upgrade your Twenty instance to use v0.44.0 image


### PR DESCRIPTION
- update publishOneServerlessFunction so it does not break the workflow if failing
- update upgrade documentation to update `docker-compose.yml` when mutated

Fixes https://github.com/twentyhq/twenty/issues/13058