### PR TITLE
fix: prevent record title reset on focus for notes and tasks

### DIFF
--- a/packages/twenty-front/src/modules/action-menu/actions/record-actions/single-record/components/CreateRelatedRecordAction.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-actions/single-record/components/CreateRelatedRecordAction.tsx
@@ -106,7 +106,7 @@ export const CreateRelatedRecordAction = ({
     if (isDefined(labelIdentifierFieldMetadataItem)) {
       openRecordTitleCell({
         recordId: createdRecord.id,
-        fieldName: labelIdentifierFieldMetadataItem.name,
+        fieldMetadataItemId: labelIdentifierFieldMetadataItem.id,
         instanceId: getRecordFieldInputInstanceId({
           recordId: createdRecord.id,
           fieldName: labelIdentifierFieldMetadataItem.name,

--- a/packages/twenty-front/src/modules/object-record/record-table/hooks/useCreateNewIndexRecord.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/hooks/useCreateNewIndexRecord.ts
@@ -108,7 +108,7 @@ export const useCreateNewIndexRecord = ({
           if (isDefined(labelIdentifierFieldMetadataItem)) {
             openRecordTitleCell({
               recordId,
-              fieldName: labelIdentifierFieldMetadataItem.name,
+              fieldMetadataItemId: labelIdentifierFieldMetadataItem.id,
               instanceId: getRecordFieldInputInstanceId({
                 recordId,
                 fieldName: labelIdentifierFieldMetadataItem.name,

--- a/packages/twenty-front/src/modules/object-record/record-title-cell/components/RecordTitleCellTextFieldDisplay.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-title-cell/components/RecordTitleCellTextFieldDisplay.tsx
@@ -1,4 +1,3 @@
-import { t } from '@lingui/core/macro';
 import { FieldContext } from '@/object-record/record-field/ui/contexts/FieldContext';
 import { recordStoreFamilyState } from '@/object-record/record-store/states/recordStoreFamilyState';
 import { useRecordTitleCell } from '@/object-record/record-title-cell/hooks/useRecordTitleCell';
@@ -6,6 +5,7 @@ import { type RecordTitleCellContainerType } from '@/object-record/record-title-
 import { getRecordFieldInputInstanceId } from '@/object-record/utils/getRecordFieldInputId';
 import { withTheme, type Theme } from '@emotion/react';
 import styled from '@emotion/styled';
+import { t } from '@lingui/core/macro';
 import { useContext } from 'react';
 import { useRecoilValue } from 'recoil';
 import { OverflowingTextWithTooltip } from 'twenty-ui/display';
@@ -51,7 +51,7 @@ export const RecordTitleCellSingleTextDisplayMode = ({
       onClick={() => {
         openRecordTitleCell({
           recordId,
-          fieldName: fieldDefinition.metadata.fieldName,
+          fieldMetadataItemId: fieldDefinition.fieldMetadataId,
           instanceId: getRecordFieldInputInstanceId({
             recordId,
             fieldName: fieldDefinition.metadata.fieldName,

--- a/packages/twenty-front/src/modules/object-record/record-title-cell/components/RecordTitleCellTextFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-title-cell/components/RecordTitleCellTextFieldInput.tsx
@@ -16,7 +16,12 @@ export const RecordTitleCellTextFieldInput = ({
   instanceId,
   sizeVariant,
 }: RecordTitleCellTextFieldInputProps) => {
-  const { fieldDefinition, draftValue, setDraftValue, fieldValue } = useTextField();
+  const {
+    fieldDefinition,
+    draftValue,
+    setDraftValue,
+    fieldValue,
+  } = useTextField();
 
   const wrapperRef = useRef<HTMLInputElement>(null);
 

--- a/packages/twenty-front/src/modules/object-record/record-title-cell/components/RecordTitleCellTextFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-title-cell/components/RecordTitleCellTextFieldInput.tsx
@@ -16,8 +16,7 @@ export const RecordTitleCellTextFieldInput = ({
   instanceId,
   sizeVariant,
 }: RecordTitleCellTextFieldInputProps) => {
-  const { fieldDefinition, draftValue, setDraftValue, fieldValue } =
-    useTextField();
+  const { fieldDefinition, draftValue, setDraftValue } = useTextField();
 
   const wrapperRef = useRef<HTMLInputElement>(null);
 
@@ -52,9 +51,6 @@ export const RecordTitleCellTextFieldInput = ({
 
   const handleFocus = (event: React.FocusEvent<HTMLInputElement>) => {
     // Ensure draft value is set from field value if it's undefined or empty when focusing
-    if (!isDefined(draftValue) && isDefined(fieldValue) && fieldValue !== '') {
-      setDraftValue(fieldValue);
-    }
     if (isDefined(draftValue)) {
       event.target.select();
     }

--- a/packages/twenty-front/src/modules/object-record/record-title-cell/components/RecordTitleCellTextFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-title-cell/components/RecordTitleCellTextFieldInput.tsx
@@ -3,7 +3,7 @@ import { useTextField } from '@/object-record/record-field/ui/meta-types/hooks/u
 import { useRegisterInputEvents } from '@/object-record/record-field/ui/meta-types/input/hooks/useRegisterInputEvents';
 
 import { TextInput } from '@/ui/input/components/TextInput';
-import { useContext, useRef } from 'react';
+import { useContext, useRef, useEffect } from 'react';
 import { isDefined } from 'twenty-shared/utils';
 import { turnIntoUndefinedIfWhitespacesOnly } from '~/utils/string/turnIntoUndefinedIfWhitespacesOnly';
 
@@ -16,9 +16,16 @@ export const RecordTitleCellTextFieldInput = ({
   instanceId,
   sizeVariant,
 }: RecordTitleCellTextFieldInputProps) => {
-  const { fieldDefinition, draftValue, setDraftValue } = useTextField();
+  const { fieldDefinition, draftValue, setDraftValue, fieldValue } = useTextField();
 
   const wrapperRef = useRef<HTMLInputElement>(null);
+
+  // Ensure draft value is initialized from field value if it's undefined or empty
+  useEffect(() => {
+    if (!isDefined(draftValue) && isDefined(fieldValue) && fieldValue !== '') {
+      setDraftValue(fieldValue);
+    }
+  }, [draftValue, fieldValue, setDraftValue]);
 
   const handleChange = (newText: string) => {
     setDraftValue(turnIntoUndefinedIfWhitespacesOnly(newText));
@@ -50,6 +57,10 @@ export const RecordTitleCellTextFieldInput = ({
   });
 
   const handleFocus = (event: React.FocusEvent<HTMLInputElement>) => {
+    // Ensure draft value is set from field value if it's undefined or empty when focusing
+    if (!isDefined(draftValue) && isDefined(fieldValue) && fieldValue !== '') {
+      setDraftValue(fieldValue);
+    }
     if (isDefined(draftValue)) {
       event.target.select();
     }

--- a/packages/twenty-front/src/modules/object-record/record-title-cell/components/RecordTitleCellTextFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-title-cell/components/RecordTitleCellTextFieldInput.tsx
@@ -16,12 +16,8 @@ export const RecordTitleCellTextFieldInput = ({
   instanceId,
   sizeVariant,
 }: RecordTitleCellTextFieldInputProps) => {
-  const {
-    fieldDefinition,
-    draftValue,
-    setDraftValue,
-    fieldValue,
-  } = useTextField();
+  const { fieldDefinition, draftValue, setDraftValue, fieldValue } =
+    useTextField();
 
   const wrapperRef = useRef<HTMLInputElement>(null);
 

--- a/packages/twenty-front/src/modules/object-record/record-title-cell/components/RecordTitleCellTextFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-title-cell/components/RecordTitleCellTextFieldInput.tsx
@@ -3,7 +3,7 @@ import { useTextField } from '@/object-record/record-field/ui/meta-types/hooks/u
 import { useRegisterInputEvents } from '@/object-record/record-field/ui/meta-types/input/hooks/useRegisterInputEvents';
 
 import { TextInput } from '@/ui/input/components/TextInput';
-import { useContext, useRef, useEffect } from 'react';
+import { useContext, useRef } from 'react';
 import { isDefined } from 'twenty-shared/utils';
 import { turnIntoUndefinedIfWhitespacesOnly } from '~/utils/string/turnIntoUndefinedIfWhitespacesOnly';
 
@@ -19,13 +19,6 @@ export const RecordTitleCellTextFieldInput = ({
   const { fieldDefinition, draftValue, setDraftValue, fieldValue } = useTextField();
 
   const wrapperRef = useRef<HTMLInputElement>(null);
-
-  // Ensure draft value is initialized from field value if it's undefined or empty
-  useEffect(() => {
-    if (!isDefined(draftValue) && isDefined(fieldValue) && fieldValue !== '') {
-      setDraftValue(fieldValue);
-    }
-  }, [draftValue, fieldValue, setDraftValue]);
 
   const handleChange = (newText: string) => {
     setDraftValue(turnIntoUndefinedIfWhitespacesOnly(newText));

--- a/packages/twenty-front/src/modules/object-record/record-title-cell/components/RecordTitleFullNameFieldDisplay.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-title-cell/components/RecordTitleFullNameFieldDisplay.tsx
@@ -1,4 +1,3 @@
-import { t } from '@lingui/core/macro';
 import { FieldContext } from '@/object-record/record-field/ui/contexts/FieldContext';
 import { useFullNameFieldDisplay } from '@/object-record/record-field/ui/meta-types/hooks/useFullNameFieldDisplay';
 import { useRecordTitleCell } from '@/object-record/record-title-cell/hooks/useRecordTitleCell';
@@ -7,6 +6,7 @@ import { usePushFocusItemToFocusStack } from '@/ui/utilities/focus/hooks/usePush
 import { FocusComponentType } from '@/ui/utilities/focus/types/FocusComponentType';
 import { withTheme, type Theme } from '@emotion/react';
 import styled from '@emotion/styled';
+import { t } from '@lingui/core/macro';
 import { isNonEmptyString } from '@sniptt/guards';
 import { useContext } from 'react';
 import { OverflowingTextWithTooltip } from 'twenty-ui/display';
@@ -73,7 +73,7 @@ export const RecordTitleFullNameFieldDisplay = ({
 
         openRecordTitleCell({
           recordId,
-          fieldName: fieldDefinition.metadata.fieldName,
+          fieldMetadataItemId: fieldDefinition.fieldMetadataId,
           instanceId: getRecordFieldInputInstanceId({
             recordId,
             fieldName: fieldDefinition.metadata.fieldName,

--- a/packages/twenty-front/src/modules/object-record/record-title-cell/hooks/useRecordTitleCell.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-title-cell/hooks/useRecordTitleCell.tsx
@@ -1,4 +1,4 @@
-import { useContextStoreObjectMetadataItem } from '@/context-store/hooks/useContextStoreObjectMetadataItem';
+import { useGetFieldMetadataItemByIdOrThrow } from '@/object-metadata/hooks/useGetFieldMetadataItemById';
 import { formatFieldMetadataItemAsColumnDefinition } from '@/object-metadata/utils/formatFieldMetadataItemAsColumnDefinition';
 import { useInitDraftValue } from '@/object-record/record-field/ui/hooks/useInitDraftValue';
 import { RecordTitleCellComponentInstanceContext } from '@/object-record/record-title-cell/states/contexts/RecordTitleCellComponentInstanceContext';
@@ -13,7 +13,7 @@ import { isDefined } from 'twenty-shared/utils';
 
 type OpenTitleCellFunctionParams = {
   recordId: string;
-  fieldName: string;
+  fieldMetadataItemId: string;
   instanceId?: string;
 };
 
@@ -29,7 +29,8 @@ export const useRecordTitleCell = () => {
   const { removeFocusItemFromFocusStackById } =
     useRemoveFocusItemFromFocusStackById();
 
-  const { objectMetadataItem } = useContextStoreObjectMetadataItem();
+  const { getFieldMetadataItemByIdOrThrow } =
+    useGetFieldMetadataItemByIdOrThrow();
 
   const closeRecordTitleCell = useRecoilCallback(
     ({ set }) =>
@@ -67,15 +68,9 @@ export const useRecordTitleCell = () => {
     ({ set }) =>
       ({
         recordId,
-        fieldName,
+        fieldMetadataItemId,
         instanceId: instanceIdFromProps,
       }: OpenTitleCellFunctionParams) => {
-        if (!isDefined(objectMetadataItem)) {
-          throw new Error(
-            'Cannot find object metadata item in openRecordTitleCell this should not happen.',
-          );
-        }
-
         const computedInstanceId = instanceIdFromProps ?? instanceId;
 
         if (!isDefined(computedInstanceId)) {
@@ -103,24 +98,14 @@ export const useRecordTitleCell = () => {
           true,
         );
 
-        const fieldDefinitions = objectMetadataItem.fields.map(
-          (fieldMetadataItem, index) =>
-            formatFieldMetadataItemAsColumnDefinition({
-              field: fieldMetadataItem,
-              objectMetadataItem,
-              position: index,
-            }),
-        );
+        const { fieldMetadataItem, objectMetadataItem } =
+          getFieldMetadataItemByIdOrThrow(fieldMetadataItemId);
 
-        const fieldDefinition = fieldDefinitions.find(
-          (field) => field.metadata.fieldName === fieldName,
-        );
-
-        if (!fieldDefinition) {
-          throw new Error(
-            `Cannot find field definition for field name ${fieldName}, this should not happen.`,
-          );
-        }
+        const fieldDefinition = formatFieldMetadataItemAsColumnDefinition({
+          field: fieldMetadataItem,
+          objectMetadataItem,
+          position: 0,
+        });
 
         initFieldInputDraftValue({
           recordId,
@@ -129,10 +114,10 @@ export const useRecordTitleCell = () => {
         });
       },
     [
-      objectMetadataItem,
       instanceId,
       pushFocusItemToFocusStack,
       initFieldInputDraftValue,
+      getFieldMetadataItemByIdOrThrow,
     ],
   );
 


### PR DESCRIPTION
Fixes issue where focusing the record title input would reset the title to empty. This ensures the draft value is properly initialized from the field value if it's undefined or empty when the input is focused.

Fixes #17437