### PR TITLE
Fix message/calendar channels stuck with null syncStageStartedAt

### DIFF
--- a/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/utils/is-sync-stale.util.ts
+++ b/packages/twenty-server/src/modules/calendar/calendar-event-import-manager/utils/is-sync-stale.util.ts
@@ -4,7 +4,7 @@ import { CALENDAR_IMPORT_ONGOING_SYNC_TIMEOUT } from 'src/modules/calendar/calen
 
 export const isSyncStale = (syncStageStartedAt?: string | null): boolean => {
   if (!isDefined(syncStageStartedAt)) {
-    return false;
+    return true;
   }
 
   const syncStageStartedTime = new Date(syncStageStartedAt).getTime();

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/utils/__tests__/is-sync-stale.util.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/utils/__tests__/is-sync-stale.util.spec.ts
@@ -24,16 +24,16 @@ describe('isSyncStale', () => {
     expect(result).toBe(false);
   });
 
-  it('should return false if syncStageStartedAt is undefined', () => {
+  it('should return true if syncStageStartedAt is undefined', () => {
     const result = isSyncStale(undefined);
 
-    expect(result).toBe(false);
+    expect(result).toBe(true);
   });
 
-  it('should return false if syncStageStartedAt is null', () => {
+  it('should return true if syncStageStartedAt is null', () => {
     const result = isSyncStale(null);
 
-    expect(result).toBe(false);
+    expect(result).toBe(true);
   });
 
   it('should throw an error if syncStageStartedAt is invalid', () => {

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/utils/is-sync-stale.util.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/utils/is-sync-stale.util.ts
@@ -4,7 +4,7 @@ import { MESSAGING_IMPORT_ONGOING_SYNC_TIMEOUT } from 'src/modules/messaging/mes
 
 export const isSyncStale = (syncStageStartedAt?: string | null): boolean => {
   if (!isDefined(syncStageStartedAt)) {
-    return false;
+    return true;
   }
 
   const syncStageStartedTime = new Date(syncStageStartedAt).getTime();


### PR DESCRIPTION
PR #17492 fixed `markAsMessagesListFetchOngoing` to set `syncStageStartedAt`, but also changed `isSyncStale` to return `false` for null values. This prevented the stale recovery job from recovering channels that were already stuck before the fix was deployed.

Changing `isSyncStale` to return `true` for null/undefined allows the stale job to properly reset stuck channels back to PENDING state.