### PR TITLE
fix: set `content-type` header for isMethodWithBody

### DIFF
--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/http-request-action/hooks/__tests__/useTestHttpRequest.test.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/http-request-action/hooks/__tests__/useTestHttpRequest.test.ts
@@ -116,7 +116,6 @@ describe('useTestHttpRequest', () => {
       expect.objectContaining({
         method: 'GET',
         headers: expect.objectContaining({
-          'Content-Type': 'application/json',
           Authorization: 'Bearer test-token-123',
         }),
       }),

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/http-request-action/hooks/useHttpRequestForm.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/http-request-action/hooks/useHttpRequestForm.ts
@@ -54,6 +54,16 @@ export const useHttpRequestForm = ({
       newFormData = { ...newFormData, body: undefined };
     }
 
+    if (field === 'method' && isMethodWithBody(value as string)) {
+      newFormData = {
+        ...newFormData,
+        headers: {
+          ...newFormData.headers,
+          'content-type': 'application/json',
+        },
+      };
+    }
+
     setFormData(newFormData);
     saveAction(newFormData);
   };

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/http-request-action/hooks/useTestHttpRequest.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/http-request-action/hooks/useTestHttpRequest.ts
@@ -58,10 +58,7 @@ export const useTestHttpRequest = (actionId: string) => {
 
       const requestOptions: RequestInit = {
         method: httpRequestFormData.method,
-        headers: {
-          'Content-Type': 'application/json',
-          ...(substitutedHeaders as Record<string, string>),
-        },
+        headers: substitutedHeaders as Record<string, string>,
       };
 
       if (['POST', 'PUT', 'PATCH'].includes(httpRequestFormData.method)) {


### PR DESCRIPTION
Fixes Workflow HTTP Request not setting `content-type` header for JSON body it was defaulting to `application/x-www-form-urlencoded` causing parsing issues

<img width="1496" height="847" alt="image" src="https://github.com/user-attachments/assets/c4bd6ac3-0f4a-47eb-b108-fae95338c019" />

/closes #13781