### PR TITLE
feat: self-signed certificate download for redis

### DIFF
--- a/packages/twenty-docker/docker-compose.yml
+++ b/packages/twenty-docker/docker-compose.yml
@@ -45,6 +45,8 @@ services:
       # EMAIL_SMTP_USER: ${EMAIL_SMTP_USER:-}
       # EMAIL_SMTP_PASSWORD: ${EMAIL_SMTP_PASSWORD:-}
 
+      # SELF_SIGNED_CERTIFICATE_URL: ${SELF_SIGNED_CERTIFICATE_URL}
+
     depends_on:
       db:
         condition: service_healthy
@@ -96,6 +98,8 @@ services:
       # EMAIL_SMTP_PORT: ${EMAIL_SMTP_PORT:-465}
       # EMAIL_SMTP_USER: ${EMAIL_SMTP_USER:-}
       # EMAIL_SMTP_PASSWORD: ${EMAIL_SMTP_PASSWORD:-}
+
+      # SELF_SIGNED_CERTIFICATE_URL: ${SELF_SIGNED_CERTIFICATE_URL}
 
     depends_on:
       db:

--- a/packages/twenty-docker/twenty/entrypoint.sh
+++ b/packages/twenty-docker/twenty/entrypoint.sh
@@ -28,7 +28,7 @@ setup_and_migrate_db() {
         NODE_OPTIONS="--max-old-space-size=1500" tsx ./scripts/setup-db.ts
         yarn database:migrate:prod
     fi
-    
+
     yarn command:prod upgrade
     echo "Successfully migrated DB!"
 }
@@ -38,7 +38,7 @@ register_background_jobs() {
         echo "Cron job registration is disabled, skipping..."
         return
     fi
-  
+
     echo "Registering background sync jobs..."
     if yarn command:prod cron:register:all; then
         echo "Successfully registered all background sync jobs!"
@@ -47,6 +47,19 @@ register_background_jobs() {
     fi
 }
 
+download_self_signed_certificate() {
+    if [ -z "${SELF_SIGNED_CERTIFICATE_URL}" ]; then
+        echo "Self-signed certificate URL is not set, skipping..."
+        return
+    fi
+
+    echo "Downloading self-signed certificate from ${SELF_SIGNED_CERTIFICATE_URL}..."
+    curl -o /app/self-signed.pem ${SELF_SIGNED_CERTIFICATE_URL} -s
+    export NODE_EXTRA_CA_CERTS=/app/self-signed.pem
+    echo "Successfully downloaded self-signed certificate!"
+}
+
+download_self_signed_certificate
 setup_and_migrate_db
 register_background_jobs
 


### PR DESCRIPTION
I use Scaleway managed service to host redis, and they have a self signed certificate. Downloading and adding the NODE_EXTRA_CA_CERTS fix the following error : 
```
server-1  | Error: self-signed certificate; if the root CA is installed locally, try running Node.js with --use-system-ca
server-1  |     at TLSSocket.onConnectSecure (node:_tls_wrap:1631:34)
server-1  |     at TLSSocket.emit (node:events:508:28)
server-1  |     at TLSSocket._finishInit (node:_tls_wrap:1077:8)
server-1  |     at ssl.onhandshakedone (node:_tls_wrap:863:12) {
server-1  |   code: 'DEPTH_ZERO_SELF_SIGNED_CERT'
server-1  | }
```