### PR TITLE
Export CSV truncates after ~860 rows when dataset > 1k

### DIFF
--- a/packages/twenty-front/src/modules/object-record/hooks/__tests__/useLazyFetchMoreRecordsWithPagination.test.tsx
+++ b/packages/twenty-front/src/modules/object-record/hooks/__tests__/useLazyFetchMoreRecordsWithPagination.test.tsx
@@ -1,0 +1,102 @@
+import { expect } from '@storybook/test';
+import { act, renderHook } from '@testing-library/react';
+import { type ReactNode } from 'react';
+import { RecoilRoot } from 'recoil';
+
+import { cursorFamilyState } from '@/object-record/states/cursorFamilyState';
+import { hasNextPageFamilyState } from '@/object-record/states/hasNextPageFamilyState';
+import { useLazyFetchMoreRecordsWithPagination } from '@/object-record/hooks/useLazyFetchMoreRecordsWithPagination';
+import { getQueryIdentifier } from '@/object-record/utils/getQueryIdentifier';
+
+import { SnackBarComponentInstanceContext } from '@/ui/feedback/snack-bar-manager/contexts/SnackBarComponentInstanceContext';
+
+import { generatedMockObjectMetadataItems } from '~/testing/utils/generatedMockObjectMetadataItems';
+
+describe('useLazyFetchMoreRecordsWithPagination', () => {
+  it('defaults to the provided limit when fetching more records', async () => {
+    const objectMetadataItem = generatedMockObjectMetadataItems[0];
+
+    if (!objectMetadataItem) {
+      throw new Error('Object metadata item not found');
+    }
+
+    const exportLimit = 200;
+    const objectNameSingular = objectMetadataItem.nameSingular;
+
+    const fetchMoreResultData = {
+      [objectMetadataItem.namePlural]: {
+        edges: [],
+        pageInfo: {
+          endCursor: null,
+          hasNextPage: false,
+        },
+        totalCount: 0,
+      },
+    };
+
+    const fetchMoreMock = jest.fn(
+      async (options: {
+        variables: {
+          limit?: number;
+        };
+        updateQuery?: (
+          previousQueryResult: unknown,
+          context: { fetchMoreResult: typeof fetchMoreResultData },
+        ) => unknown;
+      }) => {
+        options.updateQuery?.({}, { fetchMoreResult: fetchMoreResultData });
+
+        return { data: fetchMoreResultData };
+      },
+    );
+
+    const queryIdentifier = getQueryIdentifier({
+      objectNameSingular,
+      filter: undefined,
+      orderBy: undefined,
+      limit: exportLimit,
+    });
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <RecoilRoot
+        initializeState={({ set }) => {
+          set(hasNextPageFamilyState(queryIdentifier), true);
+          set(cursorFamilyState(queryIdentifier), 'cursor-1');
+        }}
+      >
+        <SnackBarComponentInstanceContext.Provider
+          value={{ instanceId: 'snack-bar-manager' }}
+        >
+          {children}
+        </SnackBarComponentInstanceContext.Provider>
+      </RecoilRoot>
+    );
+
+    const { result } = renderHook(
+      () =>
+        useLazyFetchMoreRecordsWithPagination({
+          objectNameSingular,
+          filter: undefined,
+          orderBy: undefined,
+          limit: exportLimit,
+          error: undefined,
+          fetchMore: fetchMoreMock,
+          objectMetadataItem,
+          data: undefined,
+        }),
+      {
+        wrapper,
+      },
+    );
+
+    await act(async () => {
+      await result.current.fetchMoreRecordsLazy();
+    });
+
+    expect(fetchMoreMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variables: expect.objectContaining({ limit: exportLimit }),
+      }),
+    );
+  });
+});

--- a/packages/twenty-front/src/modules/object-record/hooks/useLazyFetchMoreRecordsWithPagination.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useLazyFetchMoreRecordsWithPagination.ts
@@ -89,7 +89,11 @@ export const useLazyFetchMoreRecordsWithPagination = <
   // This function is equivalent to merge function + read function in field policy
   const fetchMoreRecordsLazy = useRecoilCallback(
     ({ snapshot, set }) =>
-      async (limit = DEFAULT_SEARCH_REQUEST_LIMIT) => {
+      async (overrideLimit?: number) => {
+        const effectiveLimit = isDefined(overrideLimit)
+          ? overrideLimit
+          : limit ?? DEFAULT_SEARCH_REQUEST_LIMIT;
+
         const hasNextPageLocal = snapshot
           .getLoadable(hasNextPageFamilyState(queryIdentifier))
           .getValue();
@@ -106,7 +110,7 @@ export const useLazyFetchMoreRecordsWithPagination = <
           try {
             const { data: fetchMoreDataResult } = await fetchMore({
               variables: {
-                limit,
+                limit: effectiveLimit,
                 filter,
                 orderBy,
                 lastCursor: isNonEmptyString(lastCursorLocal)
@@ -187,6 +191,7 @@ export const useLazyFetchMoreRecordsWithPagination = <
       fetchMore,
       filter,
       orderBy,
+      limit,
       handleFindManyRecordsError,
     ],
   );


### PR DESCRIPTION
  ## Summary
  - ensure follow-up pagination requests reuse the caller-provided limit instead of defaulting to `DEFAULT_SEARCH_REQUEST_LIMIT`
  - add a regression test for `useLazyFetchMoreRecordsWithPagination` that verifies the export page size is forwarded to `fetchMore`

  ## Testing
  - `nx test twenty-front`