### PR TITLE
fix: updated dropdown's bg for better readability over bright bg

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -84,7 +84,7 @@
       "cache": true,
       "options": {
         "cwd": "{projectRoot}",
-        "command": "tsc -b tsconfig.json --incremental"
+        "command": "NODE_OPTIONS=\"--max-old-space-size=8192\" tsc -b tsconfig.json --incremental"
       },
       "configurations": {
         "watch": {

--- a/nx.json
+++ b/nx.json
@@ -84,7 +84,7 @@
       "cache": true,
       "options": {
         "cwd": "{projectRoot}",
-        "command": "NODE_OPTIONS=\"--max-old-space-size=8192\" tsc -b tsconfig.json --incremental"
+        "command": "tsc -b tsconfig.json --incremental"
       },
       "configurations": {
         "watch": {

--- a/packages/twenty-front/src/modules/ui/layout/overlay/components/OverlayContainer.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/overlay/components/OverlayContainer.tsx
@@ -13,7 +13,7 @@ export const OverlayContainer = styled.div<{
   border-radius: ${({ theme, borderRadius }) =>
     theme.border.radius[borderRadius ?? 'md']};
 
-  background: ${({ theme }) => theme.background.transparent.primary};
+  background: ${({ theme }) => theme.background.overlayPrimary};
   border: 1px solid
     ${({ theme, hasDangerBorder }) =>
       theme.border.color[hasDangerBorder ? 'danger' : 'medium']};


### PR DESCRIPTION
# Fix dropdown readability in dark theme over bright backgrounds

## Problem

In dark theme, dropdowns wrapped by `OverlayContainer` had poor readability when displayed over bright/white backgrounds. The issue was caused by `theme.background.transparent.primary` having only 50% opacity, which didn't provide sufficient contrast against bright backgrounds even with the blur effect applied.

## Solution

Changed the background property in `OverlayContainer` from `theme.background.transparent.primary` to `theme.background.overlayPrimary`.

### Before
```typescript
background: ${({ theme }) => theme.background.transparent.primary};
```

### After
```typescript
background: ${({ theme }) => theme.background.overlayPrimary};
```

## Testing
<img width="641" height="402" alt="Screenshot 2025-09-24 213507" src="https://github.com/user-attachments/assets/04d7eb34-1d79-4d22-8e78-606770eddd9a" />

<img width="573" height="405" alt="Screenshot 2025-09-24 213649" src="https://github.com/user-attachments/assets/0eb085a2-b926-4975-b323-f1a5c15b4420" />

## Technical Details

The `overlayPrimary` background provides better contrast across both themes:

- **Dark theme**: `RGBA(gray100, 0.8)` - 80% opacity white overlay for better contrast over bright backgrounds
- **Light theme**: `RGBA(gray80, 0.8)` - 80% opacity dark overlay for consistent contrast

## Files Changed

- `packages/twenty-front/src/modules/ui/layout/overlay/components/OverlayContainer.tsx`

The change ensures that dropdown content remains clearly readable regardless of what's behind it, while maintaining the aesthetic blur effect. Test by:

1. Switch to dark theme
2. Open a dropdown over a bright/white background image or element
3. Verify that dropdown content is clearly readable
4. Test in light theme to ensure no regression

Fixes #11916

