### PR TITLE
Replace generic "Unknown error" messages with descriptive error details

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/application/services/marketplace.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/services/marketplace.service.ts
@@ -98,13 +98,13 @@ export class MarketplaceService {
           }
         } catch (error) {
           this.logger.warn(
-            `Failed to load manifest from ${appDir}: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            `Failed to load manifest from ${appDir}: ${error instanceof Error ? error.message : String(error)}`,
           );
         }
       }
     } catch (error) {
       this.logger.error(
-        `Failed to fetch marketplace apps from GitHub: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        `Failed to fetch marketplace apps from GitHub: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
 

--- a/packages/twenty-server/src/engine/core-modules/guard-redirect/services/guard-redirect.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/guard-redirect/services/guard-redirect.service.ts
@@ -97,8 +97,13 @@ export class GuardRedirectService {
   }) {
     this.captureException(error, workspace.id);
 
+    const errorMessage =
+      error instanceof AuthException
+        ? error.message
+        : `Authentication error: ${error instanceof Error ? error.message : String(error)}`;
+
     return this.workspaceDomainsService.computeWorkspaceRedirectErrorUrl(
-      error instanceof AuthException ? error.message : 'Unknown error',
+      errorMessage,
       {
         subdomain: workspace.subdomain,
         customDomain: workspace.customDomain,

--- a/packages/twenty-server/src/engine/core-modules/tool/tools/code-interpreter-tool/code-interpreter-tool.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool/tools/code-interpreter-tool/code-interpreter-tool.ts
@@ -226,7 +226,9 @@ export class CodeInterpreterTool implements Tool {
 
       const executionTimeMs = Date.now() - startTime;
       const errorMessage =
-        error instanceof Error ? error.message : 'Unknown error';
+        error instanceof Error
+          ? error.message
+          : `Unexpected error: ${String(error)}`;
 
       onCodeExecutionUpdate?.(
         this.buildExecutionState(

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-runner/interfaces/workspace-migration-runner-action-handler-service.interface.ts
@@ -300,7 +300,7 @@ export abstract class BaseWorkspaceMigrationRunnerActionHandlerService<
       await this.rollbackForMetadata(context);
     } catch (error) {
       this.logger.error(
-        `Failed to rollback ${context.action.type} action for ${context.action.metadataName}: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        `Failed to rollback ${context.action.type} action for ${context.action.metadataName}: ${error instanceof Error ? error.message : String(error)}`,
         'BaseWorkspaceMigrationRunnerActionHandlerService',
       );
     }

--- a/packages/twenty-server/src/modules/connected-account/email-alias-manager/drivers/google/services/google-email-alias-error-handler.service.ts
+++ b/packages/twenty-server/src/modules/connected-account/email-alias-manager/drivers/google/services/google-email-alias-error-handler.service.ts
@@ -30,7 +30,7 @@ export class GmailEmailAliasErrorHandlerService {
     }
 
     throw new MessageImportDriverException(
-      'Unknown error',
+      `Google email alias error: ${error instanceof Error ? error.message : String(error)}`,
       MessageImportDriverExceptionCode.UNKNOWN,
     );
   }

--- a/packages/twenty-server/src/modules/messaging/message-folder-manager/drivers/gmail/services/gmail-folders-error-handler.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-folder-manager/drivers/gmail/services/gmail-folders-error-handler.service.ts
@@ -30,7 +30,7 @@ export class GmailFoldersErrorHandlerService {
     }
 
     throw new MessageImportDriverException(
-      'Unknown error',
+      `Gmail folders fetch error: ${error instanceof Error ? error.message : String(error)}`,
       MessageImportDriverExceptionCode.UNKNOWN,
     );
   }

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-message-list-fetch-error-handler.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-message-list-fetch-error-handler.service.ts
@@ -30,7 +30,7 @@ export class GmailMessageListFetchErrorHandler {
     }
 
     throw new MessageImportDriverException(
-      'Unknown error',
+      `Gmail message list fetch error: ${error instanceof Error ? error.message : String(error)}`,
       MessageImportDriverExceptionCode.UNKNOWN,
     );
   }

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-messages-import-error-handler.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-messages-import-error-handler.service.ts
@@ -36,7 +36,7 @@ export class GmailMessagesImportErrorHandler {
     }
 
     throw new MessageImportDriverException(
-      'Unknown error',
+      `Gmail message import error: ${error instanceof Error ? error.message : String(error)}`,
       MessageImportDriverExceptionCode.UNKNOWN,
     );
   }

--- a/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/delay/jobs/resume-delayed-workflow.job.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-executor/workflow-actions/delay/jobs/resume-delayed-workflow.job.ts
@@ -101,7 +101,7 @@ export class ResumeDelayedWorkflowJob {
           error:
             error instanceof Error
               ? error.message
-              : 'Unknown error during delay resume',
+              : `Error during delay resume: ${String(error)}`,
         });
       }
     }, authContext);


### PR DESCRIPTION
## Summary

- Replace all generic `"Unknown error"` fallback messages across the server codebase with messages that include the actual error details
- The most impactful change is in `guard-redirect.service.ts`, which handles OAuth redirect errors — non-`AuthException` errors (e.g., passport state verification failures) now show `"Authentication error: <actual message>"` instead of the opaque `"Unknown error"`
- Gmail/Google error handler services now include the error message in the thrown exception instead of discarding it
- Other catch blocks (workflow delay resume, migration runner rollback, code interpreter, marketplace) now use `String(error)` for non-Error objects instead of a static fallback

Fixes the class of issues reported in https://github.com/twentyhq/twenty/issues/17812, where a user saw "Unknown error" during Google OAuth and had no way to diagnose the root cause (which turned out to be a session cookie / SSL configuration issue).

## Test plan

- [ ] Verify OAuth error flows (e.g., Google Auth with misconfigured callback URL) now display the actual error message on the `/verify` page instead of "Unknown error"
- [ ] Verify Gmail sync error handling still correctly classifies and re-throws errors with descriptive messages
- [ ] Verify workflow delay resume failures include the error details in the workflow run status


Made with [Cursor](https://cursor.com)