### PR TITLE
Let single notes take the full width (both side panel & desktop)

### DIFF
--- a/packages/twenty-front/src/modules/activities/notes/components/NoteList.tsx
+++ b/packages/twenty-front/src/modules/activities/notes/components/NoteList.tsx
@@ -1,5 +1,5 @@
-import { type ReactElement } from 'react';
 import styled from '@emotion/styled';
+import { type ReactElement } from 'react';
 
 import { type Note } from '@/activities/types/Note';
 

--- a/packages/twenty-front/src/modules/activities/notes/components/NoteList.tsx
+++ b/packages/twenty-front/src/modules/activities/notes/components/NoteList.tsx
@@ -1,5 +1,5 @@
-import styled from '@emotion/styled';
 import { type ReactElement } from 'react';
+import styled from '@emotion/styled';
 
 import { type Note } from '@/activities/types/Note';
 

--- a/packages/twenty-front/src/modules/activities/notes/components/NoteTile.tsx
+++ b/packages/twenty-front/src/modules/activities/notes/components/NoteTile.tsx
@@ -17,7 +17,7 @@ const StyledCard = styled.div<{ isSingleNote: boolean }>`
   flex-direction: column;
   height: 300px;
   justify-content: space-between;
-  max-width: ${({ isSingleNote }) => (isSingleNote ? '300px' : 'unset')};
+  width: 100%;
 `;
 
 const StyledCardDetailsContainer = styled.div`


### PR DESCRIPTION
# Current behavior

<img width="932" height="1040" alt="CleanShot 2025-11-26 at 19 10 32@2x" src="https://github.com/user-attachments/assets/309fc2f4-b9ef-481c-b550-74c1c5cfeaf4" />

<img width="2618" height="1352" alt="CleanShot 2025-11-26 at 19 10 56@2x" src="https://github.com/user-attachments/assets/f57348e9-2e09-4c91-bcf6-e776aa26598a" />


# Desired Behavior

<img width="2634" height="1304" alt="CleanShot 2025-11-26 at 19 11 32@2x" src="https://github.com/user-attachments/assets/d8e13ab5-65d7-4449-9d8d-7a2356f71160" />

<img width="1048" height="1146" alt="CleanShot 2025-11-26 at 19 11 50@2x" src="https://github.com/user-attachments/assets/8a062717-18c1-41c7-a52c-1904738cd145" />


