### PR TITLE
fix: improve clipboard copy for non-HTTPS self-hosted deployments

### DIFF
--- a/packages/twenty-front/src/hooks/useCopyToClipboard.tsx
+++ b/packages/twenty-front/src/hooks/useCopyToClipboard.tsx
@@ -3,6 +3,31 @@ import { useTheme } from '@emotion/react';
 import { useLingui } from '@lingui/react/macro';
 import { IconCopy, IconExclamationCircle } from 'twenty-ui/display';
 
+const fallbackCopyToClipboard = (text: string): boolean => {
+  const textArea = document.createElement('textarea');
+
+  textArea.value = text;
+  textArea.style.position = 'fixed';
+  textArea.style.left = '-9999px';
+  textArea.style.top = '-9999px';
+
+  document.body.appendChild(textArea);
+  textArea.focus();
+  textArea.select();
+
+  try {
+    const successful = document.execCommand('copy');
+
+    return successful;
+  } finally {
+    document.body.removeChild(textArea);
+  }
+};
+
+const canUseClipboardApi = (): boolean => {
+  return window.isSecureContext === true && navigator.clipboard !== undefined;
+};
+
 export const useCopyToClipboard = () => {
   const theme = useTheme();
   const { enqueueSuccessSnackBar, enqueueErrorSnackBar } = useSnackBar();
@@ -10,7 +35,15 @@ export const useCopyToClipboard = () => {
 
   const copyToClipboard = async (valueAsString: string, message?: string) => {
     try {
-      await navigator.clipboard.writeText(valueAsString);
+      if (canUseClipboardApi()) {
+        await navigator.clipboard.writeText(valueAsString);
+      } else {
+        const successful = fallbackCopyToClipboard(valueAsString);
+
+        if (successful !== true) {
+          throw new Error('execCommand copy failed');
+        }
+      }
 
       enqueueSuccessSnackBar({
         message: message || t`Copied to clipboard`,
@@ -20,11 +53,15 @@ export const useCopyToClipboard = () => {
         },
       });
     } catch {
+      const isInsecureContext = window.isSecureContext !== true;
+
       enqueueErrorSnackBar({
-        message: t`Couldn't copy to clipboard`,
+        message: isInsecureContext
+          ? t`Clipboard requires a secure connection (HTTPS). Please access this app over HTTPS to enable copying.`
+          : t`Couldn't copy to clipboard`,
         options: {
           icon: <IconExclamationCircle size={16} color="red" />,
-          duration: 2000,
+          duration: isInsecureContext ? 6000 : 2000,
         },
       });
     }

--- a/packages/twenty-front/src/hooks/useCopyToClipboard.tsx
+++ b/packages/twenty-front/src/hooks/useCopyToClipboard.tsx
@@ -3,47 +3,26 @@ import { useTheme } from '@emotion/react';
 import { useLingui } from '@lingui/react/macro';
 import { IconCopy, IconExclamationCircle } from 'twenty-ui/display';
 
-const fallbackCopyToClipboard = (text: string): boolean => {
-  const textArea = document.createElement('textarea');
-
-  textArea.value = text;
-  textArea.style.position = 'fixed';
-  textArea.style.left = '-9999px';
-  textArea.style.top = '-9999px';
-
-  document.body.appendChild(textArea);
-  textArea.focus();
-  textArea.select();
-
-  try {
-    const successful = document.execCommand('copy');
-
-    return successful;
-  } finally {
-    document.body.removeChild(textArea);
-  }
-};
-
-const canUseClipboardApi = (): boolean => {
-  return window.isSecureContext === true && navigator.clipboard !== undefined;
-};
-
 export const useCopyToClipboard = () => {
   const theme = useTheme();
   const { enqueueSuccessSnackBar, enqueueErrorSnackBar } = useSnackBar();
   const { t } = useLingui();
 
   const copyToClipboard = async (valueAsString: string, message?: string) => {
-    try {
-      if (canUseClipboardApi()) {
-        await navigator.clipboard.writeText(valueAsString);
-      } else {
-        const successful = fallbackCopyToClipboard(valueAsString);
+    if (!window.isSecureContext) {
+      enqueueErrorSnackBar({
+        message: t`Clipboard requires a secure connection (HTTPS). Please access this app over HTTPS to enable copying.`,
+        options: {
+          icon: <IconExclamationCircle size={16} color="red" />,
+          duration: 6000,
+        },
+      });
 
-        if (successful !== true) {
-          throw new Error('execCommand copy failed');
-        }
-      }
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(valueAsString);
 
       enqueueSuccessSnackBar({
         message: message || t`Copied to clipboard`,
@@ -53,15 +32,11 @@ export const useCopyToClipboard = () => {
         },
       });
     } catch {
-      const isInsecureContext = window.isSecureContext !== true;
-
       enqueueErrorSnackBar({
-        message: isInsecureContext
-          ? t`Clipboard requires a secure connection (HTTPS). Please access this app over HTTPS to enable copying.`
-          : t`Couldn't copy to clipboard`,
+        message: t`Couldn't copy to clipboard`,
         options: {
           icon: <IconExclamationCircle size={16} color="red" />,
-          duration: isInsecureContext ? 6000 : 2000,
+          duration: 2000,
         },
       });
     }

--- a/packages/twenty-front/src/modules/auth/sign-in-up/components/internal/SignInUpTwoFactorAuthenticationProvision.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/components/internal/SignInUpTwoFactorAuthenticationProvision.tsx
@@ -5,7 +5,6 @@ import {
   signInUpStepState,
 } from '@/auth/states/signInUpStepState';
 import { extractSecretFromOtpUri } from '@/settings/two-factor-authentication/utils/extractSecretFromOtpUri';
-import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { Trans, useLingui } from '@lingui/react/macro';
@@ -15,6 +14,7 @@ import { IconCopy } from 'twenty-ui/display';
 import { Loader } from 'twenty-ui/feedback';
 import { MainButton } from 'twenty-ui/input';
 import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
+import { useCopyToClipboard } from '~/hooks/useCopyToClipboard';
 
 const StyledMainContentContainer = styled.div`
   margin-bottom: ${({ theme }) => theme.spacing(8)};
@@ -69,7 +69,7 @@ const StyledCopySetupKeyLink = styled.button`
 export const SignInUpTwoFactorAuthenticationProvision = () => {
   const { t } = useLingui();
   const theme = useTheme();
-  const { enqueueSuccessSnackBar } = useSnackBar();
+  const { copyToClipboard } = useCopyToClipboard();
   const qrCode = useRecoilValueV2(qrCodeState);
   const setSignInUpStep = useSetRecoilState(signInUpStepState);
 
@@ -82,14 +82,7 @@ export const SignInUpTwoFactorAuthenticationProvision = () => {
 
     const secret = extractSecretFromOtpUri(qrCode);
     if (secret !== null) {
-      await navigator.clipboard.writeText(secret);
-      enqueueSuccessSnackBar({
-        message: t`Setup key copied to clipboard`,
-        options: {
-          icon: <IconCopy size={theme.icon.size.md} />,
-          duration: 2000,
-        },
-      });
+      await copyToClipboard(secret, t`Setup key copied to clipboard`);
     }
   };
 

--- a/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownVisibilityContent.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-options-dropdown/components/ObjectOptionsDropdownVisibilityContent.tsx
@@ -1,7 +1,6 @@
 import { OBJECT_OPTIONS_DROPDOWN_ID } from '@/object-record/object-options-dropdown/constants/ObjectOptionsDropdownId';
 import { useObjectOptionsDropdown } from '@/object-record/object-options-dropdown/hooks/useObjectOptionsDropdown';
 import { useHasPermissionFlag } from '@/settings/roles/hooks/useHasPermissionFlag';
-import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { DropdownContent } from '@/ui/layout/dropdown/components/DropdownContent';
 import { DropdownMenuHeader } from '@/ui/layout/dropdown/components/DropdownMenuHeader/DropdownMenuHeader';
 import { DropdownMenuHeaderLeftComponent } from '@/ui/layout/dropdown/components/DropdownMenuHeader/internal/DropdownMenuHeaderLeftComponent';
@@ -15,7 +14,6 @@ import { useRecoilComponentValue } from '@/ui/utilities/state/component-state/ho
 import { useCanPersistViewChanges } from '@/views/hooks/useCanPersistViewChanges';
 import { useGetCurrentViewOnly } from '@/views/hooks/useGetCurrentViewOnly';
 import { useUpdateCurrentView } from '@/views/hooks/useUpdateCurrentView';
-import { useTheme } from '@emotion/react';
 import { useLingui } from '@lingui/react/macro';
 import { createPortal } from 'react-dom';
 import {
@@ -30,14 +28,14 @@ import {
   ViewVisibility,
   PermissionFlagType,
 } from '~/generated-metadata/graphql';
+import { useCopyToClipboard } from '~/hooks/useCopyToClipboard';
 
 export const ObjectOptionsDropdownVisibilityContent = () => {
   const { t } = useLingui();
-  const theme = useTheme();
   const { resetContent } = useObjectOptionsDropdown();
   const { currentView } = useGetCurrentViewOnly();
   const { updateCurrentView } = useUpdateCurrentView();
-  const { enqueueSuccessSnackBar } = useSnackBar();
+  const { copyToClipboard } = useCopyToClipboard();
   const hasViewsPermission = useHasPermissionFlag(PermissionFlagType.VIEWS);
   const { canPersistChanges } = useCanPersistViewChanges();
 
@@ -59,16 +57,9 @@ export const ObjectOptionsDropdownVisibilityContent = () => {
     resetContent();
   };
 
-  const handleCopyLink = () => {
+  const handleCopyLink = async () => {
     const currentUrl = window.location.href;
-    navigator.clipboard.writeText(currentUrl);
-    enqueueSuccessSnackBar({
-      message: t`Link copied to clipboard`,
-      options: {
-        icon: <IconCopy size={theme.icon.size.md} />,
-        duration: 2000,
-      },
-    });
+    await copyToClipboard(currentUrl, t`Link copied to clipboard`);
   };
 
   const currentVisibility = currentView?.visibility ?? ViewVisibility.WORKSPACE;

--- a/packages/twenty-front/src/pages/settings/SettingsTwoFactorAuthenticationMethod.tsx
+++ b/packages/twenty-front/src/pages/settings/SettingsTwoFactorAuthenticationMethod.tsx
@@ -12,15 +12,14 @@ import { TwoFactorAuthenticationVerificationForSettings } from '@/settings/two-f
 import { useCurrentUserWorkspaceTwoFactorAuthentication } from '@/settings/two-factor-authentication/hooks/useCurrentUserWorkspaceTwoFactorAuthentication';
 import { useTwoFactorVerificationForSettings } from '@/settings/two-factor-authentication/hooks/useTwoFactorVerificationForSettings';
 import { extractSecretFromOtpUri } from '@/settings/two-factor-authentication/utils/extractSecretFromOtpUri';
-import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { SubMenuTopBarContainer } from '@/ui/layout/page/components/SubMenuTopBarContainer';
-import { useTheme } from '@emotion/react';
 import { SettingsPath } from 'twenty-shared/types';
 import { getSettingsPath } from 'twenty-shared/utils';
-import { H2Title, IconCopy } from 'twenty-ui/display';
+import { H2Title } from 'twenty-ui/display';
 import { Loader } from 'twenty-ui/feedback';
 import { Section } from 'twenty-ui/layout';
 import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
+import { useCopyToClipboard } from '~/hooks/useCopyToClipboard';
 
 const StyledQRCodeContainer = styled.div`
   margin: ${({ theme }) => theme.spacing(4)} 0;
@@ -79,8 +78,7 @@ const StyledDivider = styled.div`
 
 export const SettingsTwoFactorAuthenticationMethod = () => {
   const { t } = useLingui();
-  const theme = useTheme();
-  const { enqueueSuccessSnackBar } = useSnackBar();
+  const { copyToClipboard } = useCopyToClipboard();
   const qrCode = useRecoilValueV2(qrCodeState);
 
   const { currentUserWorkspaceTwoFactorAuthenticationMethods } =
@@ -99,14 +97,7 @@ export const SettingsTwoFactorAuthenticationMethod = () => {
 
     const secret = extractSecretFromOtpUri(qrCode);
     if (secret !== null) {
-      await navigator.clipboard.writeText(secret);
-      enqueueSuccessSnackBar({
-        message: t`Setup key copied to clipboard`,
-        options: {
-          icon: <IconCopy size={theme.icon.size.md} />,
-          duration: 2000,
-        },
-      });
+      await copyToClipboard(secret, t`Setup key copied to clipboard`);
     }
   };
 


### PR DESCRIPTION
Closes #8305

The Clipboard API (`navigator.clipboard`) requires a secure context (HTTPS or localhost). Self-hosted deployments on plain HTTP silently fail when copying.

This PR:
- Adds a `document.execCommand('copy')` fallback for insecure contexts
- Shows a descriptive error message explaining HTTPS is required when the fallback also fails
- Consolidates 3 components that were using `navigator.clipboard` directly (without error handling) to use the centralized `useCopyToClipboard` hook

Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to frontend clipboard UX with a defensive fallback and clearer errors; minimal impact outside copy flows.
> 
> **Overview**
> Improves copy-to-clipboard behavior in non-HTTPS/self-hosted deployments by enhancing `useCopyToClipboard` to use `navigator.clipboard` only in secure contexts and otherwise fall back to `document.execCommand('copy')`.
> 
> Updates 2FA setup screens and the view visibility dropdown to use the centralized `copyToClipboard` helper (with consistent snackbars), and shows a more descriptive error (longer duration) when copying fails due to an insecure context.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30944e63eba720c30f2cad5829aadc7361e67e4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->