### PR TITLE
Fix database event emission

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/billing/listeners/billing-workspace-member.listener.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/listeners/billing-workspace-member.listener.ts
@@ -27,6 +27,7 @@ export class BillingWorkspaceMemberListener {
 
   @OnDatabaseBatchEvent('workspaceMember', DatabaseEventAction.CREATED)
   @OnDatabaseBatchEvent('workspaceMember', DatabaseEventAction.DELETED)
+  @OnDatabaseBatchEvent('workspaceMember', DatabaseEventAction.DESTROYED)
   async handleCreateOrDeleteEvent(
     payload: WorkspaceEventBatch<
       ObjectRecordCreateEvent<WorkspaceMemberWorkspaceEntity>

--- a/packages/twenty-server/src/engine/twenty-orm/utils/compute-event-select-query-builder.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/compute-event-select-query-builder.util.ts
@@ -46,5 +46,14 @@ export const computeEventSelectQueryBuilder = <T extends ObjectLiteral>({
   eventSelectQueryBuilder.expressionMap.aliases = expressionMap.aliases;
   eventSelectQueryBuilder.setParameters(expressionMap.parameters);
 
+  if (
+    eventSelectQueryBuilder.expressionMap.selects.length === 0 &&
+    eventSelectQueryBuilder.expressionMap.mainAlias
+  ) {
+    eventSelectQueryBuilder.expressionMap.selects = [
+      { selection: eventSelectQueryBuilder.expressionMap.mainAlias.name },
+    ];
+  }
+
   return eventSelectQueryBuilder;
 };


### PR DESCRIPTION
Fixes https://github.com/twentyhq/private-issues/issues/395


When calling `removeUserFromWorkspaceAndPotentiallyDeleteWorkspace` from `user.service`, 
```
        await workspaceMemberRepository.delete({
          userId: userWorkspace.userId,
        });
```
related database event is not emitted.

Same issue with update has been fixed [here](https://github.com/twentyhq/twenty/pull/13287/changes)

The database event is not emitted because `await eventSelectQueryBuilder.getOne()` in `workspace-delete-query-builder` returns `null`. This happens because the `selectQueryBuilder` has no entity—the database request is sent and the raw result is not `null`, but the entity is `null`, causing the final result to be null.

It can be fixed the same way update has been fixed, updating the `workspace-entity-manager`
- Pros : consistant with update but we should not forget to fix softDelete and restore
- Cons : `workspace-entity-manager` is a copy of typeORM logic + permission injection. Should it be more ?
 
Alternatively (as featured in this PR), it can be fixed by updating computeEventSelectQueryBuilder, inspired by TypeORM's logic in typeorm/query-builder/QueryBuilder.js at line 67.
- Pros : it fit with typeORM logic + It fixes all repository operations
