### PR TITLE
Settings of morph needs a CSS fix

### DIFF
--- a/packages/twenty-front/src/modules/settings/data-model/fields/preview/components/SettingsDataModelRelationFieldPreviewSubWidget.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/preview/components/SettingsDataModelRelationFieldPreviewSubWidget.tsx
@@ -23,6 +23,7 @@ export type SettingsDataModelRelationFieldPreviewSubWidgetProps = {
 const StyledCard = styled(Card)`
   border-radius: ${({ theme }) => theme.border.radius.md};
   color: ${({ theme }) => theme.font.color.primary};
+  margin: auto;
 `;
 
 const StyledCardContent = styled(CardContent)`


### PR DESCRIPTION
adding margin auto for morph preview card in order to vertically align the box, as per figma

Before
<img width="467" height="331" alt="Screenshot 2025-11-06 at 16 36 00" src="https://github.com/user-attachments/assets/23543cdc-d0f3-4bbf-8dc1-4ac5f26f786e" />

After
<img width="576" height="362" alt="Screenshot 2025-11-06 at 16 36 16" src="https://github.com/user-attachments/assets/8530d59f-53a2-4eaa-834a-68b801bba3c8" />

Fixes https://github.com/twentyhq/core-team-issues/issues/1846