### PR TITLE
Disable raw queries without where clause

### DIFF
--- a/packages/twenty-server/src/database/typeorm/typeorm.service.ts
+++ b/packages/twenty-server/src/database/typeorm/typeorm.service.ts
@@ -8,6 +8,7 @@ import {
 import { DataSource } from 'typeorm';
 
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
+import { injectDatasourceGuards } from 'src/database/typeorm/utils/injectDatasourceGuards';
 
 @Injectable()
 export class TypeORMService implements OnModuleInit, OnModuleDestroy {
@@ -36,6 +37,8 @@ export class TypeORMService implements OnModuleInit, OnModuleDestroy {
         query_timeout: 10000,
       },
     });
+
+    injectDatasourceGuards(this.mainDataSource);
   }
 
   public getMainDataSource(): DataSource {

--- a/packages/twenty-server/src/database/typeorm/utils/__tests__/injectDatasourceGuards.spec.ts
+++ b/packages/twenty-server/src/database/typeorm/utils/__tests__/injectDatasourceGuards.spec.ts
@@ -1,0 +1,43 @@
+import { DataSource } from 'typeorm';
+
+import { injectDatasourceGuards } from 'src/database/typeorm/utils/injectDatasourceGuards';
+
+describe('injectDatasourceGuards', () => {
+  let datasource: DataSource;
+
+  beforeEach(() => {
+    datasource = {} as DataSource;
+
+    (datasource as any).query = jest.fn();
+
+    injectDatasourceGuards(datasource);
+  });
+
+  it('should block UPDATE queries without a WHERE clause', async () => {
+    const query = 'UPDATE table SET column = 1';
+
+    await expect(() => datasource.query(query)).rejects.toThrow(
+      'Blocked unsafe query',
+    );
+  });
+
+  it('should not block UPDATE queries with a WHERE clause', async () => {
+    const query = 'UPDATE table SET column = 1 WHERE id = "1"';
+
+    await expect(datasource.query(query)).resolves.not.toThrow();
+  });
+
+  it('should block DELETE queries without a WHERE clause', async () => {
+    const query = 'DELETE table SET column = 1';
+
+    await expect(() => datasource.query(query)).rejects.toThrow(
+      'Blocked unsafe query',
+    );
+  });
+
+  it('should not block DELETE queries with a WHERE clause', async () => {
+    const query = 'DELETE table SET column = 1 WHERE id = "1"';
+
+    await expect(datasource.query(query)).resolves.not.toThrow();
+  });
+});

--- a/packages/twenty-server/src/database/typeorm/utils/injectDatasourceGuards.ts
+++ b/packages/twenty-server/src/database/typeorm/utils/injectDatasourceGuards.ts
@@ -1,0 +1,27 @@
+import { DataSource } from 'typeorm';
+import { QueryRunner } from 'typeorm/query-runner/QueryRunner';
+
+export const injectDatasourceGuards = (dataSource: DataSource) => {
+  const originalQuery = dataSource.query.bind(dataSource);
+
+  dataSource.query = async (
+    query: string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    parameters?: any[],
+    queryRunner?: QueryRunner,
+  ) => {
+    const normalizedQuery = query.trim().toLowerCase().replace(/\s+/g, ' ');
+
+    if (
+      (normalizedQuery.startsWith('update') ||
+        normalizedQuery.startsWith('delete')) &&
+      !normalizedQuery.includes(' where ')
+    ) {
+      throw new Error(
+        `Blocked unsafe query. UPDATE or DELETE without WHERE clause is not allowed: ${query}`,
+      );
+    }
+
+    return originalQuery(query, parameters, queryRunner);
+  };
+};


### PR DESCRIPTION
Follow up from this issue -> https://github.com/twentyhq/twenty/pull/13718

This PR adds a check in the SQL raw queries to make sure UPDATE and DELETE queries have a WHERE clause

<img width="763" height="146" alt="image" src="https://github.com/user-attachments/assets/0194748f-2cce-4828-abce-d05e41b41c7e" />
