### PR TITLE
Enforce SecureHttpClientService for outbound HTTP requests

### DIFF
--- a/packages/twenty-server/eslint.config.mjs
+++ b/packages/twenty-server/eslint.config.mjs
@@ -251,6 +251,42 @@ export default [
     },
   },
 
+  // Security: Restrict unsafe HTTP clients
+  {
+    files: ['**/*.ts'],
+    // Exclude the files that implement the security mechanism
+    ignores: [
+      '**/secure-http-client.service.ts',
+      '**/get-secure-axios-adapter.util.ts',
+      '**/*.spec.ts',
+    ],
+    rules: {
+      // Disable the base rule to avoid conflicts if it was enabled elsewhere
+      'no-restricted-imports': 'off',
+
+      '@typescript-eslint/no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: 'axios',
+              // Allow importing types (like AxiosInstance, AxiosError)
+              allowTypeImports: true,
+              message:
+                'Direct use of axios is unsafe against SSRF. Please inject SecureHttpClientService and use .getHttpClient().',
+            },
+            {
+              name: '@nestjs/axios',
+              importNames: ['HttpService'],
+              message:
+                'HttpService is not SSRF-safe by default. Please inject SecureHttpClientService instead.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+
   // Test files
   {
     files: [

--- a/packages/twenty-server/src/engine/core-modules/tool/services/secure-http-client.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool/services/secure-http-client.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 import axios, { type AxiosInstance } from 'axios';
 
-import { getSecureAdapter } from 'src/engine/core-modules/tool/utils/get-secure-axios-adapter.util';
+import { getSecureAxiosAdapter } from 'src/engine/core-modules/tool/utils/get-secure-axios-adapter.util';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 
 @Injectable()
@@ -15,7 +15,7 @@ export class SecureHttpClientService {
     );
 
     return isSafeModeEnabled
-      ? axios.create({ adapter: getSecureAdapter() })
+      ? axios.create({ adapter: getSecureAxiosAdapter() })
       : axios.create();
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/tool/tools/code-interpreter-tool/code-interpreter-tool.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool/tools/code-interpreter-tool/code-interpreter-tool.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { HttpService } from '@nestjs/axios';
 import { Injectable, Logger } from '@nestjs/common';
 
@@ -33,7 +34,7 @@ import {
   type Tool,
   type ToolExecutionContext,
 } from 'src/engine/core-modules/tool/types/tool.type';
-import { getSecureAdapter } from 'src/engine/core-modules/tool/utils/get-secure-axios-adapter.util';
+import { getSecureAxiosAdapter } from 'src/engine/core-modules/tool/utils/get-secure-axios-adapter.util';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import { AuthProviderEnum } from 'src/engine/core-modules/workspace/types/workspace.type';
 
@@ -277,7 +278,7 @@ export class CodeInterpreterTool implements Tool {
         // Allow requests to the server's own URL (for internal file downloads)
         // but block all other private/internal IPs to prevent SSRF attacks
         const isInternalFileUrl = file.url.startsWith(serverUrl);
-        const adapter = isInternalFileUrl ? undefined : getSecureAdapter();
+        const adapter = isInternalFileUrl ? undefined : getSecureAxiosAdapter();
 
         const response = await this.httpService.axiosRef.get(file.url, {
           responseType: 'arraybuffer',

--- a/packages/twenty-server/src/engine/core-modules/tool/tools/http-tool/http-tool.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool/tools/http-tool/http-tool.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import axios, { type AxiosRequestConfig } from 'axios';
 import { isDefined } from 'twenty-shared/utils';
 import { parseDataFromContentType } from 'twenty-shared/workflow';

--- a/packages/twenty-server/src/engine/core-modules/tool/tools/search-help-center-tool/search-help-center-tool.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool/tools/search-help-center-tool/search-help-center-tool.ts
@@ -1,7 +1,9 @@
 import { Injectable } from '@nestjs/common';
 
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import axios from 'axios';
 
+import { SecureHttpClientService } from 'src/engine/core-modules/tool/services/secure-http-client.service';
 import { SearchHelpCenterInputZodSchema } from 'src/engine/core-modules/tool/tools/search-help-center-tool/search-help-center-tool.schema';
 import { type ToolInput } from 'src/engine/core-modules/tool/types/tool-input.type';
 import { type ToolOutput } from 'src/engine/core-modules/tool/types/tool-output.type';
@@ -17,7 +19,10 @@ export class SearchHelpCenterTool implements Tool {
     'Search Twenty documentation and help center to find information about features, setup, usage, and troubleshooting.';
   inputSchema = SearchHelpCenterInputZodSchema;
 
-  constructor(private readonly twentyConfigService: TwentyConfigService) {}
+  constructor(
+    private readonly twentyConfigService: TwentyConfigService,
+    private readonly secureHttpClientService: SecureHttpClientService,
+  ) {}
 
   async execute(
     parameters: ToolInput,
@@ -41,11 +46,9 @@ export class SearchHelpCenterTool implements Tool {
         ...(useDirectApi && { Authorization: `Bearer ${MINTLIFY_API_KEY}` }),
       };
 
-      const response = await axios.post(
-        endpoint,
-        { query, pageSize: 10 },
-        { headers },
-      );
+      const response = await this.secureHttpClientService
+        .getHttpClient()
+        .post(endpoint, { query, pageSize: 10 }, { headers });
 
       const results = response.data;
 

--- a/packages/twenty-server/src/engine/core-modules/tool/utils/__tests__/get-secure-axios-adapter.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool/utils/__tests__/get-secure-axios-adapter.util.spec.ts
@@ -4,9 +4,9 @@ import * as https from 'https';
 import { AxiosHeaders, type InternalAxiosRequestConfig } from 'axios';
 
 import { type SecureAdapterDependencies } from 'src/engine/core-modules/tool/utils/get-secure-axios-adapter.types';
-import { getSecureAdapter } from 'src/engine/core-modules/tool/utils/get-secure-axios-adapter.util';
+import { getSecureAxiosAdapter } from 'src/engine/core-modules/tool/utils/get-secure-axios-adapter.util';
 
-describe('getSecureAdapter', () => {
+describe('getSecureAxiosAdapter', () => {
   let mockDnsLookup: jest.Mock;
   let mockHttpAdapter: jest.Mock;
   let dependencies: SecureAdapterDependencies;
@@ -22,14 +22,14 @@ describe('getSecureAdapter', () => {
 
   describe('URL validation', () => {
     it('should throw if URL is not provided', async () => {
-      const adapter = getSecureAdapter(dependencies);
+      const adapter = getSecureAxiosAdapter(dependencies);
       const config = { url: undefined } as InternalAxiosRequestConfig;
 
       await expect(adapter(config)).rejects.toThrow('URL is required');
     });
 
     it('should throw for non-http/https protocols', async () => {
-      const adapter = getSecureAdapter(dependencies);
+      const adapter = getSecureAxiosAdapter(dependencies);
       const config = {
         url: 'file:///etc/passwd',
       } as InternalAxiosRequestConfig;
@@ -40,7 +40,7 @@ describe('getSecureAdapter', () => {
     });
 
     it('should throw for ftp protocol', async () => {
-      const adapter = getSecureAdapter(dependencies);
+      const adapter = getSecureAxiosAdapter(dependencies);
       const config = {
         url: 'ftp://example.com/file',
       } as InternalAxiosRequestConfig;
@@ -56,7 +56,7 @@ describe('getSecureAdapter', () => {
         family: 4,
       });
 
-      const adapter = getSecureAdapter(dependencies);
+      const adapter = getSecureAxiosAdapter(dependencies);
       const config = {
         url: 'http://example.com',
         headers: new AxiosHeaders(),
@@ -73,7 +73,7 @@ describe('getSecureAdapter', () => {
         family: 4,
       });
 
-      const adapter = getSecureAdapter(dependencies);
+      const adapter = getSecureAxiosAdapter(dependencies);
       const config = {
         url: 'https://example.com',
         headers: new AxiosHeaders(),
@@ -89,7 +89,7 @@ describe('getSecureAdapter', () => {
     it('should block requests to 127.0.0.1', async () => {
       mockDnsLookup.mockResolvedValue({ address: '127.0.0.1', family: 4 });
 
-      const adapter = getSecureAdapter(dependencies);
+      const adapter = getSecureAxiosAdapter(dependencies);
       const config = {
         url: 'http://localhost',
         headers: new AxiosHeaders(),
@@ -103,7 +103,7 @@ describe('getSecureAdapter', () => {
     it('should block requests to 10.x.x.x range', async () => {
       mockDnsLookup.mockResolvedValue({ address: '10.0.0.1', family: 4 });
 
-      const adapter = getSecureAdapter(dependencies);
+      const adapter = getSecureAxiosAdapter(dependencies);
       const config = {
         url: 'http://internal.example.com',
         headers: new AxiosHeaders(),
@@ -117,7 +117,7 @@ describe('getSecureAdapter', () => {
     it('should block requests to 192.168.x.x range', async () => {
       mockDnsLookup.mockResolvedValue({ address: '192.168.1.1', family: 4 });
 
-      const adapter = getSecureAdapter(dependencies);
+      const adapter = getSecureAxiosAdapter(dependencies);
       const config = {
         url: 'http://router.local',
         headers: new AxiosHeaders(),
@@ -131,7 +131,7 @@ describe('getSecureAdapter', () => {
     it('should block requests to 172.16-31.x.x range', async () => {
       mockDnsLookup.mockResolvedValue({ address: '172.16.0.1', family: 4 });
 
-      const adapter = getSecureAdapter(dependencies);
+      const adapter = getSecureAxiosAdapter(dependencies);
       const config = {
         url: 'http://internal.corp',
         headers: new AxiosHeaders(),
@@ -148,7 +148,7 @@ describe('getSecureAdapter', () => {
         family: 4,
       });
 
-      const adapter = getSecureAdapter(dependencies);
+      const adapter = getSecureAxiosAdapter(dependencies);
       const config = {
         url: 'http://metadata.google.internal',
         headers: new AxiosHeaders(),
@@ -167,7 +167,7 @@ describe('getSecureAdapter', () => {
         family: 4,
       });
 
-      const adapter = getSecureAdapter(dependencies);
+      const adapter = getSecureAxiosAdapter(dependencies);
       const config = {
         url: 'https://example.com/api/data',
         headers: new AxiosHeaders(),
@@ -188,7 +188,7 @@ describe('getSecureAdapter', () => {
         family: 4,
       });
 
-      const adapter = getSecureAdapter(dependencies);
+      const adapter = getSecureAxiosAdapter(dependencies);
       const config = {
         url: 'https://example.com/api/data',
         headers: new AxiosHeaders(),
@@ -206,7 +206,7 @@ describe('getSecureAdapter', () => {
         family: 4,
       });
 
-      const adapter = getSecureAdapter(dependencies);
+      const adapter = getSecureAxiosAdapter(dependencies);
       const config = {
         url: 'http://example.com/api/data',
         headers: new AxiosHeaders(),
@@ -224,7 +224,7 @@ describe('getSecureAdapter', () => {
         family: 4,
       });
 
-      const adapter = getSecureAdapter(dependencies);
+      const adapter = getSecureAxiosAdapter(dependencies);
       const config = {
         url: 'https://example.com/api/data',
         headers: new AxiosHeaders(),
@@ -261,7 +261,7 @@ describe('getSecureAdapter', () => {
         family: 6,
       });
 
-      const adapter = getSecureAdapter(dependencies);
+      const adapter = getSecureAxiosAdapter(dependencies);
       const config = {
         url: 'https://example.com/api/data',
         headers: new AxiosHeaders(),
@@ -295,7 +295,7 @@ describe('getSecureAdapter', () => {
         family: 4,
       });
 
-      const adapter = getSecureAdapter(dependencies);
+      const adapter = getSecureAxiosAdapter(dependencies);
       const config = {
         url: 'https://example.com/api?foo=bar&baz=qux',
         headers: new AxiosHeaders(),
@@ -316,7 +316,7 @@ describe('getSecureAdapter', () => {
         family: 4,
       });
 
-      const adapter = getSecureAdapter(dependencies);
+      const adapter = getSecureAxiosAdapter(dependencies);
       const config = {
         url: 'https://example.com:8443/api',
         headers: new AxiosHeaders(),
@@ -336,7 +336,7 @@ describe('getSecureAdapter', () => {
     it('should allow requests to public IP addresses', async () => {
       mockDnsLookup.mockResolvedValue({ address: '8.8.8.8', family: 4 });
 
-      const adapter = getSecureAdapter(dependencies);
+      const adapter = getSecureAxiosAdapter(dependencies);
       const config = {
         url: 'https://dns.google',
         headers: new AxiosHeaders(),
@@ -353,7 +353,7 @@ describe('getSecureAdapter', () => {
         family: 4,
       });
 
-      const adapter = getSecureAdapter(dependencies);
+      const adapter = getSecureAxiosAdapter(dependencies);
       const config = {
         url: 'https://example.com',
         headers: new AxiosHeaders(),
@@ -372,7 +372,7 @@ describe('getSecureAdapter', () => {
         family: 4,
       });
 
-      const adapter = getSecureAdapter(dependencies);
+      const adapter = getSecureAxiosAdapter(dependencies);
       const config = {
         url: 'https://user:pass@example.com/api',
         headers: new AxiosHeaders(),
@@ -393,7 +393,7 @@ describe('getSecureAdapter', () => {
         family: 4,
       });
 
-      const adapter = getSecureAdapter(dependencies);
+      const adapter = getSecureAxiosAdapter(dependencies);
       const config = {
         url: 'https://example.com/page#section',
         headers: new AxiosHeaders(),
@@ -410,7 +410,7 @@ describe('getSecureAdapter', () => {
         family: 4,
       });
 
-      const adapter = getSecureAdapter(dependencies);
+      const adapter = getSecureAxiosAdapter(dependencies);
       const config = {
         url: 'https://example.com',
         headers: undefined,
@@ -428,7 +428,7 @@ describe('getSecureAdapter', () => {
         family: 4,
       });
 
-      const adapter = getSecureAdapter(dependencies);
+      const adapter = getSecureAxiosAdapter(dependencies);
       const config = {
         url: 'https://example.com',
         headers: { 'Content-Type': 'application/json' },

--- a/packages/twenty-server/src/engine/core-modules/tool/utils/get-secure-axios-adapter.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool/utils/get-secure-axios-adapter.util.ts
@@ -17,7 +17,7 @@ const defaultDependencies: SecureAdapterDependencies = {
   httpAdapter: axios.getAdapter('http'),
 };
 
-export const getSecureAdapter = (
+export const getSecureAxiosAdapter = (
   dependencies: SecureAdapterDependencies = defaultDependencies,
 ): AxiosAdapter => {
   const { dnsLookup, httpAdapter } = dependencies;


### PR DESCRIPTION
## Summary

- Adds an ESLint rule (`@typescript-eslint/no-restricted-imports`) to flag direct `axios` and `@nestjs/axios` `HttpService` imports, guiding developers toward `SecureHttpClientService` for outbound HTTP requests
- Renames `getSecureAdapter` to `getSecureAxiosAdapter` for clarity
- Migrates `SearchHelpCenterTool` to use `SecureHttpClientService` instead of raw `axios.post()`
- Adds targeted `eslint-disable` comments for legitimate uses (e.g. `axios.isAxiosError()` type guards, `HttpService` in code-interpreter where per-request adapter control is needed)

## Test plan

- [x] Existing unit tests for `getSecureAxiosAdapter` updated with the rename
- [ ] Verify lint rule triggers on new files importing axios directly
- [ ] Verify `SearchHelpCenterTool` still works with secure client


Made with [Cursor](https://cursor.com)