### PR TITLE
fix view update in migration v2

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/view/flat-view/services/workspace-flat-view-map-cache.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/view/flat-view/services/workspace-flat-view-map-cache.service.ts
@@ -34,12 +34,6 @@ export class WorkspaceFlatViewMapCacheService extends WorkspaceFlatMapCacheServi
         workspaceId,
       },
       withDeleted: true,
-      relations: ['viewFields'],
-      select: {
-        viewFields: {
-          id: true,
-        },
-      },
     });
 
     return generateFlatViewMaps(views);


### PR DESCRIPTION
Legacy from early v2 implementation, we don't want to store relation ids in the cache as the new implementation handle that with flat entities properly already.

This causes some issues because when we return the updated view, it contains an array of viewField objects with only the id in it so gql complains because some fields are non-nullable in the output and the resolver can't resolve viewField directly because viewField is in the output (not complete though) already so it just ignores it.