### PR TITLE
Allow twenty standard app to access messaging items

### DIFF
--- a/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/calendar-event-find-many.post-query.hook.ts
+++ b/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/calendar-event-find-many.post-query.hook.ts
@@ -6,6 +6,7 @@ import { WorkspaceQueryHook } from 'src/engine/api/graphql/workspace-query-runne
 import { WorkspaceQueryHookType } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/types/workspace-query-hook.type';
 import { type AuthContext } from 'src/engine/core-modules/auth/types/auth-context.type';
 import { ForbiddenError } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
+import { TWENTY_STANDARD_APPLICATION } from 'src/engine/workspace-manager/twenty-standard-application/constants/twenty-standard-applications';
 import { ApplyCalendarEventsVisibilityRestrictionsService } from 'src/modules/calendar/common/query-hooks/calendar-event/services/apply-calendar-events-visibility-restrictions.service';
 import { type CalendarEventWorkspaceEntity } from 'src/modules/calendar/common/standard-objects/calendar-event.workspace-entity';
 
@@ -25,10 +26,19 @@ export class CalendarEventFindManyPostQueryHook
     _objectName: string,
     payload: CalendarEventWorkspaceEntity[],
   ): Promise<void> {
-    const { user, apiKey } = authContext;
+    const { user, apiKey, application } = authContext;
 
-    if (!isDefined(user) && !isDefined(apiKey)) {
-      throw new ForbiddenError('User is required');
+    const isTwentyStandardApplication =
+      isDefined(application) &&
+      application.universalIdentifier ===
+        TWENTY_STANDARD_APPLICATION.universalIdentifier;
+
+    if (
+      !isDefined(user) &&
+      !isDefined(apiKey) &&
+      !isTwentyStandardApplication
+    ) {
+      throw new ForbiddenError('Authentication is required');
     }
 
     const workspace = authContext.workspace;

--- a/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/calendar-event-find-one.post-query.hook.ts
+++ b/packages/twenty-server/src/modules/calendar/common/query-hooks/calendar-event/calendar-event-find-one.post-query.hook.ts
@@ -6,6 +6,7 @@ import { WorkspaceQueryHook } from 'src/engine/api/graphql/workspace-query-runne
 import { WorkspaceQueryHookType } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/types/workspace-query-hook.type';
 import { type AuthContext } from 'src/engine/core-modules/auth/types/auth-context.type';
 import { ForbiddenError } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
+import { TWENTY_STANDARD_APPLICATION } from 'src/engine/workspace-manager/twenty-standard-application/constants/twenty-standard-applications';
 import { ApplyCalendarEventsVisibilityRestrictionsService } from 'src/modules/calendar/common/query-hooks/calendar-event/services/apply-calendar-events-visibility-restrictions.service';
 import { type CalendarEventWorkspaceEntity } from 'src/modules/calendar/common/standard-objects/calendar-event.workspace-entity';
 
@@ -25,10 +26,19 @@ export class CalendarEventFindOnePostQueryHook
     _objectName: string,
     payload: CalendarEventWorkspaceEntity[],
   ): Promise<void> {
-    const { user, apiKey } = authContext;
+    const { user, apiKey, application } = authContext;
 
-    if (!isDefined(user) && !isDefined(apiKey)) {
-      throw new ForbiddenError('User is required');
+    const isTwentyStandardApplication =
+      isDefined(application) &&
+      application.universalIdentifier ===
+        TWENTY_STANDARD_APPLICATION.universalIdentifier;
+
+    if (
+      !isDefined(user) &&
+      !isDefined(apiKey) &&
+      !isTwentyStandardApplication
+    ) {
+      throw new ForbiddenError('Authentication is required');
     }
 
     const workspace = authContext.workspace;

--- a/packages/twenty-server/src/modules/messaging/common/query-hooks/message/message-find-many.post-query.hook.ts
+++ b/packages/twenty-server/src/modules/messaging/common/query-hooks/message/message-find-many.post-query.hook.ts
@@ -6,6 +6,7 @@ import { WorkspaceQueryHook } from 'src/engine/api/graphql/workspace-query-runne
 import { WorkspaceQueryHookType } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/types/workspace-query-hook.type';
 import { type AuthContext } from 'src/engine/core-modules/auth/types/auth-context.type';
 import { ForbiddenError } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
+import { TWENTY_STANDARD_APPLICATION } from 'src/engine/workspace-manager/twenty-standard-application/constants/twenty-standard-applications';
 import { ApplyMessagesVisibilityRestrictionsService } from 'src/modules/messaging/common/query-hooks/message/apply-messages-visibility-restrictions.service';
 import { type MessageWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message.workspace-entity';
 
@@ -25,10 +26,19 @@ export class MessageFindManyPostQueryHook
     _objectName: string,
     payload: MessageWorkspaceEntity[],
   ): Promise<void> {
-    const { user, apiKey } = authContext;
+    const { user, apiKey, application } = authContext;
 
-    if (!isDefined(user) && !isDefined(apiKey)) {
-      throw new ForbiddenError('User is required');
+    const isTwentyStandardApplication =
+      isDefined(application) &&
+      application.universalIdentifier ===
+        TWENTY_STANDARD_APPLICATION.universalIdentifier;
+
+    if (
+      !isDefined(user) &&
+      !isDefined(apiKey) &&
+      !isTwentyStandardApplication
+    ) {
+      throw new ForbiddenError('Authentication is required');
     }
 
     const workspace = authContext.workspace;

--- a/packages/twenty-server/src/modules/messaging/common/query-hooks/message/message-find-one.post-query.hook.ts
+++ b/packages/twenty-server/src/modules/messaging/common/query-hooks/message/message-find-one.post-query.hook.ts
@@ -6,6 +6,7 @@ import { WorkspaceQueryHook } from 'src/engine/api/graphql/workspace-query-runne
 import { WorkspaceQueryHookType } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/types/workspace-query-hook.type';
 import { type AuthContext } from 'src/engine/core-modules/auth/types/auth-context.type';
 import { ForbiddenError } from 'src/engine/core-modules/graphql/utils/graphql-errors.util';
+import { TWENTY_STANDARD_APPLICATION } from 'src/engine/workspace-manager/twenty-standard-application/constants/twenty-standard-applications';
 import { ApplyMessagesVisibilityRestrictionsService } from 'src/modules/messaging/common/query-hooks/message/apply-messages-visibility-restrictions.service';
 import { type MessageWorkspaceEntity } from 'src/modules/messaging/common/standard-objects/message.workspace-entity';
 
@@ -25,10 +26,19 @@ export class MessageFindOnePostQueryHook
     _objectName: string,
     payload: MessageWorkspaceEntity[],
   ): Promise<void> {
-    const { user, apiKey } = authContext;
+    const { user, apiKey, application } = authContext;
 
-    if (!isDefined(user) && !isDefined(apiKey)) {
-      throw new ForbiddenError('User is required');
+    const isTwentyStandardApplication =
+      isDefined(application) &&
+      application.universalIdentifier ===
+        TWENTY_STANDARD_APPLICATION.universalIdentifier;
+
+    if (
+      !isDefined(user) &&
+      !isDefined(apiKey) &&
+      !isTwentyStandardApplication
+    ) {
+      throw new ForbiddenError('Authentication is required');
     }
 
     const workspace = authContext.workspace;


### PR DESCRIPTION
This is a quick fix to unblock a user who wants to create workflows around messaging. 

We do need to think of what should be the usage for other applications - I suppose other applications will want to access messaging. Maybe we should add an **Access to messages and calendar events** setting permission key that could be granted (or not) to applications? 