### PR TITLE
Remove relations from manual trigger output schema

### DIFF
--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-schema/workflow-schema.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-schema/workflow-schema.workspace-service.ts
@@ -294,6 +294,7 @@ export class WorkflowSchemaWorkspaceService {
       return this.computeRecordOutputSchema({
         objectType: availability.objectNameSingular,
         workspaceId,
+        maxDepth: 0,
       });
     }
 
@@ -395,6 +396,7 @@ export class WorkflowSchemaWorkspaceService {
               value: await this.computeRecordOutputSchema({
                 objectType: trigger.settings.availability.objectNameSingular,
                 workspaceId,
+                maxDepth: 0,
               }),
             };
           }


### PR DESCRIPTION
Fixes https://github.com/twentyhq/twenty/issues/15319
Fixes https://github.com/twentyhq/twenty/issues/15255

On index page, we load record with only a few relation fields. So record selected on manual trigger do not contain all the fields. To match that behavior, let's remove relations from output schema. The user will do a search on relation id if needed.