### PR TITLE
fix: exclude empty strings from unique constraint on email field

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/action-handlers/index/services/__tests__/create-index-action-handler.service.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/action-handlers/index/services/__tests__/create-index-action-handler.service.spec.ts
@@ -1,4 +1,4 @@
-import { CreateIndexActionHandlerService } from '../create-index-action-handler.service';
+import { CreateIndexActionHandlerService } from 'src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/action-handlers/index/services/create-index-action-handler.service';
 
 describe('CreateIndexActionHandlerService', () => {
   let service: CreateIndexActionHandlerService;

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/action-handlers/index/services/__tests__/create-index-action-handler.service.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/action-handlers/index/services/__tests__/create-index-action-handler.service.spec.ts
@@ -1,0 +1,55 @@
+import { CreateIndexActionHandlerService } from '../create-index-action-handler.service';
+
+describe('CreateIndexActionHandlerService', () => {
+  let service: CreateIndexActionHandlerService;
+
+  beforeEach(() => {
+    service = new CreateIndexActionHandlerService(null as any);
+  });
+
+  describe('computeWhereClauseForUniqueIndex', () => {
+    it('should return existing where clause if provided', () => {
+      const result = (service as any).computeWhereClauseForUniqueIndex({
+        isUnique: true,
+        existingWhereClause: '"deletedAt" IS NULL',
+        columns: ['emailsPrimaryEmail'],
+      });
+
+      expect(result).toBe('"deletedAt" IS NULL');
+    });
+
+    it('should return undefined for non-unique indexes', () => {
+      const result = (service as any).computeWhereClauseForUniqueIndex({
+        isUnique: false,
+        existingWhereClause: null,
+        columns: ['emailsPrimaryEmail'],
+      });
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should generate WHERE clause excluding empty strings for unique indexes', () => {
+      const result = (service as any).computeWhereClauseForUniqueIndex({
+        isUnique: true,
+        existingWhereClause: null,
+        columns: ['emailsPrimaryEmail'],
+      });
+
+      expect(result).toBe(
+        '"emailsPrimaryEmail" IS NOT NULL AND "emailsPrimaryEmail" <> \'\'',
+      );
+    });
+
+    it('should generate WHERE clause for multiple columns', () => {
+      const result = (service as any).computeWhereClauseForUniqueIndex({
+        isUnique: true,
+        existingWhereClause: null,
+        columns: ['nameFirstName', 'nameLastName'],
+      });
+
+      expect(result).toBe(
+        '"nameFirstName" IS NOT NULL AND "nameFirstName" <> \'\' AND "nameLastName" IS NOT NULL AND "nameLastName" <> \'\'',
+      );
+    });
+  });
+});

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/action-handlers/index/services/create-index-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/action-handlers/index/services/create-index-action-handler.service.ts
@@ -13,6 +13,7 @@ import {
   WorkspaceQueryRunnerExceptionCode,
 } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-runner.exception';
 import { computeCompositeColumnName } from 'src/engine/metadata-modules/field-metadata/utils/compute-column-name.util';
+import { removeSqlDDLInjection } from 'src/engine/workspace-manager/workspace-migration-runner/utils/remove-sql-injection.util';
 import { isCompositeFieldMetadataType } from 'src/engine/metadata-modules/field-metadata/utils/is-composite-field-metadata-type.util';
 import {
   FlatEntityMapsException,
@@ -210,7 +211,8 @@ export class CreateIndexActionHandlerService extends WorkspaceMigrationRunnerAct
     }
 
     const nonEmptyConditions = columns.map(
-      (column) => `"${column}" IS NOT NULL AND "${column}" <> ''`,
+      (column) =>
+        `"${removeSqlDDLInjection(column)}" IS NOT NULL AND "${removeSqlDDLInjection(column)}" <> ''`,
     );
 
     return nonEmptyConditions.join(' AND ');


### PR DESCRIPTION
## Summary

**Issue #16270**: Creating a customer with an empty email via API caused a "duplicate" error if another customer already had an empty email.

**Fix**: Modified [create-index-action-handler.service.ts](cci:7://file:///Users/apple/WebstormProjects/twenty/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/action-handlers/index/services/create-index-action-handler.service.ts:0:0-0:0) to automatically add a WHERE clause to unique indexes that excludes NULL and empty string values:

```sql
WHERE "emailsPrimaryEmail" IS NOT NULL AND "emailsPrimaryEmail" <> ''
```

This allows multiple records to have empty emails while still enforcing uniqueness for non-empty values.

**Files changed**:
- [create-index-action-handler.service.ts](cci:7://file:///Users/apple/WebstormProjects/twenty/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/action-handlers/index/services/create-index-action-handler.service.ts:0:0-0:0) - Added [computeWhereClauseForUniqueIndex](cci:1://file:///Users/apple/WebstormProjects/twenty/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/action-handlers/index/services/create-index-action-handler.service.ts:194:2-216:3) method
- [create-index-action-handler.service.spec.ts](cci:7://file:///Users/apple/WebstormProjects/twenty/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/workspace-migration-runner-v2/action-handlers/index/services/__tests__/create-index-action-handler.service.spec.ts:0:0-0:0) - Added tests for the new method