### PR TITLE
fix: prevent tab synchronization between different records

### DIFF
--- a/packages/twenty-front/src/modules/page-layout/components/PageLayoutRenderer.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/PageLayoutRenderer.tsx
@@ -5,7 +5,9 @@ import { PageLayoutComponentInstanceContext } from '@/page-layout/states/context
 import { type PageLayout } from '@/page-layout/types/PageLayout';
 import { getTabListInstanceIdFromPageLayoutId } from '@/page-layout/utils/getTabListInstanceIdFromPageLayoutId';
 import { isPageLayoutEmpty } from '@/page-layout/utils/isPageLayoutEmpty';
+import { useLayoutRenderingContext } from '@/ui/layout/contexts/LayoutRenderingContext';
 import { TabListComponentInstanceContext } from '@/ui/layout/tab-list/states/contexts/TabListComponentInstanceContext';
+import { isDefined } from 'twenty-shared/utils';
 import 'react-grid-layout/css/styles.css';
 import 'react-resizable/css/styles.css';
 
@@ -19,6 +21,8 @@ export const PageLayoutRenderer = ({
   const { setIsPageLayoutInEditMode } =
     useSetIsPageLayoutInEditMode(pageLayoutId);
 
+  const layoutRenderingContext = useLayoutRenderingContext();
+
   const onInitialized = (pageLayout: PageLayout) => {
     if (isPageLayoutEmpty(pageLayout)) {
       setIsPageLayoutInEditMode(true);
@@ -26,6 +30,12 @@ export const PageLayoutRenderer = ({
       setIsPageLayoutInEditMode(false);
     }
   };
+
+  // Include record ID in tab instance ID to prevent tab synchronization between different records
+  const recordId = layoutRenderingContext?.targetRecordIdentifier?.id;
+  const tabListInstanceId = isDefined(recordId)
+    ? `${getTabListInstanceIdFromPageLayoutId(pageLayoutId)}-${recordId}`
+    : getTabListInstanceIdFromPageLayoutId(pageLayoutId);
 
   return (
     <PageLayoutComponentInstanceContext.Provider
@@ -35,7 +45,7 @@ export const PageLayoutRenderer = ({
     >
       <TabListComponentInstanceContext.Provider
         value={{
-          instanceId: getTabListInstanceIdFromPageLayoutId(pageLayoutId),
+          instanceId: tabListInstanceId,
         }}
       >
         <PageLayoutInitializationQueryEffect

--- a/packages/twenty-front/src/modules/page-layout/components/PageLayoutRenderer.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/PageLayoutRenderer.tsx
@@ -3,12 +3,10 @@ import { PageLayoutRendererContent } from '@/page-layout/components/PageLayoutRe
 import { useSetIsPageLayoutInEditMode } from '@/page-layout/hooks/useSetIsPageLayoutInEditMode';
 import { PageLayoutComponentInstanceContext } from '@/page-layout/states/contexts/PageLayoutComponentInstanceContext';
 import { type PageLayout } from '@/page-layout/types/PageLayout';
-import { getTabListInstanceIdFromPageLayoutId } from '@/page-layout/utils/getTabListInstanceIdFromPageLayoutId';
+import { getTabListInstanceIdFromPageLayoutAndRecord } from '@/page-layout/utils/getTabListInstanceIdFromPageLayoutAndRecord';
 import { isPageLayoutEmpty } from '@/page-layout/utils/isPageLayoutEmpty';
 import { useLayoutRenderingContext } from '@/ui/layout/contexts/LayoutRenderingContext';
 import { TabListComponentInstanceContext } from '@/ui/layout/tab-list/states/contexts/TabListComponentInstanceContext';
-import { PageLayoutType } from '~/generated/graphql';
-import { isDefined } from 'twenty-shared/utils';
 import 'react-grid-layout/css/styles.css';
 import 'react-resizable/css/styles.css';
 
@@ -32,15 +30,11 @@ export const PageLayoutRenderer = ({
     }
   };
 
-  // Include record ID in tab instance ID to prevent tab synchronization between different records
-  // Only for RECORD_PAGE layouts, as DASHBOARD layouts are standalone
-  const recordId =
-    layoutType === PageLayoutType.RECORD_PAGE
-      ? targetRecordIdentifier?.id
-      : undefined;
-  const tabListInstanceId = isDefined(recordId)
-    ? `${getTabListInstanceIdFromPageLayoutId(pageLayoutId)}-${recordId}`
-    : getTabListInstanceIdFromPageLayoutId(pageLayoutId);
+  const tabListInstanceId = getTabListInstanceIdFromPageLayoutAndRecord({
+    pageLayoutId,
+    layoutType,
+    targetRecordIdentifier,
+  });
 
   return (
     <PageLayoutComponentInstanceContext.Provider

--- a/packages/twenty-front/src/modules/page-layout/components/PageLayoutRenderer.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/PageLayoutRenderer.tsx
@@ -7,6 +7,7 @@ import { getTabListInstanceIdFromPageLayoutId } from '@/page-layout/utils/getTab
 import { isPageLayoutEmpty } from '@/page-layout/utils/isPageLayoutEmpty';
 import { useLayoutRenderingContext } from '@/ui/layout/contexts/LayoutRenderingContext';
 import { TabListComponentInstanceContext } from '@/ui/layout/tab-list/states/contexts/TabListComponentInstanceContext';
+import { PageLayoutType } from '~/generated/graphql';
 import { isDefined } from 'twenty-shared/utils';
 import 'react-grid-layout/css/styles.css';
 import 'react-resizable/css/styles.css';
@@ -21,7 +22,7 @@ export const PageLayoutRenderer = ({
   const { setIsPageLayoutInEditMode } =
     useSetIsPageLayoutInEditMode(pageLayoutId);
 
-  const { targetRecordIdentifier } = useLayoutRenderingContext();
+  const { targetRecordIdentifier, layoutType } = useLayoutRenderingContext();
 
   const onInitialized = (pageLayout: PageLayout) => {
     if (isPageLayoutEmpty(pageLayout)) {
@@ -32,7 +33,11 @@ export const PageLayoutRenderer = ({
   };
 
   // Include record ID in tab instance ID to prevent tab synchronization between different records
-  const recordId = targetRecordIdentifier?.id;
+  // Only for RECORD_PAGE layouts, as DASHBOARD layouts are standalone
+  const recordId =
+    layoutType === PageLayoutType.RECORD_PAGE
+      ? targetRecordIdentifier?.id
+      : undefined;
   const tabListInstanceId = isDefined(recordId)
     ? `${getTabListInstanceIdFromPageLayoutId(pageLayoutId)}-${recordId}`
     : getTabListInstanceIdFromPageLayoutId(pageLayoutId);

--- a/packages/twenty-front/src/modules/page-layout/components/PageLayoutRenderer.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/PageLayoutRenderer.tsx
@@ -21,7 +21,7 @@ export const PageLayoutRenderer = ({
   const { setIsPageLayoutInEditMode } =
     useSetIsPageLayoutInEditMode(pageLayoutId);
 
-  const layoutRenderingContext = useLayoutRenderingContext();
+  const { targetRecordIdentifier } = useLayoutRenderingContext();
 
   const onInitialized = (pageLayout: PageLayout) => {
     if (isPageLayoutEmpty(pageLayout)) {
@@ -32,7 +32,7 @@ export const PageLayoutRenderer = ({
   };
 
   // Include record ID in tab instance ID to prevent tab synchronization between different records
-  const recordId = layoutRenderingContext?.targetRecordIdentifier?.id;
+  const recordId = targetRecordIdentifier?.id;
   const tabListInstanceId = isDefined(recordId)
     ? `${getTabListInstanceIdFromPageLayoutId(pageLayoutId)}-${recordId}`
     : getTabListInstanceIdFromPageLayoutId(pageLayoutId);

--- a/packages/twenty-front/src/modules/page-layout/components/PageLayoutRendererContent.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/PageLayoutRendererContent.tsx
@@ -11,7 +11,7 @@ import { PageLayoutMainContent } from '@/page-layout/PageLayoutMainContent';
 import { isPageLayoutInEditModeComponentState } from '@/page-layout/states/isPageLayoutInEditModeComponentState';
 import { pageLayoutTabSettingsOpenTabIdComponentState } from '@/page-layout/states/pageLayoutTabSettingsOpenTabIdComponentState';
 import { getScrollWrapperInstanceIdFromPageLayoutId } from '@/page-layout/utils/getScrollWrapperInstanceIdFromPageLayoutId';
-import { getTabListInstanceIdFromPageLayoutId } from '@/page-layout/utils/getTabListInstanceIdFromPageLayoutId';
+import { getTabListInstanceIdFromPageLayoutAndRecord } from '@/page-layout/utils/getTabListInstanceIdFromPageLayoutAndRecord';
 import { getTabsByDisplayMode } from '@/page-layout/utils/getTabsByDisplayMode';
 import { getTabsWithVisibleWidgets } from '@/page-layout/utils/getTabsWithVisibleWidgets';
 import { sortTabsByPosition } from '@/page-layout/utils/sortTabsByPosition';
@@ -51,7 +51,8 @@ const StyledScrollWrapper = styled(ScrollWrapper)`
 export const PageLayoutRendererContent = () => {
   const { currentPageLayout } = useCurrentPageLayout();
 
-  const { isInRightDrawer } = useLayoutRenderingContext();
+  const { isInRightDrawer, layoutType, targetRecordIdentifier } =
+    useLayoutRenderingContext();
 
   const isPageLayoutInEditMode = useRecoilComponentValue(
     isPageLayoutInEditModeComponentState,
@@ -97,9 +98,11 @@ export const PageLayoutRendererContent = () => {
     isInRightDrawer,
   });
 
-  const tabListInstanceId = getTabListInstanceIdFromPageLayoutId(
-    currentPageLayout.id,
-  );
+  const tabListInstanceId = getTabListInstanceIdFromPageLayoutAndRecord({
+    pageLayoutId: currentPageLayout.id,
+    layoutType,
+    targetRecordIdentifier,
+  });
 
   const sortedTabs = sortTabsByPosition(tabsToRenderInTabList);
 

--- a/packages/twenty-front/src/modules/page-layout/utils/getTabListInstanceIdFromPageLayoutAndRecord.ts
+++ b/packages/twenty-front/src/modules/page-layout/utils/getTabListInstanceIdFromPageLayoutAndRecord.ts
@@ -1,0 +1,26 @@
+import { PageLayoutType } from '~/generated/graphql';
+import { type TargetRecordIdentifier } from '@/ui/layout/contexts/TargetRecordIdentifier';
+import { getTabListInstanceIdFromPageLayoutId } from './getTabListInstanceIdFromPageLayoutId';
+import { isDefined } from 'twenty-shared/utils';
+
+export const getTabListInstanceIdFromPageLayoutAndRecord = ({
+  pageLayoutId,
+  layoutType,
+  targetRecordIdentifier,
+}: {
+  pageLayoutId: string;
+  layoutType: PageLayoutType;
+  targetRecordIdentifier?: TargetRecordIdentifier;
+}) => {
+  // Include record ID in tab instance ID to prevent tab synchronization between different records
+  // Only for RECORD_PAGE layouts, as DASHBOARD layouts are standalone
+  const recordId =
+    layoutType === PageLayoutType.RECORD_PAGE
+      ? targetRecordIdentifier?.id
+      : undefined;
+  const baseInstanceId = getTabListInstanceIdFromPageLayoutId(pageLayoutId);
+  return isDefined(recordId)
+    ? `${baseInstanceId}-${recordId}`
+    : baseInstanceId;
+};
+

--- a/packages/twenty-front/src/modules/page-layout/utils/getTabListInstanceIdFromPageLayoutAndRecord.ts
+++ b/packages/twenty-front/src/modules/page-layout/utils/getTabListInstanceIdFromPageLayoutAndRecord.ts
@@ -19,8 +19,5 @@ export const getTabListInstanceIdFromPageLayoutAndRecord = ({
       ? targetRecordIdentifier?.id
       : undefined;
   const baseInstanceId = getTabListInstanceIdFromPageLayoutId(pageLayoutId);
-  return isDefined(recordId)
-    ? `${baseInstanceId}-${recordId}`
-    : baseInstanceId;
+  return isDefined(recordId) ? `${baseInstanceId}-${recordId}` : baseInstanceId;
 };
-

--- a/packages/twenty-front/src/modules/page-layout/utils/getTabListInstanceIdFromPageLayoutAndRecord.ts
+++ b/packages/twenty-front/src/modules/page-layout/utils/getTabListInstanceIdFromPageLayoutAndRecord.ts
@@ -1,7 +1,7 @@
-import { PageLayoutType } from '~/generated/graphql';
 import { type TargetRecordIdentifier } from '@/ui/layout/contexts/TargetRecordIdentifier';
 import { getTabListInstanceIdFromPageLayoutId } from './getTabListInstanceIdFromPageLayoutId';
 import { isDefined } from 'twenty-shared/utils';
+import { type PageLayoutType } from '~/generated/graphql';
 
 export const getTabListInstanceIdFromPageLayoutAndRecord = ({
   pageLayoutId,
@@ -15,9 +15,7 @@ export const getTabListInstanceIdFromPageLayoutAndRecord = ({
   // Include record ID in tab instance ID to prevent tab synchronization between different records
   // Only for RECORD_PAGE layouts, as DASHBOARD layouts are standalone
   const recordId =
-    layoutType === PageLayoutType.RECORD_PAGE
-      ? targetRecordIdentifier?.id
-      : undefined;
+    layoutType === 'RECORD_PAGE' ? targetRecordIdentifier?.id : undefined;
   const baseInstanceId = getTabListInstanceIdFromPageLayoutId(pageLayoutId);
   return isDefined(recordId) ? `${baseInstanceId}-${recordId}` : baseInstanceId;
 };

--- a/packages/twenty-front/src/modules/page-layout/utils/getTabListInstanceIdFromPageLayoutAndRecord.ts
+++ b/packages/twenty-front/src/modules/page-layout/utils/getTabListInstanceIdFromPageLayoutAndRecord.ts
@@ -1,7 +1,7 @@
 import { type TargetRecordIdentifier } from '@/ui/layout/contexts/TargetRecordIdentifier';
+import { type LayoutRenderingContextType } from '@/ui/layout/contexts/LayoutRenderingContext';
 import { getTabListInstanceIdFromPageLayoutId } from './getTabListInstanceIdFromPageLayoutId';
 import { isDefined } from 'twenty-shared/utils';
-import { type PageLayoutType } from '~/generated/graphql';
 
 export const getTabListInstanceIdFromPageLayoutAndRecord = ({
   pageLayoutId,
@@ -9,7 +9,7 @@ export const getTabListInstanceIdFromPageLayoutAndRecord = ({
   targetRecordIdentifier,
 }: {
   pageLayoutId: string;
-  layoutType: PageLayoutType;
+  layoutType: LayoutRenderingContextType['layoutType'];
   targetRecordIdentifier?: TargetRecordIdentifier;
 }) => {
   // Include record ID in tab instance ID to prevent tab synchronization between different records


### PR DESCRIPTION
Fixes issue where tabs were synchronized when opening two records of the same type in show page and side panel.

The root cause was that tab instance IDs were only based on `pageLayoutId`, causing all records using the same page layout to share the same tab state.

This change includes the record ID in the tab instance ID, making tabs unique per record while maintaining backward compatibility for cases where no record ID is available.

Fixes #17522