### PR TITLE
Do not revert isSystem update for workspaceMember

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/services/workspace-metadata-updater.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/services/workspace-metadata-updater.service.ts
@@ -29,6 +29,7 @@ import { type CompositeFieldMetadataType } from 'src/engine/metadata-modules/wor
 import { isFieldMetadataEntityOfType } from 'src/engine/utils/is-field-metadata-of-type.util';
 import { type FieldMetadataUpdate } from 'src/engine/workspace-manager/workspace-migration-builder/factories/workspace-migration-field.factory';
 import { type ObjectMetadataUpdate } from 'src/engine/workspace-manager/workspace-migration-builder/factories/workspace-migration-object.factory';
+import { STANDARD_OBJECT_IDS } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-object-ids';
 import { type WorkspaceSyncStorage } from 'src/engine/workspace-manager/workspace-sync-metadata/storage/workspace-sync.storage';
 
 @Injectable()
@@ -471,6 +472,20 @@ export class WorkspaceMetadataUpdaterService {
         ...oldEntity,
         ...updateItem,
       };
+
+      // Do not update isSystem for workspaceMember
+      // TODO to remove after https://github.com/twentyhq/twenty/issues/15688
+      const isObjectMetadataUpdate = entityClass === ObjectMetadataEntity;
+
+      if (
+        isObjectMetadataUpdate &&
+        oldEntity?.standardId === STANDARD_OBJECT_IDS.workspaceMember &&
+        'isSystem' in updateItem &&
+        'isSystem' in oldEntity
+      ) {
+        (mergedUpdate as unknown as { isSystem: boolean }).isSystem =
+          oldEntity.isSystem as boolean;
+      }
 
       // Omit keys that we don't want to override
       keysToOmit.forEach((key) => {


### PR DESCRIPTION
Until this is done: [Make workspaceMembers non-system](https://github.com/twentyhq/core-team-issues/issues/2328) 

Let's make that update to allow us to have workspaces with workspaceMember not being system object, to allow user to customize their data model.