### PR TITLE
Filters: Fix readonly on record picker + select label

### DIFF
--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/filter-action/components/WorkflowStepFilterFieldSelect.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/filter-action/components/WorkflowStepFilterFieldSelect.tsx
@@ -56,8 +56,10 @@ export const WorkflowStepFilterFieldSelect = ({
 
   const { getIcon } = useIcons();
 
-  const { fieldMetadataItem: filterFieldMetadataItem } =
-    useFieldMetadataItemById(stepFilter.fieldMetadataId ?? '');
+  const {
+    fieldMetadataItem: filterFieldMetadataItem,
+    objectMetadataItem: filterObjectMetadataItem,
+  } = useFieldMetadataItemById(stepFilter.fieldMetadataId ?? '');
 
   const { getFieldMetadataItemByIdOrThrow } =
     useGetFieldMetadataItemByIdOrThrow();
@@ -141,17 +143,26 @@ export const WorkflowStepFilterFieldSelect = ({
     return null;
   }
 
+  const isFullRecord =
+    filterFieldMetadataItem?.name === 'id' &&
+    isDefined(filterObjectMetadataItem?.labelSingular);
+
   const { variableLabel } = searchVariableThroughOutputSchema({
     stepOutputSchema: stepsOutputSchema?.[0],
     rawVariableName: stepFilter.stepOutputKey,
-    isFullRecord: false,
+    isFullRecord,
   });
 
   const isSelectedFieldNotFound = !isDefined(variableLabel);
-  const label =
-    isSelectedFieldNotFound || !isDefined(stepFilter.displayValue)
-      ? t`Select a field from a previous step`
-      : variableLabel;
+  const label = isSelectedFieldNotFound
+    ? t`Select a field from a previous step`
+    : variableLabel;
+
+  const icon = isFullRecord
+    ? getIcon(filterObjectMetadataItem?.icon)
+    : filterFieldMetadataItem?.icon
+      ? getIcon(filterFieldMetadataItem.icon)
+      : undefined;
 
   const dropdownId = `step-filter-field-${stepFilter.id}`;
 
@@ -182,9 +193,7 @@ export const WorkflowStepFilterFieldSelect = ({
             selectedOption={{
               value: stepFilter.stepOutputKey,
               label,
-              Icon: filterFieldMetadataItem?.icon
-                ? getIcon(filterFieldMetadataItem.icon)
-                : undefined,
+              Icon: icon,
             }}
             isDisabled={true}
           />
@@ -202,11 +211,9 @@ export const WorkflowStepFilterFieldSelect = ({
         clickableComponent={
           <SelectControl
             selectedOption={{
+              label,
               value: stepFilter.stepOutputKey,
-              label: label,
-              Icon: filterFieldMetadataItem?.icon
-                ? getIcon(filterFieldMetadataItem.icon)
-                : undefined,
+              Icon: icon,
             }}
             textAccent={isSelectedFieldNotFound ? 'placeholder' : 'default'}
           />

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/filter-action/components/WorkflowStepFilterValueInput.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/filter-action/components/WorkflowStepFilterValueInput.tsx
@@ -116,6 +116,7 @@ export const WorkflowStepFilterValueInput = ({
         onChange={handleValueChange}
         VariablePicker={WorkflowVariablePicker}
         objectNameSingular={objectMetadataItem.nameSingular}
+        disabled={readonly}
       />
     );
   }


### PR DESCRIPTION
As a filter V1, we do not distinguish between selecting Id and full record. We always should display the record

Before - Id and readonly not working

<img width="492" height="256" alt="Capture d’écran 2025-08-21 à 15 10 56" src="https://github.com/user-attachments/assets/5152b43f-bbda-436b-97fe-d8e391b47832" />

After - Object name and readonly working

<img width="492" height="256" alt="Capture d’écran 2025-08-21 à 15 10 15" src="https://github.com/user-attachments/assets/e35eeb1e-135c-4213-8b59-55a5d10da82b" />
