### PR TITLE
Fixed group by query order by inside group

### DIFF
--- a/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/group-by/services/group-by-with-records.service.ts
+++ b/packages/twenty-server/src/engine/api/graphql/graphql-query-runner/group-by/services/group-by-with-records.service.ts
@@ -9,13 +9,13 @@ import { FindOptionsRelations, type ObjectLiteral } from 'typeorm';
 import { ObjectRecordOrderBy } from 'src/engine/api/graphql/workspace-query-builder/interfaces/object-record.interface';
 
 import { ProcessNestedRelationsHelper } from 'src/engine/api/common/common-nested-relations-processor/process-nested-relations.helper';
+import { type GroupByDefinition } from 'src/engine/api/common/common-query-runners/types/group-by-definition.type';
 import { getObjectAlias } from 'src/engine/api/common/common-query-runners/utils/get-object-alias-for-group-by.util';
 import { CommonResultGettersService } from 'src/engine/api/common/common-result-getters/common-result-getters.service';
 import { CommonExtendedQueryRunnerContext } from 'src/engine/api/common/types/common-extended-query-runner-context.type';
 import { type CommonGroupByOutputItem } from 'src/engine/api/common/types/common-group-by-output-item.type';
 import { CommonSelectedFieldsResult } from 'src/engine/api/common/types/common-selected-fields-result.type';
 import { GraphqlQueryParser } from 'src/engine/api/graphql/graphql-query-runner/graphql-query-parsers/graphql-query.parser';
-import { type GroupByDefinition } from 'src/engine/api/common/common-query-runners/types/group-by-definition.type';
 import { formatResultWithGroupByDimensionValues } from 'src/engine/api/graphql/graphql-query-runner/group-by/resolvers/utils/format-result-with-group-by-dimension-values.util';
 import { getGroupLimit } from 'src/engine/api/graphql/graphql-query-runner/group-by/utils/get-group-limit.util';
 import { buildColumnsToSelect } from 'src/engine/api/graphql/graphql-query-runner/utils/build-columns-to-select';
@@ -198,20 +198,6 @@ export class GroupByWithRecordsService {
       orderByForRecords,
       queryBuilder: subQuery,
     });
-
-    if (!isEmpty(orderByForRecords)) {
-      const graphqlQueryParser = new GraphqlQueryParser(
-        flatObjectMetadata,
-        flatObjectMetadataMaps,
-        flatFieldMetadataMaps,
-      );
-
-      graphqlQueryParser.applyOrderToBuilder(
-        subQuery,
-        orderByForRecords,
-        flatObjectMetadata.nameSingular,
-      );
-    }
 
     let mainQueryQueryBuilder = repository.createQueryBuilder();
 


### PR DESCRIPTION
Fixes https://github.com/twentyhq/core-team-issues/issues/2229

This PR fixes a bug on board, that we thought was due to dev seeds, but that was in fact a conflict of `ORDER BY` clauses at the SQL level in group by queries.

The problem was that an ORDER BY was applied on top of a sub-query ORDER BY, thus breaking the initial ordering of each group.

# Before

<img width="1117" height="1033" alt="Capture d’écran 2026-02-17 à 16 32 56" src="https://github.com/user-attachments/assets/764183ae-4058-498b-9fe0-919e9511e67d" />

# After 

<img width="1101" height="1007" alt="Capture d’écran 2026-02-17 à 16 32 27" src="https://github.com/user-attachments/assets/b3100b30-25b5-4568-a9cf-0760f42ceb88" />
