### PR TITLE
Fix backspace shortcut preventing text deletion in command menu search bar

### DIFF
--- a/packages/twenty-front/src/modules/command-menu/hooks/useCommandMenuHotKeys.ts
+++ b/packages/twenty-front/src/modules/command-menu/hooks/useCommandMenuHotKeys.ts
@@ -117,5 +117,8 @@ export const useCommandMenuHotKeys = () => {
       goBackFromCommandMenu,
       setGlobalCommandMenuContext,
     ],
+    options: {
+      preventDefault: false,
+    },
   });
 };


### PR DESCRIPTION
Before:

https://github.com/user-attachments/assets/4d3ba0fb-9655-4f06-af14-2a4cab737a4a


After:

https://github.com/user-attachments/assets/f1bbf360-a09f-4440-9d05-2c9dc1f41f1f

