### PR TITLE
update cleaning job to progressively delete metadata

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.service.ts
@@ -625,7 +625,15 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
   }
 
   public async deleteObjectsMetadata(workspaceId: string) {
-    await this.objectMetadataRepository.delete({ workspaceId });
+    const objectsMetadata = await this.objectMetadataRepository.find({
+      where: {
+        workspaceId,
+      },
+    });
+
+    for (const objectMetadata of objectsMetadata) {
+      await this.objectMetadataRepository.delete({ id: objectMetadata.id });
+    }
   }
 
   private async handleObjectNameAndLabelUpdates({

--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.service.ts
@@ -639,9 +639,6 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
     });
 
     for (const objectMetadata of objectsMetadata) {
-      await this.fieldMetadataRepository.delete({
-        objectMetadataId: objectMetadata.id,
-      });
       await this.objectMetadataRepository.delete({
         id: objectMetadata.id,
       });

--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.service.ts
@@ -62,6 +62,8 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
   constructor(
     @InjectRepository(ObjectMetadataEntity)
     private readonly objectMetadataRepository: Repository<ObjectMetadataEntity>,
+    @InjectRepository(FieldMetadataEntity)
+    private readonly fieldMetadataRepository: Repository<FieldMetadataEntity>,
 
     private readonly dataSourceService: DataSourceService,
     private readonly workspaceMetadataCacheService: WorkspaceMetadataCacheService,
@@ -631,8 +633,18 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
       },
     });
 
+    await this.fieldMetadataRepository.delete({
+      workspaceId,
+      type: In([FieldMetadataType.MORPH_RELATION, FieldMetadataType.RELATION]),
+    });
+
     for (const objectMetadata of objectsMetadata) {
-      await this.objectMetadataRepository.delete({ id: objectMetadata.id });
+      await this.fieldMetadataRepository.delete({
+        objectMetadataId: objectMetadata.id,
+      });
+      await this.objectMetadataRepository.delete({
+        id: objectMetadata.id,
+      });
     }
   }
 

--- a/packages/twenty-server/src/engine/workspace-manager/__tests__/workspace-manager.service.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/__tests__/workspace-manager.service.spec.ts
@@ -29,7 +29,6 @@ describe('WorkspaceManagerService', () => {
   let objectMetadataService: ObjectMetadataService;
   let workspaceMigrationRepository: Repository<WorkspaceMigrationEntity>;
   let dataSourceRepository: Repository<DataSourceEntity>;
-  let workspaceFieldMetadataRepository: Repository<FieldMetadataEntity>;
   let workspaceDataSourceService: WorkspaceDataSourceService;
   let roleTargetsRepository: Repository<RoleTargetsEntity>;
   let roleRepository: Repository<RoleEntity>;
@@ -155,9 +154,6 @@ describe('WorkspaceManagerService', () => {
     dataSourceRepository = module.get<Repository<DataSourceEntity>>(
       getRepositoryToken(DataSourceEntity),
     );
-    workspaceFieldMetadataRepository = module.get<
-      Repository<FieldMetadataEntity>
-    >(getRepositoryToken(FieldMetadataEntity));
     workspaceDataSourceService = module.get<WorkspaceDataSourceService>(
       WorkspaceDataSourceService,
     );

--- a/packages/twenty-server/src/engine/workspace-manager/__tests__/workspace-manager.service.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/__tests__/workspace-manager.service.spec.ts
@@ -177,9 +177,6 @@ describe('WorkspaceManagerService', () => {
     it('should delete all the workspace metadata tables and workspace schema', async () => {
       await service.delete('workspace-id');
       expect(objectMetadataService.deleteObjectsMetadata).toHaveBeenCalled();
-      expect(workspaceFieldMetadataRepository.delete).toHaveBeenCalledWith({
-        workspaceId: 'workspace-id',
-      });
       expect(workspaceMigrationRepository.delete).toHaveBeenCalledWith({
         workspaceId: 'workspace-id',
       });

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-manager.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-manager.service.ts
@@ -158,15 +158,19 @@ export class WorkspaceManagerService {
     this.logger.log(`workspace ${workspaceId} role deleted`);
 
     await this.objectMetadataService.deleteObjectsMetadata(workspaceId);
+
     this.logger.log(`workspace ${workspaceId} object metadata deleted`);
 
     await this.workspaceMigrationService.deleteAllWithinWorkspace(workspaceId);
+
     this.logger.log(`workspace ${workspaceId} migration deleted`);
 
     await this.dataSourceService.delete(workspaceId);
+
     this.logger.log(`workspace ${workspaceId} data source deleted`);
     // Delete schema
     await this.workspaceDataSourceService.deleteWorkspaceDBSchema(workspaceId);
+
     this.logger.log(`workspace ${workspaceId} schema deleted`);
   }
 

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-manager.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-manager.service.ts
@@ -158,15 +158,12 @@ export class WorkspaceManagerService {
     this.logger.log(`workspace ${workspaceId} role deleted`);
 
     await this.objectMetadataService.deleteObjectsMetadata(workspaceId);
-
     this.logger.log(`workspace ${workspaceId} object metadata deleted`);
 
     await this.workspaceMigrationService.deleteAllWithinWorkspace(workspaceId);
-
     this.logger.log(`workspace ${workspaceId} migration deleted`);
 
     await this.dataSourceService.delete(workspaceId);
-
     this.logger.log(`workspace ${workspaceId} data source deleted`);
     // Delete schema
     await this.workspaceDataSourceService.deleteWorkspaceDBSchema(workspaceId);

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-manager.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-manager.service.ts
@@ -10,7 +10,6 @@ import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AgentService } from 'src/engine/metadata-modules/agent/agent.service';
 import { type DataSourceEntity } from 'src/engine/metadata-modules/data-source/data-source.entity';
 import { DataSourceService } from 'src/engine/metadata-modules/data-source/data-source.service';
-import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { ObjectMetadataService } from 'src/engine/metadata-modules/object-metadata/object-metadata.service';
 import { RoleTargetsEntity } from 'src/engine/metadata-modules/role/role-targets.entity';
 import { RoleEntity } from 'src/engine/metadata-modules/role/role.entity';
@@ -36,8 +35,6 @@ export class WorkspaceManagerService {
     private readonly objectMetadataService: ObjectMetadataService,
     private readonly dataSourceService: DataSourceService,
     private readonly workspaceSyncMetadataService: WorkspaceSyncMetadataService,
-    @InjectRepository(FieldMetadataEntity)
-    private readonly fieldMetadataRepository: Repository<FieldMetadataEntity>,
     @InjectRepository(UserWorkspace)
     private readonly userWorkspaceRepository: Repository<UserWorkspace>,
     private readonly roleService: RoleService,
@@ -149,11 +146,6 @@ export class WorkspaceManagerService {
   public async delete(workspaceId: string): Promise<void> {
     //TODO: delete all logs when #611 closed
     this.logger.log(`Deleting workspace ${workspaceId} ...`);
-
-    await this.fieldMetadataRepository.delete({
-      workspaceId,
-    });
-    this.logger.log(`workspace ${workspaceId} field metadata deleted`);
 
     await this.roleTargetsRepository.delete({
       workspaceId,


### PR DESCRIPTION
Workspace cleaning jobs slow down the db each hours when running. We suspect the object metadata deleting query with all cascade/depending entities (field, index, ..) to be the cause.