### PR TITLE
fix - remove Untitled default value on standard name field

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/utils/build-default-fields-for-custom-object.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/utils/build-default-fields-for-custom-object.util.ts
@@ -39,7 +39,7 @@ export const buildDefaultFieldsForCustomObject = (
     isCustom: false,
     isUIReadOnly: false,
     workspaceId,
-    defaultValue: "'Untitled'",
+    defaultValue: "''",
   },
   {
     id: v4(),

--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/utils/build-default-flat-field-metadatas-for-custom-object.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/utils/build-default-flat-field-metadatas-for-custom-object.util.ts
@@ -67,7 +67,7 @@ export const buildDefaultFlatFieldMetadatasForCustomObject = ({
     isCustom: false,
     isSystem: false,
     isUIReadOnly: false,
-    defaultValue: "'Untitled'",
+    defaultValue: "''",
 
     createdAt,
     updatedAt: createdAt,

--- a/packages/twenty-server/src/engine/metadata-modules/workspace-migration/workspace-migration.factory.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/workspace-migration/workspace-migration.factory.ts
@@ -58,7 +58,7 @@ export class WorkspaceMigrationFactory {
         {
           factory: this.basicColumnActionFactory,
           options: {
-            defaultValue: '',
+            defaultValue: "''",
           },
         },
       ],


### PR DESCRIPTION
Enable unique constraint creation on name standard field. 
Null values are handled in front with 'Untitled'.

Need to migrate fieldMetadata default value on all custom objects ?

Tested : 
- Toggle on/off uniqueness on standard name field of standard/custom object
- Create new custom text field and toggle on/off uniqueness