### PR TITLE
chore (security): bump up the axios version in server to resolve a couple dependabot alerts.

### DIFF
--- a/packages/twenty-server/package.json
+++ b/packages/twenty-server/package.json
@@ -78,7 +78,7 @@
     "ai": "^5.0.44",
     "apollo-server-core": "3.13.0",
     "archiver": "7.0.1",
-    "axios": "1.10.0",
+    "axios": "1.12.2",
     "babel-plugin-module-resolver": "5.0.2",
     "bcrypt": "5.1.1",
     "bullmq": "5.40.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -25323,18 +25323,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.10.0":
-  version: 1.10.0
-  resolution: "axios@npm:1.10.0"
-  dependencies:
-    follow-redirects: "npm:^1.15.6"
-    form-data: "npm:^4.0.0"
-    proxy-from-env: "npm:^1.1.0"
-  checksum: 10c0/2239cb269cc789eac22f5d1aabd58e1a83f8f364c92c2caa97b6f5cbb4ab2903d2e557d9dc670b5813e9bcdebfb149e783fb8ab3e45098635cd2f559b06bd5d8
-  languageName: node
-  linkType: hard
-
-"axios@npm:^1.6.0":
+"axios@npm:1.12.2, axios@npm:^1.6.0":
   version: 1.12.2
   resolution: "axios@npm:1.12.2"
   dependencies:
@@ -53072,7 +53061,7 @@ __metadata:
     ai: "npm:^5.0.44"
     apollo-server-core: "npm:3.13.0"
     archiver: "npm:7.0.1"
-    axios: "npm:1.10.0"
+    axios: "npm:1.12.2"
     babel-plugin-module-resolver: "npm:5.0.2"
     bcrypt: "npm:5.1.1"
     bullmq: "npm:5.40.0"


### PR DESCRIPTION
Fixes [Dependabot Alert 283](https://github.com/twentyhq/twenty/security/dependabot/283) and [Dependabot Alert 284](https://github.com/twentyhq/twenty/security/dependabot/284) - Axios vulnerable to Denial-of-Service (DoS) due to missing data size validation.