### PR TITLE
Fix index field comparison

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/__tests__/__snapshots__/all-universal-flat-entity-properties-to-compare-and-stringify.constant.spec.ts.snap
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/__tests__/__snapshots__/all-universal-flat-entity-properties-to-compare-and-stringify.constant.spec.ts.snap
@@ -66,12 +66,12 @@ exports[`ALL_UNIVERSAL_FLAT_ENTITY_PROPERTIES_TO_COMPARE_AND_STRINGIFY should ma
     "propertiesToCompare": [
       "indexType",
       "indexWhereClause",
-      "flatIndexFieldMetadatas",
+      "universalFlatIndexFieldMetadatas",
       "isUnique",
       "name",
     ],
     "propertiesToStringify": [
-      "flatIndexFieldMetadatas",
+      "universalFlatIndexFieldMetadatas",
     ],
   },
   "logicFunction": {

--- a/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/all-entity-properties-configuration-by-metadata-name.constant.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-entity/constant/all-entity-properties-configuration-by-metadata-name.constant.ts
@@ -33,7 +33,7 @@ type MetadataEntityPropertyConfiguration<
       ? `universal${Capitalize<K>}`
       : K extends MetadataManyToOneJoinColumn<TMetadataName> & string
         ? ToUniversalForeignKey<K>
-        : undefined;
+        : undefined | string;
     toStringify: K extends ExtractJsonbProperties<MetadataEntity<TMetadataName>>
       ? true
       : K extends keyof MetadataEntity<TMetadataName>
@@ -67,7 +67,6 @@ export const ALL_ENTITY_PROPERTIES_CONFIGURATION_BY_METADATA_NAME = {
     nameSingular: { toStringify: false, universalProperty: undefined },
     labelIdentifierFieldMetadataId: {
       toStringify: false,
-      // @ts-expect-error remove once https://github.com/twentyhq/core-team-issues/issues/2172 has been resolved
       universalProperty: 'labelIdentifierFieldMetadataUniversalIdentifier',
     },
     standardOverrides: { toStringify: true, universalProperty: undefined },
@@ -135,7 +134,7 @@ export const ALL_ENTITY_PROPERTIES_CONFIGURATION_BY_METADATA_NAME = {
     indexWhereClause: { toStringify: false, universalProperty: undefined },
     flatIndexFieldMetadatas: {
       toStringify: true,
-      universalProperty: undefined,
+      universalProperty: 'universalFlatIndexFieldMetadatas',
     },
     isUnique: { toStringify: false, universalProperty: undefined },
     name: { toStringify: false, universalProperty: undefined },


### PR DESCRIPTION
# Introduction
Related https://github.com/twentyhq/core-team-issues/issues/2227

On a field name update side effect leading to an index field mutation it wouldn't get caught by the builder leading to an index field desync

We should land on a standard pattern regarding the field index either jsonb or syncableEntity so this would not occur anymore as it would have been strictly typed