### PR TITLE
Expect node `24.5.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -327,7 +327,7 @@
     "vitest": "1.4.0"
   },
   "engines": {
-    "node": "^24.0.0",
+    "node": "^24.5.0",
     "npm": "please-use-yarn",
     "yarn": ">=4.0.2"
   },

--- a/packages/twenty-emails/package.json
+++ b/packages/twenty-emails/package.json
@@ -33,7 +33,7 @@
     }
   },
   "engines": {
-    "node": "^24.0.0",
+    "node": "^24.5.0",
     "npm": "please-use-yarn",
     "yarn": "^4.0.2"
   }

--- a/packages/twenty-front/package.json
+++ b/packages/twenty-front/package.json
@@ -9,7 +9,7 @@
     "tsup": "npx tsup"
   },
   "engines": {
-    "node": "^24.0.0",
+    "node": "^24.5.0",
     "npm": "please-use-yarn",
     "yarn": "^4.0.2"
   },

--- a/packages/twenty-server/package.json
+++ b/packages/twenty-server/package.json
@@ -95,7 +95,7 @@
     "typescript": "5.3.3"
   },
   "engines": {
-    "node": "^24.0.0",
+    "node": "^24.5.0",
     "npm": "please-use-yarn",
     "yarn": "^4.0.2"
   }

--- a/packages/twenty-shared/package.json
+++ b/packages/twenty-shared/package.json
@@ -7,7 +7,7 @@
     "build": "preconstruct build"
   },
   "engines": {
-    "node": "^24.0.0",
+    "node": "^24.5.0",
     "npm": "please-use-yarn",
     "yarn": "^4.0.2"
   },

--- a/packages/twenty-zapier/package.json
+++ b/packages/twenty-zapier/package.json
@@ -4,7 +4,7 @@
   "description": "Effortlessly sync Twenty with 3000+ apps. Automate tasks, boost productivity, and supercharge your customer relationships!",
   "main": "src/index.ts",
   "engines": {
-    "node": "^24.0.0",
+    "node": "^24.5.0",
     "npm": "please-use-yarn",
     "yarn": "^4.0.2"
   },


### PR DESCRIPTION
Unless I'm mistaken the project does not run with node `24.0.0`
Switching to node `24.5.0` ( as defined in vscode node runtime requirements in https://github.com/twentyhq/twenty/pull/13730 ) seems to fix the issue
```ts
Successfully compiled: 2897 files with swc (188.32ms)
(node:77006) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
(Use `node --trace-deprecation ...` to show where the warning was created)
Watching for file changes.

/Users/paulrastoin/ws/twenty/node_modules/buffer-equal-constant-time/index.js:37
var origSlowBufEqual = SlowBuffer.prototype.equal;
                                  ^
TypeError: Cannot read properties of undefined (reading 'prototype')
```

Updating engines so local constraint suggest a functional node version