### PR TITLE
Fix circular dependency at shared package building

### DIFF
--- a/packages/twenty-shared/src/utils/filter/computeRecordGqlOperationFilter.ts
+++ b/packages/twenty-shared/src/utils/filter/computeRecordGqlOperationFilter.ts
@@ -4,12 +4,12 @@ import {
   type RecordGqlOperationFilter,
 } from '@/types';
 import {
-  isDefined,
   turnRecordFilterGroupsIntoGqlOperationFilter,
-  turnRecordFilterIntoRecordGqlOperationFilter,
   type RecordFilter,
   type RecordFilterGroup,
-} from '@/utils';
+} from '@/utils/filter/turnRecordFilterGroupIntoGqlOperationFilter';
+import { turnRecordFilterIntoRecordGqlOperationFilter } from '@/utils/filter/turnRecordFilterIntoGqlOperationFilter';
+import { isDefined } from '@/utils/validation/isDefined';
 
 export const computeRecordGqlOperationFilter = ({
   fields,


### PR DESCRIPTION
Fixing 
<img width="708" height="271" alt="Capture d’écran 2025-10-08 à 12 27 12" src="https://github.com/user-attachments/assets/2f459e2f-146b-4452-8517-59f58b8a33a4" />

The circular-chunk warning came from computeRecordGqlOperationFilter.ts importing from the barrel @/utils, which reexports turnRecordFilterIntoRecordGqlOperationFilter and friends, creating a re-export cycle across chunks.
