### PR TITLE
switch migrationActionsWithParent to migrationActionsWithParentTmp temporary

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-runner/workspace-migration-runner.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-runner/workspace-migration-runner.service.ts
@@ -67,10 +67,20 @@ export class WorkspaceMigrationRunnerService {
       `SET LOCAL search_path TO ${schemaName}`,
     );
 
+    // temporary fix to skip view migrations issue during upgrade 1.8 -> 1.10
+    const migrationActionsWithParentTmp = [
+      ...migrationActionsWithParent.filter(
+        ({ tableAction }) => tableAction.name !== 'view',
+      ),
+      ...migrationActionsWithParent.filter(
+        ({ tableAction }) => tableAction.name === 'view',
+      ),
+    ];
+
     for (const {
       tableAction,
       parentMigrationId,
-    } of migrationActionsWithParent) {
+    } of migrationActionsWithParentTmp) {
       await this.handleTableChanges(
         transactionQueryRunner as PostgresQueryRunner,
         schemaName,
@@ -83,7 +93,7 @@ export class WorkspaceMigrationRunnerService {
       );
     }
 
-    return migrationActionsWithParent.map((item) => item.tableAction);
+    return migrationActionsWithParentTmp.map((item) => item.tableAction);
   }
 
   public async executeMigrationFromPendingMigrations(


### PR DESCRIPTION
The removal of views from the workspaces schema implies the deletion of 
```
view
viewFilter
viewFilterGroup
viewGroup
viewSort
```
Before it is created again in the core schema.

However, the syncmetadata that executes the pending migration fails because it will try to 
`query failed: DROP TABLE "workspace_xxxx"."view"`
before the removal of the other view related tables that contains a view foreign key with this kind of message
> constraint FK_c5ab40cd4debb51d588752a4857 on table "viewField" depends on table view