### PR TITLE
release - upgrade next js on twenty website

### DIFF
--- a/packages/twenty-website/package.json
+++ b/packages/twenty-website/package.json
@@ -23,7 +23,7 @@
     "drizzle-kit": "^0.20.14",
     "facepaint": "^1.2.1",
     "gray-matter": "^4.0.3",
-    "next": "^14.2.0",
+    "next": "^14.2.25",
     "next-mdx-remote": "^4.4.1",
     "next-runtime-env": "^3.3.0",
     "postgres": "^3.4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -42772,7 +42772,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next@npm:^14.2.0":
+"next@npm:^14.2.25":
   version: 14.2.33
   resolution: "next@npm:14.2.33"
   dependencies:
@@ -51994,7 +51994,7 @@ __metadata:
     eslint-config-next: "npm:^14.2.0"
     facepaint: "npm:^1.2.1"
     gray-matter: "npm:^4.0.3"
-    next: "npm:^14.2.0"
+    next: "npm:^14.2.25"
     next-mdx-remote: "npm:^4.4.1"
     next-runtime-env: "npm:^3.3.0"
     postgres: "npm:^3.4.3"


### PR DESCRIPTION
To fix https://github.com/twentyhq/twenty/security/dependabot/216