### PR TITLE
Fix not available workflow version id in runs

### DIFF
--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowRunVisualizerEffect.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowRunVisualizerEffect.tsx
@@ -9,6 +9,7 @@ import { useWorkflowVersion } from '@/workflow/hooks/useWorkflowVersion';
 import { flowComponentState } from '@/workflow/states/flowComponentState';
 import { workflowVisualizerWorkflowIdComponentState } from '@/workflow/states/workflowVisualizerWorkflowIdComponentState';
 import { workflowVisualizerWorkflowRunIdComponentState } from '@/workflow/states/workflowVisualizerWorkflowRunIdComponentState';
+import { workflowVisualizerWorkflowVersionIdComponentState } from '@/workflow/states/workflowVisualizerWorkflowVersionIdComponentState';
 import { type WorkflowRunState } from '@/workflow/types/Workflow';
 import { workflowDiagramComponentState } from '@/workflow/workflow-diagram/states/workflowDiagramComponentState';
 import { workflowDiagramStatusComponentState } from '@/workflow/workflow-diagram/states/workflowDiagramStatusComponentState';
@@ -32,11 +33,16 @@ export const WorkflowRunVisualizerEffect = ({
   const { getIcon } = useIcons();
 
   const workflowRun = useWorkflowRun({ workflowRunId });
-  const workflowVersion = useWorkflowVersion(workflowRun?.workflowVersionId);
-
   const setWorkflowRunId = useSetRecoilComponentState(
     workflowVisualizerWorkflowRunIdComponentState,
   );
+
+  const workflowVersionId = workflowRun?.workflowVersionId;
+  const workflowVersion = useWorkflowVersion(workflowVersionId);
+  const setWorkflowVisualizerWorkflowVersionId = useSetRecoilComponentState(
+    workflowVisualizerWorkflowVersionIdComponentState,
+  );
+
   const workflowVisualizerWorkflowIdState = useRecoilComponentCallbackState(
     workflowVisualizerWorkflowIdComponentState,
   );
@@ -83,6 +89,14 @@ export const WorkflowRunVisualizerEffect = ({
 
     setWorkflowVisualizerWorkflowId(workflowRun.workflowId);
   }, [setWorkflowVisualizerWorkflowId, workflowRun]);
+
+  useEffect(() => {
+    if (!isDefined(workflowVersionId)) {
+      return;
+    }
+
+    setWorkflowVisualizerWorkflowVersionId(workflowVersionId);
+  }, [setWorkflowVisualizerWorkflowVersionId, workflowVersionId]);
 
   const handleWorkflowRunDiagramGeneration = useRecoilCallback(
     ({ snapshot, set }) =>


### PR DESCRIPTION
Quick fix : make workflow version available in runs.
This would global refactor. We should not have both version and run flow here.
I will probably stop using the same component in both at some point and rather duplicate. Versions and Workflow will use version. Runs will use flow.