### PR TITLE
Stop requesting all workflowRun columns to fix out of memory issue

### DIFF
--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/cron/jobs/workflow-run-enqueue.cron.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/cron/jobs/workflow-run-enqueue.cron.job.ts
@@ -76,7 +76,7 @@ export class WorkflowRunEnqueueJob {
 
         // Using raw query to avoid storing repository in cache
         const workflowRuns = await mainDataSource.query(
-          `SELECT * FROM ${schemaName}."workflowRun" WHERE status = '${WorkflowRunStatus.NOT_STARTED}' ORDER BY "createdAt" ASC`,
+          `SELECT id FROM ${schemaName}."workflowRun" WHERE status = '${WorkflowRunStatus.NOT_STARTED}' ORDER BY "createdAt" ASC`,
         );
 
         const workflowRunsToEnqueueCount = Math.min(


### PR DESCRIPTION
Querying only useful columns in enqueue cron job