### PR TITLE
Seed morph metadata

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/flat-object-metadata/utils/from-cached-field-metadata-entity-to-flat-field-metadata.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-object-metadata/utils/from-cached-field-metadata-entity-to-flat-field-metadata.util.ts
@@ -83,6 +83,10 @@ export const fromCachedFieldMetadataEntityToFlatFieldMetadata = <
       !isCachedFieldMetadataEntityOfType(
         relationTargetCachedFieldMetadata,
         FieldMetadataType.RELATION,
+      ) &&
+      !isCachedFieldMetadataEntityOfType(
+        relationTargetCachedFieldMetadata,
+        FieldMetadataType.MORPH_RELATION,
       )
     ) {
       throw new WorkspaceMetadataCacheException(

--- a/packages/twenty-server/src/engine/workspace-manager/dev-seeder/dev-seeder.module.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/dev-seeder/dev-seeder.module.ts
@@ -12,6 +12,7 @@ import { ObjectMetadataModule } from 'src/engine/metadata-modules/object-metadat
 import { ObjectPermissionModule } from 'src/engine/metadata-modules/object-permission/object-permission.module';
 import { RoleModule } from 'src/engine/metadata-modules/role/role.module';
 import { UserRoleModule } from 'src/engine/metadata-modules/user-role/user-role.module';
+import { WorkspaceMetadataCacheModule } from 'src/engine/metadata-modules/workspace-metadata-cache/workspace-metadata-cache.module';
 import { WorkspacePermissionsCacheModule } from 'src/engine/metadata-modules/workspace-permissions-cache/workspace-permissions-cache.module';
 import { WorkspaceCacheStorageModule } from 'src/engine/workspace-cache-storage/workspace-cache-storage.module';
 import { WorkspaceDataSourceModule } from 'src/engine/workspace-datasource/workspace-datasource.module';
@@ -38,6 +39,7 @@ import { WorkspaceSyncMetadataModule } from 'src/engine/workspace-manager/worksp
     TypeOrmModule.forFeature([Workspace, ObjectMetadataEntity]),
     ObjectPermissionModule,
     WorkspacePermissionsCacheModule,
+    WorkspaceMetadataCacheModule,
   ],
   exports: [DevSeederService],
   providers: [

--- a/packages/twenty-server/src/engine/workspace-manager/dev-seeder/metadata/custom-fields/constants/pet-custom-relation-field-seeds.constant.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/dev-seeder/metadata/custom-fields/constants/pet-custom-relation-field-seeds.constant.ts
@@ -1,0 +1,22 @@
+import { FieldMetadataType, RelationType } from 'twenty-shared/types';
+
+import { type FieldMetadataSeed } from 'src/engine/workspace-manager/dev-seeder/metadata/types/field-metadata-seed.type';
+
+export const PET_CUSTOM_RELATION_FIELD_SEEDS: (FieldMetadataSeed & {
+  targetObjectMetadataNames: string[];
+})[] = [
+  {
+    type: FieldMetadataType.MORPH_RELATION,
+    label: 'Owner',
+    name: 'owner of the Pet (person or company)',
+    morphRelationsCreationPayload: [
+      {
+        type: RelationType.MANY_TO_ONE,
+        targetObjectMetadataId: 'to-be-resolved-later',
+        targetFieldLabel: 'Owner',
+        targetFieldIcon: 'IconRelationOneToMany',
+      },
+    ],
+    targetObjectMetadataNames: ['person', 'company'],
+  },
+];

--- a/packages/twenty-server/src/engine/workspace-manager/dev-seeder/metadata/custom-fields/constants/pet-custom-relation-field-seeds.constant.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/dev-seeder/metadata/custom-fields/constants/pet-custom-relation-field-seeds.constant.ts
@@ -7,16 +7,17 @@ export const PET_CUSTOM_RELATION_FIELD_SEEDS: (FieldMetadataSeed & {
 })[] = [
   {
     type: FieldMetadataType.MORPH_RELATION,
-    label: 'Owner',
-    name: 'owner of the Pet (person or company)',
+    label: 'Owner of the Pet (rocket or survey)',
+    name: 'owner',
+    icon: 'IconRelationManyToOne',
     morphRelationsCreationPayload: [
       {
         type: RelationType.MANY_TO_ONE,
         targetObjectMetadataId: 'to-be-resolved-later',
-        targetFieldLabel: 'Owner',
+        targetFieldLabel: 'Owned by',
         targetFieldIcon: 'IconRelationOneToMany',
       },
     ],
-    targetObjectMetadataNames: ['person', 'company'],
+    targetObjectMetadataNames: ['surveyResult', 'rocket'],
   },
 ];

--- a/packages/twenty-server/src/engine/workspace-manager/dev-seeder/services/dev-seeder.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/dev-seeder/services/dev-seeder.service.ts
@@ -66,6 +66,10 @@ export class DevSeederService {
       workspaceId,
     });
 
+    await this.devSeederMetadataService.seedRelations({
+      workspaceId,
+    });
+
     await this.devSeederPermissionsService.initPermissions(workspaceId);
 
     await this.devSeederDataService.seed({


### PR DESCRIPTION
in thie PR we create the tooling to allow the relation and morph relation creation during the seed process.

We use the ObjectMetadataMaps in order to fasten the process

Fixes https://github.com/twentyhq/core-team-issues/issues/1179