### PR TITLE
Fix RelationToOneSection assignment bug

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSectionDropdownToOne.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSectionDropdownToOne.tsx
@@ -84,7 +84,7 @@ export const RecordDetailRelationSectionDropdownToOne = () => {
     if (!selectedMorphItem?.recordId || !relationFieldMetadataItem?.name)
       return;
 
-    onSubmit?.({ newValue: selectedMorphItem.recordId });
+    onSubmit?.({ newValue: { id: selectedMorphItem.recordId } });
   };
 
   const { createNewRecordAndOpenRightDrawer } =


### PR DESCRIPTION
While refactoring SingleRecordPicker to support morph use case, we forgot to QA RelationDetailSection for ManyToOne.