### PR TITLE
Fix: Match cell editor width to column width

### DIFF
--- a/packages/twenty-front/src/modules/action-menu/hooks/useShouldActionBeRegisteredParams.ts
+++ b/packages/twenty-front/src/modules/action-menu/hooks/useShouldActionBeRegisteredParams.ts
@@ -16,6 +16,7 @@ import { recordStoreFamilyState } from '@/object-record/record-store/states/reco
 import { useRecoilComponentValue } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValue';
 import { useContext } from 'react';
 import { useRecoilCallback, useRecoilValue } from 'recoil';
+import { isDefined } from 'twenty-shared/utils';
 
 export const useShouldActionBeRegisteredParams = ({
   objectMetadataItem,

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellEditMode.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellEditMode.tsx
@@ -5,6 +5,7 @@ import { recordFieldInputLayoutDirectionComponentState } from '@/object-record/r
 import { recordFieldInputLayoutDirectionLoadingComponentState } from '@/object-record/record-field/ui/states/recordFieldInputLayoutDirectionLoadingComponentState';
 import { RecordTableCellContext } from '@/object-record/record-table/contexts/RecordTableCellContext';
 import { useFocusRecordTableCell } from '@/object-record/record-table/record-table-cell/hooks/useFocusRecordTableCell';
+import { getRecordTableColumnFieldWidthCSSVariableName } from '@/object-record/record-table/utils/getRecordTableColumnFieldWidthCSSVariableName';
 import { OverlayContainer } from '@/ui/layout/overlay/components/OverlayContainer';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useRecoilComponentValue } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValue';
@@ -36,6 +37,13 @@ const StyledInputModeOnlyContainer = styled.div`
   overflow: hidden;
   padding-left: 8px;
   width: 100%;
+`;
+
+const StyledOverlayContainer = styled(OverlayContainer)<{
+  columnIndex: number;
+}>`
+  width: var(${({ columnIndex }) => 
+    getRecordTableColumnFieldWidthCSSVariableName(columnIndex)});
 `;
 
 export type RecordTableCellEditModeProps = {
@@ -108,14 +116,15 @@ export const RecordTableCellEditMode = ({
           {children}
         </StyledInputModeOnlyContainer>
       ) : (
-        <OverlayContainer
+        <StyledOverlayContainer
           ref={refs.setFloating}
           style={floatingStyles}
           borderRadius="sm"
           hasDangerBorder={isFieldInError}
+          columnIndex={cellPosition.column}
         >
           {children}
-        </OverlayContainer>
+        </StyledOverlayContainer>
       )}
     </StyledEditableCellEditModeContainer>
   );


### PR DESCRIPTION
## Issue
When a cell is opened for editing, the popup cell editor has a pre-specified width that doesn't match the width of the corresponding column that triggered the cell editor to emerge.



## Root Cause
The `OverlayContainer` in [RecordTableCellEditMode](cci:1://file:///f:/HackContri/twenty/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellEditMode.tsx:45:0-122:2) was using its default width instead of matching the column width.

## Solution
Modified [RecordTableCellEditMode](cci:1://file:///f:/HackContri/twenty/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/components/RecordTableCellEditMode.tsx:45:0-122:2) to:
1. Import [getRecordTableColumnFieldWidthCSSVariableName](cci:1://file:///f:/HackContri/twenty/packages/twenty-front/src/modules/object-record/record-table/utils/getRecordTableColumnFieldWidthCSSVariableName.ts:0:0-4:2) utility
2. Create `StyledOverlayContainer` that extends `OverlayContainer` with dynamic width
3. Use CSS variable `--record-table-column-field-{columnIndex}` to set width based on column index
4. Pass `cellPosition.column` as `columnIndex` prop

## Technical Details
- Uses existing CSS variable system that stores column widths
- Leverages `cellPosition.column` from `RecordTableCellContext`
- Maintains all existing functionality while fixing the width issue
- No breaking changes to existing API

## Testing
- Cell editors now properly match their column widths
- All existing functionality is preserved
- Follows existing CSS variable patterns in the codebase

## Expected Behavior
The cell editor width now dynamically matches the width of the column that triggered it, providing a consistent and intuitive user experience.

Fixes #14599