### PR TITLE
[permissions] Remove non-readable field from aggregate options (kanban)

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-board/record-board-column/components/RecordBoardColumnHeaderAggregateDropdownContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/record-board-column/components/RecordBoardColumnHeaderAggregateDropdownContent.tsx
@@ -1,4 +1,6 @@
 import { useDropdownContextStateManagement } from '@/dropdown-context-state-management/hooks/useDropdownContextStateManagement';
+import { getReadRestrictedFieldMetadataIdsFromObjectPermissions } from '@/object-metadata/utils/getReadRestrictedFieldMetadataIdsFromObjectPermissions';
+import { useObjectPermissions } from '@/object-record/hooks/useObjectPermissions';
 import { RecordBoardColumnHeaderAggregateDropdownContext } from '@/object-record/record-board/record-board-column/components/RecordBoardColumnHeaderAggregateDropdownContext';
 import { RecordBoardColumnHeaderAggregateDropdownFieldsContent } from '@/object-record/record-board/record-board-column/components/RecordBoardColumnHeaderAggregateDropdownFieldsContent';
 import { RecordBoardColumnHeaderAggregateDropdownMenuContent } from '@/object-record/record-board/record-board-column/components/RecordBoardColumnHeaderAggregateDropdownMenuContent';
@@ -17,13 +19,24 @@ export const AggregateDropdownContent = () => {
       context: RecordBoardColumnHeaderAggregateDropdownContext,
     });
 
+  const { objectPermissionsByObjectMetadataId } = useObjectPermissions();
+
+  const restrictedFieldMetadataIds =
+    getReadRestrictedFieldMetadataIdsFromObjectPermissions({
+      objectPermissions: [
+        objectPermissionsByObjectMetadataId[objectMetadataItem.id],
+      ],
+      objectMetadataId: objectMetadataItem.id,
+    });
+
   switch (currentContentId) {
     case 'countAggregateOperationsOptions': {
       const availableAggregations: AvailableFieldsForAggregateOperation =
-        getAvailableFieldsIdsForAggregationFromObjectFields(
-          objectMetadataItem.fields,
-          COUNT_AGGREGATE_OPERATION_OPTIONS,
-        );
+        getAvailableFieldsIdsForAggregationFromObjectFields({
+          fields: objectMetadataItem.fields,
+          targetAggregateOperations: COUNT_AGGREGATE_OPERATION_OPTIONS,
+          restrictedFieldMetadataIds,
+        });
       return (
         <RecordBoardColumnHeaderAggregateDropdownOptionsContent
           availableAggregations={availableAggregations}
@@ -33,10 +46,11 @@ export const AggregateDropdownContent = () => {
     }
     case 'percentAggregateOperationsOptions': {
       const availableAggregations: AvailableFieldsForAggregateOperation =
-        getAvailableFieldsIdsForAggregationFromObjectFields(
-          objectMetadataItem.fields,
-          PERCENT_AGGREGATE_OPERATION_OPTIONS,
-        );
+        getAvailableFieldsIdsForAggregationFromObjectFields({
+          fields: objectMetadataItem.fields,
+          targetAggregateOperations: PERCENT_AGGREGATE_OPERATION_OPTIONS,
+          restrictedFieldMetadataIds,
+        });
       return (
         <RecordBoardColumnHeaderAggregateDropdownOptionsContent
           availableAggregations={availableAggregations}
@@ -46,10 +60,14 @@ export const AggregateDropdownContent = () => {
     }
     case 'datesAggregateOperationOptions': {
       const datesAvailableAggregations: AvailableFieldsForAggregateOperation =
-        getAvailableFieldsIdsForAggregationFromObjectFields(
-          objectMetadataItem.fields,
-          [DateAggregateOperations.EARLIEST, DateAggregateOperations.LATEST],
-        );
+        getAvailableFieldsIdsForAggregationFromObjectFields({
+          fields: objectMetadataItem.fields,
+          targetAggregateOperations: [
+            DateAggregateOperations.EARLIEST,
+            DateAggregateOperations.LATEST,
+          ],
+          restrictedFieldMetadataIds,
+        });
       return (
         <RecordBoardColumnHeaderAggregateDropdownOptionsContent
           availableAggregations={datesAvailableAggregations}
@@ -59,10 +77,11 @@ export const AggregateDropdownContent = () => {
     }
     case 'moreAggregateOperationOptions': {
       const availableAggregationsWithoutDates: AvailableFieldsForAggregateOperation =
-        getAvailableFieldsIdsForAggregationFromObjectFields(
-          objectMetadataItem.fields,
-          NON_STANDARD_AGGREGATE_OPERATION_OPTIONS,
-        );
+        getAvailableFieldsIdsForAggregationFromObjectFields({
+          fields: objectMetadataItem.fields,
+          targetAggregateOperations: NON_STANDARD_AGGREGATE_OPERATION_OPTIONS,
+          restrictedFieldMetadataIds,
+        });
       return (
         <RecordBoardColumnHeaderAggregateDropdownOptionsContent
           availableAggregations={availableAggregationsWithoutDates}

--- a/packages/twenty-front/src/modules/object-record/record-board/record-board-column/components/RecordBoardColumnHeaderAggregateDropdownContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/record-board-column/components/RecordBoardColumnHeaderAggregateDropdownContent.tsx
@@ -29,13 +29,16 @@ export const AggregateDropdownContent = () => {
       objectMetadataId: objectMetadataItem.id,
     });
 
+  const readableFields = objectMetadataItem.fields.filter(
+    (field) => !restrictedFieldMetadataIds.includes(field.id),
+  );
+
   switch (currentContentId) {
     case 'countAggregateOperationsOptions': {
       const availableAggregations: AvailableFieldsForAggregateOperation =
         getAvailableFieldsIdsForAggregationFromObjectFields({
-          fields: objectMetadataItem.fields,
+          fields: readableFields,
           targetAggregateOperations: COUNT_AGGREGATE_OPERATION_OPTIONS,
-          restrictedFieldMetadataIds,
         });
       return (
         <RecordBoardColumnHeaderAggregateDropdownOptionsContent
@@ -47,9 +50,8 @@ export const AggregateDropdownContent = () => {
     case 'percentAggregateOperationsOptions': {
       const availableAggregations: AvailableFieldsForAggregateOperation =
         getAvailableFieldsIdsForAggregationFromObjectFields({
-          fields: objectMetadataItem.fields,
+          fields: readableFields,
           targetAggregateOperations: PERCENT_AGGREGATE_OPERATION_OPTIONS,
-          restrictedFieldMetadataIds,
         });
       return (
         <RecordBoardColumnHeaderAggregateDropdownOptionsContent
@@ -61,12 +63,11 @@ export const AggregateDropdownContent = () => {
     case 'datesAggregateOperationOptions': {
       const datesAvailableAggregations: AvailableFieldsForAggregateOperation =
         getAvailableFieldsIdsForAggregationFromObjectFields({
-          fields: objectMetadataItem.fields,
+          fields: readableFields,
           targetAggregateOperations: [
             DateAggregateOperations.EARLIEST,
             DateAggregateOperations.LATEST,
           ],
-          restrictedFieldMetadataIds,
         });
       return (
         <RecordBoardColumnHeaderAggregateDropdownOptionsContent
@@ -78,9 +79,8 @@ export const AggregateDropdownContent = () => {
     case 'moreAggregateOperationOptions': {
       const availableAggregationsWithoutDates: AvailableFieldsForAggregateOperation =
         getAvailableFieldsIdsForAggregationFromObjectFields({
-          fields: objectMetadataItem.fields,
+          fields: readableFields,
           targetAggregateOperations: NON_STANDARD_AGGREGATE_OPERATION_OPTIONS,
-          restrictedFieldMetadataIds,
         });
       return (
         <RecordBoardColumnHeaderAggregateDropdownOptionsContent

--- a/packages/twenty-front/src/modules/object-record/utils/__tests__/getAvailableFieldsIdsForAggregationFromObjectFields.test.ts
+++ b/packages/twenty-front/src/modules/object-record/utils/__tests__/getAvailableFieldsIdsForAggregationFromObjectFields.test.ts
@@ -67,10 +67,11 @@ jest.mock(
 
 describe('getAvailableFieldsIdsForAggregationFromObjectFields', () => {
   it('should handle empty fields array', () => {
-    const result = getAvailableFieldsIdsForAggregationFromObjectFields(
-      [],
-      COUNT_AGGREGATE_OPERATION_OPTIONS,
-    );
+    const result = getAvailableFieldsIdsForAggregationFromObjectFields({
+      fields: [],
+      targetAggregateOperations: COUNT_AGGREGATE_OPERATION_OPTIONS,
+      restrictedFieldMetadataIds: [],
+    });
 
     COUNT_AGGREGATE_OPERATION_OPTIONS.forEach((operation) => {
       expect(result[operation]).toEqual([]);
@@ -79,10 +80,11 @@ describe('getAvailableFieldsIdsForAggregationFromObjectFields', () => {
 
   describe('with count aggregate operations', () => {
     it('should include all fields', () => {
-      const result = getAvailableFieldsIdsForAggregationFromObjectFields(
-        FIELDS_MOCKS as FieldMetadataItem[],
-        COUNT_AGGREGATE_OPERATION_OPTIONS,
-      );
+      const result = getAvailableFieldsIdsForAggregationFromObjectFields({
+        fields: FIELDS_MOCKS as FieldMetadataItem[],
+        targetAggregateOperations: COUNT_AGGREGATE_OPERATION_OPTIONS,
+        restrictedFieldMetadataIds: [],
+      });
 
       expect(result.COUNT).toEqual(
         expect.arrayContaining([
@@ -107,10 +109,11 @@ describe('getAvailableFieldsIdsForAggregationFromObjectFields', () => {
 
   describe('with percentage aggregate operations', () => {
     it('should include all fields', () => {
-      const result = getAvailableFieldsIdsForAggregationFromObjectFields(
-        FIELDS_MOCKS as FieldMetadataItem[],
-        PERCENT_AGGREGATE_OPERATION_OPTIONS,
-      );
+      const result = getAvailableFieldsIdsForAggregationFromObjectFields({
+        fields: FIELDS_MOCKS as FieldMetadataItem[],
+        targetAggregateOperations: PERCENT_AGGREGATE_OPERATION_OPTIONS,
+        restrictedFieldMetadataIds: [],
+      });
 
       PERCENT_AGGREGATE_OPERATION_OPTIONS.forEach((operation) => {
         expect(result[operation]).toEqual([
@@ -132,10 +135,11 @@ describe('getAvailableFieldsIdsForAggregationFromObjectFields', () => {
 
   describe('with non standard aggregate operations', () => {
     it('should exclude non-numeric fields', () => {
-      const result = getAvailableFieldsIdsForAggregationFromObjectFields(
-        FIELDS_MOCKS as FieldMetadataItem[],
-        NON_STANDARD_AGGREGATE_OPERATION_OPTIONS,
-      );
+      const result = getAvailableFieldsIdsForAggregationFromObjectFields({
+        fields: FIELDS_MOCKS as FieldMetadataItem[],
+        targetAggregateOperations: NON_STANDARD_AGGREGATE_OPERATION_OPTIONS,
+        restrictedFieldMetadataIds: [],
+      });
 
       COUNT_AGGREGATE_OPERATION_OPTIONS.forEach((operation) => {
         expect(result[operation]).toBeUndefined();

--- a/packages/twenty-front/src/modules/object-record/utils/__tests__/getAvailableFieldsIdsForAggregationFromObjectFields.test.ts
+++ b/packages/twenty-front/src/modules/object-record/utils/__tests__/getAvailableFieldsIdsForAggregationFromObjectFields.test.ts
@@ -70,7 +70,6 @@ describe('getAvailableFieldsIdsForAggregationFromObjectFields', () => {
     const result = getAvailableFieldsIdsForAggregationFromObjectFields({
       fields: [],
       targetAggregateOperations: COUNT_AGGREGATE_OPERATION_OPTIONS,
-      restrictedFieldMetadataIds: [],
     });
 
     COUNT_AGGREGATE_OPERATION_OPTIONS.forEach((operation) => {
@@ -83,7 +82,6 @@ describe('getAvailableFieldsIdsForAggregationFromObjectFields', () => {
       const result = getAvailableFieldsIdsForAggregationFromObjectFields({
         fields: FIELDS_MOCKS as FieldMetadataItem[],
         targetAggregateOperations: COUNT_AGGREGATE_OPERATION_OPTIONS,
-        restrictedFieldMetadataIds: [],
       });
 
       expect(result.COUNT).toEqual(
@@ -112,7 +110,6 @@ describe('getAvailableFieldsIdsForAggregationFromObjectFields', () => {
       const result = getAvailableFieldsIdsForAggregationFromObjectFields({
         fields: FIELDS_MOCKS as FieldMetadataItem[],
         targetAggregateOperations: PERCENT_AGGREGATE_OPERATION_OPTIONS,
-        restrictedFieldMetadataIds: [],
       });
 
       PERCENT_AGGREGATE_OPERATION_OPTIONS.forEach((operation) => {
@@ -138,7 +135,6 @@ describe('getAvailableFieldsIdsForAggregationFromObjectFields', () => {
       const result = getAvailableFieldsIdsForAggregationFromObjectFields({
         fields: FIELDS_MOCKS as FieldMetadataItem[],
         targetAggregateOperations: NON_STANDARD_AGGREGATE_OPERATION_OPTIONS,
-        restrictedFieldMetadataIds: [],
       });
 
       COUNT_AGGREGATE_OPERATION_OPTIONS.forEach((operation) => {

--- a/packages/twenty-front/src/modules/object-record/utils/getAvailableFieldsIdsForAggregationFromObjectFields.ts
+++ b/packages/twenty-front/src/modules/object-record/utils/getAvailableFieldsIdsForAggregationFromObjectFields.ts
@@ -8,11 +8,9 @@ import { isDefined } from 'twenty-shared/utils';
 export const getAvailableFieldsIdsForAggregationFromObjectFields = ({
   fields,
   targetAggregateOperations,
-  restrictedFieldMetadataIds,
 }: {
   fields: FieldMetadataItem[];
   targetAggregateOperations: ExtendedAggregateOperations[];
-  restrictedFieldMetadataIds: string[];
 }): AvailableFieldsForAggregateOperation => {
   const aggregationMap = initializeAvailableFieldsForAggregateOperationMap(
     targetAggregateOperations,
@@ -28,9 +26,7 @@ export const getAvailableFieldsIdsForAggregationFromObjectFields = ({
           if (!isDefined(acc[typedAggregation])) {
             acc[typedAggregation] = [];
           }
-          if (!restrictedFieldMetadataIds.includes(field.id)) {
-            (acc[typedAggregation] as string[]).push(field.id);
-          }
+          (acc[typedAggregation] as string[]).push(field.id);
         }
       });
     }

--- a/packages/twenty-front/src/modules/object-record/utils/getAvailableFieldsIdsForAggregationFromObjectFields.ts
+++ b/packages/twenty-front/src/modules/object-record/utils/getAvailableFieldsIdsForAggregationFromObjectFields.ts
@@ -5,10 +5,15 @@ import { getAvailableAggregationsFromObjectFields } from '@/object-record/utils/
 import { initializeAvailableFieldsForAggregateOperationMap } from '@/object-record/utils/initializeAvailableFieldsForAggregateOperationMap';
 import { isDefined } from 'twenty-shared/utils';
 
-export const getAvailableFieldsIdsForAggregationFromObjectFields = (
-  fields: FieldMetadataItem[],
-  targetAggregateOperations: ExtendedAggregateOperations[],
-): AvailableFieldsForAggregateOperation => {
+export const getAvailableFieldsIdsForAggregationFromObjectFields = ({
+  fields,
+  targetAggregateOperations,
+  restrictedFieldMetadataIds,
+}: {
+  fields: FieldMetadataItem[];
+  targetAggregateOperations: ExtendedAggregateOperations[];
+  restrictedFieldMetadataIds: string[];
+}): AvailableFieldsForAggregateOperation => {
   const aggregationMap = initializeAvailableFieldsForAggregateOperationMap(
     targetAggregateOperations,
   );
@@ -23,7 +28,9 @@ export const getAvailableFieldsIdsForAggregationFromObjectFields = (
           if (!isDefined(acc[typedAggregation])) {
             acc[typedAggregation] = [];
           }
-          (acc[typedAggregation] as string[]).push(field.id);
+          if (!restrictedFieldMetadataIds.includes(field.id)) {
+            (acc[typedAggregation] as string[]).push(field.id);
+          }
         }
       });
     }


### PR DESCRIPTION
Non-readable fields should not be an option for aggregate, as they currently were still in kanban headers.

<img width="769" height="733" alt="Capture d’écran 2025-08-01 à 18 16 16" src="https://github.com/user-attachments/assets/475621a6-9a62-4577-8dd4-eb4a3ace36e2" />
