### PR TITLE
Provide executed step output instead of result

### DIFF
--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workspace-services/workflow-executor.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workspace-services/workflow-executor.workspace-service.ts
@@ -171,7 +171,7 @@ export class WorkflowExecutorWorkspaceService {
 
     const nextStepIdsToExecute = await this.getNextStepIdsToExecute({
       executedStep: stepToExecute,
-      executedStepResult: actionOutput,
+      executedStepOutput: actionOutput,
     });
 
     if (isDefined(nextStepIdsToExecute) && nextStepIdsToExecute.length > 0) {
@@ -187,15 +187,15 @@ export class WorkflowExecutorWorkspaceService {
 
   async getNextStepIdsToExecute({
     executedStep,
-    executedStepResult,
+    executedStepOutput,
   }: {
     executedStep: WorkflowAction;
-    executedStepResult: WorkflowActionOutput;
+    executedStepOutput: WorkflowActionOutput;
   }): Promise<string[] | undefined> {
     const isIteratorStep = isWorkflowIteratorAction(executedStep);
 
     if (isIteratorStep) {
-      const iteratorStepResult = executedStepResult.result as
+      const iteratorStepResult = executedStepOutput.result as
         | WorkflowIteratorResult
         | undefined;
 
@@ -207,7 +207,7 @@ export class WorkflowExecutorWorkspaceService {
     }
 
     if (isWorkflowIfElseAction(executedStep)) {
-      const ifElseResult = executedStepResult.result as
+      const ifElseResult = executedStepOutput.result as
         | WorkflowIfElseResult
         | undefined;
 

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/jobs/run-workflow.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/jobs/run-workflow.job.ts
@@ -142,13 +142,13 @@ export class RunWorkflowJob {
       );
     }
 
-    const lastExecutedStepResult =
-      workflowRun.state?.stepInfos[lastExecutedStepId]?.result;
+    const lastExecutedStepOutput =
+      workflowRun.state?.stepInfos[lastExecutedStepId];
 
     const nextStepIdsToExecute =
       await this.workflowExecutorWorkspaceService.getNextStepIdsToExecute({
         executedStep: lastExecutedStep,
-        executedStepResult: lastExecutedStepResult,
+        executedStepOutput: lastExecutedStepOutput,
       });
 
     if (!isDefined(nextStepIdsToExecute) || nextStepIdsToExecute.length === 0) {


### PR DESCRIPTION
For huge workflows, after 20 steps, we stop the job and re-trigger a new one. 
But some of those workflows actually never stop.
See https://github.com/twentyhq/private-issues/issues/401 

Here is a first issue. We resuming the workflow, we were providing the result instead of the output 