### PR TITLE
fix: use theme-aware background color for billing credits progress bar

### DIFF
--- a/packages/twenty-front/src/modules/billing/components/SettingsBillingCreditsSection.tsx
+++ b/packages/twenty-front/src/modules/billing/components/SettingsBillingCreditsSection.tsx
@@ -14,7 +14,6 @@ import { t } from '@lingui/core/macro';
 import { H2Title } from 'twenty-ui/display';
 import { ProgressBar } from 'twenty-ui/feedback';
 import { Section } from 'twenty-ui/layout';
-import { BACKGROUND_LIGHT } from 'twenty-ui/theme';
 import { SubscriptionStatus } from '~/generated/graphql';
 import { formatToShortNumber } from '~/utils/format/formatToShortNumber';
 
@@ -86,7 +85,7 @@ export const SettingsBillingCreditsSection = ({
             barColor={
               progressBarValue > 100 ? theme.color.red8 : theme.color.blue
             }
-            backgroundColor={BACKGROUND_LIGHT.tertiary}
+            backgroundColor={theme.background.tertiary}
             withBorderRadius={true}
           />
 


### PR DESCRIPTION
## Summary
- Fixed the billing credits progress bar background color in dark mode
- The background was hardcoded to `BACKGROUND_LIGHT.tertiary`, causing it to always display a light color regardless of the current theme
- Changed to use `theme.background.tertiary` to properly respect dark/light mode

## Test plan
- [x] Navigate to Settings > Billing in dark mode
- [x] Verify the credits progress bar background matches the tertiary background color (dark in dark mode)
- [x] Verify it still looks correct in light mode

Figma reference: https://www.figma.com/design/xt8O9mFeLl46C5InWwoMrN/Twenty?node-id=64812-242606&m=dev