### PR TITLE
Remove redundant label

### DIFF
--- a/packages/twenty-front/src/modules/command-menu/components/hooks/usePageLayoutHeaderInfo.ts
+++ b/packages/twenty-front/src/modules/command-menu/components/hooks/usePageLayoutHeaderInfo.ts
@@ -129,7 +129,7 @@ export const usePageLayoutHeaderInfo = ({
 
       const headerType =
         commandMenuPage === CommandMenuPages.PageLayoutGraphFilter
-          ? t`${graphTypeLabel} Chart`
+          ? graphTypeLabel
           : t`Chart`;
 
       const title = isDefined(editedTitle)


### PR DESCRIPTION
## Before

<img width="3456" height="2234" alt="CleanShot 2026-01-29 at 17 59 55@2x" src="https://github.com/user-attachments/assets/9225b037-2394-44e7-8513-a4edbf889eb6" />

## After

<img width="3456" height="2234" alt="CleanShot 2026-01-29 at 17 59 49@2x" src="https://github.com/user-attachments/assets/9abdded0-5f17-4ed4-925c-fc6a46b81e87" />
