### PR TITLE
Perform renaming fixes and implement full access card

### DIFF
--- a/packages/twenty-front/src/modules/settings/roles/role-permissions/objects-permissions/components/SettingsRolePermissionsObjectsSection.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/role-permissions/objects-permissions/components/SettingsRolePermissionsObjectsSection.tsx
@@ -1,4 +1,3 @@
-import { SettingsOptionCardContentToggle } from '@/settings/components/SettingsOptions/SettingsOptionCardContentToggle';
 import { SettingsRolePermissionsObjectsTableHeader } from '@/settings/roles/role-permissions/objects-permissions/components/SettingsRolePermissionsObjectsTableHeader';
 import { SettingsRolePermissionsObjectsTableRow } from '@/settings/roles/role-permissions/objects-permissions/components/SettingsRolePermissionsObjectsTableRow';
 import { type SettingsRolePermissionsObjectPermission } from '@/settings/roles/role-permissions/objects-permissions/types/SettingsRolePermissionsObjectPermission';
@@ -6,8 +5,8 @@ import { settingsDraftRoleFamilyState } from '@/settings/roles/states/settingsDr
 import styled from '@emotion/styled';
 import { t } from '@lingui/core/macro';
 import { useRecoilState } from 'recoil';
-import { H2Title, IconDatabase } from 'twenty-ui/display';
-import { AnimatedExpandableContainer, Card, Section } from 'twenty-ui/layout';
+import { H2Title } from 'twenty-ui/display';
+import { Section } from 'twenty-ui/layout';
 
 const StyledTable = styled.div`
   border-bottom: 1px solid ${({ theme }) => theme.border.color.light};
@@ -16,10 +15,6 @@ const StyledTable = styled.div`
 const StyledTableRows = styled.div`
   padding-bottom: ${({ theme }) => theme.spacing(2)};
   padding-top: ${({ theme }) => theme.spacing(2)};
-`;
-
-const StyledCard = styled(Card)`
-  margin-bottom: ${({ theme }) => theme.spacing(4)};
 `;
 
 type SettingsRolePermissionsObjectsSectionProps = {
@@ -160,49 +155,22 @@ export const SettingsRolePermissionsObjectsSection = ({
         title={t`Objects`}
         description={t`Objects and fields permissions settings`}
       />
-      <StyledCard rounded>
-        <SettingsOptionCardContentToggle
-          Icon={IconDatabase}
-          title={t`Data full access`}
-          description={t`See, edit, delete and destroy all records`}
-          checked={settingsDraftRole.canUpdateAllObjectRecords}
-          disabled={!isEditable}
-          onChange={() => {
-            setSettingsDraftRole({
-              ...settingsDraftRole,
-              canUpdateAllObjectRecords:
-                !settingsDraftRole.canUpdateAllObjectRecords,
-            });
-          }}
+      <StyledTable>
+        <SettingsRolePermissionsObjectsTableHeader
+          roleId={roleId}
+          objectPermissionsConfig={objectPermissionsConfig}
+          isEditable={isEditable}
         />
-      </StyledCard>
-      <AnimatedExpandableContainer
-        isExpanded={!settingsDraftRole.canUpdateAllObjectRecords}
-        dimension="height"
-        animationDurations={{
-          opacity: 0.2,
-          size: 0.4,
-        }}
-        mode="scroll-height"
-        containAnimation={false}
-      >
-        <StyledTable>
-          <SettingsRolePermissionsObjectsTableHeader
-            roleId={roleId}
-            objectPermissionsConfig={objectPermissionsConfig}
-            isEditable={isEditable}
-          />
-          <StyledTableRows>
-            {objectPermissionsConfig.map((permission) => (
-              <SettingsRolePermissionsObjectsTableRow
-                key={permission.key}
-                permission={permission}
-                isEditable={isEditable}
-              />
-            ))}
-          </StyledTableRows>
-        </StyledTable>
-      </AnimatedExpandableContainer>
+        <StyledTableRows>
+          {objectPermissionsConfig.map((permission) => (
+            <SettingsRolePermissionsObjectsTableRow
+              key={permission.key}
+              permission={permission}
+              isEditable={isEditable}
+            />
+          ))}
+        </StyledTableRows>
+      </StyledTable>
     </Section>
   );
 };

--- a/packages/twenty-front/src/modules/settings/roles/role-permissions/objects-permissions/components/SettingsRolePermissionsObjectsSection.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/role-permissions/objects-permissions/components/SettingsRolePermissionsObjectsSection.tsx
@@ -1,3 +1,4 @@
+import { SettingsOptionCardContentToggle } from '@/settings/components/SettingsOptions/SettingsOptionCardContentToggle';
 import { SettingsRolePermissionsObjectsTableHeader } from '@/settings/roles/role-permissions/objects-permissions/components/SettingsRolePermissionsObjectsTableHeader';
 import { SettingsRolePermissionsObjectsTableRow } from '@/settings/roles/role-permissions/objects-permissions/components/SettingsRolePermissionsObjectsTableRow';
 import { type SettingsRolePermissionsObjectPermission } from '@/settings/roles/role-permissions/objects-permissions/types/SettingsRolePermissionsObjectPermission';
@@ -5,8 +6,8 @@ import { settingsDraftRoleFamilyState } from '@/settings/roles/states/settingsDr
 import styled from '@emotion/styled';
 import { t } from '@lingui/core/macro';
 import { useRecoilState } from 'recoil';
-import { H2Title } from 'twenty-ui/display';
-import { Section } from 'twenty-ui/layout';
+import { H2Title, IconDatabase } from 'twenty-ui/display';
+import { AnimatedExpandableContainer, Card, Section } from 'twenty-ui/layout';
 
 const StyledTable = styled.div`
   border-bottom: 1px solid ${({ theme }) => theme.border.color.light};
@@ -15,6 +16,10 @@ const StyledTable = styled.div`
 const StyledTableRows = styled.div`
   padding-bottom: ${({ theme }) => theme.spacing(2)};
   padding-top: ${({ theme }) => theme.spacing(2)};
+`;
+
+const StyledCard = styled(Card)`
+  margin-bottom: ${({ theme }) => theme.spacing(4)};
 `;
 
 type SettingsRolePermissionsObjectsSectionProps = {
@@ -152,25 +157,52 @@ export const SettingsRolePermissionsObjectsSection = ({
   return (
     <Section>
       <H2Title
-        title={t`All objects`}
-        description={t`Actions users can perform on all objects`}
+        title={t`Objects`}
+        description={t`Objects and fields permissions settings`}
       />
-      <StyledTable>
-        <SettingsRolePermissionsObjectsTableHeader
-          roleId={roleId}
-          objectPermissionsConfig={objectPermissionsConfig}
-          isEditable={isEditable}
+      <StyledCard rounded>
+        <SettingsOptionCardContentToggle
+          Icon={IconDatabase}
+          title={t`Data full access`}
+          description={t`See, edit, delete and destroy all records`}
+          checked={settingsDraftRole.canUpdateAllObjectRecords}
+          disabled={!isEditable}
+          onChange={() => {
+            setSettingsDraftRole({
+              ...settingsDraftRole,
+              canUpdateAllObjectRecords:
+                !settingsDraftRole.canUpdateAllObjectRecords,
+            });
+          }}
         />
-        <StyledTableRows>
-          {objectPermissionsConfig.map((permission) => (
-            <SettingsRolePermissionsObjectsTableRow
-              key={permission.key}
-              permission={permission}
-              isEditable={isEditable}
-            />
-          ))}
-        </StyledTableRows>
-      </StyledTable>
+      </StyledCard>
+      <AnimatedExpandableContainer
+        isExpanded={!settingsDraftRole.canUpdateAllObjectRecords}
+        dimension="height"
+        animationDurations={{
+          opacity: 0.2,
+          size: 0.4,
+        }}
+        mode="scroll-height"
+        containAnimation={false}
+      >
+        <StyledTable>
+          <SettingsRolePermissionsObjectsTableHeader
+            roleId={roleId}
+            objectPermissionsConfig={objectPermissionsConfig}
+            isEditable={isEditable}
+          />
+          <StyledTableRows>
+            {objectPermissionsConfig.map((permission) => (
+              <SettingsRolePermissionsObjectsTableRow
+                key={permission.key}
+                permission={permission}
+                isEditable={isEditable}
+              />
+            ))}
+          </StyledTableRows>
+        </StyledTable>
+      </AnimatedExpandableContainer>
     </Section>
   );
 };

--- a/packages/twenty-front/src/modules/settings/roles/role-permissions/objects-permissions/components/SettingsRolePermissionsObjectsTableHeader.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/role-permissions/objects-permissions/components/SettingsRolePermissionsObjectsTableHeader.tsx
@@ -43,7 +43,7 @@ export const SettingsRolePermissionsObjectsTableHeader = ({
 
   return (
     <TableRow>
-      <StyledNameHeader>{t`Name`}</StyledNameHeader>
+      <StyledNameHeader>{t`All Objects`}</StyledNameHeader>
       <StyledActionsHeader aria-label={t`Actions`}>
         <Checkbox
           checked={allPermissionsEnabled}


### PR DESCRIPTION
Closes #13861

`All Objects` has been renamed to `Objects` and `Name` has been replaced with `All Objects`. There was no specification of whether the `Data full access` card had to be implemented or not. Do let me know if that needs to be removed or something needs to be changed in its configuration.

Attaching a loom recording of the changes:
[Loom Recording](https://www.loom.com/share/42b54e9386b14619bc1118e95eb62293?sid=10ac8e8a-475b-4870-bd36-64742cd8c3c5)