### PR TITLE
- fixed coloring of item type tag in dark mode

### DIFF
--- a/packages/twenty-front/src/modules/settings/components/SettingsItemTypeTag.tsx
+++ b/packages/twenty-front/src/modules/settings/components/SettingsItemTypeTag.tsx
@@ -19,6 +19,7 @@ const StyledContainer = styled.div`
   display: flex;
   font-size: ${({ theme }) => theme.font.size.sm};
   gap: ${({ theme }) => theme.spacing(1)};
+  color: ${({ theme }) => theme.font.color.secondary};
 `;
 
 export const SettingsItemTypeTag = ({


### PR DESCRIPTION
Fixed issue #17694 

<img width="963" height="1021" alt="image" src="https://github.com/user-attachments/assets/a28948a1-126d-4f3c-8a53-c39adbb7f52d" />
