### PR TITLE
fix: on-headers is vulnerable to http response header manipulation

### DIFF
--- a/packages/twenty-server/package.json
+++ b/packages/twenty-server/package.json
@@ -97,7 +97,7 @@
     "dompurify": "3.2.6",
     "dotenv": "16.4.5",
     "express": "4.21.2",
-    "express-session": "^1.18.1",
+    "express-session": "^1.18.2",
     "file-type": "16.5.4",
     "gaxios": "5.1.3",
     "glob": "11.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -33807,19 +33807,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"express-session@npm:^1.18.1":
-  version: 1.18.1
-  resolution: "express-session@npm:1.18.1"
+"express-session@npm:^1.18.2":
+  version: 1.18.2
+  resolution: "express-session@npm:1.18.2"
   dependencies:
     cookie: "npm:0.7.2"
     cookie-signature: "npm:1.0.7"
     debug: "npm:2.6.9"
     depd: "npm:~2.0.0"
-    on-headers: "npm:~1.0.2"
+    on-headers: "npm:~1.1.0"
     parseurl: "npm:~1.3.3"
     safe-buffer: "npm:5.2.1"
     uid-safe: "npm:~2.1.5"
-  checksum: 10c0/7999f128df1528430044c97bb1aac95093afaee86c5fa54b2890c4aad9898d79745301f8c90c2df057d6dfe7af7f8ee220340bf5eb53dca5eff37e52cc2fbec7
+  checksum: 10c0/27e17c3d365e3543ba7c1315ff14916b8347a2fd28f94817c6d2e2425923e61fa97fc23e0933015981c3358ba6f11964666249f046c4f93d22015fe2a95140ac
   languageName: node
   linkType: hard
 
@@ -44833,10 +44833,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"on-headers@npm:~1.0.2":
-  version: 1.0.2
-  resolution: "on-headers@npm:1.0.2"
-  checksum: 10c0/f649e65c197bf31505a4c0444875db0258e198292f34b884d73c2f751e91792ef96bb5cf89aa0f4fecc2e4dc662461dda606b1274b0e564f539cae5d2f5fc32f
+"on-headers@npm:~1.1.0":
+  version: 1.1.0
+  resolution: "on-headers@npm:1.1.0"
+  checksum: 10c0/2c3b6b0d68ec9adbd561dc2d61c9b14da8ac03d8a2f0fd9e97bdf0600c887d5d97f664ff3be6876cf40cda6e3c587d73a4745e10b426ac50c7664fc5a0dfc0a1
   languageName: node
   linkType: hard
 
@@ -52806,7 +52806,7 @@ __metadata:
     dompurify: "npm:3.2.6"
     dotenv: "npm:16.4.5"
     express: "npm:4.21.2"
-    express-session: "npm:^1.18.1"
+    express-session: "npm:^1.18.2"
     file-type: "npm:16.5.4"
     gaxios: "npm:5.1.3"
     glob: "npm:11.0.1"


### PR DESCRIPTION
Resolves [Dependabot Alert 245](https://github.com/twentyhq/twenty/security/dependabot/245) - on-headers is vulnerable to http response header manipulation.

Updated the version of express-session from `1.18.1` to `1.18.2`.