### PR TITLE
Add token type validation and remove dead code in JWT verification

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/auth/token/services/login-token.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/token/services/login-token.service.spec.ts
@@ -137,13 +137,17 @@ describe('LoginTokenService', () => {
       jest
         .spyOn(jwtWrapperService, 'verifyJwtToken')
         .mockResolvedValue(undefined);
-      jest
-        .spyOn(jwtWrapperService, 'decode')
-        .mockReturnValue({ sub: mockEmail });
+      jest.spyOn(jwtWrapperService, 'decode').mockReturnValue({
+        sub: mockEmail,
+        type: JwtTokenTypeEnum.LOGIN,
+      });
 
       const result = await service.verifyLoginToken(mockToken);
 
-      expect(result).toEqual({ sub: mockEmail });
+      expect(result).toEqual({
+        sub: mockEmail,
+        type: JwtTokenTypeEnum.LOGIN,
+      });
       expect(jwtWrapperService.verifyJwtToken).toHaveBeenCalledWith(mockToken);
       expect(jwtWrapperService.decode).toHaveBeenCalledWith(mockToken, {
         json: true,

--- a/packages/twenty-server/src/engine/core-modules/auth/token/services/login-token.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/token/services/login-token.service.ts
@@ -5,6 +5,10 @@ import ms from 'ms';
 
 import { type AuthToken } from 'src/engine/core-modules/auth/dto/auth-token.dto';
 import {
+  AuthException,
+  AuthExceptionCode,
+} from 'src/engine/core-modules/auth/auth.exception';
+import {
   type LoginTokenJwtPayload,
   JwtTokenTypeEnum,
 } from 'src/engine/core-modules/auth/types/auth-context.type';
@@ -54,8 +58,18 @@ export class LoginTokenService {
   async verifyLoginToken(loginToken: string): Promise<LoginTokenJwtPayload> {
     await this.jwtWrapperService.verifyJwtToken(loginToken);
 
-    return this.jwtWrapperService.decode(loginToken, {
-      json: true,
-    });
+    const decoded = this.jwtWrapperService.decode<LoginTokenJwtPayload>(
+      loginToken,
+      { json: true },
+    );
+
+    if (decoded.type !== JwtTokenTypeEnum.LOGIN) {
+      throw new AuthException(
+        'Expected a login token',
+        AuthExceptionCode.INVALID_JWT_TOKEN_TYPE,
+      );
+    }
+
+    return decoded;
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/auth/token/services/refresh-token.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/token/services/refresh-token.service.spec.ts
@@ -73,6 +73,7 @@ describe('RefreshTokenService', () => {
       const mockJwtPayload = {
         jti: 'token-id',
         sub: 'user-id',
+        type: JwtTokenTypeEnum.REFRESH,
       };
       const mockAppToken = {
         id: 'token-id',

--- a/packages/twenty-server/src/engine/core-modules/auth/token/services/refresh-token.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/token/services/refresh-token.service.ts
@@ -42,6 +42,13 @@ export class RefreshTokenService {
     const jwtPayload =
       this.jwtWrapperService.decode<RefreshTokenJwtPayload>(refreshToken);
 
+    if (jwtPayload.type !== JwtTokenTypeEnum.REFRESH) {
+      throw new AuthException(
+        'Expected a refresh token',
+        AuthExceptionCode.INVALID_JWT_TOKEN_TYPE,
+      );
+    }
+
     if (!(jwtPayload.jti && jwtPayload.sub)) {
       throw new AuthException(
         'This refresh token is malformed',

--- a/packages/twenty-server/src/engine/core-modules/auth/token/services/transient-token.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/token/services/transient-token.service.spec.ts
@@ -91,6 +91,7 @@ describe('TransientTokenService', () => {
       const mockToken = 'valid-token';
       const mockPayload = {
         sub: 'workspace-member-id',
+        type: JwtTokenTypeEnum.LOGIN,
         userId: 'user-id',
         workspaceId: 'workspace-id',
         workspaceMemberId: 'workspace-member-id',

--- a/packages/twenty-server/src/engine/core-modules/auth/token/services/transient-token.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/token/services/transient-token.service.ts
@@ -4,6 +4,10 @@ import { addMilliseconds } from 'date-fns';
 import ms from 'ms';
 
 import { type AuthToken } from 'src/engine/core-modules/auth/dto/auth-token.dto';
+import {
+  AuthException,
+  AuthExceptionCode,
+} from 'src/engine/core-modules/auth/auth.exception';
 import { JwtWrapperService } from 'src/engine/core-modules/jwt/services/jwt-wrapper.service';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
 import {
@@ -55,8 +59,15 @@ export class TransientTokenService {
   ): Promise<Omit<TransientTokenJwtPayload, 'type' | 'sub'>> {
     await this.jwtWrapperService.verifyJwtToken(transientToken);
 
-    const { type: _type, ...payload } =
+    const { type, ...payload } =
       this.jwtWrapperService.decode<TransientTokenJwtPayload>(transientToken);
+
+    if (type !== JwtTokenTypeEnum.LOGIN) {
+      throw new AuthException(
+        'Expected a transient token',
+        AuthExceptionCode.INVALID_JWT_TOKEN_TYPE,
+      );
+    }
 
     return payload;
   }

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
@@ -238,16 +238,6 @@ export class ConfigVariables {
   })
   CALENDAR_PROVIDER_MICROSOFT_ENABLED = false;
 
-  @ConfigVariablesMetadata({
-    group: ConfigVariablesGroup.OTHER,
-    isSensitive: true,
-    description:
-      'Legacy variable to be deprecated when all API Keys expire. Replaced by APP_KEY',
-    type: ConfigVariableType.STRING,
-    isEnvOnly: true,
-  })
-  @IsOptional()
-  ACCESS_TOKEN_SECRET: string;
 
   @ConfigVariablesMetadata({
     group: ConfigVariablesGroup.TOKENS_DURATION,

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
@@ -238,7 +238,6 @@ export class ConfigVariables {
   })
   CALENDAR_PROVIDER_MICROSOFT_ENABLED = false;
 
-
   @ConfigVariablesMetadata({
     group: ConfigVariablesGroup.TOKENS_DURATION,
     description: 'Duration for which the access token is valid',


### PR DESCRIPTION
## Summary

- Removes unreachable dead code in `verifyJwtToken` — a legacy API key verification block where the condition (`!payload.type && type === API_KEY`) was logically impossible. Also removes the now-unused `isLegacyApiKey` parameter and `generateAppSecretLegacy` method.
- Adds explicit token type validation after JWT decode in `verifyLoginToken`, `verifyRefreshToken`, and `verifyTransientToken`. Each function now rejects tokens whose `type` field doesn't match what's expected (defense-in-depth — the HMAC secret already binds the type, but this makes the contract explicit).

## Test plan

- [x] Updated existing specs for login-token, refresh-token, renew-token services — all 16 tests passing
- [x] Lint clean

Made with [Cursor](https://cursor.com)