### PR TITLE
Add community Sealos template in self-hosted cloud provider docs

### DIFF
--- a/packages/twenty-docs/developers/self-hosting/cloud-providers.mdx
+++ b/packages/twenty-docs/developers/self-hosting/cloud-providers.mdx
@@ -39,6 +39,12 @@ Deploy Twenty on Railway with the community maintained template below.
 
 [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/nAL3hA)
 
+### Twenty on Sealos
+
+Deploy Twenty on Sealos with the community maintained template below.
+
+[![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/twenty)
+
 ## Others
 
 Please feel free to Open a PR to add more Cloud Provider options.


### PR DESCRIPTION
Added deployment instructions for Twenty on Sealos.