### PR TITLE
Fix defaultValue with enum options update in migration v2

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/action-handlers/field/services/update-field-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/action-handlers/field/services/update-field-action-handler.service.ts
@@ -170,6 +170,20 @@ export class UpdateFieldActionHandlerService extends WorkspaceMigrationRunnerAct
         });
         optimisticFlatFieldMetadata.name = update.to;
       }
+      if (isPropertyUpdate(update, 'defaultValue')) {
+        if (wasDefaultValueHandledByEnumUpdate) {
+          optimisticFlatFieldMetadata.defaultValue = update.to;
+        } else {
+          await this.handleFieldDefaultValueUpdate({
+            queryRunner,
+            schemaName,
+            tableName,
+            flatFieldMetadata: optimisticFlatFieldMetadata,
+            update,
+          });
+          optimisticFlatFieldMetadata.defaultValue = update.to;
+        }
+      }
       if (
         isPropertyUpdate(update, 'options') &&
         isEnumFlatFieldMetadata(optimisticFlatFieldMetadata)
@@ -191,20 +205,6 @@ export class UpdateFieldActionHandlerService extends WorkspaceMigrationRunnerAct
           update,
         });
         optimisticFlatFieldMetadata.options = update.to ?? [];
-      }
-      if (isPropertyUpdate(update, 'defaultValue')) {
-        if (wasDefaultValueHandledByEnumUpdate) {
-          optimisticFlatFieldMetadata.defaultValue = update.to;
-        } else {
-          await this.handleFieldDefaultValueUpdate({
-            queryRunner,
-            schemaName,
-            tableName,
-            flatFieldMetadata: optimisticFlatFieldMetadata,
-            update,
-          });
-          optimisticFlatFieldMetadata.defaultValue = update.to;
-        }
       }
       if (
         isMorphOrRelationFlatFieldMetadata(optimisticFlatFieldMetadata) &&

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/action-handlers/field/services/update-field-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/action-handlers/field/services/update-field-action-handler.service.ts
@@ -27,6 +27,7 @@ import { fieldMetadataTypeToColumnType } from 'src/engine/metadata-modules/works
 import { WorkspaceSchemaManagerService } from 'src/engine/twenty-orm/workspace-schema-manager/workspace-schema-manager.service';
 import { isMorphOrRelationFieldMetadataType } from 'src/engine/utils/is-morph-or-relation-field-metadata-type.util';
 import { PropertyUpdate } from 'src/engine/workspace-manager/workspace-migration-v2/types/property-update.type';
+import { findFlatEntityPropertyUpdate } from 'src/engine/workspace-manager/workspace-migration-v2/utils/find-flat-entity-property-update.util';
 import { isPropertyUpdate } from 'src/engine/workspace-manager/workspace-migration-v2/utils/is-property-update.util';
 import { type UpdateFieldAction } from 'src/engine/workspace-manager/workspace-migration-v2/workspace-migration-builder-v2/builders/field/types/workspace-migration-field-action-v2';
 import { serializeDefaultValueV2 } from 'src/engine/workspace-manager/workspace-migration-v2/workspace-migration-builder-v2/utils/serialize-default-value-v2.util';
@@ -147,9 +148,10 @@ export class UpdateFieldActionHandlerService extends WorkspaceMigrationRunnerAct
 
     let optimisticFlatFieldMetadata = structuredClone(currentFlatFieldMetadata);
 
-    const defaultValueUpdate = updates.find(
-      (u) => u.property === 'defaultValue',
-    );
+    const defaultValueUpdate = findFlatEntityPropertyUpdate({
+      flatEntityUpdates: updates,
+      property: 'defaultValue',
+    });
     const hasDefaultValueUpdate = isDefined(defaultValueUpdate);
 
     let wasDefaultValueHandledByEnumUpdate = false;


### PR DESCRIPTION
## Context
When updating both enum options and defaultValue, the old default might not be in the new options (or vice versa), causing PostgreSQL constraint violations regardless of update order.

## Solution
Sort updates to process defaultValue last; before updating options, temporarily set the new defaultValue in metadata so alterEnumValues creates the column with the correct default, then skip the redundant defaultValue update handler.