### PR TITLE
Animate reload icon

### DIFF
--- a/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/object-form/components/OverridableCheckbox.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/object-form/components/OverridableCheckbox.tsx
@@ -1,4 +1,4 @@
-import { useTheme } from '@emotion/react';
+import { keyframes, useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { IconReload, IconX } from 'twenty-ui/display';
 import { Checkbox } from 'twenty-ui/input';
@@ -10,6 +10,17 @@ const StyledOverridableCheckboxContainer = styled.div`
   display: inline-flex;
   justify-content: flex-start;
   width: 48px;
+`;
+
+const spin = keyframes`
+  from { transform: rotate(0deg); }
+  to { transform: rotate(90deg); }
+`;
+
+const StyledIconReload = styled(IconReload)`
+  &:hover {
+    animation: ${spin} 250ms linear forwards;
+  }
 `;
 
 const StyledOverridableCheckboxContainerItem = styled.div`
@@ -79,7 +90,7 @@ export const OverridableCheckbox = ({
               onClick={disabled ? undefined : onChange}
               isDisabled={disabled}
             >
-              <IconReload
+              <StyledIconReload
                 size={theme.icon.size.md}
                 color={theme.adaptiveColors.orange4}
               />


### PR DESCRIPTION
Closes #13864

Added a `0deg` to `90deg` transform for `IconReload` with a `250ms` duration.

Adding a loom recording:
[Recording](https://www.loom.com/share/15f6dc961c4d49c3b9b770630e54a17f?sid=611abc6c-a4e4-410e-8a58-d0f1da2004dc) 