### PR TITLE
Enhance StyledInnerContainer for responsiveness (Resizable Left Panel)

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/show-page/components/ShowPageLeftContainer.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/show-page/components/ShowPageLeftContainer.tsx
@@ -20,7 +20,19 @@ const StyledOuterContainer = styled.div<{ isMobile: boolean }>`
 const StyledInnerContainer = styled.div<{ isMobile: boolean }>`
   display: flex;
   flex-direction: column;
-  width: ${({ isMobile }) => (isMobile ? `100%` : '348px')};
+
+  ${({ isMobile }) =>
+    isMobile
+      ? `
+        width: 100%;
+      `
+      : `
+        width: 348px;      /* starting width */
+        min-width: 250px;  /* don't let it get too small */
+        max-width: 600px;  /* don't let it get too big */
+        resize: horizontal;
+        overflow: auto;
+      `}
 `;
 
 const StyledIntermediateContainer = styled.div`


### PR DESCRIPTION
This PR addresses the issue where field values in the Left Panel were getting truncated. Thus, even small to medium values, like 30 characters long, would get truncated, —  which is a bad user experience, as the user needs to hover over it to see its full value.

I have implemented resizable sidebar logic that allows users to drag the right edge of the column to adjust its width according to their needs.

**Future Proposal:** while my solution is pretty basic, in the future it would be great to implement saving the last width set by the user (maybe as a preference in localStorage of user's browser). This would remove the need to expand the left panel each time in cases when, for example, this object always has medium-sized and longer field values... 

Before:
<img width="952" height="728" alt="Screenshot 2025-11-17 at 23 06 48" src="https://github.com/user-attachments/assets/abeec5e7-7b7c-4b39-bc52-3fe6dd0c2da8" />

After:
<img width="952" height="728" alt="Screenshot 2025-11-17 at 23 07 38" src="https://github.com/user-attachments/assets/2847ec5b-88b9-42c7-adca-cde0d6578db8" />

This is my first contribution, hope it helps!