### PR TITLE
fix: enable API key management of workspace views + fix permission bypass vulnerability

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/create-view-field-permission.guard.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/create-view-field-permission.guard.ts
@@ -40,6 +40,7 @@ export class CreateViewFieldPermissionGuard implements CanActivate {
       viewId,
       request.userWorkspaceId,
       request.workspace.id,
+      request.apiKey?.id,
     );
   }
 }

--- a/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/create-view-filter-group-permission.guard.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/create-view-filter-group-permission.guard.ts
@@ -33,6 +33,7 @@ export class CreateViewFilterGroupPermissionGuard implements CanActivate {
       viewId,
       request.userWorkspaceId,
       request.workspace.id,
+      request.apiKey?.id,
     );
   }
 }

--- a/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/create-view-filter-permission.guard.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/create-view-filter-permission.guard.ts
@@ -33,6 +33,7 @@ export class CreateViewFilterPermissionGuard implements CanActivate {
       viewId,
       request.userWorkspaceId,
       request.workspace.id,
+      request.apiKey?.id,
     );
   }
 }

--- a/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/create-view-group-permission.guard.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/create-view-group-permission.guard.ts
@@ -40,6 +40,7 @@ export class CreateViewGroupPermissionGuard implements CanActivate {
       viewId,
       request.userWorkspaceId,
       request.workspace.id,
+      request.apiKey?.id,
     );
   }
 }

--- a/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/create-view-permission.guard.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/create-view-permission.guard.ts
@@ -34,6 +34,7 @@ export class CreateViewPermissionGuard implements CanActivate {
       visibility,
       request.userWorkspaceId,
       request.workspace.id,
+      request.apiKey?.id,
     );
   }
 }

--- a/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/create-view-sort-permission.guard.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/create-view-sort-permission.guard.ts
@@ -33,6 +33,7 @@ export class CreateViewSortPermissionGuard implements CanActivate {
       viewId,
       request.userWorkspaceId,
       request.workspace.id,
+      request.apiKey?.id,
     );
   }
 }

--- a/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/delete-view-field-permission.guard.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/delete-view-field-permission.guard.ts
@@ -45,6 +45,7 @@ export class DeleteViewFieldPermissionGuard implements CanActivate {
       viewId,
       request.userWorkspaceId,
       request.workspace.id,
+      request.apiKey?.id,
     );
   }
 }

--- a/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/delete-view-filter-group-permission.guard.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/delete-view-filter-group-permission.guard.ts
@@ -45,6 +45,7 @@ export class DeleteViewFilterGroupPermissionGuard implements CanActivate {
       viewId,
       request.userWorkspaceId,
       request.workspace.id,
+      request.apiKey?.id,
     );
   }
 }

--- a/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/delete-view-filter-permission.guard.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/delete-view-filter-permission.guard.ts
@@ -45,6 +45,7 @@ export class DeleteViewFilterPermissionGuard implements CanActivate {
       viewId,
       request.userWorkspaceId,
       request.workspace.id,
+      request.apiKey?.id,
     );
   }
 }

--- a/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/delete-view-group-permission.guard.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/delete-view-group-permission.guard.ts
@@ -45,6 +45,7 @@ export class DeleteViewGroupPermissionGuard implements CanActivate {
       viewId,
       request.userWorkspaceId,
       request.workspace.id,
+      request.apiKey?.id,
     );
   }
 }

--- a/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/delete-view-permission.guard.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/delete-view-permission.guard.ts
@@ -33,6 +33,7 @@ export class DeleteViewPermissionGuard implements CanActivate {
       viewId,
       request.userWorkspaceId,
       request.workspace.id,
+      request.apiKey?.id,
     );
   }
 }

--- a/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/delete-view-sort-permission.guard.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/delete-view-sort-permission.guard.ts
@@ -45,6 +45,7 @@ export class DeleteViewSortPermissionGuard implements CanActivate {
       viewId,
       request.userWorkspaceId,
       request.workspace.id,
+      request.apiKey?.id,
     );
   }
 }

--- a/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/destroy-view-field-permission.guard.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/destroy-view-field-permission.guard.ts
@@ -45,6 +45,7 @@ export class DestroyViewFieldPermissionGuard implements CanActivate {
       viewId,
       request.userWorkspaceId,
       request.workspace.id,
+      request.apiKey?.id,
     );
   }
 }

--- a/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/destroy-view-filter-group-permission.guard.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/destroy-view-filter-group-permission.guard.ts
@@ -45,6 +45,7 @@ export class DestroyViewFilterGroupPermissionGuard implements CanActivate {
       viewId,
       request.userWorkspaceId,
       request.workspace.id,
+      request.apiKey?.id,
     );
   }
 }

--- a/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/destroy-view-filter-permission.guard.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/destroy-view-filter-permission.guard.ts
@@ -45,6 +45,7 @@ export class DestroyViewFilterPermissionGuard implements CanActivate {
       viewId,
       request.userWorkspaceId,
       request.workspace.id,
+      request.apiKey?.id,
     );
   }
 }

--- a/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/destroy-view-group-permission.guard.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/destroy-view-group-permission.guard.ts
@@ -45,6 +45,7 @@ export class DestroyViewGroupPermissionGuard implements CanActivate {
       viewId,
       request.userWorkspaceId,
       request.workspace.id,
+      request.apiKey?.id,
     );
   }
 }

--- a/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/destroy-view-permission.guard.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/destroy-view-permission.guard.ts
@@ -33,6 +33,7 @@ export class DestroyViewPermissionGuard implements CanActivate {
       viewId,
       request.userWorkspaceId,
       request.workspace.id,
+      request.apiKey?.id,
     );
   }
 }

--- a/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/destroy-view-sort-permission.guard.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/destroy-view-sort-permission.guard.ts
@@ -45,6 +45,7 @@ export class DestroyViewSortPermissionGuard implements CanActivate {
       viewId,
       request.userWorkspaceId,
       request.workspace.id,
+      request.apiKey?.id,
     );
   }
 }

--- a/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/update-view-field-permission.guard.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/update-view-field-permission.guard.ts
@@ -45,6 +45,7 @@ export class UpdateViewFieldPermissionGuard implements CanActivate {
       viewId,
       request.userWorkspaceId,
       request.workspace.id,
+      request.apiKey?.id,
     );
   }
 }

--- a/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/update-view-filter-group-permission.guard.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/update-view-filter-group-permission.guard.ts
@@ -45,6 +45,7 @@ export class UpdateViewFilterGroupPermissionGuard implements CanActivate {
       viewId,
       request.userWorkspaceId,
       request.workspace.id,
+      request.apiKey?.id,
     );
   }
 }

--- a/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/update-view-filter-permission.guard.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/update-view-filter-permission.guard.ts
@@ -45,6 +45,7 @@ export class UpdateViewFilterPermissionGuard implements CanActivate {
       viewId,
       request.userWorkspaceId,
       request.workspace.id,
+      request.apiKey?.id,
     );
   }
 }

--- a/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/update-view-group-permission.guard.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/update-view-group-permission.guard.ts
@@ -45,6 +45,7 @@ export class UpdateViewGroupPermissionGuard implements CanActivate {
       viewId,
       request.userWorkspaceId,
       request.workspace.id,
+      request.apiKey?.id,
     );
   }
 }

--- a/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/update-view-permission.guard.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/update-view-permission.guard.ts
@@ -33,6 +33,7 @@ export class UpdateViewPermissionGuard implements CanActivate {
       viewId,
       request.userWorkspaceId,
       request.workspace.id,
+      request.apiKey?.id,
     );
   }
 }

--- a/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/update-view-sort-permission.guard.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-permissions/guards/update-view-sort-permission.guard.ts
@@ -45,6 +45,7 @@ export class UpdateViewSortPermissionGuard implements CanActivate {
       viewId,
       request.userWorkspaceId,
       request.workspace.id,
+      request.apiKey?.id,
     );
   }
 }

--- a/packages/twenty-server/src/engine/metadata-modules/view-permissions/services/view-access.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view-permissions/services/view-access.service.ts
@@ -126,6 +126,16 @@ export class ViewAccessService {
       return true;
     }
 
+    // API keys with VIEWS permission can manipulate workspace views
+    // (userWorkspaceId is undefined for API keys, and createdByUserWorkspaceId is null for workspace views created by API keys)
+    if (
+      !isDefined(userWorkspaceId) &&
+      !isDefined(view.createdByUserWorkspaceId) &&
+      view.visibility === ViewVisibility.WORKSPACE
+    ) {
+      return true;
+    }
+
     // Users without VIEWS permission can only manipulate their own unlisted views
     const canAccess =
       view.visibility === ViewVisibility.UNLISTED &&

--- a/packages/twenty-server/src/engine/metadata-modules/view/resolvers/view.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/view/resolvers/view.resolver.ts
@@ -153,7 +153,7 @@ export class ViewResolver {
     return await this.viewService.createOne({
       createViewInput: input,
       workspaceId: workspace.id,
-      createdByUserWorkspaceId: userWorkspaceId ?? '',
+      createdByUserWorkspaceId: userWorkspaceId,
     });
   }
 


### PR DESCRIPTION
Fixes #16739

- Remove empty string coercion in createCoreView that caused PostgreSQL UUID errors for API keys
- Add permission check allowing API keys with VIEWS permission to manage workspace views they created

API keys with 'Manage Views' permission can now create, update, and delete workspace views via both GraphQL and REST APIs.