### PR TITLE
[permissions] Fix query of foreign key field (ex: messageId)

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-selected-fields/graphql-selected-fields.parser.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-selected-fields/graphql-selected-fields.parser.ts
@@ -75,10 +75,27 @@ export class GraphqlQuerySelectedFieldsParser {
     for (const [fieldKey, fieldValue] of Object.entries(
       graphqlSelectedFields,
     )) {
-      const fieldMetadata =
+      const fieldMetadataBasedOnName =
         objectMetadataMapItem.fieldsById[
           objectMetadataMapItem.fieldIdByName[fieldKey]
         ];
+
+      const isFieldForeignKey =
+        !fieldMetadataBasedOnName && fieldKey.endsWith('Id');
+
+      if (isFieldForeignKey) {
+        const fieldMetadataBasedOnRelationName =
+          objectMetadataMapItem.fieldsById[
+            objectMetadataMapItem.fieldIdByName[fieldKey.slice(0, -2)]
+          ];
+
+        if (fieldMetadataBasedOnRelationName) {
+          accumulator.select[fieldKey] = true; // field is not a connection so should not be treated as a relation
+          continue;
+        }
+      }
+
+      const fieldMetadata = fieldMetadataBasedOnName;
 
       if (!fieldMetadata) {
         continue;


### PR DESCRIPTION
Issue introduced by [Restrict queried columns to graphql-requested fields](https://github.com/twentyhq/twenty/pull/13246)
In this query 

```ts
{
  ...
  name 
  messageId
  message {
    id
  } 
}
```

`messageId` was being filtered out from the selected fields as we failed to link it to an existing field, thus null was always returned.
`message { id }` worked because we already handled connections correctly.

