### PR TITLE
fix: use red3 for dark mode danger background color

### DIFF
--- a/packages/twenty-ui/src/theme/constants/BackgroundDark.ts
+++ b/packages/twenty-ui/src/theme/constants/BackgroundDark.ts
@@ -13,7 +13,7 @@ export const BACKGROUND_DARK = {
   quaternary: GRAY_SCALE_DARK.gray5,
   invertedPrimary: GRAY_SCALE_DARK.gray12,
   invertedSecondary: GRAY_SCALE_DARK.gray11,
-  danger: COLOR_DARK.red12,
+  danger: COLOR_DARK.red3,
   transparent: {
     primary: RadixColors.blackP3A.blackA7,
     secondary: RadixColors.blackP3A.blackA6,


### PR DESCRIPTION
## Summary

Fixes the dark mode error chip background color issue by changing `background.danger` from `red12` to `red3` in the dark theme constants.

Fixes #17657

Generated with [Claude Code](https://claude.ai/code)