### PR TITLE
Allow rich text v2 in workflows

### DIFF
--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/utils/shouldDisplayFormField.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/utils/shouldDisplayFormField.ts
@@ -21,6 +21,7 @@ const SUPPORTED_FORM_FIELD_TYPES = [
   FieldMetadataType.UUID,
   FieldMetadataType.ARRAY,
   FieldMetadataType.RELATION,
+  FieldMetadataType.RICH_TEXT_V2,
 ];
 
 export const shouldDisplayFormField = ({


### PR DESCRIPTION
Rich text V2 is supported and has probably been removed by mistake

Fix https://github.com/twentyhq/twenty/issues/15660