### PR TITLE
Improve workflow crons

### DIFF
--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/command/workflow-handle-staled-runs.command.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/command/workflow-handle-staled-runs.command.ts
@@ -52,7 +52,7 @@ export class WorkflowHandleStaledRunsCommand extends CommandRunner {
       } catch (error) {
         this.logger.error(
           `Failed to handle staled runs for workspace ${workspaceId}`,
-          error,
+          error instanceof Error ? error.stack : String(error),
         );
       }
     }

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/command/workflow-handle-staled-runs.command.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/command/workflow-handle-staled-runs.command.ts
@@ -1,3 +1,5 @@
+import { Logger } from '@nestjs/common';
+
 import { Command, CommandRunner, Option } from 'nest-commander';
 
 import { WorkflowHandleStaledRunsWorkspaceService } from 'src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-handle-staled-runs.workspace-service';
@@ -11,6 +13,8 @@ type WorkflowHandleStaledRunsCommandOptions = {
   description: 'Handles staled workflow runs',
 })
 export class WorkflowHandleStaledRunsCommand extends CommandRunner {
+  private readonly logger = new Logger(WorkflowHandleStaledRunsCommand.name);
+
   constructor(
     private readonly workflowHandleStaledRunsWorkspaceService: WorkflowHandleStaledRunsWorkspaceService,
   ) {
@@ -32,8 +36,27 @@ export class WorkflowHandleStaledRunsCommand extends CommandRunner {
   ): Promise<void> {
     const { workspaceIds } = options;
 
-    await this.workflowHandleStaledRunsWorkspaceService.handleStaledRuns({
-      workspaceIds,
-    });
+    this.logger.log('Starting WorkflowHandleStaledRunsCommand command');
+
+    for (let i = 0; i < workspaceIds.length; i++) {
+      const workspaceId = workspaceIds[i];
+
+      this.logger.log(
+        `Processing workspace ${workspaceId} (${i + 1}/${workspaceIds.length})`,
+      );
+
+      try {
+        await this.workflowHandleStaledRunsWorkspaceService.handleStaledRunsForWorkspace(
+          workspaceId,
+        );
+      } catch (error) {
+        this.logger.error(
+          `Failed to handle staled runs for workspace ${workspaceId}`,
+          error,
+        );
+      }
+    }
+
+    this.logger.log('Completed WorkflowHandleStaledRunsCommand command');
   }
 }

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/constants/not-started-runs-find-options.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/constants/not-started-runs-find-options.ts
@@ -1,0 +1,11 @@
+import { type FindOptionsWhere } from 'typeorm';
+
+import {
+  WorkflowRunStatus,
+  type WorkflowRunWorkspaceEntity,
+} from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
+
+export const NOT_STARTED_RUNS_FIND_OPTIONS: FindOptionsWhere<WorkflowRunWorkspaceEntity> =
+  {
+    status: WorkflowRunStatus.NOT_STARTED,
+  };

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/constants/number-of-workflow-runs-to-keep.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/constants/number-of-workflow-runs-to-keep.ts
@@ -1,0 +1,1 @@
+export const NUMBER_OF_WORKFLOW_RUNS_TO_KEEP = 1000;

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/constants/runs-to-clean-threshold.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/constants/runs-to-clean-threshold.ts
@@ -1,0 +1,1 @@
+export const RUNS_TO_CLEAN_THRESHOLD_DAYS = 14;

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/constants/staled-runs-threshold.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/constants/staled-runs-threshold.ts
@@ -1,0 +1,1 @@
+export const STALED_RUNS_THRESHOLD_MS = 60 * 60 * 1000; // 1 hour

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/cron/command/workflow-clean-workflow-runs.cron.command.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/cron/command/workflow-clean-workflow-runs.cron.command.ts
@@ -5,7 +5,7 @@ import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queu
 import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
 import {
   CLEAN_WORKFLOW_RUN_CRON_PATTERN,
-  WorkflowCleanWorkflowRunsJob,
+  WorkflowCleanWorkflowRunsCronJob,
 } from 'src/modules/workflow/workflow-runner/workflow-run-queue/cron/jobs/workflow-clean-workflow-runs.cron.job';
 
 @Command({
@@ -22,7 +22,7 @@ export class WorkflowCleanWorkflowRunsCronCommand extends CommandRunner {
 
   async run(): Promise<void> {
     await this.messageQueueService.addCron({
-      jobName: WorkflowCleanWorkflowRunsJob.name,
+      jobName: WorkflowCleanWorkflowRunsCronJob.name,
       data: undefined,
       options: {
         repeat: {

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/cron/command/workflow-handle-staled-runs.cron.command.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/cron/command/workflow-handle-staled-runs.cron.command.ts
@@ -5,7 +5,7 @@ import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queu
 import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
 import {
   WORKFLOW_HANDLE_STALED_RUNS_CRON_PATTERN,
-  WorkflowHandleStaledRunsJob,
+  WorkflowHandleStaledRunsCronJob,
 } from 'src/modules/workflow/workflow-runner/workflow-run-queue/cron/jobs/workflow-handle-staled-runs.cron.job';
 
 @Command({
@@ -22,7 +22,7 @@ export class WorkflowHandleStaledRunsCronCommand extends CommandRunner {
 
   async run(): Promise<void> {
     await this.messageQueueService.addCron({
-      jobName: WorkflowHandleStaledRunsJob.name,
+      jobName: WorkflowHandleStaledRunsCronJob.name,
       data: undefined,
       options: {
         repeat: {

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/cron/jobs/workflow-clean-workflow-runs.cron.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/cron/jobs/workflow-clean-workflow-runs.cron.job.ts
@@ -2,7 +2,7 @@ import { Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { WorkspaceActivationStatus } from 'twenty-shared/workspace';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 
 import { SentryCronMonitor } from 'src/engine/core-modules/cron/sentry-cron-monitor.decorator';
 import { InjectMessageQueue } from 'src/engine/core-modules/message-queue/decorators/message-queue.decorator';
@@ -13,7 +13,11 @@ import { MessageQueueService } from 'src/engine/core-modules/message-queue/servi
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
-import { WorkflowRunWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
+import {
+  WorkflowRunStatus,
+  WorkflowRunWorkspaceEntity,
+} from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
+import { NUMBER_OF_WORKFLOW_RUNS_TO_KEEP } from 'src/modules/workflow/workflow-runner/workflow-run-queue/constants/number-of-workflow-runs-to-keep';
 import {
   WorkflowCleanWorkflowRunsJob,
   WorkflowCleanWorkflowRunsJobData,
@@ -82,12 +86,21 @@ export class WorkflowCleanWorkflowRunsCronJob {
             { shouldBypassPermissionChecks: true },
           );
 
-        const count = await workflowRunRepository.count({
+        const hasOldRuns = await workflowRunRepository.exists({
           where: getRunsToCleanFindOptions(),
-          take: 1,
         });
 
-        return count > 0;
+        if (hasOldRuns) {
+          return true;
+        }
+
+        const totalCompletedRunsCount = await workflowRunRepository.count({
+          where: {
+            status: In([WorkflowRunStatus.COMPLETED, WorkflowRunStatus.FAILED]),
+          },
+        });
+
+        return totalCompletedRunsCount > NUMBER_OF_WORKFLOW_RUNS_TO_KEEP;
       },
       authContext,
     );

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/cron/jobs/workflow-clean-workflow-runs.cron.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/cron/jobs/workflow-clean-workflow-runs.cron.job.ts
@@ -1,114 +1,95 @@
 import { Logger } from '@nestjs/common';
-import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
+import { InjectRepository } from '@nestjs/typeorm';
 
 import { WorkspaceActivationStatus } from 'twenty-shared/workspace';
-import { DataSource, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 
 import { SentryCronMonitor } from 'src/engine/core-modules/cron/sentry-cron-monitor.decorator';
+import { InjectMessageQueue } from 'src/engine/core-modules/message-queue/decorators/message-queue.decorator';
 import { Process } from 'src/engine/core-modules/message-queue/decorators/process.decorator';
 import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
+import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
-import { getWorkspaceSchemaName } from 'src/engine/workspace-datasource/utils/get-workspace-schema-name.util';
+import { WorkflowRunWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
 import {
-  WorkflowRunStatus,
-  WorkflowRunWorkspaceEntity,
-} from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
+  WorkflowCleanWorkflowRunsJob,
+  WorkflowCleanWorkflowRunsJobData,
+} from 'src/modules/workflow/workflow-runner/workflow-run-queue/jobs/workflow-clean-workflow-runs.job';
+import { getRunsToCleanFindOptions } from 'src/modules/workflow/workflow-runner/workflow-run-queue/utils/get-runs-to-clean-find-options.util';
 
 export const CLEAN_WORKFLOW_RUN_CRON_PATTERN = '0 0 * * *';
 
-const NUMBER_OF_WORKFLOW_RUNS_TO_KEEP = 1000;
-
 @Processor(MessageQueue.cronQueue)
-export class WorkflowCleanWorkflowRunsJob {
-  private readonly logger = new Logger(WorkflowCleanWorkflowRunsJob.name);
+export class WorkflowCleanWorkflowRunsCronJob {
+  private readonly logger = new Logger(WorkflowCleanWorkflowRunsCronJob.name);
 
   constructor(
     @InjectRepository(WorkspaceEntity)
     private readonly workspaceRepository: Repository<WorkspaceEntity>,
+    @InjectMessageQueue(MessageQueue.workflowQueue)
+    private readonly messageQueueService: MessageQueueService,
     private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
-    @InjectDataSource()
-    private readonly coreDataSource: DataSource,
   ) {}
 
-  @Process(WorkflowCleanWorkflowRunsJob.name)
+  @Process(WorkflowCleanWorkflowRunsCronJob.name)
   @SentryCronMonitor(
-    WorkflowCleanWorkflowRunsJob.name,
+    WorkflowCleanWorkflowRunsCronJob.name,
     CLEAN_WORKFLOW_RUN_CRON_PATTERN,
   )
   async handle() {
-    this.logger.log('Starting WorkflowCleanWorkflowRunsJob cron');
+    this.logger.log('Starting WorkflowCleanWorkflowRunsCronJob cron');
 
-    try {
-      const activeWorkspaces = await this.workspaceRepository.find({
-        where: {
-          activationStatus: WorkspaceActivationStatus.ACTIVE,
-        },
-      });
+    const activeWorkspaces = await this.workspaceRepository.find({
+      where: {
+        activationStatus: WorkspaceActivationStatus.ACTIVE,
+      },
+      select: ['id'],
+    });
 
-      for (let i = 0; i < activeWorkspaces.length; i++) {
-        const activeWorkspace = activeWorkspaces[i];
+    let enqueuedCount = 0;
 
-        this.logger.log(
-          `Processing workspace ${activeWorkspace.id} (${i + 1}/${activeWorkspaces.length})`,
+    for (const workspace of activeWorkspaces) {
+      const hasRunsToClean = await this.hasRunsToClean(workspace.id);
+
+      if (hasRunsToClean) {
+        await this.messageQueueService.add<WorkflowCleanWorkflowRunsJobData>(
+          WorkflowCleanWorkflowRunsJob.name,
+          {
+            workspaceId: workspace.id,
+          },
         );
-
-        try {
-          await this.cleanWorkflowRunsForWorkspace(activeWorkspace.id);
-        } catch (error) {
-          this.logger.error(
-            `Failed to clean workflow runs for workspace ${activeWorkspace.id}`,
-            error,
-          );
-        }
+        enqueuedCount++;
       }
-
-      this.logger.log('Completed WorkflowCleanWorkflowRunsJob cron');
-    } catch (error) {
-      this.logger.error('WorkflowCleanWorkflowRunsJob cron failed', error);
-      throw error;
     }
+
+    this.logger.log(
+      `Completed WorkflowCleanWorkflowRunsCronJob cron, enqueued ${enqueuedCount} jobs`,
+    );
   }
 
-  private async cleanWorkflowRunsForWorkspace(workspaceId: string) {
-    const schemaName = getWorkspaceSchemaName(workspaceId);
+  private async hasRunsToClean(workspaceId: string): Promise<boolean> {
     const authContext = buildSystemAuthContext(workspaceId);
 
-    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
-      const workflowRunsToDelete = await this.coreDataSource.query(
-        `
-          WITH ranked_runs AS (
-            SELECT id,
-                   ROW_NUMBER() OVER (
-                      PARTITION BY "workflowId"
-                      ORDER BY "createdAt" DESC
-                   ) AS rn,
-                   "createdAt"
-            FROM ${schemaName}."workflowRun"
-            WHERE status IN ('${WorkflowRunStatus.COMPLETED}', '${WorkflowRunStatus.FAILED}')
-          )
-          SELECT id, rn FROM ranked_runs
-          WHERE rn > ${NUMBER_OF_WORKFLOW_RUNS_TO_KEEP}
-             OR "createdAt" < NOW() - INTERVAL '14 days';
-        `,
-      );
+    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+      async () => {
+        const workflowRunRepository =
+          await this.globalWorkspaceOrmManager.getRepository(
+            workspaceId,
+            WorkflowRunWorkspaceEntity,
+            { shouldBypassPermissionChecks: true },
+          );
 
-      const workflowRunRepository =
-        await this.globalWorkspaceOrmManager.getRepository(
-          workspaceId,
-          WorkflowRunWorkspaceEntity,
-          { shouldBypassPermissionChecks: true },
-        );
+        const count = await workflowRunRepository.count({
+          where: getRunsToCleanFindOptions(),
+          take: 1,
+        });
 
-      for (const workflowRunToDelete of workflowRunsToDelete) {
-        await workflowRunRepository.delete(workflowRunToDelete.id);
-      }
-
-      this.logger.log(
-        `Deleted ${workflowRunsToDelete.length} workflow runs for workspace ${workspaceId}`,
-      );
-    }, authContext);
+        return count > 0;
+      },
+      authContext,
+    );
   }
 }

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/cron/jobs/workflow-handle-staled-runs.cron.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/cron/jobs/workflow-handle-staled-runs.cron.job.ts
@@ -1,39 +1,95 @@
+import { Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { WorkspaceActivationStatus } from 'twenty-shared/workspace';
 import { Repository } from 'typeorm';
 
 import { SentryCronMonitor } from 'src/engine/core-modules/cron/sentry-cron-monitor.decorator';
+import { InjectMessageQueue } from 'src/engine/core-modules/message-queue/decorators/message-queue.decorator';
 import { Process } from 'src/engine/core-modules/message-queue/decorators/process.decorator';
 import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
+import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
-import { WorkflowHandleStaledRunsWorkspaceService } from 'src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-handle-staled-runs.workspace-service';
+import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
+import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
+import { WorkflowRunWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
+import {
+  WorkflowHandleStaledRunsJob,
+  WorkflowHandleStaledRunsJobData,
+} from 'src/modules/workflow/workflow-runner/workflow-run-queue/jobs/workflow-handle-staled-runs.job';
+import { getStaledRunsFindOptions } from 'src/modules/workflow/workflow-runner/workflow-run-queue/utils/get-staled-runs-find-options.util';
 
 export const WORKFLOW_HANDLE_STALED_RUNS_CRON_PATTERN = '0 * * * *';
 
 @Processor(MessageQueue.cronQueue)
-export class WorkflowHandleStaledRunsJob {
+export class WorkflowHandleStaledRunsCronJob {
+  private readonly logger = new Logger(WorkflowHandleStaledRunsCronJob.name);
+
   constructor(
     @InjectRepository(WorkspaceEntity)
     private readonly workspaceRepository: Repository<WorkspaceEntity>,
-    private readonly workflowHandleStaledRunsWorkspaceService: WorkflowHandleStaledRunsWorkspaceService,
+    @InjectMessageQueue(MessageQueue.workflowQueue)
+    private readonly messageQueueService: MessageQueueService,
+    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
   ) {}
 
-  @Process(WorkflowHandleStaledRunsJob.name)
+  @Process(WorkflowHandleStaledRunsCronJob.name)
   @SentryCronMonitor(
-    WorkflowHandleStaledRunsJob.name,
+    WorkflowHandleStaledRunsCronJob.name,
     WORKFLOW_HANDLE_STALED_RUNS_CRON_PATTERN,
   )
   async handle() {
+    this.logger.log('Starting WorkflowHandleStaledRunsCronJob cron');
+
     const activeWorkspaces = await this.workspaceRepository.find({
       where: {
         activationStatus: WorkspaceActivationStatus.ACTIVE,
       },
+      select: ['id'],
     });
 
-    await this.workflowHandleStaledRunsWorkspaceService.handleStaledRuns({
-      workspaceIds: activeWorkspaces.map((workspace) => workspace.id),
-    });
+    let enqueuedCount = 0;
+
+    for (const workspace of activeWorkspaces) {
+      const hasStaledRuns = await this.hasStaledRuns(workspace.id);
+
+      if (hasStaledRuns) {
+        await this.messageQueueService.add<WorkflowHandleStaledRunsJobData>(
+          WorkflowHandleStaledRunsJob.name,
+          {
+            workspaceId: workspace.id,
+          },
+        );
+        enqueuedCount++;
+      }
+    }
+
+    this.logger.log(
+      `Completed WorkflowHandleStaledRunsCronJob cron, enqueued ${enqueuedCount} jobs`,
+    );
+  }
+
+  private async hasStaledRuns(workspaceId: string): Promise<boolean> {
+    const authContext = buildSystemAuthContext(workspaceId);
+
+    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+      async () => {
+        const workflowRunRepository =
+          await this.globalWorkspaceOrmManager.getRepository(
+            workspaceId,
+            WorkflowRunWorkspaceEntity,
+            { shouldBypassPermissionChecks: true },
+          );
+
+        const count = await workflowRunRepository.count({
+          where: getStaledRunsFindOptions(),
+          take: 1,
+        });
+
+        return count > 0;
+      },
+      authContext,
+    );
   }
 }

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/cron/jobs/workflow-handle-staled-runs.cron.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/cron/jobs/workflow-handle-staled-runs.cron.job.ts
@@ -82,12 +82,9 @@ export class WorkflowHandleStaledRunsCronJob {
             { shouldBypassPermissionChecks: true },
           );
 
-        const count = await workflowRunRepository.count({
+        return workflowRunRepository.exists({
           where: getStaledRunsFindOptions(),
-          take: 1,
         });
-
-        return count > 0;
       },
       authContext,
     );

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/cron/jobs/workflow-run-enqueue.cron.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/cron/jobs/workflow-run-enqueue.cron.job.ts
@@ -83,12 +83,9 @@ export class WorkflowRunEnqueueCronJob {
             { shouldBypassPermissionChecks: true },
           );
 
-        const count = await workflowRunRepository.count({
+        return workflowRunRepository.exists({
           where: NOT_STARTED_RUNS_FIND_OPTIONS,
-          take: 1,
         });
-
-        return count > 0;
       },
       authContext,
     );

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/cron/jobs/workflow-run-enqueue.cron.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/cron/jobs/workflow-run-enqueue.cron.job.ts
@@ -5,11 +5,20 @@ import { WorkspaceActivationStatus } from 'twenty-shared/workspace';
 import { Repository } from 'typeorm';
 
 import { SentryCronMonitor } from 'src/engine/core-modules/cron/sentry-cron-monitor.decorator';
+import { InjectMessageQueue } from 'src/engine/core-modules/message-queue/decorators/message-queue.decorator';
 import { Process } from 'src/engine/core-modules/message-queue/decorators/process.decorator';
 import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
+import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
-import { WorkflowRunEnqueueWorkspaceService } from 'src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-run-enqueue.workspace-service';
+import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
+import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
+import { WorkflowRunWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
+import { NOT_STARTED_RUNS_FIND_OPTIONS } from 'src/modules/workflow/workflow-runner/workflow-run-queue/constants/not-started-runs-find-options';
+import {
+  WorkflowRunEnqueueJob,
+  WorkflowRunEnqueueJobData,
+} from 'src/modules/workflow/workflow-runner/workflow-run-queue/jobs/workflow-run-enqueue.job';
 
 export const WORKFLOW_RUN_ENQUEUE_CRON_PATTERN = '*/5 * * * *';
 
@@ -20,7 +29,9 @@ export class WorkflowRunEnqueueCronJob {
   constructor(
     @InjectRepository(WorkspaceEntity)
     private readonly workspaceRepository: Repository<WorkspaceEntity>,
-    private readonly workflowRunEnqueueWorkspaceService: WorkflowRunEnqueueWorkspaceService,
+    @InjectMessageQueue(MessageQueue.workflowQueue)
+    private readonly messageQueueService: MessageQueueService,
+    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
   ) {}
 
   @Process(WorkflowRunEnqueueCronJob.name)
@@ -31,39 +42,55 @@ export class WorkflowRunEnqueueCronJob {
   async handle() {
     this.logger.log('Starting WorkflowRunEnqueueCronJob cron');
 
-    try {
-      const activeWorkspaces = await this.workspaceRepository.find({
-        where: {
-          activationStatus: WorkspaceActivationStatus.ACTIVE,
-        },
-      });
+    const activeWorkspaces = await this.workspaceRepository.find({
+      where: {
+        activationStatus: WorkspaceActivationStatus.ACTIVE,
+      },
+      select: ['id'],
+    });
 
-      for (let i = 0; i < activeWorkspaces.length; i++) {
-        const workspace = activeWorkspaces[i];
+    let enqueuedCount = 0;
 
-        this.logger.log(
-          `Processing workspace ${workspace.id} (${i + 1}/${activeWorkspaces.length})`,
+    for (const workspace of activeWorkspaces) {
+      const hasNotStartedRuns = await this.hasNotStartedRuns(workspace.id);
+
+      if (hasNotStartedRuns) {
+        await this.messageQueueService.add<WorkflowRunEnqueueJobData>(
+          WorkflowRunEnqueueJob.name,
+          {
+            workspaceId: workspace.id,
+            isCacheMode: false,
+          },
         );
-
-        try {
-          await this.workflowRunEnqueueWorkspaceService.enqueueRunsForWorkspace(
-            {
-              workspaceId: workspace.id,
-              isCacheMode: false,
-            },
-          );
-        } catch (error) {
-          this.logger.error(
-            `Failed to enqueue runs for workspace ${workspace.id}`,
-            error,
-          );
-        }
+        enqueuedCount++;
       }
-
-      this.logger.log('Completed WorkflowRunEnqueueCronJob cron');
-    } catch (error) {
-      this.logger.error('WorkflowRunEnqueueCronJob cron failed', error);
-      throw error;
     }
+
+    this.logger.log(
+      `Completed WorkflowRunEnqueueCronJob cron, enqueued ${enqueuedCount} jobs`,
+    );
+  }
+
+  private async hasNotStartedRuns(workspaceId: string): Promise<boolean> {
+    const authContext = buildSystemAuthContext(workspaceId);
+
+    return this.globalWorkspaceOrmManager.executeInWorkspaceContext(
+      async () => {
+        const workflowRunRepository =
+          await this.globalWorkspaceOrmManager.getRepository(
+            workspaceId,
+            WorkflowRunWorkspaceEntity,
+            { shouldBypassPermissionChecks: true },
+          );
+
+        const count = await workflowRunRepository.count({
+          where: NOT_STARTED_RUNS_FIND_OPTIONS,
+          take: 1,
+        });
+
+        return count > 0;
+      },
+      authContext,
+    );
   }
 }

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/jobs/workflow-clean-workflow-runs.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/jobs/workflow-clean-workflow-runs.job.ts
@@ -1,0 +1,75 @@
+import { Logger, Scope } from '@nestjs/common';
+import { InjectDataSource } from '@nestjs/typeorm';
+
+import { DataSource } from 'typeorm';
+
+import { Process } from 'src/engine/core-modules/message-queue/decorators/process.decorator';
+import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
+import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
+import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
+import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
+import { getWorkspaceSchemaName } from 'src/engine/workspace-datasource/utils/get-workspace-schema-name.util';
+import {
+  WorkflowRunStatus,
+  WorkflowRunWorkspaceEntity,
+} from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
+import { NUMBER_OF_WORKFLOW_RUNS_TO_KEEP } from 'src/modules/workflow/workflow-runner/workflow-run-queue/constants/number-of-workflow-runs-to-keep';
+import { RUNS_TO_CLEAN_THRESHOLD_DAYS } from 'src/modules/workflow/workflow-runner/workflow-run-queue/constants/runs-to-clean-threshold';
+
+export type WorkflowCleanWorkflowRunsJobData = {
+  workspaceId: string;
+};
+
+@Processor({ queueName: MessageQueue.workflowQueue, scope: Scope.REQUEST })
+export class WorkflowCleanWorkflowRunsJob {
+  private readonly logger = new Logger(WorkflowCleanWorkflowRunsJob.name);
+
+  constructor(
+    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    @InjectDataSource()
+    private readonly dataSource: DataSource,
+  ) {}
+
+  @Process(WorkflowCleanWorkflowRunsJob.name)
+  async handle({
+    workspaceId,
+  }: WorkflowCleanWorkflowRunsJobData): Promise<void> {
+    const schemaName = getWorkspaceSchemaName(workspaceId);
+    const authContext = buildSystemAuthContext(workspaceId);
+
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const workflowRunsToDelete = await this.dataSource.query(
+        `
+          WITH ranked_runs AS (
+            SELECT id,
+                   ROW_NUMBER() OVER (
+                      PARTITION BY "workflowId"
+                      ORDER BY "createdAt" DESC
+                   ) AS rn,
+                   "createdAt"
+            FROM ${schemaName}."workflowRun"
+            WHERE status IN ('${WorkflowRunStatus.COMPLETED}', '${WorkflowRunStatus.FAILED}')
+          )
+          SELECT id, rn FROM ranked_runs
+          WHERE rn > ${NUMBER_OF_WORKFLOW_RUNS_TO_KEEP}
+             OR "createdAt" < NOW() - INTERVAL '${RUNS_TO_CLEAN_THRESHOLD_DAYS} days';
+        `,
+      );
+
+      const workflowRunRepository =
+        await this.globalWorkspaceOrmManager.getRepository(
+          workspaceId,
+          WorkflowRunWorkspaceEntity,
+          { shouldBypassPermissionChecks: true },
+        );
+
+      for (const workflowRunToDelete of workflowRunsToDelete) {
+        await workflowRunRepository.delete(workflowRunToDelete.id);
+      }
+
+      this.logger.log(
+        `Deleted ${workflowRunsToDelete.length} workflow runs for workspace ${workspaceId}`,
+      );
+    }, authContext);
+  }
+}

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/jobs/workflow-handle-staled-runs.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/jobs/workflow-handle-staled-runs.job.ts
@@ -1,0 +1,26 @@
+import { Scope } from '@nestjs/common';
+
+import { Process } from 'src/engine/core-modules/message-queue/decorators/process.decorator';
+import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
+import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
+import { WorkflowHandleStaledRunsWorkspaceService } from 'src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-handle-staled-runs.workspace-service';
+
+export type WorkflowHandleStaledRunsJobData = {
+  workspaceId: string;
+};
+
+@Processor({ queueName: MessageQueue.workflowQueue, scope: Scope.REQUEST })
+export class WorkflowHandleStaledRunsJob {
+  constructor(
+    private readonly workflowHandleStaledRunsWorkspaceService: WorkflowHandleStaledRunsWorkspaceService,
+  ) {}
+
+  @Process(WorkflowHandleStaledRunsJob.name)
+  async handle({
+    workspaceId,
+  }: WorkflowHandleStaledRunsJobData): Promise<void> {
+    await this.workflowHandleStaledRunsWorkspaceService.handleStaledRunsForWorkspace(
+      workspaceId,
+    );
+  }
+}

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/utils/get-runs-to-clean-find-options.util.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/utils/get-runs-to-clean-find-options.util.ts
@@ -1,0 +1,19 @@
+import { type FindOptionsWhere, In, LessThan } from 'typeorm';
+
+import {
+  WorkflowRunStatus,
+  type WorkflowRunWorkspaceEntity,
+} from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
+import { RUNS_TO_CLEAN_THRESHOLD_DAYS } from 'src/modules/workflow/workflow-runner/workflow-run-queue/constants/runs-to-clean-threshold';
+
+export const getRunsToCleanFindOptions =
+  (): FindOptionsWhere<WorkflowRunWorkspaceEntity> => {
+    const thresholdDate = new Date(
+      Date.now() - RUNS_TO_CLEAN_THRESHOLD_DAYS * 24 * 60 * 60 * 1000,
+    ).toISOString();
+
+    return {
+      status: In([WorkflowRunStatus.COMPLETED, WorkflowRunStatus.FAILED]),
+      createdAt: LessThan(thresholdDate),
+    };
+  };

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/utils/get-staled-runs-find-options.util.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/utils/get-staled-runs-find-options.util.ts
@@ -1,0 +1,17 @@
+import { type FindOptionsWhere, IsNull, LessThan, Or } from 'typeorm';
+
+import {
+  WorkflowRunStatus,
+  type WorkflowRunWorkspaceEntity,
+} from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
+import { STALED_RUNS_THRESHOLD_MS } from 'src/modules/workflow/workflow-runner/workflow-run-queue/constants/staled-runs-threshold';
+
+export const getStaledRunsFindOptions =
+  (): FindOptionsWhere<WorkflowRunWorkspaceEntity> => {
+    const thresholdDate = new Date(Date.now() - STALED_RUNS_THRESHOLD_MS);
+
+    return {
+      status: WorkflowRunStatus.ENQUEUED,
+      enqueuedAt: Or(LessThan(thresholdDate), IsNull()),
+    };
+  };

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workflow-run-queue.module.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workflow-run-queue.module.ts
@@ -11,9 +11,11 @@ import { WorkflowHandleStaledRunsCommand } from 'src/modules/workflow/workflow-r
 import { WorkflowCleanWorkflowRunsCronCommand } from 'src/modules/workflow/workflow-runner/workflow-run-queue/cron/command/workflow-clean-workflow-runs.cron.command';
 import { WorkflowHandleStaledRunsCronCommand } from 'src/modules/workflow/workflow-runner/workflow-run-queue/cron/command/workflow-handle-staled-runs.cron.command';
 import { WorkflowRunEnqueueCronCommand } from 'src/modules/workflow/workflow-runner/workflow-run-queue/cron/command/workflow-run-enqueue.cron.command';
-import { WorkflowCleanWorkflowRunsJob } from 'src/modules/workflow/workflow-runner/workflow-run-queue/cron/jobs/workflow-clean-workflow-runs.cron.job';
-import { WorkflowHandleStaledRunsJob } from 'src/modules/workflow/workflow-runner/workflow-run-queue/cron/jobs/workflow-handle-staled-runs.cron.job';
+import { WorkflowCleanWorkflowRunsCronJob } from 'src/modules/workflow/workflow-runner/workflow-run-queue/cron/jobs/workflow-clean-workflow-runs.cron.job';
+import { WorkflowHandleStaledRunsCronJob } from 'src/modules/workflow/workflow-runner/workflow-run-queue/cron/jobs/workflow-handle-staled-runs.cron.job';
 import { WorkflowRunEnqueueCronJob } from 'src/modules/workflow/workflow-runner/workflow-run-queue/cron/jobs/workflow-run-enqueue.cron.job';
+import { WorkflowCleanWorkflowRunsJob } from 'src/modules/workflow/workflow-runner/workflow-run-queue/jobs/workflow-clean-workflow-runs.job';
+import { WorkflowHandleStaledRunsJob } from 'src/modules/workflow/workflow-runner/workflow-run-queue/jobs/workflow-handle-staled-runs.job';
 import { WorkflowRunEnqueueJob } from 'src/modules/workflow/workflow-runner/workflow-run-queue/jobs/workflow-run-enqueue.job';
 import { WorkflowHandleStaledRunsWorkspaceService } from 'src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-handle-staled-runs.workspace-service';
 import { WorkflowRunEnqueueWorkspaceService } from 'src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-run-enqueue.workspace-service';
@@ -37,7 +39,9 @@ import { WorkflowThrottlingWorkspaceService } from 'src/modules/workflow/workflo
     WorkflowHandleStaledRunsWorkspaceService,
     WorkflowHandleStaledRunsCronCommand,
     WorkflowHandleStaledRunsCommand,
+    WorkflowHandleStaledRunsCronJob,
     WorkflowHandleStaledRunsJob,
+    WorkflowCleanWorkflowRunsCronJob,
     WorkflowCleanWorkflowRunsJob,
     WorkflowCleanWorkflowRunsCronCommand,
   ],
@@ -46,8 +50,10 @@ import { WorkflowThrottlingWorkspaceService } from 'src/modules/workflow/workflo
     WorkflowRunEnqueueJob,
     WorkflowRunEnqueueCronJob,
     WorkflowRunEnqueueCronCommand,
+    WorkflowHandleStaledRunsCronJob,
     WorkflowHandleStaledRunsCronCommand,
     WorkflowHandleStaledRunsCommand,
+    WorkflowCleanWorkflowRunsCronJob,
     WorkflowCleanWorkflowRunsCronCommand,
   ],
 })

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-handle-staled-runs.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-handle-staled-runs.workspace-service.ts
@@ -1,13 +1,12 @@
 import { Injectable, Logger } from '@nestjs/common';
 
-import { IsNull, LessThan, Or } from 'typeorm';
-
 import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
 import {
   WorkflowRunStatus,
   WorkflowRunWorkspaceEntity,
 } from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
+import { getStaledRunsFindOptions } from 'src/modules/workflow/workflow-runner/workflow-run-queue/utils/get-staled-runs-find-options.util';
 import { WorkflowThrottlingWorkspaceService } from 'src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-throttling.workspace-service';
 
 @Injectable()
@@ -20,35 +19,7 @@ export class WorkflowHandleStaledRunsWorkspaceService {
     private readonly workflowThrottlingWorkspaceService: WorkflowThrottlingWorkspaceService,
   ) {}
 
-  async handleStaledRuns({ workspaceIds }: { workspaceIds: string[] }) {
-    this.logger.log('Starting handleStaledRuns');
-
-    try {
-      for (let i = 0; i < workspaceIds.length; i++) {
-        const workspaceId = workspaceIds[i];
-
-        this.logger.log(
-          `Processing workspace ${workspaceId} (${i + 1}/${workspaceIds.length})`,
-        );
-
-        try {
-          await this.handleStaledRunsForWorkspace(workspaceId);
-        } catch (error) {
-          this.logger.error(
-            `Failed to handle staled runs for workspace ${workspaceId}`,
-            error,
-          );
-        }
-      }
-
-      this.logger.log('Completed handleStaledRuns');
-    } catch (error) {
-      this.logger.error('handleStaledRuns failed', error);
-      throw error;
-    }
-  }
-
-  private async handleStaledRunsForWorkspace(workspaceId: string) {
+  async handleStaledRunsForWorkspace(workspaceId: string) {
     const authContext = buildSystemAuthContext(workspaceId);
 
     await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
@@ -59,13 +30,8 @@ export class WorkflowHandleStaledRunsWorkspaceService {
           { shouldBypassPermissionChecks: true },
         );
 
-      const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
-
       const staledWorkflowRuns = await workflowRunRepository.find({
-        where: {
-          status: WorkflowRunStatus.ENQUEUED,
-          enqueuedAt: Or(LessThan(oneHourAgo), IsNull()),
-        },
+        where: getStaledRunsFindOptions(),
       });
 
       if (staledWorkflowRuns.length <= 0) {

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-run-enqueue.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-run-enqueue.workspace-service.ts
@@ -15,6 +15,7 @@ import {
 } from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
 import { RunWorkflowJob } from 'src/modules/workflow/workflow-runner/jobs/run-workflow.job';
 import { type RunWorkflowJobData } from 'src/modules/workflow/workflow-runner/types/run-workflow-job-data.type';
+import { NOT_STARTED_RUNS_FIND_OPTIONS } from 'src/modules/workflow/workflow-runner/workflow-run-queue/constants/not-started-runs-find-options';
 import { WorkflowThrottlingWorkspaceService } from 'src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-throttling.workspace-service';
 
 @Injectable()
@@ -86,9 +87,7 @@ export class WorkflowRunEnqueueWorkspaceService {
             );
 
             const batchRuns = await workflowRunRepository.find({
-              where: {
-                status: WorkflowRunStatus.NOT_STARTED,
-              },
+              where: NOT_STARTED_RUNS_FIND_OPTIONS,
               select: {
                 id: true,
               },

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-throttling.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/workspace-services/workflow-throttling.workspace-service.ts
@@ -1,7 +1,5 @@
 import { Injectable } from '@nestjs/common';
 
-import { In } from 'typeorm';
-
 import { InjectCacheStorage } from 'src/engine/core-modules/cache-storage/decorators/cache-storage.decorator';
 import { CacheStorageService } from 'src/engine/core-modules/cache-storage/services/cache-storage.service';
 import { CacheStorageNamespace } from 'src/engine/core-modules/cache-storage/types/cache-storage-namespace.enum';
@@ -9,10 +7,8 @@ import { ThrottlerService } from 'src/engine/core-modules/throttler/throttler.se
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
 import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
-import {
-  WorkflowRunStatus,
-  WorkflowRunWorkspaceEntity,
-} from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
+import { WorkflowRunWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow-run.workspace-entity';
+import { NOT_STARTED_RUNS_FIND_OPTIONS } from 'src/modules/workflow/workflow-runner/workflow-run-queue/constants/not-started-runs-find-options';
 
 @Injectable()
 export class WorkflowThrottlingWorkspaceService {
@@ -89,9 +85,7 @@ export class WorkflowThrottlingWorkspaceService {
             );
 
           return workflowRunRepository.count({
-            where: {
-              status: In([WorkflowRunStatus.NOT_STARTED]),
-            },
+            where: NOT_STARTED_RUNS_FIND_OPTIONS,
           });
         },
         authContext,
@@ -122,9 +116,7 @@ export class WorkflowThrottlingWorkspaceService {
           );
 
         return workflowRunRepository.count({
-          where: {
-            status: In([WorkflowRunStatus.NOT_STARTED]),
-          },
+          where: NOT_STARTED_RUNS_FIND_OPTIONS,
         });
       },
       authContext,


### PR DESCRIPTION
Issue 1: no info to debug cron trigger. Stop catching exception + using logs instead of throwing for now

Issue 2: sentry often send timeouts errors for workflow crons. Probably not real ones, it sends it if the job takes more than 5 minutes to run. To fix, on each workflow cron we do:
- loop over active workspaces
- perform a query check that workspace is relevant, using count for performances
- send a job if relevant