### PR TITLE
Fix hardcoded colors in 2FA verification screen for dark mode

### DIFF
--- a/packages/twenty-front/src/modules/auth/sign-in-up/components/internal/SignInUpTwoFactorAuthenticationVerification.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/components/internal/SignInUpTwoFactorAuthenticationVerification.tsx
@@ -118,7 +118,7 @@ const StyledCaretContainer = styled.div`
 const StyledCaret = styled.div`
   width: 1px;
   height: 2rem;
-  background-color: white;
+  background-color: ${({ theme }) => theme.font.color.light};
 `;
 
 const FakeCaret = () => {
@@ -137,7 +137,7 @@ const StyledDashContainer = styled.div`
 `;
 
 const StyledDash = styled.div`
-  background-color: black;
+  background-color: ${({ theme }) => theme.font.color.primary};
   border-radius: 9999px;
   height: 0.25rem;
   width: 0.75rem;


### PR DESCRIPTION
## Summary
- The dash separator and blinking caret in the sign-in 2FA OTP input had hardcoded `black` and `white` background colors, making them invisible in dark mode (black on black / white on white).
- Replaced with theme-aware colors (`theme.font.color.light` for the dash, `theme.font.color.primary` for the caret) to match the existing settings 2FA component.

## Test plan
- [ ] Open the 2FA verification screen in dark mode and verify the dash between digit groups is visible
- [ ] Verify the blinking caret is visible in dark mode
- [ ] Confirm both still look correct in light mode

Made with [Cursor](https://cursor.com)