### PR TITLE
fix: rename SettingsPermissionsGuard to SettingsPermissionGuard for consistency

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/admin-panel/admin-panel.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/admin-panel/admin-panel.resolver.ts
@@ -31,7 +31,7 @@ import { ConfigVariableGraphqlApiExceptionFilter } from 'src/engine/core-modules
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import { AdminPanelGuard } from 'src/engine/guards/admin-panel-guard';
 import { ServerLevelImpersonateGuard } from 'src/engine/guards/server-level-impersonate.guard';
-import { SettingsPermissionsGuard } from 'src/engine/guards/settings-permissions.guard';
+import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { UserAuthGuard } from 'src/engine/guards/user-auth.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { PermissionFlagType } from 'src/engine/metadata-modules/permissions/constants/permission-flag-type.constants';
@@ -49,7 +49,7 @@ import { QueueMetricsDataDTO } from './dtos/queue-metrics-data.dto';
 @UseGuards(
   WorkspaceAuthGuard,
   UserAuthGuard,
-  SettingsPermissionsGuard(PermissionFlagType.SECURITY),
+  SettingsPermissionGuard(PermissionFlagType.SECURITY),
 )
 export class AdminPanelResolver {
   constructor(

--- a/packages/twenty-server/src/engine/core-modules/api-key/api-key.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/api-key/api-key.resolver.ts
@@ -22,7 +22,7 @@ import { UpdateApiKeyInput } from 'src/engine/core-modules/api-key/dtos/update-a
 import { apiKeyGraphqlApiExceptionHandler } from 'src/engine/core-modules/api-key/utils/api-key-graphql-api-exception-handler.util';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
-import { SettingsPermissionsGuard } from 'src/engine/guards/settings-permissions.guard';
+import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { PermissionFlagType } from 'src/engine/metadata-modules/permissions/constants/permission-flag-type.constants';
 import { RoleDTO } from 'src/engine/metadata-modules/role/dtos/role.dto';
@@ -34,7 +34,7 @@ import { ApiKeyService } from './api-key.service';
 @Resolver(() => ApiKeyEntity)
 @UseGuards(
   WorkspaceAuthGuard,
-  SettingsPermissionsGuard(PermissionFlagType.API_KEYS_AND_WEBHOOKS),
+  SettingsPermissionGuard(PermissionFlagType.API_KEYS_AND_WEBHOOKS),
 )
 export class ApiKeyResolver {
   constructor(

--- a/packages/twenty-server/src/engine/core-modules/application/application.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application.resolver.ts
@@ -12,13 +12,13 @@ import { FeatureFlagKey } from 'src/engine/core-modules/feature-flag/enums/featu
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
 import { RequireFeatureFlag } from 'src/engine/guards/feature-flag.guard';
-import { SettingsPermissionsGuard } from 'src/engine/guards/settings-permissions.guard';
+import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { PermissionFlagType } from 'src/engine/metadata-modules/permissions/constants/permission-flag-type.constants';
 
 @UseGuards(
   WorkspaceAuthGuard,
-  SettingsPermissionsGuard(PermissionFlagType.APPLICATIONS),
+  SettingsPermissionGuard(PermissionFlagType.APPLICATIONS),
 )
 @Resolver()
 @UseFilters(ApplicationExceptionFilter)

--- a/packages/twenty-server/src/engine/core-modules/applicationVariable/application-variable.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/applicationVariable/application-variable.resolver.ts
@@ -4,13 +4,13 @@ import { Args, Mutation, Resolver } from '@nestjs/graphql';
 import { ApplicationVariableEntityExceptionFilter } from 'src/engine/core-modules/applicationVariable/application-variable-exception-filter';
 import { ApplicationVariableEntityService } from 'src/engine/core-modules/applicationVariable/application-variable.service';
 import { UpdateApplicationVariableEntityInput } from 'src/engine/core-modules/applicationVariable/dtos/update-application-variable.input';
-import { SettingsPermissionsGuard } from 'src/engine/guards/settings-permissions.guard';
+import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { PermissionFlagType } from 'src/engine/metadata-modules/permissions/constants/permission-flag-type.constants';
 
 @UseGuards(
   WorkspaceAuthGuard,
-  SettingsPermissionsGuard(PermissionFlagType.APPLICATIONS),
+  SettingsPermissionGuard(PermissionFlagType.APPLICATIONS),
 )
 @Resolver()
 @UseFilters(ApplicationVariableEntityExceptionFilter)

--- a/packages/twenty-server/src/engine/core-modules/approved-access-domain/approved-access-domain.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/approved-access-domain/approved-access-domain.resolver.ts
@@ -13,7 +13,7 @@ import { UserEntity } from 'src/engine/core-modules/user/user.entity';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AuthUser } from 'src/engine/decorators/auth/auth-user.decorator';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
-import { SettingsPermissionsGuard } from 'src/engine/guards/settings-permissions.guard';
+import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { PermissionFlagType } from 'src/engine/metadata-modules/permissions/constants/permission-flag-type.constants';
 import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.manager';
@@ -21,7 +21,7 @@ import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/sta
 
 @UseGuards(
   WorkspaceAuthGuard,
-  SettingsPermissionsGuard(PermissionFlagType.WORKSPACE_MEMBERS),
+  SettingsPermissionGuard(PermissionFlagType.WORKSPACE_MEMBERS),
 )
 @UsePipes(ResolverValidationPipe)
 @UseFilters(

--- a/packages/twenty-server/src/engine/core-modules/auth/auth.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/auth.resolver.ts
@@ -70,7 +70,7 @@ import { AuthUser } from 'src/engine/decorators/auth/auth-user.decorator';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
 import { NoPermissionGuard } from 'src/engine/guards/no-permission.guard';
 import { PublicEndpointGuard } from 'src/engine/guards/public-endpoint.guard';
-import { SettingsPermissionsGuard } from 'src/engine/guards/settings-permissions.guard';
+import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { UserAuthGuard } from 'src/engine/guards/user-auth.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { PermissionFlagType } from 'src/engine/metadata-modules/permissions/constants/permission-flag-type.constants';
@@ -783,7 +783,7 @@ export class AuthResolver {
 
   @UseGuards(
     WorkspaceAuthGuard,
-    SettingsPermissionsGuard(PermissionFlagType.API_KEYS_AND_WEBHOOKS),
+    SettingsPermissionGuard(PermissionFlagType.API_KEYS_AND_WEBHOOKS),
   )
   @Mutation(() => ApiKeyToken)
   async generateApiKeyToken(

--- a/packages/twenty-server/src/engine/core-modules/billing/billing.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/billing.resolver.ts
@@ -29,7 +29,7 @@ import { AuthUserWorkspaceId } from 'src/engine/decorators/auth/auth-user-worksp
 import { AuthUser } from 'src/engine/decorators/auth/auth-user.decorator';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
 import { NoPermissionGuard } from 'src/engine/guards/no-permission.guard';
-import { SettingsPermissionsGuard } from 'src/engine/guards/settings-permissions.guard';
+import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { UserAuthGuard } from 'src/engine/guards/user-auth.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { PermissionFlagType } from 'src/engine/metadata-modules/permissions/constants/permission-flag-type.constants';
@@ -60,7 +60,7 @@ export class BillingResolver {
   @Query(() => BillingSessionOutput)
   @UseGuards(
     WorkspaceAuthGuard,
-    SettingsPermissionsGuard(PermissionFlagType.BILLING),
+    SettingsPermissionGuard(PermissionFlagType.BILLING),
   )
   async billingPortalSession(
     @AuthWorkspace() workspace: WorkspaceEntity,
@@ -138,7 +138,7 @@ export class BillingResolver {
   @Mutation(() => BillingUpdateOutput)
   @UseGuards(
     WorkspaceAuthGuard,
-    SettingsPermissionsGuard(PermissionFlagType.BILLING),
+    SettingsPermissionGuard(PermissionFlagType.BILLING),
   )
   async switchSubscriptionInterval(
     @AuthWorkspace() workspace: WorkspaceEntity,
@@ -160,7 +160,7 @@ export class BillingResolver {
   @Mutation(() => BillingUpdateOutput)
   @UseGuards(
     WorkspaceAuthGuard,
-    SettingsPermissionsGuard(PermissionFlagType.BILLING),
+    SettingsPermissionGuard(PermissionFlagType.BILLING),
   )
   async switchBillingPlan(@AuthWorkspace() workspace: WorkspaceEntity) {
     await this.billingSubscriptionService.changePlan(workspace);
@@ -180,7 +180,7 @@ export class BillingResolver {
   @Mutation(() => BillingUpdateOutput)
   @UseGuards(
     WorkspaceAuthGuard,
-    SettingsPermissionsGuard(PermissionFlagType.BILLING),
+    SettingsPermissionGuard(PermissionFlagType.BILLING),
   )
   async cancelSwitchBillingPlan(@AuthWorkspace() workspace: WorkspaceEntity) {
     await this.billingSubscriptionService.cancelSwitchPlan(workspace);
@@ -200,7 +200,7 @@ export class BillingResolver {
   @Mutation(() => BillingUpdateOutput)
   @UseGuards(
     WorkspaceAuthGuard,
-    SettingsPermissionsGuard(PermissionFlagType.BILLING),
+    SettingsPermissionGuard(PermissionFlagType.BILLING),
   )
   async cancelSwitchBillingInterval(
     @AuthWorkspace() workspace: WorkspaceEntity,
@@ -222,7 +222,7 @@ export class BillingResolver {
   @Mutation(() => BillingUpdateOutput)
   @UseGuards(
     WorkspaceAuthGuard,
-    SettingsPermissionsGuard(PermissionFlagType.BILLING),
+    SettingsPermissionGuard(PermissionFlagType.BILLING),
   )
   async setMeteredSubscriptionPrice(
     @AuthWorkspace() workspace: WorkspaceEntity,
@@ -256,7 +256,7 @@ export class BillingResolver {
   @Mutation(() => BillingEndTrialPeriodOutput)
   @UseGuards(
     WorkspaceAuthGuard,
-    SettingsPermissionsGuard(PermissionFlagType.BILLING),
+    SettingsPermissionGuard(PermissionFlagType.BILLING),
   )
   async endSubscriptionTrialPeriod(
     @AuthWorkspace() workspace: WorkspaceEntity,
@@ -267,7 +267,7 @@ export class BillingResolver {
   @Query(() => [BillingMeteredProductUsageOutput])
   @UseGuards(
     WorkspaceAuthGuard,
-    SettingsPermissionsGuard(PermissionFlagType.BILLING),
+    SettingsPermissionGuard(PermissionFlagType.BILLING),
   )
   async getMeteredProductsUsage(
     @AuthWorkspace() workspace: WorkspaceEntity,
@@ -278,7 +278,7 @@ export class BillingResolver {
   @Mutation(() => BillingUpdateOutput)
   @UseGuards(
     WorkspaceAuthGuard,
-    SettingsPermissionsGuard(PermissionFlagType.BILLING),
+    SettingsPermissionGuard(PermissionFlagType.BILLING),
   )
   async cancelSwitchMeteredPrice(@AuthWorkspace() workspace: WorkspaceEntity) {
     await this.billingSubscriptionService.cancelSwitchMeteredPrice(workspace);

--- a/packages/twenty-server/src/engine/core-modules/emailing-domain/emailing-domain.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/emailing-domain/emailing-domain.resolver.ts
@@ -7,13 +7,13 @@ import { EmailingDomainService } from 'src/engine/core-modules/emailing-domain/s
 import { ResolverValidationPipe } from 'src/engine/core-modules/graphql/pipes/resolver-validation.pipe';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
-import { SettingsPermissionsGuard } from 'src/engine/guards/settings-permissions.guard';
+import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { PermissionFlagType } from 'src/engine/metadata-modules/permissions/constants/permission-flag-type.constants';
 
 @UseGuards(
   WorkspaceAuthGuard,
-  SettingsPermissionsGuard(PermissionFlagType.WORKSPACE),
+  SettingsPermissionGuard(PermissionFlagType.WORKSPACE),
 )
 @UsePipes(ResolverValidationPipe)
 @Resolver(() => EmailingDomainDto)

--- a/packages/twenty-server/src/engine/core-modules/file/file-upload/resolvers/file-upload.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/file-upload/resolvers/file-upload.resolver.ts
@@ -11,7 +11,7 @@ import { PreventNestToAutoLogGraphqlErrorsFilter } from 'src/engine/core-modules
 import { ResolverValidationPipe } from 'src/engine/core-modules/graphql/pipes/resolver-validation.pipe';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
-import { SettingsPermissionsGuard } from 'src/engine/guards/settings-permissions.guard';
+import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { PermissionFlagType } from 'src/engine/metadata-modules/permissions/constants/permission-flag-type.constants';
 import { streamToBuffer } from 'src/utils/stream-to-buffer';
@@ -24,7 +24,7 @@ export class FileUploadResolver {
   constructor(private readonly fileUploadService: FileUploadService) {}
 
   @Mutation(() => SignedFileDTO)
-  @UseGuards(SettingsPermissionsGuard(PermissionFlagType.UPLOAD_FILE))
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.UPLOAD_FILE))
   async uploadFile(
     @AuthWorkspace() { id: workspaceId }: WorkspaceEntity,
     @Args({ name: 'file', type: () => GraphQLUpload })
@@ -51,7 +51,7 @@ export class FileUploadResolver {
   }
 
   @Mutation(() => SignedFileDTO)
-  @UseGuards(SettingsPermissionsGuard(PermissionFlagType.UPLOAD_FILE))
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.UPLOAD_FILE))
   async uploadImage(
     @AuthWorkspace() { id: workspaceId }: WorkspaceEntity,
     @Args({ name: 'file', type: () => GraphQLUpload })

--- a/packages/twenty-server/src/engine/core-modules/file/resolvers/file.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/file/resolvers/file.resolver.ts
@@ -10,7 +10,7 @@ import { PreventNestToAutoLogGraphqlErrorsFilter } from 'src/engine/core-modules
 import { ResolverValidationPipe } from 'src/engine/core-modules/graphql/pipes/resolver-validation.pipe';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
-import { SettingsPermissionsGuard } from 'src/engine/guards/settings-permissions.guard';
+import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { PermissionFlagType } from 'src/engine/metadata-modules/permissions/constants/permission-flag-type.constants';
 import { streamToBuffer } from 'src/utils/stream-to-buffer';
@@ -23,7 +23,7 @@ export class FileResolver {
   constructor(private readonly fileMetadataService: FileMetadataService) {}
 
   @Mutation(() => FileDTO)
-  @UseGuards(SettingsPermissionsGuard(PermissionFlagType.UPLOAD_FILE))
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.UPLOAD_FILE))
   async createFile(
     @AuthWorkspace() { id: workspaceId }: WorkspaceEntity,
     @Args({ name: 'file', type: () => GraphQLUpload })
@@ -41,7 +41,7 @@ export class FileResolver {
   }
 
   @Mutation(() => FileDTO)
-  @UseGuards(SettingsPermissionsGuard(PermissionFlagType.UPLOAD_FILE))
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.UPLOAD_FILE))
   async deleteFile(
     @AuthWorkspace() { id: workspaceId }: WorkspaceEntity,
     @Args('fileId', { type: () => UUIDScalarType }) fileId: string,

--- a/packages/twenty-server/src/engine/core-modules/imap-smtp-caldav-connection/imap-smtp-caldav-connection.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/imap-smtp-caldav-connection/imap-smtp-caldav-connection.resolver.ts
@@ -22,7 +22,7 @@ import { ImapSmtpCaldavValidatorService } from 'src/engine/core-modules/imap-smt
 import { ImapSmtpCaldavService } from 'src/engine/core-modules/imap-smtp-caldav-connection/services/imap-smtp-caldav-connection.service';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
-import { SettingsPermissionsGuard } from 'src/engine/guards/settings-permissions.guard';
+import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { PermissionFlagType } from 'src/engine/metadata-modules/permissions/constants/permission-flag-type.constants';
 import { PermissionsGraphqlApiExceptionFilter } from 'src/engine/metadata-modules/permissions/utils/permissions-graphql-api-exception.filter';
@@ -33,7 +33,7 @@ import { type ConnectedAccountWorkspaceEntity } from 'src/modules/connected-acco
 @Resolver()
 @UsePipes(ResolverValidationPipe)
 @UseFilters(AuthGraphqlApiExceptionFilter, PermissionsGraphqlApiExceptionFilter)
-@UseGuards(SettingsPermissionsGuard(PermissionFlagType.WORKSPACE))
+@UseGuards(SettingsPermissionGuard(PermissionFlagType.WORKSPACE))
 export class ImapSmtpCaldavResolver {
   constructor(
     private readonly twentyORMGlobalManager: TwentyORMGlobalManager,

--- a/packages/twenty-server/src/engine/core-modules/lab/lab.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/lab/lab.resolver.ts
@@ -11,7 +11,7 @@ import { UserInputError } from 'src/engine/core-modules/graphql/utils/graphql-er
 import { UpdateLabPublicFeatureFlagInput } from 'src/engine/core-modules/lab/dtos/update-lab-public-feature-flag.input';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
-import { SettingsPermissionsGuard } from 'src/engine/guards/settings-permissions.guard';
+import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { PermissionFlagType } from 'src/engine/metadata-modules/permissions/constants/permission-flag-type.constants';
 import { PermissionsGraphqlApiExceptionFilter } from 'src/engine/metadata-modules/permissions/utils/permissions-graphql-api-exception.filter';
@@ -23,7 +23,7 @@ import { PermissionsGraphqlApiExceptionFilter } from 'src/engine/metadata-module
   PermissionsGraphqlApiExceptionFilter,
   PreventNestToAutoLogGraphqlErrorsFilter,
 )
-@UseGuards(SettingsPermissionsGuard(PermissionFlagType.WORKSPACE))
+@UseGuards(SettingsPermissionGuard(PermissionFlagType.WORKSPACE))
 export class LabResolver {
   constructor(private featureFlagService: FeatureFlagService) {}
 

--- a/packages/twenty-server/src/engine/core-modules/page-layout/resolvers/page-layout-tab.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/page-layout/resolvers/page-layout-tab.resolver.ts
@@ -11,7 +11,7 @@ import { PageLayoutTabService } from 'src/engine/core-modules/page-layout/servic
 import { PageLayoutGraphqlApiExceptionFilter } from 'src/engine/core-modules/page-layout/utils/page-layout-graphql-api-exception.filter';
 import { type WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
-import { SettingsPermissionsGuard } from 'src/engine/guards/settings-permissions.guard';
+import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { PermissionFlagType } from 'src/engine/metadata-modules/permissions/constants/permission-flag-type.constants';
 
@@ -42,7 +42,7 @@ export class PageLayoutTabResolver {
   }
 
   @Mutation(() => PageLayoutTabDTO)
-  @UseGuards(SettingsPermissionsGuard(PermissionFlagType.LAYOUTS))
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.LAYOUTS))
   async createPageLayoutTab(
     @Args('input') input: CreatePageLayoutTabInput,
     @AuthWorkspace() workspace: WorkspaceEntity,
@@ -51,7 +51,7 @@ export class PageLayoutTabResolver {
   }
 
   @Mutation(() => PageLayoutTabDTO)
-  @UseGuards(SettingsPermissionsGuard(PermissionFlagType.LAYOUTS))
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.LAYOUTS))
   async updatePageLayoutTab(
     @Args('id', { type: () => String }) id: string,
     @Args('input') input: UpdatePageLayoutTabInput,
@@ -61,7 +61,7 @@ export class PageLayoutTabResolver {
   }
 
   @Mutation(() => Boolean)
-  @UseGuards(SettingsPermissionsGuard(PermissionFlagType.LAYOUTS))
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.LAYOUTS))
   async deletePageLayoutTab(
     @Args('id', { type: () => String }) id: string,
     @AuthWorkspace() workspace: WorkspaceEntity,
@@ -75,7 +75,7 @@ export class PageLayoutTabResolver {
   }
 
   @Mutation(() => Boolean)
-  @UseGuards(SettingsPermissionsGuard(PermissionFlagType.LAYOUTS))
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.LAYOUTS))
   async destroyPageLayoutTab(
     @Args('id', { type: () => String }) id: string,
     @AuthWorkspace() workspace: WorkspaceEntity,
@@ -84,7 +84,7 @@ export class PageLayoutTabResolver {
   }
 
   @Mutation(() => PageLayoutTabDTO)
-  @UseGuards(SettingsPermissionsGuard(PermissionFlagType.LAYOUTS))
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.LAYOUTS))
   async restorePageLayoutTab(
     @Args('id', { type: () => String }) id: string,
     @AuthWorkspace() workspace: WorkspaceEntity,

--- a/packages/twenty-server/src/engine/core-modules/page-layout/resolvers/page-layout-widget.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/page-layout/resolvers/page-layout-widget.resolver.ts
@@ -18,7 +18,7 @@ import { injectWidgetConfigurationDiscriminator } from 'src/engine/core-modules/
 import { PageLayoutGraphqlApiExceptionFilter } from 'src/engine/core-modules/page-layout/utils/page-layout-graphql-api-exception.filter';
 import { type WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
-import { SettingsPermissionsGuard } from 'src/engine/guards/settings-permissions.guard';
+import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { PermissionFlagType } from 'src/engine/metadata-modules/permissions/constants/permission-flag-type.constants';
 
@@ -51,7 +51,7 @@ export class PageLayoutWidgetResolver {
   }
 
   @Mutation(() => PageLayoutWidgetDTO)
-  @UseGuards(SettingsPermissionsGuard(PermissionFlagType.LAYOUTS))
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.LAYOUTS))
   async createPageLayoutWidget(
     @Args('input') input: CreatePageLayoutWidgetInput,
     @AuthWorkspace() workspace: WorkspaceEntity,
@@ -60,7 +60,7 @@ export class PageLayoutWidgetResolver {
   }
 
   @Mutation(() => PageLayoutWidgetDTO)
-  @UseGuards(SettingsPermissionsGuard(PermissionFlagType.LAYOUTS))
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.LAYOUTS))
   async updatePageLayoutWidget(
     @Args('id', { type: () => String }) id: string,
     @Args('input') input: UpdatePageLayoutWidgetInput,
@@ -70,7 +70,7 @@ export class PageLayoutWidgetResolver {
   }
 
   @Mutation(() => PageLayoutWidgetDTO)
-  @UseGuards(SettingsPermissionsGuard(PermissionFlagType.LAYOUTS))
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.LAYOUTS))
   async deletePageLayoutWidget(
     @Args('id', { type: () => String }) id: string,
     @AuthWorkspace() workspace: WorkspaceEntity,
@@ -79,7 +79,7 @@ export class PageLayoutWidgetResolver {
   }
 
   @Mutation(() => Boolean)
-  @UseGuards(SettingsPermissionsGuard(PermissionFlagType.LAYOUTS))
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.LAYOUTS))
   async destroyPageLayoutWidget(
     @Args('id', { type: () => String }) id: string,
     @AuthWorkspace() workspace: WorkspaceEntity,
@@ -88,7 +88,7 @@ export class PageLayoutWidgetResolver {
   }
 
   @Mutation(() => PageLayoutWidgetDTO)
-  @UseGuards(SettingsPermissionsGuard(PermissionFlagType.LAYOUTS))
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.LAYOUTS))
   async restorePageLayoutWidget(
     @Args('id', { type: () => String }) id: string,
     @AuthWorkspace() workspace: WorkspaceEntity,

--- a/packages/twenty-server/src/engine/core-modules/page-layout/resolvers/page-layout.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/page-layout/resolvers/page-layout.resolver.ts
@@ -13,7 +13,7 @@ import { PageLayoutService } from 'src/engine/core-modules/page-layout/services/
 import { PageLayoutGraphqlApiExceptionFilter } from 'src/engine/core-modules/page-layout/utils/page-layout-graphql-api-exception.filter';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
-import { SettingsPermissionsGuard } from 'src/engine/guards/settings-permissions.guard';
+import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { PermissionFlagType } from 'src/engine/metadata-modules/permissions/constants/permission-flag-type.constants';
 
@@ -21,7 +21,7 @@ import { PermissionFlagType } from 'src/engine/metadata-modules/permissions/cons
 @UseFilters(PageLayoutGraphqlApiExceptionFilter)
 @UseGuards(
   WorkspaceAuthGuard,
-  SettingsPermissionsGuard(PermissionFlagType.LAYOUTS),
+  SettingsPermissionGuard(PermissionFlagType.LAYOUTS),
 )
 @UsePipes(ResolverValidationPipe)
 export class PageLayoutResolver {

--- a/packages/twenty-server/src/engine/core-modules/postgres-credentials/postgres-credentials.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/postgres-credentials/postgres-credentials.resolver.ts
@@ -5,13 +5,13 @@ import { PostgresCredentialsDTO } from 'src/engine/core-modules/postgres-credent
 import { PostgresCredentialsService } from 'src/engine/core-modules/postgres-credentials/postgres-credentials.service';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
-import { SettingsPermissionsGuard } from 'src/engine/guards/settings-permissions.guard';
+import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { PermissionFlagType } from 'src/engine/metadata-modules/permissions/constants/permission-flag-type.constants';
 
 @UseGuards(
   WorkspaceAuthGuard,
-  SettingsPermissionsGuard(PermissionFlagType.DATA_MODEL),
+  SettingsPermissionGuard(PermissionFlagType.DATA_MODEL),
 )
 @Resolver(() => PostgresCredentialsDTO)
 export class PostgresCredentialsResolver {

--- a/packages/twenty-server/src/engine/core-modules/public-domain/public-domain.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/public-domain/public-domain.resolver.ts
@@ -20,13 +20,13 @@ import {
 import { PublicDomainService } from 'src/engine/core-modules/public-domain/public-domain.service';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
-import { SettingsPermissionsGuard } from 'src/engine/guards/settings-permissions.guard';
+import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { PermissionFlagType } from 'src/engine/metadata-modules/permissions/constants/permission-flag-type.constants';
 
 @UseGuards(
   WorkspaceAuthGuard,
-  SettingsPermissionsGuard(PermissionFlagType.WORKSPACE_MEMBERS),
+  SettingsPermissionGuard(PermissionFlagType.WORKSPACE_MEMBERS),
 )
 @UsePipes(ResolverValidationPipe)
 @UseFilters(

--- a/packages/twenty-server/src/engine/core-modules/sso/sso.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/sso/sso.resolver.ts
@@ -20,7 +20,7 @@ import { SSOService } from 'src/engine/core-modules/sso/services/sso.service';
 import { type SSOException } from 'src/engine/core-modules/sso/sso.exception';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
-import { SettingsPermissionsGuard } from 'src/engine/guards/settings-permissions.guard';
+import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { PermissionFlagType } from 'src/engine/metadata-modules/permissions/constants/permission-flag-type.constants';
 import { PermissionsGraphqlApiExceptionFilter } from 'src/engine/metadata-modules/permissions/utils/permissions-graphql-api-exception.filter';
@@ -31,7 +31,7 @@ import { PermissionsGraphqlApiExceptionFilter } from 'src/engine/metadata-module
   PreventNestToAutoLogGraphqlErrorsFilter,
 )
 @UsePipes(ResolverValidationPipe)
-@UseGuards(SettingsPermissionsGuard(PermissionFlagType.SECURITY))
+@UseGuards(SettingsPermissionGuard(PermissionFlagType.SECURITY))
 export class SSOResolver {
   constructor(private readonly sSOService: SSOService) {}
 

--- a/packages/twenty-server/src/engine/core-modules/webhook/webhook.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/webhook/webhook.resolver.ts
@@ -10,7 +10,7 @@ import { UpdateWebhookInput } from 'src/engine/core-modules/webhook/dtos/update-
 import { webhookGraphqlApiExceptionHandler } from 'src/engine/core-modules/webhook/utils/webhook-graphql-api-exception-handler.util';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
-import { SettingsPermissionsGuard } from 'src/engine/guards/settings-permissions.guard';
+import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { PermissionFlagType } from 'src/engine/metadata-modules/permissions/constants/permission-flag-type.constants';
 
@@ -20,7 +20,7 @@ import { WebhookService } from './webhook.service';
 @Resolver(() => WebhookEntity)
 @UseGuards(
   WorkspaceAuthGuard,
-  SettingsPermissionsGuard(PermissionFlagType.API_KEYS_AND_WEBHOOKS),
+  SettingsPermissionGuard(PermissionFlagType.API_KEYS_AND_WEBHOOKS),
 )
 export class WebhookResolver {
   constructor(private readonly webhookService: WebhookService) {}

--- a/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-builder.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-builder.resolver.ts
@@ -9,7 +9,7 @@ import { ComputeStepOutputSchemaInput } from 'src/engine/core-modules/workflow/d
 import { WorkflowTriggerGraphqlApiExceptionFilter } from 'src/engine/core-modules/workflow/filters/workflow-trigger-graphql-api-exception.filter';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
-import { SettingsPermissionsGuard } from 'src/engine/guards/settings-permissions.guard';
+import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { UserAuthGuard } from 'src/engine/guards/user-auth.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { PermissionFlagType } from 'src/engine/metadata-modules/permissions/constants/permission-flag-type.constants';
@@ -21,7 +21,7 @@ import { WorkflowSchemaWorkspaceService } from 'src/modules/workflow/workflow-bu
 @UseGuards(
   WorkspaceAuthGuard,
   UserAuthGuard,
-  SettingsPermissionsGuard(PermissionFlagType.WORKFLOWS),
+  SettingsPermissionGuard(PermissionFlagType.WORKFLOWS),
 )
 @UsePipes(ResolverValidationPipe)
 @UseFilters(

--- a/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-trigger.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-trigger.resolver.ts
@@ -13,7 +13,7 @@ import { WorkflowTriggerGraphqlApiExceptionFilter } from 'src/engine/core-module
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AuthUser } from 'src/engine/decorators/auth/auth-user.decorator';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
-import { SettingsPermissionsGuard } from 'src/engine/guards/settings-permissions.guard';
+import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { UserAuthGuard } from 'src/engine/guards/user-auth.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { PermissionFlagType } from 'src/engine/metadata-modules/permissions/constants/permission-flag-type.constants';
@@ -26,7 +26,7 @@ import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/sta
 @UseGuards(
   WorkspaceAuthGuard,
   UserAuthGuard,
-  SettingsPermissionsGuard(PermissionFlagType.WORKFLOWS),
+  SettingsPermissionGuard(PermissionFlagType.WORKFLOWS),
 )
 @UsePipes(ResolverValidationPipe)
 @UseFilters(

--- a/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-version-edge.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-version-edge.resolver.ts
@@ -8,7 +8,7 @@ import { WorkflowVersionStepChangesDTO } from 'src/engine/core-modules/workflow/
 import { WorkflowVersionEdgeGraphqlApiExceptionFilter } from 'src/engine/core-modules/workflow/filters/workflow-version-edge-graphql-api-exception.filter';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
-import { SettingsPermissionsGuard } from 'src/engine/guards/settings-permissions.guard';
+import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { UserAuthGuard } from 'src/engine/guards/user-auth.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { PermissionFlagType } from 'src/engine/metadata-modules/permissions/constants/permission-flag-type.constants';
@@ -20,7 +20,7 @@ import { WorkflowVersionEdgeWorkspaceService } from 'src/modules/workflow/workfl
 @UseGuards(
   WorkspaceAuthGuard,
   UserAuthGuard,
-  SettingsPermissionsGuard(PermissionFlagType.WORKFLOWS),
+  SettingsPermissionGuard(PermissionFlagType.WORKFLOWS),
 )
 @UseFilters(
   PermissionsGraphqlApiExceptionFilter,

--- a/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-version-step.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-version-step.resolver.ts
@@ -20,7 +20,7 @@ import { WorkflowVersionStepChangesDTO } from 'src/engine/core-modules/workflow/
 import { WorkflowVersionStepGraphqlApiExceptionFilter } from 'src/engine/core-modules/workflow/filters/workflow-version-step-graphql-api-exception.filter';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
-import { SettingsPermissionsGuard } from 'src/engine/guards/settings-permissions.guard';
+import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { UserAuthGuard } from 'src/engine/guards/user-auth.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { PermissionFlagType } from 'src/engine/metadata-modules/permissions/constants/permission-flag-type.constants';
@@ -35,7 +35,7 @@ import { WorkflowRunnerWorkspaceService } from 'src/modules/workflow/workflow-ru
 @UseGuards(
   WorkspaceAuthGuard,
   UserAuthGuard,
-  SettingsPermissionsGuard(PermissionFlagType.WORKFLOWS),
+  SettingsPermissionGuard(PermissionFlagType.WORKFLOWS),
 )
 @UseFilters(
   PermissionsGraphqlApiExceptionFilter,

--- a/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-version.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-version.resolver.ts
@@ -8,7 +8,7 @@ import { UpdateWorkflowVersionPositionsInput } from 'src/engine/core-modules/wor
 import { WorkflowVersionDTO } from 'src/engine/core-modules/workflow/dtos/workflow-version.dto';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
-import { SettingsPermissionsGuard } from 'src/engine/guards/settings-permissions.guard';
+import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { UserAuthGuard } from 'src/engine/guards/user-auth.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { PermissionFlagType } from 'src/engine/metadata-modules/permissions/constants/permission-flag-type.constants';
@@ -20,7 +20,7 @@ import { WorkflowVersionWorkspaceService } from 'src/modules/workflow/workflow-b
 @UseGuards(
   WorkspaceAuthGuard,
   UserAuthGuard,
-  SettingsPermissionsGuard(PermissionFlagType.WORKFLOWS),
+  SettingsPermissionGuard(PermissionFlagType.WORKFLOWS),
 )
 @UseFilters(
   PermissionsGraphqlApiExceptionFilter,

--- a/packages/twenty-server/src/engine/core-modules/workspace-invitation/workspace-invitation.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace-invitation/workspace-invitation.resolver.ts
@@ -11,7 +11,7 @@ import { WorkspaceInvitationService } from 'src/engine/core-modules/workspace-in
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AuthUser } from 'src/engine/decorators/auth/auth-user.decorator';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
-import { SettingsPermissionsGuard } from 'src/engine/guards/settings-permissions.guard';
+import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { UserAuthGuard } from 'src/engine/guards/user-auth.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { PermissionFlagType } from 'src/engine/metadata-modules/permissions/constants/permission-flag-type.constants';
@@ -23,7 +23,7 @@ import { SendInvitationsInput } from './dtos/send-invitations.input';
 
 @UseGuards(
   WorkspaceAuthGuard,
-  SettingsPermissionsGuard(PermissionFlagType.WORKSPACE_MEMBERS),
+  SettingsPermissionGuard(PermissionFlagType.WORKSPACE_MEMBERS),
 )
 @UsePipes(ResolverValidationPipe)
 @UseFilters(

--- a/packages/twenty-server/src/engine/core-modules/workspace/workspace.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/workspace.resolver.ts
@@ -62,7 +62,7 @@ import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorat
 import { CustomPermissionGuard } from 'src/engine/guards/custom-permission.guard';
 import { NoPermissionGuard } from 'src/engine/guards/no-permission.guard';
 import { PublicEndpointGuard } from 'src/engine/guards/public-endpoint.guard';
-import { SettingsPermissionsGuard } from 'src/engine/guards/settings-permissions.guard';
+import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { UserAuthGuard } from 'src/engine/guards/user-auth.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { PermissionFlagType } from 'src/engine/metadata-modules/permissions/constants/permission-flag-type.constants';
@@ -148,7 +148,7 @@ export class WorkspaceResolver {
   @Mutation(() => SignedFileDTO)
   @UseGuards(
     WorkspaceAuthGuard,
-    SettingsPermissionsGuard(PermissionFlagType.WORKSPACE),
+    SettingsPermissionGuard(PermissionFlagType.WORKSPACE),
   )
   async uploadWorkspaceLogo(
     @AuthWorkspace() { id }: WorkspaceEntity,
@@ -194,7 +194,7 @@ export class WorkspaceResolver {
   @Mutation(() => WorkspaceEntity)
   @UseGuards(
     WorkspaceAuthGuard,
-    SettingsPermissionsGuard(PermissionFlagType.WORKSPACE),
+    SettingsPermissionGuard(PermissionFlagType.WORKSPACE),
   )
   async deleteCurrentWorkspace(@AuthWorkspace() { id }: WorkspaceEntity) {
     return this.workspaceService.deleteWorkspace(id);
@@ -386,7 +386,7 @@ export class WorkspaceResolver {
   @Mutation(() => DomainValidRecords, { nullable: true })
   @UseGuards(
     WorkspaceAuthGuard,
-    SettingsPermissionsGuard(PermissionFlagType.WORKSPACE),
+    SettingsPermissionGuard(PermissionFlagType.WORKSPACE),
   )
   async checkCustomDomainValidRecords(
     @AuthWorkspace() workspace: WorkspaceEntity,

--- a/packages/twenty-server/src/engine/guards/__tests__/settings-permission.guard.spec.ts
+++ b/packages/twenty-server/src/engine/guards/__tests__/settings-permission.guard.spec.ts
@@ -3,12 +3,12 @@ import { GqlExecutionContext } from '@nestjs/graphql';
 
 import { WorkspaceActivationStatus } from 'twenty-shared/workspace';
 
-import { SettingsPermissionsGuard } from 'src/engine/guards/settings-permissions.guard';
+import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { PermissionFlagType } from 'src/engine/metadata-modules/permissions/constants/permission-flag-type.constants';
 import { PermissionsException } from 'src/engine/metadata-modules/permissions/permissions.exception';
 import { type PermissionsService } from 'src/engine/metadata-modules/permissions/permissions.service';
 
-describe('SettingsPermissionsGuard', () => {
+describe('SettingsPermissionGuard', () => {
   let guard: any;
   let mockPermissionsService: jest.Mocked<PermissionsService>;
   let mockExecutionContext: ExecutionContext;
@@ -36,7 +36,7 @@ describe('SettingsPermissionsGuard', () => {
       .spyOn(GqlExecutionContext, 'create')
       .mockReturnValue({ getContext: () => mockGqlContext } as any);
 
-    const GuardClass = SettingsPermissionsGuard(PermissionFlagType.WORKSPACE);
+    const GuardClass = SettingsPermissionGuard(PermissionFlagType.WORKSPACE);
 
     guard = new GuardClass(mockPermissionsService);
   });

--- a/packages/twenty-server/src/engine/guards/custom-permission.guard.ts
+++ b/packages/twenty-server/src/engine/guards/custom-permission.guard.ts
@@ -9,7 +9,7 @@ import {
 // has custom permission checks implemented within the resolver method itself
 //
 // Use this when you need custom permission validation that cannot be expressed
-// with standard SettingsPermissionsGuard
+// with standard SettingsPermissionGuard
 //
 // Examples of when to use CustomPermissionGuard:
 // - Self-only operations (users can only modify their own data)

--- a/packages/twenty-server/src/engine/guards/no-permission.guard.ts
+++ b/packages/twenty-server/src/engine/guards/no-permission.guard.ts
@@ -15,7 +15,7 @@ import {
 //
 // Examples: activateWorkspace (onboarding), user profile updates
 //
-// WARNING: Use sparingly! Most mutations should use SettingsPermissionsGuard
+// WARNING: Use sparingly! Most mutations should use SettingsPermissionGuard
 // If you're unsure, use CustomPermissionGuard and implement checks in the method
 @Injectable()
 export class NoPermissionGuard implements CanActivate {

--- a/packages/twenty-server/src/engine/guards/settings-permission.guard.ts
+++ b/packages/twenty-server/src/engine/guards/settings-permission.guard.ts
@@ -18,11 +18,11 @@ import {
 } from 'src/engine/metadata-modules/permissions/permissions.exception';
 import { PermissionsService } from 'src/engine/metadata-modules/permissions/permissions.service';
 
-export const SettingsPermissionsGuard = (
+export const SettingsPermissionGuard = (
   requiredPermission: PermissionFlagType,
 ): Type<CanActivate> => {
   @Injectable()
-  class SettingsPermissionsMixin implements CanActivate {
+  class SettingsPermissionMixin implements CanActivate {
     constructor(private readonly permissionsService: PermissionsService) {}
 
     async canActivate(context: ExecutionContext): Promise<boolean> {
@@ -63,5 +63,5 @@ export const SettingsPermissionsGuard = (
     }
   }
 
-  return mixin(SettingsPermissionsMixin);
+  return mixin(SettingsPermissionMixin);
 };

--- a/packages/twenty-server/src/engine/metadata-modules/agent/agent-chat.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/agent/agent-chat.resolver.ts
@@ -8,7 +8,7 @@ import {
   FeatureFlagGuard,
   RequireFeatureFlag,
 } from 'src/engine/guards/feature-flag.guard';
-import { SettingsPermissionsGuard } from 'src/engine/guards/settings-permissions.guard';
+import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { AgentChatService } from 'src/engine/metadata-modules/agent/agent-chat.service';
 import { PermissionFlagType } from 'src/engine/metadata-modules/permissions/constants/permission-flag-type.constants';
@@ -19,7 +19,7 @@ import { AgentChatThreadDTO } from './dtos/agent-chat-thread.dto';
 @UseGuards(
   WorkspaceAuthGuard,
   FeatureFlagGuard,
-  SettingsPermissionsGuard(PermissionFlagType.AI),
+  SettingsPermissionGuard(PermissionFlagType.AI),
 )
 @Resolver()
 export class AgentChatResolver {

--- a/packages/twenty-server/src/engine/metadata-modules/agent/agent.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/agent/agent.resolver.ts
@@ -8,7 +8,7 @@ import {
   FeatureFlagGuard,
   RequireFeatureFlag,
 } from 'src/engine/guards/feature-flag.guard';
-import { SettingsPermissionsGuard } from 'src/engine/guards/settings-permissions.guard';
+import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { CreateAgentHandoffInput } from 'src/engine/metadata-modules/agent/dtos/create-agent-handoff.input';
 import { RemoveAgentHandoffInput } from 'src/engine/metadata-modules/agent/dtos/remove-agent-handoff.input';
@@ -72,7 +72,7 @@ export class AgentResolver {
 
   @Mutation(() => AgentDTO)
   @RequireFeatureFlag(FeatureFlagKey.IS_AI_ENABLED)
-  @UseGuards(SettingsPermissionsGuard(PermissionFlagType.AI_SETTINGS))
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.AI_SETTINGS))
   async createOneAgent(
     @Args('input') input: CreateAgentInput,
     @AuthWorkspace() { id: workspaceId }: WorkspaceEntity,
@@ -85,7 +85,7 @@ export class AgentResolver {
 
   @Mutation(() => AgentDTO)
   @RequireFeatureFlag(FeatureFlagKey.IS_AI_ENABLED)
-  @UseGuards(SettingsPermissionsGuard(PermissionFlagType.AI_SETTINGS))
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.AI_SETTINGS))
   async updateOneAgent(
     @Args('input') input: UpdateAgentInput,
     @AuthWorkspace() { id: workspaceId }: WorkspaceEntity,
@@ -95,7 +95,7 @@ export class AgentResolver {
 
   @Mutation(() => AgentDTO)
   @RequireFeatureFlag(FeatureFlagKey.IS_AI_ENABLED)
-  @UseGuards(SettingsPermissionsGuard(PermissionFlagType.AI_SETTINGS))
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.AI_SETTINGS))
   async deleteOneAgent(
     @Args('input') { id }: AgentIdInput,
     @AuthWorkspace() { id: workspaceId }: WorkspaceEntity,
@@ -105,7 +105,7 @@ export class AgentResolver {
 
   @Mutation(() => Boolean)
   @RequireFeatureFlag(FeatureFlagKey.IS_AI_ENABLED)
-  @UseGuards(SettingsPermissionsGuard(PermissionFlagType.AI_SETTINGS))
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.AI_SETTINGS))
   async createAgentHandoff(
     @Args('input') input: CreateAgentHandoffInput,
     @AuthWorkspace() { id: workspaceId }: WorkspaceEntity,
@@ -122,7 +122,7 @@ export class AgentResolver {
 
   @Mutation(() => Boolean)
   @RequireFeatureFlag(FeatureFlagKey.IS_AI_ENABLED)
-  @UseGuards(SettingsPermissionsGuard(PermissionFlagType.AI_SETTINGS))
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.AI_SETTINGS))
   async removeAgentHandoff(
     @Args('input') input: RemoveAgentHandoffInput,
     @AuthWorkspace() { id: workspaceId }: WorkspaceEntity,

--- a/packages/twenty-server/src/engine/metadata-modules/cron-trigger/resolvers/cron-trigger.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/cron-trigger/resolvers/cron-trigger.resolver.ts
@@ -8,7 +8,7 @@ import { PreventNestToAutoLogGraphqlErrorsFilter } from 'src/engine/core-modules
 import { ResolverValidationPipe } from 'src/engine/core-modules/graphql/pipes/resolver-validation.pipe';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
-import { SettingsPermissionsGuard } from 'src/engine/guards/settings-permissions.guard';
+import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { CreateCronTriggerInput } from 'src/engine/metadata-modules/cron-trigger/dtos/create-cron-trigger.input';
 import { CronTriggerIdInput } from 'src/engine/metadata-modules/cron-trigger/dtos/cron-trigger-id.input';
@@ -21,7 +21,7 @@ import { PermissionFlagType } from 'src/engine/metadata-modules/permissions/cons
 
 @UseGuards(
   WorkspaceAuthGuard,
-  SettingsPermissionsGuard(PermissionFlagType.WORKFLOWS),
+  SettingsPermissionGuard(PermissionFlagType.WORKFLOWS),
 )
 @Resolver()
 @UsePipes(ResolverValidationPipe)

--- a/packages/twenty-server/src/engine/metadata-modules/database-event-trigger/resolvers/database-event-trigger.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/database-event-trigger/resolvers/database-event-trigger.resolver.ts
@@ -8,7 +8,7 @@ import { PreventNestToAutoLogGraphqlErrorsFilter } from 'src/engine/core-modules
 import { ResolverValidationPipe } from 'src/engine/core-modules/graphql/pipes/resolver-validation.pipe';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
-import { SettingsPermissionsGuard } from 'src/engine/guards/settings-permissions.guard';
+import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { CreateDatabaseEventTriggerInput } from 'src/engine/metadata-modules/database-event-trigger/dtos/create-database-event-trigger.input';
 import { DatabaseEventTriggerIdInput } from 'src/engine/metadata-modules/database-event-trigger/dtos/database-event-trigger-id.input';
@@ -21,7 +21,7 @@ import { PermissionFlagType } from 'src/engine/metadata-modules/permissions/cons
 
 @UseGuards(
   WorkspaceAuthGuard,
-  SettingsPermissionsGuard(PermissionFlagType.WORKFLOWS),
+  SettingsPermissionGuard(PermissionFlagType.WORKFLOWS),
 )
 @Resolver()
 @UsePipes(ResolverValidationPipe)

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/field-metadata.resolver.ts
@@ -23,7 +23,7 @@ import { I18nContext } from 'src/engine/core-modules/i18n/types/i18n-context.typ
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { type IDataloaders } from 'src/engine/dataloaders/dataloader.interface';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
-import { SettingsPermissionsGuard } from 'src/engine/guards/settings-permissions.guard';
+import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { CreateOneFieldMetadataInput } from 'src/engine/metadata-modules/field-metadata/dtos/create-field.input';
 import { DeleteOneFieldInput } from 'src/engine/metadata-modules/field-metadata/dtos/delete-field.input';
@@ -56,7 +56,7 @@ export class FieldMetadataResolver {
     private readonly i18nService: I18nService,
   ) {}
 
-  @UseGuards(SettingsPermissionsGuard(PermissionFlagType.DATA_MODEL))
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.DATA_MODEL))
   @Mutation(() => FieldMetadataDTO)
   async createOneField(
     @Args('input') input: CreateOneFieldMetadataInput,
@@ -76,7 +76,7 @@ export class FieldMetadataResolver {
     }
   }
 
-  @UseGuards(SettingsPermissionsGuard(PermissionFlagType.DATA_MODEL))
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.DATA_MODEL))
   @Mutation(() => FieldMetadataDTO)
   async updateOneField(
     @Args('input') input: UpdateOneFieldMetadataInput,
@@ -114,7 +114,7 @@ export class FieldMetadataResolver {
     }
   }
 
-  @UseGuards(SettingsPermissionsGuard(PermissionFlagType.DATA_MODEL))
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.DATA_MODEL))
   @Mutation(() => FieldMetadataDTO)
   async deleteOneField(
     @Args('input') input: DeleteOneFieldInput,

--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.module.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.module.ts
@@ -11,7 +11,7 @@ import { NestjsQueryTypeOrmModule } from '@ptc-org/nestjs-query-typeorm';
 import { TypeORMModule } from 'src/database/typeorm/typeorm.module';
 import { FeatureFlagEntity } from 'src/engine/core-modules/feature-flag/feature-flag.entity';
 import { FeatureFlagModule } from 'src/engine/core-modules/feature-flag/feature-flag.module';
-import { SettingsPermissionsGuard } from 'src/engine/guards/settings-permissions.guard';
+import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { DataSourceModule } from 'src/engine/metadata-modules/data-source/data-source.module';
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
@@ -98,7 +98,7 @@ import { WorkspaceMigrationV2Module } from 'src/engine/workspace-manager/workspa
           },
           create: {
             many: { disabled: true },
-            guards: [SettingsPermissionsGuard(PermissionFlagType.DATA_MODEL)],
+            guards: [SettingsPermissionGuard(PermissionFlagType.DATA_MODEL)],
           },
           update: { disabled: true },
           delete: { disabled: true },

--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.resolver.ts
@@ -17,7 +17,7 @@ import { I18nContext } from 'src/engine/core-modules/i18n/types/i18n-context.typ
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { type IDataloaders } from 'src/engine/dataloaders/dataloader.interface';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
-import { SettingsPermissionsGuard } from 'src/engine/guards/settings-permissions.guard';
+import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { FieldMetadataDTO } from 'src/engine/metadata-modules/field-metadata/dtos/field-metadata.dto';
 import { IndexMetadataDTO } from 'src/engine/metadata-modules/index-metadata/dtos/index-metadata.dto';
@@ -96,7 +96,7 @@ export class ObjectMetadataResolver {
     );
   }
 
-  @UseGuards(SettingsPermissionsGuard(PermissionFlagType.DATA_MODEL))
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.DATA_MODEL))
   @ResolveField(() => String, { nullable: true })
   async icon(
     @Parent() objectMetadata: ObjectMetadataDTO,
@@ -112,7 +112,7 @@ export class ObjectMetadataResolver {
     );
   }
 
-  @UseGuards(SettingsPermissionsGuard(PermissionFlagType.DATA_MODEL))
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.DATA_MODEL))
   @Mutation(() => ObjectMetadataDTO)
   async deleteOneObject(
     @Args('input') input: DeleteOneObjectInput,
@@ -132,7 +132,7 @@ export class ObjectMetadataResolver {
     }
   }
 
-  @UseGuards(SettingsPermissionsGuard(PermissionFlagType.DATA_MODEL))
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.DATA_MODEL))
   @Mutation(() => ObjectMetadataDTO)
   async updateOneObject(
     @Args('input') updateObjectInput: UpdateOneObjectInput,

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-server.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-server.resolver.ts
@@ -5,7 +5,7 @@ import { PreventNestToAutoLogGraphqlErrorsFilter } from 'src/engine/core-modules
 import { ResolverValidationPipe } from 'src/engine/core-modules/graphql/pipes/resolver-validation.pipe';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
-import { SettingsPermissionsGuard } from 'src/engine/guards/settings-permissions.guard';
+import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { PermissionFlagType } from 'src/engine/metadata-modules/permissions/constants/permission-flag-type.constants';
 import { CreateRemoteServerInput } from 'src/engine/metadata-modules/remote-server/dtos/create-remote-server.input';
@@ -27,7 +27,7 @@ export class RemoteServerResolver {
   ) {}
 
   @Mutation(() => RemoteServerDTO)
-  @UseGuards(SettingsPermissionsGuard(PermissionFlagType.DATA_MODEL))
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.DATA_MODEL))
   async createOneRemoteServer(
     @Args('input') input: CreateRemoteServerInput<RemoteServerType>,
     @AuthWorkspace() { id: workspaceId }: WorkspaceEntity,
@@ -43,7 +43,7 @@ export class RemoteServerResolver {
   }
 
   @Mutation(() => RemoteServerDTO)
-  @UseGuards(SettingsPermissionsGuard(PermissionFlagType.DATA_MODEL))
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.DATA_MODEL))
   async updateOneRemoteServer(
     @Args('input') input: UpdateRemoteServerInput<RemoteServerType>,
     @AuthWorkspace() { id: workspaceId }: WorkspaceEntity,
@@ -59,7 +59,7 @@ export class RemoteServerResolver {
   }
 
   @Mutation(() => RemoteServerDTO)
-  @UseGuards(SettingsPermissionsGuard(PermissionFlagType.DATA_MODEL))
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.DATA_MODEL))
   async deleteOneRemoteServer(
     @Args('input') { id }: RemoteServerIdInput,
     @AuthWorkspace() { id: workspaceId }: WorkspaceEntity,

--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-table.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/remote-table.resolver.ts
@@ -5,7 +5,7 @@ import { PreventNestToAutoLogGraphqlErrorsFilter } from 'src/engine/core-modules
 import { ResolverValidationPipe } from 'src/engine/core-modules/graphql/pipes/resolver-validation.pipe';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
-import { SettingsPermissionsGuard } from 'src/engine/guards/settings-permissions.guard';
+import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { PermissionFlagType } from 'src/engine/metadata-modules/permissions/constants/permission-flag-type.constants';
 import { FindManyRemoteTablesInput } from 'src/engine/metadata-modules/remote-server/remote-table/dtos/find-many-remote-tables-input';
@@ -38,7 +38,7 @@ export class RemoteTableResolver {
   }
 
   @Mutation(() => RemoteTableDTO)
-  @UseGuards(SettingsPermissionsGuard(PermissionFlagType.DATA_MODEL))
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.DATA_MODEL))
   async syncRemoteTable(
     @Args('input') input: RemoteTableInput,
     @AuthWorkspace() { id: workspaceId }: WorkspaceEntity,
@@ -51,7 +51,7 @@ export class RemoteTableResolver {
   }
 
   @Mutation(() => RemoteTableDTO)
-  @UseGuards(SettingsPermissionsGuard(PermissionFlagType.DATA_MODEL))
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.DATA_MODEL))
   async unsyncRemoteTable(
     @Args('input') input: RemoteTableInput,
     @AuthWorkspace() { id: workspaceId }: WorkspaceEntity,
@@ -67,7 +67,7 @@ export class RemoteTableResolver {
   }
 
   @Mutation(() => RemoteTableDTO)
-  @UseGuards(SettingsPermissionsGuard(PermissionFlagType.DATA_MODEL))
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.DATA_MODEL))
   async syncRemoteTableSchemaChanges(
     @Args('input') input: RemoteTableInput,
     @AuthWorkspace() { id: workspaceId }: WorkspaceEntity,

--- a/packages/twenty-server/src/engine/metadata-modules/role/role.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/role/role.resolver.ts
@@ -21,7 +21,7 @@ import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.ent
 import { AuthWorkspaceMemberId } from 'src/engine/decorators/auth/auth-workspace-member-id.decorator';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
 import { RequireFeatureFlag } from 'src/engine/guards/feature-flag.guard';
-import { SettingsPermissionsGuard } from 'src/engine/guards/settings-permissions.guard';
+import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { UserAuthGuard } from 'src/engine/guards/user-auth.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { AgentRoleService } from 'src/engine/metadata-modules/agent-role/agent-role.service';
@@ -56,7 +56,7 @@ import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/sta
 @UsePipes(ResolverValidationPipe)
 @UseGuards(
   WorkspaceAuthGuard,
-  SettingsPermissionsGuard(PermissionFlagType.ROLES),
+  SettingsPermissionGuard(PermissionFlagType.ROLES),
 )
 @UseFilters(
   PermissionsGraphqlApiExceptionFilter,

--- a/packages/twenty-server/src/engine/metadata-modules/route-trigger/resolvers/route-trigger.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/route-trigger/resolvers/route-trigger.resolver.ts
@@ -8,7 +8,7 @@ import { PreventNestToAutoLogGraphqlErrorsFilter } from 'src/engine/core-modules
 import { ResolverValidationPipe } from 'src/engine/core-modules/graphql/pipes/resolver-validation.pipe';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
-import { SettingsPermissionsGuard } from 'src/engine/guards/settings-permissions.guard';
+import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { PermissionFlagType } from 'src/engine/metadata-modules/permissions/constants/permission-flag-type.constants';
 import { PermissionsGraphqlApiExceptionFilter } from 'src/engine/metadata-modules/permissions/utils/permissions-graphql-api-exception.filter';
@@ -22,7 +22,7 @@ import { routeTriggerGraphQLApiExceptionHandler } from 'src/engine/metadata-modu
 
 @UseGuards(
   WorkspaceAuthGuard,
-  SettingsPermissionsGuard(PermissionFlagType.WORKFLOWS),
+  SettingsPermissionGuard(PermissionFlagType.WORKFLOWS),
 )
 @Resolver()
 @UsePipes(ResolverValidationPipe)

--- a/packages/twenty-server/src/engine/metadata-modules/serverless-function-layer/serverless-function-layer.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/serverless-function-layer/serverless-function-layer.resolver.ts
@@ -3,7 +3,7 @@ import { Args, Mutation, Resolver } from '@nestjs/graphql';
 
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
-import { SettingsPermissionsGuard } from 'src/engine/guards/settings-permissions.guard';
+import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { PermissionFlagType } from 'src/engine/metadata-modules/permissions/constants/permission-flag-type.constants';
 import { CreateServerlessFunctionLayerInput } from 'src/engine/metadata-modules/serverless-function-layer/dtos/create-serverless-function-layer.input';
@@ -18,7 +18,7 @@ export class ServerlessFunctionLayerResolver {
   ) {}
 
   @Mutation(() => ServerlessFunctionLayerDTO)
-  @UseGuards(SettingsPermissionsGuard(PermissionFlagType.WORKFLOWS))
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.WORKFLOWS))
   async createOneServerlessFunctionLayer(
     @Args()
     createServerlessFunctionLayerInput: CreateServerlessFunctionLayerInput,

--- a/packages/twenty-server/src/engine/metadata-modules/serverless-function/serverless-function.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/serverless-function/serverless-function.resolver.ts
@@ -10,7 +10,7 @@ import { ResolverValidationPipe } from 'src/engine/core-modules/graphql/pipes/re
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
 import { FeatureFlagGuard } from 'src/engine/guards/feature-flag.guard';
-import { SettingsPermissionsGuard } from 'src/engine/guards/settings-permissions.guard';
+import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { PermissionFlagType } from 'src/engine/metadata-modules/permissions/constants/permission-flag-type.constants';
 import { CreateServerlessFunctionInput } from 'src/engine/metadata-modules/serverless-function/dtos/create-serverless-function.input';
@@ -94,7 +94,7 @@ export class ServerlessFunctionResolver {
   }
 
   @Mutation(() => ServerlessFunctionDTO)
-  @UseGuards(SettingsPermissionsGuard(PermissionFlagType.WORKFLOWS))
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.WORKFLOWS))
   async deleteOneServerlessFunction(
     @Args('input') input: ServerlessFunctionIdInput,
     @AuthWorkspace() { id: workspaceId }: WorkspaceEntity,
@@ -110,7 +110,7 @@ export class ServerlessFunctionResolver {
   }
 
   @Mutation(() => ServerlessFunctionDTO)
-  @UseGuards(SettingsPermissionsGuard(PermissionFlagType.WORKFLOWS))
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.WORKFLOWS))
   async updateOneServerlessFunction(
     @Args('input')
     input: UpdateServerlessFunctionInput,
@@ -127,7 +127,7 @@ export class ServerlessFunctionResolver {
   }
 
   @Mutation(() => ServerlessFunctionDTO)
-  @UseGuards(SettingsPermissionsGuard(PermissionFlagType.WORKFLOWS))
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.WORKFLOWS))
   async createOneServerlessFunction(
     @Args('input')
     input: CreateServerlessFunctionInput,
@@ -144,7 +144,7 @@ export class ServerlessFunctionResolver {
   }
 
   @Mutation(() => ServerlessFunctionExecutionResultDTO)
-  @UseGuards(SettingsPermissionsGuard(PermissionFlagType.WORKFLOWS))
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.WORKFLOWS))
   async executeOneServerlessFunction(
     @Args('input') input: ExecuteServerlessFunctionInput,
     @AuthWorkspace() { id: workspaceId }: WorkspaceEntity,
@@ -164,7 +164,7 @@ export class ServerlessFunctionResolver {
   }
 
   @Mutation(() => ServerlessFunctionDTO)
-  @UseGuards(SettingsPermissionsGuard(PermissionFlagType.WORKFLOWS))
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.WORKFLOWS))
   async publishServerlessFunction(
     @Args('input') input: PublishServerlessFunctionInput,
     @AuthWorkspace() { id: workspaceId }: WorkspaceEntity,

--- a/packages/twenty-server/src/modules/connected-account/channel-sync/channel-sync.resolver.ts
+++ b/packages/twenty-server/src/modules/connected-account/channel-sync/channel-sync.resolver.ts
@@ -6,7 +6,7 @@ import { AuthGraphqlApiExceptionFilter } from 'src/engine/core-modules/auth/filt
 import { ResolverValidationPipe } from 'src/engine/core-modules/graphql/pipes/resolver-validation.pipe';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
-import { SettingsPermissionsGuard } from 'src/engine/guards/settings-permissions.guard';
+import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { PermissionFlagType } from 'src/engine/metadata-modules/permissions/constants/permission-flag-type.constants';
 import { ChannelSyncSuccessDTO } from 'src/modules/connected-account/channel-sync/dtos/channel-sync-success.dto';
@@ -20,7 +20,7 @@ export class ChannelSyncResolver {
   constructor(private readonly channelSyncService: ChannelSyncService) {}
 
   @Mutation(() => ChannelSyncSuccessDTO)
-  @UseGuards(SettingsPermissionsGuard(PermissionFlagType.CONNECTED_ACCOUNTS))
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.CONNECTED_ACCOUNTS))
   async startChannelSync(
     @Args('connectedAccountId', { type: () => UUIDScalarType })
     connectedAccountId: string,

--- a/tools/eslint-rules/utils/typedTokenHelpers.ts
+++ b/tools/eslint-rules/utils/typedTokenHelpers.ts
@@ -75,7 +75,7 @@ export const typedTokenHelpers = {
       ) {
         // Check if any argument ends with PermissionGuard
         return decorator.expression.arguments.some((arg) => {
-          // Factory-style guards: SettingsPermissionsGuard(PermissionFlagType.XXX)
+          // Factory-style guards: SettingsPermissionGuard(PermissionFlagType.XXX)
           if (arg.type === TSESTree.AST_NODE_TYPES.CallExpression) {
             const callee = arg.callee;
             if (callee.type === TSESTree.AST_NODE_TYPES.Identifier) {


### PR DESCRIPTION
## Problem

The ESLint rule `graphql-resolvers-should-be-guarded` introduced in #15392 was failing on main because the guard `SettingsPermissionsGuard` had inconsistent naming.

## Root Cause

The guard was named `SettingsPermissionsGuard` (with an 's') which was inconsistent with other permission guards:
- ✅ `CustomPermissionGuard`  
- ✅ `NoPermissionGuard`
- ✅ `ImpersonatePermissionGuard`
- ❌ `SettingsPermissionsGuard` (inconsistent!)

The ESLint rule checks if guard names end with `PermissionGuard`, but `SettingsPermissionsGuard` ends with `sGuard`, so it wasn't recognized as a permission guard.

## Solution

Renamed the guard to be consistent with the naming convention:

1. ✅ Renamed file: `settings-permissions.guard.ts` → `settings-permission.guard.ts`
2. ✅ Renamed export: `SettingsPermissionsGuard` → `SettingsPermissionGuard`
3. ✅ Renamed internal class: `SettingsPermissionsMixin` → `SettingsPermissionMixin`
4. ✅ Updated all 122 references across 44 files in the codebase
5. ✅ Renamed test file: `settings-permissions.guard.spec.ts` → `settings-permission.guard.spec.ts`

## Testing

- ✅ `npx nx run twenty-server:lint` passes
- ✅ `npx nx run twenty-server:typecheck` passes
- ✅ No references to the old name remain in the codebase
- ✅ All previously failing resolver files now pass ESLint validation

## Related

Fixes issues introduced in #15392