### PR TITLE
Implement ViewGroups optimistic rendering

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-index/hooks/useHandleRecordGroupField.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/hooks/useHandleRecordGroupField.ts
@@ -110,7 +110,12 @@ export const useHandleRecordGroupField = () => {
         }
 
         if (viewGroupsToDelete.length > 0) {
-          await deleteViewGroupRecords(viewGroupsToDelete);
+          await deleteViewGroupRecords(
+            viewGroupsToDelete.map((group) => ({
+              id: group.id,
+              viewId: view.id,
+            })),
+          );
         }
       },
     [
@@ -144,7 +149,12 @@ export const useHandleRecordGroupField = () => {
           return;
         }
 
-        await deleteViewGroupRecords(view.viewGroups);
+        await deleteViewGroupRecords(
+          view.viewGroups.map((group) => ({
+            id: group.id,
+            viewId: view.id,
+          })),
+        );
 
         setRecordGroupsFromViewGroups(view.id, [], objectMetadataItem);
       },

--- a/packages/twenty-front/src/modules/views/hooks/internal/usePersistViewGroupRecords.ts
+++ b/packages/twenty-front/src/modules/views/hooks/internal/usePersistViewGroupRecords.ts
@@ -3,8 +3,10 @@ import { useCallback } from 'react';
 import { CREATE_CORE_VIEW_GROUP } from '@/views/graphql/mutations/createCoreViewGroup';
 import { DESTROY_CORE_VIEW_GROUP } from '@/views/graphql/mutations/destroyCoreViewGroup';
 import { UPDATE_CORE_VIEW_GROUP } from '@/views/graphql/mutations/updateCoreViewGroup';
+import { useTriggerViewGroupOptimisticEffect } from '@/views/optimistic-effects/hooks/useTriggerViewGroupOptimisticEffect';
 import { type ViewGroup } from '@/views/types/ViewGroup';
 import { useApolloClient } from '@apollo/client';
+import { type CoreViewGroup } from '~/generated/graphql';
 
 type CreateViewGroupRecordsArgs = {
   viewGroupsToCreate: ViewGroup[];
@@ -13,6 +15,9 @@ type CreateViewGroupRecordsArgs = {
 
 export const usePersistViewGroupRecords = () => {
   const apolloClient = useApolloClient();
+
+  const { triggerViewGroupOptimisticEffect } =
+    useTriggerViewGroupOptimisticEffect();
 
   const createCoreViewGroupRecords = useCallback(
     ({ viewGroupsToCreate, viewId }: CreateViewGroupRecordsArgs) => {
@@ -32,11 +37,19 @@ export const usePersistViewGroupRecords = () => {
                 position: viewGroup.position,
               },
             },
+            update: (_cache, { data }) => {
+              const record = data?.['createCoreViewGroup'];
+              if (!record) return;
+
+              triggerViewGroupOptimisticEffect({
+                createdViewGroups: [record],
+              });
+            },
           }),
         ),
       );
     },
-    [apolloClient],
+    [apolloClient, triggerViewGroupOptimisticEffect],
   );
 
   const updateCoreViewGroupRecords = useCallback(
@@ -44,7 +57,7 @@ export const usePersistViewGroupRecords = () => {
       if (!viewGroupsToUpdate.length) return;
 
       const mutationPromises = viewGroupsToUpdate.map((viewGroup) =>
-        apolloClient.mutate<{ updateCoreViewGroup: ViewGroup }>({
+        apolloClient.mutate<{ updateCoreViewGroup: CoreViewGroup }>({
           mutation: UPDATE_CORE_VIEW_GROUP,
           variables: {
             id: viewGroup.id,
@@ -55,31 +68,20 @@ export const usePersistViewGroupRecords = () => {
           },
           // Avoid cache being updated with stale data
           fetchPolicy: 'no-cache',
+          update: (_cache, { data }) => {
+            const record = data?.['updateCoreViewGroup'];
+            if (!record) return;
+
+            triggerViewGroupOptimisticEffect({
+              updatedViewGroups: [record],
+            });
+          },
         }),
       );
 
-      const mutationResults = await Promise.all(mutationPromises);
-
-      // FixMe: Using useUpdateOneRecord hook that call triggerUpdateRecordsOptimisticEffect is actaully causing multiple records to be created
-      // This is a temporary fix
-      mutationResults.forEach(({ data }) => {
-        const record = data?.['updateCoreViewGroup'];
-
-        if (!record) return;
-
-        apolloClient.cache.modify({
-          id: apolloClient.cache.identify({
-            __typename: 'CoreViewGroup',
-            id: record.id,
-          }),
-          fields: {
-            isVisible: () => record.isVisible,
-            position: () => record.position,
-          },
-        });
-      });
+      return Promise.all(mutationPromises);
     },
-    [apolloClient],
+    [apolloClient, triggerViewGroupOptimisticEffect],
   );
 
   const deleteCoreViewGroupRecords = useCallback(
@@ -93,11 +95,19 @@ export const usePersistViewGroupRecords = () => {
             variables: {
               id: viewGroup.id,
             },
+            update: (_cache, { data }) => {
+              const record = data?.['destroyCoreViewGroup'];
+              if (!record) return;
+
+              triggerViewGroupOptimisticEffect({
+                deletedViewGroups: [record],
+              });
+            },
           }),
         ),
       );
     },
-    [apolloClient],
+    [apolloClient, triggerViewGroupOptimisticEffect],
   );
 
   return {

--- a/packages/twenty-front/src/modules/views/hooks/internal/usePersistViewGroupRecords.ts
+++ b/packages/twenty-front/src/modules/views/hooks/internal/usePersistViewGroupRecords.ts
@@ -85,7 +85,7 @@ export const usePersistViewGroupRecords = () => {
   );
 
   const deleteCoreViewGroupRecords = useCallback(
-    async (viewGroupsToDelete: ViewGroup[]) => {
+    async (viewGroupsToDelete: Pick<CoreViewGroup, 'id' | 'viewId'>[]) => {
       if (!viewGroupsToDelete.length) return;
 
       return Promise.all(
@@ -95,12 +95,9 @@ export const usePersistViewGroupRecords = () => {
             variables: {
               id: viewGroup.id,
             },
-            update: (_cache, { data }) => {
-              const record = data?.['destroyCoreViewGroup'];
-              if (!record) return;
-
+            update: () => {
               triggerViewGroupOptimisticEffect({
-                deletedViewGroups: [record],
+                deletedViewGroups: [viewGroup],
               });
             },
           }),

--- a/packages/twenty-front/src/modules/views/hooks/useSaveCurrentViewFiltersAndSorts.ts
+++ b/packages/twenty-front/src/modules/views/hooks/useSaveCurrentViewFiltersAndSorts.ts
@@ -16,8 +16,8 @@ export const useSaveCurrentViewFiltersAndSorts = () => {
 
   const saveCurrentViewFilterAndSorts = async () => {
     await saveRecordSortsToViewSorts();
-    await saveRecordFiltersToViewFilters();
     await saveRecordFilterGroupsToViewFilterGroups();
+    await saveRecordFiltersToViewFilters();
     await saveAnyFieldFilterToView();
   };
 

--- a/packages/twenty-front/src/modules/views/optimistic-effects/hooks/useTriggerViewGroupOptimisticEffect.ts
+++ b/packages/twenty-front/src/modules/views/optimistic-effects/hooks/useTriggerViewGroupOptimisticEffect.ts
@@ -1,0 +1,142 @@
+import { getSnapshotValue } from '@/ui/utilities/state/utils/getSnapshotValue';
+import { coreViewsState } from '@/views/states/coreViewState';
+import { type CoreViewWithRelations } from '@/views/types/CoreViewWithRelations';
+import { useApolloClient } from '@apollo/client';
+import { useRecoilCallback } from 'recoil';
+import { isDefined } from 'twenty-shared/utils';
+import { type CoreViewGroup } from '~/generated/graphql';
+import { isDeeplyEqual } from '~/utils/isDeeplyEqual';
+
+export const useTriggerViewGroupOptimisticEffect = () => {
+  const apolloClient = useApolloClient();
+
+  const cache = apolloClient.cache;
+
+  const triggerViewGroupOptimisticEffect = useRecoilCallback(
+    ({ set, snapshot }) =>
+      ({
+        createdViewGroups = [],
+        updatedViewGroups = [],
+        deletedViewGroups = [],
+      }: {
+        createdViewGroups?: CoreViewGroup[];
+        updatedViewGroups?: CoreViewGroup[];
+        deletedViewGroups?: CoreViewGroup[];
+      }) => {
+        const coreViews = getSnapshotValue(snapshot, coreViewsState);
+        let newCoreViews = [...coreViews];
+
+        createdViewGroups.forEach((createdViewGroup) => {
+          cache.modify<CoreViewWithRelations>({
+            id: cache.identify({
+              __typename: 'CoreView',
+              id: createdViewGroup.viewId,
+            }),
+            fields: {
+              viewGroups: (existingViewGroups, { toReference }) => [
+                ...(existingViewGroups ?? []),
+                toReference(createdViewGroup),
+              ],
+            },
+          });
+          const toBeModifiedCoreView = newCoreViews.find(
+            (coreView) => coreView.id === createdViewGroup.viewId,
+          );
+          if (isDefined(toBeModifiedCoreView)) {
+            newCoreViews = [
+              ...newCoreViews.filter(
+                (coreView) => coreView.id !== createdViewGroup.viewId,
+              ),
+              {
+                ...toBeModifiedCoreView,
+                viewGroups: [
+                  ...toBeModifiedCoreView.viewGroups,
+                  createdViewGroup,
+                ],
+              },
+            ];
+          }
+        });
+
+        updatedViewGroups.forEach((updatedViewGroup) => {
+          cache.modify<CoreViewWithRelations>({
+            id: cache.identify({
+              __typename: 'CoreView',
+              id: updatedViewGroup.viewId,
+            }),
+            fields: {
+              viewGroups: (existingViewGroups, { readField, toReference }) =>
+                existingViewGroups.map((viewGroup) => {
+                  const viewGroupId = readField<string>('id', viewGroup);
+                  if (viewGroupId === updatedViewGroup.id) {
+                    return toReference(updatedViewGroup);
+                  }
+                  return viewGroup;
+                }),
+            },
+          });
+          const toBeModifiedCoreView = newCoreViews.find(
+            (coreView) => coreView.id === updatedViewGroup.viewId,
+          );
+          if (isDefined(toBeModifiedCoreView)) {
+            newCoreViews = [
+              ...newCoreViews.filter(
+                (coreView) => coreView.id !== updatedViewGroup.viewId,
+              ),
+              {
+                ...toBeModifiedCoreView,
+                viewGroups: [
+                  ...toBeModifiedCoreView.viewGroups.filter(
+                    (viewGroup) => viewGroup.id !== updatedViewGroup.id,
+                  ),
+                  updatedViewGroup,
+                ],
+              },
+            ];
+          }
+        });
+
+        deletedViewGroups.forEach((deletedViewGroup) => {
+          cache.modify<CoreViewWithRelations>({
+            id: cache.identify({
+              __typename: 'CoreView',
+              id: deletedViewGroup.viewId,
+            }),
+            fields: {
+              viewGroups: (existingViewGroups, { readField }) =>
+                existingViewGroups.filter(
+                  (viewGroup) =>
+                    readField('id', viewGroup) !== deletedViewGroup.id,
+                ),
+            },
+          });
+          const toBeModifiedCoreView = newCoreViews.find(
+            (coreView) => coreView.id === deletedViewGroup.viewId,
+          );
+
+          if (isDefined(toBeModifiedCoreView)) {
+            newCoreViews = [
+              ...newCoreViews.filter(
+                (coreView) => coreView.id !== deletedViewGroup.viewId,
+              ),
+              {
+                ...toBeModifiedCoreView,
+                viewGroups: toBeModifiedCoreView.viewGroups.filter(
+                  (viewGroup) => viewGroup.id !== deletedViewGroup.id,
+                ),
+              },
+            ];
+          }
+        });
+
+        if (!isDeeplyEqual(coreViews, newCoreViews)) {
+          set(coreViewsState, newCoreViews);
+        }
+      },
+    [cache],
+  );
+
+  return {
+    triggerViewGroupOptimisticEffect,
+  };
+};

--- a/packages/twenty-front/src/modules/views/optimistic-effects/hooks/useTriggerViewGroupOptimisticEffect.ts
+++ b/packages/twenty-front/src/modules/views/optimistic-effects/hooks/useTriggerViewGroupOptimisticEffect.ts
@@ -21,7 +21,7 @@ export const useTriggerViewGroupOptimisticEffect = () => {
       }: {
         createdViewGroups?: CoreViewGroup[];
         updatedViewGroups?: CoreViewGroup[];
-        deletedViewGroups?: CoreViewGroup[];
+        deletedViewGroups?: Pick<CoreViewGroup, 'id' | 'viewId'>[];
       }) => {
         const coreViews = getSnapshotValue(snapshot, coreViewsState);
         let newCoreViews = [...coreViews];


### PR DESCRIPTION
# Context

We have recently migrated from workspace.views to core.views. While doing it, we've lost the optimistic rendering on views in frontend. This is an issue for viewField and viewGroups that are persisted without having an intermediate storing layer (viewFilters, viewSorts, viewFilterGroups are not directly persisted when we do the changes, therefore we have an underlying layer to keep them and the optimistic was implemented there already).

ViewFields have been treated in a previous PR, this PR focus on ViewGroups

## What
Optimistic on ViewGroups

## Other 
+ fix a bug in the sequencing to persist viewFilter + viewFilterGroups