### PR TITLE
fix(search): add support for searching by additional emails, phones, and secondary links

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/utils/__tests__/get-ts-vectors-column-expression.utils.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/utils/__tests__/get-ts-vectors-column-expression.utils.spec.ts
@@ -135,6 +135,9 @@ describe('getTsVectorColumnExpressionFromFields', () => {
     expect(result).toContain(
       "COALESCE(public.unaccent_immutable(TRANSLATE(\"emailsAdditionalEmails\"::text, '[]\",', '    ')), '')",
     );
+    expect(result).toContain(
+      "COALESCE(public.unaccent_immutable(TRANSLATE(REPLACE(\"emailsAdditionalEmails\"::text, '@', ' '), '[]\",', '    ')), '')",
+    );
   });
 
   it('should include secondary links in search expression for LINKS type', () => {

--- a/packages/twenty-server/src/engine/workspace-manager/utils/__tests__/get-ts-vectors-column-expression.utils.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/utils/__tests__/get-ts-vectors-column-expression.utils.spec.ts
@@ -133,7 +133,7 @@ describe('getTsVectorColumnExpressionFromFields', () => {
     // Should include additional emails converted from JSON array
     expect(result).toContain('emailsAdditionalEmails');
     expect(result).toContain(
-      "COALESCE(public.unaccent_immutable(TRANSLATE(\"emailsAdditionalEmails\"::text, '[]\"', '   ')), '')",
+      "COALESCE(public.unaccent_immutable(TRANSLATE(\"emailsAdditionalEmails\"::text, '[]\",', '    ')), '')",
     );
   });
 
@@ -214,7 +214,7 @@ describe('getTsVectorColumnExpressionFromFields', () => {
       // Count COALESCE with empty string fallback patterns for JSON columns
       // Each JSON column should have a COALESCE(..., '') pattern
       const additionalEmailsCoalesce = result.includes(
-        "COALESCE(public.unaccent_immutable(TRANSLATE(\"emailsAdditionalEmails\"::text, '[]\"', '   ')), '')",
+        "COALESCE(public.unaccent_immutable(TRANSLATE(\"emailsAdditionalEmails\"::text, '[]\",', '    ')), '')",
       );
       const additionalPhonesCoalesce = result.includes(
         "COALESCE(TRANSLATE(regexp_replace(\"phonesAdditionalPhones\"::text, '\"(number|countryCode|callingCode)\"\\s*:\\s*', '', 'g'), '[]{}\",:',",

--- a/packages/twenty-server/src/engine/workspace-manager/utils/__tests__/get-ts-vectors-column-expression.utils.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/utils/__tests__/get-ts-vectors-column-expression.utils.spec.ts
@@ -108,7 +108,7 @@ describe('getTsVectorColumnExpressionFromFields', () => {
 
     expect(result).toContain('phonesPrimaryPhoneNumber');
     expect(result).toContain('phonesPrimaryPhoneCallingCode');
-    // Should include additional phones converted from JSON array
+
     expect(result).toContain('phonesAdditionalPhones');
     expect(result).toContain(
       "COALESCE(TRANSLATE(regexp_replace(\"phonesAdditionalPhones\"::text, '\"(number|countryCode|callingCode)\"\\s*:\\s*', '', 'g'), '[]{}\",:',",
@@ -128,9 +128,7 @@ describe('getTsVectorColumnExpressionFromFields', () => {
     const fields = [emailsEmailsField] as FieldTypeAndNameMetadata[];
     const result = getTsVectorColumnExpressionFromFields(fields);
 
-    // Should include primary email
     expect(result).toContain('emailsPrimaryEmail');
-    // Should include additional emails converted from JSON array
     expect(result).toContain('emailsAdditionalEmails');
     expect(result).toContain(
       "COALESCE(public.unaccent_immutable(TRANSLATE(\"emailsAdditionalEmails\"::text, '[]\",', '    ')), '')",
@@ -144,10 +142,8 @@ describe('getTsVectorColumnExpressionFromFields', () => {
     const fields = [linksLinksField] as FieldTypeAndNameMetadata[];
     const result = getTsVectorColumnExpressionFromFields(fields);
 
-    // Should include primary link fields
     expect(result).toContain('domainNamePrimaryLinkLabel');
     expect(result).toContain('domainNamePrimaryLinkUrl');
-    // Should include secondary links converted from JSON array
     expect(result).toContain('domainNameSecondaryLinks');
     expect(result).toContain(
       "COALESCE(public.unaccent_immutable(TRANSLATE(regexp_replace(\"domainNameSecondaryLinks\"::text, '\"(label|url)\"\\s*:\\s*', '', 'g'), '[]{}\",:',",
@@ -168,11 +164,9 @@ describe('getTsVectorColumnExpressionFromFields', () => {
       const fields = [emailsEmailsField] as FieldTypeAndNameMetadata[];
       const result = getTsVectorColumnExpressionFromFields(fields);
 
-      // Verify COALESCE wrapping exists for NULL safety on additionalEmails
       expect(result).toContain(
         'COALESCE(public.unaccent_immutable(TRANSLATE("emailsAdditionalEmails"::text',
       );
-      // Verify empty string fallback when column is NULL
       expect(result).toMatch(
         /COALESCE\(public\.unaccent_immutable\(TRANSLATE\("emailsAdditionalEmails"::text.*\), ''\)/,
       );
@@ -182,11 +176,9 @@ describe('getTsVectorColumnExpressionFromFields', () => {
       const fields = [phonesPhonesField] as FieldTypeAndNameMetadata[];
       const result = getTsVectorColumnExpressionFromFields(fields);
 
-      // Verify COALESCE wrapping exists for NULL safety on additionalPhones
       expect(result).toContain(
         'COALESCE(TRANSLATE(regexp_replace("phonesAdditionalPhones"::text',
       );
-      // Verify empty string fallback when column is NULL
       expect(result).toMatch(
         /COALESCE\(TRANSLATE\(regexp_replace\("phonesAdditionalPhones"::text.*\), ''\)/,
       );
@@ -196,11 +188,9 @@ describe('getTsVectorColumnExpressionFromFields', () => {
       const fields = [linksLinksField] as FieldTypeAndNameMetadata[];
       const result = getTsVectorColumnExpressionFromFields(fields);
 
-      // Verify COALESCE wrapping exists for NULL safety on secondaryLinks
       expect(result).toContain(
         'COALESCE(public.unaccent_immutable(TRANSLATE(regexp_replace("domainNameSecondaryLinks"::text',
       );
-      // Verify empty string fallback when column is NULL
       expect(result).toMatch(
         /COALESCE\(public\.unaccent_immutable\(TRANSLATE\(regexp_replace\("domainNameSecondaryLinks"::text.*\), ''\)/,
       );
@@ -214,8 +204,6 @@ describe('getTsVectorColumnExpressionFromFields', () => {
       ] as FieldTypeAndNameMetadata[];
       const result = getTsVectorColumnExpressionFromFields(fields);
 
-      // Count COALESCE with empty string fallback patterns for JSON columns
-      // Each JSON column should have a COALESCE(..., '') pattern
       const additionalEmailsCoalesce = result.includes(
         "COALESCE(public.unaccent_immutable(TRANSLATE(\"emailsAdditionalEmails\"::text, '[]\",', '    ')), '')",
       );

--- a/packages/twenty-server/src/engine/workspace-manager/utils/get-ts-vector-column-expression.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/utils/get-ts-vector-column-expression.util.ts
@@ -107,7 +107,7 @@ const getColumnExpressionsFromField = (
 
       // Convert JSONB array of additional emails to searchable text
       // Example: ["email1@example.com","email2@example.com"] -> "email1@example.com email2@example.com"
-      const additionalEmailsExpression = `COALESCE(public.unaccent_immutable(TRANSLATE(${additionalEmailsColumn}::text, '[]"', '   ')), '')`;
+      const additionalEmailsExpression = `COALESCE(public.unaccent_immutable(TRANSLATE(${additionalEmailsColumn}::text, '[]",', '    ')), '')`;
 
       return [...baseExpressions, additionalEmailsExpression];
     }

--- a/packages/twenty-server/src/engine/workspace-manager/utils/get-ts-vector-column-expression.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/utils/get-ts-vector-column-expression.util.ts
@@ -77,10 +77,6 @@ const getColumnExpressionsFromField = (
         `COALESCE('0' || ${phoneNumberColumn}, '')`,
       ];
 
-      // Convert JSONB array of additional phones to searchable text
-      // additionalPhones contains objects like: [{"number":"5551234","countryCode":"US","callingCode":"+1"}]
-      // Strip keys before TRANSLATE to avoid indexing key names.
-      // TODO(perf): If this becomes hot, consider jsonb_path_query_array with benchmarks.
       const additionalPhonesExpression = `COALESCE(TRANSLATE(regexp_replace(${additionalPhonesColumn}::text, '"(number|countryCode|callingCode)"\\s*:\\s*', '', 'g'), '[]{}",:', '        '), '')`;
 
       return [
@@ -93,10 +89,6 @@ const getColumnExpressionsFromField = (
     if (fieldMetadataTypeAndName.type === FieldMetadataType.LINKS) {
       const secondaryLinksColumn = `"${fieldMetadataTypeAndName.name}SecondaryLinks"`;
 
-      // Convert JSONB array of secondary links to searchable text
-      // secondaryLinks contains objects like: [{"label":"Work","url":"https://example.com"}]
-      // Strip keys before TRANSLATE to avoid indexing key names.
-      // TODO(perf): If this becomes hot, consider jsonb_path_query_array with benchmarks.
       const secondaryLinksExpression = `COALESCE(public.unaccent_immutable(TRANSLATE(regexp_replace(${secondaryLinksColumn}::text, '"(label|url)"\\s*:\\s*', '', 'g'), '[]{}",:', '        ')), '')`;
 
       return [...baseExpressions, secondaryLinksExpression];
@@ -105,8 +97,6 @@ const getColumnExpressionsFromField = (
     if (fieldMetadataTypeAndName.type === FieldMetadataType.EMAILS) {
       const additionalEmailsColumn = `"${fieldMetadataTypeAndName.name}AdditionalEmails"`;
 
-      // Convert JSONB array of additional emails to searchable text
-      // Example: ["email1@example.com","email2@example.com"] -> "email1@example.com email2@example.com"
       const additionalEmailsExpression = `COALESCE(public.unaccent_immutable(TRANSLATE(${additionalEmailsColumn}::text, '[]",', '    ')), '')`;
 
       return [...baseExpressions, additionalEmailsExpression];

--- a/packages/twenty-server/src/engine/workspace-manager/utils/get-ts-vector-column-expression.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/utils/get-ts-vector-column-expression.util.ts
@@ -97,7 +97,7 @@ const getColumnExpressionsFromField = (
     if (fieldMetadataTypeAndName.type === FieldMetadataType.EMAILS) {
       const additionalEmailsColumn = `"${fieldMetadataTypeAndName.name}AdditionalEmails"`;
 
-      const additionalEmailsExpression = `COALESCE(public.unaccent_immutable(TRANSLATE(${additionalEmailsColumn}::text, '[]",', '    ')), '')`;
+      const additionalEmailsExpression = `COALESCE(public.unaccent_immutable(TRANSLATE(${additionalEmailsColumn}::text, '[]",', '    ')), '') || ' ' || COALESCE(public.unaccent_immutable(TRANSLATE(REPLACE(${additionalEmailsColumn}::text, '@', ' '), '[]",', '    ')), '')`;
 
       return [...baseExpressions, additionalEmailsExpression];
     }

--- a/packages/twenty-server/test/integration/constants/test-person-ids.constants.ts
+++ b/packages/twenty-server/test/integration/constants/test-person-ids.constants.ts
@@ -5,5 +5,7 @@ export const TEST_PERSON_4_ID = '777a8457-eb2d-40ac-a707-551b615b6983';
 export const TEST_PERSON_5_ID = '777a8457-eb2d-40ac-a707-551b615b6984';
 export const TEST_PERSON_6_ID = '777a8457-eb2d-40ac-a707-551b615b6985';
 export const TEST_PERSON_7_ID = '777a8457-eb2d-40ac-a707-551b615b6986';
+export const TEST_PERSON_8_ID = '777a8457-eb2d-40ac-a707-551b615b6987';
+export const TEST_PERSON_9_ID = '777a8457-eb2d-40ac-a707-551b615b6988';
 export const NOT_EXISTING_TEST_PERSON_ID =
   '777a8457-eb2d-40ac-a707-551b615b6990';

--- a/packages/twenty-server/test/integration/graphql/suites/search/search-resolver.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/search/search-resolver.integration-spec.ts
@@ -54,6 +54,7 @@ describe('SearchResolver', () => {
         primaryPhoneNumber: '5551234567',
         primaryPhoneCallingCode: '+1',
         primaryPhoneCountryCode: 'US',
+        additionalPhones: [],
       },
     },
     { id: TEST_PERSON_3_ID, name: { firstName: 'searchInput3' } },
@@ -86,11 +87,55 @@ describe('SearchResolver', () => {
       jobTitle: 'Manager',
       emails: { primaryEmail: 'francois@naive.com' },
     },
+    {
+      id: '20202020-0000-0000-0000-000000000008',
+      name: { firstName: 'MultiEmail', lastName: 'Person' },
+      emails: {
+        primaryEmail: 'primary@example.com',
+        additionalEmails: ['secondary@example.com', 'work@company.org'],
+      },
+    },
+    {
+      id: '20202020-0000-0000-0000-000000000009',
+      name: { firstName: 'MultiPhone', lastName: 'Person' },
+      emails: {
+        primaryEmail: 'empty@arrays.com',
+        additionalEmails: [],
+      },
+      phones: {
+        primaryPhoneNumber: '9998887777',
+        primaryPhoneCallingCode: '+1',
+        primaryPhoneCountryCode: 'US',
+        additionalPhones: [
+          { number: '1112223333', countryCode: 'US', callingCode: '+1' },
+          { number: '4445556666', countryCode: 'GB', callingCode: '+44' },
+        ],
+      },
+    },
   ];
 
   const companies = [
-    { id: TEST_COMPANY_1_ID, name: 'Café Corp' },
-    { id: TEST_COMPANY_2_ID, name: 'Naïve Solutions' },
+    {
+      id: TEST_COMPANY_1_ID,
+      name: 'Café Corp',
+      domainName: {
+        primaryLinkLabel: 'Main Site',
+        primaryLinkUrl: 'https://links.example.com',
+        secondaryLinks: [
+          { label: 'DocsPortal', url: 'docs.links.example.com' },
+          { label: 'SupportHub', url: 'support.links.example.com' },
+        ],
+      },
+    },
+    {
+      id: TEST_COMPANY_2_ID,
+      name: 'Naïve Solutions',
+      domainName: {
+        primaryLinkLabel: 'NaivePortal',
+        primaryLinkUrl: 'https://naive.portal.example',
+        secondaryLinks: [],
+      },
+    },
   ];
 
   const pets = [
@@ -108,6 +153,8 @@ describe('SearchResolver', () => {
     francoisPerson,
     josePersonNoAccent,
     francoisPersonNoAccent,
+    multiEmailPerson,
+    multiPhonePerson,
   ] = persons;
   const [cafeCorp, naiveCorp] = companies;
   const [searchInput1Pet, searchInput2Pet, cafePet, naivePet] = pets;
@@ -177,6 +224,8 @@ describe('SearchResolver', () => {
             francoisPerson.id,
             josePersonNoAccent.id,
             francoisPersonNoAccent.id,
+            multiEmailPerson.id,
+            multiPhonePerson.id,
             naiveCorp.id,
             cafeCorp.id,
             searchInput1Pet.id,
@@ -189,7 +238,7 @@ describe('SearchResolver', () => {
             decodedEndCursor: {
               lastRanks: { tsRank: 0, tsRankCD: 0 },
               lastRecordIdsPerObject: {
-                person: francoisPersonNoAccent.id,
+                person: multiPhonePerson.id,
                 company: cafeCorp.id,
                 pet: naivePet.id,
               },
@@ -899,6 +948,226 @@ describe('SearchResolver', () => {
               lastRecordIdsPerObject: {
                 person: searchInput1Person.id,
                 pet: searchInput1Pet.id,
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      title: 'should find person by additional email (secondary email)',
+      context: {
+        input: {
+          searchInput: 'secondary@example.com',
+          excludedObjectNameSingulars: ['workspaceMember'],
+          limit: 50,
+        },
+        eval: {
+          orderedRecordIds: [multiEmailPerson.id],
+          pageInfo: {
+            hasNextPage: false,
+            decodedEndCursor: {
+              lastRanks: { tsRank: 0.06079271, tsRankCD: 0.1 },
+              lastRecordIdsPerObject: {
+                person: multiEmailPerson.id,
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      title: 'should find person by additional email (work email)',
+      context: {
+        input: {
+          searchInput: 'work@company.org',
+          excludedObjectNameSingulars: ['workspaceMember'],
+          limit: 50,
+        },
+        eval: {
+          orderedRecordIds: [multiEmailPerson.id],
+          pageInfo: {
+            hasNextPage: false,
+            decodedEndCursor: {
+              lastRanks: { tsRank: 0.06079271, tsRankCD: 0.1 },
+              lastRecordIdsPerObject: {
+                person: multiEmailPerson.id,
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      title: 'should find person by partial additional email',
+      context: {
+        input: {
+          searchInput: 'company.org',
+          excludedObjectNameSingulars: ['workspaceMember'],
+          limit: 50,
+        },
+        eval: {
+          orderedRecordIds: [multiEmailPerson.id],
+          pageInfo: {
+            hasNextPage: false,
+            decodedEndCursor: {
+              lastRanks: { tsRank: 0.06079271, tsRankCD: 0.1 },
+              lastRecordIdsPerObject: {
+                person: multiEmailPerson.id,
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      title: 'should find person by additional phone number',
+      context: {
+        input: {
+          searchInput: '1112223333',
+          excludedObjectNameSingulars: ['workspaceMember'],
+          limit: 50,
+        },
+        eval: {
+          orderedRecordIds: [multiPhonePerson.id],
+          pageInfo: {
+            hasNextPage: false,
+            decodedEndCursor: {
+              lastRanks: { tsRank: 0.06079271, tsRankCD: 0.1 },
+              lastRecordIdsPerObject: {
+                person: multiPhonePerson.id,
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      title: 'should find person by second additional phone number',
+      context: {
+        input: {
+          searchInput: '4445556666',
+          excludedObjectNameSingulars: ['workspaceMember'],
+          limit: 50,
+        },
+        eval: {
+          orderedRecordIds: [multiPhonePerson.id],
+          pageInfo: {
+            hasNextPage: false,
+            decodedEndCursor: {
+              lastRanks: { tsRank: 0.06079271, tsRankCD: 0.1 },
+              lastRecordIdsPerObject: {
+                person: multiPhonePerson.id,
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      title: 'should find company by secondary link url',
+      context: {
+        input: {
+          searchInput: 'docs.links.example.com',
+          excludedObjectNameSingulars: ['workspaceMember'],
+          limit: 50,
+        },
+        eval: {
+          orderedRecordIds: [cafeCorp.id],
+          pageInfo: {
+            hasNextPage: false,
+            decodedEndCursor: {
+              lastRanks: { tsRank: 0.06079271, tsRankCD: 0.1 },
+              lastRecordIdsPerObject: {
+                company: cafeCorp.id,
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      title: 'should find company by secondary link label',
+      context: {
+        input: {
+          searchInput: 'DocsPortal',
+          excludedObjectNameSingulars: ['workspaceMember'],
+          limit: 50,
+        },
+        eval: {
+          orderedRecordIds: [cafeCorp.id],
+          pageInfo: {
+            hasNextPage: false,
+            decodedEndCursor: {
+              lastRanks: { tsRank: 0.06079271, tsRankCD: 0.1 },
+              lastRecordIdsPerObject: {
+                company: cafeCorp.id,
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      title: 'should handle empty additional emails array',
+      context: {
+        input: {
+          searchInput: 'empty@arrays.com',
+          excludedObjectNameSingulars: ['workspaceMember'],
+          limit: 50,
+        },
+        eval: {
+          orderedRecordIds: [multiPhonePerson.id],
+          pageInfo: {
+            hasNextPage: false,
+            decodedEndCursor: {
+              lastRanks: { tsRank: 0.06079271, tsRankCD: 0.1 },
+              lastRecordIdsPerObject: {
+                person: multiPhonePerson.id,
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      title: 'should handle empty additional phones array',
+      context: {
+        input: {
+          searchInput: '5551234567',
+          excludedObjectNameSingulars: ['workspaceMember'],
+          limit: 50,
+        },
+        eval: {
+          orderedRecordIds: [searchInput2Person.id],
+          pageInfo: {
+            hasNextPage: false,
+            decodedEndCursor: {
+              lastRanks: { tsRank: 0.06079271, tsRankCD: 0.1 },
+              lastRecordIdsPerObject: {
+                person: searchInput2Person.id,
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      title: 'should handle empty secondary links array',
+      context: {
+        input: {
+          searchInput: 'NaivePortal',
+          excludedObjectNameSingulars: ['workspaceMember'],
+          limit: 50,
+        },
+        eval: {
+          orderedRecordIds: [naiveCorp.id],
+          pageInfo: {
+            hasNextPage: false,
+            decodedEndCursor: {
+              lastRanks: { tsRank: 0.06079271, tsRankCD: 0.1 },
+              lastRecordIdsPerObject: {
+                company: naiveCorp.id,
               },
             },
           },

--- a/packages/twenty-server/test/integration/graphql/suites/search/search-resolver.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/search/search-resolver.integration-spec.ts
@@ -690,9 +690,9 @@ describe('SearchResolver', () => {
         },
         eval: {
           orderedRecordIds: [
+            naiveCorp.id,
             francoisPerson.id,
             francoisPersonNoAccent.id,
-            naiveCorp.id,
             naivePet.id,
           ],
           pageInfo: {

--- a/packages/twenty-server/test/integration/graphql/suites/search/search-resolver.integration-spec.ts
+++ b/packages/twenty-server/test/integration/graphql/suites/search/search-resolver.integration-spec.ts
@@ -13,6 +13,8 @@ import {
   TEST_PERSON_5_ID,
   TEST_PERSON_6_ID,
   TEST_PERSON_7_ID,
+  TEST_PERSON_8_ID,
+  TEST_PERSON_9_ID,
 } from 'test/integration/constants/test-person-ids.constants';
 import {
   TEST_PET_ID_1,
@@ -88,7 +90,7 @@ describe('SearchResolver', () => {
       emails: { primaryEmail: 'francois@naive.com' },
     },
     {
-      id: '20202020-0000-0000-0000-000000000008',
+      id: TEST_PERSON_8_ID,
       name: { firstName: 'MultiEmail', lastName: 'Person' },
       emails: {
         primaryEmail: 'primary@example.com',
@@ -96,7 +98,7 @@ describe('SearchResolver', () => {
       },
     },
     {
-      id: '20202020-0000-0000-0000-000000000009',
+      id: TEST_PERSON_9_ID,
       name: { firstName: 'MultiPhone', lastName: 'Person' },
       emails: {
         primaryEmail: 'empty@arrays.com',


### PR DESCRIPTION
## Summary
- Add `additionalEmails` (EMAILS type) to tsvector search expression
- Add `additionalPhones` (PHONES type) to tsvector search expression  
- Add `secondaryLinks` (LINKS type) to tsvector search expression

This enables searching for people/companies by their secondary contact information, not just primary values.

## Test plan
- [x] Unit tests for all three composite field types (16 tests passing)
- [x] Integration tests for searching by secondary email, work email, partial domain
- [x] Integration tests for searching by additional phone numbers
- [x] Integration test for searching by secondary link URL
- [x] Lint passes