### PR TITLE
Improve view field identification command perfs and reliability 

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-16/1-16-identify-view-field-metadata.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-16/1-16-identify-view-field-metadata.command.ts
@@ -233,6 +233,16 @@ export class IdentifyViewFieldMetadataCommand extends WorkspacesMigrationCommand
             continue;
           }
 
+          const viewFieldUniversalIdentifier =
+            viewConfig.viewFields[fieldName]?.universalIdentifier;
+
+          if (!isDefined(viewFieldUniversalIdentifier)) {
+            this.logger.warn(
+              `View field for field "${fieldName}" config not found for object "${flatObjectMetadata.nameSingular}", skipping view field`,
+            );
+            continue;
+          }
+
           // Find the field metadata by universal identifier
           const flatFieldMetadata = findFlatEntityByUniversalIdentifier({
             flatEntityMaps: flatFieldMetadataMaps,
@@ -260,7 +270,7 @@ export class IdentifyViewFieldMetadataCommand extends WorkspacesMigrationCommand
 
           standardViewFieldUpdates.push({
             flatViewField: matchingFlatViewField,
-            universalIdentifier: viewFieldConfig.universalIdentifier,
+            universalIdentifier: viewFieldUniversalIdentifier,
             objectNameSingular: flatObjectMetadata.nameSingular,
             viewName: flatView.name,
             fieldName,

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-16/1-16-identify-view-field-metadata.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-16/1-16-identify-view-field-metadata.command.ts
@@ -21,8 +21,8 @@ import { getMetadataFlatEntityMapsKey } from 'src/engine/metadata-modules/flat-e
 import { getMetadataRelatedMetadataNames } from 'src/engine/metadata-modules/flat-entity/utils/get-metadata-related-metadata-names.util';
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
-import { type FlatView } from 'src/engine/metadata-modules/flat-view/types/flat-view.type';
 import { type FlatViewField } from 'src/engine/metadata-modules/flat-view-field/types/flat-view-field.type';
+import { type FlatView } from 'src/engine/metadata-modules/flat-view/types/flat-view.type';
 import { ViewFieldEntity } from 'src/engine/metadata-modules/view-field/entities/view-field.entity';
 import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
@@ -344,6 +344,7 @@ export class IdentifyViewFieldMetadataCommand extends WorkspacesMigrationCommand
         workspaceId,
         applicationId: IsNull(),
       },
+      withDeleted: true,
     });
 
     const customUpdates = remainingCustomViewFields.map((viewFieldEntity) => ({

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-16/1-16-identify-view-field-metadata.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-16/1-16-identify-view-field-metadata.command.ts
@@ -249,7 +249,10 @@ export class IdentifyViewFieldMetadataCommand extends WorkspacesMigrationCommand
             (viewField) => viewField.fieldMetadataId === flatFieldMetadata.id,
           );
 
-          if (!isDefined(matchingFlatViewField)) {
+          if (
+            !isDefined(matchingFlatViewField) ||
+            isDefined(matchingFlatViewField.applicationId)
+          ) {
             continue;
           }
 

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-16/1-16-identify-view-field-metadata.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-16/1-16-identify-view-field-metadata.command.ts
@@ -127,10 +127,12 @@ export class IdentifyViewFieldMetadataCommand extends WorkspacesMigrationCommand
     this.logger.log(
       `Invalidating caches: ${relatedCacheKeysToInvalidate.join(' ')}`,
     );
-    await this.workspaceCacheService.invalidateAndRecompute(workspaceId, [
-      'flatViewFieldMaps',
-      ...relatedCacheKeysToInvalidate,
-    ]);
+    if (!options.dryRun) {
+      await this.workspaceCacheService.invalidateAndRecompute(workspaceId, [
+        'flatViewFieldMaps',
+        ...relatedCacheKeysToInvalidate,
+      ]);
+    }
   }
 
   private async identifyStandardViewFieldsOrThrow({

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-16/1-16-identify-view-field-metadata.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-16/1-16-identify-view-field-metadata.command.ts
@@ -260,9 +260,7 @@ export class IdentifyViewFieldMetadataCommand extends WorkspacesMigrationCommand
 
           standardViewFieldUpdates.push({
             flatViewField: matchingFlatViewField,
-            universalIdentifier:
-              matchingFlatViewField.universalIdentifier ??
-              viewFieldConfig.universalIdentifier,
+            universalIdentifier: viewFieldConfig.universalIdentifier,
             objectNameSingular: flatObjectMetadata.nameSingular,
             viewName: flatView.name,
             fieldName,

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-16/1-16-identify-view-field-metadata.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-16/1-16-identify-view-field-metadata.command.ts
@@ -2,14 +2,11 @@ import { InjectRepository } from '@nestjs/typeorm';
 
 import { Command } from 'nest-commander';
 import { isDefined } from 'twenty-shared/utils';
-import { WorkspaceActivationStatus } from 'twenty-shared/workspace';
 import { IsNull, Repository } from 'typeorm';
 import { v4 } from 'uuid';
 
-import {
-  RunOnWorkspaceArgs,
-  WorkspacesMigrationCommandRunner,
-} from 'src/database/commands/command-runners/workspaces-migration.command-runner';
+import { ActiveOrSuspendedWorkspacesMigrationCommandRunner } from 'src/database/commands/command-runners/active-or-suspended-workspaces-migration.command-runner';
+import { RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspaces-migration.command-runner';
 import { ApplicationService } from 'src/engine/core-modules/application/application.service';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { DataSourceService } from 'src/engine/metadata-modules/data-source/data-source.service';
@@ -50,7 +47,7 @@ type ViewFieldMetadataException = {
   name: 'upgrade:1-16:identify-view-field-metadata',
   description: 'Identify standard view field metadata',
 })
-export class IdentifyViewFieldMetadataCommand extends WorkspacesMigrationCommandRunner {
+export class IdentifyViewFieldMetadataCommand extends ActiveOrSuspendedWorkspacesMigrationCommandRunner {
   constructor(
     @InjectRepository(WorkspaceEntity)
     protected readonly workspaceRepository: Repository<WorkspaceEntity>,
@@ -62,11 +59,7 @@ export class IdentifyViewFieldMetadataCommand extends WorkspacesMigrationCommand
     protected readonly workspaceCacheService: WorkspaceCacheService,
     private readonly flatEntityMapsCacheService: WorkspaceManyOrAllFlatEntityMapsCacheService,
   ) {
-    super(workspaceRepository, twentyORMGlobalManager, dataSourceService, [
-      WorkspaceActivationStatus.ACTIVE,
-      WorkspaceActivationStatus.SUSPENDED,
-      WorkspaceActivationStatus.ONGOING_CREATION,
-    ]);
+    super(workspaceRepository, twentyORMGlobalManager, dataSourceService);
   }
 
   override async runOnWorkspace({

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-16/1-16-identify-view-metadata.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-16/1-16-identify-view-metadata.command.ts
@@ -190,8 +190,7 @@ export class IdentifyViewMetadataCommand extends WorkspacesMigrationCommandRunne
 
           standardViewUpdates.push({
             flatView,
-            universalIdentifier:
-              flatView.universalIdentifier ?? universalIdentifier,
+            universalIdentifier,
             objectNameSingular: flatObjectMetadata.nameSingular,
           });
           continue;
@@ -216,7 +215,7 @@ export class IdentifyViewMetadataCommand extends WorkspacesMigrationCommandRunne
 
         standardViewUpdates.push({
           flatView,
-          universalIdentifier: flatView.universalIdentifier,
+          universalIdentifier,
           objectNameSingular: flatObjectMetadata.nameSingular,
         });
       }

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-16/1-16-identify-view-metadata.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-16/1-16-identify-view-metadata.command.ts
@@ -216,8 +216,7 @@ export class IdentifyViewMetadataCommand extends WorkspacesMigrationCommandRunne
 
         standardViewUpdates.push({
           flatView,
-          universalIdentifier:
-            flatView.universalIdentifier ?? universalIdentifier,
+          universalIdentifier: flatView.universalIdentifier,
           objectNameSingular: flatObjectMetadata.nameSingular,
         });
       }

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-16/1-16-identify-view-metadata.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-16/1-16-identify-view-metadata.command.ts
@@ -109,10 +109,12 @@ export class IdentifyViewMetadataCommand extends WorkspacesMigrationCommandRunne
     this.logger.log(
       `Invalidating caches: ${relatedCacheKeysToInvalidate.join(' ')}`,
     );
-    await this.workspaceCacheService.invalidateAndRecompute(workspaceId, [
-      'flatViewMaps',
-      ...relatedCacheKeysToInvalidate,
-    ]);
+    if (!options.dryRun) {
+      await this.workspaceCacheService.invalidateAndRecompute(workspaceId, [
+        'flatViewMaps',
+        ...relatedCacheKeysToInvalidate,
+      ]);
+    }
   }
 
   private async identifyStandardViewsOrThrow({

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-16/1-16-identify-view-metadata.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-16/1-16-identify-view-metadata.command.ts
@@ -284,6 +284,7 @@ export class IdentifyViewMetadataCommand extends WorkspacesMigrationCommandRunne
         workspaceId,
         applicationId: IsNull(),
       },
+      withDeleted: true,
     });
 
     const customUpdates = remainingCustomViews.map((viewEntity) => ({

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-16/1-16-identify-view-metadata.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-16/1-16-identify-view-metadata.command.ts
@@ -6,9 +6,7 @@ import { IsNull, Repository } from 'typeorm';
 import { v4 } from 'uuid';
 
 import { ActiveOrSuspendedWorkspacesMigrationCommandRunner } from 'src/database/commands/command-runners/active-or-suspended-workspaces-migration.command-runner';
-import {
-  RunOnWorkspaceArgs
-} from 'src/database/commands/command-runners/workspaces-migration.command-runner';
+import { RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspaces-migration.command-runner';
 import { ALL_ENTITY_VIEW_NAME } from 'src/database/commands/upgrade-version-command/1-16/utils/compute-formatted-view-name.util';
 import { ApplicationService } from 'src/engine/core-modules/application/application.service';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-16/1-16-identify-view-metadata.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-16/1-16-identify-view-metadata.command.ts
@@ -163,6 +163,10 @@ export class IdentifyViewMetadataCommand extends WorkspacesMigrationCommandRunne
       });
 
       for (const flatView of relatedFlatViews) {
+        if (isDefined(flatView.applicationId)) {
+          continue;
+        }
+
         // INDEX views -> forward to standard (if object has views config)
         if (
           flatView.key === ViewKey.INDEX &&


### PR DESCRIPTION
# Introduction
Related to https://github.com/twentyhq/core-team-issues/issues/1989
Same continuity than what we've done in https://github.com/twentyhq/twenty/pull/17161 comparing expect to existing instead of existing versus expected

Plus various fixes
Tried both view and view field identification on prod extract, ( clean soft deleted workspace and applied the migration WIP )