### PR TITLE
fix(docs): only download translations for supported languages

### DIFF
--- a/.github/workflows/docs-i18n-pull.yaml
+++ b/.github/workflows/docs-i18n-pull.yaml
@@ -96,6 +96,8 @@ jobs:
           create_pull_request: false
           skip_ref_checkout: true
           dryrun_action: false
+          # Only download languages supported by Mintlify (see supported-languages.ts)
+          download_language: 'fr,ar,cs,de,es,it,ja,ko,pt,ro,ru,tr,zh-CN'
         env:
           GITHUB_TOKEN: ${{ github.token }}
           CROWDIN_PROJECT_ID: '1'


### PR DESCRIPTION
## Summary
The Crowdin GitHub Action was failing at ~54% progress with the error:
> Failed to build translation. Please contact our support team for help

## Root Cause
The build was attempting to process all target languages configured in Crowdin, including languages not supported by Mintlify (as defined in `supported-languages.ts`). Some of these unsupported languages had translation issues causing the build to fail.

## Fix
Added the `download_language` parameter to the Crowdin GitHub Action to restrict downloads to only the languages supported by Mintlify:
- fr, ar, cs, de, es, it, ja, ko, pt, ro, ru, tr, zh-CN

## Testing
Verified via Crowdin API that builds succeed when specifying only these supported languages, while the full build fails.