### PR TITLE
Darker Dropdown for Improved Visibility

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/overlay/components/OverlayContainer.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/overlay/components/OverlayContainer.tsx
@@ -7,13 +7,13 @@ export const OverlayContainer = styled.div<{
 }>`
   align-items: center;
   display: flex;
-
+  background: rgba(0,0,0,0.8);
   backdrop-filter: ${({ theme }) => theme.blur.medium};
 
   border-radius: ${({ theme, borderRadius }) =>
     theme.border.radius[borderRadius ?? 'md']};
 
-  background: ${({ theme }) => theme.background.transparent.primary};
+ //background: ${({ theme }) => theme.background.transparent.primary};
   border: 1px solid
     ${({ theme, hasDangerBorder }) =>
       theme.border.color[hasDangerBorder ? 'danger' : 'medium']};


### PR DESCRIPTION
This is just a simple fix. Since text readability was low due to the background blur effect, I manually made the background of the dropdown darker, which should help readability across both light and dark mode.

Fixes #14700 