### PR TITLE
Add permission check on calendar view drag and add new

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-calendar/components/RecordCalendarAddNew.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/components/RecordCalendarAddNew.tsx
@@ -1,5 +1,6 @@
 import { useObjectPermissionsForObject } from '@/object-record/hooks/useObjectPermissionsForObject';
 import { hasAnySoftDeleteFilterOnViewComponentSelector } from '@/object-record/record-filter/states/hasAnySoftDeleteFilterOnView';
+import { isFieldMetadataReadOnlyByPermissions } from '@/object-record/read-only/utils/internal/isFieldMetadataReadOnlyByPermissions';
 import { recordIndexCalendarFieldMetadataIdState } from '@/object-record/record-index/states/recordIndexCalendarFieldMetadataIdState';
 import { useCreateNewIndexRecord } from '@/object-record/record-table/hooks/useCreateNewIndexRecord';
 import { useRecoilComponentValue } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValue';
@@ -48,10 +49,18 @@ export const RecordCalendarAddNew = ({
     (field) => field.id === recordIndexCalendarFieldMetadataId,
   );
 
+  const isCalendarFieldReadOnly = calendarFieldMetadataItem
+    ? isFieldMetadataReadOnlyByPermissions({
+        objectPermissions,
+        fieldMetadataId: calendarFieldMetadataItem.id,
+      })
+    : false;
+
   if (
     hasAnySoftDeleteFilterOnView ||
     !hasObjectUpdatePermissions ||
-    !calendarFieldMetadataItem
+    !calendarFieldMetadataItem ||
+    isCalendarFieldReadOnly
   ) {
     return null;
   }


### PR DESCRIPTION
## Context
If selected date field of the calendar view has readonly, we should not allow users to drag/drop cards nor allow them to add a new record (resulting in a permission error on the BE due to the FE updating the said field)