### PR TITLE
Fix infinite loop on FE

### DIFF
--- a/packages/twenty-front/src/modules/object-record/hooks/useLazyFindManyRecords.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useLazyFindManyRecords.ts
@@ -14,6 +14,7 @@ import { cursorFamilyState } from '@/object-record/states/cursorFamilyState';
 import { hasNextPageFamilyState } from '@/object-record/states/hasNextPageFamilyState';
 import { type ObjectRecord } from '@/object-record/types/ObjectRecord';
 import { getQueryIdentifier } from '@/object-record/utils/getQueryIdentifier';
+import { useEffect } from 'react';
 import { QUERY_DEFAULT_LIMIT_RECORDS } from 'twenty-shared/constants';
 import { isDefined } from 'twenty-shared/utils';
 
@@ -93,10 +94,17 @@ export const useLazyFindManyRecords = <T extends ObjectRecord = ObjectRecord>({
         orderBy,
       },
       fetchPolicy,
-      onCompleted: handleFindManyRecordsCompleted,
-      onError: handleFindManyRecordsError,
       client: apolloCoreClient,
     });
+
+  useEffect(() => {
+    if (isDefined(data)) {
+      handleFindManyRecordsCompleted(data);
+    }
+    if (isDefined(error)) {
+      handleFindManyRecordsError(error);
+    }
+  }, [data, error, handleFindManyRecordsCompleted, handleFindManyRecordsError]);
 
   const { fetchMoreRecordsLazy } = useLazyFetchMoreRecordsWithPagination<T>({
     objectNameSingular,

--- a/packages/twenty-front/src/modules/object-record/hooks/useLazyFindManyRecords.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useLazyFindManyRecords.ts
@@ -126,7 +126,6 @@ export const useLazyFindManyRecords = <T extends ObjectRecord = ObjectRecord>({
         const result = await findManyRecords();
         if (isDefined(result?.error)) {
           handleFindManyRecordsError(result.error);
-          return { error: result.error };
         }
 
         if (isDefined(result?.data)) {

--- a/packages/twenty-front/src/modules/object-record/hooks/useLazyFindManyRecords.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useLazyFindManyRecords.ts
@@ -14,7 +14,6 @@ import { cursorFamilyState } from '@/object-record/states/cursorFamilyState';
 import { hasNextPageFamilyState } from '@/object-record/states/hasNextPageFamilyState';
 import { type ObjectRecord } from '@/object-record/types/ObjectRecord';
 import { getQueryIdentifier } from '@/object-record/utils/getQueryIdentifier';
-import { useEffect } from 'react';
 import { QUERY_DEFAULT_LIMIT_RECORDS } from 'twenty-shared/constants';
 import { isDefined } from 'twenty-shared/utils';
 
@@ -97,15 +96,6 @@ export const useLazyFindManyRecords = <T extends ObjectRecord = ObjectRecord>({
       client: apolloCoreClient,
     });
 
-  useEffect(() => {
-    if (isDefined(data)) {
-      handleFindManyRecordsCompleted(data);
-    }
-    if (isDefined(error)) {
-      handleFindManyRecordsError(error);
-    }
-  }, [data, error, handleFindManyRecordsCompleted, handleFindManyRecordsError]);
-
   const { fetchMoreRecordsLazy } = useLazyFetchMoreRecordsWithPagination<T>({
     objectNameSingular,
     filter,
@@ -134,6 +124,14 @@ export const useLazyFindManyRecords = <T extends ObjectRecord = ObjectRecord>({
         }
 
         const result = await findManyRecords();
+        if (isDefined(result?.error)) {
+          handleFindManyRecordsError(result.error);
+          return { error: result.error };
+        }
+
+        if (isDefined(result?.data)) {
+          handleFindManyRecordsCompleted(result.data);
+        }
 
         const hasNextPage =
           result?.data?.[objectMetadataItem.namePlural]?.pageInfo.hasNextPage ??
@@ -175,6 +173,8 @@ export const useLazyFindManyRecords = <T extends ObjectRecord = ObjectRecord>({
       findManyRecords,
       objectMetadataItem.namePlural,
       queryIdentifier,
+      handleFindManyRecordsError,
+      handleFindManyRecordsCompleted,
     ],
   );
 


### PR DESCRIPTION
Fixes https://github.com/twentyhq/twenty/issues/15369

It's the first time we are hitting this weird behavior on apollo onCompleted / onError. Theoretically if the reference of the onCompleted (resp onError) callback is changing, this will trigger a re-run of onCompleted. But also theretically the reference here is a recoilCallback so should never change.

As this is synchronous I have move this logic to a sync way