### PR TITLE
fix: sha.js is missing type checks leading to hash rewind and passing on crafted data 

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -48963,19 +48963,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sha.js@npm:^2.4.0, sha.js@npm:^2.4.11, sha.js@npm:^2.4.8":
-  version: 2.4.11
-  resolution: "sha.js@npm:2.4.11"
-  dependencies:
-    inherits: "npm:^2.0.1"
-    safe-buffer: "npm:^5.0.1"
-  bin:
-    sha.js: ./bin.js
-  checksum: 10c0/b7a371bca8821c9cc98a0aeff67444a03d48d745cb103f17228b96793f455f0eb0a691941b89ea1e60f6359207e36081d9be193252b0f128e0daf9cfea2815a5
-  languageName: node
-  linkType: hard
-
-"sha.js@npm:^2.4.12":
+"sha.js@npm:^2.4.0, sha.js@npm:^2.4.11, sha.js@npm:^2.4.12, sha.js@npm:^2.4.8":
   version: 2.4.12
   resolution: "sha.js@npm:2.4.12"
   dependencies:


### PR DESCRIPTION
Fixes [Dependabot Alert 264](https://github.com/twentyhq/twenty/security/dependabot/264) - sha.js is missing type checks leading to hash rewind and passing on crafted data.

Used `yarn up sha.js --recursive` to bump up the patch version used by parent dependencies.