### PR TITLE
Fix invalid UUID/workspaceMemberId error in timeline activity worker

### DIFF
--- a/packages/twenty-server/src/modules/timeline/repositories/timeline-activity.repository.ts
+++ b/packages/twenty-server/src/modules/timeline/repositories/timeline-activity.repository.ts
@@ -99,7 +99,7 @@ export class TimelineActivityRepository {
       ),
       name: In(payloads.map((payload) => payload.name)),
       workspaceMemberId: In(
-        payloads.map((payload) => payload.workspaceMemberId),
+        payloads.map((payload) => payload.workspaceMemberId || null),
       ),
       createdAt: MoreThan(tenMinutesAgo),
     };

--- a/packages/twenty-server/src/modules/timeline/services/timeline-activity.service.ts
+++ b/packages/twenty-server/src/modules/timeline/services/timeline-activity.service.ts
@@ -214,7 +214,7 @@ export class TimelineActivityService {
 
           return {
             name: `linked-${activityType}.${action}`,
-            workspaceMemberId: event.workspaceMemberId ?? '',
+            workspaceMemberId: event.workspaceMemberId,
             recordId: activityTarget[targetColumn.replace(/Id$/, '')],
             linkedRecordCachedName: activityTitle,
             linkedRecordId: activityId,


### PR DESCRIPTION
This commit fixes a PostgresException error that occurred when processing timeline activities with empty workspaceMemberId values.

workspaceMemberId appears to be optional but we set it to an empty string when it is not present. This subsequently causes issues in the postgres query. 

This change fixes the root cause. Empty string handling is added to the postgres query also for situations where bad data has already entered the db

Example error
```
[Nest] 34  - 10/13/2025, 9:09:55 PM     LOG [BullMQDriver] Job 2274 with name MessageParticipantMatchParticipantJob processed on queue messaging-queue
query failed: SELECT "timelineActivity"."happensAt" AS "timelineActivity_happensAt", "timelineActivity"."name" AS "timelineActivity_name", "timelineActivity"."properties" AS "timelineActivity_properties", "timelineActivity"."linkedRecordCachedName" AS "timelineActivity_linkedRecordCachedName", "timelineActivity"."linkedRecordId" AS "timelineActivity_linkedRecordId", "timelineActivity"."linkedObjectMetadataId" AS "timelineActivity_linkedObjectMetadataId", "timelineActivity"."id" AS "timelineActivity_id", "timelineActivity"."createdAt" AS "timelineActivity_createdAt", "timelineActivity"."updatedAt" AS "timelineActivity_updatedAt", "timelineActivity"."deletedAt" AS "timelineActivity_deletedAt", "timelineActivity"."workspaceMemberId" AS "timelineActivity_workspaceMemberId", "timelineActivity"."personId" AS "timelineActivity_personId", "timelineActivity"."companyId" AS "timelineActivity_companyId", "timelineActivity"."opportunityId" AS "timelineActivity_opportunityId", "timelineActivity"."noteId" AS "timelineActivity_noteId", "timelineActivity"."taskId" AS "timelineActivity_taskId", "timelineActivity"."workflowId" AS "timelineActivity_workflowId", "timelineActivity"."workflowVersionId" AS "timelineActivity_workflowVersionId", "timelineActivity"."workflowRunId" AS "timelineActivity_workflowRunId" FROM "workspace_8h07bh3zq5pjg65lx9qbxbgg0"."timelineActivity" "timelineActivity" WHERE ( (("timelineActivity"."noteId" IN ($1, $2)) AND ("timelineActivity"."name" IN ($3, $4)) AND ("timelineActivity"."workspaceMemberId" IN ($5, $6)) AND ("timelineActivity"."createdAt" > $7)) ) AND ( "timelineActivity"."deletedAt" IS NULL ) ORDER BY "timelineActivity"."createdAt" DESC LIMIT 1 -- PARAMETERS: [null,"aa6f2e7f-16b1-447f-9988-0ba359358609","linked-note.created","note.created","",null,"2025-10-13T20:59:55.267Z"]
error: error: invalid input syntax for type uuid: ""
/app/packages/twenty-server/dist/src/engine/twenty-orm/error-handling/compute-twenty-orm-exception.js:36
            throw new _postgresexception.PostgresException(error.message, errorCode);
                  ^

PostgresException [Error]: invalid input syntax for type uuid: ""
    at computeTwentyORMException (/app/packages/twenty-server/dist/src/engine/twenty-orm/error-handling/compute-twenty-orm-exception.js:36:19)
    at WorkspaceSelectQueryBuilder.getMany (/app/packages/twenty-server/dist/src/engine/twenty-orm/repository/workspace-select-query-builder.js:56:76)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async WorkspaceRepository.find (/app/packages/twenty-server/dist/src/engine/twenty-orm/repository/workspace.repository.js:33:24)
    at async TimelineActivityRepository.findRecentTimelineActivities (/app/packages/twenty-server/dist/src/modules/timeline/repositories/timeline-activity.repository.js:68:16)
    at async TimelineActivityRepository.upsertTimelineActivities (/app/packages/twenty-server/dist/src/modules/timeline/repositories/timeline-activity.repository.js:27:42) {
  code: '22P02'
}
```