### PR TITLE
Fixes z-index with groups

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableContent.tsx
@@ -95,6 +95,7 @@ export const RecordTableContent = ({
         lastColumnWidth={lastColumnWidth}
         id={RECORD_TABLE_HTML_ID}
         onMouseLeave={handleMouseLeave}
+        hasRecordGroups={hasRecordGroups}
       >
         <RecordTableHeader />
         {hasRecordGroups ? (

--- a/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableEmpty.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableEmpty.tsx
@@ -1,3 +1,4 @@
+import { hasRecordGroupsComponentSelector } from '@/object-record/record-group/states/selectors/hasRecordGroupsComponentSelector';
 import { RecordTableColumnWidthEffect } from '@/object-record/record-table/components/RecordTableColumnWidthEffect';
 import { RecordTableStyleWrapper } from '@/object-record/record-table/components/RecordTableStyleWrapper';
 import { RecordTableWidthEffect } from '@/object-record/record-table/components/RecordTableWidthEffect';
@@ -71,6 +72,10 @@ export const RecordTableEmpty = ({ tableBodyRef }: RecordTableEmptyProps) => {
     emptyTableContainerComputedWidth,
   );
 
+  const hasRecordGroups = useRecoilComponentValue(
+    hasRecordGroupsComponentSelector,
+  );
+
   return (
     <StyledEmptyStateContainer width={tableContainerWidth}>
       <RecordTableStyleWrapper
@@ -78,6 +83,7 @@ export const RecordTableEmpty = ({ tableBodyRef }: RecordTableEmptyProps) => {
         visibleRecordFields={visibleRecordFields}
         lastColumnWidth={lastColumnWidth}
         id={RECORD_TABLE_HTML_ID}
+        hasRecordGroups={hasRecordGroups}
       >
         <RecordTableHeader />
       </RecordTableStyleWrapper>

--- a/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableStyleWrapper.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableStyleWrapper.tsx
@@ -21,6 +21,7 @@ const StyledTable = styled.div<{
   isDragging?: boolean;
   visibleRecordFields: RecordField[];
   lastColumnWidth: number;
+  hasRecordGroups: boolean;
 }>`
   & > * {
     pointer-events: ${({ isDragging }) =>
@@ -37,7 +38,10 @@ const StyledTable = styled.div<{
   }
 
   div.header-cell:nth-of-type(n + 5) {
-    z-index: ${TABLE_Z_INDEX.headerColumnsNormal};
+    z-index: ${({ hasRecordGroups }) =>
+      hasRecordGroups
+        ? TABLE_Z_INDEX.headerColumns.withGroups.headerColumnsNormal
+        : TABLE_Z_INDEX.headerColumns.withoutGroups.headerColumnsNormal};
   }
 
   div.header-cell:nth-of-type(1) {
@@ -45,7 +49,10 @@ const StyledTable = styled.div<{
 
     background-color: ${({ theme }) => theme.background.primary};
 
-    z-index: ${TABLE_Z_INDEX.headerColumnsSticky};
+    z-index: ${({ hasRecordGroups }) =>
+      hasRecordGroups
+        ? TABLE_Z_INDEX.headerColumns.withGroups.headerColumnsSticky
+        : TABLE_Z_INDEX.headerColumns.withoutGroups.headerColumnsSticky};
   }
 
   div.header-cell:nth-of-type(2) {
@@ -54,7 +61,10 @@ const StyledTable = styled.div<{
 
     background-color: ${({ theme }) => theme.background.primary};
 
-    z-index: ${TABLE_Z_INDEX.headerColumnsSticky};
+    z-index: ${({ hasRecordGroups }) =>
+      hasRecordGroups
+        ? TABLE_Z_INDEX.headerColumns.withGroups.headerColumnsSticky
+        : TABLE_Z_INDEX.headerColumns.withoutGroups.headerColumnsSticky};
   }
 
   div.header-cell:nth-of-type(3) {
@@ -63,7 +73,10 @@ const StyledTable = styled.div<{
 
     background-color: ${({ theme }) => theme.background.primary};
 
-    z-index: ${TABLE_Z_INDEX.headerColumnsSticky};
+    z-index: ${({ hasRecordGroups }) =>
+      hasRecordGroups
+        ? TABLE_Z_INDEX.headerColumns.withGroups.headerColumnsSticky
+        : TABLE_Z_INDEX.headerColumns.withoutGroups.headerColumnsSticky};
 
     // &::after {
     //   content: '';
@@ -86,13 +99,19 @@ const StyledTable = styled.div<{
   div.table-cell:nth-of-type(1) {
     position: sticky;
     left: 0px;
-    z-index: ${TABLE_Z_INDEX.cell.sticky};
+    z-index: ${({ hasRecordGroups }) =>
+      hasRecordGroups
+        ? TABLE_Z_INDEX.cell.withGroups.sticky
+        : TABLE_Z_INDEX.cell.withoutGroups.sticky};
   }
 
   div.table-cell:nth-of-type(2) {
     position: sticky;
     left: 16px;
-    z-index: ${TABLE_Z_INDEX.cell.sticky};
+    z-index: ${({ hasRecordGroups }) =>
+      hasRecordGroups
+        ? TABLE_Z_INDEX.cell.withGroups.sticky
+        : TABLE_Z_INDEX.cell.withoutGroups.sticky};
   }
 
   div.table-cell-0-0 {
@@ -103,7 +122,10 @@ const StyledTable = styled.div<{
   div.table-cell:nth-of-type(3) {
     position: sticky;
     left: 48px;
-    z-index: ${TABLE_Z_INDEX.cell.sticky};
+    z-index: ${({ hasRecordGroups }) =>
+      hasRecordGroups
+        ? TABLE_Z_INDEX.cell.withGroups.sticky
+        : TABLE_Z_INDEX.cell.withoutGroups.sticky};
   }
 
   div.${RECORD_TABLE_COLUMN_DRAG_AND_DROP_WIDTH_CLASS_NAME} {

--- a/packages/twenty-front/src/modules/object-record/record-table/constants/TableZIndex.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/constants/TableZIndex.ts
@@ -1,12 +1,27 @@
 export const TABLE_Z_INDEX = {
   base: 1,
   cell: {
-    default: 3,
-    sticky: 12,
-    editMode: 30,
+    withoutGroups: {
+      default: 3,
+      sticky: 12,
+      editMode: 30,
+    },
+    withGroups: {
+      default: 3,
+      sticky: 12,
+      editMode: 30,
+    },
   },
-  headerColumnsSticky: 14,
-  headerColumnsNormal: 10,
+  headerColumns: {
+    withoutGroups: {
+      headerColumnsSticky: 14,
+      headerColumnsNormal: 10,
+    },
+    withGroups: {
+      headerColumnsSticky: 21,
+      headerColumnsNormal: 20,
+    },
+  },
   withoutGroupsCell0_0: {
     cell0_0HoveredWithoutScroll: 15,
     cell0_0Normal: 12,
@@ -17,28 +32,28 @@ export const TABLE_Z_INDEX = {
   },
   withGroups: {
     noScrollAtAll: {
-      hoverPortalCellOnFirstScrollableColumn: 17,
-      hoverPortalCellOnNormalColumn: 17,
-      hoverPortalCellOnLabelIdentifierColumn: 17,
-      firstScrollableHeaderCell: 10,
+      hoverPortalCellOnFirstScrollableColumn: 16,
+      hoverPortalCellOnNormalColumn: 14,
+      hoverPortalCellOnLabelIdentifierColumn: 14,
+      firstScrollableHeaderCell: 19,
     },
     scrolledBothVerticallyAndHorizontally: {
       hoverPortalCellOnNormalColumn: 9,
       hoverPortalCellOnFirstScrollableColumn: 9,
       hoverPortalCellOnLabelIdentifierColumn: 9,
-      firstScrollableHeaderCell: 10,
+      firstScrollableHeaderCell: 19,
     },
     scrolledHorizontallyOnly: {
       hoverPortalCellOnLabelIdentifierColumn: 9,
       hoverPortalCellOnNormalColumn: 9,
       hoverPortalCellOnFirstScrollableColumn: 9,
-      firstScrollableHeaderCell: 10,
+      firstScrollableHeaderCell: 19,
     },
     scrolledVerticallyOnly: {
       hoverPortalCellOnNormalColumn: 9,
-      hoverPortalCellOnFirstScrollableColumn: 13,
+      hoverPortalCellOnFirstScrollableColumn: 16,
       hoverPortalCellOnLabelIdentifierColumn: 9,
-      firstScrollableHeaderCell: 14,
+      firstScrollableHeaderCell: 19,
     },
   },
   withoutGroups: {
@@ -70,8 +85,8 @@ export const TABLE_Z_INDEX = {
   columnGrip: 30,
   footer: {
     tableWithGroups: {
-      default: 4,
-      stickyColumn: 5,
+      default: 17,
+      stickyColumn: 18,
     },
     tableWithoutGroups: {
       default: 18,

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellEditModePortal.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellEditModePortal.tsx
@@ -1,6 +1,7 @@
 import { RecordTableCellPortalWrapper } from '@/object-record/record-table/record-table-cell/components/RecordTableCellPortalWrapper';
 import { useRecoilComponentValue } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValue';
 
+import { hasRecordGroupsComponentSelector } from '@/object-record/record-group/states/selectors/hasRecordGroupsComponentSelector';
 import { TABLE_Z_INDEX } from '@/object-record/record-table/constants/TableZIndex';
 import { RecordTableCellEditMode } from '@/object-record/record-table/record-table-cell/components/RecordTableCellEditMode';
 import { RecordTableCellFieldInput } from '@/object-record/record-table/record-table-cell/components/RecordTableCellFieldInput';
@@ -18,6 +19,10 @@ export const RecordTableCellEditModePortal = () => {
     recordTableCellEditModePositionComponentState,
   );
 
+  const hasRecordGroups = useRecoilComponentValue(
+    hasRecordGroupsComponentSelector,
+  );
+
   if (!focusedCellPosition) {
     return null;
   }
@@ -26,7 +31,11 @@ export const RecordTableCellEditModePortal = () => {
     <RecordTableCellPortalWrapper position={focusedCellPosition}>
       {currentTableCellInEditModePosition && (
         <RecordTableCellPortalRootContainer
-          zIndex={TABLE_Z_INDEX.cell.editMode}
+          zIndex={
+            hasRecordGroups
+              ? TABLE_Z_INDEX.cell.withGroups.editMode
+              : TABLE_Z_INDEX.cell.withoutGroups.editMode
+          }
         >
           <RecordTableCellEditMode>
             <RecordTableCellFieldInput />


### PR DESCRIPTION
This PR fixes a few z-index issues on table with groups.

Once the z-index issues will have been stabilized, we'll refactor this big constant file which is hard to maintain.

In https://github.com/twentyhq/core-team-issues/issues/1490, fixes : 
- Aggregate footer label identifier is hidden
- Bug sticky footer label identifier on table with groups has not the right z-index