### PR TITLE
Fix view disappearing when switching from WORKSPACE to UNLISTED visibility

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/all-flat-entity-properties-to-compare-and-stringify.constant.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/all-flat-entity-properties-to-compare-and-stringify.constant.ts
@@ -39,7 +39,12 @@ export const ALL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY = {
     propertiesToStringify: ['standardOverrides'],
   },
   view: {
-    propertiesToCompare: ['key', 'deletedAt', ...FLAT_VIEW_EDITABLE_PROPERTIES],
+    propertiesToCompare: [
+      'key',
+      'deletedAt',
+      'createdByUserWorkspaceId',
+      ...FLAT_VIEW_EDITABLE_PROPERTIES,
+    ],
     propertiesToStringify: [],
   },
   viewField: {


### PR DESCRIPTION
## Description

When switching a view's visibility from WORKSPACE to UNLISTED, the code in `view-v2.service.ts` correctly sets `createdByUserWorkspaceId` to the current user (to prevent the view from disappearing). However, this property was not included in `FLAT_VIEW_EDITABLE_PROPERTIES`, which meant:

1. The comparison logic didn't detect the change
2. No update action was created for the property  
3. The value was never persisted to the database
4. The view disappeared because it became UNLISTED with no owner

This fix adds `createdByUserWorkspaceId` to the editable properties so the change is properly detected and persisted.

Might fix https://github.com/twentyhq/twenty/issues/15955