### PR TITLE
Invalidate legacy cache after flats

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service.ts
@@ -180,18 +180,19 @@ export class WorkspaceMigrationRunnerService {
         `Cache invalidation ${flatEntitiesCacheToInvalidate.join()}`,
       );
 
-      const invalidationResults = await Promise.allSettled([
-        this.flatEntityMapsCacheService.invalidateFlatEntityMaps({
-          workspaceId,
-          flatMapsKeys: flatEntitiesCacheToInvalidate,
-        }),
-        ...this.getLegacyCacheInvalidationPromises({
+      await this.flatEntityMapsCacheService.invalidateFlatEntityMaps({
+        workspaceId,
+        flatMapsKeys: flatEntitiesCacheToInvalidate,
+      });
+
+      const invalidationResults = await Promise.allSettled(
+        this.getLegacyCacheInvalidationPromises({
           workspaceMigration: {
             actions,
             workspaceId,
           },
         }),
-      ]);
+      );
 
       const invalidationFailures = invalidationResults.filter(
         (result) => result.status === 'rejected',


### PR DESCRIPTION
# Introduction

Some legacy caches are based on the flat ones
So we need to seq invalidate before invalidating others as it could result in inter dep cache invalidation race condition