### PR TITLE
fix: graphql uncontrolled resource consumption vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -217,7 +217,7 @@
   "name": "twenty",
   "packageManager": "yarn@4.9.2",
   "resolutions": {
-    "graphql": "16.8.0",
+    "graphql": "16.8.1",
     "type-fest": "4.10.1",
     "typescript": "5.9.2",
     "graphql-redis-subscriptions/ioredis": "^5.6.0",

--- a/packages/twenty-front/package.json
+++ b/packages/twenty-front/package.json
@@ -78,7 +78,7 @@
     "docx": "^9.1.0",
     "file-saver": "^2.0.5",
     "graphiql": "^3.1.1",
-    "graphql": "^16.8.0",
+    "graphql": "16.8.1",
     "graphql-sse": "^2.5.4",
     "input-otp": "^1.4.2",
     "js-cookie": "^3.0.5",

--- a/packages/twenty-server/package.json
+++ b/packages/twenty-server/package.json
@@ -104,7 +104,7 @@
     "glob": "11.0.1",
     "google-auth-library": "8.9.0",
     "googleapis": "105.0.0",
-    "graphql": "16.8.0",
+    "graphql": "16.8.1",
     "graphql-fields": "2.0.3",
     "graphql-middleware": "^6.1.35",
     "graphql-rate-limit": "3.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -34865,10 +34865,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graphql@npm:16.8.0":
-  version: 16.8.0
-  resolution: "graphql@npm:16.8.0"
-  checksum: 10c0/f7ca0302e8d658012db90b428ec66c1453afe53fbffa21404a28b5bdec5b0e88641d38416ef3d582acad7ddde2effe729e2b050a1483a2e9d4a6111e892e4903
+"graphql@npm:16.8.1":
+  version: 16.8.1
+  resolution: "graphql@npm:16.8.1"
+  checksum: 10c0/129c318156b466f440914de80dbf7bc67d17f776f2a088a40cb0da611d19a97c224b1c6d2b13cbcbc6e5776e45ed7468b8432f9c3536724e079b44f1a3d57a8a
   languageName: node
   linkType: hard
 
@@ -51822,7 +51822,7 @@ __metadata:
     eslint-plugin-unused-imports: "npm:^3.0.0"
     file-saver: "npm:^2.0.5"
     graphiql: "npm:^3.1.1"
-    graphql: "npm:^16.8.0"
+    graphql: "npm:16.8.1"
     graphql-sse: "npm:^2.5.4"
     input-otp: "npm:^1.4.2"
     js-cookie: "npm:^3.0.5"
@@ -52002,7 +52002,7 @@ __metadata:
     glob: "npm:11.0.1"
     google-auth-library: "npm:8.9.0"
     googleapis: "npm:105.0.0"
-    graphql: "npm:16.8.0"
+    graphql: "npm:16.8.1"
     graphql-fields: "npm:2.0.3"
     graphql-middleware: "npm:^6.1.35"
     graphql-rate-limit: "npm:3.3.0"


### PR DESCRIPTION
Fixes [Dependabot Alert 73](https://github.com/twentyhq/twenty/security/dependabot/73) - graphql uncontrolled resource consumption vulnerability.

Updated the patch version - from 16.8.0 to 16.8.1 - and this patch only touches the issue identified by the alert.

<p align="center">
<img width="1175" height="472" alt="image" src="https://github.com/user-attachments/assets/4f809f03-1e63-4412-822c-227712d1e395" />
</p>

Manually tested a few mutations, ran test cases, and everything seems to work fine. Not expecting it to break anything.

Two files changed in the original patch fix: https://github.com/graphql/graphql-js/commit/8f4c64eb6a7112a929ffeef00caa67529b3f2fcf