### PR TITLE
feat(ai): add context usage display to AI chat (BREAKING: deploy server first)

### DIFF
--- a/packages/twenty-front/src/generated-metadata/graphql.ts
+++ b/packages/twenty-front/src/generated-metadata/graphql.ts
@@ -73,12 +73,11 @@ export type AgentChatThread = {
   contextWindowTokens?: Maybe<Scalars['Int']>;
   createdAt: Scalars['DateTime'];
   id: Scalars['UUID'];
-  inputCostPer1kTokensInCents?: Maybe<Scalars['Float']>;
-  outputCostPer1kTokensInCents?: Maybe<Scalars['Float']>;
   title?: Maybe<Scalars['String']>;
+  totalInputCredits: Scalars['Int'];
   totalInputTokens: Scalars['Int'];
+  totalOutputCredits: Scalars['Int'];
   totalOutputTokens: Scalars['Int'];
-  totalTokens: Scalars['Int'];
   updatedAt: Scalars['DateTime'];
 };
 
@@ -5120,7 +5119,7 @@ export type GetChatMessagesQuery = { __typename?: 'Query', chatMessages: Array<{
 export type GetChatThreadsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetChatThreadsQuery = { __typename?: 'Query', chatThreads: Array<{ __typename?: 'AgentChatThread', id: string, title?: string | null, totalInputTokens: number, totalOutputTokens: number, totalTokens: number, contextWindowTokens?: number | null, inputCostPer1kTokensInCents?: number | null, outputCostPer1kTokensInCents?: number | null, createdAt: string, updatedAt: string }> };
+export type GetChatThreadsQuery = { __typename?: 'Query', chatThreads: Array<{ __typename?: 'AgentChatThread', id: string, title?: string | null, totalInputTokens: number, totalOutputTokens: number, contextWindowTokens?: number | null, totalInputCredits: number, totalOutputCredits: number, createdAt: string, updatedAt: string }> };
 
 export type TrackAnalyticsMutationVariables = Exact<{
   type: AnalyticsType;
@@ -7730,10 +7729,9 @@ export const GetChatThreadsDocument = gql`
     title
     totalInputTokens
     totalOutputTokens
-    totalTokens
     contextWindowTokens
-    inputCostPer1kTokensInCents
-    outputCostPer1kTokensInCents
+    totalInputCredits
+    totalOutputCredits
     createdAt
     updatedAt
   }

--- a/packages/twenty-front/src/generated-metadata/graphql.ts
+++ b/packages/twenty-front/src/generated-metadata/graphql.ts
@@ -70,9 +70,15 @@ export type Agent = {
 
 export type AgentChatThread = {
   __typename?: 'AgentChatThread';
+  contextWindowTokens?: Maybe<Scalars['Int']>;
   createdAt: Scalars['DateTime'];
   id: Scalars['UUID'];
+  inputCostPer1kTokensInCents?: Maybe<Scalars['Float']>;
+  outputCostPer1kTokensInCents?: Maybe<Scalars['Float']>;
   title?: Maybe<Scalars['String']>;
+  totalInputTokens: Scalars['Int'];
+  totalOutputTokens: Scalars['Int'];
+  totalTokens: Scalars['Int'];
   updatedAt: Scalars['DateTime'];
 };
 
@@ -5114,7 +5120,7 @@ export type GetChatMessagesQuery = { __typename?: 'Query', chatMessages: Array<{
 export type GetChatThreadsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetChatThreadsQuery = { __typename?: 'Query', chatThreads: Array<{ __typename?: 'AgentChatThread', id: string, title?: string | null, createdAt: string, updatedAt: string }> };
+export type GetChatThreadsQuery = { __typename?: 'Query', chatThreads: Array<{ __typename?: 'AgentChatThread', id: string, title?: string | null, totalInputTokens: number, totalOutputTokens: number, totalTokens: number, contextWindowTokens?: number | null, inputCostPer1kTokensInCents?: number | null, outputCostPer1kTokensInCents?: number | null, createdAt: string, updatedAt: string }> };
 
 export type TrackAnalyticsMutationVariables = Exact<{
   type: AnalyticsType;
@@ -7722,6 +7728,12 @@ export const GetChatThreadsDocument = gql`
   chatThreads {
     id
     title
+    totalInputTokens
+    totalOutputTokens
+    totalTokens
+    contextWindowTokens
+    inputCostPer1kTokensInCents
+    outputCostPer1kTokensInCents
     createdAt
     updatedAt
   }

--- a/packages/twenty-front/src/generated/graphql.ts
+++ b/packages/twenty-front/src/generated/graphql.ts
@@ -70,9 +70,15 @@ export type Agent = {
 
 export type AgentChatThread = {
   __typename?: 'AgentChatThread';
+  contextWindowTokens?: Maybe<Scalars['Int']>;
   createdAt: Scalars['DateTime'];
   id: Scalars['UUID'];
+  inputCostPer1kTokensInCents?: Maybe<Scalars['Float']>;
+  outputCostPer1kTokensInCents?: Maybe<Scalars['Float']>;
   title?: Maybe<Scalars['String']>;
+  totalInputTokens: Scalars['Int'];
+  totalOutputTokens: Scalars['Int'];
+  totalTokens: Scalars['Int'];
   updatedAt: Scalars['DateTime'];
 };
 

--- a/packages/twenty-front/src/generated/graphql.ts
+++ b/packages/twenty-front/src/generated/graphql.ts
@@ -73,12 +73,11 @@ export type AgentChatThread = {
   contextWindowTokens?: Maybe<Scalars['Int']>;
   createdAt: Scalars['DateTime'];
   id: Scalars['UUID'];
-  inputCostPer1kTokensInCents?: Maybe<Scalars['Float']>;
-  outputCostPer1kTokensInCents?: Maybe<Scalars['Float']>;
   title?: Maybe<Scalars['String']>;
+  totalInputCredits: Scalars['Int'];
   totalInputTokens: Scalars['Int'];
+  totalOutputCredits: Scalars['Int'];
   totalOutputTokens: Scalars['Int'];
-  totalTokens: Scalars['Int'];
   updatedAt: Scalars['DateTime'];
 };
 

--- a/packages/twenty-front/src/modules/ai/components/AIChatTab.tsx
+++ b/packages/twenty-front/src/modules/ai/components/AIChatTab.tsx
@@ -11,6 +11,7 @@ import { ScrollWrapper } from '@/ui/utilities/scroll/components/ScrollWrapper';
 
 import { AIChatEmptyState } from '@/ai/components/AIChatEmptyState';
 import { AIChatMessage } from '@/ai/components/AIChatMessage';
+import { AIChatContextUsageButton } from '@/ai/components/internal/AIChatContextUsageButton';
 import { AIChatSkeletonLoader } from '@/ai/components/internal/AIChatSkeletonLoader';
 import { AgentChatContextPreview } from '@/ai/components/internal/AgentChatContextPreview';
 import { SendMessageButton } from '@/ai/components/internal/SendMessageButton';
@@ -138,6 +139,7 @@ export const AIChatTab = () => {
                 onClick={() => createChatThread()}
               />
               <AgentChatFileUploadButton />
+              <AIChatContextUsageButton />
               <SendMessageButton />
             </StyledButtonsContainer>
           </StyledInputArea>

--- a/packages/twenty-front/src/modules/ai/components/AIChatThreadGroup.tsx
+++ b/packages/twenty-front/src/modules/ai/components/AIChatThreadGroup.tsx
@@ -1,9 +1,11 @@
+import { agentChatUsageState } from '@/ai/states/agentChatUsageState';
 import { currentAIChatThreadState } from '@/ai/states/currentAIChatThreadState';
 import { useOpenAskAIPageInCommandMenu } from '@/command-menu/hooks/useOpenAskAIPageInCommandMenu';
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useLingui } from '@lingui/react/macro';
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useSetRecoilState } from 'recoil';
+import { isDefined } from 'twenty-shared/utils';
 import { IconSparkles } from 'twenty-ui/display';
 import { type AgentChatThread } from '~/generated-metadata/graphql';
 
@@ -76,7 +78,35 @@ export const AIChatThreadGroup = ({
   const { t } = useLingui();
   const theme = useTheme();
   const [, setCurrentAIChatThread] = useRecoilState(currentAIChatThreadState);
+  const setAgentChatUsage = useSetRecoilState(agentChatUsageState);
   const { openAskAIPage } = useOpenAskAIPageInCommandMenu();
+
+  const handleThreadClick = (thread: AgentChatThread) => {
+    setCurrentAIChatThread(thread.id);
+
+    const hasUsageData =
+      thread.totalTokens > 0 && isDefined(thread.contextWindowTokens);
+
+    setAgentChatUsage(
+      hasUsageData
+        ? {
+            inputTokens: thread.totalInputTokens,
+            outputTokens: thread.totalOutputTokens,
+            totalTokens: thread.totalTokens,
+            contextWindowTokens: thread.contextWindowTokens ?? 0,
+            inputCostPer1kTokensInCents:
+              thread.inputCostPer1kTokensInCents ?? 0,
+            outputCostPer1kTokensInCents:
+              thread.outputCostPer1kTokensInCents ?? 0,
+          }
+        : null,
+    );
+
+    openAskAIPage({
+      pageTitle: thread.title,
+      resetNavigationStack: false,
+    });
+  };
 
   if (threads.length === 0) {
     return null;
@@ -88,13 +118,7 @@ export const AIChatThreadGroup = ({
       <StyledThreadsList>
         {threads.map((thread) => (
           <StyledThreadItem
-            onClick={() => {
-              setCurrentAIChatThread(thread.id);
-              openAskAIPage({
-                pageTitle: thread.title,
-                resetNavigationStack: false,
-              });
-            }}
+            onClick={() => handleThreadClick(thread)}
             key={thread.id}
           >
             <StyledSparkleIcon>

--- a/packages/twenty-front/src/modules/ai/components/AIChatThreadGroup.tsx
+++ b/packages/twenty-front/src/modules/ai/components/AIChatThreadGroup.tsx
@@ -84,20 +84,18 @@ export const AIChatThreadGroup = ({
   const handleThreadClick = (thread: AgentChatThread) => {
     setCurrentAIChatThread(thread.id);
 
-    const hasUsageData =
-      thread.totalTokens > 0 && isDefined(thread.contextWindowTokens);
+    const totalTokens = thread.totalInputTokens + thread.totalOutputTokens;
+    const hasUsageData = totalTokens > 0 && isDefined(thread.contextWindowTokens);
 
     setAgentChatUsage(
       hasUsageData
         ? {
             inputTokens: thread.totalInputTokens,
             outputTokens: thread.totalOutputTokens,
-            totalTokens: thread.totalTokens,
+            totalTokens,
             contextWindowTokens: thread.contextWindowTokens ?? 0,
-            inputCostPer1kTokensInCents:
-              thread.inputCostPer1kTokensInCents ?? 0,
-            outputCostPer1kTokensInCents:
-              thread.outputCostPer1kTokensInCents ?? 0,
+            inputCredits: thread.totalInputCredits,
+            outputCredits: thread.totalOutputCredits,
           }
         : null,
     );

--- a/packages/twenty-front/src/modules/ai/components/AIChatThreadGroup.tsx
+++ b/packages/twenty-front/src/modules/ai/components/AIChatThreadGroup.tsx
@@ -85,7 +85,8 @@ export const AIChatThreadGroup = ({
     setCurrentAIChatThread(thread.id);
 
     const totalTokens = thread.totalInputTokens + thread.totalOutputTokens;
-    const hasUsageData = totalTokens > 0 && isDefined(thread.contextWindowTokens);
+    const hasUsageData =
+      totalTokens > 0 && isDefined(thread.contextWindowTokens);
 
     setAgentChatUsage(
       hasUsageData

--- a/packages/twenty-front/src/modules/ai/components/internal/AIChatContextUsageButton.tsx
+++ b/packages/twenty-front/src/modules/ai/components/internal/AIChatContextUsageButton.tsx
@@ -123,7 +123,8 @@ export const AIChatContextUsageButton = () => {
     100,
   );
   const formattedPercentage = percentage.toFixed(1);
-  const totalCredits = agentChatUsage.inputCredits + agentChatUsage.outputCredits;
+  const totalCredits =
+    agentChatUsage.inputCredits + agentChatUsage.outputCredits;
 
   return (
     <StyledContainer

--- a/packages/twenty-front/src/modules/ai/components/internal/AIChatContextUsageButton.tsx
+++ b/packages/twenty-front/src/modules/ai/components/internal/AIChatContextUsageButton.tsx
@@ -1,0 +1,200 @@
+import { useTheme } from '@emotion/react';
+import styled from '@emotion/styled';
+import { useState } from 'react';
+import { useRecoilValue } from 'recoil';
+import { ProgressBar } from 'twenty-ui/feedback';
+
+import { ContextUsageProgressRing } from '@/ai/components/internal/ContextUsageProgressRing';
+import { agentChatUsageState } from '@/ai/states/agentChatUsageState';
+
+const StyledContainer = styled.div`
+  position: relative;
+`;
+
+const StyledTrigger = styled.div<{ hasUsage: boolean }>`
+  align-items: center;
+  background: transparent;
+  border: 1px solid ${({ theme }) => theme.background.transparent.medium};
+  border-radius: ${({ theme }) => theme.border.radius.sm};
+  cursor: ${({ hasUsage }) => (hasUsage ? 'pointer' : 'default')};
+  display: flex;
+  gap: ${({ theme }) => theme.spacing(1)};
+  height: 24px;
+  padding: 0 ${({ theme }) => theme.spacing(2)};
+  transition: background 0.1s ease;
+
+  &:hover {
+    background: ${({ theme, hasUsage }) =>
+      hasUsage ? theme.background.transparent.light : 'transparent'};
+  }
+`;
+
+const StyledPercentage = styled.span`
+  color: ${({ theme }) => theme.font.color.secondary};
+  font-size: ${({ theme }) => theme.font.size.sm};
+  font-weight: ${({ theme }) => theme.font.weight.medium};
+`;
+
+const StyledHoverCard = styled.div`
+  background: ${({ theme }) => theme.background.primary};
+  border: 1px solid ${({ theme }) => theme.border.color.medium};
+  border-radius: ${({ theme }) => theme.border.radius.md};
+  box-shadow: ${({ theme }) => theme.boxShadow.strong};
+  min-width: 240px;
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 8px);
+  z-index: ${({ theme }) => theme.lastLayerZIndex};
+`;
+
+const StyledHeader = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing(2)};
+  padding: ${({ theme }) => theme.spacing(3)};
+`;
+
+const StyledRow = styled.div`
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+`;
+
+const StyledBody = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing(2)};
+  padding: ${({ theme }) => theme.spacing(3)};
+  padding-top: 0;
+`;
+
+const StyledLabel = styled.span`
+  color: ${({ theme }) => theme.font.color.secondary};
+  font-size: ${({ theme }) => theme.font.size.sm};
+`;
+
+const StyledValue = styled.span`
+  color: ${({ theme }) => theme.font.color.tertiary};
+  font-size: ${({ theme }) => theme.font.size.sm};
+`;
+
+const StyledFooter = styled.div`
+  align-items: center;
+  background: ${({ theme }) => theme.background.secondary};
+  border-top: 1px solid ${({ theme }) => theme.border.color.light};
+  border-radius: 0 0 ${({ theme }) => theme.border.radius.md}
+    ${({ theme }) => theme.border.radius.md};
+  display: flex;
+  justify-content: space-between;
+  padding: ${({ theme }) => theme.spacing(3)};
+`;
+
+const formatTokenCount = (count: number): string => {
+  if (count >= 1_000_000_000) {
+    return `${(count / 1_000_000_000).toFixed(1)}B`;
+  }
+  if (count >= 1_000_000) {
+    return `${(count / 1_000_000).toFixed(1)}M`;
+  }
+  if (count >= 1_000) {
+    return `${(count / 1_000).toFixed(1)}K`;
+  }
+  return count.toString();
+};
+
+// 1 credit = $0.000001, so cents * 10_000 = credits
+const centsToCredits = (cents: number): number =>
+  Math.round(cents * 10_000);
+
+const getCredits = (tokens: number, costPer1kTokensInCents: number): number =>
+  centsToCredits((tokens / 1000) * costPer1kTokensInCents);
+
+export const AIChatContextUsageButton = () => {
+  const theme = useTheme();
+  const [isHovered, setIsHovered] = useState(false);
+  const usage = useRecoilValue(agentChatUsageState);
+
+  if (!usage) {
+    return (
+      <StyledContainer>
+        <StyledTrigger hasUsage={false}>
+          <ContextUsageProgressRing percentage={0} />
+          <StyledPercentage>0%</StyledPercentage>
+        </StyledTrigger>
+      </StyledContainer>
+    );
+  }
+
+  const percentage = Math.min(
+    (usage.totalTokens / usage.contextWindowTokens) * 100,
+    100,
+  );
+  const formattedPercentage = percentage.toFixed(1);
+
+  const inputCredits = getCredits(usage.inputTokens, usage.inputCostPer1kTokens);
+  const outputCredits = getCredits(
+    usage.outputTokens,
+    usage.outputCostPer1kTokens,
+  );
+  const totalCredits = inputCredits + outputCredits;
+
+  return (
+    <StyledContainer
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      <StyledTrigger hasUsage={true}>
+        <ContextUsageProgressRing percentage={percentage} />
+        <StyledPercentage>{formattedPercentage}%</StyledPercentage>
+      </StyledTrigger>
+
+      {isHovered && (
+        <StyledHoverCard>
+          <StyledHeader>
+            <StyledRow>
+              <StyledPercentage>{formattedPercentage}%</StyledPercentage>
+              <StyledValue>
+                {formatTokenCount(usage.totalTokens)} /{' '}
+                {formatTokenCount(usage.contextWindowTokens)}
+              </StyledValue>
+            </StyledRow>
+            <ProgressBar
+              value={percentage}
+              barColor={
+                percentage > 80
+                  ? theme.color.red
+                  : percentage > 60
+                    ? theme.color.orange
+                    : theme.color.blue
+              }
+              backgroundColor={theme.background.quaternary}
+              withBorderRadius
+            />
+          </StyledHeader>
+
+          <StyledBody>
+            <StyledRow>
+              <StyledLabel>Input</StyledLabel>
+              <StyledValue>
+                {formatTokenCount(usage.inputTokens)} •{' '}
+                {inputCredits.toLocaleString()} credits
+              </StyledValue>
+            </StyledRow>
+            <StyledRow>
+              <StyledLabel>Output</StyledLabel>
+              <StyledValue>
+                {formatTokenCount(usage.outputTokens)} •{' '}
+                {outputCredits.toLocaleString()} credits
+              </StyledValue>
+            </StyledRow>
+          </StyledBody>
+
+          <StyledFooter>
+            <StyledLabel>Total credits</StyledLabel>
+            <StyledPercentage>{totalCredits.toLocaleString()}</StyledPercentage>
+          </StyledFooter>
+        </StyledHoverCard>
+      )}
+    </StyledContainer>
+  );
+};

--- a/packages/twenty-front/src/modules/ai/components/internal/AIChatContextUsageButton.tsx
+++ b/packages/twenty-front/src/modules/ai/components/internal/AIChatContextUsageButton.tsx
@@ -6,7 +6,6 @@ import { ProgressBar } from 'twenty-ui/feedback';
 
 import { ContextUsageProgressRing } from '@/ai/components/internal/ContextUsageProgressRing';
 import { agentChatUsageState } from '@/ai/states/agentChatUsageState';
-import { convertCentsToBillingCredits } from '@/ai/utils/convertCentsToBillingCredits';
 
 const StyledContainer = styled.div`
   position: relative;
@@ -103,11 +102,6 @@ const formatTokenCount = (count: number): string => {
   return count.toString();
 };
 
-const getCredits = (tokens: number, costPer1kTokensInCents: number): number => {
-  const costInCents = (tokens / 1000) * costPer1kTokensInCents;
-  return convertCentsToBillingCredits(costInCents);
-};
-
 export const AIChatContextUsageButton = () => {
   const theme = useTheme();
   const [isHovered, setIsHovered] = useState(false);
@@ -129,16 +123,7 @@ export const AIChatContextUsageButton = () => {
     100,
   );
   const formattedPercentage = percentage.toFixed(1);
-
-  const inputCredits = getCredits(
-    agentChatUsage.inputTokens,
-    agentChatUsage.inputCostPer1kTokensInCents,
-  );
-  const outputCredits = getCredits(
-    agentChatUsage.outputTokens,
-    agentChatUsage.outputCostPer1kTokensInCents,
-  );
-  const totalCredits = inputCredits + outputCredits;
+  const totalCredits = agentChatUsage.inputCredits + agentChatUsage.outputCredits;
 
   return (
     <StyledContainer
@@ -179,14 +164,14 @@ export const AIChatContextUsageButton = () => {
               <StyledLabel>Input</StyledLabel>
               <StyledValue>
                 {formatTokenCount(agentChatUsage.inputTokens)} •{' '}
-                {inputCredits.toLocaleString()} credits
+                {agentChatUsage.inputCredits.toLocaleString()} credits
               </StyledValue>
             </StyledRow>
             <StyledRow>
               <StyledLabel>Output</StyledLabel>
               <StyledValue>
                 {formatTokenCount(agentChatUsage.outputTokens)} •{' '}
-                {outputCredits.toLocaleString()} credits
+                {agentChatUsage.outputCredits.toLocaleString()} credits
               </StyledValue>
             </StyledRow>
           </StyledBody>

--- a/packages/twenty-front/src/modules/ai/components/internal/ContextUsageProgressRing.tsx
+++ b/packages/twenty-front/src/modules/ai/components/internal/ContextUsageProgressRing.tsx
@@ -1,0 +1,64 @@
+import { useTheme } from '@emotion/react';
+import styled from '@emotion/styled';
+
+type ContextUsageProgressRingProps = {
+  percentage: number;
+  size?: number;
+  strokeWidth?: number;
+};
+
+const StyledSvg = styled.svg`
+  transform: rotate(-90deg);
+`;
+
+const StyledBackgroundCircle = styled.circle`
+  fill: none;
+  stroke: ${({ theme }) => theme.background.quaternary};
+`;
+
+const StyledProgressCircle = styled.circle`
+  fill: none;
+  transition: stroke-dashoffset 0.3s ease;
+`;
+
+export const ContextUsageProgressRing = ({
+  percentage,
+  size = 16,
+  strokeWidth = 2,
+}: ContextUsageProgressRingProps) => {
+  const theme = useTheme();
+
+  const normalizedPercentage = Math.min(Math.max(percentage, 0), 100);
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const strokeDashoffset =
+    circumference - (normalizedPercentage / 100) * circumference;
+
+  const progressColor =
+    normalizedPercentage > 80
+      ? theme.color.red
+      : normalizedPercentage > 60
+        ? theme.color.orange
+        : theme.color.blue;
+
+  return (
+    <StyledSvg width={size} height={size}>
+      <StyledBackgroundCircle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        strokeWidth={strokeWidth}
+      />
+      <StyledProgressCircle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        strokeWidth={strokeWidth}
+        stroke={progressColor}
+        strokeDasharray={circumference}
+        strokeDashoffset={strokeDashoffset}
+        strokeLinecap="round"
+      />
+    </StyledSvg>
+  );
+};

--- a/packages/twenty-front/src/modules/ai/graphql/queries/getChatThreads.ts
+++ b/packages/twenty-front/src/modules/ai/graphql/queries/getChatThreads.ts
@@ -5,6 +5,12 @@ export const GET_CHAT_THREADS = gql`
     chatThreads {
       id
       title
+      totalInputTokens
+      totalOutputTokens
+      totalTokens
+      contextWindowTokens
+      inputCostPer1kTokensInCents
+      outputCostPer1kTokensInCents
       createdAt
       updatedAt
     }

--- a/packages/twenty-front/src/modules/ai/graphql/queries/getChatThreads.ts
+++ b/packages/twenty-front/src/modules/ai/graphql/queries/getChatThreads.ts
@@ -7,10 +7,9 @@ export const GET_CHAT_THREADS = gql`
       title
       totalInputTokens
       totalOutputTokens
-      totalTokens
       contextWindowTokens
-      inputCostPer1kTokensInCents
-      outputCostPer1kTokensInCents
+      totalInputCredits
+      totalOutputCredits
       createdAt
       updatedAt
     }

--- a/packages/twenty-front/src/modules/ai/hooks/useAgentChat.ts
+++ b/packages/twenty-front/src/modules/ai/hooks/useAgentChat.ts
@@ -110,8 +110,8 @@ export const useAgentChat = (uiMessages: ExtendedUIMessage[]) => {
       type ModelMetadata = {
         modelId: string;
         contextWindowTokens: number;
-        inputCostPer1kTokens: number;
-        outputCostPer1kTokens: number;
+        inputCostPer1kTokensInCents: number;
+        outputCostPer1kTokensInCents: number;
       };
       const metadata = message.metadata as
         | { usage?: UsageMetadata; model?: ModelMetadata }
@@ -125,8 +125,8 @@ export const useAgentChat = (uiMessages: ExtendedUIMessage[]) => {
           outputTokens: (prev?.outputTokens ?? 0) + usage.outputTokens,
           totalTokens: (prev?.totalTokens ?? 0) + usage.totalTokens,
           contextWindowTokens: model.contextWindowTokens,
-          inputCostPer1kTokens: model.inputCostPer1kTokens,
-          outputCostPer1kTokens: model.outputCostPer1kTokens,
+          inputCostPer1kTokensInCents: model.inputCostPer1kTokensInCents,
+          outputCostPer1kTokensInCents: model.outputCostPer1kTokensInCents,
         }));
       }
     },

--- a/packages/twenty-front/src/modules/ai/hooks/useAgentChat.ts
+++ b/packages/twenty-front/src/modules/ai/hooks/useAgentChat.ts
@@ -105,13 +105,11 @@ export const useAgentChat = (uiMessages: ExtendedUIMessage[]) => {
       type UsageMetadata = {
         inputTokens: number;
         outputTokens: number;
-        totalTokens: number;
+        inputCredits: number;
+        outputCredits: number;
       };
       type ModelMetadata = {
-        modelId: string;
         contextWindowTokens: number;
-        inputCostPer1kTokensInCents: number;
-        outputCostPer1kTokensInCents: number;
       };
       const metadata = message.metadata as
         | { usage?: UsageMetadata; model?: ModelMetadata }
@@ -123,10 +121,11 @@ export const useAgentChat = (uiMessages: ExtendedUIMessage[]) => {
         setAgentChatUsage((prev) => ({
           inputTokens: (prev?.inputTokens ?? 0) + usage.inputTokens,
           outputTokens: (prev?.outputTokens ?? 0) + usage.outputTokens,
-          totalTokens: (prev?.totalTokens ?? 0) + usage.totalTokens,
+          totalTokens:
+            (prev?.totalTokens ?? 0) + usage.inputTokens + usage.outputTokens,
           contextWindowTokens: model.contextWindowTokens,
-          inputCostPer1kTokensInCents: model.inputCostPer1kTokensInCents,
-          outputCostPer1kTokensInCents: model.outputCostPer1kTokensInCents,
+          inputCredits: (prev?.inputCredits ?? 0) + usage.inputCredits,
+          outputCredits: (prev?.outputCredits ?? 0) + usage.outputCredits,
         }));
       }
     },

--- a/packages/twenty-front/src/modules/ai/hooks/useAgentChatData.ts
+++ b/packages/twenty-front/src/modules/ai/hooks/useAgentChatData.ts
@@ -1,20 +1,20 @@
 import { useAgentChatScrollToBottom } from '@/ai/hooks/useAgentChatScrollToBottom';
 import {
-    agentChatUsageState,
-    type AgentChatUsageState,
+  agentChatUsageState,
+  type AgentChatUsageState,
 } from '@/ai/states/agentChatUsageState';
 import { currentAIChatThreadState } from '@/ai/states/currentAIChatThreadState';
 import { mapDBMessagesToUIMessages } from '@/ai/utils/mapDBMessagesToUIMessages';
 import {
-    type SetterOrUpdater,
-    useRecoilState,
-    useSetRecoilState,
+  type SetterOrUpdater,
+  useRecoilState,
+  useSetRecoilState,
 } from 'recoil';
 import { isDefined } from 'twenty-shared/utils';
 import {
-    type AgentChatThread,
-    useGetChatMessagesQuery,
-    useGetChatThreadsQuery,
+  type AgentChatThread,
+  useGetChatMessagesQuery,
+  useGetChatThreadsQuery,
 } from '~/generated-metadata/graphql';
 
 const setUsageFromThread = (

--- a/packages/twenty-front/src/modules/ai/hooks/useAgentChatData.ts
+++ b/packages/twenty-front/src/modules/ai/hooks/useAgentChatData.ts
@@ -1,39 +1,38 @@
 import { useAgentChatScrollToBottom } from '@/ai/hooks/useAgentChatScrollToBottom';
 import {
-  agentChatUsageState,
-  type AgentChatUsageState,
+    agentChatUsageState,
+    type AgentChatUsageState,
 } from '@/ai/states/agentChatUsageState';
 import { currentAIChatThreadState } from '@/ai/states/currentAIChatThreadState';
 import { mapDBMessagesToUIMessages } from '@/ai/utils/mapDBMessagesToUIMessages';
 import {
-  type SetterOrUpdater,
-  useRecoilState,
-  useSetRecoilState,
+    type SetterOrUpdater,
+    useRecoilState,
+    useSetRecoilState,
 } from 'recoil';
 import { isDefined } from 'twenty-shared/utils';
 import {
-  type AgentChatThread,
-  useGetChatMessagesQuery,
-  useGetChatThreadsQuery,
+    type AgentChatThread,
+    useGetChatMessagesQuery,
+    useGetChatThreadsQuery,
 } from '~/generated-metadata/graphql';
 
 const setUsageFromThread = (
   thread: AgentChatThread,
   setAgentChatUsage: SetterOrUpdater<AgentChatUsageState | null>,
 ) => {
-  const hasUsageData =
-    thread.totalTokens > 0 && isDefined(thread.contextWindowTokens);
+  const totalTokens = thread.totalInputTokens + thread.totalOutputTokens;
+  const hasUsageData = totalTokens > 0 && isDefined(thread.contextWindowTokens);
 
   setAgentChatUsage(
     hasUsageData
       ? {
           inputTokens: thread.totalInputTokens,
           outputTokens: thread.totalOutputTokens,
-          totalTokens: thread.totalTokens,
+          totalTokens,
           contextWindowTokens: thread.contextWindowTokens ?? 0,
-          inputCostPer1kTokensInCents: thread.inputCostPer1kTokensInCents ?? 0,
-          outputCostPer1kTokensInCents:
-            thread.outputCostPer1kTokensInCents ?? 0,
+          inputCredits: thread.totalInputCredits,
+          outputCredits: thread.totalOutputCredits,
         }
       : null,
   );

--- a/packages/twenty-front/src/modules/ai/hooks/useCreateNewAIChatThread.ts
+++ b/packages/twenty-front/src/modules/ai/hooks/useCreateNewAIChatThread.ts
@@ -1,15 +1,18 @@
+import { agentChatUsageState } from '@/ai/states/agentChatUsageState';
 import { currentAIChatThreadState } from '@/ai/states/currentAIChatThreadState';
 import { useOpenAskAIPageInCommandMenu } from '@/command-menu/hooks/useOpenAskAIPageInCommandMenu';
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useSetRecoilState } from 'recoil';
 import { useCreateChatThreadMutation } from '~/generated-metadata/graphql';
 
 export const useCreateNewAIChatThread = () => {
   const [, setCurrentAIChatThread] = useRecoilState(currentAIChatThreadState);
+  const setAgentChatUsage = useSetRecoilState(agentChatUsageState);
 
   const { openAskAIPage } = useOpenAskAIPageInCommandMenu();
   const [createChatThread] = useCreateChatThreadMutation({
     onCompleted: (data) => {
       setCurrentAIChatThread(data.createChatThread.id);
+      setAgentChatUsage(null);
       openAskAIPage({ resetNavigationStack: false });
     },
   });

--- a/packages/twenty-front/src/modules/ai/states/agentChatUsageState.ts
+++ b/packages/twenty-front/src/modules/ai/states/agentChatUsageState.ts
@@ -5,8 +5,8 @@ export type AgentChatUsageState = {
   outputTokens: number;
   totalTokens: number;
   contextWindowTokens: number;
-  inputCostPer1kTokens: number;
-  outputCostPer1kTokens: number;
+  inputCostPer1kTokensInCents: number;
+  outputCostPer1kTokensInCents: number;
 };
 
 export const agentChatUsageState = atom<AgentChatUsageState | null>({

--- a/packages/twenty-front/src/modules/ai/states/agentChatUsageState.ts
+++ b/packages/twenty-front/src/modules/ai/states/agentChatUsageState.ts
@@ -1,0 +1,15 @@
+import { atom } from 'recoil';
+
+export type AgentChatUsageState = {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  contextWindowTokens: number;
+  inputCostPer1kTokens: number;
+  outputCostPer1kTokens: number;
+};
+
+export const agentChatUsageState = atom<AgentChatUsageState | null>({
+  key: 'agentChatUsageState',
+  default: null,
+});

--- a/packages/twenty-front/src/modules/ai/states/agentChatUsageState.ts
+++ b/packages/twenty-front/src/modules/ai/states/agentChatUsageState.ts
@@ -5,8 +5,8 @@ export type AgentChatUsageState = {
   outputTokens: number;
   totalTokens: number;
   contextWindowTokens: number;
-  inputCostPer1kTokensInCents: number;
-  outputCostPer1kTokensInCents: number;
+  inputCredits: number;
+  outputCredits: number;
 };
 
 export const agentChatUsageState = atom<AgentChatUsageState | null>({

--- a/packages/twenty-front/src/modules/ai/utils/__tests__/groupThreadsByDate.test.ts
+++ b/packages/twenty-front/src/modules/ai/utils/__tests__/groupThreadsByDate.test.ts
@@ -7,10 +7,9 @@ describe('groupThreadsByDate', () => {
     updatedAt: new Date().toISOString(),
     totalInputTokens: 0,
     totalOutputTokens: 0,
-    totalTokens: 0,
     contextWindowTokens: null,
-    inputCostPer1kTokensInCents: null,
-    outputCostPer1kTokensInCents: null,
+    totalInputCredits: 0,
+    totalOutputCredits: 0,
   };
 
   const today = new Date();

--- a/packages/twenty-front/src/modules/ai/utils/__tests__/groupThreadsByDate.test.ts
+++ b/packages/twenty-front/src/modules/ai/utils/__tests__/groupThreadsByDate.test.ts
@@ -5,6 +5,12 @@ describe('groupThreadsByDate', () => {
   const baseThread: Omit<AgentChatThread, 'createdAt' | 'id'> = {
     title: 'Test Thread',
     updatedAt: new Date().toISOString(),
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalTokens: 0,
+    contextWindowTokens: null,
+    inputCostPer1kTokensInCents: null,
+    outputCostPer1kTokensInCents: null,
   };
 
   const today = new Date();

--- a/packages/twenty-front/src/modules/ai/utils/convertCentsToBillingCredits.ts
+++ b/packages/twenty-front/src/modules/ai/utils/convertCentsToBillingCredits.ts
@@ -1,0 +1,5 @@
+// Matches the server-side conversion in twenty-server
+// 1 credit = $0.000001 (1 million credits per dollar)
+// Formula: credits = (cents / 100) * 1_000_000 = cents * 10_000
+export const convertCentsToBillingCredits = (cents: number): number =>
+  Math.round(cents * 10_000);

--- a/packages/twenty-front/src/modules/ai/utils/convertCentsToBillingCredits.ts
+++ b/packages/twenty-front/src/modules/ai/utils/convertCentsToBillingCredits.ts
@@ -1,5 +1,0 @@
-// Matches the server-side conversion in twenty-server
-// 1 credit = $0.000001 (1 million credits per dollar)
-// Formula: credits = (cents / 100) * 1_000_000 = cents * 10_000
-export const convertCentsToBillingCredits = (cents: number): number =>
-  Math.round(cents * 10_000);

--- a/packages/twenty-server/src/database/typeorm/core/migrations/common/1764700000000-add-usage-columns-to-agent-chat-thread.ts
+++ b/packages/twenty-server/src/database/typeorm/core/migrations/common/1764700000000-add-usage-columns-to-agent-chat-thread.ts
@@ -13,31 +13,25 @@ export class AddUsageColumnsToAgentChatThread1764700000000
       `ALTER TABLE "core"."agentChatThread" ADD COLUMN "totalOutputTokens" integer NOT NULL DEFAULT 0`,
     );
     await queryRunner.query(
-      `ALTER TABLE "core"."agentChatThread" ADD COLUMN "totalTokens" integer NOT NULL DEFAULT 0`,
-    );
-    await queryRunner.query(
       `ALTER TABLE "core"."agentChatThread" ADD COLUMN "contextWindowTokens" integer`,
     );
     await queryRunner.query(
-      `ALTER TABLE "core"."agentChatThread" ADD COLUMN "inputCostPer1kTokensInCents" numeric(10,6)`,
+      `ALTER TABLE "core"."agentChatThread" ADD COLUMN "totalInputCredits" bigint NOT NULL DEFAULT 0`,
     );
     await queryRunner.query(
-      `ALTER TABLE "core"."agentChatThread" ADD COLUMN "outputCostPer1kTokensInCents" numeric(10,6)`,
+      `ALTER TABLE "core"."agentChatThread" ADD COLUMN "totalOutputCredits" bigint NOT NULL DEFAULT 0`,
     );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `ALTER TABLE "core"."agentChatThread" DROP COLUMN "outputCostPer1kTokensInCents"`,
+      `ALTER TABLE "core"."agentChatThread" DROP COLUMN "totalOutputCredits"`,
     );
     await queryRunner.query(
-      `ALTER TABLE "core"."agentChatThread" DROP COLUMN "inputCostPer1kTokensInCents"`,
+      `ALTER TABLE "core"."agentChatThread" DROP COLUMN "totalInputCredits"`,
     );
     await queryRunner.query(
       `ALTER TABLE "core"."agentChatThread" DROP COLUMN "contextWindowTokens"`,
-    );
-    await queryRunner.query(
-      `ALTER TABLE "core"."agentChatThread" DROP COLUMN "totalTokens"`,
     );
     await queryRunner.query(
       `ALTER TABLE "core"."agentChatThread" DROP COLUMN "totalOutputTokens"`,

--- a/packages/twenty-server/src/database/typeorm/core/migrations/common/1764700000000-add-usage-columns-to-agent-chat-thread.ts
+++ b/packages/twenty-server/src/database/typeorm/core/migrations/common/1764700000000-add-usage-columns-to-agent-chat-thread.ts
@@ -1,0 +1,49 @@
+import { type MigrationInterface, type QueryRunner } from 'typeorm';
+
+export class AddUsageColumnsToAgentChatThread1764700000000
+  implements MigrationInterface
+{
+  name = 'AddUsageColumnsToAgentChatThread1764700000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "core"."agentChatThread" ADD COLUMN "totalInputTokens" integer NOT NULL DEFAULT 0`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."agentChatThread" ADD COLUMN "totalOutputTokens" integer NOT NULL DEFAULT 0`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."agentChatThread" ADD COLUMN "totalTokens" integer NOT NULL DEFAULT 0`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."agentChatThread" ADD COLUMN "contextWindowTokens" integer`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."agentChatThread" ADD COLUMN "inputCostPer1kTokensInCents" numeric(10,6)`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."agentChatThread" ADD COLUMN "outputCostPer1kTokensInCents" numeric(10,6)`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "core"."agentChatThread" DROP COLUMN "outputCostPer1kTokensInCents"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."agentChatThread" DROP COLUMN "inputCostPer1kTokensInCents"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."agentChatThread" DROP COLUMN "contextWindowTokens"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."agentChatThread" DROP COLUMN "totalTokens"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."agentChatThread" DROP COLUMN "totalOutputTokens"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."agentChatThread" DROP COLUMN "totalInputTokens"`,
+    );
+  }
+}

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-billing/constants/dollar-to-credit-multiplier.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-billing/constants/dollar-to-credit-multiplier.ts
@@ -1,2 +1,2 @@
 // Configuration: $0.00001 = 1 credit
-export const DOLLAR_TO_CREDIT_MULTIPLIER = 1000000; // 1 / 0.000001 = 1000000 credits per dollar
+export const DOLLAR_TO_CREDIT_MULTIPLIER = 1_000_000; // 1 / 0.000001 = 1 000 000 credits per dollar

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/dtos/agent-chat-thread.dto.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/dtos/agent-chat-thread.dto.ts
@@ -1,4 +1,4 @@
-import { Field, Float, Int, ObjectType } from '@nestjs/graphql';
+import { Field, Int, ObjectType } from '@nestjs/graphql';
 
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 
@@ -16,17 +16,14 @@ export class AgentChatThreadDTO {
   @Field(() => Int)
   totalOutputTokens: number;
 
-  @Field(() => Int)
-  totalTokens: number;
-
   @Field(() => Int, { nullable: true })
   contextWindowTokens: number | null;
 
-  @Field(() => Float, { nullable: true })
-  inputCostPer1kTokensInCents: number | null;
+  @Field(() => Int)
+  totalInputCredits: number;
 
-  @Field(() => Float, { nullable: true })
-  outputCostPer1kTokensInCents: number | null;
+  @Field(() => Int)
+  totalOutputCredits: number;
 
   @Field()
   createdAt: Date;

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/dtos/agent-chat-thread.dto.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/dtos/agent-chat-thread.dto.ts
@@ -1,4 +1,4 @@
-import { Field, ObjectType } from '@nestjs/graphql';
+import { Field, Float, Int, ObjectType } from '@nestjs/graphql';
 
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 
@@ -9,6 +9,24 @@ export class AgentChatThreadDTO {
 
   @Field({ nullable: true })
   title: string;
+
+  @Field(() => Int)
+  totalInputTokens: number;
+
+  @Field(() => Int)
+  totalOutputTokens: number;
+
+  @Field(() => Int)
+  totalTokens: number;
+
+  @Field(() => Int, { nullable: true })
+  contextWindowTokens: number | null;
+
+  @Field(() => Float, { nullable: true })
+  inputCostPer1kTokensInCents: number | null;
+
+  @Field(() => Float, { nullable: true })
+  outputCostPer1kTokensInCents: number | null;
 
   @Field()
   createdAt: Date;

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/entities/agent-chat-thread.entity.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/entities/agent-chat-thread.entity.ts
@@ -1,13 +1,13 @@
 import {
-  Column,
-  CreateDateColumn,
-  Entity,
-  Index,
-  JoinColumn,
-  ManyToOne,
-  OneToMany,
-  PrimaryGeneratedColumn,
-  UpdateDateColumn,
+    Column,
+    CreateDateColumn,
+    Entity,
+    Index,
+    JoinColumn,
+    ManyToOne,
+    OneToMany,
+    PrimaryGeneratedColumn,
+    UpdateDateColumn,
 } from 'typeorm';
 
 import { Relation } from 'src/engine/workspace-manager/workspace-sync-metadata/interfaces/relation.interface';
@@ -40,17 +40,14 @@ export class AgentChatThreadEntity {
   @Column({ type: 'int', default: 0 })
   totalOutputTokens: number;
 
-  @Column({ type: 'int', default: 0 })
-  totalTokens: number;
-
   @Column({ type: 'int', nullable: true })
   contextWindowTokens: number | null;
 
-  @Column({ type: 'decimal', precision: 10, scale: 6, nullable: true })
-  inputCostPer1kTokensInCents: number | null;
+  @Column({ type: 'bigint', default: 0 })
+  totalInputCredits: number;
 
-  @Column({ type: 'decimal', precision: 10, scale: 6, nullable: true })
-  outputCostPer1kTokensInCents: number | null;
+  @Column({ type: 'bigint', default: 0 })
+  totalOutputCredits: number;
 
   @OneToMany(() => AgentTurnEntity, (turn) => turn.thread)
   turns: Relation<AgentTurnEntity[]>;

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/entities/agent-chat-thread.entity.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/entities/agent-chat-thread.entity.ts
@@ -1,13 +1,13 @@
 import {
-    Column,
-    CreateDateColumn,
-    Entity,
-    Index,
-    JoinColumn,
-    ManyToOne,
-    OneToMany,
-    PrimaryGeneratedColumn,
-    UpdateDateColumn,
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
 } from 'typeorm';
 
 import { Relation } from 'src/engine/workspace-manager/workspace-sync-metadata/interfaces/relation.interface';

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/entities/agent-chat-thread.entity.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/entities/agent-chat-thread.entity.ts
@@ -34,6 +34,24 @@ export class AgentChatThreadEntity {
   @Column({ nullable: true, type: 'varchar' })
   title: string;
 
+  @Column({ type: 'int', default: 0 })
+  totalInputTokens: number;
+
+  @Column({ type: 'int', default: 0 })
+  totalOutputTokens: number;
+
+  @Column({ type: 'int', default: 0 })
+  totalTokens: number;
+
+  @Column({ type: 'int', nullable: true })
+  contextWindowTokens: number | null;
+
+  @Column({ type: 'decimal', precision: 10, scale: 6, nullable: true })
+  inputCostPer1kTokensInCents: number | null;
+
+  @Column({ type: 'decimal', precision: 10, scale: 6, nullable: true })
+  outputCostPer1kTokensInCents: number | null;
+
   @OneToMany(() => AgentTurnEntity, (turn) => turn.thread)
   turns: Relation<AgentTurnEntity[]>;
 

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/agent-chat-streaming.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/agent-chat-streaming.service.ts
@@ -102,7 +102,8 @@ export class AgentChatStreamingService {
                     model: {
                       modelId: modelConfig.modelId,
                       contextWindowTokens: modelConfig.contextWindowTokens,
-                      inputCostPer1kTokens: modelConfig.inputCostPer1kTokensInCents,
+                      inputCostPer1kTokens:
+                        modelConfig.inputCostPer1kTokensInCents,
                       outputCostPer1kTokens:
                         modelConfig.outputCostPer1kTokensInCents,
                     },

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/agent-chat-streaming.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/agent-chat-streaming.service.ts
@@ -102,9 +102,9 @@ export class AgentChatStreamingService {
                     model: {
                       modelId: modelConfig.modelId,
                       contextWindowTokens: modelConfig.contextWindowTokens,
-                      inputCostPer1kTokens:
+                      inputCostPer1kTokensInCents:
                         modelConfig.inputCostPer1kTokensInCents,
-                      outputCostPer1kTokens:
+                      outputCostPer1kTokensInCents:
                         modelConfig.outputCostPer1kTokensInCents,
                     },
                   };

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/chat-execution.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-chat/services/chat-execution.service.ts
@@ -34,7 +34,10 @@ import { type BrowsingContextType } from 'src/engine/metadata-modules/ai/ai-agen
 import { repairToolCall } from 'src/engine/metadata-modules/ai/ai-agent/utils/repair-tool-call.util';
 import { AIBillingService } from 'src/engine/metadata-modules/ai/ai-billing/services/ai-billing.service';
 import { CHAT_SYSTEM_PROMPTS } from 'src/engine/metadata-modules/ai/ai-chat/constants/chat-system-prompts.const';
-import { ModelProvider } from 'src/engine/metadata-modules/ai/ai-models/constants/ai-models.const';
+import {
+  type AIModelConfig,
+  ModelProvider,
+} from 'src/engine/metadata-modules/ai/ai-models/constants/ai-models.const';
 import { AI_TELEMETRY_CONFIG } from 'src/engine/metadata-modules/ai/ai-models/constants/ai-telemetry.const';
 import { AiModelRegistryService } from 'src/engine/metadata-modules/ai/ai-models/services/ai-model-registry.service';
 
@@ -48,6 +51,7 @@ export type ChatExecutionOptions = {
 export type ChatExecutionResult = {
   stream: ReturnType<typeof streamText>;
   preloadedTools: string[];
+  modelConfig: AIModelConfig;
 };
 
 // Common tools to pre-load for quick access
@@ -108,6 +112,10 @@ export class ChatExecutionService {
 
     const registeredModel =
       this.aiModelRegistryService.getDefaultPerformanceModel();
+
+    const modelConfig = this.aiModelRegistryService.getEffectiveModelConfig(
+      registeredModel.modelId,
+    );
 
     const activeTools: ToolSet = {
       ...preloadedTools,
@@ -181,6 +189,7 @@ export class ChatExecutionService {
     return {
       stream,
       preloadedTools: preloadedToolNames,
+      modelConfig,
     };
   }
 

--- a/packages/twenty-shared/src/ai/index.ts
+++ b/packages/twenty-shared/src/ai/index.ts
@@ -8,10 +8,15 @@
  */
 
 export type {
-  AgentResponseFieldType,
-  AgentResponseSchema,
+    AgentResponseFieldType,
+    AgentResponseSchema
 } from './types/agent-response-schema.type';
 export type { DataMessagePart } from './types/DataMessagePart';
-export type { ExtendedUIMessage } from './types/ExtendedUIMessage';
+export type {
+    AIChatModelMetadata,
+    AIChatUsageMetadata,
+    ExtendedUIMessage
+} from './types/ExtendedUIMessage';
 export type { ExtendedUIMessagePart } from './types/ExtendedUIMessagePart';
 export type { ModelConfiguration } from './types/model-configuration.type';
+

--- a/packages/twenty-shared/src/ai/index.ts
+++ b/packages/twenty-shared/src/ai/index.ts
@@ -8,15 +8,14 @@
  */
 
 export type {
-    AgentResponseFieldType,
-    AgentResponseSchema
+  AgentResponseFieldType,
+  AgentResponseSchema,
 } from './types/agent-response-schema.type';
 export type { DataMessagePart } from './types/DataMessagePart';
 export type {
-    AIChatModelMetadata,
-    AIChatUsageMetadata,
-    ExtendedUIMessage
+  AIChatUsageMetadata,
+  AIChatModelMetadata,
+  ExtendedUIMessage,
 } from './types/ExtendedUIMessage';
 export type { ExtendedUIMessagePart } from './types/ExtendedUIMessagePart';
 export type { ModelConfiguration } from './types/model-configuration.type';
-

--- a/packages/twenty-shared/src/ai/types/ExtendedUIMessage.ts
+++ b/packages/twenty-shared/src/ai/types/ExtendedUIMessage.ts
@@ -1,8 +1,23 @@
 import { type DataMessagePart } from '@/ai/types/DataMessagePart';
 import { type UIMessage } from 'ai';
 
+export type AIChatUsageMetadata = {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+};
+
+export type AIChatModelMetadata = {
+  modelId: string;
+  contextWindowTokens: number;
+  inputCostPer1kTokens: number;
+  outputCostPer1kTokens: number;
+};
+
 type Metadata = {
   createdAt: string;
+  usage?: AIChatUsageMetadata;
+  model?: AIChatModelMetadata;
 };
 
 export type ExtendedUIMessage = UIMessage<Metadata, DataMessagePart>;

--- a/packages/twenty-shared/src/ai/types/ExtendedUIMessage.ts
+++ b/packages/twenty-shared/src/ai/types/ExtendedUIMessage.ts
@@ -10,8 +10,8 @@ export type AIChatUsageMetadata = {
 export type AIChatModelMetadata = {
   modelId: string;
   contextWindowTokens: number;
-  inputCostPer1kTokens: number;
-  outputCostPer1kTokens: number;
+  inputCostPer1kTokensInCents: number;
+  outputCostPer1kTokensInCents: number;
 };
 
 type Metadata = {

--- a/packages/twenty-shared/src/ai/types/ExtendedUIMessage.ts
+++ b/packages/twenty-shared/src/ai/types/ExtendedUIMessage.ts
@@ -4,14 +4,12 @@ import { type UIMessage } from 'ai';
 export type AIChatUsageMetadata = {
   inputTokens: number;
   outputTokens: number;
-  totalTokens: number;
+  inputCredits: number;
+  outputCredits: number;
 };
 
 export type AIChatModelMetadata = {
-  modelId: string;
   contextWindowTokens: number;
-  inputCostPer1kTokensInCents: number;
-  outputCostPer1kTokensInCents: number;
 };
 
 type Metadata = {


### PR DESCRIPTION
## Summary

- Add a context usage indicator to the AI chat interface inspired by Vercel's AI SDK Context component
- Display token consumption, context window utilization percentage, and estimated cost in credits
- Show a circular progress ring with percentage, revealing detailed breakdown on hover

## Changes

### Backend
- Stream usage metadata (tokens, model config) via `messageMetadata` callback in `agent-chat-streaming.service.ts`
- Return model config from `chat-execution.service.ts`
- Add usage and model types to `ExtendedUIMessage` metadata

### Frontend
- New `ContextUsageProgressRing` component - circular SVG progress indicator
- New `AIChatContextUsageButton` component with hover card showing:
  - Progress bar with used/total tokens
  - Input/output token counts with credit costs
  - Total credits consumed
- Track cumulative usage in Recoil state (`agentChatUsageState`)
- Reset usage when creating new chat thread
- Integrate button into `AIChatTab`

## Test plan

- [ ] Open AI chat and send a message
- [ ] Verify the context usage button appears with percentage
- [ ] Hover over the button to see detailed breakdown
- [ ] Verify credits are calculated correctly
- [ ] Create a new chat thread and verify usage resets to 0