### PR TITLE
Removed box shadow on draggable cards (used in kanbans)

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-board/record-board-card/components/RecordBoardCard.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/record-board-card/components/RecordBoardCard.tsx
@@ -35,7 +35,6 @@ const StyledBoardCard = styled.div<{
   background-color: ${({ theme }) => theme.background.secondary};
   border: 1px solid ${({ theme }) => theme.border.color.medium};
   border-radius: ${({ theme }) => theme.border.radius.sm};
-  box-shadow: ${({ theme }) => theme.boxShadow.light};
   color: ${({ theme }) => theme.font.color.primary};
   cursor: pointer;
 


### PR DESCRIPTION
Before

<img width="1788" height="1318" alt="CleanShot 2025-07-17 at 18 53 36@2x" src="https://github.com/user-attachments/assets/772e7cda-86da-4fa3-8107-d06f821da85b" />

After

<img width="1488" height="1164" alt="CleanShot 2025-07-17 at 18 54 04@2x" src="https://github.com/user-attachments/assets/716a559f-3afb-4759-a8e7-23c6c9421908" />
