### PR TITLE
Fix default relation standard field deletion

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/services/flat-field-metadata-validator.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/services/flat-field-metadata-validator.service.ts
@@ -226,8 +226,8 @@ export class FlatFieldMetadataValidatorService {
       );
 
     if (
-      isRelationFieldAndRelationTargetObjectMetadataExists &&
-      isStandardMetadata(flatFieldMetadataToDelete)
+      isStandardMetadata(flatFieldMetadataToDelete) &&
+      !isRelationFieldAndRelationTargetObjectMetadataExists
     ) {
       errors.push(
         new FieldMetadataException(
@@ -238,8 +238,8 @@ export class FlatFieldMetadataValidatorService {
     }
 
     if (
-      isRelationFieldAndRelationTargetObjectMetadataExists &&
-      flatFieldMetadataToDelete.isActive
+      flatFieldMetadataToDelete.isActive &&
+      !isRelationFieldAndRelationTargetObjectMetadataExists
     ) {
       errors.push(
         new FieldMetadataException(

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/services/flat-field-metadata-validator.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/services/flat-field-metadata-validator.service.ts
@@ -29,6 +29,7 @@ import {
   InvalidMetadataException,
   InvalidMetadataExceptionCode,
 } from 'src/engine/metadata-modules/utils/exceptions/invalid-metadata.exception';
+import { isStandardMetadata } from 'src/engine/metadata-modules/utils/is-standard-metadata.util';
 
 export type ValidateOneFieldMetadataArgs<
   T extends FieldMetadataType = FieldMetadataType,
@@ -216,17 +217,17 @@ export class FlatFieldMetadataValidatorService {
       }
     }
 
-    const isRelationAndTargetObjectMetadataNotFound =
+    const isRelationFieldAndRelationTargetObjectMetadataExists =
       isRelationFlatFieldMetadata(flatFieldMetadataToDelete) &&
-      !isDefined(
+      isDefined(
         existingFlatObjectMetadataMaps.byId[
           flatFieldMetadataToDelete.relationTargetObjectMetadataId
         ],
       );
 
     if (
-      !isRelationAndTargetObjectMetadataNotFound &&
-      !flatFieldMetadataToDelete.isCustom
+      isRelationFieldAndRelationTargetObjectMetadataExists &&
+      isStandardMetadata(flatFieldMetadataToDelete)
     ) {
       errors.push(
         new FieldMetadataException(
@@ -237,7 +238,7 @@ export class FlatFieldMetadataValidatorService {
     }
 
     if (
-      !isRelationAndTargetObjectMetadataNotFound &&
+      isRelationFieldAndRelationTargetObjectMetadataExists &&
       flatFieldMetadataToDelete.isActive
     ) {
       errors.push(

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/services/flat-field-metadata-validator.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/services/flat-field-metadata-validator.service.ts
@@ -16,6 +16,7 @@ import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-m
 import { compareTwoFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/compare-two-flat-field-metadata.util';
 import { isFlatFieldMetadataNameSyncedWithLabel } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-flat-field-metadata-name-synced-with-label.util';
 import { isFlatFieldMetadataEntityOfType } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-flat-field-metadata-of-type.util';
+import { isRelationFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-relation-flat-field-metadata.util';
 import { validateFlatFieldMetadataNameAvailability } from 'src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-flat-field-metadata-name-availability.util';
 import { validateFlatFieldMetadataName } from 'src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-flat-field-metadata-name.util';
 import { type FlatObjectMetadataMaps } from 'src/engine/metadata-modules/flat-object-metadata-maps/types/flat-object-metadata-maps.type';
@@ -215,7 +216,18 @@ export class FlatFieldMetadataValidatorService {
       }
     }
 
-    if (!flatFieldMetadataToDelete.isCustom) {
+    const isRelationAndTargetObjectMetadataNotFound =
+      isRelationFlatFieldMetadata(flatFieldMetadataToDelete) &&
+      !isDefined(
+        existingFlatObjectMetadataMaps.byId[
+          flatFieldMetadataToDelete.relationTargetObjectMetadataId
+        ],
+      );
+
+    if (
+      !isRelationAndTargetObjectMetadataNotFound &&
+      !flatFieldMetadataToDelete.isCustom
+    ) {
       errors.push(
         new FieldMetadataException(
           "Standard Fields can't be deleted",
@@ -224,7 +236,10 @@ export class FlatFieldMetadataValidatorService {
       );
     }
 
-    if (flatFieldMetadataToDelete.isActive) {
+    if (
+      !isRelationAndTargetObjectMetadataNotFound &&
+      flatFieldMetadataToDelete.isActive
+    ) {
       errors.push(
         new FieldMetadataException(
           "Active fields can't be deleted",

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/services/flat-field-metadata-validator.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/services/flat-field-metadata-validator.service.ts
@@ -217,9 +217,9 @@ export class FlatFieldMetadataValidatorService {
       }
     }
 
-    const isRelationFieldAndRelationTargetObjectMetadataExists =
+    const isRelationFieldAndRelationTargetObjectMetadataHasBeenDeleted =
       isRelationFlatFieldMetadata(flatFieldMetadataToDelete) &&
-      isDefined(
+      !isDefined(
         existingFlatObjectMetadataMaps.byId[
           flatFieldMetadataToDelete.relationTargetObjectMetadataId
         ],
@@ -227,7 +227,7 @@ export class FlatFieldMetadataValidatorService {
 
     if (
       isStandardMetadata(flatFieldMetadataToDelete) &&
-      !isRelationFieldAndRelationTargetObjectMetadataExists
+      !isRelationFieldAndRelationTargetObjectMetadataHasBeenDeleted
     ) {
       errors.push(
         new FieldMetadataException(
@@ -239,7 +239,7 @@ export class FlatFieldMetadataValidatorService {
 
     if (
       flatFieldMetadataToDelete.isActive &&
-      !isRelationFieldAndRelationTargetObjectMetadataExists
+      !isRelationFieldAndRelationTargetObjectMetadataHasBeenDeleted
     ) {
       errors.push(
         new FieldMetadataException(

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/get-default-flat-field-metadata-from-create-field-input.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/get-default-flat-field-metadata-from-create-field-input.util.ts
@@ -1,6 +1,7 @@
 import { extractAndSanitizeObjectStringFields } from 'twenty-shared/utils';
 
 import { type CreateFieldInput } from 'src/engine/metadata-modules/field-metadata/dtos/create-field.input';
+import { generateDefaultValue } from 'src/engine/metadata-modules/field-metadata/utils/generate-default-value';
 import { generateNullable } from 'src/engine/metadata-modules/field-metadata/utils/generate-nullable';
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
 
@@ -48,7 +49,7 @@ export const getDefaultFlatFieldMetadata = ({
     flatRelationTargetFieldMetadata: null,
     flatRelationTargetObjectMetadata: null,
     options: null,
-    defaultValue: defaultValue ?? null,
+    defaultValue: defaultValue ?? generateDefaultValue(createFieldInput.type),
     settings: settings ?? null,
     createdAt,
     updatedAt: createdAt,

--- a/packages/twenty-server/src/engine/metadata-modules/flat-object-metadata/services/flat-object-metadata-validator.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-object-metadata/services/flat-object-metadata-validator.service.ts
@@ -1,12 +1,11 @@
 import { Injectable } from '@nestjs/common';
 
 import { t } from '@lingui/core/macro';
-import { FieldMetadataType } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 
 import { FlatFieldMetadataValidatorService } from 'src/engine/metadata-modules/flat-field-metadata/services/flat-field-metadata-validator.service';
 import { FailedFlatFieldMetadataValidationExceptions } from 'src/engine/metadata-modules/flat-field-metadata/types/failed-flat-field-metadata-validation.type';
-import { isFlatFieldMetadataEntityOfType } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-flat-field-metadata-of-type.util';
+import { isRelationFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-relation-flat-field-metadata.util';
 import { type FlatObjectMetadataMaps } from 'src/engine/metadata-modules/flat-object-metadata-maps/types/flat-object-metadata-maps.type';
 import { addFlatFieldMetadataInFlatObjectMetadataMapsOrThrow } from 'src/engine/metadata-modules/flat-object-metadata-maps/utils/add-flat-field-metadata-in-flat-object-metadata-maps-or-throw.util';
 import { addFlatObjectMetadataToFlatObjectMetadataMapsOrThrow } from 'src/engine/metadata-modules/flat-object-metadata-maps/utils/add-flat-object-metadata-to-flat-object-metadata-maps-or-throw.util';
@@ -178,14 +177,7 @@ export class FlatObjectMetadataValidatorService {
 
     for (const flatFieldMetadataToValidate of flatObjectMetadataToValidate.flatFieldMetadatas) {
       const relationTargetFlatObjectMetadataMaps =
-        (isFlatFieldMetadataEntityOfType(
-          flatFieldMetadataToValidate,
-          FieldMetadataType.RELATION,
-        ) ||
-          isFlatFieldMetadataEntityOfType(
-            flatFieldMetadataToValidate,
-            FieldMetadataType.MORPH_RELATION,
-          )) &&
+        isRelationFlatFieldMetadata(flatFieldMetadataToValidate) &&
         isDefined(otherFlatObjectMetadataMapsToValidate)
           ? computeRelationTargetFlatObjectMetadataMaps({
               flatFieldMetadata: flatFieldMetadataToValidate,

--- a/packages/twenty-server/src/engine/metadata-modules/flat-object-metadata/utils/compute-relation-target-flat-object-metadata-maps.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-object-metadata/utils/compute-relation-target-flat-object-metadata-maps.util.ts
@@ -1,6 +1,6 @@
-import { type FieldMetadataType } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 
+import { type RelationFieldMetadataType } from 'src/engine/metadata-modules/field-metadata/types/relation-field-metadata-type.type';
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
 import { findRelationFlatFieldMetadataTargetFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/find-relation-flat-field-metadatas-target-flat-field-metadata.util';
 import { type FlatObjectMetadataMaps } from 'src/engine/metadata-modules/flat-object-metadata-maps/types/flat-object-metadata-maps.type';
@@ -10,9 +10,7 @@ export const computeRelationTargetFlatObjectMetadataMaps = ({
   flatFieldMetadata,
   flatObjectMetadataMaps,
 }: {
-  flatFieldMetadata: FlatFieldMetadata<
-    FieldMetadataType.RELATION | FieldMetadataType.MORPH_RELATION
-  >;
+  flatFieldMetadata: FlatFieldMetadata<RelationFieldMetadataType>;
   flatObjectMetadataMaps: FlatObjectMetadataMaps;
 }): FlatObjectMetadataMaps | undefined => {
   const relationTargetFlatFieldMetadata =

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-builder-v2/services/workspace-migration-builder-v2.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-builder-v2/services/workspace-migration-builder-v2.service.ts
@@ -94,7 +94,8 @@ export class WorkspaceMigrationBuilderV2Service {
       await this.workspaceMigrationV2FieldActionsBuilderService.validateAndBuildFieldActions(
         {
           buildOptions,
-          fromFlatObjectMetadataMaps,
+          fromFlatObjectMetadataMaps:
+            objectActionsValidateAndBuildResult.optimisticFlatObjectMetadataMaps,
           toFlatObjectMetadataMaps,
           objectMetadataDeletedCreatedUpdatedFields,
         },

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-builder-v2/services/workspace-migration-v2-field-actions-builder.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-builder-v2/services/workspace-migration-v2-field-actions-builder.service.ts
@@ -85,7 +85,8 @@ export class WorkspaceMigrationV2FieldActionsBuilderService {
       const validationErrors =
         await this.flatFieldMetadataValidatorService.validateFlatFieldMetadataUpdate(
           {
-            existingFlatObjectMetadataMaps: fromFlatObjectMetadataMaps,
+            existingFlatObjectMetadataMaps:
+              validateAndBuildResult.optimisticFlatObjectMetadataMaps,
             flatFieldMetadataToValidate: toFlatFieldMetadata,
             workspaceId,
             otherFlatObjectMetadataMapsToValidate: undefined,


### PR DESCRIPTION
Authorize relation standard field deletion if targetObjectMetadata is not present in existingFlatObjectMetadataMaps