### PR TITLE
Fix metadata relation field settings item type tag display

### DIFF
--- a/packages/twenty-front/src/modules/settings/data-model/object-details/components/SettingsObjectRelationItemTableRow.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/object-details/components/SettingsObjectRelationItemTableRow.tsx
@@ -194,7 +194,7 @@ export const SettingsObjectRelationItemTableRow = ({
           item={{
             isCustom: fieldMetadataItem.isCustom ?? undefined,
             isRemote: objectMetadataItem.isRemote,
-            applicationId: objectMetadataItem.applicationId,
+            applicationId: fieldMetadataItem.applicationId,
           }}
         />
       </TableCell>


### PR DESCRIPTION
# Introduction
followup https://github.com/twentyhq/twenty/pull/16880

Fixing the item tag type displayal of the relation field within an object
Inferring the application id at field level instead of object level

## From
<img width="1162" height="1220" alt="image" src="https://github.com/user-attachments/assets/28af2242-2786-4e17-b910-3fc26871bc04" />

## To
<img width="1162" height="1220" alt="image" src="https://github.com/user-attachments/assets/63fb89a0-a853-4157-baa4-d0f758648c3e" />
