### PR TITLE
Fix markdown link formatting in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -63,4 +63,4 @@ git push origin your-branch-name
 
 ## Reporting Issues
 
-If you face any issues or have suggestions, please feel free to (create an issue on Twenty's GitHub repository)[https://github.com/twentyhq/twenty/issues/new]. Please provide as much detail as possible.
+If you face any issues or have suggestions, please feel free to [create an issue on Twenty's GitHub repository](https://github.com/twentyhq/twenty/issues/new). Please provide as much detail as possible.


### PR DESCRIPTION
CC: @FelixMalfait 

Before: 
<img width="1293" height="170" alt="image" src="https://github.com/user-attachments/assets/dc02afea-2781-4a5b-885a-2617709d9e36" />

After: 
<img width="1293" height="170" alt="image" src="https://github.com/user-attachments/assets/acbc5c0b-bb96-4cd7-8c02-892cc4745f70" />
