### PR TITLE
Backfill `owner` standard field check colliding `joinColumnName`

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-16/1-16-backfill-opportunity-owner-field.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-16/1-16-backfill-opportunity-owner-field.command.ts
@@ -287,6 +287,7 @@ export class BackfillOpportunityOwnerFieldCommand extends ActiveOrSuspendedWorks
       this.logger.error(
         `Could not find custom owner relation target field ${customOwnerField.relationTargetFieldMetadataId}`,
       );
+
       return;
     }
 

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-16/1-16-backfill-opportunity-owner-field.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-16/1-16-backfill-opportunity-owner-field.command.ts
@@ -119,11 +119,14 @@ export class BackfillOpportunityOwnerFieldCommand extends ActiveOrSuspendedWorks
       return;
     }
 
-    const customOwnerField = flatFieldMetadatas.find(
-      (field) =>
-        field.name === 'owner' &&
-        field.universalIdentifier !== ownerUniversalIdentifier,
-    );
+    const customOwnerField =
+      flatFieldMetadatas.find(
+        (field) =>
+          field.name === 'owner' &&
+          field.universalIdentifier !== ownerUniversalIdentifier,
+        // Some self hoster might have run the name renaming successfully but not the joinColumnName
+        // Rather than asking them to restore db also grabbing them here
+      ) ?? flatFieldMetadatas.find((field) => field.name === 'ownerOld');
 
     if (isDefined(customOwnerField)) {
       await this.renameCustomOwnerFieldToOwnerOld({

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-16/1-16-backfill-opportunity-owner-field.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-16/1-16-backfill-opportunity-owner-field.command.ts
@@ -15,7 +15,11 @@ import { DataSourceService } from 'src/engine/metadata-modules/data-source/data-
 import { CreateFieldInput } from 'src/engine/metadata-modules/field-metadata/dtos/create-field.input';
 import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/field-metadata.entity';
 import { FieldMetadataService } from 'src/engine/metadata-modules/field-metadata/services/field-metadata.service';
+import { MetadataFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/metadata-flat-entity-maps.type';
+import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps.util';
 import { findManyFlatEntityByIdInFlatEntityMapsOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-many-flat-entity-by-id-in-flat-entity-maps-or-throw.util';
+import { FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { isMorphOrRelationFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-morph-or-relation-flat-field-metadata.util';
 import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 import { STANDARD_OBJECTS } from 'src/engine/workspace-manager/twenty-standard-application/constants/standard-object.constant';
@@ -122,25 +126,12 @@ export class BackfillOpportunityOwnerFieldCommand extends ActiveOrSuspendedWorks
     );
 
     if (isDefined(customOwnerField)) {
-      if (options.dryRun) {
-        this.logger.log(
-          `[DRY RUN] Would rename custom owner field to 'ownerOld' in workspace ${workspaceId}`,
-        );
-      } else {
-        await this.fieldMetadataService.updateOneField({
-          updateFieldInput: {
-            id: customOwnerField.id,
-            name: 'ownerOld',
-            label: 'Owner (Old)',
-          },
-          workspaceId,
-          isSystemBuild: true,
-        });
-
-        this.logger.log(
-          `Renamed custom owner field to 'ownerOld' in workspace ${workspaceId}`,
-        );
-      }
+      await this.renameCustomOwnerFieldToOwnerOld({
+        customOwnerField,
+        flatFieldMetadataMaps,
+        workspaceId,
+        dryRun: options.dryRun,
+      });
     }
 
     if (options.dryRun) {
@@ -231,5 +222,96 @@ export class BackfillOpportunityOwnerFieldCommand extends ActiveOrSuspendedWorks
       );
       throw error;
     }
+  }
+
+  private async renameCustomOwnerFieldToOwnerOld({
+    customOwnerField,
+    flatFieldMetadataMaps,
+    workspaceId,
+    dryRun,
+  }: {
+    customOwnerField: FlatFieldMetadata;
+    flatFieldMetadataMaps: MetadataFlatEntityMaps<'fieldMetadata'>;
+    workspaceId: string;
+    dryRun?: boolean;
+  }): Promise<void> {
+    if (dryRun) {
+      this.logger.log(
+        `[DRY RUN] Would rename custom owner field to 'ownerOld' in workspace and search for colloding foreignKey ${workspaceId}`,
+      );
+
+      return;
+    }
+
+    const isMorphOrRelationField =
+      isMorphOrRelationFlatFieldMetadata(customOwnerField);
+    const hasCollidingJoinColumnName =
+      isMorphOrRelationField &&
+      isDefined(customOwnerField.settings.joinColumnName) &&
+      customOwnerField.settings.joinColumnName === 'ownerId';
+
+    await this.fieldMetadataService.updateOneField({
+      updateFieldInput: {
+        id: customOwnerField.id,
+        name: 'ownerOld',
+        label: 'Owner (Old)',
+        ...(hasCollidingJoinColumnName
+          ? {
+              settings: {
+                ...customOwnerField.settings,
+                joinColumnName: `ownerOldId`,
+              },
+            }
+          : {}),
+      },
+      workspaceId,
+      isSystemBuild: true,
+    });
+    this.logger.log(
+      `Renamed custom owner field to 'ownerOld' in workspace ${workspaceId}`,
+    );
+
+    if (!isMorphOrRelationField || hasCollidingJoinColumnName) {
+      return;
+    }
+
+    const relatedFlatFieldMetadata = findFlatEntityByIdInFlatEntityMaps({
+      flatEntityId: customOwnerField.relationTargetFieldMetadataId,
+      flatEntityMaps: flatFieldMetadataMaps,
+    });
+
+    if (
+      !isDefined(relatedFlatFieldMetadata) ||
+      !isMorphOrRelationFlatFieldMetadata(relatedFlatFieldMetadata)
+    ) {
+      this.logger.error(
+        `Could not find custom owner relation target field ${customOwnerField.relationTargetFieldMetadataId}`,
+      );
+      return;
+    }
+
+    const targetHasCollidingJoinColumnName =
+      isDefined(relatedFlatFieldMetadata.settings.joinColumnName) &&
+      relatedFlatFieldMetadata.settings.joinColumnName === 'ownerId';
+
+    if (!targetHasCollidingJoinColumnName) {
+      return;
+    }
+
+    await this.fieldMetadataService.updateOneField({
+      updateFieldInput: {
+        id: relatedFlatFieldMetadata.id,
+        settings: {
+          ...relatedFlatFieldMetadata.settings,
+          joinColumnName: `ownerOldId`,
+        },
+      },
+      workspaceId,
+      isSystemBuild: true,
+    });
+
+    this.logger.log(
+      `Renamed custom owner field target related field join column name to 'ownerOldId' in workspace ${workspaceId}`,
+    );
   }
 }

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-16/1-16-backfill-opportunity-owner-field.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-16/1-16-backfill-opportunity-owner-field.command.ts
@@ -237,7 +237,7 @@ export class BackfillOpportunityOwnerFieldCommand extends ActiveOrSuspendedWorks
   }): Promise<void> {
     if (dryRun) {
       this.logger.log(
-        `[DRY RUN] Would rename custom owner field to 'ownerOld' in workspace and search for colloding foreignKey ${workspaceId}`,
+        `[DRY RUN] Would rename custom owner field to 'ownerOld' in workspace and search for colliding foreignKey ${workspaceId}`,
       );
 
       return;


### PR DESCRIPTION
# Introduction
Previously the command would have been `old` renaming only any `owner` field on `opportunity` object
Now we also search for any colliding `joinColumnName` with `ownerId` which is also introduced by the new standard owner field

In a nutshell: previously gracefully handling existing custom `owner` field collision but not for RELATION types that has an additional collision surface: `joinColumnName`

Related https://github.com/twentyhq/twenty/issues/17413#issuecomment-3799872079
