### PR TITLE
Prevent NUMERIC field type creation via API

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata-validation.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata-validation.service.ts
@@ -167,6 +167,14 @@ export class FieldMetadataValidationService {
     objectMetadata,
     existingFieldMetadata,
   }: ValidateFieldMetadataArgs): Promise<void> {
+        // Prevent NUMERIC field type from being created via API
+    if (fieldMetadataType === FieldMetadataType.NUMERIC) {
+      throw new FieldMetadataException(
+        'NUMERIC field type cannot be created via API. Please use NUMBER type instead.',
+        FieldMetadataExceptionCode.INVALID_FIELD_INPUT,
+      );
+    }
+
     if (fieldMetadataInput.name) {
       try {
         validateMetadataNameOrThrow(fieldMetadataInput.name);

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata-validation.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata-validation.service.ts
@@ -167,14 +167,7 @@ export class FieldMetadataValidationService {
     objectMetadata,
     existingFieldMetadata,
   }: ValidateFieldMetadataArgs): Promise<void> {
-        // Prevent NUMERIC field type from being created via API
-    if (fieldMetadataType === FieldMetadataType.NUMERIC) {
-      throw new FieldMetadataException(
-        'NUMERIC field type cannot be created via API. Please use NUMBER type instead.',
-        FieldMetadataExceptionCode.INVALID_FIELD_INPUT,
-      );
-    }
-
+        
     if (fieldMetadataInput.name) {
       try {
         validateMetadataNameOrThrow(fieldMetadataInput.name);

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/from-create-field-input-to-flat-field-metadatas-to-create.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/from-create-field-input-to-flat-field-metadatas-to-create.util.ts
@@ -1,4 +1,5 @@
-import { msg } from '@lingui/core/macro';
+157
+  import { msg } from '@lingui/core/macro';
 import {
   FieldMetadataType,
   type FieldMetadataOptions,
@@ -154,6 +155,15 @@ export const fromCreateFieldInputToFlatFieldMetadatasToCreate = async ({
           message: 'TS Vector is not supported for field creation',
         },
       };
+          case FieldMetadataType.NUMERIC: {
+      return {
+        status: 'fail',
+        error: {
+          code: FieldMetadataExceptionCode.INVALID_FIELD_INPUT,
+          message: 'NUMERIC field type cannot be created via API. Please use NUMBER type instead.',
+        },
+      };
+    }
     }
     case FieldMetadataType.UUID:
     case FieldMetadataType.TEXT:
@@ -163,7 +173,6 @@ export const fromCreateFieldInputToFlatFieldMetadatasToCreate = async ({
     case FieldMetadataType.DATE:
     case FieldMetadataType.BOOLEAN:
     case FieldMetadataType.NUMBER:
-    case FieldMetadataType.NUMERIC:
     case FieldMetadataType.LINKS:
     case FieldMetadataType.CURRENCY:
     case FieldMetadataType.FULL_NAME:


### PR DESCRIPTION
Add validation to prevent creation of NUMERIC field type via API.

Fixes #16023

## Changes
- Added validation in `fromCreateFieldInputToFlatFieldMetadatasToCreate` utility to prevent NUMERIC field type creation
- NUMERIC type causes data access issues for users
- Users should use NUMBER type instead
- Includes proper error handling with user-friendly message

## Related
This PR addresses the issue identified in #16023 where users were able to create NUMERIC fields via the API, leading to data access problems. The validation has been placed in the correct location within the field creation flow.