### PR TITLE
fix: suggestion menu item font color

### DIFF
--- a/packages/twenty-ui/src/navigation/menu-item/components/MenuItemSuggestion.tsx
+++ b/packages/twenty-ui/src/navigation/menu-item/components/MenuItemSuggestion.tsx
@@ -40,6 +40,7 @@ const StyledSuggestionMenuItem = styled.li<{
 
   background: ${({ selected, theme }) =>
     selected ? theme.background.transparent.medium : ''};
+  color: ${({ theme }) => theme.font.color.secondary};
 
   ${HOVER_BACKGROUND};
 


### PR DESCRIPTION
# Before
<img width="241" height="246" alt="image" src="https://github.com/user-attachments/assets/91f8ae1c-8d26-4b0a-b87b-0b26ba3676ac" />

# After
<img width="239" height="231" alt="image" src="https://github.com/user-attachments/assets/e3da0dd2-c0d7-4180-83c1-a000a26189eb" />
