### PR TITLE
Allow importing Actor composite fields (Created By) in spreadsheet importfeat(spreadsheet-import): include Actor composite fields (createdBy) …

### DIFF
--- a/packages/twenty-front/src/modules/object-record/spreadsheet-import/hooks/useBuildSpreadSheetImportFields.ts
+++ b/packages/twenty-front/src/modules/object-record/spreadsheet-import/hooks/useBuildSpreadSheetImportFields.ts
@@ -49,6 +49,7 @@ export const useBuildSpreadsheetImportFields = () => {
       case FieldMetadataType.LINKS:
       case FieldMetadataType.PHONES:
       case FieldMetadataType.RICH_TEXT_V2:
+      case FieldMetadataType.ACTOR:
         return handleCompositeFields({
           fieldMetadataItem,
           fieldType: fieldMetadataItem.type,
@@ -88,7 +89,6 @@ export const useBuildSpreadsheetImportFields = () => {
 
       case FieldMetadataType.POSITION:
       case FieldMetadataType.MORPH_RELATION:
-      case FieldMetadataType.ACTOR:
       case FieldMetadataType.TS_VECTOR:
       case FieldMetadataType.RICH_TEXT:
         return [];


### PR DESCRIPTION
…in import field options (fixes #15314) : The import UI previously excluded Actor fields, so composite subfields of Actor (e.g. createdBy.name, createdBy.source, createdBy.workspaceMemberId) were not available as mapping targets during CSV/spreadsheet import.
This change treats FieldMetadataType.ACTOR the same as other composite types when building spreadsheet-import field options, allowing actor subfields marked isImportable to appear in the mapping dropdown.
What I changed

Include FieldMetadataType.ACTOR in the composite-field handling in the spreadsheet import field builder.
Remove ACTOR from the explicit excluded types list so actor composite subfields are emitted as importable fields.
How to verify (manual)

Start the front-end dev server.
Open the CSV/Spreadsheet import flow for an object that has a createdBy (Actor) field.
In the field-mapping step, open the target-field dropdown and confirm the Created by subfields are present and selectable:
Created by / Name (createdBy.name)
Created by / Source (createdBy.source)
Created by / Workspace Member Id (createdBy.workspaceMemberId)
Select a Created by subfield and complete an import to verify the mapping is accepted.
Notes

No backend changes required.
Low-risk, small front-end change that exposes already-defined importable actor subfields (configured in SETTINGS_COMPOSITE_FIELD_TYPE_CONFIGS).