### PR TITLE
fix: ensure deactivated object records do not appear in search

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/search/services/search.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/search/services/search.service.ts
@@ -130,19 +130,24 @@ export class SearchService {
     includedObjectNameSingulars: string[];
     excludedObjectNameSingulars: string[];
   }) {
-    return flatObjectMetadatas.filter(({ nameSingular, isSearchable }) => {
-      if (!isSearchable) {
-        return false;
-      }
-      if (excludedObjectNameSingulars.includes(nameSingular)) {
-        return false;
-      }
-      if (includedObjectNameSingulars.length > 0) {
-        return includedObjectNameSingulars.includes(nameSingular);
-      }
+    return flatObjectMetadatas.filter(
+      ({ nameSingular, isSearchable, isActive }) => {
+        if (!isSearchable) {
+          return false;
+        }
+        if (!isActive) {
+          return false;
+        }
+        if (excludedObjectNameSingulars.includes(nameSingular)) {
+          return false;
+        }
+        if (includedObjectNameSingulars.length > 0) {
+          return includedObjectNameSingulars.includes(nameSingular);
+        }
 
-      return true;
-    });
+        return true;
+      },
+    );
   }
 
   async buildSearchQueryAndGetRecords<Entity extends ObjectLiteral>({


### PR DESCRIPTION
Deactivating an object still allowed querying its records in search.

<img width="1512" height="856" alt="image" src="https://github.com/user-attachments/assets/0a1ba36f-1ecf-44d3-8e97-294bb4e81e4f" />

<br />
<br />

This PR introduces a minor improvement to not query records of deactivated objects.

<img width="1512" height="856" alt="image" src="https://github.com/user-attachments/assets/f5fd1377-2fda-4653-b3cc-30a59d52e4cf" />
