### PR TITLE
[Apps] App misc - fixes + settings permissions for apps + uploadFile

### DIFF
--- a/packages/twenty-sdk/src/cli/services/generate.service.ts
+++ b/packages/twenty-sdk/src/cli/services/generate.service.ts
@@ -112,9 +112,9 @@ export default class Twenty {
     fileBuffer: Buffer,
     filename: string,
     contentType: string = 'application/octet-stream',
+    fileFolder: string = 'Attachment',
   ): Promise<{ path: string; token: string }> {
     const form = new FormData();
-    const fileFolder = "Attachment";
 
     form.append('operations', JSON.stringify({
       query: \`mutation UploadFile($file: Upload!, $fileFolder: FileFolder) {

--- a/packages/twenty-sdk/src/cli/services/generate.service.ts
+++ b/packages/twenty-sdk/src/cli/services/generate.service.ts
@@ -1,12 +1,12 @@
-import { generate } from '@genql/cli';
-import chalk from 'chalk';
-import { join, resolve } from 'path';
 import { ApiService } from '@/cli/services/api.service';
 import { ConfigService } from '@/cli/services/config.service';
+import { generate } from '@genql/cli';
+import chalk from 'chalk';
 import * as fs from 'fs-extra';
+import { join, resolve } from 'path';
 import {
-  DEFAULT_API_URL_NAME,
   DEFAULT_API_KEY_NAME,
+  DEFAULT_API_URL_NAME,
 } from 'twenty-shared/application';
 
 export const GENERATED_FOLDER_NAME = 'generated';
@@ -106,6 +106,41 @@ export default class Twenty {
 
   mutation<R extends MutationGenqlSelection>(request: R & { __name?: string }) {
     return this.client.mutation(request);
+  }
+
+  async uploadFile(
+    fileBuffer: Buffer,
+    filename: string,
+    contentType: string = 'application/octet-stream',
+  ): Promise<{ path: string; token: string }> {
+    const form = new FormData();
+    const fileFolder = "Attachment";
+
+    form.append('operations', JSON.stringify({
+      query: \`mutation UploadFile($file: Upload!, $fileFolder: FileFolder) {
+        uploadFile(file: $file, fileFolder: $fileFolder) { path token }
+      }\`,
+      variables: { file: null, fileFolder },
+    }));
+    form.append('map', JSON.stringify({ '0': ['variables.file'] }));
+    form.append('0', new Blob([fileBuffer], { type: contentType }), filename);
+
+
+    const response = await fetch(\`\${process.env.TWENTY_API_URL}/graphql\`, {
+      method: 'POST',
+      headers: {
+        Authorization: \`Bearer \${process.env.TWENTY_API_KEY}\`,
+      },
+      body: form,
+    });
+
+    const result = await response.json();
+
+    if (result.errors) {
+      throw new GenqlError(result.errors, result.data);
+    }
+
+    return result.data.uploadFile;
   }
 }
 

--- a/packages/twenty-server/src/engine/core-modules/application/application-sync.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-sync.service.ts
@@ -685,12 +685,6 @@ export class ApplicationSyncService {
         workspaceId,
         applicationId,
       });
-
-      await this.syncRelations({
-        objectsToSync: [objectToSync],
-        workspaceId,
-        applicationId,
-      });
     }
 
     const dataSourceMetadata =

--- a/packages/twenty-server/src/engine/core-modules/application/application.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application.service.ts
@@ -25,6 +25,27 @@ export class ApplicationService {
     private readonly workspaceRepository: Repository<WorkspaceEntity>,
   ) {}
 
+  async findApplicationRoleId(
+    applicationId: string,
+    workspaceId: string,
+  ): Promise<string> {
+    const application = await this.applicationRepository.findOne({
+      where: { id: applicationId, workspaceId },
+    });
+
+    if (
+      !isDefined(application) ||
+      !isDefined(application.defaultServerlessFunctionRoleId)
+    ) {
+      throw new ApplicationException(
+        `Could not find application ${applicationId}`,
+        ApplicationExceptionCode.APPLICATION_NOT_FOUND,
+      );
+    }
+
+    return application.defaultServerlessFunctionRoleId;
+  }
+
   async findWorkspaceTwentyStandardAndCustomApplicationOrThrow({
     workspace: workspaceInput,
     workspaceId,

--- a/packages/twenty-server/src/engine/guards/settings-permission.guard.ts
+++ b/packages/twenty-server/src/engine/guards/settings-permission.guard.ts
@@ -8,8 +8,8 @@ import {
 import { GqlExecutionContext } from '@nestjs/graphql';
 
 import { msg } from '@lingui/core/macro';
-import { WorkspaceActivationStatus } from 'twenty-shared/workspace';
 import { type PermissionFlagType } from 'twenty-shared/constants';
+import { WorkspaceActivationStatus } from 'twenty-shared/workspace';
 
 import {
   PermissionsException,
@@ -47,6 +47,7 @@ export const SettingsPermissionGuard = (
           setting: requiredPermission,
           workspaceId,
           apiKeyId: ctx.getContext().req.apiKey?.id,
+          applicationId: ctx.getContext().req.application?.id,
         });
 
       if (hasPermission === true) {

--- a/packages/twenty-server/src/engine/metadata-modules/permissions/__tests__/permissions.service.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/permissions/__tests__/permissions.service.spec.ts
@@ -4,6 +4,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { PermissionFlagType } from 'twenty-shared/constants';
 
 import { ApiKeyRoleService } from 'src/engine/core-modules/api-key/services/api-key-role.service';
+import { ApplicationService } from 'src/engine/core-modules/application/application.service';
 import { PermissionsService } from 'src/engine/metadata-modules/permissions/permissions.service';
 import { RoleEntity } from 'src/engine/metadata-modules/role/role.entity';
 import { UserRoleService } from 'src/engine/metadata-modules/user-role/user-role.service';
@@ -30,6 +31,10 @@ describe('PermissionsService', () => {
         },
         {
           provide: WorkspaceCacheService,
+          useValue: {},
+        },
+        {
+          provide: ApplicationService,
           useValue: {},
         },
       ],

--- a/packages/twenty-server/src/engine/metadata-modules/permissions/permissions.exception.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/permissions/permissions.exception.ts
@@ -47,6 +47,7 @@ export enum PermissionsExceptionCode {
   COMPOSITE_TYPE_NOT_FOUND = 'COMPOSITE_TYPE_NOT_FOUND',
   ROLE_MUST_HAVE_AT_LEAST_ONE_TARGET = 'ROLE_MUST_HAVE_AT_LEAST_ONE_TARGET',
   ROLE_CANNOT_BE_ASSIGNED_TO_USERS = 'ROLE_CANNOT_BE_ASSIGNED_TO_USERS',
+  APPLICATION_ROLE_NOT_FOUND = 'APPLICATION_ROLE_NOT_FOUND',
 }
 
 const getPermissionsExceptionUserFriendlyMessage = (
@@ -137,6 +138,8 @@ const getPermissionsExceptionUserFriendlyMessage = (
       return msg`Role must have at least one target.`;
     case PermissionsExceptionCode.ROLE_CANNOT_BE_ASSIGNED_TO_USERS:
       return msg`This role cannot be assigned to users.`;
+    case PermissionsExceptionCode.APPLICATION_ROLE_NOT_FOUND:
+      return msg`No role assigned to the application.`;
     default:
       assertUnreachable(code);
   }
@@ -184,4 +187,5 @@ export enum PermissionsExceptionMessage {
   EMPTY_FIELD_PERMISSION_NOT_ALLOWED = 'Empty field permission not allowed',
   ROLE_MUST_HAVE_AT_LEAST_ONE_TARGET = 'Role must be assignable to at least one target type',
   ROLE_CANNOT_BE_ASSIGNED_TO_USERS = 'Role cannot be assigned to users',
+  APPLICATION_ROLE_NOT_FOUND = 'Application role not found',
 }

--- a/packages/twenty-server/src/engine/metadata-modules/permissions/permissions.module.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/permissions/permissions.module.ts
@@ -3,9 +3,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { ApiKeyEntity } from 'src/engine/core-modules/api-key/api-key.entity';
 import { ApiKeyRoleService } from 'src/engine/core-modules/api-key/services/api-key-role.service';
+import { ApplicationEntity } from 'src/engine/core-modules/application/application.entity';
+import { ApplicationModule } from 'src/engine/core-modules/application/application.module';
 import { FeatureFlagModule } from 'src/engine/core-modules/feature-flag/feature-flag.module';
 import { UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
-import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { PermissionsService } from 'src/engine/metadata-modules/permissions/permissions.service';
 import { RoleTargetEntity } from 'src/engine/metadata-modules/role-target/role-target.entity';
 import { RoleTargetModule } from 'src/engine/metadata-modules/role-target/role-target.module';
@@ -19,13 +20,14 @@ import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache
       RoleEntity,
       RoleTargetEntity,
       ApiKeyEntity,
-      WorkspaceEntity,
+      ApplicationEntity,
     ]),
     FeatureFlagModule,
     TypeOrmModule.forFeature([UserWorkspaceEntity]),
     UserRoleModule,
     WorkspaceCacheModule,
     RoleTargetModule,
+    ApplicationModule,
   ],
   providers: [ApiKeyRoleService, PermissionsService],
   exports: [PermissionsService, ApiKeyRoleService],

--- a/packages/twenty-server/src/engine/metadata-modules/permissions/utils/permission-graphql-api-exception-handler.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/permissions/utils/permission-graphql-api-exception-handler.util.ts
@@ -69,6 +69,7 @@ export const permissionGraphqlApiExceptionHandler = (
     case PermissionsExceptionCode.JOIN_COLUMN_NAME_REQUIRED:
     case PermissionsExceptionCode.COMPOSITE_TYPE_NOT_FOUND:
     case PermissionsExceptionCode.USER_WORKSPACE_NOT_FOUND:
+    case PermissionsExceptionCode.APPLICATION_ROLE_NOT_FOUND:
       throw error;
     default: {
       return assertUnreachable(error.code);


### PR DESCRIPTION
In this PR

- handle settings permission check for applications. Until then this was unhandled and applications could not perform actions requiring settings permissions, even if they were granted them

- fix ties to attachment, noteTarget etc: 
When an object had their fields synchronized in the app, the system fields created as a side-effect of the object creation (relations to noteTarget, attachment, taskTarget, favorites, timelineActivities - created with `isCustom: true`, not sure that is correct btw) were then deleted because they are not declared in the app, and identified as deletable because of `isCustom: true`. 
Updating the logic to exclude system fields from the logic that detects fields to delete.
I think this outline the confusion we have around isCustom, isSystem etc.

- introduce uploadFile util in generated twenty client as it cannot be handled by the client's query / mutation. I had to use this for my invoicing app