### PR TITLE
Fix google compose scope not gated by feature flag

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/auth/services/google-apis-scopes.service.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/google-apis-scopes.service.util.spec.ts
@@ -92,8 +92,24 @@ describe('GoogleAPIScopesService', () => {
       expect(result).toBe(false);
     });
 
-    it('should work with the current Google API scopes', () => {
-      // What is currently returned by Google
+    it('should work with the current Google API scopes when draft email is disabled', () => {
+      const actualGoogleScopes = [
+        'https://www.googleapis.com/auth/calendar.events',
+        'https://www.googleapis.com/auth/gmail.readonly',
+        'https://www.googleapis.com/auth/gmail.send',
+        'https://www.googleapis.com/auth/profile.emails.read',
+        'https://www.googleapis.com/auth/userinfo.email',
+        'https://www.googleapis.com/auth/userinfo.profile',
+        'openid',
+      ];
+      const expectedScopes = getGoogleApisOauthScopes(false);
+
+      const result = includesExpectedScopes(actualGoogleScopes, expectedScopes);
+
+      expect(result).toBe(true);
+    });
+
+    it('should work with the current Google API scopes when draft email is enabled', () => {
       const actualGoogleScopes = [
         'https://www.googleapis.com/auth/calendar.events',
         'https://www.googleapis.com/auth/gmail.readonly',
@@ -104,7 +120,7 @@ describe('GoogleAPIScopesService', () => {
         'https://www.googleapis.com/auth/userinfo.profile',
         'openid',
       ];
-      const expectedScopes = getGoogleApisOauthScopes();
+      const expectedScopes = getGoogleApisOauthScopes(true);
 
       const result = includesExpectedScopes(actualGoogleScopes, expectedScopes);
 

--- a/packages/twenty-server/src/engine/core-modules/auth/services/google-apis-scopes.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/google-apis-scopes.ts
@@ -30,6 +30,7 @@ export class GoogleAPIScopesService {
 
   public async getScopesFromGoogleAccessTokenAndCheckIfExpectedScopesArePresent(
     accessToken: string,
+    isDraftEmailEnabled = false,
   ): Promise<{ scopes: string[]; isValid: boolean }> {
     try {
       const httpClient = this.secureHttpClientService.getHttpClient();
@@ -40,7 +41,7 @@ export class GoogleAPIScopesService {
       );
 
       const scopes = response.data.scope.split(' ');
-      const expectedScopes = getGoogleApisOauthScopes();
+      const expectedScopes = getGoogleApisOauthScopes(isDraftEmailEnabled);
 
       return {
         scopes,

--- a/packages/twenty-server/src/engine/core-modules/auth/services/google-apis.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/google-apis.service.spec.ts
@@ -10,6 +10,7 @@ import { GoogleAPIScopesService } from 'src/engine/core-modules/auth/services/go
 import { GoogleApisServiceAvailabilityService } from 'src/engine/core-modules/auth/services/google-apis-service-availability.service';
 import { GoogleAPIsService } from 'src/engine/core-modules/auth/services/google-apis.service';
 import { UpdateConnectedAccountOnReconnectService } from 'src/engine/core-modules/auth/services/update-connected-account-on-reconnect.service';
+import { FeatureFlagService } from 'src/engine/core-modules/feature-flag/services/feature-flag.service';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
 import { getQueueToken } from 'src/engine/core-modules/message-queue/utils/get-queue-token.util';
 import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
@@ -180,6 +181,12 @@ describe('GoogleAPIsService', () => {
         {
           provide: getQueueToken(MessageQueue.calendarQueue),
           useValue: mockCalendarQueueService,
+        },
+        {
+          provide: FeatureFlagService,
+          useValue: {
+            isFeatureEnabled: jest.fn().mockResolvedValue(false),
+          },
         },
       ],
     }).compile();

--- a/packages/twenty-server/src/engine/core-modules/auth/services/google-apis.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/google-apis.service.ts
@@ -13,6 +13,8 @@ import { CreateMessageChannelService } from 'src/engine/core-modules/auth/servic
 import { GoogleAPIScopesService } from 'src/engine/core-modules/auth/services/google-apis-scopes';
 import { GoogleApisServiceAvailabilityService } from 'src/engine/core-modules/auth/services/google-apis-service-availability.service';
 import { UpdateConnectedAccountOnReconnectService } from 'src/engine/core-modules/auth/services/update-connected-account-on-reconnect.service';
+import { FeatureFlagKey } from 'src/engine/core-modules/feature-flag/enums/feature-flag-key.enum';
+import { FeatureFlagService } from 'src/engine/core-modules/feature-flag/services/feature-flag.service';
 import { InjectMessageQueue } from 'src/engine/core-modules/message-queue/decorators/message-queue.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
 import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
@@ -63,6 +65,7 @@ export class GoogleAPIsService {
     private readonly updateConnectedAccountOnReconnectService: UpdateConnectedAccountOnReconnectService,
     private readonly googleAPIScopesService: GoogleAPIScopesService,
     private readonly googleApisServiceAvailabilityService: GoogleApisServiceAvailabilityService,
+    private readonly featureFlagService: FeatureFlagService,
   ) {}
 
   async refreshGoogleRefreshToken(input: {
@@ -92,9 +95,15 @@ export class GoogleAPIsService {
       'MESSAGING_PROVIDER_GMAIL_ENABLED',
     );
 
+    const isDraftEmailEnabled = await this.featureFlagService.isFeatureEnabled(
+      FeatureFlagKey.IS_DRAFT_EMAIL_ENABLED,
+      workspaceId,
+    );
+
     const { scopes, isValid } =
       await this.googleAPIScopesService.getScopesFromGoogleAccessTokenAndCheckIfExpectedScopesArePresent(
         input.accessToken,
+        isDraftEmailEnabled,
       );
 
     if (!isValid) {

--- a/packages/twenty-server/src/engine/core-modules/auth/strategies/google-apis-oauth-common.auth.strategy.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/strategies/google-apis-oauth-common.auth.strategy.ts
@@ -14,8 +14,11 @@ export abstract class GoogleAPIsOauthCommonStrategy extends PassportStrategy(
   Strategy,
   'google-apis',
 ) {
-  constructor(twentyConfigService: TwentyConfigService) {
-    const scopes = getGoogleApisOauthScopes();
+  constructor(
+    twentyConfigService: TwentyConfigService,
+    isDraftEmailEnabled = false,
+  ) {
+    const scopes = getGoogleApisOauthScopes(isDraftEmailEnabled);
 
     super({
       clientID: twentyConfigService.get('AUTH_GOOGLE_CLIENT_ID'),

--- a/packages/twenty-server/src/engine/core-modules/auth/strategies/google-apis-oauth-exchange-code-for-token.auth.strategy.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/strategies/google-apis-oauth-exchange-code-for-token.auth.strategy.ts
@@ -12,8 +12,11 @@ export type GoogleAPIScopeConfig = {
 
 @Injectable()
 export class GoogleAPIsOauthExchangeCodeForTokenStrategy extends GoogleAPIsOauthCommonStrategy {
-  constructor(twentyConfigService: TwentyConfigService) {
-    super(twentyConfigService);
+  constructor(
+    twentyConfigService: TwentyConfigService,
+    isDraftEmailEnabled = false,
+  ) {
+    super(twentyConfigService, isDraftEmailEnabled);
   }
 
   async validate(

--- a/packages/twenty-server/src/engine/core-modules/auth/strategies/google-apis-oauth-request-code.auth.strategy.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/strategies/google-apis-oauth-request-code.auth.strategy.ts
@@ -12,8 +12,11 @@ export type GoogleAPIScopeConfig = {
 
 @Injectable()
 export class GoogleAPIsOauthRequestCodeStrategy extends GoogleAPIsOauthCommonStrategy {
-  constructor(twentyConfigService: TwentyConfigService) {
-    super(twentyConfigService);
+  constructor(
+    twentyConfigService: TwentyConfigService,
+    isDraftEmailEnabled = false,
+  ) {
+    super(twentyConfigService, isDraftEmailEnabled);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/twenty-server/src/engine/core-modules/auth/utils/get-google-apis-oauth-scopes.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/utils/get-google-apis-oauth-scopes.ts
@@ -1,7 +1,7 @@
 /** email, profile and openid permission can be called without the https://www.googleapis.com/auth/ prefix
  * see https://developers.google.com/identity/protocols/oauth2/scopes
  */
-export const getGoogleApisOauthScopes = () => {
+export const getGoogleApisOauthScopes = (isDraftEmailEnabled = false) => {
   return [
     'email',
     'profile',
@@ -9,6 +9,8 @@ export const getGoogleApisOauthScopes = () => {
     'https://www.googleapis.com/auth/calendar.events',
     'https://www.googleapis.com/auth/profile.emails.read',
     'https://www.googleapis.com/auth/gmail.send',
-    'https://www.googleapis.com/auth/gmail.compose',
+    ...(isDraftEmailEnabled
+      ? ['https://www.googleapis.com/auth/gmail.compose']
+      : []),
   ];
 };


### PR DESCRIPTION
## Context
New google api scope has been introduced in https://github.com/twentyhq/twenty/pull/17793 without being gated behind a feature flag

Microsoft is using pre-existing Mail.ReadWrite scope there is nothing to gate

## Before
<img width="553" height="445" alt="Screenshot 2026-02-19 at 14 57 58" src="https://github.com/user-attachments/assets/59a4f76b-d38d-492f-b013-b6cad4091a7f" />


## After
<img width="535" height="392" alt="Screenshot 2026-02-19 at 14 58 44" src="https://github.com/user-attachments/assets/0337bf15-ec30-4549-bb9d-571a982dffd8" />
