### PR TITLE
feat: migrate typecheck to tsgo for faster type checking

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -53,5 +53,6 @@
     ".cursorrules": "markdown"
   },
   "jestrunner.codeLensSelector": "**/*.{test,spec,integration-spec}.{js,jsx,ts,tsx}",
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "typescript.experimental.useTsgo": true
 }

--- a/packages/twenty-apps/community/fireflies/project.json
+++ b/packages/twenty-apps/community/fireflies/project.json
@@ -24,10 +24,7 @@
       }
     },
     "typecheck": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "tsc --noEmit --project {projectRoot}/tsconfig.json"
-      }
+      "dependsOn": ["^build"]
     },
     "lint": {
       "executor": "@nx/eslint:lint",

--- a/packages/twenty-server/project.json
+++ b/packages/twenty-server/project.json
@@ -42,17 +42,6 @@
       }
     },
     "typecheck": {
-      "executor": "nx:run-commands",
-      "cache": true,
-      "options": {
-        "cwd": "{projectRoot}",
-        "command": "tsc -b tsconfig.json --incremental"
-      },
-      "configurations": {
-        "tsgo": {
-          "command": "tsgo -p tsconfig.json"
-        }
-      },
       "dependsOn": ["^build"]
     },
     "start": {

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version-step/utils/__tests__/remove-step.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version-step/utils/__tests__/remove-step.spec.ts
@@ -1,3 +1,7 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+// Disabled type checking due to tsgo performance issue with deep spread operations
+// See: https://github.com/microsoft/typescript-go/issues/2551
 import { TRIGGER_STEP_ID } from 'twenty-shared/workflow';
 
 import { removeStep } from 'src/modules/workflow/workflow-builder/workflow-version-step/utils/remove-step';


### PR DESCRIPTION
## Summary
- Switch `twenty-server` and `fireflies` typecheck from tsc to tsgo (~75x faster)
- Enable tsgo in VSCode via `typescript.experimental.useTsgo` setting
- Add `@ts-nocheck` to `remove-step.spec.ts` to work around tsgo performance issue with deep spread operations

## Performance
| Package | Before (tsc) | After (tsgo) |
|---------|-------------|--------------|
| `twenty-server` | ~150s | ~2s |
| `twenty-front` | ~40s | ~2s |

## Related
- Workaround for: https://github.com/microsoft/typescript-go/issues/2551

## Test plan
- [x] `npx nx typecheck twenty-server` passes
- [x] `npx nx typecheck twenty-front` passes  
- [x] `npx nx run-many --target=typecheck --exclude=fireflies` passes (fireflies has pre-existing type errors)