### PR TITLE
fix: use universalIdentifier to identify the field in migrate-attachment-to-morph-relations

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-17/1-17-migrate-attachment-to-morph-relations.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-17/1-17-migrate-attachment-to-morph-relations.command.ts
@@ -156,7 +156,9 @@ export class MigrateAttachmentToMorphRelationsCommand extends ActiveOrSuspendedW
             attachmentTargetFieldUniversalIdentifiers.has(
               field.universalIdentifier,
             );
-          const isCustomTarget = relatedObject.isCustom && !isStandardAppField;
+          const isCustomTarget =
+            !isStandardAppField &&
+            field.standardId === ATTACHMENT_STANDARD_FIELD_IDS.targetCustom;
 
           if (!isStandardTarget && !isCustomTarget) {
             return [];

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-17/1-17-migrate-attachment-to-morph-relations.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-17/1-17-migrate-attachment-to-morph-relations.command.ts
@@ -144,9 +144,11 @@ export class MigrateAttachmentToMorphRelationsCommand extends ActiveOrSuspendedW
             attachmentTargetFieldUniversalIdentifiers.has(
               field.universalIdentifier,
             );
+          const targetObjectMetadata = field.relationTargetObjectMetadataId
+            ? flatObjectMetadataMaps.byId[field.relationTargetObjectMetadataId]
+            : undefined;
           const isCustomTarget =
-            !isStandardAppField &&
-            field.standardId === ATTACHMENT_STANDARD_FIELD_IDS.targetCustom;
+            !isStandardAppField && targetObjectMetadata?.isCustom === true;
 
           return isStandardTarget || isCustomTarget;
         });


### PR DESCRIPTION
Made changes to the command based on suggestions [here](https://github.com/twentyhq/twenty/pull/17381).