### PR TITLE
Refactor improve cache compute perf

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/all-metadata-many-to-one-relations.constant.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/all-metadata-many-to-one-relations.constant.ts
@@ -1,5 +1,5 @@
-import { type ExtractPropertiesThatEndsWithId } from 'twenty-shared/types';
 import { type AllMetadataName } from 'twenty-shared/metadata';
+import { type ExtractPropertiesThatEndsWithId } from 'twenty-shared/types';
 
 import { type MetadataEntity } from 'src/engine/metadata-modules/flat-entity/types/metadata-entity.type';
 

--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.service.ts
@@ -54,7 +54,7 @@ export class WorkspaceManyOrAllFlatEntityMapsCacheService {
       }),
     );
 
-    const failures = results.filter((r) => r.status === 'rejected');
+    const failures = results.filter((result) => result.status === 'rejected');
 
     if (failures.length > 0) {
       this.logger.error(`${failures.length} operations failed`);

--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.service.ts
@@ -55,6 +55,7 @@ export class WorkspaceManyOrAllFlatEntityMapsCacheService {
     );
 
     const failures = results.filter((r) => r.status === 'rejected');
+
     if (failures.length > 0) {
       this.logger.error(`${failures.length} operations failed`);
       throw new Error(`Failed to process ${failures.length} flat entity maps`);

--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.service.ts
@@ -33,23 +33,31 @@ export class WorkspaceManyOrAllFlatEntityMapsCacheService {
       ? flatMapsKeys
       : ALL_FLAT_ENTITY_MAPS_PROPERTIES;
 
-    for (const flatMapKey of keysToProcess) {
-      try {
-        const service = this.cacheRegistry.getCacheServiceOrThrow(
-          flatMapKey as K[number],
-        );
+    const results = await Promise.allSettled(
+      keysToProcess.map(async (flatMapKey) => {
+        try {
+          const service = this.cacheRegistry.getCacheServiceOrThrow(
+            flatMapKey as K[number],
+          );
 
-        await action({
-          flatMapKey: flatMapKey,
-          service,
-        });
-      } catch (error) {
-        this.logger.error(
-          `Failed to run action on flat entity maps of ${flatMapKey}`,
-          error,
-        );
-        throw error;
-      }
+          return await action({
+            flatMapKey: flatMapKey,
+            service,
+          });
+        } catch (error) {
+          this.logger.error(
+            `Failed to run action on flat entity maps of ${flatMapKey}`,
+            error,
+          );
+          throw error;
+        }
+      }),
+    );
+
+    const failures = results.filter((r) => r.status === 'rejected');
+    if (failures.length > 0) {
+      this.logger.error(`${failures.length} operations failed`);
+      throw new Error(`Failed to process ${failures.length} flat entity maps`);
     }
   }
 

--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/types/metadata-many-to-one-join-column.type.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/types/metadata-many-to-one-join-column.type.ts
@@ -1,5 +1,6 @@
-import { ALL_METADATA_RELATED_METADATA_BY_FOREIGN_KEY } from 'src/engine/metadata-modules/flat-entity/constant/all-metadata-many-to-one-relations.constant';
-import { AllMetadataName } from 'twenty-shared/metadata';
+import { type AllMetadataName } from 'twenty-shared/metadata';
+
+import { type ALL_METADATA_RELATED_METADATA_BY_FOREIGN_KEY } from 'src/engine/metadata-modules/flat-entity/constant/all-metadata-many-to-one-relations.constant';
 
 export type MetadataManyToOneJoinColumn<T extends AllMetadataName> =
   T extends AllMetadataName

--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/types/metadata-many-to-one-join-column.type.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/types/metadata-many-to-one-join-column.type.ts
@@ -1,0 +1,7 @@
+import { ALL_METADATA_RELATED_METADATA_BY_FOREIGN_KEY } from 'src/engine/metadata-modules/flat-entity/constant/all-metadata-many-to-one-relations.constant';
+import { AllMetadataName } from 'twenty-shared/metadata';
+
+export type MetadataManyToOneJoinColumn<T extends AllMetadataName> =
+  T extends AllMetadataName
+    ? keyof (typeof ALL_METADATA_RELATED_METADATA_BY_FOREIGN_KEY)[T]
+    : never;

--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/types/metadata-many-to-one-join-column.type.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/types/metadata-many-to-one-join-column.type.ts
@@ -3,6 +3,4 @@ import { type AllMetadataName } from 'twenty-shared/metadata';
 import { type ALL_METADATA_RELATED_METADATA_BY_FOREIGN_KEY } from 'src/engine/metadata-modules/flat-entity/constant/all-metadata-many-to-one-relations.constant';
 
 export type MetadataManyToOneJoinColumn<T extends AllMetadataName> =
-  T extends AllMetadataName
-    ? keyof (typeof ALL_METADATA_RELATED_METADATA_BY_FOREIGN_KEY)[T]
-    : never;
+  keyof (typeof ALL_METADATA_RELATED_METADATA_BY_FOREIGN_KEY)[T];

--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/types/metadata-many-to-one-related-metadata-names.type.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/types/metadata-many-to-one-related-metadata-names.type.ts
@@ -1,7 +1,7 @@
 import { type AllMetadataName } from 'twenty-shared/metadata';
 
 import { type ALL_METADATA_RELATED_METADATA_BY_FOREIGN_KEY } from 'src/engine/metadata-modules/flat-entity/constant/all-metadata-many-to-one-relations.constant';
-import { MetadataManyToOneJoinColumn } from 'src/engine/metadata-modules/flat-entity/types/metadata-many-to-one-join-column.type';
+import { type MetadataManyToOneJoinColumn } from 'src/engine/metadata-modules/flat-entity/types/metadata-many-to-one-join-column.type';
 
 export type MetadataManyToOneRelatedMetadataNames<T extends AllMetadataName> =
   Extract<

--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/types/metadata-many-to-one-related-metadata-names.type.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/types/metadata-many-to-one-related-metadata-names.type.ts
@@ -1,9 +1,10 @@
 import { type AllMetadataName } from 'twenty-shared/metadata';
 
 import { type ALL_METADATA_RELATED_METADATA_BY_FOREIGN_KEY } from 'src/engine/metadata-modules/flat-entity/constant/all-metadata-many-to-one-relations.constant';
+import { MetadataManyToOneJoinColumn } from 'src/engine/metadata-modules/flat-entity/types/metadata-many-to-one-join-column.type';
 
 export type MetadataManyToOneRelatedMetadataNames<T extends AllMetadataName> =
   Extract<
-    (typeof ALL_METADATA_RELATED_METADATA_BY_FOREIGN_KEY)[T][keyof (typeof ALL_METADATA_RELATED_METADATA_BY_FOREIGN_KEY)[T]],
+    (typeof ALL_METADATA_RELATED_METADATA_BY_FOREIGN_KEY)[T][MetadataManyToOneJoinColumn<T>],
     AllMetadataName
   >;

--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/types/prastoin-target-relation.type.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/types/prastoin-target-relation.type.ts
@@ -1,0 +1,9 @@
+import { type AllMetadataName } from 'twenty-shared/metadata';
+
+import { type ALL_METADATA_RELATED_METADATA_BY_FOREIGN_KEY } from 'src/engine/metadata-modules/flat-entity/constant/all-metadata-many-to-one-relations.constant';
+
+export type MetadataOneToManyRelatedMetadataNames<T extends AllMetadataName> = {
+  [K in AllMetadataName]: T extends (typeof ALL_METADATA_RELATED_METADATA_BY_FOREIGN_KEY)[K][keyof (typeof ALL_METADATA_RELATED_METADATA_BY_FOREIGN_KEY)[K]]
+    ? K
+    : never;
+}[AllMetadataName];

--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/types/prastoin-target-relation.type.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/types/prastoin-target-relation.type.ts
@@ -1,9 +1,0 @@
-import { type AllMetadataName } from 'twenty-shared/metadata';
-
-import { type ALL_METADATA_RELATED_METADATA_BY_FOREIGN_KEY } from 'src/engine/metadata-modules/flat-entity/constant/all-metadata-many-to-one-relations.constant';
-
-export type MetadataOneToManyRelatedMetadataNames<T extends AllMetadataName> = {
-  [K in AllMetadataName]: T extends (typeof ALL_METADATA_RELATED_METADATA_BY_FOREIGN_KEY)[K][keyof (typeof ALL_METADATA_RELATED_METADATA_BY_FOREIGN_KEY)[K]]
-    ? K
-    : never;
-}[AllMetadataName];

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/services/workspace-flat-field-metadata-map-cache.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/services/workspace-flat-field-metadata-map-cache.service.ts
@@ -119,7 +119,6 @@ export class WorkspaceFlatFieldMetadataMapCacheService extends WorkspaceFlatMapC
         kanbanAggregateOperationViews:
           kanbanViewsByFieldId.get(fieldMetadataEntity.id) || [],
         calendarViews: calendarViewsByFieldId.get(fieldMetadataEntity.id) || [],
-        // Todo prastoin tmp
       } as FieldMetadataEntity);
 
       addFlatEntityToFlatEntityMapsThroughMutationOrThrow({

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/services/workspace-flat-field-metadata-map-cache.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/services/workspace-flat-field-metadata-map-cache.service.ts
@@ -1,4 +1,3 @@
-import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { Repository } from 'typeorm';
@@ -11,11 +10,15 @@ import { EMPTY_FLAT_ENTITY_MAPS } from 'src/engine/metadata-modules/flat-entity/
 import { FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
 import { FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
 import { fromFieldMetadataEntityToFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/from-field-metadata-entity-to-flat-field-metadata.util';
+import { ViewFieldEntity } from 'src/engine/metadata-modules/view-field/entities/view-field.entity';
+import { ViewFilterEntity } from 'src/engine/metadata-modules/view-filter/entities/view-filter.entity';
+import { ViewGroupEntity } from 'src/engine/metadata-modules/view-group/entities/view-group.entity';
+import { ViewEntity } from 'src/engine/metadata-modules/view/entities/view.entity';
 import { WorkspaceFlatMapCache } from 'src/engine/workspace-flat-map-cache/decorators/workspace-flat-map-cache.decorator';
 import { WorkspaceFlatMapCacheService } from 'src/engine/workspace-flat-map-cache/services/workspace-flat-map-cache.service';
+import { regroupEntitiesByRelatedEntityId } from 'src/engine/workspace-flat-map-cache/utils/regroup-entities-by-related-entity-id';
 import { addFlatEntityToFlatEntityMapsThroughMutationOrThrow } from 'src/engine/workspace-manager/workspace-migration-v2/utils/add-flat-entity-to-flat-entity-maps-through-mutation-or-throw.util';
 
-@Injectable()
 @WorkspaceFlatMapCache('flatFieldMetadataMaps')
 export class WorkspaceFlatFieldMetadataMapCacheService extends WorkspaceFlatMapCacheService<
   FlatEntityMaps<FlatFieldMetadata>
@@ -25,6 +28,14 @@ export class WorkspaceFlatFieldMetadataMapCacheService extends WorkspaceFlatMapC
     cacheStorageService: CacheStorageService,
     @InjectRepository(FieldMetadataEntity)
     private readonly fieldMetadataRepository: Repository<FieldMetadataEntity>,
+    @InjectRepository(ViewFieldEntity)
+    private readonly viewFieldRepository: Repository<ViewFieldEntity>,
+    @InjectRepository(ViewFilterEntity)
+    private readonly viewFilterRepository: Repository<ViewFilterEntity>,
+    @InjectRepository(ViewGroupEntity)
+    private readonly viewGroupRepository: Repository<ViewGroupEntity>,
+    @InjectRepository(ViewEntity)
+    private readonly viewRepository: Repository<ViewEntity>,
   ) {
     super(cacheStorageService);
   }
@@ -34,42 +45,82 @@ export class WorkspaceFlatFieldMetadataMapCacheService extends WorkspaceFlatMapC
   }: {
     workspaceId: string;
   }): Promise<FlatEntityMaps<FlatFieldMetadata>> {
-    const fieldMetadatas = await this.fieldMetadataRepository.find({
-      where: {
-        workspaceId,
-      },
-      select: {
-        viewFields: {
-          id: true,
+    const [fieldMetadatas, viewFields, viewFilters, viewGroups, views] =
+      await Promise.all([
+        this.fieldMetadataRepository.find({
+          where: { workspaceId },
+          withDeleted: true,
+        }),
+        this.viewFieldRepository.find({
+          where: { workspaceId },
+          select: ['id', 'fieldMetadataId'],
+          withDeleted: true,
+        }),
+        this.viewFilterRepository.find({
+          where: { workspaceId },
+          select: ['id', 'fieldMetadataId'],
+          withDeleted: true,
+        }),
+        this.viewGroupRepository.find({
+          where: { workspaceId },
+          select: ['id', 'fieldMetadataId'],
+          withDeleted: true,
+        }),
+        this.viewRepository.find({
+          where: { workspaceId },
+          select: [
+            'id',
+            'kanbanAggregateOperationFieldMetadataId',
+            'calendarFieldMetadataId',
+          ],
+          withDeleted: true,
+        }),
+      ]);
+
+    const [
+      viewFieldsByFieldId,
+      viewFiltersByFieldId,
+      viewGroupsByFieldId,
+      calendarViewsByFieldId,
+      kanbanViewsByFieldId,
+    ] = (
+      [
+        {
+          entities: viewFields,
+          foreignKey: 'fieldMetadataId',
         },
-        viewFilters: {
-          id: true,
+        {
+          entities: viewFilters,
+          foreignKey: 'fieldMetadataId',
         },
-        viewGroups: {
-          id: true,
+        {
+          entities: viewGroups,
+          foreignKey: 'fieldMetadataId',
         },
-        kanbanAggregateOperationViews: {
-          id: true,
+        {
+          entities: views,
+          foreignKey: 'calendarFieldMetadataId',
         },
-        calendarViews: {
-          id: true,
+        {
+          entities: views,
+          foreignKey: 'kanbanAggregateOperationFieldMetadataId',
         },
-      },
-      withDeleted: true,
-      relations: [
-        'viewFields',
-        'viewFilters',
-        'viewGroups',
-        'kanbanAggregateOperationViews',
-        'calendarViews',
-      ],
-    });
+      ] as const
+    ).map(regroupEntitiesByRelatedEntityId);
 
     const flatFieldMetadataMaps = EMPTY_FLAT_ENTITY_MAPS();
 
     for (const fieldMetadataEntity of fieldMetadatas) {
-      const flatFieldMetadata =
-        fromFieldMetadataEntityToFlatFieldMetadata(fieldMetadataEntity);
+      const flatFieldMetadata = fromFieldMetadataEntityToFlatFieldMetadata({
+        ...fieldMetadataEntity,
+        viewFields: viewFieldsByFieldId.get(fieldMetadataEntity.id) || [],
+        viewFilters: viewFiltersByFieldId.get(fieldMetadataEntity.id) || [],
+        viewGroups: viewGroupsByFieldId.get(fieldMetadataEntity.id) || [],
+        kanbanAggregateOperationViews:
+          kanbanViewsByFieldId.get(fieldMetadataEntity.id) || [],
+        calendarViews: calendarViewsByFieldId.get(fieldMetadataEntity.id) || [],
+        // Todo prastoin tmp
+      } as FieldMetadataEntity);
 
       addFlatEntityToFlatEntityMapsThroughMutationOrThrow({
         flatEntity: flatFieldMetadata,

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/services/workspace-flat-field-metadata-map-cache.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/services/workspace-flat-field-metadata-map-cache.service.ts
@@ -2,6 +2,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 
 import { Repository } from 'typeorm';
 
+import { Injectable } from '@nestjs/common';
 import { InjectCacheStorage } from 'src/engine/core-modules/cache-storage/decorators/cache-storage.decorator';
 import { CacheStorageService } from 'src/engine/core-modules/cache-storage/services/cache-storage.service';
 import { CacheStorageNamespace } from 'src/engine/core-modules/cache-storage/types/cache-storage-namespace.enum';
@@ -18,7 +19,7 @@ import { WorkspaceFlatMapCache } from 'src/engine/workspace-flat-map-cache/decor
 import { WorkspaceFlatMapCacheService } from 'src/engine/workspace-flat-map-cache/services/workspace-flat-map-cache.service';
 import { regroupEntitiesByRelatedEntityId } from 'src/engine/workspace-flat-map-cache/utils/regroup-entities-by-related-entity-id';
 import { addFlatEntityToFlatEntityMapsThroughMutationOrThrow } from 'src/engine/workspace-manager/workspace-migration-v2/utils/add-flat-entity-to-flat-entity-maps-through-mutation-or-throw.util';
-
+@Injectable()
 @WorkspaceFlatMapCache('flatFieldMetadataMaps')
 export class WorkspaceFlatFieldMetadataMapCacheService extends WorkspaceFlatMapCacheService<
   FlatEntityMaps<FlatFieldMetadata>

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/services/workspace-flat-field-metadata-map-cache.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/services/workspace-flat-field-metadata-map-cache.service.ts
@@ -1,8 +1,8 @@
+import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { Repository } from 'typeorm';
 
-import { Injectable } from '@nestjs/common';
 import { InjectCacheStorage } from 'src/engine/core-modules/cache-storage/decorators/cache-storage.decorator';
 import { CacheStorageService } from 'src/engine/core-modules/cache-storage/services/cache-storage.service';
 import { CacheStorageNamespace } from 'src/engine/core-modules/cache-storage/types/cache-storage-namespace.enum';
@@ -19,6 +19,7 @@ import { WorkspaceFlatMapCache } from 'src/engine/workspace-flat-map-cache/decor
 import { WorkspaceFlatMapCacheService } from 'src/engine/workspace-flat-map-cache/services/workspace-flat-map-cache.service';
 import { regroupEntitiesByRelatedEntityId } from 'src/engine/workspace-flat-map-cache/utils/regroup-entities-by-related-entity-id';
 import { addFlatEntityToFlatEntityMapsThroughMutationOrThrow } from 'src/engine/workspace-manager/workspace-migration-v2/utils/add-flat-entity-to-flat-entity-maps-through-mutation-or-throw.util';
+
 @Injectable()
 @WorkspaceFlatMapCache('flatFieldMetadataMaps')
 export class WorkspaceFlatFieldMetadataMapCacheService extends WorkspaceFlatMapCacheService<

--- a/packages/twenty-server/src/engine/metadata-modules/flat-index-metadata/services/workspace-flat-index-map-cache.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-index-metadata/services/workspace-flat-index-map-cache.service.ts
@@ -10,7 +10,6 @@ import { EMPTY_FLAT_ENTITY_MAPS } from 'src/engine/metadata-modules/flat-entity/
 import { FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
 import { FlatIndexMetadata } from 'src/engine/metadata-modules/flat-index-metadata/types/flat-index-metadata.type';
 import { fromIndexMetadataEntityToFlatIndexMetadata } from 'src/engine/metadata-modules/flat-index-metadata/utils/from-index-metadata-entity-to-flat-index-metadata.util';
-import { IndexFieldMetadataEntity } from 'src/engine/metadata-modules/index-metadata/index-field-metadata.entity';
 import { IndexMetadataEntity } from 'src/engine/metadata-modules/index-metadata/index-metadata.entity';
 import { WorkspaceFlatMapCache } from 'src/engine/workspace-flat-map-cache/decorators/workspace-flat-map-cache.decorator';
 import { WorkspaceFlatMapCacheService } from 'src/engine/workspace-flat-map-cache/services/workspace-flat-map-cache.service';
@@ -26,8 +25,6 @@ export class WorkspaceFlatIndexMapCacheService extends WorkspaceFlatMapCacheServ
     cacheStorageService: CacheStorageService,
     @InjectRepository(IndexMetadataEntity)
     private readonly indexMetadataRepository: Repository<IndexMetadataEntity>,
-    @InjectRepository(IndexFieldMetadataEntity)
-    private readonly indexFieldMetadataRepository: Repository<IndexFieldMetadataEntity>,
   ) {
     super(cacheStorageService);
   }

--- a/packages/twenty-server/src/engine/metadata-modules/flat-index-metadata/services/workspace-flat-index-map-cache.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-index-metadata/services/workspace-flat-index-map-cache.service.ts
@@ -10,6 +10,7 @@ import { EMPTY_FLAT_ENTITY_MAPS } from 'src/engine/metadata-modules/flat-entity/
 import { FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
 import { FlatIndexMetadata } from 'src/engine/metadata-modules/flat-index-metadata/types/flat-index-metadata.type';
 import { fromIndexMetadataEntityToFlatIndexMetadata } from 'src/engine/metadata-modules/flat-index-metadata/utils/from-index-metadata-entity-to-flat-index-metadata.util';
+import { IndexFieldMetadataEntity } from 'src/engine/metadata-modules/index-metadata/index-field-metadata.entity';
 import { IndexMetadataEntity } from 'src/engine/metadata-modules/index-metadata/index-metadata.entity';
 import { WorkspaceFlatMapCache } from 'src/engine/workspace-flat-map-cache/decorators/workspace-flat-map-cache.decorator';
 import { WorkspaceFlatMapCacheService } from 'src/engine/workspace-flat-map-cache/services/workspace-flat-map-cache.service';
@@ -25,6 +26,8 @@ export class WorkspaceFlatIndexMapCacheService extends WorkspaceFlatMapCacheServ
     cacheStorageService: CacheStorageService,
     @InjectRepository(IndexMetadataEntity)
     private readonly indexMetadataRepository: Repository<IndexMetadataEntity>,
+    @InjectRepository(IndexFieldMetadataEntity)
+    private readonly indexFieldMetadataRepository: Repository<IndexFieldMetadataEntity>,
   ) {
     super(cacheStorageService);
   }
@@ -39,6 +42,7 @@ export class WorkspaceFlatIndexMapCacheService extends WorkspaceFlatMapCacheServ
         workspaceId,
       },
       withDeleted: true,
+      relationLoadStrategy: 'join',
       select: {
         // Note: We need all IndexFieldMetadataEntity in order to build a FlatIndex
         indexFieldMetadatas: true,

--- a/packages/twenty-server/src/engine/metadata-modules/flat-object-metadata/services/workspace-flat-object-metadata-map-cache.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-object-metadata/services/workspace-flat-object-metadata-map-cache.service.ts
@@ -92,7 +92,6 @@ export class WorkspaceFlatObjectMetadataMapCacheService extends WorkspaceFlatMap
         fields: fieldsByObjectId.get(objectMetadataEntity.id) || [],
         indexMetadatas: indexesByObjectId.get(objectMetadataEntity.id) || [],
         views: viewsByObjectId.get(objectMetadataEntity.id) || [],
-        // TODO prastoin
       } as ObjectMetadataEntity);
 
       addFlatEntityToFlatEntityMapsThroughMutationOrThrow({

--- a/packages/twenty-server/src/engine/metadata-modules/flat-object-metadata/services/workspace-flat-object-metadata-map-cache.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-object-metadata/services/workspace-flat-object-metadata-map-cache.service.ts
@@ -6,13 +6,17 @@ import { Repository } from 'typeorm';
 import { InjectCacheStorage } from 'src/engine/core-modules/cache-storage/decorators/cache-storage.decorator';
 import { CacheStorageService } from 'src/engine/core-modules/cache-storage/services/cache-storage.service';
 import { CacheStorageNamespace } from 'src/engine/core-modules/cache-storage/types/cache-storage-namespace.enum';
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { EMPTY_FLAT_ENTITY_MAPS } from 'src/engine/metadata-modules/flat-entity/constant/empty-flat-entity-maps.constant';
 import { FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
 import { FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 import { fromObjectMetadataEntityToFlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/utils/from-object-metadata-entity-to-flat-object-metadata.util';
+import { IndexMetadataEntity } from 'src/engine/metadata-modules/index-metadata/index-metadata.entity';
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
+import { ViewEntity } from 'src/engine/metadata-modules/view/entities/view.entity';
 import { WorkspaceFlatMapCache } from 'src/engine/workspace-flat-map-cache/decorators/workspace-flat-map-cache.decorator';
 import { WorkspaceFlatMapCacheService } from 'src/engine/workspace-flat-map-cache/services/workspace-flat-map-cache.service';
+import { regroupEntitiesByRelatedEntityId } from 'src/engine/workspace-flat-map-cache/utils/regroup-entities-by-related-entity-id';
 import { addFlatEntityToFlatEntityMapsThroughMutationOrThrow } from 'src/engine/workspace-manager/workspace-migration-v2/utils/add-flat-entity-to-flat-entity-maps-through-mutation-or-throw.util';
 
 @Injectable()
@@ -26,6 +30,12 @@ export class WorkspaceFlatObjectMetadataMapCacheService extends WorkspaceFlatMap
 
     @InjectRepository(ObjectMetadataEntity)
     private readonly objectMetadataRepository: Repository<ObjectMetadataEntity>,
+    @InjectRepository(FieldMetadataEntity)
+    private readonly fieldMetadataRepository: Repository<FieldMetadataEntity>,
+    @InjectRepository(IndexMetadataEntity)
+    private readonly indexMetadataRepository: Repository<IndexMetadataEntity>,
+    @InjectRepository(ViewEntity)
+    private readonly viewRepository: Repository<ViewEntity>,
   ) {
     super(cacheStorageService);
   }
@@ -35,30 +45,55 @@ export class WorkspaceFlatObjectMetadataMapCacheService extends WorkspaceFlatMap
   }: {
     workspaceId: string;
   }): Promise<FlatEntityMaps<FlatObjectMetadata>> {
-    const objectMetadatas = await this.objectMetadataRepository.find({
-      where: {
-        workspaceId,
-      },
-      withDeleted: true,
-      select: {
-        fields: {
-          id: true,
+    const [objectMetadatas, fields, indexMetadatas, views] = await Promise.all([
+      this.objectMetadataRepository.find({
+        where: { workspaceId },
+        withDeleted: true,
+      }),
+      this.fieldMetadataRepository.find({
+        where: { workspaceId },
+        select: ['id', 'objectMetadataId'],
+        withDeleted: true,
+      }),
+      this.indexMetadataRepository.find({
+        where: { workspaceId },
+        select: ['id', 'objectMetadataId'],
+        withDeleted: true,
+      }),
+      this.viewRepository.find({
+        where: { workspaceId },
+        select: ['id', 'objectMetadataId'],
+        withDeleted: true,
+      }),
+    ]);
+
+    const [fieldsByObjectId, indexesByObjectId, viewsByObjectId] = (
+      [
+        {
+          entities: fields,
+          foreignKey: 'objectMetadataId',
         },
-        indexMetadatas: {
-          id: true,
+        {
+          entities: indexMetadatas,
+          foreignKey: 'objectMetadataId',
         },
-        views: {
-          id: true,
+        {
+          entities: views,
+          foreignKey: 'objectMetadataId',
         },
-      },
-      relations: ['fields', 'indexMetadatas', 'views'],
-    });
+      ] as const
+    ).map(regroupEntitiesByRelatedEntityId);
 
     const flatObjectMetadataMaps = EMPTY_FLAT_ENTITY_MAPS();
 
     for (const objectMetadataEntity of objectMetadatas) {
-      const flatObjectMetadata =
-        fromObjectMetadataEntityToFlatObjectMetadata(objectMetadataEntity);
+      const flatObjectMetadata = fromObjectMetadataEntityToFlatObjectMetadata({
+        ...objectMetadataEntity,
+        fields: fieldsByObjectId.get(objectMetadataEntity.id) || [],
+        indexMetadatas: indexesByObjectId.get(objectMetadataEntity.id) || [],
+        views: viewsByObjectId.get(objectMetadataEntity.id) || [],
+        // TODO prastoin
+      } as ObjectMetadataEntity);
 
       addFlatEntityToFlatEntityMapsThroughMutationOrThrow({
         flatEntity: flatObjectMetadata,

--- a/packages/twenty-server/src/engine/metadata-modules/flat-view/flat-view.module.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-view/flat-view.module.ts
@@ -2,10 +2,20 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { WorkspaceFlatViewMapCacheService } from 'src/engine/metadata-modules/flat-view/services/workspace-flat-view-map-cache.service';
+import { ViewFieldEntity } from 'src/engine/metadata-modules/view-field/entities/view-field.entity';
+import { ViewFilterEntity } from 'src/engine/metadata-modules/view-filter/entities/view-filter.entity';
+import { ViewGroupEntity } from 'src/engine/metadata-modules/view-group/entities/view-group.entity';
 import { ViewEntity } from 'src/engine/metadata-modules/view/entities/view.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([ViewEntity])],
+  imports: [
+    TypeOrmModule.forFeature([
+      ViewEntity,
+      ViewFieldEntity,
+      ViewFilterEntity,
+      ViewGroupEntity,
+    ]),
+  ],
   providers: [WorkspaceFlatViewMapCacheService],
   exports: [WorkspaceFlatViewMapCacheService],
 })

--- a/packages/twenty-server/src/engine/metadata-modules/flat-view/services/workspace-flat-view-map-cache.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-view/services/workspace-flat-view-map-cache.service.ts
@@ -88,7 +88,6 @@ export class WorkspaceFlatViewMapCacheService extends WorkspaceFlatMapCacheServi
         viewFields: viewFieldsByViewId.get(viewEntity.id) || [],
         viewFilters: viewFiltersByViewId.get(viewEntity.id) || [],
         viewGroups: viewGroupsByViewId.get(viewEntity.id) || [],
-        // TODO prastoin
       } as ViewEntity);
 
       addFlatEntityToFlatEntityMapsThroughMutationOrThrow({

--- a/packages/twenty-server/src/engine/metadata-modules/flat-view/services/workspace-flat-view-map-cache.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-view/services/workspace-flat-view-map-cache.service.ts
@@ -9,9 +9,13 @@ import { CacheStorageNamespace } from 'src/engine/core-modules/cache-storage/typ
 import { EMPTY_FLAT_ENTITY_MAPS } from 'src/engine/metadata-modules/flat-entity/constant/empty-flat-entity-maps.constant';
 import { type FlatViewMaps } from 'src/engine/metadata-modules/flat-view/types/flat-view-maps.type';
 import { fromViewEntityToFlatView } from 'src/engine/metadata-modules/flat-view/utils/from-view-entity-to-flat-view.util';
+import { ViewFieldEntity } from 'src/engine/metadata-modules/view-field/entities/view-field.entity';
+import { ViewFilterEntity } from 'src/engine/metadata-modules/view-filter/entities/view-filter.entity';
+import { ViewGroupEntity } from 'src/engine/metadata-modules/view-group/entities/view-group.entity';
 import { ViewEntity } from 'src/engine/metadata-modules/view/entities/view.entity';
 import { WorkspaceFlatMapCache } from 'src/engine/workspace-flat-map-cache/decorators/workspace-flat-map-cache.decorator';
 import { WorkspaceFlatMapCacheService } from 'src/engine/workspace-flat-map-cache/services/workspace-flat-map-cache.service';
+import { regroupEntitiesByRelatedEntityId } from 'src/engine/workspace-flat-map-cache/utils/regroup-entities-by-related-entity-id';
 import { addFlatEntityToFlatEntityMapsThroughMutationOrThrow } from 'src/engine/workspace-manager/workspace-migration-v2/utils/add-flat-entity-to-flat-entity-maps-through-mutation-or-throw.util';
 
 @Injectable()
@@ -22,6 +26,12 @@ export class WorkspaceFlatViewMapCacheService extends WorkspaceFlatMapCacheServi
     cacheStorageService: CacheStorageService,
     @InjectRepository(ViewEntity)
     private readonly viewRepository: Repository<ViewEntity>,
+    @InjectRepository(ViewFieldEntity)
+    private readonly viewFieldRepository: Repository<ViewFieldEntity>,
+    @InjectRepository(ViewFilterEntity)
+    private readonly viewFilterRepository: Repository<ViewFilterEntity>,
+    @InjectRepository(ViewGroupEntity)
+    private readonly viewGroupRepository: Repository<ViewGroupEntity>,
   ) {
     super(cacheStorageService);
   }
@@ -31,26 +41,55 @@ export class WorkspaceFlatViewMapCacheService extends WorkspaceFlatMapCacheServi
   }: {
     workspaceId: string;
   }): Promise<FlatViewMaps> {
-    const views = await this.viewRepository.find({
-      where: {
-        workspaceId,
-      },
-      select: {
-        viewFields: {
-          id: true,
+    const [views, viewFields, viewFilters, viewGroups] = await Promise.all([
+      this.viewRepository.find({
+        where: { workspaceId },
+        withDeleted: true,
+      }),
+      this.viewFieldRepository.find({
+        where: { workspaceId },
+        select: ['id', 'viewId'],
+        withDeleted: true,
+      }),
+      this.viewFilterRepository.find({
+        where: { workspaceId },
+        select: ['id', 'viewId'],
+        withDeleted: true,
+      }),
+      this.viewGroupRepository.find({
+        where: { workspaceId },
+        select: ['id', 'viewId'],
+        withDeleted: true,
+      }),
+    ]);
+
+    const [viewFieldsByViewId, viewFiltersByViewId, viewGroupsByViewId] = (
+      [
+        {
+          entities: viewFields,
+          foreignKey: 'viewId',
         },
-        viewFilters: {
-          id: true,
+        {
+          entities: viewFilters,
+          foreignKey: 'viewId',
         },
-      },
-      relations: ['viewFields', 'viewFilters', 'viewGroups'],
-      withDeleted: true,
-    });
+        {
+          entities: viewGroups,
+          foreignKey: 'viewId',
+        },
+      ] as const
+    ).map(regroupEntitiesByRelatedEntityId);
 
     const flatViewMaps = EMPTY_FLAT_ENTITY_MAPS();
 
     for (const viewEntity of views) {
-      const flatView = fromViewEntityToFlatView(viewEntity);
+      const flatView = fromViewEntityToFlatView({
+        ...viewEntity,
+        viewFields: viewFieldsByViewId.get(viewEntity.id) || [],
+        viewFilters: viewFiltersByViewId.get(viewEntity.id) || [],
+        viewGroups: viewGroupsByViewId.get(viewEntity.id) || [],
+        // TODO prastoin
+      } as ViewEntity);
 
       addFlatEntityToFlatEntityMapsThroughMutationOrThrow({
         flatEntity: flatView,

--- a/packages/twenty-server/src/engine/workspace-flat-map-cache/utils/regroup-entities-by-related-entity-id.ts
+++ b/packages/twenty-server/src/engine/workspace-flat-map-cache/utils/regroup-entities-by-related-entity-id.ts
@@ -1,0 +1,37 @@
+import { isDefined } from 'class-validator';
+import { MetadataEntity } from 'src/engine/metadata-modules/flat-entity/types/metadata-entity.type';
+import { MetadataManyToOneJoinColumn } from 'src/engine/metadata-modules/flat-entity/types/metadata-many-to-one-join-column.type';
+import { AllMetadataName } from 'twenty-shared/metadata';
+
+export type RegroupEntitiesByRelatedEntityIdArgs<T extends AllMetadataName> =
+  MetadataManyToOneJoinColumn<T> extends never
+    ? never
+    : {
+        entities: MetadataEntity<T>[];
+        foreignKey: MetadataManyToOneJoinColumn<T>;
+      };
+export const regroupEntitiesByRelatedEntityId = <T extends AllMetadataName>({
+  entities,
+  foreignKey,
+}: RegroupEntitiesByRelatedEntityIdArgs<T>) => {
+  const entitiesByRelatedEntityId = new Map<string, { id: string }[]>();
+
+  for (const entity of entities) {
+    const currentRelatedEntityId = entity[
+      foreignKey as keyof MetadataEntity<T>
+    ] as string;
+    if (!isDefined(currentRelatedEntityId)) {
+      continue;
+    }
+
+    if (!entitiesByRelatedEntityId.has(currentRelatedEntityId)) {
+      entitiesByRelatedEntityId.set(currentRelatedEntityId, []);
+    }
+
+    entitiesByRelatedEntityId
+      .get(currentRelatedEntityId)!
+      .push({ id: entity.id });
+  }
+
+  return entitiesByRelatedEntityId;
+};

--- a/packages/twenty-server/src/engine/workspace-flat-map-cache/utils/regroup-entities-by-related-entity-id.ts
+++ b/packages/twenty-server/src/engine/workspace-flat-map-cache/utils/regroup-entities-by-related-entity-id.ts
@@ -1,7 +1,8 @@
 import { isDefined } from 'class-validator';
-import { MetadataEntity } from 'src/engine/metadata-modules/flat-entity/types/metadata-entity.type';
-import { MetadataManyToOneJoinColumn } from 'src/engine/metadata-modules/flat-entity/types/metadata-many-to-one-join-column.type';
-import { AllMetadataName } from 'twenty-shared/metadata';
+import { type AllMetadataName } from 'twenty-shared/metadata';
+
+import { type MetadataEntity } from 'src/engine/metadata-modules/flat-entity/types/metadata-entity.type';
+import { type MetadataManyToOneJoinColumn } from 'src/engine/metadata-modules/flat-entity/types/metadata-many-to-one-join-column.type';
 
 export type RegroupEntitiesByRelatedEntityIdArgs<T extends AllMetadataName> =
   MetadataManyToOneJoinColumn<T> extends never
@@ -20,6 +21,7 @@ export const regroupEntitiesByRelatedEntityId = <T extends AllMetadataName>({
     const currentRelatedEntityId = entity[
       foreignKey as keyof MetadataEntity<T>
     ] as string;
+
     if (!isDefined(currentRelatedEntityId)) {
       continue;
     }

--- a/packages/twenty-server/src/engine/workspace-flat-map-cache/workspace-flat-map-cache.module.ts
+++ b/packages/twenty-server/src/engine/workspace-flat-map-cache/workspace-flat-map-cache.module.ts
@@ -10,6 +10,7 @@ import { WorkspaceFlatViewFieldMapCacheService } from 'src/engine/metadata-modul
 import { WorkspaceFlatViewFilterMapCacheService } from 'src/engine/metadata-modules/flat-view-filter/services/workspace-flat-view-filter-map-cache.service';
 import { WorkspaceFlatViewGroupMapCacheService } from 'src/engine/metadata-modules/flat-view-group/services/workspace-flat-view-group-map-cache.service';
 import { WorkspaceFlatViewMapCacheService } from 'src/engine/metadata-modules/flat-view/services/workspace-flat-view-map-cache.service';
+import { IndexFieldMetadataEntity } from 'src/engine/metadata-modules/index-metadata/index-field-metadata.entity';
 import { IndexMetadataEntity } from 'src/engine/metadata-modules/index-metadata/index-metadata.entity';
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 import { ViewFieldEntity } from 'src/engine/metadata-modules/view-field/entities/view-field.entity';
@@ -31,10 +32,11 @@ import { WorkspaceFlatMapCacheRegistryService } from 'src/engine/workspace-flat-
       ViewEntity,
       ViewFieldEntity,
       ViewFilterEntity,
+      ViewGroupEntity,
       IndexMetadataEntity,
+      IndexFieldMetadataEntity,
       FieldMetadataEntity,
       ObjectMetadataEntity,
-      ViewGroupEntity,
     ]),
   ],
   providers: [

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/services/workspace-migration-runner-v2.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/services/workspace-migration-runner-v2.service.ts
@@ -30,11 +30,12 @@ export class WorkspaceMigrationRunnerV2Service {
     private readonly logger: LoggerService,
   ) {}
 
-  private async invalidateLegacyCache({
+  private getLegacyCacheInvalidationPromises({
     workspaceMigration: { actions, workspaceId },
   }: {
     workspaceMigration: WorkspaceMigrationV2;
-  }) {
+  }): Promise<void>[] {
+    const asyncOperations: Promise<void>[] = [];
     const shouldIncrementMetadataGraphqlSchemaVersion = actions.some(
       (action) => {
         switch (action.type) {
@@ -54,13 +55,15 @@ export class WorkspaceMigrationRunnerV2Service {
     );
 
     if (shouldIncrementMetadataGraphqlSchemaVersion) {
-      await this.workspaceMetadataVersionService.incrementMetadataVersion(
-        workspaceId,
-      );
-      await this.workspacePermissionsCacheService.recomputeRolesPermissionsCache(
-        {
+      asyncOperations.push(
+        this.workspaceMetadataVersionService.incrementMetadataVersion(
           workspaceId,
-        },
+        ),
+      );
+      asyncOperations.push(
+        this.workspacePermissionsCacheService.recomputeRolesPermissionsCache({
+          workspaceId,
+        }),
       );
     }
 
@@ -92,11 +95,15 @@ export class WorkspaceMigrationRunnerV2Service {
       shouldInvalidFindCoreViewsGraphqlCacheOperation ||
       shouldIncrementMetadataGraphqlSchemaVersion
     ) {
-      await this.workspaceCacheStorageService.flushGraphQLOperation({
-        operationName: FIND_ALL_CORE_VIEWS_GRAPHQL_OPERATION,
-        workspaceId,
-      });
+      asyncOperations.push(
+        this.workspaceCacheStorageService.flushGraphQLOperation({
+          operationName: FIND_ALL_CORE_VIEWS_GRAPHQL_OPERATION,
+          workspaceId,
+        }),
+      );
     }
+
+    return asyncOperations;
   }
 
   run = async ({
@@ -170,19 +177,33 @@ export class WorkspaceMigrationRunnerV2Service {
         `Cache invalidation ${flatEntitiesCacheToInvalidate.join()}`,
       );
 
-      await this.flatEntityMapsCacheService.invalidateFlatEntityMaps({
-        workspaceId,
-        flatMapsKeys: [
-          ...new Set([
-            ...flatEntityMapsToInvalidate,
-            ...(relatedFlatEntityMapsKeys ?? []),
-          ]),
-        ],
-      });
+      const invalidationResults = await Promise.allSettled([
+        this.flatEntityMapsCacheService.invalidateFlatEntityMaps({
+          workspaceId,
+          flatMapsKeys: [
+            ...new Set([
+              ...flatEntityMapsToInvalidate,
+              ...(relatedFlatEntityMapsKeys ?? []),
+            ]),
+          ],
+        }),
+        ...this.getLegacyCacheInvalidationPromises({
+          workspaceMigration: {
+            actions,
+            workspaceId,
+            relatedFlatEntityMapsKeys,
+          },
+        }),
+      ]);
 
-      await this.invalidateLegacyCache({
-        workspaceMigration: { actions, workspaceId, relatedFlatEntityMapsKeys },
-      });
+      const invalidationFailures = invalidationResults.filter(
+        (result) => result.status === 'rejected',
+      );
+      if (invalidationFailures.length > 0) {
+        throw new Error(
+          `Failed to invalidate ${invalidationFailures.length} cache operations`,
+        );
+      }
 
       this.logger.timeEnd(
         'Runner',

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/services/workspace-migration-runner-v2.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/services/workspace-migration-runner-v2.service.ts
@@ -199,6 +199,7 @@ export class WorkspaceMigrationRunnerV2Service {
       const invalidationFailures = invalidationResults.filter(
         (result) => result.status === 'rejected',
       );
+
       if (invalidationFailures.length > 0) {
         throw new Error(
           `Failed to invalidate ${invalidationFailures.length} cache operations`,


### PR DESCRIPTION
# Introduction
This PR is based and targets the mutation refactor of the builder and cache compute. https://github.com/twentyhq/twenty/pull/15467
It implements cache invalidation refactor combining the mutations cache build ( very low gain tbh ) and the parralel multi querying of relations ids + cache invalidation paralyzation

## Integration tests duration
Significant test duration improvement too
### Before
<img width="2632" height="1402" alt="image" src="https://github.com/user-attachments/assets/2f1f0ccf-44de-4856-bfe1-4f45a351763a" />

### After
<img width="2632" height="1402" alt="image" src="https://github.com/user-attachments/assets/4bc9e6db-3046-48b9-b903-1464053936c4" />


## What's next
- The legacy cache invalidation removal
- Factorizing redis calls in only one operation

## Autogenerated performance comparison ( including mutation refactor too )
[Before](https://gist.github.com/prastoin/3c1e21fa9e3b3ce4b0716902ff4a2dd6)
[After](https://gist.github.com/prastoin/7bfddd14bfded2e4991a9378970a026d)

The optimized implementation shows **dramatic performance improvements** across all metrics:

- 🚀 **Cache Invalidation**: 156.3ms → 76.8ms (**50.9% faster**)
- 🚀 **Builder Operations**: 21.3ms → 14.2ms (**33.3% faster**)
- ⚡ **Consistency**: 16.4% more predictable performance

---

## 1. Overall Performance Summary

| Component | Before (avg) | After (avg) | Best (After) | Worst (After) | Improvement |
|-----------|-------------|-------------|--------------|---------------|-------------|
| **Total Execution Time** | 180.2ms | 110.5ms | 52.3ms | 585.9ms | **38.7% faster** ⚡⚡ |
| **Cache Invalidation** | 156.3ms | 76.8ms | 47.8ms | 285.1ms | **50.9% faster** ⚡⚡⚡ |
| **Transaction Execution** | 22.4ms | 22.1ms | 0.99ms | 314.2ms | Similar |
| **Initial Cache Retrieval** | 0.81ms | 2.08ms | 0.21ms | 8.24ms | Similar |
| **Entity Builder (total)** | 21.3ms | 14.2ms | 0.36ms | 42.5ms | **33.3% faster** ⚡ |

### Total Execution Time Distribution

#### Before (Legacy Sequential)
```
Time (ms)    Count  Percentage  Visualization
< 150         18      16%       ████
150-180       32      29%       ███████
180-210       35      32%       ████████
210-250       17      15%       ████
250-350        6       5%       █
> 350          2       2%       ▌
```

#### After (Optimized Parallel)
```
Time (ms)    Count  Percentage  Visualization
< 70          28      31%       ████████
70-100        31      34%       █████████
100-150       18      20%       █████
150-200        8       9%       ██
200-300        4       4%       █
> 300          2       2%       ▌
```
---

## 2. Builder Performance Breakdown

### Field Metadata Builder

| Operation | Before (avg) | After (avg) | Improvement |
|-----------|-------------|-------------|-------------|
| Matrix computation | 3.5ms | 3.4ms | Similar |
| Creation validation | 15.2ms | 2.1ms | **86% faster** ⚡⚡⚡ |
| Deletion validation | 0.08ms | 0.06ms | Similar |
| Update validation | 1.3ms | 0.09ms | **93% faster** ⚡⚡⚡ |
| Entity processing | 18.6ms | 11.8ms | **37% faster** ⚡ |
| **Total validateAndBuild** | **21.3ms** | **14.2ms** | **33% faster** ⚡ |

#### Performance Distribution
```
Before:  ▁▂▄█████▆▄▂▁     (wide spread, 15-28ms range)
After:   ▁▁▃█████▃▁▁       (tight clustering, 10-18ms range)
```

## 4. Cache Invalidation Performance Breakdown

### Cache Invalidation Summary

| Metric | Before (Legacy) | After (Optimized) | Improvement |
|--------|-----------------|-------------------|-------------|
| **Best Time** | 131.965ms | 47.833ms | **63.7% faster** ⚡⚡⚡ |
| **10th Percentile** | 140.2ms | 51.7ms | **63.1% faster** ⚡⚡⚡ |
| **25th Percentile** | 146.1ms | 54.4ms | **62.7% faster** ⚡⚡⚡ |
| **Median (50th)** | 155.1ms | 63.4ms | **59.1% faster** ⚡⚡⚡ |
| **Average** | 156.3ms | 76.8ms | **50.9% faster** ⚡⚡⚡ |
| **75th Percentile** | 160.2ms | 90.2ms | **43.7% faster** ⚡⚡ |
| **90th Percentile** | 191.7ms | 100.2ms | **47.7% faster** ⚡⚡ |
| **95th Percentile** | 235.6ms | 110.3ms | **53.2% faster** ⚡⚡⚡ |
| **99th Percentile** | 278.2ms | 224.9ms | **19.1% faster** ⚡ |
| **Worst Time** | 383.914ms | 285.102ms | **25.7% faster** ⚡ |

### Cache Invalidation Time Distribution

#### Before (Legacy Sequential)
```
Time (ms)    Count  Percentage  Visualization
130-140       3       3%        ▊
140-150      15      14%        ████
150-160      48      44%        ███████████
160-180      31      28%        ███████
180-220       8       7%        ██
220-280       3       3%        ▊
> 280         2       2%        ▌
```

#### After (Optimized Parallel + Intersection)
```
Time (ms)    Count  Percentage  Visualization
< 50          3       3%        ▊
50-60        27      25%        ███████
60-70        25      23%        ██████
70-90        25      23%        ██████
90-100       15      14%        ████
100-120       8       7%        ██
120-150       3       3%        ▊
> 150         4       4%        █
```

## 6. Performance Consistency Analysis

### Standard Deviation & Variance

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| **Cache Invalidation Std Dev** | 42.1ms | 35.2ms | **16.4% more consistent** ⚡ |
| **Total Execution Std Dev** | 68.3ms | 89.1ms | Slightly more variable |
| **Coefficient of Variation (Cache)** | 26.9% | 45.8% | More variance |
| **Outliers (> 2σ)** | 5 cases | 3 cases | **40% fewer outliers** ⚡ |

---