### PR TITLE
fix: Add redirects for broken documentation links

### DIFF
--- a/packages/twenty-website/next.config.js
+++ b/packages/twenty-website/next.config.js
@@ -9,6 +9,31 @@ const nextConfig = {
       },
     ],
   },
+  async redirects() {
+    return [
+      // Old URL structure redirects
+      {
+        source: '/user-guide/section/functions/emails',
+        destination: '/user-guide/section/integrations/emails',
+        permanent: true,
+      },
+      {
+        source: '/user-guide/section/objects/fields',
+        destination: '/user-guide/section/data-model/fields',
+        permanent: true,
+      },
+      {
+        source: '/user-guide/section/objects/views-sort-filter',
+        destination: '/user-guide/section/views/views-sort-filter',
+        permanent: true,
+      },
+      {
+        source: '/user-guide/section/objects',
+        destination: '/user-guide/section/data-model/standard-objects',
+        permanent: true,
+      },
+    ];
+  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Description

This PR fixes broken documentation links reported in #14020 by adding permanent redirects for URLs that changed when the documentation structure was reorganized.

## Problem

Users are encountering 404 errors when accessing documentation through:
- Google search results
- Site search
- Bookmarked links
- External references

### Broken URLs:
- `https://twenty.com/user-guide/section/functions/emails`
- `https://twenty.com/user-guide/section/objects/fields`
- `https://twenty.com/user-guide/section/objects/views-sort-filter`
- `https://twenty.com/user-guide/section/objects`

## Solution

Added permanent (301) redirects in `next.config.js` to map old URLs to their new locations:

```javascript
/user-guide/section/functions/emails → /user-guide/section/integrations/emails
/user-guide/section/objects/fields → /user-guide/section/data-model/fields
/user-guide/section/objects/views-sort-filter → /user-guide/section/views/views-sort-filter
/user-guide/section/objects → /user-guide/section/data-model/standard-objects
```

## Benefits

- ✅ Fixes 404 errors for users accessing old links
- ✅ Preserves SEO value from existing indexed pages
- ✅ Maintains user experience for bookmarked pages
- ✅ Uses permanent (301) redirects, signaling to search engines

## Testing

Manual testing can be done by:
1. Build the website locally: `cd packages/twenty-website && npm run build`
2. Start the server: `npm start`
3. Navigate to the old URLs and verify they redirect properly

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation improvement
- [x] Improves user experience

Fixes #14020