### PR TITLE
Remove tests run on push on main 

### DIFF
--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -1,10 +1,6 @@
 name: CI Front and E2E
 
 on:
-  push:
-    branches:
-      - main
-
   pull_request:
 
   merge_group:

--- a/.github/workflows/ci-sdk.yaml
+++ b/.github/workflows/ci-sdk.yaml
@@ -1,9 +1,7 @@
 name: CI SDK
 
 on:
-  push:
-    branches:
-      - main
+  merge_group:
 
   pull_request:
 

--- a/.github/workflows/ci-server.yaml
+++ b/.github/workflows/ci-server.yaml
@@ -1,11 +1,9 @@
 name: CI Server
 
 on:
-  push:
-    branches:
-      - main
-
   pull_request:
+
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/ci-shared.yaml
+++ b/.github/workflows/ci-shared.yaml
@@ -1,9 +1,7 @@
 name: CI Shared
 
 on:
-  push:
-    branches:
-      - main
+  merge_group:
 
   pull_request:
 

--- a/.github/workflows/ci-test-docker-compose.yaml
+++ b/.github/workflows/ci-test-docker-compose.yaml
@@ -4,6 +4,8 @@ permissions:
   contents: read
 
 on:
+  merge_group:
+
   pull_request:
 
 concurrency:

--- a/.github/workflows/ci-website.yaml
+++ b/.github/workflows/ci-website.yaml
@@ -4,9 +4,7 @@ permissions:
   contents: read
 
 on:
-  push:
-    branches:
-      - main
+  merge_group:
 
   pull_request:
 


### PR DESCRIPTION
Since tests are now run in the pre-merge queue with the latest main version, they need not to be run again when merged into main, it would be the exact same thing