### PR TITLE
fix: prioritize active fields when filtering morph relation duplicates

### DIFF
--- a/packages/twenty-server/src/engine/dataloaders/utils/filter-morph-relation-duplicate-fields.util.ts
+++ b/packages/twenty-server/src/engine/dataloaders/utils/filter-morph-relation-duplicate-fields.util.ts
@@ -3,6 +3,25 @@ import { FieldMetadataType } from 'twenty-shared/types';
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
 import { isFlatFieldMetadataOfType } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-flat-field-metadata-of-type.util';
 
+// Returns true if otherField should be preferred over currentField
+// Priority: 1) isActive (active fields preferred), 2) smaller UUID as tiebreaker
+const shouldPreferOtherField = (
+  currentField: FlatFieldMetadata<FieldMetadataType.MORPH_RELATION>,
+  otherField: FlatFieldMetadata<FieldMetadataType.MORPH_RELATION>,
+): boolean => {
+  // If one is active and the other isn't, prefer the active one
+  if (otherField.isActive && !currentField.isActive) {
+    return true;
+  }
+
+  if (currentField.isActive && !otherField.isActive) {
+    return false;
+  }
+
+  // Both have the same isActive status, use ID as tiebreaker
+  return otherField.id < currentField.id;
+};
+
 export const filterMorphRelationDuplicateFields = (
   flatFieldMetadatas: FlatFieldMetadata[],
 ): FlatFieldMetadata[] => {
@@ -45,7 +64,7 @@ export const filterMorphRelationDuplicateFields = (
         (otherField) =>
           currentField.id !== otherField.id &&
           otherField.morphId === currentField.morphId &&
-          otherField.id < currentField.id,
+          shouldPreferOtherField(currentField, otherField),
       ),
   );
 


### PR DESCRIPTION
## Summary
Fixes an issue where morph relation fields (like `noteTarget` and `taskTarget`) could appear inactive in the metadata API when they should be active.

## Root Cause
When selecting a representative field for morph relations sharing the same `morphId`, the filter previously only used UUID comparison. This could select an inactive field if it had the smallest UUID, causing the entire morph relation to appear inactive.

**In production:**
1. After the 1-17 migration, fields like `cloudUserWorkspace`, `company`, `person` etc. were converted to `MORPH_RELATION` type with the same `morphId`
2. Some fields (e.g., `cloudUserWorkspace` from internal Twenty apps) had `isActive: false`
3. The inactive field happened to have the smallest UUID
4. This field was selected to represent the morph relation in metadata
5. Frontend saw `isActive: false` and didn't include the `target` field in GraphQL queries
6. Result: Relations appeared empty even though data existed

## Fix
Modified `filterMorphRelationDuplicateFields` to prioritize:
1. **Active fields** (`isActive: true`) over inactive fields
2. Among fields with the same status, smallest UUID as tiebreaker

## Testing
Verified logic correctness. After deploying, the affected workspace will automatically show the correct `target` field with `isActive: true` in the metadata response.