### PR TITLE
Set maximum requests for fetching record IDs in delete action

### DIFF
--- a/packages/twenty-front/src/modules/action-menu/actions/record-actions/multiple-records/components/DeleteMultipleRecordsAction.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-actions/multiple-records/components/DeleteMultipleRecordsAction.tsx
@@ -64,6 +64,7 @@ export const DeleteMultipleRecordsAction = () => {
     filter: graphqlFilter,
     limit: DEFAULT_QUERY_PAGE_SIZE,
     recordGqlFields: { id: true },
+    maximumRequests: Number.MAX_SAFE_INTEGER,
   });
 
   const handleDeleteClick = async () => {


### PR DESCRIPTION
Ensure that the maximum requests are set to `Number.MAX_SAFE_INTEGER` when fetching all record IDs in the delete multiple records action.

Note: This change will ensure that all the selected records are soft-deleted. However, there will be performance issue. if there are great many records to be deleted. All of those records will be fetched on the frontend, then sent to the backend. Another alternative approach, a good one in my opinion, is to send the filter directly to backend and let it handle the soft-delete in CHUNKS.

Resolves #14601