### PR TITLE
feat(docker): add Docker secrets support to entrypoint

### DIFF
--- a/packages/twenty-docker/twenty/entrypoint.sh
+++ b/packages/twenty-docker/twenty/entrypoint.sh
@@ -1,6 +1,28 @@
 #!/bin/sh
 set -e
 
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		printf >&2 'error: both %s and %s are set (but are exclusive)\n' "$var" "$fileVar"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
 setup_and_migrate_db() {
     if [ "${DISABLE_DB_MIGRATIONS}" = "true" ]; then
         echo "Database setup and migrations are disabled, skipping..."
@@ -35,6 +57,38 @@ register_background_jobs() {
     fi
 }
 
+docker_setup_env() {
+  # Initialize values that might be stored in a file
+  local env_vars=(
+    'PG_DATABASE_URL'
+    'REDIS_URL'
+    'SERVER_URL'
+    'APP_SECRET'
+    'AUTH_GOOGLE_CLIENT_ID'
+    'AUTH_GOOGLE_CLIENT_SECRET'
+    'AUTH_GOOGLE_CALLBACK_URL'
+    'AUTH_GOOGLE_APIS_CALLBACK_URL'
+    'MESSAGING_PROVIDER_GMAIL_CALLBACK_URL'
+    'SUPPORT_FRONT_HMAC_KEY'
+    'SUPPORT_FRONT_CHAT_ID'
+    'AUTH_MICROSOFT_CLIENT_ID'
+    'AUTH_MICROSOFT_CLIENT_SECRET'
+    'AUTH_MICROSOFT_CALLBACK_URL'
+    'AUTH_MICROSOFT_APIS_CALLBACK_URL'
+    'CAPTCHA_SITE_KEY'
+    'CAPTCHA_SECRET_KEY'
+    'ENTERPRISE_KEY'
+    'CLOUDFLARE_API_KEY'
+    'CLOUDFLARE_ZONE_ID'
+    'CLOUDFLARE_WEBHOOK_SECRET'
+    'CLICKHOUSE_URL'
+  )
+  for var in "${env_vars[@]}"; do
+    file_env "$var"
+  done
+}
+
+docker_setup_env
 setup_and_migrate_db
 register_background_jobs
 


### PR DESCRIPTION
Add support for Docker secrets by implementing _FILE suffix convention for sensitive environment variables. This allows values to be read from files (typically mounted at /run/secrets/) instead of being passed directly as environment variables.

The file_env() function checks for both direct env vars and _FILE variants, reads the file content when the _FILE variant is set, and ensures both aren't set simultaneously to avoid conflicts.

Supported variables with _FILE suffix:
- PG_DATABASE_URL
- REDIS_URL
- APP_SECRET
- AUTH_GOOGLE_CLIENT_ID/SECRET
- AUTH_MICROSOFT_CLIENT_ID/SECRET
- CAPTCHA_SITE_KEY/SECRET_KEY
- ENTERPRISE_KEY
- CLOUDFLARE_API_KEY/WEBHOOK_SECRET
- CLICKHOUSE_URL
- And other authentication/integration credentials

This follows Docker best practices for managing secrets in Swarm mode and Compose, improving security by avoiding secrets in environment variables or compose files.

Fixes issue [16203](https://github.com/twentyhq/twenty/issues/16203)

References:
[Postgres docker-entrypoint.sh](https://github.com/docker-library/postgres/blob/master/docker-entrypoint.sh)
[Mysql docker-entrypoint.sh](https://github.com/docker-library/mysql/blob/master/docker-entrypoint.sh)
[Docker Secrets in MySQL docker image](https://hub.docker.com/_/mysql#docker-secrets)