### PR TITLE
chore(security): force happy-dom@20.0.0 via Yarn resolutions to patch RCE vulnerability.

### DIFF
--- a/package.json
+++ b/package.json
@@ -224,7 +224,8 @@
     "typescript": "5.9.2",
     "graphql-redis-subscriptions/ioredis": "^5.6.0",
     "prosemirror-view": "1.40.0",
-    "prosemirror-transform": "1.10.4"
+    "prosemirror-transform": "1.10.4",
+    "happy-dom": "20.0.0"
   },
   "version": "0.2.1",
   "nx": {},

--- a/package.json
+++ b/package.json
@@ -225,7 +225,7 @@
     "graphql-redis-subscriptions/ioredis": "^5.6.0",
     "prosemirror-view": "1.40.0",
     "prosemirror-transform": "1.10.4",
-    "happy-dom": "20.0.0"
+    "happy-dom": "20.0.2"
   },
   "version": "0.2.1",
   "nx": {},

--- a/yarn.lock
+++ b/yarn.lock
@@ -35406,14 +35406,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"happy-dom@npm:20.0.0":
-  version: 20.0.0
-  resolution: "happy-dom@npm:20.0.0"
+"happy-dom@npm:20.0.2":
+  version: 20.0.2
+  resolution: "happy-dom@npm:20.0.2"
   dependencies:
     "@types/node": "npm:^20.0.0"
     "@types/whatwg-mimetype": "npm:^3.0.2"
     whatwg-mimetype: "npm:^3.0.0"
-  checksum: 10c0/a205da48f3c98ae2b2bcb73c8f673fea66296cd2fc081065fcd5fa42b4411546c1b8f7c26ef2ca5adf0bdd1ced9aff4f429a3a4f5e6bce7724eec2747bef1a49
+  checksum: 10c0/d4449e087cb7566fb493f9e6ee99221c64177732bf944ec3e2f464033107832c637e201e3e78e81a8b35871d41aa510806f3f1a2f18b924fc6120226f337a845
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -22575,6 +22575,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/whatwg-mimetype@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "@types/whatwg-mimetype@npm:3.0.2"
+  checksum: 10c0/dad39d1e4abe760a0a963c84bbdbd26b1df0eb68aff83bdf6ecbb50ad781ead777f6906d19a87007790b750f7500a12e5624d31fc6a1529d14bd19b5c3a316d1
+  languageName: node
+  linkType: hard
+
 "@types/wrap-ansi@npm:^3.0.0":
   version: 3.0.0
   resolution: "@types/wrap-ansi@npm:3.0.0"
@@ -35399,14 +35406,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"happy-dom@npm:^15.11.0":
-  version: 15.11.7
-  resolution: "happy-dom@npm:15.11.7"
+"happy-dom@npm:20.0.0":
+  version: 20.0.0
+  resolution: "happy-dom@npm:20.0.0"
   dependencies:
-    entities: "npm:^4.5.0"
-    webidl-conversions: "npm:^7.0.0"
+    "@types/node": "npm:^20.0.0"
+    "@types/whatwg-mimetype": "npm:^3.0.2"
     whatwg-mimetype: "npm:^3.0.0"
-  checksum: 10c0/22b08cac20192b08edf2e9c857ceeda8333a3301c4b5965a9550787b00db60d6d107c726390bd45a35305cd12ab086abd656bf957a408be0fcdc9fcd389f1973
+  checksum: 10c0/a205da48f3c98ae2b2bcb73c8f673fea66296cd2fc081065fcd5fa42b4411546c1b8f7c26ef2ca5adf0bdd1ced9aff4f429a3a4f5e6bce7724eec2747bef1a49
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes [Dependabot Alert 290](https://github.com/twentyhq/twenty/security/dependabot/290) — Remote Code Execution vulnerability in happy-dom <20.0.0.

- Added Yarn "resolutions" entry for happy-dom@20.0.0 to override transitive dependency in @wyw-in-js/transform.
- Verified that all affected packages (@wyw-in-js/vite and @wyw-in-js/transform) now resolve to happy-dom@20.0.0.
- Ran full build, tests, and manual frontend checks - nothing breaks per my analysis.
- Confirmed happy-dom is used only during build-time DOM emulation and not in runtime bundles.