### PR TITLE
Fix loop step ids on insert

### DIFF
--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version-step/utils/__tests__/insert-step.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version-step/utils/__tests__/insert-step.spec.ts
@@ -228,4 +228,35 @@ describe('insertStep', () => {
       'existing-loop-step',
     ]);
   });
+
+  it('should handle inserting a step between two steps within an iterator', () => {
+    const existingTrigger = createMockTrigger(['1']);
+    const insertedStep = createMockAction('2');
+
+    const result = insertStep({
+      existingTrigger,
+      existingSteps: [mockIteratorStep],
+      insertedStep,
+      parentStepId: '1',
+      nextStepId: 'existing-loop-step',
+      parentStepConnectionOptions: {
+        connectedStepType: WorkflowActionType.ITERATOR,
+        settings: {
+          isConnectedToLoop: true,
+        },
+      },
+    });
+
+    const updatedIteratorStep = result.updatedSteps.find(
+      (step) => step.id === mockIteratorStep.id,
+    ) as WorkflowIteratorAction;
+    const updatedInsertedStep = result.updatedSteps.find(
+      (step) => step.id === insertedStep.id,
+    ) as WorkflowAction;
+
+    expect(updatedIteratorStep.settings.input.initialLoopStepIds).toEqual([
+      insertedStep.id,
+    ]);
+    expect(updatedInsertedStep.nextStepIds).toEqual(['existing-loop-step']);
+  });
 });

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version-step/utils/insert-step.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version-step/utils/insert-step.ts
@@ -83,6 +83,7 @@ const updateParentStep = ({
       insertedStepId,
       parentStepConnectionOptions,
       trigger,
+      nextStepId,
     });
   } else {
     return updateParentStepNextStepIds({
@@ -162,12 +163,14 @@ const updateStepsWithOptions = ({
   steps,
   parentStepConnectionOptions,
   trigger,
+  nextStepId,
 }: {
   parentStepId: string;
   insertedStepId: string;
   steps: WorkflowAction[];
   parentStepConnectionOptions: WorkflowStepConnectionOptions;
   trigger: WorkflowTrigger | null;
+  nextStepId?: string;
 }) => {
   let updatedSteps = steps;
 
@@ -193,8 +196,12 @@ const updateStepsWithOptions = ({
               input: {
                 ...step.settings.input,
                 initialLoopStepIds: [
-                  ...(step.settings.input.initialLoopStepIds || []),
-                  insertedStepId,
+                  ...new Set([
+                    ...(step.settings.input.initialLoopStepIds?.filter(
+                      (id) => id !== nextStepId,
+                    ) || []),
+                    insertedStepId,
+                  ]),
                 ],
               },
             } satisfies WorkflowIteratorActionSettings,


### PR DESCRIPTION
Existing loop step ids should now be part of the inserted step next step ids, but not be part of the initialLoopStepIds