### PR TITLE
fix(frontend): filter null records in record index query

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-index/hooks/useRecordIndexTableQuery.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/hooks/useRecordIndexTableQuery.ts
@@ -25,10 +25,7 @@ export const useRecordIndexTableQuery = (objectNameSingular: string) => {
       skip: showAuthModal,
     });
 
-  const safeRecords = (records ?? []).filter(
-  (record) => record != null
-);
-
+  const safeRecords = (records ?? []).filter((record) => record !== null);
 
   return {
     records: showAuthModal ? SIGN_IN_BACKGROUND_MOCK_COMPANIES : safeRecords,

--- a/packages/twenty-front/src/modules/object-record/record-index/hooks/useRecordIndexTableQuery.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/hooks/useRecordIndexTableQuery.ts
@@ -25,7 +25,10 @@ export const useRecordIndexTableQuery = (objectNameSingular: string) => {
       skip: showAuthModal,
     });
 
-  const safeRecords = (records ?? []).filter(Boolean);
+  const safeRecords = (records ?? []).filter(
+  (record) => record != null
+);
+
 
   return {
     records: showAuthModal ? SIGN_IN_BACKGROUND_MOCK_COMPANIES : safeRecords,

--- a/packages/twenty-front/src/modules/object-record/record-index/hooks/useRecordIndexTableQuery.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/hooks/useRecordIndexTableQuery.ts
@@ -25,7 +25,7 @@ export const useRecordIndexTableQuery = (objectNameSingular: string) => {
       skip: showAuthModal,
     });
 
-  const safeRecords = (records ?? []).filter((record) => record !== null);
+  const safeRecords = (records ?? []).filter((record) => record != null);
 
   return {
     records: showAuthModal ? SIGN_IN_BACKGROUND_MOCK_COMPANIES : safeRecords,

--- a/packages/twenty-front/src/modules/object-record/record-index/hooks/useRecordIndexTableQuery.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/hooks/useRecordIndexTableQuery.ts
@@ -25,8 +25,10 @@ export const useRecordIndexTableQuery = (objectNameSingular: string) => {
       skip: showAuthModal,
     });
 
+  const safeRecords = (records ?? []).filter(Boolean);
+
   return {
-    records: showAuthModal ? SIGN_IN_BACKGROUND_MOCK_COMPANIES : records,
+    records: showAuthModal ? SIGN_IN_BACKGROUND_MOCK_COMPANIES : safeRecords,
     loading: showAuthModal ? false : loading,
     hasNextPage,
     queryIdentifier,


### PR DESCRIPTION
Filters out null records returned from `useFindManyRecords` at the record index query boundary.

This prevents frontend crashes in record list views (e.g. notes and tasks) when unexpected null entries appear in record collections. The change is intentionally scoped and does not affect downstream components or API behavior.
