### PR TITLE
fix: expose all database event properties in workflow triggers

### DIFF
--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-schema/utils/__tests__/generate-fake-object-record-event.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-schema/utils/__tests__/generate-fake-object-record-event.spec.ts
@@ -36,58 +36,70 @@ describe('generateFakeObjectRecordEvent', () => {
     );
 
     expect(result).toEqual({
-      object: {
+      workspaceMemberId: {
         isLeaf: true,
-        icon: 'test-company-icon',
-        label: 'Company',
-        value: 'A company',
-        fieldIdName: 'properties.after.id',
-        objectMetadataId: '20202020-c03c-45d6-a4b0-04afe1357c5c',
+        type: 'string',
+        label: 'Workspace Member ID',
+        value: null,
       },
-      fields: {
-        'properties.after.field1': {
-          type: 'TEXT',
-          value: 'test',
-          fieldMetadataId: '123e4567-e89b-12d3-a456-426614174000',
-        },
-        'properties.after.field2': {
-          type: 'NUMBER',
-          value: 123,
-          fieldMetadataId: '123e4567-e89b-12d3-a456-426614174001',
-        },
+      'properties.after.field1': {
+        type: 'TEXT',
+        value: 'test',
+        fieldMetadataId: '123e4567-e89b-12d3-a456-426614174000',
       },
-      _outputSchemaType: 'RECORD',
+      'properties.after.field2': {
+        type: 'NUMBER',
+        value: 123,
+        fieldMetadataId: '123e4567-e89b-12d3-a456-426614174001',
+      },
     });
   });
 
-  it('should generate record with "after" prefix for UPDATED action', () => {
+  it('should generate record with "before" and "after" prefix for UPDATED action', () => {
     const result = generateFakeObjectRecordEvent(
       mockCompanyObjectMetadataInfo,
       DatabaseEventAction.UPDATED,
     );
 
     expect(result).toEqual({
-      object: {
+      workspaceMemberId: {
         isLeaf: true,
-        icon: 'test-company-icon',
-        label: 'Company',
-        value: 'A company',
-        fieldIdName: 'properties.after.id',
-        objectMetadataId: '20202020-c03c-45d6-a4b0-04afe1357c5c',
+        type: 'string',
+        label: 'Workspace Member ID',
+        value: null,
       },
-      fields: {
-        'properties.after.field1': {
-          type: 'TEXT',
-          value: 'test',
-          fieldMetadataId: '123e4567-e89b-12d3-a456-426614174000',
-        },
-        'properties.after.field2': {
-          type: 'NUMBER',
-          value: 123,
-          fieldMetadataId: '123e4567-e89b-12d3-a456-426614174001',
-        },
+      'properties.before.field1': {
+        type: 'TEXT',
+        value: 'test',
+        fieldMetadataId: '123e4567-e89b-12d3-a456-426614174000',
       },
-      _outputSchemaType: 'RECORD',
+      'properties.before.field2': {
+        type: 'NUMBER',
+        value: 123,
+        fieldMetadataId: '123e4567-e89b-12d3-a456-426614174001',
+      },
+      'properties.after.field1': {
+        type: 'TEXT',
+        value: 'test',
+        fieldMetadataId: '123e4567-e89b-12d3-a456-426614174000',
+      },
+      'properties.after.field2': {
+        type: 'NUMBER',
+        value: 123,
+        fieldMetadataId: '123e4567-e89b-12d3-a456-426614174001',
+      },
+      'properties.diff': {
+        isLeaf: true,
+        type: 'object',
+        label: 'Changed Fields',
+        value: {},
+      },
+      'properties.updatedFields': {
+        isLeaf: true,
+        type: 'array',
+        label: 'Updated Field Names',
+        value: [],
+      },
     });
   });
 
@@ -98,27 +110,22 @@ describe('generateFakeObjectRecordEvent', () => {
     );
 
     expect(result).toEqual({
-      object: {
+      workspaceMemberId: {
         isLeaf: true,
-        icon: 'test-company-icon',
-        label: 'Company',
-        value: 'A company',
-        fieldIdName: 'properties.before.id',
-        objectMetadataId: '20202020-c03c-45d6-a4b0-04afe1357c5c',
+        type: 'string',
+        label: 'Workspace Member ID',
+        value: null,
       },
-      fields: {
-        'properties.before.field1': {
-          type: 'TEXT',
-          value: 'test',
-          fieldMetadataId: '123e4567-e89b-12d3-a456-426614174000',
-        },
-        'properties.before.field2': {
-          type: 'NUMBER',
-          value: 123,
-          fieldMetadataId: '123e4567-e89b-12d3-a456-426614174001',
-        },
+      'properties.before.field1': {
+        type: 'TEXT',
+        value: 'test',
+        fieldMetadataId: '123e4567-e89b-12d3-a456-426614174000',
       },
-      _outputSchemaType: 'RECORD',
+      'properties.before.field2': {
+        type: 'NUMBER',
+        value: 123,
+        fieldMetadataId: '123e4567-e89b-12d3-a456-426614174001',
+      },
     });
   });
 
@@ -129,27 +136,22 @@ describe('generateFakeObjectRecordEvent', () => {
     );
 
     expect(result).toEqual({
-      object: {
+      workspaceMemberId: {
         isLeaf: true,
-        icon: 'test-company-icon',
-        label: 'Company',
-        value: 'A company',
-        fieldIdName: 'properties.before.id',
-        objectMetadataId: '20202020-c03c-45d6-a4b0-04afe1357c5c',
+        type: 'string',
+        label: 'Workspace Member ID',
+        value: null,
       },
-      fields: {
-        'properties.before.field1': {
-          type: 'TEXT',
-          value: 'test',
-          fieldMetadataId: '123e4567-e89b-12d3-a456-426614174000',
-        },
-        'properties.before.field2': {
-          type: 'NUMBER',
-          value: 123,
-          fieldMetadataId: '123e4567-e89b-12d3-a456-426614174001',
-        },
+      'properties.before.field1': {
+        type: 'TEXT',
+        value: 'test',
+        fieldMetadataId: '123e4567-e89b-12d3-a456-426614174000',
       },
-      _outputSchemaType: 'RECORD',
+      'properties.before.field2': {
+        type: 'NUMBER',
+        value: 123,
+        fieldMetadataId: '123e4567-e89b-12d3-a456-426614174001',
+      },
     });
   });
 
@@ -160,27 +162,28 @@ describe('generateFakeObjectRecordEvent', () => {
     );
 
     expect(result).toEqual({
-      object: {
+      workspaceMemberId: {
         isLeaf: true,
-        icon: 'test-company-icon',
-        label: 'Company',
-        value: 'A company',
-        fieldIdName: 'properties.after.id',
-        objectMetadataId: '20202020-c03c-45d6-a4b0-04afe1357c5c',
+        type: 'string',
+        label: 'Workspace Member ID',
+        value: null,
       },
-      fields: {
-        'properties.after.field1': {
-          type: 'TEXT',
-          value: 'test',
-          fieldMetadataId: '123e4567-e89b-12d3-a456-426614174000',
-        },
-        'properties.after.field2': {
-          type: 'NUMBER',
-          value: 123,
-          fieldMetadataId: '123e4567-e89b-12d3-a456-426614174001',
-        },
+      'properties.after.field1': {
+        type: 'TEXT',
+        value: 'test',
+        fieldMetadataId: '123e4567-e89b-12d3-a456-426614174000',
       },
-      _outputSchemaType: 'RECORD',
+      'properties.after.field2': {
+        type: 'NUMBER',
+        value: 123,
+        fieldMetadataId: '123e4567-e89b-12d3-a456-426614174001',
+      },
+      'properties.updatedFields': {
+        isLeaf: true,
+        type: 'array',
+        label: 'Updated Field Names',
+        value: [],
+      },
     });
   });
 

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-schema/utils/generate-fake-object-record-event.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-schema/utils/generate-fake-object-record-event.ts
@@ -1,6 +1,7 @@
 import { DatabaseEventAction } from 'src/engine/api/graphql/graphql-query-runner/enums/database-event-action';
 import { type ObjectMetadataInfo } from 'src/modules/workflow/common/workspace-services/workflow-common.workspace-service';
 import {
+  type BaseOutputSchema,
   type FieldOutputSchema,
   type RecordOutputSchema,
 } from 'src/modules/workflow/workflow-builder/workflow-schema/types/output-schema.type';
@@ -14,9 +15,7 @@ const generateFakeObjectRecordEventWithPrefix = ({
   prefix: string;
 }): RecordOutputSchema => {
   const { flatObjectMetadata } = objectMetadataInfo;
-  const recordFields = generateObjectRecordFields({
-    objectMetadataInfo,
-  });
+  const recordFields = generateObjectRecordFields({ objectMetadataInfo });
   const prefixedRecordFields = Object.entries(recordFields).reduce(
     (acc, [key, value]) => {
       acc[`${prefix}.${key}`] = value;
@@ -43,21 +42,85 @@ const generateFakeObjectRecordEventWithPrefix = ({
 export const generateFakeObjectRecordEvent = (
   objectMetadataInfo: ObjectMetadataInfo,
   action: DatabaseEventAction,
-): RecordOutputSchema => {
+): BaseOutputSchema => {
+  const baseFields: BaseOutputSchema = {
+    workspaceMemberId: {
+      isLeaf: true,
+      type: 'string',
+      label: 'Workspace Member ID',
+      value: null,
+    },
+  };
+
   switch (action) {
-    case DatabaseEventAction.CREATED:
-    case DatabaseEventAction.UPDATED:
-    case DatabaseEventAction.UPSERTED:
-      return generateFakeObjectRecordEventWithPrefix({
+    case DatabaseEventAction.CREATED: {
+      const afterRecord = generateFakeObjectRecordEventWithPrefix({
         objectMetadataInfo,
         prefix: 'properties.after',
       });
-    case DatabaseEventAction.DELETED:
-    case DatabaseEventAction.DESTROYED:
-      return generateFakeObjectRecordEventWithPrefix({
+
+      return {
+        ...baseFields,
+        ...(afterRecord.fields as BaseOutputSchema),
+      };
+    }
+    case DatabaseEventAction.UPDATED: {
+      const beforeRecord = generateFakeObjectRecordEventWithPrefix({
         objectMetadataInfo,
         prefix: 'properties.before',
       });
+      const afterRecord = generateFakeObjectRecordEventWithPrefix({
+        objectMetadataInfo,
+        prefix: 'properties.after',
+      });
+
+      return {
+        ...baseFields,
+        ...(beforeRecord.fields as BaseOutputSchema),
+        ...(afterRecord.fields as BaseOutputSchema),
+        'properties.diff': {
+          isLeaf: true,
+          type: 'object',
+          label: 'Changed Fields',
+          value: {},
+        },
+        'properties.updatedFields': {
+          isLeaf: true,
+          type: 'array',
+          label: 'Updated Field Names',
+          value: [],
+        },
+      };
+    }
+    case DatabaseEventAction.UPSERTED: {
+      const afterRecord = generateFakeObjectRecordEventWithPrefix({
+        objectMetadataInfo,
+        prefix: 'properties.after',
+      });
+
+      return {
+        ...baseFields,
+        ...(afterRecord.fields as BaseOutputSchema),
+        'properties.updatedFields': {
+          isLeaf: true,
+          type: 'array',
+          label: 'Updated Field Names',
+          value: [],
+        },
+      };
+    }
+    case DatabaseEventAction.DELETED:
+    case DatabaseEventAction.DESTROYED: {
+      const beforeRecord = generateFakeObjectRecordEventWithPrefix({
+        objectMetadataInfo,
+        prefix: 'properties.before',
+      });
+
+      return {
+        ...baseFields,
+        ...(beforeRecord.fields as BaseOutputSchema),
+      };
+    }
     default:
       throw new Error(`Unknown action '${action}'`);
   }


### PR DESCRIPTION
Fixes twentyhq/core-team-issues#2362

Previously, database event triggers only exposed properties.after fields. This fix exposes all relevant properties based on event type (before, after, diff, updatedFields) for complete workflow context.