### PR TITLE
Move run creation before opening side panel

### DIFF
--- a/packages/twenty-front/src/modules/workflow/hooks/useRunWorkflowVersion.tsx
+++ b/packages/twenty-front/src/modules/workflow/hooks/useRunWorkflowVersion.tsx
@@ -135,13 +135,13 @@ export const useRunWorkflowVersion = () => {
 
     setRecordInStore(recordCreatedInCache);
 
+    await mutate({
+      variables: { input: { workflowVersionId, workflowRunId, payload } },
+    });
+
     openRecordInCommandMenu({
       objectNameSingular: CoreObjectNameSingular.WorkflowRun,
       recordId: workflowRunId,
-    });
-
-    await mutate({
-      variables: { input: { workflowVersionId, workflowRunId, payload } },
     });
   };
 


### PR DESCRIPTION
Fixes https://github.com/twentyhq/twenty/issues/16837

Current flow:
- create workflow run optimistically 
- open side panel => triggers query + event stream
- mutation that actually creates the run using the optimistic id

New flow
- create workflow run optimistically 
- mutation that actually creates the run using the optimistic id
- open side panel => triggers query + event stream