### PR TITLE
Use parameterized query in getRemoteTableLocalName

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/utils/get-remote-table-local-name.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/remote-server/remote-table/utils/get-remote-table-local-name.util.ts
@@ -21,7 +21,8 @@ const isNameAvailable = async (
 ) => {
   const numberOfTablesWithSameName = +(
     await coreDataSource.query(
-      `SELECT count(table_name) FROM information_schema.tables WHERE table_name LIKE '${tableName}' AND table_schema IN ('core', '${workspaceSchemaName}')`,
+      `SELECT count(table_name) FROM information_schema.tables WHERE table_name LIKE $1 AND table_schema IN ('core', $2)`,
+      [tableName, workspaceSchemaName],
     )
   )[0].count;
 


### PR DESCRIPTION
This PR updates the `isNameAvailable` function in `getRemoteTableLocalName` to use parameterized queries instead of string interpolation when querying the information_schema.

**Changes:**
- Replaced template literal interpolation with PostgreSQL's `$1`, `$2` placeholder syntax
- Parameters are now passed as a separate array argument to `dataSource.query()`

This follows best practices for database queries.