### PR TITLE
Potential fix for code scanning alert no. 173: Uncontrolled data used in path expression

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/file-storage/drivers/local.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/file-storage/drivers/local.driver.ts
@@ -83,17 +83,20 @@ export class LocalDriver implements StorageDriver {
       params.folderPath,
       params.filename,
     );
+    let filePath: string;
 
-    if (!existsSync(joinedPath)) {
+    try {
+      filePath = realpathSync(path.resolve(joinedPath));
+    } catch {
       throw new FileStorageException(
         'File not found',
         FileStorageExceptionCode.FILE_NOT_FOUND,
       );
     }
-
     const storageRoot = realpathSync(path.resolve(this.options.storagePath));
 
-    if (!joinedPath.startsWith(storageRoot + path.sep)) {
+    if (!filePath.startsWith(storageRoot + path.sep)) {
+      // Prevent directory traversal
       throw new FileStorageException(
         'Access denied',
         FileStorageExceptionCode.FILE_NOT_FOUND,
@@ -101,7 +104,7 @@ export class LocalDriver implements StorageDriver {
     }
 
     try {
-      return createReadStream(joinedPath);
+      return createReadStream(filePath);
     } catch (error) {
       if (error.code === 'ENOENT') {
         throw new FileStorageException(

--- a/packages/twenty-server/src/engine/core-modules/file-storage/drivers/local.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/file-storage/drivers/local.driver.ts
@@ -1,4 +1,4 @@
-import { createReadStream, existsSync } from 'fs';
+import { createReadStream, existsSync, realpathSync } from 'fs';
 import * as fs from 'fs/promises';
 import path, { dirname, join } from 'path';
 import { type Readable } from 'stream';
@@ -78,11 +78,28 @@ export class LocalDriver implements StorageDriver {
     folderPath: string;
     filename: string;
   }): Promise<Readable> {
-    const filePath = join(
+    const joinedPath = join(
       `${this.options.storagePath}/`,
       params.folderPath,
       params.filename,
     );
+    let filePath: string;
+    try {
+      filePath = realpathSync(path.resolve(joinedPath));
+    } catch (err) {
+      throw new FileStorageException(
+        'File not found',
+        FileStorageExceptionCode.FILE_NOT_FOUND,
+      );
+    }
+    const storageRoot = realpathSync(path.resolve(this.options.storagePath));
+    if (!filePath.startsWith(storageRoot + path.sep)) {
+      // Prevent directory traversal
+      throw new FileStorageException(
+        'Access denied',
+        FileStorageExceptionCode.FILE_NOT_FOUND,
+      );
+    }
 
     if (!existsSync(filePath)) {
       throw new FileStorageException(

--- a/packages/twenty-server/src/engine/core-modules/file-storage/drivers/local.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/file-storage/drivers/local.driver.ts
@@ -83,33 +83,25 @@ export class LocalDriver implements StorageDriver {
       params.folderPath,
       params.filename,
     );
-    let filePath: string;
-    try {
-      filePath = realpathSync(path.resolve(joinedPath));
-    } catch (err) {
+
+    if (!existsSync(joinedPath)) {
       throw new FileStorageException(
         'File not found',
         FileStorageExceptionCode.FILE_NOT_FOUND,
       );
     }
+
     const storageRoot = realpathSync(path.resolve(this.options.storagePath));
-    if (!filePath.startsWith(storageRoot + path.sep)) {
-      // Prevent directory traversal
+
+    if (!joinedPath.startsWith(storageRoot + path.sep)) {
       throw new FileStorageException(
         'Access denied',
         FileStorageExceptionCode.FILE_NOT_FOUND,
       );
     }
 
-    if (!existsSync(filePath)) {
-      throw new FileStorageException(
-        'File not found',
-        FileStorageExceptionCode.FILE_NOT_FOUND,
-      );
-    }
-
     try {
-      return createReadStream(filePath);
+      return createReadStream(joinedPath);
     } catch (error) {
       if (error.code === 'ENOENT') {
         throw new FileStorageException(


### PR DESCRIPTION
Potential fix for [https://github.com/twentyhq/twenty/security/code-scanning/173](https://github.com/twentyhq/twenty/security/code-scanning/173)

To fix this vulnerability, ensure that any file path constructed from untrusted user input is strictly confined to the intended storage directory. This is best done through path normalization and validation. Before reading the file, the following steps should be taken:
1. **Resolve the file path**: Use `path.resolve` to normalize the resulting path, removing any ".." segments or symbolic links.
2. **Check the parent directory**: Ensure that the resolved path starts with the intended storage directory (`this.options.storagePath`).
3. **Throw an exception**: If the resolved path does not start with the storage root, throw an exception or otherwise deny the operation.

This check should be placed in all methods that build a file path from user input in `local.driver.ts`, with at least the `read` method addressed. The index for this fix will be on lines that construct and use `filePath`, specifically in the `read` method.

You will need to:
- Import `realpathSync` from `fs` (standard library).
- Add safe path resolution and containment check around file access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
