### PR TITLE
Modify translation compilation condition in Github Workflow

### DIFF
--- a/.github/workflows/i18n-pull.yaml
+++ b/.github/workflows/i18n-pull.yaml
@@ -99,7 +99,8 @@ jobs:
 
       - name: Compile translations
         id: compile_translations
-        if: inputs.force_pull || steps.compile_translations_strict.outcome == 'failure'
+        # Because we have set English as a fallback locale, this condition does not work anymore
+        # if: inputs.force_pull || steps.compile_translations_strict.outcome == 'failure'
         run: |
           npx nx run twenty-server:lingui:compile
           npx nx run twenty-emails:lingui:compile 


### PR DESCRIPTION
Translations weren't pulled because --strict does not fail since we've set english as a fallback locale (since english is set as a fallback it considers translations have been found and therefore the command does not fail as expected).

Temporary hotfix but we should do something smarter in the future

@ehconitin fyi