### PR TITLE
Search record schema migration breaks following workflow steps

### DIFF
--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/filter-action/components/WorkflowDropdownStepOutputItems.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/filter-action/components/WorkflowDropdownStepOutputItems.tsx
@@ -229,28 +229,34 @@ export const WorkflowDropdownStepOutputItems = ({
         {filteredOptions.length > 0 && shouldDisplaySubStepObject && (
           <DropdownMenuSeparator />
         )}
-        {filteredOptions.map(([key, subStep]) => (
-          <MenuItemSelect
-            key={key}
-            selected={false}
-            focused={false}
-            onClick={() => handleSelectField(key)}
-            text={subStep.label || key}
-            hasSubMenu={!subStep.isLeaf}
-            LeftIcon={
-              subStep.icon
-                ? getIcon(subStep.icon)
-                : getIcon(
-                    getStepItemIcon({
-                      itemType: subStep.type,
-                    }),
-                  )
-            }
-            contextualText={
-              subStep.isLeaf ? subStep?.value?.toString() : undefined
-            }
-          />
-        ))}
+        {filteredOptions.map(([key, subStep]) => {
+          if (!isDefined(subStep)) {
+            return null;
+          }
+
+          return (
+            <MenuItemSelect
+              key={key}
+              selected={false}
+              focused={false}
+              onClick={() => handleSelectField(key)}
+              text={subStep.label || key}
+              hasSubMenu={!subStep.isLeaf}
+              LeftIcon={
+                subStep.icon
+                  ? getIcon(subStep.icon)
+                  : getIcon(
+                      getStepItemIcon({
+                        itemType: subStep.type,
+                      }),
+                    )
+              }
+              contextualText={
+                subStep.isLeaf ? subStep?.value?.toString() : undefined
+              }
+            />
+          );
+        })}
       </DropdownMenuItemsContainer>
     </DropdownContent>
   );

--- a/packages/twenty-front/src/modules/workflow/workflow-variables/components/WorkflowVariablesDropdownStepItems.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-variables/components/WorkflowVariablesDropdownStepItems.tsx
@@ -136,28 +136,34 @@ export const WorkflowVariablesDropdownStepItems = ({
         {filteredOptions.length > 0 && shouldDisplaySubStepObject && (
           <DropdownMenuSeparator />
         )}
-        {filteredOptions.map(([key, subStep]) => (
-          <MenuItemSelect
-            key={key}
-            selected={false}
-            focused={false}
-            onClick={() => handleSelectField(key)}
-            text={subStep.label || key}
-            hasSubMenu={!subStep.isLeaf}
-            LeftIcon={
-              subStep.icon
-                ? getIcon(subStep.icon)
-                : getIcon(
-                    getStepItemIcon({
-                      itemType: subStep.type,
-                    }),
-                  )
-            }
-            contextualText={
-              subStep.isLeaf ? subStep?.value?.toString() : undefined
-            }
-          />
-        ))}
+        {filteredOptions.map(([key, subStep]) => {
+          if (!isDefined(subStep)) {
+            return null;
+          }
+
+          return (
+            <MenuItemSelect
+              key={key}
+              selected={false}
+              focused={false}
+              onClick={() => handleSelectField(key)}
+              text={subStep.label || key}
+              hasSubMenu={!subStep.isLeaf}
+              LeftIcon={
+                subStep.icon
+                  ? getIcon(subStep.icon)
+                  : getIcon(
+                      getStepItemIcon({
+                        itemType: subStep.type,
+                      }),
+                    )
+              }
+              contextualText={
+                subStep.isLeaf ? subStep?.value?.toString() : undefined
+              }
+            />
+          );
+        })}
       </DropdownMenuItemsContainer>
     </DropdownContent>
   );

--- a/packages/twenty-front/src/modules/workflow/workflow-variables/utils/filterOutputSchema.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-variables/utils/filterOutputSchema.ts
@@ -104,6 +104,10 @@ const filterBaseOutputSchema = ({
   for (const key in outputSchema) {
     const field = outputSchema[key];
 
+    if (!isDefined(field)) {
+      continue;
+    }
+
     if (field.isLeaf) {
       if (isFieldTypeCompatibleWithRecordId(field.type)) {
         filteredSchema[key] = field;


### PR DESCRIPTION
If iterator loop feature flag is not enabled, `all` field in undefined in search record schema. We need to handle that case properly.