### PR TITLE
add code checksum to flat serverless function

### DIFF
--- a/packages/twenty-front/src/generated-metadata/graphql.ts
+++ b/packages/twenty-front/src/generated-metadata/graphql.ts
@@ -1206,6 +1206,7 @@ export enum FileFolder {
   PersonPicture = 'PersonPicture',
   ProfilePicture = 'ProfilePicture',
   ServerlessFunction = 'ServerlessFunction',
+  ServerlessFunctionToDelete = 'ServerlessFunctionToDelete',
   WorkspaceLogo = 'WorkspaceLogo'
 }
 

--- a/packages/twenty-front/src/generated/graphql.ts
+++ b/packages/twenty-front/src/generated/graphql.ts
@@ -1170,6 +1170,7 @@ export enum FileFolder {
   PersonPicture = 'PersonPicture',
   ProfilePicture = 'ProfilePicture',
   ServerlessFunction = 'ServerlessFunction',
+  ServerlessFunctionToDelete = 'ServerlessFunctionToDelete',
   WorkspaceLogo = 'WorkspaceLogo'
 }
 

--- a/packages/twenty-server/project.json
+++ b/packages/twenty-server/project.json
@@ -161,6 +161,13 @@
         ]
       }
     },
+    "database:migrate:generate": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "packages/twenty-server",
+        "command": "npx nx typeorm -- migration:generate src/database/typeorm/core/migrations/common/{args.migrationName} -d src/database/typeorm/core/core.datasource.ts"
+      }
+    },
     "database:migrate:revert": {
       "executor": "nx:run-commands",
       "dependsOn": ["build"],

--- a/packages/twenty-server/src/database/typeorm/core/migrations/common/1758802648930-addChecksumToServerlessFunction.ts
+++ b/packages/twenty-server/src/database/typeorm/core/migrations/common/1758802648930-addChecksumToServerlessFunction.ts
@@ -1,0 +1,19 @@
+import { type MigrationInterface, type QueryRunner } from 'typeorm';
+
+export class AddChecksumToServerlessFunction1758802648930
+  implements MigrationInterface
+{
+  name = 'AddChecksumToServerlessFunction1758802648930';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "core"."serverlessFunction" ADD "checksum" text`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "core"."serverlessFunction" DROP COLUMN "checksum"`,
+    );
+  }
+}

--- a/packages/twenty-server/src/engine/core-modules/file-storage/drivers/interfaces/storage-driver.interface.ts
+++ b/packages/twenty-server/src/engine/core-modules/file-storage/drivers/interfaces/storage-driver.interface.ts
@@ -10,8 +10,8 @@ export interface StorageDriver {
     mimeType: string | undefined;
   }): Promise<void>;
   move(params: {
-    from: { folderPath: string; filename: string };
-    to: { folderPath: string; filename: string };
+    from: { folderPath: string; filename?: string };
+    to: { folderPath: string; filename?: string };
   }): Promise<void>;
   copy(params: {
     from: { folderPath: string; filename?: string };

--- a/packages/twenty-server/src/engine/core-modules/file-storage/drivers/local.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/file-storage/drivers/local.driver.ts
@@ -87,19 +87,19 @@ export class LocalDriver implements StorageDriver {
   }
 
   async move(params: {
-    from: { folderPath: string; filename: string };
-    to: { folderPath: string; filename: string };
+    from: { folderPath: string; filename?: string };
+    to: { folderPath: string; filename?: string };
   }): Promise<void> {
     const fromPath = join(
       `${this.options.storagePath}/`,
       params.from.folderPath,
-      params.from.filename,
+      params.from.filename || '',
     );
 
     const toPath = join(
       `${this.options.storagePath}/`,
       params.to.folderPath,
-      params.to.filename,
+      params.to.filename || '',
     );
 
     await this.createFolder(dirname(toPath));

--- a/packages/twenty-server/src/engine/core-modules/file-storage/drivers/s3.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/file-storage/drivers/s3.driver.ts
@@ -172,11 +172,11 @@ export class S3Driver implements StorageDriver {
   }
 
   async move(params: {
-    from: { folderPath: string; filename: string };
-    to: { folderPath: string; filename: string };
+    from: { folderPath: string; filename?: string };
+    to: { folderPath: string; filename?: string };
   }): Promise<void> {
-    const fromKey = `${params.from.folderPath}/${params.from.filename}`;
-    const toKey = `${params.to.folderPath}/${params.to.filename}`;
+    const fromKey = `${params.from.folderPath}/${params.from.filename || ''}`;
+    const toKey = `${params.to.folderPath}/${params.to.filename || ''}`;
 
     try {
       // Check if the source file exists

--- a/packages/twenty-server/src/engine/core-modules/file-storage/drivers/s3.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/file-storage/drivers/s3.driver.ts
@@ -70,10 +70,7 @@ export class S3Driver implements StorageDriver {
     await this.s3Client.send(command);
   }
 
-  // @ts-expect-error legacy noImplicitAny
-  private async emptyS3Directory(folderPath) {
-    this.logger.log(`${folderPath} - emptying folder`);
-
+  private async fetchS3FolderContents(folderPath: string) {
     const listParams = {
       Bucket: this.bucketName,
       Prefix: folderPath,
@@ -81,6 +78,15 @@ export class S3Driver implements StorageDriver {
 
     const listObjectsCommand = new ListObjectsV2Command(listParams);
     const listedObjects = await this.s3Client.send(listObjectsCommand);
+
+    return listedObjects;
+  }
+
+  // @ts-expect-error legacy noImplicitAny
+  private async emptyS3Directory(folderPath) {
+    this.logger.log(`${folderPath} - emptying folder`);
+
+    const listedObjects = await this.fetchS3FolderContents(folderPath);
 
     this.logger.log(
       `${folderPath} - listed objects`,
@@ -175,8 +181,14 @@ export class S3Driver implements StorageDriver {
     from: { folderPath: string; filename?: string };
     to: { folderPath: string; filename?: string };
   }): Promise<void> {
-    const fromKey = `${params.from.folderPath}/${params.from.filename || ''}`;
-    const toKey = `${params.to.folderPath}/${params.to.filename || ''}`;
+    if (!params.from.filename || !params.to.filename) {
+      await this.moveS3Folder(params);
+
+      return;
+    }
+
+    const fromKey = `${params.from.folderPath}/${params.from.filename}`;
+    const toKey = `${params.to.folderPath}/${params.to.filename}`;
 
     try {
       // Check if the source file exists
@@ -212,6 +224,45 @@ export class S3Driver implements StorageDriver {
       }
       // For other errors, throw the original error
       throw error;
+    }
+  }
+
+  async moveS3Folder(params: {
+    from: { folderPath: string };
+    to: { folderPath: string };
+  }): Promise<void> {
+    const fromKey = `${params.from.folderPath}`;
+
+    const listedObjects = await this.fetchS3FolderContents(fromKey);
+
+    if (!listedObjects.Contents || listedObjects.Contents.length === 0) {
+      throw new Error(
+        `No objects found in the source folder ${params.from.folderPath}.`,
+      );
+    }
+
+    for (const object of listedObjects.Contents) {
+      const folderAndFilePaths = this.extractFolderAndFilePaths(object.Key);
+
+      if (!isDefined(folderAndFilePaths)) {
+        continue;
+      }
+
+      const { fromFolderPath, filename } = folderAndFilePaths;
+
+      const toFolderPath = fromFolderPath.replace(
+        params.from.folderPath,
+        params.to.folderPath,
+      );
+
+      if (!isDefined(toFolderPath)) {
+        continue;
+      }
+
+      await this.move({
+        from: { folderPath: fromFolderPath, filename },
+        to: { folderPath: toFolderPath, filename },
+      });
     }
   }
 

--- a/packages/twenty-server/src/engine/core-modules/file-storage/file-storage.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/file-storage/file-storage.service.ts
@@ -36,8 +36,8 @@ export class FileStorageService implements StorageDriver {
   }
 
   move(params: {
-    from: { folderPath: string; filename: string };
-    to: { folderPath: string; filename: string };
+    from: { folderPath: string; filename?: string };
+    to: { folderPath: string; filename?: string };
   }): Promise<void> {
     const driver = this.fileStorageDriverFactory.getCurrentDriver();
 

--- a/packages/twenty-server/src/engine/core-modules/file/interfaces/file-folder.interface.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/interfaces/file-folder.interface.ts
@@ -8,6 +8,7 @@ export enum FileFolder {
   Attachment = 'attachment',
   PersonPicture = 'person-picture',
   ServerlessFunction = 'serverless-function',
+  ServerlessFunctionToDelete = 'serverless-function-to-delete',
   File = 'file',
 }
 
@@ -33,6 +34,9 @@ export const fileFolderConfigs: Record<FileFolder, FileFolderConfig> = {
     ignoreExpirationToken: false,
   },
   [FileFolder.ServerlessFunction]: {
+    ignoreExpirationToken: false,
+  },
+  [FileFolder.ServerlessFunctionToDelete]: {
     ignoreExpirationToken: false,
   },
   [FileFolder.File]: {

--- a/packages/twenty-server/src/engine/core-modules/serverless/utils/serverless-get-folder.utils.ts
+++ b/packages/twenty-server/src/engine/core-modules/serverless/utils/serverless-get-folder.utils.ts
@@ -14,9 +14,11 @@ import { type FlatServerlessFunction } from 'src/engine/metadata-modules/serverl
 export const getServerlessFolder = ({
   serverlessFunction,
   version,
+  toDelete = false,
 }: {
   serverlessFunction: ServerlessFunctionEntity | FlatServerlessFunction;
   version?: 'draft' | 'latest' | (string & NonNullable<unknown>);
+  toDelete?: boolean;
 }) => {
   if (version === 'latest' && !isDefined(serverlessFunction.latestVersion)) {
     throw new ServerlessFunctionException(
@@ -30,7 +32,9 @@ export const getServerlessFolder = ({
 
   return join(
     'workspace-' + serverlessFunction.workspaceId,
-    FileFolder.ServerlessFunction,
+    toDelete
+      ? FileFolder.ServerlessFunctionToDelete
+      : FileFolder.ServerlessFunction,
     serverlessFunction.id,
     computedVersion || '',
   );

--- a/packages/twenty-server/src/engine/metadata-modules/serverless-function/constants/flat-serverless-function-editable-properties.constant.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/serverless-function/constants/flat-serverless-function-editable-properties.constant.ts
@@ -4,4 +4,5 @@ export const FLAT_SERVERLESS_FUNCTION_EDITABLE_PROPERTIES = [
   'name',
   'description',
   'timeoutSeconds',
+  'checksum',
 ] as const satisfies (keyof FlatServerlessFunction)[];

--- a/packages/twenty-server/src/engine/metadata-modules/serverless-function/constants/flat-serverless-function-editable-properties.constant.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/serverless-function/constants/flat-serverless-function-editable-properties.constant.ts
@@ -5,4 +5,5 @@ export const FLAT_SERVERLESS_FUNCTION_EDITABLE_PROPERTIES = [
   'description',
   'timeoutSeconds',
   'checksum',
+  'code',
 ] as const satisfies (keyof FlatServerlessFunction)[];

--- a/packages/twenty-server/src/engine/metadata-modules/serverless-function/constants/flat-serverless-function-properties-to-compare.constant.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/serverless-function/constants/flat-serverless-function-properties-to-compare.constant.ts
@@ -3,4 +3,5 @@ import { type FlatServerlessFunction } from 'src/engine/metadata-modules/serverl
 
 export const FLAT_SERVERLESS_FUNCTION_PROPERTIES_TO_COMPARE = [
   ...FLAT_SERVERLESS_FUNCTION_EDITABLE_PROPERTIES,
+  'deletedAt',
 ] as const satisfies (keyof FlatServerlessFunction)[];

--- a/packages/twenty-server/src/engine/metadata-modules/serverless-function/serverless-function.entity.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/serverless-function/serverless-function.entity.ts
@@ -71,6 +71,9 @@ export class ServerlessFunctionEntity
   @Column({ nullable: true, type: 'uuid' })
   applicationId: string | null;
 
+  @Column({ nullable: true, type: 'text' })
+  checksum: string | null;
+
   @OneToMany(
     () => CronTrigger,
     (cronTrigger) => cronTrigger.serverlessFunction,

--- a/packages/twenty-server/src/engine/metadata-modules/serverless-function/serverless-function.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/serverless-function/serverless-function.resolver.ts
@@ -21,6 +21,7 @@ import { ServerlessFunctionDTO } from 'src/engine/metadata-modules/serverless-fu
 import { UpdateServerlessFunctionInput } from 'src/engine/metadata-modules/serverless-function/dtos/update-serverless-function.input';
 import { ServerlessFunctionEntity } from 'src/engine/metadata-modules/serverless-function/serverless-function.entity';
 import { ServerlessFunctionService } from 'src/engine/metadata-modules/serverless-function/serverless-function.service';
+import { ServerlessFunctionV2Service } from 'src/engine/metadata-modules/serverless-function/services/serverless-function-v2.service';
 import { serverlessFunctionGraphQLApiExceptionHandler } from 'src/engine/metadata-modules/serverless-function/utils/serverless-function-graphql-api-exception-handler.utils';
 
 @UseGuards(WorkspaceAuthGuard, FeatureFlagGuard)
@@ -30,6 +31,7 @@ import { serverlessFunctionGraphQLApiExceptionHandler } from 'src/engine/metadat
 export class ServerlessFunctionResolver {
   constructor(
     private readonly serverlessFunctionService: ServerlessFunctionService,
+    private readonly serverlessFunctionV2Service: ServerlessFunctionV2Service,
     @InjectRepository(ServerlessFunctionEntity)
     private readonly serverlessFunctionRepository: Repository<ServerlessFunctionEntity>,
   ) {}
@@ -95,8 +97,8 @@ export class ServerlessFunctionResolver {
     @AuthWorkspace() { id: workspaceId }: Workspace,
   ) {
     try {
-      return await this.serverlessFunctionService.deleteOneServerlessFunction({
-        id: input.id,
+      return await this.serverlessFunctionV2Service.destroyOne({
+        destroyServerlessFunctionInput: input,
         workspaceId,
       });
     } catch (error) {
@@ -111,7 +113,7 @@ export class ServerlessFunctionResolver {
     @AuthWorkspace() { id: workspaceId }: Workspace,
   ) {
     try {
-      return await this.serverlessFunctionService.updateOneServerlessFunction(
+      return await this.serverlessFunctionV2Service.updateOne(
         input,
         workspaceId,
       );
@@ -127,7 +129,7 @@ export class ServerlessFunctionResolver {
     @AuthWorkspace() { id: workspaceId }: Workspace,
   ) {
     try {
-      return await this.serverlessFunctionService.createOneServerlessFunction(
+      return await this.serverlessFunctionV2Service.createOne(
         input,
         workspaceId,
       );

--- a/packages/twenty-server/src/engine/metadata-modules/serverless-function/serverless-function.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/serverless-function/serverless-function.resolver.ts
@@ -21,7 +21,6 @@ import { ServerlessFunctionDTO } from 'src/engine/metadata-modules/serverless-fu
 import { UpdateServerlessFunctionInput } from 'src/engine/metadata-modules/serverless-function/dtos/update-serverless-function.input';
 import { ServerlessFunctionEntity } from 'src/engine/metadata-modules/serverless-function/serverless-function.entity';
 import { ServerlessFunctionService } from 'src/engine/metadata-modules/serverless-function/serverless-function.service';
-import { ServerlessFunctionV2Service } from 'src/engine/metadata-modules/serverless-function/services/serverless-function-v2.service';
 import { serverlessFunctionGraphQLApiExceptionHandler } from 'src/engine/metadata-modules/serverless-function/utils/serverless-function-graphql-api-exception-handler.utils';
 
 @UseGuards(WorkspaceAuthGuard, FeatureFlagGuard)
@@ -31,7 +30,6 @@ import { serverlessFunctionGraphQLApiExceptionHandler } from 'src/engine/metadat
 export class ServerlessFunctionResolver {
   constructor(
     private readonly serverlessFunctionService: ServerlessFunctionService,
-    private readonly serverlessFunctionV2Service: ServerlessFunctionV2Service,
     @InjectRepository(ServerlessFunctionEntity)
     private readonly serverlessFunctionRepository: Repository<ServerlessFunctionEntity>,
   ) {}
@@ -97,8 +95,8 @@ export class ServerlessFunctionResolver {
     @AuthWorkspace() { id: workspaceId }: Workspace,
   ) {
     try {
-      return await this.serverlessFunctionV2Service.destroyOne({
-        destroyServerlessFunctionInput: input,
+      return await this.serverlessFunctionService.deleteOneServerlessFunction({
+        id: input.id,
         workspaceId,
       });
     } catch (error) {
@@ -113,7 +111,7 @@ export class ServerlessFunctionResolver {
     @AuthWorkspace() { id: workspaceId }: Workspace,
   ) {
     try {
-      return await this.serverlessFunctionV2Service.updateOne(
+      return await this.serverlessFunctionService.updateOneServerlessFunction(
         input,
         workspaceId,
       );
@@ -129,7 +127,7 @@ export class ServerlessFunctionResolver {
     @AuthWorkspace() { id: workspaceId }: Workspace,
   ) {
     try {
-      return await this.serverlessFunctionV2Service.createOne(
+      return await this.serverlessFunctionService.createOneServerlessFunction(
         input,
         workspaceId,
       );

--- a/packages/twenty-server/src/engine/metadata-modules/serverless-function/types/flat-serverless-function.type.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/serverless-function/types/flat-serverless-function.type.ts
@@ -16,4 +16,5 @@ export type FlatServerlessFunction = Omit<
   ServerlessFunctionEntityRelationProperties
 > & {
   universalIdentifier: string;
+  code?: JSON;
 };

--- a/packages/twenty-server/src/engine/metadata-modules/serverless-function/utils/from-create-serverless-function-input-to-flat-serverless-function.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/serverless-function/utils/from-create-serverless-function-input-to-flat-serverless-function.util.ts
@@ -32,5 +32,6 @@ export const fromCreateServerlessFunctionInputToFlatServerlessFunction = ({
     timeoutSeconds: createServerlessFunctionInput.timeoutSeconds ?? 300,
     layerVersion: LAST_LAYER_VERSION,
     workspaceId,
+    checksum: null,
   };
 };

--- a/packages/twenty-server/src/engine/metadata-modules/serverless-function/utils/from-update-serverless-function-input-to-flat-serverless-function-to-update-or-throw.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/serverless-function/utils/from-update-serverless-function-input-to-flat-serverless-function-to-update-or-throw.util.ts
@@ -13,6 +13,7 @@ import {
   ServerlessFunctionExceptionCode,
 } from 'src/engine/metadata-modules/serverless-function/serverless-function.exception';
 import { type FlatServerlessFunction } from 'src/engine/metadata-modules/serverless-function/types/flat-serverless-function.type';
+import { serverlessFunctionCreateCodeChecksum } from 'src/engine/metadata-modules/serverless-function/utils/serverless-function-create-code-checksum.utils';
 import { mergeUpdateInExistingRecord } from 'src/utils/merge-update-in-existing-record.util';
 
 export const fromUpdateServerlessFunctionInputToFlatServerlessFunctionToUpdateOrThrow =
@@ -39,7 +40,12 @@ export const fromUpdateServerlessFunctionInputToFlatServerlessFunctionToUpdateOr
       );
     }
     const updatedEditableFieldProperties = extractAndSanitizeObjectStringFields(
-      rawUpdateServerlessFunctionInput,
+      {
+        ...rawUpdateServerlessFunctionInput,
+        checksum: serverlessFunctionCreateCodeChecksum(
+          rawUpdateServerlessFunctionInput.code,
+        ),
+      },
       FLAT_SERVERLESS_FUNCTION_EDITABLE_PROPERTIES,
     );
 

--- a/packages/twenty-server/src/engine/metadata-modules/serverless-function/utils/serverless-function-create-code-checksum.utils.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/serverless-function/utils/serverless-function-create-code-checksum.utils.ts
@@ -1,0 +1,15 @@
+import { serverlessFunctionCreateHash } from 'src/engine/metadata-modules/serverless-function/utils/serverless-function-create-hash.utils';
+
+export const serverlessFunctionCreateCodeChecksum = (code: JSON): string => {
+  if (!code || typeof code !== 'object') {
+    return serverlessFunctionCreateHash('');
+  }
+
+  const codeObj = code as unknown as Record<string, string>;
+  const sortedKeys = Object.keys(codeObj).sort();
+  const concatenatedContent = sortedKeys
+    .map((key) => `${key}:${codeObj[key]}`)
+    .join('|');
+
+  return serverlessFunctionCreateHash(concatenatedContent);
+};

--- a/packages/twenty-server/src/engine/metadata-modules/serverless-function/utils/serverless-function-create-code-checksum.utils.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/serverless-function/utils/serverless-function-create-code-checksum.utils.ts
@@ -1,7 +1,9 @@
+import { isDefined } from 'twenty-shared/utils';
+
 import { serverlessFunctionCreateHash } from 'src/engine/metadata-modules/serverless-function/utils/serverless-function-create-hash.utils';
 
 export const serverlessFunctionCreateCodeChecksum = (code: JSON): string => {
-  if (!code || typeof code !== 'object') {
+  if (!isDefined(code) || typeof code !== 'object') {
     return serverlessFunctionCreateHash('');
   }
 

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-builder-v2/builders/serverless-function/workspace-migration-v2-serverless-function-actions-builder.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-builder-v2/builders/serverless-function/workspace-migration-v2-serverless-function-actions-builder.service.ts
@@ -152,7 +152,7 @@ export class WorkspaceMigrationV2ServerlessFunctionActionsBuilderService extends
       type: 'update_serverless_function',
       serverlessFunctionId: toFlatServerlessFunction.id,
       updates: serverlessFunctionUpdatedProperties,
-      code: toFlatServerlessFunction.code!,
+      code: toFlatServerlessFunction.code,
     };
 
     return {

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-builder-v2/builders/serverless-function/workspace-migration-v2-serverless-function-actions-builder.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-builder-v2/builders/serverless-function/workspace-migration-v2-serverless-function-actions-builder.service.ts
@@ -45,9 +45,9 @@ export class WorkspaceMigrationV2ServerlessFunctionActionsBuilderService extends
     const validationResult =
       await this.flatServerlessFunctionValidatorService.validateFlatServerlessFunctionCreation(
         {
-          dependencyOptimisticFlatEntityMaps,
           flatServerlessFunctionToValidate,
           optimisticFlatServerlessFunctionMaps,
+          dependencyOptimisticFlatEntityMaps,
         },
       );
 
@@ -83,9 +83,9 @@ export class WorkspaceMigrationV2ServerlessFunctionActionsBuilderService extends
     const validationResult =
       this.flatServerlessFunctionValidatorService.validateFlatServerlessFunctionDeletion(
         {
-          dependencyOptimisticFlatEntityMaps,
           flatServerlessFunctionToValidate,
           optimisticFlatServerlessFunctionMaps,
+          dependencyOptimisticFlatEntityMaps,
         },
       );
 
@@ -135,9 +135,9 @@ export class WorkspaceMigrationV2ServerlessFunctionActionsBuilderService extends
     const validationResult =
       this.flatServerlessFunctionValidatorService.validateFlatServerlessFunctionUpdate(
         {
-          dependencyOptimisticFlatEntityMaps,
           flatServerlessFunctionToValidate: toFlatServerlessFunction,
           optimisticFlatServerlessFunctionMaps,
+          dependencyOptimisticFlatEntityMaps,
         },
       );
 
@@ -152,6 +152,7 @@ export class WorkspaceMigrationV2ServerlessFunctionActionsBuilderService extends
       type: 'update_serverless_function',
       serverlessFunctionId: toFlatServerlessFunction.id,
       updates: serverlessFunctionUpdatedProperties,
+      code: toFlatServerlessFunction.code!,
     };
 
     return {

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-builder-v2/types/workspace-migration-serverless-function-action-v2.type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-builder-v2/types/workspace-migration-serverless-function-action-v2.type.ts
@@ -18,6 +18,7 @@ export type CreateServerlessFunctionAction = {
 export type UpdateServerlessFunctionAction = {
   type: 'update_serverless_function';
   serverlessFunctionId: string;
+  code: JSON;
   updates: Array<
     {
       [P in FlatServerlessFunctionPropertiesToCompare]: FlatServerlessFunctionPropertyUpdate<P>;

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-builder-v2/types/workspace-migration-serverless-function-action-v2.type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-builder-v2/types/workspace-migration-serverless-function-action-v2.type.ts
@@ -1,14 +1,6 @@
-import { type FromTo } from 'twenty-shared/types';
-
-import { type ServerlessFunctionEntity } from 'src/engine/metadata-modules/serverless-function/serverless-function.entity';
 import { type FlatServerlessFunctionPropertiesToCompare } from 'src/engine/metadata-modules/serverless-function/types/flat-serverless-function-properties-to-compare.type';
 import { type FlatServerlessFunction } from 'src/engine/metadata-modules/serverless-function/types/flat-serverless-function.type';
-
-export type FlatServerlessFunctionPropertyUpdate<
-  P extends FlatServerlessFunctionPropertiesToCompare,
-> = {
-  property: P;
-} & FromTo<ServerlessFunctionEntity[P]>;
+import { type PropertyUpdate } from 'src/engine/workspace-manager/workspace-migration-v2/types/property-update.type';
 
 export type CreateServerlessFunctionAction = {
   type: 'create_serverless_function';
@@ -18,10 +10,13 @@ export type CreateServerlessFunctionAction = {
 export type UpdateServerlessFunctionAction = {
   type: 'update_serverless_function';
   serverlessFunctionId: string;
-  code: JSON;
+  code?: JSON;
   updates: Array<
     {
-      [P in FlatServerlessFunctionPropertiesToCompare]: FlatServerlessFunctionPropertyUpdate<P>;
+      [P in FlatServerlessFunctionPropertiesToCompare]: PropertyUpdate<
+        FlatServerlessFunction,
+        P
+      >;
     }[FlatServerlessFunctionPropertiesToCompare]
   >;
 };

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-builder-v2/validators/services/flat-serverless-function-validator.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-builder-v2/validators/services/flat-serverless-function-validator.service.ts
@@ -42,14 +42,6 @@ export class FlatServerlessFunctionValidatorService {
       });
     }
 
-    if (!isDefined(updatedFlatServerlessFunction.code)) {
-      errors.push({
-        code: ServerlessFunctionExceptionCode.SERVERLESS_FUNCTION_CODE_UNCHANGED,
-        message: t`Serverless function code unchanged`,
-        userFriendlyMessage: t`Serverless function code unchanged`,
-      });
-    }
-
     return {
       type: 'update_serverless_function',
       errors,

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-builder-v2/validators/services/flat-serverless-function-validator.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-builder-v2/validators/services/flat-serverless-function-validator.service.ts
@@ -42,6 +42,14 @@ export class FlatServerlessFunctionValidatorService {
       });
     }
 
+    if (!isDefined(updatedFlatServerlessFunction.code)) {
+      errors.push({
+        code: ServerlessFunctionExceptionCode.SERVERLESS_FUNCTION_CODE_UNCHANGED,
+        message: t`Serverless function code unchanged`,
+        userFriendlyMessage: t`Serverless function code unchanged`,
+      });
+    }
+
     return {
       type: 'update_serverless_function',
       errors,

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/action-handlers/serverless-function/services/delete-serverless-function-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/action-handlers/serverless-function/services/delete-serverless-function-action-handler.service.ts
@@ -7,6 +7,9 @@ import {
 
 import { AllFlatEntityMaps } from 'src/engine/core-modules/common/types/all-flat-entity-maps.type';
 import { deleteFlatEntityFromFlatEntityMapsOrThrow } from 'src/engine/core-modules/common/utils/delete-flat-entity-from-flat-entity-maps-or-throw.util';
+import { findFlatEntityByIdInFlatEntityMapsOrThrow } from 'src/engine/core-modules/common/utils/find-flat-entity-by-id-in-flat-entity-maps-or-throw.util';
+import { FileStorageService } from 'src/engine/core-modules/file-storage/file-storage.service';
+import { getServerlessFolder } from 'src/engine/core-modules/serverless/utils/serverless-get-folder.utils';
 import { ServerlessFunctionEntity } from 'src/engine/metadata-modules/serverless-function/serverless-function.entity';
 import { DeleteServerlessFunctionAction } from 'src/engine/workspace-manager/workspace-migration-v2/workspace-migration-builder-v2/types/workspace-migration-serverless-function-action-v2.type';
 import { WorkspaceMigrationActionRunnerArgs } from 'src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/types/workspace-migration-action-runner-args.type';
@@ -15,7 +18,7 @@ import { WorkspaceMigrationActionRunnerArgs } from 'src/engine/workspace-manager
 export class DeleteServerlessFunctionActionHandlerService extends WorkspaceMigrationRunnerActionHandler(
   'delete_serverless_function',
 ) {
-  constructor() {
+  constructor(private readonly fileStorageService: FileStorageService) {
     super();
   }
 
@@ -51,6 +54,18 @@ export class DeleteServerlessFunctionActionHandlerService extends WorkspaceMigra
     await serverlessFunctionRepository.delete({
       id: serverlessFunctionId,
       workspaceId,
+    });
+
+    const existingServerlessFunction =
+      findFlatEntityByIdInFlatEntityMapsOrThrow({
+        flatEntityId: serverlessFunctionId,
+        flatEntityMaps: context.allFlatEntityMaps.flatServerlessFunctionMaps,
+      });
+
+    await this.fileStorageService.delete({
+      folderPath: getServerlessFolder({
+        serverlessFunction: existingServerlessFunction,
+      }),
     });
   }
 

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/action-handlers/serverless-function/services/update-serverless-function-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/action-handlers/serverless-function/services/update-serverless-function-action-handler.service.ts
@@ -4,14 +4,9 @@ import { basename, dirname, join } from 'path';
 
 import { isDefined } from 'twenty-shared/utils';
 
-import {
-  OptimisticallyApplyActionOnAllFlatEntityMapsArgs,
-  WorkspaceMigrationRunnerActionHandler,
-} from 'src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/interfaces/workspace-migration-runner-action-handler-service.interface';
+import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/interfaces/workspace-migration-runner-action-handler-service.interface';
 
-import { AllFlatEntityMaps } from 'src/engine/core-modules/common/types/all-flat-entity-maps.type';
 import { findFlatEntityByIdInFlatEntityMapsOrThrow } from 'src/engine/core-modules/common/utils/find-flat-entity-by-id-in-flat-entity-maps-or-throw.util';
-import { replaceFlatEntityInFlatEntityMapsOrThrow } from 'src/engine/core-modules/common/utils/replace-flat-entity-in-flat-entity-maps-or-throw.util';
 import { FileStorageService } from 'src/engine/core-modules/file-storage/file-storage.service';
 import { ServerlessService } from 'src/engine/core-modules/serverless/serverless.service';
 import { getServerlessFolder } from 'src/engine/core-modules/serverless/utils/serverless-get-folder.utils';
@@ -30,35 +25,6 @@ export class UpdateServerlessFunctionActionHandlerService extends WorkspaceMigra
     private readonly serverlessService: ServerlessService,
   ) {
     super();
-  }
-
-  optimisticallyApplyActionOnAllFlatEntityMaps({
-    action,
-    allFlatEntityMaps,
-  }: OptimisticallyApplyActionOnAllFlatEntityMapsArgs<UpdateServerlessFunctionAction>): Partial<AllFlatEntityMaps> {
-    const { flatServerlessFunctionMaps } = allFlatEntityMaps;
-    const { serverlessFunctionId } = action;
-
-    const existingServerlessFunction =
-      findFlatEntityByIdInFlatEntityMapsOrThrow({
-        flatEntityId: serverlessFunctionId,
-        flatEntityMaps: flatServerlessFunctionMaps,
-      });
-
-    const updatedServerlessFunction = {
-      ...existingServerlessFunction,
-      ...fromWorkspaceMigrationUpdateActionToPartialEntity(action),
-    };
-
-    const updatedFlatServerlessFunctionMaps =
-      replaceFlatEntityInFlatEntityMapsOrThrow({
-        flatEntity: updatedServerlessFunction,
-        flatEntityMaps: flatServerlessFunctionMaps,
-      });
-
-    return {
-      flatServerlessFunctionMaps: updatedFlatServerlessFunctionMaps,
-    };
   }
 
   async executeForMetadata(
@@ -128,11 +94,5 @@ export class UpdateServerlessFunctionActionHandlerService extends WorkspaceMigra
         folder: join(fileFolder, dirname(key)),
       });
     }
-  }
-
-  async executeForWorkspaceSchema(
-    _context: WorkspaceMigrationActionRunnerArgs<UpdateServerlessFunctionAction>,
-  ): Promise<void> {
-    return;
   }
 }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/interfaces/workspace-migration-runner-action-handler-service.interface.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/interfaces/workspace-migration-runner-action-handler-service.interface.ts
@@ -15,6 +15,10 @@ export interface WorkspaceMigrationRunnerActionHandlerService<
   execute(
     context: WorkspaceMigrationActionRunnerArgs<ExtractAction<TActionType>>,
   ): Promise<Partial<AllFlatEntityMaps>>;
+
+  rollback(
+    context: WorkspaceMigrationActionRunnerArgs<ExtractAction<TActionType>>,
+  ): Promise<void>;
 }
 
 export type OptimisticallyApplyActionOnAllFlatEntityMapsArgs<
@@ -28,19 +32,34 @@ export abstract class BaseWorkspaceMigrationRunnerActionHandlerService<
   TActionType extends WorkspaceMigrationActionTypeV2,
 > implements WorkspaceMigrationRunnerActionHandlerService<TActionType>
 {
-  abstract executeForMetadata(
+  executeForMetadata(
+    // eslint-disable-next-line unused-imports/no-unused-vars
     context: WorkspaceMigrationActionRunnerArgs<ExtractAction<TActionType>>,
-  ): Promise<void>;
+  ): Promise<void> {
+    return Promise.resolve();
+  }
 
-  abstract executeForWorkspaceSchema(
+  executeForWorkspaceSchema(
+    // eslint-disable-next-line unused-imports/no-unused-vars
     context: WorkspaceMigrationActionRunnerArgs<ExtractAction<TActionType>>,
-  ): Promise<void>;
+  ): Promise<void> {
+    return Promise.resolve();
+  }
 
-  abstract optimisticallyApplyActionOnAllFlatEntityMaps(
+  optimisticallyApplyActionOnAllFlatEntityMaps(
     args: OptimisticallyApplyActionOnAllFlatEntityMapsArgs<
       ExtractAction<TActionType>
     >,
-  ): Partial<AllFlatEntityMaps>;
+  ): Partial<AllFlatEntityMaps> {
+    return args.allFlatEntityMaps;
+  }
+
+  rollbackForMetadata(
+    // eslint-disable-next-line unused-imports/no-unused-vars
+    context: WorkspaceMigrationActionRunnerArgs<ExtractAction<TActionType>>,
+  ): Promise<void> {
+    return Promise.resolve();
+  }
 
   async execute(
     context: WorkspaceMigrationActionRunnerArgs<ExtractAction<TActionType>>,
@@ -54,6 +73,12 @@ export abstract class BaseWorkspaceMigrationRunnerActionHandlerService<
       action: context.action,
       allFlatEntityMaps: context.allFlatEntityMaps,
     });
+  }
+
+  async rollback(
+    context: WorkspaceMigrationActionRunnerArgs<ExtractAction<TActionType>>,
+  ): Promise<void> {
+    await this.rollbackForMetadata(context);
   }
 }
 

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/registry/workspace-migration-runner-action-handler-registry.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/registry/workspace-migration-runner-action-handler-registry.service.ts
@@ -1,6 +1,8 @@
 import { Injectable, OnModuleInit } from '@nestjs/common';
 import { DiscoveryService } from '@nestjs/core';
 
+import { isDefined } from 'twenty-shared/utils';
+
 import { type WorkspaceMigrationRunnerActionHandlerService } from 'src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/interfaces/workspace-migration-runner-action-handler-service.interface';
 
 import { AllFlatEntityMaps } from 'src/engine/core-modules/common/types/all-flat-entity-maps.type';
@@ -70,7 +72,7 @@ export class WorkspaceMigrationRunnerActionHandlerRegistryService
       );
     }
 
-    if (rollback) {
+    if (isDefined(rollback) && rollback) {
       await handler.rollback(context);
 
       return {};

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/registry/workspace-migration-runner-action-handler-registry.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/registry/workspace-migration-runner-action-handler-registry.service.ts
@@ -52,10 +52,15 @@ export class WorkspaceMigrationRunnerActionHandlerRegistryService
     });
   }
 
-  async executeActionHandler<T extends WorkspaceMigrationActionV2>(
-    actionType: WorkspaceMigrationActionTypeV2,
-    context: WorkspaceMigrationActionRunnerArgs<T>,
-  ): Promise<Partial<AllFlatEntityMaps>> {
+  async executeActionHandler<T extends WorkspaceMigrationActionV2>({
+    actionType,
+    context,
+    rollback,
+  }: {
+    actionType: WorkspaceMigrationActionTypeV2;
+    context: WorkspaceMigrationActionRunnerArgs<T>;
+    rollback?: boolean;
+  }): Promise<Partial<AllFlatEntityMaps>> {
     const handler = this.actionHandlers.get(actionType);
 
     if (!handler) {
@@ -63,6 +68,12 @@ export class WorkspaceMigrationRunnerActionHandlerRegistryService
         `No migration runner action handler found for action: ${actionType}`,
         WorkspaceMigrationRunnerExceptionCode.INVALID_ACTION_TYPE,
       );
+    }
+
+    if (rollback) {
+      await handler.rollback(context);
+
+      return {};
     }
 
     return await handler.execute(context);

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/services/workspace-migration-runner-v2.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/services/workspace-migration-runner-v2.service.ts
@@ -41,8 +41,6 @@ export class WorkspaceMigrationRunnerV2Service {
 
     let flatEntityMapsToInvalidate: (keyof AllFlatEntityMaps)[] = [];
 
-    const invertedActions = actions.reverse();
-
     try {
       for (const action of actions) {
         const partialOptimisticCache =
@@ -91,6 +89,8 @@ export class WorkspaceMigrationRunnerV2Service {
           console.trace(`Failed to rollback transaction: ${error.message}`);
         }
       }
+
+      const invertedActions = actions.reverse();
 
       for (const invertedAction of invertedActions) {
         await this.workspaceMigrationRunnerActionHandlerRegistry.executeActionHandler(

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/services/workspace-migration-runner-v2.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/services/workspace-migration-runner-v2.service.ts
@@ -81,7 +81,7 @@ export class WorkspaceMigrationRunnerV2Service {
         flatEntities: flatEntityMapsToInvalidate,
       });
 
-      throw new Error('test');
+      return allFlatEntityMaps;
     } catch (error) {
       if (queryRunner.isTransactionActive) {
         try {


### PR DESCRIPTION
## Context
Now adding serverless code sync within the migration v2 logic itself. To do that we need to follow the
- Prepare flat input
- Build migration
- Run migration
steps where now the serverless function entity will store in DB and cache a checksum of its code and the flat input will contain the code with the checksum. Build will compare checksum and create an update action containing the code if it has changed and the migration will now run the corresponding services (instead of calling those in the parent serverless service exposed in the API) allowing us to keep that logic functional for other use cases such as import/export, twenty-cli and twenty upgrades.