### PR TITLE
[Dashboards] Fix chart axis label behavior

### DIFF
--- a/packages/twenty-front/src/modules/page-layout/widgets/graph/graphWidgetBarChart/utils/transformGroupByDataToBarChartData.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/graph/graphWidgetBarChart/utils/transformGroupByDataToBarChartData.ts
@@ -96,26 +96,34 @@ export const transformGroupByDataToBarChartData = ({
     getGroupByQueryResultGqlFieldName(objectMetadataItem);
   const rawResults = groupByData?.[queryResultGqlFieldName];
 
-  const showXAxis =
-    configuration.axisNameDisplay === AxisNameDisplay.X ||
-    configuration.axisNameDisplay === AxisNameDisplay.BOTH;
-
-  const showYAxis =
-    configuration.axisNameDisplay === AxisNameDisplay.Y ||
-    configuration.axisNameDisplay === AxisNameDisplay.BOTH;
-
-  const xAxisLabel =
-    showXAxis && isDefined(groupByFieldX) ? groupByFieldX.label : undefined;
-
-  const yAxisLabel =
-    showYAxis && isDefined(aggregateField)
-      ? `${getAggregateOperationLabel(configuration.aggregateOperation)} of ${aggregateField.label}`
-      : undefined;
-
   const layout =
     configuration.layout === BarChartLayout.HORIZONTAL
       ? BarChartLayout.HORIZONTAL
       : BarChartLayout.VERTICAL;
+
+  const isHorizontal = layout === BarChartLayout.HORIZONTAL;
+
+  const showCategoryLabel = isHorizontal
+    ? configuration.axisNameDisplay === AxisNameDisplay.Y ||
+      configuration.axisNameDisplay === AxisNameDisplay.BOTH
+    : configuration.axisNameDisplay === AxisNameDisplay.X ||
+      configuration.axisNameDisplay === AxisNameDisplay.BOTH;
+
+  const showValueLabel = isHorizontal
+    ? configuration.axisNameDisplay === AxisNameDisplay.X ||
+      configuration.axisNameDisplay === AxisNameDisplay.BOTH
+    : configuration.axisNameDisplay === AxisNameDisplay.Y ||
+      configuration.axisNameDisplay === AxisNameDisplay.BOTH;
+
+  const xAxisLabel =
+    showCategoryLabel && isDefined(groupByFieldX)
+      ? groupByFieldX.label
+      : undefined;
+
+  const yAxisLabel =
+    showValueLabel && isDefined(aggregateField)
+      ? `${getAggregateOperationLabel(configuration.aggregateOperation)} of ${aggregateField.label}`
+      : undefined;
 
   if (!isDefined(groupByData)) {
     return {

--- a/packages/twenty-front/src/modules/page-layout/widgets/graph/graphWidgetBarChart/utils/transformGroupByDataToBarChartData.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/graph/graphWidgetBarChart/utils/transformGroupByDataToBarChartData.ts
@@ -95,19 +95,12 @@ export const transformGroupByDataToBarChartData = ({
   const queryResultGqlFieldName =
     getGroupByQueryResultGqlFieldName(objectMetadataItem);
   const rawResults = groupByData?.[queryResultGqlFieldName];
-  const hasNoData =
-    !isDefined(groupByData) ||
-    !isDefined(rawResults) ||
-    !Array.isArray(rawResults) ||
-    rawResults.length === 0;
 
   const showXAxis =
-    hasNoData ||
     configuration.axisNameDisplay === AxisNameDisplay.X ||
     configuration.axisNameDisplay === AxisNameDisplay.BOTH;
 
   const showYAxis =
-    hasNoData ||
     configuration.axisNameDisplay === AxisNameDisplay.Y ||
     configuration.axisNameDisplay === AxisNameDisplay.BOTH;
 

--- a/packages/twenty-front/src/modules/page-layout/widgets/graph/graphWidgetLineChart/utils/transformGroupByDataToLineChartData.ts
+++ b/packages/twenty-front/src/modules/page-layout/widgets/graph/graphWidgetLineChart/utils/transformGroupByDataToLineChartData.ts
@@ -82,19 +82,12 @@ export const transformGroupByDataToLineChartData = ({
   const queryResultGqlFieldName =
     getGroupByQueryResultGqlFieldName(objectMetadataItem);
   const rawResults = groupByData?.[queryResultGqlFieldName];
-  const hasNoData =
-    !isDefined(groupByData) ||
-    !isDefined(rawResults) ||
-    !Array.isArray(rawResults) ||
-    rawResults.length === 0;
 
   const showXAxis =
-    hasNoData ||
     configuration.axisNameDisplay === AxisNameDisplay.X ||
     configuration.axisNameDisplay === AxisNameDisplay.BOTH;
 
   const showYAxis =
-    hasNoData ||
     configuration.axisNameDisplay === AxisNameDisplay.Y ||
     configuration.axisNameDisplay === AxisNameDisplay.BOTH;
 


### PR DESCRIPTION
- Axis labels now respect `axisNameDisplay` config when chart has no data (previously always showed both) - fixed for bar and line charts
- Horizontal bar charts now correctly map axis settings to visual positions:
    - "X axis" setting → bottom axis (value)
    - "Y axis" setting → left axis (category)
    
video QA


https://github.com/user-attachments/assets/5bf32294-9a5e-4aa6-b3fd-0d4e33608d14


