### PR TITLE
fix: Support dashes (-) in trusted domain emails

### DIFF
--- a/packages/twenty-front/src/pages/settings/security/SettingsSecurityApprovedAccessDomain.tsx
+++ b/packages/twenty-front/src/pages/settings/security/SettingsSecurityApprovedAccessDomain.tsx
@@ -69,7 +69,7 @@ export const SettingsSecurityApprovedAccessDomain = () => {
         },
         onError: (error) => {
           enqueueErrorSnackBar({
-            apolloError: error instanceof ApolloError ? error : undefined,
+            message: error ? error.message : "An unexpected error occurred",
           });
         },
       });


### PR DESCRIPTION
It's not an issue. When a user adds a domain, it first checks the invalid domain array. If any domain is in that array, it's probably an invalid domain, which is the reason it throws an error. However, this can be confusing, so i show a message to the user.

issues:#13378

https://github.com/user-attachments/assets/a3e364d8-4544-4f2e-83b0-cee2a16887ec
