### PR TITLE
fix: update calendar setup CTA to 'Finish Setup' with floppy icon

### DIFF
--- a/packages/twenty-front/src/pages/settings/accounts/SettingsAccountsConfigurationStepCalendar.tsx
+++ b/packages/twenty-front/src/pages/settings/accounts/SettingsAccountsConfigurationStepCalendar.tsx
@@ -7,7 +7,7 @@ import { SettingsPageContainer } from '@/settings/components/SettingsPageContain
 import { SubMenuTopBarContainer } from '@/ui/layout/page/components/SubMenuTopBarContainer';
 import { SettingsPath } from 'twenty-shared/types';
 import { getSettingsPath, isDefined } from 'twenty-shared/utils';
-import { IconPlus } from 'twenty-ui/display';
+import { IconDeviceFloppy } from 'twenty-ui/display';
 import { Button } from 'twenty-ui/input';
 
 type SettingsAccountsConfigurationStepCalendarProps = {
@@ -46,8 +46,8 @@ export const SettingsAccountsConfigurationStepCalendar = ({
       ]}
       actionButton={
         <Button
-          Icon={IconPlus}
-          title={t`Add account`}
+          Icon={IconDeviceFloppy}
+          title={t`Finish Setup`}
           accent="blue"
           size="small"
           variant="primary"


### PR DESCRIPTION
## Today

CTA is confusing

<img width="1442" height="947" alt="image" src="https://github.com/user-attachments/assets/d5dd6229-e78d-4068-acbc-b5766b725b14" />

## Summary
- Replace the "Add account" button text with "Finish Setup" at the end of the calendar account configuration flow
- Change the button icon from a plus sign (`IconPlus`) to a floppy disk (`IconDeviceFloppy`) to better reflect saving/completing the setup