### PR TITLE
fix: preserve relations during optimistic cache update when modifying task assignee

### DIFF
--- a/packages/twenty-front/src/modules/object-record/hooks/useUpdateOneRecord.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useUpdateOneRecord.ts
@@ -118,12 +118,15 @@ export const useUpdateOneRecord = <
       isDefined(cachedRecordWithConnection);
 
     if (shouldHandleOptimisticCache) {
-      const recordGqlFields = generateDepthRecordGqlFieldsFromRecord({
-        objectMetadataItem,
-        objectMetadataItems,
-        record: optimisticRecordInput,
-        depth: 1,
-      });
+      const recordGqlFields = {
+        ...computedRecordGqlFields,
+        ...generateDepthRecordGqlFieldsFromRecord({
+          objectMetadataItem,
+          objectMetadataItems,
+          record: optimisticRecordInput,
+          depth: 1,
+        }),
+      };
 
       updateRecordFromCache({
         objectMetadataItems,


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where changing a task's assignee on a Record page caused relations (like taskTargets) to disappear from the UI.

### Explain How the Feature Works

The optimistic cache update now preserves all existing relation fields when modifying task properties. Previously, only the fields being updated were included in the cache update, causing other relations to be dropped.

**Technical fix:**
Merge `computedRecordGqlFields` (all depth-1 fields) with fields from the optimistic input to ensure relation fields aren't lost during cache updates.

### Relevant User Scenarios

- Users editing task assignees on Company/Person record pages
- Any scenario where updating one field shouldn't affect other relations
- Prevents unexpected UI state loss during optimistic updates

fixes #16624