### PR TITLE
Fix: add a new style to the target text box

### DIFF
--- a/packages/twenty-front/src/modules/settings/playground/components/RestPlayground.tsx
+++ b/packages/twenty-front/src/modules/settings/playground/components/RestPlayground.tsx
@@ -27,6 +27,12 @@ const StyledContainer = styled.div`
     --scalar-color-2: ${({ theme }) => theme.font.color.secondary};
     --scalar-color-3: ${({ theme }) => theme.font.color.tertiary};
   }
+
+  .scalar-app .text-pretty {
+    overflow-wrap: break-word;
+    word-break: normal;
+    white-space: normal;
+  }
 `;
 
 const ApiReferenceReact = lazy(() =>


### PR DESCRIPTION
### Approach
I add some new rules for the style of the target text box. (Fix: #13229 )
<img width="842" height="545" alt="target class" src="https://github.com/user-attachments/assets/7cd0a615-392a-493b-831f-77ddb93de5fc" />


**This is what it looks like now.**
<img width="320" height="224" alt="image" src="https://github.com/user-attachments/assets/26514102-e684-49ce-915d-43e5677520a5" />
