### PR TITLE
[E2E tests] Fix run E2E tests before merge 

### DIFF
--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -354,6 +354,7 @@ jobs:
     if: always() && !cancelled()
     timeout-minutes: 5
     runs-on: ubuntu-latest
+    name: ${{ github.event_name == 'merge_group' && 'ci-e2e-merge-queue-check' || 'ci-e2e-status-check' }}
     needs: [changed-files-check-e2e, e2e-test]
     steps:
       - name: Fail job if any needs failed


### PR DESCRIPTION
I have set a [rule](https://github.com/twentyhq/twenty/settings/rules/11470513) to require `ci-e2e-status-check`  to pass before merging. The problem is, before merging, ci-e2e-tests are skipped (as we only want them to run right before merging), so ci-e2e-status-check evaluates to `passed`, which is re-used by the merge queue, even though we have a trigger for e2e-tests in the merging queue phase.
The attempt to fix this is to give a different name to `ci-e2e-status-check` in the merge queue phase (now being named `ci-e2e-merge-queue-check`), and it is this status we should require in the rule.