### PR TITLE
fix: show user-friendly error message when duplicate invite is sent

### DIFF
--- a/packages/twenty-front/src/modules/workspace/components/WorkspaceInviteTeam.tsx
+++ b/packages/twenty-front/src/modules/workspace/components/WorkspaceInviteTeam.tsx
@@ -86,7 +86,11 @@ export const WorkspaceInviteTeam = () => {
   const submit = handleSubmit(async ({ emails }) => {
     const emailsList = sanitizeEmailList(emails.split(','));
     const { data } = await sendInvitation({ emails: emailsList });
-    if (isDefined(data) && data.sendInvitations.result.length > 0) {
+    if (!isDefined(data)) {
+      return;
+    }
+
+    if (data.sendInvitations.result.length > 0) {
       const invitationCount = data.sendInvitations.result.length;
       enqueueSuccessSnackBar({
         message: t`${invitationCount} invitations sent`,
@@ -94,10 +98,13 @@ export const WorkspaceInviteTeam = () => {
           duration: 2000,
         },
       });
+
       return;
     }
-    if (isDefined(data) && !data.sendInvitations.success) {
+
+    if (!data.sendInvitations.success) {
       enqueueErrorSnackBar({
+        message: data.sendInvitations.errors.join(', '),
         options: {
           duration: 5000,
         },

--- a/packages/twenty-server/src/engine/core-modules/workspace-invitation/services/workspace-invitation.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace-invitation/services/workspace-invitation.service.ts
@@ -36,6 +36,7 @@ import {
 } from 'src/engine/core-modules/workspace-invitation/workspace-invitation.exception';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
+import { CustomException } from 'src/utils/custom-exception';
 
 @Injectable()
 export class WorkspaceInvitationService {
@@ -357,6 +358,8 @@ export class WorkspaceInvitationService {
       value: true,
     });
 
+    const i18n = this.i18nService.getI18nInstance(sender.locale);
+
     const result = invitationsPr.reduce<{
       errors: string[];
       result: ReturnType<
@@ -369,7 +372,13 @@ export class WorkspaceInvitationService {
     }>(
       (acc, invitation) => {
         if (invitation.status === 'rejected') {
-          acc.errors.push(invitation.reason?.message ?? 'Unknown error');
+          const reason = invitation.reason;
+
+          if (reason instanceof CustomException && reason.userFriendlyMessage) {
+            acc.errors.push(i18n._(reason.userFriendlyMessage));
+          } else {
+            acc.errors.push(reason?.message ?? 'Unknown error');
+          }
         } else {
           acc.result.push(
             invitation.value.isPersonalInvitation


### PR DESCRIPTION
Fixes #17822

Generated with [Claude Code](https://claude.ai/code)