### PR TITLE
fix: composite field label retrieval in spreadsheet import utility

### DIFF
--- a/packages/twenty-front/src/modules/object-record/spreadsheet-import/utils/spreadsheetImportGetRelationConnectSubFieldLabel.ts
+++ b/packages/twenty-front/src/modules/object-record/spreadsheet-import/utils/spreadsheetImportGetRelationConnectSubFieldLabel.ts
@@ -9,9 +9,9 @@ export const getRelationConnectSubFieldLabel = (
   compositeSubFieldKey?: string,
 ) => {
   const compositeSubFieldLabel =
-    isCompositeFieldType(fieldMetadataItem.type) &&
+    isCompositeFieldType(uniqueFieldMetadataItem.type) &&
     isDefined(compositeSubFieldKey)
-      ? COMPOSITE_FIELD_SUB_FIELD_LABELS[fieldMetadataItem.type][
+      ? COMPOSITE_FIELD_SUB_FIELD_LABELS[uniqueFieldMetadataItem.type][
           compositeSubFieldKey
         ]
       : undefined;


### PR DESCRIPTION
Fixes - https://github.com/twentyhq/twenty/issues/15368

Seems like the sub field was not being used for the actual label lookup part 

<img width="1302" height="354" alt="image" src="https://github.com/user-attachments/assets/444f76be-117b-4b8b-91fe-dedd293e09af" />
