### PR TITLE
Fix: AI Agent tool errors and relation field handling

### DIFF
--- a/packages/twenty-front/src/modules/ai/components/AIChatAssistantMessageRenderer.tsx
+++ b/packages/twenty-front/src/modules/ai/components/AIChatAssistantMessageRenderer.tsx
@@ -82,15 +82,7 @@ export const AIChatAssistantMessageRenderer = ({
       default:
         {
           if (isToolUIPart(part)) {
-            const { output, input, type } = part;
-            return (
-              <ToolStepRenderer
-                key={index}
-                input={input}
-                output={output}
-                toolName={type.split('-')[1]}
-              />
-            );
+            return <ToolStepRenderer key={index} toolPart={part} />;
           }
         }
         return null;

--- a/packages/twenty-front/src/modules/ai/utils/mapDBPartToUIMessagePart.ts
+++ b/packages/twenty-front/src/modules/ai/utils/mapDBPartToUIMessagePart.ts
@@ -59,7 +59,7 @@ export const mapDBPartToUIMessagePart = (
           return {
             type: part.type as `tool-${string}`,
             toolCallId: part.toolCallId!,
-            input: part.toolInput,
+            input: part.toolInput ?? {},
             output: part.toolOutput,
             errorText: part.errorMessage!,
             state: part.state,

--- a/packages/twenty-server/src/engine/core-modules/record-crud/services/create-record.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-crud/services/create-record.service.ts
@@ -73,8 +73,12 @@ export class CreateRecordService {
       });
 
       const validObjectRecord = Object.fromEntries(
-        Object.entries(objectRecord).filter(([key]) =>
-          isDefined(objectMetadataItemWithFieldsMaps.fieldIdByName[key]),
+        Object.entries(objectRecord).filter(
+          ([key]) =>
+            isDefined(objectMetadataItemWithFieldsMaps.fieldIdByName[key]) ||
+            isDefined(
+              objectMetadataItemWithFieldsMaps.fieldIdByJoinColumnName[key],
+            ),
         ),
       );
 

--- a/packages/twenty-server/src/engine/core-modules/record-crud/services/upsert-record.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-crud/services/upsert-record.service.ts
@@ -92,9 +92,13 @@ export class UpsertRecordService {
         });
 
       const uniqueFieldsToUpdate = fieldsToUpdateArray
-        .map((field) => objectMetadataItemWithFieldsMaps.fieldIdByName[field])
+        .map(
+          (field) =>
+            objectMetadataItemWithFieldsMaps.fieldIdByName[field] ||
+            objectMetadataItemWithFieldsMaps.fieldIdByJoinColumnName[field],
+        )
         .map((fieldId) => objectMetadataItemWithFieldsMaps.fieldsById[fieldId])
-        .filter((field) => field.isUnique || field.name === 'id');
+        .filter((field) => field && (field.isUnique || field.name === 'id'));
 
       const conflictPathsUniqueFieldsToUpdate = uniqueFieldsToUpdate.flatMap(
         (field) => {


### PR DESCRIPTION
### Problems Fixed

1. **Tool execution errors broke conversations**
   - Failed tool executions showed "Processing..." indefinitely instead of error messages
   - Tool errors with `input: null` caused subsequent messages to fail with `Missing required parameter: 'input[X].arguments'`

2. **Relation fields not saved in AI Agent**
   - AI Agent couldn't save relation fields (e.g., `companyId`) when creating/upserting records
   - Join column names weren't recognized during field validation

### Solutions

**Tool Error Handling:**
- Display error messages in UI with expandable error details
- Ensure tool parts always have valid `input` field (`input: part.toolInput ?? {}`)
- Refactored `ToolStepRenderer` to accept complete `toolPart` object

**Relation Field Support:**
- Updated field validation in `create-record.service.ts` and `upsert-record.service.ts`
- Check both `fieldIdByName` and `fieldIdByJoinColumnName` mappings

### Changes
- `packages/twenty-front/src/modules/ai/`
  - `ToolStepRenderer.tsx` - Error state handling
  - `AIChatAssistantMessageRenderer.tsx` - Pass complete toolPart
  - `mapDBPartToUIMessagePart.ts` - Prevent null tool input
- `packages/twenty-server/src/engine/core-modules/record-crud/services/`
  - `create-record.service.ts` - Add join column validation
  - `upsert-record.service.ts` - Add join column validation