### PR TITLE
Fix missing WHERE clause in migration

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-3/1-3-add-next-step-ids-to-workflow-runs-trigger.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-3/1-3-add-next-step-ids-to-workflow-runs-trigger.command.ts
@@ -64,8 +64,8 @@ export class AddNextStepIdsToWorkflowRunsTrigger extends ActiveOrSuspendedWorksp
         };
 
         await mainDataSource.query(
-          `UPDATE ${schemaName}."workflowRun" SET state = $1::jsonb`,
-          [updatedState],
+          `UPDATE ${schemaName}."workflowRun" SET state = $1::jsonb WHERE id = $2;`,
+          [updatedState, workflowRun.id],
         );
 
         updatedWorkflowRunCount += 1;


### PR DESCRIPTION
As title, this has been run in production and all the workflow runs have been updated with the last workflow run data