### PR TITLE
Display relation field id reaching max depth

### DIFF
--- a/packages/twenty-front/src/modules/workflow/workflow-variables/utils/__tests__/filterOutputSchema.test.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-variables/utils/__tests__/filterOutputSchema.test.ts
@@ -68,7 +68,7 @@ describe('filterOutputSchema', () => {
     });
   });
 
-  describe('shouldDisplayRecordObjects only (false, true)', () => {
+  describe('shouldDisplayRecordObjects and related fields only (false, true)', () => {
     describe('record schema', () => {
       it('should keep record schema with object and filter compatible fields', () => {
         const inputSchema = createRecordSchema('person', {
@@ -78,9 +78,11 @@ describe('filterOutputSchema', () => {
             isLeaf: false,
             value: createRecordSchema('employee'),
           },
+          domain: { isLeaf: true, type: FieldMetadataType.TEXT },
         });
 
         const expectedSchema = createRecordSchema('person', {
+          id: { isLeaf: true, type: FieldMetadataType.UUID },
           name: { isLeaf: true, value: 'string' },
           employee: {
             isLeaf: false,

--- a/packages/twenty-front/src/modules/workflow/workflow-variables/utils/isFieldTypeCompatibleWithRecordId.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-variables/utils/isFieldTypeCompatibleWithRecordId.ts
@@ -1,7 +1,13 @@
 import { type InputSchemaPropertyType } from '@/workflow/types/InputSchema';
+import { FieldMetadataType } from '~/generated-metadata/graphql';
 
 export const isFieldTypeCompatibleWithRecordId = (
   type?: InputSchemaPropertyType,
 ): boolean => {
-  return !type || type === 'string' || type === 'unknown';
+  return (
+    !type ||
+    type === 'string' ||
+    type === 'unknown' ||
+    type === FieldMetadataType.UUID
+  );
 };

--- a/packages/twenty-front/src/modules/workflow/workflow-variables/utils/searchVariableThroughRecordOutputSchema.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-variables/utils/searchVariableThroughRecordOutputSchema.ts
@@ -34,6 +34,14 @@ const getCompositeSubFieldName = (
       : undefined;
 };
 
+const isIdFieldName = (fieldName: string) => {
+  return (
+    fieldName === 'id' ||
+    // For database events, id field will have a prefix such as properties.after.id
+    fieldName.endsWith('.id')
+  );
+};
+
 const navigateToTargetField = (
   startingSchema: RecordOutputSchemaV2,
   pathSegments: string[],
@@ -75,7 +83,7 @@ const buildVariableResult = (
   const variableLabel =
     isFullRecord &&
     isRecordOutputSchemaV2(targetSchema) &&
-    targetFieldName === 'id'
+    isIdFieldName(targetFieldName)
       ? getRecordObjectLabel(targetSchema)
       : targetField?.label;
 

--- a/packages/twenty-front/src/modules/workflow/workflow-variables/utils/searchVariableThroughRecordOutputSchema.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-variables/utils/searchVariableThroughRecordOutputSchema.ts
@@ -73,7 +73,9 @@ const buildVariableResult = (
   const targetField = getFieldFromSchema(targetFieldName, targetSchema);
   // Determine the variable label based on whether we want the full record or a specific field
   const variableLabel =
-    isFullRecord && isRecordOutputSchemaV2(targetSchema)
+    isFullRecord &&
+    isRecordOutputSchemaV2(targetSchema) &&
+    targetFieldName === 'id'
       ? getRecordObjectLabel(targetSchema)
       : targetField?.label;
 

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-schema/utils/__tests__/generate-fake-object-record.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-schema/utils/__tests__/generate-fake-object-record.spec.ts
@@ -58,6 +58,7 @@ describe('generateFakeObjectRecord', () => {
     expect(generateObjectRecordFields).toHaveBeenCalledWith({
       objectMetadataInfo,
       depth: 0,
+      maxDepth: 1,
     });
   });
 });

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-schema/utils/generate-fake-object-record.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-schema/utils/generate-fake-object-record.ts
@@ -5,9 +5,11 @@ import { generateObjectRecordFields } from 'src/modules/workflow/workflow-builde
 export const generateFakeObjectRecord = ({
   objectMetadataInfo,
   depth = 0,
+  maxDepth = 1,
 }: {
   objectMetadataInfo: ObjectMetadataInfo;
   depth?: number;
+  maxDepth?: number;
 }): RecordOutputSchema => {
   return {
     object: {
@@ -22,6 +24,7 @@ export const generateFakeObjectRecord = ({
     fields: generateObjectRecordFields({
       objectMetadataInfo,
       depth,
+      maxDepth,
     }),
     _outputSchemaType: 'RECORD',
   };

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-schema/workflow-schema.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-schema/workflow-schema.workspace-service.ts
@@ -117,6 +117,7 @@ export class WorkflowSchemaWorkspaceService {
     const recordOutputSchema = await this.computeRecordOutputSchema({
       objectType,
       workspaceId,
+      maxDepth: 0,
     });
 
     return {
@@ -138,9 +139,11 @@ export class WorkflowSchemaWorkspaceService {
   private async computeRecordOutputSchema({
     objectType,
     workspaceId,
+    maxDepth = 1,
   }: {
     objectType: string;
     workspaceId: string;
+    maxDepth?: number;
   }): Promise<OutputSchema> {
     const objectMetadataInfo =
       await this.workflowCommonWorkspaceService.getObjectMetadataItemWithFieldsMaps(
@@ -148,7 +151,7 @@ export class WorkflowSchemaWorkspaceService {
         workspaceId,
       );
 
-    return generateFakeObjectRecord({ objectMetadataInfo });
+    return generateFakeObjectRecord({ objectMetadataInfo, maxDepth });
   }
 
   private computeSendEmailActionOutputSchema(): OutputSchema {


### PR DESCRIPTION
Search record action do not fetch relations. We could add it to but the logic used, based on gql filtering will be refactored soon. Issue it that the output schema of the step is displaying relation content as if there were available.

This PR:
- remove the relation content from search record output schema
- replace it by the relation field id so the user can still use it
- makes UUID selectable in object record picker field

Before 

https://github.com/user-attachments/assets/1bdb4c24-ef32-4a15-9da9-149f270abb01

After

https://github.com/user-attachments/assets/d6e97160-c5a3-4989-a603-0c7ce8128b31
