### PR TITLE
Fixed hovering of kanban cards

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellContainer.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellContainer.tsx
@@ -115,7 +115,7 @@ export const RecordInlineCellContainer = () => {
               <IconLabel stroke={theme.icon.stroke.sm} />
             </StyledIconContainer>
           )}
-          {label && (
+          {showLabel && (
             <StyledLabelContainer width={labelWidth}>
               <OverflowingTextWithTooltip text={label} displayedMaxRows={1} />
             </StyledLabelContainer>
@@ -134,7 +134,6 @@ export const RecordInlineCellContainer = () => {
           )}
         </StyledLabelAndIconContainer>
       )}
-
       <StyledValueContainer readonly={readonly ?? false} id={anchorId}>
         <RecordInlineCellValue />
       </StyledValueContainer>

--- a/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellDisplayMode.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellDisplayMode.tsx
@@ -104,9 +104,7 @@ export const RecordInlineCellDisplayMode = ({
             children
           ) : shouldShowEmptyPlaceholder ? (
             <StyledEmptyField>{emptyPlaceHolder}</StyledEmptyField>
-          ) : (
-            <></>
-          )}
+          ) : null}
         </StyledRecordInlineCellNormalModeInnerContainer>
       </StyledRecordInlineCellNormalModeOuterContainer>
       {showEditButton && (

--- a/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellDisplayMode.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellDisplayMode.tsx
@@ -87,8 +87,7 @@ export const RecordInlineCellDisplayMode = ({
 
   const emptyPlaceHolder = label ?? t`Empty`;
 
-  const shouldShowValue =
-    !isFieldEmpty || isFieldInputOnly || (!isFieldEmpty && readonly);
+  const shouldShowValue = !isFieldEmpty || isFieldInputOnly;
 
   const shouldShowEmptyPlaceholder = isFieldEmpty;
 

--- a/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellDisplayMode.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-inline-cell/components/RecordInlineCellDisplayMode.tsx
@@ -60,8 +60,6 @@ const StyledEmptyField = styled.div`
   color: ${({ theme }) => theme.font.color.light};
   display: flex;
   height: 20px;
-
-  background-color: ${({ theme }) => theme.background.secondary};
 `;
 
 export const RecordInlineCellDisplayMode = ({
@@ -74,25 +72,25 @@ export const RecordInlineCellDisplayMode = ({
 }>) => {
   const { t } = useLingui();
 
-  const { editModeContentOnly, showLabel, label, buttonIcon, readonly } =
+  const { editModeContentOnly, label, buttonIcon, readonly } =
     useRecordInlineCellContext();
 
-  const isDisplayModeContentEmpty = useIsFieldEmpty();
+  const isFieldEmpty = useIsFieldEmpty();
   const showEditButton =
     buttonIcon &&
     isHovered &&
     !readonly &&
-    !isDisplayModeContentEmpty &&
+    !isFieldEmpty &&
     !editModeContentOnly;
 
   const isFieldInputOnly = useIsFieldInputOnly();
 
-  const shouldDisplayEditModeOnFocus = isHovered && isFieldInputOnly;
+  const emptyPlaceHolder = label ?? t`Empty`;
 
-  const emptyPlaceHolder = showLabel ? t`Empty` : label;
+  const shouldShowValue =
+    !isFieldEmpty || isFieldInputOnly || (!isFieldEmpty && readonly);
 
-  const shouldShowEmptyPlaceholder =
-    (isDisplayModeContentEmpty && !shouldDisplayEditModeOnFocus) || !children;
+  const shouldShowEmptyPlaceholder = isFieldEmpty;
 
   return (
     <>
@@ -102,10 +100,12 @@ export const RecordInlineCellDisplayMode = ({
         onClick={onClick}
       >
         <StyledRecordInlineCellNormalModeInnerContainer>
-          {shouldShowEmptyPlaceholder ? (
+          {shouldShowValue ? (
+            children
+          ) : shouldShowEmptyPlaceholder ? (
             <StyledEmptyField>{emptyPlaceHolder}</StyledEmptyField>
           ) : (
-            children
+            <></>
           )}
         </StyledRecordInlineCellNormalModeInnerContainer>
       </StyledRecordInlineCellNormalModeOuterContainer>


### PR DESCRIPTION
This PR fixes the record inline cells that disappeared on board card due to recent refactors.