### PR TITLE
handle HTTP 410,404 in GmailMessagesImportErrorHandler

### DIFF
--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/utils/__tests__/parse-gmail-messages-import-error.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/utils/__tests__/parse-gmail-messages-import-error.spec.ts
@@ -138,7 +138,13 @@ describe('parseGmailMessagesImportError', () => {
       messageExternalId,
     );
 
-    expect(exception).toBe(undefined);
+    expect(exception).toBeInstanceOf(MessageImportDriverException);
+    expect(exception?.code).toBe(
+      MessageImportDriverExceptionCode.SYNC_CURSOR_ERROR,
+    );
+    expect(exception?.message).toBe(
+      `${error.error.errors[0].message} for message with externalId: ${messageExternalId}`,
+    );
   });
 
   it('should handle 410 Gone', () => {
@@ -148,7 +154,13 @@ describe('parseGmailMessagesImportError', () => {
       messageExternalId,
     );
 
-    expect(exception).toBe(undefined);
+    expect(exception).toBeInstanceOf(MessageImportDriverException);
+    expect(exception?.code).toBe(
+      MessageImportDriverExceptionCode.SYNC_CURSOR_ERROR,
+    );
+    expect(exception?.message).toBe(
+      `${error.error.errors[0].message} for message with externalId: ${messageExternalId}`,
+    );
   });
 
   it('should handle 429 Too Many Requests', () => {

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/utils/parse-gmail-messages-import-error.util.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/utils/parse-gmail-messages-import-error.util.ts
@@ -53,7 +53,11 @@ export const parseGmailMessagesImportError = (
 
     case 404:
     case 410:
-      return undefined;
+      return new MessageImportDriverException(
+        message,
+        MessageImportDriverExceptionCode.SYNC_CURSOR_ERROR,
+        { cause: options?.cause },
+      );
 
     case 429:
       return new MessageImportDriverException(


### PR DESCRIPTION
Noticed this in prod, we currently return `undefined` instead of handling it.