### PR TITLE
Always enable drag selection when side panel is opened

### DIFF
--- a/packages/twenty-front/src/modules/command-menu/hooks/useCommandMenu.ts
+++ b/packages/twenty-front/src/modules/command-menu/hooks/useCommandMenu.ts
@@ -9,7 +9,6 @@ import { isCommandMenuClosingState } from '@/command-menu/states/isCommandMenuCl
 import { CommandMenuPages } from '@/command-menu/types/CommandMenuPages';
 import { useCloseAnyOpenDropdown } from '@/ui/layout/dropdown/hooks/useCloseAnyOpenDropdown';
 import { emitSidePanelOpenEvent } from '@/ui/layout/right-drawer/utils/emitSidePanelOpenEvent';
-import { isDragSelectionStartEnabledState } from '@/ui/utilities/drag-select/states/internal/isDragSelectionStartEnabledState';
 import { useRemoveFocusItemFromFocusStackById } from '@/ui/utilities/focus/hooks/useRemoveFocusItemFromFocusStackById';
 import { t } from '@lingui/core/macro';
 import { useCallback } from 'react';
@@ -33,7 +32,6 @@ export const useCommandMenu = () => {
         if (isCommandMenuOpened) {
           set(isCommandMenuOpenedState, false);
           set(isCommandMenuClosingState, true);
-          set(isDragSelectionStartEnabledState, true);
           closeAnyOpenDropdown();
           removeFocusItemFromFocusStackById({
             focusId: COMMAND_MENU_SEARCH_INPUT_FOCUS_ID,

--- a/packages/twenty-front/src/modules/command-menu/hooks/useNavigateCommandMenu.ts
+++ b/packages/twenty-front/src/modules/command-menu/hooks/useNavigateCommandMenu.ts
@@ -12,7 +12,6 @@ import { isCommandMenuClosingState } from '@/command-menu/states/isCommandMenuCl
 import { isCommandMenuOpenedState } from '@/command-menu/states/isCommandMenuOpenedState';
 import { type CommandMenuPages } from '@/command-menu/types/CommandMenuPages';
 import { MAIN_CONTEXT_STORE_INSTANCE_ID } from '@/context-store/constants/MainContextStoreInstanceId';
-import { isDragSelectionStartEnabledState } from '@/ui/utilities/drag-select/states/internal/isDragSelectionStartEnabledState';
 import { usePushFocusItemToFocusStack } from '@/ui/utilities/focus/hooks/usePushFocusItemToFocusStack';
 import { FocusComponentType } from '@/ui/utilities/focus/types/FocusComponentType';
 import { useRecoilCallback } from 'recoil';
@@ -72,7 +71,6 @@ export const useNavigateCommandMenu = () => {
 
         set(isCommandMenuOpenedState, true);
         set(hasUserSelectedCommandState, false);
-        set(isDragSelectionStartEnabledState, false);
       },
     [
       copyContextStoreStates,


### PR DESCRIPTION
We disabled that before because the side panel was always on top of the content. But now it makes sense to enable this.