### PR TITLE
fix: brace-expansion regular expression denial of service vulnerability

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -29258,21 +29258,21 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^1.1.7":
-  version: 1.1.11
-  resolution: "brace-expansion@npm:1.1.11"
+  version: 1.1.12
+  resolution: "brace-expansion@npm:1.1.12"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
-  checksum: 10c0/695a56cd058096a7cb71fb09d9d6a7070113c7be516699ed361317aca2ec169f618e28b8af352e02ab4233fb54eb0168460a40dc320bab0034b36ab59aaad668
+  checksum: 10c0/975fecac2bb7758c062c20d0b3b6288c7cc895219ee25f0a64a9de662dbac981ff0b6e89909c3897c1f84fa353113a721923afdec5f8b2350255b097f12b1f73
   languageName: node
   linkType: hard
 
 "brace-expansion@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "brace-expansion@npm:2.0.1"
+  version: 2.0.2
+  resolution: "brace-expansion@npm:2.0.2"
   dependencies:
     balanced-match: "npm:^1.0.0"
-  checksum: 10c0/b358f2fe060e2d7a87aa015979ecea07f3c37d4018f8d6deb5bd4c229ad3a0384fe6029bb76cd8be63c81e516ee52d1a0673edbe2023d53a5191732ae3c3e49f
+  checksum: 10c0/6d117a4c793488af86b83172deb6af143e94c17bc53b0b3cec259733923b4ca84679d506ac261f4ba3c7ed37c46018e2ff442f9ce453af8643ecd64f4a54e6cf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resolves [Dependabot Alert 238](https://github.com/twentyhq/twenty/security/dependabot/238) - brace-expansion regular expression denial of service vulnerability.

This alert was closed yesterday, but `yarn.lock` went back to the previous versions somehow when an unrelated PR was reverted. Therefore, creating a PR again.

Versions on main:
<p align="center">
<img width="470" height="385" alt="image" src="https://github.com/user-attachments/assets/69fb6519-21c0-4f69-9412-a7b05451cf57" />
</p>

Updated versions in the PR:
<p align="center">
<img width="472" height="383" alt="image" src="https://github.com/user-attachments/assets/69f2a7c4-8015-4a92-8e25-1b8953f329da" />
</p>