### PR TITLE
Fix table aligment issue

### DIFF
--- a/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/field-permissions/components/SettingsRolePermissionsObjectLevelObjectFieldPermissionTable.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/field-permissions/components/SettingsRolePermissionsObjectLevelObjectFieldPermissionTable.tsx
@@ -87,6 +87,27 @@ export const SettingsRolePermissionsObjectLevelObjectFieldPermissionTable = ({
       objectMetadataItemId: objectMetadataItem.id,
     });
 
+  const readCellHeader = (
+    <TableHeader>
+      <TableHeaderText>{t`See`}</TableHeaderText>
+    </TableHeader>
+  );
+
+  const updateCellHeader = (
+    <TableHeader>
+      <TableHeaderText>{t`Edit`}</TableHeaderText>
+    </TableHeader>
+  );
+
+  const emptyCellHeader = <TableHeader key="empty-cell"></TableHeader>;
+
+  let headerCells: React.ReactNode[] = [];
+
+  if (cannotAllowFieldReadRestrict) headerCells.push(emptyCellHeader);
+  else if (cannotAllowFieldUpdateRestrict)
+    headerCells.push(emptyCellHeader, readCellHeader);
+  else headerCells.push(readCellHeader, updateCellHeader);
+
   return (
     <Section>
       <H2Title
@@ -113,20 +134,7 @@ export const SettingsRolePermissionsObjectLevelObjectFieldPermissionTable = ({
           <TableHeader>
             <TableHeaderText>{t`Data type`}</TableHeaderText>
           </TableHeader>
-          {cannotAllowFieldReadRestrict ? (
-            <TableHeader></TableHeader>
-          ) : (
-            <TableHeader>
-              <TableHeaderText>{t`See`}</TableHeaderText>
-            </TableHeader>
-          )}
-          {cannotAllowFieldUpdateRestrict ? (
-            <TableHeader></TableHeader>
-          ) : (
-            <TableHeader>
-              <TableHeaderText>{t`Edit`}</TableHeaderText>
-            </TableHeader>
-          )}
+          <>{headerCells}</>
         </StyledObjectFieldTableRow>
         <SettingsRolePermissionsObjectLevelObjectFieldPermissionTableAllHeaderRow
           roleId={roleId}

--- a/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/field-permissions/components/SettingsRolePermissionsObjectLevelObjectFieldPermissionTable.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/field-permissions/components/SettingsRolePermissionsObjectLevelObjectFieldPermissionTable.tsx
@@ -101,7 +101,7 @@ export const SettingsRolePermissionsObjectLevelObjectFieldPermissionTable = ({
 
   const emptyCellHeader = <TableHeader key="empty-cell"></TableHeader>;
 
-  let headerCells: React.ReactNode[] = [];
+  const headerCells: React.ReactNode[] = [];
 
   if (cannotAllowFieldReadRestrict) headerCells.push(emptyCellHeader);
   else if (cannotAllowFieldUpdateRestrict)

--- a/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/field-permissions/components/SettingsRolePermissionsObjectLevelObjectFieldPermissionTable.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/field-permissions/components/SettingsRolePermissionsObjectLevelObjectFieldPermissionTable.tsx
@@ -87,26 +87,11 @@ export const SettingsRolePermissionsObjectLevelObjectFieldPermissionTable = ({
       objectMetadataItemId: objectMetadataItem.id,
     });
 
-  const readCellHeader = (
-    <TableHeader>
-      <TableHeaderText>{t`See`}</TableHeaderText>
-    </TableHeader>
-  );
-
-  const updateCellHeader = (
-    <TableHeader>
-      <TableHeaderText>{t`Edit`}</TableHeaderText>
-    </TableHeader>
-  );
-
-  const emptyCellHeader = <TableHeader key="empty-cell"></TableHeader>;
-
-  const headerCells: React.ReactNode[] = [];
-
-  if (cannotAllowFieldReadRestrict) headerCells.push(emptyCellHeader);
-  else if (cannotAllowFieldUpdateRestrict)
-    headerCells.push(emptyCellHeader, readCellHeader);
-  else headerCells.push(readCellHeader, updateCellHeader);
+  const shouldShowSeeTableHeader = !cannotAllowFieldReadRestrict;
+  const shouldShowUpdateTableHeader =
+    !cannotAllowFieldReadRestrict && !cannotAllowFieldUpdateRestrict;
+  const shouldShowEmptyTableHeader =
+    cannotAllowFieldReadRestrict && cannotAllowFieldUpdateRestrict;
 
   return (
     <Section>
@@ -134,7 +119,19 @@ export const SettingsRolePermissionsObjectLevelObjectFieldPermissionTable = ({
           <TableHeader>
             <TableHeaderText>{t`Data type`}</TableHeaderText>
           </TableHeader>
-          <>{headerCells}</>
+          <>
+            {shouldShowEmptyTableHeader && <TableHeader />}
+            {shouldShowSeeTableHeader && (
+              <TableHeader>
+                <TableHeaderText>{t`See`}</TableHeaderText>
+              </TableHeader>
+            )}
+            {shouldShowUpdateTableHeader && (
+              <TableHeader>
+                <TableHeaderText>{t`Edit`}</TableHeaderText>
+              </TableHeader>
+            )}
+          </>
         </StyledObjectFieldTableRow>
         <SettingsRolePermissionsObjectLevelObjectFieldPermissionTableAllHeaderRow
           roleId={roleId}

--- a/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/field-permissions/components/SettingsRolePermissionsObjectLevelObjectFieldPermissionTableAllHeaderRow.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/field-permissions/components/SettingsRolePermissionsObjectLevelObjectFieldPermissionTableAllHeaderRow.tsx
@@ -116,7 +116,7 @@ export const SettingsRolePermissionsObjectLevelObjectFieldPermissionTableAllHead
 
     const emptyCell = <div key="empty-cell"></div>;
 
-    let readAndUpdateCellHeaders: React.ReactNode[] = [];
+    const readAndUpdateCellHeaders: React.ReactNode[] = [];
 
     if (cannotAllowFieldReadRestrict) readAndUpdateCellHeaders.push(emptyCell);
     else if (cannotAllowFieldUpdateRestrict)

--- a/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/field-permissions/components/SettingsRolePermissionsObjectLevelObjectFieldPermissionTableAllHeaderRow.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/field-permissions/components/SettingsRolePermissionsObjectLevelObjectFieldPermissionTableAllHeaderRow.tsx
@@ -92,35 +92,43 @@ export const SettingsRolePermissionsObjectLevelObjectFieldPermissionTableAllHead
       }
     };
 
+    const readCell = (
+      <StyledCheckboxContainer>
+        <OverridableCheckbox
+          disabled={false}
+          checked={true}
+          onChange={handleReadAllChange}
+          type={hasAnyRestrictionOnRead ? 'override' : 'default'}
+        />
+      </StyledCheckboxContainer>
+    );
+
+    const updateCell = (
+      <StyledCheckboxContainer>
+        <OverridableCheckbox
+          disabled={false}
+          checked={true}
+          onChange={handleUpdateAllChange}
+          type={hasAnyRestrictionOnUpdate ? 'override' : 'default'}
+        />
+      </StyledCheckboxContainer>
+    );
+
+    const emptyCell = <div key="empty-cell"></div>;
+
+    let readAndUpdateCellHeaders: React.ReactNode[] = [];
+
+    if (cannotAllowFieldReadRestrict) readAndUpdateCellHeaders.push(emptyCell);
+    else if (cannotAllowFieldUpdateRestrict)
+      readAndUpdateCellHeaders.push(emptyCell, readCell);
+    else readAndUpdateCellHeaders.push(readCell, updateCell);
+
     return (
       <>
         <StyledSectionHeader>
           <Label>{t`All`}</Label>
           <div></div>
-          {cannotAllowFieldReadRestrict ? (
-            <div></div>
-          ) : (
-            <StyledCheckboxContainer>
-              <OverridableCheckbox
-                disabled={false}
-                checked={true}
-                onChange={handleReadAllChange}
-                type={hasAnyRestrictionOnRead ? 'override' : 'default'}
-              />
-            </StyledCheckboxContainer>
-          )}
-          {cannotAllowFieldUpdateRestrict ? (
-            <div></div>
-          ) : (
-            <StyledCheckboxContainer>
-              <OverridableCheckbox
-                disabled={false}
-                checked={true}
-                onChange={handleUpdateAllChange}
-                type={hasAnyRestrictionOnUpdate ? 'override' : 'default'}
-              />
-            </StyledCheckboxContainer>
-          )}
+          <>{readAndUpdateCellHeaders}</>
         </StyledSectionHeader>
       </>
     );

--- a/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/field-permissions/components/SettingsRolePermissionsObjectLevelObjectFieldPermissionTableAllHeaderRow.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/field-permissions/components/SettingsRolePermissionsObjectLevelObjectFieldPermissionTableAllHeaderRow.tsx
@@ -92,43 +92,39 @@ export const SettingsRolePermissionsObjectLevelObjectFieldPermissionTableAllHead
       }
     };
 
-    const readCell = (
-      <StyledCheckboxContainer>
-        <OverridableCheckbox
-          disabled={false}
-          checked={true}
-          onChange={handleReadAllChange}
-          type={hasAnyRestrictionOnRead ? 'override' : 'default'}
-        />
-      </StyledCheckboxContainer>
-    );
-
-    const updateCell = (
-      <StyledCheckboxContainer>
-        <OverridableCheckbox
-          disabled={false}
-          checked={true}
-          onChange={handleUpdateAllChange}
-          type={hasAnyRestrictionOnUpdate ? 'override' : 'default'}
-        />
-      </StyledCheckboxContainer>
-    );
-
-    const emptyCell = <div key="empty-cell"></div>;
-
-    const readAndUpdateCellHeaders: React.ReactNode[] = [];
-
-    if (cannotAllowFieldReadRestrict) readAndUpdateCellHeaders.push(emptyCell);
-    else if (cannotAllowFieldUpdateRestrict)
-      readAndUpdateCellHeaders.push(emptyCell, readCell);
-    else readAndUpdateCellHeaders.push(readCell, updateCell);
+    const shouldShowSeeTableHeader = !cannotAllowFieldReadRestrict;
+    const shouldShowUpdateTableHeader =
+      !cannotAllowFieldReadRestrict && !cannotAllowFieldUpdateRestrict;
+    const shouldShowEmptyTableHeader = cannotAllowFieldUpdateRestrict;
 
     return (
       <>
         <StyledSectionHeader>
           <Label>{t`All`}</Label>
           <div></div>
-          <>{readAndUpdateCellHeaders}</>
+          <>
+            {shouldShowEmptyTableHeader && <div />}
+            {shouldShowSeeTableHeader && (
+              <StyledCheckboxContainer>
+                <OverridableCheckbox
+                  disabled={false}
+                  checked={true}
+                  onChange={handleReadAllChange}
+                  type={hasAnyRestrictionOnRead ? 'override' : 'default'}
+                />
+              </StyledCheckboxContainer>
+            )}
+            {shouldShowUpdateTableHeader && (
+              <StyledCheckboxContainer>
+                <OverridableCheckbox
+                  disabled={false}
+                  checked={true}
+                  onChange={handleUpdateAllChange}
+                  type={hasAnyRestrictionOnUpdate ? 'override' : 'default'}
+                />
+              </StyledCheckboxContainer>
+            )}
+          </>
         </StyledSectionHeader>
       </>
     );

--- a/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/field-permissions/components/SettingsRolePermissionsObjectLevelObjectFieldPermissionTableRow.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/field-permissions/components/SettingsRolePermissionsObjectLevelObjectFieldPermissionTableRow.tsx
@@ -142,6 +142,37 @@ export const SettingsRolePermissionsObjectLevelObjectFieldPermissionTableRow =
         objectMetadataItemId: objectMetadataItem.id,
       });
 
+    const readCell = (
+      <TableCell>
+        <OverridableCheckbox
+          disabled={fieldMetadataItem.isUIReadOnly ?? false}
+          checked={true}
+          onChange={handleSeeChange}
+          type={isReadRestricted ? 'override' : 'default'}
+        />
+      </TableCell>
+    );
+
+    const updateCell = (
+      <TableCell align="left">
+        <OverridableCheckbox
+          disabled={fieldMetadataItem.isUIReadOnly ?? false}
+          checked={true}
+          onChange={handleUpdateChange}
+          type={isUpdateRestricted ? 'override' : 'default'}
+        />
+      </TableCell>
+    );
+
+    const emptyCell = <TableCell key="empty-cell" />;
+
+    let readAndUpdateCells: React.ReactNode[] = [];
+
+    if (objectReadIsRestricted) readAndUpdateCells.push(emptyCell);
+    else if (objectUpdateIsRestricted)
+      readAndUpdateCells.push(emptyCell, readCell);
+    else readAndUpdateCells.push(readCell, updateCell);
+
     return (
       <StyledObjectFieldTableRow>
         <StyledNameTableCell>
@@ -172,30 +203,7 @@ export const SettingsRolePermissionsObjectLevelObjectFieldPermissionTableRow =
             value={fieldType as SettingsFieldType}
           />
         </TableCell>
-        {objectReadIsRestricted ? (
-          <TableCell />
-        ) : (
-          <TableCell>
-            <OverridableCheckbox
-              disabled={fieldMetadataItem.isUIReadOnly ?? false}
-              checked={true}
-              onChange={handleSeeChange}
-              type={isReadRestricted ? 'override' : 'default'}
-            />
-          </TableCell>
-        )}
-        {objectUpdateIsRestricted ? (
-          <TableCell />
-        ) : (
-          <TableCell align="left">
-            <OverridableCheckbox
-              disabled={fieldMetadataItem.isUIReadOnly ?? false}
-              checked={true}
-              onChange={handleUpdateChange}
-              type={isUpdateRestricted ? 'override' : 'default'}
-            />
-          </TableCell>
-        )}
+        <>{readAndUpdateCells}</>
       </StyledObjectFieldTableRow>
     );
   };

--- a/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/field-permissions/components/SettingsRolePermissionsObjectLevelObjectFieldPermissionTableRow.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/field-permissions/components/SettingsRolePermissionsObjectLevelObjectFieldPermissionTableRow.tsx
@@ -136,42 +136,16 @@ export const SettingsRolePermissionsObjectLevelObjectFieldPermissionTableRow =
       hasRestriction &&
       fieldPermissionForThisFieldMetadataItem?.canUpdateFieldValue === false;
 
-    const { objectReadIsRestricted, objectUpdateIsRestricted } =
+    const { cannotAllowFieldReadRestrict, cannotAllowFieldUpdateRestrict } =
       useObjectPermissionDerivedStates({
         roleId,
         objectMetadataItemId: objectMetadataItem.id,
       });
 
-    const readCell = (
-      <TableCell>
-        <OverridableCheckbox
-          disabled={fieldMetadataItem.isUIReadOnly ?? false}
-          checked={true}
-          onChange={handleSeeChange}
-          type={isReadRestricted ? 'override' : 'default'}
-        />
-      </TableCell>
-    );
-
-    const updateCell = (
-      <TableCell align="left">
-        <OverridableCheckbox
-          disabled={fieldMetadataItem.isUIReadOnly ?? false}
-          checked={true}
-          onChange={handleUpdateChange}
-          type={isUpdateRestricted ? 'override' : 'default'}
-        />
-      </TableCell>
-    );
-
-    const emptyCell = <TableCell key="empty-cell" />;
-
-    const readAndUpdateCells: React.ReactNode[] = [];
-
-    if (objectReadIsRestricted) readAndUpdateCells.push(emptyCell);
-    else if (objectUpdateIsRestricted)
-      readAndUpdateCells.push(emptyCell, readCell);
-    else readAndUpdateCells.push(readCell, updateCell);
+    const shouldShowSeeTableHeader = !cannotAllowFieldReadRestrict;
+    const shouldShowUpdateTableHeader =
+      !cannotAllowFieldReadRestrict && !cannotAllowFieldUpdateRestrict;
+    const shouldShowEmptyTableHeader = cannotAllowFieldUpdateRestrict;
 
     return (
       <StyledObjectFieldTableRow>
@@ -203,7 +177,29 @@ export const SettingsRolePermissionsObjectLevelObjectFieldPermissionTableRow =
             value={fieldType as SettingsFieldType}
           />
         </TableCell>
-        <>{readAndUpdateCells}</>
+        <>
+          {shouldShowEmptyTableHeader && <TableCell />}
+          {shouldShowSeeTableHeader && (
+            <TableCell>
+              <OverridableCheckbox
+                disabled={fieldMetadataItem.isUIReadOnly ?? false}
+                checked={true}
+                onChange={handleSeeChange}
+                type={isReadRestricted ? 'override' : 'default'}
+              />
+            </TableCell>
+          )}
+          {shouldShowUpdateTableHeader && (
+            <TableCell align="left">
+              <OverridableCheckbox
+                disabled={fieldMetadataItem.isUIReadOnly ?? false}
+                checked={true}
+                onChange={handleUpdateChange}
+                type={isUpdateRestricted ? 'override' : 'default'}
+              />
+            </TableCell>
+          )}
+        </>
       </StyledObjectFieldTableRow>
     );
   };

--- a/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/field-permissions/components/SettingsRolePermissionsObjectLevelObjectFieldPermissionTableRow.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/field-permissions/components/SettingsRolePermissionsObjectLevelObjectFieldPermissionTableRow.tsx
@@ -166,7 +166,7 @@ export const SettingsRolePermissionsObjectLevelObjectFieldPermissionTableRow =
 
     const emptyCell = <TableCell key="empty-cell" />;
 
-    let readAndUpdateCells: React.ReactNode[] = [];
+    const readAndUpdateCells: React.ReactNode[] = [];
 
     if (objectReadIsRestricted) readAndUpdateCells.push(emptyCell);
     else if (objectUpdateIsRestricted)

--- a/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/object-form/components/SettingsRolePermissionsObjectLevelObjectFormObjectLevelTableRow.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/object-form/components/SettingsRolePermissionsObjectLevelObjectFormObjectLevelTableRow.tsx
@@ -50,7 +50,7 @@ const StyledCheckboxCell = styled(TableCell)`
   align-items: center;
   display: flex;
   justify-content: flex-end;
-  padding-right: ${({ theme }) => theme.spacing(2)};
+  padding-right: ${({ theme }) => theme.spacing(1)};
 `;
 
 type OverridableCheckboxType = 'no_cta' | 'default' | 'override';

--- a/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/object-form/components/SettingsRolePermissionsObjectLevelObjectFormObjectLevelTableRow.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/object-form/components/SettingsRolePermissionsObjectLevelObjectFormObjectLevelTableRow.tsx
@@ -50,7 +50,7 @@ const StyledCheckboxCell = styled(TableCell)`
   align-items: center;
   display: flex;
   justify-content: flex-end;
-  padding-right: ${({ theme }) => theme.spacing(4)};
+  padding-right: ${({ theme }) => theme.spacing(2)};
 `;
 
 type OverridableCheckboxType = 'no_cta' | 'default' | 'override';


### PR DESCRIPTION
Closes #13862 

The `padding-right` for `StyledCheckboxCell` was previously set to `16px`, causing it to be pushed in. It has now been reduced to `8px`.
The read column in the table appeared as the third column regardless of whether update was restricted or not. Now, the read column appears as the last column if update is restricted, otherwise, read appears before update column.

Attaching a recording for verification:
[Loom Recording](https://www.loom.com/share/ebd07db6c4d04900aa18f3a1ba71e770?sid=75b33043-dc80-4e2d-82ae-f183efa6faa2)
