### PR TITLE
Set serverlessFunctionLayerId not nullable

### DIFF
--- a/packages/twenty-server/src/database/typeorm/core/migrations/common/1761153071116-setServerlessFunctionLayerIdNotNullable.ts
+++ b/packages/twenty-server/src/database/typeorm/core/migrations/common/1761153071116-setServerlessFunctionLayerIdNotNullable.ts
@@ -1,0 +1,31 @@
+import { type MigrationInterface, type QueryRunner } from 'typeorm';
+
+export class SetServerlessFunctionLayerIdNotNullable1761153071116
+  implements MigrationInterface
+{
+  name = 'SetServerlessFunctionLayerIdNotNullable1761153071116';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "core"."serverlessFunction" DROP CONSTRAINT "FK_4b9625a4babf7f4fa942fd26514"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."serverlessFunction" ALTER COLUMN "serverlessFunctionLayerId" SET NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."serverlessFunction" ADD CONSTRAINT "FK_4b9625a4babf7f4fa942fd26514" FOREIGN KEY ("serverlessFunctionLayerId") REFERENCES "core"."serverlessFunctionLayer"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "core"."serverlessFunction" DROP CONSTRAINT "FK_4b9625a4babf7f4fa942fd26514"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."serverlessFunction" ALTER COLUMN "serverlessFunctionLayerId" DROP NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."serverlessFunction" ADD CONSTRAINT "FK_4b9625a4babf7f4fa942fd26514" FOREIGN KEY ("serverlessFunctionLayerId") REFERENCES "core"."serverlessFunctionLayer"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+}

--- a/packages/twenty-server/src/engine/metadata-modules/serverless-function/serverless-function.entity.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/serverless-function/serverless-function.entity.ts
@@ -68,8 +68,7 @@ export class ServerlessFunctionEntity
   @Column({ nullable: true, type: 'text' })
   checksum: string | null;
 
-  // TODO: should be set to nullable: false when 1.8 released in production
-  @Column({ nullable: true, type: 'uuid' })
+  @Column({ nullable: false, type: 'uuid' })
   serverlessFunctionLayerId: string;
 
   @ManyToOne(


### PR DESCRIPTION
As title

Existing Null serverlessFunctionLayerIds have been filled with `upgrade:1-8:fill-null-serverless-function-layer-id` command

See 0 such records in production

<img width="651" height="415" alt="image" src="https://github.com/user-attachments/assets/9a5868fe-aa8e-4de0-b656-2e732560fd47" />
