### PR TITLE
add inner padding on bar chart

### DIFF
--- a/packages/twenty-front/src/modules/page-layout/widgets/graph/graphWidgetBarChart/components/GraphWidgetBarChart.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/graph/graphWidgetBarChart/components/GraphWidgetBarChart.tsx
@@ -3,6 +3,7 @@ import { GraphWidgetLegend } from '@/page-layout/widgets/graph/components/GraphW
 import { GraphWidgetTooltip } from '@/page-layout/widgets/graph/components/GraphWidgetTooltip';
 import { CustomBarItem } from '@/page-layout/widgets/graph/graphWidgetBarChart/components/CustomBarItem';
 import { CustomTotalsLayer } from '@/page-layout/widgets/graph/graphWidgetBarChart/components/CustomTotalsLayer';
+import { BAR_CHART_MINIMUM_INNER_PADDING } from '@/page-layout/widgets/graph/graphWidgetBarChart/constants/BarChartMinimumInnerPadding';
 import { useBarChartData } from '@/page-layout/widgets/graph/graphWidgetBarChart/hooks/useBarChartData';
 import { useBarChartHandlers } from '@/page-layout/widgets/graph/graphWidgetBarChart/hooks/useBarChartHandlers';
 import { useBarChartTheme } from '@/page-layout/widgets/graph/graphWidgetBarChart/hooks/useBarChartTheme';
@@ -255,6 +256,9 @@ export const GraphWidgetBarChart = ({
           gridYValues={layout === 'vertical' ? 5 : undefined}
           enableLabel={false}
           labelSkipWidth={12}
+          innerPadding={
+            groupMode !== 'stacked' ? BAR_CHART_MINIMUM_INNER_PADDING : 0
+          }
           labelSkipHeight={12}
           valueFormat={(value) =>
             formatGraphValue(Number(value), formatOptions)

--- a/packages/twenty-front/src/modules/page-layout/widgets/graph/graphWidgetBarChart/constants/BarChartMinimumInnerPadding.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/graph/graphWidgetBarChart/constants/BarChartMinimumInnerPadding.ts
@@ -1,0 +1,1 @@
+export const BAR_CHART_MINIMUM_INNER_PADDING = 4;


### PR DESCRIPTION
before:

<img width="602" height="407" alt="CleanShot 2025-11-03 at 22 06 45" src="https://github.com/user-attachments/assets/3553d3a0-2626-4f88-9adc-7d472fde2b26" />

after:

<img width="628" height="392" alt="CleanShot 2025-11-03 at 22 06 08" src="https://github.com/user-attachments/assets/d5cf2b68-c5eb-4ce7-be27-c685ccd81109" />
