### PR TITLE
fix: set a margin even for empty side-column widgets

### DIFF
--- a/packages/twenty-front/src/modules/page-layout/widgets/widget-card/components/WidgetCardContent.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/widget-card/components/WidgetCardContent.tsx
@@ -13,13 +13,25 @@ const StyledWidgetCardContent = styled.div<{
   height: 100%;
   overflow: hidden;
 
-  ${({ theme, hasHeader }) =>
-    hasHeader &&
-    css`
-      :not(:empty) {
+  ${({ theme, variant, isEditable, hasHeader }) => {
+    if (!hasHeader) {
+      return;
+    }
+
+    if (variant === 'side-column' && !isEditable) {
+      return css`
         margin-top: ${theme.spacing(2)};
-      }
-    `}
+
+        :empty {
+          margin-top: 0;
+        }
+      `;
+    }
+
+    return css`
+      margin-top: ${theme.spacing(2)};
+    `;
+  }}
 
   ${({ theme, variant, isEditable }) => {
     if (variant === 'dashboard') {


### PR DESCRIPTION
| | Read | Edit |
|--------|--------|--------|
| **Before** | <img width="762" height="2144" alt="CleanShot 2026-02-09 at 16 07 06@2x" src="https://github.com/user-attachments/assets/d93b5928-2c7b-438a-b16a-d17a434276fc" /> | <img width="762" height="2144" alt="CleanShot 2026-02-09 at 16 07 01@2x" src="https://github.com/user-attachments/assets/c5fb94db-947d-4832-9bc2-7942faa290eb" /> |
| **After** | <img width="762" height="2144" alt="CleanShot 2026-02-09 at 16 06 33@2x" src="https://github.com/user-attachments/assets/761352f3-cf18-4f41-98f0-fb0b4367f486" /> | <img width="762" height="2144" alt="CleanShot 2026-02-09 at 16 06 41@2x" src="https://github.com/user-attachments/assets/d1780671-1043-4087-860c-020343fcda87" /> | 


Closes https://github.com/twentyhq/core-team-issues/issues/2193