### PR TITLE
Fix workspace deletion broken

### DIFF
--- a/packages/twenty-front/src/modules/settings/components/SettingsProtectedRouteWrapper.tsx
+++ b/packages/twenty-front/src/modules/settings/components/SettingsProtectedRouteWrapper.tsx
@@ -31,7 +31,9 @@ export const SettingsProtectedRouteWrapper = ({
     return null;
   }
 
-  // TODO: this should be part of PageChangeEffect as otherwise we will have multiple sources of redirection
+  // TODO: this should be part of PageChangeEffect as otherwise we will have multiple sources of redirection that can:
+  // - conflict (race conditions)
+  // - degrade performance as we will redirect multiple times
   if ((requiredFeatureFlag && !requiredFeatureFlagEnabled) || !hasPermission) {
     return <Navigate to={getSettingsPath(SettingsPath.ProfilePage)} replace />;
   }

--- a/packages/twenty-front/src/modules/settings/components/SettingsProtectedRouteWrapper.tsx
+++ b/packages/twenty-front/src/modules/settings/components/SettingsProtectedRouteWrapper.tsx
@@ -1,3 +1,4 @@
+import { useIsLogged } from '@/auth/hooks/useIsLogged';
 import { useHasPermissionFlag } from '@/settings/roles/hooks/useHasPermissionFlag';
 import { SettingsPath } from '@/types/SettingsPath';
 import { useIsFeatureEnabled } from '@/workspace/hooks/useIsFeatureEnabled';
@@ -20,11 +21,17 @@ export const SettingsProtectedRouteWrapper = ({
   settingsPermission,
   requiredFeatureFlag,
 }: SettingsProtectedRouteWrapperProps) => {
+  const isLoggedIn = useIsLogged();
   const hasPermission = useHasPermissionFlag(settingsPermission);
   const requiredFeatureFlagEnabled = useIsFeatureEnabled(
     requiredFeatureFlag || null,
   );
 
+  if (!isLoggedIn) {
+    return null;
+  }
+
+  // TODO: this should be part of PageChangeEffect as otherwise we will have multiple sources of redirection
   if ((requiredFeatureFlag && !requiredFeatureFlagEnabled) || !hasPermission) {
     return <Navigate to={getSettingsPath(SettingsPath.ProfilePage)} replace />;
   }

--- a/packages/twenty-server/src/engine/workspace-datasource/workspace-datasource.service.ts
+++ b/packages/twenty-server/src/engine/workspace-datasource/workspace-datasource.service.ts
@@ -58,7 +58,7 @@ export class WorkspaceDataSourceService {
 
     const queryRunner = this.coreDataSource.createQueryRunner();
 
-    await queryRunner.dropSchema(schemaName, true);
+    await queryRunner.dropSchema(schemaName, true, true);
 
     await queryRunner.release();
   }


### PR DESCRIPTION
Workspace deletion was broken because workspace schema deletion should be "CASCADE". Otherwise postgres will refuse to remove a schema with existing tables

Also, user experience on delete was degraded because of redirect race condition:
- we were redirecting to /welcome on deletion
- also redirecting to /settings/profile as the system detects missingPermissionFlag

I'm disabling permission check if the user is not logged in as it does not makes sense. I don't think this is a big issue but we will likely revisit this later if we face race condition between Permission checks redirect and PageChangeEffect. This could also be migrated fairly easily to PageChangeEffect where we make sure that we only redirect once