### PR TITLE
fix: set user friendly message when creating an object with incorrect…

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/utils/object-metadata-graphql-api-exception-handler.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/utils/object-metadata-graphql-api-exception-handler.util.ts
@@ -51,15 +51,13 @@ export const objectMetadataGraphqlApiExceptionHandler = (error: Error) => {
         constraintName ===
         'IDX_FIELD_METADATA_NAME_OBJMID_WORKSPACE_ID_EXCEPT_MORPH_UNIQUE'
       ) {
-        throw new ConflictError(
-          new ObjectMetadataException(
-            'Field name conflicts with a system field. Please choose a different name.',
-            ObjectMetadataExceptionCode.INVALID_OBJECT_INPUT,
-            {
-              userFriendlyMessage:
-                'Field name conflicts with a system field. Please choose a different name.',
-            },
-          ),
+        throw new ObjectMetadataException(
+          'Field name conflicts with a system field. Please choose a different name.',
+          ObjectMetadataExceptionCode.INVALID_OBJECT_INPUT,
+          {
+            userFriendlyMessage:
+              'Field name conflicts with a system field. Please choose a different name.',
+          },
         );
       }
     }


### PR DESCRIPTION
/closes #13577

<img width="1496" height="848" alt="Screenshot 2025-08-06 at 3 14 18 AM" src="https://github.com/user-attachments/assets/72f3d76b-e83e-4106-abcd-6c9c1c216b39" />
