### PR TITLE
Add TTL eviction to local data cache

### DIFF
--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-base-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-base-query-runner.service.ts
@@ -3,7 +3,6 @@ import { Inject, Injectable } from '@nestjs/common';
 import { msg } from '@lingui/core/macro';
 import { type PermissionFlagType } from 'twenty-shared/constants';
 import { isDefined } from 'twenty-shared/utils';
-import { Omit } from 'zod/v4/core/util.cjs';
 
 import { WorkspaceAuthContext } from 'src/engine/api/common/interfaces/workspace-auth-context.interface';
 import { QueryResultFieldValue } from 'src/engine/api/graphql/workspace-query-runner/factories/query-result-getters/interfaces/query-result-field-value';

--- a/packages/twenty-server/src/engine/twenty-orm/global-workspace-datasource/workspace-orm-entity-metadatas-cache.service.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/global-workspace-datasource/workspace-orm-entity-metadatas-cache.service.ts
@@ -11,7 +11,7 @@ import { WorkspaceCacheProvider } from 'src/engine/workspace-cache/interfaces/wo
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 import { EntitySchemaFactory } from 'src/engine/twenty-orm/factories/entity-schema.factory';
-import { GlobalWorkspaceDataSourceService } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-datasource.service';
+import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
 import { buildEntitySchemaMetadataMaps } from 'src/engine/twenty-orm/global-workspace-datasource/types/entity-schema-metadata.type';
 import { WorkspaceCache } from 'src/engine/workspace-cache/decorators/workspace-cache.decorator';
 
@@ -26,7 +26,7 @@ export class WorkspaceORMEntityMetadatasCacheService extends WorkspaceCacheProvi
     @InjectRepository(FieldMetadataEntity)
     private readonly fieldMetadataRepository: Repository<FieldMetadataEntity>,
     private readonly entitySchemaFactory: EntitySchemaFactory,
-    private readonly globalWorkspaceDataSourceService: GlobalWorkspaceDataSourceService,
+    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
   ) {
     super();
   }
@@ -57,17 +57,21 @@ export class WorkspaceORMEntityMetadatasCacheService extends WorkspaceCacheProvi
         ),
       );
 
-    return this.buildEntityMetadatas(entitySchemas);
+    const entityMetadatas = await this.buildEntityMetadatas(entitySchemas);
+
+    return entityMetadatas;
   }
 
-  private buildEntityMetadatas(
+  private async buildEntityMetadatas(
     entitySchemas: EntitySchema[],
-  ): EntityMetadata[] {
+  ): Promise<EntityMetadata[]> {
     const transformer = new EntitySchemaTransformer();
     const metadataArgsStorage = transformer.transform(entitySchemas);
 
+    const dataSource =
+      await this.globalWorkspaceOrmManager.getGlobalWorkspaceDataSource();
     const entityMetadataBuilder = new EntityMetadataBuilder(
-      this.globalWorkspaceDataSourceService.getGlobalWorkspaceDataSource(),
+      dataSource,
       metadataArgsStorage,
     );
 


### PR DESCRIPTION
We keep different versions of our cache to avoid race conditions but we never evict stale data. This PR should fix that