### PR TITLE
website(releases): fix MDX content list to match visible releases (fix offset)

### DIFF
--- a/packages/twenty-website/src/app/(public)/releases/page.tsx
+++ b/packages/twenty-website/src/app/(public)/releases/page.tsx
@@ -35,7 +35,7 @@ const Home = async () => {
     latestGithubRelease?.tagName || 'v0.0.0',
   );
 
-  const mdxReleasesContent = await getMdxReleasesContent(releaseNotes);
+  const mdxReleasesContent = await getMdxReleasesContent(visibleReleasesNotes);
 
   return (
     <ContentContainer>


### PR DESCRIPTION
# Current behavior

1.7.0 is displayed as 1.6.0

<img width="1303" height="1082" alt="CleanShot 2025-10-06 at 11 23 38" src="https://github.com/user-attachments/assets/a502aeec-eafc-4db9-bd04-0969a00ca474" />

# Fix

Fixes an off-by-one mismatch between rendered releases and compiled MDX content by generating MDX from the filtered visible releases list. This ensures versions like 0.2.3, 0.3.0, ... display the correct content.
