### PR TITLE
fix: cache storybook-static folder to prevent EEXIST errors in tests

### DIFF
--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -17,8 +17,9 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
+  # restore-cache action adds 'v4-' prefix and '-<branch>-<sha>' suffix to the key
   STORYBOOK_BUILD_CACHE_KEY_FOR_RESTORE_ACTION: storybook-build-depot-ubuntu-24.04-8-runner
-  STORYBOOK_BUILD_CACHE_KEY_FOR_SAVE_ACTION: v3-storybook-build-depot-ubuntu-24.04-8-runner-${{ github.ref_name }}-${{ github.sha }}
+  STORYBOOK_BUILD_CACHE_KEY_FOR_SAVE_ACTION: v4-storybook-build-depot-ubuntu-24.04-8-runner-${{ github.ref_name }}-${{ github.sha }}
 
 jobs:
   changed-files-check:
@@ -147,7 +148,7 @@ jobs:
       - name: Restore storybook build cache
         uses: ./.github/actions/restore-cache
         with:
-          key: ${{ env.STORYBOOK_BUILD_CACHE_KEY }}
+          key: ${{ env.STORYBOOK_BUILD_CACHE_KEY_FOR_RESTORE_ACTION }}
       - name: Front / Write .env
         run: |
           cd packages/twenty-front


### PR DESCRIPTION
## Problem

The `front-sb-test` jobs were sometimes failing with:
```
Error: EEXIST: file already exists, mkdir './storybook-static/images/icons/android'
```

## Root Cause

1. `front-sb-build` builds storybook and saves NX cache (but NOT `storybook-static/` folder)
2. `front-sb-test` restores NX cache - NX thinks build is done, but `storybook-static/` doesn't exist
3. `storybook:serve:static` depends on `storybook:build`, so NX re-runs the build
4. Race condition in Storybook's file copy causes EEXIST error

The `storybook-static` folder was **never** included in the cache paths - I verified this by checking git history back to when the save-cache action was created.

## Solution

Add `storybook-static` to the `additional-paths` for both save and restore cache steps. This ensures the built storybook is properly cached and restored, eliminating the need for a rebuild during tests.