### PR TITLE
Enable multiworkspace and limit workspace creation to server admins

### DIFF
--- a/packages/twenty-server/.env.example
+++ b/packages/twenty-server/.env.example
@@ -7,6 +7,7 @@ SIGN_IN_PREFILLED=true
 CODE_INTERPRETER_TYPE=local
 
 FRONTEND_URL=http://localhost:3001
+IS_MULTIWORKSPACE_ENABLED=true
 
 # ———————— Optional ————————
 # PORT=3000

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
@@ -375,7 +375,7 @@ export class ConfigVariables {
     type: ConfigVariableType.BOOLEAN,
   })
   @IsOptional()
-  IS_WORKSPACE_CREATION_LIMITED_TO_SERVER_ADMINS = false;
+  IS_WORKSPACE_CREATION_LIMITED_TO_SERVER_ADMINS = true;
 
   @ConfigVariablesMetadata({
     group: ConfigVariablesGroup.STORAGE_CONFIG,


### PR DESCRIPTION
## Summary
- Added `IS_MULTIWORKSPACE_ENABLED=true` to `.env.example` for easier development setup
- Changed `IS_WORKSPACE_CREATION_LIMITED_TO_SERVER_ADMINS` default to `true` for improved security

## Test plan
- [ ] Verify multiworkspace functionality works with the new default
- [ ] Confirm workspace creation is properly restricted to server admins

🤖 Generated with [Claude Code](https://claude.com/claude-code)