### PR TITLE
feat Support dashes (-) in trusted domain emails

### DIFF
--- a/packages/twenty-front/src/pages/settings/security/SettingsSecurityApprovedAccessDomain.tsx
+++ b/packages/twenty-front/src/pages/settings/security/SettingsSecurityApprovedAccessDomain.tsx
@@ -68,9 +68,8 @@ export const SettingsSecurityApprovedAccessDomain = () => {
           navigate(SettingsPath.Security);
         },
         onError: (error) => {
-          console.log(error.message)
           enqueueErrorSnackBar({
-            message :error ? error.message :"an error occurred",
+            message: error ? error.message : "An unexpected error occurred",
           });
         },
       });

--- a/packages/twenty-front/src/pages/settings/security/SettingsSecurityApprovedAccessDomain.tsx
+++ b/packages/twenty-front/src/pages/settings/security/SettingsSecurityApprovedAccessDomain.tsx
@@ -68,8 +68,9 @@ export const SettingsSecurityApprovedAccessDomain = () => {
           navigate(SettingsPath.Security);
         },
         onError: (error) => {
+          console.log(error.message)
           enqueueErrorSnackBar({
-            apolloError: error instanceof ApolloError ? error : undefined,
+            message :error ? error.message :"an error occurred",
           });
         },
       });

--- a/packages/twenty-server/src/utils/email-providers.ts
+++ b/packages/twenty-server/src/utils/email-providers.ts
@@ -192,6 +192,7 @@ const emailProviders = `0.pl
 1aolmail.com
 1auto.com
 1blackmoon.com
+bla-bla.com
 1bstb.ru
 1ce.us
 1chuan.com

--- a/packages/twenty-server/src/utils/email-providers.ts
+++ b/packages/twenty-server/src/utils/email-providers.ts
@@ -1939,7 +1939,6 @@ bkkpkht.ga
 bkkpkht.gq
 bkkpkht.ml
 bko.kr
-bla-bla.com
 blackbird.ws
 blackburnfans.com
 blackburnmail.com

--- a/packages/twenty-ui/package.json
+++ b/packages/twenty-ui/package.json
@@ -1,173 +1,116 @@
 {
   "name": "twenty-ui",
-  "main": "dist/index.cjs",
-  "module": "dist/index.mjs",
-  "style": "./dist/style.css",
-  "type": "module",
-  "devDependencies": {
-    "@babel/preset-env": "^7.26.9",
-    "@babel/preset-react": "^7.26.3",
-    "@prettier/sync": "^0.5.2",
-    "@swc/plugin-emotion": "10.0.4",
-    "@types/babel__preset-env": "^7",
-    "@types/react": "^18.2.39",
-    "@types/react-dom": "^18.2.15",
-    "@wyw-in-js/babel-preset": "^0.6.0",
-    "babel-plugin-inline-import": "^3.0.0",
-    "babel-plugin-inline-react-svg": "^2.0.2",
-    "babel-plugin-module-resolver": "^5.0.2",
-    "cpx": "^1.5.0",
-    "tsx": "^4.19.3",
-    "vite-plugin-svgr": "^4.3.0"
-  },
-  "dependencies": {
-    "@emotion/is-prop-valid": "^1.3.0",
-    "@emotion/react": "^11.11.1",
-    "@emotion/styled": "^11.11.0",
-    "@linaria/react": "^6.2.1",
-    "@monaco-editor/react": "^4.6.0",
-    "@sniptt/guards": "^0.2.0",
-    "@tabler/icons-react": "^3.31.0",
-    "date-fns": "^2.30.0",
-    "framer-motion": "^11.18.0",
-    "glob": "^11.0.1",
-    "hex-rgb": "^5.0.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "react-responsive": "^9.0.2",
-    "react-router-dom": "^6.4.4",
-    "react-tooltip": "^5.13.1",
-    "recoil": "^0.7.7",
-    "twenty-shared": "workspace:*",
-    "zod": "3.23.8"
-  },
-  "scripts": {
-    "build": "npx vite build"
-  },
-  "files": [
-    "dist",
-    "assets",
-    "accessibility",
-    "components",
-    "display",
-    "feedback",
-    "input",
-    "json-visualizer",
-    "layout",
-    "navigation",
-    "testing",
-    "theme",
-    "utilities"
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/twenty-ui/src",
+  "projectType": "library",
+  "tags": [
+    "scope:frontend"
   ],
-  "sideEffects": [
-    "**/*.css"
-  ],
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
-    },
-    "./style.css": "./dist/style.css",
-    "./accessibility": {
-      "types": "./dist/accessibility/index.d.ts",
-      "import": "./dist/accessibility.mjs",
-      "require": "./dist/accessibility.cjs"
-    },
-    "./assets": {
-      "types": "./dist/assets/index.d.ts",
-      "import": "./dist/assets.mjs",
-      "require": "./dist/assets.cjs"
-    },
-    "./components": {
-      "types": "./dist/components/index.d.ts",
-      "import": "./dist/components.mjs",
-      "require": "./dist/components.cjs"
-    },
-    "./display": {
-      "types": "./dist/display/index.d.ts",
-      "import": "./dist/display.mjs",
-      "require": "./dist/display.cjs"
-    },
-    "./feedback": {
-      "types": "./dist/feedback/index.d.ts",
-      "import": "./dist/feedback.mjs",
-      "require": "./dist/feedback.cjs"
-    },
-    "./input": {
-      "types": "./dist/input/index.d.ts",
-      "import": "./dist/input.mjs",
-      "require": "./dist/input.cjs"
-    },
-    "./json-visualizer": {
-      "types": "./dist/json-visualizer/index.d.ts",
-      "import": "./dist/json-visualizer.mjs",
-      "require": "./dist/json-visualizer.cjs"
-    },
-    "./layout": {
-      "types": "./dist/layout/index.d.ts",
-      "import": "./dist/layout.mjs",
-      "require": "./dist/layout.cjs"
-    },
-    "./navigation": {
-      "types": "./dist/navigation/index.d.ts",
-      "import": "./dist/navigation.mjs",
-      "require": "./dist/navigation.cjs"
-    },
-    "./testing": {
-      "types": "./dist/testing/index.d.ts",
-      "import": "./dist/testing.mjs",
-      "require": "./dist/testing.cjs"
-    },
-    "./theme": {
-      "types": "./dist/theme/index.d.ts",
-      "import": "./dist/theme.mjs",
-      "require": "./dist/theme.cjs"
-    },
-    "./utilities": {
-      "types": "./dist/utilities/index.d.ts",
-      "import": "./dist/utilities.mjs",
-      "require": "./dist/utilities.cjs"
-    }
-  },
-  "typesVersions": {
-    "*": {
-      "accessibility": [
-        "dist/accessibility/index.d.ts"
+  "targets": {
+    "build": {
+      "dependsOn": [
+        "^build",
+        "generateBarrels"
       ],
-      "assets": [
-        "dist/assets/index.d.ts"
-      ],
-      "components": [
-        "dist/components/index.d.ts"
-      ],
-      "display": [
-        "dist/display/index.d.ts"
-      ],
-      "feedback": [
-        "dist/feedback/index.d.ts"
-      ],
-      "input": [
-        "dist/input/index.d.ts"
-      ],
-      "json-visualizer": [
-        "dist/json-visualizer/index.d.ts"
-      ],
-      "layout": [
-        "dist/layout/index.d.ts"
-      ],
-      "navigation": [
-        "dist/navigation/index.d.ts"
-      ],
-      "testing": [
-        "dist/testing/index.d.ts"
-      ],
-      "theme": [
-        "dist/theme/index.d.ts"
-      ],
-      "utilities": [
-        "dist/utilities/index.d.ts"
+      "outputs": [
+        "{projectRoot}/dist",
+        "{projectRoot}/accessibility/package.json",
+        "{projectRoot}/accessibility/dist",
+        "{projectRoot}/assets/package.json",
+        "{projectRoot}/assets/dist",
+        "{projectRoot}/components/package.json",
+        "{projectRoot}/components/dist",
+        "{projectRoot}/display/package.json",
+        "{projectRoot}/display/dist",
+        "{projectRoot}/feedback/package.json",
+        "{projectRoot}/feedback/dist",
+        "{projectRoot}/input/package.json",
+        "{projectRoot}/input/dist",
+        "{projectRoot}/json-visualizer/package.json",
+        "{projectRoot}/json-visualizer/dist",
+        "{projectRoot}/layout/package.json",
+        "{projectRoot}/layout/dist",
+        "{projectRoot}/navigation/package.json",
+        "{projectRoot}/navigation/dist",
+        "{projectRoot}/testing/package.json",
+        "{projectRoot}/testing/dist",
+        "{projectRoot}/theme/package.json",
+        "{projectRoot}/theme/dist",
+        "{projectRoot}/utilities/package.json",
+        "{projectRoot}/utilities/dist"
       ]
+    },
+    "generateBarrels": {
+      "executor": "nx:run-commands",
+      "cache": true,
+      "inputs": [
+        "production",
+        "{projectRoot}/scripts/generateBarrels.ts"
+      ],
+      "outputs": [
+        "{projectRoot}/src/**/*/index.ts",
+        "{projectRoot}/package.json"
+      ],
+      "options": {
+        "command": "tsx {projectRoot}/scripts/generateBarrels.ts"
+      }
+    },
+    "clean": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "rimraf {projectRoot}/dist"
+      }
+    },
+    "lint": {
+      "options": {
+        "lintFilePatterns": [
+          "{projectRoot}/src/**/*.{ts,tsx,json}",
+          "{projectRoot}/package.json"
+        ]
+      },
+      "configurations": {
+        "fix": {}
+      }
+    },
+    "fmt": {
+      "options": {
+        "files": "src"
+      },
+      "configurations": {
+        "fix": {}
+      }
+    },
+    "test": {},
+    "typecheck": {},
+    "storybook:build": {
+      "configurations": {
+        "test": {}
+      }
+    },
+    "storybook:serve:dev": {
+      "options": {
+        "port": 6007
+      }
+    },
+    "storybook:serve:static": {
+      "options": {
+        "buildTarget": "twenty-ui:storybook:build",
+        "port": 6007
+      },
+      "configurations": {
+        "test": {}
+      }
+    },
+    "storybook:coverage": {},
+    "storybook:test": {
+      "options": {
+        "port": 6007
+      }
+    },
+    "storybook:serve-and-test:static": {
+      "options": {
+        "port": 6007
+      }
     }
   }
 }


### PR DESCRIPTION


https://github.com/user-attachments/assets/6c72bc90-a573-49a2-b536-92a920cd33f3


It's not an issue. When a user adds a domain, it first checks the invalid domain array. If any domain is in that array, it's probably an invalid domain, which is the reason it throws an error. However, this can be confusing, so i show a message to the user.