### PR TITLE
fix(mcp): Remove jsonSchema wrapper from tool inputSchema for MCP compatibility

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/ai/services/__tests__/mcp.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/ai/services/__tests__/mcp.service.spec.ts
@@ -330,7 +330,7 @@ describe('McpService', () => {
             {
               name: 'testTool',
               description: 'Test tool',
-              inputSchema: jsonSchema({ type: 'object', properties: {} }),
+              inputSchema: { type: 'object', properties: {} },
             },
           ],
         }),


### PR DESCRIPTION
## Description

Fixes #15348

The Vercel AI SDK serializes tool schemas with a `jsonSchema` wrapper (`{ jsonSchema: {...} }`), but the Model Context Protocol specification expects the schema directly (`{ type: 'object', properties: {...} }`).

This was causing MCP clients like Claude Desktop to silently reject all tool definitions as invalid, leaving users with no available tools.

## Changes

Modified `handleToolsListing()` in `mcp.service.ts` to unwrap the `jsonSchema` key before returning tools to MCP clients.

## Before

```json
{
  "name": "create_company",
  "description": "...",
  "inputSchema": {
    "jsonSchema": {
      "type": "object",
      "properties": {...}
    }
  }
}
```

## After

```json
{
  "name": "create_company",
  "description": "...",
  "inputSchema": {
    "type": "object",
    "properties": {...}
  }
}
```

## Testing

Tested with:
- Direct curl request to verify schema format
- Claude Desktop client via mcp-proxy
- Verified tools now appear correctly in MCP clients

## References

- [MCP Tools Specification](https://modelcontextprotocol.io/specification/2025-06-18/server/tools)
- Related discussion in #12953