### PR TITLE
fix: jsdiff has a denial of service vulnerability in parsePatch and applyPatch

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -32531,9 +32531,9 @@ __metadata:
   linkType: hard
 
 "diff@npm:~8.0.2":
-  version: 8.0.2
-  resolution: "diff@npm:8.0.2"
-  checksum: 10c0/abfb387f033e089df3ec3be960205d17b54df8abf0924d982a7ced3a94c557a4e6cbff2e78b121f216b85f466b3d8d041673a386177c311aaea41459286cc9bc
+  version: 8.0.3
+  resolution: "diff@npm:8.0.3"
+  checksum: 10c0/d29321c70d3545fdcb56c5fdd76028c3f04c012462779e062303d4c3c531af80d2c360c26b871e6e2b9a971d2422d47e1779a859106c4cac4b5d2d143df70e20
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resolves [Dependabot Alert 366](https://github.com/twentyhq/twenty/security/dependabot/366).