### PR TITLE
[DASHBOARDS] Update iFrame error message

### DIFF
--- a/packages/twenty-front/src/modules/page-layout/widgets/components/PageLayoutWidgetNoDataDisplay.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/components/PageLayoutWidgetNoDataDisplay.tsx
@@ -1,21 +1,15 @@
+import { useCurrentWidget } from '@/page-layout/widgets/hooks/useCurrentWidget';
 import { t } from '@lingui/core/macro';
 import { AppTooltip, Status } from 'twenty-ui/display';
 import { WidgetType } from '~/generated/graphql';
 
-type PageLayoutWidgetNoDataDisplayProps = {
-  widgetId: string;
-  widgetType: WidgetType;
-};
+export const PageLayoutWidgetNoDataDisplay = () => {
+  const widget = useCurrentWidget();
+  const tooltipId = `widget-incomplete-tooltip-${widget.id}`;
 
-export const PageLayoutWidgetNoDataDisplay = ({
-  widgetId,
-  widgetType,
-}: PageLayoutWidgetNoDataDisplayProps) => {
-  const tooltipId = `widget-incomplete-tooltip-${widgetId}`;
-
-  const text = widgetType === WidgetType.IFRAME ? t`Invalid URL` : t`No Data`;
+  const text = widget.type === WidgetType.IFRAME ? t`Invalid URL` : t`No Data`;
   const tooltipContent =
-    widgetType === WidgetType.IFRAME
+    widget.type === WidgetType.IFRAME
       ? t`Invalid URL. Click edit to configure this widget.`
       : t`No data available. Click edit to configure this widget.`;
 

--- a/packages/twenty-front/src/modules/page-layout/widgets/components/PageLayoutWidgetNoDataDisplay.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/components/PageLayoutWidgetNoDataDisplay.tsx
@@ -1,23 +1,32 @@
 import { t } from '@lingui/core/macro';
 import { AppTooltip, Status } from 'twenty-ui/display';
+import { WidgetType } from '~/generated/graphql';
 
 type PageLayoutWidgetNoDataDisplayProps = {
   widgetId: string;
+  widgetType: WidgetType;
 };
 
 export const PageLayoutWidgetNoDataDisplay = ({
   widgetId,
+  widgetType,
 }: PageLayoutWidgetNoDataDisplayProps) => {
   const tooltipId = `widget-incomplete-tooltip-${widgetId}`;
+
+  const text = widgetType === WidgetType.IFRAME ? t`Invalid URL` : t`No Data`;
+  const tooltipContent =
+    widgetType === WidgetType.IFRAME
+      ? t`Invalid URL. Click edit to configure this widget.`
+      : t`No data available. Click edit to configure this widget.`;
 
   return (
     <>
       <div id={tooltipId}>
-        <Status color="red" text={t`No Data`} />
+        <Status color="red" text={text} />
       </div>
       <AppTooltip
         anchorSelect={`#${tooltipId}`}
-        content={t`No data available. Click edit to configure this widget.`}
+        content={tooltipContent}
         place="top"
       />
     </>

--- a/packages/twenty-front/src/modules/page-layout/widgets/graph/components/GraphWidget.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/graph/components/GraphWidget.tsx
@@ -40,12 +40,7 @@ export const GraphWidget = ({
   );
 
   if (!hasValidConfiguration) {
-    return (
-      <PageLayoutWidgetNoDataDisplay
-        widgetId={widget.id}
-        widgetType={widget.type}
-      />
-    );
+    return <PageLayoutWidgetNoDataDisplay />;
   }
 
   switch (graphType) {

--- a/packages/twenty-front/src/modules/page-layout/widgets/graph/components/GraphWidget.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/graph/components/GraphWidget.tsx
@@ -40,7 +40,12 @@ export const GraphWidget = ({
   );
 
   if (!hasValidConfiguration) {
-    return <PageLayoutWidgetNoDataDisplay widgetId={widget.id} />;
+    return (
+      <PageLayoutWidgetNoDataDisplay
+        widgetId={widget.id}
+        widgetType={widget.type}
+      />
+    );
   }
 
   switch (graphType) {

--- a/packages/twenty-front/src/modules/page-layout/widgets/graph/components/GraphWidgetRenderer.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/graph/components/GraphWidgetRenderer.tsx
@@ -10,12 +10,7 @@ type GraphWidgetRendererProps = {
 
 export const GraphWidgetRenderer = ({ widget }: GraphWidgetRendererProps) => {
   if (!widget.configuration || !('graphType' in widget.configuration)) {
-    return (
-      <PageLayoutWidgetNoDataDisplay
-        widgetId={widget.id}
-        widgetType={widget.type}
-      />
-    );
+    return <PageLayoutWidgetNoDataDisplay />;
   }
 
   const graphType = widget.configuration.graphType;
@@ -24,12 +19,7 @@ export const GraphWidgetRenderer = ({ widget }: GraphWidgetRendererProps) => {
     !Object.values(GraphType).includes(graphType) ||
     !isDefined(widget.objectMetadataId)
   ) {
-    return (
-      <PageLayoutWidgetNoDataDisplay
-        widgetId={widget.id}
-        widgetType={widget.type}
-      />
-    );
+    return <PageLayoutWidgetNoDataDisplay />;
   }
 
   return (

--- a/packages/twenty-front/src/modules/page-layout/widgets/graph/components/GraphWidgetRenderer.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/graph/components/GraphWidgetRenderer.tsx
@@ -10,7 +10,12 @@ type GraphWidgetRendererProps = {
 
 export const GraphWidgetRenderer = ({ widget }: GraphWidgetRendererProps) => {
   if (!widget.configuration || !('graphType' in widget.configuration)) {
-    return <PageLayoutWidgetNoDataDisplay widgetId={widget.id} />;
+    return (
+      <PageLayoutWidgetNoDataDisplay
+        widgetId={widget.id}
+        widgetType={widget.type}
+      />
+    );
   }
 
   const graphType = widget.configuration.graphType;
@@ -19,7 +24,12 @@ export const GraphWidgetRenderer = ({ widget }: GraphWidgetRendererProps) => {
     !Object.values(GraphType).includes(graphType) ||
     !isDefined(widget.objectMetadataId)
   ) {
-    return <PageLayoutWidgetNoDataDisplay widgetId={widget.id} />;
+    return (
+      <PageLayoutWidgetNoDataDisplay
+        widgetId={widget.id}
+        widgetType={widget.type}
+      />
+    );
   }
 
   return (

--- a/packages/twenty-front/src/modules/page-layout/widgets/iframe/components/IframeWidget.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/iframe/components/IframeWidget.tsx
@@ -84,7 +84,10 @@ export const IframeWidget = ({ widget }: IframeWidgetProps) => {
     return (
       <StyledContainer $isEditMode={isPageLayoutInEditMode}>
         <StyledErrorContainer>
-          <PageLayoutWidgetNoDataDisplay widgetId={widget.id} />
+          <PageLayoutWidgetNoDataDisplay
+            widgetId={widget.id}
+            widgetType={widget.type}
+          />
         </StyledErrorContainer>
       </StyledContainer>
     );

--- a/packages/twenty-front/src/modules/page-layout/widgets/iframe/components/IframeWidget.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/iframe/components/IframeWidget.tsx
@@ -84,10 +84,7 @@ export const IframeWidget = ({ widget }: IframeWidgetProps) => {
     return (
       <StyledContainer $isEditMode={isPageLayoutInEditMode}>
         <StyledErrorContainer>
-          <PageLayoutWidgetNoDataDisplay
-            widgetId={widget.id}
-            widgetType={widget.type}
-          />
+          <PageLayoutWidgetNoDataDisplay />
         </StyledErrorContainer>
       </StyledContainer>
     );


### PR DESCRIPTION
`Invalid URL` instead of `no data` for iFrame widgets.

<img width="1142" height="638" alt="CleanShot 2025-12-23 at 14 13 17@2x" src="https://github.com/user-attachments/assets/22621e57-c4ba-4e1f-91d0-5c4ef435c649" />
