### PR TITLE
Fix calendar view when switched from other layout type not updating state

### DIFF
--- a/packages/twenty-front/src/modules/object-record/object-options-dropdown/hooks/useSetViewTypeFromLayoutOptionsMenu.ts
+++ b/packages/twenty-front/src/modules/object-record/object-options-dropdown/hooks/useSetViewTypeFromLayoutOptionsMenu.ts
@@ -175,6 +175,16 @@ export const useSetViewTypeFromLayoutOptionsMenu = () => {
               },
             ]);
 
+            loadRecordIndexStates(
+              {
+                ...currentView,
+                type: viewType,
+                calendarFieldMetadataId,
+                calendarLayout: ViewCalendarLayout.MONTH,
+              },
+              objectMetadataItem,
+            );
+
             if (shouldChangeIcon(currentView.icon, currentView.type)) {
               updateCurrentViewParams.icon =
                 viewTypeIconMapping(viewType).displayName;


### PR DESCRIPTION
## Context
Switching from kanban layout to calendar was not displaying records properly. Adding the missing state update (similar to kanban case a few lines above)