### PR TITLE
Revert TS LSP to Strada

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -54,5 +54,5 @@
   },
   "jestrunner.codeLensSelector": "**/*.{test,spec,integration-spec}.{js,jsx,ts,tsx}",
   "typescript.tsdk": "node_modules/typescript/lib",
-  "typescript.experimental.useTsgo": true
+  "typescript.experimental.useTsgo": false
 }


### PR DESCRIPTION
Corsa as LSP is not stable yet memory usage increases exponentially which creates memory pressure, this PR reverts it to Strada while still keeping Corsa for typecheck commands and CI

<img width="1590" height="892" alt="image" src="https://github.com/user-attachments/assets/4377ecd5-a0dd-43d7-aeb7-9f8a34ea6c81" />


<img width="1646" height="878" alt="image" src="https://github.com/user-attachments/assets/f82f5075-7404-46be-97a2-3313649d028c" />
