### PR TITLE
Respect Gmail retry-after in messaging throttle

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-channel-standard-flat-field-metadata.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/field-metadata/compute-message-channel-standard-flat-field-metadata.util.ts
@@ -517,6 +517,23 @@ export const buildMessageChannelStandardFlatFieldMetadatas = ({
     twentyStandardApplicationId,
     now,
   }),
+  throttleRetryAfter: createStandardFieldFlatMetadata({
+    objectName,
+    workspaceId,
+    context: {
+      fieldName: 'throttleRetryAfter',
+      type: FieldMetadataType.DATE_TIME,
+      label: 'Throttle Retry After',
+      description: 'Throttle Retry After',
+      icon: 'IconClock',
+      isNullable: true,
+      isUIReadOnly: true,
+    },
+    standardObjectMetadataRelatedEntityIds,
+    dependencyFlatEntityMaps,
+    twentyStandardApplicationId,
+    now,
+  }),
   connectedAccount: createStandardRelationFieldFlatMetadata({
     objectName,
     workspaceId,

--- a/packages/twenty-server/src/modules/connected-account/utils/__tests__/is-throttled.spec.ts
+++ b/packages/twenty-server/src/modules/connected-account/utils/__tests__/is-throttled.spec.ts
@@ -1,0 +1,52 @@
+import { isThrottled } from 'src/modules/connected-account/utils/is-throttled';
+
+describe('isThrottled', () => {
+  it('should not throttle when no sync stage is active', () => {
+    expect(isThrottled(null, 3)).toBe(false);
+  });
+
+  it('should not throttle when there have been no failures', () => {
+    expect(isThrottled(new Date().toISOString(), 0)).toBe(false);
+  });
+
+  it('should keep throttling when retryAfter is in the future even though exponential backoff has expired', () => {
+    const tenMinutesAgo = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+    const fiveMinutesFromNow = new Date(
+      Date.now() + 5 * 60 * 1000,
+    ).toISOString();
+
+    expect(isThrottled(tenMinutesAgo, 1, fiveMinutesFromNow)).toBe(true);
+  });
+
+  it('should fall back to exponential backoff when retryAfter is not provided', () => {
+    const justNow = new Date().toISOString();
+
+    expect(isThrottled(justNow, 1)).toBe(true);
+  });
+
+  it('should fall back to exponential backoff when retryAfter is in the past', () => {
+    const justNow = new Date().toISOString();
+    const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+
+    expect(isThrottled(justNow, 1, fiveMinutesAgo)).toBe(true);
+  });
+
+  it('should fall back to exponential backoff when retryAfter is explicitly null', () => {
+    const justNow = new Date().toISOString();
+
+    expect(isThrottled(justNow, 1, null)).toBe(true);
+  });
+
+  it('should fall back to exponential backoff when retryAfter is an invalid date string', () => {
+    const justNow = new Date().toISOString();
+
+    expect(isThrottled(justNow, 1, 'not-a-date')).toBe(true);
+  });
+
+  it('should use exponential backoff when both backoff is active and retryAfter is in the past', () => {
+    const justNow = new Date().toISOString();
+    const oneMinuteAgo = new Date(Date.now() - 60 * 1000).toISOString();
+
+    expect(isThrottled(justNow, 1, oneMinuteAgo)).toBe(true);
+  });
+});

--- a/packages/twenty-server/src/modules/messaging/common/services/message-channel-sync-status.service.ts
+++ b/packages/twenty-server/src/modules/messaging/common/services/message-channel-sync-status.service.ts
@@ -116,6 +116,7 @@ export class MessageChannelSyncStatusService {
         syncCursor: '',
         syncStageStartedAt: null,
         throttleFailureCount: 0,
+        throttleRetryAfter: null,
         pendingGroupEmailsAction: MessageChannelPendingGroupEmailsAction.NONE,
       });
 
@@ -225,6 +226,7 @@ export class MessageChannelSyncStatusService {
         syncStatus: MessageChannelSyncStatus.ACTIVE,
         syncStage: MessageChannelSyncStage.MESSAGE_LIST_FETCH_PENDING,
         throttleFailureCount: 0,
+        throttleRetryAfter: null,
         syncStageStartedAt: null,
         syncedAt: new Date().toISOString(),
       });
@@ -307,6 +309,7 @@ export class MessageChannelSyncStatusService {
       await messageChannelRepository.update(messageChannelIds, {
         syncStage: MessageChannelSyncStage.FAILED,
         syncStatus: syncStatus,
+        throttleRetryAfter: null,
       });
 
       const metricsKey =

--- a/packages/twenty-server/src/modules/messaging/common/standard-objects/message-channel.workspace-entity.ts
+++ b/packages/twenty-server/src/modules/messaging/common/standard-objects/message-channel.workspace-entity.ts
@@ -98,6 +98,7 @@ export class MessageChannelWorkspaceEntity extends BaseWorkspaceEntity {
   syncStage: MessageChannelSyncStage;
   syncStageStartedAt: string | null;
   throttleFailureCount: number;
+  throttleRetryAfter: string | null;
   connectedAccount: EntityRelation<ConnectedAccountWorkspaceEntity>;
   connectedAccountId: string;
   messageChannelMessageAssociations: EntityRelation<

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/exceptions/message-import-driver.exception.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/exceptions/message-import-driver.exception.ts
@@ -3,6 +3,7 @@ import { type MessageNetworkExceptionCode } from 'src/modules/messaging/message-
 export class MessageImportDriverException extends Error {
   code: MessageImportDriverExceptionCode | MessageNetworkExceptionCode;
   cause?: Error;
+  throttleRetryAfter?: Date;
   context?: {
     messageChannelId?: string;
     workspaceId?: string;
@@ -14,6 +15,7 @@ export class MessageImportDriverException extends Error {
     code: MessageImportDriverExceptionCode | MessageNetworkExceptionCode,
     options?: {
       cause?: Error;
+      throttleRetryAfter?: Date;
       context?: {
         messageChannelId?: string;
         workspaceId?: string;
@@ -25,6 +27,7 @@ export class MessageImportDriverException extends Error {
     this.name = 'MessageImportDriverException';
     this.code = code;
     this.cause = options?.cause;
+    this.throttleRetryAfter = options?.throttleRetryAfter;
     this.context = options?.context;
 
     if (options?.cause?.stack) {

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/mocks/gmail-api-error-mocks.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/mocks/gmail-api-error-mocks.ts
@@ -50,9 +50,11 @@ const ERROR_DEFINITIONS: Record<number, Record<string, ErrorConfig>> = {
 export const getGmailApiError = ({
   code,
   reason,
+  message,
 }: {
   code: number;
   reason?: string;
+  message?: string;
 }): GaxiosError => {
   const statusMap = ERROR_DEFINITIONS[code];
 
@@ -62,8 +64,10 @@ export const getGmailApiError = ({
 
   const config = statusMap[reason || ''] ?? statusMap.default;
 
+  const errorMessage = message ?? config.message;
+
   return new GaxiosError(
-    config.message,
+    errorMessage,
     { url: 'https://gmail.googleapis.com/mocks' },
     {
       status: code,
@@ -71,10 +75,10 @@ export const getGmailApiError = ({
       data: {
         error: {
           code,
-          message: config.message,
+          message: errorMessage,
           errors: [
             {
-              message: config.message,
+              message: errorMessage,
               reason: config.reason,
             },
           ],

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/utils/__tests__/parse-gmail-error-retry-after.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/utils/__tests__/parse-gmail-error-retry-after.spec.ts
@@ -1,0 +1,40 @@
+import { parseGmailErrorRetryAfter } from 'src/modules/messaging/message-import-manager/drivers/gmail/utils/parse-gmail-error-retry-after.util';
+
+describe('parseGmailErrorRetryAfter', () => {
+  it('should extract the retry-after date from a Gmail 429 error message', () => {
+    const fifteenMinutesFromNow = new Date(Date.now() + 15 * 60 * 1000);
+    const message = `User-rate limit exceeded.  Retry after ${fifteenMinutesFromNow.toISOString()}`;
+
+    const result = parseGmailErrorRetryAfter(message);
+
+    expect(result).toBeInstanceOf(Date);
+    expect(result!.getTime()).toBeCloseTo(fifteenMinutesFromNow.getTime(), -3);
+  });
+
+  it('should return undefined when the message contains no retry-after timestamp', () => {
+    expect(
+      parseGmailErrorRetryAfter('Too Many Concurrent Requests'),
+    ).toBeUndefined();
+  });
+
+  it('should return undefined when the retry-after timestamp has already passed', () => {
+    const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000);
+    const message = `User-rate limit exceeded.  Retry after ${fiveMinutesAgo.toISOString()}`;
+
+    expect(parseGmailErrorRetryAfter(message)).toBeUndefined();
+  });
+
+  it('should return undefined for an empty string', () => {
+    expect(parseGmailErrorRetryAfter('')).toBeUndefined();
+  });
+
+  it('should match case variations of "Retry after"', () => {
+    const fifteenMinutesFromNow = new Date(Date.now() + 15 * 60 * 1000);
+    const message = `User-rate limit exceeded.  retry after ${fifteenMinutesFromNow.toISOString()}`;
+
+    const result = parseGmailErrorRetryAfter(message);
+
+    expect(result).toBeInstanceOf(Date);
+    expect(result!.getTime()).toBeCloseTo(fifteenMinutesFromNow.getTime(), -3);
+  });
+});

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/utils/parse-gmail-api-error.util.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/utils/parse-gmail-api-error.util.ts
@@ -4,6 +4,7 @@ import {
   MessageImportDriverException,
   MessageImportDriverExceptionCode,
 } from 'src/modules/messaging/message-import-manager/drivers/exceptions/message-import-driver.exception';
+import { parseGmailErrorRetryAfter } from 'src/modules/messaging/message-import-manager/drivers/gmail/utils/parse-gmail-error-retry-after.util';
 
 export const parseGmailApiError = (
   error: GaxiosError,
@@ -57,6 +58,9 @@ export const parseGmailApiError = (
       return new MessageImportDriverException(
         gmailApiError.message,
         MessageImportDriverExceptionCode.TEMPORARY_ERROR,
+        {
+          throttleRetryAfter: parseGmailErrorRetryAfter(gmailApiError.message),
+        },
       );
 
     case 403:
@@ -68,6 +72,11 @@ export const parseGmailApiError = (
         return new MessageImportDriverException(
           gmailApiError.message,
           MessageImportDriverExceptionCode.TEMPORARY_ERROR,
+          {
+            throttleRetryAfter: parseGmailErrorRetryAfter(
+              gmailApiError.message,
+            ),
+          },
         );
       }
       if (gmailApiError.reason === 'domainPolicy') {

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/utils/parse-gmail-error-retry-after.util.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/utils/parse-gmail-error-retry-after.util.ts
@@ -1,0 +1,24 @@
+const RETRY_AFTER_REGEX =
+  /Retry after (\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z)/i;
+
+export const parseGmailErrorRetryAfter = (
+  message: string,
+): Date | undefined => {
+  const match = message.match(RETRY_AFTER_REGEX);
+
+  if (!match) {
+    return undefined;
+  }
+
+  const retryAfter = new Date(match[1]);
+
+  if (isNaN(retryAfter.getTime())) {
+    return undefined;
+  }
+
+  if (retryAfter <= new Date()) {
+    return undefined;
+  }
+
+  return retryAfter;
+};

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/jobs/messaging-message-list-fetch.job.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/jobs/messaging-message-list-fetch.job.ts
@@ -84,6 +84,7 @@ export class MessagingMessageListFetchJob {
           isThrottled(
             messageChannel.syncStageStartedAt,
             messageChannel.throttleFailureCount,
+            messageChannel.throttleRetryAfter,
           )
         ) {
           await this.messageChannelSyncStatusService.markAsMessagesListFetchPending(

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/jobs/messaging-messages-import.job.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/jobs/messaging-messages-import.job.ts
@@ -82,6 +82,7 @@ export class MessagingMessagesImportJob {
         isThrottled(
           messageChannel.syncStageStartedAt,
           messageChannel.throttleFailureCount,
+          messageChannel.throttleRetryAfter,
         )
       ) {
         await this.messageChannelSyncStatusService.markAsMessagesImportPending(

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-cursor.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-cursor.service.ts
@@ -38,6 +38,7 @@ export class MessagingCursorService {
           },
           {
             throttleFailureCount: 0,
+            throttleRetryAfter: null,
             syncStageStartedAt: null,
             syncCursor:
               !messageChannel.syncCursor ||
@@ -61,6 +62,7 @@ export class MessagingCursorService {
           },
           {
             throttleFailureCount: 0,
+            throttleRetryAfter: null,
             syncStageStartedAt: null,
           },
         );

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-import-exception-handler.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-import-exception-handler.service.ts
@@ -161,6 +161,14 @@ export class MessageImportExceptionHandlerService {
           'messageChannel',
         );
 
+      await messageChannelRepository.increment(
+        { id: messageChannel.id },
+        'throttleFailureCount',
+        1,
+        undefined,
+        ['throttleFailureCount', 'id'],
+      );
+
       const throttleRetryAfter =
         exception instanceof MessageImportDriverException
           ? exception.throttleRetryAfter
@@ -169,10 +177,9 @@ export class MessageImportExceptionHandlerService {
       await messageChannelRepository.update(
         { id: messageChannel.id },
         {
-          throttleFailureCount: messageChannel.throttleFailureCount + 1,
-          ...(isDefined(throttleRetryAfter)
-            ? { throttleRetryAfter: throttleRetryAfter.toISOString() }
-            : {}),
+          throttleRetryAfter: isDefined(throttleRetryAfter)
+            ? throttleRetryAfter.toISOString()
+            : null,
         },
       );
     }, authContext);

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-import-exception-handler.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-import-exception-handler.service.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
+import { isDefined } from 'twenty-shared/utils';
+
 import { ExceptionHandlerService } from 'src/engine/core-modules/exception-handler/exception-handler.service';
 import {
   type TwentyORMException,
@@ -159,12 +161,19 @@ export class MessageImportExceptionHandlerService {
           'messageChannel',
         );
 
-      await messageChannelRepository.increment(
+      const throttleRetryAfter =
+        exception instanceof MessageImportDriverException
+          ? exception.throttleRetryAfter
+          : undefined;
+
+      await messageChannelRepository.update(
         { id: messageChannel.id },
-        'throttleFailureCount',
-        1,
-        undefined,
-        ['throttleFailureCount', 'id'],
+        {
+          throttleFailureCount: messageChannel.throttleFailureCount + 1,
+          ...(isDefined(throttleRetryAfter)
+            ? { throttleRetryAfter: throttleRetryAfter.toISOString() }
+            : {}),
+        },
       );
     }, authContext);
 

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-messages-import.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-messages-import.service.ts
@@ -189,6 +189,7 @@ export class MessagingMessagesImportService {
           },
           {
             throttleFailureCount: 0,
+            throttleRetryAfter: null,
             syncStageStartedAt: null,
           },
         );

--- a/packages/twenty-shared/src/metadata/standard-object.constant.ts
+++ b/packages/twenty-shared/src/metadata/standard-object.constant.ts
@@ -775,6 +775,9 @@ export const STANDARD_OBJECTS = {
       throttleFailureCount: {
         universalIdentifier: '20202020-0291-42be-9ad0-d578a51684ab',
       },
+      throttleRetryAfter: {
+        universalIdentifier: '20202020-a1e3-4d7f-b5c2-9f8e6d4c3b2a',
+      },
     },
     indexes: {
       connectedAccountIdIndex: {


### PR DESCRIPTION
Gmail 429/403 rate-limit responses include an explicit retry-after timestamp, usually ~15 minutes out. 

The exponential backoff starts at 1 minute, so the channel burns through all 5 retry attempts before the window actually closes and gets marked as permanently failed. 

Adds throttleRetryAfter to the message channel and uses max(backoff, retryAfter) in isThrottled().