### PR TITLE
Add missing migration for unaccent

### DIFF
--- a/packages/twenty-server/src/database/typeorm/core/migrations/common/1758117800000-activate-unaccent-extension.ts
+++ b/packages/twenty-server/src/database/typeorm/core/migrations/common/1758117800000-activate-unaccent-extension.ts
@@ -1,0 +1,24 @@
+import { type MigrationInterface, type QueryRunner } from 'typeorm';
+
+export class ActivateUnaccentExtension1758117800000
+  implements MigrationInterface
+{
+  name = 'ActivateUnaccentExtension1758117800000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`CREATE EXTENSION IF NOT EXISTS "unaccent"`);
+
+    await queryRunner.query(
+      `CREATE OR REPLACE FUNCTION unaccent_immutable(text) RETURNS text AS $$
+        SELECT public.unaccent($1)
+      $$ LANGUAGE sql IMMUTABLE;`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP FUNCTION IF EXISTS unaccent_immutable(text)`);
+
+    // Note: We don't drop the extension as it might be used by other parts
+    // of the application or other databases. Extensions are typically
+  }
+}

--- a/packages/twenty-server/src/database/typeorm/core/migrations/common/1758117800000-activate-unaccent-extension.ts
+++ b/packages/twenty-server/src/database/typeorm/core/migrations/common/1758117800000-activate-unaccent-extension.ts
@@ -19,6 +19,7 @@ export class ActivateUnaccentExtension1758117800000
     await queryRunner.query(`DROP FUNCTION IF EXISTS unaccent_immutable(text)`);
 
     // Note: We don't drop the extension as it might be used by other parts
-    // of the application or other databases. Extensions are typically
+    // Note: We don't drop the extension as it might be used by other parts
+    // of the application or other databases. Extensions are typically left in place.
   }
 }


### PR DESCRIPTION
It was in setup-db.ts but that's not enough for instances that are already live