### PR TITLE
Fix rest metadata api

### DIFF
--- a/packages/twenty-server/src/engine/api/rest/metadata/rest-api-metadata.service.ts
+++ b/packages/twenty-server/src/engine/api/rest/metadata/rest-api-metadata.service.ts
@@ -7,57 +7,73 @@ import {
   GraphqlApiType,
   RestApiService,
 } from 'src/engine/api/rest/rest-api.service';
-import { AccessTokenService } from 'src/engine/core-modules/auth/token/services/access-token.service';
+import { RequestContext } from 'src/engine/api/rest/types/RequestContext';
+import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
+import { getServerUrl } from 'src/utils/get-server-url';
 
 @Injectable()
 export class RestApiMetadataService {
   constructor(
-    private readonly accessTokenService: AccessTokenService,
     private readonly metadataQueryBuilderFactory: MetadataQueryBuilderFactory,
     private readonly restApiService: RestApiService,
+    private readonly twentyConfigService: TwentyConfigService,
   ) {}
 
   async get(request: Request) {
-    await this.accessTokenService.validateTokenByRequest(request);
-    const data = await this.metadataQueryBuilderFactory.get(request);
+    const requestContext = this.getRequestContext(request);
+    const data = await this.metadataQueryBuilderFactory.get(requestContext);
 
     return await this.restApiService.call(
       GraphqlApiType.METADATA,
-      request,
+      requestContext,
       data,
     );
   }
 
   async create(request: Request) {
-    await this.accessTokenService.validateTokenByRequest(request);
-    const data = await this.metadataQueryBuilderFactory.create(request);
+    const requestContext = this.getRequestContext(request);
+    const data = await this.metadataQueryBuilderFactory.create(requestContext);
 
     return await this.restApiService.call(
       GraphqlApiType.METADATA,
-      request,
+      requestContext,
       data,
     );
   }
 
   async update(request: Request) {
-    await this.accessTokenService.validateTokenByRequest(request);
-    const data = await this.metadataQueryBuilderFactory.update(request);
+    const requestContext = this.getRequestContext(request);
+    const data = await this.metadataQueryBuilderFactory.update(requestContext);
 
     return await this.restApiService.call(
       GraphqlApiType.METADATA,
-      request,
+      requestContext,
       data,
     );
   }
 
   async delete(request: Request) {
-    await this.accessTokenService.validateTokenByRequest(request);
-    const data = await this.metadataQueryBuilderFactory.delete(request);
+    const requestContext = this.getRequestContext(request);
+    const data = await this.metadataQueryBuilderFactory.delete(requestContext);
 
     return await this.restApiService.call(
       GraphqlApiType.METADATA,
-      request,
+      requestContext,
       data,
     );
+  }
+
+  private getRequestContext(request: Request): RequestContext {
+    const baseUrl = getServerUrl(
+      this.twentyConfigService.get('SERVER_URL'),
+      `${request.protocol}://${request.get('host')}`,
+    );
+
+    return {
+      body: request.body?.params?.arguments,
+      baseUrl: baseUrl,
+      path: request.url,
+      headers: request.headers,
+    };
   }
 }

--- a/packages/twenty-server/src/engine/api/rest/metadata/rest-api-metadata.service.ts
+++ b/packages/twenty-server/src/engine/api/rest/metadata/rest-api-metadata.service.ts
@@ -8,18 +8,21 @@ import {
   RestApiService,
 } from 'src/engine/api/rest/rest-api.service';
 import { RequestContext } from 'src/engine/api/rest/types/RequestContext';
+import { AccessTokenService } from 'src/engine/core-modules/auth/token/services/access-token.service';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import { getServerUrl } from 'src/utils/get-server-url';
 
 @Injectable()
 export class RestApiMetadataService {
   constructor(
+    private readonly accessTokenService: AccessTokenService,
     private readonly metadataQueryBuilderFactory: MetadataQueryBuilderFactory,
     private readonly restApiService: RestApiService,
     private readonly twentyConfigService: TwentyConfigService,
   ) {}
 
   async get(request: Request) {
+    await this.accessTokenService.validateTokenByRequest(request);
     const requestContext = this.getRequestContext(request);
     const data = await this.metadataQueryBuilderFactory.get(requestContext);
 
@@ -31,6 +34,7 @@ export class RestApiMetadataService {
   }
 
   async create(request: Request) {
+    await this.accessTokenService.validateTokenByRequest(request);
     const requestContext = this.getRequestContext(request);
     const data = await this.metadataQueryBuilderFactory.create(requestContext);
 
@@ -42,6 +46,7 @@ export class RestApiMetadataService {
   }
 
   async update(request: Request) {
+    await this.accessTokenService.validateTokenByRequest(request);
     const requestContext = this.getRequestContext(request);
     const data = await this.metadataQueryBuilderFactory.update(requestContext);
 
@@ -53,6 +58,7 @@ export class RestApiMetadataService {
   }
 
   async delete(request: Request) {
+    await this.accessTokenService.validateTokenByRequest(request);
     const requestContext = this.getRequestContext(request);
     const data = await this.metadataQueryBuilderFactory.delete(requestContext);
 

--- a/packages/twenty-server/src/engine/api/rest/metadata/rest-api-metadata.service.ts
+++ b/packages/twenty-server/src/engine/api/rest/metadata/rest-api-metadata.service.ts
@@ -76,7 +76,7 @@ export class RestApiMetadataService {
     );
 
     return {
-      body: request.body?.params?.arguments,
+      body: request.body,
       baseUrl: baseUrl,
       path: request.url,
       headers: request.headers,


### PR DESCRIPTION
Regression introduced in https://github.com/twentyhq/twenty/pull/13150 where baseUrl is now used in a new requestContext param for MCP but was not hydrated for rest metadata api 
<img width="1334" height="556" alt="Screenshot 2025-07-22 at 15 52 39" src="https://github.com/user-attachments/assets/7f13797f-eb23-40ab-87b7-49196e4b9b92" />
