### PR TITLE
Fix Global workflows not pinned

### DIFF
--- a/packages/twenty-front/src/modules/action-menu/actions/record-agnostic-actions/run-workflow-actions/hooks/useRunWorkflowRecordAgnosticActions.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-agnostic-actions/run-workflow-actions/hooks/useRunWorkflowRecordAgnosticActions.tsx
@@ -41,6 +41,7 @@ export const useRunWorkflowRecordAgnosticActions = () => {
         key: `workflow-run-${activeWorkflowVersion.id}`,
         scope: ActionScope.Global,
         label: name,
+        shortLabel: name,
         position: index,
         isPinned: activeWorkflowVersion.trigger?.settings?.isPinned,
         Icon,

--- a/packages/twenty-front/src/modules/action-menu/actions/record-agnostic-actions/run-workflow-actions/hooks/useRunWorkflowRecordAgnosticActions.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-agnostic-actions/run-workflow-actions/hooks/useRunWorkflowRecordAgnosticActions.tsx
@@ -42,6 +42,7 @@ export const useRunWorkflowRecordAgnosticActions = () => {
         scope: ActionScope.Global,
         label: name,
         position: index,
+        isPinned: activeWorkflowVersion.trigger?.settings?.isPinned,
         Icon,
         shouldBeRegistered: () => true,
         component: (


### PR DESCRIPTION
A bug was reported where workflow actions marked as Pinned were actually not pinned in the top right

In workflow edit:
<img width="400" height="379" alt="image" src="https://github.com/user-attachments/assets/adea9b4e-c898-4395-8cbf-d21282770fac" />

Consequence on Header:
<img width="400" height="53" alt="image" src="https://github.com/user-attachments/assets/a39e4201-2450-4566-978a-7f464d3a64f0" />
