### PR TITLE
Fix: Enable destroy/restore actions when viewing deleted records dire…

### DIFF
--- a/packages/twenty-front/src/modules/action-menu/hooks/useShouldActionBeRegisteredParams.ts
+++ b/packages/twenty-front/src/modules/action-menu/hooks/useShouldActionBeRegisteredParams.ts
@@ -52,9 +52,14 @@ export const useShouldActionBeRegisteredParams = ({
 
   const { isInRightDrawer } = useContext(ActionMenuContext);
 
-  const hasAnySoftDeleteFilterOnView = useRecoilComponentValue(
+  const hasAnySoftDeleteFilterOnViewFromFilters = useRecoilComponentValue(
     hasAnySoftDeleteFilterOnViewComponentSelector,
   );
+  
+  // When viewing a deleted record directly (e.g., through command menu), 
+  // treat it as if we're in a deleted records view
+  const hasAnySoftDeleteFilterOnView = 
+    hasAnySoftDeleteFilterOnViewFromFilters || isDefined(selectedRecord?.deletedAt);
 
   const isShowPage =
     useRecoilComponentValue(contextStoreCurrentViewTypeComponentState) ===


### PR DESCRIPTION
## Issue
When a user deletes a record and then tries to access it via the command menu, the "Destroy" and "Restore" buttons are not available in either the table view or the command menu.

## Root Cause
The action registration logic only considered filters to determine if we're viewing deleted records, but didn't account for the case where we're viewing a deleted record directly (e.g., through the command menu search).

## Solution
Modified the [useShouldActionBeRegisteredParams](cci:1://file:///f:/HackContri/twenty/packages/twenty-front/src/modules/action-menu/hooks/useShouldActionBeRegisteredParams.ts:19:0-127:2) hook to also consider a record as being in a deleted view when the selected record has `deletedAt` set. This ensures that both single record actions (like `DestroySingleRecordAction`) and multiple records actions (like `DestroyMultipleRecordsAction`) are properly registered when viewing deleted records directly.

## Testing
- Verified that destroy/restore actions appear when viewing deleted records through command menu
- Verified that existing functionality for filtered deleted record views still works

Fixes #15156