### PR TITLE
FIX: error in devtools while opening domain settings

### DIFF
--- a/packages/twenty-front/src/modules/settings/domains/components/SettingsPublicDomainsListCard.tsx
+++ b/packages/twenty-front/src/modules/settings/domains/components/SettingsPublicDomainsListCard.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { SettingsPath } from 'twenty-shared/types';
 import { IconAt, IconMailCog, Status } from 'twenty-ui/display';
 import { useFindManyPublicDomainsQuery } from '~/generated-metadata/graphql';
@@ -28,12 +29,17 @@ export const SettingsPublicDomainsListCard = () => {
 
   const publicDomains = data?.findManyPublicDomains;
 
+  useEffect(() => {
+    if (publicDomains?.length === 0) {
+      setSelectedPublicDomain(undefined);
+    }
+  }, [publicDomains, setSelectedPublicDomain]);
+
   if (loading || !publicDomains) {
     return null;
   }
 
   if (publicDomains.length === 0) {
-    setSelectedPublicDomain(undefined);
     return (
       <StyledLink to={getSettingsPath(SettingsPath.PublicDomain)}>
         <SettingsCard title={t`Add Public Domain`} Icon={<IconMailCog />} />


### PR DESCRIPTION
Fixes #15154 
Addressed a React warning that occurred on the "Settings > Domains" page: `Warning: Cannot update a component (Batcher) while rendering a different component (SettingsPublicDomainsListCard)`

The warning was caused by a state update being called directly within the render function of the `SettingsPublicDomainsListCard` component.  This PR fixes the issue by moving the state update into a useEffect hook. This ensures that the state is updated only after the component has rendered, which is the correct way to handle side effects in React.

Changes:  Wrapped the setSelectedPublicDomain(undefined) call in a useEffect hook in `SettingsPublicDomainsListCard.tsx`.
   