### PR TITLE
Fix Cmd + K conflict in note when adding a link (cmd+k shortcut) and opening right drawer

### DIFF
--- a/packages/twenty-front/src/modules/activities/components/ActivityRichTextEditor.tsx
+++ b/packages/twenty-front/src/modules/activities/components/ActivityRichTextEditor.tsx
@@ -411,6 +411,7 @@ export const ActivityRichTextEditor = ({
           focusId: activityId,
           globalHotkeysConfig: {
             enableGlobalHotkeysConflictingWithKeyboard: false,
+            enableGlobalHotkeysWithModifiers: false,
           },
         });
       },


### PR DESCRIPTION
Closes https://github.com/twentyhq/twenty/issues/14949

https://github.com/user-attachments/assets/c63e95a8-33ad-4307-ad35-4e4464336004


