### PR TITLE
morph dataloader specific

### DIFF
--- a/packages/twenty-front/src/generated-metadata/graphql.ts
+++ b/packages/twenty-front/src/generated-metadata/graphql.ts
@@ -758,6 +758,7 @@ export type Field = {
   isSystem?: Maybe<Scalars['Boolean']>;
   isUnique?: Maybe<Scalars['Boolean']>;
   label: Scalars['String'];
+  morphRelations?: Maybe<Array<Relation>>;
   name: Scalars['String'];
   object?: Maybe<Object>;
   options?: Maybe<Scalars['JSON']>;

--- a/packages/twenty-front/src/generated/graphql.ts
+++ b/packages/twenty-front/src/generated/graphql.ts
@@ -1,5 +1,5 @@
-import * as Apollo from '@apollo/client';
 import { gql } from '@apollo/client';
+import * as Apollo from '@apollo/client';
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };

--- a/packages/twenty-front/src/generated/graphql.ts
+++ b/packages/twenty-front/src/generated/graphql.ts
@@ -1,5 +1,5 @@
-import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
+import { gql } from '@apollo/client';
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
@@ -722,6 +722,7 @@ export type Field = {
   isSystem?: Maybe<Scalars['Boolean']>;
   isUnique?: Maybe<Scalars['Boolean']>;
   label: Scalars['String'];
+  morphRelations?: Maybe<Array<Relation>>;
   name: Scalars['String'];
   object?: Maybe<Object>;
   options?: Maybe<Scalars['JSON']>;

--- a/packages/twenty-server/src/engine/dataloaders/dataloader.interface.ts
+++ b/packages/twenty-server/src/engine/dataloaders/dataloader.interface.ts
@@ -4,6 +4,7 @@ import {
   FieldMetadataLoaderPayload,
   IndexFieldMetadataLoaderPayload,
   IndexMetadataLoaderPayload,
+  MorphRelationLoaderPayload,
   RelationLoaderPayload,
 } from 'src/engine/dataloaders/dataloader.service';
 import { FieldMetadataDTO } from 'src/engine/metadata-modules/field-metadata/dtos/field-metadata.dto';
@@ -21,6 +22,16 @@ export interface IDataloaders {
       sourceFieldMetadata: FieldMetadataEntity;
       targetFieldMetadata: FieldMetadataEntity;
     }
+  >;
+
+  morphRelationLoader: DataLoader<
+    MorphRelationLoaderPayload,
+    {
+      sourceObjectMetadata: ObjectMetadataEntity;
+      targetObjectMetadata: ObjectMetadataEntity;
+      sourceFieldMetadata: FieldMetadataEntity;
+      targetFieldMetadata: FieldMetadataEntity;
+    }[]
   >;
 
   fieldMetadataLoader: DataLoader<

--- a/packages/twenty-server/src/engine/dataloaders/dataloader.service.ts
+++ b/packages/twenty-server/src/engine/dataloaders/dataloader.service.ts
@@ -191,7 +191,6 @@ export class DataloaderService {
     );
   }
 
-  // todo: this is not used anywhere, we should remove it
   private createFieldMetadataLoader() {
     return new DataLoader<FieldMetadataLoaderPayload, FieldMetadataDTO[]>(
       async (dataLoaderParams: FieldMetadataLoaderPayload[]) => {

--- a/packages/twenty-server/src/engine/dataloaders/dataloader.service.ts
+++ b/packages/twenty-server/src/engine/dataloaders/dataloader.service.ts
@@ -9,6 +9,7 @@ import { ObjectMetadataInterface } from 'src/engine/metadata-modules/field-metad
 import { IndexMetadataInterface } from 'src/engine/metadata-modules/index-metadata/interfaces/index-metadata.interface';
 
 import { IDataloaders } from 'src/engine/dataloaders/dataloader.interface';
+import { filterMorphRelationDuplicateFieldsDTO } from 'src/engine/dataloaders/utils/filter-morph-relation-duplicate-fields.util';
 import { FieldMetadataDTO } from 'src/engine/metadata-modules/field-metadata/dtos/field-metadata.dto';
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { FieldMetadataMorphRelationService } from 'src/engine/metadata-modules/field-metadata/services/field-metadata-morph-relation.service';
@@ -211,7 +212,7 @@ export class DataloaderService {
             return [];
           }
 
-          return Object.values(objectMetadata.fieldsById).map(
+          const fields = Object.values(objectMetadata.fieldsById).map(
             // TODO: fix this as we should merge FieldMetadataEntity and FieldMetadataInterface
             (fieldMetadata) => {
               const overridesFieldToCompute = [
@@ -245,6 +246,8 @@ export class DataloaderService {
               };
             },
           );
+
+          return filterMorphRelationDuplicateFieldsDTO(fields);
         });
 
         return fieldMetadataCollection;

--- a/packages/twenty-server/src/engine/dataloaders/utils/filter-morph-relation-duplicate-fields.util.ts
+++ b/packages/twenty-server/src/engine/dataloaders/utils/filter-morph-relation-duplicate-fields.util.ts
@@ -1,0 +1,13 @@
+import { FieldMetadataDTO } from 'src/engine/metadata-modules/field-metadata/dtos/field-metadata.dto';
+
+export const filterMorphRelationDuplicateFieldsDTO = (
+  fields: FieldMetadataDTO[],
+) => {
+  return fields.filter((currentField) => {
+    return !fields.some(
+      (otherField) =>
+        otherField.name === currentField.name &&
+        otherField.id > currentField.id,
+    );
+  });
+};

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.module.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.module.ts
@@ -112,6 +112,7 @@ import { FieldMetadataService } from './services/field-metadata.service';
   exports: [
     FieldMetadataService,
     FieldMetadataRelationService,
+    FieldMetadataMorphRelationService,
     FieldMetadataRelatedRecordsService,
     FieldMetadataEnumValidationService,
     FieldMetadataValidationService,

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.resolver.ts
@@ -9,6 +9,7 @@ import {
 } from '@nestjs/graphql';
 
 import { FieldMetadataType } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
 
 import { PreventNestToAutoLogGraphqlErrorsFilter } from 'src/engine/core-modules/graphql/filters/prevent-nest-to-auto-log-graphql-errors.filter';
 import { ResolverValidationPipe } from 'src/engine/core-modules/graphql/pipes/resolver-validation.pipe';
@@ -40,7 +41,10 @@ import { FieldMetadataService } from 'src/engine/metadata-modules/field-metadata
 import { fieldMetadataGraphqlApiExceptionHandler } from 'src/engine/metadata-modules/field-metadata/utils/field-metadata-graphql-api-exception-handler.util';
 import { SettingPermissionType } from 'src/engine/metadata-modules/permissions/constants/setting-permission-type.constants';
 import { PermissionsGraphqlApiExceptionFilter } from 'src/engine/metadata-modules/permissions/utils/permissions-graphql-api-exception.filter';
-import { isRelationFieldMetadataType } from 'src/engine/utils/is-relation-field-metadata-type.util';
+import {
+  isMorphRelationFieldMetadataType,
+  isRelationFieldMetadataType,
+} from 'src/engine/utils/is-relation-field-metadata-type.util';
 
 @UseGuards(WorkspaceAuthGuard)
 @UsePipes(ResolverValidationPipe)
@@ -164,6 +168,51 @@ export class FieldMetadataResolver {
         sourceFieldMetadata,
         targetFieldMetadata,
       };
+    } catch (error) {
+      fieldMetadataGraphqlApiExceptionHandler(error);
+    }
+  }
+
+  @ResolveField(() => [RelationDTO], { nullable: true })
+  async morphRelations(
+    @AuthWorkspace() workspace: Workspace,
+    @Parent()
+    fieldMetadata: FieldMetadataEntity<FieldMetadataType.MORPH_RELATION>,
+    @Context() context: { loaders: IDataloaders },
+  ): Promise<RelationDTO[] | null | undefined> {
+    if (!isMorphRelationFieldMetadataType(fieldMetadata.type)) {
+      return null;
+    }
+
+    try {
+      const morphRelations = await context.loaders.morphRelationLoader.load({
+        fieldMetadata,
+        workspaceId: workspace.id,
+      });
+
+      if (!isDefined(fieldMetadata.settings)) {
+        throw new FieldMetadataException(
+          'Morph relation settings are required',
+          FieldMetadataExceptionCode.FIELD_METADATA_RELATION_MALFORMED,
+        );
+      }
+
+      return morphRelations.map((morphRelation) => {
+        if (!isDefined(fieldMetadata.settings?.relationType)) {
+          throw new FieldMetadataException(
+            'Morph relation relationType are required',
+            FieldMetadataExceptionCode.FIELD_METADATA_RELATION_MALFORMED,
+          );
+        }
+
+        return {
+          type: fieldMetadata.settings.relationType,
+          sourceObjectMetadata: morphRelation.sourceObjectMetadata,
+          targetObjectMetadata: morphRelation.targetObjectMetadata,
+          sourceFieldMetadata: morphRelation.sourceFieldMetadata,
+          targetFieldMetadata: morphRelation.targetFieldMetadata,
+        };
+      });
     } catch (error) {
       fieldMetadataGraphqlApiExceptionHandler(error);
     }

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.resolver.ts
@@ -190,29 +190,23 @@ export class FieldMetadataResolver {
         workspaceId: workspace.id,
       });
 
-      if (!isDefined(fieldMetadata.settings)) {
+      // typescript issue, it's not possible to use the fieldMetadata.settings directly in morphRelations.map
+      const settings = fieldMetadata.settings;
+
+      if (!isDefined(settings) || !isDefined(settings.relationType)) {
         throw new FieldMetadataException(
-          'Morph relation settings are required',
+          `Morph relation settings ${isDefined(settings) && 'relationType'} are required`,
           FieldMetadataExceptionCode.FIELD_METADATA_RELATION_MALFORMED,
         );
       }
 
-      return morphRelations.map((morphRelation) => {
-        if (!isDefined(fieldMetadata.settings?.relationType)) {
-          throw new FieldMetadataException(
-            'Morph relation relationType are required',
-            FieldMetadataExceptionCode.FIELD_METADATA_RELATION_MALFORMED,
-          );
-        }
-
-        return {
-          type: fieldMetadata.settings.relationType,
-          sourceObjectMetadata: morphRelation.sourceObjectMetadata,
-          targetObjectMetadata: morphRelation.targetObjectMetadata,
-          sourceFieldMetadata: morphRelation.sourceFieldMetadata,
-          targetFieldMetadata: morphRelation.targetFieldMetadata,
-        };
-      });
+      return morphRelations.map((morphRelation) => ({
+        type: settings.relationType,
+        sourceObjectMetadata: morphRelation.sourceObjectMetadata,
+        targetObjectMetadata: morphRelation.targetObjectMetadata,
+        sourceFieldMetadata: morphRelation.sourceFieldMetadata,
+        targetFieldMetadata: morphRelation.targetFieldMetadata,
+      }));
     } catch (error) {
       fieldMetadataGraphqlApiExceptionHandler(error);
     }

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.resolver.ts
@@ -41,10 +41,8 @@ import { FieldMetadataService } from 'src/engine/metadata-modules/field-metadata
 import { fieldMetadataGraphqlApiExceptionHandler } from 'src/engine/metadata-modules/field-metadata/utils/field-metadata-graphql-api-exception-handler.util';
 import { SettingPermissionType } from 'src/engine/metadata-modules/permissions/constants/setting-permission-type.constants';
 import { PermissionsGraphqlApiExceptionFilter } from 'src/engine/metadata-modules/permissions/utils/permissions-graphql-api-exception.filter';
-import {
-  isMorphRelationFieldMetadataType,
-  isRelationFieldMetadataType,
-} from 'src/engine/utils/is-relation-field-metadata-type.util';
+import { isMorphRelationFieldMetadataType } from 'src/engine/utils/is-morph-relation-field-metadata-type.util';
+import { isRelationFieldMetadataType } from 'src/engine/utils/is-relation-field-metadata-type.util';
 
 @UseGuards(WorkspaceAuthGuard)
 @UsePipes(ResolverValidationPipe)

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata-morph-relation.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata-morph-relation.service.ts
@@ -193,33 +193,18 @@ export class FieldMetadataMorphRelationService {
       | 'relationTargetFieldMetadataId'
       | 'relationTargetObjectMetadataId'
       | 'name'
-    >[] = [];
-
-    fieldMetadataItems.map((fieldMetadataItem) => {
-      const { relationTargetFieldMetadataId, relationTargetObjectMetadataId } =
-        fieldMetadataItem;
-
-      if (!relationTargetObjectMetadataId || !relationTargetFieldMetadataId) {
-        throw new FieldMetadataException(
-          `Relation target object metadata id or relation target field metadata id not found for field metadata ${fieldMetadataItem.id}`,
-          FieldMetadataExceptionCode.FIELD_METADATA_RELATION_MALFORMED,
-        );
-      }
-
-      // cannot use fieldsByName because it is not a unique for the Morph Relation
+    >[] = fieldMetadataItems.flatMap((fieldMetadataItem) => {
       const fieldsById =
         objectMetadataMaps.byId[fieldMetadataItem.objectMetadataId]?.fieldsById;
 
       if (!isDefined(fieldsById)) {
         throw new FieldMetadataException(
-          `Fields by id not found for object metadata ${relationTargetObjectMetadataId}`,
+          `Fields by id not found for object metadata ${fieldMetadataItem.objectMetadataId}`,
           FieldMetadataExceptionCode.FIELD_METADATA_RELATION_MALFORMED,
         );
       }
 
-      const fieldsByIdArray = Object.values(fieldsById);
-
-      const fieldMetadataItemsAndMorphSibling = fieldsByIdArray
+      return Object.values(fieldsById)
         .filter(
           (fieldMetadataById) =>
             fieldMetadataItem.name === fieldMetadataById.name,
@@ -236,10 +221,6 @@ export class FieldMetadataMorphRelationService {
             name: fieldMetadataById.name,
           };
         });
-
-      fieldMetadataItemsAndMorphSiblings.push(
-        ...fieldMetadataItemsAndMorphSibling,
-      );
     });
 
     return fieldMetadataItemsAndMorphSiblings.map((fieldMetadataItem) => {

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata-morph-relation.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata-morph-relation.service.ts
@@ -237,13 +237,6 @@ export class FieldMetadataMorphRelationService {
           };
         });
 
-      if (!fieldMetadataItemsAndMorphSibling) {
-        throw new FieldMetadataException(
-          `Target field metadata with id ${relationTargetFieldMetadataId} not found for field metadata ${fieldMetadataItem.id}`,
-          FieldMetadataExceptionCode.FIELD_METADATA_RELATION_MALFORMED,
-        );
-      }
-
       fieldMetadataItemsAndMorphSiblings.push(
         ...fieldMetadataItemsAndMorphSibling,
       );

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata-morph-relation.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata-morph-relation.service.ts
@@ -6,6 +6,7 @@ import { isDefined } from 'twenty-shared/utils';
 import { Repository } from 'typeorm';
 import { v4 } from 'uuid';
 
+import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
 import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
 
 import { CreateFieldInput } from 'src/engine/metadata-modules/field-metadata/dtos/create-field.input';
@@ -15,17 +16,21 @@ import {
   FieldMetadataExceptionCode,
 } from 'src/engine/metadata-modules/field-metadata/field-metadata.exception';
 import { FieldMetadataRelationService } from 'src/engine/metadata-modules/field-metadata/services/field-metadata-relation.service';
-import { prepareCustomFieldMetadataForCreation } from 'src/engine/metadata-modules/field-metadata/utils/prepare-field-metadata-for-creation.util';
-import { ObjectMetadataItemWithFieldMaps } from 'src/engine/metadata-modules/types/object-metadata-item-with-field-maps';
-import { ObjectMetadataMaps } from 'src/engine/metadata-modules/types/object-metadata-maps';
-import { computeMetadataNameFromLabel } from 'src/engine/metadata-modules/utils/validate-name-and-label-are-sync-or-throw.util';
 import { computeMorphRelationFieldJoinColumnName } from 'src/engine/metadata-modules/field-metadata/utils/compute-morph-relation-field-join-column-name.util';
 import { computeRelationFieldJoinColumnName } from 'src/engine/metadata-modules/field-metadata/utils/compute-relation-field-join-column-name.util';
+import { prepareCustomFieldMetadataForCreation } from 'src/engine/metadata-modules/field-metadata/utils/prepare-field-metadata-for-creation.util';
+import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
+import { ObjectMetadataItemWithFieldMaps } from 'src/engine/metadata-modules/types/object-metadata-item-with-field-maps';
+import { ObjectMetadataMaps } from 'src/engine/metadata-modules/types/object-metadata-maps';
+import { getObjectMetadataFromObjectMetadataItemWithFieldMaps } from 'src/engine/metadata-modules/utils/get-object-metadata-from-object-metadata-Item-with-field-maps';
+import { computeMetadataNameFromLabel } from 'src/engine/metadata-modules/utils/validate-name-and-label-are-sync-or-throw.util';
+import { WorkspaceCacheStorageService } from 'src/engine/workspace-cache-storage/workspace-cache-storage.service';
 
 @Injectable()
 export class FieldMetadataMorphRelationService {
   constructor(
     private readonly fieldMetadataRelationService: FieldMetadataRelationService,
+    private readonly workspaceCacheStorageService: WorkspaceCacheStorageService,
   ) {}
 
   async createMorphRelationFieldMetadataItems({
@@ -152,5 +157,144 @@ export class FieldMetadataMorphRelationService {
     }
 
     return fieldsCreated;
+  }
+
+  async findCachedFieldMetadataMorphRelation(
+    fieldMetadataItems: Array<
+      Pick<
+        FieldMetadataInterface,
+        | 'id'
+        | 'type'
+        | 'objectMetadataId'
+        | 'relationTargetFieldMetadataId'
+        | 'relationTargetObjectMetadataId'
+        | 'name'
+      >
+    >,
+    workspaceId: string,
+  ): Promise<
+    Array<{
+      sourceObjectMetadata: ObjectMetadataEntity;
+      sourceFieldMetadata: FieldMetadataEntity;
+      targetObjectMetadata: ObjectMetadataEntity;
+      targetFieldMetadata: FieldMetadataEntity;
+    }>
+  > {
+    const objectMetadataMaps =
+      await this.workspaceCacheStorageService.getObjectMetadataMapsOrThrow(
+        workspaceId,
+      );
+
+    const fieldMetadataItemsAndMorphSiblings: Pick<
+      FieldMetadataInterface,
+      | 'id'
+      | 'type'
+      | 'objectMetadataId'
+      | 'relationTargetFieldMetadataId'
+      | 'relationTargetObjectMetadataId'
+      | 'name'
+    >[] = [];
+
+    fieldMetadataItems.map((fieldMetadataItem) => {
+      const { relationTargetFieldMetadataId, relationTargetObjectMetadataId } =
+        fieldMetadataItem;
+
+      if (!relationTargetObjectMetadataId || !relationTargetFieldMetadataId) {
+        throw new FieldMetadataException(
+          `Relation target object metadata id or relation target field metadata id not found for field metadata ${fieldMetadataItem.id}`,
+          FieldMetadataExceptionCode.FIELD_METADATA_RELATION_MALFORMED,
+        );
+      }
+
+      // cannot use fieldsByName because it is not a unique for the Morph Relation
+      const fieldsById =
+        objectMetadataMaps.byId[fieldMetadataItem.objectMetadataId]?.fieldsById;
+
+      if (!isDefined(fieldsById)) {
+        throw new FieldMetadataException(
+          `Fields by id not found for object metadata ${relationTargetObjectMetadataId}`,
+          FieldMetadataExceptionCode.FIELD_METADATA_RELATION_MALFORMED,
+        );
+      }
+
+      const fieldsByIdArray = Object.values(fieldsById);
+
+      const fieldMetadataItemsAndMorphSibling = fieldsByIdArray
+        .filter(
+          (fieldMetadataById) =>
+            fieldMetadataItem.name === fieldMetadataById.name,
+        )
+        .map((fieldMetadataById) => {
+          return {
+            id: fieldMetadataById.id,
+            type: fieldMetadataById.type,
+            objectMetadataId: fieldMetadataById.objectMetadataId,
+            relationTargetFieldMetadataId:
+              fieldMetadataById.relationTargetFieldMetadataId,
+            relationTargetObjectMetadataId:
+              fieldMetadataById.relationTargetObjectMetadataId,
+            name: fieldMetadataById.name,
+          };
+        });
+
+      if (!fieldMetadataItemsAndMorphSibling) {
+        throw new FieldMetadataException(
+          `Target field metadata with id ${relationTargetFieldMetadataId} not found for field metadata ${fieldMetadataItem.id}`,
+          FieldMetadataExceptionCode.FIELD_METADATA_RELATION_MALFORMED,
+        );
+      }
+
+      fieldMetadataItemsAndMorphSiblings.push(
+        ...fieldMetadataItemsAndMorphSibling,
+      );
+    });
+
+    return fieldMetadataItemsAndMorphSiblings.map((fieldMetadataItem) => {
+      const {
+        id,
+        objectMetadataId,
+        relationTargetFieldMetadataId,
+        relationTargetObjectMetadataId,
+      } = fieldMetadataItem;
+
+      if (!relationTargetObjectMetadataId || !relationTargetFieldMetadataId) {
+        throw new FieldMetadataException(
+          `Relation target object metadata id or relation target field metadata id not found for field metadata ${id}`,
+          FieldMetadataExceptionCode.FIELD_METADATA_RELATION_MALFORMED,
+        );
+      }
+
+      const sourceObjectMetadata = objectMetadataMaps.byId[objectMetadataId];
+      const targetObjectMetadata =
+        objectMetadataMaps.byId[relationTargetObjectMetadataId];
+      const sourceFieldMetadata = sourceObjectMetadata?.fieldsById[id];
+      const targetFieldMetadata =
+        targetObjectMetadata?.fieldsById[relationTargetFieldMetadataId];
+
+      if (
+        !sourceObjectMetadata ||
+        !targetObjectMetadata ||
+        !sourceFieldMetadata ||
+        !targetFieldMetadata
+      ) {
+        throw new FieldMetadataException(
+          `Field relation metadata not found for field metadata ${id}`,
+          FieldMetadataExceptionCode.FIELD_METADATA_RELATION_MALFORMED,
+        );
+      }
+
+      return {
+        sourceObjectMetadata:
+          getObjectMetadataFromObjectMetadataItemWithFieldMaps(
+            sourceObjectMetadata,
+          ) as ObjectMetadataEntity,
+        sourceFieldMetadata: sourceFieldMetadata as FieldMetadataEntity,
+        targetObjectMetadata:
+          getObjectMetadataFromObjectMetadataItemWithFieldMaps(
+            targetObjectMetadata,
+          ) as ObjectMetadataEntity,
+        targetFieldMetadata: targetFieldMetadata as FieldMetadataEntity,
+      };
+    });
   }
 }

--- a/packages/twenty-server/src/engine/utils/is-morph-relation-field-metadata-type.util.ts
+++ b/packages/twenty-server/src/engine/utils/is-morph-relation-field-metadata-type.util.ts
@@ -1,0 +1,7 @@
+import { FieldMetadataType } from 'twenty-shared/types';
+
+export const isMorphRelationFieldMetadataType = (
+  type: FieldMetadataType,
+): type is FieldMetadataType.MORPH_RELATION => {
+  return type === FieldMetadataType.MORPH_RELATION;
+};

--- a/packages/twenty-server/src/engine/utils/is-relation-field-metadata-type.util.ts
+++ b/packages/twenty-server/src/engine/utils/is-relation-field-metadata-type.util.ts
@@ -4,3 +4,9 @@ export const isRelationFieldMetadataType = (
 ): type is FieldMetadataType.RELATION => {
   return type === FieldMetadataType.RELATION;
 };
+
+export const isMorphRelationFieldMetadataType = (
+  type: FieldMetadataType,
+): type is FieldMetadataType.MORPH_RELATION => {
+  return type === FieldMetadataType.MORPH_RELATION;
+};

--- a/packages/twenty-server/src/engine/utils/is-relation-field-metadata-type.util.ts
+++ b/packages/twenty-server/src/engine/utils/is-relation-field-metadata-type.util.ts
@@ -4,9 +4,3 @@ export const isRelationFieldMetadataType = (
 ): type is FieldMetadataType.RELATION => {
   return type === FieldMetadataType.RELATION;
 };
-
-export const isMorphRelationFieldMetadataType = (
-  type: FieldMetadataType,
-): type is FieldMetadataType.MORPH_RELATION => {
-  return type === FieldMetadataType.MORPH_RELATION;
-};


### PR DESCRIPTION
In the metadata GraphQL api, we need the resolveField for the morphRelations. This PR implements this topic.


Fixes https://github.com/twentyhq/core-team-issues/issues/1234