### PR TITLE
Fix: Kanban view crashes with 'Cannot convert undefined or null to object'

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query.parser.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query.parser.ts
@@ -77,6 +77,10 @@ export class GraphqlQueryParser {
   private checkForDeletedAtFilter = (
     filter: FindOptionsWhere<ObjectLiteral> | FindOptionsWhere<ObjectLiteral>[],
   ): boolean => {
+    if (!filter) {
+      return false;
+    }
+
     if (Array.isArray(filter)) {
       return filter.some((subFilter) =>
         this.checkForDeletedAtFilter(subFilter),

--- a/packages/twenty-server/src/engine/api/graphql/workspace-resolver-builder/factories/group-by-resolver.factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-resolver-builder/factories/group-by-resolver.factory.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 
-import { isDefined } from 'class-validator';
+import { isDefined } from 'twenty-shared/utils';
 import graphqlFields from 'graphql-fields';
 
 import { type WorkspaceResolverBuilderFactoryInterface } from 'src/engine/api/graphql/workspace-resolver-builder/interfaces/workspace-resolver-builder-factory.interface';


### PR DESCRIPTION
## Problem
Kanban views with a 'No Value' group (representing records with null values) crash with:
```
TypeError: Cannot convert undefined or null to object
```

This occurs when the filter includes `null` in the `in` clause (e.g., `{status: {in: ['TODO', 'IN_PROGRESS', 'DONE', null]}}`), which happens automatically when a Kanban view includes a 'No Value' column.

## Root Cause
The `checkForDeletedAtFilter` function in `graphql-query.parser.ts` recursively traverses filter objects but didn't handle the case where a nested value is `null`. When recursing into the filter structure, it would call `Object.entries(null)`, which throws the error.

**Timeline:**
- Sept 19, 2024: Bug introduced (latent) in PR #7133 - `checkForDeletedAtFilter` was added without null check
- Oct 7, 2025: Bug became active in PR #14923 - `applyDeletedAtToBuilder` was added to groupBy resolver

## Fix
1. Added null check at the beginning of `checkForDeletedAtFilter` to return early if filter is null/undefined
2. Changed `isDefined` import in `group-by-resolver.factory.ts` from `class-validator` to `twenty-shared/utils` (the class-validator version only checks for `undefined`, not `null`)

## Testing
Manually verified that Kanban views with 'No Value' columns now load correctly.