### PR TITLE
Make entire first cell clickable

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-header/components/RecordTableHeaderFirstCell.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-header/components/RecordTableHeaderFirstCell.tsx
@@ -7,6 +7,7 @@ import { RecordTableHeaderResizeHandler } from '@/object-record/record-table/rec
 import { RecordTableHeaderCellContainer } from '@/object-record/record-table/record-table-header/components/RecordTableHeaderCellContainer';
 
 import { hasRecordGroupsComponentSelector } from '@/object-record/record-group/states/selectors/hasRecordGroupsComponentSelector';
+import { TABLE_Z_INDEX } from '@/object-record/record-table/constants/TableZIndex';
 import { RecordTableHeaderLabelIdentifierCellPlusButton } from '@/object-record/record-table/record-table-header/components/RecordTableHeaderLabelIdentifierCellPlusButton';
 import { getVisibleFieldWithLowestPosition } from '@/object-record/record-table/record-table-header/utils/getVisibleFieldWithLowestPosition.util';
 import { isRecordTableRowActiveComponentFamilyState } from '@/object-record/record-table/states/isRecordTableRowActiveComponentFamilyState';
@@ -25,7 +26,7 @@ const StyledPlusButtonWrapper = styled.div`
   position: absolute;
   top: 0;
   right: 0;
-  z-index: 2;
+  z-index: ${TABLE_Z_INDEX.headerColumns.withoutGroups.headerColumnsSticky};
 `;
 
 export const RecordTableHeaderFirstCell = () => {

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-header/components/RecordTableHeaderFirstCell.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-header/components/RecordTableHeaderFirstCell.tsx
@@ -21,13 +21,11 @@ import { cx } from '@linaria/core';
 import { useState } from 'react';
 import { isDefined } from 'twenty-shared/utils';
 
-const StyledColumnHeadContainer = styled.div`
-  cursor: pointer;
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-
-  overflow: hidden;
+const StyledPlusButtonWrapper = styled.div`
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 2;
 `;
 
 export const RecordTableHeaderFirstCell = () => {
@@ -85,13 +83,16 @@ export const RecordTableHeaderFirstCell = () => {
       shouldDisplayBorderBottom={shouldDisplayBorderBottom}
       isResizing={isResizingAnyColumn}
     >
-      <StyledColumnHeadContainer>
-        <RecordTableColumnHeadWithDropdown
-          recordField={recordField}
-          objectMetadataId={objectMetadataItem.id}
-        />
-        {iconIsVisible && <RecordTableHeaderLabelIdentifierCellPlusButton />}
-      </StyledColumnHeadContainer>
+      <RecordTableColumnHeadWithDropdown
+        recordField={recordField}
+        objectMetadataId={objectMetadataItem.id}
+      />
+      {iconIsVisible && (
+        <StyledPlusButtonWrapper>
+          <RecordTableHeaderLabelIdentifierCellPlusButton />
+        </StyledPlusButtonWrapper>
+      )}
+
       <RecordTableHeaderResizeHandler recordFieldIndex={0} position="right" />
     </RecordTableHeaderCellContainer>
   );


### PR DESCRIPTION
Solution: 
I removed the specific layout of the first cell that was reducing the clickable area to make room for the “+” button.
Instead, I added a layout to the button, so it’s position absolute, allowing the clickable area to cover 100% of the cell while keeping the button above it.
Another possible solution would be to modify `RecordTableColumnHeadWithDropdown` to include the button inside...

- Manual test: [Loom](https://www.loom.com/share/4ceb4daa07e5457a99a07a2489db2960?sid=15959502-e272-44bd-923a-5764d077642d)
- Issue: https://github.com/twentyhq/twenty/issues/14900
