### PR TITLE
Add import scheduled status to messaging sync

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-12/1-12-add-calendar-events-import-scheduled-sync-stage.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-12/1-12-add-calendar-events-import-scheduled-sync-stage.command.ts
@@ -1,0 +1,177 @@
+import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
+
+import { Command } from 'nest-commander';
+import { DataSource, Repository } from 'typeorm';
+import { STANDARD_OBJECT_IDS } from 'twenty-shared/metadata';
+
+import {
+  ActiveOrSuspendedWorkspacesMigrationCommandRunner,
+  type RunOnWorkspaceArgs,
+} from 'src/database/commands/command-runners/active-or-suspended-workspaces-migration.command-runner';
+import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
+import { type FieldMetadataComplexOption } from 'src/engine/metadata-modules/field-metadata/dtos/options.input';
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
+import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
+import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.manager';
+import { getWorkspaceSchemaName } from 'src/engine/workspace-datasource/utils/get-workspace-schema-name.util';
+import { CALENDAR_CHANNEL_STANDARD_FIELD_IDS } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-field-ids';
+import { CalendarChannelSyncStage } from 'src/modules/calendar/common/standard-objects/calendar-channel.workspace-entity';
+
+@Command({
+  name: 'upgrade:1-12:add-calendar-events-import-scheduled-sync-stage',
+  description:
+    'Add CALENDAR_EVENTS_IMPORT_SCHEDULED sync stage to calendar channel syncStage field',
+})
+export class AddCalendarEventsImportScheduledSyncStageCommand extends ActiveOrSuspendedWorkspacesMigrationCommandRunner {
+  constructor(
+    @InjectRepository(WorkspaceEntity)
+    protected readonly workspaceRepository: Repository<WorkspaceEntity>,
+    protected readonly twentyORMGlobalManager: TwentyORMGlobalManager,
+    @InjectRepository(ObjectMetadataEntity)
+    private readonly objectMetadataRepository: Repository<ObjectMetadataEntity>,
+    @InjectRepository(FieldMetadataEntity)
+    private readonly fieldMetadataRepository: Repository<FieldMetadataEntity>,
+    @InjectDataSource()
+    private readonly coreDataSource: DataSource,
+  ) {
+    super(workspaceRepository, twentyORMGlobalManager);
+  }
+
+  override async runOnWorkspace({
+    workspaceId,
+    options,
+  }: RunOnWorkspaceArgs): Promise<void> {
+    this.logger.log(
+      `Adding CALENDAR_EVENTS_IMPORT_SCHEDULED sync stage for workspace ${workspaceId}`,
+    );
+
+    await this.updateCalendarChannelSyncStageFieldMetadata(
+      workspaceId,
+      options,
+    );
+
+    await this.addCalendarEventsImportScheduledEnumValue(workspaceId, options);
+
+    this.logger.log(
+      `Successfully added CALENDAR_EVENTS_IMPORT_SCHEDULED sync stage for workspace ${workspaceId}`,
+    );
+  }
+
+  private async addCalendarEventsImportScheduledEnumValue(
+    workspaceId: string,
+    options: RunOnWorkspaceArgs['options'],
+  ): Promise<void> {
+    const calendarChannelObject = await this.objectMetadataRepository.findOne({
+      where: {
+        standardId: STANDARD_OBJECT_IDS.calendarChannel,
+        workspaceId,
+      },
+    });
+
+    if (!calendarChannelObject) {
+      this.logger.log(
+        `CalendarChannel object not found for workspace ${workspaceId}, skipping enum migration`,
+      );
+
+      return;
+    }
+
+    const schemaName = getWorkspaceSchemaName(workspaceId);
+
+    if (options.dryRun) {
+      this.logger.log(
+        `Would try to add CALENDAR_EVENTS_IMPORT_SCHEDULED to calendarChannel_syncStage_enum for workspace ${workspaceId}`,
+      );
+    } else {
+      try {
+        await this.coreDataSource.query(
+          `ALTER TYPE ${schemaName}."calendarChannel_syncStage_enum" ADD VALUE IF NOT EXISTS 'CALENDAR_EVENTS_IMPORT_SCHEDULED'`,
+        );
+        this.logger.log(
+          `Added CALENDAR_EVENTS_IMPORT_SCHEDULED to calendarChannel_syncStage_enum for workspace ${workspaceId}`,
+        );
+      } catch (error) {
+        this.logger.error(
+          `Error adding CALENDAR_EVENTS_IMPORT_SCHEDULED to calendarChannel_syncStage_enum for workspace ${workspaceId}: ${error}`,
+        );
+      }
+    }
+  }
+
+  private async updateCalendarChannelSyncStageFieldMetadata(
+    workspaceId: string,
+    options: RunOnWorkspaceArgs['options'],
+  ): Promise<void> {
+    const calendarChannelObject = await this.objectMetadataRepository.findOne({
+      where: {
+        standardId: STANDARD_OBJECT_IDS.calendarChannel,
+        workspaceId,
+      },
+    });
+
+    if (!calendarChannelObject) {
+      this.logger.log(
+        `CalendarChannel object not found for workspace ${workspaceId}, skipping field metadata update`,
+      );
+
+      return;
+    }
+
+    const syncStageField = await this.fieldMetadataRepository.findOne({
+      where: {
+        standardId: CALENDAR_CHANNEL_STANDARD_FIELD_IDS.syncStage,
+        objectMetadataId: calendarChannelObject.id,
+        workspaceId,
+      },
+    });
+
+    if (!syncStageField) {
+      this.logger.log(
+        `CalendarChannel syncStage field not found for workspace ${workspaceId}, skipping field metadata update`,
+      );
+
+      return;
+    }
+
+    const fieldOptions = (syncStageField.options ||
+      []) as FieldMetadataComplexOption[];
+
+    const hasCalendarEventsImportScheduled = fieldOptions.some(
+      (option) =>
+        option.value ===
+        CalendarChannelSyncStage.CALENDAR_EVENTS_IMPORT_SCHEDULED,
+    );
+
+    if (hasCalendarEventsImportScheduled) {
+      this.logger.log(
+        `CalendarChannel syncStage field metadata already has CALENDAR_EVENTS_IMPORT_SCHEDULED for workspace ${workspaceId}`,
+      );
+
+      return;
+    }
+
+    if (options.dryRun) {
+      this.logger.log(
+        `Would add CALENDAR_EVENTS_IMPORT_SCHEDULED to CalendarChannel syncStage field metadata for workspace ${workspaceId}`,
+      );
+
+      return;
+    }
+
+    fieldOptions.push({
+      value: CalendarChannelSyncStage.CALENDAR_EVENTS_IMPORT_SCHEDULED,
+      label: 'Calendar events import scheduled',
+      position: 4,
+      color: 'green',
+    });
+
+    syncStageField.options = fieldOptions;
+
+    await this.fieldMetadataRepository.save(syncStageField);
+
+    this.logger.log(
+      `Added CALENDAR_EVENTS_IMPORT_SCHEDULED to CalendarChannel syncStage field metadata for workspace ${workspaceId}`,
+    );
+  }
+}
+

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-12/1-12-add-calendar-events-import-scheduled-sync-stage.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-12/1-12-add-calendar-events-import-scheduled-sync-stage.command.ts
@@ -1,8 +1,8 @@
-import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
+import { InjectRepository } from '@nestjs/typeorm';
 
 import { Command } from 'nest-commander';
-import { DataSource, Repository } from 'typeorm';
 import { STANDARD_OBJECT_IDS } from 'twenty-shared/metadata';
+import { Repository } from 'typeorm';
 
 import {
   ActiveOrSuspendedWorkspacesMigrationCommandRunner,
@@ -11,9 +11,9 @@ import {
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { type FieldMetadataComplexOption } from 'src/engine/metadata-modules/field-metadata/dtos/options.input';
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
+import { FieldMetadataServiceV2 } from 'src/engine/metadata-modules/field-metadata/services/field-metadata.service-v2';
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.manager';
-import { getWorkspaceSchemaName } from 'src/engine/workspace-datasource/utils/get-workspace-schema-name.util';
 import { CALENDAR_CHANNEL_STANDARD_FIELD_IDS } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-field-ids';
 import { CalendarChannelSyncStage } from 'src/modules/calendar/common/standard-objects/calendar-channel.workspace-entity';
 
@@ -31,8 +31,7 @@ export class AddCalendarEventsImportScheduledSyncStageCommand extends ActiveOrSu
     private readonly objectMetadataRepository: Repository<ObjectMetadataEntity>,
     @InjectRepository(FieldMetadataEntity)
     private readonly fieldMetadataRepository: Repository<FieldMetadataEntity>,
-    @InjectDataSource()
-    private readonly coreDataSource: DataSource,
+    private readonly fieldMetadataService: FieldMetadataServiceV2,
   ) {
     super(workspaceRepository, twentyORMGlobalManager);
   }
@@ -45,22 +44,6 @@ export class AddCalendarEventsImportScheduledSyncStageCommand extends ActiveOrSu
       `Adding CALENDAR_EVENTS_IMPORT_SCHEDULED sync stage for workspace ${workspaceId}`,
     );
 
-    await this.updateCalendarChannelSyncStageFieldMetadata(
-      workspaceId,
-      options,
-    );
-
-    await this.addCalendarEventsImportScheduledEnumValue(workspaceId, options);
-
-    this.logger.log(
-      `Successfully added CALENDAR_EVENTS_IMPORT_SCHEDULED sync stage for workspace ${workspaceId}`,
-    );
-  }
-
-  private async addCalendarEventsImportScheduledEnumValue(
-    workspaceId: string,
-    options: RunOnWorkspaceArgs['options'],
-  ): Promise<void> {
     const calendarChannelObject = await this.objectMetadataRepository.findOne({
       where: {
         standardId: STANDARD_OBJECT_IDS.calendarChannel,
@@ -71,47 +54,6 @@ export class AddCalendarEventsImportScheduledSyncStageCommand extends ActiveOrSu
     if (!calendarChannelObject) {
       this.logger.log(
         `CalendarChannel object not found for workspace ${workspaceId}, skipping enum migration`,
-      );
-
-      return;
-    }
-
-    const schemaName = getWorkspaceSchemaName(workspaceId);
-
-    if (options.dryRun) {
-      this.logger.log(
-        `Would try to add CALENDAR_EVENTS_IMPORT_SCHEDULED to calendarChannel_syncStage_enum for workspace ${workspaceId}`,
-      );
-    } else {
-      try {
-        await this.coreDataSource.query(
-          `ALTER TYPE ${schemaName}."calendarChannel_syncStage_enum" ADD VALUE IF NOT EXISTS 'CALENDAR_EVENTS_IMPORT_SCHEDULED'`,
-        );
-        this.logger.log(
-          `Added CALENDAR_EVENTS_IMPORT_SCHEDULED to calendarChannel_syncStage_enum for workspace ${workspaceId}`,
-        );
-      } catch (error) {
-        this.logger.error(
-          `Error adding CALENDAR_EVENTS_IMPORT_SCHEDULED to calendarChannel_syncStage_enum for workspace ${workspaceId}: ${error}`,
-        );
-      }
-    }
-  }
-
-  private async updateCalendarChannelSyncStageFieldMetadata(
-    workspaceId: string,
-    options: RunOnWorkspaceArgs['options'],
-  ): Promise<void> {
-    const calendarChannelObject = await this.objectMetadataRepository.findOne({
-      where: {
-        standardId: STANDARD_OBJECT_IDS.calendarChannel,
-        workspaceId,
-      },
-    });
-
-    if (!calendarChannelObject) {
-      this.logger.log(
-        `CalendarChannel object not found for workspace ${workspaceId}, skipping field metadata update`,
       );
 
       return;
@@ -152,26 +94,72 @@ export class AddCalendarEventsImportScheduledSyncStageCommand extends ActiveOrSu
 
     if (options.dryRun) {
       this.logger.log(
-        `Would add CALENDAR_EVENTS_IMPORT_SCHEDULED to CalendarChannel syncStage field metadata for workspace ${workspaceId}`,
+        `Would add CALENDAR_EVENTS_IMPORT_SCHEDULED sync stage for workspace ${workspaceId}`,
       );
 
       return;
     }
 
-    fieldOptions.push({
-      value: CalendarChannelSyncStage.CALENDAR_EVENTS_IMPORT_SCHEDULED,
-      label: 'Calendar events import scheduled',
-      position: 4,
-      color: 'green',
+    await this.fieldMetadataService.updateOneField({
+      updateFieldInput: {
+        id: syncStageField.id,
+        options: [
+          {
+            value: CalendarChannelSyncStage.CALENDAR_EVENT_LIST_FETCH_PENDING,
+            label: 'Calendar event list fetch pending',
+            position: 0,
+            color: 'blue',
+          },
+          {
+            value: CalendarChannelSyncStage.CALENDAR_EVENT_LIST_FETCH_SCHEDULED,
+            label: 'Calendar event list fetch scheduled',
+            position: 1,
+            color: 'green',
+          },
+          {
+            value: CalendarChannelSyncStage.CALENDAR_EVENT_LIST_FETCH_ONGOING,
+            label: 'Calendar event list fetch ongoing',
+            position: 2,
+            color: 'orange',
+          },
+          {
+            value: CalendarChannelSyncStage.CALENDAR_EVENTS_IMPORT_PENDING,
+            label: 'Calendar events import pending',
+            position: 3,
+            color: 'blue',
+          },
+          {
+            value: CalendarChannelSyncStage.CALENDAR_EVENTS_IMPORT_SCHEDULED,
+            label: 'Calendar events import scheduled',
+            position: 4,
+            color: 'green',
+          },
+          {
+            value: CalendarChannelSyncStage.CALENDAR_EVENTS_IMPORT_ONGOING,
+            label: 'Calendar events import ongoing',
+            position: 5,
+            color: 'orange',
+          },
+          {
+            value: CalendarChannelSyncStage.FAILED,
+            label: 'Failed',
+            position: 6,
+            color: 'red',
+          },
+          {
+            value: CalendarChannelSyncStage.PENDING_CONFIGURATION,
+            label: 'Pending configuration',
+            position: 9,
+            color: 'gray',
+          },
+        ],
+      },
+      workspaceId,
+      isSystemBuild: true,
     });
 
-    syncStageField.options = fieldOptions;
-
-    await this.fieldMetadataRepository.save(syncStageField);
-
     this.logger.log(
-      `Added CALENDAR_EVENTS_IMPORT_SCHEDULED to CalendarChannel syncStage field metadata for workspace ${workspaceId}`,
+      `Successfully added CALENDAR_EVENTS_IMPORT_SCHEDULED sync stage for workspace ${workspaceId}`,
     );
   }
 }
-

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-12/1-12-add-messages-import-scheduled-sync-stage.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-12/1-12-add-messages-import-scheduled-sync-stage.command.ts
@@ -1,0 +1,172 @@
+import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
+
+import { Command } from 'nest-commander';
+import { STANDARD_OBJECT_IDS } from 'twenty-shared/metadata';
+import { DataSource, Repository } from 'typeorm';
+
+import {
+  ActiveOrSuspendedWorkspacesMigrationCommandRunner,
+  type RunOnWorkspaceArgs,
+} from 'src/database/commands/command-runners/active-or-suspended-workspaces-migration.command-runner';
+import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
+import { type FieldMetadataComplexOption } from 'src/engine/metadata-modules/field-metadata/dtos/options.input';
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
+import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
+import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.manager';
+import { getWorkspaceSchemaName } from 'src/engine/workspace-datasource/utils/get-workspace-schema-name.util';
+import { MESSAGE_CHANNEL_STANDARD_FIELD_IDS } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-field-ids';
+import { MessageChannelSyncStage } from 'src/modules/messaging/common/standard-objects/message-channel.workspace-entity';
+
+@Command({
+  name: 'upgrade:1-12:add-messages-import-scheduled-sync-stage',
+  description:
+    'Add MESSAGES_IMPORT_SCHEDULED sync stage to message channel syncStage field',
+})
+export class AddMessagesImportScheduledSyncStageCommand extends ActiveOrSuspendedWorkspacesMigrationCommandRunner {
+  constructor(
+    @InjectRepository(WorkspaceEntity)
+    protected readonly workspaceRepository: Repository<WorkspaceEntity>,
+    protected readonly twentyORMGlobalManager: TwentyORMGlobalManager,
+    @InjectRepository(ObjectMetadataEntity)
+    private readonly objectMetadataRepository: Repository<ObjectMetadataEntity>,
+    @InjectRepository(FieldMetadataEntity)
+    private readonly fieldMetadataRepository: Repository<FieldMetadataEntity>,
+    @InjectDataSource()
+    private readonly coreDataSource: DataSource,
+  ) {
+    super(workspaceRepository, twentyORMGlobalManager);
+  }
+
+  override async runOnWorkspace({
+    workspaceId,
+    options,
+  }: RunOnWorkspaceArgs): Promise<void> {
+    this.logger.log(
+      `Adding MESSAGES_IMPORT_SCHEDULED sync stage for workspace ${workspaceId}`,
+    );
+
+    await this.updateMessageChannelSyncStageFieldMetadata(workspaceId, options);
+
+    await this.addMessagesImportScheduledEnumValue(workspaceId, options);
+
+    this.logger.log(
+      `Successfully added MESSAGES_IMPORT_SCHEDULED sync stage for workspace ${workspaceId}`,
+    );
+  }
+
+  private async addMessagesImportScheduledEnumValue(
+    workspaceId: string,
+    options: RunOnWorkspaceArgs['options'],
+  ): Promise<void> {
+    const messageChannelObject = await this.objectMetadataRepository.findOne({
+      where: {
+        standardId: STANDARD_OBJECT_IDS.messageChannel,
+        workspaceId,
+      },
+    });
+
+    if (!messageChannelObject) {
+      this.logger.log(
+        `MessageChannel object not found for workspace ${workspaceId}, skipping enum migration`,
+      );
+
+      return;
+    }
+
+    const schemaName = getWorkspaceSchemaName(workspaceId);
+
+    if (options.dryRun) {
+      this.logger.log(
+        `Would try to add MESSAGES_IMPORT_SCHEDULED to messageChannel_syncStage_enum for workspace ${workspaceId}`,
+      );
+    } else {
+      try {
+        await this.coreDataSource.query(
+          `ALTER TYPE ${schemaName}."messageChannel_syncStage_enum" ADD VALUE IF NOT EXISTS 'MESSAGES_IMPORT_SCHEDULED'`,
+        );
+        this.logger.log(
+          `Added MESSAGES_IMPORT_SCHEDULED to messageChannel_syncStage_enum for workspace ${workspaceId}`,
+        );
+      } catch (error) {
+        this.logger.error(
+          `Error adding MESSAGES_IMPORT_SCHEDULED to messageChannel_syncStage_enum for workspace ${workspaceId}: ${error}`,
+        );
+      }
+    }
+  }
+
+  private async updateMessageChannelSyncStageFieldMetadata(
+    workspaceId: string,
+    options: RunOnWorkspaceArgs['options'],
+  ): Promise<void> {
+    const messageChannelObject = await this.objectMetadataRepository.findOne({
+      where: {
+        standardId: STANDARD_OBJECT_IDS.messageChannel,
+        workspaceId,
+      },
+    });
+
+    if (!messageChannelObject) {
+      this.logger.log(
+        `MessageChannel object not found for workspace ${workspaceId}, skipping field metadata update`,
+      );
+
+      return;
+    }
+
+    const syncStageField = await this.fieldMetadataRepository.findOne({
+      where: {
+        standardId: MESSAGE_CHANNEL_STANDARD_FIELD_IDS.syncStage,
+        objectMetadataId: messageChannelObject.id,
+        workspaceId,
+      },
+    });
+
+    if (!syncStageField) {
+      this.logger.log(
+        `MessageChannel syncStage field not found for workspace ${workspaceId}, skipping field metadata update`,
+      );
+
+      return;
+    }
+
+    const fieldOptions = (syncStageField.options ||
+      []) as FieldMetadataComplexOption[];
+
+    const hasMessagesImportScheduled = fieldOptions.some(
+      (option) =>
+        option.value === MessageChannelSyncStage.MESSAGES_IMPORT_SCHEDULED,
+    );
+
+    if (hasMessagesImportScheduled) {
+      this.logger.log(
+        `MessageChannel syncStage field metadata already has MESSAGES_IMPORT_SCHEDULED for workspace ${workspaceId}`,
+      );
+
+      return;
+    }
+
+    if (options.dryRun) {
+      this.logger.log(
+        `Would add MESSAGES_IMPORT_SCHEDULED to MessageChannel syncStage field metadata for workspace ${workspaceId}`,
+      );
+
+      return;
+    }
+
+    fieldOptions.push({
+      value: MessageChannelSyncStage.MESSAGES_IMPORT_SCHEDULED,
+      label: 'Messages import scheduled',
+      position: 4,
+      color: 'green',
+    });
+
+    syncStageField.options = fieldOptions;
+
+    await this.fieldMetadataRepository.save(syncStageField);
+
+    this.logger.log(
+      `Added MESSAGES_IMPORT_SCHEDULED to MessageChannel syncStage field metadata for workspace ${workspaceId}`,
+    );
+  }
+}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-12/1-12-upgrade-version-command.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-12/1-12-upgrade-version-command.module.ts
@@ -9,6 +9,7 @@ import { WorkspaceCustomApplicationIdNonNullableCommand } from 'src/database/com
 import { ApplicationModule } from 'src/engine/core-modules/application/application.module';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
+import { FieldMetadataModule } from 'src/engine/metadata-modules/field-metadata/field-metadata.module';
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 import { WorkspaceSchemaManagerModule } from 'src/engine/twenty-orm/workspace-schema-manager/workspace-schema-manager.module';
 
@@ -21,6 +22,7 @@ import { WorkspaceSchemaManagerModule } from 'src/engine/twenty-orm/workspace-sc
     ]),
     WorkspaceSchemaManagerModule,
     ApplicationModule,
+    FieldMetadataModule,
   ],
   providers: [
     AddCalendarEventsImportScheduledSyncStageCommand,

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-12/1-12-upgrade-version-command.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-12/1-12-upgrade-version-command.module.ts
@@ -1,25 +1,37 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { AddCalendarEventsImportScheduledSyncStageCommand } from 'src/database/commands/upgrade-version-command/1-12/1-12-add-calendar-events-import-scheduled-sync-stage.command';
+import { AddMessagesImportScheduledSyncStageCommand } from 'src/database/commands/upgrade-version-command/1-12/1-12-add-messages-import-scheduled-sync-stage.command';
 import { CreateWorkspaceCustomApplicationCommand } from 'src/database/commands/upgrade-version-command/1-12/1-12-create-workspace-custom-application.command';
 import { SetStandardApplicationNotUninstallableCommand } from 'src/database/commands/upgrade-version-command/1-12/1-12-set-standard-application-not-uninstallable.command';
 import { WorkspaceCustomApplicationIdNonNullableCommand } from 'src/database/commands/upgrade-version-command/1-12/1-12-workspace-custom-application-id-non-nullable-migration.command';
 import { ApplicationModule } from 'src/engine/core-modules/application/application.module';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
+import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
+import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 import { WorkspaceSchemaManagerModule } from 'src/engine/twenty-orm/workspace-schema-manager/workspace-schema-manager.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([WorkspaceEntity]),
+    TypeOrmModule.forFeature([
+      WorkspaceEntity,
+      ObjectMetadataEntity,
+      FieldMetadataEntity,
+    ]),
     WorkspaceSchemaManagerModule,
     ApplicationModule,
   ],
   providers: [
+    AddCalendarEventsImportScheduledSyncStageCommand,
+    AddMessagesImportScheduledSyncStageCommand,
     CreateWorkspaceCustomApplicationCommand,
     SetStandardApplicationNotUninstallableCommand,
     WorkspaceCustomApplicationIdNonNullableCommand,
   ],
   exports: [
+    AddCalendarEventsImportScheduledSyncStageCommand,
+    AddMessagesImportScheduledSyncStageCommand,
     CreateWorkspaceCustomApplicationCommand,
     SetStandardApplicationNotUninstallableCommand,
     WorkspaceCustomApplicationIdNonNullableCommand,

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
@@ -21,6 +21,8 @@ import { RegenerateSearchVectorsCommand } from 'src/database/commands/upgrade-ve
 import { CleanOrphanedRoleTargetsCommand } from 'src/database/commands/upgrade-version-command/1-11/1-11-clean-orphaned-role-targets.command';
 import { CleanOrphanedUserWorkspacesCommand } from 'src/database/commands/upgrade-version-command/1-11/1-11-clean-orphaned-user-workspaces.command';
 import { CreateTwentyStandardApplicationCommand } from 'src/database/commands/upgrade-version-command/1-11/1-11-create-twenty-standard-application.command';
+import { AddCalendarEventsImportScheduledSyncStageCommand } from 'src/database/commands/upgrade-version-command/1-12/1-12-add-calendar-events-import-scheduled-sync-stage.command';
+import { AddMessagesImportScheduledSyncStageCommand } from 'src/database/commands/upgrade-version-command/1-12/1-12-add-messages-import-scheduled-sync-stage.command';
 import { CreateWorkspaceCustomApplicationCommand } from 'src/database/commands/upgrade-version-command/1-12/1-12-create-workspace-custom-application.command';
 import { SetStandardApplicationNotUninstallableCommand } from 'src/database/commands/upgrade-version-command/1-12/1-12-set-standard-application-not-uninstallable.command';
 import { WorkspaceCustomApplicationIdNonNullableCommand } from 'src/database/commands/upgrade-version-command/1-12/1-12-workspace-custom-application-id-non-nullable-migration.command';
@@ -84,6 +86,8 @@ export class UpgradeCommand extends UpgradeCommandRunner {
     protected readonly createTwentyStandardApplicationCommand: CreateTwentyStandardApplicationCommand,
     protected readonly createWorkspaceCustomApplicationCommand: CreateWorkspaceCustomApplicationCommand,
     protected readonly workspaceCustomApplicationIdNonNullableCommand: WorkspaceCustomApplicationIdNonNullableCommand,
+    protected readonly addMessagesImportScheduledSyncStageCommand: AddMessagesImportScheduledSyncStageCommand,
+    protected readonly addCalendarEventsImportScheduledSyncStageCommand: AddCalendarEventsImportScheduledSyncStageCommand,
   ) {
     super(
       workspaceRepository,
@@ -143,6 +147,8 @@ export class UpgradeCommand extends UpgradeCommandRunner {
       beforeSyncMetadata: [
         this.createWorkspaceCustomApplicationCommand,
         this.workspaceCustomApplicationIdNonNullableCommand,
+        this.addMessagesImportScheduledSyncStageCommand,
+        this.addCalendarEventsImportScheduledSyncStageCommand,
       ],
       afterSyncMetadata: [this.setStandardApplicationNotUninstallableCommand],
     };

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata.service-v2.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/services/field-metadata.service-v2.ts
@@ -146,9 +146,11 @@ export class FieldMetadataServiceV2 extends TypeOrmQueryService<FieldMetadataEnt
   async updateOneField({
     updateFieldInput,
     workspaceId,
+    isSystemBuild = false,
   }: {
     updateFieldInput: Omit<UpdateFieldInput, 'workspaceId'>;
     workspaceId: string;
+    isSystemBuild?: boolean;
   }): Promise<FlatFieldMetadata> {
     const {
       flatObjectMetadataMaps: existingFlatObjectMetadataMaps,
@@ -256,7 +258,7 @@ export class FieldMetadataServiceV2 extends TypeOrmQueryService<FieldMetadataEnt
             }),
           },
           buildOptions: {
-            isSystemBuild: false,
+            isSystemBuild,
             inferDeletionFromMissingEntities: {
               index: true,
               viewGroup: true,

--- a/packages/twenty-server/src/modules/messaging/common/standard-objects/message-channel.workspace-entity.ts
+++ b/packages/twenty-server/src/modules/messaging/common/standard-objects/message-channel.workspace-entity.ts
@@ -1,8 +1,8 @@
 import { registerEnumType } from '@nestjs/graphql';
 
 import { msg } from '@lingui/core/macro';
-import { FieldMetadataType, RelationOnDeleteAction } from 'twenty-shared/types';
 import { STANDARD_OBJECT_IDS } from 'twenty-shared/metadata';
+import { FieldMetadataType, RelationOnDeleteAction } from 'twenty-shared/types';
 
 import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
 import { Relation } from 'src/engine/workspace-manager/workspace-sync-metadata/interfaces/relation.interface';


### PR DESCRIPTION
We have introduced to new syncStage statuses: `messageChannel.MESSAGES_IMPORT_SCHEDULED` and `calendarChannel.CALENDAR_EVENTS_IMPORT_SCHEDULED`

We need to make sure all existing workspaces have it