### PR TITLE
Invalidate flat cache command

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/cache-storage/commands/flat-cache-invalidate.command.ts
+++ b/packages/twenty-server/src/engine/core-modules/cache-storage/commands/flat-cache-invalidate.command.ts
@@ -159,14 +159,6 @@ export class FlatCacheInvalidateCommand extends ActiveOrSuspendedWorkspacesMigra
       getMetadataFlatEntityMapsKey,
     );
 
-    if (allFlatMapsKeys.length > metadataNames.length) {
-      const relatedCount = allFlatMapsKeys.length - metadataNames.length;
-
-      this.logger.log(
-        `Added ${relatedCount} related metadata cache(s) for invalidation due to side effects`,
-      );
-    }
-
     return allFlatMapsKeys;
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/cache-storage/commands/flat-cache-invalidate.command.ts
+++ b/packages/twenty-server/src/engine/core-modules/cache-storage/commands/flat-cache-invalidate.command.ts
@@ -21,7 +21,7 @@ import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspac
 
 type FlatCacheFlushCommandOptions =
   ActiveOrSuspendedWorkspacesMigrationCommandOptions & {
-    all?: boolean;
+    allMetadata?: boolean;
   };
 
 @Command({
@@ -58,12 +58,12 @@ export class FlatCacheInvalidateCommand extends ActiveOrSuspendedWorkspacesMigra
   }
 
   @Option({
-    flags: '--all',
+    flags: '--all-metadata',
     description:
       'Flush cache for all metadata names. Takes precedence over --metadataName.',
     required: false,
   })
-  parseAll(): boolean {
+  parseAllMetadata(): boolean {
     return true;
   }
 
@@ -71,9 +71,9 @@ export class FlatCacheInvalidateCommand extends ActiveOrSuspendedWorkspacesMigra
     passedParams: string[],
     options: FlatCacheFlushCommandOptions,
   ): Promise<void> {
-    if (!options.all && this.metadataNames.length === 0) {
+    if (!options.allMetadata && this.metadataNames.length === 0) {
       this.logger.error(
-        'Either --all or at least one --metadataName must be provided.',
+        'Either --all-metadata or at least one --metadataName must be provided.',
       );
 
       return;
@@ -81,7 +81,7 @@ export class FlatCacheInvalidateCommand extends ActiveOrSuspendedWorkspacesMigra
 
     const validatedMetadataNames = this.validateAndExpandMetadataNames({
       inputMetadataNames: this.metadataNames,
-      all: options.all,
+      allMetadata: options.allMetadata,
     });
 
     if (validatedMetadataNames === null) {
@@ -112,16 +112,16 @@ export class FlatCacheInvalidateCommand extends ActiveOrSuspendedWorkspacesMigra
 
   private validateAndExpandMetadataNames({
     inputMetadataNames,
-    all,
+    allMetadata,
   }: {
     inputMetadataNames: string[];
-    all?: boolean;
+    allMetadata?: boolean;
   }): AllMetadataName[] | null {
     const validMetadataNames = Object.keys(
       ALL_METADATA_NAME,
     ) as AllMetadataName[];
 
-    if (all) {
+    if (allMetadata) {
       this.logger.log('Using all metadata names');
 
       return validMetadataNames;
@@ -136,7 +136,7 @@ export class FlatCacheInvalidateCommand extends ActiveOrSuspendedWorkspacesMigra
         `Invalid metadata name(s) provided: ${invalidNames.join(', ')}`,
       );
       this.logger.error(
-        `Valid metadata names are: ${validMetadataNames.join(', ')}, or use --all`,
+        `Valid metadata names are: ${validMetadataNames.join(', ')}, or use --all-metadata`,
       );
 
       return null;

--- a/packages/twenty-server/src/engine/core-modules/cache-storage/commands/flat-cache-invalidate.command.ts
+++ b/packages/twenty-server/src/engine/core-modules/cache-storage/commands/flat-cache-invalidate.command.ts
@@ -1,0 +1,172 @@
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { Command, Option } from 'nest-commander';
+import {
+  ALL_METADATA_NAME,
+  type AllMetadataName,
+} from 'twenty-shared/metadata';
+import { Repository } from 'typeorm';
+
+import {
+  ActiveOrSuspendedWorkspacesMigrationCommandRunner,
+  type ActiveOrSuspendedWorkspacesMigrationCommandOptions,
+} from 'src/database/commands/command-runners/active-or-suspended-workspaces-migration.command-runner';
+import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspaces-migration.command-runner';
+import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
+import { DataSourceService } from 'src/engine/metadata-modules/data-source/data-source.service';
+import { WorkspaceManyOrAllFlatEntityMapsCacheService } from 'src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.service';
+import { getMetadataFlatEntityMapsKey } from 'src/engine/metadata-modules/flat-entity/utils/get-metadata-flat-entity-maps-key.util';
+import { getMetadataRelatedMetadataNames } from 'src/engine/metadata-modules/flat-entity/utils/get-metadata-related-metadata-names.util';
+import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
+
+type FlatCacheFlushCommandOptions =
+  ActiveOrSuspendedWorkspacesMigrationCommandOptions & {
+    all?: boolean;
+  };
+
+@Command({
+  name: 'cache:flat-cache-invalidate',
+  description:
+    'Flush flat entity cache for specific metadata names and workspaces',
+})
+export class FlatCacheInvalidateCommand extends ActiveOrSuspendedWorkspacesMigrationCommandRunner<FlatCacheFlushCommandOptions> {
+  private metadataNames: string[] = [];
+  private flatMapsKeysToFlush: ReturnType<
+    typeof getMetadataFlatEntityMapsKey
+  >[] = [];
+
+  constructor(
+    @InjectRepository(WorkspaceEntity)
+    protected readonly workspaceRepository: Repository<WorkspaceEntity>,
+    protected readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    protected readonly dataSourceService: DataSourceService,
+    private readonly flatEntityMapsCacheService: WorkspaceManyOrAllFlatEntityMapsCacheService,
+  ) {
+    super(workspaceRepository, globalWorkspaceOrmManager, dataSourceService);
+  }
+
+  @Option({
+    flags: '--metadataName <metadataName>',
+    description:
+      'Metadata name(s) to flush cache for. Can be specified multiple times.',
+    required: false,
+  })
+  parseMetadataName(val: string): string[] {
+    this.metadataNames.push(val);
+
+    return this.metadataNames;
+  }
+
+  @Option({
+    flags: '--all',
+    description:
+      'Flush cache for all metadata names. Takes precedence over --metadataName.',
+    required: false,
+  })
+  parseAll(): boolean {
+    return true;
+  }
+
+  override async runMigrationCommand(
+    passedParams: string[],
+    options: FlatCacheFlushCommandOptions,
+  ): Promise<void> {
+    if (!options.all && this.metadataNames.length === 0) {
+      this.logger.error(
+        'Either --all or at least one --metadataName must be provided.',
+      );
+
+      return;
+    }
+
+    const validatedMetadataNames = this.validateAndExpandMetadataNames({
+      inputMetadataNames: this.metadataNames,
+      all: options.all,
+    });
+
+    if (validatedMetadataNames === null) {
+      return;
+    }
+
+    this.flatMapsKeysToFlush = this.computeFlatMapsKeysWithRelated(
+      validatedMetadataNames,
+    );
+
+    this.logger.log(
+      `Will flush cache for the following flat maps keys: ${this.flatMapsKeysToFlush.join(', ')}`,
+    );
+
+    await super.runMigrationCommand(passedParams, options);
+  }
+
+  override async runOnWorkspace({
+    workspaceId,
+  }: RunOnWorkspaceArgs): Promise<void> {
+    await this.flatEntityMapsCacheService.invalidateFlatEntityMaps({
+      workspaceId,
+      flatMapsKeys: this.flatMapsKeysToFlush,
+    });
+
+    this.logger.log(`Successfully flushed cache for workspace: ${workspaceId}`);
+  }
+
+  private validateAndExpandMetadataNames({
+    inputMetadataNames,
+    all,
+  }: {
+    inputMetadataNames: string[];
+    all?: boolean;
+  }): AllMetadataName[] | null {
+    const validMetadataNames = Object.keys(
+      ALL_METADATA_NAME,
+    ) as AllMetadataName[];
+
+    if (all) {
+      this.logger.log('Using all metadata names');
+
+      return validMetadataNames;
+    }
+
+    const invalidNames = inputMetadataNames.filter(
+      (name) => !validMetadataNames.includes(name as AllMetadataName),
+    );
+
+    if (invalidNames.length > 0) {
+      this.logger.error(
+        `Invalid metadata name(s) provided: ${invalidNames.join(', ')}`,
+      );
+      this.logger.error(
+        `Valid metadata names are: ${validMetadataNames.join(', ')}, or use --all`,
+      );
+
+      return null;
+    }
+
+    return inputMetadataNames as AllMetadataName[];
+  }
+
+  private computeFlatMapsKeysWithRelated(
+    metadataNames: AllMetadataName[],
+  ): ReturnType<typeof getMetadataFlatEntityMapsKey>[] {
+    const allMetadataNamesToFlush = [
+      ...new Set([
+        ...metadataNames,
+        ...metadataNames.flatMap(getMetadataRelatedMetadataNames),
+      ]),
+    ];
+
+    const allFlatMapsKeys = allMetadataNamesToFlush.map(
+      getMetadataFlatEntityMapsKey,
+    );
+
+    if (allFlatMapsKeys.length > metadataNames.length) {
+      const relatedCount = allFlatMapsKeys.length - metadataNames.length;
+
+      this.logger.log(
+        `Added ${relatedCount} related metadata cache(s) for invalidation due to side effects`,
+      );
+    }
+
+    return allFlatMapsKeys;
+  }
+}

--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.module.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.module.ts
@@ -1,6 +1,9 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { FlatCacheInvalidateCommand } from 'src/engine/core-modules/cache-storage/commands/flat-cache-invalidate.command';
+import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
+import { DataSourceModule } from 'src/engine/metadata-modules/data-source/data-source.module';
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { WorkspaceManyOrAllFlatEntityMapsCacheService } from 'src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.service';
 import { WorkspaceFlatFieldMetadataMapCacheService } from 'src/engine/metadata-modules/flat-field-metadata/services/workspace-flat-field-metadata-map-cache.service';
@@ -34,7 +37,9 @@ import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache
 @Module({
   imports: [
     WorkspaceCacheModule,
+    DataSourceModule,
     TypeOrmModule.forFeature([
+      WorkspaceEntity,
       ViewEntity,
       ViewFieldEntity,
       ViewFilterEntity,
@@ -66,6 +71,7 @@ import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache
     WorkspaceFlatPageLayoutWidgetMapCacheService,
     WorkspaceFlatRowLevelPermissionPredicateMapCacheService,
     WorkspaceFlatRowLevelPermissionPredicateGroupMapCacheService,
+    FlatCacheInvalidateCommand,
   ],
   exports: [
     WorkspaceManyOrAllFlatEntityMapsCacheService,
@@ -82,6 +88,7 @@ import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache
     WorkspaceFlatPageLayoutWidgetMapCacheService,
     WorkspaceFlatRowLevelPermissionPredicateMapCacheService,
     WorkspaceFlatRowLevelPermissionPredicateGroupMapCacheService,
+    FlatCacheInvalidateCommand,
   ],
 })
 export class WorkspaceManyOrAllFlatEntityMapsCacheModule {}


### PR DESCRIPTION
# Introduction
A command allowing to invalidate flat cache entries. Extends the active or suspended workspace coverage.

## Args
### --metadataName
If provided will invalidate metadata and related metadata cache entry ( can be repeated see usage )

### --all-metadata
Will invalidate all metadata entries

## Usage example
```
npx nx command twenty-server cache:flat-cache-invalidate --metadataName viewFilter --metadataName objectMetadata
```

```
npx nx command twenty-server cache:flat-cache-invalidate --all-metadata -w 0000-0000-0000-0000
```