### PR TITLE
Put back transparent background for code editor

### DIFF
--- a/packages/twenty-ui/src/input/code-editor/theme/utils/getBaseCodeEditorTheme.ts
+++ b/packages/twenty-ui/src/input/code-editor/theme/utils/getBaseCodeEditorTheme.ts
@@ -27,8 +27,7 @@ export const getBaseCodeEditorTheme = ({
       },
     ],
     colors: {
-      // eslint-disable-next-line @nx/workspace-no-hardcoded-colors
-      'editor.background': '#000000',
+      'editor.background': '#00000000',
       'editorCursor.foreground': theme.font.color.primary,
       'editorLineNumber.foreground': theme.font.color.extraLight,
       'editorLineNumber.activeForeground': theme.font.color.light,


### PR DESCRIPTION
It was black since this PR https://github.com/twentyhq/twenty/commit/464a480043f3d6d1c4a95ecd39489f83e0611e60

<img width="500" height="655" alt="Capture d’écran 2025-08-18 à 18 36 47" src="https://github.com/user-attachments/assets/dfb5cf01-ae0c-4048-8c3e-74022775f5b2" />
