### PR TITLE
Second Action Button - fix

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/hooks/useGetSecondaryRecordTableCellButton.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/hooks/useGetSecondaryRecordTableCellButton.ts
@@ -32,9 +32,12 @@ export const useGetSecondaryRecordTableCellButton = () => {
     return [];
   }
 
+  const mainActionOnClick =
+    fieldDefinition.metadata.settings?.clickAction ||
+    FieldMetadataSettingsOnClickAction.OPEN_LINK;
+
   const secondaryActionOnClick =
-    fieldDefinition.metadata.settings?.clickAction ===
-    FieldMetadataSettingsOnClickAction.OPEN_LINK
+    mainActionOnClick === FieldMetadataSettingsOnClickAction.OPEN_LINK
       ? FieldMetadataSettingsOnClickAction.COPY
       : FieldMetadataSettingsOnClickAction.OPEN_LINK;
 

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/hooks/useGetSecondaryRecordTableCellButton.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-cell/hooks/useGetSecondaryRecordTableCellButton.ts
@@ -33,7 +33,7 @@ export const useGetSecondaryRecordTableCellButton = () => {
   }
 
   const mainActionOnClick =
-    fieldDefinition.metadata.settings?.clickAction ||
+    fieldDefinition.metadata.settings?.clickAction ??
     FieldMetadataSettingsOnClickAction.OPEN_LINK;
 
   const secondaryActionOnClick =


### PR DESCRIPTION
Merged https://github.com/twentyhq/twenty/pull/16582 without testing case when fieldDefinition.metadata.settings?.clickAction is not set (default value)

To test : 
When 
<img width="548" height="537" alt="Screenshot 2025-12-17 at 09 37 26" src="https://github.com/user-attachments/assets/96a85093-24bb-4436-9000-340cd020e343" />
is set (or default)
In table view you can copy cell content
<img width="252" height="77" alt="Screenshot 2025-12-17 at 09 36 58" src="https://github.com/user-attachments/assets/44b938f3-74b8-4d58-8b1a-344b4f39bfbd" />
