### PR TITLE
Refactor Chip right component handling and add tests

### DIFF
--- a/packages/twenty-ui/src/components/chip/Chip.tsx
+++ b/packages/twenty-ui/src/components/chip/Chip.tsx
@@ -1,6 +1,6 @@
 import { type Theme, withTheme } from '@emotion/react';
 import { styled } from '@linaria/react';
-import { type ReactNode } from 'react';
+import { type ReactNode, useMemo } from 'react';
 
 import { OverflowingTextWithTooltip } from '@ui/display/tooltip/OverflowingTextWithTooltip';
 
@@ -127,19 +127,6 @@ const StyledContainer = withTheme(styled.div<
       : 'var(--chip-horizontal-padding)'};
 `);
 
-// TODO: refactor this
-const renderRightComponent = (
-  rightComponent: (() => ReactNode) | ReactNode | null,
-) => {
-  if (!rightComponent) {
-    return null;
-  }
-
-  return typeof rightComponent === 'function'
-    ? rightComponent()
-    : rightComponent;
-};
-
 export const Chip = ({
   size = ChipSize.Small,
   label,
@@ -155,6 +142,16 @@ export const Chip = ({
   forceEmptyText = false,
   emptyLabel = 'Untitled',
 }: ChipProps) => {
+  const resolvedRightComponent = useMemo(() => {
+    if (!rightComponent) {
+      return null;
+    }
+
+    return typeof rightComponent === 'function'
+      ? rightComponent()
+      : rightComponent;
+  }, [rightComponent]);
+
   return (
     <StyledContainer
       data-testid="chip"
@@ -174,7 +171,7 @@ export const Chip = ({
       ) : (
         ''
       )}
-      {renderRightComponent(rightComponent)}
+      {resolvedRightComponent}
     </StyledContainer>
   );
 };

--- a/packages/twenty-ui/src/components/chip/__tests__/Chip.test.tsx
+++ b/packages/twenty-ui/src/components/chip/__tests__/Chip.test.tsx
@@ -1,0 +1,62 @@
+import { ThemeProvider } from '@emotion/react';
+import { render, screen } from '@testing-library/react';
+
+import { THEME_LIGHT } from '@ui/theme';
+
+import { Chip, ChipAccent, ChipSize, ChipVariant } from '../Chip';
+
+const renderWithTheme = (ui: React.ReactElement) => {
+  return render(<ThemeProvider theme={THEME_LIGHT}>{ui}</ThemeProvider>);
+};
+
+describe('Chip', () => {
+  it('renders the label when provided', () => {
+    renderWithTheme(
+      <Chip
+        label="My chip"
+        size={ChipSize.Small}
+        variant={ChipVariant.Regular}
+        accent={ChipAccent.TextPrimary}
+      />,
+    );
+
+    expect(screen.getByText('My chip')).toBeInTheDocument();
+  });
+
+  it('renders the empty label when label is empty and forceEmptyText is false', () => {
+    renderWithTheme(
+      <Chip
+        label=""
+        emptyLabel="Fallback"
+        forceEmptyText={false}
+        size={ChipSize.Small}
+        variant={ChipVariant.Regular}
+      />,
+    );
+
+    expect(screen.getByText('Fallback')).toBeInTheDocument();
+  });
+
+  it('renders rightComponent when provided as a ReactNode', () => {
+    renderWithTheme(
+      <Chip
+        label="With right component"
+        rightComponent={<span data-testid="right-node">Right</span>}
+      />,
+    );
+
+    expect(screen.getByTestId('right-node')).toBeInTheDocument();
+  });
+
+  it('renders rightComponent when provided as a function', () => {
+    renderWithTheme(
+      <Chip
+        label="With right function"
+        rightComponent={() => <span data-testid="right-fn">Right fn</span>}
+      />,
+    );
+
+    expect(screen.getByTestId('right-fn')).toBeInTheDocument();
+  });
+}
+

--- a/packages/twenty-ui/src/components/chip/__tests__/Chip.test.tsx
+++ b/packages/twenty-ui/src/components/chip/__tests__/Chip.test.tsx
@@ -59,4 +59,3 @@ describe('Chip', () => {
     expect(screen.getByTestId('right-fn')).toBeInTheDocument();
   });
 });
-

--- a/packages/twenty-ui/src/components/chip/__tests__/Chip.test.tsx
+++ b/packages/twenty-ui/src/components/chip/__tests__/Chip.test.tsx
@@ -58,5 +58,5 @@ describe('Chip', () => {
 
     expect(screen.getByTestId('right-fn')).toBeInTheDocument();
   });
-}
+});
 


### PR DESCRIPTION
## Summary

- Refactor the Chip component rightComponent handling to use memoized resolution instead of a standalone helper.
- Add unit tests to cover label rendering, empty label fallback, and rightComponent behavior for both node and function inputs.

## Notes

- Tests were added under the twenty-ui package and rely on the existing light theme to ensure correct styling context.