### PR TITLE
Remove field metadata interface references

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-filter/graphql-query-filter-field.parser.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-filter/graphql-query-filter-field.parser.ts
@@ -1,7 +1,6 @@
 import { capitalize } from 'twenty-shared/utils';
 import { WhereExpressionBuilder } from 'typeorm';
 
-
 import {
   GraphqlQueryRunnerException,
   GraphqlQueryRunnerExceptionCode,

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-filter/graphql-query-filter-field.parser.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-filter/graphql-query-filter-field.parser.ts
@@ -1,7 +1,6 @@
 import { capitalize } from 'twenty-shared/utils';
 import { WhereExpressionBuilder } from 'typeorm';
 
-import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
 
 import {
   GraphqlQueryRunnerException,
@@ -9,6 +8,7 @@ import {
 } from 'src/engine/api/graphql/graphql-query-runner/errors/graphql-query-runner.exception';
 import { computeWhereConditionParts } from 'src/engine/api/graphql/graphql-query-runner/utils/compute-where-condition-parts';
 import { compositeTypeDefinitions } from 'src/engine/metadata-modules/field-metadata/composite-types';
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { isCompositeFieldMetadataType } from 'src/engine/metadata-modules/field-metadata/utils/is-composite-field-metadata-type.util';
 import { ObjectMetadataItemWithFieldMaps } from 'src/engine/metadata-modules/types/object-metadata-item-with-field-maps';
 import { CompositeFieldMetadataType } from 'src/engine/metadata-modules/workspace-migration/factories/composite-column-action.factory';
@@ -78,7 +78,7 @@ export class GraphqlQueryFilterFieldParser {
 
   private parseCompositeFieldForFilter(
     queryBuilder: WhereExpressionBuilder,
-    fieldMetadata: FieldMetadataInterface,
+    fieldMetadata: FieldMetadataEntity,
     objectNameSingular: string,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     fieldValue: any,

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-order/graphql-query-order.parser.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-order/graphql-query-order.parser.ts
@@ -4,13 +4,13 @@ import {
   ObjectRecordOrderBy,
   OrderByDirection,
 } from 'src/engine/api/graphql/workspace-query-builder/interfaces/object-record.interface';
-import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
 
 import {
   GraphqlQueryRunnerException,
   GraphqlQueryRunnerExceptionCode,
 } from 'src/engine/api/graphql/graphql-query-runner/errors/graphql-query-runner.exception';
 import { compositeTypeDefinitions } from 'src/engine/metadata-modules/field-metadata/composite-types';
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { isCompositeFieldMetadataType } from 'src/engine/metadata-modules/field-metadata/utils/is-composite-field-metadata-type.util';
 import { ObjectMetadataItemWithFieldMaps } from 'src/engine/metadata-modules/types/object-metadata-item-with-field-maps';
 import { CompositeFieldMetadataType } from 'src/engine/metadata-modules/workspace-migration/factories/composite-column-action.factory';
@@ -66,7 +66,7 @@ export class GraphqlQueryOrderFieldParser {
   }
 
   private parseCompositeFieldForOrder(
-    fieldMetadata: FieldMetadataInterface,
+    fieldMetadata: FieldMetadataEntity,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     value: any,
     objectNameSingular: string,

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-selected-fields/graphql-selected-fields-relation.parser.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-selected-fields/graphql-selected-fields-relation.parser.ts
@@ -1,10 +1,10 @@
-import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
 
 import {
   GraphqlQuerySelectedFieldsParser,
   GraphqlQuerySelectedFieldsResult,
 } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-selected-fields/graphql-selected-fields.parser';
 import { getTargetObjectMetadataOrThrow } from 'src/engine/api/graphql/graphql-query-runner/utils/get-target-object-metadata.util';
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { ObjectMetadataMaps } from 'src/engine/metadata-modules/types/object-metadata-maps';
 
 export class GraphqlQuerySelectedFieldsRelationParser {
@@ -15,7 +15,7 @@ export class GraphqlQuerySelectedFieldsRelationParser {
   }
 
   parseRelationField(
-    fieldMetadata: FieldMetadataInterface,
+    fieldMetadata: FieldMetadataEntity,
     fieldKey: string,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     fieldValue: any,

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-selected-fields/graphql-selected-fields-relation.parser.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-selected-fields/graphql-selected-fields-relation.parser.ts
@@ -1,4 +1,3 @@
-
 import {
   GraphqlQuerySelectedFieldsParser,
   GraphqlQuerySelectedFieldsResult,

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-selected-fields/graphql-selected-fields.parser.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-selected-fields/graphql-selected-fields.parser.ts
@@ -1,6 +1,5 @@
 import { capitalize } from 'twenty-shared/utils';
 
-
 import { GraphqlQuerySelectedFieldsAggregateParser } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-selected-fields/graphql-selected-fields-aggregate.parser';
 import { GraphqlQuerySelectedFieldsRelationParser } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-selected-fields/graphql-selected-fields-relation.parser';
 import { compositeTypeDefinitions } from 'src/engine/metadata-modules/field-metadata/composite-types';

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-selected-fields/graphql-selected-fields.parser.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-selected-fields/graphql-selected-fields.parser.ts
@@ -1,10 +1,10 @@
 import { capitalize } from 'twenty-shared/utils';
 
-import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
 
 import { GraphqlQuerySelectedFieldsAggregateParser } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-selected-fields/graphql-selected-fields-aggregate.parser';
 import { GraphqlQuerySelectedFieldsRelationParser } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query-selected-fields/graphql-selected-fields-relation.parser';
 import { compositeTypeDefinitions } from 'src/engine/metadata-modules/field-metadata/composite-types';
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { isCompositeFieldMetadataType } from 'src/engine/metadata-modules/field-metadata/utils/is-composite-field-metadata-type.util';
 import { ObjectMetadataItemWithFieldMaps } from 'src/engine/metadata-modules/types/object-metadata-item-with-field-maps';
 import { ObjectMetadataMaps } from 'src/engine/metadata-modules/types/object-metadata-maps';
@@ -146,7 +146,7 @@ export class GraphqlQuerySelectedFieldsParser {
   }
 
   private parseCompositeField(
-    fieldMetadata: FieldMetadataInterface,
+    fieldMetadata: FieldMetadataEntity,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     fieldValue: any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/helpers/object-records-to-graphql-connection.helper.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/helpers/object-records-to-graphql-connection.helper.ts
@@ -6,7 +6,6 @@ import {
   ObjectRecordOrderBy,
 } from 'src/engine/api/graphql/workspace-query-builder/interfaces/object-record.interface';
 import { IConnection } from 'src/engine/api/graphql/workspace-query-runner/interfaces/connection.interface';
-import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
 
 import { CONNECTION_MAX_DEPTH } from 'src/engine/api/graphql/graphql-query-runner/constants/connection-max-depth.constant';
 import {
@@ -17,6 +16,7 @@ import { encodeCursor } from 'src/engine/api/graphql/graphql-query-runner/utils/
 import { getTargetObjectMetadataOrThrow } from 'src/engine/api/graphql/graphql-query-runner/utils/get-target-object-metadata.util';
 import { AggregationField } from 'src/engine/api/graphql/workspace-schema-builder/utils/get-available-aggregations-from-object-fields.util';
 import { compositeTypeDefinitions } from 'src/engine/metadata-modules/field-metadata/composite-types';
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { isCompositeFieldMetadataType } from 'src/engine/metadata-modules/field-metadata/utils/is-composite-field-metadata-type.util';
 import { ObjectMetadataMaps } from 'src/engine/metadata-modules/types/object-metadata-maps';
 import { getObjectMetadataMapItemByNameSingular } from 'src/engine/metadata-modules/utils/get-object-metadata-map-item-by-name-singular.util';
@@ -236,7 +236,7 @@ export class ObjectRecordsToGraphqlConnectionHelper {
   }
 
   private processCompositeField(
-    fieldMetadata: FieldMetadataInterface,
+    fieldMetadata: FieldMetadataEntity,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     fieldValue: any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/helpers/process-nested-relations-v2.helper.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/helpers/process-nested-relations-v2.helper.ts
@@ -20,7 +20,7 @@ import { ObjectMetadataMaps } from 'src/engine/metadata-modules/types/object-met
 import { getObjectMetadataMapItemByNameSingular } from 'src/engine/metadata-modules/utils/get-object-metadata-map-item-by-name-singular.util';
 import { WorkspaceDataSource } from 'src/engine/twenty-orm/datasource/workspace.datasource';
 import { WorkspaceSelectQueryBuilder } from 'src/engine/twenty-orm/repository/workspace-select-query-builder';
-import { isFieldMetadataInterfaceOfType } from 'src/engine/utils/is-field-metadata-of-type.util';
+import { isFieldMetadataEntityOfType } from 'src/engine/utils/is-field-metadata-of-type.util';
 
 @Injectable()
 export class ProcessNestedRelationsV2Helper {
@@ -118,7 +118,7 @@ export class ProcessNestedRelationsV2Helper {
       parentObjectMetadataItem.fieldsById[sourceFieldMetadataId];
 
     if (
-      !isFieldMetadataInterfaceOfType(
+      !isFieldMetadataEntityOfType(
         sourceFieldMetadata,
         FieldMetadataType.RELATION,
       )

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/utils/build-columns-to-select.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/utils/build-columns-to-select.ts
@@ -4,7 +4,7 @@ import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfa
 
 import { InternalServerError } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
 import { ObjectMetadataItemWithFieldMaps } from 'src/engine/metadata-modules/types/object-metadata-item-with-field-maps';
-import { isFieldMetadataInterfaceOfType } from 'src/engine/utils/is-field-metadata-of-type.util';
+import { isFieldMetadataEntityOfType } from 'src/engine/utils/is-field-metadata-of-type.util';
 
 export const buildColumnsToSelect = ({
   select,
@@ -57,7 +57,7 @@ const getRequiredRelationColumns = (
     }
 
     if (
-      !isFieldMetadataInterfaceOfType(fieldMetadata, FieldMetadataType.RELATION)
+      !isFieldMetadataEntityOfType(fieldMetadata, FieldMetadataType.RELATION)
     ) {
       continue;
     }

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/utils/get-target-object-metadata.util.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/utils/get-target-object-metadata.util.ts
@@ -1,4 +1,3 @@
-
 import {
   GraphqlQueryRunnerException,
   GraphqlQueryRunnerExceptionCode,

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/utils/get-target-object-metadata.util.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/utils/get-target-object-metadata.util.ts
@@ -1,13 +1,13 @@
-import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
 
 import {
   GraphqlQueryRunnerException,
   GraphqlQueryRunnerExceptionCode,
 } from 'src/engine/api/graphql/graphql-query-runner/errors/graphql-query-runner.exception';
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { ObjectMetadataMaps } from 'src/engine/metadata-modules/types/object-metadata-maps';
 
 export const getTargetObjectMetadataOrThrow = (
-  fieldMetadata: FieldMetadataInterface,
+  fieldMetadata: FieldMetadataEntity,
   objectMetadataMaps: ObjectMetadataMaps,
 ) => {
   if (!fieldMetadata.relationTargetObjectMetadataId) {

--- a/packages/twenty-server/src/engine/api/graphql/workspace-query-builder/interfaces/workspace-query-builder-options.interface.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-query-builder/interfaces/workspace-query-builder-options.interface.ts
@@ -1,7 +1,8 @@
 import { GraphQLResolveInfo } from 'graphql';
-import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 
 import { ObjectMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/object-metadata.interface';
+
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 
 export interface WorkspaceQueryBuilderOptions {
   objectMetadataItem: ObjectMetadataInterface;

--- a/packages/twenty-server/src/engine/api/graphql/workspace-query-builder/interfaces/workspace-query-builder-options.interface.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-query-builder/interfaces/workspace-query-builder-options.interface.ts
@@ -1,12 +1,12 @@
 import { GraphQLResolveInfo } from 'graphql';
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 
-import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
 import { ObjectMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/object-metadata.interface';
 
 export interface WorkspaceQueryBuilderOptions {
   objectMetadataItem: ObjectMetadataInterface;
   info: GraphQLResolveInfo;
-  fieldMetadataCollection: FieldMetadataInterface[];
+  fieldMetadataCollection: FieldMetadataEntity[];
   objectMetadataCollection: ObjectMetadataInterface[];
   withSoftDeleted?: boolean;
 }

--- a/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/factories/query-result-getters/query-result-getters.factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/factories/query-result-getters/query-result-getters.factory.ts
@@ -136,10 +136,7 @@ export class QueryResultGettersFactory {
       )
       .filter(isDefined)
       .filter((fieldMetadata) =>
-        isFieldMetadataEntityOfType(
-          fieldMetadata,
-          FieldMetadataType.RELATION,
-        ),
+        isFieldMetadataEntityOfType(fieldMetadata, FieldMetadataType.RELATION),
       );
 
     const relationFieldsProcessedMap = {} as Record<

--- a/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/factories/query-result-getters/query-result-getters.factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/factories/query-result-getters/query-result-getters.factory.ts
@@ -21,7 +21,7 @@ import { CompositeInputTypeDefinitionFactory } from 'src/engine/api/graphql/work
 import { FileService } from 'src/engine/core-modules/file/services/file.service';
 import { ObjectMetadataItemWithFieldMaps } from 'src/engine/metadata-modules/types/object-metadata-item-with-field-maps';
 import { ObjectMetadataMaps } from 'src/engine/metadata-modules/types/object-metadata-maps';
-import { isFieldMetadataInterfaceOfType } from 'src/engine/utils/is-field-metadata-of-type.util';
+import { isFieldMetadataEntityOfType } from 'src/engine/utils/is-field-metadata-of-type.util';
 
 // TODO: find a way to prevent conflict between handlers executing logic on object relations
 // And this factory that is also executing logic on object relations
@@ -136,7 +136,7 @@ export class QueryResultGettersFactory {
       )
       .filter(isDefined)
       .filter((fieldMetadata) =>
-        isFieldMetadataInterfaceOfType(
+        isFieldMetadataEntityOfType(
           fieldMetadata,
           FieldMetadataType.RELATION,
         ),

--- a/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/factories/enum-type-definition.factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/factories/enum-type-definition.factory.ts
@@ -7,8 +7,8 @@ import { WorkspaceBuildSchemaOptions } from 'src/engine/api/graphql/workspace-sc
 import { ObjectMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/object-metadata.interface';
 
 import {
-    FieldMetadataComplexOption,
-    FieldMetadataDefaultOption,
+  FieldMetadataComplexOption,
+  FieldMetadataDefaultOption,
 } from 'src/engine/metadata-modules/field-metadata/dtos/options.input';
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { isEnumFieldMetadataType } from 'src/engine/metadata-modules/field-metadata/utils/is-enum-field-metadata-type.util';

--- a/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/factories/enum-type-definition.factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/factories/enum-type-definition.factory.ts
@@ -4,13 +4,13 @@ import { GraphQLEnumType } from 'graphql';
 import { isDefined } from 'twenty-shared/utils';
 
 import { WorkspaceBuildSchemaOptions } from 'src/engine/api/graphql/workspace-schema-builder/interfaces/workspace-build-schema-optionts.interface';
-import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
 import { ObjectMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/object-metadata.interface';
 
 import {
-  FieldMetadataComplexOption,
-  FieldMetadataDefaultOption,
+    FieldMetadataComplexOption,
+    FieldMetadataDefaultOption,
 } from 'src/engine/metadata-modules/field-metadata/dtos/options.input';
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { isEnumFieldMetadataType } from 'src/engine/metadata-modules/field-metadata/utils/is-enum-field-metadata-type.util';
 import { transformEnumValue } from 'src/engine/utils/transform-enum-value';
 import { pascalCase } from 'src/utils/pascal-case';
@@ -50,7 +50,7 @@ export class EnumTypeDefinitionFactory {
 
   private generateEnum(
     objectName: string,
-    fieldMetadata: FieldMetadataInterface,
+    fieldMetadata: FieldMetadataEntity,
     options: WorkspaceBuildSchemaOptions,
   ): GraphQLEnumType {
     // FixMe: It's a hack until Typescript get fixed on union types for reduce function

--- a/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/factories/extend-object-type-definition-v2.factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/factories/extend-object-type-definition-v2.factory.ts
@@ -1,9 +1,9 @@
 import { Injectable, Logger } from '@nestjs/common';
 
 import {
-  GraphQLFieldConfigArgumentMap,
-  GraphQLFieldConfigMap,
-  GraphQLObjectType,
+    GraphQLFieldConfigArgumentMap,
+    GraphQLFieldConfigMap,
+    GraphQLObjectType,
 } from 'graphql';
 import { FieldMetadataType } from 'twenty-shared/types';
 
@@ -15,7 +15,7 @@ import { RelationTypeV2Factory } from 'src/engine/api/graphql/workspace-schema-b
 import { TypeDefinitionsStorage } from 'src/engine/api/graphql/workspace-schema-builder/storages/type-definitions.storage';
 import { getResolverArgs } from 'src/engine/api/graphql/workspace-schema-builder/utils/get-resolver-args.util';
 import { objectContainsRelationField } from 'src/engine/api/graphql/workspace-schema-builder/utils/object-contains-relation-field';
-import { isFieldMetadataInterfaceOfType } from 'src/engine/utils/is-field-metadata-of-type.util';
+import { isFieldMetadataEntityOfType } from 'src/engine/utils/is-field-metadata-of-type.util';
 
 import { ArgsFactory } from './args.factory';
 
@@ -113,11 +113,11 @@ export class ExtendObjectTypeDefinitionV2Factory {
     for (const fieldMetadata of objectMetadata.fields) {
       // Ignore non-relation fields as they are already defined
       const isRelation =
-        isFieldMetadataInterfaceOfType(
+        isFieldMetadataEntityOfType(
           fieldMetadata,
           FieldMetadataType.RELATION,
         ) ||
-        isFieldMetadataInterfaceOfType(
+        isFieldMetadataEntityOfType(
           fieldMetadata,
           FieldMetadataType.MORPH_RELATION,
         );

--- a/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/factories/extend-object-type-definition-v2.factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/factories/extend-object-type-definition-v2.factory.ts
@@ -1,9 +1,9 @@
 import { Injectable, Logger } from '@nestjs/common';
 
 import {
-    GraphQLFieldConfigArgumentMap,
-    GraphQLFieldConfigMap,
-    GraphQLObjectType,
+  GraphQLFieldConfigArgumentMap,
+  GraphQLFieldConfigMap,
+  GraphQLObjectType,
 } from 'graphql';
 import { FieldMetadataType } from 'twenty-shared/types';
 

--- a/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/factories/relation-connect-input-type-definition.factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/factories/relation-connect-input-type-definition.factory.ts
@@ -1,18 +1,18 @@
 import { Injectable } from '@nestjs/common';
 
 import {
-    GraphQLInputFieldConfig,
-    GraphQLInputObjectType,
-    GraphQLInputType,
-    GraphQLString,
+  GraphQLInputFieldConfig,
+  GraphQLInputObjectType,
+  GraphQLInputType,
+  GraphQLString,
 } from 'graphql';
 import { getUniqueConstraintsFields } from 'twenty-shared/utils';
 
 import { ObjectMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/object-metadata.interface';
 
 import {
-    InputTypeDefinition,
-    InputTypeDefinitionKind,
+  InputTypeDefinition,
+  InputTypeDefinitionKind,
 } from 'src/engine/api/graphql/workspace-schema-builder/factories/input-type-definition.factory';
 import { TypeMapperService } from 'src/engine/api/graphql/workspace-schema-builder/services/type-mapper.service';
 import { compositeTypeDefinitions } from 'src/engine/metadata-modules/field-metadata/composite-types';

--- a/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/factories/relation-connect-input-type-definition.factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/factories/relation-connect-input-type-definition.factory.ts
@@ -1,22 +1,22 @@
 import { Injectable } from '@nestjs/common';
 
 import {
-  GraphQLInputFieldConfig,
-  GraphQLInputObjectType,
-  GraphQLInputType,
-  GraphQLString,
+    GraphQLInputFieldConfig,
+    GraphQLInputObjectType,
+    GraphQLInputType,
+    GraphQLString,
 } from 'graphql';
 import { getUniqueConstraintsFields } from 'twenty-shared/utils';
 
-import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
 import { ObjectMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/object-metadata.interface';
 
 import {
-  InputTypeDefinition,
-  InputTypeDefinitionKind,
+    InputTypeDefinition,
+    InputTypeDefinitionKind,
 } from 'src/engine/api/graphql/workspace-schema-builder/factories/input-type-definition.factory';
 import { TypeMapperService } from 'src/engine/api/graphql/workspace-schema-builder/services/type-mapper.service';
 import { compositeTypeDefinitions } from 'src/engine/metadata-modules/field-metadata/composite-types';
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { isCompositeFieldMetadataType } from 'src/engine/metadata-modules/field-metadata/utils/is-composite-field-metadata-type.util';
 import { pascalCase } from 'src/utils/pascal-case';
 
@@ -63,7 +63,7 @@ export class RelationConnectInputTypeDefinitionFactory {
     objectMetadata: ObjectMetadataInterface,
   ): Record<string, GraphQLInputFieldConfig> {
     const uniqueConstraints = getUniqueConstraintsFields<
-      FieldMetadataInterface,
+      FieldMetadataEntity,
       ObjectMetadataInterface
     >(objectMetadata);
 
@@ -140,7 +140,7 @@ export class RelationConnectInputTypeDefinitionFactory {
     };
   }
 
-  private formatConstraints(constraints: FieldMetadataInterface[][]) {
+  private formatConstraints(constraints: FieldMetadataEntity[][]) {
     return constraints
       .map((constraint) => constraint.map((field) => field.name).join(' and '))
       .join(' or ');

--- a/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/factories/relation-type-v2.factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/factories/relation-type-v2.factory.ts
@@ -3,11 +3,11 @@ import { Injectable, Logger } from '@nestjs/common';
 import { GraphQLOutputType } from 'graphql';
 import { FieldMetadataType } from 'twenty-shared/types';
 
-import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
 import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
 
 import { TypeDefinitionsStorage } from 'src/engine/api/graphql/workspace-schema-builder/storages/type-definitions.storage';
 
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { ObjectTypeDefinitionKind } from './object-type-definition.factory';
 
 @Injectable()
@@ -19,7 +19,7 @@ export class RelationTypeV2Factory {
   ) {}
 
   public create(
-    fieldMetadata: FieldMetadataInterface<
+    fieldMetadata: FieldMetadataEntity<
       FieldMetadataType.RELATION | FieldMetadataType.MORPH_RELATION
     >,
   ): GraphQLOutputType {

--- a/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/factories/relation-type-v2.factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/factories/relation-type-v2.factory.ts
@@ -6,8 +6,8 @@ import { FieldMetadataType } from 'twenty-shared/types';
 import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
 
 import { TypeDefinitionsStorage } from 'src/engine/api/graphql/workspace-schema-builder/storages/type-definitions.storage';
-
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
+
 import { ObjectTypeDefinitionKind } from './object-type-definition.factory';
 
 @Injectable()

--- a/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/utils/generate-fields.utils.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/utils/generate-fields.utils.ts
@@ -16,7 +16,7 @@ import { ObjectTypeDefinitionKind } from 'src/engine/api/graphql/workspace-schem
 import { formatRelationConnectInputTarget } from 'src/engine/api/graphql/workspace-schema-builder/factories/relation-connect-input-type-definition.factory';
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { isCompositeFieldMetadataType } from 'src/engine/metadata-modules/field-metadata/utils/is-composite-field-metadata-type.util';
-import { isFieldMetadataInterfaceOfType } from 'src/engine/utils/is-field-metadata-of-type.util';
+import { isFieldMetadataEntityOfType } from 'src/engine/utils/is-field-metadata-of-type.util';
 
 type TypeFactory<T extends InputTypeDefinitionKind | ObjectTypeDefinitionKind> =
   {
@@ -63,11 +63,11 @@ export const generateFields = <
     let generatedField;
 
     const isRelation =
-      isFieldMetadataInterfaceOfType(
+      isFieldMetadataEntityOfType(
         fieldMetadata,
         FieldMetadataType.RELATION,
       ) ||
-      isFieldMetadataInterfaceOfType(
+      isFieldMetadataEntityOfType(
         fieldMetadata,
         FieldMetadataType.MORPH_RELATION,
       );

--- a/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/utils/generate-fields.utils.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/utils/generate-fields.utils.ts
@@ -63,10 +63,7 @@ export const generateFields = <
     let generatedField;
 
     const isRelation =
-      isFieldMetadataEntityOfType(
-        fieldMetadata,
-        FieldMetadataType.RELATION,
-      ) ||
+      isFieldMetadataEntityOfType(fieldMetadata, FieldMetadataType.RELATION) ||
       isFieldMetadataEntityOfType(
         fieldMetadata,
         FieldMetadataType.MORPH_RELATION,

--- a/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/utils/generate-fields.utils.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/utils/generate-fields.utils.ts
@@ -8,13 +8,13 @@ import { FieldMetadataType } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 
 import { WorkspaceBuildSchemaOptions } from 'src/engine/api/graphql/workspace-schema-builder/interfaces/workspace-build-schema-optionts.interface';
-import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
 import { ObjectMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/object-metadata.interface';
 import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
 
 import { InputTypeDefinitionKind } from 'src/engine/api/graphql/workspace-schema-builder/factories/input-type-definition.factory';
 import { ObjectTypeDefinitionKind } from 'src/engine/api/graphql/workspace-schema-builder/factories/object-type-definition.factory';
 import { formatRelationConnectInputTarget } from 'src/engine/api/graphql/workspace-schema-builder/factories/relation-connect-input-type-definition.factory';
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { isCompositeFieldMetadataType } from 'src/engine/metadata-modules/field-metadata/utils/is-composite-field-metadata-type.util';
 import { isFieldMetadataInterfaceOfType } from 'src/engine/utils/is-field-metadata-of-type.util';
 
@@ -95,7 +95,7 @@ export const generateFields = <
 };
 
 const getTarget = <T extends FieldMetadataType>(
-  fieldMetadata: FieldMetadataInterface<T>,
+  fieldMetadata: FieldMetadataEntity<T>,
 ) => {
   return isCompositeFieldMetadataType(fieldMetadata.type)
     ? fieldMetadata.type.toString()
@@ -103,7 +103,7 @@ const getTarget = <T extends FieldMetadataType>(
 };
 
 const getTypeFactoryOptions = <T extends FieldMetadataType>(
-  fieldMetadata: FieldMetadataInterface<T>,
+  fieldMetadata: FieldMetadataEntity<T>,
   kind: InputTypeDefinitionKind | ObjectTypeDefinitionKind,
 ) => {
   return isInputTypeDefinitionKind(kind)
@@ -133,7 +133,7 @@ const generateField = <
   options,
   typeFactory,
 }: {
-  fieldMetadata: FieldMetadataInterface;
+  fieldMetadata: FieldMetadataEntity;
   kind: T;
   options: WorkspaceBuildSchemaOptions;
   typeFactory: TypeFactory<T>;
@@ -166,7 +166,7 @@ const generateRelationField = <
   options,
   typeFactory,
 }: {
-  fieldMetadata: FieldMetadataInterface<
+  fieldMetadata: FieldMetadataEntity<
     FieldMetadataType.RELATION | FieldMetadataType.MORPH_RELATION
   >;
   kind: T;

--- a/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/utils/get-available-aggregations-from-object-fields.util.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/utils/get-available-aggregations-from-object-fields.util.ts
@@ -5,9 +5,9 @@ import { FIELD_FOR_TOTAL_COUNT_AGGREGATE_OPERATION } from 'twenty-shared/constan
 import { FieldMetadataType } from 'twenty-shared/types';
 import { capitalize, isFieldMetadataDateKind } from 'twenty-shared/utils';
 
-import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
 
 import { AggregateOperations } from 'src/engine/api/graphql/graphql-query-runner/constants/aggregate-operations.constant';
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { getSubfieldsForAggregateOperation } from 'src/engine/twenty-orm/utils/get-subfields-for-aggregate-operation.util';
 
 export type AggregationField = {
@@ -21,7 +21,7 @@ export type AggregationField = {
 };
 
 export const getAvailableAggregationsFromObjectFields = (
-  fields: FieldMetadataInterface[],
+  fields: FieldMetadataEntity[],
 ): Record<string, AggregationField> => {
   return fields.reduce<Record<string, AggregationField>>(
     (acc, field) => {

--- a/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/utils/get-available-aggregations-from-object-fields.util.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/utils/get-available-aggregations-from-object-fields.util.ts
@@ -5,7 +5,6 @@ import { FIELD_FOR_TOTAL_COUNT_AGGREGATE_OPERATION } from 'twenty-shared/constan
 import { FieldMetadataType } from 'twenty-shared/types';
 import { capitalize, isFieldMetadataDateKind } from 'twenty-shared/utils';
 
-
 import { AggregateOperations } from 'src/engine/api/graphql/graphql-query-runner/constants/aggregate-operations.constant';
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { getSubfieldsForAggregateOperation } from 'src/engine/twenty-orm/utils/get-subfields-for-aggregate-operation.util';

--- a/packages/twenty-server/src/engine/api/rest/core/interfaces/rest-api-base.handler.ts
+++ b/packages/twenty-server/src/engine/api/rest/core/interfaces/rest-api-base.handler.ts
@@ -34,7 +34,7 @@ import { WorkspaceSelectQueryBuilder } from 'src/engine/twenty-orm/repository/wo
 import { WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace.repository';
 import { TwentyORMManager } from 'src/engine/twenty-orm/twenty-orm.manager';
 import { formatResult as formatGetManyData } from 'src/engine/twenty-orm/utils/format-result.util';
-import { isFieldMetadataInterfaceOfType } from 'src/engine/utils/is-field-metadata-of-type.util';
+import { isFieldMetadataEntityOfType } from 'src/engine/utils/is-field-metadata-of-type.util';
 
 export interface PageInfo {
   hasNextPage?: boolean;
@@ -160,7 +160,7 @@ export abstract class RestApiBaseHandler {
 
     Object.values(objectMetadata.objectMetadataMapItem.fieldsById).forEach(
       (field) => {
-        if (isFieldMetadataInterfaceOfType(field, FieldMetadataType.RELATION)) {
+        if (isFieldMetadataEntityOfType(field, FieldMetadataType.RELATION)) {
           if (
             depth === MAX_DEPTH &&
             isDefined(field.relationTargetObjectMetadataId)

--- a/packages/twenty-server/src/engine/api/rest/core/query-builder/utils/check-fields.utils.ts
+++ b/packages/twenty-server/src/engine/api/rest/core/query-builder/utils/check-fields.utils.ts
@@ -7,7 +7,7 @@ import { compositeTypeDefinitions } from 'src/engine/metadata-modules/field-meta
 import { isCompositeFieldMetadataType } from 'src/engine/metadata-modules/field-metadata/utils/is-composite-field-metadata-type.util';
 import { ObjectMetadataItemWithFieldMaps } from 'src/engine/metadata-modules/types/object-metadata-item-with-field-maps';
 import { computeObjectTargetTable } from 'src/engine/utils/compute-object-target-table.util';
-import { isFieldMetadataInterfaceOfType } from 'src/engine/utils/is-field-metadata-of-type.util';
+import { isFieldMetadataEntityOfType } from 'src/engine/utils/is-field-metadata-of-type.util';
 
 export const checkFields = (
   objectMetadataItemWithFieldsMaps: ObjectMetadataItemWithFieldMaps,
@@ -35,7 +35,7 @@ export const checkFields = (
         ].flat();
       }
 
-      if (isFieldMetadataInterfaceOfType(field, FieldMetadataType.RELATION)) {
+      if (isFieldMetadataEntityOfType(field, FieldMetadataType.RELATION)) {
         return field.settings?.joinColumnName;
       }
 

--- a/packages/twenty-server/src/engine/api/rest/core/query-builder/utils/map-field-metadata-to-graphql-query.utils.ts
+++ b/packages/twenty-server/src/engine/api/rest/core/query-builder/utils/map-field-metadata-to-graphql-query.utils.ts
@@ -1,9 +1,9 @@
 import { FieldMetadataType } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 
-import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
 import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
 
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { ObjectMetadataMaps } from 'src/engine/metadata-modules/types/object-metadata-maps';
 import { isFieldMetadataInterfaceOfType } from 'src/engine/utils/is-field-metadata-of-type.util';
 
@@ -12,7 +12,7 @@ const DEFAULT_DEPTH_VALUE = 1;
 // TODO: Should be properly type and based on composite type definitions
 export const mapFieldMetadataToGraphqlQuery = (
   objectMetadataMaps: ObjectMetadataMaps,
-  field: FieldMetadataInterface,
+  field: FieldMetadataEntity,
   maxDepthForRelations = DEFAULT_DEPTH_VALUE,
 ): string | undefined => {
   if (maxDepthForRelations < 0) {

--- a/packages/twenty-server/src/engine/api/rest/core/query-builder/utils/map-field-metadata-to-graphql-query.utils.ts
+++ b/packages/twenty-server/src/engine/api/rest/core/query-builder/utils/map-field-metadata-to-graphql-query.utils.ts
@@ -5,7 +5,7 @@ import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfa
 
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { ObjectMetadataMaps } from 'src/engine/metadata-modules/types/object-metadata-maps';
-import { isFieldMetadataInterfaceOfType } from 'src/engine/utils/is-field-metadata-of-type.util';
+import { isFieldMetadataEntityOfType } from 'src/engine/utils/is-field-metadata-of-type.util';
 
 const DEFAULT_DEPTH_VALUE = 1;
 
@@ -40,8 +40,8 @@ export const mapFieldMetadataToGraphqlQuery = (
   ].includes(fieldType);
 
   const isRelation =
-    isFieldMetadataInterfaceOfType(field, FieldMetadataType.RELATION) ||
-    isFieldMetadataInterfaceOfType(field, FieldMetadataType.MORPH_RELATION);
+    isFieldMetadataEntityOfType(field, FieldMetadataType.RELATION) ||
+    isFieldMetadataEntityOfType(field, FieldMetadataType.MORPH_RELATION);
 
   if (fieldIsSimpleValue) {
     return field.name;

--- a/packages/twenty-server/src/engine/dataloaders/dataloader.service.ts
+++ b/packages/twenty-server/src/engine/dataloaders/dataloader.service.ts
@@ -4,14 +4,13 @@ import DataLoader from 'dataloader';
 import { APP_LOCALES } from 'twenty-shared/translations';
 import { isDefined } from 'twenty-shared/utils';
 
-import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { ObjectMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/object-metadata.interface';
 import { IndexMetadataInterface } from 'src/engine/metadata-modules/index-metadata/interfaces/index-metadata.interface';
 
 import { IDataloaders } from 'src/engine/dataloaders/dataloader.interface';
 import { filterMorphRelationDuplicateFieldsDTO } from 'src/engine/dataloaders/utils/filter-morph-relation-duplicate-fields.util';
 import { FieldMetadataDTO } from 'src/engine/metadata-modules/field-metadata/dtos/field-metadata.dto';
-import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { FieldMetadataMorphRelationService } from 'src/engine/metadata-modules/field-metadata/services/field-metadata-morph-relation.service';
 import { FieldMetadataRelationService } from 'src/engine/metadata-modules/field-metadata/services/field-metadata-relation.service';
 import { fromFieldMetadataEntityToFieldMetadataDto } from 'src/engine/metadata-modules/field-metadata/utils/from-field-metadata-entity-to-fieldMetadata-dto.util';
@@ -24,7 +23,7 @@ import { WorkspaceMetadataCacheService } from 'src/engine/metadata-modules/works
 export type RelationMetadataLoaderPayload = {
   workspaceId: string;
   fieldMetadata: Pick<
-    FieldMetadataInterface,
+    FieldMetadataEntity,
     'type' | 'id' | 'objectMetadataId'
   >;
 };
@@ -32,7 +31,7 @@ export type RelationMetadataLoaderPayload = {
 export type RelationLoaderPayload = {
   workspaceId: string;
   fieldMetadata: Pick<
-    FieldMetadataInterface,
+    FieldMetadataEntity,
     | 'type'
     | 'id'
     | 'objectMetadataId'
@@ -44,7 +43,7 @@ export type RelationLoaderPayload = {
 export type MorphRelationLoaderPayload = {
   workspaceId: string;
   fieldMetadata: Pick<
-    FieldMetadataInterface,
+    FieldMetadataEntity,
     | 'type'
     | 'id'
     | 'objectMetadataId'
@@ -219,7 +218,7 @@ export class DataloaderService {
               'icon',
               'label',
               'description',
-            ] as const satisfies (keyof FieldMetadataInterface)[];
+            ] as const satisfies (keyof FieldMetadataEntity)[];
 
             const overrides = overridesFieldToCompute.reduce<
               Partial<Record<(typeof overridesFieldToCompute)[number], string>>

--- a/packages/twenty-server/src/engine/dataloaders/dataloader.service.ts
+++ b/packages/twenty-server/src/engine/dataloaders/dataloader.service.ts
@@ -4,10 +4,10 @@ import DataLoader from 'dataloader';
 import { APP_LOCALES } from 'twenty-shared/translations';
 import { isDefined } from 'twenty-shared/utils';
 
-import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { ObjectMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/object-metadata.interface';
 import { IndexMetadataInterface } from 'src/engine/metadata-modules/index-metadata/interfaces/index-metadata.interface';
 
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { IDataloaders } from 'src/engine/dataloaders/dataloader.interface';
 import { filterMorphRelationDuplicateFieldsDTO } from 'src/engine/dataloaders/utils/filter-morph-relation-duplicate-fields.util';
 import { FieldMetadataDTO } from 'src/engine/metadata-modules/field-metadata/dtos/field-metadata.dto';
@@ -22,10 +22,7 @@ import { WorkspaceMetadataCacheService } from 'src/engine/metadata-modules/works
 
 export type RelationMetadataLoaderPayload = {
   workspaceId: string;
-  fieldMetadata: Pick<
-    FieldMetadataEntity,
-    'type' | 'id' | 'objectMetadataId'
-  >;
+  fieldMetadata: Pick<FieldMetadataEntity, 'type' | 'id' | 'objectMetadataId'>;
 };
 
 export type RelationLoaderPayload = {

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface.ts
@@ -1,7 +1,0 @@
-import { FieldMetadataType } from 'twenty-shared/types';
-
-import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
-
-export type FieldMetadataInterface<
-  T extends FieldMetadataType = FieldMetadataType,
-> = FieldMetadataEntity<T>;

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/interfaces/object-metadata.interface.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/interfaces/object-metadata.interface.ts
@@ -1,8 +1,7 @@
 import { IndexMetadataInterface } from 'src/engine/metadata-modules/index-metadata/interfaces/index-metadata.interface';
 
 import { WorkspaceEntityDuplicateCriteria } from 'src/engine/api/graphql/workspace-query-builder/types/workspace-entity-duplicate-criteria.type';
-
-import { FieldMetadataInterface } from './field-metadata.interface';
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 
 export interface ObjectMetadataInterface {
   id: string;
@@ -15,7 +14,7 @@ export interface ObjectMetadataInterface {
   description?: string;
   icon: string;
   targetTableName: string;
-  fields: FieldMetadataInterface[];
+  fields: FieldMetadataEntity[];
   indexMetadatas: IndexMetadataInterface[];
   isSystem: boolean;
   isCustom: boolean;

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata-enum-validation.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata-enum-validation.service.ts
@@ -7,7 +7,6 @@ import { assertUnreachable, isDefined } from 'twenty-shared/utils';
 import { z } from 'zod';
 
 import { FieldMetadataOptions } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata-options.interface';
-import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
 
 import { CreateFieldInput } from 'src/engine/metadata-modules/field-metadata/dtos/create-field.input';
 import {
@@ -15,6 +14,7 @@ import {
   FieldMetadataDefaultOption,
 } from 'src/engine/metadata-modules/field-metadata/dtos/options.input';
 import { UpdateFieldInput } from 'src/engine/metadata-modules/field-metadata/dtos/update-field.input';
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import {
   FieldMetadataException,
   FieldMetadataExceptionCode,
@@ -36,7 +36,7 @@ type FieldMetadataUpdateCreateInput = CreateFieldInput | UpdateFieldInput;
 
 type ValidateEnumFieldMetadataArgs = {
   existingFieldMetadata?: Pick<
-    FieldMetadataInterface,
+    FieldMetadataEntity,
     'type' | 'isNullable' | 'defaultValue' | 'options'
   >;
   fieldMetadataInput: FieldMetadataUpdateCreateInput;

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata-morph-relation.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata-morph-relation.service.ts
@@ -6,13 +6,13 @@ import { isDefined } from 'twenty-shared/utils';
 import { Repository } from 'typeorm';
 import { v4 } from 'uuid';
 
-import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
 
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { CreateFieldInput } from 'src/engine/metadata-modules/field-metadata/dtos/create-field.input';
 import {
-    FieldMetadataException,
-    FieldMetadataExceptionCode,
+  FieldMetadataException,
+  FieldMetadataExceptionCode,
 } from 'src/engine/metadata-modules/field-metadata/field-metadata.exception';
 import { FieldMetadataRelationService } from 'src/engine/metadata-modules/field-metadata/services/field-metadata-relation.service';
 import { computeMorphRelationFieldJoinColumnName } from 'src/engine/metadata-modules/field-metadata/utils/compute-morph-relation-field-join-column-name.util';

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata-morph-relation.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata-morph-relation.service.ts
@@ -6,14 +6,13 @@ import { isDefined } from 'twenty-shared/utils';
 import { Repository } from 'typeorm';
 import { v4 } from 'uuid';
 
-import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
 
 import { CreateFieldInput } from 'src/engine/metadata-modules/field-metadata/dtos/create-field.input';
-import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import {
-  FieldMetadataException,
-  FieldMetadataExceptionCode,
+    FieldMetadataException,
+    FieldMetadataExceptionCode,
 } from 'src/engine/metadata-modules/field-metadata/field-metadata.exception';
 import { FieldMetadataRelationService } from 'src/engine/metadata-modules/field-metadata/services/field-metadata-relation.service';
 import { computeMorphRelationFieldJoinColumnName } from 'src/engine/metadata-modules/field-metadata/utils/compute-morph-relation-field-join-column-name.util';
@@ -163,7 +162,7 @@ export class FieldMetadataMorphRelationService {
   async findCachedFieldMetadataMorphRelation(
     fieldMetadataItems: Array<
       Pick<
-        FieldMetadataInterface,
+        FieldMetadataEntity,
         | 'id'
         | 'type'
         | 'objectMetadataId'
@@ -187,7 +186,7 @@ export class FieldMetadataMorphRelationService {
       );
 
     const fieldMetadataItemsAndMorphSiblings: Pick<
-      FieldMetadataInterface,
+      FieldMetadataEntity,
       | 'id'
       | 'type'
       | 'objectMetadataId'

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata-relation.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata-relation.service.ts
@@ -8,14 +8,14 @@ import { isDefined } from 'twenty-shared/utils';
 import { Repository } from 'typeorm';
 import { v4 } from 'uuid';
 
-import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
 
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { CreateFieldInput } from 'src/engine/metadata-modules/field-metadata/dtos/create-field.input';
 import { UpdateFieldInput } from 'src/engine/metadata-modules/field-metadata/dtos/update-field.input';
 import {
-    FieldMetadataException,
-    FieldMetadataExceptionCode,
+  FieldMetadataException,
+  FieldMetadataExceptionCode,
 } from 'src/engine/metadata-modules/field-metadata/field-metadata.exception';
 import { computeRelationFieldJoinColumnName } from 'src/engine/metadata-modules/field-metadata/utils/compute-relation-field-join-column-name.util';
 import { prepareCustomFieldMetadataForCreation } from 'src/engine/metadata-modules/field-metadata/utils/prepare-field-metadata-for-creation.util';

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata-relation.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata-relation.service.ts
@@ -14,8 +14,8 @@ import { CreateFieldInput } from 'src/engine/metadata-modules/field-metadata/dto
 import { UpdateFieldInput } from 'src/engine/metadata-modules/field-metadata/dtos/update-field.input';
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import {
-    FieldMetadataException,
-    FieldMetadataExceptionCode,
+  FieldMetadataException,
+  FieldMetadataExceptionCode,
 } from 'src/engine/metadata-modules/field-metadata/field-metadata.exception';
 import { computeRelationFieldJoinColumnName } from 'src/engine/metadata-modules/field-metadata/utils/compute-relation-field-join-column-name.util';
 import { prepareCustomFieldMetadataForCreation } from 'src/engine/metadata-modules/field-metadata/utils/prepare-field-metadata-for-creation.util';

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata-relation.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata-relation.service.ts
@@ -8,15 +8,14 @@ import { isDefined } from 'twenty-shared/utils';
 import { Repository } from 'typeorm';
 import { v4 } from 'uuid';
 
-import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
 
 import { CreateFieldInput } from 'src/engine/metadata-modules/field-metadata/dtos/create-field.input';
 import { UpdateFieldInput } from 'src/engine/metadata-modules/field-metadata/dtos/update-field.input';
-import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import {
-  FieldMetadataException,
-  FieldMetadataExceptionCode,
+    FieldMetadataException,
+    FieldMetadataExceptionCode,
 } from 'src/engine/metadata-modules/field-metadata/field-metadata.exception';
 import { computeRelationFieldJoinColumnName } from 'src/engine/metadata-modules/field-metadata/utils/compute-relation-field-join-column-name.util';
 import { prepareCustomFieldMetadataForCreation } from 'src/engine/metadata-modules/field-metadata/utils/prepare-field-metadata-for-creation.util';
@@ -50,7 +49,7 @@ type ValidateFieldMetadataArgs<T extends UpdateFieldInput | CreateFieldInput> =
     fieldMetadataType: FieldMetadataType;
     fieldMetadataInput: T;
     objectMetadata: ObjectMetadataItemWithFieldMaps;
-    existingFieldMetadata?: FieldMetadataInterface;
+    existingFieldMetadata?: FieldMetadataEntity;
     objectMetadataMaps: ObjectMetadataMaps;
   };
 
@@ -243,7 +242,7 @@ export class FieldMetadataRelationService {
   async findCachedFieldMetadataRelation(
     fieldMetadataItems: Array<
       Pick<
-        FieldMetadataInterface,
+        FieldMetadataEntity,
         | 'id'
         | 'type'
         | 'objectMetadataId'

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata-relation.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata-relation.service.ts
@@ -10,12 +10,12 @@ import { v4 } from 'uuid';
 
 import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
 
-import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { CreateFieldInput } from 'src/engine/metadata-modules/field-metadata/dtos/create-field.input';
 import { UpdateFieldInput } from 'src/engine/metadata-modules/field-metadata/dtos/update-field.input';
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import {
-  FieldMetadataException,
-  FieldMetadataExceptionCode,
+    FieldMetadataException,
+    FieldMetadataExceptionCode,
 } from 'src/engine/metadata-modules/field-metadata/field-metadata.exception';
 import { computeRelationFieldJoinColumnName } from 'src/engine/metadata-modules/field-metadata/utils/compute-relation-field-join-column-name.util';
 import { prepareCustomFieldMetadataForCreation } from 'src/engine/metadata-modules/field-metadata/utils/prepare-field-metadata-for-creation.util';
@@ -27,7 +27,7 @@ import { getObjectMetadataFromObjectMetadataItemWithFieldMaps } from 'src/engine
 import { validateFieldNameAvailabilityOrThrow } from 'src/engine/metadata-modules/utils/validate-field-name-availability.utils';
 import { validateMetadataNameOrThrow } from 'src/engine/metadata-modules/utils/validate-metadata-name.utils';
 import { computeMetadataNameFromLabel } from 'src/engine/metadata-modules/utils/validate-name-and-label-are-sync-or-throw.util';
-import { isFieldMetadataInterfaceOfType } from 'src/engine/utils/is-field-metadata-of-type.util';
+import { isFieldMetadataEntityOfType } from 'src/engine/utils/is-field-metadata-of-type.util';
 import { WorkspaceCacheStorageService } from 'src/engine/workspace-cache-storage/workspace-cache-storage.service';
 
 export class RelationCreationPayloadValidation {
@@ -323,11 +323,11 @@ export class FieldMetadataRelationService {
     joinColumnName: string;
   }) {
     const isRelation =
-      isFieldMetadataInterfaceOfType(
+      isFieldMetadataEntityOfType(
         fieldMetadataInput,
         FieldMetadataType.RELATION,
       ) ||
-      isFieldMetadataInterfaceOfType(
+      isFieldMetadataEntityOfType(
         fieldMetadataInput,
         FieldMetadataType.MORPH_RELATION,
       );

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata-validation.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata-validation.service.ts
@@ -15,10 +15,10 @@ import { FieldMetadataType } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 
 import { FieldMetadataSettings } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata-settings.interface';
-import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
 
 import { CreateFieldInput } from 'src/engine/metadata-modules/field-metadata/dtos/create-field.input';
 import { UpdateFieldInput } from 'src/engine/metadata-modules/field-metadata/dtos/update-field.input';
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import {
   FieldMetadataException,
   FieldMetadataExceptionCode,
@@ -34,7 +34,7 @@ type ValidateFieldMetadataArgs = {
   fieldMetadataType: FieldMetadataType;
   fieldMetadataInput: CreateFieldInput | UpdateFieldInput;
   objectMetadata: ObjectMetadataItemWithFieldMaps;
-  existingFieldMetadata?: FieldMetadataInterface;
+  existingFieldMetadata?: FieldMetadataEntity;
 };
 
 enum ValueType {

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata.service.ts
@@ -7,7 +7,7 @@ import { FieldMetadataType } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 import { DataSource, FindOneOptions, In, Repository } from 'typeorm';
 
-import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
 
 import { FeatureFlagKey } from 'src/engine/core-modules/feature-flag/enums/feature-flag-key.enum';
@@ -16,7 +16,6 @@ import { compositeTypeDefinitions } from 'src/engine/metadata-modules/field-meta
 import { CreateFieldInput } from 'src/engine/metadata-modules/field-metadata/dtos/create-field.input';
 import { DeleteOneFieldInput } from 'src/engine/metadata-modules/field-metadata/dtos/delete-field.input';
 import { UpdateFieldInput } from 'src/engine/metadata-modules/field-metadata/dtos/update-field.input';
-import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import {
   FieldMetadataException,
   FieldMetadataExceptionCode,
@@ -107,7 +106,7 @@ export class FieldMetadataService extends TypeOrmQueryService<FieldMetadataEntit
         { workspaceId: fieldMetadataInput.workspaceId },
       );
 
-    let existingFieldMetadata: FieldMetadataInterface | undefined;
+    let existingFieldMetadata: FieldMetadataEntity | undefined;
 
     for (const objectMetadataItem of Object.values(
       objectMetadataMaps.byId,

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata.service.ts
@@ -7,9 +7,9 @@ import { FieldMetadataType } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 import { DataSource, FindOneOptions, In, Repository } from 'typeorm';
 
-import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
 
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { FeatureFlagKey } from 'src/engine/core-modules/feature-flag/enums/feature-flag-key.enum';
 import { FeatureFlagService } from 'src/engine/core-modules/feature-flag/services/feature-flag.service';
 import { compositeTypeDefinitions } from 'src/engine/metadata-modules/field-metadata/composite-types';

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/utils/build-updatable-standard-field-input.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/utils/build-updatable-standard-field-input.util.ts
@@ -1,6 +1,5 @@
 import { FieldMetadataType } from 'twenty-shared/types';
 
-
 import { FieldStandardOverridesDTO } from 'src/engine/metadata-modules/field-metadata/dtos/field-standard-overrides.dto';
 import { UpdateFieldInput } from 'src/engine/metadata-modules/field-metadata/dtos/update-field.input';
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/utils/build-updatable-standard-field-input.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/utils/build-updatable-standard-field-input.util.ts
@@ -1,14 +1,14 @@
 import { FieldMetadataType } from 'twenty-shared/types';
 
-import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
 
 import { FieldStandardOverridesDTO } from 'src/engine/metadata-modules/field-metadata/dtos/field-standard-overrides.dto';
 import { UpdateFieldInput } from 'src/engine/metadata-modules/field-metadata/dtos/update-field.input';
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 
 export const buildUpdatableStandardFieldInput = (
   fieldMetadataInput: UpdateFieldInput,
   existingFieldMetadata: Pick<
-    FieldMetadataInterface,
+    FieldMetadataEntity,
     'type' | 'isNullable' | 'defaultValue' | 'options'
   >,
 ) => {

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/utils/check-can-deactivate-field-or-throw.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/utils/check-can-deactivate-field-or-throw.ts
@@ -1,4 +1,3 @@
-
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import {
   FieldMetadataException,
@@ -7,10 +6,7 @@ import {
 
 type CheckCanDeactivateFieldOptions = {
   labelIdentifierFieldMetadataId: string;
-  existingFieldMetadata: Pick<
-    FieldMetadataEntity,
-    'id' | 'isSystem' | 'name'
-  >;
+  existingFieldMetadata: Pick<FieldMetadataEntity, 'id' | 'isSystem' | 'name'>;
 };
 
 export const checkCanDeactivateFieldOrThrow = ({

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/utils/check-can-deactivate-field-or-throw.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/utils/check-can-deactivate-field-or-throw.ts
@@ -1,5 +1,5 @@
-import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
 
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import {
   FieldMetadataException,
   FieldMetadataExceptionCode,
@@ -8,7 +8,7 @@ import {
 type CheckCanDeactivateFieldOptions = {
   labelIdentifierFieldMetadataId: string;
   existingFieldMetadata: Pick<
-    FieldMetadataInterface,
+    FieldMetadataEntity,
     'id' | 'isSystem' | 'name'
   >;
 };

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/utils/compute-column-name.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/utils/compute-column-name.util.ts
@@ -1,8 +1,8 @@
 import { FieldMetadataType } from 'twenty-shared/types';
 
 import { CompositeProperty } from 'src/engine/metadata-modules/field-metadata/interfaces/composite-type.interface';
-import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
 
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import {
   FieldMetadataException,
   FieldMetadataExceptionCode,
@@ -22,12 +22,12 @@ export function computeColumnName(
   options?: ComputeColumnNameOptions,
 ): string;
 export function computeColumnName<T extends FieldMetadataType>(
-  fieldMetadata: FieldMetadataInterface<T>,
+  fieldMetadata: FieldMetadataEntity<T>,
   ioptions?: ComputeColumnNameOptions,
 ): string;
 // TODO: If we need to implement custom name logic for columns, we can do it here
 export function computeColumnName<T extends FieldMetadataType>(
-  fieldMetadataOrFieldName: FieldMetadataInterface<T> | string,
+  fieldMetadataOrFieldName: FieldMetadataEntity<T> | string,
   options?: ComputeColumnNameOptions,
 ): string {
   const generateName = (name: string) => {
@@ -52,13 +52,13 @@ export function computeCompositeColumnName(
   compositeProperty: CompositeProperty,
 ): string;
 export function computeCompositeColumnName<T extends FieldMetadataType>(
-  fieldMetadata: FieldTypeAndNameMetadata | FieldMetadataInterface<T>,
+  fieldMetadata: FieldTypeAndNameMetadata | FieldMetadataEntity<T>,
   compositeProperty: CompositeProperty,
 ): string;
 export function computeCompositeColumnName<T extends FieldMetadataType>(
   fieldMetadataOrFieldName:
     | FieldTypeAndNameMetadata
-    | FieldMetadataInterface<T>
+    | FieldMetadataEntity<T>
     | string,
   compositeProperty: CompositeProperty,
 ): string {

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/utils/compute-column-name.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/utils/compute-column-name.util.ts
@@ -23,7 +23,7 @@ export function computeColumnName(
 ): string;
 export function computeColumnName<T extends FieldMetadataType>(
   fieldMetadata: FieldMetadataEntity<T>,
-  ioptions?: ComputeColumnNameOptions,
+  options?: ComputeColumnNameOptions,
 ): string;
 // TODO: If we need to implement custom name logic for columns, we can do it here
 export function computeColumnName<T extends FieldMetadataType>(

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/utils/is-select-or-multi-select-field-metadata.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/utils/is-select-or-multi-select-field-metadata.util.ts
@@ -2,7 +2,6 @@ import { FieldMetadataType } from 'twenty-shared/types';
 
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 
-
 export type SelectOrMultiSelectFieldMetadataEntity = FieldMetadataEntity<
   FieldMetadataType.SELECT | FieldMetadataType.MULTI_SELECT
 >;

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/utils/is-select-or-multi-select-field-metadata.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/utils/is-select-or-multi-select-field-metadata.util.ts
@@ -1,15 +1,14 @@
 import { FieldMetadataType } from 'twenty-shared/types';
 
-import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
-
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
+
 
 export type SelectOrMultiSelectFieldMetadataEntity = FieldMetadataEntity<
   FieldMetadataType.SELECT | FieldMetadataType.MULTI_SELECT
 >;
 export const isSelectOrMultiSelectFieldMetadata = (
-  fieldMetadata: FieldMetadataInterface,
-): fieldMetadata is FieldMetadataInterface &
+  fieldMetadata: FieldMetadataEntity,
+): fieldMetadata is FieldMetadataEntity &
   SelectOrMultiSelectFieldMetadataEntity => {
   return [FieldMetadataType.SELECT, FieldMetadataType.MULTI_SELECT].includes(
     fieldMetadata.type,

--- a/packages/twenty-server/src/engine/metadata-modules/index-metadata/interfaces/index-field-metadata.interface.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/index-metadata/interfaces/index-field-metadata.interface.ts
@@ -1,5 +1,6 @@
-import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { IndexMetadataInterface } from 'src/engine/metadata-modules/index-metadata/interfaces/index-metadata.interface';
+
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 
 export interface IndexFieldMetadataInterface {
   id: string;

--- a/packages/twenty-server/src/engine/metadata-modules/index-metadata/interfaces/index-field-metadata.interface.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/index-metadata/interfaces/index-field-metadata.interface.ts
@@ -1,11 +1,11 @@
-import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { IndexMetadataInterface } from 'src/engine/metadata-modules/index-metadata/interfaces/index-metadata.interface';
 
 export interface IndexFieldMetadataInterface {
   id: string;
   indexMetadataId: string;
   fieldMetadataId: string;
-  fieldMetadata: FieldMetadataInterface;
+  fieldMetadata: FieldMetadataEntity;
   indexMetadata: IndexMetadataInterface;
   order: number;
   createdAt: Date;

--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/services/object-metadata-migration.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/services/object-metadata-migration.service.ts
@@ -13,16 +13,16 @@ import { ObjectMetadataItemWithFieldMaps } from 'src/engine/metadata-modules/typ
 import { fieldMetadataTypeToColumnType } from 'src/engine/metadata-modules/workspace-migration/utils/field-metadata-type-to-column-type.util';
 import { generateMigrationName } from 'src/engine/metadata-modules/workspace-migration/utils/generate-migration-name.util';
 import {
-  WorkspaceMigrationColumnActionType,
-  WorkspaceMigrationColumnDrop,
-  WorkspaceMigrationTableAction,
-  WorkspaceMigrationTableActionType,
+    WorkspaceMigrationColumnActionType,
+    WorkspaceMigrationColumnDrop,
+    WorkspaceMigrationTableAction,
+    WorkspaceMigrationTableActionType,
 } from 'src/engine/metadata-modules/workspace-migration/workspace-migration.entity';
 import { WorkspaceMigrationFactory } from 'src/engine/metadata-modules/workspace-migration/workspace-migration.factory';
 import { WorkspaceMigrationService } from 'src/engine/metadata-modules/workspace-migration/workspace-migration.service';
 import { computeObjectTargetTable } from 'src/engine/utils/compute-object-target-table.util';
 import { computeTableName } from 'src/engine/utils/compute-table-name.util';
-import { isFieldMetadataInterfaceOfType } from 'src/engine/utils/is-field-metadata-of-type.util';
+import { isFieldMetadataEntityOfType } from 'src/engine/utils/is-field-metadata-of-type.util';
 import { RELATION_MIGRATION_PRIORITY_PREFIX } from 'src/engine/workspace-manager/workspace-migration-runner/workspace-migration-runner.service';
 
 @Injectable()
@@ -244,8 +244,8 @@ export class ObjectMetadataMigrationService {
   ) {
     const relationFields = objectMetadata.fields.filter(
       (field) =>
-        isFieldMetadataInterfaceOfType(field, FieldMetadataType.RELATION) ||
-        isFieldMetadataInterfaceOfType(field, FieldMetadataType.MORPH_RELATION),
+        isFieldMetadataEntityOfType(field, FieldMetadataType.RELATION) ||
+        isFieldMetadataEntityOfType(field, FieldMetadataType.MORPH_RELATION),
     ) as FieldMetadataEntity<
       FieldMetadataType.RELATION | FieldMetadataType.MORPH_RELATION
     >[];

--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/services/object-metadata-migration.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/services/object-metadata-migration.service.ts
@@ -13,10 +13,10 @@ import { ObjectMetadataItemWithFieldMaps } from 'src/engine/metadata-modules/typ
 import { fieldMetadataTypeToColumnType } from 'src/engine/metadata-modules/workspace-migration/utils/field-metadata-type-to-column-type.util';
 import { generateMigrationName } from 'src/engine/metadata-modules/workspace-migration/utils/generate-migration-name.util';
 import {
-    WorkspaceMigrationColumnActionType,
-    WorkspaceMigrationColumnDrop,
-    WorkspaceMigrationTableAction,
-    WorkspaceMigrationTableActionType,
+  WorkspaceMigrationColumnActionType,
+  WorkspaceMigrationColumnDrop,
+  WorkspaceMigrationTableAction,
+  WorkspaceMigrationTableActionType,
 } from 'src/engine/metadata-modules/workspace-migration/workspace-migration.entity';
 import { WorkspaceMigrationFactory } from 'src/engine/metadata-modules/workspace-migration/workspace-migration.factory';
 import { WorkspaceMigrationService } from 'src/engine/metadata-modules/workspace-migration/workspace-migration.service';

--- a/packages/twenty-server/src/engine/metadata-modules/types/field-metadata-map.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/types/field-metadata-map.ts
@@ -1,3 +1,3 @@
-import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
+import { FieldMetadataEntity } from "../field-metadata/field-metadata.entity";
 
-export type FieldMetadataMap = Record<string, FieldMetadataInterface>;
+export type FieldMetadataMap = Record<string, FieldMetadataEntity>;

--- a/packages/twenty-server/src/engine/metadata-modules/types/field-metadata-map.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/types/field-metadata-map.ts
@@ -1,3 +1,3 @@
-import { FieldMetadataEntity } from "../field-metadata/field-metadata.entity";
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 
 export type FieldMetadataMap = Record<string, FieldMetadataEntity>;

--- a/packages/twenty-server/src/engine/metadata-modules/utils/generate-object-metadata-maps.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/utils/generate-object-metadata-maps.util.ts
@@ -6,7 +6,7 @@ import { ObjectMetadataInterface } from 'src/engine/metadata-modules/field-metad
 import { FieldMetadataMap } from 'src/engine/metadata-modules/types/field-metadata-map';
 import { ObjectMetadataItemWithFieldMaps } from 'src/engine/metadata-modules/types/object-metadata-item-with-field-maps';
 import { ObjectMetadataMaps } from 'src/engine/metadata-modules/types/object-metadata-maps';
-import { isFieldMetadataInterfaceOfType } from 'src/engine/utils/is-field-metadata-of-type.util';
+import { isFieldMetadataEntityOfType } from 'src/engine/utils/is-field-metadata-of-type.util';
 
 export const generateObjectMetadataMaps = (
   objectMetadataCollection: ObjectMetadataInterface[],
@@ -21,7 +21,7 @@ export const generateObjectMetadataMaps = (
 
     for (const fieldMetadata of objectMetadata.fields) {
       if (
-        isFieldMetadataInterfaceOfType(
+        isFieldMetadataEntityOfType(
           fieldMetadata,
           FieldMetadataType.RELATION,
         )

--- a/packages/twenty-server/src/engine/metadata-modules/utils/generate-object-metadata-maps.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/utils/generate-object-metadata-maps.util.ts
@@ -21,10 +21,7 @@ export const generateObjectMetadataMaps = (
 
     for (const fieldMetadata of objectMetadata.fields) {
       if (
-        isFieldMetadataEntityOfType(
-          fieldMetadata,
-          FieldMetadataType.RELATION,
-        )
+        isFieldMetadataEntityOfType(fieldMetadata, FieldMetadataType.RELATION)
       ) {
         if (fieldMetadata.settings?.joinColumnName) {
           fieldIdByJoinColumnNameMap[fieldMetadata.settings.joinColumnName] =

--- a/packages/twenty-server/src/engine/metadata-modules/utils/validate-metadata-identifier-field-metadata-id.utils.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/utils/validate-metadata-identifier-field-metadata-id.utils.ts
@@ -1,13 +1,12 @@
 import {
-    isDefined,
-    isLabelIdentifierFieldMetadataTypes,
+  isDefined,
+  isLabelIdentifierFieldMetadataTypes,
 } from 'twenty-shared/utils';
 
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
-
 import {
-    ObjectMetadataException,
-    ObjectMetadataExceptionCode,
+  ObjectMetadataException,
+  ObjectMetadataExceptionCode,
 } from 'src/engine/metadata-modules/object-metadata/object-metadata.exception';
 
 type Validator = {

--- a/packages/twenty-server/src/engine/metadata-modules/utils/validate-metadata-identifier-field-metadata-id.utils.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/utils/validate-metadata-identifier-field-metadata-id.utils.ts
@@ -1,27 +1,26 @@
 import {
-  isDefined,
-  isLabelIdentifierFieldMetadataTypes,
+    isDefined,
+    isLabelIdentifierFieldMetadataTypes,
 } from 'twenty-shared/utils';
 
-import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
-
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
+
 import {
-  ObjectMetadataException,
-  ObjectMetadataExceptionCode,
+    ObjectMetadataException,
+    ObjectMetadataExceptionCode,
 } from 'src/engine/metadata-modules/object-metadata/object-metadata.exception';
 
 type Validator = {
   validator: (args: {
     fieldMetadataId: string;
-    matchingFieldMetadata?: FieldMetadataEntity | FieldMetadataInterface;
+    matchingFieldMetadata?: FieldMetadataEntity | FieldMetadataEntity;
   }) => boolean;
   label: string;
 };
 
 type ValidateMetadataIdentifierFieldMetadataIdOrThrowArgs = {
   fieldMetadataId: string;
-  fieldMetadataItems: FieldMetadataEntity[] | FieldMetadataInterface[];
+  fieldMetadataItems: FieldMetadataEntity[] | FieldMetadataEntity[];
   validators: Validator[];
 };
 const validatorRunner = ({
@@ -46,7 +45,7 @@ const validatorRunner = ({
 type ValidateMetadataIdentifierFieldMetadataIdsArgs = {
   labelIdentifierFieldMetadataId: string | undefined;
   imageIdentifierFieldMetadataId: string | undefined;
-  fieldMetadataItems: FieldMetadataEntity[] | FieldMetadataInterface[];
+  fieldMetadataItems: FieldMetadataEntity[] | FieldMetadataEntity[];
 };
 export const validateMetadataIdentifierFieldMetadataIds = ({
   imageIdentifierFieldMetadataId,

--- a/packages/twenty-server/src/engine/metadata-modules/utils/validate-metadata-identifier-field-metadata-id.utils.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/utils/validate-metadata-identifier-field-metadata-id.utils.ts
@@ -12,14 +12,14 @@ import {
 type Validator = {
   validator: (args: {
     fieldMetadataId: string;
-    matchingFieldMetadata?: FieldMetadataEntity | FieldMetadataEntity;
+    matchingFieldMetadata?: FieldMetadataEntity;
   }) => boolean;
   label: string;
 };
 
 type ValidateMetadataIdentifierFieldMetadataIdOrThrowArgs = {
   fieldMetadataId: string;
-  fieldMetadataItems: FieldMetadataEntity[] | FieldMetadataEntity[];
+  fieldMetadataItems: FieldMetadataEntity[];
   validators: Validator[];
 };
 const validatorRunner = ({
@@ -44,7 +44,7 @@ const validatorRunner = ({
 type ValidateMetadataIdentifierFieldMetadataIdsArgs = {
   labelIdentifierFieldMetadataId: string | undefined;
   imageIdentifierFieldMetadataId: string | undefined;
-  fieldMetadataItems: FieldMetadataEntity[] | FieldMetadataEntity[];
+  fieldMetadataItems: FieldMetadataEntity[];
 };
 export const validateMetadataIdentifierFieldMetadataIds = ({
   imageIdentifierFieldMetadataId,

--- a/packages/twenty-server/src/engine/metadata-modules/workspace-migration/factories/basic-column-action.factory.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/workspace-migration/factories/basic-column-action.factory.ts
@@ -2,9 +2,9 @@ import { Injectable, Logger } from '@nestjs/common';
 
 import { FieldMetadataType } from 'twenty-shared/types';
 
-import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
 import { WorkspaceColumnActionOptions } from 'src/engine/metadata-modules/workspace-migration/interfaces/workspace-column-action-options.interface';
 
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { computeColumnName } from 'src/engine/metadata-modules/field-metadata/utils/compute-column-name.util';
 import { serializeDefaultValue } from 'src/engine/metadata-modules/field-metadata/utils/serialize-default-value';
 import { ColumnActionAbstractFactory } from 'src/engine/metadata-modules/workspace-migration/factories/column-action-abstract.factory';
@@ -36,7 +36,7 @@ export class BasicColumnActionFactory extends ColumnActionAbstractFactory<BasicF
   protected readonly logger = new Logger(BasicColumnActionFactory.name);
 
   protected handleCreateAction(
-    fieldMetadata: FieldMetadataInterface<BasicFieldMetadataType>,
+    fieldMetadata: FieldMetadataEntity<BasicFieldMetadataType>,
     options?: WorkspaceColumnActionOptions,
   ): WorkspaceMigrationColumnCreate[] {
     const columnName = computeColumnName(fieldMetadata);
@@ -57,8 +57,8 @@ export class BasicColumnActionFactory extends ColumnActionAbstractFactory<BasicF
   }
 
   protected handleAlterAction(
-    currentFieldMetadata: FieldMetadataInterface<BasicFieldMetadataType>,
-    alteredFieldMetadata: FieldMetadataInterface<BasicFieldMetadataType>,
+    currentFieldMetadata: FieldMetadataEntity<BasicFieldMetadataType>,
+    alteredFieldMetadata: FieldMetadataEntity<BasicFieldMetadataType>,
     options?: WorkspaceColumnActionOptions,
   ): WorkspaceMigrationColumnAlter[] {
     const currentColumnName = computeColumnName(currentFieldMetadata);

--- a/packages/twenty-server/src/engine/metadata-modules/workspace-migration/factories/column-action-abstract.factory.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/workspace-migration/factories/column-action-abstract.factory.ts
@@ -6,17 +6,17 @@ import { FieldMetadataType } from 'twenty-shared/types';
 import { WorkspaceColumnActionFactory } from 'src/engine/metadata-modules/workspace-migration/interfaces/workspace-column-action-factory.interface';
 import { WorkspaceColumnActionOptions } from 'src/engine/metadata-modules/workspace-migration/interfaces/workspace-column-action-options.interface';
 
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import {
-    WorkspaceMigrationColumnAction,
-    WorkspaceMigrationColumnActionType,
-    WorkspaceMigrationColumnAlter,
-    WorkspaceMigrationColumnCreate,
+  WorkspaceMigrationColumnAction,
+  WorkspaceMigrationColumnActionType,
+  WorkspaceMigrationColumnAlter,
+  WorkspaceMigrationColumnCreate,
 } from 'src/engine/metadata-modules/workspace-migration/workspace-migration.entity';
 import {
-    WorkspaceMigrationException,
-    WorkspaceMigrationExceptionCode,
+  WorkspaceMigrationException,
+  WorkspaceMigrationExceptionCode,
 } from 'src/engine/metadata-modules/workspace-migration/workspace-migration.exception';
-import { FieldMetadataEntity } from '../../field-metadata/field-metadata.entity';
 
 export class ColumnActionAbstractFactory<T extends FieldMetadataType>
   implements WorkspaceColumnActionFactory<T>

--- a/packages/twenty-server/src/engine/metadata-modules/workspace-migration/factories/column-action-abstract.factory.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/workspace-migration/factories/column-action-abstract.factory.ts
@@ -3,20 +3,20 @@ import { Logger } from '@nestjs/common';
 
 import { FieldMetadataType } from 'twenty-shared/types';
 
-import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
 import { WorkspaceColumnActionFactory } from 'src/engine/metadata-modules/workspace-migration/interfaces/workspace-column-action-factory.interface';
 import { WorkspaceColumnActionOptions } from 'src/engine/metadata-modules/workspace-migration/interfaces/workspace-column-action-options.interface';
 
 import {
-  WorkspaceMigrationColumnAction,
-  WorkspaceMigrationColumnActionType,
-  WorkspaceMigrationColumnAlter,
-  WorkspaceMigrationColumnCreate,
+    WorkspaceMigrationColumnAction,
+    WorkspaceMigrationColumnActionType,
+    WorkspaceMigrationColumnAlter,
+    WorkspaceMigrationColumnCreate,
 } from 'src/engine/metadata-modules/workspace-migration/workspace-migration.entity';
 import {
-  WorkspaceMigrationException,
-  WorkspaceMigrationExceptionCode,
+    WorkspaceMigrationException,
+    WorkspaceMigrationExceptionCode,
 } from 'src/engine/metadata-modules/workspace-migration/workspace-migration.exception';
+import { FieldMetadataEntity } from '../../field-metadata/field-metadata.entity';
 
 export class ColumnActionAbstractFactory<T extends FieldMetadataType>
   implements WorkspaceColumnActionFactory<T>
@@ -27,8 +27,8 @@ export class ColumnActionAbstractFactory<T extends FieldMetadataType>
     action:
       | WorkspaceMigrationColumnActionType.CREATE
       | WorkspaceMigrationColumnActionType.ALTER,
-    currentFieldMetadata: FieldMetadataInterface<T> | undefined,
-    alteredFieldMetadata: FieldMetadataInterface<T>,
+    currentFieldMetadata: FieldMetadataEntity<T> | undefined,
+    alteredFieldMetadata: FieldMetadataEntity<T>,
     options?: WorkspaceColumnActionOptions,
   ): WorkspaceMigrationColumnAction[] {
     switch (action) {
@@ -59,7 +59,7 @@ export class ColumnActionAbstractFactory<T extends FieldMetadataType>
   }
 
   protected handleCreateAction(
-    _fieldMetadata: FieldMetadataInterface<T>,
+    _fieldMetadata: FieldMetadataEntity<T>,
     _options?: WorkspaceColumnActionOptions,
   ): WorkspaceMigrationColumnCreate[] {
     throw new WorkspaceMigrationException(
@@ -69,8 +69,8 @@ export class ColumnActionAbstractFactory<T extends FieldMetadataType>
   }
 
   protected handleAlterAction(
-    _currentFieldMetadata: FieldMetadataInterface<T>,
-    _alteredFieldMetadata: FieldMetadataInterface<T>,
+    _currentFieldMetadata: FieldMetadataEntity<T>,
+    _alteredFieldMetadata: FieldMetadataEntity<T>,
     _options?: WorkspaceColumnActionOptions,
   ): WorkspaceMigrationColumnAlter[] {
     throw new WorkspaceMigrationException(

--- a/packages/twenty-server/src/engine/metadata-modules/workspace-migration/factories/composite-column-action.factory.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/workspace-migration/factories/composite-column-action.factory.ts
@@ -2,7 +2,6 @@ import { Injectable, Logger } from '@nestjs/common';
 
 import { FieldMetadataType } from 'twenty-shared/types';
 
-
 import { compositeTypeDefinitions } from 'src/engine/metadata-modules/field-metadata/composite-types';
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { computeCompositeColumnName } from 'src/engine/metadata-modules/field-metadata/utils/compute-column-name.util';

--- a/packages/twenty-server/src/engine/metadata-modules/workspace-migration/factories/composite-column-action.factory.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/workspace-migration/factories/composite-column-action.factory.ts
@@ -2,9 +2,9 @@ import { Injectable, Logger } from '@nestjs/common';
 
 import { FieldMetadataType } from 'twenty-shared/types';
 
-import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
 
 import { compositeTypeDefinitions } from 'src/engine/metadata-modules/field-metadata/composite-types';
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { computeCompositeColumnName } from 'src/engine/metadata-modules/field-metadata/utils/compute-column-name.util';
 import { serializeDefaultValue } from 'src/engine/metadata-modules/field-metadata/utils/serialize-default-value';
 import { ColumnActionAbstractFactory } from 'src/engine/metadata-modules/workspace-migration/factories/column-action-abstract.factory';
@@ -34,7 +34,7 @@ export class CompositeColumnActionFactory extends ColumnActionAbstractFactory<Co
   protected readonly logger = new Logger(CompositeColumnActionFactory.name);
 
   protected handleCreateAction(
-    fieldMetadata: FieldMetadataInterface<CompositeFieldMetadataType>,
+    fieldMetadata: FieldMetadataEntity<CompositeFieldMetadataType>,
   ): WorkspaceMigrationColumnCreate[] {
     const compositeType = compositeTypeDefinitions.get(fieldMetadata.type);
 
@@ -83,8 +83,8 @@ export class CompositeColumnActionFactory extends ColumnActionAbstractFactory<Co
   }
 
   protected handleAlterAction(
-    currentFieldMetadata: FieldMetadataInterface<CompositeFieldMetadataType>,
-    alteredFieldMetadata: FieldMetadataInterface<CompositeFieldMetadataType>,
+    currentFieldMetadata: FieldMetadataEntity<CompositeFieldMetadataType>,
+    alteredFieldMetadata: FieldMetadataEntity<CompositeFieldMetadataType>,
   ): WorkspaceMigrationColumnAlter[] {
     const currentCompositeType = compositeTypeDefinitions.get(
       currentFieldMetadata.type,

--- a/packages/twenty-server/src/engine/metadata-modules/workspace-migration/factories/enum-column-action.factory.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/workspace-migration/factories/enum-column-action.factory.ts
@@ -2,9 +2,9 @@ import { Injectable, Logger } from '@nestjs/common';
 
 import { FieldMetadataType } from 'twenty-shared/types';
 
-import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
 import { WorkspaceColumnActionOptions } from 'src/engine/metadata-modules/workspace-migration/interfaces/workspace-column-action-options.interface';
 
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { computeColumnName } from 'src/engine/metadata-modules/field-metadata/utils/compute-column-name.util';
 import { serializeDefaultValue } from 'src/engine/metadata-modules/field-metadata/utils/serialize-default-value';
 import { ColumnActionAbstractFactory } from 'src/engine/metadata-modules/workspace-migration/factories/column-action-abstract.factory';
@@ -29,7 +29,7 @@ export class EnumColumnActionFactory extends ColumnActionAbstractFactory<EnumFie
   protected readonly logger = new Logger(EnumColumnActionFactory.name);
 
   protected handleCreateAction(
-    fieldMetadata: FieldMetadataInterface<EnumFieldMetadataType>,
+    fieldMetadata: FieldMetadataEntity<EnumFieldMetadataType>,
     options: WorkspaceColumnActionOptions,
   ): WorkspaceMigrationColumnCreate[] {
     const columnName = computeColumnName(fieldMetadata);
@@ -54,8 +54,8 @@ export class EnumColumnActionFactory extends ColumnActionAbstractFactory<EnumFie
   }
 
   protected handleAlterAction(
-    currentFieldMetadata: FieldMetadataInterface<EnumFieldMetadataType>,
-    alteredFieldMetadata: FieldMetadataInterface<EnumFieldMetadataType>,
+    currentFieldMetadata: FieldMetadataEntity<EnumFieldMetadataType>,
+    alteredFieldMetadata: FieldMetadataEntity<EnumFieldMetadataType>,
     options: WorkspaceColumnActionOptions,
   ): WorkspaceMigrationColumnAlter[] {
     const currentColumnName = computeColumnName(currentFieldMetadata);

--- a/packages/twenty-server/src/engine/metadata-modules/workspace-migration/factories/morph-relation-column-action.factory.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/workspace-migration/factories/morph-relation-column-action.factory.ts
@@ -2,10 +2,10 @@ import { Injectable, Logger } from '@nestjs/common';
 
 import { FieldMetadataType } from 'twenty-shared/types';
 
-import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
 import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
 import { WorkspaceColumnActionOptions } from 'src/engine/metadata-modules/workspace-migration/interfaces/workspace-column-action-options.interface';
 
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { ColumnActionAbstractFactory } from 'src/engine/metadata-modules/workspace-migration/factories/column-action-abstract.factory';
 import { fieldMetadataTypeToColumnType } from 'src/engine/metadata-modules/workspace-migration/utils/field-metadata-type-to-column-type.util';
 import {
@@ -23,7 +23,7 @@ export class MorphRelationColumnActionFactory extends ColumnActionAbstractFactor
   protected readonly logger = new Logger(MorphRelationColumnActionFactory.name);
 
   protected handleCreateAction(
-    fieldMetadata: FieldMetadataInterface<FieldMetadataType.MORPH_RELATION>,
+    fieldMetadata: FieldMetadataEntity<FieldMetadataType.MORPH_RELATION>,
     _options?: WorkspaceColumnActionOptions,
   ): WorkspaceMigrationColumnCreate[] {
     if (!fieldMetadata.settings || !fieldMetadata.settings.joinColumnName) {
@@ -46,8 +46,8 @@ export class MorphRelationColumnActionFactory extends ColumnActionAbstractFactor
   }
 
   protected handleAlterAction(
-    currentFieldMetadata: FieldMetadataInterface<FieldMetadataType.MORPH_RELATION>,
-    alteredFieldMetadata: FieldMetadataInterface<FieldMetadataType.MORPH_RELATION>,
+    currentFieldMetadata: FieldMetadataEntity<FieldMetadataType.MORPH_RELATION>,
+    alteredFieldMetadata: FieldMetadataEntity<FieldMetadataType.MORPH_RELATION>,
     _options?: WorkspaceColumnActionOptions,
   ): WorkspaceMigrationColumnAlter[] {
     if (!currentFieldMetadata.settings || !alteredFieldMetadata.settings) {

--- a/packages/twenty-server/src/engine/metadata-modules/workspace-migration/factories/relation-column-action.factory.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/workspace-migration/factories/relation-column-action.factory.ts
@@ -2,10 +2,10 @@ import { Injectable, Logger } from '@nestjs/common';
 
 import { FieldMetadataType } from 'twenty-shared/types';
 
-import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
 import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
 import { WorkspaceColumnActionOptions } from 'src/engine/metadata-modules/workspace-migration/interfaces/workspace-column-action-options.interface';
 
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { ColumnActionAbstractFactory } from 'src/engine/metadata-modules/workspace-migration/factories/column-action-abstract.factory';
 import { fieldMetadataTypeToColumnType } from 'src/engine/metadata-modules/workspace-migration/utils/field-metadata-type-to-column-type.util';
 import {
@@ -23,7 +23,7 @@ export class RelationColumnActionFactory extends ColumnActionAbstractFactory<Fie
   protected readonly logger = new Logger(RelationColumnActionFactory.name);
 
   protected handleCreateAction(
-    fieldMetadata: FieldMetadataInterface<FieldMetadataType.RELATION>,
+    fieldMetadata: FieldMetadataEntity<FieldMetadataType.RELATION>,
     _options?: WorkspaceColumnActionOptions,
   ): WorkspaceMigrationColumnCreate[] {
     if (!fieldMetadata.settings || !fieldMetadata.settings.joinColumnName) {
@@ -46,8 +46,8 @@ export class RelationColumnActionFactory extends ColumnActionAbstractFactory<Fie
   }
 
   protected handleAlterAction(
-    currentFieldMetadata: FieldMetadataInterface<FieldMetadataType.RELATION>,
-    alteredFieldMetadata: FieldMetadataInterface<FieldMetadataType.RELATION>,
+    currentFieldMetadata: FieldMetadataEntity<FieldMetadataType.RELATION>,
+    alteredFieldMetadata: FieldMetadataEntity<FieldMetadataType.RELATION>,
     _options?: WorkspaceColumnActionOptions,
   ): WorkspaceMigrationColumnAlter[] {
     if (!currentFieldMetadata.settings || !alteredFieldMetadata.settings) {

--- a/packages/twenty-server/src/engine/metadata-modules/workspace-migration/factories/ts-vector-column-action.factory.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/workspace-migration/factories/ts-vector-column-action.factory.ts
@@ -2,16 +2,15 @@ import { Injectable, Logger } from '@nestjs/common';
 
 import { FieldMetadataType } from 'twenty-shared/types';
 
-
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { computeColumnName } from 'src/engine/metadata-modules/field-metadata/utils/compute-column-name.util';
 import { ColumnActionAbstractFactory } from 'src/engine/metadata-modules/workspace-migration/factories/column-action-abstract.factory';
 import { fieldMetadataTypeToColumnType } from 'src/engine/metadata-modules/workspace-migration/utils/field-metadata-type-to-column-type.util';
 import {
-    WorkspaceMigrationColumnActionType,
-    WorkspaceMigrationColumnAlter,
-    WorkspaceMigrationColumnCreate,
+  WorkspaceMigrationColumnActionType,
+  WorkspaceMigrationColumnAlter,
+  WorkspaceMigrationColumnCreate,
 } from 'src/engine/metadata-modules/workspace-migration/workspace-migration.entity';
-import { FieldMetadataEntity } from '../../field-metadata/field-metadata.entity';
 
 export type TsVectorFieldMetadata =
   FieldMetadataEntity<FieldMetadataType.TS_VECTOR> & {

--- a/packages/twenty-server/src/engine/metadata-modules/workspace-migration/factories/ts-vector-column-action.factory.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/workspace-migration/factories/ts-vector-column-action.factory.ts
@@ -2,19 +2,19 @@ import { Injectable, Logger } from '@nestjs/common';
 
 import { FieldMetadataType } from 'twenty-shared/types';
 
-import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
 
 import { computeColumnName } from 'src/engine/metadata-modules/field-metadata/utils/compute-column-name.util';
 import { ColumnActionAbstractFactory } from 'src/engine/metadata-modules/workspace-migration/factories/column-action-abstract.factory';
 import { fieldMetadataTypeToColumnType } from 'src/engine/metadata-modules/workspace-migration/utils/field-metadata-type-to-column-type.util';
 import {
-  WorkspaceMigrationColumnActionType,
-  WorkspaceMigrationColumnAlter,
-  WorkspaceMigrationColumnCreate,
+    WorkspaceMigrationColumnActionType,
+    WorkspaceMigrationColumnAlter,
+    WorkspaceMigrationColumnCreate,
 } from 'src/engine/metadata-modules/workspace-migration/workspace-migration.entity';
+import { FieldMetadataEntity } from '../../field-metadata/field-metadata.entity';
 
 export type TsVectorFieldMetadata =
-  FieldMetadataInterface<FieldMetadataType.TS_VECTOR> & {
+  FieldMetadataEntity<FieldMetadataType.TS_VECTOR> & {
     generatedType?: 'STORED' | 'VIRTUAL';
     asExpression?: string;
   };

--- a/packages/twenty-server/src/engine/metadata-modules/workspace-migration/interfaces/workspace-column-action-factory.interface.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/workspace-migration/interfaces/workspace-column-action-factory.interface.ts
@@ -1,8 +1,8 @@
 import { FieldMetadataType } from 'twenty-shared/types';
 
-import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
 import { WorkspaceColumnActionOptions } from 'src/engine/metadata-modules/workspace-migration/interfaces/workspace-column-action-options.interface';
 
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import {
   WorkspaceMigrationColumnAction,
   WorkspaceMigrationColumnActionType,
@@ -13,8 +13,8 @@ export interface WorkspaceColumnActionFactory<T extends FieldMetadataType> {
     action:
       | WorkspaceMigrationColumnActionType.CREATE
       | WorkspaceMigrationColumnActionType.ALTER,
-    currentFieldMetadata: FieldMetadataInterface<T> | undefined,
-    alteredFieldMetadata: FieldMetadataInterface<T>,
+    currentFieldMetadata: FieldMetadataEntity<T> | undefined,
+    alteredFieldMetadata: FieldMetadataEntity<T>,
     options?: WorkspaceColumnActionOptions,
   ): WorkspaceMigrationColumnAction[];
 }

--- a/packages/twenty-server/src/engine/metadata-modules/workspace-migration/workspace-migration.factory.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/workspace-migration/workspace-migration.factory.ts
@@ -2,10 +2,10 @@ import { Injectable, Logger } from '@nestjs/common';
 
 import { FieldMetadataType } from 'twenty-shared/types';
 
-import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
 import { WorkspaceColumnActionFactory } from 'src/engine/metadata-modules/workspace-migration/interfaces/workspace-column-action-factory.interface';
 import { WorkspaceColumnActionOptions } from 'src/engine/metadata-modules/workspace-migration/interfaces/workspace-column-action-options.interface';
 
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { BasicColumnActionFactory } from 'src/engine/metadata-modules/workspace-migration/factories/basic-column-action.factory';
 import { CompositeColumnActionFactory } from 'src/engine/metadata-modules/workspace-migration/factories/composite-column-action.factory';
 import { EnumColumnActionFactory } from 'src/engine/metadata-modules/workspace-migration/factories/enum-column-action.factory';
@@ -120,18 +120,18 @@ export class WorkspaceMigrationFactory {
 
   createColumnActions<T extends FieldMetadataType = FieldMetadataType>(
     action: WorkspaceMigrationColumnActionType.CREATE,
-    fieldMetadata: FieldMetadataInterface<T>,
+    fieldMetadata: FieldMetadataEntity<T>,
   ): WorkspaceMigrationColumnAction[];
 
   createColumnActions(
     action: WorkspaceMigrationColumnActionType.ALTER,
-    currentFieldMetadata: FieldMetadataInterface,
-    alteredFieldMetadata: FieldMetadataInterface,
+    currentFieldMetadata: FieldMetadataEntity,
+    alteredFieldMetadata: FieldMetadataEntity,
   ): WorkspaceMigrationColumnAction[];
 
   createColumnActions(
     action: WorkspaceMigrationColumnActionType.ALTER,
-    currentFieldMetadata: FieldMetadataInterface,
+    currentFieldMetadata: FieldMetadataEntity,
     alteredFieldMetadata: TsVectorFieldMetadata,
   ): WorkspaceMigrationColumnAction[];
 
@@ -139,8 +139,8 @@ export class WorkspaceMigrationFactory {
     action:
       | WorkspaceMigrationColumnActionType.CREATE
       | WorkspaceMigrationColumnActionType.ALTER,
-    fieldMetadataOrCurrentFieldMetadata: FieldMetadataInterface,
-    undefinedOrAlteredFieldMetadata?: FieldMetadataInterface,
+    fieldMetadataOrCurrentFieldMetadata: FieldMetadataEntity,
+    undefinedOrAlteredFieldMetadata?: FieldMetadataEntity,
   ): WorkspaceMigrationColumnAction[] {
     const currentFieldMetadata =
       action === WorkspaceMigrationColumnActionType.ALTER
@@ -176,8 +176,8 @@ export class WorkspaceMigrationFactory {
     action:
       | WorkspaceMigrationColumnActionType.CREATE
       | WorkspaceMigrationColumnActionType.ALTER,
-    currentFieldMetadata: FieldMetadataInterface | undefined,
-    alteredFieldMetadata: FieldMetadataInterface,
+    currentFieldMetadata: FieldMetadataEntity | undefined,
+    alteredFieldMetadata: FieldMetadataEntity,
   ): WorkspaceMigrationColumnAction[] {
     const { factory, options } =
       this.factoriesMap.get(alteredFieldMetadata.type) ?? {};

--- a/packages/twenty-server/src/engine/twenty-orm/entity-manager/types/relation-connect-query-config.type.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/entity-manager/types/relation-connect-query-config.type.ts
@@ -1,6 +1,6 @@
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { FieldMetadataType } from 'twenty-shared/types';
 
-import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
 
 export type UniqueFieldCondition = [field: string, value: string];
 
@@ -11,7 +11,7 @@ export type RelationConnectQueryConfig = {
   recordToConnectConditions: UniqueConstraintCondition[];
   relationFieldName: string;
   connectFieldName: string;
-  uniqueConstraintFields: FieldMetadataInterface<FieldMetadataType>[];
+  uniqueConstraintFields: FieldMetadataEntity<FieldMetadataType>[];
   recordToConnectConditionByEntityIndex: {
     [entityIndex: number]: UniqueConstraintCondition;
   };

--- a/packages/twenty-server/src/engine/twenty-orm/entity-manager/types/relation-connect-query-config.type.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/entity-manager/types/relation-connect-query-config.type.ts
@@ -1,6 +1,6 @@
-import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { FieldMetadataType } from 'twenty-shared/types';
 
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 
 export type UniqueFieldCondition = [field: string, value: string];
 

--- a/packages/twenty-server/src/engine/twenty-orm/factories/entity-schema-column.factory.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/factories/entity-schema-column.factory.ts
@@ -18,7 +18,7 @@ import {
   TwentyORMException,
   TwentyORMExceptionCode,
 } from 'src/engine/twenty-orm/exceptions/twenty-orm.exception';
-import { isFieldMetadataInterfaceOfType } from 'src/engine/utils/is-field-metadata-of-type.util';
+import { isFieldMetadataEntityOfType } from 'src/engine/utils/is-field-metadata-of-type.util';
 
 type EntitySchemaColumnMap = {
   [key: string]: EntitySchemaColumnOptions;
@@ -39,11 +39,11 @@ export class EntitySchemaColumnFactory {
       const key = fieldMetadata.name;
 
       const isRelation =
-        isFieldMetadataInterfaceOfType(
+        isFieldMetadataEntityOfType(
           fieldMetadata,
           FieldMetadataType.RELATION,
         ) ||
-        isFieldMetadataInterfaceOfType(
+        isFieldMetadataEntityOfType(
           fieldMetadata,
           FieldMetadataType.MORPH_RELATION,
         );

--- a/packages/twenty-server/src/engine/twenty-orm/factories/entity-schema-column.factory.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/factories/entity-schema-column.factory.ts
@@ -4,10 +4,10 @@ import { FieldMetadataType } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 import { ColumnType, EntitySchemaColumnOptions } from 'typeorm';
 
-import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
 import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
 
 import { compositeTypeDefinitions } from 'src/engine/metadata-modules/field-metadata/composite-types';
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { computeCompositeColumnName } from 'src/engine/metadata-modules/field-metadata/utils/compute-column-name.util';
 import { isCompositeFieldMetadataType } from 'src/engine/metadata-modules/field-metadata/utils/is-composite-field-metadata-type.util';
 import { isEnumFieldMetadataType } from 'src/engine/metadata-modules/field-metadata/utils/is-enum-field-metadata-type.util';
@@ -113,7 +113,7 @@ export class EntitySchemaColumnFactory {
   }
 
   private createCompositeColumns(
-    fieldMetadata: FieldMetadataInterface,
+    fieldMetadata: FieldMetadataEntity,
   ): EntitySchemaColumnMap {
     const entitySchemaColumnMap: EntitySchemaColumnMap = {};
     const compositeType = compositeTypeDefinitions.get(fieldMetadata.type);

--- a/packages/twenty-server/src/engine/twenty-orm/factories/entity-schema-relation.factory.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/factories/entity-schema-relation.factory.ts
@@ -6,7 +6,7 @@ import { EntitySchemaRelationOptions } from 'typeorm';
 import { ObjectMetadataItemWithFieldMaps } from 'src/engine/metadata-modules/types/object-metadata-item-with-field-maps';
 import { ObjectMetadataMaps } from 'src/engine/metadata-modules/types/object-metadata-maps';
 import { determineSchemaRelationDetails } from 'src/engine/twenty-orm/utils/determine-schema-relation-details.util';
-import { isFieldMetadataInterfaceOfType } from 'src/engine/utils/is-field-metadata-of-type.util';
+import { isFieldMetadataEntityOfType } from 'src/engine/utils/is-field-metadata-of-type.util';
 
 type EntitySchemaRelationMap = {
   [key: string]: EntitySchemaRelationOptions;
@@ -28,11 +28,11 @@ export class EntitySchemaRelationFactory {
 
     for (const fieldMetadata of fieldMetadataCollection) {
       const isRelation =
-        isFieldMetadataInterfaceOfType(
+        isFieldMetadataEntityOfType(
           fieldMetadata,
           FieldMetadataType.RELATION,
         ) ||
-        isFieldMetadataInterfaceOfType(
+        isFieldMetadataEntityOfType(
           fieldMetadata,
           FieldMetadataType.MORPH_RELATION,
         );

--- a/packages/twenty-server/src/engine/twenty-orm/utils/compute-relation-connect-query-configs.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/compute-relation-connect-query-configs.util.ts
@@ -3,10 +3,10 @@ import deepEqual from 'deep-equal';
 import { FieldMetadataType } from 'twenty-shared/types';
 import { getUniqueConstraintsFields, isDefined } from 'twenty-shared/utils';
 
-import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
 import { ObjectMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/object-metadata.interface';
 import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
 
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { isCompositeFieldMetadataType } from 'src/engine/metadata-modules/field-metadata/utils/is-composite-field-metadata-type.util';
 import { ObjectMetadataItemWithFieldMaps } from 'src/engine/metadata-modules/types/object-metadata-item-with-field-maps';
 import { ObjectMetadataMaps } from 'src/engine/metadata-modules/types/object-metadata-maps';
@@ -101,7 +101,7 @@ const updateConnectQueryConfigs = (
 const createConnectQueryConfig = (
   connectFieldName: string,
   recordToConnectCondition: UniqueConstraintCondition,
-  uniqueConstraintFields: FieldMetadataInterface<FieldMetadataType>[],
+  uniqueConstraintFields: FieldMetadataEntity<FieldMetadataType>[],
   targetObjectNameSingular: string,
   entityIndex: number,
 ) => {
@@ -125,7 +125,7 @@ const computeRecordToConnectCondition = (
   entity: Record<string, unknown>,
 ): {
   recordToConnectCondition: UniqueConstraintCondition;
-  uniqueConstraintFields: FieldMetadataInterface<FieldMetadataType>[];
+  uniqueConstraintFields: FieldMetadataEntity<FieldMetadataType>[];
   targetObjectNameSingular: string;
 } => {
   const field =
@@ -239,7 +239,7 @@ const checkUniqueConstraintFullyPopulated = (
   connectFieldName: string,
 ) => {
   const uniqueConstraintsFields = getUniqueConstraintsFields<
-    FieldMetadataInterface,
+    FieldMetadataEntity,
     ObjectMetadataInterface
   >({
     ...objectMetadata,
@@ -298,7 +298,7 @@ const checkNoRelationFieldConflictOrThrow = (
 };
 
 const computeUniqueConstraintCondition = (
-  uniqueConstraintFields: FieldMetadataInterface<FieldMetadataType>[],
+  uniqueConstraintFields: FieldMetadataEntity<FieldMetadataType>[],
   connectObject: ConnectObject,
 ): UniqueConstraintCondition => {
   return uniqueConstraintFields.reduce((acc, uniqueConstraintField) => {
@@ -326,7 +326,7 @@ const computeUniqueConstraintCondition = (
 
 const checkUniqueConstraintsAreSameOrThrow = (
   relationConnectQueryConfig: RelationConnectQueryConfig,
-  uniqueConstraintFields: FieldMetadataInterface<FieldMetadataType>[],
+  uniqueConstraintFields: FieldMetadataEntity<FieldMetadataType>[],
 ) => {
   if (
     !deepEqual(

--- a/packages/twenty-server/src/engine/twenty-orm/utils/compute-relation-connect-query-configs.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/compute-relation-connect-query-configs.util.ts
@@ -21,7 +21,7 @@ import {
 } from 'src/engine/twenty-orm/exceptions/twenty-orm.exception';
 import { formatCompositeField } from 'src/engine/twenty-orm/utils/format-data.util';
 import { getAssociatedRelationFieldName } from 'src/engine/twenty-orm/utils/get-associated-relation-field-name.util';
-import { isFieldMetadataInterfaceOfType } from 'src/engine/utils/is-field-metadata-of-type.util';
+import { isFieldMetadataEntityOfType } from 'src/engine/utils/is-field-metadata-of-type.util';
 
 export const computeRelationConnectQueryConfigs = (
   entities: Record<string, unknown>[],
@@ -132,7 +132,7 @@ const computeRecordToConnectCondition = (
     objectMetadata.fieldsById[objectMetadata.fieldIdByName[connectFieldName]];
 
   if (
-    !isFieldMetadataInterfaceOfType(field, FieldMetadataType.RELATION) ||
+    !isFieldMetadataEntityOfType(field, FieldMetadataType.RELATION) ||
     field.settings?.relationType !== RelationType.MANY_TO_ONE
   ) {
     const objectMetadataNameSingular = objectMetadata.nameSingular;

--- a/packages/twenty-server/src/engine/twenty-orm/utils/determine-schema-relation-details.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/determine-schema-relation-details.util.ts
@@ -1,7 +1,6 @@
 import { FieldMetadataType } from 'twenty-shared/types';
 import { RelationType } from 'typeorm/metadata/types/RelationTypes';
 
-
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { ObjectMetadataMaps } from 'src/engine/metadata-modules/types/object-metadata-maps';
 import {

--- a/packages/twenty-server/src/engine/twenty-orm/utils/determine-schema-relation-details.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/determine-schema-relation-details.util.ts
@@ -1,8 +1,8 @@
 import { FieldMetadataType } from 'twenty-shared/types';
 import { RelationType } from 'typeorm/metadata/types/RelationTypes';
 
-import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
 
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { ObjectMetadataMaps } from 'src/engine/metadata-modules/types/object-metadata-maps';
 import {
   RelationException,
@@ -18,7 +18,7 @@ interface RelationDetails {
 }
 
 export async function determineSchemaRelationDetails(
-  fieldMetadata: FieldMetadataInterface<
+  fieldMetadata: FieldMetadataEntity<
     FieldMetadataType.RELATION | FieldMetadataType.MORPH_RELATION
   >,
   objectMetadataMaps: ObjectMetadataMaps,

--- a/packages/twenty-server/src/engine/twenty-orm/utils/format-data.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/format-data.util.ts
@@ -1,7 +1,6 @@
 import { FieldMetadataType } from 'twenty-shared/types';
 import { capitalize } from 'twenty-shared/utils';
 
-
 import { compositeTypeDefinitions } from 'src/engine/metadata-modules/field-metadata/composite-types';
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { isCompositeFieldMetadataType } from 'src/engine/metadata-modules/field-metadata/utils/is-composite-field-metadata-type.util';

--- a/packages/twenty-server/src/engine/twenty-orm/utils/format-data.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/format-data.util.ts
@@ -1,9 +1,9 @@
 import { FieldMetadataType } from 'twenty-shared/types';
 import { capitalize } from 'twenty-shared/utils';
 
-import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
 
 import { compositeTypeDefinitions } from 'src/engine/metadata-modules/field-metadata/composite-types';
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { isCompositeFieldMetadataType } from 'src/engine/metadata-modules/field-metadata/utils/is-composite-field-metadata-type.util';
 import { ObjectMetadataItemWithFieldMaps } from 'src/engine/metadata-modules/types/object-metadata-item-with-field-maps';
 import { CompositeFieldMetadataType } from 'src/engine/metadata-modules/workspace-migration/factories/composite-column-action.factory';
@@ -57,7 +57,7 @@ export function formatData<T>(
 export function formatCompositeField(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   value: any,
-  fieldMetadata: FieldMetadataInterface,
+  fieldMetadata: FieldMetadataEntity,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): Record<string, any> {
   const compositeType = compositeTypeDefinitions.get(
@@ -80,7 +80,7 @@ export function formatCompositeField(
     if (value && value[subFieldKey] !== undefined) {
       formattedCompositeField[fullFieldName] = formatFieldMetadataValue(
         value[subFieldKey],
-        property as unknown as FieldMetadataInterface,
+        property as unknown as FieldMetadataEntity,
       );
     }
   }
@@ -91,7 +91,7 @@ export function formatCompositeField(
 function formatFieldMetadataValue(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   value: any,
-  fieldMetadata: FieldMetadataInterface,
+  fieldMetadata: FieldMetadataEntity,
 ) {
   if (
     fieldMetadata.type === FieldMetadataType.RAW_JSON &&

--- a/packages/twenty-server/src/engine/twenty-orm/utils/format-result.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/format-result.util.ts
@@ -4,9 +4,9 @@ import { isNonEmptyString } from '@sniptt/guards';
 import { FieldMetadataType } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 
-import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
 
 import { compositeTypeDefinitions } from 'src/engine/metadata-modules/field-metadata/composite-types';
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { computeCompositeColumnName } from 'src/engine/metadata-modules/field-metadata/utils/compute-column-name.util';
 import { ObjectMetadataItemWithFieldMaps } from 'src/engine/metadata-modules/types/object-metadata-item-with-field-maps';
 import { ObjectMetadataMaps } from 'src/engine/metadata-modules/types/object-metadata-maps';
@@ -52,7 +52,7 @@ export function formatResult<T>(
 
     const fieldMetadata = objectMetadataItemWithFieldMaps.fieldsById[
       fieldMetadataId
-    ] as FieldMetadataInterface<FieldMetadataType> | undefined;
+    ] as FieldMetadataEntity<FieldMetadataType> | undefined;
 
     const isRelation = fieldMetadata
       ? isFieldMetadataInterfaceOfType(
@@ -204,7 +204,7 @@ export function getCompositeFieldMetadataMap(
 function formatFieldMetadataValue(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   value: any,
-  fieldMetadata: FieldMetadataInterface,
+  fieldMetadata: FieldMetadataEntity,
 ) {
   if (
     typeof value === 'string' &&

--- a/packages/twenty-server/src/engine/twenty-orm/utils/format-result.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/format-result.util.ts
@@ -4,7 +4,6 @@ import { isNonEmptyString } from '@sniptt/guards';
 import { FieldMetadataType } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 
-
 import { compositeTypeDefinitions } from 'src/engine/metadata-modules/field-metadata/composite-types';
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { computeCompositeColumnName } from 'src/engine/metadata-modules/field-metadata/utils/compute-column-name.util';

--- a/packages/twenty-server/src/engine/twenty-orm/utils/format-result.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/format-result.util.ts
@@ -10,7 +10,7 @@ import { computeCompositeColumnName } from 'src/engine/metadata-modules/field-me
 import { ObjectMetadataItemWithFieldMaps } from 'src/engine/metadata-modules/types/object-metadata-item-with-field-maps';
 import { ObjectMetadataMaps } from 'src/engine/metadata-modules/types/object-metadata-maps';
 import { getCompositeFieldMetadataCollection } from 'src/engine/twenty-orm/utils/get-composite-field-metadata-collection';
-import { isFieldMetadataInterfaceOfType } from 'src/engine/utils/is-field-metadata-of-type.util';
+import { isFieldMetadataEntityOfType } from 'src/engine/utils/is-field-metadata-of-type.util';
 import { isDate } from 'src/utils/date/isDate';
 import { isValidDate } from 'src/utils/date/isValidDate';
 
@@ -54,7 +54,7 @@ export function formatResult<T>(
     ] as FieldMetadataEntity<FieldMetadataType> | undefined;
 
     const isRelation = fieldMetadata
-      ? isFieldMetadataInterfaceOfType(
+      ? isFieldMetadataEntityOfType(
           fieldMetadata,
           FieldMetadataType.RELATION,
         )

--- a/packages/twenty-server/src/engine/twenty-orm/utils/format-result.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/format-result.util.ts
@@ -54,10 +54,7 @@ export function formatResult<T>(
     ] as FieldMetadataEntity<FieldMetadataType> | undefined;
 
     const isRelation = fieldMetadata
-      ? isFieldMetadataEntityOfType(
-          fieldMetadata,
-          FieldMetadataType.RELATION,
-        )
+      ? isFieldMetadataEntityOfType(fieldMetadata, FieldMetadataType.RELATION)
       : false;
 
     if (!compositePropertyArgs && !isRelation) {

--- a/packages/twenty-server/src/engine/utils/is-field-metadata-of-type.util.ts
+++ b/packages/twenty-server/src/engine/utils/is-field-metadata-of-type.util.ts
@@ -2,16 +2,6 @@ import { FieldMetadataType } from 'twenty-shared/types';
 
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 
-export function isFieldMetadataInterfaceOfType<
-  Field extends FieldMetadataEntity<FieldMetadataType>,
-  Type extends FieldMetadataType,
->(
-  fieldMetadata: Pick<Field, 'type'>,
-  type: Type,
-): fieldMetadata is Field & FieldMetadataEntity<Type> {
-  return fieldMetadata.type === type;
-}
-
 export function isFieldMetadataEntityOfType<
   Field extends FieldMetadataEntity<FieldMetadataType>,
   Type extends FieldMetadataType,

--- a/packages/twenty-server/src/engine/utils/is-field-metadata-of-type.util.ts
+++ b/packages/twenty-server/src/engine/utils/is-field-metadata-of-type.util.ts
@@ -2,7 +2,6 @@ import { FieldMetadataType } from 'twenty-shared/types';
 
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 
-
 export function isFieldMetadataInterfaceOfType<
   Field extends FieldMetadataEntity<FieldMetadataType>,
   Type extends FieldMetadataType,

--- a/packages/twenty-server/src/engine/utils/is-field-metadata-of-type.util.ts
+++ b/packages/twenty-server/src/engine/utils/is-field-metadata-of-type.util.ts
@@ -1,16 +1,15 @@
 import { FieldMetadataType } from 'twenty-shared/types';
 
-import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
-
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 
+
 export function isFieldMetadataInterfaceOfType<
-  Field extends FieldMetadataInterface<FieldMetadataType>,
+  Field extends FieldMetadataEntity<FieldMetadataType>,
   Type extends FieldMetadataType,
 >(
   fieldMetadata: Pick<Field, 'type'>,
   type: Type,
-): fieldMetadata is Field & FieldMetadataInterface<Type> {
+): fieldMetadata is Field & FieldMetadataEntity<Type> {
   return fieldMetadata.type === type;
 }
 

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/interfaces/partial-field-metadata.interface.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/interfaces/partial-field-metadata.interface.ts
@@ -1,15 +1,15 @@
 import { FieldMetadataType } from 'twenty-shared/types';
 
-import { FieldMetadataInterface } from 'src/engine/metadata-modules/field-metadata/interfaces/field-metadata.interface';
 import { WorkspaceDynamicRelationMetadataArgsFactory } from 'src/engine/twenty-orm/interfaces/workspace-dynamic-relation-metadata-args.interface';
 
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 
 // Should get deprecated in favor of the FlatFieldMetadata
 export type PartialFieldMetadata<
   T extends FieldMetadataType = FieldMetadataType,
 > = Omit<
-  FieldMetadataInterface<T>,
+  FieldMetadataEntity<T>,
   | 'id'
   | 'label'
   | 'description'


### PR DESCRIPTION
# Introduction
Following https://github.com/twentyhq/twenty/pull/13264
> After this PR merge will create a new one removing the type and replacing it to FieldMetadataEntity.

This is it !