### PR TITLE
fix: 🐛 visible fields count updates when toggling field

### DIFF
--- a/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownDefaultView.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownDefaultView.tsx
@@ -1,6 +1,6 @@
 import { OBJECT_OPTIONS_DROPDOWN_ID } from '@/object-record/object-options-dropdown/constants/ObjectOptionsDropdownId';
 import { useObjectOptionsDropdown } from '@/object-record/object-options-dropdown/hooks/useObjectOptionsDropdown';
-import { useObjectOptionsForBoard } from '@/object-record/object-options-dropdown/hooks/useObjectOptionsForBoard';
+import { visibleRecordFieldsComponentSelector } from '@/object-record/record-field/states/visibleRecordFieldsComponentSelector';
 import { DropdownContent } from '@/ui/layout/dropdown/components/DropdownContent';
 import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/DropdownMenuItemsContainer';
 import { DropdownMenuSeparator } from '@/ui/layout/dropdown/components/DropdownMenuSeparator';
@@ -24,18 +24,16 @@ import { useCopyToClipboard } from '~/hooks/useCopyToClipboard';
 
 export const ObjectOptionsDropdownDefaultView = () => {
   const { t } = useLingui();
-  const { recordIndexId, objectMetadataItem, onContentChange } =
-    useObjectOptionsDropdown();
+  const { recordIndexId, onContentChange } = useObjectOptionsDropdown();
 
   const { currentView } = useGetCurrentViewOnly();
 
-  const { visibleBoardFields } = useObjectOptionsForBoard({
-    objectNameSingular: objectMetadataItem.nameSingular,
-    recordBoardId: recordIndexId,
-    viewBarId: recordIndexId,
-  });
+  const visibleRecordFields = useRecoilComponentValue(
+    visibleRecordFieldsComponentSelector,
+    recordIndexId,
+  );
 
-  const visibleFieldsCount = visibleBoardFields.length;
+  const visibleFieldsCount = visibleRecordFields.length;
 
   const selectableItemIdArray = [
     'Fields',


### PR DESCRIPTION
Fixes: #16734

Solution:
The ObjectOptionsDropdownDefaultView was reading from recordIndexFieldDefinitionsState via useObjectOptionsForBoard, while field visibility changes update currentRecordFieldsComponentState. This caused the "X shown" count to remain stale after hiding fields.

Changed to use visibleRecordFieldsComponentSelector (same state source used by ViewFieldsVisibleDropdownSection) so both components react to the same state updates.


https://github.com/user-attachments/assets/62eb5c98-f15f-4ee8-bdce-1ab4e4752f66

