### PR TITLE
Fixed drop multiple

### DIFF
--- a/packages/twenty-front/src/modules/object-record/utils/computeNewPositionsOfDraggedRecords.ts
+++ b/packages/twenty-front/src/modules/object-record/utils/computeNewPositionsOfDraggedRecords.ts
@@ -26,12 +26,6 @@ export const computeNewPositionsOfDraggedRecords = ({
     return null;
   }
 
-  const targetIsInSourceRecordIds = sourceRecordIds.includes(targetRecordId);
-
-  if (targetIsInSourceRecordIds) {
-    return null;
-  }
-
   const targetPosition = targetItem.position;
 
   const indexOfItemToMove = arrayOfRecordsWithPosition.findIndex(


### PR DESCRIPTION
This PR fixes a bug that prevented dropping multiple items from differents group into one of the groups containing an item of the selection.