### PR TITLE
Use proper PostgreSQL identifier/literal escaping in workspace DDL

### DIFF
--- a/packages/twenty-server/src/engine/twenty-orm/workspace-schema-manager/utils/__tests__/sanitize-default-value.util.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/workspace-schema-manager/utils/__tests__/sanitize-default-value.util.spec.ts
@@ -3,243 +3,147 @@ import { sanitizeDefaultValue } from 'src/engine/twenty-orm/workspace-schema-man
 describe('sanitizeDefaultValue', () => {
   describe('allowed functions', () => {
     it('should allow uuid_generate_v4() function', () => {
-      // Prepare
       const input = 'public.uuid_generate_v4()';
-
-      // Act
       const result = sanitizeDefaultValue(input);
 
-      // Assert
       expect(result).toBe('public.uuid_generate_v4()');
     });
 
     it('should allow now() function', () => {
-      // Prepare
       const input = 'now()';
-
-      // Act
       const result = sanitizeDefaultValue(input);
 
-      // Assert
       expect(result).toBe('now()');
     });
 
     it('should be case insensitive for allowed functions', () => {
-      // Act & Assert
-
       expect(sanitizeDefaultValue('NOW()')).toBe('NOW()');
     });
   });
 
-  describe('SQL injection prevention', () => {
-    it('should sanitize potential SQL injection in string values', () => {
-      // Prepare
+  describe('SQL injection prevention via escapeLiteral', () => {
+    it('should escape single quotes to prevent SQL injection', () => {
       const maliciousInput = "'; DROP TABLE users; --";
-
-      // Act
       const result = sanitizeDefaultValue(maliciousInput);
 
-      // Assert
-      expect(result).not.toContain('DROP TABLE');
-      expect(result).not.toContain(';');
-      expect(result).not.toContain('--');
-      expect(result).toBe("'DROPTABLEusers'");
+      // Single quotes are doubled, making injection impossible
+      expect(result).toBe("'''; DROP TABLE users; --'");
     });
 
-    it('should sanitize quotes in string values', () => {
-      // Prepare
+    it('should preserve double quotes inside string literals (safe in SQL strings)', () => {
       const inputWithQuotes = 'test"value';
-
-      // Act
       const result = sanitizeDefaultValue(inputWithQuotes);
 
-      // Assert
-      expect(result).not.toContain('"');
-      expect(result).toBe("'testvalue'");
+      expect(result).toBe("'test\"value'");
     });
 
-    it('should sanitize parentheses in non-function values', () => {
-      // Prepare
+    it('should preserve parentheses inside string literals (safe in SQL strings)', () => {
       const inputWithParens = 'test(value)';
-
-      // Act
       const result = sanitizeDefaultValue(inputWithParens);
 
-      // Assert
-      expect(result).not.toContain('(');
-      expect(result).not.toContain(')');
-      expect(result).toBe("'testvalue'");
+      expect(result).toBe("'test(value)'");
     });
 
-    it('should sanitize backslashes', () => {
-      // Prepare
+    it('should escape backslashes with E-string syntax', () => {
       const inputWithBackslash = 'test\\value';
-
-      // Act
       const result = sanitizeDefaultValue(inputWithBackslash);
 
-      // Assert
-      expect(result).not.toContain('\\');
-      expect(result).toBe("'testvalue'");
+      expect(result).toBe(" E'test\\\\value'");
     });
 
-    it('should sanitize SQL comment patterns', () => {
-      // Prepare
+    it('should preserve comment-like patterns inside string literals (safe in SQL strings)', () => {
       const inputWithComments = 'value/*comment*/test';
-
-      // Act
       const result = sanitizeDefaultValue(inputWithComments);
 
-      // Assert
-      expect(result).not.toContain('/*');
-      expect(result).not.toContain('*/');
-      expect(result).toBe("'valuecommenttest'");
-    });
-
-    it('should remove non-alphanumeric characters but preserve SQL keywords in alphanumeric form', () => {
-      // Prepare
-      const inputWithKeywords = 'SELECT * FROM users';
-
-      // Act
-      const result = sanitizeDefaultValue(inputWithKeywords);
-
-      // Assert
-      expect(result).toBe("'SELECTFROMusers'");
-      expect(result).not.toContain('*');
-      expect(result).not.toContain(' ');
+      expect(result).toBe("'value/*comment*/test'");
     });
   });
 
   describe('regular values', () => {
-    it('should preserve underscores and alphanumeric characters in simple string values', () => {
-      // Prepare
+    it('should preserve simple string values', () => {
       const input = 'simple_value';
-
-      // Act
       const result = sanitizeDefaultValue(input);
 
-      // Assert
       expect(result).toBe("'simple_value'");
     });
 
     it('should preserve numeric values', () => {
-      // Prepare
-      const input = 12345;
-
-      // Act
-      const result = sanitizeDefaultValue(input);
-
-      // Assert
-      expect(result).toBe(12345);
+      expect(sanitizeDefaultValue(12345)).toBe(12345);
     });
 
     it('should preserve boolean values', () => {
-      // Act & Assert
       expect(sanitizeDefaultValue(true)).toBe(true);
       expect(sanitizeDefaultValue(false)).toBe(false);
     });
 
     it('should handle empty string', () => {
-      // Prepare
-      const input = '';
-
-      // Act
-      const result = sanitizeDefaultValue(input);
-
-      // Assert
-      expect(result).toBe("''");
+      expect(sanitizeDefaultValue('')).toBe("''");
     });
 
-    it('should remove whitespace but preserve alphanumeric and underscores', () => {
-      // Prepare
+    it('should preserve whitespace in string values', () => {
       const input = '  test  ';
-
-      // Act
       const result = sanitizeDefaultValue(input);
 
-      // Assert
-      expect(result).toBe("'test'");
+      expect(result).toBe("'  test  '");
     });
 
     it('should preserve alphanumeric values with underscores', () => {
-      // Prepare
       const input = 'test_value_123';
-
-      // Act
       const result = sanitizeDefaultValue(input);
 
-      // Assert
       expect(result).toBe("'test_value_123'");
     });
   });
 
   describe('mixed cases', () => {
     it('should distinguish between allowed functions and similar strings', () => {
-      // Act & Assert
       expect(sanitizeDefaultValue('now()')).toBe('now()');
       expect(sanitizeDefaultValue('now_test')).toBe("'now_test'");
-      expect(sanitizeDefaultValue('not_now()')).toBe("'not_now'");
+      expect(sanitizeDefaultValue('not_now()')).toBe("'not_now()'");
     });
 
-    it('should handle functions with different casing but sanitize non-functions normally', () => {
-      // Act & Assert
+    it('should handle functions with different casing but escape non-functions', () => {
       expect(sanitizeDefaultValue('NOW()')).toBe('NOW()');
       expect(sanitizeDefaultValue('now_function')).toBe("'now_function'");
     });
 
-    it('should handle complex mixed input', () => {
-      // Prepare
+    it('should properly escape complex mixed input', () => {
       const complexInput = 'test"value; DROP TABLE users; /* comment */ now()';
-
-      // Act
       const result = sanitizeDefaultValue(complexInput);
 
-      // Assert
-      expect(result).toBe("'testvalueDROPTABLEuserscommentnow'");
-      expect(result).not.toContain(';');
-      expect(result).not.toContain('"');
-      expect(result).not.toContain('/*');
-      expect(result).not.toContain('*/');
-      expect(result).not.toContain(' ');
+      expect(result).toBe(
+        "'test\"value; DROP TABLE users; /* comment */ now()'",
+      );
     });
   });
 
   describe('edge cases', () => {
     it('should handle null', () => {
-      // Act & Assert
       expect(sanitizeDefaultValue(null)).toBe('NULL');
     });
 
     it('should handle strings that start with allowed function names', () => {
-      // Act & Assert
       expect(sanitizeDefaultValue('now_extended')).toBe("'now_extended'");
       expect(sanitizeDefaultValue('gen_random_uuid_custom')).toBe(
         "'gen_random_uuid_custom'",
       );
     });
 
-    it('should handle strings with special characters', () => {
-      // Prepare
+    it('should escape all special characters properly', () => {
       const specialChars = '!@#$%^&*()+=[]{}|\\:";\'<>?,.';
-
-      // Act
       const result = sanitizeDefaultValue(specialChars);
 
-      // Assert
-      expect(result).toBe("''");
+      // Backslash triggers E-string, single quotes are doubled
+      expect(result).toContain('E');
+      expect(result).toContain("''");
     });
 
-    it('should handle very long strings', () => {
-      // Prepare
-      const longString = 'a'.repeat(1000) + '; DROP TABLE users;';
-
-      // Act
+    it('should handle very long strings with injection attempts', () => {
+      const longString = 'a'.repeat(1000) + "'; DROP TABLE users;";
       const result = sanitizeDefaultValue(longString);
 
-      // Assert
-      expect(result).toBe(`'${'a'.repeat(1000)}DROPTABLEusers'`);
-      expect(result).not.toContain(';');
-      expect(result).not.toContain(' ');
+      // The single quote in the injection attempt is properly escaped
+      expect(result).toBe(`'${'a'.repeat(1000)}''; DROP TABLE users;'`);
     });
   });
 });

--- a/packages/twenty-server/src/engine/twenty-orm/workspace-schema-manager/utils/__tests__/sanitize-default-value.util.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/workspace-schema-manager/utils/__tests__/sanitize-default-value.util.spec.ts
@@ -48,7 +48,7 @@ describe('sanitizeDefaultValue', () => {
       const inputWithBackslash = 'test\\value';
       const result = sanitizeDefaultValue(inputWithBackslash);
 
-      expect(result).toBe(" E'test\\\\value'");
+      expect(result).toBe("E'test\\\\value'");
     });
 
     it('should preserve comment-like patterns inside string literals (safe in SQL strings)', () => {

--- a/packages/twenty-server/src/engine/twenty-orm/workspace-schema-manager/utils/build-sql-column-definition.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/workspace-schema-manager/utils/build-sql-column-definition.util.ts
@@ -1,19 +1,27 @@
 import { isDefined } from 'twenty-shared/utils';
 
 import { type WorkspaceSchemaColumnDefinition } from 'src/engine/twenty-orm/workspace-schema-manager/types/workspace-schema-column-definition.type';
-import { removeSqlDDLInjection } from 'src/engine/workspace-manager/workspace-migration/utils/remove-sql-injection.util';
+import { escapeIdentifier } from 'src/engine/workspace-manager/workspace-migration/utils/remove-sql-injection.util';
+
+const ALLOWED_GENERATED_TYPES = new Set(['STORED', 'VIRTUAL']);
 
 export const buildSqlColumnDefinition = (
   column: WorkspaceSchemaColumnDefinition,
 ): string => {
-  const safeName = removeSqlDDLInjection(column.name);
-  const parts = [`"${safeName}"`];
+  const parts = [escapeIdentifier(column.name)];
 
+  // column.type is either a PostgreSQL type name from fieldMetadataTypeToColumnType
+  // (safe enum-mapped), or a schema-qualified enum type pre-escaped by the caller.
   parts.push(column.isArray ? `${column.type}[]` : column.type);
 
+  // asExpression is built internally by getTsVectorColumnExpressionFromFields
+  // (never user-provided). Field names within are escaped at the source.
   if (column.asExpression && column.type === 'tsvector') {
-    parts.push(`GENERATED ALWAYS AS (${column.asExpression})`); // TODO: to sanitize
-    if (column.generatedType) {
+    parts.push(`GENERATED ALWAYS AS (${column.asExpression})`);
+    if (
+      column.generatedType &&
+      ALLOWED_GENERATED_TYPES.has(column.generatedType)
+    ) {
       parts.push(column.generatedType);
     }
   }
@@ -26,6 +34,8 @@ export const buildSqlColumnDefinition = (
     parts.push('NOT NULL');
   }
 
+  // column.default is pre-serialized by serializeDefaultValue which
+  // applies escapeLiteral/removeSqlDDLInjection to the value.
   if (isDefined(column.default) && column.type !== 'tsvector') {
     parts.push(`DEFAULT ${column.default}`);
   }

--- a/packages/twenty-server/src/engine/twenty-orm/workspace-schema-manager/utils/sanitize-default-value.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/workspace-schema-manager/utils/sanitize-default-value.util.ts
@@ -1,4 +1,9 @@
-import { removeSqlDDLInjection } from 'src/engine/workspace-manager/workspace-migration/utils/remove-sql-injection.util';
+import { escapeLiteral } from 'src/engine/workspace-manager/workspace-migration/utils/remove-sql-injection.util';
+
+const ALLOWED_DEFAULT_FUNCTIONS = new Set([
+  'public.uuid_generate_v4()',
+  'now()',
+]);
 
 export const sanitizeDefaultValue = (
   defaultValue: string | number | boolean | null,
@@ -7,14 +12,12 @@ export const sanitizeDefaultValue = (
     return 'NULL';
   }
 
-  const allowedFunctions = ['public.uuid_generate_v4()', 'now()'];
-
   if (typeof defaultValue === 'string') {
-    if (allowedFunctions.includes(defaultValue.toLowerCase())) {
+    if (ALLOWED_DEFAULT_FUNCTIONS.has(defaultValue.toLowerCase())) {
       return defaultValue;
     }
 
-    return `'${removeSqlDDLInjection(defaultValue)}'`;
+    return escapeLiteral(defaultValue);
   }
 
   return defaultValue;

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/utils/__tests__/remove-sql-injection.util.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/utils/__tests__/remove-sql-injection.util.spec.ts
@@ -1,0 +1,90 @@
+import {
+  escapeIdentifier,
+  escapeLiteral,
+  removeSqlDDLInjection,
+} from 'src/engine/workspace-manager/workspace-migration/utils/remove-sql-injection.util';
+
+describe('removeSqlDDLInjection', () => {
+  it('should strip non-alphanumeric/underscore characters', () => {
+    expect(removeSqlDDLInjection('my_table')).toBe('my_table');
+    expect(removeSqlDDLInjection('table"name')).toBe('tablename');
+    expect(removeSqlDDLInjection('drop;--')).toBe('drop');
+  });
+});
+
+describe('escapeIdentifier', () => {
+  it('should wrap identifier in double quotes', () => {
+    expect(escapeIdentifier('myTable')).toBe('"myTable"');
+  });
+
+  it('should double internal double-quote characters', () => {
+    expect(escapeIdentifier('my"table')).toBe('"my""table"');
+    expect(escapeIdentifier('a""b')).toBe('"a""""b"');
+  });
+
+  it('should handle empty string', () => {
+    expect(escapeIdentifier('')).toBe('""');
+  });
+
+  it('should handle single-quote characters without modification', () => {
+    expect(escapeIdentifier("it's")).toBe('"it\'s"');
+  });
+
+  it('should reject null bytes', () => {
+    expect(() => escapeIdentifier('my\0table')).toThrow(
+      'Null bytes are not allowed in PostgreSQL identifiers',
+    );
+  });
+
+  it('should handle SQL injection attempts in identifiers', () => {
+    expect(escapeIdentifier('"; DROP TABLE users; --')).toBe(
+      '"""; DROP TABLE users; --"',
+    );
+  });
+});
+
+describe('escapeLiteral', () => {
+  it('should wrap value in single quotes', () => {
+    expect(escapeLiteral('hello')).toBe("'hello'");
+  });
+
+  it('should double internal single-quote characters', () => {
+    expect(escapeLiteral("it's")).toBe("'it''s'");
+    expect(escapeLiteral("a''b")).toBe("'a''''b'");
+  });
+
+  it('should handle empty string', () => {
+    expect(escapeLiteral('')).toBe("''");
+  });
+
+  it('should escape backslashes and add E prefix', () => {
+    expect(escapeLiteral('test\\value')).toBe("E'test\\\\value'");
+  });
+
+  it('should handle both single quotes and backslashes', () => {
+    expect(escapeLiteral("it's a \\path")).toBe(
+      "E'it''s a \\\\path'",
+    );
+  });
+
+  it('should not add E prefix when no backslashes present', () => {
+    expect(escapeLiteral('simple')).toBe("'simple'");
+    expect(escapeLiteral("it's")).toBe("'it''s'");
+  });
+
+  it('should reject null bytes', () => {
+    expect(() => escapeLiteral('my\0value')).toThrow(
+      'Null bytes are not allowed in PostgreSQL string literals',
+    );
+  });
+
+  it('should handle SQL injection attempts in literals', () => {
+    expect(escapeLiteral("'; DROP TABLE users; --")).toBe(
+      "'''; DROP TABLE users; --'",
+    );
+  });
+
+  it('should handle double quotes without modification', () => {
+    expect(escapeLiteral('test"value')).toBe("'test\"value'");
+  });
+});

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/utils/__tests__/remove-sql-injection.util.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/utils/__tests__/remove-sql-injection.util.spec.ts
@@ -62,9 +62,7 @@ describe('escapeLiteral', () => {
   });
 
   it('should handle both single quotes and backslashes', () => {
-    expect(escapeLiteral("it's a \\path")).toBe(
-      "E'it''s a \\\\path'",
-    );
+    expect(escapeLiteral("it's a \\path")).toBe("E'it''s a \\\\path'");
   });
 
   it('should not add E prefix when no backslashes present', () => {

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/utils/__tests__/validate-index-where-clause.util.spec.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/utils/__tests__/validate-index-where-clause.util.spec.ts
@@ -1,0 +1,27 @@
+import { validateAndReturnIndexWhereClause } from 'src/engine/workspace-manager/workspace-migration/utils/validate-index-where-clause.util';
+
+describe('validateAndReturnIndexWhereClause', () => {
+  it('should return undefined for null/undefined/empty input', () => {
+    expect(validateAndReturnIndexWhereClause(null)).toBeUndefined();
+    expect(validateAndReturnIndexWhereClause(undefined)).toBeUndefined();
+    expect(validateAndReturnIndexWhereClause('')).toBeUndefined();
+  });
+
+  it('should return the clause when it is in the allowlist', () => {
+    expect(validateAndReturnIndexWhereClause('"deletedAt" IS NULL')).toBe(
+      '"deletedAt" IS NULL',
+    );
+  });
+
+  it('should throw for clauses not in the allowlist', () => {
+    expect(() =>
+      validateAndReturnIndexWhereClause('1=1; DROP TABLE users;'),
+    ).toThrow('Unsupported index WHERE clause');
+  });
+
+  it('should throw for subtle variants of allowed clauses', () => {
+    expect(() =>
+      validateAndReturnIndexWhereClause('"deletedAt" IS NOT NULL'),
+    ).toThrow('Unsupported index WHERE clause');
+  });
+});

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/utils/remove-sql-injection.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/utils/remove-sql-injection.util.ts
@@ -9,6 +9,10 @@ export const removeSqlDDLInjection = (value: string): string => {
 // doubles any internal double-quote characters.
 // e.g. my"table → "my""table"
 export const escapeIdentifier = (identifier: string): string => {
+  if (identifier.includes('\0')) {
+    throw new Error('Null bytes are not allowed in PostgreSQL identifiers');
+  }
+
   return '"' + identifier.replace(/"/g, '""') + '"';
 };
 
@@ -17,6 +21,10 @@ export const escapeIdentifier = (identifier: string): string => {
 // backslashes are present (standard_conforming_strings safety).
 // e.g. it's → 'it''s'
 export const escapeLiteral = (value: string): string => {
+  if (value.includes('\0')) {
+    throw new Error('Null bytes are not allowed in PostgreSQL string literals');
+  }
+
   let hasBackslash = false;
   let escaped = "'";
 
@@ -34,7 +42,7 @@ export const escapeLiteral = (value: string): string => {
   escaped += "'";
 
   if (hasBackslash) {
-    escaped = ' E' + escaped;
+    escaped = 'E' + escaped;
   }
 
   return escaped;

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/utils/remove-sql-injection.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/utils/remove-sql-injection.util.ts
@@ -1,3 +1,41 @@
+// Strips all characters except [a-zA-Z0-9_].
+// Use ONLY for generating safe identifier names (e.g. enum names from table+column).
+// For SQL escaping, use escapeIdentifier or escapeLiteral instead.
 export const removeSqlDDLInjection = (value: string): string => {
   return value.replace(/[^a-zA-Z0-9_]/g, '');
+};
+
+// PostgreSQL standard identifier quoting: wraps in double quotes and
+// doubles any internal double-quote characters.
+// e.g. my"table → "my""table"
+export const escapeIdentifier = (identifier: string): string => {
+  return '"' + identifier.replace(/"/g, '""') + '"';
+};
+
+// PostgreSQL standard literal quoting: wraps in single quotes and
+// doubles any internal single-quote characters. Prefixes with E when
+// backslashes are present (standard_conforming_strings safety).
+// e.g. it's → 'it''s'
+export const escapeLiteral = (value: string): string => {
+  let hasBackslash = false;
+  let escaped = "'";
+
+  for (const char of value) {
+    if (char === "'") {
+      escaped += "''";
+    } else if (char === '\\') {
+      escaped += '\\\\';
+      hasBackslash = true;
+    } else {
+      escaped += char;
+    }
+  }
+
+  escaped += "'";
+
+  if (hasBackslash) {
+    escaped = ' E' + escaped;
+  }
+
+  return escaped;
 };

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/utils/validate-index-where-clause.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/utils/validate-index-where-clause.util.ts
@@ -1,0 +1,21 @@
+// Allowlist of safe WHERE clause patterns for partial indexes.
+// Any new pattern must be reviewed for SQL injection safety before being added.
+const ALLOWED_INDEX_WHERE_CLAUSES = new Set(['"deletedAt" IS NULL']);
+
+export const validateAndReturnIndexWhereClause = (
+  clause: string | null | undefined,
+): string | undefined => {
+  if (!clause) {
+    return undefined;
+  }
+
+  if (ALLOWED_INDEX_WHERE_CLAUSES.has(clause)) {
+    return clause;
+  }
+
+  throw new Error(
+    `Unsupported index WHERE clause: "${clause}". ` +
+      'Only allowlisted patterns are permitted to prevent SQL injection. ' +
+      'Add the pattern to ALLOWED_INDEX_WHERE_CLAUSES after security review.',
+  );
+};

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/utils/serialize-default-value.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/utils/serialize-default-value.util.ts
@@ -7,7 +7,11 @@ import {
 } from 'src/engine/metadata-modules/field-metadata/field-metadata.exception';
 import { isFunctionDefaultValue } from 'src/engine/metadata-modules/field-metadata/utils/is-function-default-value.util';
 import { serializeFunctionDefaultValue } from 'src/engine/metadata-modules/field-metadata/utils/serialize-function-default-value.util';
-import { removeSqlDDLInjection } from 'src/engine/workspace-manager/workspace-migration/utils/remove-sql-injection.util';
+import {
+  escapeIdentifier,
+  escapeLiteral,
+  removeSqlDDLInjection,
+} from 'src/engine/workspace-manager/workspace-migration/utils/remove-sql-injection.util';
 
 type SerializeDefaultValueArgs = {
   defaultValue?: FieldMetadataDefaultValueForAnyType;
@@ -23,15 +27,10 @@ export const serializeDefaultValue = ({
   tableName,
   columnName,
 }: SerializeDefaultValueArgs) => {
-  const safeSchemaName = removeSqlDDLInjection(schemaName);
-  const safeTableName = removeSqlDDLInjection(tableName);
-  const safeColumnName = removeSqlDDLInjection(columnName);
-
   if (defaultValue === undefined || defaultValue === null) {
     return 'NULL';
   }
 
-  // Function default values
   if (isFunctionDefaultValue(defaultValue)) {
     const serializedTypeDefaultValue =
       serializeFunctionDefaultValue(defaultValue);
@@ -46,13 +45,16 @@ export const serializeDefaultValue = ({
     return serializedTypeDefaultValue;
   }
 
+  // Enum types need a schema-qualified cast; others use the column type directly.
+  // Enum name is built from sanitized table+column (removeSqlDDLInjection strips
+  // to [a-zA-Z0-9_]) to match computePostgresEnumName.
   const castSuffix =
     columnType === 'enum'
-      ? `::${safeSchemaName}."${safeTableName}_${safeColumnName}_enum"`
+      ? `::${escapeIdentifier(schemaName)}.${escapeIdentifier(`${removeSqlDDLInjection(tableName)}_${removeSqlDDLInjection(columnName)}_enum`)}`
       : `::${columnType}`;
 
-  const sanitizeAndAddCastPrefix = (defaultValue: string) =>
-    `'${removeSqlDDLInjection(defaultValue)}'` + castSuffix;
+  const escapeAndCast = (rawValue: string) =>
+    escapeLiteral(rawValue) + castSuffix;
 
   switch (typeof defaultValue) {
     case 'string': {
@@ -63,27 +65,29 @@ export const serializeDefaultValue = ({
         );
       }
 
-      return sanitizeAndAddCastPrefix(defaultValue);
+      // Strip the surrounding single quotes then properly escape the inner value
+      const innerValue = defaultValue.slice(1, -1);
+
+      return escapeAndCast(innerValue);
     }
     case 'boolean':
     case 'number': {
-      return sanitizeAndAddCastPrefix(`${defaultValue}`);
+      return escapeAndCast(`${defaultValue}`);
     }
     case 'object': {
       if (defaultValue instanceof Date) {
-        return sanitizeAndAddCastPrefix(`'${defaultValue.toISOString()}'`);
+        return escapeAndCast(defaultValue.toISOString());
       }
 
       if (Array.isArray(defaultValue)) {
         const arrayValues = defaultValue
-          .map((val) => `'${removeSqlDDLInjection(val)}'`)
+          .map((val) => escapeLiteral(String(val)))
           .join(',');
 
         return `ARRAY[${arrayValues}]${castSuffix}[]`;
       }
 
-      // Default value for objects won't work with sanitization here
-      return sanitizeAndAddCastPrefix(`'${JSON.stringify(defaultValue)}'`);
+      return escapeAndCast(JSON.stringify(defaultValue));
     }
     default: {
       throw new FieldMetadataException(

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/utils/serialize-default-value.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/workspace-migration-builder/utils/serialize-default-value.util.ts
@@ -1,5 +1,5 @@
-import { type ColumnType } from 'typeorm';
 import { type FieldMetadataDefaultValueForAnyType } from 'twenty-shared/types';
+import { type ColumnType } from 'typeorm';
 
 import {
   FieldMetadataException,
@@ -12,6 +12,11 @@ import {
   escapeLiteral,
   removeSqlDDLInjection,
 } from 'src/engine/workspace-manager/workspace-migration/utils/remove-sql-injection.util';
+
+// Default values arrive pre-quoted with single quotes (e.g. "'OPTION_1'").
+// Strip them so escapeLiteral can re-quote properly.
+const stripSurroundingQuotes = (value: string): string =>
+  value.startsWith("'") && value.endsWith("'") ? value.slice(1, -1) : value;
 
 type SerializeDefaultValueArgs = {
   defaultValue?: FieldMetadataDefaultValueForAnyType;
@@ -65,10 +70,7 @@ export const serializeDefaultValue = ({
         );
       }
 
-      // Strip the surrounding single quotes then properly escape the inner value
-      const innerValue = defaultValue.slice(1, -1);
-
-      return escapeAndCast(innerValue);
+      return escapeAndCast(stripSurroundingQuotes(defaultValue));
     }
     case 'boolean':
     case 'number': {
@@ -81,7 +83,7 @@ export const serializeDefaultValue = ({
 
       if (Array.isArray(defaultValue)) {
         const arrayValues = defaultValue
-          .map((val) => escapeLiteral(String(val)))
+          .map((val) => escapeLiteral(stripSurroundingQuotes(String(val))))
           .join(',');
 
         return `ARRAY[${arrayValues}]${castSuffix}[]`;


### PR DESCRIPTION
## Summary

- Replace the character-stripping approach (`removeSqlDDLInjection`) with standard PostgreSQL `escapeIdentifier` and `escapeLiteral` functions across all workspace schema manager services
- Add missing identifier escaping to `createForeignKey` (was the only method in the FK manager without it)
- Add allowlist validation for index WHERE clauses and FK action types
- Harden tsvector expression builder with proper identifier quoting

## Context

The workspace schema managers build DDL dynamically from metadata (table names, column names, enum values, etc.). The previous approach stripped all non-alphanumeric characters — safe but lossy (silently corrupts values with legitimate special characters). The new approach uses PostgreSQL's standard escaping:

- **Identifiers**: double internal `"` and wrap → `"my""table"` (same algorithm as `pg` driver's `escapeIdentifier`)
- **Literals**: double internal `'` and wrap → `'it''s a value'` (same algorithm as `pg` driver's `escapeLiteral`)

`removeSqlDDLInjection` is kept only for name generation (e.g., `computePostgresEnumName`) where stripping to `[a-zA-Z0-9_]` is the correct behavior.

## Files changed

| File | What |
|------|------|
| `remove-sql-injection.util.ts` | Added `escapeIdentifier` + `escapeLiteral` |
| `validate-index-where-clause.util.ts` | New — allowlist for partial index WHERE clauses |
| 5 schema manager services | Replaced strip+manual-quote with `escapeIdentifier`/`escapeLiteral` |
| `build-sql-column-definition.util.ts` | `escapeIdentifier` for column names, validated `generatedType` |
| `sanitize-default-value.util.ts` | `escapeLiteral` instead of stripping |
| `serialize-default-value.util.ts` | `escapeLiteral` for values, `escapeIdentifier` for enum casts |
| `get-ts-vector-column-expression.util.ts` | `escapeIdentifier` for field names in expressions |
| `sanitize-default-value.util.spec.ts` | Updated tests for escape behavior |

## Test plan

- [x] All 64 existing tests pass across 6 test suites
- [x] `lint:diff-with-main` passes
- [x] TypeScript typecheck — no new errors
- [ ] Verify workspace sync-metadata still works end-to-end
- [ ] Verify custom object/field creation works
- [ ] Verify enum field option changes work


Made with [Cursor](https://cursor.com)