### PR TITLE
Remaining standard view, view filter/group/field

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/build-standard-flat-view-field-metadata-maps.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/build-standard-flat-view-field-metadata-maps.util.ts
@@ -3,7 +3,17 @@ import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/typ
 import { addFlatEntityToFlatEntityMapsOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/add-flat-entity-to-flat-entity-maps-or-throw.util';
 import { type FlatViewField } from 'src/engine/metadata-modules/flat-view-field/types/flat-view-field.type';
 import { type AllStandardObjectName } from 'src/engine/workspace-manager/twenty-standard-application/types/all-standard-object-name.type';
+import { computeStandardCalendarEventViewFields } from 'src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-calendar-event-view-fields.util';
+import { computeStandardCompanyViewFields } from 'src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-company-view-fields.util';
+import { computeStandardDashboardViewFields } from 'src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-dashboard-view-fields.util';
+import { computeStandardMessageThreadViewFields } from 'src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-message-thread-view-fields.util';
+import { computeStandardMessageViewFields } from 'src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-message-view-fields.util';
+import { computeStandardNoteViewFields } from 'src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-note-view-fields.util';
+import { computeStandardOpportunityViewFields } from 'src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-opportunity-view-fields.util';
+import { computeStandardPersonViewFields } from 'src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-person-view-fields.util';
 import { computeStandardTaskViewFields } from 'src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-task-view-fields.util';
+import { computeStandardWorkflowRunViewFields } from 'src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-workflow-run-view-fields.util';
+import { computeStandardWorkflowViewFields } from 'src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-workflow-view-fields.util';
 import { type CreateStandardViewFieldArgs } from 'src/engine/workspace-manager/twenty-standard-application/utils/view-field/create-standard-view-field-flat-metadata.util';
 
 type StandardViewFieldBuilder<P extends AllStandardObjectName> = (
@@ -11,7 +21,17 @@ type StandardViewFieldBuilder<P extends AllStandardObjectName> = (
 ) => Record<string, FlatViewField>;
 
 const STANDARD_FLAT_VIEW_FIELD_METADATA_BUILDERS_BY_OBJECT_NAME = {
+  calendarEvent: computeStandardCalendarEventViewFields,
+  company: computeStandardCompanyViewFields,
+  dashboard: computeStandardDashboardViewFields,
+  message: computeStandardMessageViewFields,
+  messageThread: computeStandardMessageThreadViewFields,
+  note: computeStandardNoteViewFields,
+  opportunity: computeStandardOpportunityViewFields,
+  person: computeStandardPersonViewFields,
   task: computeStandardTaskViewFields,
+  workflow: computeStandardWorkflowViewFields,
+  workflowRun: computeStandardWorkflowRunViewFields,
 } as const satisfies {
   [P in AllStandardObjectName]?: StandardViewFieldBuilder<P>;
 };

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-calendar-event-view-fields.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-calendar-event-view-fields.util.ts
@@ -106,4 +106,3 @@ export const computeStandardCalendarEventViewFields = (
     }),
   };
 };
-

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-calendar-event-view-fields.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-calendar-event-view-fields.util.ts
@@ -1,0 +1,109 @@
+import { type FlatViewField } from 'src/engine/metadata-modules/flat-view-field/types/flat-view-field.type';
+import {
+  createStandardViewFieldFlatMetadata,
+  type CreateStandardViewFieldArgs,
+} from 'src/engine/workspace-manager/twenty-standard-application/utils/view-field/create-standard-view-field-flat-metadata.util';
+
+export const computeStandardCalendarEventViewFields = (
+  args: Omit<CreateStandardViewFieldArgs<'calendarEvent'>, 'context'>,
+): Record<string, FlatViewField> => {
+  return {
+    allCalendarEventsTitle: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'calendarEvent',
+      context: {
+        viewName: 'allCalendarEvents',
+        viewFieldName: 'title',
+        fieldName: 'title',
+        position: 0,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+    allCalendarEventsStartsAt: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'calendarEvent',
+      context: {
+        viewName: 'allCalendarEvents',
+        viewFieldName: 'startsAt',
+        fieldName: 'startsAt',
+        position: 1,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+    allCalendarEventsEndsAt: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'calendarEvent',
+      context: {
+        viewName: 'allCalendarEvents',
+        viewFieldName: 'endsAt',
+        fieldName: 'endsAt',
+        position: 2,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+    allCalendarEventsIsFullDay: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'calendarEvent',
+      context: {
+        viewName: 'allCalendarEvents',
+        viewFieldName: 'isFullDay',
+        fieldName: 'isFullDay',
+        position: 3,
+        isVisible: true,
+        size: 100,
+      },
+    }),
+    allCalendarEventsLocation: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'calendarEvent',
+      context: {
+        viewName: 'allCalendarEvents',
+        viewFieldName: 'location',
+        fieldName: 'location',
+        position: 4,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+    allCalendarEventsConferenceLink: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'calendarEvent',
+      context: {
+        viewName: 'allCalendarEvents',
+        viewFieldName: 'conferenceLink',
+        fieldName: 'conferenceLink',
+        position: 5,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+    allCalendarEventsIsCanceled: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'calendarEvent',
+      context: {
+        viewName: 'allCalendarEvents',
+        viewFieldName: 'isCanceled',
+        fieldName: 'isCanceled',
+        position: 6,
+        isVisible: true,
+        size: 100,
+      },
+    }),
+    allCalendarEventsCreatedAt: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'calendarEvent',
+      context: {
+        viewName: 'allCalendarEvents',
+        viewFieldName: 'createdAt',
+        fieldName: 'createdAt',
+        position: 7,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+  };
+};
+

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-company-view-fields.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-company-view-fields.util.ts
@@ -111,4 +111,3 @@ export const computeStandardCompanyViewFields = (
     }),
   };
 };
-

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-company-view-fields.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-company-view-fields.util.ts
@@ -1,0 +1,114 @@
+import { AggregateOperations } from 'src/engine/api/graphql/graphql-query-runner/constants/aggregate-operations.constant';
+import { type FlatViewField } from 'src/engine/metadata-modules/flat-view-field/types/flat-view-field.type';
+import {
+  createStandardViewFieldFlatMetadata,
+  type CreateStandardViewFieldArgs,
+} from 'src/engine/workspace-manager/twenty-standard-application/utils/view-field/create-standard-view-field-flat-metadata.util';
+
+export const computeStandardCompanyViewFields = (
+  args: Omit<CreateStandardViewFieldArgs<'company'>, 'context'>,
+): Record<string, FlatViewField> => {
+  return {
+    allCompaniesName: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'company',
+      context: {
+        viewName: 'allCompanies',
+        viewFieldName: 'name',
+        fieldName: 'name',
+        position: 0,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+    allCompaniesDomainName: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'company',
+      context: {
+        viewName: 'allCompanies',
+        viewFieldName: 'domainName',
+        fieldName: 'domainName',
+        position: 1,
+        isVisible: true,
+        size: 100,
+        aggregateOperation: AggregateOperations.COUNT,
+      },
+    }),
+    allCompaniesCreatedBy: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'company',
+      context: {
+        viewName: 'allCompanies',
+        viewFieldName: 'createdBy',
+        fieldName: 'createdBy',
+        position: 2,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+    allCompaniesAccountOwner: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'company',
+      context: {
+        viewName: 'allCompanies',
+        viewFieldName: 'accountOwner',
+        fieldName: 'accountOwner',
+        position: 3,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+    allCompaniesCreatedAt: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'company',
+      context: {
+        viewName: 'allCompanies',
+        viewFieldName: 'createdAt',
+        fieldName: 'createdAt',
+        position: 4,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+    allCompaniesEmployees: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'company',
+      context: {
+        viewName: 'allCompanies',
+        viewFieldName: 'employees',
+        fieldName: 'employees',
+        position: 5,
+        isVisible: true,
+        size: 150,
+        aggregateOperation: AggregateOperations.MAX,
+      },
+    }),
+    allCompaniesLinkedinLink: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'company',
+      context: {
+        viewName: 'allCompanies',
+        viewFieldName: 'linkedinLink',
+        fieldName: 'linkedinLink',
+        position: 6,
+        isVisible: true,
+        size: 170,
+        aggregateOperation: AggregateOperations.PERCENTAGE_EMPTY,
+      },
+    }),
+    allCompaniesAddress: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'company',
+      context: {
+        viewName: 'allCompanies',
+        viewFieldName: 'address',
+        fieldName: 'address',
+        position: 7,
+        isVisible: true,
+        size: 170,
+        aggregateOperation: AggregateOperations.COUNT_NOT_EMPTY,
+      },
+    }),
+  };
+};
+

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-dashboard-view-fields.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-dashboard-view-fields.util.ts
@@ -1,0 +1,61 @@
+import { type FlatViewField } from 'src/engine/metadata-modules/flat-view-field/types/flat-view-field.type';
+import {
+  createStandardViewFieldFlatMetadata,
+  type CreateStandardViewFieldArgs,
+} from 'src/engine/workspace-manager/twenty-standard-application/utils/view-field/create-standard-view-field-flat-metadata.util';
+
+export const computeStandardDashboardViewFields = (
+  args: Omit<CreateStandardViewFieldArgs<'dashboard'>, 'context'>,
+): Record<string, FlatViewField> => {
+  return {
+    allDashboardsTitle: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'dashboard',
+      context: {
+        viewName: 'allDashboards',
+        viewFieldName: 'title',
+        fieldName: 'title',
+        position: 0,
+        isVisible: true,
+        size: 210,
+      },
+    }),
+    allDashboardsCreatedBy: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'dashboard',
+      context: {
+        viewName: 'allDashboards',
+        viewFieldName: 'createdBy',
+        fieldName: 'createdBy',
+        position: 1,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+    allDashboardsCreatedAt: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'dashboard',
+      context: {
+        viewName: 'allDashboards',
+        viewFieldName: 'createdAt',
+        fieldName: 'createdAt',
+        position: 2,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+    allDashboardsUpdatedAt: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'dashboard',
+      context: {
+        viewName: 'allDashboards',
+        viewFieldName: 'updatedAt',
+        fieldName: 'updatedAt',
+        position: 3,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+  };
+};
+

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-dashboard-view-fields.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-dashboard-view-fields.util.ts
@@ -58,4 +58,3 @@ export const computeStandardDashboardViewFields = (
     }),
   };
 };
-

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-message-thread-view-fields.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-message-thread-view-fields.util.ts
@@ -1,0 +1,37 @@
+import { type FlatViewField } from 'src/engine/metadata-modules/flat-view-field/types/flat-view-field.type';
+import {
+  createStandardViewFieldFlatMetadata,
+  type CreateStandardViewFieldArgs,
+} from 'src/engine/workspace-manager/twenty-standard-application/utils/view-field/create-standard-view-field-flat-metadata.util';
+
+export const computeStandardMessageThreadViewFields = (
+  args: Omit<CreateStandardViewFieldArgs<'messageThread'>, 'context'>,
+): Record<string, FlatViewField> => {
+  return {
+    allMessageThreadsMessages: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'messageThread',
+      context: {
+        viewName: 'allMessageThreads',
+        viewFieldName: 'messages',
+        fieldName: 'messages',
+        position: 0,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+    allMessageThreadsCreatedAt: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'messageThread',
+      context: {
+        viewName: 'allMessageThreads',
+        viewFieldName: 'createdAt',
+        fieldName: 'createdAt',
+        position: 1,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+  };
+};
+

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-message-thread-view-fields.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-message-thread-view-fields.util.ts
@@ -34,4 +34,3 @@ export const computeStandardMessageThreadViewFields = (
     }),
   };
 };
-

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-message-view-fields.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-message-view-fields.util.ts
@@ -1,0 +1,97 @@
+import { type FlatViewField } from 'src/engine/metadata-modules/flat-view-field/types/flat-view-field.type';
+import {
+  createStandardViewFieldFlatMetadata,
+  type CreateStandardViewFieldArgs,
+} from 'src/engine/workspace-manager/twenty-standard-application/utils/view-field/create-standard-view-field-flat-metadata.util';
+
+export const computeStandardMessageViewFields = (
+  args: Omit<CreateStandardViewFieldArgs<'message'>, 'context'>,
+): Record<string, FlatViewField> => {
+  return {
+    allMessagesSubject: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'message',
+      context: {
+        viewName: 'allMessages',
+        viewFieldName: 'subject',
+        fieldName: 'subject',
+        position: 0,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+    allMessagesMessageThread: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'message',
+      context: {
+        viewName: 'allMessages',
+        viewFieldName: 'messageThread',
+        fieldName: 'messageThread',
+        position: 1,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+    allMessagesMessageParticipants: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'message',
+      context: {
+        viewName: 'allMessages',
+        viewFieldName: 'messageParticipants',
+        fieldName: 'messageParticipants',
+        position: 2,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+    allMessagesReceivedAt: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'message',
+      context: {
+        viewName: 'allMessages',
+        viewFieldName: 'receivedAt',
+        fieldName: 'receivedAt',
+        position: 3,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+    allMessagesHeaderMessageId: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'message',
+      context: {
+        viewName: 'allMessages',
+        viewFieldName: 'headerMessageId',
+        fieldName: 'headerMessageId',
+        position: 4,
+        isVisible: true,
+        size: 180,
+      },
+    }),
+    allMessagesText: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'message',
+      context: {
+        viewName: 'allMessages',
+        viewFieldName: 'text',
+        fieldName: 'text',
+        position: 5,
+        isVisible: true,
+        size: 200,
+      },
+    }),
+    allMessagesCreatedAt: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'message',
+      context: {
+        viewName: 'allMessages',
+        viewFieldName: 'createdAt',
+        fieldName: 'createdAt',
+        position: 6,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+  };
+};
+

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-message-view-fields.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-message-view-fields.util.ts
@@ -94,4 +94,3 @@ export const computeStandardMessageViewFields = (
     }),
   };
 };
-

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-note-view-fields.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-note-view-fields.util.ts
@@ -70,4 +70,3 @@ export const computeStandardNoteViewFields = (
     }),
   };
 };
-

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-note-view-fields.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-note-view-fields.util.ts
@@ -1,0 +1,73 @@
+import { type FlatViewField } from 'src/engine/metadata-modules/flat-view-field/types/flat-view-field.type';
+import {
+  createStandardViewFieldFlatMetadata,
+  type CreateStandardViewFieldArgs,
+} from 'src/engine/workspace-manager/twenty-standard-application/utils/view-field/create-standard-view-field-flat-metadata.util';
+
+export const computeStandardNoteViewFields = (
+  args: Omit<CreateStandardViewFieldArgs<'note'>, 'context'>,
+): Record<string, FlatViewField> => {
+  return {
+    allNotesTitle: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'note',
+      context: {
+        viewName: 'allNotes',
+        viewFieldName: 'title',
+        fieldName: 'title',
+        position: 0,
+        isVisible: true,
+        size: 210,
+      },
+    }),
+    allNotesNoteTargets: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'note',
+      context: {
+        viewName: 'allNotes',
+        viewFieldName: 'noteTargets',
+        fieldName: 'noteTargets',
+        position: 1,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+    allNotesBodyV2: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'note',
+      context: {
+        viewName: 'allNotes',
+        viewFieldName: 'bodyV2',
+        fieldName: 'bodyV2',
+        position: 2,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+    allNotesCreatedBy: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'note',
+      context: {
+        viewName: 'allNotes',
+        viewFieldName: 'createdBy',
+        fieldName: 'createdBy',
+        position: 3,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+    allNotesCreatedAt: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'note',
+      context: {
+        viewName: 'allNotes',
+        viewFieldName: 'createdAt',
+        fieldName: 'createdAt',
+        position: 4,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+  };
+};
+

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-opportunity-view-fields.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-opportunity-view-fields.util.ts
@@ -1,0 +1,163 @@
+import { AggregateOperations } from 'src/engine/api/graphql/graphql-query-runner/constants/aggregate-operations.constant';
+import { type FlatViewField } from 'src/engine/metadata-modules/flat-view-field/types/flat-view-field.type';
+import {
+  createStandardViewFieldFlatMetadata,
+  type CreateStandardViewFieldArgs,
+} from 'src/engine/workspace-manager/twenty-standard-application/utils/view-field/create-standard-view-field-flat-metadata.util';
+
+export const computeStandardOpportunityViewFields = (
+  args: Omit<CreateStandardViewFieldArgs<'opportunity'>, 'context'>,
+): Record<string, FlatViewField> => {
+  return {
+    // allOpportunities view fields
+    allOpportunitiesName: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'opportunity',
+      context: {
+        viewName: 'allOpportunities',
+        viewFieldName: 'name',
+        fieldName: 'name',
+        position: 0,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+    allOpportunitiesAmount: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'opportunity',
+      context: {
+        viewName: 'allOpportunities',
+        viewFieldName: 'amount',
+        fieldName: 'amount',
+        position: 1,
+        isVisible: true,
+        size: 150,
+        aggregateOperation: AggregateOperations.AVG,
+      },
+    }),
+    allOpportunitiesCreatedBy: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'opportunity',
+      context: {
+        viewName: 'allOpportunities',
+        viewFieldName: 'createdBy',
+        fieldName: 'createdBy',
+        position: 2,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+    allOpportunitiesCloseDate: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'opportunity',
+      context: {
+        viewName: 'allOpportunities',
+        viewFieldName: 'closeDate',
+        fieldName: 'closeDate',
+        position: 3,
+        isVisible: true,
+        size: 150,
+        aggregateOperation: AggregateOperations.MIN,
+      },
+    }),
+    allOpportunitiesCompany: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'opportunity',
+      context: {
+        viewName: 'allOpportunities',
+        viewFieldName: 'company',
+        fieldName: 'company',
+        position: 4,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+    allOpportunitiesPointOfContact: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'opportunity',
+      context: {
+        viewName: 'allOpportunities',
+        viewFieldName: 'pointOfContact',
+        fieldName: 'pointOfContact',
+        position: 5,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+
+    // byStage view fields
+    byStageName: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'opportunity',
+      context: {
+        viewName: 'byStage',
+        viewFieldName: 'name',
+        fieldName: 'name',
+        position: 0,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+    byStageAmount: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'opportunity',
+      context: {
+        viewName: 'byStage',
+        viewFieldName: 'amount',
+        fieldName: 'amount',
+        position: 1,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+    byStageCreatedBy: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'opportunity',
+      context: {
+        viewName: 'byStage',
+        viewFieldName: 'createdBy',
+        fieldName: 'createdBy',
+        position: 2,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+    byStageCloseDate: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'opportunity',
+      context: {
+        viewName: 'byStage',
+        viewFieldName: 'closeDate',
+        fieldName: 'closeDate',
+        position: 3,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+    byStageCompany: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'opportunity',
+      context: {
+        viewName: 'byStage',
+        viewFieldName: 'company',
+        fieldName: 'company',
+        position: 4,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+    byStagePointOfContact: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'opportunity',
+      context: {
+        viewName: 'byStage',
+        viewFieldName: 'pointOfContact',
+        fieldName: 'pointOfContact',
+        position: 5,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+  };
+};
+

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-opportunity-view-fields.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-opportunity-view-fields.util.ts
@@ -160,4 +160,3 @@ export const computeStandardOpportunityViewFields = (
     }),
   };
 };
-

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-person-view-fields.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-person-view-fields.util.ts
@@ -134,4 +134,3 @@ export const computeStandardPersonViewFields = (
     }),
   };
 };
-

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-person-view-fields.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-person-view-fields.util.ts
@@ -1,0 +1,137 @@
+import { AggregateOperations } from 'src/engine/api/graphql/graphql-query-runner/constants/aggregate-operations.constant';
+import { type FlatViewField } from 'src/engine/metadata-modules/flat-view-field/types/flat-view-field.type';
+import {
+  createStandardViewFieldFlatMetadata,
+  type CreateStandardViewFieldArgs,
+} from 'src/engine/workspace-manager/twenty-standard-application/utils/view-field/create-standard-view-field-flat-metadata.util';
+
+export const computeStandardPersonViewFields = (
+  args: Omit<CreateStandardViewFieldArgs<'person'>, 'context'>,
+): Record<string, FlatViewField> => {
+  return {
+    allPeopleName: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'person',
+      context: {
+        viewName: 'allPeople',
+        viewFieldName: 'name',
+        fieldName: 'name',
+        position: 0,
+        isVisible: true,
+        size: 210,
+      },
+    }),
+    allPeopleEmails: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'person',
+      context: {
+        viewName: 'allPeople',
+        viewFieldName: 'emails',
+        fieldName: 'emails',
+        position: 1,
+        isVisible: true,
+        size: 150,
+        aggregateOperation: AggregateOperations.COUNT_UNIQUE_VALUES,
+      },
+    }),
+    allPeopleCreatedBy: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'person',
+      context: {
+        viewName: 'allPeople',
+        viewFieldName: 'createdBy',
+        fieldName: 'createdBy',
+        position: 2,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+    allPeopleCompany: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'person',
+      context: {
+        viewName: 'allPeople',
+        viewFieldName: 'company',
+        fieldName: 'company',
+        position: 3,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+    allPeoplePhones: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'person',
+      context: {
+        viewName: 'allPeople',
+        viewFieldName: 'phones',
+        fieldName: 'phones',
+        position: 4,
+        isVisible: true,
+        size: 150,
+        aggregateOperation: AggregateOperations.PERCENTAGE_EMPTY,
+      },
+    }),
+    allPeopleCreatedAt: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'person',
+      context: {
+        viewName: 'allPeople',
+        viewFieldName: 'createdAt',
+        fieldName: 'createdAt',
+        position: 5,
+        isVisible: true,
+        size: 150,
+        aggregateOperation: AggregateOperations.MIN,
+      },
+    }),
+    allPeopleCity: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'person',
+      context: {
+        viewName: 'allPeople',
+        viewFieldName: 'city',
+        fieldName: 'city',
+        position: 6,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+    allPeopleJobTitle: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'person',
+      context: {
+        viewName: 'allPeople',
+        viewFieldName: 'jobTitle',
+        fieldName: 'jobTitle',
+        position: 7,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+    allPeopleLinkedinLink: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'person',
+      context: {
+        viewName: 'allPeople',
+        viewFieldName: 'linkedinLink',
+        fieldName: 'linkedinLink',
+        position: 8,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+    allPeopleXLink: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'person',
+      context: {
+        viewName: 'allPeople',
+        viewFieldName: 'xLink',
+        fieldName: 'xLink',
+        position: 9,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+  };
+};
+

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-workflow-run-view-fields.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-workflow-run-view-fields.util.ts
@@ -46,4 +46,3 @@ export const computeStandardWorkflowRunViewFields = (
     }),
   };
 };
-

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-workflow-run-view-fields.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-workflow-run-view-fields.util.ts
@@ -1,0 +1,49 @@
+import { type FlatViewField } from 'src/engine/metadata-modules/flat-view-field/types/flat-view-field.type';
+import {
+  createStandardViewFieldFlatMetadata,
+  type CreateStandardViewFieldArgs,
+} from 'src/engine/workspace-manager/twenty-standard-application/utils/view-field/create-standard-view-field-flat-metadata.util';
+
+export const computeStandardWorkflowRunViewFields = (
+  args: Omit<CreateStandardViewFieldArgs<'workflowRun'>, 'context'>,
+): Record<string, FlatViewField> => {
+  return {
+    allWorkflowRunsName: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'workflowRun',
+      context: {
+        viewName: 'allWorkflowRuns',
+        viewFieldName: 'name',
+        fieldName: 'name',
+        position: 0,
+        isVisible: true,
+        size: 210,
+      },
+    }),
+    allWorkflowRunsWorkflow: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'workflowRun',
+      context: {
+        viewName: 'allWorkflowRuns',
+        viewFieldName: 'workflow',
+        fieldName: 'workflow',
+        position: 1,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+    allWorkflowRunsStatus: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'workflowRun',
+      context: {
+        viewName: 'allWorkflowRuns',
+        viewFieldName: 'status',
+        fieldName: 'status',
+        position: 2,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+  };
+};
+

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-workflow-view-fields.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-workflow-view-fields.util.ts
@@ -1,0 +1,85 @@
+import { type FlatViewField } from 'src/engine/metadata-modules/flat-view-field/types/flat-view-field.type';
+import {
+  createStandardViewFieldFlatMetadata,
+  type CreateStandardViewFieldArgs,
+} from 'src/engine/workspace-manager/twenty-standard-application/utils/view-field/create-standard-view-field-flat-metadata.util';
+
+export const computeStandardWorkflowViewFields = (
+  args: Omit<CreateStandardViewFieldArgs<'workflow'>, 'context'>,
+): Record<string, FlatViewField> => {
+  return {
+    allWorkflowsName: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'workflow',
+      context: {
+        viewName: 'allWorkflows',
+        viewFieldName: 'name',
+        fieldName: 'name',
+        position: 0,
+        isVisible: true,
+        size: 210,
+      },
+    }),
+    allWorkflowsStatuses: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'workflow',
+      context: {
+        viewName: 'allWorkflows',
+        viewFieldName: 'statuses',
+        fieldName: 'statuses',
+        position: 1,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+    allWorkflowsUpdatedAt: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'workflow',
+      context: {
+        viewName: 'allWorkflows',
+        viewFieldName: 'updatedAt',
+        fieldName: 'updatedAt',
+        position: 2,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+    allWorkflowsCreatedBy: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'workflow',
+      context: {
+        viewName: 'allWorkflows',
+        viewFieldName: 'createdBy',
+        fieldName: 'createdBy',
+        position: 3,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+    allWorkflowsVersions: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'workflow',
+      context: {
+        viewName: 'allWorkflows',
+        viewFieldName: 'versions',
+        fieldName: 'versions',
+        position: 4,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+    allWorkflowsRuns: createStandardViewFieldFlatMetadata({
+      ...args,
+      objectName: 'workflow',
+      context: {
+        viewName: 'allWorkflows',
+        viewFieldName: 'runs',
+        fieldName: 'runs',
+        position: 5,
+        isVisible: true,
+        size: 150,
+      },
+    }),
+  };
+};
+

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-workflow-view-fields.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-field/compute-standard-workflow-view-fields.util.ts
@@ -82,4 +82,3 @@ export const computeStandardWorkflowViewFields = (
     }),
   };
 };
-

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-group/build-standard-flat-view-group-metadata-maps.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-group/build-standard-flat-view-group-metadata-maps.util.ts
@@ -3,6 +3,7 @@ import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/typ
 import { addFlatEntityToFlatEntityMapsOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/add-flat-entity-to-flat-entity-maps-or-throw.util';
 import { type FlatViewGroup } from 'src/engine/metadata-modules/flat-view-group/types/flat-view-group.type';
 import { type AllStandardObjectName } from 'src/engine/workspace-manager/twenty-standard-application/types/all-standard-object-name.type';
+import { computeStandardOpportunityViewGroups } from 'src/engine/workspace-manager/twenty-standard-application/utils/view-group/compute-standard-opportunity-view-groups.util';
 import { type CreateStandardViewGroupArgs } from 'src/engine/workspace-manager/twenty-standard-application/utils/view-group/create-standard-view-group-flat-metadata.util';
 import { computeStandardTaskViewGroups } from 'src/engine/workspace-manager/twenty-standard-application/utils/view-group/compute-standard-task-view-groups.util';
 
@@ -11,6 +12,7 @@ type StandardViewGroupBuilder<P extends AllStandardObjectName> = (
 ) => Record<string, FlatViewGroup>;
 
 const STANDARD_FLAT_VIEW_GROUP_METADATA_BUILDERS_BY_OBJECT_NAME = {
+  opportunity: computeStandardOpportunityViewGroups,
   task: computeStandardTaskViewGroups,
 } as const satisfies {
   [P in AllStandardObjectName]?: StandardViewGroupBuilder<P>;

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-group/compute-standard-opportunity-view-groups.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-group/compute-standard-opportunity-view-groups.util.ts
@@ -70,4 +70,3 @@ export const computeStandardOpportunityViewGroups = (
     }),
   };
 };
-

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-group/compute-standard-opportunity-view-groups.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view-group/compute-standard-opportunity-view-groups.util.ts
@@ -1,0 +1,73 @@
+import { type FlatViewGroup } from 'src/engine/metadata-modules/flat-view-group/types/flat-view-group.type';
+import {
+  createStandardViewGroupFlatMetadata,
+  type CreateStandardViewGroupArgs,
+} from 'src/engine/workspace-manager/twenty-standard-application/utils/view-group/create-standard-view-group-flat-metadata.util';
+
+export const computeStandardOpportunityViewGroups = (
+  args: Omit<CreateStandardViewGroupArgs<'opportunity'>, 'context'>,
+): Record<string, FlatViewGroup> => {
+  return {
+    byStageNew: createStandardViewGroupFlatMetadata({
+      ...args,
+      objectName: 'opportunity',
+      context: {
+        viewName: 'byStage',
+        viewGroupName: 'new',
+        fieldName: 'stage',
+        isVisible: true,
+        fieldValue: 'NEW',
+        position: 0,
+      },
+    }),
+    byStageScreening: createStandardViewGroupFlatMetadata({
+      ...args,
+      objectName: 'opportunity',
+      context: {
+        viewName: 'byStage',
+        viewGroupName: 'screening',
+        fieldName: 'stage',
+        isVisible: true,
+        fieldValue: 'SCREENING',
+        position: 1,
+      },
+    }),
+    byStageMeeting: createStandardViewGroupFlatMetadata({
+      ...args,
+      objectName: 'opportunity',
+      context: {
+        viewName: 'byStage',
+        viewGroupName: 'meeting',
+        fieldName: 'stage',
+        isVisible: true,
+        fieldValue: 'MEETING',
+        position: 2,
+      },
+    }),
+    byStageProposal: createStandardViewGroupFlatMetadata({
+      ...args,
+      objectName: 'opportunity',
+      context: {
+        viewName: 'byStage',
+        viewGroupName: 'proposal',
+        fieldName: 'stage',
+        isVisible: true,
+        fieldValue: 'PROPOSAL',
+        position: 3,
+      },
+    }),
+    byStageCustomer: createStandardViewGroupFlatMetadata({
+      ...args,
+      objectName: 'opportunity',
+      context: {
+        viewName: 'byStage',
+        viewGroupName: 'customer',
+        fieldName: 'stage',
+        isVisible: true,
+        fieldValue: 'CUSTOMER',
+        position: 4,
+      },
+    }),
+  };
+};
+

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/build-standard-flat-view-metadata-maps.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/build-standard-flat-view-metadata-maps.util.ts
@@ -3,7 +3,17 @@ import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/typ
 import { addFlatEntityToFlatEntityMapsOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/add-flat-entity-to-flat-entity-maps-or-throw.util';
 import { type FlatView } from 'src/engine/metadata-modules/flat-view/types/flat-view.type';
 import { type AllStandardObjectName } from 'src/engine/workspace-manager/twenty-standard-application/types/all-standard-object-name.type';
+import { computeStandardCalendarEventViews } from 'src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-calendar-event-views.util';
+import { computeStandardCompanyViews } from 'src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-company-views.util';
+import { computeStandardDashboardViews } from 'src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-dashboard-views.util';
+import { computeStandardMessageThreadViews } from 'src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-message-thread-views.util';
+import { computeStandardMessageViews } from 'src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-message-views.util';
+import { computeStandardNoteViews } from 'src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-note-views.util';
+import { computeStandardOpportunityViews } from 'src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-opportunity-views.util';
+import { computeStandardPersonViews } from 'src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-person-views.util';
 import { computeStandardTaskViews } from 'src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-task-views.util';
+import { computeStandardWorkflowRunViews } from 'src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-workflow-run-views.util';
+import { computeStandardWorkflowViews } from 'src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-workflow-views.util';
 import { type CreateStandardViewArgs } from 'src/engine/workspace-manager/twenty-standard-application/utils/view/create-standard-view-flat-metadata.util';
 
 type StandardViewBuilder<P extends AllStandardObjectName> = (
@@ -11,7 +21,17 @@ type StandardViewBuilder<P extends AllStandardObjectName> = (
 ) => Record<string, FlatView>;
 
 const STANDARD_FLAT_VIEW_METADATA_BUILDERS_BY_OBJECT_NAME = {
+  calendarEvent: computeStandardCalendarEventViews,
+  company: computeStandardCompanyViews,
+  dashboard: computeStandardDashboardViews,
+  message: computeStandardMessageViews,
+  messageThread: computeStandardMessageThreadViews,
+  note: computeStandardNoteViews,
+  opportunity: computeStandardOpportunityViews,
+  person: computeStandardPersonViews,
   task: computeStandardTaskViews,
+  workflow: computeStandardWorkflowViews,
+  workflowRun: computeStandardWorkflowRunViews,
 } as const satisfies {
   [P in AllStandardObjectName]?: StandardViewBuilder<P>;
 };

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-calendar-event-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-calendar-event-views.util.ts
@@ -25,4 +25,3 @@ export const computeStandardCalendarEventViews = (
     }),
   };
 };
-

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-calendar-event-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-calendar-event-views.util.ts
@@ -1,0 +1,28 @@
+import { type FlatView } from 'src/engine/metadata-modules/flat-view/types/flat-view.type';
+import { ViewKey } from 'src/engine/metadata-modules/view/enums/view-key.enum';
+import { ViewType } from 'src/engine/metadata-modules/view/enums/view-type.enum';
+import {
+  createStandardViewFlatMetadata,
+  type CreateStandardViewArgs,
+} from 'src/engine/workspace-manager/twenty-standard-application/utils/view/create-standard-view-flat-metadata.util';
+
+export const computeStandardCalendarEventViews = (
+  args: Omit<CreateStandardViewArgs<'calendarEvent'>, 'context'>,
+): Record<string, FlatView> => {
+  return {
+    allCalendarEvents: createStandardViewFlatMetadata({
+      ...args,
+      objectName: 'calendarEvent',
+      context: {
+        viewName: 'allCalendarEvents',
+        name: 'All Calendar Events',
+        type: ViewType.TABLE,
+        key: ViewKey.INDEX,
+        position: 0,
+        icon: 'IconList',
+        calendarFieldName: 'startsAt',
+      },
+    }),
+  };
+};
+

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-company-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-company-views.util.ts
@@ -1,0 +1,27 @@
+import { type FlatView } from 'src/engine/metadata-modules/flat-view/types/flat-view.type';
+import { ViewKey } from 'src/engine/metadata-modules/view/enums/view-key.enum';
+import { ViewType } from 'src/engine/metadata-modules/view/enums/view-type.enum';
+import {
+  createStandardViewFlatMetadata,
+  type CreateStandardViewArgs,
+} from 'src/engine/workspace-manager/twenty-standard-application/utils/view/create-standard-view-flat-metadata.util';
+
+export const computeStandardCompanyViews = (
+  args: Omit<CreateStandardViewArgs<'company'>, 'context'>,
+): Record<string, FlatView> => {
+  return {
+    allCompanies: createStandardViewFlatMetadata({
+      ...args,
+      objectName: 'company',
+      context: {
+        viewName: 'allCompanies',
+        name: 'All Companies',
+        type: ViewType.TABLE,
+        key: ViewKey.INDEX,
+        position: 0,
+        icon: 'IconList',
+      },
+    }),
+  };
+};
+

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-company-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-company-views.util.ts
@@ -24,4 +24,3 @@ export const computeStandardCompanyViews = (
     }),
   };
 };
-

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-dashboard-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-dashboard-views.util.ts
@@ -1,0 +1,27 @@
+import { type FlatView } from 'src/engine/metadata-modules/flat-view/types/flat-view.type';
+import { ViewKey } from 'src/engine/metadata-modules/view/enums/view-key.enum';
+import { ViewType } from 'src/engine/metadata-modules/view/enums/view-type.enum';
+import {
+  createStandardViewFlatMetadata,
+  type CreateStandardViewArgs,
+} from 'src/engine/workspace-manager/twenty-standard-application/utils/view/create-standard-view-flat-metadata.util';
+
+export const computeStandardDashboardViews = (
+  args: Omit<CreateStandardViewArgs<'dashboard'>, 'context'>,
+): Record<string, FlatView> => {
+  return {
+    allDashboards: createStandardViewFlatMetadata({
+      ...args,
+      objectName: 'dashboard',
+      context: {
+        viewName: 'allDashboards',
+        name: 'All Dashboards',
+        type: ViewType.TABLE,
+        key: ViewKey.INDEX,
+        position: 0,
+        icon: 'IconList',
+      },
+    }),
+  };
+};
+

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-dashboard-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-dashboard-views.util.ts
@@ -24,4 +24,3 @@ export const computeStandardDashboardViews = (
     }),
   };
 };
-

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-message-thread-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-message-thread-views.util.ts
@@ -1,0 +1,27 @@
+import { type FlatView } from 'src/engine/metadata-modules/flat-view/types/flat-view.type';
+import { ViewKey } from 'src/engine/metadata-modules/view/enums/view-key.enum';
+import { ViewType } from 'src/engine/metadata-modules/view/enums/view-type.enum';
+import {
+  createStandardViewFlatMetadata,
+  type CreateStandardViewArgs,
+} from 'src/engine/workspace-manager/twenty-standard-application/utils/view/create-standard-view-flat-metadata.util';
+
+export const computeStandardMessageThreadViews = (
+  args: Omit<CreateStandardViewArgs<'messageThread'>, 'context'>,
+): Record<string, FlatView> => {
+  return {
+    allMessageThreads: createStandardViewFlatMetadata({
+      ...args,
+      objectName: 'messageThread',
+      context: {
+        viewName: 'allMessageThreads',
+        name: 'All Message Threads',
+        type: ViewType.TABLE,
+        key: ViewKey.INDEX,
+        position: 0,
+        icon: 'IconList',
+      },
+    }),
+  };
+};
+

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-message-thread-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-message-thread-views.util.ts
@@ -24,4 +24,3 @@ export const computeStandardMessageThreadViews = (
     }),
   };
 };
-

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-message-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-message-views.util.ts
@@ -24,4 +24,3 @@ export const computeStandardMessageViews = (
     }),
   };
 };
-

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-message-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-message-views.util.ts
@@ -1,0 +1,27 @@
+import { type FlatView } from 'src/engine/metadata-modules/flat-view/types/flat-view.type';
+import { ViewKey } from 'src/engine/metadata-modules/view/enums/view-key.enum';
+import { ViewType } from 'src/engine/metadata-modules/view/enums/view-type.enum';
+import {
+  createStandardViewFlatMetadata,
+  type CreateStandardViewArgs,
+} from 'src/engine/workspace-manager/twenty-standard-application/utils/view/create-standard-view-flat-metadata.util';
+
+export const computeStandardMessageViews = (
+  args: Omit<CreateStandardViewArgs<'message'>, 'context'>,
+): Record<string, FlatView> => {
+  return {
+    allMessages: createStandardViewFlatMetadata({
+      ...args,
+      objectName: 'message',
+      context: {
+        viewName: 'allMessages',
+        name: 'All Messages',
+        type: ViewType.TABLE,
+        key: ViewKey.INDEX,
+        position: 0,
+        icon: 'IconList',
+      },
+    }),
+  };
+};
+

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-note-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-note-views.util.ts
@@ -24,4 +24,3 @@ export const computeStandardNoteViews = (
     }),
   };
 };
-

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-note-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-note-views.util.ts
@@ -1,0 +1,27 @@
+import { type FlatView } from 'src/engine/metadata-modules/flat-view/types/flat-view.type';
+import { ViewKey } from 'src/engine/metadata-modules/view/enums/view-key.enum';
+import { ViewType } from 'src/engine/metadata-modules/view/enums/view-type.enum';
+import {
+  createStandardViewFlatMetadata,
+  type CreateStandardViewArgs,
+} from 'src/engine/workspace-manager/twenty-standard-application/utils/view/create-standard-view-flat-metadata.util';
+
+export const computeStandardNoteViews = (
+  args: Omit<CreateStandardViewArgs<'note'>, 'context'>,
+): Record<string, FlatView> => {
+  return {
+    allNotes: createStandardViewFlatMetadata({
+      ...args,
+      objectName: 'note',
+      context: {
+        viewName: 'allNotes',
+        name: 'All Notes',
+        type: ViewType.TABLE,
+        key: ViewKey.INDEX,
+        position: 0,
+        icon: 'IconNotes',
+      },
+    }),
+  };
+};
+

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-opportunity-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-opportunity-views.util.ts
@@ -40,4 +40,3 @@ export const computeStandardOpportunityViews = (
     }),
   };
 };
-

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-opportunity-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-opportunity-views.util.ts
@@ -1,0 +1,43 @@
+import { AggregateOperations } from 'src/engine/api/graphql/graphql-query-runner/constants/aggregate-operations.constant';
+import { type FlatView } from 'src/engine/metadata-modules/flat-view/types/flat-view.type';
+import { ViewKey } from 'src/engine/metadata-modules/view/enums/view-key.enum';
+import { ViewType } from 'src/engine/metadata-modules/view/enums/view-type.enum';
+import {
+  createStandardViewFlatMetadata,
+  type CreateStandardViewArgs,
+} from 'src/engine/workspace-manager/twenty-standard-application/utils/view/create-standard-view-flat-metadata.util';
+
+export const computeStandardOpportunityViews = (
+  args: Omit<CreateStandardViewArgs<'opportunity'>, 'context'>,
+): Record<string, FlatView> => {
+  return {
+    allOpportunities: createStandardViewFlatMetadata({
+      ...args,
+      objectName: 'opportunity',
+      context: {
+        viewName: 'allOpportunities',
+        name: 'All Opportunities',
+        type: ViewType.TABLE,
+        key: ViewKey.INDEX,
+        position: 0,
+        icon: 'IconList',
+      },
+    }),
+    byStage: createStandardViewFlatMetadata({
+      ...args,
+      objectName: 'opportunity',
+      context: {
+        viewName: 'byStage',
+        name: 'By Stage',
+        type: ViewType.KANBAN,
+        key: null,
+        position: 2,
+        icon: 'IconLayoutKanban',
+        mainGroupByFieldName: 'stage',
+        kanbanAggregateOperation: AggregateOperations.MIN,
+        kanbanAggregateOperationFieldName: 'amount',
+      },
+    }),
+  };
+};
+

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-person-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-person-views.util.ts
@@ -24,4 +24,3 @@ export const computeStandardPersonViews = (
     }),
   };
 };
-

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-person-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-person-views.util.ts
@@ -1,0 +1,27 @@
+import { type FlatView } from 'src/engine/metadata-modules/flat-view/types/flat-view.type';
+import { ViewKey } from 'src/engine/metadata-modules/view/enums/view-key.enum';
+import { ViewType } from 'src/engine/metadata-modules/view/enums/view-type.enum';
+import {
+  createStandardViewFlatMetadata,
+  type CreateStandardViewArgs,
+} from 'src/engine/workspace-manager/twenty-standard-application/utils/view/create-standard-view-flat-metadata.util';
+
+export const computeStandardPersonViews = (
+  args: Omit<CreateStandardViewArgs<'person'>, 'context'>,
+): Record<string, FlatView> => {
+  return {
+    allPeople: createStandardViewFlatMetadata({
+      ...args,
+      objectName: 'person',
+      context: {
+        viewName: 'allPeople',
+        name: 'All People',
+        type: ViewType.TABLE,
+        key: ViewKey.INDEX,
+        position: 0,
+        icon: 'IconList',
+      },
+    }),
+  };
+};
+

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-workflow-run-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-workflow-run-views.util.ts
@@ -24,4 +24,3 @@ export const computeStandardWorkflowRunViews = (
     }),
   };
 };
-

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-workflow-run-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-workflow-run-views.util.ts
@@ -1,0 +1,27 @@
+import { type FlatView } from 'src/engine/metadata-modules/flat-view/types/flat-view.type';
+import { ViewKey } from 'src/engine/metadata-modules/view/enums/view-key.enum';
+import { ViewType } from 'src/engine/metadata-modules/view/enums/view-type.enum';
+import {
+  createStandardViewFlatMetadata,
+  type CreateStandardViewArgs,
+} from 'src/engine/workspace-manager/twenty-standard-application/utils/view/create-standard-view-flat-metadata.util';
+
+export const computeStandardWorkflowRunViews = (
+  args: Omit<CreateStandardViewArgs<'workflowRun'>, 'context'>,
+): Record<string, FlatView> => {
+  return {
+    allWorkflowRuns: createStandardViewFlatMetadata({
+      ...args,
+      objectName: 'workflowRun',
+      context: {
+        viewName: 'allWorkflowRuns',
+        name: 'All Workflow Runs',
+        type: ViewType.TABLE,
+        key: ViewKey.INDEX,
+        position: 0,
+        icon: 'IconList',
+      },
+    }),
+  };
+};
+

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-workflow-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-workflow-views.util.ts
@@ -1,0 +1,27 @@
+import { type FlatView } from 'src/engine/metadata-modules/flat-view/types/flat-view.type';
+import { ViewKey } from 'src/engine/metadata-modules/view/enums/view-key.enum';
+import { ViewType } from 'src/engine/metadata-modules/view/enums/view-type.enum';
+import {
+  createStandardViewFlatMetadata,
+  type CreateStandardViewArgs,
+} from 'src/engine/workspace-manager/twenty-standard-application/utils/view/create-standard-view-flat-metadata.util';
+
+export const computeStandardWorkflowViews = (
+  args: Omit<CreateStandardViewArgs<'workflow'>, 'context'>,
+): Record<string, FlatView> => {
+  return {
+    allWorkflows: createStandardViewFlatMetadata({
+      ...args,
+      objectName: 'workflow',
+      context: {
+        viewName: 'allWorkflows',
+        name: 'All Workflows',
+        type: ViewType.TABLE,
+        key: ViewKey.INDEX,
+        position: 0,
+        icon: 'IconList',
+      },
+    }),
+  };
+};
+

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-workflow-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-workflow-views.util.ts
@@ -24,4 +24,3 @@ export const computeStandardWorkflowViews = (
     }),
   };
 };
-


### PR DESCRIPTION
# Introduction
Following https://github.com/twentyhq/twenty/pull/16436
Related https://github.com/twentyhq/core-team-issues/issues/1995

## Objects

### 1. **Task** 📋
- **3 Views**: allTasks, byStatus, assignedToMe
- **20 View Fields** across all views
- **7 View Groups**: 4 for assignedToMe (TODO, IN_PROGRESS, DONE, empty), 3 for byStatus
- **1 View Filter**: assigneeIsMe

### 2. **Opportunity** 💼
- **2 Views**: allOpportunities, byStage (kanban with MIN aggregation)
- **12 View Fields** (6 per view)
- **5 View Groups**: NEW, SCREENING, MEETING, PROPOSAL, CUSTOMER

### 3. **Company** 🏢
- **1 View**: allCompanies
- **8 View Fields** (includes COUNT, MAX, PERCENTAGE_EMPTY aggregations)

### 4. **Person** 👤
- **1 View**: allPeople
- **10 View Fields** (includes COUNT_UNIQUE_VALUES, PERCENTAGE_EMPTY, MIN aggregations)

### 5. **Note** 📝
- **1 View**: allNotes
- **5 View Fields**

### 6. **Message** 📧
- **1 View**: allMessages
- **7 View Fields**

### 7. **Message Thread** 💬
- **1 View**: allMessageThreads
- **2 View Fields**

### 8. **Calendar Event** 📅
- **1 View**: allCalendarEvents (with calendar field: startsAt)
- **8 View Fields**

### 9. **Workflow** ⚙️
- **1 View**: allWorkflows
- **6 View Fields**

### 10. **Workflow Run** 🏃
- **1 View**: allWorkflowRuns
- **3 View Fields**

### 11. **Dashboard** 📊
- **1 View**: allDashboards
- **4 View Fields**

---
