### PR TITLE
Null - Fix emails field

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/record-transformer/utils/transform-emails-value.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-transformer/utils/transform-emails-value.util.ts
@@ -10,7 +10,7 @@ export const transformEmailsValue = (
   }
 
   let additionalEmails: string | null = value?.additionalEmails;
-  const primaryEmail = value?.primaryEmail
+  const primaryEmail = isNonEmptyString(value?.primaryEmail)
     ? value.primaryEmail.toLowerCase()
     : null;
 


### PR DESCRIPTION
fixes https://github.com/twentyhq/twenty/issues/16270

It happens with api user only.

Integration tests were ok because we expect a returned empty string (check in test) even if null value is expected in db (not test). How can we improve this ?