### PR TITLE
Fixes table z-index, focus, active rows and cells, pixel perfect

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableNoRecordGroupRows.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableNoRecordGroupRows.tsx
@@ -19,6 +19,7 @@ export const RecordTableNoRecordGroupRows = () => {
             recordId={recordId}
             rowIndexForFocus={rowIndex}
             rowIndexForDrag={rowIndex}
+            isFirstRowOfGroup={rowIndex === 0}
           />
         );
       })}

--- a/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableRecordGroupRows.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableRecordGroupRows.tsx
@@ -53,6 +53,7 @@ export const RecordTableRecordGroupRows = () => {
             recordId={recordId}
             rowIndexForFocus={rowIndex}
             rowIndexForDrag={rowIndexInGroup}
+            isFirstRowOfGroup={rowIndexInGroup === 0}
           />
         );
       })}

--- a/packages/twenty-front/src/modules/object-record/record-table/constants/TableZIndex.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/constants/TableZIndex.ts
@@ -7,41 +7,37 @@ export const TABLE_Z_INDEX = {
   },
   headerColumnsSticky: 14,
   headerColumnsNormal: 10,
-  withGroupsCell0_0: {
-    cell0_0HoveredWithoutScroll: 15,
-    cell0_0Normal: 13,
-  },
   withoutGroupsCell0_0: {
     cell0_0HoveredWithoutScroll: 15,
     cell0_0Normal: 12,
   },
   groupSection: {
-    stickyCell: 12,
-    normalCell: 10,
+    stickyCell: 10,
+    normalCell: 8,
   },
   withGroups: {
     noScrollAtAll: {
       hoverPortalCellOnFirstScrollableColumn: 17,
       hoverPortalCellOnNormalColumn: 17,
       hoverPortalCellOnLabelIdentifierColumn: 17,
-      firstScrollableHeaderCell: 12,
+      firstScrollableHeaderCell: 10,
     },
     scrolledBothVerticallyAndHorizontally: {
-      hoverPortalCellOnNormalColumn: 2,
-      hoverPortalCellOnFirstScrollableColumn: 11,
-      hoverPortalCellOnLabelIdentifierColumn: 15,
-      firstScrollableHeaderCell: 12,
+      hoverPortalCellOnNormalColumn: 9,
+      hoverPortalCellOnFirstScrollableColumn: 9,
+      hoverPortalCellOnLabelIdentifierColumn: 9,
+      firstScrollableHeaderCell: 10,
     },
     scrolledHorizontallyOnly: {
-      hoverPortalCellOnLabelIdentifierColumn: 15,
-      hoverPortalCellOnNormalColumn: 11,
-      hoverPortalCellOnFirstScrollableColumn: 11,
+      hoverPortalCellOnLabelIdentifierColumn: 9,
+      hoverPortalCellOnNormalColumn: 9,
+      hoverPortalCellOnFirstScrollableColumn: 9,
       firstScrollableHeaderCell: 10,
     },
     scrolledVerticallyOnly: {
       hoverPortalCellOnNormalColumn: 9,
-      hoverPortalCellOnFirstScrollableColumn: 15,
-      hoverPortalCellOnLabelIdentifierColumn: 15,
+      hoverPortalCellOnFirstScrollableColumn: 13,
+      hoverPortalCellOnLabelIdentifierColumn: 9,
       firstScrollableHeaderCell: 14,
     },
   },
@@ -80,6 +76,28 @@ export const TABLE_Z_INDEX = {
     tableWithoutGroups: {
       default: 18,
       stickyColumn: 20,
+    },
+  },
+  activeRows: {
+    firstRow: {
+      sticky: {
+        scrolledVertically: 10,
+        noVerticalScroll: 15,
+      },
+      normal: {
+        scrolledVertically: 8,
+        noVerticalScroll: 11,
+      },
+    },
+    afterFirstRow: {
+      sticky: {
+        scrolledVertically: 8,
+        noVerticalScroll: 8,
+      },
+      normal: {
+        scrolledVertically: 7,
+        noVerticalScroll: 7,
+      },
     },
   },
 };

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-body/components/RecordTableBodyLoading.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-body/components/RecordTableBodyLoading.tsx
@@ -38,6 +38,7 @@ export const RecordTableBodyLoading = () => {
               isDragging={false}
               data-testid={`row-id-${rowIndex}`}
               data-selectable-id={`row-id-${rowIndex}`}
+              isFirstRowOfGroup={rowIndex === 0}
             >
               <RecordTableCellGrip />
               <RecordTableCellCheckbox />

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellFirstRowFirstColumn.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellFirstRowFirstColumn.tsx
@@ -1,7 +1,7 @@
-import { hasRecordGroupsComponentSelector } from '@/object-record/record-group/states/selectors/hasRecordGroupsComponentSelector';
 import { TABLE_Z_INDEX } from '@/object-record/record-table/constants/TableZIndex';
 import { StyledCell } from '@/object-record/record-table/record-table-cell/components/RecordTableCellStyleWrapper';
 import { isRecordTableScrolledVerticallyComponentState } from '@/object-record/record-table/states/isRecordTableScrolledVerticallyComponentState';
+import { recordTableFocusPositionComponentState } from '@/object-record/record-table/states/recordTableFocusPositionComponentState';
 import { recordTableHoverPositionComponentState } from '@/object-record/record-table/states/recordTableHoverPositionComponentState';
 import { getRecordTableColumnFieldWidthClassName } from '@/object-record/record-table/utils/getRecordTableColumnFieldWidthClassName';
 import { useRecoilComponentState } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentState';
@@ -37,6 +37,13 @@ export const RecordTableCellFirstRowFirstColumn = ({
     recordTableHoverPositionComponentState,
   );
 
+  const focusPosition = useRecoilComponentValue(
+    recordTableFocusPositionComponentState,
+  );
+
+  const isFocusPortalOnThisCell =
+    focusPosition.column === 0 && focusPosition.row === 0;
+
   const isHoveredPortalOnThisCell =
     hoverPosition?.column === 0 && hoverPosition.row === 0;
 
@@ -44,21 +51,11 @@ export const RecordTableCellFirstRowFirstColumn = ({
     isRecordTableScrolledVerticallyComponentState,
   );
 
-  const hasRecordGroups = useRecoilComponentValue(
-    hasRecordGroupsComponentSelector,
-  );
-
-  const zIndexWithoutGroups =
-    !isRecordTableScrolledVertically && isHoveredPortalOnThisCell
+  const zIndex =
+    !isRecordTableScrolledVertically &&
+    (isHoveredPortalOnThisCell || isFocusPortalOnThisCell)
       ? TABLE_Z_INDEX.withoutGroupsCell0_0.cell0_0HoveredWithoutScroll
       : TABLE_Z_INDEX.withoutGroupsCell0_0.cell0_0Normal;
-
-  const zIndexWithGroups =
-    !isRecordTableScrolledVertically && isHoveredPortalOnThisCell
-      ? TABLE_Z_INDEX.withGroupsCell0_0.cell0_0HoveredWithoutScroll
-      : TABLE_Z_INDEX.withGroupsCell0_0.cell0_0Normal;
-
-  const zIndex = hasRecordGroups ? zIndexWithGroups : zIndexWithoutGroups;
 
   const tdBackgroundColor = isSelected
     ? theme.accent.quaternary

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellFocusedPortal.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellFocusedPortal.tsx
@@ -1,0 +1,149 @@
+import { RecordTableCellPortalWrapper } from '@/object-record/record-table/record-table-cell/components/RecordTableCellPortalWrapper';
+import { useRecoilComponentValue } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValue';
+
+import { hasRecordGroupsComponentSelector } from '@/object-record/record-group/states/selectors/hasRecordGroupsComponentSelector';
+import { TABLE_Z_INDEX } from '@/object-record/record-table/constants/TableZIndex';
+import { RecordTableCellFocusedPortalContent } from '@/object-record/record-table/record-table-cell/components/RecordTableCellFocusedPortalContent';
+import { RecordTableCellPortalRootContainer } from '@/object-record/record-table/record-table-cell/components/RecordTableCellPortalRootContainer';
+import { isRecordTableScrolledHorizontallyComponentState } from '@/object-record/record-table/states/isRecordTableScrolledHorizontallyComponentState';
+import { isRecordTableScrolledVerticallyComponentState } from '@/object-record/record-table/states/isRecordTableScrolledVerticallyComponentState';
+import { recordTableFocusPositionComponentState } from '@/object-record/record-table/states/recordTableFocusPositionComponentState';
+import { recordTableHoverPositionComponentState } from '@/object-record/record-table/states/recordTableHoverPositionComponentState';
+import { isDefined } from 'twenty-shared/utils';
+
+export const RecordTableCellFocusedPortal = () => {
+  const focusPosition = useRecoilComponentValue(
+    recordTableFocusPositionComponentState,
+  );
+
+  const isRecordTableScrolledVertically = useRecoilComponentValue(
+    isRecordTableScrolledVerticallyComponentState,
+  );
+
+  const isRecordTableScrolledHorizontally = useRecoilComponentValue(
+    isRecordTableScrolledHorizontallyComponentState,
+  );
+
+  const hasRecordGroups = useRecoilComponentValue(
+    hasRecordGroupsComponentSelector,
+  );
+
+  const hoverPosition = useRecoilComponentValue(
+    recordTableHoverPositionComponentState,
+  );
+
+  const isUnderHoveredPortal =
+    isDefined(hoverPosition) &&
+    isDefined(focusPosition) &&
+    hoverPosition.column === focusPosition.column &&
+    hoverPosition.row === focusPosition.row;
+
+  if (!isDefined(focusPosition) || isUnderHoveredPortal) {
+    return null;
+  }
+
+  const isOnFirstScrollableColumn = focusPosition.column === 1;
+  const isOnLabelIdentifierStickyColumn = focusPosition.column === 0;
+
+  const zIndexForHoveredPortalOnFirstScrollableColumnWithoutGroups =
+    isRecordTableScrolledHorizontally && isRecordTableScrolledVertically
+      ? TABLE_Z_INDEX.withoutGroups.scrolledBothVerticallyAndHorizontally
+          .hoverPortalCellOnFirstScrollableColumn
+      : isRecordTableScrolledHorizontally
+        ? TABLE_Z_INDEX.withoutGroups.scrolledHorizontallyOnly
+            .hoverPortalCellOnFirstScrollableColumn
+        : isRecordTableScrolledVertically
+          ? TABLE_Z_INDEX.withoutGroups.scrolledVerticallyOnly
+              .hoverPortalCellOnFirstScrollableColumn
+          : TABLE_Z_INDEX.withoutGroups.noScrollAtAll
+              .hoverPortalCellOnFirstScrollableColumn;
+
+  const zIndexForHoveredPortalOnLabelIdentifierStickyColumnWithoutGroups =
+    isRecordTableScrolledHorizontally && isRecordTableScrolledVertically
+      ? TABLE_Z_INDEX.withoutGroups.scrolledBothVerticallyAndHorizontally
+          .hoverPortalCellOnLabelIdentifierColumn
+      : isRecordTableScrolledHorizontally
+        ? TABLE_Z_INDEX.withoutGroups.scrolledHorizontallyOnly
+            .hoverPortalCellOnLabelIdentifierColumn
+        : isRecordTableScrolledVertically
+          ? TABLE_Z_INDEX.withoutGroups.scrolledVerticallyOnly
+              .hoverPortalCellOnLabelIdentifierColumn
+          : TABLE_Z_INDEX.withoutGroups.noScrollAtAll
+              .hoverPortalCellOnLabelIdentifierColumn;
+
+  const zIndexForHoveredPortalOnNormalColumnWithoutGroups =
+    isRecordTableScrolledHorizontally && isRecordTableScrolledVertically
+      ? TABLE_Z_INDEX.withoutGroups.scrolledBothVerticallyAndHorizontally
+          .hoverPortalCellOnNormalColumn
+      : isRecordTableScrolledHorizontally
+        ? TABLE_Z_INDEX.withoutGroups.scrolledHorizontallyOnly
+            .hoverPortalCellOnNormalColumn
+        : isRecordTableScrolledVertically
+          ? TABLE_Z_INDEX.withoutGroups.scrolledVerticallyOnly
+              .hoverPortalCellOnNormalColumn
+          : TABLE_Z_INDEX.withoutGroups.noScrollAtAll
+              .hoverPortalCellOnNormalColumn;
+
+  const zIndexForHoveredPortalWithoutGroups = isOnFirstScrollableColumn
+    ? zIndexForHoveredPortalOnFirstScrollableColumnWithoutGroups
+    : isOnLabelIdentifierStickyColumn
+      ? zIndexForHoveredPortalOnLabelIdentifierStickyColumnWithoutGroups
+      : zIndexForHoveredPortalOnNormalColumnWithoutGroups;
+
+  const zIndexForHoveredPortalOnFirstScrollableColumnWithGroups =
+    isRecordTableScrolledHorizontally && isRecordTableScrolledVertically
+      ? TABLE_Z_INDEX.withGroups.scrolledBothVerticallyAndHorizontally
+          .hoverPortalCellOnFirstScrollableColumn
+      : isRecordTableScrolledHorizontally
+        ? TABLE_Z_INDEX.withGroups.scrolledHorizontallyOnly
+            .hoverPortalCellOnFirstScrollableColumn
+        : isRecordTableScrolledVertically
+          ? TABLE_Z_INDEX.withGroups.scrolledVerticallyOnly
+              .hoverPortalCellOnFirstScrollableColumn
+          : TABLE_Z_INDEX.withGroups.noScrollAtAll
+              .hoverPortalCellOnFirstScrollableColumn;
+
+  const zIndexForHoveredPortalOnLabelIdentifierStickyColumnWithGroups =
+    isRecordTableScrolledHorizontally && isRecordTableScrolledVertically
+      ? TABLE_Z_INDEX.withGroups.scrolledBothVerticallyAndHorizontally
+          .hoverPortalCellOnLabelIdentifierColumn
+      : isRecordTableScrolledHorizontally
+        ? TABLE_Z_INDEX.withGroups.scrolledHorizontallyOnly
+            .hoverPortalCellOnLabelIdentifierColumn
+        : isRecordTableScrolledVertically
+          ? TABLE_Z_INDEX.withGroups.scrolledVerticallyOnly
+              .hoverPortalCellOnLabelIdentifierColumn
+          : TABLE_Z_INDEX.withGroups.noScrollAtAll
+              .hoverPortalCellOnLabelIdentifierColumn;
+
+  const zIndexForHoveredPortalOnNormalColumnWithGroups =
+    isRecordTableScrolledHorizontally && isRecordTableScrolledVertically
+      ? TABLE_Z_INDEX.withGroups.scrolledBothVerticallyAndHorizontally
+          .hoverPortalCellOnNormalColumn
+      : isRecordTableScrolledHorizontally
+        ? TABLE_Z_INDEX.withGroups.scrolledHorizontallyOnly
+            .hoverPortalCellOnNormalColumn
+        : isRecordTableScrolledVertically
+          ? TABLE_Z_INDEX.withGroups.scrolledVerticallyOnly
+              .hoverPortalCellOnNormalColumn
+          : TABLE_Z_INDEX.withGroups.noScrollAtAll
+              .hoverPortalCellOnNormalColumn;
+
+  const zIndexForHoveredPortalWithGroups = isOnFirstScrollableColumn
+    ? zIndexForHoveredPortalOnFirstScrollableColumnWithGroups
+    : isOnLabelIdentifierStickyColumn
+      ? zIndexForHoveredPortalOnLabelIdentifierStickyColumnWithGroups
+      : zIndexForHoveredPortalOnNormalColumnWithGroups;
+
+  const zIndex = hasRecordGroups
+    ? zIndexForHoveredPortalWithGroups
+    : zIndexForHoveredPortalWithoutGroups;
+
+  return (
+    <RecordTableCellPortalWrapper position={focusPosition}>
+      <RecordTableCellPortalRootContainer zIndex={zIndex}>
+        <RecordTableCellFocusedPortalContent />
+      </RecordTableCellPortalRootContainer>
+    </RecordTableCellPortalWrapper>
+  );
+};

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellFocusedPortalContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellFocusedPortalContent.tsx
@@ -1,0 +1,43 @@
+import { FieldDisplay } from '@/object-record/record-field/ui/components/FieldDisplay';
+import { useRecordTableRowContextOrThrow } from '@/object-record/record-table/contexts/RecordTableRowContext';
+import { RecordTableCellDisplayMode } from '@/object-record/record-table/record-table-cell/components/RecordTableCellDisplayMode';
+
+import { isRecordTableRowActiveComponentFamilyState } from '@/object-record/record-table/states/isRecordTableRowActiveComponentFamilyState';
+import { useRecoilComponentFamilyValue } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentFamilyValue';
+import styled from '@emotion/styled';
+import { BORDER_COMMON } from 'twenty-ui/theme';
+
+const StyledRecordTableCellFocusPortalContent = styled.div<{
+  isRowActive: boolean;
+}>`
+  align-items: center;
+  background: ${({ theme }) => theme.background.transparent.secondary};
+  background-color: ${({ theme, isRowActive }) =>
+    isRowActive ? theme.accent.quaternary : theme.background.primary};
+  border-radius: ${BORDER_COMMON.radius.sm};
+  box-sizing: border-box;
+  display: flex;
+
+  height: 32px;
+
+  outline: ${({ theme }) => `1px solid ${theme.color.blue}`};
+
+  user-select: none;
+`;
+
+export const RecordTableCellFocusedPortalContent = () => {
+  const { rowIndex } = useRecordTableRowContextOrThrow();
+
+  const isRowActive = useRecoilComponentFamilyValue(
+    isRecordTableRowActiveComponentFamilyState,
+    rowIndex,
+  );
+
+  return (
+    <StyledRecordTableCellFocusPortalContent isRowActive={isRowActive}>
+      <RecordTableCellDisplayMode>
+        <FieldDisplay />
+      </RecordTableCellDisplayMode>
+    </StyledRecordTableCellFocusPortalContent>
+  );
+};

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellPortalContexts.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellPortalContexts.tsx
@@ -6,19 +6,17 @@ import { recordIndexAllRecordIdsComponentSelector } from '@/object-record/record
 import { RecordTableCellContext } from '@/object-record/record-table/contexts/RecordTableCellContext';
 import { RecordTableRowContextProvider } from '@/object-record/record-table/contexts/RecordTableRowContext';
 import { RecordTableCellFieldContextWrapper } from '@/object-record/record-table/record-table-cell/components/RecordTableCellFieldContextWrapper';
-import { recordTableHoverPositionComponentState } from '@/object-record/record-table/states/recordTableHoverPositionComponentState';
+import { type TableCellPosition } from '@/object-record/record-table/types/TableCellPosition';
 import { useRecoilComponentValue } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValue';
 import { isDefined } from 'twenty-shared/utils';
 
 export const RecordTableCellPortalContexts = ({
+  position,
   children,
 }: {
+  position: TableCellPosition;
   children: React.ReactNode;
 }) => {
-  const hoverPosition = useRecoilComponentValue(
-    recordTableHoverPositionComponentState,
-  );
-
   const allRecordIds = useRecoilComponentValue(
     recordIndexAllRecordIdsComponentSelector,
   );
@@ -29,20 +27,18 @@ export const RecordTableCellPortalContexts = ({
     visibleRecordFieldsComponentSelector,
   );
 
-  const recordId = isDefined(hoverPosition)
-    ? allRecordIds.at(hoverPosition.row)
-    : null;
+  const recordId = allRecordIds.at(position.row);
 
   const isRecordReadOnly = useIsRecordReadOnly({
     recordId: recordId ?? '',
     objectMetadataId: objectMetadataItem.id,
   });
 
-  if (!hoverPosition || !isDefined(recordId)) {
+  if (!isDefined(recordId)) {
     return null;
   }
 
-  const recordField = visibleRecordFields[hoverPosition.column];
+  const recordField = visibleRecordFields[position.column];
 
   if (!isDefined(recordField)) {
     return null;
@@ -52,7 +48,7 @@ export const RecordTableCellPortalContexts = ({
     <RecordTableRowContextProvider
       value={{
         recordId,
-        rowIndex: hoverPosition.row,
+        rowIndex: position.row,
         isSelected: false,
         inView: true,
         pathToShowPage:
@@ -66,7 +62,7 @@ export const RecordTableCellPortalContexts = ({
       <RecordTableCellContext.Provider
         value={{
           recordField,
-          cellPosition: hoverPosition,
+          cellPosition: position,
         }}
       >
         <RecordTableCellFieldContextWrapper recordField={recordField}>

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellPortalWrapper.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellPortalWrapper.tsx
@@ -21,7 +21,7 @@ export const RecordTableCellPortalWrapper = ({
   return (
     <>
       {createPortal(
-        <RecordTableCellPortalContexts>
+        <RecordTableCellPortalContexts position={position}>
           {children}
         </RecordTableCellPortalContexts>,
         tableCellAnchorElement,

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellPortals.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellPortals.tsx
@@ -1,6 +1,7 @@
 import { useRecordTableContextOrThrow } from '@/object-record/record-table/contexts/RecordTableContext';
 import { RecordTableCellArrowKeysEffect } from '@/object-record/record-table/record-table-cell/components/RecordTableCellArrowKeysEffect';
 import { RecordTableCellEditModePortal } from '@/object-record/record-table/record-table-cell/components/RecordTableCellEditModePortal';
+import { RecordTableCellFocusedPortal } from '@/object-record/record-table/record-table-cell/components/RecordTableCellFocusedPortal';
 import { RecordTableCellHoveredPortal } from '@/object-record/record-table/record-table-cell/components/RecordTableCellHoveredPortal';
 import { isRecordTableCellFocusActiveComponentState } from '@/object-record/record-table/states/isRecordTableCellFocusActiveComponentState';
 import { useRecoilComponentValue } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValue';
@@ -16,6 +17,7 @@ export const RecordTableCellPortals = () => {
   return (
     <>
       <RecordTableCellHoveredPortal />
+      <RecordTableCellFocusedPortal />
       {isRecordTableFocusActive && (
         <>
           <RecordTableCellEditModePortal />

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-footer/components/RecordTableAggregateFooterCell.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-footer/components/RecordTableAggregateFooterCell.tsx
@@ -28,9 +28,6 @@ const StyledColumnFooterCell = styled.div<{
     &:hover {
       background: ${theme.background.secondary};
     };
-    &:active {
-      background: ${theme.background.tertiary};
-    };
     `;
   }};
   height: ${RECORD_TABLE_ROW_HEIGHT}px;

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-footer/components/RecordTableColumnAggregateFooterValueCell.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-footer/components/RecordTableColumnAggregateFooterValueCell.tsx
@@ -25,15 +25,10 @@ const StyledCell = styled.div<{ isUnfolded: boolean; isFirstCell: boolean }>`
   flex-grow: 1;
   max-width: 100%;
 
-  background: ${({ theme, isUnfolded }) =>
-    isUnfolded ? theme.background.transparent.light : theme.background.primary};
+  cursor: pointer;
 
-  &:hover {
-    background: ${({ theme, isUnfolded }) =>
-      isUnfolded
-        ? theme.background.transparent.medium
-        : theme.background.transparent.light};
-  }
+  background: ${({ theme, isUnfolded }) =>
+    isUnfolded ? theme.background.tertiary : 'none'};
 
   ${({ isFirstCell, theme }) =>
     isFirstCell &&

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-header/components/RecordTableHeaderAddColumnButton.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-header/components/RecordTableHeaderAddColumnButton.tsx
@@ -1,31 +1,35 @@
 import styled from '@emotion/styled';
 
+import { hasRecordGroupsComponentSelector } from '@/object-record/record-group/states/selectors/hasRecordGroupsComponentSelector';
 import { HIDDEN_TABLE_COLUMN_DROPDOWN_ID } from '@/object-record/record-table/constants/HiddenTableColumnDropdownId';
 import { RECORD_TABLE_COLUMN_ADD_COLUMN_BUTTON_WIDTH } from '@/object-record/record-table/constants/RecordTableColumnAddColumnButtonWidth';
 import { RECORD_TABLE_COLUMN_ADD_COLUMN_BUTTON_WIDTH_CLASS_NAME } from '@/object-record/record-table/constants/RecordTableColumnAddColumnButtonWidthClassName';
 import { RECORD_TABLE_ROW_HEIGHT } from '@/object-record/record-table/constants/RecordTableRowHeight';
 import { RecordTableHeaderPlusButtonContent } from '@/object-record/record-table/record-table-header/components/RecordTableHeaderPlusButtonContent';
 import { isRecordTableRowActiveComponentFamilyState } from '@/object-record/record-table/states/isRecordTableRowActiveComponentFamilyState';
+import { isRecordTableRowFocusActiveComponentState } from '@/object-record/record-table/states/isRecordTableRowFocusActiveComponentState';
 import { isRecordTableRowFocusedComponentFamilyState } from '@/object-record/record-table/states/isRecordTableRowFocusedComponentFamilyState';
+import { isRecordTableScrolledVerticallyComponentState } from '@/object-record/record-table/states/isRecordTableScrolledVerticallyComponentState';
 import { Dropdown } from '@/ui/layout/dropdown/components/Dropdown';
 import { useRecoilComponentFamilyValue } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentFamilyValue';
+import { useRecoilComponentValue } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValue';
 import { useTheme } from '@emotion/react';
 import { cx } from '@linaria/core';
 import { IconPlus } from 'twenty-ui/display';
 
 const StyledPlusIconHeaderCell = styled.div<{
-  isFirstRowActiveOrFocused: boolean;
+  shouldDisplayBorderBottom: boolean;
 }>`
-  border-bottom: ${({ isFirstRowActiveOrFocused, theme }) =>
-    isFirstRowActiveOrFocused
-      ? 'none'
-      : `1px solid ${theme.border.color.light}`};
+  border-bottom: ${({ theme, shouldDisplayBorderBottom }) =>
+    shouldDisplayBorderBottom
+      ? `1px solid ${theme.border.color.light}`
+      : 'none'};
   background-color: ${({ theme }) => theme.background.primary};
 
   color: ${({ theme }) => theme.font.color.tertiary};
   border-right: ${({ theme }) => theme.border.color.light} !important;
 
-  cursor: default;
+  cursor: pointer;
 
   width: ${RECORD_TABLE_COLUMN_ADD_COLUMN_BUTTON_WIDTH}px;
 
@@ -65,11 +69,27 @@ export const RecordTableHeaderAddColumnButton = () => {
     0,
   );
 
-  const isFirstRowActiveOrFocused = isFirstRowActive || isFirstRowFocused;
+  const isRowFocusActive = useRecoilComponentValue(
+    isRecordTableRowFocusActiveComponentState,
+  );
+
+  const isFirstRowActiveOrFocused =
+    isFirstRowActive || (isFirstRowFocused && isRowFocusActive);
+
+  const isScrolledVertically = useRecoilComponentValue(
+    isRecordTableScrolledVerticallyComponentState,
+  );
+
+  const hasRecordGroups = useRecoilComponentValue(
+    hasRecordGroupsComponentSelector,
+  );
+
+  const shouldDisplayBorderBottom =
+    hasRecordGroups || !isFirstRowActiveOrFocused || isScrolledVertically;
 
   return (
     <StyledPlusIconHeaderCell
-      isFirstRowActiveOrFocused={isFirstRowActiveOrFocused}
+      shouldDisplayBorderBottom={shouldDisplayBorderBottom}
       className={cx(
         'header-cell',
         RECORD_TABLE_COLUMN_ADD_COLUMN_BUTTON_WIDTH_CLASS_NAME,

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-header/components/RecordTableHeaderCell.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-header/components/RecordTableHeaderCell.tsx
@@ -1,13 +1,17 @@
 import { type RecordField } from '@/object-record/record-field/types/RecordField';
+import { hasRecordGroupsComponentSelector } from '@/object-record/record-group/states/selectors/hasRecordGroupsComponentSelector';
 
 import { useRecordTableContextOrThrow } from '@/object-record/record-table/contexts/RecordTableContext';
 import { RecordTableColumnHeadWithDropdown } from '@/object-record/record-table/record-table-header/components/RecordTableColumnHeadWithDropdown';
 import { RecordTableHeaderCellContainer } from '@/object-record/record-table/record-table-header/components/RecordTableHeaderCellContainer';
 import { RecordTableHeaderResizeHandler } from '@/object-record/record-table/record-table-header/components/RecordTableHeaderResizeHandler';
 import { isRecordTableRowActiveComponentFamilyState } from '@/object-record/record-table/states/isRecordTableRowActiveComponentFamilyState';
+import { isRecordTableRowFocusActiveComponentState } from '@/object-record/record-table/states/isRecordTableRowFocusActiveComponentState';
 import { isRecordTableRowFocusedComponentFamilyState } from '@/object-record/record-table/states/isRecordTableRowFocusedComponentFamilyState';
+import { isRecordTableScrolledVerticallyComponentState } from '@/object-record/record-table/states/isRecordTableScrolledVerticallyComponentState';
 import { getRecordTableColumnFieldWidthClassName } from '@/object-record/record-table/utils/getRecordTableColumnFieldWidthClassName';
 import { useRecoilComponentFamilyValue } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentFamilyValue';
+import { useRecoilComponentValue } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValue';
 import { cx } from '@linaria/core';
 
 type RecordTableHeaderCellProps = {
@@ -31,7 +35,23 @@ export const RecordTableHeaderCell = ({
     0,
   );
 
-  const isFirstRowActiveOrFocused = isFirstRowActive || isFirstRowFocused;
+  const isScrolledVertically = useRecoilComponentValue(
+    isRecordTableScrolledVerticallyComponentState,
+  );
+
+  const isRowFocusActive = useRecoilComponentValue(
+    isRecordTableRowFocusActiveComponentState,
+  );
+
+  const isFirstRowActiveOrFocused =
+    isFirstRowActive || (isFirstRowFocused && isRowFocusActive);
+
+  const hasRecordGroups = useRecoilComponentValue(
+    hasRecordGroupsComponentSelector,
+  );
+
+  const shouldDisplayBorderBottom =
+    hasRecordGroups || !isFirstRowActiveOrFocused || isScrolledVertically;
 
   return (
     <RecordTableHeaderCellContainer
@@ -40,7 +60,7 @@ export const RecordTableHeaderCell = ({
         getRecordTableColumnFieldWidthClassName(recordFieldIndex),
       )}
       key={recordField.fieldMetadataItemId}
-      isFirstRowActiveOrFocused={isFirstRowActiveOrFocused}
+      shouldDisplayBorderBottom={shouldDisplayBorderBottom}
     >
       <RecordTableColumnHeadWithDropdown
         recordField={recordField}

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-header/components/RecordTableHeaderCellContainer.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-header/components/RecordTableHeaderCellContainer.tsx
@@ -2,8 +2,8 @@ import { RECORD_TABLE_ROW_HEIGHT } from '@/object-record/record-table/constants/
 import styled from '@emotion/styled';
 
 const StyledHeaderCell = styled.div<{
-  isFirstRowActiveOrFocused: boolean;
   zIndex?: number;
+  shouldDisplayBorderBottom: boolean;
 }>`
   color: ${({ theme }) => theme.font.color.tertiary};
   padding: 0;
@@ -17,7 +17,10 @@ const StyledHeaderCell = styled.div<{
   background-color: ${({ theme }) => theme.background.primary};
   border-right: 1px solid ${({ theme }) => theme.border.color.light};
 
-  border-bottom: 1px solid ${({ theme }) => theme.border.color.light};
+  border-bottom: ${({ theme, shouldDisplayBorderBottom }) =>
+    shouldDisplayBorderBottom
+      ? `1px solid ${theme.border.color.light}`
+      : 'none'};
 
   user-select: none;
   ${({ theme }) => {
@@ -30,6 +33,8 @@ const StyledHeaderCell = styled.div<{
     };
     `;
   }};
+
+  cursor: pointer;
 
   z-index: ${({ zIndex }) => zIndex ?? 'auto'};
 `;

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-header/components/RecordTableHeaderDragDropColumn.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-header/components/RecordTableHeaderDragDropColumn.tsx
@@ -1,10 +1,20 @@
+import { hasRecordGroupsComponentSelector } from '@/object-record/record-group/states/selectors/hasRecordGroupsComponentSelector';
 import { RECORD_TABLE_COLUMN_DRAG_AND_DROP_WIDTH_CLASS_NAME } from '@/object-record/record-table/constants/RecordTableColumnDragAndDropWidthClassName';
+import { isRecordTableRowActiveComponentFamilyState } from '@/object-record/record-table/states/isRecordTableRowActiveComponentFamilyState';
+import { isRecordTableRowFocusActiveComponentState } from '@/object-record/record-table/states/isRecordTableRowFocusActiveComponentState';
+import { isRecordTableRowFocusedComponentFamilyState } from '@/object-record/record-table/states/isRecordTableRowFocusedComponentFamilyState';
+import { isRecordTableScrolledVerticallyComponentState } from '@/object-record/record-table/states/isRecordTableScrolledVerticallyComponentState';
+import { useRecoilComponentFamilyValue } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentFamilyValue';
+import { useRecoilComponentValue } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValue';
+import styled from '@emotion/styled';
 import { cx } from '@linaria/core';
-import { styled } from '@linaria/react';
 import { useContext } from 'react';
 import { ThemeContext } from 'twenty-ui/theme';
 
-const StyledDragDropHeaderCell = styled.div<{ backgroundColor: string }>`
+const StyledDragDropHeaderCell = styled.div<{
+  shouldDisplayBorderBottom: boolean;
+  backgroundColor: string;
+}>`
   background-color: ${({ backgroundColor }) => backgroundColor};
   min-width: 16px;
   width: 16px;
@@ -12,11 +22,44 @@ const StyledDragDropHeaderCell = styled.div<{ backgroundColor: string }>`
   min-height: 32px;
   max-height: 32px;
 
-  border-bottom: 1px solid ${({ backgroundColor }) => backgroundColor};
+  cursor: pointer;
+
+  border-bottom: ${({ theme, shouldDisplayBorderBottom }) =>
+    shouldDisplayBorderBottom
+      ? `1px solid ${theme.background.primary}`
+      : 'none'};
 `;
 
 export const RecordTableHeaderDragDropColumn = () => {
   const { theme } = useContext(ThemeContext);
+
+  const isScrolledVertically = useRecoilComponentValue(
+    isRecordTableScrolledVerticallyComponentState,
+  );
+
+  const isRowFocusActive = useRecoilComponentValue(
+    isRecordTableRowFocusActiveComponentState,
+  );
+
+  const isFirstRowActive = useRecoilComponentFamilyValue(
+    isRecordTableRowActiveComponentFamilyState,
+    0,
+  );
+
+  const isFirstRowFocused = useRecoilComponentFamilyValue(
+    isRecordTableRowFocusedComponentFamilyState,
+    0,
+  );
+
+  const isFirstRowActiveOrFocused =
+    isFirstRowActive || (isFirstRowFocused && isRowFocusActive);
+
+  const hasRecordGroups = useRecoilComponentValue(
+    hasRecordGroupsComponentSelector,
+  );
+
+  const shouldDisplayBorderBottom =
+    hasRecordGroups || !isFirstRowActiveOrFocused || isScrolledVertically;
 
   return (
     <StyledDragDropHeaderCell
@@ -25,6 +68,7 @@ export const RecordTableHeaderDragDropColumn = () => {
         RECORD_TABLE_COLUMN_DRAG_AND_DROP_WIDTH_CLASS_NAME,
       )}
       backgroundColor={theme.background.primary}
+      shouldDisplayBorderBottom={shouldDisplayBorderBottom}
     />
   );
 };

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-header/components/RecordTableHeaderFirstScrollableCell.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-header/components/RecordTableHeaderFirstScrollableCell.tsx
@@ -9,6 +9,7 @@ import { RecordTableHeaderCellContainer } from '@/object-record/record-table/rec
 
 import { hasRecordGroupsComponentSelector } from '@/object-record/record-group/states/selectors/hasRecordGroupsComponentSelector';
 import { isRecordTableRowActiveComponentFamilyState } from '@/object-record/record-table/states/isRecordTableRowActiveComponentFamilyState';
+import { isRecordTableRowFocusActiveComponentState } from '@/object-record/record-table/states/isRecordTableRowFocusActiveComponentState';
 import { isRecordTableRowFocusedComponentFamilyState } from '@/object-record/record-table/states/isRecordTableRowFocusedComponentFamilyState';
 import { isRecordTableScrolledHorizontallyComponentState } from '@/object-record/record-table/states/isRecordTableScrolledHorizontallyComponentState';
 import { isRecordTableScrolledVerticallyComponentState } from '@/object-record/record-table/states/isRecordTableScrolledVerticallyComponentState';
@@ -41,7 +42,12 @@ export const RecordTableHeaderFirstScrollableCell = () => {
     ),
   )[0] as RecordField | undefined;
 
-  const isFirstRowActiveOrFocused = isFirstRowActive || isFirstRowFocused;
+  const isRowFocusActive = useRecoilComponentValue(
+    isRecordTableRowFocusActiveComponentState,
+  );
+
+  const isFirstRowActiveOrFocused =
+    isFirstRowActive || (isFirstRowFocused && isRowFocusActive);
 
   const isRecordTableScrolledVertically = useRecoilComponentValue(
     isRecordTableScrolledVerticallyComponentState,
@@ -81,6 +87,13 @@ export const RecordTableHeaderFirstScrollableCell = () => {
 
   const zIndex = hasRecordGroups ? zIndexWithGroups : zIndexWithoutGroups;
 
+  const isScrolledVertically = useRecoilComponentValue(
+    isRecordTableScrolledVerticallyComponentState,
+  );
+
+  const shouldDisplayBorderBottom =
+    hasRecordGroups || !isFirstRowActiveOrFocused || isScrolledVertically;
+
   if (!recordField) {
     return <></>;
   }
@@ -89,7 +102,7 @@ export const RecordTableHeaderFirstScrollableCell = () => {
     <RecordTableHeaderCellContainer
       className={cx('header-cell', getRecordTableColumnFieldWidthClassName(1))}
       key={recordField.fieldMetadataItemId}
-      isFirstRowActiveOrFocused={isFirstRowActiveOrFocused}
+      shouldDisplayBorderBottom={shouldDisplayBorderBottom}
       zIndex={zIndex}
     >
       <RecordTableColumnHeadWithDropdown

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-header/components/RecordTableHeaderLabelIdentifierCell.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-header/components/RecordTableHeaderLabelIdentifierCell.tsx
@@ -7,11 +7,15 @@ import { RecordTableHeaderResizeHandler } from '@/object-record/record-table/rec
 
 import { RecordTableHeaderCellContainer } from '@/object-record/record-table/record-table-header/components/RecordTableHeaderCellContainer';
 
+import { hasRecordGroupsComponentSelector } from '@/object-record/record-group/states/selectors/hasRecordGroupsComponentSelector';
 import { RecordTableHeaderLabelIdentifierCellPlusButton } from '@/object-record/record-table/record-table-header/components/RecordTableHeaderLabelIdentifierCellPlusButton';
 import { isRecordTableRowActiveComponentFamilyState } from '@/object-record/record-table/states/isRecordTableRowActiveComponentFamilyState';
+import { isRecordTableRowFocusActiveComponentState } from '@/object-record/record-table/states/isRecordTableRowFocusActiveComponentState';
 import { isRecordTableRowFocusedComponentFamilyState } from '@/object-record/record-table/states/isRecordTableRowFocusedComponentFamilyState';
+import { isRecordTableScrolledVerticallyComponentState } from '@/object-record/record-table/states/isRecordTableScrolledVerticallyComponentState';
 import { getRecordTableColumnFieldWidthClassName } from '@/object-record/record-table/utils/getRecordTableColumnFieldWidthClassName';
 import { useRecoilComponentFamilyValue } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentFamilyValue';
+import { useRecoilComponentValue } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValue';
 import { cx } from '@linaria/core';
 import { useState } from 'react';
 import { findByProperty } from 'twenty-shared/utils';
@@ -21,6 +25,8 @@ const StyledColumnHeadContainer = styled.div`
   flex-direction: row;
   justify-content: space-between;
   overflow: hidden;
+
+  cursor: pointer;
 
   & > :first-of-type {
     flex: 1;
@@ -49,11 +55,27 @@ export const RecordTableHeaderLabelIdentifierCell = () => {
     findByProperty('fieldMetadataItemId', labelIdentifierFieldMetadataItem?.id),
   );
 
+  const isScrolledVertically = useRecoilComponentValue(
+    isRecordTableScrolledVerticallyComponentState,
+  );
+
+  const isRowFocusActive = useRecoilComponentValue(
+    isRecordTableRowFocusActiveComponentState,
+  );
+
+  const isFirstRowActiveOrFocused =
+    isFirstRowActive || (isFirstRowFocused && isRowFocusActive);
+
+  const hasRecordGroups = useRecoilComponentValue(
+    hasRecordGroupsComponentSelector,
+  );
+
+  const shouldDisplayBorderBottom =
+    hasRecordGroups || !isFirstRowActiveOrFocused || isScrolledVertically;
+
   if (!recordField) {
     return <></>;
   }
-
-  const isFirstRowActiveOrFocused = isFirstRowActive || isFirstRowFocused;
 
   return (
     <RecordTableHeaderCellContainer
@@ -61,7 +83,7 @@ export const RecordTableHeaderLabelIdentifierCell = () => {
       key={recordField.fieldMetadataItemId}
       onMouseEnter={() => setIconIsVisible(true)}
       onMouseLeave={() => setIconIsVisible(false)}
-      isFirstRowActiveOrFocused={isFirstRowActiveOrFocused}
+      shouldDisplayBorderBottom={shouldDisplayBorderBottom}
     >
       <StyledColumnHeadContainer>
         <RecordTableColumnHeadWithDropdown

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-header/components/RecordTableHeaderLastEmptyColumn.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-header/components/RecordTableHeaderLastEmptyColumn.tsx
@@ -1,21 +1,64 @@
+import { hasRecordGroupsComponentSelector } from '@/object-record/record-group/states/selectors/hasRecordGroupsComponentSelector';
 import { RECORD_TABLE_COLUMN_LAST_EMPTY_COLUMN_WIDTH_CLASS_NAME } from '@/object-record/record-table/constants/RecordTableColumnLastEmptyColumnWidthClassName';
+import { isRecordTableRowActiveComponentFamilyState } from '@/object-record/record-table/states/isRecordTableRowActiveComponentFamilyState';
+import { isRecordTableRowFocusActiveComponentState } from '@/object-record/record-table/states/isRecordTableRowFocusActiveComponentState';
+import { isRecordTableRowFocusedComponentFamilyState } from '@/object-record/record-table/states/isRecordTableRowFocusedComponentFamilyState';
+import { isRecordTableScrolledVerticallyComponentState } from '@/object-record/record-table/states/isRecordTableScrolledVerticallyComponentState';
+import { useRecoilComponentFamilyValue } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentFamilyValue';
+import { useRecoilComponentValue } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValue';
 import styled from '@emotion/styled';
 import { cx } from '@linaria/core';
 
-const StyledLastColumnHeader = styled.div`
-  border-bottom: 1px solid ${({ theme }) => theme.border.color.light};
+const StyledLastColumnHeader = styled.div<{
+  shouldDisplayBorderBottom: boolean;
+}>`
+  border-bottom: ${({ theme, shouldDisplayBorderBottom }) =>
+    shouldDisplayBorderBottom
+      ? `1px solid ${theme.border.color.light}`
+      : 'none'};
 
   background-color: ${({ theme }) => theme.background.primary};
   border-left: none !important;
   color: ${({ theme }) => theme.font.color.tertiary};
+
+  cursor: pointer;
 
   height: 32px;
   max-height: 32px;
 `;
 
 export const RecordTableHeaderLastEmptyColumn = () => {
+  const isScrolledVertically = useRecoilComponentValue(
+    isRecordTableScrolledVerticallyComponentState,
+  );
+
+  const isFirstRowActive = useRecoilComponentFamilyValue(
+    isRecordTableRowActiveComponentFamilyState,
+    0,
+  );
+
+  const isFirstRowFocused = useRecoilComponentFamilyValue(
+    isRecordTableRowFocusedComponentFamilyState,
+    0,
+  );
+
+  const isRowFocusActive = useRecoilComponentValue(
+    isRecordTableRowFocusActiveComponentState,
+  );
+
+  const isFirstRowActiveOrFocused =
+    isFirstRowActive || (isFirstRowFocused && isRowFocusActive);
+
+  const hasRecordGroups = useRecoilComponentValue(
+    hasRecordGroupsComponentSelector,
+  );
+
+  const shouldDisplayBorderBottom =
+    hasRecordGroups || !isFirstRowActiveOrFocused || isScrolledVertically;
+
   return (
     <StyledLastColumnHeader
+      shouldDisplayBorderBottom={shouldDisplayBorderBottom}
       className={cx(
         'header-cell',
         RECORD_TABLE_COLUMN_LAST_EMPTY_COLUMN_WIDTH_CLASS_NAME,

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-row/components/RecordTableCellsVisible.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-row/components/RecordTableCellsVisible.tsx
@@ -1,3 +1,4 @@
+import { hasRecordGroupsComponentSelector } from '@/object-record/record-group/states/selectors/hasRecordGroupsComponentSelector';
 import { useRecordTableContextOrThrow } from '@/object-record/record-table/contexts/RecordTableContext';
 import { useRecordTableRowContextOrThrow } from '@/object-record/record-table/contexts/RecordTableRowContext';
 import { useRecordTableRowDraggableContextOrThrow } from '@/object-record/record-table/contexts/RecordTableRowDraggableContext';
@@ -6,6 +7,7 @@ import { RecordTableCellFirstRowFirstColumn } from '@/object-record/record-table
 import { RecordTableCellStyleWrapper } from '@/object-record/record-table/record-table-cell/components/RecordTableCellStyleWrapper';
 import { RecordTableCellWrapper } from '@/object-record/record-table/record-table-cell/components/RecordTableCellWrapper';
 import { getRecordTableColumnFieldWidthClassName } from '@/object-record/record-table/utils/getRecordTableColumnFieldWidthClassName';
+import { useRecoilComponentValue } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValue';
 import { isDefined } from 'twenty-shared/utils';
 import { isNonEmptyArray } from '~/utils/isNonEmptyArray';
 
@@ -15,6 +17,10 @@ export const RecordTableCellsVisible = () => {
   const { isDragging } = useRecordTableRowDraggableContextOrThrow();
 
   const { visibleRecordFields } = useRecordTableContextOrThrow();
+
+  const hasRecordGroups = useRecoilComponentValue(
+    hasRecordGroupsComponentSelector,
+  );
 
   if (!isNonEmptyArray(visibleRecordFields)) {
     return null;
@@ -36,7 +42,7 @@ export const RecordTableCellsVisible = () => {
         recordField={firstRecordField}
         recordFieldIndex={0}
       >
-        {isFirstRow ? (
+        {isFirstRow && !hasRecordGroups ? (
           <RecordTableCellFirstRowFirstColumn
             isSelected={isSelected}
             isDragging={isDragging}

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-row/components/RecordTableDraggableTr.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-row/components/RecordTableDraggableTr.tsx
@@ -17,6 +17,7 @@ type RecordTableDraggableTrProps = {
   isDragDisabled?: boolean;
   onClick?: (event: React.MouseEvent<HTMLTableRowElement>) => void;
   children: ReactNode;
+  isFirstRowOfGroup?: boolean;
 };
 
 export const RecordTableDraggableTr = ({
@@ -27,6 +28,7 @@ export const RecordTableDraggableTr = ({
   isDragDisabled,
   onClick,
   children,
+  isFirstRowOfGroup,
 }: RecordTableDraggableTrProps) => {
   const theme = useTheme();
   const { recordTableId } = useRecordTableContextOrThrow();
@@ -68,6 +70,7 @@ export const RecordTableDraggableTr = ({
             data-virtualized-id={recordId}
             data-selectable-id={recordId}
             onClick={onClick}
+            isFirstRowOfGroup={isFirstRowOfGroup}
           >
             <RecordTableRowDraggableContextProvider
               value={{

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-row/components/RecordTableDraggableTrFirstRowOfGroup.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-row/components/RecordTableDraggableTrFirstRowOfGroup.tsx
@@ -8,8 +8,10 @@ import { RecordTableRowDraggableContextProvider } from '@/object-record/record-t
 import { RecordTableRowMultiDragPreview } from '@/object-record/record-table/record-table-row/components/RecordTableRowMultiDragPreview';
 import { RecordTableTr } from '@/object-record/record-table/record-table-row/components/RecordTableTr';
 import { RecordTableTrEffect } from '@/object-record/record-table/record-table-row/components/RecordTableTrEffect';
+import { isRecordTableScrolledVerticallyComponentState } from '@/object-record/record-table/states/isRecordTableScrolledVerticallyComponentState';
+import { useRecoilComponentValue } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValue';
 
-type RecordTableDraggableTrProps = {
+type RecordTableDraggableTrFirstRowOfGroupProps = {
   className?: string;
   recordId: string;
   draggableIndex: number;
@@ -19,7 +21,7 @@ type RecordTableDraggableTrProps = {
   children: ReactNode;
 };
 
-export const RecordTableDraggableTr = ({
+export const RecordTableDraggableTrFirstRowOfGroup = ({
   className,
   recordId,
   draggableIndex,
@@ -27,7 +29,7 @@ export const RecordTableDraggableTr = ({
   isDragDisabled,
   onClick,
   children,
-}: RecordTableDraggableTrProps) => {
+}: RecordTableDraggableTrFirstRowOfGroupProps) => {
   const theme = useTheme();
   const { recordTableId } = useRecordTableContextOrThrow();
   const multiDragState = useRecordDragState('table', recordTableId);
@@ -36,6 +38,10 @@ export const RecordTableDraggableTr = ({
     multiDragState?.isDragging &&
     multiDragState.originalSelection.includes(recordId) &&
     recordId !== multiDragState.primaryDraggedRecordId;
+
+  const isScrolledVertically = useRecoilComponentValue(
+    isRecordTableScrolledVerticallyComponentState,
+  );
 
   return (
     <Draggable
@@ -68,7 +74,8 @@ export const RecordTableDraggableTr = ({
             data-virtualized-id={recordId}
             data-selectable-id={recordId}
             onClick={onClick}
-            isFirstRowOfGroup={false}
+            isFirstRowOfGroup={true}
+            isScrolledVertically={isScrolledVertically}
           >
             <RecordTableRowDraggableContextProvider
               value={{

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-row/components/RecordTableFirstRowOfGroup.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-row/components/RecordTableFirstRowOfGroup.tsx
@@ -1,0 +1,58 @@
+import { RecordTableRowDiv } from '@/object-record/record-table/record-table-row/components/RecordTableRowDiv';
+import { isRecordTableScrolledVerticallyComponentState } from '@/object-record/record-table/states/isRecordTableScrolledVerticallyComponentState';
+import { useRecoilComponentValue } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValue';
+import { isActive } from '@tiptap/core';
+import { forwardRef, type ReactNode } from 'react';
+
+type RecordTableTrProps = {
+  children: ReactNode;
+  recordId: string;
+  focusIndex: number;
+  isDragging?: boolean;
+  isRowFocusActive: boolean;
+  isFocused: boolean;
+  isNextRowActiveOrFocused: boolean;
+} & Omit<
+  React.ComponentProps<typeof RecordTableRowDiv>,
+  'isActive' | 'isNextRowActiveOrFocused' | 'isFocused'
+>;
+
+export const RecordTableFirstRowOfGroup = forwardRef<
+  HTMLDivElement,
+  RecordTableTrProps
+>(
+  (
+    {
+      children,
+      recordId,
+      isNextRowActiveOrFocused,
+      isDragging = false,
+      isRowFocusActive,
+      isFocused,
+      ...props
+    },
+    ref,
+  ) => {
+    const isScrolledVertically = useRecoilComponentValue(
+      isRecordTableScrolledVerticallyComponentState,
+    );
+
+    return (
+      <RecordTableRowDiv
+        className="table-row"
+        data-virtualized-id={recordId}
+        isDragging={isDragging}
+        ref={ref}
+        data-active={isActive}
+        data-focused={isRowFocusActive && isFocused && !isActive}
+        data-next-row-active-or-focused={isNextRowActiveOrFocused}
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        {...props}
+        isScrolledVertically={isScrolledVertically}
+        isFirstRowOfGroup={true}
+      >
+        {children}
+      </RecordTableRowDiv>
+    );
+  },
+);

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-row/components/RecordTableFirstRowOfGroup.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-row/components/RecordTableFirstRowOfGroup.tsx
@@ -26,7 +26,6 @@ export const RecordTableFirstRowOfGroup = forwardRef<
       children,
       recordId,
       isNextRowActiveOrFocused,
-      focusIndex,
       isDragging = false,
       isRowFocusActive,
       isFocused,

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-row/components/RecordTableFirstRowOfGroup.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-row/components/RecordTableFirstRowOfGroup.tsx
@@ -26,6 +26,7 @@ export const RecordTableFirstRowOfGroup = forwardRef<
       children,
       recordId,
       isNextRowActiveOrFocused,
+      focusIndex,
       isDragging = false,
       isRowFocusActive,
       isFocused,

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-row/components/RecordTableRow.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-row/components/RecordTableRow.tsx
@@ -5,6 +5,7 @@ import { RecordTableLastEmptyCell } from '@/object-record/record-table/record-ta
 import { RecordTablePlusButtonCellPlaceholder } from '@/object-record/record-table/record-table-cell/components/RecordTablePlusButtonCellPlaceholder';
 import { RecordTableCells } from '@/object-record/record-table/record-table-row/components/RecordTableCells';
 import { RecordTableDraggableTr } from '@/object-record/record-table/record-table-row/components/RecordTableDraggableTr';
+import { RecordTableDraggableTrFirstRowOfGroup } from '@/object-record/record-table/record-table-row/components/RecordTableDraggableTrFirstRowOfGroup';
 import { RecordTableRowArrowKeysEffect } from '@/object-record/record-table/record-table-row/components/RecordTableRowArrowKeysEffect';
 import { RecordTableRowHotkeyEffect } from '@/object-record/record-table/record-table-row/components/RecordTableRowHotkeyEffect';
 import { isRecordTableRowFocusActiveComponentState } from '@/object-record/record-table/states/isRecordTableRowFocusActiveComponentState';
@@ -39,12 +40,34 @@ export const RecordTableRow = ({
     isRecordTableRowFocusActiveComponentState,
   );
 
-  return (
+  return isFirstRowOfGroup ? (
+    <RecordTableDraggableTrFirstRowOfGroup
+      recordId={recordId}
+      draggableIndex={rowIndexForDrag}
+      focusIndex={rowIndexForFocus}
+    >
+      {isRowFocusActive && isFocused && (
+        <>
+          <RecordTableRowHotkeyEffect />
+          <RecordTableRowArrowKeysEffect />
+        </>
+      )}
+      <RecordTableCellGrip />
+      <RecordTableCellCheckbox />
+      <RecordTableCells />
+      <RecordTablePlusButtonCellPlaceholder />
+      <RecordTableLastEmptyCell />
+      <ListenRecordUpdatesEffect
+        objectNameSingular={objectNameSingular}
+        recordId={recordId}
+        listenedFields={listenedFields}
+      />
+    </RecordTableDraggableTrFirstRowOfGroup>
+  ) : (
     <RecordTableDraggableTr
       recordId={recordId}
       draggableIndex={rowIndexForDrag}
       focusIndex={rowIndexForFocus}
-      isFirstRowOfGroup={isFirstRowOfGroup}
     >
       {isRowFocusActive && isFocused && (
         <>

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-row/components/RecordTableRow.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-row/components/RecordTableRow.tsx
@@ -18,12 +18,14 @@ type RecordTableRowProps = {
   recordId: string;
   rowIndexForFocus: number;
   rowIndexForDrag: number;
+  isFirstRowOfGroup: boolean;
 };
 
 export const RecordTableRow = ({
   recordId,
   rowIndexForFocus,
   rowIndexForDrag,
+  isFirstRowOfGroup,
 }: RecordTableRowProps) => {
   const { objectNameSingular } = useRecordIndexContextOrThrow();
   const listenedFields = getDefaultRecordFieldsToListen({
@@ -42,6 +44,7 @@ export const RecordTableRow = ({
       recordId={recordId}
       draggableIndex={rowIndexForDrag}
       focusIndex={rowIndexForFocus}
+      isFirstRowOfGroup={isFirstRowOfGroup}
     >
       {isRowFocusActive && isFocused && (
         <>

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-row/components/RecordTableRowDiv.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-row/components/RecordTableRowDiv.tsx
@@ -1,0 +1,113 @@
+import { TABLE_Z_INDEX } from '@/object-record/record-table/constants/TableZIndex';
+import styled from '@emotion/styled';
+
+const StyledTr = styled.div<{
+  isDragging: boolean;
+  isFirstRowOfGroup?: boolean;
+  isScrolledVertically?: boolean;
+}>`
+  --z-index-for-sticky-cells: ${({
+    isFirstRowOfGroup,
+    isScrolledVertically,
+  }) =>
+    isFirstRowOfGroup === true
+      ? isScrolledVertically
+        ? TABLE_Z_INDEX.activeRows.firstRow.sticky.scrolledVertically
+        : TABLE_Z_INDEX.activeRows.firstRow.sticky.noVerticalScroll
+      : isScrolledVertically
+        ? TABLE_Z_INDEX.activeRows.afterFirstRow.sticky.scrolledVertically
+        : TABLE_Z_INDEX.activeRows.afterFirstRow.sticky.noVerticalScroll};
+
+  --z-index-for-normal-cells: ${({
+    isFirstRowOfGroup,
+    isScrolledVertically,
+  }) =>
+    isFirstRowOfGroup === true
+      ? isScrolledVertically
+        ? TABLE_Z_INDEX.activeRows.firstRow.normal.scrolledVertically
+        : TABLE_Z_INDEX.activeRows.firstRow.normal.noVerticalScroll
+      : isScrolledVertically
+        ? TABLE_Z_INDEX.activeRows.afterFirstRow.normal.scrolledVertically
+        : TABLE_Z_INDEX.activeRows.afterFirstRow.normal.noVerticalScroll};
+
+  border-top: ${({ isDragging, theme }) =>
+    isDragging ? `1px solid ${theme.border.color.medium}` : 'none'};
+
+  display: flex;
+  flex-direction: row;
+
+  &[data-next-row-active-or-focused='true'] {
+    div.table-cell,
+    div.table-cell-0-0 {
+      border-bottom: none;
+    }
+  }
+
+  &[data-focused='true'] {
+    div.table-cell,
+    div.table-cell-0-0 {
+      &:not(:first-of-type) {
+        border-bottom: 1px solid ${({ theme }) => theme.border.color.medium};
+        border-top: 1px solid ${({ theme }) => theme.border.color.medium};
+        border-color: ${({ theme }) => theme.border.color.medium};
+        background-color: ${({ theme }) => theme.background.tertiary};
+      }
+      &:nth-of-type(2) {
+        border-left: 1px solid ${({ theme }) => theme.border.color.medium};
+        border-radius: ${({ theme }) => theme.border.radius.sm} 0 0
+          ${({ theme }) => theme.border.radius.sm};
+
+        margin-left: -1px;
+
+        div {
+          margin-left: -1px;
+        }
+      }
+      &:last-of-type {
+        border-right: 1px solid ${({ theme }) => theme.border.color.medium};
+        border-radius: 0 ${({ theme }) => theme.border.radius.sm}
+          ${({ theme }) => theme.border.radius.sm} 0;
+      }
+    }
+  }
+
+  &[data-active='true'] {
+    div.table-cell,
+    div.table-cell-0-0 {
+      &:not(:first-of-type) {
+        border-bottom: 1px solid ${({ theme }) => theme.adaptiveColors.blue3};
+        border-top: 1px solid ${({ theme }) => theme.adaptiveColors.blue3};
+        background-color: ${({ theme }) => theme.accent.quaternary};
+
+        z-index: var(--z-index-for-normal-cells);
+      }
+      &:nth-of-type(2) {
+        border-left: 1px solid ${({ theme }) => theme.adaptiveColors.blue3};
+        border-radius: ${({ theme }) => theme.border.radius.sm} 0 0
+          ${({ theme }) => theme.border.radius.sm};
+
+        margin-left: -1px;
+
+        div {
+          margin-left: -1px;
+        }
+
+        z-index: var(--z-index-for-sticky-cells);
+      }
+      &:nth-of-type(3) {
+        z-index: var(--z-index-for-sticky-cells);
+      }
+      &:nth-of-type(1) {
+        z-index: var(--z-index-for-sticky-cells);
+      }
+      &:last-of-type {
+        border-right: 1px solid ${({ theme }) => theme.adaptiveColors.blue3};
+        border-radius: 0 ${({ theme }) => theme.border.radius.sm}
+          ${({ theme }) => theme.border.radius.sm} 0;
+        z-index: var(--z-index-for-normal-cells);
+      }
+    }
+  }
+`;
+
+export const RecordTableRowDiv = StyledTr;

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-row/components/RecordTableTr.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-row/components/RecordTableTr.tsx
@@ -1,7 +1,11 @@
 import { getBasePathToShowPage } from '@/object-metadata/utils/getBasePathToShowPage';
 import { useIsRecordReadOnly } from '@/object-record/read-only/hooks/useIsRecordReadOnly';
+import { recordIndexAllRecordIdsComponentSelector } from '@/object-record/record-index/states/selectors/recordIndexAllRecordIdsComponentSelector';
 import { useRecordTableContextOrThrow } from '@/object-record/record-table/contexts/RecordTableContext';
 import { RecordTableRowContextProvider } from '@/object-record/record-table/contexts/RecordTableRowContext';
+import { RecordTableFirstRowOfGroup } from '@/object-record/record-table/record-table-row/components/RecordTableFirstRowOfGroup';
+import { RecordTableRowDiv } from '@/object-record/record-table/record-table-row/components/RecordTableRowDiv';
+import { isRecordIdFirstOfGroupComponentFamilySelector } from '@/object-record/record-table/record-table-row/states/isRecordIdFirstOfGroupComponentFamilySelector';
 import { isRowSelectedComponentFamilyState } from '@/object-record/record-table/record-table-row/states/isRowSelectedComponentFamilyState';
 import { isRowVisibleComponentFamilyState } from '@/object-record/record-table/record-table-row/states/isRowVisibleComponentFamilyState';
 import { isRecordTableRowActiveComponentFamilyState } from '@/object-record/record-table/states/isRecordTableRowActiveComponentFamilyState';
@@ -9,155 +13,137 @@ import { isRecordTableRowFocusActiveComponentState } from '@/object-record/recor
 import { isRecordTableRowFocusedComponentFamilyState } from '@/object-record/record-table/states/isRecordTableRowFocusedComponentFamilyState';
 import { useRecoilComponentFamilyValue } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentFamilyValue';
 import { useRecoilComponentValue } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValue';
-import styled from '@emotion/styled';
 import { forwardRef, type ReactNode } from 'react';
-
-const StyledTr = styled.div<{
-  isDragging: boolean;
-}>`
-  border-top: ${({ isDragging, theme }) =>
-    isDragging ? `1px solid ${theme.border.color.medium}` : 'none'};
-
-  display: flex;
-  flex-direction: row;
-
-  &[data-next-row-active-or-focused='true'] {
-    div.table-cell,
-    div.table-cell-0-0 {
-      border-bottom: none;
-    }
-  }
-
-  &[data-focused='true'] {
-    div.table-cell,
-    div.table-cell-0-0 {
-      &:not(:first-of-type) {
-        border-bottom: 1px solid ${({ theme }) => theme.border.color.medium};
-        border-top: 1px solid ${({ theme }) => theme.border.color.medium};
-        border-color: ${({ theme }) => theme.border.color.medium};
-        background-color: ${({ theme }) => theme.background.tertiary};
-      }
-      &:nth-of-type(2) {
-        border-left: 1px solid ${({ theme }) => theme.border.color.medium};
-        border-radius: ${({ theme }) => theme.border.radius.sm} 0 0
-          ${({ theme }) => theme.border.radius.sm};
-      }
-      &:last-of-type {
-        border-right: 1px solid ${({ theme }) => theme.border.color.medium};
-        border-radius: 0 ${({ theme }) => theme.border.radius.sm}
-          ${({ theme }) => theme.border.radius.sm} 0;
-      }
-    }
-  }
-
-  &[data-active='true'] {
-    div.table-cell,
-    div.table-cell-0-0 {
-      &:not(:first-of-type) {
-        border-bottom: 1px solid ${({ theme }) => theme.adaptiveColors.blue3};
-        border-top: 1px solid ${({ theme }) => theme.adaptiveColors.blue3};
-        background-color: ${({ theme }) => theme.accent.quaternary};
-      }
-      &:nth-of-type(2) {
-        border-left: 1px solid ${({ theme }) => theme.adaptiveColors.blue3};
-        border-radius: ${({ theme }) => theme.border.radius.sm} 0 0
-          ${({ theme }) => theme.border.radius.sm};
-      }
-      &:last-of-type {
-        border-right: 1px solid ${({ theme }) => theme.adaptiveColors.blue3};
-        border-radius: 0 ${({ theme }) => theme.border.radius.sm}
-          ${({ theme }) => theme.border.radius.sm} 0;
-      }
-    }
-  }
-`;
 
 type RecordTableTrProps = {
   children: ReactNode;
   recordId: string;
   focusIndex: number;
   isDragging?: boolean;
+  isFirstRowOfGroup?: boolean;
 } & Omit<
-  React.ComponentProps<typeof StyledTr>,
+  React.ComponentProps<typeof RecordTableRowDiv>,
   'isActive' | 'isNextRowActiveOrFocused' | 'isFocused'
 >;
 
-export const RecordTableTr = forwardRef<
-  HTMLTableRowElement,
-  RecordTableTrProps
->(({ children, recordId, focusIndex, isDragging = false, ...props }, ref) => {
-  const { objectMetadataItem } = useRecordTableContextOrThrow();
+export const RecordTableTr = forwardRef<HTMLDivElement, RecordTableTrProps>(
+  (
+    {
+      children,
+      recordId,
+      focusIndex,
+      isDragging = false,
+      isFirstRowOfGroup,
+      ...props
+    },
+    ref,
+  ) => {
+    const { objectMetadataItem } = useRecordTableContextOrThrow();
 
-  const currentRowSelected = useRecoilComponentFamilyValue(
-    isRowSelectedComponentFamilyState,
-    recordId,
-  );
+    const currentRowSelected = useRecoilComponentFamilyValue(
+      isRowSelectedComponentFamilyState,
+      recordId,
+    );
 
-  const isRowVisible = useRecoilComponentFamilyValue(
-    isRowVisibleComponentFamilyState,
-    recordId,
-  );
+    const isRowVisible = useRecoilComponentFamilyValue(
+      isRowVisibleComponentFamilyState,
+      recordId,
+    );
 
-  const isActive = useRecoilComponentFamilyValue(
-    isRecordTableRowActiveComponentFamilyState,
-    focusIndex,
-  );
+    const isActive = useRecoilComponentFamilyValue(
+      isRecordTableRowActiveComponentFamilyState,
+      focusIndex,
+    );
 
-  const isNextRowActive = useRecoilComponentFamilyValue(
-    isRecordTableRowActiveComponentFamilyState,
-    focusIndex + 1,
-  );
+    const isNextRowActive = useRecoilComponentFamilyValue(
+      isRecordTableRowActiveComponentFamilyState,
+      focusIndex + 1,
+    );
 
-  const isFocused = useRecoilComponentFamilyValue(
-    isRecordTableRowFocusedComponentFamilyState,
-    focusIndex,
-  );
+    const allRecordIds = useRecoilComponentValue(
+      recordIndexAllRecordIdsComponentSelector,
+    );
 
-  const isRowFocusActive = useRecoilComponentValue(
-    isRecordTableRowFocusActiveComponentState,
-  );
+    const nextRecordId = allRecordIds[focusIndex + 1];
 
-  const isNextRowFocused = useRecoilComponentFamilyValue(
-    isRecordTableRowFocusedComponentFamilyState,
-    focusIndex + 1,
-  );
+    const isNextRecordIdFirstOfGroup = useRecoilComponentFamilyValue(
+      isRecordIdFirstOfGroupComponentFamilySelector,
+      { recordId: nextRecordId },
+    );
 
-  const isNextRowActiveOrFocused =
-    (isRowFocusActive && isNextRowFocused) || isNextRowActive;
+    const isFocused = useRecoilComponentFamilyValue(
+      isRecordTableRowFocusedComponentFamilyState,
+      focusIndex,
+    );
 
-  const isRecordReadOnly = useIsRecordReadOnly({
-    recordId,
-    objectMetadataId: objectMetadataItem.id,
-  });
+    const isRowFocusActive = useRecoilComponentValue(
+      isRecordTableRowFocusActiveComponentState,
+    );
 
-  return (
-    <RecordTableRowContextProvider
-      value={{
-        recordId: recordId,
-        rowIndex: focusIndex,
-        pathToShowPage:
-          getBasePathToShowPage({
-            objectNameSingular: objectMetadataItem.nameSingular,
-          }) + recordId,
-        objectNameSingular: objectMetadataItem.nameSingular,
-        isSelected: currentRowSelected,
-        inView: isRowVisible,
-        isRecordReadOnly,
-      }}
-    >
-      <StyledTr
-        className="table-row"
-        data-virtualized-id={recordId}
-        isDragging={isDragging}
-        ref={ref}
-        data-active={isActive}
-        data-focused={isRowFocusActive && isFocused && !isActive}
-        data-next-row-active-or-focused={isNextRowActiveOrFocused}
-        // eslint-disable-next-line react/jsx-props-no-spreading
-        {...props}
+    const isNextRowFocused = useRecoilComponentFamilyValue(
+      isRecordTableRowFocusedComponentFamilyState,
+      focusIndex + 1,
+    );
+
+    const isNextRowActiveOrFocused =
+      !isNextRecordIdFirstOfGroup &&
+      ((isRowFocusActive && isNextRowFocused) || isNextRowActive);
+
+    const isRecordReadOnly = useIsRecordReadOnly({
+      recordId,
+      objectMetadataId: objectMetadataItem.id,
+    });
+
+    return (
+      <RecordTableRowContextProvider
+        value={{
+          recordId: recordId,
+          rowIndex: focusIndex,
+          pathToShowPage:
+            getBasePathToShowPage({
+              objectNameSingular: objectMetadataItem.nameSingular,
+            }) + recordId,
+          objectNameSingular: objectMetadataItem.nameSingular,
+          isSelected: currentRowSelected,
+          inView: isRowVisible,
+          isRecordReadOnly,
+        }}
       >
-        {children}
-      </StyledTr>
-    </RecordTableRowContextProvider>
-  );
-});
+        {isFirstRowOfGroup ? (
+          <RecordTableFirstRowOfGroup
+            className="table-row"
+            data-virtualized-id={recordId}
+            isDragging={isDragging}
+            ref={ref}
+            data-active={isActive}
+            data-focused={isRowFocusActive && isFocused && !isActive}
+            data-next-row-active-or-focused={isNextRowActiveOrFocused}
+            isNextRowActiveOrFocused={isNextRowActiveOrFocused}
+            focusIndex={focusIndex}
+            isFocused={isFocused}
+            isRowFocusActive={isRowFocusActive}
+            recordId={recordId}
+            // eslint-disable-next-line react/jsx-props-no-spreading
+            {...props}
+          >
+            {children}
+          </RecordTableFirstRowOfGroup>
+        ) : (
+          <RecordTableRowDiv
+            className="table-row"
+            data-virtualized-id={recordId}
+            isDragging={isDragging}
+            ref={ref}
+            data-active={isActive}
+            data-focused={isRowFocusActive && isFocused && !isActive}
+            data-next-row-active-or-focused={isNextRowActiveOrFocused}
+            // eslint-disable-next-line react/jsx-props-no-spreading
+            {...props}
+          >
+            {children}
+          </RecordTableRowDiv>
+        )}
+      </RecordTableRowContextProvider>
+    );
+  },
+);

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-row/states/isRecordIdFirstOfGroupComponentFamilySelector.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-row/states/isRecordIdFirstOfGroupComponentFamilySelector.ts
@@ -1,0 +1,49 @@
+import { recordGroupIdsComponentState } from '@/object-record/record-group/states/recordGroupIdsComponentState';
+import { recordIndexRecordIdsByGroupComponentFamilyState } from '@/object-record/record-index/states/recordIndexRecordIdsByGroupComponentFamilyState';
+import { recordIndexAllRecordIdsComponentSelector } from '@/object-record/record-index/states/selectors/recordIndexAllRecordIdsComponentSelector';
+import { createComponentFamilySelector } from '@/ui/utilities/state/component-state/utils/createComponentFamilySelector';
+import { ViewComponentInstanceContext } from '@/views/states/contexts/ViewComponentInstanceContext';
+
+export const isRecordIdFirstOfGroupComponentFamilySelector =
+  createComponentFamilySelector<boolean, { recordId: string }>({
+    key: 'isRecordIdFirstOfGroupComponentFamilySelector',
+    componentInstanceContext: ViewComponentInstanceContext,
+    get:
+      ({ familyKey, instanceId }) =>
+      ({ get }) => {
+        const recordGroupIds = get(
+          recordGroupIdsComponentState.atomFamily({
+            instanceId,
+          }),
+        );
+
+        const hasRecordGroups = recordGroupIds.length > 0;
+
+        if (hasRecordGroups) {
+          for (const recordGroupId of recordGroupIds) {
+            const recordIdsForThisGroup = get(
+              recordIndexRecordIdsByGroupComponentFamilyState.atomFamily({
+                instanceId,
+                familyKey: recordGroupId,
+              }),
+            );
+
+            if (recordIdsForThisGroup[0] === familyKey.recordId) {
+              return true;
+            }
+          }
+        } else {
+          const allRecordIds = get(
+            recordIndexAllRecordIdsComponentSelector.selectorFamily({
+              instanceId,
+            }),
+          );
+
+          if (allRecordIds[0] === familyKey.recordId) {
+            return true;
+          }
+        }
+
+        return false;
+      },
+  });


### PR DESCRIPTION
This PR fixes z-indices on all cases for table with and without groups.

It also fixes 1px glitches that appeared previously already and also during this refactor, with active and focused rows.

The focus on cells is no a portal similar to hovered portal, which works really easily thanks to the z-index management already done on hovered portal.

The urgent issues here https://github.com/twentyhq/core-team-issues/issues/1490 have been fixed.