### PR TITLE
Add workspaceMemberId to workflow payload

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-trigger.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-trigger.resolver.ts
@@ -83,7 +83,7 @@ export class WorkflowTriggerResolver {
     return this.workflowTriggerWorkspaceService.runWorkflowVersion({
       workflowVersionId,
       workflowRunId: workflowRunId ?? undefined,
-          payload: {
+        payload: {
           ...(payload ?? {}),
           workspaceMemberId: workspaceMember.id,
         },

--- a/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-trigger.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-trigger.resolver.ts
@@ -83,7 +83,11 @@ export class WorkflowTriggerResolver {
     return this.workflowTriggerWorkspaceService.runWorkflowVersion({
       workflowVersionId,
       workflowRunId: workflowRunId ?? undefined,
-        payload: { ...(payload ?? {}), workspaceMemberId: workspaceMember.id },      createdBy: buildCreatedByFromFullNameMetadata({
+                payload: {
+          ...(payload ?? {}),
+          workspaceMemberId: workspaceMember.id,
+        },
+        createdBy: buildCreatedByFromFullNameMetadata({
         fullNameMetadata: {
           firstName: workspaceMember.name.firstName,
           lastName: workspaceMember.name.lastName,

--- a/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-trigger.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-trigger.resolver.ts
@@ -83,7 +83,7 @@ export class WorkflowTriggerResolver {
     return this.workflowTriggerWorkspaceService.runWorkflowVersion({
       workflowVersionId,
       workflowRunId: workflowRunId ?? undefined,
-                payload: {
+          payload: {
           ...(payload ?? {}),
           workspaceMemberId: workspaceMember.id,
         },

--- a/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-trigger.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-trigger.resolver.ts
@@ -83,8 +83,7 @@ export class WorkflowTriggerResolver {
     return this.workflowTriggerWorkspaceService.runWorkflowVersion({
       workflowVersionId,
       workflowRunId: workflowRunId ?? undefined,
-      payload: payload ?? {},
-      createdBy: buildCreatedByFromFullNameMetadata({
+        payload: { ...(payload ?? {}), workspaceMemberId: workspaceMember.id },      createdBy: buildCreatedByFromFullNameMetadata({
         fullNameMetadata: {
           firstName: workspaceMember.name.firstName,
           lastName: workspaceMember.name.lastName,


### PR DESCRIPTION
This change adds the workspaceMemberId to the workflow payload so that subsequent workflow steps can access the user who submitted the form/triggered the workflow.

Fixes twentyhq/core-team-issues#1946