### PR TITLE
Store history when iterator reset the step info

### DIFF
--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/iterator/iterator.workflow-action.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/iterator/iterator.workflow-action.ts
@@ -140,6 +140,14 @@ export class IteratorWorkflowAction implements WorkflowActionInterface {
       steps,
     });
 
+    const workflowRunToUpdate =
+      await this.workflowRunWorkspaceService.getWorkflowRunOrFail({
+        workflowRunId,
+        workspaceId,
+      });
+
+    const stepInfos = workflowRunToUpdate.state.stepInfos;
+
     await this.workflowRunWorkspaceService.updateWorkflowRunStepInfos({
       stepInfos: stepIdsToReset.reduce(
         (acc, stepId) => {
@@ -147,6 +155,14 @@ export class IteratorWorkflowAction implements WorkflowActionInterface {
             status: StepStatus.NOT_STARTED,
             result: undefined,
             error: undefined,
+            history: [
+              ...(stepInfos[stepId]?.history ?? []),
+              {
+                result: stepInfos[stepId]?.result,
+                error: stepInfos[stepId]?.error,
+                status: stepInfos[stepId]?.status,
+              },
+            ],
           };
 
           return acc;
@@ -155,7 +171,6 @@ export class IteratorWorkflowAction implements WorkflowActionInterface {
       ),
       workflowRunId,
       workspaceId,
-      shouldKeepHistory: true,
     });
   }
 }

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/iterator/iterator.workflow-action.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/iterator/iterator.workflow-action.ts
@@ -105,7 +105,7 @@ export class IteratorWorkflowAction implements WorkflowActionInterface {
       hasProcessedAllItems,
     };
 
-    if (!hasProcessedAllItems) {
+    if (!hasProcessedAllItems && currentItemIndex > 0) {
       await this.resetStepsInLoop({
         iteratorStepId,
         initialLoopStepIds,
@@ -155,6 +155,7 @@ export class IteratorWorkflowAction implements WorkflowActionInterface {
       ),
       workflowRunId,
       workspaceId,
+      shouldKeepHistory: true,
     });
   }
 }

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run/workflow-run.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run/workflow-run.workspace-service.ts
@@ -258,49 +258,22 @@ export class WorkflowRunWorkspaceService {
     stepInfos,
     workflowRunId,
     workspaceId,
-    shouldKeepHistory = false,
   }: {
     stepInfos: Record<string, WorkflowRunStepInfo>;
     workflowRunId: string;
     workspaceId: string;
-    shouldKeepHistory?: boolean;
   }) {
     const workflowRunToUpdate = await this.getWorkflowRunOrFail({
       workflowRunId,
       workspaceId,
     });
 
-    const stepInfosEnrichedWithHistory: Record<string, WorkflowRunStepInfo> =
-      shouldKeepHistory
-        ? Object.entries(stepInfos).reduce((acc, [stepId, stepInfo]) => {
-            const previousStepInfo =
-              workflowRunToUpdate.state?.stepInfos[stepId];
-
-            const updatedHistory = [
-              ...(previousStepInfo?.history ?? []),
-              {
-                result: previousStepInfo?.result,
-                error: previousStepInfo?.error,
-                status: previousStepInfo?.status,
-              },
-            ];
-
-            return {
-              ...acc,
-              [stepId]: {
-                ...stepInfo,
-                history: updatedHistory,
-              },
-            };
-          }, {})
-        : stepInfos;
-
     const partialUpdate = {
       state: {
         ...workflowRunToUpdate.state,
         stepInfos: {
           ...workflowRunToUpdate.state?.stepInfos,
-          ...stepInfosEnrichedWithHistory,
+          ...stepInfos,
         },
       },
     };

--- a/packages/twenty-shared/src/workflow/types/WorkflowRunStateStepInfos.ts
+++ b/packages/twenty-shared/src/workflow/types/WorkflowRunStateStepInfos.ts
@@ -11,6 +11,11 @@ export type WorkflowRunStepInfo = {
   result?: object;
   error?: string;
   status: StepStatus;
+  history?: {
+    status: StepStatus;
+    result?: object;
+    error?: string;
+  }[];
 };
 
 export type WorkflowRunStepInfos = Record<string, WorkflowRunStepInfo>;


### PR DESCRIPTION
- before reseting the step, enrich info with previous result
- reset only when a step is executed more than once. This will avoid to store the initial `NOT_STARTED` status of the step