### PR TITLE
feat: add event logs UI and backend query support

### DIFF
--- a/packages/twenty-front/src/generated-metadata/graphql.ts
+++ b/packages/twenty-front/src/generated-metadata/graphql.ts
@@ -1368,6 +1368,90 @@ export type EmailsConfiguration = {
   configurationType: WidgetConfigurationType;
 };
 
+export type EventLogDateRangeInput = {
+  end?: InputMaybe<Scalars['DateTime']>;
+  start?: InputMaybe<Scalars['DateTime']>;
+};
+
+export type EventLogFiltersInput = {
+  /** Filter by timestamp range */
+  dateRange?: InputMaybe<EventLogDateRangeInput>;
+  /** Filter by event type */
+  eventType?: InputMaybe<Scalars['String']>;
+  /** Filter by object metadata ID (objectEvent only) */
+  objectMetadataId?: InputMaybe<Scalars['String']>;
+  /** Filter by record ID (objectEvent only) */
+  recordId?: InputMaybe<Scalars['String']>;
+  /** Filter by user ID */
+  userId?: InputMaybe<Scalars['String']>;
+};
+
+/** Order direction for event logs */
+export enum EventLogOrderByDirection {
+  ASC = 'ASC',
+  DESC = 'DESC'
+}
+
+/** Fields available for ordering event logs */
+export enum EventLogOrderByField {
+  EVENT = 'EVENT',
+  TIMESTAMP = 'TIMESTAMP',
+  USER_ID = 'USER_ID'
+}
+
+export type EventLogOrderByInput = {
+  direction?: EventLogOrderByDirection;
+  field?: EventLogOrderByField;
+};
+
+export type EventLogQueryInput = {
+  /** Filters to apply to the query */
+  filters?: InputMaybe<EventLogFiltersInput>;
+  /** Maximum number of records to return */
+  limit?: InputMaybe<Scalars['Int']>;
+  /** Number of records to skip */
+  offset?: InputMaybe<Scalars['Int']>;
+  /** Order by configuration */
+  orderBy?: InputMaybe<EventLogOrderByInput>;
+  /** The table to query */
+  table: EventLogTable;
+};
+
+export type EventLogQueryResult = {
+  __typename?: 'EventLogQueryResult';
+  /** Whether there are more records to fetch */
+  hasNextPage: Scalars['Boolean'];
+  /** The event log records */
+  records: Array<EventLogRecord>;
+  /** Total count of records matching the query */
+  totalCount: Scalars['Int'];
+};
+
+export type EventLogRecord = {
+  __typename?: 'EventLogRecord';
+  /** Event type or page name */
+  event: Scalars['String'];
+  /** Is custom object (objectEvent only) */
+  isCustom?: Maybe<Scalars['Boolean']>;
+  /** Object metadata ID (objectEvent only) */
+  objectMetadataId?: Maybe<Scalars['String']>;
+  /** Additional event properties */
+  properties?: Maybe<Scalars['JSON']>;
+  /** Record ID (objectEvent only) */
+  recordId?: Maybe<Scalars['String']>;
+  /** Timestamp of the event */
+  timestamp: Scalars['DateTime'];
+  /** User ID who triggered the event */
+  userId?: Maybe<Scalars['String']>;
+};
+
+/** Available event log tables in ClickHouse */
+export enum EventLogTable {
+  OBJECT_EVENT = 'OBJECT_EVENT',
+  PAGEVIEW = 'PAGEVIEW',
+  WORKSPACE_EVENT = 'WORKSPACE_EVENT'
+}
+
 export type EventSubscription = {
   __typename?: 'EventSubscription';
   eventStreamId: Scalars['String'];
@@ -3563,6 +3647,9 @@ export type Query = {
   getCoreViews: Array<CoreView>;
   getDatabaseConfigVariable: ConfigVariable;
   getEmailingDomains: Array<EmailingDomain>;
+  /** Get available event log tables */
+  getEventLogTables: Array<EventLogTable>;
+  getFrontComponentCode: FrontComponentCode;
   getIndicatorHealthStatus: AdminPanelHealthServiceData;
   getLogicFunctionSourceCode?: Maybe<Scalars['JSON']>;
   getMeteredProductsUsage: Array<BillingMeteredProductUsageOutput>;
@@ -3595,6 +3682,8 @@ export type Query = {
   object: Object;
   objects: ObjectConnection;
   pieChartData: PieChartDataOutput;
+  /** Query event logs from ClickHouse */
+  queryEventLogs: EventLogQueryResult;
   search: SearchResultConnection;
   skill?: Maybe<Skill>;
   skills: Array<Skill>;
@@ -3911,6 +4000,11 @@ export type QueryObjectsArgs = {
 
 export type QueryPieChartDataArgs = {
   input: PieChartDataInput;
+};
+
+
+export type QueryQueryEventLogsArgs = {
+  input: EventLogQueryInput;
 };
 
 

--- a/packages/twenty-front/src/generated/graphql.ts
+++ b/packages/twenty-front/src/generated/graphql.ts
@@ -1335,6 +1335,90 @@ export type EmailsConfiguration = {
   configurationType: WidgetConfigurationType;
 };
 
+export type EventLogDateRangeInput = {
+  end?: InputMaybe<Scalars['DateTime']>;
+  start?: InputMaybe<Scalars['DateTime']>;
+};
+
+export type EventLogFiltersInput = {
+  /** Filter by timestamp range */
+  dateRange?: InputMaybe<EventLogDateRangeInput>;
+  /** Filter by event type */
+  eventType?: InputMaybe<Scalars['String']>;
+  /** Filter by object metadata ID (objectEvent only) */
+  objectMetadataId?: InputMaybe<Scalars['String']>;
+  /** Filter by record ID (objectEvent only) */
+  recordId?: InputMaybe<Scalars['String']>;
+  /** Filter by user ID */
+  userId?: InputMaybe<Scalars['String']>;
+};
+
+/** Order direction for event logs */
+export enum EventLogOrderByDirection {
+  ASC = 'ASC',
+  DESC = 'DESC'
+}
+
+/** Fields available for ordering event logs */
+export enum EventLogOrderByField {
+  EVENT = 'EVENT',
+  TIMESTAMP = 'TIMESTAMP',
+  USER_ID = 'USER_ID'
+}
+
+export type EventLogOrderByInput = {
+  direction?: EventLogOrderByDirection;
+  field?: EventLogOrderByField;
+};
+
+export type EventLogQueryInput = {
+  /** Filters to apply to the query */
+  filters?: InputMaybe<EventLogFiltersInput>;
+  /** Maximum number of records to return */
+  limit?: InputMaybe<Scalars['Int']>;
+  /** Number of records to skip */
+  offset?: InputMaybe<Scalars['Int']>;
+  /** Order by configuration */
+  orderBy?: InputMaybe<EventLogOrderByInput>;
+  /** The table to query */
+  table: EventLogTable;
+};
+
+export type EventLogQueryResult = {
+  __typename?: 'EventLogQueryResult';
+  /** Whether there are more records to fetch */
+  hasNextPage: Scalars['Boolean'];
+  /** The event log records */
+  records: Array<EventLogRecord>;
+  /** Total count of records matching the query */
+  totalCount: Scalars['Int'];
+};
+
+export type EventLogRecord = {
+  __typename?: 'EventLogRecord';
+  /** Event type or page name */
+  event: Scalars['String'];
+  /** Is custom object (objectEvent only) */
+  isCustom?: Maybe<Scalars['Boolean']>;
+  /** Object metadata ID (objectEvent only) */
+  objectMetadataId?: Maybe<Scalars['String']>;
+  /** Additional event properties */
+  properties?: Maybe<Scalars['JSON']>;
+  /** Record ID (objectEvent only) */
+  recordId?: Maybe<Scalars['String']>;
+  /** Timestamp of the event */
+  timestamp: Scalars['DateTime'];
+  /** User ID who triggered the event */
+  userId?: Maybe<Scalars['String']>;
+};
+
+/** Available event log tables in ClickHouse */
+export enum EventLogTable {
+  OBJECT_EVENT = 'OBJECT_EVENT',
+  PAGEVIEW = 'PAGEVIEW',
+  WORKSPACE_EVENT = 'WORKSPACE_EVENT'
+}
+
 export type EventSubscription = {
   __typename?: 'EventSubscription';
   eventStreamId: Scalars['String'];
@@ -3439,6 +3523,8 @@ export type Query = {
   getCoreViews: Array<CoreView>;
   getDatabaseConfigVariable: ConfigVariable;
   getEmailingDomains: Array<EmailingDomain>;
+  /** Get available event log tables */
+  getEventLogTables: Array<EventLogTable>;
   getIndicatorHealthStatus: AdminPanelHealthServiceData;
   getLogicFunctionSourceCode?: Maybe<Scalars['JSON']>;
   getMeteredProductsUsage: Array<BillingMeteredProductUsageOutput>;
@@ -3469,6 +3555,8 @@ export type Query = {
   object: Object;
   objects: ObjectConnection;
   pieChartData: PieChartDataOutput;
+  /** Query event logs from ClickHouse */
+  queryEventLogs: EventLogQueryResult;
   search: SearchResultConnection;
   validatePasswordResetToken: ValidatePasswordResetTokenOutput;
   versionInfo: VersionInfo;
@@ -3725,6 +3813,11 @@ export type QueryLineChartDataArgs = {
 
 export type QueryPieChartDataArgs = {
   input: PieChartDataInput;
+};
+
+
+export type QueryQueryEventLogsArgs = {
+  input: EventLogQueryInput;
 };
 
 

--- a/packages/twenty-front/src/modules/app/components/SettingsRoutes.tsx
+++ b/packages/twenty-front/src/modules/app/components/SettingsRoutes.tsx
@@ -292,6 +292,14 @@ const SettingsSecurityApprovedAccessDomain = lazy(() =>
   ),
 );
 
+const SettingsEventLogs = lazy(() =>
+  import('~/pages/settings/security/event-logs/SettingsEventLogs').then(
+    (module) => ({
+      default: module.SettingsEventLogs,
+    }),
+  ),
+);
+
 const SettingsNewEmailingDomain = lazy(() =>
   import('~/pages/settings/emailing-domains/SettingsNewEmailingDomain').then(
     (module) => ({
@@ -603,6 +611,7 @@ export const SettingsRoutes = ({ isAdminPageEnabled }: SettingsRoutesProps) => (
           path={SettingsPath.NewApprovedAccessDomain}
           element={<SettingsSecurityApprovedAccessDomain />}
         />
+        <Route path={SettingsPath.EventLogs} element={<SettingsEventLogs />} />
       </Route>
 
       {isAdminPageEnabled && (

--- a/packages/twenty-front/src/modules/ui/layout/fullscreen/hooks/useShowFullscreen.ts
+++ b/packages/twenty-front/src/modules/ui/layout/fullscreen/hooks/useShowFullscreen.ts
@@ -13,7 +13,11 @@ export const useShowFullscreen = () => {
         location,
         'settings/' + SettingsPath.RestPlayground + '/*',
       ) ||
-      isMatchingLocation(location, 'settings/' + SettingsPath.GraphQLPlayground)
+      isMatchingLocation(
+        location,
+        'settings/' + SettingsPath.GraphQLPlayground,
+      ) ||
+      isMatchingLocation(location, 'settings/' + SettingsPath.EventLogs)
     ) {
       return true;
     }

--- a/packages/twenty-front/src/pages/settings/security/SettingsSecurity.tsx
+++ b/packages/twenty-front/src/pages/settings/security/SettingsSecurity.tsx
@@ -5,6 +5,7 @@ import { useDebouncedCallback } from 'use-debounce';
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { authProvidersState } from '@/client-config/states/authProvidersState';
 import { isMultiWorkspaceEnabledState } from '@/client-config/states/isMultiWorkspaceEnabledState';
+import { SettingsOptionCardContentButton } from '@/settings/components/SettingsOptions/SettingsOptionCardContentButton';
 import { SettingsOptionCardContentCounter } from '@/settings/components/SettingsOptions/SettingsOptionCardContentCounter';
 import { SettingsPageContainer } from '@/settings/components/SettingsPageContainer';
 import { SettingsSSOIdentitiesProvidersListCard } from '@/settings/security/components/SSO/SettingsSSOIdentitiesProvidersListCard';
@@ -20,8 +21,10 @@ import { useRecoilState, useRecoilValue } from 'recoil';
 import { SettingsPath } from 'twenty-shared/types';
 import { getSettingsPath } from 'twenty-shared/utils';
 import { Tag } from 'twenty-ui/components';
-import { H2Title, IconLock, IconTrash } from 'twenty-ui/display';
+import { H2Title, IconHistory, IconLock, IconTrash } from 'twenty-ui/display';
+import { Button } from 'twenty-ui/input';
 import { Card, Section } from 'twenty-ui/layout';
+import { UndecoratedLink } from 'twenty-ui/navigation';
 import { useUpdateWorkspaceMutation } from '~/generated-metadata/graphql';
 
 const StyledContainer = styled.div`
@@ -169,6 +172,28 @@ export const SettingsSecurity = () => {
               <ToggleImpersonate />
             </Section>
           )}
+          <Section>
+            <H2Title
+              title={t`Event Logs`}
+              description={t`View workspace activity logs`}
+            />
+            <Card rounded>
+              <SettingsOptionCardContentButton
+                Icon={IconHistory}
+                title={t`Event Logs`}
+                description={t`View and filter workspace events, page views, and object changes`}
+                Button={
+                  <UndecoratedLink to={getSettingsPath(SettingsPath.EventLogs)}>
+                    <Button
+                      title={t`View Logs`}
+                      variant="secondary"
+                      size="small"
+                    />
+                  </UndecoratedLink>
+                }
+              />
+            </Card>
+          </Section>
           <Section>
             <H2Title
               title={t`Other`}

--- a/packages/twenty-front/src/pages/settings/security/event-logs/SettingsEventLogs.tsx
+++ b/packages/twenty-front/src/pages/settings/security/event-logs/SettingsEventLogs.tsx
@@ -1,0 +1,146 @@
+import styled from '@emotion/styled';
+import { Trans } from '@lingui/react/macro';
+import { useState } from 'react';
+
+import { FullScreenContainer } from '@/ui/layout/fullscreen/components/FullScreenContainer';
+import { SettingsPath } from 'twenty-shared/types';
+import { getSettingsPath } from 'twenty-shared/utils';
+import { useNavigateSettings } from '~/hooks/useNavigateSettings';
+
+import { EventLogFilters } from './components/EventLogFilters';
+import { EventLogResultsTable } from './components/EventLogResultsTable';
+import { EventLogTableSelector } from './components/EventLogTableSelector';
+import { useQueryEventLogs } from './hooks/useQueryEventLogs';
+import { EventLogTable } from './types';
+
+const StyledContainer = styled.div`
+  background: ${({ theme }) => theme.background.primary};
+  border-radius: ${({ theme }) => theme.border.radius.md};
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing(4)};
+  height: 100%;
+  padding: ${({ theme }) => theme.spacing(4)};
+`;
+
+const StyledControlsRow = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing(4)};
+`;
+
+const StyledTableContainer = styled.div`
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+`;
+
+export type EventLogFiltersState = {
+  eventType?: string;
+  workspaceMemberId?: string;
+  dateRange?: {
+    start?: Date;
+    end?: Date;
+  };
+  recordId?: string;
+  objectMetadataId?: string;
+};
+
+export const SettingsEventLogs = () => {
+  const navigateSettings = useNavigateSettings();
+  const [selectedTable, setSelectedTable] = useState<EventLogTable>(
+    EventLogTable.PAGEVIEW,
+  );
+  const [filters, setFilters] = useState<EventLogFiltersState>({});
+  const [offset, setOffset] = useState(0);
+  const limit = 50;
+
+  const { records, totalCount, hasNextPage, loading, refetch } =
+    useQueryEventLogs({
+      table: selectedTable,
+      filters: {
+        eventType: filters.eventType,
+        workspaceMemberId: filters.workspaceMemberId,
+        dateRange: filters.dateRange,
+        recordId: filters.recordId,
+        objectMetadataId: filters.objectMetadataId,
+      },
+      limit,
+      offset,
+    });
+
+  const handleTableChange = (table: EventLogTable) => {
+    setSelectedTable(table);
+    setFilters({});
+    setOffset(0);
+  };
+
+  const handleFiltersChange = (newFilters: EventLogFiltersState) => {
+    setFilters(newFilters);
+    setOffset(0);
+  };
+
+  const handleNextPage = () => {
+    if (hasNextPage) {
+      setOffset(offset + limit);
+    }
+  };
+
+  const handlePreviousPage = () => {
+    if (offset > 0) {
+      setOffset(Math.max(0, offset - limit));
+    }
+  };
+
+  const handleRefresh = () => {
+    refetch();
+  };
+
+  const handleExitFullScreen = () => {
+    navigateSettings(SettingsPath.Security);
+  };
+
+  return (
+    <FullScreenContainer
+      exitFullScreen={handleExitFullScreen}
+      links={[
+        {
+          children: <Trans>Workspace</Trans>,
+          href: getSettingsPath(SettingsPath.Workspace),
+        },
+        {
+          children: <Trans>Security</Trans>,
+          href: getSettingsPath(SettingsPath.Security),
+        },
+        { children: <Trans>Event Logs</Trans> },
+      ]}
+    >
+      <StyledContainer>
+        <StyledControlsRow>
+          <EventLogTableSelector
+            value={selectedTable}
+            onChange={handleTableChange}
+          />
+          <EventLogFilters
+            table={selectedTable}
+            value={filters}
+            onChange={handleFiltersChange}
+          />
+        </StyledControlsRow>
+        <StyledTableContainer>
+          <EventLogResultsTable
+            records={records}
+            loading={loading}
+            hasNextPage={hasNextPage}
+            hasPreviousPage={offset > 0}
+            totalCount={totalCount}
+            onNextPage={handleNextPage}
+            onPreviousPage={handlePreviousPage}
+            onRefresh={handleRefresh}
+            selectedTable={selectedTable}
+          />
+        </StyledTableContainer>
+      </StyledContainer>
+    </FullScreenContainer>
+  );
+};

--- a/packages/twenty-front/src/pages/settings/security/event-logs/components/EventLogDatePickerInput.tsx
+++ b/packages/twenty-front/src/pages/settings/security/event-logs/components/EventLogDatePickerInput.tsx
@@ -1,0 +1,185 @@
+import styled from '@emotion/styled';
+import { useLingui } from '@lingui/react/macro';
+import { useEffect, useRef, useState } from 'react';
+import { Temporal } from 'temporal-polyfill';
+
+import {
+  DateTimePicker,
+  MONTH_AND_YEAR_DROPDOWN_MONTH_SELECT_ID,
+  MONTH_AND_YEAR_DROPDOWN_YEAR_SELECT_ID,
+} from '@/ui/input/components/internal/date/components/DateTimePicker';
+import { useCloseDropdown } from '@/ui/layout/dropdown/hooks/useCloseDropdown';
+import { OverlayContainer } from '@/ui/layout/overlay/components/OverlayContainer';
+import { useListenClickOutside } from '@/ui/utilities/pointer-event/hooks/useListenClickOutside';
+import { isDefined } from 'twenty-shared/utils';
+import { IconCalendar } from 'twenty-ui/display';
+
+const StyledInputContainer = styled.div`
+  position: relative;
+`;
+
+const StyledInput = styled.div<{ hasValue: boolean }>`
+  align-items: center;
+  background-color: ${({ theme }) => theme.background.transparent.lighter};
+  border: 1px solid ${({ theme }) => theme.border.color.medium};
+  border-radius: ${({ theme }) => theme.border.radius.sm};
+  box-sizing: border-box;
+  color: ${({ theme, hasValue }) =>
+    hasValue ? theme.font.color.primary : theme.font.color.light};
+  cursor: pointer;
+  display: flex;
+  gap: ${({ theme }) => theme.spacing(2)};
+  height: 32px;
+  padding: 0 ${({ theme }) => theme.spacing(2)};
+  width: 100%;
+
+  &:hover {
+    border-color: ${({ theme }) => theme.border.color.strong};
+  }
+`;
+
+const StyledLabel = styled.div`
+  color: ${({ theme }) => theme.font.color.light};
+  font-size: ${({ theme }) => theme.font.size.xs};
+  font-weight: ${({ theme }) => theme.font.weight.medium};
+  margin-bottom: ${({ theme }) => theme.spacing(1)};
+`;
+
+const StyledDatePickerContainer = styled.div<{ top: number; left: number }>`
+  position: fixed;
+  top: ${({ top }) => top}px;
+  left: ${({ left }) => left}px;
+  z-index: 1000;
+`;
+
+const StyledIconContainer = styled.div`
+  color: ${({ theme }) => theme.font.color.tertiary};
+  display: flex;
+`;
+
+type EventLogDatePickerInputProps = {
+  label: string;
+  value: Date | undefined;
+  onChange: (date: Date | undefined) => void;
+  placeholder?: string;
+};
+
+export const EventLogDatePickerInput = ({
+  label,
+  value,
+  onChange,
+  placeholder,
+}: EventLogDatePickerInputProps) => {
+  const { t } = useLingui();
+  const [isOpen, setIsOpen] = useState(false);
+  const [position, setPosition] = useState({ top: 0, left: 0 });
+  const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLDivElement>(null);
+
+  const { closeDropdown: closeDropdownMonthSelect } = useCloseDropdown();
+  const { closeDropdown: closeDropdownYearSelect } = useCloseDropdown();
+
+  useEffect(() => {
+    if (isOpen && isDefined(inputRef.current)) {
+      const rect = inputRef.current.getBoundingClientRect();
+
+      setPosition({
+        top: rect.bottom + 4,
+        left: rect.left,
+      });
+    }
+  }, [isOpen]);
+
+  const closeAllDropdowns = () => {
+    closeDropdownYearSelect(MONTH_AND_YEAR_DROPDOWN_YEAR_SELECT_ID);
+    closeDropdownMonthSelect(MONTH_AND_YEAR_DROPDOWN_MONTH_SELECT_ID);
+  };
+
+  const handleClose = () => {
+    closeAllDropdowns();
+    setIsOpen(false);
+  };
+
+  useListenClickOutside({
+    refs: [containerRef],
+    listenerId: `event-log-date-picker-${label}`,
+    callback: handleClose,
+    enabled: isOpen,
+    excludedClickOutsideIds: [
+      MONTH_AND_YEAR_DROPDOWN_MONTH_SELECT_ID,
+      MONTH_AND_YEAR_DROPDOWN_YEAR_SELECT_ID,
+    ],
+  });
+
+  const handleDateTimeChange = (
+    newDateTime: Temporal.ZonedDateTime | null,
+  ) => {
+    if (isDefined(newDateTime)) {
+      onChange(new Date(newDateTime.epochMilliseconds));
+    }
+  };
+
+  const handleDateTimeSelect = (
+    newDateTime: Temporal.ZonedDateTime | null,
+  ) => {
+    if (isDefined(newDateTime)) {
+      onChange(new Date(newDateTime.epochMilliseconds));
+    }
+    handleClose();
+  };
+
+  const handleClear = () => {
+    onChange(undefined);
+    handleClose();
+  };
+
+  const formatDisplayValue = (date: Date | undefined): string => {
+    if (!isDefined(date)) {
+      return placeholder ?? t`Select date & time`;
+    }
+
+    return date.toLocaleString(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  };
+
+  const zonedDateTime = isDefined(value)
+    ? Temporal.Instant.fromEpochMilliseconds(value.getTime()).toZonedDateTimeISO(
+        Temporal.Now.timeZoneId(),
+      )
+    : null;
+
+  return (
+    <StyledInputContainer ref={containerRef}>
+      <StyledLabel>{label}</StyledLabel>
+      <StyledInput
+        ref={inputRef}
+        hasValue={isDefined(value)}
+        onClick={() => setIsOpen(true)}
+      >
+        <StyledIconContainer>
+          <IconCalendar size={16} />
+        </StyledIconContainer>
+        {formatDisplayValue(value)}
+      </StyledInput>
+      {isOpen && (
+        <StyledDatePickerContainer top={position.top} left={position.left}>
+          <OverlayContainer>
+            <DateTimePicker
+              instanceId={`event-log-date-picker-${label}`}
+              date={zonedDateTime}
+              onChange={handleDateTimeChange}
+              onClose={handleDateTimeSelect}
+              onClear={handleClear}
+              clearable
+            />
+          </OverlayContainer>
+        </StyledDatePickerContainer>
+      )}
+    </StyledInputContainer>
+  );
+};

--- a/packages/twenty-front/src/pages/settings/security/event-logs/components/EventLogFilters.tsx
+++ b/packages/twenty-front/src/pages/settings/security/event-logs/components/EventLogFilters.tsx
@@ -1,0 +1,169 @@
+import styled from '@emotion/styled';
+import { useLingui } from '@lingui/react/macro';
+import { useRecoilValue } from 'recoil';
+
+import { currentWorkspaceMembersState } from '@/auth/states/currentWorkspaceMembersState';
+import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
+import { Select } from '@/ui/input/components/Select';
+import { TextInput } from '@/ui/input/components/TextInput';
+import { IconUser, IconBox, useIcons } from 'twenty-ui/display';
+import { type SelectOption } from 'twenty-ui/input';
+
+import { EventLogDatePickerInput } from './EventLogDatePickerInput';
+import { EventLogFiltersState } from '../SettingsEventLogs';
+import { EventLogTable } from '../types';
+
+type EventLogFiltersProps = {
+  table: EventLogTable;
+  value: EventLogFiltersState;
+  onChange: (filters: EventLogFiltersState) => void;
+};
+
+const StyledFiltersContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: ${({ theme }) => theme.spacing(2)};
+  align-items: flex-end;
+`;
+
+const StyledFilterItem = styled.div`
+  flex: 1;
+  min-width: 200px;
+  max-width: 300px;
+`;
+
+export const EventLogFilters = ({
+  table,
+  value,
+  onChange,
+}: EventLogFiltersProps) => {
+  const { t } = useLingui();
+  const currentWorkspaceMembers = useRecoilValue(currentWorkspaceMembersState);
+  const { objectMetadataItems } = useObjectMetadataItems();
+  const { getIcon } = useIcons();
+
+  const handleEventTypeChange = (eventType: string) => {
+    onChange({ ...value, eventType: eventType || undefined });
+  };
+
+  const handleWorkspaceMemberChange = (workspaceMemberId: string | null) => {
+    onChange({ ...value, workspaceMemberId: workspaceMemberId || undefined });
+  };
+
+  const handleStartDateChange = (date: Date | undefined) => {
+    onChange({
+      ...value,
+      dateRange: {
+        ...value.dateRange,
+        start: date,
+      },
+    });
+  };
+
+  const handleEndDateChange = (date: Date | undefined) => {
+    onChange({
+      ...value,
+      dateRange: {
+        ...value.dateRange,
+        end: date,
+      },
+    });
+  };
+
+  const handleRecordIdChange = (recordId: string) => {
+    onChange({ ...value, recordId: recordId || undefined });
+  };
+
+  const handleObjectMetadataIdChange = (objectMetadataId: string | null) => {
+    onChange({ ...value, objectMetadataId: objectMetadataId || undefined });
+  };
+
+  const eventLabel =
+    table === EventLogTable.PAGEVIEW ? t`Page Name` : t`Event Type`;
+
+  const workspaceMemberOptions: SelectOption<string | null>[] = [
+    { label: t`All Members`, value: null, Icon: IconUser },
+    ...currentWorkspaceMembers.map((member) => ({
+      label: `${member.name.firstName ?? ''} ${member.name.lastName ?? ''}`.trim(),
+      value: member.id,
+      Icon: IconUser,
+    })),
+  ];
+
+  const objectMetadataOptions: SelectOption<string | null>[] = [
+    { label: t`All Objects`, value: null, Icon: IconBox },
+    ...objectMetadataItems.map((item) => ({
+      label: item.labelPlural,
+      value: item.id,
+      Icon: getIcon(item.icon) ?? IconBox,
+    })),
+  ];
+
+  return (
+    <StyledFiltersContainer>
+      <StyledFilterItem>
+        <TextInput
+          label={eventLabel}
+          value={value.eventType ?? ''}
+          onChange={handleEventTypeChange}
+          placeholder={t`Filter by ${eventLabel.toLowerCase()}`}
+          fullWidth
+        />
+      </StyledFilterItem>
+
+      <StyledFilterItem>
+        <Select
+          dropdownId="event-log-workspace-member-filter"
+          label={t`Workspace Member`}
+          value={value.workspaceMemberId ?? null}
+          options={workspaceMemberOptions}
+          onChange={handleWorkspaceMemberChange}
+          fullWidth
+          withSearchInput
+        />
+      </StyledFilterItem>
+
+      <StyledFilterItem>
+        <EventLogDatePickerInput
+          label={t`Start Date`}
+          value={value.dateRange?.start}
+          onChange={handleStartDateChange}
+        />
+      </StyledFilterItem>
+
+      <StyledFilterItem>
+        <EventLogDatePickerInput
+          label={t`End Date`}
+          value={value.dateRange?.end}
+          onChange={handleEndDateChange}
+        />
+      </StyledFilterItem>
+
+      {table === EventLogTable.OBJECT_EVENT && (
+        <>
+          <StyledFilterItem>
+            <Select
+              dropdownId="event-log-object-type-filter"
+              label={t`Object Type`}
+              value={value.objectMetadataId ?? null}
+              options={objectMetadataOptions}
+              onChange={handleObjectMetadataIdChange}
+              fullWidth
+              withSearchInput
+            />
+          </StyledFilterItem>
+
+          <StyledFilterItem>
+            <TextInput
+              label={t`Record ID`}
+              value={value.recordId ?? ''}
+              onChange={handleRecordIdChange}
+              placeholder={t`Filter by record ID`}
+              fullWidth
+            />
+          </StyledFilterItem>
+        </>
+      )}
+    </StyledFiltersContainer>
+  );
+};

--- a/packages/twenty-front/src/pages/settings/security/event-logs/components/EventLogJsonCell.tsx
+++ b/packages/twenty-front/src/pages/settings/security/event-logs/components/EventLogJsonCell.tsx
@@ -1,0 +1,65 @@
+import styled from '@emotion/styled';
+import { t } from '@lingui/core/macro';
+import { useRef, useState } from 'react';
+
+import { JsonDisplay } from '@/ui/field/display/components/JsonDisplay';
+import { ExpandedFieldDisplay } from '@/ui/layout/expandable-list/components/ExpandedFieldDisplay';
+import { type JsonValue } from 'type-fest';
+import { isDefined } from 'twenty-shared/utils';
+import { isTwoFirstDepths, JsonTree } from 'twenty-ui/json-visualizer';
+import { useCopyToClipboard } from '~/hooks/useCopyToClipboard';
+
+type EventLogJsonCellProps = {
+  value: Record<string, unknown> | null | undefined;
+};
+
+const StyledJsonContainer = styled.div`
+  cursor: pointer;
+`;
+
+const StyledEmptyCell = styled.span`
+  color: ${({ theme }) => theme.font.color.tertiary};
+`;
+
+export const EventLogJsonCell = ({ value }: EventLogJsonCellProps) => {
+  const { copyToClipboard } = useCopyToClipboard();
+  const [isExpanded, setIsExpanded] = useState(false);
+  const anchorRef = useRef<HTMLDivElement>(null);
+
+  if (!isDefined(value) || Object.keys(value).length === 0) {
+    return <StyledEmptyCell>-</StyledEmptyCell>;
+  }
+
+  const handleClick = () => {
+    setIsExpanded(true);
+  };
+
+  const handleClickOutside = () => {
+    setIsExpanded(false);
+  };
+
+  return (
+    <>
+      <StyledJsonContainer ref={anchorRef} onClick={handleClick}>
+        <JsonDisplay text={JSON.stringify(value)} />
+      </StyledJsonContainer>
+      {isExpanded && (
+        <ExpandedFieldDisplay
+          anchorElement={anchorRef.current ?? undefined}
+          onClickOutside={handleClickOutside}
+        >
+          <JsonTree
+            value={value as JsonValue}
+            shouldExpandNodeInitially={isTwoFirstDepths}
+            emptyArrayLabel={t`Empty Array`}
+            emptyObjectLabel={t`Empty Object`}
+            emptyStringLabel={t`[empty string]`}
+            arrowButtonCollapsedLabel={t`Expand`}
+            arrowButtonExpandedLabel={t`Collapse`}
+            onNodeValueClick={copyToClipboard}
+          />
+        </ExpandedFieldDisplay>
+      )}
+    </>
+  );
+};

--- a/packages/twenty-front/src/pages/settings/security/event-logs/components/EventLogResultsTable.tsx
+++ b/packages/twenty-front/src/pages/settings/security/event-logs/components/EventLogResultsTable.tsx
@@ -1,0 +1,316 @@
+import styled from '@emotion/styled';
+import { Trans, useLingui } from '@lingui/react/macro';
+import { useCallback, useRef, useState } from 'react';
+
+import { beautifyPastDateRelativeToNow } from '~/utils/date-utils';
+import { Button } from 'twenty-ui/input';
+import {
+  IconChevronLeft,
+  IconChevronRight,
+  IconRefresh,
+} from 'twenty-ui/display';
+
+import { EventLogRecord, EventLogTable } from '../types';
+
+import { EventLogJsonCell } from './EventLogJsonCell';
+
+type EventLogResultsTableProps = {
+  records: EventLogRecord[];
+  loading: boolean;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  totalCount: number;
+  onNextPage: () => void;
+  onPreviousPage: () => void;
+  onRefresh: () => void;
+  selectedTable: EventLogTable;
+};
+
+const StyledTableContainer = styled.div`
+  border: 1px solid ${({ theme }) => theme.border.color.medium};
+  border-radius: ${({ theme }) => theme.border.radius.md};
+  overflow: auto;
+`;
+
+const StyledTable = styled.table`
+  border-collapse: collapse;
+  table-layout: fixed;
+  width: 100%;
+`;
+
+const StyledThead = styled.thead`
+  background-color: ${({ theme }) => theme.background.tertiary};
+`;
+
+const StyledTh = styled.th`
+  border-bottom: 1px solid ${({ theme }) => theme.border.color.light};
+  color: ${({ theme }) => theme.font.color.tertiary};
+  font-size: ${({ theme }) => theme.font.size.sm};
+  font-weight: ${({ theme }) => theme.font.weight.medium};
+  min-width: 80px;
+  overflow: hidden;
+  padding: ${({ theme }) => theme.spacing(2)} ${({ theme }) => theme.spacing(2)};
+  position: relative;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const StyledResizeHandle = styled.div`
+  background: transparent;
+  bottom: 0;
+  cursor: col-resize;
+  position: absolute;
+  right: 0;
+  top: 0;
+  width: 4px;
+
+  &:hover {
+    background: ${({ theme }) => theme.border.color.strong};
+  }
+`;
+
+const StyledTd = styled.td`
+  border-bottom: 1px solid ${({ theme }) => theme.border.color.light};
+  color: ${({ theme }) => theme.font.color.primary};
+  font-size: ${({ theme }) => theme.font.size.md};
+  max-width: 200px;
+  overflow: hidden;
+  padding: ${({ theme }) => theme.spacing(2)} ${({ theme }) => theme.spacing(2)};
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const StyledPropertiesTd = styled.td`
+  border-bottom: 1px solid ${({ theme }) => theme.border.color.light};
+  color: ${({ theme }) => theme.font.color.primary};
+  font-size: ${({ theme }) => theme.font.size.md};
+  padding: ${({ theme }) => theme.spacing(2)} ${({ theme }) => theme.spacing(2)};
+  word-break: break-word;
+`;
+
+const StyledTr = styled.tr`
+  &:hover {
+    background-color: ${({ theme }) => theme.background.transparent.light};
+  }
+`;
+
+const StyledPaginationContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: ${({ theme }) => theme.spacing(2)} ${({ theme }) => theme.spacing(4)};
+  border-top: 1px solid ${({ theme }) => theme.border.color.medium};
+  background-color: ${({ theme }) => theme.background.secondary};
+`;
+
+const StyledPaginationInfo = styled.span`
+  color: ${({ theme }) => theme.font.color.secondary};
+  font-size: ${({ theme }) => theme.font.size.sm};
+`;
+
+const StyledPaginationButtons = styled.div`
+  display: flex;
+  gap: ${({ theme }) => theme.spacing(2)};
+`;
+
+const StyledLoadingTd = styled.td`
+  color: ${({ theme }) => theme.font.color.secondary};
+  padding: ${({ theme }) => theme.spacing(8)};
+  text-align: center;
+`;
+
+const StyledEmptyTd = styled.td`
+  color: ${({ theme }) => theme.font.color.tertiary};
+  padding: ${({ theme }) => theme.spacing(8)};
+  text-align: center;
+`;
+
+const StyledRefreshButton = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+export const EventLogResultsTable = ({
+  records,
+  loading,
+  hasNextPage,
+  hasPreviousPage,
+  totalCount,
+  onNextPage,
+  onPreviousPage,
+  onRefresh,
+  selectedTable,
+}: EventLogResultsTableProps) => {
+  const { t } = useLingui();
+  const [columnWidths, setColumnWidths] = useState<Record<string, number>>({
+    event: 200,
+    timestamp: 150,
+    userId: 150,
+    recordId: 150,
+    objectId: 150,
+  });
+  const resizingRef = useRef<{
+    column: string;
+    startX: number;
+    startWidth: number;
+  } | null>(null);
+
+  const handleResizeStart = useCallback(
+    (column: string, event: React.MouseEvent) => {
+      event.preventDefault();
+      const th = (event.target as HTMLElement).parentElement;
+
+      if (!th) return;
+
+      const startWidth = th.offsetWidth;
+
+      resizingRef.current = {
+        column,
+        startX: event.clientX,
+        startWidth,
+      };
+
+      const handleMouseMove = (moveEvent: MouseEvent) => {
+        if (!resizingRef.current) return;
+
+        const diff = moveEvent.clientX - resizingRef.current.startX;
+        const newWidth = Math.max(80, resizingRef.current.startWidth + diff);
+
+        setColumnWidths((prev) => ({
+          ...prev,
+          [resizingRef.current!.column]: newWidth,
+        }));
+      };
+
+      const handleMouseUp = () => {
+        resizingRef.current = null;
+        document.removeEventListener('mousemove', handleMouseMove);
+        document.removeEventListener('mouseup', handleMouseUp);
+      };
+
+      document.addEventListener('mousemove', handleMouseMove);
+      document.addEventListener('mouseup', handleMouseUp);
+    },
+    [],
+  );
+
+  const showObjectEventColumns = selectedTable === EventLogTable.OBJECT_EVENT;
+
+  const columnCount = showObjectEventColumns ? 6 : 4;
+
+  return (
+    <StyledTableContainer>
+      <StyledTable>
+        <StyledThead>
+          <tr>
+            <StyledTh style={{ width: columnWidths['event'] }}>
+              <Trans>Event</Trans>
+              <StyledResizeHandle
+                onMouseDown={(e) => handleResizeStart('event', e)}
+              />
+            </StyledTh>
+            <StyledTh style={{ width: columnWidths['timestamp'] }}>
+              <Trans>Timestamp</Trans>
+              <StyledResizeHandle
+                onMouseDown={(e) => handleResizeStart('timestamp', e)}
+              />
+            </StyledTh>
+            <StyledTh style={{ width: columnWidths['userId'] }}>
+              <Trans>User ID</Trans>
+              <StyledResizeHandle
+                onMouseDown={(e) => handleResizeStart('userId', e)}
+              />
+            </StyledTh>
+            {showObjectEventColumns && (
+              <>
+                <StyledTh style={{ width: columnWidths['recordId'] }}>
+                  <Trans>Record ID</Trans>
+                  <StyledResizeHandle
+                    onMouseDown={(e) => handleResizeStart('recordId', e)}
+                  />
+                </StyledTh>
+                <StyledTh style={{ width: columnWidths['objectId'] }}>
+                  <Trans>Object ID</Trans>
+                  <StyledResizeHandle
+                    onMouseDown={(e) => handleResizeStart('objectId', e)}
+                  />
+                </StyledTh>
+              </>
+            )}
+            <StyledTh style={{ width: columnWidths['properties'] }}>
+              <Trans>Properties</Trans>
+            </StyledTh>
+          </tr>
+        </StyledThead>
+        <tbody>
+          {loading && (
+            <tr>
+              <StyledLoadingTd colSpan={columnCount}>
+                <Trans>Loading...</Trans>
+              </StyledLoadingTd>
+            </tr>
+          )}
+          {!loading && records.length === 0 && (
+            <tr>
+              <StyledEmptyTd colSpan={columnCount}>
+                <Trans>No event logs found</Trans>
+              </StyledEmptyTd>
+            </tr>
+          )}
+          {!loading &&
+            records.map((record, index) => (
+              <StyledTr key={`${record.timestamp}-${record.event}-${index}`}>
+                <StyledTd>{record.event}</StyledTd>
+                <StyledTd>
+                  {beautifyPastDateRelativeToNow(record.timestamp)}
+                </StyledTd>
+                <StyledTd>{record.userId ?? '-'}</StyledTd>
+                {showObjectEventColumns && (
+                  <>
+                    <StyledTd>{record.recordId ?? '-'}</StyledTd>
+                    <StyledTd>{record.objectMetadataId ?? '-'}</StyledTd>
+                  </>
+                )}
+                <StyledPropertiesTd>
+                  <EventLogJsonCell value={record.properties} />
+                </StyledPropertiesTd>
+              </StyledTr>
+            ))}
+        </tbody>
+      </StyledTable>
+      <StyledPaginationContainer>
+        <StyledPaginationInfo>
+          {t`Total: ${totalCount} records`}
+        </StyledPaginationInfo>
+        <StyledPaginationButtons>
+          <StyledRefreshButton>
+            <Button
+              Icon={IconRefresh}
+              variant="tertiary"
+              size="small"
+              onClick={onRefresh}
+              title={t`Refresh`}
+            />
+          </StyledRefreshButton>
+          <Button
+            Icon={IconChevronLeft}
+            variant="secondary"
+            size="small"
+            disabled={!hasPreviousPage}
+            onClick={onPreviousPage}
+            title={t`Previous page`}
+          />
+          <Button
+            Icon={IconChevronRight}
+            variant="secondary"
+            size="small"
+            disabled={!hasNextPage}
+            onClick={onNextPage}
+            title={t`Next page`}
+          />
+        </StyledPaginationButtons>
+      </StyledPaginationContainer>
+    </StyledTableContainer>
+  );
+};

--- a/packages/twenty-front/src/pages/settings/security/event-logs/components/EventLogTableSelector.tsx
+++ b/packages/twenty-front/src/pages/settings/security/event-logs/components/EventLogTableSelector.tsx
@@ -1,0 +1,43 @@
+import { useLingui } from '@lingui/react/macro';
+
+import { Select } from '@/ui/input/components/Select';
+
+import { EventLogTable } from '../types';
+
+type EventLogTableSelectorProps = {
+  value: EventLogTable;
+  onChange: (value: EventLogTable) => void;
+};
+
+export const EventLogTableSelector = ({
+  value,
+  onChange,
+}: EventLogTableSelectorProps) => {
+  const { t } = useLingui();
+
+  const options = [
+    {
+      value: EventLogTable.PAGEVIEW,
+      label: t`Page Views`,
+    },
+    {
+      value: EventLogTable.WORKSPACE_EVENT,
+      label: t`Workspace Events`,
+    },
+    {
+      value: EventLogTable.OBJECT_EVENT,
+      label: t`Object Events`,
+    },
+  ];
+
+  return (
+    <Select
+      dropdownId="event-log-table-selector"
+      label={t`Table`}
+      fullWidth
+      value={value}
+      options={options}
+      onChange={onChange}
+    />
+  );
+};

--- a/packages/twenty-front/src/pages/settings/security/event-logs/hooks/useQueryEventLogs.ts
+++ b/packages/twenty-front/src/pages/settings/security/event-logs/hooks/useQueryEventLogs.ts
@@ -1,0 +1,61 @@
+import { gql, useQuery } from '@apollo/client';
+
+import {
+  EventLogQueryInput,
+  EventLogQueryResult,
+  EventLogRecord,
+} from '../types';
+
+const QUERY_EVENT_LOGS = gql`
+  query QueryEventLogs($input: EventLogQueryInput!) {
+    queryEventLogs(input: $input) {
+      records {
+        event
+        timestamp
+        userId
+        properties
+        recordId
+        objectMetadataId
+        isCustom
+      }
+      totalCount
+      hasNextPage
+    }
+  }
+`;
+
+type QueryEventLogsData = {
+  queryEventLogs: EventLogQueryResult;
+};
+
+type QueryEventLogsVariables = {
+  input: EventLogQueryInput;
+};
+
+export const useQueryEventLogs = (input: EventLogQueryInput) => {
+  const { data, loading, error, refetch } = useQuery<
+    QueryEventLogsData,
+    QueryEventLogsVariables
+  >(QUERY_EVENT_LOGS, {
+    variables: { input },
+    fetchPolicy: 'network-only',
+    onError: (err) => {
+      // eslint-disable-next-line no-console
+      console.error('Event logs query error:', err);
+    },
+  });
+
+  if (error) {
+    // eslint-disable-next-line no-console
+    console.error('Event logs query error:', error);
+  }
+
+  return {
+    records: data?.queryEventLogs.records ?? ([] as EventLogRecord[]),
+    totalCount: data?.queryEventLogs.totalCount ?? 0,
+    hasNextPage: data?.queryEventLogs.hasNextPage ?? false,
+    loading,
+    error,
+    refetch,
+  };
+};

--- a/packages/twenty-front/src/pages/settings/security/event-logs/types.ts
+++ b/packages/twenty-front/src/pages/settings/security/event-logs/types.ts
@@ -1,0 +1,44 @@
+// Temporary type definitions until GraphQL codegen generates them
+// These will be replaced by the generated types from ~/generated-metadata/graphql
+
+// GraphQL enums use the keys, not the values
+export enum EventLogTable {
+  WORKSPACE_EVENT = 'WORKSPACE_EVENT',
+  PAGEVIEW = 'PAGEVIEW',
+  OBJECT_EVENT = 'OBJECT_EVENT',
+}
+
+export type EventLogRecord = {
+  event: string;
+  timestamp: string;
+  userId?: string | null;
+  properties?: Record<string, unknown> | null;
+  recordId?: string | null;
+  objectMetadataId?: string | null;
+  isCustom?: boolean | null;
+};
+
+export type EventLogQueryResult = {
+  records: EventLogRecord[];
+  totalCount: number;
+  hasNextPage: boolean;
+};
+
+export type EventLogFiltersInput = {
+  eventType?: string;
+  userId?: string;
+  workspaceMemberId?: string;
+  dateRange?: {
+    start?: Date;
+    end?: Date;
+  };
+  recordId?: string;
+  objectMetadataId?: string;
+};
+
+export type EventLogQueryInput = {
+  table: EventLogTable;
+  filters?: EventLogFiltersInput;
+  limit?: number;
+  offset?: number;
+};

--- a/packages/twenty-server/src/database/typeorm/core/migrations/common/1769300000000-addClickhouseToDataSourceTypeEnum.ts
+++ b/packages/twenty-server/src/database/typeorm/core/migrations/common/1769300000000-addClickhouseToDataSourceTypeEnum.ts
@@ -1,0 +1,45 @@
+import { type MigrationInterface, type QueryRunner } from 'typeorm';
+
+export class AddClickhouseToDataSourceTypeEnum1769300000000
+  implements MigrationInterface
+{
+  name = 'AddClickhouseToDataSourceTypeEnum1769300000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TYPE "core"."dataSource_type_enum" RENAME TO "dataSource_type_enum_old"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "core"."dataSource_type_enum" AS ENUM('postgres', 'clickhouse')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."dataSource" ALTER COLUMN "type" DROP DEFAULT`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."dataSource" ALTER COLUMN "type" TYPE "core"."dataSource_type_enum" USING "type"::"text"::"core"."dataSource_type_enum"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."dataSource" ALTER COLUMN "type" SET DEFAULT 'postgres'`,
+    );
+    await queryRunner.query(`DROP TYPE "core"."dataSource_type_enum_old"`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "core"."dataSource_type_enum_old" AS ENUM('postgres')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."dataSource" ALTER COLUMN "type" DROP DEFAULT`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."dataSource" ALTER COLUMN "type" TYPE "core"."dataSource_type_enum_old" USING "type"::"text"::"core"."dataSource_type_enum_old"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."dataSource" ALTER COLUMN "type" SET DEFAULT 'postgres'`,
+    );
+    await queryRunner.query(`DROP TYPE "core"."dataSource_type_enum"`);
+    await queryRunner.query(
+      `ALTER TYPE "core"."dataSource_type_enum_old" RENAME TO "dataSource_type_enum"`,
+    );
+  }
+}

--- a/packages/twenty-server/src/engine/api/clickhouse-query-runners/clickhouse-query-runners.module.ts
+++ b/packages/twenty-server/src/engine/api/clickhouse-query-runners/clickhouse-query-runners.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+
+import { ClickHouseModule } from 'src/database/clickHouse/clickHouse.module';
+
+import { ClickHouseFindManyQueryRunnerService } from './services/clickhouse-find-many-query-runner.service';
+import { ClickHouseFindOneQueryRunnerService } from './services/clickhouse-find-one-query-runner.service';
+import { ClickHouseGroupByQueryRunnerService } from './services/clickhouse-group-by-query-runner.service';
+
+@Module({
+  imports: [ClickHouseModule],
+  providers: [
+    ClickHouseFindManyQueryRunnerService,
+    ClickHouseFindOneQueryRunnerService,
+    ClickHouseGroupByQueryRunnerService,
+  ],
+  exports: [
+    ClickHouseFindManyQueryRunnerService,
+    ClickHouseFindOneQueryRunnerService,
+    ClickHouseGroupByQueryRunnerService,
+  ],
+})
+export class ClickHouseQueryRunnersModule {}

--- a/packages/twenty-server/src/engine/api/clickhouse-query-runners/services/clickhouse-find-many-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/clickhouse-query-runners/services/clickhouse-find-many-query-runner.service.ts
@@ -1,0 +1,193 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+import { QUERY_MAX_RECORDS } from 'twenty-shared/constants';
+import { type ObjectRecord } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
+
+import {
+  type ObjectRecordFilter,
+  type ObjectRecordOrderBy,
+} from 'src/engine/api/graphql/workspace-query-builder/interfaces/object-record.interface';
+
+import { type CommonFindManyOutput } from 'src/engine/api/common/types/common-find-many-output.type';
+import { type CommonSelectedFieldsResult } from 'src/engine/api/common/types/common-selected-fields-result.type';
+import { ClickHouseService } from 'src/database/clickHouse/clickHouse.service';
+
+import {
+  type ClickHouseQueryArgs,
+  type ClickHouseQueryRunnerContext,
+} from '../types/clickhouse-query-runner-context.type';
+import {
+  buildClickHouseCountQuery,
+  buildClickHouseSelectQuery,
+} from '../utils/clickhouse-query-builder.util';
+
+type ClickHouseFindManyArgs = ClickHouseQueryArgs & {
+  filter?: ObjectRecordFilter;
+  orderBy?: ObjectRecordOrderBy;
+  first?: number;
+  last?: number;
+  before?: string;
+  after?: string;
+  offset?: number;
+};
+
+@Injectable()
+export class ClickHouseFindManyQueryRunnerService {
+  private readonly logger = new Logger(ClickHouseFindManyQueryRunnerService.name);
+
+  constructor(private readonly clickHouseService: ClickHouseService) {}
+
+  async execute(
+    args: ClickHouseFindManyArgs,
+    context: ClickHouseQueryRunnerContext,
+  ): Promise<CommonFindManyOutput> {
+    const { tableName, authContext, flatObjectMetadata, flatFieldMetadataMaps } =
+      context;
+
+    const limit = args.first ?? args.last ?? QUERY_MAX_RECORDS;
+    const offset = args.offset ?? 0;
+
+    // Get columns from selected fields
+    const columns = this.getColumnsFromSelectedFields(
+      args.selectedFieldsResult,
+      flatObjectMetadata,
+      flatFieldMetadataMaps,
+    );
+
+    // Convert orderBy to simple format for ClickHouse
+    const orderBy = this.convertOrderBy(args.orderBy);
+
+    // Build and execute the query
+    const { query, params } = buildClickHouseSelectQuery({
+      tableName,
+      columns,
+      filter: args.filter,
+      orderBy,
+      limit: limit + 1, // Fetch one extra to check for next page
+      offset,
+      workspaceId: authContext.workspace.id,
+    });
+
+    this.logger.debug(`Executing ClickHouse query: ${query}`);
+    this.logger.debug(`With params: ${JSON.stringify(params)}`);
+
+    const records = await this.clickHouseService.select<ObjectRecord>(
+      query,
+      params,
+    );
+
+    // Get total count
+    const { query: countQuery, params: countParams } = buildClickHouseCountQuery(
+      {
+        tableName,
+        filter: args.filter,
+        workspaceId: authContext.workspace.id,
+      },
+    );
+
+    const countResult = await this.clickHouseService.select<{
+      totalCount: number;
+    }>(countQuery, countParams);
+
+    const totalCount = countResult[0]?.totalCount ?? 0;
+
+    // Check if there's a next page
+    const hasNextPage = records.length > limit;
+
+    if (hasNextPage) {
+      records.pop(); // Remove the extra record we fetched
+    }
+
+    return {
+      records,
+      aggregatedValues: { totalCount },
+      totalCount,
+      pageInfo: {
+        hasNextPage,
+        hasPreviousPage: offset > 0,
+      },
+      selectedFieldsResult: args.selectedFieldsResult,
+    };
+  }
+
+  private getColumnsFromSelectedFields(
+    selectedFieldsResult: CommonSelectedFieldsResult,
+    flatObjectMetadata: ClickHouseQueryRunnerContext['flatObjectMetadata'],
+    flatFieldMetadataMaps: ClickHouseQueryRunnerContext['flatFieldMetadataMaps'],
+  ): string[] {
+    const selectFields = selectedFieldsResult.select;
+
+    if (!isDefined(selectFields) || Object.keys(selectFields).length === 0) {
+      return ['*'];
+    }
+
+    // Extract column names from selected fields
+    const columns: string[] = [];
+
+    for (const fieldName of Object.keys(selectFields)) {
+      // Skip relation fields for ClickHouse - we don't support them
+      const fieldId = Object.keys(flatFieldMetadataMaps.byId).find(
+        (id) => flatFieldMetadataMaps.byId[id]?.name === fieldName,
+      );
+
+      if (fieldId) {
+        const fieldMetadata = flatFieldMetadataMaps.byId[fieldId];
+
+        if (fieldMetadata && !this.isRelationField(fieldMetadata)) {
+          columns.push(fieldName);
+        }
+      } else {
+        // If field not found in metadata, include it anyway (might be a computed field)
+        columns.push(fieldName);
+      }
+    }
+
+    // Always include id if not already included
+    if (!columns.includes('id')) {
+      columns.unshift('id');
+    }
+
+    return columns;
+  }
+
+  private isRelationField(
+    fieldMetadata: ClickHouseQueryRunnerContext['flatFieldMetadataMaps']['byId'][string],
+  ): boolean {
+    if (!fieldMetadata) {
+      return false;
+    }
+
+    // Check if it's a relation type field
+    return (
+      fieldMetadata.type === 'RELATION' || fieldMetadata.type === 'MORPH_MANY'
+    );
+  }
+
+  private convertOrderBy(
+    orderBy?: ObjectRecordOrderBy,
+  ): Array<Record<string, string>> | undefined {
+    if (!isDefined(orderBy) || orderBy.length === 0) {
+      return undefined;
+    }
+
+    return orderBy.map((item) => {
+      const result: Record<string, string> = {};
+
+      for (const [key, value] of Object.entries(item)) {
+        if (typeof value === 'string') {
+          result[key] = value;
+        } else if (typeof value === 'object' && value !== null) {
+          // Handle nested direction (for composite fields)
+          const direction = (value as Record<string, string>).direction;
+
+          if (direction) {
+            result[key] = direction;
+          }
+        }
+      }
+
+      return result;
+    });
+  }
+}

--- a/packages/twenty-server/src/engine/api/clickhouse-query-runners/services/clickhouse-find-one-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/clickhouse-query-runners/services/clickhouse-find-one-query-runner.service.ts
@@ -1,0 +1,136 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+import { msg } from '@lingui/core/macro';
+import { type ObjectRecord } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
+
+import { type ObjectRecordFilter } from 'src/engine/api/graphql/workspace-query-builder/interfaces/object-record.interface';
+
+import {
+  CommonQueryRunnerException,
+  CommonQueryRunnerExceptionCode,
+} from 'src/engine/api/common/common-query-runners/errors/common-query-runner.exception';
+import { type CommonSelectedFieldsResult } from 'src/engine/api/common/types/common-selected-fields-result.type';
+import { ClickHouseService } from 'src/database/clickHouse/clickHouse.service';
+
+import {
+  type ClickHouseQueryArgs,
+  type ClickHouseQueryRunnerContext,
+} from '../types/clickhouse-query-runner-context.type';
+import { buildClickHouseSelectQuery } from '../utils/clickhouse-query-builder.util';
+
+type ClickHouseFindOneArgs = ClickHouseQueryArgs & {
+  filter?: ObjectRecordFilter;
+};
+
+@Injectable()
+export class ClickHouseFindOneQueryRunnerService {
+  private readonly logger = new Logger(ClickHouseFindOneQueryRunnerService.name);
+
+  constructor(private readonly clickHouseService: ClickHouseService) {}
+
+  async execute(
+    args: ClickHouseFindOneArgs,
+    context: ClickHouseQueryRunnerContext,
+  ): Promise<ObjectRecord> {
+    const { tableName, authContext, flatObjectMetadata, flatFieldMetadataMaps } =
+      context;
+
+    // Validate filter is provided
+    if (!args.filter || Object.keys(args.filter).length === 0) {
+      throw new CommonQueryRunnerException(
+        'Missing filter argument',
+        CommonQueryRunnerExceptionCode.INVALID_QUERY_INPUT,
+        { userFriendlyMessage: msg`Filter is required for findOne queries.` },
+      );
+    }
+
+    // Get columns from selected fields
+    const columns = this.getColumnsFromSelectedFields(
+      args.selectedFieldsResult,
+      flatObjectMetadata,
+      flatFieldMetadataMaps,
+    );
+
+    // Build and execute the query
+    const { query, params } = buildClickHouseSelectQuery({
+      tableName,
+      columns,
+      filter: args.filter,
+      limit: 1,
+      workspaceId: authContext.workspace.id,
+    });
+
+    this.logger.debug(`Executing ClickHouse findOne query: ${query}`);
+    this.logger.debug(`With params: ${JSON.stringify(params)}`);
+
+    const records = await this.clickHouseService.select<ObjectRecord>(
+      query,
+      params,
+    );
+
+    if (records.length === 0) {
+      throw new CommonQueryRunnerException(
+        'Record not found',
+        CommonQueryRunnerExceptionCode.RECORD_NOT_FOUND,
+        {
+          userFriendlyMessage: msg`This record does not exist or has been deleted.`,
+        },
+      );
+    }
+
+    return records[0];
+  }
+
+  private getColumnsFromSelectedFields(
+    selectedFieldsResult: CommonSelectedFieldsResult,
+    flatObjectMetadata: ClickHouseQueryRunnerContext['flatObjectMetadata'],
+    flatFieldMetadataMaps: ClickHouseQueryRunnerContext['flatFieldMetadataMaps'],
+  ): string[] {
+    const selectFields = selectedFieldsResult.select;
+
+    if (!isDefined(selectFields) || Object.keys(selectFields).length === 0) {
+      return ['*'];
+    }
+
+    // Extract column names from selected fields
+    const columns: string[] = [];
+
+    for (const fieldName of Object.keys(selectFields)) {
+      // Skip relation fields for ClickHouse - we don't support them
+      const fieldId = Object.keys(flatFieldMetadataMaps.byId).find(
+        (id) => flatFieldMetadataMaps.byId[id]?.name === fieldName,
+      );
+
+      if (fieldId) {
+        const fieldMetadata = flatFieldMetadataMaps.byId[fieldId];
+
+        if (fieldMetadata && !this.isRelationField(fieldMetadata)) {
+          columns.push(fieldName);
+        }
+      } else {
+        // If field not found in metadata, include it anyway
+        columns.push(fieldName);
+      }
+    }
+
+    // Always include id if not already included
+    if (!columns.includes('id')) {
+      columns.unshift('id');
+    }
+
+    return columns;
+  }
+
+  private isRelationField(
+    fieldMetadata: ClickHouseQueryRunnerContext['flatFieldMetadataMaps']['byId'][string],
+  ): boolean {
+    if (!fieldMetadata) {
+      return false;
+    }
+
+    return (
+      fieldMetadata.type === 'RELATION' || fieldMetadata.type === 'MORPH_MANY'
+    );
+  }
+}

--- a/packages/twenty-server/src/engine/api/clickhouse-query-runners/services/clickhouse-group-by-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/clickhouse-query-runners/services/clickhouse-group-by-query-runner.service.ts
@@ -1,0 +1,154 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+import { isDefined } from 'twenty-shared/utils';
+
+import {
+  type ObjectRecordFilter,
+  type ObjectRecordGroupBy,
+  type ObjectRecordOrderBy,
+} from 'src/engine/api/graphql/workspace-query-builder/interfaces/object-record.interface';
+
+import { type CommonGroupByOutputItem } from 'src/engine/api/common/types/common-group-by-output-item.type';
+import { ClickHouseService } from 'src/database/clickHouse/clickHouse.service';
+
+import {
+  type ClickHouseQueryArgs,
+  type ClickHouseQueryRunnerContext,
+} from '../types/clickhouse-query-runner-context.type';
+import { buildClickHouseGroupByQuery } from '../utils/clickhouse-query-builder.util';
+
+type ClickHouseGroupByArgs = ClickHouseQueryArgs & {
+  filter?: ObjectRecordFilter;
+  groupBy?: ObjectRecordGroupBy;
+  orderBy?: ObjectRecordOrderBy;
+  limit?: number;
+  includeRecords?: boolean;
+};
+
+@Injectable()
+export class ClickHouseGroupByQueryRunnerService {
+  private readonly logger = new Logger(ClickHouseGroupByQueryRunnerService.name);
+
+  constructor(private readonly clickHouseService: ClickHouseService) {}
+
+  async execute(
+    args: ClickHouseGroupByArgs,
+    context: ClickHouseQueryRunnerContext,
+  ): Promise<CommonGroupByOutputItem[]> {
+    const { tableName, authContext } = context;
+
+    // Extract group by columns from args
+    const groupByColumns = this.extractGroupByColumns(args.groupBy);
+
+    if (groupByColumns.length === 0) {
+      return [];
+    }
+
+    // Convert orderBy to simple format for ClickHouse
+    const orderBy = this.convertOrderBy(args.orderBy);
+
+    // Build and execute the query
+    const { query, params } = buildClickHouseGroupByQuery({
+      tableName,
+      groupByColumns,
+      filter: args.filter,
+      orderBy,
+      limit: args.limit ?? 100,
+      workspaceId: authContext.workspace.id,
+    });
+
+    this.logger.debug(`Executing ClickHouse groupBy query: ${query}`);
+    this.logger.debug(`With params: ${JSON.stringify(params)}`);
+
+    const rawResults = await this.clickHouseService.select<Record<string, unknown>>(
+      query,
+      params,
+    );
+
+    // Format results into CommonGroupByOutputItem format
+    return this.formatGroupByResults(rawResults, groupByColumns);
+  }
+
+  private extractGroupByColumns(groupBy?: ObjectRecordGroupBy): string[] {
+    if (!isDefined(groupBy) || groupBy.length === 0) {
+      return [];
+    }
+
+    const columns: string[] = [];
+
+    for (const groupByItem of groupBy) {
+      for (const [fieldName, value] of Object.entries(groupByItem)) {
+        if (value === true) {
+          // Simple field grouping
+          columns.push(fieldName);
+        } else if (typeof value === 'object' && value !== null) {
+          // Composite field or date granularity grouping
+          if ('granularity' in value) {
+            // Date granularity - for now just use the field
+            columns.push(fieldName);
+          } else {
+            // Composite field - extract sub-fields
+            for (const [subFieldName, subValue] of Object.entries(value)) {
+              if (subValue === true) {
+                columns.push(`${fieldName}_${subFieldName}`);
+              }
+            }
+          }
+        }
+      }
+    }
+
+    return columns;
+  }
+
+  private formatGroupByResults(
+    rawResults: Record<string, unknown>[],
+    groupByColumns: string[],
+  ): CommonGroupByOutputItem[] {
+    return rawResults.map((row) => {
+      const result: CommonGroupByOutputItem = {
+        totalCount: Number(row.totalCount ?? 0),
+      };
+
+      // Add dimension values
+      for (const column of groupByColumns) {
+        result[column] = row[column];
+      }
+
+      // Add any additional aggregated values
+      for (const [key, value] of Object.entries(row)) {
+        if (key !== 'totalCount' && !groupByColumns.includes(key)) {
+          result[key] = value;
+        }
+      }
+
+      return result;
+    });
+  }
+
+  private convertOrderBy(
+    orderBy?: ObjectRecordOrderBy,
+  ): Array<Record<string, string>> | undefined {
+    if (!isDefined(orderBy) || orderBy.length === 0) {
+      return undefined;
+    }
+
+    return orderBy.map((item) => {
+      const result: Record<string, string> = {};
+
+      for (const [key, value] of Object.entries(item)) {
+        if (typeof value === 'string') {
+          result[key] = value;
+        } else if (typeof value === 'object' && value !== null) {
+          const direction = (value as Record<string, string>).direction;
+
+          if (direction) {
+            result[key] = direction;
+          }
+        }
+      }
+
+      return result;
+    });
+  }
+}

--- a/packages/twenty-server/src/engine/api/clickhouse-query-runners/types/clickhouse-query-runner-context.type.ts
+++ b/packages/twenty-server/src/engine/api/clickhouse-query-runners/types/clickhouse-query-runner-context.type.ts
@@ -1,0 +1,18 @@
+import { type WorkspaceAuthContext } from 'src/engine/api/common/interfaces/workspace-auth-context.interface';
+import { type CommonSelectedFieldsResult } from 'src/engine/api/common/types/common-selected-fields-result.type';
+import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
+import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
+
+export type ClickHouseQueryRunnerContext = {
+  tableName: string;
+  authContext: WorkspaceAuthContext;
+  flatObjectMetadata: FlatObjectMetadata;
+  flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>;
+  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
+};
+
+export type ClickHouseQueryArgs = {
+  selectedFields?: Record<string, unknown>;
+  selectedFieldsResult: CommonSelectedFieldsResult;
+};

--- a/packages/twenty-server/src/engine/api/clickhouse-query-runners/utils/clickhouse-filter-parser.util.ts
+++ b/packages/twenty-server/src/engine/api/clickhouse-query-runners/utils/clickhouse-filter-parser.util.ts
@@ -1,0 +1,236 @@
+import { isDefined } from 'twenty-shared/utils';
+
+import { type ObjectRecordFilter } from 'src/engine/api/graphql/workspace-query-builder/interfaces/object-record.interface';
+
+type ClickHouseFilterResult = {
+  whereClause: string;
+  params: Record<string, unknown>;
+};
+
+type FilterOperator =
+  | 'eq'
+  | 'neq'
+  | 'gt'
+  | 'gte'
+  | 'lt'
+  | 'lte'
+  | 'in'
+  | 'is'
+  | 'like'
+  | 'ilike'
+  | 'startsWith'
+  | 'endsWith'
+  | 'contains';
+
+const getClickHouseType = (value: unknown): string => {
+  if (typeof value === 'string') {
+    return 'String';
+  }
+
+  if (typeof value === 'number') {
+    return Number.isInteger(value) ? 'Int64' : 'Float64';
+  }
+
+  if (typeof value === 'boolean') {
+    return 'Bool';
+  }
+
+  return 'String';
+};
+
+const buildOperatorCondition = (
+  fieldName: string,
+  operator: FilterOperator,
+  paramName: string,
+  paramType: string,
+): string => {
+  switch (operator) {
+    case 'eq':
+      return `"${fieldName}" = {${paramName}:${paramType}}`;
+    case 'neq':
+      return `"${fieldName}" != {${paramName}:${paramType}}`;
+    case 'gt':
+      return `"${fieldName}" > {${paramName}:${paramType}}`;
+    case 'gte':
+      return `"${fieldName}" >= {${paramName}:${paramType}}`;
+    case 'lt':
+      return `"${fieldName}" < {${paramName}:${paramType}}`;
+    case 'lte':
+      return `"${fieldName}" <= {${paramName}:${paramType}}`;
+    case 'in':
+      return `"${fieldName}" IN {${paramName}:Array(${paramType})}`;
+    case 'is':
+      return `"${fieldName}" IS NULL`;
+    case 'like':
+      return `"${fieldName}" LIKE {${paramName}:${paramType}}`;
+    case 'ilike':
+      return `lower("${fieldName}") LIKE lower({${paramName}:${paramType}})`;
+    case 'startsWith':
+      return `"${fieldName}" LIKE concat({${paramName}:${paramType}}, '%')`;
+    case 'endsWith':
+      return `"${fieldName}" LIKE concat('%', {${paramName}:${paramType}})`;
+    case 'contains':
+      return `"${fieldName}" LIKE concat('%', {${paramName}:${paramType}}, '%')`;
+    default:
+      return `"${fieldName}" = {${paramName}:${paramType}}`;
+  }
+};
+
+const parseFilterValue = (
+  fieldName: string,
+  filterValue: unknown,
+  paramIndex: number,
+): { conditions: string[]; params: Record<string, unknown> } => {
+  const conditions: string[] = [];
+  const params: Record<string, unknown> = {};
+
+  if (!isDefined(filterValue) || typeof filterValue !== 'object') {
+    return { conditions, params };
+  }
+
+  const filterObj = filterValue as Record<string, unknown>;
+
+  for (const [operator, value] of Object.entries(filterObj)) {
+    if (!isDefined(value)) {
+      continue;
+    }
+
+    const paramName = `${fieldName}_${paramIndex}_${operator}`;
+
+    if (operator === 'is') {
+      if (value === 'NULL') {
+        conditions.push(`"${fieldName}" IS NULL`);
+      } else if (value === 'NOT_NULL') {
+        conditions.push(`"${fieldName}" IS NOT NULL`);
+      }
+
+      continue;
+    }
+
+    const paramType = getClickHouseType(value);
+
+    conditions.push(
+      buildOperatorCondition(
+        fieldName,
+        operator as FilterOperator,
+        paramName,
+        paramType,
+      ),
+    );
+    params[paramName] = value;
+  }
+
+  return { conditions, params };
+};
+
+export const parseClickHouseFilter = (
+  filter: ObjectRecordFilter | undefined,
+): ClickHouseFilterResult => {
+  if (!isDefined(filter) || Object.keys(filter).length === 0) {
+    return { whereClause: '', params: {} };
+  }
+
+  const allConditions: string[] = [];
+  const allParams: Record<string, unknown> = {};
+  let paramIndex = 0;
+
+  // Handle 'and' operator
+  if ('and' in filter && Array.isArray(filter.and)) {
+    const andConditions: string[] = [];
+
+    for (const subFilter of filter.and) {
+      const { whereClause, params } = parseClickHouseFilter(
+        subFilter as ObjectRecordFilter,
+      );
+
+      if (whereClause) {
+        andConditions.push(`(${whereClause})`);
+        Object.assign(allParams, params);
+      }
+    }
+
+    if (andConditions.length > 0) {
+      allConditions.push(andConditions.join(' AND '));
+    }
+  }
+
+  // Handle 'or' operator
+  if ('or' in filter && Array.isArray(filter.or)) {
+    const orConditions: string[] = [];
+
+    for (const subFilter of filter.or) {
+      const { whereClause, params } = parseClickHouseFilter(
+        subFilter as ObjectRecordFilter,
+      );
+
+      if (whereClause) {
+        orConditions.push(`(${whereClause})`);
+        Object.assign(allParams, params);
+      }
+    }
+
+    if (orConditions.length > 0) {
+      allConditions.push(`(${orConditions.join(' OR ')})`);
+    }
+  }
+
+  // Handle 'not' operator
+  if ('not' in filter && isDefined(filter.not)) {
+    const { whereClause, params } = parseClickHouseFilter(
+      filter.not as ObjectRecordFilter,
+    );
+
+    if (whereClause) {
+      allConditions.push(`NOT (${whereClause})`);
+      Object.assign(allParams, params);
+    }
+  }
+
+  // Handle field-level filters
+  for (const [fieldName, filterValue] of Object.entries(filter)) {
+    if (['and', 'or', 'not'].includes(fieldName)) {
+      continue;
+    }
+
+    const { conditions, params } = parseFilterValue(
+      fieldName,
+      filterValue,
+      paramIndex++,
+    );
+
+    allConditions.push(...conditions);
+    Object.assign(allParams, params);
+  }
+
+  return {
+    whereClause: allConditions.join(' AND '),
+    params: allParams,
+  };
+};
+
+export const parseClickHouseOrderBy = (
+  orderBy: Array<Record<string, string>> | undefined,
+): string => {
+  if (!isDefined(orderBy) || orderBy.length === 0) {
+    return '';
+  }
+
+  const orderClauses: string[] = [];
+
+  for (const orderItem of orderBy) {
+    for (const [fieldName, direction] of Object.entries(orderItem)) {
+      const normalizedDirection = direction
+        .toUpperCase()
+        .replace('NULLS_FIRST', 'NULLS FIRST')
+        .replace('NULLS_LAST', 'NULLS LAST')
+        .replace('ASC_NULLS_FIRST', 'ASC NULLS FIRST')
+        .replace('ASC_NULLS_LAST', 'ASC NULLS LAST')
+        .replace('DESC_NULLS_FIRST', 'DESC NULLS FIRST')
+        .replace('DESC_NULLS_LAST', 'DESC NULLS LAST');
+
+      orderClauses.push(`"${fieldName}" ${normalizedDirection}`);
+    }
+  }
+
+  return orderClauses.length > 0 ? `ORDER BY ${orderClauses.join(', ')}` : '';
+};

--- a/packages/twenty-server/src/engine/api/clickhouse-query-runners/utils/clickhouse-query-builder.util.ts
+++ b/packages/twenty-server/src/engine/api/clickhouse-query-runners/utils/clickhouse-query-builder.util.ts
@@ -1,0 +1,207 @@
+import { type ObjectRecordFilter } from 'src/engine/api/graphql/workspace-query-builder/interfaces/object-record.interface';
+
+import {
+  parseClickHouseFilter,
+  parseClickHouseOrderBy,
+} from './clickhouse-filter-parser.util';
+
+type ClickHouseSelectQueryOptions = {
+  tableName: string;
+  columns?: string[];
+  filter?: ObjectRecordFilter;
+  orderBy?: Array<Record<string, string>>;
+  limit?: number;
+  offset?: number;
+  workspaceId?: string;
+};
+
+type ClickHouseCountQueryOptions = {
+  tableName: string;
+  filter?: ObjectRecordFilter;
+  workspaceId?: string;
+};
+
+type ClickHouseGroupByQueryOptions = {
+  tableName: string;
+  groupByColumns: string[];
+  aggregations?: Array<{
+    column: string;
+    function: 'COUNT' | 'SUM' | 'AVG' | 'MIN' | 'MAX';
+    alias: string;
+  }>;
+  filter?: ObjectRecordFilter;
+  orderBy?: Array<Record<string, string>>;
+  limit?: number;
+  workspaceId?: string;
+};
+
+type ClickHouseQueryResult = {
+  query: string;
+  params: Record<string, unknown>;
+};
+
+export const buildClickHouseSelectQuery = (
+  options: ClickHouseSelectQueryOptions,
+): ClickHouseQueryResult => {
+  const {
+    tableName,
+    columns = ['*'],
+    filter,
+    orderBy,
+    limit = 100,
+    offset = 0,
+    workspaceId,
+  } = options;
+
+  const params: Record<string, unknown> = {};
+
+  // Build SELECT clause
+  const selectClause =
+    columns.length > 0 && columns[0] !== '*'
+      ? columns.map((col) => `"${col}"`).join(', ')
+      : '*';
+
+  // Build WHERE clause
+  const { whereClause, params: filterParams } = parseClickHouseFilter(filter);
+
+  Object.assign(params, filterParams);
+
+  const whereParts: string[] = [];
+
+  if (workspaceId) {
+    whereParts.push(`"workspaceId" = {workspaceId:String}`);
+    params.workspaceId = workspaceId;
+  }
+
+  if (whereClause) {
+    whereParts.push(whereClause);
+  }
+
+  const fullWhereClause =
+    whereParts.length > 0 ? `WHERE ${whereParts.join(' AND ')}` : '';
+
+  // Build ORDER BY clause
+  const orderByClause = parseClickHouseOrderBy(orderBy);
+
+  // Build LIMIT/OFFSET clause
+  const limitClause = `LIMIT ${limit}`;
+  const offsetClause = offset > 0 ? `OFFSET ${offset}` : '';
+
+  const query = [
+    `SELECT ${selectClause}`,
+    `FROM ${tableName}`,
+    fullWhereClause,
+    orderByClause,
+    limitClause,
+    offsetClause,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return { query, params };
+};
+
+export const buildClickHouseCountQuery = (
+  options: ClickHouseCountQueryOptions,
+): ClickHouseQueryResult => {
+  const { tableName, filter, workspaceId } = options;
+
+  const params: Record<string, unknown> = {};
+
+  // Build WHERE clause
+  const { whereClause, params: filterParams } = parseClickHouseFilter(filter);
+
+  Object.assign(params, filterParams);
+
+  const whereParts: string[] = [];
+
+  if (workspaceId) {
+    whereParts.push(`"workspaceId" = {workspaceId:String}`);
+    params.workspaceId = workspaceId;
+  }
+
+  if (whereClause) {
+    whereParts.push(whereClause);
+  }
+
+  const fullWhereClause =
+    whereParts.length > 0 ? `WHERE ${whereParts.join(' AND ')}` : '';
+
+  const query = [`SELECT count() as totalCount`, `FROM ${tableName}`, fullWhereClause]
+    .filter(Boolean)
+    .join(' ');
+
+  return { query, params };
+};
+
+export const buildClickHouseGroupByQuery = (
+  options: ClickHouseGroupByQueryOptions,
+): ClickHouseQueryResult => {
+  const {
+    tableName,
+    groupByColumns,
+    aggregations = [],
+    filter,
+    orderBy,
+    limit = 100,
+    workspaceId,
+  } = options;
+
+  const params: Record<string, unknown> = {};
+
+  // Build SELECT clause with group by columns and aggregations
+  const selectParts: string[] = [
+    ...groupByColumns.map((col) => `"${col}"`),
+    'count() as totalCount',
+    ...aggregations.map(
+      (agg) => `${agg.function}("${agg.column}") as "${agg.alias}"`,
+    ),
+  ];
+
+  const selectClause = selectParts.join(', ');
+
+  // Build WHERE clause
+  const { whereClause, params: filterParams } = parseClickHouseFilter(filter);
+
+  Object.assign(params, filterParams);
+
+  const whereParts: string[] = [];
+
+  if (workspaceId) {
+    whereParts.push(`"workspaceId" = {workspaceId:String}`);
+    params.workspaceId = workspaceId;
+  }
+
+  if (whereClause) {
+    whereParts.push(whereClause);
+  }
+
+  const fullWhereClause =
+    whereParts.length > 0 ? `WHERE ${whereParts.join(' AND ')}` : '';
+
+  // Build GROUP BY clause
+  const groupByClause =
+    groupByColumns.length > 0
+      ? `GROUP BY ${groupByColumns.map((col) => `"${col}"`).join(', ')}`
+      : '';
+
+  // Build ORDER BY clause - default to totalCount DESC if not specified
+  const orderByClause =
+    parseClickHouseOrderBy(orderBy) || 'ORDER BY totalCount DESC';
+
+  // Build LIMIT clause
+  const limitClause = `LIMIT ${limit}`;
+
+  const query = [
+    `SELECT ${selectClause}`,
+    `FROM ${tableName}`,
+    fullWhereClause,
+    groupByClause,
+    orderByClause,
+    limitClause,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return { query, params };
+};

--- a/packages/twenty-server/src/engine/core-modules/core-engine.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/core-engine.module.ts
@@ -72,6 +72,7 @@ import { DashboardModule } from 'src/modules/dashboard/dashboard.module';
 
 import { AuditModule } from './audit/audit.module';
 import { ClientConfigModule } from './client-config/client-config.module';
+import { EventLogsModule } from './event-logs/event-logs.module';
 import { FileModule } from './file/file.module';
 
 @Module({
@@ -158,6 +159,7 @@ import { FileModule } from './file/file.module';
     TrashCleanupModule,
     DashboardModule,
     RowLevelPermissionModule,
+    EventLogsModule,
   ],
   exports: [
     AuditModule,

--- a/packages/twenty-server/src/engine/core-modules/event-logs/dtos/event-log-filters.input.ts
+++ b/packages/twenty-server/src/engine/core-modules/event-logs/dtos/event-log-filters.input.ts
@@ -1,0 +1,43 @@
+import { Field, InputType } from '@nestjs/graphql';
+
+@InputType()
+export class EventLogDateRangeInput {
+  @Field(() => Date, { nullable: true })
+  start?: Date;
+
+  @Field(() => Date, { nullable: true })
+  end?: Date;
+}
+
+@InputType()
+export class EventLogFiltersInput {
+  @Field(() => String, { nullable: true, description: 'Filter by event type' })
+  eventType?: string;
+
+  @Field(() => String, { nullable: true, description: 'Filter by user ID' })
+  userId?: string;
+
+  @Field(() => String, {
+    nullable: true,
+    description: 'Filter by workspace member ID (will resolve to user ID)',
+  })
+  workspaceMemberId?: string;
+
+  @Field(() => EventLogDateRangeInput, {
+    nullable: true,
+    description: 'Filter by timestamp range',
+  })
+  dateRange?: EventLogDateRangeInput;
+
+  @Field(() => String, {
+    nullable: true,
+    description: 'Filter by record ID (objectEvent only)',
+  })
+  recordId?: string;
+
+  @Field(() => String, {
+    nullable: true,
+    description: 'Filter by object metadata ID (objectEvent only)',
+  })
+  objectMetadataId?: string;
+}

--- a/packages/twenty-server/src/engine/core-modules/event-logs/dtos/event-log-order-by.input.ts
+++ b/packages/twenty-server/src/engine/core-modules/event-logs/dtos/event-log-order-by.input.ts
@@ -1,0 +1,31 @@
+import { Field, InputType, registerEnumType } from '@nestjs/graphql';
+
+export enum EventLogOrderByField {
+  TIMESTAMP = 'timestamp',
+  EVENT = 'event',
+  USER_ID = 'userId',
+}
+
+registerEnumType(EventLogOrderByField, {
+  name: 'EventLogOrderByField',
+  description: 'Fields available for ordering event logs',
+});
+
+export enum EventLogOrderByDirection {
+  ASC = 'ASC',
+  DESC = 'DESC',
+}
+
+registerEnumType(EventLogOrderByDirection, {
+  name: 'EventLogOrderByDirection',
+  description: 'Order direction for event logs',
+});
+
+@InputType()
+export class EventLogOrderByInput {
+  @Field(() => EventLogOrderByField, { defaultValue: EventLogOrderByField.TIMESTAMP })
+  field: EventLogOrderByField;
+
+  @Field(() => EventLogOrderByDirection, { defaultValue: EventLogOrderByDirection.DESC })
+  direction: EventLogOrderByDirection;
+}

--- a/packages/twenty-server/src/engine/core-modules/event-logs/dtos/event-log-query.input.ts
+++ b/packages/twenty-server/src/engine/core-modules/event-logs/dtos/event-log-query.input.ts
@@ -1,0 +1,37 @@
+import { Field, InputType, Int } from '@nestjs/graphql';
+
+import { EventLogFiltersInput } from './event-log-filters.input';
+import { EventLogOrderByInput } from './event-log-order-by.input';
+import { EventLogTable } from './event-log-table.enum';
+
+@InputType()
+export class EventLogQueryInput {
+  @Field(() => EventLogTable, { description: 'The table to query' })
+  table: EventLogTable;
+
+  @Field(() => EventLogFiltersInput, {
+    nullable: true,
+    description: 'Filters to apply to the query',
+  })
+  filters?: EventLogFiltersInput;
+
+  @Field(() => Int, {
+    nullable: true,
+    defaultValue: 100,
+    description: 'Maximum number of records to return',
+  })
+  limit?: number;
+
+  @Field(() => Int, {
+    nullable: true,
+    defaultValue: 0,
+    description: 'Number of records to skip',
+  })
+  offset?: number;
+
+  @Field(() => EventLogOrderByInput, {
+    nullable: true,
+    description: 'Order by configuration',
+  })
+  orderBy?: EventLogOrderByInput;
+}

--- a/packages/twenty-server/src/engine/core-modules/event-logs/dtos/event-log-result.output.ts
+++ b/packages/twenty-server/src/engine/core-modules/event-logs/dtos/event-log-result.output.ts
@@ -1,0 +1,39 @@
+import { Field, Int, ObjectType } from '@nestjs/graphql';
+
+import GraphQLJSON from 'graphql-type-json';
+
+@ObjectType()
+export class EventLogRecord {
+  @Field(() => String, { description: 'Event type or page name' })
+  event: string;
+
+  @Field(() => Date, { description: 'Timestamp of the event' })
+  timestamp: Date;
+
+  @Field(() => String, { nullable: true, description: 'User ID who triggered the event' })
+  userId?: string;
+
+  @Field(() => GraphQLJSON, { nullable: true, description: 'Additional event properties' })
+  properties?: Record<string, unknown>;
+
+  @Field(() => String, { nullable: true, description: 'Record ID (objectEvent only)' })
+  recordId?: string;
+
+  @Field(() => String, { nullable: true, description: 'Object metadata ID (objectEvent only)' })
+  objectMetadataId?: string;
+
+  @Field(() => Boolean, { nullable: true, description: 'Is custom object (objectEvent only)' })
+  isCustom?: boolean;
+}
+
+@ObjectType()
+export class EventLogQueryResult {
+  @Field(() => [EventLogRecord], { description: 'The event log records' })
+  records: EventLogRecord[];
+
+  @Field(() => Int, { description: 'Total count of records matching the query' })
+  totalCount: number;
+
+  @Field(() => Boolean, { description: 'Whether there are more records to fetch' })
+  hasNextPage: boolean;
+}

--- a/packages/twenty-server/src/engine/core-modules/event-logs/dtos/event-log-table.enum.ts
+++ b/packages/twenty-server/src/engine/core-modules/event-logs/dtos/event-log-table.enum.ts
@@ -1,0 +1,12 @@
+import { registerEnumType } from '@nestjs/graphql';
+
+export enum EventLogTable {
+  WORKSPACE_EVENT = 'workspaceEvent',
+  PAGEVIEW = 'pageview',
+  OBJECT_EVENT = 'objectEvent',
+}
+
+registerEnumType(EventLogTable, {
+  name: 'EventLogTable',
+  description: 'Available event log tables in ClickHouse',
+});

--- a/packages/twenty-server/src/engine/core-modules/event-logs/dtos/index.ts
+++ b/packages/twenty-server/src/engine/core-modules/event-logs/dtos/index.ts
@@ -1,0 +1,9 @@
+export { EventLogTable } from './event-log-table.enum';
+export { EventLogFiltersInput, EventLogDateRangeInput } from './event-log-filters.input';
+export {
+  EventLogOrderByInput,
+  EventLogOrderByField,
+  EventLogOrderByDirection,
+} from './event-log-order-by.input';
+export { EventLogQueryInput } from './event-log-query.input';
+export { EventLogRecord, EventLogQueryResult } from './event-log-result.output';

--- a/packages/twenty-server/src/engine/core-modules/event-logs/event-logs.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/event-logs/event-logs.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+
+import { ClickHouseModule } from 'src/database/clickHouse/clickHouse.module';
+import { PermissionsModule } from 'src/engine/metadata-modules/permissions/permissions.module';
+import { TwentyORMModule } from 'src/engine/twenty-orm/twenty-orm.module';
+
+import { EventLogsResolver } from './event-logs.resolver';
+import { EventLogsService } from './event-logs.service';
+
+@Module({
+  imports: [ClickHouseModule, PermissionsModule, TwentyORMModule],
+  providers: [EventLogsResolver, EventLogsService],
+  exports: [EventLogsService],
+})
+export class EventLogsModule {}

--- a/packages/twenty-server/src/engine/core-modules/event-logs/event-logs.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/event-logs/event-logs.resolver.ts
@@ -1,0 +1,35 @@
+import { UseGuards } from '@nestjs/common';
+import { Args, Query, Resolver } from '@nestjs/graphql';
+
+import { PermissionFlagType } from 'twenty-shared/constants';
+
+import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
+import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
+import { SettingsPermissionGuard } from 'src/engine/guards/settings-permission.guard';
+import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
+
+import { EventLogQueryInput, EventLogQueryResult, EventLogTable } from './dtos';
+import { EventLogsService } from './event-logs.service';
+
+@Resolver()
+@UseGuards(WorkspaceAuthGuard, SettingsPermissionGuard(PermissionFlagType.SECURITY))
+export class EventLogsResolver {
+  constructor(private readonly eventLogsService: EventLogsService) {}
+
+  @Query(() => EventLogQueryResult, {
+    description: 'Query event logs from ClickHouse',
+  })
+  async queryEventLogs(
+    @AuthWorkspace() workspace: WorkspaceEntity,
+    @Args('input') input: EventLogQueryInput,
+  ): Promise<EventLogQueryResult> {
+    return this.eventLogsService.queryEventLogs(workspace.id, input);
+  }
+
+  @Query(() => [EventLogTable], {
+    description: 'Get available event log tables',
+  })
+  async getEventLogTables(): Promise<EventLogTable[]> {
+    return this.eventLogsService.getAvailableTables();
+  }
+}

--- a/packages/twenty-server/src/engine/core-modules/event-logs/event-logs.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/event-logs/event-logs.service.ts
@@ -1,0 +1,276 @@
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
+
+import { isDefined } from 'twenty-shared/utils';
+
+import { ClickHouseService } from 'src/database/clickHouse/clickHouse.service';
+import {
+  buildClickHouseCountQuery,
+  buildClickHouseSelectQuery,
+} from 'src/engine/api/clickhouse-query-runners/utils/clickhouse-query-builder.util';
+import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
+import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
+import { type WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
+
+import {
+  EventLogFiltersInput,
+  EventLogOrderByDirection,
+  EventLogOrderByField,
+  EventLogQueryInput,
+  EventLogQueryResult,
+  EventLogRecord,
+  EventLogTable,
+} from './dtos';
+
+type ClickHouseEventRecord = {
+  event?: string;
+  name?: string;
+  timestamp: string;
+  userId?: string;
+  properties?: Record<string, unknown>;
+  recordId?: string;
+  objectMetadataId?: string;
+  isCustom?: boolean;
+};
+
+@Injectable()
+export class EventLogsService {
+  private readonly logger = new Logger(EventLogsService.name);
+  private readonly MAX_LIMIT = 10000;
+  private readonly ALLOWED_TABLES: string[] = [
+    EventLogTable.WORKSPACE_EVENT,
+    EventLogTable.PAGEVIEW,
+    EventLogTable.OBJECT_EVENT,
+  ];
+
+  constructor(
+    private readonly clickHouseService: ClickHouseService,
+    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+  ) {}
+
+  async queryEventLogs(
+    workspaceId: string,
+    input: EventLogQueryInput,
+  ): Promise<EventLogQueryResult> {
+    if (!this.ALLOWED_TABLES.includes(input.table)) {
+      throw new BadRequestException(`Invalid table: ${input.table}`);
+    }
+
+    const limit = Math.min(input.limit ?? 100, this.MAX_LIMIT);
+    const offset = input.offset ?? 0;
+
+    // Resolve workspaceMemberId to userId if provided
+    const resolvedFilters = await this.resolveWorkspaceMemberFilter(
+      workspaceId,
+      input.filters,
+    );
+
+    const filter = this.buildFilter(resolvedFilters, input.table);
+    const orderBy = this.buildOrderBy(input.orderBy);
+
+    const { query, params } = buildClickHouseSelectQuery({
+      tableName: input.table,
+      filter,
+      orderBy,
+      limit: limit + 1,
+      offset,
+      workspaceId,
+    });
+
+    this.logger.debug(`Executing ClickHouse query: ${query}`);
+    this.logger.debug(`With params: ${JSON.stringify(params)}`);
+
+    const records =
+      await this.clickHouseService.select<ClickHouseEventRecord>(query, params);
+
+    const { query: countQuery, params: countParams } = buildClickHouseCountQuery(
+      {
+        tableName: input.table,
+        filter,
+        workspaceId,
+      },
+    );
+
+    const countResult = await this.clickHouseService.select<{
+      totalCount: number;
+    }>(countQuery, countParams);
+
+    const totalCount = countResult[0]?.totalCount ?? 0;
+
+    const hasNextPage = records.length > limit;
+
+    if (hasNextPage) {
+      records.pop();
+    }
+
+    const normalizedRecords = this.normalizeRecords(records, input.table);
+
+    return {
+      records: normalizedRecords,
+      totalCount,
+      hasNextPage,
+    };
+  }
+
+  private buildFilter(
+    filters: EventLogFiltersInput | undefined,
+    table: EventLogTable,
+  ): Record<string, unknown> | undefined {
+    if (!isDefined(filters)) {
+      return undefined;
+    }
+
+    const filterObj: Record<string, unknown> = {};
+
+    if (isDefined(filters.eventType)) {
+      const eventFieldName =
+        table === EventLogTable.PAGEVIEW ? 'name' : 'event';
+
+      // Use case-insensitive contains for better search experience
+      filterObj[eventFieldName] = { ilike: `%${filters.eventType}%` };
+    }
+
+    if (isDefined(filters.userId)) {
+      filterObj.userId = { eq: filters.userId };
+    }
+
+    if (isDefined(filters.dateRange)) {
+      const timestampFilter: Record<string, unknown> = {};
+
+      // Format date to 'yyyy-MM-dd HH:mm:ss' in UTC for ClickHouse DateTime64 comparison
+      // Data in ClickHouse is stored in UTC
+      const formatForClickHouse = (date: Date) => {
+        const year = date.getUTCFullYear();
+        const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+        const day = String(date.getUTCDate()).padStart(2, '0');
+        const hours = String(date.getUTCHours()).padStart(2, '0');
+        const minutes = String(date.getUTCMinutes()).padStart(2, '0');
+        const seconds = String(date.getUTCSeconds()).padStart(2, '0');
+
+        return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
+      };
+
+      if (isDefined(filters.dateRange.start)) {
+        const startDate =
+          filters.dateRange.start instanceof Date
+            ? filters.dateRange.start
+            : new Date(filters.dateRange.start);
+
+        timestampFilter.gte = formatForClickHouse(startDate);
+      }
+      if (isDefined(filters.dateRange.end)) {
+        const endDate =
+          filters.dateRange.end instanceof Date
+            ? filters.dateRange.end
+            : new Date(filters.dateRange.end);
+
+        timestampFilter.lte = formatForClickHouse(endDate);
+      }
+      if (Object.keys(timestampFilter).length > 0) {
+        filterObj.timestamp = timestampFilter;
+      }
+    }
+
+    if (table === EventLogTable.OBJECT_EVENT) {
+      if (isDefined(filters.recordId)) {
+        filterObj.recordId = { eq: filters.recordId };
+      }
+      if (isDefined(filters.objectMetadataId)) {
+        filterObj.objectMetadataId = { eq: filters.objectMetadataId };
+      }
+    }
+
+    return Object.keys(filterObj).length > 0 ? filterObj : undefined;
+  }
+
+  private buildOrderBy(
+    orderBy:
+      | { field: EventLogOrderByField; direction: EventLogOrderByDirection }
+      | undefined,
+  ): Array<Record<string, string>> {
+    if (!isDefined(orderBy)) {
+      return [{ timestamp: 'DESC' }];
+    }
+
+    return [{ [orderBy.field]: orderBy.direction }];
+  }
+
+  private normalizeRecords(
+    records: ClickHouseEventRecord[],
+    table: EventLogTable,
+  ): EventLogRecord[] {
+    return records.map((record) => {
+      const eventName =
+        table === EventLogTable.PAGEVIEW
+          ? record.name ?? ''
+          : record.event ?? '';
+
+      return {
+        event: eventName,
+        timestamp: new Date(record.timestamp),
+        userId: record.userId,
+        properties: record.properties,
+        recordId: record.recordId,
+        objectMetadataId: record.objectMetadataId,
+        isCustom: record.isCustom,
+      };
+    });
+  }
+
+  getAvailableTables(): EventLogTable[] {
+    return Object.values(EventLogTable);
+  }
+
+  private async resolveWorkspaceMemberFilter(
+    workspaceId: string,
+    filters: EventLogFiltersInput | undefined,
+  ): Promise<EventLogFiltersInput | undefined> {
+    if (!isDefined(filters) || !isDefined(filters.workspaceMemberId)) {
+      return filters;
+    }
+
+    this.logger.debug(
+      `Resolving workspaceMemberId ${filters.workspaceMemberId} to userId`,
+    );
+
+    // Look up the userId from workspace member
+    const authContext = buildSystemAuthContext(workspaceId);
+
+    const userId = await this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+      authContext,
+      async () => {
+        const workspaceMemberRepository =
+          await this.globalWorkspaceOrmManager.getRepository<WorkspaceMemberWorkspaceEntity>(
+            workspaceId,
+            'workspaceMember',
+            { shouldBypassPermissionChecks: true },
+          );
+
+        const workspaceMember = await workspaceMemberRepository.findOne({
+          where: {
+            id: filters.workspaceMemberId,
+          },
+        });
+
+        this.logger.debug(
+          `Found workspace member: ${JSON.stringify(workspaceMember)}`,
+        );
+
+        return workspaceMember?.userId;
+      },
+    );
+
+    if (!isDefined(userId)) {
+      this.logger.warn(
+        `Workspace member ${filters.workspaceMemberId} not found in workspace ${workspaceId}`,
+      );
+    } else {
+      this.logger.debug(`Resolved userId: ${userId}`);
+    }
+
+    // Return filters with resolved userId (keeping workspaceMemberId for reference)
+    return {
+      ...filters,
+      userId: userId ?? filters.userId,
+    };
+  }
+}

--- a/packages/twenty-server/src/engine/core-modules/event-logs/index.ts
+++ b/packages/twenty-server/src/engine/core-modules/event-logs/index.ts
@@ -1,0 +1,3 @@
+export { EventLogsModule } from './event-logs.module';
+export { EventLogsService } from './event-logs.service';
+export * from './dtos';

--- a/packages/twenty-shared/src/types/SettingsPath.ts
+++ b/packages/twenty-shared/src/types/SettingsPath.ts
@@ -49,6 +49,7 @@ export enum SettingsPath {
   Integrations = 'integrations',
   Security = 'security',
   NewSSOIdentityProvider = 'security/sso/new',
+  EventLogs = 'security/event-logs',
 
   AdminPanel = 'admin-panel',
   AdminPanelHealthStatus = 'admin-panel#health-status',


### PR DESCRIPTION
## Summary
Add a new Event Logs feature to the Settings > Security section that allows querying and viewing event logs from ClickHouse.

## Changes

### Frontend
- Add `SettingsEventLogs` page with table selector, filters, and results table
- Add `EventLogFilters` component with date range, event type, and user filters
- Add `EventLogResultsTable` with pagination support
- Add `EventLogTableSelector` for switching between PAGEVIEW, OBJECT_EVENT, and WORKSPACE_EVENT tables
- Update `SettingsRoutes` with new EventLogs path
- Update `SettingsSecurity` page with link to Event Logs

### Backend
- Add `EventLogsModule` with resolver and service
- Add GraphQL types for event log queries (`EventLogQueryInput`, `EventLogQueryResult`, `EventLogRecord`)
- Add ClickHouse query runners for event log data
- Add database migration for ClickHouse data source type enum

## Testing
- Navigate to Settings > Security > Event Logs
- Select different tables (Pageview, Object Event, Workspace Event)
- Apply filters and verify pagination works correctly

Co-Authored-By: Warp <agent@warp.dev>