### PR TITLE
Add vscode tasks for integration test run and inputs to debug mode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -68,6 +68,7 @@
         "./jest-integration.config.ts",
         "${relativeFile}",
         "--silent=false",
+        "${input:updateSnapshot}"
       ],
       "cwd": "${workspaceFolder}/packages/twenty-server",
       "console": "integratedTerminal",
@@ -97,6 +98,15 @@
       "env": {
         "NODE_ENV": "test"
       }
+    }
+  ],
+  "inputs": [
+    {
+      "id": "updateSnapshot",
+      "type": "pickString",
+      "description": "Update snapshots?",
+      "options": ["", "--updateSnapshot"],
+      "default": ""
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,12 +2,42 @@
 	"version": "2.0.0",
 	"tasks": [
 		{
-			"type": "npm",
-			"script": "start",
-			"path": "server",
-			"problemMatcher": [],
-			"label": "yarn: start - server",
-			"detail": "yarn start"
+			"label": "twenty-server - run integration test file",
+			"type": "shell",
+			"command": "npx nx run twenty-server:jest -- --config ./jest-integration.config.ts ${relativeFile} --silent=false ${input:watchMode} ${input:updateSnapshot}",
+			"options": {
+				"cwd": "${workspaceFolder}/packages/twenty-server",
+				"env": {
+					"NODE_ENV": "test",
+					"NODE_OPTIONS": "--max-old-space-size=12288 --import tsx/esm"
+				},
+				"shell": {
+					"executable": "/bin/zsh",
+					"args": ["-l", "-c"]
+				}
+			},
+			"presentation": {
+				"reveal": "always",
+				"panel": "new",
+				"close": false
+			},
+			"problemMatcher": []
+		}
+	],
+	"inputs": [
+		{
+			"id": "watchMode",
+			"type": "pickString",
+			"description": "Enable watch mode?",
+			"options": ["", "--watch"],
+			"default": ""
+		},
+		{
+			"id": "updateSnapshot",
+			"type": "pickString",
+			"description": "Update snapshots?",
+			"options": ["", "--updateSnapshot"],
+			"default": ""
 		}
 	]
 }


### PR DESCRIPTION
# Introduction
Created a task that allow spawning a term that will run the opened file and run its integration tests

## Motivation
Jest extension is quite buggy lately, this might just be a tmp workaround but we can't get `run test` within the test file directly. Also passing by task allows giving inputs

## Usage

`cmd+shift+P`-> `run task` -> `twenty server -  run integration test file` -> fill inputs prompts:
- watch: will rerun on every related files updates
- updateSnapshot

Note: you can add a custom shortcut to the task too, also it will appear in task history

Watch mode won't re-create the server instance on each run, meaning that nest won't hit the `createServer` making very fast to iterate with
Down side of this is that any module injection won't get hydrated