### PR TITLE
Made the code more resilient to stale value prop in date filter

### DIFF
--- a/packages/twenty-front/src/modules/views/utils/__tests__/areViewFiltersEqual.test.ts
+++ b/packages/twenty-front/src/modules/views/utils/__tests__/areViewFiltersEqual.test.ts
@@ -1,6 +1,6 @@
 import { type ViewFilter } from '@/views/types/ViewFilter';
-import { ViewFilterOperand } from 'twenty-shared/types';
 import { areViewFiltersEqual } from '@/views/utils/areViewFiltersEqual';
+import { ViewFilterOperand } from 'twenty-shared/types';
 
 describe('areViewFiltersEqual', () => {
   const baseFilter: ViewFilter = {
@@ -19,13 +19,6 @@ describe('areViewFiltersEqual', () => {
     const filterB = { ...baseFilter };
 
     expect(areViewFiltersEqual(filterA, filterB)).toBe(true);
-  });
-
-  it('should return false when displayValue is different', () => {
-    const filterA = { ...baseFilter };
-    const filterB = { ...baseFilter, displayValue: 'different' };
-
-    expect(areViewFiltersEqual(filterA, filterB)).toBe(false);
   });
 
   it('should return false when fieldMetadataId is different', () => {

--- a/packages/twenty-front/src/modules/views/utils/areViewFiltersEqual.ts
+++ b/packages/twenty-front/src/modules/views/utils/areViewFiltersEqual.ts
@@ -10,7 +10,6 @@ export const areViewFiltersEqual = (
     'viewFilterGroupId',
     'positionInViewFilterGroup',
     'value',
-    'displayValue',
     'operand',
     'subFieldName',
   ];


### PR DESCRIPTION
Fixes : https://github.com/twentyhq/twenty/issues/17035

There was a bad pattern which risked introduce this bug in `turnRecordFilterIntoRecordGqlOperationFilter` after recent refactor of date logic and date filters, which didn't create any bug during dev time because it wasn't tested with value combinations that existed before the refactor.

Code has been re-organized to make it resilient to any wrong value combination.

Also fixed a small bug that appeared during QA with `DATE` filter type, which was blocking the save button from disappearing after a save.