### PR TITLE
Fix dataloader service not provided in core graphql config

### DIFF
--- a/packages/twenty-server/src/app.module.ts
+++ b/packages/twenty-server/src/app.module.ts
@@ -17,10 +17,11 @@ import { SentryModule } from '@sentry/nestjs/setup';
 import { CoreGraphQLApiModule } from 'src/engine/api/graphql/core-graphql-api.module';
 import { GraphQLConfigModule } from 'src/engine/api/graphql/graphql-config/graphql-config.module';
 import { GraphQLConfigService } from 'src/engine/api/graphql/graphql-config/graphql-config.service';
-import { McpModule } from 'src/engine/api/mcp/mcp.module';
 import { MetadataGraphQLApiModule } from 'src/engine/api/graphql/metadata-graphql-api.module';
+import { McpModule } from 'src/engine/api/mcp/mcp.module';
 import { RestApiModule } from 'src/engine/api/rest/rest-api.module';
 import { MetricsModule } from 'src/engine/core-modules/metrics/metrics.module';
+import { DataloaderModule } from 'src/engine/dataloaders/dataloader.module';
 import { DataSourceModule } from 'src/engine/metadata-modules/data-source/data-source.module';
 import { WorkspaceMetadataCacheModule } from 'src/engine/metadata-modules/workspace-metadata-cache/workspace-metadata-cache.module';
 import { GraphQLHydrateRequestFromTokenMiddleware } from 'src/engine/middlewares/graphql-hydrate-request-from-token.middleware';
@@ -52,7 +53,7 @@ const MIGRATED_REST_METHODS = [
     }),
     GraphQLModule.forRootAsync<YogaDriverConfig>({
       driver: YogaDriver,
-      imports: [GraphQLConfigModule, MetricsModule],
+      imports: [GraphQLConfigModule, MetricsModule, DataloaderModule],
       useClass: GraphQLConfigService,
     }),
     TwentyORMModule,

--- a/packages/twenty-server/src/engine/api/graphql/graphql-config/graphql-config.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-config/graphql-config.service.ts
@@ -28,6 +28,7 @@ import { MetricsService } from 'src/engine/core-modules/metrics/metrics.service'
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import { type User } from 'src/engine/core-modules/user/user.entity';
 import { type Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
+import { DataloaderService } from 'src/engine/dataloaders/dataloader.service';
 import { handleExceptionAndConvertToGraphQLError } from 'src/engine/utils/global-exception-handler.util';
 import { renderApolloPlayground } from 'src/engine/utils/render-apollo-playground.util';
 
@@ -45,6 +46,7 @@ export class GraphQLConfigService
     private readonly twentyConfigService: TwentyConfigService,
     private readonly moduleRef: ModuleRef,
     private readonly metricsService: MetricsService,
+    private readonly dataloaderService: DataloaderService,
   ) {}
 
   createGqlOptions(): YogaDriverConfig {
@@ -145,6 +147,9 @@ export class GraphQLConfigService
       },
       resolvers: { JSON: GraphQLJSON },
       plugins: plugins,
+      context: () => ({
+        loaders: this.dataloaderService.createLoaders(),
+      }),
     };
 
     if (isDebugMode) {


### PR DESCRIPTION
## Context
Views and some other objects "leak" in the core API, this should be fixed but in the meantime they fail if they use dataloaders because it's not provided in the core config

```
  [
    TypeError: Cannot read properties of undefined (reading 'objectMetadataLoader')
  ]
  ```
in view.resolver using dataloaders to compute the name field

How to test: query views from /graphql instead of /metadata

Note: we could have a dedicated dataloader service for each gql server in the future