### PR TITLE
fix: add Node.js 25 compatibility via jwa resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
     "vite-plugin-svgr": "^4.2.0"
   },
   "engines": {
-    "node": "^24.5.0",
+    "node": ">=24.5.0",
     "npm": "please-use-yarn",
     "yarn": ">=4.0.2"
   },
@@ -207,7 +207,8 @@
     "typescript": "5.9.2",
     "graphql-redis-subscriptions/ioredis": "^5.6.0",
     "prosemirror-view": "1.40.0",
-    "prosemirror-transform": "1.10.4"
+    "prosemirror-transform": "1.10.4",
+    "jwa": "2.0.1"
   },
   "version": "0.2.1",
   "nx": {},

--- a/yarn.lock
+++ b/yarn.lock
@@ -28791,7 +28791,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"buffer-equal-constant-time@npm:1.0.1":
+"buffer-equal-constant-time@npm:^1.0.1":
   version: 1.0.1
   resolution: "buffer-equal-constant-time@npm:1.0.1"
   checksum: 10c0/fb2294e64d23c573d0dd1f1e7a466c3e978fe94a4e0f8183937912ca374619773bef8e2aceb854129d2efecbbc515bbd0cc78d2734a3e3031edb0888531bbc8e
@@ -41610,25 +41610,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jwa@npm:^1.4.1":
-  version: 1.4.1
-  resolution: "jwa@npm:1.4.1"
+"jwa@npm:2.0.1":
+  version: 2.0.1
+  resolution: "jwa@npm:2.0.1"
   dependencies:
-    buffer-equal-constant-time: "npm:1.0.1"
+    buffer-equal-constant-time: "npm:^1.0.1"
     ecdsa-sig-formatter: "npm:1.0.11"
     safe-buffer: "npm:^5.0.1"
-  checksum: 10c0/5c533540bf38702e73cf14765805a94027c66a0aa8b16bc3e89d8d905e61a4ce2791e87e21be97d1293a5ee9d4f3e5e47737e671768265ca4f25706db551d5e9
-  languageName: node
-  linkType: hard
-
-"jwa@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "jwa@npm:2.0.0"
-  dependencies:
-    buffer-equal-constant-time: "npm:1.0.1"
-    ecdsa-sig-formatter: "npm:1.0.11"
-    safe-buffer: "npm:^5.0.1"
-  checksum: 10c0/6baab823b93c038ba1d2a9e531984dcadbc04e9eb98d171f4901b7a40d2be15961a359335de1671d78cb6d987f07cbe5d350d8143255977a889160c4d90fcc3c
+  checksum: 10c0/ab3ebc6598e10dc11419d4ed675c9ca714a387481466b10e8a6f3f65d8d9c9237e2826f2505280a739cf4cbcf511cb288eeec22b5c9c63286fc5a2e4f97e78cf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Adds Node.js 25 compatibility by resolving `jwa` to version 2.0.1
- Updates engine constraint from `^24.5.0` to `>=24.5.0`

Fixes #16148

## Problem

Node.js 25 removed the `SlowBuffer` API, which breaks the `jsonwebtoken` dependency chain:

```
jsonwebtoken → jws → jwa → buffer-equal-constant-time
```

The `buffer-equal-constant-time@1.0.1` package (last updated 12 years ago) uses `SlowBuffer.prototype.equal`, causing this error on Node 25:

```
TypeError: Cannot read properties of undefined (reading 'prototype')
    at .../buffer-equal-constant-time/index.js:37:35
```

## Solution

- Add yarn resolution for `jwa@2.0.1` which uses `crypto.timingSafeEqual()` instead of the deprecated `SlowBuffer` API
- Relax Node engine constraint to allow Node 25+

## References

- [Node 24 compatibility · Issue #992 · auth0/node-jsonwebtoken](https://github.com/auth0/node-jsonwebtoken/issues/992)
- [Node.js v25.0.0 Release Notes](https://nodejs.org/en/blog/release/v25.0.0) - SlowBuffer removal

## Test plan

- [x] Verified backend starts successfully on Node.js v25.1.0
- [x] Verified `yarn install` completes without errors
- [x] Verified `yarn start` runs frontend and backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)