### PR TITLE
14066 extensibility add coretriggerroute table

### DIFF
--- a/packages/twenty-server/package.json
+++ b/packages/twenty-server/package.json
@@ -159,6 +159,7 @@
     "passport-google-oauth20": "2.0.0",
     "passport-jwt": "4.0.1",
     "passport-microsoft": "2.1.0",
+    "path-to-regexp": "^8.2.0",
     "pg": "8.12.0",
     "pg-boss": "9.0.3",
     "planer": "1.2.0",

--- a/packages/twenty-server/src/database/typeorm/core/migrations/common/1756475986194-addRouteEntity.ts
+++ b/packages/twenty-server/src/database/typeorm/core/migrations/common/1756475986194-addRouteEntity.ts
@@ -1,0 +1,31 @@
+import { type MigrationInterface, type QueryRunner } from 'typeorm';
+
+export class AddRouteEntity1756475986194 implements MigrationInterface {
+  name = 'AddRouteEntity1756475986194';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "core"."route_httpmethod_enum" AS ENUM('Get', 'Post', 'Put', 'Patch', 'Delete')`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "core"."route" ("universalIdentifier" uuid, "id" uuid NOT NULL DEFAULT uuid_generate_v4(), "path" character varying NOT NULL, "isAuthRequired" boolean NOT NULL DEFAULT true, "httpMethod" "core"."route_httpmethod_enum" NOT NULL DEFAULT 'Get', "workspaceId" uuid NOT NULL, "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "serverlessFunctionId" uuid, CONSTRAINT "IDX_ROUTE_PATH_HTTP_METHOD_WORKSPACE_ID_UNIQUE" UNIQUE ("path", "httpMethod", "workspaceId"), CONSTRAINT "PK_08affcd076e46415e5821acf52d" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_1c39502392dd9cbb186deba158" ON "core"."route" ("workspaceId", "universalIdentifier") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."route" ADD CONSTRAINT "FK_c63b1110bbf09051be2f495d0be" FOREIGN KEY ("serverlessFunctionId") REFERENCES "core"."serverlessFunction"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "core"."route" DROP CONSTRAINT "FK_c63b1110bbf09051be2f495d0be"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "core"."IDX_1c39502392dd9cbb186deba158"`,
+    );
+    await queryRunner.query(`DROP TABLE "core"."route"`);
+    await queryRunner.query(`DROP TYPE "core"."route_httpmethod_enum"`);
+  }
+}

--- a/packages/twenty-server/src/database/typeorm/core/migrations/common/1756476065711-removeUselessDeletedAt.ts
+++ b/packages/twenty-server/src/database/typeorm/core/migrations/common/1756476065711-removeUselessDeletedAt.ts
@@ -1,0 +1,23 @@
+import { type MigrationInterface, type QueryRunner } from 'typeorm';
+
+export class RemoveUselessDeletedAt1756476065711 implements MigrationInterface {
+  name = 'RemoveUselessDeletedAt1756476065711';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "core"."cronTrigger" DROP COLUMN "deletedAt"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."databaseEventTrigger" DROP COLUMN "deletedAt"`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "core"."databaseEventTrigger" ADD "deletedAt" TIMESTAMP WITH TIME ZONE`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."cronTrigger" ADD "deletedAt" TIMESTAMP WITH TIME ZONE`,
+    );
+  }
+}

--- a/packages/twenty-server/src/database/typeorm/core/migrations/common/1756803679889-addRouteEntity.ts
+++ b/packages/twenty-server/src/database/typeorm/core/migrations/common/1756803679889-addRouteEntity.ts
@@ -1,14 +1,14 @@
 import { type MigrationInterface, type QueryRunner } from 'typeorm';
 
-export class AddRouteEntity1756475986194 implements MigrationInterface {
-  name = 'AddRouteEntity1756475986194';
+export class AddRouteEntity1756803679889 implements MigrationInterface {
+  name = 'AddRouteEntity1756803679889';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `CREATE TYPE "core"."route_httpmethod_enum" AS ENUM('Get', 'Post', 'Put', 'Patch', 'Delete')`,
+      `CREATE TYPE "core"."route_httpmethod_enum" AS ENUM('GET', 'POST', 'PUT', 'PATCH', 'DELETE')`,
     );
     await queryRunner.query(
-      `CREATE TABLE "core"."route" ("universalIdentifier" uuid, "id" uuid NOT NULL DEFAULT uuid_generate_v4(), "path" character varying NOT NULL, "isAuthRequired" boolean NOT NULL DEFAULT true, "httpMethod" "core"."route_httpmethod_enum" NOT NULL DEFAULT 'Get', "workspaceId" uuid NOT NULL, "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "serverlessFunctionId" uuid, CONSTRAINT "IDX_ROUTE_PATH_HTTP_METHOD_WORKSPACE_ID_UNIQUE" UNIQUE ("path", "httpMethod", "workspaceId"), CONSTRAINT "PK_08affcd076e46415e5821acf52d" PRIMARY KEY ("id"))`,
+      `CREATE TABLE "core"."route" ("universalIdentifier" uuid, "id" uuid NOT NULL DEFAULT uuid_generate_v4(), "path" character varying NOT NULL, "isAuthRequired" boolean NOT NULL DEFAULT true, "httpMethod" "core"."route_httpmethod_enum" NOT NULL DEFAULT 'GET', "workspaceId" uuid NOT NULL, "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "serverlessFunctionId" uuid, CONSTRAINT "IDX_ROUTE_PATH_HTTP_METHOD_WORKSPACE_ID_UNIQUE" UNIQUE ("path", "httpMethod", "workspaceId"), CONSTRAINT "PK_08affcd076e46415e5821acf52d" PRIMARY KEY ("id"))`,
     );
     await queryRunner.query(
       `CREATE UNIQUE INDEX "IDX_1c39502392dd9cbb186deba158" ON "core"."route" ("workspaceId", "universalIdentifier") `,

--- a/packages/twenty-server/src/engine/metadata-modules/metadata-engine.module.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/metadata-engine.module.ts
@@ -10,6 +10,7 @@ import { RoleModule } from 'src/engine/metadata-modules/role/role.module';
 import { ServerlessFunctionModule } from 'src/engine/metadata-modules/serverless-function/serverless-function.module';
 import { WorkspaceMetadataVersionModule } from 'src/engine/metadata-modules/workspace-metadata-version/workspace-metadata-version.module';
 import { WorkspaceMigrationModule } from 'src/engine/metadata-modules/workspace-migration/workspace-migration.module';
+import { RouteModule } from 'src/engine/metadata-modules/route/route.module';
 
 @Module({
   imports: [
@@ -23,6 +24,7 @@ import { WorkspaceMigrationModule } from 'src/engine/metadata-modules/workspace-
     RemoteServerModule,
     RoleModule,
     PermissionsModule,
+    RouteModule,
   ],
   providers: [],
   exports: [

--- a/packages/twenty-server/src/engine/metadata-modules/route/route.controller.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/route/route.controller.ts
@@ -1,0 +1,86 @@
+import {
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Put,
+  Req,
+  UseFilters,
+  UseGuards,
+} from '@nestjs/common';
+
+import { Request } from 'express';
+
+import { PublicEndpointGuard } from 'src/engine/guards/public-endpoint.guard';
+import { RouteService } from 'src/engine/metadata-modules/route/route.service';
+import { HTTPMethod } from 'src/engine/metadata-modules/route/route.entity';
+import { RestApiExceptionFilter } from 'src/engine/api/rest/rest-api-exception.filter';
+
+@Controller('s/:workspaceId')
+@UseGuards(PublicEndpointGuard)
+@UseFilters(RestApiExceptionFilter)
+export class RouteController {
+  constructor(private readonly routeService: RouteService) {}
+
+  @Get('*')
+  async get(
+    @Param('workspaceId') workspaceId: string,
+    @Req() request: Request,
+  ) {
+    return await this.routeService.handle({
+      workspaceId,
+      request,
+      httpMethod: HTTPMethod.Get,
+    });
+  }
+
+  @Post('*')
+  async post(
+    @Param('workspaceId') workspaceId: string,
+    @Req() request: Request,
+  ) {
+    return await this.routeService.handle({
+      workspaceId,
+      request,
+      httpMethod: HTTPMethod.Post,
+    });
+  }
+
+  @Put('*')
+  async put(
+    @Param('workspaceId') workspaceId: string,
+    @Req() request: Request,
+  ) {
+    return await this.routeService.handle({
+      workspaceId,
+      request,
+      httpMethod: HTTPMethod.Put,
+    });
+  }
+
+  @Patch('*')
+  async patch(
+    @Param('workspaceId') workspaceId: string,
+    @Req() request: Request,
+  ) {
+    return await this.routeService.handle({
+      workspaceId,
+      request,
+      httpMethod: HTTPMethod.Patch,
+    });
+  }
+
+  @Delete('*')
+  async delete(
+    @Param('workspaceId') workspaceId: string,
+    @Req() request: Request,
+  ) {
+    return await this.routeService.handle({
+      workspaceId,
+      request,
+      httpMethod: HTTPMethod.Delete,
+    });
+  }
+}

--- a/packages/twenty-server/src/engine/metadata-modules/route/route.controller.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/route/route.controller.ts
@@ -32,7 +32,7 @@ export class RouteController {
     return await this.routeService.handle({
       workspaceId,
       request,
-      httpMethod: HTTPMethod.Get,
+      httpMethod: HTTPMethod.GET,
     });
   }
 
@@ -44,7 +44,7 @@ export class RouteController {
     return await this.routeService.handle({
       workspaceId,
       request,
-      httpMethod: HTTPMethod.Post,
+      httpMethod: HTTPMethod.POST,
     });
   }
 
@@ -56,7 +56,7 @@ export class RouteController {
     return await this.routeService.handle({
       workspaceId,
       request,
-      httpMethod: HTTPMethod.Put,
+      httpMethod: HTTPMethod.PUT,
     });
   }
 
@@ -68,7 +68,7 @@ export class RouteController {
     return await this.routeService.handle({
       workspaceId,
       request,
-      httpMethod: HTTPMethod.Patch,
+      httpMethod: HTTPMethod.PATCH,
     });
   }
 
@@ -80,7 +80,7 @@ export class RouteController {
     return await this.routeService.handle({
       workspaceId,
       request,
-      httpMethod: HTTPMethod.Delete,
+      httpMethod: HTTPMethod.DELETE,
     });
   }
 }

--- a/packages/twenty-server/src/engine/metadata-modules/route/route.entity.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/route/route.entity.ts
@@ -14,7 +14,7 @@ import { SyncableEntity } from 'src/engine/workspace-manager/workspace-sync/inte
 
 import { ServerlessFunctionEntity } from 'src/engine/metadata-modules/serverless-function/serverless-function.entity';
 
-enum HTTPMethod {
+export enum HTTPMethod {
   Get = 'Get',
   Post = 'Post',
   Put = 'Put',

--- a/packages/twenty-server/src/engine/metadata-modules/route/route.entity.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/route/route.entity.ts
@@ -1,0 +1,65 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  Relation,
+  UpdateDateColumn,
+  Unique,
+} from 'typeorm';
+
+import { SyncableEntity } from 'src/engine/workspace-manager/workspace-sync/interfaces/syncable-entity.interface';
+
+import { ServerlessFunctionEntity } from 'src/engine/metadata-modules/serverless-function/serverless-function.entity';
+
+enum HTTPMethod {
+  Get = 'Get',
+  Post = 'Post',
+  Put = 'Put',
+  Patch = 'Patch',
+  Delete = 'Delete',
+}
+
+@Entity({ name: 'route', schema: 'core' })
+@Unique('IDX_ROUTE_PATH_HTTP_METHOD_WORKSPACE_ID_UNIQUE', [
+  'path',
+  'httpMethod',
+  'workspaceId',
+])
+export class Route extends SyncableEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ nullable: false })
+  path: string;
+
+  @Column({ nullable: false, default: true })
+  isAuthRequired: boolean;
+
+  @Column({
+    type: 'enum',
+    enum: HTTPMethod,
+    default: HTTPMethod.Get,
+    nullable: false,
+  })
+  httpMethod: HTTPMethod;
+
+  @ManyToOne(
+    () => ServerlessFunctionEntity,
+    (serverlessFunction) => serverlessFunction.routes,
+    { onDelete: 'CASCADE' },
+  )
+  @JoinColumn({ name: 'serverlessFunctionId' })
+  serverlessFunction: Relation<ServerlessFunctionEntity>;
+
+  @Column({ nullable: false, type: 'uuid' })
+  workspaceId: string;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ type: 'timestamptz' })
+  updatedAt: Date;
+}

--- a/packages/twenty-server/src/engine/metadata-modules/route/route.entity.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/route/route.entity.ts
@@ -15,11 +15,11 @@ import { SyncableEntity } from 'src/engine/workspace-manager/workspace-sync/inte
 import { ServerlessFunctionEntity } from 'src/engine/metadata-modules/serverless-function/serverless-function.entity';
 
 export enum HTTPMethod {
-  Get = 'Get',
-  Post = 'Post',
-  Put = 'Put',
-  Patch = 'Patch',
-  Delete = 'Delete',
+  GET = 'GET',
+  POST = 'POST',
+  PUT = 'PUT',
+  PATCH = 'PATCH',
+  DELETE = 'DELETE',
 }
 
 @Entity({ name: 'route', schema: 'core' })
@@ -41,7 +41,7 @@ export class Route extends SyncableEntity {
   @Column({
     type: 'enum',
     enum: HTTPMethod,
-    default: HTTPMethod.Get,
+    default: HTTPMethod.GET,
     nullable: false,
   })
   httpMethod: HTTPMethod;

--- a/packages/twenty-server/src/engine/metadata-modules/route/route.module.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/route/route.module.ts
@@ -1,0 +1,4 @@
+import { Module } from '@nestjs/common';
+
+@Module({})
+export class RouteModule {}

--- a/packages/twenty-server/src/engine/metadata-modules/route/route.module.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/route/route.module.ts
@@ -1,4 +1,21 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 
-@Module({})
+import { RouteService } from 'src/engine/metadata-modules/route/route.service';
+import { Route } from 'src/engine/metadata-modules/route/route.entity';
+import { RouteController } from 'src/engine/metadata-modules/route/route.controller';
+import { AuthModule } from 'src/engine/core-modules/auth/auth.module';
+import { DomainManagerModule } from 'src/engine/core-modules/domain-manager/domain-manager.module';
+import { ServerlessFunctionModule } from 'src/engine/metadata-modules/serverless-function/serverless-function.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Route]),
+    AuthModule,
+    DomainManagerModule,
+    ServerlessFunctionModule,
+  ],
+  controllers: [RouteController],
+  providers: [RouteService],
+})
 export class RouteModule {}

--- a/packages/twenty-server/src/engine/metadata-modules/route/route.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/route/route.service.ts
@@ -1,0 +1,124 @@
+import {
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { Repository } from 'typeorm';
+import { Request } from 'express';
+import { match } from 'path-to-regexp';
+import { isDefined } from 'twenty-shared/utils';
+
+import {
+  HTTPMethod,
+  Route,
+} from 'src/engine/metadata-modules/route/route.entity';
+import { AccessTokenService } from 'src/engine/core-modules/auth/token/services/access-token.service';
+import { ServerlessFunctionService } from 'src/engine/metadata-modules/serverless-function/serverless-function.service';
+
+@Injectable()
+export class RouteService {
+  constructor(
+    private readonly accessTokenService: AccessTokenService,
+    private readonly serverlessFunctionService: ServerlessFunctionService,
+    @InjectRepository(Route)
+    private readonly routeRepository: Repository<Route>,
+  ) {}
+
+  private async getOneRouteWithPathParamsOrFail({
+    workspaceId,
+    request,
+    httpMethod,
+  }: {
+    workspaceId: string;
+    request: Request;
+    httpMethod: HTTPMethod;
+  }): Promise<{
+    route: Route;
+    pathParams: Partial<Record<string, string | string[]>>;
+  }> {
+    const routes = await this.routeRepository.find({
+      where: {
+        httpMethod,
+        workspaceId,
+      },
+      relations: ['serverlessFunction'],
+    });
+
+    const requestPath = request.path.replace(`/s/${workspaceId}/`, '');
+
+    for (const route of routes) {
+      const routeMatcher = match(route.path, { decode: decodeURIComponent });
+      const routeMatched = routeMatcher(requestPath);
+
+      if (routeMatched) {
+        return {
+          route,
+          pathParams: routeMatched.params,
+        };
+      }
+    }
+
+    throw new NotFoundException('No Route found');
+  }
+
+  private async validateWorkspaceFromRequest({
+    request,
+    workspaceId,
+  }: {
+    request: Request;
+    workspaceId: string;
+  }) {
+    const { workspace } =
+      await this.accessTokenService.validateTokenByRequest(request);
+
+    if (!isDefined(workspace)) {
+      throw new NotFoundException('Workspace not found');
+    }
+
+    if (workspace.id !== workspaceId) {
+      throw new ForbiddenException('Invalid Workspace');
+    }
+  }
+
+  async handle({
+    workspaceId,
+    request,
+    httpMethod,
+  }: {
+    workspaceId: string;
+    request: Request;
+    httpMethod: HTTPMethod;
+  }) {
+    const routeWithPathParams = await this.getOneRouteWithPathParamsOrFail({
+      workspaceId,
+      request,
+      httpMethod,
+    });
+
+    if (routeWithPathParams.route.isAuthRequired) {
+      await this.validateWorkspaceFromRequest({
+        request,
+        workspaceId: routeWithPathParams.route.workspaceId,
+      });
+    }
+
+    const queryParams = request.query;
+
+    const bodyParams = request.body;
+
+    const executionParams = {
+      ...queryParams,
+      ...bodyParams,
+      ...routeWithPathParams.pathParams,
+    };
+
+    return await this.serverlessFunctionService.executeOneServerlessFunction(
+      routeWithPathParams.route.serverlessFunction.id,
+      routeWithPathParams.route.workspaceId,
+      executionParams,
+      'draft',
+    );
+  }
+}

--- a/packages/twenty-server/src/engine/metadata-modules/serverless-function/serverless-function.entity.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/serverless-function/serverless-function.entity.ts
@@ -13,6 +13,7 @@ import {
 import { InputSchema } from 'src/modules/workflow/workflow-builder/workflow-schema/types/input-schema.type';
 import { CronTrigger } from 'src/engine/metadata-modules/trigger/entities/cron-trigger.entity';
 import { DatabaseEventTrigger } from 'src/engine/metadata-modules/trigger/entities/database-event-trigger.entity';
+import { Route } from 'src/engine/metadata-modules/route/route.entity';
 
 const DEFAULT_SERVERLESS_TIMEOUT_SECONDS = 300; // 5 minutes
 
@@ -72,6 +73,11 @@ export class ServerlessFunctionEntity {
     },
   )
   databaseEventTriggers: DatabaseEventTrigger[];
+
+  @OneToMany(() => Route, (route) => route.serverlessFunction, {
+    cascade: true,
+  })
+  routes: Route[];
 
   @CreateDateColumn({ type: 'timestamptz' })
   createdAt: Date;

--- a/packages/twenty-server/src/engine/metadata-modules/trigger/entities/cron-trigger.entity.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/trigger/entities/cron-trigger.entity.ts
@@ -2,7 +2,6 @@ import {
   Column,
   CreateDateColumn,
   Entity,
-  DeleteDateColumn,
   JoinColumn,
   ManyToOne,
   PrimaryGeneratedColumn,
@@ -44,7 +43,4 @@ export class CronTrigger extends SyncableEntity {
 
   @UpdateDateColumn({ type: 'timestamptz' })
   updatedAt: Date;
-
-  @DeleteDateColumn({ type: 'timestamptz' })
-  deletedAt?: Date;
 }

--- a/packages/twenty-server/src/engine/metadata-modules/trigger/entities/database-event-trigger.entity.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/trigger/entities/database-event-trigger.entity.ts
@@ -2,7 +2,6 @@ import {
   Column,
   CreateDateColumn,
   Entity,
-  DeleteDateColumn,
   JoinColumn,
   ManyToOne,
   PrimaryGeneratedColumn,
@@ -44,7 +43,4 @@ export class DatabaseEventTrigger extends SyncableEntity {
 
   @UpdateDateColumn({ type: 'timestamptz' })
   updatedAt: Date;
-
-  @DeleteDateColumn({ type: 'timestamptz' })
-  deletedAt?: Date;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -43930,6 +43930,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-to-regexp@npm:^8.2.0":
+  version: 8.2.0
+  resolution: "path-to-regexp@npm:8.2.0"
+  checksum: 10c0/ef7d0a887b603c0a142fad16ccebdcdc42910f0b14830517c724466ad676107476bba2fe9fffd28fd4c141391ccd42ea426f32bb44c2c82ecaefe10c37b90f5a
+  languageName: node
+  linkType: hard
+
 "path-type@npm:^4.0.0":
   version: 4.0.0
   resolution: "path-type@npm:4.0.0"
@@ -51212,6 +51219,7 @@ __metadata:
     passport-google-oauth20: "npm:2.0.0"
     passport-jwt: "npm:4.0.1"
     passport-microsoft: "npm:2.1.0"
+    path-to-regexp: "npm:^8.2.0"
     pg: "npm:8.12.0"
     pg-boss: "npm:9.0.3"
     planer: "npm:1.2.0"


### PR DESCRIPTION
This Pr 
- adds a `route` table to the core schema
- adds a controller to trigger route

For now, we need to add a `/s/<workspace_id>` prefix to all routes

We plan to create a custom domain table in order to let the users create subdomains for their workspace, and so to link their routes to a subdomain. Thank to that, we will be able to identify workspace_id from domain name, and the prefix could be `/s`. If we create a native dedicated subdomain for routes for each workspaces, the prefix could be completely removed!

Here the follow up ticket to do that -> https://github.com/twentyhq/core-team-issues/issues/1419