### PR TITLE
Fix view advanced filters broken

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-5/1-5-migrate-views-to-core.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-5/1-5-migrate-views-to-core.command.ts
@@ -562,6 +562,7 @@ export class MigrateViewsToCoreCommand extends ActiveOrSuspendedWorkspacesMigrat
         createdAt: new Date(filter.createdAt),
         updatedAt: new Date(filter.updatedAt),
         deletedAt: filter.deletedAt ? new Date(filter.deletedAt) : null,
+        subFieldName: filter.subFieldName,
       };
 
       const repository = queryRunner.manager.getRepository(ViewFilterEntity);


### PR DESCRIPTION
## Context

We recently migrated from workspaceSchema.views to core.views. While doing it we've migrated views using 1-5-migrate-views-to-core command but we forgot to migrate the subFieldName

Closes: https://github.com/twentyhq/twenty/issues/14369