### PR TITLE
Remove workspaceId from path parameter for route endpoints

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/route/route.controller.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/route/route.controller.ts
@@ -2,7 +2,6 @@ import {
   Controller,
   Delete,
   Get,
-  Param,
   Patch,
   Post,
   Put,
@@ -18,67 +17,47 @@ import { RouteService } from 'src/engine/metadata-modules/route/route.service';
 import { HTTPMethod } from 'src/engine/metadata-modules/route/route.entity';
 import { RestApiExceptionFilter } from 'src/engine/api/rest/rest-api-exception.filter';
 
-@Controller('s/:workspaceId')
+@Controller('s')
 @UseGuards(PublicEndpointGuard)
 @UseFilters(RestApiExceptionFilter)
 export class RouteController {
   constructor(private readonly routeService: RouteService) {}
 
   @Get('*')
-  async get(
-    @Param('workspaceId') workspaceId: string,
-    @Req() request: Request,
-  ) {
+  async get(@Req() request: Request) {
     return await this.routeService.handle({
-      workspaceId,
       request,
       httpMethod: HTTPMethod.GET,
     });
   }
 
   @Post('*')
-  async post(
-    @Param('workspaceId') workspaceId: string,
-    @Req() request: Request,
-  ) {
+  async post(@Req() request: Request) {
     return await this.routeService.handle({
-      workspaceId,
       request,
       httpMethod: HTTPMethod.POST,
     });
   }
 
   @Put('*')
-  async put(
-    @Param('workspaceId') workspaceId: string,
-    @Req() request: Request,
-  ) {
+  async put(@Req() request: Request) {
     return await this.routeService.handle({
-      workspaceId,
       request,
       httpMethod: HTTPMethod.PUT,
     });
   }
 
   @Patch('*')
-  async patch(
-    @Param('workspaceId') workspaceId: string,
-    @Req() request: Request,
-  ) {
+  async patch(@Req() request: Request) {
     return await this.routeService.handle({
-      workspaceId,
       request,
       httpMethod: HTTPMethod.PATCH,
     });
   }
 
   @Delete('*')
-  async delete(
-    @Param('workspaceId') workspaceId: string,
-    @Req() request: Request,
-  ) {
+  async delete(@Req() request: Request) {
     return await this.routeService.handle({
-      workspaceId,
       request,
       httpMethod: HTTPMethod.DELETE,
     });

--- a/packages/twenty-server/src/engine/metadata-modules/route/route.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/route/route.service.ts
@@ -28,7 +28,7 @@ export class RouteService {
   constructor(
     private readonly accessTokenService: AccessTokenService,
     private readonly serverlessFunctionService: ServerlessFunctionService,
-    private domainManagerService: DomainManagerService,
+    private readonly domainManagerService: DomainManagerService,
     @InjectRepository(Route)
     private readonly routeRepository: Repository<Route>,
   ) {}


### PR DESCRIPTION
- remove workspaceId from path parameter for route endpoints
- use host to infer workspaceId