### PR TITLE
Limit rest api relations depth to 1

### DIFF
--- a/packages/twenty-server/src/engine/api/rest/core/query-builder/utils/__tests__/compute-depth.utils.spec.ts
+++ b/packages/twenty-server/src/engine/api/rest/core/query-builder/utils/__tests__/compute-depth.utils.spec.ts
@@ -1,7 +1,7 @@
 import { computeDepth } from 'src/engine/api/rest/core/query-builder/utils/compute-depth.utils';
 
 describe('computeDepth', () => {
-  [0, 1, 2].forEach((depth) => {
+  [0, 1].forEach((depth) => {
     it('should compute depth from query', () => {
       const request: any = {
         query: { depth: `${depth}` },

--- a/packages/twenty-server/src/engine/api/rest/core/query-builder/utils/compute-depth.utils.ts
+++ b/packages/twenty-server/src/engine/api/rest/core/query-builder/utils/compute-depth.utils.ts
@@ -2,7 +2,7 @@ import { BadRequestException } from '@nestjs/common';
 
 import { type Request } from 'express';
 
-const ALLOWED_DEPTH_VALUES = [0, 1, 2];
+const ALLOWED_DEPTH_VALUES = [0, 1];
 
 export const computeDepth = (request: Request): number | undefined => {
   if (!request.query.depth) {

--- a/packages/twenty-server/src/engine/api/rest/input-factories/depth-input.factory.ts
+++ b/packages/twenty-server/src/engine/api/rest/input-factories/depth-input.factory.ts
@@ -6,7 +6,7 @@ export const MAX_DEPTH = 2;
 
 export type Depth = 0 | 1 | 2;
 
-const ALLOWED_DEPTH_VALUES: Depth[] = [0, 1, MAX_DEPTH];
+const ALLOWED_DEPTH_VALUES: Depth[] = [0, 1];
 
 @Injectable()
 export class DepthInputFactory {

--- a/packages/twenty-server/src/engine/core-modules/open-api/utils/__tests__/parameters.utils.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/open-api/utils/__tests__/parameters.utils.spec.ts
@@ -63,7 +63,7 @@ describe('computeParameters', () => {
         required: false,
         schema: {
           type: 'integer',
-          enum: [0, 1, 2],
+          enum: [0, 1],
           default: 1,
         },
       });

--- a/packages/twenty-server/src/engine/core-modules/open-api/utils/parameters.utils.ts
+++ b/packages/twenty-server/src/engine/core-modules/open-api/utils/parameters.utils.ts
@@ -53,7 +53,7 @@ export const computeDepthParameters = (): OpenAPIV3_1.ParameterObject => {
     required: false,
     schema: {
       type: 'integer',
-      enum: [0, 1, 2],
+      enum: [0, 1],
       default: 1,
     },
   };

--- a/packages/twenty-server/test/integration/rest/suites/rest-api-core-create-many.integration-spec.ts
+++ b/packages/twenty-server/test/integration/rest/suites/rest-api-core-create-many.integration-spec.ts
@@ -178,7 +178,7 @@ describe('Core REST API Create Many endpoint', () => {
       });
   });
 
-  it('should support depth 2 parameter', async () => {
+  it('should not support depth 2 parameter', async () => {
     const requestBody = [
       {
         id: TEST_PERSON_1_ID,
@@ -194,26 +194,7 @@ describe('Core REST API Create Many endpoint', () => {
       method: 'post',
       path: `/batch/people?depth=2`,
       body: requestBody,
-    })
-      .expect(201)
-      .expect((res) => {
-        const [createdPerson1, createdPerson2] = res.body.data.createPeople;
-
-        expect(createdPerson1.company.people).toBeDefined();
-        expect(createdPerson2.company.people).toBeDefined();
-
-        const depth2Person1 = createdPerson1.company.people.find(
-          // @ts-expect-error legacy noImplicitAny
-          (p) => p.id === createdPerson1.id,
-        );
-        const depth2Person2 = createdPerson2.company.people.find(
-          // @ts-expect-error legacy noImplicitAny
-          (p) => p.id === createdPerson2.id,
-        );
-
-        expect(depth2Person1).toBeDefined();
-        expect(depth2Person2).toBeDefined();
-      });
+    }).expect(400);
   });
 
   it('should return a BadRequestException when trying to create a person with an existing ID', async () => {

--- a/packages/twenty-server/test/integration/rest/suites/rest-api-core-create-one.integration-spec.ts
+++ b/packages/twenty-server/test/integration/rest/suites/rest-api-core-create-one.integration-spec.ts
@@ -147,7 +147,7 @@ describe('Core REST API Create One endpoint', () => {
       });
   });
 
-  it('should support depth 2 parameter', async () => {
+  it('should not support depth 2 parameter', async () => {
     const personCity = generateRecordName(TEST_PERSON_1_ID);
     const requestBody = {
       id: TEST_PERSON_1_ID,
@@ -159,19 +159,7 @@ describe('Core REST API Create One endpoint', () => {
       method: 'post',
       path: `/people?depth=2`,
       body: requestBody,
-    })
-      .expect(201)
-      .expect((res) => {
-        const createdPerson = res.body.data.createPerson;
-
-        expect(createdPerson.company.people).toBeDefined();
-        const depth2Person = createdPerson.company.people.find(
-          // @ts-expect-error legacy noImplicitAny
-          (p) => p.id === createdPerson.id,
-        );
-
-        expect(depth2Person).toBeDefined();
-      });
+    }).expect(400);
   });
 
   it('should return a BadRequestException when trying to create a person with an existing ID', async () => {

--- a/packages/twenty-server/test/integration/rest/suites/rest-api-core-find-duplicates.integration-spec.ts
+++ b/packages/twenty-server/test/integration/rest/suites/rest-api-core-find-duplicates.integration-spec.ts
@@ -240,8 +240,8 @@ describe('Core REST API Find Duplicates endpoint', () => {
     expect(personDuplicated2.company.people).not.toBeDefined();
   });
 
-  it('should support depth 2 parameter', async () => {
-    const response = await makeRestAPIRequest({
+  it('should not support depth 2 parameter', async () => {
+    await makeRestAPIRequest({
       method: 'post',
       path: `/people/duplicates?depth=2`,
       body: {
@@ -254,29 +254,6 @@ describe('Core REST API Find Duplicates endpoint', () => {
           },
         ],
       },
-    }).expect(200);
-
-    const data = response.body.data;
-
-    expect(data.length).toBe(1);
-    const duplicatesInfo = data[0];
-
-    const [personDuplicated1, personDuplicated2] =
-      duplicatesInfo.personDuplicates;
-
-    expect(personDuplicated1.company.people).toBeDefined();
-    expect(personDuplicated2.company.people).toBeDefined();
-
-    const depth2Person1 = personDuplicated1.company.people.find(
-      // @ts-expect-error legacy noImplicitAny
-      (p) => p.id === personDuplicated1.id,
-    );
-    const depth2Person2 = personDuplicated2.company.people.find(
-      // @ts-expect-error legacy noImplicitAny
-      (p) => p.id === personDuplicated2.id,
-    );
-
-    expect(depth2Person1).toBeDefined();
-    expect(depth2Person2).toBeDefined();
+    }).expect(400);
   });
 });

--- a/packages/twenty-server/test/integration/rest/suites/rest-api-core-find-many.integration-spec.ts
+++ b/packages/twenty-server/test/integration/rest/suites/rest-api-core-find-many.integration-spec.ts
@@ -490,21 +490,10 @@ describe('Core REST API Find Many endpoint', () => {
     expect(person.company.people).not.toBeDefined();
   });
 
-  it('should support depth 2 parameter', async () => {
-    const response = await makeRestAPIRequest({
+  it('should not support depth 2 parameter', async () => {
+    await makeRestAPIRequest({
       method: 'get',
       path: '/people?depth=2',
-    }).expect(200);
-
-    const people = response.body.data.people;
-
-    const person = people[0];
-
-    expect(person.company.people).toBeDefined();
-
-    // @ts-expect-error legacy noImplicitAny
-    const depth2Person = person.company.people.find((p) => p.id === person.id);
-
-    expect(depth2Person).toBeDefined();
+    }).expect(400);
   });
 });

--- a/packages/twenty-server/test/integration/rest/suites/rest-api-core-find-one.integration-spec.ts
+++ b/packages/twenty-server/test/integration/rest/suites/rest-api-core-find-one.integration-spec.ts
@@ -115,23 +115,10 @@ describe('Core REST API Find One endpoint', () => {
       });
   });
 
-  it('should support depth 2 parameter', async () => {
+  it('should not support depth 2 parameter', async () => {
     await makeRestAPIRequest({
       method: 'get',
       path: `/people/${TEST_PERSON_1_ID}?depth=2`,
-    })
-      .expect(200)
-      .expect((res) => {
-        const person = res.body.data.person;
-
-        expect(person.company.people).toBeDefined();
-
-        const depth2Person = person.company.people.find(
-          // @ts-expect-error legacy noImplicitAny
-          (p) => p.id === person.id,
-        );
-
-        expect(depth2Person).toBeDefined();
-      });
+    }).expect(400);
   });
 });

--- a/packages/twenty-server/test/integration/rest/suites/rest-api-core-update.integration-spec.ts
+++ b/packages/twenty-server/test/integration/rest/suites/rest-api-core-update.integration-spec.ts
@@ -110,20 +110,7 @@ describe('Core REST API Update One endpoint', () => {
       method: 'patch',
       path: `/people/${TEST_PERSON_1_ID}?depth=2`,
       body: updatedData,
-    })
-      .expect(200)
-      .expect((res) => {
-        const updatedPerson = res.body.data.updatePerson;
-
-        expect(updatedPerson.company.people).toBeDefined();
-
-        const depth2Person = updatedPerson.company.people.find(
-          // @ts-expect-error legacy noImplicitAny
-          (p) => p.id === updatedPerson.id,
-        );
-
-        expect(depth2Person).toBeDefined();
-      });
+    }).expect(400);
   });
 
   it('should return a EntityNotFoundError when trying to update a non-existing person', async () => {


### PR DESCRIPTION
Until we tackle [Implement relations depth 2 for rest api](https://github.com/twentyhq/core-team-issues/issues/1674), let's remove the  depth 2 query parameter which is not working (times out all the time).