### PR TITLE
Fix dashboard seeds

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/dev-seeder/core/utils/seed-page-layout-widgets.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/dev-seeder/core/utils/seed-page-layout-widgets.util.ts
@@ -17,26 +17,30 @@ export const seedPageLayoutWidgets = async ({
   objectMetadataItems: ObjectMetadataEntity[];
   isDashboardV2Enabled: boolean;
 }) => {
-  const pageLayoutWidgets = getPageLayoutWidgetDataSeeds(
+  const widgetSeeds = getPageLayoutWidgetDataSeeds(
     workspaceId,
     objectMetadataItems,
     isDashboardV2Enabled,
-  ).map((widget) => {
-    const validatedConfiguration = widget.configuration
-      ? validateAndTransformWidgetConfiguration({
-          type: widget.type,
-          configuration: widget.configuration,
-          isDashboardV2Enabled,
-        })
-      : null;
+  );
 
-    return {
-      ...widget,
-      workspaceId,
-      gridPosition: widget.gridPosition,
-      configuration: validatedConfiguration,
-    };
-  });
+  const pageLayoutWidgets = await Promise.all(
+    widgetSeeds.map(async (widget) => {
+      const validatedConfiguration = widget.configuration
+        ? await validateAndTransformWidgetConfiguration({
+            type: widget.type,
+            configuration: widget.configuration,
+            isDashboardV2Enabled,
+          })
+        : null;
+
+      return {
+        ...widget,
+        workspaceId,
+        gridPosition: widget.gridPosition,
+        configuration: validatedConfiguration,
+      };
+    }),
+  );
 
   if (pageLayoutWidgets.length > 0) {
     await dataSource


### PR DESCRIPTION
Fixes a regression on seeding introduced by https://github.com/twentyhq/twenty/pull/16296.
In the seeding process an async function was used without awaiting. This caused all the seeded configs to be empty.

Note: The need to await is because `transformRichTextV2Value` is async due to `const { ServerBlockNoteEditor } = await import('@blocknote/server-util');`. @etiennejouan do you know why is it done this way? Is it to reduce bundle size? Would it be possible to create another util which is not async and which imports `@blocknote/server-util` at the top?