### PR TITLE
fix: Support dashes (-) in trusted domain emails

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/approved-access-domain/services/approved-access-domain.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/approved-access-domain/services/approved-access-domain.service.ts
@@ -19,7 +19,7 @@ import { EmailService } from 'src/engine/core-modules/email/email.service';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import { type Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { type WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
-import { isWorkDomain } from 'src/utils/is-work-email';
+import { isValidDomain } from 'src/utils/isValidDomain';
 
 @Injectable()
 export class ApprovedAccessDomainService {
@@ -151,9 +151,9 @@ export class ApprovedAccessDomainService {
     fromWorkspaceMember: WorkspaceMemberWorkspaceEntity,
     emailToValidateDomain: string,
   ): Promise<ApprovedAccessDomainEntity> {
-    if (!isWorkDomain(domain)) {
+    if (!isValidDomain(domain)) {
       throw new ApprovedAccessDomainException(
-        'Approved access domain must be a company domain',
+        'Approved access domain must be a valid domain',
         ApprovedAccessDomainExceptionCode.APPROVED_ACCESS_DOMAIN_MUST_BE_A_COMPANY_DOMAIN,
       );
     }

--- a/packages/twenty-server/src/utils/isValidDomain.ts
+++ b/packages/twenty-server/src/utils/isValidDomain.ts
@@ -1,0 +1,11 @@
+export const isValidDomain = (domain: string) => {
+  if (typeof domain !== 'string') return false;
+
+  if (!domain.includes('.')) return false;
+
+  if (domain.includes('*') || domain.endsWith('.')) return false;
+
+  return /^(?:(?:_?[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?|xn--[a-z0-9]+)\.)+(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?|xn--[a-z0-9]+)$/i.test(
+    domain,
+  );
+};

--- a/packages/twenty-server/src/utils/isValidDomain.ts
+++ b/packages/twenty-server/src/utils/isValidDomain.ts
@@ -5,7 +5,9 @@ export const isValidDomain = (domain: string) => {
 
   if (domain.includes('*') || domain.endsWith('.')) return false;
 
-  return /^(?:(?:_?[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?|xn--[a-z0-9]+)\.)+(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?|xn--[a-z0-9]+)$/i.test(
+  const DOMAIN_REGEX = /^(?:(?:_?[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?|xn--[a-z0-9]+)\.)+(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?|xn--[a-z0-9]+)$/i;
+
+  return DOMAIN_REGEX.test(
     domain,
   );
 };


### PR DESCRIPTION
## Changes
- Enhanced domain validation to properly handle domains with dashes
- Improved the domain validation regex to be fully compliant with domain name standards
- Ensured proper validation for domains like "my-company-name.com"

## Why this approach
Instead of validating the email domain against a large list of domain providers, which seems like a very bad idea because it doesn't allow users to add their custom domain names.

Fixes #13378 