### PR TITLE
Prevent seeding empty configuration for dashboard widgets

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/dev-seeder/core/utils/get-page-layout-widget-data-seeds-v2.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/dev-seeder/core/utils/get-page-layout-widget-data-seeds-v2.util.ts
@@ -1,11 +1,11 @@
 import { CalendarStartDay } from 'twenty-shared/constants';
-import { isDefined } from 'twenty-shared/utils';
 import { STANDARD_OBJECT_IDS } from 'twenty-shared/metadata';
+import { isDefined } from 'twenty-shared/utils';
 
 import { AggregateOperations } from 'src/engine/api/graphql/graphql-query-runner/constants/aggregate-operations.constant';
+import { type ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 import { AxisNameDisplay } from 'src/engine/metadata-modules/page-layout/enums/axis-name-display.enum';
 import { WidgetType } from 'src/engine/metadata-modules/page-layout/enums/widget-type.enum';
-import { type ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 import { PAGE_LAYOUT_TAB_SEEDS } from 'src/engine/workspace-manager/dev-seeder/core/constants/page-layout-tab-seeds.constant';
 import { PAGE_LAYOUT_WIDGET_SEEDS } from 'src/engine/workspace-manager/dev-seeder/core/constants/page-layout-widget-seeds.constant';
 import { generateSeedId } from 'src/engine/workspace-manager/dev-seeder/core/utils/generate-seed-id.util';
@@ -63,177 +63,172 @@ export const getPageLayoutWidgetDataSeedsV2 = (
 
   return [
     // LINE chart: Revenue Forecast (Sales Overview)
-    {
-      id: generateSeedId(
-        workspaceId,
-        PAGE_LAYOUT_WIDGET_SEEDS.SALES_REVENUE_FORECAST,
-      ),
-      pageLayoutTabId: generateSeedId(
-        workspaceId,
-        PAGE_LAYOUT_TAB_SEEDS.SALES_OVERVIEW,
-      ),
-      title: 'Revenue Forecast',
-      type: WidgetType.GRAPH,
-      gridPosition: { row: 0, column: 7, rowSpan: 8, columnSpan: 5 },
-      configuration:
-        isDefined(opportunityAmountFieldId) &&
-        isDefined(opportunityCloseDateFieldId)
-          ? {
-              graphType: 'LINE',
-              aggregateFieldMetadataId: opportunityAmountFieldId,
-              aggregateOperation: AggregateOperations.SUM,
-              primaryAxisGroupByFieldMetadataId: opportunityCloseDateFieldId,
-              primaryAxisOrderBy: 'FIELD_ASC',
-              axisNameDisplay: AxisNameDisplay.NONE,
-              displayDataLabel: false,
-              timezone: 'UTC',
-              firstDayOfTheWeek: CalendarStartDay.MONDAY,
-            }
-          : null,
-      objectMetadataId: opportunityObject?.id ?? null,
-    },
+    isDefined(opportunityAmountFieldId) &&
+    isDefined(opportunityCloseDateFieldId)
+      ? {
+          id: generateSeedId(
+            workspaceId,
+            PAGE_LAYOUT_WIDGET_SEEDS.SALES_REVENUE_FORECAST,
+          ),
+          pageLayoutTabId: generateSeedId(
+            workspaceId,
+            PAGE_LAYOUT_TAB_SEEDS.SALES_OVERVIEW,
+          ),
+          title: 'Revenue Forecast',
+          type: WidgetType.GRAPH,
+          gridPosition: { row: 0, column: 7, rowSpan: 8, columnSpan: 5 },
+          configuration: {
+            graphType: 'LINE',
+            aggregateFieldMetadataId: opportunityAmountFieldId,
+            aggregateOperation: AggregateOperations.SUM,
+            primaryAxisGroupByFieldMetadataId: opportunityCloseDateFieldId,
+            primaryAxisOrderBy: 'FIELD_ASC',
+            axisNameDisplay: AxisNameDisplay.NONE,
+            displayDataLabel: false,
+            timezone: 'UTC',
+            firstDayOfTheWeek: CalendarStartDay.MONDAY,
+          },
+          objectMetadataId: opportunityObject?.id ?? null,
+        }
+      : null,
 
     // LINE chart: New Customers Over Time (Customer Overview)
-    {
-      id: generateSeedId(
-        workspaceId,
-        PAGE_LAYOUT_WIDGET_SEEDS.CUSTOMER_NEW_OVER_TIME,
-      ),
-      pageLayoutTabId: generateSeedId(
-        workspaceId,
-        PAGE_LAYOUT_TAB_SEEDS.CUSTOMER_OVERVIEW,
-      ),
-      title: 'New Customers Over Time',
-      type: WidgetType.GRAPH,
-      gridPosition: { row: 0, column: 3, rowSpan: 6, columnSpan: 5 },
-      configuration:
-        isDefined(companyIdFieldId) && isDefined(companyCreatedAtFieldId)
-          ? {
-              graphType: 'LINE',
-              aggregateFieldMetadataId: companyIdFieldId,
-              aggregateOperation: AggregateOperations.COUNT,
-              primaryAxisGroupByFieldMetadataId: companyCreatedAtFieldId,
-              primaryAxisOrderBy: 'FIELD_ASC',
-              axisNameDisplay: AxisNameDisplay.NONE,
-              displayDataLabel: false,
-              timezone: 'UTC',
-              firstDayOfTheWeek: CalendarStartDay.MONDAY,
-            }
-          : null,
-      objectMetadataId: companyObject?.id ?? null,
-    },
+    isDefined(companyIdFieldId) && isDefined(companyCreatedAtFieldId)
+      ? {
+          id: generateSeedId(
+            workspaceId,
+            PAGE_LAYOUT_WIDGET_SEEDS.CUSTOMER_NEW_OVER_TIME,
+          ),
+          pageLayoutTabId: generateSeedId(
+            workspaceId,
+            PAGE_LAYOUT_TAB_SEEDS.CUSTOMER_OVERVIEW,
+          ),
+          title: 'New Customers Over Time',
+          type: WidgetType.GRAPH,
+          gridPosition: { row: 0, column: 3, rowSpan: 6, columnSpan: 5 },
+          configuration: {
+            graphType: 'LINE',
+            aggregateFieldMetadataId: companyIdFieldId,
+            aggregateOperation: AggregateOperations.COUNT,
+            primaryAxisGroupByFieldMetadataId: companyCreatedAtFieldId,
+            primaryAxisOrderBy: 'FIELD_ASC',
+            axisNameDisplay: AxisNameDisplay.NONE,
+            displayDataLabel: false,
+            timezone: 'UTC',
+            firstDayOfTheWeek: CalendarStartDay.MONDAY,
+          },
+          objectMetadataId: companyObject?.id ?? null,
+        }
+      : null,
 
     // PIE chart: Revenue Distribution (Customer Analytics)
-    {
-      id: generateSeedId(
-        workspaceId,
-        PAGE_LAYOUT_WIDGET_SEEDS.CUSTOMER_REVENUE_DISTRIBUTION,
-      ),
-      pageLayoutTabId: generateSeedId(
-        workspaceId,
-        PAGE_LAYOUT_TAB_SEEDS.CUSTOMER_ANALYTICS,
-      ),
-      title: 'Revenue Distribution',
-      type: WidgetType.GRAPH,
-      gridPosition: { row: 0, column: 4, rowSpan: 2, columnSpan: 3 },
-      configuration:
-        isDefined(companyArrFieldId) && isDefined(companyNameFieldId)
-          ? {
-              graphType: 'PIE',
-              aggregateFieldMetadataId: companyArrFieldId,
-              aggregateOperation: AggregateOperations.SUM,
-              groupByFieldMetadataId: companyNameFieldId,
-              orderBy: 'VALUE_DESC',
-              displayDataLabel: true,
-              timezone: 'UTC',
-              firstDayOfTheWeek: CalendarStartDay.MONDAY,
-            }
-          : null,
-      objectMetadataId: companyObject?.id ?? null,
-    },
+    isDefined(companyArrFieldId) && isDefined(companyNameFieldId)
+      ? {
+          id: generateSeedId(
+            workspaceId,
+            PAGE_LAYOUT_WIDGET_SEEDS.CUSTOMER_REVENUE_DISTRIBUTION,
+          ),
+          pageLayoutTabId: generateSeedId(
+            workspaceId,
+            PAGE_LAYOUT_TAB_SEEDS.CUSTOMER_ANALYTICS,
+          ),
+          title: 'Revenue Distribution',
+          type: WidgetType.GRAPH,
+          gridPosition: { row: 0, column: 4, rowSpan: 2, columnSpan: 3 },
+          configuration: {
+            graphType: 'PIE',
+            aggregateFieldMetadataId: companyArrFieldId,
+            aggregateOperation: AggregateOperations.SUM,
+            groupByFieldMetadataId: companyNameFieldId,
+            orderBy: 'VALUE_DESC',
+            displayDataLabel: true,
+            timezone: 'UTC',
+            firstDayOfTheWeek: CalendarStartDay.MONDAY,
+          },
+          objectMetadataId: companyObject?.id ?? null,
+        }
+      : null,
 
     // GAUGE chart: Average ARR (Customer Analytics)
-    {
-      id: generateSeedId(
-        workspaceId,
-        PAGE_LAYOUT_WIDGET_SEEDS.CUSTOMER_AVERAGE_ARR,
-      ),
-      pageLayoutTabId: generateSeedId(
-        workspaceId,
-        PAGE_LAYOUT_TAB_SEEDS.CUSTOMER_ANALYTICS,
-      ),
-      title: 'Average ARR',
-      type: WidgetType.GRAPH,
-      gridPosition: { row: 0, column: 7, rowSpan: 6, columnSpan: 5 },
-      configuration: isDefined(companyArrFieldId)
-        ? {
+    isDefined(companyArrFieldId)
+      ? {
+          id: generateSeedId(
+            workspaceId,
+            PAGE_LAYOUT_WIDGET_SEEDS.CUSTOMER_AVERAGE_ARR,
+          ),
+          pageLayoutTabId: generateSeedId(
+            workspaceId,
+            PAGE_LAYOUT_TAB_SEEDS.CUSTOMER_ANALYTICS,
+          ),
+          title: 'Average ARR',
+          type: WidgetType.GRAPH,
+          gridPosition: { row: 0, column: 7, rowSpan: 6, columnSpan: 5 },
+          configuration: {
             graphType: 'GAUGE',
             aggregateFieldMetadataId: companyArrFieldId,
             aggregateOperation: AggregateOperations.AVG,
             displayDataLabel: true,
             timezone: 'UTC',
             firstDayOfTheWeek: CalendarStartDay.MONDAY,
-          }
-        : null,
-      objectMetadataId: companyObject?.id ?? null,
-    },
+          },
+          objectMetadataId: companyObject?.id ?? null,
+        }
+      : null,
 
     // PIE chart: Companies by LinkedIn (Customer Overview)
-    {
-      id: generateSeedId(
-        workspaceId,
-        PAGE_LAYOUT_WIDGET_SEEDS.CUSTOMER_LINKEDIN_DISTRIBUTION,
-      ),
-      pageLayoutTabId: generateSeedId(
-        workspaceId,
-        PAGE_LAYOUT_TAB_SEEDS.CUSTOMER_OVERVIEW,
-      ),
-      title: 'Companies by LinkedIn (Field Permission Test)',
-      type: WidgetType.GRAPH,
-      gridPosition: { row: 6, column: 0, rowSpan: 4, columnSpan: 6 },
-      configuration:
-        isDefined(companyIdFieldId) && isDefined(companyLinkedinLinkFieldId)
-          ? {
-              graphType: 'PIE',
-              aggregateFieldMetadataId: companyIdFieldId,
-              aggregateOperation: AggregateOperations.COUNT,
-              groupByFieldMetadataId: companyLinkedinLinkFieldId,
-              orderBy: 'VALUE_DESC',
-              displayDataLabel: true,
-              timezone: 'UTC',
-              firstDayOfTheWeek: CalendarStartDay.MONDAY,
-            }
-          : null,
-      objectMetadataId: companyObject?.id ?? null,
-    },
+    isDefined(companyIdFieldId) && isDefined(companyLinkedinLinkFieldId)
+      ? {
+          id: generateSeedId(
+            workspaceId,
+            PAGE_LAYOUT_WIDGET_SEEDS.CUSTOMER_LINKEDIN_DISTRIBUTION,
+          ),
+          pageLayoutTabId: generateSeedId(
+            workspaceId,
+            PAGE_LAYOUT_TAB_SEEDS.CUSTOMER_OVERVIEW,
+          ),
+          title: 'Companies by LinkedIn (Field Permission Test)',
+          type: WidgetType.GRAPH,
+          gridPosition: { row: 6, column: 0, rowSpan: 4, columnSpan: 6 },
+          configuration: {
+            graphType: 'PIE',
+            aggregateFieldMetadataId: companyIdFieldId,
+            aggregateOperation: AggregateOperations.COUNT,
+            groupByFieldMetadataId: companyLinkedinLinkFieldId,
+            orderBy: 'VALUE_DESC',
+            displayDataLabel: true,
+            timezone: 'UTC',
+            firstDayOfTheWeek: CalendarStartDay.MONDAY,
+          },
+          objectMetadataId: companyObject?.id ?? null,
+        }
+      : null,
 
     // PIE chart: Contact Roles (Team Metrics)
-    {
-      id: generateSeedId(
-        workspaceId,
-        PAGE_LAYOUT_WIDGET_SEEDS.TEAM_CONTACT_ROLES,
-      ),
-      pageLayoutTabId: generateSeedId(
-        workspaceId,
-        PAGE_LAYOUT_TAB_SEEDS.TEAM_METRICS,
-      ),
-      title: 'Contact Roles',
-      type: WidgetType.GRAPH,
-      gridPosition: { row: 0, column: 0, rowSpan: 4, columnSpan: 6 },
-      configuration:
-        isDefined(personIdFieldId) && isDefined(personJobTitleFieldId)
-          ? {
-              graphType: 'PIE',
-              aggregateFieldMetadataId: personIdFieldId,
-              aggregateOperation: AggregateOperations.COUNT,
-              groupByFieldMetadataId: personJobTitleFieldId,
-              orderBy: 'VALUE_DESC',
-              displayDataLabel: true,
-              timezone: 'UTC',
-              firstDayOfTheWeek: CalendarStartDay.MONDAY,
-            }
-          : null,
-      objectMetadataId: personObject?.id ?? null,
-    },
-  ];
+    isDefined(personIdFieldId) && isDefined(personJobTitleFieldId)
+      ? {
+          id: generateSeedId(
+            workspaceId,
+            PAGE_LAYOUT_WIDGET_SEEDS.TEAM_CONTACT_ROLES,
+          ),
+          pageLayoutTabId: generateSeedId(
+            workspaceId,
+            PAGE_LAYOUT_TAB_SEEDS.TEAM_METRICS,
+          ),
+          title: 'Contact Roles',
+          type: WidgetType.GRAPH,
+          gridPosition: { row: 0, column: 0, rowSpan: 4, columnSpan: 6 },
+          configuration: {
+            graphType: 'PIE',
+            aggregateFieldMetadataId: personIdFieldId,
+            aggregateOperation: AggregateOperations.COUNT,
+            groupByFieldMetadataId: personJobTitleFieldId,
+            orderBy: 'VALUE_DESC',
+            displayDataLabel: true,
+            timezone: 'UTC',
+            firstDayOfTheWeek: CalendarStartDay.MONDAY,
+          },
+          objectMetadataId: personObject?.id ?? null,
+        }
+      : null,
+  ].filter(isDefined);
 };

--- a/packages/twenty-server/src/engine/workspace-manager/dev-seeder/core/utils/get-page-layout-widget-data-seeds.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/dev-seeder/core/utils/get-page-layout-widget-data-seeds.util.ts
@@ -1,12 +1,12 @@
 import { CalendarStartDay } from 'twenty-shared/constants';
-import { isDefined } from 'twenty-shared/utils';
 import { STANDARD_OBJECT_IDS } from 'twenty-shared/metadata';
+import { isDefined } from 'twenty-shared/utils';
 
 import { AggregateOperations } from 'src/engine/api/graphql/graphql-query-runner/constants/aggregate-operations.constant';
+import { type ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 import { AxisNameDisplay } from 'src/engine/metadata-modules/page-layout/enums/axis-name-display.enum';
 import { GraphType } from 'src/engine/metadata-modules/page-layout/enums/graph-type.enum';
 import { WidgetType } from 'src/engine/metadata-modules/page-layout/enums/widget-type.enum';
-import { type ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 import { PAGE_LAYOUT_TAB_SEEDS } from 'src/engine/workspace-manager/dev-seeder/core/constants/page-layout-tab-seeds.constant';
 import { PAGE_LAYOUT_WIDGET_SEEDS } from 'src/engine/workspace-manager/dev-seeder/core/constants/page-layout-widget-seeds.constant';
 import { generateSeedId } from 'src/engine/workspace-manager/dev-seeder/core/utils/generate-seed-id.util';
@@ -80,332 +80,330 @@ export const getPageLayoutWidgetDataSeeds = (
 
   const v1Widgets = [
     // Sales Overview Tab Widgets
-    {
-      id: generateSeedId(
-        workspaceId,
-        PAGE_LAYOUT_WIDGET_SEEDS.SALES_PIPELINE_VALUE,
-      ),
-      pageLayoutTabId: generateSeedId(
-        workspaceId,
-        PAGE_LAYOUT_TAB_SEEDS.SALES_OVERVIEW,
-      ),
-      title: 'Total Pipeline Value',
-      type: WidgetType.GRAPH,
-      gridPosition: { row: 0, column: 0, rowSpan: 2, columnSpan: 3 },
-      configuration: isDefined(opportunityAmountFieldId)
-        ? {
+    isDefined(opportunityAmountFieldId)
+      ? {
+          id: generateSeedId(
+            workspaceId,
+            PAGE_LAYOUT_WIDGET_SEEDS.SALES_PIPELINE_VALUE,
+          ),
+          pageLayoutTabId: generateSeedId(
+            workspaceId,
+            PAGE_LAYOUT_TAB_SEEDS.SALES_OVERVIEW,
+          ),
+          title: 'Total Pipeline Value',
+          type: WidgetType.GRAPH,
+          gridPosition: { row: 0, column: 0, rowSpan: 2, columnSpan: 3 },
+          configuration: {
             graphType: 'AGGREGATE',
             aggregateFieldMetadataId: opportunityAmountFieldId,
             aggregateOperation: AggregateOperations.SUM,
             displayDataLabel: true,
             timezone: 'UTC',
             firstDayOfTheWeek: CalendarStartDay.MONDAY,
-          }
-        : null,
-      objectMetadataId: opportunityObject?.id ?? null,
-    },
-    {
-      id: generateSeedId(
-        workspaceId,
-        PAGE_LAYOUT_WIDGET_SEEDS.SALES_AVERAGE_DEAL_SIZE,
-      ),
-      pageLayoutTabId: generateSeedId(
-        workspaceId,
-        PAGE_LAYOUT_TAB_SEEDS.SALES_OVERVIEW,
-      ),
-      title: 'Rocket Count (Object Permission Test)',
-      type: WidgetType.GRAPH,
-      gridPosition: { row: 0, column: 3, rowSpan: 4, columnSpan: 4 },
-      configuration: isDefined(rocketIdFieldId)
-        ? {
+          },
+          objectMetadataId: opportunityObject?.id ?? null,
+        }
+      : null,
+    isDefined(rocketIdFieldId)
+      ? {
+          id: generateSeedId(
+            workspaceId,
+            PAGE_LAYOUT_WIDGET_SEEDS.SALES_AVERAGE_DEAL_SIZE,
+          ),
+          pageLayoutTabId: generateSeedId(
+            workspaceId,
+            PAGE_LAYOUT_TAB_SEEDS.SALES_OVERVIEW,
+          ),
+          title: 'Rocket Count (Object Permission Test)',
+          type: WidgetType.GRAPH,
+          gridPosition: { row: 0, column: 3, rowSpan: 4, columnSpan: 4 },
+          configuration: {
             graphType: 'AGGREGATE',
             aggregateFieldMetadataId: rocketIdFieldId,
             aggregateOperation: AggregateOperations.COUNT,
             displayDataLabel: true,
             timezone: 'UTC',
             firstDayOfTheWeek: CalendarStartDay.MONDAY,
-          }
-        : null,
-      objectMetadataId: rocketObject?.id ?? null,
-    },
-    {
-      id: generateSeedId(
-        workspaceId,
-        PAGE_LAYOUT_WIDGET_SEEDS.SALES_DEALS_BY_STAGE,
-      ),
-      pageLayoutTabId: generateSeedId(
-        workspaceId,
-        PAGE_LAYOUT_TAB_SEEDS.SALES_OVERVIEW,
-      ),
-      title: 'Pipeline Value by Close Date (Stacked by Stage)',
-      type: WidgetType.GRAPH,
-      gridPosition: { row: 4, column: 0, rowSpan: 8, columnSpan: 6 },
-      configuration:
-        isDefined(opportunityAmountFieldId) &&
-        isDefined(opportunityCloseDateFieldId) &&
-        isDefined(opportunityStageFieldId)
-          ? {
-              graphType: GraphType.VERTICAL_BAR,
-              aggregateFieldMetadataId: opportunityAmountFieldId,
-              aggregateOperation: AggregateOperations.SUM,
-              primaryAxisGroupByFieldMetadataId: opportunityCloseDateFieldId,
-              secondaryAxisGroupByFieldMetadataId: opportunityStageFieldId,
-              primaryAxisOrderBy: 'FIELD_ASC',
-              axisNameDisplay: AxisNameDisplay.NONE,
-              displayDataLabel: false,
-              color: 'auto',
-              timezone: 'UTC',
-              firstDayOfTheWeek: CalendarStartDay.MONDAY,
-            }
-          : null,
-      objectMetadataId: opportunityObject?.id ?? null,
-    },
+          },
+          objectMetadataId: rocketObject?.id ?? null,
+        }
+      : null,
+    isDefined(opportunityAmountFieldId) &&
+    isDefined(opportunityCloseDateFieldId) &&
+    isDefined(opportunityStageFieldId)
+      ? {
+          id: generateSeedId(
+            workspaceId,
+            PAGE_LAYOUT_WIDGET_SEEDS.SALES_DEALS_BY_STAGE,
+          ),
+          pageLayoutTabId: generateSeedId(
+            workspaceId,
+            PAGE_LAYOUT_TAB_SEEDS.SALES_OVERVIEW,
+          ),
+          title: 'Pipeline Value by Close Date (Stacked by Stage)',
+          type: WidgetType.GRAPH,
+          gridPosition: { row: 4, column: 0, rowSpan: 8, columnSpan: 6 },
+          configuration: {
+            graphType: GraphType.VERTICAL_BAR,
+            aggregateFieldMetadataId: opportunityAmountFieldId,
+            aggregateOperation: AggregateOperations.SUM,
+            primaryAxisGroupByFieldMetadataId: opportunityCloseDateFieldId,
+            secondaryAxisGroupByFieldMetadataId: opportunityStageFieldId,
+            primaryAxisOrderBy: 'FIELD_ASC',
+            axisNameDisplay: AxisNameDisplay.NONE,
+            displayDataLabel: false,
+            color: 'auto',
+            timezone: 'UTC',
+            firstDayOfTheWeek: CalendarStartDay.MONDAY,
+          },
+          objectMetadataId: opportunityObject?.id ?? null,
+        }
+      : null,
 
     // Sales Details Tab Widgets
-    {
-      id: generateSeedId(
-        workspaceId,
-        PAGE_LAYOUT_WIDGET_SEEDS.SALES_DEAL_DISTRIBUTION,
-      ),
-      pageLayoutTabId: generateSeedId(
-        workspaceId,
-        PAGE_LAYOUT_TAB_SEEDS.SALES_DETAILS,
-      ),
-      title: 'Rockets by Created Date (Object Permission Test)',
-      type: WidgetType.GRAPH,
-      gridPosition: { row: 0, column: 0, rowSpan: 5, columnSpan: 5 },
-      configuration:
-        isDefined(rocketIdFieldId) && isDefined(rocketCreatedAtFieldId)
-          ? {
-              graphType: GraphType.VERTICAL_BAR,
-              aggregateFieldMetadataId: rocketIdFieldId,
-              aggregateOperation: AggregateOperations.COUNT,
-              primaryAxisGroupByFieldMetadataId: rocketCreatedAtFieldId,
-              primaryAxisOrderBy: 'FIELD_ASC',
-              axisNameDisplay: AxisNameDisplay.NONE,
-              displayDataLabel: false,
-              color: 'auto',
-              timezone: 'UTC',
-              firstDayOfTheWeek: CalendarStartDay.MONDAY,
-            }
-          : null,
-      objectMetadataId: rocketObject?.id ?? null,
-    },
-    {
-      id: generateSeedId(
-        workspaceId,
-        PAGE_LAYOUT_WIDGET_SEEDS.SALES_OPPORTUNITY_COUNT,
-      ),
-      pageLayoutTabId: generateSeedId(
-        workspaceId,
-        PAGE_LAYOUT_TAB_SEEDS.SALES_DETAILS,
-      ),
-      title: 'Opportunity Count',
-      type: WidgetType.GRAPH,
-      gridPosition: { row: 0, column: 5, rowSpan: 5, columnSpan: 7 },
-      configuration: isDefined(opportunityIdFieldId)
-        ? {
+    isDefined(rocketIdFieldId) && isDefined(rocketCreatedAtFieldId)
+      ? {
+          id: generateSeedId(
+            workspaceId,
+            PAGE_LAYOUT_WIDGET_SEEDS.SALES_DEAL_DISTRIBUTION,
+          ),
+          pageLayoutTabId: generateSeedId(
+            workspaceId,
+            PAGE_LAYOUT_TAB_SEEDS.SALES_DETAILS,
+          ),
+          title: 'Rockets by Created Date (Object Permission Test)',
+          type: WidgetType.GRAPH,
+          gridPosition: { row: 0, column: 0, rowSpan: 5, columnSpan: 5 },
+          configuration: {
+            graphType: GraphType.VERTICAL_BAR,
+            aggregateFieldMetadataId: rocketIdFieldId,
+            aggregateOperation: AggregateOperations.COUNT,
+            primaryAxisGroupByFieldMetadataId: rocketCreatedAtFieldId,
+            primaryAxisOrderBy: 'FIELD_ASC',
+            axisNameDisplay: AxisNameDisplay.NONE,
+            displayDataLabel: false,
+            color: 'auto',
+            timezone: 'UTC',
+            firstDayOfTheWeek: CalendarStartDay.MONDAY,
+          },
+          objectMetadataId: rocketObject?.id ?? null,
+        }
+      : null,
+    isDefined(opportunityIdFieldId)
+      ? {
+          id: generateSeedId(
+            workspaceId,
+            PAGE_LAYOUT_WIDGET_SEEDS.SALES_OPPORTUNITY_COUNT,
+          ),
+          pageLayoutTabId: generateSeedId(
+            workspaceId,
+            PAGE_LAYOUT_TAB_SEEDS.SALES_DETAILS,
+          ),
+          title: 'Opportunity Count',
+          type: WidgetType.GRAPH,
+          gridPosition: { row: 0, column: 5, rowSpan: 5, columnSpan: 7 },
+          configuration: {
             graphType: 'AGGREGATE',
             aggregateFieldMetadataId: opportunityIdFieldId,
             aggregateOperation: AggregateOperations.COUNT,
             displayDataLabel: true,
             timezone: 'UTC',
             firstDayOfTheWeek: CalendarStartDay.MONDAY,
-          }
-        : null,
-      objectMetadataId: opportunityObject?.id ?? null,
-    },
+          },
+          objectMetadataId: opportunityObject?.id ?? null,
+        }
+      : null,
 
     // Customer Overview Tab Widgets
-    {
-      id: generateSeedId(
-        workspaceId,
-        PAGE_LAYOUT_WIDGET_SEEDS.CUSTOMER_TOTAL_COUNT,
-      ),
-      pageLayoutTabId: generateSeedId(
-        workspaceId,
-        PAGE_LAYOUT_TAB_SEEDS.CUSTOMER_OVERVIEW,
-      ),
-      title: 'Total Customers',
-      type: WidgetType.GRAPH,
-      gridPosition: { row: 0, column: 0, rowSpan: 2, columnSpan: 3 },
-      configuration: isDefined(companyIdFieldId)
-        ? {
+    isDefined(companyIdFieldId)
+      ? {
+          id: generateSeedId(
+            workspaceId,
+            PAGE_LAYOUT_WIDGET_SEEDS.CUSTOMER_TOTAL_COUNT,
+          ),
+          pageLayoutTabId: generateSeedId(
+            workspaceId,
+            PAGE_LAYOUT_TAB_SEEDS.CUSTOMER_OVERVIEW,
+          ),
+          title: 'Total Customers',
+          type: WidgetType.GRAPH,
+          gridPosition: { row: 0, column: 0, rowSpan: 2, columnSpan: 3 },
+          configuration: {
             graphType: 'AGGREGATE',
             aggregateFieldMetadataId: companyIdFieldId,
             aggregateOperation: AggregateOperations.COUNT,
             displayDataLabel: true,
             timezone: 'UTC',
             firstDayOfTheWeek: CalendarStartDay.MONDAY,
-          }
-        : null,
-      objectMetadataId: companyObject?.id ?? null,
-    },
-    {
-      id: generateSeedId(
-        workspaceId,
-        PAGE_LAYOUT_WIDGET_SEEDS.CUSTOMER_COMPANIES_BY_SIZE,
-      ),
-      pageLayoutTabId: generateSeedId(
-        workspaceId,
-        PAGE_LAYOUT_TAB_SEEDS.CUSTOMER_OVERVIEW,
-      ),
-      title: 'Companies by Size (Stacked by City)',
-      type: WidgetType.GRAPH,
-      gridPosition: { row: 0, column: 8, rowSpan: 10, columnSpan: 8 },
-      configuration:
-        isDefined(companyIdFieldId) &&
-        isDefined(companyEmployeesFieldId) &&
-        isDefined(companyAddressFieldId)
-          ? {
-              graphType: GraphType.VERTICAL_BAR,
-              aggregateFieldMetadataId: companyIdFieldId,
-              aggregateOperation: AggregateOperations.COUNT,
-              primaryAxisGroupByFieldMetadataId: companyEmployeesFieldId,
-              secondaryAxisGroupByFieldMetadataId: companyAddressFieldId,
-              secondaryAxisGroupBySubFieldName: 'addressCity',
-              secondaryAxisGroupByDateGranularity: 'DAY',
-              primaryAxisOrderBy: 'FIELD_ASC',
-              axisNameDisplay: AxisNameDisplay.NONE,
-              displayDataLabel: false,
-              color: 'auto',
-              timezone: 'UTC',
-              firstDayOfTheWeek: CalendarStartDay.MONDAY,
-            }
-          : null,
-      objectMetadataId: companyObject?.id ?? null,
-    },
+          },
+          objectMetadataId: companyObject?.id ?? null,
+        }
+      : null,
+    isDefined(companyIdFieldId) &&
+    isDefined(companyEmployeesFieldId) &&
+    isDefined(companyAddressFieldId)
+      ? {
+          id: generateSeedId(
+            workspaceId,
+            PAGE_LAYOUT_WIDGET_SEEDS.CUSTOMER_COMPANIES_BY_SIZE,
+          ),
+          pageLayoutTabId: generateSeedId(
+            workspaceId,
+            PAGE_LAYOUT_TAB_SEEDS.CUSTOMER_OVERVIEW,
+          ),
+          title: 'Companies by Size (Stacked by City)',
+          type: WidgetType.GRAPH,
+          gridPosition: { row: 0, column: 8, rowSpan: 10, columnSpan: 8 },
+          configuration: {
+            graphType: GraphType.VERTICAL_BAR,
+            aggregateFieldMetadataId: companyIdFieldId,
+            aggregateOperation: AggregateOperations.COUNT,
+            primaryAxisGroupByFieldMetadataId: companyEmployeesFieldId,
+            secondaryAxisGroupByFieldMetadataId: companyAddressFieldId,
+            secondaryAxisGroupBySubFieldName: 'addressCity',
+            secondaryAxisGroupByDateGranularity: 'DAY',
+            primaryAxisOrderBy: 'FIELD_ASC',
+            axisNameDisplay: AxisNameDisplay.NONE,
+            displayDataLabel: false,
+            color: 'auto',
+            timezone: 'UTC',
+            firstDayOfTheWeek: CalendarStartDay.MONDAY,
+          },
+          objectMetadataId: companyObject?.id ?? null,
+        }
+      : null,
 
     // Customer Analytics Tab Widgets
-    {
-      id: generateSeedId(
-        workspaceId,
-        PAGE_LAYOUT_WIDGET_SEEDS.CUSTOMER_ANNUAL_RECURRING_REVENUE,
-      ),
-      pageLayoutTabId: generateSeedId(
-        workspaceId,
-        PAGE_LAYOUT_TAB_SEEDS.CUSTOMER_ANALYTICS,
-      ),
-      title: 'Annual Recurring Revenue',
-      type: WidgetType.GRAPH,
-      gridPosition: { row: 0, column: 0, rowSpan: 4, columnSpan: 4 },
-      configuration: isDefined(companyArrFieldId)
-        ? {
+    isDefined(companyArrFieldId)
+      ? {
+          id: generateSeedId(
+            workspaceId,
+            PAGE_LAYOUT_WIDGET_SEEDS.CUSTOMER_ANNUAL_RECURRING_REVENUE,
+          ),
+          pageLayoutTabId: generateSeedId(
+            workspaceId,
+            PAGE_LAYOUT_TAB_SEEDS.CUSTOMER_ANALYTICS,
+          ),
+          title: 'Annual Recurring Revenue',
+          type: WidgetType.GRAPH,
+          gridPosition: { row: 0, column: 0, rowSpan: 4, columnSpan: 4 },
+          configuration: {
             graphType: 'AGGREGATE',
             aggregateFieldMetadataId: companyArrFieldId,
             aggregateOperation: AggregateOperations.SUM,
             displayDataLabel: true,
             timezone: 'UTC',
             firstDayOfTheWeek: CalendarStartDay.MONDAY,
-          }
-        : null,
-      objectMetadataId: companyObject?.id ?? null,
-    },
-    {
-      id: generateSeedId(
-        workspaceId,
-        PAGE_LAYOUT_WIDGET_SEEDS.CUSTOMER_LINKEDIN_COUNT,
-      ),
-      pageLayoutTabId: generateSeedId(
-        workspaceId,
-        PAGE_LAYOUT_TAB_SEEDS.CUSTOMER_OVERVIEW,
-      ),
-      title: 'LinkedIn Profiles Count (Field Permission Test)',
-      type: WidgetType.GRAPH,
-      gridPosition: { row: 2, column: 0, rowSpan: 4, columnSpan: 3 },
-      configuration: isDefined(companyLinkedinLinkFieldId)
-        ? {
+          },
+          objectMetadataId: companyObject?.id ?? null,
+        }
+      : null,
+    isDefined(companyLinkedinLinkFieldId)
+      ? {
+          id: generateSeedId(
+            workspaceId,
+            PAGE_LAYOUT_WIDGET_SEEDS.CUSTOMER_LINKEDIN_COUNT,
+          ),
+          pageLayoutTabId: generateSeedId(
+            workspaceId,
+            PAGE_LAYOUT_TAB_SEEDS.CUSTOMER_OVERVIEW,
+          ),
+          title: 'LinkedIn Profiles Count (Field Permission Test)',
+          type: WidgetType.GRAPH,
+          gridPosition: { row: 2, column: 0, rowSpan: 4, columnSpan: 3 },
+          configuration: {
             graphType: 'AGGREGATE',
             aggregateFieldMetadataId: companyLinkedinLinkFieldId,
             aggregateOperation: AggregateOperations.COUNT,
             displayDataLabel: true,
             timezone: 'UTC',
             firstDayOfTheWeek: CalendarStartDay.MONDAY,
-          }
-        : null,
-      objectMetadataId: companyObject?.id ?? null,
-    },
+          },
+          objectMetadataId: companyObject?.id ?? null,
+        }
+      : null,
 
     // Team Overview Tab Widgets
-    {
-      id: generateSeedId(workspaceId, PAGE_LAYOUT_WIDGET_SEEDS.TEAM_SIZE),
-      pageLayoutTabId: generateSeedId(
-        workspaceId,
-        PAGE_LAYOUT_TAB_SEEDS.TEAM_OVERVIEW,
-      ),
-      title: 'Team Size',
-      type: WidgetType.GRAPH,
-      gridPosition: { row: 0, column: 0, rowSpan: 5, columnSpan: 6 },
-      configuration: isDefined(personIdFieldId)
-        ? {
+    isDefined(personIdFieldId)
+      ? {
+          id: generateSeedId(workspaceId, PAGE_LAYOUT_WIDGET_SEEDS.TEAM_SIZE),
+          pageLayoutTabId: generateSeedId(
+            workspaceId,
+            PAGE_LAYOUT_TAB_SEEDS.TEAM_OVERVIEW,
+          ),
+          title: 'Team Size',
+          type: WidgetType.GRAPH,
+          gridPosition: { row: 0, column: 0, rowSpan: 5, columnSpan: 6 },
+          configuration: {
             graphType: 'AGGREGATE',
             aggregateFieldMetadataId: personIdFieldId,
             aggregateOperation: AggregateOperations.COUNT,
             displayDataLabel: true,
             timezone: 'UTC',
             firstDayOfTheWeek: CalendarStartDay.MONDAY,
-          }
-        : null,
-      objectMetadataId: personObject?.id ?? null,
-    },
-    {
-      id: generateSeedId(
-        workspaceId,
-        PAGE_LAYOUT_WIDGET_SEEDS.TEAM_GEOGRAPHIC_DISTRIBUTION,
-      ),
-      pageLayoutTabId: generateSeedId(
-        workspaceId,
-        PAGE_LAYOUT_TAB_SEEDS.TEAM_OVERVIEW,
-      ),
-      title: 'Geographic Distribution',
-      type: WidgetType.GRAPH,
-      gridPosition: { row: 0, column: 6, rowSpan: 5, columnSpan: 6 },
-      configuration:
-        isDefined(personIdFieldId) && isDefined(personCityFieldId)
-          ? {
-              graphType: GraphType.VERTICAL_BAR,
-              aggregateFieldMetadataId: personIdFieldId,
-              aggregateOperation: AggregateOperations.COUNT,
-              primaryAxisGroupByFieldMetadataId: personCityFieldId,
-              primaryAxisOrderBy: 'VALUE_DESC',
-              axisNameDisplay: AxisNameDisplay.NONE,
-              displayDataLabel: false,
-              color: 'auto',
-              timezone: 'UTC',
-              firstDayOfTheWeek: CalendarStartDay.MONDAY,
-            }
-          : null,
-      objectMetadataId: personObject?.id ?? null,
-    },
+          },
+          objectMetadataId: personObject?.id ?? null,
+        }
+      : null,
+    isDefined(personIdFieldId) && isDefined(personCityFieldId)
+      ? {
+          id: generateSeedId(
+            workspaceId,
+            PAGE_LAYOUT_WIDGET_SEEDS.TEAM_GEOGRAPHIC_DISTRIBUTION,
+          ),
+          pageLayoutTabId: generateSeedId(
+            workspaceId,
+            PAGE_LAYOUT_TAB_SEEDS.TEAM_OVERVIEW,
+          ),
+          title: 'Geographic Distribution',
+          type: WidgetType.GRAPH,
+          gridPosition: { row: 0, column: 6, rowSpan: 5, columnSpan: 6 },
+          configuration: {
+            graphType: GraphType.VERTICAL_BAR,
+            aggregateFieldMetadataId: personIdFieldId,
+            aggregateOperation: AggregateOperations.COUNT,
+            primaryAxisGroupByFieldMetadataId: personCityFieldId,
+            primaryAxisOrderBy: 'VALUE_DESC',
+            axisNameDisplay: AxisNameDisplay.NONE,
+            displayDataLabel: false,
+            color: 'auto',
+            timezone: 'UTC',
+            firstDayOfTheWeek: CalendarStartDay.MONDAY,
+          },
+          objectMetadataId: personObject?.id ?? null,
+        }
+      : null,
 
     // Team Metrics Tab Widgets
-    {
-      id: generateSeedId(workspaceId, PAGE_LAYOUT_WIDGET_SEEDS.TEAM_OPEN_TASKS),
-      pageLayoutTabId: generateSeedId(
-        workspaceId,
-        PAGE_LAYOUT_TAB_SEEDS.TEAM_METRICS,
-      ),
-      title: 'Open Tasks',
-      type: WidgetType.GRAPH,
-      gridPosition: { row: 0, column: 6, rowSpan: 6, columnSpan: 6 },
-      configuration: isDefined(taskIdFieldId)
-        ? {
+    isDefined(taskIdFieldId)
+      ? {
+          id: generateSeedId(
+            workspaceId,
+            PAGE_LAYOUT_WIDGET_SEEDS.TEAM_OPEN_TASKS,
+          ),
+          pageLayoutTabId: generateSeedId(
+            workspaceId,
+            PAGE_LAYOUT_TAB_SEEDS.TEAM_METRICS,
+          ),
+          title: 'Open Tasks',
+          type: WidgetType.GRAPH,
+          gridPosition: { row: 0, column: 6, rowSpan: 6, columnSpan: 6 },
+          configuration: {
             graphType: 'AGGREGATE',
             aggregateFieldMetadataId: taskIdFieldId,
             aggregateOperation: AggregateOperations.COUNT,
             displayDataLabel: true,
             timezone: 'UTC',
             firstDayOfTheWeek: CalendarStartDay.MONDAY,
-          }
-        : null,
-      objectMetadataId: taskObject?.id ?? null,
-    },
-  ];
+          },
+          objectMetadataId: taskObject?.id ?? null,
+        }
+      : null,
+  ].filter(isDefined);
 
-  return [
-    ...v1Widgets,
-    ...(isDashboardV2Enabled
-      ? getPageLayoutWidgetDataSeedsV2(workspaceId, objectMetadataItems)
-      : []),
-  ];
+  const v2Widgets = isDashboardV2Enabled
+    ? getPageLayoutWidgetDataSeedsV2(workspaceId, objectMetadataItems)
+    : [];
+
+  return [...v1Widgets, ...v2Widgets];
 };


### PR DESCRIPTION
We used to seed widgets with empty configuration when the fields they required weren't defined. I suggest we only seed properly defined widgets.