### PR TITLE
Fix metadata playground not accessible

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/open-api/open-api.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/open-api/open-api.service.ts
@@ -283,6 +283,8 @@ export class OpenApiService {
       },
     };
 
+    schema.tags = computeSchemaTags(webhookAndApiKeyObjectMetadataItems);
+
     return schema;
   }
 


### PR DESCRIPTION
as title


## Issue
<img width="982" height="487" alt="image" src="https://github.com/user-attachments/assets/536567a3-ec36-45ed-b928-5ba4fd98ea70" />
