### PR TITLE
Prevent querying too much on worklow index page

### DIFF
--- a/packages/twenty-front/src/modules/object-record/graphql/utils/generateDepthOneRecordGqlFields.ts
+++ b/packages/twenty-front/src/modules/object-record/graphql/utils/generateDepthOneRecordGqlFields.ts
@@ -1,3 +1,4 @@
+import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
 import { type ObjectMetadataItem } from '@/object-metadata/types/ObjectMetadataItem';
 import { isDefined } from 'twenty-shared/utils';
 
@@ -17,7 +18,17 @@ export const generateDepthOneRecordGqlFields = ({
               [field.settings.joinColumnName]: true,
             }
           : {}),
-        [field.name]: true,
+        [field.name]:
+          // TODO: Remove once we have made the workflows lighter
+          (objectMetadataItem.nameSingular ===
+            CoreObjectNameSingular.Workflow ||
+            objectMetadataItem.nameSingular ===
+              CoreObjectNameSingular.WorkflowVersion ||
+            objectMetadataItem.nameSingular ===
+              CoreObjectNameSingular.WorkflowRun) &&
+          (field.name === 'versions' || field.name === 'runs')
+            ? { id: true, name: true }
+            : true,
       };
     },
     {},

--- a/packages/twenty-front/src/modules/object-record/record-calendar/components/RecordIndexCalendarDataLoaderEffect.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/components/RecordIndexCalendarDataLoaderEffect.tsx
@@ -3,7 +3,7 @@ import { useFindManyRecords } from '@/object-record/hooks/useFindManyRecords';
 import { useRecordCalendarContextOrThrow } from '@/object-record/record-calendar/contexts/RecordCalendarContext';
 import { RecordCalendarComponentInstanceContext } from '@/object-record/record-calendar/states/contexts/RecordCalendarComponentInstanceContext';
 import { recordCalendarSelectedRecordIdsComponentSelector } from '@/object-record/record-calendar/states/selectors/recordCalendarSelectedRecordIdsComponentSelector';
-import { useRecordFieldGqlFields } from '@/object-record/record-field/hooks/useRecordTableRecordGqlFields';
+import { useRecordFieldGqlFields } from '@/object-record/record-field/hooks/useRecordFieldGqlFields';
 import { useFindManyRecordIndexTableParams } from '@/object-record/record-index/hooks/useFindManyRecordIndexTableParams';
 import { recordIndexAllRecordIdsComponentSelector } from '@/object-record/record-index/states/selectors/recordIndexAllRecordIdsComponentSelector';
 import { useUpsertRecordsInStore } from '@/object-record/record-store/hooks/useUpsertRecordsInStore';

--- a/packages/twenty-front/src/modules/object-record/record-field/hooks/useRecordFieldGqlFields.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/hooks/useRecordFieldGqlFields.ts
@@ -2,6 +2,7 @@ import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadata
 import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
 import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
 import { type ObjectMetadataItem } from '@/object-metadata/types/ObjectMetadataItem';
+import { type RecordGqlFields } from '@/object-record/graphql/types/RecordGqlFields';
 import { generateDepthOneRecordGqlFields } from '@/object-record/graphql/utils/generateDepthOneRecordGqlFields';
 import { generateDepthOneWithoutRelationsRecordGqlFields } from '@/object-record/graphql/utils/generateDepthOneWithoutRelationsRecordGqlFields';
 import { visibleRecordFieldsComponentSelector } from '@/object-record/record-field/states/visibleRecordFieldsComponentSelector';
@@ -37,38 +38,47 @@ export const useRecordFieldGqlFields = ({
       objectMetadataItem,
     });
 
-  const gqlFieldsList = Object.fromEntries(
-    visibleRecordFields.flatMap((recordField) => {
-      const fieldMetadataItem: FieldMetadataItem | undefined =
-        fieldMetadataItemByFieldMetadataItemId[recordField.fieldMetadataItemId];
+  const gqlFieldsList: RecordGqlFields = Object.fromEntries(
+    visibleRecordFields.flatMap(
+      (recordField): [string, boolean | RecordGqlFields][] => {
+        const fieldMetadataItem: FieldMetadataItem | undefined =
+          fieldMetadataItemByFieldMetadataItemId[
+            recordField.fieldMetadataItemId
+          ];
 
-      if (!isDefined(fieldMetadataItem)) {
-        throw new Error(
-          `Field ${recordField.fieldMetadataItemId} is missing, please refresh the page. If the problem persists, please contact support.`,
-        );
-      }
+        // TODO: remove this once we have made the workflowVersion lighter
+        if (fieldMetadataItem.name === 'workflowVersion') {
+          return [[fieldMetadataItem.name, { id: true, name: true }]];
+        }
 
-      const isMorphRelation =
-        fieldMetadataItem.type === FieldMetadataType.MORPH_RELATION;
+        if (!isDefined(fieldMetadataItem)) {
+          throw new Error(
+            `Field ${recordField.fieldMetadataItemId} is missing, please refresh the page. If the problem persists, please contact support.`,
+          );
+        }
 
-      if (!isMorphRelation) {
-        return [[fieldMetadataItem.name, true]];
-      }
+        const isMorphRelation =
+          fieldMetadataItem.type === FieldMetadataType.MORPH_RELATION;
 
-      if (!isDefined(fieldMetadataItem.morphRelations)) {
-        throw new Error(
-          `Field ${fieldMetadataItem.name} is missing, please refresh the page. If the problem persists, please contact support.`,
-        );
-      }
+        if (!isMorphRelation) {
+          return [[fieldMetadataItem.name, true]];
+        }
 
-      return fieldMetadataItem.morphRelations.map((morphRelation) => [
-        morphRelation.sourceFieldMetadata.name,
-        true,
-      ]);
-    }),
+        if (!isDefined(fieldMetadataItem.morphRelations)) {
+          throw new Error(
+            `Field ${fieldMetadataItem.name} is missing, please refresh the page. If the problem persists, please contact support.`,
+          );
+        }
+
+        return fieldMetadataItem.morphRelations.map((morphRelation) => [
+          morphRelation.sourceFieldMetadata.name,
+          true,
+        ]);
+      },
+    ),
   );
 
-  const recordGqlFields: Record<string, any> = {
+  return {
     ...allDepthOneWithoutRelationsRecordGqlFields,
     ...gqlFieldsList,
     noteTargets: generateDepthOneRecordGqlFields({
@@ -78,6 +88,4 @@ export const useRecordFieldGqlFields = ({
       objectMetadataItem: taskTargetObjectMetadataItem,
     }),
   };
-
-  return recordGqlFields;
 };

--- a/packages/twenty-front/src/modules/object-record/record-field/hooks/useRecordFieldGqlFields.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/hooks/useRecordFieldGqlFields.ts
@@ -46,18 +46,18 @@ export const useRecordFieldGqlFields = ({
             recordField.fieldMetadataItemId
           ];
 
+        if (!isDefined(fieldMetadataItem)) {
+          throw new Error(
+            `Field ${recordField.fieldMetadataItemId} is missing, please refresh the page. If the problem persists, please contact support.`,
+          );
+        }
+
         // TODO: remove this once we have made the workflowVersion lighter
         if (
           fieldMetadataItem.name === 'versions' ||
           fieldMetadataItem.name === 'workflowVersion'
         ) {
           return [[fieldMetadataItem.name, { id: true, name: true }]];
-        }
-
-        if (!isDefined(fieldMetadataItem)) {
-          throw new Error(
-            `Field ${recordField.fieldMetadataItemId} is missing, please refresh the page. If the problem persists, please contact support.`,
-          );
         }
 
         const isMorphRelation =

--- a/packages/twenty-front/src/modules/object-record/record-field/hooks/useRecordFieldGqlFields.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/hooks/useRecordFieldGqlFields.ts
@@ -47,7 +47,10 @@ export const useRecordFieldGqlFields = ({
           ];
 
         // TODO: remove this once we have made the workflowVersion lighter
-        if (fieldMetadataItem.name === 'workflowVersion') {
+        if (
+          fieldMetadataItem.name === 'versions' ||
+          fieldMetadataItem.name === 'workflowVersion'
+        ) {
           return [[fieldMetadataItem.name, { id: true, name: true }]];
         }
 

--- a/packages/twenty-front/src/modules/object-record/record-index/hooks/useRecordIndexTableFetchMore.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/hooks/useRecordIndexTableFetchMore.ts
@@ -1,6 +1,6 @@
 import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
 import { useLazyFindManyRecords } from '@/object-record/hooks/useLazyFindManyRecords';
-import { useRecordFieldGqlFields } from '@/object-record/record-field/hooks/useRecordTableRecordGqlFields';
+import { useRecordFieldGqlFields } from '@/object-record/record-field/hooks/useRecordFieldGqlFields';
 import { useFindManyRecordIndexTableParams } from '@/object-record/record-index/hooks/useFindManyRecordIndexTableParams';
 
 export const useRecordIndexTableFetchMore = (objectNameSingular: string) => {

--- a/packages/twenty-front/src/modules/object-record/record-index/hooks/useRecordIndexTableQuery.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/hooks/useRecordIndexTableQuery.ts
@@ -1,6 +1,6 @@
 import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
 import { useFindManyRecords } from '@/object-record/hooks/useFindManyRecords';
-import { useRecordFieldGqlFields } from '@/object-record/record-field/hooks/useRecordTableRecordGqlFields';
+import { useRecordFieldGqlFields } from '@/object-record/record-field/hooks/useRecordFieldGqlFields';
 import { useFindManyRecordIndexTableParams } from '@/object-record/record-index/hooks/useFindManyRecordIndexTableParams';
 import { SIGN_IN_BACKGROUND_MOCK_COMPANIES } from '@/sign-in-background-mock/constants/SignInBackgroundMockCompanies';
 import { useShowAuthModal } from '@/ui/layout/hooks/useShowAuthModal';

--- a/packages/twenty-front/src/modules/workflow/hooks/useActiveWorkflowVersionsWithManualTrigger.ts
+++ b/packages/twenty-front/src/modules/workflow/hooks/useActiveWorkflowVersionsWithManualTrigger.ts
@@ -53,7 +53,7 @@ export const useActiveWorkflowVersionsWithManualTrigger = ({
   const { records } = useFindManyRecords<
     Pick<
       ManualTriggerWorkflowVersion,
-      'id' | '__typename' | 'trigger' | 'status' | 'workflowId'
+      'id' | '__typename' | 'status' | 'workflowId' | 'trigger'
     > & {
       workflow: Workflow;
     }

--- a/packages/twenty-front/src/modules/workflow/hooks/useWorkflowWithCurrentVersion.ts
+++ b/packages/twenty-front/src/modules/workflow/hooks/useWorkflowWithCurrentVersion.ts
@@ -10,6 +10,7 @@ import { isDefined } from 'twenty-shared/utils';
 export const useWorkflowWithCurrentVersion = (
   workflowId: string | undefined,
 ): WorkflowWithCurrentVersion | undefined => {
+  // TODO: we should only load the data for the current version
   const { record: workflow } = useFindOneRecord<Workflow>({
     objectNameSingular: CoreObjectNameSingular.Workflow,
     objectRecordId: workflowId,


### PR DESCRIPTION
## Performance short term fix

Done in this PR:
workflowVersions and workflowRuns are heavy object. I'm preventing loading their data when they are loaded as relations. This will reduce the work on backend

## Long term fix

Todo:
We should make sure workflow data is ligher