### PR TITLE
fix(table): unify viewField creation and update design

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-header/components/RecordTableHeaderPlusButtonContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-header/components/RecordTableHeaderPlusButtonContent.tsx
@@ -5,6 +5,7 @@ import { useSetRecoilState } from 'recoil';
 import { useActiveFieldMetadataItems } from '@/object-metadata/hooks/useActiveFieldMetadataItems';
 import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
 import { useChangeRecordFieldVisibility } from '@/object-record/record-field/hooks/useChangeRecordFieldVisibility';
+import { currentRecordFieldsComponentState } from '@/object-record/record-field/states/currentRecordFieldsComponentState';
 import { type FieldMetadata } from '@/object-record/record-field/ui/types/FieldMetadata';
 import { useRecordTableContextOrThrow } from '@/object-record/record-table/contexts/RecordTableContext';
 import { type ColumnDefinition } from '@/object-record/record-table/types/ColumnDefinition';
@@ -12,6 +13,7 @@ import { DropdownContent } from '@/ui/layout/dropdown/components/DropdownContent
 import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/DropdownMenuItemsContainer';
 import { DropdownMenuSeparator } from '@/ui/layout/dropdown/components/DropdownMenuSeparator';
 import { useCloseDropdown } from '@/ui/layout/dropdown/hooks/useCloseDropdown';
+import { useRecoilComponentValue } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValue';
 import { navigationMemorizedUrlState } from '@/ui/navigation/states/navigationMemorizedUrlState';
 import { useLingui } from '@lingui/react/macro';
 import { SettingsPath } from 'twenty-shared/types';
@@ -21,8 +23,7 @@ import { MenuItem, UndecoratedLink } from 'twenty-ui/navigation';
 
 export const RecordTableHeaderPlusButtonContent = () => {
   const { t } = useLingui();
-  const { objectMetadataItem, recordTableId, visibleRecordFields } =
-    useRecordTableContextOrThrow();
+  const { objectMetadataItem, recordTableId } = useRecordTableContextOrThrow();
 
   const { closeDropdown } = useCloseDropdown();
 
@@ -49,6 +50,14 @@ export const RecordTableHeaderPlusButtonContent = () => {
   const { activeFieldMetadataItems } = useActiveFieldMetadataItems({
     objectMetadataItem,
   });
+
+  const currentRecordFields = useRecoilComponentValue(
+    currentRecordFieldsComponentState,
+  );
+
+  const visibleRecordFields = currentRecordFields.filter(
+    (recordFieldToFilter) => recordFieldToFilter.isVisible === true,
+  );
 
   const availableFieldMetadataItemsToShow = activeFieldMetadataItems.filter(
     (fieldMetadataItemToFilter) =>


### PR DESCRIPTION
## Summary
Fixes #16852 

This PR unifies the behavior of the "+" button in the table header with the "Options > Fields > Hidden Fields" dropdown.

## Problem
The "+" button in the record table header only showed fields without an existing ViewField (i.e., fields that would require creation of a new ViewField). However, the "Hidden Fields" dropdown showed all non-visible fields, including those with existing ViewFields where `isVisible: false`.

**Example:** A field like "felix" might have a ViewField with `isVisible: false`, while "deletedAt" has no ViewField at all. The "+" button only showed "deletedAt", but should show both.

## Solution
Changed [RecordTableHeaderPlusButtonContent.tsx](cci:7://file:///c:/Users/bh/Desktop/open%20source/twenty/packages/twenty-front/src/modules/object-record/record-table/record-table-header/components/RecordTableHeaderPlusButtonContent.tsx:0:0-0:0) to use `currentRecordFieldsComponentState` to access all record fields, then filter to identify visible fields (`isVisible === true`) and exclude them from the dropdown. This ensures the "+" button displays all hidden fields (including those with existing ViewFields where `isVisible: false`), matching the pattern used in [ViewFieldsHiddenDropdownSection.tsx](cci:7://file:///c:/Users/bh/Desktop/open%20source/twenty/packages/twenty-front/src/modules/views/components/ViewFieldsHiddenDropdownSection.tsx:0:0-0:0).

## Changes
- Added import for `currentRecordFieldsComponentState` and `useRecoilComponentValue`
- Modified filtering logic to show all hidden fields, not just fields without ViewFields

## Testing
- Manual testing of "+" button and "Hidden Fields" dropdown to verify they show the same list of fields
- Verified that hiding a visible field makes it appear in both dropdowns
- Verified that showing a hidden field from the "+" button works correctly