### PR TITLE
Format dates as '20 Dec, 2025' style

### DIFF
--- a/packages/twenty-front/src/utils/date-utils.ts
+++ b/packages/twenty-front/src/utils/date-utils.ts
@@ -205,12 +205,11 @@ export const formatISOStringToHumanReadableDate = (date: string) => {
 
 export const formatToHumanReadableDate = (date: Date | string) => {
   const parsedJSDate = parseDate(date).toJSDate();
-
-  return new Intl.DateTimeFormat(undefined, {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  }).format(parsedJSDate);
+  // Format: 20 Dec, 2025
+  const day = parsedJSDate.getDate();
+  const month = parsedJSDate.toLocaleString('en-US', { month: 'short' });
+  const year = parsedJSDate.getFullYear();
+  return `${day} ${month}, ${year}`;
 };
 
 export const formatToHumanReadableDateTime = (date: Date | string) => {

--- a/packages/twenty-website/src/shared-utils/formatDisplayDate.ts
+++ b/packages/twenty-website/src/shared-utils/formatDisplayDate.ts
@@ -4,14 +4,8 @@ export const formatGithubPublishedAtDisplayDate = (
   const date = new Date(dateString);
   if (Number.isNaN(date.getTime())) return '';
 
-  const now = new Date();
-  const isCurrentYear = date.getFullYear() === now.getFullYear();
-
-  const formatter = new Intl.DateTimeFormat('en-US', {
-    month: isCurrentYear ? 'long' : 'short',
-    day: 'numeric',
-    ...(isCurrentYear ? {} : { year: 'numeric' }),
-  });
-
-  return formatter.format(date);
+  const day = date.getDate();
+  const month = date.toLocaleString('en-US', { month: 'short' });
+  const year = date.getFullYear();
+  return `${day} ${month}, ${year}`;
 };


### PR DESCRIPTION
This PR updates date formatting across the codebase to consistently use the "day shortMonth, year" style (e.g., "20 Dec, 2025").

Updated [formatToHumanReadableDate](https://potential-spork-pxgpwxxp4j4h996v.github.dev/) in [date-utils.ts](https://potential-spork-pxgpwxxp4j4h996v.github.dev/)

Updated [formatGithubPublishedAtDisplayDate](https://potential-spork-pxgpwxxp4j4h996v.github.dev/) in [formatDisplayDate.ts](https://potential-spork-pxgpwxxp4j4h996v.github.dev/)

This change improves date readability and ensures a unified display format for users.

Closes #14177 