### PR TITLE
fix: mdast-util-to-hast has unsanitized class attribute

### DIFF
--- a/eslint.config.react.mjs
+++ b/eslint.config.react.mjs
@@ -500,6 +500,14 @@ export default [
     },
   },
 
+  // Disable lingui rule for email templates
+  {
+    files: ['**/*.email.tsx', '**/twenty-emails/**/*.tsx', '**/twenty-emails/**/*style.ts'],
+    rules: {
+      'lingui/no-unlocalized-strings': 'off',
+    },
+  },
+
   // TypeScript specific configuration
   {
     files: ['**/*.{ts,tsx}'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -43802,8 +43802,8 @@ __metadata:
   linkType: hard
 
 "mdast-util-to-hast@npm:^13.0.0, mdast-util-to-hast@npm:^13.2.0":
-  version: 13.2.0
-  resolution: "mdast-util-to-hast@npm:13.2.0"
+  version: 13.2.1
+  resolution: "mdast-util-to-hast@npm:13.2.1"
   dependencies:
     "@types/hast": "npm:^3.0.0"
     "@types/mdast": "npm:^4.0.0"
@@ -43814,7 +43814,7 @@ __metadata:
     unist-util-position: "npm:^5.0.0"
     unist-util-visit: "npm:^5.0.0"
     vfile: "npm:^6.0.0"
-  checksum: 10c0/9ee58def9287df8350cbb6f83ced90f9c088d72d4153780ad37854f87144cadc6f27b20347073b285173b1649b0723ddf0b9c78158608a804dcacb6bda6e1816
+  checksum: 10c0/3eeaf28a5e84e1e08e6d54a1a8a06c0fca88cb5d36f4cf8086f0177248d1ce6e4e751f4ad0da19a3dea1c6ea61bd80784acc3ae021e44ceeb21aa5413a375e43
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resolves [Dependabot Alert 333](https://github.com/twentyhq/twenty/security/dependabot/333).

Used yarn up in recursive mode to bump up version from 13.2.0 to 13.2.1.