### PR TITLE
fix: Server-level impersonation doesn't bypass 2FA when enabled

### DIFF
--- a/packages/twenty-front/src/modules/settings/admin-panel/components/SettingsAdminWorkspaceContent.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/components/SettingsAdminWorkspaceContent.tsx
@@ -20,7 +20,7 @@ import { isNonEmptyString } from '@sniptt/guards';
 import { useState } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { getImageAbsoluteURI, isDefined } from 'twenty-shared/utils';
-import { Chip, AvatarChip } from 'twenty-ui/components';
+import { AvatarChip, Chip } from 'twenty-ui/components';
 import {
   H2Title,
   IconEyeShare,
@@ -92,6 +92,7 @@ export const SettingsAdminWorkspaceContent = ({
         return executeImpersonationRedirect(
           workspace.workspaceUrls,
           loginToken.token,
+          '_blank',
         );
       },
       onError: (error) => {

--- a/packages/twenty-front/src/modules/settings/admin-panel/hooks/useImpersonationRedirect.ts
+++ b/packages/twenty-front/src/modules/settings/admin-panel/hooks/useImpersonationRedirect.ts
@@ -9,11 +9,13 @@ export const useImpersonationRedirect = () => {
   const executeImpersonationRedirect = async (
     workspaceUrls: WorkspaceUrls,
     loginToken: string,
+    target: string = '_self',
   ) => {
     return await redirectToWorkspaceDomain(
       getWorkspaceUrl(workspaceUrls),
       AppPath.Verify,
       { loginToken },
+      target,
     );
   };
 

--- a/packages/twenty-server/src/engine/core-modules/admin-panel/__tests__/admin-panel.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/admin-panel/__tests__/admin-panel.service.spec.ts
@@ -108,7 +108,7 @@ describe('AdminPanelService', () => {
       expiresAt: new Date(),
     });
 
-    const result = await service.impersonate('user-id', 'workspace-id');
+    const result = await service.impersonate('user-id', 'workspace-id', 'user-id');
 
     expect(UserFindOneMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -149,10 +149,10 @@ describe('AdminPanelService', () => {
     UserFindOneMock.mockReturnValueOnce(null);
 
     await expect(
-      service.impersonate('invalid-user-id', 'workspace-id'),
+      service.impersonate('invalid-user-id', 'workspace-id', 'user-id'),
     ).rejects.toThrow(
       new AuthException(
-        'User not found or impersonation not enable on workspace',
+        'User not found or impersonation not enabled on workspace',
         AuthExceptionCode.INVALID_INPUT,
       ),
     );

--- a/packages/twenty-server/src/engine/core-modules/admin-panel/__tests__/admin-panel.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/admin-panel/__tests__/admin-panel.service.spec.ts
@@ -4,6 +4,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import axios from 'axios';
 
 import { AdminPanelService } from 'src/engine/core-modules/admin-panel/admin-panel.service';
+import { AuditService } from 'src/engine/core-modules/audit/services/audit.service';
 import {
   AuthException,
   AuthExceptionCode,
@@ -77,6 +78,14 @@ describe('AdminPanelService', () => {
               TwentyConfigServiceGetVariableWithMetadataMock,
           },
         },
+        {
+          provide: AuditService,
+          useValue: {
+            createContext: jest.fn().mockReturnValue({
+              insertWorkspaceEvent: jest.fn(),
+            }),
+          },
+        },
       ],
     }).compile();
 
@@ -130,6 +139,8 @@ describe('AdminPanelService', () => {
     expect(LoginTokenServiceGenerateLoginTokenMock).toHaveBeenCalledWith(
       'user@example.com',
       'workspace-id',
+      'impersonation',
+      { impersonatorUserId: 'user-id' },
     );
 
     expect(result).toEqual(
@@ -156,8 +167,8 @@ describe('AdminPanelService', () => {
       service.impersonate('invalid-user-id', 'workspace-id', 'user-id'),
     ).rejects.toThrow(
       new AuthException(
-        'User not found or impersonation not enabled on workspace',
-        AuthExceptionCode.INVALID_INPUT,
+        'User not found in workspace or impersonation not enabled',
+        AuthExceptionCode.USER_WORKSPACE_NOT_FOUND,
       ),
     );
 

--- a/packages/twenty-server/src/engine/core-modules/admin-panel/__tests__/admin-panel.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/admin-panel/__tests__/admin-panel.service.spec.ts
@@ -108,7 +108,11 @@ describe('AdminPanelService', () => {
       expiresAt: new Date(),
     });
 
-    const result = await service.impersonate('user-id', 'workspace-id', 'user-id');
+    const result = await service.impersonate(
+      'user-id',
+      'workspace-id',
+      'user-id',
+    );
 
     expect(UserFindOneMock).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/twenty-server/src/engine/core-modules/admin-panel/admin-panel.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/admin-panel/admin-panel.module.ts
@@ -5,6 +5,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { AdminPanelHealthService } from 'src/engine/core-modules/admin-panel/admin-panel-health.service';
 import { AdminPanelResolver } from 'src/engine/core-modules/admin-panel/admin-panel.resolver';
 import { AdminPanelService } from 'src/engine/core-modules/admin-panel/admin-panel.service';
+import { AuditModule } from 'src/engine/core-modules/audit/audit.module';
 import { AuthModule } from 'src/engine/core-modules/auth/auth.module';
 import { DomainManagerModule } from 'src/engine/core-modules/domain-manager/domain-manager.module';
 import { FeatureFlagModule } from 'src/engine/core-modules/feature-flag/feature-flag.module';
@@ -21,6 +22,7 @@ import { User } from 'src/engine/core-modules/user/user.entity';
     RedisClientModule,
     TerminusModule,
     FeatureFlagModule,
+    AuditModule,
   ],
   providers: [AdminPanelResolver, AdminPanelService, AdminPanelHealthService],
   exports: [AdminPanelService],

--- a/packages/twenty-server/src/engine/core-modules/admin-panel/admin-panel.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/admin-panel/admin-panel.module.ts
@@ -11,6 +11,7 @@ import { DomainManagerModule } from 'src/engine/core-modules/domain-manager/doma
 import { FeatureFlagModule } from 'src/engine/core-modules/feature-flag/feature-flag.module';
 import { HealthModule } from 'src/engine/core-modules/health/health.module';
 import { RedisClientModule } from 'src/engine/core-modules/redis-client/redis-client.module';
+import { TelemetryModule } from 'src/engine/core-modules/telemetry/telemetry.module';
 import { User } from 'src/engine/core-modules/user/user.entity';
 
 @Module({
@@ -23,6 +24,7 @@ import { User } from 'src/engine/core-modules/user/user.entity';
     TerminusModule,
     FeatureFlagModule,
     AuditModule,
+    TelemetryModule,
   ],
   providers: [AdminPanelResolver, AdminPanelService, AdminPanelHealthService],
   exports: [AdminPanelService],

--- a/packages/twenty-server/src/engine/core-modules/admin-panel/admin-panel.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/admin-panel/admin-panel.resolver.ts
@@ -26,6 +26,7 @@ import { type MessageQueue } from 'src/engine/core-modules/message-queue/message
 import { type ConfigVariables } from 'src/engine/core-modules/twenty-config/config-variables';
 import { ConfigVariableGraphqlApiExceptionFilter } from 'src/engine/core-modules/twenty-config/filters/config-variable-graphql-api-exception.filter';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
+import { AuthUser } from 'src/engine/decorators/auth/auth-user.decorator';
 import { AdminPanelGuard } from 'src/engine/guards/admin-panel-guard';
 import { ImpersonateGuard } from 'src/engine/guards/impersonate-guard';
 import { UserAuthGuard } from 'src/engine/guards/user-auth.guard';
@@ -53,8 +54,9 @@ export class AdminPanelResolver {
   @Mutation(() => ImpersonateOutput)
   async impersonate(
     @Args() { workspaceId, userId }: ImpersonateInput,
+    @AuthUser() adminUser: { id: string },
   ): Promise<ImpersonateOutput> {
-    return await this.adminService.impersonate(userId, workspaceId);
+    return await this.adminService.impersonate(userId, workspaceId, adminUser.id);
   }
 
   @UseGuards(WorkspaceAuthGuard, UserAuthGuard, ImpersonateGuard)

--- a/packages/twenty-server/src/engine/core-modules/admin-panel/admin-panel.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/admin-panel/admin-panel.resolver.ts
@@ -1,7 +1,6 @@
 import { UseFilters, UseGuards, UsePipes } from '@nestjs/common';
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
 
-import { User } from '@microsoft/microsoft-graph-types';
 import GraphQLJSON from 'graphql-type-json';
 
 import { AdminPanelHealthService } from 'src/engine/core-modules/admin-panel/admin-panel-health.service';
@@ -31,6 +30,7 @@ import { type MessageQueue } from 'src/engine/core-modules/message-queue/message
 import { type ConfigVariables } from 'src/engine/core-modules/twenty-config/config-variables';
 import { ConfigVariableGraphqlApiExceptionFilter } from 'src/engine/core-modules/twenty-config/filters/config-variable-graphql-api-exception.filter';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
+import { User } from 'src/engine/core-modules/user/user.entity';
 import { AuthUser } from 'src/engine/decorators/auth/auth-user.decorator';
 import { AdminPanelGuard } from 'src/engine/guards/admin-panel-guard';
 import { ImpersonateGuard } from 'src/engine/guards/impersonate-guard';

--- a/packages/twenty-server/src/engine/core-modules/admin-panel/admin-panel.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/admin-panel/admin-panel.resolver.ts
@@ -56,7 +56,11 @@ export class AdminPanelResolver {
     @Args() { workspaceId, userId }: ImpersonateInput,
     @AuthUser() adminUser: { id: string },
   ): Promise<ImpersonateOutput> {
-    return await this.adminService.impersonate(userId, workspaceId, adminUser.id);
+    return await this.adminService.impersonate(
+      userId,
+      workspaceId,
+      adminUser.id,
+    );
   }
 
   @UseGuards(WorkspaceAuthGuard, UserAuthGuard, ImpersonateGuard)

--- a/packages/twenty-server/src/engine/core-modules/admin-panel/admin-panel.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/admin-panel/admin-panel.service.ts
@@ -87,7 +87,6 @@ export class AdminPanelService {
         user.userWorkspaces[0].workspace.id,
         AuthProviderEnum.Impersonation,
         {
-          isImpersonation: true,
           impersonatorUserId,
         },
       );

--- a/packages/twenty-server/src/engine/core-modules/admin-panel/admin-panel.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/admin-panel/admin-panel.service.ts
@@ -66,18 +66,18 @@ export class AdminPanelService {
       ),
     );
 
-    const analytics = this.auditService.createContext({
+    const auditService = this.auditService.createContext({
       workspaceId: user.userWorkspaces[0].workspace.id,
       userId: impersonatorUserId,
     });
 
-    await analytics.insertWorkspaceEvent(MONITORING_EVENT, {
+    await auditService.insertWorkspaceEvent(MONITORING_EVENT, {
       eventName: 'server.impersonation.attempt',
       message: `Impersonation attempt: targetUserId=${userId}, workspaceId=${workspaceId}, impersonatorUserId=${impersonatorUserId}`,
     });
 
     try {
-      await analytics.insertWorkspaceEvent(MONITORING_EVENT, {
+      await auditService.insertWorkspaceEvent(MONITORING_EVENT, {
         eventName: 'server.impersonation.login_token_attempt',
         message: `Impersonation token generation attempt for user ${userId}`,
       });
@@ -91,7 +91,7 @@ export class AdminPanelService {
         },
       );
 
-      await analytics.insertWorkspaceEvent(MONITORING_EVENT, {
+      await auditService.insertWorkspaceEvent(MONITORING_EVENT, {
         eventName: 'server.impersonation.login_token_generated',
         message: `Impersonation token generated successfully for user ${userId}`,
       });
@@ -106,7 +106,7 @@ export class AdminPanelService {
         loginToken,
       };
     } catch {
-      await analytics.insertWorkspaceEvent(MONITORING_EVENT, {
+      await auditService.insertWorkspaceEvent(MONITORING_EVENT, {
         eventName: 'server.impersonation.login_token_failed',
         message: `Impersonation token generation failed for targetUserId=${userId}`,
       });

--- a/packages/twenty-server/src/engine/core-modules/audit/README.md
+++ b/packages/twenty-server/src/engine/core-modules/audit/README.md
@@ -23,23 +23,23 @@ export class MyService {
 
   async doSomething() {
     // Create an analytics context
-    const analytics = this.auditService.createContext({
+    const auditService = this.auditService.createContext({
       workspaceId: 'workspace-id',
       userId: 'user-id',
     });
 
     // Track a workspace event
-    analytics.insertWorkspaceEvent(CUSTOM_DOMAIN_ACTIVATED_EVENT, {});
+    auditService.insertWorkspaceEvent(CUSTOM_DOMAIN_ACTIVATED_EVENT, {});
     
     // Track an object event
-    analytics.createObjectEvent(OBJECT_RECORD_CREATED_EVENT, {
+    auditService.createObjectEvent(OBJECT_RECORD_CREATED_EVENT, {
       recordId: 'record-id',
       objectMetadataId: 'object-metadata-id',
       // other properties
     });
     
     // Track a pageview
-    analytics.createPageviewEvent('page-name', {
+    auditService.createPageviewEvent('page-name', {
       href: '/path',
       locale: 'en-US',
       // other properties

--- a/packages/twenty-server/src/engine/core-modules/audit/jobs/create-audit-log-from-internal-event.ts
+++ b/packages/twenty-server/src/engine/core-modules/audit/jobs/create-audit-log-from-internal-event.ts
@@ -26,26 +26,26 @@ export class CreateAuditLogFromInternalEvent {
             }
           : eventData.properties;
 
-      const analytics = this.auditService.createContext({
+      const auditService = this.auditService.createContext({
         workspaceId: workspaceEventBatch.workspaceId,
         userId: eventData.userId,
       });
 
       // Since these are object record events, we use createObjectEvent
       if (workspaceEventBatch.name.endsWith('.updated')) {
-        analytics.createObjectEvent(OBJECT_RECORD_UPDATED_EVENT, {
+        auditService.createObjectEvent(OBJECT_RECORD_UPDATED_EVENT, {
           ...eventProperties,
           recordId: eventData.recordId,
           objectMetadataId: eventData.objectMetadata.id,
         });
       } else if (workspaceEventBatch.name.endsWith('.created')) {
-        analytics.createObjectEvent(OBJECT_RECORD_CREATED_EVENT, {
+        auditService.createObjectEvent(OBJECT_RECORD_CREATED_EVENT, {
           ...eventProperties,
           recordId: eventData.recordId,
           objectMetadataId: eventData.objectMetadata.id,
         });
       } else if (workspaceEventBatch.name.endsWith('.deleted')) {
-        analytics.createObjectEvent(OBJECT_RECORD_DELETED_EVENT, {
+        auditService.createObjectEvent(OBJECT_RECORD_DELETED_EVENT, {
           ...eventProperties,
           recordId: eventData.recordId,
           objectMetadataId: eventData.objectMetadata.id,

--- a/packages/twenty-server/src/engine/core-modules/auth/auth.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/auth.module.ts
@@ -8,6 +8,7 @@ import { ApiKey } from 'src/engine/core-modules/api-key/api-key.entity';
 import { ApiKeyModule } from 'src/engine/core-modules/api-key/api-key.module';
 import { AppToken } from 'src/engine/core-modules/app-token/app-token.entity';
 import { AppTokenService } from 'src/engine/core-modules/app-token/services/app-token.service';
+import { AuditModule } from 'src/engine/core-modules/audit/audit.module';
 import { GoogleAPIsAuthController } from 'src/engine/core-modules/auth/controllers/google-apis-auth.controller';
 import { GoogleAuthController } from 'src/engine/core-modules/auth/controllers/google-auth.controller';
 import { MicrosoftAPIsAuthController } from 'src/engine/core-modules/auth/controllers/microsoft-apis-auth.controller';
@@ -107,6 +108,7 @@ import { JwtAuthStrategy } from './strategies/jwt.auth.strategy';
     UserRoleModule,
     TwoFactorAuthenticationModule,
     ApiKeyModule,
+    AuditModule,
   ],
   controllers: [
     GoogleAuthController,

--- a/packages/twenty-server/src/engine/core-modules/auth/auth.resolver.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/auth.resolver.spec.ts
@@ -4,6 +4,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 
 import { ApiKeyService } from 'src/engine/core-modules/api-key/api-key.service';
 import { AppToken } from 'src/engine/core-modules/app-token/app-token.entity';
+import { AuditService } from 'src/engine/core-modules/audit/services/audit.service';
 import { SignInUpService } from 'src/engine/core-modules/auth/services/sign-in-up.service';
 import { RefreshTokenService } from 'src/engine/core-modules/auth/token/services/refresh-token.service';
 import { WorkspaceAgnosticTokenService } from 'src/engine/core-modules/auth/token/services/workspace-agnostic-token.service';
@@ -124,6 +125,14 @@ describe('AuthResolver', () => {
         {
           provide: TwentyConfigService,
           useValue: {},
+        },
+        {
+          provide: AuditService,
+          useValue: {
+            createContext: jest.fn().mockReturnValue({
+              insertWorkspaceEvent: jest.fn(),
+            }),
+          },
         },
         // {
         //   provide: OAuthService,

--- a/packages/twenty-server/src/engine/core-modules/auth/auth.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/auth.resolver.ts
@@ -574,7 +574,7 @@ export class AuthResolver {
         userId: user.id,
         workspaceId,
       });
-      
+
     if (isImpersonation === true) {
       this.logger.log(
         `Impersonation token exchange attempt for ${email} by ${impersonatorUserId}`,
@@ -593,7 +593,9 @@ export class AuthResolver {
         );
       }
 
-      const impersonatorUser = await this.userRepository.findOne({ where: { id: impersonatorUserId } });
+      const impersonatorUser = await this.userRepository.findOne({
+        where: { id: impersonatorUserId },
+      });
 
       if (!impersonatorUser || impersonatorUser.canImpersonate !== true) {
         throw new AuthException(
@@ -606,6 +608,7 @@ export class AuthResolver {
         workspaceId: workspace.id,
         userId: impersonatorUserId,
       });
+
       await analytics.insertWorkspaceEvent(MONITORING_EVENT, {
         eventName: 'server.impersonation.login_token_exchanged',
         message: 'Impersonation token exchanged',

--- a/packages/twenty-server/src/engine/core-modules/auth/auth.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/auth.resolver.ts
@@ -557,7 +557,7 @@ export class AuthResolver {
       tokenPayload.workspaceId,
     );
 
-    if (tokenPayload.isImpersonation === true) {
+    if (tokenPayload.authProvider === AuthProviderEnum.Impersonation) {
       await this.validateAndLogImpersonation(
         tokenPayload,
         workspace,

--- a/packages/twenty-server/src/engine/core-modules/auth/auth.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/auth.resolver.ts
@@ -641,12 +641,12 @@ export class AuthResolver {
   ): Promise<void> {
     const { impersonatorUserId } = tokenPayload;
 
-    const analytics = this.auditService.createContext({
+    const auditService = this.auditService.createContext({
       workspaceId: workspace.id,
       userId: impersonatorUserId,
     });
 
-    await analytics.insertWorkspaceEvent(MONITORING_EVENT, {
+    await auditService.insertWorkspaceEvent(MONITORING_EVENT, {
       eventName: 'server.impersonation.token_exchange_attempt',
       message: `Impersonation token exchange attempt for ${targetUserEmail} by ${impersonatorUserId}`,
     });
@@ -659,7 +659,7 @@ export class AuthResolver {
     }
 
     if (!impersonatorUserId) {
-      await analytics.insertWorkspaceEvent(MONITORING_EVENT, {
+      await auditService.insertWorkspaceEvent(MONITORING_EVENT, {
         eventName: 'server.impersonation.token_exchange_failed',
         message: `Invalid impersonation token (missing impersonator user ID) for ${targetUserEmail}`,
       });
@@ -674,7 +674,7 @@ export class AuthResolver {
     });
 
     if (!impersonatorUser) {
-      await analytics.insertWorkspaceEvent(MONITORING_EVENT, {
+      await auditService.insertWorkspaceEvent(MONITORING_EVENT, {
         eventName: 'server.impersonation.token_exchange_failed',
         message: `Impersonator user not found: ${impersonatorUserId} for ${targetUserEmail}`,
       });
@@ -685,7 +685,7 @@ export class AuthResolver {
     }
 
     if (impersonatorUser.canImpersonate !== true) {
-      await analytics.insertWorkspaceEvent(MONITORING_EVENT, {
+      await auditService.insertWorkspaceEvent(MONITORING_EVENT, {
         eventName: 'server.impersonation.token_exchange_failed',
         message: `User not authorized to impersonate: ${impersonatorUserId} for ${targetUserEmail}`,
       });
@@ -702,12 +702,12 @@ export class AuthResolver {
     workspaceId: string,
     impersonatorUserId: string,
   ): Promise<void> {
-    const analytics = this.auditService.createContext({
+    const auditService = this.auditService.createContext({
       workspaceId,
       userId: impersonatorUserId,
     });
 
-    await analytics.insertWorkspaceEvent(MONITORING_EVENT, {
+    await auditService.insertWorkspaceEvent(MONITORING_EVENT, {
       eventName: 'server.impersonation.login_token_exchanged',
       message: 'Impersonation token exchanged',
     });

--- a/packages/twenty-server/src/engine/core-modules/auth/services/auth.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/auth.service.ts
@@ -268,7 +268,7 @@ export class AuthService {
   async verify(
     email: string,
     workspaceId: string,
-    authProvider?: AuthProviderEnum,
+    authProvider: AuthProviderEnum,
   ): Promise<AuthTokens> {
     if (!email) {
       throw new AuthException(

--- a/packages/twenty-server/src/engine/core-modules/auth/token/services/access-token.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/token/services/access-token.service.spec.ts
@@ -13,6 +13,7 @@ import { JwtWrapperService } from 'src/engine/core-modules/jwt/services/jwt-wrap
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import { UserWorkspace } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
 import { User } from 'src/engine/core-modules/user/user.entity';
+import { AuthProviderEnum } from 'src/engine/core-modules/workspace/types/workspace.type';
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.manager';
 
@@ -131,7 +132,11 @@ describe('AccessTokenService', () => {
         } as any);
       jest.spyOn(jwtWrapperService, 'sign').mockReturnValue(mockToken);
 
-      const result = await service.generateAccessToken({ userId, workspaceId });
+      const result = await service.generateAccessToken({
+        userId,
+        workspaceId,
+        authProvider: AuthProviderEnum.Password,
+      });
 
       expect(result).toEqual({
         token: mockToken,
@@ -155,6 +160,7 @@ describe('AccessTokenService', () => {
         service.generateAccessToken({
           userId: 'non-existent-user',
           workspaceId: 'workspace-id',
+          authProvider: AuthProviderEnum.Password,
         }),
       ).rejects.toThrow(AuthException);
     });

--- a/packages/twenty-server/src/engine/core-modules/auth/token/services/login-token.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/token/services/login-token.service.spec.ts
@@ -74,7 +74,13 @@ describe('LoginTokenService', () => {
         'LOGIN_TOKEN_EXPIRES_IN',
       );
       expect(jwtWrapperService.sign).toHaveBeenCalledWith(
-        { sub: email, workspaceId, type: 'LOGIN' },
+        {
+          sub: email,
+          workspaceId,
+          type: 'LOGIN',
+          authProvider: AuthProviderEnum.Password,
+          impersonatorUserId: undefined,
+        },
         { secret: mockSecret, expiresIn: mockExpiresIn },
       );
     });
@@ -91,6 +97,7 @@ describe('LoginTokenService', () => {
       jest
         .spyOn(jwtWrapperService, 'generateAppSecret')
         .mockReturnValue(mockSecret);
+      jest.spyOn(twentyConfigService, 'get').mockReturnValue('1h');
       jest.spyOn(jwtWrapperService, 'sign').mockReturnValue(mockToken);
 
       const result = await service.generateLoginToken(

--- a/packages/twenty-server/src/engine/core-modules/auth/token/services/login-token.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/token/services/login-token.service.spec.ts
@@ -81,13 +81,18 @@ describe('LoginTokenService', () => {
       const mockSecret = 'mock-secret';
       const mockToken = 'mock-token';
       const workspaceId = 'workspace-id';
-      
+
       jest
         .spyOn(jwtWrapperService, 'generateAppSecret')
         .mockReturnValue(mockSecret);
       jest.spyOn(jwtWrapperService, 'sign').mockReturnValue(mockToken);
 
-      const result = await service.generateLoginToken(email, workspaceId, undefined, { isImpersonation: true });
+      const result = await service.generateLoginToken(
+        email,
+        workspaceId,
+        undefined,
+        { isImpersonation: true },
+      );
 
       expect(result).toEqual({
         token: mockToken,

--- a/packages/twenty-server/src/engine/core-modules/auth/token/services/login-token.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/token/services/login-token.service.spec.ts
@@ -75,6 +75,35 @@ describe('LoginTokenService', () => {
     });
   });
 
+  describe('generateLoginToken with impersonation', () => {
+    it('should include isImpersonation flag in JWT payload', async () => {
+      const email = 'test@example.com';
+      const mockSecret = 'mock-secret';
+      const mockToken = 'mock-token';
+      const workspaceId = 'workspace-id';
+      
+      jest
+        .spyOn(jwtWrapperService, 'generateAppSecret')
+        .mockReturnValue(mockSecret);
+      jest.spyOn(jwtWrapperService, 'sign').mockReturnValue(mockToken);
+
+      const result = await service.generateLoginToken(email, workspaceId, undefined, { isImpersonation: true });
+
+      expect(result).toEqual({
+        token: mockToken,
+        expiresAt: expect.any(Date),
+      });
+      expect(jwtWrapperService.generateAppSecret).toHaveBeenCalledWith(
+        'LOGIN',
+        workspaceId,
+      );
+      expect(jwtWrapperService.sign).toHaveBeenCalledWith(
+        { sub: email, workspaceId, type: 'LOGIN', isImpersonation: true },
+        { secret: mockSecret, expiresIn: expect.any(String) },
+      );
+    });
+  });
+
   describe('verifyLoginToken', () => {
     it('should verify a login token successfully', async () => {
       const mockToken = 'valid-token';

--- a/packages/twenty-server/src/engine/core-modules/auth/token/services/login-token.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/token/services/login-token.service.ts
@@ -23,14 +23,13 @@ export class LoginTokenService {
     email: string,
     workspaceId: string,
     authProvider: AuthProviderEnum,
-    options?: { isImpersonation?: boolean; impersonatorUserId?: string },
+    options?: { impersonatorUserId?: string },
   ): Promise<AuthToken> {
     const jwtPayload: LoginTokenJwtPayload = {
       type: JwtTokenTypeEnum.LOGIN,
       sub: email,
       workspaceId,
       authProvider,
-      isImpersonation: options?.isImpersonation,
       impersonatorUserId: options?.impersonatorUserId,
     };
 

--- a/packages/twenty-server/src/engine/core-modules/auth/token/services/login-token.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/token/services/login-token.service.ts
@@ -23,12 +23,15 @@ export class LoginTokenService {
     email: string,
     workspaceId: string,
     authProvider?: AuthProviderEnum,
+    options?: { isImpersonation?: boolean; impersonatorUserId?: string },
   ): Promise<AuthToken> {
     const jwtPayload: LoginTokenJwtPayload = {
       type: JwtTokenTypeEnum.LOGIN,
       sub: email,
       workspaceId,
       authProvider,
+      isImpersonation: options?.isImpersonation,
+      impersonatorUserId: options?.impersonatorUserId,
     };
 
     const secret = this.jwtWrapperService.generateAppSecret(

--- a/packages/twenty-server/src/engine/core-modules/auth/token/services/login-token.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/token/services/login-token.service.ts
@@ -4,12 +4,12 @@ import { addMilliseconds } from 'date-fns';
 import ms from 'ms';
 
 import { type AuthToken } from 'src/engine/core-modules/auth/dto/token.entity';
-import { JwtWrapperService } from 'src/engine/core-modules/jwt/services/jwt-wrapper.service';
-import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import {
   type LoginTokenJwtPayload,
   JwtTokenTypeEnum,
 } from 'src/engine/core-modules/auth/types/auth-context.type';
+import { JwtWrapperService } from 'src/engine/core-modules/jwt/services/jwt-wrapper.service';
+import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import { type AuthProviderEnum } from 'src/engine/core-modules/workspace/types/workspace.type';
 
 @Injectable()
@@ -22,7 +22,7 @@ export class LoginTokenService {
   async generateLoginToken(
     email: string,
     workspaceId: string,
-    authProvider?: AuthProviderEnum,
+    authProvider: AuthProviderEnum,
     options?: { isImpersonation?: boolean; impersonatorUserId?: string },
   ): Promise<AuthToken> {
     const jwtPayload: LoginTokenJwtPayload = {

--- a/packages/twenty-server/src/engine/core-modules/auth/token/services/renew-token.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/token/services/renew-token.service.spec.ts
@@ -10,6 +10,7 @@ import { RefreshTokenService } from 'src/engine/core-modules/auth/token/services
 import { WorkspaceAgnosticTokenService } from 'src/engine/core-modules/auth/token/services/workspace-agnostic-token.service';
 import { JwtTokenTypeEnum } from 'src/engine/core-modules/auth/types/auth-context.type';
 import { type User } from 'src/engine/core-modules/user/user.entity';
+import { AuthProviderEnum } from 'src/engine/core-modules/workspace/types/workspace.type';
 
 import { RenewTokenService } from './renew-token.service';
 
@@ -86,7 +87,7 @@ describe('RenewTokenService', () => {
       jest.spyOn(refreshTokenService, 'verifyRefreshToken').mockResolvedValue({
         user: mockUser,
         token: mockAppToken as AppToken,
-        authProvider: undefined,
+        authProvider: AuthProviderEnum.Password,
         targetedTokenType: JwtTokenTypeEnum.ACCESS,
       });
       jest.spyOn(appTokenRepository, 'update').mockResolvedValue({} as any);
@@ -114,9 +115,10 @@ describe('RenewTokenService', () => {
       expect(accessTokenService.generateAccessToken).toHaveBeenCalledWith({
         userId: mockUser.id,
         workspaceId: mockWorkspaceId,
+        authProvider: AuthProviderEnum.Password,
       });
       expect(refreshTokenService.generateRefreshToken).toHaveBeenCalledWith({
-        authProvider: undefined,
+        authProvider: AuthProviderEnum.Password,
         targetedTokenType: JwtTokenTypeEnum.ACCESS,
         userId: mockUser.id,
         workspaceId: mockWorkspaceId,

--- a/packages/twenty-server/src/engine/core-modules/auth/token/services/renew-token.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/token/services/renew-token.service.ts
@@ -59,6 +59,7 @@ export class RenewTokenService {
       targetedTokenTypeFromPayload ?? JwtTokenTypeEnum.ACCESS;
 
     // Support legacy tokens where authProvider might be undefined
+    // TODO: remove in November 2025
     const resolvedAuthProvider = authProvider ?? AuthProviderEnum.Password;
 
     const accessToken =

--- a/packages/twenty-server/src/engine/core-modules/auth/token/services/renew-token.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/token/services/renew-token.service.ts
@@ -14,6 +14,7 @@ import { AccessTokenService } from 'src/engine/core-modules/auth/token/services/
 import { RefreshTokenService } from 'src/engine/core-modules/auth/token/services/refresh-token.service';
 import { WorkspaceAgnosticTokenService } from 'src/engine/core-modules/auth/token/services/workspace-agnostic-token.service';
 import { JwtTokenTypeEnum } from 'src/engine/core-modules/auth/types/auth-context.type';
+import { AuthProviderEnum } from 'src/engine/core-modules/workspace/types/workspace.type';
 
 @Injectable()
 export class RenewTokenService {
@@ -57,6 +58,9 @@ export class RenewTokenService {
     const targetedTokenType =
       targetedTokenTypeFromPayload ?? JwtTokenTypeEnum.ACCESS;
 
+    // Support legacy tokens where authProvider might be undefined
+    const resolvedAuthProvider = authProvider ?? AuthProviderEnum.Password;
+
     const accessToken =
       isDefined(authProvider) &&
       targetedTokenType === JwtTokenTypeEnum.WORKSPACE_AGNOSTIC
@@ -69,13 +73,13 @@ export class RenewTokenService {
         : await this.accessTokenService.generateAccessToken({
             userId: user.id,
             workspaceId,
-            authProvider,
+            authProvider: resolvedAuthProvider,
           });
 
     const refreshToken = await this.refreshTokenService.generateRefreshToken({
       userId: user.id,
       workspaceId,
-      authProvider,
+      authProvider: resolvedAuthProvider,
       targetedTokenType,
     });
 

--- a/packages/twenty-server/src/engine/core-modules/auth/types/auth-context.type.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/types/auth-context.type.ts
@@ -43,8 +43,7 @@ export type FileTokenJwtPayload = CommonPropertiesJwtPayload & {
 export type LoginTokenJwtPayload = CommonPropertiesJwtPayload & {
   type: JwtTokenTypeEnum.LOGIN;
   workspaceId: string;
-  authProvider?: AuthProviderEnum;
-  isImpersonation?: boolean;
+  authProvider: AuthProviderEnum;
   impersonatorUserId?: string;
 };
 
@@ -83,7 +82,7 @@ export type AccessTokenJwtPayload = CommonPropertiesJwtPayload & {
   userId: string;
   workspaceMemberId?: string;
   userWorkspaceId: string;
-  authProvider?: AuthProviderEnum;
+  authProvider: AuthProviderEnum;
 };
 
 export type PostgresProxyTokenJwtPayload = CommonPropertiesJwtPayload & {

--- a/packages/twenty-server/src/engine/core-modules/auth/types/auth-context.type.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/types/auth-context.type.ts
@@ -44,6 +44,8 @@ export type LoginTokenJwtPayload = CommonPropertiesJwtPayload & {
   type: JwtTokenTypeEnum.LOGIN;
   workspaceId: string;
   authProvider?: AuthProviderEnum;
+  isImpersonation?: boolean;
+  impersonatorUserId?: string;
 };
 
 export type TransientTokenJwtPayload = CommonPropertiesJwtPayload & {

--- a/packages/twenty-server/src/engine/core-modules/domain-manager/controllers/cloudflare.controller.ts
+++ b/packages/twenty-server/src/engine/core-modules/domain-manager/controllers/cloudflare.controller.ts
@@ -71,7 +71,7 @@ export class CloudflareController {
 
       if (!workspace) return;
 
-      const analytics = this.auditService.createContext({
+      const auditService = this.auditService.createContext({
         workspaceId: workspace.id,
       });
 
@@ -100,7 +100,10 @@ export class CloudflareController {
           ...workspaceUpdated,
         });
 
-        await analytics.insertWorkspaceEvent(CUSTOM_DOMAIN_ACTIVATED_EVENT, {});
+        await auditService.insertWorkspaceEvent(
+          CUSTOM_DOMAIN_ACTIVATED_EVENT,
+          {},
+        );
       }
 
       return res.status(200).send();

--- a/packages/twenty-server/src/engine/core-modules/domain-manager/services/custom-domain.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/domain-manager/services/custom-domain.service.ts
@@ -199,11 +199,11 @@ export class CustomDomainService {
 
       await this.workspaceRepository.save(workspace);
 
-      const analytics = this.auditService.createContext({
+      const auditService = this.auditService.createContext({
         workspaceId: workspace.id,
       });
 
-      analytics.insertWorkspaceEvent(
+      auditService.insertWorkspaceEvent(
         workspace.isCustomDomainEnabled
           ? CUSTOM_DOMAIN_ACTIVATED_EVENT
           : CUSTOM_DOMAIN_DEACTIVATED_EVENT,

--- a/packages/twenty-server/src/engine/core-modules/webhook/jobs/call-webhook.job.ts
+++ b/packages/twenty-server/src/engine/core-modules/webhook/jobs/call-webhook.job.ts
@@ -48,7 +48,7 @@ export class CallWebhookJob {
       webhookId: data.webhookId,
       eventName: data.eventName,
     };
-    const analytics = this.auditService.createContext({
+    const auditService = this.auditService.createContext({
       workspaceId: data.workspaceId,
     });
 
@@ -79,13 +79,13 @@ export class CallWebhookJob {
 
       const success = response.status >= 200 && response.status < 300;
 
-      analytics.insertWorkspaceEvent(WEBHOOK_RESPONSE_EVENT, {
+      auditService.insertWorkspaceEvent(WEBHOOK_RESPONSE_EVENT, {
         status: response.status,
         success,
         ...commonPayload,
       });
     } catch (err) {
-      analytics.insertWorkspaceEvent(WEBHOOK_RESPONSE_EVENT, {
+      auditService.insertWorkspaceEvent(WEBHOOK_RESPONSE_EVENT, {
         success: false,
         ...commonPayload,
         ...(err.response && { status: err.response.status }),

--- a/packages/twenty-server/src/engine/core-modules/workspace/types/workspace.type.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/types/workspace.type.ts
@@ -3,4 +3,5 @@ export enum AuthProviderEnum {
   Microsoft = 'microsoft',
   Password = 'password',
   SSO = 'sso',
+  Impersonation = 'impersonation',
 }


### PR DESCRIPTION
## Description

- This PR solves the a sub-issue from https://github.com/twentyhq/core-team-issues/issues/1421
- impersonation tokens bypasses 2FA as intended 
- Added Audit trails to cover all impersonation events
- Added Proper testing coverage


