### PR TITLE
move APIs and Webhooks section out of advanced mode

### DIFF
--- a/packages/twenty-front/src/modules/settings/hooks/useSettingsNavigationItems.tsx
+++ b/packages/twenty-front/src/modules/settings/hooks/useSettingsNavigationItems.tsx
@@ -151,20 +151,20 @@ const useSettingsNavigationItems = (): SettingsNavigationSection[] => {
     },
     {
       label: t`Developers`,
-      isAdvanced: true,
+      isAdvanced: false,
       items: [
         {
           label: t`APIs`,
           path: SettingsPath.APIs,
           Icon: IconApi,
-          isAdvanced: true,
+          isAdvanced: false,
           isHidden: !permissionMap[PermissionFlagType.API_KEYS_AND_WEBHOOKS],
         },
         {
           label: t`Webhooks`,
           path: SettingsPath.Webhooks,
           Icon: IconWebhook,
-          isAdvanced: true,
+          isAdvanced: false,
           isHidden: !permissionMap[PermissionFlagType.API_KEYS_AND_WEBHOOKS],
         },
         {


### PR DESCRIPTION
Closes #13468

The `isAdvanced` parameter for `Developers`, `APIs` and `Webhooks` were set to `true` previously. Now they are set to `false`. The `Functions` section still appears under `Advanced Mode` as the issue did not specify whether it had to be moved as well.

Attaching a loom recording of before and after for verification:
[Before](https://www.loom.com/share/a06f7aea758649cc952db617074d1361?sid=8564da09-e44b-4b64-8dab-ea3f9adf7423)
[After](https://www.loom.com/share/b631397d5f7d476293e6771f6804e965?sid=f7154952-ea6b-4561-8532-5794b8960cd4)

