### PR TITLE
Allow `isUnique` mutation on standard field

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/constants/flat-field-metadata-editable-properties.constant.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/constants/flat-field-metadata-editable-properties.constant.ts
@@ -21,7 +21,6 @@ export const FLAT_FIELD_METADATA_EDITABLE_PROPERTIES = {
     'label',
     'options',
     'settings',
-    //TODO :  uncomment once universal identifier on standard fields is migrated
-    // 'isUnique', // not editable for standard fields with standard unique constraint
+    'isUnique',
   ],
 } as const satisfies Record<'standard' | 'custom', (keyof FlatFieldMetadata)[]>;

--- a/packages/twenty-server/test/integration/metadata/suites/field-metadata/successful-update-one-standard-field-metadata.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/field-metadata/successful-update-one-standard-field-metadata.integration-spec.ts
@@ -330,8 +330,7 @@ describe('Standard field isUnique update should succeed', () => {
     });
   });
 
-  // TODO: Enable this test once isUnique set as editable on standard fields
-  it.failing('should set isUnique to true on standard field', async () => {
+  it('should set isUnique to true on standard field', async () => {
     jestExpectToBeDefined(nameFieldMetadata);
 
     const { data } = await updateOneFieldMetadata({


### PR DESCRIPTION
# Introduction
As we've just [identified](https://github.com/twentyhq/twenty/pull/16981) the standard field metadata in production we can not enable the is unique comparison even for standard entities