### PR TITLE
Add workflow prefix to code step source path

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-17/1-17-migrate-workflow-code-steps.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-17/1-17-migrate-workflow-code-steps.command.ts
@@ -199,6 +199,7 @@ export class MigrateWorkflowCodeStepsCommand extends ActiveOrSuspendedWorkspaces
       },
       workspaceId,
       applicationId: oldLogicFunction.applicationId,
+      baseFolderPrefix: NEW_WORKFLOW_RESOURCE_PREFIX,
     });
 
     const newLogicFunctionId = newFlatLogicFunction.id;

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-source-builder/logic-function-source-builder.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-source-builder/logic-function-source-builder.service.ts
@@ -35,6 +35,7 @@ type SeedSourceFilesParams = {
   workspaceId: string;
   applicationUniversalIdentifier: string;
   code?: Sources;
+  baseFolderPrefix?: string;
 };
 
 type SeedSourceFilesResult = {
@@ -81,9 +82,13 @@ export class LogicFunctionSourceBuilderService {
     workspaceId,
     applicationUniversalIdentifier,
     code,
+    baseFolderPrefix,
   }: SeedSourceFilesParams): Promise<SeedSourceFilesResult> {
-    const sourceHandlerPath = `${logicFunctionId}/${DEFAULT_SOURCE_HANDLER_PATH}`;
-    const builtHandlerPath = `${logicFunctionId}/${DEFAULT_BUILT_HANDLER_PATH}`;
+    const baseFolder = baseFolderPrefix
+      ? `${baseFolderPrefix}/${logicFunctionId}`
+      : logicFunctionId;
+    const sourceHandlerPath = `${baseFolder}/${DEFAULT_SOURCE_HANDLER_PATH}`;
+    const builtHandlerPath = `${baseFolder}/${DEFAULT_BUILT_HANDLER_PATH}`;
 
     if (isDefined(code)) {
       // Use provided code

--- a/packages/twenty-server/src/engine/metadata-modules/logic-function/services/logic-function.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/logic-function/services/logic-function.service.ts
@@ -38,11 +38,13 @@ export class LogicFunctionService {
     input,
     workspaceId,
     ownerFlatApplication,
+    baseFolderPrefix,
   }: {
     input: Omit<CreateLogicFunctionInput, 'applicationId'>;
     ownerFlatApplication?: FlatApplication;
     workspaceId: string;
     applicationId?: string;
+    baseFolderPrefix?: string;
   }) {
     const resolvedOwnerFlatApplication =
       ownerFlatApplication ??
@@ -68,6 +70,7 @@ export class LogicFunctionService {
         applicationUniversalIdentifier:
           resolvedOwnerFlatApplication.universalIdentifier,
         code: input.code,
+        baseFolderPrefix,
       });
 
     // Update paths and checksum with actual values from seeding

--- a/packages/twenty-server/src/engine/metadata-modules/logic-function/utils/from-create-logic-function-input-to-flat-logic-function.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/logic-function/utils/from-create-logic-function-input-to-flat-logic-function.util.ts
@@ -13,8 +13,6 @@ import {
 import { type FlatLogicFunction } from 'src/engine/metadata-modules/logic-function/types/flat-logic-function.type';
 import { logicFunctionCreateHash } from 'src/engine/metadata-modules/logic-function/utils/logic-function-create-hash.utils';
 
-const WORKFLOW_BASE_FOLDER_PREFIX = 'workflow';
-
 export type FromCreateLogicFunctionInputToFlatLogicFunctionArgs = {
   createLogicFunctionInput: CreateLogicFunctionInput;
   workspaceId: string;
@@ -29,14 +27,12 @@ export const fromCreateLogicFunctionInputToFlatLogicFunction = ({
   const id = rawCreateLogicFunctionInput.id ?? v4();
   const currentDate = new Date();
 
-  // Build full paths including the base folder
-  const baseFolder = `${WORKFLOW_BASE_FOLDER_PREFIX}/${id}`;
   const sourceHandlerPath =
     rawCreateLogicFunctionInput.sourceHandlerPath ??
-    `${baseFolder}/${DEFAULT_SOURCE_HANDLER_PATH}`;
+    `${id}/${DEFAULT_SOURCE_HANDLER_PATH}`;
   const builtHandlerPath =
     rawCreateLogicFunctionInput.builtHandlerPath ??
-    `${baseFolder}/${DEFAULT_BUILT_HANDLER_PATH}`;
+    `${id}/${DEFAULT_BUILT_HANDLER_PATH}`;
 
   const universalIdentifier =
     rawCreateLogicFunctionInput.universalIdentifier ?? v4();

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version-step/code-step/services/code-step-build.service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version-step/code-step/services/code-step-build.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@nestjs/common';
 
 import { isDefined } from 'twenty-shared/utils';
-import { v4 } from 'uuid';
 
 import { ApplicationService } from 'src/engine/core-modules/application/services/application.service';
 import { LogicFunctionSourceBuilderService } from 'src/engine/core-modules/logic-function/logic-function-source-builder/logic-function-source-builder.service';
@@ -10,7 +9,6 @@ import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/
 import { LogicFunctionService } from 'src/engine/metadata-modules/logic-function/services/logic-function.service';
 import { type FlatLogicFunction } from 'src/engine/metadata-modules/logic-function/types/flat-logic-function.type';
 import { findFlatLogicFunctionOrThrow } from 'src/engine/metadata-modules/logic-function/utils/find-flat-logic-function-or-throw.util';
-import { fromCreateLogicFunctionInputToFlatLogicFunction } from 'src/engine/metadata-modules/logic-function/utils/from-create-logic-function-input-to-flat-logic-function.util';
 import {
   WorkflowActionType,
   type WorkflowAction,
@@ -34,11 +32,11 @@ export class CodeStepBuildService {
     existingLogicFunctionId: string;
     workspaceId: string;
   }): Promise<FlatLogicFunction> {
-    const { flatLogicFunctionMaps } =
+    const { flatLogicFunctionMaps, flatApplicationMaps } =
       await this.workspaceManyOrAllFlatEntityMapsCacheService.getOrRecomputeManyOrAllFlatEntityMaps(
         {
           workspaceId,
-          flatMapsKeys: ['flatLogicFunctionMaps'],
+          flatMapsKeys: ['flatLogicFunctionMaps', 'flatApplicationMaps'],
         },
       );
 
@@ -47,49 +45,35 @@ export class CodeStepBuildService {
       flatLogicFunctionMaps,
     });
 
-    const resolvedOwnerFlatApplication = (
-      await this.applicationService.findWorkspaceTwentyStandardAndCustomApplicationOrThrow(
-        { workspaceId },
-      )
-    ).workspaceCustomFlatApplication;
+    const applicationUniversalIdentifier = isDefined(
+      existingLogicFunction.applicationId,
+    )
+      ? flatApplicationMaps.byId[existingLogicFunction.applicationId]
+          ?.universalIdentifier
+      : undefined;
 
-    const applicationUniversalIdentifier =
-      resolvedOwnerFlatApplication.universalIdentifier;
+    if (!isDefined(applicationUniversalIdentifier)) {
+      throw new Error(
+        'Cannot duplicate code step: application not found for existing logic function',
+      );
+    }
 
-    const newId = v4();
-    const newFlatLogicFunction =
-      fromCreateLogicFunctionInputToFlatLogicFunction({
-        createLogicFunctionInput: {
-          name: existingLogicFunction.name,
-          description: existingLogicFunction.description ?? undefined,
-          timeoutSeconds: existingLogicFunction.timeoutSeconds,
-          id: newId,
-        },
+    const existingCode =
+      await this.logicFunctionSourceBuilderService.getSourceCode({
+        sourceHandlerPath: existingLogicFunction.sourceHandlerPath,
         workspaceId,
-        ownerFlatApplication: resolvedOwnerFlatApplication,
+        applicationUniversalIdentifier,
       });
-
-    await this.logicFunctionSourceBuilderService.copySourceAndBuilt({
-      fromSourceHandlerPath: existingLogicFunction.sourceHandlerPath,
-      fromBuiltHandlerPath: existingLogicFunction.builtHandlerPath,
-      toSourceHandlerPath: newFlatLogicFunction.sourceHandlerPath,
-      toBuiltHandlerPath: newFlatLogicFunction.builtHandlerPath,
-      workspaceId,
-      applicationUniversalIdentifier,
-    });
 
     const created = await this.logicFunctionService.createOne({
       input: {
         name: existingLogicFunction.name,
         description: existingLogicFunction.description ?? undefined,
         timeoutSeconds: existingLogicFunction.timeoutSeconds,
-        id: newFlatLogicFunction.id,
-        sourceHandlerPath: newFlatLogicFunction.sourceHandlerPath,
-        builtHandlerPath: newFlatLogicFunction.builtHandlerPath,
-        checksum: existingLogicFunction.checksum ?? undefined,
+        code: existingCode ?? undefined,
       },
       workspaceId,
-      ownerFlatApplication: resolvedOwnerFlatApplication,
+      baseFolderPrefix: WORKFLOW_BASE_FOLDER_PREFIX,
     });
 
     if (!isDefined(created)) {

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version-step/code-step/services/code-step-build.service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version-step/code-step/services/code-step-build.service.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@nestjs/common';
 
 import { isDefined } from 'twenty-shared/utils';
 
-import { ApplicationService } from 'src/engine/core-modules/application/services/application.service';
 import { LogicFunctionSourceBuilderService } from 'src/engine/core-modules/logic-function/logic-function-source-builder/logic-function-source-builder.service';
 import { WorkspaceManyOrAllFlatEntityMapsCacheService } from 'src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.service';
 import { findFlatEntityByIdInFlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-id-in-flat-entity-maps.util';
@@ -21,7 +20,6 @@ export class CodeStepBuildService {
   constructor(
     private readonly workspaceManyOrAllFlatEntityMapsCacheService: WorkspaceManyOrAllFlatEntityMapsCacheService,
     private readonly logicFunctionService: LogicFunctionService,
-    private readonly applicationService: ApplicationService,
     private readonly logicFunctionSourceBuilderService: LogicFunctionSourceBuilderService,
   ) {}
 

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version-step/workflow-version-step-operations.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version-step/workflow-version-step-operations.workspace-service.ts
@@ -165,6 +165,7 @@ export class WorkflowVersionStepOperationsWorkspaceService {
             description: '',
           },
           workspaceId,
+          baseFolderPrefix: 'workflow',
         });
 
         if (!isDefined(newLogicFunction)) {


### PR DESCRIPTION
Code step functions are not built, neither on activation, neither when testing workflow. Because `isWorkflowCodeStepLogicFunction` returns false. Source path needs the prefix workflow.

Also update code step duplication to copy the code but recreate a new function