### PR TITLE
fix: Convert NaN to null in GraphQL aggregate responses to prevent serialization errors

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/group-by/resolvers/utils/__tests__/format-result-with-group-by-dimension-values.util.spec.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/group-by/resolvers/utils/__tests__/format-result-with-group-by-dimension-values.util.spec.ts
@@ -1,0 +1,110 @@
+import { formatResultWithGroupByDimensionValues } from '../format-result-with-group-by-dimension-values.util';
+
+describe('formatResultWithGroupByDimensionValues', () => {
+  it('should convert NaN values to null in group results', () => {
+    const result = [
+      {
+        city: 'Paris',
+        avgEmployees: NaN,
+        totalCount: 5,
+        maxRevenue: 100000,
+      },
+      {
+        city: 'London',
+        avgEmployees: 25,
+        totalCount: 3,
+        maxRevenue: NaN,
+      },
+    ];
+
+    const groupByColumnsWithQuotes = [
+      {
+        columnNameWithQuotes: '"city"',
+        alias: 'city',
+      },
+    ];
+
+    const formatted = formatResultWithGroupByDimensionValues(
+      result,
+      groupByColumnsWithQuotes,
+    );
+
+    expect(formatted).toHaveLength(2);
+    expect(formatted[0]).toMatchObject({
+      city: 'Paris',
+      avgEmployees: null, // NaN should be converted to null
+      totalCount: 5,
+      maxRevenue: 100000,
+    });
+    expect(formatted[1]).toMatchObject({
+      city: 'London',
+      avgEmployees: 25,
+      totalCount: 3,
+      maxRevenue: null, // NaN should be converted to null
+    });
+  });
+
+  it('should handle normal numeric values correctly', () => {
+    const result = [
+      {
+        category: 'A',
+        avgValue: 42.5,
+        minValue: 0,
+        maxValue: -10.5,
+        totalCount: 100,
+      },
+    ];
+
+    const groupByColumnsWithQuotes = [
+      {
+        columnNameWithQuotes: '"category"',
+        alias: 'category',
+      },
+    ];
+
+    const formatted = formatResultWithGroupByDimensionValues(
+      result,
+      groupByColumnsWithQuotes,
+    );
+
+    expect(formatted).toHaveLength(1);
+    expect(formatted[0]).toMatchObject({
+      category: 'A',
+      avgValue: 42.5,
+      minValue: 0, // Zero should pass through
+      maxValue: -10.5, // Negative values should pass through
+      totalCount: 100,
+    });
+  });
+
+  it('should handle null and undefined values correctly', () => {
+    const result = [
+      {
+        region: 'North',
+        avgRevenue: null,
+        maxProfit: undefined,
+        totalCount: 0,
+      },
+    ];
+
+    const groupByColumnsWithQuotes = [
+      {
+        columnNameWithQuotes: '"region"',
+        alias: 'region',
+      },
+    ];
+
+    const formatted = formatResultWithGroupByDimensionValues(
+      result,
+      groupByColumnsWithQuotes,
+    );
+
+    expect(formatted).toHaveLength(1);
+    expect(formatted[0]).toMatchObject({
+      region: 'North',
+      avgRevenue: null, // null should pass through
+      maxProfit: undefined, // undefined should pass through
+      totalCount: 0,
+    });
+  });
+});

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/group-by/resolvers/utils/format-result-with-group-by-dimension-values.util.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/group-by/resolvers/utils/format-result-with-group-by-dimension-values.util.ts
@@ -27,11 +27,21 @@ export const formatResultWithGroupByDimensionValues = (
     for (const groupByColumn of groupByColumnsWithQuotes) {
       dimensionValues.push(group[groupByColumn.alias]);
     }
+
+    // Sanitize NaN values in the group object to prevent GraphQL Float serialization errors
+    const sanitizedGroup = Object.entries(group).reduce<Record<string, unknown>>(
+      (acc, [key, value]) => {
+        acc[key] = typeof value === 'number' && Number.isNaN(value) ? null : value;
+        return acc;
+      },
+      {},
+    );
+
     const groupWithValueMappedToUnaliasedColumn = {
-      ...group,
+      ...sanitizedGroup,
       ...groupByColumnsWithQuotes.reduce<Record<string, unknown>>(
         (acc, groupByColumn) => {
-          const value = group[groupByColumn.alias];
+          const value = sanitizedGroup[groupByColumn.alias];
 
           acc[removeQuotes(groupByColumn.columnNameWithQuotes)] =
             getTranslatedValueIfApplicable(

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/helpers/__tests__/object-records-to-graphql-connection.helper.spec.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/helpers/__tests__/object-records-to-graphql-connection.helper.spec.ts
@@ -1,0 +1,92 @@
+import { ObjectRecordsToGraphqlConnectionHelper } from '../object-records-to-graphql-connection.helper';
+
+describe('ObjectRecordsToGraphqlConnectionHelper', () => {
+  const mockObjectMetadataMaps = {
+    byId: {},
+    byNameSingular: {},
+    byNamePlural: {},
+  };
+
+  describe('extractAggregatedFieldsValues', () => {
+    it('should convert NaN values to null', () => {
+      const helper = new ObjectRecordsToGraphqlConnectionHelper(
+        mockObjectMetadataMaps,
+      );
+
+      const selectedAggregatedFields = {
+        avgEmployees: [],
+        avgRevenue: [],
+        totalCount: [],
+      };
+
+      const objectRecordsAggregatedValues = {
+        avgEmployees: NaN,
+        avgRevenue: 100.5,
+        totalCount: 42,
+      };
+
+      // Use reflection to access the private method for testing
+      const result = (helper as any).extractAggregatedFieldsValues({
+        selectedAggregatedFields,
+        objectRecordsAggregatedValues,
+      });
+
+      expect(result).toEqual({
+        avgEmployees: null, // NaN should be converted to null
+        avgRevenue: 100.5, // Normal numbers should pass through
+        totalCount: 42,
+      });
+    });
+
+    it('should handle null and undefined values correctly', () => {
+      const helper = new ObjectRecordsToGraphqlConnectionHelper(
+        mockObjectMetadataMaps,
+      );
+
+      const selectedAggregatedFields = {
+        avgEmployees: [],
+        maxSalary: [],
+      };
+
+      const objectRecordsAggregatedValues = {
+        avgEmployees: null,
+        maxSalary: undefined,
+      };
+
+      const result = (helper as any).extractAggregatedFieldsValues({
+        selectedAggregatedFields,
+        objectRecordsAggregatedValues,
+      });
+
+      // null should be omitted (isDefined check)
+      // undefined should be omitted (isDefined check)
+      expect(result).toEqual({});
+    });
+
+    it('should handle zero and negative numbers correctly', () => {
+      const helper = new ObjectRecordsToGraphqlConnectionHelper(
+        mockObjectMetadataMaps,
+      );
+
+      const selectedAggregatedFields = {
+        avgBalance: [],
+        minValue: [],
+      };
+
+      const objectRecordsAggregatedValues = {
+        avgBalance: 0,
+        minValue: -42.5,
+      };
+
+      const result = (helper as any).extractAggregatedFieldsValues({
+        selectedAggregatedFields,
+        objectRecordsAggregatedValues,
+      });
+
+      expect(result).toEqual({
+        avgBalance: 0, // Zero should pass through
+        minValue: -42.5, // Negative numbers should pass through
+      });
+    });
+  });
+});

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/helpers/object-records-to-graphql-connection.helper.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/helpers/object-records-to-graphql-connection.helper.ts
@@ -112,10 +112,17 @@ export class ObjectRecordsToGraphqlConnectionHelper {
           return acc;
         }
 
+        // Guard against NaN values that would cause GraphQL Float serialization errors
+        // Convert NaN to null to ensure proper GraphQL type compatibility
+        const sanitizedValue =
+          typeof aggregatedFieldValue === 'number' &&
+          Number.isNaN(aggregatedFieldValue)
+            ? null
+            : aggregatedFieldValue;
+
         return {
           ...acc,
-          [aggregatedFieldName]:
-            objectRecordsAggregatedValues[aggregatedFieldName],
+          [aggregatedFieldName]: sanitizedValue,
         };
       },
       {},


### PR DESCRIPTION
### Related issue(s)/PR(s)
- ### Fixes #15192

## Problem
When listing records with aggregated fields (especially AVG operations on CURRENCY fields like `avgAnnualRecurringRevenueAmountMicros`), the application was failing with the error:

```
ApolloError: Float cannot represent non numeric value: NaN
```

This error occurs when GraphQL's `Float` scalar type attempts to serialize a JavaScript `NaN` value, which is not allowed by the GraphQL specification.

## Solution

The fix adds NaN sanitization in two key locations where aggregate results are processed before being passed to GraphQL:

### 1. `ObjectRecordsToGraphqlConnectionHelper` (for findMany queries)

**File**: `packages/twenty-server/src/engine/api/graphql/graphql-query-runner/helpers/object-records-to-graphql-connection.helper.ts`

**Change**: Modified the `extractAggregatedFieldsValues` method to check for `NaN` values and convert them to `null`:

```typescript
// Guard against NaN values that would cause GraphQL Float serialization errors
// Convert NaN to null to ensure proper GraphQL type compatibility
const sanitizedValue =
  typeof aggregatedFieldValue === 'number' &&
  Number.isNaN(aggregatedFieldValue)
    ? null
    : aggregatedFieldValue;

return {
          ...acc,
          [aggregatedFieldName]: sanitizedValue,
        };
```

### 2. `formatResultWithGroupByDimensionValues` (for groupBy queries)

**File**: `packages/twenty-server/src/engine/api/graphql/graphql-query-runner/group-by/resolvers/utils/format-result-with-group-by-dimension-values.util.ts`

**Change**: Added sanitization of the entire group object before processing:

```typescript
    // Sanitize NaN values in the group object to prevent GraphQL Float serialization errors
    const sanitizedGroup = Object.entries(group).reduce<Record<string, unknown>>(
      (acc, [key, value]) => {
        acc[key] = typeof value === 'number' && Number.isNaN(value) ? null : value;
        return acc;
      },
      {},
    );

    const groupWithValueMappedToUnaliasedColumn = {
      ...sanitizedGroup,
      ...groupByColumnsWithQuotes.reduce<Record<string, unknown>>(
        (acc, groupByColumn) => {
          const value = sanitizedGroup[groupByColumn.alias];

          acc[removeQuotes(groupByColumn.columnNameWithQuotes)] =
            getTranslatedValueIfApplicable(
              value,
              groupByColumn.dateGranularity,
            );

          return acc;
        },
        {},
      ),
    };
```

Both now convert NaN values to null before GraphQL serialization.

## Changes
- ✅ Sanitize aggregate values in findMany queries
- ✅ Sanitize aggregate values in groupBy queries
- ✅ Add unit tests for both sanitization paths
- ✅ Preserve all other numeric values (0, negatives, Infinity)

## Why This Fix Works
1. **Type Safety**: The fix checks `typeof value === 'number'` before calling `Number.isNaN()` to ensure we only process numeric values.
2. **GraphQL Compatibility**: By converting `NaN` to `null`, we ensure all values passed to GraphQL are valid for the `Float` scalar type, which accepts finite numbers and `null`.
3. **Minimal Impact**: The fix only affects values that are already problematic (`NaN`). Normal numeric values (including `0`, negative numbers, and `Infinity`) pass through unchanged.
4. **Semantic Correctness**: Converting `NaN` to `null` is semantically appropriate for aggregate operations, as both represent "no valid value" or "undefined result".

## Testing
Added unit tests:
- **`object-records-to-graphql-connection.helper.spec.ts`**
- **`format-result-with-group-by-dimension-values.util.spec.ts`**
Unit tests were added for both modified functions:
1. **`object-records-to-graphql-connection.helper.spec.ts`**: Tests that `NaN` values in aggregated fields are converted to `null` while preserving valid numeric values.
2. **`format-result-with-group-by-dimension-values.util.spec.ts`**: Tests that `NaN` values in group-by results are converted to `null`.
- Unit tests added for both modified functions
- Verified NaN → null conversion
- Verified other numeric values pass through unchanged

## Impact
- Users can now list records with aggregate fields that have no/null values
- API returns `null` instead of throwing an error
- Minimal performance impact (simple type check)

Fixes #15192