### PR TITLE
Fix variables coming from DB events

### DIFF
--- a/packages/twenty-front/src/modules/workflow/workflow-variables/components/WorkflowVariablesDropdownStepItems.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-variables/components/WorkflowVariablesDropdownStepItems.tsx
@@ -73,7 +73,7 @@ export const WorkflowVariablesDropdownStepItems = ({
     onSelect(
       getVariableTemplateFromPath({
         stepId: step.id,
-        path: [...currentPath, 'id'],
+        path: [...currentPath, currentSubStep.object.fieldIdName ?? 'id'],
       }),
     );
   };

--- a/packages/twenty-front/src/modules/workflow/workflow-variables/types/RecordOutputSchemaV2.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-variables/types/RecordOutputSchemaV2.ts
@@ -28,6 +28,7 @@ export type RecordOutputSchemaV2 = {
     label: string;
     objectMetadataId: string;
     isRelationField?: boolean;
+    fieldIdName?: string;
   };
   fields: Record<string, FieldOutputSchemaV2>;
   _outputSchemaType: 'RECORD';


### PR DESCRIPTION
In the case of DB events, id field will be prefixed with 'property.after'. This is why we need to use the fieldIdName when provided.

Before: When providing only id, Company variable is {{trigger.id}}. Which does not exists on DB event output schema
<img width="939" height="462" alt="Capture d’écran 2025-09-16 à 17 57 42" src="https://github.com/user-attachments/assets/c46dc00a-bb0e-45b9-af42-e9ddd0a08aea" />

After: Company variable is {{trigger.property.after.id}}
<img width="939" height="578" alt="Capture d’écran 2025-09-16 à 17 57 14" src="https://github.com/user-attachments/assets/ede11de0-b98e-40df-89a1-9b283a2692ff" />

