### PR TITLE
Clarify non-implemented calendar layouts

### DIFF
--- a/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownCalendarViewContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownCalendarViewContent.tsx
@@ -12,6 +12,7 @@ import { useRecoilComponentValue } from '@/ui/utilities/state/component-state/ho
 import { useUpdateCurrentView } from '@/views/hooks/useUpdateCurrentView';
 import { t } from '@lingui/core/macro';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { Pill } from 'twenty-ui/components';
 import {
   IconCalendarMonth,
   IconCalendarWeek,
@@ -81,6 +82,8 @@ export const ObjectOptionsDropdownCalendarViewContent = () => {
               text={t`Week`}
               selected={recordIndexCalendarLayout === ViewCalendarLayout.WEEK}
               focused={selectedItemId === ViewCalendarLayout.WEEK}
+              contextualText={<Pill label={t`Soon`} />}
+              contextualTextPosition="right"
               disabled
             />
           </SelectableListItem>
@@ -105,6 +108,8 @@ export const ObjectOptionsDropdownCalendarViewContent = () => {
               text={t`Timeline`}
               selected={recordIndexCalendarLayout === ViewCalendarLayout.DAY}
               focused={selectedItemId === ViewCalendarLayout.DAY}
+              contextualText={<Pill label={t`Soon`} />}
+              contextualTextPosition="right"
               disabled
             />
           </SelectableListItem>

--- a/packages/twenty-front/src/modules/object-record/record-calendar/components/RecordCalendarTopBar.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/components/RecordCalendarTopBar.tsx
@@ -3,7 +3,6 @@ import { recordCalendarSelectedDateComponentState } from '@/object-record/record
 import { recordIndexCalendarLayoutState } from '@/object-record/record-index/states/recordIndexCalendarLayoutState';
 import { DatePickerWithoutCalendar } from '@/ui/input/components/internal/date/components/DatePickerWithoutCalendar';
 import { TimeZoneAbbreviation } from '@/ui/input/components/internal/date/components/TimeZoneAbbreviation';
-import { Select } from '@/ui/input/components/Select';
 import { SelectControl } from '@/ui/input/components/SelectControl';
 import { Dropdown } from '@/ui/layout/dropdown/components/Dropdown';
 import { DropdownContent } from '@/ui/layout/dropdown/components/DropdownContent';
@@ -23,7 +22,6 @@ import {
 } from 'twenty-shared/utils';
 import { IconChevronLeft, IconChevronRight } from 'twenty-ui/display';
 import { Button } from 'twenty-ui/input';
-import { ViewCalendarLayout } from '~/generated/graphql';
 
 const StyledContainer = styled.div`
   align-items: center;
@@ -98,27 +96,6 @@ export const RecordCalendarTopBar = () => {
   return (
     <StyledContainer>
       <StyledLeftSection>
-        <Select
-          dropdownId={`record-calendar-top-bar-layout-select-${recordCalendarId}`}
-          selectSizeVariant="small"
-          options={[
-            {
-              label: t`Month`,
-              value: ViewCalendarLayout.MONTH,
-            },
-            {
-              label: t`Week`,
-              value: ViewCalendarLayout.WEEK,
-            },
-            {
-              label: t`Timeline`,
-              value: ViewCalendarLayout.DAY,
-            },
-          ]}
-          disabled
-          value={recordIndexCalendarLayout}
-          onChange={() => {}}
-        />
         <Dropdown
           dropdownId={datePickerDropdownId}
           clickableComponent={

--- a/packages/twenty-front/src/modules/object-record/record-calendar/components/RecordCalendarTopBar.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/components/RecordCalendarTopBar.tsx
@@ -1,6 +1,5 @@
 import { RecordCalendarComponentInstanceContext } from '@/object-record/record-calendar/states/contexts/RecordCalendarComponentInstanceContext';
 import { recordCalendarSelectedDateComponentState } from '@/object-record/record-calendar/states/recordCalendarSelectedDateComponentState';
-import { recordIndexCalendarLayoutState } from '@/object-record/record-index/states/recordIndexCalendarLayoutState';
 import { DatePickerWithoutCalendar } from '@/ui/input/components/internal/date/components/DatePickerWithoutCalendar';
 import { TimeZoneAbbreviation } from '@/ui/input/components/internal/date/components/TimeZoneAbbreviation';
 import { SelectControl } from '@/ui/input/components/SelectControl';
@@ -13,7 +12,6 @@ import { useRecoilComponentState } from '@/ui/utilities/state/component-state/ho
 import styled from '@emotion/styled';
 import { t } from '@lingui/core/macro';
 import { format } from 'date-fns';
-import { useRecoilValue } from 'recoil';
 import { Temporal } from 'temporal-polyfill';
 import { type Nullable } from 'twenty-shared/types';
 import {
@@ -51,10 +49,6 @@ const StyledNavigationSection = styled.div`
 export const RecordCalendarTopBar = () => {
   const recordCalendarId = useAvailableComponentInstanceIdOrThrow(
     RecordCalendarComponentInstanceContext,
-  );
-
-  const recordIndexCalendarLayout = useRecoilValue(
-    recordIndexCalendarLayoutState,
   );
 
   const [recordCalendarSelectedDate, setRecordCalendarSelectedDate] =


### PR DESCRIPTION
## Context
Some users are confused with the dropdown showing other calendar layouts. We've decided to hide it for now since their implementation is not planned yet.

Before
<img width="1292" height="845" alt="Screenshot 2026-01-05 at 15 06 36" src="https://github.com/user-attachments/assets/e12e064a-1f58-454c-8933-b3ae2537378a" />

After
<img width="1301" height="839" alt="Screenshot 2026-01-05 at 15 00 15" src="https://github.com/user-attachments/assets/f4a65fb1-ac2e-4068-b7da-1b7ef55b174c" />
