### PR TITLE
Use array fields in filter steps

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormArrayFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormArrayFieldInput.tsx
@@ -25,6 +25,7 @@ import { isStandaloneVariableString } from '@/workflow/utils/isStandaloneVariabl
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useLingui } from '@lingui/react/macro';
+import { isNonEmptyArray } from '@sniptt/guards';
 import { useId, useRef, useState } from 'react';
 import { isDefined } from 'twenty-shared/utils';
 import { IconPlus } from 'twenty-ui/display';
@@ -74,24 +75,6 @@ const parseSpacingValueAsNumber = (value: string) => {
   return Number(value.replace('px', ''));
 };
 
-const getDefaultArrayValue = (
-  defaultValue: FieldArrayValue | string | undefined,
-): FieldArrayValue => {
-  if (!isDefined(defaultValue)) {
-    return [];
-  }
-
-  if (Array.isArray(defaultValue)) {
-    return defaultValue;
-  }
-
-  try {
-    return JSON.parse(defaultValue);
-  } catch {
-    return [];
-  }
-};
-
 export const FormArrayFieldInput = ({
   label,
   defaultValue,
@@ -129,7 +112,10 @@ export const FormArrayFieldInput = ({
         }
       : {
           type: 'static',
-          value: getDefaultArrayValue(defaultValue),
+          value:
+            isDefined(defaultValue) && isNonEmptyArray(defaultValue)
+              ? defaultValue
+              : [],
         },
   );
 

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormArrayFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormArrayFieldInput.tsx
@@ -74,6 +74,24 @@ const parseSpacingValueAsNumber = (value: string) => {
   return Number(value.replace('px', ''));
 };
 
+const getDefaultArrayValue = (
+  defaultValue: FieldArrayValue | string | undefined,
+): FieldArrayValue => {
+  if (!isDefined(defaultValue)) {
+    return [];
+  }
+
+  if (Array.isArray(defaultValue)) {
+    return defaultValue;
+  }
+
+  try {
+    return JSON.parse(defaultValue);
+  } catch {
+    return [];
+  }
+};
+
 export const FormArrayFieldInput = ({
   label,
   defaultValue,
@@ -111,7 +129,7 @@ export const FormArrayFieldInput = ({
         }
       : {
           type: 'static',
-          value: isDefined(defaultValue) ? defaultValue : [],
+          value: getDefaultArrayValue(defaultValue),
         },
   );
 

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/filter-action/components/WorkflowStepFilterFieldSelect.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/filter-action/components/WorkflowStepFilterFieldSelect.tsx
@@ -25,7 +25,6 @@ type WorkflowStepFilterFieldSelectProps = {
 const NON_SELECTABLE_FIELD_TYPES = [
   FieldMetadataType.ACTOR,
   FieldMetadataType.RICH_TEXT_V2,
-  FieldMetadataType.ARRAY,
   FieldMetadataType.RATING,
 ];
 

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/filter-action/components/WorkflowStepFilterValueInput.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/filter-action/components/WorkflowStepFilterValueInput.tsx
@@ -1,6 +1,7 @@
 import { useFieldMetadataItemById } from '@/object-metadata/hooks/useFieldMetadataItemById';
 import { configurableViewFilterOperands } from '@/object-record/object-filter-dropdown/utils/configurableViewFilterOperands';
 import { FormFieldInput } from '@/object-record/record-field/ui/components/FormFieldInput';
+import { FormArrayFieldInput } from '@/object-record/record-field/ui/form-types/components/FormArrayFieldInput';
 import { FormMultiSelectFieldInput } from '@/object-record/record-field/ui/form-types/components/FormMultiSelectFieldInput';
 import { FormRelativeDatePicker } from '@/object-record/record-field/ui/form-types/components/FormRelativeDatePicker';
 import { FormSingleRecordPicker } from '@/object-record/record-field/ui/form-types/components/FormSingleRecordPicker';
@@ -19,7 +20,7 @@ import {
   ViewFilterOperand,
   type StepFilter,
 } from 'twenty-shared/types';
-import { isDefined } from 'twenty-shared/utils';
+import { isDefined, parseJson } from 'twenty-shared/utils';
 import { type JsonValue } from 'type-fest';
 
 type WorkflowStepFilterValueInputProps = {
@@ -167,6 +168,18 @@ export const WorkflowStepFilterValueInput = ({
     return (
       <FormRelativeDatePicker
         defaultValue={stepFilter.value}
+        onChange={handleValueChange}
+        readonly={readonly}
+      />
+    );
+  }
+
+  if (variableType === FieldMetadataType.ARRAY) {
+    const arrayValue = parseJson<string[]>(stepFilter.value) ?? [];
+
+    return (
+      <FormArrayFieldInput
+        defaultValue={arrayValue}
         onChange={handleValueChange}
         readonly={readonly}
       />


### PR DESCRIPTION
Fixes https://github.com/twentyhq/twenty/issues/15247

Before - arrays not available
<img width="595" height="403" alt="Capture d’écran 2025-10-22 à 14 32 22" src="https://github.com/user-attachments/assets/6c7a5fe3-5002-4b06-8ff3-af42f26d0dae" />

After
<img width="595" height="403" alt="Capture d’écran 2025-10-22 à 14 32 03" src="https://github.com/user-attachments/assets/2e00c4f0-9e57-4bd9-94de-2caa0493446d" />
