### PR TITLE
fix: validator.js has a URL validation bypass vulnerability in its isURL function.

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -54469,9 +54469,9 @@ __metadata:
   linkType: hard
 
 "validator@npm:^13.7.0":
-  version: 13.12.0
-  resolution: "validator@npm:13.12.0"
-  checksum: 10c0/21d48a7947c9e8498790550f56cd7971e0e3d724c73388226b109c1bac2728f4f88caddfc2f7ed4b076f9b0d004316263ac786a17e9c4edf075741200718cd32
+  version: 13.15.20
+  resolution: "validator@npm:13.15.20"
+  checksum: 10c0/65453f0c91ef154ae2da4d5ff3c22acff239d2c15216335ba83895b6f79914708709c641119aa9fba0ec9dd69229c1cf8196aff0081584bdda8a7f50ea97b789
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resolves [Dependabot Alert 299](https://github.com/twentyhq/twenty/security/dependabot/299) - validator has a URL validation bypass vulnerability in its isURL function.

Used `yarn up validator --recursive` to update the version in yarn.lock file.