### PR TITLE
fix: allow reusing Person email after deletion

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/index/compute-person-standard-flat-index-metadata.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/index/compute-person-standard-flat-index-metadata.util.ts
@@ -36,6 +36,7 @@ export const buildPersonStandardFlatIndexMetadatas = ({
       indexName: 'emailsUniqueIndex',
       relatedFieldNames: ['emails'],
       isUnique: true,
+      indexWhereClause: '"deletedAt" IS NULL',
     },
     standardObjectMetadataRelatedEntityIds,
     dependencyFlatEntityMaps,


### PR DESCRIPTION
## Problem

When a Person record is deleted, the email address cannot be reused when creating a new person. The system throws an error: "This record already exists. Please check your data and try again." even though the deleted person is no longer visible in the UI.

## Solution

Added `indexWhereClause: "\"deletedAt\" IS NULL"` to the `emailsUniqueIndex` definition. This creates a partial unique index that only enforces uniqueness for non-deleted records, allowing email addresses to be reused after deletion.

## Changes

- Updated `compute-person-standard-flat-index-metadata.util.ts` to include `indexWhereClause` in the `emailsUniqueIndex` configuration
- This follows the same pattern used in other unique indexes (e.g., `messageChannelIdMessageIdUniqueIndex`)

## Testing

This fix ensures that:
- Email uniqueness is still enforced for active (non-deleted) records
- Deleted person records no longer block email reuse
- The behavior matches user expectations

Fixes #17425