### PR TITLE
Log invalid uuids

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars/uuid.scalar.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars/uuid.scalar.ts
@@ -6,10 +6,10 @@ import { ValidationError } from 'src/engine/core-modules/graphql/utils/graphql-e
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const checkUUID = (value: any): string => {
   if (typeof value !== 'string') {
-    throw new ValidationError('UUID (' + value + ') must be a string');
+    throw new ValidationError(`UUID (${value}) must be a string`);
   }
   if (!uuidValidate(value)) {
-    throw new ValidationError('Invalid UUID: ' + value);
+    throw new ValidationError(`Invalid UUID: ${value}`);
   }
 
   return value;

--- a/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars/uuid.scalar.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars/uuid.scalar.ts
@@ -6,10 +6,10 @@ import { ValidationError } from 'src/engine/core-modules/graphql/utils/graphql-e
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const checkUUID = (value: any): string => {
   if (typeof value !== 'string') {
-    throw new ValidationError('UUID must be a string');
+    throw new ValidationError('UUID (' + value + ') must be a string');
   }
   if (!uuidValidate(value)) {
-    throw new ValidationError('Invalid UUID');
+    throw new ValidationError('Invalid UUID: ' + value);
   }
 
   return value;

--- a/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars/uuid.scalar.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars/uuid.scalar.ts
@@ -22,7 +22,7 @@ export const UUIDScalarType = new GraphQLScalarType({
   parseValue: checkUUID,
   parseLiteral(ast): string {
     if (ast.kind !== Kind.STRING) {
-      throw new ValidationError('UUID must be a string');
+      throw new ValidationError(`UUID (${ast.value}) must be a string`);
     }
 
     return ast.value;

--- a/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars/uuid.scalar.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars/uuid.scalar.ts
@@ -9,7 +9,9 @@ const checkUUID = (value: any): string => {
     throw new ValidationError('UUID must be a string');
   }
   if (!uuidValidate(value)) {
-    throw new ValidationError(`Invalid UUID: ${value}`);
+    throw new ValidationError(`Invalid UUID`, {
+      value,
+    });
   }
 
   return value;

--- a/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars/uuid.scalar.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars/uuid.scalar.ts
@@ -22,7 +22,7 @@ export const UUIDScalarType = new GraphQLScalarType({
   parseValue: checkUUID,
   parseLiteral(ast): string {
     if (ast.kind !== Kind.STRING) {
-      throw new ValidationError(`UUID (${ast.value}) must be a string`);
+      throw new ValidationError('UUID must be a string');
     }
 
     return ast.value;

--- a/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars/uuid.scalar.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars/uuid.scalar.ts
@@ -6,7 +6,7 @@ import { ValidationError } from 'src/engine/core-modules/graphql/utils/graphql-e
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const checkUUID = (value: any): string => {
   if (typeof value !== 'string') {
-    throw new ValidationError(`UUID (${value}) must be a string`);
+    throw new ValidationError('UUID must be a string');
   }
   if (!uuidValidate(value)) {
     throw new ValidationError(`Invalid UUID: ${value}`);

--- a/packages/twenty-server/src/engine/core-modules/graphql/utils/graphql-errors.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/graphql/utils/graphql-errors.util.ts
@@ -122,8 +122,8 @@ export class SyntaxError extends BaseGraphQLError {
 }
 
 export class ValidationError extends BaseGraphQLError {
-  constructor(message: string) {
-    super(message, ErrorCode.GRAPHQL_VALIDATION_FAILED);
+  constructor(message: string, extensions?: BaseGraphQLError['extensions']) {
+    super(message, ErrorCode.GRAPHQL_VALIDATION_FAILED, extensions);
 
     Object.defineProperty(this, 'name', { value: 'ValidationError' });
   }

--- a/packages/twenty-server/test/integration/metadata/suites/object-metadata/__snapshots__/failing-update-one-object-metadata.integration-spec.ts.snap
+++ b/packages/twenty-server/test/integration/metadata/suites/object-metadata/__snapshots__/failing-update-one-object-metadata.integration-spec.ts.snap
@@ -164,6 +164,7 @@ exports[`Object metadata update should fail when labelIdentifier is not a uuid 1
         "status": 400,
       },
       "userFriendlyMessage": "An error occurred.",
+      "value": "not-a-uuid",
     },
     "message": "Invalid UUID",
     "name": "ValidationError",


### PR DESCRIPTION
I had an issue with invalid UUIDs, and I think it would be easier to find the offending one if the UUID were included in the error message.

This way a database dump can be easily searched.