### PR TITLE
fix: remove unused framer-motion import causing lint errors in ci

### DIFF
--- a/packages/twenty-front/src/modules/views/hooks/useUpdateView.ts
+++ b/packages/twenty-front/src/modules/views/hooks/useUpdateView.ts
@@ -2,7 +2,6 @@ import { useRecordIndexContextOrThrow } from '@/object-record/record-index/conte
 import { useRefreshCoreViewsByObjectMetadataId } from '@/views/hooks/useRefreshCoreViewsByObjectMetadataId';
 import { type GraphQLView } from '@/views/types/GraphQLView';
 import { convertUpdateViewInputToCore } from '@/views/utils/convertUpdateViewInputToCore';
-import { view } from 'framer-motion';
 import { useRecoilCallback } from 'recoil';
 import { isDefined } from 'twenty-shared/utils';
 import { useUpdateCoreViewMutation } from '~/generated/graphql';


### PR DESCRIPTION
### Summary
This PR removes an unused `view` import from **framer-motion** in `useUpdateView.ts`.

---

### Context
- The unused import was introduced in the recent commit to `main`.
- It causes ESLint to fail, which blocks all new PRs from passing CI.

### Changes
- Removed unused `view` import from `framer-motion`.

### Impact
- Lint and CI should now pass again.
- No runtime behavior is affected.
