### PR TITLE
fix: update lockfile for twenty CLI bin path change

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -57032,7 +57032,7 @@ __metadata:
     wait-on: "npm:^7.2.0"
     zod: "npm:^4.1.11"
   bin:
-    twenty: dist/cli/index.cjs
+    twenty: dist/cli.cjs
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

The lockfile had a stale reference to `dist/cli/index.cjs` but the twenty CLI bin was changed to `dist/cli.cjs`.

This was causing CI to fail with:
```
YN0028: -    twenty: dist/cli/index.cjs
YN0028: +    twenty: dist/cli.cjs
YN0028: The lockfile would have been modified by this install, which is explicitly forbidden.
```

This PR updates the lockfile to match the new path.