### PR TITLE
Fix settings data model tables to take full width and align columns

### DIFF
--- a/packages/twenty-front/src/modules/settings/data-model/object-details/components/SettingsObjectFieldItemTableRow.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/object-details/components/SettingsObjectFieldItemTableRow.tsx
@@ -37,7 +37,7 @@ type SettingsObjectFieldItemTableRowProps = {
 };
 
 export const StyledObjectFieldTableRow = styled(TableRow)`
-  grid-auto-columns: 180px 148px 148px 36px;
+  grid-template-columns: 1fr 148px 148px 36px;
 `;
 
 const StyledNameTableCell = styled(TableCell)`

--- a/packages/twenty-front/src/modules/settings/data-model/object-details/components/SettingsObjectRelationItemTableRow.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/object-details/components/SettingsObjectRelationItemTableRow.tsx
@@ -26,7 +26,7 @@ type SettingsObjectRelationItemTableRowProps = {
 };
 
 export const StyledObjectRelationTableRow = styled(TableRow)`
-  grid-template-columns: 180px 100px 148px 36px;
+  grid-template-columns: 1fr 148px 148px 36px;
 `;
 
 const StyledNameTableCell = styled(TableCell)`


### PR DESCRIPTION
## Summary
- Updated Relations and Fields tables in the object detail settings page to use flexible width (`1fr`) for the Name column instead of fixed pixels
- Aligned column widths between both tables (`1fr 148px 148px 36px`) so the App and Type/Data type columns line up

## Test plan
- [ ] Navigate to Settings > Data model > select any object (e.g., Companies)
- [ ] Verify the Relations table rows take the full available width
- [ ] Verify the Fields table rows take the full available width
- [ ] Verify the App and Type/Data type columns are aligned between both tables