### PR TITLE
Add checksum to manifest

### DIFF
--- a/packages/twenty-sdk/src/application/front-components/front-component-config.ts
+++ b/packages/twenty-sdk/src/application/front-components/front-component-config.ts
@@ -4,7 +4,7 @@ export type FrontComponentType = React.ComponentType<any>;
 
 export type FrontComponentConfig = Omit<
   FrontComponentManifest,
-  'sourceComponentPath' | 'builtComponentPath' | 'componentName'
+  'sourceComponentPath' | 'builtComponentPath' | 'builtComponentChecksum' | 'componentName'
 > & {
   name?: string;
   description?: string;

--- a/packages/twenty-sdk/src/application/functions/function-config.ts
+++ b/packages/twenty-sdk/src/application/functions/function-config.ts
@@ -7,7 +7,7 @@ export type FunctionHandler = (...args: any[]) => any | Promise<any>;
 
 export type FunctionConfig = Omit<
   ServerlessFunctionManifest,
-  'sourceHandlerPath' | 'builtHandlerPath' | 'handlerName'
+  'sourceHandlerPath' | 'builtHandlerPath' | 'builtHandlerChecksum' | 'handlerName'
 > & {
   name?: string;
   description?: string;

--- a/packages/twenty-sdk/src/cli/__tests__/apps/rich-app/__integration__/app-dev/manifest.expected.json
+++ b/packages/twenty-sdk/src/cli/__tests__/apps/rich-app/__integration__/app-dev/manifest.expected.json
@@ -17,6 +17,7 @@
   "frontComponents": [
     {
       "builtComponentPath": "front-components/src/root.front-component.mjs",
+      "builtComponentChecksum": null,
       "componentName": "RootComponent",
       "description": "A root-level front component",
       "name": "root-component",
@@ -25,6 +26,7 @@
     },
     {
       "builtComponentPath": "front-components/src/components/card.front-component.mjs",
+      "builtComponentChecksum": null,
       "componentName": "CardDisplay",
       "description": "A component using an external component file",
       "name": "card-component",
@@ -33,6 +35,7 @@
     },
     {
       "builtComponentPath": "front-components/src/components/greeting.front-component.mjs",
+      "builtComponentChecksum": null,
       "componentName": "GreetingComponent",
       "description": "A component that uses greeting utility",
       "name": "greeting-component",
@@ -41,6 +44,7 @@
     },
     {
       "builtComponentPath": "front-components/src/components/test.front-component.mjs",
+      "builtComponentChecksum": null,
       "componentName": "TestComponent",
       "description": "A test front component",
       "name": "test-component",
@@ -282,6 +286,7 @@
   ],
   "serverlessFunctions": [
     {
+      "builtHandlerChecksum": null,
       "builtHandlerPath": "functions/src/root.function.mjs",
       "handlerName": "rootHandler",
       "name": "root-function",
@@ -299,6 +304,7 @@
       "universalIdentifier": "f0f1f2f3-f4f5-4000-8000-000000000001"
     },
     {
+      "builtHandlerChecksum": null,
       "builtHandlerPath": "functions/src/functions/greeting.function.mjs",
       "handlerName": "greetingHandler",
       "name": "greeting-function",
@@ -316,6 +322,7 @@
       "universalIdentifier": "g0g1g2g3-g4g5-4000-8000-000000000001"
     },
     {
+      "builtHandlerChecksum": null,
       "builtHandlerPath": "functions/src/utils/test-function-2.util.mjs",
       "handlerName": "testFunction2",
       "name": "test-function-2",
@@ -331,6 +338,7 @@
       "universalIdentifier": "eb3ffc98-88ec-45d4-9b4a-56833b219ccb"
     },
     {
+      "builtHandlerChecksum": null,
       "builtHandlerPath": "functions/src/functions/test-function.function.mjs",
       "handlerName": "handler",
       "name": "test-function",

--- a/packages/twenty-sdk/src/cli/__tests__/apps/rich-app/__integration__/app-dev/manifest.expected.json
+++ b/packages/twenty-sdk/src/cli/__tests__/apps/rich-app/__integration__/app-dev/manifest.expected.json
@@ -17,7 +17,7 @@
   "frontComponents": [
     {
       "builtComponentPath": "front-components/src/root.front-component.mjs",
-      "builtComponentChecksum": null,
+      "builtComponentChecksum": "[checksum]",
       "componentName": "RootComponent",
       "description": "A root-level front component",
       "name": "root-component",
@@ -26,7 +26,7 @@
     },
     {
       "builtComponentPath": "front-components/src/components/card.front-component.mjs",
-      "builtComponentChecksum": null,
+      "builtComponentChecksum": "[checksum]",
       "componentName": "CardDisplay",
       "description": "A component using an external component file",
       "name": "card-component",
@@ -35,7 +35,7 @@
     },
     {
       "builtComponentPath": "front-components/src/components/greeting.front-component.mjs",
-      "builtComponentChecksum": null,
+      "builtComponentChecksum": "[checksum]",
       "componentName": "GreetingComponent",
       "description": "A component that uses greeting utility",
       "name": "greeting-component",
@@ -44,7 +44,7 @@
     },
     {
       "builtComponentPath": "front-components/src/components/test.front-component.mjs",
-      "builtComponentChecksum": null,
+      "builtComponentChecksum": "[checksum]",
       "componentName": "TestComponent",
       "description": "A test front component",
       "name": "test-component",
@@ -284,9 +284,9 @@
       "universalIdentifier": "b648f87b-1d26-4961-b974-0908fd991061"
     }
   ],
-  "serverlessFunctions": [
+  "functions": [
     {
-      "builtHandlerChecksum": null,
+      "builtHandlerChecksum": "[checksum]",
       "builtHandlerPath": "functions/src/root.function.mjs",
       "handlerName": "rootHandler",
       "name": "root-function",
@@ -304,7 +304,7 @@
       "universalIdentifier": "f0f1f2f3-f4f5-4000-8000-000000000001"
     },
     {
-      "builtHandlerChecksum": null,
+      "builtHandlerChecksum": "[checksum]",
       "builtHandlerPath": "functions/src/functions/greeting.function.mjs",
       "handlerName": "greetingHandler",
       "name": "greeting-function",
@@ -322,8 +322,8 @@
       "universalIdentifier": "g0g1g2g3-g4g5-4000-8000-000000000001"
     },
     {
-      "builtHandlerChecksum": null,
-      "builtHandlerPath": "functions/src/utils/test-function-2.util.mjs",
+      "builtHandlerChecksum": "[checksum]",
+      "builtHandlerPath": "functions/src/functions/test-function-2.function.mjs",
       "handlerName": "testFunction2",
       "name": "test-function-2",
       "sourceHandlerPath": "src/utils/test-function-2.util.ts",
@@ -338,7 +338,7 @@
       "universalIdentifier": "eb3ffc98-88ec-45d4-9b4a-56833b219ccb"
     },
     {
-      "builtHandlerChecksum": null,
+      "builtHandlerChecksum": "[checksum]",
       "builtHandlerPath": "functions/src/functions/test-function.function.mjs",
       "handlerName": "handler",
       "name": "test-function",

--- a/packages/twenty-sdk/src/cli/__tests__/apps/rich-app/__integration__/app-dev/tests/manifest.tests.ts
+++ b/packages/twenty-sdk/src/cli/__tests__/apps/rich-app/__integration__/app-dev/tests/manifest.tests.ts
@@ -15,12 +15,10 @@ export const defineManifestTests = (appPath: string): void => {
 
       const { sources: _sources, ...sanitizedManifest } = manifest;
 
-      // Compare with checksums normalized to [checksum]
       expect(normalizeManifestForComparison(sanitizedManifest)).toEqual(
         normalizeManifestForComparison(expectedManifest),
       );
 
-      // Verify checksums are populated
       for (const fn of manifest.functions) {
         expect(fn.builtHandlerChecksum).toBeDefined();
         expect(fn.builtHandlerChecksum).not.toBeNull();

--- a/packages/twenty-sdk/src/cli/__tests__/apps/rich-app/__integration__/app-dev/tests/manifest.tests.ts
+++ b/packages/twenty-sdk/src/cli/__tests__/apps/rich-app/__integration__/app-dev/tests/manifest.tests.ts
@@ -3,6 +3,17 @@ import { join } from 'path';
 
 import expectedManifest from '../manifest.expected.json';
 
+// Strip checksums from manifest for comparison (they are populated dynamically)
+const stripChecksums = (manifest: typeof expectedManifest) => ({
+  ...manifest,
+  serverlessFunctions: manifest.serverlessFunctions.map(
+    ({ builtHandlerChecksum: _hc, ...rest }) => rest,
+  ),
+  frontComponents: manifest.frontComponents?.map(
+    ({ builtComponentChecksum: _cc, ...rest }) => rest,
+  ),
+});
+
 export const defineManifestTests = (appPath: string): void => {
   const manifestOutputPath = join(appPath, '.twenty/output/manifest.json');
 
@@ -14,7 +25,21 @@ export const defineManifestTests = (appPath: string): void => {
 
       const { sources: _sources, ...sanitizedManifest } = manifest;
 
-      expect(sanitizedManifest).toEqual(expectedManifest);
+      // Compare without checksums (they are dynamically generated)
+      expect(stripChecksums(sanitizedManifest)).toEqual(stripChecksums(expectedManifest));
+
+      // Verify checksums are populated
+      for (const fn of manifest.serverlessFunctions) {
+        expect(fn.builtHandlerChecksum).toBeDefined();
+        expect(fn.builtHandlerChecksum).not.toBeNull();
+        expect(typeof fn.builtHandlerChecksum).toBe('string');
+      }
+
+      for (const component of manifest.frontComponents ?? []) {
+        expect(component.builtComponentChecksum).toBeDefined();
+        expect(component.builtComponentChecksum).not.toBeNull();
+        expect(typeof component.builtComponentChecksum).toBe('string');
+      }
     });
 
     it('should have correct application config', async () => {

--- a/packages/twenty-sdk/src/cli/__tests__/apps/rich-app/__integration__/app-dev/tests/manifest.tests.ts
+++ b/packages/twenty-sdk/src/cli/__tests__/apps/rich-app/__integration__/app-dev/tests/manifest.tests.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs-extra';
 import { join } from 'path';
 
-import { normalizeManifestForComparison } from '../../../../../integration/utils/normalize-manifest.util';
+import { normalizeManifestForComparison } from '@/cli/__tests__/integration/utils/normalize-manifest.util';
 import expectedManifest from '../manifest.expected.json';
 
 export const defineManifestTests = (appPath: string): void => {

--- a/packages/twenty-sdk/src/cli/__tests__/apps/root-app/__integration__/app-dev/manifest.expected.json
+++ b/packages/twenty-sdk/src/cli/__tests__/apps/root-app/__integration__/app-dev/manifest.expected.json
@@ -41,7 +41,8 @@
       ],
       "handlerName": "myHandler",
       "sourceHandlerPath": "my.function.ts",
-      "builtHandlerPath": "functions/my.function.mjs"
+      "builtHandlerPath": "functions/my.function.mjs",
+      "builtHandlerChecksum": null
     }
   ],
   "frontComponents": [
@@ -51,7 +52,8 @@
       "description": "A root-level front component",
       "componentName": "MyComponent",
       "sourceComponentPath": "my.front-component.tsx",
-      "builtComponentPath": "front-components/my.front-component.mjs"
+      "builtComponentPath": "front-components/my.front-component.mjs",
+      "builtComponentChecksum": null
     }
   ],
   "roles": [

--- a/packages/twenty-sdk/src/cli/__tests__/apps/root-app/__integration__/app-dev/manifest.expected.json
+++ b/packages/twenty-sdk/src/cli/__tests__/apps/root-app/__integration__/app-dev/manifest.expected.json
@@ -25,7 +25,7 @@
       ]
     }
   ],
-  "serverlessFunctions": [
+  "functions": [
     {
       "universalIdentifier": "e1e2e3e4-e5e6-4000-8000-000000000010",
       "name": "my-function",
@@ -42,7 +42,7 @@
       "handlerName": "myHandler",
       "sourceHandlerPath": "my.function.ts",
       "builtHandlerPath": "functions/my.function.mjs",
-      "builtHandlerChecksum": null
+      "builtHandlerChecksum": "[checksum]"
     }
   ],
   "frontComponents": [
@@ -53,7 +53,7 @@
       "componentName": "MyComponent",
       "sourceComponentPath": "my.front-component.tsx",
       "builtComponentPath": "front-components/my.front-component.mjs",
-      "builtComponentChecksum": null
+      "builtComponentChecksum": "[checksum]"
     }
   ],
   "roles": [

--- a/packages/twenty-sdk/src/cli/__tests__/apps/root-app/__integration__/app-dev/tests/manifest.tests.ts
+++ b/packages/twenty-sdk/src/cli/__tests__/apps/root-app/__integration__/app-dev/tests/manifest.tests.ts
@@ -22,12 +22,10 @@ export const defineManifestTests = (appPath: string): void => {
       expect(manifest.application).toEqual(expected.application);
       expect(manifest.objects).toEqual(expected.objects);
 
-      // Compare functions with checksums normalized to [checksum]
       expect(normalizeManifestForComparison({ functions: manifest.functions }).functions).toEqual(
         normalizeManifestForComparison({ functions: expected.functions }).functions,
       );
 
-      // Verify checksums are populated (not null)
       for (const fn of manifest.functions) {
         expect(fn.builtHandlerChecksum).toBeDefined();
         expect(fn.builtHandlerChecksum).not.toBeNull();

--- a/packages/twenty-sdk/src/cli/__tests__/apps/root-app/__integration__/app-dev/tests/manifest.tests.ts
+++ b/packages/twenty-sdk/src/cli/__tests__/apps/root-app/__integration__/app-dev/tests/manifest.tests.ts
@@ -2,6 +2,8 @@ import * as fs from 'fs-extra';
 import { join } from 'path';
 import { type ApplicationManifest } from 'twenty-shared/application';
 
+import { normalizeManifestForComparison } from '../../../../../integration/utils/normalize-manifest.util';
+
 export const defineManifestTests = (appPath: string): void => {
   describe('manifest', () => {
     it('should have generated manifest.json', async () => {
@@ -20,30 +22,24 @@ export const defineManifestTests = (appPath: string): void => {
       expect(manifest.application).toEqual(expected.application);
       expect(manifest.objects).toEqual(expected.objects);
 
-      // Compare serverless functions without checksums (populated dynamically)
-      const manifestFunctionsWithoutChecksums = manifest.serverlessFunctions.map(
-        ({ builtHandlerChecksum: _checksum, ...rest }) => rest,
+      // Compare functions with checksums normalized to [checksum]
+      expect(normalizeManifestForComparison({ functions: manifest.functions }).functions).toEqual(
+        normalizeManifestForComparison({ functions: expected.functions }).functions,
       );
-      const expectedFunctionsWithoutChecksums = expected.serverlessFunctions.map(
-        ({ builtHandlerChecksum: _checksum, ...rest }) => rest,
-      );
-      expect(manifestFunctionsWithoutChecksums).toEqual(expectedFunctionsWithoutChecksums);
 
       // Verify checksums are populated (not null)
-      for (const fn of manifest.serverlessFunctions) {
+      for (const fn of manifest.functions) {
         expect(fn.builtHandlerChecksum).toBeDefined();
         expect(fn.builtHandlerChecksum).not.toBeNull();
         expect(typeof fn.builtHandlerChecksum).toBe('string');
       }
 
-      // Compare front components without checksums (populated dynamically)
-      const manifestComponentsWithoutChecksums = manifest.frontComponents?.map(
-        ({ builtComponentChecksum: _checksum, ...rest }) => rest,
+      // Compare front components with checksums normalized to [checksum]
+      expect(
+        normalizeManifestForComparison({ frontComponents: manifest.frontComponents }).frontComponents,
+      ).toEqual(
+        normalizeManifestForComparison({ frontComponents: expected.frontComponents }).frontComponents,
       );
-      const expectedComponentsWithoutChecksums = expected.frontComponents?.map(
-        ({ builtComponentChecksum: _checksum, ...rest }) => rest,
-      );
-      expect(manifestComponentsWithoutChecksums).toEqual(expectedComponentsWithoutChecksums);
 
       // Verify front component checksums are populated (not null)
       for (const component of manifest.frontComponents ?? []) {

--- a/packages/twenty-sdk/src/cli/__tests__/apps/root-app/__integration__/app-dev/tests/manifest.tests.ts
+++ b/packages/twenty-sdk/src/cli/__tests__/apps/root-app/__integration__/app-dev/tests/manifest.tests.ts
@@ -19,8 +19,38 @@ export const defineManifestTests = (appPath: string): void => {
 
       expect(manifest.application).toEqual(expected.application);
       expect(manifest.objects).toEqual(expected.objects);
-      expect(manifest.serverlessFunctions).toEqual(expected.serverlessFunctions);
-      expect(manifest.frontComponents).toEqual(expected.frontComponents);
+
+      // Compare serverless functions without checksums (populated dynamically)
+      const manifestFunctionsWithoutChecksums = manifest.serverlessFunctions.map(
+        ({ builtHandlerChecksum: _checksum, ...rest }) => rest,
+      );
+      const expectedFunctionsWithoutChecksums = expected.serverlessFunctions.map(
+        ({ builtHandlerChecksum: _checksum, ...rest }) => rest,
+      );
+      expect(manifestFunctionsWithoutChecksums).toEqual(expectedFunctionsWithoutChecksums);
+
+      // Verify checksums are populated (not null)
+      for (const fn of manifest.serverlessFunctions) {
+        expect(fn.builtHandlerChecksum).toBeDefined();
+        expect(fn.builtHandlerChecksum).not.toBeNull();
+        expect(typeof fn.builtHandlerChecksum).toBe('string');
+      }
+
+      // Compare front components without checksums (populated dynamically)
+      const manifestComponentsWithoutChecksums = manifest.frontComponents?.map(
+        ({ builtComponentChecksum: _checksum, ...rest }) => rest,
+      );
+      const expectedComponentsWithoutChecksums = expected.frontComponents?.map(
+        ({ builtComponentChecksum: _checksum, ...rest }) => rest,
+      );
+      expect(manifestComponentsWithoutChecksums).toEqual(expectedComponentsWithoutChecksums);
+
+      // Verify front component checksums are populated (not null)
+      for (const component of manifest.frontComponents ?? []) {
+        expect(component.builtComponentChecksum).toBeDefined();
+        expect(component.builtComponentChecksum).not.toBeNull();
+        expect(typeof component.builtComponentChecksum).toBe('string');
+      }
       expect(manifest.roles).toEqual(expected.roles);
     });
   });

--- a/packages/twenty-sdk/src/cli/__tests__/apps/root-app/__integration__/app-dev/tests/manifest.tests.ts
+++ b/packages/twenty-sdk/src/cli/__tests__/apps/root-app/__integration__/app-dev/tests/manifest.tests.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs-extra';
 import { join } from 'path';
 import { type ApplicationManifest } from 'twenty-shared/application';
 
-import { normalizeManifestForComparison } from '../../../../../integration/utils/normalize-manifest.util';
+import { normalizeManifestForComparison } from '@/cli/__tests__/integration/utils/normalize-manifest.util';
 
 export const defineManifestTests = (appPath: string): void => {
   describe('manifest', () => {

--- a/packages/twenty-sdk/src/cli/__tests__/apps/root-app/__integration__/app-dev/tests/manifest.tests.ts
+++ b/packages/twenty-sdk/src/cli/__tests__/apps/root-app/__integration__/app-dev/tests/manifest.tests.ts
@@ -32,14 +32,12 @@ export const defineManifestTests = (appPath: string): void => {
         expect(typeof fn.builtHandlerChecksum).toBe('string');
       }
 
-      // Compare front components with checksums normalized to [checksum]
       expect(
         normalizeManifestForComparison({ frontComponents: manifest.frontComponents }).frontComponents,
       ).toEqual(
         normalizeManifestForComparison({ frontComponents: expected.frontComponents }).frontComponents,
       );
 
-      // Verify front component checksums are populated (not null)
       for (const component of manifest.frontComponents ?? []) {
         expect(component.builtComponentChecksum).toBeDefined();
         expect(component.builtComponentChecksum).not.toBeNull();

--- a/packages/twenty-sdk/src/cli/__tests__/integration/utils/normalize-manifest.util.ts
+++ b/packages/twenty-sdk/src/cli/__tests__/integration/utils/normalize-manifest.util.ts
@@ -1,0 +1,20 @@
+import { type ApplicationManifest } from 'twenty-shared/application';
+
+// Replace dynamic checksum values with a placeholder for consistent comparisons
+export const normalizeManifestForComparison = <
+  T extends Partial<ApplicationManifest>,
+>(
+  manifest: T,
+): T => ({
+  ...manifest,
+  functions: manifest.functions?.map((fn) => ({
+    ...fn,
+    builtHandlerChecksum: fn.builtHandlerChecksum ? '[checksum]' : null,
+  })),
+  frontComponents: manifest.frontComponents?.map((component) => ({
+    ...component,
+    builtComponentChecksum: component.builtComponentChecksum
+      ? '[checksum]'
+      : null,
+  })),
+});

--- a/packages/twenty-sdk/src/cli/commands/app/app-build.ts
+++ b/packages/twenty-sdk/src/cli/commands/app/app-build.ts
@@ -1,13 +1,11 @@
 import { type ApiResponse } from '@/cli/utilities/api/types/api-response.types';
-import { OUTPUT_DIR } from '@/cli/utilities/build/common/constants';
 import { createLogger } from '@/cli/utilities/build/common/logger';
 import { FrontComponentsWatcher } from '@/cli/utilities/build/front-components/front-component-watcher';
 import { FunctionsWatcher } from '@/cli/utilities/build/functions/function-watcher';
 import { runManifestBuild, type ManifestBuildResult } from '@/cli/utilities/build/manifest/manifest-build';
 import { manifestExtractFromFileServer } from '@/cli/utilities/build/manifest/manifest-extract-from-file-server';
+import { writeManifestToOutput } from '@/cli/utilities/build/manifest/manifest-writer';
 import { CURRENT_EXECUTION_DIRECTORY } from '@/cli/utilities/config/constants/current-execution-directory';
-import * as fs from 'fs-extra';
-import path from 'path';
 
 const initLogger = createLogger('init');
 
@@ -48,10 +46,7 @@ export class AppBuildCommand {
 
     await this.buildFunctions(buildResult);
     await this.buildFrontComponents(buildResult);
-
-    // Write the manifest with populated checksums
-    await this.writeManifestToOutput(buildResult);
-
+    await writeManifestToOutput(this.appPath, buildResult.manifest);
     await this.cleanup();
 
     return buildResult;
@@ -107,15 +102,6 @@ export class AppBuildCommand {
     if (component) {
       component.builtComponentChecksum = checksum;
     }
-  }
-
-  private async writeManifestToOutput(buildResult: ManifestBuildResult): Promise<void> {
-    const manifest = buildResult.manifest;
-    if (!manifest) return;
-
-    const outputDir = path.join(this.appPath, OUTPUT_DIR);
-    const manifestPath = path.join(outputDir, 'manifest.json');
-    await fs.writeJSON(manifestPath, manifest, { spaces: 2 });
   }
 
   private async cleanup(): Promise<void> {

--- a/packages/twenty-sdk/src/cli/commands/app/app-build.ts
+++ b/packages/twenty-sdk/src/cli/commands/app/app-build.ts
@@ -1,10 +1,13 @@
 import { type ApiResponse } from '@/cli/utilities/api/types/api-response.types';
+import { OUTPUT_DIR } from '@/cli/utilities/build/common/constants';
 import { createLogger } from '@/cli/utilities/build/common/logger';
 import { FrontComponentsWatcher } from '@/cli/utilities/build/front-components/front-component-watcher';
 import { FunctionsWatcher } from '@/cli/utilities/build/functions/function-watcher';
 import { runManifestBuild, type ManifestBuildResult } from '@/cli/utilities/build/manifest/manifest-build';
 import { manifestExtractFromFileServer } from '@/cli/utilities/build/manifest/manifest-extract-from-file-server';
 import { CURRENT_EXECUTION_DIRECTORY } from '@/cli/utilities/config/constants/current-execution-directory';
+import * as fs from 'fs-extra';
+import path from 'path';
 
 const initLogger = createLogger('init');
 
@@ -46,6 +49,9 @@ export class AppBuildCommand {
     await this.buildFunctions(buildResult);
     await this.buildFrontComponents(buildResult);
 
+    // Write the manifest with populated checksums
+    await this.writeManifestToOutput(buildResult);
+
     await this.cleanup();
 
     return buildResult;
@@ -56,6 +62,9 @@ export class AppBuildCommand {
       appPath: this.appPath,
       buildResult,
       watch: false,
+      onFileBuilt: (builtPath, checksum) => {
+        this.updateFunctionChecksum(buildResult, builtPath, checksum);
+      },
     });
 
     await this.functionsBuilder.start();
@@ -66,9 +75,47 @@ export class AppBuildCommand {
       appPath: this.appPath,
       buildResult,
       watch: false,
+      onFileBuilt: (builtPath, checksum) => {
+        this.updateFrontComponentChecksum(buildResult, builtPath, checksum);
+      },
     });
 
     await this.frontComponentsBuilder.start();
+  }
+
+  private updateFunctionChecksum(
+    buildResult: ManifestBuildResult,
+    builtPath: string,
+    checksum: string,
+  ): void {
+    const fn = buildResult.manifest?.serverlessFunctions.find(
+      (f) => f.builtHandlerPath === builtPath,
+    );
+    if (fn) {
+      fn.builtHandlerChecksum = checksum;
+    }
+  }
+
+  private updateFrontComponentChecksum(
+    buildResult: ManifestBuildResult,
+    builtPath: string,
+    checksum: string,
+  ): void {
+    const component = buildResult.manifest?.frontComponents?.find(
+      (c) => c.builtComponentPath === builtPath,
+    );
+    if (component) {
+      component.builtComponentChecksum = checksum;
+    }
+  }
+
+  private async writeManifestToOutput(buildResult: ManifestBuildResult): Promise<void> {
+    const manifest = buildResult.manifest;
+    if (!manifest) return;
+
+    const outputDir = path.join(this.appPath, OUTPUT_DIR);
+    const manifestPath = path.join(outputDir, 'manifest.json');
+    await fs.writeJSON(manifestPath, manifest, { spaces: 2 });
   }
 
   private async cleanup(): Promise<void> {

--- a/packages/twenty-sdk/src/cli/commands/app/app-build.ts
+++ b/packages/twenty-sdk/src/cli/commands/app/app-build.ts
@@ -55,7 +55,7 @@ export class AppBuildCommand {
   private async buildFunctions(buildResult: ManifestBuildResult): Promise<void> {
     this.functionsBuilder = new FunctionsWatcher({
       appPath: this.appPath,
-      buildResult,
+      sourcePaths: buildResult.filePaths.functions,
       watch: false,
       onFileBuilt: (builtPath, checksum) => {
         this.updateFunctionChecksum(buildResult, builtPath, checksum);
@@ -68,7 +68,7 @@ export class AppBuildCommand {
   private async buildFrontComponents(buildResult: ManifestBuildResult): Promise<void> {
     this.frontComponentsBuilder = new FrontComponentsWatcher({
       appPath: this.appPath,
-      buildResult,
+      sourcePaths: buildResult.filePaths.frontComponents,
       watch: false,
       onFileBuilt: (builtPath, checksum) => {
         this.updateFrontComponentChecksum(buildResult, builtPath, checksum);

--- a/packages/twenty-sdk/src/cli/commands/app/app-build.ts
+++ b/packages/twenty-sdk/src/cli/commands/app/app-build.ts
@@ -88,7 +88,7 @@ export class AppBuildCommand {
     builtPath: string,
     checksum: string,
   ): void {
-    const fn = buildResult.manifest?.serverlessFunctions.find(
+    const fn = buildResult.manifest?.functions.find(
       (f) => f.builtHandlerPath === builtPath,
     );
     if (fn) {

--- a/packages/twenty-sdk/src/cli/commands/app/app-dev.ts
+++ b/packages/twenty-sdk/src/cli/commands/app/app-dev.ts
@@ -1,7 +1,7 @@
 import { createLogger } from '@/cli/utilities/build/common/logger';
 import { FrontComponentsWatcher } from '@/cli/utilities/build/front-components/front-component-watcher';
 import { FunctionsWatcher } from '@/cli/utilities/build/functions/function-watcher';
-import { runManifestBuild, type ManifestBuildResult } from '@/cli/utilities/build/manifest/manifest-build';
+import { runManifestBuild } from '@/cli/utilities/build/manifest/manifest-build';
 import { ManifestWatcher } from '@/cli/utilities/build/manifest/manifest-watcher';
 import { writeManifestToOutput } from '@/cli/utilities/build/manifest/manifest-writer';
 import { CURRENT_EXECUTION_DIRECTORY } from '@/cli/utilities/config/constants/current-execution-directory';
@@ -67,8 +67,8 @@ export class AppDevCommand {
     this.initializeFileUploadStatus(buildResult.manifest);
 
     await this.startManifestWatcher();
-    await this.startFunctionsWatcher(buildResult);
-    await this.startFrontComponentsWatcher(buildResult);
+    await this.startFunctionsWatcher(buildResult.filePaths.functions);
+    await this.startFrontComponentsWatcher(buildResult.filePaths.frontComponents);
   }
 
   private initializeFileUploadStatus(manifest: ApplicationManifest): void {
@@ -104,12 +104,14 @@ export class AppDevCommand {
             this.initializeFileUploadStatus(result.manifest);
           }
 
-          if (this.functionsWatcher?.shouldRestart(result)) {
-            this.functionsWatcher.restart(result);
+          const functionSourcePaths = result.filePaths.functions;
+          if (this.functionsWatcher?.shouldRestart(functionSourcePaths)) {
+            this.functionsWatcher.restart(functionSourcePaths);
           }
 
-          if (this.frontComponentsWatcher?.shouldRestart(result)) {
-            this.frontComponentsWatcher.restart(result);
+          const componentSourcePaths = result.filePaths.frontComponents;
+          if (this.frontComponentsWatcher?.shouldRestart(componentSourcePaths)) {
+            this.frontComponentsWatcher.restart(componentSourcePaths);
           }
         },
       },
@@ -118,10 +120,10 @@ export class AppDevCommand {
     await this.manifestWatcher.start();
   }
 
-  private async startFunctionsWatcher(buildResult: ManifestBuildResult): Promise<void> {
+  private async startFunctionsWatcher(sourcePaths: string[]): Promise<void> {
     this.functionsWatcher = new FunctionsWatcher({
       appPath: this.appPath,
-      buildResult,
+      sourcePaths,
       onFileBuilt: (builtPath, checksum) => {
         this.updateFunctionFileStatus(builtPath, checksum);
       },
@@ -130,10 +132,10 @@ export class AppDevCommand {
     await this.functionsWatcher.start();
   }
 
-  private async startFrontComponentsWatcher(buildResult: ManifestBuildResult): Promise<void> {
+  private async startFrontComponentsWatcher(sourcePaths: string[]): Promise<void> {
     this.frontComponentsWatcher = new FrontComponentsWatcher({
       appPath: this.appPath,
-      buildResult,
+      sourcePaths,
       onFileBuilt: (builtPath, checksum) => {
         this.updateFrontComponentFileStatus(builtPath, checksum);
       },

--- a/packages/twenty-sdk/src/cli/commands/app/app-dev.ts
+++ b/packages/twenty-sdk/src/cli/commands/app/app-dev.ts
@@ -1,9 +1,12 @@
+import { OUTPUT_DIR } from '@/cli/utilities/build/common/constants';
 import { createLogger } from '@/cli/utilities/build/common/logger';
 import { FrontComponentsWatcher } from '@/cli/utilities/build/front-components/front-component-watcher';
 import { FunctionsWatcher } from '@/cli/utilities/build/functions/function-watcher';
 import { runManifestBuild, type ManifestBuildResult } from '@/cli/utilities/build/manifest/manifest-build';
 import { ManifestWatcher } from '@/cli/utilities/build/manifest/manifest-watcher';
 import { CURRENT_EXECUTION_DIRECTORY } from '@/cli/utilities/config/constants/current-execution-directory';
+import * as fs from 'fs-extra';
+import path from 'path';
 
 const initLogger = createLogger('init');
 
@@ -11,8 +14,20 @@ export type AppDevOptions = {
   appPath?: string;
 };
 
+export type FileStatus = {
+  builtPath: string;
+  checksum: string | null;
+  isUploaded: boolean;
+};
+
+export type FileUploadStatus = {
+  functions: Map<string, FileStatus>;
+  frontComponents: Map<string, FileStatus>;
+};
+
 type AppDevState = {
-  buildResult: ManifestBuildResult | null;
+  manifestBuildResult: ManifestBuildResult | null;
+  fileUploadStatus: FileUploadStatus;
 };
 
 export class AppDevCommand {
@@ -22,7 +37,11 @@ export class AppDevCommand {
 
   private appPath: string = '';
   private state: AppDevState = {
-    buildResult: null,
+    manifestBuildResult: null,
+    fileUploadStatus: {
+      functions: new Map(),
+      frontComponents: new Map(),
+    },
   };
 
   async execute(options: AppDevOptions): Promise<void> {
@@ -38,17 +57,39 @@ export class AppDevCommand {
   }
 
   private async startWatchers(): Promise<void> {
-    const buildResult = await runManifestBuild(this.appPath);
+    const manifestBuildResult = await runManifestBuild(this.appPath);
 
-    if (!buildResult.manifest) {
+    if (!manifestBuildResult.manifest) {
       return;
     }
 
-    this.state.buildResult = buildResult;
+    this.state.manifestBuildResult = manifestBuildResult;
+    this.initializeFileUploadStatus(manifestBuildResult);
 
     await this.startManifestWatcher();
-    await this.startFunctionsWatcher(buildResult);
-    await this.startFrontComponentsWatcher(buildResult);
+    await this.startFunctionsWatcher(manifestBuildResult);
+    await this.startFrontComponentsWatcher(manifestBuildResult);
+  }
+
+  private initializeFileUploadStatus(manifestBuildResult: ManifestBuildResult): void {
+    this.state.fileUploadStatus.functions.clear();
+    this.state.fileUploadStatus.frontComponents.clear();
+
+    for (const fn of manifestBuildResult.manifest?.serverlessFunctions ?? []) {
+      this.state.fileUploadStatus.functions.set(fn.universalIdentifier, {
+        builtPath: fn.builtHandlerPath,
+        checksum: null,
+        isUploaded: false,
+      });
+    }
+
+    for (const component of manifestBuildResult.manifest?.frontComponents ?? []) {
+      this.state.fileUploadStatus.frontComponents.set(component.universalIdentifier, {
+        builtPath: component.builtComponentPath,
+        checksum: null,
+        isUploaded: false,
+      });
+    }
   }
 
   private async startManifestWatcher(): Promise<void> {
@@ -56,7 +97,8 @@ export class AppDevCommand {
       appPath: this.appPath,
       callbacks: {
         onBuildSuccess: (result) => {
-          this.state.buildResult = result;
+          this.state.manifestBuildResult = result;
+          this.initializeFileUploadStatus(result);
 
           if (this.functionsWatcher?.shouldRestart(result)) {
             this.functionsWatcher.restart(result);
@@ -72,22 +114,81 @@ export class AppDevCommand {
     await this.manifestWatcher.start();
   }
 
-  private async startFunctionsWatcher(buildResult: ManifestBuildResult): Promise<void> {
+  private async startFunctionsWatcher(manifestBuildResult: ManifestBuildResult): Promise<void> {
     this.functionsWatcher = new FunctionsWatcher({
       appPath: this.appPath,
-      buildResult,
+      buildResult: manifestBuildResult,
+      onFileBuilt: (builtPath, checksum) => {
+        this.updateFunctionFileStatus(builtPath, checksum);
+      },
     });
 
     await this.functionsWatcher.start();
   }
 
-  private async startFrontComponentsWatcher(buildResult: ManifestBuildResult): Promise<void> {
+  private async startFrontComponentsWatcher(manifestBuildResult: ManifestBuildResult): Promise<void> {
     this.frontComponentsWatcher = new FrontComponentsWatcher({
       appPath: this.appPath,
-      buildResult,
+      buildResult: manifestBuildResult,
+      onFileBuilt: (builtPath, checksum) => {
+        this.updateFrontComponentFileStatus(builtPath, checksum);
+      },
     });
 
     await this.frontComponentsWatcher.start();
+  }
+
+  private updateFunctionFileStatus(builtPath: string, checksum: string): void {
+    for (const [_id, status] of this.state.fileUploadStatus.functions) {
+      if (status.builtPath === builtPath) {
+        status.checksum = checksum;
+        status.isUploaded = false;
+        break;
+      }
+    }
+
+    // Update the manifest with the checksum
+    const manifest = this.state.manifestBuildResult?.manifest;
+    if (manifest) {
+      const fn = manifest.serverlessFunctions.find(
+        (f) => f.builtHandlerPath === builtPath,
+      );
+      if (fn) {
+        fn.builtHandlerChecksum = checksum;
+        this.writeManifestToOutput();
+      }
+    }
+  }
+
+  private updateFrontComponentFileStatus(builtPath: string, checksum: string): void {
+    for (const [_id, status] of this.state.fileUploadStatus.frontComponents) {
+      if (status.builtPath === builtPath) {
+        status.checksum = checksum;
+        status.isUploaded = false;
+        break;
+      }
+    }
+
+    // Update the manifest with the checksum
+    const manifest = this.state.manifestBuildResult?.manifest;
+    if (manifest) {
+      const component = manifest.frontComponents?.find(
+        (c) => c.builtComponentPath === builtPath,
+      );
+      if (component) {
+        component.builtComponentChecksum = checksum;
+        this.writeManifestToOutput();
+      }
+    }
+  }
+
+  private async writeManifestToOutput(): Promise<void> {
+    const manifest = this.state.manifestBuildResult?.manifest;
+    if (!manifest) return;
+
+    const outputDir = path.join(this.appPath, OUTPUT_DIR);
+    const manifestPath = path.join(outputDir, 'manifest.json');
+    await fs.writeJSON(manifestPath, manifest, { spaces: 2 });
   }
 
   private setupGracefulShutdown(): void {

--- a/packages/twenty-sdk/src/cli/commands/app/app-dev.ts
+++ b/packages/twenty-sdk/src/cli/commands/app/app-dev.ts
@@ -1,12 +1,11 @@
-import { OUTPUT_DIR } from '@/cli/utilities/build/common/constants';
 import { createLogger } from '@/cli/utilities/build/common/logger';
 import { FrontComponentsWatcher } from '@/cli/utilities/build/front-components/front-component-watcher';
 import { FunctionsWatcher } from '@/cli/utilities/build/functions/function-watcher';
 import { runManifestBuild, type ManifestBuildResult } from '@/cli/utilities/build/manifest/manifest-build';
 import { ManifestWatcher } from '@/cli/utilities/build/manifest/manifest-watcher';
+import { writeManifestToOutput } from '@/cli/utilities/build/manifest/manifest-writer';
 import { CURRENT_EXECUTION_DIRECTORY } from '@/cli/utilities/config/constants/current-execution-directory';
-import * as fs from 'fs-extra';
-import path from 'path';
+import { type ApplicationManifest } from 'twenty-shared/application';
 
 const initLogger = createLogger('init');
 
@@ -15,6 +14,7 @@ export type AppDevOptions = {
 };
 
 export type FileStatus = {
+  sourcePath: string;
   builtPath: string;
   checksum: string | null;
   isUploaded: boolean;
@@ -26,7 +26,7 @@ export type FileUploadStatus = {
 };
 
 type AppDevState = {
-  manifestBuildResult: ManifestBuildResult | null;
+  manifest: ApplicationManifest | null;
   fileUploadStatus: FileUploadStatus;
 };
 
@@ -37,7 +37,7 @@ export class AppDevCommand {
 
   private appPath: string = '';
   private state: AppDevState = {
-    manifestBuildResult: null,
+    manifest: null,
     fileUploadStatus: {
       functions: new Map(),
       frontComponents: new Map(),
@@ -57,34 +57,36 @@ export class AppDevCommand {
   }
 
   private async startWatchers(): Promise<void> {
-    const manifestBuildResult = await runManifestBuild(this.appPath);
+    const buildResult = await runManifestBuild(this.appPath);
 
-    if (!manifestBuildResult.manifest) {
+    if (!buildResult.manifest) {
       return;
     }
 
-    this.state.manifestBuildResult = manifestBuildResult;
-    this.initializeFileUploadStatus(manifestBuildResult);
+    this.state.manifest = buildResult.manifest;
+    this.initializeFileUploadStatus(buildResult.manifest);
 
     await this.startManifestWatcher();
-    await this.startFunctionsWatcher(manifestBuildResult);
-    await this.startFrontComponentsWatcher(manifestBuildResult);
+    await this.startFunctionsWatcher(buildResult);
+    await this.startFrontComponentsWatcher(buildResult);
   }
 
-  private initializeFileUploadStatus(manifestBuildResult: ManifestBuildResult): void {
+  private initializeFileUploadStatus(manifest: ApplicationManifest): void {
     this.state.fileUploadStatus.functions.clear();
     this.state.fileUploadStatus.frontComponents.clear();
 
-    for (const fn of manifestBuildResult.manifest?.functions ?? []) {
+    for (const fn of manifest.functions ?? []) {
       this.state.fileUploadStatus.functions.set(fn.universalIdentifier, {
+        sourcePath: fn.sourceHandlerPath,
         builtPath: fn.builtHandlerPath,
         checksum: null,
         isUploaded: false,
       });
     }
 
-    for (const component of manifestBuildResult.manifest?.frontComponents ?? []) {
+    for (const component of manifest.frontComponents ?? []) {
       this.state.fileUploadStatus.frontComponents.set(component.universalIdentifier, {
+        sourcePath: component.sourceComponentPath,
         builtPath: component.builtComponentPath,
         checksum: null,
         isUploaded: false,
@@ -97,8 +99,10 @@ export class AppDevCommand {
       appPath: this.appPath,
       callbacks: {
         onBuildSuccess: (result) => {
-          this.state.manifestBuildResult = result;
-          this.initializeFileUploadStatus(result);
+          this.state.manifest = result.manifest;
+          if (result.manifest) {
+            this.initializeFileUploadStatus(result.manifest);
+          }
 
           if (this.functionsWatcher?.shouldRestart(result)) {
             this.functionsWatcher.restart(result);
@@ -114,10 +118,10 @@ export class AppDevCommand {
     await this.manifestWatcher.start();
   }
 
-  private async startFunctionsWatcher(manifestBuildResult: ManifestBuildResult): Promise<void> {
+  private async startFunctionsWatcher(buildResult: ManifestBuildResult): Promise<void> {
     this.functionsWatcher = new FunctionsWatcher({
       appPath: this.appPath,
-      buildResult: manifestBuildResult,
+      buildResult,
       onFileBuilt: (builtPath, checksum) => {
         this.updateFunctionFileStatus(builtPath, checksum);
       },
@@ -126,10 +130,10 @@ export class AppDevCommand {
     await this.functionsWatcher.start();
   }
 
-  private async startFrontComponentsWatcher(manifestBuildResult: ManifestBuildResult): Promise<void> {
+  private async startFrontComponentsWatcher(buildResult: ManifestBuildResult): Promise<void> {
     this.frontComponentsWatcher = new FrontComponentsWatcher({
       appPath: this.appPath,
-      buildResult: manifestBuildResult,
+      buildResult,
       onFileBuilt: (builtPath, checksum) => {
         this.updateFrontComponentFileStatus(builtPath, checksum);
       },
@@ -147,15 +151,12 @@ export class AppDevCommand {
       }
     }
 
-    // Update the manifest with the checksum
-    const manifest = this.state.manifestBuildResult?.manifest;
+    const manifest = this.state.manifest;
     if (manifest) {
-      const fn = manifest.functions.find(
-        (f) => f.builtHandlerPath === builtPath,
-      );
+      const fn = manifest.functions.find((f) => f.builtHandlerPath === builtPath);
       if (fn) {
         fn.builtHandlerChecksum = checksum;
-        this.writeManifestToOutput();
+        writeManifestToOutput(this.appPath, manifest);
       }
     }
   }
@@ -169,26 +170,16 @@ export class AppDevCommand {
       }
     }
 
-    // Update the manifest with the checksum
-    const manifest = this.state.manifestBuildResult?.manifest;
+    const manifest = this.state.manifest;
     if (manifest) {
       const component = manifest.frontComponents?.find(
         (c) => c.builtComponentPath === builtPath,
       );
       if (component) {
         component.builtComponentChecksum = checksum;
-        this.writeManifestToOutput();
+        writeManifestToOutput(this.appPath, manifest);
       }
     }
-  }
-
-  private async writeManifestToOutput(): Promise<void> {
-    const manifest = this.state.manifestBuildResult?.manifest;
-    if (!manifest) return;
-
-    const outputDir = path.join(this.appPath, OUTPUT_DIR);
-    const manifestPath = path.join(outputDir, 'manifest.json');
-    await fs.writeJSON(manifestPath, manifest, { spaces: 2 });
   }
 
   private setupGracefulShutdown(): void {

--- a/packages/twenty-sdk/src/cli/commands/app/app-dev.ts
+++ b/packages/twenty-sdk/src/cli/commands/app/app-dev.ts
@@ -75,7 +75,7 @@ export class AppDevCommand {
     this.state.fileUploadStatus.functions.clear();
     this.state.fileUploadStatus.frontComponents.clear();
 
-    for (const fn of manifestBuildResult.manifest?.serverlessFunctions ?? []) {
+    for (const fn of manifestBuildResult.manifest?.functions ?? []) {
       this.state.fileUploadStatus.functions.set(fn.universalIdentifier, {
         builtPath: fn.builtHandlerPath,
         checksum: null,
@@ -150,7 +150,7 @@ export class AppDevCommand {
     // Update the manifest with the checksum
     const manifest = this.state.manifestBuildResult?.manifest;
     if (manifest) {
-      const fn = manifest.serverlessFunctions.find(
+      const fn = manifest.functions.find(
         (f) => f.builtHandlerPath === builtPath,
       );
       if (fn) {

--- a/packages/twenty-sdk/src/cli/commands/app/app-dev.ts
+++ b/packages/twenty-sdk/src/cli/commands/app/app-dev.ts
@@ -20,14 +20,14 @@ export type FileStatus = {
   isUploaded: boolean;
 };
 
-export type FileUploadStatus = {
+export type FileStatusMaps = {
   functions: Map<string, FileStatus>;
   frontComponents: Map<string, FileStatus>;
 };
 
 type AppDevState = {
   manifest: ApplicationManifest | null;
-  fileUploadStatus: FileUploadStatus;
+  fileStatusMaps: FileStatusMaps;
 };
 
 export class AppDevCommand {
@@ -38,7 +38,7 @@ export class AppDevCommand {
   private appPath: string = '';
   private state: AppDevState = {
     manifest: null,
-    fileUploadStatus: {
+    fileStatusMaps: {
       functions: new Map(),
       frontComponents: new Map(),
     },
@@ -73,10 +73,10 @@ export class AppDevCommand {
   }
 
   private initializeFunctionsFileUploadStatus(manifest: ApplicationManifest): void {
-    this.state.fileUploadStatus.functions.clear();
+    this.state.fileStatusMaps.functions.clear();
 
     for (const fn of manifest.functions ?? []) {
-      this.state.fileUploadStatus.functions.set(fn.universalIdentifier, {
+      this.state.fileStatusMaps.functions.set(fn.universalIdentifier, {
         sourcePath: fn.sourceHandlerPath,
         builtPath: fn.builtHandlerPath,
         checksum: null,
@@ -86,10 +86,10 @@ export class AppDevCommand {
   }
 
   private initializeFrontComponentsFileUploadStatus(manifest: ApplicationManifest): void {
-    this.state.fileUploadStatus.frontComponents.clear();
+    this.state.fileStatusMaps.frontComponents.clear();
 
     for (const component of manifest.frontComponents ?? []) {
-      this.state.fileUploadStatus.frontComponents.set(component.universalIdentifier, {
+      this.state.fileStatusMaps.frontComponents.set(component.universalIdentifier, {
         sourcePath: component.sourceComponentPath,
         builtPath: component.builtComponentPath,
         checksum: null,
@@ -159,8 +159,8 @@ export class AppDevCommand {
     checksum: string,
   ): void {
     const statusMap = entityType === 'function'
-      ? this.state.fileUploadStatus.functions
-      : this.state.fileUploadStatus.frontComponents;
+      ? this.state.fileStatusMaps.functions
+      : this.state.fileStatusMaps.frontComponents;
 
     for (const [_id, status] of statusMap) {
       if (status.builtPath === builtPath) {

--- a/packages/twenty-sdk/src/cli/commands/function/function-execute.ts
+++ b/packages/twenty-sdk/src/cli/commands/function/function-execute.ts
@@ -164,7 +164,7 @@ export class FunctionExecuteCommand {
     fn: { universalIdentifier: string; applicationId: string | null },
     manifest: ApplicationManifest,
   ): boolean {
-    return manifest.serverlessFunctions.some(
+    return manifest.functions.some(
       (manifestFn) => manifestFn.universalIdentifier === fn.universalIdentifier,
     );
   }

--- a/packages/twenty-sdk/src/cli/utilities/build/common/esbuild-result-processor.ts
+++ b/packages/twenty-sdk/src/cli/utilities/build/common/esbuild-result-processor.ts
@@ -1,0 +1,53 @@
+import crypto from 'crypto';
+import type * as esbuild from 'esbuild';
+import * as fs from 'fs-extra';
+import path from 'path';
+import { type OnFileBuiltCallback } from './restartable-watcher.interface';
+
+export type ProcessEsbuildResultParams = {
+  result: esbuild.BuildResult;
+  outputDir: string;
+  builtDir: string;
+  lastInputsSignature: string | null;
+  onFileBuilt?: OnFileBuiltCallback;
+  onSuccess: (relativePath: string) => void;
+};
+
+export type ProcessEsbuildResultOutput = {
+  newInputsSignature: string | null;
+  skipped: boolean;
+};
+
+export const processEsbuildResult = async ({
+  result,
+  outputDir,
+  builtDir,
+  lastInputsSignature,
+  onFileBuilt,
+  onSuccess,
+}: ProcessEsbuildResultParams): Promise<ProcessEsbuildResultOutput> => {
+  const inputs = Object.keys(result.metafile?.inputs ?? {}).sort();
+  const inputsSignature = inputs.join(',');
+
+  if (lastInputsSignature === inputsSignature) {
+    return { newInputsSignature: inputsSignature, skipped: true };
+  }
+
+  const outputFiles = Object.keys(result.metafile?.outputs ?? {})
+    .filter((file) => file.endsWith('.mjs'));
+
+  for (const outputFile of outputFiles) {
+    const absoluteOutputFile = path.resolve(outputFile);
+    const relativePath = path.relative(outputDir, absoluteOutputFile);
+    const builtPath = `${builtDir}/${relativePath}`;
+    onSuccess(relativePath);
+
+    if (onFileBuilt) {
+      const content = await fs.readFile(absoluteOutputFile);
+      const checksum = crypto.createHash('md5').update(content).digest('hex');
+      onFileBuilt(builtPath, checksum);
+    }
+  }
+
+  return { newInputsSignature: inputsSignature, skipped: false };
+};

--- a/packages/twenty-sdk/src/cli/utilities/build/common/esbuild-result-processor.ts
+++ b/packages/twenty-sdk/src/cli/utilities/build/common/esbuild-result-processor.ts
@@ -15,7 +15,7 @@ export type ProcessEsbuildResultParams = {
 
 export type ProcessEsbuildResultOutput = {
   newInputsSignature: string | null;
-  skipped: boolean;
+  alreadyProcessed: boolean;
 };
 
 export const processEsbuildResult = async ({
@@ -30,7 +30,7 @@ export const processEsbuildResult = async ({
   const inputsSignature = inputs.join(',');
 
   if (lastInputsSignature === inputsSignature) {
-    return { newInputsSignature: inputsSignature, skipped: true };
+    return { newInputsSignature: inputsSignature, alreadyProcessed: true };
   }
 
   const outputFiles = Object.keys(result.metafile?.outputs ?? {})
@@ -49,5 +49,5 @@ export const processEsbuildResult = async ({
     }
   }
 
-  return { newInputsSignature: inputsSignature, skipped: false };
+  return { newInputsSignature: inputsSignature, alreadyProcessed: false };
 };

--- a/packages/twenty-sdk/src/cli/utilities/build/common/restartable-watcher.interface.ts
+++ b/packages/twenty-sdk/src/cli/utilities/build/common/restartable-watcher.interface.ts
@@ -1,17 +1,15 @@
-import { type ManifestBuildResult } from '../manifest/manifest-build';
-
 export interface RestartableWatcher {
-  restart(result: ManifestBuildResult): Promise<void>;
+  restart(sourcePaths: string[]): Promise<void>;
   start(): Promise<void>;
   close(): Promise<void>;
-  shouldRestart(result: ManifestBuildResult): boolean;
+  shouldRestart(sourcePaths: string[]): boolean;
 }
 
 export type OnFileBuiltCallback = (builtPath: string, checksum: string) => void;
 
 export type RestartableWatcherOptions = {
   appPath: string;
-  buildResult: ManifestBuildResult | null;
+  sourcePaths: string[];
   watch?: boolean;
   onFileBuilt?: OnFileBuiltCallback;
 };

--- a/packages/twenty-sdk/src/cli/utilities/build/common/restartable-watcher.interface.ts
+++ b/packages/twenty-sdk/src/cli/utilities/build/common/restartable-watcher.interface.ts
@@ -7,8 +7,11 @@ export interface RestartableWatcher {
   shouldRestart(result: ManifestBuildResult): boolean;
 }
 
+export type OnFileBuiltCallback = (builtPath: string, checksum: string) => void;
+
 export type RestartableWatcherOptions = {
   appPath: string;
   buildResult: ManifestBuildResult | null;
   watch?: boolean;
+  onFileBuilt?: OnFileBuiltCallback;
 };

--- a/packages/twenty-sdk/src/cli/utilities/build/front-components/front-component-watcher.ts
+++ b/packages/twenty-sdk/src/cli/utilities/build/front-components/front-component-watcher.ts
@@ -1,10 +1,10 @@
-import crypto from 'crypto';
 import * as esbuild from 'esbuild';
 import * as fs from 'fs-extra';
 import path from 'path';
 import { cleanupRemovedFiles } from '../common/cleanup-removed-files';
 import { OUTPUT_DIR } from '../common/constants';
 import { createLogger } from '../common/logger';
+import { processEsbuildResult } from '../common/esbuild-result-processor';
 import {
   type OnFileBuiltCallback,
   type RestartableWatcher,
@@ -135,31 +135,18 @@ export class FrontComponentsWatcher implements RestartableWatcher {
                   return;
                 }
 
-                const inputs = Object.keys(result.metafile?.inputs ?? {}).sort();
-                const inputsSignature = inputs.join(',');
+                const { newInputsSignature, skipped } = await processEsbuildResult({
+                  result,
+                  outputDir,
+                  builtDir: FRONT_COMPONENTS_DIR,
+                  lastInputsSignature: watcher.lastInputsSignature,
+                  onFileBuilt: watcher.onFileBuilt,
+                  onSuccess: (relativePath) => logger.success(`✓ Built ${relativePath}`),
+                });
 
-                if (watcher.lastInputsSignature === inputsSignature) {
-                  return;
-                }
-                watcher.lastInputsSignature = inputsSignature;
+                watcher.lastInputsSignature = newInputsSignature;
 
-                const outputFiles = Object.keys(result.metafile?.outputs ?? {})
-                  .filter((file) => file.endsWith('.mjs'));
-
-                for (const outputFile of outputFiles) {
-                  const absoluteOutputFile = path.resolve(outputFile);
-                  const relativePath = path.relative(outputDir, absoluteOutputFile);
-                  const builtPath = `${FRONT_COMPONENTS_DIR}/${relativePath}`;
-                  logger.success(`✓ Built ${relativePath}`);
-
-                  if (watcher.onFileBuilt) {
-                    const content = await fs.readFile(absoluteOutputFile);
-                    const checksum = crypto.createHash('md5').update(content).digest('hex');
-                    watcher.onFileBuilt(builtPath, checksum);
-                  }
-                }
-
-                if (watchMode) {
+                if (!skipped && watchMode) {
                   logger.log('👀 Watching for changes...');
                 }
               } finally {

--- a/packages/twenty-sdk/src/cli/utilities/build/front-components/front-component-watcher.ts
+++ b/packages/twenty-sdk/src/cli/utilities/build/front-components/front-component-watcher.ts
@@ -135,7 +135,7 @@ export class FrontComponentsWatcher implements RestartableWatcher {
                   return;
                 }
 
-                const { newInputsSignature, skipped } = await processEsbuildResult({
+                const { newInputsSignature, alreadyProcessed } = await processEsbuildResult({
                   result,
                   outputDir,
                   builtDir: FRONT_COMPONENTS_DIR,
@@ -146,7 +146,7 @@ export class FrontComponentsWatcher implements RestartableWatcher {
 
                 watcher.lastInputsSignature = newInputsSignature;
 
-                if (!skipped && watchMode) {
+                if (!alreadyProcessed && watchMode) {
                   logger.log('👀 Watching for changes...');
                 }
               } finally {

--- a/packages/twenty-sdk/src/cli/utilities/build/functions/function-watcher.ts
+++ b/packages/twenty-sdk/src/cli/utilities/build/functions/function-watcher.ts
@@ -158,7 +158,7 @@ export class FunctionsWatcher implements RestartableWatcher {
                   return;
                 }
 
-                const { newInputsSignature, skipped } = await processEsbuildResult({
+                const { newInputsSignature, alreadyProcessed } = await processEsbuildResult({
                   result,
                   outputDir,
                   builtDir: FUNCTIONS_DIR,
@@ -169,7 +169,7 @@ export class FunctionsWatcher implements RestartableWatcher {
 
                 watcher.lastInputsSignature = newInputsSignature;
 
-                if (!skipped && watchMode) {
+                if (!alreadyProcessed && watchMode) {
                   logger.log('👀 Watching for changes...');
                 }
               } finally {

--- a/packages/twenty-sdk/src/cli/utilities/build/functions/function-watcher.ts
+++ b/packages/twenty-sdk/src/cli/utilities/build/functions/function-watcher.ts
@@ -48,6 +48,8 @@ export class FunctionsWatcher implements RestartableWatcher {
   private watchMode: boolean;
   private lastInputsSignature: string | null = null;
   private onFileBuilt?: OnFileBuiltCallback;
+  private buildCompletePromise: Promise<void> = Promise.resolve();
+  private resolveBuildComplete: (() => void) | null = null;
 
   constructor(options: RestartableWatcherOptions) {
     this.appPath = options.appPath;
@@ -152,42 +154,47 @@ export class FunctionsWatcher implements RestartableWatcher {
           name: 'build-notifications',
           setup: (build) => {
             build.onEnd(async (result) => {
-              if (result.errors.length > 0) {
-                logger.error('✗ Build error:');
-                for (const error of result.errors) {
-                  logger.error(`  ${error.text}`);
+              try {
+                if (result.errors.length > 0) {
+                  logger.error('✗ Build error:');
+                  for (const error of result.errors) {
+                    logger.error(`  ${error.text}`);
+                  }
+                  return;
                 }
-                return;
-              }
 
-              const inputs = Object.keys(result.metafile?.inputs ?? {}).sort();
-              const inputsSignature = inputs.join(',');
+                const inputs = Object.keys(result.metafile?.inputs ?? {}).sort();
+                const inputsSignature = inputs.join(',');
 
-              if (watcher.lastInputsSignature === inputsSignature) {
-                return;
-              }
-              watcher.lastInputsSignature = inputsSignature;
-
-              const outputFiles = Object.keys(result.metafile?.outputs ?? {})
-                .filter((file) => file.endsWith('.mjs'));
-
-              for (const outputFile of outputFiles) {
-                // Make outputFile absolute before computing relative path
-                // (esbuild metafile keys are relative to process.cwd())
-                const absoluteOutputFile = path.resolve(outputFile);
-                const relativePath = path.relative(outputDir, absoluteOutputFile);
-                const builtPath = `${FUNCTIONS_DIR}/${relativePath}`;
-                logger.success(`✓ Built ${relativePath}`);
-
-                if (watcher.onFileBuilt) {
-                  const content = await fs.readFile(absoluteOutputFile);
-                  const checksum = crypto.createHash('md5').update(content).digest('hex');
-                  watcher.onFileBuilt(builtPath, checksum);
+                if (watcher.lastInputsSignature === inputsSignature) {
+                  return;
                 }
-              }
+                watcher.lastInputsSignature = inputsSignature;
 
-              if (watchMode) {
-                logger.log('👀 Watching for changes...');
+                const outputFiles = Object.keys(result.metafile?.outputs ?? {})
+                  .filter((file) => file.endsWith('.mjs'));
+
+                for (const outputFile of outputFiles) {
+                  // Make outputFile absolute before computing relative path
+                  // (esbuild metafile keys are relative to process.cwd())
+                  const absoluteOutputFile = path.resolve(outputFile);
+                  const relativePath = path.relative(outputDir, absoluteOutputFile);
+                  const builtPath = `${FUNCTIONS_DIR}/${relativePath}`;
+                  logger.success(`✓ Built ${relativePath}`);
+
+                  if (watcher.onFileBuilt) {
+                    const content = await fs.readFile(absoluteOutputFile);
+                    const checksum = crypto.createHash('md5').update(content).digest('hex');
+                    watcher.onFileBuilt(builtPath, checksum);
+                  }
+                }
+
+                if (watchMode) {
+                  logger.log('👀 Watching for changes...');
+                }
+              } finally {
+                // Signal that onEnd processing is complete
+                watcher.resolveBuildComplete?.();
               }
             });
           },
@@ -195,7 +202,15 @@ export class FunctionsWatcher implements RestartableWatcher {
       ],
     });
 
+    // Create a promise that will be resolved when onEnd completes
+    this.buildCompletePromise = new Promise<void>((resolve) => {
+      this.resolveBuildComplete = resolve;
+    });
+
     await this.esBuildContext.rebuild();
+
+    // Wait for the onEnd callback to finish processing checksums
+    await this.buildCompletePromise;
 
     if (this.watchMode) {
       await this.esBuildContext.watch();

--- a/packages/twenty-sdk/src/cli/utilities/build/functions/function-watcher.ts
+++ b/packages/twenty-sdk/src/cli/utilities/build/functions/function-watcher.ts
@@ -1,3 +1,4 @@
+import crypto from 'crypto';
 import * as esbuild from 'esbuild';
 import * as fs from 'fs-extra';
 import path from 'path';
@@ -5,6 +6,7 @@ import { cleanupRemovedFiles } from '../common/cleanup-removed-files';
 import { OUTPUT_DIR } from '../common/constants';
 import { createLogger } from '../common/logger';
 import {
+  type OnFileBuiltCallback,
   type RestartableWatcher,
   type RestartableWatcherOptions,
 } from '../common/restartable-watcher.interface';
@@ -45,11 +47,13 @@ export class FunctionsWatcher implements RestartableWatcher {
   private isRestarting = false;
   private watchMode: boolean;
   private lastInputsSignature: string | null = null;
+  private onFileBuilt?: OnFileBuiltCallback;
 
   constructor(options: RestartableWatcherOptions) {
     this.appPath = options.appPath;
     this.functionPaths = options.buildResult?.filePaths.functions ?? [];
     this.watchMode = options.watch ?? true;
+    this.onFileBuilt = options.onFileBuilt;
   }
 
   shouldRestart(result: ManifestBuildResult): boolean {
@@ -147,7 +151,7 @@ export class FunctionsWatcher implements RestartableWatcher {
         {
           name: 'build-notifications',
           setup: (build) => {
-            build.onEnd((result) => {
+            build.onEnd(async (result) => {
               if (result.errors.length > 0) {
                 logger.error('✗ Build error:');
                 for (const error of result.errors) {
@@ -164,13 +168,24 @@ export class FunctionsWatcher implements RestartableWatcher {
               }
               watcher.lastInputsSignature = inputsSignature;
 
-              const outputs = Object.keys(result.metafile?.outputs ?? {})
-                .filter((file) => file.endsWith('.mjs'))
-                .map((file) => path.relative(outputDir, file));
+              const outputFiles = Object.keys(result.metafile?.outputs ?? {})
+                .filter((file) => file.endsWith('.mjs'));
 
-              for (const output of outputs) {
-                logger.success(`✓ Built ${output}`);
+              for (const outputFile of outputFiles) {
+                // Make outputFile absolute before computing relative path
+                // (esbuild metafile keys are relative to process.cwd())
+                const absoluteOutputFile = path.resolve(outputFile);
+                const relativePath = path.relative(outputDir, absoluteOutputFile);
+                const builtPath = `${FUNCTIONS_DIR}/${relativePath}`;
+                logger.success(`✓ Built ${relativePath}`);
+
+                if (watcher.onFileBuilt) {
+                  const content = await fs.readFile(absoluteOutputFile);
+                  const checksum = crypto.createHash('md5').update(content).digest('hex');
+                  watcher.onFileBuilt(builtPath, checksum);
+                }
               }
+
               if (watchMode) {
                 logger.log('👀 Watching for changes...');
               }

--- a/packages/twenty-sdk/src/cli/utilities/build/manifest/__tests__/validate-manifest.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/build/manifest/__tests__/validate-manifest.spec.ts
@@ -32,7 +32,7 @@ describe('validateManifest - objectExtensions', () => {
         application: validApplication,
         objects: [],
         objectExtensions: [validObjectExtension],
-        serverlessFunctions: [],
+        functions: [],
         roles: [],
       });
 
@@ -59,7 +59,7 @@ describe('validateManifest - objectExtensions', () => {
         application: validApplication,
         objects: [],
         objectExtensions: [extensionByUuid],
-        serverlessFunctions: [],
+        functions: [],
         roles: [],
       });
 
@@ -86,7 +86,7 @@ describe('validateManifest - objectExtensions', () => {
         application: validApplication,
         objects: [],
         objectExtensions: [validObjectExtension, anotherExtension],
-        serverlessFunctions: [],
+        functions: [],
         roles: [],
       });
 
@@ -122,7 +122,7 @@ describe('validateManifest - objectExtensions', () => {
         application: validApplication,
         objects: [],
         objectExtensions: [extensionWithSelect],
-        serverlessFunctions: [],
+        functions: [],
         roles: [],
       });
 
@@ -141,7 +141,7 @@ describe('validateManifest - objectExtensions', () => {
         application: validApplication,
         objects: [],
         objectExtensions: [invalidExtension],
-        serverlessFunctions: [],
+        functions: [],
         roles: [],
       });
 
@@ -163,7 +163,7 @@ describe('validateManifest - objectExtensions', () => {
         application: validApplication,
         objects: [],
         objectExtensions: [invalidExtension],
-        serverlessFunctions: [],
+        functions: [],
         roles: [],
       });
 
@@ -189,7 +189,7 @@ describe('validateManifest - objectExtensions', () => {
         application: validApplication,
         objects: [],
         objectExtensions: [invalidExtension],
-        serverlessFunctions: [],
+        functions: [],
         roles: [],
       });
 
@@ -216,7 +216,7 @@ describe('validateManifest - objectExtensions', () => {
         application: validApplication,
         objects: [],
         objectExtensions: [invalidExtension],
-        serverlessFunctions: [],
+        functions: [],
         roles: [],
       });
 
@@ -246,7 +246,7 @@ describe('validateManifest - objectExtensions', () => {
         application: validApplication,
         objects: [],
         objectExtensions: [invalidExtension],
-        serverlessFunctions: [],
+        functions: [],
         roles: [],
       });
 
@@ -276,7 +276,7 @@ describe('validateManifest - objectExtensions', () => {
         application: validApplication,
         objects: [],
         objectExtensions: [invalidExtension],
-        serverlessFunctions: [],
+        functions: [],
         roles: [],
       });
 
@@ -306,7 +306,7 @@ describe('validateManifest - objectExtensions', () => {
         application: validApplication,
         objects: [],
         objectExtensions: [invalidExtension],
-        serverlessFunctions: [],
+        functions: [],
         roles: [],
       });
 
@@ -337,7 +337,7 @@ describe('validateManifest - objectExtensions', () => {
         application: validApplication,
         objects: [],
         objectExtensions: [invalidExtension],
-        serverlessFunctions: [],
+        functions: [],
         roles: [],
       });
 
@@ -369,7 +369,7 @@ describe('validateManifest - objectExtensions', () => {
         application: validApplication,
         objects: [],
         objectExtensions: [invalidExtension],
-        serverlessFunctions: [],
+        functions: [],
         roles: [],
       });
 
@@ -410,7 +410,7 @@ describe('validateManifest - objectExtensions', () => {
         application: validApplication,
         objects: [],
         objectExtensions: [extensionWithDuplicates],
-        serverlessFunctions: [],
+        functions: [],
         roles: [],
       });
 
@@ -457,7 +457,7 @@ describe('validateManifest - objectExtensions', () => {
             ],
           },
         ],
-        serverlessFunctions: [],
+        functions: [],
         roles: [],
       });
 

--- a/packages/twenty-sdk/src/cli/utilities/build/manifest/entities/front-component.ts
+++ b/packages/twenty-sdk/src/cli/utilities/build/manifest/entities/front-component.ts
@@ -15,7 +15,7 @@ const logger = createLogger('manifest-watch');
 
 type FrontComponentConfig = Omit<
   FrontComponentManifest,
-  'sourceComponentPath' | 'builtComponentPath' | 'componentName'
+  'sourceComponentPath' | 'builtComponentPath' | 'builtComponentChecksum' | 'componentName'
 > & {
   component: { name: string };
 };
@@ -47,6 +47,7 @@ export class FrontComponentEntityBuilder
           componentName: component.name,
           sourceComponentPath: filePath,
           builtComponentPath,
+          builtComponentChecksum: null,
         });
       } catch (error) {
         throw new Error(

--- a/packages/twenty-sdk/src/cli/utilities/build/manifest/entities/function.ts
+++ b/packages/twenty-sdk/src/cli/utilities/build/manifest/entities/function.ts
@@ -42,7 +42,9 @@ export class FunctionEntityBuilder
           );
 
         const { handlerPath, ...rest } = extracted;
-        const builtHandlerPath = this.computeBuiltHandlerPath(handlerPath);
+        // builtHandlerPath is computed from filePath (the .function.ts file)
+        // since that's what esbuild actually builds, not handlerPath
+        const builtHandlerPath = this.computeBuiltHandlerPath(filePath);
 
         manifests.push({
           ...rest,
@@ -150,7 +152,7 @@ export class FunctionEntityBuilder
 
   findDuplicates(manifest: ManifestWithoutSources): EntityIdWithLocation[] {
     const seen = new Map<string, string[]>();
-    const functions = manifest.serverlessFunctions ?? [];
+    const functions = manifest.functions ?? [];
 
     for (const fn of functions) {
       if (fn.universalIdentifier) {

--- a/packages/twenty-sdk/src/cli/utilities/build/manifest/entities/function.ts
+++ b/packages/twenty-sdk/src/cli/utilities/build/manifest/entities/function.ts
@@ -15,7 +15,7 @@ const logger = createLogger('manifest-watch');
 
 type ExtractedFunctionManifest = Omit<
   ServerlessFunctionManifest,
-  'sourceHandlerPath' | 'builtHandlerPath'
+  'sourceHandlerPath' | 'builtHandlerPath' | 'builtHandlerChecksum'
 > & {
   handlerPath: string;
 };
@@ -48,6 +48,7 @@ export class FunctionEntityBuilder
           ...rest,
           sourceHandlerPath: handlerPath,
           builtHandlerPath,
+          builtHandlerChecksum: null,
         });
       } catch (error) {
         throw new Error(

--- a/packages/twenty-sdk/src/cli/utilities/build/manifest/manifest-build.ts
+++ b/packages/twenty-sdk/src/cli/utilities/build/manifest/manifest-build.ts
@@ -152,7 +152,7 @@ export const runManifestBuild = async (
       objects: objectManifests,
       objectExtensions:
         objectExtensionManifests.length > 0 ? objectExtensionManifests : undefined,
-      serverlessFunctions: functionManifests,
+      functions: functionManifests,
       frontComponents:
         frontComponentManifests.length > 0 ? frontComponentManifests : undefined,
       roles: roleManifests,
@@ -164,7 +164,7 @@ export const runManifestBuild = async (
       application,
       objects: objectManifests,
       objectExtensions: objectExtensionManifests,
-      serverlessFunctions: functionManifests,
+      functions: functionManifests,
       frontComponents: frontComponentManifests,
       roles: roleManifests,
     });

--- a/packages/twenty-sdk/src/cli/utilities/build/manifest/manifest-build.ts
+++ b/packages/twenty-sdk/src/cli/utilities/build/manifest/manifest-build.ts
@@ -77,6 +77,48 @@ export type ManifestBuildResult = {
   filePaths: EntityFilePaths;
 };
 
+export type ManifestEntityType = 'function' | 'frontComponent';
+
+export type UpdateManifestChecksumParams = {
+  manifest: ApplicationManifest;
+  entityType: ManifestEntityType;
+  builtPath: string;
+  checksum: string;
+};
+
+export const updateManifestChecksum = ({
+  manifest,
+  entityType,
+  builtPath,
+  checksum,
+}: UpdateManifestChecksumParams): ApplicationManifest | null => {
+  if (entityType === 'function') {
+    const fnIndex = manifest.functions.findIndex((f) => f.builtHandlerPath === builtPath);
+    if (fnIndex === -1) {
+      return null;
+    }
+    return {
+      ...manifest,
+      functions: manifest.functions.map((fn, index) =>
+        index === fnIndex ? { ...fn, builtHandlerChecksum: checksum } : fn,
+      ),
+    };
+  }
+
+  const componentIndex = manifest.frontComponents?.findIndex(
+    (c) => c.builtComponentPath === builtPath,
+  ) ?? -1;
+  if (componentIndex === -1) {
+    return null;
+  }
+  return {
+    ...manifest,
+    frontComponents: manifest.frontComponents?.map((component, index) =>
+      index === componentIndex ? { ...component, builtComponentChecksum: checksum } : component,
+    ),
+  };
+};
+
 export const runManifestBuild = async (
   appPath: string,
   options: RunManifestBuildOptions = {},

--- a/packages/twenty-sdk/src/cli/utilities/build/manifest/manifest-display.ts
+++ b/packages/twenty-sdk/src/cli/utilities/build/manifest/manifest-display.ts
@@ -14,7 +14,7 @@ export const displayEntitySummary = (manifest: ApplicationManifest): void => {
     manifest.application ? [manifest.application] : [],
   );
   objectEntityBuilder.display(manifest.objects ?? []);
-  functionEntityBuilder.display(manifest.serverlessFunctions ?? []);
+  functionEntityBuilder.display(manifest.functions ?? []);
   frontComponentEntityBuilder.display(manifest.frontComponents ?? []);
   roleEntityBuilder.display(manifest.roles ?? []);
 };

--- a/packages/twenty-sdk/src/cli/utilities/build/manifest/manifest-validate.ts
+++ b/packages/twenty-sdk/src/cli/utilities/build/manifest/manifest-validate.ts
@@ -40,7 +40,7 @@ export const validateManifest = (
   );
   objectEntityBuilder.validate(manifest.objects ?? [], errors);
   objectExtensionEntityBuilder.validate(manifest.objectExtensions ?? [], errors);
-  functionEntityBuilder.validate(manifest.serverlessFunctions ?? [], errors);
+  functionEntityBuilder.validate(manifest.functions ?? [], errors);
   roleEntityBuilder.validate(manifest.roles ?? [], errors);
   frontComponentEntityBuilder.validate(manifest.frontComponents ?? [], errors);
 
@@ -58,7 +58,7 @@ export const validateManifest = (
     });
   }
 
-  if (!isNonEmptyArray(manifest.serverlessFunctions)) {
+  if (!isNonEmptyArray(manifest.functions)) {
     warnings.push({
       message: 'No functions defined',
     });

--- a/packages/twenty-sdk/src/cli/utilities/build/manifest/manifest-writer.ts
+++ b/packages/twenty-sdk/src/cli/utilities/build/manifest/manifest-writer.ts
@@ -1,0 +1,18 @@
+import * as fs from 'fs-extra';
+import path from 'path';
+import { type ApplicationManifest } from 'twenty-shared/application';
+
+import { OUTPUT_DIR } from '../common/constants';
+
+export const writeManifestToOutput = async (
+  appPath: string,
+  manifest: ApplicationManifest,
+): Promise<string> => {
+  const outputDir = path.join(appPath, OUTPUT_DIR);
+  await fs.ensureDir(outputDir);
+
+  const manifestPath = path.join(outputDir, 'manifest.json');
+  await fs.writeJSON(manifestPath, manifest, { spaces: 2 });
+
+  return manifestPath;
+};

--- a/packages/twenty-server/src/engine/core-modules/application/application-sync.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-sync.service.ts
@@ -105,7 +105,7 @@ export class ApplicationSyncService {
       });
     }
 
-    if (manifest.serverlessFunctions.length > 0) {
+    if (manifest.functions.length > 0) {
       if (!isDefined(application.serverlessFunctionLayerId)) {
         throw new ApplicationException(
           `Failed to sync serverless function, could not find a serverless function layer.`,
@@ -114,7 +114,7 @@ export class ApplicationSyncService {
       }
 
       await this.syncServerlessFunctions({
-        serverlessFunctionsToSync: manifest.serverlessFunctions,
+        serverlessFunctionsToSync: manifest.functions,
         code: manifest.sources,
         workspaceId,
         applicationId: application.id,
@@ -158,7 +158,7 @@ export class ApplicationSyncService {
 
     let serverlessFunctionLayerId = application.serverlessFunctionLayerId;
 
-    if (manifest.serverlessFunctions.length > 0) {
+    if (manifest.functions.length > 0) {
       if (!isDefined(serverlessFunctionLayerId)) {
         serverlessFunctionLayerId = (
           await this.serverlessFunctionLayerService.create(

--- a/packages/twenty-shared/src/application/applicationManifestType.ts
+++ b/packages/twenty-shared/src/application/applicationManifestType.ts
@@ -13,7 +13,7 @@ export type ApplicationManifest = {
   application: Application;
   objects: ObjectManifest[];
   objectExtensions?: ObjectExtensionManifest[];
-  serverlessFunctions: ServerlessFunctionManifest[];
+  functions: ServerlessFunctionManifest[];
   frontComponents?: FrontComponentManifest[];
   roles?: RoleManifest[];
   sources: Sources;

--- a/packages/twenty-shared/src/application/frontComponentManifestType.ts
+++ b/packages/twenty-shared/src/application/frontComponentManifestType.ts
@@ -4,5 +4,6 @@ export type FrontComponentManifest = {
   description?: string;
   sourceComponentPath: string;
   builtComponentPath: string;
+  builtComponentChecksum: string | null;
   componentName: string;
 };

--- a/packages/twenty-shared/src/application/serverlessFunctionManifestType.ts
+++ b/packages/twenty-shared/src/application/serverlessFunctionManifestType.ts
@@ -26,6 +26,7 @@ export type ServerlessFunctionManifest = SyncableEntityOptions & {
   triggers: ServerlessFunctionTriggerManifest[];
   sourceHandlerPath: string;
   builtHandlerPath: string;
+  builtHandlerChecksum: string | null;
   handlerName: string;
   toolInputSchema?: InputJsonSchema;
   isTool?: boolean;


### PR DESCRIPTION
## Refactor app-dev state management and build utilities

- Store only `manifest` in `AppDevState` instead of full `ManifestBuildResult`; add `sourcePath` to `FileStatus`
- Pass `sourcePaths` directly to watchers instead of `ManifestBuildResult`
- Only reset `fileUploadStatus` for functions/components when their source paths change
- Add pure `updateManifestChecksum` utility that returns a new manifest without side effects
- Extract `processEsbuildResult` to deduplicate build result processing between watchers
- Rename `serverlessFunctions` → `functions` in SDK code (API unchanged)
- Extract `writeManifestToOutput` to shared `manifest-writer.ts`