### PR TITLE
fix(workflows): align variable regex with validation and prevent ReDoS

### DIFF
--- a/packages/twenty-shared/src/utils/variable-resolver.ts
+++ b/packages/twenty-shared/src/utils/variable-resolver.ts
@@ -8,7 +8,7 @@ const isString = (value: any): value is string => {
   return typeof value === 'string';
 };
 
-const VARIABLE_PATTERN = RegExp('\\{\\{(.*?)\\}\\}', 'g');
+const VARIABLE_PATTERN = RegExp('\\{\\{([^{}]+)\\}\\}', 'g');
 
 export const resolveInput = (
   unresolvedInput: unknown,


### PR DESCRIPTION
**What this fixes:**
- Addresses a CodeQL security finding: the regex used to find variables in workflow strings could be slow on malicious inputs (ReDoS).
- Two alerts: [Code Scanning 181](https://github.com/twentyhq/twenty/security/code-scanning/181) and [Code Scanning 182](https://github.com/twentyhq/twenty/security/code-scanning/182)

**Context:**
- Our workflow system lets users insert variables like `{{user.name}}` or `{{trigger.properties.after.name}}` into strings and JSON (HTTP request bodies, record field values, etc.).
- The `variable-resolver.ts` module scans these strings and replaces variables with actual values.
- Our validation (`isValidVariable`) already enforces that variables contain no `{` or `}` inside them (only simple property paths like `user.name`).

**The change:**
- Updated the regex from `/\{\{(.*?)\}\}/g` to `/\{\{([^{}]+)\}\}/g` to match our validation pattern.
- This removes the ReDoS risk and aligns the resolver with the validation contract.

**Why this is safe:**
- All supported workflow usage (simple variable paths) continues to work.
- Both `match` and `replace` behave the same for valid variables.
- Only unsupported patterns with nested braces (e.g., `{{foo {bar}}}`) would stop matching, which isn't part of our supported syntax anyway.