### PR TITLE
Remove failing workflow when already started

### DIFF
--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run/workflow-run.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run/workflow-run.workspace-service.ts
@@ -151,16 +151,6 @@ export class WorkflowRunWorkspaceService {
     });
 
     if (
-      workflowRunToUpdate.status === WorkflowRunStatus.COMPLETED ||
-      workflowRunToUpdate.status === WorkflowRunStatus.FAILED
-    ) {
-      throw new WorkflowRunException(
-        'Cannot start a workflow run already ended',
-        WorkflowRunExceptionCode.INVALID_OPERATION,
-      );
-    }
-
-    if (
       workflowRunToUpdate.status !== WorkflowRunStatus.ENQUEUED &&
       workflowRunToUpdate.status !== WorkflowRunStatus.NOT_STARTED
     ) {


### PR DESCRIPTION
This is a temporary fix that needs to be revisited.

It seems that with the new enqueue system we are enqueuing jobs multiple times due to race condition. We likely want to only consider job that have been created more than x secs ago