### PR TITLE
Disable changing label identifier for standard objects

### DIFF
--- a/packages/twenty-front/src/modules/settings/data-model/objects/forms/components/SettingsDataModelObjectIdentifiersForm.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/objects/forms/components/SettingsDataModelObjectIdentifiersForm.tsx
@@ -134,6 +134,7 @@ export const SettingsDataModelObjectIdentifiersForm = ({
               options={options}
               value={value}
               withSearchInput={label === t`Record label`}
+              disabled={!objectMetadataItem.isCustom}
               callToActionButton={
                 label === t`Record label`
                   ? {


### PR DESCRIPTION
Fixes https://github.com/twentyhq/core-team-issues/issues/994