### PR TITLE
Workflow bug fixes 

### DIFF
--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/utils/getEdgePathStrategy.ts
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/utils/getEdgePathStrategy.ts
@@ -12,8 +12,9 @@ export const getEdgePathStrategy = ({
   steps: WorkflowStep[];
 }) => {
   const nextStep = steps.find((s) => s.id === nextStepId);
+
   if (!isDefined(nextStep)) {
-    throw new Error('Expected to find step defined in nextStepIds');
+    return undefined;
   }
 
   const useLoopBackToIteratorStyle =

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/filter/utils/evaluate-filter-conditions.util.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/filter/utils/evaluate-filter-conditions.util.ts
@@ -307,9 +307,9 @@ function evaluateCurrencyFilter(filter: ResolvedFilter): boolean {
   if (filter.compositeFieldSubFieldName === 'currencyCode') {
     switch (filter.operand) {
       case ViewFilterOperand.IS:
-        return filter.leftOperand === filter.rightOperand;
+        return contains(filter.leftOperand, filter.rightOperand);
       case ViewFilterOperand.IS_NOT:
-        return filter.leftOperand !== filter.rightOperand;
+        return !contains(filter.leftOperand, filter.rightOperand);
       case ViewFilterOperand.IS_EMPTY:
         return !isNonEmptyString(filter.leftOperand);
       case ViewFilterOperand.IS_NOT_EMPTY:

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/jobs/run-workflow.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/jobs/run-workflow.job.ts
@@ -156,7 +156,7 @@ export class RunWorkflowJob {
     const lastExecutedStepOutput =
       workflowRun.state?.stepInfos[lastExecutedStepId];
 
-    const nextStepIdsToExecute =
+    const { nextStepIdsToExecute } =
       await this.workflowExecutorWorkspaceService.getNextStepIdsToExecute({
         executedStep: lastExecutedStep,
         executedStepOutput: lastExecutedStepOutput,

--- a/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/cron/jobs/workflow-run-enqueue.cron.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-runner/workflow-run-queue/cron/jobs/workflow-run-enqueue.cron.job.ts
@@ -5,6 +5,7 @@ import { WorkspaceActivationStatus } from 'twenty-shared/workspace';
 import { Repository } from 'typeorm';
 
 import { SentryCronMonitor } from 'src/engine/core-modules/cron/sentry-cron-monitor.decorator';
+import { ExceptionHandlerService } from 'src/engine/core-modules/exception-handler/exception-handler.service';
 import { InjectMessageQueue } from 'src/engine/core-modules/message-queue/decorators/message-queue.decorator';
 import { Process } from 'src/engine/core-modules/message-queue/decorators/process.decorator';
 import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
@@ -32,6 +33,7 @@ export class WorkflowRunEnqueueCronJob {
     @InjectMessageQueue(MessageQueue.workflowQueue)
     private readonly messageQueueService: MessageQueueService,
     private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    private readonly exceptionHandlerService: ExceptionHandlerService,
   ) {}
 
   @Process(WorkflowRunEnqueueCronJob.name)
@@ -52,17 +54,25 @@ export class WorkflowRunEnqueueCronJob {
     let enqueuedCount = 0;
 
     for (const workspace of activeWorkspaces) {
-      const hasNotStartedRuns = await this.hasNotStartedRuns(workspace.id);
+      try {
+        const hasNotStartedRuns = await this.hasNotStartedRuns(workspace.id);
 
-      if (hasNotStartedRuns) {
-        await this.messageQueueService.add<WorkflowRunEnqueueJobData>(
-          WorkflowRunEnqueueJob.name,
-          {
-            workspaceId: workspace.id,
-            isCacheMode: false,
+        if (hasNotStartedRuns) {
+          await this.messageQueueService.add<WorkflowRunEnqueueJobData>(
+            WorkflowRunEnqueueJob.name,
+            {
+              workspaceId: workspace.id,
+              isCacheMode: false,
+            },
+          );
+          enqueuedCount++;
+        }
+      } catch (error) {
+        this.exceptionHandlerService.captureExceptions([error], {
+          workspace: {
+            id: workspace.id,
           },
-        );
-        enqueuedCount++;
+        });
       }
     }
 


### PR DESCRIPTION
Fixes https://github.com/twentyhq/private-issues/issues/418 
Currency filtering was not properly managed. Since this is a select, we were doing 'USD' == [USD]. Replacing by contains as for other select
<img width="952" height="552" alt="Capture d’écran 2026-02-12 à 11 08 42" src="https://github.com/user-attachments/assets/6945f376-c62b-44a3-9d85-dfcb82f5c478" />

Fixes https://github.com/twentyhq/twenty/issues/17611
If-else branches not executed has to be marked as skipped. Otherwise, the iterator will never start the next iteration. It will wait for some not started nodes.
<img width="673" height="559" alt="Capture d’écran 2026-02-12 à 10 56 45" src="https://github.com/user-attachments/assets/2b5396d7-a546-43df-a689-39f2686855ec" />
