### PR TITLE
optimize buildFieldMapsFromFlatObjectMetadata usages

### DIFF
--- a/packages/twenty-server/src/engine/api/common/common-result-getters/common-result-getters.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-result-getters/common-result-getters.service.ts
@@ -18,7 +18,10 @@ import { FileService } from 'src/engine/core-modules/file/services/file.service'
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
 import { findFlatEntityByIdInFlatEntityMapsOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps-or-throw.util';
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
-import { buildFieldMapsFromFlatObjectMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/build-field-maps-from-flat-object-metadata.util';
+import {
+  buildFieldMapsFromFlatObjectMetadata,
+  type FieldMapsForObject,
+} from 'src/engine/metadata-modules/flat-field-metadata/utils/build-field-maps-from-flat-object-metadata.util';
 import { isFlatFieldMetadataOfType } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-flat-field-metadata-of-type.util';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 
@@ -54,6 +57,11 @@ export class CommonResultGettersService {
     flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>,
     workspaceId: string,
   ) {
+    const fieldMaps = buildFieldMapsFromFlatObjectMetadata(
+      flatFieldMetadataMaps,
+      flatObjectMetadata,
+    );
+
     return await Promise.all(
       recordArray.map(
         async (record: ObjectRecord) =>
@@ -63,6 +71,7 @@ export class CommonResultGettersService {
             flatObjectMetadataMaps,
             flatFieldMetadataMaps,
             workspaceId,
+            fieldMaps,
           ),
       ),
     );
@@ -74,13 +83,18 @@ export class CommonResultGettersService {
     flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>,
     flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>,
     workspaceId: string,
+    fieldMapsForObject?: FieldMapsForObject,
   ): Promise<ObjectRecord> {
     const handler = this.getHandler(flatObjectMetadata.nameSingular);
 
-    const { fieldIdByName } = buildFieldMapsFromFlatObjectMetadata(
-      flatFieldMetadataMaps,
-      flatObjectMetadata,
-    );
+    const fieldMaps =
+      fieldMapsForObject ??
+      buildFieldMapsFromFlatObjectMetadata(
+        flatFieldMetadataMaps,
+        flatObjectMetadata,
+      );
+
+    const { fieldIdByName } = fieldMaps;
 
     const relationFields = Object.keys(record)
       .map(

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/helpers/process-nested-relations-v2.helper.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/helpers/process-nested-relations-v2.helper.ts
@@ -17,7 +17,10 @@ import { type AuthContext } from 'src/engine/core-modules/auth/types/auth-contex
 import { FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
 import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps.util';
 import { FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
-import { buildFieldMapsFromFlatObjectMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/build-field-maps-from-flat-object-metadata.util';
+import {
+  buildFieldMapsFromFlatObjectMetadata,
+  type FieldMapsForObject,
+} from 'src/engine/metadata-modules/flat-field-metadata/utils/build-field-maps-from-flat-object-metadata.util';
 import { FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 import { type WorkspaceDataSource } from 'src/engine/twenty-orm/datasource/workspace.datasource';
 import { type WorkspaceSelectQueryBuilder } from 'src/engine/twenty-orm/repository/workspace-select-query-builder';
@@ -112,13 +115,13 @@ export class ProcessNestedRelationsV2Helper {
     rolePermissionConfig?: RolePermissionConfig;
     selectedFields: Record<string, unknown>;
   }): Promise<void> {
-    const { fieldIdByName } = buildFieldMapsFromFlatObjectMetadata(
+    const fieldMaps = buildFieldMapsFromFlatObjectMetadata(
       flatFieldMetadataMaps,
       parentObjectMetadataItem,
     );
 
     const sourceFieldMetadata = findFlatEntityByIdInFlatEntityMaps({
-      flatEntityId: fieldIdByName[sourceFieldName],
+      flatEntityId: fieldMaps.fieldIdByName[sourceFieldName],
       flatEntityMaps: flatFieldMetadataMaps,
     });
 
@@ -154,6 +157,7 @@ export class ProcessNestedRelationsV2Helper {
         flatFieldMetadataMaps,
         parentObjectMetadataItem,
         sourceFieldName,
+        fieldMaps,
       });
 
     const targetObjectRepository = workspaceDataSource.getRepository(
@@ -250,19 +254,16 @@ export class ProcessNestedRelationsV2Helper {
     flatFieldMetadataMaps,
     parentObjectMetadataItem,
     sourceFieldName,
+    fieldMaps,
   }: {
     flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>;
     flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
     parentObjectMetadataItem: FlatObjectMetadata;
     sourceFieldName: string;
+    fieldMaps: FieldMapsForObject;
   }) {
-    const { fieldIdByName } = buildFieldMapsFromFlatObjectMetadata(
-      flatFieldMetadataMaps,
-      parentObjectMetadataItem,
-    );
-
     const targetFieldMetadata = findFlatEntityByIdInFlatEntityMaps({
-      flatEntityId: fieldIdByName[sourceFieldName],
+      flatEntityId: fieldMaps.fieldIdByName[sourceFieldName],
       flatEntityMaps: flatFieldMetadataMaps,
     });
 

--- a/packages/twenty-server/src/engine/twenty-orm/entity-manager/workspace-entity-manager.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/entity-manager/workspace-entity-manager.spec.ts
@@ -13,6 +13,7 @@ import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-m
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 import { type WorkspaceDataSource } from 'src/engine/twenty-orm/datasource/workspace.datasource';
 import { validateOperationIsPermittedOrThrow } from 'src/engine/twenty-orm/repository/permissions.utils';
+import { getObjectMetadataFromEntityTarget } from 'src/engine/twenty-orm/utils/get-object-metadata-from-entity-target.util';
 
 import { WorkspaceEntityManager } from './workspace-entity-manager';
 
@@ -23,7 +24,7 @@ jest.mock('src/engine/twenty-orm/repository/permissions.utils', () => ({
 jest.mock(
   'src/engine/twenty-orm/utils/get-object-metadata-from-entity-target.util',
   () => ({
-    getObjectMetadataFromEntityTarget: jest.fn().mockReturnValue({}),
+    getObjectMetadataFromEntityTarget: jest.fn(),
   }),
 );
 
@@ -116,6 +117,10 @@ describe('WorkspaceEntityManager', () => {
       createdAt: new Date(),
       updatedAt: new Date(),
     };
+
+    (getObjectMetadataFromEntityTarget as jest.Mock).mockReturnValue(
+      mockFlatObjectMetadata,
+    );
 
     const mockFlatFieldMetadata: FlatFieldMetadata = {
       id: 'field-id',

--- a/packages/twenty-server/src/engine/twenty-orm/utils/format-data.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/format-data.util.ts
@@ -7,7 +7,10 @@ import { capitalize } from 'twenty-shared/utils';
 import { isCompositeFieldMetadataType } from 'src/engine/metadata-modules/field-metadata/utils/is-composite-field-metadata-type.util';
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
-import { buildFieldMapsFromFlatObjectMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/build-field-maps-from-flat-object-metadata.util';
+import {
+  buildFieldMapsFromFlatObjectMetadata,
+  type FieldMapsForObject,
+} from 'src/engine/metadata-modules/flat-field-metadata/utils/build-field-maps-from-flat-object-metadata.util';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 import { type CompositeFieldMetadataType } from 'src/engine/metadata-modules/workspace-migration/factories/composite-column-action.factory';
 
@@ -15,22 +18,26 @@ export function formatData<T>(
   data: T,
   flatObjectMetadata: FlatObjectMetadata,
   flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>,
+  fieldMapsForObject?: FieldMapsForObject,
 ): T {
   if (!data) {
     return data;
   }
 
-  if (Array.isArray(data)) {
-    return data.map((item) =>
-      formatData(item, flatObjectMetadata, flatFieldMetadataMaps),
-    ) as T;
-  }
-
-  const { fieldIdByName, fieldIdByJoinColumnName } =
+  const fieldMaps =
+    fieldMapsForObject ??
     buildFieldMapsFromFlatObjectMetadata(
       flatFieldMetadataMaps,
       flatObjectMetadata,
     );
+
+  if (Array.isArray(data)) {
+    return data.map((item) =>
+      formatData(item, flatObjectMetadata, flatFieldMetadataMaps, fieldMaps),
+    ) as T;
+  }
+
+  const { fieldIdByName, fieldIdByJoinColumnName } = fieldMaps;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const newData: Record<string, any> = {};


### PR DESCRIPTION
This newly introduced util can be a bit expensive especially when done recursively.
This PR improves that


File | Pattern Fixed | Impact
-- | -- | --
format-result.util.ts | Recursive array/object processing | N array items → 1 call
format-data.util.ts | Recursive array processing | N array items → 1 call
process-nested-relations-v2.helper.ts | Duplicate call in call chain | 2 calls → 1 call
common-result-getters.service.ts | Per-record processing in array | N records → 1 call
compute-relation-connect-query-configs.util.ts | Nested loop (entities × connect fields) | N×M calls → 1 call

