### PR TITLE
fix: e2e login test - handle optional Continue with Email button

### DIFF
--- a/packages/twenty-e2e-testing/lib/pom/loginPage.ts
+++ b/packages/twenty-e2e-testing/lib/pom/loginPage.ts
@@ -85,6 +85,13 @@ export class LoginPage {
     await this.loginWithEmailButton.click();
   }
 
+  async clickLoginWithEmailIfVisible() {
+    const isVisible = await this.loginWithEmailButton.isVisible();
+    if (isVisible) {
+      await this.loginWithEmailButton.click();
+    }
+  }
+
   async clickContinueButton() {
     await this.continueButton.click();
   }

--- a/packages/twenty-e2e-testing/tests/login.setup.ts
+++ b/packages/twenty-e2e-testing/tests/login.setup.ts
@@ -18,19 +18,15 @@ test('Login test', async ({ loginPage, page }) => {
     'Logging in '.concat(page.url(), ' as ', process.env.DEFAULT_LOGIN),
     async () => {
       await page.waitForLoadState('networkidle');
-      if (
-        page.url().includes('app.twenty-next.com') ||
-        !page.url().includes('app.localhost:3001')
-      ) {
-        await loginPage.clickLoginWithEmail();
-      }
+      // Click "Continue with Email" if visible (may be skipped if password is the only auth method)
+      await loginPage.clickLoginWithEmailIfVisible();
       await loginPage.typeEmail(process.env.DEFAULT_LOGIN);
       await loginPage.clickContinueButton();
       await loginPage.typePassword(process.env.DEFAULT_PASSWORD);
       await page.waitForLoadState('networkidle');
       await loginPage.clickSignInButton();
       await page.waitForLoadState('networkidle');
-      await expect(page.getByText(/Welcome to .+/)).not.toBeVisible();
+      await expect(page.getByText(/Welcome, .+/)).not.toBeVisible();
       await expect(page.getByText('Choose a workspace')).toBeVisible();
       await page.getByText('Apple', {exact: true}).click();
       await page.waitForFunction(() => window.location.href.includes('verify'));


### PR DESCRIPTION
## Summary
The e2e login test was failing because it unconditionally tried to click 'Continue with Email' button, but this button doesn't exist when password is the only auth method.

## Root Cause
In `SignInUpWorkspaceScopeFormEffect.tsx`, when a workspace only has password authentication (no Google/Microsoft/SSO), the effect automatically calls `continueWithEmail()` which skips the Init step and shows the email field directly.

## Changes
1. **loginPage.ts**: Added `clickLoginWithEmailIfVisible()` method that only clicks the button if it exists
2. **login.setup.ts**: 
   - Replaced `clickLoginWithEmail()` with `clickLoginWithEmailIfVisible()` 
   - Updated regex from `/Welcome to .+/` to `/Welcome, .+/` to match the recent UI change