### PR TITLE
fix cache service mset

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/cache-storage/services/cache-storage.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/cache-storage/services/cache-storage.service.ts
@@ -67,20 +67,7 @@ export class CacheStorageService {
   async mset<T = unknown>(
     entries: Array<{ key: string; value: T; ttl?: Milliseconds }>,
   ): Promise<void> {
-    if (this.isRedisCache()) {
-      const pipeline = (this.cache as RedisCache).store.client.multi();
-
-      entries.forEach(({ key, value, ttl }) => {
-        const prefixedKey = this.getKey(key);
-
-        pipeline.set(prefixedKey, JSON.stringify(value));
-        if (ttl) {
-          pipeline.expire(prefixedKey, Math.floor(ttl / 1000));
-        }
-      });
-
-      await pipeline.exec();
-
+    if (entries.length === 0) {
       return;
     }
 


### PR DESCRIPTION
pipeline.exec() is a a blocking operation which means if we want to write a large chunk of data (or many maps in our case) it will block write operations and impact performances.
We prefer to simply call set multiple times in a promise.all, this is an acceptable tradeoff 