### PR TITLE
Implemented update-one event optimistic effect on table

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-body/components/RecordTableNoRecordGroupBody.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-body/components/RecordTableNoRecordGroupBody.tsx
@@ -10,6 +10,7 @@ import { RecordTableAggregateFooter } from '@/object-record/record-table/record-
 import { isRecordTableInitialLoadingComponentState } from '@/object-record/record-table/states/isRecordTableInitialLoadingComponentState';
 import { RecordTableVirtualizedDataChangedEffect } from '@/object-record/record-table/virtualization/components/RecordTableVirtualizedDataChangedEffect';
 import { RecordTableVirtualizedRowTreadmillEffect } from '@/object-record/record-table/virtualization/components/RecordTableVirtualizedRowTreadmillEffect';
+import { RecordTableVirtualizedSSEEffect } from '@/object-record/record-table/virtualization/components/RecordTableVirtualizedSSEEffect';
 import { useRecoilComponentValue } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValue';
 
 export const RecordTableNoRecordGroupBody = () => {
@@ -37,6 +38,7 @@ export const RecordTableNoRecordGroupBody = () => {
         )}
         <RecordTableVirtualizedRowTreadmillEffect />
         <RecordTableVirtualizedDataChangedEffect />
+        <RecordTableVirtualizedSSEEffect />
       </RecordTableBodyNoRecordGroupDragDropContextProvider>
     </RecordTableNoRecordGroupBodyContextProvider>
   );

--- a/packages/twenty-front/src/modules/object-record/record-table/virtualization/components/RecordTableVirtualizedSSEEffect.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/virtualization/components/RecordTableVirtualizedSSEEffect.tsx
@@ -1,0 +1,203 @@
+import { triggerUpdateRecordOptimisticEffect } from '@/apollo/optimistic-effect/utils/triggerUpdateRecordOptimisticEffect';
+import { useApolloCoreClient } from '@/object-metadata/hooks/useApolloCoreClient';
+import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
+import { useGetRecordFromCache } from '@/object-record/cache/hooks/useGetRecordFromCache';
+import { getObjectTypename } from '@/object-record/cache/utils/getObjectTypename';
+import { getRecordNodeFromRecord } from '@/object-record/cache/utils/getRecordNodeFromRecord';
+import { useFindManyRecordsQuery } from '@/object-record/hooks/useFindManyRecordsQuery';
+import { useObjectPermissions } from '@/object-record/hooks/useObjectPermissions';
+import { useRefetchAggregateQueries } from '@/object-record/hooks/useRefetchAggregateQueries';
+import { useRegisterObjectOperation } from '@/object-record/hooks/useRegisterObjectOperation';
+import { useRecordsFieldVisibleGqlFields } from '@/object-record/record-field/hooks/useRecordsFieldVisibleGqlFields';
+import { useRecordIndexContextOrThrow } from '@/object-record/record-index/contexts/RecordIndexContext';
+import { useUpsertRecordsInStore } from '@/object-record/record-store/hooks/useUpsertRecordsInStore';
+import { useRecordTableContextOrThrow } from '@/object-record/record-table/contexts/RecordTableContext';
+import { type ObjectRecord } from '@/object-record/types/ObjectRecord';
+import { ON_SUBSCRIPTION_MATCH } from '@/subscription/graphql/subscriptions/onSubscriptionMatch';
+import { useSseClient } from '@/subscription/hooks/useSseClient.util';
+import { subscriptionBrowserTabIdState } from '@/subscription/states/subscriptionBrowserTabIdState';
+import { isNonEmptyArray } from '@sniptt/guards';
+import { type ExecutionResult, print } from 'graphql';
+import { useEffect } from 'react';
+import { useRecoilState } from 'recoil';
+import { isDefined } from 'twenty-shared/utils';
+import { useDebouncedCallback } from 'use-debounce';
+import { v4 } from 'uuid';
+import {
+  DatabaseEventAction,
+  type OnSubscriptionMatchSubscription,
+} from '~/generated/graphql';
+
+export const RecordTableVirtualizedSSEEffect = () => {
+  const { objectMetadataItem } = useRecordIndexContextOrThrow();
+  const { objectNameSingular } = useRecordTableContextOrThrow();
+  const { registerObjectOperation } = useRegisterObjectOperation();
+  const { refetchAggregateQueries } = useRefetchAggregateQueries({
+    objectMetadataNamePlural: objectMetadataItem.namePlural,
+  });
+  const apolloCoreClient = useApolloCoreClient();
+  const getRecordFromCache = useGetRecordFromCache({
+    objectNameSingular,
+  });
+  const { upsertRecordsInStore } = useUpsertRecordsInStore();
+  const { objectMetadataItems } = useObjectMetadataItems();
+
+  const { sseClient } = useSseClient();
+
+  const recordGqlFields = useRecordsFieldVisibleGqlFields({
+    objectMetadataItem,
+  });
+  const { objectPermissionsByObjectMetadataId } = useObjectPermissions();
+
+  const { findManyRecordsQuery } = useFindManyRecordsQuery({
+    objectNameSingular,
+    recordGqlFields,
+  });
+
+  const debouncedRefetchAggregateQueries = useDebouncedCallback(
+    refetchAggregateQueries,
+    200,
+  );
+
+  const [subscriptionBrowserTabId, setSubscriptionBrowserTabId] =
+    useRecoilState(subscriptionBrowserTabIdState);
+
+  const subscriptionId = `${subscriptionBrowserTabId}-record-table-virtualized-data-changed`;
+
+  useEffect(() => {
+    if (!isDefined(subscriptionBrowserTabId)) {
+      return;
+    }
+
+    const unsubscribe = sseClient.subscribe(
+      {
+        query: print(ON_SUBSCRIPTION_MATCH),
+        variables: {
+          subscriptions: [
+            {
+              id: subscriptionId,
+              query: print(findManyRecordsQuery),
+            },
+          ],
+        },
+      },
+      {
+        next: (
+          executionResult: ExecutionResult<OnSubscriptionMatchSubscription>,
+        ) => {
+          const matches =
+            executionResult.data?.onSubscriptionMatch?.matches ?? [];
+
+          const matchesForThisSubscription = matches.filter((match) => {
+            return match.subscriptionIds.includes(subscriptionId);
+          });
+
+          const updateEvents = matchesForThisSubscription.filter((match) => {
+            return match.event.action === DatabaseEventAction.UPDATED;
+          });
+
+          if (updateEvents.length !== 1) {
+            return;
+          }
+
+          const cache = apolloCoreClient.cache;
+
+          for (const updateEvent of updateEvents) {
+            const updatedRecord = updateEvent.event.record;
+
+            upsertRecordsInStore({ partialRecords: [updatedRecord] });
+
+            const cachedRecord = getRecordFromCache<ObjectRecord>(
+              updatedRecord.id,
+            );
+
+            const cachedRecordWithConnection =
+              getRecordNodeFromRecord<ObjectRecord>({
+                record: cachedRecord,
+                objectMetadataItem,
+                objectMetadataItems,
+                recordGqlFields: recordGqlFields,
+                computeReferences: false,
+              });
+
+            const computedOptimisticRecord = {
+              ...updatedRecord,
+              id: updatedRecord.id,
+              __typename: getObjectTypename(objectMetadataItem.nameSingular),
+            };
+
+            const computedOptimisticRecordWithConnection =
+              getRecordNodeFromRecord<ObjectRecord>({
+                record: computedOptimisticRecord,
+                objectMetadataItem,
+                objectMetadataItems,
+                recordGqlFields: recordGqlFields,
+              });
+
+            if (
+              !isDefined(cachedRecordWithConnection) ||
+              !isDefined(computedOptimisticRecordWithConnection)
+            ) {
+              continue;
+            }
+
+            triggerUpdateRecordOptimisticEffect({
+              cache,
+              objectMetadataItem,
+              currentRecord: cachedRecordWithConnection,
+              updatedRecord: computedOptimisticRecordWithConnection,
+              objectMetadataItems,
+              objectPermissionsByObjectMetadataId,
+              upsertRecordsInStore,
+            });
+
+            const updatedFields = updateEvent.event.updatedFields ?? [];
+
+            const updatedRecordWithUpdatedFieldsOnly = Object.fromEntries(
+              updatedFields.map((fieldName) => {
+                return [fieldName, updatedRecord[fieldName]];
+              }),
+            );
+
+            registerObjectOperation(objectMetadataItem, {
+              type: 'update-one',
+              result: { updateInput: updatedRecordWithUpdatedFieldsOnly },
+            });
+          }
+
+          if (isNonEmptyArray(updateEvents)) {
+            debouncedRefetchAggregateQueries();
+          }
+        },
+        error: () => {},
+        complete: () => {},
+      },
+    );
+
+    return () => {
+      unsubscribe();
+    };
+  }, [
+    sseClient,
+    findManyRecordsQuery,
+    apolloCoreClient.cache,
+    upsertRecordsInStore,
+    getRecordFromCache,
+    objectMetadataItem,
+    objectMetadataItems,
+    recordGqlFields,
+    objectPermissionsByObjectMetadataId,
+    registerObjectOperation,
+    debouncedRefetchAggregateQueries,
+    subscriptionBrowserTabId,
+    subscriptionId,
+  ]);
+
+  useEffect(() => {
+    if (!isDefined(subscriptionBrowserTabId)) {
+      setSubscriptionBrowserTabId(v4());
+    }
+  }, [subscriptionBrowserTabId, setSubscriptionBrowserTabId]);
+
+  return <></>;
+};

--- a/packages/twenty-front/src/modules/subscription/components/SubscriptionProvider.tsx
+++ b/packages/twenty-front/src/modules/subscription/components/SubscriptionProvider.tsx
@@ -1,4 +1,3 @@
-import { SubscriptionProviderEffect } from '@/subscription/components/SubscriptionProviderEffect';
 import { SseClientContext } from '@/subscription/contexts/SseClientContext';
 import { useSseClient } from '@/subscription/hooks/useSseClient.util';
 import { type ReactNode } from 'react';
@@ -14,7 +13,6 @@ export const SubscriptionProvider = ({
 
   return (
     <SseClientContext.Provider value={sseClient}>
-      <SubscriptionProviderEffect />
       {children}
     </SseClientContext.Provider>
   );

--- a/packages/twenty-front/src/modules/subscription/states/subscriptionBrowserTabIdState.ts
+++ b/packages/twenty-front/src/modules/subscription/states/subscriptionBrowserTabIdState.ts
@@ -1,0 +1,6 @@
+import { createState } from 'twenty-ui/utilities';
+
+export const subscriptionBrowserTabIdState = createState<string | undefined>({
+  key: 'subscriptionBrowserTabIdState',
+  defaultValue: undefined,
+});

--- a/packages/twenty-server/src/engine/subscriptions/subscription.service.ts
+++ b/packages/twenty-server/src/engine/subscriptions/subscription.service.ts
@@ -58,19 +58,19 @@ export class SubscriptionService {
   }
 
   public async isSubscriptionMatchingEvent(
-    subscription: SubscriptionInput,
+    subscriptionInput: SubscriptionInput,
     event: OnDbEventDTO,
     workspaceId: string,
   ): Promise<boolean> {
-    const objectName = this.parseQueryObjectName(subscription.query);
+    const objectName = this.parseQueryObjectName(subscriptionInput.query);
 
     if (!objectName) {
       return false;
     }
 
     if (
-      subscription.selectedEventActions &&
-      !subscription.selectedEventActions.includes(event.action)
+      subscriptionInput.selectedEventActions &&
+      !subscriptionInput.selectedEventActions.includes(event.action)
     ) {
       return false;
     }
@@ -105,12 +105,7 @@ export class SubscriptionService {
 
   private parseQueryObjectName(queryString: string): string | null {
     try {
-      const { query } = JSON.parse(queryString) as {
-        query: string;
-        variables?: Record<string, unknown>;
-      };
-
-      const ast = parse(query);
+      const ast = parse(queryString);
 
       const firstOperation = ast.definitions.find(
         (def): def is OperationDefinitionNode =>


### PR DESCRIPTION
This PR implements update-one event optimistic effect on table.

It will ignore all other events. 

This is a POC, not a final implementation so things have not been cleaned yet.

This simple implementation already brings some questions.

# Optimistic update of relation ?

When updating a relation, the event that is sent does not contain the nested record that is update, only the recordId. 

Solutions proposed : 
- The frontend gives a parameter like `attachNestedRecordIdentifier`, then `workspace-event-emitter.resolver.ts` computes what's needed and modifies the event record.
- The frontend computes the record identifier, and makes a find one request if needed, not ideal, since the backend could do and avoid subsequent network round trips.

⚠️ Due to this problem, relation update event is not handled for now.

# Returning only the modified fields ? 

When an update event is sent, it would be interesting to filter out the fields that are not updated, to optimize the network load.

# Avoid sending event to the original application ?

It would be interesting to send events only to the other browser tabs. Because the original browser tab that makes the request doesn't need an event. 

The problem is that we don't have a trace id from the original mutation down to the subscription resolver, because in-between there is an abstract catch-all database event listener.

We could guess that an event is not interesting for a given frontend application, but that would still involve additional network round trip.

Another risk is that the logic that processes the even on the frontend ends up creating weird bugs due to doubling the optimistic effect, but since our optimistic engine should be idempotent, that could be ok.

# Demo

https://github.com/user-attachments/assets/5554a1ae-3f84-468d-aac3-01c2efa156e1
