### PR TITLE
Fix line break in richTextV2 field workflow editor

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/__stories__/FormRichTextV2FieldInput.stories.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/__stories__/FormRichTextV2FieldInput.stories.tsx
@@ -90,7 +90,7 @@ export const WithVariable: Story = {
     await waitFor(() => {
       expect(args.onChange).toHaveBeenCalledWith({
         blocknote: null,
-        markdown: `## Title\nVariable: {{${MOCKED_STEP_ID}.name}}`,
+        markdown: `## Title  \nVariable: {{${MOCKED_STEP_ID}.name}}`,
       });
     });
     expect(args.onChange).toHaveBeenCalledTimes(1);

--- a/packages/twenty-front/src/modules/workflow/workflow-variables/utils/__tests__/parseEditorContent.test.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-variables/utils/__tests__/parseEditorContent.test.ts
@@ -265,7 +265,7 @@ describe('parseEditorContent', () => {
       ],
     };
 
-    expect(parseEditorContent(input)).toBe('First line\nSecond line');
+    expect(parseEditorContent(input)).toBe('First line  \nSecond line');
   });
 
   it('should handle spaces between variables correctly', () => {

--- a/packages/twenty-front/src/modules/workflow/workflow-variables/utils/parseEditorContent.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-variables/utils/parseEditorContent.ts
@@ -3,6 +3,7 @@ import { isDefined } from 'twenty-shared/utils';
 
 export const parseEditorContent = (json: JSONContent): string => {
   const parseNode = (node: JSONContent): string => {
+    console.log(node);
     if (
       (node.type === 'paragraph' || node.type === 'doc') &&
       isDefined(node.content)
@@ -16,7 +17,7 @@ export const parseEditorContent = (json: JSONContent): string => {
     }
 
     if (node.type === 'hardBreak') {
-      return '\n';
+      return '  \n';
     }
 
     if (node.type === 'variableTag') {

--- a/packages/twenty-front/src/modules/workflow/workflow-variables/utils/parseEditorContent.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-variables/utils/parseEditorContent.ts
@@ -3,7 +3,6 @@ import { isDefined } from 'twenty-shared/utils';
 
 export const parseEditorContent = (json: JSONContent): string => {
   const parseNode = (node: JSONContent): string => {
-    console.log(node);
     if (
       (node.type === 'paragraph' || node.type === 'doc') &&
       isDefined(node.content)


### PR DESCRIPTION
Api expect markdown format where '\n' is escape (but not '  \n')

fixes https://github.com/twentyhq/twenty/issues/14976