### PR TITLE
Remove object relation schema from step output

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/standard-objects-prefill-data/prefill-workflows.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/standard-objects-prefill-data/prefill-workflows.ts
@@ -229,7 +229,6 @@ export const prefillWorkflows = async (
                     flatObjectMetadataMaps,
                     flatFieldMetadataMaps,
                   },
-                  depth: 0,
                 }),
               },
               errorHandlingOptions: {
@@ -272,7 +271,6 @@ export const prefillWorkflows = async (
                     flatObjectMetadataMaps,
                     flatFieldMetadataMaps,
                   },
-                  depth: 0,
                 }),
               },
               errorHandlingOptions: {

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-schema/utils/__tests__/generate-fake-object-record.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-schema/utils/__tests__/generate-fake-object-record.spec.ts
@@ -42,8 +42,6 @@ describe('generateFakeObjectRecord', () => {
 
     expect(generateObjectRecordFields).toHaveBeenCalledWith({
       objectMetadataInfo: mockCompanyObjectMetadataInfo,
-      depth: 0,
-      maxDepth: 1,
     });
   });
 });

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-schema/utils/generate-fake-object-record-event.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-schema/utils/generate-fake-object-record-event.ts
@@ -14,7 +14,9 @@ const generateFakeObjectRecordEventWithPrefix = ({
   prefix: string;
 }): RecordOutputSchema => {
   const { flatObjectMetadata } = objectMetadataInfo;
-  const recordFields = generateObjectRecordFields({ objectMetadataInfo });
+  const recordFields = generateObjectRecordFields({
+    objectMetadataInfo,
+  });
   const prefixedRecordFields = Object.entries(recordFields).reduce(
     (acc, [key, value]) => {
       acc[`${prefix}.${key}`] = value;

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-schema/utils/generate-fake-object-record.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-schema/utils/generate-fake-object-record.ts
@@ -4,12 +4,8 @@ import { generateObjectRecordFields } from 'src/modules/workflow/workflow-builde
 
 export const generateFakeObjectRecord = ({
   objectMetadataInfo,
-  depth = 0,
-  maxDepth = 1,
 }: {
   objectMetadataInfo: ObjectMetadataInfo;
-  depth?: number;
-  maxDepth?: number;
 }): RecordOutputSchema => {
   const { flatObjectMetadata } = objectMetadataInfo;
 
@@ -24,8 +20,6 @@ export const generateFakeObjectRecord = ({
     },
     fields: generateObjectRecordFields({
       objectMetadataInfo,
-      depth,
-      maxDepth,
     }),
     _outputSchemaType: 'RECORD',
   };

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-schema/utils/generate-object-record-fields.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-schema/utils/generate-object-record-fields.ts
@@ -12,8 +12,6 @@ export const generateObjectRecordFields = ({
   objectMetadataInfo,
 }: {
   objectMetadataInfo: ObjectMetadataInfo;
-  depth?: number;
-  maxDepth?: number;
 }): Record<string, FieldOutputSchema> => {
   const { flatObjectMetadata, flatFieldMetadataMaps } = objectMetadataInfo;
 

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-schema/utils/generate-object-record-fields.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-schema/utils/generate-object-record-fields.ts
@@ -1,26 +1,21 @@
 import { FieldMetadataType } from 'twenty-shared/types';
-import { isDefined } from 'twenty-shared/utils';
 
 import { findFlatEntityByIdInFlatEntityMapsOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps-or-throw.util';
 import { isMorphOrRelationFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-morph-or-relation-flat-field-metadata.util';
 import { type ObjectMetadataInfo } from 'src/modules/workflow/common/workspace-services/workflow-common.workspace-service';
 import { type FieldOutputSchema } from 'src/modules/workflow/workflow-builder/workflow-schema/types/output-schema.type';
-import { generateFakeObjectRecord } from 'src/modules/workflow/workflow-builder/workflow-schema/utils/generate-fake-object-record';
 import { generateFakeRecordField } from 'src/modules/workflow/workflow-builder/workflow-schema/utils/generate-fake-record-field';
 import { shouldGenerateFieldFakeValue } from 'src/modules/workflow/workflow-builder/workflow-schema/utils/should-generate-field-fake-value';
 import { camelToTitleCase } from 'src/utils/camel-to-title-case';
 
 export const generateObjectRecordFields = ({
   objectMetadataInfo,
-  depth = 0,
-  maxDepth = 1,
 }: {
   objectMetadataInfo: ObjectMetadataInfo;
   depth?: number;
   maxDepth?: number;
 }): Record<string, FieldOutputSchema> => {
-  const { flatObjectMetadata, flatObjectMetadataMaps, flatFieldMetadataMaps } =
-    objectMetadataInfo;
+  const { flatObjectMetadata, flatFieldMetadataMaps } = objectMetadataInfo;
 
   const result: Record<string, FieldOutputSchema> = {};
 
@@ -34,47 +29,20 @@ export const generateObjectRecordFields = ({
       continue;
     }
 
-    if (!isMorphOrRelationFlatFieldMetadata(field)) {
-      result[field.name] = generateFakeRecordField({
-        type: field.type,
-        label: field.label,
-        icon: field.icon ?? undefined,
-        fieldMetadataId: field.id,
-      });
-
-      continue;
-    }
-
-    if (depth < maxDepth) {
-      const relationTargetObjectMetadata =
-        flatObjectMetadataMaps.byId[field.relationTargetObjectMetadataId];
-
-      if (!isDefined(relationTargetObjectMetadata)) {
-        continue;
-      }
-
-      result[field.name] = {
-        isLeaf: false,
-        icon: field.icon ?? undefined,
-        label: field.label,
-        type: field.type,
-        fieldMetadataId: field.id,
-        value: generateFakeObjectRecord({
-          objectMetadataInfo: {
-            flatObjectMetadata: relationTargetObjectMetadata,
-            flatObjectMetadataMaps,
-            flatFieldMetadataMaps,
-          },
-          depth: depth + 1,
-        }),
-      };
-    } else if (depth === maxDepth) {
+    if (isMorphOrRelationFlatFieldMetadata(field)) {
       const relationIdFieldName = `${field.name}Id`;
       const relationIdFieldLabel = camelToTitleCase(relationIdFieldName);
 
       result[relationIdFieldName] = generateFakeRecordField({
         type: FieldMetadataType.UUID,
         label: relationIdFieldLabel,
+        icon: field.icon ?? undefined,
+        fieldMetadataId: field.id,
+      });
+    } else {
+      result[field.name] = generateFakeRecordField({
+        type: field.type,
+        label: field.label,
         icon: field.icon ?? undefined,
         fieldMetadataId: field.id,
       });

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-schema/workflow-schema.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-schema/workflow-schema.workspace-service.ts
@@ -237,7 +237,6 @@ export class WorkflowSchemaWorkspaceService {
     const recordOutputSchema = await this.computeRecordOutputSchema({
       objectType,
       workspaceId,
-      maxDepth: 0,
     });
 
     const objectMetadataInfo =
@@ -276,11 +275,9 @@ export class WorkflowSchemaWorkspaceService {
   private async computeRecordOutputSchema({
     objectType,
     workspaceId,
-    maxDepth = 1,
   }: {
     objectType: string;
     workspaceId: string;
-    maxDepth?: number;
   }): Promise<OutputSchema> {
     const objectMetadataInfo =
       await this.workflowCommonWorkspaceService.getObjectMetadataInfo(
@@ -288,7 +285,7 @@ export class WorkflowSchemaWorkspaceService {
         workspaceId,
       );
 
-    return generateFakeObjectRecord({ objectMetadataInfo, maxDepth });
+    return generateFakeObjectRecord({ objectMetadataInfo });
   }
 
   private computeSendEmailActionOutputSchema(): OutputSchema {
@@ -335,7 +332,6 @@ export class WorkflowSchemaWorkspaceService {
       return this.computeRecordOutputSchema({
         objectType: availability.objectNameSingular,
         workspaceId,
-        maxDepth: 0,
       });
     }
 
@@ -434,7 +430,6 @@ export class WorkflowSchemaWorkspaceService {
               value: await this.computeRecordOutputSchema({
                 objectType: trigger.settings.availability.objectNameSingular,
                 workspaceId,
-                maxDepth: 0,
               }),
             };
           }


### PR DESCRIPTION
Fix https://github.com/twentyhq/core-team-issues/issues/1931

On trigger database event and step record crud, we still display the full object for relation in the variable picker (Account Owner in screenshot).
<img width="259" height="189" alt="Capture d’écran 2025-12-09 à 14 43 06" src="https://github.com/user-attachments/assets/1d7fdebf-9183-4197-929a-7b7d719c465a" />

But as we do not enrich the data anymore, those fields are actually empty. We should instead display AccountOwnerId and, if the user needs the full Account owner, a search can be used.
<img width="259" height="189" alt="Capture d’écran 2025-12-09 à 14 42 37" src="https://github.com/user-attachments/assets/87b46762-3204-4d25-9b6a-077d6b8567bd" />
