### PR TITLE
Fixed sample CSV file generation

### DIFF
--- a/packages/twenty-front/src/modules/object-record/spreadsheet-import/utils/spreadsheetImportFilterAvailableFieldMetadataItems.ts
+++ b/packages/twenty-front/src/modules/object-record/spreadsheet-import/utils/spreadsheetImportFilterAvailableFieldMetadataItems.ts
@@ -12,6 +12,7 @@ export const spreadsheetImportFilterAvailableFieldMetadataItems = (
         (!fieldMetadataItem.isSystem || fieldMetadataItem.name === 'id') &&
         fieldMetadataItem.name !== 'createdAt' &&
         fieldMetadataItem.name !== 'updatedAt' &&
+        fieldMetadataItem.name !== 'deletedAt' &&
         (![FieldMetadataType.RELATION, FieldMetadataType.RICH_TEXT].includes(
           fieldMetadataItem.type,
         ) ||


### PR DESCRIPTION
This PR fixes a bug that created a deletedAt column in sample CSV file generated for import, that when used afterwards for import, would create soft deleted records, which gives the impression that the CSV import does not work.