### PR TITLE
Morph relation field v2 fixes

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata.service-v2.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata.service-v2.ts
@@ -152,7 +152,7 @@ export class FieldMetadataServiceV2 {
     const optimisticallyUpdatedFlatFieldMetadatas =
       inputTranspilationResult.result;
 
-    const relatedObjectMetadataIds = [
+    const objectMetadataIdWithRelatedObjectMetadataIds = [
       ...new Set(
         optimisticallyUpdatedFlatFieldMetadatas.flatMap(
           ({ objectMetadataId, relationTargetObjectMetadataId }) =>
@@ -164,7 +164,7 @@ export class FieldMetadataServiceV2 {
     ];
     const fromFlatObjectMetadataMaps = getSubFlatObjectMetadataMapsOrThrow({
       flatObjectMetadataMaps: existingFlatObjectMetadataMaps,
-      objectMetadataIds: relatedObjectMetadataIds,
+      objectMetadataIds: objectMetadataIdWithRelatedObjectMetadataIds,
     });
 
     const toFlatObjectMetadataMaps =

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata.service-v2.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata.service-v2.ts
@@ -149,12 +149,12 @@ export class FieldMetadataServiceV2 {
       throw inputTranspilationResult.error;
     }
 
-    const optimisticiallyUpdatedFlatFieldMetadatas =
+    const optimisticallyUpdatedFlatFieldMetadatas =
       inputTranspilationResult.result;
 
     const relatedObjectMetadataIds = [
       ...new Set(
-        optimisticiallyUpdatedFlatFieldMetadatas.flatMap(
+        optimisticallyUpdatedFlatFieldMetadatas.flatMap(
           ({ objectMetadataId, relationTargetObjectMetadataId }) =>
             isDefined(relationTargetObjectMetadataId)
               ? [objectMetadataId, relationTargetObjectMetadataId]
@@ -168,7 +168,7 @@ export class FieldMetadataServiceV2 {
     });
 
     const toFlatObjectMetadataMaps =
-      optimisticiallyUpdatedFlatFieldMetadatas.reduce(
+      optimisticallyUpdatedFlatFieldMetadatas.reduce(
         (flatObjectMetadataMaps, flatFieldMetadata) =>
           replaceFlatFieldMetadataInFlatObjectMetadataMapsOrThrow({
             flatObjectMetadataMaps,
@@ -199,7 +199,7 @@ export class FieldMetadataServiceV2 {
 
     return this.fieldMetadataRepository.findOneOrFail({
       where: {
-        id: optimisticiallyUpdatedFlatFieldMetadatas[0].id,
+        id: optimisticallyUpdatedFlatFieldMetadatas[0].id,
         workspaceId,
       },
     });

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata.service-v2.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata.service-v2.ts
@@ -20,6 +20,7 @@ import { fromCreateFieldInputToFlatFieldMetadatasToCreate } from 'src/engine/met
 import { fromDeleteFieldInputToFlatFieldMetadatasToDelete } from 'src/engine/metadata-modules/flat-field-metadata/utils/from-delete-field-input-to-flat-field-metadatas-to-delete.util';
 import { fromFlatFieldMetadataToFieldMetadataDto } from 'src/engine/metadata-modules/flat-field-metadata/utils/from-flat-field-metadata-to-field-metadata-dto.util';
 import { fromUpdateFieldInputToFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/from-update-field-input-to-flat-field-metadata.util';
+import { isMorphOrRelationFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-morph-or-relation-flat-field-metadata.util';
 import { throwOnFieldInputTranspilationsError } from 'src/engine/metadata-modules/flat-field-metadata/utils/throw-on-field-input-transpilations-error.util';
 import { addFlatFieldMetadataInFlatObjectMetadataMapsOrThrow } from 'src/engine/metadata-modules/flat-object-metadata-maps/utils/add-flat-field-metadata-in-flat-object-metadata-maps-or-throw.util';
 import { deleteFieldFromFlatObjectMetadataMapsOrThrow } from 'src/engine/metadata-modules/flat-object-metadata-maps/utils/delete-field-from-flat-object-metadata-maps-or-throw.util';
@@ -83,10 +84,14 @@ export class FieldMetadataServiceV2 {
     const flatObjectMetadataMapsWithImpactedObject =
       getSubFlatObjectMetadataMapsOrThrow({
         flatObjectMetadataMaps: existingFlatObjectMetadataMaps,
-        objectMetadataIds: flatFieldMetadatasToDelete.map(
-          (flatFieldMetadataToDelete) =>
-            flatFieldMetadataToDelete.objectMetadataId,
-        ),
+        objectMetadataIds: [
+          ...new Set(
+            flatFieldMetadatasToDelete.map(
+              (flatFieldMetadataToDelete) =>
+                flatFieldMetadataToDelete.objectMetadataId,
+            ),
+          ),
+        ],
       });
 
     const toFlatObjectMetadataMaps = flatFieldMetadatasToDelete.reduce(
@@ -145,13 +150,22 @@ export class FieldMetadataServiceV2 {
       throw inputTranspilationResult.error;
     }
 
-    const optimisticiallyUpdatedFlatFieldMetadata =
+    const { flatObjectMetadata, optimisticiallyUpdatedFlatFieldMetadata } =
       inputTranspilationResult.result;
+
+    const relatedObjectMetadataIds = [
+      ...new Set(
+        flatObjectMetadata.flatFieldMetadatas
+          .filter(isMorphOrRelationFlatFieldMetadata)
+          .map((el) => el.relationTargetObjectMetadataId),
+      ),
+    ];
 
     const fromFlatObjectMetadataMaps = getSubFlatObjectMetadataMapsOrThrow({
       flatObjectMetadataMaps: existingFlatObjectMetadataMaps,
       objectMetadataIds: [
         optimisticiallyUpdatedFlatFieldMetadata.objectMetadataId,
+        ...relatedObjectMetadataIds,
       ],
     });
     const toFlatObjectMetadataMaps =

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/services/flat-field-metadata-validator.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/services/flat-field-metadata-validator.service.ts
@@ -133,7 +133,7 @@ export class FlatFieldMetadataValidatorService {
       validationResult.errors.push(
         ...validateFlatFieldMetadataName(updatedFlatFieldMetadata.name),
         ...validateFlatFieldMetadataNameAvailability({
-          name: updatedFlatFieldMetadata.name,
+          flatFieldMetadata: updatedFlatFieldMetadata,
           flatObjectMetadata: flatObjectMetadata,
         }),
       );
@@ -298,7 +298,7 @@ export class FlatFieldMetadataValidatorService {
 
       validationResult.errors.push(
         ...validateFlatFieldMetadataNameAvailability({
-          name: flatFieldMetadataToValidate.name,
+          flatFieldMetadata: flatFieldMetadataToValidate,
           flatObjectMetadata: parentFlatObjectMetadata,
         }),
       );

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/compute-flat-field-metadata-related-flat-field-metadata.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/compute-flat-field-metadata-related-flat-field-metadata.util.ts
@@ -1,0 +1,42 @@
+import { FlatFieldMetadata } from "src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type";
+import { findFlatFieldMetadatasRelatedToMorphRelationOrThrow } from "src/engine/metadata-modules/flat-field-metadata/utils/find-flat-field-metadatas-related-to-morph-relation-or-throw.util";
+import { findRelationFlatFieldMetadataTargetFlatFieldMetadataOrThrow } from "src/engine/metadata-modules/flat-field-metadata/utils/find-relation-flat-field-metadatas-target-flat-field-metadata-or-throw.util";
+import { isFlatFieldMetadataEntityOfType } from "src/engine/metadata-modules/flat-field-metadata/utils/is-flat-field-metadata-of-type.util";
+import { FlatObjectMetadataMaps } from "src/engine/metadata-modules/flat-object-metadata-maps/types/flat-object-metadata-maps.type";
+import { FieldMetadataType } from "twenty-shared/types";
+
+export const computeFlatFieldMetadataRelatedFlatFieldMetadata = ({
+  flatFieldMetadata,
+  flatObjectMetadataMaps,
+}: {
+  flatFieldMetadata: FlatFieldMetadata;
+  flatObjectMetadataMaps: FlatObjectMetadataMaps;
+}): FlatFieldMetadata[] => {
+  if (
+    isFlatFieldMetadataEntityOfType(
+      flatFieldMetadata,
+      FieldMetadataType.RELATION,
+    )
+  ) {
+    return [
+      findRelationFlatFieldMetadataTargetFlatFieldMetadataOrThrow({
+        flatFieldMetadata,
+        flatObjectMetadataMaps,
+      }),
+    ];
+  }
+
+  if (
+    isFlatFieldMetadataEntityOfType(
+      flatFieldMetadata,
+      FieldMetadataType.MORPH_RELATION,
+    )
+  ) {
+    return findFlatFieldMetadatasRelatedToMorphRelationOrThrow({
+      flatFieldMetadata,
+      flatObjectMetadataMaps,
+    });
+  }
+
+  return [];
+};

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/compute-flat-field-metadata-related-flat-field-metadata.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/compute-flat-field-metadata-related-flat-field-metadata.util.ts
@@ -1,9 +1,10 @@
-import { FlatFieldMetadata } from "src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type";
-import { findFlatFieldMetadatasRelatedToMorphRelationOrThrow } from "src/engine/metadata-modules/flat-field-metadata/utils/find-flat-field-metadatas-related-to-morph-relation-or-throw.util";
-import { findRelationFlatFieldMetadataTargetFlatFieldMetadataOrThrow } from "src/engine/metadata-modules/flat-field-metadata/utils/find-relation-flat-field-metadatas-target-flat-field-metadata-or-throw.util";
-import { isFlatFieldMetadataEntityOfType } from "src/engine/metadata-modules/flat-field-metadata/utils/is-flat-field-metadata-of-type.util";
-import { FlatObjectMetadataMaps } from "src/engine/metadata-modules/flat-object-metadata-maps/types/flat-object-metadata-maps.type";
-import { FieldMetadataType } from "twenty-shared/types";
+import { FieldMetadataType } from 'twenty-shared/types';
+
+import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { findFlatFieldMetadatasRelatedToMorphRelationOrThrow } from 'src/engine/metadata-modules/flat-field-metadata/utils/find-flat-field-metadatas-related-to-morph-relation-or-throw.util';
+import { findRelationFlatFieldMetadataTargetFlatFieldMetadataOrThrow } from 'src/engine/metadata-modules/flat-field-metadata/utils/find-relation-flat-field-metadatas-target-flat-field-metadata-or-throw.util';
+import { isFlatFieldMetadataEntityOfType } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-flat-field-metadata-of-type.util';
+import { type FlatObjectMetadataMaps } from 'src/engine/metadata-modules/flat-object-metadata-maps/types/flat-object-metadata-maps.type';
 
 export const computeFlatFieldMetadataRelatedFlatFieldMetadata = ({
   flatFieldMetadata,

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/find-flat-field-metadatas-related-to-morph-relation-or-throw.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/find-flat-field-metadatas-related-to-morph-relation-or-throw.util.ts
@@ -62,6 +62,10 @@ export const findFlatFieldMetadatasRelatedToMorphRelationOrThrow = ({
           flatObjectMetadataMaps,
         });
 
+      if (flatFieldMetadata.id === morphRelationFlatFieldMetadata.id) {
+        return [relationTargetFlatFieldMetadata];
+      }
+
       return [flatFieldMetadata, relationTargetFlatFieldMetadata];
     },
   );

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/from-delete-field-input-to-flat-field-metadatas-to-delete.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/from-delete-field-input-to-flat-field-metadatas-to-delete.util.ts
@@ -1,4 +1,3 @@
-import { FieldMetadataType } from 'twenty-shared/types';
 import {
   isDefined,
   trimAndRemoveDuplicatedWhitespacesFromObjectStringProperties,
@@ -10,9 +9,7 @@ import {
   FieldMetadataExceptionCode,
 } from 'src/engine/metadata-modules/field-metadata/field-metadata.exception';
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
-import { findFlatFieldMetadatasRelatedToMorphRelationOrThrow } from 'src/engine/metadata-modules/flat-field-metadata/utils/find-flat-field-metadatas-related-to-morph-relation-or-throw.util';
-import { findRelationFlatFieldMetadataTargetFlatFieldMetadataOrThrow } from 'src/engine/metadata-modules/flat-field-metadata/utils/find-relation-flat-field-metadatas-target-flat-field-metadata-or-throw.util';
-import { isFlatFieldMetadataEntityOfType } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-flat-field-metadata-of-type.util';
+import { computeFlatFieldMetadataRelatedFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/compute-flat-field-metadata-related-flat-field-metadata.util';
 import { type FlatObjectMetadataMaps } from 'src/engine/metadata-modules/flat-object-metadata-maps/types/flat-object-metadata-maps.type';
 import { findFlatFieldMetadataInFlatObjectMetadataMapsWithOnlyFieldId } from 'src/engine/metadata-modules/flat-object-metadata-maps/utils/find-flat-field-metadata-in-flat-object-metadata-maps-with-field-id-only.util';
 
@@ -43,32 +40,11 @@ export const fromDeleteFieldInputToFlatFieldMetadatasToDelete = ({
     );
   }
 
-  if (
-    isFlatFieldMetadataEntityOfType(
-      flatFieldMetadataToDelete,
-      FieldMetadataType.MORPH_RELATION,
-    )
-  ) {
-    return findFlatFieldMetadatasRelatedToMorphRelationOrThrow({
-      flatObjectMetadataMaps: existingFlatObjectMetadataMaps,
+  const relatedFlatFieldMetadataToDelete =
+    computeFlatFieldMetadataRelatedFlatFieldMetadata({
       flatFieldMetadata: flatFieldMetadataToDelete,
+      flatObjectMetadataMaps: existingFlatObjectMetadataMaps,
     });
-  }
 
-  if (
-    isFlatFieldMetadataEntityOfType(
-      flatFieldMetadataToDelete,
-      FieldMetadataType.RELATION,
-    )
-  ) {
-    const relationTargetFlatFieldMetadata =
-      findRelationFlatFieldMetadataTargetFlatFieldMetadataOrThrow({
-        flatObjectMetadataMaps: existingFlatObjectMetadataMaps,
-        flatFieldMetadata: flatFieldMetadataToDelete,
-      });
-
-    return [flatFieldMetadataToDelete, relationTargetFlatFieldMetadata];
-  }
-
-  return [flatFieldMetadataToDelete];
+  return [flatFieldMetadataToDelete, ...relatedFlatFieldMetadataToDelete];
 };

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/from-update-field-input-to-flat-field-metadata.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/from-update-field-input-to-flat-field-metadata.util.ts
@@ -13,7 +13,7 @@ import { FLAT_FIELD_METADATA_PROPERTIES_TO_COMPARE } from 'src/engine/metadata-m
 import { type FieldInputTranspilationResult } from 'src/engine/metadata-modules/flat-field-metadata/types/field-input-transpilation-result.type';
 import { type FlatFieldMetadataPropertiesToCompare } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata-properties-to-compare.type';
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
-import {} from 'src/engine/metadata-modules/flat-field-metadata/utils/compare-two-flat-field-metadata.util';
+import { } from 'src/engine/metadata-modules/flat-field-metadata/utils/compare-two-flat-field-metadata.util';
 import { computeFlatFieldMetadataRelatedFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/compute-flat-field-metadata-related-flat-field-metadata.util';
 import { type FlatObjectMetadataMaps } from 'src/engine/metadata-modules/flat-object-metadata-maps/types/flat-object-metadata-maps.type';
 import { findFlatFieldMetadataInFlatObjectMetadataMapsWithOnlyFieldId } from 'src/engine/metadata-modules/flat-object-metadata-maps/utils/find-flat-field-metadata-in-flat-object-metadata-maps-with-field-id-only.util';
@@ -173,7 +173,7 @@ export const fromUpdateFieldInputToFlatFieldMetadata = ({
     };
   }
 
-  const relatedFlatFieldMetadatasToUdpate =
+  const relatedFlatFieldMetadatasToUpdate =
     computeFlatFieldMetadataRelatedFlatFieldMetadata({
       flatFieldMetadata: existingFlatFieldMetadataToUpdate,
       flatObjectMetadataMaps: existingFlatObjectMetadataMaps,
@@ -181,7 +181,7 @@ export const fromUpdateFieldInputToFlatFieldMetadata = ({
 
   const flatFieldMetadatasToUpdate = [
     existingFlatFieldMetadataToUpdate,
-    ...relatedFlatFieldMetadatasToUdpate,
+    ...relatedFlatFieldMetadatasToUpdate,
   ];
 
   const optimisticiallyUpdatedFlatFieldMetadatas =

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/from-update-field-input-to-flat-field-metadata.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/from-update-field-input-to-flat-field-metadata.util.ts
@@ -13,7 +13,6 @@ import { FLAT_FIELD_METADATA_PROPERTIES_TO_COMPARE } from 'src/engine/metadata-m
 import { type FieldInputTranspilationResult } from 'src/engine/metadata-modules/flat-field-metadata/types/field-input-transpilation-result.type';
 import { type FlatFieldMetadataPropertiesToCompare } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata-properties-to-compare.type';
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
-import { } from 'src/engine/metadata-modules/flat-field-metadata/utils/compare-two-flat-field-metadata.util';
 import { computeFlatFieldMetadataRelatedFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/compute-flat-field-metadata-related-flat-field-metadata.util';
 import { type FlatObjectMetadataMaps } from 'src/engine/metadata-modules/flat-object-metadata-maps/types/flat-object-metadata-maps.type';
 import { findFlatFieldMetadataInFlatObjectMetadataMapsWithOnlyFieldId } from 'src/engine/metadata-modules/flat-object-metadata-maps/utils/find-flat-field-metadata-in-flat-object-metadata-maps-with-field-id-only.util';

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/from-update-field-input-to-flat-field-metadata.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/from-update-field-input-to-flat-field-metadata.util.ts
@@ -13,9 +13,9 @@ import { FLAT_FIELD_METADATA_PROPERTIES_TO_COMPARE } from 'src/engine/metadata-m
 import { type FieldInputTranspilationResult } from 'src/engine/metadata-modules/flat-field-metadata/types/field-input-transpilation-result.type';
 import { type FlatFieldMetadataPropertiesToCompare } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata-properties-to-compare.type';
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
-import { } from 'src/engine/metadata-modules/flat-field-metadata/utils/compare-two-flat-field-metadata.util';
+import {} from 'src/engine/metadata-modules/flat-field-metadata/utils/compare-two-flat-field-metadata.util';
 import { computeFlatFieldMetadataRelatedFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/compute-flat-field-metadata-related-flat-field-metadata.util';
-import { FlatObjectMetadataMaps } from 'src/engine/metadata-modules/flat-object-metadata-maps/types/flat-object-metadata-maps.type';
+import { type FlatObjectMetadataMaps } from 'src/engine/metadata-modules/flat-object-metadata-maps/types/flat-object-metadata-maps.type';
 import { findFlatFieldMetadataInFlatObjectMetadataMapsWithOnlyFieldId } from 'src/engine/metadata-modules/flat-object-metadata-maps/utils/find-flat-field-metadata-in-flat-object-metadata-maps-with-field-id-only.util';
 import { fromFlatObjectMetadataWithFlatFieldMapsToFlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/utils/from-flat-object-metadata-with-flat-field-maps-to-flat-object-metadatas.util';
 import { isStandardMetadata } from 'src/engine/metadata-modules/utils/is-standard-metadata.util';

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-flat-field-metadata-name-availability.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-flat-field-metadata-name-availability.util.ts
@@ -57,18 +57,18 @@ export const validateFlatFieldMetadataNameAvailability = ({
   ) {
     errors.push({
       code: FieldMetadataExceptionCode.NOT_AVAILABLE,
-      value: name,
-      message: `Name "${name}" is not available as it is already used by another field`,
-      userFriendlyMessage: t`Name "${name}" is not available as it is already used by another field`,
+      value: flatFieldMetadata.name,
+      message: `Name "${flatFieldMetadata.name}" is not available as it is already used by another field`,
+      userFriendlyMessage: t`Name "${flatFieldMetadata.name}" is not available as it is already used by another field`,
     });
   }
 
   if (reservedCompositeFieldsNames.includes(flatFieldMetadata.name)) {
     errors.push({
       code: FieldMetadataExceptionCode.RESERVED_KEYWORD,
-      message: `Name "${name}" is reserved composite field name`,
-      value: name,
-      userFriendlyMessage: t`Name "${name}" is not available`,
+      message: `Name "${flatFieldMetadata.name}" is reserved composite field name`,
+      value: flatFieldMetadata.name,
+      userFriendlyMessage: t`Name "${flatFieldMetadata.name}" is not available`,
     });
   }
 

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-flat-field-metadata-name-availability.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-flat-field-metadata-name-availability.util.ts
@@ -6,7 +6,7 @@ import { FieldMetadataExceptionCode } from 'src/engine/metadata-modules/field-me
 import { computeCompositeColumnName } from 'src/engine/metadata-modules/field-metadata/utils/compute-column-name.util';
 import { isCompositeFieldMetadataType } from 'src/engine/metadata-modules/field-metadata/utils/is-composite-field-metadata-type.util';
 import { type FlatFieldMetadataValidationError } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata-validation-error.type';
-import { FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
 import { isMorphOrRelationFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-morph-or-relation-flat-field-metadata.util';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 import { isMorphOrRelationFieldMetadataType } from 'src/engine/utils/is-morph-or-relation-field-metadata-type.util';

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-flat-field-metadata-name-availability.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-flat-field-metadata-name-availability.util.ts
@@ -46,29 +46,31 @@ export const validateFlatFieldMetadataNameAvailability = ({
   const reservedCompositeFieldsNames =
     getReservedCompositeFieldNames(flatObjectMetadata);
 
+  const flatFieldMetadataName = flatFieldMetadata.name;
+
   if (
     !isMorphOrRelationFlatFieldMetadata(flatFieldMetadata) &&
     flatObjectMetadata.flatFieldMetadatas.some(
       (field) =>
-        field.name === flatFieldMetadata.name ||
+        field.name === flatFieldMetadataName ||
         (isMorphOrRelationFieldMetadataType(field.type) &&
-          `${field.name}Id` === flatFieldMetadata.name),
+          `${field.name}Id` === flatFieldMetadataName),
     )
   ) {
     errors.push({
       code: FieldMetadataExceptionCode.NOT_AVAILABLE,
-      value: flatFieldMetadata.name,
-      message: `Name "${flatFieldMetadata.name}" is not available as it is already used by another field`,
-      userFriendlyMessage: t`Name "${flatFieldMetadata.name}" is not available as it is already used by another field`,
+      value: flatFieldMetadataName,
+      message: `Name "${flatFieldMetadataName}" is not available as it is already used by another field`,
+      userFriendlyMessage: t`Name "${flatFieldMetadataName}" is not available as it is already used by another field`,
     });
   }
 
-  if (reservedCompositeFieldsNames.includes(flatFieldMetadata.name)) {
+  if (reservedCompositeFieldsNames.includes(flatFieldMetadataName)) {
     errors.push({
       code: FieldMetadataExceptionCode.RESERVED_KEYWORD,
-      message: `Name "${flatFieldMetadata.name}" is reserved composite field name`,
-      value: flatFieldMetadata.name,
-      userFriendlyMessage: t`Name "${flatFieldMetadata.name}" is not available`,
+      message: `Name "${flatFieldMetadataName}" is reserved composite field name`,
+      value: flatFieldMetadataName,
+      userFriendlyMessage: t`Name "${flatFieldMetadataName}" is not available`,
     });
   }
 

--- a/packages/twenty-server/src/engine/metadata-modules/flat-object-metadata/utils/from-delete-object-input-to-flat-field-metadatas-to-delete.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-object-metadata/utils/from-delete-object-input-to-flat-field-metadatas-to-delete.util.ts
@@ -51,6 +51,7 @@ export const fromDeleteObjectInputToFlatFieldMetadatasToDelete = ({
             flatFieldMetadata,
             flatObjectMetadataMaps: existingFlatObjectMetadataMaps,
           });
+
         return [flatFieldMetadata, ...relatedFlatFieldMetadata];
       },
     );

--- a/packages/twenty-server/src/engine/metadata-modules/flat-object-metadata/utils/from-delete-object-input-to-flat-field-metadatas-to-delete.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-object-metadata/utils/from-delete-object-input-to-flat-field-metadatas-to-delete.util.ts
@@ -1,12 +1,10 @@
-import { FieldMetadataType } from 'twenty-shared/types';
 import {
   isDefined,
   trimAndRemoveDuplicatedWhitespacesFromObjectStringProperties,
 } from 'twenty-shared/utils';
 
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
-import { findRelationFlatFieldMetadataTargetFlatFieldMetadataOrThrow } from 'src/engine/metadata-modules/flat-field-metadata/utils/find-relation-flat-field-metadatas-target-flat-field-metadata-or-throw.util';
-import { isFlatFieldMetadataEntityOfType } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-flat-field-metadata-of-type.util';
+import { computeFlatFieldMetadataRelatedFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/compute-flat-field-metadata-related-flat-field-metadata.util';
 import { type FlatObjectMetadataMaps } from 'src/engine/metadata-modules/flat-object-metadata-maps/types/flat-object-metadata-maps.type';
 import { findFlatObjectMetadataInFlatObjectMetadataMaps } from 'src/engine/metadata-modules/flat-object-metadata-maps/utils/find-flat-object-metadata-in-flat-object-metadata-maps.util';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
@@ -48,26 +46,12 @@ export const fromDeleteObjectInputToFlatFieldMetadatasToDelete = ({
   const flatFieldMetadatasToDelete =
     flatObjectMetadataToDelete.flatFieldMetadatas.flatMap(
       (flatFieldMetadata) => {
-        if (
-          isFlatFieldMetadataEntityOfType(
+        const relatedFlatFieldMetadata =
+          computeFlatFieldMetadataRelatedFlatFieldMetadata({
             flatFieldMetadata,
-            FieldMetadataType.RELATION,
-          ) ||
-          isFlatFieldMetadataEntityOfType(
-            flatFieldMetadata,
-            FieldMetadataType.MORPH_RELATION,
-          )
-        ) {
-          const relationTargetFlatFieldMetadata =
-            findRelationFlatFieldMetadataTargetFlatFieldMetadataOrThrow({
-              flatObjectMetadataMaps: existingFlatObjectMetadataMaps,
-              flatFieldMetadata,
-            });
-
-          return [flatFieldMetadata, relationTargetFlatFieldMetadata];
-        }
-
-        return flatFieldMetadata;
+            flatObjectMetadataMaps: existingFlatObjectMetadataMaps,
+          });
+        return [flatFieldMetadata, ...relatedFlatFieldMetadata];
       },
     );
 

--- a/packages/twenty-server/test/integration/metadata/suites/field-metadata/morph-relation/successful-create-one-field-metadata-morph-relation-v2.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/field-metadata/morph-relation/successful-create-one-field-metadata-morph-relation-v2.integration-spec.ts
@@ -1,0 +1,288 @@
+import { deleteOneObjectMetadata } from 'test/integration/metadata/suites/object-metadata/utils/delete-one-object-metadata.util';
+import {
+  eachTestingContextFilter,
+  type EachTestingContext,
+} from 'twenty-shared/testing';
+import { FieldMetadataType } from 'twenty-shared/types';
+
+import { FeatureFlagKey } from 'src/engine/core-modules/feature-flag/enums/feature-flag-key.enum';
+import { CreateFieldInput } from 'src/engine/metadata-modules/field-metadata/dtos/create-field.input';
+import { FieldMetadataDTO } from 'src/engine/metadata-modules/field-metadata/dtos/field-metadata.dto';
+import { RelationDTO } from 'src/engine/metadata-modules/field-metadata/dtos/relation.dto';
+import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
+import { SEED_APPLE_WORKSPACE_ID } from 'src/engine/workspace-manager/dev-seeder/core/utils/seed-workspaces.util';
+import { createOneFieldMetadata } from 'test/integration/metadata/suites/field-metadata/utils/create-one-field-metadata.util';
+import { deleteOneFieldMetadata } from 'test/integration/metadata/suites/field-metadata/utils/delete-one-field-metadata.util';
+import { updateOneFieldMetadata } from 'test/integration/metadata/suites/field-metadata/utils/update-one-field-metadata.util';
+import { forceCreateOneObjectMetadata } from 'test/integration/metadata/suites/object-metadata/utils/force-create-one-object-metadata.util';
+import { updateOneObjectMetadata } from 'test/integration/metadata/suites/object-metadata/utils/update-one-object-metadata.util';
+import { updateFeatureFlag } from 'test/integration/metadata/suites/utils/update-feature-flag.util';
+import { isDefined } from 'twenty-shared/utils';
+
+describe('createOne FieldMetadataService morph relation fields', () => {
+  let createdObjectMetadataPersonId: string;
+  let createdObjectMetadataOpportunityId: string;
+  let createdObjectMetadataCompanyId: string;
+  let createdFieldMetadataId: string | undefined = undefined;
+
+  beforeAll(async () => {
+    await updateFeatureFlag({
+      expectToFail: false,
+      featureFlag: FeatureFlagKey.IS_WORKSPACE_MIGRATION_V2_ENABLED,
+      value: true,
+      workspaceId: SEED_APPLE_WORKSPACE_ID,
+    });
+
+    const {
+      data: {
+        createOneObject: { id: objectMetadataPersonId },
+      },
+    } = await forceCreateOneObjectMetadata({
+      input: {
+        nameSingular: 'personForMorphRelationSecond',
+        namePlural: 'peopleForMorphRelationSecond',
+        labelSingular: 'Person For Morph Relation',
+        labelPlural: 'People For Morph Relation',
+        icon: 'IconPerson',
+      },
+    });
+
+    createdObjectMetadataPersonId = objectMetadataPersonId;
+
+    const {
+      data: {
+        createOneObject: { id: objectMetadataCompanyId },
+      },
+    } = await forceCreateOneObjectMetadata({
+      input: {
+        nameSingular: 'companyForMorphRelationSecond',
+        namePlural: 'companiesForMorphRelationSecond',
+        labelSingular: 'Company For Morph Relation',
+        labelPlural: 'Companies For Morph Relation',
+        icon: 'IconCompany',
+      },
+    });
+
+    createdObjectMetadataCompanyId = objectMetadataCompanyId;
+
+    const {
+      data: {
+        createOneObject: { id: objectMetadataOpportunityId },
+      },
+    } = await forceCreateOneObjectMetadata({
+      input: {
+        nameSingular: 'opportunityForMorphRelationSecond',
+        namePlural: 'opportunitiesForMorphRelationSecond',
+        labelSingular: 'Opportunity For Morph Relation',
+        labelPlural: 'Opportunities For Morph Relation',
+        icon: 'IconOpportunity',
+      },
+    });
+    createdObjectMetadataOpportunityId = objectMetadataOpportunityId;
+  });
+
+  afterAll(async () => {
+    await Promise.all(
+      [
+        createdObjectMetadataPersonId,
+        createdObjectMetadataOpportunityId,
+        createdObjectMetadataCompanyId,
+      ].map(
+        async (objectMetadataId) =>
+          await updateOneObjectMetadata({
+            expectToFail: false,
+            input: {
+              idToUpdate: objectMetadataId,
+              updatePayload: { isActive: false },
+            },
+          }),
+      ),
+    );
+
+    await Promise.all(
+      [
+        createdObjectMetadataPersonId,
+        createdObjectMetadataOpportunityId,
+        createdObjectMetadataCompanyId,
+      ].map(
+        async (objectMetadataId) =>
+          await deleteOneObjectMetadata({
+            expectToFail: false,
+            input: { idToDelete: objectMetadataId },
+          }),
+      ),
+    );
+
+    await updateFeatureFlag({
+      expectToFail: false,
+      featureFlag: FeatureFlagKey.IS_WORKSPACE_MIGRATION_V2_ENABLED,
+      value: false,
+      workspaceId: SEED_APPLE_WORKSPACE_ID,
+    });
+  });
+
+  afterEach(async () => {
+    if (!isDefined(createdFieldMetadataId)) {
+      return;
+    }
+
+    await updateOneFieldMetadata({
+      input: {
+        idToUpdate: createdFieldMetadataId,
+        updatePayload: {
+          isActive: false,
+        },
+      },
+      expectToFail: false,
+    });
+
+    await deleteOneFieldMetadata({
+      input: {
+        idToDelete: createdFieldMetadataId,
+      },
+      expectToFail: false,
+    });
+
+    createdFieldMetadataId = undefined;
+  });
+
+  type EachTestingContextArray = EachTestingContext<
+    (args: {
+      createdObjectMetadataPersonId: string;
+      createdObjectMetadataOpportunityId: string;
+      createdObjectMetadataCompanyId: string;
+    }) => Omit<
+      CreateFieldInput,
+      'morphRelationsCreationPayload' | 'workspaceId'
+    > &
+      Required<Pick<CreateFieldInput, 'morphRelationsCreationPayload'>>
+  >[];
+
+  const eachTestingContextArray: EachTestingContextArray = [
+    {
+      title: 'should create a MORPH_RELATION field type MANY_TO_ONE',
+      context: ({
+        createdObjectMetadataCompanyId,
+        createdObjectMetadataOpportunityId,
+        createdObjectMetadataPersonId,
+      }) => ({
+        label: 'field label',
+        name: 'fieldName',
+        objectMetadataId: createdObjectMetadataCompanyId,
+        type: FieldMetadataType.MORPH_RELATION,
+        morphRelationsCreationPayload: [
+          {
+            targetFieldIcon: 'Icon123',
+            targetFieldLabel: 'toto',
+            targetObjectMetadataId: createdObjectMetadataOpportunityId,
+            type: RelationType.MANY_TO_ONE,
+          },
+          {
+            targetFieldIcon: 'Icon123',
+            targetFieldLabel: 'tata',
+            targetObjectMetadataId: createdObjectMetadataPersonId,
+            type: RelationType.MANY_TO_ONE,
+          },
+        ],
+      }),
+    },
+    {
+      title: 'should create a MORPH_RELATION field type ONE_TO_MANY',
+      context: ({
+        createdObjectMetadataCompanyId,
+        createdObjectMetadataOpportunityId,
+        createdObjectMetadataPersonId,
+      }) => ({
+        label: 'field label',
+        name: 'fieldName',
+        objectMetadataId: createdObjectMetadataCompanyId,
+        type: FieldMetadataType.MORPH_RELATION,
+        morphRelationsCreationPayload: [
+          {
+            targetFieldIcon: 'Icon123',
+            targetFieldLabel: 'toto',
+            targetObjectMetadataId: createdObjectMetadataOpportunityId,
+            type: RelationType.ONE_TO_MANY,
+          },
+          {
+            targetFieldIcon: 'Icon123',
+            targetFieldLabel: 'tata',
+            targetObjectMetadataId: createdObjectMetadataPersonId,
+            type: RelationType.ONE_TO_MANY,
+          },
+        ],
+      }),
+    },
+  ];
+
+  it.each(eachTestingContextFilter(eachTestingContextArray))(
+    '$title',
+    async ({ context }) => {
+      const contextPayload = context({
+        createdObjectMetadataOpportunityId,
+        createdObjectMetadataPersonId,
+        createdObjectMetadataCompanyId,
+      });
+
+      const {
+        data: { createOneField: rawCreateOneField },
+      } = await createOneFieldMetadata({
+        input: contextPayload,
+        expectToFail: false,
+        gqlFields: `
+            id
+            name
+            label
+            isLabelSyncedWithName
+            settings
+            object {
+              id
+              nameSingular
+            }
+            morphRelations {
+              type
+              targetFieldMetadata {
+                id
+              }
+              targetObjectMetadata {
+                id
+              }
+              sourceFieldMetadata {
+                id
+              }
+              sourceObjectMetadata {
+                id
+              }
+            }
+          `,
+      });
+      const createOneField = rawCreateOneField as FieldMetadataDTO & {
+        morphRelations: RelationDTO[];
+      };
+      createdFieldMetadataId = createOneField.id;
+
+      const expectedMorphRelations =
+        contextPayload.morphRelationsCreationPayload.map(
+          ({ targetObjectMetadataId, type }) => ({
+            sourceFieldMetadata: {
+              id: expect.any(String),
+            },
+            sourceObjectMetadata: {
+              id: contextPayload.objectMetadataId,
+            },
+            targetFieldMetadata: {
+              id: expect.any(String),
+            },
+            targetObjectMetadata: {
+              id: targetObjectMetadataId,
+            },
+            type,
+          }),
+        );
+
+      expect(createOneField.morphRelations).toMatchObject(
+        expectedMorphRelations,
+      );
+    },
+  );
+});

--- a/packages/twenty-server/test/integration/metadata/suites/field-metadata/morph-relation/successful-create-one-field-metadata-morph-relation-v2.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/field-metadata/morph-relation/successful-create-one-field-metadata-morph-relation-v2.integration-spec.ts
@@ -1,24 +1,24 @@
+import { createOneFieldMetadata } from 'test/integration/metadata/suites/field-metadata/utils/create-one-field-metadata.util';
+import { deleteOneFieldMetadata } from 'test/integration/metadata/suites/field-metadata/utils/delete-one-field-metadata.util';
+import { updateOneFieldMetadata } from 'test/integration/metadata/suites/field-metadata/utils/update-one-field-metadata.util';
 import { deleteOneObjectMetadata } from 'test/integration/metadata/suites/object-metadata/utils/delete-one-object-metadata.util';
+import { updateOneObjectMetadata } from 'test/integration/metadata/suites/object-metadata/utils/update-one-object-metadata.util';
+import { updateFeatureFlag } from 'test/integration/metadata/suites/utils/update-feature-flag.util';
 import {
   eachTestingContextFilter,
   type EachTestingContext,
 } from 'twenty-shared/testing';
 import { FieldMetadataType } from 'twenty-shared/types';
-import { createOneFieldMetadata } from 'test/integration/metadata/suites/field-metadata/utils/create-one-field-metadata.util';
-import { deleteOneFieldMetadata } from 'test/integration/metadata/suites/field-metadata/utils/delete-one-field-metadata.util';
-import { updateOneFieldMetadata } from 'test/integration/metadata/suites/field-metadata/utils/update-one-field-metadata.util';
-import { forceCreateOneObjectMetadata } from 'test/integration/metadata/suites/object-metadata/utils/force-create-one-object-metadata.util';
-import { updateOneObjectMetadata } from 'test/integration/metadata/suites/object-metadata/utils/update-one-object-metadata.util';
-import { updateFeatureFlag } from 'test/integration/metadata/suites/utils/update-feature-flag.util';
 import { isDefined } from 'twenty-shared/utils';
+import { createOneObjectMetadata } from 'test/integration/metadata/suites/object-metadata/utils/create-one-object-metadata.util';
 
 import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
 
-import { SEED_APPLE_WORKSPACE_ID } from 'src/engine/workspace-manager/dev-seeder/core/utils/seed-workspaces.util';
-import { type RelationDTO } from 'src/engine/metadata-modules/field-metadata/dtos/relation.dto';
-import { type FieldMetadataDTO } from 'src/engine/metadata-modules/field-metadata/dtos/field-metadata.dto';
-import { type CreateFieldInput } from 'src/engine/metadata-modules/field-metadata/dtos/create-field.input';
 import { FeatureFlagKey } from 'src/engine/core-modules/feature-flag/enums/feature-flag-key.enum';
+import { type CreateFieldInput } from 'src/engine/metadata-modules/field-metadata/dtos/create-field.input';
+import { type FieldMetadataDTO } from 'src/engine/metadata-modules/field-metadata/dtos/field-metadata.dto';
+import { type RelationDTO } from 'src/engine/metadata-modules/field-metadata/dtos/relation.dto';
+import { SEED_APPLE_WORKSPACE_ID } from 'src/engine/workspace-manager/dev-seeder/core/utils/seed-workspaces.util';
 
 describe('createOne FieldMetadataService morph relation fields', () => {
   let createdObjectMetadataPersonId: string;
@@ -38,7 +38,8 @@ describe('createOne FieldMetadataService morph relation fields', () => {
       data: {
         createOneObject: { id: objectMetadataPersonId },
       },
-    } = await forceCreateOneObjectMetadata({
+    } = await createOneObjectMetadata({
+      expectToFail: false,
       input: {
         nameSingular: 'personForMorphRelationSecond',
         namePlural: 'peopleForMorphRelationSecond',
@@ -54,7 +55,8 @@ describe('createOne FieldMetadataService morph relation fields', () => {
       data: {
         createOneObject: { id: objectMetadataCompanyId },
       },
-    } = await forceCreateOneObjectMetadata({
+    } = await createOneObjectMetadata({
+      expectToFail: false,
       input: {
         nameSingular: 'companyForMorphRelationSecond',
         namePlural: 'companiesForMorphRelationSecond',
@@ -70,7 +72,8 @@ describe('createOne FieldMetadataService morph relation fields', () => {
       data: {
         createOneObject: { id: objectMetadataOpportunityId },
       },
-    } = await forceCreateOneObjectMetadata({
+    } = await createOneObjectMetadata({
+      expectToFail: false,
       input: {
         nameSingular: 'opportunityForMorphRelationSecond',
         namePlural: 'opportunitiesForMorphRelationSecond',

--- a/packages/twenty-server/test/integration/metadata/suites/field-metadata/morph-relation/successful-create-one-field-metadata-morph-relation-v2.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/field-metadata/morph-relation/successful-create-one-field-metadata-morph-relation-v2.integration-spec.ts
@@ -4,13 +4,6 @@ import {
   type EachTestingContext,
 } from 'twenty-shared/testing';
 import { FieldMetadataType } from 'twenty-shared/types';
-
-import { FeatureFlagKey } from 'src/engine/core-modules/feature-flag/enums/feature-flag-key.enum';
-import { CreateFieldInput } from 'src/engine/metadata-modules/field-metadata/dtos/create-field.input';
-import { FieldMetadataDTO } from 'src/engine/metadata-modules/field-metadata/dtos/field-metadata.dto';
-import { RelationDTO } from 'src/engine/metadata-modules/field-metadata/dtos/relation.dto';
-import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
-import { SEED_APPLE_WORKSPACE_ID } from 'src/engine/workspace-manager/dev-seeder/core/utils/seed-workspaces.util';
 import { createOneFieldMetadata } from 'test/integration/metadata/suites/field-metadata/utils/create-one-field-metadata.util';
 import { deleteOneFieldMetadata } from 'test/integration/metadata/suites/field-metadata/utils/delete-one-field-metadata.util';
 import { updateOneFieldMetadata } from 'test/integration/metadata/suites/field-metadata/utils/update-one-field-metadata.util';
@@ -18,6 +11,14 @@ import { forceCreateOneObjectMetadata } from 'test/integration/metadata/suites/o
 import { updateOneObjectMetadata } from 'test/integration/metadata/suites/object-metadata/utils/update-one-object-metadata.util';
 import { updateFeatureFlag } from 'test/integration/metadata/suites/utils/update-feature-flag.util';
 import { isDefined } from 'twenty-shared/utils';
+
+import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
+
+import { SEED_APPLE_WORKSPACE_ID } from 'src/engine/workspace-manager/dev-seeder/core/utils/seed-workspaces.util';
+import { type RelationDTO } from 'src/engine/metadata-modules/field-metadata/dtos/relation.dto';
+import { type FieldMetadataDTO } from 'src/engine/metadata-modules/field-metadata/dtos/field-metadata.dto';
+import { type CreateFieldInput } from 'src/engine/metadata-modules/field-metadata/dtos/create-field.input';
+import { FeatureFlagKey } from 'src/engine/core-modules/feature-flag/enums/feature-flag-key.enum';
 
 describe('createOne FieldMetadataService morph relation fields', () => {
   let createdObjectMetadataPersonId: string;
@@ -78,6 +79,7 @@ describe('createOne FieldMetadataService morph relation fields', () => {
         icon: 'IconOpportunity',
       },
     });
+
     createdObjectMetadataOpportunityId = objectMetadataOpportunityId;
   });
 
@@ -259,6 +261,7 @@ describe('createOne FieldMetadataService morph relation fields', () => {
       const createOneField = rawCreateOneField as FieldMetadataDTO & {
         morphRelations: RelationDTO[];
       };
+
       createdFieldMetadataId = createOneField.id;
 
       const expectedMorphRelations =

--- a/packages/twenty-server/test/integration/metadata/suites/field-metadata/morph-relation/successful-update-one-field-metadata-morph-relation-v2.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/field-metadata/morph-relation/successful-update-one-field-metadata-morph-relation-v2.integration-spec.ts
@@ -1,0 +1,183 @@
+import { createOneFieldMetadata } from 'test/integration/metadata/suites/field-metadata/utils/create-one-field-metadata.util';
+import { deleteOneFieldMetadata } from 'test/integration/metadata/suites/field-metadata/utils/delete-one-field-metadata.util';
+import { updateOneFieldMetadata } from 'test/integration/metadata/suites/field-metadata/utils/update-one-field-metadata.util';
+import { deleteOneObjectMetadata } from 'test/integration/metadata/suites/object-metadata/utils/delete-one-object-metadata.util';
+import { updateOneObjectMetadata } from 'test/integration/metadata/suites/object-metadata/utils/update-one-object-metadata.util';
+import { updateFeatureFlag } from 'test/integration/metadata/suites/utils/update-feature-flag.util';
+import { FieldMetadataType } from 'twenty-shared/types';
+import { createOneObjectMetadata } from 'test/integration/metadata/suites/object-metadata/utils/create-one-object-metadata.util';
+
+import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
+
+import { FeatureFlagKey } from 'src/engine/core-modules/feature-flag/enums/feature-flag-key.enum';
+import { SEED_APPLE_WORKSPACE_ID } from 'src/engine/workspace-manager/dev-seeder/core/utils/seed-workspaces.util';
+
+describe('updateOne FieldMetadataService morph relation fields v2', () => {
+  let createdObjectMetadataPersonId: string;
+  let createdObjectMetadataOpportunityId: string;
+  let createdObjectMetadataCompanyId: string;
+  let createdFieldMetadataId: string;
+
+  beforeAll(async () => {
+    await updateFeatureFlag({
+      expectToFail: false,
+      featureFlag: FeatureFlagKey.IS_WORKSPACE_MIGRATION_V2_ENABLED,
+      value: true,
+      workspaceId: SEED_APPLE_WORKSPACE_ID,
+    });
+
+    const {
+      data: {
+        createOneObject: { id: objectMetadataPersonId },
+      },
+    } = await createOneObjectMetadata({
+      expectToFail: false,
+      input: {
+        nameSingular: 'personForMorphRelationSecond',
+        namePlural: 'peopleForMorphRelationSecond',
+        labelSingular: 'Person For Morph Relation',
+        labelPlural: 'People For Morph Relation',
+        icon: 'IconPerson',
+      },
+    });
+
+    createdObjectMetadataPersonId = objectMetadataPersonId;
+
+    const {
+      data: {
+        createOneObject: { id: objectMetadataCompanyId },
+      },
+    } = await createOneObjectMetadata({
+      expectToFail: false,
+      input: {
+        nameSingular: 'companyForMorphRelationSecond',
+        namePlural: 'companiesForMorphRelationSecond',
+        labelSingular: 'Company For Morph Relation',
+        labelPlural: 'Companies For Morph Relation',
+        icon: 'IconCompany',
+      },
+    });
+
+    createdObjectMetadataCompanyId = objectMetadataCompanyId;
+
+    const {
+      data: {
+        createOneObject: { id: objectMetadataOpportunityId },
+      },
+    } = await createOneObjectMetadata({
+      expectToFail: false,
+      input: {
+        nameSingular: 'opportunityForMorphRelationSecond',
+        namePlural: 'opportunitiesForMorphRelationSecond',
+        labelSingular: 'Opportunity For Morph Relation',
+        labelPlural: 'Opportunities For Morph Relation',
+        icon: 'IconOpportunity',
+      },
+    });
+
+    createdObjectMetadataOpportunityId = objectMetadataOpportunityId;
+  });
+
+  afterAll(async () => {
+    await Promise.all(
+      [
+        createdObjectMetadataPersonId,
+        createdObjectMetadataOpportunityId,
+        createdObjectMetadataCompanyId,
+      ].map(
+        async (objectMetadataId) =>
+          await updateOneObjectMetadata({
+            expectToFail: false,
+            input: {
+              idToUpdate: objectMetadataId,
+              updatePayload: { isActive: false },
+            },
+          }),
+      ),
+    );
+
+    await Promise.all(
+      [
+        createdObjectMetadataPersonId,
+        createdObjectMetadataOpportunityId,
+        createdObjectMetadataCompanyId,
+      ].map(
+        async (objectMetadataId) =>
+          await deleteOneObjectMetadata({
+            expectToFail: false,
+            input: { idToDelete: objectMetadataId },
+          }),
+      ),
+    );
+
+    await updateFeatureFlag({
+      expectToFail: false,
+      featureFlag: FeatureFlagKey.IS_WORKSPACE_MIGRATION_V2_ENABLED,
+      value: false,
+      workspaceId: SEED_APPLE_WORKSPACE_ID,
+    });
+  });
+
+  beforeEach(async () => {
+    const {
+      data: { createOneField: rawCreateOneField },
+    } = await createOneFieldMetadata({
+      input: {
+        label: 'field label',
+        name: 'fieldName',
+        objectMetadataId: createdObjectMetadataCompanyId,
+        type: FieldMetadataType.MORPH_RELATION,
+        morphRelationsCreationPayload: [
+          {
+            targetFieldIcon: 'Icon123',
+            targetFieldLabel: 'toto',
+            targetObjectMetadataId: createdObjectMetadataOpportunityId,
+            type: RelationType.MANY_TO_ONE,
+          },
+          {
+            targetFieldIcon: 'Icon123',
+            targetFieldLabel: 'tata',
+            targetObjectMetadataId: createdObjectMetadataPersonId,
+            type: RelationType.MANY_TO_ONE,
+          },
+        ],
+      },
+      expectToFail: false,
+    });
+
+    createdFieldMetadataId = rawCreateOneField.id;
+  });
+
+  it('It should update all morph related flat field metadata allowing its deletion', async () => {
+    const input = {
+      idToUpdate: createdFieldMetadataId,
+      updatePayload: {
+        isActive: false,
+        label: 'new label',
+        description: 'new description',
+      },
+    };
+    const {
+      data: { updateOneField },
+    } = await updateOneFieldMetadata({
+      expectToFail: false,
+      input,
+      gqlFields: `
+        id
+        isActive
+        description
+        name
+        label
+        `,
+    });
+
+    expect(updateOneField).toMatchObject(input.updatePayload);
+
+    await deleteOneFieldMetadata({
+      input: {
+        idToDelete: createdFieldMetadataId,
+      },
+      expectToFail: false,
+    });
+  });
+});


### PR DESCRIPTION
Fixes, depending on the contextual current operation in order to retrieve relation target and all morph related fields to be delete:
- DELETE Field,
- DELETE Object, 
- UPDATE Field, that affects all others related fields