### PR TITLE
Twenty-shared tests parses decorator

### DIFF
--- a/packages/twenty-server/package.json
+++ b/packages/twenty-server/package.json
@@ -86,7 +86,7 @@
     "cache-manager-redis-yet": "^4.1.2",
     "chalk": "4.1.2",
     "class-transformer": "0.5.1",
-    "class-validator": "patch:class-validator@0.14.0#./patches/class-validator+0.14.0.patch",
+    "class-validator": "0.14.0",
     "class-validator-jsonschema": "^5.0.2",
     "cloudflare": "^4.5.0",
     "connect-redis": "^7.1.1",

--- a/packages/twenty-shared/jest.config.mjs
+++ b/packages/twenty-shared/jest.config.mjs
@@ -9,8 +9,15 @@ const jestConfig = {
       '@swc/jest',
       {
         jsc: {
-          parser: { syntax: 'typescript', tsx: true },
-          transform: { react: { runtime: 'automatic' } },
+          parser: {
+            syntax: 'typescript',
+            tsx: true,
+            decorators: true,
+          },
+          transform: {
+            react: { runtime: 'automatic' },
+            decoratorMetadata: true,
+          },
         },
       },
     ],

--- a/packages/twenty-shared/package.json
+++ b/packages/twenty-shared/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@sniptt/guards": "^0.2.0",
+    "class-validator": "^0.14.0",
     "handlebars": "^4.7.8",
     "libphonenumber-js": "^1.10.26",
     "qs": "^6.11.2",

--- a/packages/twenty-shared/src/utils/filter/dates/utils/getStartUnitOfDateTime.ts
+++ b/packages/twenty-shared/src/utils/filter/dates/utils/getStartUnitOfDateTime.ts
@@ -18,14 +18,6 @@ export const getStartUnitOfDateTime = (
         const firstDayOfTheWeekAsDateFNSNumber =
           getFirstDayOfTheWeekAsANumberForDateFNS(firstDayOfTheWeek);
 
-        console.log({
-          firstDayOfTheWeek,
-          firstDayOfTheWeekAsDateFNSNumber,
-          startOfWekk: startOfWeek(dateTime, {
-            weekStartsOn: firstDayOfTheWeekAsDateFNSNumber,
-          }),
-        });
-
         return startOfWeek(dateTime, {
           weekStartsOn: firstDayOfTheWeekAsDateFNSNumber,
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -30531,17 +30531,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"class-validator@patch:class-validator@0.14.0#./patches/class-validator+0.14.0.patch::locator=twenty-server%40workspace%3Apackages%2Ftwenty-server":
-  version: 0.14.0
-  resolution: "class-validator@patch:class-validator@npm%3A0.14.0#./patches/class-validator+0.14.0.patch::version=0.14.0&hash=053904&locator=twenty-server%40workspace%3Apackages%2Ftwenty-server"
-  dependencies:
-    "@types/validator": "npm:^13.7.10"
-    libphonenumber-js: "npm:^1.10.14"
-    validator: "npm:^13.7.0"
-  checksum: 10c0/d996aa04abefb737f07ec3f389f74c7ee6f3ec7f0ab13a8244f1bdc777cef827f3b2297789b4814b24440cf8fa936f5af0beee21f84b9ae413c7568b4c8e7407
-  languageName: node
-  linkType: hard
-
 "classcat@npm:^5.0.3":
   version: 5.0.5
   resolution: "classcat@npm:5.0.5"
@@ -55983,7 +55972,7 @@ __metadata:
     cache-manager-redis-yet: "npm:^4.1.2"
     chalk: "npm:4.1.2"
     class-transformer: "npm:0.5.1"
-    class-validator: "patch:class-validator@0.14.0#./patches/class-validator+0.14.0.patch"
+    class-validator: "npm:0.14.0"
     class-validator-jsonschema: "npm:^5.0.2"
     cloudflare: "npm:^4.5.0"
     connect-redis: "npm:^7.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -25040,6 +25040,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/validator@npm:^13.11.8":
+  version: 13.15.6
+  resolution: "@types/validator@npm:13.15.6"
+  checksum: 10c0/a7c1a0041180fa083bf5feb5aa751d415ceaf3635643dd116d0dc0db83d872ff7b5378f178176887474362fe7b93aa831bd7555d3763534cee898b84ff4d499f
+  languageName: node
+  linkType: hard
+
 "@types/validator@npm:^13.7.10":
   version: 13.12.0
   resolution: "@types/validator@npm:13.12.0"
@@ -30510,6 +30517,17 @@ __metadata:
     libphonenumber-js: "npm:^1.10.14"
     validator: "npm:^13.7.0"
   checksum: 10c0/1f7c34052f0c342b1d27c5aec7c42b646bb77a56874acc0d8003e2ad8f0294e7da18b43e9caaac8e8817cbb309cf9f14bcebe4611994390ca4818f3b393783dc
+  languageName: node
+  linkType: hard
+
+"class-validator@npm:^0.14.0":
+  version: 0.14.2
+  resolution: "class-validator@npm:0.14.2"
+  dependencies:
+    "@types/validator": "npm:^13.11.8"
+    libphonenumber-js: "npm:^1.11.1"
+    validator: "npm:^13.9.0"
+  checksum: 10c0/5bb67389d38fa23d342dffdd8e2dcee8235e1906e59799df5b2050278a6d89292fcaa88167f0215e3ddd684f47dcd51b004efa7be32d8aded91ee06cb317b3b8
   languageName: node
   linkType: hard
 
@@ -42599,6 +42617,13 @@ __metadata:
   version: 1.11.5
   resolution: "libphonenumber-js@npm:1.11.5"
   checksum: 10c0/c57b4d75d56fc32e611ea2dfdb196f18413caa1d72923250631ed0db915edb958b50f2ecee062241dbce98d9ed7afb6fe744776b6b325746cff0ab44ed69e756
+  languageName: node
+  linkType: hard
+
+"libphonenumber-js@npm:^1.11.1":
+  version: 1.12.26
+  resolution: "libphonenumber-js@npm:1.12.26"
+  checksum: 10c0/20d79a32f4ec8d4d67d32897085cfd74a2a4c950b1ff1b6bedc35da37f2f369a8b0a8798d0e8a7b4b91ad8633ef6476320f52051af489fbe70e35e0271e39da9
   languageName: node
   linkType: hard
 
@@ -56063,6 +56088,7 @@ __metadata:
     "@types/babel__preset-env": "npm:^7"
     "@types/handlebars": "npm:^4.1.0"
     babel-plugin-module-resolver: "npm:^5.0.2"
+    class-validator: "npm:^0.14.0"
     glob: "npm:^11.0.1"
     handlebars: "npm:^4.7.8"
     libphonenumber-js: "npm:^1.10.26"
@@ -57798,6 +57824,13 @@ __metadata:
   version: 13.15.20
   resolution: "validator@npm:13.15.20"
   checksum: 10c0/65453f0c91ef154ae2da4d5ff3c22acff239d2c15216335ba83895b6f79914708709c641119aa9fba0ec9dd69229c1cf8196aff0081584bdda8a7f50ea97b789
+  languageName: node
+  linkType: hard
+
+"validator@npm:^13.9.0":
+  version: 13.15.23
+  resolution: "validator@npm:13.15.23"
+  checksum: 10c0/22a05ec6a98d48d2b6fb34d43ce854af61d15842362d142e64cfca0325d4d0c2d1051d9f9d3a0f741e58ea888f73a35baf7a2a810f5aed0f89183bd5040f0177
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Introduction
Since we've moved some class validator instances from twenty-server to twenty-shared tests are red because they do not know how to parse decorators declarations

We've fixed this by explicitly installing `class-validator` in `twenty-shared` and configuring jest swc accordingly 

## Twenty-server class validator patch
I don't even know if that's something we need anymore
Seems to be a patch either fixing or introducing credit card and phone number validation
Would prefer discussing the need or not to either before merging this as it could introduce regression at runtime:
- Centralize the patch to be consumed in both `twenty-server` and `twenty-shared`
- Remove the patch

We should also document every patch motivations we do as it's quite though to iterate over a such huge one