### PR TITLE
[Critical bugfix]: hotKeyScope configuration record title and dropdown

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-title-cell/hooks/useRecordTitleCell.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-title-cell/hooks/useRecordTitleCell.tsx
@@ -79,6 +79,10 @@ export const useRecordTitleCell = () => {
               prefix: containerType,
             }),
           },
+          globalHotkeysConfig: {
+            enableGlobalHotkeysConflictingWithKeyboard: false,
+            enableGlobalHotkeysWithModifiers: false,
+          },
         });
 
         const recordTitleCellId = getRecordFieldInputInstanceId({

--- a/packages/twenty-front/src/modules/ui/input/components/IconPicker.tsx
+++ b/packages/twenty-front/src/modules/ui/input/components/IconPicker.tsx
@@ -60,6 +60,15 @@ const StyledLightIconButton = styled(LightIconButton)<{
         : 'transparent'};
 `;
 
+const StyledMatrixItem = styled.div`
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+`;
+
 const convertIconKeyToLabel = (iconKey: string) =>
   iconKey.replace(/[A-Z]/g, (letter) => ` ${letter}`).trim();
 
@@ -84,18 +93,20 @@ const IconPickerIcon = ({
   );
 
   return (
-    <SelectableListItem itemId={iconKey} onEnter={onClick}>
-      <StyledLightIconButton
-        key={iconKey}
-        aria-label={convertIconKeyToLabel(iconKey)}
-        size="medium"
-        title={iconKey}
-        isSelected={iconKey === selectedIconKey || !!isSelectedItemId}
-        isFocused={iconKey === focusedIconKey}
-        Icon={Icon}
-        onClick={onClick}
-      />
-    </SelectableListItem>
+    <StyledMatrixItem>
+      <SelectableListItem itemId={iconKey} onEnter={onClick}>
+        <StyledLightIconButton
+          key={iconKey}
+          aria-label={convertIconKeyToLabel(iconKey)}
+          size="medium"
+          title={iconKey}
+          isSelected={iconKey === selectedIconKey || !!isSelectedItemId}
+          isFocused={iconKey === focusedIconKey}
+          Icon={Icon}
+          onClick={onClick}
+        />
+      </SelectableListItem>
+    </StyledMatrixItem>
   );
 };
 

--- a/packages/twenty-front/src/modules/ui/layout/dropdown/hooks/useOpenDropdown.ts
+++ b/packages/twenty-front/src/modules/ui/layout/dropdown/hooks/useOpenDropdown.ts
@@ -50,7 +50,14 @@ export const useOpenDropdown = () => {
             type: FocusComponentType.DROPDOWN,
             instanceId: dropdownComponentInstanceId,
           },
-          globalHotkeysConfig: args?.globalHotkeysConfig ?? undefined,
+          globalHotkeysConfig: {
+            enableGlobalHotkeysConflictingWithKeyboard:
+              args?.globalHotkeysConfig
+                ?.enableGlobalHotkeysConflictingWithKeyboard ?? false,
+            enableGlobalHotkeysWithModifiers:
+              args?.globalHotkeysConfig?.enableGlobalHotkeysWithModifiers ??
+              false,
+          },
         });
       },
     [


### PR DESCRIPTION
This PR fixes two bugs : 
- Some important push item to focus stack calls were setting global hotkey conflicting keys to true (like open dropdown)
- Icon picker matrix items were broken