### PR TITLE
add fallback for gmail http range 500 instead of propagating to sentry

### DIFF
--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/utils/parse-gmail-api-error.util.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/utils/parse-gmail-api-error.util.ts
@@ -116,7 +116,11 @@ export const parseGmailApiError = (
           MessageImportDriverExceptionCode.TEMPORARY_ERROR,
         );
       }
-      break;
+
+      return new MessageImportDriverException(
+        `${gmailApiError.code} - ${gmailApiError.message}`,
+        MessageImportDriverExceptionCode.TEMPORARY_ERROR,
+      );
 
     default:
       break;


### PR DESCRIPTION
fixes TWENTY-SERVER-D3X