### PR TITLE
fix(billing): retain original casing for `event_name` in Stripe meter…

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/billing/stripe/services/stripe-billing-meter-event.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/stripe/services/stripe-billing-meter-event.service.ts
@@ -35,7 +35,7 @@ export class StripeBillingMeterEventService {
     stripeCustomerId: string;
   }) {
     await this.stripe.billing.meterEvents.create({
-      event_name: eventName.toLowerCase(),
+      event_name: eventName,
       payload: {
         value: value.toString(),
         stripe_customer_id: stripeCustomerId,


### PR DESCRIPTION
…ed event creation