### PR TITLE
Fix scroll to start when resize or move around columns

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-table/virtualization/components/RecordTableVirtualizedInitialDataLoadEffect.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/virtualization/components/RecordTableVirtualizedInitialDataLoadEffect.tsx
@@ -79,15 +79,8 @@ export const RecordTableVirtualizedInitialDataLoadEffect = () => {
         const lastFields = lastContextStoreVisibleRecordFields || [];
         const currentFields = visibleRecordFields || [];
 
-        const shouldRefetchData = lastFields.some((lastField, index) => {
-          const currentField = currentFields[index];
-          return (
-            !currentField ||
-            lastField.fieldMetadataItemId !==
-              currentField.fieldMetadataItemId ||
-            lastField.isVisible !== currentField.isVisible
-          );
-        });
+        const shouldRefetchData = currentFields.length > lastFields.length;
+
         if (shouldRefetchData) {
           await triggerInitialRecordTableDataLoad({
             shouldScrollToStart: isEmpty(lastFields),

--- a/packages/twenty-front/src/modules/object-record/record-table/virtualization/hooks/useTriggerInitialRecordTableDataLoad.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/virtualization/hooks/useTriggerInitialRecordTableDataLoad.ts
@@ -104,7 +104,9 @@ export const useTriggerInitialRecordTableDataLoad = () => {
 
   const triggerInitialRecordTableDataLoad = useRecoilCallback(
     ({ snapshot, set }) =>
-      async () => {
+      async ({
+        shouldScrollToStart = true,
+      }: { shouldScrollToStart?: boolean } = {}) => {
         const isInitializingVirtualTableDataLoading = getSnapshotValue(
           snapshot,
           isInitializingVirtualTableDataLoadingCallbackState,
@@ -189,11 +191,14 @@ export const useTriggerInitialRecordTableDataLoad = () => {
 
         setIsRecordTableScrolledHorizontally(false);
         setIsRecordTableScrolledVertically(false);
+        resetTableFocuses();
 
-        scrollTableToPosition({
-          horizontalScrollInPx: 0,
-          verticalScrollInPx: 0,
-        });
+        if (shouldScrollToStart) {
+          scrollTableToPosition({
+            horizontalScrollInPx: 0,
+            verticalScrollInPx: 0,
+          });
+        }
       },
     [
       isInitializingVirtualTableDataLoadingCallbackState,


### PR DESCRIPTION
Fixes https://github.com/twentyhq/private-issues/issues/361

There's room for more improvement here - triggerInitialRecordTableDataLoad does a lot of things, should not be triggered so much. actually even RecordTableVirtualizedInitialDataLoadEffect should not be triggered when there's just a metadata field change (if we trust the name initialDataLoad)