### PR TITLE
Add flat map cache service

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/view/flat-view/flat-view.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/view/flat-view/flat-view.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { ViewEntity } from 'src/engine/core-modules/view/entities/view.entity';
+import { WorkspaceFlatViewMapCacheService } from 'src/engine/core-modules/view/flat-view/services/workspace-flat-view-map-cache.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([ViewEntity])],
+  providers: [WorkspaceFlatViewMapCacheService],
+  exports: [WorkspaceFlatViewMapCacheService],
+})
+export class FlatViewModule {}

--- a/packages/twenty-server/src/engine/core-modules/view/flat-view/services/workspace-flat-view-map-cache.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/view/flat-view/services/workspace-flat-view-map-cache.service.ts
@@ -24,7 +24,11 @@ export class WorkspaceFlatViewMapCacheService extends WorkspaceFlatMapCacheServi
     super(cacheStorageService);
   }
 
-  protected async computeFlatMap(workspaceId: string): Promise<FlatViewMaps> {
+  protected async computeFlatMap({
+    workspaceId,
+  }: {
+    workspaceId: string;
+  }): Promise<FlatViewMaps> {
     const views = await this.viewRepository.find({
       where: {
         workspaceId,

--- a/packages/twenty-server/src/engine/core-modules/view/flat-view/services/workspace-flat-view-map-cache.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/view/flat-view/services/workspace-flat-view-map-cache.service.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { Repository } from 'typeorm';
+
+import { InjectCacheStorage } from 'src/engine/core-modules/cache-storage/decorators/cache-storage.decorator';
+import { CacheStorageService } from 'src/engine/core-modules/cache-storage/services/cache-storage.service';
+import { CacheStorageNamespace } from 'src/engine/core-modules/cache-storage/types/cache-storage-namespace.enum';
+import { ViewEntity } from 'src/engine/core-modules/view/entities/view.entity';
+import { type FlatViewMaps } from 'src/engine/core-modules/view/flat-view/types/flat-view-maps.type';
+import { generateFlatViewMaps } from 'src/engine/core-modules/view/flat-view/utils/generate-flat-view-maps.util';
+import { WorkspaceFlatMapCache } from 'src/engine/workspace-flat-map-cache/decorators/workspace-flat-map-cache.decorator';
+import { WorkspaceFlatMapCacheService } from 'src/engine/workspace-flat-map-cache/services/workspace-flat-map-cache.service';
+
+@Injectable()
+@WorkspaceFlatMapCache('view')
+export class WorkspaceFlatViewMapCacheService extends WorkspaceFlatMapCacheService<FlatViewMaps> {
+  constructor(
+    @InjectCacheStorage(CacheStorageNamespace.EngineWorkspace)
+    cacheStorageService: CacheStorageService,
+    @InjectRepository(ViewEntity)
+    private readonly viewRepository: Repository<ViewEntity>,
+  ) {
+    super(cacheStorageService);
+  }
+
+  protected async computeFlatMap(workspaceId: string): Promise<FlatViewMaps> {
+    const views = await this.viewRepository.find({
+      where: {
+        workspaceId,
+      },
+      relations: ['viewFields'],
+      select: {
+        viewFields: {
+          id: true,
+        },
+      },
+    });
+
+    return generateFlatViewMaps(views);
+  }
+}

--- a/packages/twenty-server/src/engine/core-modules/view/services/view.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/view/services/view.service.ts
@@ -27,9 +27,9 @@ export class ViewService {
   ) {}
 
   async findByWorkspaceId(workspaceId: string): Promise<ViewEntity[]> {
-    await this.workspaceFlatViewMapCacheService.getExistingOrRecomputeFlatMaps(
+    await this.workspaceFlatViewMapCacheService.getExistingOrRecomputeFlatMaps({
       workspaceId,
-    );
+    });
 
     return this.viewRepository.find({
       where: {
@@ -126,9 +126,9 @@ export class ViewService {
 
     const createdView = await this.viewRepository.save(view);
 
-    await this.workspaceFlatViewMapCacheService.invalidateCache(
-      viewData.workspaceId,
-    );
+    await this.workspaceFlatViewMapCacheService.invalidateCache({
+      workspaceId: viewData.workspaceId,
+    });
 
     return createdView;
   }
@@ -155,7 +155,9 @@ export class ViewService {
       ...updateData,
     });
 
-    await this.workspaceFlatViewMapCacheService.invalidateCache(workspaceId);
+    await this.workspaceFlatViewMapCacheService.invalidateCache({
+      workspaceId,
+    });
 
     return { ...existingView, ...updatedView };
   }
@@ -175,7 +177,9 @@ export class ViewService {
 
     await this.viewRepository.softDelete(id);
 
-    await this.workspaceFlatViewMapCacheService.invalidateCache(workspaceId);
+    await this.workspaceFlatViewMapCacheService.invalidateCache({
+      workspaceId,
+    });
 
     return view;
   }
@@ -195,7 +199,9 @@ export class ViewService {
 
     await this.viewRepository.delete(id);
 
-    await this.workspaceFlatViewMapCacheService.invalidateCache(workspaceId);
+    await this.workspaceFlatViewMapCacheService.invalidateCache({
+      workspaceId,
+    });
 
     return true;
   }

--- a/packages/twenty-server/src/engine/core-modules/view/services/view.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/view/services/view.service.ts
@@ -27,10 +27,9 @@ export class ViewService {
   ) {}
 
   async findByWorkspaceId(workspaceId: string): Promise<ViewEntity[]> {
-    const flatViewMaps =
-      await this.workspaceFlatViewMapCacheService.getExistingOrRecomputeFlatMaps(
-        workspaceId,
-      );
+    await this.workspaceFlatViewMapCacheService.getExistingOrRecomputeFlatMaps(
+      workspaceId,
+    );
 
     return this.viewRepository.find({
       where: {

--- a/packages/twenty-server/src/engine/core-modules/view/services/view.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/view/services/view.service.ts
@@ -15,7 +15,6 @@ import {
   generateViewExceptionMessage,
   generateViewUserFriendlyExceptionMessage,
 } from 'src/engine/core-modules/view/exceptions/view.exception';
-import { WorkspaceFlatViewMapCacheService } from 'src/engine/core-modules/view/flat-view/services/workspace-flat-view-map-cache.service';
 
 @Injectable()
 export class ViewService {
@@ -23,14 +22,9 @@ export class ViewService {
     @InjectRepository(ViewEntity)
     private readonly viewRepository: Repository<ViewEntity>,
     private readonly i18nService: I18nService,
-    private readonly workspaceFlatViewMapCacheService: WorkspaceFlatViewMapCacheService,
   ) {}
 
   async findByWorkspaceId(workspaceId: string): Promise<ViewEntity[]> {
-    await this.workspaceFlatViewMapCacheService.getExistingOrRecomputeFlatMaps({
-      workspaceId,
-    });
-
     return this.viewRepository.find({
       where: {
         workspaceId,
@@ -124,13 +118,7 @@ export class ViewService {
       isCustom: true,
     });
 
-    const createdView = await this.viewRepository.save(view);
-
-    await this.workspaceFlatViewMapCacheService.invalidateCache({
-      workspaceId: viewData.workspaceId,
-    });
-
-    return createdView;
+    return this.viewRepository.save(view);
   }
 
   async update(
@@ -155,10 +143,6 @@ export class ViewService {
       ...updateData,
     });
 
-    await this.workspaceFlatViewMapCacheService.invalidateCache({
-      workspaceId,
-    });
-
     return { ...existingView, ...updatedView };
   }
 
@@ -177,10 +161,6 @@ export class ViewService {
 
     await this.viewRepository.softDelete(id);
 
-    await this.workspaceFlatViewMapCacheService.invalidateCache({
-      workspaceId,
-    });
-
     return view;
   }
 
@@ -198,10 +178,6 @@ export class ViewService {
     }
 
     await this.viewRepository.delete(id);
-
-    await this.workspaceFlatViewMapCacheService.invalidateCache({
-      workspaceId,
-    });
 
     return true;
   }

--- a/packages/twenty-server/src/engine/core-modules/view/view.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/view/view.module.ts
@@ -15,6 +15,7 @@ import { ViewFilterEntity } from 'src/engine/core-modules/view/entities/view-fil
 import { ViewGroupEntity } from 'src/engine/core-modules/view/entities/view-group.entity';
 import { ViewSortEntity } from 'src/engine/core-modules/view/entities/view-sort.entity';
 import { ViewEntity } from 'src/engine/core-modules/view/entities/view.entity';
+import { FlatViewModule } from 'src/engine/core-modules/view/flat-view/flat-view.module';
 import { ViewFieldResolver } from 'src/engine/core-modules/view/resolvers/view-field.resolver';
 import { ViewFilterGroupResolver } from 'src/engine/core-modules/view/resolvers/view-filter-group.resolver';
 import { ViewFilterResolver } from 'src/engine/core-modules/view/resolvers/view-filter.resolver';
@@ -48,6 +49,7 @@ import { WorkspaceMigrationV2Module } from 'src/engine/workspace-manager/workspa
     WorkspaceMetadataCacheModule,
     WorkspaceMigrationV2Module,
     ViewCacheModule,
+    FlatViewModule,
   ],
   controllers: [
     ViewController,

--- a/packages/twenty-server/src/engine/workspace-flat-map-cache/decorators/workspace-flat-map-cache.decorator.ts
+++ b/packages/twenty-server/src/engine/workspace-flat-map-cache/decorators/workspace-flat-map-cache.decorator.ts
@@ -1,0 +1,6 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const WORKSPACE_FLAT_MAP_CACHE_KEY = 'workspaceFlatMapCacheKey';
+
+export const WorkspaceFlatMapCache = (cacheKey: string) =>
+  SetMetadata(WORKSPACE_FLAT_MAP_CACHE_KEY, cacheKey);

--- a/packages/twenty-server/src/engine/workspace-flat-map-cache/exceptions/workspace-flat-map-cache.exception.ts
+++ b/packages/twenty-server/src/engine/workspace-flat-map-cache/exceptions/workspace-flat-map-cache.exception.ts
@@ -1,0 +1,12 @@
+import {
+  appendCommonExceptionCode,
+  CustomException,
+} from 'src/utils/custom-exception';
+
+export class WorkspaceFlatMapCacheException extends CustomException<
+  keyof typeof WorkspaceFlatMapCacheExceptionCode
+> {}
+
+export const WorkspaceFlatMapCacheExceptionCode = appendCommonExceptionCode({
+  MISSING_DECORATOR: 'MISSING_DECORATOR',
+} as const);

--- a/packages/twenty-server/src/engine/workspace-flat-map-cache/services/workspace-flat-map-cache.service.ts
+++ b/packages/twenty-server/src/engine/workspace-flat-map-cache/services/workspace-flat-map-cache.service.ts
@@ -1,0 +1,153 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+
+import crypto from 'crypto';
+
+import { InjectCacheStorage } from 'src/engine/core-modules/cache-storage/decorators/cache-storage.decorator';
+import { CacheStorageService } from 'src/engine/core-modules/cache-storage/services/cache-storage.service';
+import { CacheStorageNamespace } from 'src/engine/core-modules/cache-storage/types/cache-storage-namespace.enum';
+import { type FlatEntityMaps } from 'src/engine/core-modules/common/types/flat-entity-maps.type';
+import { type FlatEntity } from 'src/engine/core-modules/common/types/flat-entity.type';
+import { WORKSPACE_FLAT_MAP_CACHE_KEY } from 'src/engine/workspace-flat-map-cache/decorators/workspace-flat-map-cache.decorator';
+import {
+  WorkspaceFlatMapCacheException,
+  WorkspaceFlatMapCacheExceptionCode,
+} from 'src/engine/workspace-flat-map-cache/exceptions/workspace-flat-map-cache.exception';
+
+@Injectable()
+export abstract class WorkspaceFlatMapCacheService<
+  T extends FlatEntityMaps<FlatEntity>,
+> {
+  protected readonly logger = new Logger(this.constructor.name);
+
+  private readonly localCacheFlatMaps = new Map<string, T>();
+  private readonly localCacheHashes = new Map<string, string>();
+  private readonly reflector = new Reflector();
+
+  constructor(
+    @InjectCacheStorage(CacheStorageNamespace.EngineWorkspace)
+    private readonly cacheStorageService: CacheStorageService,
+  ) {}
+
+  protected abstract computeFlatMap(workspaceId: string): Promise<T>;
+
+  async getExistingOrRecomputeFlatMaps(workspaceId: string): Promise<T> {
+    const localCacheHash = this.localCacheHashes.get(workspaceId);
+    const remoteCacheHash = await this.getHashFromRemoteCache(workspaceId);
+
+    if (
+      localCacheHash &&
+      remoteCacheHash &&
+      localCacheHash === remoteCacheHash
+    ) {
+      return this.localCacheFlatMaps.get(workspaceId)!;
+    }
+
+    if (remoteCacheHash) {
+      const remoteCacheFlatMap =
+        await this.getFlatMapFromRemoteCache(workspaceId);
+
+      if (remoteCacheFlatMap) {
+        this.localCacheFlatMaps.set(workspaceId, remoteCacheFlatMap);
+        this.localCacheHashes.set(workspaceId, remoteCacheHash);
+
+        return remoteCacheFlatMap;
+      }
+    }
+
+    const freshFlatMap = await this.recomputeAndStoreInCache(workspaceId);
+
+    return freshFlatMap;
+  }
+
+  async recomputeAndStoreInCache(workspaceId: string): Promise<T> {
+    const freshFlatMap = await this.computeFlatMap(workspaceId);
+    const newHash = this.generateHash(freshFlatMap);
+
+    await this.setFlatMapInRemoteCache(workspaceId, freshFlatMap);
+    await this.setHashInRemoteCache(workspaceId, newHash);
+
+    this.localCacheFlatMaps.set(workspaceId, freshFlatMap);
+    this.localCacheHashes.set(workspaceId, newHash);
+
+    return freshFlatMap;
+  }
+
+  async invalidateCache(workspaceId: string): Promise<void> {
+    const { flatMapKey, hashKey } = this.buildRemoteCacheKeys(workspaceId);
+
+    await this.cacheStorageService.del(flatMapKey);
+    await this.cacheStorageService.del(hashKey);
+
+    this.localCacheFlatMaps.delete(workspaceId);
+    this.localCacheHashes.delete(workspaceId);
+
+    await this.recomputeAndStoreInCache(workspaceId);
+  }
+
+  private getFlatMapCacheKey(): string {
+    const cacheKey = this.reflector.get<string>(
+      WORKSPACE_FLAT_MAP_CACHE_KEY,
+      this.constructor,
+    );
+
+    if (!cacheKey) {
+      throw new WorkspaceFlatMapCacheException(
+        `${this.constructor.name} must be decorated with @WorkspaceFlatMapCache('cacheKey')`,
+        WorkspaceFlatMapCacheExceptionCode.MISSING_DECORATOR,
+      );
+    }
+
+    return cacheKey;
+  }
+
+  private buildRemoteCacheKeys(workspaceId: string) {
+    const cacheKey = this.getFlatMapCacheKey();
+
+    return {
+      flatMapKey: `flat-maps:${cacheKey}:${workspaceId}:flat-map`,
+      hashKey: `flat-maps:${cacheKey}:${workspaceId}:hash`,
+    };
+  }
+
+  private generateHash(flatMap: T): string {
+    return crypto
+      .createHash('sha256')
+      .update(JSON.stringify(flatMap))
+      .digest('hex');
+  }
+
+  private async getHashFromRemoteCache(
+    workspaceId: string,
+  ): Promise<string | undefined> {
+    const { hashKey } = this.buildRemoteCacheKeys(workspaceId);
+
+    return this.cacheStorageService.get<string>(hashKey);
+  }
+
+  private async setHashInRemoteCache(
+    workspaceId: string,
+    hash: string,
+  ): Promise<void> {
+    const { hashKey } = this.buildRemoteCacheKeys(workspaceId);
+
+    await this.cacheStorageService.set(hashKey, hash);
+  }
+
+  private async getFlatMapFromRemoteCache(
+    workspaceId: string,
+  ): Promise<T | undefined> {
+    const { flatMapKey } = this.buildRemoteCacheKeys(workspaceId);
+
+    return this.cacheStorageService.get<T>(flatMapKey);
+  }
+
+  private async setFlatMapInRemoteCache(
+    workspaceId: string,
+    flatMap: T,
+  ): Promise<void> {
+    const { flatMapKey } = this.buildRemoteCacheKeys(workspaceId);
+
+    await this.cacheStorageService.set(flatMapKey, flatMap);
+  }
+}

--- a/packages/twenty-server/src/engine/workspace-flat-map-cache/services/workspace-flat-map-cache.service.ts
+++ b/packages/twenty-server/src/engine/workspace-flat-map-cache/services/workspace-flat-map-cache.service.ts
@@ -40,7 +40,11 @@ export abstract class WorkspaceFlatMapCacheService<
       remoteCacheHash &&
       localCacheHash === remoteCacheHash
     ) {
-      return this.localCacheFlatMaps.get(workspaceId)!;
+      const localCacheFlatMap = this.localCacheFlatMaps.get(workspaceId);
+
+      if (localCacheFlatMap) {
+        return localCacheFlatMap;
+      }
     }
 
     if (remoteCacheHash) {
@@ -113,7 +117,7 @@ export abstract class WorkspaceFlatMapCacheService<
   private generateHash(flatMap: T): string {
     return crypto
       .createHash('sha256')
-      .update(JSON.stringify(flatMap))
+      .update(JSON.stringify(flatMap, Object.keys(flatMap).sort()))
       .digest('hex');
   }
 

--- a/packages/twenty-server/src/engine/workspace-flat-map-cache/workspace-flat-map-cache.module.ts
+++ b/packages/twenty-server/src/engine/workspace-flat-map-cache/workspace-flat-map-cache.module.ts
@@ -1,8 +1,7 @@
-import { Global, Module } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 
 import { CacheStorageModule } from 'src/engine/core-modules/cache-storage/cache-storage.module';
 
-@Global()
 @Module({
   imports: [CacheStorageModule],
   providers: [],

--- a/packages/twenty-server/src/engine/workspace-flat-map-cache/workspace-flat-map-cache.module.ts
+++ b/packages/twenty-server/src/engine/workspace-flat-map-cache/workspace-flat-map-cache.module.ts
@@ -1,0 +1,11 @@
+import { Global, Module } from '@nestjs/common';
+
+import { CacheStorageModule } from 'src/engine/core-modules/cache-storage/cache-storage.module';
+
+@Global()
+@Module({
+  imports: [CacheStorageModule],
+  providers: [],
+  exports: [],
+})
+export class WorkspaceFlatMapCacheModule {}


### PR DESCRIPTION
## Context
Adding a new service that provides an abstract caching system for FlatEntityMaps. 
This takes care of cache invalidation and storing local and remote cache for the map with retrieval after a comparison with map hash between local and remote (redis).

## Implementation
Remote (redis) keys
- Flat map data: `engine:workspace:flat-maps:{flatMapKey}:{workspaceId}:flat-map`
- Content hash: `engine:workspace:flat-maps:{flatMapKey}:{workspaceId}:hash`

**Local Cache Hit**: If local hash matches Redis hash, return local data
**Remote Cache Hit**: If Redis has data with different hash, update local cache
**Remote Cache Miss**: Recompute from database, store in Remote and locally
**Invalidation**: Remove from Remote, triggering recomputation on next access

## Usage
```typescript
@WorkspaceFlatMapCache('view') // redis key
export class WorkspaceFlatViewMapCacheService extends WorkspaceFlatMapCacheService<FlatViewMaps> {
  constructor(
    @InjectCacheStorage(CacheStorageNamespace.EngineWorkspace)
    cacheStorageService: CacheStorageService,
    @InjectRepository(ViewEntity)
    private readonly viewRepository: Repository<ViewEntity>,
  ) {
    super(cacheStorageService);
  }

  // only method to implement
  public async computeFlatMap(workspaceId: string): Promise<FlatViewMaps> {
    const views = await this.viewRepository.find({
      where: { workspaceId },
      relations: ['viewFields'],
      select: { viewFields: { id: true } },
    });

    return generateFlatViewMaps(views);
  }
}
```

```typescript
// 2 public methods, getExistingOrRecomputeFlatMaps to fetch the map and invalidateCache after a mutation 
  await this.workspaceFlatViewMapCacheService.invalidateCache(
    viewData.workspaceId,
  );

  const flatViewMaps =
    await this.workspaceFlatViewMapCacheService.getExistingOrRecomputeFlatMaps(
      workspaceId,
    );
```

## Multi-Pod Synchronization
- Each pod maintains local cache for performance
- SHA256 hash of flatMap content used for version comparison
- `invalidateCache()` reset Redis data, forcing other pods to refresh when calling getExistingOrRecomputeFlatMaps 

--- 
<img width="1072" height="325" alt="Screenshot 2025-09-11 at 15 04 48" src="https://github.com/user-attachments/assets/ed6ce82c-db35-4a1b-8a4e-247b694e2ddf" />
<img width="1030" height="328" alt="Screenshot 2025-09-11 at 15 04 40" src="https://github.com/user-attachments/assets/43a15789-7f27-4104-a9bb-bef19908a5cd" />

Next step: Implement a locking mechanism by reusing existing WithLock decorator