### PR TITLE
Fix row level permission predicate group creation order

### DIFF
--- a/packages/twenty-front/src/modules/settings/roles/role/hooks/useSaveDraftRoleToDB.ts
+++ b/packages/twenty-front/src/modules/settings/roles/role/hooks/useSaveDraftRoleToDB.ts
@@ -317,10 +317,10 @@ export const useSaveDraftRoleToDB = ({
         objectUsedGroupIds.has(group.id),
       );
 
-      // Sort groups so parents are created before children
       const sortedGroups: typeof objectPredicateGroups = [];
       const groupsById = new Map(objectPredicateGroups.map((g) => [g.id, g]));
       const added = new Set<string>();
+      const visiting = new Set<string>();
 
       const addGroupWithParents = (
         group: (typeof objectPredicateGroups)[0],
@@ -328,6 +328,12 @@ export const useSaveDraftRoleToDB = ({
         if (added.has(group.id) === true) {
           return;
         }
+
+        if (visiting.has(group.id) === true) {
+          return;
+        }
+
+        visiting.add(group.id);
 
         if (isDefined(group.parentRowLevelPermissionPredicateGroupId)) {
           const parent = groupsById.get(
@@ -337,6 +343,8 @@ export const useSaveDraftRoleToDB = ({
             addGroupWithParents(parent);
           }
         }
+
+        visiting.delete(group.id);
 
         sortedGroups.push(group);
         added.add(group.id);

--- a/packages/twenty-front/src/modules/settings/roles/role/hooks/useSaveDraftRoleToDB.ts
+++ b/packages/twenty-front/src/modules/settings/roles/role/hooks/useSaveDraftRoleToDB.ts
@@ -364,16 +364,7 @@ export const useSaveDraftRoleToDB = ({
               positionInRowLevelPermissionPredicateGroup:
                 predicate.positionInRowLevelPermissionPredicateGroup,
             })),
-            predicateGroups: objectPredicateGroups.map((group) => ({
-              id: group.id,
-              objectMetadataId,
-              parentRowLevelPermissionPredicateGroupId:
-                group.parentRowLevelPermissionPredicateGroupId,
-              logicalOperator:
-                group.logicalOperator as RowLevelPermissionPredicateGroupLogicalOperator,
-              positionInRowLevelPermissionPredicateGroup:
-                group.positionInRowLevelPermissionPredicateGroup,
-            })),
+            predicateGroups: [],
           },
         },
         refetchQueries: [getOperationName(GET_ROLES) ?? ''],

--- a/packages/twenty-front/src/modules/settings/roles/role/hooks/useSaveDraftRoleToDB.ts
+++ b/packages/twenty-front/src/modules/settings/roles/role/hooks/useSaveDraftRoleToDB.ts
@@ -317,16 +317,41 @@ export const useSaveDraftRoleToDB = ({
         objectUsedGroupIds.has(group.id),
       );
 
-      // First, create/update predicate groups
-      // This must be done before creating predicates that reference these groups
-      if (objectPredicateGroups.length > 0) {
+      // Sort groups so parents are created before children
+      const sortedGroups: typeof objectPredicateGroups = [];
+      const groupsById = new Map(objectPredicateGroups.map((g) => [g.id, g]));
+      const added = new Set<string>();
+
+      const addGroupWithParents = (
+        group: (typeof objectPredicateGroups)[0],
+      ) => {
+        if (added.has(group.id) === true) {
+          return;
+        }
+
+        if (isDefined(group.parentRowLevelPermissionPredicateGroupId)) {
+          const parent = groupsById.get(
+            group.parentRowLevelPermissionPredicateGroupId,
+          );
+          if (isDefined(parent)) {
+            addGroupWithParents(parent);
+          }
+        }
+
+        sortedGroups.push(group);
+        added.add(group.id);
+      };
+
+      objectPredicateGroups.forEach(addGroupWithParents);
+
+      if (sortedGroups.length > 0) {
         await upsertRowLevelPermissionPredicates({
           variables: {
             input: {
               roleId: targetRoleId,
               objectMetadataId,
               predicates: [],
-              predicateGroups: objectPredicateGroups.map((group) => ({
+              predicateGroups: sortedGroups.map((group) => ({
                 id: group.id,
                 objectMetadataId,
                 parentRowLevelPermissionPredicateGroupId:
@@ -343,7 +368,6 @@ export const useSaveDraftRoleToDB = ({
         });
       }
 
-      // Then, create/update predicates that reference the groups
       await upsertRowLevelPermissionPredicates({
         variables: {
           input: {
@@ -364,7 +388,16 @@ export const useSaveDraftRoleToDB = ({
               positionInRowLevelPermissionPredicateGroup:
                 predicate.positionInRowLevelPermissionPredicateGroup,
             })),
-            predicateGroups: [],
+            predicateGroups: sortedGroups.map((group) => ({
+              id: group.id,
+              objectMetadataId,
+              parentRowLevelPermissionPredicateGroupId:
+                group.parentRowLevelPermissionPredicateGroupId,
+              logicalOperator:
+                group.logicalOperator as RowLevelPermissionPredicateGroupLogicalOperator,
+              positionInRowLevelPermissionPredicateGroup:
+                group.positionInRowLevelPermissionPredicateGroup,
+            })),
           },
         },
         refetchQueries: [getOperationName(GET_ROLES) ?? ''],

--- a/packages/twenty-front/src/modules/settings/roles/role/hooks/useSaveDraftRoleToDB.ts
+++ b/packages/twenty-front/src/modules/settings/roles/role/hooks/useSaveDraftRoleToDB.ts
@@ -317,6 +317,33 @@ export const useSaveDraftRoleToDB = ({
         objectUsedGroupIds.has(group.id),
       );
 
+      // First, create/update predicate groups
+      // This must be done before creating predicates that reference these groups
+      if (objectPredicateGroups.length > 0) {
+        await upsertRowLevelPermissionPredicates({
+          variables: {
+            input: {
+              roleId: targetRoleId,
+              objectMetadataId,
+              predicates: [],
+              predicateGroups: objectPredicateGroups.map((group) => ({
+                id: group.id,
+                objectMetadataId,
+                parentRowLevelPermissionPredicateGroupId:
+                  group.parentRowLevelPermissionPredicateGroupId,
+                logicalOperator:
+                  group.logicalOperator as RowLevelPermissionPredicateGroupLogicalOperator,
+                positionInRowLevelPermissionPredicateGroup:
+                  group.positionInRowLevelPermissionPredicateGroup,
+              })),
+            },
+          },
+          refetchQueries: [getOperationName(GET_ROLES) ?? ''],
+          awaitRefetchQueries: true,
+        });
+      }
+
+      // Then, create/update predicates that reference the groups
       await upsertRowLevelPermissionPredicates({
         variables: {
           input: {


### PR DESCRIPTION
Split the upsertRowLevelPermissionPredicates call into two sequential operations:
1. First create/update predicate groups
2. Then create/update predicates that reference those groups

This prevents the error "Could not find rowLevelPermissionPredicateGroup for given rowLevelPermissionPredicateGroupId" when creating predicates that reference newly created groups in the same request.