### PR TITLE
Fix: Favorite records not showing in sidebar

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/navigation-menu-item/navigation-menu-item.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/navigation-menu-item/navigation-menu-item.resolver.ts
@@ -11,10 +11,10 @@ import {
 
 import { isDefined } from 'twenty-shared/utils';
 
-import { type WorkspaceAuthContext } from 'src/engine/core-modules/auth/types/workspace-auth-context.type';
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 import { ApiKeyEntity } from 'src/engine/core-modules/api-key/api-key.entity';
 import { ApplicationEntity } from 'src/engine/core-modules/application/application.entity';
+import { getWorkspaceAuthContext } from 'src/engine/core-modules/auth/storage/workspace-auth-context.storage';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AuthApiKey } from 'src/engine/decorators/auth/auth-api-key.decorator';
 import { AuthUserWorkspaceId } from 'src/engine/decorators/auth/auth-user-workspace-id.decorator';
@@ -122,7 +122,6 @@ export class NavigationMenuItemResolver {
   async targetRecordIdentifier(
     @Parent() navigationMenuItem: NavigationMenuItemDTO,
     @AuthWorkspace() workspace: WorkspaceEntity,
-    @Context() context: { req: WorkspaceAuthContext },
   ): Promise<RecordIdentifierDTO | null> {
     if (
       !isDefined(navigationMenuItem.targetRecordId) ||
@@ -131,11 +130,13 @@ export class NavigationMenuItemResolver {
       return null;
     }
 
+    const authContext = getWorkspaceAuthContext();
+
     return await this.navigationMenuItemService.findTargetRecord({
       targetRecordId: navigationMenuItem.targetRecordId,
       targetObjectMetadataId: navigationMenuItem.targetObjectMetadataId,
       workspaceId: workspace.id,
-      authContext: context.req,
+      authContext,
     });
   }
 }


### PR DESCRIPTION
## Problem
Favorite records (`NavigationMenuItems`) were not showing in the sidebar under Favorites as the BE was returning `null` for `targetRecordIdentifier`.
## Root cause
The `targetRecordIdentifier` resolver used `context.req`, which does not have the typed `WorkspaceAuthContext` shape. 
## Fix
Use `getWorkspaceAuthContext()` instead of `context.req` so the resolver receives the typed auth context.