### PR TITLE
fix: E2E login test flakiness

### DIFF
--- a/packages/twenty-e2e-testing/lib/pom/loginPage.ts
+++ b/packages/twenty-e2e-testing/lib/pom/loginPage.ts
@@ -1,4 +1,4 @@
-import { expect, Locator, Page } from '@playwright/test';
+import { type Locator, type Page } from '@playwright/test';
 
 export class LoginPage {
   private readonly loginWithGoogleButton: Locator;
@@ -86,9 +86,10 @@ export class LoginPage {
   }
 
   async clickLoginWithEmailIfVisible() {
-    const isVisible = await this.loginWithEmailButton.isVisible();
-    if (isVisible) {
+    try {
       await this.loginWithEmailButton.click();
+    } catch {
+      // Button not found - email field might already be visible (SSO-only or different auth flow)
     }
   }
 
@@ -105,11 +106,7 @@ export class LoginPage {
   }
 
   async typeEmail(email: string) {
-    // Wait for the email field to be visible before trying to interact
-    await this.emailField.waitFor({ state: 'visible' });
-    await expect(this.emailField).toBeVisible();
-
-    await this.emailField.fill(email);
+    await this.emailField.fill(email, { timeout: 10000 });
   }
 
   async typePassword(email: string) {


### PR DESCRIPTION
## Summary
- Fix E2E login test flakiness by using `click()` auto-waiting instead of `isVisible()` check
- The login form shows a loader while GraphQL data loads. The previous `isVisible()` check returned immediately (no waiting) and would fail while the loader was showing
- Using `click()` which has built-in auto-waiting for elements to be visible and actionable fixes this

## Test plan
- E2E tests should pass more reliably in CI
- Login setup test should no longer timeout waiting for the email field