### PR TITLE
Add get current workflow version tool

### DIFF
--- a/packages/twenty-server/src/modules/workflow/workflow-tools/services/workflow-tool.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/services/workflow-tool.workspace-service.ts
@@ -23,6 +23,7 @@ import { createCreateWorkflowVersionStepTool } from 'src/modules/workflow/workfl
 import { createDeactivateWorkflowVersionTool } from 'src/modules/workflow/workflow-tools/tools/deactivate-workflow-version.tool';
 import { createDeleteWorkflowVersionEdgeTool } from 'src/modules/workflow/workflow-tools/tools/delete-workflow-version-edge.tool';
 import { createDeleteWorkflowVersionStepTool } from 'src/modules/workflow/workflow-tools/tools/delete-workflow-version-step.tool';
+import { createGetWorkflowCurrentVersionTool } from 'src/modules/workflow/workflow-tools/tools/get-workflow-current-version.tool';
 import { createUpdateWorkflowVersionPositionsTool } from 'src/modules/workflow/workflow-tools/tools/update-workflow-version-positions.tool';
 import { createUpdateWorkflowVersionStepTool } from 'src/modules/workflow/workflow-tools/tools/update-workflow-version-step.tool';
 import { type WorkflowToolDependencies } from 'src/modules/workflow/workflow-tools/types/workflow-tool-dependencies.type';
@@ -106,6 +107,10 @@ export class WorkflowToolWorkspaceService {
       this.deps,
       context,
     );
+    const getWorkflowCurrentVersion = createGetWorkflowCurrentVersionTool(
+      this.deps,
+      context,
+    );
 
     return {
       [createCompleteWorkflow.name]: createCompleteWorkflow,
@@ -119,6 +124,7 @@ export class WorkflowToolWorkspaceService {
       [activateWorkflowVersion.name]: activateWorkflowVersion,
       [deactivateWorkflowVersion.name]: deactivateWorkflowVersion,
       [computeStepOutputSchema.name]: computeStepOutputSchema,
+      [getWorkflowCurrentVersion.name]: getWorkflowCurrentVersion,
     };
   }
 

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/get-workflow-current-version.tool.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/get-workflow-current-version.tool.ts
@@ -1,0 +1,115 @@
+import { isDefined } from 'twenty-shared/utils';
+import { z } from 'zod';
+
+import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
+import {
+  WorkflowVersionStatus,
+  type WorkflowVersionWorkspaceEntity,
+} from 'src/modules/workflow/common/standard-objects/workflow-version.workspace-entity';
+import { type WorkflowWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow.workspace-entity';
+import {
+  type WorkflowToolContext,
+  type WorkflowToolDependencies,
+} from 'src/modules/workflow/workflow-tools/types/workflow-tool-dependencies.type';
+
+const getWorkflowCurrentVersionSchema = z.object({
+  workflowId: z
+    .string()
+    .describe('The ID of the workflow to get the current version for'),
+});
+
+type GetWorkflowCurrentVersionInput = z.infer<
+  typeof getWorkflowCurrentVersionSchema
+>;
+
+export const createGetWorkflowCurrentVersionTool = (
+  deps: Pick<WorkflowToolDependencies, 'globalWorkspaceOrmManager'>,
+  context: WorkflowToolContext,
+) => ({
+  name: 'get_workflow_current_version' as const,
+  description:
+    'Get the current version of a workflow. Returns the draft version if one exists, otherwise the last published version.',
+  inputSchema: getWorkflowCurrentVersionSchema,
+  execute: async (parameters: GetWorkflowCurrentVersionInput) => {
+    try {
+      const authContext = buildSystemAuthContext(context.workspaceId);
+
+      return await deps.globalWorkspaceOrmManager.executeInWorkspaceContext(
+        authContext,
+        async () => {
+          const workflowRepository =
+            await deps.globalWorkspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
+              context.workspaceId,
+              'workflow',
+              { shouldBypassPermissionChecks: true },
+            );
+
+          const workflow = await workflowRepository.findOne({
+            where: { id: parameters.workflowId },
+          });
+
+          if (!isDefined(workflow)) {
+            return {
+              success: false,
+              error: `Workflow ${parameters.workflowId} not found`,
+            };
+          }
+
+          const workflowVersionRepository =
+            await deps.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+              context.workspaceId,
+              'workflowVersion',
+              { shouldBypassPermissionChecks: true },
+            );
+
+          const versions = await workflowVersionRepository.find({
+            where: [
+              {
+                workflowId: parameters.workflowId,
+                status: WorkflowVersionStatus.DRAFT,
+              },
+              {
+                workflowId: parameters.workflowId,
+                status: WorkflowVersionStatus.ACTIVE,
+              },
+            ],
+          });
+
+          const draftVersion = versions.find(
+            (version) => version.status === WorkflowVersionStatus.DRAFT,
+          );
+          const activeVersion = versions.find(
+            (version) => version.status === WorkflowVersionStatus.ACTIVE,
+          );
+
+          const currentVersion = draftVersion ?? activeVersion;
+
+          if (!isDefined(currentVersion)) {
+            return {
+              success: false,
+              error: `Workflow ${parameters.workflowId} has no draft or active version`,
+            };
+          }
+
+          return {
+            success: true,
+            workflowVersion: {
+              id: currentVersion.id,
+              name: currentVersion.name,
+              status: currentVersion.status,
+              trigger: currentVersion.trigger,
+              steps: currentVersion.steps,
+              workflowId: currentVersion.workflowId,
+            },
+          };
+        },
+      );
+    } catch (error) {
+      return {
+        success: false,
+        error: error.message,
+        message: `Failed to get workflow current version: ${error.message}`,
+      };
+    }
+  },
+});


### PR DESCRIPTION
This is required so an agent can easily understand what version should be updated from the workflow show page.