### PR TITLE
Stop parsing the PG_DATABASE_URL, use it directly

### DIFF
--- a/packages/twenty-docker/docker-compose.yml
+++ b/packages/twenty-docker/docker-compose.yml
@@ -109,8 +109,9 @@ services:
     volumes:
       - db-data:/var/lib/postgresql/data
     environment:
-      POSTGRES_USER: ${PG_DATABASE_USER:-postgres}
+      POSTGRES_DB: ${PG_DATABASE_NAME:-default}
       POSTGRES_PASSWORD: ${PG_DATABASE_PASSWORD:-postgres}
+      POSTGRES_USER: ${PG_DATABASE_USER:-postgres}
     healthcheck:
       test: pg_isready -U ${PG_DATABASE_USER:-postgres} -h localhost -d postgres
       interval: 5s

--- a/packages/twenty-docker/twenty/entrypoint.sh
+++ b/packages/twenty-docker/twenty/entrypoint.sh
@@ -8,27 +8,15 @@ setup_and_migrate_db() {
     fi
 
     echo "Running database setup and migrations..."
-    PGUSER=$(echo $PG_DATABASE_URL | awk -F '//' '{print $2}' | awk -F ':' '{print $1}')
-    PGPASS=$(echo $PG_DATABASE_URL | awk -F ':' '{print $3}' | awk -F '@' '{print $1}')
-    PGHOST=$(echo $PG_DATABASE_URL | awk -F '@' '{print $2}' | awk -F ':' '{print $1}')
-    PGPORT=$(echo $PG_DATABASE_URL | awk -F ':' '{print $4}' | awk -F '/' '{print $1}')
-    PGDATABASE=$(echo $PG_DATABASE_URL | awk -F '/' '{print $NF}' | cut -d'?' -f1)
-
-    # Creating the database if it doesn't exist
-    db_count=$(PGPASSWORD=${PGPASS} psql -h ${PGHOST} -p ${PGPORT} -U ${PGUSER} -d postgres -tAc "SELECT COUNT(*) FROM pg_database WHERE datname = '${PGDATABASE}'")
-    if [ "$db_count" = "0" ]; then
-        echo "Database ${PGDATABASE} does not exist, creating..."
-        PGPASSWORD=${PGPASS} psql -h ${PGHOST} -p ${PGPORT} -U ${PGUSER} -d postgres -c "CREATE DATABASE \"${PGDATABASE}\""
-    fi
 
     # Run setup and migration scripts
-    has_schema=$(PGPASSWORD=${PGPASS} psql -h ${PGHOST} -p ${PGPORT} -U ${PGUSER} -d ${PGDATABASE} -tAc "SELECT EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = 'core')")
+    has_schema=$(psql -tAc "SELECT EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = 'core')" ${PG_DATABASE_URL})
     if [ "$has_schema" = "f" ]; then
         echo "Database appears to be empty, running migrations."
         NODE_OPTIONS="--max-old-space-size=1500" tsx ./scripts/setup-db.ts
         yarn database:migrate:prod
     fi
-    
+
     yarn command:prod upgrade
     echo "Successfully migrated DB!"
 }
@@ -38,7 +26,7 @@ register_background_jobs() {
         echo "Cron job registration is disabled, skipping..."
         return
     fi
-  
+
     echo "Registering background sync jobs..."
     if yarn command:prod cron:register:all; then
         echo "Successfully registered all background sync jobs!"


### PR DESCRIPTION
Addresses https://github.com/twentyhq/twenty/issues/15274

There's no need to parse the URL, since psql is happy to use it directly. If you are going to parse the URL, you should parse it correctly - the logic removed here make a number of assumptions about the URL that are inaccurate and reject many types of valid URIs.

This does drop the ability to create the database which may be handy for people that don't do database administration. For people that do, this is an anti-feature.