### PR TITLE
Refactor runner delete action to be workspace agnostic

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/agent/workspace-migration-agent-actions-builder.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/agent/workspace-migration-agent-actions-builder.service.ts
@@ -64,7 +64,7 @@ export class WorkspaceMigrationAgentActionsBuilderService extends WorkspaceEntit
       action: {
         type: 'delete',
         metadataName: 'agent',
-        entityId: flatAgentToValidate.id,
+        universalIdentifier: flatAgentToValidate.universalIdentifier,
       },
     };
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/command-menu-item/workspace-migration-command-menu-item-actions-builder.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/command-menu-item/workspace-migration-command-menu-item-actions-builder.service.ts
@@ -74,7 +74,7 @@ export class WorkspaceMigrationCommandMenuItemActionsBuilderService extends Work
       action: {
         type: 'delete',
         metadataName: 'commandMenuItem',
-        entityId: flatCommandMenuItemToValidate.id,
+        universalIdentifier: flatCommandMenuItemToValidate.universalIdentifier,
       },
     };
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/cron-trigger/workspace-migration-cron-trigger-action-builder.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/cron-trigger/workspace-migration-cron-trigger-action-builder.service.ts
@@ -74,7 +74,7 @@ export class WorkspaceMigrationCronTriggerActionsBuilderService extends Workspac
       action: {
         type: 'delete',
         metadataName: 'cronTrigger',
-        entityId: flatCronTriggerToValidate.id,
+        universalIdentifier: flatCronTriggerToValidate.universalIdentifier,
       },
     };
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/database-event-trigger/workspace-migration-database-event-trigger-actions-builder.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/database-event-trigger/workspace-migration-database-event-trigger-actions-builder.service.ts
@@ -78,7 +78,8 @@ export class WorkspaceMigrationDatabaseEventTriggerActionsBuilderService extends
       action: {
         type: 'delete',
         metadataName: 'databaseEventTrigger',
-        entityId: flatDatabaseEventTriggerToValidate.id,
+        universalIdentifier:
+          flatDatabaseEventTriggerToValidate.universalIdentifier,
       },
     };
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/field/workspace-migration-field-actions-builder.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/field/workspace-migration-field-actions-builder.service.ts
@@ -72,7 +72,7 @@ export class WorkspaceMigrationFieldActionsBuilderService extends WorkspaceEntit
       action: {
         type: 'delete',
         metadataName: 'fieldMetadata',
-        entityId: flatFieldMetadataToValidate.id,
+        universalIdentifier: flatFieldMetadataToValidate.universalIdentifier,
         objectMetadataId: flatFieldMetadataToValidate.objectMetadataId,
       },
     };

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/front-component/workspace-migration-front-component-actions-builder.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/front-component/workspace-migration-front-component-actions-builder.service.ts
@@ -74,7 +74,7 @@ export class WorkspaceMigrationFrontComponentActionsBuilderService extends Works
       action: {
         type: 'delete',
         metadataName: 'frontComponent',
-        entityId: flatFrontComponentToValidate.id,
+        universalIdentifier: flatFrontComponentToValidate.universalIdentifier,
       },
     };
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/index/workspace-migration-index-actions-builder.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/index/workspace-migration-index-actions-builder.service.ts
@@ -70,7 +70,7 @@ export class WorkspaceMigrationIndexActionsBuilderService extends WorkspaceEntit
       action: {
         type: 'delete',
         metadataName: 'index',
-        entityId: flatIndexToValidate.id,
+        universalIdentifier: flatIndexToValidate.universalIdentifier,
       },
     };
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/object/workspace-migration-object-actions-builder.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/object/workspace-migration-object-actions-builder.service.ts
@@ -71,7 +71,7 @@ export class WorkspaceMigrationObjectActionsBuilderService extends WorkspaceEnti
       action: {
         type: 'delete',
         metadataName: 'objectMetadata',
-        entityId: flatObjectMetadataToValidate.id,
+        universalIdentifier: flatObjectMetadataToValidate.universalIdentifier,
       },
     };
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/page-layout-tab/workspace-migration-page-layout-tab-actions-builder.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/page-layout-tab/workspace-migration-page-layout-tab-actions-builder.service.ts
@@ -74,7 +74,7 @@ export class WorkspaceMigrationPageLayoutTabActionsBuilderService extends Worksp
       action: {
         type: 'delete',
         metadataName: 'pageLayoutTab',
-        entityId: flatPageLayoutTabToValidate.id,
+        universalIdentifier: flatPageLayoutTabToValidate.universalIdentifier,
       },
     };
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/page-layout-widget/workspace-migration-page-layout-widget-actions-builder.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/page-layout-widget/workspace-migration-page-layout-widget-actions-builder.service.ts
@@ -74,8 +74,7 @@ export class WorkspaceMigrationPageLayoutWidgetActionsBuilderService extends Wor
       action: {
         type: 'delete',
         metadataName: 'pageLayoutWidget',
-        universalIdentifier:
-          flatPageLayoutWidgetToValidate.universalIdentifier,
+        universalIdentifier: flatPageLayoutWidgetToValidate.universalIdentifier,
       },
     };
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/page-layout-widget/workspace-migration-page-layout-widget-actions-builder.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/page-layout-widget/workspace-migration-page-layout-widget-actions-builder.service.ts
@@ -74,7 +74,8 @@ export class WorkspaceMigrationPageLayoutWidgetActionsBuilderService extends Wor
       action: {
         type: 'delete',
         metadataName: 'pageLayoutWidget',
-        entityId: flatPageLayoutWidgetToValidate.id,
+        universalIdentifier:
+          flatPageLayoutWidgetToValidate.universalIdentifier,
       },
     };
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/page-layout/workspace-migration-page-layout-actions-builder.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/page-layout/workspace-migration-page-layout-actions-builder.service.ts
@@ -72,7 +72,7 @@ export class WorkspaceMigrationPageLayoutActionsBuilderService extends Workspace
       action: {
         type: 'delete',
         metadataName: 'pageLayout',
-        entityId: flatPageLayoutToValidate.id,
+        universalIdentifier: flatPageLayoutToValidate.universalIdentifier,
       },
     };
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/role-target/workspace-migration-role-target-actions-builder.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/role-target/workspace-migration-role-target-actions-builder.service.ts
@@ -70,7 +70,7 @@ export class WorkspaceMigrationRoleTargetActionsBuilderService extends Workspace
       action: {
         type: 'delete',
         metadataName: 'roleTarget',
-        entityId: flatRoleTargetToValidate.id,
+        universalIdentifier: flatRoleTargetToValidate.universalIdentifier,
       },
     };
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/role/workspace-migration-role-actions-builder.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/role/workspace-migration-role-actions-builder.service.ts
@@ -64,7 +64,7 @@ export class WorkspaceMigrationRoleActionsBuilderService extends WorkspaceEntity
       action: {
         type: 'delete',
         metadataName: 'role',
-        entityId: flatRoleToValidate.id,
+        universalIdentifier: flatRoleToValidate.universalIdentifier,
       },
     };
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/route-trigger/workspace-migration-route-trigger-actions-builder.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/route-trigger/workspace-migration-route-trigger-actions-builder.service.ts
@@ -74,7 +74,7 @@ export class WorkspaceMigrationRouteTriggerActionsBuilderService extends Workspa
       action: {
         type: 'delete',
         metadataName: 'routeTrigger',
-        entityId: flatRouteTriggerToValidate.id,
+        universalIdentifier: flatRouteTriggerToValidate.universalIdentifier,
       },
     };
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/row-level-permission-predicate-group/workspace-migration-row-level-permission-predicate-group-actions-builder.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/row-level-permission-predicate-group/workspace-migration-row-level-permission-predicate-group-actions-builder.service.ts
@@ -74,7 +74,9 @@ export class WorkspaceMigrationRowLevelPermissionPredicateGroupActionsBuilderSer
     }
 
     const {
-      flatEntityToValidate: { id: predicateGroupId },
+      flatEntityToValidate: {
+        universalIdentifier: predicateGroupUniversalIdentifier,
+      },
     } = args;
 
     return {
@@ -82,7 +84,7 @@ export class WorkspaceMigrationRowLevelPermissionPredicateGroupActionsBuilderSer
       action: {
         type: 'delete',
         metadataName: 'rowLevelPermissionPredicateGroup',
-        entityId: predicateGroupId,
+        universalIdentifier: predicateGroupUniversalIdentifier,
       },
     };
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/row-level-permission-predicate/workspace-migration-row-level-permission-predicate-actions-builder.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/row-level-permission-predicate/workspace-migration-row-level-permission-predicate-actions-builder.service.ts
@@ -74,7 +74,7 @@ export class WorkspaceMigrationRowLevelPermissionPredicateActionsBuilderService 
     }
 
     const {
-      flatEntityToValidate: { id: predicateId },
+      flatEntityToValidate: { universalIdentifier: predicateUniversalIdentifier },
     } = args;
 
     return {
@@ -82,7 +82,7 @@ export class WorkspaceMigrationRowLevelPermissionPredicateActionsBuilderService 
       action: {
         type: 'delete',
         metadataName: 'rowLevelPermissionPredicate',
-        entityId: predicateId,
+        universalIdentifier: predicateUniversalIdentifier,
       },
     };
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/row-level-permission-predicate/workspace-migration-row-level-permission-predicate-actions-builder.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/row-level-permission-predicate/workspace-migration-row-level-permission-predicate-actions-builder.service.ts
@@ -74,7 +74,9 @@ export class WorkspaceMigrationRowLevelPermissionPredicateActionsBuilderService 
     }
 
     const {
-      flatEntityToValidate: { universalIdentifier: predicateUniversalIdentifier },
+      flatEntityToValidate: {
+        universalIdentifier: predicateUniversalIdentifier,
+      },
     } = args;
 
     return {

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/serverless-function/workspace-migration-serverless-function-actions-builder.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/serverless-function/workspace-migration-serverless-function-actions-builder.service.ts
@@ -5,9 +5,9 @@ import { ALL_METADATA_NAME } from 'twenty-shared/metadata';
 import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps.util';
 import { UpdateServerlessFunctionAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/serverless-function/types/workspace-migration-serverless-function-action.type';
 import {
-    ValidateAndBuildArgs,
-    ValidateAndBuildReturnType,
-    WorkspaceEntityMigrationBuilderService,
+  ValidateAndBuildArgs,
+  ValidateAndBuildReturnType,
+  WorkspaceEntityMigrationBuilderService,
 } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/services/workspace-entity-migration-builder.service';
 import { FlatEntityUpdateValidationArgs } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/flat-entity-update-validation-args.type';
 import { FlatEntityValidationArgs } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/flat-entity-validation-args.type';
@@ -114,7 +114,8 @@ export class WorkspaceMigrationServerlessFunctionActionsBuilderService extends W
       action: {
         type: 'delete',
         metadataName: 'serverlessFunction',
-        universalIdentifier: flatServerlessFunctionToValidate.universalIdentifier,
+        universalIdentifier:
+          flatServerlessFunctionToValidate.universalIdentifier,
       },
     };
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/serverless-function/workspace-migration-serverless-function-actions-builder.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/serverless-function/workspace-migration-serverless-function-actions-builder.service.ts
@@ -5,9 +5,9 @@ import { ALL_METADATA_NAME } from 'twenty-shared/metadata';
 import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps.util';
 import { UpdateServerlessFunctionAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/serverless-function/types/workspace-migration-serverless-function-action.type';
 import {
-  ValidateAndBuildArgs,
-  ValidateAndBuildReturnType,
-  WorkspaceEntityMigrationBuilderService,
+    ValidateAndBuildArgs,
+    ValidateAndBuildReturnType,
+    WorkspaceEntityMigrationBuilderService,
 } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/services/workspace-entity-migration-builder.service';
 import { FlatEntityUpdateValidationArgs } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/flat-entity-update-validation-args.type';
 import { FlatEntityValidationArgs } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/flat-entity-validation-args.type';
@@ -114,7 +114,7 @@ export class WorkspaceMigrationServerlessFunctionActionsBuilderService extends W
       action: {
         type: 'delete',
         metadataName: 'serverlessFunction',
-        entityId: flatServerlessFunctionToValidate.id,
+        universalIdentifier: flatServerlessFunctionToValidate.universalIdentifier,
       },
     };
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/skill/workspace-migration-skill-actions-builder.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/skill/workspace-migration-skill-actions-builder.service.ts
@@ -64,7 +64,7 @@ export class WorkspaceMigrationSkillActionsBuilderService extends WorkspaceEntit
       action: {
         type: 'delete',
         metadataName: 'skill',
-        entityId: flatSkillToValidate.id,
+        universalIdentifier: flatSkillToValidate.universalIdentifier,
       },
     };
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/view-field/workspace-migration-view-field-actions-builder.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/view-field/workspace-migration-view-field-actions-builder.service.ts
@@ -68,7 +68,7 @@ export class WorkspaceMigrationViewFieldActionsBuilderService extends WorkspaceE
       action: {
         type: 'delete',
         metadataName: 'viewField',
-        entityId: flatViewFieldToValidate.id,
+        universalIdentifier: flatViewFieldToValidate.universalIdentifier,
       },
     };
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/view-filter-group/workspace-migration-view-filter-group-actions-builder.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/view-filter-group/workspace-migration-view-filter-group-actions-builder.service.ts
@@ -74,7 +74,7 @@ export class WorkspaceMigrationViewFilterGroupActionsBuilderService extends Work
       action: {
         type: 'delete',
         metadataName: 'viewFilterGroup',
-        entityId: flatViewFilterGroupToValidate.id,
+        universalIdentifier: flatViewFilterGroupToValidate.universalIdentifier,
       },
     };
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/view-filter/workspace-migration-view-filter-actions-builder.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/view-filter/workspace-migration-view-filter-actions-builder.service.ts
@@ -70,7 +70,7 @@ export class WorkspaceMigrationViewFilterActionsBuilderService extends Workspace
       action: {
         type: 'delete',
         metadataName: 'viewFilter',
-        entityId: flatViewFilterToValidate.id,
+        universalIdentifier: flatViewFilterToValidate.universalIdentifier,
       },
     };
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/view-group/workspace-migration-view-group-actions-builder.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/view-group/workspace-migration-view-group-actions-builder.service.ts
@@ -70,7 +70,7 @@ export class WorkspaceMigrationViewGroupActionsBuilderService extends WorkspaceE
       action: {
         type: 'delete',
         metadataName: 'viewGroup',
-        entityId: flatViewGroupToValidate.id,
+        universalIdentifier: flatViewGroupToValidate.universalIdentifier,
       },
     };
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/view/workspace-migration-view-actions-builder.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/view/workspace-migration-view-actions-builder.service.ts
@@ -64,7 +64,7 @@ export class WorkspaceMigrationViewActionsBuilderService extends WorkspaceEntity
       action: {
         type: 'delete',
         metadataName: 'view',
-        entityId: flatViewToValidate.id,
+        universalIdentifier: flatViewToValidate.universalIdentifier,
       },
     };
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-delete-workspace-migration-action.type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-delete-workspace-migration-action.type.ts
@@ -1,7 +1,7 @@
 import { type AllMetadataName } from 'twenty-shared/metadata';
 
 export type BaseDeleteWorkspaceMigrationAction<T extends AllMetadataName> = {
-  entityId: string;
+  universalIdentifier: string;
   type: 'delete';
   metadataName: T;
 };

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/agent/services/delete-agent-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/agent/services/delete-agent-action-handler.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@nestjs/common';
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
 import { AgentEntity } from 'src/engine/metadata-modules/ai/ai-agent/entities/agent.entity';
+import { findFlatEntityByUniversalIdentifierOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier-or-throw.util';
 import { DeleteAgentAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/agent/types/workspace-migration-agent-action-builder.service';
 import { WorkspaceMigrationActionRunnerArgs } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/types/workspace-migration-action-runner-args.type';
 
@@ -18,13 +19,18 @@ export class DeleteAgentActionHandlerService extends WorkspaceMigrationRunnerAct
   async executeForMetadata(
     context: WorkspaceMigrationActionRunnerArgs<DeleteAgentAction>,
   ): Promise<void> {
-    const { action, queryRunner, workspaceId } = context;
-    const { entityId } = action;
+    const { action, queryRunner, workspaceId, allFlatEntityMaps } = context;
+    const { universalIdentifier } = action;
+
+    const flatAgent = findFlatEntityByUniversalIdentifierOrThrow({
+      flatEntityMaps: allFlatEntityMaps.flatAgentMaps,
+      universalIdentifier,
+    });
 
     const agentRepository =
       queryRunner.manager.getRepository<AgentEntity>(AgentEntity);
 
-    await agentRepository.delete({ id: entityId, workspaceId });
+    await agentRepository.delete({ id: flatAgent.id, workspaceId });
   }
 
   async executeForWorkspaceSchema(

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/command-menu-item/services/delete-command-menu-item-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/command-menu-item/services/delete-command-menu-item-action-handler.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@nestjs/common';
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
 import { CommandMenuItemEntity } from 'src/engine/metadata-modules/command-menu-item/entities/command-menu-item.entity';
+import { findFlatEntityByUniversalIdentifierOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier-or-throw.util';
 import { DeleteCommandMenuItemAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/command-menu-item/types/workspace-migration-command-menu-item-action.type';
 import { WorkspaceMigrationActionRunnerArgs } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/types/workspace-migration-action-runner-args.type';
 
@@ -18,15 +19,23 @@ export class DeleteCommandMenuItemActionHandlerService extends WorkspaceMigratio
   async executeForMetadata(
     context: WorkspaceMigrationActionRunnerArgs<DeleteCommandMenuItemAction>,
   ): Promise<void> {
-    const { action, queryRunner, workspaceId } = context;
-    const { entityId } = action;
+    const { action, queryRunner, workspaceId, allFlatEntityMaps } = context;
+    const { universalIdentifier } = action;
+
+    const flatCommandMenuItem = findFlatEntityByUniversalIdentifierOrThrow({
+      flatEntityMaps: allFlatEntityMaps.flatCommandMenuItemMaps,
+      universalIdentifier,
+    });
 
     const commandMenuItemRepository =
       queryRunner.manager.getRepository<CommandMenuItemEntity>(
         CommandMenuItemEntity,
       );
 
-    await commandMenuItemRepository.delete({ id: entityId, workspaceId });
+    await commandMenuItemRepository.delete({
+      id: flatCommandMenuItem.id,
+      workspaceId,
+    });
   }
 
   async executeForWorkspaceSchema(

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/cron-trigger/services/delete-cron-trigger-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/cron-trigger/services/delete-cron-trigger-action-handler.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@nestjs/common';
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
 import { CronTriggerEntity } from 'src/engine/metadata-modules/cron-trigger/entities/cron-trigger.entity';
+import { findFlatEntityByUniversalIdentifierOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier-or-throw.util';
 import { DeleteCronTriggerAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/cron-trigger/types/workspace-migration-cron-trigger-action.type';
 import { WorkspaceMigrationActionRunnerArgs } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/types/workspace-migration-action-runner-args.type';
 
@@ -18,14 +19,19 @@ export class DeleteCronTriggerActionHandlerService extends WorkspaceMigrationRun
   async executeForMetadata(
     context: WorkspaceMigrationActionRunnerArgs<DeleteCronTriggerAction>,
   ): Promise<void> {
-    const { action, queryRunner, workspaceId } = context;
-    const { entityId } = action;
+    const { action, queryRunner, workspaceId, allFlatEntityMaps } = context;
+    const { universalIdentifier } = action;
+
+    const flatCronTrigger = findFlatEntityByUniversalIdentifierOrThrow({
+      flatEntityMaps: allFlatEntityMaps.flatCronTriggerMaps,
+      universalIdentifier,
+    });
 
     const cronTriggerRepository =
       queryRunner.manager.getRepository<CronTriggerEntity>(CronTriggerEntity);
 
     await cronTriggerRepository.delete({
-      id: entityId,
+      id: flatCronTrigger.id,
       workspaceId,
     });
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/database-event-trigger/services/delete-database-event-trigger-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/database-event-trigger/services/delete-database-event-trigger-action-handler.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@nestjs/common';
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
 import { DatabaseEventTriggerEntity } from 'src/engine/metadata-modules/database-event-trigger/entities/database-event-trigger.entity';
+import { findFlatEntityByUniversalIdentifierOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier-or-throw.util';
 import { DeleteDatabaseEventTriggerAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/database-event-trigger/types/workspace-migration-database-event-trigger-action.type';
 import { WorkspaceMigrationActionRunnerArgs } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/types/workspace-migration-action-runner-args.type';
 
@@ -18,8 +19,15 @@ export class DeleteDatabaseEventTriggerActionHandlerService extends WorkspaceMig
   async executeForMetadata(
     context: WorkspaceMigrationActionRunnerArgs<DeleteDatabaseEventTriggerAction>,
   ): Promise<void> {
-    const { action, queryRunner, workspaceId } = context;
-    const { entityId } = action;
+    const { action, queryRunner, workspaceId, allFlatEntityMaps } = context;
+    const { universalIdentifier } = action;
+
+    const flatDatabaseEventTrigger = findFlatEntityByUniversalIdentifierOrThrow(
+      {
+        flatEntityMaps: allFlatEntityMaps.flatDatabaseEventTriggerMaps,
+        universalIdentifier,
+      },
+    );
 
     const databaseEventTriggerRepository =
       queryRunner.manager.getRepository<DatabaseEventTriggerEntity>(
@@ -27,7 +35,7 @@ export class DeleteDatabaseEventTriggerActionHandlerService extends WorkspaceMig
       );
 
     await databaseEventTriggerRepository.delete({
-      id: entityId,
+      id: flatDatabaseEventTrigger.id,
       workspaceId,
     });
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/field/services/delete-field-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/field/services/delete-field-action-handler.service.ts
@@ -1,7 +1,5 @@
 import { Injectable } from '@nestjs/common';
 
-import { In } from 'typeorm';
-
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
@@ -46,7 +44,8 @@ export class DeleteFieldActionHandlerService extends WorkspaceMigrationRunnerAct
       );
 
     await fieldMetadataRepository.delete({
-      id: In([flatFieldMetadata.id]),
+      id: flatFieldMetadata.id,
+      workspaceId: context.workspaceId,
     });
   }
 

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/field/services/delete-field-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/field/services/delete-field-action-handler.service.ts
@@ -13,9 +13,9 @@ import { type WorkspaceMigrationActionRunnerArgs } from 'src/engine/workspace-ma
 import { generateColumnDefinitions } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/generate-column-definitions.util';
 import { getWorkspaceSchemaContextForMigration } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/get-workspace-schema-context-for-migration.util';
 import {
-    collectEnumOperationsForField,
-    EnumOperation,
-    executeBatchEnumOperations,
+  collectEnumOperationsForField,
+  EnumOperation,
+  executeBatchEnumOperations,
 } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/workspace-schema-enum-operations.util';
 
 @Injectable()

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/front-component/services/delete-front-component-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/front-component/services/delete-front-component-action-handler.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
+import { findFlatEntityByUniversalIdentifierOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier-or-throw.util';
 import { FrontComponentEntity } from 'src/engine/metadata-modules/front-component/entities/front-component.entity';
 import { DeleteFrontComponentAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/front-component/types/workspace-migration-front-component-action.type';
 import { WorkspaceMigrationActionRunnerArgs } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/types/workspace-migration-action-runner-args.type';
@@ -18,15 +19,23 @@ export class DeleteFrontComponentActionHandlerService extends WorkspaceMigration
   async executeForMetadata(
     context: WorkspaceMigrationActionRunnerArgs<DeleteFrontComponentAction>,
   ): Promise<void> {
-    const { action, queryRunner, workspaceId } = context;
-    const { entityId } = action;
+    const { action, queryRunner, workspaceId, allFlatEntityMaps } = context;
+    const { universalIdentifier } = action;
+
+    const flatFrontComponent = findFlatEntityByUniversalIdentifierOrThrow({
+      flatEntityMaps: allFlatEntityMaps.flatFrontComponentMaps,
+      universalIdentifier,
+    });
 
     const frontComponentRepository =
       queryRunner.manager.getRepository<FrontComponentEntity>(
         FrontComponentEntity,
       );
 
-    await frontComponentRepository.delete({ id: entityId, workspaceId });
+    await frontComponentRepository.delete({
+      id: flatFrontComponent.id,
+      workspaceId,
+    });
   }
 
   async executeForWorkspaceSchema(

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/index/services/delete-index-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/index/services/delete-index-action-handler.service.ts
@@ -26,7 +26,7 @@ export class DeleteIndexActionHandlerService extends WorkspaceMigrationRunnerAct
   async executeForMetadata(
     context: WorkspaceMigrationActionRunnerArgs<DeleteIndexAction>,
   ): Promise<void> {
-    const { action, queryRunner, allFlatEntityMaps } = context;
+    const { action, queryRunner, allFlatEntityMaps, workspaceId } = context;
     const { universalIdentifier } = action;
 
     const flatIndex = findFlatEntityByUniversalIdentifierOrThrow({
@@ -37,6 +37,7 @@ export class DeleteIndexActionHandlerService extends WorkspaceMigrationRunnerAct
     await deleteIndexMetadata({
       entityId: flatIndex.id,
       queryRunner,
+      workspaceId,
     });
   }
 

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/index/services/delete-index-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/index/services/delete-index-action-handler.service.ts
@@ -2,13 +2,13 @@ import { Injectable } from '@nestjs/common';
 
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
-import { findFlatEntityByIdInFlatEntityMapsOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps-or-throw.util';
+import { findFlatEntityByUniversalIdentifierOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier-or-throw.util';
 import { WorkspaceSchemaManagerService } from 'src/engine/twenty-orm/workspace-schema-manager/workspace-schema-manager.service';
 import { getWorkspaceSchemaName } from 'src/engine/workspace-datasource/utils/get-workspace-schema-name.util';
 import { type DeleteIndexAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/index/types/workspace-migration-index-action';
 import {
-  deleteIndexMetadata,
-  dropIndexFromWorkspaceSchema,
+    deleteIndexMetadata,
+    dropIndexFromWorkspaceSchema,
 } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/index/utils/index-action-handler.utils';
 import { type WorkspaceMigrationActionRunnerArgs } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/types/workspace-migration-action-runner-args.type';
 
@@ -26,10 +26,16 @@ export class DeleteIndexActionHandlerService extends WorkspaceMigrationRunnerAct
   async executeForMetadata(
     context: WorkspaceMigrationActionRunnerArgs<DeleteIndexAction>,
   ): Promise<void> {
-    const { action, queryRunner } = context;
+    const { action, queryRunner, allFlatEntityMaps } = context;
+    const { universalIdentifier } = action;
+
+    const flatIndex = findFlatEntityByUniversalIdentifierOrThrow({
+      flatEntityMaps: allFlatEntityMaps.flatIndexMaps,
+      universalIdentifier,
+    });
 
     await deleteIndexMetadata({
-      entityId: action.entityId,
+      entityId: flatIndex.id,
       queryRunner,
     });
   }
@@ -43,13 +49,13 @@ export class DeleteIndexActionHandlerService extends WorkspaceMigrationRunnerAct
       queryRunner,
       workspaceId,
     } = context;
+    const { universalIdentifier } = action;
 
-    const flatIndexMetadataToDelete = findFlatEntityByIdInFlatEntityMapsOrThrow(
-      {
-        flatEntityId: action.entityId,
+    const flatIndexMetadataToDelete =
+      findFlatEntityByUniversalIdentifierOrThrow({
+        universalIdentifier,
         flatEntityMaps: flatIndexMaps,
-      },
-    );
+      });
 
     const schemaName = getWorkspaceSchemaName(workspaceId);
 

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/index/services/delete-index-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/index/services/delete-index-action-handler.service.ts
@@ -7,8 +7,8 @@ import { WorkspaceSchemaManagerService } from 'src/engine/twenty-orm/workspace-s
 import { getWorkspaceSchemaName } from 'src/engine/workspace-datasource/utils/get-workspace-schema-name.util';
 import { type DeleteIndexAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/index/types/workspace-migration-index-action';
 import {
-    deleteIndexMetadata,
-    dropIndexFromWorkspaceSchema,
+  deleteIndexMetadata,
+  dropIndexFromWorkspaceSchema,
 } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/index/utils/index-action-handler.utils';
 import { type WorkspaceMigrationActionRunnerArgs } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/types/workspace-migration-action-runner-args.type';
 

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/index/services/update-index-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/index/services/update-index-action-handler.service.ts
@@ -28,12 +28,13 @@ export class UpdateIndexActionHandlerService extends WorkspaceMigrationRunnerAct
   async executeForMetadata(
     context: WorkspaceMigrationActionRunnerArgs<UpdateIndexAction>,
   ): Promise<void> {
-    const { action, queryRunner } = context;
+    const { action, queryRunner, workspaceId } = context;
 
     // Delete old index metadata
     await deleteIndexMetadata({
       entityId: action.entityId,
       queryRunner,
+      workspaceId,
     });
 
     // Create new index metadata

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/index/utils/index-action-handler.utils.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/index/utils/index-action-handler.utils.ts
@@ -124,15 +124,18 @@ export const insertIndexMetadata = async ({
 export const deleteIndexMetadata = async ({
   entityId,
   queryRunner,
+  workspaceId,
 }: {
   entityId: string;
   queryRunner: QueryRunner;
+  workspaceId: string;
 }): Promise<void> => {
   const indexMetadataRepository =
     queryRunner.manager.getRepository<IndexMetadataEntity>(IndexMetadataEntity);
 
   await indexMetadataRepository.delete({
     id: entityId,
+    workspaceId,
   });
 };
 

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/object/services/delete-object-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/object/services/delete-object-action-handler.service.ts
@@ -12,9 +12,9 @@ import { type DeleteObjectAction } from 'src/engine/workspace-manager/workspace-
 import { type WorkspaceMigrationActionRunnerArgs } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/types/workspace-migration-action-runner-args.type';
 import { getWorkspaceSchemaContextForMigration } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/get-workspace-schema-context-for-migration.util';
 import {
-    collectEnumOperationsForObject,
-    EnumOperation,
-    executeBatchEnumOperations,
+  collectEnumOperationsForObject,
+  EnumOperation,
+  executeBatchEnumOperations,
 } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/workspace-schema-enum-operations.util';
 
 @Injectable()

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/object/services/delete-object-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/object/services/delete-object-action-handler.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
-import { findFlatEntityByIdInFlatEntityMapsOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps-or-throw.util';
+import { findFlatEntityByUniversalIdentifierOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier-or-throw.util';
 import { findManyFlatEntityByIdInFlatEntityMapsOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-many-flat-entity-by-id-in-flat-entity-maps-or-throw.util';
 import { isCompositeFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-composite-flat-field-metadata.util';
 import { isEnumFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-enum-flat-field-metadata.util';
@@ -12,9 +12,9 @@ import { type DeleteObjectAction } from 'src/engine/workspace-manager/workspace-
 import { type WorkspaceMigrationActionRunnerArgs } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/types/workspace-migration-action-runner-args.type';
 import { getWorkspaceSchemaContextForMigration } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/get-workspace-schema-context-for-migration.util';
 import {
-  collectEnumOperationsForObject,
-  EnumOperation,
-  executeBatchEnumOperations,
+    collectEnumOperationsForObject,
+    EnumOperation,
+    executeBatchEnumOperations,
 } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/workspace-schema-enum-operations.util';
 
 @Injectable()
@@ -31,15 +31,20 @@ export class DeleteObjectActionHandlerService extends WorkspaceMigrationRunnerAc
   async executeForMetadata(
     context: WorkspaceMigrationActionRunnerArgs<DeleteObjectAction>,
   ): Promise<void> {
-    const { action, queryRunner } = context;
-    const { entityId } = action;
+    const { action, queryRunner, allFlatEntityMaps } = context;
+    const { universalIdentifier } = action;
+
+    const flatObjectMetadata = findFlatEntityByUniversalIdentifierOrThrow({
+      flatEntityMaps: allFlatEntityMaps.flatObjectMetadataMaps,
+      universalIdentifier,
+    });
 
     const objectMetadataRepository =
       queryRunner.manager.getRepository<ObjectMetadataEntity>(
         ObjectMetadataEntity,
       );
 
-    await objectMetadataRepository.delete(entityId);
+    await objectMetadataRepository.delete(flatObjectMetadata.id);
   }
 
   async executeForWorkspaceSchema(
@@ -51,11 +56,11 @@ export class DeleteObjectActionHandlerService extends WorkspaceMigrationRunnerAc
       allFlatEntityMaps: { flatObjectMetadataMaps, flatFieldMetadataMaps },
       workspaceId,
     } = context;
-    const { entityId } = action;
+    const { universalIdentifier } = action;
 
-    const flatObjectMetadata = findFlatEntityByIdInFlatEntityMapsOrThrow({
+    const flatObjectMetadata = findFlatEntityByUniversalIdentifierOrThrow({
       flatEntityMaps: flatObjectMetadataMaps,
-      flatEntityId: entityId,
+      universalIdentifier,
     });
 
     const { schemaName, tableName } = getWorkspaceSchemaContextForMigration({

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/page-layout-tab/services/delete-page-layout-tab-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/page-layout-tab/services/delete-page-layout-tab-action-handler.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
+import { findFlatEntityByUniversalIdentifierOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier-or-throw.util';
 import { PageLayoutTabEntity } from 'src/engine/metadata-modules/page-layout-tab/entities/page-layout-tab.entity';
 import { DeletePageLayoutTabAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/page-layout-tab/types/workspace-migration-page-layout-tab-action.type';
 import { WorkspaceMigrationActionRunnerArgs } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/types/workspace-migration-action-runner-args.type';
@@ -18,15 +19,23 @@ export class DeletePageLayoutTabActionHandlerService extends WorkspaceMigrationR
   async executeForMetadata(
     context: WorkspaceMigrationActionRunnerArgs<DeletePageLayoutTabAction>,
   ): Promise<void> {
-    const { action, queryRunner, workspaceId } = context;
-    const { entityId } = action;
+    const { action, queryRunner, workspaceId, allFlatEntityMaps } = context;
+    const { universalIdentifier } = action;
+
+    const flatPageLayoutTab = findFlatEntityByUniversalIdentifierOrThrow({
+      flatEntityMaps: allFlatEntityMaps.flatPageLayoutTabMaps,
+      universalIdentifier,
+    });
 
     const pageLayoutTabRepository =
       queryRunner.manager.getRepository<PageLayoutTabEntity>(
         PageLayoutTabEntity,
       );
 
-    await pageLayoutTabRepository.delete({ id: entityId, workspaceId });
+    await pageLayoutTabRepository.delete({
+      id: flatPageLayoutTab.id,
+      workspaceId,
+    });
   }
 
   async executeForWorkspaceSchema(

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/page-layout-widget/services/delete-page-layout-widget-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/page-layout-widget/services/delete-page-layout-widget-action-handler.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
+import { findFlatEntityByUniversalIdentifierOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier-or-throw.util';
 import { PageLayoutWidgetEntity } from 'src/engine/metadata-modules/page-layout-widget/entities/page-layout-widget.entity';
 import { DeletePageLayoutWidgetAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/page-layout-widget/types/workspace-migration-page-layout-widget-action.type';
 import { WorkspaceMigrationActionRunnerArgs } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/types/workspace-migration-action-runner-args.type';
@@ -18,15 +19,20 @@ export class DeletePageLayoutWidgetActionHandlerService extends WorkspaceMigrati
   async executeForMetadata(
     context: WorkspaceMigrationActionRunnerArgs<DeletePageLayoutWidgetAction>,
   ): Promise<void> {
-    const { action, queryRunner } = context;
-    const { entityId } = action;
+    const { action, queryRunner, allFlatEntityMaps } = context;
+    const { universalIdentifier } = action;
+
+    const flatPageLayoutWidget = findFlatEntityByUniversalIdentifierOrThrow({
+      flatEntityMaps: allFlatEntityMaps.flatPageLayoutWidgetMaps,
+      universalIdentifier,
+    });
 
     const pageLayoutWidgetRepository =
       queryRunner.manager.getRepository<PageLayoutWidgetEntity>(
         PageLayoutWidgetEntity,
       );
 
-    await pageLayoutWidgetRepository.delete({ id: entityId });
+    await pageLayoutWidgetRepository.delete({ id: flatPageLayoutWidget.id });
   }
 
   async executeForWorkspaceSchema(

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/page-layout/services/delete-page-layout-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/page-layout/services/delete-page-layout-action-handler.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
+import { findFlatEntityByUniversalIdentifierOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier-or-throw.util';
 import { PageLayoutEntity } from 'src/engine/metadata-modules/page-layout/entities/page-layout.entity';
 import { DeletePageLayoutAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/page-layout/types/workspace-migration-page-layout-action.type';
 import { WorkspaceMigrationActionRunnerArgs } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/types/workspace-migration-action-runner-args.type';
@@ -18,13 +19,18 @@ export class DeletePageLayoutActionHandlerService extends WorkspaceMigrationRunn
   async executeForMetadata(
     context: WorkspaceMigrationActionRunnerArgs<DeletePageLayoutAction>,
   ): Promise<void> {
-    const { action, queryRunner, workspaceId } = context;
-    const { entityId } = action;
+    const { action, queryRunner, workspaceId, allFlatEntityMaps } = context;
+    const { universalIdentifier } = action;
+
+    const flatPageLayout = findFlatEntityByUniversalIdentifierOrThrow({
+      flatEntityMaps: allFlatEntityMaps.flatPageLayoutMaps,
+      universalIdentifier,
+    });
 
     const pageLayoutRepository =
       queryRunner.manager.getRepository<PageLayoutEntity>(PageLayoutEntity);
 
-    await pageLayoutRepository.delete({ id: entityId, workspaceId });
+    await pageLayoutRepository.delete({ id: flatPageLayout.id, workspaceId });
   }
 
   async executeForWorkspaceSchema(

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/role-target/services/delete-role-target-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/role-target/services/delete-role-target-action-handler.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
+import { findFlatEntityByUniversalIdentifierOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier-or-throw.util';
 import { RoleTargetEntity } from 'src/engine/metadata-modules/role-target/role-target.entity';
 import { DeleteRoleTargetAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/role-target/types/workspace-migration-role-target-action.type';
 import { WorkspaceMigrationActionRunnerArgs } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/types/workspace-migration-action-runner-args.type';
@@ -18,14 +19,19 @@ export class DeleteRoleTargetActionHandlerService extends WorkspaceMigrationRunn
   async executeForMetadata(
     context: WorkspaceMigrationActionRunnerArgs<DeleteRoleTargetAction>,
   ): Promise<void> {
-    const { action, queryRunner, workspaceId } = context;
-    const { entityId } = action;
+    const { action, queryRunner, workspaceId, allFlatEntityMaps } = context;
+    const { universalIdentifier } = action;
+
+    const flatRoleTarget = findFlatEntityByUniversalIdentifierOrThrow({
+      flatEntityMaps: allFlatEntityMaps.flatRoleTargetMaps,
+      universalIdentifier,
+    });
 
     const roleTargetRepository =
       queryRunner.manager.getRepository<RoleTargetEntity>(RoleTargetEntity);
 
     await roleTargetRepository.delete({
-      id: entityId,
+      id: flatRoleTarget.id,
       workspaceId,
     });
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/role/services/delete-role-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/role/services/delete-role-action-handler.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
+import { findFlatEntityByUniversalIdentifierOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier-or-throw.util';
 import { RoleEntity } from 'src/engine/metadata-modules/role/role.entity';
 import { DeleteRoleAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/role/types/workspace-migration-role-action.type';
 import { WorkspaceMigrationActionRunnerArgs } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/types/workspace-migration-action-runner-args.type';
@@ -18,13 +19,18 @@ export class DeleteRoleActionHandlerService extends WorkspaceMigrationRunnerActi
   async executeForMetadata(
     context: WorkspaceMigrationActionRunnerArgs<DeleteRoleAction>,
   ): Promise<void> {
-    const { action, queryRunner, workspaceId } = context;
-    const { entityId } = action;
+    const { action, queryRunner, workspaceId, allFlatEntityMaps } = context;
+    const { universalIdentifier } = action;
+
+    const flatRole = findFlatEntityByUniversalIdentifierOrThrow({
+      flatEntityMaps: allFlatEntityMaps.flatRoleMaps,
+      universalIdentifier,
+    });
 
     const roleRepository =
       queryRunner.manager.getRepository<RoleEntity>(RoleEntity);
 
-    await roleRepository.delete({ id: entityId, workspaceId });
+    await roleRepository.delete({ id: flatRole.id, workspaceId });
   }
 
   async executeForWorkspaceSchema(

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/route-trigger/services/delete-route-trigger-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/route-trigger/services/delete-route-trigger-action-handler.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
+import { findFlatEntityByUniversalIdentifierOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier-or-throw.util';
 import { RouteTriggerEntity } from 'src/engine/metadata-modules/route-trigger/route-trigger.entity';
 import { DeleteRouteTriggerAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/route-trigger/types/workspace-migration-route-trigger-action.type';
 import { WorkspaceMigrationActionRunnerArgs } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/types/workspace-migration-action-runner-args.type';
@@ -18,14 +19,19 @@ export class DeleteRouteTriggerActionHandlerService extends WorkspaceMigrationRu
   async executeForMetadata(
     context: WorkspaceMigrationActionRunnerArgs<DeleteRouteTriggerAction>,
   ): Promise<void> {
-    const { action, queryRunner, workspaceId } = context;
-    const { entityId } = action;
+    const { action, queryRunner, workspaceId, allFlatEntityMaps } = context;
+    const { universalIdentifier } = action;
+
+    const flatRouteTrigger = findFlatEntityByUniversalIdentifierOrThrow({
+      flatEntityMaps: allFlatEntityMaps.flatRouteTriggerMaps,
+      universalIdentifier,
+    });
 
     const routeTriggerRepository =
       queryRunner.manager.getRepository<RouteTriggerEntity>(RouteTriggerEntity);
 
     await routeTriggerRepository.delete({
-      id: entityId,
+      id: flatRouteTrigger.id,
       workspaceId,
     });
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/row-level-permission-predicate-group/services/delete-row-level-permission-predicate-group-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/row-level-permission-predicate-group/services/delete-row-level-permission-predicate-group-action-handler.service.ts
@@ -4,6 +4,7 @@ import { Injectable } from '@nestjs/common';
 
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
+import { findFlatEntityByUniversalIdentifierOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier-or-throw.util';
 import { RowLevelPermissionPredicateGroupEntity } from 'src/engine/metadata-modules/row-level-permission-predicate/entities/row-level-permission-predicate-group.entity';
 import { DeleteRowLevelPermissionPredicateGroupAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/row-level-permission-predicate-group/types/workspace-migration-row-level-permission-predicate-group-action.type';
 import { WorkspaceMigrationActionRunnerArgs } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/types/workspace-migration-action-runner-args.type';
@@ -16,8 +17,15 @@ export class DeleteRowLevelPermissionPredicateGroupActionHandlerService extends 
   async executeForMetadata(
     context: WorkspaceMigrationActionRunnerArgs<DeleteRowLevelPermissionPredicateGroupAction>,
   ): Promise<void> {
-    const { action, queryRunner, workspaceId } = context;
-    const { entityId } = action;
+    const { action, queryRunner, workspaceId, allFlatEntityMaps } = context;
+    const { universalIdentifier } = action;
+
+    const flatRowLevelPermissionPredicateGroup =
+      findFlatEntityByUniversalIdentifierOrThrow({
+        flatEntityMaps:
+          allFlatEntityMaps.flatRowLevelPermissionPredicateGroupMaps,
+        universalIdentifier,
+      });
 
     const repository =
       queryRunner.manager.getRepository<RowLevelPermissionPredicateGroupEntity>(
@@ -25,7 +33,7 @@ export class DeleteRowLevelPermissionPredicateGroupActionHandlerService extends 
       );
 
     await repository.delete({
-      id: entityId,
+      id: flatRowLevelPermissionPredicateGroup.id,
       workspaceId,
     });
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/row-level-permission-predicate/services/delete-row-level-permission-predicate-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/row-level-permission-predicate/services/delete-row-level-permission-predicate-action-handler.service.ts
@@ -4,6 +4,7 @@ import { Injectable } from '@nestjs/common';
 
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
+import { findFlatEntityByUniversalIdentifierOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier-or-throw.util';
 import { RowLevelPermissionPredicateEntity } from 'src/engine/metadata-modules/row-level-permission-predicate/entities/row-level-permission-predicate.entity';
 import { DeleteRowLevelPermissionPredicateAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/row-level-permission-predicate/types/workspace-migration-row-level-permission-predicate-action.type';
 import { WorkspaceMigrationActionRunnerArgs } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/types/workspace-migration-action-runner-args.type';
@@ -16,8 +17,14 @@ export class DeleteRowLevelPermissionPredicateActionHandlerService extends Works
   async executeForMetadata(
     context: WorkspaceMigrationActionRunnerArgs<DeleteRowLevelPermissionPredicateAction>,
   ): Promise<void> {
-    const { action, queryRunner, workspaceId } = context;
-    const { entityId } = action;
+    const { action, queryRunner, workspaceId, allFlatEntityMaps } = context;
+    const { universalIdentifier } = action;
+
+    const flatRowLevelPermissionPredicate =
+      findFlatEntityByUniversalIdentifierOrThrow({
+        flatEntityMaps: allFlatEntityMaps.flatRowLevelPermissionPredicateMaps,
+        universalIdentifier,
+      });
 
     const repository =
       queryRunner.manager.getRepository<RowLevelPermissionPredicateEntity>(
@@ -25,7 +32,7 @@ export class DeleteRowLevelPermissionPredicateActionHandlerService extends Works
       );
 
     await repository.delete({
-      id: entityId,
+      id: flatRowLevelPermissionPredicate.id,
       workspaceId,
     });
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/skill/services/delete-skill-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/skill/services/delete-skill-action-handler.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
+import { findFlatEntityByUniversalIdentifierOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier-or-throw.util';
 import { SkillEntity } from 'src/engine/metadata-modules/skill/entities/skill.entity';
 import { DeleteSkillAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/skill/types/workspace-migration-skill-action.type';
 import { WorkspaceMigrationActionRunnerArgs } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/types/workspace-migration-action-runner-args.type';
@@ -18,13 +19,18 @@ export class DeleteSkillActionHandlerService extends WorkspaceMigrationRunnerAct
   async executeForMetadata(
     context: WorkspaceMigrationActionRunnerArgs<DeleteSkillAction>,
   ): Promise<void> {
-    const { action, queryRunner, workspaceId } = context;
-    const { entityId } = action;
+    const { action, queryRunner, workspaceId, allFlatEntityMaps } = context;
+    const { universalIdentifier } = action;
+
+    const flatSkill = findFlatEntityByUniversalIdentifierOrThrow({
+      flatEntityMaps: allFlatEntityMaps.flatSkillMaps,
+      universalIdentifier,
+    });
 
     const skillRepository =
       queryRunner.manager.getRepository<SkillEntity>(SkillEntity);
 
-    await skillRepository.delete({ id: entityId, workspaceId });
+    await skillRepository.delete({ id: flatSkill.id, workspaceId });
   }
 
   async executeForWorkspaceSchema(

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/view-field/services/delete-view-field-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/view-field/services/delete-view-field-action-handler.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
+import { findFlatEntityByUniversalIdentifierOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier-or-throw.util';
 import { ViewFieldEntity } from 'src/engine/metadata-modules/view-field/entities/view-field.entity';
 import { DeleteViewFieldAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/view-field/types/workspace-migration-view-field-action.type';
 import { WorkspaceMigrationActionRunnerArgs } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/types/workspace-migration-action-runner-args.type';
@@ -18,14 +19,19 @@ export class DeleteViewFieldActionHandlerService extends WorkspaceMigrationRunne
   async executeForMetadata(
     context: WorkspaceMigrationActionRunnerArgs<DeleteViewFieldAction>,
   ): Promise<void> {
-    const { action, queryRunner, workspaceId } = context;
-    const { entityId } = action;
+    const { action, queryRunner, workspaceId, allFlatEntityMaps } = context;
+    const { universalIdentifier } = action;
+
+    const flatViewField = findFlatEntityByUniversalIdentifierOrThrow({
+      flatEntityMaps: allFlatEntityMaps.flatViewFieldMaps,
+      universalIdentifier,
+    });
 
     const viewFieldRepository =
       queryRunner.manager.getRepository<ViewFieldEntity>(ViewFieldEntity);
 
     await viewFieldRepository.delete({
-      id: entityId,
+      id: flatViewField.id,
       workspaceId,
     });
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/view-filter-group/services/delete-view-filter-group-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/view-filter-group/services/delete-view-filter-group-action-handler.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
+import { findFlatEntityByUniversalIdentifierOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier-or-throw.util';
 import { ViewFilterGroupEntity } from 'src/engine/metadata-modules/view-filter-group/entities/view-filter-group.entity';
 import { type DeleteViewFilterGroupAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/view-filter-group/types/workspace-migration-view-filter-group-action.type';
 import { type WorkspaceMigrationActionRunnerArgs } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/types/workspace-migration-action-runner-args.type';
@@ -18,8 +19,13 @@ export class DeleteViewFilterGroupActionHandlerService extends WorkspaceMigratio
   async executeForMetadata(
     context: WorkspaceMigrationActionRunnerArgs<DeleteViewFilterGroupAction>,
   ): Promise<void> {
-    const { action, queryRunner, workspaceId } = context;
-    const { entityId } = action;
+    const { action, queryRunner, workspaceId, allFlatEntityMaps } = context;
+    const { universalIdentifier } = action;
+
+    const flatViewFilterGroup = findFlatEntityByUniversalIdentifierOrThrow({
+      flatEntityMaps: allFlatEntityMaps.flatViewFilterGroupMaps,
+      universalIdentifier,
+    });
 
     const viewFilterGroupRepository =
       queryRunner.manager.getRepository<ViewFilterGroupEntity>(
@@ -27,7 +33,7 @@ export class DeleteViewFilterGroupActionHandlerService extends WorkspaceMigratio
       );
 
     await viewFilterGroupRepository.delete({
-      id: entityId,
+      id: flatViewFilterGroup.id,
       workspaceId,
     });
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/view-filter/services/delete-view-filter-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/view-filter/services/delete-view-filter-action-handler.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
+import { findFlatEntityByUniversalIdentifierOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier-or-throw.util';
 import { ViewFilterEntity } from 'src/engine/metadata-modules/view-filter/entities/view-filter.entity';
 import { DeleteViewFilterAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/view-filter/types/workspace-migration-view-filter-action.type';
 import { WorkspaceMigrationActionRunnerArgs } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/types/workspace-migration-action-runner-args.type';
@@ -18,14 +19,19 @@ export class DeleteViewFilterActionHandlerService extends WorkspaceMigrationRunn
   async executeForMetadata(
     context: WorkspaceMigrationActionRunnerArgs<DeleteViewFilterAction>,
   ): Promise<void> {
-    const { action, queryRunner, workspaceId } = context;
-    const { entityId } = action;
+    const { action, queryRunner, workspaceId, allFlatEntityMaps } = context;
+    const { universalIdentifier } = action;
+
+    const flatViewFilter = findFlatEntityByUniversalIdentifierOrThrow({
+      flatEntityMaps: allFlatEntityMaps.flatViewFilterMaps,
+      universalIdentifier,
+    });
 
     const viewFilterRepository =
       queryRunner.manager.getRepository<ViewFilterEntity>(ViewFilterEntity);
 
     await viewFilterRepository.delete({
-      id: entityId,
+      id: flatViewFilter.id,
       workspaceId,
     });
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/view-group/services/delete-view-group-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/view-group/services/delete-view-group-action-handler.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
+import { findFlatEntityByUniversalIdentifierOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier-or-throw.util';
 import { ViewGroupEntity } from 'src/engine/metadata-modules/view-group/entities/view-group.entity';
 import { DeleteViewGroupAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/view-group/types/workspace-migration-view-group-action.type';
 import { WorkspaceMigrationActionRunnerArgs } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/types/workspace-migration-action-runner-args.type';
@@ -14,14 +15,19 @@ export class DeleteViewGroupActionHandlerService extends WorkspaceMigrationRunne
   async executeForMetadata(
     context: WorkspaceMigrationActionRunnerArgs<DeleteViewGroupAction>,
   ): Promise<void> {
-    const { action, queryRunner, workspaceId } = context;
-    const { entityId } = action;
+    const { action, queryRunner, workspaceId, allFlatEntityMaps } = context;
+    const { universalIdentifier } = action;
+
+    const flatViewGroup = findFlatEntityByUniversalIdentifierOrThrow({
+      flatEntityMaps: allFlatEntityMaps.flatViewGroupMaps,
+      universalIdentifier,
+    });
 
     const viewGroupRepository =
       queryRunner.manager.getRepository<ViewGroupEntity>(ViewGroupEntity);
 
     await viewGroupRepository.delete({
-      id: entityId,
+      id: flatViewGroup.id,
       workspaceId,
     });
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/view/services/delete-view-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/view/services/delete-view-action-handler.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
+import { findFlatEntityByUniversalIdentifierOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier-or-throw.util';
 import { ViewEntity } from 'src/engine/metadata-modules/view/entities/view.entity';
 import { DeleteViewAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/view/types/workspace-migration-view-action.type';
 import { WorkspaceMigrationActionRunnerArgs } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/types/workspace-migration-action-runner-args.type';
@@ -18,14 +19,19 @@ export class DeleteViewActionHandlerService extends WorkspaceMigrationRunnerActi
   async executeForMetadata(
     context: WorkspaceMigrationActionRunnerArgs<DeleteViewAction>,
   ): Promise<void> {
-    const { action, queryRunner, workspaceId } = context;
-    const { entityId } = action;
+    const { action, queryRunner, workspaceId, allFlatEntityMaps } = context;
+    const { universalIdentifier } = action;
+
+    const flatView = findFlatEntityByUniversalIdentifierOrThrow({
+      flatEntityMaps: allFlatEntityMaps.flatViewMaps,
+      universalIdentifier,
+    });
 
     const viewRepository =
       queryRunner.manager.getRepository<ViewEntity>(ViewEntity);
 
     await viewRepository.delete({
-      id: entityId,
+      id: flatView.id,
       workspaceId,
     });
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/optimistically-apply-delete-action-on-all-flat-entity-maps.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/optimistically-apply-delete-action-on-all-flat-entity-maps.util.ts
@@ -5,7 +5,7 @@ import { type AllFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/
 import { type AllFlatEntityTypesByMetadataName } from 'src/engine/metadata-modules/flat-entity/types/all-flat-entity-types-by-metadata-name';
 import { type MetadataFlatEntity } from 'src/engine/metadata-modules/flat-entity/types/metadata-flat-entity.type';
 import { deleteFlatEntityFromFlatEntityAndRelatedEntityMapsThroughMutationOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/delete-flat-entity-from-flat-entity-and-related-entity-maps-through-mutation-or-throw.util';
-import { findFlatEntityByIdInFlatEntityMapsOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps-or-throw.util';
+import { findFlatEntityByUniversalIdentifierOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier-or-throw.util';
 import { getMetadataFlatEntityMapsKey } from 'src/engine/metadata-modules/flat-entity/utils/get-metadata-flat-entity-maps-key.util';
 
 type DeleteAction<TMetadataName extends AllMetadataName> =
@@ -48,10 +48,10 @@ export const optimisticallyApplyDeleteActionOnAllFlatEntityMaps = <
     case 'pageLayoutTab':
     case 'commandMenuItem':
     case 'frontComponent': {
-      const flatEntityToDelete = findFlatEntityByIdInFlatEntityMapsOrThrow<
+      const flatEntityToDelete = findFlatEntityByUniversalIdentifierOrThrow<
         MetadataFlatEntity<typeof action.metadataName>
       >({
-        flatEntityId: action.entityId,
+        universalIdentifier: action.universalIdentifier,
         flatEntityMaps:
           allFlatEntityMaps[getMetadataFlatEntityMapsKey(action.metadataName)],
       });


### PR DESCRIPTION
# Introduction

Straight to the point refactor passing only universalIdentifier in workspace migration delete actions instead of id so it can be run on any workspace

Related to https://github.com/orgs/twentyhq/projects/1/views/8?pane=issue&itemId=132343284&issue=twentyhq%7Ccore-team-issues%7C1641