### PR TITLE
Issue #16615 Removes the dropdown chevron to align with the Figma file

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormMultiSelectFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormMultiSelectFieldInput.tsx
@@ -223,10 +223,6 @@ export const FormMultiSelectFieldInput = ({
                 ) : (
                   <StyledPlaceholder />
                 )}
-                <IconChevronDown
-                  size={theme.icon.size.md}
-                  color={theme.font.color.light}
-                />
               </StyledDisplayModeReadonlyContainer>
             ) : (
               <StyledDisplayModeContainer

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormSingleRecordPicker.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormSingleRecordPicker.tsx
@@ -20,7 +20,7 @@ import styled from '@emotion/styled';
 import { isNonEmptyString } from '@sniptt/guards';
 import { useCallback, useId } from 'react';
 import { CustomError, isDefined, isValidUuid } from 'twenty-shared/utils';
-import { IconChevronDown, IconForbid } from 'twenty-ui/display';
+import { IconForbid } from 'twenty-ui/display';
 
 const StyledFormSelectContainer = styled(FormFieldInputInnerContainer)<{
   readonly?: boolean;
@@ -201,12 +201,6 @@ export const FormSingleRecordPicker = ({
                   onRemove={handleUnlinkVariable}
                   disabled={disabled}
                 />
-                <StyledIconButton>
-                  <IconChevronDown
-                    size={theme.icon.size.md}
-                    color={theme.font.color.light}
-                  />
-                </StyledIconButton>
               </StyledFormSelectContainer>
             }
             dropdownComponents={


### PR DESCRIPTION
### Explain How the Feature Works

The Unique Fields section is informational and displays existing unique constraints. Matching and value mapping should be done in the fields section below.
Removing the dropdown indicator makes this behavior clearer.

### Technical fix

Removed `IconChevronDown` from:

- `packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormMultiSelectFieldInput.tsx`
- `packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormMultiSelectFieldInputContainer.tsx`

UI now matches the Figma design referenced in the issue comments.

## After
Dropdown indicator removed

<img width="583" height="767" alt="Screenshot 2025-12-19 at 12 14 18 AM" src="https://github.com/user-attachments/assets/68379884-7fa9-4fe0-a7dc-8b89bf198115" />
