### PR TITLE
fix(workflow): UUID filter in "Search Records" action

### DIFF
--- a/packages/twenty-shared/src/utils/filter/__tests__/computeRecordGqlOperationFilter.test.ts
+++ b/packages/twenty-shared/src/utils/filter/__tests__/computeRecordGqlOperationFilter.test.ts
@@ -1,46 +1,42 @@
 import { computeRecordGqlOperationFilter } from '../computeRecordGqlOperationFilter';
 import type { RecordFilter } from '../turnRecordFilterGroupIntoGqlOperationFilter';
 
-import type { PartialFieldMetadataItem } from '@/types/PartialFieldMetadataItem';
 import { FieldMetadataType } from '@/types/FieldMetadataType';
+import type { PartialFieldMetadataItem } from '@/types/PartialFieldMetadataItem';
 import { ViewFilterOperand } from '@/types/ViewFilterOperand';
 
 describe('computeRecordGqlOperationFilter', () => {
-  describe('workflow find-records filters targeting a UUID field', () => {
-    // Regression for workflow automation “Search Records” -> “ID is <UUID>” (issue #15746)
-    it('injects the UUID entered in the filter into the gql filter when no recordIdsForUuid context is present', () => {
-      const companyIdField: PartialFieldMetadataItem = {
-        id: 'company-id-field',
-        name: 'id',
-        label: 'ID',
-        type: FieldMetadataType.UUID,
-      };
+  it('should match Is UUID', () => {
+    const companyIdField: PartialFieldMetadataItem = {
+      id: 'company-id-field',
+      name: 'id',
+      label: 'ID',
+      type: FieldMetadataType.UUID,
+    };
 
-      const uuidValue = '4f83d5c0-7c7a-4f67-9f29-0a6aad1f4eb1';
+    const uuidValue = '4f83d5c0-7c7a-4f67-9f29-0a6aad1f4eb1';
 
-      const recordFilters: RecordFilter[] = [
-        {
-          id: 'uuid-filter',
-          fieldMetadataId: companyIdField.id,
-          value: uuidValue,
-          type: 'UUID',
-          operand: ViewFilterOperand.IS,
-        },
-      ];
+    const recordFilters: RecordFilter[] = [
+      {
+        id: 'uuid-filter',
+        fieldMetadataId: companyIdField.id,
+        value: uuidValue,
+        type: 'UUID',
+        operand: ViewFilterOperand.IS,
+      },
+    ];
 
-      const filter = computeRecordGqlOperationFilter({
-        fields: [companyIdField],
-        recordFilters,
-        recordFilterGroups: [],
-        filterValueDependencies: {},
-      });
+    const filter = computeRecordGqlOperationFilter({
+      fields: [companyIdField],
+      recordFilters,
+      recordFilterGroups: [],
+      filterValueDependencies: {},
+    });
 
-      expect(filter).toEqual({
-        id: {
-          in: [uuidValue],
-        },
-      });
+    expect(filter).toEqual({
+      id: {
+        in: [uuidValue],
+      },
     });
   });
 });
-

--- a/packages/twenty-shared/src/utils/filter/__tests__/computeRecordGqlOperationFilter.test.ts
+++ b/packages/twenty-shared/src/utils/filter/__tests__/computeRecordGqlOperationFilter.test.ts
@@ -1,0 +1,46 @@
+import { computeRecordGqlOperationFilter } from '../computeRecordGqlOperationFilter';
+import type { RecordFilter } from '../turnRecordFilterGroupIntoGqlOperationFilter';
+
+import type { PartialFieldMetadataItem } from '@/types/PartialFieldMetadataItem';
+import { FieldMetadataType } from '@/types/FieldMetadataType';
+import { ViewFilterOperand } from '@/types/ViewFilterOperand';
+
+describe('computeRecordGqlOperationFilter', () => {
+  describe('workflow find-records filters targeting a UUID field', () => {
+    // Regression for workflow automation “Search Records” -> “ID is <UUID>” (issue #15746)
+    it('injects the UUID entered in the filter into the gql filter when no recordIdsForUuid context is present', () => {
+      const companyIdField: PartialFieldMetadataItem = {
+        id: 'company-id-field',
+        name: 'id',
+        label: 'ID',
+        type: FieldMetadataType.UUID,
+      };
+
+      const uuidValue = '4f83d5c0-7c7a-4f67-9f29-0a6aad1f4eb1';
+
+      const recordFilters: RecordFilter[] = [
+        {
+          id: 'uuid-filter',
+          fieldMetadataId: companyIdField.id,
+          value: uuidValue,
+          type: 'UUID',
+          operand: ViewFilterOperand.IS,
+        },
+      ];
+
+      const filter = computeRecordGqlOperationFilter({
+        fields: [companyIdField],
+        recordFilters,
+        recordFilterGroups: [],
+        filterValueDependencies: {},
+      });
+
+      expect(filter).toEqual({
+        id: {
+          in: [uuidValue],
+        },
+      });
+    });
+  });
+});
+

--- a/packages/twenty-shared/src/utils/filter/turnRecordFilterIntoGqlOperationFilter.ts
+++ b/packages/twenty-shared/src/utils/filter/turnRecordFilterIntoGqlOperationFilter.ts
@@ -70,13 +70,11 @@ type TurnRecordFilterIntoRecordGqlOperationFilterParams = {
   filterValueDependencies?: RecordFilterValueDependencies;
   recordFilter: RecordFilter;
   fieldMetadataItems: FieldShared[];
-  recordIdsForUuid?: string[];
 };
 
 export const turnRecordFilterIntoRecordGqlOperationFilter = ({
   recordFilter,
   fieldMetadataItems,
-  recordIdsForUuid,
   filterValueDependencies,
 }: TurnRecordFilterIntoRecordGqlOperationFilterParams):
   | RecordGqlOperationFilter
@@ -1303,10 +1301,7 @@ export const turnRecordFilterIntoRecordGqlOperationFilter = ({
       };
     }
     case 'UUID': {
-      const recordIds =
-        recordIdsForUuid && recordIdsForUuid.length > 0
-          ? recordIdsForUuid
-          : arrayOfUuidOrVariableSchema.parse(recordFilter.value);
+      const recordIds = arrayOfUuidOrVariableSchema.parse(recordFilter.value);
 
       if (!isDefined(recordIds) || recordIds.length === 0) return;
 

--- a/packages/twenty-shared/src/utils/filter/turnRecordFilterIntoGqlOperationFilter.ts
+++ b/packages/twenty-shared/src/utils/filter/turnRecordFilterIntoGqlOperationFilter.ts
@@ -1303,7 +1303,10 @@ export const turnRecordFilterIntoRecordGqlOperationFilter = ({
       };
     }
     case 'UUID': {
-      const recordIds = recordIdsForUuid;
+      const recordIds =
+        recordIdsForUuid && recordIdsForUuid.length > 0
+          ? recordIdsForUuid
+          : arrayOfUuidOrVariableSchema.parse(recordFilter.value);
 
       if (!isDefined(recordIds) || recordIds.length === 0) return;
 


### PR DESCRIPTION
## Summary
- add a regression test that reproduces the workflow "Search Records → ID is <UUID>" failure (issue #15067 / #15746)
- adjust `turnRecordFilterIntoRecordGqlOperationFilter` so UUID filters fall back to the literal value when no `recordIdsForUuid` context is provided, always emitting an `in` clause

## Testing
- npx nx test twenty-shared -- --testPathPattern=computeRecordGqlOperationFilter.test.ts --coverage=false
- Manual: workflow "Search Records" with filter "ID is <UUID>" now returns the correct record

Fixes #15067
Fixes #15746