### PR TITLE
Add multiple recipients (To/CC/BCC) to Send Email workflow action

### DIFF
--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/components/EmailRecipientsInput.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/components/EmailRecipientsInput.tsx
@@ -1,6 +1,7 @@
 import { FormFieldInputContainer } from '@/object-record/record-field/ui/form-types/components/FormFieldInputContainer';
 import { FormTextFieldInput } from '@/object-record/record-field/ui/form-types/components/FormTextFieldInput';
 import { InputLabel } from '@/ui/input/components/InputLabel';
+import { extractNonEmptyEmails } from '@/workflow/workflow-steps/workflow-actions/email-action/utils/extractNonEmptyEmails';
 import { WorkflowVariablePicker } from '@/workflow/workflow-variables/components/WorkflowVariablePicker';
 import styled from '@emotion/styled';
 import { t } from '@lingui/core/macro';
@@ -55,16 +56,14 @@ export const EmailRecipientsInput = ({
 
     newEntries[index] = { ...newEntries[index], value: newValue };
 
-    if (index === entries.length - 1 && newValue.trim().length > 0) {
+    const isLastEntry = entryId === entries[entries.length - 1].id;
+
+    if (isLastEntry && newValue.trim().length > 0) {
       newEntries.push({ id: v4(), value: '' });
     }
 
     setEntries(newEntries);
-
-    const nonEmptyValues = newEntries
-      .map((entry) => entry.value.trim())
-      .filter((value) => value.length > 0);
-    onChange(nonEmptyValues);
+    onChange(extractNonEmptyEmails(newEntries));
   };
 
   const handleRemoveEntry = (entryId: string) => {
@@ -75,35 +74,37 @@ export const EmailRecipientsInput = ({
     }
 
     setEntries(newEntries);
-
-    const nonEmptyValues = newEntries
-      .map((entry) => entry.value.trim())
-      .filter((value) => value.length > 0);
-    onChange(nonEmptyValues);
+    onChange(extractNonEmptyEmails(newEntries));
   };
 
   return (
     <FormFieldInputContainer>
       <InputLabel>{label}</InputLabel>
       <StyledContainer>
-        {entries.map((entry, index) => (
-          <StyledEmailRow key={entry.id} readonly={readonly}>
-            <FormTextFieldInput
-              placeholder={placeholder ?? t`Enter email address`}
-              readonly={readonly}
-              defaultValue={entry.value}
-              onChange={(value) => handleEntryChange(entry.id, value ?? '')}
-              VariablePicker={WorkflowVariablePicker}
-            />
-            {!readonly && (
-              <Button
-                onClick={() => handleRemoveEntry(entry.id)}
-                Icon={IconTrash}
-                disabled={index === entries.length - 1}
+        {entries.map((entry) => {
+          const isLastEntry = entry.id === entries[entries.length - 1].id;
+
+          return (
+            <StyledEmailRow key={entry.id} readonly={readonly}>
+              <FormTextFieldInput
+                placeholder={placeholder ?? t`Enter email address`}
+                readonly={readonly}
+                defaultValue={entry.value}
+                onChange={(value) => handleEntryChange(entry.id, value ?? '')}
+                VariablePicker={WorkflowVariablePicker}
               />
-            )}
-          </StyledEmailRow>
-        ))}
+              {!readonly &&
+                (isLastEntry ? (
+                  <Button Icon={IconTrash} disabled={true} />
+                ) : (
+                  <Button
+                    onClick={() => handleRemoveEntry(entry.id)}
+                    Icon={IconTrash}
+                  />
+                ))}
+            </StyledEmailRow>
+          );
+        })}
       </StyledContainer>
     </FormFieldInputContainer>
   );

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/components/EmailRecipientsInput.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/components/EmailRecipientsInput.tsx
@@ -1,0 +1,110 @@
+import { FormFieldInputContainer } from '@/object-record/record-field/ui/form-types/components/FormFieldInputContainer';
+import { FormTextFieldInput } from '@/object-record/record-field/ui/form-types/components/FormTextFieldInput';
+import { InputLabel } from '@/ui/input/components/InputLabel';
+import { WorkflowVariablePicker } from '@/workflow/workflow-variables/components/WorkflowVariablePicker';
+import styled from '@emotion/styled';
+import { t } from '@lingui/core/macro';
+import { useState } from 'react';
+import { IconTrash } from 'twenty-ui/display';
+import { Button } from 'twenty-ui/input';
+import { v4 } from 'uuid';
+
+const StyledContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing(2)};
+`;
+
+const StyledEmailRow = styled.div<{ readonly: boolean | undefined }>`
+  display: grid;
+  gap: ${({ theme }) => theme.spacing(2)};
+  grid-template-columns: ${({ readonly, theme }) =>
+    readonly ? '1fr' : `1fr ${theme.spacing(8)}`};
+`;
+
+type EmailEntry = {
+  id: string;
+  value: string;
+};
+
+type EmailRecipientsInputProps = {
+  label: string;
+  defaultValue: string[];
+  onChange: (emails: string[]) => void;
+  readonly?: boolean;
+  placeholder?: string;
+};
+
+export const EmailRecipientsInput = ({
+  label,
+  defaultValue,
+  onChange,
+  readonly,
+  placeholder,
+}: EmailRecipientsInputProps) => {
+  const [entries, setEntries] = useState<EmailEntry[]>(() => {
+    const initial = defaultValue.map((email) => ({ id: v4(), value: email }));
+    return initial.length > 0
+      ? [...initial, { id: v4(), value: '' }]
+      : [{ id: v4(), value: '' }];
+  });
+
+  const handleEntryChange = (entryId: string, newValue: string) => {
+    const index = entries.findIndex((entry) => entry.id === entryId);
+    const newEntries = [...entries];
+
+    newEntries[index] = { ...newEntries[index], value: newValue };
+
+    if (index === entries.length - 1 && newValue.trim()) {
+      newEntries.push({ id: v4(), value: '' });
+    }
+
+    setEntries(newEntries);
+
+    const nonEmptyValues = newEntries
+      .map((entry) => entry.value.trim())
+      .filter((value) => value.length > 0);
+    onChange(nonEmptyValues);
+  };
+
+  const handleRemoveEntry = (entryId: string) => {
+    const newEntries = entries.filter((entry) => entry.id !== entryId);
+
+    if (newEntries.length === 0) {
+      newEntries.push({ id: v4(), value: '' });
+    }
+
+    setEntries(newEntries);
+
+    const nonEmptyValues = newEntries
+      .map((entry) => entry.value.trim())
+      .filter((value) => value.length > 0);
+    onChange(nonEmptyValues);
+  };
+
+  return (
+    <FormFieldInputContainer>
+      <InputLabel>{label}</InputLabel>
+      <StyledContainer>
+        {entries.map((entry, index) => (
+          <StyledEmailRow key={entry.id} readonly={readonly}>
+            <FormTextFieldInput
+              placeholder={placeholder ?? t`Enter email address`}
+              readonly={readonly}
+              defaultValue={entry.value}
+              onChange={(value) => handleEntryChange(entry.id, value ?? '')}
+              VariablePicker={WorkflowVariablePicker}
+            />
+            {!readonly && (
+              <Button
+                onClick={() => handleRemoveEntry(entry.id)}
+                Icon={IconTrash}
+                disabled={index === entries.length - 1}
+              />
+            )}
+          </StyledEmailRow>
+        ))}
+      </StyledContainer>
+    </FormFieldInputContainer>
+  );
+};

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/components/EmailRecipientsInput.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/components/EmailRecipientsInput.tsx
@@ -55,7 +55,7 @@ export const EmailRecipientsInput = ({
 
     newEntries[index] = { ...newEntries[index], value: newValue };
 
-    if (index === entries.length - 1 && newValue.trim()) {
+    if (index === entries.length - 1 && newValue.trim().length > 0) {
       newEntries.push({ id: v4(), value: '' });
     }
 

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/components/__stories__/WorkflowEditActionSendEmail.stories.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/components/__stories__/WorkflowEditActionSendEmail.stories.tsx
@@ -24,7 +24,11 @@ const DEFAULT_ACTION: WorkflowSendEmailAction = {
   settings: {
     input: {
       connectedAccountId: '',
-      email: '',
+      recipients: {
+        to: [],
+        cc: [],
+        bcc: [],
+      },
       subject: '',
       body: '',
       files: [],
@@ -49,7 +53,11 @@ const CONFIGURED_ACTION: WorkflowSendEmailAction = {
   settings: {
     input: {
       connectedAccountId: mockedConnectedAccounts[0].accountOwnerId,
-      email: 'test@twenty.com',
+      recipients: {
+        to: ['test@twenty.com'],
+        cc: [],
+        bcc: [],
+      },
       subject: 'Welcome to Twenty!',
       body: 'Dear Tim,\n\nWelcome to Twenty! We are excited to have you on board.\n\nBest regards,\nThe Team',
       files: [],
@@ -58,6 +66,31 @@ const CONFIGURED_ACTION: WorkflowSendEmailAction = {
     errorHandlingOptions: {
       retryOnFailure: {
         value: true,
+      },
+      continueOnFailure: {
+        value: false,
+      },
+    },
+  },
+};
+
+const LEGACY_ACTION: WorkflowSendEmailAction = {
+  id: getWorkflowNodeIdMock(),
+  name: 'Legacy Email Action',
+  type: 'SEND_EMAIL',
+  valid: true,
+  settings: {
+    input: {
+      connectedAccountId: mockedConnectedAccounts[0].accountOwnerId,
+      email: 'legacy@twenty.com',
+      subject: 'Legacy Format Test',
+      body: 'Testing backward compatibility with legacy email field.',
+      files: [],
+    },
+    outputSchema: {},
+    errorHandlingOptions: {
+      retryOnFailure: {
+        value: false,
       },
       continueOnFailure: {
         value: false,
@@ -111,6 +144,9 @@ export const Default: Story = {
     const canvas = within(canvasElement);
 
     expect(await canvas.findByText('Account')).toBeVisible();
+    expect(await canvas.findByText('To')).toBeVisible();
+    expect(await canvas.findByText('CC')).toBeVisible();
+    expect(await canvas.findByText('BCC')).toBeVisible();
     expect(await canvas.findByText('Subject')).toBeVisible();
     expect(await canvas.findByText('Body')).toBeVisible();
   },
@@ -127,13 +163,29 @@ export const Configured: Story = {
     const canvas = within(canvasElement);
 
     expect(await canvas.findByText('Account')).toBeVisible();
-    expect(await canvas.findByText('Subject')).toBeVisible();
-    expect(await canvas.findByText('Body')).toBeVisible();
+    expect(await canvas.findByText('To')).toBeVisible();
 
     const emailInput = await canvas.findByText('tim@twenty.com');
     expect(emailInput).toBeVisible();
 
     const subjectInput = await canvas.findByText('Welcome to Twenty!');
     expect(subjectInput).toBeVisible();
+  },
+};
+
+export const LegacyFormat: Story = {
+  args: {
+    action: LEGACY_ACTION,
+    actionOptions: {
+      onActionUpdate: fn(),
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    expect(await canvas.findByText('To')).toBeVisible();
+
+    const emailInput = await canvas.findByText('legacy@twenty.com');
+    expect(emailInput).toBeVisible();
   },
 };

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/email-action/utils/extractNonEmptyEmails.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/email-action/utils/extractNonEmptyEmails.ts
@@ -1,0 +1,4 @@
+export const extractNonEmptyEmails = (entries: { value: string }[]): string[] =>
+  entries
+    .map((entry) => entry.value.trim())
+    .filter((value) => value.length > 0);

--- a/packages/twenty-server/src/engine/core-modules/tool/tools/send-email-tool/send-email-tool.schema.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool/tools/send-email-tool/send-email-tool.schema.ts
@@ -2,20 +2,53 @@ import { isValidUuid } from 'twenty-shared/utils';
 import { workflowFileSchema } from 'twenty-shared/workflow';
 import { z } from 'zod';
 
-export const SendEmailInputZodSchema = z.object({
-  email: z.email().describe('The recipient email address'),
-  subject: z.string().describe('The email subject line'),
-  body: z.string().describe('The email body content (HTML or plain text)'),
-  connectedAccountId: z
-    .string()
-    .refine((val) => isValidUuid(val))
-    .describe(
-      'The UUID of the connected account to send the email from. Provide this only if you have it; otherwise, leave blank.',
-    )
-    .optional(),
-  files: z
-    .array(workflowFileSchema)
-    .describe('Array of file objects to attach to the email')
+export const EmailRecipientsZodSchema = z.object({
+  to: z
+    .array(z.string())
+    .describe('Array of recipient email addresses (To)')
+    .default([]),
+  cc: z
+    .array(z.string())
+    .describe('Array of CC email addresses')
+    .optional()
+    .default([]),
+  bcc: z
+    .array(z.string())
+    .describe('Array of BCC email addresses')
     .optional()
     .default([]),
 });
+
+export const SendEmailInputZodSchema = z
+  .object({
+    email: z
+      .email()
+      .describe('The recipient email address (legacy, use recipients instead)')
+      .optional(),
+    recipients: EmailRecipientsZodSchema.describe(
+      'Recipients object with to, cc, and bcc arrays',
+    ).optional(),
+    subject: z.string().describe('The email subject line'),
+    body: z.string().describe('The email body content (HTML or plain text)'),
+    connectedAccountId: z
+      .string()
+      .refine((val) => isValidUuid(val))
+      .describe(
+        'The UUID of the connected account to send the email from. Provide this only if you have it; otherwise, leave blank.',
+      )
+      .optional(),
+    files: z
+      .array(workflowFileSchema)
+      .describe('Array of file objects to attach to the email')
+      .optional()
+      .default([]),
+  })
+  .refine(
+    (data) =>
+      data.email ||
+      (data.recipients && data.recipients.to && data.recipients.to.length > 0),
+    {
+      message:
+        'Either email or recipients.to must be provided with at least one recipient',
+    },
+  );

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-send-message.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-send-message.service.ts
@@ -82,6 +82,7 @@ export class MessagingSendMessageService {
           to: sendMessageInput.to,
           cc: sendMessageInput.cc,
           bcc: sendMessageInput.bcc,
+          keepBcc: true,
           subject: sendMessageInput.subject,
           text: sendMessageInput.body,
           html: sendMessageInput.html,

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-send-message.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-send-message.service.ts
@@ -15,18 +15,23 @@ import {
 import { ImapClientProvider } from 'src/modules/messaging/message-import-manager/drivers/imap/providers/imap-client.provider';
 import { SmtpClientProvider } from 'src/modules/messaging/message-import-manager/drivers/smtp/providers/smtp-client.provider';
 import { mimeEncode } from 'src/modules/messaging/message-import-manager/utils/mime-encode.util';
+import { toMicrosoftRecipients } from 'src/modules/messaging/message-import-manager/utils/to-microsoft-recipients.util';
 
-interface SendMessageInput {
+type EmailAddress = string | string[];
+
+type SendMessageInput = {
   body: string;
   subject: string;
-  to: string;
+  to: EmailAddress;
+  cc?: EmailAddress;
+  bcc?: EmailAddress;
   html: string;
   attachments?: {
     filename: string;
     content: Buffer;
     contentType: string;
   }[];
-}
+};
 
 @Injectable()
 export class MessagingSendMessageService {
@@ -75,6 +80,8 @@ export class MessagingSendMessageService {
             ? `"${mimeEncode(fromName)}" <${fromEmail}>`
             : `${fromEmail}`,
           to: sendMessageInput.to,
+          cc: sendMessageInput.cc,
+          bcc: sendMessageInput.bcc,
           subject: sendMessageInput.subject,
           text: sendMessageInput.body,
           html: sendMessageInput.html,
@@ -113,7 +120,9 @@ export class MessagingSendMessageService {
             contentType: 'HTML',
             content: sendMessageInput.html,
           },
-          toRecipients: [{ emailAddress: { address: sendMessageInput.to } }],
+          toRecipients: toMicrosoftRecipients(sendMessageInput.to),
+          ccRecipients: toMicrosoftRecipients(sendMessageInput.cc),
+          bccRecipients: toMicrosoftRecipients(sendMessageInput.bcc),
           ...(sendMessageInput.attachments &&
           sendMessageInput.attachments.length > 0
             ? {
@@ -154,6 +163,8 @@ export class MessagingSendMessageService {
         const mail = new MailComposer({
           from: handle,
           to: sendMessageInput.to,
+          cc: sendMessageInput.cc,
+          bcc: sendMessageInput.bcc,
           subject: sendMessageInput.subject,
           text: sendMessageInput.body,
           html: sendMessageInput.html,
@@ -174,6 +185,8 @@ export class MessagingSendMessageService {
         await smtpClient.sendMail({
           from: handle,
           to: sendMessageInput.to,
+          cc: sendMessageInput.cc,
+          bcc: sendMessageInput.bcc,
           raw: messageBuffer,
         });
 

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-send-message.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-send-message.service.ts
@@ -82,7 +82,6 @@ export class MessagingSendMessageService {
           to: sendMessageInput.to,
           cc: sendMessageInput.cc,
           bcc: sendMessageInput.bcc,
-          keepBcc: true,
           subject: sendMessageInput.subject,
           text: sendMessageInput.body,
           html: sendMessageInput.html,
@@ -98,7 +97,11 @@ export class MessagingSendMessageService {
             : {}),
         });
 
-        const messageBuffer = await mail.compile().build();
+        const compiledMessage = mail.compile();
+
+        compiledMessage.keepBcc = true;
+
+        const messageBuffer = await compiledMessage.build();
         const encodedMessage = Buffer.from(messageBuffer).toString('base64');
 
         await gmailClient.users.messages.send({

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/utils/__tests__/to-microsoft-recipients.util.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/utils/__tests__/to-microsoft-recipients.util.spec.ts
@@ -1,0 +1,39 @@
+import { toMicrosoftRecipients } from 'src/modules/messaging/message-import-manager/utils/to-microsoft-recipients.util';
+
+describe('toMicrosoftRecipients', () => {
+  it('should return empty array when addresses is undefined', () => {
+    expect(toMicrosoftRecipients(undefined)).toEqual([]);
+  });
+
+  it('should convert a single email string to Microsoft recipient format', () => {
+    const result = toMicrosoftRecipients('john@example.com');
+
+    expect(result).toEqual([{ emailAddress: { address: 'john@example.com' } }]);
+  });
+
+  it('should convert an array of emails to Microsoft recipient format', () => {
+    const result = toMicrosoftRecipients([
+      'john@example.com',
+      'jane@example.com',
+    ]);
+
+    expect(result).toEqual([
+      { emailAddress: { address: 'john@example.com' } },
+      { emailAddress: { address: 'jane@example.com' } },
+    ]);
+  });
+
+  it('should return empty array for empty string array', () => {
+    expect(toMicrosoftRecipients([])).toEqual([]);
+  });
+
+  it('should preserve email addresses exactly as provided', () => {
+    const emailWithPlus = 'user+tag@example.com';
+    const emailWithDots = 'first.last@sub.domain.com';
+
+    const result = toMicrosoftRecipients([emailWithPlus, emailWithDots]);
+
+    expect(result[0].emailAddress.address).toBe(emailWithPlus);
+    expect(result[1].emailAddress.address).toBe(emailWithDots);
+  });
+});

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/utils/to-microsoft-recipients.util.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/utils/to-microsoft-recipients.util.ts
@@ -1,0 +1,19 @@
+type EmailAddress = string | string[];
+
+type MicrosoftRecipient = {
+  emailAddress: {
+    address: string;
+  };
+};
+
+export const toMicrosoftRecipients = (
+  addresses: EmailAddress | undefined,
+): MicrosoftRecipient[] => {
+  if (!addresses) return [];
+
+  const addressArray = Array.isArray(addresses) ? addresses : [addresses];
+
+  return addressArray.map((address) => ({
+    emailAddress: { address },
+  }));
+};

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/mail-sender/types/workflow-send-email-action-input.type.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/mail-sender/types/workflow-send-email-action-input.type.ts
@@ -1,6 +1,13 @@
+export type EmailRecipients = {
+  to: string[];
+  cc?: string[];
+  bcc?: string[];
+};
+
 export type WorkflowSendEmailActionInput = {
   connectedAccountId: string;
-  email: string;
+  email?: string;
+  recipients?: EmailRecipients;
   subject?: string;
   body?: string;
 };

--- a/packages/twenty-shared/src/workflow/index.ts
+++ b/packages/twenty-shared/src/workflow/index.ts
@@ -44,7 +44,10 @@ export { workflowIteratorActionSettingsSchema } from './schemas/iterator-action-
 export { workflowManualTriggerSchema } from './schemas/manual-trigger-schema';
 export { objectRecordSchema } from './schemas/object-record-schema';
 export { workflowSendEmailActionSchema } from './schemas/send-email-action-schema';
-export { workflowSendEmailActionSettingsSchema } from './schemas/send-email-action-settings-schema';
+export {
+  workflowEmailRecipientsSchema,
+  workflowSendEmailActionSettingsSchema,
+} from './schemas/send-email-action-settings-schema';
 export { stepFilterGroupSchema } from './schemas/step-filter-group-schema';
 export { stepFilterSchema } from './schemas/step-filter-schema';
 export { workflowUpdateRecordActionSchema } from './schemas/update-record-action-schema';

--- a/packages/twenty-shared/src/workflow/schemas/send-email-action-settings-schema.ts
+++ b/packages/twenty-shared/src/workflow/schemas/send-email-action-settings-schema.ts
@@ -2,11 +2,18 @@ import { z } from 'zod';
 import { baseWorkflowActionSettingsSchema } from './base-workflow-action-settings-schema';
 import { workflowFileSchema } from './workflow-file-action-schema';
 
+export const workflowEmailRecipientsSchema = z.object({
+  to: z.array(z.string()).optional().default([]),
+  cc: z.array(z.string()).optional().default([]),
+  bcc: z.array(z.string()).optional().default([]),
+});
+
 export const workflowSendEmailActionSettingsSchema =
   baseWorkflowActionSettingsSchema.extend({
     input: z.object({
       connectedAccountId: z.string(),
-      email: z.string(),
+      email: z.string().optional(),
+      recipients: workflowEmailRecipientsSchema.optional(),
       subject: z.string().optional(),
       body: z.string().optional(),
       files: z.array(workflowFileSchema).optional().default([]),


### PR DESCRIPTION
Adds support for multiple recipients in the Send Email workflow action

<img width="420" height="710" alt="image" src="https://github.com/user-attachments/assets/0dff67a7-ecf4-40d3-8ff7-71d5f970cff0" />


/closes #17383