### PR TITLE
Do not throw on corrupted labelFieldMetadataIdentifier

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/flat-object-metadata/utils/from-object-metadata-entity-to-flat-object-metadata.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-object-metadata/utils/from-object-metadata-entity-to-flat-object-metadata.util.ts
@@ -43,12 +43,13 @@ export const fromObjectMetadataEntityToFlatObjectMetadata = ({
         objectMetadataEntity.labelIdentifierFieldMetadataId,
       ) ?? null;
 
-    if (!isDefined(labelIdentifierFieldMetadataUniversalIdentifier)) {
-      throw new FlatEntityMapsException(
-        `Label identifier field metadata with id ${objectMetadataEntity.labelIdentifierFieldMetadataId} not found when building flat object metadata for object ${objectMetadataEntity.id}`,
-        FlatEntityMapsExceptionCode.ENTITY_NOT_FOUND,
-      );
-    }
+    // TODO uncomment once https://github.com/twentyhq/core-team-issues/issues/2172 has been resolved
+    // if (!isDefined(labelIdentifierFieldMetadataUniversalIdentifier)) {
+    //   throw new FlatEntityMapsException(
+    //     `Label identifier field metadata with id ${objectMetadataEntity.labelIdentifierFieldMetadataId} not found when building flat object metadata for object ${objectMetadataEntity.id}`,
+    //     FlatEntityMapsExceptionCode.ENTITY_NOT_FOUND,
+    //   );
+    // }
   }
 
   let imageIdentifierFieldMetadataUniversalIdentifier: string | null = null;
@@ -59,12 +60,13 @@ export const fromObjectMetadataEntityToFlatObjectMetadata = ({
         objectMetadataEntity.imageIdentifierFieldMetadataId,
       ) ?? null;
 
-    if (!isDefined(imageIdentifierFieldMetadataUniversalIdentifier)) {
-      throw new FlatEntityMapsException(
-        `Image identifier field metadata with id ${objectMetadataEntity.imageIdentifierFieldMetadataId} not found when building flat object metadata for object ${objectMetadataEntity.id}`,
-        FlatEntityMapsExceptionCode.ENTITY_NOT_FOUND,
-      );
-    }
+    // TODO uncomment once https://github.com/twentyhq/core-team-issues/issues/2172 has been resolved
+    // if (!isDefined(imageIdentifierFieldMetadataUniversalIdentifier)) {
+    //   throw new FlatEntityMapsException(
+    //     `Image identifier field metadata with id ${objectMetadataEntity.imageIdentifierFieldMetadataId} not found when building flat object metadata for object ${objectMetadataEntity.id}`,
+    //     FlatEntityMapsExceptionCode.ENTITY_NOT_FOUND,
+    //   );
+    // }
   }
 
   return {

--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.entity.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/object-metadata.entity.ts
@@ -97,7 +97,7 @@ export class ObjectMetadataEntity
   shortcut: string | null;
 
   // TODO: This should not be nullable - legacy field introduced when label identifier was nullable
-  // TODO: This should be a joinColumn and we should have a FK on this too
+  // TODO: This should be a joinColumn and we should have a FK on this too https://github.com/twentyhq/core-team-issues/issues/2172
   @Column({ nullable: true, type: 'uuid' })
   labelIdentifierFieldMetadataId: string | null;
 


### PR DESCRIPTION
# Introduction
As we don't enforce any FK on object labelIdentifierFieldMetadataId we have some that are either null or pointing to non-existing field metadata resulting in exception thrown at cache computation lvl

Commenting the exception throw until we've closed https://github.com/twentyhq/core-team-issues/issues/2172

closes https://github.com/twentyhq/core-team-issues/issues/2221