### PR TITLE
[DASHBOARDS] Fix pie chart gap when there is only one slice

### DIFF
--- a/packages/twenty-front/src/modules/page-layout/widgets/graph/graphWidgetPieChart/components/GraphWidgetPieChart.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/graph/graphWidgetPieChart/components/GraphWidgetPieChart.tsx
@@ -140,7 +140,7 @@ export const GraphWidgetPieChart = ({
   const chartColors = hasNoData
     ? [theme.background.tertiary]
     : enrichedData.map((item) => item.colorScheme.solid);
-  const pieChartPadAngle = hasNoData ? 0 : 0.4;
+  const pieChartPadAngle = hasNoData || enrichedData.length <= 1 ? 0 : 0.4;
 
   const ArcsLayer = useCallback(
     (props: PieCustomLayerProps<PieChartDataItemWithColor>) => (


### PR DESCRIPTION
## Before
<img width="1290" height="764" alt="CleanShot 2026-01-23 at 11 00 44@2x" src="https://github.com/user-attachments/assets/f276f42b-7f2d-4c2a-98cf-cb693cda1242" />

## After
<img width="1292" height="762" alt="CleanShot 2026-01-23 at 11 00 28@2x" src="https://github.com/user-attachments/assets/a2d3df70-7965-4d4d-851b-729199a52510" />
