### PR TITLE
[Dashboards] [ai] expand widget schemas with subfield grouping, color, and styling options

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/skill-metadata/create-standard-flat-skill-metadata.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/skill-metadata/create-standard-flat-skill-metadata.util.ts
@@ -164,9 +164,9 @@ Users describe charts using UI terminology. Here's how to translate:
 **Y axis section (what's being measured + optional secondary grouping):**
 - "Y axis" / "data on display" / "measure" / "metric": aggregateFieldMetadataId + aggregateOperation
 - "Group by" / "stacking" / "colors" / "breakdown": secondaryAxisGroupByFieldMetadataId
-- "Date granularity" (on Group by): secondaryAxisDateGranularity
+- "Date granularity" (on Group by): secondaryAxisGroupByDateGranularity
 - "Sort by" (on Group by): secondaryAxisOrderBy
-- "Cumulative" / "running total": cumulative
+- "Cumulative" / "running total": isCumulative
 - "Min range" / "Max range": rangeMin, rangeMax
 
 **Style section:**
@@ -220,7 +220,7 @@ Required:
 - configuration.aggregateFieldMetadataId: field to aggregate
 - configuration.aggregateOperation: aggregation type
 - configuration.primaryAxisGroupByFieldMetadataId: X axis (usually date)
-Optional: secondaryAxisGroupByFieldMetadataId (for multiple lines), cumulative, displayDataLabel, filter
+Optional: secondaryAxisGroupByFieldMetadataId (for multiple lines), isCumulative, displayDataLabel, filter
 
 ### PIE_CHART
 Shows data distribution as slices.

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/skill-metadata/create-standard-flat-skill-metadata.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/skill-metadata/create-standard-flat-skill-metadata.util.ts
@@ -154,20 +154,22 @@ Users describe charts using UI terminology. Here's how to translate:
 
 **Data section:**
 - "Source" / "change the object": objectMetadataId
-- "Filter" / "filter the data": configuration.filter
 
 **X axis section (primary grouping - the bars/categories):**
 - "X axis" / "data on display" / "categories": primaryAxisGroupByFieldMetadataId
+- "X axis subfield" / "Address.city": primaryAxisGroupBySubFieldName
 - "Date granularity" (on X axis): primaryAxisDateGranularity
 - "Sort by" (on X axis): primaryAxisOrderBy
 
 **Y axis section (what's being measured + optional secondary grouping):**
 - "Y axis" / "data on display" / "measure" / "metric": aggregateFieldMetadataId + aggregateOperation
 - "Group by" / "stacking" / "colors" / "breakdown": secondaryAxisGroupByFieldMetadataId
+- "Group by subfield" / "Address.city": secondaryAxisGroupBySubFieldName
 - "Date granularity" (on Group by): secondaryAxisGroupByDateGranularity
 - "Sort by" (on Group by): secondaryAxisOrderBy
 - "Cumulative" / "running total": isCumulative
 - "Min range" / "Max range": rangeMin, rangeMax
+- "Hide empty values" / "omit nulls": omitNullValues
 
 **Style section:**
 - "Stacked" / "stacked bars": layout stays same, it's about secondaryAxisGroupByFieldMetadataId
@@ -183,12 +185,14 @@ When users say this for bar/line charts, they mean remove the SECONDARY grouping
 
 ### Pie Chart Settings
 - "Each slice represents" / "slices": groupByFieldMetadataId
+- "Slice subfield" / "Address.city": groupBySubFieldName
 - "Hide empty category": hideEmptyCategory
 - "Show value in center": showValueInCenter
 
 ### Aggregate Chart Settings (KPI numbers)
 - "Prefix" (e.g., "$"): prefix
 - "Suffix" (e.g., "%"): suffix
+- "Ratio by option" / "percent of a value": ratioAggregateConfig
 
 ## Widget Configuration Types
 
@@ -199,7 +203,7 @@ Required:
 - configuration.configurationType: "AGGREGATE_CHART"
 - configuration.aggregateFieldMetadataId: UUID of field to aggregate
 - configuration.aggregateOperation: "COUNT", "SUM", "AVG", "MIN", "MAX"
-Optional: prefix, suffix, displayDataLabel, filter
+Optional: prefix, suffix, displayDataLabel, ratioAggregateConfig
 
 ### BAR_CHART
 Shows data grouped by categories with optional secondary grouping.
@@ -210,7 +214,7 @@ Required:
 - configuration.aggregateOperation: aggregation type
 - configuration.primaryAxisGroupByFieldMetadataId: X axis categories
 - configuration.layout: "VERTICAL" or "HORIZONTAL"
-Optional: secondaryAxisGroupByFieldMetadataId (for stacking/colors), displayDataLabel, displayLegend, filter
+Optional: secondaryAxisGroupByFieldMetadataId (for stacking/colors), primaryAxisGroupBySubFieldName, secondaryAxisGroupBySubFieldName, omitNullValues, displayDataLabel, displayLegend
 
 ### LINE_CHART
 Shows trends over a dimension.
@@ -220,7 +224,7 @@ Required:
 - configuration.aggregateFieldMetadataId: field to aggregate
 - configuration.aggregateOperation: aggregation type
 - configuration.primaryAxisGroupByFieldMetadataId: X axis (usually date)
-Optional: secondaryAxisGroupByFieldMetadataId (for multiple lines), isCumulative, displayDataLabel, filter
+Optional: secondaryAxisGroupByFieldMetadataId (for multiple lines), primaryAxisGroupBySubFieldName, secondaryAxisGroupBySubFieldName, omitNullValues, isCumulative, displayDataLabel
 
 ### PIE_CHART
 Shows data distribution as slices.
@@ -230,7 +234,7 @@ Required:
 - configuration.aggregateFieldMetadataId: field to aggregate
 - configuration.aggregateOperation: aggregation type
 - configuration.groupByFieldMetadataId: field to slice by (NOTE: different field name than bar/line!)
-Optional: displayDataLabel, hideEmptyCategory, showValueInCenter, filter
+Optional: groupBySubFieldName, displayDataLabel, hideEmptyCategory, showValueInCenter
 
 ### IFRAME
 Embeds external content:

--- a/packages/twenty-server/src/modules/dashboard/tools/schemas/widget.schema.ts
+++ b/packages/twenty-server/src/modules/dashboard/tools/schemas/widget.schema.ts
@@ -358,9 +358,6 @@ const richTextConfigSchema = z.object({
       blocknote: z.string().nullable().optional(),
       markdown: z.string().nullable().optional(),
     })
-    .refine((value) => value.blocknote != null || value.markdown != null, {
-      message: 'body must include blocknote or markdown',
-    })
     .describe('Rich text content (RichTextV2Body)'),
 });
 

--- a/packages/twenty-server/src/modules/dashboard/tools/schemas/widget.schema.ts
+++ b/packages/twenty-server/src/modules/dashboard/tools/schemas/widget.schema.ts
@@ -1,3 +1,4 @@
+import { isNumber } from '@sniptt/guards';
 import { ObjectRecordGroupByDateGranularity } from 'twenty-shared/types';
 import { z } from 'zod';
 
@@ -153,8 +154,8 @@ const withRangeMinMaxRefinement = <T extends z.ZodType<RangeMinMaxFields>>(
   schema.refine(
     (data) =>
       !(
-        typeof data.rangeMin === 'number' &&
-        typeof data.rangeMax === 'number' &&
+        isNumber(data.rangeMin) &&
+        isNumber(data.rangeMax) &&
         data.rangeMin > data.rangeMax
       ),
     {

--- a/packages/twenty-server/src/modules/dashboard/tools/schemas/widget.schema.ts
+++ b/packages/twenty-server/src/modules/dashboard/tools/schemas/widget.schema.ts
@@ -105,6 +105,11 @@ type RangeMinMaxFields = {
   rangeMax?: number;
 };
 
+const ratioAggregateConfigSchema = z.object({
+  fieldMetadataId: z.uuid(),
+  optionValue: z.string(),
+});
+
 const withPrimarySecondaryManualSortRefinements = <
   T extends z.ZodType<PrimarySecondaryManualSortFields>,
 >(
@@ -197,11 +202,11 @@ const aggregateChartConfigSchemaBase = z.object({
   aggregateOperation: z
     .enum(AGGREGATE_OPERATION_OPTIONS)
     .describe('Aggregation operation: COUNT, SUM, AVG, MIN, MAX, etc.'),
-  displayDataLabel: displayDataLabelSchema,
   label: z.string().optional(),
+  displayDataLabel: displayDataLabelSchema,
   prefix: z.string().optional(),
   suffix: z.string().optional(),
-  filter: z.record(z.string(), z.unknown()).optional(),
+  ratioAggregateConfig: ratioAggregateConfigSchema.optional(),
 });
 
 const aggregateChartConfigSchema = aggregateChartConfigSchemaBase.extend({
@@ -219,11 +224,14 @@ const barChartConfigSchemaCore = z.object({
   primaryAxisGroupByFieldMetadataId: z
     .uuid()
     .describe('Field UUID to group by on primary axis'),
+  primaryAxisGroupBySubFieldName: z.string().optional(),
   secondaryAxisGroupByFieldMetadataId: z.uuid().optional(),
+  secondaryAxisGroupBySubFieldName: z.string().optional(),
   primaryAxisOrderBy: z.enum(GRAPH_ORDER_BY_OPTIONS).optional(),
   primaryAxisManualSortOrder: z.array(z.string()).optional(),
   secondaryAxisOrderBy: z.enum(GRAPH_ORDER_BY_OPTIONS).optional(),
   secondaryAxisManualSortOrder: z.array(z.string()).optional(),
+  omitNullValues: z.boolean().optional(),
   primaryAxisDateGranularity: z
     .enum(DATE_GRANULARITY_OPTIONS)
     .optional()
@@ -249,7 +257,6 @@ const barChartConfigSchemaCore = z.object({
   layout: z
     .enum(BAR_CHART_LAYOUT_OPTIONS)
     .describe('Layout orientation for bar charts'),
-  filter: z.record(z.string(), z.unknown()).optional(),
 });
 
 const barChartConfigSchemaWithoutDefaults = withRangeMinMaxRefinement(
@@ -271,11 +278,14 @@ const lineChartConfigSchemaCore = z.object({
   aggregateFieldMetadataId: z.uuid(),
   aggregateOperation: z.enum(AGGREGATE_OPERATION_OPTIONS),
   primaryAxisGroupByFieldMetadataId: z.uuid(),
+  primaryAxisGroupBySubFieldName: z.string().optional(),
   secondaryAxisGroupByFieldMetadataId: z.uuid().optional(),
+  secondaryAxisGroupBySubFieldName: z.string().optional(),
   primaryAxisOrderBy: z.enum(GRAPH_ORDER_BY_OPTIONS).optional(),
   primaryAxisManualSortOrder: z.array(z.string()).optional(),
   secondaryAxisOrderBy: z.enum(GRAPH_ORDER_BY_OPTIONS).optional(),
   secondaryAxisManualSortOrder: z.array(z.string()).optional(),
+  omitNullValues: z.boolean().optional(),
   primaryAxisDateGranularity: z
     .enum(DATE_GRANULARITY_OPTIONS)
     .optional()
@@ -295,7 +305,6 @@ const lineChartConfigSchemaCore = z.object({
   isCumulative: z.boolean().optional().describe('Show running totals'),
   rangeMin: z.number().optional().describe('Y axis minimum value'),
   rangeMax: z.number().optional().describe('Y axis maximum value'),
-  filter: z.record(z.string(), z.unknown()).optional(),
 });
 
 const lineChartConfigSchemaWithoutDefaults = withRangeMinMaxRefinement(
@@ -317,6 +326,7 @@ const pieChartConfigSchemaCore = z.object({
   aggregateFieldMetadataId: z.uuid(),
   aggregateOperation: z.enum(AGGREGATE_OPERATION_OPTIONS),
   groupByFieldMetadataId: z.uuid().describe('Field UUID to slice by'),
+  groupBySubFieldName: z.string().optional(),
   orderBy: z.enum(GRAPH_ORDER_BY_OPTIONS).optional(),
   manualSortOrder: z.array(z.string()).optional(),
   dateGranularity: z
@@ -328,7 +338,6 @@ const pieChartConfigSchemaCore = z.object({
   displayLegend: displayLegendSchema,
   showCenterMetric: showCenterMetricSchema,
   hideEmptyCategory: hideEmptyCategorySchema,
-  filter: z.record(z.string(), z.unknown()).optional(),
 });
 
 const pieChartConfigSchemaWithoutDefaults = withManualSortRefinement(

--- a/packages/twenty-server/src/modules/dashboard/tools/schemas/widget.schema.ts
+++ b/packages/twenty-server/src/modules/dashboard/tools/schemas/widget.schema.ts
@@ -1,8 +1,167 @@
+import { ObjectRecordGroupByDateGranularity } from 'twenty-shared/types';
 import { z } from 'zod';
 
 import { AggregateOperations } from 'src/engine/api/graphql/graphql-query-runner/constants/aggregate-operations.constant';
+import { AxisNameDisplay } from 'src/engine/metadata-modules/page-layout-widget/enums/axis-name-display.enum';
+import { BarChartGroupMode } from 'src/engine/metadata-modules/page-layout-widget/enums/bar-chart-group-mode.enum';
+import { BarChartLayout } from 'src/engine/metadata-modules/page-layout-widget/enums/bar-chart-layout.enum';
+import { GraphOrderBy } from 'src/engine/metadata-modules/page-layout-widget/enums/graph-order-by.enum';
 import { WidgetConfigurationType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
 import { WidgetType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-type.enum';
+
+// Chart color options (MAIN_COLOR_NAMES plus 'auto').
+// should we export MAIN_COLOR_NAMES from twenty-ui to twenty-shared and use that here?
+const CHART_COLORS = [
+  'auto',
+  'red',
+  'ruby',
+  'crimson',
+  'tomato',
+  'orange',
+  'amber',
+  'yellow',
+  'lime',
+  'grass',
+  'green',
+  'jade',
+  'mint',
+  'turquoise',
+  'cyan',
+  'sky',
+  'blue',
+  'iris',
+  'violet',
+  'purple',
+  'plum',
+  'pink',
+  'bronze',
+  'gold',
+  'brown',
+  'gray',
+] as const;
+
+const DATE_GRANULARITY_OPTIONS = [
+  ObjectRecordGroupByDateGranularity.DAY,
+  ObjectRecordGroupByDateGranularity.WEEK,
+  ObjectRecordGroupByDateGranularity.MONTH,
+  ObjectRecordGroupByDateGranularity.QUARTER,
+  ObjectRecordGroupByDateGranularity.YEAR,
+  ObjectRecordGroupByDateGranularity.DAY_OF_THE_WEEK,
+  ObjectRecordGroupByDateGranularity.MONTH_OF_THE_YEAR,
+  ObjectRecordGroupByDateGranularity.QUARTER_OF_THE_YEAR,
+] as const;
+
+const GRAPH_ORDER_BY_OPTIONS = Object.values(GraphOrderBy) as [
+  GraphOrderBy,
+  ...GraphOrderBy[],
+];
+
+const AXIS_NAME_DISPLAY_OPTIONS = Object.values(AxisNameDisplay) as [
+  AxisNameDisplay,
+  ...AxisNameDisplay[],
+];
+
+const BAR_CHART_GROUP_MODE_OPTIONS = Object.values(BarChartGroupMode) as [
+  BarChartGroupMode,
+  ...BarChartGroupMode[],
+];
+
+const BAR_CHART_LAYOUT_OPTIONS = Object.values(BarChartLayout) as [
+  BarChartLayout,
+  ...BarChartLayout[],
+];
+
+const AGGREGATE_OPERATION_OPTIONS = Object.values(AggregateOperations) as [
+  AggregateOperations,
+  ...AggregateOperations[],
+];
+
+const displayDataLabelSchema = z.boolean().optional();
+const displayLegendSchema = z.boolean().optional();
+const showCenterMetricSchema = z
+  .boolean()
+  .optional()
+  .describe('Show aggregate value in center');
+const hideEmptyCategorySchema = z
+  .boolean()
+  .optional()
+  .describe('Hide slices with zero values');
+
+type PrimarySecondaryManualSortFields = {
+  primaryAxisOrderBy?: GraphOrderBy;
+  primaryAxisManualSortOrder?: string[];
+  secondaryAxisOrderBy?: GraphOrderBy;
+  secondaryAxisManualSortOrder?: string[];
+};
+
+type ManualSortFields = {
+  orderBy?: GraphOrderBy;
+  manualSortOrder?: string[];
+};
+
+type RangeMinMaxFields = {
+  rangeMin?: number;
+  rangeMax?: number;
+};
+
+const withPrimarySecondaryManualSortRefinements = <
+  T extends z.ZodType<PrimarySecondaryManualSortFields>,
+>(
+  schema: T,
+) =>
+  schema
+    .refine(
+      (data) =>
+        data.primaryAxisOrderBy !== GraphOrderBy.MANUAL ||
+        (Array.isArray(data.primaryAxisManualSortOrder) &&
+          data.primaryAxisManualSortOrder.length > 0),
+      {
+        message:
+          'primaryAxisManualSortOrder must be a non-empty array when primaryAxisOrderBy is MANUAL',
+        path: ['primaryAxisManualSortOrder'],
+      },
+    )
+    .refine(
+      (data) =>
+        data.secondaryAxisOrderBy !== GraphOrderBy.MANUAL ||
+        (Array.isArray(data.secondaryAxisManualSortOrder) &&
+          data.secondaryAxisManualSortOrder.length > 0),
+      {
+        message:
+          'secondaryAxisManualSortOrder must be a non-empty array when secondaryAxisOrderBy is MANUAL',
+        path: ['secondaryAxisManualSortOrder'],
+      },
+    );
+
+const withManualSortRefinement = <T extends z.ZodType<ManualSortFields>>(
+  schema: T,
+) =>
+  schema.refine(
+    (data) =>
+      data.orderBy !== GraphOrderBy.MANUAL ||
+      (Array.isArray(data.manualSortOrder) && data.manualSortOrder.length > 0),
+    {
+      message:
+        'manualSortOrder must be a non-empty array when orderBy is MANUAL',
+      path: ['manualSortOrder'],
+    },
+  );
+
+const withRangeMinMaxRefinement = <T extends z.ZodType<RangeMinMaxFields>>(
+  schema: T,
+) =>
+  schema.refine(
+    (data) =>
+      !(
+        typeof data.rangeMin === 'number' &&
+        typeof data.rangeMax === 'number' &&
+        data.rangeMin > data.rangeMax
+      ),
+    {
+      message: 'rangeMin must be less than or equal to rangeMax',
+      path: ['rangeMin'],
+    },
+  );
 
 export const gridPositionSchema = z.object({
   row: z.number().min(0).describe('Row position (0-based)'),
@@ -27,185 +186,162 @@ export const widgetTypeSchema = z.enum([
 ]);
 
 // Graph configuration schema for AGGREGATE type (KPI numbers)
-const aggregateChartConfigSchema = z.object({
+const aggregateChartConfigSchemaBase = z.object({
   configurationType: z.literal(WidgetConfigurationType.AGGREGATE_CHART),
   aggregateFieldMetadataId: z
-    .string()
     .uuid()
     .describe(
       'Field UUID to aggregate (must be from the widget objectMetadataId)',
     ),
   aggregateOperation: z
-    .nativeEnum(AggregateOperations)
+    .enum(AGGREGATE_OPERATION_OPTIONS)
     .describe('Aggregation operation: COUNT, SUM, AVG, MIN, MAX, etc.'),
-  displayDataLabel: z.boolean().optional().default(true),
+  displayDataLabel: displayDataLabelSchema,
   label: z.string().optional(),
   prefix: z.string().optional(),
   suffix: z.string().optional(),
   filter: z.record(z.string(), z.unknown()).optional(),
 });
 
+const aggregateChartConfigSchema = aggregateChartConfigSchemaBase.extend({
+  displayDataLabel: displayDataLabelSchema.default(true),
+});
+
+const aggregateChartConfigSchemaWithoutDefaults =
+  aggregateChartConfigSchemaBase;
+
 // Graph configuration schema for BAR charts
-const barChartConfigSchema = z
-  .object({
-    configurationType: z.literal(WidgetConfigurationType.BAR_CHART),
-    aggregateFieldMetadataId: z
-      .string()
-      .uuid()
-      .describe('Field UUID to aggregate'),
-    aggregateOperation: z.nativeEnum(AggregateOperations),
-    primaryAxisGroupByFieldMetadataId: z
-      .string()
-      .uuid()
-      .describe('Field UUID to group by on primary axis'),
-    secondaryAxisGroupByFieldMetadataId: z.string().uuid().optional(),
-    primaryAxisOrderBy: z
-      .enum([
-        'FIELD_ASC',
-        'FIELD_DESC',
-        'FIELD_POSITION_ASC',
-        'FIELD_POSITION_DESC',
-        'VALUE_ASC',
-        'VALUE_DESC',
-        'MANUAL',
-      ])
-      .optional(),
-    primaryAxisManualSortOrder: z.array(z.string()).optional(),
-    secondaryAxisOrderBy: z
-      .enum([
-        'FIELD_ASC',
-        'FIELD_DESC',
-        'FIELD_POSITION_ASC',
-        'FIELD_POSITION_DESC',
-        'VALUE_ASC',
-        'VALUE_DESC',
-        'MANUAL',
-      ])
-      .optional(),
-    secondaryAxisManualSortOrder: z.array(z.string()).optional(),
-    displayDataLabel: z.boolean().optional().default(false),
-    displayLegend: z.boolean().optional().default(true),
-    layout: z
-      .enum(['VERTICAL', 'HORIZONTAL'])
-      .describe('Layout orientation for bar charts'),
-    filter: z.record(z.string(), z.unknown()).optional(),
-  })
-  .refine(
-    (data) =>
-      data.primaryAxisOrderBy !== 'MANUAL' ||
-      (Array.isArray(data.primaryAxisManualSortOrder) &&
-        data.primaryAxisManualSortOrder.length > 0),
-    {
-      message:
-        'primaryAxisManualSortOrder must be a non-empty array when primaryAxisOrderBy is MANUAL',
-      path: ['primaryAxisManualSortOrder'],
-    },
-  )
-  .refine(
-    (data) =>
-      data.secondaryAxisOrderBy !== 'MANUAL' ||
-      (Array.isArray(data.secondaryAxisManualSortOrder) &&
-        data.secondaryAxisManualSortOrder.length > 0),
-    {
-      message:
-        'secondaryAxisManualSortOrder must be a non-empty array when secondaryAxisOrderBy is MANUAL',
-      path: ['secondaryAxisManualSortOrder'],
-    },
-  );
+const barChartConfigSchemaCore = z.object({
+  configurationType: z.literal(WidgetConfigurationType.BAR_CHART),
+  aggregateFieldMetadataId: z.uuid().describe('Field UUID to aggregate'),
+  aggregateOperation: z.enum(AGGREGATE_OPERATION_OPTIONS),
+  primaryAxisGroupByFieldMetadataId: z
+    .uuid()
+    .describe('Field UUID to group by on primary axis'),
+  secondaryAxisGroupByFieldMetadataId: z.uuid().optional(),
+  primaryAxisOrderBy: z.enum(GRAPH_ORDER_BY_OPTIONS).optional(),
+  primaryAxisManualSortOrder: z.array(z.string()).optional(),
+  secondaryAxisOrderBy: z.enum(GRAPH_ORDER_BY_OPTIONS).optional(),
+  secondaryAxisManualSortOrder: z.array(z.string()).optional(),
+  primaryAxisDateGranularity: z
+    .enum(DATE_GRANULARITY_OPTIONS)
+    .optional()
+    .describe('Date grouping granularity for X axis'),
+  secondaryAxisGroupByDateGranularity: z
+    .enum(DATE_GRANULARITY_OPTIONS)
+    .optional()
+    .describe('Date grouping granularity for secondary grouping'),
+  color: z.enum(CHART_COLORS).optional().describe('Chart color theme'),
+  axisNameDisplay: z
+    .enum(AXIS_NAME_DISPLAY_OPTIONS)
+    .optional()
+    .describe('Which axis labels to show'),
+  displayDataLabel: displayDataLabelSchema,
+  displayLegend: displayLegendSchema,
+  groupMode: z
+    .enum(BAR_CHART_GROUP_MODE_OPTIONS)
+    .optional()
+    .describe('Bar display mode when using secondary grouping'),
+  isCumulative: z.boolean().optional().describe('Show running totals'),
+  rangeMin: z.number().optional().describe('Y axis minimum value'),
+  rangeMax: z.number().optional().describe('Y axis maximum value'),
+  layout: z
+    .enum(BAR_CHART_LAYOUT_OPTIONS)
+    .describe('Layout orientation for bar charts'),
+  filter: z.record(z.string(), z.unknown()).optional(),
+});
+
+const barChartConfigSchemaWithoutDefaults = withRangeMinMaxRefinement(
+  withPrimarySecondaryManualSortRefinements(barChartConfigSchemaCore),
+);
+
+const barChartConfigSchema = withRangeMinMaxRefinement(
+  withPrimarySecondaryManualSortRefinements(
+    barChartConfigSchemaCore.extend({
+      displayDataLabel: displayDataLabelSchema.default(false),
+      displayLegend: displayLegendSchema.default(true),
+    }),
+  ),
+);
 
 // Graph configuration schema for LINE charts
-const lineChartConfigSchema = z
-  .object({
-    configurationType: z.literal(WidgetConfigurationType.LINE_CHART),
-    aggregateFieldMetadataId: z.string().uuid(),
-    aggregateOperation: z.nativeEnum(AggregateOperations),
-    primaryAxisGroupByFieldMetadataId: z.string().uuid(),
-    secondaryAxisGroupByFieldMetadataId: z.string().uuid().optional(),
-    primaryAxisOrderBy: z
-      .enum([
-        'FIELD_ASC',
-        'FIELD_DESC',
-        'FIELD_POSITION_ASC',
-        'FIELD_POSITION_DESC',
-        'VALUE_ASC',
-        'VALUE_DESC',
-        'MANUAL',
-      ])
-      .optional(),
-    primaryAxisManualSortOrder: z.array(z.string()).optional(),
-    secondaryAxisOrderBy: z
-      .enum([
-        'FIELD_ASC',
-        'FIELD_DESC',
-        'FIELD_POSITION_ASC',
-        'FIELD_POSITION_DESC',
-        'VALUE_ASC',
-        'VALUE_DESC',
-        'MANUAL',
-      ])
-      .optional(),
-    secondaryAxisManualSortOrder: z.array(z.string()).optional(),
-    displayDataLabel: z.boolean().optional().default(false),
-    filter: z.record(z.string(), z.unknown()).optional(),
-  })
-  .refine(
-    (data) =>
-      data.primaryAxisOrderBy !== 'MANUAL' ||
-      (Array.isArray(data.primaryAxisManualSortOrder) &&
-        data.primaryAxisManualSortOrder.length > 0),
-    {
-      message:
-        'primaryAxisManualSortOrder must be a non-empty array when primaryAxisOrderBy is MANUAL',
-      path: ['primaryAxisManualSortOrder'],
-    },
-  )
-  .refine(
-    (data) =>
-      data.secondaryAxisOrderBy !== 'MANUAL' ||
-      (Array.isArray(data.secondaryAxisManualSortOrder) &&
-        data.secondaryAxisManualSortOrder.length > 0),
-    {
-      message:
-        'secondaryAxisManualSortOrder must be a non-empty array when secondaryAxisOrderBy is MANUAL',
-      path: ['secondaryAxisManualSortOrder'],
-    },
-  );
+const lineChartConfigSchemaCore = z.object({
+  configurationType: z.literal(WidgetConfigurationType.LINE_CHART),
+  aggregateFieldMetadataId: z.uuid(),
+  aggregateOperation: z.enum(AGGREGATE_OPERATION_OPTIONS),
+  primaryAxisGroupByFieldMetadataId: z.uuid(),
+  secondaryAxisGroupByFieldMetadataId: z.uuid().optional(),
+  primaryAxisOrderBy: z.enum(GRAPH_ORDER_BY_OPTIONS).optional(),
+  primaryAxisManualSortOrder: z.array(z.string()).optional(),
+  secondaryAxisOrderBy: z.enum(GRAPH_ORDER_BY_OPTIONS).optional(),
+  secondaryAxisManualSortOrder: z.array(z.string()).optional(),
+  primaryAxisDateGranularity: z
+    .enum(DATE_GRANULARITY_OPTIONS)
+    .optional()
+    .describe('Date grouping granularity for X axis'),
+  secondaryAxisGroupByDateGranularity: z
+    .enum(DATE_GRANULARITY_OPTIONS)
+    .optional()
+    .describe('Date grouping granularity for secondary grouping'),
+  color: z.enum(CHART_COLORS).optional().describe('Line color theme'),
+  axisNameDisplay: z
+    .enum(AXIS_NAME_DISPLAY_OPTIONS)
+    .optional()
+    .describe('Which axis labels to show'),
+  displayDataLabel: displayDataLabelSchema,
+  displayLegend: displayLegendSchema,
+  isStacked: z.boolean().optional().describe('Stack multiple lines'),
+  isCumulative: z.boolean().optional().describe('Show running totals'),
+  rangeMin: z.number().optional().describe('Y axis minimum value'),
+  rangeMax: z.number().optional().describe('Y axis maximum value'),
+  filter: z.record(z.string(), z.unknown()).optional(),
+});
+
+const lineChartConfigSchemaWithoutDefaults = withRangeMinMaxRefinement(
+  withPrimarySecondaryManualSortRefinements(lineChartConfigSchemaCore),
+);
+
+const lineChartConfigSchema = withRangeMinMaxRefinement(
+  withPrimarySecondaryManualSortRefinements(
+    lineChartConfigSchemaCore.extend({
+      displayDataLabel: displayDataLabelSchema.default(false),
+      displayLegend: displayLegendSchema.default(true),
+    }),
+  ),
+);
 
 // Graph configuration schema for PIE charts
-const pieChartConfigSchema = z
-  .object({
-    configurationType: z.literal(WidgetConfigurationType.PIE_CHART),
-    aggregateFieldMetadataId: z.string().uuid(),
-    aggregateOperation: z.nativeEnum(AggregateOperations),
-    groupByFieldMetadataId: z
-      .string()
-      .uuid()
-      .describe('Field UUID to slice by'),
-    orderBy: z
-      .enum([
-        'FIELD_ASC',
-        'FIELD_DESC',
-        'FIELD_POSITION_ASC',
-        'FIELD_POSITION_DESC',
-        'VALUE_ASC',
-        'VALUE_DESC',
-        'MANUAL',
-      ])
-      .optional(),
-    manualSortOrder: z.array(z.string()).optional(),
-    displayDataLabel: z.boolean().optional().default(true),
-    filter: z.record(z.string(), z.unknown()).optional(),
-  })
-  .refine(
-    (data) =>
-      data.orderBy !== 'MANUAL' ||
-      (Array.isArray(data.manualSortOrder) && data.manualSortOrder.length > 0),
-    {
-      message:
-        'manualSortOrder must be a non-empty array when orderBy is MANUAL',
-      path: ['manualSortOrder'],
-    },
-  );
+const pieChartConfigSchemaCore = z.object({
+  configurationType: z.literal(WidgetConfigurationType.PIE_CHART),
+  aggregateFieldMetadataId: z.uuid(),
+  aggregateOperation: z.enum(AGGREGATE_OPERATION_OPTIONS),
+  groupByFieldMetadataId: z.uuid().describe('Field UUID to slice by'),
+  orderBy: z.enum(GRAPH_ORDER_BY_OPTIONS).optional(),
+  manualSortOrder: z.array(z.string()).optional(),
+  dateGranularity: z
+    .enum(DATE_GRANULARITY_OPTIONS)
+    .optional()
+    .describe('Date grouping granularity when slicing by date'),
+  color: z.enum(CHART_COLORS).optional().describe('Chart color theme'),
+  displayDataLabel: displayDataLabelSchema,
+  displayLegend: displayLegendSchema,
+  showCenterMetric: showCenterMetricSchema,
+  hideEmptyCategory: hideEmptyCategorySchema,
+  filter: z.record(z.string(), z.unknown()).optional(),
+});
+
+const pieChartConfigSchemaWithoutDefaults = withManualSortRefinement(
+  pieChartConfigSchemaCore,
+);
+
+const pieChartConfigSchema = withManualSortRefinement(
+  pieChartConfigSchemaCore.extend({
+    displayDataLabel: displayDataLabelSchema.default(true),
+    displayLegend: displayLegendSchema.default(true),
+    showCenterMetric: showCenterMetricSchema.default(true),
+    hideEmptyCategory: hideEmptyCategorySchema.default(false),
+  }),
+);
 
 // Iframe configuration
 const iframeConfigSchema = z.object({
@@ -216,7 +352,15 @@ const iframeConfigSchema = z.object({
 // Rich text configuration
 const richTextConfigSchema = z.object({
   configurationType: z.literal(WidgetConfigurationType.STANDALONE_RICH_TEXT),
-  body: z.unknown().optional().describe('Rich text content (RichTextV2Body)'),
+  body: z
+    .object({
+      blocknote: z.string().nullable().optional(),
+      markdown: z.string().nullable().optional(),
+    })
+    .refine((value) => value.blocknote != null || value.markdown != null, {
+      message: 'body must include blocknote or markdown',
+    })
+    .describe('Rich text content (RichTextV2Body)'),
 });
 
 export const graphConfigurationSchema = z.discriminatedUnion(
@@ -229,12 +373,34 @@ export const graphConfigurationSchema = z.discriminatedUnion(
   ],
 );
 
+export const graphConfigurationSchemaWithoutDefaults = z.discriminatedUnion(
+  'configurationType',
+  [
+    aggregateChartConfigSchemaWithoutDefaults,
+    barChartConfigSchemaWithoutDefaults,
+    lineChartConfigSchemaWithoutDefaults,
+    pieChartConfigSchemaWithoutDefaults,
+  ],
+);
+
 export const widgetConfigurationSchema = z
   .discriminatedUnion('configurationType', [
     aggregateChartConfigSchema,
     barChartConfigSchema,
     lineChartConfigSchema,
     pieChartConfigSchema,
+    iframeConfigSchema,
+    richTextConfigSchema,
+  ])
+  .optional()
+  .describe('Widget configuration - structure depends on widget type');
+
+export const widgetConfigurationSchemaWithoutDefaults = z
+  .discriminatedUnion('configurationType', [
+    aggregateChartConfigSchemaWithoutDefaults,
+    barChartConfigSchemaWithoutDefaults,
+    lineChartConfigSchemaWithoutDefaults,
+    pieChartConfigSchemaWithoutDefaults,
     iframeConfigSchema,
     richTextConfigSchema,
   ])

--- a/packages/twenty-server/src/modules/dashboard/tools/update-dashboard-widget.tool.ts
+++ b/packages/twenty-server/src/modules/dashboard/tools/update-dashboard-widget.tool.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import { type WidgetType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-type.enum';
 import {
   gridPositionSchema,
-  widgetConfigurationSchema,
+  widgetConfigurationSchemaWithoutDefaults,
   widgetTypeSchema,
 } from 'src/modules/dashboard/tools/schemas/widget.schema';
 import {
@@ -24,7 +24,7 @@ const updateDashboardWidgetSchema = z.object({
     .uuid()
     .optional()
     .describe('New object metadata ID'),
-  configuration: widgetConfigurationSchema.optional(),
+  configuration: widgetConfigurationSchemaWithoutDefaults,
 });
 
 export const createUpdateDashboardWidgetTool = (

--- a/packages/twenty-server/src/modules/dashboard/tools/update-dashboard-widget.tool.ts
+++ b/packages/twenty-server/src/modules/dashboard/tools/update-dashboard-widget.tool.ts
@@ -24,7 +24,7 @@ const updateDashboardWidgetSchema = z.object({
     .uuid()
     .optional()
     .describe('New object metadata ID'),
-  configuration: widgetConfigurationSchemaWithoutDefaults,
+  configuration: widgetConfigurationSchemaWithoutDefaults.optional(),
 });
 
 export const createUpdateDashboardWidgetTool = (


### PR DESCRIPTION
Got rid of filters for now -- filters would need extra tailoring since they depend on field names/types and the RecordGqlOperationFilter DSL (nested AND/OR and composite subfields), which the AI can’t reliably construct without additional metadata and skills 

created a followup to tackle the same https://github.com/twentyhq/core-team-issues/issues/2108