### PR TITLE
Fix rest filter parsing

### DIFF
--- a/packages/twenty-server/src/engine/api/rest/core/query-builder/utils/filter-utils/parse-filter.utils.ts
+++ b/packages/twenty-server/src/engine/api/rest/core/query-builder/utils/filter-utils/parse-filter.utils.ts
@@ -21,7 +21,7 @@ export const parseFilter = (
 ): Record<string, FieldValue> => {
   const result = {};
   const match = filterQuery.match(
-    `^(${Object.values(Conjunctions).join('|')})((.+))$`,
+    `^(${Object.values(Conjunctions).join('|')})\\((.+)\\)$`,
   );
 
   if (match) {


### PR DESCRIPTION
Should now properly match logical expressions like and(...), or(...) instead of and/or without parenthesis, this should fix the issue with fields that start with or/and