### PR TITLE
[DOCS] Error Workaround twenty-server start on WSL - JavaScript heap out of memory

### DIFF
--- a/packages/twenty-website/src/content/developers/self-hosting/troubleshooting.mdx
+++ b/packages/twenty-website/src/content/developers/self-hosting/troubleshooting.mdx
@@ -73,6 +73,18 @@ In `packages/twenty-front/.env` uncomment `VITE_DISABLE_TYPESCRIPT_CHECKER=true`
 Run only the services you need, instead of `npx nx start`. For instance, if you work on the server, run only `npx nx worker twenty-server`
 
 **If it does not work:**  
+If you tried to run only `npx nx run twenty-server:start` on WSL and its failing with the below memory error:
+
+`FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory`
+
+Workaround is to execute below command in terminal or add it in .bashrc profile to get setup automatically:
+
+`export NODE_OPTIONS="--max-old-space-size=8192"`  
+
+Please note that system memory requirement is minimum 2Gb of RAM but by setting 8GB here in WSL it should work.
+Reference: https://stackoverflow.com/questions/56982005/where-do-i-set-node-options-max-old-space-size-2048
+
+**If it does not work:**  
 Investigate which processes are taking you most of your machine RAM. At Twenty, we noticed that some VScode extensions were taking a lot of RAM so we temporarily disable them. 
 
 **If it does not work:**  

--- a/packages/twenty-website/src/content/developers/self-hosting/troubleshooting.mdx
+++ b/packages/twenty-website/src/content/developers/self-hosting/troubleshooting.mdx
@@ -81,7 +81,7 @@ Workaround is to execute below command in terminal or add it in .bashrc profile 
 
 `export NODE_OPTIONS="--max-old-space-size=8192"`  
 
-The --max-old-space-size=8192 flag sets an upper limit of 8ÿGB for the Node.js heap; usage scales with application demand.
+The --max-old-space-size=8192 flag sets an upper limit of 8GB for the Node.js heap; usage scales with application demand.
 Reference: https://stackoverflow.com/questions/56982005/where-do-i-set-node-options-max-old-space-size-2048
 
 **If it does not work:**  

--- a/packages/twenty-website/src/content/developers/self-hosting/troubleshooting.mdx
+++ b/packages/twenty-website/src/content/developers/self-hosting/troubleshooting.mdx
@@ -73,7 +73,7 @@ In `packages/twenty-front/.env` uncomment `VITE_DISABLE_TYPESCRIPT_CHECKER=true`
 Run only the services you need, instead of `npx nx start`. For instance, if you work on the server, run only `npx nx worker twenty-server`
 
 **If it does not work:**  
-If you tried to run only `npx nx run twenty-server:start` on WSL and its failing with the below memory error:
+If you tried to run only `npx nx run twenty-server:start` on WSL and it's failing with the below memory error:
 
 `FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory`
 
@@ -81,7 +81,7 @@ Workaround is to execute below command in terminal or add it in .bashrc profile 
 
 `export NODE_OPTIONS="--max-old-space-size=8192"`  
 
-Please note that system memory requirement is minimum 2Gb of RAM but by setting 8GB here in WSL it should work.
+The --max-old-space-size=8192 flag sets an upper limit of 8ÿGB for the Node.js heap; usage scales with application demand.
 Reference: https://stackoverflow.com/questions/56982005/where-do-i-set-node-options-max-old-space-size-2048
 
 **If it does not work:**  


### PR DESCRIPTION
This PR updates the troubleshooting documentation to address Javascript heap out of memory error during first start of the twenty-server. Here's a summary of the key changes:

- Added new workaround in troubleshooting.mdx addressing heap out of memory error during twenty-server:start on WSL