### PR TITLE
fast-follows: fix placeholder not appearing when no widgets in a tab

### DIFF
--- a/packages/twenty-front/src/modules/page-layout/components/PageLayoutGridLayout.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/PageLayoutGridLayout.tsx
@@ -113,8 +113,7 @@ export const PageLayoutGridLayout = ({ tabId }: PageLayoutGridLayoutProps) => {
   const isLayoutEmpty =
     !isDefined(activeTabWidgets) || activeTabWidgets.length === 0;
 
-  const hasPendingPlaceholder =
-    isDefined(pageLayoutDraggedArea) && !isLayoutEmpty;
+  const hasPendingPlaceholder = isDefined(pageLayoutDraggedArea);
 
   const baseLayouts = isLayoutEmpty
     ? EMPTY_LAYOUT

--- a/packages/twenty-front/src/modules/page-layout/utils/__tests__/prepareGridLayoutItemsWithPlaceholders.test.ts
+++ b/packages/twenty-front/src/modules/page-layout/utils/__tests__/prepareGridLayoutItemsWithPlaceholders.test.ts
@@ -53,12 +53,12 @@ describe('prepareGridLayoutItemsWithPlaceholders', () => {
       });
     });
 
-    it('should return empty placeholder even when shouldIncludePendingPlaceholder is true', () => {
+    it('should return pending placeholder when shouldIncludePendingPlaceholder is true and layout is empty', () => {
       const result = prepareGridLayoutItemsWithPlaceholders([], true);
 
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual({
-        id: 'empty-placeholder',
+        id: PENDING_WIDGET_PLACEHOLDER_LAYOUT_KEY,
         type: 'placeholder',
       });
     });

--- a/packages/twenty-front/src/modules/page-layout/utils/prepareGridLayoutItemsWithPlaceholders.ts
+++ b/packages/twenty-front/src/modules/page-layout/utils/prepareGridLayoutItemsWithPlaceholders.ts
@@ -10,6 +10,15 @@ export const prepareGridLayoutItemsWithPlaceholders = (
   const hasWidgets = isDefined(widgets) && widgets.length > 0;
 
   if (!hasWidgets) {
+    if (shouldIncludePendingPlaceholder) {
+      return [
+        {
+          id: PENDING_WIDGET_PLACEHOLDER_LAYOUT_KEY,
+          type: 'placeholder' as const,
+        },
+      ];
+    }
+
     return [
       {
         id: 'empty-placeholder',


### PR DESCRIPTION
closes - https://discord.com/channels/1130383047699738754/1435261256251605053

before:

https://github.com/user-attachments/assets/fbbfd6b0-6c25-48c3-9367-efbf47efd34a

after:

https://github.com/user-attachments/assets/87105c4e-cf79-43c0-83bb-ebb4c32a64fc

