### PR TITLE
Attest standard object isActive update regression + TDD tests

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/utils/__tests__/__snapshots__/compare-two-flat-entity.util.spec.ts.snap
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/utils/__tests__/__snapshots__/compare-two-flat-entity.util.spec.ts.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`compareTwoFlatEntity It should detect flat field metadata isActive diff from true to false 1`] = `
+[
+  {
+    "from": true,
+    "property": "isActive",
+    "to": false,
+  },
+]
+`;
+
+exports[`compareTwoFlatEntity It should detect flat field metadata isActive diff from true to false 2`] = `
+[
+  {
+    "from": false,
+    "property": "isActive",
+    "to": true,
+  },
+]
+`;

--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/utils/__tests__/compare-two-flat-entity.util.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/utils/__tests__/compare-two-flat-entity.util.spec.ts
@@ -1,0 +1,80 @@
+import { ALL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY } from 'src/engine/metadata-modules/flat-entity/constant/all-flat-entity-properties-to-compare-and-stringify.constant';
+import { MetadataFlatEntity } from 'src/engine/metadata-modules/flat-entity/types/metadata-flat-entity.type';
+import { compareTwoFlatEntity } from 'src/engine/metadata-modules/flat-entity/utils/compare-two-flat-entity.util';
+import { getFlatFieldMetadataMock } from 'src/engine/metadata-modules/flat-field-metadata/__mocks__/get-flat-field-metadata.mock';
+import { extractRecordIdsAndDatesAsExpectAny } from 'test/utils/extract-record-ids-and-dates-as-expect-any';
+import { AllMetadataName } from 'twenty-shared/metadata';
+import {
+  eachTestingContextFilter,
+  type EachTestingContext,
+} from 'twenty-shared/testing';
+
+import { FieldMetadataType, FromTo } from 'twenty-shared/types';
+
+type TestContext<T extends AllMetadataName = AllMetadataName> = FromTo<
+  MetadataFlatEntity<T>,
+  'flatEntity'
+> & { metadataName: T };
+
+describe('compareTwoFlatEntity', () => {
+  const testCases = [
+    {
+      title:
+        'It should detect flat field metadata isActive diff from true to false',
+      context: {
+        fromFlatEntity: getFlatFieldMetadataMock({
+          objectMetadataId: 'object-metadata-id',
+          type: FieldMetadataType.TEXT,
+          universalIdentifier: 'universal-identifier',
+          isActive: true,
+        }),
+        metadataName: 'fieldMetadata',
+        toFlatEntity: getFlatFieldMetadataMock({
+          objectMetadataId: 'object-metadata-id',
+          type: FieldMetadataType.TEXT,
+          universalIdentifier: 'universal-identifier',
+          isActive: false,
+        }),
+      },
+    },
+    {
+      title:
+        'It should detect flat field metadata isActive diff from true to false',
+      context: {
+        fromFlatEntity: getFlatFieldMetadataMock({
+          objectMetadataId: 'object-metadata-id',
+          type: FieldMetadataType.TEXT,
+          universalIdentifier: 'universal-identifier',
+          isActive: false,
+        }),
+        metadataName: 'fieldMetadata',
+        toFlatEntity: getFlatFieldMetadataMock({
+          objectMetadataId: 'object-metadata-id',
+          type: FieldMetadataType.TEXT,
+          universalIdentifier: 'universal-identifier',
+          isActive: true,
+        }),
+      },
+    },
+  ] as const satisfies EachTestingContext<TestContext>[];
+
+  test.each(eachTestingContextFilter(testCases))(
+    '$title',
+    ({ context: { metadataName, fromFlatEntity, toFlatEntity } }) => {
+      const result = compareTwoFlatEntity({
+        fromFlatEntity,
+        propertiesToCompare:
+          ALL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY[metadataName]
+            .propertiesToCompare as any,
+        propertiesToStringify:
+          ALL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY[metadataName]
+            .propertiesToStringify as any,
+        toFlatEntity,
+      });
+
+      expect(result).toMatchSnapshot(
+        extractRecordIdsAndDatesAsExpectAny(result),
+      );
+    },
+  );
+});

--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/utils/__tests__/compare-two-flat-entity.util.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/utils/__tests__/compare-two-flat-entity.util.spec.ts
@@ -1,15 +1,15 @@
-import { ALL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY } from 'src/engine/metadata-modules/flat-entity/constant/all-flat-entity-properties-to-compare-and-stringify.constant';
-import { MetadataFlatEntity } from 'src/engine/metadata-modules/flat-entity/types/metadata-flat-entity.type';
-import { compareTwoFlatEntity } from 'src/engine/metadata-modules/flat-entity/utils/compare-two-flat-entity.util';
-import { getFlatFieldMetadataMock } from 'src/engine/metadata-modules/flat-field-metadata/__mocks__/get-flat-field-metadata.mock';
 import { extractRecordIdsAndDatesAsExpectAny } from 'test/utils/extract-record-ids-and-dates-as-expect-any';
-import { AllMetadataName } from 'twenty-shared/metadata';
+import { type AllMetadataName } from 'twenty-shared/metadata';
 import {
   eachTestingContextFilter,
   type EachTestingContext,
 } from 'twenty-shared/testing';
+import { FieldMetadataType, type FromTo } from 'twenty-shared/types';
 
-import { FieldMetadataType, FromTo } from 'twenty-shared/types';
+import { ALL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY } from 'src/engine/metadata-modules/flat-entity/constant/all-flat-entity-properties-to-compare-and-stringify.constant';
+import { type MetadataFlatEntity } from 'src/engine/metadata-modules/flat-entity/types/metadata-flat-entity.type';
+import { compareTwoFlatEntity } from 'src/engine/metadata-modules/flat-entity/utils/compare-two-flat-entity.util';
+import { getFlatFieldMetadataMock } from 'src/engine/metadata-modules/flat-field-metadata/__mocks__/get-flat-field-metadata.mock';
 
 type TestContext<T extends AllMetadataName = AllMetadataName> = FromTo<
   MetadataFlatEntity<T>,

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/utils/__tests__/__snapshots__/flat-entity-deleted-created-updated-matrix-dispatcher.util.spec.ts.snap
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/utils/__tests__/__snapshots__/flat-entity-deleted-created-updated-matrix-dispatcher.util.spec.ts.snap
@@ -1,0 +1,275 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`flatEntityDeletedCreatedUpdatedMatrixDispatcher It should detect a created entity 1`] = `
+{
+  "createdFlatEntityMaps": {
+    "byId": {
+      "field-id-1": {
+        "applicationId": "application-id-1",
+        "calendarViewIds": [],
+        "createdAt": 2024-01-01T00:00:00.000Z,
+        "defaultValue": null,
+        "description": "default flat field metadata description",
+        "icon": "icon",
+        "id": "field-id-1",
+        "isActive": true,
+        "isCustom": true,
+        "isLabelSyncedWithName": false,
+        "isNullable": true,
+        "isSystem": false,
+        "isUIReadOnly": false,
+        "isUnique": false,
+        "kanbanAggregateOperationViewIds": [],
+        "label": "flat field metadata label",
+        "morphId": null,
+        "name": "flatFieldMetadataName",
+        "objectMetadataId": "object-metadata-id-1",
+        "options": null,
+        "relationTargetFieldMetadataId": null,
+        "relationTargetObjectMetadataId": null,
+        "settings": null,
+        "standardId": null,
+        "standardOverrides": null,
+        "type": "TEXT",
+        "universalIdentifier": "universal-identifier-1",
+        "updatedAt": 2024-01-01T00:00:00.000Z,
+        "viewFieldIds": [],
+        "viewFilterIds": [],
+        "viewGroupIds": [],
+        "workspaceId": "workspace-id-1",
+      },
+    },
+    "idByUniversalIdentifier": {
+      "universal-identifier-1": "field-id-1",
+    },
+    "universalIdentifiersByApplicationId": {
+      "application-id-1": [
+        "universal-identifier-1",
+      ],
+    },
+  },
+  "deletedFlatEntityMaps": {
+    "byId": {},
+    "idByUniversalIdentifier": {},
+    "universalIdentifiersByApplicationId": {},
+  },
+  "updatedFlatEntityMaps": {
+    "byId": {},
+  },
+}
+`;
+
+exports[`flatEntityDeletedCreatedUpdatedMatrixDispatcher It should detect a deleted entity 1`] = `
+{
+  "createdFlatEntityMaps": {
+    "byId": {},
+    "idByUniversalIdentifier": {},
+    "universalIdentifiersByApplicationId": {},
+  },
+  "deletedFlatEntityMaps": {
+    "byId": {
+      "field-id-1": {
+        "applicationId": "application-id-1",
+        "calendarViewIds": [],
+        "createdAt": 2024-01-01T00:00:00.000Z,
+        "defaultValue": null,
+        "description": "default flat field metadata description",
+        "icon": "icon",
+        "id": "field-id-1",
+        "isActive": true,
+        "isCustom": true,
+        "isLabelSyncedWithName": false,
+        "isNullable": true,
+        "isSystem": false,
+        "isUIReadOnly": false,
+        "isUnique": false,
+        "kanbanAggregateOperationViewIds": [],
+        "label": "flat field metadata label",
+        "morphId": null,
+        "name": "flatFieldMetadataName",
+        "objectMetadataId": "object-metadata-id-1",
+        "options": null,
+        "relationTargetFieldMetadataId": null,
+        "relationTargetObjectMetadataId": null,
+        "settings": null,
+        "standardId": null,
+        "standardOverrides": null,
+        "type": "TEXT",
+        "universalIdentifier": "universal-identifier-1",
+        "updatedAt": 2024-01-01T00:00:00.000Z,
+        "viewFieldIds": [],
+        "viewFilterIds": [],
+        "viewGroupIds": [],
+        "workspaceId": "workspace-id-1",
+      },
+    },
+    "idByUniversalIdentifier": {
+      "universal-identifier-1": "field-id-1",
+    },
+    "universalIdentifiersByApplicationId": {
+      "application-id-1": [
+        "universal-identifier-1",
+      ],
+    },
+  },
+  "updatedFlatEntityMaps": {
+    "byId": {},
+  },
+}
+`;
+
+exports[`flatEntityDeletedCreatedUpdatedMatrixDispatcher It should detect an updated entity 1`] = `
+{
+  "createdFlatEntityMaps": {
+    "byId": {},
+    "idByUniversalIdentifier": {},
+    "universalIdentifiersByApplicationId": {},
+  },
+  "deletedFlatEntityMaps": {
+    "byId": {},
+    "idByUniversalIdentifier": {},
+    "universalIdentifiersByApplicationId": {},
+  },
+  "updatedFlatEntityMaps": {
+    "byId": {
+      "field-id-1": {
+        "updates": [
+          {
+            "from": false,
+            "property": "isActive",
+            "to": true,
+          },
+        ],
+      },
+    },
+  },
+}
+`;
+
+exports[`flatEntityDeletedCreatedUpdatedMatrixDispatcher It should detect created, deleted and updated entities 1`] = `
+{
+  "createdFlatEntityMaps": {
+    "byId": {
+      "field-id-3": {
+        "applicationId": "application-id-1",
+        "calendarViewIds": [],
+        "createdAt": 2024-01-01T00:00:00.000Z,
+        "defaultValue": null,
+        "description": "default flat field metadata description",
+        "icon": "icon",
+        "id": "field-id-3",
+        "isActive": true,
+        "isCustom": true,
+        "isLabelSyncedWithName": false,
+        "isNullable": true,
+        "isSystem": false,
+        "isUIReadOnly": false,
+        "isUnique": false,
+        "kanbanAggregateOperationViewIds": [],
+        "label": "flat field metadata label",
+        "morphId": null,
+        "name": "flatFieldMetadataName",
+        "objectMetadataId": "object-metadata-id-1",
+        "options": null,
+        "relationTargetFieldMetadataId": null,
+        "relationTargetObjectMetadataId": null,
+        "settings": null,
+        "standardId": null,
+        "standardOverrides": null,
+        "type": "TEXT",
+        "universalIdentifier": "universal-identifier-3",
+        "updatedAt": 2024-01-01T00:00:00.000Z,
+        "viewFieldIds": [],
+        "viewFilterIds": [],
+        "viewGroupIds": [],
+        "workspaceId": "workspace-id-1",
+      },
+    },
+    "idByUniversalIdentifier": {
+      "universal-identifier-3": "field-id-3",
+    },
+    "universalIdentifiersByApplicationId": {
+      "application-id-1": [
+        "universal-identifier-3",
+      ],
+    },
+  },
+  "deletedFlatEntityMaps": {
+    "byId": {
+      "field-id-2": {
+        "applicationId": "application-id-1",
+        "calendarViewIds": [],
+        "createdAt": 2024-01-01T00:00:00.000Z,
+        "defaultValue": null,
+        "description": "default flat field metadata description",
+        "icon": "icon",
+        "id": "field-id-2",
+        "isActive": true,
+        "isCustom": true,
+        "isLabelSyncedWithName": false,
+        "isNullable": true,
+        "isSystem": false,
+        "isUIReadOnly": false,
+        "isUnique": false,
+        "kanbanAggregateOperationViewIds": [],
+        "label": "flat field metadata label",
+        "morphId": null,
+        "name": "flatFieldMetadataName",
+        "objectMetadataId": "object-metadata-id-1",
+        "options": null,
+        "relationTargetFieldMetadataId": null,
+        "relationTargetObjectMetadataId": null,
+        "settings": null,
+        "standardId": null,
+        "standardOverrides": null,
+        "type": "TEXT",
+        "universalIdentifier": "universal-identifier-2",
+        "updatedAt": 2024-01-01T00:00:00.000Z,
+        "viewFieldIds": [],
+        "viewFilterIds": [],
+        "viewGroupIds": [],
+        "workspaceId": "workspace-id-1",
+      },
+    },
+    "idByUniversalIdentifier": {
+      "universal-identifier-2": "field-id-2",
+    },
+    "universalIdentifiersByApplicationId": {
+      "application-id-1": [
+        "universal-identifier-2",
+      ],
+    },
+  },
+  "updatedFlatEntityMaps": {
+    "byId": {
+      "field-id-1": {
+        "updates": [
+          {
+            "from": true,
+            "property": "isActive",
+            "to": false,
+          },
+        ],
+      },
+    },
+  },
+}
+`;
+
+exports[`flatEntityDeletedCreatedUpdatedMatrixDispatcher It should not detect deleted entities when inferDeletionFromMissingEntities is false 1`] = `
+{
+  "createdFlatEntityMaps": {
+    "byId": {},
+    "idByUniversalIdentifier": {},
+    "universalIdentifiersByApplicationId": {},
+  },
+  "deletedFlatEntityMaps": {
+    "byId": {},
+    "idByUniversalIdentifier": {},
+    "universalIdentifiersByApplicationId": {},
+  },
+  "updatedFlatEntityMaps": {
+    "byId": {},
+  },
+}
+`;

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/utils/__tests__/flat-entity-deleted-created-updated-matrix-dispatcher.util.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/utils/__tests__/flat-entity-deleted-created-updated-matrix-dispatcher.util.spec.ts
@@ -1,28 +1,195 @@
+import { MetadataFlatEntity } from 'src/engine/metadata-modules/flat-entity/types/metadata-flat-entity.type';
+import { getFlatFieldMetadataMock } from 'src/engine/metadata-modules/flat-field-metadata/__mocks__/get-flat-field-metadata.mock';
+import { flatEntityDeletedCreatedUpdatedMatrixDispatcher } from 'src/engine/workspace-manager/workspace-migration-v2/utils/flat-entity-deleted-created-updated-matrix-dispatcher.util';
+import { type WorkspaceMigrationBuilderOptions } from 'src/engine/workspace-manager/workspace-migration-v2/workspace-migration-builder-v2/types/workspace-migration-builder-options.type';
 import {
-    eachTestingContextFilter,
-    type EachTestingContext,
+  eachTestingContextFilter,
+  type EachTestingContext,
 } from 'twenty-shared/testing';
+import { FieldMetadataType, FromTo } from 'twenty-shared/types';
 
-
-type TestContext = {
-  input: {
-    // Define input properties here
-  };
-  expected: {
-    // Define expected output properties here
-  };
+type TestContext = FromTo<MetadataFlatEntity<'fieldMetadata'>[]> & {
+  metadataName: 'fieldMetadata';
+  buildOptions: WorkspaceMigrationBuilderOptions;
 };
 
 describe('flatEntityDeletedCreatedUpdatedMatrixDispatcher', () => {
-  const testCases: EachTestingContext<TestContext>[] = [
-    // Add test cases here
-  ];
+  const testCases = [
+    {
+      title: 'It should detect a created entity',
+      context: {
+        from: [],
+        to: [
+          getFlatFieldMetadataMock({
+            objectMetadataId: 'object-metadata-id-1',
+            type: FieldMetadataType.TEXT,
+            universalIdentifier: 'universal-identifier-1',
+            id: 'field-id-1',
+            workspaceId: 'workspace-id-1',
+            applicationId: 'application-id-1',
+            createdAt: new Date('2024-01-01T00:00:00.000Z'),
+            updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+          }),
+        ],
+        metadataName: 'fieldMetadata',
+        buildOptions: {
+          inferDeletionFromMissingEntities: { fieldMetadata: false },
+          isSystemBuild: false,
+        },
+      },
+    },
+    {
+      title: 'It should detect a deleted entity',
+      context: {
+        from: [
+          getFlatFieldMetadataMock({
+            objectMetadataId: 'object-metadata-id-1',
+            type: FieldMetadataType.TEXT,
+            universalIdentifier: 'universal-identifier-1',
+            id: 'field-id-1',
+            workspaceId: 'workspace-id-1',
+            applicationId: 'application-id-1',
+            createdAt: new Date('2024-01-01T00:00:00.000Z'),
+            updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+          }),
+        ],
+        to: [],
+        metadataName: 'fieldMetadata',
+        buildOptions: {
+          inferDeletionFromMissingEntities: { fieldMetadata: true },
+          isSystemBuild: false,
+        },
+      },
+    },
+    {
+      title: 'It should detect an updated entity',
+      context: {
+        from: [
+          getFlatFieldMetadataMock({
+            objectMetadataId: 'object-metadata-id-1',
+            type: FieldMetadataType.TEXT,
+            universalIdentifier: 'universal-identifier-1',
+            id: 'field-id-1',
+            workspaceId: 'workspace-id-1',
+            applicationId: 'application-id-1',
+            createdAt: new Date('2024-01-01T00:00:00.000Z'),
+            updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+            isActive: false,
+          }),
+        ],
+        to: [
+          getFlatFieldMetadataMock({
+            objectMetadataId: 'object-metadata-id-1',
+            type: FieldMetadataType.TEXT,
+            universalIdentifier: 'universal-identifier-1',
+            id: 'field-id-1',
+            workspaceId: 'workspace-id-1',
+            applicationId: 'application-id-1',
+            createdAt: new Date('2024-01-01T00:00:00.000Z'),
+            updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+            isActive: true,
+          }),
+        ],
+        metadataName: 'fieldMetadata',
+        buildOptions: {
+          inferDeletionFromMissingEntities: { fieldMetadata: false },
+          isSystemBuild: false,
+        },
+      },
+    },
+    {
+      title: 'It should detect created, deleted and updated entities',
+      context: {
+        from: [
+          getFlatFieldMetadataMock({
+            objectMetadataId: 'object-metadata-id-1',
+            type: FieldMetadataType.TEXT,
+            universalIdentifier: 'universal-identifier-1',
+            id: 'field-id-1',
+            workspaceId: 'workspace-id-1',
+            applicationId: 'application-id-1',
+            createdAt: new Date('2024-01-01T00:00:00.000Z'),
+            updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+            isActive: true,
+          }),
+          getFlatFieldMetadataMock({
+            objectMetadataId: 'object-metadata-id-1',
+            type: FieldMetadataType.TEXT,
+            universalIdentifier: 'universal-identifier-2',
+            id: 'field-id-2',
+            workspaceId: 'workspace-id-1',
+            applicationId: 'application-id-1',
+            createdAt: new Date('2024-01-01T00:00:00.000Z'),
+            updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+          }),
+        ],
+        to: [
+          getFlatFieldMetadataMock({
+            objectMetadataId: 'object-metadata-id-1',
+            type: FieldMetadataType.TEXT,
+            universalIdentifier: 'universal-identifier-1',
+            id: 'field-id-1',
+            workspaceId: 'workspace-id-1',
+            applicationId: 'application-id-1',
+            createdAt: new Date('2024-01-01T00:00:00.000Z'),
+            updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+            isActive: false,
+          }),
+          getFlatFieldMetadataMock({
+            objectMetadataId: 'object-metadata-id-1',
+            type: FieldMetadataType.TEXT,
+            universalIdentifier: 'universal-identifier-3',
+            id: 'field-id-3',
+            workspaceId: 'workspace-id-1',
+            applicationId: 'application-id-1',
+            createdAt: new Date('2024-01-01T00:00:00.000Z'),
+            updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+          }),
+        ],
+        metadataName: 'fieldMetadata',
+        buildOptions: {
+          inferDeletionFromMissingEntities: { fieldMetadata: true },
+          isSystemBuild: false,
+        },
+      },
+    },
+    {
+      title:
+        'It should not detect deleted entities when inferDeletionFromMissingEntities is false',
+      context: {
+        from: [
+          getFlatFieldMetadataMock({
+            objectMetadataId: 'object-metadata-id-1',
+            type: FieldMetadataType.TEXT,
+            universalIdentifier: 'universal-identifier-1',
+            id: 'field-id-1',
+            workspaceId: 'workspace-id-1',
+            applicationId: 'application-id-1',
+            createdAt: new Date('2024-01-01T00:00:00.000Z'),
+            updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+          }),
+        ],
+        to: [],
+        metadataName: 'fieldMetadata',
+        buildOptions: {
+          inferDeletionFromMissingEntities: { fieldMetadata: false },
+          isSystemBuild: false,
+        },
+      },
+    },
+  ] as EachTestingContext<TestContext>[];
 
   test.each(eachTestingContextFilter(testCases))(
     '$title',
-    ({ context: { input, expected } }) => {
-      // Add test implementation here
+    ({ context: { from, to, metadataName, buildOptions } }) => {
+      const result = flatEntityDeletedCreatedUpdatedMatrixDispatcher({
+        from: from as any,
+        to: to as any,
+        metadataName,
+        buildOptions,
+      });
+
+      expect(result).toMatchSnapshot();
     },
   );
 });
-

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/utils/__tests__/flat-entity-deleted-created-updated-matrix-dispatcher.util.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/utils/__tests__/flat-entity-deleted-created-updated-matrix-dispatcher.util.spec.ts
@@ -1,12 +1,13 @@
-import { MetadataFlatEntity } from 'src/engine/metadata-modules/flat-entity/types/metadata-flat-entity.type';
-import { getFlatFieldMetadataMock } from 'src/engine/metadata-modules/flat-field-metadata/__mocks__/get-flat-field-metadata.mock';
-import { flatEntityDeletedCreatedUpdatedMatrixDispatcher } from 'src/engine/workspace-manager/workspace-migration-v2/utils/flat-entity-deleted-created-updated-matrix-dispatcher.util';
-import { type WorkspaceMigrationBuilderOptions } from 'src/engine/workspace-manager/workspace-migration-v2/workspace-migration-builder-v2/types/workspace-migration-builder-options.type';
 import {
   eachTestingContextFilter,
   type EachTestingContext,
 } from 'twenty-shared/testing';
-import { FieldMetadataType, FromTo } from 'twenty-shared/types';
+import { FieldMetadataType, type FromTo } from 'twenty-shared/types';
+
+import { type MetadataFlatEntity } from 'src/engine/metadata-modules/flat-entity/types/metadata-flat-entity.type';
+import { getFlatFieldMetadataMock } from 'src/engine/metadata-modules/flat-field-metadata/__mocks__/get-flat-field-metadata.mock';
+import { flatEntityDeletedCreatedUpdatedMatrixDispatcher } from 'src/engine/workspace-manager/workspace-migration-v2/utils/flat-entity-deleted-created-updated-matrix-dispatcher.util';
+import { type WorkspaceMigrationBuilderOptions } from 'src/engine/workspace-manager/workspace-migration-v2/workspace-migration-builder-v2/types/workspace-migration-builder-options.type';
 
 type TestContext = FromTo<MetadataFlatEntity<'fieldMetadata'>[]> & {
   metadataName: 'fieldMetadata';

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/utils/__tests__/flat-entity-deleted-created-updated-matrix-dispatcher.util.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/utils/__tests__/flat-entity-deleted-created-updated-matrix-dispatcher.util.spec.ts
@@ -1,0 +1,28 @@
+import {
+    eachTestingContextFilter,
+    type EachTestingContext,
+} from 'twenty-shared/testing';
+
+
+type TestContext = {
+  input: {
+    // Define input properties here
+  };
+  expected: {
+    // Define expected output properties here
+  };
+};
+
+describe('flatEntityDeletedCreatedUpdatedMatrixDispatcher', () => {
+  const testCases: EachTestingContext<TestContext>[] = [
+    // Add test cases here
+  ];
+
+  test.each(eachTestingContextFilter(testCases))(
+    '$title',
+    ({ context: { input, expected } }) => {
+      // Add test implementation here
+    },
+  );
+});
+

--- a/packages/twenty-server/test/integration/metadata/suites/field-metadata/__snapshots__/successful-update-one-standard-field-metadata.integration-spec.ts.snap
+++ b/packages/twenty-server/test/integration/metadata/suites/field-metadata/__snapshots__/successful-update-one-standard-field-metadata.integration-spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Standard field metadata update should succeed when setting isActive to false 1`] = `
+exports[`Standard field metadata update should succeed Atomic update test suite when setting isActive to false 1`] = `
 {
   "defaultValue": "'NEW'",
   "description": "Opportunity stage",
@@ -51,7 +51,7 @@ exports[`Standard field metadata update should succeed when setting isActive to 
 }
 `;
 
-exports[`Standard field metadata update should succeed when updating defaultValue 1`] = `
+exports[`Standard field metadata update should succeed Atomic update test suite when updating defaultValue 1`] = `
 {
   "defaultValue": "'SCREENING'",
   "description": "Opportunity stage",
@@ -102,7 +102,7 @@ exports[`Standard field metadata update should succeed when updating defaultValu
 }
 `;
 
-exports[`Standard field metadata update should succeed when updating description 1`] = `
+exports[`Standard field metadata update should succeed Atomic update test suite when updating description 1`] = `
 {
   "defaultValue": "'NEW'",
   "description": "Opportunity stage",
@@ -157,7 +157,7 @@ exports[`Standard field metadata update should succeed when updating description
 }
 `;
 
-exports[`Standard field metadata update should succeed when updating icon 1`] = `
+exports[`Standard field metadata update should succeed Atomic update test suite when updating icon 1`] = `
 {
   "defaultValue": "'NEW'",
   "description": "Opportunity stage",
@@ -212,7 +212,7 @@ exports[`Standard field metadata update should succeed when updating icon 1`] = 
 }
 `;
 
-exports[`Standard field metadata update should succeed when updating label 1`] = `
+exports[`Standard field metadata update should succeed Atomic update test suite when updating label 1`] = `
 {
   "defaultValue": "'NEW'",
   "description": "Opportunity stage",
@@ -267,7 +267,7 @@ exports[`Standard field metadata update should succeed when updating label 1`] =
 }
 `;
 
-exports[`Standard field metadata update should succeed when updating options 1`] = `
+exports[`Standard field metadata update should succeed Atomic update test suite when updating options 1`] = `
 {
   "defaultValue": "'NEW'",
   "description": "Opportunity stage",

--- a/packages/twenty-server/test/integration/metadata/suites/field-metadata/successful-update-one-standard-field-metadata.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/field-metadata/successful-update-one-standard-field-metadata.integration-spec.ts
@@ -79,6 +79,7 @@ const successfulUpdateTestsUseCase: UpdateOneStandardFieldMetadataTestingContext
 describe('Standard field metadata update should succeed', () => {
   const opportunityObjectFields: FieldMetadataDTO[] = [];
   let originalFieldMetadataToRestore: FieldMetadataDTO[] = [];
+  let originalStageFieldMetadata: FieldMetadataDTO | undefined;
 
   beforeAll(async () => {
     const { objects } = await findManyObjectMetadata({
@@ -118,6 +119,10 @@ describe('Standard field metadata update should succeed', () => {
     jestExpectToBeDefined(opportunityObject?.fieldsList);
 
     opportunityObjectFields.push(...opportunityObject.fieldsList);
+
+    originalStageFieldMetadata = opportunityObjectFields.find(
+      (field) => field.name === 'stage' && !field.isCustom,
+    );
   });
 
   afterEach(async () => {
@@ -142,9 +147,6 @@ describe('Standard field metadata update should succeed', () => {
   });
 
   describe('Atomic update test suite', () => {
-    const originalStageFieldMetadata = opportunityObjectFields.find(
-      (field) => field.name === 'stage' && !field.isCustom,
-    );
     it.each(eachTestingContextFilter(successfulUpdateTestsUseCase))(
       '$title',
       async ({ context }) => {
@@ -187,6 +189,7 @@ describe('Standard field metadata update should succeed', () => {
     const deletedAtField = opportunityObjectFields.find(
       (field) => field.name === 'deletedAt',
     );
+
     jestExpectToBeDefined(deletedAtField);
     expect(deletedAtField.isActive).toBe(true);
 
@@ -222,7 +225,7 @@ describe('Standard field metadata update should succeed', () => {
       input: {
         idToUpdate: deletedAtField.id,
         updatePayload: {
-          isActive: false,
+          isActive: true,
         },
       },
       expectToFail: false,
@@ -243,6 +246,7 @@ describe('Standard field metadata update should succeed', () => {
           }
         `,
     });
+
     expect(secondUpdateData.updateOneField.isActive).toBe(true);
   });
 });

--- a/packages/twenty-server/test/integration/metadata/suites/field-metadata/successful-update-one-standard-field-metadata.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/field-metadata/successful-update-one-standard-field-metadata.integration-spec.ts
@@ -185,7 +185,7 @@ describe('Standard field metadata update should succeed', () => {
     );
   });
 
-  it('Should deactivate and reactivate standard field successfully', async () => {
+  it.failing('Should deactivate and reactivate standard field successfully', async () => {
     const deletedAtField = opportunityObjectFields.find(
       (field) => field.name === 'deletedAt',
     );

--- a/packages/twenty-server/test/integration/metadata/suites/field-metadata/successful-update-one-standard-field-metadata.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/field-metadata/successful-update-one-standard-field-metadata.integration-spec.ts
@@ -185,23 +185,25 @@ describe('Standard field metadata update should succeed', () => {
     );
   });
 
-  it.failing('Should deactivate and reactivate standard field successfully', async () => {
-    const deletedAtField = opportunityObjectFields.find(
-      (field) => field.name === 'deletedAt',
-    );
+  it.failing(
+    'Should deactivate and reactivate standard field successfully',
+    async () => {
+      const deletedAtField = opportunityObjectFields.find(
+        (field) => field.name === 'deletedAt',
+      );
 
-    jestExpectToBeDefined(deletedAtField);
-    expect(deletedAtField.isActive).toBe(true);
+      jestExpectToBeDefined(deletedAtField);
+      expect(deletedAtField.isActive).toBe(true);
 
-    const { data: firstUpdateData } = await updateOneFieldMetadata({
-      input: {
-        idToUpdate: deletedAtField.id,
-        updatePayload: {
-          isActive: false,
+      const { data: firstUpdateData } = await updateOneFieldMetadata({
+        input: {
+          idToUpdate: deletedAtField.id,
+          updatePayload: {
+            isActive: false,
+          },
         },
-      },
-      expectToFail: false,
-      gqlFields: `
+        expectToFail: false,
+        gqlFields: `
           id
           name
           label
@@ -217,19 +219,19 @@ describe('Standard field metadata update should succeed', () => {
             icon
           }
         `,
-    });
+      });
 
-    expect(firstUpdateData.updateOneField.isActive).toBe(false);
+      expect(firstUpdateData.updateOneField.isActive).toBe(false);
 
-    const { data: secondUpdateData } = await updateOneFieldMetadata({
-      input: {
-        idToUpdate: deletedAtField.id,
-        updatePayload: {
-          isActive: true,
+      const { data: secondUpdateData } = await updateOneFieldMetadata({
+        input: {
+          idToUpdate: deletedAtField.id,
+          updatePayload: {
+            isActive: true,
+          },
         },
-      },
-      expectToFail: false,
-      gqlFields: `
+        expectToFail: false,
+        gqlFields: `
           id
           name
           label
@@ -245,8 +247,9 @@ describe('Standard field metadata update should succeed', () => {
             icon
           }
         `,
-    });
+      });
 
-    expect(secondUpdateData.updateOneField.isActive).toBe(true);
-  });
+      expect(secondUpdateData.updateOneField.isActive).toBe(true);
+    },
+  );
 });


### PR DESCRIPTION
# Introduction
Related https://github.com/twentyhq/twenty/issues/15846

The root cause is that universalIdentifier is still optional in database and fallbacked when extracted out of database to standardId. But all `BaseWorkspaceEntity` and `CustomWorkspaceEntity` share the same standardId for their default standard fields `createdAt` `deletedAt` resulting in such compare result in dispatcher

```ts
{
  "initialDispatcher": {
    "createdFlatEntityMaps": {
      "byId": {},
      "idByUniversalIdentifier": {},
      "universalIdentifiersByApplicationId": {}
    },
    "deletedFlatEntityMaps": {
      "byId": {},
      "idByUniversalIdentifier": {},
      "universalIdentifiersByApplicationId": {}
    },
    "updatedFlatEntityMaps": {
      "byId": {
        "55e1568c-eb87-4b8a-9f1b-19bbf6042f3e": {
          "updates": [
            {
              "from": "Deletion date",
              "to": "Date when the record was deleted",
              "property": "description"
            },
            {
              "from": "IconCalendarClock",
              "to": "IconCalendarMinus",
              "property": "icon"
            },
            {
              "from": false,
              "to": true,
              "property": "isLabelSyncedWithName"
            },
            {
              "from": null,
              "to": {
                "displayFormat": "RELATIVE"
              },
              "property": "settings"
            }
          ]
        }
      }
    }
  },
  "fromFlatEntity": {
    "universalIdentifier": "20202020-b9a7-48d8-8387-b9a3090a50ec",
    "applicationId": null,
    "id": "9c97c8bf-1f64-463c-915c-f68f41d3cd60",
    "standardId": "20202020-b9a7-48d8-8387-b9a3090a50ec",
    "objectMetadataId": "e9565126-8351-457b-b003-3ea4c6d253bc",
    "type": "DATE_TIME",
    "name": "deletedAt",
    "label": "Deleted at",
    "defaultValue": null,
    "description": "Deletion date",
    "icon": "IconCalendarClock",
    "standardOverrides": null,
    "options": null,
    "settings": null,
    "isCustom": false,
    "isActive": true,
    "isSystem": false,
    "isUIReadOnly": true,
    "isNullable": true,
    "isUnique": false,
    "workspaceId": "20202020-1c25-4d02-bf25-6aeccf7ea419",
    "isLabelSyncedWithName": false,
    "relationTargetFieldMetadataId": null,
    "relationTargetObjectMetadataId": null,
    "morphId": null,
    "createdAt": "2025-11-20T17:28:45.474Z",
    "updatedAt": "2025-11-20T17:28:45.474Z",
    "kanbanAggregateOperationViewIds": [],
    "calendarViewIds": [],
    "viewGroupIds": [],
    "viewFieldIds": [],
    "viewFilterIds": []
  },
  "toFlatEntity": {
    "universalIdentifier": "20202020-b9a7-48d8-8387-b9a3090a50ec",
    "applicationId": null,
    "id": "55e1568c-eb87-4b8a-9f1b-19bbf6042f3e",
    "standardId": "20202020-b9a7-48d8-8387-b9a3090a50ec",
    "objectMetadataId": "37263f48-6858-4d28-a6e1-5f7321e49c24",
    "type": "DATE_TIME",
    "name": "deletedAt",
    "label": "Deleted at",
    "defaultValue": null,
    "description": "Date when the record was deleted",
    "icon": "IconCalendarMinus",
    "standardOverrides": null,
    "options": null,
    "settings": {
      "displayFormat": "RELATIVE"
    },
    "isCustom": false,
    "isActive": true,
    "isSystem": false,
    "isUIReadOnly": true,
    "isNullable": true,
    "isUnique": false,
    "workspaceId": "20202020-1c25-4d02-bf25-6aeccf7ea419",
    "isLabelSyncedWithName": true,
    "relationTargetFieldMetadataId": null,
    "relationTargetObjectMetadataId": null,
    "morphId": null,
    "createdAt": "2025-11-20T17:28:44.267Z",
    "updatedAt": "2025-11-21T17:17:55.057Z",
    "kanbanAggregateOperationViewIds": [],
    "calendarViewIds": [],
    "viewGroupIds": [],
    "viewFieldIds": [],
    "viewFilterIds": []
  }
}
```

## Impact
- This might be corrupting label and description of an other standard field of an other object
- Race condition on latest universalIdentifier assigned in cache making the update sometime accurate sometimes not

## Fix
Will be fixed by the in coming work on applicationId and universalIdentifier as required in database + upgrade command that will handle retro-comp. ( won't handle description corruption though, should be anecdotical )
https://github.com/twentyhq/twenty/pull/15911 ( handling this only for new workspace, retro comp upgrade command will be coming just after  )

## PR scope
- Introduce TDD integration tests as failing
- Added unit test to critical methods that might have been involved in the root cause ( still worth it to keep )