### PR TITLE
Prevent losing form data when workflow is not defined

### DIFF
--- a/packages/twenty-front/src/modules/command-menu/pages/workflow/step/edit/components/CommandMenuWorkflowEditStep.tsx
+++ b/packages/twenty-front/src/modules/command-menu/pages/workflow/step/edit/components/CommandMenuWorkflowEditStep.tsx
@@ -1,24 +1,18 @@
 import { useCommandMenuWorkflowIdOrThrow } from '@/command-menu/pages/workflow/hooks/useCommandMenuWorkflowIdOrThrow';
 import { CommandMenuWorkflowEditStepContent } from '@/command-menu/pages/workflow/step/edit/components/CommandMenuWorkflowEditStepContent';
-import { useWorkflowWithCurrentVersion } from '@/workflow/hooks/useWorkflowWithCurrentVersion';
 import { getWorkflowVisualizerComponentInstanceId } from '@/workflow/utils/getWorkflowVisualizerComponentInstanceId';
 import { WorkflowVisualizerComponentInstanceContext } from '@/workflow/workflow-diagram/states/contexts/WorkflowVisualizerComponentInstanceContext';
-import { isDefined } from 'twenty-shared/utils';
 
 export const CommandMenuWorkflowEditStep = () => {
   const workflowId = useCommandMenuWorkflowIdOrThrow();
-  const workflow = useWorkflowWithCurrentVersion(workflowId);
-
-  if (!isDefined(workflow)) {
-    return null;
-  }
+  const instanceId = getWorkflowVisualizerComponentInstanceId({
+    recordId: workflowId,
+  });
 
   return (
     <WorkflowVisualizerComponentInstanceContext.Provider
       value={{
-        instanceId: getWorkflowVisualizerComponentInstanceId({
-          recordId: workflowId,
-        }),
+        instanceId,
       }}
     >
       <CommandMenuWorkflowEditStepContent />

--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramEffect.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramEffect.tsx
@@ -28,9 +28,6 @@ export const WorkflowDiagramEffect = () => {
   const workflowDiagramState = useRecoilComponentCallbackState(
     workflowDiagramComponentState,
   );
-  const setWorkflowDiagram = useSetRecoilComponentState(
-    workflowDiagramComponentState,
-  );
   const setFlow = useSetRecoilComponentState(flowComponentState);
   const { populateStepsOutputSchema } = useStepsOutputSchema();
 
@@ -88,8 +85,6 @@ export const WorkflowDiagramEffect = () => {
 
   useEffect(() => {
     if (!isDefined(currentVersion)) {
-      // setFlow(undefined);
-      // setWorkflowDiagram(undefined);
       return;
     }
 
@@ -100,12 +95,7 @@ export const WorkflowDiagramEffect = () => {
     });
 
     computeAndMergeNewWorkflowDiagram(currentVersion);
-  }, [
-    computeAndMergeNewWorkflowDiagram,
-    setFlow,
-    setWorkflowDiagram,
-    currentVersion,
-  ]);
+  }, [computeAndMergeNewWorkflowDiagram, setFlow, currentVersion]);
 
   useEffect(() => {
     if (!isDefined(currentVersion)) {


### PR DESCRIPTION
When updating an active version, we :
- create a draft
- update the draft

Issue is that after the creation, workflow is shortly null. So the component is re-rendered and the form data are lost.
Removing the check on the null allow to keep the form data.