### PR TITLE
Nested serialized relation property

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/__tests__/format-jsonb-serialized-relation.test-type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/__tests__/format-jsonb-serialized-relation.test-type.ts
@@ -2,32 +2,26 @@ import { type Equal, type Expect } from 'twenty-shared/testing';
 import { type SerializedRelation } from 'twenty-shared/types';
 
 import { type FormatJsonbSerializedRelation } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/format-jsonb-serialized-relation.type';
-import {
-  type JSONB_PROPERTY_BRAND,
-  type JsonbProperty,
-} from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/jsonb-property.type';
+import { type JsonbProperty } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/jsonb-property.type';
 
-type BrandedObjectWithRelation = JsonbProperty<{
-  name: string;
-  targetFieldMetadataId: SerializedRelation;
-}>;
-
-type BrandedObjectWithoutRelation = JsonbProperty<{
-  name: string;
-  count: number;
-}>;
-
-type UnbrandedObject = {
+type ObjectWithRelation = {
   name: string;
   targetFieldMetadataId: SerializedRelation;
 };
 
+type ObjectWithoutRelation = {
+  name: string;
+  count: number;
+};
+
+type BrandedObjectWithRelation = JsonbProperty<ObjectWithRelation>;
+
 // eslint-disable-next-line unused-imports/no-unused-vars
-type BrandedObjectAssertions = [
-  // Branded object with SerializedRelation: Id suffix renamed to UniversalIdentifier
+type ObjectAssertions = [
+  // Object with SerializedRelation: Id suffix renamed to UniversalIdentifier
   Expect<
     Equal<
-      FormatJsonbSerializedRelation<BrandedObjectWithRelation>,
+      FormatJsonbSerializedRelation<ObjectWithRelation>,
       {
         name: string;
         targetFieldMetadataUniversalIdentifier: SerializedRelation;
@@ -35,23 +29,24 @@ type BrandedObjectAssertions = [
     >
   >,
 
-  // Branded object without SerializedRelation: no renaming, just removes brand
+  // Branded object with SerializedRelation: renames property, preserves brand key
   Expect<
     Equal<
-      FormatJsonbSerializedRelation<BrandedObjectWithoutRelation>,
+      FormatJsonbSerializedRelation<BrandedObjectWithRelation>,
       {
         name: string;
-        count: number;
+        targetFieldMetadataUniversalIdentifier: SerializedRelation;
+        __JsonbPropertyBrand__?: undefined;
       }
     >
   >,
-];
 
-// eslint-disable-next-line unused-imports/no-unused-vars
-type UnbrandedObjectAssertions = [
-  // Unbranded objects pass through unchanged
+  // Object without SerializedRelation: no changes
   Expect<
-    Equal<FormatJsonbSerializedRelation<UnbrandedObject>, UnbrandedObject>
+    Equal<
+      FormatJsonbSerializedRelation<ObjectWithoutRelation>,
+      ObjectWithoutRelation
+    >
   >,
 ];
 
@@ -65,10 +60,10 @@ type PrimitiveAssertions = [
 
 // eslint-disable-next-line unused-imports/no-unused-vars
 type ArrayAssertions = [
-  // Array of branded objects: transforms each element
+  // Array of objects with relation: transforms each element
   Expect<
     Equal<
-      FormatJsonbSerializedRelation<BrandedObjectWithRelation[]>,
+      FormatJsonbSerializedRelation<ObjectWithRelation[]>,
       {
         name: string;
         targetFieldMetadataUniversalIdentifier: SerializedRelation;
@@ -76,48 +71,35 @@ type ArrayAssertions = [
     >
   >,
 
-  // Array of unbranded objects: passes through unchanged
+  // Array of objects without relation: passes through unchanged
   Expect<
-    Equal<FormatJsonbSerializedRelation<UnbrandedObject[]>, UnbrandedObject[]>
+    Equal<
+      FormatJsonbSerializedRelation<ObjectWithoutRelation[]>,
+      ObjectWithoutRelation[]
+    >
   >,
 
   // Array of primitives: passes through unchanged
   Expect<Equal<FormatJsonbSerializedRelation<string[]>, string[]>>,
 
-  // Nested array of branded objects: transforms innermost elements
+  // Nested array of objects: transforms innermost elements
   Expect<
     Equal<
-      FormatJsonbSerializedRelation<BrandedObjectWithRelation[][]>,
+      FormatJsonbSerializedRelation<ObjectWithRelation[][]>,
       {
         name: string;
         targetFieldMetadataUniversalIdentifier: SerializedRelation;
       }[][]
     >
   >,
-
-  // Array of unbranded and branded objects union: transforms branded element
-  Expect<
-    Equal<
-      FormatJsonbSerializedRelation<
-        (BrandedObjectWithRelation | UnbrandedObject)[]
-      >,
-      (
-        | {
-            name: string;
-            targetFieldMetadataUniversalIdentifier: SerializedRelation;
-          }
-        | UnbrandedObject
-      )[]
-    >
-  >,
 ];
 
 // eslint-disable-next-line unused-imports/no-unused-vars
 type UnionAssertions = [
-  // Union with null: transforms branded object, keeps null
+  // Union with null: transforms object, keeps null
   Expect<
     Equal<
-      FormatJsonbSerializedRelation<BrandedObjectWithRelation | null>,
+      FormatJsonbSerializedRelation<ObjectWithRelation | null>,
       {
         name: string;
         targetFieldMetadataUniversalIdentifier: SerializedRelation;
@@ -128,7 +110,7 @@ type UnionAssertions = [
   // Array of union: transforms elements appropriately
   Expect<
     Equal<
-      FormatJsonbSerializedRelation<(BrandedObjectWithRelation | null)[]>,
+      FormatJsonbSerializedRelation<(ObjectWithRelation | null)[]>,
       ({
         name: string;
         targetFieldMetadataUniversalIdentifier: SerializedRelation;
@@ -137,12 +119,12 @@ type UnionAssertions = [
   >,
 ];
 
-type MultipleRelationsObject = JsonbProperty<{
+type MultipleRelationsObject = {
   name: string;
   sourceFieldId: SerializedRelation;
   targetFieldId: SerializedRelation;
   regularId: string;
-}>;
+};
 
 // eslint-disable-next-line unused-imports/no-unused-vars
 type MultipleRelationsAssertions = [
@@ -160,14 +142,113 @@ type MultipleRelationsAssertions = [
   >,
 ];
 
-// Verify brand is removed
-type BrandRemovedCheck =
-  FormatJsonbSerializedRelation<BrandedObjectWithRelation>;
+type NestedObjectWithRelation = {
+  name: string;
+  nested: {
+    fieldMetadataId: SerializedRelation;
+  };
+};
+
+type DeeplyNestedObjectWithRelation = {
+  name: string;
+  level1: {
+    level2: {
+      targetId: SerializedRelation;
+    };
+  };
+};
+
+type MixedNestedObject = {
+  name: string;
+  directRelationId: SerializedRelation;
+  nested: {
+    nestedRelationId: SerializedRelation;
+    plainField: string;
+  };
+};
+
+type NullableNestedObject = {
+  name: string;
+  nested: {
+    relationId: SerializedRelation;
+  } | null;
+};
+
+type NestedWithArrayOfObjects = {
+  name: string;
+  items: {
+    itemRelationId: SerializedRelation;
+  }[];
+};
 
 // eslint-disable-next-line unused-imports/no-unused-vars
-type BrandRemovedAssertion = Expect<
-  Equal<
-    typeof JSONB_PROPERTY_BRAND extends keyof BrandRemovedCheck ? true : false,
-    false
-  >
->;
+type NestedObjectAssertions = [
+  // Simple nested object: transforms relation inside nested object
+  Expect<
+    Equal<
+      FormatJsonbSerializedRelation<NestedObjectWithRelation>,
+      {
+        name: string;
+        nested: {
+          fieldMetadataUniversalIdentifier: SerializedRelation;
+        };
+      }
+    >
+  >,
+
+  // Deeply nested object: transforms relation at any depth
+  Expect<
+    Equal<
+      FormatJsonbSerializedRelation<DeeplyNestedObjectWithRelation>,
+      {
+        name: string;
+        level1: {
+          level2: {
+            targetUniversalIdentifier: SerializedRelation;
+          };
+        };
+      }
+    >
+  >,
+
+  // Mixed: transforms both direct and nested relations
+  Expect<
+    Equal<
+      FormatJsonbSerializedRelation<MixedNestedObject>,
+      {
+        name: string;
+        directRelationUniversalIdentifier: SerializedRelation;
+        nested: {
+          nestedRelationUniversalIdentifier: SerializedRelation;
+          plainField: string;
+        };
+      }
+    >
+  >,
+
+  // Nullable nested object: transforms relation inside, preserves union with null
+  Expect<
+    Equal<
+      FormatJsonbSerializedRelation<NullableNestedObject>,
+      {
+        name: string;
+        nested: {
+          relationUniversalIdentifier: SerializedRelation;
+        } | null;
+      }
+    >
+  >,
+
+  // Nested with array of objects: transforms relations inside array elements
+  Expect<
+    Equal<
+      FormatJsonbSerializedRelation<NestedWithArrayOfObjects>,
+      {
+        name: string;
+        items: {
+          itemRelationUniversalIdentifier: SerializedRelation;
+        }[];
+      }
+    >
+  >,
+];

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/__tests__/format-record-serialized-relation-properties.test-type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/__tests__/format-record-serialized-relation-properties.test-type.ts
@@ -1,7 +1,7 @@
 import { type Equal, type Expect } from 'twenty-shared/testing';
 import { type SerializedRelation } from 'twenty-shared/types';
 
-import { type FormatJsonbSerializedRelation } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/format-jsonb-serialized-relation.type';
+import { type FormatRecordSerializedRelationProperties } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/format-record-serialized-relation-properties.type';
 import { type JsonbProperty } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/jsonb-property.type';
 
 type ObjectWithRelation = {
@@ -21,7 +21,7 @@ type ObjectAssertions = [
   // Object with SerializedRelation: Id suffix renamed to UniversalIdentifier
   Expect<
     Equal<
-      FormatJsonbSerializedRelation<ObjectWithRelation>,
+      FormatRecordSerializedRelationProperties<ObjectWithRelation>,
       {
         name: string;
         targetFieldMetadataUniversalIdentifier: SerializedRelation;
@@ -32,7 +32,7 @@ type ObjectAssertions = [
   // Branded object with SerializedRelation: renames property, preserves brand key
   Expect<
     Equal<
-      FormatJsonbSerializedRelation<BrandedObjectWithRelation>,
+      FormatRecordSerializedRelationProperties<BrandedObjectWithRelation>,
       {
         name: string;
         targetFieldMetadataUniversalIdentifier: SerializedRelation;
@@ -44,7 +44,7 @@ type ObjectAssertions = [
   // Object without SerializedRelation: no changes
   Expect<
     Equal<
-      FormatJsonbSerializedRelation<ObjectWithoutRelation>,
+      FormatRecordSerializedRelationProperties<ObjectWithoutRelation>,
       ObjectWithoutRelation
     >
   >,
@@ -53,9 +53,9 @@ type ObjectAssertions = [
 // eslint-disable-next-line unused-imports/no-unused-vars
 type PrimitiveAssertions = [
   // Primitives pass through unchanged
-  Expect<Equal<FormatJsonbSerializedRelation<string>, string>>,
-  Expect<Equal<FormatJsonbSerializedRelation<number>, number>>,
-  Expect<Equal<FormatJsonbSerializedRelation<null>, null>>,
+  Expect<Equal<FormatRecordSerializedRelationProperties<string>, string>>,
+  Expect<Equal<FormatRecordSerializedRelationProperties<number>, number>>,
+  Expect<Equal<FormatRecordSerializedRelationProperties<null>, null>>,
 ];
 
 // eslint-disable-next-line unused-imports/no-unused-vars
@@ -63,7 +63,7 @@ type ArrayAssertions = [
   // Array of objects with relation: transforms each element
   Expect<
     Equal<
-      FormatJsonbSerializedRelation<ObjectWithRelation[]>,
+      FormatRecordSerializedRelationProperties<ObjectWithRelation[]>,
       {
         name: string;
         targetFieldMetadataUniversalIdentifier: SerializedRelation;
@@ -74,18 +74,18 @@ type ArrayAssertions = [
   // Array of objects without relation: passes through unchanged
   Expect<
     Equal<
-      FormatJsonbSerializedRelation<ObjectWithoutRelation[]>,
+      FormatRecordSerializedRelationProperties<ObjectWithoutRelation[]>,
       ObjectWithoutRelation[]
     >
   >,
 
   // Array of primitives: passes through unchanged
-  Expect<Equal<FormatJsonbSerializedRelation<string[]>, string[]>>,
+  Expect<Equal<FormatRecordSerializedRelationProperties<string[]>, string[]>>,
 
   // Nested array of objects: transforms innermost elements
   Expect<
     Equal<
-      FormatJsonbSerializedRelation<ObjectWithRelation[][]>,
+      FormatRecordSerializedRelationProperties<ObjectWithRelation[][]>,
       {
         name: string;
         targetFieldMetadataUniversalIdentifier: SerializedRelation;
@@ -99,7 +99,7 @@ type UnionAssertions = [
   // Union with null: transforms object, keeps null
   Expect<
     Equal<
-      FormatJsonbSerializedRelation<ObjectWithRelation | null>,
+      FormatRecordSerializedRelationProperties<ObjectWithRelation | null>,
       {
         name: string;
         targetFieldMetadataUniversalIdentifier: SerializedRelation;
@@ -110,7 +110,7 @@ type UnionAssertions = [
   // Array of union: transforms elements appropriately
   Expect<
     Equal<
-      FormatJsonbSerializedRelation<(ObjectWithRelation | null)[]>,
+      FormatRecordSerializedRelationProperties<(ObjectWithRelation | null)[]>,
       ({
         name: string;
         targetFieldMetadataUniversalIdentifier: SerializedRelation;
@@ -131,7 +131,7 @@ type MultipleRelationsAssertions = [
   // Multiple SerializedRelation properties: all get renamed
   Expect<
     Equal<
-      FormatJsonbSerializedRelation<MultipleRelationsObject>,
+      FormatRecordSerializedRelationProperties<MultipleRelationsObject>,
       {
         name: string;
         sourceFieldUniversalIdentifier: SerializedRelation;
@@ -186,7 +186,7 @@ type NestedObjectAssertions = [
   // Simple nested object: transforms relation inside nested object
   Expect<
     Equal<
-      FormatJsonbSerializedRelation<NestedObjectWithRelation>,
+      FormatRecordSerializedRelationProperties<NestedObjectWithRelation>,
       {
         name: string;
         nested: {
@@ -199,7 +199,7 @@ type NestedObjectAssertions = [
   // Deeply nested object: transforms relation at any depth
   Expect<
     Equal<
-      FormatJsonbSerializedRelation<DeeplyNestedObjectWithRelation>,
+      FormatRecordSerializedRelationProperties<DeeplyNestedObjectWithRelation>,
       {
         name: string;
         level1: {
@@ -214,7 +214,7 @@ type NestedObjectAssertions = [
   // Mixed: transforms both direct and nested relations
   Expect<
     Equal<
-      FormatJsonbSerializedRelation<MixedNestedObject>,
+      FormatRecordSerializedRelationProperties<MixedNestedObject>,
       {
         name: string;
         directRelationUniversalIdentifier: SerializedRelation;
@@ -229,7 +229,7 @@ type NestedObjectAssertions = [
   // Nullable nested object: transforms relation inside, preserves union with null
   Expect<
     Equal<
-      FormatJsonbSerializedRelation<NullableNestedObject>,
+      FormatRecordSerializedRelationProperties<NullableNestedObject>,
       {
         name: string;
         nested: {
@@ -242,7 +242,7 @@ type NestedObjectAssertions = [
   // Nested with array of objects: transforms relations inside array elements
   Expect<
     Equal<
-      FormatJsonbSerializedRelation<NestedWithArrayOfObjects>,
+      FormatRecordSerializedRelationProperties<NestedWithArrayOfObjects>,
       {
         name: string;
         items: {

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/__tests__/universal-flat-field-metadata.test-type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/__tests__/universal-flat-field-metadata.test-type.ts
@@ -99,6 +99,7 @@ type NarrowedExpectedResult = {
   onDelete?: RelationOnDeleteAction | undefined;
   joinColumnName?: string | null | undefined;
   junctionTargetFieldUniversalIdentifier?: SerializedRelation | undefined;
+  __JsonbPropertyBrand__?: undefined;
 };
 
 type SettingsTestCase = UniversalFlatFieldMetadata<
@@ -111,14 +112,17 @@ type SettingsExpectedResult =
       onDelete?: RelationOnDeleteAction | undefined;
       joinColumnName?: string | null | undefined;
       junctionTargetFieldUniversalIdentifier?: SerializedRelation | undefined;
+      __JsonbPropertyBrand__?: undefined;
     }
   | {
       dataType?: NumberDataType | undefined;
       decimals?: number | undefined;
       type?: FieldNumberVariant | undefined;
+      __JsonbPropertyBrand__?: undefined;
     }
   | {
       displayedMaxRows?: number | undefined;
+      __JsonbPropertyBrand__?: undefined;
     }
   | null;
 
@@ -137,11 +141,13 @@ type DefaultValueExpectedResult =
   | {
       amountMicros: string | null;
       currencyCode: string | null;
+      __JsonbPropertyBrand__?: undefined;
     }
   | {
       primaryLinkLabel: string | null;
       primaryLinkUrl: string | null;
       secondaryLinks: LinkMetadata[] | null;
+      __JsonbPropertyBrand__?: undefined;
     };
 
 type OptionsTestCase =

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/format-jsonb-serialized-relation.type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/format-jsonb-serialized-relation.type.ts
@@ -1,21 +1,18 @@
 import { type ExtractSerializedRelationProperties } from 'twenty-shared/types';
 
-import { type HasJsonbPropertyBrand } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/extract-jsonb-properties.type';
-import { type JSONB_PROPERTY_BRAND } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/jsonb-property.type';
 import { type RemoveSuffix } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/remove-suffix.type';
 
 export type FormatJsonbSerializedRelation<T> = T extends unknown
   ? T extends (infer U)[]
     ? FormatJsonbSerializedRelation<U>[]
-    : HasJsonbPropertyBrand<T> extends true
-      ? Omit<
-          {
+    : T extends string
+      ? T
+      : T extends object
+        ? {
             [P in keyof T as P extends ExtractSerializedRelationProperties<T> &
               string
               ? `${RemoveSuffix<P, 'Id'>}UniversalIdentifier`
-              : P]: T[P];
-          },
-          typeof JSONB_PROPERTY_BRAND
-        >
-      : T
+              : P]: FormatJsonbSerializedRelation<T[P]>;
+          }
+        : T
   : never;

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/format-record-serialized-relation-properties.type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/format-record-serialized-relation-properties.type.ts
@@ -2,9 +2,9 @@ import { type ExtractSerializedRelationProperties } from 'twenty-shared/types';
 
 import { type RemoveSuffix } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/remove-suffix.type';
 
-export type FormatJsonbSerializedRelation<T> = T extends unknown
+export type FormatRecordSerializedRelationProperties<T> = T extends unknown
   ? T extends (infer U)[]
-    ? FormatJsonbSerializedRelation<U>[]
+    ? FormatRecordSerializedRelationProperties<U>[]
     : T extends string
       ? T
       : T extends object
@@ -12,7 +12,7 @@ export type FormatJsonbSerializedRelation<T> = T extends unknown
             [P in keyof T as P extends ExtractSerializedRelationProperties<T> &
               string
               ? `${RemoveSuffix<P, 'Id'>}UniversalIdentifier`
-              : P]: FormatJsonbSerializedRelation<T[P]>;
+              : P]: FormatRecordSerializedRelationProperties<T[P]>;
           }
         : T
   : never;

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-entity-from.type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-entity-from.type.ts
@@ -8,7 +8,6 @@ import { type MetadataManyToOneJoinColumn } from 'src/engine/metadata-modules/fl
 import { type SyncableEntity } from 'src/engine/workspace-manager/types/syncable-entity.interface';
 import { type ExtractJsonbProperties } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/extract-jsonb-properties.type';
 import { type FormatJsonbSerializedRelation } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/format-jsonb-serialized-relation.type';
-import { JSONB_PROPERTY_BRAND } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/jsonb-property.type';
 import { type RemoveSuffix } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/remove-suffix.type';
 
 // TODO Handle universal settings
@@ -39,7 +38,6 @@ export type UniversalFlatEntityFrom<
   } & {
     applicationUniversalIdentifier: string;
   } & {
-    [P in ExtractJsonbProperties<TEntity>]: Omit<FormatJsonbSerializedRelation<
-      TEntity[P]
-    >, typeof JSONB_PROPERTY_BRAND>;
+    [P in ExtractJsonbProperties<TEntity>]:
+      FormatJsonbSerializedRelation<TEntity[P]>
   };

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-entity-from.type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-entity-from.type.ts
@@ -7,7 +7,7 @@ import { type FromMetadataEntityToMetadataName } from 'src/engine/metadata-modul
 import { type MetadataManyToOneJoinColumn } from 'src/engine/metadata-modules/flat-entity/types/metadata-many-to-one-join-column.type';
 import { type SyncableEntity } from 'src/engine/workspace-manager/types/syncable-entity.interface';
 import { type ExtractJsonbProperties } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/extract-jsonb-properties.type';
-import { type FormatJsonbSerializedRelation } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/format-jsonb-serialized-relation.type';
+import { type FormatRecordSerializedRelationProperties } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/format-record-serialized-relation-properties.type';
 import { type RemoveSuffix } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/remove-suffix.type';
 
 // TODO Handle universal settings
@@ -38,7 +38,7 @@ export type UniversalFlatEntityFrom<
   } & {
     applicationUniversalIdentifier: string;
   } & {
-    [P in ExtractJsonbProperties<TEntity>]: FormatJsonbSerializedRelation<
+    [P in ExtractJsonbProperties<TEntity>]: FormatRecordSerializedRelationProperties<
       TEntity[P]
     >;
   };

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-entity-from.type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-entity-from.type.ts
@@ -38,6 +38,7 @@ export type UniversalFlatEntityFrom<
   } & {
     applicationUniversalIdentifier: string;
   } & {
-    [P in ExtractJsonbProperties<TEntity>]:
-      FormatJsonbSerializedRelation<TEntity[P]>
+    [P in ExtractJsonbProperties<TEntity>]: FormatJsonbSerializedRelation<
+      TEntity[P]
+    >;
   };

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-entity-from.type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-entity-from.type.ts
@@ -8,6 +8,7 @@ import { type MetadataManyToOneJoinColumn } from 'src/engine/metadata-modules/fl
 import { type SyncableEntity } from 'src/engine/workspace-manager/types/syncable-entity.interface';
 import { type ExtractJsonbProperties } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/extract-jsonb-properties.type';
 import { type FormatJsonbSerializedRelation } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/format-jsonb-serialized-relation.type';
+import { JSONB_PROPERTY_BRAND } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/jsonb-property.type';
 import { type RemoveSuffix } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/remove-suffix.type';
 
 // TODO Handle universal settings
@@ -38,7 +39,7 @@ export type UniversalFlatEntityFrom<
   } & {
     applicationUniversalIdentifier: string;
   } & {
-    [P in ExtractJsonbProperties<TEntity>]: FormatJsonbSerializedRelation<
+    [P in ExtractJsonbProperties<TEntity>]: Omit<FormatJsonbSerializedRelation<
       TEntity[P]
-    >;
+    >, typeof JSONB_PROPERTY_BRAND>;
   };


### PR DESCRIPTION
## Introduction
Handling nested serializedRelation references mapping
Removed the brand signature omit for the moment
I want to determine if it's really problematic later in the devx 
## Motivation

```ts
@ObjectType('RatioAggregateConfig')
export class RatioAggregateConfigDTO {
  @Field(() => UUIDScalarType)
  @IsUUID()
  @IsNotEmpty()
  fieldMetadataId: SerializedRelation;

  @Field(() => String)
  @IsString()
  @IsNotEmpty()
  optionValue: string;
}


@ObjectType('AggregateChartConfiguration')
export class AggregateChartConfigurationDTO
  implements PageLayoutWidgetConfigurationBase
{
// ...
  @Field(() => RatioAggregateConfigDTO, { nullable: true })
  @ValidateNested()
  @Type(() => RatioAggregateConfigDTO)
  @IsOptional()
  ratioAggregateConfig?: RatioAggregateConfigDTO;
}

```

Blocking https://github.com/twentyhq/twenty/pull/17452