### PR TITLE
Connect/Disconnect - Add Disconnect logic + Migration to query builders (insert/update)

### DIFF
--- a/package.json
+++ b/package.json
@@ -355,7 +355,7 @@
   "name": "twenty",
   "packageManager": "yarn@4.9.2",
   "resolutions": {
-    "graphql": "16.8.0",
+    "graphql": "16.9.0",
     "type-fest": "4.10.1",
     "typescript": "5.3.3",
     "graphql-redis-subscriptions/ioredis": "^5.6.0",

--- a/package.json
+++ b/package.json
@@ -355,7 +355,7 @@
   "name": "twenty",
   "packageManager": "yarn@4.9.2",
   "resolutions": {
-    "graphql": "16.9.0",
+    "graphql": "16.8.0",
     "type-fest": "4.10.1",
     "typescript": "5.3.3",
     "graphql-redis-subscriptions/ioredis": "^5.6.0",

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-create-many-resolver.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-create-many-resolver.service.ts
@@ -275,6 +275,7 @@ export class GraphqlQueryCreateManyResolverService extends GraphqlQueryBaseResol
 
         const existingRec = existingRecords.find(
           (existingRecord) =>
+            isDefined(existingRecord[field.column]) &&
             existingRecord[field.column] === requestFieldValue,
         );
 

--- a/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/factories/relation-connect-input-type-definition.factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/factories/relation-connect-input-type-definition.factory.ts
@@ -51,7 +51,6 @@ export class RelationConnectInputTypeDefinitionFactory {
   ): GraphQLInputObjectType {
     return new GraphQLInputObjectType({
       name: `${pascalCase(objectMetadata.nameSingular)}RelationInput`,
-      isOneOf: true,
       fields: () => ({
         [RELATION_NESTED_QUERY_KEYWORDS.CONNECT]: {
           type: new GraphQLInputObjectType({

--- a/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/factories/relation-connect-input-type-definition.factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/factories/relation-connect-input-type-definition.factory.ts
@@ -38,6 +38,11 @@ export class RelationConnectInputTypeDefinitionFactory {
         kind: InputTypeDefinitionKind.Create,
         type: fields,
       },
+      {
+        target,
+        kind: InputTypeDefinitionKind.Update,
+        type: fields,
+      },
     ];
   }
 

--- a/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/factories/relation-connect-input-type-definition.factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/factories/relation-connect-input-type-definition.factory.ts
@@ -1,11 +1,13 @@
 import { Injectable } from '@nestjs/common';
 
 import {
+  GraphQLBoolean,
   GraphQLInputFieldConfig,
   GraphQLInputObjectType,
   GraphQLInputType,
   GraphQLString,
 } from 'graphql';
+import { RELATION_NESTED_QUERY_KEYWORDS } from 'twenty-shared/constants';
 
 import {
   InputTypeDefinition,
@@ -44,13 +46,18 @@ export class RelationConnectInputTypeDefinitionFactory {
   ): GraphQLInputObjectType {
     return new GraphQLInputObjectType({
       name: `${pascalCase(objectMetadata.nameSingular)}RelationInput`,
+      isOneOf: true,
       fields: () => ({
-        connect: {
+        [RELATION_NESTED_QUERY_KEYWORDS.CONNECT]: {
           type: new GraphQLInputObjectType({
             name: `${pascalCase(objectMetadata.nameSingular)}ConnectInput`,
             fields: this.generateRelationWhereInputType(objectMetadata),
           }),
           description: `Connect to a ${objectMetadata.nameSingular} record`,
+        },
+        [RELATION_NESTED_QUERY_KEYWORDS.DISCONNECT]: {
+          type: GraphQLBoolean,
+          description: `Disconnect from a ${objectMetadata.nameSingular} record`,
         },
       }),
     });
@@ -127,7 +134,7 @@ export class RelationConnectInputTypeDefinitionFactory {
     });
 
     return {
-      where: {
+      [RELATION_NESTED_QUERY_KEYWORDS.CONNECT_WHERE]: {
         type: new GraphQLInputObjectType({
           name: `${pascalCase(objectMetadata.nameSingular)}WhereUniqueInput`,
           fields: () => fields,

--- a/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/utils/generate-fields.utils.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/utils/generate-fields.utils.ts
@@ -200,7 +200,7 @@ const generateRelationField = <
   };
 
   if (
-    [InputTypeDefinitionKind.Create].includes(
+    [InputTypeDefinitionKind.Create, InputTypeDefinitionKind.Update].includes(
       kind as InputTypeDefinitionKind,
     ) &&
     isDefined(fieldMetadata.relationTargetObjectMetadataId)

--- a/packages/twenty-server/src/engine/twenty-orm/entity-manager/types/query-deep-partial-entity-with-relation-connect.type.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/entity-manager/types/query-deep-partial-entity-with-relation-connect.type.ts
@@ -1,3 +1,4 @@
+import { RELATION_NESTED_QUERY_KEYWORDS } from 'twenty-shared/constants';
 import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 
 import { BaseWorkspaceEntity } from 'src/engine/twenty-orm/base.workspace-entity';
@@ -7,9 +8,13 @@ export type ConnectWhereValue = string | Record<string, string>;
 export type ConnectWhere = Record<string, ConnectWhereValue>;
 
 export type ConnectObject = {
-  connect: {
-    where: ConnectWhere;
+  [RELATION_NESTED_QUERY_KEYWORDS.CONNECT]: {
+    [RELATION_NESTED_QUERY_KEYWORDS.CONNECT_WHERE]: ConnectWhere;
   };
+};
+
+export type DisconnectObject = {
+  [RELATION_NESTED_QUERY_KEYWORDS.DISCONNECT]: true;
 };
 
 type EntityRelationFields<T> = {
@@ -21,6 +26,6 @@ export type QueryDeepPartialEntityWithRelationConnect<T> = Omit<
   EntityRelationFields<T>
 > & {
   [K in keyof T]?: T[K] extends BaseWorkspaceEntity | null
-    ? T[K] | ConnectObject
+    ? T[K] | ConnectObject | DisconnectObject
     : T[K];
 };

--- a/packages/twenty-server/src/engine/twenty-orm/entity-manager/types/query-deep-partial-entity-with-relation-connect.type.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/entity-manager/types/query-deep-partial-entity-with-relation-connect.type.ts
@@ -21,7 +21,7 @@ type EntityRelationFields<T> = {
   [K in keyof T]: T[K] extends BaseWorkspaceEntity | null ? K : never;
 }[keyof T];
 
-export type QueryDeepPartialEntityWithRelationConnect<T> = Omit<
+export type QueryDeepPartialEntityWithNestedRelationFields<T> = Omit<
   QueryDeepPartialEntity<T>,
   EntityRelationFields<T>
 > & {

--- a/packages/twenty-server/src/engine/twenty-orm/entity-manager/types/relation-nested-query-fields-by-entity-index.type.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/entity-manager/types/relation-nested-query-fields-by-entity-index.type.ts
@@ -1,15 +1,14 @@
-import { RELATION_NESTED_QUERY_KEYWORDS } from 'twenty-shared/constants';
-
 import {
   ConnectObject,
   DisconnectObject,
 } from 'src/engine/twenty-orm/entity-manager/types/query-deep-partial-entity-with-relation-connect.type';
 
-export type RelationNestedQueryFieldsByEntityIndex = {
+export type RelationConnectQueryFieldsByEntityIndex = {
+  [entityIndex: string]: { [key: string]: ConnectObject };
+};
+
+export type RelationDisconnectQueryFieldsByEntityIndex = {
   [entityIndex: string]: {
-    [RELATION_NESTED_QUERY_KEYWORDS.CONNECT]?: { [key: string]: ConnectObject };
-    [RELATION_NESTED_QUERY_KEYWORDS.DISCONNECT]?: {
-      [key: string]: DisconnectObject;
-    };
+    [key: string]: DisconnectObject;
   };
 };

--- a/packages/twenty-server/src/engine/twenty-orm/entity-manager/types/relation-nested-query-fields-by-entity-index.type.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/entity-manager/types/relation-nested-query-fields-by-entity-index.type.ts
@@ -1,0 +1,15 @@
+import { RELATION_NESTED_QUERY_KEYWORDS } from 'twenty-shared/constants';
+
+import {
+  ConnectObject,
+  DisconnectObject,
+} from 'src/engine/twenty-orm/entity-manager/types/query-deep-partial-entity-with-relation-connect.type';
+
+export type RelationNestedQueryFieldsByEntityIndex = {
+  [entityIndex: string]: {
+    [RELATION_NESTED_QUERY_KEYWORDS.CONNECT]?: { [key: string]: ConnectObject };
+    [RELATION_NESTED_QUERY_KEYWORDS.DISCONNECT]?: {
+      [key: string]: DisconnectObject;
+    };
+  };
+};

--- a/packages/twenty-server/src/engine/twenty-orm/entity-manager/workspace-entity-manager.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/entity-manager/workspace-entity-manager.ts
@@ -1493,6 +1493,7 @@ export class WorkspaceEntityManager extends EntityManager {
     entities: QueryDeepPartialEntityWithRelationConnect<Entity>[],
     target: EntityTarget<Entity>,
     permissionOptions?: PermissionOptions,
+    queryRunner?: QueryRunner,
   ): Promise<QueryDeepPartialEntity<Entity>[]> {
     const nestedRelationQueryFieldsByEntityIndex =
       extractNestedRelationFieldsByEntityIndex(entities);
@@ -1507,6 +1508,7 @@ export class WorkspaceEntityManager extends EntityManager {
       target,
       permissionOptions,
       nestedRelationQueryFieldsByEntityIndex,
+      queryRunner,
     });
 
     return updatedEntitiesWithConnect;
@@ -1517,11 +1519,13 @@ export class WorkspaceEntityManager extends EntityManager {
     target,
     permissionOptions,
     nestedRelationQueryFieldsByEntityIndex,
+    queryRunner,
   }: {
     entities: QueryDeepPartialEntityWithRelationConnect<Entity>[];
     target: EntityTarget<Entity>;
     permissionOptions?: PermissionOptions;
     nestedRelationQueryFieldsByEntityIndex: RelationNestedQueryFieldsByEntityIndex;
+    queryRunner?: QueryRunner;
   }): Promise<QueryDeepPartialEntity<Entity>[]> {
     const objectMetadata = getObjectMetadataFromEntityTarget(
       target,
@@ -1542,6 +1546,7 @@ export class WorkspaceEntityManager extends EntityManager {
     const recordsToConnectWithConfig = await this.executeConnectQueries(
       relationConnectQueryConfigs,
       permissionOptions,
+      queryRunner,
     );
 
     const updatedEntities = this.updateEntitiesWithRecordToConnectId<Entity>(
@@ -1555,6 +1560,7 @@ export class WorkspaceEntityManager extends EntityManager {
   private async executeConnectQueries(
     relationConnectQueryConfigs: Record<string, RelationConnectQueryConfig>,
     permissionOptions?: PermissionOptions,
+    queryRunner?: QueryRunner,
   ): Promise<[RelationConnectQueryConfig, Record<string, unknown>[]][]> {
     const AllRecordsToConnectWithConfig: [
       RelationConnectQueryConfig,
@@ -1572,7 +1578,7 @@ export class WorkspaceEntityManager extends EntityManager {
       const recordsToConnect = await this.createQueryBuilder(
         connectQueryConfig.targetObjectName,
         connectQueryConfig.targetObjectName,
-        undefined,
+        queryRunner,
         permissionOptions,
       )
         .select(getRecordToConnectFields(connectQueryConfig))

--- a/packages/twenty-server/src/engine/twenty-orm/relation-nested-queries/relation-nested-queries.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/relation-nested-queries/relation-nested-queries.ts
@@ -1,0 +1,263 @@
+import { isDefined } from 'class-validator';
+import { RELATION_NESTED_QUERY_KEYWORDS } from 'twenty-shared/constants';
+import { ObjectRecordsPermissions } from 'twenty-shared/types';
+import { EntityTarget, ObjectLiteral, QueryRunner } from 'typeorm';
+import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
+
+import { WorkspaceInternalContext } from 'src/engine/twenty-orm/interfaces/workspace-internal-context.interface';
+
+import { QueryDeepPartialEntityWithRelationConnect } from 'src/engine/twenty-orm/entity-manager/types/query-deep-partial-entity-with-relation-connect.type';
+import { RelationConnectQueryConfig } from 'src/engine/twenty-orm/entity-manager/types/relation-connect-query-config.type';
+import {
+  RelationConnectQueryFieldsByEntityIndex,
+  RelationDisconnectQueryFieldsByEntityIndex,
+} from 'src/engine/twenty-orm/entity-manager/types/relation-nested-query-fields-by-entity-index.type';
+import { WorkspaceEntityManager } from 'src/engine/twenty-orm/entity-manager/workspace-entity-manager';
+import {
+  TwentyORMException,
+  TwentyORMExceptionCode,
+} from 'src/engine/twenty-orm/exceptions/twenty-orm.exception';
+import { computeRelationConnectQueryConfigs } from 'src/engine/twenty-orm/utils/compute-relation-connect-query-configs.util';
+import { createSqlWhereTupleInClause } from 'src/engine/twenty-orm/utils/create-sql-where-tuple-in-clause.utils';
+import { extractNestedRelationFieldsByEntityIndex } from 'src/engine/twenty-orm/utils/extract-nested-relation-fields-by-entity-index.util';
+import { getAssociatedRelationFieldName } from 'src/engine/twenty-orm/utils/get-associated-relation-field-name.util';
+import { getObjectMetadataFromEntityTarget } from 'src/engine/twenty-orm/utils/get-object-metadata-from-entity-target.util';
+import { getRecordToConnectFields } from 'src/engine/twenty-orm/utils/get-record-to-connect-fields.util';
+
+export class RelationNestedQueries {
+  private readonly queryRunner?: QueryRunner;
+  private readonly internalContext: WorkspaceInternalContext;
+  private readonly workspaceEntityManager: WorkspaceEntityManager;
+
+  constructor(
+    internalContext: WorkspaceInternalContext,
+    workspaceEntityManager: WorkspaceEntityManager,
+    queryRunner?: QueryRunner,
+  ) {
+    this.queryRunner = queryRunner;
+    this.internalContext = internalContext;
+    this.workspaceEntityManager = workspaceEntityManager;
+  }
+
+  prepareNestedRelationQueries<Entity extends ObjectLiteral>(
+    entities:
+      | QueryDeepPartialEntityWithRelationConnect<Entity>[]
+      | QueryDeepPartialEntityWithRelationConnect<Entity>,
+    target: EntityTarget<Entity>,
+  ) {
+    const entitiesArray = Array.isArray(entities) ? entities : [entities];
+
+    const {
+      relationConnectQueryFieldsByEntityIndex,
+      relationDisconnectQueryFieldsByEntityIndex,
+    } = extractNestedRelationFieldsByEntityIndex(entitiesArray);
+
+    const connectConfig = this.prepareRelationConnect(
+      entitiesArray,
+      target,
+      relationConnectQueryFieldsByEntityIndex,
+    );
+
+    return {
+      disconnectConfig: relationDisconnectQueryFieldsByEntityIndex,
+      connectConfig,
+    };
+  }
+
+  private prepareRelationConnect<Entity extends ObjectLiteral>(
+    entities: QueryDeepPartialEntityWithRelationConnect<Entity>[],
+    target: EntityTarget<Entity>,
+    relationConnectQueryFieldsByEntityIndex: RelationConnectQueryFieldsByEntityIndex,
+  ) {
+    const objectMetadata = getObjectMetadataFromEntityTarget(
+      target,
+      this.internalContext,
+    );
+
+    const objectMetadataMap = this.internalContext.objectMetadataMaps;
+
+    const relationConnectQueryConfigs = computeRelationConnectQueryConfigs(
+      entities,
+      objectMetadata,
+      objectMetadataMap,
+      relationConnectQueryFieldsByEntityIndex,
+    );
+
+    return relationConnectQueryConfigs;
+  }
+
+  async processRelationNestedQueries<Entity extends ObjectLiteral>(
+    entities:
+      | QueryDeepPartialEntityWithRelationConnect<Entity>[]
+      | QueryDeepPartialEntityWithRelationConnect<Entity>,
+    relationDisconnectQueryFieldsByEntityIndex: RelationDisconnectQueryFieldsByEntityIndex,
+    relationConnectQueryConfigs: Record<string, RelationConnectQueryConfig>,
+    permissionOptions?: {
+      shouldBypassPermissionChecks?: boolean;
+      objectRecordsPermissions?: ObjectRecordsPermissions;
+    },
+    queryRunner?: QueryRunner,
+  ): Promise<QueryDeepPartialEntity<Entity>[]> {
+    const entitiesArray = Array.isArray(entities) ? entities : [entities];
+
+    const updatedEntitiesWithDisconnect = this.processRelationDisconnect({
+      entities: entitiesArray,
+      relationDisconnectQueryFieldsByEntityIndex,
+    });
+
+    const updatedEntitiesWithConnect = await this.processRelationConnect({
+      entities: updatedEntitiesWithDisconnect,
+      permissionOptions,
+      relationConnectQueryConfigs,
+      queryRunner,
+    });
+
+    return updatedEntitiesWithConnect;
+  }
+
+  private async processRelationConnect<Entity extends ObjectLiteral>({
+    entities,
+    relationConnectQueryConfigs,
+    permissionOptions,
+    queryRunner,
+  }: {
+    entities: QueryDeepPartialEntityWithRelationConnect<Entity>[];
+    relationConnectQueryConfigs: Record<string, RelationConnectQueryConfig>;
+    permissionOptions?: {
+      shouldBypassPermissionChecks?: boolean;
+      objectRecordsPermissions?: ObjectRecordsPermissions;
+    };
+    queryRunner?: QueryRunner;
+  }): Promise<QueryDeepPartialEntity<Entity>[]> {
+    if (!isDefined(relationConnectQueryConfigs)) return entities;
+
+    const recordsToConnectWithConfig = await this.executeConnectQueries(
+      relationConnectQueryConfigs,
+      permissionOptions,
+      queryRunner,
+    );
+
+    const updatedEntities = this.updateEntitiesWithRecordToConnectId<Entity>(
+      entities,
+      recordsToConnectWithConfig,
+    );
+
+    return updatedEntities;
+  }
+
+  private async executeConnectQueries(
+    relationConnectQueryConfigs: Record<string, RelationConnectQueryConfig>,
+    permissionOptions?: {
+      shouldBypassPermissionChecks?: boolean;
+      objectRecordsPermissions?: ObjectRecordsPermissions;
+    },
+    queryRunner?: QueryRunner,
+  ): Promise<[RelationConnectQueryConfig, Record<string, unknown>[]][]> {
+    const AllRecordsToConnectWithConfig: [
+      RelationConnectQueryConfig,
+      Record<string, unknown>[],
+    ][] = [];
+
+    for (const connectQueryConfig of Object.values(
+      relationConnectQueryConfigs,
+    )) {
+      const { clause, parameters } = createSqlWhereTupleInClause(
+        connectQueryConfig.recordToConnectConditions,
+        connectQueryConfig.targetObjectName,
+      );
+
+      const recordsToConnect = await this.workspaceEntityManager
+        .createQueryBuilder(
+          connectQueryConfig.targetObjectName,
+          connectQueryConfig.targetObjectName,
+          queryRunner,
+          permissionOptions,
+        )
+        .select(getRecordToConnectFields(connectQueryConfig))
+        .where(clause, parameters)
+        .getRawMany();
+
+      AllRecordsToConnectWithConfig.push([
+        connectQueryConfig,
+        recordsToConnect,
+      ]);
+    }
+
+    return AllRecordsToConnectWithConfig;
+  }
+
+  private updateEntitiesWithRecordToConnectId<Entity extends ObjectLiteral>(
+    entities: QueryDeepPartialEntityWithRelationConnect<Entity>[],
+    recordsToConnectWithConfig: [
+      RelationConnectQueryConfig,
+      Record<string, unknown>[],
+    ][],
+  ): QueryDeepPartialEntity<Entity>[] {
+    return entities.map((entity, index) => {
+      for (const [
+        connectQueryConfig,
+        recordsToConnect,
+      ] of recordsToConnectWithConfig) {
+        if (
+          isDefined(
+            connectQueryConfig.recordToConnectConditionByEntityIndex[index],
+          )
+        ) {
+          const recordToConnect = recordsToConnect.filter((record) =>
+            connectQueryConfig.recordToConnectConditionByEntityIndex[
+              index
+            ].every(([field, value]) => record[field] === value),
+          );
+
+          if (recordToConnect.length !== 1) {
+            const recordToConnectTotal = recordToConnect.length;
+            const connectFieldName = connectQueryConfig.connectFieldName;
+
+            throw new TwentyORMException(
+              `Expected 1 record to connect to ${connectFieldName}, but found ${recordToConnectTotal}.`,
+              TwentyORMExceptionCode.CONNECT_RECORD_NOT_FOUND,
+            );
+          }
+
+          entity = {
+            ...entity,
+            [connectQueryConfig.relationFieldName]: recordToConnect[0]['id'],
+            [connectQueryConfig.connectFieldName]: null,
+          };
+        }
+      }
+
+      return entity;
+    });
+  }
+
+  private processRelationDisconnect<Entity extends ObjectLiteral>({
+    entities,
+    relationDisconnectQueryFieldsByEntityIndex,
+  }: {
+    entities: QueryDeepPartialEntityWithRelationConnect<Entity>[];
+    relationDisconnectQueryFieldsByEntityIndex: RelationDisconnectQueryFieldsByEntityIndex;
+  }): QueryDeepPartialEntityWithRelationConnect<Entity>[] {
+    return entities.map((entity, index) => {
+      const nestedRelationDisconnectFields =
+        relationDisconnectQueryFieldsByEntityIndex[index];
+
+      if (!isDefined(nestedRelationDisconnectFields)) return entity;
+
+      for (const [disconnectFieldName, disconnectObject] of Object.entries(
+        nestedRelationDisconnectFields ?? {},
+      )) {
+        entity = {
+          ...entity,
+          [disconnectFieldName]: null,
+          ...(disconnectObject[RELATION_NESTED_QUERY_KEYWORDS.DISCONNECT] ===
+          true
+            ? { [getAssociatedRelationFieldName(disconnectFieldName)]: null }
+            : {}),
+        };
+      }
+
+      return entity;
+    });
+  }
+}

--- a/packages/twenty-server/src/engine/twenty-orm/relation-nested-queries/relation-nested-queries.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/relation-nested-queries/relation-nested-queries.ts
@@ -121,7 +121,7 @@ export class RelationNestedQueries {
     relationConnectQueryConfigs: RelationConnectQueryConfig[];
     queryBuilder: WorkspaceSelectQueryBuilder<Entity>;
   }): Promise<QueryDeepPartialEntity<Entity>[]> {
-    if (!isDefined(relationConnectQueryConfigs)) return entities;
+    if (relationConnectQueryConfigs.length === 0) return entities;
 
     const recordsToConnectWithConfig = await this.executeConnectQueries(
       relationConnectQueryConfigs,
@@ -140,7 +140,7 @@ export class RelationNestedQueries {
     relationConnectQueryConfigs: RelationConnectQueryConfig[],
     queryBuilder: WorkspaceSelectQueryBuilder<Entity>,
   ): Promise<[RelationConnectQueryConfig, Record<string, unknown>[]][]> {
-    const AllRecordsToConnectWithConfig: [
+    const allRecordsToConnectWithConfig: [
       RelationConnectQueryConfig,
       Record<string, unknown>[],
     ][] = [];
@@ -163,13 +163,13 @@ export class RelationNestedQueries {
         )
         .getRawMany();
 
-      AllRecordsToConnectWithConfig.push([
+      allRecordsToConnectWithConfig.push([
         connectQueryConfig,
         recordsToConnect,
       ]);
     }
 
-    return AllRecordsToConnectWithConfig;
+    return allRecordsToConnectWithConfig;
   }
 
   private updateEntitiesWithRecordToConnectId<Entity extends ObjectLiteral>(

--- a/packages/twenty-server/src/engine/twenty-orm/repository/workspace-insert-query-builder.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/repository/workspace-insert-query-builder.ts
@@ -38,8 +38,10 @@ export class WorkspaceInsertQueryBuilder<
   private authContext?: AuthContext;
   private featureFlagMap?: FeatureFlagMap;
   private relationNestedQueries: RelationNestedQueries;
-  private connectConfig: Record<string, RelationConnectQueryConfig>;
-  private disconnectConfig: RelationDisconnectQueryFieldsByEntityIndex;
+  private relationNestedConfig: [
+    RelationConnectQueryConfig[],
+    RelationDisconnectQueryFieldsByEntityIndex,
+  ];
 
   constructor(
     queryBuilder: InsertQueryBuilder<T>,
@@ -80,14 +82,11 @@ export class WorkspaceInsertQueryBuilder<
   ): this {
     const mainAliasTarget = this.getMainAliasTarget();
 
-    const { disconnectConfig, connectConfig } =
+    this.relationNestedConfig =
       this.relationNestedQueries.prepareNestedRelationQueries(
         values,
         mainAliasTarget,
       );
-
-    this.disconnectConfig = disconnectConfig;
-    this.connectConfig = connectConfig;
 
     const objectMetadata = getObjectMetadataFromEntityTarget(
       mainAliasTarget,
@@ -129,8 +128,7 @@ export class WorkspaceInsertQueryBuilder<
         entities: this.expressionMap.valuesSet as
           | QueryDeepPartialEntityWithNestedRelationFields<T>
           | QueryDeepPartialEntityWithNestedRelationFields<T>[],
-        relationDisconnectQueryFieldsByEntityIndex: this.disconnectConfig,
-        relationConnectQueryConfigs: this.connectConfig,
+        relationNestedConfig: this.relationNestedConfig,
         queryBuilder,
       });
 

--- a/packages/twenty-server/src/engine/twenty-orm/repository/workspace-insert-query-builder.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/repository/workspace-insert-query-builder.ts
@@ -115,7 +115,7 @@ export class WorkspaceInsertQueryBuilder<
       this.internalContext,
     );
 
-    const queryBuilder = new WorkspaceSelectQueryBuilder(
+    const nestedRelationQueryBuilder = new WorkspaceSelectQueryBuilder(
       this as unknown as WorkspaceSelectQueryBuilder<T>,
       this.objectRecordsPermissions,
       this.internalContext,
@@ -129,7 +129,7 @@ export class WorkspaceInsertQueryBuilder<
           | QueryDeepPartialEntityWithNestedRelationFields<T>
           | QueryDeepPartialEntityWithNestedRelationFields<T>[],
         relationNestedConfig: this.relationNestedConfig,
-        queryBuilder,
+        queryBuilder: nestedRelationQueryBuilder,
       });
 
     this.expressionMap.valuesSet = updatedValues;

--- a/packages/twenty-server/src/engine/twenty-orm/repository/workspace-update-query-builder.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/repository/workspace-update-query-builder.ts
@@ -164,7 +164,6 @@ export class WorkspaceUpdateQueryBuilder<
     };
   }
 
-  //tododo : fix all typing issues
   override set(
     _values:
       | QueryDeepPartialEntityWithNestedRelationFields<T>

--- a/packages/twenty-server/src/engine/twenty-orm/repository/workspace-update-query-builder.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/repository/workspace-update-query-builder.ts
@@ -13,10 +13,14 @@ import { WorkspaceInternalContext } from 'src/engine/twenty-orm/interfaces/works
 import { DatabaseEventAction } from 'src/engine/api/graphql/graphql-query-runner/enums/database-event-action';
 import { AuthContext } from 'src/engine/core-modules/auth/types/auth-context.type';
 import { FeatureFlagKey } from 'src/engine/core-modules/feature-flag/enums/feature-flag-key.enum';
+import { QueryDeepPartialEntityWithNestedRelationFields } from 'src/engine/twenty-orm/entity-manager/types/query-deep-partial-entity-with-relation-connect.type';
+import { RelationConnectQueryConfig } from 'src/engine/twenty-orm/entity-manager/types/relation-connect-query-config.type';
+import { RelationDisconnectQueryFieldsByEntityIndex } from 'src/engine/twenty-orm/entity-manager/types/relation-nested-query-fields-by-entity-index.type';
 import {
   TwentyORMException,
   TwentyORMExceptionCode,
 } from 'src/engine/twenty-orm/exceptions/twenty-orm.exception';
+import { RelationNestedQueries } from 'src/engine/twenty-orm/relation-nested-queries/relation-nested-queries';
 import { validateQueryIsPermittedOrThrow } from 'src/engine/twenty-orm/repository/permissions.utils';
 import { WorkspaceDeleteQueryBuilder } from 'src/engine/twenty-orm/repository/workspace-delete-query-builder';
 import { WorkspaceSelectQueryBuilder } from 'src/engine/twenty-orm/repository/workspace-select-query-builder';
@@ -33,6 +37,10 @@ export class WorkspaceUpdateQueryBuilder<
   private internalContext: WorkspaceInternalContext;
   private authContext?: AuthContext;
   private featureFlagMap?: FeatureFlagMap;
+  private relationNestedQueries: RelationNestedQueries;
+  private connectConfig: Record<string, RelationConnectQueryConfig>;
+  private disconnectConfig: RelationDisconnectQueryFieldsByEntityIndex;
+
   constructor(
     queryBuilder: UpdateQueryBuilder<T>,
     objectRecordsPermissions: ObjectRecordsPermissions,
@@ -47,13 +55,16 @@ export class WorkspaceUpdateQueryBuilder<
     this.shouldBypassPermissionChecks = shouldBypassPermissionChecks;
     this.authContext = authContext;
     this.featureFlagMap = featureFlagMap;
+    this.relationNestedQueries = new RelationNestedQueries(
+      this.internalContext,
+    );
   }
 
   override clone(): this {
     const clonedQueryBuilder = super.clone();
 
     return new WorkspaceUpdateQueryBuilder(
-      clonedQueryBuilder,
+      clonedQueryBuilder as UpdateQueryBuilder<T>,
       this.objectRecordsPermissions,
       this.internalContext,
       this.shouldBypassPermissionChecks,
@@ -94,6 +105,28 @@ export class WorkspaceUpdateQueryBuilder<
 
     const before = await eventSelectQueryBuilder.getMany();
 
+    const nestedRelationQueryBuilder = new WorkspaceSelectQueryBuilder(
+      this as unknown as WorkspaceSelectQueryBuilder<T>,
+      this.objectRecordsPermissions,
+      this.internalContext,
+      this.shouldBypassPermissionChecks,
+      this.authContext,
+    );
+
+    const updatedValues =
+      await this.relationNestedQueries.processRelationNestedQueries({
+        entities: this.expressionMap.valuesSet as
+          | QueryDeepPartialEntityWithNestedRelationFields<T>
+          | QueryDeepPartialEntityWithNestedRelationFields<T>[],
+        relationDisconnectQueryFieldsByEntityIndex: this.disconnectConfig,
+        relationConnectQueryConfigs: this.connectConfig,
+        queryBuilder: nestedRelationQueryBuilder,
+      });
+
+    this.expressionMap.valuesSet = Array.isArray(updatedValues)
+      ? updatedValues[0]
+      : updatedValues;
+
     const formattedBefore = formatResult<T[]>(
       before,
       objectMetadata,
@@ -131,7 +164,22 @@ export class WorkspaceUpdateQueryBuilder<
     };
   }
 
-  override set(_values: QueryDeepPartialEntity<T>): this {
+  //tododo : fix all typing issues
+  override set(
+    _values:
+      | QueryDeepPartialEntityWithNestedRelationFields<T>
+      | QueryDeepPartialEntityWithNestedRelationFields<T>[],
+  ): this;
+
+  override set(_values: QueryDeepPartialEntity<T>): this;
+
+  override set(
+    _values:
+      | QueryDeepPartialEntityWithNestedRelationFields<T>
+      | QueryDeepPartialEntityWithNestedRelationFields<T>[]
+      | QueryDeepPartialEntity<T>
+      | QueryDeepPartialEntity<T>[],
+  ): this {
     const mainAliasTarget = this.getMainAliasTarget();
 
     const objectMetadata = getObjectMetadataFromEntityTarget(
@@ -139,9 +187,21 @@ export class WorkspaceUpdateQueryBuilder<
       this.internalContext,
     );
 
+    const extendedValues = _values as
+      | QueryDeepPartialEntityWithNestedRelationFields<T>
+      | QueryDeepPartialEntityWithNestedRelationFields<T>[];
+    const { disconnectConfig, connectConfig } =
+      this.relationNestedQueries.prepareNestedRelationQueries(
+        extendedValues,
+        mainAliasTarget,
+      );
+
+    this.disconnectConfig = disconnectConfig;
+    this.connectConfig = connectConfig;
+
     const formattedUpdateSet = formatData(_values, objectMetadata);
 
-    return super.set(formattedUpdateSet);
+    return super.set(formattedUpdateSet as QueryDeepPartialEntity<T>);
   }
 
   override select(): WorkspaceSelectQueryBuilder<T> {

--- a/packages/twenty-server/src/engine/twenty-orm/repository/workspace-update-query-builder.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/repository/workspace-update-query-builder.ts
@@ -124,9 +124,8 @@ export class WorkspaceUpdateQueryBuilder<
         queryBuilder: nestedRelationQueryBuilder,
       });
 
-    this.expressionMap.valuesSet = Array.isArray(updatedValues)
-      ? updatedValues[0]
-      : updatedValues;
+    this.expressionMap.valuesSet =
+      updatedValues.length === 1 ? updatedValues[0] : updatedValues;
 
     const formattedBefore = formatResult<T[]>(
       before,

--- a/packages/twenty-server/src/engine/twenty-orm/repository/workspace-update-query-builder.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/repository/workspace-update-query-builder.ts
@@ -38,8 +38,10 @@ export class WorkspaceUpdateQueryBuilder<
   private authContext?: AuthContext;
   private featureFlagMap?: FeatureFlagMap;
   private relationNestedQueries: RelationNestedQueries;
-  private connectConfig: Record<string, RelationConnectQueryConfig>;
-  private disconnectConfig: RelationDisconnectQueryFieldsByEntityIndex;
+  private relationNestedConfig: [
+    RelationConnectQueryConfig[],
+    RelationDisconnectQueryFieldsByEntityIndex,
+  ];
 
   constructor(
     queryBuilder: UpdateQueryBuilder<T>,
@@ -118,8 +120,7 @@ export class WorkspaceUpdateQueryBuilder<
         entities: this.expressionMap.valuesSet as
           | QueryDeepPartialEntityWithNestedRelationFields<T>
           | QueryDeepPartialEntityWithNestedRelationFields<T>[],
-        relationDisconnectQueryFieldsByEntityIndex: this.disconnectConfig,
-        relationConnectQueryConfigs: this.connectConfig,
+        relationNestedConfig: this.relationNestedConfig,
         queryBuilder: nestedRelationQueryBuilder,
       });
 
@@ -189,14 +190,12 @@ export class WorkspaceUpdateQueryBuilder<
     const extendedValues = _values as
       | QueryDeepPartialEntityWithNestedRelationFields<T>
       | QueryDeepPartialEntityWithNestedRelationFields<T>[];
-    const { disconnectConfig, connectConfig } =
+
+    this.relationNestedConfig =
       this.relationNestedQueries.prepareNestedRelationQueries(
         extendedValues,
         mainAliasTarget,
       );
-
-    this.disconnectConfig = disconnectConfig;
-    this.connectConfig = connectConfig;
 
     const formattedUpdateSet = formatData(_values, objectMetadata);
 

--- a/packages/twenty-server/src/engine/twenty-orm/repository/workspace.repository.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/repository/workspace.repository.ts
@@ -27,7 +27,7 @@ import {
   PermissionsException,
   PermissionsExceptionCode,
 } from 'src/engine/metadata-modules/permissions/permissions.exception';
-import { QueryDeepPartialEntityWithRelationConnect } from 'src/engine/twenty-orm/entity-manager/types/query-deep-partial-entity-with-relation-connect.type';
+import { QueryDeepPartialEntityWithNestedRelationFields } from 'src/engine/twenty-orm/entity-manager/types/query-deep-partial-entity-with-relation-connect.type';
 import { WorkspaceEntityManager } from 'src/engine/twenty-orm/entity-manager/workspace-entity-manager';
 import { WorkspaceSelectQueryBuilder } from 'src/engine/twenty-orm/repository/workspace-select-query-builder';
 import { formatData } from 'src/engine/twenty-orm/utils/format-data.util';
@@ -536,8 +536,8 @@ export class WorkspaceRepository<
    */
   override async insert(
     entity:
-      | QueryDeepPartialEntityWithRelationConnect<T>
-      | QueryDeepPartialEntityWithRelationConnect<T>[],
+      | QueryDeepPartialEntityWithNestedRelationFields<T>
+      | QueryDeepPartialEntityWithNestedRelationFields<T>[],
     entityManager?: WorkspaceEntityManager,
     selectedColumns?: string[],
   ): Promise<InsertResult> {

--- a/packages/twenty-server/src/engine/twenty-orm/utils/__tests__/compute-relation-connect-query-configs.util.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/__tests__/compute-relation-connect-query-configs.util.spec.ts
@@ -160,6 +160,7 @@ describe('computeRelationConnectQueryConfigs', () => {
       peopleEntityInputs,
       personMetadata,
       objectMetadataMaps,
+      {},
     );
 
     expect(result).toEqual({});
@@ -176,11 +177,20 @@ describe('computeRelationConnectQueryConfigs', () => {
       },
     ];
 
+    const nestedRelationQueryFieldsByEntityIndex = {
+      '0': {
+        connect: {
+          name: { connect: { where: { name: { lastName: 'Doe' } } } },
+        },
+      },
+    };
+
     expect(() => {
       computeRelationConnectQueryConfigs(
         peopleEntityInputs,
         personMetadata,
         objectMetadataMaps,
+        nestedRelationQueryFieldsByEntityIndex,
       );
     }).toThrow('Connect is not allowed for name on person');
   });
@@ -195,11 +205,20 @@ describe('computeRelationConnectQueryConfigs', () => {
       },
     ];
 
+    const nestedRelationQueryFieldsByEntityIndex = {
+      '0': {
+        connect: {
+          'company-related-to-1': { connect: { where: { name: 'company1' } } },
+        },
+      },
+    };
+
     expect(() => {
       computeRelationConnectQueryConfigs(
         peopleEntityInputs,
         personMetadata,
         objectMetadataMaps,
+        nestedRelationQueryFieldsByEntityIndex,
       );
     }).toThrow(
       "Missing required fields: at least one unique constraint have to be fully populated for 'company-related-to-1'.",
@@ -222,11 +241,28 @@ describe('computeRelationConnectQueryConfigs', () => {
       },
     ];
 
+    const nestedRelationQueryFieldsByEntityIndex = {
+      '0': {
+        connect: {
+          'company-related-to-1': {
+            connect: {
+              where: {
+                domainName: { primaryLinkUrl: 'company1.com' },
+                id: '1',
+                address: 'company1 address',
+              },
+            },
+          },
+        },
+      },
+    };
+
     expect(() => {
       computeRelationConnectQueryConfigs(
         peopleEntityInputs,
         personMetadata,
         objectMetadataMaps,
+        nestedRelationQueryFieldsByEntityIndex,
       );
     }).toThrow(
       "Field address is not a unique constraint field for 'company-related-to-1'.",
@@ -255,11 +291,31 @@ describe('computeRelationConnectQueryConfigs', () => {
       },
     ];
 
+    const nestedRelationQueryFieldsByEntityIndex = {
+      '0': {
+        connect: {
+          'company-related-to-1': {
+            connect: {
+              where: {
+                domainName: { primaryLinkUrl: 'company1.com' },
+              },
+            },
+          },
+        },
+      },
+      '1': {
+        connect: {
+          'company-related-to-1': { connect: { where: { id: '2' } } },
+        },
+      },
+    };
+
     expect(() => {
       computeRelationConnectQueryConfigs(
         peopleEntityInputs,
         personMetadata,
         objectMetadataMaps,
+        nestedRelationQueryFieldsByEntityIndex,
       );
     }).toThrow(
       'Expected the same constraint fields to be used consistently across all operations for company-related-to-1.',
@@ -298,10 +354,42 @@ describe('computeRelationConnectQueryConfigs', () => {
       },
     ];
 
+    const nestedRelationQueryFieldsByEntityIndex = {
+      '0': {
+        connect: {
+          'company-related-to-1': {
+            connect: {
+              where: { domainName: { primaryLinkUrl: 'company.com' } },
+            },
+          },
+          'company-related-to-2': {
+            connect: {
+              where: { id: '1' },
+            },
+          },
+        },
+      },
+      '1': {
+        connect: {
+          'company-related-to-1': {
+            connect: {
+              where: { domainName: { primaryLinkUrl: 'other-company.com' } },
+            },
+          },
+          'company-related-to-2': {
+            connect: {
+              where: { id: '2' },
+            },
+          },
+        },
+      },
+    };
+
     const result = computeRelationConnectQueryConfigs(
       peopleEntityInputs,
       personMetadata,
       objectMetadataMaps,
+      nestedRelationQueryFieldsByEntityIndex,
     );
 
     expect(result).toEqual({

--- a/packages/twenty-server/src/engine/twenty-orm/utils/__tests__/compute-relation-connect-query-configs.util.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/__tests__/compute-relation-connect-query-configs.util.spec.ts
@@ -177,11 +177,9 @@ describe('computeRelationConnectQueryConfigs', () => {
       },
     ];
 
-    const nestedRelationQueryFieldsByEntityIndex = {
+    const relationConnectQueryFieldsByEntityIndex = {
       '0': {
-        connect: {
-          name: { connect: { where: { name: { lastName: 'Doe' } } } },
-        },
+        name: { connect: { where: { name: { lastName: 'Doe' } } } },
       },
     };
 
@@ -190,7 +188,7 @@ describe('computeRelationConnectQueryConfigs', () => {
         peopleEntityInputs,
         personMetadata,
         objectMetadataMaps,
-        nestedRelationQueryFieldsByEntityIndex,
+        relationConnectQueryFieldsByEntityIndex,
       );
     }).toThrow('Connect is not allowed for name on person');
   });
@@ -205,11 +203,9 @@ describe('computeRelationConnectQueryConfigs', () => {
       },
     ];
 
-    const nestedRelationQueryFieldsByEntityIndex = {
+    const relationConnectQueryFieldsByEntityIndex = {
       '0': {
-        connect: {
-          'company-related-to-1': { connect: { where: { name: 'company1' } } },
-        },
+        'company-related-to-1': { connect: { where: { name: 'company1' } } },
       },
     };
 
@@ -218,7 +214,7 @@ describe('computeRelationConnectQueryConfigs', () => {
         peopleEntityInputs,
         personMetadata,
         objectMetadataMaps,
-        nestedRelationQueryFieldsByEntityIndex,
+        relationConnectQueryFieldsByEntityIndex,
       );
     }).toThrow(
       "Missing required fields: at least one unique constraint have to be fully populated for 'company-related-to-1'.",
@@ -241,16 +237,14 @@ describe('computeRelationConnectQueryConfigs', () => {
       },
     ];
 
-    const nestedRelationQueryFieldsByEntityIndex = {
+    const relationConnectQueryFieldsByEntityIndex = {
       '0': {
-        connect: {
-          'company-related-to-1': {
-            connect: {
-              where: {
-                domainName: { primaryLinkUrl: 'company1.com' },
-                id: '1',
-                address: 'company1 address',
-              },
+        'company-related-to-1': {
+          connect: {
+            where: {
+              domainName: { primaryLinkUrl: 'company1.com' },
+              id: '1',
+              address: 'company1 address',
             },
           },
         },
@@ -262,7 +256,7 @@ describe('computeRelationConnectQueryConfigs', () => {
         peopleEntityInputs,
         personMetadata,
         objectMetadataMaps,
-        nestedRelationQueryFieldsByEntityIndex,
+        relationConnectQueryFieldsByEntityIndex,
       );
     }).toThrow(
       "Field address is not a unique constraint field for 'company-related-to-1'.",
@@ -291,22 +285,18 @@ describe('computeRelationConnectQueryConfigs', () => {
       },
     ];
 
-    const nestedRelationQueryFieldsByEntityIndex = {
+    const relationConnectQueryFieldsByEntityIndex = {
       '0': {
-        connect: {
-          'company-related-to-1': {
-            connect: {
-              where: {
-                domainName: { primaryLinkUrl: 'company1.com' },
-              },
+        'company-related-to-1': {
+          connect: {
+            where: {
+              domainName: { primaryLinkUrl: 'company1.com' },
             },
           },
         },
       },
       '1': {
-        connect: {
-          'company-related-to-1': { connect: { where: { id: '2' } } },
-        },
+        'company-related-to-1': { connect: { where: { id: '2' } } },
       },
     };
 
@@ -315,7 +305,7 @@ describe('computeRelationConnectQueryConfigs', () => {
         peopleEntityInputs,
         personMetadata,
         objectMetadataMaps,
-        nestedRelationQueryFieldsByEntityIndex,
+        relationConnectQueryFieldsByEntityIndex,
       );
     }).toThrow(
       'Expected the same constraint fields to be used consistently across all operations for company-related-to-1.',
@@ -354,32 +344,28 @@ describe('computeRelationConnectQueryConfigs', () => {
       },
     ];
 
-    const nestedRelationQueryFieldsByEntityIndex = {
+    const relationConnectQueryFieldsByEntityIndex = {
       '0': {
-        connect: {
-          'company-related-to-1': {
-            connect: {
-              where: { domainName: { primaryLinkUrl: 'company.com' } },
-            },
+        'company-related-to-1': {
+          connect: {
+            where: { domainName: { primaryLinkUrl: 'company.com' } },
           },
-          'company-related-to-2': {
-            connect: {
-              where: { id: '1' },
-            },
+        },
+        'company-related-to-2': {
+          connect: {
+            where: { id: '1' },
           },
         },
       },
       '1': {
-        connect: {
-          'company-related-to-1': {
-            connect: {
-              where: { domainName: { primaryLinkUrl: 'other-company.com' } },
-            },
+        'company-related-to-1': {
+          connect: {
+            where: { domainName: { primaryLinkUrl: 'other-company.com' } },
           },
-          'company-related-to-2': {
-            connect: {
-              where: { id: '2' },
-            },
+        },
+        'company-related-to-2': {
+          connect: {
+            where: { id: '2' },
           },
         },
       },
@@ -389,7 +375,7 @@ describe('computeRelationConnectQueryConfigs', () => {
       peopleEntityInputs,
       personMetadata,
       objectMetadataMaps,
-      nestedRelationQueryFieldsByEntityIndex,
+      relationConnectQueryFieldsByEntityIndex,
     );
 
     expect(result).toEqual({

--- a/packages/twenty-server/src/engine/twenty-orm/utils/__tests__/compute-relation-connect-query-configs.util.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/__tests__/compute-relation-connect-query-configs.util.spec.ts
@@ -163,7 +163,7 @@ describe('computeRelationConnectQueryConfigs', () => {
       {},
     );
 
-    expect(result).toEqual({});
+    expect(result).toEqual([]);
   });
 
   it('should throw an error if a connect field is not a relation field', () => {
@@ -378,8 +378,8 @@ describe('computeRelationConnectQueryConfigs', () => {
       relationConnectQueryFieldsByEntityIndex,
     );
 
-    expect(result).toEqual({
-      'company-related-to-1': {
+    expect(result).toEqual([
+      {
         connectFieldName: 'company-related-to-1',
         recordToConnectConditions: [
           [['domainNamePrimaryLinkUrl', 'company.com']],
@@ -400,7 +400,7 @@ describe('computeRelationConnectQueryConfigs', () => {
           },
         ],
       },
-      'company-related-to-2': {
+      {
         connectFieldName: 'company-related-to-2',
         recordToConnectConditions: [[['id', '1']], [['id', '2']]],
         recordToConnectConditionByEntityIndex: {
@@ -418,6 +418,6 @@ describe('computeRelationConnectQueryConfigs', () => {
           },
         ],
       },
-    });
+    ]);
   });
 });

--- a/packages/twenty-server/src/engine/twenty-orm/utils/__tests__/create-sql-where-tuple-in-clause.util.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/__tests__/create-sql-where-tuple-in-clause.util.spec.ts
@@ -17,7 +17,7 @@ describe('createSqlWhereTupleInClause', () => {
     const result = createSqlWhereTupleInClause(conditions, tableName);
 
     expect(result.clause).toBe(
-      '(table_name.field1, table_name.field2) IN ((:value0_0, :value0_1), (:value1_0, :value1_1))',
+      '("table_name"."field1", "table_name"."field2") IN ((:value0_0, :value0_1), (:value1_0, :value1_1))',
     );
     expect(result.parameters).toEqual({
       value0_0: 'value1',

--- a/packages/twenty-server/src/engine/twenty-orm/utils/compute-relation-connect-query-configs.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/compute-relation-connect-query-configs.util.ts
@@ -1,6 +1,5 @@
 import { t } from '@lingui/core/macro';
 import deepEqual from 'deep-equal';
-import { RELATION_NESTED_QUERY_KEYWORDS } from 'twenty-shared/constants';
 import { FieldMetadataType } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 
@@ -17,7 +16,7 @@ import {
   RelationConnectQueryConfig,
   UniqueConstraintCondition,
 } from 'src/engine/twenty-orm/entity-manager/types/relation-connect-query-config.type';
-import { RelationNestedQueryFieldsByEntityIndex } from 'src/engine/twenty-orm/entity-manager/types/relation-nested-query-fields-by-entity-index.type';
+import { RelationConnectQueryFieldsByEntityIndex } from 'src/engine/twenty-orm/entity-manager/types/relation-nested-query-fields-by-entity-index.type';
 import {
   TwentyORMException,
   TwentyORMExceptionCode,
@@ -30,15 +29,13 @@ export const computeRelationConnectQueryConfigs = (
   entities: Record<string, unknown>[],
   objectMetadata: ObjectMetadataItemWithFieldMaps,
   objectMetadataMap: ObjectMetadataMaps,
-  nestedRelationQueryFieldsByEntityIndex: RelationNestedQueryFieldsByEntityIndex,
+  relationConnectQueryFieldsByEntityIndex: RelationConnectQueryFieldsByEntityIndex,
 ) => {
   const allConnectQueryConfigs: Record<string, RelationConnectQueryConfig> = {};
 
   for (const [entityIndex, entity] of entities.entries()) {
     const nestedRelationConnectFields =
-      nestedRelationQueryFieldsByEntityIndex[entityIndex]?.[
-        RELATION_NESTED_QUERY_KEYWORDS.CONNECT
-      ];
+      relationConnectQueryFieldsByEntityIndex[entityIndex];
 
     if (!isDefined(nestedRelationConnectFields)) continue;
 

--- a/packages/twenty-server/src/engine/twenty-orm/utils/compute-relation-connect-query-configs.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/compute-relation-connect-query-configs.util.ts
@@ -79,7 +79,7 @@ export const computeRelationConnectQueryConfigs = (
     }
   }
 
-  return allConnectQueryConfigs;
+  return Object.values(allConnectQueryConfigs);
 };
 
 const updateConnectQueryConfigs = (

--- a/packages/twenty-server/src/engine/twenty-orm/utils/compute-relation-connect-query-configs.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/compute-relation-connect-query-configs.util.ts
@@ -1,5 +1,6 @@
 import { t } from '@lingui/core/macro';
 import deepEqual from 'deep-equal';
+import { RELATION_NESTED_QUERY_KEYWORDS } from 'twenty-shared/constants';
 import { FieldMetadataType } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 
@@ -16,6 +17,7 @@ import {
   RelationConnectQueryConfig,
   UniqueConstraintCondition,
 } from 'src/engine/twenty-orm/entity-manager/types/relation-connect-query-config.type';
+import { RelationNestedQueryFieldsByEntityIndex } from 'src/engine/twenty-orm/entity-manager/types/relation-nested-query-fields-by-entity-index.type';
 import {
   TwentyORMException,
   TwentyORMExceptionCode,
@@ -28,19 +30,21 @@ export const computeRelationConnectQueryConfigs = (
   entities: Record<string, unknown>[],
   objectMetadata: ObjectMetadataItemWithFieldMaps,
   objectMetadataMap: ObjectMetadataMaps,
+  nestedRelationQueryFieldsByEntityIndex: RelationNestedQueryFieldsByEntityIndex,
 ) => {
   const allConnectQueryConfigs: Record<string, RelationConnectQueryConfig> = {};
 
   for (const [entityIndex, entity] of entities.entries()) {
-    const connectFields = extractConnectFields(entity);
+    const nestedRelationConnectFields =
+      nestedRelationQueryFieldsByEntityIndex[entityIndex]?.[
+        RELATION_NESTED_QUERY_KEYWORDS.CONNECT
+      ];
 
-    if (connectFields.length === 0) {
-      continue;
-    }
+    if (!isDefined(nestedRelationConnectFields)) continue;
 
-    for (const connectField of connectFields) {
-      const [connectFieldName, connectObject] = Object.entries(connectField)[0];
-
+    for (const [connectFieldName, connectObject] of Object.entries(
+      nestedRelationConnectFields,
+    )) {
       const {
         recordToConnectCondition,
         uniqueConstraintFields,
@@ -175,63 +179,6 @@ const computeRecordToConnectCondition = (
     uniqueConstraintFields,
     targetObjectNameSingular: targetObjectMetadata.nameSingular,
   };
-};
-
-const extractConnectFields = (
-  entity: Record<string, unknown>,
-): { [connectFieldName: string]: ConnectObject }[] => {
-  const connectFields: { [entityKey: string]: ConnectObject }[] = [];
-
-  for (const [key, value] of Object.entries(entity)) {
-    if (hasRelationConnect(value)) {
-      connectFields.push({ [key]: value });
-    }
-  }
-
-  return connectFields;
-};
-
-const hasRelationConnect = (value: unknown): value is ConnectObject => {
-  if (!isDefined(value) || typeof value !== 'object') {
-    return false;
-  }
-
-  const obj = value as Record<string, unknown>;
-
-  if (!isDefined(obj.connect) || typeof obj.connect !== 'object') {
-    return false;
-  }
-
-  const connect = obj.connect as Record<string, unknown>;
-
-  if (!isDefined(connect.where) || typeof connect.where !== 'object') {
-    return false;
-  }
-
-  const where = connect.where as Record<string, unknown>;
-
-  const whereKeys = Object.keys(where);
-
-  if (whereKeys.length === 0) {
-    return false;
-  }
-
-  return whereKeys.every((key) => {
-    const whereValue = where[key];
-
-    if (typeof whereValue === 'string') {
-      return true;
-    }
-    if (whereValue && typeof whereValue === 'object') {
-      const subObj = whereValue as Record<string, unknown>;
-
-      return Object.values(subObj).every(
-        (subValue) => typeof subValue === 'string',
-      );
-    }
-
-    return false;
-  });
 };
 
 const checkUniqueConstraintFullyPopulated = (

--- a/packages/twenty-server/src/engine/twenty-orm/utils/create-sql-where-tuple-in-clause.utils.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/create-sql-where-tuple-in-clause.utils.ts
@@ -5,7 +5,7 @@ export const createSqlWhereTupleInClause = (
   const fieldNames = conditions[0].map(([field, _]) => field);
 
   const tupleClause = fieldNames
-    .map((field) => `${tableName}.${field}`)
+    .map((field) => `"${tableName}"."${field}"`)
     .join(', ');
   const valuePlaceholders = conditions
     .map((_, index) => {

--- a/packages/twenty-server/src/engine/twenty-orm/utils/extract-nested-relation-fields-by-entity-index.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/extract-nested-relation-fields-by-entity-index.util.ts
@@ -5,7 +5,10 @@ import {
   ConnectObject,
   DisconnectObject,
 } from 'src/engine/twenty-orm/entity-manager/types/query-deep-partial-entity-with-relation-connect.type';
-import { RelationNestedQueryFieldsByEntityIndex } from 'src/engine/twenty-orm/entity-manager/types/relation-nested-query-fields-by-entity-index.type';
+import {
+  RelationConnectQueryFieldsByEntityIndex,
+  RelationDisconnectQueryFieldsByEntityIndex,
+} from 'src/engine/twenty-orm/entity-manager/types/relation-nested-query-fields-by-entity-index.type';
 import {
   TwentyORMException,
   TwentyORMExceptionCode,
@@ -82,8 +85,13 @@ const hasRelationDisconnect = (value: unknown): value is DisconnectObject => {
 
 export const extractNestedRelationFieldsByEntityIndex = (
   entities: Record<string, unknown>[],
-): RelationNestedQueryFieldsByEntityIndex => {
-  const nestedRelationQueryFieldsByEntityIndex: RelationNestedQueryFieldsByEntityIndex =
+): {
+  relationConnectQueryFieldsByEntityIndex: RelationConnectQueryFieldsByEntityIndex;
+  relationDisconnectQueryFieldsByEntityIndex: RelationDisconnectQueryFieldsByEntityIndex;
+} => {
+  const relationConnectQueryFieldsByEntityIndex: RelationConnectQueryFieldsByEntityIndex =
+    {};
+  const relationDisconnectQueryFieldsByEntityIndex: RelationDisconnectQueryFieldsByEntityIndex =
     {};
 
   for (const [entityIndex, entity] of Object.entries(entities)) {
@@ -98,30 +106,30 @@ export const extractNestedRelationFieldsByEntityIndex = (
         );
       }
 
-      const nestedRelationQueryFields =
-        nestedRelationQueryFieldsByEntityIndex?.[entityIndex] || {};
+      const relationConnectQueryFields =
+        relationConnectQueryFieldsByEntityIndex?.[entityIndex] || {};
 
       if (hasConnect) {
-        nestedRelationQueryFieldsByEntityIndex[entityIndex] = {
-          ...nestedRelationQueryFields,
-          connect: {
-            ...(nestedRelationQueryFields.connect || {}),
-            [key]: value,
-          },
+        relationConnectQueryFieldsByEntityIndex[entityIndex] = {
+          ...relationConnectQueryFields,
+          [key]: value,
         };
+      }
 
-        if (hasDisconnect) {
-          nestedRelationQueryFieldsByEntityIndex[entityIndex] = {
-            ...nestedRelationQueryFields,
-            disconnect: {
-              ...(nestedRelationQueryFields.disconnect || {}),
-              [key]: value,
-            },
-          };
-        }
+      const relationDisconnectQueryFields =
+        relationDisconnectQueryFieldsByEntityIndex?.[entityIndex] || {};
+
+      if (hasDisconnect) {
+        relationDisconnectQueryFieldsByEntityIndex[entityIndex] = {
+          ...relationDisconnectQueryFields,
+          [key]: value,
+        };
       }
     }
   }
 
-  return nestedRelationQueryFieldsByEntityIndex;
+  return {
+    relationConnectQueryFieldsByEntityIndex,
+    relationDisconnectQueryFieldsByEntityIndex,
+  };
 };

--- a/packages/twenty-server/src/engine/twenty-orm/utils/extract-nested-relation-fields-by-entity-index.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/extract-nested-relation-fields-by-entity-index.util.ts
@@ -1,0 +1,127 @@
+import { isDefined } from 'class-validator';
+import { RELATION_NESTED_QUERY_KEYWORDS } from 'twenty-shared/constants';
+
+import {
+  ConnectObject,
+  DisconnectObject,
+} from 'src/engine/twenty-orm/entity-manager/types/query-deep-partial-entity-with-relation-connect.type';
+import { RelationNestedQueryFieldsByEntityIndex } from 'src/engine/twenty-orm/entity-manager/types/relation-nested-query-fields-by-entity-index.type';
+import {
+  TwentyORMException,
+  TwentyORMExceptionCode,
+} from 'src/engine/twenty-orm/exceptions/twenty-orm.exception';
+
+const hasRelationConnect = (value: unknown): value is ConnectObject => {
+  if (!isDefined(value) || typeof value !== 'object') {
+    return false;
+  }
+
+  const obj = value as Record<string, unknown>;
+
+  if (
+    !isDefined(obj[RELATION_NESTED_QUERY_KEYWORDS.CONNECT]) ||
+    typeof obj[RELATION_NESTED_QUERY_KEYWORDS.CONNECT] !== 'object'
+  ) {
+    return false;
+  }
+
+  const connect = obj[RELATION_NESTED_QUERY_KEYWORDS.CONNECT] as Record<
+    string,
+    unknown
+  >;
+
+  if (
+    !isDefined(connect[RELATION_NESTED_QUERY_KEYWORDS.CONNECT_WHERE]) ||
+    typeof connect[RELATION_NESTED_QUERY_KEYWORDS.CONNECT_WHERE] !== 'object'
+  ) {
+    return false;
+  }
+
+  const where = connect[RELATION_NESTED_QUERY_KEYWORDS.CONNECT_WHERE] as Record<
+    string,
+    unknown
+  >;
+
+  const whereKeys = Object.keys(where);
+
+  if (whereKeys.length === 0) {
+    return false;
+  }
+
+  return whereKeys.every((key) => {
+    const whereValue = where[key];
+
+    if (typeof whereValue === 'string') {
+      return true;
+    }
+    if (whereValue && typeof whereValue === 'object') {
+      const subObj = whereValue as Record<string, unknown>;
+
+      return Object.values(subObj).every(
+        (subValue) => typeof subValue === 'string',
+      );
+    }
+
+    return false;
+  });
+};
+
+const hasRelationDisconnect = (value: unknown): value is DisconnectObject => {
+  if (!isDefined(value) || typeof value !== 'object') return false;
+
+  const obj = value as Record<string, unknown>;
+
+  if (
+    !isDefined(obj[RELATION_NESTED_QUERY_KEYWORDS.DISCONNECT]) ||
+    typeof obj[RELATION_NESTED_QUERY_KEYWORDS.DISCONNECT] !== 'boolean'
+  )
+    return false;
+
+  return true;
+};
+
+export const extractNestedRelationFieldsByEntityIndex = (
+  entities: Record<string, unknown>[],
+): RelationNestedQueryFieldsByEntityIndex => {
+  const nestedRelationQueryFieldsByEntityIndex: RelationNestedQueryFieldsByEntityIndex =
+    {};
+
+  for (const [entityIndex, entity] of Object.entries(entities)) {
+    for (const [key, value] of Object.entries(entity)) {
+      const hasConnect = hasRelationConnect(value);
+      const hasDisconnect = hasRelationDisconnect(value);
+
+      if (hasConnect && hasDisconnect) {
+        throw new TwentyORMException(
+          `Cannot have both connect and disconnect for the same field on ${entity.key}.`,
+          TwentyORMExceptionCode.CONNECT_NOT_ALLOWED,
+        );
+      }
+
+      const nestedRelationQueryFields =
+        nestedRelationQueryFieldsByEntityIndex?.[entityIndex] || {};
+
+      if (hasConnect) {
+        nestedRelationQueryFieldsByEntityIndex[entityIndex] = {
+          ...nestedRelationQueryFields,
+          connect: {
+            ...(nestedRelationQueryFields.connect || {}),
+            [key]: value,
+          },
+        };
+
+        if (hasDisconnect) {
+          nestedRelationQueryFieldsByEntityIndex[entityIndex] = {
+            ...nestedRelationQueryFields,
+            disconnect: {
+              ...(nestedRelationQueryFields.disconnect || {}),
+              [key]: value,
+            },
+          };
+        }
+      }
+    }
+  }
+
+  return nestedRelationQueryFieldsByEntityIndex;
+};

--- a/packages/twenty-server/test/integration/graphql/suites/object-generated/nested-relation-queries.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/object-generated/nested-relation-queries.integration-spec.ts
@@ -384,7 +384,7 @@ describe('relation connect in workspace createOne/createMany resolvers  (e2e)', 
 
     expect(response.body.errors).toBeDefined();
     expect(response.body.errors[0].message).toBe(
-      'Exactly one key must be specified for OneOf type "CompanyRelationInput".',
+      'Cannot have both connect and disconnect for the same field on undefined.',
     );
   });
 

--- a/packages/twenty-server/test/integration/graphql/utils/create-many-operation-factory.util.ts
+++ b/packages/twenty-server/test/integration/graphql/utils/create-many-operation-factory.util.ts
@@ -6,6 +6,7 @@ type CreateManyOperationFactoryParams = {
   objectMetadataPluralName: string;
   gqlFields: string;
   data?: object;
+  upsert?: boolean;
 };
 
 export const createManyOperationFactory = ({
@@ -13,15 +14,17 @@ export const createManyOperationFactory = ({
   objectMetadataPluralName,
   gqlFields,
   data = {},
+  upsert = false,
 }: CreateManyOperationFactoryParams) => ({
   query: gql`
-    mutation Create${capitalize(objectMetadataSingularName)}($data: [${capitalize(objectMetadataSingularName)}CreateInput!]!) {
-    create${capitalize(objectMetadataPluralName)}(data: $data) {
+    mutation Create${capitalize(objectMetadataSingularName)}($data: [${capitalize(objectMetadataSingularName)}CreateInput!]!, $upsert: Boolean) {
+    create${capitalize(objectMetadataPluralName)}(data: $data, upsert: $upsert) {
       ${gqlFields}
     }
   }
   `,
   variables: {
     data,
+    upsert,
   },
 });

--- a/packages/twenty-shared/src/constants/RelationNestedQueriesKeyword.ts
+++ b/packages/twenty-shared/src/constants/RelationNestedQueriesKeyword.ts
@@ -1,0 +1,5 @@
+export const RELATION_NESTED_QUERY_KEYWORDS = {
+  CONNECT: 'connect',
+  CONNECT_WHERE: 'where',
+  DISCONNECT: 'disconnect',
+} as const;

--- a/packages/twenty-shared/src/constants/index.ts
+++ b/packages/twenty-shared/src/constants/index.ts
@@ -13,6 +13,7 @@ export { FIELD_RESTRICTED_ADDITIONAL_PERMISSIONS_REQUIRED } from './FieldRestric
 export { LABEL_IDENTIFIER_FIELD_METADATA_TYPES } from './LabelIdentifierFieldMetadataTypes';
 export { PermissionsOnAllObjectRecords } from './PermissionsOnAllObjectRecords';
 export { QUERY_MAX_RECORDS } from './QueryMaxRecords';
+export { RELATION_NESTED_QUERY_KEYWORDS } from './RelationNestedQueriesKeyword';
 export { STANDARD_OBJECT_RECORDS_UNDER_OBJECT_RECORDS_PERMISSIONS } from './StandardObjectRecordsUnderObjectRecordsPermissions';
 export { TWENTY_COMPANIES_BASE_URL } from './TwentyCompaniesBaseUrl';
 export { TWENTY_ICONS_BASE_URL } from './TwentyIconsBaseUrl';

--- a/yarn.lock
+++ b/yarn.lock
@@ -38080,10 +38080,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graphql@npm:16.9.0":
-  version: 16.9.0
-  resolution: "graphql@npm:16.9.0"
-  checksum: 10c0/a8850f077ff767377237d1f8b1da2ec70aeb7623cdf1dfc9e1c7ae93accc0c8149c85abe68923be9871a2934b1bce5a2496f846d4d56e1cfb03eaaa7ddba9b6a
+"graphql@npm:16.8.0":
+  version: 16.8.0
+  resolution: "graphql@npm:16.8.0"
+  checksum: 10c0/f7ca0302e8d658012db90b428ec66c1453afe53fbffa21404a28b5bdec5b0e88641d38416ef3d582acad7ddde2effe729e2b050a1483a2e9d4a6111e892e4903
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -38080,10 +38080,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graphql@npm:16.8.0":
-  version: 16.8.0
-  resolution: "graphql@npm:16.8.0"
-  checksum: 10c0/f7ca0302e8d658012db90b428ec66c1453afe53fbffa21404a28b5bdec5b0e88641d38416ef3d582acad7ddde2effe729e2b050a1483a2e9d4a6111e892e4903
+"graphql@npm:16.9.0":
+  version: 16.9.0
+  resolution: "graphql@npm:16.9.0"
+  checksum: 10c0/a8850f077ff767377237d1f8b1da2ec70aeb7623cdf1dfc9e1c7ae93accc0c8149c85abe68923be9871a2934b1bce5a2496f846d4d56e1cfb03eaaa7ddba9b6a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Context : 
Large PR with 600+ test files. Enable connect and disconnect logic in createMany (upsert true) / updateOne / updateMany resolvers

- Add disconnect logic
- Gather disconnect and connect logic -> called relation nested queries
- Move logic to query builder (insert and update one) with a preparation step in .set/.values and an execution step in .execute
- Add integration tests

Test : 
- Test API call on updateMany, updateOne, createMany (upsert:true) with connect/disconnect
