### PR TITLE
fix: hide "Add new" button for workspace member relations

### DIFF
--- a/packages/twenty-front/src/modules/activities/timeline-activities/rows/main-object/components/__stories__/EventRowMainObjectUpdated.stories.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/rows/main-object/components/__stories__/EventRowMainObjectUpdated.stories.tsx
@@ -3,6 +3,7 @@ import { type TimelineActivity } from '@/activities/timeline-activities/types/Ti
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 
 import { ComponentDecorator, RouterDecorator } from 'twenty-ui/testing';
+import { I18nFrontDecorator } from '~/testing/decorators/I18nFrontDecorator';
 import { ObjectMetadataItemsDecorator } from '~/testing/decorators/ObjectMetadataItemsDecorator';
 import { SnackBarDecorator } from '~/testing/decorators/SnackBarDecorator';
 import { generatedMockObjectMetadataItems } from '~/testing/utils/generatedMockObjectMetadataItems';
@@ -44,6 +45,7 @@ const meta: Meta<typeof EventRowMainObjectUpdated> = {
     ObjectMetadataItemsDecorator,
     SnackBarDecorator,
     RouterDecorator,
+    I18nFrontDecorator,
   ],
 };
 

--- a/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSectionDropdownToMany.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSectionDropdownToMany.tsx
@@ -23,7 +23,7 @@ import { useCloseDropdown } from '@/ui/layout/dropdown/hooks/useCloseDropdown';
 import { dropdownPlacementComponentState } from '@/ui/layout/dropdown/states/dropdownPlacementComponentState';
 import { useRecoilComponentValue } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValue';
 import { useSetRecoilComponentState } from '@/ui/utilities/state/component-state/hooks/useSetRecoilComponentState';
-import { CustomError } from 'twenty-shared/utils';
+import { CustomError, isDefined } from 'twenty-shared/utils';
 import { IconPlus } from 'twenty-ui/display';
 import { LightIconButton } from 'twenty-ui/input';
 
@@ -182,7 +182,9 @@ export const RecordDetailRelationSectionDropdownToMany = ({
           focusId={dropdownId}
           componentInstanceId={dropdownId}
           onCreate={
-            createNewRecordAndOpenRightDrawer ? handleCreateNew : undefined
+            isDefined(createNewRecordAndOpenRightDrawer)
+              ? handleCreateNew
+              : undefined
           }
           objectMetadataItemIdForCreate={relationObjectMetadataItem.id}
           onChange={updateRelation}

--- a/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSectionDropdownToMany.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field-list/record-detail-section/relation/components/RecordDetailRelationSectionDropdownToMany.tsx
@@ -181,7 +181,9 @@ export const RecordDetailRelationSectionDropdownToMany = ({
         <MultipleRecordPicker
           focusId={dropdownId}
           componentInstanceId={dropdownId}
-          onCreate={handleCreateNew}
+          onCreate={
+            createNewRecordAndOpenRightDrawer ? handleCreateNew : undefined
+          }
           objectMetadataItemIdForCreate={relationObjectMetadataItem.id}
           onChange={updateRelation}
           onSubmit={() => {

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/RelationManyToOneFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/RelationManyToOneFieldInput.tsx
@@ -110,7 +110,7 @@ export const RelationManyToOneFieldInput = () => {
       EmptyIcon={IconForbid}
       emptyLabel={t`No ${fieldLabel}`}
       onCancel={onCancel}
-      onCreate={handleCreateNew}
+      onCreate={createNewRecordAndOpenRightDrawer ? handleCreateNew : undefined}
       onMorphItemSelected={handleMorphItemSelected}
       objectNameSingulars={[
         fieldDefinition.metadata.relationObjectMetadataNameSingular,

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/RelationManyToOneFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/RelationManyToOneFieldInput.tsx
@@ -110,7 +110,11 @@ export const RelationManyToOneFieldInput = () => {
       EmptyIcon={IconForbid}
       emptyLabel={t`No ${fieldLabel}`}
       onCancel={onCancel}
-      onCreate={createNewRecordAndOpenRightDrawer ? handleCreateNew : undefined}
+      onCreate={
+        isDefined(createNewRecordAndOpenRightDrawer)
+          ? handleCreateNew
+          : undefined
+      }
       onMorphItemSelected={handleMorphItemSelected}
       objectNameSingulars={[
         fieldDefinition.metadata.relationObjectMetadataNameSingular,


### PR DESCRIPTION
**Description**

Fixes the "Add new" button appearing in relation picker dropdowns for workspace member relations (e.g., Account Owner on companies). Workspace members cannot be created from relation pickers, so this button should not appear.

**Changes Made**

- Modified RelationManyToOneFieldInput.tsx to conditionally pass the onCreate prop to SingleRecordPicker only when createNewRecordAndOpenRightDrawer is defined.
- Moved the conditional check to the JSX level for clarity.

**Technical Details**

The useAddNewRecordAndOpenRightDrawer hook already returns undefined for workspace member relations, but the component was still passing a handler function to SingleRecordPicker, causing the "Add new" button to appear. The fix ensures that when createNewRecordAndOpenRightDrawer is undefined, onCreate is also undefined, which prevents SingleRecordPickerMenuItemsWithSearch from rendering the button.

Testing

- Verified that the "Add new" button no longer appears in the Account Owner dropdown for companies.
- Confirmed that the "Add new" button still appears for other relation fields where it's appropriate (e.g., People, Opportunities).
- Tested that existing functionality for selecting workspace members from the dropdown still works correctly.

Fixes #17060 