### PR TITLE
Fix APIKey in search resolver for get role

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/search/search.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/search/search.resolver.ts
@@ -3,6 +3,7 @@ import { Args, Query, Resolver } from '@nestjs/graphql';
 
 import { isDefined } from 'twenty-shared/utils';
 
+import { ApiKeyEntity } from 'src/engine/core-modules/api-key/api-key.entity';
 import { ApiKeyRoleService } from 'src/engine/core-modules/api-key/services/api-key-role.service';
 import { PreventNestToAutoLogGraphqlErrorsFilter } from 'src/engine/core-modules/graphql/filters/prevent-nest-to-auto-log-graphql-errors.filter';
 import { ResolverValidationPipe } from 'src/engine/core-modules/graphql/pipes/resolver-validation.pipe';
@@ -36,7 +37,7 @@ export class SearchResolver {
   async search(
     @AuthWorkspace() workspace: WorkspaceEntity,
     @AuthUserWorkspaceId() userWorkspaceId: string | undefined,
-    @AuthApiKey() apiKey: string | undefined,
+    @AuthApiKey() apiKey: ApiKeyEntity | undefined,
     @Args()
     {
       searchInput,
@@ -71,7 +72,7 @@ export class SearchResolver {
 
     if (isDefined(apiKey)) {
       const roleId = await this.apiKeyRoleService.getRoleIdForApiKey(
-        apiKey,
+        apiKey.id,
         workspace.id,
       );
 


### PR DESCRIPTION
Fixes https://github.com/twentyhq/twenty/issues/16534

Typing was wrong, apiKey from request object is ApiKeyEntity and not a string which was then failing when using 
```typescript
const roleId = apiKeyRoleMap[apiKeyId];

    if (!isDefined(roleId)) {
      throw new ApiKeyException(
        `API key ${apiKeyId} has no role assigned`,
        ApiKeyExceptionCode.API_KEY_NO_ROLE_ASSIGNED,
      );
    }
```

error
```
API key [object Object] has no role assigned"
```

## Before
<img width="963" height="316" alt="Screenshot 2025-12-12 at 17 37 06" src="https://github.com/user-attachments/assets/761a75c6-1bac-48d7-b8cd-3356e9a56028" />

## After
<img width="905" height="313" alt="Screenshot 2025-12-12 at 17 36 44" src="https://github.com/user-attachments/assets/475b7106-713c-408e-99d0-1447599f7152" />

