### PR TITLE
Potential fix for code scanning alert no. 52: Incomplete string escaping or encoding

### DIFF
--- a/packages/twenty-server/src/engine/api/rest/input-factories/order-by-input.factory.ts
+++ b/packages/twenty-server/src/engine/api/rest/input-factories/order-by-input.factory.ts
@@ -38,7 +38,7 @@ export class OrderByInputFactory {
       // orderByItem -> field_1[AscNullsFirst]
       if (orderByItem.includes('[') && orderByItem.includes(']')) {
         const [fieldsString, direction] = orderByItem
-          .replace(']', '')
+          .replace(/\]/g, '')
           .split('[');
 
         // fields -> [field_1] ; direction -> AscNullsFirst


### PR DESCRIPTION
Potential fix for [https://github.com/twentyhq/twenty/security/code-scanning/52](https://github.com/twentyhq/twenty/security/code-scanning/52)

The problem is that `.replace(']', '')` only replaces the first occurrence of the `]` character. To comprehensively remove all instances of `]` from the string, use a regular expression with the global flag: `.replace(/\]/g, '')`. This change should be made on line 41 of the provided code, inside the `OrderByInputFactory.create` method. No imports are required for this fix, as the JavaScript String `.replace` method accepts regular expressions natively.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
