### PR TITLE
Fix event logic for soft-delete and restore

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/listeners/entity-events-to-db.listener.ts
+++ b/packages/twenty-server/src/engine/api/graphql/workspace-query-runner/listeners/entity-events-to-db.listener.ts
@@ -109,7 +109,10 @@ export class EntityEventsToDbListener {
         promises.push(
           this.entityEventsToDbQueueService.add<
             WorkspaceEventBatch<ObjectRecordNonDestructiveEvent>
-          >(UpsertTimelineActivityFromInternalEvent.name, batchEvent),
+          >(
+            UpsertTimelineActivityFromInternalEvent.name,
+            batchEvent as WorkspaceEventBatch<ObjectRecordNonDestructiveEvent>,
+          ),
         );
       }
     }

--- a/packages/twenty-server/src/engine/twenty-orm/repository/workspace-delete-query-builder.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/repository/workspace-delete-query-builder.ts
@@ -1,4 +1,5 @@
 import { type ObjectsPermissions } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
 import {
   DeleteQueryBuilder,
   type DeleteResult,
@@ -120,12 +121,18 @@ export class WorkspaceDeleteQueryBuilder<
         this.internalContext.flatFieldMetadataMaps,
       );
 
-      const formattedBefore = formatResult<T[]>(
+      const formattedBefore = formatResult<T | null>(
         before,
         objectMetadata,
         this.internalContext.flatObjectMetadataMaps,
         this.internalContext.flatFieldMetadataMaps,
       );
+
+      const recordsBefore = isDefined(formattedBefore)
+        ? Array.isArray(formattedBefore)
+          ? formattedBefore
+          : [formattedBefore]
+        : [];
 
       this.internalContext.eventEmitterService.emitDatabaseBatchEvent(
         formatTwentyOrmEventToDatabaseBatchEvent({
@@ -133,7 +140,7 @@ export class WorkspaceDeleteQueryBuilder<
           objectMetadataItem: objectMetadata,
           flatFieldMetadataMaps: this.internalContext.flatFieldMetadataMaps,
           workspaceId: this.internalContext.workspaceId,
-          entities: formattedBefore,
+          recordsBefore,
           authContext: this.authContext,
         }),
       );

--- a/packages/twenty-server/src/engine/twenty-orm/repository/workspace-insert-query-builder.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/repository/workspace-insert-query-builder.ts
@@ -213,7 +213,7 @@ export class WorkspaceInsertQueryBuilder<
           objectMetadataItem: objectMetadata,
           flatFieldMetadataMaps: this.internalContext.flatFieldMetadataMaps,
           workspaceId: this.internalContext.workspaceId,
-          entities: formattedResultForEvent,
+          recordsAfter: formattedResultForEvent,
           authContext: this.authContext,
         }),
       );
@@ -224,7 +224,7 @@ export class WorkspaceInsertQueryBuilder<
           objectMetadataItem: objectMetadata,
           flatFieldMetadataMaps: this.internalContext.flatFieldMetadataMaps,
           workspaceId: this.internalContext.workspaceId,
-          entities: formattedResultForEvent,
+          recordsAfter: formattedResultForEvent,
           authContext: this.authContext,
         }),
       );

--- a/packages/twenty-server/src/engine/twenty-orm/repository/workspace-soft-delete-query-builder.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/repository/workspace-soft-delete-query-builder.ts
@@ -111,10 +111,12 @@ export class WorkspaceSoftDeleteQueryBuilder<
         aliasName: objectMetadata.nameSingular,
       }) as WhereClause[];
 
-      const after = await super.execute();
+      const typeORMSoftRemoveResultWithOnlyIdColumn = await super.execute();
+
+      const afterWithAllFields = await beforeEventSelectQueryBuilder.getMany();
 
       const formattedAfter = formatResult<T[]>(
-        after.raw,
+        afterWithAllFields,
         objectMetadata,
         this.internalContext.flatObjectMetadataMaps,
         this.internalContext.flatFieldMetadataMaps,
@@ -133,15 +135,16 @@ export class WorkspaceSoftDeleteQueryBuilder<
           objectMetadataItem: objectMetadata,
           flatFieldMetadataMaps: this.internalContext.flatFieldMetadataMaps,
           workspaceId: this.internalContext.workspaceId,
-          entities: formattedBefore,
+          recordsBefore: formattedBefore,
+          recordsAfter: formattedAfter,
           authContext: this.authContext,
         }),
       );
 
       return {
-        raw: after.raw,
+        raw: typeORMSoftRemoveResultWithOnlyIdColumn.raw,
         generatedMaps: formattedAfter,
-        affected: after.affected,
+        affected: typeORMSoftRemoveResultWithOnlyIdColumn.affected,
       };
     } catch (error) {
       throw await computeTwentyORMException(error);

--- a/packages/twenty-server/src/engine/twenty-orm/repository/workspace-update-query-builder.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/repository/workspace-update-query-builder.ts
@@ -209,8 +209,8 @@ export class WorkspaceUpdateQueryBuilder<
           objectMetadataItem: objectMetadata,
           flatFieldMetadataMaps: this.internalContext.flatFieldMetadataMaps,
           workspaceId: this.internalContext.workspaceId,
-          entities: formattedAfter,
-          beforeEntities: formattedBefore,
+          recordsAfter: formattedAfter,
+          recordsBefore: formattedBefore,
           authContext: this.authContext,
         }),
       );
@@ -221,8 +221,8 @@ export class WorkspaceUpdateQueryBuilder<
           objectMetadataItem: objectMetadata,
           flatFieldMetadataMaps: this.internalContext.flatFieldMetadataMaps,
           workspaceId: this.internalContext.workspaceId,
-          entities: formattedAfter,
-          beforeEntities: formattedBefore,
+          recordsAfter: formattedAfter,
+          recordsBefore: formattedBefore,
           authContext: this.authContext,
         }),
       );
@@ -388,8 +388,8 @@ export class WorkspaceUpdateQueryBuilder<
           objectMetadataItem: objectMetadata,
           flatFieldMetadataMaps: this.internalContext.flatFieldMetadataMaps,
           workspaceId: this.internalContext.workspaceId,
-          entities: formattedAfter,
-          beforeEntities: formattedBefore,
+          recordsAfter: formattedAfter,
+          recordsBefore: formattedBefore,
           authContext: this.authContext,
         }),
       );
@@ -400,8 +400,8 @@ export class WorkspaceUpdateQueryBuilder<
           objectMetadataItem: objectMetadata,
           flatFieldMetadataMaps: this.internalContext.flatFieldMetadataMaps,
           workspaceId: this.internalContext.workspaceId,
-          entities: formattedAfter,
-          beforeEntities: formattedBefore,
+          recordsAfter: formattedAfter,
+          recordsBefore: formattedBefore,
           authContext: this.authContext,
         }),
       );

--- a/packages/twenty-server/src/engine/twenty-orm/utils/__tests__/format-twenty-orm-event-to-database-batch-event.util.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/__tests__/format-twenty-orm-event-to-database-batch-event.util.spec.ts
@@ -1,5 +1,5 @@
-import { FieldMetadataType } from 'twenty-shared/types';
 import { type ObjectRecordUpdateEvent } from 'twenty-shared/database-events';
+import { FieldMetadataType } from 'twenty-shared/types';
 
 import { DatabaseEventAction } from 'src/engine/api/graphql/graphql-query-runner/enums/database-event-action';
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
@@ -114,8 +114,8 @@ describe('formatTwentyOrmEventToDatabaseBatchEvent', () => {
           flatFieldMetadataMaps,
           workspaceId: mockWorkspaceId,
           authContext: mockAuthContext,
-          entities: afterEntities,
-          beforeEntities: beforeEntities,
+          recordsAfter: afterEntities,
+          recordsBefore: beforeEntities,
         });
       } catch (error) {
         expect(error).toBeInstanceOf(TwentyORMException);
@@ -157,8 +157,8 @@ describe('formatTwentyOrmEventToDatabaseBatchEvent', () => {
         flatFieldMetadataMaps,
         workspaceId: mockWorkspaceId,
         authContext: mockAuthContext,
-        entities: afterEntities,
-        beforeEntities: beforeEntities,
+        recordsAfter: afterEntities,
+        recordsBefore: beforeEntities,
       });
 
       expect(result).toBeDefined();
@@ -179,33 +179,6 @@ describe('formatTwentyOrmEventToDatabaseBatchEvent', () => {
       expect(updateEvent1.properties?.after?.name).toBe('John Doe Updated');
       expect(updateEvent2.properties?.before?.name).toBe('Jane Doe');
       expect(updateEvent2.properties?.after?.name).toBe('Jane Doe Updated');
-    });
-
-    it('should handle single entity (non-array) for both before and after', () => {
-      const afterEntity = {
-        id: 'record-1',
-        name: 'John Doe Updated',
-      };
-
-      const beforeEntity = {
-        id: 'record-1',
-        name: 'John Doe',
-      };
-
-      const result = formatTwentyOrmEventToDatabaseBatchEvent({
-        action: DatabaseEventAction.UPDATED,
-        objectMetadataItem: flatObjectMetadata,
-        flatFieldMetadataMaps,
-        workspaceId: mockWorkspaceId,
-        authContext: mockAuthContext,
-        entities: afterEntity,
-        beforeEntities: beforeEntity,
-      });
-
-      expect(result).toBeDefined();
-      expect(result?.action).toBe(DatabaseEventAction.UPDATED);
-      expect(result?.events).toHaveLength(1);
-      expect(result?.events[0].recordId).toBe('record-1');
     });
   });
 });

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/listeners/workflow-database-event-trigger.listener.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/listeners/workflow-database-event-trigger.listener.ts
@@ -1,10 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
 
 import {
+  ObjectRecordEvent,
   type ObjectRecordCreateEvent,
   type ObjectRecordDeleteEvent,
   type ObjectRecordDestroyEvent,
-  type ObjectRecordNonDestructiveEvent,
   type ObjectRecordUpdateEvent,
   type ObjectRecordUpsertEvent,
 } from 'twenty-shared/database-events';
@@ -308,7 +308,7 @@ export class WorkflowDatabaseEventTriggerListener {
   }
 
   private async shouldIgnoreEvent(
-    payload: WorkspaceEventBatch<ObjectRecordNonDestructiveEvent>,
+    payload: WorkspaceEventBatch<ObjectRecordEvent>,
   ) {
     const workspaceId = payload.workspaceId;
     const databaseEventName = payload.name;
@@ -330,7 +330,7 @@ export class WorkflowDatabaseEventTriggerListener {
     payload,
     action,
   }: {
-    payload: WorkspaceEventBatch<ObjectRecordNonDestructiveEvent>;
+    payload: WorkspaceEventBatch<ObjectRecordEvent>;
     action: DatabaseEventAction;
   }) {
     const workspaceId = payload.workspaceId;
@@ -390,7 +390,7 @@ export class WorkflowDatabaseEventTriggerListener {
     eventListener,
     action,
   }: {
-    eventPayload: ObjectRecordNonDestructiveEvent;
+    eventPayload: ObjectRecordEvent;
     eventListener: WorkflowAutomatedTriggerWorkspaceEntity;
     action: DatabaseEventAction;
   }) {

--- a/packages/twenty-shared/src/database-events/object-record-delete.event.ts
+++ b/packages/twenty-shared/src/database-events/object-record-delete.event.ts
@@ -1,3 +1,4 @@
+import { type ObjectRecordDiff } from '@/database-events/object-record-diff';
 import { ObjectRecordBaseEvent } from '@/database-events/object-record.base.event';
 
 export class ObjectRecordDeleteEvent<
@@ -5,5 +6,8 @@ export class ObjectRecordDeleteEvent<
 > extends ObjectRecordBaseEvent<T> {
   declare properties: {
     before: T;
+    after: T;
+    updatedFields: string[];
+    diff: Partial<ObjectRecordDiff<T>>;
   };
 }

--- a/packages/twenty-shared/src/database-events/object-record-restore.event.ts
+++ b/packages/twenty-shared/src/database-events/object-record-restore.event.ts
@@ -1,9 +1,13 @@
 import { ObjectRecordCreateEvent } from '@/database-events/object-record-create.event';
+import { type ObjectRecordDiff } from '@/database-events/object-record-diff';
 
 export class ObjectRecordRestoreEvent<
   T = object,
 > extends ObjectRecordCreateEvent<T> {
   declare properties: {
+    before: T;
     after: T;
+    updatedFields: string[];
+    diff: Partial<ObjectRecordDiff<T>>;
   };
 }

--- a/packages/twenty-shared/src/database-events/object-record-update.event.ts
+++ b/packages/twenty-shared/src/database-events/object-record-update.event.ts
@@ -1,12 +1,12 @@
-import { ObjectRecordBaseEvent } from '@/database-events/object-record.base.event';
 import { type ObjectRecordDiff } from '@/database-events/object-record-diff';
+import { ObjectRecordBaseEvent } from '@/database-events/object-record.base.event';
 
 export class ObjectRecordUpdateEvent<
   T = object,
 > extends ObjectRecordBaseEvent<T> {
   declare properties: {
-    updatedFields?: string[];
-    diff?: Partial<ObjectRecordDiff<T>>;
+    updatedFields: string[];
+    diff: Partial<ObjectRecordDiff<T>>;
     before: T;
     after: T;
   };


### PR DESCRIPTION
This PR changes the shape and logic of SSE events `DELETE` and `RESTORE`, because they behave like `UPDATE` events in practice, they should share the same logic.

Before this PR, it was impossible for the frontend to obtain the `deletedAt` value, and the logic to handle soft-delete and restore would have been flawed.

Because there is a typing confusion in the parameters of `formatTwentyOrmEventToDatabaseBatchEvent`, due to TypeORM, we also update this util to only accept an array of records, instead of `T | T[]`. We should improve our TypeORM layer in the future. 

Also the naming was not clear, so we clearly use `recordsAfter` and `recordsBefore` as much as possible, because that is what we have at the end in events.

Events are sent from their respective query builders, so these last ones have been updated also.

Because TypeORM `soft-remove` operation only returns record ids, we add `.getMany()` to fetch all fields for soft-removed records, so that our event can have before and after.