### PR TITLE
fix: regular expression denial of service (ReDoS) in cross-spawn

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/serverless/drivers/layers/1/yarn.lock
+++ b/packages/twenty-server/src/engine/core-modules/serverless/drivers/layers/1/yarn.lock
@@ -944,13 +944,13 @@ __metadata:
   linkType: hard
 
 "cross-spawn@npm:^7.0.0":
-  version: 7.0.3
-  resolution: "cross-spawn@npm:7.0.3"
+  version: 7.0.6
+  resolution: "cross-spawn@npm:7.0.6"
   dependencies:
     path-key: "npm:^3.1.0"
     shebang-command: "npm:^2.0.0"
     which: "npm:^2.0.1"
-  checksum: 10c0/5738c312387081c98d69c98e105b6327b069197f864a60593245d64c8089c8a0a744e16349281210d56835bb9274130d825a78b2ad6853ca13cfbeffc0c31750
+  checksum: 10c0/053ea8b2135caff68a9e81470e845613e374e7309a47731e81639de3eaeb90c3d01af0e0b44d2ab9d50b43467223b88567dfeb3262db942dc063b9976718ffc1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resolves [Dependabot Alert #161](https://github.com/twentyhq/twenty/security/dependabot/161) - regular expression denial of service (ReDoS) in cross-spawn.

Ran `yarn up cross-spawn --recursive` to move the version of cross-spawn used from 7.0.3 to 7.0.6.