### PR TITLE
Fix navigation memory after custom object rename

### DIFF
--- a/packages/twenty-front/src/modules/settings/data-model/object-details/components/SettingsUpdateDataModelObjectAboutForm.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/object-details/components/SettingsUpdateDataModelObjectAboutForm.tsx
@@ -6,6 +6,7 @@ import {
   type SettingsDataModelObjectAboutFormValues,
   settingsDataModelObjectAboutFormSchema,
 } from '@/settings/data-model/validation-schemas/settingsDataModelObjectAboutFormSchema';
+import { navigationMemorizedUrlState } from '@/ui/navigation/states/navigationMemorizedUrlState';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useSetRecoilState } from 'recoil';
@@ -27,6 +28,10 @@ export const SettingsUpdateDataModelObjectAboutForm = ({
   const setUpdatedObjectNamePlural = useSetRecoilState(
     updatedObjectNamePluralState,
   );
+  const setNavigationMemorizedUrl = useSetRecoilState(
+    navigationMemorizedUrlState,
+  );
+
   const { updateOneObjectMetadataItem } = useUpdateOneObjectMetadataItem();
   const {
     description,
@@ -94,6 +99,28 @@ export const SettingsUpdateDataModelObjectAboutForm = ({
 
     navigate(SettingsPath.ObjectDetail, {
       objectNamePlural: objectNamePluralForRedirection,
+    });
+
+    const previousNamePlural = objectMetadataItem.namePlural;
+    const updatedNamePlural = updatedObject?.data?.updateOneObject.namePlural;
+
+    if (!updatedNamePlural) return;
+
+    setNavigationMemorizedUrl((prev) => {
+      if (!prev) return prev;
+
+      const objectRouteRegex = new RegExp(
+        `^/objects/${previousNamePlural}(/|\\?|$)`,
+      );
+
+      if (!objectRouteRegex.test(prev)) {
+        return prev;
+      }
+
+      return prev.replace(
+        new RegExp(`^/objects/${previousNamePlural}`),
+        `/objects/${updatedNamePlural}`,
+      );
     });
   };
 

--- a/packages/twenty-front/src/modules/settings/data-model/object-details/components/SettingsUpdateDataModelObjectAboutForm.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/object-details/components/SettingsUpdateDataModelObjectAboutForm.tsx
@@ -1,6 +1,7 @@
 import { useUpdateOneObjectMetadataItem } from '@/object-metadata/hooks/useUpdateOneObjectMetadataItem';
 import { type ObjectMetadataItem } from '@/object-metadata/types/ObjectMetadataItem';
 import { isObjectMetadataReadOnly } from '@/object-record/read-only/utils/isObjectMetadataReadOnly';
+import { computeUpdatedNavigationMemorizedUrlAfterObjectNamePluralChange } from '@/settings/data-model/object-details/utils/computeUpdatedNavigationMemorizedUrlAfterObjectNamePluralChange.util';
 import { SettingsDataModelObjectAboutForm } from '@/settings/data-model/objects/forms/components/SettingsDataModelObjectAboutForm';
 import {
   type SettingsDataModelObjectAboutFormValues,
@@ -11,6 +12,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useSetRecoilState } from 'recoil';
 import { SettingsPath } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
 import { useNavigateSettings } from '~/hooks/useNavigateSettings';
 import { updatedObjectNamePluralState } from '~/pages/settings/data-model/states/updatedObjectNamePluralState';
 
@@ -101,27 +103,20 @@ export const SettingsUpdateDataModelObjectAboutForm = ({
       objectNamePlural: objectNamePluralForRedirection,
     });
 
-    const previousNamePlural = objectMetadataItem.namePlural;
-    const updatedNamePlural = updatedObject?.data?.updateOneObject.namePlural;
+    const updatedObjectNamePlural =
+      updatedObject?.data?.updateOneObject.namePlural;
 
-    if (!updatedNamePlural) return;
+    if (!isDefined(updatedObjectNamePlural)) {
+      return;
+    }
 
-    setNavigationMemorizedUrl((prev) => {
-      if (!prev) return prev;
-
-      const objectRouteRegex = new RegExp(
-        `^/objects/${previousNamePlural}(/|\\?|$)`,
-      );
-
-      if (!objectRouteRegex.test(prev)) {
-        return prev;
-      }
-
-      return prev.replace(
-        new RegExp(`^/objects/${previousNamePlural}`),
-        `/objects/${updatedNamePlural}`,
-      );
-    });
+    setNavigationMemorizedUrl((previousNavigationMemorizedUrl) =>
+      computeUpdatedNavigationMemorizedUrlAfterObjectNamePluralChange(
+        previousNavigationMemorizedUrl,
+        objectMetadataItem.namePlural,
+        updatedObjectNamePlural,
+      ),
+    );
   };
 
   const updateObjectMetadata = async (

--- a/packages/twenty-front/src/modules/settings/data-model/object-details/utils/computeUpdatedNavigationMemorizedUrlAfterObjectNamePluralChange.util.ts
+++ b/packages/twenty-front/src/modules/settings/data-model/object-details/utils/computeUpdatedNavigationMemorizedUrlAfterObjectNamePluralChange.util.ts
@@ -1,0 +1,25 @@
+export const computeUpdatedNavigationMemorizedUrlAfterObjectNamePluralChange = (
+  navigationMemorizedUrl: string,
+  previousObjectNamePlural: string,
+  updatedObjectNamePlural: string,
+): string => {
+  const objectRoutePatternWithPreviousNamePlural = `^/objects/${previousObjectNamePlural}`;
+  const objectRouteRegexMatchingPreviousNamePlural = new RegExp(
+    `${objectRoutePatternWithPreviousNamePlural}(/|\\?|$)`,
+  );
+
+  const isNavigationMemorizedUrlMatchingPreviousObjectRoute =
+    objectRouteRegexMatchingPreviousNamePlural.test(navigationMemorizedUrl);
+
+  if (!isNavigationMemorizedUrlMatchingPreviousObjectRoute) {
+    return navigationMemorizedUrl;
+  }
+
+  const navigationMemorizedUrlWithUpdatedObjectNamePlural =
+    navigationMemorizedUrl.replace(
+      new RegExp(objectRoutePatternWithPreviousNamePlural),
+      `/objects/${updatedObjectNamePlural}`,
+    );
+
+  return navigationMemorizedUrlWithUpdatedObjectNamePlural;
+};


### PR DESCRIPTION
This PR fixes an issue where exiting Settings after renaming a custom object could redirect to a stale object URL and result in a `404`. When a custom object name was updated, the memorized navigation URL was not kept in sync, causing redirects to use the old object route. 
The navigation state is now updated only when the memorized URL belongs to the renamed object, ensuring redirects always point to the correct route while preserving unrelated navigation context.

Fixes https://github.com/twentyhq/twenty/issues/11291