### PR TITLE
Fix Data Model instances counter showing 0

### DIFF
--- a/packages/twenty-front/src/modules/object-record/multiple-objects/hooks/__tests__/useCombinedGetTotalCount.test.tsx
+++ b/packages/twenty-front/src/modules/object-record/multiple-objects/hooks/__tests__/useCombinedGetTotalCount.test.tsx
@@ -1,0 +1,137 @@
+import { gql } from '@apollo/client';
+import { renderHook, waitFor } from '@testing-library/react';
+import { GraphQLError } from 'graphql';
+
+import { useCombinedGetTotalCount } from '@/object-record/multiple-objects/hooks/useCombinedGetTotalCount';
+import { useGenerateCombinedFindManyRecordsQuery } from '@/object-record/multiple-objects/hooks/useGenerateCombinedFindManyRecordsQuery';
+import { generatedMockObjectMetadataItems } from '~/testing/utils/generatedMockObjectMetadataItems';
+import { getJestMetadataAndApolloMocksWrapper } from '~/testing/jest/getJestMetadataAndApolloMocksWrapper';
+
+jest.mock(
+  '@/object-record/multiple-objects/hooks/useGenerateCombinedFindManyRecordsQuery',
+  () => ({
+    useGenerateCombinedFindManyRecordsQuery: jest.fn(),
+  }),
+);
+
+const mockQuery = gql`
+  query CombinedFindManyRecords {
+    companies {
+      totalCount
+    }
+    apiKeys {
+      totalCount
+    }
+  }
+`;
+
+describe('useCombinedGetTotalCount', () => {
+  const companyObjectMetadataItem = generatedMockObjectMetadataItems.find(
+    ({ nameSingular }) => nameSingular === 'company',
+  );
+  const apiKeyObjectMetadataItem = generatedMockObjectMetadataItems.find(
+    ({ nameSingular }) => nameSingular === 'apiKey',
+  );
+
+  beforeEach(() => {
+    (useGenerateCombinedFindManyRecordsQuery as jest.Mock).mockReturnValue(
+      mockQuery,
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should keep available totals when one object resolver fails', async () => {
+    if (!companyObjectMetadataItem || !apiKeyObjectMetadataItem) {
+      throw new Error('Missing required mock object metadata items');
+    }
+
+    const mocks = [
+      {
+        request: {
+          query: mockQuery,
+        },
+        result: {
+          data: {
+            companies: {
+              totalCount: 7,
+            },
+            apiKeys: null,
+          },
+          errors: [new GraphQLError('Forbidden')],
+        },
+      },
+    ];
+
+    const { result } = renderHook(
+      () =>
+        useCombinedGetTotalCount({
+          objectMetadataItems: [
+            companyObjectMetadataItem,
+            apiKeyObjectMetadataItem,
+          ],
+        }),
+      {
+        wrapper: getJestMetadataAndApolloMocksWrapper({ apolloMocks: mocks }),
+      },
+    );
+
+    await waitFor(() => {
+      expect(
+        result.current.totalCountByObjectMetadataItemNamePlural.companies,
+      ).toBe(7);
+    });
+
+    expect(result.current.totalCountByObjectMetadataItemNamePlural).toEqual({
+      companies: 7,
+    });
+  });
+
+  it('should map totals when every object succeeds', async () => {
+    if (!companyObjectMetadataItem || !apiKeyObjectMetadataItem) {
+      throw new Error('Missing required mock object metadata items');
+    }
+
+    const mocks = [
+      {
+        request: {
+          query: mockQuery,
+        },
+        result: {
+          data: {
+            companies: {
+              totalCount: 7,
+            },
+            apiKeys: {
+              totalCount: 3,
+            },
+          },
+        },
+      },
+    ];
+
+    const { result } = renderHook(
+      () =>
+        useCombinedGetTotalCount({
+          objectMetadataItems: [
+            companyObjectMetadataItem,
+            apiKeyObjectMetadataItem,
+          ],
+        }),
+      {
+        wrapper: getJestMetadataAndApolloMocksWrapper({ apolloMocks: mocks }),
+      },
+    );
+
+    await waitFor(() => {
+      expect(
+        result.current.totalCountByObjectMetadataItemNamePlural.companies,
+      ).toBe(7);
+      expect(
+        result.current.totalCountByObjectMetadataItemNamePlural.apiKeys,
+      ).toBe(3);
+    });
+  });
+});

--- a/packages/twenty-front/src/modules/object-record/multiple-objects/hooks/useCombinedGetTotalCount.ts
+++ b/packages/twenty-front/src/modules/object-record/multiple-objects/hooks/useCombinedGetTotalCount.ts
@@ -35,14 +35,24 @@ export const useCombinedGetTotalCount = ({
     {
       skip,
       client: apolloCoreClient,
+      errorPolicy: 'all',
+      returnPartialData: true,
     },
   );
 
-  const totalCountByObjectMetadataItemNamePlural = Object.fromEntries(
-    Object.entries(data ?? {}).map(([namePlural, objectRecordConnection]) => [
-      namePlural,
-      objectRecordConnection.totalCount,
-    ]),
+  const totalCountByObjectMetadataItemNamePlural = Object.entries(
+    data ?? {},
+  ).reduce<Record<string, number>>(
+    (acc, [namePlural, objectRecordConnection]) => {
+      const totalCount = objectRecordConnection?.totalCount;
+
+      if (typeof totalCount === 'number') {
+        acc[namePlural] = totalCount;
+      }
+
+      return acc;
+    },
+    {},
   );
 
   return {

--- a/packages/twenty-front/src/pages/settings/data-model/SettingsObjectTable.tsx
+++ b/packages/twenty-front/src/pages/settings/data-model/SettingsObjectTable.tsx
@@ -58,9 +58,19 @@ export const SettingsObjectTable = ({
 
   const { updateOneObjectMetadataItem } = useUpdateOneObjectMetadataItem();
 
+  const objectMetadataItemsForTotalCount = useMemo(
+    () =>
+      objectMetadataItems.filter(
+        (objectMetadataItem) =>
+          (showDeactivated || objectMetadataItem.isActive) &&
+          (showSystemObjects || !objectMetadataItem.isSystem),
+      ),
+    [objectMetadataItems, showDeactivated, showSystemObjects],
+  );
+
   const { totalCountByObjectMetadataItemNamePlural } = useCombinedGetTotalCount(
     {
-      objectMetadataItems,
+      objectMetadataItems: objectMetadataItemsForTotalCount,
     },
   );
 


### PR DESCRIPTION
## Summary
- make combined object count queries resilient to partial GraphQL failures by accepting partial data
- ignore invalid/null object connections when building totalCountByObjectMetadataItemNamePlural
- scope Data Model Settings count queries to the same active/system object subset currently visible in the table, avoiding root-resolver overfetch
- add regression tests for useCombinedGetTotalCount covering partial failure and full success

## Validation
- npx jest --config packages/twenty-front/jest.config.mjs --runTestsByPath packages/twenty-front/src/modules/object-record/multiple-objects/hooks/__tests__/useCombinedGetTotalCount.test.tsx
- npx eslint packages/twenty-front/src/pages/settings/data-model/SettingsObjectTable.tsx packages/twenty-front/src/modules/object-record/multiple-objects/hooks/useCombinedGetTotalCount.ts packages/twenty-front/src/modules/object-record/multiple-objects/hooks/__tests__/useCombinedGetTotalCount.test.tsx
