### PR TITLE
Fix display currency amount if currency code is empty string

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/ui/types/guards/isFieldCurrencyValue.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/types/guards/isFieldCurrencyValue.ts
@@ -4,7 +4,7 @@ import { CurrencyCode } from 'twenty-shared/constants';
 import { type FieldCurrencyValue } from '../FieldMetadata';
 
 const currencySchema = z.object({
-  currencyCode: z.enum(CurrencyCode).nullable(),
+  currencyCode: z.union([z.enum(CurrencyCode), z.literal('')]).nullable(),
   amountMicros: z.number().nullable(),
 });
 


### PR DESCRIPTION
## Context
Amount are not displayed if the currency code is an empty string. This is not consistent everywhere so I'm removing the limitation until we plan to make the API more robuste if we decide to validate currencyCode (should be non nullable imho)

## Before
<img width="1306" height="841" alt="Screenshot 2025-11-05 at 18 40 05" src="https://github.com/user-attachments/assets/964f5771-bd91-4cb2-9684-52073b845580" />


## After
<img width="1297" height="795" alt="Screenshot 2025-11-05 at 18 39 55" src="https://github.com/user-attachments/assets/4ae99265-7459-4579-9f65-e2d8225e8306" />
