### PR TITLE
fix: menu item close issue with enter and escape

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/MultiItemFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/MultiItemFieldInput.tsx
@@ -85,7 +85,7 @@ export const MultiItemFieldInput = <T,>({
 
   useHotkeysOnFocusedElement({
     focusId: instanceId,
-    keys: [Key.Escape],
+    keys: [Key.Escape, Key.Enter],
     callback: handleDropdownClose,
     dependencies: [handleDropdownClose],
   });


### PR DESCRIPTION

[Screencast from 2025-07-10 15-30-39.webm](https://github.com/user-attachments/assets/817ca8cc-ebdc-4d7c-8572-483cd2690393)
Hi,
My previous implementation was correct, but I had also fixed another issue within the same code. So i remove pre pull request.

I’ve now updated the code and pushed it again, including the fix for:
Resolved: Cannot close MenuItemFieldInput (Ref: #13139)