### PR TITLE
Fix options menu button height in side panel footer

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/dropdown/components/OptionsDropdownMenu.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/dropdown/components/OptionsDropdownMenu.tsx
@@ -68,7 +68,11 @@ export const OptionsDropdownMenu = ({
       dropdownId={dropdownId}
       data-select-disable
       clickableComponent={
-        <Button title={t`Options`} hotkeys={[getOsControlSymbol(), 'O']} />
+        <Button
+          title={t`Options`}
+          hotkeys={[getOsControlSymbol(), 'O']}
+          size="small"
+        />
       }
       dropdownPlacement="top-end"
       dropdownOffset={{ y: parseInt(theme.spacing(2), 10) }}


### PR DESCRIPTION
## Description
Fixed the height of the options menu button in the side panel footer to be 24px instead of 32px, matching the height of other buttons in the footer.

## Changes
- Added `size="small"` prop to the `Button` component in `OptionsDropdownMenu.tsx`
- This ensures consistent button sizing across the side panel footer

## Before
The options menu button was 32px high (medium size), making it larger than other footer buttons.

<img width="543" height="421" alt="image" src="https://github.com/user-attachments/assets/3c4fdfd0-73d1-4884-a639-3382090dfe15" />


## After
The options menu button is now 24px high (small size), consistent with other side panel footer buttons.

<img width="1000" height="824" alt="CleanShot 2025-11-26 at 18 50 43@2x" src="https://github.com/user-attachments/assets/798e7975-a7a8-4c00-b2e7-c0d1261249f8" />
