### PR TITLE
Hardcode workflow objects and dashboards to be last in the navigation drawer

### DIFF
--- a/packages/twenty-front/src/modules/object-metadata/components/NavigationDrawerSectionForObjectMetadataItems.tsx
+++ b/packages/twenty-front/src/modules/object-metadata/components/NavigationDrawerSectionForObjectMetadataItems.tsx
@@ -20,8 +20,6 @@ const ORDERED_FIRST_STANDARD_OBJECTS: string[] = [
 
 const ORDERED_LAST_STANDARD_OBJECTS: string[] = [
   CoreObjectNameSingular.Workflow,
-  CoreObjectNameSingular.WorkflowVersion,
-  CoreObjectNameSingular.WorkflowRun,
   CoreObjectNameSingular.Dashboard,
 ];
 

--- a/packages/twenty-front/src/modules/object-metadata/components/NavigationDrawerSectionForObjectMetadataItems.tsx
+++ b/packages/twenty-front/src/modules/object-metadata/components/NavigationDrawerSectionForObjectMetadataItems.tsx
@@ -8,13 +8,21 @@ import { NavigationDrawerSection } from '@/ui/navigation/navigation-drawer/compo
 import { NavigationDrawerSectionTitle } from '@/ui/navigation/navigation-drawer/components/NavigationDrawerSectionTitle';
 import { useNavigationSection } from '@/ui/navigation/navigation-drawer/hooks/useNavigationSection';
 import { useRecoilValue } from 'recoil';
+import { isDefined } from 'twenty-shared/utils';
 
-const ORDERED_STANDARD_OBJECTS: string[] = [
+const ORDERED_FIRST_STANDARD_OBJECTS: string[] = [
   CoreObjectNameSingular.Person,
   CoreObjectNameSingular.Company,
   CoreObjectNameSingular.Opportunity,
   CoreObjectNameSingular.Task,
   CoreObjectNameSingular.Note,
+];
+
+const ORDERED_LAST_STANDARD_OBJECTS: string[] = [
+  CoreObjectNameSingular.Workflow,
+  CoreObjectNameSingular.WorkflowVersion,
+  CoreObjectNameSingular.WorkflowRun,
+  CoreObjectNameSingular.Dashboard,
 ];
 
 type NavigationDrawerSectionForObjectMetadataItemsProps = {
@@ -35,12 +43,16 @@ export const NavigationDrawerSectionForObjectMetadataItems = ({
   const { objectPermissionsByObjectMetadataId } = useObjectPermissions();
 
   const sortedStandardObjectMetadataItems = [...objectMetadataItems]
-    .filter((item) => ORDERED_STANDARD_OBJECTS.includes(item.nameSingular))
+    .filter(
+      (item) =>
+        ORDERED_FIRST_STANDARD_OBJECTS.includes(item.nameSingular) &&
+        !ORDERED_LAST_STANDARD_OBJECTS.includes(item.nameSingular),
+    )
     .sort((objectMetadataItemA, objectMetadataItemB) => {
-      const indexA = ORDERED_STANDARD_OBJECTS.indexOf(
+      const indexA = ORDERED_FIRST_STANDARD_OBJECTS.indexOf(
         objectMetadataItemA.nameSingular,
       );
-      const indexB = ORDERED_STANDARD_OBJECTS.indexOf(
+      const indexB = ORDERED_FIRST_STANDARD_OBJECTS.indexOf(
         objectMetadataItemB.nameSingular,
       );
       if (indexA === -1 || indexB === -1) {
@@ -52,7 +64,11 @@ export const NavigationDrawerSectionForObjectMetadataItems = ({
     });
 
   const sortedCustomObjectMetadataItems = [...objectMetadataItems]
-    .filter((item) => !ORDERED_STANDARD_OBJECTS.includes(item.nameSingular))
+    .filter(
+      (item) =>
+        !ORDERED_FIRST_STANDARD_OBJECTS.includes(item.nameSingular) &&
+        !ORDERED_LAST_STANDARD_OBJECTS.includes(item.nameSingular),
+    )
     .sort((objectMetadataItemA, objectMetadataItemB) => {
       return new Date(objectMetadataItemA.createdAt) <
         new Date(objectMetadataItemB.createdAt)
@@ -60,9 +76,17 @@ export const NavigationDrawerSectionForObjectMetadataItems = ({
         : -1;
     });
 
+  const sortedLastStandardObjectMetadataItems =
+    ORDERED_LAST_STANDARD_OBJECTS.map((nameSingular) => {
+      return objectMetadataItems.find(
+        (item) => item.nameSingular === nameSingular,
+      );
+    }).filter(isDefined);
+
   const objectMetadataItemsForNavigationItems = [
     ...sortedStandardObjectMetadataItems,
     ...sortedCustomObjectMetadataItems,
+    ...sortedLastStandardObjectMetadataItems,
   ];
 
   const objectMetadataItemsForNavigationItemsWithReadPermission =


### PR DESCRIPTION
Closes https://github.com/twentyhq/core-team-issues/issues/2058

We settled on a simpler solution by just hardcoding the objects order for now. We will change this once it's possible to reorder the workspace favorites with drag and drop.