### PR TITLE
Disable hover and active styles when button is disabled in primary/default variant

### DIFF
--- a/packages/twenty-ui/src/input/button/components/Button/Button.tsx
+++ b/packages/twenty-ui/src/input/button/components/Button/Button.tsx
@@ -88,16 +88,20 @@ const StyledButton = styled('button', {
                   ? theme.font.color.secondary
                   : theme.font.color.extraLight
                 : theme.font.color.secondary};
-              &:hover {
-                background: ${!inverted
-                  ? theme.background.tertiary
-                  : theme.background.secondary};
-              }
-              &:active {
-                background: ${!inverted
-                  ? theme.background.quaternary
-                  : theme.background.tertiary};
-              }
+              ${disabled
+                ? ''
+                : css`
+                    &:hover {
+                      background: ${!inverted
+                        ? theme.background.tertiary
+                        : theme.background.secondary};
+                    }
+                    &:active {
+                      background: ${!inverted
+                        ? theme.background.quaternary
+                        : theme.background.tertiary};
+                    }
+                  `}
             `;
           case 'blue':
             return css`


### PR DESCRIPTION
Follow up of https://github.com/twentyhq/twenty/pull/14439.

After diving in, it seems primary/default is the only variant that wasn't protected against this edge case.

## Before

https://github.com/user-attachments/assets/e7b1e61e-8db3-4e0e-82b4-e54c390e744b

## After

https://github.com/user-attachments/assets/bb3b2466-e63d-4727-b520-04f4578d579a