### PR TITLE
Fix formatData util logging

### DIFF
--- a/packages/twenty-server/src/engine/twenty-orm/utils/format-data.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/format-data.util.ts
@@ -48,9 +48,6 @@ export function formatData<T>(
     const fieldMetadata = flatFieldMetadataMaps.byId[fieldMetadataId];
 
     if (!fieldMetadata) {
-      this.logger.warn(
-        `Field metadata for field "${key}" is missing in object metadata ${flatObjectMetadata.nameSingular} for data: ${JSON.stringify(data)}`,
-      );
       throw new Error(
         `Field metadata for field "${key}" is missing in object metadata ${flatObjectMetadata.nameSingular}`,
       );


### PR DESCRIPTION
Log introduced in https://github.com/twentyhq/twenty/pull/16389
However this is a util hence cannot simply inject the logger service. I'm removing the log for now as adding loggerService as a parameter of a util might not be the right solution (yet)
```typescript
this.logger.warn(`Field metadata for field "${key}" is missing in object metadata ${flatObjectMetadata.nameSingular} for data: ${JSON.stringify(data)}`);
                 ^
TypeError: Cannot read properties of undefined (reading 'logger')
```