### PR TITLE
Add WorkspaceAuthContextMiddleware

### DIFF
--- a/packages/twenty-server/src/app.module.ts
+++ b/packages/twenty-server/src/app.module.ts
@@ -24,6 +24,7 @@ import { MetricsModule } from 'src/engine/core-modules/metrics/metrics.module';
 import { DataloaderModule } from 'src/engine/dataloaders/dataloader.module';
 import { DataSourceModule } from 'src/engine/metadata-modules/data-source/data-source.module';
 import { WorkspaceMetadataVersionModule } from 'src/engine/metadata-modules/workspace-metadata-version/workspace-metadata-version.module';
+import { WorkspaceAuthContextMiddleware } from 'src/engine/core-modules/auth/middlewares/workspace-auth-context.middleware';
 import { GraphQLHydrateRequestFromTokenMiddleware } from 'src/engine/middlewares/graphql-hydrate-request-from-token.middleware';
 import { MiddlewareModule } from 'src/engine/middlewares/middleware.module';
 import { RestCoreMiddleware } from 'src/engine/middlewares/rest-core.middleware';
@@ -116,16 +117,22 @@ export class AppModule {
 
   configure(consumer: MiddlewareConsumer) {
     consumer
-      .apply(GraphQLHydrateRequestFromTokenMiddleware)
+      .apply(
+        GraphQLHydrateRequestFromTokenMiddleware,
+        WorkspaceAuthContextMiddleware,
+      )
       .forRoutes({ path: 'graphql', method: RequestMethod.ALL });
 
     consumer
-      .apply(GraphQLHydrateRequestFromTokenMiddleware)
+      .apply(
+        GraphQLHydrateRequestFromTokenMiddleware,
+        WorkspaceAuthContextMiddleware,
+      )
       .forRoutes({ path: 'metadata', method: RequestMethod.ALL });
 
     for (const method of MIGRATED_REST_METHODS) {
       consumer
-        .apply(RestCoreMiddleware)
+        .apply(RestCoreMiddleware, WorkspaceAuthContextMiddleware)
         .forRoutes({ path: 'rest/*path', method });
     }
   }

--- a/packages/twenty-server/src/database/commands/command-runners/__tests__/upgrade.command-runner.spec.ts
+++ b/packages/twenty-server/src/database/commands/command-runners/__tests__/upgrade.command-runner.spec.ts
@@ -123,7 +123,7 @@ const buildUpgradeCommandModule = async ({
           getDataSourceForWorkspace: jest.fn(),
           executeInWorkspaceContext: jest
             .fn()
-            .mockImplementation((_authContext: any, fn: () => any) => fn()),
+            .mockImplementation((fn: () => any, _authContext?: any) => fn()),
         },
       },
       {

--- a/packages/twenty-server/src/database/commands/command-runners/workspaces-migration.command-runner.ts
+++ b/packages/twenty-server/src/database/commands/command-runners/workspaces-migration.command-runner.ts
@@ -142,7 +142,6 @@ export abstract class WorkspacesMigrationCommandRunner<
         const authContext = buildSystemAuthContext(workspaceId);
 
         await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-          authContext,
           async () => {
             const workspaceHasDataSource =
               await this.dataSourceService.getLastDataSourceMetadataFromWorkspaceId(
@@ -161,6 +160,7 @@ export abstract class WorkspacesMigrationCommandRunner<
               total: workspaceIdsToProcess.length,
             });
           },
+          authContext,
         );
 
         this.migrationReport.success.push({

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-base-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-base-query-runner.service.ts
@@ -141,7 +141,6 @@ export abstract class CommonBaseQueryRunnerService<
     } as CommonExtendedInput<Args>;
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () =>
         this.executeQueryAndEnrichResults(
           processedArgs,
@@ -149,6 +148,7 @@ export abstract class CommonBaseQueryRunnerService<
           queryRunnerContext,
           commonQueryParser,
         ),
+      authContext,
     );
   }
 

--- a/packages/twenty-server/src/engine/core-modules/actor/services/__tests__/actor-from-auth-context.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/actor/services/__tests__/actor-from-auth-context.service.spec.ts
@@ -45,7 +45,7 @@ describe('ActorFromAuthContextService', () => {
     getRepository: jest.fn().mockResolvedValue(mockWorkspaceMemberRepository),
     executeInWorkspaceContext: jest
       .fn()
-      .mockImplementation((_authContext: any, fn: () => any) => fn()),
+      .mockImplementation((fn: () => any, _authContext?: any) => fn()),
   };
 
   beforeEach(async () => {

--- a/packages/twenty-server/src/engine/core-modules/actor/services/actor-from-auth-context.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/actor/services/actor-from-auth-context.service.ts
@@ -165,7 +165,6 @@ export class ActorFromAuthContextService {
 
     if (isDefined(user)) {
       return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        authContext as WorkspaceAuthContext,
         async () => {
           const workspaceMemberRepository =
             await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
@@ -187,6 +186,7 @@ export class ActorFromAuthContextService {
             workspaceMemberId: workspaceMember.id,
           });
         },
+        authContext as WorkspaceAuthContext,
       );
     }
 

--- a/packages/twenty-server/src/engine/core-modules/approved-access-domain/approved-access-domain.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/approved-access-domain/approved-access-domain.resolver.ts
@@ -47,7 +47,6 @@ export class ApprovedAccessDomainResolver {
 
     const workspaceMember =
       await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        authContext,
         async () => {
           const workspaceMemberRepository =
             await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
@@ -62,6 +61,7 @@ export class ApprovedAccessDomainResolver {
             },
           });
         },
+        authContext,
       );
 
     return this.approvedAccessDomainService.createApprovedAccessDomain(

--- a/packages/twenty-server/src/engine/core-modules/auth/middlewares/workspace-auth-context.middleware.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/middlewares/workspace-auth-context.middleware.ts
@@ -1,0 +1,33 @@
+import { Injectable, type NestMiddleware } from '@nestjs/common';
+
+import { type NextFunction, type Request, type Response } from 'express';
+import { isDefined } from 'twenty-shared/utils';
+
+import { type WorkspaceAuthContext } from 'src/engine/api/common/interfaces/workspace-auth-context.interface';
+
+import { withWorkspaceAuthContext } from 'src/engine/core-modules/auth/storage/workspace-auth-context.storage';
+
+@Injectable()
+export class WorkspaceAuthContextMiddleware implements NestMiddleware {
+  use(req: Request, _res: Response, next: NextFunction) {
+    if (!isDefined(req.workspace)) {
+      next();
+
+      return;
+    }
+
+    const authContext: WorkspaceAuthContext = {
+      user: req.user,
+      workspace: req.workspace,
+      workspaceMemberId: req.workspaceMemberId,
+      workspaceMember: req.workspaceMember,
+      userWorkspaceId: req.userWorkspaceId,
+      apiKey: req.apiKey,
+      application: req.application,
+    } as WorkspaceAuthContext;
+
+    withWorkspaceAuthContext(authContext, () => {
+      next();
+    });
+  }
+}

--- a/packages/twenty-server/src/engine/core-modules/auth/services/create-calendar-channel.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/create-calendar-channel.service.ts
@@ -42,7 +42,6 @@ export class CreateCalendarChannelService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const calendarChannelRepository =
           await this.globalWorkspaceOrmManager.getRepository<CalendarChannelWorkspaceEntity>(
@@ -70,6 +69,7 @@ export class CreateCalendarChannelService {
 
         return newCalendarChannel.id;
       },
+      authContext,
     );
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/auth/services/create-connected-account.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/create-connected-account.service.ts
@@ -42,29 +42,26 @@ export class CreateConnectedAccountService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const connectedAccountRepository =
-          await this.globalWorkspaceOrmManager.getRepository<ConnectedAccountWorkspaceEntity>(
-            workspaceId,
-            'connectedAccount',
-          );
-
-        await connectedAccountRepository.save(
-          {
-            id: connectedAccountId,
-            handle,
-            provider,
-            accessToken,
-            refreshToken,
-            accountOwnerId,
-            scopes,
-          },
-          {},
-          manager,
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const connectedAccountRepository =
+        await this.globalWorkspaceOrmManager.getRepository<ConnectedAccountWorkspaceEntity>(
+          workspaceId,
+          'connectedAccount',
         );
-      },
-    );
+
+      await connectedAccountRepository.save(
+        {
+          id: connectedAccountId,
+          handle,
+          provider,
+          accessToken,
+          refreshToken,
+          accountOwnerId,
+          scopes,
+        },
+        {},
+        manager,
+      );
+    }, authContext);
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/auth/services/create-message-channel.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/create-message-channel.service.ts
@@ -47,7 +47,6 @@ export class CreateMessageChannelService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const messageChannelRepository =
           await this.globalWorkspaceOrmManager.getRepository<MessageChannelWorkspaceEntity>(
@@ -93,6 +92,7 @@ export class CreateMessageChannelService {
 
         return newMessageChannelId;
       },
+      authContext,
     );
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/auth/services/google-apis.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/google-apis.service.spec.ts
@@ -98,7 +98,7 @@ describe('GoogleAPIsService', () => {
               .mockResolvedValue(mockWorkspaceDataSource),
             executeInWorkspaceContext: jest
               .fn()
-              .mockImplementation((_authContext: any, fn: () => any) => fn()),
+              .mockImplementation((fn: () => any, _authContext?: any) => fn()),
           },
         },
         {

--- a/packages/twenty-server/src/engine/core-modules/auth/services/google-apis.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/google-apis.service.ts
@@ -100,7 +100,6 @@ export class GoogleAPIsService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const connectedAccountRepository =
           await this.globalWorkspaceOrmManager.getRepository<ConnectedAccountWorkspaceEntity>(
@@ -258,6 +257,7 @@ export class GoogleAPIsService {
 
         return newOrExistingConnectedAccountId;
       },
+      authContext,
     );
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/auth/services/microsoft-apis.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/microsoft-apis.service.spec.ts
@@ -97,7 +97,7 @@ describe('MicrosoftAPIsService', () => {
               .mockResolvedValue(mockWorkspaceDataSource),
             executeInWorkspaceContext: jest
               .fn()
-              .mockImplementation((_authContext: any, fn: () => any) => fn()),
+              .mockImplementation((fn: () => any, _authContext?: any) => fn()),
           },
         },
         {

--- a/packages/twenty-server/src/engine/core-modules/auth/services/microsoft-apis.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/microsoft-apis.service.ts
@@ -81,7 +81,6 @@ export class MicrosoftAPIsService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const connectedAccountRepository =
           await this.globalWorkspaceOrmManager.getRepository<ConnectedAccountWorkspaceEntity>(
@@ -247,6 +246,7 @@ export class MicrosoftAPIsService {
 
         return newOrExistingConnectedAccountId;
       },
+      authContext,
     );
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/auth/services/update-connected-account-on-reconnect.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/update-connected-account-on-reconnect.service.ts
@@ -35,28 +35,25 @@ export class UpdateConnectedAccountOnReconnectService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const connectedAccountRepository =
-          await this.globalWorkspaceOrmManager.getRepository<ConnectedAccountWorkspaceEntity>(
-            workspaceId,
-            'connectedAccount',
-          );
-
-        await connectedAccountRepository.update(
-          {
-            id: connectedAccountId,
-          },
-          {
-            accessToken,
-            refreshToken,
-            scopes,
-            authFailedAt: null,
-          },
-          manager,
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const connectedAccountRepository =
+        await this.globalWorkspaceOrmManager.getRepository<ConnectedAccountWorkspaceEntity>(
+          workspaceId,
+          'connectedAccount',
         );
-      },
-    );
+
+      await connectedAccountRepository.update(
+        {
+          id: connectedAccountId,
+        },
+        {
+          accessToken,
+          refreshToken,
+          scopes,
+          authFailedAt: null,
+        },
+        manager,
+      );
+    }, authContext);
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/auth/storage/workspace-auth-context.storage.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/storage/workspace-auth-context.storage.ts
@@ -1,0 +1,25 @@
+import { AsyncLocalStorage } from 'async_hooks';
+
+import { type WorkspaceAuthContext } from 'src/engine/api/common/interfaces/workspace-auth-context.interface';
+
+export const workspaceAuthContextStorage =
+  new AsyncLocalStorage<WorkspaceAuthContext>();
+
+export const getWorkspaceAuthContext = (): WorkspaceAuthContext => {
+  const context = workspaceAuthContextStorage.getStore();
+
+  if (!context) {
+    throw new Error(
+      'Workspace auth context not set. Operations must be wrapped with withWorkspaceAuthContext()',
+    );
+  }
+
+  return context;
+};
+
+export const withWorkspaceAuthContext = <T>(
+  context: WorkspaceAuthContext,
+  fn: () => T | Promise<T>,
+): T | Promise<T> => {
+  return workspaceAuthContextStorage.run(context, fn);
+};

--- a/packages/twenty-server/src/engine/core-modules/auth/token/services/access-token.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/token/services/access-token.service.spec.ts
@@ -82,7 +82,7 @@ describe('AccessTokenService', () => {
             getRepository: jest.fn(),
             executeInWorkspaceContext: jest
               .fn()
-              .mockImplementation((_authContext: any, fn: () => any) => fn()),
+              .mockImplementation((fn: () => any, _authContext?: any) => fn()),
           },
         },
       ],

--- a/packages/twenty-server/src/engine/core-modules/auth/token/services/access-token.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/token/services/access-token.service.ts
@@ -84,7 +84,6 @@ export class AccessTokenService {
 
       tokenWorkspaceMemberId =
         await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-          authContext,
           async () => {
             const workspaceMemberRepository =
               await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
@@ -112,6 +111,7 @@ export class AccessTokenService {
 
             return workspaceMember.id;
           },
+          authContext,
         );
     }
     const userWorkspace = await this.userWorkspaceRepository.findOne({

--- a/packages/twenty-server/src/engine/core-modules/billing/jobs/update-subscription-quantity.job.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/jobs/update-subscription-quantity.job.ts
@@ -29,36 +29,33 @@ export class UpdateSubscriptionQuantityJob {
   async handle(data: UpdateSubscriptionQuantityJobData): Promise<void> {
     const authContext = buildSystemAuthContext(data.workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const workspaceMemberRepository =
-          await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-            data.workspaceId,
-            'workspaceMember',
-          );
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const workspaceMemberRepository =
+        await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+          data.workspaceId,
+          'workspaceMember',
+        );
 
-        const workspaceMembersCount = await workspaceMemberRepository.count();
+      const workspaceMembersCount = await workspaceMemberRepository.count();
 
-        if (!workspaceMembersCount || workspaceMembersCount <= 0) {
-          return;
-        }
+      if (!workspaceMembersCount || workspaceMembersCount <= 0) {
+        return;
+      }
 
-        try {
-          await this.billingSubscriptionUpdateService.changeSeats(
-            data.workspaceId,
-            workspaceMembersCount,
-          );
+      try {
+        await this.billingSubscriptionUpdateService.changeSeats(
+          data.workspaceId,
+          workspaceMembersCount,
+        );
 
-          this.logger.log(
-            `Updating workspace ${data.workspaceId} subscription quantity to ${workspaceMembersCount} members`,
-          );
-        } catch (e) {
-          this.logger.warn(
-            `Failed to update workspace ${data.workspaceId} subscription quantity to ${workspaceMembersCount} members. Error: ${e}`,
-          );
-        }
-      },
-    );
+        this.logger.log(
+          `Updating workspace ${data.workspaceId} subscription quantity to ${workspaceMembersCount} members`,
+        );
+      } catch (e) {
+        this.logger.warn(
+          `Failed to update workspace ${data.workspaceId} subscription quantity to ${workspaceMembersCount} members. Error: ${e}`,
+        );
+      }
+    }, authContext);
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/calendar/timeline-calendar-event.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/calendar/timeline-calendar-event.service.spec.ts
@@ -40,7 +40,7 @@ describe('TimelineCalendarEventService', () => {
       getRepository: jest.fn().mockResolvedValue(mockCalendarEventRepository),
       executeInWorkspaceContext: jest
         .fn()
-        .mockImplementation((_authContext: any, fn: () => any) => fn()),
+        .mockImplementation((fn: () => any, _authContext?: any) => fn()),
     };
 
     const module: TestingModule = await Test.createTestingModule({

--- a/packages/twenty-server/src/engine/core-modules/calendar/timeline-calendar-event.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/calendar/timeline-calendar-event.service.ts
@@ -35,7 +35,6 @@ export class TimelineCalendarEventService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const offset = (page - 1) * pageSize;
 
@@ -166,6 +165,7 @@ export class TimelineCalendarEventService {
           timelineCalendarEvents,
         };
       },
+      authContext,
     );
   }
 
@@ -185,7 +185,6 @@ export class TimelineCalendarEventService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const personRepository =
           await this.globalWorkspaceOrmManager.getRepository<PersonWorkspaceEntity>(
@@ -222,6 +221,7 @@ export class TimelineCalendarEventService {
 
         return calendarEvents;
       },
+      authContext,
     );
   }
 
@@ -241,7 +241,6 @@ export class TimelineCalendarEventService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const opportunityRepository =
           await this.globalWorkspaceOrmManager.getRepository<OpportunityWorkspaceEntity>(
@@ -276,6 +275,7 @@ export class TimelineCalendarEventService {
 
         return calendarEvents;
       },
+      authContext,
     );
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/imap-smtp-caldav-connection/services/imap-smtp-caldav-connection.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/imap-smtp-caldav-connection/services/imap-smtp-caldav-connection.service.ts
@@ -187,7 +187,6 @@ export class ImapSmtpCaldavService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const connectedAccountRepository =
           await this.globalWorkspaceOrmManager.getRepository<ConnectedAccountWorkspaceEntity>(
@@ -204,6 +203,7 @@ export class ImapSmtpCaldavService {
 
         return connectedAccount;
       },
+      authContext,
     );
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/messaging/services/get-messages.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/messaging/services/get-messages.service.ts
@@ -77,7 +77,6 @@ export class GetMessagesService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const personRepository =
           await this.globalWorkspaceOrmManager.getRepository<PersonWorkspaceEntity>(
@@ -113,6 +112,7 @@ export class GetMessagesService {
 
         return messageThreads;
       },
+      authContext,
     );
   }
 
@@ -126,7 +126,6 @@ export class GetMessagesService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const opportunityRepository =
           await this.globalWorkspaceOrmManager.getRepository<OpportunityWorkspaceEntity>(
@@ -161,6 +160,7 @@ export class GetMessagesService {
 
         return messageThreads;
       },
+      authContext,
     );
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/messaging/services/timeline-messaging.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/messaging/services/timeline-messaging.service.ts
@@ -35,7 +35,6 @@ export class TimelineMessagingService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const messageThreadRepository =
           await this.globalWorkspaceOrmManager.getRepository<MessageThreadWorkspaceEntity>(
@@ -99,6 +98,7 @@ export class TimelineMessagingService {
           totalNumberOfThreads,
         };
       },
+      authContext,
     );
   }
 
@@ -111,7 +111,6 @@ export class TimelineMessagingService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const messageParticipantRepository =
           await this.globalWorkspaceOrmManager.getRepository<MessageParticipantWorkspaceEntity>(
@@ -198,6 +197,7 @@ export class TimelineMessagingService {
           {},
         );
       },
+      authContext,
     );
   }
 
@@ -211,7 +211,6 @@ export class TimelineMessagingService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const messageThreadRepository =
           await this.globalWorkspaceOrmManager.getRepository<MessageThreadWorkspaceEntity>(
@@ -267,6 +266,7 @@ export class TimelineMessagingService {
 
         return threadVisibilityByThreadId;
       },
+      authContext,
     );
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/record-position/services/__tests__/record-position.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-position/services/__tests__/record-position.service.spec.ts
@@ -20,7 +20,7 @@ describe('RecordPositionService', () => {
       getRepository: jest.fn().mockResolvedValue(mockRepository),
       executeInWorkspaceContext: jest
         .fn()
-        .mockImplementation((_authContext: any, fn: () => any) => fn()),
+        .mockImplementation((fn: () => any, _authContext?: any) => fn()),
     } as unknown as jest.Mocked<GlobalWorkspaceOrmManager>;
 
     const module: TestingModule = await Test.createTestingModule({

--- a/packages/twenty-server/src/engine/core-modules/record-position/services/record-position.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-position/services/record-position.service.ts
@@ -163,7 +163,6 @@ export class RecordPositionService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const repository = await this.globalWorkspaceOrmManager.getRepository(
           workspaceId,
@@ -179,6 +178,7 @@ export class RecordPositionService {
 
         return record ? { id: record.id, position: record.position } : null;
       },
+      authContext,
     );
   }
 
@@ -190,22 +190,19 @@ export class RecordPositionService {
   ): Promise<void> {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const repository = await this.globalWorkspaceOrmManager.getRepository(
-          workspaceId,
-          objectMetadata.nameSingular,
-          {
-            shouldBypassPermissionChecks: true,
-          },
-        );
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const repository = await this.globalWorkspaceOrmManager.getRepository(
+        workspaceId,
+        objectMetadata.nameSingular,
+        {
+          shouldBypassPermissionChecks: true,
+        },
+      );
 
-        await repository.update(recordId, {
-          position: positionValue,
-        });
-      },
-    );
+      await repository.update(recordId, {
+        position: positionValue,
+      });
+    }, authContext);
   }
 
   private async findMinPosition(
@@ -216,7 +213,6 @@ export class RecordPositionService {
 
     const result =
       await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        authContext,
         async () => {
           const repository = await this.globalWorkspaceOrmManager.getRepository(
             workspaceId,
@@ -228,6 +224,7 @@ export class RecordPositionService {
 
           return await repository.minimum('position');
         },
+        authContext,
       );
 
     return sanitizeNumber(result);
@@ -241,7 +238,6 @@ export class RecordPositionService {
 
     const result =
       await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        authContext,
         async () => {
           const repository = await this.globalWorkspaceOrmManager.getRepository(
             workspaceId,
@@ -253,6 +249,7 @@ export class RecordPositionService {
 
           return await repository.maximum('position');
         },
+        authContext,
       );
 
     return sanitizeNumber(result);

--- a/packages/twenty-server/src/engine/core-modules/search/services/search.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/search/services/search.service.ts
@@ -33,7 +33,6 @@ import { SEARCH_VECTOR_FIELD } from 'src/engine/metadata-modules/search-field-me
 import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
 import { type WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace.repository';
 import { type RolePermissionConfig } from 'src/engine/twenty-orm/types/role-permission-config';
-import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 
 type LastRanks = { tsRankCD: number; tsRank: number };
 
@@ -82,13 +81,10 @@ export class SearchService {
       OBJECT_METADATA_ITEMS_CHUNK_SIZE,
     );
 
-    const authContext = buildSystemAuthContext(workspaceId);
-
     for (const objectMetadataItemChunk of filteredObjectMetadataItemsChunks) {
       const recordsWithObjectMetadataItems = await Promise.all(
         objectMetadataItemChunk.map(async (flatObjectMetadata) => {
           return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-            authContext,
             async () => {
               const repository =
                 await this.globalWorkspaceOrmManager.getRepository<ObjectRecord>(

--- a/packages/twenty-server/src/engine/core-modules/tool/tools/send-email-tool/send-email-tool.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool/tools/send-email-tool/send-email-tool.ts
@@ -65,7 +65,6 @@ export class SendEmailTool implements Tool {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const connectedAccountRepository =
           await this.globalWorkspaceOrmManager.getRepository<ConnectedAccountWorkspaceEntity>(
@@ -91,6 +90,7 @@ export class SendEmailTool implements Tool {
 
         return connectedAccount;
       },
+      authContext,
     );
   }
 
@@ -100,7 +100,6 @@ export class SendEmailTool implements Tool {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const connectedAccountRepository =
           await this.globalWorkspaceOrmManager.getRepository<ConnectedAccountWorkspaceEntity>(
@@ -118,6 +117,7 @@ export class SendEmailTool implements Tool {
 
         return allAccounts[0].id;
       },
+      authContext,
     );
   }
 

--- a/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.spec.ts
@@ -106,7 +106,9 @@ describe('UserWorkspaceService', () => {
           useValue: {
             executeInWorkspaceContext: jest
               .fn()
-              .mockImplementation(async (_authContext, callback) => callback()),
+              .mockImplementation(
+                async (callback: () => any, _authContext?: any) => callback(),
+              ),
             getRepository: jest.fn(),
           },
         },

--- a/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.ts
@@ -95,47 +95,44 @@ export class UserWorkspaceService extends TypeOrmQueryService<UserWorkspaceEntit
   async createWorkspaceMember(workspaceId: string, user: UserEntity) {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const workspaceMemberRepository =
-          await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-            workspaceId,
-            'workspaceMember',
-            { shouldBypassPermissionChecks: true },
-          );
-
-        const userWorkspace = await this.userWorkspaceRepository.findOneOrFail({
-          where: {
-            userId: user.id,
-            workspaceId,
-          },
-        });
-
-        await workspaceMemberRepository.insert({
-          name: {
-            firstName: user.firstName,
-            lastName: user.lastName,
-          },
-          colorScheme: 'System',
-          userId: user.id,
-          userEmail: user.email,
-          avatarUrl: userWorkspace.defaultAvatarUrl ?? '',
-          locale: (user.locale ?? SOURCE_LOCALE) as keyof typeof APP_LOCALES,
-        });
-
-        const workspaceMember = await workspaceMemberRepository.find({
-          where: {
-            userId: user.id,
-          },
-        });
-
-        assert(
-          workspaceMember?.length === 1,
-          `Error while creating workspace member ${user.email} on workspace ${workspaceId}`,
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const workspaceMemberRepository =
+        await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+          workspaceId,
+          'workspaceMember',
+          { shouldBypassPermissionChecks: true },
         );
-      },
-    );
+
+      const userWorkspace = await this.userWorkspaceRepository.findOneOrFail({
+        where: {
+          userId: user.id,
+          workspaceId,
+        },
+      });
+
+      await workspaceMemberRepository.insert({
+        name: {
+          firstName: user.firstName,
+          lastName: user.lastName,
+        },
+        colorScheme: 'System',
+        userId: user.id,
+        userEmail: user.email,
+        avatarUrl: userWorkspace.defaultAvatarUrl ?? '',
+        locale: (user.locale ?? SOURCE_LOCALE) as keyof typeof APP_LOCALES,
+      });
+
+      const workspaceMember = await workspaceMemberRepository.find({
+        where: {
+          userId: user.id,
+        },
+      });
+
+      assert(
+        workspaceMember?.length === 1,
+        `Error while creating workspace member ${user.email} on workspace ${workspaceId}`,
+      );
+    }, authContext);
   }
 
   async addUserToWorkspaceIfUserNotInWorkspace(
@@ -356,7 +353,6 @@ export class UserWorkspaceService extends TypeOrmQueryService<UserWorkspaceEntit
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const workspaceMemberRepository =
           await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
@@ -377,6 +373,7 @@ export class UserWorkspaceService extends TypeOrmQueryService<UserWorkspaceEntit
 
         return workspaceMember;
       },
+      authContext,
     );
   }
 

--- a/packages/twenty-server/src/engine/core-modules/user/jobs/update-workspace-member-email.job.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/jobs/update-workspace-member-email.job.ts
@@ -35,21 +35,15 @@ export class UpdateWorkspaceMemberEmailJob {
 
     const authContext = buildSystemAuthContext(workspace.id);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const workspaceMemberRepository =
-          await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-            workspace.id,
-            'workspaceMember',
-            { shouldBypassPermissionChecks: true },
-          );
-
-        await workspaceMemberRepository.update(
-          { userId },
-          { userEmail: email },
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const workspaceMemberRepository =
+        await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+          workspace.id,
+          'workspaceMember',
+          { shouldBypassPermissionChecks: true },
         );
-      },
-    );
+
+      await workspaceMemberRepository.update({ userId }, { userEmail: email });
+    }, authContext);
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/user/services/user.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/services/user.service.spec.ts
@@ -76,7 +76,7 @@ describe('UserService', () => {
             executeInWorkspaceContext: jest
               .fn()
 
-              .mockImplementation((_authContext: any, fn: () => any) => fn()),
+              .mockImplementation((fn: () => any, _authContext?: any) => fn()),
           },
         },
         {

--- a/packages/twenty-server/src/engine/core-modules/user/services/user.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/services/user.service.ts
@@ -66,7 +66,6 @@ export class UserService extends TypeOrmQueryService<UserEntity> {
     const authContext = buildSystemAuthContext(workspace.id);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const workspaceMemberRepository =
           await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
@@ -81,6 +80,7 @@ export class UserService extends TypeOrmQueryService<UserEntity> {
           },
         });
       },
+      authContext,
     );
   }
 
@@ -92,7 +92,6 @@ export class UserService extends TypeOrmQueryService<UserEntity> {
     const authContext = buildSystemAuthContext(workspace.id);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const workspaceMemberRepository =
           await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
@@ -105,6 +104,7 @@ export class UserService extends TypeOrmQueryService<UserEntity> {
           withDeleted: withDeleted,
         });
       },
+      authContext,
     );
   }
 
@@ -116,7 +116,6 @@ export class UserService extends TypeOrmQueryService<UserEntity> {
     const authContext = buildSystemAuthContext(workspace.id);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const workspaceMemberRepository =
           await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
@@ -130,6 +129,7 @@ export class UserService extends TypeOrmQueryService<UserEntity> {
           withDeleted: true,
         });
       },
+      authContext,
     );
   }
 
@@ -202,7 +202,6 @@ export class UserService extends TypeOrmQueryService<UserEntity> {
 
     const workspaceMembers =
       await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        authContext,
         async () => {
           const workspaceMemberRepository =
             await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
@@ -213,6 +212,7 @@ export class UserService extends TypeOrmQueryService<UserEntity> {
 
           return workspaceMemberRepository.find();
         },
+        authContext,
       );
 
     const userWorkspaceId = userWorkspace.id;
@@ -255,21 +255,18 @@ export class UserService extends TypeOrmQueryService<UserEntity> {
 
     assert(workspaceMember, 'WorkspaceMember not found');
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const workspaceMemberRepository =
-          await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
-            workspaceId,
-            'workspaceMember',
-            { shouldBypassPermissionChecks: true },
-          );
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const workspaceMemberRepository =
+        await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+          workspaceId,
+          'workspaceMember',
+          { shouldBypassPermissionChecks: true },
+        );
 
-        await workspaceMemberRepository.delete({
-          userId: userWorkspace.userId,
-        });
-      },
-    );
+      await workspaceMemberRepository.delete({
+        userId: userWorkspace.userId,
+      });
+    }, authContext);
 
     await this.userWorkspaceService.deleteUserWorkspace({
       userWorkspaceId,

--- a/packages/twenty-server/src/engine/core-modules/user/services/workspace-flat-workspace-member-map-cache.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/services/workspace-flat-workspace-member-map-cache.service.ts
@@ -20,7 +20,6 @@ export class WorkspaceFlatWorkspaceMemberMapCacheService extends WorkspaceCacheP
   async computeForCache(workspaceId: string): Promise<FlatWorkspaceMemberMaps> {
     const flatWorkspaceMemberMaps =
       await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        buildSystemAuthContext(workspaceId),
         async () => {
           const workspaceMemberRepository =
             await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
@@ -45,6 +44,7 @@ export class WorkspaceFlatWorkspaceMemberMapCacheService extends WorkspaceCacheP
 
           return flatWorkspaceMemberMaps;
         },
+        buildSystemAuthContext(workspaceId),
       );
 
     return flatWorkspaceMemberMaps;

--- a/packages/twenty-server/src/engine/core-modules/user/user.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/user.resolver.ts
@@ -391,7 +391,6 @@ export class UserResolver {
 
     const workspaceMemberToDelete =
       await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        authContext,
         async () => {
           const workspaceMemberRepository =
             await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
@@ -406,6 +405,7 @@ export class UserResolver {
             },
           });
         },
+        authContext,
       );
 
     if (!isDefined(workspaceMemberToDelete)) {

--- a/packages/twenty-server/src/engine/core-modules/workflow/controllers/workflow-trigger.controller.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/controllers/workflow-trigger.controller.ts
@@ -93,7 +93,6 @@ export class WorkflowTriggerController {
 
     const { workflow } =
       await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        authContext,
         async () => {
           const workflowRepository =
             await this.globalWorkspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
@@ -156,6 +155,7 @@ export class WorkflowTriggerController {
 
           return { workflow, workflowVersion };
         },
+        authContext,
       );
 
     const { workflowRunId } =

--- a/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-trigger.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-trigger.resolver.ts
@@ -77,7 +77,6 @@ export class WorkflowTriggerResolver {
 
     const workspaceMember =
       await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        authContext,
         async () => {
           const workspaceMemberRepository =
             await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
@@ -92,6 +91,7 @@ export class WorkflowTriggerResolver {
             },
           });
         },
+        authContext,
       );
 
     return this.workflowTriggerWorkspaceService.runWorkflowVersion({

--- a/packages/twenty-server/src/engine/core-modules/workspace-invitation/workspace-invitation.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace-invitation/workspace-invitation.resolver.ts
@@ -60,7 +60,6 @@ export class WorkspaceInvitationResolver {
 
     const workspaceMember =
       await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        authContext,
         async () => {
           const workspaceMemberRepository =
             await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
@@ -75,6 +74,7 @@ export class WorkspaceInvitationResolver {
             },
           });
         },
+        authContext,
       );
 
     return this.workspaceInvitationService.resendWorkspaceInvitation(
@@ -100,7 +100,6 @@ export class WorkspaceInvitationResolver {
 
     const workspaceMember =
       await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        authContext,
         async () => {
           const workspaceMemberRepository =
             await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
@@ -115,6 +114,7 @@ export class WorkspaceInvitationResolver {
             },
           });
         },
+        authContext,
       );
 
     return await this.workspaceInvitationService.sendInvitations(

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/agent-actor-context.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-agent-execution/services/agent-actor-context.service.ts
@@ -46,7 +46,6 @@ export class AgentActorContextService {
 
     const workspaceMember =
       await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        authContext,
         async () => {
           const workspaceMemberRepository =
             await this.globalWorkspaceOrmManager.getRepository(
@@ -61,6 +60,7 @@ export class AgentActorContextService {
             },
           });
         },
+        authContext,
       );
 
     if (!workspaceMember) {

--- a/packages/twenty-server/src/engine/metadata-modules/navigation-menu-item/navigation-menu-item.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/navigation-menu-item/navigation-menu-item.service.ts
@@ -427,7 +427,6 @@ export class NavigationMenuItemService {
 
       const record =
         await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-          authContext,
           async () => {
             const repository =
               await this.globalWorkspaceOrmManager.getRepository(
@@ -462,6 +461,7 @@ export class NavigationMenuItemService {
 
             return formattedRecord;
           },
+          authContext,
         );
 
       if (!isDefined(record)) {

--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.service.ts
@@ -526,23 +526,20 @@ export class ObjectMetadataService extends TypeOrmQueryService<ObjectMetadataEnt
   }) {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const favoriteRepository =
-          await this.globalWorkspaceOrmManager.getRepository<FavoriteWorkspaceEntity>(
-            workspaceId,
-            'favorite',
-          );
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const favoriteRepository =
+        await this.globalWorkspaceOrmManager.getRepository<FavoriteWorkspaceEntity>(
+          workspaceId,
+          'favorite',
+        );
 
-        const favoriteCount = await favoriteRepository.count();
+      const favoriteCount = await favoriteRepository.count();
 
-        await favoriteRepository.insert({
-          viewId: view.id,
-          position: favoriteCount,
-        });
-      },
-    );
+      await favoriteRepository.insert({
+        viewId: view.id,
+        position: favoriteCount,
+      });
+    }, authContext);
   }
 
   public async deleteWorkspaceAllObjectMetadata({

--- a/packages/twenty-server/src/engine/metadata-modules/page-layout/services/page-layout.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/page-layout/services/page-layout.service.ts
@@ -410,26 +410,23 @@ export class PageLayoutService {
   }): Promise<void> {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const dashboardRepository =
-          await this.globalWorkspaceOrmManager.getRepository(
-            workspaceId,
-            'dashboard',
-            { shouldBypassPermissionChecks: true },
-          );
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const dashboardRepository =
+        await this.globalWorkspaceOrmManager.getRepository(
+          workspaceId,
+          'dashboard',
+          { shouldBypassPermissionChecks: true },
+        );
 
-        const dashboards = await dashboardRepository.find({
-          where: {
-            pageLayoutId,
-          },
-        });
+      const dashboards = await dashboardRepository.find({
+        where: {
+          pageLayoutId,
+        },
+      });
 
-        for (const dashboard of dashboards) {
-          await dashboardRepository.delete(dashboard.id);
-        }
-      },
-    );
+      for (const dashboard of dashboards) {
+        await dashboardRepository.delete(dashboard.id);
+      }
+    }, authContext);
   }
 }

--- a/packages/twenty-server/src/engine/metadata-modules/user-role/user-role.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/user-role/user-role.service.ts
@@ -154,7 +154,6 @@ export class UserRoleService {
       );
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const workspaceMemberRepository =
           await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
@@ -171,6 +170,7 @@ export class UserRoleService {
 
         return workspaceMembers;
       },
+      authContext,
     );
   }
 

--- a/packages/twenty-server/src/engine/trash-cleanup/services/__tests__/trash-cleanup.service.spec.ts
+++ b/packages/twenty-server/src/engine/trash-cleanup/services/__tests__/trash-cleanup.service.spec.ts
@@ -18,7 +18,7 @@ describe('TrashCleanupService', () => {
       getRepository: jest.fn(),
       executeInWorkspaceContext: jest
         .fn()
-        .mockImplementation((_authContext: any, fn: () => any) => fn()),
+        .mockImplementation((fn: () => any, _authContext?: any) => fn()),
     };
 
     const module: TestingModule = await Test.createTestingModule({

--- a/packages/twenty-server/src/engine/trash-cleanup/services/trash-cleanup.service.ts
+++ b/packages/twenty-server/src/engine/trash-cleanup/services/trash-cleanup.service.ts
@@ -100,7 +100,6 @@ export class TrashCleanupService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const repository = await this.globalWorkspaceOrmManager.getRepository(
           workspaceId,
@@ -137,6 +136,7 @@ export class TrashCleanupService {
 
         return deleted;
       },
+      authContext,
     );
   }
 

--- a/packages/twenty-server/src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager.ts
@@ -4,6 +4,7 @@ import { type ObjectLiteral } from 'typeorm';
 
 import { type WorkspaceAuthContext } from 'src/engine/api/common/interfaces/workspace-auth-context.interface';
 
+import { getWorkspaceAuthContext } from 'src/engine/core-modules/auth/storage/workspace-auth-context.storage';
 import { buildObjectIdByNameMaps } from 'src/engine/metadata-modules/flat-object-metadata/utils/build-object-id-by-name-maps.util';
 import { GlobalWorkspaceDataSource } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-datasource';
 import { GlobalWorkspaceDataSourceService } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-datasource.service';
@@ -67,10 +68,11 @@ export class GlobalWorkspaceOrmManager {
   }
 
   async executeInWorkspaceContext<T>(
-    authContext: WorkspaceAuthContext,
     fn: () => T | Promise<T>,
+    authContext?: WorkspaceAuthContext,
   ): Promise<T> {
-    const context = await this.loadWorkspaceContext(authContext);
+    const resolvedAuthContext = authContext ?? getWorkspaceAuthContext();
+    const context = await this.loadWorkspaceContext(resolvedAuthContext);
 
     return withWorkspaceContext(context, fn);
   }

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/services/twenty-standard-application.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/services/twenty-standard-application.service.ts
@@ -41,24 +41,21 @@ export class TwentyStandardApplicationService {
   }) {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const favoriteRepository =
-          await this.globalWorkspaceOrmManager.getRepository<FavoriteWorkspaceEntity>(
-            workspaceId,
-            'favorite',
-          );
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const favoriteRepository =
+        await this.globalWorkspaceOrmManager.getRepository<FavoriteWorkspaceEntity>(
+          workspaceId,
+          'favorite',
+        );
 
-        const favoriteCount = await favoriteRepository.count();
-        const favoriteToCreate = flatViews.map((flatView, index) => ({
-          viewId: flatView.id,
-          position: favoriteCount + index,
-        }));
+      const favoriteCount = await favoriteRepository.count();
+      const favoriteToCreate = flatViews.map((flatView, index) => ({
+        viewId: flatView.id,
+        position: favoriteCount + index,
+      }));
 
-        await favoriteRepository.insert(favoriteToCreate);
-      },
-    );
+      await favoriteRepository.insert(favoriteToCreate);
+    }, authContext);
   }
 
   private async createManyNavigationMenuItem({

--- a/packages/twenty-server/src/modules/blocklist/blocklist-validation-manager/services/blocklist-validation.service.ts
+++ b/packages/twenty-server/src/modules/blocklist/blocklist-validation-manager/services/blocklist-validation.service.ts
@@ -88,7 +88,6 @@ export class BlocklistValidationService {
 
     const currentWorkspaceMember =
       await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        authContext,
         async () => {
           const workspaceMemberRepository =
             await this.globalWorkspaceOrmManager.getRepository(
@@ -100,6 +99,7 @@ export class BlocklistValidationService {
             userId,
           });
         },
+        authContext,
       );
 
     const currentBlocklist =
@@ -145,7 +145,6 @@ export class BlocklistValidationService {
 
     const currentWorkspaceMember =
       await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        authContext,
         async () => {
           const workspaceMemberRepository =
             await this.globalWorkspaceOrmManager.getRepository(
@@ -157,6 +156,7 @@ export class BlocklistValidationService {
             userId,
           });
         },
+        authContext,
       );
 
     const currentBlocklist =

--- a/packages/twenty-server/src/modules/blocklist/repositories/blocklist.repository.ts
+++ b/packages/twenty-server/src/modules/blocklist/repositories/blocklist.repository.ts
@@ -17,7 +17,6 @@ export class BlocklistRepository {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const blockListRepository =
           await this.globalWorkspaceOrmManager.getRepository(
@@ -32,6 +31,7 @@ export class BlocklistRepository {
           id,
         });
       },
+      authContext,
     );
   }
 
@@ -42,7 +42,6 @@ export class BlocklistRepository {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const blockListRepository =
           await this.globalWorkspaceOrmManager.getRepository(
@@ -56,6 +55,7 @@ export class BlocklistRepository {
           },
         });
       },
+      authContext,
     );
   }
 }

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/jobs/calendar-events-import.job.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/jobs/calendar-events-import.job.ts
@@ -35,54 +35,51 @@ export class CalendarEventsImportJob {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const calendarChannelRepository =
-          await this.globalWorkspaceOrmManager.getRepository<CalendarChannelWorkspaceEntity>(
-            workspaceId,
-            'calendarChannel',
-          );
-        const calendarChannel = await calendarChannelRepository.findOne({
-          where: {
-            id: calendarChannelId,
-            isSyncEnabled: true,
-          },
-          relations: ['connectedAccount'],
-        });
-
-        if (!calendarChannel?.isSyncEnabled) {
-          return;
-        }
-
-        if (
-          calendarChannel.syncStage !==
-          CalendarChannelSyncStage.CALENDAR_EVENTS_IMPORT_SCHEDULED
-        ) {
-          return;
-        }
-
-        if (
-          isThrottled(
-            calendarChannel.syncStageStartedAt,
-            calendarChannel.throttleFailureCount,
-          )
-        ) {
-          await this.calendarChannelSyncStatusService.markAsCalendarEventsImportPending(
-            [calendarChannel.id],
-            workspaceId,
-            true,
-          );
-
-          return;
-        }
-
-        await this.calendarEventsImportService.processCalendarEventsImport(
-          calendarChannel,
-          calendarChannel.connectedAccount,
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const calendarChannelRepository =
+        await this.globalWorkspaceOrmManager.getRepository<CalendarChannelWorkspaceEntity>(
           workspaceId,
+          'calendarChannel',
         );
-      },
-    );
+      const calendarChannel = await calendarChannelRepository.findOne({
+        where: {
+          id: calendarChannelId,
+          isSyncEnabled: true,
+        },
+        relations: ['connectedAccount'],
+      });
+
+      if (!calendarChannel?.isSyncEnabled) {
+        return;
+      }
+
+      if (
+        calendarChannel.syncStage !==
+        CalendarChannelSyncStage.CALENDAR_EVENTS_IMPORT_SCHEDULED
+      ) {
+        return;
+      }
+
+      if (
+        isThrottled(
+          calendarChannel.syncStageStartedAt,
+          calendarChannel.throttleFailureCount,
+        )
+      ) {
+        await this.calendarChannelSyncStatusService.markAsCalendarEventsImportPending(
+          [calendarChannel.id],
+          workspaceId,
+          true,
+        );
+
+        return;
+      }
+
+      await this.calendarEventsImportService.processCalendarEventsImport(
+        calendarChannel,
+        calendarChannel.connectedAccount,
+        workspaceId,
+      );
+    }, authContext);
   }
 }

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/jobs/calendar-ongoing-stale.job.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/jobs/calendar-ongoing-stale.job.ts
@@ -35,63 +35,60 @@ export class CalendarOngoingStaleJob {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const calendarChannelRepository =
-          await this.globalWorkspaceOrmManager.getRepository<CalendarChannelWorkspaceEntity>(
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const calendarChannelRepository =
+        await this.globalWorkspaceOrmManager.getRepository<CalendarChannelWorkspaceEntity>(
+          workspaceId,
+          'calendarChannel',
+        );
+
+      const calendarChannels = await calendarChannelRepository.find({
+        where: {
+          syncStage: In([
+            CalendarChannelSyncStage.CALENDAR_EVENTS_IMPORT_ONGOING,
+            CalendarChannelSyncStage.CALENDAR_EVENT_LIST_FETCH_ONGOING,
+            CalendarChannelSyncStage.CALENDAR_EVENTS_IMPORT_SCHEDULED,
+            CalendarChannelSyncStage.CALENDAR_EVENT_LIST_FETCH_SCHEDULED,
+          ]),
+        },
+      });
+
+      for (const calendarChannel of calendarChannels) {
+        if (
+          calendarChannel.syncStageStartedAt &&
+          isSyncStale(calendarChannel.syncStageStartedAt)
+        ) {
+          await this.calendarChannelSyncStatusService.resetSyncStageStartedAt(
+            [calendarChannel.id],
             workspaceId,
-            'calendarChannel',
           );
 
-        const calendarChannels = await calendarChannelRepository.find({
-          where: {
-            syncStage: In([
-              CalendarChannelSyncStage.CALENDAR_EVENTS_IMPORT_ONGOING,
-              CalendarChannelSyncStage.CALENDAR_EVENT_LIST_FETCH_ONGOING,
-              CalendarChannelSyncStage.CALENDAR_EVENTS_IMPORT_SCHEDULED,
-              CalendarChannelSyncStage.CALENDAR_EVENT_LIST_FETCH_SCHEDULED,
-            ]),
-          },
-        });
-
-        for (const calendarChannel of calendarChannels) {
-          if (
-            calendarChannel.syncStageStartedAt &&
-            isSyncStale(calendarChannel.syncStageStartedAt)
-          ) {
-            await this.calendarChannelSyncStatusService.resetSyncStageStartedAt(
-              [calendarChannel.id],
-              workspaceId,
-            );
-
-            switch (calendarChannel.syncStage) {
-              case CalendarChannelSyncStage.CALENDAR_EVENT_LIST_FETCH_ONGOING:
-              case CalendarChannelSyncStage.CALENDAR_EVENT_LIST_FETCH_SCHEDULED:
-                this.logger.log(
-                  `Sync for calendar channel ${calendarChannel.id} and workspace ${workspaceId} is stale. Setting sync stage to CALENDAR_EVENT_LIST_FETCH_PENDING`,
-                );
-                await this.calendarChannelSyncStatusService.markAsCalendarEventListFetchPending(
-                  [calendarChannel.id],
-                  workspaceId,
-                );
-                break;
-              case CalendarChannelSyncStage.CALENDAR_EVENTS_IMPORT_ONGOING:
-              case CalendarChannelSyncStage.CALENDAR_EVENTS_IMPORT_SCHEDULED:
-                this.logger.log(
-                  `Sync for calendar channel ${calendarChannel.id} and workspace ${workspaceId} is stale. Setting sync stage to CALENDAR_EVENTS_IMPORT_PENDING`,
-                );
-                await this.calendarChannelSyncStatusService.markAsCalendarEventsImportPending(
-                  [calendarChannel.id],
-                  workspaceId,
-                );
-                break;
-              default:
-                break;
-            }
+          switch (calendarChannel.syncStage) {
+            case CalendarChannelSyncStage.CALENDAR_EVENT_LIST_FETCH_ONGOING:
+            case CalendarChannelSyncStage.CALENDAR_EVENT_LIST_FETCH_SCHEDULED:
+              this.logger.log(
+                `Sync for calendar channel ${calendarChannel.id} and workspace ${workspaceId} is stale. Setting sync stage to CALENDAR_EVENT_LIST_FETCH_PENDING`,
+              );
+              await this.calendarChannelSyncStatusService.markAsCalendarEventListFetchPending(
+                [calendarChannel.id],
+                workspaceId,
+              );
+              break;
+            case CalendarChannelSyncStage.CALENDAR_EVENTS_IMPORT_ONGOING:
+            case CalendarChannelSyncStage.CALENDAR_EVENTS_IMPORT_SCHEDULED:
+              this.logger.log(
+                `Sync for calendar channel ${calendarChannel.id} and workspace ${workspaceId} is stale. Setting sync stage to CALENDAR_EVENTS_IMPORT_PENDING`,
+              );
+              await this.calendarChannelSyncStatusService.markAsCalendarEventsImportPending(
+                [calendarChannel.id],
+                workspaceId,
+              );
+              break;
+            default:
+              break;
           }
         }
-      },
-    );
+      }
+    }, authContext);
   }
 }

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-event-import-exception-handler.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-event-import-exception-handler.service.ts
@@ -133,26 +133,23 @@ export class CalendarEventImportErrorHandlerService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const calendarChannelRepository =
-          await this.globalWorkspaceOrmManager.getRepository<CalendarChannelWorkspaceEntity>(
-            workspaceId,
-            'calendarChannel',
-          );
-
-        await calendarChannelRepository.increment(
-          {
-            id: calendarChannel.id,
-          },
-          'throttleFailureCount',
-          1,
-          undefined,
-          ['throttleFailureCount', 'id'],
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const calendarChannelRepository =
+        await this.globalWorkspaceOrmManager.getRepository<CalendarChannelWorkspaceEntity>(
+          workspaceId,
+          'calendarChannel',
         );
-      },
-    );
+
+      await calendarChannelRepository.increment(
+        {
+          id: calendarChannel.id,
+        },
+        'throttleFailureCount',
+        1,
+        undefined,
+        ['throttleFailureCount', 'id'],
+      );
+    }, authContext);
 
     switch (syncStep) {
       case CalendarEventImportSyncStep.CALENDAR_EVENT_LIST_FETCH:

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-fetch-events.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-fetch-events.service.ts
@@ -48,68 +48,51 @@ export class CalendarFetchEventsService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        try {
-          const { accessToken, refreshToken } =
-            await this.calendarAccountAuthenticationService.validateAndRefreshConnectedAccountAuthentication(
-              {
-                connectedAccount,
-                workspaceId,
-                calendarChannelId: calendarChannel.id,
-              },
-            );
-
-          const connectedAccountWithFreshTokens = {
-            ...connectedAccount,
-            accessToken,
-            refreshToken,
-          };
-
-          if (!isDefined(calendarChannel.syncCursor)) {
-            throw new CalendarEventImportDriverException(
-              'Sync cursor is required',
-              CalendarEventImportDriverExceptionCode.SYNC_CURSOR_ERROR,
-            );
-          }
-
-          const getCalendarEventsResponse =
-            await this.getCalendarEventsService.getCalendarEvents(
-              connectedAccountWithFreshTokens,
-              calendarChannel.syncCursor,
-            );
-
-          const hasFullEvents = getCalendarEventsResponse.fullEvents;
-
-          const calendarEvents = hasFullEvents
-            ? getCalendarEventsResponse.calendarEvents
-            : null;
-          const calendarEventIds = getCalendarEventsResponse.calendarEventIds;
-          const nextSyncCursor = getCalendarEventsResponse.nextSyncCursor;
-
-          const calendarChannelRepository =
-            await this.globalWorkspaceOrmManager.getRepository<CalendarChannelWorkspaceEntity>(
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      try {
+        const { accessToken, refreshToken } =
+          await this.calendarAccountAuthenticationService.validateAndRefreshConnectedAccountAuthentication(
+            {
+              connectedAccount,
               workspaceId,
-              'calendarChannel',
-            );
+              calendarChannelId: calendarChannel.id,
+            },
+          );
 
-          if (!calendarEvents || calendarEvents?.length === 0) {
-            await calendarChannelRepository.update(
-              {
-                id: calendarChannel.id,
-              },
-              {
-                syncCursor: nextSyncCursor,
-              },
-            );
+        const connectedAccountWithFreshTokens = {
+          ...connectedAccount,
+          accessToken,
+          refreshToken,
+        };
 
-            await this.calendarChannelSyncStatusService.markAsCalendarEventListFetchPending(
-              [calendarChannel.id],
-              workspaceId,
-            );
-          }
+        if (!isDefined(calendarChannel.syncCursor)) {
+          throw new CalendarEventImportDriverException(
+            'Sync cursor is required',
+            CalendarEventImportDriverExceptionCode.SYNC_CURSOR_ERROR,
+          );
+        }
 
+        const getCalendarEventsResponse =
+          await this.getCalendarEventsService.getCalendarEvents(
+            connectedAccountWithFreshTokens,
+            calendarChannel.syncCursor,
+          );
+
+        const hasFullEvents = getCalendarEventsResponse.fullEvents;
+
+        const calendarEvents = hasFullEvents
+          ? getCalendarEventsResponse.calendarEvents
+          : null;
+        const calendarEventIds = getCalendarEventsResponse.calendarEventIds;
+        const nextSyncCursor = getCalendarEventsResponse.nextSyncCursor;
+
+        const calendarChannelRepository =
+          await this.globalWorkspaceOrmManager.getRepository<CalendarChannelWorkspaceEntity>(
+            workspaceId,
+            'calendarChannel',
+          );
+
+        if (!calendarEvents || calendarEvents?.length === 0) {
           await calendarChannelRepository.update(
             {
               id: calendarChannel.id,
@@ -119,42 +102,56 @@ export class CalendarFetchEventsService {
             },
           );
 
-          if (hasFullEvents && calendarEvents) {
-            await this.calendarEventsImportService.processCalendarEventsImport(
-              calendarChannel,
-              connectedAccount,
-              workspaceId,
-              calendarEvents,
-            );
-          } else if (!hasFullEvents && calendarEventIds) {
-            await this.cacheStorage.setAdd(
-              `calendar-events-to-import:${workspaceId}:${calendarChannel.id}`,
-              calendarEventIds,
-            );
-
-            await this.calendarChannelSyncStatusService.markAsCalendarEventsImportPending(
-              [calendarChannel.id],
-              workspaceId,
-            );
-          } else {
-            throw new CalendarEventImportDriverException(
-              "Expected 'calendarEvents' or 'calendarEventIds' to be present",
-              CalendarEventImportDriverExceptionCode.UNKNOWN,
-            );
-          }
-        } catch (error) {
-          this.logger.log(
-            `Calendar event fetch error for workspace ${workspaceId} and calendar channel ${calendarChannel.id}`,
-          );
-          this.logger.error(error);
-          await this.calendarEventImportErrorHandlerService.handleDriverException(
-            error,
-            CalendarEventImportSyncStep.CALENDAR_EVENT_LIST_FETCH,
-            calendarChannel,
+          await this.calendarChannelSyncStatusService.markAsCalendarEventListFetchPending(
+            [calendarChannel.id],
             workspaceId,
           );
         }
-      },
-    );
+
+        await calendarChannelRepository.update(
+          {
+            id: calendarChannel.id,
+          },
+          {
+            syncCursor: nextSyncCursor,
+          },
+        );
+
+        if (hasFullEvents && calendarEvents) {
+          await this.calendarEventsImportService.processCalendarEventsImport(
+            calendarChannel,
+            connectedAccount,
+            workspaceId,
+            calendarEvents,
+          );
+        } else if (!hasFullEvents && calendarEventIds) {
+          await this.cacheStorage.setAdd(
+            `calendar-events-to-import:${workspaceId}:${calendarChannel.id}`,
+            calendarEventIds,
+          );
+
+          await this.calendarChannelSyncStatusService.markAsCalendarEventsImportPending(
+            [calendarChannel.id],
+            workspaceId,
+          );
+        } else {
+          throw new CalendarEventImportDriverException(
+            "Expected 'calendarEvents' or 'calendarEventIds' to be present",
+            CalendarEventImportDriverExceptionCode.UNKNOWN,
+          );
+        }
+      } catch (error) {
+        this.logger.log(
+          `Calendar event fetch error for workspace ${workspaceId} and calendar channel ${calendarChannel.id}`,
+        );
+        this.logger.error(error);
+        await this.calendarEventImportErrorHandlerService.handleDriverException(
+          error,
+          CalendarEventImportSyncStep.CALENDAR_EVENT_LIST_FETCH,
+          calendarChannel,
+          workspaceId,
+        );
+      }
+    }, authContext);
   }
 }

--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-save-events.service.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/services/calendar-save-events.service.ts
@@ -34,248 +34,239 @@ export class CalendarSaveEventsService {
   ): Promise<void> {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const calendarEventRepository =
-          await this.globalWorkspaceOrmManager.getRepository<CalendarEventWorkspaceEntity>(
-            workspaceId,
-            'calendarEvent',
-          );
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const calendarEventRepository =
+        await this.globalWorkspaceOrmManager.getRepository<CalendarEventWorkspaceEntity>(
+          workspaceId,
+          'calendarEvent',
+        );
 
-        const calendarChannelEventAssociationRepository =
-          await this.globalWorkspaceOrmManager.getRepository<CalendarChannelEventAssociationWorkspaceEntity>(
-            workspaceId,
-            'calendarChannelEventAssociation',
-          );
+      const calendarChannelEventAssociationRepository =
+        await this.globalWorkspaceOrmManager.getRepository<CalendarChannelEventAssociationWorkspaceEntity>(
+          workspaceId,
+          'calendarChannelEventAssociation',
+        );
 
-        const workspaceDataSource =
-          await this.globalWorkspaceOrmManager.getGlobalWorkspaceDataSource();
+      const workspaceDataSource =
+        await this.globalWorkspaceOrmManager.getGlobalWorkspaceDataSource();
 
-        await workspaceDataSource.transaction(
-          async (transactionManager: WorkspaceEntityManager) => {
-            const existingCalendarEvents = await calendarEventRepository.find(
-              {
-                where: {
-                  iCalUid: Any(
-                    fetchedCalendarEvents.map(
-                      (event) => event.iCalUid as string,
-                    ),
-                  ),
-                },
+      await workspaceDataSource.transaction(
+        async (transactionManager: WorkspaceEntityManager) => {
+          const existingCalendarEvents = await calendarEventRepository.find(
+            {
+              where: {
+                iCalUid: Any(
+                  fetchedCalendarEvents.map((event) => event.iCalUid as string),
+                ),
               },
-              transactionManager,
-            );
+            },
+            transactionManager,
+          );
 
-            const fetchedCalendarEventsWithDBEvents: FetchedCalendarEventWithDBEvent[] =
-              fetchedCalendarEvents.map(
-                (event): FetchedCalendarEventWithDBEvent => {
-                  const existingEventWithSameiCalUid =
-                    existingCalendarEvents.find(
-                      (existingEvent) =>
-                        existingEvent.iCalUid === event.iCalUid,
-                    );
-
-                  return {
-                    fetchedCalendarEvent: event,
-                    existingCalendarEvent: existingEventWithSameiCalUid ?? null,
-                    newlyCreatedCalendarEvent: null,
-                  };
-                },
-              );
-
-            const newCalendarEventsToInsert = fetchedCalendarEventsWithDBEvents
-              .filter(
-                ({ existingCalendarEvent }) => existingCalendarEvent === null,
-              )
-              .map(({ fetchedCalendarEvent }) => ({
-                id: uuid(),
-                iCalUid: fetchedCalendarEvent.iCalUid,
-                title: fetchedCalendarEvent.title,
-                description: fetchedCalendarEvent.description,
-                startsAt: fetchedCalendarEvent.startsAt,
-                endsAt: fetchedCalendarEvent.endsAt,
-                location: fetchedCalendarEvent.location,
-                isFullDay: fetchedCalendarEvent.isFullDay,
-                isCanceled: fetchedCalendarEvent.isCanceled,
-                conferenceSolution: fetchedCalendarEvent.conferenceSolution,
-                conferenceLink: {
-                  primaryLinkLabel: fetchedCalendarEvent.conferenceLinkLabel,
-                  primaryLinkUrl: fetchedCalendarEvent.conferenceLinkUrl,
-                  secondaryLinks: [],
-                },
-                externalCreatedAt: fetchedCalendarEvent.externalCreatedAt,
-                externalUpdatedAt: fetchedCalendarEvent.externalUpdatedAt,
-              }));
-
-            if (newCalendarEventsToInsert.length > 0) {
-              await calendarEventRepository.insert(
-                newCalendarEventsToInsert,
-                transactionManager,
-              );
-            }
-
-            const fetchedCalendarEventsWithDBEventsEnrichedWithSavedEvents: FetchedCalendarEventWithDBEvent[] =
-              fetchedCalendarEventsWithDBEvents.map(
-                ({ fetchedCalendarEvent, existingCalendarEvent }) => {
-                  const savedCalendarEvent = newCalendarEventsToInsert.find(
-                    (inserted) =>
-                      inserted.iCalUid === fetchedCalendarEvent.iCalUid,
+          const fetchedCalendarEventsWithDBEvents: FetchedCalendarEventWithDBEvent[] =
+            fetchedCalendarEvents.map(
+              (event): FetchedCalendarEventWithDBEvent => {
+                const existingEventWithSameiCalUid =
+                  existingCalendarEvents.find(
+                    (existingEvent) => existingEvent.iCalUid === event.iCalUid,
                   );
-
-                  return {
-                    fetchedCalendarEvent,
-                    existingCalendarEvent: existingCalendarEvent,
-                    newlyCreatedCalendarEvent: savedCalendarEvent
-                      ? ({
-                          id: savedCalendarEvent.id,
-                          iCalUid: savedCalendarEvent.iCalUid,
-                        } as CalendarEventWorkspaceEntity)
-                      : null,
-                  };
-                },
-              );
-
-            const existingEventsToUpdate =
-              fetchedCalendarEventsWithDBEventsEnrichedWithSavedEvents
-                .filter(
-                  ({ existingCalendarEvent }) => existingCalendarEvent !== null,
-                )
-                .map(({ fetchedCalendarEvent, existingCalendarEvent }) => {
-                  if (!existingCalendarEvent) {
-                    throw new Error(
-                      `Existing calendar event with iCalUid ${fetchedCalendarEvent.iCalUid} not found - should never happen`,
-                    );
-                  }
-
-                  return {
-                    criteria: existingCalendarEvent.id,
-                    partialEntity: {
-                      iCalUid: fetchedCalendarEvent.iCalUid,
-                      title: fetchedCalendarEvent.title,
-                      description: fetchedCalendarEvent.description,
-                      startsAt: fetchedCalendarEvent.startsAt,
-                      endsAt: fetchedCalendarEvent.endsAt,
-                      location: fetchedCalendarEvent.location,
-                      isFullDay: fetchedCalendarEvent.isFullDay,
-                      isCanceled: fetchedCalendarEvent.isCanceled,
-                      conferenceSolution:
-                        fetchedCalendarEvent.conferenceSolution,
-                      conferenceLink: {
-                        primaryLinkLabel:
-                          fetchedCalendarEvent.conferenceLinkLabel,
-                        primaryLinkUrl: fetchedCalendarEvent.conferenceLinkUrl,
-                        secondaryLinks: [],
-                      },
-                      externalCreatedAt: fetchedCalendarEvent.externalCreatedAt,
-                      externalUpdatedAt: fetchedCalendarEvent.externalUpdatedAt,
-                    },
-                  };
-                });
-
-            if (existingEventsToUpdate.length > 0) {
-              await calendarEventRepository.updateMany(
-                existingEventsToUpdate,
-                transactionManager,
-              );
-            }
-
-            const calendarChannelEventAssociationsToSave: Pick<
-              CalendarChannelEventAssociationWorkspaceEntity,
-              | 'calendarEventId'
-              | 'eventExternalId'
-              | 'calendarChannelId'
-              | 'recurringEventExternalId'
-            >[] = fetchedCalendarEventsWithDBEventsEnrichedWithSavedEvents.map(
-              ({
-                fetchedCalendarEvent,
-                existingCalendarEvent,
-                newlyCreatedCalendarEvent,
-              }) => {
-                const calendarEventId =
-                  existingCalendarEvent?.id ?? newlyCreatedCalendarEvent?.id;
-
-                if (!calendarEventId) {
-                  throw new Error(
-                    `Calendar event id not found for event with iCalUid ${fetchedCalendarEvent.iCalUid} - should never happen`,
-                  );
-                }
 
                 return {
-                  calendarEventId,
-                  eventExternalId: fetchedCalendarEvent.id,
-                  calendarChannelId: calendarChannel.id,
-                  recurringEventExternalId:
-                    fetchedCalendarEvent.recurringEventExternalId ?? '',
+                  fetchedCalendarEvent: event,
+                  existingCalendarEvent: existingEventWithSameiCalUid ?? null,
+                  newlyCreatedCalendarEvent: null,
                 };
               },
             );
 
-            if (calendarChannelEventAssociationsToSave.length > 0) {
-              await calendarChannelEventAssociationRepository.insert(
-                calendarChannelEventAssociationsToSave,
-                transactionManager,
-              );
-            }
+          const newCalendarEventsToInsert = fetchedCalendarEventsWithDBEvents
+            .filter(
+              ({ existingCalendarEvent }) => existingCalendarEvent === null,
+            )
+            .map(({ fetchedCalendarEvent }) => ({
+              id: uuid(),
+              iCalUid: fetchedCalendarEvent.iCalUid,
+              title: fetchedCalendarEvent.title,
+              description: fetchedCalendarEvent.description,
+              startsAt: fetchedCalendarEvent.startsAt,
+              endsAt: fetchedCalendarEvent.endsAt,
+              location: fetchedCalendarEvent.location,
+              isFullDay: fetchedCalendarEvent.isFullDay,
+              isCanceled: fetchedCalendarEvent.isCanceled,
+              conferenceSolution: fetchedCalendarEvent.conferenceSolution,
+              conferenceLink: {
+                primaryLinkLabel: fetchedCalendarEvent.conferenceLinkLabel,
+                primaryLinkUrl: fetchedCalendarEvent.conferenceLinkUrl,
+                secondaryLinks: [],
+              },
+              externalCreatedAt: fetchedCalendarEvent.externalCreatedAt,
+              externalUpdatedAt: fetchedCalendarEvent.externalUpdatedAt,
+            }));
 
-            const participantsToCreate =
-              fetchedCalendarEventsWithDBEventsEnrichedWithSavedEvents
-                .filter(
-                  ({ newlyCreatedCalendarEvent }) =>
-                    newlyCreatedCalendarEvent !== null,
-                )
-                .flatMap(
-                  ({ newlyCreatedCalendarEvent, fetchedCalendarEvent }) => {
-                    if (!newlyCreatedCalendarEvent?.id) {
-                      throw new Error(
-                        `Newly created calendar event with iCalUid ${fetchedCalendarEvent.iCalUid} not found - should never happen`,
-                      );
-                    }
+          if (newCalendarEventsToInsert.length > 0) {
+            await calendarEventRepository.insert(
+              newCalendarEventsToInsert,
+              transactionManager,
+            );
+          }
 
-                    return fetchedCalendarEvent.participants.map(
-                      (participant) => ({
-                        ...participant,
-                        calendarEventId: newlyCreatedCalendarEvent.id,
-                      }),
-                    );
-                  },
+          const fetchedCalendarEventsWithDBEventsEnrichedWithSavedEvents: FetchedCalendarEventWithDBEvent[] =
+            fetchedCalendarEventsWithDBEvents.map(
+              ({ fetchedCalendarEvent, existingCalendarEvent }) => {
+                const savedCalendarEvent = newCalendarEventsToInsert.find(
+                  (inserted) =>
+                    inserted.iCalUid === fetchedCalendarEvent.iCalUid,
                 );
 
-            // todo: we should prevent duplicate rows on calendarEventAssociation by creating
-            // an index on calendarChannelId and calendarEventId
-            const participantsToUpdate =
-              fetchedCalendarEventsWithDBEventsEnrichedWithSavedEvents
-                .filter(
-                  ({ existingCalendarEvent }) => existingCalendarEvent !== null,
-                )
-                .flatMap(({ fetchedCalendarEvent, existingCalendarEvent }) => {
-                  if (!existingCalendarEvent?.id) {
+                return {
+                  fetchedCalendarEvent,
+                  existingCalendarEvent: existingCalendarEvent,
+                  newlyCreatedCalendarEvent: savedCalendarEvent
+                    ? ({
+                        id: savedCalendarEvent.id,
+                        iCalUid: savedCalendarEvent.iCalUid,
+                      } as CalendarEventWorkspaceEntity)
+                    : null,
+                };
+              },
+            );
+
+          const existingEventsToUpdate =
+            fetchedCalendarEventsWithDBEventsEnrichedWithSavedEvents
+              .filter(
+                ({ existingCalendarEvent }) => existingCalendarEvent !== null,
+              )
+              .map(({ fetchedCalendarEvent, existingCalendarEvent }) => {
+                if (!existingCalendarEvent) {
+                  throw new Error(
+                    `Existing calendar event with iCalUid ${fetchedCalendarEvent.iCalUid} not found - should never happen`,
+                  );
+                }
+
+                return {
+                  criteria: existingCalendarEvent.id,
+                  partialEntity: {
+                    iCalUid: fetchedCalendarEvent.iCalUid,
+                    title: fetchedCalendarEvent.title,
+                    description: fetchedCalendarEvent.description,
+                    startsAt: fetchedCalendarEvent.startsAt,
+                    endsAt: fetchedCalendarEvent.endsAt,
+                    location: fetchedCalendarEvent.location,
+                    isFullDay: fetchedCalendarEvent.isFullDay,
+                    isCanceled: fetchedCalendarEvent.isCanceled,
+                    conferenceSolution: fetchedCalendarEvent.conferenceSolution,
+                    conferenceLink: {
+                      primaryLinkLabel:
+                        fetchedCalendarEvent.conferenceLinkLabel,
+                      primaryLinkUrl: fetchedCalendarEvent.conferenceLinkUrl,
+                      secondaryLinks: [],
+                    },
+                    externalCreatedAt: fetchedCalendarEvent.externalCreatedAt,
+                    externalUpdatedAt: fetchedCalendarEvent.externalUpdatedAt,
+                  },
+                };
+              });
+
+          if (existingEventsToUpdate.length > 0) {
+            await calendarEventRepository.updateMany(
+              existingEventsToUpdate,
+              transactionManager,
+            );
+          }
+
+          const calendarChannelEventAssociationsToSave: Pick<
+            CalendarChannelEventAssociationWorkspaceEntity,
+            | 'calendarEventId'
+            | 'eventExternalId'
+            | 'calendarChannelId'
+            | 'recurringEventExternalId'
+          >[] = fetchedCalendarEventsWithDBEventsEnrichedWithSavedEvents.map(
+            ({
+              fetchedCalendarEvent,
+              existingCalendarEvent,
+              newlyCreatedCalendarEvent,
+            }) => {
+              const calendarEventId =
+                existingCalendarEvent?.id ?? newlyCreatedCalendarEvent?.id;
+
+              if (!calendarEventId) {
+                throw new Error(
+                  `Calendar event id not found for event with iCalUid ${fetchedCalendarEvent.iCalUid} - should never happen`,
+                );
+              }
+
+              return {
+                calendarEventId,
+                eventExternalId: fetchedCalendarEvent.id,
+                calendarChannelId: calendarChannel.id,
+                recurringEventExternalId:
+                  fetchedCalendarEvent.recurringEventExternalId ?? '',
+              };
+            },
+          );
+
+          if (calendarChannelEventAssociationsToSave.length > 0) {
+            await calendarChannelEventAssociationRepository.insert(
+              calendarChannelEventAssociationsToSave,
+              transactionManager,
+            );
+          }
+
+          const participantsToCreate =
+            fetchedCalendarEventsWithDBEventsEnrichedWithSavedEvents
+              .filter(
+                ({ newlyCreatedCalendarEvent }) =>
+                  newlyCreatedCalendarEvent !== null,
+              )
+              .flatMap(
+                ({ newlyCreatedCalendarEvent, fetchedCalendarEvent }) => {
+                  if (!newlyCreatedCalendarEvent?.id) {
                     throw new Error(
-                      `Existing calendar event with iCalUid ${fetchedCalendarEvent.iCalUid} not found - should never happen`,
+                      `Newly created calendar event with iCalUid ${fetchedCalendarEvent.iCalUid} not found - should never happen`,
                     );
                   }
 
                   return fetchedCalendarEvent.participants.map(
                     (participant) => ({
                       ...participant,
-                      calendarEventId: existingCalendarEvent.id,
+                      calendarEventId: newlyCreatedCalendarEvent.id,
                     }),
                   );
-                });
+                },
+              );
 
-            await this.calendarEventParticipantService.upsertAndDeleteCalendarEventParticipants(
-              {
-                participantsToCreate,
-                participantsToUpdate,
-                transactionManager,
-                calendarChannel,
-                connectedAccount,
-                workspaceId,
-              },
-            );
-          },
-        );
-      },
-    );
+          // todo: we should prevent duplicate rows on calendarEventAssociation by creating
+          // an index on calendarChannelId and calendarEventId
+          const participantsToUpdate =
+            fetchedCalendarEventsWithDBEventsEnrichedWithSavedEvents
+              .filter(
+                ({ existingCalendarEvent }) => existingCalendarEvent !== null,
+              )
+              .flatMap(({ fetchedCalendarEvent, existingCalendarEvent }) => {
+                if (!existingCalendarEvent?.id) {
+                  throw new Error(
+                    `Existing calendar event with iCalUid ${fetchedCalendarEvent.iCalUid} not found - should never happen`,
+                  );
+                }
+
+                return fetchedCalendarEvent.participants.map((participant) => ({
+                  ...participant,
+                  calendarEventId: existingCalendarEvent.id,
+                }));
+              });
+
+          await this.calendarEventParticipantService.upsertAndDeleteCalendarEventParticipants(
+            {
+              participantsToCreate,
+              participantsToUpdate,
+              transactionManager,
+              calendarChannel,
+              connectedAccount,
+              workspaceId,
+            },
+          );
+        },
+      );
+    }, authContext);
   }
 }

--- a/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/services/apply-calendar-events-visibility-restrictions.service.spec.ts
+++ b/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/services/apply-calendar-events-visibility-restrictions.service.spec.ts
@@ -66,7 +66,7 @@ describe('ApplyCalendarEventsVisibilityRestrictionsService', () => {
     }),
     executeInWorkspaceContext: jest
       .fn()
-      .mockImplementation((_authContext: any, fn: () => any) => fn()),
+      .mockImplementation((fn: () => any, _authContext?: any) => fn()),
   };
 
   beforeEach(async () => {

--- a/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/services/apply-calendar-events-visibility-restrictions.service.ts
+++ b/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/services/apply-calendar-events-visibility-restrictions.service.ts
@@ -27,7 +27,6 @@ export class ApplyCalendarEventsVisibilityRestrictionsService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const calendarChannelEventAssociationRepository =
           await this.globalWorkspaceOrmManager.getRepository<CalendarChannelEventAssociationWorkspaceEntity>(
@@ -117,6 +116,7 @@ export class ApplyCalendarEventsVisibilityRestrictionsService {
 
         return calendarEvents;
       },
+      authContext,
     );
   }
 }

--- a/packages/twenty-server/src/modules/calendar/common/services/calendar-channel-sync-status.service.ts
+++ b/packages/twenty-server/src/modules/calendar/common/services/calendar-channel-sync-status.service.ts
@@ -39,21 +39,18 @@ export class CalendarChannelSyncStatusService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const calendarChannelRepository =
-          await this.globalWorkspaceOrmManager.getRepository<CalendarChannelWorkspaceEntity>(
-            workspaceId,
-            'calendarChannel',
-          );
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const calendarChannelRepository =
+        await this.globalWorkspaceOrmManager.getRepository<CalendarChannelWorkspaceEntity>(
+          workspaceId,
+          'calendarChannel',
+        );
 
-        await calendarChannelRepository.update(calendarChannelIds, {
-          syncStage: CalendarChannelSyncStage.CALENDAR_EVENT_LIST_FETCH_PENDING,
-          ...(!preserveSyncStageStartedAt ? { syncStageStartedAt: null } : {}),
-        });
-      },
-    );
+      await calendarChannelRepository.update(calendarChannelIds, {
+        syncStage: CalendarChannelSyncStage.CALENDAR_EVENT_LIST_FETCH_PENDING,
+        ...(!preserveSyncStageStartedAt ? { syncStageStartedAt: null } : {}),
+      });
+    }, authContext);
   }
 
   public async markAsCalendarEventListFetchOngoing(
@@ -66,22 +63,19 @@ export class CalendarChannelSyncStatusService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const calendarChannelRepository =
-          await this.globalWorkspaceOrmManager.getRepository<CalendarChannelWorkspaceEntity>(
-            workspaceId,
-            'calendarChannel',
-          );
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const calendarChannelRepository =
+        await this.globalWorkspaceOrmManager.getRepository<CalendarChannelWorkspaceEntity>(
+          workspaceId,
+          'calendarChannel',
+        );
 
-        await calendarChannelRepository.update(calendarChannelIds, {
-          syncStage: CalendarChannelSyncStage.CALENDAR_EVENT_LIST_FETCH_ONGOING,
-          syncStatus: CalendarChannelSyncStatus.ONGOING,
-          syncStageStartedAt: new Date().toISOString(),
-        });
-      },
-    );
+      await calendarChannelRepository.update(calendarChannelIds, {
+        syncStage: CalendarChannelSyncStage.CALENDAR_EVENT_LIST_FETCH_ONGOING,
+        syncStatus: CalendarChannelSyncStatus.ONGOING,
+        syncStageStartedAt: new Date().toISOString(),
+      });
+    }, authContext);
   }
 
   public async resetAndMarkAsCalendarEventListFetchPending(
@@ -100,22 +94,19 @@ export class CalendarChannelSyncStatusService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const calendarChannelRepository =
-          await this.globalWorkspaceOrmManager.getRepository<CalendarChannelWorkspaceEntity>(
-            workspaceId,
-            'calendarChannel',
-          );
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const calendarChannelRepository =
+        await this.globalWorkspaceOrmManager.getRepository<CalendarChannelWorkspaceEntity>(
+          workspaceId,
+          'calendarChannel',
+        );
 
-        await calendarChannelRepository.update(calendarChannelIds, {
-          syncCursor: '',
-          syncStageStartedAt: null,
-          throttleFailureCount: 0,
-        });
-      },
-    );
+      await calendarChannelRepository.update(calendarChannelIds, {
+        syncCursor: '',
+        syncStageStartedAt: null,
+        throttleFailureCount: 0,
+      });
+    }, authContext);
 
     await this.markAsCalendarEventListFetchPending(
       calendarChannelIds,
@@ -133,20 +124,17 @@ export class CalendarChannelSyncStatusService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const calendarChannelRepository =
-          await this.globalWorkspaceOrmManager.getRepository<CalendarChannelWorkspaceEntity>(
-            workspaceId,
-            'calendarChannel',
-          );
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const calendarChannelRepository =
+        await this.globalWorkspaceOrmManager.getRepository<CalendarChannelWorkspaceEntity>(
+          workspaceId,
+          'calendarChannel',
+        );
 
-        await calendarChannelRepository.update(calendarChannelIds, {
-          syncStageStartedAt: null,
-        });
-      },
-    );
+      await calendarChannelRepository.update(calendarChannelIds, {
+        syncStageStartedAt: null,
+      });
+    }, authContext);
   }
 
   public async markAsCalendarEventsImportPending(
@@ -160,21 +148,18 @@ export class CalendarChannelSyncStatusService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const calendarChannelRepository =
-          await this.globalWorkspaceOrmManager.getRepository<CalendarChannelWorkspaceEntity>(
-            workspaceId,
-            'calendarChannel',
-          );
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const calendarChannelRepository =
+        await this.globalWorkspaceOrmManager.getRepository<CalendarChannelWorkspaceEntity>(
+          workspaceId,
+          'calendarChannel',
+        );
 
-        await calendarChannelRepository.update(calendarChannelIds, {
-          syncStage: CalendarChannelSyncStage.CALENDAR_EVENTS_IMPORT_PENDING,
-          ...(!preserveSyncStageStartedAt ? { syncStageStartedAt: null } : {}),
-        });
-      },
-    );
+      await calendarChannelRepository.update(calendarChannelIds, {
+        syncStage: CalendarChannelSyncStage.CALENDAR_EVENTS_IMPORT_PENDING,
+        ...(!preserveSyncStageStartedAt ? { syncStageStartedAt: null } : {}),
+      });
+    }, authContext);
   }
 
   public async markAsCalendarEventsImportOngoing(
@@ -187,21 +172,18 @@ export class CalendarChannelSyncStatusService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const calendarChannelRepository =
-          await this.globalWorkspaceOrmManager.getRepository<CalendarChannelWorkspaceEntity>(
-            workspaceId,
-            'calendarChannel',
-          );
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const calendarChannelRepository =
+        await this.globalWorkspaceOrmManager.getRepository<CalendarChannelWorkspaceEntity>(
+          workspaceId,
+          'calendarChannel',
+        );
 
-        await calendarChannelRepository.update(calendarChannelIds, {
-          syncStage: CalendarChannelSyncStage.CALENDAR_EVENTS_IMPORT_ONGOING,
-          syncStatus: CalendarChannelSyncStatus.ONGOING,
-        });
-      },
-    );
+      await calendarChannelRepository.update(calendarChannelIds, {
+        syncStage: CalendarChannelSyncStage.CALENDAR_EVENTS_IMPORT_ONGOING,
+        syncStatus: CalendarChannelSyncStatus.ONGOING,
+      });
+    }, authContext);
   }
 
   public async markAsCompletedAndMarkAsCalendarEventListFetchPending(
@@ -214,24 +196,21 @@ export class CalendarChannelSyncStatusService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const calendarChannelRepository =
-          await this.globalWorkspaceOrmManager.getRepository<CalendarChannelWorkspaceEntity>(
-            workspaceId,
-            'calendarChannel',
-          );
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const calendarChannelRepository =
+        await this.globalWorkspaceOrmManager.getRepository<CalendarChannelWorkspaceEntity>(
+          workspaceId,
+          'calendarChannel',
+        );
 
-        await calendarChannelRepository.update(calendarChannelIds, {
-          syncStage: CalendarChannelSyncStage.CALENDAR_EVENT_LIST_FETCH_PENDING,
-          syncStatus: CalendarChannelSyncStatus.ACTIVE,
-          throttleFailureCount: 0,
-          syncStageStartedAt: null,
-          syncedAt: new Date().toISOString(),
-        });
-      },
-    );
+      await calendarChannelRepository.update(calendarChannelIds, {
+        syncStage: CalendarChannelSyncStage.CALENDAR_EVENT_LIST_FETCH_PENDING,
+        syncStatus: CalendarChannelSyncStatus.ACTIVE,
+        throttleFailureCount: 0,
+        syncStageStartedAt: null,
+        syncedAt: new Date().toISOString(),
+      });
+    }, authContext);
 
     await this.markAsCalendarEventListFetchPending(
       calendarChannelIds,
@@ -260,21 +239,18 @@ export class CalendarChannelSyncStatusService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const calendarChannelRepository =
-          await this.globalWorkspaceOrmManager.getRepository<CalendarChannelWorkspaceEntity>(
-            workspaceId,
-            'calendarChannel',
-          );
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const calendarChannelRepository =
+        await this.globalWorkspaceOrmManager.getRepository<CalendarChannelWorkspaceEntity>(
+          workspaceId,
+          'calendarChannel',
+        );
 
-        await calendarChannelRepository.update(calendarChannelIds, {
-          syncStatus: CalendarChannelSyncStatus.FAILED_UNKNOWN,
-          syncStage: CalendarChannelSyncStage.FAILED,
-        });
-      },
-    );
+      await calendarChannelRepository.update(calendarChannelIds, {
+        syncStatus: CalendarChannelSyncStatus.FAILED_UNKNOWN,
+        syncStage: CalendarChannelSyncStage.FAILED,
+      });
+    }, authContext);
 
     await this.metricsService.batchIncrementCounter({
       key: MetricsKeys.CalendarEventSyncJobFailedUnknown,
@@ -298,48 +274,45 @@ export class CalendarChannelSyncStatusService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const calendarChannelRepository =
-          await this.globalWorkspaceOrmManager.getRepository<CalendarChannelWorkspaceEntity>(
-            workspaceId,
-            'calendarChannel',
-          );
-
-        await calendarChannelRepository.update(calendarChannelIds, {
-          syncStatus: CalendarChannelSyncStatus.FAILED_INSUFFICIENT_PERMISSIONS,
-          syncStage: CalendarChannelSyncStage.FAILED,
-        });
-
-        const connectedAccountRepository =
-          await this.globalWorkspaceOrmManager.getRepository<ConnectedAccountWorkspaceEntity>(
-            workspaceId,
-            'connectedAccount',
-          );
-
-        const calendarChannels = await calendarChannelRepository.find({
-          select: ['id', 'connectedAccountId'],
-          where: { id: Any(calendarChannelIds) },
-        });
-
-        const connectedAccountIds = calendarChannels.map(
-          (calendarChannel) => calendarChannel.connectedAccountId,
-        );
-
-        await connectedAccountRepository.update(
-          { id: Any(connectedAccountIds) },
-          {
-            authFailedAt: new Date(),
-          },
-        );
-
-        await this.addToAccountsToReconnect(
-          calendarChannels.map((calendarChannel) => calendarChannel.id),
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const calendarChannelRepository =
+        await this.globalWorkspaceOrmManager.getRepository<CalendarChannelWorkspaceEntity>(
           workspaceId,
+          'calendarChannel',
         );
-      },
-    );
+
+      await calendarChannelRepository.update(calendarChannelIds, {
+        syncStatus: CalendarChannelSyncStatus.FAILED_INSUFFICIENT_PERMISSIONS,
+        syncStage: CalendarChannelSyncStage.FAILED,
+      });
+
+      const connectedAccountRepository =
+        await this.globalWorkspaceOrmManager.getRepository<ConnectedAccountWorkspaceEntity>(
+          workspaceId,
+          'connectedAccount',
+        );
+
+      const calendarChannels = await calendarChannelRepository.find({
+        select: ['id', 'connectedAccountId'],
+        where: { id: Any(calendarChannelIds) },
+      });
+
+      const connectedAccountIds = calendarChannels.map(
+        (calendarChannel) => calendarChannel.connectedAccountId,
+      );
+
+      await connectedAccountRepository.update(
+        { id: Any(connectedAccountIds) },
+        {
+          authFailedAt: new Date(),
+        },
+      );
+
+      await this.addToAccountsToReconnect(
+        calendarChannels.map((calendarChannel) => calendarChannel.id),
+        workspaceId,
+      );
+    }, authContext);
 
     await this.metricsService.batchIncrementCounter({
       key: MetricsKeys.CalendarEventSyncJobFailedInsufficientPermissions,

--- a/packages/twenty-server/src/modules/connected-account/email-alias-manager/services/email-alias-manager.service.spec.ts
+++ b/packages/twenty-server/src/modules/connected-account/email-alias-manager/services/email-alias-manager.service.spec.ts
@@ -35,7 +35,7 @@ describe('Email Alias Manager Service', () => {
               .mockResolvedValue(connectedAccountRepository),
             executeInWorkspaceContext: jest
               .fn()
-              .mockImplementation((_authContext: any, fn: () => any) => fn()),
+              .mockImplementation((fn: () => any, _authContext?: any) => fn()),
           },
         },
         EmailAliasManagerService,

--- a/packages/twenty-server/src/modules/connected-account/email-alias-manager/services/email-alias-manager.service.ts
+++ b/packages/twenty-server/src/modules/connected-account/email-alias-manager/services/email-alias-manager.service.ts
@@ -49,22 +49,19 @@ export class EmailAliasManagerService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const connectedAccountRepository =
-          await this.globalWorkspaceOrmManager.getRepository<ConnectedAccountWorkspaceEntity>(
-            workspaceId,
-            'connectedAccount',
-          );
-
-        await connectedAccountRepository.update(
-          { id: connectedAccount.id },
-          {
-            handleAliases: handleAliases.join(','), // TODO: modify handleAliases to be of fieldmetadatatype array
-          },
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const connectedAccountRepository =
+        await this.globalWorkspaceOrmManager.getRepository<ConnectedAccountWorkspaceEntity>(
+          workspaceId,
+          'connectedAccount',
         );
-      },
-    );
+
+      await connectedAccountRepository.update(
+        { id: connectedAccount.id },
+        {
+          handleAliases: handleAliases.join(','), // TODO: modify handleAliases to be of fieldmetadatatype array
+        },
+      );
+    }, authContext);
   }
 }

--- a/packages/twenty-server/src/modules/connected-account/jobs/delete-workspace-member-connected-accounts.job.ts
+++ b/packages/twenty-server/src/modules/connected-account/jobs/delete-workspace-member-connected-accounts.job.ts
@@ -24,19 +24,16 @@ export class DeleteWorkspaceMemberConnectedAccountsCleanupJob {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const connectedAccountRepository =
-          await this.globalWorkspaceOrmManager.getRepository<ConnectedAccountWorkspaceEntity>(
-            workspaceId,
-            'connectedAccount',
-          );
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const connectedAccountRepository =
+        await this.globalWorkspaceOrmManager.getRepository<ConnectedAccountWorkspaceEntity>(
+          workspaceId,
+          'connectedAccount',
+        );
 
-        await connectedAccountRepository.delete({
-          accountOwnerId: workspaceMemberId,
-        });
-      },
-    );
+      await connectedAccountRepository.delete({
+        accountOwnerId: workspaceMemberId,
+      });
+    }, authContext);
   }
 }

--- a/packages/twenty-server/src/modules/connected-account/query-hooks/connected-account-delete-one.pre-query.hook.ts
+++ b/packages/twenty-server/src/modules/connected-account/query-hooks/connected-account-delete-one.pre-query.hook.ts
@@ -41,7 +41,6 @@ export class ConnectedAccountDeleteOnePreQueryHook
 
     const messageChannels =
       await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        authContext as WorkspaceAuthContext,
         async () => {
           const messageChannelRepository =
             await this.globalWorkspaceOrmManager.getRepository<MessageChannelWorkspaceEntity>(
@@ -53,6 +52,7 @@ export class ConnectedAccountDeleteOnePreQueryHook
             connectedAccountId,
           });
         },
+        authContext as WorkspaceAuthContext,
       );
 
     const objectMetadataEntity =

--- a/packages/twenty-server/src/modules/connected-account/refresh-tokens-manager/services/connected-account-refresh-tokens.service.spec.ts
+++ b/packages/twenty-server/src/modules/connected-account/refresh-tokens-manager/services/connected-account-refresh-tokens.service.spec.ts
@@ -48,7 +48,7 @@ describe('ConnectedAccountRefreshTokensService', () => {
             executeInWorkspaceContext: jest
               .fn()
 
-              .mockImplementation((_authContext: any, fn: () => any) => fn()),
+              .mockImplementation((fn: () => any, _authContext?: any) => fn()),
           },
         },
       ],

--- a/packages/twenty-server/src/modules/connected-account/refresh-tokens-manager/services/connected-account-refresh-tokens.service.ts
+++ b/packages/twenty-server/src/modules/connected-account/refresh-tokens-manager/services/connected-account-refresh-tokens.service.ts
@@ -77,24 +77,21 @@ export class ConnectedAccountRefreshTokensService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const connectedAccountRepository =
-          await this.globalWorkspaceOrmManager.getRepository<ConnectedAccountWorkspaceEntity>(
-            workspaceId,
-            'connectedAccount',
-          );
-
-        await connectedAccountRepository.update(
-          { id: connectedAccount.id },
-          {
-            ...connectedAccountTokens,
-            lastCredentialsRefreshedAt: new Date(),
-          },
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const connectedAccountRepository =
+        await this.globalWorkspaceOrmManager.getRepository<ConnectedAccountWorkspaceEntity>(
+          workspaceId,
+          'connectedAccount',
         );
-      },
-    );
+
+      await connectedAccountRepository.update(
+        { id: connectedAccount.id },
+        {
+          ...connectedAccountTokens,
+          lastCredentialsRefreshedAt: new Date(),
+        },
+      );
+    }, authContext);
 
     return connectedAccountTokens;
   }

--- a/packages/twenty-server/src/modules/connected-account/services/imap-smtp-caldav-apis.service.spec.ts
+++ b/packages/twenty-server/src/modules/connected-account/services/imap-smtp-caldav-apis.service.spec.ts
@@ -70,7 +70,7 @@ describe('ImapSmtpCalDavAPIService', () => {
             executeInWorkspaceContext: jest
               .fn()
 
-              .mockImplementation((_authContext: any, fn: () => any) => fn()),
+              .mockImplementation((fn: () => any, _authContext?: any) => fn()),
           },
         },
         {

--- a/packages/twenty-server/src/modules/connected-account/services/imap-smtp-caldav-apis.service.ts
+++ b/packages/twenty-server/src/modules/connected-account/services/imap-smtp-caldav-apis.service.ts
@@ -29,7 +29,6 @@ export class ImapSmtpCalDavAPIService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const connectedAccountRepository =
           await this.globalWorkspaceOrmManager.getRepository<ConnectedAccountWorkspaceEntity>(
@@ -41,6 +40,7 @@ export class ImapSmtpCalDavAPIService {
           where: { id, provider: ConnectedAccountProvider.IMAP_SMTP_CALDAV },
         });
       },
+      authContext,
     );
   }
 
@@ -57,7 +57,6 @@ export class ImapSmtpCalDavAPIService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const connectedAccountRepository =
           await this.globalWorkspaceOrmManager.getRepository<ConnectedAccountWorkspaceEntity>(
@@ -147,6 +146,7 @@ export class ImapSmtpCalDavAPIService {
 
         return newOrExistingAccountId;
       },
+      authContext,
     );
   }
 }

--- a/packages/twenty-server/src/modules/contact-creation-manager/services/__tests__/create-company.service.spec.ts
+++ b/packages/twenty-server/src/modules/contact-creation-manager/services/__tests__/create-company.service.spec.ts
@@ -120,7 +120,7 @@ describe('CreateCompanyService', () => {
             getRepository: jest.fn().mockResolvedValue(mockCompanyRepository),
             executeInWorkspaceContext: jest
               .fn()
-              .mockImplementation((_authContext: any, fn: () => any) => fn()),
+              .mockImplementation((fn: () => any, _authContext?: any) => fn()),
           },
         },
         {

--- a/packages/twenty-server/src/modules/contact-creation-manager/services/create-company.service.ts
+++ b/packages/twenty-server/src/modules/contact-creation-manager/services/create-company.service.ts
@@ -56,7 +56,6 @@ export class CreateCompanyService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const companyRepository =
           await this.globalWorkspaceOrmManager.getRepository(
@@ -157,6 +156,7 @@ export class CreateCompanyService {
             : {}),
         };
       },
+      authContext,
     );
   }
 

--- a/packages/twenty-server/src/modules/contact-creation-manager/services/create-person.service.ts
+++ b/packages/twenty-server/src/modules/contact-creation-manager/services/create-person.service.ts
@@ -22,7 +22,6 @@ export class CreatePersonService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const personRepository =
           await this.globalWorkspaceOrmManager.getRepository(
@@ -47,6 +46,7 @@ export class CreatePersonService {
 
         return createdPeople.raw;
       },
+      authContext,
     );
   }
 
@@ -61,7 +61,6 @@ export class CreatePersonService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const personRepository =
           await this.globalWorkspaceOrmManager.getRepository(
@@ -86,6 +85,7 @@ export class CreatePersonService {
 
         return restoredPeople.raw;
       },
+      authContext,
     );
   }
 

--- a/packages/twenty-server/src/modules/dashboard-sync/services/dashboard-sync.service.ts
+++ b/packages/twenty-server/src/modules/dashboard-sync/services/dashboard-sync.service.ts
@@ -60,7 +60,6 @@ export class DashboardSyncService {
 
     try {
       await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        authContext,
         async () => {
           const dashboardRepository =
             await this.globalWorkspaceOrmManager.getRepository(
@@ -71,6 +70,7 @@ export class DashboardSyncService {
 
           await dashboardRepository.update({ pageLayoutId }, { updatedAt });
         },
+        authContext,
       );
     } catch (error) {
       this.logger.error(

--- a/packages/twenty-server/src/modules/dashboard/services/dashboard-duplication.service.ts
+++ b/packages/twenty-server/src/modules/dashboard/services/dashboard-duplication.service.ts
@@ -44,7 +44,6 @@ export class DashboardDuplicationService {
     const workspaceId = workspace.id;
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext as WorkspaceAuthContext,
       async () => {
         const dashboardRepository =
           await this.globalWorkspaceOrmManager.getRepository<DashboardWorkspaceEntity>(
@@ -108,6 +107,7 @@ export class DashboardDuplicationService {
           throw error;
         }
       },
+      authContext as WorkspaceAuthContext,
     );
   }
 

--- a/packages/twenty-server/src/modules/dashboard/services/dashboard-to-page-layout-sync.service.ts
+++ b/packages/twenty-server/src/modules/dashboard/services/dashboard-to-page-layout-sync.service.ts
@@ -52,32 +52,29 @@ export class DashboardToPageLayoutSyncService {
   }): Promise<void> {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const dashboardRepository =
-          await this.globalWorkspaceOrmManager.getRepository<DashboardWorkspaceEntity>(
-            workspaceId,
-            'dashboard',
-            { shouldBypassPermissionChecks: true },
-          );
-
-        const dashboards = await dashboardRepository.find({
-          where: {
-            id: In(dashboardIds),
-          },
-          withDeleted: true,
-        });
-
-        const pageLayoutIds = dashboards
-          .map((dashboard) => dashboard.pageLayoutId)
-          .filter(isDefined);
-
-        await this.pageLayoutService.destroyMany({
-          ids: pageLayoutIds,
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const dashboardRepository =
+        await this.globalWorkspaceOrmManager.getRepository<DashboardWorkspaceEntity>(
           workspaceId,
-        });
-      },
-    );
+          'dashboard',
+          { shouldBypassPermissionChecks: true },
+        );
+
+      const dashboards = await dashboardRepository.find({
+        where: {
+          id: In(dashboardIds),
+        },
+        withDeleted: true,
+      });
+
+      const pageLayoutIds = dashboards
+        .map((dashboard) => dashboard.pageLayoutId)
+        .filter(isDefined);
+
+      await this.pageLayoutService.destroyMany({
+        ids: pageLayoutIds,
+        workspaceId,
+      });
+    }, authContext);
   }
 }

--- a/packages/twenty-server/src/modules/dashboard/tools/create-complete-dashboard.tool.ts
+++ b/packages/twenty-server/src/modules/dashboard/tools/create-complete-dashboard.tool.ts
@@ -206,27 +206,24 @@ const createDashboardRecord = async (
 ): Promise<string> => {
   const authContext = buildSystemAuthContext(context.workspaceId);
 
-  return deps.globalWorkspaceOrmManager.executeInWorkspaceContext(
-    authContext,
-    async () => {
-      const dashboardRepository =
-        await deps.globalWorkspaceOrmManager.getRepository(
-          context.workspaceId,
-          'dashboard',
-          { shouldBypassPermissionChecks: true },
-        );
+  return deps.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+    const dashboardRepository =
+      await deps.globalWorkspaceOrmManager.getRepository(
+        context.workspaceId,
+        'dashboard',
+        { shouldBypassPermissionChecks: true },
+      );
 
-      const position = await deps.recordPositionService.buildRecordPosition({
-        value: 'first',
-        objectMetadata: { isCustom: false, nameSingular: 'dashboard' },
-        workspaceId: context.workspaceId,
-      });
+    const position = await deps.recordPositionService.buildRecordPosition({
+      value: 'first',
+      objectMetadata: { isCustom: false, nameSingular: 'dashboard' },
+      workspaceId: context.workspaceId,
+    });
 
-      const dashboard = { id: uuidv4(), title, pageLayoutId, position };
+    const dashboard = { id: uuidv4(), title, pageLayoutId, position };
 
-      await dashboardRepository.insert(dashboard);
+    await dashboardRepository.insert(dashboard);
 
-      return dashboard.id;
-    },
-  );
+    return dashboard.id;
+  }, authContext);
 };

--- a/packages/twenty-server/src/modules/dashboard/tools/get-dashboard.tool.ts
+++ b/packages/twenty-server/src/modules/dashboard/tools/get-dashboard.tool.ts
@@ -27,7 +27,6 @@ export const createGetDashboardTool = (
 
       const dashboard =
         await deps.globalWorkspaceOrmManager.executeInWorkspaceContext(
-          authContext,
           async () => {
             const repo = await deps.globalWorkspaceOrmManager.getRepository(
               context.workspaceId,
@@ -37,6 +36,7 @@ export const createGetDashboardTool = (
 
             return repo.findOne({ where: { id: parameters.dashboardId } });
           },
+          authContext,
         );
 
       if (!isDefined(dashboard)) {

--- a/packages/twenty-server/src/modules/dashboard/tools/list-dashboards.tool.ts
+++ b/packages/twenty-server/src/modules/dashboard/tools/list-dashboards.tool.ts
@@ -30,7 +30,6 @@ export const createListDashboardsTool = (
 
       const dashboards =
         await deps.globalWorkspaceOrmManager.executeInWorkspaceContext(
-          authContext,
           async () => {
             const repo = await deps.globalWorkspaceOrmManager.getRepository(
               context.workspaceId,
@@ -40,6 +39,7 @@ export const createListDashboardsTool = (
 
             return repo.find({ take: limit, order: { position: 'ASC' } });
           },
+          authContext,
         );
 
       const dashboardList = dashboards.map((d) => ({

--- a/packages/twenty-server/src/modules/favorite-folder/listeners/favorite-folder.listener.ts
+++ b/packages/twenty-server/src/modules/favorite-folder/listeners/favorite-folder.listener.ts
@@ -25,22 +25,19 @@ export class FavoriteFolderDeletionListener {
     const workspaceId = payload.workspaceId;
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        for (const eventPayload of payload.events) {
-          const favoriteRepository =
-            await this.globalWorkspaceOrmManager.getRepository<FavoriteWorkspaceEntity>(
-              workspaceId,
-              'favorite',
-            );
-
-          await favoriteRepository.update(
-            { favoriteFolderId: eventPayload.recordId },
-            { deletedAt: new Date().toISOString() },
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      for (const eventPayload of payload.events) {
+        const favoriteRepository =
+          await this.globalWorkspaceOrmManager.getRepository<FavoriteWorkspaceEntity>(
+            workspaceId,
+            'favorite',
           );
-        }
-      },
-    );
+
+        await favoriteRepository.update(
+          { favoriteFolderId: eventPayload.recordId },
+          { deletedAt: new Date().toISOString() },
+        );
+      }
+    }, authContext);
   }
 }

--- a/packages/twenty-server/src/modules/messaging/blocklist-manager/jobs/messaging-blocklist-item-delete-messages.job.ts
+++ b/packages/twenty-server/src/modules/messaging/blocklist-manager/jobs/messaging-blocklist-item-delete-messages.job.ts
@@ -36,132 +36,129 @@ export class BlocklistItemDeleteMessagesJob {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const blocklistItemIds = data.events.map(
-          (eventPayload) => eventPayload.recordId,
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const blocklistItemIds = data.events.map(
+        (eventPayload) => eventPayload.recordId,
+      );
+
+      const blocklistRepository =
+        await this.globalWorkspaceOrmManager.getRepository<BlocklistWorkspaceEntity>(
+          workspaceId,
+          'blocklist',
         );
 
-        const blocklistRepository =
-          await this.globalWorkspaceOrmManager.getRepository<BlocklistWorkspaceEntity>(
-            workspaceId,
-            'blocklist',
-          );
+      const blocklist = await blocklistRepository.find({
+        where: {
+          id: Any(blocklistItemIds),
+        },
+      });
 
-        const blocklist = await blocklistRepository.find({
-          where: {
-            id: Any(blocklistItemIds),
+      const handlesToDeleteByWorkspaceMemberIdMap = blocklist.reduce(
+        (acc, blocklistItem) => {
+          const { handle, workspaceMemberId } = blocklistItem;
+
+          if (!acc.has(workspaceMemberId)) {
+            acc.set(workspaceMemberId, []);
+          }
+
+          if (!isDefined(handle)) {
+            return acc;
+          }
+
+          acc.get(workspaceMemberId)?.push(handle);
+
+          return acc;
+        },
+        new Map<string, string[]>(),
+      );
+
+      const messageChannelRepository =
+        await this.globalWorkspaceOrmManager.getRepository<MessageChannelWorkspaceEntity>(
+          workspaceId,
+          'messageChannel',
+        );
+
+      const messageChannelMessageAssociationRepository =
+        await this.globalWorkspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
+          workspaceId,
+          'messageChannelMessageAssociation',
+        );
+
+      for (const workspaceMemberId of handlesToDeleteByWorkspaceMemberIdMap.keys()) {
+        const handles =
+          handlesToDeleteByWorkspaceMemberIdMap.get(workspaceMemberId);
+
+        if (!handles) {
+          continue;
+        }
+
+        const rolesToDelete = [
+          MessageParticipantRole.FROM,
+          MessageParticipantRole.TO,
+        ] as const;
+
+        const messageChannels = await messageChannelRepository.find({
+          select: {
+            id: true,
+            handle: true,
+            connectedAccount: {
+              handleAliases: true,
+            },
           },
+          where: {
+            connectedAccount: {
+              accountOwnerId: workspaceMemberId,
+            },
+          },
+          relations: ['connectedAccount'],
         });
 
-        const handlesToDeleteByWorkspaceMemberIdMap = blocklist.reduce(
-          (acc, blocklistItem) => {
-            const { handle, workspaceMemberId } = blocklistItem;
+        for (const messageChannel of messageChannels) {
+          const messageChannelHandles = [messageChannel.handle];
 
-            if (!acc.has(workspaceMemberId)) {
-              acc.set(workspaceMemberId, []);
-            }
+          if (messageChannel.connectedAccount.handleAliases) {
+            messageChannelHandles.push(
+              ...messageChannel.connectedAccount.handleAliases.split(','),
+            );
+          }
 
-            if (!isDefined(handle)) {
-              return acc;
-            }
+          const handleConditions = handles.map((handle) => {
+            const isHandleDomain = handle.startsWith('@');
 
-            acc.get(workspaceMemberId)?.push(handle);
+            return isHandleDomain
+              ? {
+                  handle: And(
+                    Or(ILike(`%${handle}`), ILike(`%.${handle.slice(1)}`)),
+                    Not(In(messageChannelHandles)),
+                  ),
+                  role: In(rolesToDelete),
+                }
+              : { handle, role: In(rolesToDelete) };
+          });
 
-            return acc;
-          },
-          new Map<string, string[]>(),
-        );
+          const messageChannelMessageAssociationsToDelete =
+            await messageChannelMessageAssociationRepository.find({
+              where: {
+                messageChannelId: messageChannel.id,
+                message: {
+                  messageParticipants: handleConditions,
+                },
+              },
+            });
 
-        const messageChannelRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageChannelWorkspaceEntity>(
-            workspaceId,
-            'messageChannel',
-          );
-
-        const messageChannelMessageAssociationRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
-            workspaceId,
-            'messageChannelMessageAssociation',
-          );
-
-        for (const workspaceMemberId of handlesToDeleteByWorkspaceMemberIdMap.keys()) {
-          const handles =
-            handlesToDeleteByWorkspaceMemberIdMap.get(workspaceMemberId);
-
-          if (!handles) {
+          if (messageChannelMessageAssociationsToDelete.length === 0) {
             continue;
           }
 
-          const rolesToDelete = [
-            MessageParticipantRole.FROM,
-            MessageParticipantRole.TO,
-          ] as const;
-
-          const messageChannels = await messageChannelRepository.find({
-            select: {
-              id: true,
-              handle: true,
-              connectedAccount: {
-                handleAliases: true,
-              },
-            },
-            where: {
-              connectedAccount: {
-                accountOwnerId: workspaceMemberId,
-              },
-            },
-            relations: ['connectedAccount'],
-          });
-
-          for (const messageChannel of messageChannels) {
-            const messageChannelHandles = [messageChannel.handle];
-
-            if (messageChannel.connectedAccount.handleAliases) {
-              messageChannelHandles.push(
-                ...messageChannel.connectedAccount.handleAliases.split(','),
-              );
-            }
-
-            const handleConditions = handles.map((handle) => {
-              const isHandleDomain = handle.startsWith('@');
-
-              return isHandleDomain
-                ? {
-                    handle: And(
-                      Or(ILike(`%${handle}`), ILike(`%.${handle.slice(1)}`)),
-                      Not(In(messageChannelHandles)),
-                    ),
-                    role: In(rolesToDelete),
-                  }
-                : { handle, role: In(rolesToDelete) };
-            });
-
-            const messageChannelMessageAssociationsToDelete =
-              await messageChannelMessageAssociationRepository.find({
-                where: {
-                  messageChannelId: messageChannel.id,
-                  message: {
-                    messageParticipants: handleConditions,
-                  },
-                },
-              });
-
-            if (messageChannelMessageAssociationsToDelete.length === 0) {
-              continue;
-            }
-
-            await messageChannelMessageAssociationRepository.delete(
-              messageChannelMessageAssociationsToDelete.map(({ id }) => id),
-            );
-          }
+          await messageChannelMessageAssociationRepository.delete(
+            messageChannelMessageAssociationsToDelete.map(({ id }) => id),
+          );
         }
+      }
 
-        await this.threadCleanerService.cleanOrphanMessagesAndThreads(
-          workspaceId,
-        );
-      },
-    );
+      await this.threadCleanerService.cleanOrphanMessagesAndThreads(
+        workspaceId,
+      );
+    }, authContext);
   }
 }

--- a/packages/twenty-server/src/modules/messaging/common/query-hooks/message/apply-messages-visibility-restrictions.service.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/common/query-hooks/message/apply-messages-visibility-restrictions.service.spec.ts
@@ -56,7 +56,7 @@ describe('ApplyMessagesVisibilityRestrictionsService', () => {
     }),
     executeInWorkspaceContext: jest
       .fn()
-      .mockImplementation((_authContext: any, fn: () => any) => fn()),
+      .mockImplementation((fn: () => any, _authContext?: any) => fn()),
   };
 
   beforeEach(async () => {

--- a/packages/twenty-server/src/modules/messaging/common/query-hooks/message/apply-messages-visibility-restrictions.service.ts
+++ b/packages/twenty-server/src/modules/messaging/common/query-hooks/message/apply-messages-visibility-restrictions.service.ts
@@ -28,7 +28,6 @@ export class ApplyMessagesVisibilityRestrictionsService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const messageChannelMessageAssociationRepository =
           await this.globalWorkspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
@@ -128,6 +127,7 @@ export class ApplyMessagesVisibilityRestrictionsService {
 
         return messages;
       },
+      authContext,
     );
   }
 }

--- a/packages/twenty-server/src/modules/messaging/common/query-hooks/message/message-channel-update-one.pre-query.hook.ts
+++ b/packages/twenty-server/src/modules/messaging/common/query-hooks/message/message-channel-update-one.pre-query.hook.ts
@@ -56,7 +56,6 @@ export class MessageChannelUpdateOnePreQueryHook
     const systemAuthContext = buildSystemAuthContext(workspace.id);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      systemAuthContext,
       async () => {
         const messageChannelRepository =
           await this.globalWorkspaceOrmManager.getRepository<MessageChannelWorkspaceEntity>(
@@ -144,6 +143,7 @@ export class MessageChannelUpdateOnePreQueryHook
 
         return payload;
       },
+      systemAuthContext,
     );
   }
 }

--- a/packages/twenty-server/src/modules/messaging/common/services/message-channel-sync-status.service.ts
+++ b/packages/twenty-server/src/modules/messaging/common/services/message-channel-sync-status.service.ts
@@ -44,21 +44,18 @@ export class MessageChannelSyncStatusService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const messageChannelRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageChannelWorkspaceEntity>(
-            workspaceId,
-            'messageChannel',
-          );
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const messageChannelRepository =
+        await this.globalWorkspaceOrmManager.getRepository<MessageChannelWorkspaceEntity>(
+          workspaceId,
+          'messageChannel',
+        );
 
-        await messageChannelRepository.update(messageChannelIds, {
-          syncStage: MessageChannelSyncStage.MESSAGE_LIST_FETCH_PENDING,
-          ...(!preserveSyncStageStartedAt ? { syncStageStartedAt: null } : {}),
-        });
-      },
-    );
+      await messageChannelRepository.update(messageChannelIds, {
+        syncStage: MessageChannelSyncStage.MESSAGE_LIST_FETCH_PENDING,
+        ...(!preserveSyncStageStartedAt ? { syncStageStartedAt: null } : {}),
+      });
+    }, authContext);
   }
 
   public async markAsMessagesImportPending(
@@ -72,21 +69,18 @@ export class MessageChannelSyncStatusService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const messageChannelRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageChannelWorkspaceEntity>(
-            workspaceId,
-            'messageChannel',
-          );
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const messageChannelRepository =
+        await this.globalWorkspaceOrmManager.getRepository<MessageChannelWorkspaceEntity>(
+          workspaceId,
+          'messageChannel',
+        );
 
-        await messageChannelRepository.update(messageChannelIds, {
-          syncStage: MessageChannelSyncStage.MESSAGES_IMPORT_PENDING,
-          ...(!preserveSyncStageStartedAt ? { syncStageStartedAt: null } : {}),
-        });
-      },
-    );
+      await messageChannelRepository.update(messageChannelIds, {
+        syncStage: MessageChannelSyncStage.MESSAGES_IMPORT_PENDING,
+        ...(!preserveSyncStageStartedAt ? { syncStageStartedAt: null } : {}),
+      });
+    }, authContext);
   }
 
   public async resetAndMarkAsMessagesListFetchPending(
@@ -105,37 +99,34 @@ export class MessageChannelSyncStatusService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const messageChannelRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageChannelWorkspaceEntity>(
-            workspaceId,
-            'messageChannel',
-          );
-
-        const messageFolderRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageFolderWorkspaceEntity>(
-            workspaceId,
-            'messageFolder',
-          );
-
-        await messageChannelRepository.update(messageChannelIds, {
-          syncCursor: '',
-          syncStageStartedAt: null,
-          throttleFailureCount: 0,
-          pendingGroupEmailsAction: MessageChannelPendingGroupEmailsAction.NONE,
-        });
-
-        await messageFolderRepository.update(
-          { messageChannelId: In(messageChannelIds) },
-          {
-            syncCursor: '',
-            pendingSyncAction: MessageFolderPendingSyncAction.NONE,
-          },
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const messageChannelRepository =
+        await this.globalWorkspaceOrmManager.getRepository<MessageChannelWorkspaceEntity>(
+          workspaceId,
+          'messageChannel',
         );
-      },
-    );
+
+      const messageFolderRepository =
+        await this.globalWorkspaceOrmManager.getRepository<MessageFolderWorkspaceEntity>(
+          workspaceId,
+          'messageFolder',
+        );
+
+      await messageChannelRepository.update(messageChannelIds, {
+        syncCursor: '',
+        syncStageStartedAt: null,
+        throttleFailureCount: 0,
+        pendingGroupEmailsAction: MessageChannelPendingGroupEmailsAction.NONE,
+      });
+
+      await messageFolderRepository.update(
+        { messageChannelId: In(messageChannelIds) },
+        {
+          syncCursor: '',
+          pendingSyncAction: MessageFolderPendingSyncAction.NONE,
+        },
+      );
+    }, authContext);
 
     await this.markAsMessagesListFetchPending(messageChannelIds, workspaceId);
   }
@@ -150,20 +141,17 @@ export class MessageChannelSyncStatusService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const messageChannelRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageChannelWorkspaceEntity>(
-            workspaceId,
-            'messageChannel',
-          );
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const messageChannelRepository =
+        await this.globalWorkspaceOrmManager.getRepository<MessageChannelWorkspaceEntity>(
+          workspaceId,
+          'messageChannel',
+        );
 
-        await messageChannelRepository.update(messageChannelIds, {
-          syncStageStartedAt: null,
-        });
-      },
-    );
+      await messageChannelRepository.update(messageChannelIds, {
+        syncStageStartedAt: null,
+      });
+    }, authContext);
   }
 
   public async markAsMessagesListFetchScheduled(
@@ -176,22 +164,19 @@ export class MessageChannelSyncStatusService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const messageChannelRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageChannelWorkspaceEntity>(
-            workspaceId,
-            'messageChannel',
-          );
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const messageChannelRepository =
+        await this.globalWorkspaceOrmManager.getRepository<MessageChannelWorkspaceEntity>(
+          workspaceId,
+          'messageChannel',
+        );
 
-        await messageChannelRepository.update(messageChannelIds, {
-          syncStage: MessageChannelSyncStage.MESSAGE_LIST_FETCH_SCHEDULED,
-          syncStatus: MessageChannelSyncStatus.ONGOING,
-          syncStageStartedAt: new Date().toISOString(),
-        });
-      },
-    );
+      await messageChannelRepository.update(messageChannelIds, {
+        syncStage: MessageChannelSyncStage.MESSAGE_LIST_FETCH_SCHEDULED,
+        syncStatus: MessageChannelSyncStatus.ONGOING,
+        syncStageStartedAt: new Date().toISOString(),
+      });
+    }, authContext);
   }
 
   public async markAsMessagesListFetchOngoing(
@@ -204,21 +189,18 @@ export class MessageChannelSyncStatusService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const messageChannelRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageChannelWorkspaceEntity>(
-            workspaceId,
-            'messageChannel',
-          );
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const messageChannelRepository =
+        await this.globalWorkspaceOrmManager.getRepository<MessageChannelWorkspaceEntity>(
+          workspaceId,
+          'messageChannel',
+        );
 
-        await messageChannelRepository.update(messageChannelIds, {
-          syncStage: MessageChannelSyncStage.MESSAGE_LIST_FETCH_ONGOING,
-          syncStatus: MessageChannelSyncStatus.ONGOING,
-        });
-      },
-    );
+      await messageChannelRepository.update(messageChannelIds, {
+        syncStage: MessageChannelSyncStage.MESSAGE_LIST_FETCH_ONGOING,
+        syncStatus: MessageChannelSyncStatus.ONGOING,
+      });
+    }, authContext);
   }
 
   public async markAsCompletedAndMarkAsMessagesListFetchPending(
@@ -231,24 +213,21 @@ export class MessageChannelSyncStatusService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const messageChannelRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageChannelWorkspaceEntity>(
-            workspaceId,
-            'messageChannel',
-          );
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const messageChannelRepository =
+        await this.globalWorkspaceOrmManager.getRepository<MessageChannelWorkspaceEntity>(
+          workspaceId,
+          'messageChannel',
+        );
 
-        await messageChannelRepository.update(messageChannelIds, {
-          syncStatus: MessageChannelSyncStatus.ACTIVE,
-          syncStage: MessageChannelSyncStage.MESSAGE_LIST_FETCH_PENDING,
-          throttleFailureCount: 0,
-          syncStageStartedAt: null,
-          syncedAt: new Date().toISOString(),
-        });
-      },
-    );
+      await messageChannelRepository.update(messageChannelIds, {
+        syncStatus: MessageChannelSyncStatus.ACTIVE,
+        syncStage: MessageChannelSyncStage.MESSAGE_LIST_FETCH_PENDING,
+        throttleFailureCount: 0,
+        syncStageStartedAt: null,
+        syncedAt: new Date().toISOString(),
+      });
+    }, authContext);
 
     await this.metricsService.batchIncrementCounter({
       key: MetricsKeys.MessageChannelSyncJobActive,
@@ -266,20 +245,17 @@ export class MessageChannelSyncStatusService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const messageChannelRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageChannelWorkspaceEntity>(
-            workspaceId,
-            'messageChannel',
-          );
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const messageChannelRepository =
+        await this.globalWorkspaceOrmManager.getRepository<MessageChannelWorkspaceEntity>(
+          workspaceId,
+          'messageChannel',
+        );
 
-        await messageChannelRepository.update(messageChannelIds, {
-          syncStage: MessageChannelSyncStage.MESSAGES_IMPORT_SCHEDULED,
-        });
-      },
-    );
+      await messageChannelRepository.update(messageChannelIds, {
+        syncStage: MessageChannelSyncStage.MESSAGES_IMPORT_SCHEDULED,
+      });
+    }, authContext);
   }
 
   public async markAsMessagesImportOngoing(
@@ -292,21 +268,18 @@ export class MessageChannelSyncStatusService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const messageChannelRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageChannelWorkspaceEntity>(
-            workspaceId,
-            'messageChannel',
-          );
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const messageChannelRepository =
+        await this.globalWorkspaceOrmManager.getRepository<MessageChannelWorkspaceEntity>(
+          workspaceId,
+          'messageChannel',
+        );
 
-        await messageChannelRepository.update(messageChannelIds, {
-          syncStage: MessageChannelSyncStage.MESSAGES_IMPORT_ONGOING,
-          syncStageStartedAt: new Date().toISOString(),
-        });
-      },
-    );
+      await messageChannelRepository.update(messageChannelIds, {
+        syncStage: MessageChannelSyncStage.MESSAGES_IMPORT_ONGOING,
+        syncStageStartedAt: new Date().toISOString(),
+      });
+    }, authContext);
   }
 
   public async markAsFailed(
@@ -322,64 +295,59 @@ export class MessageChannelSyncStatusService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const messageChannelRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageChannelWorkspaceEntity>(
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const messageChannelRepository =
+        await this.globalWorkspaceOrmManager.getRepository<MessageChannelWorkspaceEntity>(
+          workspaceId,
+          'messageChannel',
+        );
+
+      await messageChannelRepository.update(messageChannelIds, {
+        syncStage: MessageChannelSyncStage.FAILED,
+        syncStatus: syncStatus,
+      });
+
+      const metricsKey =
+        syncStatus === MessageChannelSyncStatus.FAILED_INSUFFICIENT_PERMISSIONS
+          ? MetricsKeys.MessageChannelSyncJobFailedInsufficientPermissions
+          : MetricsKeys.MessageChannelSyncJobFailedUnknown;
+
+      await this.metricsService.batchIncrementCounter({
+        key: metricsKey,
+        eventIds: messageChannelIds,
+      });
+
+      if (
+        syncStatus === MessageChannelSyncStatus.FAILED_INSUFFICIENT_PERMISSIONS
+      ) {
+        const connectedAccountRepository =
+          await this.globalWorkspaceOrmManager.getRepository<ConnectedAccountWorkspaceEntity>(
             workspaceId,
-            'messageChannel',
+            'connectedAccount',
           );
 
-        await messageChannelRepository.update(messageChannelIds, {
-          syncStage: MessageChannelSyncStage.FAILED,
-          syncStatus: syncStatus,
+        const messageChannels = await messageChannelRepository.find({
+          select: ['id', 'connectedAccountId'],
+          where: { id: Any(messageChannelIds) },
         });
 
-        const metricsKey =
-          syncStatus ===
-          MessageChannelSyncStatus.FAILED_INSUFFICIENT_PERMISSIONS
-            ? MetricsKeys.MessageChannelSyncJobFailedInsufficientPermissions
-            : MetricsKeys.MessageChannelSyncJobFailedUnknown;
+        const connectedAccountIds = messageChannels.map(
+          (messageChannel) => messageChannel.connectedAccountId,
+        );
 
-        await this.metricsService.batchIncrementCounter({
-          key: metricsKey,
-          eventIds: messageChannelIds,
-        });
+        await connectedAccountRepository.update(
+          { id: Any(connectedAccountIds) },
+          {
+            authFailedAt: new Date(),
+          },
+        );
 
-        if (
-          syncStatus ===
-          MessageChannelSyncStatus.FAILED_INSUFFICIENT_PERMISSIONS
-        ) {
-          const connectedAccountRepository =
-            await this.globalWorkspaceOrmManager.getRepository<ConnectedAccountWorkspaceEntity>(
-              workspaceId,
-              'connectedAccount',
-            );
-
-          const messageChannels = await messageChannelRepository.find({
-            select: ['id', 'connectedAccountId'],
-            where: { id: Any(messageChannelIds) },
-          });
-
-          const connectedAccountIds = messageChannels.map(
-            (messageChannel) => messageChannel.connectedAccountId,
-          );
-
-          await connectedAccountRepository.update(
-            { id: Any(connectedAccountIds) },
-            {
-              authFailedAt: new Date(),
-            },
-          );
-
-          await this.addToAccountsToReconnect(
-            messageChannels.map((messageChannel) => messageChannel.id),
-            workspaceId,
-          );
-        }
-      },
-    );
+        await this.addToAccountsToReconnect(
+          messageChannels.map((messageChannel) => messageChannel.id),
+          workspaceId,
+        );
+      }
+    }, authContext);
   }
 
   private async addToAccountsToReconnect(

--- a/packages/twenty-server/src/modules/messaging/message-cleaner/services/messaging-message-cleaner.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-cleaner/services/messaging-message-cleaner.service.ts
@@ -29,197 +29,191 @@ export class MessagingMessageCleanerService {
   }) {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const messageRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageWorkspaceEntity>(
-            workspaceId,
-            'message',
-          );
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const messageRepository =
+        await this.globalWorkspaceOrmManager.getRepository<MessageWorkspaceEntity>(
+          workspaceId,
+          'message',
+        );
 
-        const messageChannelMessageAssociationRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
-            workspaceId,
-            'messageChannelMessageAssociation',
-          );
+      const messageChannelMessageAssociationRepository =
+        await this.globalWorkspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
+          workspaceId,
+          'messageChannelMessageAssociation',
+        );
 
-        const messageThreadRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageThreadWorkspaceEntity>(
-            workspaceId,
-            'messageThread',
-          );
+      const messageThreadRepository =
+        await this.globalWorkspaceOrmManager.getRepository<MessageThreadWorkspaceEntity>(
+          workspaceId,
+          'messageThread',
+        );
 
-        const messageExternalIdsChunks = chunk(messageExternalIds, 500);
+      const messageExternalIdsChunks = chunk(messageExternalIds, 500);
 
-        for (const messageExternalIdsChunk of messageExternalIdsChunks) {
-          const messageChannelMessageAssociationsToDelete =
-            await messageChannelMessageAssociationRepository.find({
-              where: {
-                messageExternalId: In(messageExternalIdsChunk),
-                messageChannelId,
-              },
-            });
-
-          if (messageChannelMessageAssociationsToDelete.length <= 0) {
-            continue;
-          }
-
-          await messageChannelMessageAssociationRepository.delete(
-            messageChannelMessageAssociationsToDelete.map(({ id }) => id),
-          );
-
-          this.logger.log(
-            `WorkspaceId: ${workspaceId} Deleting ${messageChannelMessageAssociationsToDelete.length} message channel message associations`,
-          );
-
-          const orphanMessages = await messageRepository.find({
+      for (const messageExternalIdsChunk of messageExternalIdsChunks) {
+        const messageChannelMessageAssociationsToDelete =
+          await messageChannelMessageAssociationRepository.find({
             where: {
-              id: In(
-                messageChannelMessageAssociationsToDelete.map(
-                  ({ messageId }) => messageId,
-                ),
-              ),
-              messageChannelMessageAssociations: {
-                id: IsNull(),
-              },
+              messageExternalId: In(messageExternalIdsChunk),
+              messageChannelId,
             },
           });
 
-          if (orphanMessages.length <= 0) {
-            continue;
-          }
-
-          this.logger.log(
-            `WorkspaceId: ${workspaceId} Deleting ${orphanMessages.length} orphan messages`,
-          );
-
-          await messageRepository.delete(orphanMessages.map(({ id }) => id));
-
-          const orphanMessageThreads = await messageThreadRepository.find({
-            where: {
-              id: In(
-                orphanMessages.map(({ messageThreadId }) => messageThreadId),
-              ),
-              messages: {
-                id: IsNull(),
-              },
-            },
-          });
-
-          if (orphanMessageThreads.length <= 0) {
-            continue;
-          }
-
-          this.logger.log(
-            `WorkspaceId: ${workspaceId} Deleting ${orphanMessageThreads.length} orphan message threads`,
-          );
-
-          await messageThreadRepository.delete(
-            orphanMessageThreads.map(({ id }) => id),
-          );
+        if (messageChannelMessageAssociationsToDelete.length <= 0) {
+          continue;
         }
-      },
-    );
+
+        await messageChannelMessageAssociationRepository.delete(
+          messageChannelMessageAssociationsToDelete.map(({ id }) => id),
+        );
+
+        this.logger.log(
+          `WorkspaceId: ${workspaceId} Deleting ${messageChannelMessageAssociationsToDelete.length} message channel message associations`,
+        );
+
+        const orphanMessages = await messageRepository.find({
+          where: {
+            id: In(
+              messageChannelMessageAssociationsToDelete.map(
+                ({ messageId }) => messageId,
+              ),
+            ),
+            messageChannelMessageAssociations: {
+              id: IsNull(),
+            },
+          },
+        });
+
+        if (orphanMessages.length <= 0) {
+          continue;
+        }
+
+        this.logger.log(
+          `WorkspaceId: ${workspaceId} Deleting ${orphanMessages.length} orphan messages`,
+        );
+
+        await messageRepository.delete(orphanMessages.map(({ id }) => id));
+
+        const orphanMessageThreads = await messageThreadRepository.find({
+          where: {
+            id: In(
+              orphanMessages.map(({ messageThreadId }) => messageThreadId),
+            ),
+            messages: {
+              id: IsNull(),
+            },
+          },
+        });
+
+        if (orphanMessageThreads.length <= 0) {
+          continue;
+        }
+
+        this.logger.log(
+          `WorkspaceId: ${workspaceId} Deleting ${orphanMessageThreads.length} orphan message threads`,
+        );
+
+        await messageThreadRepository.delete(
+          orphanMessageThreads.map(({ id }) => id),
+        );
+      }
+    }, authContext);
   }
 
   public async cleanOrphanMessagesAndThreads(workspaceId: string) {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const messageThreadRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageThreadWorkspaceEntity>(
-            workspaceId,
-            'messageThread',
-          );
-
-        const messageRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageWorkspaceEntity>(
-            workspaceId,
-            'message',
-          );
-
-        const workspaceDataSource =
-          await this.globalWorkspaceOrmManager.getGlobalWorkspaceDataSource();
-
-        await workspaceDataSource.transaction(
-          async (transactionManager: WorkspaceEntityManager) => {
-            await deleteUsingPagination(
-              workspaceId,
-              500,
-              async (
-                limit: number,
-                offset: number,
-                _workspaceId: string,
-                transactionManager: WorkspaceEntityManager,
-              ) => {
-                const nonAssociatedMessages = await messageRepository.find(
-                  {
-                    where: {
-                      messageChannelMessageAssociations: {
-                        id: IsNull(),
-                      },
-                    },
-                    take: limit,
-                    skip: offset,
-                    relations: ['messageChannelMessageAssociations'],
-                  },
-                  transactionManager,
-                );
-
-                return nonAssociatedMessages.map(({ id }) => id);
-              },
-              async (
-                ids: string[],
-                workspaceId: string,
-                transactionManager?: WorkspaceEntityManager,
-              ) => {
-                this.logger.log(
-                  `WorkspaceId: ${workspaceId} Deleting ${ids.length} messages from message cleaner`,
-                );
-                await messageRepository.delete(ids, transactionManager);
-              },
-              transactionManager,
-            );
-
-            await deleteUsingPagination(
-              workspaceId,
-              500,
-              async (
-                limit: number,
-                offset: number,
-                _workspaceId: string,
-                transactionManager?: WorkspaceEntityManager,
-              ) => {
-                const orphanThreads = await messageThreadRepository.find(
-                  {
-                    where: {
-                      messages: {
-                        id: IsNull(),
-                      },
-                    },
-                    take: limit,
-                    skip: offset,
-                  },
-                  transactionManager,
-                );
-
-                return orphanThreads.map(({ id }) => id);
-              },
-              async (
-                ids: string[],
-                _workspaceId: string,
-                transactionManager?: WorkspaceEntityManager,
-              ) => {
-                await messageThreadRepository.delete(ids, transactionManager);
-              },
-              transactionManager,
-            );
-          },
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const messageThreadRepository =
+        await this.globalWorkspaceOrmManager.getRepository<MessageThreadWorkspaceEntity>(
+          workspaceId,
+          'messageThread',
         );
-      },
-    );
+
+      const messageRepository =
+        await this.globalWorkspaceOrmManager.getRepository<MessageWorkspaceEntity>(
+          workspaceId,
+          'message',
+        );
+
+      const workspaceDataSource =
+        await this.globalWorkspaceOrmManager.getGlobalWorkspaceDataSource();
+
+      await workspaceDataSource.transaction(
+        async (transactionManager: WorkspaceEntityManager) => {
+          await deleteUsingPagination(
+            workspaceId,
+            500,
+            async (
+              limit: number,
+              offset: number,
+              _workspaceId: string,
+              transactionManager: WorkspaceEntityManager,
+            ) => {
+              const nonAssociatedMessages = await messageRepository.find(
+                {
+                  where: {
+                    messageChannelMessageAssociations: {
+                      id: IsNull(),
+                    },
+                  },
+                  take: limit,
+                  skip: offset,
+                  relations: ['messageChannelMessageAssociations'],
+                },
+                transactionManager,
+              );
+
+              return nonAssociatedMessages.map(({ id }) => id);
+            },
+            async (
+              ids: string[],
+              workspaceId: string,
+              transactionManager?: WorkspaceEntityManager,
+            ) => {
+              this.logger.log(
+                `WorkspaceId: ${workspaceId} Deleting ${ids.length} messages from message cleaner`,
+              );
+              await messageRepository.delete(ids, transactionManager);
+            },
+            transactionManager,
+          );
+
+          await deleteUsingPagination(
+            workspaceId,
+            500,
+            async (
+              limit: number,
+              offset: number,
+              _workspaceId: string,
+              transactionManager?: WorkspaceEntityManager,
+            ) => {
+              const orphanThreads = await messageThreadRepository.find(
+                {
+                  where: {
+                    messages: {
+                      id: IsNull(),
+                    },
+                  },
+                  take: limit,
+                  skip: offset,
+                },
+                transactionManager,
+              );
+
+              return orphanThreads.map(({ id }) => id);
+            },
+            async (
+              ids: string[],
+              _workspaceId: string,
+              transactionManager?: WorkspaceEntityManager,
+            ) => {
+              await messageThreadRepository.delete(ids, transactionManager);
+            },
+            transactionManager,
+          );
+        },
+      );
+    }, authContext);
   }
 }

--- a/packages/twenty-server/src/modules/messaging/message-folder-manager/services/sync-message-folders.service.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-folder-manager/services/sync-message-folders.service.spec.ts
@@ -126,7 +126,9 @@ describe('SyncMessageFoldersService', () => {
           useValue: {
             executeInWorkspaceContext: jest
               .fn()
-              .mockImplementation((_, callback) => callback()),
+              .mockImplementation((callback: () => any, _authContext?: any) =>
+                callback(),
+              ),
             getRepository: jest.fn().mockResolvedValue(mockRepository),
             getDataSourceForWorkspace: jest
               .fn()

--- a/packages/twenty-server/src/modules/messaging/message-folder-manager/services/sync-message-folders.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-folder-manager/services/sync-message-folders.service.ts
@@ -133,7 +133,6 @@ export class SyncMessageFoldersService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const messageFolderRepository =
           await this.globalWorkspaceOrmManager.getRepository<MessageFolderWorkspaceEntity>(
@@ -188,6 +187,7 @@ export class SyncMessageFoldersService {
           },
         );
       },
+      authContext,
     );
   }
 }

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/jobs/messaging-ongoing-stale.job.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/jobs/messaging-ongoing-stale.job.ts
@@ -35,63 +35,60 @@ export class MessagingOngoingStaleJob {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const messageChannelRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageChannelWorkspaceEntity>(
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const messageChannelRepository =
+        await this.globalWorkspaceOrmManager.getRepository<MessageChannelWorkspaceEntity>(
+          workspaceId,
+          'messageChannel',
+        );
+
+      const messageChannels = await messageChannelRepository.find({
+        where: {
+          syncStage: In([
+            MessageChannelSyncStage.MESSAGES_IMPORT_ONGOING,
+            MessageChannelSyncStage.MESSAGE_LIST_FETCH_ONGOING,
+            MessageChannelSyncStage.MESSAGES_IMPORT_SCHEDULED,
+            MessageChannelSyncStage.MESSAGE_LIST_FETCH_SCHEDULED,
+          ]),
+        },
+      });
+
+      for (const messageChannel of messageChannels) {
+        if (
+          messageChannel.syncStageStartedAt &&
+          isSyncStale(messageChannel.syncStageStartedAt)
+        ) {
+          await this.messageChannelSyncStatusService.resetSyncStageStartedAt(
+            [messageChannel.id],
             workspaceId,
-            'messageChannel',
           );
 
-        const messageChannels = await messageChannelRepository.find({
-          where: {
-            syncStage: In([
-              MessageChannelSyncStage.MESSAGES_IMPORT_ONGOING,
-              MessageChannelSyncStage.MESSAGE_LIST_FETCH_ONGOING,
-              MessageChannelSyncStage.MESSAGES_IMPORT_SCHEDULED,
-              MessageChannelSyncStage.MESSAGE_LIST_FETCH_SCHEDULED,
-            ]),
-          },
-        });
-
-        for (const messageChannel of messageChannels) {
-          if (
-            messageChannel.syncStageStartedAt &&
-            isSyncStale(messageChannel.syncStageStartedAt)
-          ) {
-            await this.messageChannelSyncStatusService.resetSyncStageStartedAt(
-              [messageChannel.id],
-              workspaceId,
-            );
-
-            switch (messageChannel.syncStage) {
-              case MessageChannelSyncStage.MESSAGE_LIST_FETCH_ONGOING:
-              case MessageChannelSyncStage.MESSAGE_LIST_FETCH_SCHEDULED:
-                this.logger.log(
-                  `Sync for message channel ${messageChannel.id} and workspace ${workspaceId} is stale. Setting sync stage to MESSAGE_LIST_FETCH_PENDING`,
-                );
-                await this.messageChannelSyncStatusService.markAsMessagesListFetchPending(
-                  [messageChannel.id],
-                  workspaceId,
-                );
-                break;
-              case MessageChannelSyncStage.MESSAGES_IMPORT_ONGOING:
-              case MessageChannelSyncStage.MESSAGES_IMPORT_SCHEDULED:
-                this.logger.log(
-                  `Sync for message channel ${messageChannel.id} and workspace ${workspaceId} is stale. Setting sync stage to MESSAGES_IMPORT_PENDING`,
-                );
-                await this.messageChannelSyncStatusService.markAsMessagesImportPending(
-                  [messageChannel.id],
-                  workspaceId,
-                );
-                break;
-              default:
-                break;
-            }
+          switch (messageChannel.syncStage) {
+            case MessageChannelSyncStage.MESSAGE_LIST_FETCH_ONGOING:
+            case MessageChannelSyncStage.MESSAGE_LIST_FETCH_SCHEDULED:
+              this.logger.log(
+                `Sync for message channel ${messageChannel.id} and workspace ${workspaceId} is stale. Setting sync stage to MESSAGE_LIST_FETCH_PENDING`,
+              );
+              await this.messageChannelSyncStatusService.markAsMessagesListFetchPending(
+                [messageChannel.id],
+                workspaceId,
+              );
+              break;
+            case MessageChannelSyncStage.MESSAGES_IMPORT_ONGOING:
+            case MessageChannelSyncStage.MESSAGES_IMPORT_SCHEDULED:
+              this.logger.log(
+                `Sync for message channel ${messageChannel.id} and workspace ${workspaceId} is stale. Setting sync stage to MESSAGES_IMPORT_PENDING`,
+              );
+              await this.messageChannelSyncStatusService.markAsMessagesImportPending(
+                [messageChannel.id],
+                workspaceId,
+              );
+              break;
+            default:
+              break;
           }
         }
-      },
-    );
+      }
+    }, authContext);
   }
 }

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/__tests__/messaging-message-list-fetch.service.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/__tests__/messaging-message-list-fetch.service.spec.ts
@@ -213,7 +213,7 @@ describe('MessagingMessageListFetchService', () => {
             executeInWorkspaceContext: jest
               .fn()
 
-              .mockImplementation((_authContext: any, fn: () => any) => fn()),
+              .mockImplementation((fn: () => any, _authContext?: any) => fn()),
             getRepository: jest.fn().mockImplementation((workspaceId, name) => {
               if (name === 'messageChannel') {
                 return {

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/__tests__/messaging-messages-import.service.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/__tests__/messaging-messages-import.service.spec.ts
@@ -113,7 +113,7 @@ describe('MessagingMessagesImportService', () => {
           }),
           executeInWorkspaceContext: jest
             .fn()
-            .mockImplementation((_authContext: any, fn: () => any) => fn()),
+            .mockImplementation((fn: () => any, _authContext?: any) => fn()),
         },
       },
       {

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-cursor.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-cursor.service.ts
@@ -19,55 +19,52 @@ export class MessagingCursorService {
   ) {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const messageChannelRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageChannelWorkspaceEntity>(
-            workspaceId,
-            'messageChannel',
-          );
-        const folderRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageFolderWorkspaceEntity>(
-            workspaceId,
-            'messageFolder',
-          );
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const messageChannelRepository =
+        await this.globalWorkspaceOrmManager.getRepository<MessageChannelWorkspaceEntity>(
+          workspaceId,
+          'messageChannel',
+        );
+      const folderRepository =
+        await this.globalWorkspaceOrmManager.getRepository<MessageFolderWorkspaceEntity>(
+          workspaceId,
+          'messageFolder',
+        );
 
-        if (!folderId) {
-          await messageChannelRepository.update(
-            {
-              id: messageChannel.id,
-            },
-            {
-              throttleFailureCount: 0,
-              syncStageStartedAt: null,
-              syncCursor:
-                !messageChannel.syncCursor ||
-                nextSyncCursor > messageChannel.syncCursor
-                  ? nextSyncCursor
-                  : messageChannel.syncCursor,
-            },
-          );
-        } else {
-          await folderRepository.update(
-            {
-              id: folderId,
-            },
-            {
-              syncCursor: nextSyncCursor,
-            },
-          );
-          await messageChannelRepository.update(
-            {
-              id: messageChannel.id,
-            },
-            {
-              throttleFailureCount: 0,
-              syncStageStartedAt: null,
-            },
-          );
-        }
-      },
-    );
+      if (!folderId) {
+        await messageChannelRepository.update(
+          {
+            id: messageChannel.id,
+          },
+          {
+            throttleFailureCount: 0,
+            syncStageStartedAt: null,
+            syncCursor:
+              !messageChannel.syncCursor ||
+              nextSyncCursor > messageChannel.syncCursor
+                ? nextSyncCursor
+                : messageChannel.syncCursor,
+          },
+        );
+      } else {
+        await folderRepository.update(
+          {
+            id: folderId,
+          },
+          {
+            syncCursor: nextSyncCursor,
+          },
+        );
+        await messageChannelRepository.update(
+          {
+            id: messageChannel.id,
+          },
+          {
+            throttleFailureCount: 0,
+            syncStageStartedAt: null,
+          },
+        );
+      }
+    }, authContext);
   }
 }

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-delete-group-email-messages.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-delete-group-email-messages.service.ts
@@ -41,7 +41,6 @@ export class MessagingDeleteGroupEmailMessagesService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const messageChannelMessageAssociationRepository =
           await this.globalWorkspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
@@ -146,6 +145,7 @@ export class MessagingDeleteGroupEmailMessagesService {
 
         return totalDeletedCount;
       },
+      authContext,
     );
   }
 }

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-import-exception-handler.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-import-exception-handler.service.ts
@@ -150,24 +150,21 @@ export class MessageImportExceptionHandlerService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const messageChannelRepository =
-          await this.globalWorkspaceOrmManager.getRepository<MessageChannelWorkspaceEntity>(
-            workspaceId,
-            'messageChannel',
-          );
-
-        await messageChannelRepository.increment(
-          { id: messageChannel.id },
-          'throttleFailureCount',
-          1,
-          undefined,
-          ['throttleFailureCount', 'id'],
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const messageChannelRepository =
+        await this.globalWorkspaceOrmManager.getRepository<MessageChannelWorkspaceEntity>(
+          workspaceId,
+          'messageChannel',
         );
-      },
-    );
+
+      await messageChannelRepository.increment(
+        { id: messageChannel.id },
+        'throttleFailureCount',
+        1,
+        undefined,
+        ['throttleFailureCount', 'id'],
+      );
+    }, authContext);
 
     switch (syncStep) {
       case MessageImportSyncStep.MESSAGE_LIST_FETCH:

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-message-list-fetch.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-message-list-fetch.service.ts
@@ -58,254 +58,250 @@ export class MessagingMessageListFetchService {
   ) {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        try {
-          const pendingGroupEmailActionsProcessed =
-            await this.processPendingGroupEmailActions(
-              messageChannel,
-              workspaceId,
-            );
-
-          const pendingFolderActionsProcessed =
-            await this.processPendingFolderActions(messageChannel, workspaceId);
-
-          await this.messageChannelSyncStatusService.markAsMessagesListFetchOngoing(
-            [messageChannel.id],
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      try {
+        const pendingGroupEmailActionsProcessed =
+          await this.processPendingGroupEmailActions(
+            messageChannel,
             workspaceId,
           );
 
-          this.logger.log(
-            `messageChannelId: ${messageChannel.id} Processing message list fetch`,
+        const pendingFolderActionsProcessed =
+          await this.processPendingFolderActions(messageChannel, workspaceId);
+
+        await this.messageChannelSyncStatusService.markAsMessagesListFetchOngoing(
+          [messageChannel.id],
+          workspaceId,
+        );
+
+        this.logger.log(
+          `messageChannelId: ${messageChannel.id} Processing message list fetch`,
+        );
+
+        const messageChannelRepository =
+          await this.globalWorkspaceOrmManager.getRepository<MessageChannelWorkspaceEntity>(
+            workspaceId,
+            'messageChannel',
           );
 
-          const messageChannelRepository =
-            await this.globalWorkspaceOrmManager.getRepository<MessageChannelWorkspaceEntity>(
+        const freshMessageChannel =
+          pendingGroupEmailActionsProcessed || pendingFolderActionsProcessed
+            ? await messageChannelRepository.findOne({
+                where: {
+                  id: messageChannel.id,
+                },
+                relations: ['connectedAccount', 'messageFolders'],
+              })
+            : messageChannel;
+
+        if (!isDefined(freshMessageChannel)) {
+          this.logger.error(
+            `error processing message list fetch: messageChannelId: ${messageChannel.id} Message channel not found`,
+          );
+
+          return;
+        }
+
+        const { accessToken, refreshToken } =
+          await this.messagingAccountAuthenticationService.validateAndRefreshConnectedAccountAuthentication(
+            {
+              connectedAccount: freshMessageChannel.connectedAccount,
               workspaceId,
-              'messageChannel',
-            );
-
-          const freshMessageChannel =
-            pendingGroupEmailActionsProcessed || pendingFolderActionsProcessed
-              ? await messageChannelRepository.findOne({
-                  where: {
-                    id: messageChannel.id,
-                  },
-                  relations: ['connectedAccount', 'messageFolders'],
-                })
-              : messageChannel;
-
-          if (!isDefined(freshMessageChannel)) {
-            this.logger.error(
-              `error processing message list fetch: messageChannelId: ${messageChannel.id} Message channel not found`,
-            );
-
-            return;
-          }
-
-          const { accessToken, refreshToken } =
-            await this.messagingAccountAuthenticationService.validateAndRefreshConnectedAccountAuthentication(
-              {
-                connectedAccount: freshMessageChannel.connectedAccount,
-                workspaceId,
-                messageChannelId: freshMessageChannel.id,
-              },
-            );
-
-          const messageChannelWithFreshTokens = {
-            ...freshMessageChannel,
-            connectedAccount: {
-              ...freshMessageChannel.connectedAccount,
-              accessToken,
-              refreshToken,
+              messageChannelId: freshMessageChannel.id,
             },
-          };
+          );
 
-          const messageFolders =
-            await this.syncMessageFoldersService.syncMessageFolders({
-              messageChannel: messageChannelWithFreshTokens,
-              workspaceId,
+        const messageChannelWithFreshTokens = {
+          ...freshMessageChannel,
+          connectedAccount: {
+            ...freshMessageChannel.connectedAccount,
+            accessToken,
+            refreshToken,
+          },
+        };
+
+        const messageFolders =
+          await this.syncMessageFoldersService.syncMessageFolders({
+            messageChannel: messageChannelWithFreshTokens,
+            workspaceId,
+          });
+
+        const messageFoldersToSync = messageFolders.filter(
+          (folder) =>
+            folder.pendingSyncAction === MessageFolderPendingSyncAction.NONE,
+        );
+
+        const messageLists =
+          await this.messagingGetMessageListService.getMessageLists(
+            messageChannelWithFreshTokens,
+            messageFoldersToSync,
+          );
+
+        await this.cacheStorage.del(
+          `messages-to-import:${workspaceId}:${freshMessageChannel.id}`,
+        );
+
+        const messageExternalIds = messageLists.flatMap(
+          (messageList) => messageList.messageExternalIds,
+        );
+
+        const messageExternalIdsToDelete = messageLists.flatMap(
+          (messageList) => messageList.messageExternalIdsToDelete,
+        );
+
+        const isFullSync =
+          messageLists.every(
+            (messageList) => !isNonEmptyString(messageList.previousSyncCursor),
+          ) && !isNonEmptyString(freshMessageChannel.syncCursor);
+
+        let totalMessagesToImportCount = 0;
+
+        this.logger.log(
+          `messageChannelId: ${freshMessageChannel.id} Is full sync: ${isFullSync} and toImportCount: ${messageExternalIds.length}, toDeleteCount: ${messageExternalIdsToDelete.length}, cursors: ${messageLists.map(
+            (messageList) => {
+              messageList.nextSyncCursor;
+            },
+          )}`,
+        );
+
+        const messageChannelMessageAssociationRepository =
+          await this.globalWorkspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
+            workspaceId,
+            'messageChannelMessageAssociation',
+          );
+
+        const messageExternalIdsChunks = chunk(messageExternalIds, 200);
+
+        for (const [
+          index,
+          messageExternalIdsChunk,
+        ] of messageExternalIdsChunks.entries()) {
+          const existingMessageChannelMessageAssociations =
+            await messageChannelMessageAssociationRepository.find({
+              where: {
+                messageChannelId: freshMessageChannel.id,
+                messageExternalId: In(messageExternalIdsChunk),
+              },
             });
 
-          const messageFoldersToSync = messageFolders.filter(
-            (folder) =>
-              folder.pendingSyncAction === MessageFolderPendingSyncAction.NONE,
-          );
-
-          const messageLists =
-            await this.messagingGetMessageListService.getMessageLists(
-              messageChannelWithFreshTokens,
-              messageFoldersToSync,
-            );
-
-          await this.cacheStorage.del(
-            `messages-to-import:${workspaceId}:${freshMessageChannel.id}`,
-          );
-
-          const messageExternalIds = messageLists.flatMap(
-            (messageList) => messageList.messageExternalIds,
-          );
-
-          const messageExternalIdsToDelete = messageLists.flatMap(
-            (messageList) => messageList.messageExternalIdsToDelete,
-          );
-
-          const isFullSync =
-            messageLists.every(
-              (messageList) =>
-                !isNonEmptyString(messageList.previousSyncCursor),
-            ) && !isNonEmptyString(freshMessageChannel.syncCursor);
-
-          let totalMessagesToImportCount = 0;
-
-          this.logger.log(
-            `messageChannelId: ${freshMessageChannel.id} Is full sync: ${isFullSync} and toImportCount: ${messageExternalIds.length}, toDeleteCount: ${messageExternalIdsToDelete.length}, cursors: ${messageLists.map(
-              (messageList) => {
-                messageList.nextSyncCursor;
-              },
-            )}`,
-          );
-
-          const messageChannelMessageAssociationRepository =
-            await this.globalWorkspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
-              workspaceId,
-              'messageChannelMessageAssociation',
-            );
-
-          const messageExternalIdsChunks = chunk(messageExternalIds, 200);
-
-          for (const [
-            index,
-            messageExternalIdsChunk,
-          ] of messageExternalIdsChunks.entries()) {
-            const existingMessageChannelMessageAssociations =
-              await messageChannelMessageAssociationRepository.find({
-                where: {
-                  messageChannelId: freshMessageChannel.id,
-                  messageExternalId: In(messageExternalIdsChunk),
-                },
-              });
-
-            const existingMessageChannelMessageAssociationsExternalIds =
-              existingMessageChannelMessageAssociations.map(
-                (messageChannelMessageAssociation) =>
-                  messageChannelMessageAssociation.messageExternalId,
-              );
-
-            const messageExternalIdsToImport = messageExternalIdsChunk.filter(
-              (messageExternalId) =>
-                !existingMessageChannelMessageAssociationsExternalIds.includes(
-                  messageExternalId,
-                ),
-            );
-
-            if (messageExternalIdsToImport.length) {
-              this.logger.log(
-                `messageChannelId: ${freshMessageChannel.id} Adding ${messageExternalIdsToImport.length} message external ids to import in batch ${index + 1}`,
-              );
-
-              totalMessagesToImportCount += messageExternalIdsToImport.length;
-
-              await this.cacheStorage.setAdd(
-                `messages-to-import:${workspaceId}:${messageChannelWithFreshTokens.id}`,
-                messageExternalIdsToImport,
-                ONE_WEEK_IN_MILLISECONDS,
-              );
-            }
-          }
-
-          for (const messageList of messageLists) {
-            const { nextSyncCursor, folderId } = messageList;
-
-            await this.messagingCursorService.updateCursor(
-              messageChannelWithFreshTokens,
-              nextSyncCursor,
-              workspaceId,
-              folderId,
-            );
-          }
-
-          const fullSyncMessageChannelMessageAssociationsToDelete = isFullSync
-            ? await this.computeFullSyncMessageChannelMessageAssociationsToDelete(
-                freshMessageChannel,
-                messageExternalIds,
-                workspaceId,
-              )
-            : [];
-
-          const allMessageExternalIdsToDelete = [
-            ...messageExternalIdsToDelete,
-            ...fullSyncMessageChannelMessageAssociationsToDelete.map(
+          const existingMessageChannelMessageAssociationsExternalIds =
+            existingMessageChannelMessageAssociations.map(
               (messageChannelMessageAssociation) =>
                 messageChannelMessageAssociation.messageExternalId,
-            ),
-          ];
+            );
 
-          if (allMessageExternalIdsToDelete.length) {
+          const messageExternalIdsToImport = messageExternalIdsChunk.filter(
+            (messageExternalId) =>
+              !existingMessageChannelMessageAssociationsExternalIds.includes(
+                messageExternalId,
+              ),
+          );
+
+          if (messageExternalIdsToImport.length) {
             this.logger.log(
-              `messageChannelId: ${freshMessageChannel.id} Deleting ${allMessageExternalIdsToDelete.length} message channel message associations`,
+              `messageChannelId: ${freshMessageChannel.id} Adding ${messageExternalIdsToImport.length} message external ids to import in batch ${index + 1}`,
             );
 
-            const toDeleteChunks = chunk(allMessageExternalIdsToDelete, 200);
+            totalMessagesToImportCount += messageExternalIdsToImport.length;
 
-            for (const [index, toDeleteChunk] of toDeleteChunks.entries()) {
-              this.logger.log(
-                `messageChannelId: ${freshMessageChannel.id} Deleting ${toDeleteChunk.length} message channel message associations in batch ${index + 1}`,
-              );
-
-              await this.messagingMessageCleanerService.deleteMessagesChannelMessageAssociationsAndRelatedOrphans(
-                {
-                  workspaceId,
-                  messageExternalIds: toDeleteChunk.filter(
-                    (messageExternalId) => isNonEmptyString(messageExternalId),
-                  ),
-                  messageChannelId: messageChannelWithFreshTokens.id,
-                },
-              );
-            }
+            await this.cacheStorage.setAdd(
+              `messages-to-import:${workspaceId}:${messageChannelWithFreshTokens.id}`,
+              messageExternalIdsToImport,
+              ONE_WEEK_IN_MILLISECONDS,
+            );
           }
+        }
 
-          this.logger.log(
-            `messageChannelId: ${freshMessageChannel.id} Total messages to import count: ${totalMessagesToImportCount}`,
+        for (const messageList of messageLists) {
+          const { nextSyncCursor, folderId } = messageList;
+
+          await this.messagingCursorService.updateCursor(
+            messageChannelWithFreshTokens,
+            nextSyncCursor,
+            workspaceId,
+            folderId,
           );
+        }
 
-          if (totalMessagesToImportCount === 0) {
-            await this.messageChannelSyncStatusService.markAsCompletedAndMarkAsMessagesListFetchPending(
-              [messageChannelWithFreshTokens.id],
+        const fullSyncMessageChannelMessageAssociationsToDelete = isFullSync
+          ? await this.computeFullSyncMessageChannelMessageAssociationsToDelete(
+              freshMessageChannel,
+              messageExternalIds,
               workspaceId,
-            );
+            )
+          : [];
 
-            return;
-          }
+        const allMessageExternalIdsToDelete = [
+          ...messageExternalIdsToDelete,
+          ...fullSyncMessageChannelMessageAssociationsToDelete.map(
+            (messageChannelMessageAssociation) =>
+              messageChannelMessageAssociation.messageExternalId,
+          ),
+        ];
 
+        if (allMessageExternalIdsToDelete.length) {
           this.logger.log(
-            `messageChannelId: ${freshMessageChannel.id} Scheduling direct messages import`,
+            `messageChannelId: ${freshMessageChannel.id} Deleting ${allMessageExternalIdsToDelete.length} message channel message associations`,
           );
 
-          await this.messageChannelSyncStatusService.markAsMessagesImportScheduled(
+          const toDeleteChunks = chunk(allMessageExternalIdsToDelete, 200);
+
+          for (const [index, toDeleteChunk] of toDeleteChunks.entries()) {
+            this.logger.log(
+              `messageChannelId: ${freshMessageChannel.id} Deleting ${toDeleteChunk.length} message channel message associations in batch ${index + 1}`,
+            );
+
+            await this.messagingMessageCleanerService.deleteMessagesChannelMessageAssociationsAndRelatedOrphans(
+              {
+                workspaceId,
+                messageExternalIds: toDeleteChunk.filter((messageExternalId) =>
+                  isNonEmptyString(messageExternalId),
+                ),
+                messageChannelId: messageChannelWithFreshTokens.id,
+              },
+            );
+          }
+        }
+
+        this.logger.log(
+          `messageChannelId: ${freshMessageChannel.id} Total messages to import count: ${totalMessagesToImportCount}`,
+        );
+
+        if (totalMessagesToImportCount === 0) {
+          await this.messageChannelSyncStatusService.markAsCompletedAndMarkAsMessagesListFetchPending(
             [messageChannelWithFreshTokens.id],
             workspaceId,
           );
 
-          await this.messagingMessagesImportService.processMessageBatchImport(
-            {
-              ...messageChannelWithFreshTokens,
-              syncStage: MessageChannelSyncStage.MESSAGES_IMPORT_SCHEDULED,
-            },
-            messageChannelWithFreshTokens.connectedAccount,
-            workspaceId,
-          );
-        } catch (error) {
-          await this.messageImportErrorHandlerService.handleDriverException(
-            error,
-            MessageImportSyncStep.MESSAGE_LIST_FETCH,
-            messageChannel,
-            workspaceId,
-          );
+          return;
         }
-      },
-    );
+
+        this.logger.log(
+          `messageChannelId: ${freshMessageChannel.id} Scheduling direct messages import`,
+        );
+
+        await this.messageChannelSyncStatusService.markAsMessagesImportScheduled(
+          [messageChannelWithFreshTokens.id],
+          workspaceId,
+        );
+
+        await this.messagingMessagesImportService.processMessageBatchImport(
+          {
+            ...messageChannelWithFreshTokens,
+            syncStage: MessageChannelSyncStage.MESSAGES_IMPORT_SCHEDULED,
+          },
+          messageChannelWithFreshTokens.connectedAccount,
+          workspaceId,
+        );
+      } catch (error) {
+        await this.messageImportErrorHandlerService.handleDriverException(
+          error,
+          MessageImportSyncStep.MESSAGE_LIST_FETCH,
+          messageChannel,
+          workspaceId,
+        );
+      }
+    }, authContext);
   }
 
   private async processPendingGroupEmailActions(

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-message.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-message.service.ts
@@ -55,7 +55,6 @@ export class MessagingMessageService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const messageChannelMessageAssociationRepository =
           await this.globalWorkspaceOrmManager.getRepository<MessageChannelMessageAssociationWorkspaceEntity>(
@@ -245,6 +244,7 @@ export class MessagingMessageService {
           messageExternalIdsAndIdsMap,
         };
       },
+      authContext,
     );
   }
 

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-messages-import.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-messages-import.service.ts
@@ -60,159 +60,55 @@ export class MessagingMessagesImportService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        try {
-          if (
-            messageChannel.syncStage !==
-            MessageChannelSyncStage.MESSAGES_IMPORT_SCHEDULED
-          ) {
-            return;
-          }
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      try {
+        if (
+          messageChannel.syncStage !==
+          MessageChannelSyncStage.MESSAGES_IMPORT_SCHEDULED
+        ) {
+          return;
+        }
 
-          await this.messagingMonitoringService.track({
-            eventName: 'messages_import.started',
-            workspaceId,
-            connectedAccountId: messageChannel.connectedAccountId,
-            messageChannelId: messageChannel.id,
-          });
+        await this.messagingMonitoringService.track({
+          eventName: 'messages_import.started',
+          workspaceId,
+          connectedAccountId: messageChannel.connectedAccountId,
+          messageChannelId: messageChannel.id,
+        });
 
-          await this.messageChannelSyncStatusService.markAsMessagesImportOngoing(
+        await this.messageChannelSyncStatusService.markAsMessagesImportOngoing(
+          [messageChannel.id],
+          workspaceId,
+        );
+
+        const { accessToken, refreshToken } =
+          await this.messagingAccountAuthenticationService.validateAndRefreshConnectedAccountAuthentication(
+            {
+              connectedAccount,
+              workspaceId,
+              messageChannelId: messageChannel.id,
+            },
+          );
+
+        const connectedAccountWithFreshTokens = {
+          ...connectedAccount,
+          accessToken,
+          refreshToken,
+        };
+
+        await this.emailAliasManagerService.refreshHandleAliases(
+          connectedAccountWithFreshTokens,
+          workspaceId,
+        );
+
+        messageIdsToFetch = await this.cacheStorage.setPop(
+          `messages-to-import:${workspaceId}:${messageChannel.id}`,
+          MESSAGING_GMAIL_USERS_MESSAGES_GET_BATCH_SIZE,
+        );
+
+        if (!messageIdsToFetch?.length) {
+          await this.messageChannelSyncStatusService.markAsCompletedAndMarkAsMessagesListFetchPending(
             [messageChannel.id],
-            workspaceId,
-          );
-
-          const { accessToken, refreshToken } =
-            await this.messagingAccountAuthenticationService.validateAndRefreshConnectedAccountAuthentication(
-              {
-                connectedAccount,
-                workspaceId,
-                messageChannelId: messageChannel.id,
-              },
-            );
-
-          const connectedAccountWithFreshTokens = {
-            ...connectedAccount,
-            accessToken,
-            refreshToken,
-          };
-
-          await this.emailAliasManagerService.refreshHandleAliases(
-            connectedAccountWithFreshTokens,
-            workspaceId,
-          );
-
-          messageIdsToFetch = await this.cacheStorage.setPop(
-            `messages-to-import:${workspaceId}:${messageChannel.id}`,
-            MESSAGING_GMAIL_USERS_MESSAGES_GET_BATCH_SIZE,
-          );
-
-          if (!messageIdsToFetch?.length) {
-            await this.messageChannelSyncStatusService.markAsCompletedAndMarkAsMessagesListFetchPending(
-              [messageChannel.id],
-              workspaceId,
-            );
-
-            return await this.trackMessageImportCompleted(
-              messageChannel,
-              workspaceId,
-            );
-          }
-
-          const allMessages =
-            await this.messagingGetMessagesService.getMessages(
-              messageIdsToFetch,
-              connectedAccountWithFreshTokens,
-            );
-
-          const blocklist =
-            await this.blocklistRepository.getByWorkspaceMemberId(
-              connectedAccountWithFreshTokens.accountOwnerId,
-              workspaceId,
-            );
-
-          if (!isDefined(messageChannel.handle)) {
-            throw new MessageImportDriverException(
-              'Message channel handle is required',
-              MessageImportDriverExceptionCode.CHANNEL_MISCONFIGURED,
-            );
-          }
-
-          if (!isDefined(connectedAccountWithFreshTokens.handleAliases)) {
-            throw new MessageImportDriverException(
-              'Message channel handle is required',
-              MessageImportDriverExceptionCode.CHANNEL_MISCONFIGURED,
-            );
-          }
-
-          const messagesToSave = filterEmails(
-            messageChannel.handle,
-            [...connectedAccountWithFreshTokens.handleAliases.split(',')],
-            allMessages,
-            blocklist
-              .map((blocklistItem) => blocklistItem.handle)
-              .filter(isDefined),
-            messageChannel.excludeGroupEmails,
-          );
-
-          if (messagesToSave.length > 0) {
-            await this.saveMessagesAndEnqueueContactCreationService.saveMessagesAndEnqueueContactCreation(
-              messagesToSave,
-              messageChannel,
-              connectedAccountWithFreshTokens,
-              workspaceId,
-            );
-          }
-
-          if (
-            messageIdsToFetch.length <
-            MESSAGING_GMAIL_USERS_MESSAGES_GET_BATCH_SIZE
-          ) {
-            await this.messageChannelSyncStatusService.markAsCompletedAndMarkAsMessagesListFetchPending(
-              [messageChannel.id],
-              workspaceId,
-            );
-          } else {
-            await this.messageChannelSyncStatusService.markAsMessagesImportPending(
-              [messageChannel.id],
-              workspaceId,
-            );
-          }
-
-          const messageChannelRepository =
-            await this.globalWorkspaceOrmManager.getRepository<MessageChannelWorkspaceEntity>(
-              workspaceId,
-              'messageChannel',
-            );
-
-          await messageChannelRepository.update(
-            {
-              id: messageChannel.id,
-            },
-            {
-              throttleFailureCount: 0,
-              syncStageStartedAt: null,
-            },
-          );
-
-          return await this.trackMessageImportCompleted(
-            messageChannel,
-            workspaceId,
-          );
-        } catch (error) {
-          this.logger.error(
-            `Error (${error.code}) importing messages for workspace ${workspaceId.slice(0, 8)} and account ${connectedAccount.id.slice(0, 8)}: ${error.message} - ${error.body}`,
-          );
-          await this.cacheStorage.setAdd(
-            `messages-to-import:${workspaceId}:${messageChannel.id}`,
-            messageIdsToFetch,
-          );
-
-          await this.messageImportErrorHandlerService.handleDriverException(
-            error,
-            MessageImportSyncStep.MESSAGES_IMPORT_ONGOING,
-            messageChannel,
             workspaceId,
           );
 
@@ -221,8 +117,107 @@ export class MessagingMessagesImportService {
             workspaceId,
           );
         }
-      },
-    );
+
+        const allMessages = await this.messagingGetMessagesService.getMessages(
+          messageIdsToFetch,
+          connectedAccountWithFreshTokens,
+        );
+
+        const blocklist = await this.blocklistRepository.getByWorkspaceMemberId(
+          connectedAccountWithFreshTokens.accountOwnerId,
+          workspaceId,
+        );
+
+        if (!isDefined(messageChannel.handle)) {
+          throw new MessageImportDriverException(
+            'Message channel handle is required',
+            MessageImportDriverExceptionCode.CHANNEL_MISCONFIGURED,
+          );
+        }
+
+        if (!isDefined(connectedAccountWithFreshTokens.handleAliases)) {
+          throw new MessageImportDriverException(
+            'Message channel handle is required',
+            MessageImportDriverExceptionCode.CHANNEL_MISCONFIGURED,
+          );
+        }
+
+        const messagesToSave = filterEmails(
+          messageChannel.handle,
+          [...connectedAccountWithFreshTokens.handleAliases.split(',')],
+          allMessages,
+          blocklist
+            .map((blocklistItem) => blocklistItem.handle)
+            .filter(isDefined),
+          messageChannel.excludeGroupEmails,
+        );
+
+        if (messagesToSave.length > 0) {
+          await this.saveMessagesAndEnqueueContactCreationService.saveMessagesAndEnqueueContactCreation(
+            messagesToSave,
+            messageChannel,
+            connectedAccountWithFreshTokens,
+            workspaceId,
+          );
+        }
+
+        if (
+          messageIdsToFetch.length <
+          MESSAGING_GMAIL_USERS_MESSAGES_GET_BATCH_SIZE
+        ) {
+          await this.messageChannelSyncStatusService.markAsCompletedAndMarkAsMessagesListFetchPending(
+            [messageChannel.id],
+            workspaceId,
+          );
+        } else {
+          await this.messageChannelSyncStatusService.markAsMessagesImportPending(
+            [messageChannel.id],
+            workspaceId,
+          );
+        }
+
+        const messageChannelRepository =
+          await this.globalWorkspaceOrmManager.getRepository<MessageChannelWorkspaceEntity>(
+            workspaceId,
+            'messageChannel',
+          );
+
+        await messageChannelRepository.update(
+          {
+            id: messageChannel.id,
+          },
+          {
+            throttleFailureCount: 0,
+            syncStageStartedAt: null,
+          },
+        );
+
+        return await this.trackMessageImportCompleted(
+          messageChannel,
+          workspaceId,
+        );
+      } catch (error) {
+        this.logger.error(
+          `Error (${error.code}) importing messages for workspace ${workspaceId.slice(0, 8)} and account ${connectedAccount.id.slice(0, 8)}: ${error.message} - ${error.body}`,
+        );
+        await this.cacheStorage.setAdd(
+          `messages-to-import:${workspaceId}:${messageChannel.id}`,
+          messageIdsToFetch,
+        );
+
+        await this.messageImportErrorHandlerService.handleDriverException(
+          error,
+          MessageImportSyncStep.MESSAGES_IMPORT_ONGOING,
+          messageChannel,
+          workspaceId,
+        );
+
+        return await this.trackMessageImportCompleted(
+          messageChannel,
+          workspaceId,
+        );
+      }
+    }, authContext);
   }
 
   private async trackMessageImportCompleted(

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-process-folder-actions.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-process-folder-actions.service.ts
@@ -90,7 +90,6 @@ export class MessagingProcessFolderActionsService {
       const authContext = buildSystemAuthContext(workspaceId);
 
       await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        authContext,
         async () => {
           const workspaceDataSource =
             await this.globalWorkspaceOrmManager.getGlobalWorkspaceDataSource();
@@ -128,6 +127,7 @@ export class MessagingProcessFolderActionsService {
             },
           );
         },
+        authContext,
       );
     }
   }

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-save-messages-and-enqueue-contact-creation.service.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-save-messages-and-enqueue-contact-creation.service.spec.ts
@@ -159,7 +159,7 @@ describe('MessagingSaveMessagesAndEnqueueContactCreationService', () => {
               .mockResolvedValue(datasourceInstance),
             executeInWorkspaceContext: jest
               .fn()
-              .mockImplementation((_authContext: any, fn: () => any) => fn()),
+              .mockImplementation((fn: () => any, _authContext?: any) => fn()),
           },
         },
       ],

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-save-messages-and-enqueue-contact-creation.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-save-messages-and-enqueue-contact-creation.service.ts
@@ -47,7 +47,6 @@ export class MessagingSaveMessagesAndEnqueueContactCreationService {
 
     const participantsWithMessageId =
       await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        authContext,
         async () => {
           const workspaceDataSource =
             await this.globalWorkspaceOrmManager.getGlobalWorkspaceDataSource();
@@ -117,6 +116,7 @@ export class MessagingSaveMessagesAndEnqueueContactCreationService {
             },
           );
         },
+        authContext,
       );
 
     if (

--- a/packages/twenty-server/src/modules/messaging/monitoring/crons/jobs/messaging-message-channel-sync-status-monitoring.cron.job.ts
+++ b/packages/twenty-server/src/modules/messaging/monitoring/crons/jobs/messaging-message-channel-sync-status-monitoring.cron.job.ts
@@ -50,7 +50,6 @@ export class MessagingMessageChannelSyncStatusMonitoringCronJob {
         const authContext = buildSystemAuthContext(activeWorkspace.id);
 
         await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-          authContext,
           async () => {
             const messageChannelRepository =
               await this.globalWorkspaceOrmManager.getRepository<MessageChannelWorkspaceEntity>(
@@ -76,6 +75,7 @@ export class MessagingMessageChannelSyncStatusMonitoringCronJob {
               });
             }
           },
+          authContext,
         );
       } catch (error) {
         this.exceptionHandlerService.captureExceptions([error], {

--- a/packages/twenty-server/src/modules/note/query-hooks/note-post-query-hook.service.ts
+++ b/packages/twenty-server/src/modules/note/query-hooks/note-post-query-hook.service.ts
@@ -29,20 +29,17 @@ export class NotePostQueryHookService {
 
     assertIsDefinedOrThrow(workspace, WorkspaceNotFoundDefaultError);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext as WorkspaceAuthContext,
-      async () => {
-        const noteTargetRepository =
-          await this.globalWorkspaceOrmManager.getRepository<NoteTargetWorkspaceEntity>(
-            workspace.id,
-            'noteTarget',
-          );
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const noteTargetRepository =
+        await this.globalWorkspaceOrmManager.getRepository<NoteTargetWorkspaceEntity>(
+          workspace.id,
+          'noteTarget',
+        );
 
-        await noteTargetRepository.softDelete({
-          noteId: In(payload.map((note) => note.id)),
-        });
-      },
-    );
+      await noteTargetRepository.softDelete({
+        noteId: In(payload.map((note) => note.id)),
+      });
+    }, authContext as WorkspaceAuthContext);
   }
 
   async handleNoteTargetsRestore(
@@ -57,19 +54,16 @@ export class NotePostQueryHookService {
 
     assertIsDefinedOrThrow(workspace, WorkspaceNotFoundDefaultError);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext as WorkspaceAuthContext,
-      async () => {
-        const noteTargetRepository =
-          await this.globalWorkspaceOrmManager.getRepository<NoteTargetWorkspaceEntity>(
-            workspace.id,
-            'noteTarget',
-          );
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const noteTargetRepository =
+        await this.globalWorkspaceOrmManager.getRepository<NoteTargetWorkspaceEntity>(
+          workspace.id,
+          'noteTarget',
+        );
 
-        await noteTargetRepository.restore({
-          noteId: In(payload.map((note) => note.id)),
-        });
-      },
-    );
+      await noteTargetRepository.restore({
+        noteId: In(payload.map((note) => note.id)),
+      });
+    }, authContext as WorkspaceAuthContext);
   }
 }

--- a/packages/twenty-server/src/modules/task/query-hooks/task-post-query-hook.service.ts
+++ b/packages/twenty-server/src/modules/task/query-hooks/task-post-query-hook.service.ts
@@ -29,20 +29,17 @@ export class TaskPostQueryHookService {
 
     assertIsDefinedOrThrow(workspace, WorkspaceNotFoundDefaultError);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext as WorkspaceAuthContext,
-      async () => {
-        const taskTargetRepository =
-          await this.globalWorkspaceOrmManager.getRepository<TaskTargetWorkspaceEntity>(
-            workspace.id,
-            'taskTarget',
-          );
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const taskTargetRepository =
+        await this.globalWorkspaceOrmManager.getRepository<TaskTargetWorkspaceEntity>(
+          workspace.id,
+          'taskTarget',
+        );
 
-        await taskTargetRepository.softDelete({
-          taskId: In(payload.map((task) => task.id)),
-        });
-      },
-    );
+      await taskTargetRepository.softDelete({
+        taskId: In(payload.map((task) => task.id)),
+      });
+    }, authContext as WorkspaceAuthContext);
   }
 
   async handleTaskTargetsRestore(
@@ -57,19 +54,16 @@ export class TaskPostQueryHookService {
 
     assertIsDefinedOrThrow(workspace, WorkspaceNotFoundDefaultError);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext as WorkspaceAuthContext,
-      async () => {
-        const taskTargetRepository =
-          await this.globalWorkspaceOrmManager.getRepository<TaskTargetWorkspaceEntity>(
-            workspace.id,
-            'taskTarget',
-          );
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const taskTargetRepository =
+        await this.globalWorkspaceOrmManager.getRepository<TaskTargetWorkspaceEntity>(
+          workspace.id,
+          'taskTarget',
+        );
 
-        await taskTargetRepository.restore({
-          taskId: In(payload.map((task) => task.id)),
-        });
-      },
-    );
+      await taskTargetRepository.restore({
+        taskId: In(payload.map((task) => task.id)),
+      });
+    }, authContext as WorkspaceAuthContext);
   }
 }

--- a/packages/twenty-server/src/modules/timeline/services/timeline-activity.service.ts
+++ b/packages/twenty-server/src/modules/timeline/services/timeline-activity.service.ts
@@ -192,7 +192,6 @@ export class TimelineActivityService {
 
     const activityTargets =
       await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        authContext,
         async () => {
           const activityTargetRepository =
             await this.globalWorkspaceOrmManager.getRepository(
@@ -209,6 +208,7 @@ export class TimelineActivityService {
             },
           });
         },
+        authContext,
       );
 
     if (activityTargets.length === 0) {
@@ -277,7 +277,6 @@ export class TimelineActivityService {
 
     const activities =
       await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        authContext,
         async () => {
           const activityRepository =
             await this.globalWorkspaceOrmManager.getRepository(
@@ -303,6 +302,7 @@ export class TimelineActivityService {
             },
           });
         },
+        authContext,
       );
 
     if (activities.length === 0) {

--- a/packages/twenty-server/src/modules/workflow/common/query-hooks/workflow-create-many.post-query.hook.ts
+++ b/packages/twenty-server/src/modules/workflow/common/query-hooks/workflow-create-many.post-query.hook.ts
@@ -36,37 +36,34 @@ export class WorkflowCreateManyPostQueryHook
 
     assertIsDefinedOrThrow(workspace, WorkspaceNotFoundDefaultError);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext as WorkspaceAuthContext,
-      async () => {
-        const workflowVersionRepository =
-          await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
-            workspace.id,
-            'workflowVersion',
-          );
-
-        const position = await this.recordPositionService.buildRecordPosition({
-          value: 'first',
-          objectMetadata: {
-            isCustom: false,
-            nameSingular: 'workflowVersion',
-          },
-          workspaceId: workspace.id,
-        });
-
-        const workflowVersionsToCreate = payload.map((workflow) => ({
-          workflowId: workflow.id,
-          status: WorkflowVersionStatus.DRAFT,
-          name: 'v1',
-          position,
-        }));
-
-        await Promise.all(
-          workflowVersionsToCreate.map((workflowVersion) => {
-            return workflowVersionRepository.insert(workflowVersion);
-          }),
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const workflowVersionRepository =
+        await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+          workspace.id,
+          'workflowVersion',
         );
-      },
-    );
+
+      const position = await this.recordPositionService.buildRecordPosition({
+        value: 'first',
+        objectMetadata: {
+          isCustom: false,
+          nameSingular: 'workflowVersion',
+        },
+        workspaceId: workspace.id,
+      });
+
+      const workflowVersionsToCreate = payload.map((workflow) => ({
+        workflowId: workflow.id,
+        status: WorkflowVersionStatus.DRAFT,
+        name: 'v1',
+        position,
+      }));
+
+      await Promise.all(
+        workflowVersionsToCreate.map((workflowVersion) => {
+          return workflowVersionRepository.insert(workflowVersion);
+        }),
+      );
+    }, authContext as WorkspaceAuthContext);
   }
 }

--- a/packages/twenty-server/src/modules/workflow/common/query-hooks/workflow-create-one.post-query.hook.ts
+++ b/packages/twenty-server/src/modules/workflow/common/query-hooks/workflow-create-one.post-query.hook.ts
@@ -38,31 +38,28 @@ export class WorkflowCreateOnePostQueryHook
 
     const workflow = payload[0];
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext as WorkspaceAuthContext,
-      async () => {
-        const workflowVersionRepository =
-          await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
-            workspace.id,
-            'workflowVersion',
-          );
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const workflowVersionRepository =
+        await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+          workspace.id,
+          'workflowVersion',
+        );
 
-        const position = await this.recordPositionService.buildRecordPosition({
-          value: 'first',
-          objectMetadata: {
-            isCustom: false,
-            nameSingular: 'workflowVersion',
-          },
-          workspaceId: workspace.id,
-        });
+      const position = await this.recordPositionService.buildRecordPosition({
+        value: 'first',
+        objectMetadata: {
+          isCustom: false,
+          nameSingular: 'workflowVersion',
+        },
+        workspaceId: workspace.id,
+      });
 
-        await workflowVersionRepository.insert({
-          workflowId: workflow.id,
-          status: WorkflowVersionStatus.DRAFT,
-          name: 'v1',
-          position,
-        });
-      },
-    );
+      await workflowVersionRepository.insert({
+        workflowId: workflow.id,
+        status: WorkflowVersionStatus.DRAFT,
+        name: 'v1',
+        position,
+      });
+    }, authContext as WorkspaceAuthContext);
   }
 }

--- a/packages/twenty-server/src/modules/workflow/common/workspace-services/workflow-version-validation.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/common/workspace-services/workflow-version-validation.workspace-service.ts
@@ -48,36 +48,33 @@ export class WorkflowVersionValidationWorkspaceService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const workflowVersionRepository =
-          await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
-            workspaceId,
-            'workflowVersion',
-            { shouldBypassPermissionChecks: true },
-          );
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const workflowVersionRepository =
+        await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+          workspaceId,
+          'workflowVersion',
+          { shouldBypassPermissionChecks: true },
+        );
 
-        const workflowAlreadyHasDraftVersion =
-          await workflowVersionRepository.exists({
-            where: {
-              workflowId: payload.data.workflowId,
-              status: WorkflowVersionStatus.DRAFT,
-              deletedAt: IsNull(),
-            },
-          });
+      const workflowAlreadyHasDraftVersion =
+        await workflowVersionRepository.exists({
+          where: {
+            workflowId: payload.data.workflowId,
+            status: WorkflowVersionStatus.DRAFT,
+            deletedAt: IsNull(),
+          },
+        });
 
-        if (workflowAlreadyHasDraftVersion) {
-          throw new WorkflowQueryValidationException(
-            'Cannot create multiple draft versions for the same workflow',
-            WorkflowQueryValidationExceptionCode.FORBIDDEN,
-            {
-              userFriendlyMessage: msg`Cannot create multiple draft versions for the same workflow`,
-            },
-          );
-        }
-      },
-    );
+      if (workflowAlreadyHasDraftVersion) {
+        throw new WorkflowQueryValidationException(
+          'Cannot create multiple draft versions for the same workflow',
+          WorkflowQueryValidationExceptionCode.FORBIDDEN,
+          {
+            userFriendlyMessage: msg`Cannot create multiple draft versions for the same workflow`,
+          },
+        );
+      }
+    }, authContext);
   }
 
   async validateWorkflowVersionForUpdateOne({
@@ -130,35 +127,33 @@ export class WorkflowVersionValidationWorkspaceService {
 
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const workflowVersionRepository =
-          await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
-            workspaceId,
-            'workflowVersion',
-            { shouldBypassPermissionChecks: true },
-          );
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const workflowVersionRepository =
+        await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+          workspaceId,
+          'workflowVersion',
+          { shouldBypassPermissionChecks: true },
+        );
 
-        const otherWorkflowVersionsExist =
-          await workflowVersionRepository.exists({
-            where: {
-              workflowId: workflowVersion.workflowId,
-              deletedAt: IsNull(),
-              id: Not(workflowVersion.id),
-            },
-          });
+      const otherWorkflowVersionsExist = await workflowVersionRepository.exists(
+        {
+          where: {
+            workflowId: workflowVersion.workflowId,
+            deletedAt: IsNull(),
+            id: Not(workflowVersion.id),
+          },
+        },
+      );
 
-        if (!otherWorkflowVersionsExist) {
-          throw new WorkflowQueryValidationException(
-            'The initial version of a workflow can not be deleted',
-            WorkflowQueryValidationExceptionCode.FORBIDDEN,
-            {
-              userFriendlyMessage: msg`The initial version of a workflow can not be deleted`,
-            },
-          );
-        }
-      },
-    );
+      if (!otherWorkflowVersionsExist) {
+        throw new WorkflowQueryValidationException(
+          'The initial version of a workflow can not be deleted',
+          WorkflowQueryValidationExceptionCode.FORBIDDEN,
+          {
+            userFriendlyMessage: msg`The initial version of a workflow can not be deleted`,
+          },
+        );
+      }
+    }, authContext);
   }
 }

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version-edge/__tests__/workflow-version-edge.workspace-service.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version-edge/__tests__/workflow-version-edge.workspace-service.spec.ts
@@ -91,7 +91,9 @@ describe('WorkflowVersionEdgeWorkspaceService', () => {
     globalWorkspaceOrmManager = {
       executeInWorkspaceContext: jest
         .fn()
-        .mockImplementation(async (_authContext, callback) => callback()),
+        .mockImplementation(async (callback: () => any, _authContext?: any) =>
+          callback(),
+        ),
       getRepository: jest
         .fn()
         .mockResolvedValue(mockWorkflowVersionWorkspaceRepository),

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version-edge/workflow-version-edge.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version-edge/workflow-version-edge.workspace-service.ts
@@ -45,7 +45,6 @@ export class WorkflowVersionEdgeWorkspaceService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const workflowVersionRepository =
           await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
@@ -96,6 +95,7 @@ export class WorkflowVersionEdgeWorkspaceService {
           });
         }
       },
+      authContext,
     );
   }
 
@@ -115,7 +115,6 @@ export class WorkflowVersionEdgeWorkspaceService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const workflowVersionRepository =
           await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
@@ -166,6 +165,7 @@ export class WorkflowVersionEdgeWorkspaceService {
           });
         }
       },
+      authContext,
     );
   }
 

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version-step/__tests__/workflow-version-step.workspace-service.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version-step/__tests__/workflow-version-step.workspace-service.spec.ts
@@ -115,7 +115,7 @@ describe('WorkflowVersionStepWorkspaceService', () => {
       executeInWorkspaceContext: jest
         .fn()
 
-        .mockImplementation((_authContext: any, fn: () => any) => fn()),
+        .mockImplementation((fn: () => any, _authContext?: any) => fn()),
     } as unknown as jest.Mocked<GlobalWorkspaceOrmManager>;
 
     const module: TestingModule = await Test.createTestingModule({

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version-step/workflow-version-step-helpers.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version-step/workflow-version-step-helpers.workspace-service.ts
@@ -46,28 +46,25 @@ export class WorkflowVersionStepHelpersWorkspaceService {
   }): Promise<void> {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const workflowVersionRepository =
-          await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
-            workspaceId,
-            'workflowVersion',
-            { shouldBypassPermissionChecks: true },
-          );
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const workflowVersionRepository =
+        await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+          workspaceId,
+          'workflowVersion',
+          { shouldBypassPermissionChecks: true },
+        );
 
-        const updateData: Partial<WorkflowVersionWorkspaceEntity> = {};
+      const updateData: Partial<WorkflowVersionWorkspaceEntity> = {};
 
-        if (steps !== undefined) {
-          updateData.steps = steps;
-        }
+      if (steps !== undefined) {
+        updateData.steps = steps;
+      }
 
-        if (trigger !== undefined) {
-          updateData.trigger = trigger;
-        }
+      if (trigger !== undefined) {
+        updateData.trigger = trigger;
+      }
 
-        await workflowVersionRepository.update(workflowVersionId, updateData);
-      },
-    );
+      await workflowVersionRepository.update(workflowVersionId, updateData);
+    }, authContext);
   }
 }

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version-step/workflow-version-step-operations.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version-step/workflow-version-step-operations.workspace-service.ts
@@ -533,7 +533,6 @@ export class WorkflowVersionStepOperationsWorkspaceService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const responseKeys = Object.keys(response);
 
@@ -598,6 +597,7 @@ export class WorkflowVersionStepOperationsWorkspaceService {
           return acc;
         }, {});
       },
+      authContext,
     );
   }
 
@@ -727,7 +727,6 @@ export class WorkflowVersionStepOperationsWorkspaceService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const workflowVersionRepository =
           await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
@@ -777,6 +776,7 @@ export class WorkflowVersionStepOperationsWorkspaceService {
 
         return emptyNodeStep;
       },
+      authContext,
     );
   }
 
@@ -797,7 +797,6 @@ export class WorkflowVersionStepOperationsWorkspaceService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const workflowVersionRepository =
           await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
@@ -878,6 +877,7 @@ export class WorkflowVersionStepOperationsWorkspaceService {
           branches,
         };
       },
+      authContext,
     );
   }
 

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version/workflow-version.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version/workflow-version.workspace-service.ts
@@ -50,7 +50,6 @@ export class WorkflowVersionWorkspaceService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const workflowVersionRepository =
           await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
@@ -139,6 +138,7 @@ export class WorkflowVersionWorkspaceService {
           trigger: newWorkflowVersionTrigger,
         };
       },
+      authContext,
     );
   }
 
@@ -154,7 +154,6 @@ export class WorkflowVersionWorkspaceService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const workflowRepository =
           await this.globalWorkspaceOrmManager.getRepository(
@@ -311,6 +310,7 @@ export class WorkflowVersionWorkspaceService {
           trigger: remappedTrigger ?? null,
         };
       },
+      authContext,
     );
   }
 
@@ -325,61 +325,55 @@ export class WorkflowVersionWorkspaceService {
   }) {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const workflowVersionRepository =
-          await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
-            workspaceId,
-            'workflowVersion',
-            { shouldBypassPermissionChecks: true },
-          );
-
-        const workflowVersion = await workflowVersionRepository.findOneOrFail({
-          where: {
-            id: workflowVersionId,
-          },
-        });
-
-        assertWorkflowVersionIsDraft(workflowVersion);
-
-        const triggerPosition = positions.find(
-          (position) => position.id === TRIGGER_STEP_ID,
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const workflowVersionRepository =
+        await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+          workspaceId,
+          'workflowVersion',
+          { shouldBypassPermissionChecks: true },
         );
 
-        const updatedTrigger =
-          isDefined(triggerPosition) && isDefined(workflowVersion.trigger)
-            ? {
-                ...workflowVersion.trigger,
-                position: triggerPosition.position,
-              }
-            : undefined;
+      const workflowVersion = await workflowVersionRepository.findOneOrFail({
+        where: {
+          id: workflowVersionId,
+        },
+      });
 
-        const updatedSteps = workflowVersion.steps?.map((step) => {
-          const updatedStep = positions.find(
-            (position) => position.id === step.id,
-          );
+      assertWorkflowVersionIsDraft(workflowVersion);
 
-          if (updatedStep) {
-            return {
-              ...step,
-              position: updatedStep.position,
-            };
-          }
+      const triggerPosition = positions.find(
+        (position) => position.id === TRIGGER_STEP_ID,
+      );
 
-          return step;
-        });
+      const updatedTrigger =
+        isDefined(triggerPosition) && isDefined(workflowVersion.trigger)
+          ? {
+              ...workflowVersion.trigger,
+              position: triggerPosition.position,
+            }
+          : undefined;
 
-        const updatePayload = {
-          ...(!isDefined(updatedTrigger) ? {} : { trigger: updatedTrigger }),
-          ...(!isDefined(updatedSteps) ? {} : { steps: updatedSteps }),
-        };
-
-        await workflowVersionRepository.update(
-          workflowVersionId,
-          updatePayload,
+      const updatedSteps = workflowVersion.steps?.map((step) => {
+        const updatedStep = positions.find(
+          (position) => position.id === step.id,
         );
-      },
-    );
+
+        if (updatedStep) {
+          return {
+            ...step,
+            position: updatedStep.position,
+          };
+        }
+
+        return step;
+      });
+
+      const updatePayload = {
+        ...(!isDefined(updatedTrigger) ? {} : { trigger: updatedTrigger }),
+        ...(!isDefined(updatedSteps) ? {} : { steps: updatedSteps }),
+      };
+
+      await workflowVersionRepository.update(workflowVersionId, updatePayload);
+    }, authContext);
   }
 }

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/jobs/run-workflow.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/jobs/run-workflow.job.ts
@@ -39,32 +39,29 @@ export class RunWorkflowJob {
   }: RunWorkflowJobData): Promise<void> {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        try {
-          if (lastExecutedStepId) {
-            await this.resumeWorkflowExecution({
-              workspaceId,
-              workflowRunId,
-              lastExecutedStepId,
-            });
-          } else {
-            await this.startWorkflowExecution({
-              workflowRunId,
-              workspaceId,
-            });
-          }
-        } catch (error) {
-          await this.workflowRunWorkspaceService.endWorkflowRun({
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      try {
+        if (lastExecutedStepId) {
+          await this.resumeWorkflowExecution({
             workspaceId,
             workflowRunId,
-            status: WorkflowRunStatus.FAILED,
-            error: error.message,
+            lastExecutedStepId,
+          });
+        } else {
+          await this.startWorkflowExecution({
+            workflowRunId,
+            workspaceId,
           });
         }
-      },
-    );
+      } catch (error) {
+        await this.workflowRunWorkspaceService.endWorkflowRun({
+          workspaceId,
+          workflowRunId,
+          status: WorkflowRunStatus.FAILED,
+          error: error.message,
+        });
+      }
+    }, authContext);
   }
 
   private async startWorkflowExecution({

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-handle-staled-runs.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-handle-staled-runs.workspace-service.ts
@@ -51,41 +51,38 @@ export class WorkflowHandleStaledRunsWorkspaceService {
   private async handleStaledRunsForWorkspace(workspaceId: string) {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const workflowRunRepository =
-          await this.globalWorkspaceOrmManager.getRepository(
-            workspaceId,
-            WorkflowRunWorkspaceEntity,
-            { shouldBypassPermissionChecks: true },
-          );
-
-        const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
-
-        const staledWorkflowRuns = await workflowRunRepository.find({
-          where: {
-            status: WorkflowRunStatus.ENQUEUED,
-            enqueuedAt: Or(LessThan(oneHourAgo), IsNull()),
-          },
-        });
-
-        if (staledWorkflowRuns.length <= 0) {
-          return;
-        }
-
-        await workflowRunRepository.update(
-          staledWorkflowRuns.map((workflowRun) => workflowRun.id),
-          {
-            enqueuedAt: null,
-            status: WorkflowRunStatus.NOT_STARTED,
-          },
-        );
-
-        await this.workflowThrottlingWorkspaceService.recomputeWorkflowRunNotStartedCount(
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const workflowRunRepository =
+        await this.globalWorkspaceOrmManager.getRepository(
           workspaceId,
+          WorkflowRunWorkspaceEntity,
+          { shouldBypassPermissionChecks: true },
         );
-      },
-    );
+
+      const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
+
+      const staledWorkflowRuns = await workflowRunRepository.find({
+        where: {
+          status: WorkflowRunStatus.ENQUEUED,
+          enqueuedAt: Or(LessThan(oneHourAgo), IsNull()),
+        },
+      });
+
+      if (staledWorkflowRuns.length <= 0) {
+        return;
+      }
+
+      await workflowRunRepository.update(
+        staledWorkflowRuns.map((workflowRun) => workflowRun.id),
+        {
+          enqueuedAt: null,
+          status: WorkflowRunStatus.NOT_STARTED,
+        },
+      );
+
+      await this.workflowThrottlingWorkspaceService.recomputeWorkflowRunNotStartedCount(
+        workspaceId,
+      );
+    }, authContext);
   }
 }

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-run-enqueue.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-run-enqueue.workspace-service.ts
@@ -48,7 +48,6 @@ export class WorkflowRunEnqueueWorkspaceService {
       const authContext = buildSystemAuthContext(workspaceId);
 
       await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        authContext,
         async () => {
           const workflowRunRepository =
             await this.globalWorkspaceOrmManager.getRepository(
@@ -152,6 +151,7 @@ export class WorkflowRunEnqueueWorkspaceService {
             );
           }
         },
+        authContext,
       );
     } catch (error) {
       this.metricsService.incrementCounter({

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-throttling.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-throttling.workspace-service.ts
@@ -80,7 +80,6 @@ export class WorkflowThrottlingWorkspaceService {
 
     const currentlyNotStartedWorkflowRunCount =
       await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        authContext,
         async () => {
           const workflowRunRepository =
             await this.globalWorkspaceOrmManager.getRepository(
@@ -95,6 +94,7 @@ export class WorkflowThrottlingWorkspaceService {
             },
           });
         },
+        authContext,
       );
 
     await this.setWorkflowRunNotStartedCount(
@@ -113,7 +113,6 @@ export class WorkflowThrottlingWorkspaceService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const workflowRunRepository =
           await this.globalWorkspaceOrmManager.getRepository(
@@ -128,6 +127,7 @@ export class WorkflowThrottlingWorkspaceService {
           },
         });
       },
+      authContext,
     );
   }
 

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run/workflow-run.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run/workflow-run.workspace-service.ts
@@ -57,7 +57,6 @@ export class WorkflowRunWorkspaceService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const workflowRunRepository =
           await this.globalWorkspaceOrmManager.getRepository<WorkflowRunWorkspaceEntity>(
@@ -136,6 +135,7 @@ export class WorkflowRunWorkspaceService {
 
         return workflowRun.id;
       },
+      authContext,
     );
   }
 
@@ -346,7 +346,6 @@ export class WorkflowRunWorkspaceService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const workflowRunRepository =
           await this.globalWorkspaceOrmManager.getRepository<WorkflowRunWorkspaceEntity>(
@@ -359,6 +358,7 @@ export class WorkflowRunWorkspaceService {
           where: { id: workflowRunId },
         });
       },
+      authContext,
     );
   }
 
@@ -395,35 +395,32 @@ export class WorkflowRunWorkspaceService {
   }) {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const workflowRunRepository =
-          await this.globalWorkspaceOrmManager.getRepository<WorkflowRunWorkspaceEntity>(
-            workspaceId,
-            'workflowRun',
-            { shouldBypassPermissionChecks: true },
-          );
-
-        const workflowRunToUpdate = await workflowRunRepository.findOneBy({
-          id: workflowRunId,
-        });
-
-        if (!workflowRunToUpdate) {
-          throw new WorkflowRunException(
-            `workflowRun ${workflowRunId} not found`,
-            WorkflowRunExceptionCode.WORKFLOW_RUN_NOT_FOUND,
-          );
-        }
-
-        await workflowRunRepository.update(
-          workflowRunToUpdate.id,
-          partialUpdate,
-          undefined,
-          ['id'],
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const workflowRunRepository =
+        await this.globalWorkspaceOrmManager.getRepository<WorkflowRunWorkspaceEntity>(
+          workspaceId,
+          'workflowRun',
+          { shouldBypassPermissionChecks: true },
         );
-      },
-    );
+
+      const workflowRunToUpdate = await workflowRunRepository.findOneBy({
+        id: workflowRunId,
+      });
+
+      if (!workflowRunToUpdate) {
+        throw new WorkflowRunException(
+          `workflowRun ${workflowRunId} not found`,
+          WorkflowRunExceptionCode.WORKFLOW_RUN_NOT_FOUND,
+        );
+      }
+
+      await workflowRunRepository.update(
+        workflowRunToUpdate.id,
+        partialUpdate,
+        undefined,
+        ['id'],
+      );
+    }, authContext);
   }
 
   private getInitState(

--- a/packages/twenty-server/src/modules/workflow/workflow-status/jobs/__tests__/workflow-statuses-update.job.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-status/jobs/__tests__/workflow-statuses-update.job.spec.ts
@@ -49,7 +49,7 @@ describe('WorkflowStatusesUpdate', () => {
     executeInWorkspaceContext: jest
       .fn()
 
-      .mockImplementation((_authContext: any, fn: () => any) => fn()),
+      .mockImplementation((fn: () => any, _authContext?: any) => fn()),
   };
 
   const mockServerlessFunctionService = {

--- a/packages/twenty-server/src/modules/workflow/workflow-status/jobs/workflow-statuses-update.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-status/jobs/workflow-statuses-update.job.ts
@@ -78,36 +78,33 @@ export class WorkflowStatusesUpdateJob {
   async handle(event: WorkflowVersionBatchEvent): Promise<void> {
     const authContext = buildSystemAuthContext(event.workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        switch (event.type) {
-          case WorkflowVersionEventType.CREATE:
-          case WorkflowVersionEventType.DELETE:
-            await Promise.all(
-              event.workflowIds.map((workflowId) =>
-                this.handleWorkflowVersionCreatedOrDeleted({
-                  workflowId,
-                  workspaceId: event.workspaceId,
-                }),
-              ),
-            );
-            break;
-          case WorkflowVersionEventType.STATUS_UPDATE:
-            await Promise.all(
-              event.statusUpdates.map((statusUpdate) =>
-                this.handleWorkflowVersionStatusUpdated({
-                  statusUpdate,
-                  workspaceId: event.workspaceId,
-                }),
-              ),
-            );
-            break;
-          default:
-            break;
-        }
-      },
-    );
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      switch (event.type) {
+        case WorkflowVersionEventType.CREATE:
+        case WorkflowVersionEventType.DELETE:
+          await Promise.all(
+            event.workflowIds.map((workflowId) =>
+              this.handleWorkflowVersionCreatedOrDeleted({
+                workflowId,
+                workspaceId: event.workspaceId,
+              }),
+            ),
+          );
+          break;
+        case WorkflowVersionEventType.STATUS_UPDATE:
+          await Promise.all(
+            event.statusUpdates.map((statusUpdate) =>
+              this.handleWorkflowVersionStatusUpdated({
+                statusUpdate,
+                workspaceId: event.workspaceId,
+              }),
+            ),
+          );
+          break;
+        default:
+          break;
+      }
+    }, authContext);
   }
 
   private async handleWorkflowVersionCreatedOrDeleted({

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/create-complete-workflow.tool.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/create-complete-workflow.tool.ts
@@ -206,38 +206,35 @@ const createWorkflow = async ({
 }): Promise<string> => {
   const authContext = buildSystemAuthContext(context.workspaceId);
 
-  return deps.globalWorkspaceOrmManager.executeInWorkspaceContext(
-    authContext,
-    async () => {
-      const workflowRepository =
-        await deps.globalWorkspaceOrmManager.getRepository(
-          context.workspaceId,
-          'workflow',
-          context.rolePermissionConfig,
-        );
+  return deps.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+    const workflowRepository =
+      await deps.globalWorkspaceOrmManager.getRepository(
+        context.workspaceId,
+        'workflow',
+        context.rolePermissionConfig,
+      );
 
-      const workflowPosition =
-        await deps.recordPositionService.buildRecordPosition({
-          value: 'first',
-          objectMetadata: {
-            isCustom: false,
-            nameSingular: 'workflow',
-          },
-          workspaceId: context.workspaceId,
-        });
+    const workflowPosition =
+      await deps.recordPositionService.buildRecordPosition({
+        value: 'first',
+        objectMetadata: {
+          isCustom: false,
+          nameSingular: 'workflow',
+        },
+        workspaceId: context.workspaceId,
+      });
 
-      const workflow = {
-        id: uuidv4(),
-        name,
-        statuses: [WorkflowStatus.DRAFT],
-        position: workflowPosition,
-      };
+    const workflow = {
+      id: uuidv4(),
+      name,
+      statuses: [WorkflowStatus.DRAFT],
+      position: workflowPosition,
+    };
 
-      await workflowRepository.insert(workflow);
+    await workflowRepository.insert(workflow);
 
-      return workflow.id;
-    },
-  );
+    return workflow.id;
+  }, authContext);
 };
 
 const createWorkflowVersion = async ({
@@ -255,41 +252,38 @@ const createWorkflowVersion = async ({
 }): Promise<string> => {
   const authContext = buildSystemAuthContext(context.workspaceId);
 
-  return deps.globalWorkspaceOrmManager.executeInWorkspaceContext(
-    authContext,
-    async () => {
-      const workflowVersionRepository =
-        await deps.globalWorkspaceOrmManager.getRepository(
-          context.workspaceId,
-          'workflowVersion',
-          context.rolePermissionConfig,
-        );
+  return deps.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+    const workflowVersionRepository =
+      await deps.globalWorkspaceOrmManager.getRepository(
+        context.workspaceId,
+        'workflowVersion',
+        context.rolePermissionConfig,
+      );
 
-      const versionPosition =
-        await deps.recordPositionService.buildRecordPosition({
-          value: 'first',
-          objectMetadata: {
-            isCustom: false,
-            nameSingular: 'workflowVersion',
-          },
-          workspaceId: context.workspaceId,
-        });
+    const versionPosition =
+      await deps.recordPositionService.buildRecordPosition({
+        value: 'first',
+        objectMetadata: {
+          isCustom: false,
+          nameSingular: 'workflowVersion',
+        },
+        workspaceId: context.workspaceId,
+      });
 
-      const workflowVersion = {
-        id: uuidv4(),
-        workflowId,
-        name: 'v1',
-        status: WorkflowVersionStatus.DRAFT,
-        trigger,
-        steps,
-        position: versionPosition,
-      };
+    const workflowVersion = {
+      id: uuidv4(),
+      workflowId,
+      name: 'v1',
+      status: WorkflowVersionStatus.DRAFT,
+      trigger,
+      steps,
+      position: versionPosition,
+    };
 
-      await workflowVersionRepository.insert(workflowVersion);
+    await workflowVersionRepository.insert(workflowVersion);
 
-      return workflowVersion.id;
-    },
-  );
+    return workflowVersion.id;
+  }, authContext);
 };
 
 const updateWorkflowStatus = async ({
@@ -305,20 +299,17 @@ const updateWorkflowStatus = async ({
 }) => {
   const authContext = buildSystemAuthContext(context.workspaceId);
 
-  await deps.globalWorkspaceOrmManager.executeInWorkspaceContext(
-    authContext,
-    async () => {
-      const workflowRepository =
-        await deps.globalWorkspaceOrmManager.getRepository(
-          context.workspaceId,
-          'workflow',
-          context.rolePermissionConfig,
-        );
+  await deps.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+    const workflowRepository =
+      await deps.globalWorkspaceOrmManager.getRepository(
+        context.workspaceId,
+        'workflow',
+        context.rolePermissionConfig,
+      );
 
-      await workflowRepository.update(workflowId, {
-        statuses: [WorkflowStatus.ACTIVE],
-        lastPublishedVersionId: workflowVersionId,
-      });
-    },
-  );
+    await workflowRepository.update(workflowId, {
+      statuses: [WorkflowStatus.ACTIVE],
+      lastPublishedVersionId: workflowVersionId,
+    });
+  }, authContext);
 };

--- a/packages/twenty-server/src/modules/workflow/workflow-tools/tools/get-workflow-current-version.tool.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-tools/tools/get-workflow-current-version.tool.ts
@@ -35,7 +35,6 @@ export const createGetWorkflowCurrentVersionTool = (
       const authContext = buildSystemAuthContext(context.workspaceId);
 
       return await deps.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        authContext,
         async () => {
           const workflowRepository =
             await deps.globalWorkspaceOrmManager.getRepository<WorkflowWorkspaceEntity>(
@@ -103,6 +102,7 @@ export const createGetWorkflowCurrentVersionTool = (
             },
           };
         },
+        authContext,
       );
     } catch (error) {
       return {

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/automated-trigger.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/automated-trigger.workspace-service.ts
@@ -27,22 +27,19 @@ export class AutomatedTriggerWorkspaceService {
   }) {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const workflowAutomatedTriggerRepository =
-          await this.globalWorkspaceOrmManager.getRepository<WorkflowAutomatedTriggerWorkspaceEntity>(
-            workspaceId,
-            'workflowAutomatedTrigger',
-          );
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const workflowAutomatedTriggerRepository =
+        await this.globalWorkspaceOrmManager.getRepository<WorkflowAutomatedTriggerWorkspaceEntity>(
+          workspaceId,
+          'workflowAutomatedTrigger',
+        );
 
-        await workflowAutomatedTriggerRepository.insert({
-          type,
-          settings,
-          workflowId,
-        });
-      },
-    );
+      await workflowAutomatedTriggerRepository.insert({
+        type,
+        settings,
+        workflowId,
+      });
+    }, authContext);
   }
 
   async deleteAutomatedTrigger({
@@ -54,17 +51,14 @@ export class AutomatedTriggerWorkspaceService {
   }) {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
-      async () => {
-        const workflowAutomatedTriggerRepository =
-          await this.globalWorkspaceOrmManager.getRepository<WorkflowAutomatedTriggerWorkspaceEntity>(
-            workspaceId,
-            'workflowAutomatedTrigger',
-          );
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const workflowAutomatedTriggerRepository =
+        await this.globalWorkspaceOrmManager.getRepository<WorkflowAutomatedTriggerWorkspaceEntity>(
+          workspaceId,
+          'workflowAutomatedTrigger',
+        );
 
-        await workflowAutomatedTriggerRepository.delete({ workflowId });
-      },
-    );
+      await workflowAutomatedTriggerRepository.delete({ workflowId });
+    }, authContext);
   }
 }

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/listeners/__tests__/workflow-database-event-trigger.listener.spec.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/automated-trigger/listeners/__tests__/workflow-database-event-trigger.listener.spec.ts
@@ -52,7 +52,7 @@ describe('WorkflowDatabaseEventTriggerListener', () => {
       getRepository: jest.fn().mockResolvedValue(mockRepository),
       executeInWorkspaceContext: jest
         .fn()
-        .mockImplementation((_authContext: any, fn: () => any) => fn()),
+        .mockImplementation((fn: () => any, _authContext?: any) => fn()),
     } as any;
 
     messageQueueService = {

--- a/packages/twenty-server/src/modules/workflow/workflow-trigger/workspace-services/workflow-trigger.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-trigger/workspace-services/workflow-trigger.workspace-service.ts
@@ -82,7 +82,6 @@ export class WorkflowTriggerWorkspaceService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const workflowVersionRepository =
           await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
@@ -132,6 +131,7 @@ export class WorkflowTriggerWorkspaceService {
 
         return true;
       },
+      authContext,
     );
   }
 
@@ -142,7 +142,6 @@ export class WorkflowTriggerWorkspaceService {
     const authContext = buildSystemAuthContext(workspaceId);
 
     return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-      authContext,
       async () => {
         const workflowVersionRepository =
           await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
@@ -159,6 +158,7 @@ export class WorkflowTriggerWorkspaceService {
 
         return true;
       },
+      authContext,
     );
   }
 

--- a/packages/twenty-server/src/modules/workspace-member/query-hooks/workspace-member-delete-one.post-query.hook.ts
+++ b/packages/twenty-server/src/modules/workspace-member/query-hooks/workspace-member-delete-one.post-query.hook.ts
@@ -63,7 +63,6 @@ export class WorkspaceMemberDeleteOnePostQueryHook
 
     const workspaceMember =
       await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
-        authContext as WorkspaceAuthContext,
         async () => {
           const workspaceMemberRepository =
             await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
@@ -78,6 +77,7 @@ export class WorkspaceMemberDeleteOnePostQueryHook
             withDeleted: true,
           });
         },
+        authContext as WorkspaceAuthContext,
       );
 
     if (!isDefined(workspaceMember)) {


### PR DESCRIPTION
## Context
Introduces a middleware that automatically sets the workspace auth context in AsyncLocalStorage for HTTP requests, making it available throughout the request lifecycle without explicit parameter passing.

The motivation behind this change is to reduce boilerplate and simplify the developer experience when working with workspace data in HTTP request handlers.

The Problem (Before)
Every HTTP request handler that needed to access workspace data had to:
- Extract auth-related info from decorators (@AuthWorkspace(), @AuthUserWorkspaceId(), etc.) in controller/resolver and pass down to services
- Build or pass the authContext explicitly (sometimes with type assertion which was flaky)
Then call executeInWorkspaceContext(authContext, async () => { ... })

## Changes
- Add WorkspaceAuthContextMiddleware that extracts auth context from the request and stores it in AsyncLocalStorage
- Register middleware for GraphQL, metadata, and REST routes (runs after hydration middlewares)
- Simplify executeInWorkspaceContext signature: fn is now the first parameter, authContext is optional second
- If authContext is not provided, it's automatically retrieved from the storage (set by middleware)
- Update all callers (~120 files) to use the new parameter order


- Fixes a bug in search where system auth context was used, bypassing RLS feature.