### PR TITLE
fix: force Claude Code to use Opus model

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -74,7 +74,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           additional_permissions: |
             actions: read
-          claude_args: "--max-turns 50"
+          claude_args: "--max-turns 50 --model opus"
 
   claude-cross-repo:
     if: github.event_name == 'repository_dispatch'
@@ -139,7 +139,7 @@ jobs:
           prompt: ${{ steps.prompt.outputs.prompt }}
           additional_permissions: |
             actions: read
-          claude_args: "--max-turns 50"
+          claude_args: "--max-turns 50 --model opus"
       - name: Post response to source issue
         if: always()
         uses: actions/github-script@v7


### PR DESCRIPTION
## Summary
- Add `--model opus` to `claude_args` in both the direct and cross-repo Claude jobs

## Test plan
- [ ] Merge and trigger @claude — verify it reports running Opus 4.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)