### PR TITLE
Permission table fixes

### DIFF
--- a/packages/twenty-front/src/modules/settings/data-model/object-details/components/SettingsObjectFieldItemTableRow.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/object-details/components/SettingsObjectFieldItemTableRow.tsx
@@ -38,8 +38,11 @@ type SettingsObjectFieldItemTableRowProps = {
   mode: 'view' | 'new-field';
 };
 
-export const StyledObjectFieldTableRow = styled(TableRow)`
-  grid-auto-columns: 180px 148px 148px 36px;
+export const StyledObjectFieldTableRow = styled(TableRow)<{
+  $gridColumns?: string;
+}>`
+  grid-auto-columns: ${({ $gridColumns }) =>
+    $gridColumns || '180px 148px 148px 36px'};
 `;
 
 const StyledNameTableCell = styled(TableCell)`

--- a/packages/twenty-front/src/modules/settings/data-model/object-details/components/SettingsObjectFieldItemTableRow.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/object-details/components/SettingsObjectFieldItemTableRow.tsx
@@ -38,11 +38,8 @@ type SettingsObjectFieldItemTableRowProps = {
   mode: 'view' | 'new-field';
 };
 
-export const StyledObjectFieldTableRow = styled(TableRow)<{
-  $gridColumns?: string;
-}>`
-  grid-auto-columns: ${({ $gridColumns }) =>
-    $gridColumns || '180px 148px 148px 36px'};
+export const StyledObjectFieldTableRow = styled(TableRow)`
+  grid-auto-columns: 180px 148px 148px 36px;
 `;
 
 const StyledNameTableCell = styled(TableCell)`

--- a/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/field-permissions/components/SettingsRolePermissionsObjectLevelObjectFieldPermissionTable.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/field-permissions/components/SettingsRolePermissionsObjectLevelObjectFieldPermissionTable.tsx
@@ -1,6 +1,5 @@
 import { type ObjectMetadataItem } from '@/object-metadata/types/ObjectMetadataItem';
 import { filterUserFacingFieldMetadataItems } from '@/object-metadata/utils/filterUserFacingFieldMetadataItems';
-import { StyledObjectFieldTableRow } from '@/settings/data-model/object-details/components/SettingsObjectFieldItemTableRow';
 import { SettingsRolePermissionsObjectLevelObjectFieldPermissionTableAllHeaderRow } from '@/settings/roles/role-permissions/object-level-permissions/field-permissions/components/SettingsRolePermissionsObjectLevelObjectFieldPermissionTableAllHeaderRow';
 import { SettingsRolePermissionsObjectLevelObjectFieldPermissionTableRow } from '@/settings/roles/role-permissions/object-level-permissions/field-permissions/components/SettingsRolePermissionsObjectLevelObjectFieldPermissionTableRow';
 import { FIELD_LEVEL_PERMISSION_TABLE_GRID_TEMPLATE_COLUMNS } from '@/settings/roles/role-permissions/object-level-permissions/field-permissions/constants/FieldLevelPermissionTableGridTemplateColumns';
@@ -12,6 +11,7 @@ import { SortableTableHeader } from '@/ui/layout/table/components/SortableTableH
 import { Table } from '@/ui/layout/table/components/Table';
 import { TableHeader } from '@/ui/layout/table/components/TableHeader';
 import { TableHeaderText } from '@/ui/layout/table/components/TableHeaderText';
+import { TableRow } from '@/ui/layout/table/components/TableRow';
 import { sortedFieldByTableFamilyState } from '@/ui/layout/table/states/sortedFieldByTableFamilyState';
 import styled from '@emotion/styled';
 import { useLingui } from '@lingui/react/macro';
@@ -29,6 +29,10 @@ export const SETTINGS_ROLE_PERMISSION_OBJECT_LEVEL_FIELD_PERMISSION_TABLE_ID =
 const StyledSearchInput = styled(SettingsTextInput)`
   padding-bottom: ${({ theme }) => theme.spacing(2)};
   width: 100%;
+`;
+
+const StyledObjectFieldTableRow = styled(TableRow)`
+  grid-auto-columns: ${FIELD_LEVEL_PERMISSION_TABLE_GRID_TEMPLATE_COLUMNS};
 `;
 
 export type SettingsRolePermissionsObjectLevelObjectFieldPermissionTableProps =
@@ -97,9 +101,7 @@ export const SettingsRolePermissionsObjectLevelObjectFieldPermissionTable = ({
         onChange={setSearchTerm}
       />
       <Table>
-        <StyledObjectFieldTableRow
-          $gridColumns={FIELD_LEVEL_PERMISSION_TABLE_GRID_TEMPLATE_COLUMNS}
-        >
+        <StyledObjectFieldTableRow>
           <SortableTableHeader
             fieldName={'label'}
             label={t`Name`}

--- a/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/field-permissions/components/SettingsRolePermissionsObjectLevelObjectFieldPermissionTable.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/field-permissions/components/SettingsRolePermissionsObjectLevelObjectFieldPermissionTable.tsx
@@ -3,6 +3,7 @@ import { filterUserFacingFieldMetadataItems } from '@/object-metadata/utils/filt
 import { StyledObjectFieldTableRow } from '@/settings/data-model/object-details/components/SettingsObjectFieldItemTableRow';
 import { SettingsRolePermissionsObjectLevelObjectFieldPermissionTableAllHeaderRow } from '@/settings/roles/role-permissions/object-level-permissions/field-permissions/components/SettingsRolePermissionsObjectLevelObjectFieldPermissionTableAllHeaderRow';
 import { SettingsRolePermissionsObjectLevelObjectFieldPermissionTableRow } from '@/settings/roles/role-permissions/object-level-permissions/field-permissions/components/SettingsRolePermissionsObjectLevelObjectFieldPermissionTableRow';
+import { FIELD_LEVEL_PERMISSION_TABLE_GRID_TEMPLATE_COLUMNS } from '@/settings/roles/role-permissions/object-level-permissions/field-permissions/constants/FieldLevelPermissionTableGridTemplateColumns';
 import { useObjectPermissionDerivedStates } from '@/settings/roles/role-permissions/object-level-permissions/field-permissions/hooks/useObjectPermissionDerivedStates';
 import { settingsDraftRoleFamilyState } from '@/settings/roles/states/settingsDraftRoleFamilyState';
 import { type OrderBy } from '@/types/OrderBy';
@@ -12,7 +13,6 @@ import { Table } from '@/ui/layout/table/components/Table';
 import { TableHeader } from '@/ui/layout/table/components/TableHeader';
 import { TableHeaderText } from '@/ui/layout/table/components/TableHeaderText';
 import { sortedFieldByTableFamilyState } from '@/ui/layout/table/states/sortedFieldByTableFamilyState';
-import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useLingui } from '@lingui/react/macro';
 import { useState } from 'react';
@@ -41,7 +41,6 @@ export const SettingsRolePermissionsObjectLevelObjectFieldPermissionTable = ({
   objectMetadataItem,
   roleId,
 }: SettingsRolePermissionsObjectLevelObjectFieldPermissionTableProps) => {
-  const theme = useTheme();
   const { t } = useLingui();
   const [searchTerm, setSearchTerm] = useState('');
 
@@ -98,7 +97,9 @@ export const SettingsRolePermissionsObjectLevelObjectFieldPermissionTable = ({
         onChange={setSearchTerm}
       />
       <Table>
-        <StyledObjectFieldTableRow>
+        <StyledObjectFieldTableRow
+          $gridColumns={FIELD_LEVEL_PERMISSION_TABLE_GRID_TEMPLATE_COLUMNS}
+        >
           <SortableTableHeader
             fieldName={'label'}
             label={t`Name`}
@@ -113,7 +114,7 @@ export const SettingsRolePermissionsObjectLevelObjectFieldPermissionTable = ({
           {cannotAllowFieldReadRestrict ? (
             <TableHeader></TableHeader>
           ) : (
-            <TableHeader align="center">
+            <TableHeader>
               <TableHeaderText>{t`See`}</TableHeaderText>
             </TableHeader>
           )}

--- a/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/field-permissions/components/SettingsRolePermissionsObjectLevelObjectFieldPermissionTable.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/field-permissions/components/SettingsRolePermissionsObjectLevelObjectFieldPermissionTable.tsx
@@ -17,7 +17,7 @@ import styled from '@emotion/styled';
 import { useLingui } from '@lingui/react/macro';
 import { useState } from 'react';
 import { useRecoilValue } from 'recoil';
-import { H2Title, IconEye, IconPencil, IconSearch } from 'twenty-ui/display';
+import { H2Title, IconPencil, IconSearch } from 'twenty-ui/display';
 import { Section } from 'twenty-ui/layout';
 import { sortByProperty } from '~/utils/array/sortByProperty';
 import { isNonEmptyArray } from '~/utils/isNonEmptyArray';
@@ -115,10 +115,6 @@ export const SettingsRolePermissionsObjectLevelObjectFieldPermissionTable = ({
           ) : (
             <TableHeader align="center">
               <TableHeaderText>{t`See`}</TableHeaderText>
-              <IconEye
-                size={theme.icon.size.sm}
-                stroke={theme.icon.stroke.md}
-              />
             </TableHeader>
           )}
           {cannotAllowFieldUpdateRestrict ? (

--- a/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/field-permissions/components/SettingsRolePermissionsObjectLevelObjectFieldPermissionTable.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/field-permissions/components/SettingsRolePermissionsObjectLevelObjectFieldPermissionTable.tsx
@@ -17,7 +17,7 @@ import styled from '@emotion/styled';
 import { useLingui } from '@lingui/react/macro';
 import { useState } from 'react';
 import { useRecoilValue } from 'recoil';
-import { H2Title, IconPencil, IconSearch } from 'twenty-ui/display';
+import { H2Title, IconSearch } from 'twenty-ui/display';
 import { Section } from 'twenty-ui/layout';
 import { sortByProperty } from '~/utils/array/sortByProperty';
 import { isNonEmptyArray } from '~/utils/isNonEmptyArray';
@@ -122,10 +122,6 @@ export const SettingsRolePermissionsObjectLevelObjectFieldPermissionTable = ({
           ) : (
             <TableHeader>
               <TableHeaderText>{t`Edit`}</TableHeaderText>
-              <IconPencil
-                size={theme.icon.size.sm}
-                stroke={theme.icon.stroke.md}
-              />
             </TableHeader>
           )}
         </StyledObjectFieldTableRow>


### PR DESCRIPTION
Closes #13865 
`IconEye` has been removed as specified in the issue. There was also a `PencilIcon` for the `Edit` section, which has been removed. The alignment issue was caused due to the `See` label being aligned to `center`, which has now been removed. An optional parameter `gridColumns` has been added to `StyledObjectFieldTableRow`. 

Adding a screenshot for reference:
<img width="1153" height="498" alt="image" src="https://github.com/user-attachments/assets/12357084-f8d2-45d4-9b58-651488609c07" />
