### PR TITLE
Update integration test to include cases for bi-directional accent-insensitive search.

### DIFF
--- a/packages/twenty-server/test/integration/constants/test-person-ids.constants.ts
+++ b/packages/twenty-server/test/integration/constants/test-person-ids.constants.ts
@@ -3,5 +3,7 @@ export const TEST_PERSON_2_ID = '777a8457-eb2d-40ac-a707-551b615b6981';
 export const TEST_PERSON_3_ID = '777a8457-eb2d-40ac-a707-551b615b6982';
 export const TEST_PERSON_4_ID = '777a8457-eb2d-40ac-a707-551b615b6983';
 export const TEST_PERSON_5_ID = '777a8457-eb2d-40ac-a707-551b615b6984';
+export const TEST_PERSON_6_ID = '777a8457-eb2d-40ac-a707-551b615b6985';
+export const TEST_PERSON_7_ID = '777a8457-eb2d-40ac-a707-551b615b6986';
 export const NOT_EXISTING_TEST_PERSON_ID =
   '777a8457-eb2d-40ac-a707-551b615b6990';

--- a/packages/twenty-server/test/integration/constants/test-pet-ids.constants.ts
+++ b/packages/twenty-server/test/integration/constants/test-pet-ids.constants.ts
@@ -1,2 +1,4 @@
 export const TEST_PET_ID_1 = 'a4907cff-a582-4daf-8635-ad6c782c7c25';
 export const TEST_PET_ID_2 = 'c4e97187-9b9b-4e1f-a3c5-b7883c590332';
+export const TEST_PET_ID_3 = 'e4907cff-a582-4aaf-8635-ad6c782c7c26';
+export const TEST_PET_ID_4 = 'f4907cff-a582-4aaf-8635-ad6c782c7c27';

--- a/packages/twenty-server/test/integration/graphql/suites/search/search-resolver.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/search/search-resolver.integration-spec.ts
@@ -1,13 +1,24 @@
+import { COMPANY_GQL_FIELDS } from 'test/integration/constants/company-gql-fields.constants';
 import { OBJECT_MODEL_COMMON_FIELDS } from 'test/integration/constants/object-model-common-fields';
 import { PERSON_GQL_FIELDS } from 'test/integration/constants/person-gql-fields.constants';
+import {
+  TEST_COMPANY_1_ID,
+  TEST_COMPANY_2_ID,
+} from 'test/integration/constants/test-company-ids.constants';
 import {
   TEST_PERSON_1_ID,
   TEST_PERSON_2_ID,
   TEST_PERSON_3_ID,
+  TEST_PERSON_4_ID,
+  TEST_PERSON_5_ID,
+  TEST_PERSON_6_ID,
+  TEST_PERSON_7_ID,
 } from 'test/integration/constants/test-person-ids.constants';
 import {
   TEST_PET_ID_1,
   TEST_PET_ID_2,
+  TEST_PET_ID_3,
+  TEST_PET_ID_4,
 } from 'test/integration/constants/test-pet-ids.constants';
 import { makeGraphqlAPIRequest } from 'test/integration/graphql/utils/make-graphql-api-request.util';
 import { performCreateManyOperation } from 'test/integration/graphql/utils/perform-create-many-operation.utils';
@@ -35,6 +46,46 @@ describe('SearchResolver', () => {
     { id: TEST_PET_ID_2, name: 'searchInput2' },
   ];
 
+  const [firstAccentPerson, secondAccentPerson] = [
+    {
+      id: TEST_PERSON_4_ID,
+      name: { firstName: 'José', lastName: 'García' },
+      jobTitle: 'Café Manager',
+      emails: { primaryEmail: 'josé@café.com' },
+    },
+    {
+      id: TEST_PERSON_5_ID,
+      name: { firstName: 'François', lastName: 'Müller' },
+      jobTitle: 'Manager',
+      emails: { primaryEmail: 'françois@naïve.com' },
+    },
+  ];
+
+  const [firstNonAccentPerson, secondNonAccentPerson] = [
+    {
+      id: TEST_PERSON_6_ID,
+      name: { firstName: 'Jose', lastName: 'Garcia' },
+      jobTitle: 'Cafe Manager',
+      emails: { primaryEmail: 'jose@cafe.com' },
+    },
+    {
+      id: TEST_PERSON_7_ID,
+      name: { firstName: 'Francois', lastName: 'Muller' },
+      jobTitle: 'Manager',
+      emails: { primaryEmail: 'francois@naive.com' },
+    },
+  ];
+
+  const [firstAccentCompany, secondAccentCompany] = [
+    { id: TEST_COMPANY_1_ID, name: 'Café Corp' },
+    { id: TEST_COMPANY_2_ID, name: 'Naïve Solutions' },
+  ];
+
+  const [firstAccentPet, secondAccentPet] = [
+    { id: TEST_PET_ID_3, name: 'Café' },
+    { id: TEST_PET_ID_4, name: 'Naïve' },
+  ];
+
   beforeAll(async () => {
     await deleteAllRecords('person');
     await deleteAllRecords('company');
@@ -52,14 +103,25 @@ describe('SearchResolver', () => {
         'pet',
         'pets',
         OBJECT_MODEL_COMMON_FIELDS,
-        [firstPet, secondPet],
+        [firstPet, secondPet, firstAccentPet, secondAccentPet],
       );
 
       await performCreateManyOperation('person', 'people', PERSON_GQL_FIELDS, [
         firstPerson,
         secondPerson,
         thirdPerson,
+        firstAccentPerson,
+        secondAccentPerson,
+        firstNonAccentPerson,
+        secondNonAccentPerson,
       ]);
+
+      await performCreateManyOperation(
+        'company',
+        'companies',
+        COMPANY_GQL_FIELDS,
+        [firstAccentCompany, secondAccentCompany],
+      );
     } catch (error) {
       // eslint-disable-next-line no-console
       console.log(error);
@@ -91,16 +153,25 @@ describe('SearchResolver', () => {
             firstPerson.id,
             secondPerson.id,
             thirdPerson.id,
+            firstAccentPerson.id,
+            secondAccentPerson.id,
+            firstNonAccentPerson.id,
+            secondNonAccentPerson.id,
+            secondAccentCompany.id,
+            firstAccentCompany.id,
             firstPet.id,
             secondPet.id,
+            firstAccentPet.id,
+            secondAccentPet.id,
           ],
           pageInfo: {
             hasNextPage: false,
             decodedEndCursor: {
               lastRanks: { tsRank: 0, tsRankCD: 0 },
               lastRecordIdsPerObject: {
-                person: thirdPerson.id,
-                pet: secondPet.id,
+                person: secondNonAccentPerson.id,
+                company: firstAccentCompany.id,
+                pet: secondAccentPet.id,
               },
             },
           },
@@ -140,13 +211,13 @@ describe('SearchResolver', () => {
           limit: 50,
         },
         eval: {
-          orderedRecordIds: [firstPet.id, secondPet.id],
+          orderedRecordIds: [firstPet.id, secondPet.id, firstAccentPet.id, secondAccentPet.id],
           pageInfo: {
             hasNextPage: false,
             decodedEndCursor: {
               lastRanks: { tsRank: 0, tsRankCD: 0 },
               lastRecordIdsPerObject: {
-                pet: secondPet.id,
+                pet: secondAccentPet.id,
               },
             },
           },
@@ -162,13 +233,14 @@ describe('SearchResolver', () => {
           limit: 50,
         },
         eval: {
-          orderedRecordIds: [firstPet.id, secondPet.id],
+          orderedRecordIds: [secondAccentCompany.id, firstAccentCompany.id, firstPet.id, secondPet.id, firstAccentPet.id, secondAccentPet.id],
           pageInfo: {
             hasNextPage: false,
             decodedEndCursor: {
               lastRanks: { tsRank: 0, tsRankCD: 0 },
               lastRecordIdsPerObject: {
-                pet: secondPet.id,
+                company: firstAccentCompany.id,
+                pet: secondAccentPet.id,
               },
             },
           },
@@ -211,15 +283,14 @@ describe('SearchResolver', () => {
             firstPerson.id,
             secondPerson.id,
             thirdPerson.id,
-            firstPet.id,
+            firstAccentPerson.id,
           ],
           pageInfo: {
             hasNextPage: true,
             decodedEndCursor: {
               lastRanks: { tsRank: 0, tsRankCD: 0 },
               lastRecordIdsPerObject: {
-                pet: firstPet.id,
-                person: thirdPerson.id,
+                person: firstAccentPerson.id,
               },
             },
           },
@@ -263,14 +334,13 @@ describe('SearchResolver', () => {
           limit: 2,
         },
         eval: {
-          orderedRecordIds: [thirdPerson.id, firstPet.id],
+          orderedRecordIds: [thirdPerson.id, firstAccentPerson.id],
           pageInfo: {
             hasNextPage: true,
             decodedEndCursor: {
               lastRanks: { tsRank: 0, tsRankCD: 0 },
               lastRecordIdsPerObject: {
-                pet: firstPet.id,
-                person: thirdPerson.id,
+                person: firstAccentPerson.id,
               },
             },
           },
@@ -397,13 +467,13 @@ describe('SearchResolver', () => {
           limit: 1,
         },
         eval: {
-          orderedRecordIds: [firstPet.id],
+          orderedRecordIds: [secondAccentCompany.id],
           pageInfo: {
             hasNextPage: true,
             decodedEndCursor: {
               lastRanks: { tsRank: 0, tsRankCD: 0 },
               lastRecordIdsPerObject: {
-                pet: firstPet.id,
+                company: secondAccentCompany.id,
               },
             },
           },
@@ -446,6 +516,142 @@ describe('SearchResolver', () => {
           pageInfo: {
             hasNextPage: true,
             decodedEndCursor: null,
+          },
+        },
+      },
+    },
+    {
+      title: 'should find both "José" and "Jose" when searching for "jose" (bidirectional accent-insensitive)',
+      context: {
+        input: {
+          searchInput: 'jose',
+          excludedObjectNameSingulars: ['workspaceMember'],
+          limit: 50,
+        },
+        eval: {
+          orderedRecordIds: [firstAccentPerson.id, firstNonAccentPerson.id],
+          pageInfo: {
+            hasNextPage: false,
+            decodedEndCursor: {
+              lastRanks: { tsRank: 0.12158542, tsRankCD: 0.2 },
+              lastRecordIdsPerObject: {
+                person: firstNonAccentPerson.id,
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      title: 'should find both "García" and "Garcia" when searching for "garcia" (bidirectional accent-insensitive)',
+      context: {
+        input: {
+          searchInput: 'garcia',
+          excludedObjectNameSingulars: ['workspaceMember'],
+          limit: 50,
+        },
+        eval: {
+          orderedRecordIds: [firstAccentPerson.id, firstNonAccentPerson.id],
+          pageInfo: {
+            hasNextPage: false,
+            decodedEndCursor: {
+              lastRanks: { tsRank: 0.06079271, tsRankCD: 0.1 },
+              lastRecordIdsPerObject: {
+                person: firstNonAccentPerson.id,
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      title: 'should find both accented and non-accented "Café"/"Cafe" records when searching for "cafe" (bidirectional accent-insensitive)',
+      context: {
+        input: {
+          searchInput: 'cafe',
+          excludedObjectNameSingulars: ['workspaceMember'],
+          limit: 50,
+        },
+        eval: {
+          orderedRecordIds: [firstAccentPerson.id, firstNonAccentPerson.id, firstAccentCompany.id, firstAccentPet.id],
+          pageInfo: {
+            hasNextPage: false,
+            decodedEndCursor: {
+              lastRanks: { tsRank: 0.06079271, tsRankCD: 0.1 },
+              lastRecordIdsPerObject: {
+                person: firstNonAccentPerson.id,
+                company: firstAccentCompany.id,
+                pet: firstAccentPet.id,
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      title: 'should find both accented and non-accented "Naïve"/"Naive" records when searching for "naive" (bidirectional accent-insensitive)',
+      context: {
+        input: {
+          searchInput: 'naive',
+          excludedObjectNameSingulars: ['workspaceMember'],
+          limit: 50,
+        },
+        eval: {
+          orderedRecordIds: [secondAccentPerson.id, secondNonAccentPerson.id, secondAccentCompany.id, secondAccentPet.id],
+          pageInfo: {
+            hasNextPage: false,
+            decodedEndCursor: {
+              lastRanks: { tsRank: 0.06079271, tsRankCD: 0.1 },
+              lastRecordIdsPerObject: {
+                person: secondNonAccentPerson.id,
+                company: secondAccentCompany.id,
+                pet: secondAccentPet.id,
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      title: 'should find both "Müller" and "Muller" when searching for "muller" (bidirectional accent-insensitive)',
+      context: {
+        input: {
+          searchInput: 'muller',
+          excludedObjectNameSingulars: ['workspaceMember'],
+          limit: 50,
+        },
+        eval: {
+          orderedRecordIds: [secondAccentPerson.id, secondNonAccentPerson.id],
+          pageInfo: {
+            hasNextPage: false,
+            decodedEndCursor: {
+              lastRanks: { tsRank: 0.06079271, tsRankCD: 0.1 },
+              lastRecordIdsPerObject: {
+                person: secondNonAccentPerson.id,
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      title: 'should find both "François" and "Francois" when searching for "francois" (bidirectional accent-insensitive)',
+      context: {
+        input: {
+          searchInput: 'francois',
+          excludedObjectNameSingulars: ['workspaceMember'],
+          limit: 50,
+        },
+        eval: {
+          orderedRecordIds: [secondAccentPerson.id, secondNonAccentPerson.id],
+          pageInfo: {
+            hasNextPage: false,
+            decodedEndCursor: {
+              lastRanks: { tsRank: 0.12158542, tsRankCD: 0.2 },
+              lastRecordIdsPerObject: {
+                person: secondNonAccentPerson.id,
+              },
+            },
           },
         },
       },
@@ -537,7 +743,7 @@ describe('SearchResolver', () => {
       excludedObjectNameSingulars: ['workspaceMember'],
       limit: 2,
       after: encodeCursorData({
-        lastRanks: { tsRankCD: 0.1, tsRank: 0.06079271 },
+        lastRanks: { tsRank: 0.06079271, tsRankCD: 0.1 },
         lastRecordIdsPerObject: {
           person: secondPerson.id,
         },

--- a/packages/twenty-server/test/integration/graphql/suites/search/search-resolver.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/search/search-resolver.integration-spec.ts
@@ -77,7 +77,15 @@ describe('SearchResolver', () => {
     { id: TEST_PET_ID_4, name: 'Naïve' },
   ];
 
-  const [searchInput1Person, searchInput2Person, searchInput3Person, josePerson, francoisPerson, josePersonNoAccent, francoisPersonNoAccent] = persons;
+  const [
+    searchInput1Person,
+    searchInput2Person,
+    searchInput3Person,
+    josePerson,
+    francoisPerson,
+    josePersonNoAccent,
+    francoisPersonNoAccent,
+  ] = persons;
   const [cafeCorp, naiveCorp] = companies;
   const [searchInput1Pet, searchInput2Pet, cafePet, naivePet] = pets;
 
@@ -101,7 +109,12 @@ describe('SearchResolver', () => {
         pets,
       );
 
-      await performCreateManyOperation('person', 'people', PERSON_GQL_FIELDS, persons);
+      await performCreateManyOperation(
+        'person',
+        'people',
+        PERSON_GQL_FIELDS,
+        persons,
+      );
 
       await performCreateManyOperation(
         'company',
@@ -198,7 +211,12 @@ describe('SearchResolver', () => {
           limit: 50,
         },
         eval: {
-          orderedRecordIds: [searchInput1Pet.id, searchInput2Pet.id, cafePet.id, naivePet.id],
+          orderedRecordIds: [
+            searchInput1Pet.id,
+            searchInput2Pet.id,
+            cafePet.id,
+            naivePet.id,
+          ],
           pageInfo: {
             hasNextPage: false,
             decodedEndCursor: {
@@ -220,7 +238,14 @@ describe('SearchResolver', () => {
           limit: 50,
         },
         eval: {
-          orderedRecordIds: [naiveCorp.id, cafeCorp.id, searchInput1Pet.id, searchInput2Pet.id, cafePet.id, naivePet.id],
+          orderedRecordIds: [
+            naiveCorp.id,
+            cafeCorp.id,
+            searchInput1Pet.id,
+            searchInput2Pet.id,
+            cafePet.id,
+            naivePet.id,
+          ],
           pageInfo: {
             hasNextPage: false,
             decodedEndCursor: {
@@ -508,7 +533,8 @@ describe('SearchResolver', () => {
       },
     },
     {
-      title: 'should find both "José" and "Jose" when searching for "jose" (bidirectional accent-insensitive)',
+      title:
+        'should find both "José" and "Jose" when searching for "jose" (bidirectional accent-insensitive)',
       context: {
         input: {
           searchInput: 'jose',
@@ -530,7 +556,8 @@ describe('SearchResolver', () => {
       },
     },
     {
-      title: 'should find both "García" and "Garcia" when searching for "garcia" (bidirectional accent-insensitive)',
+      title:
+        'should find both "García" and "Garcia" when searching for "garcia" (bidirectional accent-insensitive)',
       context: {
         input: {
           searchInput: 'garcia',
@@ -552,7 +579,8 @@ describe('SearchResolver', () => {
       },
     },
     {
-      title: 'should find both accented and non-accented "Café"/"Cafe" records when searching for "cafe" (bidirectional accent-insensitive)',
+      title:
+        'should find both accented and non-accented "Café"/"Cafe" records when searching for "cafe" (bidirectional accent-insensitive)',
       context: {
         input: {
           searchInput: 'cafe',
@@ -560,7 +588,12 @@ describe('SearchResolver', () => {
           limit: 50,
         },
         eval: {
-          orderedRecordIds: [josePerson.id, josePersonNoAccent.id, cafeCorp.id, cafePet.id],
+          orderedRecordIds: [
+            josePerson.id,
+            josePersonNoAccent.id,
+            cafeCorp.id,
+            cafePet.id,
+          ],
           pageInfo: {
             hasNextPage: false,
             decodedEndCursor: {
@@ -576,7 +609,8 @@ describe('SearchResolver', () => {
       },
     },
     {
-      title: 'should find both accented and non-accented "Naïve"/"Naive" records when searching for "naive" (bidirectional accent-insensitive)',
+      title:
+        'should find both accented and non-accented "Naïve"/"Naive" records when searching for "naive" (bidirectional accent-insensitive)',
       context: {
         input: {
           searchInput: 'naive',
@@ -584,7 +618,12 @@ describe('SearchResolver', () => {
           limit: 50,
         },
         eval: {
-          orderedRecordIds: [francoisPerson.id, francoisPersonNoAccent.id, naiveCorp.id, naivePet.id],
+          orderedRecordIds: [
+            francoisPerson.id,
+            francoisPersonNoAccent.id,
+            naiveCorp.id,
+            naivePet.id,
+          ],
           pageInfo: {
             hasNextPage: false,
             decodedEndCursor: {
@@ -600,7 +639,8 @@ describe('SearchResolver', () => {
       },
     },
     {
-      title: 'should find both "Müller" and "Muller" when searching for "muller" (bidirectional accent-insensitive)',
+      title:
+        'should find both "Müller" and "Muller" when searching for "muller" (bidirectional accent-insensitive)',
       context: {
         input: {
           searchInput: 'muller',
@@ -622,7 +662,8 @@ describe('SearchResolver', () => {
       },
     },
     {
-      title: 'should find both "François" and "Francois" when searching for "francois" (bidirectional accent-insensitive)',
+      title:
+        'should find both "François" and "Francois" when searching for "francois" (bidirectional accent-insensitive)',
       context: {
         input: {
           searchInput: 'francois',

--- a/packages/twenty-server/test/integration/graphql/suites/search/search-resolver.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/search/search-resolver.integration-spec.ts
@@ -35,18 +35,10 @@ import { type SearchResultEdgeDTO } from 'src/engine/core-modules/search/dtos/se
 import { type SearchCursor } from 'src/engine/core-modules/search/services/search.service';
 
 describe('SearchResolver', () => {
-  const [firstPerson, secondPerson, thirdPerson] = [
+  const persons = [
     { id: TEST_PERSON_1_ID, name: { firstName: 'searchInput1' } },
     { id: TEST_PERSON_2_ID, name: { firstName: 'searchInput2' } },
     { id: TEST_PERSON_3_ID, name: { firstName: 'searchInput3' } },
-  ];
-
-  const [firstPet, secondPet] = [
-    { id: TEST_PET_ID_1, name: 'searchInput1' },
-    { id: TEST_PET_ID_2, name: 'searchInput2' },
-  ];
-
-  const [firstAccentPerson, secondAccentPerson] = [
     {
       id: TEST_PERSON_4_ID,
       name: { firstName: 'José', lastName: 'García' },
@@ -59,9 +51,6 @@ describe('SearchResolver', () => {
       jobTitle: 'Manager',
       emails: { primaryEmail: 'françois@naïve.com' },
     },
-  ];
-
-  const [firstNonAccentPerson, secondNonAccentPerson] = [
     {
       id: TEST_PERSON_6_ID,
       name: { firstName: 'Jose', lastName: 'Garcia' },
@@ -76,15 +65,21 @@ describe('SearchResolver', () => {
     },
   ];
 
-  const [firstAccentCompany, secondAccentCompany] = [
+  const companies = [
     { id: TEST_COMPANY_1_ID, name: 'Café Corp' },
     { id: TEST_COMPANY_2_ID, name: 'Naïve Solutions' },
   ];
 
-  const [firstAccentPet, secondAccentPet] = [
+  const pets = [
+    { id: TEST_PET_ID_1, name: 'searchInput1' },
+    { id: TEST_PET_ID_2, name: 'searchInput2' },
     { id: TEST_PET_ID_3, name: 'Café' },
     { id: TEST_PET_ID_4, name: 'Naïve' },
   ];
+
+  const [searchInput1Person, searchInput2Person, searchInput3Person, josePerson, francoisPerson, josePersonNoAccent, francoisPersonNoAccent] = persons;
+  const [cafeCorp, naiveCorp] = companies;
+  const [searchInput1Pet, searchInput2Pet, cafePet, naivePet] = pets;
 
   beforeAll(async () => {
     await deleteAllRecords('person');
@@ -103,24 +98,16 @@ describe('SearchResolver', () => {
         'pet',
         'pets',
         OBJECT_MODEL_COMMON_FIELDS,
-        [firstPet, secondPet, firstAccentPet, secondAccentPet],
+        pets,
       );
 
-      await performCreateManyOperation('person', 'people', PERSON_GQL_FIELDS, [
-        firstPerson,
-        secondPerson,
-        thirdPerson,
-        firstAccentPerson,
-        secondAccentPerson,
-        firstNonAccentPerson,
-        secondNonAccentPerson,
-      ]);
+      await performCreateManyOperation('person', 'people', PERSON_GQL_FIELDS, persons);
 
       await performCreateManyOperation(
         'company',
         'companies',
         COMPANY_GQL_FIELDS,
-        [firstAccentCompany, secondAccentCompany],
+        companies,
       );
     } catch (error) {
       // eslint-disable-next-line no-console
@@ -150,28 +137,28 @@ describe('SearchResolver', () => {
         },
         eval: {
           orderedRecordIds: [
-            firstPerson.id,
-            secondPerson.id,
-            thirdPerson.id,
-            firstAccentPerson.id,
-            secondAccentPerson.id,
-            firstNonAccentPerson.id,
-            secondNonAccentPerson.id,
-            secondAccentCompany.id,
-            firstAccentCompany.id,
-            firstPet.id,
-            secondPet.id,
-            firstAccentPet.id,
-            secondAccentPet.id,
+            searchInput1Person.id,
+            searchInput2Person.id,
+            searchInput3Person.id,
+            josePerson.id,
+            francoisPerson.id,
+            josePersonNoAccent.id,
+            francoisPersonNoAccent.id,
+            naiveCorp.id,
+            cafeCorp.id,
+            searchInput1Pet.id,
+            searchInput2Pet.id,
+            cafePet.id,
+            naivePet.id,
           ],
           pageInfo: {
             hasNextPage: false,
             decodedEndCursor: {
               lastRanks: { tsRank: 0, tsRankCD: 0 },
               lastRecordIdsPerObject: {
-                person: secondNonAccentPerson.id,
-                company: firstAccentCompany.id,
-                pet: secondAccentPet.id,
+                person: francoisPersonNoAccent.id,
+                company: cafeCorp.id,
+                pet: naivePet.id,
               },
             },
           },
@@ -187,14 +174,14 @@ describe('SearchResolver', () => {
           limit: 50,
         },
         eval: {
-          orderedRecordIds: [firstPerson.id, firstPet.id],
+          orderedRecordIds: [searchInput1Person.id, searchInput1Pet.id],
           pageInfo: {
             hasNextPage: false,
             decodedEndCursor: {
               lastRanks: { tsRank: 0.06079271, tsRankCD: 0.1 },
               lastRecordIdsPerObject: {
-                person: firstPerson.id,
-                pet: firstPet.id,
+                person: searchInput1Person.id,
+                pet: searchInput1Pet.id,
               },
             },
           },
@@ -211,13 +198,13 @@ describe('SearchResolver', () => {
           limit: 50,
         },
         eval: {
-          orderedRecordIds: [firstPet.id, secondPet.id, firstAccentPet.id, secondAccentPet.id],
+          orderedRecordIds: [searchInput1Pet.id, searchInput2Pet.id, cafePet.id, naivePet.id],
           pageInfo: {
             hasNextPage: false,
             decodedEndCursor: {
               lastRanks: { tsRank: 0, tsRankCD: 0 },
               lastRecordIdsPerObject: {
-                pet: secondAccentPet.id,
+                pet: naivePet.id,
               },
             },
           },
@@ -233,14 +220,14 @@ describe('SearchResolver', () => {
           limit: 50,
         },
         eval: {
-          orderedRecordIds: [secondAccentCompany.id, firstAccentCompany.id, firstPet.id, secondPet.id, firstAccentPet.id, secondAccentPet.id],
+          orderedRecordIds: [naiveCorp.id, cafeCorp.id, searchInput1Pet.id, searchInput2Pet.id, cafePet.id, naivePet.id],
           pageInfo: {
             hasNextPage: false,
             decodedEndCursor: {
               lastRanks: { tsRank: 0, tsRankCD: 0 },
               lastRecordIdsPerObject: {
-                company: firstAccentCompany.id,
-                pet: secondAccentPet.id,
+                company: cafeCorp.id,
+                pet: naivePet.id,
               },
             },
           },
@@ -253,17 +240,17 @@ describe('SearchResolver', () => {
         input: {
           searchInput: '',
           excludedObjectNameSingulars: ['workspaceMember'],
-          filter: { id: { eq: firstPet.id } },
+          filter: { id: { eq: searchInput1Pet.id } },
           limit: 50,
         },
         eval: {
-          orderedRecordIds: [firstPet.id],
+          orderedRecordIds: [searchInput1Pet.id],
           pageInfo: {
             hasNextPage: false,
             decodedEndCursor: {
               lastRanks: { tsRank: 0, tsRankCD: 0 },
               lastRecordIdsPerObject: {
-                pet: firstPet.id,
+                pet: searchInput1Pet.id,
               },
             },
           },
@@ -280,17 +267,17 @@ describe('SearchResolver', () => {
         },
         eval: {
           orderedRecordIds: [
-            firstPerson.id,
-            secondPerson.id,
-            thirdPerson.id,
-            firstAccentPerson.id,
+            searchInput1Person.id,
+            searchInput2Person.id,
+            searchInput3Person.id,
+            josePerson.id,
           ],
           pageInfo: {
             hasNextPage: true,
             decodedEndCursor: {
               lastRanks: { tsRank: 0, tsRankCD: 0 },
               lastRecordIdsPerObject: {
-                person: firstAccentPerson.id,
+                person: josePerson.id,
               },
             },
           },
@@ -306,13 +293,13 @@ describe('SearchResolver', () => {
           limit: 2,
         },
         eval: {
-          orderedRecordIds: [firstPerson.id, secondPerson.id],
+          orderedRecordIds: [searchInput1Person.id, searchInput2Person.id],
           pageInfo: {
             hasNextPage: true,
             decodedEndCursor: {
               lastRanks: { tsRank: 0, tsRankCD: 0 },
               lastRecordIdsPerObject: {
-                person: secondPerson.id,
+                person: searchInput2Person.id,
               },
             },
           },
@@ -328,19 +315,19 @@ describe('SearchResolver', () => {
           after: encodeCursorData({
             lastRanks: { tsRank: 0, tsRankCD: 0 },
             lastRecordIdsPerObject: {
-              person: secondPerson.id,
+              person: searchInput2Person.id,
             },
           }),
           limit: 2,
         },
         eval: {
-          orderedRecordIds: [thirdPerson.id, firstAccentPerson.id],
+          orderedRecordIds: [searchInput3Person.id, josePerson.id],
           pageInfo: {
             hasNextPage: true,
             decodedEndCursor: {
               lastRanks: { tsRank: 0, tsRankCD: 0 },
               lastRecordIdsPerObject: {
-                person: firstAccentPerson.id,
+                person: josePerson.id,
               },
             },
           },
@@ -357,18 +344,18 @@ describe('SearchResolver', () => {
         },
         eval: {
           orderedRecordIds: [
-            firstPerson.id,
-            secondPerson.id,
-            thirdPerson.id,
-            firstPet.id,
+            searchInput1Person.id,
+            searchInput2Person.id,
+            searchInput3Person.id,
+            searchInput1Pet.id,
           ],
           pageInfo: {
             hasNextPage: true,
             decodedEndCursor: {
               lastRanks: { tsRank: 0.06079271, tsRankCD: 0.1 },
               lastRecordIdsPerObject: {
-                pet: firstPet.id,
-                person: thirdPerson.id,
+                pet: searchInput1Pet.id,
+                person: searchInput3Person.id,
               },
             },
           },
@@ -384,13 +371,13 @@ describe('SearchResolver', () => {
           limit: 2,
         },
         eval: {
-          orderedRecordIds: [firstPerson.id, secondPerson.id],
+          orderedRecordIds: [searchInput1Person.id, searchInput2Person.id],
           pageInfo: {
             hasNextPage: true,
             decodedEndCursor: {
               lastRanks: { tsRank: 0.06079271, tsRankCD: 0.1 },
               lastRecordIdsPerObject: {
-                person: secondPerson.id,
+                person: searchInput2Person.id,
               },
             },
           },
@@ -407,20 +394,20 @@ describe('SearchResolver', () => {
           after: encodeCursorData({
             lastRanks: { tsRank: 0.06079271, tsRankCD: 0.1 },
             lastRecordIdsPerObject: {
-              person: secondPerson.id,
+              person: searchInput2Person.id,
             },
           }),
           limit: 2,
         },
         eval: {
-          orderedRecordIds: [thirdPerson.id, firstPet.id],
+          orderedRecordIds: [searchInput3Person.id, searchInput1Pet.id],
           pageInfo: {
             hasNextPage: true,
             decodedEndCursor: {
               lastRanks: { tsRank: 0.06079271, tsRankCD: 0.1 },
               lastRecordIdsPerObject: {
-                pet: firstPet.id,
-                person: thirdPerson.id,
+                pet: searchInput1Pet.id,
+                person: searchInput3Person.id,
               },
             },
           },
@@ -437,21 +424,21 @@ describe('SearchResolver', () => {
           after: encodeCursorData({
             lastRanks: { tsRank: 0.06079271, tsRankCD: 0.1 },
             lastRecordIdsPerObject: {
-              person: secondPerson.id,
+              person: searchInput2Person.id,
             },
           }),
           limit: 2,
-          filter: { id: { neq: firstPet.id } },
+          filter: { id: { neq: searchInput1Pet.id } },
         },
         eval: {
-          orderedRecordIds: [thirdPerson.id, secondPet.id],
+          orderedRecordIds: [searchInput3Person.id, searchInput2Pet.id],
           pageInfo: {
             hasNextPage: false,
             decodedEndCursor: {
               lastRanks: { tsRank: 0.06079271, tsRankCD: 0.1 },
               lastRecordIdsPerObject: {
-                person: thirdPerson.id,
-                pet: secondPet.id,
+                person: searchInput3Person.id,
+                pet: searchInput2Pet.id,
               },
             },
           },
@@ -467,13 +454,13 @@ describe('SearchResolver', () => {
           limit: 1,
         },
         eval: {
-          orderedRecordIds: [secondAccentCompany.id],
+          orderedRecordIds: [naiveCorp.id],
           pageInfo: {
             hasNextPage: true,
             decodedEndCursor: {
               lastRanks: { tsRank: 0, tsRankCD: 0 },
               lastRecordIdsPerObject: {
-                company: secondAccentCompany.id,
+                company: naiveCorp.id,
               },
             },
           },
@@ -490,13 +477,13 @@ describe('SearchResolver', () => {
           limit: 1,
         },
         eval: {
-          orderedRecordIds: [firstPet.id],
+          orderedRecordIds: [searchInput1Pet.id],
           pageInfo: {
             hasNextPage: true,
             decodedEndCursor: {
               lastRanks: { tsRank: 0, tsRankCD: 0 },
               lastRecordIdsPerObject: {
-                pet: firstPet.id,
+                pet: searchInput1Pet.id,
               },
             },
           },
@@ -529,13 +516,13 @@ describe('SearchResolver', () => {
           limit: 50,
         },
         eval: {
-          orderedRecordIds: [firstAccentPerson.id, firstNonAccentPerson.id],
+          orderedRecordIds: [josePerson.id, josePersonNoAccent.id],
           pageInfo: {
             hasNextPage: false,
             decodedEndCursor: {
               lastRanks: { tsRank: 0.12158542, tsRankCD: 0.2 },
               lastRecordIdsPerObject: {
-                person: firstNonAccentPerson.id,
+                person: josePersonNoAccent.id,
               },
             },
           },
@@ -551,13 +538,13 @@ describe('SearchResolver', () => {
           limit: 50,
         },
         eval: {
-          orderedRecordIds: [firstAccentPerson.id, firstNonAccentPerson.id],
+          orderedRecordIds: [josePerson.id, josePersonNoAccent.id],
           pageInfo: {
             hasNextPage: false,
             decodedEndCursor: {
               lastRanks: { tsRank: 0.06079271, tsRankCD: 0.1 },
               lastRecordIdsPerObject: {
-                person: firstNonAccentPerson.id,
+                person: josePersonNoAccent.id,
               },
             },
           },
@@ -573,15 +560,15 @@ describe('SearchResolver', () => {
           limit: 50,
         },
         eval: {
-          orderedRecordIds: [firstAccentPerson.id, firstNonAccentPerson.id, firstAccentCompany.id, firstAccentPet.id],
+          orderedRecordIds: [josePerson.id, josePersonNoAccent.id, cafeCorp.id, cafePet.id],
           pageInfo: {
             hasNextPage: false,
             decodedEndCursor: {
               lastRanks: { tsRank: 0.06079271, tsRankCD: 0.1 },
               lastRecordIdsPerObject: {
-                person: firstNonAccentPerson.id,
-                company: firstAccentCompany.id,
-                pet: firstAccentPet.id,
+                person: josePersonNoAccent.id,
+                company: cafeCorp.id,
+                pet: cafePet.id,
               },
             },
           },
@@ -597,15 +584,15 @@ describe('SearchResolver', () => {
           limit: 50,
         },
         eval: {
-          orderedRecordIds: [secondAccentPerson.id, secondNonAccentPerson.id, secondAccentCompany.id, secondAccentPet.id],
+          orderedRecordIds: [francoisPerson.id, francoisPersonNoAccent.id, naiveCorp.id, naivePet.id],
           pageInfo: {
             hasNextPage: false,
             decodedEndCursor: {
               lastRanks: { tsRank: 0.06079271, tsRankCD: 0.1 },
               lastRecordIdsPerObject: {
-                person: secondNonAccentPerson.id,
-                company: secondAccentCompany.id,
-                pet: secondAccentPet.id,
+                person: francoisPersonNoAccent.id,
+                company: naiveCorp.id,
+                pet: naivePet.id,
               },
             },
           },
@@ -621,13 +608,13 @@ describe('SearchResolver', () => {
           limit: 50,
         },
         eval: {
-          orderedRecordIds: [secondAccentPerson.id, secondNonAccentPerson.id],
+          orderedRecordIds: [francoisPerson.id, francoisPersonNoAccent.id],
           pageInfo: {
             hasNextPage: false,
             decodedEndCursor: {
               lastRanks: { tsRank: 0.06079271, tsRankCD: 0.1 },
               lastRecordIdsPerObject: {
-                person: secondNonAccentPerson.id,
+                person: francoisPersonNoAccent.id,
               },
             },
           },
@@ -643,13 +630,13 @@ describe('SearchResolver', () => {
           limit: 50,
         },
         eval: {
-          orderedRecordIds: [secondAccentPerson.id, secondNonAccentPerson.id],
+          orderedRecordIds: [francoisPerson.id, francoisPersonNoAccent.id],
           pageInfo: {
             hasNextPage: false,
             decodedEndCursor: {
               lastRanks: { tsRank: 0.12158542, tsRankCD: 0.2 },
               lastRecordIdsPerObject: {
-                person: secondNonAccentPerson.id,
+                person: francoisPersonNoAccent.id,
               },
             },
           },
@@ -703,7 +690,7 @@ describe('SearchResolver', () => {
           cursor: encodeCursorData({
             lastRanks: { tsRankCD: 0.1, tsRank: 0.06079271 },
             lastRecordIdsPerObject: {
-              person: firstPerson.id,
+              person: searchInput1Person.id,
             },
           }),
         },
@@ -711,7 +698,7 @@ describe('SearchResolver', () => {
           cursor: encodeCursorData({
             lastRanks: { tsRankCD: 0.1, tsRank: 0.06079271 },
             lastRecordIdsPerObject: {
-              person: secondPerson.id,
+              person: searchInput2Person.id,
             },
           }),
         },
@@ -721,7 +708,7 @@ describe('SearchResolver', () => {
         endCursor: encodeCursorData({
           lastRanks: { tsRankCD: 0.1, tsRank: 0.06079271 },
           lastRecordIdsPerObject: {
-            person: secondPerson.id,
+            person: searchInput2Person.id,
           },
         }),
       },
@@ -745,7 +732,7 @@ describe('SearchResolver', () => {
       after: encodeCursorData({
         lastRanks: { tsRank: 0.06079271, tsRankCD: 0.1 },
         lastRecordIdsPerObject: {
-          person: secondPerson.id,
+          person: searchInput2Person.id,
         },
       }),
     });
@@ -758,7 +745,7 @@ describe('SearchResolver', () => {
           cursor: encodeCursorData({
             lastRanks: { tsRankCD: 0.1, tsRank: 0.06079271 },
             lastRecordIdsPerObject: {
-              person: thirdPerson.id,
+              person: searchInput3Person.id,
             },
           }),
         },
@@ -766,8 +753,8 @@ describe('SearchResolver', () => {
           cursor: encodeCursorData({
             lastRanks: { tsRankCD: 0.1, tsRank: 0.06079271 },
             lastRecordIdsPerObject: {
-              person: thirdPerson.id,
-              pet: firstPet.id,
+              person: searchInput3Person.id,
+              pet: searchInput1Pet.id,
             },
           }),
         },
@@ -777,8 +764,8 @@ describe('SearchResolver', () => {
         endCursor: encodeCursorData({
           lastRanks: { tsRankCD: 0.1, tsRank: 0.06079271 },
           lastRecordIdsPerObject: {
-            person: thirdPerson.id,
-            pet: firstPet.id,
+            person: searchInput3Person.id,
+            pet: searchInput1Pet.id,
           },
         }),
       },


### PR DESCRIPTION
## Summary

Enhanced the search resolver integration tests to comprehensively validate bidirectional accent-insensitive search functionality. Users can now search with or without accents and find all relevant records regardless of how the data was originally stored.

## Changes Made

### Test Data Enhancements

- Added 2 new person IDs: `TEST_PERSON_6_ID`, `TEST_PERSON_7_ID`
- Expanded corpus from 5 to 13 records:
  - 7 persons
  - 2 companies
  - 4 pets
- Refactored test data into single arrays with content-driven variable naming for better maintainability

### Test Coverage Improvements

- Added 6 comprehensive bidirectional tests covering French, Spanish, and German characters
- Validated multiple fields:
  - `firstName`, `lastName`, `jobTitle`, `email`, `company name`, `pet name`
- Cross-object search testing across Person, Company, and Pet
- Updated all ranking values to account for the enlarged test corpus (5 → 13 records)

## Test Cases Added/Updated

- [x] should find both **"José"** and **"Jose"** when searching for `"jose"` (bidirectional accent-insensitive)
- [x] should find both **"García"** and **"Garcia"** when searching for `"garcia"` (bidirectional accent-insensitive)
- [x] should find both accented and non-accented **"Café"** / **"Cafe"** records when searching for `"cafe"` (bidirectional accent-insensitive)
- [x] should find both accented and non-accented **"Naïve"** / **"Naive"** records when searching for `"naive"` (bidirectional accent-insensitive)
- [x] should find both **"Müller"** and **"Muller"** when searching for `"muller"` (bidirectional accent-insensitive)
- [x] should find both **"François"** and **"Francois"** when searching for `"francois"` (bidirectional accent-insensitive)
