### PR TITLE
fix createMany resolver when updating softdeleted record

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-create-many-resolver.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-create-many-resolver.service.ts
@@ -210,6 +210,7 @@ export class GraphqlQueryCreateManyResolverService extends GraphqlQueryBaseResol
       .setFindOptions({
         select: selectedColumns,
       })
+      .withDeleted()
       .getMany();
   }
 


### PR DESCRIPTION
Context: updateOne/Many works on soft deleted records but the update of the upsertMany throws error

fixes https://github.com/twentyhq/twenty/issues/13195