### PR TITLE
Fix: only display the objectname in contextual  dropdowns if there are multiple objectmetadatanamessingluar

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-picker/single-record-picker/hooks/useSingleRecordPickerPerformSearch.ts
+++ b/packages/twenty-front/src/modules/object-record/record-picker/single-record-picker/hooks/useSingleRecordPickerPerformSearch.ts
@@ -48,10 +48,12 @@ export const useSingleRecordPickerPerformSearch = ({
           singleRecordPickerSearchableObjectMetadataItemsComponentState.atomFamily(
             { instanceId: singleRecordPickerInstanceId },
           ),
-          objectMetadataItems,
+          objectMetadataItems.filter((objectMetadataItem) =>
+            objectNameSingulars.includes(objectMetadataItem.nameSingular),
+          ),
         );
       },
-    [objectMetadataItems, singleRecordPickerInstanceId],
+    [objectMetadataItems, objectNameSingulars, singleRecordPickerInstanceId],
   );
 
   const selectedIdsFilter = { id: { in: selectedIds } };


### PR DESCRIPTION
Quick bugfix I found

We want this for normal relations :
<img width="260" height="326" alt="Screenshot 2025-10-16 at 13 40 00" src="https://github.com/user-attachments/assets/1710f0b7-c469-44a7-b62d-9640f4b1cdd5" />

Instead we have currently this:
<img width="243" height="284" alt="Screenshot 2025-10-16 at 13 42 07" src="https://github.com/user-attachments/assets/7b5c3dff-7221-408f-bc53-6254f2c6d4e5" />

For morph we still want this :
<img width="370" height="233" alt="Screenshot 2025-10-16 at 13 41 08" src="https://github.com/user-attachments/assets/488b7e18-fb98-4bd7-a28a-068d4289e0b9" />

