### PR TITLE
Enable filters in iterators

### DIFF
--- a/packages/twenty-server/src/modules/workflow/workflow-executor/types/workflow-action-output.type.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/types/workflow-action-output.type.ts
@@ -4,4 +4,5 @@ export type WorkflowActionOutput = {
   pendingEvent?: boolean;
   shouldEndWorkflowRun?: boolean;
   shouldRemainRunning?: boolean;
+  shouldSkipStepExecution?: boolean;
 };

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/utils/__tests__/should-execute-step.util.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/utils/__tests__/should-execute-step.util.spec.ts
@@ -1,13 +1,13 @@
 import { StepStatus } from 'twenty-shared/workflow';
 
+import { WorkflowRunStatus } from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
+import { shouldExecuteStep } from 'src/modules/workflow/workflow-executor/utils/should-execute-step.util';
 import {
   type WorkflowAction,
   WorkflowActionType,
 } from 'src/modules/workflow/workflow-executor/workflow-actions/types/workflow-action.type';
-import { canExecuteStep } from 'src/modules/workflow/workflow-executor/utils/can-execute-step.util';
-import { WorkflowRunStatus } from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
 
-describe('canExecuteStep', () => {
+describe('shouldExecuteStep', () => {
   const steps = [
     {
       id: 'step-1',
@@ -57,10 +57,10 @@ describe('canExecuteStep', () => {
       },
     };
 
-    const result = canExecuteStep({
+    const result = shouldExecuteStep({
       stepInfos,
       steps,
-      stepId: 'step-3',
+      step: steps[2],
       workflowRunStatus: WorkflowRunStatus.RUNNING,
     });
 
@@ -69,7 +69,7 @@ describe('canExecuteStep', () => {
 
   it('should return false if one parent is not succeeded', () => {
     expect(
-      canExecuteStep({
+      shouldExecuteStep({
         stepInfos: {
           'step-1': {
             status: StepStatus.NOT_STARTED,
@@ -82,13 +82,13 @@ describe('canExecuteStep', () => {
           },
         },
         steps,
-        stepId: 'step-3',
+        step: steps[2],
         workflowRunStatus: WorkflowRunStatus.RUNNING,
       }),
     ).toBe(false);
 
     expect(
-      canExecuteStep({
+      shouldExecuteStep({
         stepInfos: {
           'step-1': {
             status: StepStatus.SUCCESS,
@@ -101,13 +101,13 @@ describe('canExecuteStep', () => {
           },
         },
         steps,
-        stepId: 'step-3',
+        step: steps[2],
         workflowRunStatus: WorkflowRunStatus.RUNNING,
       }),
     ).toBe(false);
 
     expect(
-      canExecuteStep({
+      shouldExecuteStep({
         stepInfos: {
           'step-1': {
             status: StepStatus.NOT_STARTED,
@@ -120,7 +120,7 @@ describe('canExecuteStep', () => {
           },
         },
         steps,
-        stepId: 'step-3',
+        step: steps[2],
         workflowRunStatus: WorkflowRunStatus.RUNNING,
       }),
     ).toBe(false);
@@ -128,7 +128,7 @@ describe('canExecuteStep', () => {
 
   it('should return false if step has already ran', () => {
     expect(
-      canExecuteStep({
+      shouldExecuteStep({
         stepInfos: {
           'step-1': {
             status: StepStatus.SUCCESS,
@@ -141,13 +141,13 @@ describe('canExecuteStep', () => {
           },
         },
         steps,
-        stepId: 'step-3',
+        step: steps[2],
         workflowRunStatus: WorkflowRunStatus.RUNNING,
       }),
     ).toBe(false);
 
     expect(
-      canExecuteStep({
+      shouldExecuteStep({
         stepInfos: {
           'step-1': {
             status: StepStatus.SUCCESS,
@@ -160,13 +160,13 @@ describe('canExecuteStep', () => {
           },
         },
         steps,
-        stepId: 'step-3',
+        step: steps[2],
         workflowRunStatus: WorkflowRunStatus.RUNNING,
       }),
     ).toBe(false);
 
     expect(
-      canExecuteStep({
+      shouldExecuteStep({
         stepInfos: {
           'step-1': {
             status: StepStatus.SUCCESS,
@@ -179,13 +179,13 @@ describe('canExecuteStep', () => {
           },
         },
         steps,
-        stepId: 'step-3',
+        step: steps[2],
         workflowRunStatus: WorkflowRunStatus.RUNNING,
       }),
     ).toBe(false);
 
     expect(
-      canExecuteStep({
+      shouldExecuteStep({
         stepInfos: {
           'step-1': {
             status: StepStatus.SUCCESS,
@@ -198,7 +198,7 @@ describe('canExecuteStep', () => {
           },
         },
         steps,
-        stepId: 'step-3',
+        step: steps[2],
         workflowRunStatus: WorkflowRunStatus.RUNNING,
       }),
     ).toBe(false);
@@ -223,10 +223,10 @@ describe('canExecuteStep', () => {
       WorkflowRunStatus.COMPLETED,
       WorkflowRunStatus.NOT_STARTED,
     ]) {
-      const result = canExecuteStep({
+      const result = shouldExecuteStep({
         stepInfos,
         steps,
-        stepId: 'step-3',
+        step: steps[2],
         workflowRunStatus,
       });
 

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/utils/__tests__/should-execute-step.util.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/utils/__tests__/should-execute-step.util.spec.ts
@@ -233,4 +233,238 @@ describe('shouldExecuteStep', () => {
       expect(result).toBe(false);
     }
   });
+
+  it('should return true when step has no parent steps', () => {
+    const stepsWithoutParents = [
+      {
+        id: 'step-1',
+        name: 'Mock Step',
+        type: WorkflowActionType.CODE,
+        settings: {
+          input: {
+            serverlessFunctionId: 'mock-function-id',
+            serverlessFunctionVersion: 'mock-function-version',
+            serverlessFunctionInput: {},
+          },
+          errorHandlingOptions: {
+            continueOnFailure: { value: false },
+            retryOnFailure: { value: false },
+          },
+          outputSchema: {},
+        },
+        valid: true,
+        nextStepIds: [],
+      },
+    ] as WorkflowAction[];
+
+    const stepInfos = {
+      'step-1': {
+        status: StepStatus.NOT_STARTED,
+      },
+    };
+
+    const result = shouldExecuteStep({
+      stepInfos,
+      steps: stepsWithoutParents,
+      step: stepsWithoutParents[0],
+      workflowRunStatus: WorkflowRunStatus.RUNNING,
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('should return false when one parent is RUNNING', () => {
+    const result = shouldExecuteStep({
+      stepInfos: {
+        'step-1': {
+          status: StepStatus.SUCCESS,
+        },
+        'step-2': {
+          status: StepStatus.RUNNING,
+        },
+        'step-3': {
+          status: StepStatus.NOT_STARTED,
+        },
+      },
+      steps,
+      step: steps[2],
+      workflowRunStatus: WorkflowRunStatus.RUNNING,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('should handle undefined parent steps gracefully', () => {
+    const stepsWithUndefined = [
+      {
+        id: 'step-1',
+        type: WorkflowActionType.CODE,
+        settings: {
+          errorHandlingOptions: {
+            continueOnFailure: { value: false },
+            retryOnFailure: { value: false },
+          },
+        },
+        nextStepIds: ['step-3'],
+      },
+      undefined as unknown as WorkflowAction,
+      {
+        id: 'step-3',
+        type: WorkflowActionType.SEND_EMAIL,
+        settings: {
+          errorHandlingOptions: {
+            continueOnFailure: { value: false },
+            retryOnFailure: { value: false },
+          },
+        },
+        nextStepIds: [],
+      },
+    ] as WorkflowAction[];
+
+    const stepInfos = {
+      'step-1': {
+        status: StepStatus.SUCCESS,
+      },
+      'step-3': {
+        status: StepStatus.NOT_STARTED,
+      },
+    };
+
+    const result = shouldExecuteStep({
+      stepInfos,
+      steps: stepsWithUndefined,
+      step: stepsWithUndefined[2],
+      workflowRunStatus: WorkflowRunStatus.RUNNING,
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('should return false when at least one parent is FAILED', () => {
+    const result = shouldExecuteStep({
+      stepInfos: {
+        'step-1': {
+          status: StepStatus.SUCCESS,
+        },
+        'step-2': {
+          status: StepStatus.FAILED,
+        },
+        'step-3': {
+          status: StepStatus.NOT_STARTED,
+        },
+      },
+      steps,
+      step: steps[2],
+      workflowRunStatus: WorkflowRunStatus.RUNNING,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('should work correctly with multiple successful parents', () => {
+    const multiParentSteps = [
+      {
+        id: 'step-1',
+        type: WorkflowActionType.CODE,
+        settings: {
+          errorHandlingOptions: {
+            continueOnFailure: { value: false },
+            retryOnFailure: { value: false },
+          },
+        },
+        nextStepIds: ['step-4'],
+      },
+      {
+        id: 'step-2',
+        type: WorkflowActionType.SEND_EMAIL,
+        settings: {
+          errorHandlingOptions: {
+            continueOnFailure: { value: false },
+            retryOnFailure: { value: false },
+          },
+        },
+        nextStepIds: ['step-4'],
+      },
+      {
+        id: 'step-3',
+        type: WorkflowActionType.CODE,
+        settings: {
+          errorHandlingOptions: {
+            continueOnFailure: { value: false },
+            retryOnFailure: { value: false },
+          },
+        },
+        nextStepIds: ['step-4'],
+      },
+      {
+        id: 'step-4',
+        type: WorkflowActionType.SEND_EMAIL,
+        settings: {
+          errorHandlingOptions: {
+            continueOnFailure: { value: false },
+            retryOnFailure: { value: false },
+          },
+        },
+        nextStepIds: [],
+      },
+    ] as WorkflowAction[];
+
+    const stepInfos = {
+      'step-1': { status: StepStatus.SUCCESS },
+      'step-2': { status: StepStatus.SUCCESS },
+      'step-3': { status: StepStatus.SUCCESS },
+      'step-4': { status: StepStatus.NOT_STARTED },
+    };
+
+    const result = shouldExecuteStep({
+      stepInfos,
+      steps: multiParentSteps,
+      step: multiParentSteps[3],
+      workflowRunStatus: WorkflowRunStatus.RUNNING,
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('should return false when step status is SKIPPED', () => {
+    const result = shouldExecuteStep({
+      stepInfos: {
+        'step-1': {
+          status: StepStatus.SUCCESS,
+        },
+        'step-2': {
+          status: StepStatus.SUCCESS,
+        },
+        'step-3': {
+          status: StepStatus.SKIPPED,
+        },
+      },
+      steps,
+      step: steps[2],
+      workflowRunStatus: WorkflowRunStatus.RUNNING,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('should return false when step status is STOPPED', () => {
+    const result = shouldExecuteStep({
+      stepInfos: {
+        'step-1': {
+          status: StepStatus.SUCCESS,
+        },
+        'step-2': {
+          status: StepStatus.SUCCESS,
+        },
+        'step-3': {
+          status: StepStatus.STOPPED,
+        },
+      },
+      steps,
+      step: steps[2],
+      workflowRunStatus: WorkflowRunStatus.RUNNING,
+    });
+
+    expect(result).toBe(false);
+  });
 });

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/utils/__tests__/should-skip-step-execution.util.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/utils/__tests__/should-skip-step-execution.util.spec.ts
@@ -1,0 +1,323 @@
+import { StepStatus } from 'twenty-shared/workflow';
+
+import { shouldSkipStepExecution } from 'src/modules/workflow/workflow-executor/utils/should-skip-step-execution.util';
+import {
+  type WorkflowAction,
+  WorkflowActionType,
+} from 'src/modules/workflow/workflow-executor/workflow-actions/types/workflow-action.type';
+
+describe('shouldSkipStepExecution', () => {
+  const createMockStep = (
+    id: string,
+    nextStepIds: string[] = [],
+  ): WorkflowAction => ({
+    id,
+    name: 'Mock Step',
+    type: WorkflowActionType.CODE,
+    settings: {
+      input: {
+        serverlessFunctionId: 'mock-function-id',
+        serverlessFunctionVersion: 'mock-function-version',
+        serverlessFunctionInput: {},
+      },
+      errorHandlingOptions: {
+        continueOnFailure: { value: false },
+        retryOnFailure: { value: false },
+      },
+      outputSchema: {},
+    },
+    valid: true,
+    nextStepIds,
+  });
+
+  it('should return true when all parent steps are skipped', () => {
+    const steps = [
+      createMockStep('step-1', ['step-3']),
+      createMockStep('step-2', ['step-3']),
+      createMockStep('step-3', []),
+    ];
+    const stepInfos = {
+      'step-1': { status: StepStatus.SKIPPED },
+      'step-2': { status: StepStatus.SKIPPED },
+      'step-3': { status: StepStatus.NOT_STARTED },
+    };
+
+    const result = shouldSkipStepExecution({
+      step: steps[2],
+      steps,
+      stepInfos,
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('should return true when all parent steps are stopped', () => {
+    const steps = [
+      createMockStep('step-1', ['step-3']),
+      createMockStep('step-2', ['step-3']),
+      createMockStep('step-3', []),
+    ];
+    const stepInfos = {
+      'step-1': { status: StepStatus.STOPPED },
+      'step-2': { status: StepStatus.STOPPED },
+      'step-3': { status: StepStatus.NOT_STARTED },
+    };
+
+    const result = shouldSkipStepExecution({
+      step: steps[2],
+      steps,
+      stepInfos,
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('should return true when parent steps are mix of skipped and stopped', () => {
+    const steps = [
+      createMockStep('step-1', ['step-3']),
+      createMockStep('step-2', ['step-3']),
+      createMockStep('step-3', []),
+    ];
+    const stepInfos = {
+      'step-1': { status: StepStatus.SKIPPED },
+      'step-2': { status: StepStatus.STOPPED },
+      'step-3': { status: StepStatus.NOT_STARTED },
+    };
+
+    const result = shouldSkipStepExecution({
+      step: steps[2],
+      steps,
+      stepInfos,
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('should return false when at least one parent step is successful', () => {
+    const steps = [
+      createMockStep('step-1', ['step-3']),
+      createMockStep('step-2', ['step-3']),
+      createMockStep('step-3', []),
+    ];
+    const stepInfos = {
+      'step-1': { status: StepStatus.SKIPPED },
+      'step-2': { status: StepStatus.SUCCESS },
+      'step-3': { status: StepStatus.NOT_STARTED },
+    };
+
+    const result = shouldSkipStepExecution({
+      step: steps[2],
+      steps,
+      stepInfos,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('should return false when at least one parent step is failed', () => {
+    const steps = [
+      createMockStep('step-1', ['step-3']),
+      createMockStep('step-2', ['step-3']),
+      createMockStep('step-3', []),
+    ];
+    const stepInfos = {
+      'step-1': { status: StepStatus.SKIPPED },
+      'step-2': { status: StepStatus.FAILED },
+      'step-3': { status: StepStatus.NOT_STARTED },
+    };
+
+    const result = shouldSkipStepExecution({
+      step: steps[2],
+      steps,
+      stepInfos,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('should return false when at least one parent step is running', () => {
+    const steps = [
+      createMockStep('step-1', ['step-3']),
+      createMockStep('step-2', ['step-3']),
+      createMockStep('step-3', []),
+    ];
+    const stepInfos = {
+      'step-1': { status: StepStatus.SKIPPED },
+      'step-2': { status: StepStatus.RUNNING },
+      'step-3': { status: StepStatus.NOT_STARTED },
+    };
+
+    const result = shouldSkipStepExecution({
+      step: steps[2],
+      steps,
+      stepInfos,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('should return false when at least one parent step is not started', () => {
+    const steps = [
+      createMockStep('step-1', ['step-3']),
+      createMockStep('step-2', ['step-3']),
+      createMockStep('step-3', []),
+    ];
+    const stepInfos = {
+      'step-1': { status: StepStatus.SKIPPED },
+      'step-2': { status: StepStatus.NOT_STARTED },
+      'step-3': { status: StepStatus.NOT_STARTED },
+    };
+
+    const result = shouldSkipStepExecution({
+      step: steps[2],
+      steps,
+      stepInfos,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('should return false when there are no parent steps', () => {
+    const steps = [
+      createMockStep('step-1', ['step-2']),
+      createMockStep('step-2', []),
+      createMockStep('step-3', []),
+    ];
+    const stepInfos = {
+      'step-1': { status: StepStatus.SKIPPED },
+      'step-2': { status: StepStatus.SKIPPED },
+      'step-3': { status: StepStatus.NOT_STARTED },
+    };
+
+    const result = shouldSkipStepExecution({
+      step: steps[2],
+      steps,
+      stepInfos,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('should return true when single parent step is skipped', () => {
+    const steps = [
+      createMockStep('step-1', ['step-2']),
+      createMockStep('step-2', []),
+    ];
+    const stepInfos = {
+      'step-1': { status: StepStatus.SKIPPED },
+      'step-2': { status: StepStatus.NOT_STARTED },
+    };
+
+    const result = shouldSkipStepExecution({
+      step: steps[1],
+      steps,
+      stepInfos,
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('should handle undefined steps gracefully', () => {
+    const steps = [
+      createMockStep('step-1', ['step-2']),
+      undefined as unknown as WorkflowAction,
+      createMockStep('step-2', []),
+    ];
+    const stepInfos = {
+      'step-1': { status: StepStatus.SKIPPED },
+      'step-2': { status: StepStatus.NOT_STARTED },
+    };
+
+    const result = shouldSkipStepExecution({
+      step: steps[2],
+      steps,
+      stepInfos,
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('should return false when parent step status is pending', () => {
+    const steps = [
+      createMockStep('step-1', ['step-2']),
+      createMockStep('step-2', []),
+    ];
+    const stepInfos = {
+      'step-1': { status: StepStatus.PENDING },
+      'step-2': { status: StepStatus.NOT_STARTED },
+    };
+
+    const result = shouldSkipStepExecution({
+      step: steps[1],
+      steps,
+      stepInfos,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('should work with multiple parent steps with different statuses', () => {
+    const steps = [
+      createMockStep('step-1', ['step-4']),
+      createMockStep('step-2', ['step-4']),
+      createMockStep('step-3', ['step-4']),
+      createMockStep('step-4', []),
+    ];
+
+    // Test case 1: All skipped - should return true
+    expect(
+      shouldSkipStepExecution({
+        step: steps[3],
+        steps,
+        stepInfos: {
+          'step-1': { status: StepStatus.SKIPPED },
+          'step-2': { status: StepStatus.SKIPPED },
+          'step-3': { status: StepStatus.SKIPPED },
+          'step-4': { status: StepStatus.NOT_STARTED },
+        },
+      }),
+    ).toBe(true);
+
+    // Test case 2: Mixed skipped/stopped - should return true
+    expect(
+      shouldSkipStepExecution({
+        step: steps[3],
+        steps,
+        stepInfos: {
+          'step-1': { status: StepStatus.SKIPPED },
+          'step-2': { status: StepStatus.STOPPED },
+          'step-3': { status: StepStatus.SKIPPED },
+          'step-4': { status: StepStatus.NOT_STARTED },
+        },
+      }),
+    ).toBe(true);
+
+    // Test case 3: One success among skipped - should return false
+    expect(
+      shouldSkipStepExecution({
+        step: steps[3],
+        steps,
+        stepInfos: {
+          'step-1': { status: StepStatus.SKIPPED },
+          'step-2': { status: StepStatus.SUCCESS },
+          'step-3': { status: StepStatus.SKIPPED },
+          'step-4': { status: StepStatus.NOT_STARTED },
+        },
+      }),
+    ).toBe(false);
+
+    // Test case 4: One failed among skipped - should return false
+    expect(
+      shouldSkipStepExecution({
+        step: steps[3],
+        steps,
+        stepInfos: {
+          'step-1': { status: StepStatus.SKIPPED },
+          'step-2': { status: StepStatus.FAILED },
+          'step-3': { status: StepStatus.SKIPPED },
+          'step-4': { status: StepStatus.NOT_STARTED },
+        },
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/utils/should-execute-step.util.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/utils/should-execute-step.util.ts
@@ -4,48 +4,54 @@ import { StepStatus, type WorkflowRunStepInfos } from 'twenty-shared/workflow';
 import { WorkflowRunStatus } from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
 import { stepHasBeenStarted } from 'src/modules/workflow/workflow-executor/utils/step-has-been-started.util';
 import { isWorkflowIteratorAction } from 'src/modules/workflow/workflow-executor/workflow-actions/iterator/guards/is-workflow-iterator-action.guard';
-import { canExecuteIteratorStep } from 'src/modules/workflow/workflow-executor/workflow-actions/iterator/utils/can-execute-iterator-step.util';
+import { shouldExecuteIteratorStep } from 'src/modules/workflow/workflow-executor/workflow-actions/iterator/utils/should-execute-iterator-step.util';
 import { type WorkflowAction } from 'src/modules/workflow/workflow-executor/workflow-actions/types/workflow-action.type';
 
-export const canExecuteStep = ({
-  stepId,
+export const shouldExecuteStep = ({
+  step,
   steps,
   stepInfos,
   workflowRunStatus,
 }: {
+  step: WorkflowAction;
   steps: WorkflowAction[];
   stepInfos: WorkflowRunStepInfos;
-  stepId: string;
   workflowRunStatus: WorkflowRunStatus;
 }) => {
   if (workflowRunStatus !== WorkflowRunStatus.RUNNING) {
     return false;
   }
 
-  const step = steps.find((step) => step.id === stepId);
-
-  if (!step) {
-    return false;
-  }
-
   if (isWorkflowIteratorAction(step)) {
-    return canExecuteIteratorStep({
+    return shouldExecuteIteratorStep({
       step,
       steps,
       stepInfos,
     });
   }
 
-  if (stepHasBeenStarted(stepId, stepInfos)) {
+  if (stepHasBeenStarted(step.id, stepInfos)) {
     return false;
   }
 
   const parentSteps = steps.filter(
     (parentStep) =>
-      isDefined(parentStep) && parentStep.nextStepIds?.includes(stepId),
+      isDefined(parentStep) && parentStep.nextStepIds?.includes(step.id),
   );
 
-  return parentSteps.every(
+  if (parentSteps.length === 0) {
+    return true;
+  }
+
+  const hasSuccessfulParentStep = parentSteps.some(
     (parentStep) => stepInfos[parentStep.id]?.status === StepStatus.SUCCESS,
   );
+
+  const hasFailedNorNotStartedParentStep = parentSteps.some(
+    (parentStep) =>
+      stepInfos[parentStep.id]?.status === StepStatus.FAILED ||
+      stepInfos[parentStep.id]?.status === StepStatus.NOT_STARTED,
+  );
+
+  return hasSuccessfulParentStep && !hasFailedNorNotStartedParentStep;
 };

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/utils/should-execute-step.util.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/utils/should-execute-step.util.ts
@@ -47,11 +47,12 @@ export const shouldExecuteStep = ({
     (parentStep) => stepInfos[parentStep.id]?.status === StepStatus.SUCCESS,
   );
 
-  const hasFailedNorNotStartedParentStep = parentSteps.some(
+  const areAllParentsCompleted = parentSteps.every(
     (parentStep) =>
-      stepInfos[parentStep.id]?.status === StepStatus.FAILED ||
-      stepInfos[parentStep.id]?.status === StepStatus.NOT_STARTED,
+      stepInfos[parentStep.id]?.status === StepStatus.SUCCESS ||
+      stepInfos[parentStep.id]?.status === StepStatus.STOPPED ||
+      stepInfos[parentStep.id]?.status === StepStatus.SKIPPED,
   );
 
-  return hasSuccessfulParentStep && !hasFailedNorNotStartedParentStep;
+  return hasSuccessfulParentStep && areAllParentsCompleted;
 };

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/utils/should-skip-step-execution.util.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/utils/should-skip-step-execution.util.ts
@@ -1,0 +1,35 @@
+import { isDefined } from 'twenty-shared/utils';
+import { StepStatus, type WorkflowRunStepInfos } from 'twenty-shared/workflow';
+
+import { isWorkflowIteratorAction } from 'src/modules/workflow/workflow-executor/workflow-actions/iterator/guards/is-workflow-iterator-action.guard';
+import { shouldSkipIteratorStepExecution } from 'src/modules/workflow/workflow-executor/workflow-actions/iterator/utils/should-skip-iterator-step-execution.util';
+import { type WorkflowAction } from 'src/modules/workflow/workflow-executor/workflow-actions/types/workflow-action.type';
+
+export const shouldSkipStepExecution = ({
+  step,
+  steps,
+  stepInfos,
+}: {
+  step: WorkflowAction;
+  steps: WorkflowAction[];
+  stepInfos: WorkflowRunStepInfos;
+}) => {
+  if (isWorkflowIteratorAction(step)) {
+    return shouldSkipIteratorStepExecution({
+      step,
+      steps,
+      stepInfos,
+    });
+  }
+
+  const parentSteps = steps.filter(
+    (parentStep) =>
+      isDefined(parentStep) && parentStep.nextStepIds?.includes(step.id),
+  );
+
+  return parentSteps.every(
+    (step) =>
+      stepInfos[step.id]?.status === StepStatus.SKIPPED ||
+      stepInfos[step.id]?.status === StepStatus.STOPPED,
+  );
+};

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/utils/should-skip-step-execution.util.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/utils/should-skip-step-execution.util.ts
@@ -27,6 +27,10 @@ export const shouldSkipStepExecution = ({
       isDefined(parentStep) && parentStep.nextStepIds?.includes(step.id),
   );
 
+  if (parentSteps.length === 0) {
+    return false;
+  }
+
   return parentSteps.every(
     (step) =>
       stepInfos[step.id]?.status === StepStatus.SKIPPED ||

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/utils/workflow-should-keep-running.util.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/utils/workflow-should-keep-running.util.ts
@@ -1,8 +1,8 @@
 import { StepStatus, type WorkflowRunStepInfos } from 'twenty-shared/workflow';
 
-import { canExecuteStep } from 'src/modules/workflow/workflow-executor/utils/can-execute-step.util';
-import { type WorkflowAction } from 'src/modules/workflow/workflow-executor/workflow-actions/types/workflow-action.type';
 import { WorkflowRunStatus } from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
+import { shouldExecuteStep } from 'src/modules/workflow/workflow-executor/utils/should-execute-step.util';
+import { type WorkflowAction } from 'src/modules/workflow/workflow-executor/workflow-actions/types/workflow-action.type';
 
 export const workflowShouldKeepRunning = ({
   stepInfos,
@@ -20,16 +20,23 @@ export const workflowShouldKeepRunning = ({
   const successStepWithNotStartedExecutableChildren = steps.some(
     (step) =>
       stepInfos[step.id]?.status === StepStatus.SUCCESS &&
-      (step.nextStepIds ?? []).some(
-        (nextStepId) =>
+      (step.nextStepIds ?? []).some((nextStepId) => {
+        const nextStep = steps.find((step) => step.id === nextStepId);
+
+        if (!nextStep) {
+          return false;
+        }
+
+        return (
           stepInfos[nextStepId]?.status === StepStatus.NOT_STARTED &&
-          canExecuteStep({
-            stepId: nextStepId,
+          shouldExecuteStep({
+            step: nextStep,
             steps,
             stepInfos,
             workflowRunStatus: WorkflowRunStatus.RUNNING,
-          }),
-      ),
+          })
+        );
+      }),
   );
 
   return (

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/iterator/utils/__tests__/should-execute-iterator-step.util.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/iterator/utils/__tests__/should-execute-iterator-step.util.spec.ts
@@ -1,6 +1,6 @@
 import { StepStatus } from 'twenty-shared/workflow';
 
-import { canExecuteIteratorStep } from 'src/modules/workflow/workflow-executor/workflow-actions/iterator/utils/can-execute-iterator-step.util';
+import { shouldExecuteIteratorStep } from 'src/modules/workflow/workflow-executor/workflow-actions/iterator/utils/should-execute-iterator-step.util';
 import {
   type WorkflowAction,
   type WorkflowIteratorAction,
@@ -19,7 +19,7 @@ const { getAllStepIdsInLoop } = jest.requireMock(
   'src/modules/workflow/workflow-executor/workflow-actions/iterator/utils/get-all-step-ids-in-loop.util',
 );
 
-describe('canExecuteIteratorStep', () => {
+describe('shouldExecuteIteratorStep', () => {
   const createMockIteratorStep = (
     id: string,
     initialLoopStepIds: string[] = [],
@@ -90,7 +90,7 @@ describe('canExecuteIteratorStep', () => {
       // Mock getAllStepIdsInLoop to return the loop step IDs
       getAllStepIdsInLoop.mockReturnValue(['step-1', 'step-2']);
 
-      const result = canExecuteIteratorStep({
+      const result = shouldExecuteIteratorStep({
         step: iteratorStep,
         steps,
         stepInfos,
@@ -121,7 +121,7 @@ describe('canExecuteIteratorStep', () => {
 
       getAllStepIdsInLoop.mockReturnValue(['step-2']);
 
-      const result = canExecuteIteratorStep({
+      const result = shouldExecuteIteratorStep({
         step: iteratorStep,
         steps,
         stepInfos,
@@ -147,7 +147,7 @@ describe('canExecuteIteratorStep', () => {
 
       getAllStepIdsInLoop.mockReturnValue(['step-1']);
 
-      const result = canExecuteIteratorStep({
+      const result = shouldExecuteIteratorStep({
         step: iteratorStep,
         steps,
         stepInfos,
@@ -171,7 +171,7 @@ describe('canExecuteIteratorStep', () => {
       // Only step-1 is in the loop
       getAllStepIdsInLoop.mockReturnValue(['step-1']);
 
-      const result = canExecuteIteratorStep({
+      const result = shouldExecuteIteratorStep({
         step: iteratorStep,
         steps,
         stepInfos,
@@ -194,7 +194,7 @@ describe('canExecuteIteratorStep', () => {
 
       getAllStepIdsInLoop.mockReturnValue([]);
 
-      const result = canExecuteIteratorStep({
+      const result = shouldExecuteIteratorStep({
         step: iteratorStep,
         steps,
         stepInfos,
@@ -216,7 +216,7 @@ describe('canExecuteIteratorStep', () => {
 
       getAllStepIdsInLoop.mockReturnValue(['step-1']);
 
-      const result = canExecuteIteratorStep({
+      const result = shouldExecuteIteratorStep({
         step: iteratorStep,
         steps,
         stepInfos,
@@ -247,7 +247,7 @@ describe('canExecuteIteratorStep', () => {
 
       getAllStepIdsInLoop.mockReturnValue(['step-1', 'step-2', 'step-3']);
 
-      const result = canExecuteIteratorStep({
+      const result = shouldExecuteIteratorStep({
         step: iteratorStep,
         steps,
         stepInfos,
@@ -273,7 +273,7 @@ describe('canExecuteIteratorStep', () => {
 
       getAllStepIdsInLoop.mockReturnValue(['step-1']);
 
-      const result = canExecuteIteratorStep({
+      const result = shouldExecuteIteratorStep({
         step: iteratorStep,
         steps,
         stepInfos,
@@ -297,7 +297,7 @@ describe('canExecuteIteratorStep', () => {
 
       getAllStepIdsInLoop.mockReturnValue(['step-1']);
 
-      const result = canExecuteIteratorStep({
+      const result = shouldExecuteIteratorStep({
         step: iteratorStep,
         steps,
         stepInfos,
@@ -321,7 +321,7 @@ describe('canExecuteIteratorStep', () => {
 
       getAllStepIdsInLoop.mockReturnValue(['step-1']);
 
-      const result = canExecuteIteratorStep({
+      const result = shouldExecuteIteratorStep({
         step: iteratorStep,
         steps,
         stepInfos,
@@ -340,7 +340,7 @@ describe('canExecuteIteratorStep', () => {
 
       getAllStepIdsInLoop.mockReturnValue([]);
 
-      const result = canExecuteIteratorStep({
+      const result = shouldExecuteIteratorStep({
         step: iteratorStep,
         steps,
         stepInfos,
@@ -364,7 +364,7 @@ describe('canExecuteIteratorStep', () => {
 
       getAllStepIdsInLoop.mockReturnValue(['step-1']);
 
-      const result = canExecuteIteratorStep({
+      const result = shouldExecuteIteratorStep({
         step: iteratorStep,
         steps,
         stepInfos,

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/iterator/utils/__tests__/should-skip-iterator-step-execution.util.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/iterator/utils/__tests__/should-skip-iterator-step-execution.util.spec.ts
@@ -1,0 +1,496 @@
+import { StepStatus } from 'twenty-shared/workflow';
+
+import { shouldSkipIteratorStepExecution } from 'src/modules/workflow/workflow-executor/workflow-actions/iterator/utils/should-skip-iterator-step-execution.util';
+import {
+  type WorkflowAction,
+  type WorkflowIteratorAction,
+  WorkflowActionType,
+} from 'src/modules/workflow/workflow-executor/workflow-actions/types/workflow-action.type';
+
+// Mock the getAllStepIdsInLoop utility
+jest.mock(
+  'src/modules/workflow/workflow-executor/workflow-actions/iterator/utils/get-all-step-ids-in-loop.util',
+  () => ({
+    getAllStepIdsInLoop: jest.fn(),
+  }),
+);
+
+const { getAllStepIdsInLoop } = jest.requireMock(
+  'src/modules/workflow/workflow-executor/workflow-actions/iterator/utils/get-all-step-ids-in-loop.util',
+);
+
+describe('shouldSkipIteratorStepExecution', () => {
+  const createMockIteratorStep = (
+    id: string,
+    initialLoopStepIds: string[] = [],
+  ): WorkflowIteratorAction => ({
+    id,
+    name: 'Iterator Step',
+    type: WorkflowActionType.ITERATOR,
+    settings: {
+      input: {
+        initialLoopStepIds,
+        items: [],
+      },
+      errorHandlingOptions: {
+        continueOnFailure: { value: false },
+        retryOnFailure: { value: false },
+      },
+      outputSchema: {},
+    },
+    valid: true,
+    nextStepIds: [],
+  });
+
+  const createMockStep = (
+    id: string,
+    nextStepIds: string[] = [],
+  ): WorkflowAction => ({
+    id,
+    name: 'Mock Step',
+    type: WorkflowActionType.CODE,
+    settings: {
+      input: {
+        serverlessFunctionId: 'mock-function-id',
+        serverlessFunctionVersion: 'mock-function-version',
+        serverlessFunctionInput: {},
+      },
+      errorHandlingOptions: {
+        continueOnFailure: { value: false },
+        retryOnFailure: { value: false },
+      },
+      outputSchema: {},
+    },
+    valid: true,
+    nextStepIds,
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('when the iterator has not been started', () => {
+    it('should return true when all parent steps are skipped', () => {
+      const iteratorStep = createMockIteratorStep('iterator-1', ['step-1']);
+      const steps = [
+        createMockStep('step-1', ['iterator-1']),
+        createMockStep('step-2', ['iterator-1']),
+        iteratorStep,
+      ];
+      const stepInfos = {
+        'step-1': { status: StepStatus.SKIPPED },
+        'step-2': { status: StepStatus.SKIPPED },
+      };
+
+      getAllStepIdsInLoop.mockReturnValue(['step-1']);
+
+      const result = shouldSkipIteratorStepExecution({
+        step: iteratorStep,
+        steps,
+        stepInfos,
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it('should return true when all parent steps are stopped', () => {
+      const iteratorStep = createMockIteratorStep('iterator-1', ['step-1']);
+      const steps = [
+        createMockStep('step-1', ['iterator-1']),
+        createMockStep('step-2', ['iterator-1']),
+        iteratorStep,
+      ];
+      const stepInfos = {
+        'step-1': { status: StepStatus.STOPPED },
+        'step-2': { status: StepStatus.STOPPED },
+      };
+
+      getAllStepIdsInLoop.mockReturnValue(['step-1']);
+
+      const result = shouldSkipIteratorStepExecution({
+        step: iteratorStep,
+        steps,
+        stepInfos,
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it('should return true when parent steps are mix of skipped and stopped', () => {
+      const iteratorStep = createMockIteratorStep('iterator-1', ['step-1']);
+      const steps = [
+        createMockStep('step-1', ['iterator-1']),
+        createMockStep('step-2', ['iterator-1']),
+        iteratorStep,
+      ];
+      const stepInfos = {
+        'step-1': { status: StepStatus.SKIPPED },
+        'step-2': { status: StepStatus.STOPPED },
+      };
+
+      getAllStepIdsInLoop.mockReturnValue(['step-1']);
+
+      const result = shouldSkipIteratorStepExecution({
+        step: iteratorStep,
+        steps,
+        stepInfos,
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false when at least one parent step is successful', () => {
+      const iteratorStep = createMockIteratorStep('iterator-1', ['step-1']);
+      const steps = [
+        createMockStep('step-1', ['iterator-1']),
+        createMockStep('step-2', ['iterator-1']),
+        iteratorStep,
+      ];
+      const stepInfos = {
+        'step-1': { status: StepStatus.SKIPPED },
+        'step-2': { status: StepStatus.SUCCESS },
+      };
+
+      getAllStepIdsInLoop.mockReturnValue(['step-1']);
+
+      const result = shouldSkipIteratorStepExecution({
+        step: iteratorStep,
+        steps,
+        stepInfos,
+      });
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when at least one parent step is failed', () => {
+      const iteratorStep = createMockIteratorStep('iterator-1', ['step-1']);
+      const steps = [
+        createMockStep('step-1', ['iterator-1']),
+        createMockStep('step-2', ['iterator-1']),
+        iteratorStep,
+      ];
+      const stepInfos = {
+        'step-1': { status: StepStatus.SKIPPED },
+        'step-2': { status: StepStatus.FAILED },
+      };
+
+      getAllStepIdsInLoop.mockReturnValue(['step-1']);
+
+      const result = shouldSkipIteratorStepExecution({
+        step: iteratorStep,
+        steps,
+        stepInfos,
+      });
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when at least one parent step is not started', () => {
+      const iteratorStep = createMockIteratorStep('iterator-1', ['step-1']);
+      const steps = [
+        createMockStep('step-1', ['iterator-1']),
+        createMockStep('step-2', ['iterator-1']),
+        iteratorStep,
+      ];
+      const stepInfos = {
+        'step-1': { status: StepStatus.SKIPPED },
+        'step-2': { status: StepStatus.NOT_STARTED },
+      };
+
+      getAllStepIdsInLoop.mockReturnValue(['step-1']);
+
+      const result = shouldSkipIteratorStepExecution({
+        step: iteratorStep,
+        steps,
+        stepInfos,
+      });
+
+      expect(result).toBe(false);
+    });
+
+    it('should only check parent steps not in loop', () => {
+      const iteratorStep = createMockIteratorStep('iterator-1', ['step-1']);
+      const steps = [
+        createMockStep('step-1', ['iterator-1']), // In loop
+        createMockStep('step-2', ['iterator-1']), // Not in loop
+        iteratorStep,
+      ];
+      const stepInfos = {
+        'step-1': { status: StepStatus.SUCCESS }, // This should be ignored
+        'step-2': { status: StepStatus.SKIPPED },
+      };
+
+      getAllStepIdsInLoop.mockReturnValue(['step-1']);
+
+      const result = shouldSkipIteratorStepExecution({
+        step: iteratorStep,
+        steps,
+        stepInfos,
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false when there are no parent steps', () => {
+      const iteratorStep = createMockIteratorStep('iterator-1', []);
+      const steps = [
+        createMockStep('step-1', ['step-2']),
+        createMockStep('step-2', []),
+        iteratorStep,
+      ];
+      const stepInfos = {
+        'step-1': { status: StepStatus.SKIPPED },
+        'step-2': { status: StepStatus.SKIPPED },
+      };
+
+      getAllStepIdsInLoop.mockReturnValue([]);
+
+      const result = shouldSkipIteratorStepExecution({
+        step: iteratorStep,
+        steps,
+        stepInfos,
+      });
+
+      expect(result).toBe(false);
+    });
+
+    it('should handle undefined steps gracefully', () => {
+      const iteratorStep = createMockIteratorStep('iterator-1', ['step-1']);
+      const steps = [
+        createMockStep('step-1', ['iterator-1']),
+        undefined as unknown as WorkflowAction,
+        createMockStep('step-2', ['iterator-1']),
+        iteratorStep,
+      ];
+      const stepInfos = {
+        'step-1': { status: StepStatus.SKIPPED },
+        'step-2': { status: StepStatus.SKIPPED },
+      };
+
+      getAllStepIdsInLoop.mockReturnValue(['step-1']);
+
+      const result = shouldSkipIteratorStepExecution({
+        step: iteratorStep,
+        steps,
+        stepInfos,
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it('should work correctly with multiple steps targeting the same iterator', () => {
+      const iteratorStep = createMockIteratorStep('iterator-1', [
+        'step-1',
+        'step-2',
+      ]);
+      const steps = [
+        createMockStep('step-1', ['iterator-1']), // In loop
+        createMockStep('step-2', ['iterator-1']), // In loop
+        createMockStep('step-3', ['iterator-1']), // Not in loop
+        createMockStep('step-4', ['iterator-1']), // Not in loop
+        iteratorStep,
+      ];
+      const stepInfos = {
+        'step-1': { status: StepStatus.SUCCESS }, // Loop step, should be ignored
+        'step-2': { status: StepStatus.SUCCESS }, // Loop step, should be ignored
+        'step-3': { status: StepStatus.SKIPPED },
+        'step-4': { status: StepStatus.STOPPED },
+      };
+
+      getAllStepIdsInLoop.mockReturnValue(['step-1', 'step-2']);
+
+      const result = shouldSkipIteratorStepExecution({
+        step: iteratorStep,
+        steps,
+        stepInfos,
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false when one non-loop parent is not skipped/stopped', () => {
+      const iteratorStep = createMockIteratorStep('iterator-1', ['step-1']);
+      const steps = [
+        createMockStep('step-1', ['iterator-1']), // In loop
+        createMockStep('step-2', ['iterator-1']), // Not in loop
+        createMockStep('step-3', ['iterator-1']), // Not in loop
+        iteratorStep,
+      ];
+      const stepInfos = {
+        'step-1': { status: StepStatus.SUCCESS }, // Loop step, ignored
+        'step-2': { status: StepStatus.SKIPPED },
+        'step-3': { status: StepStatus.RUNNING }, // This should make it return false
+      };
+
+      getAllStepIdsInLoop.mockReturnValue(['step-1']);
+
+      const result = shouldSkipIteratorStepExecution({
+        step: iteratorStep,
+        steps,
+        stepInfos,
+      });
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('when the iterator has been started', () => {
+    it('should return false when iterator has been started', () => {
+      const iteratorStep = createMockIteratorStep('iterator-1', ['step-1']);
+      const steps = [
+        createMockStep('step-1', ['iterator-1']),
+        createMockStep('step-2', ['iterator-1']),
+        iteratorStep,
+      ];
+      const stepInfos = {
+        'iterator-1': { status: StepStatus.RUNNING }, // Iterator has been started
+        'step-1': { status: StepStatus.SKIPPED },
+        'step-2': { status: StepStatus.SKIPPED },
+      };
+
+      getAllStepIdsInLoop.mockReturnValue(['step-1']);
+
+      const result = shouldSkipIteratorStepExecution({
+        step: iteratorStep,
+        steps,
+        stepInfos,
+      });
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false even when all parent steps are skipped/stopped', () => {
+      const iteratorStep = createMockIteratorStep('iterator-1', ['step-1']);
+      const steps = [
+        createMockStep('step-1', ['iterator-1']),
+        createMockStep('step-2', ['iterator-1']),
+        iteratorStep,
+      ];
+      const stepInfos = {
+        'iterator-1': { status: StepStatus.SUCCESS }, // Iterator has been started
+        'step-1': { status: StepStatus.SKIPPED },
+        'step-2': { status: StepStatus.STOPPED },
+      };
+
+      getAllStepIdsInLoop.mockReturnValue(['step-1']);
+
+      const result = shouldSkipIteratorStepExecution({
+        step: iteratorStep,
+        steps,
+        stepInfos,
+      });
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when iterator is pending', () => {
+      const iteratorStep = createMockIteratorStep('iterator-1', ['step-1']);
+      const steps = [createMockStep('step-1', ['iterator-1']), iteratorStep];
+      const stepInfos = {
+        'iterator-1': { status: StepStatus.PENDING },
+        'step-1': { status: StepStatus.SKIPPED },
+      };
+
+      getAllStepIdsInLoop.mockReturnValue(['step-1']);
+
+      const result = shouldSkipIteratorStepExecution({
+        step: iteratorStep,
+        steps,
+        stepInfos,
+      });
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when iterator is skipped', () => {
+      const iteratorStep = createMockIteratorStep('iterator-1', ['step-1']);
+      const steps = [createMockStep('step-1', ['iterator-1']), iteratorStep];
+      const stepInfos = {
+        'iterator-1': { status: StepStatus.SKIPPED },
+        'step-1': { status: StepStatus.SKIPPED },
+      };
+
+      getAllStepIdsInLoop.mockReturnValue(['step-1']);
+
+      const result = shouldSkipIteratorStepExecution({
+        step: iteratorStep,
+        steps,
+        stepInfos,
+      });
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when iterator failed', () => {
+      const iteratorStep = createMockIteratorStep('iterator-1', ['step-1']);
+      const steps = [createMockStep('step-1', ['iterator-1']), iteratorStep];
+      const stepInfos = {
+        'iterator-1': { status: StepStatus.FAILED },
+        'step-1': { status: StepStatus.SKIPPED },
+      };
+
+      getAllStepIdsInLoop.mockReturnValue(['step-1']);
+
+      const result = shouldSkipIteratorStepExecution({
+        step: iteratorStep,
+        steps,
+        stepInfos,
+      });
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('edge cases with initialLoopStepIds', () => {
+    it('should handle undefined initialLoopStepIds', () => {
+      const iteratorStep = {
+        ...createMockIteratorStep('iterator-1'),
+        settings: {
+          input: {
+            initialLoopStepIds: undefined,
+            items: [],
+          },
+          errorHandlingOptions: {
+            continueOnFailure: { value: false },
+            retryOnFailure: { value: false },
+          },
+          outputSchema: {},
+        },
+      } as WorkflowIteratorAction;
+
+      const steps = [createMockStep('step-1', ['iterator-1']), iteratorStep];
+      const stepInfos = {
+        'step-1': { status: StepStatus.SKIPPED },
+      };
+
+      getAllStepIdsInLoop.mockReturnValue([]);
+
+      const result = shouldSkipIteratorStepExecution({
+        step: iteratorStep,
+        steps,
+        stepInfos,
+      });
+
+      expect(result).toBe(true);
+      expect(getAllStepIdsInLoop).not.toHaveBeenCalled();
+    });
+
+    it('should handle empty initialLoopStepIds array', () => {
+      const iteratorStep = createMockIteratorStep('iterator-1', []);
+      const steps = [createMockStep('step-1', ['iterator-1']), iteratorStep];
+      const stepInfos = {
+        'step-1': { status: StepStatus.SKIPPED },
+      };
+
+      getAllStepIdsInLoop.mockReturnValue([]);
+
+      const result = shouldSkipIteratorStepExecution({
+        step: iteratorStep,
+        steps,
+        stepInfos,
+      });
+
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/iterator/utils/should-execute-iterator-step.util.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/iterator/utils/should-execute-iterator-step.util.ts
@@ -1,0 +1,59 @@
+import { isDefined } from 'twenty-shared/utils';
+import { StepStatus, type WorkflowRunStepInfos } from 'twenty-shared/workflow';
+
+import { stepHasBeenStarted } from 'src/modules/workflow/workflow-executor/utils/step-has-been-started.util';
+import { getAllStepIdsInLoop } from 'src/modules/workflow/workflow-executor/workflow-actions/iterator/utils/get-all-step-ids-in-loop.util';
+import {
+  type WorkflowAction,
+  type WorkflowIteratorAction,
+} from 'src/modules/workflow/workflow-executor/workflow-actions/types/workflow-action.type';
+
+export const shouldExecuteIteratorStep = ({
+  step,
+  steps,
+  stepInfos,
+}: {
+  step: WorkflowIteratorAction;
+  steps: WorkflowAction[];
+  stepInfos: WorkflowRunStepInfos;
+}) => {
+  const stepsTargetingIterator = steps.filter(
+    (parentStep) =>
+      isDefined(parentStep) && parentStep.nextStepIds?.includes(step.id),
+  );
+
+  const initialLoopStepIds = step.settings.input.initialLoopStepIds;
+
+  const stepIdsInLoop = isDefined(initialLoopStepIds)
+    ? getAllStepIdsInLoop({
+        iteratorStepId: step.id,
+        initialLoopStepIds,
+        steps,
+      })
+    : [];
+
+  const parentSteps = stepsTargetingIterator.filter(
+    (step) => !stepIdsInLoop.includes(step.id),
+  );
+
+  const stepsToCheck = stepHasBeenStarted(step.id, stepInfos)
+    ? stepsTargetingIterator
+    : parentSteps;
+
+  if (stepsToCheck.length === 0) {
+    return true;
+  }
+
+  const hasSuccessfulParentStep = stepsToCheck.some(
+    (parentStep) => stepInfos[parentStep.id]?.status === StepStatus.SUCCESS,
+  );
+
+  const hasFailedNorNotStartedOrRunningParentStep = stepsToCheck.some(
+    (parentStep) =>
+      stepInfos[parentStep.id]?.status === StepStatus.FAILED ||
+      stepInfos[parentStep.id]?.status === StepStatus.NOT_STARTED ||
+      stepInfos[parentStep.id]?.status === StepStatus.RUNNING,
+  );
+
+  return hasSuccessfulParentStep && !hasFailedNorNotStartedOrRunningParentStep;
+};

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/iterator/utils/should-skip-iterator-step-execution.util.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/iterator/utils/should-skip-iterator-step-execution.util.ts
@@ -8,7 +8,7 @@ import {
   type WorkflowIteratorAction,
 } from 'src/modules/workflow/workflow-executor/workflow-actions/types/workflow-action.type';
 
-export const canExecuteIteratorStep = ({
+export const shouldSkipIteratorStepExecution = ({
   step,
   steps,
   stepInfos,
@@ -22,28 +22,27 @@ export const canExecuteIteratorStep = ({
       isDefined(parentStep) && parentStep.nextStepIds?.includes(step.id),
   );
 
-  // If the step has been started, we need to check if all the steps targeting the iterator have been successful.
+  const initialLoopStepIds = step.settings.input.initialLoopStepIds;
+
+  const stepIdsInLoop = isDefined(initialLoopStepIds)
+    ? getAllStepIdsInLoop({
+        iteratorStepId: step.id,
+        initialLoopStepIds,
+        steps,
+      })
+    : [];
+
+  const parentSteps = stepsTargetingIterator.filter(
+    (step) => !stepIdsInLoop.includes(step.id),
+  );
+
   if (stepHasBeenStarted(step.id, stepInfos)) {
-    return stepsTargetingIterator.every(
-      (step) => stepInfos[step.id]?.status === StepStatus.SUCCESS,
-    );
-  } else {
-    const initialLoopStepIds = step.settings.input.initialLoopStepIds;
-
-    const stepIdsInLoop = isDefined(initialLoopStepIds)
-      ? getAllStepIdsInLoop({
-          iteratorStepId: step.id,
-          initialLoopStepIds,
-          steps,
-        })
-      : [];
-
-    const parentSteps = stepsTargetingIterator.filter(
-      (step) => !stepIdsInLoop.includes(step.id),
-    );
-
-    return parentSteps.every(
-      (step) => stepInfos[step.id]?.status === StepStatus.SUCCESS,
-    );
+    return false;
   }
+
+  return parentSteps.every(
+    (step) =>
+      stepInfos[step.id]?.status === StepStatus.SKIPPED ||
+      stepInfos[step.id]?.status === StepStatus.STOPPED,
+  );
 };

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/iterator/utils/should-skip-iterator-step-execution.util.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/iterator/utils/should-skip-iterator-step-execution.util.ts
@@ -36,7 +36,7 @@ export const shouldSkipIteratorStepExecution = ({
     (step) => !stepIdsInLoop.includes(step.id),
   );
 
-  if (stepHasBeenStarted(step.id, stepInfos)) {
+  if (stepHasBeenStarted(step.id, stepInfos) || parentSteps.length === 0) {
     return false;
   }
 

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workspace-services/__tests__/workflow-executor.workspace-service.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workspace-services/__tests__/workflow-executor.workspace-service.spec.ts
@@ -8,7 +8,7 @@ import { BillingMeterEventName } from 'src/engine/core-modules/billing/enums/bil
 import { BillingService } from 'src/engine/core-modules/billing/services/billing.service';
 import { WorkspaceEventEmitter } from 'src/engine/workspace-event-emitter/workspace-event-emitter';
 import { WorkflowActionFactory } from 'src/modules/workflow/workflow-executor/factories/workflow-action.factory';
-import { canExecuteStep } from 'src/modules/workflow/workflow-executor/utils/can-execute-step.util';
+import { shouldExecuteStep } from 'src/modules/workflow/workflow-executor/utils/should-execute-step.util';
 import {
   type WorkflowAction,
   WorkflowActionType,
@@ -17,15 +17,15 @@ import { WorkflowExecutorWorkspaceService } from 'src/modules/workflow/workflow-
 import { WorkflowRunWorkspaceService } from 'src/modules/workflow/workflow-runner/workflow-run/workflow-run.workspace-service';
 
 jest.mock(
-  'src/modules/workflow/workflow-executor/utils/can-execute-step.util',
+  'src/modules/workflow/workflow-executor/utils/should-execute-step.util',
   () => {
     const actual = jest.requireActual(
-      'src/modules/workflow/workflow-executor/utils/can-execute-step.util',
+      'src/modules/workflow/workflow-executor/utils/should-execute-step.util',
     );
 
     return {
       ...actual,
-      canExecuteStep: jest.fn().mockReturnValue(true), // default behavior
+      shouldExecuteStep: jest.fn().mockReturnValue(true), // default behavior
     };
   },
 );
@@ -325,7 +325,7 @@ describe('WorkflowExecutorWorkspaceService', () => {
     });
 
     it('should return if step should not be executed', async () => {
-      (canExecuteStep as jest.Mock).mockReturnValueOnce(false);
+      (shouldExecuteStep as jest.Mock).mockReturnValueOnce(false);
 
       await service.executeFromSteps({
         workflowRunId: mockWorkflowRunId,

--- a/packages/twenty-shared/src/workflow/types/WorkflowRunStateStepInfos.ts
+++ b/packages/twenty-shared/src/workflow/types/WorkflowRunStateStepInfos.ts
@@ -9,6 +9,7 @@ export enum StepStatus {
   STOPPED = 'STOPPED',
   FAILED = 'FAILED',
   PENDING = 'PENDING',
+  SKIPPED = 'SKIPPED',
 }
 
 export type WorkflowRunStepInfo = z.infer<

--- a/packages/twenty-ui/src/json-visualizer/components/JsonNode.tsx
+++ b/packages/twenty-ui/src/json-visualizer/components/JsonNode.tsx
@@ -1,7 +1,6 @@
 import {
   isBoolean,
   isNonEmptyString,
-  isNull,
   isNumber,
   isString,
 } from '@sniptt/guards';
@@ -16,6 +15,7 @@ import { JsonObjectNode } from '@ui/json-visualizer/components/JsonObjectNode';
 import { JsonValueNode } from '@ui/json-visualizer/components/JsonValueNode';
 import { useJsonTreeContextOrThrow } from '@ui/json-visualizer/hooks/useJsonTreeContextOrThrow';
 import { isArray } from '@ui/json-visualizer/utils/isArray';
+import { isDefined } from 'twenty-shared/utils';
 import { type JsonValue } from 'type-fest';
 
 export const JsonNode = ({
@@ -33,7 +33,7 @@ export const JsonNode = ({
 
   const highlighting = getNodeHighlighting?.(keyPath);
 
-  if (isNull(value)) {
+  if (!isDefined(value)) {
     return (
       <JsonValueNode
         label={label}


### PR DESCRIPTION
Filters should not cut the whole workflow. These should only stop the branch. This PR:
- adds a new skipped status 
- when a filter stops, it still goes to the next step
- the next step will execute if there is at least a successful step
- if only skipped step, it will be skipped as well

It allows to use filters in iterators.

https://github.com/user-attachments/assets/1cfca052-55c0-4ce5-9eb8-63736618d082

