### PR TITLE
Update object-level permissions design

### DIFF
--- a/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/components/SettingsRolePermissionsObjectLevelSection.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/components/SettingsRolePermissionsObjectLevelSection.tsx
@@ -12,7 +12,7 @@ import styled from '@emotion/styled';
 import { t } from '@lingui/core/macro';
 import { useRecoilValue } from 'recoil';
 import { isDefined } from 'twenty-shared/utils';
-import { H2Title, IconPlus } from 'twenty-ui/display';
+import { IconPlus } from 'twenty-ui/display';
 import { Button } from 'twenty-ui/input';
 import { Section } from 'twenty-ui/layout';
 import { useNavigateSettings } from '~/hooks/useNavigateSettings';
@@ -81,17 +81,14 @@ export const SettingsRolePermissionsObjectLevelSection = ({
     });
   };
 
+  const hasPermissions = isDefined(filteredObjectPermissions) && filteredObjectPermissions?.length > 0;
+
   return (
     <Section>
-      <H2Title
-        title={t`Object-Level`}
-        description={t`Actions users can perform on specific objects`}
-      />
       <Table>
-        <SettingsRolePermissionsObjectLevelTableHeader />
+        <SettingsRolePermissionsObjectLevelTableHeader showPermissionsLabel={hasPermissions} />
         <StyledTableRows>
-          {isDefined(filteredObjectPermissions) &&
-          filteredObjectPermissions?.length > 0 ? (
+          {hasPermissions ? (
             filteredObjectPermissions?.map((objectPermission) => (
               <SettingsRolePermissionsObjectLevelTableRow
                 key={objectPermission.objectMetadataId}
@@ -103,14 +100,16 @@ export const SettingsRolePermissionsObjectLevelSection = ({
               />
             ))
           ) : (
-            <StyledNoOverride>{t`No permissions found`}</StyledNoOverride>
+            <StyledNoOverride>
+              {t`No permissions have been set for individual objects.`}
+            </StyledNoOverride>
           )}
         </StyledTableRows>
       </Table>
       <StyledCreateObjectOverrideSection>
         <Button
           Icon={IconPlus}
-          title={t`Add rule`}
+          title={t`Add object rule`}
           variant="secondary"
           size="small"
           disabled={!isEditable || allObjectsHaveSetPermission}

--- a/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/components/SettingsRolePermissionsObjectLevelSection.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/components/SettingsRolePermissionsObjectLevelSection.tsx
@@ -81,14 +81,18 @@ export const SettingsRolePermissionsObjectLevelSection = ({
     });
   };
 
-  const hasPermissions = isDefined(filteredObjectPermissions) && filteredObjectPermissions?.length > 0;
+  const hasObjectPermissions =
+    isDefined(filteredObjectPermissions) &&
+    filteredObjectPermissions?.length > 0;
 
   return (
     <Section>
       <Table>
-        <SettingsRolePermissionsObjectLevelTableHeader showPermissionsLabel={hasPermissions} />
+        <SettingsRolePermissionsObjectLevelTableHeader
+          showPermissionsLabel={hasObjectPermissions}
+        />
         <StyledTableRows>
-          {hasPermissions ? (
+          {hasObjectPermissions ? (
             filteredObjectPermissions?.map((objectPermission) => (
               <SettingsRolePermissionsObjectLevelTableRow
                 key={objectPermission.objectMetadataId}

--- a/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/components/SettingsRolePermissionsObjectLevelTableHeader.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/components/SettingsRolePermissionsObjectLevelTableHeader.tsx
@@ -2,10 +2,16 @@ import { TableHeader } from '@/ui/layout/table/components/TableHeader';
 import { TableRow } from '@/ui/layout/table/components/TableRow';
 import { t } from '@lingui/core/macro';
 
-export const SettingsRolePermissionsObjectLevelTableHeader = () => (
+type SettingsRolePermissionsObjectLevelTableHeaderProps = {
+  showPermissionsLabel?: boolean;
+};
+
+export const SettingsRolePermissionsObjectLevelTableHeader = ({
+  showPermissionsLabel = true,
+}: SettingsRolePermissionsObjectLevelTableHeaderProps) => (
   <TableRow gridAutoColumns="180px 1fr 1fr">
-    <TableHeader>{t`Object`}</TableHeader>
-    <TableHeader>{t`Permissions`}</TableHeader>
+    <TableHeader>{t`Object-Level`}</TableHeader>
+    <TableHeader>{showPermissionsLabel ? t`Permissions` : ''}</TableHeader>
     <TableHeader></TableHeader>
   </TableRow>
 );


### PR DESCRIPTION
<img width="569" height="448" alt="Screenshot 2025-08-05 at 07 25 15" src="https://github.com/user-attachments/assets/3bd628ed-e79e-4850-a24c-002e6cb246e7" />
<img width="549" height="441" alt="Screenshot 2025-08-05 at 07 25 26" src="https://github.com/user-attachments/assets/0941541c-d28b-4c17-98ee-1d8fb0c47f6b" />

I did keep the empty state + "object rule" instead of rule for clarity