### PR TITLE
Fix spurious logouts by deduplicating concurrent token renewals

### DIFF
--- a/packages/twenty-front/src/modules/apollo/services/apollo.factory.ts
+++ b/packages/twenty-front/src/modules/apollo/services/apollo.factory.ts
@@ -22,6 +22,7 @@ import { type AuthTokenPair } from '~/generated/graphql';
 import { logDebug } from '~/utils/logDebug';
 
 import { REST_API_BASE_URL } from '@/apollo/constant/rest-api-base-url';
+import { REACT_APP_SERVER_BASE_URL } from '~/config';
 import { getTokenPair } from '@/apollo/utils/getTokenPair';
 import { i18n } from '@lingui/core';
 import { t } from '@lingui/core/macro';
@@ -40,6 +41,11 @@ import { loggerLink } from '@/apollo/utils/loggerLink';
 import { StreamingRestLink } from '@/apollo/utils/streamingRestLink';
 
 const logger = loggerLink(() => 'Twenty');
+
+// Shared across all ApolloFactory instances so concurrent
+// UNAUTHENTICATED errors from /graphql and /metadata clients
+// deduplicate into a single renewal request.
+let renewalPromise: Promise<void> | null = null;
 
 export interface Options<TCacheShape> extends ApolloClientOptions<TCacheShape> {
   onError?: (err: readonly GraphQLFormattedError[] | undefined) => void;
@@ -145,8 +151,12 @@ export class ApolloFactory<TCacheShape> implements ApolloManager<TCacheShape> {
         operation: Operation,
         forward: (operation: Operation) => Observable<FetchResult>,
       ) => {
-        return fromPromise(
-          renewToken(uri, getTokenPair())
+        if (!renewalPromise) {
+          // Always renew through /graphql since the RenewToken
+          // mutation may not be exposed on other endpoints (e.g. /metadata).
+          const graphqlUri = `${REACT_APP_SERVER_BASE_URL}/graphql`;
+
+          renewalPromise = renewToken(graphqlUri, getTokenPair())
             .then((tokens) => {
               if (isDefined(tokens)) {
                 // eslint-disable-next-line no-console
@@ -161,8 +171,13 @@ export class ApolloFactory<TCacheShape> implements ApolloManager<TCacheShape> {
                 'Failed to renew token, triggering unauthenticated error from handleTokenRenewal',
               );
               onUnauthenticatedError?.();
-            }),
-        ).flatMap(() => forward(operation));
+            })
+            .finally(() => {
+              renewalPromise = null;
+            });
+        }
+
+        return fromPromise(renewalPromise).flatMap(() => forward(operation));
       };
 
       const sendToSentry = ({

--- a/packages/twenty-front/src/modules/apollo/services/apollo.factory.ts
+++ b/packages/twenty-front/src/modules/apollo/services/apollo.factory.ts
@@ -22,8 +22,10 @@ import { type AuthTokenPair } from '~/generated/graphql';
 import { logDebug } from '~/utils/logDebug';
 
 import { REST_API_BASE_URL } from '@/apollo/constant/rest-api-base-url';
-import { REACT_APP_SERVER_BASE_URL } from '~/config';
+import { type ApolloManager } from '@/apollo/types/apolloManager.interface';
 import { getTokenPair } from '@/apollo/utils/getTokenPair';
+import { loggerLink } from '@/apollo/utils/loggerLink';
+import { StreamingRestLink } from '@/apollo/utils/streamingRestLink';
 import { i18n } from '@lingui/core';
 import { t } from '@lingui/core/macro';
 import {
@@ -34,11 +36,9 @@ import {
 } from 'graphql';
 import isEmpty from 'lodash.isempty';
 import { getGenericOperationName, isDefined } from 'twenty-shared/utils';
+import { REACT_APP_SERVER_BASE_URL } from '~/config';
 import { cookieStorage } from '~/utils/cookie-storage';
 import { isUndefinedOrNull } from '~/utils/isUndefinedOrNull';
-import { type ApolloManager } from '@/apollo/types/apolloManager.interface';
-import { loggerLink } from '@/apollo/utils/loggerLink';
-import { StreamingRestLink } from '@/apollo/utils/streamingRestLink';
 
 const logger = loggerLink(() => 'Twenty');
 
@@ -152,9 +152,8 @@ export class ApolloFactory<TCacheShape> implements ApolloManager<TCacheShape> {
         forward: (operation: Operation) => Observable<FetchResult>,
       ) => {
         if (!renewalPromise) {
-          // Always renew through /graphql since the RenewToken
-          // mutation may not be exposed on other endpoints (e.g. /metadata).
-          const graphqlUri = `${REACT_APP_SERVER_BASE_URL}/graphql`;
+          // Always renew through /metadata since the RenewToken is only exposed there
+          const graphqlUri = `${REACT_APP_SERVER_BASE_URL}/metadata`;
 
           renewalPromise = renewToken(graphqlUri, getTokenPair())
             .then((tokens) => {


### PR DESCRIPTION
## Summary

- When returning to the app after idle (or after a deploy), the expired access token causes multiple simultaneous GraphQL queries to fail with `UNAUTHENTICATED`. Previously, each failure independently triggered its own `renewToken` call with the same refresh token. If **any single** renewal failed (e.g. server briefly slow after a deploy), the `catch` handler would nuke the session and redirect to sign-in — even if another concurrent renewal had already succeeded and written valid tokens.
- This adds a shared `renewalPromise` so that only the first `UNAUTHENTICATED` error triggers a server-side renewal. All concurrent callers await the same promise and replay their operations once it resolves. This eliminates redundant refresh token rotation on the server and removes the race condition where a straggling failure could log out an already-renewed session.

## Test plan

- [ ] Log in, wait >30 minutes (or manually expire the access token), then interact with the app — should silently renew without redirect to sign-in
- [ ] Open browser DevTools Network tab, trigger the above scenario, and verify only **one** `renewToken` mutation is sent (instead of N)
- [ ] With server temporarily stopped, verify that a genuine renewal failure still correctly redirects to sign-in (single `onUnauthenticatedError` call)
- [ ] Open multiple browser tabs, let access tokens expire, interact in one tab — other tabs should also recover gracefully on their next request


Made with [Cursor](https://cursor.com)