### PR TITLE
Restrict workflow object permissions

### DIFF
--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/components/WorkflowEditActionCreateRecord.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/components/WorkflowEditActionCreateRecord.tsx
@@ -15,6 +15,7 @@ import { WorkflowVariablePicker } from '@/workflow/workflow-variables/components
 import { useTheme } from '@emotion/react';
 import { useEffect, useState } from 'react';
 import { isDefined } from 'twenty-shared/utils';
+import { canObjectBeManagedByWorkflow } from 'twenty-shared/workflow';
 import { HorizontalSeparator, useIcons } from 'twenty-ui/display';
 import { type SelectOption } from 'twenty-ui/input';
 import { type JsonValue } from 'type-fest';
@@ -73,11 +74,18 @@ export const WorkflowEditActionCreateRecord = ({
     useFilteredObjectMetadataItems();
 
   const availableMetadata: Array<SelectOption<string>> =
-    activeNonSystemObjectMetadataItems.map((item) => ({
-      Icon: getIcon(item.icon),
-      label: item.labelPlural,
-      value: item.nameSingular,
-    }));
+    activeNonSystemObjectMetadataItems
+      .filter((objectMetadataItem) =>
+        canObjectBeManagedByWorkflow({
+          nameSingular: objectMetadataItem.nameSingular,
+          isSystem: objectMetadataItem.isSystem,
+        }),
+      )
+      .map((item) => ({
+        Icon: getIcon(item.icon),
+        label: item.labelPlural,
+        value: item.nameSingular,
+      }));
 
   const [formData, setFormData] = useState<CreateRecordFormData>({
     objectName: action.settings.input.objectName,

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/components/WorkflowEditActionDeleteRecord.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/components/WorkflowEditActionDeleteRecord.tsx
@@ -11,6 +11,7 @@ import { useWorkflowActionHeader } from '@/workflow/workflow-steps/workflow-acti
 import { WorkflowVariablePicker } from '@/workflow/workflow-variables/components/WorkflowVariablePicker';
 import { useTheme } from '@emotion/react';
 import { isDefined } from 'twenty-shared/utils';
+import { canObjectBeManagedByWorkflow } from 'twenty-shared/workflow';
 import { HorizontalSeparator, useIcons } from 'twenty-ui/display';
 import { type SelectOption } from 'twenty-ui/input';
 import { type JsonValue } from 'type-fest';
@@ -45,11 +46,18 @@ export const WorkflowEditActionDeleteRecord = ({
     useFilteredObjectMetadataItems();
 
   const availableMetadata: Array<SelectOption<string>> =
-    activeNonSystemObjectMetadataItems.map((item) => ({
-      Icon: getIcon(item.icon),
-      label: item.labelPlural,
-      value: item.nameSingular,
-    }));
+    activeNonSystemObjectMetadataItems
+      .filter((objectMetadataItem) =>
+        canObjectBeManagedByWorkflow({
+          nameSingular: objectMetadataItem.nameSingular,
+          isSystem: objectMetadataItem.isSystem,
+        }),
+      )
+      .map((item) => ({
+        Icon: getIcon(item.icon),
+        label: item.labelPlural,
+        value: item.nameSingular,
+      }));
 
   const [formData, setFormData] = useState<DeleteRecordFormData>({
     objectNameSingular: action.settings.input.objectName,

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/components/WorkflowEditActionUpdateRecord.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/components/WorkflowEditActionUpdateRecord.tsx
@@ -16,6 +16,7 @@ import { shouldDisplayFormField } from '@/workflow/workflow-steps/workflow-actio
 import { WorkflowVariablePicker } from '@/workflow/workflow-variables/components/WorkflowVariablePicker';
 import { useTheme } from '@emotion/react';
 import { isDefined } from 'twenty-shared/utils';
+import { canObjectBeManagedByWorkflow } from 'twenty-shared/workflow';
 import { HorizontalSeparator, useIcons } from 'twenty-ui/display';
 import { type SelectOption } from 'twenty-ui/input';
 import { type JsonValue } from 'type-fest';
@@ -53,11 +54,18 @@ export const WorkflowEditActionUpdateRecord = ({
     useFilteredObjectMetadataItems();
 
   const availableMetadata: Array<SelectOption<string>> =
-    activeNonSystemObjectMetadataItems.map((item) => ({
-      Icon: getIcon(item.icon),
-      label: item.labelPlural,
-      value: item.nameSingular,
-    }));
+    activeNonSystemObjectMetadataItems
+      .filter((objectMetadataItem) =>
+        canObjectBeManagedByWorkflow({
+          nameSingular: objectMetadataItem.nameSingular,
+          isSystem: objectMetadataItem.isSystem,
+        }),
+      )
+      .map((item) => ({
+        Icon: getIcon(item.icon),
+        label: item.labelPlural,
+        value: item.nameSingular,
+      }));
 
   const [formData, setFormData] = useState<UpdateRecordFormData>({
     objectNameSingular: action.settings.input.objectName,

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-schema/utils/__tests__/should-generate-field-fake-value.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-schema/utils/__tests__/should-generate-field-fake-value.spec.ts
@@ -61,7 +61,7 @@ describe('shouldGenerateFieldFakeValue', () => {
     expect(shouldGenerateFieldFakeValue(field)).toBe(false);
   });
 
-  it('should return false for system fields (except id)', () => {
+  it('should return true for system fields', () => {
     const field = getMockFieldMetadataEntity({
       workspaceId: '20202020-0000-0000-0000-000000000000',
       objectMetadataId: '20202020-0000-0000-0000-000000000001',
@@ -77,7 +77,7 @@ describe('shouldGenerateFieldFakeValue', () => {
       updatedAt: new Date(),
     });
 
-    expect(shouldGenerateFieldFakeValue(field)).toBe(false);
+    expect(shouldGenerateFieldFakeValue(field)).toBe(true);
   });
 
   it('should return false for relation fields', () => {

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-schema/utils/should-generate-field-fake-value.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-schema/utils/should-generate-field-fake-value.ts
@@ -12,7 +12,7 @@ export const shouldGenerateFieldFakeValue = <T extends FieldMetadataType>(
 ) => {
   return (
     field.isActive &&
-    (!field.isSystem || field.name === 'id' || field.name === 'userEmail') &&
+    field.name !== 'searchVector' &&
     (field.type !== FieldMetadataType.RELATION ||
       isManyToOneRelationField(field as unknown as FieldMetadataEntity))
   );

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/record-crud/update-record.workflow-action.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/record-crud/update-record.workflow-action.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 import deepEqual from 'deep-equal';
 import { isDefined, isValidUuid, resolveInput } from 'twenty-shared/utils';
+import { canObjectBeManagedByWorkflow } from 'twenty-shared/workflow';
 
 import { type WorkflowAction } from 'src/modules/workflow/workflow-executor/interfaces/workflow-action.interface';
 
@@ -105,6 +106,18 @@ export class UpdateRecordWorkflowAction implements WorkflowAction {
         workflowActionInput.objectName,
         workspaceId,
       );
+
+    if (
+      !canObjectBeManagedByWorkflow({
+        nameSingular: objectMetadataItemWithFieldsMaps.nameSingular,
+        isSystem: objectMetadataItemWithFieldsMaps.isSystem,
+      })
+    ) {
+      throw new RecordCRUDActionException(
+        'Failed to update: Object cannot be updated by workflow',
+        RecordCRUDActionExceptionCode.INVALID_REQUEST,
+      );
+    }
 
     const objectRecordWithFilteredFields = Object.keys(
       workflowActionInput.objectRecord,

--- a/packages/twenty-shared/src/workflow/index.ts
+++ b/packages/twenty-shared/src/workflow/index.ts
@@ -53,4 +53,5 @@ export type {
   WorkflowRunStepInfos,
 } from './types/WorkflowRunStateStepInfos';
 export { StepStatus } from './types/WorkflowRunStateStepInfos';
+export { canObjectBeManagedByWorkflow } from './utils/canObjectBeManagedByWorkflow';
 export { getWorkflowRunContext } from './utils/getWorkflowRunContext';

--- a/packages/twenty-shared/src/workflow/utils/canObjectBeManagedByWorkflow.ts
+++ b/packages/twenty-shared/src/workflow/utils/canObjectBeManagedByWorkflow.ts
@@ -1,0 +1,18 @@
+export const canObjectBeManagedByWorkflow = ({
+  nameSingular,
+  isSystem,
+}: {
+  nameSingular: string;
+  isSystem: boolean;
+}) => {
+  const excludedNonSystemObjectMetadataItemNames = [
+    'workflow',
+    'workflowVersion',
+    'workflowRun',
+    'dashboard',
+  ];
+
+  return !excludedNonSystemObjectMetadataItemNames.includes(
+    nameSingular,
+  ) && !isSystem;
+};


### PR DESCRIPTION
- workflows should not edit system objects or workflow related objects
- system fields should be usable within variables for reading