### PR TITLE
[`Validate build and run`] Early return if workspace migration has no actions

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/services/workspace-migration-validate-build-and-run-service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/services/workspace-migration-validate-build-and-run-service.ts
@@ -193,7 +193,7 @@ export class WorkspaceMigrationValidateBuildAndRunService {
     // As with the current implementation passing an empty workspace migration might result
     // in dependency flat entity maps invalidation
     if (validateAndBuildResult.workspaceMigration.actions.length === 0) {
-      return undefined;
+      return;
     }
 
     await this.workspaceMigrationRunnerV2Service

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/services/workspace-migration-validate-build-and-run-service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/services/workspace-migration-validate-build-and-run-service.ts
@@ -189,7 +189,7 @@ export class WorkspaceMigrationValidateBuildAndRunService {
       return validateAndBuildResult;
     }
 
-    // Note: This should be removed once we've refactored the runner optimsitic rendering
+    // Note: This should be removed once we've refactored the runner optimistic rendering
     // As with the current implementation passing an empty workspace migration might result
     // in dependency flat entity maps invalidation
     if (validateAndBuildResult.workspaceMigration.actions.length === 0) {

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/services/workspace-migration-validate-build-and-run-service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration-v2/services/workspace-migration-validate-build-and-run-service.ts
@@ -189,6 +189,13 @@ export class WorkspaceMigrationValidateBuildAndRunService {
       return validateAndBuildResult;
     }
 
+    // Note: This should be removed once we've refactored the runner optimsitic rendering
+    // As with the current implementation passing an empty workspace migration might result
+    // in dependency flat entity maps invalidation
+    if (validateAndBuildResult.workspaceMigration.actions.length === 0) {
+      return undefined;
+    }
+
     await this.workspaceMigrationRunnerV2Service
       .run(validateAndBuildResult.workspaceMigration)
       .catch((error) => {


### PR DESCRIPTION
# Introduction
Early returning in `validateBuildAndRun` as the runner even if passed an empty workspace migration actions array be invalidating dependency related flat entity maps.
When we will refactor the runner to consume the generic flat entity maps tools such as `addFlatEntityToFlatEntityAndRelatedEntityMapsThroughMutationOrThrow` we will be able to remove the dependency cache invalidation