### PR TITLE
Fix identify remaining entities command to cover soft-deleted rows

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-16/1-16-identify-remaining-entities-metadata.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-16/1-16-identify-remaining-entities-metadata.command.ts
@@ -101,6 +101,7 @@ export class IdentifyRemainingEntitiesMetadataCommand extends ActiveOrSuspendedW
         workspaceId,
         applicationId: IsNull(),
       },
+      withDeleted: true,
     });
 
     if (entitiesWithoutApplicationId.length === 0) {
@@ -164,6 +165,7 @@ export class IdentifyRemainingEntitiesMetadataCommand extends ActiveOrSuspendedW
         workspaceId,
         applicationId: IsNull(),
       },
+      withDeleted: true,
     });
 
     if (viewSortsWithoutApplicationId.length === 0) {


### PR DESCRIPTION
# Introduction
Some entities aren't passing the migration due to not covering the soft deleted rows

## Entities that implements soft deletion
Inserted with universal programmatically
- rowLevelPermissionPredicate
- rowLevelPermissionPredicateGroup
- pageLayout
- pageLayoutTab
- pageLayoutWidget

Legacy might contains null
- viewFilterGroup
- serverlessFunction
- viewSort