### PR TITLE
IMAP fix edge case of nested folder filtering of unwanted folders

### DIFF
--- a/packages/twenty-server/src/modules/messaging/message-folder-manager/drivers/imap/services/imap-get-all-folders.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-folder-manager/drivers/imap/services/imap-get-all-folders.service.ts
@@ -102,7 +102,7 @@ export class ImapGetAllFoldersService implements MessageFolderDriver {
       pathToExternalIdMap.set(mailbox.path, externalId);
 
       if (this.isValidMailbox(mailbox, folders)) {
-        const standardFolder = getStandardFolderByRegex(mailbox.path);
+        const standardFolder = getStandardFolderByRegex(mailbox.name);
 
         if (!shouldCreateFolderByDefault(standardFolder)) {
           continue;

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/utils/__tests__/get-sent-folder-candidates-by-regex.util.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/utils/__tests__/get-sent-folder-candidates-by-regex.util.spec.ts
@@ -141,4 +141,18 @@ describe('getSentFolderCandidatesByRegex', () => {
 
     expect(result).toEqual([]);
   });
+
+  it('matches Sent folder when nested under INBOX', () => {
+    const input: ListResponse[] = [
+      { path: 'INBOX', name: 'Inbox' } as ListResponse,
+      { path: 'INBOX/Sent', name: 'Sent' } as ListResponse,
+      { path: 'INBOX/Archive', name: 'Archive' } as ListResponse,
+    ];
+
+    const result = getImapSentFolderCandidatesByRegex(input);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].path).toBe('INBOX/Sent');
+    expect(result[0].name).toBe('Sent');
+  });
 });

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/utils/get-sent-folder-candidates-by-regex.util.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/utils/get-sent-folder-candidates-by-regex.util.ts
@@ -9,7 +9,7 @@ export function getImapSentFolderCandidatesByRegex(
   const regexCandidateFolders: string[] = [];
 
   for (const folder of list) {
-    const standardFolder = getStandardFolderByRegex(folder.path);
+    const standardFolder = getStandardFolderByRegex(folder.name);
 
     if (standardFolder === StandardFolder.SENT) {
       regexCandidateFolders.push(folder.path);


### PR DESCRIPTION
Fixes this edge case I saw on a customer's account, where INBOX was the parent folder of standard folders

<img width="580" height="634" alt="edge case folders" src="https://github.com/user-attachments/assets/c715e5c6-8d37-45a8-a962-16da2bf38ced" />
