### PR TITLE
refactor: drop uuid package

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "tslib": "^2.8.1",
     "type-fest": "4.10.1",
     "typescript": "5.9.2",
-    "uuid": "^9.0.0",
     "vite-tsconfig-paths": "^4.2.1",
     "xlsx-ugnis": "^0.19.3",
     "zod": "^4.1.11"
@@ -152,7 +151,6 @@
     "@types/react-datepicker": "^6.2.0",
     "@types/react-dom": "^18.2.15",
     "@types/supertest": "^2.0.11",
-    "@types/uuid": "^9.0.2",
     "@typescript-eslint/eslint-plugin": "^8.39.0",
     "@typescript-eslint/parser": "^8.39.0",
     "@typescript-eslint/utils": "^8.39.0",

--- a/packages/twenty-front/src/modules/activities/components/ActivityRichTextEditor.tsx
+++ b/packages/twenty-front/src/modules/activities/components/ActivityRichTextEditor.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useMemo } from 'react';
 import { useRecoilCallback, useRecoilState } from 'recoil';
-import { v4 } from 'uuid';
 
 import { useUploadAttachmentFile } from '@/activities/files/hooks/useUploadAttachmentFile';
 import { useUpsertActivity } from '@/activities/hooks/useUpsertActivity';
@@ -342,7 +341,7 @@ export const ActivityRichTextEditor = ({
     keyboardEvent.stopPropagation();
     keyboardEvent.stopImmediatePropagation();
 
-    const newBlockId = v4();
+    const newBlockId = crypto.randomUUID();
     const newBlock = {
       id: newBlockId,
       type: 'paragraph' as const,

--- a/packages/twenty-front/src/modules/activities/utils/getActivityTargetsToCreateFromTargetableObjects.ts
+++ b/packages/twenty-front/src/modules/activities/utils/getActivityTargetsToCreateFromTargetableObjects.ts
@@ -1,5 +1,3 @@
-import { v4 } from 'uuid';
-
 import { type ActivityTargetableObject } from '@/activities/types/ActivityTargetableEntity';
 import { type Note } from '@/activities/types/Note';
 import { type NoteTarget } from '@/activities/types/NoteTarget';
@@ -31,7 +29,7 @@ export const makeActivityTargetsToCreateFromTargetableObjects = ({
       [targetableObjectFieldIdName]: targetableObject.id,
       activity,
       activityId: activity.id,
-      id: v4(),
+      id: crypto.randomUUID(),
       updatedAt: new Date().toISOString(),
       createdAt: new Date().toISOString(),
     } as Partial<NoteTarget | TaskTarget>;

--- a/packages/twenty-front/src/modules/ai/hooks/useAiAgentOutputSchema.ts
+++ b/packages/twenty-front/src/modules/ai/hooks/useAiAgentOutputSchema.ts
@@ -4,7 +4,6 @@ import { type BaseOutputSchemaDeprecated } from '@/workflow/workflow-variables/t
 import { useState } from 'react';
 import { isDefined } from 'twenty-shared/utils';
 import { useDebouncedCallback } from 'use-debounce';
-import { v4 } from 'uuid';
 
 export const useAiAgentOutputSchema = (
   outputSchema?: BaseOutputSchemaDeprecated,
@@ -14,7 +13,7 @@ export const useAiAgentOutputSchema = (
 ) => {
   const [outputFields, setOutputFields] = useState<OutputSchemaField[]>(
     Object.entries(outputSchema || {}).map(([name, field]) => ({
-      id: v4(),
+      id: crypto.randomUUID(),
       name,
       type: field.type,
     })),

--- a/packages/twenty-front/src/modules/analytics/hooks/useEventTracker.ts
+++ b/packages/twenty-front/src/modules/analytics/hooks/useEventTracker.ts
@@ -1,5 +1,4 @@
 import { useCallback } from 'react';
-import { v4 } from 'uuid';
 import {
   AnalyticsType,
   type MutationTrackAnalyticsArgs,
@@ -17,7 +16,7 @@ export const getSessionId = (): string => {
 };
 
 export const setSessionId = (domain?: string): void => {
-  const sessionId = getSessionId() || v4();
+  const sessionId = getSessionId() || crypto.randomUUID();
   const baseCookie = `${ANALYTICS_COOKIE_NAME}=${sessionId}; Max-Age=1800; path=/; secure`;
   const cookie = domain ? baseCookie + `; domain=${domain}` : baseCookie;
 

--- a/packages/twenty-front/src/modules/settings/data-model/fields/forms/select/hooks/useSelectSettingsFormInitialValues.ts
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/forms/select/hooks/useSelectSettingsFormInitialValues.ts
@@ -1,6 +1,5 @@
 import { useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
-import { v4 } from 'uuid';
 
 import { useFieldMetadataItemById } from '@/object-metadata/hooks/useFieldMetadataItemById';
 import { type FieldMetadataItemOption } from '@/object-metadata/types/FieldMetadataItem';
@@ -9,7 +8,7 @@ import { computeOptionValueFromLabel } from '~/pages/settings/data-model/utils/c
 
 const DEFAULT_OPTION: FieldMetadataItemOption = {
   color: 'green',
-  id: v4(),
+  id: crypto.randomUUID(),
   label: 'Option 1',
   position: 0,
   value: computeOptionValueFromLabel('Option 1'),

--- a/packages/twenty-front/src/modules/settings/data-model/fields/forms/select/utils/generateNewSelectOption.ts
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/forms/select/utils/generateNewSelectOption.ts
@@ -1,5 +1,3 @@
-import { v4 } from 'uuid';
-
 import { type FieldMetadataItemOption } from '@/object-metadata/types/FieldMetadataItem';
 import { generateNewSelectOptionLabel } from '@/settings/data-model/fields/forms/select/utils/generateNewSelectOptionLabel';
 import { getNextThemeColor } from 'twenty-ui/theme';
@@ -12,7 +10,7 @@ export const generateNewSelectOption = (
 
   return {
     color: getNextThemeColor(options[options.length - 1]?.color),
-    id: v4(),
+    id: crypto.randomUUID(),
     label: newOptionLabel,
     position: options.length,
     value: computeOptionValueFromLabel(newOptionLabel),

--- a/packages/twenty-front/src/modules/settings/data-model/fields/preview/components/SettingsDataModelRelationFieldPreview.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/preview/components/SettingsDataModelRelationFieldPreview.tsx
@@ -10,7 +10,6 @@ import { RecordFieldComponentInstanceContext } from '@/object-record/record-fiel
 import { SettingsDataModelSetFieldValueEffect } from '@/settings/data-model/fields/preview/components/SettingsDataModelSetFieldValueEffect';
 import { useFieldPreviewValue } from '@/settings/data-model/fields/preview/hooks/useFieldPreviewValue';
 import { useIcons } from 'twenty-ui/display';
-import { v4 } from 'uuid';
 import { FieldMetadataType } from '~/generated-metadata/graphql';
 
 type SettingsDataModelRelationFieldPreviewProps = {
@@ -69,7 +68,7 @@ export const SettingsDataModelRelationFieldPreview = ({
     relationObjectNameSingular: relationTargetObjectNameSingular,
   });
 
-  const fieldName = v4();
+  const fieldName = crypto.randomUUID();
 
   const recordId = `${relationTargetObjectNameSingular}-${fieldName}-preview`;
 
@@ -86,20 +85,20 @@ export const SettingsDataModelRelationFieldPreview = ({
             {
               type: fieldMetadataItem.settings?.relationType,
               sourceFieldMetadata: {
-                id: v4(),
+                id: crypto.randomUUID(),
                 name: fieldName,
               },
               targetFieldMetadata: {
-                id: v4(),
+                id: crypto.randomUUID(),
                 name: 'does-not-matter',
               },
               sourceObjectMetadata: {
-                id: v4(),
+                id: crypto.randomUUID(),
                 namePlural: 'does-not-matter',
                 nameSingular: 'does-not-matter',
               },
               targetObjectMetadata: {
-                id: v4(),
+                id: crypto.randomUUID(),
                 namePlural: relationTargetObjectMetadataItem.namePlural,
                 nameSingular: relationTargetObjectMetadataItem.nameSingular,
               },

--- a/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/field-permissions/components/SettingsRolePermissionsObjectLevelObjectFieldPermissionTableRow.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/field-permissions/components/SettingsRolePermissionsObjectLevelObjectFieldPermissionTableRow.tsx
@@ -14,7 +14,6 @@ import styled from '@emotion/styled';
 import { useMemo } from 'react';
 import { isDefined } from 'twenty-shared/utils';
 import { useIcons } from 'twenty-ui/display';
-import { v4 } from 'uuid';
 import { type FieldPermission, RelationType } from '~/generated/graphql';
 
 export const StyledObjectFieldTableRow = styled(TableRow)`
@@ -93,7 +92,7 @@ export const SettingsRolePermissionsObjectLevelObjectFieldPermissionTableRow =
         }
       } else {
         upsertFieldPermissionInDraftRole({
-          id: v4(),
+          id: crypto.randomUUID(),
           fieldMetadataId: fieldMetadataItem.id,
           objectMetadataId: objectMetadataItem.id,
           canReadFieldValue: false,
@@ -121,7 +120,7 @@ export const SettingsRolePermissionsObjectLevelObjectFieldPermissionTableRow =
         }
       } else {
         upsertFieldPermissionInDraftRole({
-          id: v4(),
+          id: crypto.randomUUID(),
           fieldMetadataId: fieldMetadataItem.id,
           objectMetadataId: objectMetadataItem.id,
           canUpdateFieldValue: false,

--- a/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/field-permissions/hooks/useRestrictReadOnAllFieldsOfObject.ts
+++ b/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/field-permissions/hooks/useRestrictReadOnAllFieldsOfObject.ts
@@ -4,7 +4,6 @@ import { useUpsertFieldPermissionInDraftRole } from '@/settings/roles/role-permi
 import { settingsDraftRoleFamilyState } from '@/settings/roles/states/settingsDraftRoleFamilyState';
 import { useRecoilValue } from 'recoil';
 import { isDefined } from 'twenty-shared/utils';
-import { v4 } from 'uuid';
 
 export const useRestrictReadOnAllFieldsOfObject = ({
   roleId,
@@ -38,7 +37,7 @@ export const useRestrictReadOnAllFieldsOfObject = ({
           objectMetadataId: objectMetadataItem.id,
           canUpdateFieldValue: false,
           canReadFieldValue: false,
-          id: v4(),
+          id: crypto.randomUUID(),
           roleId,
         });
       }
@@ -61,7 +60,7 @@ export const useRestrictReadOnAllFieldsOfObject = ({
             objectMetadataId: objectMetadataItem.id,
             canReadFieldValue: false,
             canUpdateFieldValue: false,
-            id: v4(),
+            id: crypto.randomUUID(),
             roleId,
           });
         }

--- a/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/field-permissions/hooks/useRestrictUpdateOnAllFieldsOfObject.ts
+++ b/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/field-permissions/hooks/useRestrictUpdateOnAllFieldsOfObject.ts
@@ -4,7 +4,6 @@ import { useUpsertFieldPermissionInDraftRole } from '@/settings/roles/role-permi
 import { settingsDraftRoleFamilyState } from '@/settings/roles/states/settingsDraftRoleFamilyState';
 import { useRecoilValue } from 'recoil';
 import { isDefined } from 'twenty-shared/utils';
-import { v4 } from 'uuid';
 
 export const useRestrictUpdateOnAllFieldsOfObject = ({
   roleId,
@@ -41,7 +40,7 @@ export const useRestrictUpdateOnAllFieldsOfObject = ({
           objectMetadataId: objectMetadataItem.id,
           canUpdateFieldValue: false,
           canReadFieldValue: null,
-          id: v4(),
+          id: crypto.randomUUID(),
           roleId,
         });
       }
@@ -64,7 +63,7 @@ export const useRestrictUpdateOnAllFieldsOfObject = ({
             objectMetadataId: objectMetadataItem.id,
             canUpdateFieldValue: false,
             canReadFieldValue: null,
-            id: v4(),
+            id: crypto.randomUUID(),
             roleId,
           });
         }

--- a/packages/twenty-front/src/modules/settings/roles/role-permissions/permission-flags/components/SettingsRolePermissionsSettingsTableHeader.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/role-permissions/permission-flags/components/SettingsRolePermissionsSettingsTableHeader.tsx
@@ -7,7 +7,6 @@ import { Checkbox } from 'twenty-ui/input';
 import { type SettingsRolePermissionsSettingPermission } from '@/settings/roles/role-permissions/permission-flags/types/SettingsRolePermissionsSettingPermission';
 import { settingsDraftRoleFamilyState } from '@/settings/roles/states/settingsDraftRoleFamilyState';
 import { useRecoilState } from 'recoil';
-import { v4 } from 'uuid';
 
 type SettingsRolePermissionsSettingsTableHeaderProps = {
   roleId: string;
@@ -63,7 +62,7 @@ export const SettingsRolePermissionsSettingsTableHeader = ({
               ...settingsDraftRole,
               permissionFlags: newValue
                 ? settingsPermissionsConfig.map((permission) => ({
-                    id: v4(),
+                    id: crypto.randomUUID(),
                     flag: permission.key,
                     roleId,
                   }))

--- a/packages/twenty-front/src/modules/settings/roles/role-permissions/permission-flags/components/SettingsRolePermissionsSettingsTableRow.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/role-permissions/permission-flags/components/SettingsRolePermissionsSettingsTableRow.tsx
@@ -6,7 +6,6 @@ import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useRecoilState } from 'recoil';
 import { Checkbox } from 'twenty-ui/input';
-import { v4 } from 'uuid';
 
 const StyledTableRow = styled(TableRow)<{ isDisabled: boolean }>`
   cursor: ${({ isDisabled }) => (isDisabled ? 'default' : 'pointer')};
@@ -83,7 +82,7 @@ export const SettingsRolePermissionsSettingsTableRow = ({
         permissionFlags: [
           ...currentPermissions,
           {
-            id: v4(),
+            id: crypto.randomUUID(),
             flag: permission.key,
             roleId,
           },

--- a/packages/twenty-front/src/modules/settings/security/utils/sSOIdentityProviderDefaultValues.ts
+++ b/packages/twenty-front/src/modules/settings/security/utils/sSOIdentityProviderDefaultValues.ts
@@ -1,7 +1,6 @@
 /* @license Enterprise */
 
 import { type SettingSecurityNewSSOIdentityFormValues } from '@/settings/security/types/SSOIdentityProvider';
-import { v4 } from 'uuid';
 import { type IdentityProviderType } from '~/generated/graphql';
 
 export const sSOIdentityProviderDefaultValues: Record<
@@ -12,7 +11,7 @@ export const sSOIdentityProviderDefaultValues: Record<
     type: 'SAML',
     ssoURL: '',
     name: '',
-    id: v4(),
+    id: crypto.randomUUID(),
     certificate: '',
     issuer: '',
   }),

--- a/packages/twenty-front/src/modules/settings/serverless-functions/components/tabs/SettingsServerlessFunctionTabEnvironmentVariablesSection.tsx
+++ b/packages/twenty-front/src/modules/settings/serverless-functions/components/tabs/SettingsServerlessFunctionTabEnvironmentVariablesSection.tsx
@@ -12,7 +12,6 @@ import { H2Title, IconPlus, IconSearch } from 'twenty-ui/display';
 import { Button } from 'twenty-ui/input';
 import { Section } from 'twenty-ui/layout';
 import { MOBILE_VIEWPORT } from 'twenty-ui/theme';
-import { v4 } from 'uuid';
 
 const StyledSearchInput = styled(SettingsTextInput)`
   padding-bottom: ${({ theme }) => theme.spacing(2)};
@@ -49,7 +48,7 @@ export const SettingsServerlessFunctionTabEnvironmentVariablesSection = ({
     ? dotenv.parse(formValues.code['.env'])
     : {};
   const environmentVariablesList = Object.entries(environmentVariables).map(
-    ([key, value]) => ({ id: v4(), key, value }),
+    ([key, value]) => ({ id: crypto.randomUUID(), key, value }),
   );
 
   const [searchTerm, setSearchTerm] = useState('');
@@ -142,7 +141,7 @@ export const SettingsServerlessFunctionTabEnvironmentVariablesSection = ({
           variant="secondary"
           onClick={() => {
             setEnvVariables((prevState) => {
-              return [...prevState, { id: v4(), key: '', value: '' }];
+              return [...prevState, { id: crypto.randomUUID(), key: '', value: '' }];
             });
             setNewEnvVarAdded(true);
           }}

--- a/packages/twenty-front/src/modules/ui/feedback/dialog-manager/hooks/__tests__/useDialogManager.test.tsx
+++ b/packages/twenty-front/src/modules/ui/feedback/dialog-manager/hooks/__tests__/useDialogManager.test.tsx
@@ -1,17 +1,11 @@
 import { act, renderHook } from '@testing-library/react';
 import { RecoilRoot } from 'recoil';
-import { v4 as uuidv4 } from 'uuid';
 
 import { DialogComponentInstanceContext } from '@/ui/feedback/dialog-manager/contexts/DialogComponentInstanceContext';
 import { useDialogManager } from '@/ui/feedback/dialog-manager/hooks/useDialogManager';
 import { dialogInternalComponentState } from '@/ui/feedback/dialog-manager/states/dialogInternalComponentState';
 import { type DialogOptions } from '@/ui/feedback/dialog-manager/types/DialogOptions';
 import { useRecoilComponentValue } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValue';
-
-const mockedUuid = 'mocked-uuid';
-jest.mock('uuid');
-
-(uuidv4 as jest.Mock).mockReturnValue(mockedUuid);
 
 const Wrapper = ({ children }: { children: React.ReactNode }) => (
   <RecoilRoot>

--- a/packages/twenty-front/src/modules/ui/feedback/dialog-manager/hooks/useDialogManager.ts
+++ b/packages/twenty-front/src/modules/ui/feedback/dialog-manager/hooks/useDialogManager.ts
@@ -1,5 +1,4 @@
 import { useRecoilCallback } from 'recoil';
-import { v4 } from 'uuid';
 
 import { DIALOG_FOCUS_ID } from '@/ui/feedback/dialog-manager/constants/DialogFocusId';
 import { useRemoveFocusItemFromFocusStackById } from '@/ui/utilities/focus/hooks/useRemoveFocusItemFromFocusStackById';
@@ -61,7 +60,7 @@ export const useDialogManager = () => {
 
   const enqueueDialog = (options?: Omit<DialogOptions, 'id'>) => {
     setDialogQueue({
-      id: v4(),
+      id: crypto.randomUUID(),
       ...options,
     });
   };

--- a/packages/twenty-front/src/modules/ui/feedback/snack-bar-manager/hooks/useSnackBar.ts
+++ b/packages/twenty-front/src/modules/ui/feedback/snack-bar-manager/hooks/useSnackBar.ts
@@ -1,6 +1,5 @@
 import { useCallback } from 'react';
 import { useRecoilCallback } from 'recoil';
-import { v4 as uuidv4 } from 'uuid';
 
 import { SnackBarVariant } from '@/ui/feedback/snack-bar-manager/components/SnackBar';
 import { SnackBarComponentInstanceContext } from '@/ui/feedback/snack-bar-manager/contexts/SnackBarComponentInstanceContext';
@@ -77,7 +76,7 @@ export const useSnackBar = () => {
       options?: Omit<SnackBarOptions, 'message' | 'id'>;
     }) => {
       setSnackBarQueue({
-        id: uuidv4(),
+        id: crypto.randomUUID(),
         message,
         ...options,
         variant: SnackBarVariant.Success,
@@ -95,7 +94,7 @@ export const useSnackBar = () => {
       options?: Omit<SnackBarOptions, 'message' | 'id'>;
     }) => {
       setSnackBarQueue({
-        id: uuidv4(),
+        id: crypto.randomUUID(),
         message,
         ...options,
         variant: SnackBarVariant.Info,
@@ -113,7 +112,7 @@ export const useSnackBar = () => {
       options?: Omit<SnackBarOptions, 'message' | 'id'>;
     }) => {
       setSnackBarQueue({
-        id: uuidv4(),
+        id: crypto.randomUUID(),
         message,
         ...options,
         variant: SnackBarVariant.Warning,
@@ -143,7 +142,7 @@ export const useSnackBar = () => {
           ? getErrorMessageFromApolloError(apolloError)
           : t`An error occurred.`;
       setSnackBarQueue({
-        id: uuidv4(),
+        id: crypto.randomUUID(),
         message: errorMessage,
         ...options,
         variant: SnackBarVariant.Error,

--- a/packages/twenty-front/src/modules/ui/field/input/components/AddressInput.tsx
+++ b/packages/twenty-front/src/modules/ui/field/input/components/AddressInput.tsx
@@ -16,7 +16,6 @@ import { useListenClickOutside } from '@/ui/utilities/pointer-event/hooks/useLis
 import { useRecoilValue } from 'recoil';
 import { isDefined } from 'twenty-shared/utils';
 import { MOBILE_VIEWPORT } from 'twenty-ui/theme';
-import { v4 } from 'uuid';
 
 import { type AllowedAddressSubField } from 'twenty-shared/types';
 import { useAddressAutocomplete } from '../hooks/useAddressAutocomplete';
@@ -147,7 +146,7 @@ export const AddressInput = ({
       onChange?.(updatedAddress);
 
       if (field === 'addressStreet1' || field === 'addressCity') {
-        const token = tokenForPlaceApi ?? v4();
+        const token = tokenForPlaceApi ?? crypto.randomUUID();
         if (token !== tokenForPlaceApi) {
           setTokenForPlaceApi(token);
         }

--- a/packages/twenty-front/src/modules/ui/layout/draggable-list/components/DraggableList.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/draggable-list/components/DraggableList.tsx
@@ -6,7 +6,7 @@ import {
   type OnDragStartResponder,
 } from '@hello-pangea/dnd';
 import { useState } from 'react';
-import { v4 } from 'uuid';
+
 type DraggableListProps = {
   draggableItems: React.ReactNode;
   onDragEnd: OnDragEndResponder;
@@ -22,7 +22,7 @@ export const DraggableList = ({
   onDragEnd,
   onDragStart,
 }: DraggableListProps) => {
-  const [v4Persistable] = useState(v4());
+  const [v4Persistable] = useState(crypto.randomUUID());
 
   return (
     <DragDropContext onDragEnd={onDragEnd} onDragStart={onDragStart}>

--- a/packages/twenty-front/src/modules/ui/layout/show-page/components/ShowPageSummaryCard.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/show-page/components/ShowPageSummaryCard.tsx
@@ -12,7 +12,6 @@ import {
   type AvatarType,
   type IconComponent,
 } from 'twenty-ui/display';
-import { v4 as uuidV4 } from 'uuid';
 import { dateLocaleState } from '~/localization/states/dateLocaleState';
 import {
   beautifyExactDateTime,
@@ -127,7 +126,7 @@ export const ShowPageSummaryCard = ({
   const beautifiedCreatedAt =
     date !== '' ? beautifyPastDateRelativeToNow(date, localeCatalog) : '';
   const exactCreatedAt = date !== '' ? beautifyExactDateTime(date) : '';
-  const dateElementId = `date-id-${uuidV4()}`;
+  const dateElementId = `date-id-${crypto.randomUUID()}`;
   const inputFileRef = useRef<HTMLInputElement>(null);
   const onFileChange = (e: ChangeEvent<HTMLInputElement>) => {
     if (isDefined(e.target.files)) onUploadPicture?.(e.target.files[0]);

--- a/packages/twenty-front/src/modules/views/components/ViewBarFilterDropdownAdvancedFilterButton.tsx
+++ b/packages/twenty-front/src/modules/views/components/ViewBarFilterDropdownAdvancedFilterButton.tsx
@@ -24,7 +24,6 @@ import { isDefined } from 'twenty-shared/utils';
 import { Pill } from 'twenty-ui/components';
 import { IconFilter } from 'twenty-ui/display';
 import { MenuItem } from 'twenty-ui/navigation';
-import { v4 } from 'uuid';
 
 const StyledPill = styled(Pill)`
   background: ${({ theme }) => theme.color.blueAccent10};
@@ -86,7 +85,7 @@ export const ViewBarFilterDropdownAdvancedFilterButton = () => {
 
     if (!alreadyHasAdvancedFilterGroup) {
       const newRecordFilterGroup = {
-        id: v4(),
+        id: crypto.randomUUID(),
         viewId: currentView.id,
         logicalOperator: RecordFilterGroupLogicalOperator.AND,
       };

--- a/packages/twenty-front/src/modules/views/hooks/useCreateViewFromCurrentView.ts
+++ b/packages/twenty-front/src/modules/views/hooks/useCreateViewFromCurrentView.ts
@@ -26,7 +26,6 @@ import { mapRecordFilterToViewFilter } from '@/views/utils/mapRecordFilterToView
 import { mapRecordSortToViewSort } from '@/views/utils/mapRecordSortToViewSort';
 import { useRecoilCallback } from 'recoil';
 import { isDefined } from 'twenty-shared/utils';
-import { v4 } from 'uuid';
 import { ViewCalendarLayout } from '~/generated-metadata/graphql';
 import {
   type CreateCoreViewFieldMutationVariables,
@@ -123,7 +122,7 @@ export const useCreateViewFromCurrentView = (viewBarComponentId?: string) => {
         const result = await createCoreViewMutation({
           variables: {
             input: {
-              id: id ?? v4(),
+              id: id ?? crypto.randomUUID(),
               name: name ?? sourceView.name,
               icon: icon ?? sourceView.icon,
               key: null,
@@ -160,7 +159,7 @@ export const useCreateViewFromCurrentView = (viewBarComponentId?: string) => {
         await createViewFieldRecords(
           sourceView.viewFields.map<CreateCoreViewFieldMutationVariables>(
             ({ __typename, id: _id, ...viewField }) => ({
-              input: { ...viewField, id: v4(), viewId: newViewId },
+              input: { ...viewField, id: crypto.randomUUID(), viewId: newViewId },
             }),
           ),
         );
@@ -176,7 +175,7 @@ export const useCreateViewFromCurrentView = (viewBarComponentId?: string) => {
               ?.options?.map(
                 (option, index) =>
                   ({
-                    id: v4(),
+                    id: crypto.randomUUID(),
                     __typename: 'ViewGroup',
                     fieldMetadataId: kanbanFieldMetadataId,
                     fieldValue: option.value,
@@ -187,7 +186,7 @@ export const useCreateViewFromCurrentView = (viewBarComponentId?: string) => {
 
           viewGroupsToCreate.push({
             __typename: 'ViewGroup',
-            id: v4(),
+            id: crypto.randomUUID(),
             fieldValue: '',
             position: viewGroupsToCreate.length,
             isVisible: true,
@@ -225,7 +224,7 @@ export const useCreateViewFromCurrentView = (viewBarComponentId?: string) => {
             .map((recordSort) => mapRecordSortToViewSort(recordSort, newViewId))
             .map((viewSort) => ({
               ...viewSort,
-              id: v4(),
+              id: crypto.randomUUID(),
             }));
 
           await createViewFilterGroupRecords(viewFilterGroupsToCreate, {

--- a/packages/twenty-front/src/modules/views/hooks/useInitializeFilterOnFieldMetadataItemFromViewBarFilterDropdown.ts
+++ b/packages/twenty-front/src/modules/views/hooks/useInitializeFilterOnFieldMetadataItemFromViewBarFilterDropdown.ts
@@ -15,7 +15,6 @@ import { useRecoilComponentCallbackState } from '@/ui/utilities/state/component-
 import { VIEW_BAR_FILTER_DROPDOWN_ID } from '@/views/constants/ViewBarFilterDropdownId';
 import { useRecoilCallback } from 'recoil';
 import { getFilterTypeFromFieldType, isDefined } from 'twenty-shared/utils';
-import { v4 } from 'uuid';
 
 export const useInitializeFilterOnFieldMetadataItemFromViewBarFilterDropdown =
   () => {
@@ -115,7 +114,7 @@ export const useInitializeFilterOnFieldMetadataItemFromViewBarFilterDropdown =
                 );
 
                 const initialDateRecordFilter: RecordFilter = {
-                  id: v4(),
+                  id: crypto.randomUUID(),
                   fieldMetadataId: fieldMetadataItem.id,
                   operand: defaultOperand,
                   displayValue,

--- a/packages/twenty-front/src/modules/views/hooks/useVectorSearchFilterActions.ts
+++ b/packages/twenty-front/src/modules/views/hooks/useVectorSearchFilterActions.ts
@@ -4,7 +4,6 @@ import { isRecordFilterConsideredEmpty } from '@/object-record/record-filter/uti
 import { useVectorSearchFieldInRecordIndexContextOrThrow } from '@/views/hooks/useVectorSearchFieldInRecordIndexContextOrThrow';
 import { ViewFilterOperand } from 'twenty-shared/types';
 import { getFilterTypeFromFieldType, isDefined } from 'twenty-shared/utils';
-import { v4 } from 'uuid';
 import { useVectorSearchFilterState } from './useVectorSearchFilterState';
 
 export const useVectorSearchFilterActions = () => {
@@ -22,7 +21,7 @@ export const useVectorSearchFilterActions = () => {
     const existingVectorSearchFilter = getExistingVectorSearchFilter();
 
     const vectorSearchRecordFilter = {
-      id: existingVectorSearchFilter?.id ?? v4(),
+      id: existingVectorSearchFilter?.id ?? crypto.randomUUID(),
       fieldMetadataId: vectorSearchField.id,
       value: value,
       displayValue: value,

--- a/packages/twenty-front/src/modules/views/utils/duplicateViewFiltersAndViewFilterGroups.ts
+++ b/packages/twenty-front/src/modules/views/utils/duplicateViewFiltersAndViewFilterGroups.ts
@@ -1,6 +1,5 @@
 import { type ViewFilter } from '@/views/types/ViewFilter';
 import { type ViewFilterGroup } from '@/views/types/ViewFilterGroup';
-import { v4 } from 'uuid';
 import { isDefined } from 'twenty-shared/utils';
 
 export const duplicateViewFiltersAndViewFilterGroups = ({
@@ -18,7 +17,7 @@ export const duplicateViewFiltersAndViewFilterGroups = ({
   for (const viewFilterGroupToCopy of viewFilterGroupsToDuplicate) {
     oldViewFilterGroupIdToNewViewFilterGroupIdMap.set(
       viewFilterGroupToCopy.id,
-      v4(),
+      crypto.randomUUID(),
     );
   }
 
@@ -70,7 +69,7 @@ export const duplicateViewFiltersAndViewFilterGroups = ({
 
     return {
       ...viewFilter,
-      id: v4(),
+      id: crypto.randomUUID(),
       viewFilterGroupId: newParentViewFilterGroupId,
     } satisfies ViewFilter;
   });

--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/utils/generateNodesAndEdgesForDefaultNode.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/utils/generateNodesAndEdgesForDefaultNode.ts
@@ -12,7 +12,6 @@ import { WORKFLOW_DIAGRAM_NODE_DEFAULT_SOURCE_HANDLE_ID } from '@/workflow/workf
 import { WORKFLOW_DIAGRAM_NODE_DEFAULT_TARGET_HANDLE_ID } from '@/workflow/workflow-diagram/workflow-nodes/constants/WorkflowDiagramNodeDefaultTargetHandleId';
 import { isNonEmptyArray } from '@sniptt/guards';
 import { isDefined } from 'twenty-shared/utils';
-import { v4 } from 'uuid';
 
 export const generateNodesAndEdgesForDefaultNode = ({
   step,
@@ -66,7 +65,7 @@ export const generateNodesAndEdgesForDefaultNode = ({
       updatedEdges.push({
         ...WORKFLOW_VISUALIZER_EDGE_DEFAULT_CONFIGURATION,
         type: edgeTypeBetweenTwoNodes,
-        id: v4(),
+        id: crypto.randomUUID(),
         source: step.id,
         sourceHandle: WORKFLOW_DIAGRAM_NODE_DEFAULT_SOURCE_HANDLE_ID,
         target: nextStepId,

--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/utils/generateNodesAndEdgesForIteratorNode.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/utils/generateNodesAndEdgesForIteratorNode.ts
@@ -18,7 +18,6 @@ import { msg } from '@lingui/core/macro';
 import { isNonEmptyArray, isNonEmptyString } from '@sniptt/guards';
 import { Position } from '@xyflow/react';
 import { isDefined } from 'twenty-shared/utils';
-import { v4 } from 'uuid';
 
 export const generateNodesAndEdgesForIteratorNode = ({
   step,
@@ -87,7 +86,7 @@ export const generateNodesAndEdgesForIteratorNode = ({
     updatedEdges.push({
       ...WORKFLOW_VISUALIZER_EDGE_DEFAULT_CONFIGURATION,
       type: edgeTypeBetweenTwoNodes,
-      id: v4(),
+      id: crypto.randomUUID(),
       source: step.id,
       sourceHandle: WORKFLOW_DIAGRAM_ITERATOR_NODE_LOOP_HANDLE_ID,
       target: initialLoopStepId,
@@ -115,7 +114,7 @@ export const generateNodesAndEdgesForIteratorNode = ({
       updatedEdges.push({
         ...WORKFLOW_VISUALIZER_EDGE_DEFAULT_CONFIGURATION,
         type: edgeTypeBetweenTwoNodes,
-        id: v4(),
+        id: crypto.randomUUID(),
         source: step.id,
         sourceHandle: WORKFLOW_DIAGRAM_NODE_DEFAULT_SOURCE_HANDLE_ID,
         target: nextStepId,

--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/utils/generateWorkflowDiagram.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/utils/generateWorkflowDiagram.ts
@@ -20,7 +20,6 @@ import { WORKFLOW_DIAGRAM_NODE_DEFAULT_SOURCE_HANDLE_ID } from '@/workflow/workf
 import { WORKFLOW_DIAGRAM_NODE_DEFAULT_TARGET_HANDLE_ID } from '@/workflow/workflow-diagram/workflow-nodes/constants/WorkflowDiagramNodeDefaultTargetHandleId';
 import { isDefined } from 'twenty-shared/utils';
 import { TRIGGER_STEP_ID } from 'twenty-shared/workflow';
-import { v4 } from 'uuid';
 
 export const generateWorkflowDiagram = ({
   trigger,
@@ -48,7 +47,7 @@ export const generateWorkflowDiagram = ({
     edges.push({
       ...WORKFLOW_VISUALIZER_EDGE_DEFAULT_CONFIGURATION,
       type: edgeTypeBetweenTwoNodes,
-      id: v4(),
+      id: crypto.randomUUID(),
       source: TRIGGER_STEP_ID,
       sourceHandle: WORKFLOW_DIAGRAM_NODE_DEFAULT_SOURCE_HANDLE_ID,
       target: stepLinkToTriggerId,

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/hooks/__tests__/useCreateStep.test.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/hooks/__tests__/useCreateStep.test.tsx
@@ -33,8 +33,6 @@ jest.mock('@/workflow/hooks/useGetUpdatableWorkflowVersionOrThrow', () => ({
   }),
 }));
 
-jest.mock('uuid', () => ({ v4: () => 'step-id' }));
-
 const wrapper = ({ children }: { children: React.ReactNode }) => {
   const workflowVisualizerComponentInstanceId =
     'workflow-visualizer-instance-id';

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/ai-agent-action/components/WorkflowOutputSchemaBuilder.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/ai-agent-action/components/WorkflowOutputSchemaBuilder.tsx
@@ -9,7 +9,6 @@ import styled from '@emotion/styled';
 import { t } from '@lingui/core/macro';
 import { IconPlus, IconTrash } from 'twenty-ui/display';
 import { LightIconButton } from 'twenty-ui/input';
-import { v4 } from 'uuid';
 import { WorkflowOutputFieldTypeSelector } from './WorkflowOutputFieldTypeSelector';
 
 type WorkflowOutputSchemaBuilderProps = {
@@ -111,7 +110,7 @@ export const WorkflowOutputSchemaBuilder = ({
 
   const addField = () => {
     const newField: OutputSchemaField = {
-      id: v4(),
+      id: crypto.randomUUID(),
       name: '',
       description: '',
       type: 'TEXT' as InputSchemaPropertyType,

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/find-records-action/components/WorkflowFindRecordsAddFilterButton.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/find-records-action/components/WorkflowFindRecordsAddFilterButton.tsx
@@ -12,7 +12,7 @@ import { RecordFilterGroupLogicalOperator } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 import { IconFilter } from 'twenty-ui/display';
 import { Button } from 'twenty-ui/input';
-import { v4 } from 'uuid';
+
 export const WorkflowFindRecordsAddFilterButton = ({
   defaultFieldMetadataItem,
 }: {
@@ -43,7 +43,7 @@ export const WorkflowFindRecordsAddFilterButton = ({
       setHasInitializedCurrentRecordFilters(false);
 
       const newRecordFilterGroup = {
-        id: v4(),
+        id: crypto.randomUUID(),
         logicalOperator: RecordFilterGroupLogicalOperator.AND,
       };
 

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/form-action/components/WorkflowEditActionFormBuilder.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/form-action/components/WorkflowEditActionFormBuilder.tsx
@@ -33,7 +33,6 @@ import {
 } from 'twenty-ui/display';
 import { LightIconButton } from 'twenty-ui/input';
 import { useDebouncedCallback } from 'use-debounce';
-import { v4 } from 'uuid';
 
 export type WorkflowEditActionFormBuilderProps = {
   action: WorkflowFormAction;
@@ -368,7 +367,7 @@ export const WorkflowEditActionFormBuilder = ({
                     );
 
                     const newField: WorkflowFormActionField = {
-                      id: v4(),
+                      id: crypto.randomUUID(),
                       name,
                       type: FieldMetadataType.TEXT,
                       label,

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/form-action/utils/__tests__/getDefaultFormFieldSettings.test.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/form-action/utils/__tests__/getDefaultFormFieldSettings.test.ts
@@ -1,10 +1,6 @@
 import { FieldMetadataType } from 'twenty-shared/types';
-import { v4 } from 'uuid';
 import { getDefaultFormFieldSettings } from '../getDefaultFormFieldSettings';
 
-jest.mock('uuid', () => ({
-  v4: jest.fn(() => 'test-uuid-123'),
-}));
 
 describe('getDefaultFormFieldSettings', () => {
   beforeEach(() => {

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/form-action/utils/getDefaultFormFieldSettings.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/form-action/utils/getDefaultFormFieldSettings.ts
@@ -1,34 +1,33 @@
 import { type WorkflowFormFieldType } from '@/workflow/workflow-steps/workflow-actions/form-action/types/WorkflowFormFieldType';
 import { FieldMetadataType } from 'twenty-shared/types';
 import { assertUnreachable } from 'twenty-shared/utils';
-import { v4 } from 'uuid';
 
 export const getDefaultFormFieldSettings = (type: WorkflowFormFieldType) => {
   switch (type) {
     case FieldMetadataType.TEXT:
       return {
-        id: v4(),
+        id: crypto.randomUUID(),
         name: 'text',
         label: 'Text',
         placeholder: 'Enter your text',
       };
     case FieldMetadataType.NUMBER:
       return {
-        id: v4(),
+        id: crypto.randomUUID(),
         name: 'number',
         label: 'Number',
         placeholder: '1000',
       };
     case FieldMetadataType.DATE:
       return {
-        id: v4(),
+        id: crypto.randomUUID(),
         name: 'date',
         label: 'Date',
         placeholder: 'mm/dd/yyyy',
       };
     case 'RECORD':
       return {
-        id: v4(),
+        id: crypto.randomUUID(),
         name: 'record',
         label: 'Record',
         placeholder: `Select a Company`,
@@ -38,7 +37,7 @@ export const getDefaultFormFieldSettings = (type: WorkflowFormFieldType) => {
       };
     case FieldMetadataType.SELECT:
       return {
-        id: v4(),
+        id: crypto.randomUUID(),
         name: 'select',
         label: 'Select',
         placeholder: 'Choose a value',

--- a/packages/twenty-front/src/modules/workspace/hooks/__tests__/useSubscriptionStatus.test.ts
+++ b/packages/twenty-front/src/modules/workspace/hooks/__tests__/useSubscriptionStatus.test.ts
@@ -1,6 +1,5 @@
 import { act, renderHook } from '@testing-library/react';
 import { RecoilRoot, useSetRecoilState } from 'recoil';
-import { v4 } from 'uuid';
 
 import {
   type CurrentWorkspace,
@@ -47,7 +46,7 @@ describe('useSubscriptionStatus', () => {
         setCurrentWorkspace({
           ...currentWorkspace,
           currentBillingSubscription: {
-            id: v4(),
+            id: crypto.randomUUID(),
             status: subscriptionStatus,
             metadata: {},
             phases: [],

--- a/packages/twenty-front/src/pages/settings/roles/SettingsRoleCreate.tsx
+++ b/packages/twenty-front/src/pages/settings/roles/SettingsRoleCreate.tsx
@@ -1,10 +1,9 @@
 import { SettingsRolesQueryEffect } from '@/settings/roles/components/SettingsRolesQueryEffect';
 import { SettingsRole } from '@/settings/roles/role/components/SettingsRole';
 import { SettingsRoleCreateEffect } from '@/settings/roles/role/components/SettingsRoleCreateEffect';
-import { v4 } from 'uuid';
 
 export const SettingsRoleCreate = () => {
-  const newRoleId = v4();
+  const newRoleId = crypto.randomUUID();
 
   return (
     <>

--- a/packages/twenty-server/package.json
+++ b/packages/twenty-server/package.json
@@ -173,7 +173,6 @@
     "type-fest": "4.10.1",
     "typeorm": "patch:typeorm@0.3.20#./patches/typeorm+0.3.20.patch",
     "unzipper": "^0.12.3",
-    "uuid": "9.0.1",
     "vite-tsconfig-paths": "4.3.2",
     "zod": "^4.1.11"
   },

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-merge-many-resolver.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/resolvers/graphql-query-merge-many-resolver.service.ts
@@ -7,7 +7,7 @@ import {
 import { FieldMetadataType } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 import { In } from 'typeorm';
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID } from 'crypto';
 
 import {
   GraphqlQueryBaseResolverService,
@@ -228,7 +228,7 @@ export class GraphqlQueryMergeManyResolverService extends GraphqlQueryBaseResolv
     const dryRunRecord = {
       ...priorityRecord,
       ...mergedData,
-      id: uuidv4(),
+      id: randomUUID(),
       deletedAt: new Date().toISOString(),
     } as ObjectRecord;
 

--- a/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars/uuid.scalar.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars/uuid.scalar.ts
@@ -1,5 +1,5 @@
 import { GraphQLScalarType, Kind } from 'graphql';
-import { validate as uuidValidate } from 'uuid';
+import { randomUUID } from 'crypto';
 
 import { ValidationError } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
 
@@ -8,7 +8,7 @@ const checkUUID = (value: any): string => {
   if (typeof value !== 'string') {
     throw new ValidationError('UUID must be a string');
   }
-  if (!uuidValidate(value)) {
+  if (!randomUUID(value)) {
     throw new ValidationError('Invalid UUID');
   }
 

--- a/packages/twenty-shared/src/utils/filter/utils/createAnyFieldRecordFilterBaseProperties.ts
+++ b/packages/twenty-shared/src/utils/filter/utils/createAnyFieldRecordFilterBaseProperties.ts
@@ -1,6 +1,5 @@
 import { type PartialFieldMetadataItem } from '@/types';
 import { type RecordFilter } from '@/utils/filter';
-import { v4 } from 'uuid';
 
 export const createAnyFieldRecordFilterBaseProperties = ({
   filterValue,
@@ -13,7 +12,7 @@ export const createAnyFieldRecordFilterBaseProperties = ({
   'id' | 'value' | 'fieldMetadataId'
 > => {
   return {
-    id: v4(),
+    id: crypto.randomUUID(),
     value: filterValue,
     fieldMetadataId: fieldMetadataItem.id,
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -22535,7 +22535,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/uuid@npm:^9.0.1, @types/uuid@npm:^9.0.2":
+"@types/uuid@npm:^9.0.1":
   version: 9.0.8
   resolution: "@types/uuid@npm:9.0.8"
   checksum: 10c0/b411b93054cb1d4361919579ef3508a1f12bf15b5fdd97337d3d351bece6c921b52b6daeef89b62340fd73fd60da407878432a1af777f40648cbe53a01723489
@@ -53170,7 +53170,6 @@ __metadata:
     type-fest: "npm:4.10.1"
     typeorm: "patch:typeorm@0.3.20#./patches/typeorm+0.3.20.patch"
     unzipper: "npm:^0.12.3"
-    uuid: "npm:9.0.1"
     vite-tsconfig-paths: "npm:4.3.2"
     zod: "npm:^4.1.11"
   languageName: unknown
@@ -53380,7 +53379,6 @@ __metadata:
     "@types/react-datepicker": "npm:^6.2.0"
     "@types/react-dom": "npm:^18.2.15"
     "@types/supertest": "npm:^2.0.11"
-    "@types/uuid": "npm:^9.0.2"
     "@typescript-eslint/eslint-plugin": "npm:^8.39.0"
     "@typescript-eslint/parser": "npm:^8.39.0"
     "@typescript-eslint/utils": "npm:^8.39.0"
@@ -53485,7 +53483,6 @@ __metadata:
     tsx: "npm:^4.17.0"
     type-fest: "npm:4.10.1"
     typescript: "npm:5.9.2"
-    uuid: "npm:^9.0.0"
     vite: "npm:^7.0.0"
     vite-plugin-checker: "npm:^0.10.2"
     vite-plugin-cjs-interop: "npm:^2.2.0"


### PR DESCRIPTION
This PR drops the uuid package from node modules and replaces it with standard randomUUID usage.
* [Node.js crypto](https://nodejs.org/api/crypto.html#cryptorandomuuidoptions)
* [Web crypto](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID)