### PR TITLE
Add upgrade enqueue enum V2 command

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-2/1-2-add-enqueued-status-to-workflow-run-v2.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-2/1-2-add-enqueued-status-to-workflow-run-v2.command.ts
@@ -1,0 +1,135 @@
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { Command } from 'nest-commander';
+import { Repository } from 'typeorm';
+
+import {
+  ActiveOrSuspendedWorkspacesMigrationCommandRunner,
+  RunOnWorkspaceArgs,
+} from 'src/database/commands/command-runners/active-or-suspended-workspaces-migration.command-runner';
+import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
+import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
+import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.manager';
+import { getWorkspaceSchemaName } from 'src/engine/workspace-datasource/utils/get-workspace-schema-name.util';
+import { WorkspaceDataSourceService } from 'src/engine/workspace-datasource/workspace-datasource.service';
+import { WORKFLOW_RUN_STANDARD_FIELD_IDS } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-field-ids';
+import { STANDARD_OBJECT_IDS } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-object-ids';
+import { WorkflowRunStatus } from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
+
+@Command({
+  name: 'upgrade:1-2:add-enqueued-status-to-workflow-run-v2',
+  description: 'Add enqueued status to workflow run',
+})
+export class AddEnqueuedStatusToWorkflowRunV2Command extends ActiveOrSuspendedWorkspacesMigrationCommandRunner {
+  constructor(
+    @InjectRepository(Workspace, 'core')
+    protected readonly workspaceRepository: Repository<Workspace>,
+    protected readonly twentyORMGlobalManager: TwentyORMGlobalManager,
+    @InjectRepository(ObjectMetadataEntity, 'core')
+    private readonly objectMetadataRepository: Repository<ObjectMetadataEntity>,
+    @InjectRepository(FieldMetadataEntity, 'core')
+    private readonly fieldMetadataRepository: Repository<FieldMetadataEntity>,
+    private readonly workspaceDataSourceService: WorkspaceDataSourceService,
+  ) {
+    super(workspaceRepository, twentyORMGlobalManager);
+  }
+
+  override async runOnWorkspace({
+    workspaceId,
+    options,
+  }: RunOnWorkspaceArgs): Promise<void> {
+    this.logger.log(
+      `Adding enqueued status to workflow run for workspace ${workspaceId}`,
+    );
+
+    const workflowRunObjectMetadata =
+      await this.objectMetadataRepository.findOne({
+        where: {
+          workspaceId,
+          standardId: STANDARD_OBJECT_IDS.workflowRun,
+        },
+      });
+
+    if (!workflowRunObjectMetadata) {
+      this.logger.error(
+        `Workflow run object metadata not found for workspace ${workspaceId}`,
+      );
+
+      return;
+    }
+
+    const workflowRunStatusFieldMetadata =
+      await this.fieldMetadataRepository.findOne({
+        where: {
+          standardId: WORKFLOW_RUN_STANDARD_FIELD_IDS.status,
+          objectMetadataId: workflowRunObjectMetadata.id,
+        },
+      });
+
+    if (!workflowRunStatusFieldMetadata) {
+      this.logger.error(
+        `Workflow run status field metadata not found for workspace ${workspaceId}`,
+      );
+
+      return;
+    }
+
+    const workflowRunStatusFieldMetadataOptions =
+      workflowRunStatusFieldMetadata.options;
+
+    // check if enqueued status is already in the field metadata options
+    if (
+      workflowRunStatusFieldMetadataOptions?.some(
+        (option) => option.value === WorkflowRunStatus.ENQUEUED,
+      )
+    ) {
+      this.logger.log(
+        `Workflow run status field metadata options already contain enqueued status for workspace ${workspaceId}`,
+      );
+
+      return;
+    } else if (options.dryRun) {
+      this.logger.log(
+        `Would add enqueued status to workflow run status field metadata for workspace ${workspaceId}`,
+      );
+    } else {
+      workflowRunStatusFieldMetadataOptions?.push({
+        value: WorkflowRunStatus.ENQUEUED,
+        label: 'Enqueued',
+        position: 4,
+        color: 'blue',
+      });
+
+      await this.fieldMetadataRepository.save(workflowRunStatusFieldMetadata);
+
+      this.logger.log(
+        `Enqueued status added to workflow run status field metadata for workspace ${workspaceId}`,
+      );
+    }
+
+    const schemaName = getWorkspaceSchemaName(workspaceId);
+
+    const mainDataSource =
+      await this.workspaceDataSourceService.connectToMainDataSource();
+
+    if (options.dryRun) {
+      this.logger.log(
+        `Would try to add enqueued status to workflow run status enum for workspace ${workspaceId}`,
+      );
+    } else {
+      try {
+        await mainDataSource.query(
+          `ALTER TYPE ${schemaName}."workflowRun_status_enum" ADD VALUE 'ENQUEUED'`,
+        );
+        this.logger.log(
+          `Enqueued status added to workflow run status enum for workspace ${workspaceId}`,
+        );
+      } catch (error) {
+        this.logger.error(
+          `Error adding enqueued status to workflow run status enum for workspace ${workspaceId}: ${error}`,
+        );
+      }
+    }
+  }
+}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-2/1-2-upgrade-version-command.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-2/1-2-upgrade-version-command.module.ts
@@ -1,19 +1,31 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { AddEnqueuedStatusToWorkflowRunV2Command } from 'src/database/commands/upgrade-version-command/1-2/1-2-add-enqueued-status-to-workflow-run-v2.command';
+import { AddNextStepIdsToWorkflowVersionTriggers } from 'src/database/commands/upgrade-version-command/1-2/1-2-add-next-step-ids-to-workflow-version-triggers.command';
 import { RemoveWorkflowRunsWithoutState } from 'src/database/commands/upgrade-version-command/1-2/1-2-remove-workflow-runs-without-state.command';
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
-import { AddNextStepIdsToWorkflowVersionTriggers } from 'src/database/commands/upgrade-version-command/1-2/1-2-add-next-step-ids-to-workflow-version-triggers.command';
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
+import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
+import { WorkspaceDataSourceModule } from 'src/engine/workspace-datasource/workspace-datasource.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Workspace], 'core')],
+  imports: [
+    TypeOrmModule.forFeature(
+      [Workspace, FieldMetadataEntity, ObjectMetadataEntity],
+      'core',
+    ),
+    WorkspaceDataSourceModule,
+  ],
   providers: [
     RemoveWorkflowRunsWithoutState,
     AddNextStepIdsToWorkflowVersionTriggers,
+    AddEnqueuedStatusToWorkflowRunV2Command,
   ],
   exports: [
     RemoveWorkflowRunsWithoutState,
     AddNextStepIdsToWorkflowVersionTriggers,
+    AddEnqueuedStatusToWorkflowRunV2Command,
   ],
 })
 export class V1_2_UpgradeVersionCommandModule {}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
@@ -26,13 +26,14 @@ import { FixSchemaArrayTypeCommand } from 'src/database/commands/upgrade-version
 import { FixUpdateStandardFieldsIsLabelSyncedWithName } from 'src/database/commands/upgrade-version-command/1-1/1-1-fix-update-standard-field-is-label-synced-with-name.command';
 import { MigrateApiKeysWebhooksToCoreCommand } from 'src/database/commands/upgrade-version-command/1-1/1-1-migrate-api-keys-webhooks-to-core.command';
 import { MigrateWorkflowRunStatesCommand } from 'src/database/commands/upgrade-version-command/1-1/1-1-migrate-workflow-run-state.command';
+import { AddEnqueuedStatusToWorkflowRunV2Command } from 'src/database/commands/upgrade-version-command/1-2/1-2-add-enqueued-status-to-workflow-run-v2.command';
+import { AddNextStepIdsToWorkflowVersionTriggers } from 'src/database/commands/upgrade-version-command/1-2/1-2-add-next-step-ids-to-workflow-version-triggers.command';
+import { RemoveWorkflowRunsWithoutState } from 'src/database/commands/upgrade-version-command/1-2/1-2-remove-workflow-runs-without-state.command';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.manager';
 import { SyncWorkspaceMetadataCommand } from 'src/engine/workspace-manager/workspace-sync-metadata/commands/sync-workspace-metadata.command';
 import { compareVersionMajorAndMinor } from 'src/utils/version/compare-version-minor-and-major';
-import { RemoveWorkflowRunsWithoutState } from 'src/database/commands/upgrade-version-command/1-2/1-2-remove-workflow-runs-without-state.command';
-import { AddNextStepIdsToWorkflowVersionTriggers } from 'src/database/commands/upgrade-version-command/1-2/1-2-add-next-step-ids-to-workflow-version-triggers.command';
 
 const execPromise = promisify(exec);
 
@@ -153,6 +154,7 @@ export class UpgradeCommand extends UpgradeCommandRunner {
     // 1.2 Commands
     protected readonly removeWorkflowRunsWithoutState: RemoveWorkflowRunsWithoutState,
     protected readonly addNextStepIdsToWorkflowVersionTriggers: AddNextStepIdsToWorkflowVersionTriggers,
+    protected readonly addEnqueuedStatusToWorkflowRunV2Command: AddEnqueuedStatusToWorkflowRunV2Command,
 
     // 1.3 Commands
   ) {
@@ -209,6 +211,7 @@ export class UpgradeCommand extends UpgradeCommandRunner {
       beforeSyncMetadata: [
         this.removeWorkflowRunsWithoutState,
         this.addNextStepIdsToWorkflowVersionTriggers,
+        this.addEnqueuedStatusToWorkflowRunV2Command,
       ],
       afterSyncMetadata: [],
     };


### PR DESCRIPTION
Duplicated the existing command `AddEnqueuedStatusToWorkflowRunCommand`. Adding two steps:
- fetch the `workflowRun` object of the selected workspace
- using that object metadata id in the status field selection