### PR TITLE
Change cookie storage duration

### DIFF
--- a/packages/twenty-front/src/utils/recoil-effects.ts
+++ b/packages/twenty-front/src/utils/recoil-effects.ts
@@ -53,7 +53,7 @@ export const cookieStorageEffect =
     }
 
     const defaultAttributes = {
-      expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 7),
+      expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 180),
       ...(attributes ?? {}),
     };
 


### PR DESCRIPTION
Set it to 180 days like Notion does.

Currently **Access Token Expires In** is set to 90 days but this setting is ignored because the cookie is cleared after 7 days