### PR TITLE
[Side Panel V2] Bring back old container

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/show-page/components/ShowPageSubContainer.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/show-page/components/ShowPageSubContainer.tsx
@@ -45,23 +45,12 @@ const StyledTabList = styled(TabList)`
   padding-left: ${({ theme }) => theme.spacing(2)};
 `;
 
-const StyledContentContainer = styled.div<{
-  isInRightDrawer: boolean;
-}>`
-  background: ${({ theme, isInRightDrawer }) =>
-    isInRightDrawer ? theme.background.secondary : theme.background.primary};
-  border: ${({ theme, isInRightDrawer }) =>
-    isInRightDrawer ? `1px solid ${theme.border.color.light}` : 'none'};
-  border-radius: ${({ theme, isInRightDrawer }) =>
-    isInRightDrawer ? theme.border.radius.md : '0'};
+const StyledContentContainer = styled.div<{ isInRightDrawer: boolean }>`
   flex: 1;
-  margin: ${({ theme, isInRightDrawer }) =>
-    isInRightDrawer ? theme.spacing(3) : '0'};
   overflow-y: auto;
-
-  .scroll-wrapper-y-enabled {
-    height: auto;
-  }
+  background: ${({ theme }) => theme.background.primary};
+  padding-bottom: ${({ theme, isInRightDrawer }) =>
+    isInRightDrawer ? theme.spacing(16) : 0};
 `;
 
 type ShowPageSubContainerProps = {


### PR DESCRIPTION
## Before

<img width="1446" height="780" alt="image" src="https://github.com/user-attachments/assets/fa25f22d-b979-4a8f-9989-004d07f862d7" />

## After

<img width="3456" height="2160" alt="CleanShot 2025-11-25 at 17 35 59@2x" src="https://github.com/user-attachments/assets/a87880c4-3faa-47c3-9215-34afc36270a3" />
