### PR TITLE
fix: email input auto complete

### DIFF
--- a/packages/twenty-front/src/modules/auth/sign-in-up/components/internal/SignInUpEmailField.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/components/internal/SignInUpEmailField.tsx
@@ -42,6 +42,7 @@ export const SignInUpEmailField = ({
           <StyledInputContainer>
             <SettingsTextInput
               instanceId="sign-in-up-email"
+              autoComplete="email"
               autoFocus
               value={value}
               placeholder="Email"


### PR DESCRIPTION
`autoComplete` defaults to `off` which breaks Bitwarden

<img width="1058" height="224" alt="image" src="https://github.com/user-attachments/assets/432fade7-5a9c-40cb-9e7f-f0942ae56bd2" />
