### PR TITLE
fix: resolve GitHub Actions security vulnerabilities

### DIFF
--- a/.github/workflows/ci-test-docker-compose.yaml
+++ b/.github/workflows/ci-test-docker-compose.yaml
@@ -1,4 +1,8 @@
 name: 'Test Docker Compose'
+
+permissions:
+  contents: read
+
 on:
   pull_request:
 

--- a/.github/workflows/docs-i18n-pull.yaml
+++ b/.github/workflows/docs-i18n-pull.yaml
@@ -124,7 +124,9 @@ jobs:
             exit 0
           fi
           git commit -m "chore: sync docs artifacts"
-          git push origin HEAD:${{ github.head_ref }}
+          git push origin "HEAD:$HEAD_REF"
+        env:
+          HEAD_REF: ${{ github.head_ref }}
 
       - name: Check for changes and commit
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
## 🔒 Security Fixes

This PR addresses security vulnerabilities identified by GitHub CodeQL security scanning.

### Changes

#### 1. Fix Shell Command Injection (High Severity)
**File:** `.github/workflows/docs-i18n-pull.yaml`

**Issue:** Direct interpolation of `${{ github.head_ref }}` in shell command was susceptible to command injection attacks.

**Fix:** Assign GitHub context variable to environment variable first:
```yaml
run: |
  git push origin "HEAD:$HEAD_REF"
env:
  HEAD_REF: ${{ github.head_ref }}
```

This prevents malicious input from being executed as shell commands.

#### 2. Add Missing Workflow Permissions (Medium Severity)
**File:** `.github/workflows/ci-test-docker-compose.yaml`

**Issue:** Workflow did not explicitly define GITHUB_TOKEN permissions, running with overly broad defaults.

**Fix:** Added explicit minimal permissions:
```yaml
permissions:
  contents: read
```

This applies to all 3 jobs in the workflow:
- `changed-files-check`
- `test`
- `ci-test-docker-compose-status-check`

### Security Impact

- ✅ Prevents potential shell injection attacks via pull request branch names
- ✅ Follows principle of least privilege for GitHub Actions tokens
- ✅ Aligns with GitHub Actions security best practices
- ✅ Resolves all CodeQL security alerts for these workflows

### References

- [GitHub Actions: Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)
- [GitHub Actions: Permissions for the GITHUB_TOKEN](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)
- Related attacks: 2025 Nx supply chain attack, 2024 ultralytics/actions attack