### PR TITLE
Fix worker health check using wrong Redis connection

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/health/indicators/worker.health.ts
+++ b/packages/twenty-server/src/engine/core-modules/health/indicators/worker.health.ts
@@ -54,7 +54,7 @@ export class WorkerHealthIndicator {
       pointsNeeded?: number;
     },
   ): Promise<WorkerQueueHealth | null> {
-    const redis = this.redisClient.getClient();
+    const redis = this.redisClient.getQueueClient();
     const queue = new Queue(queueName, { connection: redis });
 
     try {


### PR DESCRIPTION
Health check was connecting to REDIS_URL instead of REDIS_QUEUE_URL where workers are actually running.