### PR TITLE
Attach file entity to front-component

### DIFF
--- a/packages/twenty-front/src/generated-metadata/graphql.ts
+++ b/packages/twenty-front/src/generated-metadata/graphql.ts
@@ -1001,6 +1001,7 @@ export type CreateFrontComponentInput = {
   builtComponentPath: Scalars['String'];
   componentName: Scalars['String'];
   description?: InputMaybe<Scalars['String']>;
+  fileId?: InputMaybe<Scalars['UUID']>;
   id?: InputMaybe<Scalars['UUID']>;
   name: Scalars['String'];
   sourceComponentPath: Scalars['String'];
@@ -1673,6 +1674,7 @@ export type FrontComponent = {
   componentName: Scalars['String'];
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
+  fileId?: Maybe<Scalars['UUID']>;
   id: Scalars['UUID'];
   name: Scalars['String'];
   sourceComponentPath: Scalars['String'];
@@ -4713,6 +4715,7 @@ export type UpdateFrontComponentInput = {
 
 export type UpdateFrontComponentInputUpdates = {
   description?: InputMaybe<Scalars['String']>;
+  fileId?: InputMaybe<Scalars['UUID']>;
   name?: InputMaybe<Scalars['String']>;
 };
 

--- a/packages/twenty-front/src/generated/graphql.ts
+++ b/packages/twenty-front/src/generated/graphql.ts
@@ -997,6 +997,7 @@ export type CreateFrontComponentInput = {
   builtComponentPath: Scalars['String'];
   componentName: Scalars['String'];
   description?: InputMaybe<Scalars['String']>;
+  fileId?: InputMaybe<Scalars['UUID']>;
   id?: InputMaybe<Scalars['UUID']>;
   name: Scalars['String'];
   sourceComponentPath: Scalars['String'];
@@ -1645,6 +1646,7 @@ export type FrontComponent = {
   componentName: Scalars['String'];
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
+  fileId?: Maybe<Scalars['UUID']>;
   id: Scalars['UUID'];
   name: Scalars['String'];
   sourceComponentPath: Scalars['String'];
@@ -4551,6 +4553,7 @@ export type UpdateFrontComponentInput = {
 
 export type UpdateFrontComponentInputUpdates = {
   description?: InputMaybe<Scalars['String']>;
+  fileId?: InputMaybe<Scalars['UUID']>;
   name?: InputMaybe<Scalars['String']>;
 };
 

--- a/packages/twenty-sdk/src/cli/utilities/api/api-service.ts
+++ b/packages/twenty-sdk/src/cli/utilities/api/api-service.ts
@@ -525,7 +525,7 @@ export class ApiService {
     builtHandlerPath: string;
     fileFolder: FileFolder;
     applicationUniversalIdentifier: string;
-  }): Promise<ApiResponse<boolean>> {
+  }): Promise<ApiResponse<{ id: string; path: string }>> {
     try {
       const absolutePath = path.resolve(filePath);
 
@@ -543,7 +543,7 @@ export class ApiService {
       const mutation = `
       mutation UploadApplicationFile($file: Upload!, $applicationUniversalIdentifier: String!, $fileFolder: FileFolder!, $filePath: String!) {
         uploadApplicationFile(file: $file, applicationUniversalIdentifier: $applicationUniversalIdentifier, fileFolder: $fileFolder, filePath: $filePath)
-        { path }
+        { id path }
       }
     `;
 

--- a/packages/twenty-sdk/src/cli/utilities/build/manifest/manifest-update-checksums.ts
+++ b/packages/twenty-sdk/src/cli/utilities/build/manifest/manifest-update-checksums.ts
@@ -14,7 +14,12 @@ export type UpdateManifestChecksumParams = {
   manifest: Manifest;
   builtFileInfos: Map<
     string,
-    { checksum: string; builtPath: string; fileFolder: FileFolder }
+    {
+      checksum: string;
+      builtPath: string;
+      fileFolder: FileFolder;
+      fileId?: string;
+    }
   >;
 };
 
@@ -25,7 +30,7 @@ export const manifestUpdateChecksums = ({
   let result = structuredClone(manifest);
   for (const [
     builtPath,
-    { fileFolder, checksum },
+    { fileFolder, checksum, fileId },
   ] of builtFileInfos.entries()) {
     const rootBuiltPath = relative(OUTPUT_DIR, builtPath);
     if (fileFolder === FileFolder.BuiltLogicFunction) {
@@ -72,7 +77,11 @@ export const manifestUpdateChecksums = ({
         ...result,
         frontComponents: frontComponents.map((component, index) =>
           index === componentIndex
-            ? { ...component, builtComponentChecksum: checksum }
+            ? {
+                ...component,
+                builtComponentChecksum: checksum,
+                ...(fileId ? { fileId } : {}),
+              }
             : component,
         ),
       };

--- a/packages/twenty-sdk/src/cli/utilities/dev/dev-mode-orchestrator.ts
+++ b/packages/twenty-sdk/src/cli/utilities/dev/dev-mode-orchestrator.ts
@@ -30,6 +30,7 @@ export class DevModeOrchestrator {
       builtPath: string;
       sourcePath: string;
       fileFolder: FileFolder;
+      fileId?: string;
     }
   >();
 
@@ -175,6 +176,12 @@ export class DevModeOrchestrator {
     })
       .then((result) => {
         if (result.success) {
+          const existingInfo = this.builtFileInfos.get(builtPath);
+
+          if (existingInfo) {
+            existingInfo.fileId = result.data.id;
+          }
+
           this.uiStateManager.addEvent({
             message: `Successfully uploaded ${builtPath}`,
             status: 'success',

--- a/packages/twenty-server/src/database/typeorm/core/migrations/common/1770742116157-addFileRelationToFrontComponent.ts
+++ b/packages/twenty-server/src/database/typeorm/core/migrations/common/1770742116157-addFileRelationToFrontComponent.ts
@@ -1,0 +1,31 @@
+import { type MigrationInterface, type QueryRunner } from 'typeorm';
+
+export class AddFileRelationToFrontComponent1770742116157
+  implements MigrationInterface
+{
+  name = 'AddFileRelationToFrontComponent1770742116157';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "core"."frontComponent" ADD "fileId" uuid`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."frontComponent" ADD CONSTRAINT "UQ_fd86790edb444e6f6e36e021b64" UNIQUE ("fileId")`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."frontComponent" ADD CONSTRAINT "FK_fd86790edb444e6f6e36e021b64" FOREIGN KEY ("fileId") REFERENCES "core"."file"("id") ON DELETE RESTRICT ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "core"."frontComponent" DROP CONSTRAINT "FK_fd86790edb444e6f6e36e021b64"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."frontComponent" DROP CONSTRAINT "UQ_fd86790edb444e6f6e36e021b64"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."frontComponent" DROP COLUMN "fileId"`,
+    );
+  }
+}

--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/__tests__/__snapshots__/all-universal-flat-entity-properties-to-compare-and-stringify.constant.constant.spec.ts.snap
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/__tests__/__snapshots__/all-universal-flat-entity-properties-to-compare-and-stringify.constant.constant.spec.ts.snap
@@ -59,6 +59,7 @@ exports[`ALL_UNIVERSAL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY should ma
       "sourceComponentPath",
       "builtComponentPath",
       "componentName",
+      "fileId",
     ],
     "propertiesToStringify": [],
   },

--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/all-entity-properties-configuration-by-metadata-name.constant.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/all-entity-properties-configuration-by-metadata-name.constant.ts
@@ -341,6 +341,7 @@ export const ALL_ENTITY_PROPERTIES_CONFIGURATION_BY_METADATA_NAME = {
     sourceComponentPath: { toStringify: false, universalProperty: undefined },
     builtComponentPath: { toStringify: false, universalProperty: undefined },
     componentName: { toStringify: false, universalProperty: undefined },
+    fileId: { toStringify: false, universalProperty: undefined },
   },
   webhook: {
     targetUrl: { toStringify: false, universalProperty: undefined },

--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/all-metadata-relations.constant.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/all-metadata-relations.constant.ts
@@ -494,6 +494,7 @@ export const ALL_METADATA_RELATIONS = {
     manyToOne: {
       workspace: null,
       application: null,
+      file: null,
     },
     oneToMany: {},
   },

--- a/packages/twenty-server/src/engine/metadata-modules/flat-front-component/constants/flat-front-component-editable-properties.constant.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-front-component/constants/flat-front-component-editable-properties.constant.ts
@@ -7,4 +7,5 @@ export const FLAT_FRONT_COMPONENT_EDITABLE_PROPERTIES = [
   'sourceComponentPath',
   'builtComponentPath',
   'componentName',
+  'fileId',
 ] as const satisfies MetadataEntityPropertyName<'frontComponent'>[];

--- a/packages/twenty-server/src/engine/metadata-modules/flat-front-component/utils/from-create-front-component-input-to-flat-front-component-to-create.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-front-component/utils/from-create-front-component-input-to-flat-front-component-to-create.util.ts
@@ -33,6 +33,7 @@ export const fromCreateFrontComponentInputToFlatFrontComponentToCreate = ({
     builtComponentPath: createFrontComponentInput.builtComponentPath,
     componentName: createFrontComponentInput.componentName,
     builtComponentChecksum: createFrontComponentInput.builtComponentChecksum,
+    fileId: createFrontComponentInput.fileId ?? null,
     workspaceId,
     createdAt: now,
     updatedAt: now,

--- a/packages/twenty-server/src/engine/metadata-modules/flat-front-component/utils/from-flat-front-component-to-front-component-dto.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-front-component/utils/from-flat-front-component-to-front-component-dto.util.ts
@@ -15,6 +15,9 @@ export const fromFlatFrontComponentToFrontComponentDto = (
   builtComponentPath: flatFrontComponent.builtComponentPath,
   componentName: flatFrontComponent.componentName,
   builtComponentChecksum: flatFrontComponent.builtComponentChecksum,
+  fileId: isDefined(flatFrontComponent.fileId)
+    ? flatFrontComponent.fileId
+    : undefined,
   universalIdentifier: isDefined(flatFrontComponent.universalIdentifier)
     ? flatFrontComponent.universalIdentifier
     : undefined,

--- a/packages/twenty-server/src/engine/metadata-modules/flat-front-component/utils/from-front-component-entity-to-flat-front-component.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-front-component/utils/from-front-component-entity-to-flat-front-component.util.ts
@@ -31,6 +31,7 @@ export const fromFrontComponentEntityToFlatFrontComponent = ({
     builtComponentPath: frontComponentEntity.builtComponentPath,
     componentName: frontComponentEntity.componentName,
     builtComponentChecksum: frontComponentEntity.builtComponentChecksum,
+    fileId: frontComponentEntity.fileId,
     workspaceId: frontComponentEntity.workspaceId,
     universalIdentifier: frontComponentEntity.universalIdentifier,
     applicationId: frontComponentEntity.applicationId,

--- a/packages/twenty-server/src/engine/metadata-modules/front-component/dtos/create-front-component.input.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/front-component/dtos/create-front-component.input.ts
@@ -44,4 +44,9 @@ export class CreateFrontComponentInput {
   @IsNotEmpty()
   @Field()
   builtComponentChecksum: string;
+
+  @IsUUID()
+  @IsOptional()
+  @Field(() => UUIDScalarType, { nullable: true })
+  fileId?: string;
 }

--- a/packages/twenty-server/src/engine/metadata-modules/front-component/dtos/front-component.dto.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/front-component/dtos/front-component.dto.ts
@@ -46,6 +46,11 @@ export class FrontComponentDTO {
   @IsUUID()
   @IsOptional()
   @Field(() => UUIDScalarType, { nullable: true })
+  fileId?: string;
+
+  @IsUUID()
+  @IsOptional()
+  @Field(() => UUIDScalarType, { nullable: true })
   universalIdentifier?: string;
 
   @HideField()

--- a/packages/twenty-server/src/engine/metadata-modules/front-component/dtos/update-front-component.input.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/front-component/dtos/update-front-component.input.ts
@@ -27,6 +27,11 @@ export class UpdateFrontComponentInputUpdates {
   @IsString()
   @HideField()
   builtComponentChecksum?: string;
+
+  @IsOptional()
+  @IsUUID()
+  @Field(() => UUIDScalarType, { nullable: true })
+  fileId?: string;
 }
 
 @InputType()

--- a/packages/twenty-server/src/engine/metadata-modules/front-component/entities/front-component.entity.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/front-component/entities/front-component.entity.ts
@@ -2,10 +2,14 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  JoinColumn,
+  OneToOne,
   PrimaryGeneratedColumn,
+  Relation,
   UpdateDateColumn,
 } from 'typeorm';
 
+import { FileEntity } from 'src/engine/core-modules/file/entities/file.entity';
 import { SyncableEntity } from 'src/engine/workspace-manager/types/syncable-entity.interface';
 
 @Entity('frontComponent')
@@ -33,6 +37,13 @@ export class FrontComponentEntity
 
   @Column({ nullable: false })
   builtComponentChecksum: string;
+
+  @Column({ nullable: true, type: 'uuid' })
+  fileId: string | null;
+
+  @OneToOne(() => FileEntity, { onDelete: 'RESTRICT' })
+  @JoinColumn({ name: 'fileId' })
+  file: Relation<FileEntity> | null;
 
   @CreateDateColumn({ type: 'timestamptz' })
   createdAt: Date;

--- a/packages/twenty-server/src/engine/metadata-modules/front-component/front-component.module.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/front-component/front-component.module.ts
@@ -1,6 +1,9 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { ApplicationEntity } from 'src/engine/core-modules/application/application.entity';
 import { ApplicationModule } from 'src/engine/core-modules/application/application.module';
+import { FileEntity } from 'src/engine/core-modules/file/entities/file.entity';
 import { WorkspaceManyOrAllFlatEntityMapsCacheModule } from 'src/engine/metadata-modules/flat-entity/services/workspace-many-or-all-flat-entity-maps-cache.module';
 import { FlatFrontComponentModule } from 'src/engine/metadata-modules/flat-front-component/flat-front-component.module';
 import { FrontComponentController } from 'src/engine/metadata-modules/front-component/controllers/front-component.controller';
@@ -14,6 +17,7 @@ import { WorkspaceMigrationModule } from 'src/engine/workspace-manager/workspace
 
 @Module({
   imports: [
+    TypeOrmModule.forFeature([FileEntity, ApplicationEntity]),
     WorkspaceManyOrAllFlatEntityMapsCacheModule,
     WorkspaceMigrationModule,
     ApplicationModule,

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/constants/all-universal-metadata-relations.constant.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/constants/all-universal-metadata-relations.constant.ts
@@ -504,6 +504,7 @@ export const ALL_UNIVERSAL_METADATA_RELATIONS = {
     manyToOne: {
       workspace: null,
       application: null,
+      file: null,
     },
     oneToMany: {},
   },

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/workspace-schema-migration-runner-action-handlers.module.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/workspace-schema-migration-runner-action-handlers.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { ApplicationEntity } from 'src/engine/core-modules/application/application.entity';
+import { FileEntity } from 'src/engine/core-modules/file/entities/file.entity';
 import { WorkspaceSchemaManagerModule } from 'src/engine/twenty-orm/workspace-schema-manager/workspace-schema-manager.module';
 import { CreateAgentActionHandlerService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/agent/services/create-agent-action-handler.service';
 import { DeleteAgentActionHandlerService } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/action-handlers/agent/services/delete-agent-action-handler.service';
@@ -72,7 +73,7 @@ import { UpdateViewActionHandlerService } from 'src/engine/workspace-manager/wor
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([ApplicationEntity]),
+    TypeOrmModule.forFeature([ApplicationEntity, FileEntity]),
     WorkspaceSchemaManagerModule,
   ],
   providers: [

--- a/packages/twenty-shared/src/application/frontComponentManifestType.ts
+++ b/packages/twenty-shared/src/application/frontComponentManifestType.ts
@@ -6,4 +6,5 @@ export type FrontComponentManifest = {
   builtComponentPath: string;
   builtComponentChecksum: string;
   componentName: string;
+  fileId?: string;
 };


### PR DESCRIPTION
## Context
Deprecating (while still keeping it for retro-compatibility) front component built file path in favor of the new file entity.
The file entity was already created during file upload but not directly attached to the associated front component 



<img width="908" height="63" alt="Screenshot 2026-02-11 at 11 10 52" src="https://github.com/user-attachments/assets/8230e8a0-32a3-4426-bbe4-d278e68b7e53" />
<img width="865" height="680" alt="Screenshot 2026-02-11 at 10 48 25" src="https://github.com/user-attachments/assets/012db28b-da71-4fb6-a80d-684b0f879992" />

