### PR TITLE
CalDav throw error If a user tries to connect an unsupported server.

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/imap-smtp-caldav-connection/services/imap-smtp-caldav-connection.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/imap-smtp-caldav-connection/services/imap-smtp-caldav-connection.service.ts
@@ -128,11 +128,19 @@ export class ImapSmtpCaldavService {
 
     try {
       await client.listCalendars();
+      await client.validateSyncCollectionSupport();
     } catch (error) {
       this.logger.error(
         `CALDAV connection failed: ${error.message}`,
         error.stack,
       );
+
+      if (error.message?.includes('CALDAV_SYNC_COLLECTION_NOT_SUPPORTED')) {
+        throw new UserInputError(`CALDAV connection failed: ${error.message}`, {
+          userFriendlyMessage: msg`Your CalDAV server does not support incremental sync (RFC 6578). Please use a compatible provider such as Nextcloud, iCloud, or Fastmail.`,
+        });
+      }
+
       if (error.code === 'FailedToOpenSocket') {
         throw new UserInputError(`CALDAV connection failed: ${error.message}`, {
           userFriendlyMessage: msg`We couldn't connect to your CalDAV server. Please check your server settings and try again.`,

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/caldav/lib/caldav.client.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/drivers/caldav/lib/caldav.client.ts
@@ -145,6 +145,32 @@ export class CalDAVClient {
     }
   }
 
+  async validateSyncCollectionSupport(): Promise<void> {
+    const account = await this.getAccount();
+
+    const calendars = await fetchCalendars({
+      account,
+      headers: this.headers,
+    });
+
+    const eventCalendar = calendars.find((calendar) =>
+      calendar.components?.includes('VEVENT'),
+    );
+
+    if (!eventCalendar) {
+      throw new Error('No calendar with event support found');
+    }
+
+    const supportsSyncCollection =
+      eventCalendar.reports?.includes('syncCollection') ?? false;
+
+    if (!supportsSyncCollection) {
+      throw new Error(
+        'CALDAV_SYNC_COLLECTION_NOT_SUPPORTED: Your CalDAV server does not support incremental sync (RFC 6578)',
+      );
+    }
+  }
+
   /**
    * Determines if an event is a full-day event by checking the raw iCal data.
    * Full-day events use VALUE=DATE parameter in DTSTART/DTEND properties.


### PR DESCRIPTION
Legacy CalDav servers don't support `syncCollection` which is required to store a `syncCursor` this PR updates the code to let user know we don't support their server.

Source: https://github.com/natelindev/tsdav/blob/main/src/collection.ts#L193-L194