### PR TITLE
Cleanup remaining old component states

### DIFF
--- a/packages/twenty-front/src/modules/action-menu/components/RecordIndexActionMenuDropdown.tsx
+++ b/packages/twenty-front/src/modules/action-menu/components/RecordIndexActionMenuDropdown.tsx
@@ -16,10 +16,8 @@ import { SelectableListItem } from '@/ui/layout/selectable-list/components/Selec
 import { selectedItemIdComponentState } from '@/ui/layout/selectable-list/states/selectedItemIdComponentState';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useRecoilComponentValueV2 } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValueV2';
-import { extractComponentState } from '@/ui/utilities/state/component-state/utils/extractComponentState';
 import styled from '@emotion/styled';
 import { useContext } from 'react';
-import { useRecoilValue } from 'recoil';
 import { IconLayoutSidebarRightExpand } from 'twenty-ui/display';
 import { MenuItem } from 'twenty-ui/navigation';
 
@@ -49,11 +47,9 @@ export const RecordIndexActionMenuDropdown = () => {
   const dropdownId = getActionMenuDropdownIdFromActionMenuId(actionMenuId);
   const { closeDropdown } = useCloseDropdown();
 
-  const actionMenuDropdownPosition = useRecoilValue(
-    extractComponentState(
-      recordIndexActionMenuDropdownPositionComponentState,
-      dropdownId,
-    ),
+  const actionMenuDropdownPosition = useRecoilComponentValueV2(
+    recordIndexActionMenuDropdownPositionComponentState,
+    dropdownId,
   );
 
   const { openCommandMenu } = useCommandMenu();

--- a/packages/twenty-front/src/modules/action-menu/components/__stories__/RecordIndexActionMenuDropdown.stories.tsx
+++ b/packages/twenty-front/src/modules/action-menu/components/__stories__/RecordIndexActionMenuDropdown.stories.tsx
@@ -10,7 +10,6 @@ import { ActionMenuComponentInstanceContext } from '@/action-menu/states/context
 import { recordIndexActionMenuDropdownPositionComponentState } from '@/action-menu/states/recordIndexActionMenuDropdownPositionComponentState';
 
 import { isDropdownOpenComponentState } from '@/ui/layout/dropdown/states/isDropdownOpenComponentState';
-import { extractComponentState } from '@/ui/utilities/state/component-state/utils/extractComponentState';
 import {
   RouterDecorator,
   getCanvasElementForDropdownTesting,
@@ -31,10 +30,9 @@ const meta: Meta<typeof RecordIndexActionMenuDropdown> = {
       <RecoilRoot
         initializeState={({ set }) => {
           set(
-            extractComponentState(
-              recordIndexActionMenuDropdownPositionComponentState,
-              'action-menu-dropdown-story',
-            ),
+            recordIndexActionMenuDropdownPositionComponentState.atomFamily({
+              instanceId: 'action-menu-dropdown-story',
+            }),
             { x: 10, y: 10 },
           );
 

--- a/packages/twenty-front/src/modules/action-menu/states/recordIndexActionMenuDropdownPositionComponentState.ts
+++ b/packages/twenty-front/src/modules/action-menu/states/recordIndexActionMenuDropdownPositionComponentState.ts
@@ -1,11 +1,13 @@
+import { ActionMenuComponentInstanceContext } from '@/action-menu/states/contexts/ActionMenuComponentInstanceContext';
 import { PositionType } from '@/action-menu/types/PositionType';
-import { createComponentState } from '@/ui/utilities/state/component-state/utils/createComponentState';
+import { createComponentStateV2 } from '@/ui/utilities/state/component-state/utils/createComponentStateV2';
 
 export const recordIndexActionMenuDropdownPositionComponentState =
-  createComponentState<PositionType>({
+  createComponentStateV2<PositionType>({
     key: 'recordIndexActionMenuDropdownPositionComponentState',
     defaultValue: {
       x: null,
       y: null,
     },
+    componentInstanceContext: ActionMenuComponentInstanceContext,
   });

--- a/packages/twenty-front/src/modules/activities/states/objectRecordsIdsMultiSelectComponentState.ts
+++ b/packages/twenty-front/src/modules/activities/states/objectRecordsIdsMultiSelectComponentState.ts
@@ -1,8 +1,0 @@
-import { createComponentState } from '@/ui/utilities/state/component-state/utils/createComponentState';
-
-export const objectRecordsIdsMultiSelecComponentState = createComponentState<
-  string[]
->({
-  key: 'objectRecordsIdsMultiSelectComponentState',
-  defaultValue: [],
-});

--- a/packages/twenty-front/src/modules/object-record/record-board/record-board-card/components/RecordBoardCard.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/record-board-card/components/RecordBoardCard.tsx
@@ -21,11 +21,10 @@ import { useScrollWrapperElement } from '@/ui/utilities/scroll/hooks/useScrollWr
 import { useRecoilComponentFamilyStateV2 } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentFamilyStateV2';
 import { useRecoilComponentFamilyValueV2 } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentFamilyValueV2';
 import { useRecoilComponentValueV2 } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValueV2';
-import { extractComponentState } from '@/ui/utilities/state/component-state/utils/extractComponentState';
+import { useSetRecoilComponentStateV2 } from '@/ui/utilities/state/component-state/hooks/useSetRecoilComponentStateV2';
 import styled from '@emotion/styled';
 import { useContext, useState } from 'react';
 import { InView, useInView } from 'react-intersection-observer';
-import { useSetRecoilState } from 'recoil';
 import { AnimatedEaseInOut } from 'twenty-ui/utilities';
 import { useDebouncedCallback } from 'use-debounce';
 
@@ -132,11 +131,9 @@ export const RecordBoardCard = () => {
   const actionMenuDropdownId =
     getActionMenuDropdownIdFromActionMenuId(actionMenuId);
 
-  const setActionMenuDropdownPosition = useSetRecoilState(
-    extractComponentState(
-      recordIndexActionMenuDropdownPositionComponentState,
-      actionMenuDropdownId,
-    ),
+  const setActionMenuDropdownPosition = useSetRecoilComponentStateV2(
+    recordIndexActionMenuDropdownPositionComponentState,
+    actionMenuDropdownId,
   );
 
   const { openDropdown } = useOpenDropdown();

--- a/packages/twenty-front/src/modules/object-record/record-board/states/recordBoardObjectSingularNameComponentState.ts
+++ b/packages/twenty-front/src/modules/object-record/record-board/states/recordBoardObjectSingularNameComponentState.ts
@@ -1,8 +1,0 @@
-import { createComponentState } from '@/ui/utilities/state/component-state/utils/createComponentState';
-
-export const recordBoardObjectSingularNameComponentState = createComponentState<
-  string | undefined
->({
-  key: 'recordBoardObjectSingularNameComponentState',
-  defaultValue: undefined,
-});

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/hooks/useTriggerActionMenuDropdown.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/hooks/useTriggerActionMenuDropdown.ts
@@ -9,7 +9,6 @@ import { useOpenDropdown } from '@/ui/layout/dropdown/hooks/useOpenDropdown';
 import { getSnapshotValue } from '@/ui/utilities/recoil-scope/utils/getSnapshotValue';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useRecoilComponentCallbackStateV2 } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentCallbackStateV2';
-import { extractComponentState } from '@/ui/utilities/state/component-state/utils/extractComponentState';
 
 export const useTriggerActionMenuDropdown = ({
   recordTableId,
@@ -28,10 +27,11 @@ export const useTriggerActionMenuDropdown = ({
   const actionMenuDropdownId =
     getActionMenuDropdownIdFromActionMenuId(actionMenuInstanceId);
 
-  const recordIndexActionMenuDropdownPositionState = extractComponentState(
-    recordIndexActionMenuDropdownPositionComponentState,
-    actionMenuDropdownId,
-  );
+  const recordIndexActionMenuDropdownPositionCallbackState =
+    useRecoilComponentCallbackStateV2(
+      recordIndexActionMenuDropdownPositionComponentState,
+      actionMenuDropdownId,
+    );
 
   const { openDropdown } = useOpenDropdown();
 
@@ -42,7 +42,7 @@ export const useTriggerActionMenuDropdown = ({
       (event: React.MouseEvent, recordId: string) => {
         event.preventDefault();
 
-        set(recordIndexActionMenuDropdownPositionState, {
+        set(recordIndexActionMenuDropdownPositionCallbackState, {
           x: event.pageX,
           y: event.pageY,
         });
@@ -63,7 +63,7 @@ export const useTriggerActionMenuDropdown = ({
         });
       },
     [
-      recordIndexActionMenuDropdownPositionState,
+      recordIndexActionMenuDropdownPositionCallbackState,
       isRowSelectedFamilyState,
       closeCommandMenu,
       openDropdown,

--- a/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/hooks/useNavigationSection.ts
+++ b/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/hooks/useNavigationSection.ts
@@ -1,18 +1,12 @@
 import { useRecoilCallback } from 'recoil';
 
-import { isNavigationSectionOpenComponentState } from '@/ui/navigation/navigation-drawer/states/isNavigationSectionOpenComponentState';
-import { extractComponentState } from '@/ui/utilities/state/component-state/utils/extractComponentState';
+import { isNavigationSectionOpenFamilytState } from '@/ui/navigation/navigation-drawer/states/isNavigationSectionOpenComponentState';
 
 export const useNavigationSection = (scopeId: string) => {
   const closeNavigationSection = useRecoilCallback(
     ({ set }) =>
       () => {
-        set(
-          isNavigationSectionOpenComponentState({
-            scopeId,
-          }),
-          false,
-        );
+        set(isNavigationSectionOpenFamilytState(scopeId), false);
       },
     [scopeId],
   );
@@ -20,12 +14,7 @@ export const useNavigationSection = (scopeId: string) => {
   const openNavigationSection = useRecoilCallback(
     ({ set }) =>
       () => {
-        set(
-          isNavigationSectionOpenComponentState({
-            scopeId,
-          }),
-          true,
-        );
+        set(isNavigationSectionOpenFamilytState(scopeId), true);
       },
     [scopeId],
   );
@@ -34,7 +23,7 @@ export const useNavigationSection = (scopeId: string) => {
     ({ snapshot }) =>
       () => {
         const isNavigationSectionOpen = snapshot
-          .getLoadable(isNavigationSectionOpenComponentState({ scopeId }))
+          .getLoadable(isNavigationSectionOpenFamilytState(scopeId))
           .getValue();
 
         if (isNavigationSectionOpen) {
@@ -46,10 +35,8 @@ export const useNavigationSection = (scopeId: string) => {
     [closeNavigationSection, openNavigationSection, scopeId],
   );
 
-  const isNavigationSectionOpenState = extractComponentState(
-    isNavigationSectionOpenComponentState,
-    scopeId,
-  );
+  const isNavigationSectionOpenState =
+    isNavigationSectionOpenFamilytState(scopeId);
 
   return {
     isNavigationSectionOpenState,

--- a/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/hooks/useNavigationSection.ts
+++ b/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/hooks/useNavigationSection.ts
@@ -1,12 +1,12 @@
 import { useRecoilCallback } from 'recoil';
 
-import { isNavigationSectionOpenFamilytState } from '@/ui/navigation/navigation-drawer/states/isNavigationSectionOpenComponentState';
+import { isNavigationSectionOpenFamilyState } from '@/ui/navigation/navigation-drawer/states/isNavigationSectionOpenFamilyState';
 
 export const useNavigationSection = (scopeId: string) => {
   const closeNavigationSection = useRecoilCallback(
     ({ set }) =>
       () => {
-        set(isNavigationSectionOpenFamilytState(scopeId), false);
+        set(isNavigationSectionOpenFamilyState(scopeId), false);
       },
     [scopeId],
   );
@@ -14,7 +14,7 @@ export const useNavigationSection = (scopeId: string) => {
   const openNavigationSection = useRecoilCallback(
     ({ set }) =>
       () => {
-        set(isNavigationSectionOpenFamilytState(scopeId), true);
+        set(isNavigationSectionOpenFamilyState(scopeId), true);
       },
     [scopeId],
   );
@@ -23,7 +23,7 @@ export const useNavigationSection = (scopeId: string) => {
     ({ snapshot }) =>
       () => {
         const isNavigationSectionOpen = snapshot
-          .getLoadable(isNavigationSectionOpenFamilytState(scopeId))
+          .getLoadable(isNavigationSectionOpenFamilyState(scopeId))
           .getValue();
 
         if (isNavigationSectionOpen) {
@@ -36,7 +36,7 @@ export const useNavigationSection = (scopeId: string) => {
   );
 
   const isNavigationSectionOpenState =
-    isNavigationSectionOpenFamilytState(scopeId);
+    isNavigationSectionOpenFamilyState(scopeId);
 
   return {
     isNavigationSectionOpenState,

--- a/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/states/isNavigationSectionOpenComponentState.ts
+++ b/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/states/isNavigationSectionOpenComponentState.ts
@@ -1,9 +1,11 @@
-import { createComponentState } from '@/ui/utilities/state/component-state/utils/createComponentState';
+import { createFamilyState } from '@/ui/utilities/state/utils/createFamilyState';
 import { localStorageEffect } from '~/utils/recoil-effects';
 
-export const isNavigationSectionOpenComponentState =
-  createComponentState<boolean>({
-    key: 'isNavigationSectionOpenComponentState',
-    defaultValue: true,
-    effects: [localStorageEffect()],
-  });
+export const isNavigationSectionOpenFamilytState = createFamilyState<
+  boolean,
+  string
+>({
+  key: 'isNavigationSectionOpenFamilytState',
+  defaultValue: true,
+  effects: [localStorageEffect()],
+});

--- a/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/states/isNavigationSectionOpenFamilyState.ts
+++ b/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/states/isNavigationSectionOpenFamilyState.ts
@@ -1,11 +1,11 @@
 import { createFamilyState } from '@/ui/utilities/state/utils/createFamilyState';
 import { localStorageEffect } from '~/utils/recoil-effects';
 
-export const isNavigationSectionOpenFamilytState = createFamilyState<
+export const isNavigationSectionOpenFamilyState = createFamilyState<
   boolean,
   string
 >({
-  key: 'isNavigationSectionOpenFamilytState',
+  key: 'isNavigationSectionOpenFamilyState',
   defaultValue: true,
   effects: [localStorageEffect()],
 });

--- a/packages/twenty-front/src/modules/ui/utilities/state/utils/createFamilyState.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/state/utils/createFamilyState.ts
@@ -1,4 +1,4 @@
-import { atomFamily, SerializableParam } from 'recoil';
+import { AtomEffect, atomFamily, SerializableParam } from 'recoil';
 
 export const createFamilyState = <
   ValueType,
@@ -6,12 +6,15 @@ export const createFamilyState = <
 >({
   key,
   defaultValue,
+  effects,
 }: {
   key: string;
   defaultValue: ValueType;
+  effects?: ReadonlyArray<AtomEffect<ValueType>>;
 }) => {
   return atomFamily<ValueType, FamilyKey>({
     key,
     default: defaultValue,
+    effects,
   });
 };


### PR DESCRIPTION
This PR cleans up the remaining legacy component states.

Everything that is on the v1 of component states, scoped states, dropdown scope, scoped id, etc.

