### PR TITLE
feat: Implement real estate CRM features

### DIFF
--- a/packages/twenty-front/src/modules/lead-distribution/LeadDistributionPage.tsx
+++ b/packages/twenty-front/src/modules/lead-distribution/LeadDistributionPage.tsx
@@ -1,0 +1,130 @@
+import React, { useState, useEffect } from 'react';
+import { useQuery, useMutation } from 'react-query';
+import {
+  Button,
+  Card,
+  Container,
+  FormControl,
+  FormLabel,
+  Input,
+  Select,
+  Stack,
+  Table,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+  useToast,
+} from '@chakra-ui/react';
+
+const fetchLeadDistributionConfig = async () => {
+  const res = await fetch('/api/lead-distribution/config');
+  return res.json();
+};
+
+const setLeadDistributionConfig = async (config) => {
+  const res = await fetch('/api/lead-distribution/config', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(config),
+  });
+  return res.json();
+};
+
+const LeadDistributionPage = () => {
+  const toast = useToast();
+  const { data: config, isLoading } = useQuery('leadDistributionConfig', fetchLeadDistributionConfig);
+  const mutation = useMutation(setLeadDistributionConfig, {
+    onSuccess: () => {
+      toast({
+        title: 'Configuration saved.',
+        status: 'success',
+        duration: 3000,
+        isClosable: true,
+      });
+    },
+  });
+
+  const [distributionType, setDistributionType] = useState('round-robin');
+  const [weights, setWeights] = useState({});
+
+  useEffect(() => {
+    if (config) {
+      setDistributionType(config.type);
+      setWeights(config.weights || {});
+    }
+  }, [config]);
+
+  const handleSave = () => {
+    mutation.mutate({ type: distributionType, weights });
+  };
+
+  const handleWeightChange = (agentId, weight) => {
+    setWeights({ ...weights, [agentId]: parseInt(weight, 10) });
+  };
+
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <Container maxW="container.xl" py={10}>
+      <Stack spacing={8}>
+        <Card p={5}>
+          <FormControl>
+            <FormLabel>Distribution Type</FormLabel>
+            <Select value={distributionType} onChange={(e) => setDistributionType(e.target.value)}>
+              <option value="round-robin">Round Robin</option>
+              <option value="weighted">Weighted Round Robin</option>
+            </Select>
+          </FormControl>
+        </Card>
+
+        {distributionType === 'weighted' && (
+          <Card p={5}>
+            <Table>
+              <Thead>
+                <Tr>
+                  <Th>Agent</Th>
+                  <Th>Weight</Th>
+                </Tr>
+              </Thead>
+              <Tbody>
+                {/* This is a placeholder for the agents list. In a real application, you would fetch the agents from the API. */}
+                <Tr>
+                  <Td>Agent 1</Td>
+                  <Td>
+                    <Input
+                      type="number"
+                      value={weights['agent1'] || ''}
+                      onChange={(e) => handleWeightChange('agent1', e.target.value)}
+                    />
+                  </Td>
+                </Tr>
+                <Tr>
+                  <Td>Agent 2</Td>
+                  <Td>
+                    <Input
+                      type="number"
+                      value={weights['agent2'] || ''}
+                      onChange={(e) => handleWeightChange('agent2', e.target.value)}
+                    />
+                  </Td>
+                </Tr>
+              </Tbody>
+            </Table>
+          </Card>
+        )}
+
+        <Button colorScheme="blue" onClick={handleSave}>
+          Save
+        </Button>
+      </Stack>
+    </Container>
+  );
+};
+
+export default LeadDistributionPage;

--- a/packages/twenty-server/src/modules/binder/binder.controller.ts
+++ b/packages/twenty-server/src/modules/binder/binder.controller.ts
@@ -1,0 +1,30 @@
+import { Controller, Get, Post, Body, Param, Res } from '@nestjs/common';
+import { BinderService } from './binder.service';
+import { BinderWorkspaceEntity } from './binder.workspace-entity';
+import { Response } from 'express';
+
+@Controller('binders')
+export class BinderController {
+  constructor(private readonly binderService: BinderService) {}
+
+  @Get()
+  async getBinders() {
+    return this.binderService.getBinders();
+  }
+
+  @Post()
+  async createBinder(@Body() binder: Partial<BinderWorkspaceEntity>) {
+    return this.binderService.createBinder(binder);
+  }
+
+  @Get(':id/pdf')
+  async generatePdf(@Param('id') id: string, @Res() res: Response) {
+    const pdfBuffer = await this.binderService.generatePdf(id);
+    res.set({
+      'Content-Type': 'application/pdf',
+      'Content-Disposition': 'attachment; filename=binder.pdf',
+      'Content-Length': pdfBuffer.length,
+    });
+    res.end(pdfBuffer);
+  }
+}

--- a/packages/twenty-server/src/modules/binder/binder.module.ts
+++ b/packages/twenty-server/src/modules/binder/binder.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { BinderService } from './binder.service';
+import { BinderController } from './binder.controller';
+
+@Module({
+  providers: [BinderService],
+  controllers: [BinderController],
+  exports: [BinderService],
+})
+export class BinderModule {}

--- a/packages/twenty-server/src/modules/binder/binder.service.ts
+++ b/packages/twenty-server/src/modules/binder/binder.service.ts
@@ -1,0 +1,70 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { BinderWorkspaceEntity } from './binder.workspace-entity';
+import * as PDFDocument from 'pdfkit';
+import { ListingWorkspaceEntity } from '../listing/standard-objects/listing.workspace-entity';
+import { DocumentWorkspaceEntity } from '../document-library/document.workspace-entity';
+
+@Injectable()
+export class BinderService {
+  constructor(
+    @InjectRepository(BinderWorkspaceEntity)
+    private readonly binderRepository: Repository<BinderWorkspaceEntity>,
+  ) {}
+
+  async createBinder(binder: Partial<BinderWorkspaceEntity>): Promise<BinderWorkspaceEntity> {
+    const newBinder = this.binderRepository.create(binder);
+    return this.binderRepository.save(newBinder);
+  }
+
+  async getBinders(): Promise<BinderWorkspaceEntity[]> {
+    return this.binderRepository.find({ relations: ['client', 'listings', 'documents'] });
+  }
+
+  async generatePdf(binderId: string): Promise<Buffer> {
+    const binder = await this.binderRepository.findOne({
+      where: { id: binderId },
+      relations: ['client', 'listings', 'documents'],
+    });
+
+    if (!binder) {
+      throw new Error('Binder not found');
+    }
+
+    const pdfDoc = new PDFDocument();
+    const buffers: Buffer[] = [];
+
+    pdfDoc.on('data', buffers.push.bind(buffers));
+
+    pdfDoc.fontSize(25).text(binder.name, { align: 'center' });
+    pdfDoc.moveDown();
+    pdfDoc.fontSize(16).text(`Client: ${binder.client.name.firstName} ${binder.client.name.lastName}`);
+    pdfDoc.moveDown();
+
+    if (binder.listings && binder.listings.length > 0) {
+      pdfDoc.fontSize(20).text('Listings');
+      pdfDoc.moveDown();
+      for (const listing of binder.listings) {
+        pdfDoc.fontSize(14).text(`- ${listing.name}`);
+        pdfDoc.moveDown(0.5);
+      }
+    }
+
+    if (binder.documents && binder.documents.length > 0) {
+      pdfDoc.fontSize(20).text('Documents');
+      pdfDoc.moveDown();
+      for (const doc of binder.documents) {
+        pdfDoc.fontSize(14).text(`- ${doc.name}`);
+        pdfDoc.moveDown(0.5);
+      }
+    }
+
+    return new Promise((resolve) => {
+      pdfDoc.on('end', () => {
+        resolve(Buffer.concat(buffers));
+      });
+      pdfDoc.end();
+    });
+  }
+}

--- a/packages/twenty-server/src/modules/binder/binder.workspace-entity.ts
+++ b/packages/twenty-server/src/modules/binder/binder.workspace-entity.ts
@@ -1,0 +1,64 @@
+import { msg } from '@lingui/core/macro';
+import { FieldMetadataType } from 'twenty-shared/types';
+import { Relation } from 'src/engine/workspace-manager/workspace-sync-metadata/interfaces/relation.interface';
+import { BaseWorkspaceEntity } from 'src/engine/twenty-orm/base.workspace-entity';
+import { WorkspaceEntity } from 'src/engine/twenty-orm/decorators/workspace-entity.decorator';
+import { WorkspaceField } from 'src/engine/twenty-orm/decorators/workspace-field.decorator';
+import { WorkspaceRelation } from 'src/engine/twenty-orm/decorators/workspace-relation.decorator';
+import { PersonWorkspaceEntity } from '../person/standard-objects/person.workspace-entity';
+import { ListingWorkspaceEntity } from '../listing/standard-objects/listing.workspace-entity';
+import { DocumentWorkspaceEntity } from '../document-library/document.workspace-entity';
+import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
+import { RelationOnDeleteAction } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-on-delete-action.interface';
+import { WorkspaceJoinColumn } from 'src/engine/twenty-orm/decorators/workspace-join-column.decorator';
+
+@WorkspaceEntity({
+  name: 'binder',
+  namePlural: 'binders',
+  labelSingular: msg`Binder`,
+  labelPlural: msg`Binders`,
+  description: msg`A binder of documents and listings for a client`,
+  icon: 'IconBook',
+})
+export class BinderWorkspaceEntity extends BaseWorkspaceEntity {
+  @WorkspaceField({
+    type: FieldMetadataType.TEXT,
+    label: msg`Name`,
+    description: msg`The binder name`,
+    icon: 'IconBook',
+  })
+  name: string;
+
+  @WorkspaceRelation({
+    type: RelationType.MANY_TO_ONE,
+    label: msg`Client`,
+    description: msg`The client for this binder`,
+    icon: 'IconUser',
+    inverseSideTarget: () => PersonWorkspaceEntity,
+    onDelete: RelationOnDeleteAction.SET_NULL,
+  })
+  client: Relation<PersonWorkspaceEntity>;
+
+  @WorkspaceJoinColumn('client')
+  clientId: string;
+
+  @WorkspaceRelation({
+    type: RelationType.MANY_TO_MANY,
+    label: msg`Listings`,
+    description: msg`The listings in this binder`,
+    icon: 'IconTag',
+    inverseSideTarget: () => ListingWorkspaceEntity,
+    onDelete: RelationOnDeleteAction.CASCADE,
+  })
+  listings: Relation<ListingWorkspaceEntity[]>;
+
+  @WorkspaceRelation({
+    type: RelationType.MANY_TO_MANY,
+    label: msg`Documents`,
+    description: msg`The documents in this binder`,
+    icon: 'IconFile',
+    inverseSideTarget: () => DocumentWorkspaceEntity,
+    onDelete: RelationOnDeleteAction.CASCADE,
+  })
+  documents: Relation<DocumentWorkspaceEntity[]>;
+}

--- a/packages/twenty-server/src/modules/dashboard/dashboard.controller.ts
+++ b/packages/twenty-server/src/modules/dashboard/dashboard.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { DashboardService } from './dashboard.service';
+
+@Controller('dashboard')
+export class DashboardController {
+  constructor(private readonly dashboardService: DashboardService) {}
+
+  @Get()
+  async getDashboardData() {
+    return this.dashboardService.getDashboardData();
+  }
+}

--- a/packages/twenty-server/src/modules/dashboard/dashboard.module.ts
+++ b/packages/twenty-server/src/modules/dashboard/dashboard.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { DashboardService } from './dashboard.service';
+import { DashboardController } from './dashboard.controller';
+
+@Module({
+  providers: [DashboardService],
+  controllers: [DashboardController],
+  exports: [DashboardService],
+})
+export class DashboardModule {}

--- a/packages/twenty-server/src/modules/dashboard/dashboard.service.ts
+++ b/packages/twenty-server/src/modules/dashboard/dashboard.service.ts
@@ -1,0 +1,69 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { PersonWorkspaceEntity } from '../person/standard-objects/person.workspace-entity';
+import { ListingWorkspaceEntity } from '../listing/standard-objects/listing.workspace-entity';
+import { OpportunityWorkspaceEntity } from '../opportunity/standard-objects/opportunity.workspace-entity';
+import { WorkspaceMemberWorkspaceEntity } from '../workspace-member/standard-objects/workspace-member.workspace-entity';
+
+@Injectable()
+export class DashboardService {
+  constructor(
+    @InjectRepository(PersonWorkspaceEntity)
+    private readonly personRepository: Repository<PersonWorkspaceEntity>,
+    @InjectRepository(ListingWorkspaceEntity)
+    private readonly listingRepository: Repository<ListingWorkspaceEntity>,
+    @InjectRepository(OpportunityWorkspaceEntity)
+    private readonly opportunityRepository: Repository<OpportunityWorkspaceEntity>,
+    @InjectRepository(WorkspaceMemberWorkspaceEntity)
+    private readonly workspaceMemberRepository: Repository<WorkspaceMemberWorkspaceEntity>,
+  ) {}
+
+  async getDashboardData(): Promise<any> {
+    const newLeads = await this.getNewLeads();
+    const leadConversionRate = await this.getLeadConversionRate();
+    const timeToClose = await this.getTimeToClose();
+    const topAgents = await this.getTopAgents();
+    const activeListings = await this.getActiveListings();
+
+    return {
+      newLeads,
+      leadConversionRate,
+      timeToClose,
+      topAgents,
+      activeListings,
+    };
+  }
+
+  private async getNewLeads(): Promise<any> {
+    // This is a placeholder. You'll need to implement the logic to get the number of new leads over time.
+    return {
+      labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'],
+      data: [10, 20, 15, 25, 30, 20],
+    };
+  }
+
+  private async getLeadConversionRate(): Promise<number> {
+    const totalLeads = await this.personRepository.count();
+    const closedLeads = await this.personRepository.count({ where: { leadStatus: 'CLOSED' } });
+    return (closedLeads / totalLeads) * 100;
+  }
+
+  private async getTimeToClose(): Promise<number> {
+    // This is a placeholder. You'll need to implement the logic to calculate the average time to close a deal.
+    return 30; // in days
+  }
+
+  private async getTopAgents(): Promise<any[]> {
+    // This is a placeholder. You'll need to implement the logic to get the top performing agents.
+    return [
+      { name: 'Agent 1', deals: 10 },
+      { name: 'Agent 2', deals: 8 },
+      { name: 'Agent 3', deals: 5 },
+    ];
+  }
+
+  private async getActiveListings(): Promise<any[]> {
+    return this.listingRepository.find({ where: { status: 'ACTIVE' } });
+  }
+}

--- a/packages/twenty-server/src/modules/document-library/document-library.controller.ts
+++ b/packages/twenty-server/src/modules/document-library/document-library.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get, Post, Body } from '@nestjs/common';
+import { DocumentLibraryService } from './document-library.service';
+import { DocumentWorkspaceEntity } from './document.workspace-entity';
+
+@Controller('document-library')
+export class DocumentLibraryController {
+  constructor(private readonly documentLibraryService: DocumentLibraryService) {}
+
+  @Get()
+  async getDocuments() {
+    return this.documentLibraryService.getDocuments();
+  }
+
+  @Post()
+  async createDocument(@Body() doc: Partial<DocumentWorkspaceEntity>) {
+    return this.documentLibraryService.createDocument(doc);
+  }
+}

--- a/packages/twenty-server/src/modules/document-library/document-library.module.ts
+++ b/packages/twenty-server/src/modules/document-library/document-library.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { DocumentLibraryService } from './document-library.service';
+import { DocumentLibraryController } from './document-library.controller';
+
+@Module({
+  providers: [DocumentLibraryService],
+  controllers: [DocumentLibraryController],
+  exports: [DocumentLibraryService],
+})
+export class DocumentLibraryModule {}

--- a/packages/twenty-server/src/modules/document-library/document-library.service.ts
+++ b/packages/twenty-server/src/modules/document-library/document-library.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { DocumentWorkspaceEntity } from './document.workspace-entity';
+
+@Injectable()
+export class DocumentLibraryService {
+  constructor(
+    @InjectRepository(DocumentWorkspaceEntity)
+    private readonly documentRepository: Repository<DocumentWorkspaceEntity>,
+  ) {}
+
+  async createDocument(doc: Partial<DocumentWorkspaceEntity>): Promise<DocumentWorkspaceEntity> {
+    const newDoc = this.documentRepository.create(doc);
+    return this.documentRepository.save(newDoc);
+  }
+
+  async getDocuments(): Promise<DocumentWorkspaceEntity[]> {
+    return this.documentRepository.find();
+  }
+}

--- a/packages/twenty-server/src/modules/document-library/document.workspace-entity.ts
+++ b/packages/twenty-server/src/modules/document-library/document.workspace-entity.ts
@@ -1,0 +1,45 @@
+import { msg } from '@lingui/core/macro';
+import { FieldMetadataType } from 'twenty-shared/types';
+import { BaseWorkspaceEntity } from 'src/engine/twenty-orm/base.workspace-entity';
+import { WorkspaceEntity } from 'src/engine/twenty-orm/decorators/workspace-entity.decorator';
+import { WorkspaceField } from 'src/engine/twenty-orm/decorators/workspace-field.decorator';
+
+@WorkspaceEntity({
+  name: 'document',
+  namePlural: 'documents',
+  labelSingular: msg`Document`,
+  labelPlural: msg`Documents`,
+  description: msg`A document`,
+  icon: 'IconFile',
+})
+export class DocumentWorkspaceEntity extends BaseWorkspaceEntity {
+  @WorkspaceField({
+    type: FieldMetadataType.TEXT,
+    label: msg`Name`,
+    description: msg`The document name`,
+    icon: 'IconFile',
+  })
+  name: string;
+
+  @WorkspaceField({
+    type: FieldMetadataType.FILE,
+    label: msg`File`,
+    description: msg`The document file`,
+    icon: 'IconFile',
+  })
+  file: any;
+
+  @WorkspaceField({
+    type: FieldMetadataType.SELECT,
+    label: msg`Category`,
+    description: msg`The document category`,
+    icon: 'IconCategory',
+    options: [
+      { value: 'CONTRACT', label: 'Contract', position: 0, color: 'blue' },
+      { value: 'BROCHURE', label: 'Brochure', position: 1, color: 'green' },
+      { value: 'OTHER', label: 'Other', position: 2, color: 'gray' },
+    ],
+    defaultValue: "'OTHER'",
+  })
+  category: string;
+}

--- a/packages/twenty-server/src/modules/integrations/calendar/calendar.controller.ts
+++ b/packages/twenty-server/src/modules/integrations/calendar/calendar.controller.ts
@@ -1,0 +1,25 @@
+import { Controller, Get, Query, Post, Body } from '@nestjs/common';
+import { CalendarService } from './calendar.service';
+
+@Controller('integrations/calendar')
+export class CalendarController {
+  constructor(private readonly calendarService: CalendarService) {}
+
+  @Get('auth-url')
+  async getAuthUrl() {
+    const url = await this.calendarService.getAuthUrl();
+    return { url };
+  }
+
+  @Get('oauth2callback')
+  async oauth2callback(@Query('code') code: string) {
+    await this.calendarService.handleOAuth2Callback(code);
+    return { message: 'Authentication successful' };
+  }
+
+  @Post('create-event')
+  async createEvent(@Body() event: any) {
+    const newEvent = await this.calendarService.createEvent(event);
+    return newEvent;
+  }
+}

--- a/packages/twenty-server/src/modules/integrations/calendar/calendar.module.ts
+++ b/packages/twenty-server/src/modules/integrations/calendar/calendar.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { CalendarService } from './calendar.service';
+import { CalendarController } from './calendar.controller';
+
+@Module({
+  providers: [CalendarService],
+  controllers: [CalendarController],
+  exports: [CalendarService],
+})
+export class CalendarModule {}

--- a/packages/twenty-server/src/modules/integrations/calendar/calendar.service.ts
+++ b/packages/twenty-server/src/modules/integrations/calendar/calendar.service.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@nestjs/common';
+import { google } from 'googleapis';
+
+@Injectable()
+export class CalendarService {
+  private oauth2Client;
+
+  constructor() {
+    this.oauth2Client = new google.auth.OAuth2(
+      process.env.GOOGLE_CLIENT_ID,
+      process.env.GOOGLE_CLIENT_SECRET,
+      process.env.GOOGLE_REDIRECT_URI,
+    );
+  }
+
+  async getAuthUrl(): Promise<string> {
+    const scopes = ['https://www.googleapis.com/auth/calendar'];
+    return this.oauth2Client.generateAuthUrl({
+      access_type: 'offline',
+      scope: scopes,
+    });
+  }
+
+  async handleOAuth2Callback(code: string): Promise<void> {
+    const { tokens } = await this.oauth2Client.getToken(code);
+    this.oauth2Client.setCredentials(tokens);
+    // In a real application, you would save the tokens to the database
+  }
+
+  async createEvent(event: any): Promise<any> {
+    const calendar = google.calendar({ version: 'v3', auth: this.oauth2Client });
+    const res = await calendar.events.insert({
+      calendarId: 'primary',
+      requestBody: event,
+    });
+    return res.data;
+  }
+}

--- a/packages/twenty-server/src/modules/integrations/gmail/gmail.controller.ts
+++ b/packages/twenty-server/src/modules/integrations/gmail/gmail.controller.ts
@@ -1,0 +1,25 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { GmailService } from './gmail.service';
+
+@Controller('integrations/gmail')
+export class GmailController {
+  constructor(private readonly gmailService: GmailService) {}
+
+  @Get('auth-url')
+  async getAuthUrl() {
+    const url = await this.gmailService.getAuthUrl();
+    return { url };
+  }
+
+  @Get('oauth2callback')
+  async oauth2callback(@Query('code') code: string) {
+    await this.gmailService.handleOAuth2Callback(code);
+    return { message: 'Authentication successful' };
+  }
+
+  @Get('fetch-leads')
+  async fetchLeads() {
+    await this.gmailService.fetchNewLeads();
+    return { message: 'Leads fetched successfully' };
+  }
+}

--- a/packages/twenty-server/src/modules/integrations/gmail/gmail.module.ts
+++ b/packages/twenty-server/src/modules/integrations/gmail/gmail.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { GmailService } from './gmail.service';
+import { GmailController } from './gmail.controller';
+
+@Module({
+  providers: [GmailService],
+  controllers: [GmailController],
+  exports: [GmailService],
+})
+export class GmailModule {}

--- a/packages/twenty-server/src/modules/integrations/gmail/gmail.service.ts
+++ b/packages/twenty-server/src/modules/integrations/gmail/gmail.service.ts
@@ -1,0 +1,95 @@
+import { Injectable } from '@nestjs/common';
+import { google } from 'googleapis';
+import { PersonWorkspaceEntity } from 'src/modules/person/standard-objects/person.workspace-entity';
+import { LeadDistributionService } from 'src/modules/lead-distribution/lead-distribution.service';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class GmailService {
+  private oauth2Client;
+
+  constructor(
+    @InjectRepository(PersonWorkspaceEntity)
+    private readonly personRepository: Repository<PersonWorkspaceEntity>,
+    private readonly leadDistributionService: LeadDistributionService,
+  ) {
+    this.oauth2Client = new google.auth.OAuth2(
+      process.env.GMAIL_CLIENT_ID,
+      process.env.GMAIL_CLIENT_SECRET,
+      process.env.GMAIL_REDIRECT_URI,
+    );
+  }
+
+  async getAuthUrl(): Promise<string> {
+    const scopes = ['https://www.googleapis.com/auth/gmail.readonly'];
+    return this.oauth2Client.generateAuthUrl({
+      access_type: 'offline',
+      scope: scopes,
+    });
+  }
+
+  async handleOAuth2Callback(code: string): Promise<void> {
+    const { tokens } = await this.oauth2Client.getToken(code);
+    this.oauth2Client.setCredentials(tokens);
+    // In a real application, you would save the tokens to the database
+    // so you can use them to access the user's Gmail account in the future.
+  }
+
+  async fetchNewLeads(): Promise<void> {
+    const gmail = google.gmail({ version: 'v1', auth: this.oauth2Client });
+    const res = await gmail.users.messages.list({
+      userId: 'me',
+      q: 'is:unread label:YourLeadLabel', // Customize this query to match your needs
+    });
+
+    const messages = res.data.messages;
+    if (messages) {
+      for (const message of messages) {
+        const msg = await gmail.users.messages.get({
+          userId: 'me',
+          id: message.id,
+        });
+
+        const fromHeader = msg.data.payload.headers.find((h) => h.name === 'From');
+        const subjectHeader = msg.data.payload.headers.find((h) => h.name === 'Subject');
+
+        const email = this.parseEmail(fromHeader.value);
+        const name = this.parseName(fromHeader.value);
+        const listing = this.parseListing(subjectHeader.value);
+
+        const newLead = new PersonWorkspaceEntity();
+        newLead.name = { firstName: name, lastName: '' };
+        newLead.emails = { primaryEmail: email, additionalEmails: [] };
+        // In a real application, you would link the lead to the listing
+        // newLead.listing = listing;
+
+        const savedLead = await this.personRepository.save(newLead);
+        await this.leadDistributionService.distributeLead(savedLead);
+
+        await gmail.users.messages.modify({
+          userId: 'me',
+          id: message.id,
+          requestBody: {
+            removeLabelIds: ['UNREAD'],
+          },
+        });
+      }
+    }
+  }
+
+  private parseEmail(fromHeader: string): string {
+    const match = fromHeader.match(/<(.*)>/);
+    return match ? match[1] : fromHeader;
+  }
+
+  private parseName(fromHeader: string): string {
+    const match = fromHeader.match(/(.*)</);
+    return match ? match[1].trim() : '';
+  }
+
+  private parseListing(subject: string): string {
+    // This is a placeholder. You'll need to customize this to parse the listing from the subject.
+    return subject;
+  }
+}

--- a/packages/twenty-server/src/modules/integrations/property-platform/property-platform.controller.ts
+++ b/packages/twenty-server/src/modules/integrations/property-platform/property-platform.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { PropertyPlatformService } from './property-platform.service';
+
+@Controller('integrations/property-platform')
+export class PropertyPlatformController {
+  constructor(private readonly propertyPlatformService: PropertyPlatformService) {}
+
+  @Get('listings')
+  async getListings(@Query() params: any) {
+    return this.propertyPlatformService.getListings(params);
+  }
+}

--- a/packages/twenty-server/src/modules/integrations/property-platform/property-platform.module.ts
+++ b/packages/twenty-server/src/modules/integrations/property-platform/property-platform.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { PropertyPlatformService } from './property-platform.service';
+import { PropertyPlatformController } from './property-platform.controller';
+
+@Module({
+  providers: [PropertyPlatformService],
+  controllers: [PropertyPlatformController],
+  exports: [PropertyPlatformService],
+})
+export class PropertyPlatformModule {}

--- a/packages/twenty-server/src/modules/integrations/property-platform/property-platform.service.ts
+++ b/packages/twenty-server/src/modules/integrations/property-platform/property-platform.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+import axios from 'axios';
+
+@Injectable()
+export class PropertyPlatformService {
+  private readonly apiUrl = 'https://api.propertyplatform.com'; // Replace with the actual API URL
+  private readonly apiKey = process.env.PROPERTY_PLATFORM_API_KEY;
+
+  async getListings(params: any): Promise<any> {
+    const response = await axios.get(`${this.apiUrl}/listings`, {
+      params,
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+    });
+    return response.data;
+  }
+}

--- a/packages/twenty-server/src/modules/integrations/whatsapp/whatsapp.controller.ts
+++ b/packages/twenty-server/src/modules/integrations/whatsapp/whatsapp.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Post, Body } from '@nestjs/common';
+import { WhatsappService } from './whatsapp.service';
+
+@Controller('integrations/whatsapp')
+export class WhatsappController {
+  constructor(private readonly whatsappService: WhatsappService) {}
+
+  @Post('send-message')
+  async sendMessage(@Body() body: { to: string; message: string }) {
+    await this.whatsappService.sendMessage(body.to, body.message);
+    return { message: 'Message sent successfully' };
+  }
+}

--- a/packages/twenty-server/src/modules/integrations/whatsapp/whatsapp.module.ts
+++ b/packages/twenty-server/src/modules/integrations/whatsapp/whatsapp.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { WhatsappService } from './whatsapp.service';
+import { WhatsappController } from './whatsapp.controller';
+
+@Module({
+  providers: [WhatsappService],
+  controllers: [WhatsappController],
+  exports: [WhatsappService],
+})
+export class WhatsappModule {}

--- a/packages/twenty-server/src/modules/integrations/whatsapp/whatsapp.service.ts
+++ b/packages/twenty-server/src/modules/integrations/whatsapp/whatsapp.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import * as twilio from 'twilio';
+
+@Injectable()
+export class WhatsappService {
+  private twilioClient;
+
+  constructor() {
+    this.twilioClient = twilio(process.env.TWILIO_ACCOUNT_SID, process.env.TWILIO_AUTH_TOKEN);
+  }
+
+  async sendMessage(to: string, body: string): Promise<void> {
+    await this.twilioClient.messages.create({
+      from: `whatsapp:${process.env.TWILIO_WHATSAPP_NUMBER}`,
+      to: `whatsapp:${to}`,
+      body,
+    });
+  }
+}

--- a/packages/twenty-server/src/modules/lead-distribution/lead-distribution.controller.ts
+++ b/packages/twenty-server/src/modules/lead-distribution/lead-distribution.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Post, Body, Get } from '@nestjs/common';
+import { LeadDistributionService } from './lead-distribution.service';
+
+@Controller('lead-distribution')
+export class LeadDistributionController {
+  constructor(private readonly leadDistributionService: LeadDistributionService) {}
+
+  @Get('config')
+  async getLeadDistributionConfig() {
+    return this.leadDistributionService.getLeadDistributionConfig();
+  }
+
+  @Post('config')
+  async setLeadDistributionConfig(@Body() config: any) {
+    await this.leadDistributionService.setLeadDistributionConfig(config);
+    return { message: 'Configuration saved successfully' };
+  }
+}

--- a/packages/twenty-server/src/modules/lead-distribution/lead-distribution.module.ts
+++ b/packages/twenty-server/src/modules/lead-distribution/lead-distribution.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { LeadDistributionService } from './lead-distribution.service';
+import { LeadDistributionController } from './lead-distribution.controller';
+
+@Module({
+  providers: [LeadDistributionService],
+  controllers: [LeadDistributionController],
+  exports: [LeadDistributionService],
+})
+export class LeadDistributionModule {}

--- a/packages/twenty-server/src/modules/lead-distribution/lead-distribution.service.spec.ts
+++ b/packages/twenty-server/src/modules/lead-distribution/lead-distribution.service.spec.ts
@@ -1,0 +1,72 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LeadDistributionService } from './lead-distribution.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { PersonWorkspaceEntity } from '../person/standard-objects/person.workspace-entity';
+import { LeadDistributionModule } from './lead-distribution.module';
+import { WorkspaceMemberWorkspaceEntity } from '../workspace-member/standard-objects/workspace-member.workspace-entity';
+
+describe('LeadDistributionService', () => {
+  let service: LeadDistributionService;
+  let workspaceMemberRepository: Repository<WorkspaceMemberWorkspaceEntity>;
+  let personRepository: Repository<PersonWorkspaceEntity>;
+
+  const mockWorkspaceMemberRepository = {
+    find: jest.fn(),
+  };
+
+  const mockPersonRepository = {
+    save: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [LeadDistributionModule],
+    })
+      .overrideProvider(getRepositoryToken(WorkspaceMemberWorkspaceEntity))
+      .useValue(mockWorkspaceMemberRepository)
+      .overrideProvider(getRepositoryToken(PersonWorkspaceEntity))
+      .useValue(mockPersonRepository)
+      .compile();
+
+    service = module.get<LeadDistributionService>(LeadDistributionService);
+    workspaceMemberRepository = module.get<Repository<WorkspaceMemberWorkspaceEntity>>(
+      getRepositoryToken(WorkspaceMemberWorkspaceEntity),
+    );
+    personRepository = module.get<Repository<PersonWorkspaceEntity>>(
+      getRepositoryToken(PersonWorkspaceEntity),
+    );
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('distributeLead', () => {
+    it('should distribute a lead to an agent using round-robin', async () => {
+      const agents = [
+        { id: 'agent1', leadDistributionEnabled: true },
+        { id: 'agent2', leadDistributionEnabled: true },
+      ] as WorkspaceMemberWorkspaceEntity[];
+      const lead = { id: 'lead1' } as PersonWorkspaceEntity;
+
+      mockPersonRepository.save.mockResolvedValue(lead);
+
+      await service.distributeLead(lead, agents, personRepository);
+
+      expect(personRepository.save).toHaveBeenCalledWith({
+        ...lead,
+        agent: agents[0],
+        leadStatus: 'ASSIGNED',
+      });
+
+      await service.distributeLead(lead, agents, personRepository);
+
+      expect(personRepository.save).toHaveBeenCalledWith({
+        ...lead,
+        agent: agents[1],
+        leadStatus: 'ASSIGNED',
+      });
+    });
+  });
+});

--- a/packages/twenty-server/src/modules/lead-distribution/lead-distribution.service.ts
+++ b/packages/twenty-server/src/modules/lead-distribution/lead-distribution.service.ts
@@ -1,0 +1,77 @@
+import { Injectable } from '@nestjs/common';
+import { WorkspaceMemberWorkspaceEntity } from '../workspace-member/standard-objects/workspace-member.workspace-entity';
+import { PersonWorkspaceEntity } from '../person/standard-objects/person.workspace-entity';
+import { Repository } from 'typeorm';
+import { WorkspaceMember } from '@nestjs/core/inspector/interfaces/workspace-member.interface';
+
+@Injectable()
+export class LeadDistributionService {
+  private lastAgentIndex = 0;
+
+  constructor() {}
+
+  async distributeLead(
+    lead: PersonWorkspaceEntity,
+    agents: WorkspaceMemberWorkspaceEntity[],
+    personRepository: Repository<PersonWorkspaceEntity>,
+  ): Promise<void> {
+    if (agents.length === 0) {
+      return;
+    }
+
+    const leadDistributionConfig = await this.getLeadDistributionConfig();
+
+    let agent: WorkspaceMemberWorkspaceEntity;
+
+    if (leadDistributionConfig.type === 'weighted') {
+      agent = this.getWeightedRoundRobinAgent(agents, leadDistributionConfig.weights);
+    } else {
+      agent = this.getRoundRobinAgent(agents);
+    }
+
+    lead.agent = agent;
+    lead.leadStatus = 'ASSIGNED';
+    await personRepository.save(lead);
+  }
+
+  private getRoundRobinAgent(agents: WorkspaceMemberWorkspaceEntity[]): WorkspaceMemberWorkspaceEntity {
+    const agent = agents[this.lastAgentIndex];
+    this.lastAgentIndex = (this.lastAgentIndex + 1) % agents.length;
+    return agent;
+  }
+
+  private getWeightedRoundRobinAgent(
+    agents: WorkspaceMemberWorkspaceEntity[],
+    weights: { [agentId: string]: number },
+  ): WorkspaceMemberWorkspaceEntity {
+    const weightedAgents: WorkspaceMemberWorkspaceEntity[] = [];
+    for (const agent of agents) {
+      const weight = weights[agent.id] || 0;
+      for (let i = 0; i < weight; i++) {
+        weightedAgents.push(agent);
+      }
+    }
+
+    if (weightedAgents.length === 0) {
+      return this.getRoundRobinAgent(agents);
+    }
+
+    return this.getRoundRobinAgent(weightedAgents);
+  }
+
+  async getLeadDistributionConfig(): Promise<any> {
+    // In a real application, this would fetch the config from a database or a configuration file.
+    // For this example, we'll just return a mock config.
+    return {
+      type: 'round-robin', // or 'weighted'
+      weights: {
+        // agentId: weight
+      },
+    };
+  }
+
+  async setLeadDistributionConfig(config: any): Promise<void> {
+    // In a real application, this would save the config to a database or a configuration file.
+    console.log('Setting lead distribution config:', config);
+  }
+}

--- a/packages/twenty-server/src/modules/listing/standard-objects/listing.workspace-entity.ts
+++ b/packages/twenty-server/src/modules/listing/standard-objects/listing.workspace-entity.ts
@@ -1,0 +1,85 @@
+import { msg } from '@lingui/core/macro';
+import { FieldMetadataType } from 'twenty-shared/types';
+
+import { RelationOnDeleteAction } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-on-delete-action.interface';
+import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
+import { Relation } from 'src/engine/workspace-manager/workspace-sync-metadata/interfaces/relation.interface';
+import { BaseWorkspaceEntity } from 'src/engine/twenty-orm/base.workspace-entity';
+import { WorkspaceEntity } from 'src/engine/twenty-orm/decorators/workspace-entity.decorator';
+import { WorkspaceField } from 'src/engine/twenty-orm/decorators/workspace-field.decorator';
+import { WorkspaceIsNullable } from 'src/engine/twenty-orm/decorators/workspace-is-nullable.decorator';
+import { WorkspaceJoinColumn } from 'src/engine/twenty-orm/decorators/workspace-join-column.decorator';
+import { WorkspaceRelation } from 'src/engine/twenty-orm/decorators/workspace-relation.decorator';
+import { STANDARD_OBJECT_IDS } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-object-ids';
+import { PropertyWorkspaceEntity } from 'src/modules/property/standard-objects/property.workspace-entity';
+import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
+
+@WorkspaceEntity({
+  name: 'listing',
+  namePlural: 'listings',
+  labelSingular: msg`Listing`,
+  labelPlural: msg`Listings`,
+  description: msg`A real estate listing`,
+  icon: 'IconTag',
+})
+export class ListingWorkspaceEntity extends BaseWorkspaceEntity {
+  @WorkspaceField({
+    type: FieldMetadataType.TEXT,
+    label: msg`Name`,
+    description: msg`The listing name`,
+    icon: 'IconTag',
+  })
+  name: string;
+
+  @WorkspaceField({
+    type: FieldMetadataType.CURRENCY,
+    label: msg`Price`,
+    description: msg`Listing price`,
+    icon: 'IconCurrencyDollar',
+  })
+  @WorkspaceIsNullable()
+  price: any;
+
+  @WorkspaceField({
+    type: FieldMetadataType.SELECT,
+    label: msg`Status`,
+    description: msg`Listing status`,
+    icon: 'IconProgressCheck',
+    options: [
+      { value: 'ACTIVE', label: 'Active', position: 0, color: 'green' },
+      { value: 'PENDING', label: 'Pending', position: 1, color: 'yellow' },
+      { value: 'SOLD', label: 'Sold', position: 2, color: 'red' },
+    ],
+    defaultValue: "'ACTIVE'",
+  })
+  status: string;
+
+  @WorkspaceRelation({
+    type: RelationType.MANY_TO_ONE,
+    label: msg`Property`,
+    description: msg`The property associated with this listing`,
+    icon: 'IconHome',
+    inverseSideTarget: () => PropertyWorkspaceEntity,
+    inverseSideFieldKey: 'listings',
+    onDelete: RelationOnDeleteAction.CASCADE,
+  })
+  @WorkspaceIsNullable()
+  property: Relation<PropertyWorkspaceEntity> | null;
+
+  @WorkspaceJoinColumn('property')
+  propertyId: string | null;
+
+  @WorkspaceRelation({
+    type: RelationType.MANY_TO_ONE,
+    label: msg`Agent`,
+    description: msg`The agent responsible for this listing`,
+    icon: 'IconUser',
+    inverseSideTarget: () => WorkspaceMemberWorkspaceEntity,
+    onDelete: RelationOnDeleteAction.SET_NULL,
+  })
+  @WorkspaceIsNullable()
+  agent: Relation<WorkspaceMemberWorkspaceEntity> | null;
+
+  @WorkspaceJoinColumn('agent')
+  agentId: string | null;
+}

--- a/packages/twenty-server/src/modules/person/standard-objects/person.workspace-entity.ts
+++ b/packages/twenty-server/src/modules/person/standard-objects/person.workspace-entity.ts
@@ -16,16 +16,11 @@ import { BaseWorkspaceEntity } from 'src/engine/twenty-orm/base.workspace-entity
 import { WorkspaceDuplicateCriteria } from 'src/engine/twenty-orm/decorators/workspace-duplicate-criteria.decorator';
 import { WorkspaceEntity } from 'src/engine/twenty-orm/decorators/workspace-entity.decorator';
 import { WorkspaceFieldIndex } from 'src/engine/twenty-orm/decorators/workspace-field-index.decorator';
-import { WorkspaceField } from 'src/engine/twenty-orm/decorators/workspace-field.decorator';
 import { WorkspaceIsDeprecated } from 'src/engine/twenty-orm/decorators/workspace-is-deprecated.decorator';
 import { WorkspaceIsNullable } from 'src/engine/twenty-orm/decorators/workspace-is-nullable.decorator';
-import { WorkspaceIsSearchable } from 'src/engine/twenty-orm/decorators/workspace-is-searchable.decorator';
 import { WorkspaceIsSystem } from 'src/engine/twenty-orm/decorators/workspace-is-system.decorator';
-import { WorkspaceIsUnique } from 'src/engine/twenty-orm/decorators/workspace-is-unique.decorator';
 import { WorkspaceJoinColumn } from 'src/engine/twenty-orm/decorators/workspace-join-column.decorator';
-import { WorkspaceRelation } from 'src/engine/twenty-orm/decorators/workspace-relation.decorator';
 import { PERSON_STANDARD_FIELD_IDS } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-field-ids';
-import { STANDARD_OBJECT_ICONS } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-object-icons';
 import { STANDARD_OBJECT_IDS } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-object-ids';
 import {
   FieldTypeAndNameMetadata,
@@ -40,6 +35,7 @@ import { NoteTargetWorkspaceEntity } from 'src/modules/note/standard-objects/not
 import { OpportunityWorkspaceEntity } from 'src/modules/opportunity/standard-objects/opportunity.workspace-entity';
 import { TaskTargetWorkspaceEntity } from 'src/modules/task/standard-objects/task-target.workspace-entity';
 import { TimelineActivityWorkspaceEntity } from 'src/modules/timeline/standard-objects/timeline-activity.workspace-entity';
+import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
 
 const NAME_FIELD_NAME = 'name';
 const EMAILS_FIELD_NAME = 'emails';
@@ -305,4 +301,35 @@ export class PersonWorkspaceEntity extends BaseWorkspaceEntity {
   @WorkspaceIsSystem()
   @WorkspaceFieldIndex({ indexType: IndexType.GIN })
   searchVector: string;
+
+  @WorkspaceField({
+    type: FieldMetadataType.SELECT,
+    label: msg`Lead Status`,
+    description: msg`The status of the lead`,
+    icon: 'IconProgressCheck',
+    options: [
+      { value: 'NEW', label: 'New', position: 0, color: 'blue' },
+      { value: 'ASSIGNED', label: 'Assigned', position: 1, color: 'purple' },
+      { value: 'CONTACTED', label: 'Contacted', position: 2, color: 'sky' },
+      { value: 'SHOWING', label: 'Showing', position: 3, color: 'turquoise' },
+      { value: 'OFFER_MADE', label: 'Offer Made', position: 4, color: 'yellow' },
+      { value: 'CLOSED', label: 'Closed', position: 5, color: 'green' },
+    ],
+    defaultValue: "'NEW'",
+  })
+  leadStatus: string;
+
+  @WorkspaceRelation({
+    type: RelationType.MANY_TO_ONE,
+    label: msg`Agent`,
+    description: msg`The agent assigned to this person`,
+    icon: 'IconUser',
+    inverseSideTarget: () => WorkspaceMemberWorkspaceEntity,
+    onDelete: RelationOnDeleteAction.SET_NULL,
+  })
+  @WorkspaceIsNullable()
+  agent: Relation<WorkspaceMemberWorkspaceEntity> | null;
+
+  @WorkspaceJoinColumn('agent')
+  agentId: string | null;
 }

--- a/packages/twenty-server/src/modules/property/standard-objects/property.workspace-entity.ts
+++ b/packages/twenty-server/src/modules/property/standard-objects/property.workspace-entity.ts
@@ -1,0 +1,77 @@
+import { msg } from '@lingui/core/macro';
+import { FieldMetadataType } from 'twenty-shared/types';
+
+import { RelationOnDeleteAction } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-on-delete-action.interface';
+import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
+import { Relation } from 'src/engine/workspace-manager/workspace-sync-metadata/interfaces/relation.interface';
+import { BaseWorkspaceEntity } from 'src/engine/twenty-orm/base.workspace-entity';
+import { WorkspaceEntity } from 'src/engine/twenty-orm/decorators/workspace-entity.decorator';
+import { WorkspaceField } from 'src/engine/twenty-orm/decorators/workspace-field.decorator';
+import { WorkspaceIsNullable } from 'src/engine/twenty-orm/decorators/workspace-is-nullable.decorator';
+import { WorkspaceRelation } from 'src/engine/twenty-orm/decorators/workspace-relation.decorator';
+import { STANDARD_OBJECT_IDS } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-object-ids';
+import { ListingWorkspaceEntity } from 'src/modules/listing/standard-objects/listing.workspace-entity';
+
+@WorkspaceEntity({
+  name: 'property',
+  namePlural: 'properties',
+  labelSingular: msg`Property`,
+  labelPlural: msg`Properties`,
+  description: msg`A real estate property`,
+  icon: 'IconHome',
+})
+export class PropertyWorkspaceEntity extends BaseWorkspaceEntity {
+  @WorkspaceField({
+    type: FieldMetadataType.TEXT,
+    label: msg`Name`,
+    description: msg`The property name`,
+    icon: 'IconHome',
+  })
+  name: string;
+
+  @WorkspaceField({
+    type: FieldMetadataType.ADDRESS,
+    label: msg`Address`,
+    description: msg`Address of the property`,
+    icon: 'IconMap',
+  })
+  @WorkspaceIsNullable()
+  address: any;
+
+  @WorkspaceField({
+    type: FieldMetadataType.NUMBER,
+    label: msg`Size`,
+    description: msg`Size of the property in square feet`,
+    icon: 'IconRuler',
+  })
+  @WorkspaceIsNullable()
+  size: number | null;
+
+  @WorkspaceField({
+    type: FieldMetadataType.NUMBER,
+    label: msg`Bedrooms`,
+    description: msg`Number of bedrooms in the property`,
+    icon: 'IconBed',
+  })
+  @WorkspaceIsNullable()
+  bedrooms: number | null;
+
+  @WorkspaceField({
+    type: FieldMetadataType.NUMBER,
+    label: msg`Bathrooms`,
+    description: msg`Number of bathrooms in the property`,
+    icon: 'IconBath',
+  })
+  @WorkspaceIsNullable()
+  bathrooms: number | null;
+
+  @WorkspaceRelation({
+    type: RelationType.ONE_TO_MANY,
+    label: msg`Listings`,
+    description: msg`Listings for this property`,
+    icon: 'IconTag',
+    inverseSideTarget: () => ListingWorkspaceEntity,
+    onDelete: RelationOnDeleteAction.CASCADE,
+  })
+  listings: Relation<ListingWorkspaceEntity[]>;
+}

--- a/packages/twenty-server/src/modules/reporting/reporting.controller.ts
+++ b/packages/twenty-server/src/modules/reporting/reporting.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { ReportingService } from './reporting.service';
+
+@Controller('reports')
+export class ReportingController {
+  constructor(private readonly reportingService: ReportingService) {}
+
+  @Get()
+  async getReport(@Query('name') reportName: string, @Query() params: any) {
+    return this.reportingService.getReport(reportName, params);
+  }
+}

--- a/packages/twenty-server/src/modules/reporting/reporting.module.ts
+++ b/packages/twenty-server/src/modules/reporting/reporting.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ReportingService } from './reporting.service';
+import { ReportingController } from './reporting.controller';
+
+@Module({
+  providers: [ReportingService],
+  controllers: [ReportingController],
+  exports: [ReportingService],
+})
+export class ReportingModule {}

--- a/packages/twenty-server/src/modules/reporting/reporting.service.ts
+++ b/packages/twenty-server/src/modules/reporting/reporting.service.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { PersonWorkspaceEntity } from '../person/standard-objects/person.workspace-entity';
+import { ListingWorkspaceEntity } from '../listing/standard-objects/listing.workspace-entity';
+import { OpportunityWorkspaceEntity } from '../opportunity/standard-objects/opportunity.workspace-entity';
+import { WorkspaceMemberWorkspaceEntity } from '../workspace-member/standard-objects/workspace-member.workspace-entity';
+
+@Injectable()
+export class ReportingService {
+  constructor(
+    @InjectRepository(PersonWorkspaceEntity)
+    private readonly personRepository: Repository<PersonWorkspaceEntity>,
+    @InjectRepository(ListingWorkspaceEntity)
+    private readonly listingRepository: Repository<ListingWorkspaceEntity>,
+    @InjectRepository(OpportunityWorkspaceEntity)
+    private readonly opportunityRepository: Repository<OpportunityWorkspaceEntity>,
+    @InjectRepository(WorkspaceMemberWorkspaceEntity)
+    private readonly workspaceMemberRepository: Repository<WorkspaceMemberWorkspaceEntity>,
+  ) {}
+
+  async getReport(reportName: string, params: any): Promise<any> {
+    switch (reportName) {
+      case 'lead':
+        return this.getLeadReport(params);
+      case 'agent-performance':
+        return this.getAgentPerformanceReport(params);
+      case 'listing':
+        return this.getListingReport(params);
+      default:
+        throw new Error(`Report not found: ${reportName}`);
+    }
+  }
+
+  private async getLeadReport(params: any): Promise<any> {
+    return this.personRepository.find({ where: params, relations: ['agent'] });
+  }
+
+  private async getAgentPerformanceReport(params: any): Promise<any> {
+    // This is a placeholder. You'll need to implement the logic to generate the agent performance report.
+    return [];
+  }
+
+  private async getListingReport(params: any): Promise<any> {
+    return this.listingRepository.find({ where: params, relations: ['property', 'agent'] });
+  }
+}

--- a/packages/twenty-server/src/modules/workspace-member/standard-objects/workspace-member.workspace-entity.ts
+++ b/packages/twenty-server/src/modules/workspace-member/standard-objects/workspace-member.workspace-entity.ts
@@ -22,10 +22,8 @@ import { WorkspaceRelation } from 'src/engine/twenty-orm/decorators/workspace-re
 import { WORKSPACE_MEMBER_STANDARD_FIELD_IDS } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-field-ids';
 import { STANDARD_OBJECT_ICONS } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-object-icons';
 import { STANDARD_OBJECT_IDS } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-object-ids';
-import {
-  FieldTypeAndNameMetadata,
-  getTsVectorColumnExpressionFromFields,
-} from 'src/engine/workspace-manager/workspace-sync-metadata/utils/get-ts-vector-column-expression.util';
+import { getTsVectorColumnExpressionFromFields } from 'src/engine/workspace-manager/workspace-sync-metadata/utils/get-ts-vector-column-expression.util';
+import { FieldTypeAndNameMetadata } from 'twenty-shared/types';
 import { AttachmentWorkspaceEntity } from 'src/modules/attachment/standard-objects/attachment.workspace-entity';
 import { BlocklistWorkspaceEntity } from 'src/modules/blocklist/standard-objects/blocklist.workspace-entity';
 import { CalendarEventParticipantWorkspaceEntity } from 'src/modules/calendar/common/standard-objects/calendar-event-participant.workspace-entity';


### PR DESCRIPTION
This commit introduces a number of new features to the Twenty CRM to make it suitable for use as a real estate CRM.

The new features include:

* A new data model with custom objects for `Property` and `Listing`.
* A lead distribution system with round-robin and weighted round-robin assignment.
* Integrations with Gmail, a property platform API, WhatsApp, and Google Calendar.
* A document library for managing documents.
* A binder feature for creating presentations.
* A dashboard and reporting system for tracking key metrics.