### PR TITLE
fix: bump up js-yaml patch number inside fireflies app

### DIFF
--- a/packages/twenty-apps/hacktoberfest-2025/fireflies/yarn.lock
+++ b/packages/twenty-apps/hacktoberfest-2025/fireflies/yarn.lock
@@ -2825,14 +2825,14 @@ __metadata:
   linkType: hard
 
 "js-yaml@npm:^3.13.1":
-  version: 3.14.1
-  resolution: "js-yaml@npm:3.14.1"
+  version: 3.14.2
+  resolution: "js-yaml@npm:3.14.2"
   dependencies:
     argparse: "npm:^1.0.7"
     esprima: "npm:^4.0.0"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/6746baaaeac312c4db8e75fa22331d9a04cccb7792d126ed8ce6a0bbcfef0cedaddd0c5098fade53db067c09fe00aa1c957674b4765610a8b06a5a189e46433b
+  checksum: 10c0/3261f25912f5dd76605e5993d0a126c2b6c346311885d3c483706cd722efe34f697ea0331f654ce27c00a42b426e524518ec89d65ed02ea47df8ad26dcc8ce69
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resolves the last remaining js-yaml alert: [Dependabot Alert 304](https://github.com/twentyhq/twenty/security/dependabot/304).

Updates version of js-yaml from 3.14.1 to 3.14.2.