### PR TITLE
fix: prevent metadata schema leakage into /graphql and disable auto-discovery

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/__tests__/metadata-resolvers.spec.ts
+++ b/packages/twenty-server/src/engine/api/graphql/__tests__/metadata-resolvers.spec.ts
@@ -1,0 +1,63 @@
+import { metadataResolvers } from 'src/engine/api/graphql/metadata-resolvers';
+
+describe('metadataResolvers', () => {
+  it('should export a non-empty array of resolver classes', () => {
+    expect(metadataResolvers).toBeDefined();
+    expect(Array.isArray(metadataResolvers)).toBe(true);
+    expect(metadataResolvers.length).toBeGreaterThan(0);
+  });
+
+  it('should contain only function (class) references', () => {
+    for (const resolver of metadataResolvers) {
+      expect(typeof resolver).toBe('function');
+    }
+  });
+
+  it('should not contain duplicates', () => {
+    const uniqueResolvers = new Set(metadataResolvers);
+
+    expect(uniqueResolvers.size).toBe(metadataResolvers.length);
+  });
+
+  it('should contain all expected metadata resolver classes', () => {
+    const resolverNames = metadataResolvers.map((r) => r.name);
+
+    expect(resolverNames).toContain('AgentTurnResolver');
+    expect(resolverNames).toContain('AgentResolver');
+    expect(resolverNames).toContain('AgentChatResolver');
+    expect(resolverNames).toContain('CommandMenuItemResolver');
+    expect(resolverNames).toContain('FieldMetadataResolver');
+    expect(resolverNames).toContain('FrontComponentResolver');
+    expect(resolverNames).toContain('IndexMetadataResolver');
+    expect(resolverNames).toContain('LogicFunctionLayerResolver');
+    expect(resolverNames).toContain('LogicFunctionResolver');
+    expect(resolverNames).toContain('NavigationMenuItemResolver');
+    expect(resolverNames).toContain('ObjectMetadataResolver');
+    expect(resolverNames).toContain('PageLayoutTabResolver');
+    expect(resolverNames).toContain('PageLayoutWidgetResolver');
+    expect(resolverNames).toContain('PageLayoutResolver');
+    expect(resolverNames).toContain('RoleResolver');
+    expect(resolverNames).toContain('SkillResolver');
+    expect(resolverNames).toContain('ViewFieldResolver');
+    expect(resolverNames).toContain('ViewFilterGroupResolver');
+    expect(resolverNames).toContain('ViewFilterResolver');
+    expect(resolverNames).toContain('ViewGroupResolver');
+    expect(resolverNames).toContain('ViewSortResolver');
+    expect(resolverNames).toContain('ViewResolver');
+    expect(resolverNames).toContain('WebhookResolver');
+  });
+
+  it('should not contain any core resolvers', () => {
+    const resolverNames = metadataResolvers.map((r) => r.name);
+
+    // These are core resolvers that should NOT be in the metadata list
+    expect(resolverNames).not.toContain('AuthResolver');
+    expect(resolverNames).not.toContain('UserResolver');
+    expect(resolverNames).not.toContain('WorkspaceResolver');
+    expect(resolverNames).not.toContain('BillingResolver');
+    expect(resolverNames).not.toContain('AdminPanelResolver');
+    expect(resolverNames).not.toContain('FileUploadResolver');
+    expect(resolverNames).not.toContain('SearchResolver');
+    expect(resolverNames).not.toContain('ClientConfigResolver');
+  });
+});

--- a/packages/twenty-server/src/engine/api/graphql/__tests__/metadata.module-factory.spec.ts
+++ b/packages/twenty-server/src/engine/api/graphql/__tests__/metadata.module-factory.spec.ts
@@ -23,7 +23,7 @@ describe('metadataModuleFactory', () => {
   } as any;
 
   it('should build schema explicitly using GraphQLSchemaFactory', async () => {
-    const config = await metadataModuleFactory(
+    await metadataModuleFactory(
       mockTwentyConfigService,
       mockExceptionHandlerService,
       mockDataloaderService,

--- a/packages/twenty-server/src/engine/api/graphql/__tests__/metadata.module-factory.spec.ts
+++ b/packages/twenty-server/src/engine/api/graphql/__tests__/metadata.module-factory.spec.ts
@@ -1,0 +1,127 @@
+import { GraphQLSchema } from 'graphql';
+
+import { metadataModuleFactory } from 'src/engine/api/graphql/metadata.module-factory';
+
+describe('metadataModuleFactory', () => {
+  const mockSchema = new GraphQLSchema({});
+
+  const mockTwentyConfigService = {
+    get: jest.fn().mockReturnValue('test'),
+  } as any;
+  const mockExceptionHandlerService = {} as any;
+  const mockDataloaderService = {
+    createLoaders: jest.fn().mockReturnValue({}),
+  } as any;
+  const mockCacheStorageService = {
+    get: jest.fn(),
+    set: jest.fn(),
+  } as any;
+  const mockMetricsService = {} as any;
+  const mockI18nService = {} as any;
+  const mockGraphQLSchemaFactory = {
+    create: jest.fn().mockResolvedValue(mockSchema),
+  } as any;
+
+  it('should build schema explicitly using GraphQLSchemaFactory', async () => {
+    const config = await metadataModuleFactory(
+      mockTwentyConfigService,
+      mockExceptionHandlerService,
+      mockDataloaderService,
+      mockCacheStorageService,
+      mockMetricsService,
+      mockI18nService,
+      mockGraphQLSchemaFactory,
+    );
+
+    expect(mockGraphQLSchemaFactory.create).toHaveBeenCalledTimes(1);
+    expect(mockGraphQLSchemaFactory.create).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({ numberScalarMode: 'integer' }),
+    );
+  });
+
+  it('should not include autoSchemaFile in the config', async () => {
+    const config = await metadataModuleFactory(
+      mockTwentyConfigService,
+      mockExceptionHandlerService,
+      mockDataloaderService,
+      mockCacheStorageService,
+      mockMetricsService,
+      mockI18nService,
+      mockGraphQLSchemaFactory,
+    );
+
+    expect(config).not.toHaveProperty('autoSchemaFile');
+  });
+
+  it('should not include include property in the config', async () => {
+    const config = await metadataModuleFactory(
+      mockTwentyConfigService,
+      mockExceptionHandlerService,
+      mockDataloaderService,
+      mockCacheStorageService,
+      mockMetricsService,
+      mockI18nService,
+      mockGraphQLSchemaFactory,
+    );
+
+    expect(config).not.toHaveProperty('include');
+  });
+
+  it('should set the schema property from GraphQLSchemaFactory', async () => {
+    const config = await metadataModuleFactory(
+      mockTwentyConfigService,
+      mockExceptionHandlerService,
+      mockDataloaderService,
+      mockCacheStorageService,
+      mockMetricsService,
+      mockI18nService,
+      mockGraphQLSchemaFactory,
+    );
+
+    expect(config.schema).toBe(mockSchema);
+  });
+
+  it('should set path to /metadata', async () => {
+    const config = await metadataModuleFactory(
+      mockTwentyConfigService,
+      mockExceptionHandlerService,
+      mockDataloaderService,
+      mockCacheStorageService,
+      mockMetricsService,
+      mockI18nService,
+      mockGraphQLSchemaFactory,
+    );
+
+    expect(config.path).toBe('/metadata');
+  });
+
+  it('should include resolvers with JSON scalar', async () => {
+    const config = await metadataModuleFactory(
+      mockTwentyConfigService,
+      mockExceptionHandlerService,
+      mockDataloaderService,
+      mockCacheStorageService,
+      mockMetricsService,
+      mockI18nService,
+      mockGraphQLSchemaFactory,
+    );
+
+    expect(config.resolvers).toHaveProperty('JSON');
+  });
+
+  it('should include plugins', async () => {
+    const config = await metadataModuleFactory(
+      mockTwentyConfigService,
+      mockExceptionHandlerService,
+      mockDataloaderService,
+      mockCacheStorageService,
+      mockMetricsService,
+      mockI18nService,
+      mockGraphQLSchemaFactory,
+    );
+
+    expect(config.plugins).toBeDefined();
+    expect(config.plugins!.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/twenty-server/src/engine/api/graphql/graphql-config/__tests__/graphql-config.service.spec.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-config/__tests__/graphql-config.service.spec.ts
@@ -26,22 +26,27 @@ describe('GraphQLConfigService', () => {
   });
 
   describe('createGqlOptions', () => {
-    it('should not include autoSchemaFile in the config', () => {
+    it('should include autoSchemaFile for core-engine resolvers', () => {
       const config = service.createGqlOptions();
 
-      expect(config).not.toHaveProperty('autoSchemaFile');
+      expect(config).toHaveProperty('autoSchemaFile', true);
     });
 
-    it('should not include include property in the config', () => {
+    it('should include CoreEngineModule in include list', () => {
       const config = service.createGqlOptions();
 
-      expect(config).not.toHaveProperty('include');
+      expect(config).toHaveProperty('include');
+      expect(config.include).toHaveLength(1);
     });
 
-    it('should not include buildSchemaOptions in the config', () => {
+    it('should include buildSchemaOptions with orphanedTypes', () => {
       const config = service.createGqlOptions();
 
-      expect(config).not.toHaveProperty('buildSchemaOptions');
+      expect(config).toHaveProperty('buildSchemaOptions');
+      expect(config.buildSchemaOptions?.orphanedTypes).toBeDefined();
+      expect(config.buildSchemaOptions!.orphanedTypes!.length).toBeGreaterThan(
+        0,
+      );
     });
 
     it('should include conditionalSchema in the config', () => {

--- a/packages/twenty-server/src/engine/api/graphql/graphql-config/__tests__/graphql-config.service.spec.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-config/__tests__/graphql-config.service.spec.ts
@@ -1,0 +1,68 @@
+import { GraphQLConfigService } from 'src/engine/api/graphql/graphql-config/graphql-config.service';
+
+describe('GraphQLConfigService', () => {
+  let service: GraphQLConfigService;
+
+  beforeEach(() => {
+    const mockExceptionHandlerService = {} as any;
+    const mockTwentyConfigService = {
+      get: jest.fn().mockReturnValue('test'),
+    } as any;
+    const mockModuleRef = {} as any;
+    const mockMetricsService = {} as any;
+    const mockDataloaderService = {
+      createLoaders: jest.fn().mockReturnValue({}),
+    } as any;
+    const mockI18nService = {} as any;
+
+    service = new GraphQLConfigService(
+      mockExceptionHandlerService,
+      mockTwentyConfigService,
+      mockModuleRef,
+      mockMetricsService,
+      mockDataloaderService,
+      mockI18nService,
+    );
+  });
+
+  describe('createGqlOptions', () => {
+    it('should not include autoSchemaFile in the config', () => {
+      const config = service.createGqlOptions();
+
+      expect(config).not.toHaveProperty('autoSchemaFile');
+    });
+
+    it('should not include include property in the config', () => {
+      const config = service.createGqlOptions();
+
+      expect(config).not.toHaveProperty('include');
+    });
+
+    it('should not include buildSchemaOptions in the config', () => {
+      const config = service.createGqlOptions();
+
+      expect(config).not.toHaveProperty('buildSchemaOptions');
+    });
+
+    it('should include conditionalSchema in the config', () => {
+      const config = service.createGqlOptions();
+
+      expect(config).toHaveProperty('conditionalSchema');
+      expect(typeof config.conditionalSchema).toBe('function');
+    });
+
+    it('should include resolvers with JSON scalar', () => {
+      const config = service.createGqlOptions();
+
+      expect(config.resolvers).toBeDefined();
+      expect(config.resolvers).toHaveProperty('JSON');
+    });
+
+    it('should include plugins', () => {
+      const config = service.createGqlOptions();
+
+      expect(config.plugins).toBeDefined();
+      expect(config.plugins!.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/packages/twenty-server/src/engine/api/graphql/graphql-config/graphql-config.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-config/graphql-config.service.ts
@@ -19,6 +19,18 @@ import { isDefined } from 'twenty-shared/utils';
 import { NodeEnvironment } from 'src/engine/core-modules/twenty-config/interfaces/node-environment.interface';
 
 import { WorkspaceSchemaFactory } from 'src/engine/api/graphql/workspace-schema.factory';
+import {
+  ApiConfig,
+  Billing,
+  Captcha,
+  ClientAIModelConfig,
+  NativeModelCapabilities,
+  PublicFeatureFlag,
+  PublicFeatureFlagMetadata,
+  Sentry as SentryConfig,
+  Support,
+} from 'src/engine/core-modules/client-config/client-config.entity';
+import { CoreEngineModule } from 'src/engine/core-modules/core-engine.module';
 import { ExceptionHandlerService } from 'src/engine/core-modules/exception-handler/exception-handler.service';
 import { useSentryTracing } from 'src/engine/core-modules/exception-handler/hooks/use-sentry-tracing';
 import { useDisableIntrospectionAndSuggestionsForUnauthenticatedUsers } from 'src/engine/core-modules/graphql/hooks/use-disable-introspection-and-suggestions-for-unauthenticated-users.hook';
@@ -79,6 +91,21 @@ export class GraphQLConfigService
     }
 
     const config: YogaDriverConfig = {
+      autoSchemaFile: true,
+      include: [CoreEngineModule],
+      buildSchemaOptions: {
+        orphanedTypes: [
+          ApiConfig,
+          Billing,
+          Captcha,
+          ClientAIModelConfig,
+          NativeModelCapabilities,
+          PublicFeatureFlag,
+          PublicFeatureFlagMetadata,
+          SentryConfig,
+          Support,
+        ],
+      },
       conditionalSchema: async (context) => {
         const { workspace, user } = context.req;
 

--- a/packages/twenty-server/src/engine/api/graphql/graphql-config/graphql-config.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-config/graphql-config.service.ts
@@ -19,18 +19,6 @@ import { isDefined } from 'twenty-shared/utils';
 import { NodeEnvironment } from 'src/engine/core-modules/twenty-config/interfaces/node-environment.interface';
 
 import { WorkspaceSchemaFactory } from 'src/engine/api/graphql/workspace-schema.factory';
-import {
-  ApiConfig,
-  Billing,
-  Captcha,
-  ClientAIModelConfig,
-  NativeModelCapabilities,
-  PublicFeatureFlag,
-  PublicFeatureFlagMetadata,
-  Sentry as SentryConfig,
-  Support,
-} from 'src/engine/core-modules/client-config/client-config.entity';
-import { CoreEngineModule } from 'src/engine/core-modules/core-engine.module';
 import { ExceptionHandlerService } from 'src/engine/core-modules/exception-handler/exception-handler.service';
 import { useSentryTracing } from 'src/engine/core-modules/exception-handler/hooks/use-sentry-tracing';
 import { useDisableIntrospectionAndSuggestionsForUnauthenticatedUsers } from 'src/engine/core-modules/graphql/hooks/use-disable-introspection-and-suggestions-for-unauthenticated-users.hook';
@@ -91,21 +79,6 @@ export class GraphQLConfigService
     }
 
     const config: YogaDriverConfig = {
-      autoSchemaFile: true,
-      include: [CoreEngineModule],
-      buildSchemaOptions: {
-        orphanedTypes: [
-          ApiConfig,
-          Billing,
-          Captcha,
-          ClientAIModelConfig,
-          NativeModelCapabilities,
-          PublicFeatureFlag,
-          PublicFeatureFlagMetadata,
-          SentryConfig,
-          Support,
-        ],
-      },
       conditionalSchema: async (context) => {
         const { workspace, user } = context.req;
 

--- a/packages/twenty-server/src/engine/api/graphql/metadata-graphql-api.module.ts
+++ b/packages/twenty-server/src/engine/api/graphql/metadata-graphql-api.module.ts
@@ -1,5 +1,9 @@
 import { Module } from '@nestjs/common';
-import { GraphQLModule } from '@nestjs/graphql';
+import {
+  GraphQLModule,
+  GraphQLSchemaBuilderModule,
+  GraphQLSchemaFactory,
+} from '@nestjs/graphql';
 
 import { YogaDriver, type YogaDriverConfig } from '@graphql-yoga/nestjs';
 
@@ -26,6 +30,7 @@ import { MetadataEngineModule } from 'src/engine/metadata-modules/metadata-engin
         DataloaderModule,
         MetricsModule,
         I18nModule,
+        GraphQLSchemaBuilderModule,
       ],
       inject: [
         TwentyConfigService,
@@ -34,6 +39,7 @@ import { MetadataEngineModule } from 'src/engine/metadata-modules/metadata-engin
         CacheStorageNamespace.EngineWorkspace,
         MetricsService,
         I18nService,
+        GraphQLSchemaFactory,
       ],
     }),
     MetadataEngineModule,

--- a/packages/twenty-server/src/engine/api/graphql/metadata-resolvers.ts
+++ b/packages/twenty-server/src/engine/api/graphql/metadata-resolvers.ts
@@ -1,0 +1,52 @@
+import { AgentTurnResolver } from 'src/engine/metadata-modules/ai/ai-agent-monitor/resolvers/agent-turn.resolver';
+import { AgentResolver } from 'src/engine/metadata-modules/ai/ai-agent/agent.resolver';
+import { AgentChatResolver } from 'src/engine/metadata-modules/ai/ai-chat/resolvers/agent-chat.resolver';
+import { CommandMenuItemResolver } from 'src/engine/metadata-modules/command-menu-item/command-menu-item.resolver';
+import { FieldMetadataResolver } from 'src/engine/metadata-modules/field-metadata/field-metadata.resolver';
+import { FrontComponentResolver } from 'src/engine/metadata-modules/front-component/front-component.resolver';
+import { IndexMetadataResolver } from 'src/engine/metadata-modules/index-metadata/index-metadata.resolver';
+import { LogicFunctionLayerResolver } from 'src/engine/metadata-modules/logic-function-layer/logic-function-layer.resolver';
+import { LogicFunctionResolver } from 'src/engine/metadata-modules/logic-function/logic-function.resolver';
+import { NavigationMenuItemResolver } from 'src/engine/metadata-modules/navigation-menu-item/navigation-menu-item.resolver';
+import { ObjectMetadataResolver } from 'src/engine/metadata-modules/object-metadata/object-metadata.resolver';
+import { PageLayoutTabResolver } from 'src/engine/metadata-modules/page-layout-tab/resolvers/page-layout-tab.resolver';
+import { PageLayoutWidgetResolver } from 'src/engine/metadata-modules/page-layout-widget/resolvers/page-layout-widget.resolver';
+import { PageLayoutResolver } from 'src/engine/metadata-modules/page-layout/resolvers/page-layout.resolver';
+import { RoleResolver } from 'src/engine/metadata-modules/role/role.resolver';
+import { SkillResolver } from 'src/engine/metadata-modules/skill/skill.resolver';
+import { ViewFieldResolver } from 'src/engine/metadata-modules/view-field/resolvers/view-field.resolver';
+import { ViewFilterGroupResolver } from 'src/engine/metadata-modules/view-filter-group/resolvers/view-filter-group.resolver';
+import { ViewFilterResolver } from 'src/engine/metadata-modules/view-filter/resolvers/view-filter.resolver';
+import { ViewGroupResolver } from 'src/engine/metadata-modules/view-group/resolvers/view-group.resolver';
+import { ViewSortResolver } from 'src/engine/metadata-modules/view-sort/resolvers/view-sort.resolver';
+import { ViewResolver } from 'src/engine/metadata-modules/view/resolvers/view.resolver';
+import { WebhookResolver } from 'src/engine/metadata-modules/webhook/webhook.resolver';
+
+// Centralized list of all metadata resolvers.
+// When adding a new metadata resolver, add it to this list to ensure
+// it is included in the /metadata GraphQL schema.
+export const metadataResolvers = [
+  AgentTurnResolver,
+  AgentResolver,
+  AgentChatResolver,
+  CommandMenuItemResolver,
+  FieldMetadataResolver,
+  FrontComponentResolver,
+  IndexMetadataResolver,
+  LogicFunctionLayerResolver,
+  LogicFunctionResolver,
+  NavigationMenuItemResolver,
+  ObjectMetadataResolver,
+  PageLayoutTabResolver,
+  PageLayoutWidgetResolver,
+  PageLayoutResolver,
+  RoleResolver,
+  SkillResolver,
+  ViewFieldResolver,
+  ViewFilterGroupResolver,
+  ViewFilterResolver,
+  ViewGroupResolver,
+  ViewSortResolver,
+  ViewResolver,
+  WebhookResolver,
+] as const;

--- a/packages/twenty-server/src/engine/api/graphql/metadata.module-factory.ts
+++ b/packages/twenty-server/src/engine/api/graphql/metadata.module-factory.ts
@@ -1,10 +1,12 @@
+import { type GraphQLSchemaFactory } from '@nestjs/graphql';
+
 import { type YogaDriverConfig } from '@graphql-yoga/nestjs';
 import GraphQLJSON from 'graphql-type-json';
 
 import { NodeEnvironment } from 'src/engine/core-modules/twenty-config/interfaces/node-environment.interface';
 
 import { useCachedMetadata } from 'src/engine/api/graphql/graphql-config/hooks/use-cached-metadata';
-import { MetadataGraphQLApiModule } from 'src/engine/api/graphql/metadata-graphql-api.module';
+import { metadataResolvers } from 'src/engine/api/graphql/metadata-resolvers';
 import { type CacheStorageService } from 'src/engine/core-modules/cache-storage/services/cache-storage.service';
 import { type ExceptionHandlerService } from 'src/engine/core-modules/exception-handler/exception-handler.service';
 import { useDisableIntrospectionAndSuggestionsForUnauthenticatedUsers } from 'src/engine/core-modules/graphql/hooks/use-disable-introspection-and-suggestions-for-unauthenticated-users.hook';
@@ -23,13 +25,14 @@ export const metadataModuleFactory = async (
   cacheStorageService: CacheStorageService,
   metricsService: MetricsService,
   i18nService: I18nService,
+  graphQLSchemaFactory: GraphQLSchemaFactory,
 ): Promise<YogaDriverConfig> => {
+  const schema = await graphQLSchemaFactory.create([...metadataResolvers], {
+    numberScalarMode: 'integer',
+  });
+
   const config: YogaDriverConfig = {
-    autoSchemaFile: true,
-    include: [MetadataGraphQLApiModule],
-    renderGraphiQL() {
-      return renderApolloPlayground({ path: 'metadata' });
-    },
+    schema,
     resolvers: { JSON: GraphQLJSON },
     plugins: [
       useGraphQLErrorHandlerHook({

--- a/packages/twenty-server/test/integration/metadata/suites/schema-isolation.integration-spec.ts
+++ b/packages/twenty-server/test/integration/metadata/suites/schema-isolation.integration-spec.ts
@@ -1,0 +1,163 @@
+import request from 'supertest';
+
+const client = request(`http://localhost:${APP_PORT}`);
+
+// GraphQL introspection query to get all type names
+const INTROSPECTION_QUERY = `
+  query IntrospectionQuery {
+    __schema {
+      types {
+        name
+        kind
+      }
+      queryType {
+        fields {
+          name
+        }
+      }
+      mutationType {
+        fields {
+          name
+        }
+      }
+    }
+  }
+`;
+
+// Metadata types that should ONLY appear on /metadata, not on /graphql
+const METADATA_ONLY_TYPE_NAMES = [
+  'ObjectMetadataDTO',
+  'FieldMetadataDTO',
+  'IndexMetadataDTO',
+  'CreateOneObjectInput',
+  'UpdateOneObjectInput',
+  'DeleteOneObjectInput',
+  'CreateOneFieldMetadataInput',
+  'UpdateOneFieldMetadataInput',
+  'ViewDTO',
+  'ViewFieldDTO',
+  'ViewFilterDTO',
+  'ViewSortDTO',
+  'ViewGroupDTO',
+  'ViewFilterGroupDTO',
+  'RoleDTO',
+  'WebhookDTO',
+  'PageLayoutDTO',
+  'PageLayoutTabDTO',
+  'PageLayoutWidgetDTO',
+  'SkillDTO',
+  'LogicFunctionDTO',
+  'AgentDTO',
+  'AgentChatDTO',
+  'FrontComponentDTO',
+  'CommandMenuItemDTO',
+  'NavigationMenuItemDTO',
+];
+
+// Metadata mutation/query names that should NOT appear on /graphql
+const METADATA_ONLY_OPERATIONS = [
+  'createOneObject',
+  'updateOneObject',
+  'deleteOneObject',
+  'createOneField',
+  'updateOneField',
+  'deleteOneField',
+  'createOneView',
+  'deleteOneView',
+  'createOneRole',
+  'deleteOneRole',
+  'createOneWebhook',
+  'deleteOneWebhook',
+];
+
+describe('Schema Isolation (integration)', () => {
+  describe('/metadata endpoint', () => {
+    it('should expose metadata types via introspection', () => {
+      return client
+        .post('/metadata')
+        .set('Authorization', `Bearer ${APPLE_JANE_ADMIN_ACCESS_TOKEN}`)
+        .send({ query: INTROSPECTION_QUERY })
+        .expect(200)
+        .expect((res) => {
+          expect(res.body.data).toBeDefined();
+          expect(res.body.data.__schema).toBeDefined();
+
+          const typeNames = res.body.data.__schema.types.map(
+            (t: { name: string }) => t.name,
+          );
+
+          // Metadata types should be present
+          for (const metadataType of [
+            'ObjectMetadataDTO',
+            'FieldMetadataDTO',
+          ]) {
+            expect(typeNames).toContain(metadataType);
+          }
+        });
+    });
+
+    it('should have query and mutation types defined', () => {
+      return client
+        .post('/metadata')
+        .set('Authorization', `Bearer ${APPLE_JANE_ADMIN_ACCESS_TOKEN}`)
+        .send({ query: INTROSPECTION_QUERY })
+        .expect(200)
+        .expect((res) => {
+          expect(res.body.data).toBeDefined();
+
+          const { queryType, mutationType } = res.body.data.__schema;
+
+          expect(queryType).toBeDefined();
+          expect(queryType.fields.length).toBeGreaterThan(0);
+          expect(mutationType).toBeDefined();
+          expect(mutationType.fields.length).toBeGreaterThan(0);
+        });
+    });
+  });
+
+  describe('/graphql endpoint', () => {
+    it('should not expose metadata-specific types via introspection', () => {
+      return client
+        .post('/graphql')
+        .set('Authorization', `Bearer ${APPLE_JANE_ADMIN_ACCESS_TOKEN}`)
+        .send({ query: INTROSPECTION_QUERY })
+        .expect(200)
+        .expect((res) => {
+          expect(res.body.data).toBeDefined();
+          expect(res.body.data.__schema).toBeDefined();
+
+          const typeNames = res.body.data.__schema.types.map(
+            (t: { name: string }) => t.name,
+          );
+
+          // No metadata types should appear
+          for (const metadataType of METADATA_ONLY_TYPE_NAMES) {
+            expect(typeNames).not.toContain(metadataType);
+          }
+        });
+    });
+
+    it('should not expose metadata-specific mutations via introspection', () => {
+      return client
+        .post('/graphql')
+        .set('Authorization', `Bearer ${APPLE_JANE_ADMIN_ACCESS_TOKEN}`)
+        .send({ query: INTROSPECTION_QUERY })
+        .expect(200)
+        .expect((res) => {
+          expect(res.body.data).toBeDefined();
+
+          const { mutationType } = res.body.data.__schema;
+
+          if (mutationType) {
+            const mutationNames = mutationType.fields.map(
+              (f: { name: string }) => f.name,
+            );
+
+            for (const metadataOp of METADATA_ONLY_OPERATIONS) {
+              expect(mutationNames).not.toContain(metadataOp);
+            }
+          }
+        });
+    });
+  });
+});


### PR DESCRIPTION
Closes #17638

## Summary
- Remove `autoSchemaFile` and `include` from core `/graphql` config so schema comes exclusively from `conditionalSchema` via `WorkspaceSchemaFactory`
- Create centralized metadata resolver list (`metadata-resolvers.ts`)
- Build metadata `/metadata` schema explicitly using `GraphQLSchemaFactory` instead of auto-discovery scanning
- Add unit tests for config isolation and resolver list completeness
- Add integration test verifying `/graphql` does not expose metadata types

Generated with [Claude Code](https://claude.ai/code)