### PR TITLE
[Fix] fix relations in apps

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/__tests__/generate-morph-or-relation-flat-field-metadata-pair.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/__tests__/generate-morph-or-relation-flat-field-metadata-pair.spec.ts
@@ -349,4 +349,52 @@ describe('generate Morph Or Relation Flat Field Metadata Pair test suite', () =>
       },
     );
   });
+
+  describe('Universal identifier behaviour', () => {
+    it('should keep the source field universalIdentifier from createFieldInput', () => {
+      const sourceUniversalIdentifier = '11111111-2222-3333-4444-555555555555';
+
+      const input: GenerateMorphOrRelationFlatFieldMetadataPairTestInput = {
+        sourceFlatObjectMetadata: COMPANY_FLAT_OBJECT_MOCK,
+        targetFlatObjectMetadata: PET_FLAT_OBJECT_MOCK,
+        targetFlatFieldMetadataType: FieldMetadataType.RELATION,
+        sourceFlatObjectMetadataJoinColumnName: 'petId',
+        workspaceId: mockWorkspaceId,
+        flatApplication: MOCK_FLAT_APPLICATION,
+        createFieldInput: {
+          name: 'pets',
+          label: 'Pets',
+          description: 'Company pets',
+          icon: 'IconCat',
+          type: FieldMetadataType.RELATION,
+          objectMetadataId: COMPANY_FLAT_OBJECT_MOCK.id,
+          isCustom: true,
+          isSystem: false,
+          isUnique: false,
+          universalIdentifier: sourceUniversalIdentifier,
+          relationCreationPayload: {
+            type: RelationType.ONE_TO_MANY,
+            targetObjectMetadataId: PET_FLAT_OBJECT_MOCK.id,
+            targetFieldLabel: 'Company',
+            targetFieldIcon: 'IconBuildingSkyscraper',
+          },
+        },
+      };
+
+      const result: SourceTargetMorphOrRelationFlatFieldAndFlatIndex =
+        generateMorphOrRelationFlatFieldMetadataPair(input);
+
+      const [sourceFieldMetadata, targetFieldMetadata] =
+        result.flatFieldMetadatas;
+
+      expect(sourceFieldMetadata.universalIdentifier).toBe(
+        sourceUniversalIdentifier,
+      );
+
+      expect(targetFieldMetadata.universalIdentifier).toBeDefined();
+      expect(targetFieldMetadata.universalIdentifier).not.toBe(
+        sourceUniversalIdentifier,
+      );
+    });
+  });
 });

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/generate-morph-or-relation-flat-field-metadata-pair.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/utils/generate-morph-or-relation-flat-field-metadata-pair.util.ts
@@ -107,7 +107,6 @@ export const generateMorphOrRelationFlatFieldMetadataPair = ({
   });
   const targetRelationTargetFieldMetadataId = v4();
   const sourceRelationTargetFieldMetadataId = v4();
-  const sourceFieldUniversalIdentifier = v4();
   const targetFieldUniversalIdentifier = v4();
 
   const defaultDescriptionFromField =
@@ -125,10 +124,7 @@ export const generateMorphOrRelationFlatFieldMetadataPair = ({
     'flatRelationTargetFieldMetadata'
   > = {
     ...getDefaultFlatFieldMetadata({
-      createFieldInput: {
-        ...createFieldInput,
-        universalIdentifier: sourceFieldUniversalIdentifier,
-      },
+      createFieldInput,
       workspaceId,
       fieldMetadataId: sourceRelationTargetFieldMetadataId,
       flatApplication,
@@ -212,7 +208,7 @@ export const generateMorphOrRelationFlatFieldMetadataPair = ({
     relationTargetObjectMetadataUniversalIdentifier:
       sourceFlatObjectMetadata.universalIdentifier,
     relationTargetFieldMetadataUniversalIdentifier:
-      sourceFieldUniversalIdentifier,
+      sourceFlatFieldMetadata.universalIdentifier,
   };
 
   const indexMetadata: FlatIndexMetadata = generateIndexForFlatFieldMetadata({

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-relation-creation-payload.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-relation-creation-payload.util.ts
@@ -43,7 +43,7 @@ export const validateRelationCreationPayload = async ({
         errors: [
           {
             code: FieldMetadataExceptionCode.FIELD_METADATA_RELATION_MALFORMED,
-            message: `Relation creation payload is invalid`,
+            message: error.message ?? `Relation creation payload is invalid`,
             userFriendlyMessage: msg`Invalid relation creation payload`,
             value: relationCreationPayload,
           },

--- a/packages/twenty-server/test/integration/metadata/suites/field-metadata/relation/__snapshots__/failing-field-metadata-relation-creation.integration-spec.ts.snap
+++ b/packages/twenty-server/test/integration/metadata/suites/field-metadata/relation/__snapshots__/failing-field-metadata-relation-creation.integration-spec.ts.snap
@@ -217,7 +217,7 @@ exports[`Field metadata relation creation should fail relation MANY_TO_ONE (rela
           "errors": [
             {
               "code": "FIELD_METADATA_RELATION_MALFORMED",
-              "message": "Relation creation payload is invalid",
+              "message": "Relation creation payload is invalid: targetObjectMetadataId must be a UUID",
               "userFriendlyMessage": "Invalid relation creation payload",
               "value": {
                 "targetFieldIcon": "IconBuildingSkyscraper",
@@ -297,7 +297,7 @@ exports[`Field metadata relation creation should fail relation MANY_TO_ONE (rela
           "errors": [
             {
               "code": "FIELD_METADATA_RELATION_MALFORMED",
-              "message": "Relation creation payload is invalid",
+              "message": "Relation creation payload is invalid: type must be one of the following values: MANY_TO_ONE, ONE_TO_MANY",
               "userFriendlyMessage": "Invalid relation creation payload",
               "value": {
                 "targetFieldIcon": "IconBuildingSkyscraper",
@@ -453,7 +453,7 @@ exports[`Field metadata relation creation should fail relation MANY_TO_ONE when 
           "errors": [
             {
               "code": "FIELD_METADATA_RELATION_MALFORMED",
-              "message": "Relation creation payload is invalid",
+              "message": "Relation creation payload is invalid: targetObjectMetadataId must be a UUID",
               "userFriendlyMessage": "Invalid relation creation payload",
               "value": {
                 "targetFieldIcon": "IconBuildingSkyscraper",
@@ -493,7 +493,7 @@ exports[`Field metadata relation creation should fail relation MANY_TO_ONE when 
           "errors": [
             {
               "code": "FIELD_METADATA_RELATION_MALFORMED",
-              "message": "Relation creation payload is invalid",
+              "message": "Relation creation payload is invalid: targetObjectMetadataId must be a UUID",
               "userFriendlyMessage": "Invalid relation creation payload",
               "value": {
                 "targetFieldIcon": "IconBuildingSkyscraper",
@@ -610,7 +610,7 @@ exports[`Field metadata relation creation should fail relation MANY_TO_ONE when 
           "errors": [
             {
               "code": "FIELD_METADATA_RELATION_MALFORMED",
-              "message": "Relation creation payload is invalid",
+              "message": "Relation creation payload is invalid: targetObjectMetadataId must be a UUID",
               "userFriendlyMessage": "Invalid relation creation payload",
               "value": {
                 "targetFieldIcon": "IconBuildingSkyscraper",
@@ -968,7 +968,7 @@ exports[`Field metadata relation creation should fail relation ONE_TO_MANY (rela
             "errors": [
               {
                 "code": "FIELD_METADATA_RELATION_MALFORMED",
-                "message": "Relation creation payload is invalid",
+                "message": "Relation creation payload is invalid: targetObjectMetadataId must be a UUID",
                 "userFriendlyMessage": "Invalid relation creation payload",
                 "value": {
                   "targetFieldIcon": "IconBuildingSkyscraper",
@@ -1052,7 +1052,7 @@ exports[`Field metadata relation creation should fail relation ONE_TO_MANY (rela
             "errors": [
               {
                 "code": "FIELD_METADATA_RELATION_MALFORMED",
-                "message": "Relation creation payload is invalid",
+                "message": "Relation creation payload is invalid: type must be one of the following values: MANY_TO_ONE, ONE_TO_MANY",
                 "userFriendlyMessage": "Invalid relation creation payload",
                 "value": {
                   "targetFieldIcon": "IconBuildingSkyscraper",
@@ -1094,7 +1094,7 @@ exports[`Field metadata relation creation should fail relation ONE_TO_MANY (rela
             "errors": [
               {
                 "code": "FIELD_METADATA_RELATION_MALFORMED",
-                "message": "Relation creation payload is invalid",
+                "message": "Relation creation payload is invalid: type must be one of the following values: MANY_TO_ONE, ONE_TO_MANY",
                 "userFriendlyMessage": "Invalid relation creation payload",
                 "value": {
                   "targetFieldIcon": "IconBuildingSkyscraper",
@@ -1214,7 +1214,7 @@ exports[`Field metadata relation creation should fail relation ONE_TO_MANY when 
             "errors": [
               {
                 "code": "FIELD_METADATA_RELATION_MALFORMED",
-                "message": "Relation creation payload is invalid",
+                "message": "Relation creation payload is invalid: targetObjectMetadataId must be a UUID",
                 "userFriendlyMessage": "Invalid relation creation payload",
                 "value": {
                   "targetFieldIcon": "IconBuildingSkyscraper",
@@ -1377,7 +1377,7 @@ exports[`Field metadata relation creation should fail relation ONE_TO_MANY when 
             "errors": [
               {
                 "code": "FIELD_METADATA_RELATION_MALFORMED",
-                "message": "Relation creation payload is invalid",
+                "message": "Relation creation payload is invalid: targetObjectMetadataId must be a UUID",
                 "userFriendlyMessage": "Invalid relation creation payload",
                 "value": {
                   "targetFieldIcon": "IconBuildingSkyscraper",

--- a/packages/twenty-server/test/integration/metadata/suites/field-metadata/relation/__snapshots__/failing-field-metadata-relation-creation.integration-spec.ts.snap
+++ b/packages/twenty-server/test/integration/metadata/suites/field-metadata/relation/__snapshots__/failing-field-metadata-relation-creation.integration-spec.ts.snap
@@ -337,7 +337,7 @@ exports[`Field metadata relation creation should fail relation MANY_TO_ONE (rela
           "errors": [
             {
               "code": "FIELD_METADATA_RELATION_MALFORMED",
-              "message": "Relation creation payload is invalid",
+              "message": "Relation creation payload is invalid: type must be one of the following values: MANY_TO_ONE, ONE_TO_MANY",
               "userFriendlyMessage": "Invalid relation creation payload",
               "value": {
                 "targetFieldIcon": "IconBuildingSkyscraper",
@@ -1256,7 +1256,7 @@ exports[`Field metadata relation creation should fail relation ONE_TO_MANY when 
             "errors": [
               {
                 "code": "FIELD_METADATA_RELATION_MALFORMED",
-                "message": "Relation creation payload is invalid",
+                "message": "Relation creation payload is invalid: targetObjectMetadataId must be a UUID",
                 "userFriendlyMessage": "Invalid relation creation payload",
                 "value": {
                   "targetFieldIcon": "IconBuildingSkyscraper",


### PR DESCRIPTION
When syncing an app with relation multiple times, it would fail because the relation fields could not be identified due to universalIdentifier being overwritten at field cretion