### PR TITLE
feat: add customizable field ordering for detail views

### DIFF
--- a/packages/twenty-front/src/modules/object-metadata/types/ObjectMetadataItem.ts
+++ b/packages/twenty-front/src/modules/object-metadata/types/ObjectMetadataItem.ts
@@ -18,4 +18,5 @@ export type ObjectMetadataItem = Omit<
   updatableFields: FieldMetadataItem[];
   labelIdentifierFieldMetadataId: string;
   indexMetadatas: IndexMetadataItem[];
+  detailFieldOrder?: string[] | null;
 };

--- a/packages/twenty-front/src/modules/settings/data-model/object-details/components/SettingsDetailFieldOrderSection.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/object-details/components/SettingsDetailFieldOrderSection.tsx
@@ -1,0 +1,189 @@
+import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
+import { useUpdateOneObjectMetadataItem } from '@/object-metadata/hooks/useUpdateOneObjectMetadataItem';
+import { type ObjectMetadataItem } from '@/object-metadata/types/ObjectMetadataItem';
+import { isFieldCellSupported } from '@/object-record/utils/isFieldCellSupported';
+import { DraggableItem } from '@/ui/layout/draggable-list/components/DraggableItem';
+import { DraggableList } from '@/ui/layout/draggable-list/components/DraggableList';
+import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
+import styled from '@emotion/styled';
+import { useLingui } from '@lingui/react/macro';
+import { useState, useEffect, useMemo } from 'react';
+import { FieldMetadataType } from 'twenty-shared/types';
+import { H2Title, IconGripVertical } from 'twenty-ui/display';
+import { Section } from 'twenty-ui/layout';
+import { type OnDragEndResponder } from '@hello-pangea/dnd';
+import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
+import { useLabelIdentifierFieldMetadataItem } from '@/object-metadata/hooks/useLabelIdentifierFieldMetadataItem';
+
+const StyledFieldItem = styled.div<{ isDragging: boolean }>`
+  align-items: center;
+  background-color: ${({ theme, isDragging }) =>
+    isDragging ? theme.background.transparent.light : theme.background.primary};
+  border: 1px solid ${({ theme }) => theme.border.color.medium};
+  border-radius: ${({ theme }) => theme.border.radius.sm};
+  cursor: grab;
+  display: flex;
+  gap: ${({ theme }) => theme.spacing(2)};
+  padding: ${({ theme }) => theme.spacing(2)};
+  margin-bottom: ${({ theme }) => theme.spacing(2)};
+
+  &:active {
+    cursor: grabbing;
+  }
+`;
+
+const StyledFieldName = styled.div`
+  color: ${({ theme }) => theme.font.color.primary};
+  font-size: ${({ theme }) => theme.font.size.md};
+  font-weight: ${({ theme }) => theme.font.weight.medium};
+`;
+
+const StyledFieldType = styled.div`
+  color: ${({ theme }) => theme.font.color.tertiary};
+  font-size: ${({ theme }) => theme.font.size.sm};
+  margin-left: auto;
+`;
+
+const StyledIconContainer = styled.div`
+  color: ${({ theme }) => theme.font.color.tertiary};
+  display: flex;
+  align-items: center;
+`;
+
+type SettingsDetailFieldOrderSectionProps = {
+  objectMetadataItem: ObjectMetadataItem;
+};
+
+export const SettingsDetailFieldOrderSection = ({
+  objectMetadataItem,
+}: SettingsDetailFieldOrderSectionProps) => {
+  const { t } = useLingui();
+  const { updateOneObjectMetadataItem } = useUpdateOneObjectMetadataItem();
+  const { enqueueSuccessSnackBar } = useSnackBar();
+  const { objectMetadataItems } = useObjectMetadataItems();
+  const { labelIdentifierFieldMetadataItem } =
+    useLabelIdentifierFieldMetadataItem({
+      objectNameSingular: objectMetadataItem.nameSingular,
+    });
+
+  // Get all available fields for this object, excluding label identifier and unsupported fields
+  const availableFields = useMemo(() => {
+    return objectMetadataItem.fields
+      .filter(
+        (field) =>
+          isFieldCellSupported(field, objectMetadataItems) &&
+          field.id !== labelIdentifierFieldMetadataItem?.id &&
+          field.name !== 'createdAt' &&
+          field.name !== 'deletedAt' &&
+          field.type !== FieldMetadataType.RICH_TEXT_V2,
+      )
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }, [objectMetadataItem.fields, objectMetadataItems, labelIdentifierFieldMetadataItem]);
+
+  // Initialize ordered fields based on saved order or default alphabetical
+  const [orderedFieldIds, setOrderedFieldIds] = useState<string[]>(() => {
+    if (objectMetadataItem.detailFieldOrder && objectMetadataItem.detailFieldOrder.length > 0) {
+      // Filter out any field IDs that no longer exist
+      const validFieldIds = objectMetadataItem.detailFieldOrder.filter((id) =>
+        availableFields.some((field) => field.id === id),
+      );
+      // Add any new fields that aren't in the saved order
+      const newFieldIds = availableFields
+        .filter((field) => !validFieldIds.includes(field.id))
+        .map((field) => field.id);
+      return [...validFieldIds, ...newFieldIds];
+    }
+    return availableFields.map((field) => field.id);
+  });
+
+  // Update ordered fields when available fields change
+  useEffect(() => {
+    const currentFieldIds = new Set(orderedFieldIds);
+    const availableFieldIds = new Set(availableFields.map((f) => f.id));
+
+    // Check if we need to update (fields added or removed)
+    const needsUpdate =
+      orderedFieldIds.some(id => !availableFieldIds.has(id)) ||
+      availableFields.some(field => !currentFieldIds.has(field.id));
+
+    if (needsUpdate) {
+      const validFieldIds = orderedFieldIds.filter((id) =>
+        availableFieldIds.has(id),
+      );
+      const newFieldIds = availableFields
+        .filter((field) => !currentFieldIds.has(field.id))
+        .map((field) => field.id);
+      setOrderedFieldIds([...validFieldIds, ...newFieldIds]);
+    }
+  }, [availableFields, orderedFieldIds]);
+
+  const orderedFields = useMemo(() => {
+    return orderedFieldIds
+      .map((id) => availableFields.find((field) => field.id === id))
+      .filter((field): field is NonNullable<typeof field> => field !== undefined);
+  }, [orderedFieldIds, availableFields]);
+
+  const handleDragEnd: OnDragEndResponder = async (result) => {
+    if (!result.destination) {
+      return;
+    }
+
+    const sourceIndex = result.source.index;
+    const destinationIndex = result.destination.index;
+
+    if (sourceIndex === destinationIndex) {
+      return;
+    }
+
+    // Reorder the fields
+    const newOrderedFieldIds = Array.from(orderedFieldIds);
+    const [movedFieldId] = newOrderedFieldIds.splice(sourceIndex, 1);
+    newOrderedFieldIds.splice(destinationIndex, 0, movedFieldId);
+
+    setOrderedFieldIds(newOrderedFieldIds);
+
+    // Save to backend
+    const updateResult = await updateOneObjectMetadataItem({
+      idToUpdate: objectMetadataItem.id,
+      updatePayload: { detailFieldOrder: newOrderedFieldIds },
+    });
+
+    if (updateResult.status === 'successful') {
+      enqueueSuccessSnackBar({
+        message: t`Field order updated`,
+      });
+    }
+  };
+
+  return (
+    <Section>
+      <H2Title
+        title={t`Detail View Field Order`}
+        description={t`Drag and drop to reorder how fields appear in the detail view`}
+      />
+      <DraggableList
+        onDragEnd={handleDragEnd}
+        draggableItems={
+          <>
+            {orderedFields.map((field, index) => (
+              <DraggableItem
+                key={field.id}
+                draggableId={field.id}
+                index={index}
+                itemComponent={({ isDragging }) => (
+                  <StyledFieldItem isDragging={isDragging}>
+                    <StyledIconContainer>
+                      <IconGripVertical size={16} />
+                    </StyledIconContainer>
+                    <StyledFieldName>{field.label}</StyledFieldName>
+                    <StyledFieldType>{field.type}</StyledFieldType>
+                  </StyledFieldItem>
+                )}
+              />
+            ))}
+          </>
+        }
+      />
+    </Section>
+  );
+};

--- a/packages/twenty-front/src/modules/settings/data-model/object-details/components/tabs/ObjectFields.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/object-details/components/tabs/ObjectFields.tsx
@@ -12,11 +12,18 @@ import { Section } from 'twenty-ui/layout';
 import { UndecoratedLink } from 'twenty-ui/navigation';
 import { isObjectMetadataSettingsReadOnly } from '@/object-record/read-only/utils/isObjectMetadataSettingsReadOnly';
 import { useRecoilValue } from 'recoil';
+import { SettingsDetailFieldOrderSection } from '@/settings/data-model/object-details/components/SettingsDetailFieldOrderSection';
 
 const StyledDiv = styled.div`
   display: flex;
   justify-content: flex-end;
   padding-top: ${({ theme }) => theme.spacing(2)};
+`;
+
+const StyledContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing(8)};
 `;
 
 type ObjectFieldsProps = {
@@ -35,31 +42,34 @@ export const ObjectFields = ({ objectMetadataItem }: ObjectFieldsProps) => {
   const objectLabelSingular = objectMetadataItem.labelSingular;
 
   return (
-    <Section>
-      <H2Title
-        title={t`Fields`}
-        description={t`Customise the fields available in the ${objectLabelSingular} views.`}
-      />
-      <SettingsObjectFieldTable
-        objectMetadataItem={objectMetadataItem}
-        mode="view"
-      />
-      {!readonly && (
-        <StyledDiv>
-          <UndecoratedLink
-            to={getSettingsPath(SettingsPath.ObjectNewFieldSelect, {
-              objectNamePlural: objectMetadataItem.namePlural,
-            })}
-          >
-            <Button
-              Icon={IconPlus}
-              title={t`Add Field`}
-              size="small"
-              variant="secondary"
-            />
-          </UndecoratedLink>
-        </StyledDiv>
-      )}
-    </Section>
+    <StyledContainer>
+      <Section>
+        <H2Title
+          title={t`Fields`}
+          description={t`Customise the fields available in the ${objectLabelSingular} views.`}
+        />
+        <SettingsObjectFieldTable
+          objectMetadataItem={objectMetadataItem}
+          mode="view"
+        />
+        {!readonly && (
+          <StyledDiv>
+            <UndecoratedLink
+              to={getSettingsPath(SettingsPath.ObjectNewFieldSelect, {
+                objectNamePlural: objectMetadataItem.namePlural,
+              })}
+            >
+              <Button
+                Icon={IconPlus}
+                title={t`Add Field`}
+                size="small"
+                variant="secondary"
+              />
+            </UndecoratedLink>
+          </StyledDiv>
+        )}
+      </Section>
+      <SettingsDetailFieldOrderSection objectMetadataItem={objectMetadataItem} />
+    </StyledContainer>
   );
 };

--- a/packages/twenty-server/src/database/typeorm/core/migrations/common/1766420584000-addDetailFieldOrderToObjectMetadata.ts
+++ b/packages/twenty-server/src/database/typeorm/core/migrations/common/1766420584000-addDetailFieldOrderToObjectMetadata.ts
@@ -1,0 +1,19 @@
+import { type MigrationInterface, type QueryRunner } from 'typeorm';
+
+export class AddDetailFieldOrderToObjectMetadata1766420584000
+  implements MigrationInterface
+{
+  name = 'AddDetailFieldOrderToObjectMetadata1766420584000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "core"."objectMetadata" ADD "detailFieldOrder" jsonb`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "core"."objectMetadata" DROP COLUMN "detailFieldOrder"`,
+    );
+  }
+}

--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/dtos/object-metadata.dto.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/dtos/object-metadata.dto.ts
@@ -56,6 +56,9 @@ export class ObjectMetadataDTO {
   @Field({ nullable: true })
   shortcut?: string;
 
+  @Field(() => [String], { nullable: true })
+  detailFieldOrder?: string[] | null;
+
   @FilterableField()
   isCustom: boolean;
 

--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/dtos/update-object.input.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/dtos/update-object.input.ts
@@ -2,6 +2,7 @@ import { Field, InputType } from '@nestjs/graphql';
 
 import { Type } from 'class-transformer';
 import {
+  IsArray,
   IsBoolean,
   IsNotEmpty,
   IsOptional,
@@ -51,6 +52,11 @@ export class UpdateObjectPayload {
   @IsOptional()
   @Field({ nullable: true })
   shortcut?: string;
+
+  @IsArray()
+  @IsOptional()
+  @Field(() => [String], { nullable: true })
+  detailFieldOrder?: string[] | null;
 
   @IsBoolean()
   @IsOptional()

--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.entity.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.entity.ts
@@ -97,6 +97,9 @@ export class ObjectMetadataEntity
   @Column({ nullable: true, type: 'varchar' })
   shortcut: string | null;
 
+  @Column({ type: 'jsonb', nullable: true })
+  detailFieldOrder: string[] | null;
+
   // TODO: This should not be nullable - legacy field introduced when label identifier was nullable
   @Column({ nullable: true, type: 'uuid' })
   labelIdentifierFieldMetadataId: string | null;


### PR DESCRIPTION
This commit implements a new feature that allows users to reorder fields in detail views through a drag-and-drop interface in settings.

Changes:
- Added detailFieldOrder column to objectMetadata table to store custom field order
- Updated ObjectMetadataEntity and GraphQL DTOs to include detailFieldOrder
- Created SettingsDetailFieldOrderSection component with drag-and-drop functionality
- Updated useFieldListFieldMetadataItems to use custom field order when available
- Integrated field ordering UI into ObjectFields settings tab

The field order is persisted per object type and automatically applied to all detail views. If no custom order is set, fields display alphabetically (existing behavior).