### PR TITLE
Fix redirect to deleted workspace subdomain after workspace deletion

### DIFF
--- a/packages/twenty-front/src/modules/settings/profile/components/DeleteWorkspace.tsx
+++ b/packages/twenty-front/src/modules/settings/profile/components/DeleteWorkspace.tsx
@@ -3,6 +3,7 @@ import { useRecoilValue } from 'recoil';
 
 import { useAuth } from '@/auth/hooks/useAuth';
 import { currentUserState } from '@/auth/states/currentUserState';
+import { useRedirectToDefaultDomain } from '@/domain-manager/hooks/useRedirectToDefaultDomain';
 import { ConfirmationModal } from '@/ui/layout/modal/components/ConfirmationModal';
 import { useModal } from '@/ui/layout/modal/hooks/useModal';
 import { H2Title, IconTrash } from 'twenty-ui/display';
@@ -19,10 +20,12 @@ export const DeleteWorkspace = () => {
   const { openModal } = useModal();
 
   const { signOut } = useAuth();
+  const { redirectToDefaultDomain } = useRedirectToDefaultDomain();
 
   const deleteWorkspace = async () => {
     await deleteCurrentWorkspace();
     await signOut();
+    redirectToDefaultDomain();
   };
 
   return (


### PR DESCRIPTION
## Summary
- After deleting a workspace, the app was incorrectly redirecting to the deleted workspace's subdomain (e.g. `myworkspace.ourapp.com/sign-in-up`) because `signOut()` only performs a client-side React Router navigation which stays on the current domain.
- Added an explicit `redirectToDefaultDomain()` call after sign out in the workspace deletion flow, which does a hard browser redirect to the base domain (e.g. `app.ourapp.com`).

## Test plan
- [ ] Delete a workspace in a multi-workspace environment
- [ ] Verify the browser redirects to the base domain (`app.ourapp.com`) instead of staying on the deleted workspace's subdomain
- [ ] Verify normal sign-out (without workspace deletion) still works as expected

Made with [Cursor](https://cursor.com)