### PR TITLE
morph bug fix

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-store/states/selectors/recordStoreFieldValueSelector.ts
+++ b/packages/twenty-front/src/modules/object-record/record-store/states/selectors/recordStoreFieldValueSelector.ts
@@ -58,7 +58,10 @@ export const recordStoreFieldValueSelector = selectorFamily({
       const relationType = morphRelations[0].type;
 
       if (relationType === RelationType.ONE_TO_MANY) {
-        return morphValuesWithObjectName as {
+        return morphValuesWithObjectName.map((morphValue) => ({
+          ...morphValue,
+          value: morphValue.value ? morphValue.value : [],
+        })) as {
           objectNameSingular: string;
           value: ObjectRecord[];
         }[];

--- a/packages/twenty-front/src/modules/object-record/utils/prefillRecord.ts
+++ b/packages/twenty-front/src/modules/object-record/utils/prefillRecord.ts
@@ -27,7 +27,7 @@ export const prefillRecord = <T extends ObjectRecord>({
           fieldMetadataItem.relation?.type === RelationType.MANY_TO_ONE
         ) {
           const joinColumnValue =
-            input[fieldMetadataItem.settings?.joinColumnName];
+            input[fieldMetadataItem.settings?.joinColumnName] ?? null;
           throwIfInputRelationDataIsInconsistent(input, fieldMetadataItem);
 
           return [


### PR DESCRIPTION
Two bug fixes here: 

# MorphRelationOneToManyFieldDisplay
we expect an empty array, not undefined (run time error otherwise)


Fixes `Cannot read properties of undefined (reading 'length'): Cannot read properties of undefined (reading 'length')` in **MorphRelationOneToManyFieldDisplay**

```js
morphValuesWithObjectNameSingular.every(
      (morphValueWithObjectNameSingular) =>
        morphValueWithObjectNameSingular.value.length === 0,
    );
```

# create record in table mode
if the record has a relation there is currenlty a bug in production when it is created. A cache issue.

`Missing field 'companyFoundedId' while writing result `