### PR TITLE
Increment metadata version  only if schema changes v2

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/services/workspace-migration-runner-v2.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/services/workspace-migration-runner-v2.service.ts
@@ -109,7 +109,7 @@ export class WorkspaceMigrationRunnerV2Service {
               return true;
             }
             default: {
-              false;
+              return false;
             }
           }
         },

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/services/workspace-migration-runner-v2.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/services/workspace-migration-runner-v2.service.ts
@@ -97,11 +97,24 @@ export class WorkspaceMigrationRunnerV2Service {
         'Runner',
         `Cache invalidation ${flatEntitiesCacheToInvalidate.join()}`,
       );
-      if (
-        flatEntitiesCacheToInvalidate.includes('flatObjectMetadataMaps') ||
-        flatEntitiesCacheToInvalidate.includes('flatFieldMetadataMaps')
-      ) {
-        // Temporarily invalidation old cache too until it's deprecated
+      const shouldIncrementMetadataGraphqlSchemaVersion = actions.some(
+        (action) => {
+          switch (action.type) {
+            case 'delete_field':
+            case 'create_field':
+            case 'update_field':
+            case 'delete_object':
+            case 'create_object':
+            case 'update_object': {
+              return true;
+            }
+            default: {
+              false;
+            }
+          }
+        },
+      );
+      if (shouldIncrementMetadataGraphqlSchemaVersion) {
         await this.workspaceMetadataVersionService.incrementMetadataVersion(
           workspaceId,
         );

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/services/workspace-migration-runner-v2.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/services/workspace-migration-runner-v2.service.ts
@@ -114,6 +114,7 @@ export class WorkspaceMigrationRunnerV2Service {
           }
         },
       );
+
       if (shouldIncrementMetadataGraphqlSchemaVersion) {
         await this.workspaceMetadataVersionService.incrementMetadataVersion(
           workspaceId,


### PR DESCRIPTION
# Introduction
After updating a `viewField` in a view the frontend receives a missmatch metadata version.

That's because the `flatFieldMetadata` needs to be invalidated on a viewField addition as it contains its primary key in its cache.
Before we would be checking updated flat entity maps, meaning that on a view field update the flat field metadata maps would also get updated, but we also invalidate the old v1 cache at the same time. Resuling in a metadata version missmatch that's not really relevant for the gql schema integrity

Now we only check if a object or field actions has been processed, if yes increment the metadata version.
We should deco-relate the v1 object and fields cache from the metadata version that should only serve as a "Please refresh browser state because gql schema has mutated"