### PR TITLE
Filter dropdown by types

### DIFF
--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/filter-action/components/WorkflowStepFilterFieldSelect.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/filter-action/components/WorkflowStepFilterFieldSelect.tsx
@@ -15,6 +15,7 @@ import { useContext } from 'react';
 import { useRecoilCallback, useRecoilValue } from 'recoil';
 import { StepFilter } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
+import { FieldMetadataType } from '~/generated-metadata/graphql';
 
 type WorkflowStepFilterFieldSelectProps = {
   stepFilter: StepFilter;
@@ -163,6 +164,7 @@ export const WorkflowStepFilterFieldSelect = ({
       shouldDisplayRecordFields={shouldDisplayRecordFields}
       shouldDisplayRecordObjects={shouldDisplayRecordObjects}
       shouldEnableSelectRelationObject={true}
+      typesToFilter={[FieldMetadataType.ACTOR, FieldMetadataType.RICH_TEXT_V2]}
     />
   );
 };

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/filter-action/components/WorkflowStepFilterFieldSelect.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/filter-action/components/WorkflowStepFilterFieldSelect.tsx
@@ -21,6 +21,11 @@ type WorkflowStepFilterFieldSelectProps = {
   stepFilter: StepFilter;
 };
 
+const NON_SELECTABLE_FIELD_TYPES = [
+  FieldMetadataType.ACTOR,
+  FieldMetadataType.RICH_TEXT_V2,
+];
+
 export const WorkflowStepFilterFieldSelect = ({
   stepFilter,
 }: WorkflowStepFilterFieldSelectProps) => {
@@ -164,7 +169,7 @@ export const WorkflowStepFilterFieldSelect = ({
       shouldDisplayRecordFields={shouldDisplayRecordFields}
       shouldDisplayRecordObjects={shouldDisplayRecordObjects}
       shouldEnableSelectRelationObject={true}
-      typesToFilter={[FieldMetadataType.ACTOR, FieldMetadataType.RICH_TEXT_V2]}
+      fieldTypesToExclude={NON_SELECTABLE_FIELD_TYPES}
     />
   );
 };

--- a/packages/twenty-front/src/modules/workflow/workflow-variables/components/WorkflowVariablesDropdown.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-variables/components/WorkflowVariablesDropdown.tsx
@@ -38,7 +38,7 @@ export const WorkflowVariablesDropdown = ({
   disabled,
   shouldDisplayRecordFields,
   shouldDisplayRecordObjects,
-  typesToFilter,
+  fieldTypesToExclude,
   shouldEnableSelectRelationObject,
   multiline,
   clickableComponent,
@@ -47,7 +47,7 @@ export const WorkflowVariablesDropdown = ({
   onVariableSelect: (variableName: string) => void;
   shouldDisplayRecordFields: boolean;
   shouldDisplayRecordObjects: boolean;
-  typesToFilter?: InputSchemaPropertyType[];
+  fieldTypesToExclude?: InputSchemaPropertyType[];
   shouldEnableSelectRelationObject?: boolean;
   disabled?: boolean;
   multiline?: boolean;
@@ -64,7 +64,7 @@ export const WorkflowVariablesDropdown = ({
   const availableVariablesInWorkflowStep = useAvailableVariablesInWorkflowStep({
     shouldDisplayRecordFields,
     shouldDisplayRecordObjects,
-    typesToFilter,
+    fieldTypesToExclude,
   });
 
   const noAvailableVariables = availableVariablesInWorkflowStep.length === 0;

--- a/packages/twenty-front/src/modules/workflow/workflow-variables/components/WorkflowVariablesDropdown.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-variables/components/WorkflowVariablesDropdown.tsx
@@ -3,6 +3,7 @@ import { StyledDropdownButtonContainer } from '@/ui/layout/dropdown/components/S
 import { useCloseDropdown } from '@/ui/layout/dropdown/hooks/useCloseDropdown';
 import { isDropdownOpenComponentState } from '@/ui/layout/dropdown/states/isDropdownOpenComponentState';
 import { useRecoilComponentValue } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValue';
+import { InputSchemaPropertyType } from '@/workflow/types/InputSchema';
 import { WorkflowVariablesDropdownAllItems } from '@/workflow/workflow-variables/components/WorkflowVariablesDropdownAllItems';
 import { WorkflowVariablesDropdownFieldItems } from '@/workflow/workflow-variables/components/WorkflowVariablesDropdownFieldItems';
 import { WorkflowVariablesDropdownWorkflowStepItems } from '@/workflow/workflow-variables/components/WorkflowVariablesDropdownWorkflowStepItems';
@@ -37,6 +38,7 @@ export const WorkflowVariablesDropdown = ({
   disabled,
   shouldDisplayRecordFields,
   shouldDisplayRecordObjects,
+  typesToFilter,
   shouldEnableSelectRelationObject,
   multiline,
   clickableComponent,
@@ -45,6 +47,7 @@ export const WorkflowVariablesDropdown = ({
   onVariableSelect: (variableName: string) => void;
   shouldDisplayRecordFields: boolean;
   shouldDisplayRecordObjects: boolean;
+  typesToFilter?: InputSchemaPropertyType[];
   shouldEnableSelectRelationObject?: boolean;
   disabled?: boolean;
   multiline?: boolean;
@@ -61,6 +64,7 @@ export const WorkflowVariablesDropdown = ({
   const availableVariablesInWorkflowStep = useAvailableVariablesInWorkflowStep({
     shouldDisplayRecordFields,
     shouldDisplayRecordObjects,
+    typesToFilter,
   });
 
   const noAvailableVariables = availableVariablesInWorkflowStep.length === 0;

--- a/packages/twenty-front/src/modules/workflow/workflow-variables/hooks/useAvailableVariablesInWorkflowStep.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-variables/hooks/useAvailableVariablesInWorkflowStep.ts
@@ -1,5 +1,6 @@
 import { useFlowOrThrow } from '@/workflow/hooks/useFlowOrThrow';
 import { stepsOutputSchemaFamilySelector } from '@/workflow/states/selectors/stepsOutputSchemaFamilySelector';
+import { InputSchemaPropertyType } from '@/workflow/types/InputSchema';
 import { useWorkflowSelectedNodeOrThrow } from '@/workflow/workflow-diagram/hooks/useWorkflowSelectedNodeOrThrow';
 import { getPreviousSteps } from '@/workflow/workflow-steps/utils/getWorkflowPreviousSteps';
 import { TRIGGER_STEP_ID } from '@/workflow/workflow-trigger/constants/TriggerStepId';
@@ -15,9 +16,11 @@ import { isEmptyObject } from '~/utils/isEmptyObject';
 export const useAvailableVariablesInWorkflowStep = ({
   shouldDisplayRecordFields,
   shouldDisplayRecordObjects,
+  typesToFilter,
 }: {
   shouldDisplayRecordFields: boolean;
   shouldDisplayRecordObjects: boolean;
+  typesToFilter?: InputSchemaPropertyType[];
 }): StepOutputSchema[] => {
   const workflowSelectedNode = useWorkflowSelectedNodeOrThrow();
   const flow = useFlowOrThrow();
@@ -41,6 +44,7 @@ export const useAvailableVariablesInWorkflowStep = ({
         shouldDisplayRecordFields,
         shouldDisplayRecordObjects,
         outputSchema: stepOutputSchema.outputSchema,
+        typesToFilter,
       }) as OutputSchema;
 
       if (!isDefined(outputSchema) || isEmptyObject(outputSchema)) {

--- a/packages/twenty-front/src/modules/workflow/workflow-variables/hooks/useAvailableVariablesInWorkflowStep.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-variables/hooks/useAvailableVariablesInWorkflowStep.ts
@@ -16,11 +16,11 @@ import { isEmptyObject } from '~/utils/isEmptyObject';
 export const useAvailableVariablesInWorkflowStep = ({
   shouldDisplayRecordFields,
   shouldDisplayRecordObjects,
-  typesToFilter,
+  fieldTypesToExclude,
 }: {
   shouldDisplayRecordFields: boolean;
   shouldDisplayRecordObjects: boolean;
-  typesToFilter?: InputSchemaPropertyType[];
+  fieldTypesToExclude?: InputSchemaPropertyType[];
 }): StepOutputSchema[] => {
   const workflowSelectedNode = useWorkflowSelectedNodeOrThrow();
   const flow = useFlowOrThrow();
@@ -44,7 +44,7 @@ export const useAvailableVariablesInWorkflowStep = ({
         shouldDisplayRecordFields,
         shouldDisplayRecordObjects,
         outputSchema: stepOutputSchema.outputSchema,
-        typesToFilter,
+        fieldTypesToExclude,
       }) as OutputSchema;
 
       if (!isDefined(outputSchema) || isEmptyObject(outputSchema)) {

--- a/packages/twenty-front/src/modules/workflow/workflow-variables/utils/__tests__/filterOutputSchema.test.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-variables/utils/__tests__/filterOutputSchema.test.ts
@@ -225,4 +225,44 @@ describe('filterOutputSchema', () => {
       ).toBeUndefined();
     });
   });
+
+  describe('typesToFilter', () => {
+    it('should filter out the types', () => {
+      const inputSchema = createRecordSchema('person', {
+        name: { isLeaf: true, type: undefined, value: 'toto' },
+        age: { isLeaf: true, type: FieldMetadataType.NUMBER },
+        id: { isLeaf: true, type: FieldMetadataType.UUID },
+      });
+
+      const expectedSchema = createRecordSchema('person', {
+        name: { isLeaf: true, type: undefined, value: 'toto' },
+        age: { isLeaf: true, type: FieldMetadataType.NUMBER },
+      });
+
+      expect(
+        filterOutputSchema({
+          shouldDisplayRecordFields: true,
+          shouldDisplayRecordObjects: false,
+          outputSchema: inputSchema,
+          typesToFilter: [FieldMetadataType.UUID],
+        }),
+      ).toEqual(expectedSchema);
+    });
+
+    it('should return the same schema if no types to filter', () => {
+      const inputSchema = createRecordSchema('person', {
+        name: { isLeaf: true, value: 'string' },
+        id: { isLeaf: true, type: FieldMetadataType.UUID },
+      });
+
+      expect(
+        filterOutputSchema({
+          shouldDisplayRecordFields: true,
+          shouldDisplayRecordObjects: false,
+          outputSchema: inputSchema,
+          typesToFilter: [],
+        }),
+      ).toEqual(inputSchema);
+    });
+  });
 });

--- a/packages/twenty-front/src/modules/workflow/workflow-variables/utils/__tests__/filterOutputSchema.test.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-variables/utils/__tests__/filterOutputSchema.test.ts
@@ -226,7 +226,7 @@ describe('filterOutputSchema', () => {
     });
   });
 
-  describe('typesToFilter', () => {
+  describe('fieldTypesToExclude', () => {
     it('should filter out the types', () => {
       const inputSchema = createRecordSchema('person', {
         name: { isLeaf: true, type: undefined, value: 'toto' },
@@ -244,7 +244,7 @@ describe('filterOutputSchema', () => {
           shouldDisplayRecordFields: true,
           shouldDisplayRecordObjects: false,
           outputSchema: inputSchema,
-          typesToFilter: [FieldMetadataType.UUID],
+          fieldTypesToExclude: [FieldMetadataType.UUID],
         }),
       ).toEqual(expectedSchema);
     });
@@ -260,7 +260,7 @@ describe('filterOutputSchema', () => {
           shouldDisplayRecordFields: true,
           shouldDisplayRecordObjects: false,
           outputSchema: inputSchema,
-          typesToFilter: [],
+          fieldTypesToExclude: [],
         }),
       ).toEqual(inputSchema);
     });

--- a/packages/twenty-front/src/modules/workflow/workflow-variables/utils/filterOutputSchema.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-variables/utils/filterOutputSchema.ts
@@ -131,17 +131,17 @@ const filterBaseOutputSchema = ({
 
 const filterRecordOutputSchemaFieldsByType = ({
   outputSchema,
-  typesToFilter,
+  fieldTypesToExclude,
 }: {
   outputSchema: RecordOutputSchema;
-  typesToFilter: InputSchemaPropertyType[];
+  fieldTypesToExclude: InputSchemaPropertyType[];
 }) => {
   const filteredFields: BaseOutputSchema = {};
 
   for (const key in outputSchema.fields) {
     const field = outputSchema.fields[key];
 
-    if (isDefined(field.type) && typesToFilter.includes(field.type)) {
+    if (isDefined(field.type) && fieldTypesToExclude.includes(field.type)) {
       continue;
     }
 
@@ -150,6 +150,7 @@ const filterRecordOutputSchemaFieldsByType = ({
 
   return {
     ...outputSchema,
+    // Relations could be filtered recursively but this util requires a global simplification first
     fields: filteredFields,
   };
 };
@@ -158,22 +159,22 @@ export const filterOutputSchema = ({
   shouldDisplayRecordFields,
   shouldDisplayRecordObjects,
   outputSchema,
-  typesToFilter,
+  fieldTypesToExclude,
 }: {
   shouldDisplayRecordFields: boolean;
   shouldDisplayRecordObjects: boolean;
   outputSchema?: OutputSchema;
-  typesToFilter?: InputSchemaPropertyType[];
+  fieldTypesToExclude?: InputSchemaPropertyType[];
 }): OutputSchema | undefined => {
   if (!isDefined(outputSchema)) {
     return undefined;
   }
 
   if (!shouldDisplayRecordObjects || shouldDisplayRecordFields) {
-    if (isRecordOutputSchema(outputSchema) && isDefined(typesToFilter)) {
+    if (isRecordOutputSchema(outputSchema) && isDefined(fieldTypesToExclude)) {
       return filterRecordOutputSchemaFieldsByType({
         outputSchema,
-        typesToFilter,
+        fieldTypesToExclude,
       });
     }
 

--- a/packages/twenty-front/src/modules/workflow/workflow-variables/utils/filterOutputSchema.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-variables/utils/filterOutputSchema.ts
@@ -1,3 +1,4 @@
+import { InputSchemaPropertyType } from '@/workflow/types/InputSchema';
 import {
   BaseOutputSchema,
   OutputSchema,
@@ -128,20 +129,63 @@ const filterBaseOutputSchema = ({
   return undefined;
 };
 
+const filterRecordOutputSchemaFieldsByType = ({
+  outputSchema,
+  typesToFilter,
+}: {
+  outputSchema: RecordOutputSchema;
+  typesToFilter?: InputSchemaPropertyType[];
+}) => {
+  if (!isDefined(typesToFilter)) {
+    return outputSchema.fields;
+  }
+
+  const filteredFields: BaseOutputSchema = {};
+
+  for (const key in outputSchema.fields) {
+    const field = outputSchema.fields[key];
+
+    if (!isDefined(field.type)) {
+      filteredFields[key] = field;
+      continue;
+    }
+
+    if (typesToFilter.includes(field.type)) {
+      continue;
+    }
+
+    filteredFields[key] = field;
+  }
+
+  return {
+    ...outputSchema,
+    fields: filteredFields,
+  };
+};
+
 export const filterOutputSchema = ({
   shouldDisplayRecordFields,
   shouldDisplayRecordObjects,
   outputSchema,
+  typesToFilter,
 }: {
   shouldDisplayRecordFields: boolean;
   shouldDisplayRecordObjects: boolean;
   outputSchema?: OutputSchema;
+  typesToFilter?: InputSchemaPropertyType[];
 }): OutputSchema | undefined => {
-  if (
-    !shouldDisplayRecordObjects ||
-    shouldDisplayRecordFields ||
-    !outputSchema
-  ) {
+  if (!isDefined(outputSchema)) {
+    return undefined;
+  }
+
+  if (!shouldDisplayRecordObjects || shouldDisplayRecordFields) {
+    if (isRecordOutputSchema(outputSchema)) {
+      return filterRecordOutputSchemaFieldsByType({
+        outputSchema,
+        typesToFilter,
+      });
+    }
+
     return outputSchema;
   }
 

--- a/packages/twenty-front/src/modules/workflow/workflow-variables/utils/filterOutputSchema.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-variables/utils/filterOutputSchema.ts
@@ -134,23 +134,14 @@ const filterRecordOutputSchemaFieldsByType = ({
   typesToFilter,
 }: {
   outputSchema: RecordOutputSchema;
-  typesToFilter?: InputSchemaPropertyType[];
+  typesToFilter: InputSchemaPropertyType[];
 }) => {
-  if (!isDefined(typesToFilter)) {
-    return outputSchema.fields;
-  }
-
   const filteredFields: BaseOutputSchema = {};
 
   for (const key in outputSchema.fields) {
     const field = outputSchema.fields[key];
 
-    if (!isDefined(field.type)) {
-      filteredFields[key] = field;
-      continue;
-    }
-
-    if (typesToFilter.includes(field.type)) {
+    if (isDefined(field.type) && typesToFilter.includes(field.type)) {
       continue;
     }
 
@@ -179,7 +170,7 @@ export const filterOutputSchema = ({
   }
 
   if (!shouldDisplayRecordObjects || shouldDisplayRecordFields) {
-    if (isRecordOutputSchema(outputSchema)) {
+    if (isRecordOutputSchema(outputSchema) && isDefined(typesToFilter)) {
       return filterRecordOutputSchemaFieldsByType({
         outputSchema,
         typesToFilter,


### PR DESCRIPTION
Allow to filter types in variable dropdown. This will avoid unsupported types for filters (RICH_TEXT, ACTOR)
<img width="579" height="505" alt="Capture d’écran 2025-08-07 à 09 58 42" src="https://github.com/user-attachments/assets/c3fbeb3f-61ab-4c2c-bb2c-6f2c6292ef9e" />
