### PR TITLE
Fix Gmail sync edge case with multi-label emails

### DIFF
--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-get-message-list.service.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-get-message-list.service.spec.ts
@@ -390,7 +390,10 @@ describe('GmailGetMessageListService', () => {
         messageFolders,
       });
 
-      const expectedQuery = computeGmailExcludeSearchFilter(messageFolders);
+      const expectedQuery = computeGmailExcludeSearchFilter(
+        messageFolders,
+        MessageFolderImportPolicy.SELECTED_FOLDERS,
+      );
 
       expect(mockGmailClient.users.messages.list).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -399,7 +402,7 @@ describe('GmailGetMessageListService', () => {
       );
     });
 
-    it('should not include exclusion filter when ALL_FOLDERS policy is set', async () => {
+    it('should only include default exclusions when ALL_FOLDERS policy is set', async () => {
       const mockGmailClient = {
         users: {
           messages: {
@@ -439,9 +442,11 @@ describe('GmailGetMessageListService', () => {
         ],
       });
 
-      expect(mockGmailClient.users.messages.list).toHaveBeenCalledWith(
-        expect.objectContaining({ q: '' }),
-      );
+      const callArgs = mockGmailClient.users.messages.list.mock.calls[0][0];
+
+      expect(callArgs.q).toContain('-label:spam');
+      expect(callArgs.q).toContain('-category:promotions');
+      expect(callArgs.q).not.toContain('label:inbox');
     });
   });
 

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-get-message-list.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-get-message-list.service.ts
@@ -63,11 +63,10 @@ export class GmailGetMessageListService {
 
     const messageExternalIds: string[] = [];
 
-    const excludedSearchFilter =
-      messageChannel.messageFolderImportPolicy ===
-      MessageFolderImportPolicy.SELECTED_FOLDERS
-        ? computeGmailExcludeSearchFilter(messageFolders)
-        : '';
+    const excludedSearchFilter = computeGmailExcludeSearchFilter(
+      messageFolders,
+      messageChannel.messageFolderImportPolicy,
+    );
 
     while (hasMoreMessages) {
       const messageList = await gmailClient.users.messages

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/utils/__tests__/compute-gmail-exclude-search-filter.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/utils/__tests__/compute-gmail-exclude-search-filter.spec.ts
@@ -1,4 +1,3 @@
-import { MESSAGING_GMAIL_DEFAULT_NOT_SYNCED_LABELS } from 'src/modules/messaging/message-import-manager/drivers/gmail/constants/messaging-gmail-default-not-synced-labels';
 import { computeGmailExcludeSearchFilter } from 'src/modules/messaging/message-import-manager/drivers/gmail/utils/compute-gmail-exclude-search-filter.util';
 
 describe('computeGmailExcludeSearchFilter', () => {
@@ -49,7 +48,7 @@ describe('computeGmailExcludeSearchFilter', () => {
     expect(result).not.toContain('-label:sent');
   });
 
-  it('always excludes spam, promotions, and other unwanted categories', () => {
+  it('uses correct Gmail search syntax for labels and categories', () => {
     const result = computeGmailExcludeSearchFilter([
       {
         externalId: 'Label_1',
@@ -59,9 +58,10 @@ describe('computeGmailExcludeSearchFilter', () => {
       },
     ]);
 
-    MESSAGING_GMAIL_DEFAULT_NOT_SYNCED_LABELS.forEach((label) => {
-      expect(result).toContain(`-label:${label.toLowerCase()}`);
-    });
+    expect(result).toContain('-label:trash');
+    expect(result).toContain('-label:spam');
+    expect(result).toContain('-category:promotions');
+    expect(result).toContain('-category:social');
   });
 
   it('handles nested folder paths correctly', () => {

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/utils/__tests__/compute-gmail-exclude-search-filter.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/utils/__tests__/compute-gmail-exclude-search-filter.spec.ts
@@ -1,85 +1,137 @@
+import { MessageFolderImportPolicy } from 'src/modules/messaging/common/standard-objects/message-channel.workspace-entity';
 import { computeGmailExcludeSearchFilter } from 'src/modules/messaging/message-import-manager/drivers/gmail/utils/compute-gmail-exclude-search-filter.util';
 
 describe('computeGmailExcludeSearchFilter', () => {
-  it('returns empty string when no folders are synced', () => {
-    const result = computeGmailExcludeSearchFilter([
-      {
-        externalId: 'INBOX',
-        name: 'INBOX',
-        isSynced: false,
-        parentFolderId: null,
-      },
-    ]);
+  describe('SELECTED_FOLDERS policy', () => {
+    it('returns empty string when no folders are synced', () => {
+      const result = computeGmailExcludeSearchFilter(
+        [
+          {
+            externalId: 'INBOX',
+            name: 'INBOX',
+            isSynced: false,
+            parentFolderId: null,
+          },
+        ],
+        MessageFolderImportPolicy.SELECTED_FOLDERS,
+      );
 
-    expect(result).toBe('');
+      expect(result).toBe('');
+    });
+
+    it('builds positive OR query for selected folders', () => {
+      const result = computeGmailExcludeSearchFilter(
+        [
+          {
+            externalId: 'Label_1',
+            name: 'CRM',
+            isSynced: true,
+            parentFolderId: null,
+          },
+          {
+            externalId: 'Label_2',
+            name: 'Twenty visible',
+            isSynced: true,
+            parentFolderId: null,
+          },
+          {
+            externalId: 'INBOX',
+            name: 'INBOX',
+            isSynced: false,
+            parentFolderId: null,
+          },
+        ],
+        MessageFolderImportPolicy.SELECTED_FOLDERS,
+      );
+
+      expect(result).toContain('(label:crm OR label:twenty-visible)');
+      expect(result).not.toContain('-label:inbox');
+    });
+
+    it('returns only default exclusions when all folders are synced', () => {
+      const result = computeGmailExcludeSearchFilter(
+        [
+          {
+            externalId: 'INBOX',
+            name: 'INBOX',
+            isSynced: true,
+            parentFolderId: null,
+          },
+          {
+            externalId: 'Label_1',
+            name: 'CRM',
+            isSynced: true,
+            parentFolderId: null,
+          },
+        ],
+        MessageFolderImportPolicy.SELECTED_FOLDERS,
+      );
+
+      expect(result).toContain('-label:spam');
+      expect(result).toContain('-category:promotions');
+      expect(result).not.toContain('label:inbox');
+      expect(result).not.toContain('label:crm');
+    });
+
+    it('handles nested folder paths correctly', () => {
+      const result = computeGmailExcludeSearchFilter(
+        [
+          {
+            externalId: 'Label_parent',
+            name: 'Projects',
+            isSynced: false,
+            parentFolderId: null,
+          },
+          {
+            externalId: 'Label_child',
+            name: 'Active',
+            isSynced: true,
+            parentFolderId: 'Label_parent',
+          },
+        ],
+        MessageFolderImportPolicy.SELECTED_FOLDERS,
+      );
+
+      expect(result).toContain('label:projects-active');
+    });
   });
 
-  it('builds positive OR query for selected folders instead of negative exclusions', () => {
-    const result = computeGmailExcludeSearchFilter([
-      {
-        externalId: 'Label_1',
-        name: 'CRM',
-        isSynced: true,
-        parentFolderId: null,
-      },
-      {
-        externalId: 'Label_2',
-        name: 'Twenty visible',
-        isSynced: true,
-        parentFolderId: null,
-      },
-      {
-        externalId: 'INBOX',
-        name: 'INBOX',
-        isSynced: false,
-        parentFolderId: null,
-      },
-      {
-        externalId: 'SENT',
-        name: 'SENT',
-        isSynced: false,
-        parentFolderId: null,
-      },
-    ]);
+  describe('ALL_FOLDERS policy', () => {
+    it('returns only default exclusions', () => {
+      const result = computeGmailExcludeSearchFilter(
+        [
+          {
+            externalId: 'INBOX',
+            name: 'INBOX',
+            isSynced: true,
+            parentFolderId: null,
+          },
+        ],
+        MessageFolderImportPolicy.ALL_FOLDERS,
+      );
 
-    expect(result).toContain('(label:crm OR label:twenty-visible)');
-
-    expect(result).not.toContain('-label:inbox');
-    expect(result).not.toContain('-label:sent');
+      expect(result).toContain('-label:spam');
+      expect(result).toContain('-category:promotions');
+      expect(result).not.toContain('label:inbox');
+    });
   });
 
   it('uses correct Gmail search syntax for labels and categories', () => {
-    const result = computeGmailExcludeSearchFilter([
-      {
-        externalId: 'Label_1',
-        name: 'Work',
-        isSynced: true,
-        parentFolderId: null,
-      },
-    ]);
+    const result = computeGmailExcludeSearchFilter(
+      [
+        {
+          externalId: 'Label_1',
+          name: 'Work',
+          isSynced: true,
+          parentFolderId: null,
+        },
+      ],
+      MessageFolderImportPolicy.SELECTED_FOLDERS,
+    );
 
     expect(result).toContain('-label:trash');
     expect(result).toContain('-label:spam');
     expect(result).toContain('-category:promotions');
     expect(result).toContain('-category:social');
-  });
-
-  it('handles nested folder paths correctly', () => {
-    const result = computeGmailExcludeSearchFilter([
-      {
-        externalId: 'Label_parent',
-        name: 'Projects',
-        isSynced: false,
-        parentFolderId: null,
-      },
-      {
-        externalId: 'Label_child',
-        name: 'Active',
-        isSynced: true,
-        parentFolderId: 'Label_parent',
-      },
-    ]);
-
-    expect(result).toContain('label:projects-active');
   });
 });

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/utils/compute-gmail-default-not-synced-labels-search-filter.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/utils/compute-gmail-default-not-synced-labels-search-filter.ts
@@ -1,0 +1,13 @@
+const CATEGORY_PREFIX = 'CATEGORY_';
+
+export const computeGmailDefaultNotSyncedLabelsSearchFilter = (
+  labelId: string,
+): string => {
+  if (labelId.startsWith(CATEGORY_PREFIX)) {
+    const category = labelId.slice(CATEGORY_PREFIX.length).toLowerCase();
+
+    return `-category:${category}`;
+  }
+
+  return `-label:${labelId.toLowerCase()}`;
+};

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/utils/compute-gmail-exclude-search-filter.util.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/utils/compute-gmail-exclude-search-filter.util.ts
@@ -1,6 +1,7 @@
 import { isDefined } from 'twenty-shared/utils';
 
 import { type MessageFolderWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message-folder.workspace-entity';
+import { MESSAGING_GMAIL_DEFAULT_NOT_SYNCED_LABELS } from 'src/modules/messaging/message-import-manager/drivers/gmail/constants/messaging-gmail-default-not-synced-labels';
 import { buildGmailLabelSearchName } from 'src/modules/messaging/message-import-manager/drivers/gmail/utils/build-gmail-label-search-name.util';
 
 export const computeGmailExcludeSearchFilter = (
@@ -8,10 +9,24 @@ export const computeGmailExcludeSearchFilter = (
     MessageFolderWorkspaceEntity,
     'externalId' | 'isSynced' | 'name' | 'parentFolderId'
   >[],
-) =>
-  messageFolders
-    .filter((folder) => !folder.isSynced)
+): string => {
+  const labelNamesToInclude = messageFolders
+    .filter((folder) => folder.isSynced)
     .map((folder) => buildGmailLabelSearchName(folder, messageFolders))
-    .filter(isDefined)
-    .map((name) => `-label:${name}`)
-    .join(' ');
+    .filter(isDefined);
+
+  if (labelNamesToInclude.length === 0) {
+    return '';
+  }
+
+  const inclusionQuery =
+    labelNamesToInclude.length === 1
+      ? `label:${labelNamesToInclude[0]}`
+      : `(${labelNamesToInclude.map((name) => `label:${name}`).join(' OR ')})`;
+
+  const defaultExclusions = MESSAGING_GMAIL_DEFAULT_NOT_SYNCED_LABELS.map(
+    (label) => `-label:${label.toLowerCase()}`,
+  ).join(' ');
+
+  return `${inclusionQuery} ${defaultExclusions}`;
+};

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/utils/compute-gmail-exclude-search-filter.util.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/utils/compute-gmail-exclude-search-filter.util.ts
@@ -3,6 +3,7 @@ import { isDefined } from 'twenty-shared/utils';
 import { type MessageFolderWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message-folder.workspace-entity';
 import { MESSAGING_GMAIL_DEFAULT_NOT_SYNCED_LABELS } from 'src/modules/messaging/message-import-manager/drivers/gmail/constants/messaging-gmail-default-not-synced-labels';
 import { buildGmailLabelSearchName } from 'src/modules/messaging/message-import-manager/drivers/gmail/utils/build-gmail-label-search-name.util';
+import { computeGmailDefaultNotSyncedLabelsSearchFilter } from 'src/modules/messaging/message-import-manager/drivers/gmail/utils/compute-gmail-default-not-synced-labels-search-filter';
 
 export const computeGmailExcludeSearchFilter = (
   messageFolders: Pick<
@@ -25,7 +26,7 @@ export const computeGmailExcludeSearchFilter = (
       : `(${labelNamesToInclude.map((name) => `label:${name}`).join(' OR ')})`;
 
   const defaultExclusions = MESSAGING_GMAIL_DEFAULT_NOT_SYNCED_LABELS.map(
-    (label) => `-label:${label.toLowerCase()}`,
+    computeGmailDefaultNotSyncedLabelsSearchFilter,
   ).join(' ');
 
   return `${inclusionQuery} ${defaultExclusions}`;

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/utils/compute-gmail-exclude-search-filter.util.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/utils/compute-gmail-exclude-search-filter.util.ts
@@ -1,5 +1,6 @@
 import { isDefined } from 'twenty-shared/utils';
 
+import { MessageFolderImportPolicy } from 'src/modules/messaging/common/standard-objects/message-channel.workspace-entity';
 import { type MessageFolderWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message-folder.workspace-entity';
 import { MESSAGING_GMAIL_DEFAULT_NOT_SYNCED_LABELS } from 'src/modules/messaging/message-import-manager/drivers/gmail/constants/messaging-gmail-default-not-synced-labels';
 import { buildGmailLabelSearchName } from 'src/modules/messaging/message-import-manager/drivers/gmail/utils/build-gmail-label-search-name.util';
@@ -10,7 +11,24 @@ export const computeGmailExcludeSearchFilter = (
     MessageFolderWorkspaceEntity,
     'externalId' | 'isSynced' | 'name' | 'parentFolderId'
   >[],
+  messageFolderImportPolicy: MessageFolderImportPolicy,
 ): string => {
+  const defaultExclusions = MESSAGING_GMAIL_DEFAULT_NOT_SYNCED_LABELS.map(
+    computeGmailDefaultNotSyncedLabelsSearchFilter,
+  ).join(' ');
+
+  if (messageFolderImportPolicy === MessageFolderImportPolicy.ALL_FOLDERS) {
+    return defaultExclusions;
+  }
+
+  const allFoldersSynced =
+    messageFolders.length > 0 &&
+    messageFolders.every((folder) => folder.isSynced);
+
+  if (allFoldersSynced) {
+    return defaultExclusions;
+  }
+
   const labelNamesToInclude = messageFolders
     .filter((folder) => folder.isSynced)
     .map((folder) => buildGmailLabelSearchName(folder, messageFolders))
@@ -24,10 +42,6 @@ export const computeGmailExcludeSearchFilter = (
     labelNamesToInclude.length === 1
       ? `label:${labelNamesToInclude[0]}`
       : `(${labelNamesToInclude.map((name) => `label:${name}`).join(' OR ')})`;
-
-  const defaultExclusions = MESSAGING_GMAIL_DEFAULT_NOT_SYNCED_LABELS.map(
-    computeGmailDefaultNotSyncedLabelsSearchFilter,
-  ).join(' ');
 
   return `${inclusionQuery} ${defaultExclusions}`;
 };


### PR DESCRIPTION
Gmail emails often have multiple labels - an email in "XYZ" label typically also has "INBOX". The previous negative filter approach (-label:inbox -label:sent...) excluded these emails entirely, even when they had a selected label.

Switched to positive OR filtering: (label:cyz OR label:xyz-visible) -label:spam... which correctly fetches emails with any of the selected labels regardless of other labels they have.

This edge case wasn't caught earlier because manual testing with INBOX selected worked fine - it only surfaced when selecting custom labels without INBOX.