### PR TITLE
fix: lodash has prototype pollution vulnerability in _.unset and _.omit functions

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/logic-function-executor/drivers/layers/1/yarn.lock
+++ b/packages/twenty-server/src/engine/core-modules/logic-function-executor/drivers/layers/1/yarn.lock
@@ -2048,9 +2048,9 @@ __metadata:
   linkType: hard
 
 "lodash@npm:^4.17.15":
-  version: 4.17.21
-  resolution: "lodash@npm:4.17.21"
-  checksum: 10c0/d8cbea072bb08655bb4c989da418994b073a608dffa608b09ac04b43a791b12aeae7cd7ad919aa4c925f33b48490b5cfe6c1f71d827956071dae2e7bb3a6b74c
+  version: 4.17.23
+  resolution: "lodash@npm:4.17.23"
+  checksum: 10c0/1264a90469f5bb95d4739c43eb6277d15b6d9e186df4ac68c3620443160fc669e2f14c11e7d8b2ccf078b81d06147c01a8ccced9aab9f9f63d50dcf8cace6bf6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resolves [Dependabot Alert 399](https://github.com/twentyhq/twenty/security/dependabot/399).