### PR TITLE
[fix] Handle null icon for field metadata

### DIFF
--- a/packages/twenty-front/src/modules/object-metadata/validation-schemas/fieldMetadataItemSchema.ts
+++ b/packages/twenty-front/src/modules/object-metadata/validation-schemas/fieldMetadataItemSchema.ts
@@ -12,7 +12,10 @@ export const fieldMetadataItemSchema = (existingLabels?: string[]) => {
     createdAt: z.string().datetime(),
     defaultValue: z.any().optional(),
     description: z.string().trim().nullable().optional(),
-    icon: z.string().startsWith('Icon').trim().nullable(),
+    icon: z
+      .union([z.string().startsWith('Icon').trim(), z.literal('')])
+      .nullable()
+      .optional(),
     id: z.string().uuid(),
     isActive: z.boolean(),
     isCustom: z.boolean(),


### PR DESCRIPTION
Fixes https://github.com/twentyhq/twenty/issues/14548.

When creating a field metadata through the api, the field's icon can be null (from twenty UI, a default icon is always added by default and it is not possible to remove it). Then this value is turned into an empty string in the payload - i don't know why we don't send the null value.
When updating the field through the UI, we run a zod validation that either accepts a null value for Icon, or a value that starts with `"Icon".` In our case, the value for Icon was `""` (an empty string), which is not valid. Therefore the form was considered not valid until an icon was added. 

While the fix suggested works, we should probably sort out the `null` conversion to `""`, as it is prone to errors.