### PR TITLE
fix: prevent text overflow in view picker and record table action row

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-row/components/RecordTableActionRow.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-row/components/RecordTableActionRow.tsx
@@ -90,9 +90,9 @@ const StyledText = styled.span`
   font-size: ${({ theme }) => theme.font.size.md};
   text-align: left;
   vertical-align: middle;
+  white-space: nowrap;
 
   position: absolute;
-  width: 100px;
 `;
 
 type RecordTableActionRowProps = {

--- a/packages/twenty-front/src/modules/views/view-picker/components/ViewPickerDropdown.tsx
+++ b/packages/twenty-front/src/modules/views/view-picker/components/ViewPickerDropdown.tsx
@@ -1,6 +1,6 @@
-import { t } from '@lingui/core/macro';
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
+import { t } from '@lingui/core/macro';
 
 import { Dropdown } from '@/ui/layout/dropdown/components/Dropdown';
 import { StyledDropdownButtonContainer } from '@/ui/layout/dropdown/components/StyledDropdownButtonContainer';
@@ -25,25 +25,31 @@ import {
 } from 'twenty-ui/display';
 import { MOBILE_VIEWPORT } from 'twenty-ui/theme';
 
+const StyledIconContainer = styled.span`
+  display: flex;
+  flex-shrink: 0;
+`;
+
 const StyledDropdownLabelAdornments = styled.span`
   align-items: center;
   color: ${({ theme }) => theme.grayScale.gray8};
-  display: inline-flex;
+  display: flex;
+  flex-shrink: 0;
   gap: ${({ theme }) => theme.spacing(1)};
   margin-left: ${({ theme }) => theme.spacing(1)};
 `;
 
 const StyledViewName = styled.span`
   margin-left: ${({ theme }) => theme.spacing(1)};
-  display: inline-block;
   max-width: 130px;
+  min-width: 0;
+  overflow: hidden;
   @media (max-width: 375px) {
     max-width: 90px;
   }
   @media (min-width: 376px) and (max-width: ${MOBILE_VIEWPORT}px) {
     max-width: 110px;
   }
-  vertical-align: middle;
 `;
 
 export const ViewPickerDropdown = () => {
@@ -80,11 +86,13 @@ export const ViewPickerDropdown = () => {
       onClickOutside={handleClickOutside}
       clickableComponent={
         <StyledDropdownButtonContainer isUnfolded={isDropdownOpen}>
-          {currentView && CurrentViewIcon ? (
-            <CurrentViewIcon size={theme.icon.size.md} />
-          ) : (
-            <IconList size={theme.icon.size.md} />
-          )}
+          <StyledIconContainer>
+            {currentView && CurrentViewIcon ? (
+              <CurrentViewIcon size={theme.icon.size.md} />
+            ) : (
+              <IconList size={theme.icon.size.md} />
+            )}
+          </StyledIconContainer>
           <StyledViewName>
             <OverflowingTextWithTooltip text={currentView?.name ?? t`All`} />
           </StyledViewName>


### PR DESCRIPTION
## Summary
Fixes text overflow issues in the UI that were particularly visible with longer translations (e.g., French).

## Changes

### RecordTableActionRow
- Added `white-space: nowrap` to prevent the 'Add New' text from wrapping to multiple lines
- Removed the fixed `width: 100px` that was causing overflow issues

### ViewPickerDropdown
- Fixed flexbox layout to properly handle long view names
- Added `flex-shrink: 0` to the icon container and adornments to prevent them from shrinking
- Added `min-width: 0` to the view name container for proper text truncation
- Removed `display: inline-block` and `vertical-align: middle` which don't work in flex containers

## Before
- 'Ajouter Nouveau' was displayed on two lines
- View names could push the count to a new line
- Icons could shrink when view names were long

## After
- Text stays on one line with proper ellipsis truncation
- Layout remains stable regardless of text length
- Icons maintain their size