### PR TITLE
Revert "fix: prevent default object re-selection in relation field fo…

### DIFF
--- a/packages/twenty-front/src/modules/settings/components/SettingsMorphRelationMultiSelect.tsx
+++ b/packages/twenty-front/src/modules/settings/components/SettingsMorphRelationMultiSelect.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { plural, t } from '@lingui/core/macro';
+import { plural } from '@lingui/core/macro';
 import { useMemo, useRef, useState, type MouseEvent } from 'react';
 
 import { Dropdown } from '@/ui/layout/dropdown/components/Dropdown';
@@ -191,7 +191,6 @@ export const SettingsMorphRelationMultiSelect = ({
           isDisabled={isDisabled}
           selectSizeVariant={selectSizeVariant}
           hasRightElement={hasRightElement}
-          placeholderText={t`Select objects...`}
         />
       ) : (
         <Dropdown
@@ -214,7 +213,6 @@ export const SettingsMorphRelationMultiSelect = ({
               isDisabled={isDisabled}
               selectSizeVariant={selectSizeVariant}
               hasRightElement={hasRightElement}
-              placeholderText={t`Select objects...`}
             />
           }
           dropdownComponents={

--- a/packages/twenty-front/src/modules/settings/data-model/fields/forms/morph-relation/components/SettingsDataModelFieldRelationForm.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/forms/morph-relation/components/SettingsDataModelFieldRelationForm.tsx
@@ -17,7 +17,6 @@ import { SettingsTextInput } from '@/ui/input/components/SettingsTextInput';
 import { useIsMobile } from '@/ui/utilities/responsive/hooks/useIsMobile';
 import styled from '@emotion/styled';
 import { useLingui } from '@lingui/react/macro';
-import { useMemo } from 'react';
 import { isDefined } from 'twenty-shared/utils';
 import { RelationType } from '~/generated-metadata/graphql';
 
@@ -115,14 +114,10 @@ export const SettingsDataModelFieldRelationForm = ({
       relationType: initialRelationType,
     });
 
-  const initialMorphRelationsObjectMetadataIds = useMemo(
-    () =>
-      initialRelationObjectMetadataItems.map(
-        (relationObjectMetadataItem) => relationObjectMetadataItem.id,
-      ),
-    [initialRelationObjectMetadataItems],
-  );
-
+  const initialMorphRelationsObjectMetadataIds =
+    initialRelationObjectMetadataItems.map(
+      (relationObjectMetadataItem) => relationObjectMetadataItem.id,
+    );
   const isMobile = useIsMobile();
 
   return (

--- a/packages/twenty-front/src/modules/ui/input/components/MultiSelectControl.tsx
+++ b/packages/twenty-front/src/modules/ui/input/components/MultiSelectControl.tsx
@@ -20,7 +20,6 @@ type MultiSelectControlProps = Omit<SelectControlProps, 'selectedOption'> & {
   fixedIcon?: IconComponent;
   fixedText?: string;
   selectedOptions: MultiSelectOptionType[];
-  placeholderText?: string;
 };
 
 export const MultiSelectControl = ({
@@ -31,22 +30,16 @@ export const MultiSelectControl = ({
   selectSizeVariant,
   textAccent = 'default',
   hasRightElement,
-  placeholderText,
 }: MultiSelectControlProps) => {
   const theme = useTheme();
 
-  const firstSelectedOption = selectedOptions[0];
-  const hasSelection = selectedOptions.length > 0;
-
+  const firstSelectedOption = selectedOptions?.[0];
   return (
     <StyledControlContainer
       disabled={isDisabled}
-      hasIcon={
-        isDefined(fixedIcon) ||
-        (hasSelection && isDefined(firstSelectedOption?.Icon))
-      }
+      hasIcon={isDefined(fixedIcon) || isDefined(firstSelectedOption?.Icon)}
       selectSizeVariant={selectSizeVariant}
-      textAccent={hasSelection ? textAccent : 'placeholder'}
+      textAccent={textAccent}
       hasRightElement={hasRightElement}
     >
       {isDefined(fixedIcon) ? (
@@ -55,7 +48,7 @@ export const MultiSelectControl = ({
           size: theme.icon.size.md,
           stroke: theme.icon.stroke.sm,
         })
-      ) : hasSelection && isDefined(firstSelectedOption.Icon) ? (
+      ) : isDefined(firstSelectedOption?.Icon) ? (
         <firstSelectedOption.Icon
           color={isDisabled ? theme.font.color.light : theme.font.color.primary}
           size={theme.icon.size.md}
@@ -64,11 +57,9 @@ export const MultiSelectControl = ({
       ) : null}
       {isDefined(fixedText) ? (
         <OverflowingTextWithTooltip text={fixedText} />
-      ) : hasSelection ? (
-        <OverflowingTextWithTooltip text={firstSelectedOption.label} />
-      ) : isDefined(placeholderText) ? (
-        <OverflowingTextWithTooltip text={placeholderText} />
-      ) : null}
+      ) : (
+        <OverflowingTextWithTooltip text={firstSelectedOption?.label ?? ''} />
+      )}
 
       <StyledSelectControlIconChevronDown
         disabled={isDisabled}


### PR DESCRIPTION
I suggest to revert [this PR](https://github.com/twentyhq/twenty/pull/17313) as it had already been fixed [in this PR](https://github.com/twentyhq/twenty/pull/17209/changes) (which fixes more than it says in its title). Issue was tracked by [this ticket](https://github.com/twentyhq/core-team-issues/issues/2049) not very explicit - sorry, my fault.
Code added in the PR does not add value