### PR TITLE
Fix date field creation with disabled save button

### DIFF
--- a/packages/twenty-front/src/modules/settings/data-model/fields/forms/date/hooks/useDateSettingsFormInitialValues.ts
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/forms/date/hooks/useDateSettingsFormInitialValues.ts
@@ -9,10 +9,11 @@ export const useDateSettingsFormInitialValues = ({
 }: {
   fieldMetadataItem?: Pick<FieldMetadataItem, 'settings'>;
 }) => {
-  const initialDisplayFormat = fieldMetadataItem?.settings
-    ?.displayFormat as FieldDateDisplayFormat;
-  const initialCustomUnicodeDateFormat = fieldMetadataItem?.settings
-    ?.customUnicodeDateFormat as string;
+  const initialDisplayFormat =
+    (fieldMetadataItem?.settings?.displayFormat as FieldDateDisplayFormat) ??
+    FieldDateDisplayFormat.USER_SETTINGS;
+  const initialCustomUnicodeDateFormat =
+    (fieldMetadataItem?.settings?.customUnicodeDateFormat as string) ?? '';
 
   const { resetField } = useFormContext<SettingsDataModelFieldDateFormValues>();
 


### PR DESCRIPTION
Fixes https://github.com/twentyhq/twenty/issues/13297

See SettingsDataModelFieldDateForm form validation which expects a settings field to be present with a default display format. This PR adds the missing initial value.