### PR TITLE
Remove X icon for fields that cannot be removed

### DIFF
--- a/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/object-form/components/OverridableCheckbox.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/object-form/components/OverridableCheckbox.tsx
@@ -59,10 +59,12 @@ export const OverridableCheckbox = ({
               onClick={disabled ? undefined : onChange}
               isDisabled={disabled}
             >
-              <IconX
-                size={theme.icon.size.md}
-                color={theme.font.color.secondary}
-              />
+              {!disabled && (
+                <IconX
+                  size={theme.icon.size.md}
+                  color={theme.font.color.secondary}
+                />
+              )}
             </StyledIconWrapper>
           </StyledOverridableCheckboxContainerItem>
         </>


### PR DESCRIPTION
Closes #13867
The `IconX` now only renders when `disabled` is `false`. This means, that the IconX only appears when the field can actually be removed.

Attaching screenshot for reference
<img width="622" height="606" alt="image" src="https://github.com/user-attachments/assets/7b8895c3-4ed1-4de9-98dc-585ee33e2960" />
