### PR TITLE
[E2E tests] Fix run E2E tests before merge - attempt #2

### DIFF
--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -351,7 +351,7 @@ jobs:
         if: contains(needs.*.result, 'failure')
         run: exit 1
   ci-e2e-status-check:
-    if: always() && !cancelled()
+    if: always() && !cancelled() && github.event_name != 'merge_group'
     timeout-minutes: 5
     runs-on: ubuntu-latest
     needs: [changed-files-check-e2e, e2e-test]
@@ -359,3 +359,13 @@ jobs:
       - name: Fail job if any needs failed
         if: contains(needs.*.result, 'failure')
         run: exit 1
+  ci-e2e-merge-queue-check:
+    if: |
+      always() && !cancelled() && github.event_name == 'merge_group'
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    needs: [changed-files-check-e2e, e2e-test]
+    steps:
+      - name: Fail job if any needs failed
+        if: contains(needs.*.result, 'failure')
+        run: exit

--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -368,4 +368,4 @@ jobs:
     steps:
       - name: Fail job if any needs failed
         if: contains(needs.*.result, 'failure')
-        run: exit
+        run: exit 1


### PR DESCRIPTION
Following [this PR](https://github.com/twentyhq/twenty/pull/16931), this is another attempt to trigger E2E tests in merge queue. 