### PR TITLE
Fix messaging crons

### DIFF
--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/commands/calendar-relaunch-failed-calendar-channels.command.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/commands/calendar-relaunch-failed-calendar-channels.command.ts
@@ -58,7 +58,7 @@ export class CalendarRelaunchFailedCalendarChannelsCommand extends ActiveOrSuspe
           failedCalendarChannels.map(({ id }) => id),
           {
             syncStage:
-              CalendarChannelSyncStage.CALENDAR_EVENT_LIST_FETCH_PENDING,
+              CalendarChannelSyncStage.FULL_CALENDAR_EVENT_LIST_FETCH_PENDING,
             syncStatus: CalendarChannelSyncStatus.ACTIVE,
           },
         );

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/crons/jobs/calendar-event-list-fetch.cron.job.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/crons/jobs/calendar-event-list-fetch.cron.job.ts
@@ -51,7 +51,7 @@ export class CalendarEventListFetchCronJob {
         const schemaName = getWorkspaceSchemaName(activeWorkspace.id);
 
         const calendarChannels = await this.coreDataSource.query(
-          `SELECT * FROM ${schemaName}."calendarChannel" WHERE "isSyncEnabled" = true AND "syncStage" IN ('${CalendarChannelSyncStage.FULL_CALENDAR_EVENT_LIST_FETCH_PENDING}', '${CalendarChannelSyncStage.PARTIAL_CALENDAR_EVENT_LIST_FETCH_PENDING}', '${CalendarChannelSyncStage.CALENDAR_EVENT_LIST_FETCH_PENDING}')`,
+          `SELECT * FROM ${schemaName}."calendarChannel" WHERE "isSyncEnabled" = true AND "syncStage" IN ('${CalendarChannelSyncStage.FULL_CALENDAR_EVENT_LIST_FETCH_PENDING}', '${CalendarChannelSyncStage.PARTIAL_CALENDAR_EVENT_LIST_FETCH_PENDING}')`,
         );
 
         for (const calendarChannel of calendarChannels) {

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/commands/messaging-relaunch-failed-message-channels.command.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/commands/messaging-relaunch-failed-message-channels.command.ts
@@ -57,7 +57,7 @@ export class MessagingRelaunchFailedMessageChannelsCommand extends ActiveOrSuspe
         await messageChannelRepository.update(
           failedMessageChannels.map(({ id }) => id),
           {
-            syncStage: MessageChannelSyncStage.MESSAGE_LIST_FETCH_PENDING,
+            syncStage: MessageChannelSyncStage.FULL_MESSAGE_LIST_FETCH_PENDING,
             syncStatus: MessageChannelSyncStatus.ACTIVE,
           },
         );

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/crons/jobs/messaging-message-list-fetch.cron.job.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/crons/jobs/messaging-message-list-fetch.cron.job.ts
@@ -50,7 +50,7 @@ export class MessagingMessageListFetchCronJob {
 
         // TODO: deprecate looking for FULL_MESSAGE_LIST_FETCH_PENDING as we introduce MESSAGE_LIST_FETCH_PENDING
         const messageChannels = await this.coreDataSource.query(
-          `SELECT * FROM ${schemaName}."messageChannel" WHERE "isSyncEnabled" = true AND "syncStage" IN ('${MessageChannelSyncStage.PARTIAL_MESSAGE_LIST_FETCH_PENDING}', '${MessageChannelSyncStage.FULL_MESSAGE_LIST_FETCH_PENDING}', '${MessageChannelSyncStage.MESSAGE_LIST_FETCH_PENDING}')`,
+          `SELECT * FROM ${schemaName}."messageChannel" WHERE "isSyncEnabled" = true AND "syncStage" IN ('${MessageChannelSyncStage.PARTIAL_MESSAGE_LIST_FETCH_PENDING}', '${MessageChannelSyncStage.FULL_MESSAGE_LIST_FETCH_PENDING}')`,
         );
 
         for (const messageChannel of messageChannels) {


### PR DESCRIPTION
## Context

While refactoring messaging, I forgot that workspaces that have been created before july do not have 'CALENDAR_EVENT_LIST_FETCH_PENDING' and 'MESSAGE_LIST_FETCH_PENDING' enum values (as we don't sync-metadata the enum values, we would need a migrate command that has not been written yet)

In the current implementation CALENDAR_EVENT_LIST_FETCH_PENDING = FULL_CALENDAR_EVENT_LIST_FETCH_PENDING, so I'm putting it back as it was before