### PR TITLE
Run migrations on empty databases on docker compose

### DIFF
--- a/packages/twenty-docker/twenty/entrypoint.sh
+++ b/packages/twenty-docker/twenty/entrypoint.sh
@@ -19,8 +19,12 @@ setup_and_migrate_db() {
     if [ "$db_count" = "0" ]; then
         echo "Database ${PGDATABASE} does not exist, creating..."
         PGPASSWORD=${PGPASS} psql -h ${PGHOST} -p ${PGPORT} -U ${PGUSER} -d postgres -c "CREATE DATABASE \"${PGDATABASE}\""
+    fi
 
-        # Run setup and migration scripts
+    # Run setup and migration scripts
+    has_schema=$(PGPASSWORD=${PGPASS} psql -h ${PGHOST} -p ${PGPORT} -U ${PGUSER} -d ${PGDATABASE} -tAc "SELECT EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = 'core')")
+    if [ "$has_schema" = "f" ]; then
+        echo "Database appears to be empty, running migrations."
         NODE_OPTIONS="--max-old-space-size=1500" tsx ./scripts/setup-db.ts
         yarn database:migrate:prod
     fi


### PR DESCRIPTION
It is possible an empty database might already with the configured name. Check whether the core schema exists and run migration scripts if it doesn't.

For example, some may prefer creating a postgres database and user and assigning the user access only to that specific database.