### PR TITLE
Fix creating kanban view when no select field

### DIFF
--- a/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownLayoutContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownLayoutContent.tsx
@@ -89,6 +89,7 @@ export const ObjectOptionsDropdownLayoutContent = () => {
     if (availableFieldsForKanban.length === 0) {
       navigateToSelectSettings();
       closeDropdown(dropdownId);
+      return;
     }
     if (currentView?.type !== ViewType.Kanban) {
       await setAndPersistViewType(ViewType.Kanban);
@@ -102,6 +103,7 @@ export const ObjectOptionsDropdownLayoutContent = () => {
     if (availableFieldsForCalendar.length === 0) {
       navigateToDateFieldSettings();
       closeDropdown(dropdownId);
+      return;
     }
     if (currentView?.type !== ViewType.Calendar) {
       await setAndPersistViewType(ViewType.Calendar);


### PR DESCRIPTION
Adding an early return when no select field exists and you are redirected to the setting page otherwise it tries to call setAndPersistViewType with kanban and fails with "No fields for kanban - should not happen"