### PR TITLE
Patch `formatResult` to pass Date object through

### DIFF
--- a/packages/twenty-server/src/engine/twenty-orm/utils/format-result.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/format-result.util.ts
@@ -201,19 +201,13 @@ export function formatResult<T>(
       continue;
     }
 
-    if (typeof rawUpdatedDateTime === 'string') {
+    if (
+      typeof rawUpdatedDateTime === 'string' ||
+      rawUpdatedDateTime instanceof Date ||
+      isPlainObject(rawUpdatedDateTime)
+    ) {
       // @ts-expect-error legacy noImplicitAny
       newData[dateTimeField.name] = rawUpdatedDateTime;
-    } else if (rawUpdatedDateTime instanceof Date) {
-      const dateIsoString = rawUpdatedDateTime.toISOString();
-
-      // @ts-expect-error legacy noImplicitAny
-      newData[dateTimeField.name] = dateIsoString;
-    } else if (isPlainObject(rawUpdatedDateTime)) {
-      const plainObjectValue = rawUpdatedDateTime;
-
-      // @ts-expect-error legacy noImplicitAny
-      newData[dateTimeField.name] = plainObjectValue;
     } else {
       const stringifiedUnknownValue = stringifySafely(rawUpdatedDateTime);
 


### PR DESCRIPTION
This PR reverts the change that was made to turn `Date` objects into ISO string, because right now there are too many places in the code that use both, either Date or ISO string from an entity returned by the querying layer.

Unifying everything with ISO string is clearly the long term goal, but right now it is too difficult, we should first refactor each part to ISO string, then at the end remove Date from the codebase.