### PR TITLE
Migrate all remaining workspace migration create action to universal

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/types/all-flat-entity-types-by-metadata-name.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/types/all-flat-entity-types-by-metadata-name.ts
@@ -41,15 +41,28 @@ import { type FlatRowLevelPermissionPredicateGroupMaps } from 'src/engine/metada
 import { type FlatRowLevelPermissionPredicateGroup } from 'src/engine/metadata-modules/row-level-permission-predicate/types/flat-row-level-permission-predicate-group.type';
 import { type FlatRowLevelPermissionPredicateMaps } from 'src/engine/metadata-modules/row-level-permission-predicate/types/flat-row-level-permission-predicate-maps.type';
 import { type FlatRowLevelPermissionPredicate } from 'src/engine/metadata-modules/row-level-permission-predicate/types/flat-row-level-permission-predicate.type';
+import { type UniversalFlatAgent } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-agent.type';
+import { type UniversalFlatCommandMenuItem } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-command-menu-item.type';
 import { type UniversalFlatEntityFrom } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-entity-from.type';
+import { type UniversalFlatFrontComponent } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-front-component.type';
 import { type UniversalFlatIndexMetadata } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-index-metadata.type';
+import { type UniversalFlatLogicFunction } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-logic-function.type';
+import { type UniversalFlatNavigationMenuItem } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-navigation-menu-item.type';
 import { type UniversalFlatObjectMetadata } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-object-metadata.type';
+import { type UniversalFlatPageLayout } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout.type';
+import { type UniversalFlatPageLayoutTab } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-tab.type';
+import { type UniversalFlatPageLayoutWidget } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type';
+import { type UniversalFlatRole } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-role.type';
+import { type UniversalFlatRoleTarget } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-role-target.type';
+import { type UniversalFlatRowLevelPermissionPredicate } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-row-level-permission-predicate.type';
+import { type UniversalFlatRowLevelPermissionPredicateGroup } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-row-level-permission-predicate-group.type';
 import { type UniversalFlatSkill } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-skill.type';
 import { type UniversalFlatViewField } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-view-field.type';
 import { type UniversalFlatViewFilterGroup } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-view-filter-group.type';
 import { type UniversalFlatViewFilter } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-view-filter.type';
 import { type UniversalFlatViewGroup } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-view-group.type';
 import { type UniversalFlatView } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-view.type';
+import { type UniversalFlatWebhook } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-webhook.type';
 import {
   type FlatCreateAgentAction,
   type FlatDeleteAgentAction,
@@ -324,7 +337,7 @@ export type AllFlatEntityTypesByMetadataName = {
       delete: FlatDeleteRowLevelPermissionPredicateAction;
     };
     flatEntity: FlatRowLevelPermissionPredicate;
-    universalFlatEntity: FlatRowLevelPermissionPredicate;
+    universalFlatEntity: UniversalFlatRowLevelPermissionPredicate;
     entity: MetadataEntity<'rowLevelPermissionPredicate'>;
   };
   rowLevelPermissionPredicateGroup: {
@@ -340,7 +353,7 @@ export type AllFlatEntityTypesByMetadataName = {
       delete: FlatDeleteRowLevelPermissionPredicateGroupAction;
     };
     flatEntity: FlatRowLevelPermissionPredicateGroup;
-    universalFlatEntity: FlatRowLevelPermissionPredicateGroup;
+    universalFlatEntity: UniversalFlatRowLevelPermissionPredicateGroup;
     entity: MetadataEntity<'rowLevelPermissionPredicateGroup'>;
   };
   viewFilterGroup: {
@@ -388,7 +401,7 @@ export type AllFlatEntityTypesByMetadataName = {
       delete: FlatDeleteLogicFunctionAction;
     };
     flatEntity: FlatLogicFunction;
-    universalFlatEntity: FlatLogicFunction;
+    universalFlatEntity: UniversalFlatLogicFunction;
     entity: MetadataEntity<'logicFunction'>;
   };
   viewFilter: {
@@ -420,7 +433,7 @@ export type AllFlatEntityTypesByMetadataName = {
       delete: FlatDeleteRoleAction;
     };
     flatEntity: FlatRole;
-    universalFlatEntity: FlatRole;
+    universalFlatEntity: UniversalFlatRole;
     entity: MetadataEntity<'role'>;
   };
   roleTarget: {
@@ -436,7 +449,7 @@ export type AllFlatEntityTypesByMetadataName = {
       delete: FlatDeleteRoleTargetAction;
     };
     flatEntity: FlatRoleTarget;
-    universalFlatEntity: FlatRoleTarget;
+    universalFlatEntity: UniversalFlatRoleTarget;
     entity: MetadataEntity<'roleTarget'>;
   };
   agent: {
@@ -452,7 +465,7 @@ export type AllFlatEntityTypesByMetadataName = {
       delete: FlatDeleteAgentAction;
     };
     flatEntity: FlatAgent;
-    universalFlatEntity: FlatAgent;
+    universalFlatEntity: UniversalFlatAgent;
     entity: MetadataEntity<'agent'>;
   };
   skill: {
@@ -484,7 +497,7 @@ export type AllFlatEntityTypesByMetadataName = {
       delete: FlatDeleteCommandMenuItemAction;
     };
     flatEntity: FlatCommandMenuItem;
-    universalFlatEntity: FlatCommandMenuItem;
+    universalFlatEntity: UniversalFlatCommandMenuItem;
     entity: MetadataEntity<'commandMenuItem'>;
   };
   navigationMenuItem: {
@@ -500,7 +513,7 @@ export type AllFlatEntityTypesByMetadataName = {
       delete: FlatDeleteNavigationMenuItemAction;
     };
     flatEntity: FlatNavigationMenuItem;
-    universalFlatEntity: FlatNavigationMenuItem;
+    universalFlatEntity: UniversalFlatNavigationMenuItem;
     entity: NavigationMenuItemEntity;
   };
   pageLayout: {
@@ -516,7 +529,7 @@ export type AllFlatEntityTypesByMetadataName = {
       delete: FlatDeletePageLayoutAction;
     };
     flatEntity: FlatPageLayout;
-    universalFlatEntity: FlatPageLayout;
+    universalFlatEntity: UniversalFlatPageLayout;
     entity: MetadataEntity<'pageLayout'>;
   };
   pageLayoutWidget: {
@@ -532,7 +545,7 @@ export type AllFlatEntityTypesByMetadataName = {
       delete: FlatDeletePageLayoutWidgetAction;
     };
     flatEntity: FlatPageLayoutWidget;
-    universalFlatEntity: FlatPageLayoutWidget;
+    universalFlatEntity: UniversalFlatPageLayoutWidget;
     entity: MetadataEntity<'pageLayoutWidget'>;
   };
   pageLayoutTab: {
@@ -548,7 +561,7 @@ export type AllFlatEntityTypesByMetadataName = {
       delete: FlatDeletePageLayoutTabAction;
     };
     flatEntity: FlatPageLayoutTab;
-    universalFlatEntity: FlatPageLayoutTab;
+    universalFlatEntity: UniversalFlatPageLayoutTab;
     entity: MetadataEntity<'pageLayoutTab'>;
   };
   frontComponent: {
@@ -564,7 +577,7 @@ export type AllFlatEntityTypesByMetadataName = {
       delete: FlatDeleteFrontComponentAction;
     };
     flatEntity: FlatFrontComponent;
-    universalFlatEntity: FlatFrontComponent;
+    universalFlatEntity: UniversalFlatFrontComponent;
     entity: MetadataEntity<'frontComponent'>;
   };
   webhook: {
@@ -580,7 +593,7 @@ export type AllFlatEntityTypesByMetadataName = {
       delete: FlatDeleteWebhookAction;
     };
     flatEntity: FlatWebhook;
-    universalFlatEntity: FlatWebhook;
+    universalFlatEntity: UniversalFlatWebhook;
     entity: MetadataEntity<'webhook'>;
   };
 };

--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/types/all-flat-entity-types-by-metadata-name.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/types/all-flat-entity-types-by-metadata-name.ts
@@ -54,6 +54,7 @@ import {
   type FlatCreateAgentAction,
   type FlatDeleteAgentAction,
   type FlatUpdateAgentAction,
+  type UniversalCreateAgentAction,
   type UniversalDeleteAgentAction,
   type UniversalUpdateAgentAction,
 } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/agent/types/workspace-migration-agent-action-builder.service';
@@ -61,6 +62,7 @@ import {
   type FlatCreateCommandMenuItemAction,
   type FlatDeleteCommandMenuItemAction,
   type FlatUpdateCommandMenuItemAction,
+  type UniversalCreateCommandMenuItemAction,
   type UniversalDeleteCommandMenuItemAction,
   type UniversalUpdateCommandMenuItemAction,
 } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/command-menu-item/types/workspace-migration-command-menu-item-action.type';
@@ -76,6 +78,7 @@ import {
   type FlatCreateFrontComponentAction,
   type FlatDeleteFrontComponentAction,
   type FlatUpdateFrontComponentAction,
+  type UniversalCreateFrontComponentAction,
   type UniversalDeleteFrontComponentAction,
   type UniversalUpdateFrontComponentAction,
 } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/front-component/types/workspace-migration-front-component-action.type';
@@ -91,6 +94,7 @@ import {
   type FlatCreateLogicFunctionAction,
   type FlatDeleteLogicFunctionAction,
   type FlatUpdateLogicFunctionAction,
+  type UniversalCreateLogicFunctionAction,
   type UniversalDeleteLogicFunctionAction,
   type UniversalUpdateLogicFunctionAction,
 } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/logic-function/types/workspace-migration-logic-function-action.type';
@@ -98,6 +102,7 @@ import {
   type FlatCreateNavigationMenuItemAction,
   type FlatDeleteNavigationMenuItemAction,
   type FlatUpdateNavigationMenuItemAction,
+  type UniversalCreateNavigationMenuItemAction,
   type UniversalDeleteNavigationMenuItemAction,
   type UniversalUpdateNavigationMenuItemAction,
 } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/navigation-menu-item/types/workspace-migration-navigation-menu-item-action.type';
@@ -113,6 +118,7 @@ import {
   type FlatCreatePageLayoutTabAction,
   type FlatDeletePageLayoutTabAction,
   type FlatUpdatePageLayoutTabAction,
+  type UniversalCreatePageLayoutTabAction,
   type UniversalDeletePageLayoutTabAction,
   type UniversalUpdatePageLayoutTabAction,
 } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/page-layout-tab/types/workspace-migration-page-layout-tab-action.type';
@@ -120,6 +126,7 @@ import {
   type FlatCreatePageLayoutWidgetAction,
   type FlatDeletePageLayoutWidgetAction,
   type FlatUpdatePageLayoutWidgetAction,
+  type UniversalCreatePageLayoutWidgetAction,
   type UniversalDeletePageLayoutWidgetAction,
   type UniversalUpdatePageLayoutWidgetAction,
 } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/page-layout-widget/types/workspace-migration-page-layout-widget-action.type';
@@ -127,6 +134,7 @@ import {
   type FlatCreatePageLayoutAction,
   type FlatDeletePageLayoutAction,
   type FlatUpdatePageLayoutAction,
+  type UniversalCreatePageLayoutAction,
   type UniversalDeletePageLayoutAction,
   type UniversalUpdatePageLayoutAction,
 } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/page-layout/types/workspace-migration-page-layout-action.type';
@@ -134,6 +142,7 @@ import {
   type FlatCreateRoleTargetAction,
   type FlatDeleteRoleTargetAction,
   type FlatUpdateRoleTargetAction,
+  type UniversalCreateRoleTargetAction,
   type UniversalDeleteRoleTargetAction,
   type UniversalUpdateRoleTargetAction,
 } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/role-target/types/workspace-migration-role-target-action.type';
@@ -141,6 +150,7 @@ import {
   type FlatCreateRoleAction,
   type FlatDeleteRoleAction,
   type FlatUpdateRoleAction,
+  type UniversalCreateRoleAction,
   type UniversalDeleteRoleAction,
   type UniversalUpdateRoleAction,
 } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/role/types/workspace-migration-role-action.type';
@@ -148,6 +158,7 @@ import {
   type FlatCreateRowLevelPermissionPredicateGroupAction,
   type FlatDeleteRowLevelPermissionPredicateGroupAction,
   type FlatUpdateRowLevelPermissionPredicateGroupAction,
+  type UniversalCreateRowLevelPermissionPredicateGroupAction,
   type UniversalDeleteRowLevelPermissionPredicateGroupAction,
   type UniversalUpdateRowLevelPermissionPredicateGroupAction,
 } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/row-level-permission-predicate-group/types/workspace-migration-row-level-permission-predicate-group-action.type';
@@ -155,6 +166,7 @@ import {
   type FlatCreateRowLevelPermissionPredicateAction,
   type FlatDeleteRowLevelPermissionPredicateAction,
   type FlatUpdateRowLevelPermissionPredicateAction,
+  type UniversalCreateRowLevelPermissionPredicateAction,
   type UniversalDeleteRowLevelPermissionPredicateAction,
   type UniversalUpdateRowLevelPermissionPredicateAction,
 } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/row-level-permission-predicate/types/workspace-migration-row-level-permission-predicate-action.type';
@@ -210,6 +222,7 @@ import {
   type FlatCreateWebhookAction,
   type FlatDeleteWebhookAction,
   type FlatUpdateWebhookAction,
+  type UniversalCreateWebhookAction,
   type UniversalDeleteWebhookAction,
   type UniversalUpdateWebhookAction,
 } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/webhook/types/workspace-migration-webhook-action.type';
@@ -301,7 +314,7 @@ export type AllFlatEntityTypesByMetadataName = {
   rowLevelPermissionPredicate: {
     flatEntityMaps: FlatRowLevelPermissionPredicateMaps;
     universalActions: {
-      create: FlatCreateRowLevelPermissionPredicateAction;
+      create: UniversalCreateRowLevelPermissionPredicateAction;
       update: UniversalUpdateRowLevelPermissionPredicateAction;
       delete: UniversalDeleteRowLevelPermissionPredicateAction;
     };
@@ -317,7 +330,7 @@ export type AllFlatEntityTypesByMetadataName = {
   rowLevelPermissionPredicateGroup: {
     flatEntityMaps: FlatRowLevelPermissionPredicateGroupMaps;
     universalActions: {
-      create: FlatCreateRowLevelPermissionPredicateGroupAction;
+      create: UniversalCreateRowLevelPermissionPredicateGroupAction;
       update: UniversalUpdateRowLevelPermissionPredicateGroupAction;
       delete: UniversalDeleteRowLevelPermissionPredicateGroupAction;
     };
@@ -365,7 +378,7 @@ export type AllFlatEntityTypesByMetadataName = {
   logicFunction: {
     flatEntityMaps: FlatEntityMaps<FlatLogicFunction>;
     universalActions: {
-      create: FlatCreateLogicFunctionAction;
+      create: UniversalCreateLogicFunctionAction;
       update: UniversalUpdateLogicFunctionAction;
       delete: UniversalDeleteLogicFunctionAction;
     };
@@ -397,7 +410,7 @@ export type AllFlatEntityTypesByMetadataName = {
   role: {
     flatEntityMaps: FlatEntityMaps<FlatRole>;
     universalActions: {
-      create: FlatCreateRoleAction;
+      create: UniversalCreateRoleAction;
       update: UniversalUpdateRoleAction;
       delete: UniversalDeleteRoleAction;
     };
@@ -413,7 +426,7 @@ export type AllFlatEntityTypesByMetadataName = {
   roleTarget: {
     flatEntityMaps: FlatRoleTargetMaps;
     universalActions: {
-      create: FlatCreateRoleTargetAction;
+      create: UniversalCreateRoleTargetAction;
       update: UniversalUpdateRoleTargetAction;
       delete: UniversalDeleteRoleTargetAction;
     };
@@ -429,7 +442,7 @@ export type AllFlatEntityTypesByMetadataName = {
   agent: {
     flatEntityMaps: FlatAgentMaps;
     universalActions: {
-      create: FlatCreateAgentAction;
+      create: UniversalCreateAgentAction;
       update: UniversalUpdateAgentAction;
       delete: UniversalDeleteAgentAction;
     };
@@ -461,7 +474,7 @@ export type AllFlatEntityTypesByMetadataName = {
   commandMenuItem: {
     flatEntityMaps: FlatCommandMenuItemMaps;
     universalActions: {
-      create: FlatCreateCommandMenuItemAction;
+      create: UniversalCreateCommandMenuItemAction;
       update: UniversalUpdateCommandMenuItemAction;
       delete: UniversalDeleteCommandMenuItemAction;
     };
@@ -477,7 +490,7 @@ export type AllFlatEntityTypesByMetadataName = {
   navigationMenuItem: {
     flatEntityMaps: FlatNavigationMenuItemMaps;
     universalActions: {
-      create: FlatCreateNavigationMenuItemAction;
+      create: UniversalCreateNavigationMenuItemAction;
       update: UniversalUpdateNavigationMenuItemAction;
       delete: UniversalDeleteNavigationMenuItemAction;
     };
@@ -493,7 +506,7 @@ export type AllFlatEntityTypesByMetadataName = {
   pageLayout: {
     flatEntityMaps: FlatPageLayoutMaps;
     universalActions: {
-      create: FlatCreatePageLayoutAction;
+      create: UniversalCreatePageLayoutAction;
       update: UniversalUpdatePageLayoutAction;
       delete: UniversalDeletePageLayoutAction;
     };
@@ -509,7 +522,7 @@ export type AllFlatEntityTypesByMetadataName = {
   pageLayoutWidget: {
     flatEntityMaps: FlatPageLayoutWidgetMaps;
     universalActions: {
-      create: FlatCreatePageLayoutWidgetAction;
+      create: UniversalCreatePageLayoutWidgetAction;
       update: UniversalUpdatePageLayoutWidgetAction;
       delete: UniversalDeletePageLayoutWidgetAction;
     };
@@ -525,7 +538,7 @@ export type AllFlatEntityTypesByMetadataName = {
   pageLayoutTab: {
     flatEntityMaps: FlatPageLayoutTabMaps;
     universalActions: {
-      create: FlatCreatePageLayoutTabAction;
+      create: UniversalCreatePageLayoutTabAction;
       update: UniversalUpdatePageLayoutTabAction;
       delete: UniversalDeletePageLayoutTabAction;
     };
@@ -541,7 +554,7 @@ export type AllFlatEntityTypesByMetadataName = {
   frontComponent: {
     flatEntityMaps: FlatFrontComponentMaps;
     universalActions: {
-      create: FlatCreateFrontComponentAction;
+      create: UniversalCreateFrontComponentAction;
       update: UniversalUpdateFrontComponentAction;
       delete: UniversalDeleteFrontComponentAction;
     };
@@ -557,7 +570,7 @@ export type AllFlatEntityTypesByMetadataName = {
   webhook: {
     flatEntityMaps: FlatWebhookMaps;
     universalActions: {
-      create: FlatCreateWebhookAction;
+      create: UniversalCreateWebhookAction;
       update: UniversalUpdateWebhookAction;
       delete: UniversalDeleteWebhookAction;
     };

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/types/base-graph-configuration.type.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/types/base-graph-configuration.type.ts
@@ -1,6 +1,0 @@
-import { type GraphConfiguration } from './graph-configuration.type';
-
-export type BaseGraphConfiguration = Pick<
-  GraphConfiguration,
-  'configurationType' | 'aggregateFieldMetadataId' | 'aggregateOperation'
->;

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-bar-chart-configuration.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-bar-chart-configuration.util.ts
@@ -2,16 +2,24 @@ import { msg, t } from '@lingui/core/macro';
 import { isDefined } from 'twenty-shared/utils';
 
 import { type FlatPageLayoutWidgetValidationError } from 'src/engine/metadata-modules/flat-page-layout-widget/types/flat-page-layout-widget-validation-error.type';
-import { type BarChartConfigurationDTO } from 'src/engine/metadata-modules/page-layout-widget/dtos/bar-chart-configuration.dto';
+import { WidgetConfigurationType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
 import { PageLayoutWidgetExceptionCode } from 'src/engine/metadata-modules/page-layout-widget/exceptions/page-layout-widget.exception';
+import { UniversalFlatPageLayoutWidget } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type';
 
-export const validateBarChartConfiguration = (
-  configuration: BarChartConfigurationDTO,
-  widgetTitle: string,
-): FlatPageLayoutWidgetValidationError[] => {
+export const validateBarChartConfiguration = ({
+  graphUniversalConfiguration,
+  widgetTitle,
+}: {
+  graphUniversalConfiguration: UniversalFlatPageLayoutWidget<WidgetConfigurationType.BAR_CHART>['universalConfiguration'];
+  widgetTitle: string;
+}): FlatPageLayoutWidgetValidationError[] => {
   const errors: FlatPageLayoutWidgetValidationError[] = [];
 
-  if (!isDefined(configuration.primaryAxisGroupByFieldMetadataId)) {
+  if (
+    !isDefined(
+      graphUniversalConfiguration.primaryAxisGroupByFieldMetadataUniversalIdentifier,
+    )
+  ) {
     errors.push({
       code: PageLayoutWidgetExceptionCode.INVALID_PAGE_LAYOUT_WIDGET_DATA,
       message: t`Primary axis group by field is required for bar chart widget "${widgetTitle}"`,
@@ -19,7 +27,7 @@ export const validateBarChartConfiguration = (
     });
   }
 
-  if (!isDefined(configuration.layout)) {
+  if (!isDefined(graphUniversalConfiguration.layout)) {
     errors.push({
       code: PageLayoutWidgetExceptionCode.INVALID_PAGE_LAYOUT_WIDGET_DATA,
       message: t`Layout is required for bar chart widget "${widgetTitle}"`,

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-bar-chart-configuration.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-bar-chart-configuration.util.ts
@@ -2,9 +2,9 @@ import { msg, t } from '@lingui/core/macro';
 import { isDefined } from 'twenty-shared/utils';
 
 import { type FlatPageLayoutWidgetValidationError } from 'src/engine/metadata-modules/flat-page-layout-widget/types/flat-page-layout-widget-validation-error.type';
-import { WidgetConfigurationType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
+import { type WidgetConfigurationType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
 import { PageLayoutWidgetExceptionCode } from 'src/engine/metadata-modules/page-layout-widget/exceptions/page-layout-widget.exception';
-import { UniversalFlatPageLayoutWidget } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type';
+import { type UniversalFlatPageLayoutWidget } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type';
 
 export const validateBarChartConfiguration = ({
   graphUniversalConfiguration,

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-base-graph-fields.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-base-graph-fields.util.ts
@@ -2,24 +2,30 @@ import { msg, t } from '@lingui/core/macro';
 import { isDefined } from 'twenty-shared/utils';
 
 import { type FlatPageLayoutWidgetValidationError } from 'src/engine/metadata-modules/flat-page-layout-widget/types/flat-page-layout-widget-validation-error.type';
-import { type BaseGraphConfiguration } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/types/base-graph-configuration.type';
+import { AllGraphWidgetConfigurationType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
 import { PageLayoutWidgetExceptionCode } from 'src/engine/metadata-modules/page-layout-widget/exceptions/page-layout-widget.exception';
+import { UniversalFlatPageLayoutWidget } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type';
 
-export const validateBaseGraphFields = (
-  configuration: BaseGraphConfiguration,
-  widgetTitle: string,
-): FlatPageLayoutWidgetValidationError[] => {
+export const validateBaseGraphFields = ({
+  graphUniversalConfiguration,
+  widgetTitle,
+}: {
+  graphUniversalConfiguration: UniversalFlatPageLayoutWidget<AllGraphWidgetConfigurationType>['universalConfiguration'];
+  widgetTitle: string;
+}): FlatPageLayoutWidgetValidationError[] => {
   const errors: FlatPageLayoutWidgetValidationError[] = [];
 
-  if (!isDefined(configuration.aggregateFieldMetadataId)) {
+  if (
+    !isDefined(graphUniversalConfiguration.aggregateFieldMetadataUniversalIdentifier)
+  ) {
     errors.push({
       code: PageLayoutWidgetExceptionCode.INVALID_PAGE_LAYOUT_WIDGET_DATA,
-      message: t`Aggregate field metadata ID is required for graph widget "${widgetTitle}"`,
+      message: t`Aggregate field metadata is required for graph widget "${widgetTitle}"`,
       userFriendlyMessage: msg`Aggregate field is required for graph widget`,
     });
   }
 
-  if (!isDefined(configuration.aggregateOperation)) {
+  if (!isDefined(graphUniversalConfiguration.aggregateOperation)) {
     errors.push({
       code: PageLayoutWidgetExceptionCode.INVALID_PAGE_LAYOUT_WIDGET_DATA,
       message: t`Aggregate operation is required for graph widget "${widgetTitle}"`,

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-base-graph-fields.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-base-graph-fields.util.ts
@@ -2,9 +2,9 @@ import { msg, t } from '@lingui/core/macro';
 import { isDefined } from 'twenty-shared/utils';
 
 import { type FlatPageLayoutWidgetValidationError } from 'src/engine/metadata-modules/flat-page-layout-widget/types/flat-page-layout-widget-validation-error.type';
-import { AllGraphWidgetConfigurationType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
+import { type AllGraphWidgetConfigurationType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
 import { PageLayoutWidgetExceptionCode } from 'src/engine/metadata-modules/page-layout-widget/exceptions/page-layout-widget.exception';
-import { UniversalFlatPageLayoutWidget } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type';
+import { type UniversalFlatPageLayoutWidget } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type';
 
 export const validateBaseGraphFields = ({
   graphUniversalConfiguration,
@@ -16,7 +16,9 @@ export const validateBaseGraphFields = ({
   const errors: FlatPageLayoutWidgetValidationError[] = [];
 
   if (
-    !isDefined(graphUniversalConfiguration.aggregateFieldMetadataUniversalIdentifier)
+    !isDefined(
+      graphUniversalConfiguration.aggregateFieldMetadataUniversalIdentifier,
+    )
   ) {
     errors.push({
       code: PageLayoutWidgetExceptionCode.INVALID_PAGE_LAYOUT_WIDGET_DATA,

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-front-component-configuration-type.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-front-component-configuration-type.util.ts
@@ -2,20 +2,20 @@ import { msg, t } from '@lingui/core/macro';
 import { isDefined } from 'twenty-shared/utils';
 
 import { type FlatPageLayoutWidgetValidationError } from 'src/engine/metadata-modules/flat-page-layout-widget/types/flat-page-layout-widget-validation-error.type';
-import { type FrontComponentConfigurationDTO } from 'src/engine/metadata-modules/page-layout-widget/dtos/front-component-configuration.dto';
 import { WidgetConfigurationType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
 import { PageLayoutWidgetExceptionCode } from 'src/engine/metadata-modules/page-layout-widget/exceptions/page-layout-widget.exception';
+import { UniversalFlatPageLayoutWidget } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type';
 
-export const validateFrontComponentConfigurationType = (
-  configuration: FrontComponentConfigurationDTO,
-  widgetTitle: string,
-): FlatPageLayoutWidgetValidationError[] => {
+export const validateFrontComponentConfigurationType = ({
+  universalConfiguration,
+  title,
+}: Pick<UniversalFlatPageLayoutWidget, 'universalConfiguration' | 'title'>): FlatPageLayoutWidgetValidationError[] => {
   const errors: FlatPageLayoutWidgetValidationError[] = [];
 
-  if (!isDefined(configuration.configurationType)) {
+  if (!isDefined(universalConfiguration.configurationType)) {
     errors.push({
       code: PageLayoutWidgetExceptionCode.INVALID_PAGE_LAYOUT_WIDGET_DATA,
-      message: t`Configuration type is required for widget "${widgetTitle}"`,
+      message: t`Configuration type is required for widget "${title}"`,
       userFriendlyMessage: msg`Configuration type is required`,
     });
 
@@ -23,15 +23,15 @@ export const validateFrontComponentConfigurationType = (
   }
 
   if (
-    configuration.configurationType !== WidgetConfigurationType.FRONT_COMPONENT
+    universalConfiguration.configurationType !== WidgetConfigurationType.FRONT_COMPONENT
   ) {
-    const configurationTypeString = String(configuration.configurationType);
+    const configurationTypeString = String(universalConfiguration.configurationType);
 
     errors.push({
       code: PageLayoutWidgetExceptionCode.INVALID_PAGE_LAYOUT_WIDGET_DATA,
-      message: t`Invalid configuration type for front component widget "${widgetTitle}". Expected FRONT_COMPONENT, got ${configurationTypeString}`,
+      message: t`Invalid configuration type for front component widget "${title}". Expected FRONT_COMPONENT, got ${configurationTypeString}`,
       userFriendlyMessage: msg`Invalid configuration type for front component widget`,
-      value: configuration.configurationType,
+      value: universalConfiguration.configurationType,
     });
   }
 

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-front-component-configuration-type.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-front-component-configuration-type.util.ts
@@ -4,12 +4,15 @@ import { isDefined } from 'twenty-shared/utils';
 import { type FlatPageLayoutWidgetValidationError } from 'src/engine/metadata-modules/flat-page-layout-widget/types/flat-page-layout-widget-validation-error.type';
 import { WidgetConfigurationType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
 import { PageLayoutWidgetExceptionCode } from 'src/engine/metadata-modules/page-layout-widget/exceptions/page-layout-widget.exception';
-import { UniversalFlatPageLayoutWidget } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type';
+import { type UniversalFlatPageLayoutWidget } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type';
 
 export const validateFrontComponentConfigurationType = ({
   universalConfiguration,
   title,
-}: Pick<UniversalFlatPageLayoutWidget, 'universalConfiguration' | 'title'>): FlatPageLayoutWidgetValidationError[] => {
+}: Pick<
+  UniversalFlatPageLayoutWidget,
+  'universalConfiguration' | 'title'
+>): FlatPageLayoutWidgetValidationError[] => {
   const errors: FlatPageLayoutWidgetValidationError[] = [];
 
   if (!isDefined(universalConfiguration.configurationType)) {
@@ -23,9 +26,12 @@ export const validateFrontComponentConfigurationType = ({
   }
 
   if (
-    universalConfiguration.configurationType !== WidgetConfigurationType.FRONT_COMPONENT
+    universalConfiguration.configurationType !==
+    WidgetConfigurationType.FRONT_COMPONENT
   ) {
-    const configurationTypeString = String(universalConfiguration.configurationType);
+    const configurationTypeString = String(
+      universalConfiguration.configurationType,
+    );
 
     errors.push({
       code: PageLayoutWidgetExceptionCode.INVALID_PAGE_LAYOUT_WIDGET_DATA,

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-front-component-flat-page-layout-widget-for-creation.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-front-component-flat-page-layout-widget-for-creation.util.ts
@@ -4,17 +4,16 @@ import { isDefined } from 'twenty-shared/utils';
 import { type ValidateFlatPageLayoutWidgetTypeSpecificitiesForCreationArgs } from 'src/engine/metadata-modules/flat-page-layout-widget/services/flat-page-layout-widget-type-validator.service';
 import { type FlatPageLayoutWidgetValidationError } from 'src/engine/metadata-modules/flat-page-layout-widget/types/flat-page-layout-widget-validation-error.type';
 import { validateFrontComponentConfigurationType } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-front-component-configuration-type.util';
-import { type FrontComponentConfigurationDTO } from 'src/engine/metadata-modules/page-layout-widget/dtos/front-component-configuration.dto';
 import { PageLayoutWidgetExceptionCode } from 'src/engine/metadata-modules/page-layout-widget/exceptions/page-layout-widget.exception';
 
 export const validateFrontComponentFlatPageLayoutWidgetForCreation = (
   args: ValidateFlatPageLayoutWidgetTypeSpecificitiesForCreationArgs,
 ): FlatPageLayoutWidgetValidationError[] => {
   const { flatEntityToValidate } = args;
-  const { configuration, title } = flatEntityToValidate;
+  const { universalConfiguration, title } = flatEntityToValidate;
   const errors: FlatPageLayoutWidgetValidationError[] = [];
 
-  if (!isDefined(configuration)) {
+  if (!isDefined(universalConfiguration)) {
     errors.push({
       code: PageLayoutWidgetExceptionCode.INVALID_PAGE_LAYOUT_WIDGET_DATA,
       message: t`Configuration is required for front component widget "${title}"`,
@@ -24,13 +23,10 @@ export const validateFrontComponentFlatPageLayoutWidgetForCreation = (
     return errors;
   }
 
-  const frontComponentConfiguration =
-    configuration as FrontComponentConfigurationDTO;
-
-  const configurationTypeErrors = validateFrontComponentConfigurationType(
-    frontComponentConfiguration,
+  const configurationTypeErrors = validateFrontComponentConfigurationType({
+    universalConfiguration,
     title,
-  );
+  });
 
   errors.push(...configurationTypeErrors);
 

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-front-component-flat-page-layout-widget-for-update.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-front-component-flat-page-layout-widget-for-update.util.ts
@@ -3,26 +3,22 @@ import { isDefined } from 'twenty-shared/utils';
 import { type ValidateFlatPageLayoutWidgetTypeSpecificitiesForUpdateArgs } from 'src/engine/metadata-modules/flat-page-layout-widget/services/flat-page-layout-widget-type-validator.service';
 import { type FlatPageLayoutWidgetValidationError } from 'src/engine/metadata-modules/flat-page-layout-widget/types/flat-page-layout-widget-validation-error.type';
 import { validateFrontComponentConfigurationType } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-front-component-configuration-type.util';
-import { type FrontComponentConfigurationDTO } from 'src/engine/metadata-modules/page-layout-widget/dtos/front-component-configuration.dto';
 
 export const validateFrontComponentFlatPageLayoutWidgetForUpdate = (
   args: ValidateFlatPageLayoutWidgetTypeSpecificitiesForUpdateArgs,
 ): FlatPageLayoutWidgetValidationError[] => {
   const { flatEntityToValidate } = args;
-  const { configuration, title } = flatEntityToValidate;
+  const { universalConfiguration, title } = flatEntityToValidate;
   const errors: FlatPageLayoutWidgetValidationError[] = [];
 
-  if (!isDefined(configuration)) {
+  if (!isDefined(universalConfiguration)) {
     return [];
   }
 
-  const frontComponentConfiguration =
-    configuration as FrontComponentConfigurationDTO;
-
-  const configurationTypeErrors = validateFrontComponentConfigurationType(
-    frontComponentConfiguration,
+  const configurationTypeErrors = validateFrontComponentConfigurationType({
+    universalConfiguration,
     title,
-  );
+  });
 
   errors.push(...configurationTypeErrors);
 

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-graph-configuration-by-type.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-graph-configuration-by-type.util.ts
@@ -2,8 +2,11 @@ import { type FlatPageLayoutWidgetValidationError } from 'src/engine/metadata-mo
 import { validateBarChartConfiguration } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-bar-chart-configuration.util';
 import { validateLineChartConfiguration } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-line-chart-configuration.util';
 import { validatePieChartConfiguration } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-pie-chart-configuration.util';
-import { AllGraphWidgetConfigurationType, WidgetConfigurationType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
-import { UniversalFlatPageLayoutWidget } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type';
+import {
+  type AllGraphWidgetConfigurationType,
+  WidgetConfigurationType,
+} from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
+import { type UniversalFlatPageLayoutWidget } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type';
 
 export const validateGraphConfigurationByType = ({
   graphUniversalConfiguration,

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-graph-configuration-by-type.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-graph-configuration-by-type.util.ts
@@ -1,23 +1,35 @@
 import { type FlatPageLayoutWidgetValidationError } from 'src/engine/metadata-modules/flat-page-layout-widget/types/flat-page-layout-widget-validation-error.type';
-import { type GraphConfiguration } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/types/graph-configuration.type';
 import { validateBarChartConfiguration } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-bar-chart-configuration.util';
 import { validateLineChartConfiguration } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-line-chart-configuration.util';
 import { validatePieChartConfiguration } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-pie-chart-configuration.util';
-import { WidgetConfigurationType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
+import { AllGraphWidgetConfigurationType, WidgetConfigurationType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
+import { UniversalFlatPageLayoutWidget } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type';
 
-export const validateGraphConfigurationByType = (
-  configuration: GraphConfiguration,
-  widgetTitle: string,
-): FlatPageLayoutWidgetValidationError[] => {
-  const configurationType = configuration.configurationType;
+export const validateGraphConfigurationByType = ({
+  graphUniversalConfiguration,
+  widgetTitle,
+}: {
+  graphUniversalConfiguration: UniversalFlatPageLayoutWidget<AllGraphWidgetConfigurationType>['universalConfiguration'];
+  widgetTitle: string;
+}): FlatPageLayoutWidgetValidationError[] => {
+  const configurationType = graphUniversalConfiguration.configurationType;
 
   switch (configurationType) {
     case WidgetConfigurationType.BAR_CHART:
-      return validateBarChartConfiguration(configuration, widgetTitle);
+      return validateBarChartConfiguration({
+        graphUniversalConfiguration,
+        widgetTitle,
+      });
     case WidgetConfigurationType.LINE_CHART:
-      return validateLineChartConfiguration(configuration, widgetTitle);
+      return validateLineChartConfiguration({
+        graphUniversalConfiguration,
+        widgetTitle,
+      });
     case WidgetConfigurationType.PIE_CHART:
-      return validatePieChartConfiguration(configuration, widgetTitle);
+      return validatePieChartConfiguration({
+        graphUniversalConfiguration,
+        widgetTitle,
+      });
     case WidgetConfigurationType.AGGREGATE_CHART:
     case WidgetConfigurationType.GAUGE_CHART:
       return [];

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-graph-configuration-type.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-graph-configuration-type.util.ts
@@ -3,9 +3,9 @@ import { isDefined } from 'twenty-shared/utils';
 
 import { type FlatPageLayoutWidgetValidationError } from 'src/engine/metadata-modules/flat-page-layout-widget/types/flat-page-layout-widget-validation-error.type';
 import { VALID_GRAPH_CONFIGURATION_TYPES } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/constants/valid-graph-configuration-types.constant';
-import { AllGraphWidgetConfigurationType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
+import { type AllGraphWidgetConfigurationType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
 import { PageLayoutWidgetExceptionCode } from 'src/engine/metadata-modules/page-layout-widget/exceptions/page-layout-widget.exception';
-import { UniversalFlatPageLayoutWidget } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type';
+import { type UniversalFlatPageLayoutWidget } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type';
 
 export const validateGraphConfigurationType = ({
   universalConfiguration,

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-graph-configuration-type.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-graph-configuration-type.util.ts
@@ -3,42 +3,67 @@ import { isDefined } from 'twenty-shared/utils';
 
 import { type FlatPageLayoutWidgetValidationError } from 'src/engine/metadata-modules/flat-page-layout-widget/types/flat-page-layout-widget-validation-error.type';
 import { VALID_GRAPH_CONFIGURATION_TYPES } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/constants/valid-graph-configuration-types.constant';
-import { type GraphConfiguration } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/types/graph-configuration.type';
+import { AllGraphWidgetConfigurationType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
 import { PageLayoutWidgetExceptionCode } from 'src/engine/metadata-modules/page-layout-widget/exceptions/page-layout-widget.exception';
+import { UniversalFlatPageLayoutWidget } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type';
 
-export const validateGraphConfigurationType = (
-  configuration: GraphConfiguration,
-  widgetTitle: string,
-): FlatPageLayoutWidgetValidationError[] => {
-  const errors: FlatPageLayoutWidgetValidationError[] = [];
-
-  if (!isDefined(configuration.configurationType)) {
-    errors.push({
-      code: PageLayoutWidgetExceptionCode.INVALID_PAGE_LAYOUT_WIDGET_DATA,
-      message: t`Configuration type is required for widget "${widgetTitle}"`,
-      userFriendlyMessage: msg`Configuration type is required`,
-    });
-
-    return errors;
+export const validateGraphConfigurationType = ({
+  universalConfiguration,
+  widgetTitle,
+}: {
+  universalConfiguration: UniversalFlatPageLayoutWidget['universalConfiguration'];
+  widgetTitle: string;
+}):
+  | {
+      status: 'fail';
+      errors: FlatPageLayoutWidgetValidationError[];
+    }
+  | {
+      status: 'success';
+      graphUniversalConfiguration: UniversalFlatPageLayoutWidget<AllGraphWidgetConfigurationType>['universalConfiguration'];
+    } => {
+  if (!isDefined(universalConfiguration.configurationType)) {
+    return {
+      errors: [
+        {
+          code: PageLayoutWidgetExceptionCode.INVALID_PAGE_LAYOUT_WIDGET_DATA,
+          message: t`Configuration type is required for widget "${widgetTitle}"`,
+          userFriendlyMessage: msg`Configuration type is required`,
+        },
+      ],
+      status: 'fail',
+    };
   }
 
   const isValidGraphConfigurationType =
-    VALID_GRAPH_CONFIGURATION_TYPES.includes(configuration.configurationType);
+    VALID_GRAPH_CONFIGURATION_TYPES.includes(
+      universalConfiguration.configurationType as (typeof VALID_GRAPH_CONFIGURATION_TYPES)[number],
+    );
 
   if (!isValidGraphConfigurationType) {
     const expectedConfigurationTypes = VALID_GRAPH_CONFIGURATION_TYPES.map(
       (type) => type.toString(),
     ).join(', ');
 
-    const configurationTypeString = configuration.configurationType.toString();
+    const configurationTypeString =
+      universalConfiguration.configurationType.toString();
 
-    errors.push({
-      code: PageLayoutWidgetExceptionCode.INVALID_PAGE_LAYOUT_WIDGET_DATA,
-      message: t`Invalid configuration type for graph widget "${widgetTitle}". Expected one of ${expectedConfigurationTypes}, got ${configurationTypeString}`,
-      userFriendlyMessage: msg`Invalid configuration type for graph widget`,
-      value: configuration.configurationType,
-    });
+    return {
+      errors: [
+        {
+          code: PageLayoutWidgetExceptionCode.INVALID_PAGE_LAYOUT_WIDGET_DATA,
+          message: t`Invalid configuration type for graph widget "${widgetTitle}". Expected one of ${expectedConfigurationTypes}, got ${configurationTypeString}`,
+          userFriendlyMessage: msg`Invalid configuration type for graph widget`,
+          value: universalConfiguration.configurationType,
+        },
+      ],
+      status: 'fail',
+    };
   }
 
-  return errors;
+  return {
+    status: 'success',
+    graphUniversalConfiguration:
+      universalConfiguration as UniversalFlatPageLayoutWidget<AllGraphWidgetConfigurationType>['universalConfiguration'],
+  };
 };

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-graph-flat-page-layout-widget-for-creation.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-graph-flat-page-layout-widget-for-creation.util.ts
@@ -3,7 +3,6 @@ import { isDefined } from 'twenty-shared/utils';
 
 import { type ValidateFlatPageLayoutWidgetTypeSpecificitiesForCreationArgs } from 'src/engine/metadata-modules/flat-page-layout-widget/services/flat-page-layout-widget-type-validator.service';
 import { type FlatPageLayoutWidgetValidationError } from 'src/engine/metadata-modules/flat-page-layout-widget/types/flat-page-layout-widget-validation-error.type';
-import { type GraphConfiguration } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/types/graph-configuration.type';
 import { validateBaseGraphFields } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-base-graph-fields.util';
 import { validateGraphConfigurationByType } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-graph-configuration-by-type.util';
 import { validateGraphConfigurationType } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-graph-configuration-type.util';
@@ -13,40 +12,41 @@ export const validateGraphFlatPageLayoutWidgetForCreation = (
   args: ValidateFlatPageLayoutWidgetTypeSpecificitiesForCreationArgs,
 ): FlatPageLayoutWidgetValidationError[] => {
   const { flatEntityToValidate } = args;
-  const { configuration, title } = flatEntityToValidate;
+  const { universalConfiguration, title: widgetTitle } = flatEntityToValidate;
   const errors: FlatPageLayoutWidgetValidationError[] = [];
 
-  if (!isDefined(configuration)) {
+  if (!isDefined(universalConfiguration)) {
     errors.push({
       code: PageLayoutWidgetExceptionCode.INVALID_PAGE_LAYOUT_WIDGET_DATA,
-      message: t`Configuration is required for graph widget "${title}"`,
+      message: t`Configuration is required for graph widget "${widgetTitle}"`,
       userFriendlyMessage: msg`Configuration is required for graph widget`,
     });
 
     return errors;
   }
 
-  const graphConfiguration = configuration as GraphConfiguration;
+  const result = validateGraphConfigurationType({
+    universalConfiguration,
+    widgetTitle,
+  });
 
-  const configurationTypeErrors = validateGraphConfigurationType(
-    graphConfiguration,
-    title,
-  );
-
-  errors.push(...configurationTypeErrors);
-
-  if (configurationTypeErrors.length > 0) {
-    return errors;
+  if (result.status === 'fail') {
+    return [...errors, ...result.errors];
   }
 
-  const baseFieldErrors = validateBaseGraphFields(graphConfiguration, title);
+  const { graphUniversalConfiguration } = result;
+
+  const baseFieldErrors = validateBaseGraphFields({
+    graphUniversalConfiguration,
+    widgetTitle,
+  });
 
   errors.push(...baseFieldErrors);
 
-  const typeSpecificErrors = validateGraphConfigurationByType(
-    graphConfiguration,
-    title,
-  );
+  const typeSpecificErrors = validateGraphConfigurationByType({
+    graphUniversalConfiguration,
+    widgetTitle,
+  });
 
   errors.push(...typeSpecificErrors);
 

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-graph-flat-page-layout-widget-for-update.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-graph-flat-page-layout-widget-for-update.util.ts
@@ -2,7 +2,6 @@ import { isDefined } from 'twenty-shared/utils';
 
 import { type ValidateFlatPageLayoutWidgetTypeSpecificitiesForUpdateArgs } from 'src/engine/metadata-modules/flat-page-layout-widget/services/flat-page-layout-widget-type-validator.service';
 import { type FlatPageLayoutWidgetValidationError } from 'src/engine/metadata-modules/flat-page-layout-widget/types/flat-page-layout-widget-validation-error.type';
-import { type GraphConfiguration } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/types/graph-configuration.type';
 import { validateBaseGraphFields } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-base-graph-fields.util';
 import { validateGraphConfigurationByType } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-graph-configuration-by-type.util';
 import { validateGraphConfigurationType } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-graph-configuration-type.util';
@@ -11,34 +10,34 @@ export const validateGraphFlatPageLayoutWidgetForUpdate = (
   args: ValidateFlatPageLayoutWidgetTypeSpecificitiesForUpdateArgs,
 ): FlatPageLayoutWidgetValidationError[] => {
   const { flatEntityToValidate } = args;
-  const { configuration, title } = flatEntityToValidate;
+  const { universalConfiguration, title: widgetTitle } = flatEntityToValidate;
   const errors: FlatPageLayoutWidgetValidationError[] = [];
 
-  if (!isDefined(configuration)) {
+  if (!isDefined(universalConfiguration)) {
     return [];
   }
 
-  const graphConfiguration = configuration as GraphConfiguration;
+  const result = validateGraphConfigurationType({
+    universalConfiguration,
+    widgetTitle,
+  });
 
-  const configurationTypeErrors = validateGraphConfigurationType(
-    graphConfiguration,
-    title,
-  );
-
-  errors.push(...configurationTypeErrors);
-
-  if (configurationTypeErrors.length > 0) {
-    return errors;
+  if (result.status === 'fail') {
+    return result.errors;
   }
+  const { graphUniversalConfiguration } = result;
 
-  const baseFieldErrors = validateBaseGraphFields(graphConfiguration, title);
+  const baseFieldErrors = validateBaseGraphFields({
+    graphUniversalConfiguration,
+    widgetTitle,
+  });
 
   errors.push(...baseFieldErrors);
 
-  const typeSpecificErrors = validateGraphConfigurationByType(
-    graphConfiguration,
-    title,
-  );
+  const typeSpecificErrors = validateGraphConfigurationByType({
+    graphUniversalConfiguration,
+    widgetTitle,
+  });
 
   errors.push(...typeSpecificErrors);
 

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-iframe-configuration-type.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-iframe-configuration-type.util.ts
@@ -2,36 +2,60 @@ import { msg, t } from '@lingui/core/macro';
 import { isDefined } from 'twenty-shared/utils';
 
 import { type FlatPageLayoutWidgetValidationError } from 'src/engine/metadata-modules/flat-page-layout-widget/types/flat-page-layout-widget-validation-error.type';
-import { type IframeConfiguration } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/types/iframe-configuration.type';
 import { WidgetConfigurationType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
 import { PageLayoutWidgetExceptionCode } from 'src/engine/metadata-modules/page-layout-widget/exceptions/page-layout-widget.exception';
+import { UniversalFlatPageLayoutWidget } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type';
 
-export const validateIframeConfigurationType = (
-  configuration: IframeConfiguration,
-  widgetTitle: string,
-): FlatPageLayoutWidgetValidationError[] => {
-  const errors: FlatPageLayoutWidgetValidationError[] = [];
-
-  if (!isDefined(configuration.configurationType)) {
-    errors.push({
-      code: PageLayoutWidgetExceptionCode.INVALID_PAGE_LAYOUT_WIDGET_DATA,
-      message: t`Configuration type is required for widget "${widgetTitle}"`,
-      userFriendlyMessage: msg`Configuration type is required`,
-    });
-
-    return errors;
+export const validateIframeConfigurationType = ({
+  universalConfiguration,
+  widgetTitle,
+}: {
+  universalConfiguration: UniversalFlatPageLayoutWidget['universalConfiguration'];
+  widgetTitle: string;
+}):
+  | {
+      status: 'fail';
+      errors: FlatPageLayoutWidgetValidationError[];
+    }
+  | {
+      status: 'success';
+      iframeUniversalConfiguration: UniversalFlatPageLayoutWidget<WidgetConfigurationType.IFRAME>['universalConfiguration'];
+    } => {
+  if (!isDefined(universalConfiguration.configurationType)) {
+    return {
+      errors: [
+        {
+          code: PageLayoutWidgetExceptionCode.INVALID_PAGE_LAYOUT_WIDGET_DATA,
+          message: t`Configuration type is required for widget "${widgetTitle}"`,
+          userFriendlyMessage: msg`Configuration type is required`,
+        },
+      ],
+      status: 'fail',
+    };
   }
 
-  if (configuration.configurationType !== WidgetConfigurationType.IFRAME) {
-    const configurationTypeString = configuration.configurationType.toString();
+  if (
+    universalConfiguration.configurationType !== WidgetConfigurationType.IFRAME
+  ) {
+    const configurationTypeString =
+      universalConfiguration.configurationType.toString();
 
-    errors.push({
-      code: PageLayoutWidgetExceptionCode.INVALID_PAGE_LAYOUT_WIDGET_DATA,
-      message: t`Invalid configuration type for iframe widget "${widgetTitle}". Expected IFRAME, got ${configurationTypeString}`,
-      userFriendlyMessage: msg`Invalid configuration type for iframe widget`,
-      value: configuration.configurationType,
-    });
+    return {
+      errors: [
+        {
+          code: PageLayoutWidgetExceptionCode.INVALID_PAGE_LAYOUT_WIDGET_DATA,
+          message: t`Invalid configuration type for iframe widget "${widgetTitle}". Expected IFRAME, got ${configurationTypeString}`,
+          userFriendlyMessage: msg`Invalid configuration type for iframe widget`,
+          value: universalConfiguration.configurationType,
+        },
+      ],
+      status: 'fail',
+    };
   }
 
-  return errors;
+  return {
+    status: 'success',
+    iframeUniversalConfiguration:
+      universalConfiguration as UniversalFlatPageLayoutWidget<WidgetConfigurationType.IFRAME>['universalConfiguration'],
+  };
 };

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-iframe-configuration-type.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-iframe-configuration-type.util.ts
@@ -4,7 +4,7 @@ import { isDefined } from 'twenty-shared/utils';
 import { type FlatPageLayoutWidgetValidationError } from 'src/engine/metadata-modules/flat-page-layout-widget/types/flat-page-layout-widget-validation-error.type';
 import { WidgetConfigurationType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
 import { PageLayoutWidgetExceptionCode } from 'src/engine/metadata-modules/page-layout-widget/exceptions/page-layout-widget.exception';
-import { UniversalFlatPageLayoutWidget } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type';
+import { type UniversalFlatPageLayoutWidget } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type';
 
 export const validateIframeConfigurationType = ({
   universalConfiguration,

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-iframe-flat-page-layout-widget-for-creation.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-iframe-flat-page-layout-widget-for-creation.util.ts
@@ -3,7 +3,6 @@ import { isDefined } from 'twenty-shared/utils';
 
 import { type ValidateFlatPageLayoutWidgetTypeSpecificitiesForCreationArgs } from 'src/engine/metadata-modules/flat-page-layout-widget/services/flat-page-layout-widget-type-validator.service';
 import { type FlatPageLayoutWidgetValidationError } from 'src/engine/metadata-modules/flat-page-layout-widget/types/flat-page-layout-widget-validation-error.type';
-import { type IframeConfiguration } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/types/iframe-configuration.type';
 import { validateIframeConfigurationType } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-iframe-configuration-type.util';
 import { validateIframeUrl } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-iframe-url.util';
 import { PageLayoutWidgetExceptionCode } from 'src/engine/metadata-modules/page-layout-widget/exceptions/page-layout-widget.exception';
@@ -12,29 +11,34 @@ export const validateIframeFlatPageLayoutWidgetForCreation = (
   args: ValidateFlatPageLayoutWidgetTypeSpecificitiesForCreationArgs,
 ): FlatPageLayoutWidgetValidationError[] => {
   const { flatEntityToValidate } = args;
-  const { configuration, title } = flatEntityToValidate;
+  const { universalConfiguration, title: widgetTitle } = flatEntityToValidate;
   const errors: FlatPageLayoutWidgetValidationError[] = [];
 
-  if (!isDefined(configuration)) {
+  if (!isDefined(universalConfiguration)) {
     errors.push({
       code: PageLayoutWidgetExceptionCode.INVALID_PAGE_LAYOUT_WIDGET_DATA,
-      message: t`Configuration is required for iframe widget "${title}"`,
+      message: t`Configuration is required for iframe widget "${widgetTitle}"`,
       userFriendlyMessage: msg`Configuration is required for iframe widget`,
     });
 
     return errors;
   }
 
-  const iframeConfiguration = configuration as IframeConfiguration;
+  const result = validateIframeConfigurationType({
+    universalConfiguration,
+    widgetTitle,
+  });
 
-  const configurationTypeErrors = validateIframeConfigurationType(
-    iframeConfiguration,
-    title,
-  );
+  if (result.status === 'fail') {
+    return [...errors, ...result.errors];
+  }
 
-  errors.push(...configurationTypeErrors);
+  const { iframeUniversalConfiguration } = result;
 
-  const urlErrors = validateIframeUrl(iframeConfiguration, title);
+  const urlErrors = validateIframeUrl({
+    iframeUniversalConfiguration,
+    widgetTitle,
+  });
 
   errors.push(...urlErrors);
 

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-iframe-flat-page-layout-widget-for-update.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-iframe-flat-page-layout-widget-for-update.util.ts
@@ -2,7 +2,6 @@ import { isDefined } from 'twenty-shared/utils';
 
 import { type ValidateFlatPageLayoutWidgetTypeSpecificitiesForUpdateArgs } from 'src/engine/metadata-modules/flat-page-layout-widget/services/flat-page-layout-widget-type-validator.service';
 import { type FlatPageLayoutWidgetValidationError } from 'src/engine/metadata-modules/flat-page-layout-widget/types/flat-page-layout-widget-validation-error.type';
-import { type IframeConfiguration } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/types/iframe-configuration.type';
 import { validateIframeConfigurationType } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-iframe-configuration-type.util';
 import { validateIframeUrl } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-iframe-url.util';
 
@@ -10,23 +9,28 @@ export const validateIframeFlatPageLayoutWidgetForUpdate = (
   args: ValidateFlatPageLayoutWidgetTypeSpecificitiesForUpdateArgs,
 ): FlatPageLayoutWidgetValidationError[] => {
   const { flatEntityToValidate } = args;
-  const { configuration, title } = flatEntityToValidate;
+  const { universalConfiguration, title: widgetTitle } = flatEntityToValidate;
   const errors: FlatPageLayoutWidgetValidationError[] = [];
 
-  if (!isDefined(configuration)) {
+  if (!isDefined(universalConfiguration)) {
     return [];
   }
 
-  const iframeConfiguration = configuration as IframeConfiguration;
+  const result = validateIframeConfigurationType({
+    universalConfiguration,
+    widgetTitle,
+  });
 
-  const configurationTypeErrors = validateIframeConfigurationType(
-    iframeConfiguration,
-    title,
-  );
+  if (result.status === 'fail') {
+    return result.errors;
+  }
 
-  errors.push(...configurationTypeErrors);
+  const { iframeUniversalConfiguration } = result;
 
-  const urlErrors = validateIframeUrl(iframeConfiguration, title);
+  const urlErrors = validateIframeUrl({
+    iframeUniversalConfiguration,
+    widgetTitle,
+  });
 
   errors.push(...urlErrors);
 

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-iframe-url.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-iframe-url.util.ts
@@ -2,9 +2,9 @@ import { msg, t } from '@lingui/core/macro';
 import { isDefined } from 'twenty-shared/utils';
 
 import { type FlatPageLayoutWidgetValidationError } from 'src/engine/metadata-modules/flat-page-layout-widget/types/flat-page-layout-widget-validation-error.type';
-import { WidgetConfigurationType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
+import { type WidgetConfigurationType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
 import { PageLayoutWidgetExceptionCode } from 'src/engine/metadata-modules/page-layout-widget/exceptions/page-layout-widget.exception';
-import { UniversalFlatPageLayoutWidget } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type';
+import { type UniversalFlatPageLayoutWidget } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type';
 
 export const validateIframeUrl = ({
   iframeUniversalConfiguration,

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-iframe-url.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-iframe-url.util.ts
@@ -2,21 +2,28 @@ import { msg, t } from '@lingui/core/macro';
 import { isDefined } from 'twenty-shared/utils';
 
 import { type FlatPageLayoutWidgetValidationError } from 'src/engine/metadata-modules/flat-page-layout-widget/types/flat-page-layout-widget-validation-error.type';
-import { type IframeConfiguration } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/types/iframe-configuration.type';
+import { WidgetConfigurationType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
 import { PageLayoutWidgetExceptionCode } from 'src/engine/metadata-modules/page-layout-widget/exceptions/page-layout-widget.exception';
+import { UniversalFlatPageLayoutWidget } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type';
 
-export const validateIframeUrl = (
-  configuration: IframeConfiguration,
-  widgetTitle: string,
-): FlatPageLayoutWidgetValidationError[] => {
+export const validateIframeUrl = ({
+  iframeUniversalConfiguration,
+  widgetTitle,
+}: {
+  iframeUniversalConfiguration: UniversalFlatPageLayoutWidget<WidgetConfigurationType.IFRAME>['universalConfiguration'];
+  widgetTitle: string;
+}): FlatPageLayoutWidgetValidationError[] => {
   const errors: FlatPageLayoutWidgetValidationError[] = [];
 
-  if (isDefined(configuration.url) && typeof configuration.url !== 'string') {
+  if (
+    isDefined(iframeUniversalConfiguration.url) &&
+    typeof iframeUniversalConfiguration.url !== 'string'
+  ) {
     errors.push({
       code: PageLayoutWidgetExceptionCode.INVALID_PAGE_LAYOUT_WIDGET_DATA,
       message: t`URL must be a string for widget "${widgetTitle}"`,
       userFriendlyMessage: msg`URL must be a string`,
-      value: configuration.url,
+      value: iframeUniversalConfiguration.url,
     });
   }
 

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-line-chart-configuration.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-line-chart-configuration.util.ts
@@ -2,16 +2,24 @@ import { msg, t } from '@lingui/core/macro';
 import { isDefined } from 'twenty-shared/utils';
 
 import { type FlatPageLayoutWidgetValidationError } from 'src/engine/metadata-modules/flat-page-layout-widget/types/flat-page-layout-widget-validation-error.type';
-import { type LineChartConfigurationDTO } from 'src/engine/metadata-modules/page-layout-widget/dtos/line-chart-configuration.dto';
+import { WidgetConfigurationType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
 import { PageLayoutWidgetExceptionCode } from 'src/engine/metadata-modules/page-layout-widget/exceptions/page-layout-widget.exception';
+import { UniversalFlatPageLayoutWidget } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type';
 
-export const validateLineChartConfiguration = (
-  configuration: LineChartConfigurationDTO,
-  widgetTitle: string,
-): FlatPageLayoutWidgetValidationError[] => {
+export const validateLineChartConfiguration = ({
+  graphUniversalConfiguration,
+  widgetTitle,
+}: {
+  graphUniversalConfiguration: UniversalFlatPageLayoutWidget<WidgetConfigurationType.LINE_CHART>['universalConfiguration'];
+  widgetTitle: string;
+}): FlatPageLayoutWidgetValidationError[] => {
   const errors: FlatPageLayoutWidgetValidationError[] = [];
 
-  if (!isDefined(configuration.primaryAxisGroupByFieldMetadataId)) {
+  if (
+    !isDefined(
+      graphUniversalConfiguration.primaryAxisGroupByFieldMetadataUniversalIdentifier,
+    )
+  ) {
     errors.push({
       code: PageLayoutWidgetExceptionCode.INVALID_PAGE_LAYOUT_WIDGET_DATA,
       message: t`Primary axis group by field is required for line chart widget "${widgetTitle}"`,

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-line-chart-configuration.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-line-chart-configuration.util.ts
@@ -2,9 +2,9 @@ import { msg, t } from '@lingui/core/macro';
 import { isDefined } from 'twenty-shared/utils';
 
 import { type FlatPageLayoutWidgetValidationError } from 'src/engine/metadata-modules/flat-page-layout-widget/types/flat-page-layout-widget-validation-error.type';
-import { WidgetConfigurationType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
+import { type WidgetConfigurationType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
 import { PageLayoutWidgetExceptionCode } from 'src/engine/metadata-modules/page-layout-widget/exceptions/page-layout-widget.exception';
-import { UniversalFlatPageLayoutWidget } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type';
+import { type UniversalFlatPageLayoutWidget } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type';
 
 export const validateLineChartConfiguration = ({
   graphUniversalConfiguration,

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-pie-chart-configuration.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-pie-chart-configuration.util.ts
@@ -2,16 +2,20 @@ import { msg, t } from '@lingui/core/macro';
 import { isDefined } from 'twenty-shared/utils';
 
 import { type FlatPageLayoutWidgetValidationError } from 'src/engine/metadata-modules/flat-page-layout-widget/types/flat-page-layout-widget-validation-error.type';
-import { type PieChartConfigurationDTO } from 'src/engine/metadata-modules/page-layout-widget/dtos/pie-chart-configuration.dto';
+import { WidgetConfigurationType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
 import { PageLayoutWidgetExceptionCode } from 'src/engine/metadata-modules/page-layout-widget/exceptions/page-layout-widget.exception';
+import { UniversalFlatPageLayoutWidget } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type';
 
-export const validatePieChartConfiguration = (
-  configuration: PieChartConfigurationDTO,
-  widgetTitle: string,
-): FlatPageLayoutWidgetValidationError[] => {
+export const validatePieChartConfiguration = ({
+  graphUniversalConfiguration,
+  widgetTitle,
+}: {
+  graphUniversalConfiguration: UniversalFlatPageLayoutWidget<WidgetConfigurationType.PIE_CHART>['universalConfiguration'];
+  widgetTitle: string;
+}): FlatPageLayoutWidgetValidationError[] => {
   const errors: FlatPageLayoutWidgetValidationError[] = [];
 
-  if (!isDefined(configuration.groupByFieldMetadataId)) {
+  if (!isDefined(graphUniversalConfiguration.groupByFieldMetadataUniversalIdentifier)) {
     errors.push({
       code: PageLayoutWidgetExceptionCode.INVALID_PAGE_LAYOUT_WIDGET_DATA,
       message: t`Group by field is required for pie chart widget "${widgetTitle}"`,

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-pie-chart-configuration.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-pie-chart-configuration.util.ts
@@ -2,9 +2,9 @@ import { msg, t } from '@lingui/core/macro';
 import { isDefined } from 'twenty-shared/utils';
 
 import { type FlatPageLayoutWidgetValidationError } from 'src/engine/metadata-modules/flat-page-layout-widget/types/flat-page-layout-widget-validation-error.type';
-import { WidgetConfigurationType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
+import { type WidgetConfigurationType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
 import { PageLayoutWidgetExceptionCode } from 'src/engine/metadata-modules/page-layout-widget/exceptions/page-layout-widget.exception';
-import { UniversalFlatPageLayoutWidget } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type';
+import { type UniversalFlatPageLayoutWidget } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type';
 
 export const validatePieChartConfiguration = ({
   graphUniversalConfiguration,
@@ -15,7 +15,11 @@ export const validatePieChartConfiguration = ({
 }): FlatPageLayoutWidgetValidationError[] => {
   const errors: FlatPageLayoutWidgetValidationError[] = [];
 
-  if (!isDefined(graphUniversalConfiguration.groupByFieldMetadataUniversalIdentifier)) {
+  if (
+    !isDefined(
+      graphUniversalConfiguration.groupByFieldMetadataUniversalIdentifier,
+    )
+  ) {
     errors.push({
       code: PageLayoutWidgetExceptionCode.INVALID_PAGE_LAYOUT_WIDGET_DATA,
       message: t`Group by field is required for pie chart widget "${widgetTitle}"`,

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-standalone-rich-text-body.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-standalone-rich-text-body.util.ts
@@ -2,16 +2,20 @@ import { msg, t } from '@lingui/core/macro';
 import { isDefined } from 'twenty-shared/utils';
 
 import { type FlatPageLayoutWidgetValidationError } from 'src/engine/metadata-modules/flat-page-layout-widget/types/flat-page-layout-widget-validation-error.type';
-import { type StandaloneRichTextConfigurationDTO } from 'src/engine/metadata-modules/page-layout-widget/dtos/standalone-rich-text-configuration.dto';
+import { WidgetConfigurationType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
 import { PageLayoutWidgetExceptionCode } from 'src/engine/metadata-modules/page-layout-widget/exceptions/page-layout-widget.exception';
+import { UniversalFlatPageLayoutWidget } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type';
 
-export const validateStandaloneRichTextBody = (
-  configuration: StandaloneRichTextConfigurationDTO,
-  widgetTitle: string,
-): FlatPageLayoutWidgetValidationError[] => {
+export const validateStandaloneRichTextBody = ({
+  standaloneRichTextUniversalConfiguration,
+  widgetTitle,
+}: {
+  standaloneRichTextUniversalConfiguration: UniversalFlatPageLayoutWidget<WidgetConfigurationType.STANDALONE_RICH_TEXT>['universalConfiguration'];
+  widgetTitle: string;
+}): FlatPageLayoutWidgetValidationError[] => {
   const errors: FlatPageLayoutWidgetValidationError[] = [];
 
-  if (!isDefined(configuration.body)) {
+  if (!isDefined(standaloneRichTextUniversalConfiguration.body)) {
     errors.push({
       code: PageLayoutWidgetExceptionCode.INVALID_PAGE_LAYOUT_WIDGET_DATA,
       message: t`Body is required for standalone rich text widget "${widgetTitle}"`,
@@ -22,14 +26,14 @@ export const validateStandaloneRichTextBody = (
   }
 
   if (
-    typeof configuration.body !== 'object' ||
-    Array.isArray(configuration.body)
+    typeof standaloneRichTextUniversalConfiguration.body !== 'object' ||
+    Array.isArray(standaloneRichTextUniversalConfiguration.body)
   ) {
     errors.push({
       code: PageLayoutWidgetExceptionCode.INVALID_PAGE_LAYOUT_WIDGET_DATA,
       message: t`Body must be an object for widget "${widgetTitle}"`,
       userFriendlyMessage: msg`Body must be an object`,
-      value: configuration.body,
+      value: standaloneRichTextUniversalConfiguration.body,
     });
   }
 

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-standalone-rich-text-body.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-standalone-rich-text-body.util.ts
@@ -2,9 +2,9 @@ import { msg, t } from '@lingui/core/macro';
 import { isDefined } from 'twenty-shared/utils';
 
 import { type FlatPageLayoutWidgetValidationError } from 'src/engine/metadata-modules/flat-page-layout-widget/types/flat-page-layout-widget-validation-error.type';
-import { WidgetConfigurationType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
+import { type WidgetConfigurationType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
 import { PageLayoutWidgetExceptionCode } from 'src/engine/metadata-modules/page-layout-widget/exceptions/page-layout-widget.exception';
-import { UniversalFlatPageLayoutWidget } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type';
+import { type UniversalFlatPageLayoutWidget } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type';
 
 export const validateStandaloneRichTextBody = ({
   standaloneRichTextUniversalConfiguration,

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-standalone-rich-text-configuration-type.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-standalone-rich-text-configuration-type.util.ts
@@ -2,42 +2,61 @@ import { msg, t } from '@lingui/core/macro';
 import { isDefined } from 'twenty-shared/utils';
 
 import { type FlatPageLayoutWidgetValidationError } from 'src/engine/metadata-modules/flat-page-layout-widget/types/flat-page-layout-widget-validation-error.type';
-import { type StandaloneRichTextConfigurationDTO } from 'src/engine/metadata-modules/page-layout-widget/dtos/standalone-rich-text-configuration.dto';
 import { WidgetConfigurationType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
 import { PageLayoutWidgetExceptionCode } from 'src/engine/metadata-modules/page-layout-widget/exceptions/page-layout-widget.exception';
+import { UniversalFlatPageLayoutWidget } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type';
 
-export const validateStandaloneRichTextConfigurationType = (
-  configuration: StandaloneRichTextConfigurationDTO,
-  widgetTitle: string,
-): FlatPageLayoutWidgetValidationError[] => {
-  const errors: FlatPageLayoutWidgetValidationError[] = [];
-
-  if (!isDefined(configuration.configurationType)) {
-    errors.push({
-      code: PageLayoutWidgetExceptionCode.INVALID_PAGE_LAYOUT_WIDGET_DATA,
-      message: t`Configuration type is required for widget "${widgetTitle}"`,
-      userFriendlyMessage: msg`Configuration type is required`,
-    });
-
-    return errors;
+export const validateStandaloneRichTextConfigurationType = ({
+  universalConfiguration,
+  widgetTitle,
+}: {
+  universalConfiguration: UniversalFlatPageLayoutWidget['universalConfiguration'];
+  widgetTitle: string;
+}):
+  | {
+      status: 'fail';
+      errors: FlatPageLayoutWidgetValidationError[];
+    }
+  | {
+      status: 'success';
+      standaloneRichTextUniversalConfiguration: UniversalFlatPageLayoutWidget<WidgetConfigurationType.STANDALONE_RICH_TEXT>['universalConfiguration'];
+    } => {
+  if (!isDefined(universalConfiguration.configurationType)) {
+    return {
+      errors: [
+        {
+          code: PageLayoutWidgetExceptionCode.INVALID_PAGE_LAYOUT_WIDGET_DATA,
+          message: t`Configuration type is required for widget "${widgetTitle}"`,
+          userFriendlyMessage: msg`Configuration type is required`,
+        },
+      ],
+      status: 'fail',
+    };
   }
 
   if (
-    configuration.configurationType !==
+    universalConfiguration.configurationType !==
     WidgetConfigurationType.STANDALONE_RICH_TEXT
   ) {
-    const expectedConfigurationType =
-      WidgetConfigurationType.STANDALONE_RICH_TEXT;
+    const configurationTypeString =
+      universalConfiguration.configurationType.toString();
 
-    const configurationType = configuration.configurationType;
-
-    errors.push({
-      code: PageLayoutWidgetExceptionCode.INVALID_PAGE_LAYOUT_WIDGET_DATA,
-      message: t`Invalid configuration type for standalone rich text widget "${widgetTitle}". Expected ${expectedConfigurationType}, got ${configurationType}`,
-      userFriendlyMessage: msg`Invalid configuration type for standalone rich text widget`,
-      value: configuration.configurationType,
-    });
+    return {
+      errors: [
+        {
+          code: PageLayoutWidgetExceptionCode.INVALID_PAGE_LAYOUT_WIDGET_DATA,
+          message: t`Invalid configuration type for standalone rich text widget "${widgetTitle}". Expected STANDALONE_RICH_TEXT, got ${configurationTypeString}`,
+          userFriendlyMessage: msg`Invalid configuration type for standalone rich text widget`,
+          value: universalConfiguration.configurationType,
+        },
+      ],
+      status: 'fail',
+    };
   }
 
-  return errors;
+  return {
+    status: 'success',
+    standaloneRichTextUniversalConfiguration:
+      universalConfiguration as UniversalFlatPageLayoutWidget<WidgetConfigurationType.STANDALONE_RICH_TEXT>['universalConfiguration'],
+  };
 };

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-standalone-rich-text-configuration-type.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-standalone-rich-text-configuration-type.util.ts
@@ -4,7 +4,7 @@ import { isDefined } from 'twenty-shared/utils';
 import { type FlatPageLayoutWidgetValidationError } from 'src/engine/metadata-modules/flat-page-layout-widget/types/flat-page-layout-widget-validation-error.type';
 import { WidgetConfigurationType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
 import { PageLayoutWidgetExceptionCode } from 'src/engine/metadata-modules/page-layout-widget/exceptions/page-layout-widget.exception';
-import { UniversalFlatPageLayoutWidget } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type';
+import { type UniversalFlatPageLayoutWidget } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type';
 
 export const validateStandaloneRichTextConfigurationType = ({
   universalConfiguration,

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-standalone-rich-text-flat-page-layout-widget-for-creation.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-standalone-rich-text-flat-page-layout-widget-for-creation.util.ts
@@ -5,40 +5,40 @@ import { type ValidateFlatPageLayoutWidgetTypeSpecificitiesForCreationArgs } fro
 import { type FlatPageLayoutWidgetValidationError } from 'src/engine/metadata-modules/flat-page-layout-widget/types/flat-page-layout-widget-validation-error.type';
 import { validateStandaloneRichTextBody } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-standalone-rich-text-body.util';
 import { validateStandaloneRichTextConfigurationType } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-standalone-rich-text-configuration-type.util';
-import { type StandaloneRichTextConfigurationDTO } from 'src/engine/metadata-modules/page-layout-widget/dtos/standalone-rich-text-configuration.dto';
 import { PageLayoutWidgetExceptionCode } from 'src/engine/metadata-modules/page-layout-widget/exceptions/page-layout-widget.exception';
 
 export const validateStandaloneRichTextFlatPageLayoutWidgetForCreation = (
   args: ValidateFlatPageLayoutWidgetTypeSpecificitiesForCreationArgs,
 ): FlatPageLayoutWidgetValidationError[] => {
   const { flatEntityToValidate } = args;
-  const { configuration, title } = flatEntityToValidate;
+  const { universalConfiguration, title: widgetTitle } = flatEntityToValidate;
   const errors: FlatPageLayoutWidgetValidationError[] = [];
 
-  if (!isDefined(configuration)) {
+  if (!isDefined(universalConfiguration)) {
     errors.push({
       code: PageLayoutWidgetExceptionCode.INVALID_PAGE_LAYOUT_WIDGET_DATA,
-      message: t`Configuration is required for standalone rich text widget "${title}"`,
+      message: t`Configuration is required for standalone rich text widget "${widgetTitle}"`,
       userFriendlyMessage: msg`Configuration is required for standalone rich text widget`,
     });
 
     return errors;
   }
 
-  const standaloneRichTextConfiguration =
-    configuration as StandaloneRichTextConfigurationDTO;
+  const result = validateStandaloneRichTextConfigurationType({
+    universalConfiguration,
+    widgetTitle,
+  });
 
-  const configurationTypeErrors = validateStandaloneRichTextConfigurationType(
-    standaloneRichTextConfiguration,
-    title,
-  );
+  if (result.status === 'fail') {
+    return [...errors, ...result.errors];
+  }
 
-  errors.push(...configurationTypeErrors);
+  const { standaloneRichTextUniversalConfiguration } = result;
 
-  const bodyErrors = validateStandaloneRichTextBody(
-    standaloneRichTextConfiguration,
-    title,
-  );
+  const bodyErrors = validateStandaloneRichTextBody({
+    standaloneRichTextUniversalConfiguration,
+    widgetTitle,
+  });
 
   errors.push(...bodyErrors);
 

--- a/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-standalone-rich-text-flat-page-layout-widget-for-update.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-standalone-rich-text-flat-page-layout-widget-for-update.util.ts
@@ -4,33 +4,33 @@ import { type ValidateFlatPageLayoutWidgetTypeSpecificitiesForUpdateArgs } from 
 import { type FlatPageLayoutWidgetValidationError } from 'src/engine/metadata-modules/flat-page-layout-widget/types/flat-page-layout-widget-validation-error.type';
 import { validateStandaloneRichTextBody } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-standalone-rich-text-body.util';
 import { validateStandaloneRichTextConfigurationType } from 'src/engine/metadata-modules/flat-page-layout-widget/validators/utils/validate-standalone-rich-text-configuration-type.util';
-import { type StandaloneRichTextConfigurationDTO } from 'src/engine/metadata-modules/page-layout-widget/dtos/standalone-rich-text-configuration.dto';
 
 export const validateStandaloneRichTextFlatPageLayoutWidgetForUpdate = (
   args: ValidateFlatPageLayoutWidgetTypeSpecificitiesForUpdateArgs,
 ): FlatPageLayoutWidgetValidationError[] => {
   const { flatEntityToValidate } = args;
-  const { configuration, title } = flatEntityToValidate;
+  const { universalConfiguration, title: widgetTitle } = flatEntityToValidate;
   const errors: FlatPageLayoutWidgetValidationError[] = [];
 
-  if (!isDefined(configuration)) {
+  if (!isDefined(universalConfiguration)) {
     return [];
   }
 
-  const standaloneRichTextConfiguration =
-    configuration as StandaloneRichTextConfigurationDTO;
+  const result = validateStandaloneRichTextConfigurationType({
+    universalConfiguration,
+    widgetTitle,
+  });
 
-  const configurationTypeErrors = validateStandaloneRichTextConfigurationType(
-    standaloneRichTextConfiguration,
-    title,
-  );
+  if (result.status === 'fail') {
+    return result.errors;
+  }
 
-  errors.push(...configurationTypeErrors);
+  const { standaloneRichTextUniversalConfiguration } = result;
 
-  const bodyErrors = validateStandaloneRichTextBody(
-    standaloneRichTextConfiguration,
-    title,
-  );
+  const bodyErrors = validateStandaloneRichTextBody({
+    standaloneRichTextUniversalConfiguration,
+    widgetTitle,
+  });
 
   errors.push(...bodyErrors);
 

--- a/packages/twenty-server/src/engine/metadata-modules/flat-role/constants/flat-role-required-properties.constants.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-role/constants/flat-role-required-properties.constants.ts
@@ -1,4 +1,4 @@
-import { type FlatRole } from 'src/engine/metadata-modules/flat-role/types/flat-role.type';
+import { type UniversalFlatRole } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-role.type';
 
 export const FLAT_ROLE_REQUIRED_PROPERTIES = [
   'label',
@@ -8,4 +8,4 @@ export const FLAT_ROLE_REQUIRED_PROPERTIES = [
   'canUpdateAllObjectRecords',
   'canSoftDeleteAllObjectRecords',
   'canDestroyAllObjectRecords',
-] as const satisfies (keyof FlatRole)[];
+] as const satisfies (keyof UniversalFlatRole)[];

--- a/packages/twenty-server/src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type.ts
@@ -27,6 +27,12 @@ export enum WidgetConfigurationType {
   WORKFLOW_RUN = 'WORKFLOW_RUN',
   FRONT_COMPONENT = 'FRONT_COMPONENT',
 }
+export type AllGraphWidgetConfigurationType =
+  | WidgetConfigurationType.AGGREGATE_CHART
+  | WidgetConfigurationType.GAUGE_CHART
+  | WidgetConfigurationType.PIE_CHART
+  | WidgetConfigurationType.BAR_CHART
+  | WidgetConfigurationType.LINE_CHART;
 
 registerEnumType(WidgetConfigurationType, {
   name: 'WidgetConfigurationType',

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-agent.type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-agent.type.ts
@@ -1,0 +1,7 @@
+import { type AgentEntity } from 'src/engine/metadata-modules/ai/ai-agent/entities/agent.entity';
+import { type UniversalFlatEntityFrom } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-entity-from.type';
+
+export type UniversalFlatAgent = UniversalFlatEntityFrom<
+  AgentEntity,
+  'agent'
+>;

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-agent.type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-agent.type.ts
@@ -1,7 +1,4 @@
 import { type AgentEntity } from 'src/engine/metadata-modules/ai/ai-agent/entities/agent.entity';
 import { type UniversalFlatEntityFrom } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-entity-from.type';
 
-export type UniversalFlatAgent = UniversalFlatEntityFrom<
-  AgentEntity,
-  'agent'
->;
+export type UniversalFlatAgent = UniversalFlatEntityFrom<AgentEntity, 'agent'>;

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-command-menu-item.type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-command-menu-item.type.ts
@@ -1,0 +1,7 @@
+import { type CommandMenuItemEntity } from 'src/engine/metadata-modules/command-menu-item/entities/command-menu-item.entity';
+import { type UniversalFlatEntityFrom } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-entity-from.type';
+
+export type UniversalFlatCommandMenuItem = UniversalFlatEntityFrom<
+  CommandMenuItemEntity,
+  'commandMenuItem'
+>;

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-front-component.type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-front-component.type.ts
@@ -1,0 +1,7 @@
+import { type FrontComponentEntity } from 'src/engine/metadata-modules/front-component/entities/front-component.entity';
+import { type UniversalFlatEntityFrom } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-entity-from.type';
+
+export type UniversalFlatFrontComponent = UniversalFlatEntityFrom<
+  FrontComponentEntity,
+  'frontComponent'
+>;

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-logic-function.type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-logic-function.type.ts
@@ -1,0 +1,7 @@
+import { type LogicFunctionEntity } from 'src/engine/metadata-modules/logic-function/logic-function.entity';
+import { type UniversalFlatEntityFrom } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-entity-from.type';
+
+export type UniversalFlatLogicFunction = UniversalFlatEntityFrom<
+  LogicFunctionEntity,
+  'logicFunction'
+>;

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-logic-function.type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-logic-function.type.ts
@@ -1,7 +1,11 @@
+import { type Sources } from 'twenty-shared/types';
+
 import { type LogicFunctionEntity } from 'src/engine/metadata-modules/logic-function/logic-function.entity';
 import { type UniversalFlatEntityFrom } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-entity-from.type';
 
 export type UniversalFlatLogicFunction = UniversalFlatEntityFrom<
   LogicFunctionEntity,
   'logicFunction'
->;
+> & {
+  code?: Sources;
+};

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-navigation-menu-item.type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-navigation-menu-item.type.ts
@@ -1,0 +1,7 @@
+import { type NavigationMenuItemEntity } from 'src/engine/metadata-modules/navigation-menu-item/entities/navigation-menu-item.entity';
+import { type UniversalFlatEntityFrom } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-entity-from.type';
+
+export type UniversalFlatNavigationMenuItem = UniversalFlatEntityFrom<
+  NavigationMenuItemEntity,
+  'navigationMenuItem'
+>;

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-tab.type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-tab.type.ts
@@ -1,0 +1,7 @@
+import { type PageLayoutTabEntity } from 'src/engine/metadata-modules/page-layout-tab/entities/page-layout-tab.entity';
+import { type UniversalFlatEntityFrom } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-entity-from.type';
+
+export type UniversalFlatPageLayoutTab = UniversalFlatEntityFrom<
+  PageLayoutTabEntity,
+  'pageLayoutTab'
+>;

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type.ts
@@ -1,5 +1,5 @@
 import { type PageLayoutWidgetEntity } from 'src/engine/metadata-modules/page-layout-widget/entities/page-layout-widget.entity';
-import { WidgetConfigurationType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
+import { type WidgetConfigurationType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
 import { type UniversalFlatEntityFrom } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-entity-from.type';
 
 export type UniversalFlatPageLayoutWidget<

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type.ts
@@ -1,7 +1,11 @@
 import { type PageLayoutWidgetEntity } from 'src/engine/metadata-modules/page-layout-widget/entities/page-layout-widget.entity';
+import { WidgetConfigurationType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-configuration-type.type';
 import { type UniversalFlatEntityFrom } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-entity-from.type';
 
-export type UniversalFlatPageLayoutWidget = UniversalFlatEntityFrom<
-  PageLayoutWidgetEntity,
+export type UniversalFlatPageLayoutWidget<
+  TWidgetConfigurationType extends
+    WidgetConfigurationType = WidgetConfigurationType,
+> = UniversalFlatEntityFrom<
+  PageLayoutWidgetEntity<TWidgetConfigurationType>,
   'pageLayoutWidget'
 >;

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-widget.type.ts
@@ -1,0 +1,7 @@
+import { type PageLayoutWidgetEntity } from 'src/engine/metadata-modules/page-layout-widget/entities/page-layout-widget.entity';
+import { type UniversalFlatEntityFrom } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-entity-from.type';
+
+export type UniversalFlatPageLayoutWidget = UniversalFlatEntityFrom<
+  PageLayoutWidgetEntity,
+  'pageLayoutWidget'
+>;

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout.type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout.type.ts
@@ -1,0 +1,7 @@
+import { type PageLayoutEntity } from 'src/engine/metadata-modules/page-layout/entities/page-layout.entity';
+import { type UniversalFlatEntityFrom } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-entity-from.type';
+
+export type UniversalFlatPageLayout = UniversalFlatEntityFrom<
+  PageLayoutEntity,
+  'pageLayout'
+>;

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-role-target.type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-role-target.type.ts
@@ -1,0 +1,7 @@
+import { type RoleTargetEntity } from 'src/engine/metadata-modules/role-target/role-target.entity';
+import { type UniversalFlatEntityFrom } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-entity-from.type';
+
+export type UniversalFlatRoleTarget = UniversalFlatEntityFrom<
+  RoleTargetEntity,
+  'roleTarget'
+>;

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-row-level-permission-predicate-group.type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-row-level-permission-predicate-group.type.ts
@@ -1,0 +1,8 @@
+import { type RowLevelPermissionPredicateGroupEntity } from 'src/engine/metadata-modules/row-level-permission-predicate/entities/row-level-permission-predicate-group.entity';
+import { type UniversalFlatEntityFrom } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-entity-from.type';
+
+export type UniversalFlatRowLevelPermissionPredicateGroup =
+  UniversalFlatEntityFrom<
+    RowLevelPermissionPredicateGroupEntity,
+    'rowLevelPermissionPredicateGroup'
+  >;

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-row-level-permission-predicate.type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-row-level-permission-predicate.type.ts
@@ -1,8 +1,7 @@
 import { type RowLevelPermissionPredicateEntity } from 'src/engine/metadata-modules/row-level-permission-predicate/entities/row-level-permission-predicate.entity';
 import { type UniversalFlatEntityFrom } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-entity-from.type';
 
-export type UniversalFlatRowLevelPermissionPredicate =
-  UniversalFlatEntityFrom<
-    RowLevelPermissionPredicateEntity,
-    'rowLevelPermissionPredicate'
-  >;
+export type UniversalFlatRowLevelPermissionPredicate = UniversalFlatEntityFrom<
+  RowLevelPermissionPredicateEntity,
+  'rowLevelPermissionPredicate'
+>;

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-row-level-permission-predicate.type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-row-level-permission-predicate.type.ts
@@ -1,0 +1,8 @@
+import { type RowLevelPermissionPredicateEntity } from 'src/engine/metadata-modules/row-level-permission-predicate/entities/row-level-permission-predicate.entity';
+import { type UniversalFlatEntityFrom } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-entity-from.type';
+
+export type UniversalFlatRowLevelPermissionPredicate =
+  UniversalFlatEntityFrom<
+    RowLevelPermissionPredicateEntity,
+    'rowLevelPermissionPredicate'
+  >;

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-webhook.type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-webhook.type.ts
@@ -1,0 +1,7 @@
+import { type WebhookEntity } from 'src/engine/metadata-modules/webhook/entities/webhook.entity';
+import { type UniversalFlatEntityFrom } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-entity-from.type';
+
+export type UniversalFlatWebhook = UniversalFlatEntityFrom<
+  WebhookEntity,
+  'webhook'
+>;

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/agent/types/workspace-migration-agent-action-builder.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/agent/types/workspace-migration-agent-action-builder.service.ts
@@ -1,11 +1,15 @@
 import { type BaseFlatCreateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-flat-create-workspace-migration-action.type';
 import { type BaseFlatDeleteWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-flat-delete-workspace-migration-action.type';
 import { type BaseFlatUpdateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-flat-update-workspace-migration-action.type';
+import { type BaseUniversalCreateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-universal-create-workspace-migration-action.type';
 import { type BaseUniversalDeleteWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-universal-delete-workspace-migration-action.type';
 import { type BaseUniversalUpdateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-universal-update-workspace-migration-action.type';
 
 export type FlatCreateAgentAction =
   BaseFlatCreateWorkspaceMigrationAction<'agent'>;
+
+export type UniversalCreateAgentAction =
+  BaseUniversalCreateWorkspaceMigrationAction<'agent'>;
 
 export type FlatUpdateAgentAction =
   BaseFlatUpdateWorkspaceMigrationAction<'agent'>;

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/command-menu-item/types/workspace-migration-command-menu-item-action.type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/command-menu-item/types/workspace-migration-command-menu-item-action.type.ts
@@ -1,11 +1,15 @@
 import { type BaseFlatCreateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-flat-create-workspace-migration-action.type';
 import { type BaseFlatDeleteWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-flat-delete-workspace-migration-action.type';
 import { type BaseFlatUpdateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-flat-update-workspace-migration-action.type';
+import { type BaseUniversalCreateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-universal-create-workspace-migration-action.type';
 import { type BaseUniversalDeleteWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-universal-delete-workspace-migration-action.type';
 import { type BaseUniversalUpdateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-universal-update-workspace-migration-action.type';
 
 export type FlatCreateCommandMenuItemAction =
   BaseFlatCreateWorkspaceMigrationAction<'commandMenuItem'>;
+
+export type UniversalCreateCommandMenuItemAction =
+  BaseUniversalCreateWorkspaceMigrationAction<'commandMenuItem'>;
 
 export type FlatUpdateCommandMenuItemAction =
   BaseFlatUpdateWorkspaceMigrationAction<'commandMenuItem'>;

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/front-component/types/workspace-migration-front-component-action.type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/front-component/types/workspace-migration-front-component-action.type.ts
@@ -1,11 +1,15 @@
 import { type BaseFlatCreateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-flat-create-workspace-migration-action.type';
 import { type BaseFlatDeleteWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-flat-delete-workspace-migration-action.type';
 import { type BaseFlatUpdateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-flat-update-workspace-migration-action.type';
+import { type BaseUniversalCreateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-universal-create-workspace-migration-action.type';
 import { type BaseUniversalDeleteWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-universal-delete-workspace-migration-action.type';
 import { type BaseUniversalUpdateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-universal-update-workspace-migration-action.type';
 
 export type FlatCreateFrontComponentAction =
   BaseFlatCreateWorkspaceMigrationAction<'frontComponent'>;
+
+export type UniversalCreateFrontComponentAction =
+  BaseUniversalCreateWorkspaceMigrationAction<'frontComponent'>;
 
 export type FlatUpdateFrontComponentAction =
   BaseFlatUpdateWorkspaceMigrationAction<'frontComponent'>;

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/logic-function/types/workspace-migration-logic-function-action.type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/logic-function/types/workspace-migration-logic-function-action.type.ts
@@ -3,11 +3,15 @@ import { type Sources } from 'twenty-shared/types';
 import { type BaseFlatCreateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-flat-create-workspace-migration-action.type';
 import { type BaseFlatDeleteWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-flat-delete-workspace-migration-action.type';
 import { type BaseFlatUpdateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-flat-update-workspace-migration-action.type';
+import { type BaseUniversalCreateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-universal-create-workspace-migration-action.type';
 import { type BaseUniversalDeleteWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-universal-delete-workspace-migration-action.type';
 import { type BaseUniversalUpdateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-universal-update-workspace-migration-action.type';
 
 export type FlatCreateLogicFunctionAction =
   BaseFlatCreateWorkspaceMigrationAction<'logicFunction'>;
+
+export type UniversalCreateLogicFunctionAction =
+  BaseUniversalCreateWorkspaceMigrationAction<'logicFunction'>;
 
 export type FlatUpdateLogicFunctionAction =
   BaseFlatUpdateWorkspaceMigrationAction<'logicFunction'> & {

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/navigation-menu-item/types/workspace-migration-navigation-menu-item-action.type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/navigation-menu-item/types/workspace-migration-navigation-menu-item-action.type.ts
@@ -1,11 +1,15 @@
 import { type BaseFlatCreateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-flat-create-workspace-migration-action.type';
 import { type BaseFlatDeleteWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-flat-delete-workspace-migration-action.type';
 import { type BaseFlatUpdateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-flat-update-workspace-migration-action.type';
+import { type BaseUniversalCreateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-universal-create-workspace-migration-action.type';
 import { type BaseUniversalDeleteWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-universal-delete-workspace-migration-action.type';
 import { type BaseUniversalUpdateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-universal-update-workspace-migration-action.type';
 
 export type FlatCreateNavigationMenuItemAction =
   BaseFlatCreateWorkspaceMigrationAction<'navigationMenuItem'>;
+
+export type UniversalCreateNavigationMenuItemAction =
+  BaseUniversalCreateWorkspaceMigrationAction<'navigationMenuItem'>;
 
 export type FlatUpdateNavigationMenuItemAction =
   BaseFlatUpdateWorkspaceMigrationAction<'navigationMenuItem'>;

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/page-layout-tab/types/workspace-migration-page-layout-tab-action.type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/page-layout-tab/types/workspace-migration-page-layout-tab-action.type.ts
@@ -1,11 +1,15 @@
 import { type BaseFlatCreateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-flat-create-workspace-migration-action.type';
 import { type BaseFlatDeleteWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-flat-delete-workspace-migration-action.type';
 import { type BaseFlatUpdateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-flat-update-workspace-migration-action.type';
+import { type BaseUniversalCreateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-universal-create-workspace-migration-action.type';
 import { type BaseUniversalDeleteWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-universal-delete-workspace-migration-action.type';
 import { type BaseUniversalUpdateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-universal-update-workspace-migration-action.type';
 
 export type FlatCreatePageLayoutTabAction =
   BaseFlatCreateWorkspaceMigrationAction<'pageLayoutTab'>;
+
+export type UniversalCreatePageLayoutTabAction =
+  BaseUniversalCreateWorkspaceMigrationAction<'pageLayoutTab'>;
 
 export type FlatUpdatePageLayoutTabAction =
   BaseFlatUpdateWorkspaceMigrationAction<'pageLayoutTab'>;

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/page-layout-widget/types/workspace-migration-page-layout-widget-action.type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/page-layout-widget/types/workspace-migration-page-layout-widget-action.type.ts
@@ -1,11 +1,15 @@
 import { type BaseFlatCreateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-flat-create-workspace-migration-action.type';
 import { type BaseFlatDeleteWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-flat-delete-workspace-migration-action.type';
 import { type BaseFlatUpdateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-flat-update-workspace-migration-action.type';
+import { type BaseUniversalCreateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-universal-create-workspace-migration-action.type';
 import { type BaseUniversalDeleteWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-universal-delete-workspace-migration-action.type';
 import { type BaseUniversalUpdateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-universal-update-workspace-migration-action.type';
 
 export type FlatCreatePageLayoutWidgetAction =
   BaseFlatCreateWorkspaceMigrationAction<'pageLayoutWidget'>;
+
+export type UniversalCreatePageLayoutWidgetAction =
+  BaseUniversalCreateWorkspaceMigrationAction<'pageLayoutWidget'>;
 
 export type FlatUpdatePageLayoutWidgetAction =
   BaseFlatUpdateWorkspaceMigrationAction<'pageLayoutWidget'>;

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/page-layout/types/workspace-migration-page-layout-action.type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/page-layout/types/workspace-migration-page-layout-action.type.ts
@@ -1,11 +1,15 @@
 import { type BaseFlatCreateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-flat-create-workspace-migration-action.type';
 import { type BaseFlatDeleteWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-flat-delete-workspace-migration-action.type';
 import { type BaseFlatUpdateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-flat-update-workspace-migration-action.type';
+import { type BaseUniversalCreateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-universal-create-workspace-migration-action.type';
 import { type BaseUniversalDeleteWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-universal-delete-workspace-migration-action.type';
 import { type BaseUniversalUpdateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-universal-update-workspace-migration-action.type';
 
 export type FlatCreatePageLayoutAction =
   BaseFlatCreateWorkspaceMigrationAction<'pageLayout'>;
+
+export type UniversalCreatePageLayoutAction =
+  BaseUniversalCreateWorkspaceMigrationAction<'pageLayout'>;
 
 export type FlatUpdatePageLayoutAction =
   BaseFlatUpdateWorkspaceMigrationAction<'pageLayout'>;

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/role-target/types/workspace-migration-role-target-action.type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/role-target/types/workspace-migration-role-target-action.type.ts
@@ -1,11 +1,15 @@
 import { type BaseFlatCreateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-flat-create-workspace-migration-action.type';
 import { type BaseFlatDeleteWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-flat-delete-workspace-migration-action.type';
 import { type BaseFlatUpdateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-flat-update-workspace-migration-action.type';
+import { type BaseUniversalCreateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-universal-create-workspace-migration-action.type';
 import { type BaseUniversalDeleteWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-universal-delete-workspace-migration-action.type';
 import { type BaseUniversalUpdateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-universal-update-workspace-migration-action.type';
 
 export type FlatCreateRoleTargetAction =
   BaseFlatCreateWorkspaceMigrationAction<'roleTarget'>;
+
+export type UniversalCreateRoleTargetAction =
+  BaseUniversalCreateWorkspaceMigrationAction<'roleTarget'>;
 
 export type FlatUpdateRoleTargetAction =
   BaseFlatUpdateWorkspaceMigrationAction<'roleTarget'>;

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/role/types/workspace-migration-role-action.type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/role/types/workspace-migration-role-action.type.ts
@@ -1,11 +1,15 @@
 import { type BaseFlatCreateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-flat-create-workspace-migration-action.type';
 import { type BaseFlatDeleteWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-flat-delete-workspace-migration-action.type';
 import { type BaseFlatUpdateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-flat-update-workspace-migration-action.type';
+import { type BaseUniversalCreateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-universal-create-workspace-migration-action.type';
 import { type BaseUniversalDeleteWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-universal-delete-workspace-migration-action.type';
 import { type BaseUniversalUpdateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-universal-update-workspace-migration-action.type';
 
 export type FlatCreateRoleAction =
   BaseFlatCreateWorkspaceMigrationAction<'role'>;
+
+export type UniversalCreateRoleAction =
+  BaseUniversalCreateWorkspaceMigrationAction<'role'>;
 
 export type FlatUpdateRoleAction =
   BaseFlatUpdateWorkspaceMigrationAction<'role'>;

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/row-level-permission-predicate-group/types/workspace-migration-row-level-permission-predicate-group-action.type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/row-level-permission-predicate-group/types/workspace-migration-row-level-permission-predicate-group-action.type.ts
@@ -3,11 +3,15 @@
 import { type BaseFlatCreateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-flat-create-workspace-migration-action.type';
 import { type BaseFlatDeleteWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-flat-delete-workspace-migration-action.type';
 import { type BaseFlatUpdateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-flat-update-workspace-migration-action.type';
+import { type BaseUniversalCreateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-universal-create-workspace-migration-action.type';
 import { type BaseUniversalDeleteWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-universal-delete-workspace-migration-action.type';
 import { type BaseUniversalUpdateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-universal-update-workspace-migration-action.type';
 
 export type FlatCreateRowLevelPermissionPredicateGroupAction =
   BaseFlatCreateWorkspaceMigrationAction<'rowLevelPermissionPredicateGroup'>;
+
+export type UniversalCreateRowLevelPermissionPredicateGroupAction =
+  BaseUniversalCreateWorkspaceMigrationAction<'rowLevelPermissionPredicateGroup'>;
 
 export type FlatUpdateRowLevelPermissionPredicateGroupAction =
   BaseFlatUpdateWorkspaceMigrationAction<'rowLevelPermissionPredicateGroup'>;

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/row-level-permission-predicate/types/workspace-migration-row-level-permission-predicate-action.type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/row-level-permission-predicate/types/workspace-migration-row-level-permission-predicate-action.type.ts
@@ -3,11 +3,15 @@
 import { type BaseFlatCreateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-flat-create-workspace-migration-action.type';
 import { type BaseFlatDeleteWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-flat-delete-workspace-migration-action.type';
 import { type BaseFlatUpdateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-flat-update-workspace-migration-action.type';
+import { type BaseUniversalCreateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-universal-create-workspace-migration-action.type';
 import { type BaseUniversalDeleteWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-universal-delete-workspace-migration-action.type';
 import { type BaseUniversalUpdateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-universal-update-workspace-migration-action.type';
 
 export type FlatCreateRowLevelPermissionPredicateAction =
   BaseFlatCreateWorkspaceMigrationAction<'rowLevelPermissionPredicate'>;
+
+export type UniversalCreateRowLevelPermissionPredicateAction =
+  BaseUniversalCreateWorkspaceMigrationAction<'rowLevelPermissionPredicate'>;
 
 export type FlatUpdateRowLevelPermissionPredicateAction =
   BaseFlatUpdateWorkspaceMigrationAction<'rowLevelPermissionPredicate'>;

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/webhook/types/workspace-migration-webhook-action.type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/webhook/types/workspace-migration-webhook-action.type.ts
@@ -1,11 +1,15 @@
 import { type BaseFlatCreateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-flat-create-workspace-migration-action.type';
 import { type BaseFlatDeleteWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-flat-delete-workspace-migration-action.type';
 import { type BaseFlatUpdateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-flat-update-workspace-migration-action.type';
+import { type BaseUniversalCreateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-universal-create-workspace-migration-action.type';
 import { type BaseUniversalDeleteWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-universal-delete-workspace-migration-action.type';
 import { type BaseUniversalUpdateWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/base-universal-update-workspace-migration-action.type';
 
 export type FlatCreateWebhookAction =
   BaseFlatCreateWorkspaceMigrationAction<'webhook'>;
+
+export type UniversalCreateWebhookAction =
+  BaseUniversalCreateWorkspaceMigrationAction<'webhook'>;
 
 export type FlatUpdateWebhookAction =
   BaseFlatUpdateWorkspaceMigrationAction<'webhook'>;

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-agent-validator.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-agent-validator.service.ts
@@ -5,8 +5,8 @@ import { ALL_METADATA_NAME } from 'twenty-shared/metadata';
 import { isDefined } from 'twenty-shared/utils';
 
 import { AgentExceptionCode } from 'src/engine/metadata-modules/ai/ai-agent/agent.exception';
-import { type FlatAgent } from 'src/engine/metadata-modules/flat-agent/types/flat-agent.type';
 import { findFlatEntityByUniversalIdentifier } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier.util';
+import { type UniversalFlatAgent } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-agent.type';
 import { belongsToTwentyStandardApp } from 'src/engine/metadata-modules/utils/belongs-to-twenty-standard-app.util';
 import { type FailedFlatEntityValidation } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/types/failed-flat-entity-validation.type';
 import { getEmptyFlatEntityValidationError } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/utils/get-flat-entity-validation-error.util';
@@ -162,7 +162,7 @@ export class FlatAgentValidatorService {
       });
     }
 
-    const optimisticFlatAgent: FlatAgent = {
+    const optimisticFlatAgent: UniversalFlatAgent = {
       ...fromFlatAgent,
       ...flatEntityUpdate,
     };

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-command-menu-item-validator.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-command-menu-item-validator.service.ts
@@ -38,12 +38,14 @@ export class FlatCommandMenuItemValidatorService {
     const hasWorkflowVersionId = isDefined(
       flatCommandMenuItem.workflowVersionId,
     );
-    const hasFrontComponentId = isDefined(flatCommandMenuItem.frontComponentId);
+    const hasFrontComponentUniversalIdentifier = isDefined(
+      flatCommandMenuItem.frontComponentUniversalIdentifier,
+    );
 
-    if (hasWorkflowVersionId === hasFrontComponentId) {
+    if (hasWorkflowVersionId === hasFrontComponentUniversalIdentifier) {
       validationResult.errors.push({
         code: CommandMenuItemExceptionCode.WORKFLOW_OR_FRONT_COMPONENT_REQUIRED,
-        message: t`Exactly one of workflowVersionId or frontComponentId is required`,
+        message: t`Exactly one of workflowVersionId or frontComponentUniversalIdentifier is required`,
         userFriendlyMessage: msg`Exactly one of workflow version or front component is required`,
       });
     }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-page-layout-widget-validator.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-page-layout-widget-validator.service.ts
@@ -10,13 +10,12 @@ import { isDefined } from 'twenty-shared/utils';
 
 import { FeatureFlagKey } from 'src/engine/core-modules/feature-flag/enums/feature-flag-key.enum';
 import { findFlatEntityByUniversalIdentifier } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier.util';
-import { type FlatPageLayoutTab } from 'src/engine/metadata-modules/flat-page-layout-tab/types/flat-page-layout-tab.type';
+import { type UniversalFlatPageLayoutTab } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-page-layout-tab.type';
 import { FlatPageLayoutWidgetTypeValidatorService } from 'src/engine/metadata-modules/flat-page-layout-widget/services/flat-page-layout-widget-type-validator.service';
 import { PageLayoutTabExceptionCode } from 'src/engine/metadata-modules/page-layout-tab/exceptions/page-layout-tab.exception';
 import { GraphType } from 'src/engine/metadata-modules/page-layout-widget/enums/graph-type.enum';
 import { WidgetType } from 'src/engine/metadata-modules/page-layout-widget/enums/widget-type.enum';
 import { PageLayoutWidgetExceptionCode } from 'src/engine/metadata-modules/page-layout-widget/exceptions/page-layout-widget.exception';
-import { AllPageLayoutWidgetConfiguration } from 'src/engine/metadata-modules/page-layout-widget/types/all-page-layout-widget-configuration.type';
 import { GridPosition } from 'src/engine/metadata-modules/page-layout-widget/types/grid-position.type';
 import { validatePageLayoutWidgetGridPosition } from 'src/engine/metadata-modules/page-layout-widget/utils/validate-page-layout-widget-grid-position.util';
 import { validatePageLayoutWidgetVerticalListPosition } from 'src/engine/metadata-modules/page-layout-widget/utils/validate-page-layout-widget-vertical-list-position.util';
@@ -107,7 +106,7 @@ export class FlatPageLayoutWidgetValidatorService {
 
     const featureFlagErrors = this.validateFeatureFlags({
       type: updatedFlatPageLayoutWidget.type,
-      configuration: updatedFlatPageLayoutWidget.configuration,
+      configuration: updatedFlatPageLayoutWidget.universalConfiguration,
       widgetTitle: updatedFlatPageLayoutWidget.title,
       isDashboardV2Enabled,
     });
@@ -239,7 +238,7 @@ export class FlatPageLayoutWidgetValidatorService {
 
     const featureFlagErrors = this.validateFeatureFlags({
       type: flatPageLayoutWidgetToValidate.type,
-      configuration: flatPageLayoutWidgetToValidate.configuration,
+      configuration: flatPageLayoutWidgetToValidate.universalConfiguration,
       widgetTitle: flatPageLayoutWidgetToValidate.title,
       isDashboardV2Enabled,
     });
@@ -290,7 +289,7 @@ export class FlatPageLayoutWidgetValidatorService {
     isDashboardV2Enabled,
   }: {
     type: WidgetType | undefined;
-    configuration: AllPageLayoutWidgetConfiguration | null | undefined;
+    configuration: { configurationType?: unknown } | null | undefined;
     widgetTitle: string;
     isDashboardV2Enabled: boolean;
   }): FlatEntityValidationError[] {
@@ -302,7 +301,7 @@ export class FlatPageLayoutWidgetValidatorService {
       return [];
     }
 
-    const graphConfiguration = configuration as unknown as {
+    const graphConfiguration = configuration as {
       configurationType?: GraphType;
     };
 
@@ -330,7 +329,7 @@ export class FlatPageLayoutWidgetValidatorService {
     widgetTitle,
   }: {
     position: PageLayoutWidgetPosition | null | undefined;
-    pageLayoutTab: FlatPageLayoutTab | undefined;
+    pageLayoutTab: UniversalFlatPageLayoutTab | undefined;
     widgetTitle: string;
   }): FlatEntityValidationError[] {
     if (!isDefined(position)) {

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-group-validator.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-group-validator.service.ts
@@ -180,27 +180,34 @@ export class FlatRowLevelPermissionPredicateGroupValidatorService {
       ...flatEntityUpdate,
     };
 
-    if (updatedPredicateGroup.roleId !== existingPredicateGroup.roleId) {
-      const existingRoleId = existingPredicateGroup.roleId;
-      const updatedRoleId = updatedPredicateGroup.roleId;
+    if (
+      updatedPredicateGroup.roleUniversalIdentifier !==
+      existingPredicateGroup.roleUniversalIdentifier
+    ) {
+      const existingRoleIdentifier =
+        existingPredicateGroup.roleUniversalIdentifier;
+      const updatedRoleIdentifier =
+        updatedPredicateGroup.roleUniversalIdentifier;
 
       validationResult.errors.push({
         code: RowLevelPermissionPredicateGroupExceptionCode.UNAUTHORIZED_ROLE_MODIFICATION,
-        message: t`Cannot modify predicate group to change its role from ${existingRoleId} to ${updatedRoleId}`,
+        message: t`Cannot modify predicate group to change its role from ${existingRoleIdentifier} to ${updatedRoleIdentifier}`,
         userFriendlyMessage: msg`Cannot modify predicate group to change its role`,
       });
     }
 
     if (
-      updatedPredicateGroup.objectMetadataId !==
-      existingPredicateGroup.objectMetadataId
+      updatedPredicateGroup.objectMetadataUniversalIdentifier !==
+      existingPredicateGroup.objectMetadataUniversalIdentifier
     ) {
-      const existingObjectMetadataId = existingPredicateGroup.objectMetadataId;
-      const updatedObjectMetadataId = updatedPredicateGroup.objectMetadataId;
+      const existingObjectMetadataIdentifier =
+        existingPredicateGroup.objectMetadataUniversalIdentifier;
+      const updatedObjectMetadataIdentifier =
+        updatedPredicateGroup.objectMetadataUniversalIdentifier;
 
       validationResult.errors.push({
         code: RowLevelPermissionPredicateGroupExceptionCode.UNAUTHORIZED_OBJECT_MODIFICATION,
-        message: t`Cannot modify predicate group to change its object from ${existingObjectMetadataId} to ${updatedObjectMetadataId}`,
+        message: t`Cannot modify predicate group to change its object from ${existingObjectMetadataIdentifier} to ${updatedObjectMetadataIdentifier}`,
         userFriendlyMessage: msg`Cannot modify predicate group to change its object`,
       });
     }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-validator.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-validator.service.ts
@@ -200,10 +200,8 @@ export class FlatRowLevelPermissionPredicateValidatorService {
       updatedPredicate.roleUniversalIdentifier !==
       existingPredicate.roleUniversalIdentifier
     ) {
-      const existingRoleIdentifier =
-        existingPredicate.roleUniversalIdentifier;
-      const updatedRoleIdentifier =
-        updatedPredicate.roleUniversalIdentifier;
+      const existingRoleIdentifier = existingPredicate.roleUniversalIdentifier;
+      const updatedRoleIdentifier = updatedPredicate.roleUniversalIdentifier;
 
       validationResult.errors.push({
         code: RowLevelPermissionPredicateExceptionCode.UNAUTHORIZED_ROLE_MODIFICATION,

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-validator.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/services/flat-row-level-permission-predicate-validator.service.ts
@@ -196,26 +196,34 @@ export class FlatRowLevelPermissionPredicateValidatorService {
       ...flatEntityUpdate,
     };
 
-    if (updatedPredicate.roleId !== existingPredicate.roleId) {
-      const existingRoleId = existingPredicate.roleId;
-      const updatedRoleId = updatedPredicate.roleId;
+    if (
+      updatedPredicate.roleUniversalIdentifier !==
+      existingPredicate.roleUniversalIdentifier
+    ) {
+      const existingRoleIdentifier =
+        existingPredicate.roleUniversalIdentifier;
+      const updatedRoleIdentifier =
+        updatedPredicate.roleUniversalIdentifier;
 
       validationResult.errors.push({
         code: RowLevelPermissionPredicateExceptionCode.UNAUTHORIZED_ROLE_MODIFICATION,
-        message: t`Cannot modify predicate to change its role from ${existingRoleId} to ${updatedRoleId}`,
+        message: t`Cannot modify predicate to change its role from ${existingRoleIdentifier} to ${updatedRoleIdentifier}`,
         userFriendlyMessage: msg`Cannot modify predicate to change its role`,
       });
     }
 
     if (
-      updatedPredicate.objectMetadataId !== existingPredicate.objectMetadataId
+      updatedPredicate.objectMetadataUniversalIdentifier !==
+      existingPredicate.objectMetadataUniversalIdentifier
     ) {
-      const existingObjectMetadataId = existingPredicate.objectMetadataId;
-      const updatedObjectMetadataId = updatedPredicate.objectMetadataId;
+      const existingObjectMetadataIdentifier =
+        existingPredicate.objectMetadataUniversalIdentifier;
+      const updatedObjectMetadataIdentifier =
+        updatedPredicate.objectMetadataUniversalIdentifier;
 
       validationResult.errors.push({
         code: RowLevelPermissionPredicateExceptionCode.UNAUTHORIZED_OBJECT_MODIFICATION,
-        message: t`Cannot modify predicate to change its object from ${existingObjectMetadataId} to ${updatedObjectMetadataId}`,
+        message: t`Cannot modify predicate to change its object from ${existingObjectMetadataIdentifier} to ${updatedObjectMetadataIdentifier}`,
         userFriendlyMessage: msg`Cannot modify predicate to change its object`,
       });
     }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-agent-name-uniqueness.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-agent-name-uniqueness.util.ts
@@ -1,7 +1,7 @@
 import { msg, t } from '@lingui/core/macro';
 
 import { AgentExceptionCode } from 'src/engine/metadata-modules/ai/ai-agent/agent.exception';
-import { type FlatAgent } from 'src/engine/metadata-modules/flat-agent/types/flat-agent.type';
+import { type UniversalFlatAgent } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-agent.type';
 import { type FlatEntityValidationError } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/types/failed-flat-entity-validation.type';
 
 export const validateAgentNameUniqueness = ({
@@ -9,7 +9,7 @@ export const validateAgentNameUniqueness = ({
   existingFlatAgents,
 }: {
   name: string;
-  existingFlatAgents: FlatAgent[];
+  existingFlatAgents: UniversalFlatAgent[];
 }): FlatEntityValidationError<AgentExceptionCode>[] => {
   const errors: FlatEntityValidationError<AgentExceptionCode>[] = [];
 

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-agent-required-properties.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-agent-required-properties.util.ts
@@ -2,12 +2,12 @@ import { msg, t } from '@lingui/core/macro';
 import { isNonEmptyString } from '@sniptt/guards';
 
 import { AgentExceptionCode } from 'src/engine/metadata-modules/ai/ai-agent/agent.exception';
-import { type FlatAgent } from 'src/engine/metadata-modules/flat-agent/types/flat-agent.type';
+import { type UniversalFlatAgent } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-agent.type';
 import { type FlatEntityValidationError } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/types/failed-flat-entity-validation.type';
 
 type ValidateAgentRequiredPropertiesArgs = {
-  flatAgent: FlatAgent;
-  updatedProperties?: Partial<FlatAgent>;
+  flatAgent: UniversalFlatAgent;
+  updatedProperties?: Partial<UniversalFlatAgent>;
 };
 
 export const validateAgentRequiredProperties = ({

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-flat-role-target-assignation-availability.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-flat-role-target-assignation-availability.util.ts
@@ -1,14 +1,14 @@
 import { msg, t } from '@lingui/core/macro';
 import { isDefined } from 'class-validator';
 
-import { type FlatRoleTarget } from 'src/engine/metadata-modules/flat-role-target/types/flat-role-target.type';
-import { type FlatRole } from 'src/engine/metadata-modules/flat-role/types/flat-role.type';
 import { RoleTargetExceptionCode } from 'src/engine/metadata-modules/role/exceptions/role-target.exception';
+import { type UniversalFlatRole } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-role.type';
+import { type UniversalFlatRoleTarget } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-role-target.type';
 import { type FlatEntityValidationError } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/types/failed-flat-entity-validation.type';
 
 type ValidateFlatRoleTargetAssignationAvailabilityArgs = {
-  flatRole: FlatRole;
-  flatRoleTarget: FlatRoleTarget;
+  flatRole: UniversalFlatRole;
+  flatRoleTarget: UniversalFlatRoleTarget;
 };
 export const validateFlatRoleTargetAssignationAvailability = ({
   flatRole,

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-flat-role-target-targets-only-one-entity.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-flat-role-target-targets-only-one-entity.util.ts
@@ -1,14 +1,14 @@
 import { msg, t } from '@lingui/core/macro';
 import { isDefined } from 'twenty-shared/utils';
 
-import { type FlatRoleTarget } from 'src/engine/metadata-modules/flat-role-target/types/flat-role-target.type';
 import { RoleTargetExceptionCode } from 'src/engine/metadata-modules/role/exceptions/role-target.exception';
+import { type UniversalFlatRoleTarget } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-role-target.type';
 import { type FlatEntityValidationError } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/types/failed-flat-entity-validation.type';
 
 export const validateFlatRoleTargetTargetsOnlyOneEntity = ({
   flatRoleTarget,
 }: {
-  flatRoleTarget: FlatRoleTarget;
+  flatRoleTarget: UniversalFlatRoleTarget;
 }) => {
   const errors: FlatEntityValidationError[] = [];
 

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-role-is-editable.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-role-is-editable.util.ts
@@ -1,10 +1,10 @@
 import { msg } from '@lingui/core/macro';
 
-import { type FlatRole } from 'src/engine/metadata-modules/flat-role/types/flat-role.type';
 import {
   PermissionsExceptionCode,
   PermissionsExceptionMessage,
 } from 'src/engine/metadata-modules/permissions/permissions.exception';
+import { type UniversalFlatRole } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-role.type';
 import { type FlatEntityValidationError } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/types/failed-flat-entity-validation.type';
 import { type WorkspaceMigrationBuilderOptions } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/workspace-migration-builder-options.type';
 
@@ -12,7 +12,7 @@ export const validateRoleIsEditable = ({
   flatRole,
   buildOptions,
 }: {
-  flatRole: FlatRole;
+  flatRole: UniversalFlatRole;
   buildOptions: WorkspaceMigrationBuilderOptions;
 }): FlatEntityValidationError[] => {
   const errors: FlatEntityValidationError[] = [];

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-role-label-uniqueness.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-role-label-uniqueness.util.ts
@@ -1,10 +1,10 @@
 import { msg } from '@lingui/core/macro';
 
-import { type FlatRole } from 'src/engine/metadata-modules/flat-role/types/flat-role.type';
 import {
   PermissionsExceptionCode,
   PermissionsExceptionMessage,
 } from 'src/engine/metadata-modules/permissions/permissions.exception';
+import { type UniversalFlatRole } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-role.type';
 import { type FlatEntityValidationError } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/types/failed-flat-entity-validation.type';
 
 export const validateRoleLabelUniqueness = ({
@@ -12,7 +12,7 @@ export const validateRoleLabelUniqueness = ({
   existingFlatRoles,
 }: {
   label: string;
-  existingFlatRoles: FlatRole[];
+  existingFlatRoles: UniversalFlatRole[];
 }): FlatEntityValidationError[] => {
   const errors: FlatEntityValidationError[] = [];
 

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-role-read-write-permissions-consistency.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-role-read-write-permissions-consistency.util.ts
@@ -1,16 +1,16 @@
 import { msg } from '@lingui/core/macro';
 
-import { type FlatRole } from 'src/engine/metadata-modules/flat-role/types/flat-role.type';
 import {
   PermissionsExceptionCode,
   PermissionsExceptionMessage,
 } from 'src/engine/metadata-modules/permissions/permissions.exception';
+import { type UniversalFlatRole } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-role.type';
 import { type FlatEntityValidationError } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/types/failed-flat-entity-validation.type';
 
 export const validateRoleReadWritePermissionsConsistency = ({
   flatRole,
 }: {
-  flatRole: FlatRole;
+  flatRole: UniversalFlatRole;
 }): FlatEntityValidationError[] => {
   const errors: FlatEntityValidationError[] = [];
 

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-role-required-properties-are-defined.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/validators/utils/validate-role-required-properties-are-defined.util.ts
@@ -2,14 +2,14 @@ import { msg, t } from '@lingui/core/macro';
 import { isDefined } from 'twenty-shared/utils';
 
 import { FLAT_ROLE_REQUIRED_PROPERTIES } from 'src/engine/metadata-modules/flat-role/constants/flat-role-required-properties.constants';
-import { type FlatRole } from 'src/engine/metadata-modules/flat-role/types/flat-role.type';
 import { PermissionsExceptionCode } from 'src/engine/metadata-modules/permissions/permissions.exception';
+import { type UniversalFlatRole } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-role.type';
 import { type FlatEntityValidationError } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/types/failed-flat-entity-validation.type';
 
 export const validateRoleRequiredPropertiesAreDefined = ({
   flatRole,
 }: {
-  flatRole: FlatRole;
+  flatRole: UniversalFlatRole;
 }): FlatEntityValidationError[] =>
   FLAT_ROLE_REQUIRED_PROPERTIES.flatMap<FlatEntityValidationError>(
     (property) => {

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/agent/services/create-agent-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/agent/services/create-agent-action-handler.service.ts
@@ -3,7 +3,10 @@ import { Injectable } from '@nestjs/common';
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
 import { AgentEntity } from 'src/engine/metadata-modules/ai/ai-agent/entities/agent.entity';
-import { FlatCreateAgentAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/agent/types/workspace-migration-agent-action-builder.service';
+import {
+  FlatCreateAgentAction,
+  UniversalCreateAgentAction,
+} from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/agent/types/workspace-migration-agent-action-builder.service';
 import {
   WorkspaceMigrationActionRunnerArgs,
   WorkspaceMigrationActionRunnerContext,
@@ -19,7 +22,7 @@ export class CreateAgentActionHandlerService extends WorkspaceMigrationRunnerAct
   }
 
   override async transpileUniversalActionToFlatAction(
-    context: WorkspaceMigrationActionRunnerArgs<FlatCreateAgentAction>,
+    context: WorkspaceMigrationActionRunnerArgs<UniversalCreateAgentAction>,
   ): Promise<FlatCreateAgentAction> {
     return context.action;
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/agent/services/create-agent-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/agent/services/create-agent-action-handler.service.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
+import { v4 } from 'uuid';
+
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
 import { AgentEntity } from 'src/engine/metadata-modules/ai/ai-agent/entities/agent.entity';
@@ -21,10 +23,20 @@ export class CreateAgentActionHandlerService extends WorkspaceMigrationRunnerAct
     super();
   }
 
-  override async transpileUniversalActionToFlatAction(
-    context: WorkspaceMigrationActionRunnerArgs<UniversalCreateAgentAction>,
-  ): Promise<FlatCreateAgentAction> {
-    return context.action;
+  override async transpileUniversalActionToFlatAction({
+    action,
+    flatApplication,
+    workspaceId,
+  }: WorkspaceMigrationActionRunnerArgs<UniversalCreateAgentAction>): Promise<FlatCreateAgentAction> {
+    return {
+      ...action,
+      flatEntity: {
+        ...action.flatEntity,
+        applicationId: flatApplication.id,
+        id: action.id ?? v4(),
+        workspaceId,
+      },
+    };
   }
 
   async executeForMetadata(

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/command-menu-item/services/create-command-menu-item-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/command-menu-item/services/create-command-menu-item-action-handler.service.ts
@@ -3,7 +3,10 @@ import { Injectable } from '@nestjs/common';
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
 import { CommandMenuItemEntity } from 'src/engine/metadata-modules/command-menu-item/entities/command-menu-item.entity';
-import { FlatCreateCommandMenuItemAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/command-menu-item/types/workspace-migration-command-menu-item-action.type';
+import {
+  FlatCreateCommandMenuItemAction,
+  UniversalCreateCommandMenuItemAction,
+} from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/command-menu-item/types/workspace-migration-command-menu-item-action.type';
 import {
   WorkspaceMigrationActionRunnerArgs,
   WorkspaceMigrationActionRunnerContext,
@@ -19,7 +22,7 @@ export class CreateCommandMenuItemActionHandlerService extends WorkspaceMigratio
   }
 
   override async transpileUniversalActionToFlatAction(
-    context: WorkspaceMigrationActionRunnerArgs<FlatCreateCommandMenuItemAction>,
+    context: WorkspaceMigrationActionRunnerArgs<UniversalCreateCommandMenuItemAction>,
   ): Promise<FlatCreateCommandMenuItemAction> {
     return context.action;
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/command-menu-item/services/create-command-menu-item-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/command-menu-item/services/create-command-menu-item-action-handler.service.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
+import { v4 } from 'uuid';
+
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
 import { CommandMenuItemEntity } from 'src/engine/metadata-modules/command-menu-item/entities/command-menu-item.entity';
@@ -21,10 +23,20 @@ export class CreateCommandMenuItemActionHandlerService extends WorkspaceMigratio
     super();
   }
 
-  override async transpileUniversalActionToFlatAction(
-    context: WorkspaceMigrationActionRunnerArgs<UniversalCreateCommandMenuItemAction>,
-  ): Promise<FlatCreateCommandMenuItemAction> {
-    return context.action;
+  override async transpileUniversalActionToFlatAction({
+    action,
+    flatApplication,
+    workspaceId,
+  }: WorkspaceMigrationActionRunnerArgs<UniversalCreateCommandMenuItemAction>): Promise<FlatCreateCommandMenuItemAction> {
+    return {
+      ...action,
+      flatEntity: {
+        ...action.flatEntity,
+        applicationId: flatApplication.id,
+        id: action.id ?? v4(),
+        workspaceId,
+      },
+    };
   }
 
   async executeForMetadata(

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/command-menu-item/services/create-command-menu-item-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/command-menu-item/services/create-command-menu-item-action-handler.service.ts
@@ -5,6 +5,7 @@ import { v4 } from 'uuid';
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
 import { CommandMenuItemEntity } from 'src/engine/metadata-modules/command-menu-item/entities/command-menu-item.entity';
+import { resolveUniversalRelationIdentifiersToIds } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/utils/resolve-universal-relation-identifiers-to-ids.util';
 import {
   FlatCreateCommandMenuItemAction,
   UniversalCreateCommandMenuItemAction,
@@ -25,13 +26,23 @@ export class CreateCommandMenuItemActionHandlerService extends WorkspaceMigratio
 
   override async transpileUniversalActionToFlatAction({
     action,
+    allFlatEntityMaps,
     flatApplication,
     workspaceId,
   }: WorkspaceMigrationActionRunnerArgs<UniversalCreateCommandMenuItemAction>): Promise<FlatCreateCommandMenuItemAction> {
+    const { availabilityObjectMetadataId, frontComponentId } =
+      resolveUniversalRelationIdentifiersToIds({
+        flatEntityMaps: allFlatEntityMaps,
+        metadataName: action.metadataName,
+        universalForeignKeyValues: action.flatEntity,
+      });
+
     return {
       ...action,
       flatEntity: {
         ...action.flatEntity,
+        availabilityObjectMetadataId,
+        frontComponentId,
         applicationId: flatApplication.id,
         id: action.id ?? v4(),
         workspaceId,

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/front-component/services/create-front-component-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/front-component/services/create-front-component-action-handler.service.ts
@@ -11,7 +11,10 @@ import {
   FrontComponentException,
   FrontComponentExceptionCode,
 } from 'src/engine/metadata-modules/front-component/front-component.exception';
-import { FlatCreateFrontComponentAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/front-component/types/workspace-migration-front-component-action.type';
+import {
+  FlatCreateFrontComponentAction,
+  UniversalCreateFrontComponentAction,
+} from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/front-component/types/workspace-migration-front-component-action.type';
 import {
   WorkspaceMigrationActionRunnerArgs,
   WorkspaceMigrationActionRunnerContext,
@@ -27,7 +30,7 @@ export class CreateFrontComponentActionHandlerService extends WorkspaceMigration
   }
 
   override async transpileUniversalActionToFlatAction(
-    context: WorkspaceMigrationActionRunnerArgs<FlatCreateFrontComponentAction>,
+    context: WorkspaceMigrationActionRunnerArgs<UniversalCreateFrontComponentAction>,
   ): Promise<FlatCreateFrontComponentAction> {
     return context.action;
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/front-component/services/create-front-component-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/front-component/services/create-front-component-action-handler.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 import { FileFolder } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
+import { v4 } from 'uuid';
 
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
@@ -29,10 +30,20 @@ export class CreateFrontComponentActionHandlerService extends WorkspaceMigration
     super();
   }
 
-  override async transpileUniversalActionToFlatAction(
-    context: WorkspaceMigrationActionRunnerArgs<UniversalCreateFrontComponentAction>,
-  ): Promise<FlatCreateFrontComponentAction> {
-    return context.action;
+  override async transpileUniversalActionToFlatAction({
+    action,
+    flatApplication,
+    workspaceId,
+  }: WorkspaceMigrationActionRunnerArgs<UniversalCreateFrontComponentAction>): Promise<FlatCreateFrontComponentAction> {
+    return {
+      ...action,
+      flatEntity: {
+        ...action.flatEntity,
+        applicationId: flatApplication.id,
+        id: action.id ?? v4(),
+        workspaceId,
+      },
+    };
   }
 
   async executeForMetadata(

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/logic-function/services/create-logic-function-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/logic-function/services/create-logic-function-action-handler.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
 import { FileFolder } from 'twenty-shared/types';
+import { v4 } from 'uuid';
 
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
@@ -28,10 +29,20 @@ export class CreateLogicFunctionActionHandlerService extends WorkspaceMigrationR
     super();
   }
 
-  override async transpileUniversalActionToFlatAction(
-    context: WorkspaceMigrationActionRunnerArgs<UniversalCreateLogicFunctionAction>,
-  ): Promise<FlatCreateLogicFunctionAction> {
-    return context.action;
+  override async transpileUniversalActionToFlatAction({
+    action,
+    flatApplication,
+    workspaceId,
+  }: WorkspaceMigrationActionRunnerArgs<UniversalCreateLogicFunctionAction>): Promise<FlatCreateLogicFunctionAction> {
+    return {
+      ...action,
+      flatEntity: {
+        ...action.flatEntity,
+        applicationId: flatApplication.id,
+        id: action.id ?? v4(),
+        workspaceId,
+      },
+    };
   }
 
   async executeForMetadata(

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/logic-function/services/create-logic-function-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/logic-function/services/create-logic-function-action-handler.service.ts
@@ -10,7 +10,10 @@ import {
   LogicFunctionException,
   LogicFunctionExceptionCode,
 } from 'src/engine/metadata-modules/logic-function/logic-function.exception';
-import { FlatCreateLogicFunctionAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/logic-function/types/workspace-migration-logic-function-action.type';
+import {
+  FlatCreateLogicFunctionAction,
+  UniversalCreateLogicFunctionAction,
+} from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/logic-function/types/workspace-migration-logic-function-action.type';
 import {
   WorkspaceMigrationActionRunnerArgs,
   WorkspaceMigrationActionRunnerContext,
@@ -26,7 +29,7 @@ export class CreateLogicFunctionActionHandlerService extends WorkspaceMigrationR
   }
 
   override async transpileUniversalActionToFlatAction(
-    context: WorkspaceMigrationActionRunnerArgs<FlatCreateLogicFunctionAction>,
+    context: WorkspaceMigrationActionRunnerArgs<UniversalCreateLogicFunctionAction>,
   ): Promise<FlatCreateLogicFunctionAction> {
     return context.action;
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/navigation-menu-item/services/create-navigation-menu-item-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/navigation-menu-item/services/create-navigation-menu-item-action-handler.service.ts
@@ -3,7 +3,10 @@ import { Injectable } from '@nestjs/common';
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
 import { NavigationMenuItemEntity } from 'src/engine/metadata-modules/navigation-menu-item/entities/navigation-menu-item.entity';
-import { FlatCreateNavigationMenuItemAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/navigation-menu-item/types/workspace-migration-navigation-menu-item-action.type';
+import {
+  FlatCreateNavigationMenuItemAction,
+  UniversalCreateNavigationMenuItemAction,
+} from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/navigation-menu-item/types/workspace-migration-navigation-menu-item-action.type';
 import {
   WorkspaceMigrationActionRunnerArgs,
   WorkspaceMigrationActionRunnerContext,
@@ -19,7 +22,7 @@ export class CreateNavigationMenuItemActionHandlerService extends WorkspaceMigra
   }
 
   override async transpileUniversalActionToFlatAction(
-    context: WorkspaceMigrationActionRunnerArgs<FlatCreateNavigationMenuItemAction>,
+    context: WorkspaceMigrationActionRunnerArgs<UniversalCreateNavigationMenuItemAction>,
   ): Promise<FlatCreateNavigationMenuItemAction> {
     return context.action;
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/navigation-menu-item/services/create-navigation-menu-item-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/navigation-menu-item/services/create-navigation-menu-item-action-handler.service.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
+import { v4 } from 'uuid';
+
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
 import { NavigationMenuItemEntity } from 'src/engine/metadata-modules/navigation-menu-item/entities/navigation-menu-item.entity';
@@ -21,10 +23,20 @@ export class CreateNavigationMenuItemActionHandlerService extends WorkspaceMigra
     super();
   }
 
-  override async transpileUniversalActionToFlatAction(
-    context: WorkspaceMigrationActionRunnerArgs<UniversalCreateNavigationMenuItemAction>,
-  ): Promise<FlatCreateNavigationMenuItemAction> {
-    return context.action;
+  override async transpileUniversalActionToFlatAction({
+    action,
+    flatApplication,
+    workspaceId,
+  }: WorkspaceMigrationActionRunnerArgs<UniversalCreateNavigationMenuItemAction>): Promise<FlatCreateNavigationMenuItemAction> {
+    return {
+      ...action,
+      flatEntity: {
+        ...action.flatEntity,
+        applicationId: flatApplication.id,
+        id: action.id ?? v4(),
+        workspaceId,
+      },
+    };
   }
 
   async executeForMetadata(

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/navigation-menu-item/services/create-navigation-menu-item-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/navigation-menu-item/services/create-navigation-menu-item-action-handler.service.ts
@@ -5,6 +5,7 @@ import { v4 } from 'uuid';
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
 import { NavigationMenuItemEntity } from 'src/engine/metadata-modules/navigation-menu-item/entities/navigation-menu-item.entity';
+import { resolveUniversalRelationIdentifiersToIds } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/utils/resolve-universal-relation-identifiers-to-ids.util';
 import {
   FlatCreateNavigationMenuItemAction,
   UniversalCreateNavigationMenuItemAction,
@@ -25,13 +26,24 @@ export class CreateNavigationMenuItemActionHandlerService extends WorkspaceMigra
 
   override async transpileUniversalActionToFlatAction({
     action,
+    allFlatEntityMaps,
     flatApplication,
     workspaceId,
   }: WorkspaceMigrationActionRunnerArgs<UniversalCreateNavigationMenuItemAction>): Promise<FlatCreateNavigationMenuItemAction> {
+    const { targetObjectMetadataId, folderId, viewId } =
+      resolveUniversalRelationIdentifiersToIds({
+        flatEntityMaps: allFlatEntityMaps,
+        metadataName: action.metadataName,
+        universalForeignKeyValues: action.flatEntity,
+      });
+
     return {
       ...action,
       flatEntity: {
         ...action.flatEntity,
+        targetObjectMetadataId,
+        folderId,
+        viewId,
         applicationId: flatApplication.id,
         id: action.id ?? v4(),
         workspaceId,

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/page-layout-tab/services/create-page-layout-tab-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/page-layout-tab/services/create-page-layout-tab-action-handler.service.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
+import { v4 } from 'uuid';
+
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
 import { PageLayoutTabEntity } from 'src/engine/metadata-modules/page-layout-tab/entities/page-layout-tab.entity';
@@ -21,10 +23,20 @@ export class CreatePageLayoutTabActionHandlerService extends WorkspaceMigrationR
     super();
   }
 
-  override async transpileUniversalActionToFlatAction(
-    context: WorkspaceMigrationActionRunnerArgs<UniversalCreatePageLayoutTabAction>,
-  ): Promise<FlatCreatePageLayoutTabAction> {
-    return context.action;
+  override async transpileUniversalActionToFlatAction({
+    action,
+    flatApplication,
+    workspaceId,
+  }: WorkspaceMigrationActionRunnerArgs<UniversalCreatePageLayoutTabAction>): Promise<FlatCreatePageLayoutTabAction> {
+    return {
+      ...action,
+      flatEntity: {
+        ...action.flatEntity,
+        applicationId: flatApplication.id,
+        id: action.id ?? v4(),
+        workspaceId,
+      },
+    };
   }
 
   async executeForMetadata(

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/page-layout-tab/services/create-page-layout-tab-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/page-layout-tab/services/create-page-layout-tab-action-handler.service.ts
@@ -3,7 +3,10 @@ import { Injectable } from '@nestjs/common';
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
 import { PageLayoutTabEntity } from 'src/engine/metadata-modules/page-layout-tab/entities/page-layout-tab.entity';
-import { FlatCreatePageLayoutTabAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/page-layout-tab/types/workspace-migration-page-layout-tab-action.type';
+import {
+  FlatCreatePageLayoutTabAction,
+  UniversalCreatePageLayoutTabAction,
+} from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/page-layout-tab/types/workspace-migration-page-layout-tab-action.type';
 import {
   WorkspaceMigrationActionRunnerArgs,
   WorkspaceMigrationActionRunnerContext,
@@ -19,7 +22,7 @@ export class CreatePageLayoutTabActionHandlerService extends WorkspaceMigrationR
   }
 
   override async transpileUniversalActionToFlatAction(
-    context: WorkspaceMigrationActionRunnerArgs<FlatCreatePageLayoutTabAction>,
+    context: WorkspaceMigrationActionRunnerArgs<UniversalCreatePageLayoutTabAction>,
   ): Promise<FlatCreatePageLayoutTabAction> {
     return context.action;
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/page-layout-tab/services/create-page-layout-tab-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/page-layout-tab/services/create-page-layout-tab-action-handler.service.ts
@@ -5,6 +5,7 @@ import { v4 } from 'uuid';
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
 import { PageLayoutTabEntity } from 'src/engine/metadata-modules/page-layout-tab/entities/page-layout-tab.entity';
+import { resolveUniversalRelationIdentifiersToIds } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/utils/resolve-universal-relation-identifiers-to-ids.util';
 import {
   FlatCreatePageLayoutTabAction,
   UniversalCreatePageLayoutTabAction,
@@ -25,16 +26,25 @@ export class CreatePageLayoutTabActionHandlerService extends WorkspaceMigrationR
 
   override async transpileUniversalActionToFlatAction({
     action,
+    allFlatEntityMaps,
     flatApplication,
     workspaceId,
   }: WorkspaceMigrationActionRunnerArgs<UniversalCreatePageLayoutTabAction>): Promise<FlatCreatePageLayoutTabAction> {
+    const { pageLayoutId } = resolveUniversalRelationIdentifiersToIds({
+      flatEntityMaps: allFlatEntityMaps,
+      metadataName: action.metadataName,
+      universalForeignKeyValues: action.flatEntity,
+    });
+
     return {
       ...action,
       flatEntity: {
         ...action.flatEntity,
+        pageLayoutId,
         applicationId: flatApplication.id,
         id: action.id ?? v4(),
         workspaceId,
+        widgetIds: [],
       },
     };
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/page-layout-widget/services/create-page-layout-widget-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/page-layout-widget/services/create-page-layout-widget-action-handler.service.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
+import { v4 } from 'uuid';
+
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
 import { PageLayoutWidgetEntity } from 'src/engine/metadata-modules/page-layout-widget/entities/page-layout-widget.entity';
@@ -21,10 +23,20 @@ export class CreatePageLayoutWidgetActionHandlerService extends WorkspaceMigrati
     super();
   }
 
-  override async transpileUniversalActionToFlatAction(
-    context: WorkspaceMigrationActionRunnerArgs<UniversalCreatePageLayoutWidgetAction>,
-  ): Promise<FlatCreatePageLayoutWidgetAction> {
-    return context.action;
+  override async transpileUniversalActionToFlatAction({
+    action,
+    flatApplication,
+    workspaceId,
+  }: WorkspaceMigrationActionRunnerArgs<UniversalCreatePageLayoutWidgetAction>): Promise<FlatCreatePageLayoutWidgetAction> {
+    return {
+      ...action,
+      flatEntity: {
+        ...action.flatEntity,
+        applicationId: flatApplication.id,
+        id: action.id ?? v4(),
+        workspaceId,
+      },
+    };
   }
 
   async executeForMetadata(

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/page-layout-widget/services/create-page-layout-widget-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/page-layout-widget/services/create-page-layout-widget-action-handler.service.ts
@@ -5,10 +5,12 @@ import { v4 } from 'uuid';
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
 import { PageLayoutWidgetEntity } from 'src/engine/metadata-modules/page-layout-widget/entities/page-layout-widget.entity';
+import { resolveUniversalRelationIdentifiersToIds } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/utils/resolve-universal-relation-identifiers-to-ids.util';
 import {
   FlatCreatePageLayoutWidgetAction,
   UniversalCreatePageLayoutWidgetAction,
 } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/page-layout-widget/types/workspace-migration-page-layout-widget-action.type';
+import { fromUniversalConfigurationToFlatPageLayoutWidgetConfiguration } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/page-layout-widget/services/utils/from-universal-configuration-to-flat-page-layout-widget-configuration.util';
 import {
   WorkspaceMigrationActionRunnerArgs,
   WorkspaceMigrationActionRunnerContext,
@@ -25,13 +27,30 @@ export class CreatePageLayoutWidgetActionHandlerService extends WorkspaceMigrati
 
   override async transpileUniversalActionToFlatAction({
     action,
+    allFlatEntityMaps,
     flatApplication,
     workspaceId,
   }: WorkspaceMigrationActionRunnerArgs<UniversalCreatePageLayoutWidgetAction>): Promise<FlatCreatePageLayoutWidgetAction> {
+    const { pageLayoutTabId, objectMetadataId } =
+      resolveUniversalRelationIdentifiersToIds({
+        flatEntityMaps: allFlatEntityMaps,
+        metadataName: action.metadataName,
+        universalForeignKeyValues: action.flatEntity,
+      });
+
+    const configuration =
+      fromUniversalConfigurationToFlatPageLayoutWidgetConfiguration({
+        universalConfiguration: action.flatEntity.universalConfiguration,
+        flatFieldMetadataMaps: allFlatEntityMaps.flatFieldMetadataMaps,
+      });
+
     return {
       ...action,
       flatEntity: {
         ...action.flatEntity,
+        configuration,
+        pageLayoutTabId,
+        objectMetadataId,
         applicationId: flatApplication.id,
         id: action.id ?? v4(),
         workspaceId,

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/page-layout-widget/services/create-page-layout-widget-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/page-layout-widget/services/create-page-layout-widget-action-handler.service.ts
@@ -3,7 +3,10 @@ import { Injectable } from '@nestjs/common';
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
 import { PageLayoutWidgetEntity } from 'src/engine/metadata-modules/page-layout-widget/entities/page-layout-widget.entity';
-import { FlatCreatePageLayoutWidgetAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/page-layout-widget/types/workspace-migration-page-layout-widget-action.type';
+import {
+  FlatCreatePageLayoutWidgetAction,
+  UniversalCreatePageLayoutWidgetAction,
+} from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/page-layout-widget/types/workspace-migration-page-layout-widget-action.type';
 import {
   WorkspaceMigrationActionRunnerArgs,
   WorkspaceMigrationActionRunnerContext,
@@ -19,7 +22,7 @@ export class CreatePageLayoutWidgetActionHandlerService extends WorkspaceMigrati
   }
 
   override async transpileUniversalActionToFlatAction(
-    context: WorkspaceMigrationActionRunnerArgs<FlatCreatePageLayoutWidgetAction>,
+    context: WorkspaceMigrationActionRunnerArgs<UniversalCreatePageLayoutWidgetAction>,
   ): Promise<FlatCreatePageLayoutWidgetAction> {
     return context.action;
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/page-layout/services/create-page-layout-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/page-layout/services/create-page-layout-action-handler.service.ts
@@ -5,6 +5,7 @@ import { v4 } from 'uuid';
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
 import { PageLayoutEntity } from 'src/engine/metadata-modules/page-layout/entities/page-layout.entity';
+import { resolveUniversalRelationIdentifiersToIds } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/utils/resolve-universal-relation-identifiers-to-ids.util';
 import {
   FlatCreatePageLayoutAction,
   UniversalCreatePageLayoutAction,
@@ -25,16 +26,27 @@ export class CreatePageLayoutActionHandlerService extends WorkspaceMigrationRunn
 
   override async transpileUniversalActionToFlatAction({
     action,
+    allFlatEntityMaps,
     flatApplication,
     workspaceId,
   }: WorkspaceMigrationActionRunnerArgs<UniversalCreatePageLayoutAction>): Promise<FlatCreatePageLayoutAction> {
+    const { objectMetadataId, defaultTabToFocusOnMobileAndSidePanelId } =
+      resolveUniversalRelationIdentifiersToIds({
+        flatEntityMaps: allFlatEntityMaps,
+        metadataName: action.metadataName,
+        universalForeignKeyValues: action.flatEntity,
+      });
+
     return {
       ...action,
       flatEntity: {
         ...action.flatEntity,
+        objectMetadataId,
+        defaultTabToFocusOnMobileAndSidePanelId,
         applicationId: flatApplication.id,
         id: action.id ?? v4(),
         workspaceId,
+        tabIds: [],
       },
     };
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/page-layout/services/create-page-layout-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/page-layout/services/create-page-layout-action-handler.service.ts
@@ -3,7 +3,10 @@ import { Injectable } from '@nestjs/common';
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
 import { PageLayoutEntity } from 'src/engine/metadata-modules/page-layout/entities/page-layout.entity';
-import { FlatCreatePageLayoutAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/page-layout/types/workspace-migration-page-layout-action.type';
+import {
+  FlatCreatePageLayoutAction,
+  UniversalCreatePageLayoutAction,
+} from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/page-layout/types/workspace-migration-page-layout-action.type';
 import {
   WorkspaceMigrationActionRunnerArgs,
   WorkspaceMigrationActionRunnerContext,
@@ -19,7 +22,7 @@ export class CreatePageLayoutActionHandlerService extends WorkspaceMigrationRunn
   }
 
   override async transpileUniversalActionToFlatAction(
-    context: WorkspaceMigrationActionRunnerArgs<FlatCreatePageLayoutAction>,
+    context: WorkspaceMigrationActionRunnerArgs<UniversalCreatePageLayoutAction>,
   ): Promise<FlatCreatePageLayoutAction> {
     return context.action;
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/page-layout/services/create-page-layout-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/page-layout/services/create-page-layout-action-handler.service.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
+import { v4 } from 'uuid';
+
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
 import { PageLayoutEntity } from 'src/engine/metadata-modules/page-layout/entities/page-layout.entity';
@@ -21,10 +23,20 @@ export class CreatePageLayoutActionHandlerService extends WorkspaceMigrationRunn
     super();
   }
 
-  override async transpileUniversalActionToFlatAction(
-    context: WorkspaceMigrationActionRunnerArgs<UniversalCreatePageLayoutAction>,
-  ): Promise<FlatCreatePageLayoutAction> {
-    return context.action;
+  override async transpileUniversalActionToFlatAction({
+    action,
+    flatApplication,
+    workspaceId,
+  }: WorkspaceMigrationActionRunnerArgs<UniversalCreatePageLayoutAction>): Promise<FlatCreatePageLayoutAction> {
+    return {
+      ...action,
+      flatEntity: {
+        ...action.flatEntity,
+        applicationId: flatApplication.id,
+        id: action.id ?? v4(),
+        workspaceId,
+      },
+    };
   }
 
   async executeForMetadata(

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/role-target/services/create-role-target-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/role-target/services/create-role-target-action-handler.service.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
+import { v4 } from 'uuid';
+
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
 import { RoleTargetEntity } from 'src/engine/metadata-modules/role-target/role-target.entity';
@@ -17,10 +19,20 @@ export class CreateRoleTargetActionHandlerService extends WorkspaceMigrationRunn
   'create',
   'roleTarget',
 ) {
-  override async transpileUniversalActionToFlatAction(
-    context: WorkspaceMigrationActionRunnerArgs<UniversalCreateRoleTargetAction>,
-  ): Promise<FlatCreateRoleTargetAction> {
-    return context.action;
+  override async transpileUniversalActionToFlatAction({
+    action,
+    flatApplication,
+    workspaceId,
+  }: WorkspaceMigrationActionRunnerArgs<UniversalCreateRoleTargetAction>): Promise<FlatCreateRoleTargetAction> {
+    return {
+      ...action,
+      flatEntity: {
+        ...action.flatEntity,
+        applicationId: flatApplication.id,
+        id: action.id ?? v4(),
+        workspaceId,
+      },
+    };
   }
 
   async executeForMetadata(

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/role-target/services/create-role-target-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/role-target/services/create-role-target-action-handler.service.ts
@@ -3,7 +3,10 @@ import { Injectable } from '@nestjs/common';
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
 import { RoleTargetEntity } from 'src/engine/metadata-modules/role-target/role-target.entity';
-import { FlatCreateRoleTargetAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/role-target/types/workspace-migration-role-target-action.type';
+import {
+  FlatCreateRoleTargetAction,
+  UniversalCreateRoleTargetAction,
+} from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/role-target/types/workspace-migration-role-target-action.type';
 import {
   WorkspaceMigrationActionRunnerArgs,
   WorkspaceMigrationActionRunnerContext,
@@ -15,7 +18,7 @@ export class CreateRoleTargetActionHandlerService extends WorkspaceMigrationRunn
   'roleTarget',
 ) {
   override async transpileUniversalActionToFlatAction(
-    context: WorkspaceMigrationActionRunnerArgs<FlatCreateRoleTargetAction>,
+    context: WorkspaceMigrationActionRunnerArgs<UniversalCreateRoleTargetAction>,
   ): Promise<FlatCreateRoleTargetAction> {
     return context.action;
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/role-target/services/create-role-target-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/role-target/services/create-role-target-action-handler.service.ts
@@ -5,6 +5,7 @@ import { v4 } from 'uuid';
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
 import { RoleTargetEntity } from 'src/engine/metadata-modules/role-target/role-target.entity';
+import { resolveUniversalRelationIdentifiersToIds } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/utils/resolve-universal-relation-identifiers-to-ids.util';
 import {
   FlatCreateRoleTargetAction,
   UniversalCreateRoleTargetAction,
@@ -21,13 +22,21 @@ export class CreateRoleTargetActionHandlerService extends WorkspaceMigrationRunn
 ) {
   override async transpileUniversalActionToFlatAction({
     action,
+    allFlatEntityMaps,
     flatApplication,
     workspaceId,
   }: WorkspaceMigrationActionRunnerArgs<UniversalCreateRoleTargetAction>): Promise<FlatCreateRoleTargetAction> {
+    const { roleId } = resolveUniversalRelationIdentifiersToIds({
+      flatEntityMaps: allFlatEntityMaps,
+      metadataName: action.metadataName,
+      universalForeignKeyValues: action.flatEntity,
+    });
+
     return {
       ...action,
       flatEntity: {
         ...action.flatEntity,
+        roleId,
         applicationId: flatApplication.id,
         id: action.id ?? v4(),
         workspaceId,

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/role/services/create-role-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/role/services/create-role-action-handler.service.ts
@@ -35,6 +35,12 @@ export class CreateRoleActionHandlerService extends WorkspaceMigrationRunnerActi
         applicationId: flatApplication.id,
         id: action.id ?? v4(),
         workspaceId,
+        roleTargetIds: [],
+        rowLevelPermissionPredicateIds: [],
+        rowLevelPermissionPredicateGroupIds: [],
+        objectPermissionIds: [],
+        permissionFlagIds: [],
+        fieldPermissionIds: [],
       },
     };
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/role/services/create-role-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/role/services/create-role-action-handler.service.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
+import { v4 } from 'uuid';
+
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
 import { RoleEntity } from 'src/engine/metadata-modules/role/role.entity';
@@ -21,10 +23,20 @@ export class CreateRoleActionHandlerService extends WorkspaceMigrationRunnerActi
     super();
   }
 
-  override async transpileUniversalActionToFlatAction(
-    context: WorkspaceMigrationActionRunnerArgs<UniversalCreateRoleAction>,
-  ): Promise<FlatCreateRoleAction> {
-    return context.action;
+  override async transpileUniversalActionToFlatAction({
+    action,
+    flatApplication,
+    workspaceId,
+  }: WorkspaceMigrationActionRunnerArgs<UniversalCreateRoleAction>): Promise<FlatCreateRoleAction> {
+    return {
+      ...action,
+      flatEntity: {
+        ...action.flatEntity,
+        applicationId: flatApplication.id,
+        id: action.id ?? v4(),
+        workspaceId,
+      },
+    };
   }
 
   async executeForMetadata(

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/role/services/create-role-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/role/services/create-role-action-handler.service.ts
@@ -3,7 +3,10 @@ import { Injectable } from '@nestjs/common';
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
 import { RoleEntity } from 'src/engine/metadata-modules/role/role.entity';
-import { FlatCreateRoleAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/role/types/workspace-migration-role-action.type';
+import {
+  FlatCreateRoleAction,
+  UniversalCreateRoleAction,
+} from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/role/types/workspace-migration-role-action.type';
 import {
   WorkspaceMigrationActionRunnerArgs,
   WorkspaceMigrationActionRunnerContext,
@@ -19,7 +22,7 @@ export class CreateRoleActionHandlerService extends WorkspaceMigrationRunnerActi
   }
 
   override async transpileUniversalActionToFlatAction(
-    context: WorkspaceMigrationActionRunnerArgs<FlatCreateRoleAction>,
+    context: WorkspaceMigrationActionRunnerArgs<UniversalCreateRoleAction>,
   ): Promise<FlatCreateRoleAction> {
     return context.action;
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/row-level-permission-predicate-group/services/create-row-level-permission-predicate-group-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/row-level-permission-predicate-group/services/create-row-level-permission-predicate-group-action-handler.service.ts
@@ -5,7 +5,10 @@ import { Injectable } from '@nestjs/common';
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
 import { RowLevelPermissionPredicateGroupEntity } from 'src/engine/metadata-modules/row-level-permission-predicate/entities/row-level-permission-predicate-group.entity';
-import { FlatCreateRowLevelPermissionPredicateGroupAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/row-level-permission-predicate-group/types/workspace-migration-row-level-permission-predicate-group-action.type';
+import {
+  FlatCreateRowLevelPermissionPredicateGroupAction,
+  UniversalCreateRowLevelPermissionPredicateGroupAction,
+} from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/row-level-permission-predicate-group/types/workspace-migration-row-level-permission-predicate-group-action.type';
 import {
   WorkspaceMigrationActionRunnerArgs,
   WorkspaceMigrationActionRunnerContext,
@@ -17,7 +20,7 @@ export class CreateRowLevelPermissionPredicateGroupActionHandlerService extends 
   'rowLevelPermissionPredicateGroup',
 ) {
   override async transpileUniversalActionToFlatAction(
-    context: WorkspaceMigrationActionRunnerArgs<FlatCreateRowLevelPermissionPredicateGroupAction>,
+    context: WorkspaceMigrationActionRunnerArgs<UniversalCreateRowLevelPermissionPredicateGroupAction>,
   ): Promise<FlatCreateRowLevelPermissionPredicateGroupAction> {
     return context.action;
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/row-level-permission-predicate-group/services/create-row-level-permission-predicate-group-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/row-level-permission-predicate-group/services/create-row-level-permission-predicate-group-action-handler.service.ts
@@ -7,6 +7,7 @@ import { v4 } from 'uuid';
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
 import { RowLevelPermissionPredicateGroupEntity } from 'src/engine/metadata-modules/row-level-permission-predicate/entities/row-level-permission-predicate-group.entity';
+import { resolveUniversalRelationIdentifiersToIds } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/utils/resolve-universal-relation-identifiers-to-ids.util';
 import {
   FlatCreateRowLevelPermissionPredicateGroupAction,
   UniversalCreateRowLevelPermissionPredicateGroupAction,
@@ -23,16 +24,32 @@ export class CreateRowLevelPermissionPredicateGroupActionHandlerService extends 
 ) {
   override async transpileUniversalActionToFlatAction({
     action,
+    allFlatEntityMaps,
     flatApplication,
     workspaceId,
   }: WorkspaceMigrationActionRunnerArgs<UniversalCreateRowLevelPermissionPredicateGroupAction>): Promise<FlatCreateRowLevelPermissionPredicateGroupAction> {
+    const {
+      objectMetadataId,
+      roleId,
+      parentRowLevelPermissionPredicateGroupId,
+    } = resolveUniversalRelationIdentifiersToIds({
+      flatEntityMaps: allFlatEntityMaps,
+      metadataName: action.metadataName,
+      universalForeignKeyValues: action.flatEntity,
+    });
+
     return {
       ...action,
       flatEntity: {
         ...action.flatEntity,
+        objectMetadataId,
+        roleId,
+        parentRowLevelPermissionPredicateGroupId,
         applicationId: flatApplication.id,
         id: action.id ?? v4(),
         workspaceId,
+        rowLevelPermissionPredicateIds: [],
+        childRowLevelPermissionPredicateGroupIds: [],
       },
     };
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/row-level-permission-predicate-group/services/create-row-level-permission-predicate-group-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/row-level-permission-predicate-group/services/create-row-level-permission-predicate-group-action-handler.service.ts
@@ -2,6 +2,8 @@
 
 import { Injectable } from '@nestjs/common';
 
+import { v4 } from 'uuid';
+
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
 import { RowLevelPermissionPredicateGroupEntity } from 'src/engine/metadata-modules/row-level-permission-predicate/entities/row-level-permission-predicate-group.entity';
@@ -19,10 +21,20 @@ export class CreateRowLevelPermissionPredicateGroupActionHandlerService extends 
   'create',
   'rowLevelPermissionPredicateGroup',
 ) {
-  override async transpileUniversalActionToFlatAction(
-    context: WorkspaceMigrationActionRunnerArgs<UniversalCreateRowLevelPermissionPredicateGroupAction>,
-  ): Promise<FlatCreateRowLevelPermissionPredicateGroupAction> {
-    return context.action;
+  override async transpileUniversalActionToFlatAction({
+    action,
+    flatApplication,
+    workspaceId,
+  }: WorkspaceMigrationActionRunnerArgs<UniversalCreateRowLevelPermissionPredicateGroupAction>): Promise<FlatCreateRowLevelPermissionPredicateGroupAction> {
+    return {
+      ...action,
+      flatEntity: {
+        ...action.flatEntity,
+        applicationId: flatApplication.id,
+        id: action.id ?? v4(),
+        workspaceId,
+      },
+    };
   }
 
   async executeForMetadata(

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/row-level-permission-predicate/services/create-row-level-permission-predicate-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/row-level-permission-predicate/services/create-row-level-permission-predicate-action-handler.service.ts
@@ -2,6 +2,8 @@
 
 import { Injectable } from '@nestjs/common';
 
+import { v4 } from 'uuid';
+
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
 import { RowLevelPermissionPredicateEntity } from 'src/engine/metadata-modules/row-level-permission-predicate/entities/row-level-permission-predicate.entity';
@@ -19,10 +21,20 @@ export class CreateRowLevelPermissionPredicateActionHandlerService extends Works
   'create',
   'rowLevelPermissionPredicate',
 ) {
-  override async transpileUniversalActionToFlatAction(
-    context: WorkspaceMigrationActionRunnerArgs<UniversalCreateRowLevelPermissionPredicateAction>,
-  ): Promise<FlatCreateRowLevelPermissionPredicateAction> {
-    return context.action;
+  override async transpileUniversalActionToFlatAction({
+    action,
+    flatApplication,
+    workspaceId,
+  }: WorkspaceMigrationActionRunnerArgs<UniversalCreateRowLevelPermissionPredicateAction>): Promise<FlatCreateRowLevelPermissionPredicateAction> {
+    return {
+      ...action,
+      flatEntity: {
+        ...action.flatEntity,
+        applicationId: flatApplication.id,
+        id: action.id ?? v4(),
+        workspaceId,
+      },
+    };
   }
 
   async executeForMetadata(

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/row-level-permission-predicate/services/create-row-level-permission-predicate-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/row-level-permission-predicate/services/create-row-level-permission-predicate-action-handler.service.ts
@@ -5,7 +5,10 @@ import { Injectable } from '@nestjs/common';
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
 import { RowLevelPermissionPredicateEntity } from 'src/engine/metadata-modules/row-level-permission-predicate/entities/row-level-permission-predicate.entity';
-import { FlatCreateRowLevelPermissionPredicateAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/row-level-permission-predicate/types/workspace-migration-row-level-permission-predicate-action.type';
+import {
+  FlatCreateRowLevelPermissionPredicateAction,
+  UniversalCreateRowLevelPermissionPredicateAction,
+} from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/row-level-permission-predicate/types/workspace-migration-row-level-permission-predicate-action.type';
 import {
   WorkspaceMigrationActionRunnerArgs,
   WorkspaceMigrationActionRunnerContext,
@@ -17,7 +20,7 @@ export class CreateRowLevelPermissionPredicateActionHandlerService extends Works
   'rowLevelPermissionPredicate',
 ) {
   override async transpileUniversalActionToFlatAction(
-    context: WorkspaceMigrationActionRunnerArgs<FlatCreateRowLevelPermissionPredicateAction>,
+    context: WorkspaceMigrationActionRunnerArgs<UniversalCreateRowLevelPermissionPredicateAction>,
   ): Promise<FlatCreateRowLevelPermissionPredicateAction> {
     return context.action;
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/row-level-permission-predicate/services/create-row-level-permission-predicate-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/row-level-permission-predicate/services/create-row-level-permission-predicate-action-handler.service.ts
@@ -7,6 +7,7 @@ import { v4 } from 'uuid';
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
 import { RowLevelPermissionPredicateEntity } from 'src/engine/metadata-modules/row-level-permission-predicate/entities/row-level-permission-predicate.entity';
+import { resolveUniversalRelationIdentifiersToIds } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/utils/resolve-universal-relation-identifiers-to-ids.util';
 import {
   FlatCreateRowLevelPermissionPredicateAction,
   UniversalCreateRowLevelPermissionPredicateAction,
@@ -23,13 +24,31 @@ export class CreateRowLevelPermissionPredicateActionHandlerService extends Works
 ) {
   override async transpileUniversalActionToFlatAction({
     action,
+    allFlatEntityMaps,
     flatApplication,
     workspaceId,
   }: WorkspaceMigrationActionRunnerArgs<UniversalCreateRowLevelPermissionPredicateAction>): Promise<FlatCreateRowLevelPermissionPredicateAction> {
+    const {
+      roleId,
+      fieldMetadataId,
+      workspaceMemberFieldMetadataId,
+      objectMetadataId,
+      rowLevelPermissionPredicateGroupId,
+    } = resolveUniversalRelationIdentifiersToIds({
+      flatEntityMaps: allFlatEntityMaps,
+      metadataName: action.metadataName,
+      universalForeignKeyValues: action.flatEntity,
+    });
+
     return {
       ...action,
       flatEntity: {
         ...action.flatEntity,
+        roleId,
+        fieldMetadataId,
+        workspaceMemberFieldMetadataId,
+        objectMetadataId,
+        rowLevelPermissionPredicateGroupId,
         applicationId: flatApplication.id,
         id: action.id ?? v4(),
         workspaceId,

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/webhook/services/create-webhook-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/webhook/services/create-webhook-action-handler.service.ts
@@ -3,7 +3,10 @@ import { Injectable } from '@nestjs/common';
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
 import { WebhookEntity } from 'src/engine/metadata-modules/webhook/entities/webhook.entity';
-import { FlatCreateWebhookAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/webhook/types/workspace-migration-webhook-action.type';
+import {
+  FlatCreateWebhookAction,
+  UniversalCreateWebhookAction,
+} from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/builders/webhook/types/workspace-migration-webhook-action.type';
 import {
   WorkspaceMigrationActionRunnerArgs,
   WorkspaceMigrationActionRunnerContext,
@@ -19,7 +22,7 @@ export class CreateWebhookActionHandlerService extends WorkspaceMigrationRunnerA
   }
 
   override async transpileUniversalActionToFlatAction(
-    context: WorkspaceMigrationActionRunnerArgs<FlatCreateWebhookAction>,
+    context: WorkspaceMigrationActionRunnerArgs<UniversalCreateWebhookAction>,
   ): Promise<FlatCreateWebhookAction> {
     return context.action;
   }

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/webhook/services/create-webhook-action-handler.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/webhook/services/create-webhook-action-handler.service.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
+import { v4 } from 'uuid';
+
 import { WorkspaceMigrationRunnerActionHandler } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface';
 
 import { WebhookEntity } from 'src/engine/metadata-modules/webhook/entities/webhook.entity';
@@ -21,10 +23,20 @@ export class CreateWebhookActionHandlerService extends WorkspaceMigrationRunnerA
     super();
   }
 
-  override async transpileUniversalActionToFlatAction(
-    context: WorkspaceMigrationActionRunnerArgs<UniversalCreateWebhookAction>,
-  ): Promise<FlatCreateWebhookAction> {
-    return context.action;
+  override async transpileUniversalActionToFlatAction({
+    action,
+    flatApplication,
+    workspaceId,
+  }: WorkspaceMigrationActionRunnerArgs<UniversalCreateWebhookAction>): Promise<FlatCreateWebhookAction> {
+    return {
+      ...action,
+      flatEntity: {
+        ...action.flatEntity,
+        applicationId: flatApplication.id,
+        id: action.id ?? v4(),
+        workspaceId,
+      },
+    };
   }
 
   async executeForMetadata(


### PR DESCRIPTION
# Introduction
Completely finalize the universal migration at builder and runner levels.
Which mean that from now on the builder only compares `universalFlatEntity` and produces universal workspace migration that the runner ingest

## What's done
Migrated all create metadata remaining for
- agent
- skill
- commandMenuItem
- navigationMenuItem
- fieldMetadata
- objectMetadata
- view
- viewField
- viewFilter
- viewGroup
- viewFilterGroup
- index
- logicFunction
- role
- roleTarget
- pageLayout
- pageLayoutTab
- pageLayoutWidget
- rowLevelPermissionPredicate
- rowLevelPermissionPredicateGroup
- frontComponent