### PR TITLE
Bar chart: Prevent left tick labels to overlap on label

### DIFF
--- a/packages/twenty-front/src/modules/page-layout/widgets/graph/graphWidgetBarChart/constants/BarChartMargins.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/graph/graphWidgetBarChart/constants/BarChartMargins.ts
@@ -2,5 +2,5 @@ export const BAR_CHART_MARGINS = {
   top: 20,
   right: 20,
   bottom: 60,
-  left: 70,
+  left: 80,
 } as const;

--- a/packages/twenty-front/src/modules/page-layout/widgets/graph/graphWidgetBarChart/utils/getBarChartAxisConfigs.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/graph/graphWidgetBarChart/utils/getBarChartAxisConfigs.ts
@@ -11,6 +11,9 @@ import {
 const AVERAGE_CHARACTER_WIDTH_RATIO = 0.6;
 const MIN_TICK_LABEL_LENGTH = 5;
 const MAX_LEFT_AXIS_LABEL_LENGTH = 10;
+const LEFT_AXIS_LEGEND_OFFSET_PADDING = 5;
+const TICK_PADDING = 5;
+const BOTTOM_AXIS_LEGEND_OFFSET = 40;
 
 type GetBarChartAxisConfigsProps = {
   width: number;
@@ -64,23 +67,23 @@ export const getBarChartAxisConfigs = ({
     return {
       axisBottom: {
         tickSize: 0,
-        tickPadding: 5,
+        tickPadding: TICK_PADDING,
         tickRotation: 0,
         tickValues: categoryTickValues,
         legend: xAxisLabel,
         legendPosition: 'middle' as const,
-        legendOffset: 40,
+        legendOffset: BOTTOM_AXIS_LEGEND_OFFSET,
         format: (value: string | number) =>
           truncateTickLabel(String(value), maxLabelLength),
       },
       axisLeft: {
         tickSize: 0,
-        tickPadding: 5,
+        tickPadding: TICK_PADDING,
         tickRotation: 0,
         tickValues: numberOfValueTicks,
         legend: yAxisLabel,
         legendPosition: 'middle' as const,
-        legendOffset: -BAR_CHART_MARGINS.left + 5,
+        legendOffset: -BAR_CHART_MARGINS.left + LEFT_AXIS_LEGEND_OFFSET_PADDING,
         format: (value: string | number) =>
           truncateTickLabel(String(value), MAX_LEFT_AXIS_LABEL_LENGTH),
       },
@@ -90,22 +93,22 @@ export const getBarChartAxisConfigs = ({
   return {
     axisBottom: {
       tickSize: 0,
-      tickPadding: 5,
+      tickPadding: TICK_PADDING,
       tickRotation: 0,
       tickValues: numberOfValueTicks,
       legend: yAxisLabel,
       legendPosition: 'middle' as const,
-      legendOffset: 40,
+      legendOffset: BOTTOM_AXIS_LEGEND_OFFSET,
       format: (value: number) => formatGraphValue(value, formatOptions || {}),
     },
     axisLeft: {
       tickSize: 0,
-      tickPadding: 5,
+      tickPadding: TICK_PADDING,
       tickRotation: 0,
       tickValues: categoryTickValues,
       legend: xAxisLabel,
       legendPosition: 'middle' as const,
-      legendOffset: -BAR_CHART_MARGINS.left + 5,
+      legendOffset: -BAR_CHART_MARGINS.left + LEFT_AXIS_LEGEND_OFFSET_PADDING,
       format: (value: string | number) =>
         truncateTickLabel(String(value), MAX_LEFT_AXIS_LABEL_LENGTH),
     },

--- a/packages/twenty-front/src/modules/page-layout/widgets/graph/graphWidgetBarChart/utils/getBarChartAxisConfigs.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/graph/graphWidgetBarChart/utils/getBarChartAxisConfigs.ts
@@ -10,7 +10,7 @@ import {
 
 const AVERAGE_CHARACTER_WIDTH_RATIO = 0.6;
 const MIN_TICK_LABEL_LENGTH = 5;
-const MAX_LEFT_AXIS_LABEL_LENGTH = 20;
+const MAX_LEFT_AXIS_LABEL_LENGTH = 10;
 
 type GetBarChartAxisConfigsProps = {
   width: number;
@@ -80,8 +80,9 @@ export const getBarChartAxisConfigs = ({
         tickValues: numberOfValueTicks,
         legend: yAxisLabel,
         legendPosition: 'middle' as const,
-        legendOffset: -50,
-        format: (value: number) => formatGraphValue(value, formatOptions || {}),
+        legendOffset: -BAR_CHART_MARGINS.left + 5,
+        format: (value: string | number) =>
+          truncateTickLabel(String(value), MAX_LEFT_AXIS_LABEL_LENGTH),
       },
     };
   }
@@ -104,7 +105,7 @@ export const getBarChartAxisConfigs = ({
       tickValues: categoryTickValues,
       legend: xAxisLabel,
       legendPosition: 'middle' as const,
-      legendOffset: -50,
+      legendOffset: -BAR_CHART_MARGINS.left + 5,
       format: (value: string | number) =>
         truncateTickLabel(String(value), MAX_LEFT_AXIS_LABEL_LENGTH),
     },

--- a/packages/twenty-front/src/modules/page-layout/widgets/graph/graphWidgetBarChart/utils/getBarChartAxisConfigs.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/graph/graphWidgetBarChart/utils/getBarChartAxisConfigs.ts
@@ -84,8 +84,11 @@ export const getBarChartAxisConfigs = ({
         legend: yAxisLabel,
         legendPosition: 'middle' as const,
         legendOffset: -BAR_CHART_MARGINS.left + LEFT_AXIS_LEGEND_OFFSET_PADDING,
-        format: (value: string | number) =>
-          truncateTickLabel(String(value), MAX_LEFT_AXIS_LABEL_LENGTH),
+        format: (value: number) =>
+          truncateTickLabel(
+            formatGraphValue(value, formatOptions ?? {}),
+            MAX_LEFT_AXIS_LABEL_LENGTH,
+          ),
       },
     };
   }


### PR DESCRIPTION
Prevent left tick labels to overlap on label by truncating the tick label