### PR TITLE
Remove unwanted workflow fetch on right drawer open

### DIFF
--- a/packages/twenty-front/src/modules/action-menu/contexts/ActionMenuContextProviderWorkflowsEnabled.tsx
+++ b/packages/twenty-front/src/modules/action-menu/contexts/ActionMenuContextProviderWorkflowsEnabled.tsx
@@ -9,7 +9,6 @@ import { useShouldActionBeRegisteredParams } from '@/action-menu/hooks/useShould
 import { contextStoreTargetedRecordsRuleComponentState } from '@/context-store/states/contextStoreTargetedRecordsRuleComponentState';
 import { ObjectMetadataItem } from '@/object-metadata/types/ObjectMetadataItem';
 import { useRecoilComponentValueV2 } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValueV2';
-import { useWorkflowWithCurrentVersion } from '@/workflow/hooks/useWorkflowWithCurrentVersion';
 
 export const ActionMenuContextProviderWorkflowsEnabled = ({
   objectMetadataItem,
@@ -28,13 +27,8 @@ export const ActionMenuContextProviderWorkflowsEnabled = ({
     objectMetadataItem,
   });
 
-  const workflowWithCurrentVersion = useWorkflowWithCurrentVersion(
-    params.selectedRecord?.id,
-  );
-
   const shouldBeRegisteredParams = {
     ...params,
-    workflowWithCurrentVersion,
   };
 
   const actions = useRegisteredActions(shouldBeRegisteredParams);


### PR DESCRIPTION
There was a mistake in the ActionConfig load, we were trying to fetch a workflow with the opened recordId (which is not always a workflow)