### PR TITLE
fix: remove the error message for test failure in ci-front

### DIFF
--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -202,14 +202,6 @@ jobs:
         with:
           tag: scope:frontend
           tasks: ${{ matrix.task }}
-      - name: Check for coverage threshold failure
-        if: always() && steps.run-task.outcome == 'failure' && matrix.task == 'test'
-        shell: bash
-        run: |
-          echo "::error::The test task failed. If no individual test is failing, this is likely a coverage threshold not being met."
-          echo ""
-          echo "To debug locally, run: npx nx run twenty-front:test:ci"
-          exit 1
       - name: Save ${{ matrix.task }} cache
         uses: ./.github/actions/save-cache
         with:


### PR DESCRIPTION
Introduced an error message on twenty-front CI earlier to try and inform the user that test failure could be a coverage issue if no individual test was failing. However, it led to the assumption that it must be coverage failure in all cases even when it was test failure leading to the CI being red.

This PR reverts the change.