### PR TITLE
fix: ensure side panel content doesn't shrink

### DIFF
--- a/packages/twenty-front/src/modules/command-menu/components/CommandMenuSidePanelForDesktop.tsx
+++ b/packages/twenty-front/src/modules/command-menu/components/CommandMenuSidePanelForDesktop.tsx
@@ -37,7 +37,7 @@ const StyledSidePanel = styled.aside`
   height: 100%;
   overflow: hidden;
   position: relative;
-  width: 100%;
+  width: var(${COMMAND_MENU_WIDTH_VAR});
   box-sizing: border-box;
 `;
 


### PR DESCRIPTION
Ensure side panel's content doesn't change during the animation. I set a fixed width to the content and rely on the parent to hide overflowing content.

## Before

https://github.com/user-attachments/assets/c5086155-f59e-4c6a-8430-2945996db891

## After

https://github.com/user-attachments/assets/f5c0ac35-be17-4c80-a9ce-7a3899785c84