### PR TITLE
[Bug] Fix broken variables for database event

### DIFF
--- a/packages/twenty-front/src/modules/workflow/workflow-steps/components/WorkflowDropdownStepOutputItems.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/components/WorkflowDropdownStepOutputItems.tsx
@@ -176,7 +176,7 @@ export const WorkflowDropdownStepOutputItems = ({
     updateStepFilter({
       rawVariableName: getVariableTemplateFromPath({
         stepId: step.id,
-        path: [...currentPath, 'id'],
+        path: [...currentPath, currentSubStep.object.fieldIdName ?? 'id'],
       }),
       isFullRecord: true,
     });

--- a/packages/twenty-shared/src/workflow/utils/__tests__/variable-path.util.test.ts
+++ b/packages/twenty-shared/src/workflow/utils/__tests__/variable-path.util.test.ts
@@ -12,10 +12,6 @@ describe('variable path utility functions', () => {
       expect(needsEscaping('toto toto')).toBe(true);
     });
 
-    it('should return true for keys with dots', () => {
-      expect(needsEscaping('key.with.dots')).toBe(true);
-    });
-
     it('should return true for keys with brackets', () => {
       expect(needsEscaping('key[0]')).toBe(true);
       expect(needsEscaping('[key]')).toBe(true);
@@ -33,10 +29,6 @@ describe('variable path utility functions', () => {
         expect(escapePathSegment('key with space')).toBe('[key with space]');
       });
 
-      it('should wrap keys with dots in brackets', () => {
-        expect(escapePathSegment('key.with.dots')).toBe('[key.with.dots]');
-      });
-
       it('should not modify simple keys', () => {
         expect(escapePathSegment('simpleKey')).toBe('simpleKey');
       });
@@ -52,12 +44,6 @@ describe('variable path utility functions', () => {
       it('should escape segments with spaces', () => {
         expect(joinVariablePath(['step', 'key with space', 'value'])).toBe(
           'step.[key with space].value',
-        );
-      });
-
-      it('should escape segments with dots', () => {
-        expect(joinVariablePath(['step', 'key.with.dots'])).toBe(
-          'step.[key.with.dots]',
         );
       });
 
@@ -94,13 +80,6 @@ describe('variable path utility functions', () => {
         ]);
       });
 
-      it('should parse path with bracketed segments containing dots', () => {
-        expect(parseVariablePath('step.[key.with.dots]')).toEqual([
-          'step',
-          'key.with.dots',
-        ]);
-      });
-
       it('should handle multiple bracketed segments', () => {
         expect(
           parseVariablePath('[first key].[second key].[third key]'),
@@ -131,7 +110,6 @@ describe('variable path utility functions', () => {
         const paths = [
           ['step', 'field', 'value'],
           ['step', 'key with space', 'value'],
-          ['step', 'key.with.dots'],
           ['step', 'normal', 'has space', 'another'],
         ];
 

--- a/packages/twenty-shared/src/workflow/utils/variable-path.util.ts
+++ b/packages/twenty-shared/src/workflow/utils/variable-path.util.ts
@@ -1,6 +1,5 @@
 // Characters that require bracket escaping in variable paths
-// Spaces, dots, and brackets would break the dot-notation parsing
-const SPECIAL_CHARS_REGEX = /[\s.[]/;
+const SPECIAL_CHARS_REGEX = /[\s[]/;
 
 export const needsEscaping = (key: string): boolean =>
   SPECIAL_CHARS_REGEX.test(key);


### PR DESCRIPTION
Fix https://github.com/twentyhq/twenty/issues/17524

Recent update meant to support variable with spaces and dots broken the database event variables. Inserting a variable `My Name` will be inserted as `{{trigger.[My Name]}}`

For example, for a database event, we send `trigger.properties.after.id` instead of `id`.
With the new code, we will consider `properties.after.id` as a variable to wrap in `[]`, giving `trigger.[properties.after.id]` which cannot be resolve.

Let's only support variable with spaces. Removing the logic to wrap variable with dots.