### PR TITLE
feat: lazy dev env setup for Claude CI workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -55,15 +55,6 @@ jobs:
           fetch-depth: 0
       - name: Install dependencies
         uses: ./.github/actions/yarn-install
-      - name: Restore Nx and build cache
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            .nx/cache
-            .cache
-          key: claude-nx-${{ github.run_id }}
-          restore-keys: |
-            claude-nx-
       - name: Run Claude Code
         uses: anthropics/claude-code-action@v1
         with:
@@ -76,14 +67,6 @@ jobs:
                 "PG_DATABASE_URL": "postgres://postgres:postgres@localhost:5432/default"
               }
             }
-      - name: Save Nx and build cache
-        uses: actions/cache/save@v4
-        if: always()
-        with:
-          path: |
-            .nx/cache
-            .cache
-          key: claude-nx-${{ github.run_id }}
 
   claude-cross-repo:
     if: github.event_name == 'repository_dispatch'
@@ -113,15 +96,6 @@ jobs:
           fetch-depth: 0
       - name: Install dependencies
         uses: ./.github/actions/yarn-install
-      - name: Restore Nx and build cache
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            .nx/cache
-            .cache
-          key: claude-nx-${{ github.run_id }}
-          restore-keys: |
-            claude-nx-
       - name: Build prompt from dispatch payload
         id: prompt
         uses: actions/github-script@v7
@@ -151,14 +125,6 @@ jobs:
                 "PG_DATABASE_URL": "postgres://postgres:postgres@localhost:5432/default"
               }
             }
-      - name: Save Nx and build cache
-        uses: actions/cache/save@v4
-        if: always()
-        with:
-          path: |
-            .nx/cache
-            .cache
-          key: claude-nx-${{ github.run_id }}
       - name: Post response to source issue
         if: always()
         uses: actions/github-script@v7

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,7 +30,6 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write
-      actions: read
     services:
       postgres:
         image: postgres:16
@@ -56,25 +55,35 @@ jobs:
           fetch-depth: 0
       - name: Install dependencies
         uses: ./.github/actions/yarn-install
-      - name: Build shared dependencies
-        run: |
-          npx nx build twenty-shared
-          npx nx build twenty-emails
-      - name: Setup env files
-        run: |
-          npx nx reset:env twenty-front
-          npx nx reset:env twenty-server
-      - name: Create databases
-        run: |
-          PGPASSWORD=postgres psql -h localhost -p 5432 -U postgres -d postgres -c 'CREATE DATABASE "default";'
-          PGPASSWORD=postgres psql -h localhost -p 5432 -U postgres -d postgres -c 'CREATE DATABASE "test";'
+      - name: Restore Nx and build cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            .nx/cache
+            .cache
+          key: claude-nx-${{ github.sha }}
+          restore-keys: |
+            claude-nx-
       - name: Run Claude Code
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          additional_permissions: |
-            actions: read
           claude_args: "--max-turns 50 --model opus"
+          allowed_tools: "Bash(bash packages/twenty-utils/setup-dev-env.sh),Bash(npx nx *),Bash(npx jest *),Bash(yarn *)"
+          settings: |
+            {
+              "env": {
+                "PG_DATABASE_URL": "postgres://postgres:postgres@localhost:5432/default"
+              }
+            }
+      - name: Save Nx and build cache
+        uses: actions/cache/save@v4
+        if: always()
+        with:
+          path: |
+            .nx/cache
+            .cache
+          key: claude-nx-${{ github.sha }}
 
   claude-cross-repo:
     if: github.event_name == 'repository_dispatch'
@@ -104,18 +113,15 @@ jobs:
           fetch-depth: 0
       - name: Install dependencies
         uses: ./.github/actions/yarn-install
-      - name: Build shared dependencies
-        run: |
-          npx nx build twenty-shared
-          npx nx build twenty-emails
-      - name: Setup env files
-        run: |
-          npx nx reset:env twenty-front
-          npx nx reset:env twenty-server
-      - name: Create databases
-        run: |
-          PGPASSWORD=postgres psql -h localhost -p 5432 -U postgres -d postgres -c 'CREATE DATABASE "default";'
-          PGPASSWORD=postgres psql -h localhost -p 5432 -U postgres -d postgres -c 'CREATE DATABASE "test";'
+      - name: Restore Nx and build cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            .nx/cache
+            .cache
+          key: claude-nx-${{ github.sha }}
+          restore-keys: |
+            claude-nx-
       - name: Build prompt from dispatch payload
         id: prompt
         uses: actions/github-script@v7
@@ -137,9 +143,22 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.prompt.outputs.prompt }}
-          additional_permissions: |
-            actions: read
           claude_args: "--max-turns 50 --model opus"
+          allowed_tools: "Bash(bash packages/twenty-utils/setup-dev-env.sh),Bash(npx nx *),Bash(npx jest *),Bash(yarn *)"
+          settings: |
+            {
+              "env": {
+                "PG_DATABASE_URL": "postgres://postgres:postgres@localhost:5432/default"
+              }
+            }
+      - name: Save Nx and build cache
+        uses: actions/cache/save@v4
+        if: always()
+        with:
+          path: |
+            .nx/cache
+            .cache
+          key: claude-nx-${{ github.sha }}
       - name: Post response to source issue
         if: always()
         uses: actions/github-script@v7

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -61,7 +61,7 @@ jobs:
           path: |
             .nx/cache
             .cache
-          key: claude-nx-${{ github.sha }}
+          key: claude-nx-${{ github.run_id }}
           restore-keys: |
             claude-nx-
       - name: Run Claude Code
@@ -83,7 +83,7 @@ jobs:
           path: |
             .nx/cache
             .cache
-          key: claude-nx-${{ github.sha }}
+          key: claude-nx-${{ github.run_id }}
 
   claude-cross-repo:
     if: github.event_name == 'repository_dispatch'
@@ -119,7 +119,7 @@ jobs:
           path: |
             .nx/cache
             .cache
-          key: claude-nx-${{ github.sha }}
+          key: claude-nx-${{ github.run_id }}
           restore-keys: |
             claude-nx-
       - name: Build prompt from dispatch payload
@@ -158,7 +158,7 @@ jobs:
           path: |
             .nx/cache
             .cache
-          key: claude-nx-${{ github.sha }}
+          key: claude-nx-${{ github.run_id }}
       - name: Post response to source issue
         if: always()
         uses: actions/github-script@v7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,6 +186,14 @@ IMPORTANT: Use Context7 for code generation, setup or configuration steps, or li
 - Descriptive test names: "should [behavior] when [condition]"
 - Clear mocks between tests with `jest.clearAllMocks()`
 
+## CI Environment (GitHub Actions)
+
+When running in CI, the dev environment is **not** pre-configured. Dependencies are installed but builds, env files, and databases are not set up.
+
+- **Before running tests, builds, lint, type checks, or DB operations**, run: `bash packages/twenty-utils/setup-dev-env.sh`
+- **Skip the setup script** for tasks that only read code — architecture questions, code review, documentation, etc.
+- The script is idempotent and safe to run multiple times.
+
 ## Important Files
 - `nx.json` - Nx workspace configuration with task definitions
 - `tsconfig.base.json` - Base TypeScript configuration

--- a/packages/twenty-utils/setup-dev-env.sh
+++ b/packages/twenty-utils/setup-dev-env.sh
@@ -3,9 +3,6 @@ set -e
 
 echo "Setting up dev environment..."
 
-npx nx build twenty-shared
-npx nx build twenty-emails
-
 npx nx reset:env twenty-front
 npx nx reset:env twenty-server
 

--- a/packages/twenty-utils/setup-dev-env.sh
+++ b/packages/twenty-utils/setup-dev-env.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+echo "Setting up dev environment..."
+
+npx nx build twenty-shared
+npx nx build twenty-emails
+
+npx nx reset:env twenty-front
+npx nx reset:env twenty-server
+
+PGPASSWORD=postgres psql -h localhost -p 5432 -U postgres -d postgres -c 'CREATE DATABASE "default";' 2>/dev/null || true
+PGPASSWORD=postgres psql -h localhost -p 5432 -U postgres -d postgres -c 'CREATE DATABASE "test";' 2>/dev/null || true
+
+echo "Dev environment ready."


### PR DESCRIPTION
## Summary
- Move build/env/DB setup out of the GitHub Actions workflow into an on-demand script (`packages/twenty-utils/setup-dev-env.sh`) that Claude invokes only when needed
- Add Nx/build cache restore/save steps to speed up repeated runs
- Add `allowed_tools` so Claude can run the setup script and common dev commands (nx, jest, yarn)
- Add `PG_DATABASE_URL` env var via `settings` for the postgres MCP server
- Remove unnecessary `actions: read` permission grant
- Document the lazy setup pattern in CLAUDE.md

This makes read-only tasks (code review, architecture questions, docs) fast by skipping the ~2min build/setup overhead, while still letting Claude run tests and builds when it needs to.

## Test plan
- [ ] Comment `@claude what is the architecture of the backend?` — should answer fast without running setup
- [ ] Comment `@claude run the twenty-server unit tests` — should call setup script first, then run tests
- [ ] Verify cross-repo dispatch still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)