### PR TITLE
fix: remove section scrolling in filter menu (#16637)

### DIFF
--- a/packages/twenty-front/src/modules/views/components/ViewBarFilterDropdownFieldSelectMenu.tsx
+++ b/packages/twenty-front/src/modules/views/components/ViewBarFilterDropdownFieldSelectMenu.tsx
@@ -51,6 +51,14 @@ export const StyledInput = styled.input`
   }
 `;
 
+const ScrollableContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+  overflow-y: auto;
+`;
+
 export const ViewBarFilterDropdownFieldSelectMenu = () => {
   const [objectFilterDropdownSearchInput, setObjectFilterDropdownSearchInput] =
     useRecoilComponentState(objectFilterDropdownSearchInputComponentState);
@@ -112,10 +120,11 @@ export const ViewBarFilterDropdownFieldSelectMenu = () => {
         selectableListInstanceId={FILTER_FIELD_LIST_ID}
         focusId={VIEW_BAR_FILTER_DROPDOWN_ID}
       >
+      <ScrollableContainer>
         {shouldShowVisibleFields && (
           <>
             <DropdownMenuSectionLabel label={t`Visible fields`} />
-            <DropdownMenuItemsContainer>
+            <DropdownMenuItemsContainer scrollable={false}>
               {selectableVisibleFieldMetadataItems.map(
                 (visibleFieldMetadataItem) => (
                   <ViewBarFilterDropdownFieldSelectMenuItem
@@ -131,7 +140,7 @@ export const ViewBarFilterDropdownFieldSelectMenu = () => {
         {shouldShowHiddenFields && (
           <>
             <DropdownMenuSectionLabel label={t`Hidden fields`} />
-            <DropdownMenuItemsContainer>
+            <DropdownMenuItemsContainer scrollable={false}>
               {selectableHiddenFieldMetadataItems.map(
                 (hiddenFieldMetadataItem) => (
                   <ViewBarFilterDropdownFieldSelectMenuItem
@@ -145,6 +154,7 @@ export const ViewBarFilterDropdownFieldSelectMenu = () => {
         )}
         {hasSelectableItems && <DropdownMenuSeparator />}
         <ViewBarFilterDropdownBottomMenu />
+      </ScrollableContainer>
       </SelectableList>
     </DropdownContent>
   );


### PR DESCRIPTION
Description: This PR removes the independent scrolling of sections ("Visible fields", "Hidden fields") in the filter menu, replacing it with a single scrollable container for the entire menu.

Fixes: #16637

Changes:

Wrapped field list sections in a ScrollableContainer with overflow-y: auto.
Disabled scrolling on inner DropdownMenuItemsContainer components.
Verification:

Verified visually in Storybook that the menu now scrolls as a single unit.
Linting checks passed.