### PR TITLE
feat: enforce credit limits via Stripe alerts for all billing scenarios

### DIFF
--- a/packages/twenty-front/src/modules/ai/components/AIChatCreditsExhaustedMessage.tsx
+++ b/packages/twenty-front/src/modules/ai/components/AIChatCreditsExhaustedMessage.tsx
@@ -52,7 +52,6 @@ export const AIChatCreditsExhaustedMessage = () => {
     const result = await endTrialPeriod();
     setIsProcessing(false);
 
-    // If no payment method, redirect to billing portal to add one
     if (!result.success) {
       openBillingPortal();
     }

--- a/packages/twenty-front/src/modules/ai/components/ToolStepRenderer.tsx
+++ b/packages/twenty-front/src/modules/ai/components/ToolStepRenderer.tsx
@@ -142,7 +142,6 @@ export const ToolStepRenderer = ({ toolPart }: { toolPart: ToolUIPart }) => {
   const hasError = isDefined(errorText);
   const isExpandable = isDefined(output) || hasError;
 
-  // Special handling for code_interpreter tool
   if (toolName === 'code_interpreter') {
     const codeInput = toolInput as { code?: string } | undefined;
     const codeOutput = output as {

--- a/packages/twenty-server/src/engine/core-modules/billing-webhook/services/billing-webhook-invoice.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing-webhook/services/billing-webhook-invoice.service.ts
@@ -2,11 +2,15 @@ import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { isDefined } from 'twenty-shared/utils';
-import { Repository } from 'typeorm';
+import { type Repository } from 'typeorm';
 
 import type Stripe from 'stripe';
 
+import { BillingProductKey } from 'src/engine/core-modules/billing/enums/billing-product-key.enum';
 import { BillingSubscriptionItemEntity } from 'src/engine/core-modules/billing/entities/billing-subscription-item.entity';
+import { BillingSubscriptionItemService } from 'src/engine/core-modules/billing/services/billing-subscription-item.service';
+import { BillingSubscriptionService } from 'src/engine/core-modules/billing/services/billing-subscription.service';
+import { StripeBillingAlertService } from 'src/engine/core-modules/billing/stripe/services/stripe-billing-alert.service';
 
 const SUBSCRIPTION_CYCLE_BILLING_REASON = 'subscription_cycle';
 
@@ -16,12 +20,20 @@ export class BillingWebhookInvoiceService {
   constructor(
     @InjectRepository(BillingSubscriptionItemEntity)
     private readonly billingSubscriptionItemRepository: Repository<BillingSubscriptionItemEntity>,
+    private readonly billingSubscriptionService: BillingSubscriptionService,
+    private readonly billingSubscriptionItemService: BillingSubscriptionItemService,
+    private readonly stripeBillingAlertService: StripeBillingAlertService,
   ) {}
 
   async processStripeEvent(data: Stripe.InvoiceFinalizedEvent.Data) {
-    const { billing_reason: billingReason, subscription } = data.object;
+    const {
+      billing_reason: billingReason,
+      subscription,
+      customer,
+    } = data.object;
 
     const stripeSubscriptionId = subscription as string | undefined;
+    const stripeCustomerId = customer as string | undefined;
 
     if (
       isDefined(stripeSubscriptionId) &&
@@ -31,6 +43,54 @@ export class BillingWebhookInvoiceService {
         { stripeSubscriptionId },
         { hasReachedCurrentPeriodCap: false },
       );
+
+      // Create new billing alert for this billing period
+      if (isDefined(stripeCustomerId)) {
+        await this.createBillingAlertForNewPeriod(
+          stripeSubscriptionId,
+          stripeCustomerId,
+        );
+      }
     }
+  }
+
+  private async createBillingAlertForNewPeriod(
+    stripeSubscriptionId: string,
+    stripeCustomerId: string,
+  ): Promise<void> {
+    const subscription =
+      await this.billingSubscriptionService.getCurrentBillingSubscription({
+        stripeCustomerId,
+      });
+
+    if (!isDefined(subscription)) {
+      this.logger.warn(
+        `Cannot create billing alert: subscription not found for stripeCustomerId ${stripeCustomerId}`,
+      );
+
+      return;
+    }
+
+    const meteredItemDetails =
+      await this.billingSubscriptionItemService.getMeteredSubscriptionItemDetails(
+        subscription.id,
+      );
+
+    const workflowItem = meteredItemDetails.find(
+      (item) => item.productKey === BillingProductKey.WORKFLOW_NODE_EXECUTION,
+    );
+
+    if (!isDefined(workflowItem)) {
+      this.logger.warn(
+        `Cannot create billing alert: workflow subscription item not found for subscription ${subscription.id}`,
+      );
+
+      return;
+    }
+
+    await this.stripeBillingAlertService.createUsageThresholdAlertForCustomerMeter(
+      stripeCustomerId,
+      workflowItem.tierQuantity,
+    );
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/billing-webhook/services/billing-webhook-invoice.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing-webhook/services/billing-webhook-invoice.service.ts
@@ -44,7 +44,6 @@ export class BillingWebhookInvoiceService {
         { hasReachedCurrentPeriodCap: false },
       );
 
-      // Create new billing alert for this billing period
       if (isDefined(stripeCustomerId)) {
         await this.createBillingAlertForNewPeriod(
           stripeSubscriptionId,

--- a/packages/twenty-server/src/engine/core-modules/billing/services/__test__/billing-subscription.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/services/__test__/billing-subscription.service.spec.ts
@@ -20,6 +20,7 @@ import { BillingSubscriptionService } from 'src/engine/core-modules/billing/serv
 import { StripeCustomerService } from 'src/engine/core-modules/billing/stripe/services/stripe-customer.service';
 import { StripeSubscriptionItemService } from 'src/engine/core-modules/billing/stripe/services/stripe-subscription-item.service';
 import { StripeSubscriptionScheduleService } from 'src/engine/core-modules/billing/stripe/services/stripe-subscription-schedule.service';
+import { StripeBillingAlertService } from 'src/engine/core-modules/billing/stripe/services/stripe-billing-alert.service';
 import { StripeSubscriptionService } from 'src/engine/core-modules/billing/stripe/services/stripe-subscription.service';
 import { SubscriptionUpdateType } from 'src/engine/core-modules/billing/types/billing-subscription-update.type';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
@@ -163,6 +164,12 @@ describe('BillingSubscriptionService', () => {
         {
           provide: getRepositoryToken(BillingCustomerEntity),
           useValue: repoMock<BillingCustomerEntity>(),
+        },
+        {
+          provide: StripeBillingAlertService,
+          useValue: {
+            createUsageThresholdAlertForCustomerMeter: jest.fn(),
+          },
         },
         BillingPriceService,
       ],

--- a/packages/twenty-server/src/engine/core-modules/billing/services/billing-subscription.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/services/billing-subscription.service.ts
@@ -39,6 +39,7 @@ import { BillingPlanService } from 'src/engine/core-modules/billing/services/bil
 import { BillingPriceService } from 'src/engine/core-modules/billing/services/billing-price.service';
 import { BillingProductService } from 'src/engine/core-modules/billing/services/billing-product.service';
 import { BillingSubscriptionPhaseService } from 'src/engine/core-modules/billing/services/billing-subscription-phase.service';
+import { StripeBillingAlertService } from 'src/engine/core-modules/billing/stripe/services/stripe-billing-alert.service';
 import { StripeCustomerService } from 'src/engine/core-modules/billing/stripe/services/stripe-customer.service';
 import { StripeSubscriptionScheduleService } from 'src/engine/core-modules/billing/stripe/services/stripe-subscription-schedule.service';
 import { StripeSubscriptionService } from 'src/engine/core-modules/billing/stripe/services/stripe-subscription.service';
@@ -81,6 +82,7 @@ export class BillingSubscriptionService {
     private readonly billingSubscriptionPhaseService: BillingSubscriptionPhaseService,
     @InjectRepository(BillingCustomerEntity)
     private readonly billingCustomerRepository: Repository<BillingSubscriptionEntity>,
+    private readonly stripeBillingAlertService: StripeBillingAlertService,
   ) {}
 
   async getBillingSubscriptions(workspaceId: string) {
@@ -221,10 +223,35 @@ export class BillingSubscriptionService {
       { workspaceId },
     );
 
-    await this.updateSubscription(billingSubscription.id, {
+    const subscriptionUpdate = {
       type: SubscriptionUpdateType.METERED_PRICE,
       newMeteredPriceId: meteredPriceId,
-    });
+    } as const;
+
+    const isScheduledForPeriodEnd =
+      await this.shouldUpdateAtSubscriptionPeriodEnd(
+        billingSubscription,
+        subscriptionUpdate,
+      );
+
+    await this.updateSubscription(billingSubscription.id, subscriptionUpdate);
+
+    // If it's an immediate upgrade (not scheduled for period end),
+    // reset the cap flag and create an alert at the new tier cap
+    if (!isScheduledForPeriodEnd) {
+      await this.billingSubscriptionItemRepository.update(
+        { stripeSubscriptionId: billingSubscription.stripeSubscriptionId },
+        { hasReachedCurrentPeriodCap: false },
+      );
+
+      const newTierCap =
+        await this.getWorkflowTierCapFromPriceId(meteredPriceId);
+
+      await this.stripeBillingAlertService.createUsageThresholdAlertForCustomerMeter(
+        billingSubscription.stripeCustomerId,
+        newTierCap,
+      );
+    }
   }
 
   async cancelSwitchMeteredPrice(workspace: WorkspaceEntity): Promise<void> {
@@ -272,6 +299,16 @@ export class BillingSubscriptionService {
     await this.billingSubscriptionItemRepository.update(
       { stripeSubscriptionId: updatedSubscription.id },
       { hasReachedCurrentPeriodCap: false },
+    );
+
+    // Create billing alert at the paid tier cap (not trial cap)
+    const tierCap = await this.getWorkflowTierCapForSubscription(
+      billingSubscription.id,
+    );
+
+    await this.stripeBillingAlertService.createUsageThresholdAlertForCustomerMeter(
+      billingSubscription.stripeCustomerId,
+      tierCap,
     );
 
     return {
@@ -511,6 +548,59 @@ export class BillingSubscriptionService {
           : 'BILLING_FREE_WORKFLOW_CREDITS_FOR_TRIAL_PERIOD_WITHOUT_CREDIT_CARD',
       ),
     );
+  }
+
+  async getWorkflowTierCapForSubscription(
+    subscriptionId: string,
+  ): Promise<number> {
+    const subscription = await this.billingSubscriptionRepository.findOneOrFail(
+      {
+        where: { id: subscriptionId },
+        relations: [
+          'billingSubscriptionItems',
+          'billingSubscriptionItems.billingProduct',
+          'billingSubscriptionItems.billingProduct.billingPrices',
+        ],
+      },
+    );
+
+    const workflowItem = subscription.billingSubscriptionItems.find(
+      (item) =>
+        item.billingProduct.metadata.productKey ===
+        BillingProductKey.WORKFLOW_NODE_EXECUTION,
+    );
+
+    if (!isDefined(workflowItem)) {
+      throw new BillingException(
+        'Workflow subscription item not found',
+        BillingExceptionCode.BILLING_SUBSCRIPTION_ITEM_NOT_FOUND,
+      );
+    }
+
+    const matchingPrice = workflowItem.billingProduct.billingPrices.find(
+      (price) => price.stripePriceId === workflowItem.stripePriceId,
+    );
+
+    if (!isDefined(matchingPrice)) {
+      throw new BillingException(
+        `Cannot find price for product ${workflowItem.stripeProductId}`,
+        BillingExceptionCode.BILLING_PRICE_NOT_FOUND,
+      );
+    }
+
+    billingValidator.assertIsMeteredTiersSchemaOrThrow(matchingPrice.tiers);
+
+    return matchingPrice.tiers[0].up_to;
+  }
+
+  async getWorkflowTierCapFromPriceId(meteredPriceId: string): Promise<number> {
+    const price = await this.billingPriceRepository.findOneOrFail({
+      where: { stripePriceId: meteredPriceId },
+    });
+
+    billingValidator.assertIsMeteredTiersSchemaOrThrow(price.tiers);
+
+    return price.tiers[0].up_to;
   }
 
   private async runSubscriptionUpdate({

--- a/packages/twenty-server/src/engine/core-modules/billing/services/billing-subscription.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/services/billing-subscription.service.ts
@@ -236,8 +236,6 @@ export class BillingSubscriptionService {
 
     await this.updateSubscription(billingSubscription.id, subscriptionUpdate);
 
-    // If it's an immediate upgrade (not scheduled for period end),
-    // reset the cap flag and create an alert at the new tier cap
     if (!isScheduledForPeriodEnd) {
       await this.billingSubscriptionItemRepository.update(
         { stripeSubscriptionId: billingSubscription.stripeSubscriptionId },
@@ -301,7 +299,6 @@ export class BillingSubscriptionService {
       { hasReachedCurrentPeriodCap: false },
     );
 
-    // Create billing alert at the paid tier cap (not trial cap)
     const tierCap = await this.getWorkflowTierCapForSubscription(
       billingSubscription.id,
     );

--- a/packages/twenty-server/src/engine/core-modules/billing/services/billing-subscription.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/services/billing-subscription.service.ts
@@ -595,9 +595,7 @@ export class BillingSubscriptionService {
     return price.tiers[0].up_to;
   }
 
-  async createBillingAlertForCustomer(
-    stripeCustomerId: string,
-  ): Promise<void> {
+  async createBillingAlertForCustomer(stripeCustomerId: string): Promise<void> {
     const subscription = await this.getCurrentBillingSubscription({
       stripeCustomerId,
     });

--- a/packages/twenty-server/src/engine/core-modules/billing/stripe/services/stripe-billing-alert.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/stripe/services/stripe-billing-alert.service.ts
@@ -91,7 +91,7 @@ export class StripeBillingAlertService {
 
     for (const alert of customerAlerts) {
       await this.stripe.billing.alerts.archive(alert.id);
-      this.logger.log(`Archived billing alert ${alert.id} for customer ${customerId}`);
+      this.logger.log(`Archived alert ${alert.id} for customer ${customerId}`);
     }
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/billing/stripe/services/stripe-billing-alert.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/stripe/services/stripe-billing-alert.service.ts
@@ -7,6 +7,7 @@ import type Stripe from 'stripe';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import { StripeSDKService } from 'src/engine/core-modules/billing/stripe/stripe-sdk/services/stripe-sdk.service';
 import { StripeBillingMeterService } from 'src/engine/core-modules/billing/stripe/services/stripe-billing-meter.service';
+import { StripeBillingMeterEventService } from 'src/engine/core-modules/billing/stripe/services/stripe-billing-meter-event.service';
 import { BillingMeterEventName } from 'src/engine/core-modules/billing/enums/billing-meter-event-names';
 
 @Injectable()
@@ -18,6 +19,7 @@ export class StripeBillingAlertService {
     private readonly twentyConfigService: TwentyConfigService,
     private readonly stripeSDKService: StripeSDKService,
     private readonly stripeBillingMeterService: StripeBillingMeterService,
+    private readonly stripeBillingMeterEventService: StripeBillingMeterEventService,
   ) {
     if (!this.twentyConfigService.get('IS_BILLING_ENABLED')) {
       return;
@@ -29,7 +31,7 @@ export class StripeBillingAlertService {
 
   async createUsageThresholdAlertForCustomerMeter(
     customerId: string,
-    gte: number,
+    tierCap: number,
   ): Promise<void> {
     const meter = (await this.stripeBillingMeterService.getAllMeters()).find(
       (meter) => {
@@ -39,11 +41,21 @@ export class StripeBillingAlertService {
 
     assertIsDefinedOrThrow(meter);
 
+    await this.archiveAlertsForCustomer(customerId, meter.id);
+
+    const cumulativeUsage =
+      await this.stripeBillingMeterEventService.getTotalCumulativeUsage(
+        meter.id,
+        customerId,
+      );
+
+    const dynamicThreshold = cumulativeUsage + tierCap;
+
     await this.stripe.billing.alerts.create({
       alert_type: 'usage_threshold',
       title: `Usage cap for customer ${customerId}`,
       usage_threshold: {
-        gte,
+        gte: dynamicThreshold,
         meter: meter.id,
         recurrence: 'one_time',
         filters: [
@@ -54,5 +66,32 @@ export class StripeBillingAlertService {
         ],
       },
     });
+
+    this.logger.log(
+      `Created billing alert for customer ${customerId}: threshold=${dynamicThreshold} (cumulative=${cumulativeUsage} + tierCap=${tierCap})`,
+    );
+  }
+
+  private async archiveAlertsForCustomer(
+    customerId: string,
+    meterId: string,
+  ): Promise<void> {
+    const alerts = await this.stripe.billing.alerts.list({
+      meter: meterId,
+    });
+
+    const customerAlerts = alerts.data.filter(
+      (alert) =>
+        alert.status === 'active' &&
+        alert.usage_threshold?.filters?.some(
+          (filter) =>
+            filter.type === 'customer' && filter.customer === customerId,
+        ),
+    );
+
+    for (const alert of customerAlerts) {
+      await this.stripe.billing.alerts.archive(alert.id);
+      this.logger.log(`Archived billing alert ${alert.id} for customer ${customerId}`);
+    }
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/billing/stripe/services/stripe-billing-alert.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/stripe/services/stripe-billing-alert.service.ts
@@ -41,7 +41,7 @@ export class StripeBillingAlertService {
 
     await this.stripe.billing.alerts.create({
       alert_type: 'usage_threshold',
-      title: `Trial usage cap for customer ${customerId}`,
+      title: `Usage cap for customer ${customerId}`,
       usage_threshold: {
         gte,
         meter: meter.id,

--- a/packages/twenty-server/src/engine/core-modules/billing/stripe/services/stripe-billing-meter-event.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/stripe/services/stripe-billing-meter-event.service.ts
@@ -79,4 +79,19 @@ export class StripeBillingMeterEventService {
       return acc + eventSummary.aggregated_value;
     }, 0);
   }
+
+  async getTotalCumulativeUsage(
+    stripeMeterId: string,
+    stripeCustomerId: string,
+  ): Promise<number> {
+    const startTime = new Date(0);
+    const endTime = new Date();
+
+    return this.sumMeterEvents(
+      stripeMeterId,
+      stripeCustomerId,
+      startTime,
+      endTime,
+    );
+  }
 }


### PR DESCRIPTION
## Summary

This PR ensures usage alerts are created for all billing scenarios.

## Background

Per [Stripe documentation](https://docs.stripe.com/billing/subscriptions/usage-based/alerts), usage alerts are **one-time per customer** - they trigger once and only consider usage reported after the alert is created. This means we need to create a new alert whenever:

1. ✅ Subscription is created (trial) - Already implemented
2. ✅ Trial ends (user becomes Active subscriber) - **Added in this PR**
3. ✅ Credit tier changes (upgrade) - **Added in this PR**
4. ✅ **New billing cycle starts** - **Critical fix in this PR!**

## The Issue

Previously, the invoice webhook reset `hasReachedCurrentPeriodCap = false` at cycle end, but didn't create a new alert. This meant after the first billing period, there was no alert to trigger and users could exceed their limit without being blocked.

## Changes

### 1. Invoice Webhook (`billing-webhook-invoice.service.ts`)
When invoice is finalized for `subscription_cycle`:
- Reset `hasReachedCurrentPeriodCap = false` ✅ (already done)
- **NEW**: Create alert at the current tier cap

### 2. End Trial Period (`billing-subscription.service.ts`)
In `endTrialPeriod()`:
- **NEW**: Create alert at the paid tier cap (not trial cap)

### 3. Credit Tier Upgrades (`billing-subscription.service.ts`)
In `changeMeteredPrice()`, when upgrading immediately (not scheduled for period end):
- **NEW**: Reset `hasReachedCurrentPeriodCap = false`
- **NEW**: Create alert at new tier cap

### 4. Alert Title Update (`stripe-billing-alert.service.ts`)
Changed from "Trial usage cap" to "Usage cap" since alerts are now used for all scenarios.

## Stripe Alert Limits

- Max 25 alerts per meter+customer combination
- Alerts only evaluate usage reported after creation
- One-time alerts trigger once per customer

With monthly billing cycles + occasional tier changes, we should stay well under the 25 alert limit.

## Testing

- TypeScript typechecking passes
- Backend services properly inject new dependencies