### PR TITLE
New record button on dashboard index page and reorder

### DIFF
--- a/packages/twenty-front/src/modules/action-menu/actions/record-actions/constants/DashboardActionsConfig.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-actions/constants/DashboardActionsConfig.tsx
@@ -1,4 +1,5 @@
 import { NoSelectionRecordActionKeys } from '@/action-menu/actions/record-actions/no-selection/types/NoSelectionRecordActionsKeys';
+import { AddToFavoritesSingleRecordAction } from '@/action-menu/actions/record-actions/single-record/components/AddToFavoritesSingleRecordAction';
 import { CancelDashboardSingleRecordAction } from '@/action-menu/actions/record-actions/single-record/dashboard-actions/components/CancelDashboardSingleRecordAction';
 import { EditDashboardSingleRecordAction } from '@/action-menu/actions/record-actions/single-record/dashboard-actions/components/EditDashboardSingleRecordAction';
 import { SaveDashboardSingleRecordAction } from '@/action-menu/actions/record-actions/single-record/dashboard-actions/components/SaveDashboardSingleRecordAction';
@@ -10,16 +11,37 @@ import { ActionViewType } from '@/action-menu/actions/types/ActionViewType';
 import { PageLayoutSingleRecordActionKeys } from '@/page-layout/actions/PageLayoutSingleRecordActionKeys';
 import { msg } from '@lingui/core/macro';
 import { isDefined } from 'twenty-shared/utils';
-import { IconDeviceFloppy, IconPencil, IconX } from 'twenty-ui/display';
+import {
+  IconDeviceFloppy,
+  IconHeart,
+  IconPencil,
+  IconX,
+} from 'twenty-ui/display';
 
 export const DASHBOARD_ACTIONS_CONFIG = inheritActionsFromDefaultConfig({
   config: {
+    [PageLayoutSingleRecordActionKeys.ADD_TO_FAVORITES_READ_MODE]: {
+      key: PageLayoutSingleRecordActionKeys.ADD_TO_FAVORITES_READ_MODE,
+      label: msg`Add to favorites`,
+      shortLabel: msg`Add to favorites`,
+      isPinned: true,
+      position: 0,
+      Icon: IconHeart,
+      type: ActionType.Standard,
+      scope: ActionScope.RecordSelection,
+      shouldBeRegistered: ({ selectedRecord }) =>
+        isDefined(selectedRecord) &&
+        !selectedRecord?.isRemote &&
+        !isDefined(selectedRecord?.deletedAt),
+      availableOn: [ActionViewType.SHOW_PAGE],
+      component: <AddToFavoritesSingleRecordAction />,
+    },
     [PageLayoutSingleRecordActionKeys.EDIT_LAYOUT]: {
       key: PageLayoutSingleRecordActionKeys.EDIT_LAYOUT,
       label: msg`Edit Dashboard`,
       shortLabel: msg`Edit`,
       isPinned: true,
-      position: 0,
+      position: 1,
       Icon: IconPencil,
       type: ActionType.Standard,
       scope: ActionScope.RecordSelection,
@@ -30,6 +52,23 @@ export const DASHBOARD_ACTIONS_CONFIG = inheritActionsFromDefaultConfig({
         isDefined(selectedRecord?.pageLayoutId),
       availableOn: [ActionViewType.SHOW_PAGE],
       component: <EditDashboardSingleRecordAction />,
+    },
+    [PageLayoutSingleRecordActionKeys.CANCEL_LAYOUT_EDITION]: {
+      key: PageLayoutSingleRecordActionKeys.CANCEL_LAYOUT_EDITION,
+      label: msg`Cancel Edition`,
+      shortLabel: msg`Cancel`,
+      isPinned: true,
+      position: 0,
+      Icon: IconX,
+      type: ActionType.Standard,
+      scope: ActionScope.RecordSelection,
+      shouldBeRegistered: ({ selectedRecord }) =>
+        isDefined(selectedRecord) &&
+        !selectedRecord?.isRemote &&
+        !isDefined(selectedRecord?.deletedAt) &&
+        isDefined(selectedRecord?.pageLayoutId),
+      availableOn: [ActionViewType.SHOW_PAGE],
+      component: <CancelDashboardSingleRecordAction />,
     },
     [PageLayoutSingleRecordActionKeys.SAVE_LAYOUT]: {
       key: PageLayoutSingleRecordActionKeys.SAVE_LAYOUT,
@@ -47,23 +86,6 @@ export const DASHBOARD_ACTIONS_CONFIG = inheritActionsFromDefaultConfig({
         isDefined(selectedRecord?.pageLayoutId),
       availableOn: [ActionViewType.SHOW_PAGE],
       component: <SaveDashboardSingleRecordAction />,
-    },
-    [PageLayoutSingleRecordActionKeys.CANCEL_LAYOUT_EDITION]: {
-      key: PageLayoutSingleRecordActionKeys.CANCEL_LAYOUT_EDITION,
-      label: msg`Cancel Edition`,
-      shortLabel: msg`Cancel`,
-      isPinned: true,
-      position: 2,
-      Icon: IconX,
-      type: ActionType.Standard,
-      scope: ActionScope.RecordSelection,
-      shouldBeRegistered: ({ selectedRecord }) =>
-        isDefined(selectedRecord) &&
-        !selectedRecord?.isRemote &&
-        !isDefined(selectedRecord?.deletedAt) &&
-        isDefined(selectedRecord?.pageLayoutId),
-      availableOn: [ActionViewType.SHOW_PAGE],
-      component: <CancelDashboardSingleRecordAction />,
     },
   },
   actionKeys: [
@@ -83,33 +105,34 @@ export const DASHBOARD_ACTIONS_CONFIG = inheritActionsFromDefaultConfig({
       label: msg`Create new dashboard`,
     },
     [SingleRecordActionKeys.ADD_TO_FAVORITES]: {
-      position: 4,
+      position: 3,
+      isPinned: false,
     },
     [SingleRecordActionKeys.REMOVE_FROM_FAVORITES]: {
-      position: 5,
+      position: 4,
     },
     [SingleRecordActionKeys.DELETE]: {
-      position: 6,
+      position: 2,
       label: msg`Delete dashboard`,
     },
     [SingleRecordActionKeys.EXPORT_FROM_RECORD_SHOW]: {
-      position: 7,
+      position: 5,
       label: msg`Export dashboard`,
     },
     [SingleRecordActionKeys.DESTROY]: {
-      position: 8,
+      position: 6,
       label: msg`Permanently destroy dashboard`,
     },
     [SingleRecordActionKeys.RESTORE]: {
-      position: 9,
+      position: 7,
       label: msg`Restore dashboard`,
     },
     [SingleRecordActionKeys.NAVIGATE_TO_PREVIOUS_RECORD]: {
-      position: 10,
+      position: 8,
       label: msg`Navigate to previous dashboard`,
     },
     [SingleRecordActionKeys.NAVIGATE_TO_NEXT_RECORD]: {
-      position: 11,
+      position: 9,
       label: msg`Navigate to next dashboard`,
     },
   },

--- a/packages/twenty-front/src/modules/action-menu/actions/record-actions/constants/DashboardActionsConfig.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-actions/constants/DashboardActionsConfig.tsx
@@ -1,3 +1,4 @@
+import { NoSelectionRecordActionKeys } from '@/action-menu/actions/record-actions/no-selection/types/NoSelectionRecordActionsKeys';
 import { CancelDashboardSingleRecordAction } from '@/action-menu/actions/record-actions/single-record/dashboard-actions/components/CancelDashboardSingleRecordAction';
 import { EditDashboardSingleRecordAction } from '@/action-menu/actions/record-actions/single-record/dashboard-actions/components/EditDashboardSingleRecordAction';
 import { SaveDashboardSingleRecordAction } from '@/action-menu/actions/record-actions/single-record/dashboard-actions/components/SaveDashboardSingleRecordAction';
@@ -66,6 +67,7 @@ export const DASHBOARD_ACTIONS_CONFIG = inheritActionsFromDefaultConfig({
     },
   },
   actionKeys: [
+    NoSelectionRecordActionKeys.CREATE_NEW_RECORD,
     SingleRecordActionKeys.ADD_TO_FAVORITES,
     SingleRecordActionKeys.REMOVE_FROM_FAVORITES,
     SingleRecordActionKeys.DELETE,
@@ -76,34 +78,38 @@ export const DASHBOARD_ACTIONS_CONFIG = inheritActionsFromDefaultConfig({
     SingleRecordActionKeys.NAVIGATE_TO_NEXT_RECORD,
   ],
   propertiesToOverwrite: {
-    [SingleRecordActionKeys.ADD_TO_FAVORITES]: {
-      position: 3,
+    [NoSelectionRecordActionKeys.CREATE_NEW_RECORD]: {
+      position: 0,
+      label: msg`Create new dashboard`,
     },
-    [SingleRecordActionKeys.REMOVE_FROM_FAVORITES]: {
+    [SingleRecordActionKeys.ADD_TO_FAVORITES]: {
       position: 4,
     },
-    [SingleRecordActionKeys.DELETE]: {
+    [SingleRecordActionKeys.REMOVE_FROM_FAVORITES]: {
       position: 5,
+    },
+    [SingleRecordActionKeys.DELETE]: {
+      position: 6,
       label: msg`Delete dashboard`,
     },
     [SingleRecordActionKeys.EXPORT_FROM_RECORD_SHOW]: {
-      position: 6,
+      position: 7,
       label: msg`Export dashboard`,
     },
     [SingleRecordActionKeys.DESTROY]: {
-      position: 7,
+      position: 8,
       label: msg`Permanently destroy dashboard`,
     },
     [SingleRecordActionKeys.RESTORE]: {
-      position: 8,
+      position: 9,
       label: msg`Restore dashboard`,
     },
     [SingleRecordActionKeys.NAVIGATE_TO_PREVIOUS_RECORD]: {
-      position: 9,
+      position: 10,
       label: msg`Navigate to previous dashboard`,
     },
     [SingleRecordActionKeys.NAVIGATE_TO_NEXT_RECORD]: {
-      position: 10,
+      position: 11,
       label: msg`Navigate to next dashboard`,
     },
   },

--- a/packages/twenty-front/src/modules/page-layout/actions/PageLayoutSingleRecordActionKeys.ts
+++ b/packages/twenty-front/src/modules/page-layout/actions/PageLayoutSingleRecordActionKeys.ts
@@ -2,4 +2,5 @@ export enum PageLayoutSingleRecordActionKeys {
   EDIT_LAYOUT = 'edit-layout-single-record',
   SAVE_LAYOUT = 'save-layout-single-record',
   CANCEL_LAYOUT_EDITION = 'cancel-layout-edition-single-record',
+  ADD_TO_FAVORITES_READ_MODE = 'add-to-favorites-read-mode-dashboard',
 }

--- a/packages/twenty-front/src/modules/page-layout/hooks/useSetIsPageLayoutInEditMode.ts
+++ b/packages/twenty-front/src/modules/page-layout/hooks/useSetIsPageLayoutInEditMode.ts
@@ -1,3 +1,4 @@
+import { SingleRecordActionKeys } from '@/action-menu/actions/record-actions/single-record/types/SingleRecordActionsKey';
 import { forceRegisteredActionsByKeyState } from '@/action-menu/actions/states/forceRegisteredActionsMapComponentState';
 import { PageLayoutSingleRecordActionKeys } from '@/page-layout/actions/PageLayoutSingleRecordActionKeys';
 import { PageLayoutComponentInstanceContext } from '@/page-layout/states/contexts/PageLayoutComponentInstanceContext';
@@ -26,6 +27,8 @@ export const useSetIsPageLayoutInEditMode = (pageLayoutIdFromProps: string) => {
           [PageLayoutSingleRecordActionKeys.EDIT_LAYOUT]: !value,
           [PageLayoutSingleRecordActionKeys.SAVE_LAYOUT]: value,
           [PageLayoutSingleRecordActionKeys.CANCEL_LAYOUT_EDITION]: value,
+          [PageLayoutSingleRecordActionKeys.ADD_TO_FAVORITES_READ_MODE]: !value,
+          [SingleRecordActionKeys.ADD_TO_FAVORITES]: value,
         }));
       },
     [isPageLayoutInEditModeState],


### PR DESCRIPTION
closes https://discord.com/channels/1130383047699738754/1430825009773019258 and
https://discord.com/channels/1130383047699738754/1430601431542530249
before: 
index page:

<img width="1187" height="644" alt="Screenshot 2025-10-27 at 12 42 31" src="https://github.com/user-attachments/assets/9bb0feba-b1e8-4436-a965-0a53abe74364" />

record page:
read mode:

<img width="1303" height="823" alt="Screenshot 2025-10-27 at 14 00 35" src="https://github.com/user-attachments/assets/62e7d18c-8ebd-442f-88a3-7b8bbe200b4e" />


edit mode:

<img width="1303" height="824" alt="Screenshot 2025-10-27 at 14 00 52" src="https://github.com/user-attachments/assets/56c6b172-8847-4a68-a792-9c03dc01fb21" />

-----------------------------------------------------------------------------------------------------------------------
after:

index page:

<img width="1186" height="565" alt="Screenshot 2025-10-27 at 12 41 05" src="https://github.com/user-attachments/assets/4700242b-367b-4fd0-80bc-a1f696f4317c" />

record page:
read mode:

<img width="1302" height="823" alt="Screenshot 2025-10-27 at 13 58 58" src="https://github.com/user-attachments/assets/4f0fe715-f216-4586-a41d-b7e5520f8d4a" />

edit mode:

<img width="1300" height="824" alt="Screenshot 2025-10-27 at 13 59 08" src="https://github.com/user-attachments/assets/cb15f327-7c0c-4b0a-ad2e-f1833c0f0134" />
