### PR TITLE
Fix null user crash in admin panel user lookup

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/admin-panel/admin-panel.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/admin-panel/admin-panel.service.ts
@@ -4,6 +4,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { msg } from '@lingui/core/macro';
 import axios from 'axios';
 import semver from 'semver';
+import { isDefined } from 'twenty-shared/utils';
 import { Repository } from 'typeorm';
 import * as z from 'zod';
 
@@ -91,12 +92,14 @@ export class AdminPanelService {
           customDomain: userWorkspace.workspace.customDomain,
           isCustomDomainEnabled: userWorkspace.workspace.isCustomDomainEnabled,
         }),
-        users: userWorkspace.workspace.workspaceUsers.map((workspaceUser) => ({
-          id: workspaceUser.user.id,
-          email: workspaceUser.user.email,
-          firstName: workspaceUser.user.firstName,
-          lastName: workspaceUser.user.lastName,
-        })),
+        users: userWorkspace.workspace.workspaceUsers
+          .filter((workspaceUser) => isDefined(workspaceUser.user))
+          .map((workspaceUser) => ({
+            id: workspaceUser.user.id,
+            email: workspaceUser.user.email,
+            firstName: workspaceUser.user.firstName,
+            lastName: workspaceUser.user.lastName,
+          })),
         featureFlags: allFeatureFlagKeys.map((key) => ({
           key,
           value:

--- a/packages/twenty-server/src/engine/core-modules/workspace/services/workspace.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace/services/workspace.service.ts
@@ -508,6 +508,7 @@ export class WorkspaceService extends TypeOrmQueryService<WorkspaceEntity> {
       : userWorkspaces.length > 0;
 
     if (!hasOtherUserWorkspaces) {
+      await this.userWorkspaceRepository.softDelete({ userId });
       await this.userRepository.softDelete(userId);
     }
   }


### PR DESCRIPTION
Fixes TWENTY-SERVER-EKX

When a user is soft-deleted, their UserWorkspace records could remain in the database pointing to a null user. This caused a TypeError when the admin panel tried to map workspace users.

Two changes:
- Soft-delete all UserWorkspace records when soft-deleting a user in handleRemoveWorkspaceMember
- Filter out null users in the admin panel query as a safety net