### PR TITLE
Cache WorkspaceMember

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/auth/strategies/jwt.auth.strategy.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/strategies/jwt.auth.strategy.ts
@@ -202,8 +202,11 @@ export class JwtAuthStrategy extends PassportStrategy(Strategy, 'jwt') {
         'flatWorkspaceMemberMaps',
       ]);
 
-    const workspaceMember = isDefined(payload.workspaceMemberId) ?
-      flatWorkspaceMemberMaps.byId[payload.workspaceMemberId] : undefined;
+    const workspaceMemberId = flatWorkspaceMemberMaps.idByUserId[user.id];
+
+    const workspaceMember = isDefined(workspaceMemberId)
+      ? flatWorkspaceMemberMaps.byId[workspaceMemberId]
+      : undefined;
 
     assertIsDefinedOrThrow(
       workspaceMember,

--- a/packages/twenty-server/src/engine/core-modules/auth/strategies/jwt.auth.strategy.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/strategies/jwt.auth.strategy.ts
@@ -31,9 +31,7 @@ import { UserEntity } from 'src/engine/core-modules/user/user.entity';
 import { userValidator } from 'src/engine/core-modules/user/user.validate';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { PermissionsService } from 'src/engine/metadata-modules/permissions/permissions.service';
-import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
-import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
-import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
+import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 
 @Injectable()
 export class JwtAuthStrategy extends PassportStrategy(Strategy, 'jwt') {
@@ -50,7 +48,7 @@ export class JwtAuthStrategy extends PassportStrategy(Strategy, 'jwt') {
     @InjectRepository(ApiKeyEntity)
     private readonly apiKeyRepository: Repository<ApiKeyEntity>,
     private readonly permissionsService: PermissionsService,
-    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly workspaceCacheService: WorkspaceCacheService,
   ) {
     const jwtFromRequestFunction = jwtWrapperService.extractJwtFromRequest();
     // @ts-expect-error legacy noImplicitAny
@@ -199,37 +197,24 @@ export class JwtAuthStrategy extends PassportStrategy(Strategy, 'jwt') {
       return context;
     }
 
-    const workspaceMember =
-      await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        buildSystemAuthContext(workspace.id),
-        async () => {
-          const workspaceMemberRepository =
-            await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-              workspace.id,
-              'workspaceMember',
-              { shouldBypassPermissionChecks: true },
-            );
+    const { flatWorkspaceMemberMaps } =
+      await this.workspaceCacheService.getOrRecompute(workspace.id, [
+        'flatWorkspaceMemberMaps',
+      ]);
 
-          const workspaceMember = await workspaceMemberRepository.findOne({
-            where: {
-              userId: user.id,
-            },
-          });
+    const workspaceMember = isDefined(payload.workspaceMemberId) ?
+      flatWorkspaceMemberMaps.byId[payload.workspaceMemberId] : undefined;
 
-          assertIsDefinedOrThrow(
-            workspaceMember,
-            new AuthException(
-              'User is not a member of the workspace',
-              AuthExceptionCode.FORBIDDEN_EXCEPTION,
-              {
-                userFriendlyMessage: msg`User is not a member of the workspace.`,
-              },
-            ),
-          );
-
-          return workspaceMember;
+    assertIsDefinedOrThrow(
+      workspaceMember,
+      new AuthException(
+        'User is not a member of the workspace',
+        AuthExceptionCode.FORBIDDEN_EXCEPTION,
+        {
+          userFriendlyMessage: msg`User is not a member of the workspace.`,
         },
-      );
+      ),
+    );
 
     return {
       ...context,

--- a/packages/twenty-server/src/engine/core-modules/auth/token/token.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/token/token.module.ts
@@ -4,8 +4,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { TypeORMModule } from 'src/database/typeorm/typeorm.module';
 import { ApiKeyEntity } from 'src/engine/core-modules/api-key/api-key.entity';
 import { AppTokenEntity } from 'src/engine/core-modules/app-token/app-token.entity';
+import { ApplicationEntity } from 'src/engine/core-modules/application/application.entity';
 import { JwtAuthStrategy } from 'src/engine/core-modules/auth/strategies/jwt.auth.strategy';
 import { AccessTokenService } from 'src/engine/core-modules/auth/token/services/access-token.service';
+import { ApplicationTokenService } from 'src/engine/core-modules/auth/token/services/application-token.service';
 import { LoginTokenService } from 'src/engine/core-modules/auth/token/services/login-token.service';
 import { RefreshTokenService } from 'src/engine/core-modules/auth/token/services/refresh-token.service';
 import { RenewTokenService } from 'src/engine/core-modules/auth/token/services/renew-token.service';
@@ -16,8 +18,7 @@ import { UserEntity } from 'src/engine/core-modules/user/user.entity';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { DataSourceModule } from 'src/engine/metadata-modules/data-source/data-source.module';
 import { PermissionsModule } from 'src/engine/metadata-modules/permissions/permissions.module';
-import { ApplicationTokenService } from 'src/engine/core-modules/auth/token/services/application-token.service';
-import { ApplicationEntity } from 'src/engine/core-modules/application/application.entity';
+import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
 
 @Module({
   imports: [
@@ -33,6 +34,7 @@ import { ApplicationEntity } from 'src/engine/core-modules/application/applicati
     TypeORMModule,
     DataSourceModule,
     PermissionsModule,
+    WorkspaceCacheModule
   ],
   providers: [
     RenewTokenService,

--- a/packages/twenty-server/src/engine/core-modules/auth/token/token.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/token/token.module.ts
@@ -34,7 +34,7 @@ import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache
     TypeORMModule,
     DataSourceModule,
     PermissionsModule,
-    WorkspaceCacheModule
+    WorkspaceCacheModule,
   ],
   providers: [
     RenewTokenService,

--- a/packages/twenty-server/src/engine/core-modules/user/services/global-workspace-member.listener.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/services/global-workspace-member.listener.ts
@@ -1,0 +1,44 @@
+import { Injectable } from '@nestjs/common';
+
+import {
+  ObjectRecordCreateEvent,
+  ObjectRecordRestoreEvent,
+  ObjectRecordUpdateEvent,
+  ObjectRecordUpsertEvent,
+  type ObjectRecordDeleteEvent,
+  type ObjectRecordDestroyEvent,
+} from 'twenty-shared/database-events';
+
+import { OnDatabaseBatchEvent } from 'src/engine/api/graphql/graphql-query-runner/decorators/on-database-batch-event.decorator';
+import { DatabaseEventAction } from 'src/engine/api/graphql/graphql-query-runner/enums/database-event-action';
+import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
+import { WorkspaceEventBatch } from 'src/engine/workspace-event-emitter/types/workspace-event-batch.type';
+import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
+
+@Injectable()
+export class GlobalWorkspaceMemberListener {
+  constructor(
+    private readonly workspaceCacheService: WorkspaceCacheService,
+  ) {}
+
+  @OnDatabaseBatchEvent('workspaceMember', DatabaseEventAction.CREATED)
+  @OnDatabaseBatchEvent('workspaceMember', DatabaseEventAction.UPDATED)
+  @OnDatabaseBatchEvent('workspaceMember', DatabaseEventAction.DELETED)
+  @OnDatabaseBatchEvent('workspaceMember', DatabaseEventAction.DESTROYED)
+  @OnDatabaseBatchEvent('workspaceMember', DatabaseEventAction.RESTORED)
+  @OnDatabaseBatchEvent('workspaceMember', DatabaseEventAction.UPSERTED)
+  async handleWorkspaceMemberEvent(
+    payload: WorkspaceEventBatch<
+      | ObjectRecordCreateEvent<WorkspaceMemberWorkspaceEntity>
+      | ObjectRecordUpdateEvent<WorkspaceMemberWorkspaceEntity>
+      | ObjectRecordDeleteEvent<WorkspaceMemberWorkspaceEntity>
+      | ObjectRecordDestroyEvent<WorkspaceMemberWorkspaceEntity>
+      | ObjectRecordRestoreEvent<WorkspaceMemberWorkspaceEntity>
+      | ObjectRecordUpsertEvent<WorkspaceMemberWorkspaceEntity>
+    >,
+  ) {
+    await this.workspaceCacheService.invalidateAndRecompute(payload.workspaceId, [
+      'flatWorkspaceMemberMaps',
+    ]);
+  }
+}

--- a/packages/twenty-server/src/engine/core-modules/user/services/global-workspace-member.listener.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/services/global-workspace-member.listener.ts
@@ -17,9 +17,7 @@ import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/sta
 
 @Injectable()
 export class GlobalWorkspaceMemberListener {
-  constructor(
-    private readonly workspaceCacheService: WorkspaceCacheService,
-  ) {}
+  constructor(private readonly workspaceCacheService: WorkspaceCacheService) {}
 
   @OnDatabaseBatchEvent('workspaceMember', DatabaseEventAction.CREATED)
   @OnDatabaseBatchEvent('workspaceMember', DatabaseEventAction.UPDATED)
@@ -37,8 +35,9 @@ export class GlobalWorkspaceMemberListener {
       | ObjectRecordUpsertEvent<WorkspaceMemberWorkspaceEntity>
     >,
   ) {
-    await this.workspaceCacheService.invalidateAndRecompute(payload.workspaceId, [
-      'flatWorkspaceMemberMaps',
-    ]);
+    await this.workspaceCacheService.invalidateAndRecompute(
+      payload.workspaceId,
+      ['flatWorkspaceMemberMaps'],
+    );
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/user/services/workspace-flat-workspace-member-map-cache.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/services/workspace-flat-workspace-member-map-cache.service.ts
@@ -1,8 +1,6 @@
 import { Injectable } from '@nestjs/common';
 
-
 import { WorkspaceCacheProvider } from 'src/engine/workspace-cache/interfaces/workspace-cache-provider.service';
-
 
 import { FlatWorkspaceMemberMaps } from 'src/engine/core-modules/user/types/flat-workspace-member-maps.type';
 import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
@@ -11,7 +9,7 @@ import { WorkspaceCache } from 'src/engine/workspace-cache/decorators/workspace-
 import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
 
 @Injectable()
-@WorkspaceCache('flatWorkspaceMemberMaps', { localDataOnly: true })
+@WorkspaceCache('flatWorkspaceMemberMaps', { localDataOnly: false })
 export class WorkspaceFlatWorkspaceMemberMapCacheService extends WorkspaceCacheProvider<FlatWorkspaceMemberMaps> {
   constructor(
     protected readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
@@ -35,17 +33,22 @@ export class WorkspaceFlatWorkspaceMemberMapCacheService extends WorkspaceCacheP
             byId: {},
             idByUserId: {},
           };
-          const workspaceMembers = await workspaceMemberRepository.find();
+          const workspaceMembers = await workspaceMemberRepository.find(
+            {
+              withDeleted: true,
+            },
+          );
 
           for (const workspaceMember of workspaceMembers) {
             flatWorkspaceMemberMaps.byId[workspaceMember.id] = workspaceMember;
-            flatWorkspaceMemberMaps.idByUserId[workspaceMember.userId] = workspaceMember.id;
+            flatWorkspaceMemberMaps.idByUserId[workspaceMember.userId] =
+              workspaceMember.id;
           }
 
           return flatWorkspaceMemberMaps;
         },
       );
 
-      return flatWorkspaceMemberMaps;
+    return flatWorkspaceMemberMaps;
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/user/services/workspace-flat-workspace-member-map-cache.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/services/workspace-flat-workspace-member-map-cache.service.ts
@@ -1,0 +1,51 @@
+import { Injectable } from '@nestjs/common';
+
+
+import { WorkspaceCacheProvider } from 'src/engine/workspace-cache/interfaces/workspace-cache-provider.service';
+
+
+import { FlatWorkspaceMemberMaps } from 'src/engine/core-modules/user/types/flat-workspace-member-maps.type';
+import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
+import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
+import { WorkspaceCache } from 'src/engine/workspace-cache/decorators/workspace-cache.decorator';
+import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
+
+@Injectable()
+@WorkspaceCache('flatWorkspaceMemberMaps', { localDataOnly: true })
+export class WorkspaceFlatWorkspaceMemberMapCacheService extends WorkspaceCacheProvider<FlatWorkspaceMemberMaps> {
+  constructor(
+    protected readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+  ) {
+    super();
+  }
+
+  async computeForCache(workspaceId: string): Promise<FlatWorkspaceMemberMaps> {
+    const flatWorkspaceMemberMaps =
+      await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+        buildSystemAuthContext(workspaceId),
+        async () => {
+          const workspaceMemberRepository =
+            await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+              workspaceId,
+              'workspaceMember',
+              { shouldBypassPermissionChecks: true },
+            );
+
+          const flatWorkspaceMemberMaps: FlatWorkspaceMemberMaps = {
+            byId: {},
+            idByUserId: {},
+          };
+          const workspaceMembers = await workspaceMemberRepository.find();
+
+          for (const workspaceMember of workspaceMembers) {
+            flatWorkspaceMemberMaps.byId[workspaceMember.id] = workspaceMember;
+            flatWorkspaceMemberMaps.idByUserId[workspaceMember.userId] = workspaceMember.id;
+          }
+
+          return flatWorkspaceMemberMaps;
+        },
+      );
+
+      return flatWorkspaceMemberMaps;
+  }
+}

--- a/packages/twenty-server/src/engine/core-modules/user/services/workspace-flat-workspace-member-map-cache.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/services/workspace-flat-workspace-member-map-cache.service.ts
@@ -9,7 +9,7 @@ import { WorkspaceCache } from 'src/engine/workspace-cache/decorators/workspace-
 import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
 
 @Injectable()
-@WorkspaceCache('flatWorkspaceMemberMaps', { localDataOnly: false })
+@WorkspaceCache('flatWorkspaceMemberMaps', { localDataOnly: true })
 export class WorkspaceFlatWorkspaceMemberMapCacheService extends WorkspaceCacheProvider<FlatWorkspaceMemberMaps> {
   constructor(
     protected readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
@@ -33,11 +33,9 @@ export class WorkspaceFlatWorkspaceMemberMapCacheService extends WorkspaceCacheP
             byId: {},
             idByUserId: {},
           };
-          const workspaceMembers = await workspaceMemberRepository.find(
-            {
-              withDeleted: true,
-            },
-          );
+          const workspaceMembers = await workspaceMemberRepository.find({
+            withDeleted: true,
+          });
 
           for (const workspaceMember of workspaceMembers) {
             flatWorkspaceMemberMaps.byId[workspaceMember.id] = workspaceMember;

--- a/packages/twenty-server/src/engine/core-modules/user/types/flat-workspace-member-maps.type.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/types/flat-workspace-member-maps.type.ts
@@ -1,0 +1,6 @@
+import { FlatWorkspaceMember } from "src/engine/core-modules/user/types/flat-workspace-member.type";
+
+export type FlatWorkspaceMemberMaps = {
+  byId: Partial<Record<string, FlatWorkspaceMember>>;
+  idByUserId: Partial<Record<string, string>>;
+}

--- a/packages/twenty-server/src/engine/core-modules/user/types/flat-workspace-member-maps.type.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/types/flat-workspace-member-maps.type.ts
@@ -1,6 +1,6 @@
-import { FlatWorkspaceMember } from "src/engine/core-modules/user/types/flat-workspace-member.type";
+import { type FlatWorkspaceMember } from 'src/engine/core-modules/user/types/flat-workspace-member.type';
 
 export type FlatWorkspaceMemberMaps = {
   byId: Partial<Record<string, FlatWorkspaceMember>>;
   idByUserId: Partial<Record<string, string>>;
-}
+};

--- a/packages/twenty-server/src/engine/core-modules/user/types/flat-workspace-member.type.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/types/flat-workspace-member.type.ts
@@ -1,4 +1,5 @@
 import { type FlatEntityFrom } from 'src/engine/metadata-modules/flat-entity/types/flat-entity.type';
-import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
+import { type WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
 
-export type FlatWorkspaceMember = FlatEntityFrom<WorkspaceMemberWorkspaceEntity>;
+export type FlatWorkspaceMember =
+  FlatEntityFrom<WorkspaceMemberWorkspaceEntity>;

--- a/packages/twenty-server/src/engine/core-modules/user/types/flat-workspace-member.type.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/types/flat-workspace-member.type.ts
@@ -1,0 +1,4 @@
+import { type FlatEntityFrom } from 'src/engine/metadata-modules/flat-entity/types/flat-entity.type';
+import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
+
+export type FlatWorkspaceMember = FlatEntityFrom<WorkspaceMemberWorkspaceEntity>;

--- a/packages/twenty-server/src/engine/core-modules/user/user.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/user.module.ts
@@ -25,11 +25,11 @@ import { DataSourceModule } from 'src/engine/metadata-modules/data-source/data-s
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 import { PermissionsModule } from 'src/engine/metadata-modules/permissions/permissions.module';
 import { UserRoleModule } from 'src/engine/metadata-modules/user-role/user-role.module';
+import { GlobalWorkspaceMemberListener } from 'src/engine/core-modules/user/services/global-workspace-member.listener';
+import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
 
 import { userAutoResolverOpts } from './user.auto-resolver-opts';
 
-import { GlobalWorkspaceMemberListener } from 'src/engine/core-modules/user/services/global-workspace-member.listener';
-import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
 import { UserService } from './services/user.service';
 
 @Module({

--- a/packages/twenty-server/src/engine/core-modules/user/user.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/user.module.ts
@@ -6,6 +6,8 @@ import { NestjsQueryTypeOrmModule } from '@ptc-org/nestjs-query-typeorm';
 
 import { TypeORMModule } from 'src/database/typeorm/typeorm.module';
 import { AuditModule } from 'src/engine/core-modules/audit/audit.module';
+import { WorkspaceDomainsModule } from 'src/engine/core-modules/domain/workspace-domains/workspace-domains.module';
+import { EmailVerificationModule } from 'src/engine/core-modules/email-verification/email-verification.module';
 import { FeatureFlagModule } from 'src/engine/core-modules/feature-flag/feature-flag.module';
 import { FileUploadModule } from 'src/engine/core-modules/file/file-upload/file-upload.module';
 import { FileModule } from 'src/engine/core-modules/file/file.module';
@@ -22,11 +24,10 @@ import { DataSourceModule } from 'src/engine/metadata-modules/data-source/data-s
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 import { PermissionsModule } from 'src/engine/metadata-modules/permissions/permissions.module';
 import { UserRoleModule } from 'src/engine/metadata-modules/user-role/user-role.module';
-import { WorkspaceDomainsModule } from 'src/engine/core-modules/domain/workspace-domains/workspace-domains.module';
-import { EmailVerificationModule } from 'src/engine/core-modules/email-verification/email-verification.module';
 
 import { userAutoResolverOpts } from './user.auto-resolver-opts';
 
+import { WorkspaceFlatWorkspaceMemberMapCacheService } from 'src/engine/core-modules/user/services/workspace-flat-workspace-member-map-cache.service';
 import { UserService } from './services/user.service';
 
 @Module({
@@ -55,6 +56,6 @@ import { UserService } from './services/user.service';
     WorkspaceDomainsModule,
   ],
   exports: [UserService, WorkspaceMemberTranspiler],
-  providers: [UserService, UserResolver, WorkspaceMemberTranspiler],
+  providers: [UserService, UserResolver, WorkspaceMemberTranspiler, WorkspaceFlatWorkspaceMemberMapCacheService],
 })
 export class UserModule {}

--- a/packages/twenty-server/src/engine/core-modules/user/user.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/user.module.ts
@@ -15,6 +15,7 @@ import { KeyValuePairEntity } from 'src/engine/core-modules/key-value-pair/key-v
 import { OnboardingModule } from 'src/engine/core-modules/onboarding/onboarding.module';
 import { UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
 import { UserWorkspaceModule } from 'src/engine/core-modules/user-workspace/user-workspace.module';
+import { WorkspaceFlatWorkspaceMemberMapCacheService } from 'src/engine/core-modules/user/services/workspace-flat-workspace-member-map-cache.service';
 import { WorkspaceMemberTranspiler } from 'src/engine/core-modules/user/services/workspace-member-transpiler.service';
 import { UserVarsModule } from 'src/engine/core-modules/user/user-vars/user-vars.module';
 import { UserEntity } from 'src/engine/core-modules/user/user.entity';
@@ -27,7 +28,8 @@ import { UserRoleModule } from 'src/engine/metadata-modules/user-role/user-role.
 
 import { userAutoResolverOpts } from './user.auto-resolver-opts';
 
-import { WorkspaceFlatWorkspaceMemberMapCacheService } from 'src/engine/core-modules/user/services/workspace-flat-workspace-member-map-cache.service';
+import { GlobalWorkspaceMemberListener } from 'src/engine/core-modules/user/services/global-workspace-member.listener';
+import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
 import { UserService } from './services/user.service';
 
 @Module({
@@ -54,8 +56,15 @@ import { UserService } from './services/user.service';
     PermissionsModule,
     EmailVerificationModule,
     WorkspaceDomainsModule,
+    WorkspaceCacheModule,
   ],
   exports: [UserService, WorkspaceMemberTranspiler],
-  providers: [UserService, UserResolver, WorkspaceMemberTranspiler, WorkspaceFlatWorkspaceMemberMapCacheService],
+  providers: [
+    UserService,
+    UserResolver,
+    WorkspaceMemberTranspiler,
+    WorkspaceFlatWorkspaceMemberMapCacheService,
+    GlobalWorkspaceMemberListener,
+  ],
 })
 export class UserModule {}

--- a/packages/twenty-server/src/engine/workspace-cache/types/workspace-cache-key.type.ts
+++ b/packages/twenty-server/src/engine/workspace-cache/types/workspace-cache-key.type.ts
@@ -3,6 +3,7 @@ import { type EntityMetadata } from 'typeorm';
 
 import { type FlatApplicationCacheMaps } from 'src/engine/core-modules/application/types/flat-application-cache-maps.type';
 import { type FeatureFlagKey } from 'src/engine/core-modules/feature-flag/enums/feature-flag-key.enum';
+import { type FlatWorkspaceMemberMaps } from 'src/engine/core-modules/user/types/flat-workspace-member-maps.type';
 import { type FlatRoleTargetByAgentIdMaps } from 'src/engine/metadata-modules/flat-agent/types/flat-role-target-by-agent-id-maps.type';
 import { type AllFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/all-flat-entity-maps.type';
 import { type UserWorkspaceRoleMap } from 'src/engine/metadata-modules/role-target/services/workspace-user-workspace-role-map-cache.service';
@@ -42,6 +43,7 @@ export const WORKSPACE_CACHE_KEYS_V2 = {
   flatRowLevelPermissionPredicateGroupMaps:
     'flat-maps:row-level-permission-predicate-group',
   flatFrontComponentMaps: 'flat-maps:front-component',
+  flatWorkspaceMemberMaps: 'flat-maps:workspace-member',
 } as const satisfies Record<WorkspaceCacheKeyName, string>;
 
 export type AdditionalCacheDataMaps = {
@@ -54,6 +56,7 @@ export type AdditionalCacheDataMaps = {
   flatRoleTargetByAgentIdMaps: FlatRoleTargetByAgentIdMaps;
   flatRowLevelPermissionPredicateMaps: FlatRowLevelPermissionPredicateMaps;
   flatRowLevelPermissionPredicateGroupMaps: FlatRowLevelPermissionPredicateGroupMaps;
+  flatWorkspaceMemberMaps: FlatWorkspaceMemberMaps;
 };
 
 export type WorkspaceCacheDataMap = AllFlatEntityMaps & AdditionalCacheDataMaps;

--- a/packages/twenty-server/src/modules/workspace-member/standard-objects/workspace-member.workspace-entity.ts
+++ b/packages/twenty-server/src/modules/workspace-member/standard-objects/workspace-member.workspace-entity.ts
@@ -2,6 +2,7 @@ import { registerEnumType } from '@nestjs/graphql';
 
 import { type APP_LOCALES } from 'twenty-shared/translations';
 import { FieldMetadataType, type FullNameMetadata } from 'twenty-shared/types';
+import { type Relation } from 'typeorm';
 
 import { BaseWorkspaceEntity } from 'src/engine/twenty-orm/base.workspace-entity';
 import { type FieldTypeAndNameMetadata } from 'src/engine/workspace-manager/utils/get-ts-vector-column-expression.util';
@@ -15,7 +16,6 @@ import { type MessageParticipantWorkspaceEntity } from 'src/modules/messaging/co
 import { type OpportunityWorkspaceEntity } from 'src/modules/opportunity/standard-objects/opportunity.workspace-entity';
 import { type TaskWorkspaceEntity } from 'src/modules/task/standard-objects/task.workspace-entity';
 import { type TimelineActivityWorkspaceEntity } from 'src/modules/timeline/standard-objects/timeline-activity.workspace-entity';
-import { Relation } from 'typeorm';
 
 export enum WorkspaceMemberDateFormatEnum {
   SYSTEM = 'SYSTEM',

--- a/packages/twenty-server/src/modules/workspace-member/standard-objects/workspace-member.workspace-entity.ts
+++ b/packages/twenty-server/src/modules/workspace-member/standard-objects/workspace-member.workspace-entity.ts
@@ -5,7 +5,6 @@ import { FieldMetadataType, type FullNameMetadata } from 'twenty-shared/types';
 
 import { BaseWorkspaceEntity } from 'src/engine/twenty-orm/base.workspace-entity';
 import { type FieldTypeAndNameMetadata } from 'src/engine/workspace-manager/utils/get-ts-vector-column-expression.util';
-import { type EntityRelation } from 'src/engine/workspace-manager/workspace-migration/types/entity-relation.interface';
 import { type AttachmentWorkspaceEntity } from 'src/modules/attachment/standard-objects/attachment.workspace-entity';
 import { type BlocklistWorkspaceEntity } from 'src/modules/blocklist/standard-objects/blocklist.workspace-entity';
 import { type CalendarEventParticipantWorkspaceEntity } from 'src/modules/calendar/common/standard-objects/calendar-event-participant.workspace-entity';
@@ -16,6 +15,7 @@ import { type MessageParticipantWorkspaceEntity } from 'src/modules/messaging/co
 import { type OpportunityWorkspaceEntity } from 'src/modules/opportunity/standard-objects/opportunity.workspace-entity';
 import { type TaskWorkspaceEntity } from 'src/modules/task/standard-objects/task.workspace-entity';
 import { type TimelineActivityWorkspaceEntity } from 'src/modules/timeline/standard-objects/timeline-activity.workspace-entity';
+import { Relation } from 'typeorm';
 
 export enum WorkspaceMemberDateFormatEnum {
   SYSTEM = 'SYSTEM',
@@ -74,18 +74,18 @@ export class WorkspaceMemberWorkspaceEntity extends BaseWorkspaceEntity {
   timeZone: string;
   dateFormat: string;
   timeFormat: string;
-  assignedTasks: EntityRelation<TaskWorkspaceEntity[]>;
-  favorites: EntityRelation<FavoriteWorkspaceEntity[]>;
-  accountOwnerForCompanies: EntityRelation<CompanyWorkspaceEntity[]>;
-  authoredAttachments: EntityRelation<AttachmentWorkspaceEntity[]>;
-  connectedAccounts: EntityRelation<ConnectedAccountWorkspaceEntity[]>;
-  messageParticipants: EntityRelation<MessageParticipantWorkspaceEntity[]>;
-  blocklist: EntityRelation<BlocklistWorkspaceEntity[]>;
-  calendarEventParticipants: EntityRelation<
+  assignedTasks: Relation<TaskWorkspaceEntity[]>;
+  favorites: Relation<FavoriteWorkspaceEntity[]>;
+  accountOwnerForCompanies: Relation<CompanyWorkspaceEntity[]>;
+  authoredAttachments: Relation<AttachmentWorkspaceEntity[]>;
+  connectedAccounts: Relation<ConnectedAccountWorkspaceEntity[]>;
+  messageParticipants: Relation<MessageParticipantWorkspaceEntity[]>;
+  blocklist: Relation<BlocklistWorkspaceEntity[]>;
+  calendarEventParticipants: Relation<
     CalendarEventParticipantWorkspaceEntity[]
   >;
-  timelineActivities: EntityRelation<TimelineActivityWorkspaceEntity[]>;
-  ownedOpportunities: EntityRelation<OpportunityWorkspaceEntity[]>;
+  timelineActivities: Relation<TimelineActivityWorkspaceEntity[]>;
+  ownedOpportunities: Relation<OpportunityWorkspaceEntity[]>;
   searchVector: string;
   numberFormat: string;
 }


### PR DESCRIPTION
## Context
Due to RLS feature, workspaceMember entity and its properties is becoming necessary in different places of the backend. To avoid querying many times, this PR adds a map of workspace members per workspaceId, leveraging WorkspaceCache pattern for WorkspaceEntity (in opposition with CoreEntity)

Due to its content (mostly PII), I prefer to cache it locally only (node process VS Redis) using localDataOnly.

TODO: invalidation logic when the workspaceMember object is updated (more precisely, when its field map is updated). There is no easy way today to update that list so it can be done in another PR imho