### PR TITLE
[Admin Panel] fix invalid uuid issue on health status

### DIFF
--- a/packages/twenty-front/src/generated-metadata/graphql.ts
+++ b/packages/twenty-front/src/generated-metadata/graphql.ts
@@ -31,7 +31,7 @@ export type AdminPanelHealthServiceData = {
   description: Scalars['String'];
   details?: Maybe<Scalars['String']>;
   errorMessage?: Maybe<Scalars['String']>;
-  id: Scalars['UUID'];
+  id: HealthIndicatorId;
   label: Scalars['String'];
   queues?: Maybe<Array<AdminPanelWorkerQueueHealth>>;
   status: AdminPanelHealthServiceStatus;
@@ -3840,7 +3840,7 @@ export type GetIndicatorHealthStatusQueryVariables = Exact<{
 }>;
 
 
-export type GetIndicatorHealthStatusQuery = { __typename?: 'Query', getIndicatorHealthStatus: { __typename?: 'AdminPanelHealthServiceData', id: string, label: string, description: string, status: AdminPanelHealthServiceStatus, errorMessage?: string | null, details?: string | null, queues?: Array<{ __typename?: 'AdminPanelWorkerQueueHealth', id: string, queueName: string, status: AdminPanelHealthServiceStatus }> | null } };
+export type GetIndicatorHealthStatusQuery = { __typename?: 'Query', getIndicatorHealthStatus: { __typename?: 'AdminPanelHealthServiceData', id: HealthIndicatorId, label: string, description: string, status: AdminPanelHealthServiceStatus, errorMessage?: string | null, details?: string | null, queues?: Array<{ __typename?: 'AdminPanelWorkerQueueHealth', id: string, queueName: string, status: AdminPanelHealthServiceStatus }> | null } };
 
 export type GetQueueMetricsQueryVariables = Exact<{
   queueName: Scalars['String'];

--- a/packages/twenty-front/src/generated/graphql.ts
+++ b/packages/twenty-front/src/generated/graphql.ts
@@ -31,7 +31,7 @@ export type AdminPanelHealthServiceData = {
   description: Scalars['String'];
   details?: Maybe<Scalars['String']>;
   errorMessage?: Maybe<Scalars['String']>;
-  id: Scalars['UUID'];
+  id: HealthIndicatorId;
   label: Scalars['String'];
   queues?: Maybe<Array<AdminPanelWorkerQueueHealth>>;
   status: AdminPanelHealthServiceStatus;

--- a/packages/twenty-front/src/modules/settings/admin-panel/health-status/contexts/SettingsAdminIndicatorHealthContext.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/health-status/contexts/SettingsAdminIndicatorHealthContext.tsx
@@ -2,6 +2,7 @@ import { createContext } from 'react';
 import {
   AdminPanelHealthServiceData,
   AdminPanelHealthServiceStatus,
+  HealthIndicatorId,
 } from '~/generated/graphql';
 
 type SettingsAdminIndicatorHealthContextType = {
@@ -11,7 +12,7 @@ type SettingsAdminIndicatorHealthContextType = {
 export const SettingsAdminIndicatorHealthContext =
   createContext<SettingsAdminIndicatorHealthContextType>({
     indicatorHealth: {
-      id: '',
+      id: HealthIndicatorId.app,
       label: '',
       description: '',
       errorMessage: '',

--- a/packages/twenty-front/src/pages/settings/admin-panel/SettingsAdminIndicatorHealthStatus.tsx
+++ b/packages/twenty-front/src/pages/settings/admin-panel/SettingsAdminIndicatorHealthStatus.tsx
@@ -61,7 +61,7 @@ export const SettingsAdminIndicatorHealthStatus = () => {
         <SettingsAdminIndicatorHealthContext.Provider
           value={{
             indicatorHealth: {
-              id: data?.getIndicatorHealthStatus?.id ?? '',
+              id: data?.getIndicatorHealthStatus?.id ?? HealthIndicatorId.app,
               label: data?.getIndicatorHealthStatus?.label ?? '',
               description: data?.getIndicatorHealthStatus?.description ?? '',
               errorMessage: data?.getIndicatorHealthStatus?.errorMessage,

--- a/packages/twenty-server/src/engine/core-modules/admin-panel/dtos/admin-panel-health-service-data.dto.ts
+++ b/packages/twenty-server/src/engine/core-modules/admin-panel/dtos/admin-panel-health-service-data.dto.ts
@@ -1,13 +1,13 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 
-import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 import { AdminPanelWorkerQueueHealth } from 'src/engine/core-modules/admin-panel/dtos/admin-panel-worker-queue-health.dto';
 import { AdminPanelHealthServiceStatus } from 'src/engine/core-modules/admin-panel/enums/admin-panel-health-service-status.enum';
+import { HealthIndicatorId } from 'src/engine/core-modules/health/enums/health-indicator-id.enum';
 
 @ObjectType()
 export class AdminPanelHealthServiceData {
-  @Field(() => UUIDScalarType)
-  id: string;
+  @Field(() => HealthIndicatorId)
+  id: HealthIndicatorId;
 
   @Field(() => String)
   label: string;


### PR DESCRIPTION
Health status queries are failing at the moment - regression was introduced in 01f25519f618f67aa8c26e2b06a05e844432195a
health status ids are not uuids, we use params to fetch them on the frontend.
But maybe @FelixMalfait and @abdulrahmancodes have more context on this one?
