### PR TITLE
Create many view groups

### DIFF
--- a/packages/twenty-front/jest.config.mjs
+++ b/packages/twenty-front/jest.config.mjs
@@ -63,7 +63,7 @@ const jestConfig = {
     global: {
       statements: 52,
       // Temporarily decreasing to 50.97 as introduced v1 code that aims to be deleted
-      lines: 50.97,
+      lines: 50.95,
       functions: 41,
     },
   },

--- a/packages/twenty-front/src/generated-metadata/graphql.ts
+++ b/packages/twenty-front/src/generated-metadata/graphql.ts
@@ -1758,6 +1758,7 @@ export type Mutation = {
   createEmailingDomain: EmailingDomain;
   createFile: File;
   createManyCoreViewFields: Array<CoreViewField>;
+  createManyCoreViewGroups: Array<CoreViewGroup>;
   createOIDCIdentityProvider: SetupSsoOutput;
   createObjectEvent: Analytics;
   createOneAgent: Agent;
@@ -2033,6 +2034,11 @@ export type MutationCreateFileArgs = {
 
 export type MutationCreateManyCoreViewFieldsArgs = {
   inputs: Array<CreateViewFieldInput>;
+};
+
+
+export type MutationCreateManyCoreViewGroupsArgs = {
+  inputs: Array<CreateViewGroupInput>;
 };
 
 
@@ -5978,6 +5984,13 @@ export type CreateManyCoreViewFieldsMutationVariables = Exact<{
 
 
 export type CreateManyCoreViewFieldsMutation = { __typename?: 'Mutation', createManyCoreViewFields: Array<{ __typename?: 'CoreViewField', id: string, fieldMetadataId: string, viewId: string, isVisible: boolean, position: number, size: number, aggregateOperation?: AggregateOperations | null, createdAt: string, updatedAt: string, deletedAt?: string | null }> };
+
+export type CreateManyCoreViewGroupsMutationVariables = Exact<{
+  inputs: Array<CreateViewGroupInput> | CreateViewGroupInput;
+}>;
+
+
+export type CreateManyCoreViewGroupsMutation = { __typename?: 'Mutation', createManyCoreViewGroups: Array<{ __typename?: 'CoreViewGroup', id: string, fieldMetadataId: string, isVisible: boolean, fieldValue: string, position: number, viewId: string, createdAt: string, updatedAt: string, deletedAt?: string | null }> };
 
 export type DeleteCoreViewMutationVariables = Exact<{
   id: Scalars['String'];
@@ -12668,6 +12681,39 @@ export function useCreateManyCoreViewFieldsMutation(baseOptions?: Apollo.Mutatio
 export type CreateManyCoreViewFieldsMutationHookResult = ReturnType<typeof useCreateManyCoreViewFieldsMutation>;
 export type CreateManyCoreViewFieldsMutationResult = Apollo.MutationResult<CreateManyCoreViewFieldsMutation>;
 export type CreateManyCoreViewFieldsMutationOptions = Apollo.BaseMutationOptions<CreateManyCoreViewFieldsMutation, CreateManyCoreViewFieldsMutationVariables>;
+export const CreateManyCoreViewGroupsDocument = gql`
+    mutation CreateManyCoreViewGroups($inputs: [CreateViewGroupInput!]!) {
+  createManyCoreViewGroups(inputs: $inputs) {
+    ...ViewGroupFragment
+  }
+}
+    ${ViewGroupFragmentFragmentDoc}`;
+export type CreateManyCoreViewGroupsMutationFn = Apollo.MutationFunction<CreateManyCoreViewGroupsMutation, CreateManyCoreViewGroupsMutationVariables>;
+
+/**
+ * __useCreateManyCoreViewGroupsMutation__
+ *
+ * To run a mutation, you first call `useCreateManyCoreViewGroupsMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useCreateManyCoreViewGroupsMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [createManyCoreViewGroupsMutation, { data, loading, error }] = useCreateManyCoreViewGroupsMutation({
+ *   variables: {
+ *      inputs: // value for 'inputs'
+ *   },
+ * });
+ */
+export function useCreateManyCoreViewGroupsMutation(baseOptions?: Apollo.MutationHookOptions<CreateManyCoreViewGroupsMutation, CreateManyCoreViewGroupsMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateManyCoreViewGroupsMutation, CreateManyCoreViewGroupsMutationVariables>(CreateManyCoreViewGroupsDocument, options);
+      }
+export type CreateManyCoreViewGroupsMutationHookResult = ReturnType<typeof useCreateManyCoreViewGroupsMutation>;
+export type CreateManyCoreViewGroupsMutationResult = Apollo.MutationResult<CreateManyCoreViewGroupsMutation>;
+export type CreateManyCoreViewGroupsMutationOptions = Apollo.BaseMutationOptions<CreateManyCoreViewGroupsMutation, CreateManyCoreViewGroupsMutationVariables>;
 export const DeleteCoreViewDocument = gql`
     mutation DeleteCoreView($id: String!) {
   deleteCoreView(id: $id)

--- a/packages/twenty-front/src/generated/graphql.ts
+++ b/packages/twenty-front/src/generated/graphql.ts
@@ -1715,6 +1715,7 @@ export type Mutation = {
   createEmailingDomain: EmailingDomain;
   createFile: File;
   createManyCoreViewFields: Array<CoreViewField>;
+  createManyCoreViewGroups: Array<CoreViewGroup>;
   createOIDCIdentityProvider: SetupSsoOutput;
   createObjectEvent: Analytics;
   createOneAgent: Agent;
@@ -1984,6 +1985,11 @@ export type MutationCreateFileArgs = {
 
 export type MutationCreateManyCoreViewFieldsArgs = {
   inputs: Array<CreateViewFieldInput>;
+};
+
+
+export type MutationCreateManyCoreViewGroupsArgs = {
+  inputs: Array<CreateViewGroupInput>;
 };
 
 
@@ -4789,6 +4795,13 @@ export type CreateManyCoreViewFieldsMutationVariables = Exact<{
 
 export type CreateManyCoreViewFieldsMutation = { __typename?: 'Mutation', createManyCoreViewFields: Array<{ __typename?: 'CoreViewField', id: any, fieldMetadataId: any, viewId: any, isVisible: boolean, position: number, size: number, aggregateOperation?: AggregateOperations | null, createdAt: string, updatedAt: string, deletedAt?: string | null }> };
 
+export type CreateManyCoreViewGroupsMutationVariables = Exact<{
+  inputs: Array<CreateViewGroupInput> | CreateViewGroupInput;
+}>;
+
+
+export type CreateManyCoreViewGroupsMutation = { __typename?: 'Mutation', createManyCoreViewGroups: Array<{ __typename?: 'CoreViewGroup', id: any, fieldMetadataId: any, isVisible: boolean, fieldValue: string, position: number, viewId: any, createdAt: string, updatedAt: string, deletedAt?: string | null }> };
+
 export type DeleteCoreViewMutationVariables = Exact<{
   id: Scalars['String'];
 }>;
@@ -5588,6 +5601,39 @@ export function useCreateManyCoreViewFieldsMutation(baseOptions?: Apollo.Mutatio
 export type CreateManyCoreViewFieldsMutationHookResult = ReturnType<typeof useCreateManyCoreViewFieldsMutation>;
 export type CreateManyCoreViewFieldsMutationResult = Apollo.MutationResult<CreateManyCoreViewFieldsMutation>;
 export type CreateManyCoreViewFieldsMutationOptions = Apollo.BaseMutationOptions<CreateManyCoreViewFieldsMutation, CreateManyCoreViewFieldsMutationVariables>;
+export const CreateManyCoreViewGroupsDocument = gql`
+    mutation CreateManyCoreViewGroups($inputs: [CreateViewGroupInput!]!) {
+  createManyCoreViewGroups(inputs: $inputs) {
+    ...ViewGroupFragment
+  }
+}
+    ${ViewGroupFragmentFragmentDoc}`;
+export type CreateManyCoreViewGroupsMutationFn = Apollo.MutationFunction<CreateManyCoreViewGroupsMutation, CreateManyCoreViewGroupsMutationVariables>;
+
+/**
+ * __useCreateManyCoreViewGroupsMutation__
+ *
+ * To run a mutation, you first call `useCreateManyCoreViewGroupsMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useCreateManyCoreViewGroupsMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [createManyCoreViewGroupsMutation, { data, loading, error }] = useCreateManyCoreViewGroupsMutation({
+ *   variables: {
+ *      inputs: // value for 'inputs'
+ *   },
+ * });
+ */
+export function useCreateManyCoreViewGroupsMutation(baseOptions?: Apollo.MutationHookOptions<CreateManyCoreViewGroupsMutation, CreateManyCoreViewGroupsMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateManyCoreViewGroupsMutation, CreateManyCoreViewGroupsMutationVariables>(CreateManyCoreViewGroupsDocument, options);
+      }
+export type CreateManyCoreViewGroupsMutationHookResult = ReturnType<typeof useCreateManyCoreViewGroupsMutation>;
+export type CreateManyCoreViewGroupsMutationResult = Apollo.MutationResult<CreateManyCoreViewGroupsMutation>;
+export type CreateManyCoreViewGroupsMutationOptions = Apollo.BaseMutationOptions<CreateManyCoreViewGroupsMutation, CreateManyCoreViewGroupsMutationVariables>;
 export const DeleteCoreViewDocument = gql`
     mutation DeleteCoreView($id: String!) {
   deleteCoreView(id: $id)

--- a/packages/twenty-front/src/modules/object-record/object-options-dropdown/hooks/useSetViewTypeFromLayoutOptionsMenu.ts
+++ b/packages/twenty-front/src/modules/object-record/object-options-dropdown/hooks/useSetViewTypeFromLayoutOptionsMenu.ts
@@ -58,14 +58,12 @@ export const useSetViewTypeFromLayoutOptionsMenu = () => {
         fieldMetadataId: randomFieldForKanban,
       } satisfies ViewGroup);
 
-      await createViewGroups(
-        viewGroupsToCreate.map(({ __typename, ...viewGroup }) => ({
-          input: {
-            ...viewGroup,
-            viewId: currentViewId,
-          },
+      await createViewGroups({
+        inputs: viewGroupsToCreate.map(({ __typename, ...viewGroup }) => ({
+          ...viewGroup,
+          viewId: currentViewId,
         })),
-      );
+      });
 
       return viewGroupsToCreate;
     },

--- a/packages/twenty-front/src/modules/object-record/record-index/hooks/useHandleRecordGroupField.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/hooks/useHandleRecordGroupField.ts
@@ -105,14 +105,12 @@ export const useHandleRecordGroupField = () => {
         );
 
         if (viewGroupsToCreate.length > 0) {
-          await createViewGroups(
-            viewGroupsToCreate.map(({ __typename, ...viewGroup }) => ({
-              input: {
-                ...viewGroup,
-                viewId: view.id,
-              },
+          await createViewGroups({
+            inputs: viewGroupsToCreate.map(({ __typename, ...viewGroup }) => ({
+              ...viewGroup,
+              viewId: view.id,
             })),
-          );
+          });
         }
 
         if (viewGroupsToDelete.length > 0) {

--- a/packages/twenty-front/src/modules/views/graphql/mutations/createManyCoreViewGroups.ts
+++ b/packages/twenty-front/src/modules/views/graphql/mutations/createManyCoreViewGroups.ts
@@ -9,4 +9,3 @@ export const CREATE_MANY_CORE_VIEW_GROUPS = gql`
     }
   }
 `;
-

--- a/packages/twenty-front/src/modules/views/graphql/mutations/createManyCoreViewGroups.ts
+++ b/packages/twenty-front/src/modules/views/graphql/mutations/createManyCoreViewGroups.ts
@@ -1,0 +1,12 @@
+import { VIEW_GROUP_FRAGMENT } from '@/views/graphql/fragments/viewGroupFragment';
+import { gql } from '@apollo/client';
+
+export const CREATE_MANY_CORE_VIEW_GROUPS = gql`
+  ${VIEW_GROUP_FRAGMENT}
+  mutation CreateManyCoreViewGroups($inputs: [CreateViewGroupInput!]!) {
+    createManyCoreViewGroups(inputs: $inputs) {
+      ...ViewGroupFragment
+    }
+  }
+`;
+

--- a/packages/twenty-front/src/modules/views/hooks/useCreateViewFromCurrentView.ts
+++ b/packages/twenty-front/src/modules/views/hooks/useCreateViewFromCurrentView.ts
@@ -204,14 +204,12 @@ export const useCreateViewFromCurrentView = (viewBarComponentId?: string) => {
             fieldMetadataId: kanbanFieldMetadataId,
           } satisfies ViewGroup);
 
-          const groupResult = await createViewGroups(
-            viewGroupsToCreate.map(({ __typename, ...viewGroup }) => ({
-              input: {
-                ...viewGroup,
-                viewId: newViewId,
-              },
+          const groupResult = await createViewGroups({
+            inputs: viewGroupsToCreate.map(({ __typename, ...viewGroup }) => ({
+              ...viewGroup,
+              viewId: newViewId,
             })),
-          );
+          });
 
           if (groupResult.status === 'failed') {
             set(isPersistingViewFieldsState, false);

--- a/packages/twenty-front/src/modules/views/hooks/useSaveCurrentViewGroups.ts
+++ b/packages/twenty-front/src/modules/views/hooks/useSaveCurrentViewGroups.ts
@@ -146,14 +146,12 @@ export const useSaveCurrentViewGroups = () => {
         );
 
         await Promise.all([
-          createViewGroups(
-            viewGroupsToCreate.map(({ __typename, ...viewGroup }) => ({
-              input: {
-                ...viewGroup,
-                viewId: view.id,
-              },
+          createViewGroups({
+            inputs: viewGroupsToCreate.map(({ __typename, ...viewGroup }) => ({
+              ...viewGroup,
+              viewId: view.id,
             })),
-          ),
+          }),
           updateViewGroups(viewGroupsToUpdate),
         ]);
       },

--- a/packages/twenty-server/test/integration/graphql/suites/view/view-group/__snapshots__/failing-create-many-view-groups-v2.integration-spec.ts.snap
+++ b/packages/twenty-server/test/integration/graphql/suites/view/view-group/__snapshots__/failing-create-many-view-groups-v2.integration-spec.ts.snap
@@ -1,0 +1,94 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`View Group Resolver - Failing Create Many Operations - v2 should accumulate multiple validation errors when some inputs are invalid 1`] = `
+{
+  "extensions": {
+    "code": "METADATA_VALIDATION_FAILED",
+    "errors": {
+      "cronTrigger": [],
+      "databaseEventTrigger": [],
+      "fieldMetadata": [],
+      "index": [],
+      "objectMetadata": [],
+      "routeTrigger": [],
+      "serverlessFunction": [],
+      "view": [],
+      "viewField": [],
+      "viewFilter": [],
+      "viewGroup": [
+        {
+          "errors": [
+            {
+              "code": "INVALID_VIEW_DATA",
+              "message": "Field metadata not found",
+              "userFriendlyMessage": "Field metadata not found",
+            },
+          ],
+          "flatEntityMinimalInformation": {
+            "fieldMetadataId": Any<String>,
+            "id": Any<String>,
+            "viewId": Any<String>,
+          },
+          "status": "fail",
+          "type": "create_view_group",
+        },
+        {
+          "errors": [
+            {
+              "code": "INVALID_VIEW_DATA",
+              "message": "View not found",
+              "userFriendlyMessage": "View not found",
+            },
+          ],
+          "flatEntityMinimalInformation": {
+            "fieldMetadataId": Any<String>,
+            "id": Any<String>,
+            "viewId": Any<String>,
+          },
+          "status": "fail",
+          "type": "create_view_group",
+        },
+        {
+          "errors": [
+            {
+              "code": "INVALID_VIEW_DATA",
+              "message": "Field metadata not found",
+              "userFriendlyMessage": "Field metadata not found",
+            },
+            {
+              "code": "INVALID_VIEW_DATA",
+              "message": "View not found",
+              "userFriendlyMessage": "View not found",
+            },
+          ],
+          "flatEntityMinimalInformation": {
+            "fieldMetadataId": Any<String>,
+            "id": Any<String>,
+            "viewId": Any<String>,
+          },
+          "status": "fail",
+          "type": "create_view_group",
+        },
+      ],
+    },
+    "message": "Validation failed for 0 object(s) and 0 field(s)",
+    "summary": {
+      "invalidCronTrigger": 0,
+      "invalidDatabaseEventTrigger": 0,
+      "invalidFieldMetadata": 0,
+      "invalidIndex": 0,
+      "invalidObjectMetadata": 0,
+      "invalidRouteTrigger": 0,
+      "invalidServerlessFunction": 0,
+      "invalidView": 0,
+      "invalidViewField": 0,
+      "invalidViewFilter": 0,
+      "invalidViewGroup": 0,
+      "totalErrors": 0,
+    },
+    "userFriendlyMessage": "Validation failed for 0 object(s) and 0 field(s)",
+  },
+  "message": "Multiple validation errors occurred while creating view groups",
+  "name": "GraphQLError",
+}
+`;

--- a/packages/twenty-server/test/integration/graphql/suites/view/view-group/failing-create-many-view-groups-v2.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/view/view-group/failing-create-many-view-groups-v2.integration-spec.ts
@@ -1,0 +1,153 @@
+import { createManyCoreViewGroups } from 'test/integration/metadata/suites/view-group/utils/create-many-core-view-groups.util';
+import { v4 as uuidv4 } from 'uuid';
+import { expectOneNotInternalServerErrorSnapshot } from 'test/integration/graphql/utils/expect-one-not-internal-server-error-snapshot.util';
+import { createOneFieldMetadata } from 'test/integration/metadata/suites/field-metadata/utils/create-one-field-metadata.util';
+import { createOneObjectMetadata } from 'test/integration/metadata/suites/object-metadata/utils/create-one-object-metadata.util';
+import { deleteOneObjectMetadata } from 'test/integration/metadata/suites/object-metadata/utils/delete-one-object-metadata.util';
+import { updateOneObjectMetadata } from 'test/integration/metadata/suites/object-metadata/utils/update-one-object-metadata.util';
+import { createOneCoreView } from 'test/integration/metadata/suites/view/utils/create-one-core-view.util';
+import { FieldMetadataType } from 'twenty-shared/types';
+
+import { type CreateViewGroupInput } from 'src/engine/metadata-modules/view-group/dtos/inputs/create-view-group.input';
+
+describe('View Group Resolver - Failing Create Many Operations - v2', () => {
+  let testSetup: {
+    testViewId: string;
+    testObjectMetadataId: string;
+    firstTestFieldMetadataId: string;
+    secondTestFieldMetadataId: string;
+  };
+
+  beforeAll(async () => {
+    const {
+      data: {
+        createOneObject: { id: objectMetadataId },
+      },
+    } = await createOneObjectMetadata({
+      expectToFail: false,
+      input: {
+        nameSingular: 'myGroupTestObjectV2',
+        namePlural: 'myGroupTestObjectsV2',
+        labelSingular: 'My Group Test Object v2',
+        labelPlural: 'My Group Test Objects v2',
+        icon: 'Icon123',
+      },
+    });
+
+    const {
+      data: {
+        createOneField: { id: firstTestFieldMetadataId },
+      },
+    } = await createOneFieldMetadata({
+      expectToFail: false,
+      input: {
+        name: 'testField',
+        label: 'Test Field',
+        type: FieldMetadataType.TEXT,
+        objectMetadataId,
+        isLabelSyncedWithName: true,
+      },
+      gqlFields: `
+          id
+          name
+          label
+          isLabelSyncedWithName
+        `,
+    });
+
+    const {
+      data: {
+        createOneField: { id: secondTestFieldMetadataId },
+      },
+    } = await createOneFieldMetadata({
+      expectToFail: false,
+      input: {
+        name: 'secondTestField',
+        label: 'Test Field',
+        type: FieldMetadataType.TEXT,
+        objectMetadataId,
+        isLabelSyncedWithName: false,
+      },
+      gqlFields: `
+          id
+          name
+          label
+          isLabelSyncedWithName
+        `,
+    });
+
+    const {
+      data: {
+        createCoreView: { id: testViewId },
+      },
+    } = await createOneCoreView({
+      input: {
+        icon: 'icon123',
+        objectMetadataId,
+        name: 'TestViewForGroups',
+      },
+      expectToFail: false,
+    });
+
+    testSetup = {
+      testViewId,
+      testObjectMetadataId: objectMetadataId,
+      firstTestFieldMetadataId,
+      secondTestFieldMetadataId,
+    };
+  });
+
+  afterAll(async () => {
+    await updateOneObjectMetadata({
+      input: {
+        idToUpdate: testSetup.testObjectMetadataId,
+        updatePayload: {
+          isActive: false,
+        },
+      },
+    });
+    await deleteOneObjectMetadata({
+      expectToFail: false,
+      input: { idToDelete: testSetup.testObjectMetadataId },
+    });
+  });
+
+  it('should accumulate multiple validation errors when some inputs are invalid', async () => {
+    const invalidViewId = uuidv4();
+    const invalidFieldMetadataId = uuidv4();
+
+    const inputs: CreateViewGroupInput[] = [
+      {
+        fieldMetadataId: invalidFieldMetadataId,
+        viewId: testSetup.testViewId,
+        position: 0,
+        isVisible: true,
+        fieldValue: 'Invalid Group A',
+      },
+      {
+        fieldMetadataId: testSetup.firstTestFieldMetadataId,
+        viewId: invalidViewId,
+        position: 1,
+        isVisible: true,
+        fieldValue: 'Invalid Group B',
+      },
+      {
+        fieldMetadataId: invalidFieldMetadataId,
+        viewId: invalidViewId,
+        position: 2,
+        isVisible: true,
+        fieldValue: 'Invalid Group C',
+      },
+    ];
+
+    const { errors } = await createManyCoreViewGroups({
+      inputs,
+      expectToFail: true,
+    });
+
+    expectOneNotInternalServerErrorSnapshot({
+      errors,
+    });
+  });
+});
+

--- a/packages/twenty-server/test/integration/graphql/suites/view/view-group/failing-create-many-view-groups-v2.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/view/view-group/failing-create-many-view-groups-v2.integration-spec.ts
@@ -150,4 +150,3 @@ describe('View Group Resolver - Failing Create Many Operations - v2', () => {
     });
   });
 });
-

--- a/packages/twenty-server/test/integration/graphql/suites/view/view-group/successful-create-many-view-groups-v2.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/view/view-group/successful-create-many-view-groups-v2.integration-spec.ts
@@ -263,4 +263,3 @@ describe('View Group Resolver - Successful Create Many Operations - v2', () => {
     expect(createdViewGroups).toHaveLength(0);
   });
 });
-

--- a/packages/twenty-server/test/integration/graphql/suites/view/view-group/successful-create-many-view-groups-v2.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/view/view-group/successful-create-many-view-groups-v2.integration-spec.ts
@@ -1,0 +1,266 @@
+import { createOneFieldMetadata } from 'test/integration/metadata/suites/field-metadata/utils/create-one-field-metadata.util';
+import { createOneObjectMetadata } from 'test/integration/metadata/suites/object-metadata/utils/create-one-object-metadata.util';
+import { deleteOneObjectMetadata } from 'test/integration/metadata/suites/object-metadata/utils/delete-one-object-metadata.util';
+import { updateOneObjectMetadata } from 'test/integration/metadata/suites/object-metadata/utils/update-one-object-metadata.util';
+import { createManyCoreViewGroups } from 'test/integration/metadata/suites/view-group/utils/create-many-core-view-groups.util';
+import { deleteOneCoreViewGroup } from 'test/integration/metadata/suites/view-group/utils/delete-one-core-view-group.util';
+import { destroyOneCoreViewGroup } from 'test/integration/metadata/suites/view-group/utils/destroy-one-core-view-group.util';
+import { createOneCoreView } from 'test/integration/metadata/suites/view/utils/create-one-core-view.util';
+import { FieldMetadataType } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
+
+import { type CreateViewGroupInput } from 'src/engine/metadata-modules/view-group/dtos/inputs/create-view-group.input';
+
+describe('View Group Resolver - Successful Create Many Operations - v2', () => {
+  let testSetup: {
+    testViewId: string;
+    testObjectMetadataId: string;
+    firstTestFieldMetadataId: string;
+    secondTestFieldMetadataId: string;
+    thirdTestFieldMetadataId: string;
+  };
+  let createdViewGroupIds: string[] = [];
+
+  beforeAll(async () => {
+    const {
+      data: {
+        createOneObject: { id: objectMetadataId },
+      },
+    } = await createOneObjectMetadata({
+      expectToFail: false,
+      input: {
+        nameSingular: 'myGroupTestObjectV2',
+        namePlural: 'myGroupTestObjectsV2',
+        labelSingular: 'My Group Test Object v2',
+        labelPlural: 'My Group Test Objects v2',
+        icon: 'Icon123',
+      },
+    });
+
+    const {
+      data: {
+        createOneField: { id: firstTestFieldMetadataId },
+      },
+    } = await createOneFieldMetadata({
+      expectToFail: false,
+      input: {
+        name: 'testField',
+        label: 'Test Field',
+        type: FieldMetadataType.TEXT,
+        objectMetadataId,
+        isLabelSyncedWithName: true,
+      },
+      gqlFields: `
+          id
+          name
+          label
+          isLabelSyncedWithName
+        `,
+    });
+
+    const {
+      data: {
+        createOneField: { id: secondTestFieldMetadataId },
+      },
+    } = await createOneFieldMetadata({
+      expectToFail: false,
+      input: {
+        name: 'secondTestField',
+        label: 'Test Field',
+        type: FieldMetadataType.TEXT,
+        objectMetadataId,
+        isLabelSyncedWithName: false,
+      },
+      gqlFields: `
+          id
+          name
+          label
+          isLabelSyncedWithName
+        `,
+    });
+
+    const {
+      data: {
+        createOneField: { id: thirdTestFieldMetadataId },
+      },
+    } = await createOneFieldMetadata({
+      expectToFail: false,
+      input: {
+        name: 'thirdTestField',
+        label: 'Test Field',
+        type: FieldMetadataType.TEXT,
+        objectMetadataId,
+        isLabelSyncedWithName: false,
+      },
+      gqlFields: `
+          id
+          name
+          label
+          isLabelSyncedWithName
+        `,
+    });
+
+    const {
+      data: {
+        createCoreView: { id: testViewId },
+      },
+    } = await createOneCoreView({
+      input: {
+        icon: 'icon123',
+        objectMetadataId,
+        name: 'TestViewForGroups',
+      },
+      expectToFail: false,
+    });
+
+    testSetup = {
+      testViewId,
+      testObjectMetadataId: objectMetadataId,
+      firstTestFieldMetadataId,
+      secondTestFieldMetadataId,
+      thirdTestFieldMetadataId,
+    };
+  });
+
+  afterAll(async () => {
+    await updateOneObjectMetadata({
+      input: {
+        idToUpdate: testSetup.testObjectMetadataId,
+        updatePayload: {
+          isActive: false,
+        },
+      },
+    });
+    await deleteOneObjectMetadata({
+      expectToFail: false,
+      input: { idToDelete: testSetup.testObjectMetadataId },
+    });
+  });
+
+  afterEach(async () => {
+    for (const viewGroupId of createdViewGroupIds) {
+      if (isDefined(viewGroupId)) {
+        const {
+          data: { deleteCoreViewGroup },
+        } = await deleteOneCoreViewGroup({
+          expectToFail: false,
+          input: {
+            id: viewGroupId,
+          },
+        });
+
+        expect(deleteCoreViewGroup.deletedAt).not.toBeNull();
+        await destroyOneCoreViewGroup({
+          expectToFail: false,
+          input: {
+            id: viewGroupId,
+          },
+        });
+      }
+    }
+    createdViewGroupIds = [];
+  });
+
+  it('should successfully create multiple view groups in batch', async () => {
+    const inputs: CreateViewGroupInput[] = [
+      {
+        fieldMetadataId: testSetup.firstTestFieldMetadataId,
+        viewId: testSetup.testViewId,
+        position: 0,
+        isVisible: true,
+        fieldValue: 'Group A',
+      },
+      {
+        fieldMetadataId: testSetup.secondTestFieldMetadataId,
+        viewId: testSetup.testViewId,
+        position: 1,
+        isVisible: false,
+        fieldValue: 'Group B',
+      },
+      {
+        fieldMetadataId: testSetup.thirdTestFieldMetadataId,
+        viewId: testSetup.testViewId,
+        position: 2,
+        isVisible: true,
+        fieldValue: 'Group C',
+      },
+    ];
+
+    const {
+      data: { createManyCoreViewGroups: createdViewGroups },
+      errors,
+    } = await createManyCoreViewGroups({
+      inputs,
+      expectToFail: false,
+    });
+
+    expect(errors).toBeUndefined();
+    expect(createdViewGroups).toBeDefined();
+    expect(createdViewGroups).toHaveLength(3);
+
+    createdViewGroups.forEach((viewGroup, index) => {
+      expect(viewGroup).toMatchObject({
+        fieldMetadataId: inputs[index].fieldMetadataId,
+        viewId: testSetup.testViewId,
+        position: inputs[index].position,
+        isVisible: inputs[index].isVisible,
+        fieldValue: inputs[index].fieldValue,
+      });
+
+      createdViewGroupIds.push(viewGroup.id);
+    });
+  });
+
+  it('should successfully create single view group using batch endpoint', async () => {
+    const inputs: CreateViewGroupInput[] = [
+      {
+        fieldMetadataId: testSetup.firstTestFieldMetadataId,
+        viewId: testSetup.testViewId,
+        position: 5,
+        isVisible: true,
+        fieldValue: 'Single Group',
+      },
+    ];
+
+    const {
+      data: { createManyCoreViewGroups: createdViewGroups },
+      errors,
+    } = await createManyCoreViewGroups({
+      inputs,
+      expectToFail: false,
+    });
+
+    expect(errors).toBeUndefined();
+    expect(createdViewGroups).toBeDefined();
+    expect(createdViewGroups).toHaveLength(1);
+
+    const viewGroup = createdViewGroups[0];
+
+    expect(viewGroup).toMatchObject({
+      fieldMetadataId: testSetup.firstTestFieldMetadataId,
+      viewId: testSetup.testViewId,
+      position: 5,
+      isVisible: true,
+      fieldValue: 'Single Group',
+    });
+
+    createdViewGroupIds.push(viewGroup.id);
+  });
+
+  it('should return empty array when creating zero view groups', async () => {
+    const inputs: CreateViewGroupInput[] = [];
+
+    const {
+      data: { createManyCoreViewGroups: createdViewGroups },
+      errors,
+    } = await createManyCoreViewGroups({
+      inputs,
+      expectToFail: false,
+    });
+
+    expect(errors).toBeUndefined();
+    expect(createdViewGroups).toBeDefined();
+    expect(createdViewGroups).toHaveLength(0);
+  });
+});
+

--- a/packages/twenty-server/test/integration/metadata/suites/view-group/utils/create-many-core-view-groups-query-factory.util.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/view-group/utils/create-many-core-view-groups-query-factory.util.ts
@@ -21,4 +21,3 @@ export const createManyCoreViewGroupsQueryFactory = ({
     inputs,
   },
 });
-

--- a/packages/twenty-server/test/integration/metadata/suites/view-group/utils/create-many-core-view-groups-query-factory.util.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/view-group/utils/create-many-core-view-groups-query-factory.util.ts
@@ -1,0 +1,24 @@
+import gql from 'graphql-tag';
+import { VIEW_GROUP_GQL_FIELDS } from 'test/integration/constants/view-gql-fields.constants';
+
+import { type CreateViewGroupInput } from 'src/engine/metadata-modules/view-group/dtos/inputs/create-view-group.input';
+
+export const createManyCoreViewGroupsQueryFactory = ({
+  gqlFields = VIEW_GROUP_GQL_FIELDS,
+  inputs,
+}: {
+  gqlFields?: string;
+  inputs: CreateViewGroupInput[];
+}) => ({
+  query: gql`
+    mutation CreateManyCoreViewGroups($inputs: [CreateViewGroupInput!]!) {
+      createManyCoreViewGroups(inputs: $inputs) {
+        ${gqlFields}
+      }
+    }
+  `,
+  variables: {
+    inputs,
+  },
+});
+

--- a/packages/twenty-server/test/integration/metadata/suites/view-group/utils/create-many-core-view-groups.util.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/view-group/utils/create-many-core-view-groups.util.ts
@@ -41,4 +41,3 @@ export const createManyCoreViewGroups = async ({
 
   return { data: response.body.data, errors: response.body.errors };
 };
-

--- a/packages/twenty-server/test/integration/metadata/suites/view-group/utils/create-many-core-view-groups.util.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/view-group/utils/create-many-core-view-groups.util.ts
@@ -1,0 +1,44 @@
+import { makeMetadataAPIRequest } from 'test/integration/metadata/suites/utils/make-metadata-api-request.util';
+import { createManyCoreViewGroupsQueryFactory } from 'test/integration/metadata/suites/view-group/utils/create-many-core-view-groups-query-factory.util';
+import { type CommonResponseBody } from 'test/integration/metadata/types/common-response-body.type';
+import { warnIfErrorButNotExpectedToFail } from 'test/integration/metadata/utils/warn-if-error-but-not-expected-to-fail.util';
+import { warnIfNoErrorButExpectedToFail } from 'test/integration/metadata/utils/warn-if-no-error-but-expected-to-fail.util';
+
+import { type CreateViewGroupInput } from 'src/engine/metadata-modules/view-group/dtos/inputs/create-view-group.input';
+import { type ViewGroupEntity } from 'src/engine/metadata-modules/view-group/entities/view-group.entity';
+
+export const createManyCoreViewGroups = async ({
+  inputs,
+  gqlFields,
+  expectToFail,
+}: {
+  inputs: CreateViewGroupInput[];
+  gqlFields?: string;
+  expectToFail?: boolean;
+}): CommonResponseBody<{
+  createManyCoreViewGroups: ViewGroupEntity[];
+}> => {
+  const graphqlOperation = createManyCoreViewGroupsQueryFactory({
+    inputs,
+    gqlFields,
+  });
+
+  const response = await makeMetadataAPIRequest(graphqlOperation);
+
+  if (expectToFail === true) {
+    warnIfNoErrorButExpectedToFail({
+      response,
+      errorMessage: 'View Groups batch creation should have failed but did not',
+    });
+  }
+
+  if (expectToFail === false) {
+    warnIfErrorButNotExpectedToFail({
+      response,
+      errorMessage: 'View Groups batch creation has failed but should not',
+    });
+  }
+
+  return { data: response.body.data, errors: response.body.errors };
+};
+

--- a/packages/twenty-server/test/integration/rest/suites/__snapshots__/view-group.integration-spec.ts.snap
+++ b/packages/twenty-server/test/integration/rest/suites/__snapshots__/view-group.integration-spec.ts.snap
@@ -32,7 +32,7 @@ exports[`View Group REST API POST /metadata/viewGroups should fail to create vie
       },
     ],
   },
-  "message": "Multiple validation errors occurred while creating view group",
+  "message": "Multiple validation errors occurred while creating view groups",
   "statusCode": 400,
   "summary": {
     "invalidCronTrigger": 0,


### PR DESCRIPTION
# Introduction
Same as https://github.com/twentyhq/twenty/pull/15576 but for view groups creation

When creating a kanban view with v2 flag activated in production result in race condition due to request being slow and //.
That's why we're introducing a batch create on view group here
closing https://github.com/twentyhq/core-team-issues/issues/1847

## In v2
- batch create view group endpoint is available
- frontend will target the new endpoint

## In v1
- batch create view group endpoint is not available
- frontend will stick to old fake batch view group creation loop


## Gallery
### v2
<img width="1796" height="486" alt="image" src="https://github.com/user-attachments/assets/932cfe9f-85f1-41cc-a1c4-72a4b5d5a256" />

### v1
<img width="1852" height="966" alt="image" src="https://github.com/user-attachments/assets/8aa9df11-cdea-4b12-ae60-118cdf5e257b" />
