### PR TITLE
Fix phone not empty filter

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-filter/utils/__tests__/computeViewRecordGqlOperationFilter.test.ts
+++ b/packages/twenty-front/src/modules/object-record/record-filter/utils/__tests__/computeViewRecordGqlOperationFilter.test.ts
@@ -744,20 +744,6 @@ describe('should work as expected for the different field types', () => {
               or: [
                 {
                   phones: {
-                    primaryPhoneCallingCode: { is: 'NULL' },
-                  },
-                },
-                {
-                  phones: {
-                    primaryPhoneCallingCode: { ilike: '' },
-                  },
-                },
-              ],
-            },
-            {
-              or: [
-                {
-                  phones: {
                     additionalPhones: { is: 'NULL' },
                   },
                 },
@@ -783,20 +769,6 @@ describe('should work as expected for the different field types', () => {
                   {
                     phones: {
                       primaryPhoneNumber: { ilike: '' },
-                    },
-                  },
-                ],
-              },
-              {
-                or: [
-                  {
-                    phones: {
-                      primaryPhoneCallingCode: { is: 'NULL' },
-                    },
-                  },
-                  {
-                    phones: {
-                      primaryPhoneCallingCode: { ilike: '' },
                     },
                   },
                 ],

--- a/packages/twenty-shared/src/utils/filter/utils/getEmptyRecordGqlOperationFilter.ts
+++ b/packages/twenty-shared/src/utils/filter/utils/getEmptyRecordGqlOperationFilter.ts
@@ -74,20 +74,6 @@ export const getEmptyRecordGqlOperationFilter = ({
               or: [
                 {
                   [correspondingField.name]: {
-                    primaryPhoneCallingCode: { is: 'NULL' },
-                  } as PhonesFilter,
-                },
-                {
-                  [correspondingField.name]: {
-                    primaryPhoneCallingCode: { ilike: '' },
-                  } as PhonesFilter,
-                },
-              ],
-            },
-            {
-              or: [
-                {
-                  [correspondingField.name]: {
                     additionalPhones: { is: 'NULL' },
                   } as PhonesFilter,
                 },


### PR DESCRIPTION
This PR fixes the filter on not empty phones.

We can end up with phone numbers that only have a country code, but it makes no sense to consider this special edge case "not empty".

If we have no phone number, then it's empty, so this PR applies this particular use case for NOT EMPTY filter on phone fields.

Fixes https://github.com/twentyhq/twenty/issues/15638