### PR TITLE
fix: crash when clicking '...' menu in mobile mode on record index

### DIFF
--- a/packages/twenty-front/src/modules/command-menu/components/CommandMenuContainer.tsx
+++ b/packages/twenty-front/src/modules/command-menu/components/CommandMenuContainer.tsx
@@ -8,6 +8,7 @@ import { objectMetadataItemsState } from '@/object-metadata/states/objectMetadat
 import { RecordComponentInstanceContextsWrapper } from '@/object-record/components/RecordComponentInstanceContextsWrapper';
 import { getRecordIndexIdFromObjectNamePluralAndViewId } from '@/object-record/utils/getRecordIndexIdFromObjectNamePluralAndViewId';
 import { useRecoilComponentValue } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValue';
+import { ViewComponentInstanceContext } from '@/views/states/contexts/ViewComponentInstanceContext';
 import { useRecoilValue } from 'recoil';
 
 type CommandMenuContainerProps = {
@@ -39,16 +40,22 @@ export const CommandMenuContainer = ({
   );
 
   return (
-    <RecordComponentInstanceContextsWrapper componentInstanceId={recordIndexId}>
-      <ContextStoreComponentInstanceContext.Provider
-        value={{ instanceId: COMMAND_MENU_COMPONENT_INSTANCE_ID }}
+    <ViewComponentInstanceContext.Provider
+      value={{ instanceId: recordIndexId }}
+    >
+      <RecordComponentInstanceContextsWrapper
+        componentInstanceId={recordIndexId}
       >
-        <ActionMenuComponentInstanceContext.Provider
+        <ContextStoreComponentInstanceContext.Provider
           value={{ instanceId: COMMAND_MENU_COMPONENT_INSTANCE_ID }}
         >
-          <AgentChatProvider>{children}</AgentChatProvider>
-        </ActionMenuComponentInstanceContext.Provider>
-      </ContextStoreComponentInstanceContext.Provider>
-    </RecordComponentInstanceContextsWrapper>
+          <ActionMenuComponentInstanceContext.Provider
+            value={{ instanceId: COMMAND_MENU_COMPONENT_INSTANCE_ID }}
+          >
+            <AgentChatProvider>{children}</AgentChatProvider>
+          </ActionMenuComponentInstanceContext.Provider>
+        </ContextStoreComponentInstanceContext.Provider>
+      </RecordComponentInstanceContextsWrapper>
+    </ViewComponentInstanceContext.Provider>
   );
 };

--- a/packages/twenty-front/src/modules/ui/layout/top-bar/components/TopBar.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/top-bar/components/TopBar.tsx
@@ -10,9 +10,10 @@ type TopBarProps = {
 };
 
 const StyledContainer = styled.div`
+  background: ${({ theme }) => theme.background.primary};
   border-bottom: ${({ theme }) => `1px solid ${theme.border.color.light}`};
   display: flex;
-  margin-left: ${({ theme }) => theme.spacing(3)};
+  padding-left: ${({ theme }) => theme.spacing(3)};
 
   flex-direction: column;
 `;


### PR DESCRIPTION
## Summary

This PR fixes a crash that occurs when clicking the '...' menu button in mobile mode on the record index page (e.g., viewing People, Companies, etc.).

## Bug

When in mobile mode, clicking the '...' options menu causes a frontend crash with:
```
Uncaught Error: Instance id is not provided and cannot be found in context.
    at useAvailableComponentInstanceIdOrThrow
```

The crash affects multiple action components:
- `CreateNewIndexRecordNoSelectionRecordAction`
- `ExportMultipleRecordsAction`

## Root Cause

Action menu components use hooks (`useCreateNewIndexRecord`, `useRecordIndexExportRecords`) that rely on Recoil component state selectors configured with `ViewComponentInstanceContext`:
- `recordGroupDefinitionsComponentSelector`
- `recordIndexGroupFieldMetadataItemComponentState`
- `recordGroupIdsComponentState`

`CommandMenuContainer` was wrapping children with `RecordComponentInstanceContextsWrapper` but was **missing** the `ViewComponentInstanceContext.Provider`. When `useRecoilComponentValue` called `useAvailableComponentInstanceIdOrThrow`, it couldn't find the instance ID from context, causing the crash.

## Fix

Added `ViewComponentInstanceContext.Provider` wrapping the existing providers in `CommandMenuContainer`, matching the pattern already used in `RecordIndexContainerGater.tsx`:

```tsx
<ViewComponentInstanceContext.Provider value={{ instanceId: recordIndexId }}>
  <RecordComponentInstanceContextsWrapper componentInstanceId={recordIndexId}>
    ...
  </RecordComponentInstanceContextsWrapper>
</ViewComponentInstanceContext.Provider>
```

## Testing

1. Open the app on a mobile viewport (or use responsive mode in devtools)
2. Navigate to any record index page (People, Companies, etc.)
3. Click the '...' button in the header
4. Verify the menu opens without crashing