### PR TITLE
Fix tsconfigpaths root

### DIFF
--- a/packages/twenty-emails/vite.config.ts
+++ b/packages/twenty-emails/vite.config.ts
@@ -1,10 +1,10 @@
 import { lingui } from '@lingui/vite-plugin';
 import react from '@vitejs/plugin-react-swc';
 import * as path from 'path';
+import { APP_LOCALES } from 'twenty-shared/translations';
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
 import tsconfigPaths from 'vite-tsconfig-paths';
-import { APP_LOCALES } from 'twenty-shared/translations';
 
 export default defineConfig({
   root: __dirname,
@@ -17,7 +17,9 @@ export default defineConfig({
     lingui({
       configPath: path.resolve(__dirname, './lingui.config.ts'),
     }),
-    tsconfigPaths(),
+    tsconfigPaths({
+      root: __dirname
+    }),
     dts({
       entryRoot: 'src',
       tsconfigPath: path.join(__dirname, 'tsconfig.lib.json'),

--- a/packages/twenty-front/vite.config.ts
+++ b/packages/twenty-front/vite.config.ts
@@ -112,6 +112,7 @@ export default defineConfig(({ command, mode }) => {
         plugins: [['@lingui/swc-plugin', {}]],
       }),
       tsconfigPaths({
+        root: __dirname,
         projects: ['tsconfig.json'],
       }),
       svgr(),

--- a/packages/twenty-shared/vite.config.ts
+++ b/packages/twenty-shared/vite.config.ts
@@ -42,8 +42,10 @@ export default defineConfig(() => {
     root: __dirname,
     cacheDir: '../../node_modules/.vite/packages/twenty-shared',
     plugins: [
-      tsconfigPaths(),
-      dts({ entryRoot: 'src', tsconfigPath: tsConfigPath }),
+      tsconfigPaths({
+        root: __dirname
+      }),
+      dts({ entryRoot: './src', tsconfigPath: tsConfigPath }),
     ],
     build: {
       outDir: 'dist',

--- a/packages/twenty-ui/vite.config.ts
+++ b/packages/twenty-ui/vite.config.ts
@@ -72,6 +72,7 @@ export default defineConfig(({ command }) => {
         plugins: [['@swc/plugin-emotion', {}]],
       }),
       tsconfigPaths({
+        root: __dirname,
         projects: ['tsconfig.json'],
       }),
       svgr(),


### PR DESCRIPTION
# Introduction
We've facing facing intra package build error for a moment such as:
```ts
vite v7.1.12 building for production...
src/components/BaseEmail.tsx:20:19 - error TS2719: Type 'import("/Users/paulrastoin/ws/twenty/node_modules/@lingui/core/dist/index").I18n' is not assignable to type 'import("/Users/paulrastoin/ws/twenty/node_modules/@lingui/core/dist/index").I18n'. Two different types with this name exist, but they are unrelated.
  Types have separate declarations of a private property '_locale'.

20     <I18nProvider i18n={i18nInstance}>
                     ~~~~

  node_modules/@lingui/react/dist/shared/react.b2b749a9.d.ts:42:5
    42     i18n: I18n;
           ~~~~
    The expected type comes from property 'i18n' which is declared here on type 'IntrinsicAttributes & Omit<I18nContext, "_"> & { children?: ReactNode; }'
```

and now since hacktoberfest merge getting even more such as:
```ts
➜  twenty git:(main) ✗ npx nx build twenty-emails

   ✔  2/2 dependent project tasks succeeded [2 read from cache]

   Hint: you can run the command with --verbose to see the full dependent project outputs

——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————

[tsconfig-paths] An error occurred while parsing "/Users/paulrastoin/ws/twenty/packages/twenty-apps/hacktoberfest-2025/linkedin-browser-extension/browser-extension/tsconfig.json". See below for details. To disable this message, set the `ignoreConfigErrors` option to true.
TSConfckParseError: failed to resolve "extends":"./.wxt/tsconfig.json" in /Users/paulrastoin/ws/twenty/packages/twenty-apps/hacktoberfest-2025/linkedin-browser-extension/browser-extension/tsconfig.json
    at resolveExtends (file:///Users/paulrastoin/ws/twenty/node_modules/tsconfck/src/parse.js:261:8)
    at parseExtends (file:///Users/paulrastoin/ws/twenty/node_modules/tsconfck/src/parse.js:196:24)
    ... 5 lines matching cause stack trace ...
    at async createBuilder (file:///Users/paulrastoin/ws/twenty/node_modules/vite/dist/node/chunks/config.js:34104:19)
    at async CAC.<anonymous> (file:///Users/paulrastoin/ws/twenty/node_modules/vite/dist/node/cli.js:629:10) {
  code: 'EXTENDS_RESOLVE',
  cause: Error: Cannot find module './.wxt/tsconfig.json'
  Require stack:
  - /Users/paulrastoin/ws/twenty/packages/twenty-apps/hacktoberfest-2025/linkedin-browser-extension/browser-extension/tsconfig.json
      at Module._resolveFilename (node:internal/modules/cjs/loader:1410:15)
      at require.resolve (node:internal/modules/helpers:163:19)
      at resolveExtends (file:///Users/paulrastoin/ws/twenty/node_modules/tsconfck/src/parse.js:249:14)
      at parseExtends (file:///Users/paulrastoin/ws/twenty/node_modules/tsconfck/src/parse.js:196:24)
      at Module.parse (file:///Users/paulrastoin/ws/twenty/node_modules/tsconfck/src/parse.js:54:23)
      at async Promise.all (index 21)
      at async BasicMinimalPluginContext.configResolved (/Users/paulrastoin/ws/twenty/node_modules/vite-tsconfig-paths/dist/index.js:134:9)
      at async Promise.all (index 0)
      at async resolveConfig (file:///Users/paulrastoin/ws/twenty/node_modules/vite/dist/node/chunks/config.js:35892:2)
      at async createBuilder (file:///Users/paulrastoin/ws/twenty/node_modules/vite/dist/node/chunks/config.js:34104:19) {
    code: 'MODULE_NOT_FOUND',
    requireStack: [
      '/Users/paulrastoin/ws/twenty/packages/twenty-apps/hacktoberfest-2025/linkedin-browser-extension/browser-extension/tsconfig.json'
    ]
  },
  tsconfigFile: '/Users/paulrastoin/ws/twenty/packages/twenty-apps/hacktoberfest-2025/linkedin-browser-extension/browser-extension/tsconfig.json'
}
vite v7.1.12 building for production...
src/components/BaseEmail.tsx:20:19 - error TS2719: Type 'import("/Users/paulrastoin/ws/twenty/node_modules/@lingui/core/dist/index").I18n' is not assignable to type 'import("/Users/paulrastoin/ws/twenty/node_modules/@lingui/core/dist/index").I18n'. Two different types with this name exist, but they are unrelated.
  Types have separate declarations of a private property '_locale'.

20     <I18nProvider i18n={i18nInstance}>
                     ~~~~

  node_modules/@lingui/react/dist/shared/react.b2b749a9.d.ts:42:5
    42     i18n: I18n;
           ~~~~
    The expected type comes from property 'i18n' which is declared here on type 'IntrinsicAttributes & Omit<I18nContext, "_"> & { children?: ReactNode; }'

✓ 492 modules transformed.

[vite:dts] Start generate declaration files...
computing gzip size (31)...[vite:dts] Declaration files built in 981ms.

dist/locales/generated/zh-CN.mjs        4.16 kB │ gzip:   2.02 kB
dist/locales/generated/zh-TW.mjs        4.21 kB │ gzip:   2.05 kB
dist/locales/generated/en.mjs           4.34 kB │ gzip:   1.28 kB
dist/locales/generated/fi-FI.mjs        4.45 kB │ gzip:   1.90 kB
dist/locales/generated/af-ZA.mjs        4.50 kB │ gzip:   1.88 kB
dist/locales/generated/no-NO.mjs        4.52 kB │ gzip:   1.85 kB
dist/locales/generated/da-DK.mjs        4.52 kB │ gzip:   1.84 kB
dist/locales/generated/pt-BR.mjs        4.54 kB │ gzip:   1.89 kB
dist/locales/generated/sv-SE.mjs        4.54 kB │ gzip:   1.88 kB
dist/locales/generated/nl-NL.mjs        4.55 kB │ gzip:   1.87 kB
dist/locales/generated/pt-PT.mjs        4.56 kB │ gzip:   1.88 kB
dist/locales/generated/it-IT.mjs        4.59 kB │ gzip:   1.87 kB
dist/locales/generated/pl-PL.mjs        4.66 kB │ gzip:   2.04 kB
dist/locales/generated/cs-CZ.mjs        4.67 kB │ gzip:   2.05 kB
dist/locales/generated/es-ES.mjs        4.70 kB │ gzip:   1.90 kB
dist/locales/generated/tr-TR.mjs        4.70 kB │ gzip:   2.02 kB
dist/locales/generated/de-DE.mjs        4.71 kB │ gzip:   1.97 kB
dist/locales/generated/ca-ES.mjs        4.73 kB │ gzip:   1.92 kB
dist/locales/generated/ko-KR.mjs        4.73 kB │ gzip:   2.14 kB
dist/locales/generated/ro-RO.mjs        4.73 kB │ gzip:   1.95 kB
dist/locales/generated/fr-FR.mjs        4.74 kB │ gzip:   1.92 kB
dist/locales/generated/hu-HU.mjs        4.82 kB │ gzip:   2.09 kB
dist/locales/generated/he-IL.mjs        4.88 kB │ gzip:   1.99 kB
dist/locales/generated/ja-JP.mjs        4.95 kB │ gzip:   2.19 kB
dist/locales/generated/vi-VN.mjs        5.19 kB │ gzip:   2.14 kB
dist/locales/generated/ar-SA.mjs        5.35 kB │ gzip:   2.21 kB
dist/locales/generated/pseudo-en.mjs    5.68 kB │ gzip:   2.27 kB
dist/locales/generated/sr-Cyrl.mjs      5.82 kB │ gzip:   2.32 kB
dist/locales/generated/uk-UA.mjs        6.11 kB │ gzip:   2.41 kB
dist/locales/generated/el-GR.mjs        6.47 kB │ gzip:   2.53 kB
dist/locales/generated/ru-RU.mjs        6.62 kB │ gzip:   2.55 kB
dist/index.mjs                        822.22 kB │ gzip: 179.78 kB
dist/locales/generated/zh-CN.js        4.23 kB │ gzip:   2.08 kB
dist/locales/generated/zh-TW.js        4.28 kB │ gzip:   2.10 kB
dist/locales/generated/en.js           4.41 kB │ gzip:   1.33 kB
dist/locales/generated/fi-FI.js        4.52 kB │ gzip:   1.95 kB
dist/locales/generated/af-ZA.js        4.56 kB │ gzip:   1.93 kB
dist/locales/generated/no-NO.js        4.58 kB │ gzip:   1.90 kB
dist/locales/generated/da-DK.js        4.59 kB │ gzip:   1.89 kB
dist/locales/generated/pt-BR.js        4.60 kB │ gzip:   1.94 kB
dist/locales/generated/sv-SE.js        4.61 kB │ gzip:   1.93 kB
dist/locales/generated/nl-NL.js        4.62 kB │ gzip:   1.92 kB
dist/locales/generated/pt-PT.js        4.63 kB │ gzip:   1.93 kB
dist/locales/generated/it-IT.js        4.66 kB │ gzip:   1.92 kB
dist/locales/generated/pl-PL.js        4.73 kB │ gzip:   2.09 kB
dist/locales/generated/cs-CZ.js        4.74 kB │ gzip:   2.10 kB
dist/locales/generated/es-ES.js        4.77 kB │ gzip:   1.95 kB
dist/locales/generated/tr-TR.js        4.77 kB │ gzip:   2.07 kB
dist/locales/generated/de-DE.js        4.77 kB │ gzip:   2.02 kB
dist/locales/generated/ca-ES.js        4.80 kB │ gzip:   1.97 kB
dist/locales/generated/ko-KR.js        4.80 kB │ gzip:   2.20 kB
dist/locales/generated/ro-RO.js        4.80 kB │ gzip:   2.00 kB
dist/locales/generated/fr-FR.js        4.81 kB │ gzip:   1.97 kB
dist/locales/generated/hu-HU.js        4.89 kB │ gzip:   2.14 kB
dist/locales/generated/he-IL.js        4.95 kB │ gzip:   2.04 kB
dist/locales/generated/ja-JP.js        5.02 kB │ gzip:   2.24 kB
dist/locales/generated/vi-VN.js        5.26 kB │ gzip:   2.19 kB
dist/locales/generated/ar-SA.js        5.42 kB │ gzip:   2.26 kB
dist/locales/generated/pseudo-en.js    5.75 kB │ gzip:   2.32 kB
dist/locales/generated/sr-Cyrl.js      5.89 kB │ gzip:   2.37 kB
dist/locales/generated/uk-UA.js        6.18 kB │ gzip:   2.47 kB
dist/locales/generated/el-GR.js        6.54 kB │ gzip:   2.58 kB
dist/locales/generated/ru-RU.js        6.69 kB │ gzip:   2.60 kB
dist/index.js                        606.48 kB │ gzip: 160.10 kB
✓ built in 2.45s

——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————

 NX   Successfully ran target build for project twenty-emails and 2 tasks it depends on (5s)

Nx read the output from the cache instead of running the command for 2 out of 3 tasks.
```

Fixing folder to search for tsconfig from