### PR TITLE
Fix app deletion missing cache invalidation

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/application/application.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application.service.ts
@@ -1,17 +1,19 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
-import { Repository } from 'typeorm';
 import { isDefined } from 'twenty-shared/utils';
+import { Repository } from 'typeorm';
 
 import { ApplicationEntity } from 'src/engine/core-modules/application/application.entity';
 import { PackageJson } from 'src/engine/core-modules/application/types/application.types';
+import { WorkspaceManyOrAllFlatEntityMapsCacheService } from 'src/engine/core-modules/common/services/workspace-many-or-all-flat-entity-maps-cache.service';
 
 @Injectable()
 export class ApplicationService {
   constructor(
     @InjectRepository(ApplicationEntity)
     private readonly applicationRepository: Repository<ApplicationEntity>,
+    private readonly flatEntityMapsCacheService: WorkspaceManyOrAllFlatEntityMapsCacheService,
   ) {}
 
   async findById(id: string): Promise<ApplicationEntity | null> {
@@ -84,6 +86,10 @@ export class ApplicationService {
 
     await this.applicationRepository.delete({
       universalIdentifier,
+      workspaceId,
+    });
+
+    await this.flatEntityMapsCacheService.invalidateFlatEntityMaps({
       workspaceId,
     });
   }


### PR DESCRIPTION
App deletion currently deletes all related entities through postgres cascade delete meaning we never run actual migrations ourself and never trigger cache invalidation (part of migration engine)