### PR TITLE
[feat]:Added Copy Email Functionality

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/MultiItemFieldMenuItem.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/MultiItemFieldMenuItem.tsx
@@ -8,9 +8,9 @@ import React, { useState } from 'react';
 import {
   IconBookmark,
   IconBookmarkPlus,
-  IconPencil,
-  IconTrash,
   IconCopy,
+  IconPencil,
+  IconTrash
 } from 'twenty-ui/display';
 import { MenuItem } from 'twenty-ui/navigation';
 
@@ -20,7 +20,7 @@ type MultiItemFieldMenuItemProps<T> = {
   onEdit?: () => void;
   onSetAsPrimary?: () => void;
   onDelete?: () => void;
-  onCopy?: () => void;
+  onCopy?:()=> void;
   DisplayComponent: React.ComponentType<{ value: T }>;
   showPrimaryIcon: boolean;
   showSetAsPrimaryButton: boolean;
@@ -33,6 +33,7 @@ export const MultiItemFieldMenuItem = <T,>({
   onCopy,
   onSetAsPrimary,
   onDelete,
+
   DisplayComponent,
   showPrimaryIcon,
   showSetAsPrimaryButton,
@@ -44,19 +45,20 @@ export const MultiItemFieldMenuItem = <T,>({
     dropdownId,
   );
 
-  const handleCopyClick = async (event: React.MouseEvent<HTMLDivElement>) => {
-    event.stopPropagation();
-    event.preventDefault();
+  const handleCopyClick = async(event: React.MouseEvent<HTMLDivElement>) => {
+  event.stopPropagation();
+  event.preventDefault();
+
   
   try {
     await navigator.clipboard.writeText(String(value));
-  } catch (e){
-    console.error("Copy Failed:", e);
-  }
+  } catch {}
+  
+  closeDropdown(dropdownId);
 
-    closeDropdown(dropdownId);
-    onCopy?.();
-  };
+  closeDropdown(dropdownId);
+  onCopy?.();
+};
 
   const handleMouseEnter = () => setIsHovered(true);
   const handleMouseLeave = () => {

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/MultiItemFieldMenuItem.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/MultiItemFieldMenuItem.tsx
@@ -10,7 +10,7 @@ import {
   IconBookmarkPlus,
   IconPencil,
   IconTrash,
-  IconCopy
+  IconCopy,
 } from 'twenty-ui/display';
 import { MenuItem } from 'twenty-ui/navigation';
 
@@ -20,7 +20,7 @@ type MultiItemFieldMenuItemProps<T> = {
   onEdit?: () => void;
   onSetAsPrimary?: () => void;
   onDelete?: () => void;
-  onCopy?:()=> void;
+  onCopy?: () => void;
   DisplayComponent: React.ComponentType<{ value: T }>;
   showPrimaryIcon: boolean;
   showSetAsPrimaryButton: boolean;
@@ -33,7 +33,6 @@ export const MultiItemFieldMenuItem = <T,>({
   onCopy,
   onSetAsPrimary,
   onDelete,
-
   DisplayComponent,
   showPrimaryIcon,
   showSetAsPrimaryButton,
@@ -45,19 +44,19 @@ export const MultiItemFieldMenuItem = <T,>({
     dropdownId,
   );
 
-  const handleCopyClick = async(event: React.MouseEvent<HTMLDivElement>) => {
-  event.stopPropagation();
-  event.preventDefault();
-
+  const handleCopyClick = async (event: React.MouseEvent<HTMLDivElement>) => {
+    event.stopPropagation();
+    event.preventDefault();
   
   try {
     await navigator.clipboard.writeText(String(value));
-  } catch {}
+  } catch (e){
+    console.error("Copy Failed:", e);
+  }
 
-
-  closeDropdown(dropdownId);
-  onCopy?.();
-};
+    closeDropdown(dropdownId);
+    onCopy?.();
+  };
 
   const handleMouseEnter = () => setIsHovered(true);
   const handleMouseLeave = () => {

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/MultiItemFieldMenuItem.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/MultiItemFieldMenuItem.tsx
@@ -52,7 +52,7 @@ export const MultiItemFieldMenuItem = <T,>({
     try {
       await navigator.clipboard.writeText(String(value));
     } catch (e) {
-     // Silently ignore clipboard errors 
+      // Silently ignore clipboard errors 
     }
 
 

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/MultiItemFieldMenuItem.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/MultiItemFieldMenuItem.tsx
@@ -45,14 +45,15 @@ export const MultiItemFieldMenuItem = <T,>({
     dropdownId,
   );
 
-  const handleCopyClick = async(event: React.MouseEvent<HTMLDivElement>) => {
-  event.stopPropagation();
-  event.preventDefault();
+  const handleCopyClick = async (event: React.MouseEvent<HTMLDivElement>) => {
+    event.stopPropagation();
+    event.preventDefault();
 
-  
   try {
     await navigator.clipboard.writeText(String(value));
-  } catch {}
+    } catch (e) {
+      console.error("Copy Failed:", e);
+  }
 
 
   closeDropdown(dropdownId);
@@ -116,7 +117,12 @@ export const MultiItemFieldMenuItem = <T,>({
               LeftIcon={IconCopy}
               text="Copy"
               onClick={handleCopyClick}
-              />
+            />
+            <MenuItem
+              LeftIcon={IconCopy}
+              text="Copy"
+              onClick={handleCopyClick}
+            />
             <MenuItem
               accent="danger"
               LeftIcon={IconTrash}

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/MultiItemFieldMenuItem.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/MultiItemFieldMenuItem.tsx
@@ -10,7 +10,7 @@ import {
   IconBookmarkPlus,
   IconCopy,
   IconPencil,
-  IconTrash
+  IconTrash,
 } from 'twenty-ui/display';
 import { MenuItem } from 'twenty-ui/navigation';
 
@@ -20,7 +20,7 @@ type MultiItemFieldMenuItemProps<T> = {
   onEdit?: () => void;
   onSetAsPrimary?: () => void;
   onDelete?: () => void;
-  onCopy?:()=> void;
+  onCopy?: () => void;
   DisplayComponent: React.ComponentType<{ value: T }>;
   showPrimaryIcon: boolean;
   showSetAsPrimaryButton: boolean;
@@ -55,10 +55,9 @@ export const MultiItemFieldMenuItem = <T,>({
       // Silently ignore clipboard errors
     }
 
-
-  closeDropdown(dropdownId);
-  onCopy?.();
-};
+    closeDropdown(dropdownId);
+    onCopy?.();
+  };
 
   const handleMouseEnter = () => setIsHovered(true);
   const handleMouseLeave = () => {

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/MultiItemFieldMenuItem.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/MultiItemFieldMenuItem.tsx
@@ -49,11 +49,10 @@ export const MultiItemFieldMenuItem = <T,>({
     event.stopPropagation();
     event.preventDefault();
 
-  try {
-    await navigator.clipboard.writeText(String(value));
-    } catch (e) {
-      console.error("Copy Failed:", e);
-  }
+    try {
+      await navigator.clipboard.writeText(String(value));
+    } catch {
+    }
 
 
   closeDropdown(dropdownId);

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/MultiItemFieldMenuItem.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/MultiItemFieldMenuItem.tsx
@@ -53,8 +53,7 @@ export const MultiItemFieldMenuItem = <T,>({
   try {
     await navigator.clipboard.writeText(String(value));
   } catch {}
-  
-  closeDropdown(dropdownId);
+
 
   closeDropdown(dropdownId);
   onCopy?.();

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/MultiItemFieldMenuItem.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/MultiItemFieldMenuItem.tsx
@@ -51,7 +51,8 @@ export const MultiItemFieldMenuItem = <T,>({
 
     try {
       await navigator.clipboard.writeText(String(value));
-    } catch {
+    } catch (e) {
+     // Silently ignore clipboard errors 
     }
 
 

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/MultiItemFieldMenuItem.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/MultiItemFieldMenuItem.tsx
@@ -10,6 +10,7 @@ import {
   IconBookmarkPlus,
   IconPencil,
   IconTrash,
+  IconCopy
 } from 'twenty-ui/display';
 import { MenuItem } from 'twenty-ui/navigation';
 
@@ -19,6 +20,7 @@ type MultiItemFieldMenuItemProps<T> = {
   onEdit?: () => void;
   onSetAsPrimary?: () => void;
   onDelete?: () => void;
+  onCopy?:()=> void;
   DisplayComponent: React.ComponentType<{ value: T }>;
   showPrimaryIcon: boolean;
   showSetAsPrimaryButton: boolean;
@@ -28,8 +30,10 @@ export const MultiItemFieldMenuItem = <T,>({
   dropdownId,
   value,
   onEdit,
+  onCopy,
   onSetAsPrimary,
   onDelete,
+
   DisplayComponent,
   showPrimaryIcon,
   showSetAsPrimaryButton,
@@ -40,6 +44,21 @@ export const MultiItemFieldMenuItem = <T,>({
     isDropdownOpenComponentState,
     dropdownId,
   );
+
+  const handleCopyClick = async(event: React.MouseEvent<HTMLDivElement>) => {
+  event.stopPropagation();
+  event.preventDefault();
+
+  
+  try {
+    await navigator.clipboard.writeText(String(value));
+  } catch {}
+  
+  closeDropdown(dropdownId);
+
+  closeDropdown(dropdownId);
+  onCopy?.();
+};
 
   const handleMouseEnter = () => setIsHovered(true);
   const handleMouseLeave = () => {
@@ -94,6 +113,11 @@ export const MultiItemFieldMenuItem = <T,>({
               text="Edit"
               onClick={handleEditClick}
             />
+            <MenuItem
+              LeftIcon={IconCopy}
+              text="Copy"
+              onClick={handleCopyClick}
+              />
             <MenuItem
               accent="danger"
               LeftIcon={IconTrash}

--- a/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/MultiItemFieldMenuItem.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/MultiItemFieldMenuItem.tsx
@@ -52,7 +52,7 @@ export const MultiItemFieldMenuItem = <T,>({
     try {
       await navigator.clipboard.writeText(String(value));
     } catch (e) {
-      // Silently ignore clipboard errors 
+      // Silently ignore clipboard errors
     }
 
 

--- a/packages/twenty-server/project.json
+++ b/packages/twenty-server/project.json
@@ -46,7 +46,7 @@
       "dependsOn": ["typecheck", "build"],
       "options": {
         "cwd": "packages/twenty-server",
-        "command": "NODE_ENV=development && nest start --watch"
+        "command": "NODE_ENV=development & nest start --watch"
       }
     },
     "start:ci": {

--- a/packages/twenty-server/project.json
+++ b/packages/twenty-server/project.json
@@ -46,7 +46,7 @@
       "dependsOn": ["typecheck", "build"],
       "options": {
         "cwd": "packages/twenty-server",
-        "command": "NODE_ENV=development & nest start --watch"
+        "command": "NODE_ENV=development && nest start --watch"
       }
     },
     "start:ci": {


### PR DESCRIPTION
## Feature

**Closes:**  #13089  – Added Copy Email Functionality in the Email Column

---

## Description

This feature ensures that there is a copy functionality on the email column along with Delete and Edit functionality.

### Key Changes:

- ✅ Added a copy function
- ✅ Added  a copy button below the edit button

---

## Files Changed

- `packages/twenty-front/src/modules/object-record/record-field/meta-types/input/components/MultiItemFieldMenuItem.tsx

---

## Below is the video showing the button and functionality

https://github.com/user-attachments/assets/1e6fe356-2afa-42e1-be5a-986822f4d18a

