### PR TITLE
rename application standardId to universalIdentifier

### DIFF
--- a/packages/twenty-server/src/database/typeorm/core/migrations/common/1759341429047-renameApplicationStandardIdToUniversalIdentifier.ts
+++ b/packages/twenty-server/src/database/typeorm/core/migrations/common/1759341429047-renameApplicationStandardIdToUniversalIdentifier.ts
@@ -1,0 +1,37 @@
+import { type MigrationInterface, type QueryRunner } from 'typeorm';
+
+export class RenameApplicationStandardIdToUniversalIdentifier1759341429047
+  implements MigrationInterface
+{
+  name = 'RenameApplicationStandardIdToUniversalIdentifier1759341429047';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "core"."IDX_APPLICATION_STANDARD_ID_WORKSPACE_ID_UNIQUE"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."application" RENAME COLUMN "standardId" TO "universalIdentifier"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."agent" ADD "modelConfiguration" jsonb`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_APPLICATION_UNIVERSAL_IDENTIFIER_WORKSPACE_ID_UNIQUE" ON "core"."application" ("universalIdentifier", "workspaceId") WHERE "deletedAt" IS NULL AND "universalIdentifier" IS NOT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "core"."IDX_APPLICATION_UNIVERSAL_IDENTIFIER_WORKSPACE_ID_UNIQUE"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."agent" DROP COLUMN "modelConfiguration"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."application" RENAME COLUMN "universalIdentifier" TO "standardId"`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_APPLICATION_STANDARD_ID_WORKSPACE_ID_UNIQUE" ON "core"."application" ("standardId", "workspaceId") WHERE (("deletedAt" IS NULL) AND ("standardId" IS NOT NULL))`,
+    );
+  }
+}

--- a/packages/twenty-server/src/database/typeorm/core/migrations/common/1759341941773-renameApplicationStandardIdToUniversalIdentifier.ts
+++ b/packages/twenty-server/src/database/typeorm/core/migrations/common/1759341941773-renameApplicationStandardIdToUniversalIdentifier.ts
@@ -1,9 +1,9 @@
 import { type MigrationInterface, type QueryRunner } from 'typeorm';
 
-export class RenameApplicationStandardIdToUniversalIdentifier1759341429047
+export class RenameApplicationStandardIdToUniversalIdentifier1759341941773
   implements MigrationInterface
 {
-  name = 'RenameApplicationStandardIdToUniversalIdentifier1759341429047';
+  name = 'RenameApplicationStandardIdToUniversalIdentifier1759341941773';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
@@ -13,9 +13,6 @@ export class RenameApplicationStandardIdToUniversalIdentifier1759341429047
       `ALTER TABLE "core"."application" RENAME COLUMN "standardId" TO "universalIdentifier"`,
     );
     await queryRunner.query(
-      `ALTER TABLE "core"."agent" ADD "modelConfiguration" jsonb`,
-    );
-    await queryRunner.query(
       `CREATE UNIQUE INDEX "IDX_APPLICATION_UNIVERSAL_IDENTIFIER_WORKSPACE_ID_UNIQUE" ON "core"."application" ("universalIdentifier", "workspaceId") WHERE "deletedAt" IS NULL AND "universalIdentifier" IS NOT NULL`,
     );
   }
@@ -23,9 +20,6 @@ export class RenameApplicationStandardIdToUniversalIdentifier1759341429047
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
       `DROP INDEX "core"."IDX_APPLICATION_UNIVERSAL_IDENTIFIER_WORKSPACE_ID_UNIQUE"`,
-    );
-    await queryRunner.query(
-      `ALTER TABLE "core"."agent" DROP COLUMN "modelConfiguration"`,
     );
     await queryRunner.query(
       `ALTER TABLE "core"."application" RENAME COLUMN "universalIdentifier" TO "standardId"`,

--- a/packages/twenty-server/src/engine/core-modules/application/application-sync.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-sync.service.ts
@@ -3,21 +3,21 @@ import { Injectable, Logger } from '@nestjs/common';
 import { isDefined } from 'twenty-shared/utils';
 
 import {
-  AgentManifest,
-  ObjectManifest,
-} from 'src/engine/core-modules/application/types/application.types';
-import { ApplicationService } from 'src/engine/core-modules/application/application.service';
-import { WorkspaceManyOrAllFlatEntityMapsCacheService } from 'src/engine/core-modules/common/services/workspace-many-or-all-flat-entity-maps-cache.service.';
-import type { FlatObjectMetadataWithFlatFieldMaps } from 'src/engine/metadata-modules/flat-object-metadata-maps/types/flat-object-metadata-with-flat-field-metadata-maps.type';
-import { ObjectMetadataServiceV2 } from 'src/engine/metadata-modules/object-metadata/object-metadata-v2.service';
-import { DataSourceService } from 'src/engine/metadata-modules/data-source/data-source.service';
-import { AgentService } from 'src/engine/metadata-modules/agent/agent.service';
-import {
   ApplicationException,
   ApplicationExceptionCode,
 } from 'src/engine/core-modules/application/application.exception';
-import { ServerlessFunctionLayerService } from 'src/engine/metadata-modules/serverless-function-layer/serverless-function-layer.service';
+import { ApplicationService } from 'src/engine/core-modules/application/application.service';
 import { ApplicationInput } from 'src/engine/core-modules/application/dtos/application.input';
+import {
+  AgentManifest,
+  ObjectManifest,
+} from 'src/engine/core-modules/application/types/application.types';
+import { WorkspaceManyOrAllFlatEntityMapsCacheService } from 'src/engine/core-modules/common/services/workspace-many-or-all-flat-entity-maps-cache.service.';
+import { AgentService } from 'src/engine/metadata-modules/agent/agent.service';
+import { DataSourceService } from 'src/engine/metadata-modules/data-source/data-source.service';
+import type { FlatObjectMetadataWithFlatFieldMaps } from 'src/engine/metadata-modules/flat-object-metadata-maps/types/flat-object-metadata-with-flat-field-metadata-maps.type';
+import { ObjectMetadataServiceV2 } from 'src/engine/metadata-modules/object-metadata/object-metadata-v2.service';
+import { ServerlessFunctionLayerService } from 'src/engine/metadata-modules/serverless-function-layer/serverless-function-layer.service';
 
 @Injectable()
 export class ApplicationSyncService {
@@ -70,7 +70,7 @@ export class ApplicationSyncService {
   }: ApplicationInput & {
     workspaceId: string;
   }): Promise<string> {
-    const application = await this.applicationService.findByStandardId(
+    const application = await this.applicationService.findByUniversalIdentifier(
       manifest.standardId,
       workspaceId,
     );
@@ -85,7 +85,7 @@ export class ApplicationSyncService {
           workspaceId,
         );
       const createdApplication = await this.applicationService.create({
-        standardId: manifest.standardId,
+        universalIdentifier: manifest.universalIdentifier,
         label: manifest.label,
         description: manifest.description,
         version: manifest.version,

--- a/packages/twenty-server/src/engine/core-modules/application/application-sync.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-sync.service.ts
@@ -85,7 +85,7 @@ export class ApplicationSyncService {
           workspaceId,
         );
       const createdApplication = await this.applicationService.create({
-        universalIdentifier: manifest.universalIdentifier,
+        universalIdentifier: manifest.standardId,
         label: manifest.label,
         description: manifest.description,
         version: manifest.version,

--- a/packages/twenty-server/src/engine/core-modules/application/application.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application.entity.ts
@@ -15,18 +15,18 @@ import {
 
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AgentEntity } from 'src/engine/metadata-modules/agent/agent.entity';
-import { ServerlessFunctionEntity } from 'src/engine/metadata-modules/serverless-function/serverless-function.entity';
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 import { ServerlessFunctionLayerEntity } from 'src/engine/metadata-modules/serverless-function-layer/serverless-function-layer.entity';
+import { ServerlessFunctionEntity } from 'src/engine/metadata-modules/serverless-function/serverless-function.entity';
 
 @Entity({ name: 'application', schema: 'core' })
 @Index('IDX_APPLICATION_WORKSPACE_ID', ['workspaceId'])
 @Index(
-  'IDX_APPLICATION_STANDARD_ID_WORKSPACE_ID_UNIQUE',
-  ['standardId', 'workspaceId'],
+  'IDX_APPLICATION_UNIVERSAL_IDENTIFIER_WORKSPACE_ID_UNIQUE',
+  ['universalIdentifier', 'workspaceId'],
   {
     unique: true,
-    where: '"deletedAt" IS NULL AND "standardId" IS NOT NULL',
+    where: '"deletedAt" IS NULL AND "universalIdentifier" IS NOT NULL',
   },
 )
 export class ApplicationEntity {
@@ -34,7 +34,7 @@ export class ApplicationEntity {
   id: string;
 
   @Column({ nullable: true, type: 'uuid' })
-  standardId?: string;
+  universalIdentifier?: string;
 
   @Column({ nullable: false, type: 'text' })
   label: string;

--- a/packages/twenty-server/src/engine/core-modules/application/application.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application.service.ts
@@ -19,10 +19,13 @@ export class ApplicationService {
     });
   }
 
-  async findByStandardId(standardId: string, workspaceId: string) {
+  async findByUniversalIdentifier(
+    universalIdentifier: string,
+    workspaceId: string,
+  ) {
     return this.applicationRepository.findOne({
       where: {
-        standardId,
+        universalIdentifier,
         workspaceId,
       },
     });

--- a/packages/twenty-server/src/engine/core-modules/application/application.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application.service.ts
@@ -32,7 +32,7 @@ export class ApplicationService {
   }
 
   async create(data: {
-    standardId?: string;
+    universalIdentifier?: string;
     label: string;
     description?: string;
     version?: string;


### PR DESCRIPTION
## Context
Rename standardId in application table to universalIdentifier to align with the rest of migration v2 guidelines