### PR TITLE
Refactor `delete` `objectMetadata` action type and handler to be workspace agnostic

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/application/application.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application.resolver.ts
@@ -117,7 +117,6 @@ export class ApplicationResolver {
     }
 
     await this.workspaceMigrationRunnerService.run({
-      // @ts-expect-error ignoring until we implement a production ready validation schema for workspaceMigration
       actions,
       workspaceId,
     });

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/utils/__tests__/aggregate-orchestrator-actions-report-deprioritize-search-vector-update-field-actions.util.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/utils/__tests__/aggregate-orchestrator-actions-report-deprioritize-search-vector-update-field-actions.util.spec.ts
@@ -21,7 +21,6 @@ describe('aggregateOrchestratorActionsReportDeprioritizeSearchVectorUpdateFieldA
             type: 'update',
             metadataName: 'fieldMetadata',
             entityId: 'search-vector-field-1',
-            objectMetadataId: 'object-1',
             updates: [
               {
                 property: 'label',
@@ -34,7 +33,6 @@ describe('aggregateOrchestratorActionsReportDeprioritizeSearchVectorUpdateFieldA
             type: 'update',
             metadataName: 'fieldMetadata',
             entityId: 'regular-field-1',
-            objectMetadataId: 'object-1',
             updates: [
               {
                 property: 'label',
@@ -47,7 +45,6 @@ describe('aggregateOrchestratorActionsReportDeprioritizeSearchVectorUpdateFieldA
             type: 'update',
             metadataName: 'fieldMetadata',
             entityId: 'regular-field-2',
-            objectMetadataId: 'object-1',
             updates: [
               {
                 property: 'label',

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/field/types/workspace-migration-field-action.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/field/types/workspace-migration-field-action.ts
@@ -12,12 +12,7 @@ export type CreateFieldAction = Omit<
 };
 
 export type UpdateFieldAction =
-  BaseUpdateWorkspaceMigrationAction<'fieldMetadata'> & {
-    objectMetadataId: string;
-  };
+  BaseUpdateWorkspaceMigrationAction<'fieldMetadata'>;
 
 export type DeleteFieldAction =
-  BaseDeleteWorkspaceMigrationAction<'fieldMetadata'> & {
-    // Remove this
-    objectMetadataId: string;
-  };
+  BaseDeleteWorkspaceMigrationAction<'fieldMetadata'>;

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/field/workspace-migration-field-actions-builder.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/field/workspace-migration-field-actions-builder.service.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@nestjs/common';
 
 import { ALL_METADATA_NAME } from 'twenty-shared/metadata';
 
-import { findFlatEntityByIdInFlatEntityMapsOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps-or-throw.util';
 import { UpdateFieldAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/field/types/workspace-migration-field-action';
 import { WorkspaceEntityMigrationBuilderService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/services/workspace-entity-migration-builder.service';
 import { FlatEntityUpdateValidationArgs } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/flat-entity-update-validation-args.type';
@@ -73,7 +72,6 @@ export class WorkspaceMigrationFieldActionsBuilderService extends WorkspaceEntit
         type: 'delete',
         metadataName: 'fieldMetadata',
         universalIdentifier: flatFieldMetadataToValidate.universalIdentifier,
-        objectMetadataId: flatFieldMetadataToValidate.objectMetadataId,
       },
     };
   }
@@ -96,23 +94,12 @@ export class WorkspaceMigrationFieldActionsBuilderService extends WorkspaceEntit
       };
     }
 
-    const {
-      flatEntityId,
-      flatEntityUpdates,
-      optimisticFlatEntityMapsAndRelatedFlatEntityMaps,
-    } = args;
-
-    const flatFieldMetadata = findFlatEntityByIdInFlatEntityMapsOrThrow({
-      flatEntityId: flatEntityId,
-      flatEntityMaps:
-        optimisticFlatEntityMapsAndRelatedFlatEntityMaps.flatFieldMetadataMaps,
-    });
+    const { flatEntityId, flatEntityUpdates } = args;
 
     const updateFieldAction: UpdateFieldAction = {
       type: 'update',
       metadataName: 'fieldMetadata',
       entityId: flatEntityId,
-      objectMetadataId: flatFieldMetadata.objectMetadataId,
       updates: flatEntityUpdates,
     };
 

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/field/services/delete-field-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/field/services/delete-field-action-handler.service.ts
@@ -8,6 +8,10 @@ import { FieldMetadataEntity } from 'src/engine/metadata-modules/field-metadata/
 import { findFlatEntityByUniversalIdentifierOrThrow } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier-or-throw.util';
 import { WorkspaceSchemaManagerService } from 'src/engine/twenty-orm/workspace-schema-manager/workspace-schema-manager.service';
 import { type DeleteFieldAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/field/types/workspace-migration-field-action';
+import {
+  WorkspaceMigrationActionExecutionException,
+  WorkspaceMigrationActionExecutionExceptionCode,
+} from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/exceptions/workspace-migration-action-execution.exception';
 import { type WorkspaceMigrationActionRunnerArgs } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/types/workspace-migration-action-runner-args.type';
 import { generateColumnDefinitions } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/generate-column-definitions.util';
 import { getWorkspaceSchemaContextForMigration } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/get-workspace-schema-context-for-migration.util';
@@ -70,9 +74,10 @@ export class DeleteFieldActionHandlerService extends WorkspaceMigrationRunnerAct
       fieldMetadata.__universal?.objectMetadataUniversalIdentifier;
 
     if (!isDefined(objectMetadataUniversalIdentifier)) {
-      throw new Error(
-        `objectMetadataUniversalIdentifier is not defined for field metadata ${universalIdentifier}`,
-      );
+      throw new WorkspaceMigrationActionExecutionException({
+        message: `objectMetadataUniversalIdentifier is not defined for field metadata ${universalIdentifier}`,
+        code: WorkspaceMigrationActionExecutionExceptionCode.NOT_SUPPORTED,
+      });
     }
 
     const flatObjectMetadata = findFlatEntityByUniversalIdentifierOrThrow({

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/field/services/update-field-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/field/services/update-field-action-handler.service.ts
@@ -100,7 +100,7 @@ export class UpdateFieldActionHandlerService extends WorkspaceMigrationRunnerAct
     const objectMetadataUniversalIdentifier =
       currentFlatFieldMetadata.__universal?.objectMetadataUniversalIdentifier;
 
-    if (!objectMetadataUniversalIdentifier) {
+    if (!isDefined(objectMetadataUniversalIdentifier)) {
       throw new WorkspaceMigrationActionExecutionException({
         message: `objectMetadataUniversalIdentifier is not defined for field metadata ${entityId}`,
         code: WorkspaceMigrationActionExecutionExceptionCode.NOT_SUPPORTED,

--- a/packages/twenty-server/test/integration/metadata/suites/application/__snapshots__/failing-install-application.integration-spec.ts.snap
+++ b/packages/twenty-server/test/integration/metadata/suites/application/__snapshots__/failing-install-application.integration-spec.ts.snap
@@ -17,7 +17,7 @@ exports[`Install application should fail when entity does not exist should fail 
       },
       "workspaceSchema": {
         "code": "ENTITY_NOT_FOUND",
-        "message": "Could not find flat entity in maps",
+        "message": "Could not find flat entity with universal identifier 20202020-6110-4547-9fd0-2525257a2c3f",
       },
     },
     "exceptionEventId": Any<String>,


### PR DESCRIPTION
# Introduction
Refactoring the delete and update field to use cached flatEntitty.__universal.objectMetadataUniversalIdentifier to infer related object