### PR TITLE
Emitting the correct event based on whether the record is being soft deleted or restored.

### DIFF
--- a/packages/twenty-server/src/engine/twenty-orm/repository/workspace-soft-delete-query-builder.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/repository/workspace-soft-delete-query-builder.ts
@@ -131,7 +131,10 @@ export class WorkspaceSoftDeleteQueryBuilder<
 
       this.internalContext.eventEmitterService.emitDatabaseBatchEvent(
         formatTwentyOrmEventToDatabaseBatchEvent({
-          action: DatabaseEventAction.DELETED,
+          action:
+            this.expressionMap.queryType === 'restore'
+              ? DatabaseEventAction.RESTORED
+              : DatabaseEventAction.DELETED,
           objectMetadataItem: objectMetadata,
           flatFieldMetadataMaps: this.internalContext.flatFieldMetadataMaps,
           workspaceId: this.internalContext.workspaceId,


### PR DESCRIPTION
fix for #17262 
This change ensures that when the record is restored, instead of emitting a database event of "DELETED", a database event of "RESTORED" will be emitted, as it is happening in the inner working of TypeORM.

This ensures that the DELETED event are not fired on RESTORED, for example, triggering a workflow.

The screen recording shows that restoring the soft deleted records does not trigger the workflow set to to run on "Record Deleted"

https://github.com/user-attachments/assets/90e0184f-2e08-466c-a40d-1592b60e64ff


