### PR TITLE
Add Development Setup section to CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -18,6 +18,19 @@ To avoid conflicts, we follow these guidelines:
 1. For `Good First Issue` and `Experienced Contributor` issues without `size: long` labels, we'll merge the first PRs that meet our [code quality standards](https://docs.twenty.com/developers). **We don't assign contributors to these issues**. For `priority: high` issues, our core team will step in within days if no adequate contributions are received.
 2. For `size: long` Issues, assigned contributors have one week to submit their first draft PR.
 
+## Development Setup
+
+Before contributing, you’ll need to set up the project locally.
+
+### Prerequisites
+
+Make sure you have the following installed:
+- Node.js (recommended version: see `.nvmrc` if available)
+- Package manager (npm / yarn / pnpm — see project docs)
+- Git
+
+Additional requirements (database, services, etc.) are documented in the main README.
+
 ## How to Contribute
 
 1. **Fork the Repository:** Click on the 'Fork' button in the upper right corner of the repository's GitHub page. This will create a copy of the repository in your GitHub account.


### PR DESCRIPTION
This PR adds a **Development Setup** section to `CONTRIBUTING.md` to help new contributors get the project running locally before making changes.

Currently, the contributing guide assumes contributors already know how to:
- install dependencies
- configure environment variables
- run the project and tests

This section fills that gap and makes “Good first issues” more accessible to first-time contributors.

### Checklist
- [x] Documentation-only change
- [x] No breaking changes
- [x] Follows existing documentation style
