### PR TITLE
[Dashboards] deep-clone widget configuration on duplication to avoid shared draft state

### DIFF
--- a/packages/twenty-front/src/modules/page-layout/hooks/__tests__/useDuplicatePageLayoutWidget.test.tsx
+++ b/packages/twenty-front/src/modules/page-layout/hooks/__tests__/useDuplicatePageLayoutWidget.test.tsx
@@ -1,0 +1,150 @@
+import { useDuplicatePageLayoutWidget } from '@/page-layout/hooks/useDuplicatePageLayoutWidget';
+import { pageLayoutCurrentLayoutsComponentState } from '@/page-layout/states/pageLayoutCurrentLayoutsComponentState';
+import { pageLayoutDraftComponentState } from '@/page-layout/states/pageLayoutDraftComponentState';
+import { useRecoilComponentValue } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValue';
+import { useSetRecoilComponentState } from '@/ui/utilities/state/component-state/hooks/useSetRecoilComponentState';
+import { act, renderHook } from '@testing-library/react';
+import {
+  PageLayoutType,
+  WidgetConfigurationType,
+  WidgetType,
+} from '~/generated/graphql';
+import {
+  PAGE_LAYOUT_TEST_INSTANCE_ID,
+  PageLayoutTestWrapper,
+} from './PageLayoutTestWrapper';
+
+jest.mock('uuid', () => ({
+  v4: jest.fn(() => 'mock-uuid'),
+}));
+
+describe('useDuplicatePageLayoutWidget', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should deep clone widget configuration when duplicating', () => {
+    const { result } = renderHook(
+      () => {
+        const setPageLayoutDraft = useSetRecoilComponentState(
+          pageLayoutDraftComponentState,
+          PAGE_LAYOUT_TEST_INSTANCE_ID,
+        );
+        const setPageLayoutCurrentLayouts = useSetRecoilComponentState(
+          pageLayoutCurrentLayoutsComponentState,
+          PAGE_LAYOUT_TEST_INSTANCE_ID,
+        );
+        const pageLayoutDraft = useRecoilComponentValue(
+          pageLayoutDraftComponentState,
+          PAGE_LAYOUT_TEST_INSTANCE_ID,
+        );
+        const { duplicateWidget } = useDuplicatePageLayoutWidget(
+          PAGE_LAYOUT_TEST_INSTANCE_ID,
+        );
+
+        return {
+          setPageLayoutDraft,
+          setPageLayoutCurrentLayouts,
+          pageLayoutDraft,
+          duplicateWidget,
+        };
+      },
+      {
+        wrapper: PageLayoutTestWrapper,
+      },
+    );
+
+    const now = new Date().toISOString();
+
+    act(() => {
+      result.current.setPageLayoutDraft({
+        id: 'layout-1',
+        name: 'Test Layout',
+        type: PageLayoutType.DASHBOARD,
+        objectMetadataId: null,
+        tabs: [
+          {
+            __typename: 'PageLayoutTab',
+            id: 'tab-1',
+            title: 'Tab 1',
+            position: 0,
+            pageLayoutId: 'layout-1',
+            createdAt: now,
+            updatedAt: now,
+            deletedAt: null,
+            widgets: [
+              {
+                __typename: 'PageLayoutWidget',
+                id: 'widget-1',
+                title: 'Notes',
+                type: WidgetType.STANDALONE_RICH_TEXT,
+                objectMetadataId: null,
+                pageLayoutTabId: 'tab-1',
+                gridPosition: {
+                  __typename: 'GridPosition',
+                  row: 0,
+                  column: 0,
+                  rowSpan: 2,
+                  columnSpan: 2,
+                },
+                configuration: {
+                  __typename: 'StandaloneRichTextConfiguration',
+                  configurationType:
+                    WidgetConfigurationType.STANDALONE_RICH_TEXT,
+                  body: {
+                    __typename: 'RichTextV2Body',
+                    blocknote: '[]',
+                    markdown: null,
+                  },
+                },
+                createdAt: now,
+                updatedAt: now,
+                deletedAt: null,
+              },
+            ],
+          },
+        ],
+      });
+
+      result.current.setPageLayoutCurrentLayouts({
+        'tab-1': {
+          desktop: [
+            {
+              i: 'widget-1',
+              x: 0,
+              y: 0,
+              w: 2,
+              h: 2,
+            },
+          ],
+          mobile: [],
+        },
+      });
+    });
+
+    act(() => {
+      result.current.duplicateWidget('widget-1');
+    });
+
+    const widgets = result.current.pageLayoutDraft.tabs[0].widgets;
+    const sourceWidget = widgets.find((widget) => widget.id === 'widget-1');
+    const duplicatedWidget = widgets.find(
+      (widget) => widget.id === 'mock-uuid',
+    );
+
+    expect(widgets).toHaveLength(2);
+    expect(sourceWidget).toBeDefined();
+    expect(duplicatedWidget).toBeDefined();
+
+    expect(duplicatedWidget?.configuration).toEqual(
+      sourceWidget?.configuration,
+    );
+    expect(duplicatedWidget?.configuration).not.toBe(
+      sourceWidget?.configuration,
+    );
+
+    expect(
+      (duplicatedWidget?.configuration as { body?: unknown })?.body,
+    ).not.toBe((sourceWidget?.configuration as { body?: unknown })?.body);
+  });
+});

--- a/packages/twenty-front/src/modules/page-layout/hooks/__tests__/usePageLayoutWithRelationWidgets.test.tsx
+++ b/packages/twenty-front/src/modules/page-layout/hooks/__tests__/usePageLayoutWithRelationWidgets.test.tsx
@@ -5,6 +5,9 @@ import { type PageLayout } from '@/page-layout/types/PageLayout';
 import { useLayoutRenderingContext } from '@/ui/layout/contexts/LayoutRenderingContext';
 import { renderHook } from '@testing-library/react';
 import {
+  AggregateOperations,
+  BarChartLayout,
+  GraphOrderBy,
   PageLayoutType,
   WidgetConfigurationType,
   WidgetType,
@@ -100,11 +103,11 @@ describe('usePageLayoutWithRelationWidgets', () => {
             configuration: {
               __typename: 'BarChartConfiguration',
               configurationType: WidgetConfigurationType.BAR_CHART,
-              layout: 'VERTICAL',
-              aggregateOperation: 'COUNT',
+              layout: BarChartLayout.VERTICAL,
+              aggregateOperation: AggregateOperations.COUNT,
               aggregateFieldMetadataId: 'id',
               primaryAxisGroupByFieldMetadataId: 'createdAt',
-              primaryAxisOrderBy: 'FIELD_ASC',
+              primaryAxisOrderBy: GraphOrderBy.FIELD_ASC,
               displayDataLabel: false,
             },
             createdAt: new Date().toISOString(),
@@ -222,11 +225,11 @@ describe('usePageLayoutWithRelationWidgets', () => {
               configuration: {
                 __typename: 'BarChartConfiguration',
                 configurationType: WidgetConfigurationType.BAR_CHART,
-                layout: 'VERTICAL',
-                aggregateOperation: 'COUNT',
+                layout: BarChartLayout.VERTICAL,
+                aggregateOperation: AggregateOperations.COUNT,
                 aggregateFieldMetadataId: 'id',
                 primaryAxisGroupByFieldMetadataId: 'createdAt',
-                primaryAxisOrderBy: 'FIELD_ASC',
+                primaryAxisOrderBy: GraphOrderBy.FIELD_ASC,
                 displayDataLabel: false,
               },
               createdAt: new Date().toISOString(),

--- a/packages/twenty-front/src/modules/page-layout/hooks/useDuplicatePageLayoutWidget.ts
+++ b/packages/twenty-front/src/modules/page-layout/hooks/useDuplicatePageLayoutWidget.ts
@@ -77,6 +77,9 @@ export const useDuplicatePageLayoutWidget = (
           ...sourceWidget,
           id: newWidgetId,
           title: appendCopySuffix(sourceWidget.title),
+          configuration: isDefined(sourceWidget.configuration)
+            ? structuredClone(sourceWidget.configuration)
+            : sourceWidget.configuration,
           ...generateDuplicatedTimestamps(),
         };
 


### PR DESCRIPTION
closes 4th issue from this bug bucket - https://github.com/twentyhq/core-team-issues/issues/2109

<img width="767" height="84" alt="CleanShot 2026-01-21 at 17 55 59" src="https://github.com/user-attachments/assets/be112938-68b0-44e9-8436-534fa3014e0d" />
