### PR TITLE
Fix focused row group section border bottom

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-section/components/RecordTableRecordGroupSection.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-section/components/RecordTableRecordGroupSection.tsx
@@ -198,7 +198,8 @@ export const RecordTableRecordGroupSection = () => {
 
   const isFirstRowActiveOrFocused = isFirstRowActive || isFirstRowFocused;
 
-  const shouldDisplayBorderBottom = !isFirstRowActiveOrFocused;
+  const shouldDisplayBorderBottom =
+    !isFirstRowActiveOrFocused || !isRecordGroupTableSectionToggled;
 
   if (!isDefined(recordGroup)) {
     return null;


### PR DESCRIPTION
This PR fixes the focused row that was making the group section border bottom disappear if collapsed.

In https://github.com/twentyhq/core-team-issues/issues/1490, fixes : 
- Section border-bottom disappear if the focus is on the first row of a collapsed section