### PR TITLE
Support primitive types in filters

### DIFF
--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/filter-action/components/__stories__/WorkflowStepFilterValueInput.stories.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/filter-action/components/__stories__/WorkflowStepFilterValueInput.stories.tsx
@@ -67,6 +67,6 @@ export const NumberInput: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    await expect(await canvas.findByText('100')).toBeVisible();
+    await expect(await canvas.findByDisplayValue(100)).toBeVisible();
   },
 };

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/filter-action/utils/getStepFilterOperands.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/filter-action/utils/getStepFilterOperands.ts
@@ -60,7 +60,7 @@ export const FILTER_OPERANDS_MAP = {
     ...emptyOperands,
   ],
   BOOLEAN: [ViewFilterOperand.IS],
-  UUID: [ViewFilterOperand.IS],
+  UUID: [ViewFilterOperand.IS, ViewFilterOperand.IS_NOT],
   NUMERIC: [
     ViewFilterOperand.GREATER_THAN_OR_EQUAL,
     ViewFilterOperand.LESS_THAN_OR_EQUAL,

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/filter-action/utils/getStepFilterOperands.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/filter-action/utils/getStepFilterOperands.ts
@@ -108,6 +108,7 @@ export const getStepFilterOperands = ({
       }
     }
     case 'NUMBER':
+    case 'number':
       return FILTER_OPERANDS_MAP.NUMBER;
     case 'RAW_JSON':
       return FILTER_OPERANDS_MAP.RAW_JSON;
@@ -123,8 +124,10 @@ export const getStepFilterOperands = ({
     case 'SELECT':
       return FILTER_OPERANDS_MAP.SELECT;
     case 'ARRAY':
+    case 'array':
       return FILTER_OPERANDS_MAP.ARRAY;
     case 'BOOLEAN':
+    case 'boolean':
       return FILTER_OPERANDS_MAP.BOOLEAN;
     case 'UUID':
       return FILTER_OPERANDS_MAP.UUID;

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/filter/utils/__tests__/evaluate-filter-conditions.util.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/filter/utils/__tests__/evaluate-filter-conditions.util.spec.ts
@@ -412,7 +412,12 @@ describe('evaluateFilterConditions', () => {
       });
 
       it('should handle truthy/falsy conversion', () => {
-        const filter = createFilter(ViewFilterOperand.IS, 1, true, 'BOOLEAN');
+        const filter = createFilter(
+          ViewFilterOperand.IS,
+          'true',
+          true,
+          'BOOLEAN',
+        );
         const result = evaluateFilterConditions({ filters: [filter] });
 
         expect(result).toBe(true);

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/filter/utils/evaluate-filter-conditions.util.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/filter/utils/evaluate-filter-conditions.util.ts
@@ -11,6 +11,7 @@ import {
   type ViewFilterOperandDeprecated,
 } from 'twenty-shared/types';
 import { convertViewFilterOperandToCoreOperand as convertViewFilterOperandDeprecated } from 'twenty-shared/utils';
+import { parseBooleanFromStringValue } from 'twenty-shared/workflow';
 
 import { parseAndEvaluateRelativeDateFilter } from 'src/modules/workflow/workflow-executor/workflow-actions/filter/utils/parse-and-evaluate-relative-date-filter.util';
 
@@ -43,6 +44,7 @@ function evaluateFilter(
   switch (filter.type) {
     case 'NUMBER':
     case 'NUMERIC':
+    case 'number':
       return evaluateNumberFilter(filterWithConvertedOperand);
     case 'DATE':
     case 'DATE_TIME':
@@ -55,11 +57,13 @@ function evaluateFilter(
     case 'ADDRESS':
     case 'LINKS':
     case 'ARRAY':
+    case 'array':
     case 'RAW_JSON':
       return evaluateTextAndArrayFilter(filterWithConvertedOperand);
     case 'SELECT':
       return evaluateSelectFilter(filterWithConvertedOperand);
     case 'BOOLEAN':
+    case 'boolean':
       return evaluateBooleanFilter(filterWithConvertedOperand);
     case 'UUID':
       return evaluateUuidFilter(filterWithConvertedOperand);
@@ -168,7 +172,10 @@ function isNotEmptyTextOrArray(value: unknown): boolean {
 function evaluateBooleanFilter(filter: ResolvedFilter): boolean {
   switch (filter.operand) {
     case ViewFilterOperand.IS:
-      return Boolean(filter.leftOperand) === Boolean(filter.rightOperand);
+      return (
+        parseBooleanFromStringValue(filter.leftOperand) ===
+        parseBooleanFromStringValue(filter.rightOperand)
+      );
     default:
       throw new Error(
         `Operand ${filter.operand} not supported for boolean filter`,

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/filter/utils/evaluate-filter-conditions.util.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/filter/utils/evaluate-filter-conditions.util.ts
@@ -263,6 +263,10 @@ function evaluateRelationFilter(filter: ResolvedFilter): boolean {
       return leftValue === rightValue;
     case ViewFilterOperand.IS_NOT:
       return leftValue !== rightValue;
+    case ViewFilterOperand.IS_EMPTY:
+      return !isNonEmptyString(leftValue);
+    case ViewFilterOperand.IS_NOT_EMPTY:
+      return isNonEmptyString(leftValue);
     default:
       throw new Error(
         `Operand ${filter.operand} not supported for relation filter`,

--- a/packages/twenty-shared/src/workflow/index.ts
+++ b/packages/twenty-shared/src/workflow/index.ts
@@ -64,6 +64,7 @@ export { StepStatus } from './types/WorkflowRunStateStepInfos';
 export { canObjectBeManagedByWorkflow } from './utils/canObjectBeManagedByWorkflow';
 export { extractRawVariableNamePart } from './utils/extractRawVariableNameParts';
 export { getWorkflowRunContext } from './utils/getWorkflowRunContext';
+export { parseBooleanFromStringValue } from './utils/parseBooleanFromStringValue';
 export { parseDataFromContentType } from './utils/parseDataFromContentType';
 export type {
   LeafType,

--- a/packages/twenty-shared/src/workflow/utils/parseBooleanFromStringValue.ts
+++ b/packages/twenty-shared/src/workflow/utils/parseBooleanFromStringValue.ts
@@ -1,0 +1,11 @@
+export const parseBooleanFromStringValue = (value: unknown) => {
+  if (value === 'true') {
+    return true;
+  }
+
+  if (value === 'false') {
+    return false;
+  }
+
+  return value;
+};

--- a/packages/twenty-shared/src/workflow/utils/parseBooleanFromStringValue.ts
+++ b/packages/twenty-shared/src/workflow/utils/parseBooleanFromStringValue.ts
@@ -1,4 +1,4 @@
-export const parseBooleanFromStringValue = (value: unknown) => {
+export const parseBooleanFromStringValue = (value: unknown): boolean | unknown => {
   if (value === 'true') {
     return true;
   }


### PR DESCRIPTION
When using primitive types such as array, number and boolean, we display a text field in filters because fieldmetadataId is empty. We should instead support these as we would do for our own fields.

Adding also a fix for https://github.com/twentyhq/twenty/issues/15282