### PR TITLE
fix: prevent infinite loop when metadata version cache is empty

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/graphql/hooks/use-graphql-error-handler.hook.ts
+++ b/packages/twenty-server/src/engine/core-modules/graphql/hooks/use-graphql-error-handler.hook.ts
@@ -265,6 +265,7 @@ export const useGraphQLErrorHandlerHook = <
 
         if (
           requestMetadataVersion &&
+          isDefined(currentMetadataVersion) &&
           requestMetadataVersion !== `${currentMetadataVersion}`
         ) {
           options.metricsService.incrementCounter({


### PR DESCRIPTION
## Context

After flushing the Redis cache (e.g., via `cache:flush` command), users get stuck in an infinite loop showing "Your workspace has been updated with a new data model. Please refresh the page." - refreshing the page doesn't help.

## Root Cause

When the cache is flushed, `getMetadataVersion()` returns `undefined`. The version comparison in the error handler then becomes:

```typescript
requestMetadataVersion !== `${currentMetadataVersion}`
// Evaluates to: "5" !== "undefined" → always true
```

This triggers the schema mismatch error on every request, even after page refresh.

## History

| Date | Commit | What Happened |
|------|--------|---------------|
| Aug 2024 | #6691 (`17a1760afd`) | Introduced the `${currentMetadataVersion}` template literal that converts `undefined` to the string `"undefined"` |
| Dec 2025 | #16536 (`0035fc1145`) | Removed the safety check that would throw an early error when cache is empty, allowing `undefined` to propagate |

## Fix

Add `isDefined(currentMetadataVersion)` check before comparing versions. If the server doesn't have a cached version, we shouldn't treat it as a mismatch - the schema factory already handles populating the cache when it actually needs the version.

```typescript
if (
  requestMetadataVersion &&
  isDefined(currentMetadataVersion) &&  // ← Added this check
  requestMetadataVersion !== `${currentMetadataVersion}`
) {
```

## Testing

1. Flush the cache: `npx nx run twenty-server:command cache:flush`
2. Refresh the page
3. Verify no infinite loop occurs and app loads normally