### PR TITLE
Fix error "No widget found in canvas layout"

### DIFF
--- a/packages/twenty-front/src/modules/page-layout/components/PageLayoutCanvasViewer.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/PageLayoutCanvasViewer.tsx
@@ -18,7 +18,7 @@ export const PageLayoutCanvasViewer = ({
   const widget = widgets.at(0);
 
   if (!isDefined(widget)) {
-    throw new Error('No widget found in canvas layout');
+    return null;
   }
 
   return (


### PR DESCRIPTION
Fix https://github.com/twentyhq/twenty/issues/17507

The canvas layout mode is expected to render a single widget. Previously, we threw an error when trying to render a canvas layout with no widgets at all. This worked fine when we immediately rendered a widget that used a single-widget canvas layout.

However, the active tab ID is shared across all page layouts with the same ID, which doesn’t work well with conditional display. The available tabs may depend on conditions such as the device displaying the page. For example, when displaying a Note on the show page, the Note widget appears on a separate tab. On mobile and in the side panel, however, it is moved to the Home tab.

After that, if the user opens a Note in the side panel, the default active tab might be the Note tab, which uses a _canvas_ layout mode and would have no widgets at all when rendered in the side panel. This leads to the error mentioned above.

The simple workaround is to wait one tick. An `Effect` component then detects that the active tab doesn’t exist in the list of allowed tabs and switches to another tab by default.

This feels more like a workaround than a proper solution, but I prefer to fix it this way for now. We can later revisit this and design a better separation for the selected tab ID state.

## Before

https://github.com/user-attachments/assets/500e332c-1623-48e5-b69b-5a4fa4e5e28d

## After

https://github.com/user-attachments/assets/b39dcf96-1852-42e4-a8cc-a79bf9036579


