### PR TITLE
Fix settings admin workspace

### DIFF
--- a/packages/twenty-front/src/modules/settings/admin-panel/components/SettingsAdminWorkspaceContent.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/components/SettingsAdminWorkspaceContent.tsx
@@ -169,7 +169,9 @@ export const SettingsAdminWorkspaceContent = ({
     {
       Icon: IconId,
       label: t`Schema name`,
-      value: getWorkspaceSchemaName(activeWorkspace?.id!),
+      value: isDefined(activeWorkspace?.id)
+        ? getWorkspaceSchemaName(activeWorkspace.id)
+        : '',
     },
     {
       Icon: IconLink,


### PR DESCRIPTION
We have a bug in production where activeWorkspace isn't defined and call to getWorkspaceSchemaName() breaks. 
Let's fix it!