### PR TITLE
fix: resolve N+1 query issue in view name resolver with DataLoaders

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/view/resolvers/view.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/view/resolvers/view.resolver.ts
@@ -13,6 +13,7 @@ import { isDefined } from 'twenty-shared/utils';
 
 import { I18nService } from 'src/engine/core-modules/i18n/i18n.service';
 import { type I18nContext } from 'src/engine/core-modules/i18n/types/i18n-context.type';
+import { type IDataloaders } from 'src/engine/dataloaders/dataloader.interface';
 import { generateMessageId } from 'src/engine/core-modules/i18n/utils/generateMessageId';
 import { CreateViewInput } from 'src/engine/core-modules/view/dtos/inputs/create-view.input';
 import { UpdateViewInput } from 'src/engine/core-modules/view/dtos/inputs/update-view.input';
@@ -51,14 +52,14 @@ export class ViewResolver {
   @ResolveField(() => String)
   async name(
     @Parent() view: ViewDTO,
-    @Context() context: I18nContext,
+    @Context() context: { loaders: IDataloaders } & I18nContext,
     @AuthWorkspace() workspace: Workspace,
   ): Promise<string> {
     if (view.name.includes('{objectLabelPlural}')) {
-      const objectMetadata = await this.viewService.getObjectMetadataByViewId(
-        view.id,
-        workspace.id,
-      );
+      const objectMetadata = await context.loaders.objectMetadataLoader.load({
+        objectMetadataId: view.objectMetadataId,
+        workspaceId: workspace.id,
+      });
 
       if (objectMetadata) {
         const translatedObjectLabel = resolveObjectMetadataStandardOverride(

--- a/packages/twenty-server/src/engine/core-modules/view/services/view.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/view/services/view.service.ts
@@ -5,8 +5,6 @@ import { isDefined } from 'twenty-shared/utils';
 import { IsNull, Repository } from 'typeorm';
 
 import { View } from 'src/engine/core-modules/view/entities/view.entity';
-import { type ObjectMetadataItemWithFieldMaps } from 'src/engine/metadata-modules/types/object-metadata-item-with-field-maps';
-import { WorkspaceMetadataCacheService } from 'src/engine/metadata-modules/workspace-metadata-cache/services/workspace-metadata-cache.service';
 import {
   ViewException,
   ViewExceptionCode,
@@ -20,7 +18,6 @@ export class ViewService {
   constructor(
     @InjectRepository(View, 'core')
     private readonly viewRepository: Repository<View>,
-    private readonly workspaceMetadataCacheService: WorkspaceMetadataCacheService,
   ) {}
 
   async findByWorkspaceId(workspaceId: string): Promise<View[]> {
@@ -179,26 +176,5 @@ export class ViewService {
     await this.viewRepository.delete(id);
 
     return true;
-  }
-
-  async getObjectMetadataByViewId(
-    viewId: string,
-    workspaceId: string,
-  ): Promise<ObjectMetadataItemWithFieldMaps | null> {
-    const view = await this.viewRepository.findOne({
-      where: { id: viewId },
-      select: ['objectMetadataId'],
-    });
-
-    if (!view) {
-      return null;
-    }
-
-    const { objectMetadataMaps } =
-      await this.workspaceMetadataCacheService.getExistingOrRecomputeMetadataMaps(
-        { workspaceId },
-      );
-
-    return objectMetadataMaps.byId[view.objectMetadataId] || null;
   }
 }

--- a/packages/twenty-server/src/engine/dataloaders/dataloader.interface.ts
+++ b/packages/twenty-server/src/engine/dataloaders/dataloader.interface.ts
@@ -5,6 +5,7 @@ import {
   type IndexFieldMetadataLoaderPayload,
   type IndexMetadataLoaderPayload,
   type MorphRelationLoaderPayload,
+  type ObjectMetadataLoaderPayload,
   type RelationLoaderPayload,
 } from 'src/engine/dataloaders/dataloader.service';
 import { type FieldMetadataDTO } from 'src/engine/metadata-modules/field-metadata/dtos/field-metadata.dto';
@@ -12,6 +13,7 @@ import { type FieldMetadataEntity } from 'src/engine/metadata-modules/field-meta
 import { type IndexFieldMetadataDTO } from 'src/engine/metadata-modules/index-metadata/dtos/index-field-metadata.dto';
 import { type IndexMetadataDTO } from 'src/engine/metadata-modules/index-metadata/dtos/index-metadata.dto';
 import { type ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
+import { type ObjectMetadataItemWithFieldMaps } from 'src/engine/metadata-modules/types/object-metadata-item-with-field-maps';
 
 export interface IDataloaders {
   relationLoader: DataLoader<
@@ -47,5 +49,10 @@ export interface IDataloaders {
   indexFieldMetadataLoader: DataLoader<
     IndexFieldMetadataLoaderPayload,
     IndexFieldMetadataDTO[]
+  >;
+
+  objectMetadataLoader: DataLoader<
+    ObjectMetadataLoaderPayload,
+    ObjectMetadataItemWithFieldMaps | null
   >;
 }

--- a/packages/twenty-server/src/engine/dataloaders/dataloader.service.ts
+++ b/packages/twenty-server/src/engine/dataloaders/dataloader.service.ts
@@ -8,6 +8,7 @@ import { type IndexMetadataInterface } from 'src/engine/metadata-modules/index-m
 
 import { I18nService } from 'src/engine/core-modules/i18n/i18n.service';
 import { type IDataloaders } from 'src/engine/dataloaders/dataloader.interface';
+import { type ObjectMetadataItemWithFieldMaps } from 'src/engine/metadata-modules/types/object-metadata-item-with-field-maps';
 import { filterMorphRelationDuplicateFieldsDTO } from 'src/engine/dataloaders/utils/filter-morph-relation-duplicate-fields.util';
 import { type FieldMetadataDTO } from 'src/engine/metadata-modules/field-metadata/dtos/field-metadata.dto';
 import { type FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
@@ -67,6 +68,11 @@ export type IndexFieldMetadataLoaderPayload = {
   indexMetadata: Pick<IndexMetadataInterface, 'id'>;
 };
 
+export type ObjectMetadataLoaderPayload = {
+  workspaceId: string;
+  objectMetadataId: string;
+};
+
 @Injectable()
 export class DataloaderService {
   constructor(
@@ -82,6 +88,7 @@ export class DataloaderService {
     const fieldMetadataLoader = this.createFieldMetadataLoader();
     const indexMetadataLoader = this.createIndexMetadataLoader();
     const indexFieldMetadataLoader = this.createIndexFieldMetadataLoader();
+    const objectMetadataLoader = this.createObjectMetadataLoader();
 
     return {
       relationLoader,
@@ -89,6 +96,7 @@ export class DataloaderService {
       fieldMetadataLoader,
       indexMetadataLoader,
       indexFieldMetadataLoader,
+      objectMetadataLoader,
     };
   }
 
@@ -306,6 +314,27 @@ export class DataloaderService {
           );
         },
       );
+    });
+  }
+
+  private createObjectMetadataLoader() {
+    return new DataLoader<
+      ObjectMetadataLoaderPayload,
+      ObjectMetadataItemWithFieldMaps | null
+    >(async (dataLoaderParams: ObjectMetadataLoaderPayload[]) => {
+      const workspaceId = dataLoaderParams[0].workspaceId;
+      const objectMetadataIds = dataLoaderParams.map(
+        (dataLoaderParam) => dataLoaderParam.objectMetadataId,
+      );
+
+      const { objectMetadataMaps } =
+        await this.workspaceMetadataCacheService.getExistingOrRecomputeMetadataMaps(
+          { workspaceId },
+        );
+
+      return objectMetadataIds.map((objectMetadataId) => {
+        return objectMetadataMaps.byId[objectMetadataId] || null;
+      });
     });
   }
 }


### PR DESCRIPTION
## What
Fixed N+1 query issue where each view's name resolution triggered a separate DB query to fetch objectMetadataId, even though it was already available in the parent view object.

## How
  - Added `objectMetadataLoader` to DataloaderService to batch metadata lookups
  - Updated ViewResolver to use context.loaders (following existing pattern from other metadata
  resolvers)
  - Removed unused `getObjectMetadataByViewId` method and its tests

  Now uses the already-loaded `view.objectMetadataId` directly instead of making unnecessary
  queries.

  Much cleaner!