### PR TITLE
docs: add MCP capability guide and wire extend navigation

### DIFF
--- a/packages/twenty-docs/developers/extend/capabilities/apis.mdx
+++ b/packages/twenty-docs/developers/extend/capabilities/apis.mdx
@@ -19,6 +19,10 @@ Twenty generates APIs specifically for your data model:
 Your personalized API documentation is available under **Settings → API & Webhooks** after creating an API key. Since Twenty generates APIs that match your custom data model, the documentation is unique to your workspace.
 </Note>
 
+<Tip>
+If you're connecting an AI client (Claude, Cursor, VS Code), use the [MCP guide](/developers/extend/capabilities/mcp) for a faster setup.
+</Tip>
+
 ## The Two API Types
 
 ### Core API
@@ -138,4 +142,3 @@ API requests are throttled to ensure platform stability:
 <Tip>
 Use batch operations to maximize throughput — process up to 60 records in a single API call instead of making individual requests.
 </Tip>
-

--- a/packages/twenty-docs/developers/extend/capabilities/mcp.mdx
+++ b/packages/twenty-docs/developers/extend/capabilities/mcp.mdx
@@ -102,7 +102,7 @@ Twenty MCP uses `streamable-http` transport. Use one server entry per schema.
 You can copy ready-made MCP JSON from **Settings → AI → MCP Server** in Twenty.
 </Tip>
 
-## Tool Coverage
+## Supported MCP Methods
 
 Current MCP behavior includes:
 
@@ -110,6 +110,8 @@ Current MCP behavior includes:
 - `ping`
 - `tools/list`
 - `tools/call`
+- `prompts/list`
+- `resources/list`
 
 Prompts and resources are currently listed as empty arrays.
 

--- a/packages/twenty-docs/developers/extend/capabilities/mcp.mdx
+++ b/packages/twenty-docs/developers/extend/capabilities/mcp.mdx
@@ -1,0 +1,136 @@
+---
+title: MCP (Model Context Protocol)
+description: Connect AI clients like Claude and Cursor to your Twenty workspace using MCP.
+---
+
+MCP lets AI clients connect directly to your Twenty workspace as a tool server. You can use it to let agents read and update CRM data through your existing Twenty permissions model.
+
+## What Twenty MCP Provides
+
+Twenty exposes two MCP endpoints:
+
+- **Core schema** (`/mcp`): Workspace data access tools
+- **Metadata schema** (`/mcp/metadata`): Data model and metadata tools
+
+Both endpoints use your Twenty API key for authentication.
+
+## Prerequisites
+
+- A Twenty workspace (cloud or self-hosted)
+- An API key from **Settings → APIs & Webhooks**
+- AI enabled for your workspace
+
+<Note>
+API key role permissions still apply. MCP only exposes tools your key is allowed to use.
+</Note>
+
+## Endpoints
+
+| Environment | Core MCP | Metadata MCP |
+|-------------|----------|--------------|
+| **Cloud** | `https://api.twenty.com/mcp` | `https://api.twenty.com/mcp/metadata` |
+| **Self-Hosted** | `https://{your-domain}/mcp` | `https://{your-domain}/mcp/metadata` |
+
+## Authentication
+
+Send your API key as a bearer token:
+
+```text
+Authorization: Bearer YOUR_API_KEY
+```
+
+## Client Configuration
+
+Twenty MCP uses `streamable-http` transport. Use one server entry per schema.
+
+### Claude Desktop
+
+```json
+{
+  "mcpServers": {
+    "twenty": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    },
+    "twenty-metadata": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp/metadata",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+### Cursor
+
+```json
+{
+  "mcpServers": {
+    "twenty": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+### VS Code MCP
+
+```json
+{
+  "mcpServers": {
+    "twenty": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+<Tip>
+You can copy ready-made MCP JSON from **Settings → AI → MCP Server** in Twenty.
+</Tip>
+
+## Tool Coverage
+
+Current MCP behavior includes:
+
+- `initialize`
+- `ping`
+- `tools/list`
+- `tools/call`
+
+Prompts and resources are currently listed as empty arrays.
+
+## Security Best Practices
+
+- Create dedicated API keys for MCP clients
+- Assign the minimum role permissions needed
+- Rotate keys regularly
+- Use HTTPS in production (especially for self-hosting)
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---------|--------------|-----|
+| `401` or `403` | Missing/invalid API key, role restrictions, or AI disabled | Verify `Authorization` header, role assignment, and AI settings |
+| No tools listed | Key does not have permissions for available tools | Assign a role with required tool permissions |
+| Validation error | Invalid JSON-RPC payload | Ensure client sends valid MCP JSON-RPC requests |
+| Connection issues on self-host | URL/TLS/reverse proxy configuration | Confirm public HTTPS URL and route forwarding to `/mcp` |
+
+## Related
+
+- [APIs](/developers/extend/capabilities/apis)
+- [Webhooks](/developers/extend/capabilities/webhooks)
+- [Apps](/developers/extend/capabilities/apps)

--- a/packages/twenty-docs/developers/extend/extend.mdx
+++ b/packages/twenty-docs/developers/extend/extend.mdx
@@ -13,6 +13,7 @@ Twenty is designed to be extensible. Use our APIs, webhooks, and app framework t
 ## What You Can Do
 
 - **APIs**: Query and modify your CRM data programmatically using REST or GraphQL
+- **MCP**: Connect AI clients like Claude and Cursor to your workspace tools
 - **Webhooks**: Receive real-time notifications when events occur in Twenty
 - **Apps**: Build custom applications that extend Twenty's capabilities - Coming soon!
 
@@ -22,6 +23,9 @@ Twenty is designed to be extensible. Use our APIs, webhooks, and app framework t
   <Card title="APIs" icon="code" href="/developers/extend/capabilities/apis">
     Connect to Twenty programmatically
   </Card>
+  <Card title="MCP" icon="code" href="/developers/extend/capabilities/mcp">
+    Connect AI clients to your workspace data
+  </Card>
   <Card title="Webhooks" icon="bell" href="/developers/extend/capabilities/webhooks">
     Get notified of events in real-time
   </Card>
@@ -29,5 +33,3 @@ Twenty is designed to be extensible. Use our APIs, webhooks, and app framework t
     Build customizations as code (Alpha)
   </Card>
 </CardGroup>
-
-

--- a/packages/twenty-docs/docs.json
+++ b/packages/twenty-docs/docs.json
@@ -363,6 +363,7 @@
                     "group": "Capabilities",
                     "pages": [
                       "developers/extend/capabilities/apis",
+                      "developers/extend/capabilities/mcp",
                       "developers/extend/capabilities/webhooks",
                       "developers/extend/capabilities/apps"
                     ]
@@ -808,6 +809,7 @@
                     "group": "Capacités",
                     "pages": [
                       "l/fr/developers/extend/capabilities/apis",
+                      "l/fr/developers/extend/capabilities/mcp",
                       "l/fr/developers/extend/capabilities/webhooks",
                       "l/fr/developers/extend/capabilities/apps"
                     ]
@@ -1253,6 +1255,7 @@
                     "group": "القدرات",
                     "pages": [
                       "l/ar/developers/extend/capabilities/apis",
+                      "l/ar/developers/extend/capabilities/mcp",
                       "l/ar/developers/extend/capabilities/webhooks",
                       "l/ar/developers/extend/capabilities/apps"
                     ]
@@ -1698,6 +1701,7 @@
                     "group": "Možnosti",
                     "pages": [
                       "l/cs/developers/extend/capabilities/apis",
+                      "l/cs/developers/extend/capabilities/mcp",
                       "l/cs/developers/extend/capabilities/webhooks",
                       "l/cs/developers/extend/capabilities/apps"
                     ]
@@ -2143,6 +2147,7 @@
                     "group": "Funktionen",
                     "pages": [
                       "l/de/developers/extend/capabilities/apis",
+                      "l/de/developers/extend/capabilities/mcp",
                       "l/de/developers/extend/capabilities/webhooks",
                       "l/de/developers/extend/capabilities/apps"
                     ]
@@ -2588,6 +2593,7 @@
                     "group": "Capacidades",
                     "pages": [
                       "l/es/developers/extend/capabilities/apis",
+                      "l/es/developers/extend/capabilities/mcp",
                       "l/es/developers/extend/capabilities/webhooks",
                       "l/es/developers/extend/capabilities/apps"
                     ]
@@ -3033,6 +3039,7 @@
                     "group": "Funzionalità",
                     "pages": [
                       "l/it/developers/extend/capabilities/apis",
+                      "l/it/developers/extend/capabilities/mcp",
                       "l/it/developers/extend/capabilities/webhooks",
                       "l/it/developers/extend/capabilities/apps"
                     ]
@@ -3478,6 +3485,7 @@
                     "group": "機能",
                     "pages": [
                       "l/ja/developers/extend/capabilities/apis",
+                      "l/ja/developers/extend/capabilities/mcp",
                       "l/ja/developers/extend/capabilities/webhooks",
                       "l/ja/developers/extend/capabilities/apps"
                     ]
@@ -3923,6 +3931,7 @@
                     "group": "기능",
                     "pages": [
                       "l/ko/developers/extend/capabilities/apis",
+                      "l/ko/developers/extend/capabilities/mcp",
                       "l/ko/developers/extend/capabilities/webhooks",
                       "l/ko/developers/extend/capabilities/apps"
                     ]
@@ -4368,6 +4377,7 @@
                     "group": "Capabilities",
                     "pages": [
                       "l/pt/developers/extend/capabilities/apis",
+                      "l/pt/developers/extend/capabilities/mcp",
                       "l/pt/developers/extend/capabilities/webhooks",
                       "l/pt/developers/extend/capabilities/apps"
                     ]
@@ -4813,6 +4823,7 @@
                     "group": "Capabilities",
                     "pages": [
                       "l/ro/developers/extend/capabilities/apis",
+                      "l/ro/developers/extend/capabilities/mcp",
                       "l/ro/developers/extend/capabilities/webhooks",
                       "l/ro/developers/extend/capabilities/apps"
                     ]
@@ -5258,6 +5269,7 @@
                     "group": "Возможности",
                     "pages": [
                       "l/ru/developers/extend/capabilities/apis",
+                      "l/ru/developers/extend/capabilities/mcp",
                       "l/ru/developers/extend/capabilities/webhooks",
                       "l/ru/developers/extend/capabilities/apps"
                     ]
@@ -5703,6 +5715,7 @@
                     "group": "Yetkinlikler",
                     "pages": [
                       "l/tr/developers/extend/capabilities/apis",
+                      "l/tr/developers/extend/capabilities/mcp",
                       "l/tr/developers/extend/capabilities/webhooks",
                       "l/tr/developers/extend/capabilities/apps"
                     ]
@@ -6148,6 +6161,7 @@
                     "group": "功能",
                     "pages": [
                       "l/zh/developers/extend/capabilities/apis",
+                      "l/zh/developers/extend/capabilities/mcp",
                       "l/zh/developers/extend/capabilities/webhooks",
                       "l/zh/developers/extend/capabilities/apps"
                     ]

--- a/packages/twenty-docs/l/ar/developers/extend/capabilities/mcp.mdx
+++ b/packages/twenty-docs/l/ar/developers/extend/capabilities/mcp.mdx
@@ -102,7 +102,7 @@ Twenty MCP uses `streamable-http` transport. Use one server entry per schema.
 You can copy ready-made MCP JSON from **Settings → AI → MCP Server** in Twenty.
 </Tip>
 
-## Tool Coverage
+## Supported MCP Methods
 
 Current MCP behavior includes:
 
@@ -110,6 +110,8 @@ Current MCP behavior includes:
 - `ping`
 - `tools/list`
 - `tools/call`
+- `prompts/list`
+- `resources/list`
 
 Prompts and resources are currently listed as empty arrays.
 
@@ -131,6 +133,6 @@ Prompts and resources are currently listed as empty arrays.
 
 ## Related
 
-- [APIs](/developers/extend/capabilities/apis)
-- [Webhooks](/developers/extend/capabilities/webhooks)
-- [Apps](/developers/extend/capabilities/apps)
+- [APIs](/l/ar/developers/extend/capabilities/apis)
+- [Webhooks](/l/ar/developers/extend/capabilities/webhooks)
+- [Apps](/l/ar/developers/extend/capabilities/apps)

--- a/packages/twenty-docs/l/ar/developers/extend/capabilities/mcp.mdx
+++ b/packages/twenty-docs/l/ar/developers/extend/capabilities/mcp.mdx
@@ -1,0 +1,136 @@
+---
+title: MCP (Model Context Protocol)
+description: Connect AI clients like Claude and Cursor to your Twenty workspace using MCP.
+---
+
+MCP lets AI clients connect directly to your Twenty workspace as a tool server. You can use it to let agents read and update CRM data through your existing Twenty permissions model.
+
+## What Twenty MCP Provides
+
+Twenty exposes two MCP endpoints:
+
+- **Core schema** (`/mcp`): Workspace data access tools
+- **Metadata schema** (`/mcp/metadata`): Data model and metadata tools
+
+Both endpoints use your Twenty API key for authentication.
+
+## Prerequisites
+
+- A Twenty workspace (cloud or self-hosted)
+- An API key from **Settings → APIs & Webhooks**
+- AI enabled for your workspace
+
+<Note>
+API key role permissions still apply. MCP only exposes tools your key is allowed to use.
+</Note>
+
+## Endpoints
+
+| Environment | Core MCP | Metadata MCP |
+|-------------|----------|--------------|
+| **Cloud** | `https://api.twenty.com/mcp` | `https://api.twenty.com/mcp/metadata` |
+| **Self-Hosted** | `https://{your-domain}/mcp` | `https://{your-domain}/mcp/metadata` |
+
+## Authentication
+
+Send your API key as a bearer token:
+
+```text
+Authorization: Bearer YOUR_API_KEY
+```
+
+## Client Configuration
+
+Twenty MCP uses `streamable-http` transport. Use one server entry per schema.
+
+### Claude Desktop
+
+```json
+{
+  "mcpServers": {
+    "twenty": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    },
+    "twenty-metadata": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp/metadata",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+### Cursor
+
+```json
+{
+  "mcpServers": {
+    "twenty": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+### VS Code MCP
+
+```json
+{
+  "mcpServers": {
+    "twenty": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+<Tip>
+You can copy ready-made MCP JSON from **Settings → AI → MCP Server** in Twenty.
+</Tip>
+
+## Tool Coverage
+
+Current MCP behavior includes:
+
+- `initialize`
+- `ping`
+- `tools/list`
+- `tools/call`
+
+Prompts and resources are currently listed as empty arrays.
+
+## Security Best Practices
+
+- Create dedicated API keys for MCP clients
+- Assign the minimum role permissions needed
+- Rotate keys regularly
+- Use HTTPS in production (especially for self-hosting)
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---------|--------------|-----|
+| `401` or `403` | Missing/invalid API key, role restrictions, or AI disabled | Verify `Authorization` header, role assignment, and AI settings |
+| No tools listed | Key does not have permissions for available tools | Assign a role with required tool permissions |
+| Validation error | Invalid JSON-RPC payload | Ensure client sends valid MCP JSON-RPC requests |
+| Connection issues on self-host | URL/TLS/reverse proxy configuration | Confirm public HTTPS URL and route forwarding to `/mcp` |
+
+## Related
+
+- [APIs](/developers/extend/capabilities/apis)
+- [Webhooks](/developers/extend/capabilities/webhooks)
+- [Apps](/developers/extend/capabilities/apps)

--- a/packages/twenty-docs/l/cs/developers/extend/capabilities/mcp.mdx
+++ b/packages/twenty-docs/l/cs/developers/extend/capabilities/mcp.mdx
@@ -1,0 +1,136 @@
+---
+title: MCP (Model Context Protocol)
+description: Connect AI clients like Claude and Cursor to your Twenty workspace using MCP.
+---
+
+MCP lets AI clients connect directly to your Twenty workspace as a tool server. You can use it to let agents read and update CRM data through your existing Twenty permissions model.
+
+## What Twenty MCP Provides
+
+Twenty exposes two MCP endpoints:
+
+- **Core schema** (`/mcp`): Workspace data access tools
+- **Metadata schema** (`/mcp/metadata`): Data model and metadata tools
+
+Both endpoints use your Twenty API key for authentication.
+
+## Prerequisites
+
+- A Twenty workspace (cloud or self-hosted)
+- An API key from **Settings → APIs & Webhooks**
+- AI enabled for your workspace
+
+<Note>
+API key role permissions still apply. MCP only exposes tools your key is allowed to use.
+</Note>
+
+## Endpoints
+
+| Environment | Core MCP | Metadata MCP |
+|-------------|----------|--------------|
+| **Cloud** | `https://api.twenty.com/mcp` | `https://api.twenty.com/mcp/metadata` |
+| **Self-Hosted** | `https://{your-domain}/mcp` | `https://{your-domain}/mcp/metadata` |
+
+## Authentication
+
+Send your API key as a bearer token:
+
+```text
+Authorization: Bearer YOUR_API_KEY
+```
+
+## Client Configuration
+
+Twenty MCP uses `streamable-http` transport. Use one server entry per schema.
+
+### Claude Desktop
+
+```json
+{
+  "mcpServers": {
+    "twenty": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    },
+    "twenty-metadata": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp/metadata",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+### Cursor
+
+```json
+{
+  "mcpServers": {
+    "twenty": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+### VS Code MCP
+
+```json
+{
+  "mcpServers": {
+    "twenty": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+<Tip>
+You can copy ready-made MCP JSON from **Settings → AI → MCP Server** in Twenty.
+</Tip>
+
+## Tool Coverage
+
+Current MCP behavior includes:
+
+- `initialize`
+- `ping`
+- `tools/list`
+- `tools/call`
+
+Prompts and resources are currently listed as empty arrays.
+
+## Security Best Practices
+
+- Create dedicated API keys for MCP clients
+- Assign the minimum role permissions needed
+- Rotate keys regularly
+- Use HTTPS in production (especially for self-hosting)
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---------|--------------|-----|
+| `401` or `403` | Missing/invalid API key, role restrictions, or AI disabled | Verify `Authorization` header, role assignment, and AI settings |
+| No tools listed | Key does not have permissions for available tools | Assign a role with required tool permissions |
+| Validation error | Invalid JSON-RPC payload | Ensure client sends valid MCP JSON-RPC requests |
+| Connection issues on self-host | URL/TLS/reverse proxy configuration | Confirm public HTTPS URL and route forwarding to `/mcp` |
+
+## Related
+
+- [APIs](/developers/extend/capabilities/apis)
+- [Webhooks](/developers/extend/capabilities/webhooks)
+- [Apps](/developers/extend/capabilities/apps)

--- a/packages/twenty-docs/l/cs/developers/extend/capabilities/mcp.mdx
+++ b/packages/twenty-docs/l/cs/developers/extend/capabilities/mcp.mdx
@@ -102,7 +102,7 @@ Twenty MCP uses `streamable-http` transport. Use one server entry per schema.
 You can copy ready-made MCP JSON from **Settings → AI → MCP Server** in Twenty.
 </Tip>
 
-## Tool Coverage
+## Supported MCP Methods
 
 Current MCP behavior includes:
 
@@ -110,6 +110,8 @@ Current MCP behavior includes:
 - `ping`
 - `tools/list`
 - `tools/call`
+- `prompts/list`
+- `resources/list`
 
 Prompts and resources are currently listed as empty arrays.
 
@@ -131,6 +133,6 @@ Prompts and resources are currently listed as empty arrays.
 
 ## Related
 
-- [APIs](/developers/extend/capabilities/apis)
-- [Webhooks](/developers/extend/capabilities/webhooks)
-- [Apps](/developers/extend/capabilities/apps)
+- [APIs](/l/cs/developers/extend/capabilities/apis)
+- [Webhooks](/l/cs/developers/extend/capabilities/webhooks)
+- [Apps](/l/cs/developers/extend/capabilities/apps)

--- a/packages/twenty-docs/l/de/developers/extend/capabilities/mcp.mdx
+++ b/packages/twenty-docs/l/de/developers/extend/capabilities/mcp.mdx
@@ -1,0 +1,136 @@
+---
+title: MCP (Model Context Protocol)
+description: Connect AI clients like Claude and Cursor to your Twenty workspace using MCP.
+---
+
+MCP lets AI clients connect directly to your Twenty workspace as a tool server. You can use it to let agents read and update CRM data through your existing Twenty permissions model.
+
+## What Twenty MCP Provides
+
+Twenty exposes two MCP endpoints:
+
+- **Core schema** (`/mcp`): Workspace data access tools
+- **Metadata schema** (`/mcp/metadata`): Data model and metadata tools
+
+Both endpoints use your Twenty API key for authentication.
+
+## Prerequisites
+
+- A Twenty workspace (cloud or self-hosted)
+- An API key from **Settings → APIs & Webhooks**
+- AI enabled for your workspace
+
+<Note>
+API key role permissions still apply. MCP only exposes tools your key is allowed to use.
+</Note>
+
+## Endpoints
+
+| Environment | Core MCP | Metadata MCP |
+|-------------|----------|--------------|
+| **Cloud** | `https://api.twenty.com/mcp` | `https://api.twenty.com/mcp/metadata` |
+| **Self-Hosted** | `https://{your-domain}/mcp` | `https://{your-domain}/mcp/metadata` |
+
+## Authentication
+
+Send your API key as a bearer token:
+
+```text
+Authorization: Bearer YOUR_API_KEY
+```
+
+## Client Configuration
+
+Twenty MCP uses `streamable-http` transport. Use one server entry per schema.
+
+### Claude Desktop
+
+```json
+{
+  "mcpServers": {
+    "twenty": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    },
+    "twenty-metadata": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp/metadata",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+### Cursor
+
+```json
+{
+  "mcpServers": {
+    "twenty": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+### VS Code MCP
+
+```json
+{
+  "mcpServers": {
+    "twenty": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+<Tip>
+You can copy ready-made MCP JSON from **Settings → AI → MCP Server** in Twenty.
+</Tip>
+
+## Tool Coverage
+
+Current MCP behavior includes:
+
+- `initialize`
+- `ping`
+- `tools/list`
+- `tools/call`
+
+Prompts and resources are currently listed as empty arrays.
+
+## Security Best Practices
+
+- Create dedicated API keys for MCP clients
+- Assign the minimum role permissions needed
+- Rotate keys regularly
+- Use HTTPS in production (especially for self-hosting)
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---------|--------------|-----|
+| `401` or `403` | Missing/invalid API key, role restrictions, or AI disabled | Verify `Authorization` header, role assignment, and AI settings |
+| No tools listed | Key does not have permissions for available tools | Assign a role with required tool permissions |
+| Validation error | Invalid JSON-RPC payload | Ensure client sends valid MCP JSON-RPC requests |
+| Connection issues on self-host | URL/TLS/reverse proxy configuration | Confirm public HTTPS URL and route forwarding to `/mcp` |
+
+## Related
+
+- [APIs](/developers/extend/capabilities/apis)
+- [Webhooks](/developers/extend/capabilities/webhooks)
+- [Apps](/developers/extend/capabilities/apps)

--- a/packages/twenty-docs/l/de/developers/extend/capabilities/mcp.mdx
+++ b/packages/twenty-docs/l/de/developers/extend/capabilities/mcp.mdx
@@ -102,7 +102,7 @@ Twenty MCP uses `streamable-http` transport. Use one server entry per schema.
 You can copy ready-made MCP JSON from **Settings → AI → MCP Server** in Twenty.
 </Tip>
 
-## Tool Coverage
+## Supported MCP Methods
 
 Current MCP behavior includes:
 
@@ -110,6 +110,8 @@ Current MCP behavior includes:
 - `ping`
 - `tools/list`
 - `tools/call`
+- `prompts/list`
+- `resources/list`
 
 Prompts and resources are currently listed as empty arrays.
 
@@ -131,6 +133,6 @@ Prompts and resources are currently listed as empty arrays.
 
 ## Related
 
-- [APIs](/developers/extend/capabilities/apis)
-- [Webhooks](/developers/extend/capabilities/webhooks)
-- [Apps](/developers/extend/capabilities/apps)
+- [APIs](/l/de/developers/extend/capabilities/apis)
+- [Webhooks](/l/de/developers/extend/capabilities/webhooks)
+- [Apps](/l/de/developers/extend/capabilities/apps)

--- a/packages/twenty-docs/l/es/developers/extend/capabilities/mcp.mdx
+++ b/packages/twenty-docs/l/es/developers/extend/capabilities/mcp.mdx
@@ -102,7 +102,7 @@ Twenty MCP uses `streamable-http` transport. Use one server entry per schema.
 You can copy ready-made MCP JSON from **Settings → AI → MCP Server** in Twenty.
 </Tip>
 
-## Tool Coverage
+## Supported MCP Methods
 
 Current MCP behavior includes:
 
@@ -110,6 +110,8 @@ Current MCP behavior includes:
 - `ping`
 - `tools/list`
 - `tools/call`
+- `prompts/list`
+- `resources/list`
 
 Prompts and resources are currently listed as empty arrays.
 
@@ -131,6 +133,6 @@ Prompts and resources are currently listed as empty arrays.
 
 ## Related
 
-- [APIs](/developers/extend/capabilities/apis)
-- [Webhooks](/developers/extend/capabilities/webhooks)
-- [Apps](/developers/extend/capabilities/apps)
+- [APIs](/l/es/developers/extend/capabilities/apis)
+- [Webhooks](/l/es/developers/extend/capabilities/webhooks)
+- [Apps](/l/es/developers/extend/capabilities/apps)

--- a/packages/twenty-docs/l/es/developers/extend/capabilities/mcp.mdx
+++ b/packages/twenty-docs/l/es/developers/extend/capabilities/mcp.mdx
@@ -1,0 +1,136 @@
+---
+title: MCP (Model Context Protocol)
+description: Connect AI clients like Claude and Cursor to your Twenty workspace using MCP.
+---
+
+MCP lets AI clients connect directly to your Twenty workspace as a tool server. You can use it to let agents read and update CRM data through your existing Twenty permissions model.
+
+## What Twenty MCP Provides
+
+Twenty exposes two MCP endpoints:
+
+- **Core schema** (`/mcp`): Workspace data access tools
+- **Metadata schema** (`/mcp/metadata`): Data model and metadata tools
+
+Both endpoints use your Twenty API key for authentication.
+
+## Prerequisites
+
+- A Twenty workspace (cloud or self-hosted)
+- An API key from **Settings → APIs & Webhooks**
+- AI enabled for your workspace
+
+<Note>
+API key role permissions still apply. MCP only exposes tools your key is allowed to use.
+</Note>
+
+## Endpoints
+
+| Environment | Core MCP | Metadata MCP |
+|-------------|----------|--------------|
+| **Cloud** | `https://api.twenty.com/mcp` | `https://api.twenty.com/mcp/metadata` |
+| **Self-Hosted** | `https://{your-domain}/mcp` | `https://{your-domain}/mcp/metadata` |
+
+## Authentication
+
+Send your API key as a bearer token:
+
+```text
+Authorization: Bearer YOUR_API_KEY
+```
+
+## Client Configuration
+
+Twenty MCP uses `streamable-http` transport. Use one server entry per schema.
+
+### Claude Desktop
+
+```json
+{
+  "mcpServers": {
+    "twenty": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    },
+    "twenty-metadata": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp/metadata",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+### Cursor
+
+```json
+{
+  "mcpServers": {
+    "twenty": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+### VS Code MCP
+
+```json
+{
+  "mcpServers": {
+    "twenty": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+<Tip>
+You can copy ready-made MCP JSON from **Settings → AI → MCP Server** in Twenty.
+</Tip>
+
+## Tool Coverage
+
+Current MCP behavior includes:
+
+- `initialize`
+- `ping`
+- `tools/list`
+- `tools/call`
+
+Prompts and resources are currently listed as empty arrays.
+
+## Security Best Practices
+
+- Create dedicated API keys for MCP clients
+- Assign the minimum role permissions needed
+- Rotate keys regularly
+- Use HTTPS in production (especially for self-hosting)
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---------|--------------|-----|
+| `401` or `403` | Missing/invalid API key, role restrictions, or AI disabled | Verify `Authorization` header, role assignment, and AI settings |
+| No tools listed | Key does not have permissions for available tools | Assign a role with required tool permissions |
+| Validation error | Invalid JSON-RPC payload | Ensure client sends valid MCP JSON-RPC requests |
+| Connection issues on self-host | URL/TLS/reverse proxy configuration | Confirm public HTTPS URL and route forwarding to `/mcp` |
+
+## Related
+
+- [APIs](/developers/extend/capabilities/apis)
+- [Webhooks](/developers/extend/capabilities/webhooks)
+- [Apps](/developers/extend/capabilities/apps)

--- a/packages/twenty-docs/l/fr/developers/extend/capabilities/mcp.mdx
+++ b/packages/twenty-docs/l/fr/developers/extend/capabilities/mcp.mdx
@@ -102,7 +102,7 @@ Twenty MCP uses `streamable-http` transport. Use one server entry per schema.
 You can copy ready-made MCP JSON from **Settings → AI → MCP Server** in Twenty.
 </Tip>
 
-## Tool Coverage
+## Supported MCP Methods
 
 Current MCP behavior includes:
 
@@ -110,6 +110,8 @@ Current MCP behavior includes:
 - `ping`
 - `tools/list`
 - `tools/call`
+- `prompts/list`
+- `resources/list`
 
 Prompts and resources are currently listed as empty arrays.
 
@@ -131,6 +133,6 @@ Prompts and resources are currently listed as empty arrays.
 
 ## Related
 
-- [APIs](/developers/extend/capabilities/apis)
-- [Webhooks](/developers/extend/capabilities/webhooks)
-- [Apps](/developers/extend/capabilities/apps)
+- [APIs](/l/fr/developers/extend/capabilities/apis)
+- [Webhooks](/l/fr/developers/extend/capabilities/webhooks)
+- [Apps](/l/fr/developers/extend/capabilities/apps)

--- a/packages/twenty-docs/l/fr/developers/extend/capabilities/mcp.mdx
+++ b/packages/twenty-docs/l/fr/developers/extend/capabilities/mcp.mdx
@@ -1,0 +1,136 @@
+---
+title: MCP (Model Context Protocol)
+description: Connect AI clients like Claude and Cursor to your Twenty workspace using MCP.
+---
+
+MCP lets AI clients connect directly to your Twenty workspace as a tool server. You can use it to let agents read and update CRM data through your existing Twenty permissions model.
+
+## What Twenty MCP Provides
+
+Twenty exposes two MCP endpoints:
+
+- **Core schema** (`/mcp`): Workspace data access tools
+- **Metadata schema** (`/mcp/metadata`): Data model and metadata tools
+
+Both endpoints use your Twenty API key for authentication.
+
+## Prerequisites
+
+- A Twenty workspace (cloud or self-hosted)
+- An API key from **Settings → APIs & Webhooks**
+- AI enabled for your workspace
+
+<Note>
+API key role permissions still apply. MCP only exposes tools your key is allowed to use.
+</Note>
+
+## Endpoints
+
+| Environment | Core MCP | Metadata MCP |
+|-------------|----------|--------------|
+| **Cloud** | `https://api.twenty.com/mcp` | `https://api.twenty.com/mcp/metadata` |
+| **Self-Hosted** | `https://{your-domain}/mcp` | `https://{your-domain}/mcp/metadata` |
+
+## Authentication
+
+Send your API key as a bearer token:
+
+```text
+Authorization: Bearer YOUR_API_KEY
+```
+
+## Client Configuration
+
+Twenty MCP uses `streamable-http` transport. Use one server entry per schema.
+
+### Claude Desktop
+
+```json
+{
+  "mcpServers": {
+    "twenty": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    },
+    "twenty-metadata": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp/metadata",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+### Cursor
+
+```json
+{
+  "mcpServers": {
+    "twenty": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+### VS Code MCP
+
+```json
+{
+  "mcpServers": {
+    "twenty": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+<Tip>
+You can copy ready-made MCP JSON from **Settings → AI → MCP Server** in Twenty.
+</Tip>
+
+## Tool Coverage
+
+Current MCP behavior includes:
+
+- `initialize`
+- `ping`
+- `tools/list`
+- `tools/call`
+
+Prompts and resources are currently listed as empty arrays.
+
+## Security Best Practices
+
+- Create dedicated API keys for MCP clients
+- Assign the minimum role permissions needed
+- Rotate keys regularly
+- Use HTTPS in production (especially for self-hosting)
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---------|--------------|-----|
+| `401` or `403` | Missing/invalid API key, role restrictions, or AI disabled | Verify `Authorization` header, role assignment, and AI settings |
+| No tools listed | Key does not have permissions for available tools | Assign a role with required tool permissions |
+| Validation error | Invalid JSON-RPC payload | Ensure client sends valid MCP JSON-RPC requests |
+| Connection issues on self-host | URL/TLS/reverse proxy configuration | Confirm public HTTPS URL and route forwarding to `/mcp` |
+
+## Related
+
+- [APIs](/developers/extend/capabilities/apis)
+- [Webhooks](/developers/extend/capabilities/webhooks)
+- [Apps](/developers/extend/capabilities/apps)

--- a/packages/twenty-docs/l/it/developers/extend/capabilities/mcp.mdx
+++ b/packages/twenty-docs/l/it/developers/extend/capabilities/mcp.mdx
@@ -102,7 +102,7 @@ Twenty MCP uses `streamable-http` transport. Use one server entry per schema.
 You can copy ready-made MCP JSON from **Settings → AI → MCP Server** in Twenty.
 </Tip>
 
-## Tool Coverage
+## Supported MCP Methods
 
 Current MCP behavior includes:
 
@@ -110,6 +110,8 @@ Current MCP behavior includes:
 - `ping`
 - `tools/list`
 - `tools/call`
+- `prompts/list`
+- `resources/list`
 
 Prompts and resources are currently listed as empty arrays.
 
@@ -131,6 +133,6 @@ Prompts and resources are currently listed as empty arrays.
 
 ## Related
 
-- [APIs](/developers/extend/capabilities/apis)
-- [Webhooks](/developers/extend/capabilities/webhooks)
-- [Apps](/developers/extend/capabilities/apps)
+- [APIs](/l/it/developers/extend/capabilities/apis)
+- [Webhooks](/l/it/developers/extend/capabilities/webhooks)
+- [Apps](/l/it/developers/extend/capabilities/apps)

--- a/packages/twenty-docs/l/it/developers/extend/capabilities/mcp.mdx
+++ b/packages/twenty-docs/l/it/developers/extend/capabilities/mcp.mdx
@@ -1,0 +1,136 @@
+---
+title: MCP (Model Context Protocol)
+description: Connect AI clients like Claude and Cursor to your Twenty workspace using MCP.
+---
+
+MCP lets AI clients connect directly to your Twenty workspace as a tool server. You can use it to let agents read and update CRM data through your existing Twenty permissions model.
+
+## What Twenty MCP Provides
+
+Twenty exposes two MCP endpoints:
+
+- **Core schema** (`/mcp`): Workspace data access tools
+- **Metadata schema** (`/mcp/metadata`): Data model and metadata tools
+
+Both endpoints use your Twenty API key for authentication.
+
+## Prerequisites
+
+- A Twenty workspace (cloud or self-hosted)
+- An API key from **Settings → APIs & Webhooks**
+- AI enabled for your workspace
+
+<Note>
+API key role permissions still apply. MCP only exposes tools your key is allowed to use.
+</Note>
+
+## Endpoints
+
+| Environment | Core MCP | Metadata MCP |
+|-------------|----------|--------------|
+| **Cloud** | `https://api.twenty.com/mcp` | `https://api.twenty.com/mcp/metadata` |
+| **Self-Hosted** | `https://{your-domain}/mcp` | `https://{your-domain}/mcp/metadata` |
+
+## Authentication
+
+Send your API key as a bearer token:
+
+```text
+Authorization: Bearer YOUR_API_KEY
+```
+
+## Client Configuration
+
+Twenty MCP uses `streamable-http` transport. Use one server entry per schema.
+
+### Claude Desktop
+
+```json
+{
+  "mcpServers": {
+    "twenty": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    },
+    "twenty-metadata": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp/metadata",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+### Cursor
+
+```json
+{
+  "mcpServers": {
+    "twenty": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+### VS Code MCP
+
+```json
+{
+  "mcpServers": {
+    "twenty": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+<Tip>
+You can copy ready-made MCP JSON from **Settings → AI → MCP Server** in Twenty.
+</Tip>
+
+## Tool Coverage
+
+Current MCP behavior includes:
+
+- `initialize`
+- `ping`
+- `tools/list`
+- `tools/call`
+
+Prompts and resources are currently listed as empty arrays.
+
+## Security Best Practices
+
+- Create dedicated API keys for MCP clients
+- Assign the minimum role permissions needed
+- Rotate keys regularly
+- Use HTTPS in production (especially for self-hosting)
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---------|--------------|-----|
+| `401` or `403` | Missing/invalid API key, role restrictions, or AI disabled | Verify `Authorization` header, role assignment, and AI settings |
+| No tools listed | Key does not have permissions for available tools | Assign a role with required tool permissions |
+| Validation error | Invalid JSON-RPC payload | Ensure client sends valid MCP JSON-RPC requests |
+| Connection issues on self-host | URL/TLS/reverse proxy configuration | Confirm public HTTPS URL and route forwarding to `/mcp` |
+
+## Related
+
+- [APIs](/developers/extend/capabilities/apis)
+- [Webhooks](/developers/extend/capabilities/webhooks)
+- [Apps](/developers/extend/capabilities/apps)

--- a/packages/twenty-docs/l/ja/developers/extend/capabilities/mcp.mdx
+++ b/packages/twenty-docs/l/ja/developers/extend/capabilities/mcp.mdx
@@ -102,7 +102,7 @@ Twenty MCP uses `streamable-http` transport. Use one server entry per schema.
 You can copy ready-made MCP JSON from **Settings → AI → MCP Server** in Twenty.
 </Tip>
 
-## Tool Coverage
+## Supported MCP Methods
 
 Current MCP behavior includes:
 
@@ -110,6 +110,8 @@ Current MCP behavior includes:
 - `ping`
 - `tools/list`
 - `tools/call`
+- `prompts/list`
+- `resources/list`
 
 Prompts and resources are currently listed as empty arrays.
 
@@ -131,6 +133,6 @@ Prompts and resources are currently listed as empty arrays.
 
 ## Related
 
-- [APIs](/developers/extend/capabilities/apis)
-- [Webhooks](/developers/extend/capabilities/webhooks)
-- [Apps](/developers/extend/capabilities/apps)
+- [APIs](/l/ja/developers/extend/capabilities/apis)
+- [Webhooks](/l/ja/developers/extend/capabilities/webhooks)
+- [Apps](/l/ja/developers/extend/capabilities/apps)

--- a/packages/twenty-docs/l/ja/developers/extend/capabilities/mcp.mdx
+++ b/packages/twenty-docs/l/ja/developers/extend/capabilities/mcp.mdx
@@ -1,0 +1,136 @@
+---
+title: MCP (Model Context Protocol)
+description: Connect AI clients like Claude and Cursor to your Twenty workspace using MCP.
+---
+
+MCP lets AI clients connect directly to your Twenty workspace as a tool server. You can use it to let agents read and update CRM data through your existing Twenty permissions model.
+
+## What Twenty MCP Provides
+
+Twenty exposes two MCP endpoints:
+
+- **Core schema** (`/mcp`): Workspace data access tools
+- **Metadata schema** (`/mcp/metadata`): Data model and metadata tools
+
+Both endpoints use your Twenty API key for authentication.
+
+## Prerequisites
+
+- A Twenty workspace (cloud or self-hosted)
+- An API key from **Settings → APIs & Webhooks**
+- AI enabled for your workspace
+
+<Note>
+API key role permissions still apply. MCP only exposes tools your key is allowed to use.
+</Note>
+
+## Endpoints
+
+| Environment | Core MCP | Metadata MCP |
+|-------------|----------|--------------|
+| **Cloud** | `https://api.twenty.com/mcp` | `https://api.twenty.com/mcp/metadata` |
+| **Self-Hosted** | `https://{your-domain}/mcp` | `https://{your-domain}/mcp/metadata` |
+
+## Authentication
+
+Send your API key as a bearer token:
+
+```text
+Authorization: Bearer YOUR_API_KEY
+```
+
+## Client Configuration
+
+Twenty MCP uses `streamable-http` transport. Use one server entry per schema.
+
+### Claude Desktop
+
+```json
+{
+  "mcpServers": {
+    "twenty": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    },
+    "twenty-metadata": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp/metadata",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+### Cursor
+
+```json
+{
+  "mcpServers": {
+    "twenty": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+### VS Code MCP
+
+```json
+{
+  "mcpServers": {
+    "twenty": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+<Tip>
+You can copy ready-made MCP JSON from **Settings → AI → MCP Server** in Twenty.
+</Tip>
+
+## Tool Coverage
+
+Current MCP behavior includes:
+
+- `initialize`
+- `ping`
+- `tools/list`
+- `tools/call`
+
+Prompts and resources are currently listed as empty arrays.
+
+## Security Best Practices
+
+- Create dedicated API keys for MCP clients
+- Assign the minimum role permissions needed
+- Rotate keys regularly
+- Use HTTPS in production (especially for self-hosting)
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---------|--------------|-----|
+| `401` or `403` | Missing/invalid API key, role restrictions, or AI disabled | Verify `Authorization` header, role assignment, and AI settings |
+| No tools listed | Key does not have permissions for available tools | Assign a role with required tool permissions |
+| Validation error | Invalid JSON-RPC payload | Ensure client sends valid MCP JSON-RPC requests |
+| Connection issues on self-host | URL/TLS/reverse proxy configuration | Confirm public HTTPS URL and route forwarding to `/mcp` |
+
+## Related
+
+- [APIs](/developers/extend/capabilities/apis)
+- [Webhooks](/developers/extend/capabilities/webhooks)
+- [Apps](/developers/extend/capabilities/apps)

--- a/packages/twenty-docs/l/ko/developers/extend/capabilities/mcp.mdx
+++ b/packages/twenty-docs/l/ko/developers/extend/capabilities/mcp.mdx
@@ -102,7 +102,7 @@ Twenty MCP uses `streamable-http` transport. Use one server entry per schema.
 You can copy ready-made MCP JSON from **Settings → AI → MCP Server** in Twenty.
 </Tip>
 
-## Tool Coverage
+## Supported MCP Methods
 
 Current MCP behavior includes:
 
@@ -110,6 +110,8 @@ Current MCP behavior includes:
 - `ping`
 - `tools/list`
 - `tools/call`
+- `prompts/list`
+- `resources/list`
 
 Prompts and resources are currently listed as empty arrays.
 
@@ -131,6 +133,6 @@ Prompts and resources are currently listed as empty arrays.
 
 ## Related
 
-- [APIs](/developers/extend/capabilities/apis)
-- [Webhooks](/developers/extend/capabilities/webhooks)
-- [Apps](/developers/extend/capabilities/apps)
+- [APIs](/l/ko/developers/extend/capabilities/apis)
+- [Webhooks](/l/ko/developers/extend/capabilities/webhooks)
+- [Apps](/l/ko/developers/extend/capabilities/apps)

--- a/packages/twenty-docs/l/ko/developers/extend/capabilities/mcp.mdx
+++ b/packages/twenty-docs/l/ko/developers/extend/capabilities/mcp.mdx
@@ -1,0 +1,136 @@
+---
+title: MCP (Model Context Protocol)
+description: Connect AI clients like Claude and Cursor to your Twenty workspace using MCP.
+---
+
+MCP lets AI clients connect directly to your Twenty workspace as a tool server. You can use it to let agents read and update CRM data through your existing Twenty permissions model.
+
+## What Twenty MCP Provides
+
+Twenty exposes two MCP endpoints:
+
+- **Core schema** (`/mcp`): Workspace data access tools
+- **Metadata schema** (`/mcp/metadata`): Data model and metadata tools
+
+Both endpoints use your Twenty API key for authentication.
+
+## Prerequisites
+
+- A Twenty workspace (cloud or self-hosted)
+- An API key from **Settings → APIs & Webhooks**
+- AI enabled for your workspace
+
+<Note>
+API key role permissions still apply. MCP only exposes tools your key is allowed to use.
+</Note>
+
+## Endpoints
+
+| Environment | Core MCP | Metadata MCP |
+|-------------|----------|--------------|
+| **Cloud** | `https://api.twenty.com/mcp` | `https://api.twenty.com/mcp/metadata` |
+| **Self-Hosted** | `https://{your-domain}/mcp` | `https://{your-domain}/mcp/metadata` |
+
+## Authentication
+
+Send your API key as a bearer token:
+
+```text
+Authorization: Bearer YOUR_API_KEY
+```
+
+## Client Configuration
+
+Twenty MCP uses `streamable-http` transport. Use one server entry per schema.
+
+### Claude Desktop
+
+```json
+{
+  "mcpServers": {
+    "twenty": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    },
+    "twenty-metadata": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp/metadata",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+### Cursor
+
+```json
+{
+  "mcpServers": {
+    "twenty": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+### VS Code MCP
+
+```json
+{
+  "mcpServers": {
+    "twenty": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+<Tip>
+You can copy ready-made MCP JSON from **Settings → AI → MCP Server** in Twenty.
+</Tip>
+
+## Tool Coverage
+
+Current MCP behavior includes:
+
+- `initialize`
+- `ping`
+- `tools/list`
+- `tools/call`
+
+Prompts and resources are currently listed as empty arrays.
+
+## Security Best Practices
+
+- Create dedicated API keys for MCP clients
+- Assign the minimum role permissions needed
+- Rotate keys regularly
+- Use HTTPS in production (especially for self-hosting)
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---------|--------------|-----|
+| `401` or `403` | Missing/invalid API key, role restrictions, or AI disabled | Verify `Authorization` header, role assignment, and AI settings |
+| No tools listed | Key does not have permissions for available tools | Assign a role with required tool permissions |
+| Validation error | Invalid JSON-RPC payload | Ensure client sends valid MCP JSON-RPC requests |
+| Connection issues on self-host | URL/TLS/reverse proxy configuration | Confirm public HTTPS URL and route forwarding to `/mcp` |
+
+## Related
+
+- [APIs](/developers/extend/capabilities/apis)
+- [Webhooks](/developers/extend/capabilities/webhooks)
+- [Apps](/developers/extend/capabilities/apps)

--- a/packages/twenty-docs/l/pt/developers/extend/capabilities/mcp.mdx
+++ b/packages/twenty-docs/l/pt/developers/extend/capabilities/mcp.mdx
@@ -102,7 +102,7 @@ Twenty MCP uses `streamable-http` transport. Use one server entry per schema.
 You can copy ready-made MCP JSON from **Settings → AI → MCP Server** in Twenty.
 </Tip>
 
-## Tool Coverage
+## Supported MCP Methods
 
 Current MCP behavior includes:
 
@@ -110,6 +110,8 @@ Current MCP behavior includes:
 - `ping`
 - `tools/list`
 - `tools/call`
+- `prompts/list`
+- `resources/list`
 
 Prompts and resources are currently listed as empty arrays.
 
@@ -131,6 +133,6 @@ Prompts and resources are currently listed as empty arrays.
 
 ## Related
 
-- [APIs](/developers/extend/capabilities/apis)
-- [Webhooks](/developers/extend/capabilities/webhooks)
-- [Apps](/developers/extend/capabilities/apps)
+- [APIs](/l/pt/developers/extend/capabilities/apis)
+- [Webhooks](/l/pt/developers/extend/capabilities/webhooks)
+- [Apps](/l/pt/developers/extend/capabilities/apps)

--- a/packages/twenty-docs/l/pt/developers/extend/capabilities/mcp.mdx
+++ b/packages/twenty-docs/l/pt/developers/extend/capabilities/mcp.mdx
@@ -1,0 +1,136 @@
+---
+title: MCP (Model Context Protocol)
+description: Connect AI clients like Claude and Cursor to your Twenty workspace using MCP.
+---
+
+MCP lets AI clients connect directly to your Twenty workspace as a tool server. You can use it to let agents read and update CRM data through your existing Twenty permissions model.
+
+## What Twenty MCP Provides
+
+Twenty exposes two MCP endpoints:
+
+- **Core schema** (`/mcp`): Workspace data access tools
+- **Metadata schema** (`/mcp/metadata`): Data model and metadata tools
+
+Both endpoints use your Twenty API key for authentication.
+
+## Prerequisites
+
+- A Twenty workspace (cloud or self-hosted)
+- An API key from **Settings → APIs & Webhooks**
+- AI enabled for your workspace
+
+<Note>
+API key role permissions still apply. MCP only exposes tools your key is allowed to use.
+</Note>
+
+## Endpoints
+
+| Environment | Core MCP | Metadata MCP |
+|-------------|----------|--------------|
+| **Cloud** | `https://api.twenty.com/mcp` | `https://api.twenty.com/mcp/metadata` |
+| **Self-Hosted** | `https://{your-domain}/mcp` | `https://{your-domain}/mcp/metadata` |
+
+## Authentication
+
+Send your API key as a bearer token:
+
+```text
+Authorization: Bearer YOUR_API_KEY
+```
+
+## Client Configuration
+
+Twenty MCP uses `streamable-http` transport. Use one server entry per schema.
+
+### Claude Desktop
+
+```json
+{
+  "mcpServers": {
+    "twenty": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    },
+    "twenty-metadata": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp/metadata",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+### Cursor
+
+```json
+{
+  "mcpServers": {
+    "twenty": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+### VS Code MCP
+
+```json
+{
+  "mcpServers": {
+    "twenty": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+<Tip>
+You can copy ready-made MCP JSON from **Settings → AI → MCP Server** in Twenty.
+</Tip>
+
+## Tool Coverage
+
+Current MCP behavior includes:
+
+- `initialize`
+- `ping`
+- `tools/list`
+- `tools/call`
+
+Prompts and resources are currently listed as empty arrays.
+
+## Security Best Practices
+
+- Create dedicated API keys for MCP clients
+- Assign the minimum role permissions needed
+- Rotate keys regularly
+- Use HTTPS in production (especially for self-hosting)
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---------|--------------|-----|
+| `401` or `403` | Missing/invalid API key, role restrictions, or AI disabled | Verify `Authorization` header, role assignment, and AI settings |
+| No tools listed | Key does not have permissions for available tools | Assign a role with required tool permissions |
+| Validation error | Invalid JSON-RPC payload | Ensure client sends valid MCP JSON-RPC requests |
+| Connection issues on self-host | URL/TLS/reverse proxy configuration | Confirm public HTTPS URL and route forwarding to `/mcp` |
+
+## Related
+
+- [APIs](/developers/extend/capabilities/apis)
+- [Webhooks](/developers/extend/capabilities/webhooks)
+- [Apps](/developers/extend/capabilities/apps)

--- a/packages/twenty-docs/l/ro/developers/extend/capabilities/mcp.mdx
+++ b/packages/twenty-docs/l/ro/developers/extend/capabilities/mcp.mdx
@@ -1,0 +1,136 @@
+---
+title: MCP (Model Context Protocol)
+description: Connect AI clients like Claude and Cursor to your Twenty workspace using MCP.
+---
+
+MCP lets AI clients connect directly to your Twenty workspace as a tool server. You can use it to let agents read and update CRM data through your existing Twenty permissions model.
+
+## What Twenty MCP Provides
+
+Twenty exposes two MCP endpoints:
+
+- **Core schema** (`/mcp`): Workspace data access tools
+- **Metadata schema** (`/mcp/metadata`): Data model and metadata tools
+
+Both endpoints use your Twenty API key for authentication.
+
+## Prerequisites
+
+- A Twenty workspace (cloud or self-hosted)
+- An API key from **Settings → APIs & Webhooks**
+- AI enabled for your workspace
+
+<Note>
+API key role permissions still apply. MCP only exposes tools your key is allowed to use.
+</Note>
+
+## Endpoints
+
+| Environment | Core MCP | Metadata MCP |
+|-------------|----------|--------------|
+| **Cloud** | `https://api.twenty.com/mcp` | `https://api.twenty.com/mcp/metadata` |
+| **Self-Hosted** | `https://{your-domain}/mcp` | `https://{your-domain}/mcp/metadata` |
+
+## Authentication
+
+Send your API key as a bearer token:
+
+```text
+Authorization: Bearer YOUR_API_KEY
+```
+
+## Client Configuration
+
+Twenty MCP uses `streamable-http` transport. Use one server entry per schema.
+
+### Claude Desktop
+
+```json
+{
+  "mcpServers": {
+    "twenty": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    },
+    "twenty-metadata": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp/metadata",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+### Cursor
+
+```json
+{
+  "mcpServers": {
+    "twenty": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+### VS Code MCP
+
+```json
+{
+  "mcpServers": {
+    "twenty": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+<Tip>
+You can copy ready-made MCP JSON from **Settings → AI → MCP Server** in Twenty.
+</Tip>
+
+## Tool Coverage
+
+Current MCP behavior includes:
+
+- `initialize`
+- `ping`
+- `tools/list`
+- `tools/call`
+
+Prompts and resources are currently listed as empty arrays.
+
+## Security Best Practices
+
+- Create dedicated API keys for MCP clients
+- Assign the minimum role permissions needed
+- Rotate keys regularly
+- Use HTTPS in production (especially for self-hosting)
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---------|--------------|-----|
+| `401` or `403` | Missing/invalid API key, role restrictions, or AI disabled | Verify `Authorization` header, role assignment, and AI settings |
+| No tools listed | Key does not have permissions for available tools | Assign a role with required tool permissions |
+| Validation error | Invalid JSON-RPC payload | Ensure client sends valid MCP JSON-RPC requests |
+| Connection issues on self-host | URL/TLS/reverse proxy configuration | Confirm public HTTPS URL and route forwarding to `/mcp` |
+
+## Related
+
+- [APIs](/developers/extend/capabilities/apis)
+- [Webhooks](/developers/extend/capabilities/webhooks)
+- [Apps](/developers/extend/capabilities/apps)

--- a/packages/twenty-docs/l/ro/developers/extend/capabilities/mcp.mdx
+++ b/packages/twenty-docs/l/ro/developers/extend/capabilities/mcp.mdx
@@ -102,7 +102,7 @@ Twenty MCP uses `streamable-http` transport. Use one server entry per schema.
 You can copy ready-made MCP JSON from **Settings → AI → MCP Server** in Twenty.
 </Tip>
 
-## Tool Coverage
+## Supported MCP Methods
 
 Current MCP behavior includes:
 
@@ -110,6 +110,8 @@ Current MCP behavior includes:
 - `ping`
 - `tools/list`
 - `tools/call`
+- `prompts/list`
+- `resources/list`
 
 Prompts and resources are currently listed as empty arrays.
 
@@ -131,6 +133,6 @@ Prompts and resources are currently listed as empty arrays.
 
 ## Related
 
-- [APIs](/developers/extend/capabilities/apis)
-- [Webhooks](/developers/extend/capabilities/webhooks)
-- [Apps](/developers/extend/capabilities/apps)
+- [APIs](/l/ro/developers/extend/capabilities/apis)
+- [Webhooks](/l/ro/developers/extend/capabilities/webhooks)
+- [Apps](/l/ro/developers/extend/capabilities/apps)

--- a/packages/twenty-docs/l/ru/developers/extend/capabilities/mcp.mdx
+++ b/packages/twenty-docs/l/ru/developers/extend/capabilities/mcp.mdx
@@ -102,7 +102,7 @@ Twenty MCP uses `streamable-http` transport. Use one server entry per schema.
 You can copy ready-made MCP JSON from **Settings → AI → MCP Server** in Twenty.
 </Tip>
 
-## Tool Coverage
+## Supported MCP Methods
 
 Current MCP behavior includes:
 
@@ -110,6 +110,8 @@ Current MCP behavior includes:
 - `ping`
 - `tools/list`
 - `tools/call`
+- `prompts/list`
+- `resources/list`
 
 Prompts and resources are currently listed as empty arrays.
 
@@ -131,6 +133,6 @@ Prompts and resources are currently listed as empty arrays.
 
 ## Related
 
-- [APIs](/developers/extend/capabilities/apis)
-- [Webhooks](/developers/extend/capabilities/webhooks)
-- [Apps](/developers/extend/capabilities/apps)
+- [APIs](/l/ru/developers/extend/capabilities/apis)
+- [Webhooks](/l/ru/developers/extend/capabilities/webhooks)
+- [Apps](/l/ru/developers/extend/capabilities/apps)

--- a/packages/twenty-docs/l/ru/developers/extend/capabilities/mcp.mdx
+++ b/packages/twenty-docs/l/ru/developers/extend/capabilities/mcp.mdx
@@ -1,0 +1,136 @@
+---
+title: MCP (Model Context Protocol)
+description: Connect AI clients like Claude and Cursor to your Twenty workspace using MCP.
+---
+
+MCP lets AI clients connect directly to your Twenty workspace as a tool server. You can use it to let agents read and update CRM data through your existing Twenty permissions model.
+
+## What Twenty MCP Provides
+
+Twenty exposes two MCP endpoints:
+
+- **Core schema** (`/mcp`): Workspace data access tools
+- **Metadata schema** (`/mcp/metadata`): Data model and metadata tools
+
+Both endpoints use your Twenty API key for authentication.
+
+## Prerequisites
+
+- A Twenty workspace (cloud or self-hosted)
+- An API key from **Settings → APIs & Webhooks**
+- AI enabled for your workspace
+
+<Note>
+API key role permissions still apply. MCP only exposes tools your key is allowed to use.
+</Note>
+
+## Endpoints
+
+| Environment | Core MCP | Metadata MCP |
+|-------------|----------|--------------|
+| **Cloud** | `https://api.twenty.com/mcp` | `https://api.twenty.com/mcp/metadata` |
+| **Self-Hosted** | `https://{your-domain}/mcp` | `https://{your-domain}/mcp/metadata` |
+
+## Authentication
+
+Send your API key as a bearer token:
+
+```text
+Authorization: Bearer YOUR_API_KEY
+```
+
+## Client Configuration
+
+Twenty MCP uses `streamable-http` transport. Use one server entry per schema.
+
+### Claude Desktop
+
+```json
+{
+  "mcpServers": {
+    "twenty": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    },
+    "twenty-metadata": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp/metadata",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+### Cursor
+
+```json
+{
+  "mcpServers": {
+    "twenty": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+### VS Code MCP
+
+```json
+{
+  "mcpServers": {
+    "twenty": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+<Tip>
+You can copy ready-made MCP JSON from **Settings → AI → MCP Server** in Twenty.
+</Tip>
+
+## Tool Coverage
+
+Current MCP behavior includes:
+
+- `initialize`
+- `ping`
+- `tools/list`
+- `tools/call`
+
+Prompts and resources are currently listed as empty arrays.
+
+## Security Best Practices
+
+- Create dedicated API keys for MCP clients
+- Assign the minimum role permissions needed
+- Rotate keys regularly
+- Use HTTPS in production (especially for self-hosting)
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---------|--------------|-----|
+| `401` or `403` | Missing/invalid API key, role restrictions, or AI disabled | Verify `Authorization` header, role assignment, and AI settings |
+| No tools listed | Key does not have permissions for available tools | Assign a role with required tool permissions |
+| Validation error | Invalid JSON-RPC payload | Ensure client sends valid MCP JSON-RPC requests |
+| Connection issues on self-host | URL/TLS/reverse proxy configuration | Confirm public HTTPS URL and route forwarding to `/mcp` |
+
+## Related
+
+- [APIs](/developers/extend/capabilities/apis)
+- [Webhooks](/developers/extend/capabilities/webhooks)
+- [Apps](/developers/extend/capabilities/apps)

--- a/packages/twenty-docs/l/tr/developers/extend/capabilities/mcp.mdx
+++ b/packages/twenty-docs/l/tr/developers/extend/capabilities/mcp.mdx
@@ -102,7 +102,7 @@ Twenty MCP uses `streamable-http` transport. Use one server entry per schema.
 You can copy ready-made MCP JSON from **Settings → AI → MCP Server** in Twenty.
 </Tip>
 
-## Tool Coverage
+## Supported MCP Methods
 
 Current MCP behavior includes:
 
@@ -110,6 +110,8 @@ Current MCP behavior includes:
 - `ping`
 - `tools/list`
 - `tools/call`
+- `prompts/list`
+- `resources/list`
 
 Prompts and resources are currently listed as empty arrays.
 
@@ -131,6 +133,6 @@ Prompts and resources are currently listed as empty arrays.
 
 ## Related
 
-- [APIs](/developers/extend/capabilities/apis)
-- [Webhooks](/developers/extend/capabilities/webhooks)
-- [Apps](/developers/extend/capabilities/apps)
+- [APIs](/l/tr/developers/extend/capabilities/apis)
+- [Webhooks](/l/tr/developers/extend/capabilities/webhooks)
+- [Apps](/l/tr/developers/extend/capabilities/apps)

--- a/packages/twenty-docs/l/tr/developers/extend/capabilities/mcp.mdx
+++ b/packages/twenty-docs/l/tr/developers/extend/capabilities/mcp.mdx
@@ -1,0 +1,136 @@
+---
+title: MCP (Model Context Protocol)
+description: Connect AI clients like Claude and Cursor to your Twenty workspace using MCP.
+---
+
+MCP lets AI clients connect directly to your Twenty workspace as a tool server. You can use it to let agents read and update CRM data through your existing Twenty permissions model.
+
+## What Twenty MCP Provides
+
+Twenty exposes two MCP endpoints:
+
+- **Core schema** (`/mcp`): Workspace data access tools
+- **Metadata schema** (`/mcp/metadata`): Data model and metadata tools
+
+Both endpoints use your Twenty API key for authentication.
+
+## Prerequisites
+
+- A Twenty workspace (cloud or self-hosted)
+- An API key from **Settings → APIs & Webhooks**
+- AI enabled for your workspace
+
+<Note>
+API key role permissions still apply. MCP only exposes tools your key is allowed to use.
+</Note>
+
+## Endpoints
+
+| Environment | Core MCP | Metadata MCP |
+|-------------|----------|--------------|
+| **Cloud** | `https://api.twenty.com/mcp` | `https://api.twenty.com/mcp/metadata` |
+| **Self-Hosted** | `https://{your-domain}/mcp` | `https://{your-domain}/mcp/metadata` |
+
+## Authentication
+
+Send your API key as a bearer token:
+
+```text
+Authorization: Bearer YOUR_API_KEY
+```
+
+## Client Configuration
+
+Twenty MCP uses `streamable-http` transport. Use one server entry per schema.
+
+### Claude Desktop
+
+```json
+{
+  "mcpServers": {
+    "twenty": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    },
+    "twenty-metadata": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp/metadata",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+### Cursor
+
+```json
+{
+  "mcpServers": {
+    "twenty": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+### VS Code MCP
+
+```json
+{
+  "mcpServers": {
+    "twenty": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+<Tip>
+You can copy ready-made MCP JSON from **Settings → AI → MCP Server** in Twenty.
+</Tip>
+
+## Tool Coverage
+
+Current MCP behavior includes:
+
+- `initialize`
+- `ping`
+- `tools/list`
+- `tools/call`
+
+Prompts and resources are currently listed as empty arrays.
+
+## Security Best Practices
+
+- Create dedicated API keys for MCP clients
+- Assign the minimum role permissions needed
+- Rotate keys regularly
+- Use HTTPS in production (especially for self-hosting)
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---------|--------------|-----|
+| `401` or `403` | Missing/invalid API key, role restrictions, or AI disabled | Verify `Authorization` header, role assignment, and AI settings |
+| No tools listed | Key does not have permissions for available tools | Assign a role with required tool permissions |
+| Validation error | Invalid JSON-RPC payload | Ensure client sends valid MCP JSON-RPC requests |
+| Connection issues on self-host | URL/TLS/reverse proxy configuration | Confirm public HTTPS URL and route forwarding to `/mcp` |
+
+## Related
+
+- [APIs](/developers/extend/capabilities/apis)
+- [Webhooks](/developers/extend/capabilities/webhooks)
+- [Apps](/developers/extend/capabilities/apps)

--- a/packages/twenty-docs/l/zh/developers/extend/capabilities/mcp.mdx
+++ b/packages/twenty-docs/l/zh/developers/extend/capabilities/mcp.mdx
@@ -102,7 +102,7 @@ Twenty MCP uses `streamable-http` transport. Use one server entry per schema.
 You can copy ready-made MCP JSON from **Settings → AI → MCP Server** in Twenty.
 </Tip>
 
-## Tool Coverage
+## Supported MCP Methods
 
 Current MCP behavior includes:
 
@@ -110,6 +110,8 @@ Current MCP behavior includes:
 - `ping`
 - `tools/list`
 - `tools/call`
+- `prompts/list`
+- `resources/list`
 
 Prompts and resources are currently listed as empty arrays.
 
@@ -131,6 +133,6 @@ Prompts and resources are currently listed as empty arrays.
 
 ## Related
 
-- [APIs](/developers/extend/capabilities/apis)
-- [Webhooks](/developers/extend/capabilities/webhooks)
-- [Apps](/developers/extend/capabilities/apps)
+- [APIs](/l/zh/developers/extend/capabilities/apis)
+- [Webhooks](/l/zh/developers/extend/capabilities/webhooks)
+- [Apps](/l/zh/developers/extend/capabilities/apps)

--- a/packages/twenty-docs/l/zh/developers/extend/capabilities/mcp.mdx
+++ b/packages/twenty-docs/l/zh/developers/extend/capabilities/mcp.mdx
@@ -1,0 +1,136 @@
+---
+title: MCP (Model Context Protocol)
+description: Connect AI clients like Claude and Cursor to your Twenty workspace using MCP.
+---
+
+MCP lets AI clients connect directly to your Twenty workspace as a tool server. You can use it to let agents read and update CRM data through your existing Twenty permissions model.
+
+## What Twenty MCP Provides
+
+Twenty exposes two MCP endpoints:
+
+- **Core schema** (`/mcp`): Workspace data access tools
+- **Metadata schema** (`/mcp/metadata`): Data model and metadata tools
+
+Both endpoints use your Twenty API key for authentication.
+
+## Prerequisites
+
+- A Twenty workspace (cloud or self-hosted)
+- An API key from **Settings → APIs & Webhooks**
+- AI enabled for your workspace
+
+<Note>
+API key role permissions still apply. MCP only exposes tools your key is allowed to use.
+</Note>
+
+## Endpoints
+
+| Environment | Core MCP | Metadata MCP |
+|-------------|----------|--------------|
+| **Cloud** | `https://api.twenty.com/mcp` | `https://api.twenty.com/mcp/metadata` |
+| **Self-Hosted** | `https://{your-domain}/mcp` | `https://{your-domain}/mcp/metadata` |
+
+## Authentication
+
+Send your API key as a bearer token:
+
+```text
+Authorization: Bearer YOUR_API_KEY
+```
+
+## Client Configuration
+
+Twenty MCP uses `streamable-http` transport. Use one server entry per schema.
+
+### Claude Desktop
+
+```json
+{
+  "mcpServers": {
+    "twenty": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    },
+    "twenty-metadata": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp/metadata",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+### Cursor
+
+```json
+{
+  "mcpServers": {
+    "twenty": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+### VS Code MCP
+
+```json
+{
+  "mcpServers": {
+    "twenty": {
+      "type": "streamable-http",
+      "url": "https://api.twenty.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+<Tip>
+You can copy ready-made MCP JSON from **Settings → AI → MCP Server** in Twenty.
+</Tip>
+
+## Tool Coverage
+
+Current MCP behavior includes:
+
+- `initialize`
+- `ping`
+- `tools/list`
+- `tools/call`
+
+Prompts and resources are currently listed as empty arrays.
+
+## Security Best Practices
+
+- Create dedicated API keys for MCP clients
+- Assign the minimum role permissions needed
+- Rotate keys regularly
+- Use HTTPS in production (especially for self-hosting)
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---------|--------------|-----|
+| `401` or `403` | Missing/invalid API key, role restrictions, or AI disabled | Verify `Authorization` header, role assignment, and AI settings |
+| No tools listed | Key does not have permissions for available tools | Assign a role with required tool permissions |
+| Validation error | Invalid JSON-RPC payload | Ensure client sends valid MCP JSON-RPC requests |
+| Connection issues on self-host | URL/TLS/reverse proxy configuration | Confirm public HTTPS URL and route forwarding to `/mcp` |
+
+## Related
+
+- [APIs](/developers/extend/capabilities/apis)
+- [Webhooks](/developers/extend/capabilities/webhooks)
+- [Apps](/developers/extend/capabilities/apps)

--- a/packages/twenty-docs/navigation/base-structure.json
+++ b/packages/twenty-docs/navigation/base-structure.json
@@ -370,6 +370,7 @@
               "label": "Capabilities",
               "pages": [
                 "developers/extend/capabilities/apis",
+                "developers/extend/capabilities/mcp",
                 "developers/extend/capabilities/webhooks",
                 "developers/extend/capabilities/apps"
               ]

--- a/packages/twenty-docs/navigation/navigation-schema.json
+++ b/packages/twenty-docs/navigation/navigation-schema.json
@@ -369,6 +369,7 @@
               "label": "Capabilities",
               "pages": [
                 "developers/extend/capabilities/apis",
+                "developers/extend/capabilities/mcp",
                 "developers/extend/capabilities/webhooks",
                 "developers/extend/capabilities/apps"
               ]

--- a/packages/twenty-shared/src/constants/DocumentationPaths.ts
+++ b/packages/twenty-shared/src/constants/DocumentationPaths.ts
@@ -47,6 +47,7 @@ export const DOCUMENTATION_PATHS = {
   DEVELOPERS_CONTRIBUTE_CONTRIBUTE: '/developers/contribute/contribute',
   DEVELOPERS_EXTEND_CAPABILITIES_APIS: '/developers/extend/capabilities/apis',
   DEVELOPERS_EXTEND_CAPABILITIES_APPS: '/developers/extend/capabilities/apps',
+  DEVELOPERS_EXTEND_CAPABILITIES_MCP: '/developers/extend/capabilities/mcp',
   DEVELOPERS_EXTEND_CAPABILITIES_WEBHOOKS:
     '/developers/extend/capabilities/webhooks',
   DEVELOPERS_EXTEND_EXTEND: '/developers/extend/extend',


### PR DESCRIPTION
## Summary
- Add a new MCP capability page for external integrators under Developers > Extend > Capabilities
- Add MCP entry points from existing developer docs pages
- Wire MCP into docs navigation sources and generated navigation artifacts
- Add localized MCP page files so locale navigation paths resolve

## Main Changes
- New page: packages/twenty-docs/developers/extend/capabilities/mcp.mdx
- Updated: packages/twenty-docs/developers/extend/extend.mdx
- Updated: packages/twenty-docs/developers/extend/capabilities/apis.mdx
- Navigation wiring: packages/twenty-docs/navigation/base-structure.json, packages/twenty-docs/navigation/navigation-schema.json
- Generated artifacts: packages/twenty-docs/docs.json, packages/twenty-shared/src/constants/DocumentationPaths.ts
- Locale MCP pages added under packages/twenty-docs/l/*/developers/extend/capabilities/mcp.mdx

## Validation
- yarn docs:generate-navigation-template
- yarn docs:generate
- Note: Nx docs build/lint commands were inconclusive in this terminal environment (processes hung without output), but docs generation completed and the working tree is clean after generation.
