### PR TITLE
Add invalid step input error

### DIFF
--- a/packages/twenty-server/src/modules/workflow/workflow-executor/exceptions/workflow-step-executor.exception.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/exceptions/workflow-step-executor.exception.ts
@@ -8,6 +8,7 @@ import { CustomException } from 'src/utils/custom-exception';
 export enum WorkflowStepExecutorExceptionCode {
   SCOPED_WORKSPACE_NOT_FOUND = 'SCOPED_WORKSPACE_NOT_FOUND',
   INVALID_STEP_TYPE = 'INVALID_STEP_TYPE',
+  INVALID_STEP_INPUT = 'INVALID_STEP_INPUT',
   STEP_NOT_FOUND = 'STEP_NOT_FOUND',
   INTERNAL_ERROR = 'INTERNAL_ERROR',
 }
@@ -22,6 +23,8 @@ const getWorkflowStepExecutorExceptionUserFriendlyMessage = (
       return msg`Invalid workflow step type.`;
     case WorkflowStepExecutorExceptionCode.STEP_NOT_FOUND:
       return msg`Workflow step not found.`;
+    case WorkflowStepExecutorExceptionCode.INVALID_STEP_INPUT:
+      return msg`Invalid workflow step input.`;
     case WorkflowStepExecutorExceptionCode.INTERNAL_ERROR:
       return STANDARD_ERROR_MESSAGE;
     default:

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/delay/delay.workflow-action.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/delay/delay.workflow-action.ts
@@ -55,7 +55,7 @@ export class DelayWorkflowAction implements WorkflowAction {
       if (!workflowActionInput.scheduledDateTime) {
         throw new WorkflowStepExecutorException(
           'Scheduled date time is required for scheduled date delay',
-          WorkflowStepExecutorExceptionCode.INVALID_STEP_TYPE,
+          WorkflowStepExecutorExceptionCode.INVALID_STEP_INPUT,
         );
       }
 
@@ -67,14 +67,14 @@ export class DelayWorkflowAction implements WorkflowAction {
       if (delayInMs < 0) {
         throw new WorkflowStepExecutorException(
           'Scheduled date cannot be in the past',
-          WorkflowStepExecutorExceptionCode.INVALID_STEP_TYPE,
+          WorkflowStepExecutorExceptionCode.INVALID_STEP_INPUT,
         );
       }
     } else if (workflowActionInput.delayType === 'DURATION') {
       if (!workflowActionInput.duration) {
         throw new WorkflowStepExecutorException(
           'Duration is required for duration delay',
-          WorkflowStepExecutorExceptionCode.INVALID_STEP_TYPE,
+          WorkflowStepExecutorExceptionCode.INVALID_STEP_INPUT,
         );
       }
 
@@ -93,7 +93,7 @@ export class DelayWorkflowAction implements WorkflowAction {
     } else {
       throw new WorkflowStepExecutorException(
         'Invalid delay type',
-        WorkflowStepExecutorExceptionCode.INVALID_STEP_TYPE,
+        WorkflowStepExecutorExceptionCode.INVALID_STEP_INPUT,
       );
     }
 

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/if-else/if-else.workflow-action.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/if-else/if-else.workflow-action.ts
@@ -36,14 +36,14 @@ export class IfElseWorkflowAction implements WorkflowAction {
     if (!branches || branches.length === 0) {
       throw new WorkflowStepExecutorException(
         'If-else action must have at least one branch',
-        WorkflowStepExecutorExceptionCode.INVALID_STEP_TYPE,
+        WorkflowStepExecutorExceptionCode.INVALID_STEP_INPUT,
       );
     }
 
     if (!stepFilterGroups || !stepFilters) {
       throw new WorkflowStepExecutorException(
         'If-else action must have stepFilterGroups and stepFilters defined',
-        WorkflowStepExecutorExceptionCode.INVALID_STEP_TYPE,
+        WorkflowStepExecutorExceptionCode.INVALID_STEP_INPUT,
       );
     }
 


### PR DESCRIPTION
`INVALID_STEP_TYPE` is used even when the step type is not the error cause.
Adding a new `INVALID_STEP_INPUT` exception code