### PR TITLE
Fix command menu input text color

### DIFF
--- a/packages/twenty-front/src/modules/command-menu/components/CommandMenuItemNumberInput.tsx
+++ b/packages/twenty-front/src/modules/command-menu/components/CommandMenuItemNumberInput.tsx
@@ -16,10 +16,6 @@ type CommandMenuItemNumberInputProps = {
 };
 const StyledRightAlignedTextInput = styled(TextInput)`
   input {
-    :focus {
-      color: ${({ theme }) => theme.font.color.primary};
-    }
-    color: ${({ theme }) => theme.font.color.tertiary};
     text-align: right;
   }
 `;

--- a/packages/twenty-front/src/modules/command-menu/components/CommandMenuItemTextInput.tsx
+++ b/packages/twenty-front/src/modules/command-menu/components/CommandMenuItemTextInput.tsx
@@ -11,10 +11,6 @@ type CommandMenuItemTextInputProps = {
 
 const StyledRightAlignedTextInput = styled(TextInput)`
   input {
-    :focus {
-      color: ${({ theme }) => theme.font.color.primary};
-    }
-    color: ${({ theme }) => theme.font.color.tertiary};
     text-align: right;
   }
 `;


### PR DESCRIPTION
## Before
<img width="798" height="164" alt="CleanShot 2025-12-18 at 11 48 15@2x" src="https://github.com/user-attachments/assets/f67c0d4b-8480-4649-8e46-f8ff6c9bacca" />

## After
<img width="400" height="76" alt="image" src="https://github.com/user-attachments/assets/502a378b-ce89-4992-b5da-3fe6f4413feb" />

