### PR TITLE
1825 extensibility v1 see serverless logs using subscriptions in twnty cli or settings serverkess section

### DIFF
--- a/packages/create-twenty-app/README.md
+++ b/packages/create-twenty-app/README.md
@@ -42,8 +42,14 @@ yarn dev
 # Or run a one‑time sync
 yarn sync
 
+# Watch your application's functions logs
+yarn logs
+
 # Uninstall the application from the current workspace
 yarn uninstall
+
+# Display commands' help
+yarn help
 ```
 
 ## What gets scaffolded

--- a/packages/create-twenty-app/package.json
+++ b/packages/create-twenty-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-twenty-app",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "description": "Command-line interface to create Twenty application",
   "main": "dist/cli.cjs",
   "bin": "dist/cli.cjs",

--- a/packages/create-twenty-app/src/constants/base-application/README.md
+++ b/packages/create-twenty-app/src/constants/base-application/README.md
@@ -8,21 +8,13 @@ First, authenticate to your workspace:
 yarn auth
 ```
 
-Then, run the development server:
+Then, install this app to your workspace:
 
 ```bash
-yarn dev
+yarn sync
 ```
 
 Open your Twenty instance and go to `/settings/applications` section to see the result.
-
-You can start adding twenty entities by running
-
-```bash
-yarn create-entity
-```
-
-The application auto-updates as you edit the file.
 
 ## Learn More
 

--- a/packages/create-twenty-app/src/utils/app-template.ts
+++ b/packages/create-twenty-app/src/utils/app-template.ts
@@ -121,11 +121,13 @@ const createPackageJson = async ({
       dev: 'twenty app dev',
       generate: 'twenty app generate',
       sync: 'twenty app sync',
+      logs: 'twenty app logs',
       uninstall: 'twenty app uninstall',
+      help: 'twenty help',
       auth: 'twenty auth login',
     },
     dependencies: {
-      'twenty-sdk': '0.1.2',
+      'twenty-sdk': '0.1.3',
     },
     devDependencies: {
       '@types/node': '^24.7.2',

--- a/packages/twenty-front/src/generated-metadata/graphql.ts
+++ b/packages/twenty-front/src/generated-metadata/graphql.ts
@@ -3940,6 +3940,20 @@ export type ServerlessFunctionLayer = {
   updatedAt: Scalars['DateTime'];
 };
 
+export type ServerlessFunctionLogs = {
+  __typename?: 'ServerlessFunctionLogs';
+  /** Execution Logs */
+  logs: Scalars['String'];
+};
+
+export type ServerlessFunctionLogsInput = {
+  applicationId?: InputMaybe<Scalars['UUID']>;
+  applicationUniversalIdentifier?: InputMaybe<Scalars['UUID']>;
+  id?: InputMaybe<Scalars['UUID']>;
+  name?: InputMaybe<Scalars['String']>;
+  universalIdentifier?: InputMaybe<Scalars['UUID']>;
+};
+
 export type SetupOidcSsoInput = {
   clientID: Scalars['String'];
   clientSecret: Scalars['String'];
@@ -3997,11 +4011,17 @@ export type SubmitFormStepInput = {
 export type Subscription = {
   __typename?: 'Subscription';
   onDbEvent: OnDbEvent;
+  serverlessFunctionLogs: ServerlessFunctionLogs;
 };
 
 
 export type SubscriptionOnDbEventArgs = {
   input: OnDbEventInput;
+};
+
+
+export type SubscriptionServerlessFunctionLogsArgs = {
+  input: ServerlessFunctionLogsInput;
 };
 
 export enum SubscriptionInterval {

--- a/packages/twenty-front/src/generated/graphql.ts
+++ b/packages/twenty-front/src/generated/graphql.ts
@@ -3777,6 +3777,20 @@ export type ServerlessFunctionLayer = {
   updatedAt: Scalars['DateTime'];
 };
 
+export type ServerlessFunctionLogs = {
+  __typename?: 'ServerlessFunctionLogs';
+  /** Execution Logs */
+  logs: Scalars['String'];
+};
+
+export type ServerlessFunctionLogsInput = {
+  applicationId?: InputMaybe<Scalars['UUID']>;
+  applicationUniversalIdentifier?: InputMaybe<Scalars['UUID']>;
+  id?: InputMaybe<Scalars['UUID']>;
+  name?: InputMaybe<Scalars['String']>;
+  universalIdentifier?: InputMaybe<Scalars['UUID']>;
+};
+
 export type SetupOidcSsoInput = {
   clientID: Scalars['String'];
   clientSecret: Scalars['String'];
@@ -3834,11 +3848,17 @@ export type SubmitFormStepInput = {
 export type Subscription = {
   __typename?: 'Subscription';
   onDbEvent: OnDbEvent;
+  serverlessFunctionLogs: ServerlessFunctionLogs;
 };
 
 
 export type SubscriptionOnDbEventArgs = {
   input: OnDbEventInput;
+};
+
+
+export type SubscriptionServerlessFunctionLogsArgs = {
+  input: ServerlessFunctionLogsInput;
 };
 
 export enum SubscriptionInterval {

--- a/packages/twenty-front/src/modules/serverless-functions/components/ServerlessFunctionExecutionResult.tsx
+++ b/packages/twenty-front/src/modules/serverless-functions/components/ServerlessFunctionExecutionResult.tsx
@@ -7,9 +7,11 @@ import { ServerlessFunctionExecutionStatus } from '~/generated-metadata/graphql'
 
 export const ServerlessFunctionExecutionResult = ({
   serverlessFunctionTestData,
+  maxHeight,
   isTesting = false,
 }: {
   serverlessFunctionTestData: ServerlessFunctionTestData;
+  maxHeight?: number;
   isTesting?: boolean;
 }) => {
   const result =
@@ -40,7 +42,10 @@ export const ServerlessFunctionExecutionResult = ({
     <WorkflowStepExecutionResult
       result={result}
       language={serverlessFunctionTestData.language}
-      height={serverlessFunctionTestData.height}
+      height={Math.min(
+        serverlessFunctionTestData.height,
+        maxHeight ?? serverlessFunctionTestData.height,
+      )}
       status={status}
       isTesting={isTesting}
       loadingMessage="Running function"

--- a/packages/twenty-front/src/modules/settings/serverless-functions/components/tabs/SettingsServerlessFunctionTestTab.tsx
+++ b/packages/twenty-front/src/modules/settings/serverless-functions/components/tabs/SettingsServerlessFunctionTestTab.tsx
@@ -6,6 +6,8 @@ import { useRecoilState } from 'recoil';
 import { H2Title, IconPlayerPlay } from 'twenty-ui/display';
 import { Button, CodeEditor, CoreEditorHeader } from 'twenty-ui/input';
 import { Section } from 'twenty-ui/layout';
+import { InputLabel } from '@/ui/input/components/InputLabel';
+import { TextArea } from '@/ui/input/components/TextArea';
 
 const StyledInputsContainer = styled.div`
   display: flex;
@@ -37,6 +39,8 @@ export const SettingsServerlessFunctionTestTab = ({
       input: JSON.parse(newInput),
     }));
   };
+
+  const testLogsTextAreaId = `${serverlessFunctionId}-test-logs`;
 
   return (
     <Section>
@@ -72,6 +76,17 @@ export const SettingsServerlessFunctionTestTab = ({
           serverlessFunctionTestData={serverlessFunctionTestData}
           isTesting={isTesting}
         />
+        {serverlessFunctionTestData.output.logs.length > 0 && (
+          <StyledCodeEditorContainer>
+            <InputLabel>Logs</InputLabel>
+            <TextArea
+              textAreaId={testLogsTextAreaId}
+              value={isTesting ? '' : serverlessFunctionTestData.output.logs}
+              maxRows={20}
+              disabled
+            />
+          </StyledCodeEditorContainer>
+        )}
       </StyledInputsContainer>
     </Section>
   );

--- a/packages/twenty-front/src/modules/settings/serverless-functions/components/tabs/SettingsServerlessFunctionTestTab.tsx
+++ b/packages/twenty-front/src/modules/settings/serverless-functions/components/tabs/SettingsServerlessFunctionTestTab.tsx
@@ -67,13 +67,16 @@ export const SettingsServerlessFunctionTestTab = ({
           <CodeEditor
             value={JSON.stringify(serverlessFunctionTestData.input, null, 4)}
             language="json"
-            height={200}
+            height={100}
             onChange={onChange}
             variant="with-header"
           />
         </StyledCodeEditorContainer>
         <ServerlessFunctionExecutionResult
           serverlessFunctionTestData={serverlessFunctionTestData}
+          maxHeight={
+            serverlessFunctionTestData.output.logs.length > 0 ? 200 : undefined
+          }
           isTesting={isTesting}
         />
         {serverlessFunctionTestData.output.logs.length > 0 && (

--- a/packages/twenty-sdk/package.json
+++ b/packages/twenty-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twenty-sdk",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
@@ -38,6 +38,7 @@
     "dotenv": "^16.4.0",
     "fs-extra": "^11.2.0",
     "graphql": "^16.8.1",
+    "graphql-sse": "^2.5.4",
     "inquirer": "^10.0.0",
     "jsonc-parser": "^3.2.0",
     "lodash.camelcase": "^4.3.0",
@@ -66,5 +67,8 @@
   "engines": {
     "node": "^24.5.0",
     "yarn": "^4.0.2"
+  },
+  "typesVersions": {
+    "*": {}
   }
 }

--- a/packages/twenty-sdk/src/cli/commands/app-logs.command.ts
+++ b/packages/twenty-sdk/src/cli/commands/app-logs.command.ts
@@ -47,12 +47,12 @@ export class AppLogsCommand {
     functionName?: string;
   }): void {
     const appPath = appName ?? 'Twenty Application';
+
     const functionIdentifier =
       functionUniversalIdentifier || functionName
         ? `function "${functionUniversalIdentifier || functionName}"`
         : 'functions';
-    if (functionUniversalIdentifier || functionName) {
-    }
+
     console.log(
       chalk.blue(`🚀 Watching ${appPath} ${functionIdentifier} logs:`),
     );

--- a/packages/twenty-sdk/src/cli/commands/app-logs.command.ts
+++ b/packages/twenty-sdk/src/cli/commands/app-logs.command.ts
@@ -17,6 +17,11 @@ export class AppLogsCommand {
   }): Promise<void> {
     try {
       const { manifest } = await loadManifest(appPath);
+      this.logWatchInfo({
+        appName: manifest.application.displayName,
+        functionUniversalIdentifier,
+        functionName,
+      });
       await this.apiService.subscribeToLogs({
         applicationUniversalIdentifier:
           manifest.application.universalIdentifier,
@@ -30,5 +35,28 @@ export class AppLogsCommand {
       );
       process.exit(1);
     }
+  }
+
+  private logWatchInfo({
+    appName,
+    functionUniversalIdentifier,
+    functionName,
+  }: {
+    appName?: string;
+    functionUniversalIdentifier?: string;
+    functionName?: string;
+  }): void {
+    const appPath = appName ?? 'Twenty Application';
+    const functionIdentifier =
+      functionUniversalIdentifier || functionName
+        ? `function "${functionUniversalIdentifier || functionName}"`
+        : 'functions';
+    if (functionUniversalIdentifier || functionName) {
+    }
+    console.log(
+      chalk.blue(`🚀 Watching ${appPath} ${functionIdentifier} logs:`),
+    );
+
+    console.log('');
   }
 }

--- a/packages/twenty-sdk/src/cli/commands/app-logs.command.ts
+++ b/packages/twenty-sdk/src/cli/commands/app-logs.command.ts
@@ -1,0 +1,34 @@
+import chalk from 'chalk';
+import { CURRENT_EXECUTION_DIRECTORY } from '@/cli/constants/current-execution-directory';
+import { loadManifest } from '@/cli/utils/load-manifest';
+import { ApiService } from '@/cli/services/api.service';
+
+export class AppLogsCommand {
+  private apiService = new ApiService();
+
+  async execute({
+    appPath = CURRENT_EXECUTION_DIRECTORY,
+    functionUniversalIdentifier,
+    functionName,
+  }: {
+    appPath?: string;
+    functionUniversalIdentifier?: string;
+    functionName?: string;
+  }): Promise<void> {
+    try {
+      const { manifest } = await loadManifest(appPath);
+      await this.apiService.subscribeToLogs({
+        applicationUniversalIdentifier:
+          manifest.application.universalIdentifier,
+        functionUniversalIdentifier,
+        functionName,
+      });
+    } catch (error) {
+      console.error(
+        chalk.red('Watch logs failed:'),
+        error instanceof Error ? error.message : error,
+      );
+      process.exit(1);
+    }
+  }
+}

--- a/packages/twenty-sdk/src/cli/commands/app.command.ts
+++ b/packages/twenty-sdk/src/cli/commands/app.command.ts
@@ -10,6 +10,7 @@ import { AppDevCommand } from './app-dev.command';
 import { AppSyncCommand } from './app-sync.command';
 import { formatPath } from '../utils/format-path';
 import { AppGenerateCommand } from './app-generate.command';
+import { AppLogsCommand } from '@/cli/commands/app-logs.command';
 
 export class AppCommand {
   private devCommand = new AppDevCommand();
@@ -17,6 +18,7 @@ export class AppCommand {
   private uninstallCommand = new AppUninstallCommand();
   private addCommand = new AppAddCommand();
   private generateCommand = new AppGenerateCommand();
+  private logsCommand = new AppLogsCommand();
 
   getCommand(): Command {
     const appCommand = new Command('app');
@@ -109,6 +111,32 @@ export class AppCommand {
       .action(async (appPath?: string) => {
         await this.generateCommand.execute(formatPath(appPath));
       });
+
+    appCommand
+      .command('logs [appPath]')
+      .option(
+        '-u, --functionUniversalIdentifier <functionUniversalIdentifier>',
+        'Only show logs for the function with this universal ID',
+      )
+      .option(
+        '-n, --functionName <functionName>',
+        'Only show logs for the function with this name',
+      )
+      .description('Watch application function logs')
+      .action(
+        async (
+          appPath?: string,
+          options?: {
+            functionUniversalIdentifier?: string;
+            functionName?: string;
+          },
+        ) => {
+          await this.logsCommand.execute({
+            ...options,
+            appPath: formatPath(appPath),
+          });
+        },
+      );
 
     return appCommand;
   }

--- a/packages/twenty-server/src/engine/metadata-modules/serverless-function/constants/serverless-function-logs-trigger.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/serverless-function/constants/serverless-function-logs-trigger.ts
@@ -1,0 +1,1 @@
+export const SERVERLESS_FUNCTION_LOGS_TRIGGER = 'serverlessFunctionLogs';

--- a/packages/twenty-server/src/engine/metadata-modules/serverless-function/dtos/serverless-function-logs.dto.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/serverless-function/dtos/serverless-function-logs.dto.ts
@@ -1,0 +1,19 @@
+import { Field, HideField, ObjectType } from '@nestjs/graphql';
+
+@ObjectType('ServerlessFunctionLogs')
+export class ServerlessFunctionLogsDTO {
+  @Field({ description: 'Execution Logs' })
+  logs: string;
+
+  @HideField()
+  applicationId?: string;
+
+  @HideField()
+  name?: string;
+
+  @HideField()
+  id?: string;
+
+  @HideField()
+  universalIdentifier?: string;
+}

--- a/packages/twenty-server/src/engine/metadata-modules/serverless-function/dtos/serverless-function-logs.dto.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/serverless-function/dtos/serverless-function-logs.dto.ts
@@ -6,6 +6,9 @@ export class ServerlessFunctionLogsDTO {
   logs: string;
 
   @HideField()
+  applicationUniversalIdentifier?: string;
+
+  @HideField()
   applicationId?: string;
 
   @HideField()

--- a/packages/twenty-server/src/engine/metadata-modules/serverless-function/dtos/serverless-function-logs.input.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/serverless-function/dtos/serverless-function-logs.input.ts
@@ -1,0 +1,18 @@
+import { Field, InputType } from '@nestjs/graphql';
+
+import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
+
+@InputType('ServerlessFunctionLogs')
+export class ServerlessFunctionLogsInput {
+  @Field(() => UUIDScalarType, { nullable: true })
+  applicationId?: string;
+
+  @Field(() => String, { nullable: true })
+  name?: string;
+
+  @Field(() => UUIDScalarType, { nullable: true })
+  id?: string;
+
+  @Field(() => UUIDScalarType, { nullable: true })
+  universalIdentifier?: string;
+}

--- a/packages/twenty-server/src/engine/metadata-modules/serverless-function/dtos/serverless-function-logs.input.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/serverless-function/dtos/serverless-function-logs.input.ts
@@ -2,10 +2,13 @@ import { Field, InputType } from '@nestjs/graphql';
 
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 
-@InputType('ServerlessFunctionLogs')
+@InputType('ServerlessFunctionLogsInput')
 export class ServerlessFunctionLogsInput {
   @Field(() => UUIDScalarType, { nullable: true })
   applicationId?: string;
+
+  @Field(() => UUIDScalarType, { nullable: true })
+  applicationUniversalIdentifier?: string;
 
   @Field(() => String, { nullable: true })
   name?: string;

--- a/packages/twenty-server/src/engine/metadata-modules/serverless-function/serverless-function.module.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/serverless-function/serverless-function.module.ts
@@ -23,6 +23,7 @@ import { ServerlessFunctionService } from 'src/engine/metadata-modules/serverles
 import { ServerlessFunctionV2Service } from 'src/engine/metadata-modules/serverless-function/services/serverless-function-v2.service';
 import { WorkspaceFlatServerlessFunctionMapCacheService } from 'src/engine/metadata-modules/serverless-function/services/workspace-flat-serverless-function-map-cache.service';
 import { WorkspaceMigrationV2Module } from 'src/engine/workspace-manager/workspace-migration-v2/workspace-migration-v2.module';
+import { SubscriptionsModule } from 'src/engine/subscriptions/subscriptions.module';
 
 @Module({
   imports: [
@@ -43,6 +44,7 @@ import { WorkspaceMigrationV2Module } from 'src/engine/workspace-manager/workspa
     WorkspaceManyOrAllFlatEntityMapsCacheModule,
     WorkspaceMigrationV2Module,
     ServerlessFunctionLayerModule,
+    SubscriptionsModule,
   ],
   providers: [
     ServerlessFunctionService,

--- a/packages/twenty-server/src/engine/metadata-modules/serverless-function/serverless-function.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/serverless-function/serverless-function.resolver.ts
@@ -4,8 +4,8 @@ import { InjectRepository } from '@nestjs/typeorm';
 
 import graphqlTypeJson from 'graphql-type-json';
 import { Repository } from 'typeorm';
-import { isDefined } from 'twenty-shared/utils';
 import { RedisPubSub } from 'graphql-redis-subscriptions';
+import { isDefined } from 'twenty-shared/utils';
 
 import { PreventNestToAutoLogGraphqlErrorsFilter } from 'src/engine/core-modules/graphql/filters/prevent-nest-to-auto-log-graphql-errors.filter';
 import { ResolverValidationPipe } from 'src/engine/core-modules/graphql/pipes/resolver-validation.pipe';
@@ -198,33 +198,35 @@ export class ServerlessFunctionResolver {
       variables: { input: ServerlessFunctionLogsInput },
     ) => {
       const { serverlessFunctionLogs } = payload;
-      const { id, universalIdentifier, applicationId, name } =
-        serverlessFunctionLogs;
+      const {
+        id,
+        universalIdentifier,
+        applicationId,
+        applicationUniversalIdentifier,
+        name,
+      } = serverlessFunctionLogs;
       const {
         id: inputId,
         universalIdentifier: inputUniversalIdentifier,
-        applicationId: inputApplicationId,
         name: inputName,
+        applicationId: inputApplicationId,
+        applicationUniversalIdentifier: inputApplicationUniversalIdentifier,
       } = variables.input;
 
       return (
-        !isDefined(inputId) &&
-        inputId === id &&
-        !isDefined(inputUniversalIdentifier) &&
-        inputUniversalIdentifier === universalIdentifier &&
-        !isDefined(inputApplicationId) &&
-        inputApplicationId === applicationId &&
-        !isDefined(inputName) &&
-        inputName === name
+        (!isDefined(inputId) || inputId === id) &&
+        (!isDefined(inputUniversalIdentifier) ||
+          inputUniversalIdentifier === universalIdentifier) &&
+        (!isDefined(inputName) || inputName === name) &&
+        (!isDefined(inputApplicationId) ||
+          inputApplicationId === applicationId) &&
+        (!isDefined(inputApplicationUniversalIdentifier) ||
+          inputApplicationUniversalIdentifier ===
+            applicationUniversalIdentifier)
       );
     },
-    resolve: (payload: {
-      serverlessFunctionLogs: ServerlessFunctionLogsDTO;
-    }) => {
-      return payload.serverlessFunctionLogs;
-    },
   })
-  serverlessFunctionLogs() {
+  serverlessFunctionLogs(@Args('input') _: ServerlessFunctionLogsInput) {
     return this.pubSub.asyncIterator(SERVERLESS_FUNCTION_LOGS_TRIGGER);
   }
 }

--- a/packages/twenty-server/src/engine/metadata-modules/serverless-function/serverless-function.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/serverless-function/serverless-function.resolver.ts
@@ -1,9 +1,11 @@
-import { UseFilters, UseGuards, UsePipes } from '@nestjs/common';
-import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
+import { Inject, UseFilters, UseGuards, UsePipes } from '@nestjs/common';
+import { Args, Mutation, Query, Resolver, Subscription } from '@nestjs/graphql';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import graphqlTypeJson from 'graphql-type-json';
 import { Repository } from 'typeorm';
+import { isDefined } from 'twenty-shared/utils';
+import { RedisPubSub } from 'graphql-redis-subscriptions';
 
 import { PreventNestToAutoLogGraphqlErrorsFilter } from 'src/engine/core-modules/graphql/filters/prevent-nest-to-auto-log-graphql-errors.filter';
 import { ResolverValidationPipe } from 'src/engine/core-modules/graphql/pipes/resolver-validation.pipe';
@@ -24,6 +26,9 @@ import { UpdateServerlessFunctionInput } from 'src/engine/metadata-modules/serve
 import { ServerlessFunctionEntity } from 'src/engine/metadata-modules/serverless-function/serverless-function.entity';
 import { ServerlessFunctionService } from 'src/engine/metadata-modules/serverless-function/serverless-function.service';
 import { serverlessFunctionGraphQLApiExceptionHandler } from 'src/engine/metadata-modules/serverless-function/utils/serverless-function-graphql-api-exception-handler.utils';
+import { ServerlessFunctionLogsDTO } from 'src/engine/metadata-modules/serverless-function/dtos/serverless-function-logs.dto';
+import { ServerlessFunctionLogsInput } from 'src/engine/metadata-modules/serverless-function/dtos/serverless-function-logs.input';
+import { SERVERLESS_FUNCTION_LOGS_TRIGGER } from 'src/engine/metadata-modules/serverless-function/constants/serverless-function-logs-trigger';
 
 @UseGuards(
   WorkspaceAuthGuard,
@@ -38,6 +43,8 @@ export class ServerlessFunctionResolver {
     private readonly serverlessFunctionService: ServerlessFunctionService,
     @InjectRepository(ServerlessFunctionEntity)
     private readonly serverlessFunctionRepository: Repository<ServerlessFunctionEntity>,
+    @Inject('PUB_SUB')
+    private readonly pubSub: RedisPubSub,
   ) {}
 
   @Query(() => ServerlessFunctionDTO)
@@ -183,5 +190,41 @@ export class ServerlessFunctionResolver {
     } catch (error) {
       serverlessFunctionGraphQLApiExceptionHandler(error);
     }
+  }
+
+  @Subscription(() => ServerlessFunctionLogsDTO, {
+    filter: (
+      payload: { serverlessFunctionLogs: ServerlessFunctionLogsDTO },
+      variables: { input: ServerlessFunctionLogsInput },
+    ) => {
+      const { serverlessFunctionLogs } = payload;
+      const { id, universalIdentifier, applicationId, name } =
+        serverlessFunctionLogs;
+      const {
+        id: inputId,
+        universalIdentifier: inputUniversalIdentifier,
+        applicationId: inputApplicationId,
+        name: inputName,
+      } = variables.input;
+
+      return (
+        !isDefined(inputId) &&
+        inputId === id &&
+        !isDefined(inputUniversalIdentifier) &&
+        inputUniversalIdentifier === universalIdentifier &&
+        !isDefined(inputApplicationId) &&
+        inputApplicationId === applicationId &&
+        !isDefined(inputName) &&
+        inputName === name
+      );
+    },
+    resolve: (payload: {
+      serverlessFunctionLogs: ServerlessFunctionLogsDTO;
+    }) => {
+      return payload.serverlessFunctionLogs;
+    },
+  })
+  serverlessFunctionLogs() {
+    return this.pubSub.asyncIterator(SERVERLESS_FUNCTION_LOGS_TRIGGER);
   }
 }

--- a/packages/twenty-server/src/engine/metadata-modules/serverless-function/serverless-function.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/serverless-function/serverless-function.service.ts
@@ -102,6 +102,7 @@ export class ServerlessFunctionService {
         },
         relations: [
           'serverlessFunctionLayer',
+          'application',
           'application.applicationVariables',
         ],
       });

--- a/packages/twenty-server/src/engine/metadata-modules/serverless-function/serverless-function.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/serverless-function/serverless-function.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { join } from 'path';
@@ -6,6 +6,7 @@ import { join } from 'path';
 import deepEqual from 'deep-equal';
 import { isDefined } from 'twenty-shared/utils';
 import { IsNull, Not, Repository } from 'typeorm';
+import { RedisPubSub } from 'graphql-redis-subscriptions';
 
 import { FileStorageExceptionCode } from 'src/engine/core-modules/file-storage/interfaces/file-storage-exception';
 import { type ServerlessExecuteResult } from 'src/engine/core-modules/serverless/drivers/interfaces/serverless-driver.interface';
@@ -31,6 +32,7 @@ import {
   WorkflowVersionStepException,
   WorkflowVersionStepExceptionCode,
 } from 'src/modules/workflow/common/exceptions/workflow-version-step.exception';
+import { SERVERLESS_FUNCTION_LOGS_TRIGGER } from 'src/engine/metadata-modules/serverless-function/constants/serverless-function-logs-trigger';
 
 @Injectable()
 export class ServerlessFunctionService {
@@ -43,6 +45,8 @@ export class ServerlessFunctionService {
     private readonly throttlerService: ThrottlerService,
     private readonly twentyConfigService: TwentyConfigService,
     private readonly auditService: AuditService,
+    @Inject('PUB_SUB')
+    private readonly pubSub: RedisPubSub,
   ) {}
 
   async hasServerlessFunctionPublishedVersion(serverlessFunctionId: string) {
@@ -112,6 +116,16 @@ export class ServerlessFunctionService {
       /* eslint-disable no-console */
       console.log(resultServerlessFunction.logs);
     }
+
+    await this.pubSub.publish(SERVERLESS_FUNCTION_LOGS_TRIGGER, {
+      serverlessFunctionLogs: {
+        logs: resultServerlessFunction.logs,
+        id: functionToExecute.id,
+        name: functionToExecute.name,
+        universalIdentifier: functionToExecute.universalIdentifier,
+        applicationId: functionToExecute.applicationId,
+      },
+    });
 
     this.auditService
       .createContext({

--- a/packages/twenty-server/src/engine/metadata-modules/serverless-function/serverless-function.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/serverless-function/serverless-function.service.ts
@@ -124,6 +124,8 @@ export class ServerlessFunctionService {
         name: functionToExecute.name,
         universalIdentifier: functionToExecute.universalIdentifier,
         applicationId: functionToExecute.applicationId,
+        applicationUniversalIdentifier:
+          functionToExecute.application?.universalIdentifier,
       },
     });
 

--- a/packages/twenty-server/src/engine/subscriptions/constants/on-db-event-trigger.ts
+++ b/packages/twenty-server/src/engine/subscriptions/constants/on-db-event-trigger.ts
@@ -1,0 +1,1 @@
+export const ON_DB_EVENT_TRIGGER = 'onDbEvent';

--- a/packages/twenty-server/src/engine/subscriptions/subscriptions.resolver.ts
+++ b/packages/twenty-server/src/engine/subscriptions/subscriptions.resolver.ts
@@ -11,6 +11,7 @@ import { UserAuthGuard } from 'src/engine/guards/user-auth.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { OnDbEventDTO } from 'src/engine/subscriptions/dtos/on-db-event.dto';
 import { OnDbEventInput } from 'src/engine/subscriptions/dtos/on-db-event.input';
+import { ON_DB_EVENT_TRIGGER } from 'src/engine/subscriptions/constants/on-db-event-trigger';
 
 @Resolver()
 @UseGuards(WorkspaceAuthGuard, UserAuthGuard, NoPermissionGuard)
@@ -43,6 +44,6 @@ export class SubscriptionsResolver {
     },
   })
   onDbEvent(@Args('input') _: OnDbEventInput) {
-    return this.pubSub.asyncIterator('onDbEvent');
+    return this.pubSub.asyncIterator(ON_DB_EVENT_TRIGGER);
   }
 }

--- a/packages/twenty-server/src/engine/subscriptions/subscriptions.service.ts
+++ b/packages/twenty-server/src/engine/subscriptions/subscriptions.service.ts
@@ -5,6 +5,7 @@ import { RedisPubSub } from 'graphql-redis-subscriptions';
 import { type ObjectRecordEvent } from 'src/engine/core-modules/event-emitter/types/object-record-event.event';
 import { WorkspaceEventBatch } from 'src/engine/workspace-event-emitter/types/workspace-event-batch.type';
 import { transformEventToWebhookEvent } from 'src/engine/core-modules/webhook/utils/transform-event-to-webhook-event';
+import { ON_DB_EVENT_TRIGGER } from 'src/engine/subscriptions/constants/on-db-event-trigger';
 
 @Injectable()
 export class SubscriptionsService {
@@ -21,7 +22,7 @@ export class SubscriptionsService {
         event: eventData,
       });
 
-      await this.pubSub.publish('onDbEvent', {
+      await this.pubSub.publish(ON_DB_EVENT_TRIGGER, {
         onDbEvent: {
           action: operation,
           objectNameSingular: nameSingular,

--- a/yarn.lock
+++ b/yarn.lock
@@ -56104,6 +56104,7 @@ __metadata:
     dotenv: "npm:^16.4.0"
     fs-extra: "npm:^11.2.0"
     graphql: "npm:^16.8.1"
+    graphql-sse: "npm:^2.5.4"
     inquirer: "npm:^10.0.0"
     jest: "npm:^29.5.0"
     jsonc-parser: "npm:^3.2.0"


### PR DESCRIPTION
- Adds a log section to settings serverless functions test tab

<img width="1303" height="827" alt="image" src="https://github.com/user-attachments/assets/2ce70558-91bc-4cfc-aced-42ac9e0226bf" />

- Adds a new subscription endpoint to graphql api `serverlessFunctionLogs` that that emit function logs

- Adds a new command `twenty app logs` to `twenty-sdk` to watch logs in terminal 

<img width="1109" height="182" alt="image" src="https://github.com/user-attachments/assets/2e874060-e99d-4978-ab9c-c91e52cb7478" />


<img width="1061" height="176" alt="image" src="https://github.com/user-attachments/assets/1f533e32-7435-4d7b-89c6-d1154816a8ab" />

- add new version for create-twenty-app and twenty-sdk `0.1.3`
