### PR TITLE
fixed changelog date parsing issue

### DIFF
--- a/packages/twenty-website/src/content/releases/0.10.0.mdx
+++ b/packages/twenty-website/src/content/releases/0.10.0.mdx
@@ -1,6 +1,6 @@
 ---
 release: 0.10.0
-Date: Apr 15th 2024
+Date: 2024-04-15
 ---
 
 # More Field Types, More Power

--- a/packages/twenty-website/src/content/releases/0.11.0.mdx
+++ b/packages/twenty-website/src/content/releases/0.11.0.mdx
@@ -1,6 +1,6 @@
 ---
 release: 0.11.0
-Date: May 6th 2024
+Date: 2024-05-06
 ---
 
 # Google Calendar Integration

--- a/packages/twenty-website/src/content/releases/0.12.0.mdx
+++ b/packages/twenty-website/src/content/releases/0.12.0.mdx
@@ -1,6 +1,6 @@
 ---
 release: 0.12.0
-Date: May 24th 2024
+Date: 2024-05-24
 ---
 
 # Notifications

--- a/packages/twenty-website/src/content/releases/0.2.3.mdx
+++ b/packages/twenty-website/src/content/releases/0.2.3.mdx
@@ -1,6 +1,6 @@
 ---
 release: 0.2.3
-Date: Jan 17th 2024
+Date: 2024-01-17
 ---
 
 # Webhooks

--- a/packages/twenty-website/src/content/releases/0.20.0.mdx
+++ b/packages/twenty-website/src/content/releases/0.20.0.mdx
@@ -1,6 +1,6 @@
 ---
 release: 0.20.0
-Date: June 14th 2024
+Date: 2024-06-14
 ---
 
 # Enhanced Timeline

--- a/packages/twenty-website/src/content/releases/0.21.0.mdx
+++ b/packages/twenty-website/src/content/releases/0.21.0.mdx
@@ -1,6 +1,6 @@
 ---
 release: 0.21.0
-Date: June 28th 2024
+Date: 2024-06-28
 ---
 
 # Enhanced One-to-Many Relations Editing

--- a/packages/twenty-website/src/content/releases/0.22.0.mdx
+++ b/packages/twenty-website/src/content/releases/0.22.0.mdx
@@ -1,6 +1,6 @@
 ---
 release: 0.22.0
-Date: July 11th 2024
+Date: 2024-07-11
 ---
 
 # Enhanced Kanban Board

--- a/packages/twenty-website/src/content/releases/0.23.0.mdx
+++ b/packages/twenty-website/src/content/releases/0.23.0.mdx
@@ -1,6 +1,6 @@
 ---
 release: 0.23.0
-Date: August 1st 2024
+Date: 2024-08-01
 ---
 
 # Notes and Tasks standard objects

--- a/packages/twenty-website/src/content/releases/0.24.0.mdx
+++ b/packages/twenty-website/src/content/releases/0.24.0.mdx
@@ -1,6 +1,6 @@
 ---
 release: 0.24.0
-Date: August 29th 2024
+Date: 2024-08-29
 ---
 
 # Soft Delete

--- a/packages/twenty-website/src/content/releases/0.3.0.mdx
+++ b/packages/twenty-website/src/content/releases/0.3.0.mdx
@@ -1,6 +1,6 @@
 ---
 release: 0.3.0
-Date: Feb 3rd 2024
+Date: 2024-02-03
 ---
 
 # Rating field

--- a/packages/twenty-website/src/content/releases/0.3.1.mdx
+++ b/packages/twenty-website/src/content/releases/0.3.1.mdx
@@ -1,6 +1,6 @@
 ---
 release: 0.3.1
-Date: February 16th 2024
+Date: 2024-02-16
 ---
 
 # Contributors page

--- a/packages/twenty-website/src/content/releases/0.3.2.mdx
+++ b/packages/twenty-website/src/content/releases/0.3.2.mdx
@@ -1,6 +1,6 @@
 ---
 release: 0.3.2
-Date: Feb 29th 2024
+Date: 2024-02-29
 ---
 
 # New record page

--- a/packages/twenty-website/src/content/releases/0.3.3.mdx
+++ b/packages/twenty-website/src/content/releases/0.3.3.mdx
@@ -1,6 +1,6 @@
 ---
 release: 0.3.3
-Date: Mar 19th 2024
+Date: 2024-03-19
 ---
 
 # Gmail integration

--- a/packages/twenty-website/src/content/releases/0.30.0.mdx
+++ b/packages/twenty-website/src/content/releases/0.30.0.mdx
@@ -1,6 +1,6 @@
 ---
 release: 0.30.0
-Date: September 18th 2024
+Date: 2024-09-18
 ---
 
 # New Settings layout

--- a/packages/twenty-website/src/content/releases/0.31.0.mdx
+++ b/packages/twenty-website/src/content/releases/0.31.0.mdx
@@ -1,6 +1,6 @@
 ---
 release: 0.31.0
-Date: October 7th 2024
+Date: 2024-10-07
 ---
 
 # Advanced Settings

--- a/packages/twenty-website/src/content/releases/0.32.0.mdx
+++ b/packages/twenty-website/src/content/releases/0.32.0.mdx
@@ -1,6 +1,6 @@
 ---
 release: 0.32.0
-Date: November 12th 2024
+Date: 2024-11-12
 ---
 
 # Smart ⌘K

--- a/packages/twenty-website/src/content/releases/0.33.0.mdx
+++ b/packages/twenty-website/src/content/releases/0.33.0.mdx
@@ -1,6 +1,6 @@
 ---
 release: 0.33.0
-Date: November 21th 2024
+Date: 2024-11-21
 ---
 
 # Filter by Multi-Select

--- a/packages/twenty-website/src/content/releases/0.34.0.mdx
+++ b/packages/twenty-website/src/content/releases/0.34.0.mdx
@@ -1,6 +1,6 @@
 ---
 release: 0.34.0
-Date: December 12th 2024
+Date: 2024-12-12
 ---
 
 # Customize your sub-domain

--- a/packages/twenty-website/src/content/releases/0.35.0.mdx
+++ b/packages/twenty-website/src/content/releases/0.35.0.mdx
@@ -1,6 +1,6 @@
 ---
 release: 0.35.0
-Date: December 20th 2024
+Date: 2024-12-20
 ---
 
 # Favorites Views and Favorites Folders

--- a/packages/twenty-website/src/content/releases/0.4.0.mdx
+++ b/packages/twenty-website/src/content/releases/0.4.0.mdx
@@ -1,6 +1,6 @@
 ---
 release: 0.4.0
-Date: Apr 1st 2024
+Date: 2024-04-01
 ---
 
 # Relation Fields on Record Page

--- a/packages/twenty-website/src/content/releases/0.40.0.mdx
+++ b/packages/twenty-website/src/content/releases/0.40.0.mdx
@@ -1,6 +1,6 @@
 ---
 release: 0.40.0
-Date: January 17th 2025
+Date: 2025-01-17
 ---
 
 # View Groups

--- a/packages/twenty-website/src/content/releases/0.41.0.mdx
+++ b/packages/twenty-website/src/content/releases/0.41.0.mdx
@@ -1,6 +1,6 @@
 ---
 release: 0.41.0
-Date: February 04th 2025
+Date: 2025-02-04
 ---
 
 # Labs

--- a/packages/twenty-website/src/content/releases/0.42.0.mdx
+++ b/packages/twenty-website/src/content/releases/0.42.0.mdx
@@ -1,6 +1,6 @@
 ---
 release: 0.42.0
-Date: February 18th 2025
+Date: 2025-02-18
 ---
 
 # Microsoft o365 Integration

--- a/packages/twenty-website/src/content/releases/0.43.0.mdx
+++ b/packages/twenty-website/src/content/releases/0.43.0.mdx
@@ -1,6 +1,6 @@
 ---
 release: 0.43.0
-Date: March 4th 2025
+Date: 2025-03-04
 ---
 
 # Upgraded Search

--- a/packages/twenty-website/src/content/releases/0.44.0.mdx
+++ b/packages/twenty-website/src/content/releases/0.44.0.mdx
@@ -1,6 +1,6 @@
 ---
 release: 0.44.0
-Date: March 17th 2025
+Date: 2025-03-17
 ---
 
 # New Side Panel

--- a/packages/twenty-website/src/content/releases/0.50.0.mdx
+++ b/packages/twenty-website/src/content/releases/0.50.0.mdx
@@ -1,6 +1,6 @@
 ---
 release: 0.50.0
-Date: March 27th 2025
+Date: 2025-03-27
 ---
 
 # Permissions V1

--- a/packages/twenty-website/src/content/releases/0.51.0.mdx
+++ b/packages/twenty-website/src/content/releases/0.51.0.mdx
@@ -1,6 +1,6 @@
 ---
 release: 0.51.0
-Date: March 27th 2025
+Date: 2025-03-27
 ---
 
 # Revamp View Options Menu

--- a/packages/twenty-website/src/content/releases/0.52.0.mdx
+++ b/packages/twenty-website/src/content/releases/0.52.0.mdx
@@ -1,6 +1,6 @@
 ---
 release: 0.52.0
-Date: April 25th 2025
+Date: 2025-04-25
 ---
 
 # Add records to filtered views

--- a/packages/twenty-website/src/content/releases/1.00.0.mdx
+++ b/packages/twenty-website/src/content/releases/1.00.0.mdx
@@ -1,6 +1,6 @@
 ---
 release: 1.00.0
-Date: June 25th 2025
+Date: 2025-06-25
 ---
 
 # Permissions V2

--- a/packages/twenty-website/src/content/releases/1.1.0.mdx
+++ b/packages/twenty-website/src/content/releases/1.1.0.mdx
@@ -1,6 +1,6 @@
 ---
 release: 1.1.0
-Date: July 10th 2025
+Date: 2025-07-10
 ---
 
 # Multi-Record Workflow Triggers

--- a/packages/twenty-website/src/content/releases/1.2.0.mdx
+++ b/packages/twenty-website/src/content/releases/1.2.0.mdx
@@ -1,6 +1,6 @@
 ---
 release: 1.2.0
-Date: July 25th 2025
+Date: 2025-07-25
 ---
 
 # Import Relations

--- a/packages/twenty-website/src/shared-utils/formatDisplayDate.ts
+++ b/packages/twenty-website/src/shared-utils/formatDisplayDate.ts
@@ -2,12 +2,11 @@ export const formatGithubPublishedAtDisplayDate = (
   dateString: string,
 ): string => {
   const date = new Date(dateString);
-  const currentYear = new Date().getFullYear();
 
   const formatter = new Intl.DateTimeFormat('en-US', {
     month: 'short',
     day: 'numeric',
-    ...(date.getFullYear() !== currentYear && { year: 'numeric' }),
+    year: 'numeric',
   });
 
   return formatter.format(date);


### PR DESCRIPTION
# Before

<img width="3450" height="2078" alt="CleanShot 2025-08-11 at 11 25 25@2x" src="https://github.com/user-attachments/assets/a6b53846-8012-453a-9ff8-2fd51f2d9efd" />

# After

<img width="3456" height="2076" alt="CleanShot 2025-08-11 at 11 25 37@2x" src="https://github.com/user-attachments/assets/1784ebd7-6040-4ab3-9ca6-26efd5d240a0" />
