### PR TITLE
Edit workflow and serverless throttling

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/throttler/throttler.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/throttler/throttler.service.ts
@@ -15,19 +15,6 @@ export class ThrottlerService {
     private readonly cacheStorage: CacheStorageService,
   ) {}
 
-  async throttle(key: string, limit: number, ttl: number): Promise<void> {
-    const currentCount = (await this.cacheStorage.get<number>(key)) ?? 0;
-
-    if (currentCount >= limit) {
-      throw new ThrottlerException(
-        'Limit reached',
-        ThrottlerExceptionCode.LIMIT_REACHED,
-      );
-    }
-
-    await this.cacheStorage.set(key, currentCount + 1, ttl);
-  }
-
   async tokenBucketThrottleOrThrow(
     key: string,
     tokensToConsume: number,

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
@@ -468,7 +468,7 @@ export class ConfigVariables {
     type: ConfigVariableType.NUMBER,
   })
   @CastToPositiveNumber()
-  SERVERLESS_FUNCTION_EXEC_THROTTLE_LIMIT = 10;
+  SERVERLESS_FUNCTION_EXEC_THROTTLE_LIMIT = 1000;
 
   // milliseconds
   @ConfigVariablesMetadata({
@@ -477,7 +477,7 @@ export class ConfigVariables {
     type: ConfigVariableType.NUMBER,
   })
   @CastToPositiveNumber()
-  SERVERLESS_FUNCTION_EXEC_THROTTLE_TTL = 1000;
+  SERVERLESS_FUNCTION_EXEC_THROTTLE_TTL = 60_000;
 
   @ConfigVariablesMetadata({
     group: ConfigVariablesGroup.SERVERLESS_CONFIG,

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
@@ -1179,7 +1179,7 @@ export class ConfigVariables {
     type: ConfigVariableType.NUMBER,
   })
   @CastToPositiveNumber()
-  WORKFLOW_EXEC_THROTTLE_LIMIT = 10;
+  WORKFLOW_EXEC_THROTTLE_LIMIT = 100;
 
   @ConfigVariablesMetadata({
     group: ConfigVariablesGroup.RATE_LIMITING,
@@ -1187,7 +1187,7 @@ export class ConfigVariables {
     type: ConfigVariableType.NUMBER,
   })
   @CastToPositiveNumber()
-  WORKFLOW_EXEC_THROTTLE_TTL = 1000;
+  WORKFLOW_EXEC_THROTTLE_TTL = 60_000;
 
   @ConfigVariablesMetadata({
     group: ConfigVariablesGroup.CAPTCHA_CONFIG,

--- a/packages/twenty-server/src/engine/metadata-modules/serverless-function/serverless-function.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/serverless-function/serverless-function.service.ts
@@ -458,8 +458,9 @@ export class ServerlessFunctionService {
 
   private async throttleExecution(workspaceId: string) {
     try {
-      await this.throttlerService.throttle(
+      await this.throttlerService.tokenBucketThrottleOrThrow(
         `${workspaceId}-serverless-function-execution`,
+        1,
         this.twentyConfigService.get('SERVERLESS_FUNCTION_EXEC_THROTTLE_LIMIT'),
         this.twentyConfigService.get('SERVERLESS_FUNCTION_EXEC_THROTTLE_TTL'),
       );

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/jobs/run-workflow.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/jobs/run-workflow.job.ts
@@ -172,8 +172,9 @@ export class RunWorkflowJob {
 
   private async throttleExecution(workflowId: string) {
     try {
-      await this.throttlerService.throttle(
+      await this.throttlerService.tokenBucketThrottleOrThrow(
         `${workflowId}-workflow-execution`,
+        1,
         this.twentyConfigService.get('WORKFLOW_EXEC_THROTTLE_LIMIT'),
         this.twentyConfigService.get('WORKFLOW_EXEC_THROTTLE_TTL'),
       );


### PR DESCRIPTION
Serverless:  1000 / min.

Workflows: 100 / min. This is a security in case of infinite loops. 