### PR TITLE
fix: Hide Accounts settings and skip SYNC_EMAIL onboarding when CONNECTED_ACCOUNTS permission is disabled

### DIFF
--- a/packages/twenty-front/src/modules/onboarding/hooks/useSetNextOnboardingStatus.ts
+++ b/packages/twenty-front/src/modules/onboarding/hooks/useSetNextOnboardingStatus.ts
@@ -9,21 +9,29 @@ import {
   currentWorkspaceState,
 } from '@/auth/states/currentWorkspaceState';
 import { calendarBookingPageIdState } from '@/client-config/states/calendarBookingPageIdState';
+import { usePermissionFlagMap } from '@/settings/roles/hooks/usePermissionFlagMap';
 import { isDefined } from 'twenty-shared/utils';
-import { OnboardingStatus } from '~/generated/graphql';
+import { OnboardingStatus, PermissionFlagType } from '~/generated/graphql';
 
 const getNextOnboardingStatus = (
   currentUser: CurrentUser | null,
   currentWorkspace: CurrentWorkspace | null,
   calendarBookingPageId: string | null,
+  hasConnectedAccountsPermission: boolean,
 ) => {
   if (currentUser?.onboardingStatus === OnboardingStatus.WORKSPACE_ACTIVATION) {
     return OnboardingStatus.PROFILE_CREATION;
   }
 
   if (currentUser?.onboardingStatus === OnboardingStatus.PROFILE_CREATION) {
-    if (currentWorkspace?.workspaceMembersCount === 1) {
+    if (
+      currentWorkspace?.workspaceMembersCount === 1 &&
+      hasConnectedAccountsPermission
+    ) {
       return OnboardingStatus.SYNC_EMAIL;
+    }
+    if (currentWorkspace?.workspaceMembersCount === 1) {
+      return OnboardingStatus.INVITE_TEAM;
     }
     return OnboardingStatus.COMPLETED;
   }
@@ -48,6 +56,10 @@ export const useSetNextOnboardingStatus = () => {
   const currentUser = useRecoilValue(currentUserState);
   const currentWorkspace = useRecoilValue(currentWorkspaceState);
   const calendarBookingPageId = useRecoilValue(calendarBookingPageIdState);
+  const permissionMap = usePermissionFlagMap();
+
+  const hasConnectedAccountsPermission =
+    permissionMap[PermissionFlagType.CONNECTED_ACCOUNTS];
 
   return useRecoilCallback(
     ({ set }) =>
@@ -56,6 +68,7 @@ export const useSetNextOnboardingStatus = () => {
           currentUser,
           currentWorkspace,
           calendarBookingPageId,
+          hasConnectedAccountsPermission,
         );
         set(currentUserState, (current) => {
           if (isDefined(current)) {
@@ -67,6 +80,11 @@ export const useSetNextOnboardingStatus = () => {
           return current;
         });
       },
-    [currentWorkspace, currentUser, calendarBookingPageId],
+    [
+      currentWorkspace,
+      currentUser,
+      calendarBookingPageId,
+      hasConnectedAccountsPermission,
+    ],
   );
 };

--- a/packages/twenty-front/src/modules/settings/hooks/__tests__/useSettingsNavigationItems.test.tsx
+++ b/packages/twenty-front/src/modules/settings/hooks/__tests__/useSettingsNavigationItems.test.tsx
@@ -114,7 +114,11 @@ describe('useSettingsNavigationItems', () => {
     expect(workspaceSection?.items.some((item) => !item.isHidden)).toBe(true);
   });
 
-  it('should show user section items regardless of permissions', () => {
+  it('should show user section items (except Accounts) regardless of permissions', () => {
+    (usePermissionFlagMap as jest.Mock).mockImplementation(() => ({
+      [PermissionFlagType.CONNECTED_ACCOUNTS]: false,
+    }));
+
     const { result } = renderHook(() => useSettingsNavigationItems(), {
       wrapper: Wrapper,
     });
@@ -123,6 +127,50 @@ describe('useSettingsNavigationItems', () => {
       (section) => section.label === 'User',
     );
     expect(userSection?.items.length).toBeGreaterThan(0);
-    expect(userSection?.items.every((item) => !item.isHidden)).toBe(true);
+
+    const profileItem = userSection?.items.find(
+      (item) => item.label === 'Profile',
+    );
+    const experienceItem = userSection?.items.find(
+      (item) => item.label === 'Experience',
+    );
+    expect(profileItem?.isHidden).toBeFalsy();
+    expect(experienceItem?.isHidden).toBeFalsy();
+  });
+
+  it('should hide Accounts when no CONNECTED_ACCOUNTS permission', () => {
+    (usePermissionFlagMap as jest.Mock).mockImplementation(() => ({
+      [PermissionFlagType.CONNECTED_ACCOUNTS]: false,
+    }));
+
+    const { result } = renderHook(() => useSettingsNavigationItems(), {
+      wrapper: Wrapper,
+    });
+
+    const userSection = result.current.find(
+      (section) => section.label === 'User',
+    );
+    const accountsItem = userSection?.items.find(
+      (item) => item.label === 'Accounts',
+    );
+    expect(accountsItem?.isHidden).toBe(true);
+  });
+
+  it('should show Accounts when has CONNECTED_ACCOUNTS permission', () => {
+    (usePermissionFlagMap as jest.Mock).mockImplementation(() => ({
+      [PermissionFlagType.CONNECTED_ACCOUNTS]: true,
+    }));
+
+    const { result } = renderHook(() => useSettingsNavigationItems(), {
+      wrapper: Wrapper,
+    });
+
+    const userSection = result.current.find(
+      (section) => section.label === 'User',
+    );
+    const accountsItem = userSection?.items.find(
+      (item) => item.label === 'Accounts',
+    );
+    expect(accountsItem?.isHidden).toBe(false);
   });
 });

--- a/packages/twenty-front/src/modules/settings/hooks/useSettingsNavigationItems.tsx
+++ b/packages/twenty-front/src/modules/settings/hooks/useSettingsNavigationItems.tsx
@@ -96,6 +96,7 @@ const useSettingsNavigationItems = (): SettingsNavigationSection[] => {
           label: t`Accounts`,
           path: SettingsPath.Accounts,
           Icon: IconAt,
+          isHidden: !permissionMap[PermissionFlagType.CONNECTED_ACCOUNTS],
           subItems: [
             {
               label: t`Emails`,


### PR DESCRIPTION
## Summary

Fixes #17411

When `CONNECTED_ACCOUNTS` permission is disabled for a role, users were still seeing:
1. The "Emails and Calendar" onboarding step (SYNC_EMAIL)
2. The Settings > Accounts navigation item

This creates a confusing UX where users are prompted to do something their role doesn't permit.

## Changes

### Frontend

1. **Settings Navigation** (`useSettingsNavigationItems.tsx`):
   - Added `isHidden: !permissionMap[PermissionFlagType.CONNECTED_ACCOUNTS]` to the Accounts navigation item
   - Users without CONNECTED_ACCOUNTS permission will no longer see the Accounts section in Settings

2. **Onboarding Flow** (`useSetNextOnboardingStatus.ts`):
   - Added permission check using `usePermissionFlagMap`
   - When CONNECTED_ACCOUNTS permission is disabled, the SYNC_EMAIL step is skipped
   - Users go directly from PROFILE_CREATION to INVITE_TEAM

### Tests

- Updated `useSetNextOnboardingStatus.test.ts` to cover the new permission-based skip logic
- Updated `useSettingsNavigationItems.test.tsx` to verify Accounts visibility based on permissions

## Testing

1. Create a role with CONNECTED_ACCOUNTS permission disabled
2. Create a new user with that role
3. Verify onboarding skips the SYNC_EMAIL step
4. Verify Settings > Accounts is hidden