### PR TITLE
Rework locale computation on BE

### DIFF
--- a/packages/twenty-front/src/generated-metadata/graphql.ts
+++ b/packages/twenty-front/src/generated-metadata/graphql.ts
@@ -2727,6 +2727,7 @@ export type User = {
   supportUserHash?: Maybe<Scalars['String']>;
   updatedAt: Scalars['DateTime'];
   userVars?: Maybe<Scalars['JSONObject']>;
+  userWorkspaces: Array<UserWorkspace>;
   workspaceMember?: Maybe<WorkspaceMember>;
   workspaceMembers?: Maybe<Array<WorkspaceMember>>;
   workspaces: Array<UserWorkspace>;

--- a/packages/twenty-front/src/generated/graphql.ts
+++ b/packages/twenty-front/src/generated/graphql.ts
@@ -2565,6 +2565,7 @@ export type User = {
   supportUserHash?: Maybe<Scalars['String']>;
   updatedAt: Scalars['DateTime'];
   userVars?: Maybe<Scalars['JSONObject']>;
+  userWorkspaces: Array<UserWorkspace>;
   workspaceMember?: Maybe<WorkspaceMember>;
   workspaceMembers?: Maybe<Array<WorkspaceMember>>;
   workspaces: Array<UserWorkspace>;

--- a/packages/twenty-front/src/modules/workflow/utils/__tests__/parseAndValidateVariableFriendlyStringifiedJson.test.ts
+++ b/packages/twenty-front/src/modules/workflow/utils/__tests__/parseAndValidateVariableFriendlyStringifiedJson.test.ts
@@ -133,7 +133,7 @@ describe('parseAndValidateVariableFriendlyStringifiedJson', () => {
 
       expect(result.isValid).toBe(false);
       expect(result.error).toContain(
-        "SyntaxError: Expected ',' or '}' after property value in JSON at position 15 (line 1 column 16)",
+        'SyntaxError: Unexpected end of JSON input',
       );
     });
 

--- a/packages/twenty-front/src/modules/workflow/utils/__tests__/parseAndValidateVariableFriendlyStringifiedJson.test.ts
+++ b/packages/twenty-front/src/modules/workflow/utils/__tests__/parseAndValidateVariableFriendlyStringifiedJson.test.ts
@@ -133,7 +133,7 @@ describe('parseAndValidateVariableFriendlyStringifiedJson', () => {
 
       expect(result.isValid).toBe(false);
       expect(result.error).toContain(
-        'SyntaxError: Unexpected end of JSON input',
+        "SyntaxError: Expected ',' or '}' after property value in JSON at position 15 (line 1 column 16)",
       );
     });
 

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/0-54/0-54-lowercase-user-and-invitation-emails.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/0-54/0-54-lowercase-user-and-invitation-emails.command.ts
@@ -49,7 +49,7 @@ export class LowercaseUserAndInvitationEmailsCommand extends ActiveOrSuspendedWo
   private async lowercaseUserEmails(workspaceId: string, dryRun: boolean) {
     const users = await this.userRepository.find({
       where: {
-        workspaces: {
+        userWorkspaces: {
           workspaceId,
         },
         email: Raw((alias) => `LOWER(${alias}) != ${alias}`),

--- a/packages/twenty-server/src/engine/api/graphql/graphql-config/hooks/use-cached-metadata.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-config/hooks/use-cached-metadata.ts
@@ -42,7 +42,7 @@ export function useCachedMetadata(config: CacheMetadataPluginConfig): Plugin {
     serverContext?.req?.body?.operationName;
 
   return {
-    onRequest: async ({ endResponse, serverContext, request }) => {
+    onRequest: async ({ endResponse, serverContext }) => {
       if (!config.operationsToCache.includes(getOperationName(serverContext))) {
         return;
       }
@@ -50,7 +50,7 @@ export function useCachedMetadata(config: CacheMetadataPluginConfig): Plugin {
       const cacheKey = computeCacheKey({
         operationName: getOperationName(serverContext),
         // TODO: we should probably override the graphql-yoga request type to include the workspace and locale
-        request: request as unknown as Request,
+        request: (serverContext as unknown as { req: Request }).req,
       });
       const cachedResponse = await config.cacheGetter(cacheKey);
 
@@ -67,7 +67,7 @@ export function useCachedMetadata(config: CacheMetadataPluginConfig): Plugin {
 
       const cacheKey = computeCacheKey({
         operationName: getOperationName(serverContext),
-        request: request as unknown as Request,
+        request: (serverContext as unknown as { req: Request }).req,
       });
 
       const cachedResponse = await config.cacheGetter(cacheKey);

--- a/packages/twenty-server/src/engine/api/graphql/graphql-config/hooks/use-cached-metadata.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-config/hooks/use-cached-metadata.ts
@@ -60,7 +60,7 @@ export function useCachedMetadata(config: CacheMetadataPluginConfig): Plugin {
         return endResponse(earlyResponse);
       }
     },
-    onResponse: async ({ response, serverContext, request }) => {
+    onResponse: async ({ response, serverContext }) => {
       if (!config.operationsToCache.includes(getOperationName(serverContext))) {
         return;
       }

--- a/packages/twenty-server/src/engine/api/graphql/graphql-config/hooks/use-cached-metadata.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-config/hooks/use-cached-metadata.ts
@@ -1,7 +1,10 @@
 import { createHash } from 'crypto';
 
-import { isNonEmptyString } from '@sniptt/guards';
+import { Request } from 'express';
 import { Plugin } from 'graphql-yoga';
+import { isDefined } from 'twenty-shared/utils';
+
+import { InternalServerError } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
 
 export type CacheMetadataPluginConfig = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -12,19 +15,26 @@ export type CacheMetadataPluginConfig = {
 };
 
 export function useCachedMetadata(config: CacheMetadataPluginConfig): Plugin {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const computeCacheKey = (serverContext: any) => {
-    const workspaceId = serverContext.req.workspace?.id ?? 'anonymous';
-    const workspaceMetadataVersion =
-      serverContext.req.workspaceMetadataVersion ?? '0';
-    const operationName = getOperationName(serverContext);
-    const locale = serverContext.req.locale;
-    const localeCacheKey = isNonEmptyString(locale) ? `:${locale}` : '';
+  const computeCacheKey = ({
+    operationName,
+    request,
+  }: {
+    operationName: string;
+    request: Pick<Request, 'workspace' | 'locale' | 'body'>;
+  }) => {
+    const workspace = request.workspace;
+
+    if (!isDefined(workspace)) {
+      throw new InternalServerError('Workspace is not defined');
+    }
+
+    const workspaceMetadataVersion = workspace.metadataVersion ?? '0';
+    const locale = request.locale;
     const queryHash = createHash('sha256')
-      .update(serverContext.req.body.query)
+      .update(request.body.query)
       .digest('hex');
 
-    return `graphql:operations:${operationName}:${workspaceId}:${workspaceMetadataVersion}${localeCacheKey}:${queryHash}`;
+    return `graphql:operations:${operationName}:${workspace.id}:${workspaceMetadataVersion}:${locale}:${queryHash}`;
   };
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -32,12 +42,16 @@ export function useCachedMetadata(config: CacheMetadataPluginConfig): Plugin {
     serverContext?.req?.body?.operationName;
 
   return {
-    onRequest: async ({ endResponse, serverContext }) => {
+    onRequest: async ({ endResponse, serverContext, request }) => {
       if (!config.operationsToCache.includes(getOperationName(serverContext))) {
         return;
       }
 
-      const cacheKey = computeCacheKey(serverContext);
+      const cacheKey = computeCacheKey({
+        operationName: getOperationName(serverContext),
+        // TODO: we should probably override the graphql-yoga request type to include the workspace and locale
+        request: request as unknown as Request,
+      });
       const cachedResponse = await config.cacheGetter(cacheKey);
 
       if (cachedResponse) {
@@ -46,12 +60,15 @@ export function useCachedMetadata(config: CacheMetadataPluginConfig): Plugin {
         return endResponse(earlyResponse);
       }
     },
-    onResponse: async ({ response, serverContext }) => {
+    onResponse: async ({ response, serverContext, request }) => {
       if (!config.operationsToCache.includes(getOperationName(serverContext))) {
         return;
       }
 
-      const cacheKey = computeCacheKey(serverContext);
+      const cacheKey = computeCacheKey({
+        operationName: getOperationName(serverContext),
+        request: request as unknown as Request,
+      });
 
       const cachedResponse = await config.cacheGetter(cacheKey);
 

--- a/packages/twenty-server/src/engine/core-modules/admin-panel/__tests__/admin-panel.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/admin-panel/__tests__/admin-panel.service.spec.ts
@@ -91,7 +91,7 @@ describe('AdminPanelService', () => {
     const mockUser = {
       id: 'user-id',
       email: 'user@example.com',
-      workspaces: [
+      userWorkspaces: [
         {
           workspace: {
             id: 'workspace-id',

--- a/packages/twenty-server/src/engine/core-modules/admin-panel/__tests__/admin-panel.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/admin-panel/__tests__/admin-panel.service.spec.ts
@@ -114,12 +114,12 @@ describe('AdminPanelService', () => {
       expect.objectContaining({
         where: expect.objectContaining({
           id: 'user-id',
-          workspaces: {
+          userWorkspaces: {
             workspaceId: 'workspace-id',
             workspace: { allowImpersonation: true },
           },
         }),
-        relations: ['workspaces', 'workspaces.workspace'],
+        relations: { userWorkspaces: { workspace: true } },
       }),
     );
 

--- a/packages/twenty-server/src/engine/core-modules/admin-panel/admin-panel.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/admin-panel/admin-panel.service.ts
@@ -39,14 +39,14 @@ export class AdminPanelService {
     const user = await this.userRepository.findOne({
       where: {
         id: userId,
-        workspaces: {
+        userWorkspaces: {
           workspaceId,
           workspace: {
             allowImpersonation: true,
           },
         },
       },
-      relations: ['workspaces', 'workspaces.workspace'],
+      relations: ['userWorkspaces', 'userWorkspaces.workspace'],
     });
 
     userValidator.assertIsDefinedOrThrow(
@@ -59,14 +59,14 @@ export class AdminPanelService {
 
     const loginToken = await this.loginTokenService.generateLoginToken(
       user.email,
-      user.workspaces[0].workspace.id,
+      user.userWorkspaces[0].workspace.id,
     );
 
     return {
       workspace: {
-        id: user.workspaces[0].workspace.id,
+        id: user.userWorkspaces[0].workspace.id,
         workspaceUrls: this.domainManagerService.getWorkspaceUrls(
-          user.workspaces[0].workspace,
+          user.userWorkspaces[0].workspace,
         ),
       },
       loginToken,
@@ -101,7 +101,7 @@ export class AdminPanelService {
         firstName: targetUser.firstName,
         lastName: targetUser.lastName,
       },
-      workspaces: targetUser.workspaces.map((userWorkspace) => ({
+      workspaces: targetUser.userWorkspaces.map((userWorkspace) => ({
         id: userWorkspace.workspace.id,
         name: userWorkspace.workspace.displayName ?? '',
         totalUsers: userWorkspace.workspace.workspaceUsers.length,

--- a/packages/twenty-server/src/engine/core-modules/admin-panel/admin-panel.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/admin-panel/admin-panel.service.ts
@@ -46,7 +46,7 @@ export class AdminPanelService {
           },
         },
       },
-      relations: ['userWorkspaces', 'userWorkspaces.workspace'],
+      relations: { userWorkspaces: { workspace: true } },
     });
 
     userValidator.assertIsDefinedOrThrow(

--- a/packages/twenty-server/src/engine/core-modules/approved-access-domain/services/approved-access-domain.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/approved-access-domain/services/approved-access-domain.service.ts
@@ -6,7 +6,6 @@ import crypto from 'crypto';
 import { t } from '@lingui/core/macro';
 import { render } from '@react-email/render';
 import { SendApprovedAccessDomainValidation } from 'twenty-emails';
-import { APP_LOCALES } from 'twenty-shared/translations';
 import { Repository } from 'typeorm';
 
 import { ApprovedAccessDomain as ApprovedAccessDomainEntity } from 'src/engine/core-modules/approved-access-domain/approved-access-domain.entity';
@@ -78,7 +77,7 @@ export class ApprovedAccessDomainService {
         lastName: sender.name.lastName,
       },
       serverUrl: this.twentyConfigService.get('SERVER_URL'),
-      locale: 'en' as keyof typeof APP_LOCALES,
+      locale: 'en',
     });
     const html = await render(emailTemplate);
     const text = await render(emailTemplate, {

--- a/packages/twenty-server/src/engine/core-modules/auth/auth.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/auth.resolver.ts
@@ -528,14 +528,13 @@ export class AuthResolver {
   async updatePasswordViaResetToken(
     @Args()
     { passwordResetToken, newPassword }: UpdatePasswordViaResetTokenInput,
-    @Context() context: I18nContext,
   ): Promise<InvalidatePassword> {
     const { id } =
       await this.resetPasswordService.validatePasswordResetToken(
         passwordResetToken,
       );
 
-    await this.authService.updatePassword(id, newPassword, context.req.locale);
+    await this.authService.updatePassword(id, newPassword);
 
     return await this.resetPasswordService.invalidatePasswordResetToken(id);
   }

--- a/packages/twenty-server/src/engine/core-modules/auth/controllers/sso-auth.controller.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/controllers/sso-auth.controller.ts
@@ -115,7 +115,7 @@ export class SSOAuthController {
     const workspaceIdentityProvider =
       await this.workspaceSSOIdentityProviderRepository.findOne({
         where: { id: req.user.identityProviderId },
-        relations: ['workspace'],
+        relations: { workspace: true },
       });
 
     try {

--- a/packages/twenty-server/src/engine/core-modules/auth/services/auth.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/auth.service.ts
@@ -141,7 +141,7 @@ export class AuthService {
       where: {
         email: input.email,
       },
-      relations: ['workspaces'],
+      relations: { userWorkspaces: true },
     });
 
     if (!user) {
@@ -433,7 +433,7 @@ export class AuthService {
 
     const user = await this.userRepository.findOne({
       where: { id: userId },
-      relations: ['userWorkspaces'],
+      relations: { userWorkspaces: true },
     });
 
     if (!user) {

--- a/packages/twenty-server/src/engine/core-modules/auth/services/auth.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/auth.service.ts
@@ -448,7 +448,7 @@ export class AuthService {
     if (!firstUserWorkspace) {
       throw new AuthException(
         'User does not have a workspace',
-        AuthExceptionCode.USER_NOT_FOUND,
+        AuthExceptionCode.USER_WORKSPACE_NOT_FOUND,
       );
     }
 

--- a/packages/twenty-server/src/engine/core-modules/auth/services/auth.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/auth.service.ts
@@ -9,7 +9,6 @@ import { render } from '@react-email/render';
 import { addMilliseconds } from 'date-fns';
 import ms from 'ms';
 import { PasswordUpdateNotifyEmail } from 'twenty-emails';
-import { APP_LOCALES } from 'twenty-shared/translations';
 import { isDefined } from 'twenty-shared/utils';
 import { Repository } from 'typeorm';
 
@@ -424,7 +423,6 @@ export class AuthService {
   async updatePassword(
     userId: string,
     newPassword: string,
-    locale: keyof typeof APP_LOCALES,
   ): Promise<UpdatePassword> {
     if (!userId) {
       throw new AuthException(
@@ -433,11 +431,23 @@ export class AuthService {
       );
     }
 
-    const user = await this.userRepository.findOneBy({ id: userId });
+    const user = await this.userRepository.findOne({
+      where: { id: userId },
+      relations: ['userWorkspaces'],
+    });
 
     if (!user) {
       throw new AuthException(
         'User not found',
+        AuthExceptionCode.USER_NOT_FOUND,
+      );
+    }
+
+    const [firstUserWorkspace] = user.userWorkspaces;
+
+    if (!firstUserWorkspace) {
+      throw new AuthException(
+        'User does not have a workspace',
         AuthExceptionCode.USER_NOT_FOUND,
       );
     }
@@ -461,13 +471,13 @@ export class AuthService {
       userName: `${user.firstName} ${user.lastName}`,
       email: user.email,
       link: this.domainManagerService.getBaseUrl().toString(),
-      locale,
+      locale: firstUserWorkspace.locale,
     });
 
     const html = await render(emailTemplate, { pretty: true });
     const text = await render(emailTemplate, { plainText: true });
 
-    i18n.activate(locale);
+    i18n.activate(firstUserWorkspace.locale);
 
     this.emailService.send({
       from: `${this.twentyConfigService.get(

--- a/packages/twenty-server/src/engine/core-modules/email-verification/email-verification.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/email-verification/email-verification.resolver.ts
@@ -23,6 +23,7 @@ export class EmailVerificationResolver {
     private readonly domainManagerService: DomainManagerService,
   ) {}
 
+  // TODO: this should be an authenticated endpoint
   @Mutation(() => ResendEmailVerificationTokenOutput)
   @UseGuards(PublicEndpointGuard)
   async resendEmailVerificationToken(

--- a/packages/twenty-server/src/engine/core-modules/sso/services/sso.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/sso/services/sso.service.ts
@@ -132,7 +132,7 @@ export class SSOService {
   async findSSOIdentityProviderById(identityProviderId: string) {
     return (await this.workspaceSSOIdentityProviderRepository.findOne({
       where: { id: identityProviderId },
-      relations: ['workspace'],
+      relations: { workspace: true },
     })) as (SSOConfiguration & WorkspaceSSOIdentityProvider) | null;
   }
 

--- a/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.entity.ts
@@ -72,7 +72,7 @@ export class UserWorkspace {
   defaultAvatarUrl: string;
 
   @Field(() => String, { nullable: false })
-  @Column({ nullable: false, default: 'en', type: 'text' })
+  @Column({ nullable: false, default: 'en', type: 'varchar' })
   locale: keyof typeof APP_LOCALES;
 
   @Field()

--- a/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.entity.ts
@@ -2,6 +2,7 @@ import { Field, ObjectType, registerEnumType } from '@nestjs/graphql';
 
 import { IDField } from '@ptc-org/nestjs-query-graphql';
 import { PermissionsOnAllObjectRecords } from 'twenty-shared/constants';
+import { APP_LOCALES } from 'twenty-shared/translations';
 import {
   Column,
   CreateDateColumn,
@@ -46,7 +47,7 @@ export class UserWorkspace {
   id: string;
 
   @Field(() => User)
-  @ManyToOne(() => User, (user) => user.workspaces, {
+  @ManyToOne(() => User, (user) => user.userWorkspaces, {
     onDelete: 'CASCADE',
   })
   @JoinColumn({ name: 'userId' })
@@ -71,8 +72,8 @@ export class UserWorkspace {
   defaultAvatarUrl: string;
 
   @Field(() => String, { nullable: false })
-  @Column({ nullable: false, default: 'en' })
-  locale: string;
+  @Column({ nullable: false, default: 'en', type: 'text' })
+  locale: keyof typeof APP_LOCALES;
 
   @Field()
   @CreateDateColumn({ type: 'timestamptz' })

--- a/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.spec.ts
@@ -803,9 +803,9 @@ describe('UserWorkspaceService', () => {
         where: {
           id: userId,
         },
-        relations: ['workspaces', 'workspaces.workspace'],
+        relations: { userWorkspaces: { workspace: true } },
         order: {
-          workspaces: {
+          userWorkspaces: {
             workspace: {
               createdAt: 'ASC',
             },

--- a/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.spec.ts
@@ -645,12 +645,14 @@ describe('UserWorkspaceService', () => {
         where: {
           email,
         },
-        relations: [
-          'workspaces',
-          'workspaces.workspace',
-          'workspaces.workspace.workspaceSSOIdentityProviders',
-          'workspaces.workspace.approvedAccessDomains',
-        ],
+        relations: {
+          userWorkspaces: {
+            workspace: {
+              workspaceSSOIdentityProviders: true,
+              approvedAccessDomains: true,
+            },
+          },
+        },
       });
 
       expect(result).toEqual({
@@ -727,12 +729,14 @@ describe('UserWorkspaceService', () => {
         where: {
           email,
         },
-        relations: [
-          'workspaces',
-          'workspaces.workspace',
-          'workspaces.workspace.workspaceSSOIdentityProviders',
-          'workspaces.workspace.approvedAccessDomains',
-        ],
+        relations: {
+          userWorkspaces: {
+            workspace: {
+              workspaceSSOIdentityProviders: true,
+              approvedAccessDomains: true,
+            },
+          },
+        },
       });
 
       expect(result).toEqual({
@@ -792,7 +796,7 @@ describe('UserWorkspaceService', () => {
       } as unknown as Workspace;
       const user = {
         id: userId,
-        workspaces: [{ workspace: workspace1 }, { workspace: workspace2 }],
+        userWorkspaces: [{ workspace: workspace1 }, { workspace: workspace2 }],
       } as unknown as User;
 
       jest.spyOn(userRepository, 'findOne').mockResolvedValue(user);

--- a/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.spec.ts
@@ -615,7 +615,7 @@ describe('UserWorkspaceService', () => {
       } as unknown as Workspace;
       const user = {
         email,
-        workspaces: [
+        userWorkspaces: [
           {
             workspaceId: workspace1.id,
             workspace: workspace1,
@@ -694,7 +694,7 @@ describe('UserWorkspaceService', () => {
 
       const user = {
         email,
-        workspaces: [
+        userWorkspaces: [
           {
             workspaceId: workspace1.id,
             workspace: workspace1,

--- a/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.ts
@@ -222,7 +222,7 @@ export class UserWorkspaceService extends TypeOrmQueryService<UserWorkspace> {
       where: {
         id: userId,
       },
-      relations: ['userWorkspaces', 'userWorkspaces.workspace'],
+      relations: { userWorkspaces: { workspace: true } },
       order: {
         userWorkspaces: {
           workspace: {

--- a/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.ts
@@ -250,12 +250,14 @@ export class UserWorkspaceService extends TypeOrmQueryService<UserWorkspace> {
       where: {
         email,
       },
-      relations: [
-        'userWorkspaces',
-        'userWorkspaces.workspace',
-        'userWorkspaces.workspace.workspaceSSOIdentityProviders',
-        'userWorkspaces.workspace.approvedAccessDomains',
-      ],
+      relations: {
+        userWorkspaces: {
+          workspace: {
+            workspaceSSOIdentityProviders: true,
+            approvedAccessDomains: true,
+          },
+        },
+      },
     });
 
     const alreadyMemberWorkspaces = user

--- a/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.ts
@@ -222,9 +222,9 @@ export class UserWorkspaceService extends TypeOrmQueryService<UserWorkspace> {
       where: {
         id: userId,
       },
-      relations: ['workspaces', 'workspaces.workspace'],
+      relations: ['userWorkspaces', 'userWorkspaces.workspace'],
       order: {
-        workspaces: {
+        userWorkspaces: {
           workspace: {
             createdAt: 'ASC',
           },
@@ -232,7 +232,7 @@ export class UserWorkspaceService extends TypeOrmQueryService<UserWorkspace> {
       },
     });
 
-    const workspace = user?.workspaces?.[0]?.workspace;
+    const workspace = user?.userWorkspaces?.[0]?.workspace;
 
     workspaceValidator.assertIsDefinedOrThrow(
       workspace,
@@ -251,15 +251,15 @@ export class UserWorkspaceService extends TypeOrmQueryService<UserWorkspace> {
         email,
       },
       relations: [
-        'workspaces',
-        'workspaces.workspace',
-        'workspaces.workspace.workspaceSSOIdentityProviders',
-        'workspaces.workspace.approvedAccessDomains',
+        'userWorkspaces',
+        'userWorkspaces.workspace',
+        'userWorkspaces.workspace.workspaceSSOIdentityProviders',
+        'userWorkspaces.workspace.approvedAccessDomains',
       ],
     });
 
     const alreadyMemberWorkspaces = user
-      ? user.workspaces.map(({ workspace }) => ({ workspace }))
+      ? user.userWorkspaces.map(({ workspace }) => ({ workspace }))
       : [];
 
     const alreadyMemberWorkspacesIds = alreadyMemberWorkspaces.map(

--- a/packages/twenty-server/src/engine/core-modules/user/services/user.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/services/user.service.ts
@@ -97,7 +97,7 @@ export class UserService extends TypeOrmQueryService<User> {
       where: {
         id: userId,
       },
-      relations: ['userWorkspaces'],
+      relations: { userWorkspaces: true },
     });
 
     userValidator.assertIsDefinedOrThrow(user);
@@ -204,7 +204,7 @@ export class UserService extends TypeOrmQueryService<User> {
           workspaceId,
         },
       },
-      relations: ['userWorkspaces'],
+      relations: { userWorkspaces: true },
     });
 
     userValidator.assertIsDefinedOrThrow(

--- a/packages/twenty-server/src/engine/core-modules/user/services/user.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/services/user.service.ts
@@ -97,13 +97,13 @@ export class UserService extends TypeOrmQueryService<User> {
       where: {
         id: userId,
       },
-      relations: ['workspaces'],
+      relations: ['userWorkspaces'],
     });
 
     userValidator.assertIsDefinedOrThrow(user);
 
     const prepareForUserDeletionInWorkspaces = await Promise.all(
-      user.workspaces.map(async (userWorkspace) => {
+      user.userWorkspaces.map(async (userWorkspace) => {
         const { workspaceId } = userWorkspace;
 
         const workspaceMemberRepository =
@@ -200,11 +200,11 @@ export class UserService extends TypeOrmQueryService<User> {
     const user = await this.userRepository.findOne({
       where: {
         id: userId,
-        workspaces: {
+        userWorkspaces: {
           workspaceId,
         },
       },
-      relations: ['workspaces'],
+      relations: ['userWorkspaces'],
     });
 
     userValidator.assertIsDefinedOrThrow(

--- a/packages/twenty-server/src/engine/core-modules/user/user.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/user.entity.ts
@@ -112,7 +112,7 @@ export class User {
 
   @Field(() => [UserWorkspace])
   @OneToMany(() => UserWorkspace, (userWorkspace) => userWorkspace.user)
-  workspaces: Relation<UserWorkspace[]>;
+  userWorkspaces: Relation<UserWorkspace[]>;
 
   @Field(() => OnboardingStatus, { nullable: true })
   onboardingStatus: OnboardingStatus;

--- a/packages/twenty-server/src/engine/core-modules/user/user.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/user.resolver.ts
@@ -121,7 +121,7 @@ export class UserResolver {
       where: {
         id: userId,
       },
-      relations: ['userWorkspaces'],
+      relations: { userWorkspaces: true },
     });
 
     userValidator.assertIsDefinedOrThrow(
@@ -385,6 +385,16 @@ export class UserResolver {
     @AuthWorkspace({ allowUndefined: true }) workspace: Workspace | undefined,
   ) {
     return workspace;
+  }
+
+  @ResolveField(() => [UserWorkspace], {
+    nullable: false,
+  })
+  async workspaces(@Parent() user: User) {
+    return user.userWorkspaces.map((userWorkspace) => ({
+      ...userWorkspace,
+      workspace: userWorkspace.workspace,
+    }));
   }
 
   @ResolveField(() => AvailableWorkspaces)

--- a/packages/twenty-server/src/engine/core-modules/user/user.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/user.resolver.ts
@@ -391,10 +391,7 @@ export class UserResolver {
     nullable: false,
   })
   async workspaces(@Parent() user: User) {
-    return user.userWorkspaces.map((userWorkspace) => ({
-      ...userWorkspace,
-      workspace: userWorkspace.workspace,
-    }));
+    return user.userWorkspaces;
   }
 
   @ResolveField(() => AvailableWorkspaces)

--- a/packages/twenty-server/src/engine/core-modules/user/user.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/user.resolver.ts
@@ -121,7 +121,7 @@ export class UserResolver {
       where: {
         id: userId,
       },
-      relations: ['workspaces'],
+      relations: ['userWorkspaces'],
     });
 
     userValidator.assertIsDefinedOrThrow(
@@ -133,7 +133,7 @@ export class UserResolver {
       return user;
     }
 
-    const currentUserWorkspace = user.workspaces.find(
+    const currentUserWorkspace = user.userWorkspaces.find(
       (userWorkspace) => userWorkspace.workspaceId === workspace.id,
     );
 

--- a/packages/twenty-server/src/engine/core-modules/workspace-invitation/services/workspace-invitation.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace-invitation/services/workspace-invitation.service.ts
@@ -9,7 +9,6 @@ import { render } from '@react-email/render';
 import { addMilliseconds } from 'date-fns';
 import ms from 'ms';
 import { SendInviteLinkEmail } from 'twenty-emails';
-import { APP_LOCALES } from 'twenty-shared/translations';
 import { IsNull, Repository } from 'typeorm';
 
 import {
@@ -298,7 +297,7 @@ export class WorkspaceInvitationService {
             lastName: sender.name.lastName,
           },
           serverUrl: this.twentyConfigService.get('SERVER_URL'),
-          locale: sender.locale as keyof typeof APP_LOCALES,
+          locale: sender.locale,
         };
 
         const emailTemplate = SendInviteLinkEmail(emailData);

--- a/packages/twenty-server/src/engine/core-modules/workspace-invitation/services/workspace-invitation.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace-invitation/services/workspace-invitation.service.ts
@@ -60,7 +60,7 @@ export class WorkspaceInvitationService {
           value: workspacePersonalInviteToken,
           type: AppTokenType.InvitationToken,
         },
-        relations: ['workspace'],
+        relations: { workspace: true },
       });
 
       if (!appToken) {
@@ -118,7 +118,7 @@ export class WorkspaceInvitationService {
         value: invitationToken,
         type: AppTokenType.InvitationToken,
       },
-      relations: ['workspace'],
+      relations: { workspace: true },
     });
 
     if (!appToken) {

--- a/packages/twenty-server/src/engine/middlewares/middleware.service.ts
+++ b/packages/twenty-server/src/engine/middlewares/middleware.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
 import { Request, Response } from 'express';
-import { APP_LOCALES, SOURCE_LOCALE } from 'twenty-shared/translations';
+import { SOURCE_LOCALE } from 'twenty-shared/translations';
 import { isDefined } from 'twenty-shared/utils';
 
 import { AuthException } from 'src/engine/core-modules/auth/auth.exception';
@@ -160,10 +160,7 @@ export class MiddlewareService {
     request.userWorkspaceId = data.userWorkspaceId;
     request.authProvider = data.authProvider;
 
-    request.locale =
-      ((data.userWorkspace?.locale ??
-        request.headers['x-locale']) as keyof typeof APP_LOCALES) ??
-      SOURCE_LOCALE;
+    request.locale = data.userWorkspace?.locale ?? SOURCE_LOCALE;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/twenty-server/src/engine/middlewares/middleware.service.ts
+++ b/packages/twenty-server/src/engine/middlewares/middleware.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
 import { Request, Response } from 'express';
-import { SOURCE_LOCALE } from 'twenty-shared/translations';
+import { APP_LOCALES, SOURCE_LOCALE } from 'twenty-shared/translations';
 import { isDefined } from 'twenty-shared/utils';
 
 import { AuthException } from 'src/engine/core-modules/auth/auth.exception';
@@ -160,7 +160,10 @@ export class MiddlewareService {
     request.userWorkspaceId = data.userWorkspaceId;
     request.authProvider = data.authProvider;
 
-    request.locale = data.userWorkspace?.locale ?? SOURCE_LOCALE;
+    request.locale =
+      data.userWorkspace?.locale ??
+      (request.headers['x-locale'] as keyof typeof APP_LOCALES) ??
+      SOURCE_LOCALE;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Context:

Users are complaining to see their workspace in a language they don't know. This behavior is transient, happens on data model update and disappear on refresh
I've check the cache for users that got the issue and did not spot any weird language
==> I think we somehow fallback the the request header locale. I feel we should always use the userWorkspace.locale, request locale should not be used in BE in my opinion except for unauthenticated endpoints. I'm also adding logs to understand the locale issue
In this PR:

rename user.workspaces into user.userWorkspaces which is more correct
improve / simplify LOCALES typing