### PR TITLE
Fix - Record text should always be visible and in first position in views

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-header/components/RecordTableHeader.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-header/components/RecordTableHeader.tsx
@@ -4,8 +4,8 @@ import { RecordTableHeaderAddColumnButton } from '@/object-record/record-table/r
 import { RecordTableHeaderCell } from '@/object-record/record-table/record-table-header/components/RecordTableHeaderCell';
 import { RecordTableHeaderCheckboxColumn } from '@/object-record/record-table/record-table-header/components/RecordTableHeaderCheckboxColumn';
 import { RecordTableHeaderDragDropColumn } from '@/object-record/record-table/record-table-header/components/RecordTableHeaderDragDropColumn';
+import { RecordTableHeaderFirstCell } from '@/object-record/record-table/record-table-header/components/RecordTableHeaderFirstCell';
 import { RecordTableHeaderFirstScrollableCell } from '@/object-record/record-table/record-table-header/components/RecordTableHeaderFirstScrollableCell';
-import { RecordTableHeaderLabelIdentifierCell } from '@/object-record/record-table/record-table-header/components/RecordTableHeaderLabelIdentifierCell';
 import { RecordTableHeaderLastEmptyColumn } from '@/object-record/record-table/record-table-header/components/RecordTableHeaderLastEmptyColumn';
 import { useResizeTableHeader } from '@/object-record/record-table/record-table-header/hooks/useResizeTableHeader';
 import { filterOutByProperty } from 'twenty-shared/utils';
@@ -29,7 +29,7 @@ export const RecordTableHeader = () => {
     <>
       <RecordTableHeaderDragDropColumn />
       <RecordTableHeaderCheckboxColumn />
-      <RecordTableHeaderLabelIdentifierCell />
+      <RecordTableHeaderFirstCell />
       <RecordTableHeaderFirstScrollableCell />
       {recordFieldsWithoutLabelIdentifierAndFirstOne.map(
         (recordField, index) => (

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-header/components/RecordTableHeaderFirstCell.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-header/components/RecordTableHeaderFirstCell.tsx
@@ -1,6 +1,5 @@
 import styled from '@emotion/styled';
 
-import { useRecordIndexContextOrThrow } from '@/object-record/record-index/contexts/RecordIndexContext';
 import { useRecordTableContextOrThrow } from '@/object-record/record-table/contexts/RecordTableContext';
 import { RecordTableColumnHeadWithDropdown } from '@/object-record/record-table/record-table-header/components/RecordTableColumnHeadWithDropdown';
 import { RecordTableHeaderResizeHandler } from '@/object-record/record-table/record-table-header/components/RecordTableHeaderResizeHandler';
@@ -9,6 +8,7 @@ import { RecordTableHeaderCellContainer } from '@/object-record/record-table/rec
 
 import { hasRecordGroupsComponentSelector } from '@/object-record/record-group/states/selectors/hasRecordGroupsComponentSelector';
 import { RecordTableHeaderLabelIdentifierCellPlusButton } from '@/object-record/record-table/record-table-header/components/RecordTableHeaderLabelIdentifierCellPlusButton';
+import { getVisibleFieldWithLowestPosition } from '@/object-record/record-table/record-table-header/utils/getVisibleFieldWithLowestPosition.util';
 import { isRecordTableRowActiveComponentFamilyState } from '@/object-record/record-table/states/isRecordTableRowActiveComponentFamilyState';
 import { isRecordTableRowFocusActiveComponentState } from '@/object-record/record-table/states/isRecordTableRowFocusActiveComponentState';
 import { isRecordTableRowFocusedComponentFamilyState } from '@/object-record/record-table/states/isRecordTableRowFocusedComponentFamilyState';
@@ -19,7 +19,7 @@ import { useRecoilComponentFamilyValue } from '@/ui/utilities/state/component-st
 import { useRecoilComponentValue } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValue';
 import { cx } from '@linaria/core';
 import { useState } from 'react';
-import { findByProperty, isDefined } from 'twenty-shared/utils';
+import { isDefined } from 'twenty-shared/utils';
 
 const StyledColumnHeadContainer = styled.div`
   cursor: pointer;
@@ -30,7 +30,7 @@ const StyledColumnHeadContainer = styled.div`
   overflow: hidden;
 `;
 
-export const RecordTableHeaderLabelIdentifierCell = () => {
+export const RecordTableHeaderFirstCell = () => {
   const { objectMetadataItem, visibleRecordFields } =
     useRecordTableContextOrThrow();
 
@@ -46,11 +46,7 @@ export const RecordTableHeaderLabelIdentifierCell = () => {
     0,
   );
 
-  const { labelIdentifierFieldMetadataItem } = useRecordIndexContextOrThrow();
-
-  const recordField = visibleRecordFields.find(
-    findByProperty('fieldMetadataItemId', labelIdentifierFieldMetadataItem?.id),
-  );
+  const recordField = getVisibleFieldWithLowestPosition(visibleRecordFields);
 
   const isScrolledVertically = useRecoilComponentValue(
     isRecordTableScrolledVerticallyComponentState,

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-header/utils/getVisibleFieldWithLowestPosition.util.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-header/utils/getVisibleFieldWithLowestPosition.util.ts
@@ -3,8 +3,11 @@ import { type RecordField } from '@/object-record/record-field/types/RecordField
 export const getVisibleFieldWithLowestPosition = (
   visibleRecordFields: RecordField[],
 ) => {
+  if (visibleRecordFields.length === 0) {
+    return undefined;
+  }
   return visibleRecordFields.reduce((lowestPositionField, currentField) => {
-    if (currentField.position < lowestPositionField.position) {
+    if (currentField?.position < lowestPositionField?.position) {
       return currentField;
     }
     return lowestPositionField;

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-header/utils/getVisibleFieldWithLowestPosition.util.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-header/utils/getVisibleFieldWithLowestPosition.util.ts
@@ -1,0 +1,12 @@
+import { type RecordField } from '@/object-record/record-field/types/RecordField';
+
+export const getVisibleFieldWithLowestPosition = (
+  visibleRecordFields: RecordField[],
+) => {
+  return visibleRecordFields.reduce((lowestPositionField, currentField) => {
+    if (currentField.position < lowestPositionField.position) {
+      return currentField;
+    }
+    return lowestPositionField;
+  }, visibleRecordFields[0]);
+};

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-6/1-6-fix-label-identifier-position.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-6/1-6-fix-label-identifier-position.command.ts
@@ -1,0 +1,102 @@
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { Command } from 'nest-commander';
+import { Repository } from 'typeorm';
+
+import {
+  ActiveOrSuspendedWorkspacesMigrationCommandRunner,
+  type RunOnWorkspaceArgs,
+} from 'src/database/commands/command-runners/active-or-suspended-workspaces-migration.command-runner';
+import { ViewFieldEntity } from 'src/engine/core-modules/view/entities/view-field.entity';
+import { ViewEntity } from 'src/engine/core-modules/view/entities/view.entity';
+import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
+import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.manager';
+
+@Command({
+  name: 'upgrade:1-6:fix-label-identifier-position',
+  description:
+    'Fix label identifier position to ensure it has the minimal position in each view',
+})
+export class FixLabelIdentifierPositionCommand extends ActiveOrSuspendedWorkspacesMigrationCommandRunner {
+  constructor(
+    @InjectRepository(Workspace)
+    protected readonly workspaceRepository: Repository<Workspace>,
+    protected readonly twentyORMGlobalManager: TwentyORMGlobalManager,
+    @InjectRepository(ViewEntity)
+    private readonly viewRepository: Repository<ViewEntity>,
+    @InjectRepository(ViewFieldEntity)
+    private readonly viewFieldRepository: Repository<ViewFieldEntity>,
+  ) {
+    super(workspaceRepository, twentyORMGlobalManager);
+  }
+
+  override async runOnWorkspace({
+    workspaceId,
+    options,
+  }: RunOnWorkspaceArgs): Promise<void> {
+    this.logger.log(
+      `Checking label identifiers position for workspace ${workspaceId}`,
+    );
+
+    // Get all views with their related object metadata and view fields
+    const views = await this.viewRepository.find({
+      where: { workspaceId },
+      relations: {
+        objectMetadata: true,
+        viewFields: true,
+      },
+    });
+
+    for (const view of views) {
+      const { objectMetadata, viewFields } = view;
+
+      // Skip if no label identifier field metadata ID
+      if (!objectMetadata.labelIdentifierFieldMetadataId) {
+        continue;
+      }
+
+      // Find the label identifier view field
+      const labelIdentifierViewField = viewFields.find(
+        (viewField: ViewFieldEntity) =>
+          viewField.fieldMetadataId ===
+          objectMetadata.labelIdentifierFieldMetadataId,
+      );
+
+      // Skip if label identifier view field not found
+      if (!labelIdentifierViewField) {
+        continue;
+      }
+
+      // Find the minimum position among all view fields
+      const minPosition = Math.min(
+        ...viewFields.map((viewField: ViewFieldEntity) => viewField.position),
+      );
+
+      // Check if label identifier already has the minimal position
+      if (labelIdentifierViewField.position === minPosition) {
+        this.logger.log(
+          `Label identifier position is already the minimal position for view ${view.id} in workspace ${workspaceId}`,
+        );
+        continue;
+      }
+
+      // Update the label identifier position to be the minimal one
+      const newPosition = minPosition - 1;
+
+      if (!options.dryRun) {
+        await this.viewFieldRepository.update(
+          { id: labelIdentifierViewField.id },
+          { position: newPosition },
+        );
+
+        this.logger.log(
+          `Fixed label identifier position for view ${view.id} in workspace ${workspaceId}: ${labelIdentifierViewField.position} -> ${newPosition}`,
+        );
+      } else {
+        this.logger.log(
+          `Would fix label identifier position for view ${view.id} in workspace ${workspaceId}: ${labelIdentifierViewField.position} -> ${newPosition}`,
+        );
+      }
+    }
+  }
+}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-6/1-6-upgrade-version-command.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-6/1-6-upgrade-version-command.module.ts
@@ -1,6 +1,9 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { FixLabelIdentifierPositionCommand } from 'src/database/commands/upgrade-version-command/1-6/1-6-fix-label-identifier-position.command';
+import { ViewFieldEntity } from 'src/engine/core-modules/view/entities/view-field.entity';
+import { ViewEntity } from 'src/engine/core-modules/view/entities/view.entity';
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
@@ -14,12 +17,14 @@ import { WorkspaceDataSourceModule } from 'src/engine/workspace-datasource/works
       Workspace,
       FieldMetadataEntity,
       ObjectMetadataEntity,
+      ViewEntity,
+      ViewFieldEntity,
     ]),
     WorkspaceDataSourceModule,
     WorkspaceSchemaManagerModule,
     WorkspaceMetadataVersionModule,
   ],
-  providers: [],
-  exports: [],
+  providers: [FixLabelIdentifierPositionCommand],
+  exports: [FixLabelIdentifierPositionCommand],
 })
 export class V1_6_UpgradeVersionCommandModule {}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-6/1-6-upgrade-version-command.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-6/1-6-upgrade-version-command.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
-import { FixLabelIdentifierPositionCommand } from 'src/database/commands/upgrade-version-command/1-6/1-6-fix-label-identifier-position.command';
+import { FixLabelIdentifierPositionAndVisibilityCommand } from 'src/database/commands/upgrade-version-command/1-6/1-6-fix-label-identifier-position-and-visibility.command';
 import { ViewFieldEntity } from 'src/engine/core-modules/view/entities/view-field.entity';
 import { ViewEntity } from 'src/engine/core-modules/view/entities/view.entity';
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
@@ -24,7 +24,7 @@ import { WorkspaceDataSourceModule } from 'src/engine/workspace-datasource/works
     WorkspaceSchemaManagerModule,
     WorkspaceMetadataVersionModule,
   ],
-  providers: [FixLabelIdentifierPositionCommand],
-  exports: [FixLabelIdentifierPositionCommand],
+  providers: [FixLabelIdentifierPositionAndVisibilityCommand],
+  exports: [FixLabelIdentifierPositionAndVisibilityCommand],
 })
 export class V1_6_UpgradeVersionCommandModule {}

--- a/packages/twenty-server/src/engine/core-modules/view/services/tests/view-field.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/view/services/tests/view-field.service.spec.ts
@@ -214,6 +214,54 @@ describe('ViewFieldService', () => {
         ),
       );
     });
+
+    it('should throw exception if position is lower than label metadata identifier', async () => {
+      const labelIdentifierFieldMetadataId =
+        'label-identifier-field-matadata-id';
+      const labelIdentifierViewFieldId =
+        'view-field-for-label-metadata-identifier-id';
+
+      const labelIdentifierViewField = {
+        ...mockViewField,
+        id: labelIdentifierViewFieldId,
+        fieldMetadataId: labelIdentifierFieldMetadataId,
+        position: 0,
+      };
+
+      const mockView = {
+        id: 'view-id',
+        objectMetadata: {
+          labelIdentifierFieldMetadataId,
+        },
+        viewFields: [
+          labelIdentifierViewField,
+          { ...mockViewField, position: 1 },
+        ],
+      } as ViewEntity;
+
+      jest.spyOn(viewFieldService, 'findById').mockImplementation((id) => {
+        if (id === mockViewField.id) {
+          return Promise.resolve(mockViewField);
+        }
+
+        return Promise.resolve(null);
+      });
+      jest
+        .spyOn(viewService, 'findByIdWithRelatedObjectMetadata')
+        .mockResolvedValue(mockView);
+
+      const invalidData = { ...validViewFieldData, position: -1 };
+
+      await expect(viewFieldService.create(invalidData)).rejects.toThrow(
+        new UserInputError(
+          'Label metadata identifier must keep the minimal position in the view.',
+          {
+            userFriendlyMessage:
+              'Record text must be in first position of the view.',
+          },
+        ),
+      );
+    });
   });
 
   describe('update', () => {
@@ -274,10 +322,13 @@ describe('ViewFieldService', () => {
       const updateData = { position: 2 };
       const labelIdentifierFieldMetadataId =
         'label-identifier-field-matadata-id';
+      const labelIdentifierViewFieldId =
+        'view-field-for-label-metadata-identifier-id';
 
       const labelIdentifierViewField = {
         ...mockViewField,
-        id: labelIdentifierFieldMetadataId,
+        id: labelIdentifierViewFieldId,
+        fieldMetadataId: labelIdentifierFieldMetadataId,
         position: 0,
       };
 
@@ -293,7 +344,7 @@ describe('ViewFieldService', () => {
       } as ViewEntity;
 
       jest.spyOn(viewFieldService, 'findById').mockImplementation((id) => {
-        if (id === labelIdentifierFieldMetadataId) {
+        if (id === labelIdentifierViewFieldId) {
           return Promise.resolve(labelIdentifierViewField);
         }
 
@@ -305,7 +356,7 @@ describe('ViewFieldService', () => {
 
       await expect(
         viewFieldService.update(
-          labelIdentifierFieldMetadataId,
+          labelIdentifierViewFieldId,
           workspaceId,
           updateData,
         ),
@@ -325,10 +376,13 @@ describe('ViewFieldService', () => {
       const updateData = { position: -1 };
       const labelIdentifierFieldMetadataId =
         'label-identifier-field-matadata-id';
+      const labelIdentifierViewFieldId =
+        'view-field-for-label-metadata-identifier-id';
 
       const labelIdentifierViewField = {
         ...mockViewField,
-        id: labelIdentifierFieldMetadataId,
+        id: labelIdentifierViewFieldId,
+        fieldMetadataId: labelIdentifierFieldMetadataId,
         position: 0,
       };
 
@@ -372,10 +426,13 @@ describe('ViewFieldService', () => {
       const updateData = { isVisible: false };
       const labelIdentifierFieldMetadataId =
         'label-identifier-field-matadata-id';
+      const labelIdentifierViewFieldId =
+        'view-field-for-label-metadata-identifier-id';
 
       const labelIdentifierViewField = {
         ...mockViewField,
-        id: labelIdentifierFieldMetadataId,
+        id: labelIdentifierViewFieldId,
+        fieldMetadataId: labelIdentifierFieldMetadataId,
         position: 0,
       };
 
@@ -388,7 +445,7 @@ describe('ViewFieldService', () => {
       } as ViewEntity;
 
       jest.spyOn(viewFieldService, 'findById').mockImplementation((id) => {
-        if (id === labelIdentifierFieldMetadataId) {
+        if (id === labelIdentifierViewFieldId) {
           return Promise.resolve(labelIdentifierViewField);
         }
 

--- a/packages/twenty-server/src/engine/core-modules/view/services/tests/view-field.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/view/services/tests/view-field.service.spec.ts
@@ -361,6 +361,53 @@ describe('ViewFieldService', () => {
         ),
       );
     });
+
+    it('should throw exception when attempting to make label metadata identifier invisible', async () => {
+      const workspaceId = 'workspace-id';
+      const updateData = { isVisible: false };
+      const labelIdentifierFieldMetadataId =
+        'label-identifier-field-matadata-id';
+
+      const labelIdentifierViewField = {
+        ...mockViewField,
+        id: labelIdentifierFieldMetadataId,
+        position: 0,
+      };
+
+      const mockView = {
+        id: 'view-id',
+        objectMetadata: {
+          labelIdentifierFieldMetadataId,
+        },
+        viewFields: [labelIdentifierViewField, mockViewField],
+      } as ViewEntity;
+
+      jest.spyOn(viewFieldService, 'findById').mockImplementation((id) => {
+        if (id === labelIdentifierFieldMetadataId) {
+          return Promise.resolve(labelIdentifierViewField);
+        }
+
+        return Promise.resolve(null);
+      });
+      jest
+        .spyOn(
+          viewFieldService['viewService'],
+          'findByIdWithRelatedObjectMetadata',
+        )
+        .mockResolvedValue(mockView);
+
+      await expect(
+        viewFieldService.update(
+          labelIdentifierViewField.id,
+          workspaceId,
+          updateData,
+        ),
+      ).rejects.toThrow(
+        new UserInputError('Label metadata identifier must stay visible.', {
+          userFriendlyMessage: 'Record text must stay visible.',
+        }),
+      );
+    });
   });
 
   describe('delete', () => {

--- a/packages/twenty-server/src/engine/core-modules/view/services/tests/view-field.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/view/services/tests/view-field.service.spec.ts
@@ -223,10 +223,21 @@ describe('ViewFieldService', () => {
       const updateData = { position: 1 };
       const updatedViewField = { ...mockViewField, ...updateData };
 
+      const mockView = {
+        id: 'view-id',
+        objectMetadata: {
+          labelIdentifierFieldMetadataId: mockViewField.fieldMetadataId,
+        },
+        viewFields: [mockViewField],
+      } as ViewEntity;
+
       jest.spyOn(viewFieldService, 'findById').mockResolvedValue(mockViewField);
       jest
         .spyOn(viewFieldRepository, 'save')
         .mockResolvedValue(updatedViewField);
+      jest
+        .spyOn(viewService, 'findByIdWithRelatedObjectMetadata')
+        .mockResolvedValue(mockView);
 
       const result = await viewFieldService.update(id, workspaceId, updateData);
 
@@ -289,10 +300,7 @@ describe('ViewFieldService', () => {
         return Promise.resolve(null);
       });
       jest
-        .spyOn(
-          viewFieldService['viewService'],
-          'findByIdWithRelatedObjectMetadata',
-        )
+        .spyOn(viewService, 'findByIdWithRelatedObjectMetadata')
         .mockResolvedValue(mockView);
 
       await expect(
@@ -343,10 +351,7 @@ describe('ViewFieldService', () => {
         return Promise.resolve(null);
       });
       jest
-        .spyOn(
-          viewFieldService['viewService'],
-          'findByIdWithRelatedObjectMetadata',
-        )
+        .spyOn(viewService, 'findByIdWithRelatedObjectMetadata')
         .mockResolvedValue(mockView);
 
       await expect(

--- a/packages/twenty-server/src/engine/core-modules/view/services/tests/view-field.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/view/services/tests/view-field.service.spec.ts
@@ -1,9 +1,11 @@
 import { Test, type TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 
+import { UserInputError } from 'apollo-server-core';
 import { type Repository } from 'typeorm';
 
 import { ViewFieldEntity } from 'src/engine/core-modules/view/entities/view-field.entity';
+import { type ViewEntity } from 'src/engine/core-modules/view/entities/view.entity';
 import {
   ViewFieldException,
   ViewFieldExceptionCode,
@@ -12,10 +14,12 @@ import {
   generateViewFieldUserFriendlyExceptionMessage,
 } from 'src/engine/core-modules/view/exceptions/view-field.exception';
 import { ViewFieldService } from 'src/engine/core-modules/view/services/view-field.service';
+import { ViewService } from 'src/engine/core-modules/view/services/view.service';
 
 describe('ViewFieldService', () => {
   let viewFieldService: ViewFieldService;
   let viewFieldRepository: Repository<ViewFieldEntity>;
+  let viewService: ViewService;
 
   const mockViewField = {
     id: 'view-field-id',
@@ -45,6 +49,12 @@ describe('ViewFieldService', () => {
             delete: jest.fn(),
           },
         },
+        {
+          provide: ViewService,
+          useValue: {
+            findByIdWithRelatedObjectMetadata: jest.fn(),
+          },
+        },
       ],
     }).compile();
 
@@ -52,6 +62,7 @@ describe('ViewFieldService', () => {
     viewFieldRepository = module.get<Repository<ViewFieldEntity>>(
       getRepositoryToken(ViewFieldEntity),
     );
+    viewService = module.get<ViewService>(ViewService);
   });
 
   it('should be defined', () => {
@@ -243,6 +254,110 @@ describe('ViewFieldService', () => {
             id,
           ),
           ViewFieldExceptionCode.VIEW_FIELD_NOT_FOUND,
+        ),
+      );
+    });
+
+    it('should throw exception when label metadata identifier is not in first position (label metadata identifier field update case)', async () => {
+      const workspaceId = 'workspace-id';
+      const updateData = { position: 2 };
+      const labelIdentifierFieldMetadataId =
+        'label-identifier-field-matadata-id';
+
+      const labelIdentifierViewField = {
+        ...mockViewField,
+        id: labelIdentifierFieldMetadataId,
+        position: 0,
+      };
+
+      const mockView = {
+        id: 'view-id',
+        objectMetadata: {
+          labelIdentifierFieldMetadataId,
+        },
+        viewFields: [
+          labelIdentifierViewField,
+          { ...mockViewField, position: 1 },
+        ],
+      } as ViewEntity;
+
+      jest.spyOn(viewFieldService, 'findById').mockImplementation((id) => {
+        if (id === labelIdentifierFieldMetadataId) {
+          return Promise.resolve(labelIdentifierViewField);
+        }
+
+        return Promise.resolve(null);
+      });
+      jest
+        .spyOn(
+          viewFieldService['viewService'],
+          'findByIdWithRelatedObjectMetadata',
+        )
+        .mockResolvedValue(mockView);
+
+      await expect(
+        viewFieldService.update(
+          labelIdentifierFieldMetadataId,
+          workspaceId,
+          updateData,
+        ),
+      ).rejects.toThrow(
+        new UserInputError(
+          'Label metadata identifier must keep the minimal position in the view.',
+          {
+            userFriendlyMessage:
+              'Record text must be in first position of the view.',
+          },
+        ),
+      );
+    });
+
+    it('should throw exception when label metadata identifier is not in first position (regular field update case)', async () => {
+      const workspaceId = 'workspace-id';
+      const updateData = { position: -1 };
+      const labelIdentifierFieldMetadataId =
+        'label-identifier-field-matadata-id';
+
+      const labelIdentifierViewField = {
+        ...mockViewField,
+        id: labelIdentifierFieldMetadataId,
+        position: 0,
+      };
+
+      const mockView = {
+        id: 'view-id',
+        objectMetadata: {
+          labelIdentifierFieldMetadataId,
+        },
+        viewFields: [
+          labelIdentifierViewField,
+          { ...mockViewField, position: 1 },
+        ],
+      } as ViewEntity;
+
+      jest.spyOn(viewFieldService, 'findById').mockImplementation((id) => {
+        if (id === mockViewField.id) {
+          return Promise.resolve(mockViewField);
+        }
+
+        return Promise.resolve(null);
+      });
+      jest
+        .spyOn(
+          viewFieldService['viewService'],
+          'findByIdWithRelatedObjectMetadata',
+        )
+        .mockResolvedValue(mockView);
+
+      await expect(
+        viewFieldService.update(mockViewField.id, workspaceId, updateData),
+      ).rejects.toThrow(
+        new UserInputError(
+          'Label metadata identifier must keep the minimal position in the view.',
+          {
+            userFriendlyMessage:
+              'Record text must be in first position of the view.',
+          },
         ),
       );
     });

--- a/packages/twenty-server/src/engine/core-modules/view/services/view-field.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/view/services/view-field.service.ts
@@ -334,13 +334,6 @@ export class ViewFieldService {
       return;
     }
 
-    const minPositionInViewWithoutUpdatedViewField =
-      viewFieldsWithoutUpdatedViewField.reduce(
-        (minViewField, viewField) =>
-          viewField.position < minViewField.position ? viewField : minViewField,
-        viewFieldsWithoutUpdatedViewField[0],
-      ).position;
-
     const labelMetadataIdentifierFieldMetadataId =
       view.objectMetadata.labelIdentifierFieldMetadataId;
 
@@ -348,6 +341,15 @@ export class ViewFieldService {
       labelMetadataIdentifierFieldMetadataId ===
       newOrUpdatedViewField.fieldMetadataId
     ) {
+      const minPositionInViewWithoutUpdatedViewField =
+        viewFieldsWithoutUpdatedViewField.reduce(
+          (minViewField, viewField) =>
+            viewField.position < minViewField.position
+              ? viewField
+              : minViewField,
+          viewFieldsWithoutUpdatedViewField[0],
+        ).position;
+
       if (
         newOrUpdatedViewField.position >=
         minPositionInViewWithoutUpdatedViewField

--- a/packages/twenty-server/src/engine/core-modules/view/services/view-field.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/view/services/view-field.service.ts
@@ -300,12 +300,15 @@ export class ViewFieldService {
         (minField, field) =>
           field.position < minField.position ? field : minField,
         viewFieldsWithUpdatedPosition[0],
-      );
+      ).fieldMetadataId;
 
-    if (labelMetadataIdentifierFieldMetadataId === existingViewField.id) {
+    if (
+      labelMetadataIdentifierFieldMetadataId ===
+      existingViewField.fieldMetadataId
+    ) {
       if (
-        fieldMetadataIdWithMinPositionInViewAfterUpdate.id !==
-        existingViewField.id
+        fieldMetadataIdWithMinPositionInViewAfterUpdate !==
+        existingViewField.fieldMetadataId
       ) {
         throw new UserInputError(
           'Label metadata identifier must keep the minimal position in the view.',
@@ -317,8 +320,8 @@ export class ViewFieldService {
       }
     } else {
       if (
-        fieldMetadataIdWithMinPositionInViewAfterUpdate.id ===
-        existingViewField.id
+        fieldMetadataIdWithMinPositionInViewAfterUpdate ===
+        existingViewField.fieldMetadataId
       ) {
         throw new UserInputError(
           'Label metadata identifier must keep the minimal position in the view.',

--- a/packages/twenty-server/src/engine/core-modules/view/services/view.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/view/services/view.service.ts
@@ -84,6 +84,22 @@ export class ViewService {
     return view || null;
   }
 
+  async findByIdWithRelatedObjectMetadata(
+    id: string,
+    workspaceId: string,
+  ): Promise<ViewEntity | null> {
+    const view = await this.viewRepository.findOne({
+      where: {
+        id,
+        workspaceId,
+        deletedAt: IsNull(),
+      },
+      relations: ['workspace', 'objectMetadata', 'viewFields'],
+    });
+
+    return view || null;
+  }
+
   async create(viewData: Partial<ViewEntity>): Promise<ViewEntity> {
     if (!isDefined(viewData.workspaceId)) {
       throw new ViewException(

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata-related-records.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata-related-records.service.ts
@@ -22,6 +22,7 @@ import {
 } from 'src/engine/metadata-modules/field-metadata/field-metadata.exception';
 import { isSelectFieldMetadataType } from 'src/engine/metadata-modules/field-metadata/utils/is-select-field-metadata-type.util';
 import { type SelectOrMultiSelectFieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/utils/is-select-or-multi-select-field-metadata.util';
+import { DEFAULT_VIEW_FIELD_SIZE } from 'src/engine/workspace-manager/standard-objects-prefill-data/views/constants/DEFAULT_VIEW_FIELD_SIZE';
 
 type Differences<T> = {
   created: T[];
@@ -376,7 +377,7 @@ export class FieldMetadataRelatedRecordsService {
         fieldMetadataId: createdFieldMetadata.id,
         position: lastPosition + 1,
         isVisible,
-        size: 180,
+        size: DEFAULT_VIEW_FIELD_SIZE,
         viewId: indexView.id,
         workspaceId: createdFieldMetadata.workspaceId,
       });

--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.service.ts
@@ -401,11 +401,24 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
         workspaceId,
         queryRunner,
       );
-      if (inputPayload.labelIdentifierFieldMetadataId) {
+
+      const didUpdateLabelIdentifierFieldMetadata =
+        isDefined(inputPayload.labelIdentifierFieldMetadataId) &&
+        inputPayload.labelIdentifierFieldMetadataId !==
+          existingObjectMetadata.labelIdentifierFieldMetadataId;
+
+      if (didUpdateLabelIdentifierFieldMetadata) {
         const labelIdentifierFieldMetadata =
           existingObjectMetadata.fieldsById[
-            inputPayload.labelIdentifierFieldMetadataId
+            inputPayload.labelIdentifierFieldMetadataId!
           ];
+
+        await this.objectMetadataRelatedRecordsService.updateLabelMetadataIdentifierInObjectViews(
+          {
+            newLabelMetadataIdentifierFieldMetadata:
+              labelIdentifierFieldMetadata,
+          },
+        );
 
         if (isSearchableFieldType(labelIdentifierFieldMetadata.type)) {
           await this.searchVectorService.updateSearchVector(

--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.service.ts
@@ -402,10 +402,10 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
         queryRunner,
       );
 
-      if (didUpdateLabelOrIcon) {
+      if (inputPayload.labelIdentifierFieldMetadataId) {
         const labelIdentifierFieldMetadata =
           existingObjectMetadata.fieldsById[
-            inputPayload.labelIdentifierFieldMetadataId!
+            inputPayload.labelIdentifierFieldMetadataId
           ];
 
         if (isSearchableFieldType(labelIdentifierFieldMetadata.type)) {
@@ -443,15 +443,14 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
         );
       }
 
-      const didUpdateLabelIdentifierFieldMetadata =
+      if (
         isDefined(inputPayload.labelIdentifierFieldMetadataId) &&
         inputPayload.labelIdentifierFieldMetadataId !==
-          existingObjectMetadata.labelIdentifierFieldMetadataId;
-
-      if (didUpdateLabelIdentifierFieldMetadata) {
+          existingObjectMetadata.labelIdentifierFieldMetadataId
+      ) {
         const labelIdentifierFieldMetadata =
           existingObjectMetadata.fieldsById[
-            inputPayload.labelIdentifierFieldMetadataId!
+            inputPayload.labelIdentifierFieldMetadataId
           ];
 
         await this.objectMetadataRelatedRecordsService.updateLabelMetadataIdentifierInObjectViews(

--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.service.ts
@@ -402,23 +402,11 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
         queryRunner,
       );
 
-      const didUpdateLabelIdentifierFieldMetadata =
-        isDefined(inputPayload.labelIdentifierFieldMetadataId) &&
-        inputPayload.labelIdentifierFieldMetadataId !==
-          existingObjectMetadata.labelIdentifierFieldMetadataId;
-
-      if (didUpdateLabelIdentifierFieldMetadata) {
+      if (didUpdateLabelOrIcon) {
         const labelIdentifierFieldMetadata =
           existingObjectMetadata.fieldsById[
             inputPayload.labelIdentifierFieldMetadataId!
           ];
-
-        await this.objectMetadataRelatedRecordsService.updateLabelMetadataIdentifierInObjectViews(
-          {
-            newLabelMetadataIdentifierFieldMetadata:
-              labelIdentifierFieldMetadata,
-          },
-        );
 
         if (isSearchableFieldType(labelIdentifierFieldMetadata.type)) {
           await this.searchVectorService.updateSearchVector(
@@ -452,6 +440,25 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
         await this.objectMetadataRelatedRecordsService.updateObjectViews(
           updatedObject,
           workspaceId,
+        );
+      }
+
+      const didUpdateLabelIdentifierFieldMetadata =
+        isDefined(inputPayload.labelIdentifierFieldMetadataId) &&
+        inputPayload.labelIdentifierFieldMetadataId !==
+          existingObjectMetadata.labelIdentifierFieldMetadataId;
+
+      if (didUpdateLabelIdentifierFieldMetadata) {
+        const labelIdentifierFieldMetadata =
+          existingObjectMetadata.fieldsById[
+            inputPayload.labelIdentifierFieldMetadataId!
+          ];
+
+        await this.objectMetadataRelatedRecordsService.updateLabelMetadataIdentifierInObjectViews(
+          {
+            newLabelMetadataIdentifierFieldMetadata:
+              labelIdentifierFieldMetadata,
+          },
         );
       }
 

--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/services/object-metadata-related-records.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/services/object-metadata-related-records.service.ts
@@ -58,7 +58,7 @@ export class ObjectMetadataRelatedRecordsService {
       );
 
       if (!labelMetadataIdentifierViewField) {
-        return await this.viewFieldService.create({
+        await this.viewFieldService.create({
           fieldMetadataId: newLabelMetadataIdentifierFieldMetadata.id,
           position: currentMinPositionAmongViewFields - 1,
           isVisible: true,
@@ -66,6 +66,7 @@ export class ObjectMetadataRelatedRecordsService {
           viewId: view.id,
           workspaceId: newLabelMetadataIdentifierFieldMetadata.workspaceId,
         });
+        continue;
       }
 
       await this.viewFieldService.update(
@@ -80,6 +81,10 @@ export class ObjectMetadataRelatedRecordsService {
   }
 
   private getViewFieldsMinPosition(viewFields: ViewFieldEntity[]): number {
+    if (viewFields.length === 0) {
+      return 0;
+    }
+
     return viewFields.reduce((min, field) => Math.min(min, field.position), 0);
   }
 

--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/services/object-metadata-related-records.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/services/object-metadata-related-records.service.ts
@@ -5,13 +5,16 @@ import { isDefined } from 'twenty-shared/utils';
 import { Repository } from 'typeorm';
 
 import { ViewDTO } from 'src/engine/core-modules/view/dtos/view.dto';
+import { ViewFieldEntity } from 'src/engine/core-modules/view/entities/view-field.entity';
 import { ViewEntity } from 'src/engine/core-modules/view/entities/view.entity';
 import { ViewKey } from 'src/engine/core-modules/view/enums/view-key.enum';
 import { ViewType } from 'src/engine/core-modules/view/enums/view-type.enum';
 import { ViewFieldService } from 'src/engine/core-modules/view/services/view-field.service';
 import { ViewService } from 'src/engine/core-modules/view/services/view.service';
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { type ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.manager';
+import { DEFAULT_VIEW_FIELD_SIZE } from 'src/engine/workspace-manager/standard-objects-prefill-data/views/constants/DEFAULT_VIEW_FIELD_SIZE';
 import { type FavoriteWorkspaceEntity } from 'src/modules/favorite/standard-objects/favorite.workspace-entity';
 
 @Injectable()
@@ -31,6 +34,50 @@ export class ObjectMetadataRelatedRecordsService {
 
     await this.createViewFields(objectMetadata, view.id);
     await this.createViewWorkspaceFavorite(objectMetadata.workspaceId, view.id);
+  }
+
+  public async updateLabelMetadataIdentifierInObjectViews({
+    newLabelMetadataIdentifierFieldMetadata,
+  }: {
+    newLabelMetadataIdentifierFieldMetadata: FieldMetadataEntity;
+  }) {
+    const objectMetadataViews = await this.viewService.findByObjectMetadataId(
+      newLabelMetadataIdentifierFieldMetadata.workspaceId,
+      newLabelMetadataIdentifierFieldMetadata.objectMetadataId,
+    );
+
+    for (const view of objectMetadataViews) {
+      let labelMetadataIdentifierViewField = view.viewFields.find(
+        (viewField) =>
+          viewField.fieldMetadataId ===
+          newLabelMetadataIdentifierFieldMetadata.id,
+      );
+
+      const currentMinPositionAmongViewFields = this.getViewFieldsMinPosition(
+        view.viewFields,
+      );
+
+      if (!labelMetadataIdentifierViewField) {
+        return await this.viewFieldService.create({
+          fieldMetadataId: newLabelMetadataIdentifierFieldMetadata.id,
+          position: currentMinPositionAmongViewFields - 1,
+          isVisible: true,
+          size: DEFAULT_VIEW_FIELD_SIZE,
+          viewId: view.id,
+          workspaceId: newLabelMetadataIdentifierFieldMetadata.workspaceId,
+        });
+      }
+
+      await this.viewFieldService.update(
+        labelMetadataIdentifierViewField.id,
+        newLabelMetadataIdentifierFieldMetadata.workspaceId,
+        { position: currentMinPositionAmongViewFields - 1 },
+      );
+    }
+  }
+
+  private getViewFieldsMinPosition(viewFields: ViewFieldEntity[]): number {
+    return viewFields.reduce((min, field) => Math.min(min, field.position), 0);
   }
 
   private async createView(
@@ -56,7 +103,7 @@ export class ObjectMetadataRelatedRecordsService {
         fieldMetadataId: field.id,
         position: index,
         isVisible: true,
-        size: 180,
+        size: DEFAULT_VIEW_FIELD_SIZE,
         viewId: viewId,
         workspaceId: objectMetadata.workspaceId,
       }));

--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/services/object-metadata-related-records.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/services/object-metadata-related-records.service.ts
@@ -71,7 +71,10 @@ export class ObjectMetadataRelatedRecordsService {
       await this.viewFieldService.update(
         labelMetadataIdentifierViewField.id,
         newLabelMetadataIdentifierFieldMetadata.workspaceId,
-        { position: currentMinPositionAmongViewFields - 1 },
+        {
+          position: currentMinPositionAmongViewFields - 1,
+          isVisible: true,
+        },
       );
     }
   }

--- a/packages/twenty-server/src/engine/workspace-manager/standard-objects-prefill-data/views/companies-all.view.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/standard-objects-prefill-data/views/companies-all.view.ts
@@ -2,6 +2,7 @@ import { msg } from '@lingui/core/macro';
 
 import { AggregateOperations } from 'src/engine/api/graphql/graphql-query-runner/constants/aggregate-operations.constant';
 import { type ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
+import { DEFAULT_VIEW_FIELD_SIZE } from 'src/engine/workspace-manager/standard-objects-prefill-data/views/constants/DEFAULT_VIEW_FIELD_SIZE';
 import {
   BASE_OBJECT_STANDARD_FIELD_IDS,
   COMPANY_STANDARD_FIELD_IDS,
@@ -37,7 +38,7 @@ export const companiesAllView = (
           )?.id ?? '',
         position: 0,
         isVisible: true,
-        size: 180,
+        size: DEFAULT_VIEW_FIELD_SIZE,
       },
       {
         fieldMetadataId:

--- a/packages/twenty-server/src/engine/workspace-manager/standard-objects-prefill-data/views/constants/DEFAULT_VIEW_FIELD_SIZE.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/standard-objects-prefill-data/views/constants/DEFAULT_VIEW_FIELD_SIZE.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_VIEW_FIELD_SIZE = 180;

--- a/packages/twenty-server/src/engine/workspace-manager/standard-objects-prefill-data/views/custom-all.view.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/standard-objects-prefill-data/views/custom-all.view.ts
@@ -1,6 +1,7 @@
 import { msg } from '@lingui/core/macro';
 
 import { type ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
+import { DEFAULT_VIEW_FIELD_SIZE } from 'src/engine/workspace-manager/standard-objects-prefill-data/views/constants/DEFAULT_VIEW_FIELD_SIZE';
 
 export const customAllView = (
   objectMetadataItem: ObjectMetadataEntity,
@@ -39,13 +40,13 @@ export const customAllView = (
             ?.id ?? '',
         position: 0,
         isVisible: true,
-        size: 180,
+        size: DEFAULT_VIEW_FIELD_SIZE,
       },
       ...otherFields.map((field, index) => ({
         fieldMetadataId: field.id,
         position: index + 1,
         isVisible: true,
-        size: 180,
+        size: DEFAULT_VIEW_FIELD_SIZE,
       })),
     ],
   };


### PR DESCRIPTION
Fixes https://github.com/twentyhq/twenty/issues/14442

Issues were
1. Table headers always used label metadata identifier (or record text) as first column, while table body followed viewFields positions
2. Label metadata identifier should always be visible and in first position for the table views to work as expected, while when updating the label metadata identifier for an object, no changes were brought to the viewFields

To fix that
1. In the BE: 
- a new logic is implemented to i) update label identifier's viewFields position and visibility when an object's label identifier is updated to a new field; ii) add validation on the update of a viewField's position and visibility to make sure the label identifier's viewField always has the lowest position + is visible
- a command was added to check all existing views and viewfields
3. In the FE: at first I tried to replicate the logic of the headers (based on the label identifier rather than the positions) on the body, but it was too complex and error-prone as in multiple places we are based on the positions. It also feels more right to have only one source of truth which is the viewField position. @lucasbordeau if that does not suit you, we can throw an error if the field with the lowest position is not the label metadata identifier, as you said the table view will be very buggy / wont work if the label identifier is not in the first position. but now it should never be the case thanks to the validation implemented in the BE 

This should be migrated to viewFieldService V2 when relevant @Weiko @prastoin 