### PR TITLE
Add lock to enqueue workflow job

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/cache-storage/services/cache-storage.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/cache-storage/services/cache-storage.service.ts
@@ -208,6 +208,22 @@ export class CacheStorageService {
     await this.del(key);
   }
 
+  async incrBy(key: string, increment: number): Promise<number> {
+    if (this.isRedisCache()) {
+      return (this.cache as RedisCache).store.client.incrBy(
+        this.getKey(key),
+        increment,
+      );
+    }
+
+    const current = (await this.get<number>(key)) ?? 0;
+    const newValue = current + increment;
+
+    await this.set(key, newValue);
+
+    return newValue;
+  }
+
   private isRedisCache() {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return (this.cache.store as any)?.name === 'redis';

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/cron/jobs/workflow-run-enqueue.cron.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/cron/jobs/workflow-run-enqueue.cron.job.ts
@@ -17,7 +17,7 @@ export class WorkflowRunEnqueueCronJob {
   constructor(
     @InjectRepository(WorkspaceEntity)
     private readonly workspaceRepository: Repository<WorkspaceEntity>,
-    private readonly WorkflowRunEnqueueWorkspaceService: WorkflowRunEnqueueWorkspaceService,
+    private readonly workflowRunEnqueueWorkspaceService: WorkflowRunEnqueueWorkspaceService,
   ) {}
 
   @Process(WorkflowRunEnqueueCronJob.name)
@@ -32,7 +32,7 @@ export class WorkflowRunEnqueueCronJob {
       },
     });
 
-    await this.WorkflowRunEnqueueWorkspaceService.enqueueRuns({
+    await this.workflowRunEnqueueWorkspaceService.enqueueRuns({
       workspaceIds: activeWorkspaces.map((workspace) => workspace.id),
       isCacheMode: false,
     });

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/jobs/workflow-run-enqueue.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/jobs/workflow-run-enqueue.job.ts
@@ -8,7 +8,6 @@ import { WorkflowRunEnqueueWorkspaceService } from 'src/modules/workflow/workflo
 export type WorkflowRunEnqueueJobData = {
   workspaceId: string;
   isCacheMode: boolean;
-  priorityWorkflowRunId?: string;
 };
 
 @Processor({ queueName: MessageQueue.workflowQueue, scope: Scope.REQUEST })
@@ -21,11 +20,9 @@ export class WorkflowRunEnqueueJob {
   async handle({
     workspaceId,
     isCacheMode,
-    priorityWorkflowRunId,
   }: WorkflowRunEnqueueJobData): Promise<void> {
     await this.WorkflowRunEnqueueWorkspaceService.enqueueRunsForWorkspace({
       workspaceId,
-      priorityWorkflowRunId,
       isCacheMode,
     });
   }

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/utils/get-workflow-run-not-started-count-cache-key.util.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/utils/get-workflow-run-not-started-count-cache-key.util.ts
@@ -1,3 +1,0 @@
-export const getWorkflowRunNotStartedCountCacheKey = (
-  workspaceId: string,
-): string => `workflow-run-not-started-count:${workspaceId}`;

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-run-enqueue.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-run-enqueue.workspace-service.ts
@@ -1,6 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
 
-import { isDefined } from 'twenty-shared/utils';
 import { Not } from 'typeorm';
 
 import { InjectMessageQueue } from 'src/engine/core-modules/message-queue/decorators/message-queue.decorator';
@@ -42,11 +41,9 @@ export class WorkflowRunEnqueueWorkspaceService {
 
   async enqueueRunsForWorkspace({
     workspaceId,
-    priorityWorkflowRunId,
     isCacheMode,
   }: {
     workspaceId: string;
-    priorityWorkflowRunId?: string;
     isCacheMode: boolean;
   }) {
     const lockAcquired =
@@ -90,23 +87,6 @@ export class WorkflowRunEnqueueWorkspaceService {
         );
 
       const workflowRunIdsToEnqueue: string[] = [];
-
-      if (isDefined(priorityWorkflowRunId)) {
-        const priorityRun = await workflowRunRepository.findOne({
-          where: {
-            id: priorityWorkflowRunId,
-            status: WorkflowRunStatus.NOT_STARTED,
-          },
-          select: {
-            id: true,
-          },
-        });
-
-        if (isDefined(priorityRun)) {
-          workflowRunIdsToEnqueue.push(priorityRun.id);
-          remainingWorkflowRunToEnqueueCount--;
-        }
-      }
 
       if (remainingWorkflowRunToEnqueueCount > 0) {
         const additionalRunsToEnqueue = await workflowRunRepository.find({

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-run-enqueue.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-run-enqueue.workspace-service.ts
@@ -72,11 +72,9 @@ export class WorkflowRunEnqueueWorkspaceService {
           );
 
       if (notStartedRunsCount <= 0) {
-        if (!isCacheMode) {
-          await this.workflowThrottlingWorkspaceService.recomputeWorkflowRunNotStartedCount(
-            workspaceId,
-          );
-        }
+        await this.workflowThrottlingWorkspaceService.recomputeWorkflowRunNotStartedCount(
+          workspaceId,
+        );
 
         return;
       }

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-run-enqueue.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-run-enqueue.workspace-service.ts
@@ -49,6 +49,15 @@ export class WorkflowRunEnqueueWorkspaceService {
     priorityWorkflowRunId?: string;
     isCacheMode: boolean;
   }) {
+    const lockAcquired =
+      await this.workflowThrottlingWorkspaceService.acquireWorkflowEnqueueLock(
+        workspaceId,
+      );
+
+    if (!lockAcquired) {
+      return;
+    }
+
     try {
       const workflowRunRepository =
         await this.twentyORMGlobalManager.getRepositoryForWorkspace(
@@ -172,6 +181,10 @@ export class WorkflowRunEnqueueWorkspaceService {
       this.logger.error(
         `Failed to enqueue workflow runs for workspace: ${workspaceId}`,
         error,
+      );
+    } finally {
+      await this.workflowThrottlingWorkspaceService.releaseWorkflowEnqueueLock(
+        workspaceId,
       );
     }
   }


### PR DESCRIPTION
- Add lock to run one enqueue job at a time. It will avoid race conditions
- Enqueue manual workflows directly, without waiting for the job