### PR TITLE
fix: add NODE_OPTIONS to storybook build to prevent OOM errors

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -179,7 +179,7 @@
       ],
       "options": {
         "cwd": "{projectRoot}",
-        "command": "VITE_DISABLE_TYPESCRIPT_CHECKER=true storybook build --test",
+        "command": "NODE_OPTIONS='--max-old-space-size=10240' VITE_DISABLE_TYPESCRIPT_CHECKER=true storybook build --test",
         "output-dir": "storybook-static",
         "config-dir": ".storybook"
       },


### PR DESCRIPTION
## Description

The CI was failing with 'JavaScript heap out of memory' errors during storybook builds:

```
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
```

The build was consuming ~6.4GB of memory before crashing.

## Solution

This inlines `NODE_OPTIONS='--max-old-space-size=10240'` directly in the storybook build command, following the same pattern used for other memory-intensive builds in the codebase (e.g., `front-build` job in CI).

## Notes

- The `project.json` had an `env` option with `NODE_OPTIONS`, but it used underscores (`max_old_space_size`) instead of hyphens (`max-old-space-size`), and the `env` option may not be reliably passed through the `nx:run-commands` executor to subprocesses.
- Inlining the env variable in the command is more reliable and matches the pattern used elsewhere in the codebase.