### PR TITLE
fix: dset prototype pollution vulnerability

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -30828,9 +30828,9 @@ __metadata:
   linkType: hard
 
 "dset@npm:^3.1.1, dset@npm:^3.1.2":
-  version: 3.1.3
-  resolution: "dset@npm:3.1.3"
-  checksum: 10c0/b1ff68f1f42af373baa85b00b04d89094cd0d7f74f94bd11364cba575f2762ed52a0a0503bbfcc92eccd07c6d55426813c8a7a6cfa020338eaea1f4edfd332c2
+  version: 3.1.4
+  resolution: "dset@npm:3.1.4"
+  checksum: 10c0/b67bbd28dd8a539e90c15ffb61100eb64ef995c5270a124d4f99bbb53f4d82f55a051b731ba81f3215dd9dce2b4c8d69927dc20b3be1c5fc88bab159467aa438
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes [Dependabot Alert 123](https://github.com/twentyhq/twenty/security/dependabot/123) - dset prototype pollution vulnerability.

Used `yarn up dset --recursive` to update the patch versions. Two parent packages depend on dset - `@graphql-tools/utils` and `graphql-yoga`. Both allow patch version updates with `^` - `^3.1.1` and `^3.1.2`.