### PR TITLE
Refactor metadata events to contain `scalarEntity`

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/types/metadata-event.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/types/metadata-event.ts
@@ -1,6 +1,8 @@
 import { type AllMetadataName } from 'twenty-shared/metadata';
 
+import { MetadataEntity } from 'src/engine/metadata-modules/flat-entity/types/metadata-entity.type';
 import { type MetadataFlatEntity } from 'src/engine/metadata-modules/flat-entity/types/metadata-flat-entity.type';
+import { ScalarFlatEntity } from 'src/engine/metadata-modules/flat-entity/types/scalar-flat-entity.type';
 import { type MetadataUniversalFlatEntityPropertiesToCompare } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/metadata-universal-flat-entity-properties-to-compare.type';
 
 type BaseMetadataEvent<T extends AllMetadataName, TPayload extends object> = {
@@ -11,7 +13,7 @@ type BaseMetadataEvent<T extends AllMetadataName, TPayload extends object> = {
 
 export type DeleteMetadataEvent<T extends AllMetadataName> = BaseMetadataEvent<
   T,
-  { before: MetadataFlatEntity<T> }
+  { before: ScalarFlatEntity<MetadataEntity<T>> }
 > & {
   type: 'deleted';
 };
@@ -35,15 +37,15 @@ export type UpdateMetadataEvent<
   {
     updatedFields: TProperties[];
     diff: UpdateMetadataEventDiff<T, TProperties>;
-    before: MetadataFlatEntity<T>;
-    after: MetadataFlatEntity<T>;
+    before: ScalarFlatEntity<MetadataEntity<T>>;
+    after: ScalarFlatEntity<MetadataEntity<T>>;
   }
 > & { type: 'updated' };
 
 export type CreateMetadataEvent<T extends AllMetadataName> = BaseMetadataEvent<
   T,
   {
-    after: MetadataFlatEntity<T>;
+    after: ScalarFlatEntity<MetadataEntity<T>>;
   }
 > & { type: 'created' };
 

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/types/metadata-event.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/types/metadata-event.ts
@@ -1,8 +1,8 @@
 import { type AllMetadataName } from 'twenty-shared/metadata';
 
-import { MetadataEntity } from 'src/engine/metadata-modules/flat-entity/types/metadata-entity.type';
+import { type MetadataEntity } from 'src/engine/metadata-modules/flat-entity/types/metadata-entity.type';
 import { type MetadataFlatEntity } from 'src/engine/metadata-modules/flat-entity/types/metadata-flat-entity.type';
-import { ScalarFlatEntity } from 'src/engine/metadata-modules/flat-entity/types/scalar-flat-entity.type';
+import { type ScalarFlatEntity } from 'src/engine/metadata-modules/flat-entity/types/scalar-flat-entity.type';
 import { type MetadataUniversalFlatEntityPropertiesToCompare } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/metadata-universal-flat-entity-properties-to-compare.type';
 
 type BaseMetadataEvent<T extends AllMetadataName, TPayload extends object> = {

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/derive-metadata-events-from-create-action.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/derive-metadata-events-from-create-action.util.ts
@@ -18,7 +18,10 @@ export const deriveMetadataEventsFromCreateAction = (
           recordId: flatFieldMetadata.id,
           metadataName: 'fieldMetadata',
           properties: {
-            after: flatFieldMetadata,
+            after: flatEntityToScalarFlatEntity({
+              flatEntity: flatFieldMetadata,
+              metadataName: 'fieldMetadata',
+            }),
           },
         }),
       );

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/derive-metadata-events-from-create-action.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/derive-metadata-events-from-create-action.util.ts
@@ -5,6 +5,7 @@ import {
   type CreateMetadataEvent,
   type MetadataEvent,
 } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/types/metadata-event';
+import { flatEntityToScalarFlatEntity } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/flat-entity-to-scalar-flat-entity.util';
 
 export const deriveMetadataEventsFromCreateAction = (
   flatAction: AllFlatWorkspaceMigrationAction<'create'>,
@@ -28,7 +29,10 @@ export const deriveMetadataEventsFromCreateAction = (
         metadataName: 'objectMetadata',
         recordId: flatAction.flatEntity.id,
         properties: {
-          after: flatAction.flatEntity,
+          after: flatEntityToScalarFlatEntity({
+            flatEntity: flatAction.flatEntity,
+            metadataName: 'objectMetadata',
+          }),
         },
       };
 
@@ -38,7 +42,10 @@ export const deriveMetadataEventsFromCreateAction = (
           recordId: flatFieldMetadata.id,
           metadataName: 'fieldMetadata',
           properties: {
-            after: flatFieldMetadata,
+            after: flatEntityToScalarFlatEntity({
+              flatEntity: flatFieldMetadata,
+              metadataName: 'fieldMetadata',
+            }),
           },
         }),
       );
@@ -72,7 +79,10 @@ export const deriveMetadataEventsFromCreateAction = (
           recordId: flatAction.flatEntity.id,
           metadataName: flatAction.metadataName,
           properties: {
-            after: flatAction.flatEntity,
+            after: flatEntityToScalarFlatEntity({
+              flatEntity: flatAction.flatEntity,
+              metadataName: flatAction.metadataName,
+            }),
           },
         },
       ];

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/derive-metadata-events-from-delete-action.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/derive-metadata-events-from-delete-action.util.ts
@@ -6,6 +6,7 @@ import { findFlatEntityByIdInFlatEntityMapsOrThrow } from 'src/engine/metadata-m
 import { getMetadataFlatEntityMapsKey } from 'src/engine/metadata-modules/flat-entity/utils/get-metadata-flat-entity-maps-key.util';
 import { type AllFlatWorkspaceMigrationAction } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-builder/types/workspace-migration-action-common';
 import { type MetadataEvent } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/types/metadata-event';
+import { flatEntityToScalarFlatEntity } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/flat-entity-to-scalar-flat-entity.util';
 
 export type DeriveMetadataEventsFromDeleteActionArgs = {
   flatAction: AllFlatWorkspaceMigrationAction<'delete'>;
@@ -56,7 +57,10 @@ export const deriveMetadataEventsFromDeleteAction = ({
           metadataName: flatAction.metadataName,
           recordId: flatAction.entityId,
           properties: {
-            before: flatEntityToDelete,
+            before: flatEntityToScalarFlatEntity({
+              flatEntity: flatEntityToDelete,
+              metadataName: flatAction.metadataName,
+            }),
           },
         },
       ];

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/derive-metadata-events-from-update-action.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/derive-metadata-events-from-update-action.util.ts
@@ -14,6 +14,7 @@ import {
   type UpdateMetadataEvent,
   type UpdateMetadataEventDiff,
 } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/types/metadata-event';
+import { flatEntityToScalarFlatEntity } from 'src/engine/workspace-manager/workspace-migration/workspace-migration-runner/utils/flat-entity-to-scalar-flat-entity.util';
 
 export type DeriveMetadataEventsFromUpdateActionArgs = {
   flatAction: AllFlatWorkspaceMigrationAction<'update'>;
@@ -48,8 +49,11 @@ const buildUpdateMetadataEvent = <TMetadataName extends AllMetadataName>({
     properties: {
       updatedFields,
       diff,
-      before,
-      after,
+      before: flatEntityToScalarFlatEntity({
+        flatEntity: before,
+        metadataName,
+      }),
+      after: flatEntityToScalarFlatEntity({ flatEntity: after, metadataName }),
     },
   };
 };
@@ -71,7 +75,10 @@ export const deriveMetadataEventsFromUpdateAction = ({
         metadataName: 'index',
         recordId: fromFlatEntity.id,
         properties: {
-          before: fromFlatEntity,
+          before: flatEntityToScalarFlatEntity({
+            flatEntity: fromFlatEntity,
+            metadataName: 'index',
+          }),
         },
         type: 'deleted',
       };
@@ -80,7 +87,10 @@ export const deriveMetadataEventsFromUpdateAction = ({
         metadataName: 'index',
         recordId: toFlatEntity.id,
         properties: {
-          after: toFlatEntity,
+          after: flatEntityToScalarFlatEntity({
+            flatEntity: toFlatEntity,
+            metadataName: 'index',
+          }),
         },
         type: 'created',
       };


### PR DESCRIPTION
# Introduction
Avoid sending flat entity that contains server specific properties such as foreignKey aggregators and universal properties by transpiling from flat entity to scalar flat entity

A scalar flat entity is the exact match with the entities columns

Following https://github.com/twentyhq/twenty/pull/17622