### PR TITLE
Front Extensibility: Introduce Front Component Entity

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -73,7 +73,8 @@
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
       "env": {
-        "NODE_ENV": "test"
+        "NODE_ENV": "test",
+        "NODE_OPTIONS": "--max-old-space-size=12288 --import tsx/esm"
       }
     },
     {

--- a/packages/twenty-front/src/generated-metadata/graphql.ts
+++ b/packages/twenty-front/src/generated-metadata/graphql.ts
@@ -875,6 +875,11 @@ export type CreateFieldInput = {
   type: FieldMetadataType;
 };
 
+export type CreateFrontComponentInput = {
+  id?: InputMaybe<Scalars['UUID']>;
+  name: Scalars['String'];
+};
+
 export type CreateObjectInput = {
   description?: InputMaybe<Scalars['String']>;
   icon?: InputMaybe<Scalars['String']>;
@@ -984,6 +989,7 @@ export type CreateSkillInput = {
   content: Scalars['String'];
   description?: InputMaybe<Scalars['String']>;
   icon?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['UUID']>;
   label: Scalars['String'];
   name: Scalars['String'];
 };
@@ -1533,6 +1539,15 @@ export type FindAvailableSsoidpOutput = {
   workspace: WorkspaceNameAndId;
 };
 
+export type FrontComponent = {
+  __typename?: 'FrontComponent';
+  applicationId: Scalars['UUID'];
+  createdAt: Scalars['DateTime'];
+  id: Scalars['UUID'];
+  name: Scalars['String'];
+  updatedAt: Scalars['DateTime'];
+};
+
 export type FullName = {
   __typename?: 'FullName';
   firstName: Scalars['String'];
@@ -1873,6 +1888,7 @@ export type Mutation = {
   createDraftFromWorkflowVersion: WorkflowVersionDto;
   createEmailingDomain: EmailingDomain;
   createFile: File;
+  createFrontComponent: FrontComponent;
   createManyCoreViewFields: Array<CoreViewField>;
   createManyCoreViewGroups: Array<CoreViewGroup>;
   createOIDCIdentityProvider: SetupSsoOutput;
@@ -1911,6 +1927,7 @@ export type Mutation = {
   deleteDatabaseConfigVariable: Scalars['Boolean'];
   deleteEmailingDomain: Scalars['Boolean'];
   deleteFile: File;
+  deleteFrontComponent: FrontComponent;
   deleteJobs: DeleteJobsResponse;
   deleteOneAgent: Agent;
   deleteOneCronTrigger: CronTrigger;
@@ -1997,6 +2014,7 @@ export type Mutation = {
   updateCoreViewGroup: CoreViewGroup;
   updateCoreViewSort: CoreViewSort;
   updateDatabaseConfigVariable: Scalars['Boolean'];
+  updateFrontComponent: FrontComponent;
   updateLabPublicFeatureFlag: FeatureFlagDto;
   updateOneAgent: Agent;
   updateOneApplicationVariable: Scalars['Boolean'];
@@ -2156,6 +2174,11 @@ export type MutationCreateEmailingDomainArgs = {
 
 export type MutationCreateFileArgs = {
   file: Scalars['Upload'];
+};
+
+
+export type MutationCreateFrontComponentArgs = {
+  input: CreateFrontComponentInput;
 };
 
 
@@ -2345,6 +2368,11 @@ export type MutationDeleteEmailingDomainArgs = {
 
 export type MutationDeleteFileArgs = {
   fileId: Scalars['UUID'];
+};
+
+
+export type MutationDeleteFrontComponentArgs = {
+  id: Scalars['UUID'];
 };
 
 
@@ -2764,6 +2792,11 @@ export type MutationUpdateCoreViewSortArgs = {
 export type MutationUpdateDatabaseConfigVariableArgs = {
   key: Scalars['String'];
   value: Scalars['JSON'];
+};
+
+
+export type MutationUpdateFrontComponentArgs = {
+  input: UpdateFrontComponentInput;
 };
 
 
@@ -3375,6 +3408,8 @@ export type Query = {
   findOneServerlessFunction: ServerlessFunction;
   findWorkspaceFromInviteHash: Workspace;
   findWorkspaceInvitations: Array<WorkspaceInvitation>;
+  frontComponent?: Maybe<FrontComponent>;
+  frontComponents: Array<FrontComponent>;
   getAddressDetails: PlaceDetailsResult;
   getApprovedAccessDomains: Array<ApprovedAccessDomain>;
   getAutoCompleteAddress: Array<AutocompleteResult>;
@@ -3515,6 +3550,11 @@ export type QueryFindOneServerlessFunctionArgs = {
 
 export type QueryFindWorkspaceFromInviteHashArgs = {
   inviteHash: Scalars['String'];
+};
+
+
+export type QueryFrontComponentArgs = {
+  id: Scalars['UUID'];
 };
 
 
@@ -4487,6 +4527,17 @@ export type UpdateFieldInput = {
   name?: InputMaybe<Scalars['String']>;
   options?: InputMaybe<Scalars['JSON']>;
   settings?: InputMaybe<Scalars['JSON']>;
+};
+
+export type UpdateFrontComponentInput = {
+  /** The id of the front component to update */
+  id: Scalars['UUID'];
+  /** The front component fields to update */
+  update: UpdateFrontComponentInputUpdates;
+};
+
+export type UpdateFrontComponentInputUpdates = {
+  name?: InputMaybe<Scalars['String']>;
 };
 
 export type UpdateLabPublicFeatureFlagInput = {

--- a/packages/twenty-front/src/generated/graphql.ts
+++ b/packages/twenty-front/src/generated/graphql.ts
@@ -1516,6 +1516,15 @@ export type FindAvailableSsoidpOutput = {
   workspace: WorkspaceNameAndId;
 };
 
+export type FrontComponent = {
+  __typename?: 'FrontComponent';
+  applicationId: Scalars['UUID'];
+  createdAt: Scalars['DateTime'];
+  id: Scalars['UUID'];
+  name: Scalars['String'];
+  updatedAt: Scalars['DateTime'];
+};
+
 export type FullName = {
   __typename?: 'FullName';
   firstName: Scalars['String'];

--- a/packages/twenty-front/src/modules/metadata-error-handler/hooks/useMetadataErrorHandler.ts
+++ b/packages/twenty-front/src/modules/metadata-error-handler/hooks/useMetadataErrorHandler.ts
@@ -42,6 +42,7 @@ export const useMetadataErrorHandler = () => {
     rowLevelPermissionPredicate: t`row level permission predicate`,
     rowLevelPermissionPredicateGroup: t`row level permission predicate group`,
     viewFilterGroup: t`view filter group`,
+    frontComponent: t`front component`,
   } as const satisfies Record<AllMetadataName, string>;
 
   const handleMetadataError = (

--- a/packages/twenty-server/src/database/typeorm/core/migrations/common/1768495429374-addFrontComponent.ts
+++ b/packages/twenty-server/src/database/typeorm/core/migrations/common/1768495429374-addFrontComponent.ts
@@ -5,7 +5,7 @@ export class AddFrontComponent1768495429374 implements MigrationInterface {
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `CREATE TABLE "core"."frontComponent" ("workspaceId" uuid NOT NULL, "universalIdentifier" uuid NOT NULL, "applicationId" uuid NOT NULL, "id" uuid NOT NULL DEFAULT uuid_generate_v4(), "name" character varying NOT NULL, "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP WITH TIME ZONE, CONSTRAINT "PK_843479d93ef40e58dc4587339aa" PRIMARY KEY ("id"))`,
+      `CREATE TABLE "core"."frontComponent" ("workspaceId" uuid NOT NULL, "universalIdentifier" uuid NOT NULL, "applicationId" uuid NOT NULL, "id" uuid NOT NULL DEFAULT uuid_generate_v4(), "name" character varying NOT NULL, "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), CONSTRAINT "PK_843479d93ef40e58dc4587339aa" PRIMARY KEY ("id"))`,
     );
     await queryRunner.query(
       `CREATE UNIQUE INDEX "IDX_a1413f7f0e71cb5825ac40c4fa" ON "core"."frontComponent" ("workspaceId", "universalIdentifier") `,

--- a/packages/twenty-server/src/database/typeorm/core/migrations/common/1768495429374-addFrontComponent.ts
+++ b/packages/twenty-server/src/database/typeorm/core/migrations/common/1768495429374-addFrontComponent.ts
@@ -1,0 +1,33 @@
+import { type MigrationInterface, type QueryRunner } from 'typeorm';
+
+export class AddFrontComponent1768495429374 implements MigrationInterface {
+  name = 'AddFrontComponent1768495429374';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "core"."frontComponent" ("workspaceId" uuid NOT NULL, "universalIdentifier" uuid NOT NULL, "applicationId" uuid NOT NULL, "id" uuid NOT NULL DEFAULT uuid_generate_v4(), "name" character varying NOT NULL, "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP WITH TIME ZONE, CONSTRAINT "PK_843479d93ef40e58dc4587339aa" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_a1413f7f0e71cb5825ac40c4fa" ON "core"."frontComponent" ("workspaceId", "universalIdentifier") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."frontComponent" ADD CONSTRAINT "FK_b5e4eea33659f066e865ab6afe0" FOREIGN KEY ("workspaceId") REFERENCES "core"."workspace"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."frontComponent" ADD CONSTRAINT "FK_63e430d5f8e554c4282e7b48876" FOREIGN KEY ("applicationId") REFERENCES "core"."application"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "core"."frontComponent" DROP CONSTRAINT "FK_63e430d5f8e554c4282e7b48876"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."frontComponent" DROP CONSTRAINT "FK_b5e4eea33659f066e865ab6afe0"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "core"."IDX_a1413f7f0e71cb5825ac40c4fa"`,
+    );
+    await queryRunner.query(`DROP TABLE "core"."frontComponent"`);
+  }
+}

--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/all-flat-entity-properties-to-compare-and-stringify.constant.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/all-flat-entity-properties-to-compare-and-stringify.constant.ts
@@ -5,6 +5,7 @@ import { FLAT_DATABASE_EVENT_TRIGGER_EDITABLE_PROPERTIES } from 'src/engine/meta
 import { FLAT_AGENT_EDITABLE_PROPERTIES } from 'src/engine/metadata-modules/flat-agent/constants/flat-agent-editable-properties.constant';
 import { type MetadataFlatEntity } from 'src/engine/metadata-modules/flat-entity/types/metadata-flat-entity.type';
 import { FLAT_FIELD_METADATA_EDITABLE_PROPERTIES } from 'src/engine/metadata-modules/flat-field-metadata/constants/flat-field-metadata-editable-properties.constant';
+import { FLAT_FRONT_COMPONENT_EDITABLE_PROPERTIES } from 'src/engine/metadata-modules/flat-front-component/constants/flat-front-component-editable-properties.constant';
 import { FLAT_OBJECT_METADATA_EDITABLE_PROPERTIES } from 'src/engine/metadata-modules/flat-object-metadata/constants/flat-object-metadata-editable-properties.constant';
 import { FLAT_PAGE_LAYOUT_TAB_EDITABLE_PROPERTIES } from 'src/engine/metadata-modules/flat-page-layout-tab/constants/flat-page-layout-tab-editable-properties.constant';
 import { FLAT_PAGE_LAYOUT_WIDGET_EDITABLE_PROPERTIES } from 'src/engine/metadata-modules/flat-page-layout-widget/constants/flat-page-layout-widget-editable-properties.constant';
@@ -13,7 +14,6 @@ import { FLAT_ROLE_TARGET_EDITABLE_PROPERTIES } from 'src/engine/metadata-module
 import { FLAT_ROLE_EDITABLE_PROPERTIES } from 'src/engine/metadata-modules/flat-role/constants/flat-role-editable-properties.constant';
 import { FLAT_ROW_LEVEL_PERMISSION_PREDICATE_GROUP_EDITABLE_PROPERTIES } from 'src/engine/metadata-modules/flat-row-level-permission-predicate-group/constants/flat-row-level-permission-predicate-group-editable-properties.constant';
 import { FLAT_ROW_LEVEL_PERMISSION_PREDICATE_EDITABLE_PROPERTIES } from 'src/engine/metadata-modules/flat-row-level-permission-predicate/constants/flat-row-level-permission-predicate-editable-properties.constant';
-import { FLAT_FRONT_COMPONENT_EDITABLE_PROPERTIES } from 'src/engine/metadata-modules/flat-front-component/constants/flat-front-component-editable-properties.constant';
 import { FLAT_SKILL_EDITABLE_PROPERTIES } from 'src/engine/metadata-modules/flat-skill/constants/flat-skill-editable-properties.constant';
 import { FLAT_VIEW_FIELD_EDITABLE_PROPERTIES } from 'src/engine/metadata-modules/flat-view-field/constants/flat-view-field-editable-properties.constant';
 import { FLAT_VIEW_FILTER_GROUP_EDITABLE_PROPERTIES } from 'src/engine/metadata-modules/flat-view-filter-group/constants/flat-view-filter-group-editable-properties.constant';
@@ -164,10 +164,7 @@ export const ALL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY = {
     propertiesToStringify: [],
   },
   frontComponent: {
-    propertiesToCompare: [
-      ...FLAT_FRONT_COMPONENT_EDITABLE_PROPERTIES,
-      'deletedAt',
-    ],
+    propertiesToCompare: [...FLAT_FRONT_COMPONENT_EDITABLE_PROPERTIES],
     propertiesToStringify: [],
   },
 } as const satisfies {

--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/all-flat-entity-properties-to-compare-and-stringify.constant.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/all-flat-entity-properties-to-compare-and-stringify.constant.ts
@@ -13,6 +13,7 @@ import { FLAT_ROLE_TARGET_EDITABLE_PROPERTIES } from 'src/engine/metadata-module
 import { FLAT_ROLE_EDITABLE_PROPERTIES } from 'src/engine/metadata-modules/flat-role/constants/flat-role-editable-properties.constant';
 import { FLAT_ROW_LEVEL_PERMISSION_PREDICATE_GROUP_EDITABLE_PROPERTIES } from 'src/engine/metadata-modules/flat-row-level-permission-predicate-group/constants/flat-row-level-permission-predicate-group-editable-properties.constant';
 import { FLAT_ROW_LEVEL_PERMISSION_PREDICATE_EDITABLE_PROPERTIES } from 'src/engine/metadata-modules/flat-row-level-permission-predicate/constants/flat-row-level-permission-predicate-editable-properties.constant';
+import { FLAT_FRONT_COMPONENT_EDITABLE_PROPERTIES } from 'src/engine/metadata-modules/flat-front-component/constants/flat-front-component-editable-properties.constant';
 import { FLAT_SKILL_EDITABLE_PROPERTIES } from 'src/engine/metadata-modules/flat-skill/constants/flat-skill-editable-properties.constant';
 import { FLAT_VIEW_FIELD_EDITABLE_PROPERTIES } from 'src/engine/metadata-modules/flat-view-field/constants/flat-view-field-editable-properties.constant';
 import { FLAT_VIEW_FILTER_GROUP_EDITABLE_PROPERTIES } from 'src/engine/metadata-modules/flat-view-filter-group/constants/flat-view-filter-group-editable-properties.constant';
@@ -159,6 +160,13 @@ export const ALL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY = {
       'viewId',
       'deletedAt',
       ...FLAT_VIEW_FILTER_GROUP_EDITABLE_PROPERTIES,
+    ],
+    propertiesToStringify: [],
+  },
+  frontComponent: {
+    propertiesToCompare: [
+      ...FLAT_FRONT_COMPONENT_EDITABLE_PROPERTIES,
+      'deletedAt',
     ],
     propertiesToStringify: [],
   },

--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/all-metadata-relations.constant.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/all-metadata-relations.constant.ts
@@ -430,6 +430,13 @@ export const ALL_METADATA_RELATIONS = {
       },
     },
   },
+  frontComponent: {
+    manyToOne: {
+      workspace: null,
+      application: null,
+    },
+    oneToMany: {},
+  },
 } as const satisfies MetadataRelationsProperties;
 
 // Note: satisfies with complex mapped types involving nested generics doesn't always catch missing required keys

--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/all-metadata-required-metadata-for-validation.constant.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/all-metadata-required-metadata-for-validation.constant.ts
@@ -82,4 +82,5 @@ export const ALL_METADATA_REQUIRED_METADATA_FOR_VALIDATION = {
     role: true,
     objectMetadata: true,
   },
+  frontComponent: {},
 } as const satisfies MetadataRequiredForValidation;

--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/types/all-flat-entity-types-by-metadata-name.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/types/all-flat-entity-types-by-metadata-name.ts
@@ -1,4 +1,6 @@
 import { type AgentEntity } from 'src/engine/metadata-modules/ai/ai-agent/entities/agent.entity';
+import { type FlatFrontComponent } from 'src/engine/metadata-modules/flat-front-component/types/flat-front-component.type';
+import { type FrontComponentEntity } from 'src/engine/metadata-modules/front-component/entities/front-component.entity';
 import { type CronTriggerEntity } from 'src/engine/metadata-modules/cron-trigger/entities/cron-trigger.entity';
 import { type FlatCronTrigger } from 'src/engine/metadata-modules/cron-trigger/types/flat-cron-trigger.type';
 import { type DatabaseEventTriggerEntity } from 'src/engine/metadata-modules/database-event-trigger/entities/database-event-trigger.entity';
@@ -145,6 +147,11 @@ import {
   type DeleteViewAction,
   type UpdateViewAction,
 } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/view/types/workspace-migration-view-action.type';
+import {
+  type CreateFrontComponentAction,
+  type DeleteFrontComponentAction,
+  type UpdateFrontComponentAction,
+} from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/front-component/types/workspace-migration-front-component-action.type';
 
 export type AllFlatEntityTypesByMetadataName = {
   fieldMetadata: {
@@ -335,5 +342,14 @@ export type AllFlatEntityTypesByMetadataName = {
     };
     flatEntity: FlatPageLayoutTab;
     entity: PageLayoutTabEntity;
+  };
+  frontComponent: {
+    actions: {
+      create: CreateFrontComponentAction;
+      update: UpdateFrontComponentAction;
+      delete: DeleteFrontComponentAction;
+    };
+    flatEntity: FlatFrontComponent;
+    entity: FrontComponentEntity;
   };
 };

--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/utils/__tests__/__snapshots__/get-metadata-related-metadata-names.util.spec.ts.snap
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/utils/__tests__/__snapshots__/get-metadata-related-metadata-names.util.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`getMetadataRelatedMetadataNames should return related metadata names for agent 1`] = `[]`;
 
@@ -23,6 +23,8 @@ exports[`getMetadataRelatedMetadataNames should return related metadata names fo
   "view",
 ]
 `;
+
+exports[`getMetadataRelatedMetadataNames should return related metadata names for frontComponent 1`] = `[]`;
 
 exports[`getMetadataRelatedMetadataNames should return related metadata names for index 1`] = `
 [

--- a/packages/twenty-server/src/engine/metadata-modules/flat-front-component/constants/flat-front-component-editable-properties.constant.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-front-component/constants/flat-front-component-editable-properties.constant.ts
@@ -1,0 +1,5 @@
+import { type FlatFrontComponent } from 'src/engine/metadata-modules/flat-front-component/types/flat-front-component.type';
+
+export const FLAT_FRONT_COMPONENT_EDITABLE_PROPERTIES = [
+  'name',
+] as const satisfies (keyof FlatFrontComponent)[];

--- a/packages/twenty-server/src/engine/metadata-modules/flat-front-component/flat-front-component.module.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-front-component/flat-front-component.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { WorkspaceManyOrAllFlatEntityMapsCacheModule } from 'src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.module';
+import { WorkspaceFlatFrontComponentMapCacheService } from 'src/engine/metadata-modules/flat-front-component/services/workspace-flat-front-component-map-cache.service';
+import { FrontComponentEntity } from 'src/engine/metadata-modules/front-component/entities/front-component.entity';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([FrontComponentEntity]),
+    WorkspaceManyOrAllFlatEntityMapsCacheModule,
+  ],
+  providers: [WorkspaceFlatFrontComponentMapCacheService],
+  exports: [WorkspaceFlatFrontComponentMapCacheService],
+})
+export class FlatFrontComponentModule {}

--- a/packages/twenty-server/src/engine/metadata-modules/flat-front-component/services/workspace-flat-front-component-map-cache.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-front-component/services/workspace-flat-front-component-map-cache.service.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { Repository } from 'typeorm';
+
+import { WorkspaceCacheProvider } from 'src/engine/workspace-cache/interfaces/workspace-cache-provider.service';
+
+import { createEmptyFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/constant/create-empty-flat-entity-maps.constant';
+import { type FlatFrontComponentMaps } from 'src/engine/metadata-modules/flat-front-component/types/flat-front-component-maps.type';
+import { fromFrontComponentEntityToFlatFrontComponent } from 'src/engine/metadata-modules/flat-front-component/utils/from-front-component-entity-to-flat-front-component.util';
+import { FrontComponentEntity } from 'src/engine/metadata-modules/front-component/entities/front-component.entity';
+import { WorkspaceCache } from 'src/engine/workspace-cache/decorators/workspace-cache.decorator';
+import { addFlatEntityToFlatEntityMapsThroughMutationOrThrow } from 'src/engine/workspace-manager/workspace-migration/utils/add-flat-entity-to-flat-entity-maps-through-mutation-or-throw.util';
+
+@Injectable()
+@WorkspaceCache('flatFrontComponentMaps')
+export class WorkspaceFlatFrontComponentMapCacheService extends WorkspaceCacheProvider<FlatFrontComponentMaps> {
+  constructor(
+    @InjectRepository(FrontComponentEntity)
+    private readonly frontComponentRepository: Repository<FrontComponentEntity>,
+  ) {
+    super();
+  }
+
+  async computeForCache(workspaceId: string): Promise<FlatFrontComponentMaps> {
+    const frontComponents = await this.frontComponentRepository.find({
+      where: { workspaceId },
+      withDeleted: true,
+    });
+
+    const flatFrontComponentMaps = createEmptyFlatEntityMaps();
+
+    for (const frontComponentEntity of frontComponents) {
+      const flatFrontComponent =
+        fromFrontComponentEntityToFlatFrontComponent(frontComponentEntity);
+
+      addFlatEntityToFlatEntityMapsThroughMutationOrThrow({
+        flatEntity: flatFrontComponent,
+        flatEntityMapsToMutate: flatFrontComponentMaps,
+      });
+    }
+
+    return flatFrontComponentMaps;
+  }
+}

--- a/packages/twenty-server/src/engine/metadata-modules/flat-front-component/services/workspace-flat-front-component-map-cache.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-front-component/services/workspace-flat-front-component-map-cache.service.ts
@@ -25,7 +25,6 @@ export class WorkspaceFlatFrontComponentMapCacheService extends WorkspaceCachePr
   async computeForCache(workspaceId: string): Promise<FlatFrontComponentMaps> {
     const frontComponents = await this.frontComponentRepository.find({
       where: { workspaceId },
-      withDeleted: true,
     });
 
     const flatFrontComponentMaps = createEmptyFlatEntityMaps();

--- a/packages/twenty-server/src/engine/metadata-modules/flat-front-component/types/flat-front-component-maps.type.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-front-component/types/flat-front-component-maps.type.ts
@@ -1,0 +1,4 @@
+import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
+import { type FlatFrontComponent } from 'src/engine/metadata-modules/flat-front-component/types/flat-front-component.type';
+
+export type FlatFrontComponentMaps = FlatEntityMaps<FlatFrontComponent>;

--- a/packages/twenty-server/src/engine/metadata-modules/flat-front-component/types/flat-front-component.type.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-front-component/types/flat-front-component.type.ts
@@ -1,0 +1,4 @@
+import { type FlatEntityFrom } from 'src/engine/metadata-modules/flat-entity/types/flat-entity.type';
+import { type FrontComponentEntity } from 'src/engine/metadata-modules/front-component/entities/front-component.entity';
+
+export type FlatFrontComponent = FlatEntityFrom<FrontComponentEntity>;

--- a/packages/twenty-server/src/engine/metadata-modules/flat-front-component/utils/from-create-front-component-input-to-flat-front-component-to-create.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-front-component/utils/from-create-front-component-input-to-flat-front-component-to-create.util.ts
@@ -1,0 +1,36 @@
+import { trimAndRemoveDuplicatedWhitespacesFromObjectStringProperties } from 'twenty-shared/utils';
+import { v4 } from 'uuid';
+
+import { type FlatFrontComponent } from 'src/engine/metadata-modules/flat-front-component/types/flat-front-component.type';
+import { type CreateFrontComponentInput } from 'src/engine/metadata-modules/front-component/dtos/create-front-component.input';
+
+export const fromCreateFrontComponentInputToFlatFrontComponentToCreate = ({
+  createFrontComponentInput,
+  workspaceId,
+  applicationId,
+}: {
+  createFrontComponentInput: CreateFrontComponentInput;
+  workspaceId: string;
+  applicationId: string;
+}): FlatFrontComponent => {
+  const now = new Date().toISOString();
+
+  const { name } =
+    trimAndRemoveDuplicatedWhitespacesFromObjectStringProperties(
+      createFrontComponentInput,
+      ['name'],
+    );
+
+  const id = v4();
+
+  return {
+    id,
+    name,
+    workspaceId,
+    createdAt: now,
+    updatedAt: now,
+    deletedAt: null,
+    universalIdentifier: id,
+    applicationId,
+  };
+};

--- a/packages/twenty-server/src/engine/metadata-modules/flat-front-component/utils/from-create-front-component-input-to-flat-front-component-to-create.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-front-component/utils/from-create-front-component-input-to-flat-front-component-to-create.util.ts
@@ -15,11 +15,10 @@ export const fromCreateFrontComponentInputToFlatFrontComponentToCreate = ({
 }): FlatFrontComponent => {
   const now = new Date().toISOString();
 
-  const { name } =
-    trimAndRemoveDuplicatedWhitespacesFromObjectStringProperties(
-      createFrontComponentInput,
-      ['name'],
-    );
+  const { name } = trimAndRemoveDuplicatedWhitespacesFromObjectStringProperties(
+    createFrontComponentInput,
+    ['name'],
+  );
 
   const id = v4();
 

--- a/packages/twenty-server/src/engine/metadata-modules/flat-front-component/utils/from-create-front-component-input-to-flat-front-component-to-create.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-front-component/utils/from-create-front-component-input-to-flat-front-component-to-create.util.ts
@@ -28,7 +28,6 @@ export const fromCreateFrontComponentInputToFlatFrontComponentToCreate = ({
     workspaceId,
     createdAt: now,
     updatedAt: now,
-    deletedAt: null,
     universalIdentifier: id,
     applicationId,
   };

--- a/packages/twenty-server/src/engine/metadata-modules/flat-front-component/utils/from-create-front-component-input-to-flat-front-component-to-create.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-front-component/utils/from-create-front-component-input-to-flat-front-component-to-create.util.ts
@@ -20,7 +20,7 @@ export const fromCreateFrontComponentInputToFlatFrontComponentToCreate = ({
     ['name'],
   );
 
-  const id = v4();
+  const id = createFrontComponentInput.id ?? v4();
 
   return {
     id,

--- a/packages/twenty-server/src/engine/metadata-modules/flat-front-component/utils/from-delete-front-component-input-to-flat-front-component-or-throw.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-front-component/utils/from-delete-front-component-input-to-flat-front-component-or-throw.util.ts
@@ -1,0 +1,31 @@
+import { isDefined } from 'twenty-shared/utils';
+
+import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
+import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps.util';
+import { type FlatFrontComponent } from 'src/engine/metadata-modules/flat-front-component/types/flat-front-component.type';
+import {
+  FrontComponentException,
+  FrontComponentExceptionCode,
+} from 'src/engine/metadata-modules/front-component/front-component.exception';
+
+export const fromDeleteFrontComponentInputToFlatFrontComponentOrThrow = ({
+  flatFrontComponentMaps,
+  frontComponentId,
+}: {
+  flatFrontComponentMaps: FlatEntityMaps<FlatFrontComponent>;
+  frontComponentId: string;
+}): FlatFrontComponent => {
+  const existingFlatFrontComponent = findFlatEntityByIdInFlatEntityMaps({
+    flatEntityId: frontComponentId,
+    flatEntityMaps: flatFrontComponentMaps,
+  });
+
+  if (!isDefined(existingFlatFrontComponent)) {
+    throw new FrontComponentException(
+      'Front component not found',
+      FrontComponentExceptionCode.FRONT_COMPONENT_NOT_FOUND,
+    );
+  }
+
+  return existingFlatFrontComponent;
+};

--- a/packages/twenty-server/src/engine/metadata-modules/flat-front-component/utils/from-flat-front-component-to-front-component-dto.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-front-component/utils/from-flat-front-component-to-front-component-dto.util.ts
@@ -1,0 +1,13 @@
+import { type FlatFrontComponent } from 'src/engine/metadata-modules/flat-front-component/types/flat-front-component.type';
+import { type FrontComponentDTO } from 'src/engine/metadata-modules/front-component/dtos/front-component.dto';
+
+export const fromFlatFrontComponentToFrontComponentDto = (
+  flatFrontComponent: FlatFrontComponent,
+): FrontComponentDTO => ({
+  id: flatFrontComponent.id,
+  name: flatFrontComponent.name,
+  workspaceId: flatFrontComponent.workspaceId,
+  applicationId: flatFrontComponent.applicationId,
+  createdAt: new Date(flatFrontComponent.createdAt),
+  updatedAt: new Date(flatFrontComponent.updatedAt),
+});

--- a/packages/twenty-server/src/engine/metadata-modules/flat-front-component/utils/from-front-component-entity-to-flat-front-component.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-front-component/utils/from-front-component-entity-to-flat-front-component.util.ts
@@ -12,6 +12,5 @@ export const fromFrontComponentEntityToFlatFrontComponent = (
     applicationId: frontComponentEntity.applicationId,
     createdAt: frontComponentEntity.createdAt.toISOString(),
     updatedAt: frontComponentEntity.updatedAt.toISOString(),
-    deletedAt: frontComponentEntity.deletedAt?.toISOString() ?? null,
   };
 };

--- a/packages/twenty-server/src/engine/metadata-modules/flat-front-component/utils/from-front-component-entity-to-flat-front-component.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-front-component/utils/from-front-component-entity-to-flat-front-component.util.ts
@@ -1,0 +1,17 @@
+import { type FlatFrontComponent } from 'src/engine/metadata-modules/flat-front-component/types/flat-front-component.type';
+import { type FrontComponentEntity } from 'src/engine/metadata-modules/front-component/entities/front-component.entity';
+
+export const fromFrontComponentEntityToFlatFrontComponent = (
+  frontComponentEntity: FrontComponentEntity,
+): FlatFrontComponent => {
+  return {
+    id: frontComponentEntity.id,
+    name: frontComponentEntity.name,
+    workspaceId: frontComponentEntity.workspaceId,
+    universalIdentifier: frontComponentEntity.universalIdentifier,
+    applicationId: frontComponentEntity.applicationId,
+    createdAt: frontComponentEntity.createdAt.toISOString(),
+    updatedAt: frontComponentEntity.updatedAt.toISOString(),
+    deletedAt: frontComponentEntity.deletedAt?.toISOString() ?? null,
+  };
+};

--- a/packages/twenty-server/src/engine/metadata-modules/flat-front-component/utils/from-update-front-component-input-to-flat-front-component-to-update-or-throw.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-front-component/utils/from-update-front-component-input-to-flat-front-component-to-update-or-throw.util.ts
@@ -1,0 +1,44 @@
+import { isDefined } from 'twenty-shared/utils';
+
+import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
+import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps.util';
+import { FLAT_FRONT_COMPONENT_EDITABLE_PROPERTIES } from 'src/engine/metadata-modules/flat-front-component/constants/flat-front-component-editable-properties.constant';
+import { type FlatFrontComponent } from 'src/engine/metadata-modules/flat-front-component/types/flat-front-component.type';
+import { type UpdateFrontComponentInput } from 'src/engine/metadata-modules/front-component/dtos/update-front-component.input';
+import {
+  FrontComponentException,
+  FrontComponentExceptionCode,
+} from 'src/engine/metadata-modules/front-component/front-component.exception';
+import { mergeUpdateInExistingRecord } from 'src/utils/merge-update-in-existing-record.util';
+
+export const fromUpdateFrontComponentInputToFlatFrontComponentToUpdateOrThrow =
+  ({
+    flatFrontComponentMaps,
+    updateFrontComponentInput,
+  }: {
+    flatFrontComponentMaps: FlatEntityMaps<FlatFrontComponent>;
+    updateFrontComponentInput: UpdateFrontComponentInput;
+  }): FlatFrontComponent => {
+    const existingFlatFrontComponent = findFlatEntityByIdInFlatEntityMaps({
+      flatEntityId: updateFrontComponentInput.id,
+      flatEntityMaps: flatFrontComponentMaps,
+    });
+
+    if (!isDefined(existingFlatFrontComponent)) {
+      throw new FrontComponentException(
+        'Front component not found',
+        FrontComponentExceptionCode.FRONT_COMPONENT_NOT_FOUND,
+      );
+    }
+
+    const { id: _id, ...updates } = updateFrontComponentInput;
+
+    return {
+      ...mergeUpdateInExistingRecord({
+        existing: existingFlatFrontComponent,
+        properties: [...FLAT_FRONT_COMPONENT_EDITABLE_PROPERTIES],
+        update: updates,
+      }),
+      updatedAt: new Date().toISOString(),
+    };
+  };

--- a/packages/twenty-server/src/engine/metadata-modules/flat-front-component/utils/from-update-front-component-input-to-flat-front-component-to-update-or-throw.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-front-component/utils/from-update-front-component-input-to-flat-front-component-to-update-or-throw.util.ts
@@ -31,13 +31,11 @@ export const fromUpdateFrontComponentInputToFlatFrontComponentToUpdateOrThrow =
       );
     }
 
-    const { id: _id, ...updates } = updateFrontComponentInput;
-
     return {
       ...mergeUpdateInExistingRecord({
         existing: existingFlatFrontComponent,
         properties: [...FLAT_FRONT_COMPONENT_EDITABLE_PROPERTIES],
-        update: updates,
+        update: updateFrontComponentInput.update,
       }),
       updatedAt: new Date().toISOString(),
     };

--- a/packages/twenty-server/src/engine/metadata-modules/flat-skill/utils/from-create-skill-input-to-flat-skill-to-create.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-skill/utils/from-create-skill-input-to-flat-skill-to-create.util.ts
@@ -24,7 +24,7 @@ export const fromCreateSkillInputToFlatSkillToCreate = ({
   // Content is markdown - only trim, don't collapse whitespace (preserve newlines)
   const content = createSkillInput.content.trim();
 
-  const id = v4();
+  const id = createSkillInput.id ?? v4();
 
   return {
     id,

--- a/packages/twenty-server/src/engine/metadata-modules/front-component/dtos/create-front-component.input.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/front-component/dtos/create-front-component.input.ts
@@ -1,9 +1,16 @@
 import { Field, InputType } from '@nestjs/graphql';
 
-import { IsNotEmpty, IsString } from 'class-validator';
+import { IsNotEmpty, IsOptional, IsString, IsUUID } from 'class-validator';
+
+import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 
 @InputType()
 export class CreateFrontComponentInput {
+  @IsUUID()
+  @IsOptional()
+  @Field(() => UUIDScalarType, { nullable: true })
+  id?: string;
+
   @IsString()
   @IsNotEmpty()
   @Field()

--- a/packages/twenty-server/src/engine/metadata-modules/front-component/dtos/create-front-component.input.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/front-component/dtos/create-front-component.input.ts
@@ -1,0 +1,11 @@
+import { Field, InputType } from '@nestjs/graphql';
+
+import { IsNotEmpty, IsString } from 'class-validator';
+
+@InputType()
+export class CreateFrontComponentInput {
+  @IsString()
+  @IsNotEmpty()
+  @Field()
+  name: string;
+}

--- a/packages/twenty-server/src/engine/metadata-modules/front-component/dtos/front-component.dto.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/front-component/dtos/front-component.dto.ts
@@ -1,0 +1,31 @@
+import { Field, HideField, ObjectType } from '@nestjs/graphql';
+
+import { IsDateString, IsNotEmpty, IsString, IsUUID } from 'class-validator';
+
+import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
+
+@ObjectType('FrontComponent')
+export class FrontComponentDTO {
+  @IsUUID()
+  @IsNotEmpty()
+  @Field(() => UUIDScalarType)
+  id: string;
+
+  @IsString()
+  @Field()
+  name: string;
+
+  @HideField()
+  workspaceId: string;
+
+  @Field(() => UUIDScalarType)
+  applicationId: string;
+
+  @IsDateString()
+  @Field()
+  createdAt: Date;
+
+  @IsDateString()
+  @Field()
+  updatedAt: Date;
+}

--- a/packages/twenty-server/src/engine/metadata-modules/front-component/dtos/update-front-component.input.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/front-component/dtos/update-front-component.input.ts
@@ -1,18 +1,37 @@
 import { Field, InputType } from '@nestjs/graphql';
 
-import { IsNotEmpty, IsOptional, IsString, IsUUID } from 'class-validator';
+import { Type } from 'class-transformer';
+import {
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUUID,
+  ValidateNested,
+} from 'class-validator';
 
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
+
+@InputType()
+export class UpdateFrontComponentInputUpdates {
+  @IsOptional()
+  @IsString()
+  @Field({ nullable: true })
+  name?: string;
+}
 
 @InputType()
 export class UpdateFrontComponentInput {
   @IsUUID()
   @IsNotEmpty()
-  @Field(() => UUIDScalarType)
+  @Field(() => UUIDScalarType, {
+    description: 'The id of the front component to update',
+  })
   id: string;
 
-  @IsString()
-  @IsOptional()
-  @Field({ nullable: true })
-  name?: string;
+  @Type(() => UpdateFrontComponentInputUpdates)
+  @ValidateNested()
+  @Field(() => UpdateFrontComponentInputUpdates, {
+    description: 'The front component fields to update',
+  })
+  update: UpdateFrontComponentInputUpdates;
 }

--- a/packages/twenty-server/src/engine/metadata-modules/front-component/dtos/update-front-component.input.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/front-component/dtos/update-front-component.input.ts
@@ -1,0 +1,18 @@
+import { Field, InputType } from '@nestjs/graphql';
+
+import { IsNotEmpty, IsOptional, IsString, IsUUID } from 'class-validator';
+
+import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
+
+@InputType()
+export class UpdateFrontComponentInput {
+  @IsUUID()
+  @IsNotEmpty()
+  @Field(() => UUIDScalarType)
+  id: string;
+
+  @IsString()
+  @IsOptional()
+  @Field({ nullable: true })
+  name?: string;
+}

--- a/packages/twenty-server/src/engine/metadata-modules/front-component/entities/front-component.entity.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/front-component/entities/front-component.entity.ts
@@ -1,7 +1,6 @@
 import {
   Column,
   CreateDateColumn,
-  DeleteDateColumn,
   Entity,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
@@ -25,7 +24,4 @@ export class FrontComponentEntity
 
   @UpdateDateColumn({ type: 'timestamptz' })
   updatedAt: Date;
-
-  @DeleteDateColumn({ type: 'timestamptz', nullable: true })
-  deletedAt: Date | null;
 }

--- a/packages/twenty-server/src/engine/metadata-modules/front-component/entities/front-component.entity.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/front-component/entities/front-component.entity.ts
@@ -1,0 +1,31 @@
+import {
+  Column,
+  CreateDateColumn,
+  DeleteDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+import { SyncableEntityRequired } from 'src/engine/workspace-manager/types/syncable-entity-required.interface';
+
+@Entity('frontComponent')
+export class FrontComponentEntity
+  extends SyncableEntityRequired
+  implements Required<FrontComponentEntity>
+{
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ nullable: false })
+  name: string;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ type: 'timestamptz' })
+  updatedAt: Date;
+
+  @DeleteDateColumn({ type: 'timestamptz', nullable: true })
+  deletedAt: Date | null;
+}

--- a/packages/twenty-server/src/engine/metadata-modules/front-component/front-component.exception.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/front-component/front-component.exception.ts
@@ -1,0 +1,40 @@
+import { type MessageDescriptor } from '@lingui/core';
+import { msg } from '@lingui/core/macro';
+import { assertUnreachable } from 'twenty-shared/utils';
+
+import { CustomException } from 'src/utils/custom-exception';
+
+export enum FrontComponentExceptionCode {
+  FRONT_COMPONENT_NOT_FOUND = 'FRONT_COMPONENT_NOT_FOUND',
+  FRONT_COMPONENT_ALREADY_EXISTS = 'FRONT_COMPONENT_ALREADY_EXISTS',
+  INVALID_FRONT_COMPONENT_INPUT = 'INVALID_FRONT_COMPONENT_INPUT',
+}
+
+const getFrontComponentExceptionUserFriendlyMessage = (
+  code: FrontComponentExceptionCode,
+) => {
+  switch (code) {
+    case FrontComponentExceptionCode.FRONT_COMPONENT_NOT_FOUND:
+      return msg`Front component not found.`;
+    case FrontComponentExceptionCode.FRONT_COMPONENT_ALREADY_EXISTS:
+      return msg`A front component with this name already exists.`;
+    case FrontComponentExceptionCode.INVALID_FRONT_COMPONENT_INPUT:
+      return msg`Invalid front component input.`;
+    default:
+      assertUnreachable(code);
+  }
+};
+
+export class FrontComponentException extends CustomException<FrontComponentExceptionCode> {
+  constructor(
+    message: string,
+    code: FrontComponentExceptionCode,
+    { userFriendlyMessage }: { userFriendlyMessage?: MessageDescriptor } = {},
+  ) {
+    super(message, code, {
+      userFriendlyMessage:
+        userFriendlyMessage ??
+        getFrontComponentExceptionUserFriendlyMessage(code),
+    });
+  }
+}

--- a/packages/twenty-server/src/engine/metadata-modules/front-component/front-component.module.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/front-component/front-component.module.ts
@@ -1,0 +1,27 @@
+import { Module } from '@nestjs/common';
+
+import { ApplicationModule } from 'src/engine/core-modules/application/application.module';
+import { WorkspaceManyOrAllFlatEntityMapsCacheModule } from 'src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.module';
+import { FlatFrontComponentModule } from 'src/engine/metadata-modules/flat-front-component/flat-front-component.module';
+import { FrontComponentResolver } from 'src/engine/metadata-modules/front-component/front-component.resolver';
+import { FrontComponentService } from 'src/engine/metadata-modules/front-component/front-component.service';
+import { FrontComponentGraphqlApiExceptionInterceptor } from 'src/engine/metadata-modules/front-component/interceptors/front-component-graphql-api-exception.interceptor';
+import { WorkspaceMigrationBuilderGraphqlApiExceptionInterceptor } from 'src/engine/workspace-manager/workspace-migration/interceptors/workspace-migration-builder-graphql-api-exception.interceptor';
+import { WorkspaceMigrationModule } from 'src/engine/workspace-manager/workspace-migration/workspace-migration.module';
+
+@Module({
+  imports: [
+    WorkspaceManyOrAllFlatEntityMapsCacheModule,
+    WorkspaceMigrationModule,
+    ApplicationModule,
+    FlatFrontComponentModule,
+  ],
+  providers: [
+    FrontComponentService,
+    FrontComponentResolver,
+    FrontComponentGraphqlApiExceptionInterceptor,
+    WorkspaceMigrationBuilderGraphqlApiExceptionInterceptor,
+  ],
+  exports: [FrontComponentService],
+})
+export class FrontComponentModule {}

--- a/packages/twenty-server/src/engine/metadata-modules/front-component/front-component.module.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/front-component/front-component.module.ts
@@ -6,6 +6,7 @@ import { FlatFrontComponentModule } from 'src/engine/metadata-modules/flat-front
 import { FrontComponentResolver } from 'src/engine/metadata-modules/front-component/front-component.resolver';
 import { FrontComponentService } from 'src/engine/metadata-modules/front-component/front-component.service';
 import { FrontComponentGraphqlApiExceptionInterceptor } from 'src/engine/metadata-modules/front-component/interceptors/front-component-graphql-api-exception.interceptor';
+import { PermissionsModule } from 'src/engine/metadata-modules/permissions/permissions.module';
 import { WorkspaceMigrationBuilderGraphqlApiExceptionInterceptor } from 'src/engine/workspace-manager/workspace-migration/interceptors/workspace-migration-builder-graphql-api-exception.interceptor';
 import { WorkspaceMigrationModule } from 'src/engine/workspace-manager/workspace-migration/workspace-migration.module';
 
@@ -14,6 +15,7 @@ import { WorkspaceMigrationModule } from 'src/engine/workspace-manager/workspace
     WorkspaceManyOrAllFlatEntityMapsCacheModule,
     WorkspaceMigrationModule,
     ApplicationModule,
+    PermissionsModule,
     FlatFrontComponentModule,
   ],
   providers: [

--- a/packages/twenty-server/src/engine/metadata-modules/front-component/front-component.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/front-component/front-component.resolver.ts
@@ -30,7 +30,7 @@ export class FrontComponentResolver {
   async frontComponents(
     @AuthWorkspace() workspace: WorkspaceEntity,
   ): Promise<FrontComponentDTO[]> {
-    return this.frontComponentService.findAll(workspace.id);
+    return await this.frontComponentService.findAll(workspace.id);
   }
 
   @Query(() => FrontComponentDTO, { nullable: true })
@@ -39,7 +39,7 @@ export class FrontComponentResolver {
     @Args('id', { type: () => UUIDScalarType }) id: string,
     @AuthWorkspace() workspace: WorkspaceEntity,
   ): Promise<FrontComponentDTO | null> {
-    return this.frontComponentService.findById(id, workspace.id);
+    return await this.frontComponentService.findById(id, workspace.id);
   }
 
   @Mutation(() => FrontComponentDTO)
@@ -48,7 +48,7 @@ export class FrontComponentResolver {
     @Args('input') input: CreateFrontComponentInput,
     @AuthWorkspace() workspace: WorkspaceEntity,
   ): Promise<FrontComponentDTO> {
-    return this.frontComponentService.create(input, workspace.id);
+    return await this.frontComponentService.create(input, workspace.id);
   }
 
   @Mutation(() => FrontComponentDTO)
@@ -57,7 +57,7 @@ export class FrontComponentResolver {
     @Args('input') input: UpdateFrontComponentInput,
     @AuthWorkspace() workspace: WorkspaceEntity,
   ): Promise<FrontComponentDTO> {
-    return this.frontComponentService.update(input, workspace.id);
+    return await this.frontComponentService.update(input, workspace.id);
   }
 
   @Mutation(() => FrontComponentDTO)
@@ -66,6 +66,6 @@ export class FrontComponentResolver {
     @Args('id', { type: () => UUIDScalarType }) id: string,
     @AuthWorkspace() workspace: WorkspaceEntity,
   ): Promise<FrontComponentDTO> {
-    return this.frontComponentService.delete(id, workspace.id);
+    return await this.frontComponentService.delete(id, workspace.id);
   }
 }

--- a/packages/twenty-server/src/engine/metadata-modules/front-component/front-component.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/front-component/front-component.resolver.ts
@@ -1,9 +1,13 @@
 import { UseGuards, UseInterceptors } from '@nestjs/common';
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
 
+import { PermissionFlagType } from 'twenty-shared/constants';
+
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
+import { NoPermissionGuard } from 'src/engine/guards/no-permission.guard';
+import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { CreateFrontComponentInput } from 'src/engine/metadata-modules/front-component/dtos/create-front-component.input';
 import { FrontComponentDTO } from 'src/engine/metadata-modules/front-component/dtos/front-component.dto';
@@ -19,11 +23,10 @@ import { WorkspaceMigrationBuilderGraphqlApiExceptionInterceptor } from 'src/eng
 )
 @Resolver(() => FrontComponentDTO)
 export class FrontComponentResolver {
-  constructor(
-    private readonly frontComponentService: FrontComponentService,
-  ) {}
+  constructor(private readonly frontComponentService: FrontComponentService) {}
 
   @Query(() => [FrontComponentDTO])
+  @UseGuards(NoPermissionGuard)
   async frontComponents(
     @AuthWorkspace() workspace: WorkspaceEntity,
   ): Promise<FrontComponentDTO[]> {
@@ -31,6 +34,7 @@ export class FrontComponentResolver {
   }
 
   @Query(() => FrontComponentDTO, { nullable: true })
+  @UseGuards(NoPermissionGuard)
   async frontComponent(
     @Args('id', { type: () => UUIDScalarType }) id: string,
     @AuthWorkspace() workspace: WorkspaceEntity,
@@ -39,6 +43,7 @@ export class FrontComponentResolver {
   }
 
   @Mutation(() => FrontComponentDTO)
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.APPLICATIONS))
   async createFrontComponent(
     @Args('input') input: CreateFrontComponentInput,
     @AuthWorkspace() workspace: WorkspaceEntity,
@@ -47,6 +52,7 @@ export class FrontComponentResolver {
   }
 
   @Mutation(() => FrontComponentDTO)
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.APPLICATIONS))
   async updateFrontComponent(
     @Args('input') input: UpdateFrontComponentInput,
     @AuthWorkspace() workspace: WorkspaceEntity,
@@ -55,6 +61,7 @@ export class FrontComponentResolver {
   }
 
   @Mutation(() => FrontComponentDTO)
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.APPLICATIONS))
   async deleteFrontComponent(
     @Args('id', { type: () => UUIDScalarType }) id: string,
     @AuthWorkspace() workspace: WorkspaceEntity,

--- a/packages/twenty-server/src/engine/metadata-modules/front-component/front-component.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/front-component/front-component.service.ts
@@ -1,0 +1,235 @@
+import { Injectable } from '@nestjs/common';
+
+import { isDefined } from 'twenty-shared/utils';
+
+import { ApplicationService } from 'src/engine/core-modules/application/application.service';
+import { WorkspaceManyOrAllFlatEntityMapsCacheService } from 'src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.service';
+import { findFlatEntityByIdInFlatEntityMapsOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps-or-throw.util';
+import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps.util';
+import { fromCreateFrontComponentInputToFlatFrontComponentToCreate } from 'src/engine/metadata-modules/flat-front-component/utils/from-create-front-component-input-to-flat-front-component-to-create.util';
+import { fromDeleteFrontComponentInputToFlatFrontComponentOrThrow } from 'src/engine/metadata-modules/flat-front-component/utils/from-delete-front-component-input-to-flat-front-component-or-throw.util';
+import { fromFlatFrontComponentToFrontComponentDto } from 'src/engine/metadata-modules/flat-front-component/utils/from-flat-front-component-to-front-component-dto.util';
+import { fromUpdateFrontComponentInputToFlatFrontComponentToUpdateOrThrow } from 'src/engine/metadata-modules/flat-front-component/utils/from-update-front-component-input-to-flat-front-component-to-update-or-throw.util';
+import { type CreateFrontComponentInput } from 'src/engine/metadata-modules/front-component/dtos/create-front-component.input';
+import { type FrontComponentDTO } from 'src/engine/metadata-modules/front-component/dtos/front-component.dto';
+import { type UpdateFrontComponentInput } from 'src/engine/metadata-modules/front-component/dtos/update-front-component.input';
+import {
+  FrontComponentException,
+  FrontComponentExceptionCode,
+} from 'src/engine/metadata-modules/front-component/front-component.exception';
+import { WorkspaceMigrationBuilderException } from 'src/engine/workspace-manager/workspace-migration/exceptions/workspace-migration-builder-exception';
+import { WorkspaceMigrationValidateBuildAndRunService } from 'src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service';
+
+@Injectable()
+export class FrontComponentService {
+  constructor(
+    private readonly workspaceMigrationValidateBuildAndRunService: WorkspaceMigrationValidateBuildAndRunService,
+    private readonly workspaceManyOrAllFlatEntityMapsCacheService: WorkspaceManyOrAllFlatEntityMapsCacheService,
+    private readonly applicationService: ApplicationService,
+  ) {}
+
+  async findAll(workspaceId: string): Promise<FrontComponentDTO[]> {
+    const { flatFrontComponentMaps } =
+      await this.workspaceManyOrAllFlatEntityMapsCacheService.getOrRecomputeManyOrAllFlatEntityMaps(
+        {
+          workspaceId,
+          flatMapsKeys: ['flatFrontComponentMaps'],
+        },
+      );
+
+    return Object.values(flatFrontComponentMaps.byId)
+      .filter(isDefined)
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .map(fromFlatFrontComponentToFrontComponentDto);
+  }
+
+  async findById(
+    id: string,
+    workspaceId: string,
+  ): Promise<FrontComponentDTO | null> {
+    const { flatFrontComponentMaps } =
+      await this.workspaceManyOrAllFlatEntityMapsCacheService.getOrRecomputeManyOrAllFlatEntityMaps(
+        {
+          workspaceId,
+          flatMapsKeys: ['flatFrontComponentMaps'],
+        },
+      );
+
+    const flatFrontComponent = findFlatEntityByIdInFlatEntityMaps({
+      flatEntityId: id,
+      flatEntityMaps: flatFrontComponentMaps,
+    });
+
+    if (!isDefined(flatFrontComponent)) {
+      return null;
+    }
+
+    return fromFlatFrontComponentToFrontComponentDto(flatFrontComponent);
+  }
+
+  async create(
+    input: CreateFrontComponentInput,
+    workspaceId: string,
+  ): Promise<FrontComponentDTO> {
+    const { workspaceCustomFlatApplication } =
+      await this.applicationService.findWorkspaceTwentyStandardAndCustomApplicationOrThrow(
+        { workspaceId },
+      );
+
+    const flatFrontComponentToCreate =
+      fromCreateFrontComponentInputToFlatFrontComponentToCreate({
+        createFrontComponentInput: input,
+        workspaceId,
+        applicationId: workspaceCustomFlatApplication.id,
+      });
+
+    const validateAndBuildResult =
+      await this.workspaceMigrationValidateBuildAndRunService.validateBuildAndRunWorkspaceMigration(
+        {
+          allFlatEntityOperationByMetadataName: {
+            frontComponent: {
+              flatEntityToCreate: [flatFrontComponentToCreate],
+              flatEntityToDelete: [],
+              flatEntityToUpdate: [],
+            },
+          },
+          workspaceId,
+          isSystemBuild: false,
+        },
+      );
+
+    if (isDefined(validateAndBuildResult)) {
+      throw new WorkspaceMigrationBuilderException(
+        validateAndBuildResult,
+        'Multiple validation errors occurred while creating front component',
+      );
+    }
+
+    const { flatFrontComponentMaps: recomputedFlatFrontComponentMaps } =
+      await this.workspaceManyOrAllFlatEntityMapsCacheService.getOrRecomputeManyOrAllFlatEntityMaps(
+        {
+          workspaceId,
+          flatMapsKeys: ['flatFrontComponentMaps'],
+        },
+      );
+
+    return fromFlatFrontComponentToFrontComponentDto(
+      findFlatEntityByIdInFlatEntityMapsOrThrow({
+        flatEntityId: flatFrontComponentToCreate.id,
+        flatEntityMaps: recomputedFlatFrontComponentMaps,
+      }),
+    );
+  }
+
+  async update(
+    input: UpdateFrontComponentInput,
+    workspaceId: string,
+  ): Promise<FrontComponentDTO> {
+    const { flatFrontComponentMaps: existingFlatFrontComponentMaps } =
+      await this.workspaceManyOrAllFlatEntityMapsCacheService.getOrRecomputeManyOrAllFlatEntityMaps(
+        {
+          workspaceId,
+          flatMapsKeys: ['flatFrontComponentMaps'],
+        },
+      );
+
+    const flatFrontComponentToUpdate =
+      fromUpdateFrontComponentInputToFlatFrontComponentToUpdateOrThrow({
+        flatFrontComponentMaps: existingFlatFrontComponentMaps,
+        updateFrontComponentInput: input,
+      });
+
+    const validateAndBuildResult =
+      await this.workspaceMigrationValidateBuildAndRunService.validateBuildAndRunWorkspaceMigration(
+        {
+          allFlatEntityOperationByMetadataName: {
+            frontComponent: {
+              flatEntityToCreate: [],
+              flatEntityToDelete: [],
+              flatEntityToUpdate: [flatFrontComponentToUpdate],
+            },
+          },
+          workspaceId,
+          isSystemBuild: false,
+        },
+      );
+
+    if (isDefined(validateAndBuildResult)) {
+      throw new WorkspaceMigrationBuilderException(
+        validateAndBuildResult,
+        'Multiple validation errors occurred while updating front component',
+      );
+    }
+
+    const { flatFrontComponentMaps: recomputedFlatFrontComponentMaps } =
+      await this.workspaceManyOrAllFlatEntityMapsCacheService.getOrRecomputeManyOrAllFlatEntityMaps(
+        {
+          workspaceId,
+          flatMapsKeys: ['flatFrontComponentMaps'],
+        },
+      );
+
+    return fromFlatFrontComponentToFrontComponentDto(
+      findFlatEntityByIdInFlatEntityMapsOrThrow({
+        flatEntityId: input.id,
+        flatEntityMaps: recomputedFlatFrontComponentMaps,
+      }),
+    );
+  }
+
+  async delete(id: string, workspaceId: string): Promise<FrontComponentDTO> {
+    const { flatFrontComponentMaps: existingFlatFrontComponentMaps } =
+      await this.workspaceManyOrAllFlatEntityMapsCacheService.getOrRecomputeManyOrAllFlatEntityMaps(
+        {
+          workspaceId,
+          flatMapsKeys: ['flatFrontComponentMaps'],
+        },
+      );
+
+    const flatFrontComponentToDelete =
+      fromDeleteFrontComponentInputToFlatFrontComponentOrThrow({
+        flatFrontComponentMaps: existingFlatFrontComponentMaps,
+        frontComponentId: id,
+      });
+
+    const validateAndBuildResult =
+      await this.workspaceMigrationValidateBuildAndRunService.validateBuildAndRunWorkspaceMigration(
+        {
+          allFlatEntityOperationByMetadataName: {
+            frontComponent: {
+              flatEntityToCreate: [],
+              flatEntityToDelete: [flatFrontComponentToDelete],
+              flatEntityToUpdate: [],
+            },
+          },
+          workspaceId,
+          isSystemBuild: false,
+        },
+      );
+
+    if (isDefined(validateAndBuildResult)) {
+      throw new WorkspaceMigrationBuilderException(
+        validateAndBuildResult,
+        'Multiple validation errors occurred while deleting front component',
+      );
+    }
+
+    return fromFlatFrontComponentToFrontComponentDto(flatFrontComponentToDelete);
+  }
+
+  async findByIdOrThrow(
+    id: string,
+    workspaceId: string,
+  ): Promise<FrontComponentDTO> {
+    const frontComponent = await this.findById(id, workspaceId);
+
+    if (!isDefined(frontComponent)) {
+      throw new FrontComponentException(
+        'Front component not found',
+        FrontComponentExceptionCode.FRONT_COMPONENT_NOT_FOUND,
+      );
+    }
+
+    return frontComponent;
+  }
+}

--- a/packages/twenty-server/src/engine/metadata-modules/front-component/front-component.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/front-component/front-component.service.ts
@@ -214,7 +214,9 @@ export class FrontComponentService {
       );
     }
 
-    return fromFlatFrontComponentToFrontComponentDto(flatFrontComponentToDelete);
+    return fromFlatFrontComponentToFrontComponentDto(
+      flatFrontComponentToDelete,
+    );
   }
 
   async findByIdOrThrow(

--- a/packages/twenty-server/src/engine/metadata-modules/front-component/interceptors/front-component-graphql-api-exception.interceptor.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/front-component/interceptors/front-component-graphql-api-exception.interceptor.ts
@@ -1,0 +1,24 @@
+import {
+  type CallHandler,
+  type ExecutionContext,
+  Injectable,
+  type NestInterceptor,
+} from '@nestjs/common';
+
+import { type Observable, catchError } from 'rxjs';
+
+import { frontComponentGraphqlApiExceptionHandler } from 'src/engine/metadata-modules/front-component/utils/front-component-graphql-api-exception-handler.util';
+
+@Injectable()
+export class FrontComponentGraphqlApiExceptionInterceptor
+  implements NestInterceptor
+{
+  intercept(
+    _context: ExecutionContext,
+    next: CallHandler,
+  ): Observable<unknown> {
+    return next
+      .handle()
+      .pipe(catchError(frontComponentGraphqlApiExceptionHandler));
+  }
+}

--- a/packages/twenty-server/src/engine/metadata-modules/front-component/utils/front-component-graphql-api-exception-handler.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/front-component/utils/front-component-graphql-api-exception-handler.util.ts
@@ -1,0 +1,29 @@
+import { assertUnreachable } from 'twenty-shared/utils';
+
+import {
+  ConflictError,
+  NotFoundError,
+  UserInputError,
+} from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
+import {
+  FrontComponentException,
+  FrontComponentExceptionCode,
+} from 'src/engine/metadata-modules/front-component/front-component.exception';
+
+export const frontComponentGraphqlApiExceptionHandler = (error: Error) => {
+  if (error instanceof FrontComponentException) {
+    switch (error.code) {
+      case FrontComponentExceptionCode.FRONT_COMPONENT_NOT_FOUND:
+        throw new NotFoundError(error);
+      case FrontComponentExceptionCode.INVALID_FRONT_COMPONENT_INPUT:
+        throw new UserInputError(error);
+      case FrontComponentExceptionCode.FRONT_COMPONENT_ALREADY_EXISTS:
+        throw new ConflictError(error);
+      default: {
+        return assertUnreachable(error.code);
+      }
+    }
+  }
+
+  throw error;
+};

--- a/packages/twenty-server/src/engine/metadata-modules/metadata-engine.module.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/metadata-engine.module.ts
@@ -7,6 +7,7 @@ import { CronTriggerModule } from 'src/engine/metadata-modules/cron-trigger/cron
 import { DataSourceModule } from 'src/engine/metadata-modules/data-source/data-source.module';
 import { DatabaseEventTriggerModule } from 'src/engine/metadata-modules/database-event-trigger/database-event-trigger.module';
 import { FieldMetadataModule } from 'src/engine/metadata-modules/field-metadata/field-metadata.module';
+import { FrontComponentModule } from 'src/engine/metadata-modules/front-component/front-component.module';
 import { ObjectMetadataModule } from 'src/engine/metadata-modules/object-metadata/object-metadata.module';
 import { PermissionsModule } from 'src/engine/metadata-modules/permissions/permissions.module';
 import { RoleModule } from 'src/engine/metadata-modules/role/role.module';
@@ -22,6 +23,7 @@ import { WorkspaceMetadataVersionModule } from 'src/engine/metadata-modules/work
   imports: [
     DataSourceModule,
     FieldMetadataModule,
+    FrontComponentModule,
     ObjectMetadataModule,
     SearchFieldMetadataModule,
     ServerlessFunctionModule,
@@ -42,6 +44,7 @@ import { WorkspaceMetadataVersionModule } from 'src/engine/metadata-modules/work
   exports: [
     DataSourceModule,
     FieldMetadataModule,
+    FrontComponentModule,
     ObjectMetadataModule,
     SearchFieldMetadataModule,
     ServerlessFunctionModule,

--- a/packages/twenty-server/src/engine/metadata-modules/skill/dtos/create-skill.input.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/skill/dtos/create-skill.input.ts
@@ -1,9 +1,16 @@
 import { Field, InputType } from '@nestjs/graphql';
 
-import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { IsNotEmpty, IsOptional, IsString, IsUUID } from 'class-validator';
+
+import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 
 @InputType()
 export class CreateSkillInput {
+  @IsUUID()
+  @IsOptional()
+  @Field(() => UUIDScalarType, { nullable: true })
+  id?: string;
+
   @IsString()
   @IsNotEmpty()
   @Field()

--- a/packages/twenty-server/src/engine/workspace-cache/types/workspace-cache-key.type.ts
+++ b/packages/twenty-server/src/engine/workspace-cache/types/workspace-cache-key.type.ts
@@ -40,6 +40,7 @@ export const WORKSPACE_CACHE_KEYS_V2 = {
     'flat-maps:row-level-permission-predicate',
   flatRowLevelPermissionPredicateGroupMaps:
     'flat-maps:row-level-permission-predicate-group',
+  flatFrontComponentMaps: 'flat-maps:front-component',
 } as const satisfies Record<WorkspaceCacheKeyName, string>;
 
 export type AdditionalCacheDataMaps = {

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/services/workspace-migration-build-orchestrator.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/services/workspace-migration-build-orchestrator.service.ts
@@ -18,6 +18,7 @@ import { WorkspaceMigrationAgentActionsBuilderService } from 'src/engine/workspa
 import { WorkspaceMigrationCronTriggerActionsBuilderService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/cron-trigger/workspace-migration-cron-trigger-action-builder.service';
 import { WorkspaceMigrationDatabaseEventTriggerActionsBuilderService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/database-event-trigger/workspace-migration-database-event-trigger-actions-builder.service';
 import { WorkspaceMigrationFieldActionsBuilderService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/field/workspace-migration-field-actions-builder.service';
+import { WorkspaceMigrationFrontComponentActionsBuilderService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/front-component/workspace-migration-front-component-actions-builder.service';
 import { WorkspaceMigrationIndexActionsBuilderService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/index/workspace-migration-index-actions-builder.service';
 import { WorkspaceMigrationObjectActionsBuilderService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/object/workspace-migration-object-actions-builder.service';
 import { WorkspaceMigrationPageLayoutTabActionsBuilderService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/page-layout-tab/workspace-migration-page-layout-tab-actions-builder.service';
@@ -30,7 +31,6 @@ import { WorkspaceMigrationRowLevelPermissionPredicateGroupActionsBuilderService
 import { WorkspaceMigrationRowLevelPermissionPredicateActionsBuilderService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/row-level-permission-predicate/workspace-migration-row-level-permission-predicate-actions-builder.service';
 import { WorkspaceMigrationServerlessFunctionActionsBuilderService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/serverless-function/workspace-migration-serverless-function-actions-builder.service';
 import { WorkspaceMigrationSkillActionsBuilderService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/skill/workspace-migration-skill-actions-builder.service';
-import { WorkspaceMigrationFrontComponentActionsBuilderService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/front-component/workspace-migration-front-component-actions-builder.service';
 import { WorkspaceMigrationViewFieldActionsBuilderService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/view-field/workspace-migration-view-field-actions-builder.service';
 import { WorkspaceMigrationViewFilterGroupActionsBuilderService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/view-filter-group/workspace-migration-view-filter-group-actions-builder.service';
 import { WorkspaceMigrationViewFilterActionsBuilderService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/view-filter/workspace-migration-view-filter-actions-builder.service';
@@ -932,10 +932,8 @@ export class WorkspaceMigrationBuildOrchestratorService {
     }
 
     if (isDefined(flatFrontComponentMaps)) {
-      const {
-        from: fromFlatFrontComponentMaps,
-        to: toFlatFrontComponentMaps,
-      } = flatFrontComponentMaps;
+      const { from: fromFlatFrontComponentMaps, to: toFlatFrontComponentMaps } =
+        flatFrontComponentMaps;
 
       const frontComponentResult =
         await this.workspaceMigrationFrontComponentActionsBuilderService.validateAndBuild(

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/front-component/types/workspace-migration-front-component-action.type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/front-component/types/workspace-migration-front-component-action.type.ts
@@ -1,0 +1,12 @@
+import { type BaseCreateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-create-workspace-migration-action.type';
+import { type BaseDeleteWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-delete-workspace-migration-action.type';
+import { type BaseUpdateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-update-workspace-migration-action.type';
+
+export type CreateFrontComponentAction =
+  BaseCreateWorkspaceMigrationAction<'frontComponent'>;
+
+export type UpdateFrontComponentAction =
+  BaseUpdateWorkspaceMigrationAction<'frontComponent'>;
+
+export type DeleteFrontComponentAction =
+  BaseDeleteWorkspaceMigrationAction<'frontComponent'>;

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/front-component/workspace-migration-front-component-actions-builder.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/front-component/workspace-migration-front-component-actions-builder.service.ts
@@ -80,7 +80,9 @@ export class WorkspaceMigrationFrontComponentActionsBuilderService extends Works
   }
 
   protected validateFlatEntityUpdate(
-    args: FlatEntityUpdateValidationArgs<typeof ALL_METADATA_NAME.frontComponent>,
+    args: FlatEntityUpdateValidationArgs<
+      typeof ALL_METADATA_NAME.frontComponent
+    >,
   ): FlatEntityValidationReturnType<
     typeof ALL_METADATA_NAME.frontComponent,
     'update'

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/front-component/workspace-migration-front-component-actions-builder.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/front-component/workspace-migration-front-component-actions-builder.service.ts
@@ -1,0 +1,114 @@
+import { Injectable } from '@nestjs/common';
+
+import { ALL_METADATA_NAME } from 'twenty-shared/metadata';
+
+import { UpdateFrontComponentAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/front-component/types/workspace-migration-front-component-action.type';
+import { WorkspaceEntityMigrationBuilderService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/services/workspace-entity-migration-builder.service';
+import { FlatEntityUpdateValidationArgs } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/flat-entity-update-validation-args.type';
+import { FlatEntityValidationArgs } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/flat-entity-validation-args.type';
+import { FlatEntityValidationReturnType } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/flat-entity-validation-result.type';
+import { FlatFrontComponentValidatorService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-front-component-validator.service';
+
+@Injectable()
+export class WorkspaceMigrationFrontComponentActionsBuilderService extends WorkspaceEntityMigrationBuilderService<
+  typeof ALL_METADATA_NAME.frontComponent
+> {
+  constructor(
+    private readonly flatFrontComponentValidatorService: FlatFrontComponentValidatorService,
+  ) {
+    super(ALL_METADATA_NAME.frontComponent);
+  }
+
+  protected validateFlatEntityCreation(
+    args: FlatEntityValidationArgs<typeof ALL_METADATA_NAME.frontComponent>,
+  ): FlatEntityValidationReturnType<
+    typeof ALL_METADATA_NAME.frontComponent,
+    'create'
+  > {
+    const validationResult =
+      this.flatFrontComponentValidatorService.validateFlatFrontComponentCreation(
+        args,
+      );
+
+    if (validationResult.errors.length > 0) {
+      return {
+        status: 'fail',
+        ...validationResult,
+      };
+    }
+
+    const { flatEntityToValidate: flatFrontComponentToValidate } = args;
+
+    return {
+      status: 'success',
+      action: {
+        type: 'create',
+        metadataName: 'frontComponent',
+        flatEntity: flatFrontComponentToValidate,
+      },
+    };
+  }
+
+  protected validateFlatEntityDeletion(
+    args: FlatEntityValidationArgs<typeof ALL_METADATA_NAME.frontComponent>,
+  ): FlatEntityValidationReturnType<
+    typeof ALL_METADATA_NAME.frontComponent,
+    'delete'
+  > {
+    const validationResult =
+      this.flatFrontComponentValidatorService.validateFlatFrontComponentDeletion(
+        args,
+      );
+
+    if (validationResult.errors.length > 0) {
+      return {
+        status: 'fail',
+        ...validationResult,
+      };
+    }
+
+    const { flatEntityToValidate: flatFrontComponentToValidate } = args;
+
+    return {
+      status: 'success',
+      action: {
+        type: 'delete',
+        metadataName: 'frontComponent',
+        entityId: flatFrontComponentToValidate.id,
+      },
+    };
+  }
+
+  protected validateFlatEntityUpdate(
+    args: FlatEntityUpdateValidationArgs<typeof ALL_METADATA_NAME.frontComponent>,
+  ): FlatEntityValidationReturnType<
+    typeof ALL_METADATA_NAME.frontComponent,
+    'update'
+  > {
+    const validationResult =
+      this.flatFrontComponentValidatorService.validateFlatFrontComponentUpdate(
+        args,
+      );
+
+    if (validationResult.errors.length > 0) {
+      return {
+        status: 'fail',
+        ...validationResult,
+      };
+    }
+
+    const { flatEntityId, flatEntityUpdates } = args;
+
+    const updateFrontComponentAction: UpdateFrontComponentAction = {
+      type: 'update',
+      metadataName: 'frontComponent',
+      entityId: flatEntityId,
+      updates: flatEntityUpdates,
+    };
+
+    return {
+      status: 'success',
+      action: updateFrontComponentAction,
+    };
+  }
+}

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-front-component-validator.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-front-component-validator.service.ts
@@ -1,0 +1,112 @@
+import { Injectable } from '@nestjs/common';
+
+import { msg, t } from '@lingui/core/macro';
+import { ALL_METADATA_NAME } from 'twenty-shared/metadata';
+import { isDefined } from 'twenty-shared/utils';
+
+import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps.util';
+import { FrontComponentExceptionCode } from 'src/engine/metadata-modules/front-component/front-component.exception';
+import { type FailedFlatEntityValidation } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/types/failed-flat-entity-validation.type';
+import { getEmptyFlatEntityValidationError } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/utils/get-flat-entity-validation-error.util';
+import { type FlatEntityUpdateValidationArgs } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/flat-entity-update-validation-args.type';
+import { type FlatEntityValidationArgs } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/flat-entity-validation-args.type';
+
+@Injectable()
+export class FlatFrontComponentValidatorService {
+  public validateFlatFrontComponentCreation({
+    flatEntityToValidate: flatFrontComponent,
+  }: FlatEntityValidationArgs<
+    typeof ALL_METADATA_NAME.frontComponent
+  >): FailedFlatEntityValidation<'frontComponent', 'create'> {
+    const validationResult = getEmptyFlatEntityValidationError({
+      flatEntityMinimalInformation: {
+        id: flatFrontComponent.id,
+        universalIdentifier: flatFrontComponent.universalIdentifier,
+        name: flatFrontComponent.name,
+      },
+      metadataName: 'frontComponent',
+      type: 'create',
+    });
+
+    if (!isDefined(flatFrontComponent.name) || flatFrontComponent.name === '') {
+      validationResult.errors.push({
+        code: FrontComponentExceptionCode.INVALID_FRONT_COMPONENT_INPUT,
+        message: t`Front component name is required`,
+        userFriendlyMessage: msg`Front component name is required`,
+      });
+    }
+
+    return validationResult;
+  }
+
+  public validateFlatFrontComponentDeletion({
+    flatEntityToValidate,
+    optimisticFlatEntityMapsAndRelatedFlatEntityMaps: {
+      flatFrontComponentMaps: optimisticFlatFrontComponentMaps,
+    },
+  }: FlatEntityValidationArgs<
+    typeof ALL_METADATA_NAME.frontComponent
+  >): FailedFlatEntityValidation<'frontComponent', 'delete'> {
+    const validationResult = getEmptyFlatEntityValidationError({
+      flatEntityMinimalInformation: {
+        id: flatEntityToValidate.id,
+        universalIdentifier: flatEntityToValidate.universalIdentifier,
+        name: flatEntityToValidate.name,
+      },
+      metadataName: 'frontComponent',
+      type: 'delete',
+    });
+
+    const existingFrontComponent = findFlatEntityByIdInFlatEntityMaps({
+      flatEntityId: flatEntityToValidate.id,
+      flatEntityMaps: optimisticFlatFrontComponentMaps,
+    });
+
+    if (!isDefined(existingFrontComponent)) {
+      validationResult.errors.push({
+        code: FrontComponentExceptionCode.FRONT_COMPONENT_NOT_FOUND,
+        message: t`Front component not found`,
+        userFriendlyMessage: msg`Front component not found`,
+      });
+
+      return validationResult;
+    }
+
+    return validationResult;
+  }
+
+  public validateFlatFrontComponentUpdate({
+    flatEntityId,
+    optimisticFlatEntityMapsAndRelatedFlatEntityMaps: {
+      flatFrontComponentMaps: optimisticFlatFrontComponentMaps,
+    },
+  }: FlatEntityUpdateValidationArgs<
+    typeof ALL_METADATA_NAME.frontComponent
+  >): FailedFlatEntityValidation<'frontComponent', 'update'> {
+    const fromFlatFrontComponent = findFlatEntityByIdInFlatEntityMaps({
+      flatEntityId,
+      flatEntityMaps: optimisticFlatFrontComponentMaps,
+    });
+
+    const validationResult = getEmptyFlatEntityValidationError({
+      flatEntityMinimalInformation: {
+        id: flatEntityId,
+        universalIdentifier: fromFlatFrontComponent?.universalIdentifier,
+      },
+      metadataName: 'frontComponent',
+      type: 'update',
+    });
+
+    if (!isDefined(fromFlatFrontComponent)) {
+      validationResult.errors.push({
+        code: FrontComponentExceptionCode.FRONT_COMPONENT_NOT_FOUND,
+        message: t`Front component not found`,
+        userFriendlyMessage: msg`Front component not found`,
+      });
+
+      return validationResult;
+    }
+
+    return validationResult;
+  }
+}

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-front-component-validator.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-front-component-validator.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
 import { msg, t } from '@lingui/core/macro';
+import { isNonEmptyString } from '@sniptt/guards';
 import { ALL_METADATA_NAME } from 'twenty-shared/metadata';
 import { isDefined } from 'twenty-shared/utils';
 
@@ -28,7 +29,7 @@ export class FlatFrontComponentValidatorService {
       type: 'create',
     });
 
-    if (!isDefined(flatFrontComponent.name) || flatFrontComponent.name === '') {
+    if (!isNonEmptyString(flatFrontComponent.name)) {
       validationResult.errors.push({
         code: FrontComponentExceptionCode.INVALID_FRONT_COMPONENT_INPUT,
         message: t`Front component name is required`,

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/workspace-migration-builder-validators.module.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/workspace-migration-builder-validators.module.ts
@@ -19,6 +19,7 @@ import { FlatRowLevelPermissionPredicateGroupValidatorService } from 'src/engine
 import { FlatRowLevelPermissionPredicateValidatorService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-validator.service';
 import { FlatServerlessFunctionValidatorService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-serverless-function-validator.service';
 import { FlatSkillValidatorService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-skill-validator.service';
+import { FlatFrontComponentValidatorService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-front-component-validator.service';
 import { FlatViewFieldValidatorService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-field-validator.service';
 import { FlatViewFilterGroupValidatorService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-filter-group-validator.service';
 import { FlatViewFilterValidatorService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-view-filter-validator.service';
@@ -51,6 +52,7 @@ import { FlatViewValidatorService } from 'src/engine/workspace-manager/workspace
     FlatPageLayoutTabValidatorService,
     FlatRowLevelPermissionPredicateValidatorService,
     FlatRowLevelPermissionPredicateGroupValidatorService,
+    FlatFrontComponentValidatorService,
   ],
   exports: [
     FlatViewValidatorService,
@@ -75,6 +77,7 @@ import { FlatViewValidatorService } from 'src/engine/workspace-manager/workspace
     FlatPageLayoutTabValidatorService,
     FlatRowLevelPermissionPredicateValidatorService,
     FlatRowLevelPermissionPredicateGroupValidatorService,
+    FlatFrontComponentValidatorService,
   ],
 })
 export class WorkspaceMigrationBuilderValidatorsModule {}

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/workspace-migration-builder.module.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/workspace-migration-builder.module.ts
@@ -18,6 +18,7 @@ import { WorkspaceMigrationRowLevelPermissionPredicateGroupActionsBuilderService
 import { WorkspaceMigrationRowLevelPermissionPredicateActionsBuilderService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/row-level-permission-predicate/workspace-migration-row-level-permission-predicate-actions-builder.service';
 import { WorkspaceMigrationServerlessFunctionActionsBuilderService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/serverless-function/workspace-migration-serverless-function-actions-builder.service';
 import { WorkspaceMigrationSkillActionsBuilderService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/skill/workspace-migration-skill-actions-builder.service';
+import { WorkspaceMigrationFrontComponentActionsBuilderService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/front-component/workspace-migration-front-component-actions-builder.service';
 import { WorkspaceMigrationViewFieldActionsBuilderService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/view-field/workspace-migration-view-field-actions-builder.service';
 import { WorkspaceMigrationViewFilterGroupActionsBuilderService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/view-filter-group/workspace-migration-view-filter-group-actions-builder.service';
 import { WorkspaceMigrationViewFilterActionsBuilderService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/view-filter/workspace-migration-view-filter-actions-builder.service';
@@ -50,6 +51,7 @@ import { WorkspaceMigrationBuilderValidatorsModule } from 'src/engine/workspace-
     WorkspaceMigrationPageLayoutTabActionsBuilderService,
     WorkspaceMigrationRowLevelPermissionPredicateActionsBuilderService,
     WorkspaceMigrationRowLevelPermissionPredicateGroupActionsBuilderService,
+    WorkspaceMigrationFrontComponentActionsBuilderService,
   ],
   exports: [
     WorkspaceMigrationViewActionsBuilderService,
@@ -74,6 +76,7 @@ import { WorkspaceMigrationBuilderValidatorsModule } from 'src/engine/workspace-
     WorkspaceMigrationRowLevelPermissionPredicateActionsBuilderService,
     WorkspaceMigrationRowLevelPermissionPredicateGroupActionsBuilderService,
     FlatFieldMetadataTypeValidatorService,
+    WorkspaceMigrationFrontComponentActionsBuilderService,
   ],
 })
 export class WorkspaceMigrationBuilderModule {}

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/front-component/services/create-front-component-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/front-component/services/create-front-component-action-handler.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@nestjs/common';
+
+import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
+
+import { FrontComponentEntity } from 'src/engine/metadata-modules/front-component/entities/front-component.entity';
+import { CreateFrontComponentAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/front-component/types/workspace-migration-front-component-action.type';
+import { WorkspaceMigrationActionRunnerArgs } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/types/workspace-migration-action-runner-args.type';
+
+@Injectable()
+export class CreateFrontComponentActionHandlerService extends WorkspaceMigrationRunnerActionHandler(
+  'create',
+  'frontComponent',
+) {
+  constructor() {
+    super();
+  }
+
+  async executeForMetadata(
+    context: WorkspaceMigrationActionRunnerArgs<CreateFrontComponentAction>,
+  ): Promise<void> {
+    const { action, queryRunner, workspaceId } = context;
+    const { flatEntity } = action;
+
+    const frontComponentRepository =
+      queryRunner.manager.getRepository<FrontComponentEntity>(
+        FrontComponentEntity,
+      );
+
+    await frontComponentRepository.save({
+      ...flatEntity,
+      workspaceId,
+    });
+  }
+
+  async executeForWorkspaceSchema(
+    _context: WorkspaceMigrationActionRunnerArgs<CreateFrontComponentAction>,
+  ): Promise<void> {
+    return;
+  }
+}

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/front-component/services/create-front-component-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/front-component/services/create-front-component-action-handler.service.ts
@@ -26,7 +26,7 @@ export class CreateFrontComponentActionHandlerService extends WorkspaceMigration
         FrontComponentEntity,
       );
 
-    await frontComponentRepository.save({
+    await frontComponentRepository.insert({
       ...flatEntity,
       workspaceId,
     });

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/front-component/services/delete-front-component-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/front-component/services/delete-front-component-action-handler.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@nestjs/common';
+
+import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
+
+import { FrontComponentEntity } from 'src/engine/metadata-modules/front-component/entities/front-component.entity';
+import { DeleteFrontComponentAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/front-component/types/workspace-migration-front-component-action.type';
+import { WorkspaceMigrationActionRunnerArgs } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/types/workspace-migration-action-runner-args.type';
+
+@Injectable()
+export class DeleteFrontComponentActionHandlerService extends WorkspaceMigrationRunnerActionHandler(
+  'delete',
+  'frontComponent',
+) {
+  constructor() {
+    super();
+  }
+
+  async executeForMetadata(
+    context: WorkspaceMigrationActionRunnerArgs<DeleteFrontComponentAction>,
+  ): Promise<void> {
+    const { action, queryRunner, workspaceId } = context;
+    const { entityId } = action;
+
+    const frontComponentRepository =
+      queryRunner.manager.getRepository<FrontComponentEntity>(
+        FrontComponentEntity,
+      );
+
+    await frontComponentRepository.delete({ id: entityId, workspaceId });
+  }
+
+  async executeForWorkspaceSchema(
+    _context: WorkspaceMigrationActionRunnerArgs<DeleteFrontComponentAction>,
+  ): Promise<void> {
+    return;
+  }
+}

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/front-component/services/update-front-component-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/front-component/services/update-front-component-action-handler.service.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@nestjs/common';
+
+import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
+
+import { FrontComponentEntity } from 'src/engine/metadata-modules/front-component/entities/front-component.entity';
+import { UpdateFrontComponentAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/front-component/types/workspace-migration-front-component-action.type';
+import { WorkspaceMigrationActionRunnerArgs } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/types/workspace-migration-action-runner-args.type';
+import { fromFlatEntityPropertiesUpdatesToPartialFlatEntity } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/from-flat-entity-properties-updates-to-partial-flat-entity';
+
+@Injectable()
+export class UpdateFrontComponentActionHandlerService extends WorkspaceMigrationRunnerActionHandler(
+  'update',
+  'frontComponent',
+) {
+  async executeForMetadata(
+    context: WorkspaceMigrationActionRunnerArgs<UpdateFrontComponentAction>,
+  ): Promise<void> {
+    const { action, queryRunner, workspaceId } = context;
+    const { entityId, updates } = action;
+
+    const frontComponentRepository =
+      queryRunner.manager.getRepository<FrontComponentEntity>(
+        FrontComponentEntity,
+      );
+
+    await frontComponentRepository.update(
+      { id: entityId, workspaceId },
+      fromFlatEntityPropertiesUpdatesToPartialFlatEntity({
+        updates,
+      }),
+    );
+  }
+
+  async executeForWorkspaceSchema(
+    _context: WorkspaceMigrationActionRunnerArgs<UpdateFrontComponentAction>,
+  ): Promise<void> {
+    return;
+  }
+}

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/workspace-schema-migration-runner-action-handlers.module.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/workspace-schema-migration-runner-action-handlers.module.ts
@@ -48,6 +48,9 @@ import { DeleteServerlessFunctionActionHandlerService } from 'src/engine/workspa
 import { UpdateServerlessFunctionActionHandlerService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/serverless-function/services/update-serverless-function-action-handler.service';
 import { CreateSkillActionHandlerService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/skill/services/create-skill-action-handler.service';
 import { DeleteSkillActionHandlerService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/skill/services/delete-skill-action-handler.service';
+import { CreateFrontComponentActionHandlerService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/front-component/services/create-front-component-action-handler.service';
+import { UpdateFrontComponentActionHandlerService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/front-component/services/update-front-component-action-handler.service';
+import { DeleteFrontComponentActionHandlerService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/front-component/services/delete-front-component-action-handler.service';
 import { UpdateSkillActionHandlerService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/skill/services/update-skill-action-handler.service';
 import { CreateViewFieldActionHandlerService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/view-field/services/create-view-field-action-handler.service';
 import { DeleteViewFieldActionHandlerService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/view-field/services/delete-view-field-action-handler.service';
@@ -151,6 +154,10 @@ import { UpdateViewActionHandlerService } from 'src/engine/workspace-manager/wor
     CreateRowLevelPermissionPredicateGroupActionHandlerService,
     UpdateRowLevelPermissionPredicateGroupActionHandlerService,
     DeleteRowLevelPermissionPredicateGroupActionHandlerService,
+
+    CreateFrontComponentActionHandlerService,
+    UpdateFrontComponentActionHandlerService,
+    DeleteFrontComponentActionHandlerService,
   ],
 })
 export class WorkspaceSchemaMigrationRunnerActionHandlersModule {}

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/optimistically-apply-create-action-on-all-flat-entity-maps.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/optimistically-apply-create-action-on-all-flat-entity-maps.util.ts
@@ -68,6 +68,7 @@ export const optimisticallyApplyCreateActionOnAllFlatEntityMaps = <
     case 'skill':
     case 'pageLayout':
     case 'pageLayoutWidget':
+    case 'frontComponent':
     case 'pageLayoutTab': {
       addFlatEntityToFlatEntityAndRelatedEntityMapsThroughMutationOrThrow({
         flatEntity: action.flatEntity,

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/optimistically-apply-delete-action-on-all-flat-entity-maps.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/optimistically-apply-delete-action-on-all-flat-entity-maps.util.ts
@@ -45,6 +45,7 @@ export const optimisticallyApplyDeleteActionOnAllFlatEntityMaps = <
     case 'skill':
     case 'pageLayout':
     case 'pageLayoutWidget':
+    case 'frontComponent':
     case 'pageLayoutTab': {
       const flatEntityToDelete = findFlatEntityByIdInFlatEntityMapsOrThrow<
         MetadataFlatEntity<typeof action.metadataName>

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/optimistically-apply-update-action-on-all-flat-entity-maps.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/optimistically-apply-update-action-on-all-flat-entity-maps.util.ts
@@ -67,7 +67,8 @@ export const optimisticallyApplyUpdateActionOnAllFlatEntityMaps = <
     case 'skill':
     case 'pageLayout':
     case 'pageLayoutWidget':
-    case 'pageLayoutTab': {
+    case 'pageLayoutTab':
+    case 'frontComponent': {
       const flatEntityMapsKey = getMetadataFlatEntityMapsKey(
         action.metadataName,
       );

--- a/packages/twenty-server/test/integration/metadata/suites/front-component/__snapshots__/failing-front-component-creation.integration-spec.ts.snap
+++ b/packages/twenty-server/test/integration/metadata/suites/front-component/__snapshots__/failing-front-component-creation.integration-spec.ts.snap
@@ -1,0 +1,89 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`Front component creation should fail when name is empty 1`] = `
+{
+  "extensions": {
+    "code": "METADATA_VALIDATION_FAILED",
+    "errors": {
+      "frontComponent": [
+        {
+          "errors": [
+            {
+              "code": "INVALID_FRONT_COMPONENT_INPUT",
+              "message": "Front component name is required",
+              "userFriendlyMessage": "Front component name is required",
+            },
+          ],
+          "flatEntityMinimalInformation": {
+            "id": Any<String>,
+            "name": "",
+            "universalIdentifier": Any<String>,
+          },
+          "metadataName": "frontComponent",
+          "status": "fail",
+          "type": "create",
+        },
+      ],
+    },
+    "message": "Validation failed for 1 frontComponent",
+    "summary": {
+      "frontComponent": 1,
+      "totalErrors": 1,
+    },
+    "userFriendlyMessage": "Metadata validation failed",
+  },
+  "message": "Multiple validation errors occurred while creating front component",
+  "name": "GraphQLError",
+}
+`;
+
+exports[`Front component creation should fail when name is too long 1`] = `
+{
+  "extensions": {
+    "code": "BAD_USER_INPUT",
+    "http": {
+      "status": 400,
+    },
+    "userFriendlyMessage": "An error occurred.",
+  },
+  "message": "Expected non-nullable type "String!" not to be null.",
+  "name": "GraphQLError",
+}
+`;
+
+exports[`Front component creation should fail when name is whitespace-only 1`] = `
+{
+  "extensions": {
+    "code": "METADATA_VALIDATION_FAILED",
+    "errors": {
+      "frontComponent": [
+        {
+          "errors": [
+            {
+              "code": "INVALID_FRONT_COMPONENT_INPUT",
+              "message": "Front component name is required",
+              "userFriendlyMessage": "Front component name is required",
+            },
+          ],
+          "flatEntityMinimalInformation": {
+            "id": Any<String>,
+            "name": "",
+            "universalIdentifier": Any<String>,
+          },
+          "metadataName": "frontComponent",
+          "status": "fail",
+          "type": "create",
+        },
+      ],
+    },
+    "message": "Validation failed for 1 frontComponent",
+    "summary": {
+      "frontComponent": 1,
+      "totalErrors": 1,
+    },
+    "userFriendlyMessage": "Metadata validation failed",
+  },
+  "message": "Multiple validation errors occurred while creating front component",
+  "name": "GraphQLError",
+}
+`;

--- a/packages/twenty-server/test/integration/metadata/suites/front-component/__snapshots__/failing-front-component-deletion.integration-spec.ts.snap
+++ b/packages/twenty-server/test/integration/metadata/suites/front-component/__snapshots__/failing-front-component-deletion.integration-spec.ts.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`Front component deletion should fail when front component does not exist 1`] = `
+{
+  "extensions": {
+    "code": "NOT_FOUND",
+    "subCode": "FRONT_COMPONENT_NOT_FOUND",
+    "userFriendlyMessage": "Front component not found.",
+  },
+  "message": "Front component not found",
+  "name": "NotFoundError",
+}
+`;

--- a/packages/twenty-server/test/integration/metadata/suites/front-component/__snapshots__/failing-front-component-update.integration-spec.ts.snap
+++ b/packages/twenty-server/test/integration/metadata/suites/front-component/__snapshots__/failing-front-component-update.integration-spec.ts.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`Front component update should fail when front component does not exist 1`] = `
+{
+  "extensions": {
+    "code": "NOT_FOUND",
+    "subCode": "FRONT_COMPONENT_NOT_FOUND",
+    "userFriendlyMessage": "Front component not found.",
+  },
+  "message": "Front component not found",
+  "name": "NotFoundError",
+}
+`;

--- a/packages/twenty-server/test/integration/metadata/suites/front-component/failing-front-component-creation.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/front-component/failing-front-component-creation.integration-spec.ts
@@ -1,0 +1,27 @@
+import { createFrontComponent } from 'test/integration/metadata/suites/front-component/utils/create-front-component.util';
+
+describe('Front component creation should fail', () => {
+  it('should fail when creating a front component with empty name', async () => {
+    const { errors } = await createFrontComponent({
+      expectToFail: true,
+      input: {
+        name: '',
+      },
+    });
+
+    expect(errors).toBeDefined();
+    expect(errors?.length).toBeGreaterThan(0);
+  });
+
+  it('should fail when creating a front component with whitespace-only name', async () => {
+    const { errors } = await createFrontComponent({
+      expectToFail: true,
+      input: {
+        name: '   ',
+      },
+    });
+
+    expect(errors).toBeDefined();
+    expect(errors?.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/twenty-server/test/integration/metadata/suites/front-component/failing-front-component-creation.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/front-component/failing-front-component-creation.integration-spec.ts
@@ -1,27 +1,49 @@
+import { expectOneNotInternalServerErrorSnapshot } from 'test/integration/graphql/utils/expect-one-not-internal-server-error-snapshot.util';
 import { createFrontComponent } from 'test/integration/metadata/suites/front-component/utils/create-front-component.util';
+import {
+  type EachTestingContext,
+  eachTestingContextFilter,
+} from 'twenty-shared/testing';
+
+import { type CreateFrontComponentInput } from 'src/engine/metadata-modules/front-component/dtos/create-front-component.input';
+
+type TestContext = {
+  name: string | null;
+};
+
+const FAILING_TEST_CASES: EachTestingContext<TestContext>[] = [
+  {
+    title: 'when name is empty',
+    context: {
+      name: '',
+    },
+  },
+  {
+    title: 'when name is whitespace-only',
+    context: {
+      name: '   ',
+    },
+  },
+  {
+    title: 'when name is too long',
+    context: {
+      name: null,
+    },
+  },
+];
 
 describe('Front component creation should fail', () => {
-  it('should fail when creating a front component with empty name', async () => {
-    const { errors } = await createFrontComponent({
-      expectToFail: true,
-      input: {
-        name: '',
-      },
-    });
+  it.each(eachTestingContextFilter(FAILING_TEST_CASES))(
+    '$title',
+    async ({ context }) => {
+      const { errors } = await createFrontComponent({
+        expectToFail: true,
+        input: {
+          name: context.name,
+        } as CreateFrontComponentInput,
+      });
 
-    expect(errors).toBeDefined();
-    expect(errors?.length).toBeGreaterThan(0);
-  });
-
-  it('should fail when creating a front component with whitespace-only name', async () => {
-    const { errors } = await createFrontComponent({
-      expectToFail: true,
-      input: {
-        name: '   ',
-      },
-    });
-
-    expect(errors).toBeDefined();
-    expect(errors?.length).toBeGreaterThan(0);
-  });
+      expectOneNotInternalServerErrorSnapshot({ errors });
+    },
+  );
 });

--- a/packages/twenty-server/test/integration/metadata/suites/front-component/failing-front-component-deletion.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/front-component/failing-front-component-deletion.integration-spec.ts
@@ -1,16 +1,34 @@
+import { expectOneNotInternalServerErrorSnapshot } from 'test/integration/graphql/utils/expect-one-not-internal-server-error-snapshot.util';
 import { deleteFrontComponent } from 'test/integration/metadata/suites/front-component/utils/delete-front-component.util';
+import {
+  type EachTestingContext,
+  eachTestingContextFilter,
+} from 'twenty-shared/testing';
 import { v4 } from 'uuid';
 
+type TestContext = {
+  id: string;
+};
+
+const FAILING_TEST_CASES: EachTestingContext<TestContext>[] = [
+  {
+    title: 'when front component does not exist',
+    context: {
+      id: v4(),
+    },
+  },
+];
+
 describe('Front component deletion should fail', () => {
-  it('should fail when deleting a non-existent front component', async () => {
-    const nonExistentId = v4();
+  it.each(eachTestingContextFilter(FAILING_TEST_CASES))(
+    '$title',
+    async ({ context }) => {
+      const { errors } = await deleteFrontComponent({
+        expectToFail: true,
+        input: { id: context.id },
+      });
 
-    const { errors } = await deleteFrontComponent({
-      expectToFail: true,
-      input: { id: nonExistentId },
-    });
-
-    expect(errors).toBeDefined();
-    expect(errors?.length).toBeGreaterThan(0);
-  });
+      expectOneNotInternalServerErrorSnapshot({ errors });
+    },
+  );
 });

--- a/packages/twenty-server/test/integration/metadata/suites/front-component/failing-front-component-deletion.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/front-component/failing-front-component-deletion.integration-spec.ts
@@ -1,6 +1,5 @@
-import { v4 } from 'uuid';
-
 import { deleteFrontComponent } from 'test/integration/metadata/suites/front-component/utils/delete-front-component.util';
+import { v4 } from 'uuid';
 
 describe('Front component deletion should fail', () => {
   it('should fail when deleting a non-existent front component', async () => {

--- a/packages/twenty-server/test/integration/metadata/suites/front-component/failing-front-component-deletion.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/front-component/failing-front-component-deletion.integration-spec.ts
@@ -1,0 +1,17 @@
+import { v4 } from 'uuid';
+
+import { deleteFrontComponent } from 'test/integration/metadata/suites/front-component/utils/delete-front-component.util';
+
+describe('Front component deletion should fail', () => {
+  it('should fail when deleting a non-existent front component', async () => {
+    const nonExistentId = v4();
+
+    const { errors } = await deleteFrontComponent({
+      expectToFail: true,
+      input: { id: nonExistentId },
+    });
+
+    expect(errors).toBeDefined();
+    expect(errors?.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/twenty-server/test/integration/metadata/suites/front-component/failing-front-component-update.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/front-component/failing-front-component-update.integration-spec.ts
@@ -1,6 +1,5 @@
-import { v4 } from 'uuid';
-
 import { updateFrontComponent } from 'test/integration/metadata/suites/front-component/utils/update-front-component.util';
+import { v4 } from 'uuid';
 
 describe('Front component update should fail', () => {
   it('should fail when updating a non-existent front component', async () => {

--- a/packages/twenty-server/test/integration/metadata/suites/front-component/failing-front-component-update.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/front-component/failing-front-component-update.integration-spec.ts
@@ -9,7 +9,9 @@ describe('Front component update should fail', () => {
       expectToFail: true,
       input: {
         id: nonExistentId,
-        name: 'updatedName',
+        update: {
+          name: 'updatedName',
+        },
       },
     });
 

--- a/packages/twenty-server/test/integration/metadata/suites/front-component/failing-front-component-update.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/front-component/failing-front-component-update.integration-spec.ts
@@ -1,21 +1,41 @@
+import { expectOneNotInternalServerErrorSnapshot } from 'test/integration/graphql/utils/expect-one-not-internal-server-error-snapshot.util';
 import { updateFrontComponent } from 'test/integration/metadata/suites/front-component/utils/update-front-component.util';
+import {
+  type EachTestingContext,
+  eachTestingContextFilter,
+} from 'twenty-shared/testing';
 import { v4 } from 'uuid';
 
+type TestContext = {
+  id: string;
+  name: string;
+};
+
+const FAILING_TEST_CASES: EachTestingContext<TestContext>[] = [
+  {
+    title: 'when front component does not exist',
+    context: {
+      id: v4(),
+      name: 'updatedName',
+    },
+  },
+];
+
 describe('Front component update should fail', () => {
-  it('should fail when updating a non-existent front component', async () => {
-    const nonExistentId = v4();
-
-    const { errors } = await updateFrontComponent({
-      expectToFail: true,
-      input: {
-        id: nonExistentId,
-        update: {
-          name: 'updatedName',
+  it.each(eachTestingContextFilter(FAILING_TEST_CASES))(
+    '$title',
+    async ({ context }) => {
+      const { errors } = await updateFrontComponent({
+        expectToFail: true,
+        input: {
+          id: context.id,
+          update: {
+            name: context.name,
+          },
         },
-      },
-    });
+      });
 
-    expect(errors).toBeDefined();
-    expect(errors?.length).toBeGreaterThan(0);
-  });
+      expectOneNotInternalServerErrorSnapshot({ errors });
+    },
+  );
 });

--- a/packages/twenty-server/test/integration/metadata/suites/front-component/failing-front-component-update.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/front-component/failing-front-component-update.integration-spec.ts
@@ -1,0 +1,20 @@
+import { v4 } from 'uuid';
+
+import { updateFrontComponent } from 'test/integration/metadata/suites/front-component/utils/update-front-component.util';
+
+describe('Front component update should fail', () => {
+  it('should fail when updating a non-existent front component', async () => {
+    const nonExistentId = v4();
+
+    const { errors } = await updateFrontComponent({
+      expectToFail: true,
+      input: {
+        id: nonExistentId,
+        name: 'updatedName',
+      },
+    });
+
+    expect(errors).toBeDefined();
+    expect(errors?.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/twenty-server/test/integration/metadata/suites/front-component/successful-front-component-creation.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/front-component/successful-front-component-creation.integration-spec.ts
@@ -2,7 +2,7 @@ import { createFrontComponent } from 'test/integration/metadata/suites/front-com
 import { deleteFrontComponent } from 'test/integration/metadata/suites/front-component/utils/delete-front-component.util';
 
 describe('Front component creation should succeed', () => {
-  let createdFrontComponentId: string;
+  let createdFrontComponentId: string | undefined;
 
   afterEach(async () => {
     if (createdFrontComponentId) {
@@ -10,7 +10,7 @@ describe('Front component creation should succeed', () => {
         expectToFail: false,
         input: { id: createdFrontComponentId },
       });
-      createdFrontComponentId = '';
+      createdFrontComponentId = undefined;
     }
   });
 

--- a/packages/twenty-server/test/integration/metadata/suites/front-component/successful-front-component-creation.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/front-component/successful-front-component-creation.integration-spec.ts
@@ -10,6 +10,7 @@ describe('Front component creation should succeed', () => {
         expectToFail: false,
         input: { id: createdFrontComponentId },
       });
+      createdFrontComponentId = '';
     }
   });
 

--- a/packages/twenty-server/test/integration/metadata/suites/front-component/successful-front-component-creation.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/front-component/successful-front-component-creation.integration-spec.ts
@@ -1,0 +1,47 @@
+import { createFrontComponent } from 'test/integration/metadata/suites/front-component/utils/create-front-component.util';
+import { deleteFrontComponent } from 'test/integration/metadata/suites/front-component/utils/delete-front-component.util';
+
+describe('Front component creation should succeed', () => {
+  let createdFrontComponentId: string;
+
+  afterEach(async () => {
+    if (createdFrontComponentId) {
+      await deleteFrontComponent({
+        expectToFail: false,
+        input: { id: createdFrontComponentId },
+      });
+    }
+  });
+
+  it('should create a basic front component with minimal input', async () => {
+    const { data } = await createFrontComponent({
+      expectToFail: false,
+      input: {
+        name: 'testFrontComponent',
+      },
+    });
+
+    createdFrontComponentId = data?.createFrontComponent?.id;
+
+    expect(data.createFrontComponent).toMatchObject({
+      id: expect.any(String),
+      name: 'testFrontComponent',
+    });
+  });
+
+  it('should sanitize input by trimming whitespace', async () => {
+    const { data } = await createFrontComponent({
+      expectToFail: false,
+      input: {
+        name: '  frontComponentWithSpaces  ',
+      },
+    });
+
+    createdFrontComponentId = data?.createFrontComponent?.id;
+
+    expect(data.createFrontComponent).toMatchObject({
+      id: expect.any(String),
+      name: 'frontComponentWithSpaces',
+    });
+  });
+});

--- a/packages/twenty-server/test/integration/metadata/suites/front-component/successful-front-component-deletion.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/front-component/successful-front-component-deletion.integration-spec.ts
@@ -1,0 +1,40 @@
+import { createFrontComponent } from 'test/integration/metadata/suites/front-component/utils/create-front-component.util';
+import { deleteFrontComponent } from 'test/integration/metadata/suites/front-component/utils/delete-front-component.util';
+import { findFrontComponent } from 'test/integration/metadata/suites/front-component/utils/find-front-component.util';
+
+describe('Front component deletion should succeed', () => {
+  it('should successfully delete a front component', async () => {
+    const { data: createData } = await createFrontComponent({
+      expectToFail: false,
+      input: {
+        name: 'frontComponentToDelete',
+      },
+    });
+
+    const frontComponentId = createData.createFrontComponent.id;
+
+    const { data: findBeforeData } = await findFrontComponent({
+      expectToFail: false,
+      input: { id: frontComponentId },
+    });
+
+    expect(findBeforeData.frontComponent.id).toBe(frontComponentId);
+
+    const { data: deleteData } = await deleteFrontComponent({
+      expectToFail: false,
+      input: { id: frontComponentId },
+    });
+
+    expect(deleteData.deleteFrontComponent).toMatchObject({
+      id: frontComponentId,
+      name: 'frontComponentToDelete',
+    });
+
+    const { data: findAfterData } = await findFrontComponent({
+      expectToFail: false,
+      input: { id: frontComponentId },
+    });
+
+    expect(findAfterData.frontComponent).toBeNull();
+  });
+});

--- a/packages/twenty-server/test/integration/metadata/suites/front-component/successful-front-component-update.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/front-component/successful-front-component-update.integration-spec.ts
@@ -1,9 +1,12 @@
 import { createFrontComponent } from 'test/integration/metadata/suites/front-component/utils/create-front-component.util';
+import { type DeleteFrontComponentFactoryInput } from 'test/integration/metadata/suites/front-component/utils/delete-front-component-query-factory.util';
 import { deleteFrontComponent } from 'test/integration/metadata/suites/front-component/utils/delete-front-component.util';
 import { updateFrontComponent } from 'test/integration/metadata/suites/front-component/utils/update-front-component.util';
 
+import { type UpdateFrontComponentInput } from 'src/engine/metadata-modules/front-component/dtos/update-front-component.input';
+
 describe('Front component update should succeed', () => {
-  let testFrontComponentId: string;
+  let testFrontComponentId: string | undefined;
 
   beforeEach(async () => {
     const { data } = await createFrontComponent({
@@ -19,8 +22,9 @@ describe('Front component update should succeed', () => {
   afterEach(async () => {
     await deleteFrontComponent({
       expectToFail: false,
-      input: { id: testFrontComponentId },
+      input: { id: testFrontComponentId } as DeleteFrontComponentFactoryInput,
     });
+    testFrontComponentId = undefined;
   });
 
   it('should update front component name', async () => {
@@ -31,7 +35,7 @@ describe('Front component update should succeed', () => {
         update: {
           name: 'updatedFrontComponentName',
         },
-      },
+      } as UpdateFrontComponentInput,
     });
 
     expect(data.updateFrontComponent).toMatchObject({

--- a/packages/twenty-server/test/integration/metadata/suites/front-component/successful-front-component-update.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/front-component/successful-front-component-update.integration-spec.ts
@@ -1,9 +1,7 @@
 import { createFrontComponent } from 'test/integration/metadata/suites/front-component/utils/create-front-component.util';
-import { type DeleteFrontComponentFactoryInput } from 'test/integration/metadata/suites/front-component/utils/delete-front-component-query-factory.util';
 import { deleteFrontComponent } from 'test/integration/metadata/suites/front-component/utils/delete-front-component.util';
 import { updateFrontComponent } from 'test/integration/metadata/suites/front-component/utils/update-front-component.util';
-
-import { type UpdateFrontComponentInput } from 'src/engine/metadata-modules/front-component/dtos/update-front-component.input';
+import { isDefined } from 'twenty-shared/utils';
 
 describe('Front component update should succeed', () => {
   let testFrontComponentId: string | undefined;
@@ -20,14 +18,20 @@ describe('Front component update should succeed', () => {
   });
 
   afterEach(async () => {
-    await deleteFrontComponent({
-      expectToFail: false,
-      input: { id: testFrontComponentId } as DeleteFrontComponentFactoryInput,
-    });
-    testFrontComponentId = undefined;
+    if (isDefined(testFrontComponentId)) {
+      await deleteFrontComponent({
+        expectToFail: false,
+        input: { id: testFrontComponentId },
+      });
+      testFrontComponentId = undefined;
+    }
   });
 
   it('should update front component name', async () => {
+    if (!isDefined(testFrontComponentId)) {
+      throw new Error('testFrontComponentId should be defined');
+    }
+
     const { data } = await updateFrontComponent({
       expectToFail: false,
       input: {
@@ -35,7 +39,7 @@ describe('Front component update should succeed', () => {
         update: {
           name: 'updatedFrontComponentName',
         },
-      } as UpdateFrontComponentInput,
+      },
     });
 
     expect(data.updateFrontComponent).toMatchObject({

--- a/packages/twenty-server/test/integration/metadata/suites/front-component/successful-front-component-update.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/front-component/successful-front-component-update.integration-spec.ts
@@ -1,0 +1,40 @@
+import { createFrontComponent } from 'test/integration/metadata/suites/front-component/utils/create-front-component.util';
+import { deleteFrontComponent } from 'test/integration/metadata/suites/front-component/utils/delete-front-component.util';
+import { updateFrontComponent } from 'test/integration/metadata/suites/front-component/utils/update-front-component.util';
+
+describe('Front component update should succeed', () => {
+  let testFrontComponentId: string;
+
+  beforeEach(async () => {
+    const { data } = await createFrontComponent({
+      expectToFail: false,
+      input: {
+        name: 'testFrontComponentToUpdate',
+      },
+    });
+
+    testFrontComponentId = data.createFrontComponent.id;
+  });
+
+  afterEach(async () => {
+    await deleteFrontComponent({
+      expectToFail: false,
+      input: { id: testFrontComponentId },
+    });
+  });
+
+  it('should update front component name', async () => {
+    const { data } = await updateFrontComponent({
+      expectToFail: false,
+      input: {
+        id: testFrontComponentId,
+        name: 'updatedFrontComponentName',
+      },
+    });
+
+    expect(data.updateFrontComponent).toMatchObject({
+      id: testFrontComponentId,
+      name: 'updatedFrontComponentName',
+    });
+  });
+});

--- a/packages/twenty-server/test/integration/metadata/suites/front-component/successful-front-component-update.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/front-component/successful-front-component-update.integration-spec.ts
@@ -28,7 +28,9 @@ describe('Front component update should succeed', () => {
       expectToFail: false,
       input: {
         id: testFrontComponentId,
-        name: 'updatedFrontComponentName',
+        update: {
+          name: 'updatedFrontComponentName',
+        },
       },
     });
 

--- a/packages/twenty-server/test/integration/metadata/suites/front-component/utils/create-front-component-query-factory.util.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/front-component/utils/create-front-component-query-factory.util.ts
@@ -1,0 +1,30 @@
+import gql from 'graphql-tag';
+import { type PerformMetadataQueryParams } from 'test/integration/metadata/types/perform-metadata-query.type';
+
+import { type CreateFrontComponentInput } from 'src/engine/metadata-modules/front-component/dtos/create-front-component.input';
+
+export type CreateFrontComponentFactoryInput = CreateFrontComponentInput;
+
+const DEFAULT_FRONT_COMPONENT_GQL_FIELDS = `
+  id
+  name
+  applicationId
+  createdAt
+  updatedAt
+`;
+
+export const createFrontComponentQueryFactory = ({
+  input,
+  gqlFields = DEFAULT_FRONT_COMPONENT_GQL_FIELDS,
+}: PerformMetadataQueryParams<CreateFrontComponentFactoryInput>) => ({
+  query: gql`
+    mutation CreateFrontComponent($input: CreateFrontComponentInput!) {
+      createFrontComponent(input: $input) {
+        ${gqlFields}
+      }
+    }
+  `,
+  variables: {
+    input,
+  },
+});

--- a/packages/twenty-server/test/integration/metadata/suites/front-component/utils/create-front-component.util.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/front-component/utils/create-front-component.util.ts
@@ -1,0 +1,43 @@
+import {
+  type CreateFrontComponentFactoryInput,
+  createFrontComponentQueryFactory,
+} from 'test/integration/metadata/suites/front-component/utils/create-front-component-query-factory.util';
+import { makeMetadataAPIRequest } from 'test/integration/metadata/suites/utils/make-metadata-api-request.util';
+import { type CommonResponseBody } from 'test/integration/metadata/types/common-response-body.type';
+import { type PerformMetadataQueryParams } from 'test/integration/metadata/types/perform-metadata-query.type';
+import { warnIfErrorButNotExpectedToFail } from 'test/integration/metadata/utils/warn-if-error-but-not-expected-to-fail.util';
+import { warnIfNoErrorButExpectedToFail } from 'test/integration/metadata/utils/warn-if-no-error-but-expected-to-fail.util';
+
+import { type FrontComponentDTO } from 'src/engine/metadata-modules/front-component/dtos/front-component.dto';
+
+export const createFrontComponent = async ({
+  input,
+  gqlFields,
+  expectToFail = false,
+  token,
+}: PerformMetadataQueryParams<CreateFrontComponentFactoryInput>): CommonResponseBody<{
+  createFrontComponent: FrontComponentDTO;
+}> => {
+  const graphqlOperation = createFrontComponentQueryFactory({
+    input,
+    gqlFields,
+  });
+
+  const response = await makeMetadataAPIRequest(graphqlOperation, token);
+
+  if (expectToFail === true) {
+    warnIfNoErrorButExpectedToFail({
+      response,
+      errorMessage: 'Front component creation should have failed but did not',
+    });
+  }
+
+  if (expectToFail === false) {
+    warnIfErrorButNotExpectedToFail({
+      response,
+      errorMessage: 'Front component creation has failed but should not',
+    });
+  }
+
+  return { data: response.body.data, errors: response.body.errors };
+};

--- a/packages/twenty-server/test/integration/metadata/suites/front-component/utils/create-front-component.util.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/front-component/utils/create-front-component.util.ts
@@ -8,7 +8,7 @@ import { type PerformMetadataQueryParams } from 'test/integration/metadata/types
 import { warnIfErrorButNotExpectedToFail } from 'test/integration/metadata/utils/warn-if-error-but-not-expected-to-fail.util';
 import { warnIfNoErrorButExpectedToFail } from 'test/integration/metadata/utils/warn-if-no-error-but-expected-to-fail.util';
 
-import { type CreateFrontComponentInput } from 'src/engine/metadata-modules/front-component/dtos/create-front-component.input';
+import { type FrontComponentDTO } from 'src/engine/metadata-modules/front-component/dtos/front-component.dto';
 
 export const createFrontComponent = async ({
   input,
@@ -16,7 +16,7 @@ export const createFrontComponent = async ({
   expectToFail = false,
   token,
 }: PerformMetadataQueryParams<CreateFrontComponentFactoryInput>): CommonResponseBody<{
-  createFrontComponent: CreateFrontComponentInput;
+  createFrontComponent: FrontComponentDTO;
 }> => {
   const graphqlOperation = createFrontComponentQueryFactory({
     input,

--- a/packages/twenty-server/test/integration/metadata/suites/front-component/utils/create-front-component.util.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/front-component/utils/create-front-component.util.ts
@@ -8,7 +8,7 @@ import { type PerformMetadataQueryParams } from 'test/integration/metadata/types
 import { warnIfErrorButNotExpectedToFail } from 'test/integration/metadata/utils/warn-if-error-but-not-expected-to-fail.util';
 import { warnIfNoErrorButExpectedToFail } from 'test/integration/metadata/utils/warn-if-no-error-but-expected-to-fail.util';
 
-import { type FrontComponentDTO } from 'src/engine/metadata-modules/front-component/dtos/front-component.dto';
+import { type CreateFrontComponentInput } from 'src/engine/metadata-modules/front-component/dtos/create-front-component.input';
 
 export const createFrontComponent = async ({
   input,
@@ -16,7 +16,7 @@ export const createFrontComponent = async ({
   expectToFail = false,
   token,
 }: PerformMetadataQueryParams<CreateFrontComponentFactoryInput>): CommonResponseBody<{
-  createFrontComponent: FrontComponentDTO;
+  createFrontComponent: CreateFrontComponentInput;
 }> => {
   const graphqlOperation = createFrontComponentQueryFactory({
     input,

--- a/packages/twenty-server/test/integration/metadata/suites/front-component/utils/delete-front-component-query-factory.util.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/front-component/utils/delete-front-component-query-factory.util.ts
@@ -1,0 +1,27 @@
+import gql from 'graphql-tag';
+import { type PerformMetadataQueryParams } from 'test/integration/metadata/types/perform-metadata-query.type';
+
+export type DeleteFrontComponentFactoryInput = {
+  id: string;
+};
+
+const DEFAULT_FRONT_COMPONENT_GQL_FIELDS = `
+  id
+  name
+`;
+
+export const deleteFrontComponentQueryFactory = ({
+  input,
+  gqlFields = DEFAULT_FRONT_COMPONENT_GQL_FIELDS,
+}: PerformMetadataQueryParams<DeleteFrontComponentFactoryInput>) => ({
+  query: gql`
+    mutation DeleteFrontComponent($id: UUID!) {
+      deleteFrontComponent(id: $id) {
+        ${gqlFields}
+      }
+    }
+  `,
+  variables: {
+    id: input.id,
+  },
+});

--- a/packages/twenty-server/test/integration/metadata/suites/front-component/utils/delete-front-component.util.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/front-component/utils/delete-front-component.util.ts
@@ -1,0 +1,43 @@
+import {
+  type DeleteFrontComponentFactoryInput,
+  deleteFrontComponentQueryFactory,
+} from 'test/integration/metadata/suites/front-component/utils/delete-front-component-query-factory.util';
+import { makeMetadataAPIRequest } from 'test/integration/metadata/suites/utils/make-metadata-api-request.util';
+import { type CommonResponseBody } from 'test/integration/metadata/types/common-response-body.type';
+import { type PerformMetadataQueryParams } from 'test/integration/metadata/types/perform-metadata-query.type';
+import { warnIfErrorButNotExpectedToFail } from 'test/integration/metadata/utils/warn-if-error-but-not-expected-to-fail.util';
+import { warnIfNoErrorButExpectedToFail } from 'test/integration/metadata/utils/warn-if-no-error-but-expected-to-fail.util';
+
+import { type FrontComponentDTO } from 'src/engine/metadata-modules/front-component/dtos/front-component.dto';
+
+export const deleteFrontComponent = async ({
+  input,
+  gqlFields,
+  expectToFail = false,
+  token,
+}: PerformMetadataQueryParams<DeleteFrontComponentFactoryInput>): CommonResponseBody<{
+  deleteFrontComponent: FrontComponentDTO;
+}> => {
+  const graphqlOperation = deleteFrontComponentQueryFactory({
+    input,
+    gqlFields,
+  });
+
+  const response = await makeMetadataAPIRequest(graphqlOperation, token);
+
+  if (expectToFail === true) {
+    warnIfNoErrorButExpectedToFail({
+      response,
+      errorMessage: 'Front component deletion should have failed but did not',
+    });
+  }
+
+  if (expectToFail === false) {
+    warnIfErrorButNotExpectedToFail({
+      response,
+      errorMessage: 'Front component deletion has failed but should not',
+    });
+  }
+
+  return { data: response.body.data, errors: response.body.errors };
+};

--- a/packages/twenty-server/test/integration/metadata/suites/front-component/utils/delete-front-component.util.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/front-component/utils/delete-front-component.util.ts
@@ -8,13 +8,15 @@ import { type PerformMetadataQueryParams } from 'test/integration/metadata/types
 import { warnIfErrorButNotExpectedToFail } from 'test/integration/metadata/utils/warn-if-error-but-not-expected-to-fail.util';
 import { warnIfNoErrorButExpectedToFail } from 'test/integration/metadata/utils/warn-if-no-error-but-expected-to-fail.util';
 
+import { type FrontComponentDTO } from 'src/engine/metadata-modules/front-component/dtos/front-component.dto';
+
 export const deleteFrontComponent = async ({
   input,
   gqlFields,
   expectToFail = false,
   token,
 }: PerformMetadataQueryParams<DeleteFrontComponentFactoryInput>): CommonResponseBody<{
-  deleteFrontComponent: DeleteFrontComponentFactoryInput;
+  deleteFrontComponent: FrontComponentDTO;
 }> => {
   const graphqlOperation = deleteFrontComponentQueryFactory({
     input,

--- a/packages/twenty-server/test/integration/metadata/suites/front-component/utils/delete-front-component.util.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/front-component/utils/delete-front-component.util.ts
@@ -8,15 +8,13 @@ import { type PerformMetadataQueryParams } from 'test/integration/metadata/types
 import { warnIfErrorButNotExpectedToFail } from 'test/integration/metadata/utils/warn-if-error-but-not-expected-to-fail.util';
 import { warnIfNoErrorButExpectedToFail } from 'test/integration/metadata/utils/warn-if-no-error-but-expected-to-fail.util';
 
-import { type FrontComponentDTO } from 'src/engine/metadata-modules/front-component/dtos/front-component.dto';
-
 export const deleteFrontComponent = async ({
   input,
   gqlFields,
   expectToFail = false,
   token,
 }: PerformMetadataQueryParams<DeleteFrontComponentFactoryInput>): CommonResponseBody<{
-  deleteFrontComponent: FrontComponentDTO;
+  deleteFrontComponent: DeleteFrontComponentFactoryInput;
 }> => {
   const graphqlOperation = deleteFrontComponentQueryFactory({
     input,

--- a/packages/twenty-server/test/integration/metadata/suites/front-component/utils/find-front-component-query-factory.util.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/front-component/utils/find-front-component-query-factory.util.ts
@@ -1,0 +1,30 @@
+import gql from 'graphql-tag';
+import { type PerformMetadataQueryParams } from 'test/integration/metadata/types/perform-metadata-query.type';
+
+export type FindFrontComponentFactoryInput = {
+  id: string;
+};
+
+const DEFAULT_FRONT_COMPONENT_GQL_FIELDS = `
+  id
+  name
+  applicationId
+  createdAt
+  updatedAt
+`;
+
+export const findFrontComponentQueryFactory = ({
+  input,
+  gqlFields = DEFAULT_FRONT_COMPONENT_GQL_FIELDS,
+}: PerformMetadataQueryParams<FindFrontComponentFactoryInput>) => ({
+  query: gql`
+    query FrontComponent($id: UUID!) {
+      frontComponent(id: $id) {
+        ${gqlFields}
+      }
+    }
+  `,
+  variables: {
+    id: input.id,
+  },
+});

--- a/packages/twenty-server/test/integration/metadata/suites/front-component/utils/find-front-component.util.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/front-component/utils/find-front-component.util.ts
@@ -1,0 +1,43 @@
+import {
+  type FindFrontComponentFactoryInput,
+  findFrontComponentQueryFactory,
+} from 'test/integration/metadata/suites/front-component/utils/find-front-component-query-factory.util';
+import { makeMetadataAPIRequest } from 'test/integration/metadata/suites/utils/make-metadata-api-request.util';
+import { type CommonResponseBody } from 'test/integration/metadata/types/common-response-body.type';
+import { type PerformMetadataQueryParams } from 'test/integration/metadata/types/perform-metadata-query.type';
+import { warnIfErrorButNotExpectedToFail } from 'test/integration/metadata/utils/warn-if-error-but-not-expected-to-fail.util';
+import { warnIfNoErrorButExpectedToFail } from 'test/integration/metadata/utils/warn-if-no-error-but-expected-to-fail.util';
+
+import { type FrontComponentDTO } from 'src/engine/metadata-modules/front-component/dtos/front-component.dto';
+
+export const findFrontComponent = async ({
+  input,
+  gqlFields,
+  expectToFail = false,
+  token,
+}: PerformMetadataQueryParams<FindFrontComponentFactoryInput>): CommonResponseBody<{
+  frontComponent: FrontComponentDTO;
+}> => {
+  const graphqlOperation = findFrontComponentQueryFactory({
+    input,
+    gqlFields,
+  });
+
+  const response = await makeMetadataAPIRequest(graphqlOperation, token);
+
+  if (expectToFail === true) {
+    warnIfNoErrorButExpectedToFail({
+      response,
+      errorMessage: 'Finding front component should have failed but did not',
+    });
+  }
+
+  if (expectToFail === false) {
+    warnIfErrorButNotExpectedToFail({
+      response,
+      errorMessage: 'Finding front component has failed but should not',
+    });
+  }
+
+  return { data: response.body.data, errors: response.body.errors };
+};

--- a/packages/twenty-server/test/integration/metadata/suites/front-component/utils/find-front-components-query-factory.util.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/front-component/utils/find-front-components-query-factory.util.ts
@@ -1,0 +1,22 @@
+import gql from 'graphql-tag';
+import { type PerformMetadataQueryParams } from 'test/integration/metadata/types/perform-metadata-query.type';
+
+const DEFAULT_FRONT_COMPONENT_GQL_FIELDS = `
+  id
+  name
+  applicationId
+  createdAt
+  updatedAt
+`;
+
+export const findFrontComponentsQueryFactory = ({
+  gqlFields = DEFAULT_FRONT_COMPONENT_GQL_FIELDS,
+}: PerformMetadataQueryParams<void>) => ({
+  query: gql`
+    query FrontComponents {
+      frontComponents {
+        ${gqlFields}
+      }
+    }
+  `,
+});

--- a/packages/twenty-server/test/integration/metadata/suites/front-component/utils/find-front-components.util.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/front-component/utils/find-front-components.util.ts
@@ -1,0 +1,39 @@
+import { findFrontComponentsQueryFactory } from 'test/integration/metadata/suites/front-component/utils/find-front-components-query-factory.util';
+import { makeMetadataAPIRequest } from 'test/integration/metadata/suites/utils/make-metadata-api-request.util';
+import { type CommonResponseBody } from 'test/integration/metadata/types/common-response-body.type';
+import { type PerformMetadataQueryParams } from 'test/integration/metadata/types/perform-metadata-query.type';
+import { warnIfErrorButNotExpectedToFail } from 'test/integration/metadata/utils/warn-if-error-but-not-expected-to-fail.util';
+import { warnIfNoErrorButExpectedToFail } from 'test/integration/metadata/utils/warn-if-no-error-but-expected-to-fail.util';
+
+import { type FrontComponentDTO } from 'src/engine/metadata-modules/front-component/dtos/front-component.dto';
+
+export const findFrontComponents = async ({
+  gqlFields,
+  expectToFail = false,
+  token,
+}: PerformMetadataQueryParams<undefined>): CommonResponseBody<{
+  frontComponents: FrontComponentDTO[];
+}> => {
+  const graphqlOperation = findFrontComponentsQueryFactory({
+    gqlFields,
+    input: undefined,
+  });
+
+  const response = await makeMetadataAPIRequest(graphqlOperation, token);
+
+  if (expectToFail === true) {
+    warnIfNoErrorButExpectedToFail({
+      response,
+      errorMessage: 'Finding front components should have failed but did not',
+    });
+  }
+
+  if (expectToFail === false) {
+    warnIfErrorButNotExpectedToFail({
+      response,
+      errorMessage: 'Finding front components has failed but should not',
+    });
+  }
+
+  return { data: response.body.data, errors: response.body.errors };
+};

--- a/packages/twenty-server/test/integration/metadata/suites/front-component/utils/update-front-component-query-factory.util.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/front-component/utils/update-front-component-query-factory.util.ts
@@ -1,0 +1,30 @@
+import gql from 'graphql-tag';
+import { type PerformMetadataQueryParams } from 'test/integration/metadata/types/perform-metadata-query.type';
+
+import { type UpdateFrontComponentInput } from 'src/engine/metadata-modules/front-component/dtos/update-front-component.input';
+
+export type UpdateFrontComponentFactoryInput = UpdateFrontComponentInput;
+
+const DEFAULT_FRONT_COMPONENT_GQL_FIELDS = `
+  id
+  name
+  applicationId
+  createdAt
+  updatedAt
+`;
+
+export const updateFrontComponentQueryFactory = ({
+  gqlFields = DEFAULT_FRONT_COMPONENT_GQL_FIELDS,
+  input,
+}: PerformMetadataQueryParams<UpdateFrontComponentFactoryInput>) => ({
+  query: gql`
+    mutation UpdateFrontComponent($input: UpdateFrontComponentInput!) {
+      updateFrontComponent(input: $input) {
+        ${gqlFields}
+      }
+    }
+  `,
+  variables: {
+    input,
+  },
+});

--- a/packages/twenty-server/test/integration/metadata/suites/front-component/utils/update-front-component.util.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/front-component/utils/update-front-component.util.ts
@@ -1,0 +1,43 @@
+import {
+  type UpdateFrontComponentFactoryInput,
+  updateFrontComponentQueryFactory,
+} from 'test/integration/metadata/suites/front-component/utils/update-front-component-query-factory.util';
+import { makeMetadataAPIRequest } from 'test/integration/metadata/suites/utils/make-metadata-api-request.util';
+import { type CommonResponseBody } from 'test/integration/metadata/types/common-response-body.type';
+import { type PerformMetadataQueryParams } from 'test/integration/metadata/types/perform-metadata-query.type';
+import { warnIfErrorButNotExpectedToFail } from 'test/integration/metadata/utils/warn-if-error-but-not-expected-to-fail.util';
+import { warnIfNoErrorButExpectedToFail } from 'test/integration/metadata/utils/warn-if-no-error-but-expected-to-fail.util';
+
+import { type FrontComponentDTO } from 'src/engine/metadata-modules/front-component/dtos/front-component.dto';
+
+export const updateFrontComponent = async ({
+  input,
+  gqlFields,
+  expectToFail = false,
+  token,
+}: PerformMetadataQueryParams<UpdateFrontComponentFactoryInput>): CommonResponseBody<{
+  updateFrontComponent: FrontComponentDTO;
+}> => {
+  const graphqlOperation = updateFrontComponentQueryFactory({
+    input,
+    gqlFields,
+  });
+
+  const response = await makeMetadataAPIRequest(graphqlOperation, token);
+
+  if (expectToFail === true) {
+    warnIfNoErrorButExpectedToFail({
+      response,
+      errorMessage: 'Front component update should have failed but did not',
+    });
+  }
+
+  if (expectToFail === false) {
+    warnIfErrorButNotExpectedToFail({
+      response,
+      errorMessage: 'Front component update has failed but should not',
+    });
+  }
+
+  return { data: response.body.data, errors: response.body.errors };
+};

--- a/packages/twenty-server/test/integration/metadata/suites/skill/successful-skill-deletion.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/skill/successful-skill-deletion.integration-spec.ts
@@ -1,6 +1,7 @@
 import { createSkill } from 'test/integration/metadata/suites/skill/utils/create-skill.util';
 import { deleteSkill } from 'test/integration/metadata/suites/skill/utils/delete-skill.util';
 import { findSkill } from 'test/integration/metadata/suites/skill/utils/find-skill.util';
+import { isDefined } from 'twenty-shared/utils';
 
 describe('Skill deletion should succeed', () => {
   it('should successfully delete a custom skill', async () => {
@@ -14,6 +15,10 @@ describe('Skill deletion should succeed', () => {
     });
 
     const skillId = createData.createSkill.id;
+
+    if (!isDefined(skillId)) {
+      return;
+    }
 
     const { data: findBeforeData } = await findSkill({
       expectToFail: false,

--- a/packages/twenty-server/test/integration/metadata/suites/skill/successful-skill-update.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/skill/successful-skill-update.integration-spec.ts
@@ -5,13 +5,9 @@ import { deleteSkill } from 'test/integration/metadata/suites/skill/utils/delete
 import { updateSkill } from 'test/integration/metadata/suites/skill/utils/update-skill.util';
 
 describe('Skill update should succeed', () => {
-  let testSkillId: string | undefined;
+  let testSkillId: string;
 
   beforeEach(async () => {
-    await deleteSkill({
-      expectToFail: false,
-      input: { id: testSkillId ?? '' },
-    });
     const { data } = await createSkill({
       expectToFail: false,
       input: {
@@ -29,7 +25,7 @@ describe('Skill update should succeed', () => {
   afterEach(async () => {
     await deleteSkill({
       expectToFail: false,
-      input: { id: testSkillId ?? '' },
+      input: { id: testSkillId },
     });
   });
 
@@ -37,7 +33,7 @@ describe('Skill update should succeed', () => {
     const { data } = await updateSkill({
       expectToFail: false,
       input: {
-        id: testSkillId ?? '',
+        id: testSkillId,
         label: 'Updated Skill Label',
       },
     });
@@ -55,13 +51,13 @@ describe('Skill update should succeed', () => {
     const { data } = await updateSkill({
       expectToFail: false,
       input: {
-        id: testSkillId ?? '',
+        id: testSkillId,
         description: 'Updated description',
       },
     });
 
     expect(data.updateSkill).toMatchObject({
-      id: testSkillId ?? '',
+      id: testSkillId,
       label: 'Test Skill To Update',
       description: 'Updated description',
     });
@@ -71,7 +67,7 @@ describe('Skill update should succeed', () => {
     const { data } = await updateSkill({
       expectToFail: false,
       input: {
-        id: testSkillId ?? '',
+        id: testSkillId,
         icon: 'IconRobot',
       },
     });
@@ -88,13 +84,13 @@ describe('Skill update should succeed', () => {
     const { data } = await updateSkill({
       expectToFail: false,
       input: {
-        id: testSkillId ?? '',
+        id: testSkillId,
         content: newContent,
       },
     });
 
     expect(data.updateSkill).toMatchObject({
-      id: testSkillId ?? '',
+      id: testSkillId,
       content: newContent,
     });
   });
@@ -103,7 +99,7 @@ describe('Skill update should succeed', () => {
     const { data } = await updateSkill({
       expectToFail: false,
       input: {
-        id: testSkillId ?? '',
+        id: testSkillId,
         label: 'Completely Updated Skill',
         description: 'Completely updated description',
         icon: 'IconBrain',
@@ -112,7 +108,7 @@ describe('Skill update should succeed', () => {
     });
 
     expect(data.updateSkill).toMatchObject({
-      id: testSkillId ?? '',
+      id: testSkillId,
       label: 'Completely Updated Skill',
       description: 'Completely updated description',
       icon: 'IconBrain',

--- a/packages/twenty-server/test/integration/metadata/suites/skill/successful-skill-update.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/skill/successful-skill-update.integration-spec.ts
@@ -1,9 +1,12 @@
+import { afterEach } from 'node:test';
+
 import { createSkill } from 'test/integration/metadata/suites/skill/utils/create-skill.util';
 import { deleteSkill } from 'test/integration/metadata/suites/skill/utils/delete-skill.util';
 import { updateSkill } from 'test/integration/metadata/suites/skill/utils/update-skill.util';
+import { isDefined } from 'twenty-shared/utils';
 
 describe('Skill update should succeed', () => {
-  let testSkillId: string;
+  let testSkillId: string | undefined;
 
   beforeEach(async () => {
     const { data } = await createSkill({
@@ -21,31 +24,39 @@ describe('Skill update should succeed', () => {
   });
 
   afterEach(async () => {
-    await deleteSkill({
-      expectToFail: false,
-      input: { id: testSkillId },
-    });
+    if (isDefined(testSkillId)) {
+      await deleteSkill({
+        expectToFail: false,
+        input: { id: testSkillId },
+      });
+    }
   });
 
   it('should update skill label', async () => {
-    const { data } = await updateSkill({
-      expectToFail: false,
-      input: {
+    if (isDefined(testSkillId)) {
+      const { data } = await updateSkill({
+        expectToFail: false,
+        input: {
+          id: testSkillId,
+          label: 'Updated Skill Label',
+        },
+      });
+
+      expect(data.updateSkill).toMatchObject({
         id: testSkillId,
         label: 'Updated Skill Label',
-      },
-    });
-
-    expect(data.updateSkill).toMatchObject({
-      id: testSkillId,
-      label: 'Updated Skill Label',
-      description: 'Original description',
-      icon: 'IconSparkles',
-      content: 'Original content',
-    });
+        description: 'Original description',
+        icon: 'IconSparkles',
+        content: 'Original content',
+      });
+    }
   });
 
   it('should update skill description', async () => {
+    if (!isDefined(testSkillId)) {
+      return;
+    }
+
     const { data } = await updateSkill({
       expectToFail: false,
       input: {
@@ -62,6 +73,10 @@ describe('Skill update should succeed', () => {
   });
 
   it('should update skill icon', async () => {
+    if (!isDefined(testSkillId)) {
+      return;
+    }
+
     const { data } = await updateSkill({
       expectToFail: false,
       input: {
@@ -79,6 +94,10 @@ describe('Skill update should succeed', () => {
   it('should update skill content', async () => {
     const newContent = 'Updated content with new instructions';
 
+    if (!isDefined(testSkillId)) {
+      return;
+    }
+
     const { data } = await updateSkill({
       expectToFail: false,
       input: {
@@ -94,6 +113,10 @@ describe('Skill update should succeed', () => {
   });
 
   it('should update multiple fields at once', async () => {
+    if (!isDefined(testSkillId)) {
+      return;
+    }
+
     const { data } = await updateSkill({
       expectToFail: false,
       input: {
@@ -115,6 +138,10 @@ describe('Skill update should succeed', () => {
   });
 
   it('should update label to a unique value', async () => {
+    if (!isDefined(testSkillId)) {
+      return;
+    }
+
     const { data } = await updateSkill({
       expectToFail: false,
       input: {

--- a/packages/twenty-server/test/integration/metadata/suites/skill/successful-skill-update.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/skill/successful-skill-update.integration-spec.ts
@@ -3,12 +3,15 @@ import { afterEach } from 'node:test';
 import { createSkill } from 'test/integration/metadata/suites/skill/utils/create-skill.util';
 import { deleteSkill } from 'test/integration/metadata/suites/skill/utils/delete-skill.util';
 import { updateSkill } from 'test/integration/metadata/suites/skill/utils/update-skill.util';
-import { isDefined } from 'twenty-shared/utils';
 
 describe('Skill update should succeed', () => {
   let testSkillId: string | undefined;
 
   beforeEach(async () => {
+    await deleteSkill({
+      expectToFail: false,
+      input: { id: testSkillId ?? '' },
+    });
     const { data } = await createSkill({
       expectToFail: false,
       input: {
@@ -24,63 +27,51 @@ describe('Skill update should succeed', () => {
   });
 
   afterEach(async () => {
-    if (isDefined(testSkillId)) {
-      await deleteSkill({
-        expectToFail: false,
-        input: { id: testSkillId },
-      });
-    }
+    await deleteSkill({
+      expectToFail: false,
+      input: { id: testSkillId ?? '' },
+    });
   });
 
   it('should update skill label', async () => {
-    if (isDefined(testSkillId)) {
-      const { data } = await updateSkill({
-        expectToFail: false,
-        input: {
-          id: testSkillId,
-          label: 'Updated Skill Label',
-        },
-      });
-
-      expect(data.updateSkill).toMatchObject({
-        id: testSkillId,
-        label: 'Updated Skill Label',
-        description: 'Original description',
-        icon: 'IconSparkles',
-        content: 'Original content',
-      });
-    }
-  });
-
-  it('should update skill description', async () => {
-    if (!isDefined(testSkillId)) {
-      return;
-    }
-
     const { data } = await updateSkill({
       expectToFail: false,
       input: {
-        id: testSkillId,
-        description: 'Updated description',
+        id: testSkillId ?? '',
+        label: 'Updated Skill Label',
       },
     });
 
     expect(data.updateSkill).toMatchObject({
       id: testSkillId,
+      label: 'Updated Skill Label',
+      description: 'Original description',
+      icon: 'IconSparkles',
+      content: 'Original content',
+    });
+  });
+
+  it('should update skill description', async () => {
+    const { data } = await updateSkill({
+      expectToFail: false,
+      input: {
+        id: testSkillId ?? '',
+        description: 'Updated description',
+      },
+    });
+
+    expect(data.updateSkill).toMatchObject({
+      id: testSkillId ?? '',
       label: 'Test Skill To Update',
       description: 'Updated description',
     });
   });
 
   it('should update skill icon', async () => {
-    if (!isDefined(testSkillId)) {
-      return;
-    }
-
     const { data } = await updateSkill({
       expectToFail: false,
       input: {
-        id: testSkillId,
+        id: testSkillId ?? '',
         icon: 'IconRobot',
       },
     });
@@ -94,33 +85,25 @@ describe('Skill update should succeed', () => {
   it('should update skill content', async () => {
     const newContent = 'Updated content with new instructions';
 
-    if (!isDefined(testSkillId)) {
-      return;
-    }
-
     const { data } = await updateSkill({
       expectToFail: false,
       input: {
-        id: testSkillId,
+        id: testSkillId ?? '',
         content: newContent,
       },
     });
 
     expect(data.updateSkill).toMatchObject({
-      id: testSkillId,
+      id: testSkillId ?? '',
       content: newContent,
     });
   });
 
   it('should update multiple fields at once', async () => {
-    if (!isDefined(testSkillId)) {
-      return;
-    }
-
     const { data } = await updateSkill({
       expectToFail: false,
       input: {
-        id: testSkillId,
+        id: testSkillId ?? '',
         label: 'Completely Updated Skill',
         description: 'Completely updated description',
         icon: 'IconBrain',
@@ -129,7 +112,7 @@ describe('Skill update should succeed', () => {
     });
 
     expect(data.updateSkill).toMatchObject({
-      id: testSkillId,
+      id: testSkillId ?? '',
       label: 'Completely Updated Skill',
       description: 'Completely updated description',
       icon: 'IconBrain',
@@ -138,14 +121,10 @@ describe('Skill update should succeed', () => {
   });
 
   it('should update label to a unique value', async () => {
-    if (!isDefined(testSkillId)) {
-      return;
-    }
-
     const { data } = await updateSkill({
       expectToFail: false,
       input: {
-        id: testSkillId,
+        id: testSkillId ?? '',
         label: 'Unique Updated Label',
       },
     });

--- a/packages/twenty-server/test/integration/metadata/suites/skill/successful-skill-update.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/skill/successful-skill-update.integration-spec.ts
@@ -1,5 +1,3 @@
-import { afterEach } from 'node:test';
-
 import { createSkill } from 'test/integration/metadata/suites/skill/utils/create-skill.util';
 import { deleteSkill } from 'test/integration/metadata/suites/skill/utils/delete-skill.util';
 import { updateSkill } from 'test/integration/metadata/suites/skill/utils/update-skill.util';
@@ -120,7 +118,7 @@ describe('Skill update should succeed', () => {
     const { data } = await updateSkill({
       expectToFail: false,
       input: {
-        id: testSkillId ?? '',
+        id: testSkillId,
         label: 'Unique Updated Label',
       },
     });

--- a/packages/twenty-server/test/integration/metadata/suites/skill/utils/create-skill.util.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/skill/utils/create-skill.util.ts
@@ -8,7 +8,7 @@ import { type PerformMetadataQueryParams } from 'test/integration/metadata/types
 import { warnIfErrorButNotExpectedToFail } from 'test/integration/metadata/utils/warn-if-error-but-not-expected-to-fail.util';
 import { warnIfNoErrorButExpectedToFail } from 'test/integration/metadata/utils/warn-if-no-error-but-expected-to-fail.util';
 
-import { type SkillDTO } from 'src/engine/metadata-modules/skill/dtos/skill.dto';
+import { type CreateSkillInput } from 'src/engine/metadata-modules/skill/dtos/create-skill.input';
 
 export const createSkill = async ({
   input,
@@ -16,7 +16,7 @@ export const createSkill = async ({
   expectToFail = false,
   token,
 }: PerformMetadataQueryParams<CreateSkillFactoryInput>): CommonResponseBody<{
-  createSkill: SkillDTO;
+  createSkill: CreateSkillInput;
 }> => {
   const graphqlOperation = createSkillQueryFactory({
     input,

--- a/packages/twenty-server/test/integration/metadata/suites/skill/utils/create-skill.util.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/skill/utils/create-skill.util.ts
@@ -8,7 +8,7 @@ import { type PerformMetadataQueryParams } from 'test/integration/metadata/types
 import { warnIfErrorButNotExpectedToFail } from 'test/integration/metadata/utils/warn-if-error-but-not-expected-to-fail.util';
 import { warnIfNoErrorButExpectedToFail } from 'test/integration/metadata/utils/warn-if-no-error-but-expected-to-fail.util';
 
-import { type CreateSkillInput } from 'src/engine/metadata-modules/skill/dtos/create-skill.input';
+import { type SkillDTO } from 'src/engine/metadata-modules/skill/dtos/skill.dto';
 
 export const createSkill = async ({
   input,
@@ -16,7 +16,7 @@ export const createSkill = async ({
   expectToFail = false,
   token,
 }: PerformMetadataQueryParams<CreateSkillFactoryInput>): CommonResponseBody<{
-  createSkill: CreateSkillInput;
+  createSkill: SkillDTO;
 }> => {
   const graphqlOperation = createSkillQueryFactory({
     input,

--- a/packages/twenty-shared/src/metadata/all-metadata-name.constant.ts
+++ b/packages/twenty-shared/src/metadata/all-metadata-name.constant.ts
@@ -20,4 +20,5 @@ export const ALL_METADATA_NAME = {
   pageLayout: 'pageLayout',
   pageLayoutWidget: 'pageLayoutWidget',
   pageLayoutTab: 'pageLayoutTab',
+  frontComponent: 'frontComponent',
 } as const;


### PR DESCRIPTION
As part of the extensibility effort, we are introducing a new engine entity called "Front Component". This represents a dynamic react component that will be rendered in CommandMenu actions or in PageLayout widgets

This PR introduce the entity and all the necessary boilerplate to make it syncable and cachable in the engine