### PR TITLE
Fix cleaning command

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/services/cleaner.workspace-service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/services/cleaner.workspace-service.ts
@@ -86,7 +86,9 @@ export class CleanerWorkspaceService {
         lastSubscription.status !== SubscriptionStatus.Unpaid &&
         lastSubscription.status !== SubscriptionStatus.Canceled
       ) {
-        throw new Error();
+        throw new Error(
+          'No cancelled or unpaid billing subscription found for workspace',
+        );
       }
 
       const daysSinceSubscriptionUnpaid = differenceInDays(

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/services/cleaner.workspace-service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/services/cleaner.workspace-service.ts
@@ -70,7 +70,7 @@ export class CleanerWorkspaceService {
       );
   }
 
-  async computeDaysSinceSubscriptionUnpaid(
+  async computeDaysSinceSubscriptionUnpaidOrThrow(
     workspace: WorkspaceEntity,
   ): Promise<number> {
     try {
@@ -383,7 +383,7 @@ export class CleanerWorkspaceService {
         }
 
         const workspaceInactivity =
-          await this.computeDaysSinceSubscriptionUnpaid(workspace);
+          await this.computeDaysSinceSubscriptionUnpaidOrThrow(workspace);
 
         if (workspaceInactivity > this.inactiveDaysBeforeSoftDelete) {
           await this.informWorkspaceMembersAndSoftDeleteWorkspace(


### PR DESCRIPTION
Previous behavior:

Used billingSubscription.updatedAt (when the subscription record was last modified)
Problem: updatedAt changes for ANY update, not just status changes, making it unreliable for tracking when payment problems started

Current behavior:

Uses currentPeriodStart when subscription status is Unpaid or Canceled
Why it works: WORKSPACE_INACTIVE_DAYS_BEFORE_SOFT_DELETION is shorter than the minimum billing interval (1 month). Then if a workspace is unpaid for the entire current billing period, it will always exceed the deletion threshold before the next period starts

Ideal fix:
Track workspace.suspendedAt explicitly, giving you the exact timestamp of when payment problems began, regardless of billing periods.
