### PR TITLE
Clean soft deleted suspended workspace command and `ignore-grace-period` flag

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/workspace/services/__tests__/workspace.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/services/__tests__/workspace.service.spec.ts
@@ -26,6 +26,7 @@ import { WorkspaceInvitationService } from 'src/engine/core-modules/workspace-in
 import { WorkspaceService } from 'src/engine/core-modules/workspace/services/workspace.service';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { WorkspaceManyOrAllFlatEntityMapsCacheService } from 'src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.service';
+import { ObjectMetadataService } from 'src/engine/metadata-modules/object-metadata/object-metadata.service';
 import { PermissionsService } from 'src/engine/metadata-modules/permissions/permissions.service';
 import { WorkspaceCacheStorageService } from 'src/engine/workspace-cache-storage/workspace-cache-storage.service';
 import { WorkspaceDataSourceService } from 'src/engine/workspace-datasource/workspace-datasource.service';
@@ -58,6 +59,12 @@ describe('WorkspaceService', () => {
           provide: getRepositoryToken(ApprovedAccessDomainEntity),
           useValue: {
             findOneBy: jest.fn(),
+          },
+        },
+        {
+          provide: ObjectMetadataService,
+          useValue: {
+            deleteWorkspaceAllObjectMetadata: jest.fn(),
           },
         },
         {

--- a/packages/twenty-server/src/engine/core-modules/workspace/services/__tests__/workspace.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/services/__tests__/workspace.service.spec.ts
@@ -280,16 +280,10 @@ describe('WorkspaceService', () => {
         .spyOn(workspaceRepository, 'findOne')
         .mockResolvedValue(mockWorkspace);
       jest.spyOn(userWorkspaceRepository, 'find').mockResolvedValue([]);
-      jest
-        .spyOn(service, 'deleteMetadataSchemaCacheAndUserWorkspace')
-        .mockResolvedValue({} as WorkspaceEntity);
 
       await service.deleteWorkspace(mockWorkspace.id, false);
 
       expect(workspaceRepository.delete).toHaveBeenCalledWith(mockWorkspace.id);
-      expect(
-        service.deleteMetadataSchemaCacheAndUserWorkspace,
-      ).toHaveBeenCalled();
       expect(workspaceRepository.softDelete).not.toHaveBeenCalled();
       expect(workspaceCacheStorageService.flush).toHaveBeenCalledWith(
         mockWorkspace.id,
@@ -331,9 +325,6 @@ describe('WorkspaceService', () => {
         .spyOn(workspaceRepository, 'findOne')
         .mockResolvedValue(mockWorkspace);
       jest.spyOn(userWorkspaceRepository, 'find').mockResolvedValue([]);
-      jest
-        .spyOn(service, 'deleteMetadataSchemaCacheAndUserWorkspace')
-        .mockResolvedValue({} as WorkspaceEntity);
 
       await service.deleteWorkspace(mockWorkspace.id, false);
 

--- a/packages/twenty-server/src/engine/core-modules/workspace/services/workspace.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/services/workspace.service.ts
@@ -322,10 +322,6 @@ export class WorkspaceService extends TypeOrmQueryService<WorkspaceEntity> {
       return workspace;
     }
 
-    await this.userWorkspaceService.deleteUserWorkspace({
-      userWorkspaceId: workspace.id,
-    });
-
     // Note: not relying on workspace id FK cascade deletion here to avoid query read timeout later on workspace deletion
     await this.objectMetadataService.deleteWorkspaceAllObjectMetadata({
       workspaceId: workspace.id,

--- a/packages/twenty-server/src/engine/core-modules/workspace/workspace.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/workspace.module.ts
@@ -31,6 +31,7 @@ import { WorkspaceResolver } from 'src/engine/core-modules/workspace/workspace.r
 import { AiAgentModule } from 'src/engine/metadata-modules/ai/ai-agent/ai-agent.module';
 import { DataSourceModule } from 'src/engine/metadata-modules/data-source/data-source.module';
 import { WorkspaceManyOrAllFlatEntityMapsCacheModule } from 'src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.module';
+import { ObjectMetadataModule } from 'src/engine/metadata-modules/object-metadata/object-metadata.module';
 import { PermissionsModule } from 'src/engine/metadata-modules/permissions/permissions.module';
 import { RoleModule } from 'src/engine/metadata-modules/role/role.module';
 import { ViewModule } from 'src/engine/metadata-modules/view/view.module';
@@ -55,6 +56,7 @@ import { WorkspaceManagerModule } from 'src/engine/workspace-manager/workspace-m
           UserWorkspaceEntity,
           PublicDomainEntity,
         ]),
+        ObjectMetadataModule,
         UserWorkspaceModule,
         WorkspaceManagerModule,
         FeatureFlagModule,

--- a/packages/twenty-server/src/engine/metadata-modules/workspace-metadata-version/services/workspace-metadata-version.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/workspace-metadata-version/services/workspace-metadata-version.service.ts
@@ -24,6 +24,7 @@ export class WorkspaceMetadataVersionService {
   async incrementMetadataVersion(workspaceId: string): Promise<void> {
     const workspace = await this.workspaceRepository.findOne({
       where: { id: workspaceId },
+      withDeleted: true,
     });
 
     const metadataVersion = workspace?.metadataVersion;

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/commands/clean-soft-deleted-suspended-workspaces.command.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/commands/clean-soft-deleted-suspended-workspaces.command.ts
@@ -1,0 +1,95 @@
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { Command, Option } from 'nest-commander';
+import { isDefined } from 'twenty-shared/utils';
+import { WorkspaceActivationStatus } from 'twenty-shared/workspace';
+import { In, IsNull, Not, Repository } from 'typeorm';
+
+import {
+  type MigrationCommandOptions,
+  MigrationCommandRunner,
+} from 'src/database/commands/command-runners/migration.command-runner';
+import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
+import { CleanerWorkspaceService } from 'src/engine/workspace-manager/workspace-cleaner/services/cleaner.workspace-service';
+
+type HardDeleteSoftDeletedSuspendedWorkspacesCommandOptions =
+  MigrationCommandOptions & {
+    force?: boolean;
+  };
+
+@Command({
+  name: 'workspace:hard-delete-soft-deleted',
+  description: 'Hard delete soft-deleted suspended workspaces',
+})
+export class HardDeleteSoftDeletedSuspendedWorkspacesCommand extends MigrationCommandRunner {
+  private workspaceIds: string[] = [];
+
+  constructor(
+    private readonly cleanerWorkspaceService: CleanerWorkspaceService,
+    @InjectRepository(WorkspaceEntity)
+    protected readonly workspaceRepository: Repository<WorkspaceEntity>,
+  ) {
+    super();
+  }
+
+  @Option({
+    flags: '-w, --workspace-id [workspace_id]',
+    description:
+      'workspace id. Command runs on all suspended workspaces if not provided',
+    required: false,
+  })
+  parseWorkspaceId(val: string): string[] {
+    this.workspaceIds.push(val);
+
+    return this.workspaceIds;
+  }
+
+  @Option({
+    flags: '--force',
+    description:
+      'Force hard deletion of soft-deleted workspaces, bypassing the grace period and deletion limit',
+    required: false,
+  })
+  parseForceHardDelete(): boolean {
+    return true;
+  }
+
+  async fetchSuspendedSoftDeletedWorkspaces({
+    workspaceIds,
+  }: {
+    workspaceIds?: string[];
+  }): Promise<WorkspaceEntity[]> {
+    return await this.workspaceRepository.find({
+      select: ['id'],
+      where: {
+        activationStatus: In([WorkspaceActivationStatus.SUSPENDED]),
+        deletedAt: Not(IsNull()),
+        ...(isDefined(workspaceIds) ? { id: In(workspaceIds) } : {}),
+      },
+      withDeleted: true,
+    });
+  }
+
+  override async runMigrationCommand(
+    _passedParams: string[],
+    options: HardDeleteSoftDeletedSuspendedWorkspacesCommandOptions,
+  ): Promise<void> {
+    const { dryRun, force } = options;
+
+    const suspendedWorkspaces = await this.fetchSuspendedSoftDeletedWorkspaces({
+      workspaceIds: this.workspaceIds,
+    });
+
+    this.logger.log(
+      `${dryRun ? 'DRY RUN - ' : ''}${force ? 'FORCE HARD DELETE - ' : ''}Destroying ${suspendedWorkspaces.length} suspended workspaces`,
+    );
+
+    for (const workspace of suspendedWorkspaces) {
+      await this.cleanerWorkspaceService.hardDeleteSoftDeletedWorkspace({
+        workspace,
+        dryRun,
+        force,
+      });
+    }
+  }
+}

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/commands/clean-soft-deleted-suspended-workspaces.command.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/commands/clean-soft-deleted-suspended-workspaces.command.ts
@@ -14,7 +14,7 @@ import { CleanerWorkspaceService } from 'src/engine/workspace-manager/workspace-
 
 type HardDeleteSoftDeletedSuspendedWorkspacesCommandOptions =
   MigrationCommandOptions & {
-    force?: boolean;
+    ignoreGracePeriod?: boolean;
   };
 
 @Command({
@@ -45,12 +45,12 @@ export class HardDeleteSoftDeletedSuspendedWorkspacesCommand extends MigrationCo
   }
 
   @Option({
-    flags: '--force',
+    flags: '--ignore-grace-period',
     description:
-      'Force hard deletion of soft-deleted workspaces, bypassing the grace period and deletion limit',
+      'Ignore the grace period and hard delete soft-deleted workspaces immediately',
     required: false,
   })
-  parseForceHardDelete(): boolean {
+  parseIgnoreGracePeriod(): boolean {
     return true;
   }
 
@@ -69,14 +69,14 @@ export class HardDeleteSoftDeletedSuspendedWorkspacesCommand extends MigrationCo
     _passedParams: string[],
     options: HardDeleteSoftDeletedSuspendedWorkspacesCommandOptions,
   ): Promise<void> {
-    const { dryRun, force } = options;
+    const { dryRun, ignoreGracePeriod } = options;
 
     const softDeletedSuspendedWorkspaces =
       await this.fetchSuspendedSoftDeletedWorkspaces();
     let deletedWorkspaceCounter = 0;
 
     this.logger.log(
-      `${dryRun ? 'DRY RUN - ' : ''}${force ? 'FORCE HARD DELETE - ' : ''}Iterating over ${softDeletedSuspendedWorkspaces.length} soft deleted suspended workspaces`,
+      `${dryRun ? 'DRY RUN - ' : ''}${ignoreGracePeriod ? 'IGNORING GRACE PERIOD - ' : ''}Iterating over ${softDeletedSuspendedWorkspaces.length} soft deleted suspended workspaces`,
     );
 
     for (const workspace of softDeletedSuspendedWorkspaces) {
@@ -84,7 +84,7 @@ export class HardDeleteSoftDeletedSuspendedWorkspacesCommand extends MigrationCo
         await this.cleanerWorkspaceService.hardDeleteSoftDeletedWorkspace({
           workspace,
           dryRun,
-          force,
+          ignoreGracePeriod,
         });
 
       if (isDefined(result)) {

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/commands/clean-soft-deleted-suspended-workspaces.command.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/commands/clean-soft-deleted-suspended-workspaces.command.ts
@@ -80,15 +80,22 @@ export class HardDeleteSoftDeletedSuspendedWorkspacesCommand extends MigrationCo
     );
 
     for (const workspace of softDeletedSuspendedWorkspaces) {
-      const result =
-        await this.cleanerWorkspaceService.hardDeleteSoftDeletedWorkspace({
-          workspace,
-          dryRun,
-          ignoreGracePeriod,
-        });
+      try {
+        const result =
+          await this.cleanerWorkspaceService.hardDeleteSoftDeletedWorkspace({
+            workspace,
+            dryRun,
+            ignoreGracePeriod,
+          });
 
-      if (isDefined(result)) {
-        deletedWorkspaceCounter++;
+        if (isDefined(result)) {
+          deletedWorkspaceCounter++;
+        }
+      } catch (error) {
+        this.logger.error(
+          `Failed to destroy soft deleted workspace ${workspace.id}`,
+          error,
+        );
       }
     }
 

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/commands/clean-suspended-workspaces.command.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/commands/clean-suspended-workspaces.command.ts
@@ -12,7 +12,7 @@ import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.ent
 import { CleanerWorkspaceService } from 'src/engine/workspace-manager/workspace-cleaner/services/cleaner.workspace-service';
 
 type CleanSuspendedWorkspacesCommandOptions = MigrationCommandOptions & {
-  force?: boolean;
+  forceHardDelete?: boolean;
 };
 
 @Command({
@@ -43,12 +43,12 @@ export class CleanSuspendedWorkspacesCommand extends MigrationCommandRunner {
   }
 
   @Option({
-    flags: '-f, --force',
+    flags: '--force-hard-delete',
     description:
-      'Force hard delete of soft-deleted workspaces without waiting for the minimum grace period',
+      'Force hard deletion of soft-deleted workspaces, bypassing the grace period and deletion limit',
     required: false,
   })
-  parseForce(): boolean {
+  parseForceHardDelete(): boolean {
     return true;
   }
 
@@ -68,7 +68,7 @@ export class CleanSuspendedWorkspacesCommand extends MigrationCommandRunner {
     _passedParams: string[],
     options: CleanSuspendedWorkspacesCommandOptions,
   ): Promise<void> {
-    const { dryRun, force } = options;
+    const { dryRun, forceHardDelete } = options;
 
     const suspendedWorkspaceIds =
       this.workspaceIds.length > 0
@@ -76,13 +76,13 @@ export class CleanSuspendedWorkspacesCommand extends MigrationCommandRunner {
         : await this.fetchSuspendedWorkspaceIds();
 
     this.logger.log(
-      `${dryRun ? 'DRY RUN - ' : ''}${force ? 'FORCE MODE - ' : ''}Cleaning ${suspendedWorkspaceIds.length} suspended workspaces`,
+      `${dryRun ? 'DRY RUN - ' : ''}${forceHardDelete ? 'FORCE HARD DELETE - ' : ''}Cleaning ${suspendedWorkspaceIds.length} suspended workspaces`,
     );
 
     await this.cleanerWorkspaceService.batchWarnOrCleanSuspendedWorkspaces({
       workspaceIds: suspendedWorkspaceIds,
       dryRun,
-      force,
+      forceHardDelete,
     });
   }
 }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/crons/clean-suspended-workspaces.job.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/crons/clean-suspended-workspaces.job.ts
@@ -33,8 +33,8 @@ export class CleanSuspendedWorkspacesJob {
       withDeleted: true,
     });
 
-    await this.cleanerWorkspaceService.batchWarnOrCleanSuspendedWorkspaces(
-      suspendedWorkspaceIds.map((workspace) => workspace.id),
-    );
+    await this.cleanerWorkspaceService.batchWarnOrCleanSuspendedWorkspaces({
+      workspaceIds: suspendedWorkspaceIds.map((workspace) => workspace.id),
+    });
   }
 }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/services/cleaner.workspace-service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/services/cleaner.workspace-service.ts
@@ -331,10 +331,10 @@ export class CleanerWorkspaceService {
 
   async hardDeleteSoftDeletedWorkspace({
     workspace,
-    force = false,
+    ignoreGracePeriod = false,
     dryRun = false,
   }: {
-    force?: boolean;
+    ignoreGracePeriod?: boolean;
     dryRun?: boolean;
     workspace: WorkspaceEntity;
   }): Promise<WorkspaceEntity | undefined> {
@@ -350,7 +350,7 @@ export class CleanerWorkspaceService {
       daysSinceSoftDeleted >
       this.inactiveDaysBeforeDelete - this.inactiveDaysBeforeSoftDelete;
 
-    const canHardDelete = force || hasPassedGracePeriod;
+    const canHardDelete = ignoreGracePeriod || hasPassedGracePeriod;
 
     if (!canHardDelete) {
       return;

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/services/cleaner.workspace-service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/services/cleaner.workspace-service.ts
@@ -332,14 +332,14 @@ export class CleanerWorkspaceService {
   async batchWarnOrCleanSuspendedWorkspaces({
     workspaceIds,
     dryRun = false,
-    force = false,
+    forceHardDelete = false,
   }: {
     workspaceIds: string[];
     dryRun?: boolean;
-    force?: boolean;
+    forceHardDelete?: boolean;
   }): Promise<void> {
     this.logger.log(
-      `${dryRun ? 'DRY RUN - ' : ''}${force ? 'FORCE MODE - ' : ''}batchWarnOrCleanSuspendedWorkspaces running...`,
+      `${dryRun ? 'DRY RUN - ' : ''}${forceHardDelete ? 'FORCE HARD DELETE - ' : ''}batchWarnOrCleanSuspendedWorkspaces running...`,
     );
 
     const workspaces = await this.workspaceRepository.find({
@@ -374,7 +374,7 @@ export class CleanerWorkspaceService {
             this.maxNumberOfWorkspacesDeletedPerExecution;
 
           const canHardDelete =
-            force || (hasPassedGracePeriod && isWithinDeletionLimit);
+            forceHardDelete || (hasPassedGracePeriod && isWithinDeletionLimit);
 
           if (canHardDelete) {
             this.logger.log(

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/services/cleaner.workspace-service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/services/cleaner.workspace-service.ts
@@ -408,7 +408,7 @@ export class CleanerWorkspaceService {
           const result = await this.hardDeleteSoftDeletedWorkspace({
             workspace,
             dryRun,
-            force: false,
+            ignoreGracePeriod: false,
           });
 
           if (isDefined(result)) {

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/services/cleaner.workspace-service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/services/cleaner.workspace-service.ts
@@ -328,6 +328,7 @@ export class CleanerWorkspaceService {
       );
     }
   }
+
   async hardDeleteSoftDeletedWorkspace({
     workspace,
     force = false,

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/workspace-cleaner.module.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-cleaner/workspace-cleaner.module.ts
@@ -13,6 +13,7 @@ import { WorkspaceModule } from 'src/engine/core-modules/workspace/workspace.mod
 import { DataSourceModule } from 'src/engine/metadata-modules/data-source/data-source.module';
 import { CleanOnboardingWorkspacesCommand } from 'src/engine/workspace-manager/workspace-cleaner/commands/clean-onboarding-workspaces.command';
 import { CleanOnboardingWorkspacesCronCommand } from 'src/engine/workspace-manager/workspace-cleaner/commands/clean-onboarding-workspaces.cron.command';
+import { HardDeleteSoftDeletedSuspendedWorkspacesCommand } from 'src/engine/workspace-manager/workspace-cleaner/commands/clean-soft-deleted-suspended-workspaces.command';
 import { CleanSuspendedWorkspacesCommand } from 'src/engine/workspace-manager/workspace-cleaner/commands/clean-suspended-workspaces.command';
 import { CleanSuspendedWorkspacesCronCommand } from 'src/engine/workspace-manager/workspace-cleaner/commands/clean-suspended-workspaces.cron.command';
 import { DeleteWorkspacesCommand } from 'src/engine/workspace-manager/workspace-cleaner/commands/delete-workspaces.command';
@@ -39,6 +40,7 @@ import { CleanerWorkspaceService } from 'src/engine/workspace-manager/workspace-
     DestroyWorkspaceCommand,
     CleanSuspendedWorkspacesCronCommand,
     CleanSuspendedWorkspacesCommand,
+    HardDeleteSoftDeletedSuspendedWorkspacesCommand,
     CleanOnboardingWorkspacesCommand,
     CleanOnboardingWorkspacesCronCommand,
     CleanerWorkspaceService,

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-manager.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-manager.service.ts
@@ -8,12 +8,9 @@ import { FlatApplication } from 'src/engine/core-modules/application/types/flat-
 import { UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { DataSourceService } from 'src/engine/metadata-modules/data-source/data-source.service';
-import { ObjectMetadataService } from 'src/engine/metadata-modules/object-metadata/object-metadata.service';
-import { RoleTargetEntity } from 'src/engine/metadata-modules/role-target/role-target.entity';
 import { ADMIN_ROLE } from 'src/engine/metadata-modules/role/constants/admin-role';
 import { RoleEntity } from 'src/engine/metadata-modules/role/role.entity';
 import { RoleService } from 'src/engine/metadata-modules/role/role.service';
-import { ServerlessFunctionEntity } from 'src/engine/metadata-modules/serverless-function/serverless-function.entity';
 import { UserRoleService } from 'src/engine/metadata-modules/user-role/user-role.service';
 import { WorkspaceDataSourceService } from 'src/engine/workspace-datasource/workspace-datasource.service';
 import { TwentyStandardApplicationService } from 'src/engine/workspace-manager/twenty-standard-application/services/twenty-standard-application.service';
@@ -24,7 +21,6 @@ export class WorkspaceManagerService {
 
   constructor(
     private readonly workspaceDataSourceService: WorkspaceDataSourceService,
-    private readonly objectMetadataService: ObjectMetadataService,
     private readonly dataSourceService: DataSourceService,
     @InjectRepository(UserWorkspaceEntity)
     private readonly userWorkspaceRepository: Repository<UserWorkspaceEntity>,
@@ -35,10 +31,6 @@ export class WorkspaceManagerService {
     private readonly workspaceRepository: Repository<WorkspaceEntity>,
     @InjectRepository(RoleEntity)
     private readonly roleRepository: Repository<RoleEntity>,
-    @InjectRepository(RoleTargetEntity)
-    private readonly roleTargetRepository: Repository<RoleTargetEntity>,
-    @InjectRepository(ServerlessFunctionEntity)
-    private readonly serverlessFunctionRepository: Repository<ServerlessFunctionEntity>,
     private readonly applicationService: ApplicationService,
   ) {}
 
@@ -97,29 +89,6 @@ export class WorkspaceManagerService {
       userId,
       workspaceCustomFlatApplication,
     });
-  }
-
-  /**
-   * @deprecated Should be removed once AddWorkspaceForeignKeysMigrationCommand has been run successfully in production
-   * As we will be able to rely on foreignKey delete cascading
-   */
-  public async delete(workspaceId: string): Promise<void> {
-    await this.roleTargetRepository.delete({
-      workspaceId,
-    });
-    await this.roleRepository.delete({
-      workspaceId,
-    });
-
-    await this.serverlessFunctionRepository.delete({
-      workspaceId,
-    });
-
-    await this.objectMetadataService.deleteWorkspaceAllObjectMetadata({
-      workspaceId,
-    });
-
-    await this.dataSourceService.delete(workspaceId);
   }
 
   private async setupDefaultRoles({

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service.ts
@@ -202,7 +202,7 @@ export class WorkspaceMigrationRunnerService {
         invalidationFailures.forEach((err) =>
           this.logger.error(
             `Failed to invalidate a legacy cache ${err.reason}`,
-            err.status,
+            'Runner',
           ),
         );
         throw new Error(

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/services/workspace-migration-runner.service.ts
@@ -199,6 +199,12 @@ export class WorkspaceMigrationRunnerService {
       );
 
       if (invalidationFailures.length > 0) {
+        invalidationFailures.forEach((err) =>
+          this.logger.error(
+            `Failed to invalidate a legacy cache ${err.reason}`,
+            err.status,
+          ),
+        );
         throw new Error(
           `Failed to invalidate ${invalidationFailures.length} cache operations`,
         );


### PR DESCRIPTION
# Introduction

In the https://github.com/twentyhq/core-team-issues/issues/1989 's context we will apply migration through an upgrade command post entity backfill to fit the applied constraint. But suspended soft deleted workspace are not included in the upgrade workspace batches 

In order to be able to pass the constraint in production, discussed with @FelixMalfait, we will manually clear all the currently suspended and soft deleted workspace ignore their grace period

## Force mode
When running the command in force it will ignore the limit per execution ( which really serve the cron job ) and the grace period

## Test
Tested on a production extract