### PR TITLE
Intercept all abortErrors

### DIFF
--- a/packages/twenty-front/src/modules/error-handler/components/PromiseRejectionEffect.tsx
+++ b/packages/twenty-front/src/modules/error-handler/components/PromiseRejectionEffect.tsx
@@ -23,7 +23,11 @@ export const PromiseRejectionEffect = () => {
         return; // already handled by apolloLink
       }
 
-      if (error.networkError?.name !== 'AbortError') {
+      const isAbortError =
+        error.networkError?.name === 'AbortError' ||
+        error.name === 'AbortError';
+
+      if (!isAbortError) {
         enqueueErrorSnackBar({});
       }
 


### PR DESCRIPTION
Fixes https://github.com/twentyhq/twenty/issues/14569

Some extensions, such as SimilarWeb, are incompatible with twenty: they trigger intempestive "AbortErrors" converted into error snackbar. While twenty remains usable it is very annoying. 

I did not take time to deeply investigate which requests are problematic. According to ClaudeAI it may be because twenty makes a lot of queries to the same endpoint /graphql, a pattern that SimilarWeb may interpret as tracking which they try to intercept. 

In this PR, we finish the work started in [this PR](https://github.com/twentyhq/twenty/pull/13080) to silent harmless AbortErrors.