### PR TITLE
Added public lab feature flag for search any field

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/feature-flag/constants/public-feature-flag.const.ts
+++ b/packages/twenty-server/src/engine/core-modules/feature-flag/constants/public-feature-flag.const.ts
@@ -30,6 +30,15 @@ export const PUBLIC_FEATURE_FLAGS: PublicFeatureFlag[] = [
       imagePath: '',
     },
   },
+  {
+    key: FeatureFlagKey.IS_ANY_FIELD_SEARCH_ENABLED,
+    metadata: {
+      label: 'Any field filter',
+      description:
+        'Search multiple fields at the same time with the new "Search any field" feature on tables and kanbans',
+      imagePath: '',
+    },
+  },
   ...(process.env.CLOUDFLARE_API_KEY
     ? [
         // {

--- a/packages/twenty-server/src/engine/workspace-manager/dev-seeder/core/utils/seed-feature-flags.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/dev-seeder/core/utils/seed-feature-flags.util.ts
@@ -58,7 +58,7 @@ export const seedFeatureFlags = async (
       {
         key: FeatureFlagKey.IS_ANY_FIELD_SEARCH_ENABLED,
         workspaceId: workspaceId,
-        value: true,
+        value: false,
       },
       {
         key: FeatureFlagKey.IS_TWO_FACTOR_AUTHENTICATION_ENABLED,


### PR DESCRIPTION
This PR adds a public feature flag for search any field.

This feature flag default value has been set to false also to avoid breaking the frontend, we'll wait for a sync metadata in the next release on all workspace to remove this feature flag.