### PR TITLE
Do not enrich relations when id undefined

### DIFF
--- a/packages/twenty-front/src/modules/ui/input/components/SelectControl.tsx
+++ b/packages/twenty-front/src/modules/ui/input/components/SelectControl.tsx
@@ -48,7 +48,7 @@ const StyledControlContainer = styled.div<{
       ? theme.font.color.tertiary
       : textAccent === 'default'
         ? theme.font.color.primary
-        : theme.font.color.secondary};
+        : theme.font.color.tertiary};
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
   text-align: left;
 `;

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/filter-action/components/WorkflowEditActionFilterBody.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/filter-action/components/WorkflowEditActionFilterBody.tsx
@@ -1,3 +1,4 @@
+import { InputLabel } from '@/ui/input/components/InputLabel';
 import { useRecoilComponentValueV2 } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValueV2';
 import { WorkflowFilterAction } from '@/workflow/types/Workflow';
 import { WorkflowStepBody } from '@/workflow/workflow-steps/components/WorkflowStepBody';
@@ -11,6 +12,7 @@ import { WorkflowStepFilterContext } from '@/workflow/workflow-steps/workflow-ac
 import { rootLevelStepFilterGroupComponentSelector } from '@/workflow/workflow-steps/workflow-actions/filter-action/states/rootLevelStepFilterGroupComponentSelector';
 import { isStepFilterGroupChildAStepFilterGroup } from '@/workflow/workflow-steps/workflow-actions/filter-action/utils/isStepFilterGroupChildAStepFilterGroup';
 import styled from '@emotion/styled';
+import { t } from '@lingui/core/macro';
 import { isDefined } from 'twenty-shared/utils';
 
 const StyledContainer = styled.div`
@@ -25,6 +27,10 @@ const StyledChildContainer = styled.div`
   flex-direction: column;
   gap: ${({ theme }) => theme.spacing(6)};
   width: 100%;
+`;
+
+const StyledFilterBodyContainer = styled(WorkflowStepBody)`
+  gap: ${({ theme }) => theme.spacing(0)};
 `;
 
 type WorkflowEditActionFilterBodyProps = {
@@ -77,7 +83,8 @@ export const WorkflowEditActionFilterBody = ({
         onFilterSettingsUpdate,
       }}
     >
-      <WorkflowStepBody>
+      <StyledFilterBodyContainer>
+        <InputLabel>{t`Conditions`}</InputLabel>
         {isDefined(rootStepFilterGroup) ? (
           <StyledContainer>
             <StyledChildContainer>
@@ -111,7 +118,7 @@ export const WorkflowEditActionFilterBody = ({
         ) : (
           <WorkflowStepFilterAddRootStepFilterButton />
         )}
-      </WorkflowStepBody>
+      </StyledFilterBodyContainer>
     </WorkflowStepFilterContext.Provider>
   );
 };

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/filter-action/components/WorkflowStepFilterAddRootStepFilterButton.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/filter-action/components/WorkflowStepFilterAddRootStepFilterButton.tsx
@@ -1,9 +1,14 @@
 import { useAddRootStepFilter } from '@/workflow/workflow-steps/workflow-actions/filter-action/hooks/useAddRootStepFilter';
 import { WorkflowStepFilterContext } from '@/workflow/workflow-steps/workflow-actions/filter-action/states/context/WorkflowStepFilterContext';
+import styled from '@emotion/styled';
 import { useLingui } from '@lingui/react/macro';
 import { useContext } from 'react';
 import { IconFilter } from 'twenty-ui/display';
 import { Button } from 'twenty-ui/input';
+
+const StyledButton = styled(Button)`
+  margin-top: ${({ theme }) => theme.spacing(2)};
+`;
 
 export const WorkflowStepFilterAddRootStepFilterButton = () => {
   const { t } = useLingui();
@@ -11,7 +16,7 @@ export const WorkflowStepFilterAddRootStepFilterButton = () => {
   const { addRootStepFilter } = useAddRootStepFilter();
 
   return (
-    <Button
+    <StyledButton
       Icon={IconFilter}
       size="small"
       variant="secondary"

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/listeners/database-event-trigger.listener.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/listeners/database-event-trigger.listener.ts
@@ -189,6 +189,11 @@ export class DatabaseEventTriggerListener {
       const joinField =
         objectMetadataItemWithFieldsMaps.fieldsById[joinFieldId];
       const joinRecordId = record[joinColumnName];
+
+      if (!isDefined(joinRecordId)) {
+        continue;
+      }
+
       const relatedObjectMetadataId = joinField.relationTargetObjectMetadataId;
 
       if (!isDefined(relatedObjectMetadataId)) {


### PR DESCRIPTION
Fixes https://github.com/twentyhq/twenty/issues/13428
We perform the call enrichment even with id undefined. It returns the first item in DB.

Adding two more fixes related to filters:
- Conditions title
- Fixing placeholder color for select control (only other impacted field is in Advanced filters)