### PR TITLE
fix: make $groupBy parameter required in group-by queries

### DIFF
--- a/packages/twenty-front/src/modules/page-layout/widgets/graph/utils/__tests__/__snapshots__/generateGroupByQuery.test.ts.snap
+++ b/packages/twenty-front/src/modules/page-layout/widgets/graph/utils/__tests__/__snapshots__/generateGroupByQuery.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`generateGroupByQuery should generate valid GraphQL query for empty aggregate operations 1`] = `
 "
     query PeopleGroupBy(
-      $groupBy: [PersonGroupByInput!]
+      $groupBy: [PersonGroupByInput!]!
       $filter: PersonFilterInput
       $orderBy: [PersonOrderByWithGroupByInput!]
       $viewId: UUID
@@ -23,7 +23,7 @@ exports[`generateGroupByQuery should generate valid GraphQL query for empty aggr
 exports[`generateGroupByQuery should generate valid GraphQL query for multiple aggregate operations 1`] = `
 "
     query OpportunitiesGroupBy(
-      $groupBy: [OpportunityGroupByInput!]
+      $groupBy: [OpportunityGroupByInput!]!
       $filter: OpportunityFilterInput
       $orderBy: [OpportunityOrderByWithGroupByInput!]
       $viewId: UUID
@@ -46,7 +46,7 @@ exports[`generateGroupByQuery should generate valid GraphQL query for multiple a
 exports[`generateGroupByQuery should generate valid GraphQL query for single aggregate operation 1`] = `
 "
     query OpportunitiesGroupBy(
-      $groupBy: [OpportunityGroupByInput!]
+      $groupBy: [OpportunityGroupByInput!]!
       $filter: OpportunityFilterInput
       $orderBy: [OpportunityOrderByWithGroupByInput!]
       $viewId: UUID

--- a/packages/twenty-front/src/modules/page-layout/widgets/graph/utils/generateGroupByQuery.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/graph/utils/generateGroupByQuery.ts
@@ -17,7 +17,7 @@ export const generateGroupByQuery = ({
 
   return gql`
     query ${queryName}(
-      $groupBy: [${capitalizedSingular}GroupByInput!]
+      $groupBy: [${capitalizedSingular}GroupByInput!]!
       $filter: ${capitalizedSingular}FilterInput
       $orderBy: [${capitalizedSingular}OrderByWithGroupByInput!]
       $viewId: UUID


### PR DESCRIPTION
before:

<img width="953" height="692" alt="Screenshot 2025-10-31 at 12 16 22" src="https://github.com/user-attachments/assets/d2ec2a49-256d-4f17-baa7-6fb541e6e691" />

after:

<img width="960" height="718" alt="Screenshot 2025-10-31 at 12 16 34" src="https://github.com/user-attachments/assets/39843363-8f77-40cc-8203-ed9895efa57e" />
