### PR TITLE
Fix Ctrl+K shortcut conflict between command menu and link insertion

### DIFF
--- a/packages/twenty-front/src/modules/command-menu/hooks/useCommandMenuHotKeys.ts
+++ b/packages/twenty-front/src/modules/command-menu/hooks/useCommandMenuHotKeys.ts
@@ -45,9 +45,18 @@ export const useCommandMenuHotKeys = () => {
 
   useGlobalHotkeys({
     keys: ['ctrl+k', 'meta+k'],
-    callback: () => {
-      closeKeyboardShortcutMenu();
-      toggleCommandMenu();
+    callback: (e: KeyboardEvent) => {
+      const active = document.activeElement;
+      const isInEditor = active?.closest('.editor');
+      if (isInEditor !== null) {
+        return true;
+      }
+
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        closeKeyboardShortcutMenu();
+        toggleCommandMenu();
+      }
     },
     containsModifier: true,
     dependencies: [closeKeyboardShortcutMenu, toggleCommandMenu],


### PR DESCRIPTION
## Description

Ensures the Notes editor’s link shortcut (ctrl+K / cmd+K) takes priority when focused, preventing the global command menu from triggering inside the editor.

Closes #14949 