### PR TITLE
Fixed dropping into empty group

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-drag/shared/utils/processGroupDragOperation.ts
+++ b/packages/twenty-front/src/modules/object-record/record-drag/shared/utils/processGroupDragOperation.ts
@@ -49,16 +49,43 @@ export const processGroupDragOperation = ({
     recordIdsByGroupFamilyState(destinationGroupId),
   ) as string[];
 
-  const recordsWithPosition = extractRecordPositions(
-    destinationRecordIds,
-    snapshot,
-  );
-
   const draggedRecordId = result.draggableId;
+
   const dragOperationType = getDragOperationType({
     draggedRecordId,
     selectedRecordIds,
   });
+
+  const targetGroupIsEmpty = destinationRecordIds.length === 0;
+
+  if (targetGroupIsEmpty) {
+    if (dragOperationType === 'single') {
+      onUpdateRecord(
+        {
+          recordId: draggedRecordId,
+          position: 1,
+        },
+        recordGroup.value,
+      );
+    } else {
+      for (const [index, selectedRecordId] of selectedRecordIds.entries()) {
+        onUpdateRecord(
+          {
+            recordId: selectedRecordId,
+            position: index + 1,
+          },
+          recordGroup.value,
+        );
+      }
+    }
+
+    return;
+  }
+
+  const recordsWithPosition = extractRecordPositions(
+    destinationRecordIds,
+    snapshot,
+  );
 
   const destinationIndex = result.destination.index;
 


### PR DESCRIPTION
This PR fixes a bug when dropping into an empty group with the recent refactor of the drag and drop logic in #14743 