### PR TITLE
fix: add base_path to Crowdin configs for correct path resolution

### DIFF
--- a/.github/crowdin-app.yml
+++ b/.github/crowdin-app.yml
@@ -5,6 +5,7 @@
 #
 
 "preserve_hierarchy": true
+"base_path": ".."
 
 files: [
   {

--- a/.github/crowdin-docs.yml
+++ b/.github/crowdin-docs.yml
@@ -6,6 +6,7 @@
 "project_id": 2
 "preserve_hierarchy": true
 "base_url": "https://twenty.api.crowdin.com"
+"base_path": ".."
 
 files: [
   {


### PR DESCRIPTION
## Problem
The Crowdin GitHub Actions were failing with:
```
❌ No sources found for 'packages/twenty-docs/user-guide/**/*.mdx' pattern
❌ No sources found for 'packages/twenty-docs/developers/**/*.mdx' pattern
❌ No sources found for 'packages/twenty-docs/twenty-ui/**/*.mdx' pattern
❌ No sources found for 'packages/twenty-docs/navigation/navigation.template.json' pattern
```

## Root Cause
The Crowdin config files are located at `.github/crowdin-docs.yml` and `.github/crowdin-app.yml`. By default, the Crowdin CLI resolves source paths relative to the config file's directory (`.github/`), not the repository root.

So paths like `packages/twenty-docs/...` were being resolved as `.github/packages/twenty-docs/...`, which doesn't exist.

## Fix
Added `base_path: ".."` to both Crowdin config files to make paths resolve relative to the repository root.