### PR TITLE
When workflow is completed, mark as failed steps still running

### DIFF
--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run/workflow-run.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run/workflow-run.workspace-service.ts
@@ -198,11 +198,40 @@ export class WorkflowRunWorkspaceService {
       workspaceId,
     });
 
+    const updatedStepInfos = Object.entries(
+      workflowRunToUpdate.state?.stepInfos ?? {},
+    )
+      .map(([stepId, step]) => {
+        if (
+          step.status === StepStatus.RUNNING ||
+          step.status === StepStatus.PENDING
+        ) {
+          return {
+            [stepId]: {
+              ...step,
+              status: StepStatus.FAILED,
+              error: 'Workflow has been ended before this step was completed',
+            },
+          };
+        }
+
+        return {
+          [stepId]: step,
+        };
+      })
+      .reduce((acc, current) => {
+        return {
+          ...acc,
+          ...current,
+        };
+      }, {});
+
     const partialUpdate = {
       status,
       endedAt: new Date().toISOString(),
       state: {
         ...workflowRunToUpdate.state,
+        stepInfos: updatedStepInfos,
         workflowRunError: error,
       },
     };


### PR DESCRIPTION
As title. 