### PR TITLE
feat: add "Created by: Me" filter for ACTOR workspaceMemberId subfield

### DIFF
--- a/packages/twenty-front/src/modules/object-record/advanced-filter/components/AdvancedFilterDropdownFilterInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/advanced-filter/components/AdvancedFilterDropdownFilterInput.tsx
@@ -3,6 +3,7 @@ import { ObjectFilterDropdownRatingInput } from '@/object-record/object-filter-d
 import { ObjectFilterDropdownRecordSelect } from '@/object-record/object-filter-dropdown/components/ObjectFilterDropdownRecordSelect';
 import { ObjectFilterDropdownSearchInput } from '@/object-record/object-filter-dropdown/components/ObjectFilterDropdownSearchInput';
 import { ObjectFilterDropdownSourceSelect } from '@/object-record/object-filter-dropdown/components/ObjectFilterDropdownSourceSelect';
+import { ObjectFilterDropdownWorkspaceMemberSelect } from '@/object-record/object-filter-dropdown/components/ObjectFilterDropdownWorkspaceMemberSelect';
 import { DropdownMenuSeparator } from '@/ui/layout/dropdown/components/DropdownMenuSeparator';
 
 import { AdvancedFilterDropdownTextInput } from '@/object-record/advanced-filter/components/AdvancedFilterDropdownTextInput';
@@ -14,6 +15,7 @@ import { ObjectFilterDropdownDateTimeInput } from '@/object-record/object-filter
 import { ObjectFilterDropdownTextInput } from '@/object-record/object-filter-dropdown/components/ObjectFilterDropdownTextInput';
 import { subFieldNameUsedInDropdownComponentState } from '@/object-record/object-filter-dropdown/states/subFieldNameUsedInDropdownComponentState';
 import { isFilterOnActorSourceSubField } from '@/object-record/object-filter-dropdown/utils/isFilterOnActorSourceSubField';
+import { isFilterOnActorWorkspaceMemberSubField } from '@/object-record/object-filter-dropdown/utils/isFilterOnActorWorkspaceMemberSubField';
 import { type RecordFilter } from '@/object-record/record-filter/types/RecordFilter';
 import { DropdownContent } from '@/ui/layout/dropdown/components/DropdownContent';
 import { GenericDropdownContentWidth } from '@/ui/layout/dropdown/constants/GenericDropdownContentWidth';
@@ -39,6 +41,9 @@ export const AdvancedFilterDropdownFilterInput = ({
   const isActorSourceCompositeFilter = isFilterOnActorSourceSubField(
     subFieldNameUsedInDropdown,
   );
+
+  const isActorWorkspaceMemberCompositeFilter =
+    isFilterOnActorWorkspaceMemberSubField(subFieldNameUsedInDropdown);
 
   return (
     <>
@@ -68,6 +73,17 @@ export const AdvancedFilterDropdownFilterInput = ({
       {filterType === 'ACTOR' &&
         (isActorSourceCompositeFilter ? (
           <ObjectFilterDropdownSourceSelect dropdownId={filterDropdownId} />
+        ) : isActorWorkspaceMemberCompositeFilter ? (
+          <DropdownContent
+            widthInPixels={GenericDropdownContentWidth.ExtraLarge}
+          >
+            <ObjectFilterDropdownSearchInput />
+            <DropdownMenuSeparator />
+            <ObjectFilterDropdownWorkspaceMemberSelect
+              recordFilterId={recordFilter.id}
+              dropdownId={filterDropdownId}
+            />
+          </DropdownContent>
         ) : (
           <ObjectFilterDropdownTextInput />
         ))}

--- a/packages/twenty-front/src/modules/object-record/advanced-filter/components/AdvancedFilterDropdownFilterInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/advanced-filter/components/AdvancedFilterDropdownFilterInput.tsx
@@ -34,6 +34,7 @@ export const AdvancedFilterDropdownFilterInput = ({
 }: AdvancedFilterDropdownFilterInputProps) => {
   const subFieldNameUsedInDropdown = useRecoilComponentValue(
     subFieldNameUsedInDropdownComponentState,
+    filterDropdownId,
   );
 
   const filterType = recordFilter.type;

--- a/packages/twenty-front/src/modules/object-record/object-filter-dropdown/components/ObjectFilterDropdownFilterInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-filter-dropdown/components/ObjectFilterDropdownFilterInput.tsx
@@ -4,6 +4,7 @@ import { ObjectFilterDropdownOptionSelect } from '@/object-record/object-filter-
 import { ObjectFilterDropdownRatingInput } from '@/object-record/object-filter-dropdown/components/ObjectFilterDropdownRatingInput';
 import { ObjectFilterDropdownRecordSelect } from '@/object-record/object-filter-dropdown/components/ObjectFilterDropdownRecordSelect';
 import { ObjectFilterDropdownSearchInput } from '@/object-record/object-filter-dropdown/components/ObjectFilterDropdownSearchInput';
+import { ObjectFilterDropdownWorkspaceMemberSelect } from '@/object-record/object-filter-dropdown/components/ObjectFilterDropdownWorkspaceMemberSelect';
 import { DropdownMenuSeparator } from '@/ui/layout/dropdown/components/DropdownMenuSeparator';
 
 import { ViewFilterOperand } from 'twenty-shared/types';
@@ -17,6 +18,8 @@ import { NUMBER_FILTER_TYPES } from '@/object-record/object-filter-dropdown/cons
 import { TEXT_FILTER_TYPES } from '@/object-record/object-filter-dropdown/constants/TextFilterTypes';
 import { fieldMetadataItemUsedInDropdownComponentSelector } from '@/object-record/object-filter-dropdown/states/fieldMetadataItemUsedInDropdownComponentSelector';
 import { selectedOperandInDropdownComponentState } from '@/object-record/object-filter-dropdown/states/selectedOperandInDropdownComponentState';
+import { subFieldNameUsedInDropdownComponentState } from '@/object-record/object-filter-dropdown/states/subFieldNameUsedInDropdownComponentState';
+import { isFilterOnActorWorkspaceMemberSubField } from '@/object-record/object-filter-dropdown/utils/isFilterOnActorWorkspaceMemberSubField';
 import { useRecoilComponentValue } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValue';
 import { getFilterTypeFromFieldType, isDefined } from 'twenty-shared/utils';
 
@@ -36,6 +39,11 @@ export const ObjectFilterDropdownFilterInput = ({
 
   const selectedOperandInDropdown = useRecoilComponentValue(
     selectedOperandInDropdownComponentState,
+    filterDropdownId,
+  );
+
+  const subFieldNameUsedInDropdown = useRecoilComponentValue(
+    subFieldNameUsedInDropdownComponentState,
     filterDropdownId,
   );
 
@@ -115,7 +123,21 @@ export const ObjectFilterDropdownFilterInput = ({
             />
           </>
         )}
-        {filterType === 'ACTOR' && <ObjectFilterDropdownTextInput />}
+        {filterType === 'ACTOR' &&
+          (isFilterOnActorWorkspaceMemberSubField(
+            subFieldNameUsedInDropdown,
+          ) ? (
+            <>
+              <ObjectFilterDropdownSearchInput />
+              <DropdownMenuSeparator />
+              <ObjectFilterDropdownWorkspaceMemberSelect
+                recordFilterId={recordFilterId}
+                dropdownId={filterDropdownId}
+              />
+            </>
+          ) : (
+            <ObjectFilterDropdownTextInput />
+          ))}
         {filterType === 'ADDRESS' && <ObjectFilterDropdownTextInput />}
         {filterType === 'CURRENCY' && <ObjectFilterDropdownNumberInput />}
         {['SELECT', 'MULTI_SELECT'].includes(filterType) && (

--- a/packages/twenty-front/src/modules/object-record/object-filter-dropdown/components/ObjectFilterDropdownWorkspaceMemberSelect.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-filter-dropdown/components/ObjectFilterDropdownWorkspaceMemberSelect.tsx
@@ -13,9 +13,9 @@ import { DropdownMenuSeparator } from '@/ui/layout/dropdown/components/DropdownM
 import { useRecoilComponentValue } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValue';
 import { type RelationFilterValue } from '@/views/view-filter-value/types/RelationFilterValue';
 import {
-    arrayOfUuidOrVariableSchema,
-    isDefined,
-    jsonRelationFilterValueSchema,
+  arrayOfUuidOrVariableSchema,
+  isDefined,
+  jsonRelationFilterValueSchema,
 } from 'twenty-shared/utils';
 import { IconUserCircle } from 'twenty-ui/display';
 

--- a/packages/twenty-front/src/modules/object-record/object-filter-dropdown/components/ObjectFilterDropdownWorkspaceMemberSelect.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-filter-dropdown/components/ObjectFilterDropdownWorkspaceMemberSelect.tsx
@@ -1,0 +1,215 @@
+import { ObjectFilterDropdownRecordPinnedItems } from '@/object-record/object-filter-dropdown/components/ObjectFilterDropdownRecordPinnedItems';
+import { CURRENT_WORKSPACE_MEMBER_SELECTABLE_ITEM_ID } from '@/object-record/object-filter-dropdown/constants/CurrentWorkspaceMemberSelectableItemId';
+import { useApplyObjectFilterDropdownFilterValue } from '@/object-record/object-filter-dropdown/hooks/useApplyObjectFilterDropdownFilterValue';
+import { useObjectFilterDropdownFilterValue } from '@/object-record/object-filter-dropdown/hooks/useObjectFilterDropdownFilterValue';
+import { fieldMetadataItemUsedInDropdownComponentSelector } from '@/object-record/object-filter-dropdown/states/fieldMetadataItemUsedInDropdownComponentSelector';
+import { objectFilterDropdownSearchInputComponentState } from '@/object-record/object-filter-dropdown/states/objectFilterDropdownSearchInputComponentState';
+import { selectedOperandInDropdownComponentState } from '@/object-record/object-filter-dropdown/states/selectedOperandInDropdownComponentState';
+import { currentRecordFiltersComponentState } from '@/object-record/record-filter/states/currentRecordFiltersComponentState';
+import { MultipleSelectDropdown } from '@/object-record/select/components/MultipleSelectDropdown';
+import { useRecordsForSelect } from '@/object-record/select/hooks/useRecordsForSelect';
+import { type SelectableItem } from '@/object-record/select/types/SelectableItem';
+import { DropdownMenuSeparator } from '@/ui/layout/dropdown/components/DropdownMenuSeparator';
+import { useRecoilComponentValue } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValue';
+import { type RelationFilterValue } from '@/views/view-filter-value/types/RelationFilterValue';
+import {
+    arrayOfUuidOrVariableSchema,
+    isDefined,
+    jsonRelationFilterValueSchema,
+} from 'twenty-shared/utils';
+import { IconUserCircle } from 'twenty-ui/display';
+
+export const EMPTY_FILTER_VALUE: string = JSON.stringify({
+  isCurrentWorkspaceMemberSelected: false,
+  selectedRecordIds: [],
+} satisfies RelationFilterValue);
+
+export const MAX_MEMBERS_TO_DISPLAY = 3;
+
+type ObjectFilterDropdownWorkspaceMemberSelectProps = {
+  recordFilterId?: string;
+  dropdownId: string;
+};
+
+export const ObjectFilterDropdownWorkspaceMemberSelect = ({
+  recordFilterId,
+  dropdownId,
+}: ObjectFilterDropdownWorkspaceMemberSelectProps) => {
+  const fieldMetadataItemUsedInFilterDropdown = useRecoilComponentValue(
+    fieldMetadataItemUsedInDropdownComponentSelector,
+  );
+
+  const { objectFilterDropdownFilterValue } =
+    useObjectFilterDropdownFilterValue();
+
+  const { applyObjectFilterDropdownFilterValue } =
+    useApplyObjectFilterDropdownFilterValue();
+
+  const selectedOperandInDropdown = useRecoilComponentValue(
+    selectedOperandInDropdownComponentState,
+  );
+
+  const objectFilterDropdownSearchInput = useRecoilComponentValue(
+    objectFilterDropdownSearchInputComponentState,
+  );
+
+  const currentRecordFilters = useRecoilComponentValue(
+    currentRecordFiltersComponentState,
+  );
+
+  const { isCurrentWorkspaceMemberSelected } = jsonRelationFilterValueSchema
+    .catch({
+      isCurrentWorkspaceMemberSelected: false,
+      selectedRecordIds: arrayOfUuidOrVariableSchema.parse(
+        objectFilterDropdownFilterValue,
+      ),
+    })
+    .parse(objectFilterDropdownFilterValue);
+
+  if (!isDefined(fieldMetadataItemUsedInFilterDropdown)) {
+    throw new Error('fieldMetadataItemUsedInFilterDropdown is not defined');
+  }
+
+  const firstSimpleRecordFilterForFieldMetadataItemUsedInDropdown =
+    currentRecordFilters.find(
+      (filter) =>
+        filter.fieldMetadataId === fieldMetadataItemUsedInFilterDropdown?.id &&
+        !isDefined(filter.recordFilterGroupId),
+    );
+
+  const recordFilterPassedInProps = currentRecordFilters.find(
+    (filter) => filter.id === recordFilterId,
+  );
+
+  const recordFilterUsedInDropdown = isDefined(recordFilterId)
+    ? recordFilterPassedInProps
+    : firstSimpleRecordFilterForFieldMetadataItemUsedInDropdown;
+
+  const { selectedRecordIds } = jsonRelationFilterValueSchema
+    .catch({
+      isCurrentWorkspaceMemberSelected: false,
+      selectedRecordIds: arrayOfUuidOrVariableSchema.parse(
+        recordFilterUsedInDropdown?.value,
+      ),
+    })
+    .parse(recordFilterUsedInDropdown?.value);
+
+  const { loading, filteredSelectedRecords, recordsToSelect, selectedRecords } =
+    useRecordsForSelect({
+      searchFilterText: objectFilterDropdownSearchInput,
+      selectedIds: selectedRecordIds,
+      objectNameSingular: 'workspaceMember',
+      limit: 10,
+    });
+
+  const currentWorkspaceMemberSelectableItem: SelectableItem = {
+    id: CURRENT_WORKSPACE_MEMBER_SELECTABLE_ITEM_ID,
+    name: 'Me',
+    isSelected: isCurrentWorkspaceMemberSelected ?? false,
+    AvatarIcon: IconUserCircle,
+  };
+
+  const pinnedSelectableItems: SelectableItem[] = [
+    currentWorkspaceMemberSelectableItem,
+  ];
+
+  const filteredPinnedSelectableItems = pinnedSelectableItems.filter((item) =>
+    item.name
+      .toLowerCase()
+      .includes(objectFilterDropdownSearchInput.toLowerCase()),
+  );
+
+  const handleMultipleRecordSelectChange = (
+    itemToSelect: SelectableItem,
+    isNewSelectedValue: boolean,
+  ) => {
+    if (loading) {
+      return;
+    }
+
+    const isItemCurrentWorkspaceMember =
+      itemToSelect.id === CURRENT_WORKSPACE_MEMBER_SELECTABLE_ITEM_ID;
+
+    const selectedRecordIdsWithAddedRecord = [
+      ...selectedRecordIds,
+      itemToSelect.id,
+    ];
+
+    const selectedRecordIdsWithRemovedRecord = selectedRecordIds.filter(
+      (id) => id !== itemToSelect.id,
+    );
+
+    const newSelectedRecordIds = isItemCurrentWorkspaceMember
+      ? selectedRecordIds
+      : isNewSelectedValue
+        ? selectedRecordIdsWithAddedRecord
+        : selectedRecordIdsWithRemovedRecord;
+
+    const newIsCurrentWorkspaceMemberSelected = isItemCurrentWorkspaceMember
+      ? isNewSelectedValue
+      : isCurrentWorkspaceMemberSelected;
+
+    const selectedRecordNames = [
+      ...recordsToSelect,
+      ...selectedRecords,
+      ...filteredSelectedRecords,
+    ]
+      .filter(
+        (record, index, self) =>
+          self.findIndex((r) => r.id === record.id) === index,
+      )
+      .filter((record) => newSelectedRecordIds.includes(record.id))
+      .map((record) => record.name);
+
+    const selectedPinnedItemNames = newIsCurrentWorkspaceMemberSelected
+      ? [currentWorkspaceMemberSelectableItem.name]
+      : [];
+
+    const selectedItemNames = [
+      ...selectedPinnedItemNames,
+      ...selectedRecordNames,
+    ];
+
+    const filterDisplayValue =
+      selectedItemNames.length > MAX_MEMBERS_TO_DISPLAY
+        ? `${selectedItemNames.length} members`
+        : selectedItemNames.join(', ');
+
+    if (isDefined(selectedOperandInDropdown)) {
+      const newFilterValue =
+        newSelectedRecordIds.length > 0 || newIsCurrentWorkspaceMemberSelected
+          ? JSON.stringify({
+              isCurrentWorkspaceMemberSelected:
+                newIsCurrentWorkspaceMemberSelected,
+              selectedRecordIds: newSelectedRecordIds,
+            } satisfies RelationFilterValue)
+          : '';
+
+      applyObjectFilterDropdownFilterValue(newFilterValue, filterDisplayValue);
+    }
+  };
+
+  return (
+    <>
+      {filteredPinnedSelectableItems.length > 0 && (
+        <>
+          <ObjectFilterDropdownRecordPinnedItems
+            selectableItems={filteredPinnedSelectableItems}
+            onChange={handleMultipleRecordSelectChange}
+          />
+          <DropdownMenuSeparator />
+        </>
+      )}
+      <MultipleSelectDropdown
+        selectableListId="object-filter-workspace-member-select-id"
+        focusId={dropdownId}
+        itemsToSelect={recordsToSelect}
+        filteredSelectedItems={filteredSelectedRecords}
+        selectedItems={selectedRecords}
+        onChange={handleMultipleRecordSelectChange}
+        searchFilter={objectFilterDropdownSearchInput}
+        loadingItems={loading}
+      />
+    </>
+  );
+};

--- a/packages/twenty-front/src/modules/object-record/object-filter-dropdown/utils/__tests__/getSubMenuOptions.test.ts
+++ b/packages/twenty-front/src/modules/object-record/object-filter-dropdown/utils/__tests__/getSubMenuOptions.test.ts
@@ -1,0 +1,76 @@
+import { getSubMenuOptions } from '../getSubMenuOptions';
+
+describe('getSubMenuOptions', () => {
+  describe('ACTOR field type', () => {
+    it('should return three options for ACTOR submenu', () => {
+      const options = getSubMenuOptions('ACTOR');
+
+      expect(options).toHaveLength(3);
+    });
+
+    it('should include Creation Source option', () => {
+      const options = getSubMenuOptions('ACTOR');
+
+      const sourceOption = options.find((opt) => opt.type === 'SOURCE');
+      expect(sourceOption).toBeDefined();
+      expect(sourceOption?.name).toBe('Creation Source');
+      expect(sourceOption?.icon).toBe('IconPlug');
+    });
+
+    it('should include Creator Name option', () => {
+      const options = getSubMenuOptions('ACTOR');
+
+      const nameOption = options.find(
+        (opt) => opt.type === 'ACTOR' && opt.name === 'Creator Name',
+      );
+      expect(nameOption).toBeDefined();
+      expect(nameOption?.icon).toBe('IconId');
+    });
+
+    it('should include Workspace Member option', () => {
+      const options = getSubMenuOptions('ACTOR');
+
+      const workspaceMemberOption = options.find(
+        (opt) => opt.type === 'WORKSPACE_MEMBER',
+      );
+      expect(workspaceMemberOption).toBeDefined();
+      expect(workspaceMemberOption?.name).toBe('Workspace Member');
+      expect(workspaceMemberOption?.icon).toBe('IconUser');
+    });
+
+    it('should return options in correct order: Source, Name, Workspace Member', () => {
+      const options = getSubMenuOptions('ACTOR');
+
+      expect(options[0].type).toBe('SOURCE');
+      expect(options[1].type).toBe('ACTOR');
+      expect(options[2].type).toBe('WORKSPACE_MEMBER');
+    });
+  });
+
+  describe('non-ACTOR field types', () => {
+    it('should return empty array for null', () => {
+      const options = getSubMenuOptions(null);
+
+      expect(options).toEqual([]);
+    });
+
+    it('should return empty array for TEXT field type', () => {
+      const options = getSubMenuOptions('TEXT');
+
+      expect(options).toEqual([]);
+    });
+
+    it('should return empty array for RELATION field type', () => {
+      const options = getSubMenuOptions('RELATION');
+
+      expect(options).toEqual([]);
+    });
+
+    it('should return empty array for SELECT field type', () => {
+      const options = getSubMenuOptions('SELECT');
+
+      expect(options).toEqual([]);
+    });
+  });
+});
+

--- a/packages/twenty-front/src/modules/object-record/object-filter-dropdown/utils/__tests__/getSubMenuOptions.test.ts
+++ b/packages/twenty-front/src/modules/object-record/object-filter-dropdown/utils/__tests__/getSubMenuOptions.test.ts
@@ -73,4 +73,3 @@ describe('getSubMenuOptions', () => {
     });
   });
 });
-

--- a/packages/twenty-front/src/modules/object-record/object-filter-dropdown/utils/__tests__/isFilterOnActorWorkspaceMemberSubField.test.ts
+++ b/packages/twenty-front/src/modules/object-record/object-filter-dropdown/utils/__tests__/isFilterOnActorWorkspaceMemberSubField.test.ts
@@ -33,4 +33,3 @@ describe('isFilterOnActorWorkspaceMemberSubField', () => {
     );
   });
 });
-

--- a/packages/twenty-front/src/modules/object-record/object-filter-dropdown/utils/__tests__/isFilterOnActorWorkspaceMemberSubField.test.ts
+++ b/packages/twenty-front/src/modules/object-record/object-filter-dropdown/utils/__tests__/isFilterOnActorWorkspaceMemberSubField.test.ts
@@ -1,0 +1,36 @@
+import { isFilterOnActorWorkspaceMemberSubField } from '../isFilterOnActorWorkspaceMemberSubField';
+
+describe('isFilterOnActorWorkspaceMemberSubField', () => {
+  it('should return true when subFieldName is "workspaceMemberId"', () => {
+    expect(isFilterOnActorWorkspaceMemberSubField('workspaceMemberId')).toBe(
+      true,
+    );
+  });
+
+  it('should return false when subFieldName is "source"', () => {
+    expect(isFilterOnActorWorkspaceMemberSubField('source')).toBe(false);
+  });
+
+  it('should return false when subFieldName is "name"', () => {
+    expect(isFilterOnActorWorkspaceMemberSubField('name')).toBe(false);
+  });
+
+  it('should return false when subFieldName is undefined', () => {
+    expect(isFilterOnActorWorkspaceMemberSubField(undefined)).toBe(false);
+  });
+
+  it('should return false when subFieldName is null', () => {
+    expect(isFilterOnActorWorkspaceMemberSubField(null)).toBe(false);
+  });
+
+  it('should return false when subFieldName is an empty string', () => {
+    expect(isFilterOnActorWorkspaceMemberSubField('')).toBe(false);
+  });
+
+  it('should return false for arbitrary string values', () => {
+    expect(isFilterOnActorWorkspaceMemberSubField('someOtherField')).toBe(
+      false,
+    );
+  });
+});
+

--- a/packages/twenty-front/src/modules/object-record/object-filter-dropdown/utils/getSubMenuOptions.ts
+++ b/packages/twenty-front/src/modules/object-record/object-filter-dropdown/utils/getSubMenuOptions.ts
@@ -14,6 +14,11 @@ export const getSubMenuOptions = (subMenu: FilterableFieldType | null) => {
           icon: 'IconId',
           type: 'ACTOR',
         },
+        {
+          name: 'Workspace Member',
+          icon: 'IconUser',
+          type: 'WORKSPACE_MEMBER',
+        },
       ];
     default:
       return [];

--- a/packages/twenty-front/src/modules/object-record/object-filter-dropdown/utils/isFilterOnActorWorkspaceMemberSubField.ts
+++ b/packages/twenty-front/src/modules/object-record/object-filter-dropdown/utils/isFilterOnActorWorkspaceMemberSubField.ts
@@ -1,0 +1,7 @@
+import { type FieldActorValue } from '@/object-record/record-field/ui/types/FieldMetadata';
+
+export const isFilterOnActorWorkspaceMemberSubField = (
+  subFieldName?: string | null | undefined,
+) => {
+  return subFieldName === ('workspaceMemberId' satisfies keyof FieldActorValue);
+};

--- a/packages/twenty-front/src/modules/object-record/record-filter/constants/IconNameBySubField.ts
+++ b/packages/twenty-front/src/modules/object-record/record-filter/constants/IconNameBySubField.ts
@@ -7,6 +7,7 @@ export const ICON_NAME_BY_SUB_FIELD: Partial<
   amountMicros: 'IconNumber95Small',
   name: 'IconTextSize',
   source: 'IconTransferIn',
+  workspaceMemberId: 'IconUser',
   primaryEmail: 'IconMail',
   additionalEmails: 'IconMailPlus',
   primaryLinkLabel: 'IconTextSize',

--- a/packages/twenty-front/src/modules/object-record/record-filter/utils/__tests__/getRecordFilterOperands.test.ts
+++ b/packages/twenty-front/src/modules/object-record/record-filter/utils/__tests__/getRecordFilterOperands.test.ts
@@ -1,0 +1,139 @@
+import { ViewFilterOperand } from 'twenty-shared/types';
+
+import { getRecordFilterOperands } from '../getRecordFilterOperands';
+
+describe('getRecordFilterOperands', () => {
+  describe('ACTOR field type', () => {
+    it('should return CONTAINS, DOES_NOT_CONTAIN, IS_EMPTY, IS_NOT_EMPTY for default ACTOR filter (name subfield)', () => {
+      const operands = getRecordFilterOperands({
+        filterType: 'ACTOR',
+        subFieldName: undefined,
+      });
+
+      expect(operands).toContain(ViewFilterOperand.CONTAINS);
+      expect(operands).toContain(ViewFilterOperand.DOES_NOT_CONTAIN);
+      expect(operands).toContain(ViewFilterOperand.IS_EMPTY);
+      expect(operands).toContain(ViewFilterOperand.IS_NOT_EMPTY);
+      expect(operands).not.toContain(ViewFilterOperand.IS);
+      expect(operands).not.toContain(ViewFilterOperand.IS_NOT);
+    });
+
+    it('should return IS, IS_NOT, IS_EMPTY, IS_NOT_EMPTY for source subfield', () => {
+      const operands = getRecordFilterOperands({
+        filterType: 'ACTOR',
+        subFieldName: 'source',
+      });
+
+      expect(operands).toContain(ViewFilterOperand.IS);
+      expect(operands).toContain(ViewFilterOperand.IS_NOT);
+      expect(operands).toContain(ViewFilterOperand.IS_EMPTY);
+      expect(operands).toContain(ViewFilterOperand.IS_NOT_EMPTY);
+      expect(operands).not.toContain(ViewFilterOperand.CONTAINS);
+      expect(operands).not.toContain(ViewFilterOperand.DOES_NOT_CONTAIN);
+    });
+
+    it('should return IS, IS_NOT, IS_EMPTY, IS_NOT_EMPTY for workspaceMemberId subfield', () => {
+      const operands = getRecordFilterOperands({
+        filterType: 'ACTOR',
+        subFieldName: 'workspaceMemberId',
+      });
+
+      expect(operands).toContain(ViewFilterOperand.IS);
+      expect(operands).toContain(ViewFilterOperand.IS_NOT);
+      expect(operands).toContain(ViewFilterOperand.IS_EMPTY);
+      expect(operands).toContain(ViewFilterOperand.IS_NOT_EMPTY);
+      expect(operands).not.toContain(ViewFilterOperand.CONTAINS);
+      expect(operands).not.toContain(ViewFilterOperand.DOES_NOT_CONTAIN);
+    });
+
+    it('should return name subfield operands for null subFieldName', () => {
+      const operands = getRecordFilterOperands({
+        filterType: 'ACTOR',
+        subFieldName: null,
+      });
+
+      expect(operands).toContain(ViewFilterOperand.CONTAINS);
+      expect(operands).toContain(ViewFilterOperand.DOES_NOT_CONTAIN);
+    });
+
+    it('should return name subfield operands for "name" subFieldName', () => {
+      const operands = getRecordFilterOperands({
+        filterType: 'ACTOR',
+        subFieldName: 'name',
+      });
+
+      expect(operands).toContain(ViewFilterOperand.CONTAINS);
+      expect(operands).toContain(ViewFilterOperand.DOES_NOT_CONTAIN);
+    });
+  });
+
+  describe('RELATION field type', () => {
+    it('should return IS, IS_NOT, IS_EMPTY, IS_NOT_EMPTY for RELATION', () => {
+      const operands = getRecordFilterOperands({
+        filterType: 'RELATION',
+        subFieldName: undefined,
+      });
+
+      expect(operands).toContain(ViewFilterOperand.IS);
+      expect(operands).toContain(ViewFilterOperand.IS_NOT);
+      expect(operands).toContain(ViewFilterOperand.IS_EMPTY);
+      expect(operands).toContain(ViewFilterOperand.IS_NOT_EMPTY);
+    });
+  });
+
+  describe('TEXT field type', () => {
+    it('should return CONTAINS, DOES_NOT_CONTAIN, IS_EMPTY, IS_NOT_EMPTY for TEXT', () => {
+      const operands = getRecordFilterOperands({
+        filterType: 'TEXT',
+        subFieldName: undefined,
+      });
+
+      expect(operands).toContain(ViewFilterOperand.CONTAINS);
+      expect(operands).toContain(ViewFilterOperand.DOES_NOT_CONTAIN);
+      expect(operands).toContain(ViewFilterOperand.IS_EMPTY);
+      expect(operands).toContain(ViewFilterOperand.IS_NOT_EMPTY);
+    });
+  });
+
+  describe('SELECT field type', () => {
+    it('should return IS, IS_NOT, IS_EMPTY, IS_NOT_EMPTY for SELECT', () => {
+      const operands = getRecordFilterOperands({
+        filterType: 'SELECT',
+        subFieldName: undefined,
+      });
+
+      expect(operands).toContain(ViewFilterOperand.IS);
+      expect(operands).toContain(ViewFilterOperand.IS_NOT);
+      expect(operands).toContain(ViewFilterOperand.IS_EMPTY);
+      expect(operands).toContain(ViewFilterOperand.IS_NOT_EMPTY);
+    });
+  });
+
+  describe('NUMBER field type', () => {
+    it('should return IS, IS_NOT, GREATER_THAN_OR_EQUAL, LESS_THAN_OR_EQUAL, IS_EMPTY, IS_NOT_EMPTY for NUMBER', () => {
+      const operands = getRecordFilterOperands({
+        filterType: 'NUMBER',
+        subFieldName: undefined,
+      });
+
+      expect(operands).toContain(ViewFilterOperand.IS);
+      expect(operands).toContain(ViewFilterOperand.IS_NOT);
+      expect(operands).toContain(ViewFilterOperand.GREATER_THAN_OR_EQUAL);
+      expect(operands).toContain(ViewFilterOperand.LESS_THAN_OR_EQUAL);
+      expect(operands).toContain(ViewFilterOperand.IS_EMPTY);
+      expect(operands).toContain(ViewFilterOperand.IS_NOT_EMPTY);
+    });
+  });
+
+  describe('BOOLEAN field type', () => {
+    it('should return only IS for BOOLEAN', () => {
+      const operands = getRecordFilterOperands({
+        filterType: 'BOOLEAN',
+        subFieldName: undefined,
+      });
+
+      expect(operands).toEqual([ViewFilterOperand.IS]);
+    });
+  });
+});
+

--- a/packages/twenty-front/src/modules/object-record/record-filter/utils/__tests__/getRecordFilterOperands.test.ts
+++ b/packages/twenty-front/src/modules/object-record/record-filter/utils/__tests__/getRecordFilterOperands.test.ts
@@ -136,4 +136,3 @@ describe('getRecordFilterOperands', () => {
     });
   });
 });
-

--- a/packages/twenty-front/src/modules/object-record/record-filter/utils/getRecordFilterOperands.ts
+++ b/packages/twenty-front/src/modules/object-record/record-filter/utils/getRecordFilterOperands.ts
@@ -1,4 +1,5 @@
 import { isFilterOnActorSourceSubField } from '@/object-record/object-filter-dropdown/utils/isFilterOnActorSourceSubField';
+import { isFilterOnActorWorkspaceMemberSubField } from '@/object-record/object-filter-dropdown/utils/isFilterOnActorWorkspaceMemberSubField';
 import { type CompositeFieldSubFieldName } from '@/settings/data-model/types/CompositeFieldSubFieldName';
 import {
   FieldMetadataType,
@@ -195,6 +196,14 @@ export const getRecordFilterOperands = ({
       return FILTER_OPERANDS_MAP.SELECT;
     case 'ACTOR': {
       if (isFilterOnActorSourceSubField(subFieldName)) {
+        return [
+          RecordFilterOperand.IS,
+          RecordFilterOperand.IS_NOT,
+          ...emptyOperands,
+        ];
+      }
+
+      if (isFilterOnActorWorkspaceMemberSubField(subFieldName)) {
         return [
           RecordFilterOperand.IS,
           RecordFilterOperand.IS_NOT,

--- a/packages/twenty-front/src/modules/settings/data-model/constants/CompositeFieldSubFieldLabel.ts
+++ b/packages/twenty-front/src/modules/settings/data-model/constants/CompositeFieldSubFieldLabel.ts
@@ -40,7 +40,7 @@ export const COMPOSITE_FIELD_SUB_FIELD_LABELS: {
   [FieldMetadataType.ACTOR]: {
     source: 'Source',
     name: 'Name',
-    workspaceMemberId: 'Workspace Member ID',
+    workspaceMemberId: 'Workspace Member',
     context: 'Context',
   },
   [FieldMetadataType.RICH_TEXT_V2]: {

--- a/packages/twenty-front/src/modules/settings/data-model/constants/SettingsCompositeFieldTypeConfigs.ts
+++ b/packages/twenty-front/src/modules/settings/data-model/constants/SettingsCompositeFieldTypeConfigs.ts
@@ -464,7 +464,7 @@ export const SETTINGS_COMPOSITE_FIELD_TYPE_CONFIGS = {
           COMPOSITE_FIELD_SUB_FIELD_LABELS[FieldMetadataType.ACTOR]
             .workspaceMemberId,
         isImportable: true,
-        isFilterable: false,
+        isFilterable: true,
         isIncludedInUniqueConstraint: false,
       },
       {

--- a/packages/twenty-front/src/modules/settings/data-model/constants/__tests__/SettingsCompositeFieldTypeConfigs.test.ts
+++ b/packages/twenty-front/src/modules/settings/data-model/constants/__tests__/SettingsCompositeFieldTypeConfigs.test.ts
@@ -1,0 +1,82 @@
+import { FieldMetadataType } from 'twenty-shared/types';
+
+import { SETTINGS_COMPOSITE_FIELD_TYPE_CONFIGS } from '../SettingsCompositeFieldTypeConfigs';
+
+describe('SETTINGS_COMPOSITE_FIELD_TYPE_CONFIGS', () => {
+  describe('ACTOR field type', () => {
+    const actorConfig =
+      SETTINGS_COMPOSITE_FIELD_TYPE_CONFIGS[FieldMetadataType.ACTOR];
+
+    it('should have source subfield as filterable', () => {
+      const sourceField = actorConfig.subFields.find(
+        (field) => field.subFieldName === 'source',
+      );
+
+      expect(sourceField).toBeDefined();
+      expect(sourceField?.isFilterable).toBe(true);
+    });
+
+    it('should have name subfield as filterable', () => {
+      const nameField = actorConfig.subFields.find(
+        (field) => field.subFieldName === 'name',
+      );
+
+      expect(nameField).toBeDefined();
+      expect(nameField?.isFilterable).toBe(true);
+    });
+
+    it('should have workspaceMemberId subfield as filterable', () => {
+      const workspaceMemberIdField = actorConfig.subFields.find(
+        (field) => field.subFieldName === 'workspaceMemberId',
+      );
+
+      expect(workspaceMemberIdField).toBeDefined();
+      expect(workspaceMemberIdField?.isFilterable).toBe(true);
+    });
+
+    it('should have exactly 3 filterable subfields for ACTOR', () => {
+      const filterableSubFields = actorConfig.subFields.filter(
+        (field) => field.isFilterable === true,
+      );
+
+      expect(filterableSubFields).toHaveLength(3);
+      expect(filterableSubFields.map((f) => f.subFieldName)).toEqual(
+        expect.arrayContaining(['source', 'name', 'workspaceMemberId']),
+      );
+    });
+
+    it('should have context subfield as NOT filterable', () => {
+      const contextField = actorConfig.subFields.find(
+        (field) => field.subFieldName === 'context',
+      );
+
+      expect(contextField).toBeDefined();
+      expect(contextField?.isFilterable).toBe(false);
+    });
+  });
+
+  describe('other composite field types', () => {
+    it('should have CURRENCY subfields as filterable', () => {
+      const currencyConfig =
+        SETTINGS_COMPOSITE_FIELD_TYPE_CONFIGS[FieldMetadataType.CURRENCY];
+
+      const filterableSubFields = currencyConfig.subFields.filter(
+        (field) => field.isFilterable === true,
+      );
+
+      expect(filterableSubFields.length).toBeGreaterThan(0);
+    });
+
+    it('should have FULL_NAME subfields as filterable', () => {
+      const fullNameConfig =
+        SETTINGS_COMPOSITE_FIELD_TYPE_CONFIGS[FieldMetadataType.FULL_NAME];
+
+      const filterableSubFields = fullNameConfig.subFields.filter(
+        (field) => field.isFilterable === true,
+      );
+
+      expect(filterableSubFields.length).toBeGreaterThan(0);
+    });
+  });
+});
+

--- a/packages/twenty-front/src/modules/settings/data-model/constants/__tests__/SettingsCompositeFieldTypeConfigs.test.ts
+++ b/packages/twenty-front/src/modules/settings/data-model/constants/__tests__/SettingsCompositeFieldTypeConfigs.test.ts
@@ -79,4 +79,3 @@ describe('SETTINGS_COMPOSITE_FIELD_TYPE_CONFIGS', () => {
     });
   });
 });
-

--- a/packages/twenty-shared/src/types/RecordGqlOperationFilter.ts
+++ b/packages/twenty-shared/src/types/RecordGqlOperationFilter.ts
@@ -103,6 +103,7 @@ export type LinksFilter = {
 export type ActorFilter = {
   name?: StringFilter;
   source?: SelectFilter;
+  workspaceMemberId?: UUIDFilter;
 };
 
 export type EmailsFilter = {

--- a/packages/twenty-shared/src/utils/filter/__tests__/turnRecordFilterIntoGqlOperationFilter.actorWorkspaceMemberId.test.ts
+++ b/packages/twenty-shared/src/utils/filter/__tests__/turnRecordFilterIntoGqlOperationFilter.actorWorkspaceMemberId.test.ts
@@ -1,0 +1,290 @@
+import { FieldMetadataType } from '@/types/FieldMetadataType';
+import type { PartialFieldMetadataItem } from '@/types/PartialFieldMetadataItem';
+import { ViewFilterOperand } from '@/types/ViewFilterOperand';
+
+import { turnRecordFilterIntoRecordGqlOperationFilter } from '../turnRecordFilterIntoGqlOperationFilter';
+
+describe('turnRecordFilterIntoRecordGqlOperationFilter - ACTOR workspaceMemberId subfield', () => {
+  const createdByField: PartialFieldMetadataItem = {
+    id: 'created-by-field-id',
+    name: 'createdBy',
+    label: 'Created by',
+    type: FieldMetadataType.ACTOR,
+  };
+
+  const workspaceMemberId1 = '550e8400-e29b-41d4-a716-446655440001';
+  const workspaceMemberId2 = '550e8400-e29b-41d4-a716-446655440002';
+  const currentWorkspaceMemberId = '550e8400-e29b-41d4-a716-446655440000';
+
+  describe('IS operand', () => {
+    it('should generate filter for selected workspace member IDs', () => {
+      const filterValue = JSON.stringify({
+        isCurrentWorkspaceMemberSelected: false,
+        selectedRecordIds: [workspaceMemberId1, workspaceMemberId2],
+      });
+
+      const result = turnRecordFilterIntoRecordGqlOperationFilter({
+        recordFilter: {
+          id: 'filter-id',
+          fieldMetadataId: createdByField.id,
+          value: filterValue,
+          type: 'ACTOR',
+          operand: ViewFilterOperand.IS,
+          subFieldName: 'workspaceMemberId',
+        },
+        fieldMetadataItems: [createdByField],
+        filterValueDependencies: { currentWorkspaceMemberId },
+      });
+
+      expect(result).toEqual({
+        createdBy: {
+          workspaceMemberId: {
+            in: [workspaceMemberId1, workspaceMemberId2],
+          },
+        },
+      });
+    });
+
+    it('should include current workspace member ID when "Me" is selected', () => {
+      const filterValue = JSON.stringify({
+        isCurrentWorkspaceMemberSelected: true,
+        selectedRecordIds: [workspaceMemberId1],
+      });
+
+      const result = turnRecordFilterIntoRecordGqlOperationFilter({
+        recordFilter: {
+          id: 'filter-id',
+          fieldMetadataId: createdByField.id,
+          value: filterValue,
+          type: 'ACTOR',
+          operand: ViewFilterOperand.IS,
+          subFieldName: 'workspaceMemberId',
+        },
+        fieldMetadataItems: [createdByField],
+        filterValueDependencies: { currentWorkspaceMemberId },
+      });
+
+      expect(result).toEqual({
+        createdBy: {
+          workspaceMemberId: {
+            in: [workspaceMemberId1, currentWorkspaceMemberId],
+          },
+        },
+      });
+    });
+
+    it('should include only current workspace member ID when only "Me" is selected', () => {
+      const filterValue = JSON.stringify({
+        isCurrentWorkspaceMemberSelected: true,
+        selectedRecordIds: [],
+      });
+
+      const result = turnRecordFilterIntoRecordGqlOperationFilter({
+        recordFilter: {
+          id: 'filter-id',
+          fieldMetadataId: createdByField.id,
+          value: filterValue,
+          type: 'ACTOR',
+          operand: ViewFilterOperand.IS,
+          subFieldName: 'workspaceMemberId',
+        },
+        fieldMetadataItems: [createdByField],
+        filterValueDependencies: { currentWorkspaceMemberId },
+      });
+
+      expect(result).toEqual({
+        createdBy: {
+          workspaceMemberId: {
+            in: [currentWorkspaceMemberId],
+          },
+        },
+      });
+    });
+
+    it('should return undefined when no members are selected', () => {
+      const filterValue = JSON.stringify({
+        isCurrentWorkspaceMemberSelected: false,
+        selectedRecordIds: [],
+      });
+
+      const result = turnRecordFilterIntoRecordGqlOperationFilter({
+        recordFilter: {
+          id: 'filter-id',
+          fieldMetadataId: createdByField.id,
+          value: filterValue,
+          type: 'ACTOR',
+          operand: ViewFilterOperand.IS,
+          subFieldName: 'workspaceMemberId',
+        },
+        fieldMetadataItems: [createdByField],
+        filterValueDependencies: { currentWorkspaceMemberId },
+      });
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('IS_NOT operand', () => {
+    it('should generate NOT filter for selected workspace member IDs', () => {
+      const filterValue = JSON.stringify({
+        isCurrentWorkspaceMemberSelected: false,
+        selectedRecordIds: [workspaceMemberId1],
+      });
+
+      const result = turnRecordFilterIntoRecordGqlOperationFilter({
+        recordFilter: {
+          id: 'filter-id',
+          fieldMetadataId: createdByField.id,
+          value: filterValue,
+          type: 'ACTOR',
+          operand: ViewFilterOperand.IS_NOT,
+          subFieldName: 'workspaceMemberId',
+        },
+        fieldMetadataItems: [createdByField],
+        filterValueDependencies: { currentWorkspaceMemberId },
+      });
+
+      expect(result).toEqual({
+        or: [
+          {
+            not: {
+              createdBy: {
+                workspaceMemberId: {
+                  in: [workspaceMemberId1],
+                },
+              },
+            },
+          },
+          {
+            createdBy: {
+              workspaceMemberId: {
+                is: 'NULL',
+              },
+            },
+          },
+        ],
+      });
+    });
+
+    it('should generate NOT filter including current workspace member when "Me" is selected', () => {
+      const filterValue = JSON.stringify({
+        isCurrentWorkspaceMemberSelected: true,
+        selectedRecordIds: [],
+      });
+
+      const result = turnRecordFilterIntoRecordGqlOperationFilter({
+        recordFilter: {
+          id: 'filter-id',
+          fieldMetadataId: createdByField.id,
+          value: filterValue,
+          type: 'ACTOR',
+          operand: ViewFilterOperand.IS_NOT,
+          subFieldName: 'workspaceMemberId',
+        },
+        fieldMetadataItems: [createdByField],
+        filterValueDependencies: { currentWorkspaceMemberId },
+      });
+
+      expect(result).toEqual({
+        or: [
+          {
+            not: {
+              createdBy: {
+                workspaceMemberId: {
+                  in: [currentWorkspaceMemberId],
+                },
+              },
+            },
+          },
+          {
+            createdBy: {
+              workspaceMemberId: {
+                is: 'NULL',
+              },
+            },
+          },
+        ],
+      });
+    });
+
+    it('should return undefined when no members are selected for IS_NOT', () => {
+      const filterValue = JSON.stringify({
+        isCurrentWorkspaceMemberSelected: false,
+        selectedRecordIds: [],
+      });
+
+      const result = turnRecordFilterIntoRecordGqlOperationFilter({
+        recordFilter: {
+          id: 'filter-id',
+          fieldMetadataId: createdByField.id,
+          value: filterValue,
+          type: 'ACTOR',
+          operand: ViewFilterOperand.IS_NOT,
+          subFieldName: 'workspaceMemberId',
+        },
+        fieldMetadataItems: [createdByField],
+        filterValueDependencies: { currentWorkspaceMemberId },
+      });
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle missing currentWorkspaceMemberId in dependencies', () => {
+      const filterValue = JSON.stringify({
+        isCurrentWorkspaceMemberSelected: true,
+        selectedRecordIds: [workspaceMemberId1],
+      });
+
+      const result = turnRecordFilterIntoRecordGqlOperationFilter({
+        recordFilter: {
+          id: 'filter-id',
+          fieldMetadataId: createdByField.id,
+          value: filterValue,
+          type: 'ACTOR',
+          operand: ViewFilterOperand.IS,
+          subFieldName: 'workspaceMemberId',
+        },
+        fieldMetadataItems: [createdByField],
+        filterValueDependencies: {},
+      });
+
+      // Should only include the explicitly selected member, not undefined
+      expect(result).toEqual({
+        createdBy: {
+          workspaceMemberId: {
+            in: [workspaceMemberId1],
+          },
+        },
+      });
+    });
+
+    it('should handle legacy array format for filter value', () => {
+      // Legacy format: just an array of UUIDs
+      const filterValue = JSON.stringify([workspaceMemberId1, workspaceMemberId2]);
+
+      const result = turnRecordFilterIntoRecordGqlOperationFilter({
+        recordFilter: {
+          id: 'filter-id',
+          fieldMetadataId: createdByField.id,
+          value: filterValue,
+          type: 'ACTOR',
+          operand: ViewFilterOperand.IS,
+          subFieldName: 'workspaceMemberId',
+        },
+        fieldMetadataItems: [createdByField],
+        filterValueDependencies: { currentWorkspaceMemberId },
+      });
+
+      expect(result).toEqual({
+        createdBy: {
+          workspaceMemberId: {
+            in: [workspaceMemberId1, workspaceMemberId2],
+          },
+        },
+      });
+    });
+  });
+});
+


### PR DESCRIPTION


## Summary

Adds the ability to filter records by the `createdBy` field's `workspaceMemberId`, with a special "Me" option for the current user. This allows users to quickly find records they created.

## Changes

### Implementation
- **`SettingsCompositeFieldTypeConfigs.ts`** - Enabled `isFilterable: true` for `workspaceMemberId` subfield
- **`CompositeFieldSubFieldLabel.ts`** - Changed label to "Workspace Member" for better UX
- **`IconNameBySubField.ts`** - Added `IconUser` icon for the new filter option
- **`ObjectFilterDropdownWorkspaceMemberSelect.tsx`** - New component with "Me" pinned option
- **`isFilterOnActorWorkspaceMemberSubField.ts`** - Helper utility function
- **`getSubMenuOptions.ts`** - Added "Workspace Member" option to ACTOR submenu
- **`getRecordFilterOperands.ts`** - Added IS/IS_NOT operands for workspaceMemberId
- **`ObjectFilterDropdownFilterInput.tsx`** - Renders workspace member select for ACTOR filter
- **`AdvancedFilterDropdownFilterInput.tsx`** - Same handling for advanced filters
- **`turnRecordFilterIntoGqlOperationFilter.ts`** - Added GQL filter generation with `isCurrentWorkspaceMemberSelected` support

### Tests (42 test cases)
- `SettingsCompositeFieldTypeConfigs.test.ts` - Config tests to ensure workspaceMemberId is filterable
- `isFilterOnActorWorkspaceMemberSubField.test.ts` - Helper function tests
- `getSubMenuOptions.test.ts` - Submenu options tests
- `getRecordFilterOperands.test.ts` - Filter operands tests
- `turnRecordFilterIntoGqlOperationFilter.actorWorkspaceMemberId.test.ts` - GQL filter generation tests

## UI Flow

1. User clicks "Created by" filter field
2. Submenu shows: **Source**, **Name**, **Workspace Member** (new!)
3. Selecting "Workspace Member" shows:
   - **"Me"** pinned at top
   - Search bar
   - List of workspace members
4. Filter displays as "Created by is Me" or "Created by is [Member Name]"

## Screenshots

![CleanShot 2025-12-17 at 23 59 56](https://github.com/user-attachments/assets/3c3ea332-f4b7-4461-9c15-86184b8f5933)


## GraphQL Filter Output

```graphql
{
  createdBy: {
    workspaceMemberId: {
      in: ["member-id-1", "current-user-id"]
    }
  }
}
```

## How to Test

1. Go to any record list (People, Companies, Opportunities, etc.)
2. Click "Add filter" → "Created by"
3. Select "Workspace Member" from submenu
4. Select "Me" or any workspace member
5. Verify records are filtered correctly

```bash
# Run unit tests
npx jest --config=packages/twenty-front/jest.config.mjs \
  packages/twenty-front/src/modules/settings/data-model/constants/__tests__/SettingsCompositeFieldTypeConfigs.test.ts \
  packages/twenty-front/src/modules/object-record/object-filter-dropdown/utils/__tests__/isFilterOnActorWorkspaceMemberSubField.test.ts \
  packages/twenty-front/src/modules/object-record/object-filter-dropdown/utils/__tests__/getSubMenuOptions.test.ts \
  packages/twenty-front/src/modules/object-record/record-filter/utils/__tests__/getRecordFilterOperands.test.ts

npx jest --config=packages/twenty-shared/jest.config.mjs \
  packages/twenty-shared/src/utils/filter/__tests__/turnRecordFilterIntoGqlOperationFilter.actorWorkspaceMemberId.test.ts
```
this solves: #16619
https://github.com/twentyhq/twenty/issues/16619
## Checklist

- [x] Implementation complete
- [x] Unit tests added (42 test cases)
- [x] Config test to prevent regression
- [x] Screenshots attached
- [x] Manual testing done
