### PR TITLE
[Company record] fix unable to reuse the domain from a deleted record for the current company

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/index/compute-company-standard-flat-index-metadata.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/index/compute-company-standard-flat-index-metadata.util.ts
@@ -36,6 +36,7 @@ export const buildCompanyStandardFlatIndexMetadatas = ({
       indexName: 'domainNameUniqueIndex',
       relatedFieldNames: ['domainName'],
       isUnique: true,
+      indexWhereClause: '"deletedAt" IS NULL',
     },
     standardObjectMetadataRelatedEntityIds,
     dependencyFlatEntityMaps,


### PR DESCRIPTION
## Summary ##
This aims to fix issue #16978 
When soft-deleting a company in Twenty, the domainName unique constraint was still enforcing uniqueness against deleted records. This prevented users from creating a new company with the same domain name as a previously deleted company.

## Root Cause ##
The domainNameUniqueIndex on the Company entity was defined without a partial index condition, meaning it applied to ALL records regardless of their deletedAt status. Since Twenty uses soft delete (setting deletedAt timestamp rather than actually deleting), the unique constraint blocked legitimate operations.

## Changes ##
```compute-company-standard-flat-index-metadata.util.ts```:

Added ``` indexWhereClause: '"deletedAt" IS NULL' ``` to the domainNameUniqueIndex definition
This makes the unique constraint only apply to active (non-deleted) records.