### PR TITLE
Fix wrong empty string formatting

### DIFF
--- a/packages/twenty-front/src/modules/ui/field/display/components/CurrencyDisplay.tsx
+++ b/packages/twenty-front/src/modules/ui/field/display/components/CurrencyDisplay.tsx
@@ -23,8 +23,6 @@ export const CurrencyDisplay = ({
 }: CurrencyDisplayProps) => {
   const theme = useTheme();
 
-  const shouldDisplayCurrency = isDefined(currencyValue?.currencyCode);
-
   const CurrencyIcon = isDefined(currencyValue?.currencyCode)
     ? SETTINGS_FIELD_CURRENCY_CODES[currencyValue?.currencyCode]?.Icon
     : null;
@@ -35,10 +33,6 @@ export const CurrencyDisplay = ({
 
   const format = fieldDefinition.metadata.settings?.format;
   const { formatNumber } = useNumberFormat();
-
-  if (!shouldDisplayCurrency) {
-    return <EllipsisDisplay>{0}</EllipsisDisplay>;
-  }
 
   return (
     <EllipsisDisplay>

--- a/packages/twenty-shared/src/utils/variable-resolver.test.ts
+++ b/packages/twenty-shared/src/utils/variable-resolver.test.ts
@@ -10,10 +10,29 @@ describe('resolveInput', () => {
       theme: 'dark',
       notifications: true,
     },
+    specialValues: {
+      nullValue: null,
+      undefinedValue: undefined,
+      emptyString: '',
+      zero: 0,
+      booleanFalse: false,
+      booleanTrue: true,
+    },
   };
 
   it('should return null for null input', () => {
     expect(resolveInput(null, context)).toBeNull();
+  });
+
+  it('should support special values', () => {
+    expect(resolveInput('{{specialValues.nullValue}}', context)).toBeNull();
+    expect(
+      resolveInput('{{specialValues.undefinedValue}}', context),
+    ).toBeUndefined();
+    expect(resolveInput('{{specialValues.emptyString}}', context)).toBe('');
+    expect(resolveInput('{{specialValues.zero}}', context)).toBe(0);
+    expect(resolveInput('{{specialValues.booleanFalse}}', context)).toBe(false);
+    expect(resolveInput('{{specialValues.booleanTrue}}', context)).toBe(true);
   });
 
   it('should return undefined for undefined input', () => {

--- a/packages/twenty-shared/src/utils/variable-resolver.ts
+++ b/packages/twenty-shared/src/utils/variable-resolver.ts
@@ -99,7 +99,7 @@ const evalFromContext = (input: string, context: Record<string, unknown>) => {
       },
     });
 
-    return JSON.parse(inferredInput) ?? '';
+    return JSON.parse(inferredInput);
   } catch {
     return undefined;
   }


### PR DESCRIPTION
As title, solves this kind of issues https://twentyfortwenty.twenty.com/object/workflowRun/d6aca50e-68ba-4715-8835-ea22bd44fb88

Solves null currencyDisplay when null currencyCode and null amountMicros

### Before
<img width="147" height="81" alt="image" src="https://github.com/user-attachments/assets/d250d65e-b984-43f4-ad67-1397a684cf6a" />

 ### After
 
<img width="128" height="74" alt="image" src="https://github.com/user-attachments/assets/4f9c9d80-f8bb-495a-9be0-ecfb984ded81" />
