### PR TITLE
fix: removed scrollbar, elipsified overflow text supporting tooltip

### DIFF
--- a/packages/twenty-front/src/modules/settings/components/SettingsMorphRelationMultiSelect.tsx
+++ b/packages/twenty-front/src/modules/settings/components/SettingsMorphRelationMultiSelect.tsx
@@ -68,20 +68,6 @@ const StyledDescription = styled.span`
   font-size: ${({ theme }) => theme.font.size.sm};
 `;
 
-const StyledMenuItemWrapper = styled.div`
-  width: 100%;
-  display: flex;
-  align-items: center;
-  gap: ${({ theme }) => theme.spacing(2)};
-  min-width: 0;
-
-  > div > div {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-`;
-
 export const SettingsMorphRelationMultiSelect = ({
   className,
   disabled: disabledFromProps,
@@ -253,29 +239,27 @@ export const SettingsMorphRelationMultiSelect = ({
                           closeDropdown(dropdownId);
                         }}
                       >
-                        <StyledMenuItemWrapper>
-                          <MenuItemMultiSelect
-                            className=""
-                            LeftIcon={option.Icon ?? undefined}
-                            text={option.label}
-                            selected={selectedObjectMetadataIds.some(
-                              (selectedObjectMetadataId) =>
-                                selectedObjectMetadataId ===
+                        <MenuItemMultiSelect
+                          className=""
+                          LeftIcon={option.Icon ?? undefined}
+                          text={option.label}
+                          selected={selectedObjectMetadataIds.some(
+                            (selectedObjectMetadataId) =>
+                              selectedObjectMetadataId ===
+                              option.objectMetadataId,
+                          )}
+                          isKeySelected={selectedItemId === option.label}
+                          onSelectChange={() => {
+                            let newSelectedObjectMetadataIds =
+                              addOrRemoveFromArray(
+                                selectedObjectMetadataIds,
                                 option.objectMetadataId,
-                            )}
-                            isKeySelected={selectedItemId === option.label}
-                            onSelectChange={() => {
-                              let newSelectedObjectMetadataIds =
-                                addOrRemoveFromArray(
-                                  selectedObjectMetadataIds,
-                                  option.objectMetadataId,
-                                );
+                              );
 
-                              onChange?.(newSelectedObjectMetadataIds);
-                              onBlur?.();
-                            }}
-                          />
-                        </StyledMenuItemWrapper>
+                            onChange?.(newSelectedObjectMetadataIds);
+                            onBlur?.();
+                          }}
+                        />
                       </SelectableListItem>
                     ))}
                   </SelectableList>

--- a/packages/twenty-front/src/modules/settings/components/SettingsMorphRelationMultiSelect.tsx
+++ b/packages/twenty-front/src/modules/settings/components/SettingsMorphRelationMultiSelect.tsx
@@ -68,6 +68,20 @@ const StyledDescription = styled.span`
   font-size: ${({ theme }) => theme.font.size.sm};
 `;
 
+const StyledMenuItemWrapper = styled.div`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing(2)};
+  min-width: 0;
+
+  > div > div {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+`;
+
 export const SettingsMorphRelationMultiSelect = ({
   className,
   disabled: disabledFromProps,
@@ -239,27 +253,29 @@ export const SettingsMorphRelationMultiSelect = ({
                           closeDropdown(dropdownId);
                         }}
                       >
-                        <MenuItemMultiSelect
-                          className=""
-                          LeftIcon={option.Icon ?? undefined}
-                          text={option.label}
-                          selected={selectedObjectMetadataIds.some(
-                            (selectedObjectMetadataId) =>
-                              selectedObjectMetadataId ===
-                              option.objectMetadataId,
-                          )}
-                          isKeySelected={selectedItemId === option.label}
-                          onSelectChange={() => {
-                            let newSelectedObjectMetadataIds =
-                              addOrRemoveFromArray(
-                                selectedObjectMetadataIds,
+                        <StyledMenuItemWrapper>
+                          <MenuItemMultiSelect
+                            className=""
+                            LeftIcon={option.Icon ?? undefined}
+                            text={option.label}
+                            selected={selectedObjectMetadataIds.some(
+                              (selectedObjectMetadataId) =>
+                                selectedObjectMetadataId ===
                                 option.objectMetadataId,
-                              );
+                            )}
+                            isKeySelected={selectedItemId === option.label}
+                            onSelectChange={() => {
+                              let newSelectedObjectMetadataIds =
+                                addOrRemoveFromArray(
+                                  selectedObjectMetadataIds,
+                                  option.objectMetadataId,
+                                );
 
-                            onChange?.(newSelectedObjectMetadataIds);
-                            onBlur?.();
-                          }}
-                        />{' '}
+                              onChange?.(newSelectedObjectMetadataIds);
+                              onBlur?.();
+                            }}
+                          />
+                        </StyledMenuItemWrapper>
                       </SelectableListItem>
                     ))}
                   </SelectableList>

--- a/packages/twenty-ui/src/navigation/menu/menu-item/components/MenuItemMultiSelect.tsx
+++ b/packages/twenty-ui/src/navigation/menu/menu-item/components/MenuItemMultiSelect.tsx
@@ -12,6 +12,8 @@ const StyledLeftContentWithCheckboxContainer = styled.div`
   display: flex;
   flex-direction: row;
   gap: ${({ theme }) => theme.spacing(2)};
+  min-width: 0;
+  overflow: hidden;
 `;
 
 type MenuItemMultiSelectProps = {


### PR DESCRIPTION
fixes #15152 

Added CSS to ellipsify overflowing text with tooltip support, consistent with existing dropdown implementations such as the address dropdown for long country names.
This approach resolves the issue locally without modifying global components, avoiding the limitations of previous attempts.

<img width="655" height="508" alt="Screenshot 2026-01-11 at 4 09 45 PM" src="https://github.com/user-attachments/assets/3e11f6c2-3f13-4c1a-91da-59fc1a34e9dd" />


Before :

<img width="547" height="496" alt="Screenshot 2026-01-11 at 4 09 11 PM" src="https://github.com/user-attachments/assets/43181d93-0603-4338-bb6e-688cffac91c9" />

After :

<img width="578" height="527" alt="Screenshot 2026-01-11 at 4 08 28 PM" src="https://github.com/user-attachments/assets/0f277f3b-eeff-4866-99d9-6b31309c02af" />


