### PR TITLE
fix: prevent quick search focus from being stolen by note editor

### DIFF
--- a/packages/twenty-front/src/modules/activities/components/ActivityRichTextEditor.tsx
+++ b/packages/twenty-front/src/modules/activities/components/ActivityRichTextEditor.tsx
@@ -351,7 +351,7 @@ export const ActivityRichTextEditor = ({
       return;
     }
 
-        // Don't intercept keystrokes when command menu is open
+    // Don't intercept keystrokes when command menu is open
     if (isCommandMenuOpened) {
       return;
     }

--- a/packages/twenty-front/src/modules/activities/components/ActivityRichTextEditor.tsx
+++ b/packages/twenty-front/src/modules/activities/components/ActivityRichTextEditor.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from 'react';
-import { useRecoilCallback, useRecoilState } from 'recoil';
+import { useRecoilCallback, useRecoilState, useRecoilValue } from 'recoil';
 import { v4 } from 'uuid';
+import { isCommandMenuOpenedState } from '@/command-menu/states/isCommandMenuOpenedState';
 
 import { useUploadAttachmentFile } from '@/activities/files/hooks/useUploadAttachmentFile';
 import { useUpsertActivity } from '@/activities/hooks/useUpsertActivity';
@@ -59,6 +60,7 @@ export const ActivityRichTextEditor = ({
   activityObjectNameSingular,
 }: ActivityRichTextEditorProps) => {
   const [activityInStore] = useRecoilState(recordStoreFamilyState(activityId));
+    const isCommandMenuOpened = useRecoilValue(isCommandMenuOpenedState);
 
   const cache = useApolloCoreClient().cache;
   const activity = activityInStore as Task | Note | null;
@@ -346,6 +348,11 @@ export const ActivityRichTextEditor = ({
 
   const handleAllKeys = (keyboardEvent: KeyboardEvent) => {
     if (keyboardEvent.key === Key.Escape) {
+      return;
+    }
+
+        // Don't intercept keystrokes when command menu is open
+    if (isCommandMenuOpened) {
       return;
     }
 

--- a/packages/twenty-front/src/modules/activities/components/ActivityRichTextEditor.tsx
+++ b/packages/twenty-front/src/modules/activities/components/ActivityRichTextEditor.tsx
@@ -60,7 +60,7 @@ export const ActivityRichTextEditor = ({
   activityObjectNameSingular,
 }: ActivityRichTextEditorProps) => {
   const [activityInStore] = useRecoilState(recordStoreFamilyState(activityId));
-    const isCommandMenuOpened = useRecoilValue(isCommandMenuOpenedState);
+  const isCommandMenuOpened = useRecoilValue(isCommandMenuOpenedState);
 
   const cache = useApolloCoreClient().cache;
   const activity = activityInStore as Task | Note | null;


### PR DESCRIPTION
Fixes #16045

The ActivityRichTextEditor was intercepting all keyboard input when SIDE_PANEL_FOCUS_ID was active, even when the command menu (quick search) was open. This caused keystrokes intended for the search input to be redirected to the note editor.

This fix adds a check in handleAllKeys to return early if the command menu is currently open, allowing the search input to receive keystrokes properly.