### PR TITLE
Fix refetch cached views after field creation

### DIFF
--- a/packages/twenty-front/src/modules/object-metadata/hooks/useCreateOneFieldMetadataItem.ts
+++ b/packages/twenty-front/src/modules/object-metadata/hooks/useCreateOneFieldMetadataItem.ts
@@ -9,6 +9,7 @@ import {
 import { CREATE_ONE_FIELD_METADATA_ITEM } from '../graphql/mutations';
 
 import { useRefreshObjectMetadataItems } from '@/object-metadata/hooks/useRefreshObjectMetadataItem';
+import { useRefreshCachedViews } from '@/views/hooks/useRefreshViews';
 
 export const useCreateOneFieldMetadataItem = () => {
   const { refreshObjectMetadataItems } =
@@ -18,6 +19,8 @@ export const useCreateOneFieldMetadataItem = () => {
     CreateOneFieldMetadataItemMutation,
     CreateOneFieldMetadataItemMutationVariables
   >(CREATE_ONE_FIELD_METADATA_ITEM);
+
+  const { refreshCachedViews } = useRefreshCachedViews()
 
   const createOneFieldMetadataItem = async (input: CreateFieldInput) => {
     const result = await mutate({
@@ -29,6 +32,8 @@ export const useCreateOneFieldMetadataItem = () => {
     });
 
     await refreshObjectMetadataItems();
+
+    await refreshCachedViews()
 
     return result;
   };

--- a/packages/twenty-front/src/modules/object-metadata/hooks/useCreateOneFieldMetadataItem.ts
+++ b/packages/twenty-front/src/modules/object-metadata/hooks/useCreateOneFieldMetadataItem.ts
@@ -20,7 +20,7 @@ export const useCreateOneFieldMetadataItem = () => {
     CreateOneFieldMetadataItemMutationVariables
   >(CREATE_ONE_FIELD_METADATA_ITEM);
 
-  const { refreshCachedViews } = useRefreshCachedViews()
+  const { refreshCachedViews } = useRefreshCachedViews();
 
   const createOneFieldMetadataItem = async (input: CreateFieldInput) => {
     const result = await mutate({
@@ -33,7 +33,7 @@ export const useCreateOneFieldMetadataItem = () => {
 
     await refreshObjectMetadataItems();
 
-    await refreshCachedViews()
+    await refreshCachedViews();
 
     return result;
   };

--- a/packages/twenty-front/src/pages/settings/data-model/new-field/SettingsObjectNewFieldConfigure.tsx
+++ b/packages/twenty-front/src/pages/settings/data-model/new-field/SettingsObjectNewFieldConfigure.tsx
@@ -17,7 +17,6 @@ import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { SubMenuTopBarContainer } from '@/ui/layout/page/components/SubMenuTopBarContainer';
 import { View } from '@/views/types/View';
 import { ViewType } from '@/views/types/ViewType';
-import { useApolloClient } from '@apollo/client';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useLingui } from '@lingui/react/macro';
 import { useEffect, useState } from 'react';
@@ -57,7 +56,6 @@ export const SettingsObjectNewFieldConfigure = () => {
   const activeObjectMetadataItem =
     findActiveObjectMetadataItemByNamePlural(objectNamePlural);
   const { createMetadataField } = useFieldMetadataItem();
-  const apolloClient = useApolloClient();
 
   const formConfig = useForm<SettingsDataModelNewFieldFormValues>({
     mode: 'onTouched',


### PR DESCRIPTION
This PR fixes a bug that happened when adding a field to a table right after a field creation in the data model settings.

This happened because the backend adds the newly created field to all relevant views without telling the frontend (because we don't have web sockets yet), so the frontend ended up in a stale state, and when the user added the field manually to a view the backend rightly threw an error telling that the view field it already existed.

So  the fix is just to refetch all views after a field creation, sparing us the difficult work of manually updating the Apollo cache.

Fixes https://github.com/twentyhq/twenty/issues/13071