### PR TITLE
[DASHBOARDS] Hide pinned workflow actions when dashboard is in edit mode

### DIFF
--- a/packages/twenty-front/src/modules/action-menu/actions/record-actions/run-workflow-actions/hooks/useRunWorkflowRecordActions.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-actions/run-workflow-actions/hooks/useRunWorkflowRecordActions.tsx
@@ -2,6 +2,7 @@ import { Action } from '@/action-menu/actions/components/Action';
 import { isBulkRecordsManualTrigger } from '@/action-menu/actions/record-actions/utils/isBulkRecordsManualTrigger';
 import { ActionScope } from '@/action-menu/actions/types/ActionScope';
 import { ActionType } from '@/action-menu/actions/types/ActionType';
+import { contextStoreIsPageInEditModeComponentState } from '@/context-store/states/contextStoreIsPageInEditModeComponentState';
 import { contextStoreTargetedRecordsRuleComponentState } from '@/context-store/states/contextStoreTargetedRecordsRuleComponentState';
 import { type ObjectMetadataItem } from '@/object-metadata/types/ObjectMetadataItem';
 import { recordStoreFamilyState } from '@/object-record/record-store/states/recordStoreFamilyState';
@@ -29,6 +30,10 @@ export const useRunWorkflowRecordActions = ({
   const { enqueueWarningSnackBar } = useSnackBar();
   const contextStoreTargetedRecordsRule = useRecoilComponentValue(
     contextStoreTargetedRecordsRuleComponentState,
+  );
+
+  const isPageInEditMode = useRecoilComponentValue(
+    contextStoreIsPageInEditModeComponentState,
   );
 
   const selectedRecordIds =
@@ -130,7 +135,9 @@ export const useRunWorkflowRecordActions = ({
         shortLabel: name,
         position: index,
         Icon,
-        isPinned: activeWorkflowVersion.trigger?.settings?.isPinned,
+        isPinned:
+          !isPageInEditMode &&
+          activeWorkflowVersion.trigger?.settings?.isPinned,
         shouldBeRegistered: () => true,
         component: (
           <Action

--- a/packages/twenty-front/src/modules/action-menu/actions/record-agnostic-actions/run-workflow-actions/hooks/useRunWorkflowRecordAgnosticActions.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-agnostic-actions/run-workflow-actions/hooks/useRunWorkflowRecordAgnosticActions.tsx
@@ -2,6 +2,8 @@ import { Action } from '@/action-menu/actions/components/Action';
 import { ActionScope } from '@/action-menu/actions/types/ActionScope';
 import { ActionType } from '@/action-menu/actions/types/ActionType';
 import { ActionMenuContext } from '@/action-menu/contexts/ActionMenuContext';
+import { contextStoreIsPageInEditModeComponentState } from '@/context-store/states/contextStoreIsPageInEditModeComponentState';
+import { useRecoilComponentValue } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValue';
 import { useActiveWorkflowVersionsWithManualTrigger } from '@/workflow/hooks/useActiveWorkflowVersionsWithManualTrigger';
 import { useRunWorkflowVersion } from '@/workflow/hooks/useRunWorkflowVersion';
 import { COMMAND_MENU_DEFAULT_ICON } from '@/workflow/workflow-trigger/constants/CommandMenuDefaultIcon';
@@ -11,6 +13,10 @@ import { useIcons } from 'twenty-ui/display';
 
 export const useRunWorkflowRecordAgnosticActions = () => {
   const { getIcon } = useIcons();
+
+  const isPageInEditMode = useRecoilComponentValue(
+    contextStoreIsPageInEditModeComponentState,
+  );
 
   const { actionMenuType } = useContext(ActionMenuContext);
 
@@ -43,7 +49,9 @@ export const useRunWorkflowRecordAgnosticActions = () => {
         label: name,
         shortLabel: name,
         position: index,
-        isPinned: activeWorkflowVersion.trigger?.settings?.isPinned,
+        isPinned:
+          !isPageInEditMode &&
+          activeWorkflowVersion.trigger?.settings?.isPinned,
         Icon,
         shouldBeRegistered: () => true,
         component: (


### PR DESCRIPTION
## Before

https://github.com/user-attachments/assets/85fe3929-eebf-4412-bdb6-e069e623838d


## After


https://github.com/user-attachments/assets/5fd6d3ea-d667-4c70-86c1-ace57d3aee2f

