### PR TITLE
fix: prevent workflow step title from transferring between steps.

### DIFF
--- a/packages/twenty-front/src/modules/command-menu/components/CommandMenuPageInfo.tsx
+++ b/packages/twenty-front/src/modules/command-menu/components/CommandMenuPageInfo.tsx
@@ -41,6 +41,7 @@ export const CommandMenuPageInfo = ({ pageChip }: CommandMenuPageInfoProps) => {
   if (isWorkflowStepPage && isDefined(pageChip.page?.pageId)) {
     return (
       <CommandMenuWorkflowStepInfo
+        key={pageChip.page.pageId}
         commandMenuPageInstanceId={pageChip.page.pageId}
       />
     );


### PR DESCRIPTION
fixes (#16754)

Solution:
Add key prop to CommandMenuWorkflowStepInfo to force React to remount the component when switching between steps, ensuring fresh state.


https://github.com/user-attachments/assets/77f51f5b-6b25-4c05-aaf7-8704ab8bee0f
