### PR TITLE
Display "Not shared" indicator for RLS-restricted relation fields

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/display/components/RelationToOneFieldDisplay.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/display/components/RelationToOneFieldDisplay.tsx
@@ -1,15 +1,24 @@
 import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
 import { RecordChip } from '@/object-record/components/RecordChip';
 import { FieldContext } from '@/object-record/record-field/ui/contexts/FieldContext';
+import { ForbiddenFieldDisplay } from '@/object-record/record-field/ui/meta-types/display/components/ForbiddenFieldDisplay';
 import { useRelationToOneFieldDisplay } from '@/object-record/record-field/ui/meta-types/hooks/useRelationToOneFieldDisplay';
 import { useContext } from 'react';
 import { isDefined } from 'twenty-shared/utils';
 
 export const RelationToOneFieldDisplay = () => {
-  const { fieldValue, fieldDefinition, generateRecordChipData } =
-    useRelationToOneFieldDisplay();
+  const {
+    fieldValue,
+    fieldDefinition,
+    generateRecordChipData,
+    foreignKeyFieldValue,
+  } = useRelationToOneFieldDisplay();
 
   const { disableChipClick, triggerEvent } = useContext(FieldContext);
+
+  if (!isDefined(fieldValue) && isDefined(foreignKeyFieldValue)) {
+    return <ForbiddenFieldDisplay />;
+  }
 
   if (
     !isDefined(fieldValue) ||

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/hooks/useRelationToOneFieldDisplay.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/hooks/useRelationToOneFieldDisplay.ts
@@ -11,6 +11,7 @@ import { generateDefaultRecordChipData } from '@/object-metadata/utils/generateD
 import { FieldContext } from '@/object-record/record-field/ui/contexts/FieldContext';
 import { assertFieldMetadata } from '@/object-record/record-field/ui/types/guards/assertFieldMetadata';
 import { isFieldRelation } from '@/object-record/record-field/ui/types/guards/isFieldRelation';
+import { getJoinColumnName } from '@/object-record/record-field/ui/utils/junction/getJoinColumnName';
 import { useRecordFieldValue } from '@/object-record/record-store/hooks/useRecordFieldValue';
 import { isDefined } from 'twenty-shared/utils';
 
@@ -41,6 +42,15 @@ export const useRelationToOneFieldDisplay = () => {
     fieldDefinition,
   );
 
+  const joinColumnName =
+    getJoinColumnName(fieldDefinition.metadata.settings) ?? `${fieldName}Id`;
+
+  const foreignKeyFieldValue = useRecordFieldValue<string | null | undefined>(
+    recordId,
+    joinColumnName,
+    { type: FieldMetadataType.UUID, metadata: { fieldName: joinColumnName } },
+  );
+
   const maxWidthForField =
     isDefined(button) && isDefined(maxWidth)
       ? maxWidth - FIELD_EDIT_BUTTON_WIDTH
@@ -69,6 +79,7 @@ export const useRelationToOneFieldDisplay = () => {
   return {
     fieldDefinition,
     fieldValue,
+    foreignKeyFieldValue,
     maxWidth: maxWidthForField,
     recordId,
     generateRecordChipData,

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/hooks/useRelationToOneFieldDisplay.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/hooks/useRelationToOneFieldDisplay.ts
@@ -11,7 +11,7 @@ import { generateDefaultRecordChipData } from '@/object-metadata/utils/generateD
 import { FieldContext } from '@/object-record/record-field/ui/contexts/FieldContext';
 import { assertFieldMetadata } from '@/object-record/record-field/ui/types/guards/assertFieldMetadata';
 import { isFieldRelation } from '@/object-record/record-field/ui/types/guards/isFieldRelation';
-import { getJoinColumnName } from '@/object-record/record-field/ui/utils/junction/getJoinColumnName';
+import { getJoinColumnNameOrThrow } from '@/object-record/record-field/ui/utils/junction/getJoinColumnNameOrThrow';
 import { useRecordFieldValue } from '@/object-record/record-store/hooks/useRecordFieldValue';
 import { isDefined } from 'twenty-shared/utils';
 
@@ -42,8 +42,9 @@ export const useRelationToOneFieldDisplay = () => {
     fieldDefinition,
   );
 
-  const joinColumnName =
-    getJoinColumnName(fieldDefinition.metadata.settings) ?? `${fieldName}Id`;
+  const joinColumnName = getJoinColumnNameOrThrow(
+    fieldDefinition.metadata.settings,
+  );
 
   const foreignKeyFieldValue = useRecordFieldValue<string | null | undefined>(
     recordId,

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/getJoinColumnNameOrThrow.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/utils/junction/getJoinColumnNameOrThrow.ts
@@ -1,0 +1,13 @@
+import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
+import { getJoinColumnName } from '@/object-record/record-field/ui/utils/junction/getJoinColumnName';
+import { isDefined } from 'twenty-shared/utils';
+
+export const getJoinColumnNameOrThrow = (
+  settings: FieldMetadataItem['settings'],
+): string => {
+  const joinColumnName = getJoinColumnName(settings);
+  if (!isDefined(joinColumnName)) {
+    throw new Error('Join column name is not defined');
+  }
+  return joinColumnName;
+};

--- a/packages/twenty-front/src/modules/settings/data-model/fields/forms/morph-relation/components/SettingsDataModelFieldRelationFormCard.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/forms/morph-relation/components/SettingsDataModelFieldRelationFormCard.tsx
@@ -84,6 +84,7 @@ export const SettingsDataModelFieldRelationFormCard = ({
               type: FieldMetadataType.RELATION,
               settings: {
                 relationType,
+                joinColumnName: 'previewJoinColumnId',
               },
             }}
             shrink
@@ -107,6 +108,7 @@ export const SettingsDataModelFieldRelationFormCard = ({
               type: FieldMetadataType.RELATION,
               settings: {
                 relationType: oppositeRelationType,
+                joinColumnName: 'previewJoinColumnId',
               },
             }}
             shrink

--- a/packages/twenty-sdk/project.json
+++ b/packages/twenty-sdk/project.json
@@ -3,10 +3,16 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "packages/twenty-sdk/src",
   "projectType": "library",
-  "tags": ["scope:sdk", "scope:shared"],
+  "tags": [
+    "scope:sdk",
+    "scope:shared"
+  ],
   "targets": {
     "build": {
-      "dependsOn": ["generateBarrels", "^build"],
+      "dependsOn": [
+        "generateBarrels",
+        "^build"
+      ],
       "outputs": [
         "{projectRoot}/dist",
         "{projectRoot}/front-component/package.json",
@@ -19,7 +25,10 @@
     },
     "dev": {
       "executor": "nx:run-commands",
-      "dependsOn": ["generateBarrels", "^build"],
+      "dependsOn": [
+        "generateBarrels",
+        "^build"
+      ],
       "options": {
         "cwd": "packages/twenty-sdk",
         "command": "npx rimraf dist && npx vite build --watch"
@@ -27,7 +36,9 @@
     },
     "start": {
       "executor": "nx:run-commands",
-      "dependsOn": ["build"],
+      "dependsOn": [
+        "build"
+      ],
       "options": {
         "cwd": "packages/twenty-sdk",
         "command": "node dist/cli.cjs"
@@ -36,7 +47,10 @@
     "generateBarrels": {
       "executor": "nx:run-commands",
       "cache": true,
-      "inputs": ["production", "{projectRoot}/scripts/generateBarrels.ts"],
+      "inputs": [
+        "production",
+        "{projectRoot}/scripts/generateBarrels.ts"
+      ],
       "outputs": [
         "{projectRoot}/src/index.ts",
         "{projectRoot}/src/*/index.ts",
@@ -49,12 +63,16 @@
     "typecheck": {},
     "lint": {
       "options": {
-        "lintFilePatterns": ["{projectRoot}/src/**/*.{ts,json}"],
+        "lintFilePatterns": [
+          "{projectRoot}/src/**/*.{ts,json}"
+        ],
         "maxWarnings": 0
       },
       "configurations": {
         "ci": {
-          "lintFilePatterns": ["{projectRoot}/src/**/*.{ts,json}"],
+          "lintFilePatterns": [
+            "{projectRoot}/src/**/*.{ts,json}"
+          ],
           "maxWarnings": 0
         },
         "fix": {}
@@ -62,7 +80,9 @@
     },
     "test": {
       "executor": "@nx/vitest:test",
-      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "outputs": [
+        "{workspaceRoot}/coverage/{projectRoot}"
+      ],
       "options": {
         "config": "{projectRoot}/vitest.config.ts"
       },
@@ -126,7 +146,9 @@
     "storybook:prebuild": {
       "executor": "nx:run-commands",
       "cache": true,
-      "dependsOn": ["generateRemoteDomElements"],
+      "dependsOn": [
+        "generateRemoteDomElements"
+      ],
       "inputs": [
         "{projectRoot}/src/front-component/__stories__/mocks/**/*",
         "{projectRoot}/src/front-component/__stories__/utils/**/*",
@@ -134,19 +156,25 @@
         "{projectRoot}/src/front-component-constants/**/*",
         "{projectRoot}/src/sdk/**/*"
       ],
-      "outputs": ["{projectRoot}/src/front-component/__stories__/built/*"],
+      "outputs": [
+        "{projectRoot}/src/front-component/__stories__/built/*"
+      ],
       "options": {
         "command": "tsx {projectRoot}/src/front-component/__stories__/utils/buildMockComponents.ts"
       }
     },
     "storybook:build": {
-      "dependsOn": ["storybook:prebuild"],
+      "dependsOn": [
+        "storybook:prebuild"
+      ],
       "configurations": {
         "test": {}
       }
     },
     "storybook:serve:dev": {
-      "dependsOn": ["storybook:prebuild"],
+      "dependsOn": [
+        "storybook:prebuild"
+      ],
       "options": {
         "port": 6008
       }
@@ -161,13 +189,17 @@
       }
     },
     "storybook:test": {
-      "dependsOn": ["storybook:prebuild"],
+      "dependsOn": [
+        "storybook:prebuild"
+      ],
       "options": {
         "command": "vitest run --coverage --config vitest.storybook.config.ts --shard={args.shard}"
       }
     },
     "storybook:test:no-coverage": {
-      "dependsOn": ["storybook:prebuild"],
+      "dependsOn": [
+        "storybook:prebuild"
+      ],
       "options": {
         "command": "vitest run --config vitest.storybook.config.ts --shard={args.shard}"
       }

--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/helpers/process-nested-relations-v2.helper.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/helpers/process-nested-relations-v2.helper.ts
@@ -417,9 +417,6 @@ export class ProcessNestedRelationsV2Helper {
           (rel) => rel[joinField] === item.id,
         );
       } else {
-        if (relationResults.length === 0) {
-          item[`${sourceFieldName}Id`] = null;
-        }
         item[sourceFieldName] =
           relationResults.find(
             (rel) => rel.id === item[`${sourceFieldName}Id`],


### PR DESCRIPTION
## Context
Previously, if for example a Person had a companyId but the company relation was null due to RLS, the company column appeared empty. Now it displays ForbiddenFieldDisplay to indicate the relation exists but is inaccessible.

When RLS restricts access to a related record, the frontend now shows a "Not shared" indicator (with lock icon) instead of an empty field.

<img width="1275" height="399" alt="Screenshot 2026-02-04 at 15 37 53" src="https://github.com/user-attachments/assets/870306f8-f811-4dc0-b23b-a33e89043a37" />
