### PR TITLE
Fix rest metadata version missing

### DIFF
--- a/packages/twenty-server/src/engine/middlewares/middleware.service.ts
+++ b/packages/twenty-server/src/engine/middlewares/middleware.service.ts
@@ -106,18 +106,6 @@ export class MiddlewareService {
         )
       : undefined;
 
-    if (metadataVersion === undefined && isDefined(data.workspace)) {
-      await this.flatEntityMapsCacheService.invalidateFlatEntityMaps({
-        workspaceId: data.workspace.id,
-        flatMapsKeys: [
-          'flatObjectMetadataMaps',
-          'flatFieldMetadataMaps',
-          'flatIndexMaps',
-        ],
-      });
-      throw new Error('Metadata cache version not found');
-    }
-
     const dataSourcesMetadata = data.workspace
       ? await this.dataSourceService.getDataSourcesMetadataFromWorkspaceId(
           data.workspace.id,


### PR DESCRIPTION
## Context

The REST pipeline re-fetches/sets the metadata version later in RestApiBaseHandler#getObjectMetadata by reading from DB and seeding the cache if it’s missing. That’s the place that actually needs it and already handles the “undefined” case.

This also mirror the graphql path that was updated 3 weeks ago