### PR TITLE
fix: scroll to selected element without animation when dropdown opens

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/selectable-list/components/SelectableListItem.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/selectable-list/components/SelectableListItem.tsx
@@ -35,8 +35,8 @@ export const SelectableListItem = ({
   useEffect(() => {
     if (isSelectedItemId) {
       listItemRef.current?.scrollIntoView({
-        behavior: 'smooth',
-        block: 'center',
+        behavior: 'auto',
+        block: 'start',
       });
     }
   }, [isSelectedItemId]);


### PR DESCRIPTION
Fixes #13957 

### Changes made

- updated `scrollIntoView` options to `behavior: auto` and `block: start` in the `SelectableListItem.tsx` component.

### New behaviour

https://github.com/user-attachments/assets/7e71e132-f6e3-4451-8ee0-fa59ae9edd67



