### PR TITLE
Remove redundant self-build from Nx targets that compile on the fly

### DIFF
--- a/packages/twenty-server/project.json
+++ b/packages/twenty-server/project.json
@@ -47,7 +47,7 @@
     "start": {
       "executor": "nx:run-commands",
       "cache": false,
-      "dependsOn": ["build"],
+      "dependsOn": ["^build"],
       "options": {
         "cwd": "packages/twenty-server",
         "command": "NODE_ENV=development nest start --watch"
@@ -70,10 +70,10 @@
     },
     "start:debug": {
       "executor": "nx:run-commands",
-      "dependsOn": ["build"],
+      "dependsOn": ["^build"],
       "options": {
         "cwd": "packages/twenty-server",
-        "command": "nx start --debug"
+        "command": "NODE_ENV=development nest start --watch --debug"
       }
     },
     "reset:env": {
@@ -125,11 +125,11 @@
         "cwd": "packages/twenty-server",
         "command": "ts-node --transpile-only -P tsconfig.json ../../node_modules/typeorm/cli.js"
       },
-      "dependsOn": ["build"]
+      "dependsOn": ["^build"]
     },
     "ts-node": {
       "executor": "nx:run-commands",
-      "dependsOn": ["build"],
+      "dependsOn": ["^build"],
       "options": {
         "cwd": "packages/twenty-server",
         "command": "ts-node"
@@ -181,7 +181,7 @@
     },
     "database:migrate": {
       "executor": "nx:run-commands",
-      "dependsOn": ["build"],
+      "dependsOn": ["^build"],
       "options": {
         "cwd": "packages/twenty-server",
         "commands": [
@@ -198,7 +198,7 @@
     },
     "database:migrate:revert": {
       "executor": "nx:run-commands",
-      "dependsOn": ["build"],
+      "dependsOn": ["^build"],
       "options": {
         "cwd": "packages/twenty-server",
         "commands": [


### PR DESCRIPTION
## Summary

- Changed 6 Nx targets (`start`, `start:debug`, `typeorm`, `ts-node`, `database:migrate`, `database:migrate:revert`) from `dependsOn: ["build"]` to `dependsOn: ["^build"]` to eliminate a redundant full SWC compilation step (~30-60s per invocation).
- These targets all use `nest start --watch`, `ts-node`, or TypeORM's CLI (which runs under ts-node), so they already compile TypeScript themselves. The `build` dependency was causing `rimraf dist && nest build` to run first, only for the target's own command to recompile everything again.
- Fixed `start:debug` to call `nest start --watch --debug` directly instead of routing through `nx start --debug`, which would trigger yet another build cycle.

Note: targets that run pre-compiled code from `dist/` (like `database:reset`) intentionally keep `dependsOn: ["build"]`.

## Test plan

- [ ] Run `npx nx start twenty-server` and verify the server starts with only one SWC compilation pass instead of two
- [ ] Run `npx nx start:debug twenty-server` and verify the debugger attaches correctly
- [ ] Run `npx nx run twenty-server:database:migrate` and verify migrations run correctly
- [ ] Run `npx nx run twenty-server:database:reset twenty-server` and verify it still builds before running (unchanged)


Made with [Cursor](https://cursor.com)