### PR TITLE
Fix: Multi-select field now displays all selected options with overflow chip

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/display/components/MultiSelectFieldDisplay.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/display/components/MultiSelectFieldDisplay.tsx
@@ -17,8 +17,9 @@ export const MultiSelectFieldDisplay = () => {
 
   if (!selectedOptions) return null;
 
-  return isFocused ? (
-    <ExpandableList isChipCountDisplayed={isFocused}>
+  // When focused, show all options (no chip count). When not focused, show chip count for overflow.
+  return (
+    <ExpandableList isChipCountDisplayed={!isFocused}>
       {selectedOptions.map((selectedOption, index) => (
         <Tag
           key={index}
@@ -27,10 +28,5 @@ export const MultiSelectFieldDisplay = () => {
         />
       ))}
     </ExpandableList>
-  ) : (
-    <MultiSelectDisplay
-      values={fieldValue}
-      options={fieldDefinition.metadata.options}
-    />
   );
 };


### PR DESCRIPTION
Problem

Previously, the multi-select field in record tables only displayed all selected options when the cell was hovered or focused.
When not hovered, it showed only a single option—even if multiple values were selected and the cell was wide enough.
This made it difficult for users to quickly see all selected values at a glance.

This issue was reported in [#14280]
.

Solution

This PR updates the MultiSelectFieldDisplay component to always use the ExpandableList for rendering selected options.

When not focused/hovered:

As many selected options as fit within the cell width are displayed.

If additional options exist, a “+N” overflow chip is shown.

When focused/hovered:

All selected options are shown, with no overflow chip.

This ensures users can always view as many selected values as possible, improving usability and clarity.

Implementation

Refactored MultiSelectFieldDisplay.tsx to consistently use ExpandableList.

Set the isChipCountDisplayed prop to !isFocused → overflow chip only appears when the cell is not focused.

Removed the previous fallback to MultiSelectDisplay, which hid multiple values unless hovered.

Impact

Fixes #14280.

Enhances the user experience by making selected values more transparent in multi-select fields.

No breaking changes; only the display logic is affected.