### PR TITLE
Fix i18n issues on datamodel translation

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/i18n/i18n.middleware.ts
+++ b/packages/twenty-server/src/engine/core-modules/i18n/i18n.middleware.ts
@@ -4,6 +4,7 @@ import { i18n } from '@lingui/core';
 import { NextFunction, Request, Response } from 'express';
 import { APP_LOCALES, SOURCE_LOCALE } from 'twenty-shared/translations';
 
+// TODO: this should be deprecated as singleton pattern won't work: user will keep changing locales for eachothers
 @Injectable()
 export class I18nMiddleware implements NestMiddleware {
   use(req: Request, res: Response, next: NextFunction) {

--- a/packages/twenty-server/src/engine/core-modules/i18n/i18n.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/i18n/i18n.service.ts
@@ -37,10 +37,8 @@ import { messages as zhHantMessages } from 'src/engine/core-modules/i18n/locales
 
 @Injectable()
 export class I18nService implements OnModuleInit {
-  private i18nMap: Record<keyof typeof APP_LOCALES, I18n> = {} as Record<
-    keyof typeof APP_LOCALES,
-    I18n
-  >;
+  private i18nInstancesMap: Record<keyof typeof APP_LOCALES, I18n> =
+    {} as Record<keyof typeof APP_LOCALES, I18n>;
 
   async loadTranslations() {
     const messagesByLocale: Record<keyof typeof APP_LOCALES, Messages> = {
@@ -85,28 +83,28 @@ export class I18nService implements OnModuleInit {
       localeI18n.load(locale, messages);
       localeI18n.activate(locale);
 
-      this.i18nMap[locale] = localeI18n;
+      this.i18nInstancesMap[locale] = localeI18n;
     });
   }
 
-  getI18n(locale: keyof typeof APP_LOCALES) {
-    return this.i18nMap[locale];
+  getI18nInstance(locale: keyof typeof APP_LOCALES) {
+    return this.i18nInstancesMap[locale];
   }
 
-  getTranslation({
-    id,
+  translateMessage({
+    messageId,
     values,
     locale = SOURCE_LOCALE,
     options,
   }: {
-    id: string;
+    messageId: string;
     values?: Record<string, string>;
     locale?: keyof typeof APP_LOCALES;
     options?: MessageOptions;
   }) {
-    const i18n = this.i18nMap[locale];
+    const i18n = this.getI18nInstance(locale);
 
-    return i18n._(id, values, options);
+    return i18n._(messageId, values, options);
   }
 
   async onModuleInit() {

--- a/packages/twenty-server/src/engine/core-modules/i18n/i18n.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/i18n/i18n.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, OnModuleInit } from '@nestjs/common';
 
-import { I18n, MessageOptions, Messages, setupI18n } from '@lingui/core';
+import { I18n, MessageOptions, Messages, i18n, setupI18n } from '@lingui/core';
 import { APP_LOCALES, SOURCE_LOCALE } from 'twenty-shared/translations';
 
 import { messages as afMessages } from 'src/engine/core-modules/i18n/locales/generated/af-ZA';
@@ -84,6 +84,10 @@ export class I18nService implements OnModuleInit {
       localeI18n.activate(locale);
 
       this.i18nInstancesMap[locale] = localeI18n;
+
+      // TODO: deprecate this line which is legacy as soon as we only use the i18nInstancesMap
+      // Also deprecate i18n.middleware.ts
+      i18n.load(locale, messages);
     });
   }
 

--- a/packages/twenty-server/src/engine/core-modules/i18n/i18n.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/i18n/i18n.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, OnModuleInit } from '@nestjs/common';
 
-import { i18n } from '@lingui/core';
+import { I18n, MessageOptions, Messages, setupI18n } from '@lingui/core';
 import { APP_LOCALES, SOURCE_LOCALE } from 'twenty-shared/translations';
 
 import { messages as afMessages } from 'src/engine/core-modules/i18n/locales/generated/af-ZA';
@@ -37,9 +37,13 @@ import { messages as zhHantMessages } from 'src/engine/core-modules/i18n/locales
 
 @Injectable()
 export class I18nService implements OnModuleInit {
+  private i18nMap: Record<keyof typeof APP_LOCALES, I18n> = {} as Record<
+    keyof typeof APP_LOCALES,
+    I18n
+  >;
+
   async loadTranslations() {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const messages: Record<keyof typeof APP_LOCALES, any> = {
+    const messagesByLocale: Record<keyof typeof APP_LOCALES, Messages> = {
       en: enMessages,
       'pseudo-en': pseudoEnMessages,
       'af-ZA': afMessages,
@@ -73,14 +77,36 @@ export class I18nService implements OnModuleInit {
       'zh-TW': zhHantMessages,
     };
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (Object.entries(messages) as [keyof typeof APP_LOCALES, any][]).forEach(
-      ([locale, message]) => {
-        i18n.load(locale, message);
-      },
-    );
+    (
+      Object.entries(messagesByLocale) as [keyof typeof APP_LOCALES, Messages][]
+    ).forEach(([locale, messages]) => {
+      const localeI18n = setupI18n();
 
-    i18n.activate(SOURCE_LOCALE);
+      localeI18n.load(locale, messages);
+      localeI18n.activate(locale);
+
+      this.i18nMap[locale] = localeI18n;
+    });
+  }
+
+  getI18n(locale: keyof typeof APP_LOCALES) {
+    return this.i18nMap[locale];
+  }
+
+  getTranslation({
+    id,
+    values,
+    locale = SOURCE_LOCALE,
+    options,
+  }: {
+    id: string;
+    values?: Record<string, string>;
+    locale?: keyof typeof APP_LOCALES;
+    options?: MessageOptions;
+  }) {
+    const i18n = this.i18nMap[locale];
+
+    return i18n._(id, values, options);
   }
 
   async onModuleInit() {

--- a/packages/twenty-server/src/engine/core-modules/i18n/i18n.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/i18n/i18n.service.ts
@@ -89,6 +89,9 @@ export class I18nService implements OnModuleInit {
       // Also deprecate i18n.middleware.ts
       i18n.load(locale, messages);
     });
+
+    // TODO: deprecate this line which is legacy as soon as we only use the i18nInstancesMap
+    i18n.activate(SOURCE_LOCALE);
   }
 
   getI18nInstance(locale: keyof typeof APP_LOCALES) {

--- a/packages/twenty-server/src/engine/dataloaders/dataloader.service.ts
+++ b/packages/twenty-server/src/engine/dataloaders/dataloader.service.ts
@@ -1,12 +1,12 @@
 import { Injectable } from '@nestjs/common';
 
 import DataLoader from 'dataloader';
-import { APP_LOCALES } from 'twenty-shared/translations';
+import { APP_LOCALES, SOURCE_LOCALE } from 'twenty-shared/translations';
 import { isDefined } from 'twenty-shared/utils';
 
 import { IndexMetadataInterface } from 'src/engine/metadata-modules/index-metadata/interfaces/index-metadata.interface';
 
-import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
+import { I18nService } from 'src/engine/core-modules/i18n/i18n.service';
 import { IDataloaders } from 'src/engine/dataloaders/dataloader.interface';
 import { filterMorphRelationDuplicateFieldsDTO } from 'src/engine/dataloaders/utils/filter-morph-relation-duplicate-fields.util';
 import { FieldMetadataDTO } from 'src/engine/metadata-modules/field-metadata/dtos/field-metadata.dto';
@@ -17,6 +17,7 @@ import { fromFieldMetadataEntityToFieldMetadataDto } from 'src/engine/metadata-m
 import { resolveFieldMetadataStandardOverride } from 'src/engine/metadata-modules/field-metadata/utils/resolve-field-metadata-standard-override.util';
 import { IndexFieldMetadataDTO } from 'src/engine/metadata-modules/index-metadata/dtos/index-field-metadata.dto';
 import { IndexMetadataDTO } from 'src/engine/metadata-modules/index-metadata/dtos/index-metadata.dto';
+import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 import { WorkspaceMetadataCacheService } from 'src/engine/metadata-modules/workspace-metadata-cache/services/workspace-metadata-cache.service';
 
 export type RelationMetadataLoaderPayload = {
@@ -69,6 +70,7 @@ export type IndexFieldMetadataLoaderPayload = {
 @Injectable()
 export class DataloaderService {
   constructor(
+    private readonly i18nService: I18nService,
     private readonly fieldMetadataRelationService: FieldMetadataRelationService,
     private readonly fieldMetadataMorphRelationService: FieldMetadataMorphRelationService,
     private readonly workspaceMetadataCacheService: WorkspaceMetadataCacheService,
@@ -190,6 +192,8 @@ export class DataloaderService {
   private createFieldMetadataLoader() {
     return new DataLoader<FieldMetadataLoaderPayload, FieldMetadataDTO[]>(
       async (dataLoaderParams: FieldMetadataLoaderPayload[]) => {
+        const locale = dataLoaderParams[0].locale;
+        const i18n = this.i18nService.getI18n(locale ?? SOURCE_LOCALE);
         const workspaceId = dataLoaderParams[0].workspaceId;
         const objectMetadataIds = dataLoaderParams.map(
           (dataLoaderParam) => dataLoaderParam.objectMetadata.id,
@@ -232,6 +236,7 @@ export class DataloaderService {
                   },
                   field,
                   dataLoaderParams[0].locale,
+                  i18n,
                 ),
               }),
               {},

--- a/packages/twenty-server/src/engine/dataloaders/dataloader.service.ts
+++ b/packages/twenty-server/src/engine/dataloaders/dataloader.service.ts
@@ -193,7 +193,9 @@ export class DataloaderService {
     return new DataLoader<FieldMetadataLoaderPayload, FieldMetadataDTO[]>(
       async (dataLoaderParams: FieldMetadataLoaderPayload[]) => {
         const locale = dataLoaderParams[0].locale;
-        const i18n = this.i18nService.getI18n(locale ?? SOURCE_LOCALE);
+        const i18nInstance = this.i18nService.getI18nInstance(
+          locale ?? SOURCE_LOCALE,
+        );
         const workspaceId = dataLoaderParams[0].workspaceId;
         const objectMetadataIds = dataLoaderParams.map(
           (dataLoaderParam) => dataLoaderParam.objectMetadata.id,
@@ -236,7 +238,7 @@ export class DataloaderService {
                   },
                   field,
                   dataLoaderParams[0].locale,
-                  i18n,
+                  i18nInstance,
                 ),
               }),
               {},

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/utils/__tests__/resolve-field-metadata-standard-override.util.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/utils/__tests__/resolve-field-metadata-standard-override.util.spec.ts
@@ -31,6 +31,7 @@ describe('resolveFieldMetadataStandardOverride', () => {
         fieldMetadata,
         'label',
         'fr-FR',
+        mockI18n,
       );
 
       expect(result).toBe('Custom Label');
@@ -49,6 +50,7 @@ describe('resolveFieldMetadataStandardOverride', () => {
         fieldMetadata,
         'description',
         undefined,
+        mockI18n,
       );
 
       expect(result).toBe('Custom Description');
@@ -67,6 +69,7 @@ describe('resolveFieldMetadataStandardOverride', () => {
         fieldMetadata,
         'icon',
         SOURCE_LOCALE,
+        mockI18n,
       );
 
       expect(result).toBe('custom-icon');
@@ -89,6 +92,7 @@ describe('resolveFieldMetadataStandardOverride', () => {
         fieldMetadata,
         'icon',
         'fr-FR',
+        mockI18n,
       );
 
       expect(result).toBe('override-icon');
@@ -113,13 +117,19 @@ describe('resolveFieldMetadataStandardOverride', () => {
       };
 
       expect(
-        resolveFieldMetadataStandardOverride(fieldMetadata, 'label', 'fr-FR'),
+        resolveFieldMetadataStandardOverride(
+          fieldMetadata,
+          'label',
+          'fr-FR',
+          mockI18n,
+        ),
       ).toBe('Libellé traduit');
       expect(
         resolveFieldMetadataStandardOverride(
           fieldMetadata,
           'description',
           'fr-FR',
+          mockI18n,
         ),
       ).toBe('Description traduite');
     });
@@ -146,6 +156,7 @@ describe('resolveFieldMetadataStandardOverride', () => {
         fieldMetadata,
         'label',
         'fr-FR',
+        mockI18n,
       );
 
       expect(result).toBe('Standard Label');
@@ -173,6 +184,7 @@ describe('resolveFieldMetadataStandardOverride', () => {
         fieldMetadata,
         'description',
         'fr-FR',
+        mockI18n,
       );
 
       expect(result).toBe('Standard Description');
@@ -200,6 +212,7 @@ describe('resolveFieldMetadataStandardOverride', () => {
         fieldMetadata,
         'label',
         undefined,
+        mockI18n,
       );
 
       expect(result).toBe('Standard Label');
@@ -225,6 +238,7 @@ describe('resolveFieldMetadataStandardOverride', () => {
           fieldMetadata,
           'label',
           SOURCE_LOCALE,
+          mockI18n,
         ),
       ).toBe('Overridden Label');
       expect(
@@ -232,6 +246,7 @@ describe('resolveFieldMetadataStandardOverride', () => {
           fieldMetadata,
           'description',
           SOURCE_LOCALE,
+          mockI18n,
         ),
       ).toBe('Overridden Description');
       expect(
@@ -239,6 +254,7 @@ describe('resolveFieldMetadataStandardOverride', () => {
           fieldMetadata,
           'icon',
           SOURCE_LOCALE,
+          mockI18n,
         ),
       ).toBe('overridden-icon');
     });
@@ -261,6 +277,7 @@ describe('resolveFieldMetadataStandardOverride', () => {
         fieldMetadata,
         'label',
         'fr-FR',
+        mockI18n,
       );
 
       expect(result).toBe('Standard Label');
@@ -284,6 +301,7 @@ describe('resolveFieldMetadataStandardOverride', () => {
         fieldMetadata,
         'label',
         SOURCE_LOCALE,
+        mockI18n,
       );
 
       expect(result).toBe('Standard Label');
@@ -307,6 +325,7 @@ describe('resolveFieldMetadataStandardOverride', () => {
         fieldMetadata,
         'label',
         SOURCE_LOCALE,
+        mockI18n,
       );
 
       expect(result).toBe('Standard Label');
@@ -330,6 +349,7 @@ describe('resolveFieldMetadataStandardOverride', () => {
         fieldMetadata,
         'label',
         'fr-FR',
+        mockI18n,
       );
 
       expect(mockGenerateMessageId).toHaveBeenCalledWith('Standard Label');
@@ -355,6 +375,7 @@ describe('resolveFieldMetadataStandardOverride', () => {
         fieldMetadata,
         'label',
         'fr-FR',
+        mockI18n,
       );
 
       expect(result).toBe('Standard Label');
@@ -382,6 +403,7 @@ describe('resolveFieldMetadataStandardOverride', () => {
         fieldMetadata,
         'label',
         'fr-FR',
+        mockI18n,
       );
 
       expect(result).toBe('Translation Override');
@@ -404,6 +426,7 @@ describe('resolveFieldMetadataStandardOverride', () => {
         fieldMetadata,
         'label',
         SOURCE_LOCALE,
+        mockI18n,
       );
 
       expect(result).toBe('Source Override');
@@ -427,6 +450,7 @@ describe('resolveFieldMetadataStandardOverride', () => {
         fieldMetadata,
         'label',
         'de-DE',
+        mockI18n,
       );
 
       expect(result).toBe('Auto Translated Label');

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/utils/resolve-field-metadata-standard-override.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/utils/resolve-field-metadata-standard-override.util.ts
@@ -1,4 +1,4 @@
-import { i18n } from '@lingui/core';
+import { setupI18n } from '@lingui/core';
 import { isNonEmptyString } from '@sniptt/guards';
 import { APP_LOCALES, SOURCE_LOCALE } from 'twenty-shared/translations';
 import { isDefined } from 'twenty-shared/utils';
@@ -43,6 +43,9 @@ export const resolveFieldMetadataStandardOverride = (
   }
 
   const messageId = generateMessageId(fieldMetadata[labelKey] ?? '');
+  const i18n = setupI18n();
+
+  i18n.activate(locale ?? SOURCE_LOCALE);
   const translatedMessage = i18n._(messageId);
 
   if (translatedMessage === messageId) {

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/utils/resolve-field-metadata-standard-override.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/utils/resolve-field-metadata-standard-override.util.ts
@@ -13,7 +13,7 @@ export const resolveFieldMetadataStandardOverride = (
   >,
   labelKey: 'label' | 'description' | 'icon',
   locale: keyof typeof APP_LOCALES | undefined,
-  i18n: I18n,
+  i18nInstance: I18n,
 ): string => {
   if (fieldMetadata.isCustom) {
     return fieldMetadata[labelKey] ?? '';
@@ -45,7 +45,7 @@ export const resolveFieldMetadataStandardOverride = (
 
   const messageId = generateMessageId(fieldMetadata[labelKey] ?? '');
 
-  const translatedMessage = i18n._(messageId);
+  const translatedMessage = i18nInstance._(messageId);
 
   if (translatedMessage === messageId) {
     return fieldMetadata[labelKey] ?? '';

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/utils/resolve-field-metadata-standard-override.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/utils/resolve-field-metadata-standard-override.util.ts
@@ -1,4 +1,4 @@
-import { setupI18n } from '@lingui/core';
+import { I18n } from '@lingui/core';
 import { isNonEmptyString } from '@sniptt/guards';
 import { APP_LOCALES, SOURCE_LOCALE } from 'twenty-shared/translations';
 import { isDefined } from 'twenty-shared/utils';
@@ -13,6 +13,7 @@ export const resolveFieldMetadataStandardOverride = (
   >,
   labelKey: 'label' | 'description' | 'icon',
   locale: keyof typeof APP_LOCALES | undefined,
+  i18n: I18n,
 ): string => {
   if (fieldMetadata.isCustom) {
     return fieldMetadata[labelKey] ?? '';
@@ -43,9 +44,7 @@ export const resolveFieldMetadataStandardOverride = (
   }
 
   const messageId = generateMessageId(fieldMetadata[labelKey] ?? '');
-  const i18n = setupI18n();
 
-  i18n.activate(locale ?? SOURCE_LOCALE);
   const translatedMessage = i18n._(messageId);
 
   if (translatedMessage === messageId) {


### PR DESCRIPTION
As per title, I believe calling i18n is bad because it's a singleton.

This singleton is being set back and force by users in i18n.middleware.ts

Strategy:
we need to load the translations dynamically! Should be straight forward:
- singleton (i18nService) containing all translationMessages
- singleton also containing a map of i18n instances loaded for each locale => I've checked it's not heavy on RAM at all
- some methods to get the translation for a messageId x locale or the whole i18n instance

==> use it everywhere, this PR only takes care of data model translation