### PR TITLE
Message/Calendar thread temporary fix during datasource refactoring

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/calendar/timeline-calendar-event.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/calendar/timeline-calendar-event.service.ts
@@ -191,6 +191,7 @@ export class TimelineCalendarEventService {
           await this.globalWorkspaceOrmManager.getRepository<PersonWorkspaceEntity>(
             workspaceId,
             'person',
+            { shouldBypassPermissionChecks: true },
           );
 
         const personIds = await personRepository.find({
@@ -246,6 +247,7 @@ export class TimelineCalendarEventService {
           await this.globalWorkspaceOrmManager.getRepository<OpportunityWorkspaceEntity>(
             workspaceId,
             'opportunity',
+            { shouldBypassPermissionChecks: true },
           );
 
         const opportunity = await opportunityRepository.findOne({

--- a/packages/twenty-server/src/engine/core-modules/messaging/services/get-messages.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/messaging/services/get-messages.service.ts
@@ -83,6 +83,7 @@ export class GetMessagesService {
           await this.globalWorkspaceOrmManager.getRepository<PersonWorkspaceEntity>(
             workspaceId,
             'person',
+            { shouldBypassPermissionChecks: true },
           );
         const personIds = (
           await personRepository.find({
@@ -131,6 +132,7 @@ export class GetMessagesService {
           await this.globalWorkspaceOrmManager.getRepository<OpportunityWorkspaceEntity>(
             workspaceId,
             'opportunity',
+            { shouldBypassPermissionChecks: true },
           );
 
         const opportunity = await opportunityRepository.findOne({


### PR DESCRIPTION
The current repository implementation require the caller to pass the permissionConfig which is not the case in messaging and calendar custom resolver. We are bypassing the permission as fetching the role in the caller will likely not be needed anymore in the new datasource / orm implementation