### PR TITLE
Increase QUERY_MAX_RECORDS to 10,000 and update related components to…

### DIFF
--- a/packages/twenty-front/src/modules/action-menu/actions/record-actions/run-workflow-actions/hooks/useRunWorkflowRecordActions.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-actions/run-workflow-actions/hooks/useRunWorkflowRecordActions.tsx
@@ -5,6 +5,7 @@ import { ActionType } from '@/action-menu/actions/types/ActionType';
 import { contextStoreTargetedRecordsRuleComponentState } from '@/context-store/states/contextStoreTargetedRecordsRuleComponentState';
 import { type ObjectMetadataItem } from '@/object-metadata/types/ObjectMetadataItem';
 import { recordStoreFamilyState } from '@/object-record/record-store/states/recordStoreFamilyState';
+import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { useRecoilComponentValue } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValue';
 import { useActiveWorkflowVersionsWithManualTrigger } from '@/workflow/hooks/useActiveWorkflowVersionsWithManualTrigger';
 import { useRunWorkflowVersion } from '@/workflow/hooks/useRunWorkflowVersion';
@@ -12,6 +13,8 @@ import { useRunWorkflowVersion } from '@/workflow/hooks/useRunWorkflowVersion';
 import { type WorkflowVersion } from '@/workflow/types/Workflow';
 import { COMMAND_MENU_DEFAULT_ICON } from '@/workflow/workflow-trigger/constants/CommandMenuDefaultIcon';
 import { useRecoilCallback } from 'recoil';
+import { t } from '@lingui/core/macro';
+import { QUERY_MAX_RECORDS } from 'twenty-shared/constants';
 import { capitalize, isDefined } from 'twenty-shared/utils';
 import { useIcons } from 'twenty-ui/display';
 
@@ -23,6 +26,7 @@ export const useRunWorkflowRecordActions = ({
   skip?: boolean;
 }) => {
   const { getIcon } = useIcons();
+  const { enqueueWarningSnackBar } = useSnackBar();
   const contextStoreTargetedRecordsRule = useRecoilComponentValue(
     contextStoreTargetedRecordsRuleComponentState,
   );
@@ -49,12 +53,32 @@ export const useRunWorkflowRecordActions = ({
           'id' | 'workflowId' | 'trigger'
         >,
       ) => {
+        let limitedSelectedRecordIds = selectedRecordIds;
+
+        if (selectedRecordIds.length > QUERY_MAX_RECORDS) {
+          limitedSelectedRecordIds = selectedRecordIds.slice(
+            0,
+            QUERY_MAX_RECORDS,
+          );
+
+          const selectedCountFormatted =
+            selectedRecordIds.length.toLocaleString();
+          const limitFormatted = QUERY_MAX_RECORDS.toLocaleString();
+
+          enqueueWarningSnackBar({
+            message: t`You selected ${selectedCountFormatted} records but manual triggers can run on at most ${limitFormatted} records at once. Only the first ${limitFormatted} records will be processed.`,
+            options: {
+              dedupeKey: 'workflow-manual-trigger-selection-limit',
+            },
+          });
+        }
+
         if (
           isDefined(activeWorkflowVersion?.trigger) &&
           isBulkRecordsManualTrigger(activeWorkflowVersion.trigger)
         ) {
           const objectNamePlural = objectMetadataItem.namePlural;
-          const selectedRecords = selectedRecordIds
+          const selectedRecords = limitedSelectedRecordIds
             .map((recordId) =>
               snapshot.getLoadable(recordStoreFamilyState(recordId)).getValue(),
             )
@@ -68,7 +92,7 @@ export const useRunWorkflowRecordActions = ({
             },
           });
         } else {
-          for (const selectedRecordId of selectedRecordIds) {
+          for (const selectedRecordId of limitedSelectedRecordIds) {
             const selectedRecord = snapshot
               .getLoadable(recordStoreFamilyState(selectedRecordId))
               .getValue();
@@ -85,7 +109,7 @@ export const useRunWorkflowRecordActions = ({
           }
         }
       },
-    [runWorkflowVersion, objectMetadataItem],
+    [runWorkflowVersion, objectMetadataItem, enqueueWarningSnackBar],
   );
 
   return activeWorkflowVersions

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/find-records-action/components/WorkflowEditActionFindRecords.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/find-records-action/components/WorkflowEditActionFindRecords.tsx
@@ -24,6 +24,7 @@ import { WorkflowFindRecordsSorts } from '@/workflow/workflow-steps/workflow-act
 import { useWorkflowActionHeader } from '@/workflow/workflow-steps/workflow-actions/hooks/useWorkflowActionHeader';
 import { useLingui } from '@lingui/react/macro';
 import { isNumber } from '@sniptt/guards';
+import { QUERY_MAX_RECORDS } from 'twenty-shared/constants';
 import { isDefined } from 'twenty-shared/utils';
 import { HorizontalSeparator, useIcons } from 'twenty-ui/display';
 import { type SelectOption } from 'twenty-ui/input';
@@ -66,6 +67,7 @@ export const WorkflowEditActionFindRecords = ({
 }: WorkflowEditActionFindRecordsProps) => {
   const { getIcon } = useIcons();
   const { t } = useLingui();
+  const maxRecordsFormatted = QUERY_MAX_RECORDS.toLocaleString();
 
   const { activeNonSystemObjectMetadataItems } =
     useFilteredObjectMetadataItems();
@@ -77,12 +79,17 @@ export const WorkflowEditActionFindRecords = ({
       value: item.nameSingular,
     }));
 
-  const [formData, setFormData] = useState<FindRecordsFormData>({
+  const [formData, setFormData] = useState<FindRecordsFormData>(() => ({
     objectNameSingular: action.settings.input.objectName,
-    limit: action.settings.input.limit,
+    limit:
+      isNumber(action.settings.input.limit) &&
+      action.settings.input.limit > QUERY_MAX_RECORDS
+        ? QUERY_MAX_RECORDS
+        : action.settings.input.limit ?? 1,
     filter: action.settings.input.filter as FindRecordsActionFilter,
     orderBy: action.settings.input.orderBy as FindRecordsActionOrderBy,
-  });
+  }));
+  const [limitError, setLimitError] = useState<string | undefined>(undefined);
   const isFormDisabled = actionOptions.readonly ?? false;
   const instanceId = `workflow-edit-action-record-find-records-${action.id}-${formData.objectNameSingular}`;
 
@@ -145,6 +152,32 @@ export const WorkflowEditActionFindRecords = ({
       action,
       defaultTitle: FIND_RECORDS_ACTION.defaultLabel,
     });
+
+  useEffect(() => {
+    if (
+      actionOptions.readonly === true ||
+      !isNumber(action.settings.input.limit) ||
+      action.settings.input.limit <= QUERY_MAX_RECORDS
+    ) {
+      return;
+    }
+
+    actionOptions.onActionUpdate({
+      ...action,
+      settings: {
+        ...action.settings,
+        input: {
+          ...action.settings.input,
+          limit: QUERY_MAX_RECORDS,
+        },
+      },
+    });
+  }, [
+    action,
+    action.settings.input,
+    action.settings.input.limit,
+    actionOptions,
+  ]);
 
   return (
     <>
@@ -277,18 +310,35 @@ export const WorkflowEditActionFindRecords = ({
         )}
 
         <FormNumberFieldInput
-          label="Limit"
+          label={t`Limit`}
           defaultValue={formData.limit}
-          placeholder="Enter limit"
+          placeholder={t`Enter limit`}
           readonly={isFormDisabled}
+          hint={t`This action can return up to ${maxRecordsFormatted} records.`}
+          error={limitError}
           onChange={(limit) => {
             if (isFormDisabled === true || !isNumber(limit)) {
               return;
             }
 
+            const normalizedLimit = Math.floor(limit);
+
+            if (normalizedLimit <= 0) {
+              setLimitError(t`Limit must be greater than 0.`);
+              return;
+            }
+
+            const cappedLimit = Math.min(normalizedLimit, QUERY_MAX_RECORDS);
+
+            setLimitError(
+              normalizedLimit > QUERY_MAX_RECORDS
+                ? t`Limit cannot exceed ${maxRecordsFormatted} records.`
+                : undefined,
+            );
+
             const newFormData: FindRecordsFormData = {
               ...formData,
-              limit,
+              limit: cappedLimit,
             };
 
             setFormData(newFormData);

--- a/packages/twenty-front/src/modules/workflow/workflow-trigger/components/WorkflowEditTriggerManual.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-trigger/components/WorkflowEditTriggerManual.tsx
@@ -17,6 +17,7 @@ import { getTriggerIconColor } from '@/workflow/workflow-trigger/utils/getTrigge
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useLingui } from '@lingui/react/macro';
+import { QUERY_MAX_RECORDS } from 'twenty-shared/constants';
 import { TRIGGER_STEP_ID } from 'twenty-shared/workflow';
 import { useIcons } from 'twenty-ui/display';
 import { type SelectOption } from 'twenty-ui/input';
@@ -61,6 +62,7 @@ export const WorkflowEditTriggerManual = ({
   const { t } = useLingui();
 
   const { getIcon } = useIcons();
+  const maxRecordsFormatted = QUERY_MAX_RECORDS.toLocaleString();
 
   const { activeNonSystemObjectMetadataItems } =
     useFilteredObjectMetadataItems();
@@ -82,7 +84,7 @@ export const WorkflowEditTriggerManual = ({
 
   const availabilityDescriptions = {
     SINGLE_RECORD: t`The selected record will be passed to your workflow`,
-    BULK_RECORDS: t`The selected records will be passed to your workflow`,
+    BULK_RECORDS: t`The selected records (up to ${maxRecordsFormatted}) will be passed to your workflow`,
     GLOBAL: t`No record is required to trigger this workflow`,
   };
 

--- a/packages/twenty-shared/src/constants/QueryMaxRecords.ts
+++ b/packages/twenty-shared/src/constants/QueryMaxRecords.ts
@@ -1,1 +1,1 @@
-export const QUERY_MAX_RECORDS = 200;
+export const QUERY_MAX_RECORDS = 10_000;


### PR DESCRIPTION
# Introduction
fixes https://github.com/twentyhq/twenty/issues/15704

## Content
This pull request increases the maximum number of records that can be processed in bulk workflow actions from 200 to 10,000 and ensures that this new limit is consistently enforced and communicated throughout the UI. It updates logic, validation, and user feedback to handle scenarios where users exceed the maximum allowed records, and improves form handling for related workflow configuration screens.

**Bulk Workflow Record Limit Increase and Enforcement**

* Increased the value of `QUERY_MAX_RECORDS` from 200 to 10,000 in `twenty-shared/constants/QueryMaxRecords.ts`, raising the cap for bulk workflow operations.
* Updated the logic in `useRunWorkflowRecordActions` to enforce the 10,000 record limit: if a user selects more than the limit, only the first 10,000 are processed and a warning snackbar is shown to inform the user. [[1]](diffhunk://#diff-e97b5d7997b4b2202af3ef61bce1bbab33c9ed42581603d85083f8fa04961992R56-R81) [[2]](diffhunk://#diff-e97b5d7997b4b2202af3ef61bce1bbab33c9ed42581603d85083f8fa04961992L71-R95) [[3]](diffhunk://#diff-e97b5d7997b4b2202af3ef61bce1bbab33c9ed42581603d85083f8fa04961992R29) [[4]](diffhunk://#diff-e97b5d7997b4b2202af3ef61bce1bbab33c9ed42581603d85083f8fa04961992R8-R17) [[5]](diffhunk://#diff-e97b5d7997b4b2202af3ef61bce1bbab33c9ed42581603d85083f8fa04961992L88-R112)

**User Interface and Validation Improvements**

* Enhanced the `WorkflowEditActionFindRecords` form to cap the limit field at 10,000, display an error if the user enters a value above the limit, and show a hint about the maximum. Also, if the action is loaded with a value above the new limit, it is automatically adjusted down. [[1]](diffhunk://#diff-5f3eec6a6ba653b2e9b14e832a6fcbce6a09185b229e0af0660a929c05267eafL80-R92) [[2]](diffhunk://#diff-5f3eec6a6ba653b2e9b14e832a6fcbce6a09185b229e0af0660a929c05267eafR156-R181) [[3]](diffhunk://#diff-5f3eec6a6ba653b2e9b14e832a6fcbce6a09185b229e0af0660a929c05267eafL280-R341) [[4]](diffhunk://#diff-5f3eec6a6ba653b2e9b14e832a6fcbce6a09185b229e0af0660a929c05267eafR27) [[5]](diffhunk://#diff-5f3eec6a6ba653b2e9b14e832a6fcbce6a09185b229e0af0660a929c05267eafR70)
* Updated the manual trigger configuration UI to clarify that bulk triggers will only pass up to 10,000 records to the workflow, ensuring users are aware of the new cap. [[1]](diffhunk://#diff-76fd74936daddd3a4c6e96c00e1a7e177072dad014d8453e1f9c90810a8a7679R20) [[2]](diffhunk://#diff-76fd74936daddd3a4c6e96c00e1a7e177072dad014d8453e1f9c90810a8a7679R65) [[3]](diffhunk://#diff-76fd74936daddd3a4c6e96c00e1a7e177072dad014d8453e1f9c90810a8a7679L85-R87)