### PR TITLE
fix: Update billing on removing a workspaceMember 

### DIFF
--- a/packages/twenty-server/src/engine/twenty-orm/repository/workspace-delete-query-builder.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/repository/workspace-delete-query-builder.ts
@@ -103,7 +103,7 @@ export class WorkspaceDeleteQueryBuilder<
         objectMetadata.isCustom,
       );
 
-      const before = await eventSelectQueryBuilder.getOne();
+      const before = await eventSelectQueryBuilder.getMany();
 
       this.expressionMap.wheres = applyTableAliasOnWhereCondition({
         condition: this.expressionMap.wheres,


### PR DESCRIPTION
Fixes #16912 


When removing a workspace member by clicking the "Delete Account" button from Settings, the billing seats were not being updated because database events were not properly emitted for deleted records.

Root Cause
In `WorkspaceDeleteQueryBuilder.execute()`, the code was using `getOne()` to fetch the record before deletion for event emission. This meant only a single record's `DESTROYED` event would be emitted, even if the delete operation affected multiple records.

Fix
Changed `getOne()` to `getMany()` to ensure all affected records are captured, and proper events are emitted for each one.

The `BillingWorkspaceMemberListener` now correctly receives `workspaceMember.destroyed` events, triggering `UpdateSubscriptionQuantityJob` to update the seat count in the billing system.
