### PR TITLE
fix(record-index): Allow RecordIndexContainer to use full available height (#15127)

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-index/components/RecordIndexContainer.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-index/components/RecordIndexContainer.tsx
@@ -30,7 +30,7 @@ const StyledContainer = styled.div`
 
 const StyledContainerWithPadding = styled.div`
   box-sizing: border-box;
-  height=100% ; 
+  height: 100% ; 
   margin-left: ${({ theme }) => theme.spacing(2)};
 `;
 

--- a/packages/twenty-front/src/modules/object-record/record-index/components/RecordIndexContainer.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-index/components/RecordIndexContainer.tsx
@@ -30,7 +30,7 @@ const StyledContainer = styled.div`
 
 const StyledContainerWithPadding = styled.div`
   box-sizing: border-box;
-  height: calc(100% - ${({ theme }) => theme.spacing(10)});
+  height=100% ; 
   margin-left: ${({ theme }) => theme.spacing(2)};
 `;
 


### PR DESCRIPTION
## Description

This Pull Request addresses the issue where the Calendar view (and potentially other content nested within the RecordIndexContainer) was being cut off due to an unnecessary fixed height calculation.

The container was using:
`height: calc(100% - theme.spacing(10));`

This calculation subtracted a fixed height, preventing the content from scrolling correctly and using the full viewport space.

## Solution

I have updated the CSS-in-JS definition to remove the fixed subtraction, ensuring the container utilizes the full available height.

**Change made in `RecordIndexContainer.tsx` (Line 33):**
- **BEFORE:** `height: calc(100% - ${({ theme }) => theme.spacing(10)});`
- **AFTER:** `height: 100%;`

This fix ensures the content is no longer prematurely constrained.

---

**Fixes #15127**