### PR TITLE
Format pasted JSON in Workflow HttpRequest Action

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/hooks/useTextVariableEditor.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/hooks/useTextVariableEditor.ts
@@ -8,6 +8,7 @@ import { Placeholder, UndoRedo } from '@tiptap/extensions';
 import { AllSelection } from '@tiptap/pm/state';
 import { type Editor, useEditor } from '@tiptap/react';
 import { isDefined } from 'twenty-shared/utils';
+
 type UseTextVariableEditorProps = {
   placeholder: string | undefined;
   multiline: boolean | undefined;
@@ -15,6 +16,7 @@ type UseTextVariableEditorProps = {
   defaultValue: string | undefined | null;
   onUpdate: (editor: Editor) => void;
 };
+
 export const useTextVariableEditor = ({
   placeholder,
   multiline,
@@ -27,7 +29,9 @@ export const useTextVariableEditor = ({
       Document,
       Paragraph,
       Text,
-      Placeholder.configure({ placeholder }),
+      Placeholder.configure({
+        placeholder,
+      }),
       VariableTag,
       ...(multiline
         ? [
@@ -49,14 +53,18 @@ export const useTextVariableEditor = ({
       handleKeyDown: (view, event) => {
         if (event.key === 'Enter' && !event.shiftKey) {
           event.preventDefault();
+
+          // Insert hard break using the view's state and dispatch
           if (multiline === true) {
             const { state } = view;
             const { tr } = state;
             const transaction = tr.replaceSelectionWith(
               state.schema.nodes.hardBreak.create(),
             );
+
             view.dispatch(transaction);
           }
+
           return true;
         }
         return false;
@@ -91,5 +99,6 @@ export const useTextVariableEditor = ({
     enablePasteRules: false,
     injectCSS: false,
   });
+
   return editor;
 };

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/hooks/useTextVariableEditor.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/hooks/useTextVariableEditor.ts
@@ -88,7 +88,7 @@ export const useTextVariableEditor = ({
             state: { schema, tr },
           } = view;
           const originalPos = tr.selection.from;
-          const pastedText = slice.content.firstChild?.textContent!;
+          const pastedText = slice.content.firstChild?.textContent ?? '';
 
           // Apply the clipboard text to the document without formatting
           tr.replaceSelection(slice);


### PR DESCRIPTION
## Context 

The _expected response body_ does not use monaco-editor, so enabling `formatOnPaste `as mentioned in this [comment](https://github.com/twentyhq/twenty/issues/13506#issuecomment-3188746787) didn't fix the issue below. However, the `TextVariableEditor` uses tiptap editor which has a `handlePaste` option that we can use to format JSON.
- Issue https://github.com/twentyhq/twenty/issues/13506

## Implementation:

1. Insert the clipboard text at the current selection.
2. Retrieve the full editor content, parse it as JSON and stringify it with indentation.
3. Re-use the method that transforms the text into `JSONContent`.
4. Replace the root node with the newly formatted `JSONContent`.
5. Update the cursor position based on the type of pasted text.
6. Apply the transaction with `view.dispatch()`

Note: If parsing fails (invalid JSON), the input will fall back to a normal paste.

## test

Loom: https://www.loom.com/share/f2e84d078662481f9f9f71fc98b772a1?sid=a649c4e9-8c55-4cbe-b031-7aba60af0e05
