### PR TITLE
Exclude community apps from Dependabot scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,8 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    exclude-paths:
+      - "packages/twenty-apps/community/**"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3


### PR DESCRIPTION
## Summary
- Adds `exclude-paths` configuration to Dependabot to skip `packages/twenty-apps/community/**`
- Community-maintained apps have their own dependency management and don't need the same security requirements as core packages

## Test plan
- Verify Dependabot no longer creates alerts/PRs for dependencies in community apps