### PR TITLE
Rename permissions and fix add rule button

### DIFF
--- a/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/components/SettingsRolePermissionsObjectLevelSection.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/components/SettingsRolePermissionsObjectLevelSection.tsx
@@ -103,7 +103,7 @@ export const SettingsRolePermissionsObjectLevelSection = ({
       <StyledCreateObjectOverrideSection>
         <Button
           Icon={IconPlus}
-          title={t`Add object rule`}
+          title={t`Add rule`}
           variant="secondary"
           size="small"
           disabled={!isEditable || allObjectsHaveSetPermission}

--- a/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/components/SettingsRolePermissionsObjectLevelTableHeader.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/components/SettingsRolePermissionsObjectLevelTableHeader.tsx
@@ -23,7 +23,7 @@ export const SettingsRolePermissionsObjectLevelTableHeader = ({
     }
   >
     <TableHeader>{t`Object-Level`}</TableHeader>
-    <TableHeader>{showPermissionsLabel ? t`Permissions` : ''}</TableHeader>
+    <TableHeader>{showPermissionsLabel ? t`Records` : ''}</TableHeader>
     {isFieldsPermissionsEnabled && (
       <>
         <TableHeader>{showPermissionsLabel ? t`See Fields` : ''}</TableHeader>


### PR DESCRIPTION
Closes #13868

- `Permissions` has been renamed to `Records`
- `Add object rule` has been shortened to `Add rule`

Attaching screenshot for reference
<img width="730" height="491" alt="image" src="https://github.com/user-attachments/assets/09141334-07ad-4916-9f3b-c9a537f52def" />

