### PR TITLE
Fix increment/decrement methods in twenty orm

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-create-one-resolver.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-create-one-resolver.service.ts
@@ -52,14 +52,6 @@ export class GraphqlQueryCreateOneResolverService extends GraphqlQueryBaseResolv
           selectedColumns,
         );
 
-    await executionArgs.repository.increment(
-      {
-        id: In(objectRecords.generatedMaps.map((record) => record.id)),
-      },
-      'position',
-      1,
-    );
-
     const queryBuilder = executionArgs.repository.createQueryBuilder(
       objectMetadataItemWithFieldMaps.nameSingular,
     );

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-create-one-resolver.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-create-one-resolver.service.ts
@@ -52,6 +52,14 @@ export class GraphqlQueryCreateOneResolverService extends GraphqlQueryBaseResolv
           selectedColumns,
         );
 
+    await executionArgs.repository.increment(
+      {
+        id: In(objectRecords.generatedMaps.map((record) => record.id)),
+      },
+      'position',
+      1,
+    );
+
     const queryBuilder = executionArgs.repository.createQueryBuilder(
       objectMetadataItemWithFieldMaps.nameSingular,
     );

--- a/packages/twenty-server/src/engine/twenty-orm/entity-manager/workspace-entity-manager.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/entity-manager/workspace-entity-manager.ts
@@ -352,17 +352,13 @@ export class WorkspaceEntityManager extends EntityManager {
       () => this.connection.driver.escape(column.databaseName) + ' + ' + value,
     );
 
-    return this.createQueryBuilder(
+    return this.update(
       target,
-      'entity',
-      undefined,
+      criteria,
+      values,
       permissionOptions,
-    )
-      .update(target as QueryDeepPartialEntity<Entity>)
-      .set(values)
-      .where(criteria)
-      .returning(selectedColumns)
-      .execute();
+      selectedColumns,
+    );
   }
 
   validatePermissions<Entity extends ObjectLiteral>({
@@ -951,17 +947,13 @@ export class WorkspaceEntityManager extends EntityManager {
       () => this.connection.driver.escape(column.databaseName) + ' - ' + value,
     );
 
-    return this.createQueryBuilder(
+    return this.update(
       target,
-      'entity',
-      undefined,
+      criteria,
+      values,
       permissionOptions,
-    )
-      .update(target as QueryDeepPartialEntity<Entity>)
-      .set(values)
-      .where(criteria)
-      .returning(selectedColumns)
-      .execute();
+      selectedColumns,
+    );
   }
 
   override async findByIds<Entity extends ObjectLiteral>(


### PR DESCRIPTION
Increment/Decrement methods were broken and were executing a SELECT query while selecting twice the same table so the id column reference was not precise enough. For some reason it didn't recognise the builder as an update builder AND aliases were not parsed properly 
I've modified the code to re-use the existing update method that is correctly implemented-

BEFORE
```sql
query failed: SELECT entity FROM "workspace_1wgvd1injqtife6y4rvfbu3h5"."viewField" "entity", "workspace_1wgvd1injqtife6y4rvfbu3h5"."viewField" "workspace_1wgvd1injqtife6y4rvfbu3h5.viewField" WHERE "id" IN ($1) -- PARAMETERS: ["cd665f5b-c3ce-44ec-a9b0-51a2d711287e"]
error: error: column reference "id" is ambiguous
```


AFTER
```sql
query: UPDATE "workspace_1wgvd1injqtife6y4rvfbu3h5"."viewField" SET "position" = "position" + 1, "updatedAt" = CURRENT_TIMESTAMP WHERE "id" IN ($1) -- PARAMETERS: ["cd665f5b-c3ce-44ec-a9b0-51a2d711287e"]
```