### PR TITLE
Fix importing people with mixed-case domain URL failing to match company

### DIFF
--- a/packages/twenty-front/src/modules/object-record/spreadsheet-import/utils/buildRecordFromImportedStructuredRow.ts
+++ b/packages/twenty-front/src/modules/object-record/spreadsheet-import/utils/buildRecordFromImportedStructuredRow.ts
@@ -52,6 +52,9 @@ const buildRelationConnectFieldRecord = (
   fieldMetadataItem: FieldMetadataItem,
   importedStructuredRow: ImportedStructuredRow,
   spreadsheetImportFields: SpreadsheetImportFields,
+  compositeFieldTransformConfigs: Partial<
+    Record<FieldMetadataType, Record<string, ((value: any) => any) | undefined>>
+  >,
 ) => {
   if (fieldMetadataItem.relation?.type !== RelationType.MANY_TO_ONE)
     return undefined;
@@ -75,13 +78,10 @@ const buildRelationConnectFieldRecord = (
         isDefined(field.compositeSubFieldKey)
       ) {
         const rawValue = importedStructuredRow[field.key];
-        const isLinkUrlField =
-          uniqueFieldMetadataItem.type === FieldMetadataType.LINKS &&
-          field.compositeSubFieldKey === 'primaryLinkUrl' &&
-          typeof rawValue === 'string';
-        const value = isLinkUrlField
-          ? lowercaseUrlOriginAndRemoveTrailingSlash(rawValue)
-          : rawValue;
+        const transformConfig =
+          compositeFieldTransformConfigs[uniqueFieldMetadataItem.type];
+        const transform = transformConfig?.[field.compositeSubFieldKey];
+        const value = transform ? transform(rawValue) : rawValue;
 
         return {
           ...acc,
@@ -185,7 +185,7 @@ export const buildRecordFromImportedStructuredRow = ({
     },
     [FieldMetadataType.LINKS]: {
       primaryLinkLabel: castToString,
-      primaryLinkUrl: castToString,
+      primaryLinkUrl: lowercaseUrlOriginAndRemoveTrailingSlash,
       secondaryLinks: linkArrayJSONSchema.parse,
     },
 
@@ -316,6 +316,7 @@ export const buildRecordFromImportedStructuredRow = ({
           field,
           importedStructuredRow,
           spreadsheetImportFields,
+          COMPOSITE_FIELD_TRANSFORM_CONFIGS,
         );
         if (isDefined(relationConnectFieldValue)) {
           recordToBuild[field.name] = relationConnectFieldValue;

--- a/packages/twenty-front/src/modules/object-record/spreadsheet-import/utils/buildRecordFromImportedStructuredRow.ts
+++ b/packages/twenty-front/src/modules/object-record/spreadsheet-import/utils/buildRecordFromImportedStructuredRow.ts
@@ -12,6 +12,7 @@ import {
   assertUnreachable,
   isDefined,
   isEmptyObject,
+  lowercaseUrlOriginAndRemoveTrailingSlash,
 } from 'twenty-shared/utils';
 import { z } from 'zod';
 import { FieldMetadataType, RelationType } from '~/generated-metadata/graphql';
@@ -73,13 +74,22 @@ const buildRelationConnectFieldRecord = (
         isCompositeFieldType(uniqueFieldMetadataItem.type) &&
         isDefined(field.compositeSubFieldKey)
       ) {
+        const rawValue = importedStructuredRow[field.key];
+        const isLinkUrlField =
+          uniqueFieldMetadataItem.type === FieldMetadataType.LINKS &&
+          field.compositeSubFieldKey === 'primaryLinkUrl' &&
+          typeof rawValue === 'string';
+        const value = isLinkUrlField
+          ? lowercaseUrlOriginAndRemoveTrailingSlash(rawValue)
+          : rawValue;
+
         return {
           ...acc,
           [uniqueFieldMetadataItem.name]: {
             ...(isDefined(acc?.[uniqueFieldMetadataItem.name])
               ? acc[uniqueFieldMetadataItem.name]
               : {}),
-            [field.compositeSubFieldKey]: importedStructuredRow[field.key],
+            [field.compositeSubFieldKey]: value,
           },
         };
       }


### PR DESCRIPTION
Fix #17711 
### Reproduce steps
1. import this xlsx file [test-import.xlsx](https://github.com/user-attachments/files/25156642/test-import.xlsx)

2. import company worksheet at first and then import people worksheet
3. you will see an error  <img width="324" height="101" alt="Snipaste_2026-02-07_19-22-04" src="https://github.com/user-attachments/assets/bf2703da-a57a-4795-805b-6ddcc689c621" />

And I found neither the frontend nor the backend applies lowercase normalization to the query value. Although the standard UI input always displays company links in lowercase, user might mixed the case in their xlsx/csv bulk import. So I did a simple check in frontend.

### Additional findings:
1. Email has the same case sensitivity issue when opportunities import. You can test same as in test-import.xlsx file (I created a opportunities worksheet. It will have same issue: <img width="330" height="101" alt="email error" src="https://github.com/user-attachments/assets/db36b19b-2abe-4c61-a661-f8d1eb357a5e" />

2. API also has: I also tested via the GraphQL API Playground and confirmed that createOnePerson with a mixed-case URL fails to find an existing company.  <img width="1419" height="513" alt="Snipaste_2026-02-07_23-33-56" src="https://github.com/user-attachments/assets/c189f1fd-9793-42d5-a1a9-616cffd2592e" />

### Approach:
1. Only change it in frontend, and I will add email check later; (my current commit)
2. Or backend: Normalize values in computeUniqueConstraintCondition in twenty-server/src/engine/twenty-orm/utils/compute-relation-connect-query-configs.util.ts (which handles connect.where queries, and this will cover xlsx import and api import: createone, createmany, updatemany, updateone. And much better for future extension.

(Personally, I'd prefer the backend approach. But I'd love to hear your thoughts on which approach you'd prefer, and whether my analysis is on the right track.