### PR TITLE
`FindAllCoreViews` graphql cache operation invalidation in view related v2 action run

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/services/workspace-migration-runner-v2.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/services/workspace-migration-runner-v2.service.ts
@@ -64,7 +64,7 @@ export class WorkspaceMigrationRunnerV2Service {
       );
     }
 
-    const shouldInvalidFindCoreViewsGraphqlChacheOperation = actions.some(
+    const shouldInvalidFindCoreViewsGraphqlCacheOperation = actions.some(
       (action) => {
         switch (action.type) {
           case 'delete_view':
@@ -89,7 +89,7 @@ export class WorkspaceMigrationRunnerV2Service {
     );
 
     if (
-      shouldInvalidFindCoreViewsGraphqlChacheOperation ||
+      shouldInvalidFindCoreViewsGraphqlCacheOperation ||
       shouldIncrementMetadataGraphqlSchemaVersion
     ) {
       await this.workspaceCacheStorageService.flushGraphQLOperation({

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/services/workspace-migration-runner-v2.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/services/workspace-migration-runner-v2.service.ts
@@ -10,8 +10,10 @@ import {
 import { LoggerService } from 'src/engine/core-modules/logger/logger.service';
 import { WorkspaceManyOrAllFlatEntityMapsCacheService } from 'src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.service';
 import { AllFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/all-flat-entity-maps.type';
+import { FIND_ALL_CORE_VIEWS_GRAPHQL_OPERATION } from 'src/engine/metadata-modules/view/constants/find-all-core-views-graphql-operation.constant';
 import { WorkspaceMetadataVersionService } from 'src/engine/metadata-modules/workspace-metadata-version/services/workspace-metadata-version.service';
 import { WorkspacePermissionsCacheService } from 'src/engine/metadata-modules/workspace-permissions-cache/workspace-permissions-cache.service';
+import { WorkspaceCacheStorageService } from 'src/engine/workspace-cache-storage/workspace-cache-storage.service';
 import { WorkspaceMigrationV2 } from 'src/engine/workspace-manager/workspace-migration-v2/workspace-migration-builder-v2/types/workspace-migration-v2';
 import { WorkspaceMigrationRunnerActionHandlerRegistryService } from 'src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/registry/workspace-migration-runner-action-handler-registry.service';
 
@@ -24,8 +26,78 @@ export class WorkspaceMigrationRunnerV2Service {
     private readonly workspaceMigrationRunnerActionHandlerRegistry: WorkspaceMigrationRunnerActionHandlerRegistryService,
     private readonly workspaceMetadataVersionService: WorkspaceMetadataVersionService,
     private readonly workspacePermissionsCacheService: WorkspacePermissionsCacheService,
+    private readonly workspaceCacheStorageService: WorkspaceCacheStorageService,
     private readonly logger: LoggerService,
   ) {}
+
+  private async invalidateLegacyCache({
+    workspaceMigration: { actions, workspaceId },
+  }: {
+    workspaceMigration: WorkspaceMigrationV2;
+  }) {
+    const shouldIncrementMetadataGraphqlSchemaVersion = actions.some(
+      (action) => {
+        switch (action.type) {
+          case 'delete_field':
+          case 'create_field':
+          case 'update_field':
+          case 'delete_object':
+          case 'create_object':
+          case 'update_object': {
+            return true;
+          }
+          default: {
+            return false;
+          }
+        }
+      },
+    );
+
+    if (shouldIncrementMetadataGraphqlSchemaVersion) {
+      await this.workspaceMetadataVersionService.incrementMetadataVersion(
+        workspaceId,
+      );
+      await this.workspacePermissionsCacheService.recomputeRolesPermissionsCache(
+        {
+          workspaceId,
+        },
+      );
+    }
+
+    const shouldInvalidFindCoreViewsGraphqlChacheOperation = actions.some(
+      (action) => {
+        switch (action.type) {
+          case 'delete_view':
+          case 'create_view':
+          case 'update_view':
+          case 'delete_view_filter':
+          case 'create_view_filter':
+          case 'update_view_filter':
+          case 'delete_view_group':
+          case 'create_view_group':
+          case 'update_view_group':
+          case 'delete_view_field':
+          case 'create_view_field':
+          case 'update_view_field': {
+            return true;
+          }
+          default: {
+            return false;
+          }
+        }
+      },
+    );
+
+    if (
+      shouldInvalidFindCoreViewsGraphqlChacheOperation ||
+      shouldIncrementMetadataGraphqlSchemaVersion
+    ) {
+      await this.workspaceCacheStorageService.flushGraphQLOperation({
+        operationName: FIND_ALL_CORE_VIEWS_GRAPHQL_OPERATION,
+        workspaceId,
+      });
+    }
+  }
 
   run = async ({
     actions,
@@ -97,34 +169,6 @@ export class WorkspaceMigrationRunnerV2Service {
         'Runner',
         `Cache invalidation ${flatEntitiesCacheToInvalidate.join()}`,
       );
-      const shouldIncrementMetadataGraphqlSchemaVersion = actions.some(
-        (action) => {
-          switch (action.type) {
-            case 'delete_field':
-            case 'create_field':
-            case 'update_field':
-            case 'delete_object':
-            case 'create_object':
-            case 'update_object': {
-              return true;
-            }
-            default: {
-              return false;
-            }
-          }
-        },
-      );
-
-      if (shouldIncrementMetadataGraphqlSchemaVersion) {
-        await this.workspaceMetadataVersionService.incrementMetadataVersion(
-          workspaceId,
-        );
-        await this.workspacePermissionsCacheService.recomputeRolesPermissionsCache(
-          {
-            workspaceId,
-          },
-        );
-      }
 
       await this.flatEntityMapsCacheService.invalidateFlatEntityMaps({
         workspaceId,
@@ -134,6 +178,10 @@ export class WorkspaceMigrationRunnerV2Service {
             ...(relatedFlatEntityMapsKeys ?? []),
           ]),
         ],
+      });
+
+      await this.invalidateLegacyCache({
+        workspaceMigration: { actions, workspaceId, relatedFlatEntityMapsKeys },
       });
 
       this.logger.timeEnd(

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/workspace-migration-runner-v2.module.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/workspace-migration-runner-v2.module.ts
@@ -8,6 +8,7 @@ import { WorkspaceManyOrAllFlatEntityMapsCacheModule } from 'src/engine/metadata
 import { WorkspaceMetadataCacheModule } from 'src/engine/metadata-modules/workspace-metadata-cache/workspace-metadata-cache.module';
 import { WorkspaceMetadataVersionModule } from 'src/engine/metadata-modules/workspace-metadata-version/workspace-metadata-version.module';
 import { WorkspacePermissionsCacheModule } from 'src/engine/metadata-modules/workspace-permissions-cache/workspace-permissions-cache.module';
+import { WorkspaceCacheStorageModule } from 'src/engine/workspace-cache-storage/workspace-cache-storage.module';
 import { WorkspaceSchemaMigrationRunnerActionHandlersModule } from 'src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/action-handlers/workspace-schema-migration-runner-action-handlers.module';
 import { WorkspaceMigrationRunnerActionHandlerRegistryService } from 'src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/registry/workspace-migration-runner-action-handler-registry.service';
 import { WorkspaceMigrationRunnerV2Service } from 'src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/services/workspace-migration-runner-v2.service';
@@ -23,6 +24,7 @@ import { WorkspaceMigrationRunnerV2Service } from 'src/engine/workspace-manager/
     WorkspaceSchemaMigrationRunnerActionHandlersModule,
     WorkspaceManyOrAllFlatEntityMapsCacheModule,
     DiscoveryModule,
+    WorkspaceCacheStorageModule,
   ],
   providers: [
     WorkspaceMigrationRunnerV2Service,


### PR DESCRIPTION
# Introduction
Adding a view field to a view in v2 would be optimistically rendered by the front but on refresh would not get persisted.
That's because we cache both:
```ts
      useCachedMetadata({
        cacheGetter: cacheStorageService.get.bind(cacheStorageService),
        cacheSetter: cacheStorageService.set.bind(cacheStorageService),
        operationsToCache: ['ObjectMetadataItems', 'FindAllCoreViews'],
      }),
```
With keys that look like:
```ts
    return `graphql:operations:${operationName}:${workspace.id}:${workspaceMetadataVersion}:${locale}:${queryHash}`;
```

It was functional in v1 as we would be incrementing metadata version often.

In v2 it gets incremented only if implies an interaction to metadata object or fields ( will be deprecated in the future though, until we finish the // run )

The fix was to check if an `view` or related has been processed in the workspace migration or if we incremented the metadata in order to manually flush the `findAllCoreViews` redis cache.

## Conclusion
Related to https://github.com/twentyhq/core-team-issues/issues/1753