### PR TITLE
[Fix] display current object label in morph relation picker after rename 2/2

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-picker/single-record-picker/components/SingleRecordPickerMenuItem.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-picker/single-record-picker/components/SingleRecordPickerMenuItem.tsx
@@ -85,7 +85,7 @@ export const SingleRecordPickerMenuItem = ({
         }
         contextualText={
           showObjectName
-            ? capitalize(searchRecord.objectNameSingular)
+            ? capitalize(searchRecord.objectLabelSingular)
             : undefined
         }
       />

--- a/packages/twenty-sdk/src/cli/utilities/build/manifest/manifest-validate.ts
+++ b/packages/twenty-sdk/src/cli/utilities/build/manifest/manifest-validate.ts
@@ -1,19 +1,19 @@
+import { isNonEmptyArray } from 'twenty-shared/utils';
+import { applicationEntityBuilder } from './entities/application';
 import {
   type EntityIdWithLocation,
   type ManifestWithoutSources,
 } from '@/cli/utilities/build/manifest/entities/entity-interface';
-import {
-  type ValidationError,
-  type ValidationResult,
-  type ValidationWarning,
-} from '@/cli/utilities/build/manifest/manifest-types';
-import { isNonEmptyArray } from 'twenty-shared/utils';
-import { applicationEntityBuilder } from './entities/application';
 import { frontComponentEntityBuilder } from './entities/front-component';
 import { functionEntityBuilder } from './entities/function';
 import { objectEntityBuilder } from './entities/object';
 import { objectExtensionEntityBuilder } from './entities/object-extension';
 import { roleEntityBuilder } from './entities/role';
+import {
+  type ValidationError,
+  type ValidationResult,
+  type ValidationWarning,
+} from '@/cli/utilities/build/manifest/manifest-types';
 
 const collectAllDuplicates = (
   manifest: ManifestWithoutSources,
@@ -34,15 +34,18 @@ export const validateManifest = (
   const errors: ValidationError[] = [];
   const warnings: ValidationWarning[] = [];
 
-  applicationEntityBuilder.validate([manifest.application], errors);
-  objectEntityBuilder.validate(manifest.objects, errors);
+  applicationEntityBuilder.validate(
+    manifest.application ? [manifest.application] : [],
+    errors,
+  );
+  objectEntityBuilder.validate(manifest.objects ?? [], errors);
   objectExtensionEntityBuilder.validate(
     manifest.objectExtensions ?? [],
     errors,
   );
-  functionEntityBuilder.validate(manifest.functions, errors);
+  functionEntityBuilder.validate(manifest.functions ?? [], errors);
   roleEntityBuilder.validate(manifest.roles ?? [], errors);
-  frontComponentEntityBuilder.validate(manifest.frontComponents, errors);
+  frontComponentEntityBuilder.validate(manifest.frontComponents ?? [], errors);
 
   const duplicates = collectAllDuplicates(manifest);
   for (const dup of duplicates) {

--- a/packages/twenty-sdk/src/cli/utilities/build/manifest/manifest-validate.ts
+++ b/packages/twenty-sdk/src/cli/utilities/build/manifest/manifest-validate.ts
@@ -1,19 +1,19 @@
-import { isNonEmptyArray } from 'twenty-shared/utils';
-import { applicationEntityBuilder } from './entities/application';
 import {
   type EntityIdWithLocation,
   type ManifestWithoutSources,
 } from '@/cli/utilities/build/manifest/entities/entity-interface';
-import { frontComponentEntityBuilder } from './entities/front-component';
-import { functionEntityBuilder } from './entities/function';
-import { objectEntityBuilder } from './entities/object';
-import { objectExtensionEntityBuilder } from './entities/object-extension';
-import { roleEntityBuilder } from './entities/role';
 import {
   type ValidationError,
   type ValidationResult,
   type ValidationWarning,
 } from '@/cli/utilities/build/manifest/manifest-types';
+import { isNonEmptyArray } from 'twenty-shared/utils';
+import { applicationEntityBuilder } from './entities/application';
+import { frontComponentEntityBuilder } from './entities/front-component';
+import { functionEntityBuilder } from './entities/function';
+import { objectEntityBuilder } from './entities/object';
+import { objectExtensionEntityBuilder } from './entities/object-extension';
+import { roleEntityBuilder } from './entities/role';
 
 const collectAllDuplicates = (
   manifest: ManifestWithoutSources,
@@ -34,18 +34,15 @@ export const validateManifest = (
   const errors: ValidationError[] = [];
   const warnings: ValidationWarning[] = [];
 
-  applicationEntityBuilder.validate(
-    manifest.application ? [manifest.application] : [],
-    errors,
-  );
-  objectEntityBuilder.validate(manifest.objects ?? [], errors);
+  applicationEntityBuilder.validate([manifest.application], errors);
+  objectEntityBuilder.validate(manifest.objects, errors);
   objectExtensionEntityBuilder.validate(
     manifest.objectExtensions ?? [],
     errors,
   );
-  functionEntityBuilder.validate(manifest.functions ?? [], errors);
+  functionEntityBuilder.validate(manifest.functions, errors);
   roleEntityBuilder.validate(manifest.roles ?? [], errors);
-  frontComponentEntityBuilder.validate(manifest.frontComponents ?? [], errors);
+  frontComponentEntityBuilder.validate(manifest.frontComponents, errors);
 
   const duplicates = collectAllDuplicates(manifest);
   for (const dup of duplicates) {

--- a/packages/twenty-server/src/engine/core-modules/search/services/search.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/search/services/search.service.ts
@@ -453,7 +453,9 @@ export class SearchService {
           return {
             recordId: record.id,
             objectNameSingular: objectMetadataItem.nameSingular,
-            objectLabelSingular: objectMetadataItem.labelSingular,
+            objectLabelSingular:
+              objectMetadataItem.standardOverrides?.labelSingular ??
+              objectMetadataItem.labelSingular,
             label: this.getLabelIdentifierValue(
               record,
               objectMetadataItem,


### PR DESCRIPTION
Following https://github.com/twentyhq/twenty/pull/17209

The goal is to display the updated label. For SingleRecordPickerMenuItemsWithSearch, we did it in two parts to avoid the breaking change by calling `objectLabelSingular` after its addition has been deployed to prod
<img width="410" height="295" alt="image" src="https://github.com/user-attachments/assets/d6014391-b943-4fdb-a15f-e62717463d74" />
