### PR TITLE
revert to align center as we add an issue on edit mode. Fixed the inp…

### DIFF
--- a/packages/twenty-front/src/modules/command-menu/components/CommandMenuPageInfoLayout.tsx
+++ b/packages/twenty-front/src/modules/command-menu/components/CommandMenuPageInfoLayout.tsx
@@ -19,7 +19,7 @@ export const StyledPageInfoIcon = styled.div<{ iconColor?: string }>`
 `;
 
 export const StyledPageInfoTextContainer = styled.div`
-  align-items: baseline;
+  align-items: center;
   display: flex;
   flex: 1;
   gap: ${({ theme }) => theme.spacing(0.5)};

--- a/packages/twenty-front/src/modules/object-record/record-title-cell/components/RecordTitleCellTextFieldDisplay.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-title-cell/components/RecordTitleCellTextFieldDisplay.tsx
@@ -16,7 +16,7 @@ const StyledDiv = styled.div`
   color: ${({ theme }) => theme.font.color.primary};
   cursor: pointer;
   overflow: hidden;
-  height: 28px;
+  height: 24px;
   padding: ${({ theme }) => theme.spacing(0, 1.25)};
   box-sizing: border-box;
   display: flex;

--- a/packages/twenty-front/src/modules/object-record/record-title-cell/components/RecordTitleFullNameFieldDisplay.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-title-cell/components/RecordTitleFullNameFieldDisplay.tsx
@@ -11,14 +11,13 @@ import { useContext } from 'react';
 import { OverflowingTextWithTooltip } from 'twenty-ui/display';
 
 const StyledDiv = styled.div`
-  align-items: center;
   background: inherit;
   border: none;
   border-radius: ${({ theme }) => theme.border.radius.sm};
   color: ${({ theme }) => theme.font.color.primary};
   cursor: pointer;
   overflow: hidden;
-  height: 28px;
+  height: 24px;
   padding: ${({ theme }) => theme.spacing(0, 1.25)};
   box-sizing: border-box;
   display: flex;


### PR DESCRIPTION
# Current Behavior

<img width="441" height="81" alt="image" src="https://github.com/user-attachments/assets/cc3301b1-c92a-44c3-b452-49264ff5d323" />

Revert behavior to align center
fixed input size (24px)

<img width="670" height="202" alt="CleanShot 2025-11-28 at 16 05 30@2x" src="https://github.com/user-attachments/assets/5c7ca79f-53d7-45c1-a2a6-7c3b1b78524c" />
