### PR TITLE
feat(database): add chunked insert method for ClickHouse integration

### DIFF
--- a/packages/twenty-server/src/database/clickHouse/clickHouse.service.ts
+++ b/packages/twenty-server/src/database/clickHouse/clickHouse.service.ts
@@ -243,8 +243,6 @@ export class ClickHouseService implements OnModuleInit, OnModuleDestroy {
 
     const flush = async () => {
       if (chunk.length === 0) return;
-      const estimatedSizeMB =
-        Buffer.byteLength(JSON.stringify(chunk)) / 1024 / 1024;
       await client.insert({
         table,
         values: chunk,

--- a/packages/twenty-server/src/database/clickHouse/clickHouse.service.ts
+++ b/packages/twenty-server/src/database/clickHouse/clickHouse.service.ts
@@ -254,10 +254,12 @@ export class ClickHouseService implements OnModuleInit, OnModuleDestroy {
 
     for (const row of values) {
       const rowSize = Buffer.byteLength(JSON.stringify(row));
+
       chunk.push(row);
       currentSizeBytes += rowSize;
 
       const currentSizeMB = currentSizeBytes / 1024 / 1024;
+
       if (
         chunk.length >= chunkSize ||
         (maxMemoryMB !== undefined && currentSizeMB >= maxMemoryMB)

--- a/packages/twenty-server/src/database/clickHouse/clickHouse.service.ts
+++ b/packages/twenty-server/src/database/clickHouse/clickHouse.service.ts
@@ -229,6 +229,7 @@ export class ClickHouseService implements OnModuleInit, OnModuleDestroy {
     }
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private async insertInChunks<T extends Record<string, any>>(
     client: ClickHouseClient,
     table: string,

--- a/packages/twenty-server/src/database/clickHouse/clickHouse.service.ts
+++ b/packages/twenty-server/src/database/clickHouse/clickHouse.service.ts
@@ -148,10 +148,9 @@ export class ClickHouseService implements OnModuleInit, OnModuleDestroy {
         return { success: false };
       }
 
-      await client.insert({
-        table,
-        values,
-        format: 'JSONEachRow',
+      await this.insertInChunks(client, table, values, {
+        chunkSize: 1000,
+        maxMemoryMB: 4,
       });
 
       return { success: true };
@@ -228,5 +227,47 @@ export class ClickHouseService implements OnModuleInit, OnModuleDestroy {
 
       return false;
     }
+  }
+
+  private async insertInChunks<T extends Record<string, any>>(
+    client: ClickHouseClient,
+    table: string,
+    values: T[],
+    options: { chunkSize?: number; maxMemoryMB?: number } = {},
+  ): Promise<void> {
+    const chunkSize = options.chunkSize ?? 1000;
+    const maxMemoryMB = options.maxMemoryMB;
+
+    let chunk: T[] = [];
+    let currentSizeBytes = 0;
+
+    const flush = async () => {
+      if (chunk.length === 0) return;
+      const estimatedSizeMB =
+        Buffer.byteLength(JSON.stringify(chunk)) / 1024 / 1024;
+      await client.insert({
+        table,
+        values: chunk,
+        format: 'JSONEachRow',
+      });
+      chunk = [];
+      currentSizeBytes = 0;
+    };
+
+    for (const row of values) {
+      const rowSize = Buffer.byteLength(JSON.stringify(row));
+      chunk.push(row);
+      currentSizeBytes += rowSize;
+
+      const currentSizeMB = currentSizeBytes / 1024 / 1024;
+      if (
+        chunk.length >= chunkSize ||
+        (maxMemoryMB !== undefined && currentSizeMB >= maxMemoryMB)
+      ) {
+        await flush();
+      }
+    }
+
+    await flush();
   }
 }


### PR DESCRIPTION
- Introduced `insertInChunks` to handle large data inserts with chunking and memory control.
- Updated existing insert logic to utilize the new chunked approach.
- Allowed configuration of chunk sizes and memory limits.