### PR TITLE
fix: Claude workflow — prevent bot self-cancellation and add CI permissions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -9,21 +9,19 @@ on:
     types: [submitted]
   issues:
     types: [opened, assigned]
-  discussion_comment:
-    types: [created]
   repository_dispatch:
     types: [claude-core-team-issues]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number || github.event.client_payload.issue_number || github.event.discussion.number }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number || github.event.client_payload.issue_number }}
+  cancel-in-progress: false
 
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && github.event.comment.user.type != 'Bot') ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && github.event.comment.user.type != 'Bot') ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && github.event.review.user.type != 'Bot') ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -61,6 +59,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            actions: read
           claude_args: '--max-turns 50 --model opus --allowedTools "Edit,Write,WebFetch,Bash(bash packages/twenty-utils/setup-dev-env.sh),Bash(npx nx *),Bash(npx jest *),Bash(yarn *),Bash(git *),Bash(gh *),Bash(sed *),Bash(python3 *)"'
           settings: |
             {
@@ -68,81 +68,6 @@ jobs:
                 "PG_DATABASE_URL": "postgres://postgres:postgres@localhost:5432/default"
               }
             }
-
-  claude-discussion:
-    if: |
-      github.event_name == 'discussion_comment' && contains(github.event.comment.body, '@claude')
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    permissions:
-      contents: write
-      pull-requests: write
-      issues: write
-      id-token: write
-      discussions: write
-    services:
-      postgres:
-        image: postgres:16
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: postgres
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-      redis:
-        image: redis
-        ports:
-          - 6379:6379
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Install dependencies
-        uses: ./.github/actions/yarn-install
-      - name: Build prompt from discussion
-        id: prompt
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const discussion = context.payload.discussion;
-            const comment = context.payload.comment;
-            const prompt = `You are responding to a comment on discussion #${discussion.number} ("${discussion.title}") in the ${context.repo.owner}/${context.repo.repo} repository.\n\nThe comment by @${comment.user.login} says:\n\n${comment.body}\n\nDiscussion body:\n\n${discussion.body}\n\nPlease help with this request. The code you are working with is the twenty codebase (this repository).`;
-            core.setOutput('prompt', prompt);
-            core.setOutput('discussion_node_id', discussion.node_id);
-      - name: Run Claude Code
-        id: claude
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          prompt: ${{ steps.prompt.outputs.prompt }}
-          claude_args: '--max-turns 50 --model opus --allowedTools "Edit,Write,WebFetch,Bash(bash packages/twenty-utils/setup-dev-env.sh),Bash(npx nx *),Bash(npx jest *),Bash(yarn *),Bash(git *),Bash(gh *),Bash(sed *),Bash(python3 *)"'
-          settings: |
-            {
-              "env": {
-                "PG_DATABASE_URL": "postgres://postgres:postgres@localhost:5432/default"
-              }
-            }
-      - name: Post response to discussion
-        if: always()
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const response = `Claude finished processing this request. [See workflow run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`;
-            await github.graphql(`
-              mutation($discussionId: ID!, $body: String!) {
-                addDiscussionComment(input: {discussionId: $discussionId, body: $body}) {
-                  comment { id }
-                }
-              }
-            `, {
-              discussionId: '${{ steps.prompt.outputs.discussion_node_id }}',
-              body: response
-            });
 
   claude-cross-repo:
     if: github.event_name == 'repository_dispatch'
@@ -198,6 +123,8 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.prompt.outputs.prompt }}
+          additional_permissions: |
+            actions: read
           claude_args: '--max-turns 50 --model opus --allowedTools "Edit,Write,WebFetch,Bash(bash packages/twenty-utils/setup-dev-env.sh),Bash(npx nx *),Bash(npx jest *),Bash(yarn *),Bash(git *),Bash(gh *),Bash(sed *),Bash(python3 *)"'
           settings: |
             {


### PR DESCRIPTION
## Summary
- **Set `cancel-in-progress: false`** — Claude's own comments (e.g. error reports) were triggering new workflow runs via `issue_comment`, which cancelled the in-progress Claude run before the new run's `if` condition could skip it. Disabling cancel-in-progress prevents this.
- **Filter out Bot users in `if` conditions** — Added `github.event.comment.user.type != 'Bot'` so Claude's own comments don't start job evaluation at all.
- **Add back `additional_permissions: actions: read`** — Lets Claude read CI failure logs to help debug broken builds.
- **Remove `discussion_comment` trigger and job** — `claude-code-action` doesn't support this event type yet (throws `Unsupported event type: discussion_comment`). Listed as planned in their security.md.

## Context
Claude runs were consistently failing with `The operation was canceled` because:
1. Claude posts an error/status comment back to the issue
2. That comment triggers a new `issue_comment` workflow run on the same issue number
3. The concurrency group cancels the in-progress run before the new run evaluates its `if` and skips

## Test plan
- [ ] Tag `@claude` on an issue — should run to completion without being cancelled
- [ ] Verify Claude's own reply comments don't trigger new workflow runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)