### PR TITLE
fix: update tmp to a safer version.

### DIFF
--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -24,6 +24,7 @@ jobs:
     with:
       files: |
         package.json
+        yarn.lock
         packages/twenty-front/**
         packages/twenty-ui/**
         packages/twenty-shared/**

--- a/.github/workflows/ci-server.yaml
+++ b/.github/workflows/ci-server.yaml
@@ -23,6 +23,7 @@ jobs:
     with:
       files: |
         package.json
+        yarn.lock
         packages/twenty-server/**
         packages/twenty-front/src/generated/**
         packages/twenty-front/src/generated-metadata/**

--- a/yarn.lock
+++ b/yarn.lock
@@ -54723,9 +54723,9 @@ __metadata:
   linkType: hard
 
 "tmp@npm:~0.2.1":
-  version: 0.2.3
-  resolution: "tmp@npm:0.2.3"
-  checksum: 10c0/3e809d9c2f46817475b452725c2aaa5d11985cf18d32a7a970ff25b568438e2c076c2e8609224feef3b7923fa9749b74428e3e634f6b8e520c534eef2fd24125
+  version: 0.2.5
+  resolution: "tmp@npm:0.2.5"
+  checksum: 10c0/cee5bb7d674bb4ba3ab3f3841c2ca7e46daeb2109eec395c1ec7329a91d52fcb21032b79ac25161a37b2565c4858fefab927af9735926a113ef7bac9091a6e0e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
@charlesBochet had a conversation with Felix and he said we don't need to spend time upgrading `zapier-platform-core` and `zapier-platform-cli` since `twenty-zapier` will be deprecated anyway, making those packages irrelevant.

I have updated tmp to a safer version elsewhere using `yarn up tmp --recursive`. Also added `yarn.lock` to both server and front ci.

The massive changes in `yarn.lock` were introduced by `zapier-platform-cli` version 17x - not sure if they caused those breaking changes, but if they did and we still want update zapier-related packages, I will take that up in another PR.