### PR TITLE
fix(workflow): clicking on 'See runs' shows executions from all workflows

### DIFF
--- a/packages/twenty-front/src/modules/object-metadata/utils/getFilterFilterableFieldMetadataItems.ts
+++ b/packages/twenty-front/src/modules/object-metadata/utils/getFilterFilterableFieldMetadataItems.ts
@@ -11,6 +11,10 @@ export const getFilterFilterableFieldMetadataItems = ({
     const isFieldActive = field.isActive;
     const isIdField = field.name === 'id';
 
+    const isWorkflowRelationField =
+      field.type === FieldMetadataType.RELATION &&
+      (field.name === 'workflow' || field.name === 'workflowVersion');
+
     const isRelationFieldHandled = !(
       field.type === FieldMetadataType.RELATION &&
       field.relation?.type !== RelationType.MANY_TO_ONE
@@ -39,7 +43,7 @@ export const getFilterFilterableFieldMetadataItems = ({
     ].includes(field.type);
 
     const isFieldFilterable =
-      (!isSystemField || isIdField) &&
+      (!isSystemField || isIdField || isWorkflowRelationField) &&
       isFieldActive &&
       isRelationFieldHandled &&
       isFieldTypeFilterable;


### PR DESCRIPTION
Fixes: #16229 and #16286

This PR fixes the bug where click on 'See All Runs' button for a specific workflow was not filtering the runs for that speciific workflow. 

**Reason** : The filter logic in `getFilterFilterableFieldMetadataItems` was excluding ALL system fields(except field id) from being filterable, which prevented these essential business relations from being used in filters. 

**Fix** : Added a targeted exception to allow specific system relation fields (`workflow` and `workflowVersion`) to be filterable, similar to how the `id` system field is already whitelisted.


### Before


https://github.com/user-attachments/assets/50b98626-ccdc-468a-96f9-0c911fec9a39

<img width="1511" height="587" alt="Screenshot 2025-12-03 at 11 52 50 PM" src="https://github.com/user-attachments/assets/db6ea12b-8441-41c0-8a53-b9786b5c543a" />

### After


https://github.com/user-attachments/assets/856bbd61-4958-43de-8fa5-3f52ca9e7260



<img width="835" height="562" alt="Screenshot 2025-12-04 at 12 33 32 AM" src="https://github.com/user-attachments/assets/bdcb43c7-d4ce-4932-8317-f0736d880784" />

