### PR TITLE
fix: Added isReadonly logic to css

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellContainer.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellContainer.tsx
@@ -41,17 +41,19 @@ const StyledLabelAndIconContainer = styled.div`
   height: 24px;
 `;
 
-const StyledValueContainer = styled.div<{
-  readonly: boolean;
-}>`
+const StyledValueContainer = styled.div<{ readonly: boolean }>`
   display: flex;
   min-width: 0;
   position: relative;
   width: 100%;
 
-  &:hover .record-inline-cell-value-display {
-    opacity: 0;
-  }
+  ${({ readonly }) =>
+    !readonly &&
+    `
+    &:hover .record-inline-cell-value-display {
+      opacity: 0;
+    }
+  `}
 `;
 
 const StyledLabelContainer = styled.div<{ width?: number }>`


### PR DESCRIPTION
### Description

Field values in RecordInlineCell were disappearing on hover even when read-only.
This was caused by the hover CSS being applied unconditionally and readonly prop not used properly.

Fixes #14582  
---

### Changes

- Added $readonly prop to StyledValueContainer to conditionally apply hover opacity.

- Read-only fields now display values normally;

---

### Video ->

[Screencast from 2025-09-18 06-17-20.webm](https://github.com/user-attachments/assets/d1ad8a0a-5903-4709-b02a-77ae2e1315f1)
