### PR TITLE
Continue Jotai migration

### DIFF
--- a/packages/twenty-front/src/hooks/usePageChangeEffectNavigateLocation.ts
+++ b/packages/twenty-front/src/hooks/usePageChangeEffectNavigateLocation.ts
@@ -5,6 +5,7 @@ import { useIsCurrentLocationOnAWorkspace } from '@/domain-manager/hooks/useIsCu
 import { useDefaultHomePagePath } from '@/navigation/hooks/useDefaultHomePagePath';
 import { objectMetadataItemsState } from '@/object-metadata/states/objectMetadataItemsState';
 import { useOnboardingStatus } from '@/onboarding/hooks/useOnboardingStatus';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { useIsWorkspaceActivationStatusEqualsTo } from '@/workspace/hooks/useIsWorkspaceActivationStatusEqualsTo';
 import { useLocation, useParams } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
@@ -49,7 +50,9 @@ export const usePageChangeEffectNavigateLocation = () => {
   const objectMetadataItem = objectMetadataItems?.find(
     (objectMetadataItem) => objectMetadataItem.namePlural === objectNamePlural,
   );
-  const verifyEmailRedirectPath = useRecoilValue(verifyEmailRedirectPathState);
+  const verifyEmailRedirectPath = useRecoilValueV2(
+    verifyEmailRedirectPathState,
+  );
 
   if (
     (!isLoggedIn || (isLoggedIn && !isOnAWorkspace)) &&

--- a/packages/twenty-front/src/modules/action-menu/hooks/useShouldActionBeRegisteredParams.ts
+++ b/packages/twenty-front/src/modules/action-menu/hooks/useShouldActionBeRegisteredParams.ts
@@ -17,6 +17,7 @@ import { hasAnySoftDeleteFilterOnViewComponentSelector } from '@/object-record/r
 import { recordStoreFamilyState } from '@/object-record/record-store/states/recordStoreFamilyState';
 import { useRecoilComponentValue } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValue';
 import { useIsFeatureEnabled } from '@/workspace/hooks/useIsFeatureEnabled';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { useContext, useMemo } from 'react';
 import { useRecoilCallback, useRecoilValue } from 'recoil';
 import { isDefined } from 'twenty-shared/utils';
@@ -136,7 +137,7 @@ export const useShouldActionBeRegisteredParams = ({
     forceRegisteredActionsByKeyState,
   );
 
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
 
   const isFeatureFlagEnabled = (featureFlagKey: FeatureFlagKey) => {
     const featureFlag = currentWorkspace?.featureFlags?.find(

--- a/packages/twenty-front/src/modules/activities/calendar/components/CalendarEventRow.tsx
+++ b/packages/twenty-front/src/modules/activities/calendar/components/CalendarEventRow.tsx
@@ -2,7 +2,7 @@ import { css, useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { t } from '@lingui/core/macro';
 import { format } from 'date-fns';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import {
   CalendarChannelVisibility,
   type TimelineCalendarEvent,
@@ -85,7 +85,7 @@ export const CalendarEventRow = ({
   className,
 }: CalendarEventRowProps) => {
   const theme = useTheme();
-  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+  const currentWorkspaceMember = useRecoilValueV2(currentWorkspaceMemberState);
   const { openCalendarEventInCommandMenu } =
     useOpenCalendarEventInCommandMenu();
 

--- a/packages/twenty-front/src/modules/activities/hooks/__tests__/useActivityTargetObjectRecords.test.tsx
+++ b/packages/twenty-front/src/modules/activities/hooks/__tests__/useActivityTargetObjectRecords.test.tsx
@@ -2,12 +2,14 @@ import { gql, InMemoryCache } from '@apollo/client';
 import { MockedProvider } from '@apollo/client/testing';
 import { act, renderHook } from '@testing-library/react';
 import { type ReactNode } from 'react';
+import { Provider as JotaiProvider } from 'jotai';
 import { RecoilRoot, useSetRecoilState } from 'recoil';
 
 import { useActivityTargetObjectRecords } from '@/activities/hooks/useActivityTargetObjectRecords';
 import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
 import { objectMetadataItemsState } from '@/object-metadata/states/objectMetadataItemsState';
 import { recordStoreFamilyState } from '@/object-record/record-store/states/recordStoreFamilyState';
+import { jotaiStore } from '@/ui/utilities/state/jotai/jotaiStore';
 import { SnackBarComponentInstanceContext } from '@/ui/feedback/snack-bar-manager/contexts/SnackBarComponentInstanceContext';
 import { JestObjectMetadataItemSetter } from '~/testing/jest/JestObjectMetadataItemSetter';
 import { mockWorkspaceMembers } from '~/testing/mock-data/workspace-members';
@@ -111,26 +113,27 @@ const task = {
 };
 
 const Wrapper = ({ children }: { children: ReactNode }) => (
-  <RecoilRoot>
-    <MockedProvider cache={cache}>
-      <JestObjectMetadataItemSetter>
-        <SnackBarComponentInstanceContext.Provider
-          value={{ instanceId: 'snack-bar-manager' }}
-        >
-          {children}
-        </SnackBarComponentInstanceContext.Provider>
-      </JestObjectMetadataItemSetter>
-    </MockedProvider>
-  </RecoilRoot>
+  <JotaiProvider store={jotaiStore}>
+    <RecoilRoot>
+      <MockedProvider cache={cache}>
+        <JestObjectMetadataItemSetter>
+          <SnackBarComponentInstanceContext.Provider
+            value={{ instanceId: 'snack-bar-manager' }}
+          >
+            {children}
+          </SnackBarComponentInstanceContext.Provider>
+        </JestObjectMetadataItemSetter>
+      </MockedProvider>
+    </RecoilRoot>
+  </JotaiProvider>
 );
 
 describe('useActivityTargetObjectRecords', () => {
   it('return targetObjects', async () => {
+    jotaiStore.set(currentWorkspaceMemberState.atom, mockWorkspaceMembers[0]);
+
     const { result } = renderHook(
       () => {
-        const setCurrentWorkspaceMember = useSetRecoilState(
-          currentWorkspaceMemberState,
-        );
         const setObjectMetadataItems = useSetRecoilState(
           objectMetadataItemsState,
         );
@@ -145,7 +148,6 @@ describe('useActivityTargetObjectRecords', () => {
 
         return {
           activityTargetObjectRecords,
-          setCurrentWorkspaceMember,
           setObjectMetadataItems,
           setRecordFromStore,
         };
@@ -154,7 +156,6 @@ describe('useActivityTargetObjectRecords', () => {
     );
 
     act(() => {
-      result.current.setCurrentWorkspaceMember(mockWorkspaceMembers[0]);
       result.current.setObjectMetadataItems(generatedMockObjectMetadataItems);
       result.current.setRecordFromStore(task);
     });

--- a/packages/twenty-front/src/modules/activities/timeline-activities/components/EventRow.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/components/EventRow.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { useContext } from 'react';
 import { useRecoilValue } from 'recoil';
 
@@ -92,7 +93,7 @@ export const EventRow = ({
   event,
   mainObjectMetadataItem,
 }: EventRowProps) => {
-  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+  const currentWorkspaceMember = useRecoilValueV2(currentWorkspaceMemberState);
 
   const allowRequestsToTwentyIcons = useRecoilValue(
     allowRequestsToTwentyIconsState,

--- a/packages/twenty-front/src/modules/ai/components/AIChatTab.tsx
+++ b/packages/twenty-front/src/modules/ai/components/AIChatTab.tsx
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled';
 import { EditorContent } from '@tiptap/react';
 import { useState } from 'react';
-import { useRecoilValue } from 'recoil';
 import { LightButton } from 'twenty-ui/input';
 
 import { DropZone } from '@/activities/files/components/DropZone';
@@ -23,6 +22,7 @@ import { useAIChatFileUpload } from '@/ai/hooks/useAIChatFileUpload';
 import { useAgentChatContextOrThrow } from '@/ai/hooks/useAgentChatContextOrThrow';
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { useIsMobile } from '@/ui/utilities/responsive/hooks/useIsMobile';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 
 const StyledContainer = styled.div<{ isDraggingFile: boolean }>`
   background: ${({ theme }) => theme.background.primary};
@@ -144,7 +144,7 @@ export const AIChatTab = () => {
   const hasMessages = messages.length > 0;
 
   const { uploadFiles } = useAIChatFileUpload();
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
   const smartModelLabel = useAiModelLabel(currentWorkspace?.smartModel, false);
 
   const { editor, handleSendAndClear } = useAIChatEditor({

--- a/packages/twenty-front/src/modules/ai/hooks/useAgentChat.ts
+++ b/packages/twenty-front/src/modules/ai/hooks/useAgentChat.ts
@@ -1,5 +1,3 @@
-import { useSetRecoilState } from 'recoil';
-
 import { useGetBrowsingContext } from '@/ai/hooks/useBrowsingContext';
 import { agentChatSelectedFilesStateV2 } from '@/ai/states/agentChatSelectedFilesStateV2';
 import { agentChatUploadedFilesStateV2 } from '@/ai/states/agentChatUploadedFilesStateV2';
@@ -23,7 +21,7 @@ import { REACT_APP_SERVER_BASE_URL } from '~/config';
 import { cookieStorage } from '~/utils/cookie-storage';
 
 export const useAgentChat = (uiMessages: ExtendedUIMessage[]) => {
-  const setTokenPair = useSetRecoilState(tokenPairState);
+  const setTokenPair = useSetRecoilStateV2(tokenPairState);
   const setAgentChatUsage = useSetRecoilStateV2(agentChatUsageStateV2);
 
   const { getBrowsingContext } = useGetBrowsingContext();

--- a/packages/twenty-front/src/modules/apollo/hooks/useApolloFactory.ts
+++ b/packages/twenty-front/src/modules/apollo/hooks/useApolloFactory.ts
@@ -1,41 +1,42 @@
 import { InMemoryCache, type NormalizedCacheObject } from '@apollo/client';
 import { useMemo, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { useRecoilState, useSetRecoilState } from 'recoil';
 
+import { ApolloFactory, type Options } from '@/apollo/services/apollo.factory';
 import { currentUserState } from '@/auth/states/currentUserState';
+import { currentUserWorkspaceState } from '@/auth/states/currentUserWorkspaceState';
 import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { previousUrlState } from '@/auth/states/previousUrlState';
 import { tokenPairState } from '@/auth/states/tokenPairState';
+import { appVersionState } from '@/client-config/states/appVersionState';
+import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
+import { useRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilStateV2';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
+import { useSetRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useSetRecoilStateV2';
+import { AppPath } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
 import { REACT_APP_SERVER_BASE_URL } from '~/config';
 import { useUpdateEffect } from '~/hooks/useUpdateEffect';
 import { isMatchingLocation } from '~/utils/isMatchingLocation';
-
-import { ApolloFactory, type Options } from '@/apollo/services/apollo.factory';
-import { currentUserWorkspaceState } from '@/auth/states/currentUserWorkspaceState';
-import { appVersionState } from '@/client-config/states/appVersionState';
-import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
-import { AppPath } from 'twenty-shared/types';
-import { isDefined } from 'twenty-shared/utils';
-import { useSetRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useSetRecoilStateV2';
-import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 
 export const useApolloFactory = (options: Partial<Options<any>> = {}) => {
   // eslint-disable-next-line twenty/no-state-useref
   const apolloRef = useRef<ApolloFactory<NormalizedCacheObject> | null>(null);
 
   const navigate = useNavigate();
-  const setTokenPair = useSetRecoilState(tokenPairState);
-  const [currentWorkspace, setCurrentWorkspace] = useRecoilState(
+  const setTokenPair = useSetRecoilStateV2(tokenPairState);
+  const [currentWorkspace, setCurrentWorkspace] = useRecoilStateV2(
     currentWorkspaceState,
   );
   const appVersion = useRecoilValueV2(appVersionState);
-  const [currentWorkspaceMember, setCurrentWorkspaceMember] = useRecoilState(
+  const [currentWorkspaceMember, setCurrentWorkspaceMember] = useRecoilStateV2(
     currentWorkspaceMemberState,
   );
-  const setCurrentUser = useSetRecoilState(currentUserState);
-  const setCurrentUserWorkspace = useSetRecoilState(currentUserWorkspaceState);
+  const setCurrentUser = useSetRecoilStateV2(currentUserState);
+  const setCurrentUserWorkspace = useSetRecoilStateV2(
+    currentUserWorkspaceState,
+  );
 
   const setPreviousUrl = useSetRecoilStateV2(previousUrlState);
   const location = useLocation();

--- a/packages/twenty-front/src/modules/app/components/AppRouter.tsx
+++ b/packages/twenty-front/src/modules/app/components/AppRouter.tsx
@@ -1,13 +1,13 @@
 import { useCreateAppRouter } from '@/app/hooks/useCreateAppRouter';
 import { currentUserState } from '@/auth/states/currentUserState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { RouterProvider } from 'react-router-dom';
-import { useRecoilValue } from 'recoil';
 
 export const AppRouter = () => {
   // We want to disable logic function settings but keep the code for now
   const isFunctionSettingsEnabled = false;
 
-  const currentUser = useRecoilValue(currentUserState);
+  const currentUser = useRecoilValueV2(currentUserState);
 
   const isAdminPageEnabled =
     (currentUser?.canImpersonate || currentUser?.canAccessFullAdminPanel) ??

--- a/packages/twenty-front/src/modules/app/effect-components/PageChangeEffect.tsx
+++ b/packages/twenty-front/src/modules/app/effect-components/PageChangeEffect.tsx
@@ -1,12 +1,3 @@
-import { useEffect, useState } from 'react';
-import {
-  matchPath,
-  useLocation,
-  useNavigate,
-  useParams,
-} from 'react-router-dom';
-import { useRecoilCallback, useRecoilValue } from 'recoil';
-
 import {
   setSessionId,
   useEventTracker,
@@ -15,6 +6,15 @@ import { useExecuteTasksOnAnyLocationChange } from '@/app/hooks/useExecuteTasksO
 import { isAppEffectRedirectEnabledState } from '@/app/states/isAppEffectRedirectEnabledState';
 import { useRequestFreshCaptchaToken } from '@/captcha/hooks/useRequestFreshCaptchaToken';
 import { isCaptchaScriptLoadedState } from '@/captcha/states/isCaptchaScriptLoadedState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
+import { useEffect, useState } from 'react';
+import {
+  matchPath,
+  useLocation,
+  useNavigate,
+  useParams,
+} from 'react-router-dom';
+import { useRecoilCallback } from 'recoil';
 import { isCaptchaRequiredForPath } from '@/captcha/utils/isCaptchaRequiredForPath';
 import { useCommandMenu } from '@/command-menu/hooks/useCommandMenu';
 import { commandMenuPageState } from '@/command-menu/states/commandMenuPageState';
@@ -93,7 +93,7 @@ export const PageChangeEffect = () => {
   const { executeTasksOnAnyLocationChange } =
     useExecuteTasksOnAnyLocationChange();
 
-  const isAppEffectRedirectEnabled = useRecoilValue(
+  const isAppEffectRedirectEnabled = useRecoilValueV2(
     isAppEffectRedirectEnabledState,
   );
 
@@ -366,7 +366,7 @@ export const PageChangeEffect = () => {
   }, [eventTracker, location.pathname]);
 
   const { requestFreshCaptchaToken } = useRequestFreshCaptchaToken();
-  const isCaptchaScriptLoaded = useRecoilValue(isCaptchaScriptLoadedState);
+  const isCaptchaScriptLoaded = useRecoilValueV2(isCaptchaScriptLoadedState);
 
   useEffect(() => {
     if (isCaptchaScriptLoaded && isCaptchaRequiredForPath(location.pathname)) {

--- a/packages/twenty-front/src/modules/app/hooks/useInitializeQueryParamState.ts
+++ b/packages/twenty-front/src/modules/app/hooks/useInitializeQueryParamState.ts
@@ -1,63 +1,60 @@
-import { useRecoilCallback } from 'recoil';
+import { useCallback } from 'react';
 
 import { billingCheckoutSessionState } from '@/auth/states/billingCheckoutSessionState';
 import { type BillingCheckoutSession } from '@/auth/types/billingCheckoutSession.type';
 import { BILLING_CHECKOUT_SESSION_DEFAULT_VALUE } from '@/billing/constants/BillingCheckoutSessionDefaultValue';
+import { jotaiStore } from '@/ui/utilities/state/jotai/jotaiStore';
 import deepEqual from 'deep-equal';
 
 // Initialize state that are hydrated from query parameters
 // We used to use recoil-sync to do this, but it was causing issues with Firefox
 export const useInitializeQueryParamState = () => {
-  const initializeQueryParamState = useRecoilCallback(
-    ({ set, snapshot }) =>
-      () => {
-        const handlers = {
-          billingCheckoutSession: (value: string) => {
-            const billingCheckoutSession = snapshot
-              .getLoadable(billingCheckoutSessionState)
-              .getValue();
+  const initializeQueryParamState = useCallback(() => {
+    const handlers = {
+      billingCheckoutSession: (value: string) => {
+        const billingCheckoutSession = jotaiStore.get(
+          billingCheckoutSessionState.atom,
+        );
 
-            try {
-              const parsedValue = JSON.parse(decodeURIComponent(value));
+        try {
+          const parsedValue = JSON.parse(decodeURIComponent(value));
 
-              if (
-                typeof parsedValue === 'object' &&
-                parsedValue !== null &&
-                'plan' in parsedValue &&
-                'interval' in parsedValue &&
-                'requirePaymentMethod' in parsedValue &&
-                !deepEqual(billingCheckoutSession, parsedValue)
-              ) {
-                set(
-                  billingCheckoutSessionState,
-                  parsedValue as BillingCheckoutSession,
-                );
-              }
-            } catch (error) {
-              // eslint-disable-next-line no-console
-              console.error(
-                'Failed to parse billingCheckoutSession from URL',
-                error,
-              );
-              set(
-                billingCheckoutSessionState,
-                BILLING_CHECKOUT_SESSION_DEFAULT_VALUE,
-              );
-            }
-          },
-        };
-
-        const queryParams = new URLSearchParams(window.location.search);
-
-        for (const [paramName, handler] of Object.entries(handlers)) {
-          const value = queryParams.get(paramName);
-          if (value !== null) {
-            handler(value);
+          if (
+            typeof parsedValue === 'object' &&
+            parsedValue !== null &&
+            'plan' in parsedValue &&
+            'interval' in parsedValue &&
+            'requirePaymentMethod' in parsedValue &&
+            !deepEqual(billingCheckoutSession, parsedValue)
+          ) {
+            jotaiStore.set(
+              billingCheckoutSessionState.atom,
+              parsedValue as BillingCheckoutSession,
+            );
           }
+        } catch (error) {
+          // eslint-disable-next-line no-console
+          console.error(
+            'Failed to parse billingCheckoutSession from URL',
+            error,
+          );
+          jotaiStore.set(
+            billingCheckoutSessionState.atom,
+            BILLING_CHECKOUT_SESSION_DEFAULT_VALUE,
+          );
         }
       },
-    [],
-  );
+    };
+
+    const queryParams = new URLSearchParams(window.location.search);
+
+    for (const [paramName, handler] of Object.entries(handlers)) {
+      const value = queryParams.get(paramName);
+      if (value !== null) {
+        handler(value);
+      }
+    }
+  }, []);
 
   return { initializeQueryParamState };
 };

--- a/packages/twenty-front/src/modules/app/states/isAppEffectRedirectEnabledState.ts
+++ b/packages/twenty-front/src/modules/app/states/isAppEffectRedirectEnabledState.ts
@@ -1,5 +1,5 @@
-import { createState } from '@/ui/utilities/state/utils/createState';
-export const isAppEffectRedirectEnabledState = createState<boolean>({
+import { createStateV2 } from '@/ui/utilities/state/jotai/utils/createStateV2';
+export const isAppEffectRedirectEnabledState = createStateV2<boolean>({
   key: 'isAppEffectRedirectEnabledState',
   defaultValue: true,
 });

--- a/packages/twenty-front/src/modules/app/states/verifyEmailRedirectPathState.ts
+++ b/packages/twenty-front/src/modules/app/states/verifyEmailRedirectPathState.ts
@@ -1,6 +1,6 @@
-import { createState } from '@/ui/utilities/state/utils/createState';
+import { createStateV2 } from '@/ui/utilities/state/jotai/utils/createStateV2';
 
-export const verifyEmailRedirectPathState = createState<string | undefined>({
+export const verifyEmailRedirectPathState = createStateV2<string | undefined>({
   key: 'verifyEmailRedirectPathState',
   defaultValue: undefined,
 });

--- a/packages/twenty-front/src/modules/auth/components/AuthProvider.tsx
+++ b/packages/twenty-front/src/modules/auth/components/AuthProvider.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
-import { useRecoilValue } from 'recoil';
 
 import { AuthContext } from '@/auth/contexts/AuthContext';
 import { currentWorkspaceDeletedMembersState } from '@/auth/states/currentWorkspaceDeletedMembersState';
 import { currentWorkspaceMembersState } from '@/auth/states/currentWorkspaceMembersState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 
 export const AuthProvider = ({ children }: React.PropsWithChildren) => {
-  const currentWorkspaceMembers = useRecoilValue(currentWorkspaceMembersState);
-  const currentWorkspaceDeletedMembers = useRecoilValue(
+  const currentWorkspaceMembers = useRecoilValueV2(
+    currentWorkspaceMembersState,
+  );
+  const currentWorkspaceDeletedMembers = useRecoilValueV2(
     currentWorkspaceDeletedMembersState,
   );
 

--- a/packages/twenty-front/src/modules/auth/components/TwoFactorAuthenticationProvisionEffect.tsx
+++ b/packages/twenty-front/src/modules/auth/components/TwoFactorAuthenticationProvisionEffect.tsx
@@ -5,7 +5,6 @@ import { useCurrentUserWorkspaceTwoFactorAuthentication } from '@/settings/two-f
 import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { useLingui } from '@lingui/react/macro';
 import { useEffect } from 'react';
-import { useRecoilValue } from 'recoil';
 import { useSetRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useSetRecoilStateV2';
 import { AppPath } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
@@ -19,7 +18,7 @@ export const TwoFactorAuthenticationSetupEffect = () => {
 
   const navigate = useNavigateApp();
   const { origin } = useOrigin();
-  const loginToken = useRecoilValue(loginTokenState);
+  const loginToken = useRecoilValueV2(loginTokenState);
   const qrCode = useRecoilValueV2(qrCodeState);
   const setQrCodeState = useSetRecoilStateV2(qrCodeState);
 

--- a/packages/twenty-front/src/modules/auth/components/VerifyEmailEffect.tsx
+++ b/packages/twenty-front/src/modules/auth/components/VerifyEmailEffect.tsx
@@ -12,11 +12,12 @@ import { Modal } from '@/ui/layout/modal/components/Modal';
 import { useLingui } from '@lingui/react/macro';
 import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilValue } from 'recoil';
 import { isDefined } from 'twenty-shared/utils';
 import { useNavigateApp } from '~/hooks/useNavigateApp';
 import { getWorkspaceUrl } from '~/utils/getWorkspaceUrl';
 import { EmailVerificationSent } from '@/auth/sign-in-up/components/EmailVerificationSent';
+import { useSetRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useSetRecoilStateV2';
 
 export const VerifyEmailEffect = () => {
   const {
@@ -29,7 +30,7 @@ export const VerifyEmailEffect = () => {
   const [searchParams] = useSearchParams();
   const [isError, setIsError] = useState(false);
 
-  const setVerifyEmailRedirectPath = useSetRecoilState(
+  const setVerifyEmailRedirectPath = useSetRecoilStateV2(
     verifyEmailRedirectPathState,
   );
 

--- a/packages/twenty-front/src/modules/auth/hooks/__tests__/useAuth.test.tsx
+++ b/packages/twenty-front/src/modules/auth/hooks/__tests__/useAuth.test.tsx
@@ -4,6 +4,7 @@ import { isDeveloperDefaultSignInPrefilledState } from '@/client-config/states/i
 import { supportChatState } from '@/client-config/states/supportChatState';
 
 import { workspaceAuthProvidersState } from '@/workspace/states/workspaceAuthProvidersState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { useApolloClient } from '@apollo/client';
 import { MockedProvider } from '@apollo/client/testing';
 import { type ReactNode, act } from 'react';
@@ -158,7 +159,7 @@ describe('useAuth', () => {
     const { result } = renderHook(
       () => {
         const client = useApolloClient();
-        const workspaceAuthProviders = useRecoilValue(
+        const workspaceAuthProviders = useRecoilValueV2(
           workspaceAuthProvidersState,
         );
         const billing = useRecoilValue(billingState);

--- a/packages/twenty-front/src/modules/auth/hooks/__tests__/useIsLogged.test.ts
+++ b/packages/twenty-front/src/modules/auth/hooks/__tests__/useIsLogged.test.ts
@@ -1,14 +1,15 @@
 import { act, renderHook } from '@testing-library/react';
-import { RecoilRoot, useSetRecoilState } from 'recoil';
+import { RecoilRoot } from 'recoil';
 
 import { useIsLogged } from '@/auth/hooks/useIsLogged';
 import { tokenPairState } from '@/auth/states/tokenPairState';
+import { useSetRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useSetRecoilStateV2';
 
 const renderHooks = () => {
   const { result } = renderHook(
     () => {
       const isLogged = useIsLogged();
-      const setTokenPair = useSetRecoilState(tokenPairState);
+      const setTokenPair = useSetRecoilStateV2(tokenPairState);
 
       return {
         isLogged,

--- a/packages/twenty-front/src/modules/auth/hooks/useAuth.ts
+++ b/packages/twenty-front/src/modules/auth/hooks/useAuth.ts
@@ -5,7 +5,6 @@ import {
   useGotoRecoilSnapshot,
   useRecoilCallback,
   useRecoilValue,
-  useSetRecoilState,
 } from 'recoil';
 import { AppPath } from 'twenty-shared/types';
 
@@ -29,6 +28,9 @@ import {
 
 import { tokenPairState } from '@/auth/states/tokenPairState';
 import { isDeveloperDefaultSignInPrefilledState } from '@/client-config/states/isDeveloperDefaultSignInPrefilledState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
+import { useSetRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useSetRecoilStateV2';
+import { jotaiStore } from '@/ui/utilities/state/jotai/jotaiStore';
 
 import { isAppEffectRedirectEnabledState } from '@/app/states/isAppEffectRedirectEnabledState';
 import { useSignUpInNewWorkspace } from '@/auth/sign-in-up/hooks/useSignUpInNewWorkspace';
@@ -71,15 +73,15 @@ import { cookieStorage } from '~/utils/cookie-storage';
 import { getWorkspaceUrl } from '~/utils/getWorkspaceUrl';
 
 export const useAuth = () => {
-  const setTokenPair = useSetRecoilState(tokenPairState);
-  const setLoginToken = useSetRecoilState(loginTokenState);
-  const setIsAppEffectRedirectEnabled = useSetRecoilState(
+  const setTokenPair = useSetRecoilStateV2(tokenPairState);
+  const setLoginToken = useSetRecoilStateV2(loginTokenState);
+  const setIsAppEffectRedirectEnabled = useSetRecoilStateV2(
     isAppEffectRedirectEnabledState,
   );
 
   const { origin } = useOrigin();
   const { requestFreshCaptchaToken } = useRequestFreshCaptchaToken();
-  const isCaptchaScriptLoaded = useRecoilValue(isCaptchaScriptLoadedState);
+  const isCaptchaScriptLoaded = useRecoilValueV2(isCaptchaScriptLoadedState);
   const isMultiWorkspaceEnabled = useRecoilValue(isMultiWorkspaceEnabledState);
   const isEmailVerificationRequired = useRecoilValue(
     isEmailVerificationRequiredState,
@@ -89,7 +91,7 @@ export const useAuth = () => {
   const { refreshObjectMetadataItems } = useRefreshObjectMetadataItems();
   const { createWorkspace } = useSignUpInNewWorkspace();
 
-  const setSignInUpStep = useSetRecoilState(signInUpStepState);
+  const setSignInUpStep = useSetRecoilStateV2(signInUpStepState);
   const { redirect } = useRedirect();
   const { redirectToWorkspaceDomain } = useRedirectToWorkspaceDomain();
 
@@ -106,7 +108,7 @@ export const useAuth = () => {
     useVerifyEmailAndGetWorkspaceAgnosticTokenMutation();
   const [getAuthTokensFromOtp] = useGetAuthTokensFromOtpMutation();
 
-  const workspacePublicData = useRecoilValue(workspacePublicDataState);
+  const workspacePublicData = useRecoilValueV2(workspacePublicDataState);
 
   const { setLastAuthenticateWorkspaceDomain } =
     useLastAuthenticatedWorkspaceDomain();
@@ -123,7 +125,7 @@ export const useAuth = () => {
   const { loadMockedObjectMetadataItems } = useLoadMockedObjectMetadataItems();
 
   const clearSession = useRecoilCallback(
-    ({ snapshot, set }) =>
+    ({ snapshot }) =>
       async () => {
         const sseClient = getSnapshotValue(snapshot, sseClientState);
 
@@ -131,9 +133,9 @@ export const useAuth = () => {
 
         const emptySnapshot = snapshot_UNSTABLE();
 
-        const authProvidersValue = snapshot
-          .getLoadable(workspaceAuthProvidersState)
-          .getValue();
+        const authProvidersValue = jotaiStore.get(
+          workspaceAuthProvidersState.atom,
+        );
         const billing = snapshot.getLoadable(billingState).getValue();
         const isDeveloperDefaultSignInPrefilled = snapshot
           .getLoadable(isDeveloperDefaultSignInPrefilledState)
@@ -143,26 +145,28 @@ export const useAuth = () => {
         const clientConfigApiStatus = snapshot
           .getLoadable(clientConfigApiStatusState)
           .getValue();
-        const isCurrentUserLoaded = snapshot
-          .getLoadable(isCurrentUserLoadedState)
-          .getValue();
+        const isCurrentUserLoadedValue = jotaiStore.get(
+          isCurrentUserLoadedState.atom,
+        );
         const isMultiWorkspaceEnabled = snapshot
           .getLoadable(isMultiWorkspaceEnabledState)
           .getValue();
-        const domainConfiguration = snapshot
-          .getLoadable(domainConfigurationState)
-          .getValue();
+        const domainConfigurationValue = jotaiStore.get(
+          domainConfigurationState.atom,
+        );
         const apiConfig = snapshot.getLoadable(apiConfigState).getValue();
         const sentryConfig = snapshot.getLoadable(sentryConfigState).getValue();
-        const workspacePublicData = snapshot
-          .getLoadable(workspacePublicDataState)
-          .getValue();
-        const lastAuthenticatedMethod = snapshot
-          .getLoadable(lastAuthenticatedMethodState)
-          .getValue();
+        const workspacePublicDataValue = jotaiStore.get(
+          workspacePublicDataState.atom,
+        );
+        const lastAuthenticatedMethod = jotaiStore.get(
+          lastAuthenticatedMethodState.atom,
+        );
+        const isCaptchaScriptLoadedValue = jotaiStore.get(
+          isCaptchaScriptLoadedState.atom,
+        );
 
         const initialSnapshot = emptySnapshot.map(({ set }) => {
-          set(workspaceAuthProvidersState, authProvidersValue);
           set(billingState, billing);
           set(
             isDeveloperDefaultSignInPrefilledState,
@@ -172,12 +176,8 @@ export const useAuth = () => {
           set(captchaState, captcha);
           set(apiConfigState, apiConfig);
           set(sentryConfigState, sentryConfig);
-          set(workspacePublicDataState, workspacePublicData);
           set(clientConfigApiStatusState, clientConfigApiStatus);
-          set(isCurrentUserLoadedState, isCurrentUserLoaded);
           set(isMultiWorkspaceEnabledState, isMultiWorkspaceEnabled);
-          set(domainConfigurationState, domainConfiguration);
-          set(isCaptchaScriptLoadedState, isCaptchaScriptLoaded);
           return undefined;
         });
 
@@ -186,7 +186,18 @@ export const useAuth = () => {
 
         goToRecoilSnapshot(initialSnapshot);
 
-        set(lastAuthenticatedMethodState, lastAuthenticatedMethod);
+        jotaiStore.set(workspaceAuthProvidersState.atom, authProvidersValue);
+        jotaiStore.set(workspacePublicDataState.atom, workspacePublicDataValue);
+        jotaiStore.set(isCurrentUserLoadedState.atom, isCurrentUserLoadedValue);
+        jotaiStore.set(domainConfigurationState.atom, domainConfigurationValue);
+        jotaiStore.set(
+          isCaptchaScriptLoadedState.atom,
+          isCaptchaScriptLoadedValue,
+        );
+        jotaiStore.set(
+          lastAuthenticatedMethodState.atom,
+          lastAuthenticatedMethod,
+        );
 
         await client.clearStore();
         setLastAuthenticateWorkspaceDomain(null);
@@ -199,7 +210,6 @@ export const useAuth = () => {
       setLastAuthenticateWorkspaceDomain,
       loadMockedObjectMetadataItems,
       navigate,
-      isCaptchaScriptLoaded,
     ],
   );
 

--- a/packages/twenty-front/src/modules/auth/hooks/useIsLogged.ts
+++ b/packages/twenty-front/src/modules/auth/hooks/useIsLogged.ts
@@ -1,8 +1,7 @@
-import { useRecoilState } from 'recoil';
-
 import { tokenPairState } from '@/auth/states/tokenPairState';
+import { useRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilStateV2';
 
 export const useIsLogged = (): boolean => {
-  const [tokenPair] = useRecoilState(tokenPairState);
+  const [tokenPair] = useRecoilStateV2(tokenPairState);
   return !!tokenPair;
 };

--- a/packages/twenty-front/src/modules/auth/sign-in-up/components/EmailVerificationSent.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/components/EmailVerificationSent.tsx
@@ -9,7 +9,7 @@ import {
 } from '@/auth/states/signInUpStepState';
 import { OnboardingModalCircularIcon } from '@/onboarding/components/OnboardingModalCircularIcon';
 import { t } from '@lingui/core/macro';
-import { useSetRecoilState } from 'recoil';
+import { useSetRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useSetRecoilStateV2';
 import {
   IconGmail,
   IconMail,
@@ -89,7 +89,7 @@ export const EmailVerificationSent = ({
   email: string | null;
   isError?: boolean;
 }) => {
-  const setSignInUpStep = useSetRecoilState(signInUpStepState);
+  const setSignInUpStep = useSetRecoilStateV2(signInUpStepState);
 
   const { handleResendEmailVerificationToken, loading: isLoading } =
     useHandleResendEmailVerificationToken();

--- a/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpGlobalScopeForm.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpGlobalScopeForm.tsx
@@ -5,7 +5,6 @@ import styled from '@emotion/styled';
 import { Trans, useLingui } from '@lingui/react/macro';
 import { motion } from 'framer-motion';
 import { FormProvider } from 'react-hook-form';
-import { useRecoilValue } from 'recoil';
 import { ClickToActionLink, UndecoratedLink } from 'twenty-ui/navigation';
 
 import { useAuth } from '@/auth/hooks/useAuth';
@@ -126,12 +125,12 @@ const StyledActionLinkContainer = styled.div`
 
 export const SignInUpGlobalScopeForm = () => {
   const authProviders = useRecoilValueV2(authProvidersState);
-  const signInUpStep = useRecoilValue(signInUpStepState);
+  const signInUpStep = useRecoilValueV2(signInUpStepState);
   const { buildWorkspaceUrl } = useBuildWorkspaceUrl();
   const { signOut } = useAuth();
 
   const { createWorkspace } = useSignUpInNewWorkspace();
-  const availableWorkspaces = useRecoilValue(availableWorkspacesState);
+  const availableWorkspaces = useRecoilValueV2(availableWorkspacesState);
   const theme = useTheme();
   const { t } = useLingui();
 

--- a/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpWorkspaceScopeForm.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpWorkspaceScopeForm.tsx
@@ -12,9 +12,9 @@ import { workspaceAuthProvidersState } from '@/workspace/states/workspaceAuthPro
 import styled from '@emotion/styled';
 import { Trans } from '@lingui/react/macro';
 import { FormProvider } from 'react-hook-form';
-import { useRecoilValue } from 'recoil';
 import { HorizontalSeparator } from 'twenty-ui/display';
 import { ClickToActionLink } from 'twenty-ui/navigation';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 
 const StyledContentContainer = styled.div`
   margin-bottom: ${({ theme }) => theme.spacing(8)};
@@ -23,8 +23,8 @@ const StyledContentContainer = styled.div`
 `;
 
 export const SignInUpWorkspaceScopeForm = () => {
-  const workspaceAuthProviders = useRecoilValue(workspaceAuthProvidersState);
-  const workspaceAuthBypassProviders = useRecoilValue(
+  const workspaceAuthProviders = useRecoilValueV2(workspaceAuthProvidersState);
+  const workspaceAuthBypassProviders = useRecoilValueV2(
     workspaceAuthBypassProvidersState,
   );
   const { shouldOfferBypass, shouldUseBypass } = useWorkspaceBypass();

--- a/packages/twenty-front/src/modules/auth/sign-in-up/components/internal/SignInUpGlobalScopeFormEffect.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/components/internal/SignInUpGlobalScopeFormEffect.tsx
@@ -6,11 +6,11 @@ import {
 import { useLoadCurrentUser } from '@/users/hooks/useLoadCurrentUser';
 import { useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { useSetRecoilState } from 'recoil';
+import { useSetRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useSetRecoilStateV2';
 import { isDefined } from 'twenty-shared/utils';
 
 export const SignInUpGlobalScopeFormEffect = () => {
-  const setSignInUpStep = useSetRecoilState(signInUpStepState);
+  const setSignInUpStep = useSetRecoilStateV2(signInUpStepState);
   const [searchParams, setSearchParams] = useSearchParams();
   const { setAuthTokens } = useAuth();
   const { loadCurrentUser } = useLoadCurrentUser();

--- a/packages/twenty-front/src/modules/auth/sign-in-up/components/internal/SignInUpSSOIdentityProviderSelection.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/components/internal/SignInUpSSOIdentityProviderSelection.tsx
@@ -3,13 +3,13 @@
 import { useSSO } from '@/auth/sign-in-up/hooks/useSSO';
 import { guessSSOIdentityProviderIconByUrl } from '@/settings/security/utils/guessSSOIdentityProviderIconByUrl';
 import styled from '@emotion/styled';
-import { useRecoilValue } from 'recoil';
 
 import { workspaceAuthProvidersState } from '@/workspace/states/workspaceAuthProvidersState';
 import React from 'react';
 import { isDefined } from 'twenty-shared/utils';
 import { HorizontalSeparator } from 'twenty-ui/display';
 import { MainButton } from 'twenty-ui/input';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 
 const StyledContentContainer = styled.div`
   margin-bottom: ${({ theme }) => theme.spacing(8)};
@@ -17,7 +17,7 @@ const StyledContentContainer = styled.div`
 `;
 
 export const SignInUpSSOIdentityProviderSelection = () => {
-  const workspaceAuthProviders = useRecoilValue(workspaceAuthProvidersState);
+  const workspaceAuthProviders = useRecoilValueV2(workspaceAuthProvidersState);
 
   const { redirectToSSOLoginPage } = useSSO();
 

--- a/packages/twenty-front/src/modules/auth/sign-in-up/components/internal/SignInUpTwoFactorAuthenticationProvision.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/components/internal/SignInUpTwoFactorAuthenticationProvision.tsx
@@ -9,7 +9,7 @@ import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { Trans, useLingui } from '@lingui/react/macro';
 import QRCode from 'react-qr-code';
-import { useSetRecoilState } from 'recoil';
+import { useSetRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useSetRecoilStateV2';
 import { IconCopy } from 'twenty-ui/display';
 import { Loader } from 'twenty-ui/feedback';
 import { MainButton } from 'twenty-ui/input';
@@ -71,7 +71,7 @@ export const SignInUpTwoFactorAuthenticationProvision = () => {
   const theme = useTheme();
   const { copyToClipboard } = useCopyToClipboard();
   const qrCode = useRecoilValueV2(qrCodeState);
-  const setSignInUpStep = useSetRecoilState(signInUpStepState);
+  const setSignInUpStep = useSetRecoilStateV2(signInUpStepState);
 
   const handleClick = () => {
     setSignInUpStep(SignInUpStep.TwoFactorAuthenticationVerification);

--- a/packages/twenty-front/src/modules/auth/sign-in-up/components/internal/SignInUpTwoFactorAuthenticationVerification.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/components/internal/SignInUpTwoFactorAuthenticationVerification.tsx
@@ -18,11 +18,12 @@ import { Trans, useLingui } from '@lingui/react/macro';
 import { OTPInput, type SlotProps } from 'input-otp';
 import { useState } from 'react';
 import { Controller } from 'react-hook-form';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { AppPath } from 'twenty-shared/types';
 import { MainButton } from 'twenty-ui/input';
 import { ClickToActionLink } from 'twenty-ui/navigation';
 import { useNavigateApp } from '~/hooks/useNavigateApp';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
+import { useSetRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useSetRecoilStateV2';
 
 const StyledMainContentContainer = styled.div`
   margin-bottom: ${({ theme }) => theme.spacing(8)};
@@ -186,8 +187,8 @@ export const SignInUpTOTPVerification = () => {
   const navigate = useNavigateApp();
   const { readCaptchaToken } = useReadCaptchaToken();
   const { isCaptchaReady } = useCaptcha();
-  const loginToken = useRecoilValue(loginTokenState);
-  const setSignInUpStep = useSetRecoilState(signInUpStepState);
+  const loginToken = useRecoilValueV2(loginTokenState);
+  const setSignInUpStep = useSetRecoilStateV2(signInUpStepState);
   const { t } = useLingui();
 
   const { form } = useTwoFactorAuthenticationForm();

--- a/packages/twenty-front/src/modules/auth/sign-in-up/components/internal/SignInUpWithCredentials.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/components/internal/SignInUpWithCredentials.tsx
@@ -19,10 +19,12 @@ import styled from '@emotion/styled';
 import { useLingui } from '@lingui/react/macro';
 import { useMemo, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilValue } from 'recoil';
 import { isDefined } from 'twenty-shared/utils';
 import { Loader } from 'twenty-ui/feedback';
 import { MainButton } from 'twenty-ui/input';
+import { useRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilStateV2';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 
 const StyledForm = styled.form`
   align-items: center;
@@ -39,13 +41,15 @@ export const SignInUpWithCredentials = ({
   const { t } = useLingui();
   const form = useFormContext<Form>();
 
-  const [signInUpStep, setSignInUpStep] = useRecoilState(signInUpStepState);
+  const [signInUpStep, setSignInUpStep] = useRecoilStateV2(signInUpStepState);
   const [showErrors, setShowErrors] = useState(false);
   const captcha = useRecoilValue(captchaState);
-  const isRequestingCaptchaToken = useRecoilValue(
+  const isRequestingCaptchaToken = useRecoilValueV2(
     isRequestingCaptchaTokenState,
   );
-  const lastAuthenticatedMethod = useRecoilValue(lastAuthenticatedMethodState);
+  const lastAuthenticatedMethod = useRecoilValueV2(
+    lastAuthenticatedMethodState,
+  );
   const hasMultipleAuthMethods = useHasMultipleAuthMethods();
 
   const {

--- a/packages/twenty-front/src/modules/auth/sign-in-up/components/internal/SignInUpWithGoogle.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/components/internal/SignInUpWithGoogle.tsx
@@ -10,9 +10,10 @@ import { type SocialSSOSignInUpActionType } from '@/auth/types/socialSSOSignInUp
 import { useTheme } from '@emotion/react';
 import { useLingui } from '@lingui/react/macro';
 import { memo } from 'react';
-import { useRecoilState, useRecoilValue } from 'recoil';
 import { HorizontalSeparator, IconGoogle } from 'twenty-ui/display';
 import { MainButton } from 'twenty-ui/input';
+import { useRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilStateV2';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { LastUsedPill } from './LastUsedPill';
 import { StyledSSOButtonContainer } from './SignInUpSSOButtonStyles';
 
@@ -29,10 +30,9 @@ export const SignInUpWithGoogle = ({
   isGlobalScope?: boolean;
 }) => {
   const { t } = useLingui();
-  const signInUpStep = useRecoilValue(signInUpStepState);
-  const [lastAuthenticatedMethod, setLastAuthenticatedMethod] = useRecoilState(
-    lastAuthenticatedMethodState,
-  );
+  const signInUpStep = useRecoilValueV2(signInUpStepState);
+  const [lastAuthenticatedMethod, setLastAuthenticatedMethod] =
+    useRecoilStateV2(lastAuthenticatedMethodState);
   const { signInWithGoogle } = useSignInWithGoogle();
   const hasMultipleAuthMethods = useHasMultipleAuthMethods();
 

--- a/packages/twenty-front/src/modules/auth/sign-in-up/components/internal/SignInUpWithMicrosoft.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/components/internal/SignInUpWithMicrosoft.tsx
@@ -9,9 +9,10 @@ import { AuthenticatedMethod } from '@/auth/types/AuthenticatedMethod.enum';
 import { type SocialSSOSignInUpActionType } from '@/auth/types/socialSSOSignInUp.type';
 import { useTheme } from '@emotion/react';
 import { useLingui } from '@lingui/react/macro';
-import { useRecoilState, useRecoilValue } from 'recoil';
 import { HorizontalSeparator, IconMicrosoft } from 'twenty-ui/display';
 import { MainButton } from 'twenty-ui/input';
+import { useRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilStateV2';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { LastUsedPill } from './LastUsedPill';
 import { StyledSSOButtonContainer } from './SignInUpSSOButtonStyles';
 
@@ -25,10 +26,9 @@ export const SignInUpWithMicrosoft = ({
   const theme = useTheme();
   const { t } = useLingui();
 
-  const signInUpStep = useRecoilValue(signInUpStepState);
-  const [lastAuthenticatedMethod, setLastAuthenticatedMethod] = useRecoilState(
-    lastAuthenticatedMethodState,
-  );
+  const signInUpStep = useRecoilValueV2(signInUpStepState);
+  const [lastAuthenticatedMethod, setLastAuthenticatedMethod] =
+    useRecoilStateV2(lastAuthenticatedMethodState);
   const { signInWithMicrosoft } = useSignInWithMicrosoft();
   const hasMultipleAuthMethods = useHasMultipleAuthMethods();
 

--- a/packages/twenty-front/src/modules/auth/sign-in-up/components/internal/SignInUpWithSSO.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/components/internal/SignInUpWithSSO.tsx
@@ -7,6 +7,9 @@ import {
 } from '@/auth/states/signInUpStepState';
 import { AuthenticatedMethod } from '@/auth/types/AuthenticatedMethod.enum';
 import { workspaceAuthProvidersState } from '@/workspace/states/workspaceAuthProvidersState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
+import { useRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilStateV2';
+import { useSetRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useSetRecoilStateV2';
 import { useTheme } from '@emotion/react';
 import { useLingui } from '@lingui/react/macro';
 import { isDefined } from 'twenty-shared/utils';

--- a/packages/twenty-front/src/modules/auth/sign-in-up/components/internal/SignInUpWithSSO.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/components/internal/SignInUpWithSSO.tsx
@@ -9,7 +9,6 @@ import { AuthenticatedMethod } from '@/auth/types/AuthenticatedMethod.enum';
 import { workspaceAuthProvidersState } from '@/workspace/states/workspaceAuthProvidersState';
 import { useTheme } from '@emotion/react';
 import { useLingui } from '@lingui/react/macro';
-import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import { isDefined } from 'twenty-shared/utils';
 import { HorizontalSeparator, IconLock } from 'twenty-ui/display';
 import { MainButton } from 'twenty-ui/input';
@@ -19,12 +18,11 @@ import { StyledSSOButtonContainer } from './SignInUpSSOButtonStyles';
 export const SignInUpWithSSO = () => {
   const theme = useTheme();
   const { t } = useLingui();
-  const setSignInUpStep = useSetRecoilState(signInUpStepState);
-  const workspaceAuthProviders = useRecoilValue(workspaceAuthProvidersState);
-  const signInUpStep = useRecoilValue(signInUpStepState);
-  const [lastAuthenticatedMethod, setLastAuthenticatedMethod] = useRecoilState(
-    lastAuthenticatedMethodState,
-  );
+  const setSignInUpStep = useSetRecoilStateV2(signInUpStepState);
+  const workspaceAuthProviders = useRecoilValueV2(workspaceAuthProvidersState);
+  const signInUpStep = useRecoilValueV2(signInUpStepState);
+  const [lastAuthenticatedMethod, setLastAuthenticatedMethod] =
+    useRecoilStateV2(lastAuthenticatedMethodState);
   const hasMultipleAuthMethods = useHasMultipleAuthMethods();
 
   const { redirectToSSOLoginPage } = useSSO();

--- a/packages/twenty-front/src/modules/auth/sign-in-up/components/internal/SignInUpWorkspaceScopeFormEffect.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/components/internal/SignInUpWorkspaceScopeFormEffect.tsx
@@ -8,7 +8,7 @@ import { isRequestingCaptchaTokenState } from '@/captcha/states/isRequestingCapt
 import { captchaState } from '@/client-config/states/captchaState';
 import { workspaceAuthProvidersState } from '@/workspace/states/workspaceAuthProvidersState';
 import { useEffect, useState } from 'react';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilValue } from 'recoil';
 import { isDefined } from 'twenty-shared/utils';
 
 const searchParams = new URLSearchParams(window.location.search);
@@ -21,9 +21,9 @@ enum LoadingStatus {
 }
 
 export const SignInUpWorkspaceScopeFormEffect = () => {
-  const workspaceAuthProviders = useRecoilValue(workspaceAuthProvidersState);
+  const workspaceAuthProviders = useRecoilValueV2(workspaceAuthProvidersState);
 
-  const isRequestingCaptchaToken = useRecoilValue(
+  const isRequestingCaptchaToken = useRecoilValueV2(
     isRequestingCaptchaTokenState,
   );
 
@@ -38,7 +38,7 @@ export const SignInUpWorkspaceScopeFormEffect = () => {
   const { signInUpStep, continueWithEmail, continueWithCredentials } =
     useSignInUp(form);
 
-  const setSignInUpStep = useSetRecoilState(signInUpStepState);
+  const setSignInUpStep = useSetRecoilStateV2(signInUpStepState);
 
   useEffect(() => {
     if (!workspaceAuthProviders) {

--- a/packages/twenty-front/src/modules/auth/sign-in-up/components/internal/SignInUpWorkspaceScopeFormEffect.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/components/internal/SignInUpWorkspaceScopeFormEffect.tsx
@@ -7,6 +7,8 @@ import {
 import { isRequestingCaptchaTokenState } from '@/captcha/states/isRequestingCaptchaTokenState';
 import { captchaState } from '@/client-config/states/captchaState';
 import { workspaceAuthProvidersState } from '@/workspace/states/workspaceAuthProvidersState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
+import { useSetRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useSetRecoilStateV2';
 import { useEffect, useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import { isDefined } from 'twenty-shared/utils';

--- a/packages/twenty-front/src/modules/auth/sign-in-up/hooks/__tests__/useHandleResetPassword.test.ts
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/hooks/__tests__/useHandleResetPassword.test.ts
@@ -1,11 +1,14 @@
 import { i18n } from '@lingui/core';
 import { I18nProvider } from '@lingui/react';
 import { act, renderHook } from '@testing-library/react';
+import { type ReactNode, createElement } from 'react';
+import { Provider as JotaiProvider } from 'jotai';
 import { RecoilRoot } from 'recoil';
 
 import { useHandleResetPassword } from '@/auth/sign-in-up/hooks/useHandleResetPassword';
 import { workspacePublicDataState } from '@/auth/states/workspacePublicDataState';
 import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
+import { jotaiStore } from '@/ui/utilities/state/jotai/jotaiStore';
 import { SOURCE_LOCALE } from 'twenty-shared/translations';
 import {
   type PublicWorkspaceDataOutput,
@@ -20,16 +23,21 @@ jest.mock('~/generated-metadata/graphql');
 dynamicActivate(SOURCE_LOCALE);
 
 const renderHooks = () => {
+  jotaiStore.set(workspacePublicDataState.atom, {
+    id: 'workspace-id',
+  } as PublicWorkspaceDataOutput);
+
   const { result } = renderHook(() => useHandleResetPassword(), {
-    wrapper: ({ children }) =>
-      RecoilRoot({
-        initializeState: ({ set }) => {
-          set(workspacePublicDataState, {
-            id: 'workspace-id',
-          } as PublicWorkspaceDataOutput);
-        },
-        children: I18nProvider({ i18n, children }),
-      }),
+    wrapper: ({ children }: { children: ReactNode }) =>
+      createElement(
+        JotaiProvider,
+        { store: jotaiStore },
+        createElement(
+          RecoilRoot,
+          null as any,
+          createElement(I18nProvider, { i18n }, children),
+        ),
+      ),
   });
   return { result };
 };

--- a/packages/twenty-front/src/modules/auth/sign-in-up/hooks/useHandleResetPassword.ts
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/hooks/useHandleResetPassword.ts
@@ -5,14 +5,14 @@ import { workspacePublicDataState } from '@/auth/states/workspacePublicDataState
 import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { ApolloError } from '@apollo/client';
 import { useLingui } from '@lingui/react/macro';
-import { useRecoilValue } from 'recoil';
 import { useEmailPasswordResetLinkMutation } from '~/generated-metadata/graphql';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 
 export const useHandleResetPassword = () => {
   const { enqueueErrorSnackBar, enqueueSuccessSnackBar } = useSnackBar();
   const [emailPasswordResetLink] = useEmailPasswordResetLinkMutation();
-  const workspacePublicData = useRecoilValue(workspacePublicDataState);
-  const currentUser = useRecoilValue(currentUserState);
+  const workspacePublicData = useRecoilValueV2(workspacePublicDataState);
+  const currentUser = useRecoilValueV2(currentUserState);
 
   const { t } = useLingui();
 

--- a/packages/twenty-front/src/modules/auth/sign-in-up/hooks/useHasMultipleAuthMethods.ts
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/hooks/useHasMultipleAuthMethods.ts
@@ -1,8 +1,8 @@
 import { workspaceAuthProvidersState } from '@/workspace/states/workspaceAuthProvidersState';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 
 export const useHasMultipleAuthMethods = () => {
-  const workspaceAuthProviders = useRecoilValue(workspaceAuthProvidersState);
+  const workspaceAuthProviders = useRecoilValueV2(workspaceAuthProvidersState);
 
   if (!workspaceAuthProviders) {
     return false;

--- a/packages/twenty-front/src/modules/auth/sign-in-up/hooks/useSignInUp.ts
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/hooks/useSignInUp.ts
@@ -18,7 +18,7 @@ import { useIsCurrentLocationOnAWorkspace } from '@/domain-manager/hooks/useIsCu
 import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { ApolloError } from '@apollo/client';
 import { useLingui } from '@lingui/react/macro';
-import { useRecoilState, useSetRecoilState } from 'recoil';
+import { useSetRecoilState } from 'recoil';
 import { AppPath } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 import { buildAppPathWithQueryParams } from '~/utils/buildAppPathWithQueryParams';
@@ -30,7 +30,7 @@ export const useSignInUp = (form: UseFormReturn<Form>) => {
   const { enqueueErrorSnackBar } = useSnackBar();
   const { t } = useLingui();
 
-  const [signInUpStep, setSignInUpStep] = useRecoilState(signInUpStepState);
+  const [signInUpStep, setSignInUpStep] = useRecoilStateV2(signInUpStepState);
   const [signInUpMode, setSignInUpMode] = useRecoilStateV2(signInUpModeState);
   const { isOnAWorkspace } = useIsCurrentLocationOnAWorkspace();
   const { isCaptchaReady } = useCaptcha();

--- a/packages/twenty-front/src/modules/auth/sign-in-up/hooks/useSignInUp.ts
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/hooks/useSignInUp.ts
@@ -18,13 +18,13 @@ import { useIsCurrentLocationOnAWorkspace } from '@/domain-manager/hooks/useIsCu
 import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { ApolloError } from '@apollo/client';
 import { useLingui } from '@lingui/react/macro';
-import { useSetRecoilState } from 'recoil';
 import { AppPath } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 import { buildAppPathWithQueryParams } from '~/utils/buildAppPathWithQueryParams';
 import { isMatchingLocation } from '~/utils/isMatchingLocation';
 import { useAuth } from '@/auth/hooks/useAuth';
 import { useRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilStateV2';
+import { useSetRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useSetRecoilStateV2';
 
 export const useSignInUp = (form: UseFormReturn<Form>) => {
   const { enqueueErrorSnackBar } = useSnackBar();
@@ -34,7 +34,7 @@ export const useSignInUp = (form: UseFormReturn<Form>) => {
   const [signInUpMode, setSignInUpMode] = useRecoilStateV2(signInUpModeState);
   const { isOnAWorkspace } = useIsCurrentLocationOnAWorkspace();
   const { isCaptchaReady } = useCaptcha();
-  const setLastAuthenticatedMethod = useSetRecoilState(
+  const setLastAuthenticatedMethod = useSetRecoilStateV2(
     lastAuthenticatedMethodState,
   );
 

--- a/packages/twenty-front/src/modules/auth/sign-in-up/hooks/useSignInUpForm.ts
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/hooks/useSignInUpForm.ts
@@ -13,6 +13,7 @@ import {
 import { PASSWORD_REGEX } from '@/auth/utils/passwordRegex';
 import { isDeveloperDefaultSignInPrefilledState } from '@/client-config/states/isDeveloperDefaultSignInPrefilledState';
 import { isDefined } from 'twenty-shared/utils';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 
 const makeValidationSchema = (signInUpStep: SignInUpStep) =>
   z
@@ -34,7 +35,7 @@ const makeValidationSchema = (signInUpStep: SignInUpStep) =>
 
 export type Form = z.infer<ReturnType<typeof makeValidationSchema>>;
 export const useSignInUpForm = () => {
-  const signInUpStep = useRecoilValue(signInUpStepState);
+  const signInUpStep = useRecoilValueV2(signInUpStepState);
 
   const validationSchema = makeValidationSchema(signInUpStep); // Create schema based on the current step
 

--- a/packages/twenty-front/src/modules/auth/sign-in-up/hooks/useSignInWithMicrosoft.ts
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/hooks/useSignInWithMicrosoft.ts
@@ -2,15 +2,15 @@ import { useParams, useSearchParams } from 'react-router-dom';
 
 import { useAuth } from '@/auth/hooks/useAuth';
 import { billingCheckoutSessionState } from '@/auth/states/billingCheckoutSessionState';
-import { useRecoilValue } from 'recoil';
 import { type SocialSSOSignInUpActionType } from '@/auth/types/socialSSOSignInUp.type';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 
 export const useSignInWithMicrosoft = () => {
   const workspaceInviteHash = useParams().workspaceInviteHash;
   const [searchParams] = useSearchParams();
   const workspacePersonalInviteToken =
     searchParams.get('inviteToken') ?? undefined;
-  const billingCheckoutSession = useRecoilValue(billingCheckoutSessionState);
+  const billingCheckoutSession = useRecoilValueV2(billingCheckoutSessionState);
 
   const { signInWithMicrosoft } = useAuth();
   return {

--- a/packages/twenty-front/src/modules/auth/sign-in-up/hooks/useWorkspaceBypass.ts
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/hooks/useWorkspaceBypass.ts
@@ -1,16 +1,16 @@
-import { useRecoilState, useRecoilValue } from 'recoil';
-
 import { useIsCurrentLocationOnAWorkspace } from '@/domain-manager/hooks/useIsCurrentLocationOnAWorkspace';
 import { workspaceAuthBypassProvidersState } from '@/workspace/states/workspaceAuthBypassProvidersState';
 import { workspaceAuthProvidersState } from '@/workspace/states/workspaceAuthProvidersState';
 import { workspaceBypassModeState } from '@/workspace/states/workspaceBypassModeState';
+import { useRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilStateV2';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 
 export const useWorkspaceBypass = () => {
-  const workspaceAuthProviders = useRecoilValue(workspaceAuthProvidersState);
-  const workspaceAuthBypassProviders = useRecoilValue(
+  const workspaceAuthProviders = useRecoilValueV2(workspaceAuthProvidersState);
+  const workspaceAuthBypassProviders = useRecoilValueV2(
     workspaceAuthBypassProvidersState,
   );
-  const [workspaceBypassMode, setWorkspaceBypassMode] = useRecoilState(
+  const [workspaceBypassMode, setWorkspaceBypassMode] = useRecoilStateV2(
     workspaceBypassModeState,
   );
 

--- a/packages/twenty-front/src/modules/auth/sign-in-up/hooks/useWorkspaceFromInviteHash.ts
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/hooks/useWorkspaceFromInviteHash.ts
@@ -1,8 +1,8 @@
 import { useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { useRecoilValue } from 'recoil';
 
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 
 import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 
@@ -16,7 +16,7 @@ export const useWorkspaceFromInviteHash = () => {
   const { enqueueErrorSnackBar, enqueueInfoSnackBar } = useSnackBar();
   const navigate = useNavigateApp();
   const workspaceInviteHash = useParams().workspaceInviteHash;
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
   const [initiallyLoggedIn] = useState(isDefined(currentWorkspace));
 
   const { data: workspaceFromInviteHash, loading } =

--- a/packages/twenty-front/src/modules/auth/states/availableWorkspacesState.ts
+++ b/packages/twenty-front/src/modules/auth/states/availableWorkspacesState.ts
@@ -1,7 +1,7 @@
-import { createState } from '@/ui/utilities/state/utils/createState';
+import { createStateV2 } from '@/ui/utilities/state/jotai/utils/createStateV2';
 import { type AvailableWorkspaces } from '~/generated-metadata/graphql';
 
-export const availableWorkspacesState = createState<AvailableWorkspaces>({
+export const availableWorkspacesState = createStateV2<AvailableWorkspaces>({
   key: 'availableWorkspacesState',
   defaultValue: {
     availableWorkspacesForSignIn: [],

--- a/packages/twenty-front/src/modules/auth/states/billingCheckoutSessionState.ts
+++ b/packages/twenty-front/src/modules/auth/states/billingCheckoutSessionState.ts
@@ -1,8 +1,9 @@
 import { type BillingCheckoutSession } from '@/auth/types/billingCheckoutSession.type';
 import { BILLING_CHECKOUT_SESSION_DEFAULT_VALUE } from '@/billing/constants/BillingCheckoutSessionDefaultValue';
-import { createState } from '@/ui/utilities/state/utils/createState';
+import { createStateV2 } from '@/ui/utilities/state/jotai/utils/createStateV2';
 
-export const billingCheckoutSessionState = createState<BillingCheckoutSession>({
-  key: 'billingCheckoutSessionState',
-  defaultValue: BILLING_CHECKOUT_SESSION_DEFAULT_VALUE,
-});
+export const billingCheckoutSessionState =
+  createStateV2<BillingCheckoutSession>({
+    key: 'billingCheckoutSessionState',
+    defaultValue: BILLING_CHECKOUT_SESSION_DEFAULT_VALUE,
+  });

--- a/packages/twenty-front/src/modules/auth/states/currentUserState.ts
+++ b/packages/twenty-front/src/modules/auth/states/currentUserState.ts
@@ -1,4 +1,4 @@
-import { createState } from '@/ui/utilities/state/utils/createState';
+import { createStateV2 } from '@/ui/utilities/state/jotai/utils/createStateV2';
 import { type User } from '~/generated-metadata/graphql';
 
 export type CurrentUser = Pick<
@@ -15,7 +15,7 @@ export type CurrentUser = Pick<
   | 'hasPassword'
 >;
 
-export const currentUserState = createState<CurrentUser | null>({
+export const currentUserState = createStateV2<CurrentUser | null>({
   key: 'currentUserState',
   defaultValue: null,
 });

--- a/packages/twenty-front/src/modules/auth/states/currentUserWorkspaceState.ts
+++ b/packages/twenty-front/src/modules/auth/states/currentUserWorkspaceState.ts
@@ -1,5 +1,5 @@
 import { type ObjectPermissions } from 'twenty-shared/types';
-import { createState } from '@/ui/utilities/state/utils/createState';
+import { createStateV2 } from '@/ui/utilities/state/jotai/utils/createStateV2';
 import { type UserWorkspace } from '~/generated-metadata/graphql';
 
 export type CurrentUserWorkspace = Pick<
@@ -10,7 +10,7 @@ export type CurrentUserWorkspace = Pick<
 };
 
 export const currentUserWorkspaceState =
-  createState<CurrentUserWorkspace | null>({
+  createStateV2<CurrentUserWorkspace | null>({
     key: 'currentUserWorkspaceState',
     defaultValue: null,
   });

--- a/packages/twenty-front/src/modules/auth/states/currentWorkspaceDeletedMembersState.ts
+++ b/packages/twenty-front/src/modules/auth/states/currentWorkspaceDeletedMembersState.ts
@@ -1,7 +1,7 @@
-import { createState } from '@/ui/utilities/state/utils/createState';
+import { createStateV2 } from '@/ui/utilities/state/jotai/utils/createStateV2';
 import { type DeletedWorkspaceMember } from '~/generated-metadata/graphql';
 
-export const currentWorkspaceDeletedMembersState = createState<
+export const currentWorkspaceDeletedMembersState = createStateV2<
   DeletedWorkspaceMember[]
 >({
   key: 'currentWorkspaceDeletedMembersState',

--- a/packages/twenty-front/src/modules/auth/states/currentWorkspaceMemberState.ts
+++ b/packages/twenty-front/src/modules/auth/states/currentWorkspaceMemberState.ts
@@ -1,5 +1,5 @@
 import { type WorkspaceMember } from '@/workspace-member/types/WorkspaceMember';
-import { createState } from '@/ui/utilities/state/utils/createState';
+import { createStateV2 } from '@/ui/utilities/state/jotai/utils/createStateV2';
 
 export type CurrentWorkspaceMember = Omit<
   WorkspaceMember,
@@ -7,7 +7,7 @@ export type CurrentWorkspaceMember = Omit<
 >;
 
 export const currentWorkspaceMemberState =
-  createState<CurrentWorkspaceMember | null>({
+  createStateV2<CurrentWorkspaceMember | null>({
     key: 'currentWorkspaceMemberState',
     defaultValue: null,
   });

--- a/packages/twenty-front/src/modules/auth/states/currentWorkspaceMembersState.ts
+++ b/packages/twenty-front/src/modules/auth/states/currentWorkspaceMembersState.ts
@@ -1,7 +1,7 @@
 import { type PartialWorkspaceMember } from '@/settings/roles/types/RoleWithPartialMembers';
-import { createState } from '@/ui/utilities/state/utils/createState';
+import { createStateV2 } from '@/ui/utilities/state/jotai/utils/createStateV2';
 
-export const currentWorkspaceMembersState = createState<
+export const currentWorkspaceMembersState = createStateV2<
   PartialWorkspaceMember[]
 >({
   key: 'currentWorkspaceMembersState',

--- a/packages/twenty-front/src/modules/auth/states/currentWorkspaceState.ts
+++ b/packages/twenty-front/src/modules/auth/states/currentWorkspaceState.ts
@@ -1,4 +1,4 @@
-import { createState } from '@/ui/utilities/state/utils/createState';
+import { createStateV2 } from '@/ui/utilities/state/jotai/utils/createStateV2';
 import {
   type Application,
   type Role,
@@ -43,7 +43,7 @@ export type CurrentWorkspace = Pick<
   workspaceCustomApplication: Pick<Application, 'id'> | null;
 };
 
-export const currentWorkspaceState = createState<CurrentWorkspace | null>({
+export const currentWorkspaceState = createStateV2<CurrentWorkspace | null>({
   key: 'currentWorkspaceState',
   defaultValue: null,
 });

--- a/packages/twenty-front/src/modules/auth/states/isCurrentUserLoadedState.ts
+++ b/packages/twenty-front/src/modules/auth/states/isCurrentUserLoadedState.ts
@@ -1,5 +1,5 @@
-import { createState } from '@/ui/utilities/state/utils/createState';
-export const isCurrentUserLoadedState = createState<boolean>({
+import { createStateV2 } from '@/ui/utilities/state/jotai/utils/createStateV2';
+export const isCurrentUserLoadedState = createStateV2<boolean>({
   key: 'isCurrentUserLoadedState',
   defaultValue: false,
 });

--- a/packages/twenty-front/src/modules/auth/states/isImpersonatingState.ts
+++ b/packages/twenty-front/src/modules/auth/states/isImpersonatingState.ts
@@ -1,9 +1,10 @@
 import { jwtDecode } from 'jwt-decode';
-import { selector } from 'recoil';
 import { isDefined } from 'twenty-shared/utils';
-import { tokenPairState } from './tokenPairState';
 
-export const isImpersonatingState = selector<boolean>({
+import { tokenPairState } from '@/auth/states/tokenPairState';
+import { createSelectorV2 } from '@/ui/utilities/state/jotai/utils/createSelectorV2';
+
+export const isImpersonatingState = createSelectorV2<boolean>({
   key: 'isImpersonatingState',
   get: ({ get }) => {
     const tokenPair = get(tokenPairState);

--- a/packages/twenty-front/src/modules/auth/states/lastAuthenticatedMethodState.ts
+++ b/packages/twenty-front/src/modules/auth/states/lastAuthenticatedMethodState.ts
@@ -1,12 +1,9 @@
-import { atom } from 'recoil';
-
 import { type AuthenticatedMethod } from '@/auth/types/AuthenticatedMethod.enum';
-import { localStorageEffect } from '~/utils/recoil/localStorageEffect';
+import { createStateV2 } from '@/ui/utilities/state/jotai/utils/createStateV2';
 
-const LAST_AUTHENTICATED_METHOD_STORAGE_KEY = 'lastAuthenticatedMethodState';
-
-export const lastAuthenticatedMethodState = atom<AuthenticatedMethod | null>({
-  key: LAST_AUTHENTICATED_METHOD_STORAGE_KEY,
-  default: null,
-  effects: [localStorageEffect()],
-});
+export const lastAuthenticatedMethodState =
+  createStateV2<AuthenticatedMethod | null>({
+    key: 'lastAuthenticatedMethodState',
+    defaultValue: null,
+    useLocalStorage: true,
+  });

--- a/packages/twenty-front/src/modules/auth/states/loginTokenState.ts
+++ b/packages/twenty-front/src/modules/auth/states/loginTokenState.ts
@@ -1,7 +1,7 @@
-import { createState } from '@/ui/utilities/state/utils/createState';
+import { createStateV2 } from '@/ui/utilities/state/jotai/utils/createStateV2';
 import { type AuthToken } from '~/generated-metadata/graphql';
 
-export const loginTokenState = createState<AuthToken['token'] | null>({
+export const loginTokenState = createStateV2<AuthToken['token'] | null>({
   key: 'loginTokenState',
   defaultValue: null,
 });

--- a/packages/twenty-front/src/modules/auth/states/objectPermissionsFamilySelector.ts
+++ b/packages/twenty-front/src/modules/auth/states/objectPermissionsFamilySelector.ts
@@ -1,7 +1,10 @@
 import { currentUserWorkspaceState } from '@/auth/states/currentUserWorkspaceState';
 import { objectMetadataItemsState } from '@/object-metadata/states/objectMetadataItemsState';
+import { jotaiStore } from '@/ui/utilities/state/jotai/jotaiStore';
 import { selectorFamily } from 'recoil';
 
+// Temporary bridge: reads from Jotai store for migrated state.
+// Will be fully migrated to Jotai in PR 6.
 export const objectPermissionsFamilySelector = selectorFamily<
   {
     canRead: boolean;
@@ -13,7 +16,9 @@ export const objectPermissionsFamilySelector = selectorFamily<
   get:
     ({ objectNameSingular }) =>
     ({ get }) => {
-      const currentUserWorkspace = get(currentUserWorkspaceState);
+      const currentUserWorkspace = jotaiStore.get(
+        currentUserWorkspaceState.atom,
+      );
       const objectMetadataItems = get(objectMetadataItemsState);
 
       const objectMetadataItem = objectMetadataItems.find(

--- a/packages/twenty-front/src/modules/auth/states/signInUpStepState.ts
+++ b/packages/twenty-front/src/modules/auth/states/signInUpStepState.ts
@@ -1,4 +1,4 @@
-import { createState } from '@/ui/utilities/state/utils/createState';
+import { createStateV2 } from '@/ui/utilities/state/jotai/utils/createStateV2';
 export enum SignInUpStep {
   Init = 'init',
   Email = 'email',
@@ -10,7 +10,7 @@ export enum SignInUpStep {
   TwoFactorAuthenticationProvision = 'TwoFactorAuthenticationProvision',
 }
 
-export const signInUpStepState = createState<SignInUpStep>({
+export const signInUpStepState = createStateV2<SignInUpStep>({
   key: 'signInUpStepState',
   defaultValue: SignInUpStep.Init,
 });

--- a/packages/twenty-front/src/modules/auth/states/tokenPairState.ts
+++ b/packages/twenty-front/src/modules/auth/states/tokenPairState.ts
@@ -1,18 +1,12 @@
-import { createState } from '@/ui/utilities/state/utils/createState';
+import { createStateV2 } from '@/ui/utilities/state/jotai/utils/createStateV2';
 import { type AuthTokenPair } from '~/generated-metadata/graphql';
-import { cookieStorageEffect } from '~/utils/recoil/cookieStorageEffect';
 
-export const tokenPairState = createState<AuthTokenPair | null>({
+export const tokenPairState = createStateV2<AuthTokenPair | null>({
   key: 'tokenPairState',
   defaultValue: null,
-  effects: [
-    cookieStorageEffect(
-      'tokenPair',
-      {},
-      {
-        validateInitFn: (payload: AuthTokenPair) =>
-          Boolean(payload['accessOrWorkspaceAgnosticToken']),
-      },
-    ),
-  ],
+  useCookieStorage: {
+    cookieKey: 'tokenPair',
+    validateInitFn: (payload: AuthTokenPair) =>
+      Boolean(payload['accessOrWorkspaceAgnosticToken']),
+  },
 });

--- a/packages/twenty-front/src/modules/auth/states/workspacePublicDataState.ts
+++ b/packages/twenty-front/src/modules/auth/states/workspacePublicDataState.ts
@@ -1,8 +1,8 @@
 import { type PublicWorkspaceDataOutput } from '~/generated-metadata/graphql';
-import { createState } from '@/ui/utilities/state/utils/createState';
+import { createStateV2 } from '@/ui/utilities/state/jotai/utils/createStateV2';
 
 export const workspacePublicDataState =
-  createState<PublicWorkspaceDataOutput | null>({
+  createStateV2<PublicWorkspaceDataOutput | null>({
     key: 'workspacePublicDataState',
     defaultValue: null,
   });

--- a/packages/twenty-front/src/modules/billing/components/SettingsBillingContent.tsx
+++ b/packages/twenty-front/src/modules/billing/components/SettingsBillingContent.tsx
@@ -1,5 +1,4 @@
 import { useLingui } from '@lingui/react/macro';
-import { useRecoilValue } from 'recoil';
 
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { SettingsBillingCreditsSection } from '@/billing/components/SettingsBillingCreditsSection';
@@ -16,13 +15,14 @@ import {
   useBillingPortalSessionQuery,
 } from '~/generated-metadata/graphql';
 import { useGetWorkflowNodeExecutionUsage } from '@/billing/hooks/useGetWorkflowNodeExecutionUsage';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 
 export const SettingsBillingContent = () => {
   const { t } = useLingui();
 
   const { redirect } = useRedirect();
 
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
 
   const subscriptions = currentWorkspace?.billingSubscriptions;
 

--- a/packages/twenty-front/src/modules/billing/components/SettingsBillingSubscriptionInfo.tsx
+++ b/packages/twenty-front/src/modules/billing/components/SettingsBillingSubscriptionInfo.tsx
@@ -29,8 +29,8 @@ import { useModal } from '@/ui/layout/modal/hooks/useModal';
 import { useSubscriptionStatus } from '@/workspace/hooks/useSubscriptionStatus';
 import styled from '@emotion/styled';
 import { useLingui } from '@lingui/react/macro';
+import { useSetRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useSetRecoilStateV2';
 import { useMemo, useState } from 'react';
-import { useSetRecoilState } from 'recoil';
 import { isDefined } from 'twenty-shared/utils';
 import {
   H2Title,
@@ -144,7 +144,7 @@ export const SettingsBillingSubscriptionInfo = ({
 
   const [cancelSwitchMeteredPrice] = useCancelSwitchMeteredPriceMutation();
 
-  const setCurrentWorkspace = useSetRecoilState(currentWorkspaceState);
+  const setCurrentWorkspace = useSetRecoilStateV2(currentWorkspaceState);
 
   const isTrialPeriod = subscriptionStatus === SubscriptionStatus.Trialing;
 

--- a/packages/twenty-front/src/modules/billing/components/internal/MeteredPriceSelector.tsx
+++ b/packages/twenty-front/src/modules/billing/components/internal/MeteredPriceSelector.tsx
@@ -7,6 +7,7 @@ import {
   type MeteredBillingPrice,
 } from '@/billing/types/billing-price-tiers.type';
 import { useNumberFormat } from '@/localization/hooks/useNumberFormat';
+import { useRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilStateV2';
 import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { Select } from '@/ui/input/components/Select';
 import { ConfirmationModal } from '@/ui/layout/modal/components/ConfirmationModal';
@@ -14,7 +15,6 @@ import { useModal } from '@/ui/layout/modal/hooks/useModal';
 import styled from '@emotion/styled';
 import { t } from '@lingui/core/macro';
 import { useState } from 'react';
-import { useRecoilState } from 'recoil';
 import { findOrThrow, isDefined } from 'twenty-shared/utils';
 import { H2Title } from 'twenty-ui/display';
 import { Button } from 'twenty-ui/input';
@@ -48,7 +48,7 @@ export const MeteredPriceSelector = ({
   const { currentMeteredBillingPrice } = useCurrentMetered();
   const { formatNumber } = useNumberFormat();
 
-  const [currentWorkspace, setCurrentWorkspace] = useRecoilState(
+  const [currentWorkspace, setCurrentWorkspace] = useRecoilStateV2(
     currentWorkspaceState,
   );
 

--- a/packages/twenty-front/src/modules/billing/hooks/useBillingWording.ts
+++ b/packages/twenty-front/src/modules/billing/hooks/useBillingWording.ts
@@ -12,12 +12,12 @@ import { beautifyExactDate } from '~/utils/date-utils';
 import { useCurrentPlan } from '@/billing/hooks/useCurrentPlan';
 import { useCurrentMetered } from '@/billing/hooks/useCurrentMetered';
 import { useCurrentBillingFlags } from '@/billing/hooks/useCurrentBillingFlags';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 
 export const useBillingWording = () => {
   const { t } = useLingui();
 
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
 
   assertIsDefinedOrThrow(currentWorkspace);
 

--- a/packages/twenty-front/src/modules/billing/hooks/useCurrentBillingFlags.ts
+++ b/packages/twenty-front/src/modules/billing/hooks/useCurrentBillingFlags.ts
@@ -3,11 +3,11 @@ import {
   BillingPlanKey,
 } from '~/generated-metadata/graphql';
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { assertIsDefinedOrThrow } from 'twenty-shared/utils';
 
 export const useCurrentBillingFlags = () => {
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
 
   assertIsDefinedOrThrow(currentWorkspace);
 

--- a/packages/twenty-front/src/modules/billing/hooks/useCurrentMetered.ts
+++ b/packages/twenty-front/src/modules/billing/hooks/useCurrentMetered.ts
@@ -1,7 +1,7 @@
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { useCurrentPlan } from '@/billing/hooks/useCurrentPlan';
 import type { MeteredBillingPrice } from '@/billing/types/billing-price-tiers.type';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { assertIsDefinedOrThrow, findOrThrow } from 'twenty-shared/utils';
 import {
   BillingProductKey,
@@ -11,7 +11,7 @@ import {
 export const useCurrentMetered = () => {
   const { currentPlan } = useCurrentPlan();
 
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
 
   assertIsDefinedOrThrow(currentWorkspace);
 

--- a/packages/twenty-front/src/modules/billing/hooks/useCurrentPlan.ts
+++ b/packages/twenty-front/src/modules/billing/hooks/useCurrentPlan.ts
@@ -2,12 +2,12 @@ import { BillingPlanKey } from '~/generated-metadata/graphql';
 import { assertIsDefinedOrThrow, findOrThrow } from 'twenty-shared/utils';
 import { usePlans } from './usePlans';
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 
 export const useCurrentPlan = () => {
   const { listPlans } = usePlans();
 
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
 
   assertIsDefinedOrThrow(currentWorkspace);
 

--- a/packages/twenty-front/src/modules/billing/hooks/useEndSubscriptionTrialPeriod.ts
+++ b/packages/twenty-front/src/modules/billing/hooks/useEndSubscriptionTrialPeriod.ts
@@ -1,16 +1,16 @@
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { useRedirect } from '@/domain-manager/hooks/useRedirect';
+import { useRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilStateV2';
 import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { t } from '@lingui/core/macro';
 import { useState } from 'react';
-import { useRecoilState } from 'recoil';
 import { isDefined } from 'twenty-shared/utils';
 import { useEndSubscriptionTrialPeriodMutation } from '~/generated-metadata/graphql';
 
 export const useEndSubscriptionTrialPeriod = () => {
   const { enqueueSuccessSnackBar, enqueueErrorSnackBar } = useSnackBar();
   const [endSubscriptionTrialPeriod] = useEndSubscriptionTrialPeriodMutation();
-  const [currentWorkspace, setCurrentWorkspace] = useRecoilState(
+  const [currentWorkspace, setCurrentWorkspace] = useRecoilStateV2(
     currentWorkspaceState,
   );
   const [isLoading, setIsLoading] = useState(false);

--- a/packages/twenty-front/src/modules/billing/hooks/useHasNextBillingPhase.ts
+++ b/packages/twenty-front/src/modules/billing/hooks/useHasNextBillingPhase.ts
@@ -1,8 +1,8 @@
-import { useRecoilValue } from 'recoil';
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 
 export const useHasNextBillingPhase = () => {
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
 
   const hasNextBillingPhase =
     currentWorkspace?.currentBillingSubscription?.phases.length === 2;

--- a/packages/twenty-front/src/modules/billing/hooks/useNextBillingPhase.ts
+++ b/packages/twenty-front/src/modules/billing/hooks/useNextBillingPhase.ts
@@ -1,8 +1,8 @@
-import { useRecoilValue } from 'recoil';
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 
 export const useNextBillingPhase = () => {
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
 
   const nextBillingPhase =
     currentWorkspace?.currentBillingSubscription?.phases[1];

--- a/packages/twenty-front/src/modules/captcha/components/CaptchaProviderScriptLoaderEffect.tsx
+++ b/packages/twenty-front/src/modules/captcha/components/CaptchaProviderScriptLoaderEffect.tsx
@@ -1,19 +1,19 @@
-import { useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
-
 import { useRequestFreshCaptchaToken } from '@/captcha/hooks/useRequestFreshCaptchaToken';
 import { isCaptchaScriptLoadedState } from '@/captcha/states/isCaptchaScriptLoadedState';
 import { getCaptchaUrlByProvider } from '@/captcha/utils/getCaptchaUrlByProvider';
 import { isCaptchaRequiredForPath } from '@/captcha/utils/isCaptchaRequiredForPath';
 import { useCaptcha } from '@/client-config/hooks/useCaptcha';
 import { captchaState } from '@/client-config/states/captchaState';
+import { useSetRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useSetRecoilStateV2';
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
 import { assertIsDefinedOrThrow } from 'twenty-shared/utils';
 import { CaptchaDriverType } from '~/generated-metadata/graphql';
 
 export const CaptchaProviderScriptLoaderEffect = () => {
   const captcha = useRecoilValue(captchaState);
-  const setIsCaptchaScriptLoaded = useSetRecoilState(
+  const setIsCaptchaScriptLoaded = useSetRecoilStateV2(
     isCaptchaScriptLoadedState,
   );
   const { isCaptchaScriptLoaded, isCaptchaConfigured } = useCaptcha();

--- a/packages/twenty-front/src/modules/captcha/hooks/__tests__/useRequestFreshCaptchaToken.test.tsx
+++ b/packages/twenty-front/src/modules/captcha/hooks/__tests__/useRequestFreshCaptchaToken.test.tsx
@@ -1,13 +1,26 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
-import { RecoilRoot } from 'recoil';
+import { type ReactNode } from 'react';
+import { type MutableSnapshot, RecoilRoot } from 'recoil';
+import { Provider as JotaiProvider } from 'jotai';
 
 import { useRequestFreshCaptchaToken } from '@/captcha/hooks/useRequestFreshCaptchaToken';
 import { isRequestingCaptchaTokenState } from '@/captcha/states/isRequestingCaptchaTokenState';
 import { isCaptchaRequiredForPath } from '@/captcha/utils/isCaptchaRequiredForPath';
 import { captchaState } from '@/client-config/states/captchaState';
-import { CaptchaDriverType } from '~/generated-metadata/graphql';
+import { jotaiStore } from '@/ui/utilities/state/jotai/jotaiStore';
+import { type Captcha, CaptchaDriverType } from '~/generated-metadata/graphql';
 
 jest.mock('@/captcha/utils/isCaptchaRequiredForPath');
+
+const createWrapper =
+  (initializeRecoilState?: (mutableSnapshot: MutableSnapshot) => void) =>
+  ({ children }: { children: ReactNode }) => (
+    <JotaiProvider store={jotaiStore}>
+      <RecoilRoot initializeState={initializeRecoilState}>
+        {children}
+      </RecoilRoot>
+    </JotaiProvider>
+  );
 
 describe('useRequestFreshCaptchaToken', () => {
   const mockGrecaptchaExecute = jest.fn();
@@ -47,7 +60,7 @@ describe('useRequestFreshCaptchaToken', () => {
     (isCaptchaRequiredForPath as jest.Mock).mockReturnValue(false);
 
     const { result } = renderHook(() => useRequestFreshCaptchaToken(), {
-      wrapper: RecoilRoot,
+      wrapper: createWrapper(),
     });
 
     await act(async () => {
@@ -61,7 +74,7 @@ describe('useRequestFreshCaptchaToken', () => {
 
   it('should not request a token if captcha provider is undefined', async () => {
     const { result } = renderHook(() => useRequestFreshCaptchaToken(), {
-      wrapper: RecoilRoot,
+      wrapper: createWrapper(),
     });
 
     await act(async () => {
@@ -74,20 +87,15 @@ describe('useRequestFreshCaptchaToken', () => {
   });
 
   it('should request a token from Google reCAPTCHA when provider is GOOGLE_RECAPTCHA', async () => {
+    jotaiStore.set(isRequestingCaptchaTokenState.atom, false);
+
     const { result } = renderHook(() => useRequestFreshCaptchaToken(), {
-      wrapper: ({ children }) => (
-        <RecoilRoot
-          initializeState={({ set }) => {
-            set(captchaState, {
-              provider: CaptchaDriverType.GOOGLE_RECAPTCHA,
-              siteKey: 'google-site-key',
-            });
-            set(isRequestingCaptchaTokenState, false);
-          }}
-        >
-          {children}
-        </RecoilRoot>
-      ),
+      wrapper: createWrapper(({ set }) => {
+        set(captchaState, {
+          provider: CaptchaDriverType.GOOGLE_RECAPTCHA,
+          siteKey: 'google-site-key',
+        } as Captcha);
+      }),
     });
 
     await act(async () => {
@@ -104,20 +112,15 @@ describe('useRequestFreshCaptchaToken', () => {
   });
 
   it('should request a token from Turnstile when provider is TURNSTILE', async () => {
+    jotaiStore.set(isRequestingCaptchaTokenState.atom, false);
+
     const { result } = renderHook(() => useRequestFreshCaptchaToken(), {
-      wrapper: ({ children }) => (
-        <RecoilRoot
-          initializeState={({ set }) => {
-            set(captchaState, {
-              provider: CaptchaDriverType.TURNSTILE,
-              siteKey: 'turnstile-site-key',
-            });
-            set(isRequestingCaptchaTokenState, false);
-          }}
-        >
-          {children}
-        </RecoilRoot>
-      ),
+      wrapper: createWrapper(({ set }) => {
+        set(captchaState, {
+          provider: CaptchaDriverType.TURNSTILE,
+          siteKey: 'turnstile-site-key',
+        } as Captcha);
+      }),
     });
 
     await act(async () => {

--- a/packages/twenty-front/src/modules/captcha/hooks/useReadCaptchaToken.ts
+++ b/packages/twenty-front/src/modules/captcha/hooks/useReadCaptchaToken.ts
@@ -1,22 +1,16 @@
-import { useRecoilCallback } from 'recoil';
-
 import { captchaTokenState } from '@/captcha/states/captchaTokenState';
+import { jotaiStore } from '@/ui/utilities/state/jotai/jotaiStore';
+import { useCallback } from 'react';
 import { isDefined } from 'twenty-shared/utils';
 
 export const useReadCaptchaToken = () => {
-  const readCaptchaToken = useRecoilCallback(
-    ({ snapshot }) =>
-      () => {
-        const existingCaptchaToken = snapshot
-          .getLoadable(captchaTokenState)
-          .getValue();
+  const readCaptchaToken = useCallback(() => {
+    const existingCaptchaToken = jotaiStore.get(captchaTokenState.atom);
 
-        if (isDefined(existingCaptchaToken)) {
-          return existingCaptchaToken;
-        }
-      },
-    [],
-  );
+    if (isDefined(existingCaptchaToken)) {
+      return existingCaptchaToken;
+    }
+  }, []);
 
   return { readCaptchaToken };
 };

--- a/packages/twenty-front/src/modules/captcha/hooks/useRequestFreshCaptchaToken.ts
+++ b/packages/twenty-front/src/modules/captcha/hooks/useRequestFreshCaptchaToken.ts
@@ -1,15 +1,15 @@
-import { useRecoilCallback, useSetRecoilState } from 'recoil';
-
 import { captchaTokenState } from '@/captcha/states/captchaTokenState';
 import { isRequestingCaptchaTokenState } from '@/captcha/states/isRequestingCaptchaTokenState';
 import { isCaptchaRequiredForPath } from '@/captcha/utils/isCaptchaRequiredForPath';
 import { captchaState } from '@/client-config/states/captchaState';
+import { useSetRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useSetRecoilStateV2';
+import { useRecoilCallback } from 'recoil';
 import { assertIsDefinedOrThrow, isDefined } from 'twenty-shared/utils';
 import { CaptchaDriverType } from '~/generated-metadata/graphql';
 
 export const useRequestFreshCaptchaToken = () => {
-  const setCaptchaToken = useSetRecoilState(captchaTokenState);
-  const setIsRequestingCaptchaToken = useSetRecoilState(
+  const setCaptchaToken = useSetRecoilStateV2(captchaTokenState);
+  const setIsRequestingCaptchaToken = useSetRecoilStateV2(
     isRequestingCaptchaTokenState,
   );
 

--- a/packages/twenty-front/src/modules/captcha/states/captchaTokenState.ts
+++ b/packages/twenty-front/src/modules/captcha/states/captchaTokenState.ts
@@ -1,5 +1,5 @@
-import { createState } from '@/ui/utilities/state/utils/createState';
-export const captchaTokenState = createState<string | undefined>({
+import { createStateV2 } from '@/ui/utilities/state/jotai/utils/createStateV2';
+export const captchaTokenState = createStateV2<string | undefined>({
   key: 'captchaTokenState',
   defaultValue: undefined,
 });

--- a/packages/twenty-front/src/modules/captcha/states/isCaptchaScriptLoadedState.ts
+++ b/packages/twenty-front/src/modules/captcha/states/isCaptchaScriptLoadedState.ts
@@ -1,5 +1,5 @@
-import { createState } from '@/ui/utilities/state/utils/createState';
-export const isCaptchaScriptLoadedState = createState<boolean>({
+import { createStateV2 } from '@/ui/utilities/state/jotai/utils/createStateV2';
+export const isCaptchaScriptLoadedState = createStateV2<boolean>({
   key: 'isCaptchaScriptLoadedState',
   defaultValue: false,
 });

--- a/packages/twenty-front/src/modules/captcha/states/isRequestingCaptchaTokenState.ts
+++ b/packages/twenty-front/src/modules/captcha/states/isRequestingCaptchaTokenState.ts
@@ -1,5 +1,5 @@
-import { createState } from '@/ui/utilities/state/utils/createState';
-export const isRequestingCaptchaTokenState = createState<boolean>({
+import { createStateV2 } from '@/ui/utilities/state/jotai/utils/createStateV2';
+export const isRequestingCaptchaTokenState = createStateV2<boolean>({
   key: 'isRequestingCaptchaTokenState',
   defaultValue: false,
 });

--- a/packages/twenty-front/src/modules/chrome-extension-sidecar/components/ChromeExtensionSidecarEffect.tsx
+++ b/packages/twenty-front/src/modules/chrome-extension-sidecar/components/ChromeExtensionSidecarEffect.tsx
@@ -1,19 +1,18 @@
-import { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { useSetRecoilState } from 'recoil';
-
 import { tokenPairState } from '@/auth/states/tokenPairState';
 import { isLoadingTokensFromExtensionState } from '@/chrome-extension-sidecar/states/isLoadingTokensFromExtensionState';
 import { chromeExtensionIdState } from '@/client-config/states/chromeExtensionIdState';
-import { isInFrame } from '~/utils/isInIframe';
-import { isDefined } from 'twenty-shared/utils';
 import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
+import { useSetRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useSetRecoilStateV2';
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { isDefined } from 'twenty-shared/utils';
+import { isInFrame } from '~/utils/isInIframe';
 
 export const ChromeExtensionSidecarEffect = () => {
   const navigate = useNavigate();
-  const setTokenPair = useSetRecoilState(tokenPairState);
+  const setTokenPair = useSetRecoilStateV2(tokenPairState);
   const chromeExtensionId = useRecoilValueV2(chromeExtensionIdState);
-  const setIsLoadingTokensFromExtension = useSetRecoilState(
+  const setIsLoadingTokensFromExtension = useSetRecoilStateV2(
     isLoadingTokensFromExtensionState,
   );
 

--- a/packages/twenty-front/src/modules/chrome-extension-sidecar/states/isLoadingTokensFromExtensionState.ts
+++ b/packages/twenty-front/src/modules/chrome-extension-sidecar/states/isLoadingTokensFromExtensionState.ts
@@ -1,5 +1,5 @@
-import { createState } from '@/ui/utilities/state/utils/createState';
-export const isLoadingTokensFromExtensionState = createState<boolean | null>({
+import { createStateV2 } from '@/ui/utilities/state/jotai/utils/createStateV2';
+export const isLoadingTokensFromExtensionState = createStateV2<boolean | null>({
   key: 'isLoadingTokensFromExtensionState',
   defaultValue: null,
 });

--- a/packages/twenty-front/src/modules/client-config/hooks/useCaptcha.ts
+++ b/packages/twenty-front/src/modules/client-config/hooks/useCaptcha.ts
@@ -2,15 +2,16 @@ import { captchaTokenState } from '@/captcha/states/captchaTokenState';
 import { isCaptchaScriptLoadedState } from '@/captcha/states/isCaptchaScriptLoadedState';
 import { captchaState } from '@/client-config/states/captchaState';
 import { clientConfigApiStatusState } from '@/client-config/states/clientConfigApiStatusState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { useRecoilValue } from 'recoil';
 import { isDefined } from 'twenty-shared/utils';
 import { isUndefinedOrNull } from '~/utils/isUndefinedOrNull';
 
 export const useCaptcha = () => {
   const captcha = useRecoilValue(captchaState);
-  const captchaToken = useRecoilValue(captchaTokenState);
+  const captchaToken = useRecoilValueV2(captchaTokenState);
   const clientConfigApiStatus = useRecoilValue(clientConfigApiStatusState);
-  const isCaptchaScriptLoaded = useRecoilValue(isCaptchaScriptLoadedState);
+  const isCaptchaScriptLoaded = useRecoilValueV2(isCaptchaScriptLoadedState);
 
   const isClientConfigLoaded = clientConfigApiStatus.isLoadedOnce;
   const isSiteKeyDefined = isDefined(captcha?.siteKey);

--- a/packages/twenty-front/src/modules/client-config/hooks/useClientConfig.ts
+++ b/packages/twenty-front/src/modules/client-config/hooks/useClientConfig.ts
@@ -45,7 +45,7 @@ type UseClientConfigResult = {
 
 export const useClientConfig = (): UseClientConfigResult => {
   const setIsAnalyticsEnabled = useSetRecoilStateV2(isAnalyticsEnabledState);
-  const setDomainConfiguration = useSetRecoilState(domainConfigurationState);
+  const setDomainConfiguration = useSetRecoilStateV2(domainConfigurationState);
   const setAuthProviders = useSetRecoilStateV2(authProvidersState);
   const setAiModels = useSetRecoilStateV2(aiModelsState);
 

--- a/packages/twenty-front/src/modules/command-menu/components/__stories__/CommandMenu.stories.tsx
+++ b/packages/twenty-front/src/modules/command-menu/components/__stories__/CommandMenu.stories.tsx
@@ -8,6 +8,7 @@ import { expect, userEvent, within } from 'storybook/test';
 
 import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
+import { useSetRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useSetRecoilStateV2';
 import { ComponentWithRouterDecorator } from '~/testing/decorators/ComponentWithRouterDecorator';
 import { ObjectMetadataItemsDecorator } from '~/testing/decorators/ObjectMetadataItemsDecorator';
 import { SnackBarDecorator } from '~/testing/decorators/SnackBarDecorator';
@@ -72,11 +73,11 @@ const meta: Meta<typeof CommandMenu> = {
   component: CommandMenuRouter,
   decorators: [
     (Story) => {
-      const setCurrentWorkspace = useSetRecoilState(currentWorkspaceState);
-      const setCurrentUserWorkspace = useSetRecoilState(
+      const setCurrentWorkspace = useSetRecoilStateV2(currentWorkspaceState);
+      const setCurrentUserWorkspace = useSetRecoilStateV2(
         currentUserWorkspaceState,
       );
-      const setCurrentWorkspaceMember = useSetRecoilState(
+      const setCurrentWorkspaceMember = useSetRecoilStateV2(
         currentWorkspaceMemberState,
       );
       const setIsCommandMenuOpened = useSetRecoilState(
@@ -138,7 +139,7 @@ export const LimitedPermissions: Story = {
   },
   decorators: [
     (Story) => {
-      const setCurrentUserWorkspace = useSetRecoilState(
+      const setCurrentUserWorkspace = useSetRecoilStateV2(
         currentUserWorkspaceState,
       );
       setCurrentUserWorkspace(

--- a/packages/twenty-front/src/modules/domain-manager/hooks/useBuildSearchParamsFromUrlSyncedStates.ts
+++ b/packages/twenty-front/src/modules/domain-manager/hooks/useBuildSearchParamsFromUrlSyncedStates.ts
@@ -1,27 +1,25 @@
+import { useCallback } from 'react';
+
 import { billingCheckoutSessionState } from '@/auth/states/billingCheckoutSessionState';
 import { BILLING_CHECKOUT_SESSION_DEFAULT_VALUE } from '@/billing/constants/BillingCheckoutSessionDefaultValue';
-import { useRecoilCallback } from 'recoil';
+import { jotaiStore } from '@/ui/utilities/state/jotai/jotaiStore';
 
 export const useBuildSearchParamsFromUrlSyncedStates = () => {
-  const buildSearchParamsFromUrlSyncedStates = useRecoilCallback(
-    ({ snapshot }) =>
-      async () => {
-        const billingCheckoutSession = snapshot
-          .getLoadable(billingCheckoutSessionState)
-          .getValue();
+  const buildSearchParamsFromUrlSyncedStates = useCallback(async () => {
+    const billingCheckoutSession = jotaiStore.get(
+      billingCheckoutSessionState.atom,
+    );
 
-        const output = {
-          ...(billingCheckoutSession !== BILLING_CHECKOUT_SESSION_DEFAULT_VALUE
-            ? {
-                billingCheckoutSession: JSON.stringify(billingCheckoutSession),
-              }
-            : {}),
-        };
+    const output = {
+      ...(billingCheckoutSession !== BILLING_CHECKOUT_SESSION_DEFAULT_VALUE
+        ? {
+            billingCheckoutSession: JSON.stringify(billingCheckoutSession),
+          }
+        : {}),
+    };
 
-        return output;
-      },
-    [],
-  );
+    return output;
+  }, []);
 
   return {
     buildSearchParamsFromUrlSyncedStates,

--- a/packages/twenty-front/src/modules/domain-manager/hooks/useGetPublicWorkspaceDataByDomain.ts
+++ b/packages/twenty-front/src/modules/domain-manager/hooks/useGetPublicWorkspaceDataByDomain.ts
@@ -4,9 +4,11 @@ import { isMultiWorkspaceEnabledState } from '@/client-config/states/isMultiWork
 import { useIsCurrentLocationOnDefaultDomain } from '@/domain-manager/hooks/useIsCurrentLocationOnDefaultDomain';
 import { useOrigin } from '@/domain-manager/hooks/useOrigin';
 import { useRedirectToDefaultDomain } from '@/domain-manager/hooks/useRedirectToDefaultDomain';
-import { workspaceAuthProvidersState } from '@/workspace/states/workspaceAuthProvidersState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
+import { useSetRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useSetRecoilStateV2';
 import { workspaceAuthBypassProvidersState } from '@/workspace/states/workspaceAuthBypassProvidersState';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { workspaceAuthProvidersState } from '@/workspace/states/workspaceAuthProvidersState';
+import { useRecoilValue } from 'recoil';
 import { isDefined } from 'twenty-shared/utils';
 import { useGetPublicWorkspaceDataByDomainQuery } from '~/generated-metadata/graphql';
 
@@ -14,15 +16,15 @@ export const useGetPublicWorkspaceDataByDomain = () => {
   const { isDefaultDomain } = useIsCurrentLocationOnDefaultDomain();
   const isMultiWorkspaceEnabled = useRecoilValue(isMultiWorkspaceEnabledState);
   const { origin } = useOrigin();
-  const setWorkspaceAuthProviders = useSetRecoilState(
+  const setWorkspaceAuthProviders = useSetRecoilStateV2(
     workspaceAuthProvidersState,
   );
-  const setWorkspaceAuthBypassProviders = useSetRecoilState(
+  const setWorkspaceAuthBypassProviders = useSetRecoilStateV2(
     workspaceAuthBypassProvidersState,
   );
-  const workspacePublicData = useRecoilValue(workspacePublicDataState);
+  const workspacePublicData = useRecoilValueV2(workspacePublicDataState);
   const { redirectToDefaultDomain } = useRedirectToDefaultDomain();
-  const setWorkspacePublicDataState = useSetRecoilState(
+  const setWorkspacePublicDataState = useSetRecoilStateV2(
     workspacePublicDataState,
   );
   const clientConfigApiStatus = useRecoilValue(clientConfigApiStatusState);

--- a/packages/twenty-front/src/modules/domain-manager/hooks/useIsCurrentLocationOnAWorkspace.ts
+++ b/packages/twenty-front/src/modules/domain-manager/hooks/useIsCurrentLocationOnAWorkspace.ts
@@ -1,6 +1,7 @@
 import { isMultiWorkspaceEnabledState } from '@/client-config/states/isMultiWorkspaceEnabledState';
 import { useReadDefaultDomainFromConfiguration } from '@/domain-manager/hooks/useReadDefaultDomainFromConfiguration';
 import { domainConfigurationState } from '@/domain-manager/states/domainConfigurationState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { useRecoilValue } from 'recoil';
 import { isDefined } from 'twenty-shared/utils';
 
@@ -8,7 +9,7 @@ export const useIsCurrentLocationOnAWorkspace = () => {
   const { defaultDomain } = useReadDefaultDomainFromConfiguration();
 
   const isMultiWorkspaceEnabled = useRecoilValue(isMultiWorkspaceEnabledState);
-  const domainConfiguration = useRecoilValue(domainConfigurationState);
+  const domainConfiguration = useRecoilValueV2(domainConfigurationState);
 
   if (
     isMultiWorkspaceEnabled &&

--- a/packages/twenty-front/src/modules/domain-manager/hooks/useLastAuthenticatedWorkspaceDomain.ts
+++ b/packages/twenty-front/src/modules/domain-manager/hooks/useLastAuthenticatedWorkspaceDomain.ts
@@ -1,10 +1,11 @@
 import { domainConfigurationState } from '@/domain-manager/states/domainConfigurationState';
 import { lastAuthenticatedWorkspaceDomainState } from '@/domain-manager/states/lastAuthenticatedWorkspaceDomainState';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
+import { useSetRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useSetRecoilStateV2';
 
 export const useLastAuthenticatedWorkspaceDomain = () => {
-  const domainConfiguration = useRecoilValue(domainConfigurationState);
-  const setLastAuthenticatedWorkspaceDomain = useSetRecoilState(
+  const domainConfiguration = useRecoilValueV2(domainConfigurationState);
+  const setLastAuthenticatedWorkspaceDomain = useSetRecoilStateV2(
     lastAuthenticatedWorkspaceDomainState,
   );
   const setLastAuthenticateWorkspaceDomainWithCookieAttributes = (

--- a/packages/twenty-front/src/modules/domain-manager/hooks/useReadDefaultDomainFromConfiguration.ts
+++ b/packages/twenty-front/src/modules/domain-manager/hooks/useReadDefaultDomainFromConfiguration.ts
@@ -1,9 +1,10 @@
 import { isMultiWorkspaceEnabledState } from '@/client-config/states/isMultiWorkspaceEnabledState';
 import { domainConfigurationState } from '@/domain-manager/states/domainConfigurationState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { useRecoilValue } from 'recoil';
 
 export const useReadDefaultDomainFromConfiguration = () => {
-  const domainConfiguration = useRecoilValue(domainConfigurationState);
+  const domainConfiguration = useRecoilValueV2(domainConfigurationState);
   const isMultiWorkspaceEnabled = useRecoilValue(isMultiWorkspaceEnabledState);
 
   const defaultDomain = isMultiWorkspaceEnabled

--- a/packages/twenty-front/src/modules/domain-manager/states/domainConfigurationState.ts
+++ b/packages/twenty-front/src/modules/domain-manager/states/domainConfigurationState.ts
@@ -1,7 +1,7 @@
 import { type ClientConfig } from '@/client-config/types/ClientConfig';
-import { createState } from '@/ui/utilities/state/utils/createState';
+import { createStateV2 } from '@/ui/utilities/state/jotai/utils/createStateV2';
 
-export const domainConfigurationState = createState<
+export const domainConfigurationState = createStateV2<
   Pick<ClientConfig, 'frontDomain' | 'defaultSubdomain'>
 >({
   key: 'domainConfiguration',

--- a/packages/twenty-front/src/modules/domain-manager/states/lastAuthenticatedWorkspaceDomainState.ts
+++ b/packages/twenty-front/src/modules/domain-manager/states/lastAuthenticatedWorkspaceDomainState.ts
@@ -1,7 +1,6 @@
-import { cookieStorageEffect } from '~/utils/recoil/cookieStorageEffect';
-import { createState } from '@/ui/utilities/state/utils/createState';
+import { createStateV2 } from '@/ui/utilities/state/jotai/utils/createStateV2';
 
-export const lastAuthenticatedWorkspaceDomainState = createState<
+export const lastAuthenticatedWorkspaceDomainState = createStateV2<
   | {
       workspaceUrl: string;
       workspaceId: string;
@@ -13,9 +12,10 @@ export const lastAuthenticatedWorkspaceDomainState = createState<
 >({
   key: 'lastAuthenticateWorkspaceDomain',
   defaultValue: null,
-  effects: [
-    cookieStorageEffect('lastAuthenticateWorkspaceDomain', {
-      expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 365), // 1 year
-    }),
-  ],
+  useCookieStorage: {
+    cookieKey: 'lastAuthenticateWorkspaceDomain',
+    attributes: {
+      expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 365),
+    },
+  },
 });

--- a/packages/twenty-front/src/modules/error-handler/components/SentryInitEffect.tsx
+++ b/packages/twenty-front/src/modules/error-handler/components/SentryInitEffect.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useState } from 'react';
-import { useRecoilValue } from 'recoil';
-
 import { currentUserState } from '@/auth/states/currentUserState';
 import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { sentryConfigState } from '@/client-config/states/sentryConfigState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
+import { useEffect, useState } from 'react';
+import { useRecoilValue } from 'recoil';
 import { isNonEmptyString } from '@sniptt/guards';
 import { isDefined } from 'twenty-shared/utils';
 import { REACT_APP_SERVER_BASE_URL } from '~/config';
@@ -12,9 +12,9 @@ import { REACT_APP_SERVER_BASE_URL } from '~/config';
 export const SentryInitEffect = () => {
   const sentryConfig = useRecoilValue(sentryConfigState);
 
-  const currentUser = useRecoilValue(currentUserState);
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
-  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+  const currentUser = useRecoilValueV2(currentUserState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
+  const currentWorkspaceMember = useRecoilValueV2(currentWorkspaceMemberState);
 
   const [isSentryInitialized, setIsSentryInitialized] = useState(false);
   const [isSentryInitializing, setIsSentryInitializing] = useState(false);

--- a/packages/twenty-front/src/modules/favorites/components/CurrentWorkspaceMemberFavoritesFolders.tsx
+++ b/packages/twenty-front/src/modules/favorites/components/CurrentWorkspaceMemberFavoritesFolders.tsx
@@ -13,14 +13,14 @@ import { NavigationDrawerSectionTitle } from '@/ui/navigation/navigation-drawer/
 import { useNavigationSection } from '@/ui/navigation/navigation-drawer/hooks/useNavigationSection';
 import { isNavigationSectionOpenFamilyState } from '@/ui/navigation/navigation-drawer/states/isNavigationSectionOpenFamilyState';
 import { useFamilyRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useFamilyRecoilValueV2';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { useLingui } from '@lingui/react/macro';
-import { useRecoilValue } from 'recoil';
 import { isDefined } from 'twenty-shared/utils';
 import { IconFolderPlus } from 'twenty-ui/display';
 import { LightIconButton } from 'twenty-ui/input';
 
 export const CurrentWorkspaceMemberFavoritesFolders = () => {
-  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+  const currentWorkspaceMember = useRecoilValueV2(currentWorkspaceMemberState);
   const { sortedFavorites: favorites } = useFavorites();
   const { favoritesByFolder } = useFavoritesByFolder();
 

--- a/packages/twenty-front/src/modules/favorites/hooks/__tests__/useCreateFavorite.test.tsx
+++ b/packages/twenty-front/src/modules/favorites/hooks/__tests__/useCreateFavorite.test.tsx
@@ -5,6 +5,7 @@ import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMembe
 import { useCreateFavorite } from '@/favorites/hooks/useCreateFavorite';
 import { objectMetadataItemsState } from '@/object-metadata/states/objectMetadataItemsState';
 import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
+import { jotaiStore } from '@/ui/utilities/state/jotai/jotaiStore';
 import { getJestMetadataAndApolloMocksWrapper } from '~/testing/jest/getJestMetadataAndApolloMocksWrapper';
 import { generatedMockObjectMetadataItems } from '~/testing/utils/generatedMockObjectMetadataItems';
 import {
@@ -46,13 +47,10 @@ const Wrapper = getJestMetadataAndApolloMocksWrapper({
 
 describe('useCreateFavorite', () => {
   it('should create favorite successfully', async () => {
+    jotaiStore.set(currentWorkspaceMemberState.atom, mockWorkspaceMember);
+
     const { result } = renderHook(
       () => {
-        const setCurrentWorkspaceMember = useSetRecoilState(
-          currentWorkspaceMemberState,
-        );
-        setCurrentWorkspaceMember(mockWorkspaceMember);
-
         const setMetadataItems = useSetRecoilState(objectMetadataItemsState);
         setMetadataItems(generatedMockObjectMetadataItems);
 

--- a/packages/twenty-front/src/modules/favorites/hooks/__tests__/useDeleteFavorite.test.tsx
+++ b/packages/twenty-front/src/modules/favorites/hooks/__tests__/useDeleteFavorite.test.tsx
@@ -4,6 +4,7 @@ import { useSetRecoilState } from 'recoil';
 import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
 import { useDeleteFavorite } from '@/favorites/hooks/useDeleteFavorite';
 import { objectMetadataItemsState } from '@/object-metadata/states/objectMetadataItemsState';
+import { jotaiStore } from '@/ui/utilities/state/jotai/jotaiStore';
 import { getJestMetadataAndApolloMocksWrapper } from '~/testing/jest/getJestMetadataAndApolloMocksWrapper';
 import { generatedMockObjectMetadataItems } from '~/testing/utils/generatedMockObjectMetadataItems';
 import {
@@ -23,13 +24,10 @@ const Wrapper = getJestMetadataAndApolloMocksWrapper({
 
 describe('useDeleteFavorite', () => {
   it('should delete favorite successfully', async () => {
+    jotaiStore.set(currentWorkspaceMemberState.atom, mockWorkspaceMember);
+
     const { result } = renderHook(
       () => {
-        const setCurrentWorkspaceMember = useSetRecoilState(
-          currentWorkspaceMemberState,
-        );
-        setCurrentWorkspaceMember(mockWorkspaceMember);
-
         const setMetadataItems = useSetRecoilState(objectMetadataItemsState);
         setMetadataItems(generatedMockObjectMetadataItems);
 

--- a/packages/twenty-front/src/modules/favorites/hooks/__tests__/useFavorites.test.tsx
+++ b/packages/twenty-front/src/modules/favorites/hooks/__tests__/useFavorites.test.tsx
@@ -6,6 +6,7 @@ import { useFavorites } from '@/favorites/hooks/useFavorites';
 
 import { objectMetadataItemsState } from '@/object-metadata/states/objectMetadataItemsState';
 import { prefetchFavoritesState } from '@/prefetch/states/prefetchFavoritesState';
+import { jotaiStore } from '@/ui/utilities/state/jotai/jotaiStore';
 import { getJestMetadataAndApolloMocksWrapper } from '~/testing/jest/getJestMetadataAndApolloMocksWrapper';
 import { generatedMockObjectMetadataItems } from '~/testing/utils/generatedMockObjectMetadataItems';
 import {
@@ -20,15 +21,12 @@ const Wrapper = getJestMetadataAndApolloMocksWrapper({
 
 describe('useFavorites', () => {
   it('should fetch and sort favorites successfully', () => {
+    jotaiStore.set(currentWorkspaceMemberState.atom, mockWorkspaceMember);
+
     const { result } = renderHook(
       () => {
         const setPrefetchFavorites = useSetRecoilState(prefetchFavoritesState);
         setPrefetchFavorites(initialFavorites);
-
-        const setCurrentWorkspaceMember = useSetRecoilState(
-          currentWorkspaceMemberState,
-        );
-        setCurrentWorkspaceMember(mockWorkspaceMember);
 
         const setMetadataItems = useSetRecoilState(objectMetadataItemsState);
         setMetadataItems(generatedMockObjectMetadataItems);

--- a/packages/twenty-front/src/modules/favorites/hooks/__tests__/useHandleFavoriteDragAndDrop.test.tsx
+++ b/packages/twenty-front/src/modules/favorites/hooks/__tests__/useHandleFavoriteDragAndDrop.test.tsx
@@ -11,6 +11,7 @@ import { createFolderDroppableId } from '@/favorites/utils/createFolderDroppable
 import { createFolderHeaderDroppableId } from '@/favorites/utils/createFolderHeaderDroppableId';
 import { objectMetadataItemsState } from '@/object-metadata/states/objectMetadataItemsState';
 import { prefetchFavoritesState } from '@/prefetch/states/prefetchFavoritesState';
+import { jotaiStore } from '@/ui/utilities/state/jotai/jotaiStore';
 import { getJestMetadataAndApolloMocksWrapper } from '~/testing/jest/getJestMetadataAndApolloMocksWrapper';
 import { generatedMockObjectMetadataItems } from '~/testing/utils/generatedMockObjectMetadataItems';
 import {
@@ -33,17 +34,14 @@ describe('useHandleFavoriteDragAndDrop', () => {
   };
 
   const setupHook = () => {
+    jotaiStore.set(currentWorkspaceMemberState.atom, mockWorkspaceMember);
+
     return renderHook(
       () => {
         const setPrefetchFavorites = useSetRecoilState(prefetchFavoritesState);
         setPrefetchFavorites(initialFavorites as Favorite[]);
 
-        const setCurrentWorkspaceMember = useSetRecoilState(
-          currentWorkspaceMemberState,
-        );
         const setMetadataItems = useSetRecoilState(objectMetadataItemsState);
-
-        setCurrentWorkspaceMember(mockWorkspaceMember);
         setMetadataItems(generatedMockObjectMetadataItems);
 
         return {

--- a/packages/twenty-front/src/modules/favorites/hooks/usePrefetchedFavoritesData.ts
+++ b/packages/twenty-front/src/modules/favorites/hooks/usePrefetchedFavoritesData.ts
@@ -1,6 +1,7 @@
 import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
 import { type Favorite } from '@/favorites/types/Favorite';
 import { prefetchFavoritesState } from '@/prefetch/states/prefetchFavoritesState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { useRecoilValue } from 'recoil';
 
 type PrefetchedFavoritesData = {
@@ -10,7 +11,7 @@ type PrefetchedFavoritesData = {
 };
 
 export const usePrefetchedFavoritesData = (): PrefetchedFavoritesData => {
-  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+  const currentWorkspaceMember = useRecoilValueV2(currentWorkspaceMemberState);
   const currentWorkspaceMemberId = currentWorkspaceMember?.id;
   const prefetchFavorites = useRecoilValue(prefetchFavoritesState);
 

--- a/packages/twenty-front/src/modules/favorites/hooks/usePrefetchedFavoritesFoldersData.ts
+++ b/packages/twenty-front/src/modules/favorites/hooks/usePrefetchedFavoritesFoldersData.ts
@@ -1,6 +1,7 @@
 import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
 import { type FavoriteFolder } from '@/favorites/types/FavoriteFolder';
 import { prefetchFavoriteFoldersState } from '@/prefetch/states/prefetchFavoriteFoldersState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { useRecoilValue } from 'recoil';
 
 type PrefetchedFavoritesFoldersData = {
@@ -10,7 +11,9 @@ type PrefetchedFavoritesFoldersData = {
 
 export const usePrefetchedFavoritesFoldersData =
   (): PrefetchedFavoritesFoldersData => {
-    const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+    const currentWorkspaceMember = useRecoilValueV2(
+      currentWorkspaceMemberState,
+    );
     const currentWorkspaceMemberId = currentWorkspaceMember?.id;
 
     const prefetchFavoriteFolders = useRecoilValue(

--- a/packages/twenty-front/src/modules/front-components/hooks/useFrontComponentExecutionContext.ts
+++ b/packages/twenty-front/src/modules/front-components/hooks/useFrontComponentExecutionContext.ts
@@ -1,4 +1,3 @@
-import { useRecoilValue } from 'recoil';
 import {
   type FrontComponentExecutionContext,
   type FrontComponentHostCommunicationApi,
@@ -6,13 +5,14 @@ import {
 import { type AppPath } from 'twenty-shared/types';
 
 import { currentUserState } from '@/auth/states/currentUserState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { useNavigateApp } from '~/hooks/useNavigateApp';
 
 export const useFrontComponentExecutionContext = (): {
   executionContext: FrontComponentExecutionContext;
   frontComponentHostCommunicationApi: FrontComponentHostCommunicationApi;
 } => {
-  const currentUser = useRecoilValue(currentUserState);
+  const currentUser = useRecoilValueV2(currentUserState);
   const navigateApp = useNavigateApp();
 
   const navigate: FrontComponentHostCommunicationApi['navigate'] = async (

--- a/packages/twenty-front/src/modules/information-banner/components/impersonate/InformationBannerIsImpersonating.tsx
+++ b/packages/twenty-front/src/modules/information-banner/components/impersonate/InformationBannerIsImpersonating.tsx
@@ -3,13 +3,13 @@ import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMembe
 import { isImpersonatingState } from '@/auth/states/isImpersonatingState';
 import { InformationBanner } from '@/information-banner/components/InformationBanner';
 import { t } from '@lingui/core/macro';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { isDefined } from 'twenty-shared/utils';
 import { IconLogout } from 'twenty-ui/display';
 
 export const InformationBannerIsImpersonating = () => {
-  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
-  const isImpersonating = useRecoilValue(isImpersonatingState);
+  const currentWorkspaceMember = useRecoilValueV2(currentWorkspaceMemberState);
+  const isImpersonating = useRecoilValueV2(isImpersonatingState);
 
   const { signOut } = useAuth();
 

--- a/packages/twenty-front/src/modules/information-banner/hooks/useAccountToReconnect.ts
+++ b/packages/twenty-front/src/modules/information-banner/hooks/useAccountToReconnect.ts
@@ -3,10 +3,10 @@ import { currentUserState } from '@/auth/states/currentUserState';
 import { type InformationBannerKeys } from '@/information-banner/types/InformationBannerKeys';
 import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
 import { useFindOneRecord } from '@/object-record/hooks/useFindOneRecord';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 
 export const useAccountToReconnect = (key: InformationBannerKeys) => {
-  const currentUser = useRecoilValue(currentUserState);
+  const currentUser = useRecoilValueV2(currentUserState);
 
   const userVars = currentUser?.userVars;
 

--- a/packages/twenty-front/src/modules/localization/hooks/__tests__/useFormatPreferences.test.tsx
+++ b/packages/twenty-front/src/modules/localization/hooks/__tests__/useFormatPreferences.test.tsx
@@ -1,6 +1,7 @@
 import { act, renderHook } from '@testing-library/react';
 import { type ReactNode } from 'react';
-import { RecoilRoot, type MutableSnapshot } from 'recoil';
+import { type MutableSnapshot, RecoilRoot } from 'recoil';
+import { Provider as JotaiProvider } from 'jotai';
 
 import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
 import { DateFormat } from '@/localization/constants/DateFormat';
@@ -8,6 +9,7 @@ import { NumberFormat } from '@/localization/constants/NumberFormat';
 import { TimeFormat } from '@/localization/constants/TimeFormat';
 import { useFormatPreferences } from '@/localization/hooks/useFormatPreferences';
 import { workspaceMemberFormatPreferencesState } from '@/localization/states/workspaceMemberFormatPreferencesState';
+import { jotaiStore } from '@/ui/utilities/state/jotai/jotaiStore';
 import { detectCalendarStartDay } from '@/localization/utils/detection/detectCalendarStartDay';
 import { detectDateFormat } from '@/localization/utils/detection/detectDateFormat';
 import { detectNumberFormat } from '@/localization/utils/detection/detectNumberFormat';
@@ -73,18 +75,29 @@ const mockInitialPreferences = {
   calendarStartDay: CalendarStartDay.MONDAY,
 };
 
-const Wrapper = ({ children }: { children: ReactNode }) => {
-  const initializeState = ({ set }: MutableSnapshot) => {
-    set(currentWorkspaceMemberState, mockCurrentWorkspaceMember);
-    set(workspaceMemberFormatPreferencesState, mockInitialPreferences);
-  };
+const createWrapper =
+  (initializeRecoilState?: (mutableSnapshot: MutableSnapshot) => void) =>
+  ({ children }: { children: ReactNode }) => {
+    const defaultInitState = ({ set }: MutableSnapshot) => {
+      set(workspaceMemberFormatPreferencesState, mockInitialPreferences);
+      initializeRecoilState?.({ set } as MutableSnapshot);
+    };
 
-  return <RecoilRoot initializeState={initializeState}>{children}</RecoilRoot>;
-};
+    return (
+      <JotaiProvider store={jotaiStore}>
+        <RecoilRoot initializeState={defaultInitState}>{children}</RecoilRoot>
+      </JotaiProvider>
+    );
+  };
 
 describe('useFormatPreferences', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+
+    jotaiStore.set(
+      currentWorkspaceMemberState.atom,
+      mockCurrentWorkspaceMember,
+    );
 
     mockUseUpdateOneRecord.mockReturnValue({
       updateOneRecord: mockUpdateOneRecord,
@@ -106,7 +119,7 @@ describe('useFormatPreferences', () => {
 
   it('should return format preferences and update functions', () => {
     const { result } = renderHook(() => useFormatPreferences(), {
-      wrapper: Wrapper,
+      wrapper: createWrapper(),
     });
 
     expect(result.current).toHaveProperty('formatPreferences');
@@ -123,7 +136,7 @@ describe('useFormatPreferences', () => {
 
   it('should return current format preferences', () => {
     const { result } = renderHook(() => useFormatPreferences(), {
-      wrapper: Wrapper,
+      wrapper: createWrapper(),
     });
 
     expect(result.current.formatPreferences).toEqual(mockInitialPreferences);
@@ -131,7 +144,7 @@ describe('useFormatPreferences', () => {
 
   it('should update single format preference successfully', async () => {
     const { result } = renderHook(() => useFormatPreferences(), {
-      wrapper: Wrapper,
+      wrapper: createWrapper(),
     });
 
     const newTimeZone = 'Europe/London';
@@ -152,7 +165,7 @@ describe('useFormatPreferences', () => {
 
   it('should handle SYSTEM values by detecting actual format', async () => {
     const { result } = renderHook(() => useFormatPreferences(), {
-      wrapper: Wrapper,
+      wrapper: createWrapper(),
     });
 
     mockDetectTimeZone.mockReturnValue('America/Chicago');
@@ -174,7 +187,7 @@ describe('useFormatPreferences', () => {
 
   it('should update multiple format preferences successfully', async () => {
     const { result } = renderHook(() => useFormatPreferences(), {
-      wrapper: Wrapper,
+      wrapper: createWrapper(),
     });
 
     const updates = {
@@ -198,17 +211,10 @@ describe('useFormatPreferences', () => {
   });
 
   it('should not update preferences when user is not logged in', async () => {
-    const { result } = renderHook(() => useFormatPreferences(), {
-      wrapper: ({ children }: { children: ReactNode }) => {
-        const initializeState = ({ set }: MutableSnapshot) => {
-          set(currentWorkspaceMemberState, null);
-          set(workspaceMemberFormatPreferencesState, mockInitialPreferences);
-        };
+    jotaiStore.set(currentWorkspaceMemberState.atom, null);
 
-        return (
-          <RecoilRoot initializeState={initializeState}>{children}</RecoilRoot>
-        );
-      },
+    const { result } = renderHook(() => useFormatPreferences(), {
+      wrapper: createWrapper(),
     });
 
     await act(async () => {
@@ -220,7 +226,7 @@ describe('useFormatPreferences', () => {
 
   it('should handle update errors gracefully', async () => {
     const { result } = renderHook(() => useFormatPreferences(), {
-      wrapper: Wrapper,
+      wrapper: createWrapper(),
     });
 
     const error = new Error('Update failed');
@@ -238,7 +244,7 @@ describe('useFormatPreferences', () => {
 
   it('should initialize format preferences from workspace member', () => {
     const { result } = renderHook(() => useFormatPreferences(), {
-      wrapper: Wrapper,
+      wrapper: createWrapper(),
     });
 
     act(() => {
@@ -250,7 +256,7 @@ describe('useFormatPreferences', () => {
 
   it('should not initialize format preferences when workspace member is null', () => {
     const { result } = renderHook(() => useFormatPreferences(), {
-      wrapper: Wrapper,
+      wrapper: createWrapper(),
     });
 
     act(() => {

--- a/packages/twenty-front/src/modules/localization/hooks/useFormatPreferences.ts
+++ b/packages/twenty-front/src/modules/localization/hooks/useFormatPreferences.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilState } from 'recoil';
 
 import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
 import { DateFormat } from '@/localization/constants/DateFormat';
@@ -18,6 +18,8 @@ import { getFormatPreferencesFromWorkspaceMember } from '@/localization/utils/fo
 import { getWorkspaceMemberUpdateFromFormatPreferences } from '@/localization/utils/format-preferences/getWorkspaceMemberUpdateFromFormatPreferences';
 import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
 import { useUpdateOneRecord } from '@/object-record/hooks/useUpdateOneRecord';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
+import { useSetRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useSetRecoilStateV2';
 import { CalendarStartDay } from 'twenty-shared/constants';
 import { logError } from '~/utils/logError';
 
@@ -28,8 +30,8 @@ export const useFormatPreferences = () => {
     workspaceMemberFormatPreferences,
     setWorkspaceMemberFormatPreferences,
   ] = useRecoilState(workspaceMemberFormatPreferencesState);
-  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
-  const setCurrentWorkspaceMember = useSetRecoilState(
+  const currentWorkspaceMember = useRecoilValueV2(currentWorkspaceMemberState);
+  const setCurrentWorkspaceMember = useSetRecoilStateV2(
     currentWorkspaceMemberState,
   );
 

--- a/packages/twenty-front/src/modules/navigation-menu-item/components/CurrentWorkspaceMemberNavigationMenuItemFolders.tsx
+++ b/packages/twenty-front/src/modules/navigation-menu-item/components/CurrentWorkspaceMemberNavigationMenuItemFolders.tsx
@@ -1,10 +1,8 @@
+import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
 import { useLingui } from '@lingui/react/macro';
-import { useRecoilValue } from 'recoil';
 import { isDefined } from 'twenty-shared/utils';
 import { IconFolderPlus } from 'twenty-ui/display';
 import { LightIconButton } from 'twenty-ui/input';
-
-import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
 import { CurrentWorkspaceMemberOrphanNavigationMenuItems } from '@/navigation-menu-item/components/CurrentWorkspaceMemberOrphanNavigationMenuItems';
 import { NavigationMenuItemFolders } from '@/navigation-menu-item/components/NavigationMenuItemFolders';
 import { NavigationMenuItemSkeletonLoader } from '@/navigation-menu-item/components/NavigationMenuItemSkeletonLoader';
@@ -19,9 +17,10 @@ import { NavigationDrawerSectionTitle } from '@/ui/navigation/navigation-drawer/
 import { useNavigationSection } from '@/ui/navigation/navigation-drawer/hooks/useNavigationSection';
 import { isNavigationSectionOpenFamilyState } from '@/ui/navigation/navigation-drawer/states/isNavigationSectionOpenFamilyState';
 import { useFamilyRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useFamilyRecoilValueV2';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 
 export const CurrentWorkspaceMemberNavigationMenuItemFolders = () => {
-  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+  const currentWorkspaceMember = useRecoilValueV2(currentWorkspaceMemberState);
   const { navigationMenuItemsSorted } = useSortedNavigationMenuItems();
   const { userNavigationMenuItemsByFolder } = useNavigationMenuItemsByFolder();
 

--- a/packages/twenty-front/src/modules/navigation-menu-item/hooks/usePrefetchedNavigationMenuItemsData.ts
+++ b/packages/twenty-front/src/modules/navigation-menu-item/hooks/usePrefetchedNavigationMenuItemsData.ts
@@ -5,6 +5,7 @@ import { filterWorkspaceNavigationMenuItems } from '@/navigation-menu-item/utils
 import { prefetchNavigationMenuItemsState } from '@/prefetch/states/prefetchNavigationMenuItemsState';
 import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { useRecoilValue } from 'recoil';
+
 import { isDefined } from 'twenty-shared/utils';
 import { type NavigationMenuItem } from '~/generated-metadata/graphql';
 
@@ -16,7 +17,9 @@ type PrefetchedNavigationMenuItemsData = {
 
 export const usePrefetchedNavigationMenuItemsData =
   (): PrefetchedNavigationMenuItemsData => {
-    const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+    const currentWorkspaceMember = useRecoilValueV2(
+      currentWorkspaceMemberState,
+    );
     const currentWorkspaceMemberId = currentWorkspaceMember?.id;
     const prefetchNavigationMenuItems = useRecoilValue(
       prefetchNavigationMenuItemsState,

--- a/packages/twenty-front/src/modules/navigation/components/MainNavigationDrawer.tsx
+++ b/packages/twenty-front/src/modules/navigation/components/MainNavigationDrawer.tsx
@@ -1,7 +1,5 @@
-import styled from '@emotion/styled';
-import { useRecoilValue } from 'recoil';
-
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
+import styled from '@emotion/styled';
 import { useFavoritesByFolder } from '@/favorites/hooks/useFavoritesByFolder';
 import { NavigationMenuItemFolderContentDispatcherEffect } from '@/navigation-menu-item/components/NavigationMenuItemFolderContentDispatcher';
 import { useNavigationMenuItemsByFolder } from '@/navigation-menu-item/hooks/useNavigationMenuItemsByFolder';
@@ -22,7 +20,7 @@ const StyledScrollableContent = styled.div`
 `;
 
 export const MainNavigationDrawer = ({ className }: { className?: string }) => {
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
   const currentFavoriteFolderId = useRecoilValueV2(
     currentFavoriteFolderIdStateV2,
   );

--- a/packages/twenty-front/src/modules/navigation/hooks/__tests__/useDefaultHomePagePath.test.ts
+++ b/packages/twenty-front/src/modules/navigation/hooks/__tests__/useDefaultHomePagePath.test.ts
@@ -6,6 +6,7 @@ import { currentUserState } from '@/auth/states/currentUserState';
 import { currentUserWorkspaceState } from '@/auth/states/currentUserWorkspaceState';
 import { useDefaultHomePagePath } from '@/navigation/hooks/useDefaultHomePagePath';
 import { objectMetadataItemsState } from '@/object-metadata/states/objectMetadataItemsState';
+import { useSetRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useSetRecoilStateV2';
 import { AggregateOperations } from '@/object-record/record-table/constants/AggregateOperations';
 import { coreViewsState } from '@/views/states/coreViewState';
 import { AppPath } from 'twenty-shared/types';
@@ -27,8 +28,8 @@ const renderHooks = ({
 }) => {
   const { result } = renderHook(
     () => {
-      const setCurrentUser = useSetRecoilState(currentUserState);
-      const setCurrentUserWorkspace = useSetRecoilState(
+      const setCurrentUser = useSetRecoilStateV2(currentUserState);
+      const setCurrentUserWorkspace = useSetRecoilStateV2(
         currentUserWorkspaceState,
       );
       const setObjectMetadataItems = useSetRecoilState(

--- a/packages/twenty-front/src/modules/navigation/hooks/useDefaultHomePagePath.ts
+++ b/packages/twenty-front/src/modules/navigation/hooks/useDefaultHomePagePath.ts
@@ -4,16 +4,17 @@ import { type ObjectPathInfo } from '@/navigation/types/ObjectPathInfo';
 import { useFilteredObjectMetadataItems } from '@/object-metadata/hooks/useFilteredObjectMetadataItems';
 import { useObjectPermissions } from '@/object-record/hooks/useObjectPermissions';
 import { getObjectPermissionsFromMapByObjectMetadataId } from '@/settings/roles/role-permissions/objects-permissions/utils/getObjectPermissionsFromMapByObjectMetadataId';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { coreViewsState } from '@/views/states/coreViewState';
 import { convertCoreViewToView } from '@/views/utils/convertCoreViewToView';
 import isEmpty from 'lodash.isempty';
 import { useCallback, useMemo } from 'react';
-import { useRecoilCallback, useRecoilValue } from 'recoil';
+import { useRecoilCallback } from 'recoil';
 import { AppPath, SettingsPath } from 'twenty-shared/types';
 import { getAppPath, getSettingsPath, isDefined } from 'twenty-shared/utils';
 
 export const useDefaultHomePagePath = () => {
-  const currentUser = useRecoilValue(currentUserState);
+  const currentUser = useRecoilValueV2(currentUserState);
   const { objectPermissionsByObjectMetadataId } = useObjectPermissions();
 
   const { alphaSortedActiveNonSystemObjectMetadataItems } =

--- a/packages/twenty-front/src/modules/object-metadata/components/ObjectMetadataItemsLoadEffect.tsx
+++ b/packages/twenty-front/src/modules/object-metadata/components/ObjectMetadataItemsLoadEffect.tsx
@@ -1,16 +1,15 @@
-import { useEffect, useState } from 'react';
-import { useRecoilValue } from 'recoil';
-
 import { currentUserState } from '@/auth/states/currentUserState';
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
+import { useEffect, useState } from 'react';
 import { useLoadMockedObjectMetadataItems } from '@/object-metadata/hooks/useLoadMockedObjectMetadataItems';
 import { useRefreshObjectMetadataItems } from '@/object-metadata/hooks/useRefreshObjectMetadataItems';
 import { isWorkspaceActiveOrSuspended } from 'twenty-shared/workspace';
 import { isUndefinedOrNull } from '~/utils/isUndefinedOrNull';
 
 export const ObjectMetadataItemsLoadEffect = () => {
-  const currentUser = useRecoilValue(currentUserState);
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
+  const currentUser = useRecoilValueV2(currentUserState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
   const [isInitialized, setIsInitialized] = useState(false);
 
   const { refreshObjectMetadataItems } = useRefreshObjectMetadataItems();

--- a/packages/twenty-front/src/modules/object-metadata/components/RemoteNavigationDrawerSection.tsx
+++ b/packages/twenty-front/src/modules/object-metadata/components/RemoteNavigationDrawerSection.tsx
@@ -1,15 +1,14 @@
-import { useRecoilValue } from 'recoil';
-
 import { currentUserState } from '@/auth/states/currentUserState';
 import { NavigationDrawerSectionForObjectMetadataItems } from '@/object-metadata/components/NavigationDrawerSectionForObjectMetadataItems';
 import { NavigationDrawerSectionForObjectMetadataItemsSkeletonLoader } from '@/object-metadata/components/NavigationDrawerSectionForObjectMetadataItemsSkeletonLoader';
 import { useFilteredObjectMetadataItems } from '@/object-metadata/hooks/useFilteredObjectMetadataItems';
 import { useIsPrefetchLoading } from '@/prefetch/hooks/useIsPrefetchLoading';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { useLingui } from '@lingui/react/macro';
 import { isDefined } from 'twenty-shared/utils';
 
 export const RemoteNavigationDrawerSection = () => {
-  const currentUser = useRecoilValue(currentUserState);
+  const currentUser = useRecoilValueV2(currentUserState);
   const { t } = useLingui();
 
   const { activeNonSystemObjectMetadataItems } =

--- a/packages/twenty-front/src/modules/object-metadata/hooks/__tests__/useColumnDefinitionsFromObjectMetadata.test.ts
+++ b/packages/twenty-front/src/modules/object-metadata/hooks/__tests__/useColumnDefinitionsFromObjectMetadata.test.ts
@@ -6,6 +6,7 @@ import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { CUSTOM_WORKSPACE_APPLICATION_MOCK } from '@/object-metadata/hooks/__tests__/constants/CustomWorkspaceApplicationMock.test.constant';
 import { useColumnDefinitionsFromObjectMetadata } from '@/object-metadata/hooks/useColumnDefinitionsFromObjectMetadata';
 import { type ObjectMetadataItem } from '@/object-metadata/types/ObjectMetadataItem';
+import { jotaiStore } from '@/ui/utilities/state/jotai/jotaiStore';
 import {
   SubscriptionInterval,
   SubscriptionStatus,
@@ -18,8 +19,14 @@ const Wrapper = getJestMetadataAndApolloMocksAndActionMenuWrapper({
   apolloMocks: [],
   componentInstanceId: 'instanceId',
   contextStoreCurrentObjectMetadataNameSingular: 'company',
-  onInitializeRecoilSnapshot: ({ set }) => {
-    set(currentWorkspaceState, {
+  onInitializeRecoilSnapshot: () => {
+    // Recoil state initialization removed - using Jotai instead
+  },
+});
+
+describe('useColumnDefinitionsFromObjectMetadata', () => {
+  it('should return expected definitions', () => {
+    jotaiStore.set(currentWorkspaceState.atom, {
       workspaceCustomApplication: {
         id: CUSTOM_WORKSPACE_APPLICATION_MOCK.id,
       },
@@ -65,11 +72,7 @@ const Wrapper = getJestMetadataAndApolloMocksAndActionMenuWrapper({
       fastModel: DEFAULT_FAST_MODEL,
       smartModel: DEFAULT_SMART_MODEL,
     });
-  },
-});
 
-describe('useColumnDefinitionsFromObjectMetadata', () => {
-  it('should return expected definitions', () => {
     const companyObjectMetadata = generatedMockObjectMetadataItems.find(
       (item) => item.nameSingular === 'company',
     );

--- a/packages/twenty-front/src/modules/object-metadata/hooks/useLoadMockedObjectMetadataItems.ts
+++ b/packages/twenty-front/src/modules/object-metadata/hooks/useLoadMockedObjectMetadataItems.ts
@@ -1,6 +1,7 @@
 import { isAppEffectRedirectEnabledState } from '@/app/states/isAppEffectRedirectEnabledState';
 import { objectMetadataItemsState } from '@/object-metadata/states/objectMetadataItemsState';
 import { shouldAppBeLoadingState } from '@/object-metadata/states/shouldAppBeLoadingState';
+import { jotaiStore } from '@/ui/utilities/state/jotai/jotaiStore';
 import { useRecoilCallback } from 'recoil';
 import { generatedMockObjectMetadataItems } from '~/testing/utils/generatedMockObjectMetadataItems';
 import { isDeeplyEqual } from '~/utils/isDeeplyEqual';
@@ -22,11 +23,8 @@ export const useLoadMockedObjectMetadataItems = () => {
           set(shouldAppBeLoadingState, false);
         }
 
-        if (
-          snapshot.getLoadable(isAppEffectRedirectEnabledState).getValue() ===
-          false
-        ) {
-          set(isAppEffectRedirectEnabledState, true);
+        if (jotaiStore.get(isAppEffectRedirectEnabledState.atom) === false) {
+          jotaiStore.set(isAppEffectRedirectEnabledState.atom, true);
         }
       },
     [],

--- a/packages/twenty-front/src/modules/object-metadata/hooks/useRefreshObjectMetadataItems.ts
+++ b/packages/twenty-front/src/modules/object-metadata/hooks/useRefreshObjectMetadataItems.ts
@@ -6,6 +6,7 @@ import { shouldAppBeLoadingState } from '@/object-metadata/states/shouldAppBeLoa
 import { type ObjectMetadataItem } from '@/object-metadata/types/ObjectMetadataItem';
 import { enrichObjectMetadataItemsWithPermissions } from '@/object-metadata/utils/enrichObjectMetadataItemsWithPermissions';
 import { mapPaginatedObjectMetadataItemsToObjectMetadataItems } from '@/object-metadata/utils/mapPaginatedObjectMetadataItemsToObjectMetadataItems';
+import { jotaiStore } from '@/ui/utilities/state/jotai/jotaiStore';
 import { type FetchPolicy, useApolloClient } from '@apollo/client';
 import { useRecoilCallback } from 'recoil';
 import { type ObjectPermissions } from 'twenty-shared/types';
@@ -41,9 +42,9 @@ export const useRefreshObjectMetadataItems = (
           'readableFields' | 'updatableFields'
         >[],
       ) => {
-        const currentUserWorkspace = snapshot
-          .getLoadable(currentUserWorkspaceState)
-          .getValue();
+        const currentUserWorkspace = jotaiStore.get(
+          currentUserWorkspaceState.atom,
+        );
 
         if (!isDefined(currentUserWorkspace)) {
           return;
@@ -82,11 +83,8 @@ export const useRefreshObjectMetadataItems = (
           set(shouldAppBeLoadingState, false);
         }
 
-        if (
-          snapshot.getLoadable(isAppEffectRedirectEnabledState).getValue() ===
-          false
-        ) {
-          set(isAppEffectRedirectEnabledState, true);
+        if (jotaiStore.get(isAppEffectRedirectEnabledState.atom) === false) {
+          jotaiStore.set(isAppEffectRedirectEnabledState.atom, true);
         }
 
         return newObjectMetadataItems;

--- a/packages/twenty-front/src/modules/object-metadata/states/availableFieldMetadataItemsForFilterFamilySelector.ts
+++ b/packages/twenty-front/src/modules/object-metadata/states/availableFieldMetadataItemsForFilterFamilySelector.ts
@@ -1,18 +1,21 @@
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { objectMetadataItemsState } from '@/object-metadata/states/objectMetadataItemsState';
 import { getFilterFilterableFieldMetadataItems } from '@/object-metadata/utils/getFilterFilterableFieldMetadataItems';
+import { jotaiStore } from '@/ui/utilities/state/jotai/jotaiStore';
 import { checkIfFeatureFlagIsEnabledOnWorkspace } from '@/workspace/utils/checkIfFeatureFlagIsEnabledOnWorkspace';
 import { selectorFamily } from 'recoil';
 import { isDefined } from 'twenty-shared/utils';
 import { FeatureFlagKey } from '~/generated-metadata/graphql';
 
+// Temporary bridge: reads from Jotai store for migrated state.
+// Will be fully migrated to Jotai in PR 6.
 export const availableFieldMetadataItemsForFilterFamilySelector =
   selectorFamily({
     key: 'availableFieldMetadataItemsForFilterFamilySelector',
     get:
       ({ objectMetadataItemId }: { objectMetadataItemId: string }) =>
       ({ get }) => {
-        const currentWorkspace = get(currentWorkspaceState);
+        const currentWorkspace = jotaiStore.get(currentWorkspaceState.atom);
         const objectMetadataItems = get(objectMetadataItemsState);
 
         const objectMetadataItem = objectMetadataItems.find(

--- a/packages/twenty-front/src/modules/object-record/hooks/__tests__/useFindManyRecords.test.tsx
+++ b/packages/twenty-front/src/modules/object-record/hooks/__tests__/useFindManyRecords.test.tsx
@@ -3,25 +3,27 @@ import { renderHook } from '@testing-library/react';
 import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
 import { objectMetadataItemsState } from '@/object-metadata/states/objectMetadataItemsState';
 import { useFindManyRecords } from '@/object-record/hooks/useFindManyRecords';
+import { jotaiStore } from '@/ui/utilities/state/jotai/jotaiStore';
 import { getJestMetadataAndApolloMocksWrapper } from '~/testing/jest/getJestMetadataAndApolloMocksWrapper';
 import { generatedMockObjectMetadataItems } from '~/testing/utils/generatedMockObjectMetadataItems';
 
 const Wrapper = getJestMetadataAndApolloMocksWrapper({
   apolloMocks: [],
   onInitializeRecoilSnapshot: (snapshot) => {
-    snapshot.set(currentWorkspaceMemberState, {
-      id: '32219445-f587-4c40-b2b1-6d3205ed96da',
-      name: { firstName: 'John', lastName: 'Connor' },
-      locale: 'en',
-      colorScheme: 'Light',
-      userEmail: 'userEmail',
-    });
     snapshot.set(objectMetadataItemsState, generatedMockObjectMetadataItems);
   },
 });
 
 describe('useFindManyRecords', () => {
   it('should work as expected', async () => {
+    jotaiStore.set(currentWorkspaceMemberState.atom, {
+      id: '32219445-f587-4c40-b2b1-6d3205ed96da',
+      name: { firstName: 'John', lastName: 'Connor' },
+      locale: 'en',
+      colorScheme: 'Light',
+      userEmail: 'userEmail',
+    });
+
     const onCompleted = jest.fn();
 
     const { result } = renderHook(

--- a/packages/twenty-front/src/modules/object-record/hooks/useBuildRecordInputFromRLSPredicates.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useBuildRecordInputFromRLSPredicates.ts
@@ -14,7 +14,7 @@ import { buildRecordInputFromFilter } from '@/object-record/record-table/utils/b
 import { buildCompositeValueFromSubField } from '@/object-record/record-table/utils/buildValueFromFilter';
 import { type ObjectRecord } from '@/object-record/types/ObjectRecord';
 import { isUndefined } from '@sniptt/guards';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { RelationType } from 'twenty-shared/types';
 import { isDefined, isPlainObject } from 'twenty-shared/utils';
 
@@ -31,7 +31,7 @@ export const useBuildRecordInputFromRLSPredicates = ({
 }: {
   objectMetadataItem: ObjectMetadataItem;
 }) => {
-  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+  const currentWorkspaceMember = useRecoilValueV2(currentWorkspaceMemberState);
 
   const { record: currentWorkspaceMemberRecord } = useFindOneRecord({
     objectNameSingular: CoreObjectNameSingular.WorkspaceMember,

--- a/packages/twenty-front/src/modules/object-record/hooks/useCreateManyRecords.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useCreateManyRecords.ts
@@ -22,7 +22,7 @@ import { computeOptimisticRecordFromInput } from '@/object-record/utils/computeO
 import { dispatchObjectRecordOperationBrowserEvent } from '@/browser-event/utils/dispatchObjectRecordOperationBrowserEvent';
 import { getCreateManyRecordsMutationResponseField } from '@/object-record/utils/getCreateManyRecordsMutationResponseField';
 import { sanitizeRecordInput } from '@/object-record/utils/sanitizeRecordInput';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { type RecordGqlOperationGqlRecordFields } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 
@@ -78,7 +78,7 @@ export const useCreateManyRecords = <
     objectMetadataItem,
   });
 
-  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+  const currentWorkspaceMember = useRecoilValueV2(currentWorkspaceMemberState);
 
   const { objectMetadataItems } = useObjectMetadataItems();
   const { objectPermissionsByObjectMetadataId } = useObjectPermissions();

--- a/packages/twenty-front/src/modules/object-record/hooks/useCreateOneRecord.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useCreateOneRecord.ts
@@ -29,7 +29,7 @@ import { computeOptimisticRecordFromInput } from '@/object-record/utils/computeO
 import { dispatchObjectRecordOperationBrowserEvent } from '@/browser-event/utils/dispatchObjectRecordOperationBrowserEvent';
 import { getCreateOneRecordMutationResponseField } from '@/object-record/utils/getCreateOneRecordMutationResponseField';
 import { sanitizeRecordInput } from '@/object-record/utils/sanitizeRecordInput';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { CustomError, isDefined } from 'twenty-shared/utils';
 
 type useCreateOneRecordProps = {
@@ -68,7 +68,7 @@ export const useCreateOneRecord = <
     recordGqlFields: computedRecordGqlFields,
   });
 
-  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+  const currentWorkspaceMember = useRecoilValueV2(currentWorkspaceMemberState);
 
   const createOneRecordInCache = useCreateOneRecordInCache<CreatedObjectRecord>(
     {

--- a/packages/twenty-front/src/modules/object-record/hooks/useObjectPermissions.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useObjectPermissions.ts
@@ -1,6 +1,5 @@
-import { useRecoilValue } from 'recoil';
-
 import { currentUserWorkspaceState } from '@/auth/states/currentUserWorkspaceState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { type ObjectPermissions } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 
@@ -12,7 +11,7 @@ type useObjectPermissionsReturnType = {
 };
 
 export const useObjectPermissions = (): useObjectPermissionsReturnType => {
-  const currentUserWorkspace = useRecoilValue(currentUserWorkspaceState);
+  const currentUserWorkspace = useRecoilValueV2(currentUserWorkspaceState);
   const objectsPermissions = currentUserWorkspace?.objectsPermissions;
 
   if (!isDefined(objectsPermissions)) {

--- a/packages/twenty-front/src/modules/object-record/hooks/useObjectRecordSearchRecords.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useObjectRecordSearchRecords.ts
@@ -5,7 +5,7 @@ import { useDoObjectMetadataItemsExist } from '@/object-metadata/hooks/useDoObje
 import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { type WatchQueryFetchPolicy } from '@apollo/client';
 import { useMemo } from 'react';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { isDefined } from 'twenty-shared/utils';
 import {
   type ObjectRecordFilterInput,
@@ -35,7 +35,7 @@ export const useObjectRecordSearchRecords = ({
   filter,
   fetchPolicy,
 }: UseSearchRecordsParams) => {
-  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+  const currentWorkspaceMember = useRecoilValueV2(currentWorkspaceMemberState);
   const areDefined = useDoObjectMetadataItemsExist(objectNameSingulars);
 
   const { enqueueErrorSnackBar } = useSnackBar();

--- a/packages/twenty-front/src/modules/object-record/hooks/useUpdateOneRecord.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useUpdateOneRecord.ts
@@ -21,7 +21,7 @@ import { getUpdatedFieldsFromRecordInput } from '@/object-record/utils/getUpdate
 import { getUpdateOneRecordMutationResponseField } from '@/object-record/utils/getUpdateOneRecordMutationResponseField';
 import { sanitizeRecordInput } from '@/object-record/utils/sanitizeRecordInput';
 import { isNull } from '@sniptt/guards';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { isDefined } from 'twenty-shared/utils';
 import { buildRecordFromKeysWithSameValue } from '~/utils/array/buildRecordFromKeysWithSameValue';
 
@@ -37,7 +37,7 @@ export const useUpdateOneRecord = () => {
   const apolloCoreClient = useApolloCoreClient();
   const { upsertRecordsInStore } = useUpsertRecordsInStore();
 
-  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+  const currentWorkspaceMember = useRecoilValueV2(currentWorkspaceMemberState);
 
   const { objectMetadataItems } = useObjectMetadataItems();
   const { objectPermissionsByObjectMetadataId } = useObjectPermissions();

--- a/packages/twenty-front/src/modules/object-record/object-filter-dropdown/components/ObjectFilterDropdownDateInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-filter-dropdown/components/ObjectFilterDropdownDateInput.tsx
@@ -8,6 +8,7 @@ import { selectedOperandInDropdownComponentState } from '@/object-record/object-
 import { getRelativeDateDisplayValue } from '@/object-record/object-filter-dropdown/utils/getRelativeDateDisplayValue';
 import { DatePicker } from '@/ui/input/components/internal/date/components/DatePicker';
 import { useRecoilComponentValue } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValue';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { UserContext } from '@/users/contexts/UserContext';
 import { stringifyRelativeDateFilter } from '@/views/view-filter-value/utils/stringifyRelativeDateFilter';
 import { useContext } from 'react';
@@ -24,7 +25,7 @@ import { formatDateString } from '~/utils/string/formatDateString';
 export const ObjectFilterDropdownDateInput = () => {
   const { dateFormat, timeZone } = useContext(UserContext);
   const dateLocale = useRecoilValue(dateLocaleState);
-  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+  const currentWorkspaceMember = useRecoilValueV2(currentWorkspaceMemberState);
 
   const selectedOperandInDropdown = useRecoilComponentValue(
     selectedOperandInDropdownComponentState,

--- a/packages/twenty-front/src/modules/object-record/object-filter-dropdown/components/ObjectFilterDropdownDateTimeInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-filter-dropdown/components/ObjectFilterDropdownDateTimeInput.tsx
@@ -7,6 +7,7 @@ import { objectFilterDropdownCurrentRecordFilterComponentState } from '@/object-
 import { getRelativeDateDisplayValue } from '@/object-record/object-filter-dropdown/utils/getRelativeDateDisplayValue';
 import { DateTimePicker } from '@/ui/input/components/internal/date/components/DateTimePicker';
 import { useRecoilComponentValue } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValue';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { UserContext } from '@/users/contexts/UserContext';
 import { stringifyRelativeDateFilter } from '@/views/view-filter-value/utils/stringifyRelativeDateFilter';
 import { useContext } from 'react';
@@ -27,7 +28,7 @@ import { formatDateTimeString } from '~/utils/string/formatDateTimeString';
 export const ObjectFilterDropdownDateTimeInput = () => {
   const { dateFormat, timeFormat, timeZone } = useContext(UserContext);
   const dateLocale = useRecoilValue(dateLocaleState);
-  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+  const currentWorkspaceMember = useRecoilValueV2(currentWorkspaceMemberState);
 
   const { userTimezone } = useUserTimezone();
 

--- a/packages/twenty-front/src/modules/object-record/record-calendar/month/hooks/useRecordCalendarMonthDaysRange.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-calendar/month/hooks/useRecordCalendarMonthDaysRange.tsx
@@ -9,6 +9,7 @@ import {
   format,
   startOfWeek,
 } from 'date-fns';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { useRecoilValue } from 'recoil';
 
 import { type Temporal } from 'temporal-polyfill';
@@ -23,7 +24,7 @@ import { dateLocaleState } from '~/localization/states/dateLocaleState';
 export const useRecordCalendarMonthDaysRange = (
   selectedDate: Temporal.PlainDate,
 ) => {
-  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+  const currentWorkspaceMember = useRecoilValueV2(currentWorkspaceMemberState);
   const dateLocale = useRecoilValue(dateLocaleState);
 
   if (!currentWorkspaceMember) {

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useOpenFieldInputEditMode.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/useOpenFieldInputEditMode.ts
@@ -33,6 +33,7 @@ import { getRecordFieldInputInstanceId } from '@/object-record/utils/getRecordFi
 import { usePushFocusItemToFocusStack } from '@/ui/utilities/focus/hooks/usePushFocusItemToFocusStack';
 import { useRemoveFocusItemFromFocusStackById } from '@/ui/utilities/focus/hooks/useRemoveFocusItemFromFocusStackById';
 import { FocusComponentType } from '@/ui/utilities/focus/types/FocusComponentType';
+import { jotaiStore } from '@/ui/utilities/state/jotai/jotaiStore';
 import { useRecoilCallback } from 'recoil';
 import { isDefined } from 'twenty-shared/utils';
 
@@ -74,9 +75,7 @@ export const useOpenFieldInputEditMode = () => {
           .getLoadable(objectMetadataItemsState)
           .getValue();
 
-        const currentWorkspace = snapshot
-          .getLoadable(currentWorkspaceState)
-          .getValue();
+        const currentWorkspace = jotaiStore.get(currentWorkspaceState.atom);
 
         const isJunctionRelationsEnabled =
           currentWorkspace?.featureFlags?.find(

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/__stories__/RelationManyToOneFieldInput.stories.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/__stories__/RelationManyToOneFieldInput.stories.tsx
@@ -4,7 +4,6 @@ import {
   type StoryObj,
 } from '@storybook/react-vite';
 import { useEffect } from 'react';
-import { useSetRecoilState } from 'recoil';
 import { expect, userEvent, waitFor, within } from 'storybook/test';
 
 import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
@@ -23,6 +22,7 @@ import { RecordFieldComponentInstanceContext } from '@/object-record/record-fiel
 import { recordFieldInputLayoutDirectionLoadingComponentState } from '@/object-record/record-field/ui/states/recordFieldInputLayoutDirectionLoadingComponentState';
 import { usePushFocusItemToFocusStack } from '@/ui/utilities/focus/hooks/usePushFocusItemToFocusStack';
 import { FocusComponentType } from '@/ui/utilities/focus/types/FocusComponentType';
+import { jotaiStore } from '@/ui/utilities/state/jotai/jotaiStore';
 import { useSetRecoilComponentState } from '@/ui/utilities/state/component-state/hooks/useSetRecoilComponentState';
 import { FieldMetadataType } from 'twenty-shared/types';
 
@@ -30,24 +30,16 @@ import { RelationManyToOneFieldInput } from '@/object-record/record-field/ui/met
 import { getFieldInputEventContextProviderWithJestMocks } from './utils/getFieldInputEventContextProviderWithJestMocks';
 
 const RelationWorkspaceSetterEffect = () => {
-  const setCurrentWorkspace = useSetRecoilState(currentWorkspaceState);
-  const setCurrentWorkspaceMember = useSetRecoilState(
-    currentWorkspaceMemberState,
-  );
   const setRecordFieldInputLayoutDirectionLoading = useSetRecoilComponentState(
     recordFieldInputLayoutDirectionLoadingComponentState,
     'relation-to-one-field-input-123-Relation',
   );
 
   useEffect(() => {
-    setCurrentWorkspace(mockCurrentWorkspace);
-    setCurrentWorkspaceMember(mockedWorkspaceMemberData);
+    jotaiStore.set(currentWorkspaceState.atom, mockCurrentWorkspace);
+    jotaiStore.set(currentWorkspaceMemberState.atom, mockedWorkspaceMemberData);
     setRecordFieldInputLayoutDirectionLoading(false);
-  }, [
-    setCurrentWorkspace,
-    setCurrentWorkspaceMember,
-    setRecordFieldInputLayoutDirectionLoading,
-  ]);
+  }, [setRecordFieldInputLayoutDirectionLoading]);
 
   return <></>;
 };

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/__stories__/RelationOneToManyFieldInput.stories.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/__stories__/RelationOneToManyFieldInput.stories.tsx
@@ -5,6 +5,7 @@ import { useSetRecoilState } from 'recoil';
 import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { usePushFocusItemToFocusStack } from '@/ui/utilities/focus/hooks/usePushFocusItemToFocusStack';
+import { jotaiStore } from '@/ui/utilities/state/jotai/jotaiStore';
 import { FileUploadDecorator } from '~/testing/decorators/FileUploadDecorator';
 import { ObjectMetadataItemsDecorator } from '~/testing/decorators/ObjectMetadataItemsDecorator';
 import { SnackBarDecorator } from '~/testing/decorators/SnackBarDecorator';
@@ -25,15 +26,10 @@ import { FieldMetadataType } from 'twenty-shared/types';
 import { RelationType } from '~/generated-metadata/graphql';
 
 const RelationWorkspaceSetterEffect = () => {
-  const setCurrentWorkspace = useSetRecoilState(currentWorkspaceState);
-  const setCurrentWorkspaceMember = useSetRecoilState(
-    currentWorkspaceMemberState,
-  );
-
   useEffect(() => {
-    setCurrentWorkspace(mockCurrentWorkspace);
-    setCurrentWorkspaceMember(mockedWorkspaceMemberData);
-  }, [setCurrentWorkspace, setCurrentWorkspaceMember]);
+    jotaiStore.set(currentWorkspaceState.atom, mockCurrentWorkspace);
+    jotaiStore.set(currentWorkspaceMemberState.atom, mockedWorkspaceMemberData);
+  }, []);
 
   return <></>;
 };

--- a/packages/twenty-front/src/modules/object-record/record-filter/hooks/useFilterValueDependencies.ts
+++ b/packages/twenty-front/src/modules/object-record/record-filter/hooks/useFilterValueDependencies.ts
@@ -1,13 +1,13 @@
 import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
 import { useUserTimezone } from '@/ui/input/components/internal/date/hooks/useUserTimezone';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { type RecordFilterValueDependencies } from 'twenty-shared/types';
 
 export const useFilterValueDependencies = (): {
   filterValueDependencies: RecordFilterValueDependencies;
 } => {
   const { id: currentWorkspaceMemberId } =
-    useRecoilValue(currentWorkspaceMemberState) ?? {};
+    useRecoilValueV2(currentWorkspaceMemberState) ?? {};
 
   const { userTimezone } = useUserTimezone();
 

--- a/packages/twenty-front/src/modules/object-record/record-filter/hooks/useGetRelativeDateFilterWithUserTimezone.ts
+++ b/packages/twenty-front/src/modules/object-record/record-filter/hooks/useGetRelativeDateFilterWithUserTimezone.ts
@@ -1,14 +1,14 @@
 import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
 import { detectCalendarStartDay } from '@/localization/utils/detection/detectCalendarStartDay';
 import { useUserTimezone } from '@/ui/input/components/internal/date/hooks/useUserTimezone';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { CalendarStartDay } from 'twenty-shared/constants';
 import { type FirstDayOfTheWeek } from 'twenty-shared/types';
 import { type RelativeDateFilter } from 'twenty-shared/utils';
 
 export const useGetRelativeDateFilterWithUserTimezone = () => {
   const { userTimezone } = useUserTimezone();
-  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+  const currentWorkspaceMember = useRecoilValueV2(currentWorkspaceMemberState);
 
   const getRelativeDateFilterWithUserTimezone = (
     relativeDateFilter: RelativeDateFilter,

--- a/packages/twenty-front/src/modules/object-record/record-table/hooks/useBuildRecordInputFromFilters.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/hooks/useBuildRecordInputFromFilters.ts
@@ -5,19 +5,18 @@ import { buildRecordInputFromFilter } from '@/object-record/record-table/utils/b
 
 import { type ObjectRecord } from '@/object-record/types/ObjectRecord';
 import { useRecoilComponentValue } from '@/ui/utilities/state/component-state/hooks/useRecoilComponentValue';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 
 export const useBuildRecordInputFromFilters = ({
   objectMetadataItem,
 }: {
   objectMetadataItem: ObjectMetadataItem;
 }) => {
-  // we might need to build a recoil callback for better performance
   const currentRecordFilters = useRecoilComponentValue(
     currentRecordFiltersComponentState,
   );
 
-  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+  const currentWorkspaceMember = useRecoilValueV2(currentWorkspaceMemberState);
 
   const buildRecordInputFromFilters = (): Partial<ObjectRecord> => {
     return buildRecordInputFromFilter({

--- a/packages/twenty-front/src/modules/onboarding/hooks/__tests__/useOnboardingStatus.test.ts
+++ b/packages/twenty-front/src/modules/onboarding/hooks/__tests__/useOnboardingStatus.test.ts
@@ -1,12 +1,15 @@
 import { renderHook } from '@testing-library/react';
-import { act } from 'react';
-import { RecoilRoot, useSetRecoilState } from 'recoil';
+import { createElement, act } from 'react';
+import { Provider as JotaiProvider } from 'jotai';
+import { RecoilRoot } from 'recoil';
 
 import {
   type CurrentUser,
   currentUserState,
 } from '@/auth/states/currentUserState';
 import { tokenPairState } from '@/auth/states/tokenPairState';
+import { useSetRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useSetRecoilStateV2';
+import { jotaiStore } from '@/ui/utilities/state/jotai/jotaiStore';
 import { useOnboardingStatus } from '@/onboarding/hooks/useOnboardingStatus';
 import { OnboardingStatus } from '~/generated-metadata/graphql';
 
@@ -22,12 +25,19 @@ const currentUser = {
   onboardingStatus: null,
 } as CurrentUser;
 
+const Wrapper = ({ children }: { children: React.ReactNode }) =>
+  createElement(
+    JotaiProvider,
+    { store: jotaiStore },
+    createElement(RecoilRoot, null, children),
+  );
+
 const renderHooks = () => {
   const { result } = renderHook(
     () => {
       const onboardingStatus = useOnboardingStatus();
-      const setCurrentUser = useSetRecoilState(currentUserState);
-      const setTokenPair = useSetRecoilState(tokenPairState);
+      const setCurrentUser = useSetRecoilStateV2(currentUserState);
+      const setTokenPair = useSetRecoilStateV2(tokenPairState);
 
       return {
         onboardingStatus,
@@ -36,7 +46,7 @@ const renderHooks = () => {
       };
     },
     {
-      wrapper: RecoilRoot,
+      wrapper: Wrapper,
     },
   );
   return { result };

--- a/packages/twenty-front/src/modules/onboarding/hooks/__tests__/useSetNextOnboardingStatus.test.ts
+++ b/packages/twenty-front/src/modules/onboarding/hooks/__tests__/useSetNextOnboardingStatus.test.ts
@@ -1,11 +1,19 @@
 import { act, renderHook } from '@testing-library/react';
-import { RecoilRoot, useRecoilState, useSetRecoilState } from 'recoil';
+import { createElement } from 'react';
+import { Provider as JotaiProvider } from 'jotai';
+import { RecoilRoot } from 'recoil';
 import { v4 } from 'uuid';
 
 import { currentUserState } from '@/auth/states/currentUserState';
 import { currentUserWorkspaceState } from '@/auth/states/currentUserWorkspaceState';
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { useSetNextOnboardingStatus } from '@/onboarding/hooks/useSetNextOnboardingStatus';
+import { useRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilStateV2';
+import { useSetRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useSetRecoilStateV2';
+import {
+  jotaiStore,
+  resetJotaiStore,
+} from '@/ui/utilities/state/jotai/jotaiStore';
 
 import {
   OnboardingStatus,
@@ -17,6 +25,13 @@ import {
   mockedUserData,
 } from '~/testing/mock-data/users';
 
+const Wrapper = ({ children }: { children: React.ReactNode }) =>
+  createElement(
+    JotaiProvider,
+    { store: jotaiStore },
+    createElement(RecoilRoot, null, children),
+  );
+
 const renderHooks = (
   onboardingStatus: OnboardingStatus,
   withCurrentBillingSubscription: boolean,
@@ -25,11 +40,11 @@ const renderHooks = (
 ) => {
   const { result } = renderHook(
     () => {
-      const [currentUser, setCurrentUser] = useRecoilState(currentUserState);
-      const setCurrentUserWorkspace = useSetRecoilState(
+      const [currentUser, setCurrentUser] = useRecoilStateV2(currentUserState);
+      const setCurrentUserWorkspace = useSetRecoilStateV2(
         currentUserWorkspaceState,
       );
-      const setCurrentWorkspace = useSetRecoilState(currentWorkspaceState);
+      const setCurrentWorkspace = useSetRecoilStateV2(currentWorkspaceState);
       const setNextOnboardingStatus = useSetNextOnboardingStatus();
       return {
         currentUser,
@@ -40,7 +55,7 @@ const renderHooks = (
       };
     },
     {
-      wrapper: RecoilRoot,
+      wrapper: Wrapper,
     },
   );
   act(() => {
@@ -69,6 +84,10 @@ const renderHooks = (
 };
 
 describe('useSetNextOnboardingStatus', () => {
+  beforeEach(() => {
+    resetJotaiStore();
+  });
+
   it('should set next onboarding status for ProfileCreation', () => {
     const nextOnboardingStatus = renderHooks(
       OnboardingStatus.PROFILE_CREATION,

--- a/packages/twenty-front/src/modules/onboarding/hooks/useOnboardingStatus.ts
+++ b/packages/twenty-front/src/modules/onboarding/hooks/useOnboardingStatus.ts
@@ -1,11 +1,10 @@
-import { useRecoilValue } from 'recoil';
-
 import { useIsLogged } from '@/auth/hooks/useIsLogged';
 import { currentUserState } from '@/auth/states/currentUserState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { type OnboardingStatus } from '~/generated-metadata/graphql';
 
 export const useOnboardingStatus = (): OnboardingStatus | null | undefined => {
-  const currentUser = useRecoilValue(currentUserState);
+  const currentUser = useRecoilValueV2(currentUserState);
   const isLoggedIn = useIsLogged();
   return isLoggedIn ? currentUser?.onboardingStatus : undefined;
 };

--- a/packages/twenty-front/src/modules/onboarding/hooks/useSetNextOnboardingStatus.ts
+++ b/packages/twenty-front/src/modules/onboarding/hooks/useSetNextOnboardingStatus.ts
@@ -1,5 +1,3 @@
-import { useRecoilCallback, useRecoilValue } from 'recoil';
-
 import { isDefined } from 'twenty-shared/utils';
 
 import {
@@ -12,7 +10,11 @@ import {
 } from '@/auth/states/currentWorkspaceState';
 import { calendarBookingPageIdState } from '@/client-config/states/calendarBookingPageIdState';
 import { usePermissionFlagMap } from '@/settings/roles/hooks/usePermissionFlagMap';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
+import { jotaiStore } from '@/ui/utilities/state/jotai/jotaiStore';
 
+import { useCallback } from 'react';
+import { useRecoilValue } from 'recoil';
 import {
   OnboardingStatus,
   PermissionFlagType,
@@ -62,37 +64,33 @@ const getNextOnboardingStatus = ({
 };
 
 export const useSetNextOnboardingStatus = () => {
-  const currentUser = useRecoilValue(currentUserState);
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
+  const currentUser = useRecoilValueV2(currentUserState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
   const calendarBookingPageId = useRecoilValue(calendarBookingPageIdState);
   const permissionMap = usePermissionFlagMap();
   const isAccountSyncEnabled =
     permissionMap[PermissionFlagType.CONNECTED_ACCOUNTS];
 
-  return useRecoilCallback(
-    ({ set }) =>
-      () => {
-        const nextOnboardingStatus = getNextOnboardingStatus({
-          currentUser,
-          currentWorkspace,
-          calendarBookingPageId,
-          isAccountSyncEnabled,
-        });
-        set(currentUserState, (current) => {
-          if (isDefined(current)) {
-            return {
-              ...current,
-              onboardingStatus: nextOnboardingStatus,
-            };
-          }
-          return current;
-        });
-      },
-    [
+  return useCallback(() => {
+    const nextOnboardingStatus = getNextOnboardingStatus({
       currentUser,
       currentWorkspace,
       calendarBookingPageId,
       isAccountSyncEnabled,
-    ],
-  );
+    });
+    jotaiStore.set(currentUserState.atom, (current) => {
+      if (isDefined(current)) {
+        return {
+          ...current,
+          onboardingStatus: nextOnboardingStatus,
+        };
+      }
+      return current;
+    });
+  }, [
+    currentUser,
+    currentWorkspace,
+    calendarBookingPageId,
+    isAccountSyncEnabled,
+  ]);
 };

--- a/packages/twenty-front/src/modules/page-layout/widgets/components/__stories__/WidgetRenderer.stories.tsx
+++ b/packages/twenty-front/src/modules/page-layout/widgets/components/__stories__/WidgetRenderer.stories.tsx
@@ -14,6 +14,7 @@ import { currentUserWorkspaceState } from '@/auth/states/currentUserWorkspaceSta
 import { ApolloCoreClientContext } from '@/object-metadata/contexts/ApolloCoreClientContext';
 import { objectMetadataItemsState } from '@/object-metadata/states/objectMetadataItemsState';
 import { shouldAppBeLoadingState } from '@/object-metadata/states/shouldAppBeLoadingState';
+import { jotaiStore } from '@/ui/utilities/state/jotai/jotaiStore';
 import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
 import { recordStoreFamilyState } from '@/object-record/record-store/states/recordStoreFamilyState';
 import { type ObjectRecord } from '@/object-record/types/ObjectRecord';
@@ -1654,8 +1655,9 @@ export const Catalog: CatalogStory<Story, typeof WidgetRenderer> = {
         );
       }
 
+      // currentUserWorkspaceState is now a Jotai state, set it directly
       if (isRestricted === true) {
-        snapshot.set(currentUserWorkspaceState, {
+        jotaiStore.set(currentUserWorkspaceState.atom, {
           permissionFlags: [],
           twoFactorAuthenticationMethodSummary: null,
           objectsPermissions: [
@@ -1672,7 +1674,7 @@ export const Catalog: CatalogStory<Story, typeof WidgetRenderer> = {
           ],
         });
       } else {
-        snapshot.set(currentUserWorkspaceState, {
+        jotaiStore.set(currentUserWorkspaceState.atom, {
           permissionFlags: [],
           twoFactorAuthenticationMethodSummary: null,
           objectsPermissions: [

--- a/packages/twenty-front/src/modules/prefetch/components/PrefetchRunFavoriteQueriesEffect.tsx
+++ b/packages/twenty-front/src/modules/prefetch/components/PrefetchRunFavoriteQueriesEffect.tsx
@@ -1,7 +1,7 @@
-import { useEffect } from 'react';
-import { useRecoilCallback, useRecoilValue, useSetRecoilState } from 'recoil';
-
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
+import { useEffect } from 'react';
+import { useRecoilCallback, useSetRecoilState } from 'recoil';
 import { type Favorite } from '@/favorites/types/Favorite';
 import { type FavoriteFolder } from '@/favorites/types/FavoriteFolder';
 import { useIsSettingsPage } from '@/navigation/hooks/useIsSettingsPage';
@@ -28,7 +28,7 @@ export const PrefetchRunFavoriteQueriesEffect = () => {
   );
   const showAuthModal = useShowAuthModal();
   const isSettingsPage = useIsSettingsPage();
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
   const isWorkspaceActive =
     currentWorkspace?.activationStatus === WorkspaceActivationStatus.ACTIVE;
 

--- a/packages/twenty-front/src/modules/prefetch/components/PrefetchRunNavigationMenuItemQueriesEffect.tsx
+++ b/packages/twenty-front/src/modules/prefetch/components/PrefetchRunNavigationMenuItemQueriesEffect.tsx
@@ -1,7 +1,7 @@
-import { useEffect } from 'react';
-import { useRecoilCallback, useRecoilValue, useSetRecoilState } from 'recoil';
-
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
+import { useEffect } from 'react';
+import { useRecoilCallback, useSetRecoilState } from 'recoil';
 import { useIsSettingsPage } from '@/navigation/hooks/useIsSettingsPage';
 import { prefetchIsLoadedFamilyState } from '@/prefetch/states/prefetchIsLoadedFamilyState';
 import { prefetchNavigationMenuItemsState } from '@/prefetch/states/prefetchNavigationMenuItemsState';
@@ -24,7 +24,7 @@ export const PrefetchRunNavigationMenuItemQueriesEffect = () => {
 
   const showAuthModal = useShowAuthModal();
   const isSettingsPage = useIsSettingsPage();
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
   const isWorkspaceActive =
     currentWorkspace?.activationStatus === WorkspaceActivationStatus.ACTIVE;
 

--- a/packages/twenty-front/src/modules/settings/accounts/components/SettingsAccountsBlocklistSection.tsx
+++ b/packages/twenty-front/src/modules/settings/accounts/components/SettingsAccountsBlocklistSection.tsx
@@ -1,7 +1,6 @@
-import { useRecoilValue } from 'recoil';
-
 import { type BlocklistItem } from '@/accounts/types/BlocklistItem';
 import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
 import { useCreateOneRecord } from '@/object-record/hooks/useCreateOneRecord';
 import { useDeleteOneRecord } from '@/object-record/hooks/useDeleteOneRecord';
@@ -16,7 +15,7 @@ import { Section } from 'twenty-ui/layout';
 export const SettingsAccountsBlocklistSection = () => {
   const { t } = useLingui();
 
-  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+  const currentWorkspaceMember = useRecoilValueV2(currentWorkspaceMemberState);
 
   const currentWorkspaceMemberId = currentWorkspaceMember?.id ?? '';
 

--- a/packages/twenty-front/src/modules/settings/accounts/components/SettingsAccountsCalendarChannelsContainer.tsx
+++ b/packages/twenty-front/src/modules/settings/accounts/components/SettingsAccountsCalendarChannelsContainer.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import { useRecoilValue } from 'recoil';
 
 import {
   type CalendarChannel,
@@ -7,6 +6,7 @@ import {
 } from '@/accounts/types/CalendarChannel';
 import { type ConnectedAccount } from '@/accounts/types/ConnectedAccount';
 import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
 import { useFindManyRecords } from '@/object-record/hooks/useFindManyRecords';
 import { SettingsAccountsCalendarChannelDetails } from '@/settings/accounts/components/SettingsAccountsCalendarChannelDetails';
@@ -26,7 +26,7 @@ export const SettingsAccountsCalendarChannelsContainer = () => {
     activeTabIdComponentState,
     SETTINGS_ACCOUNT_CALENDAR_CHANNELS_TAB_LIST_COMPONENT_ID,
   );
-  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+  const currentWorkspaceMember = useRecoilValueV2(currentWorkspaceMemberState);
 
   const { records: accounts } = useFindManyRecords<ConnectedAccount>({
     objectNameSingular: CoreObjectNameSingular.ConnectedAccount,

--- a/packages/twenty-front/src/modules/settings/accounts/components/SettingsAccountsCalendarChannelsGeneral.tsx
+++ b/packages/twenty-front/src/modules/settings/accounts/components/SettingsAccountsCalendarChannelsGeneral.tsx
@@ -6,7 +6,7 @@ import styled from '@emotion/styled';
 import { t } from '@lingui/core/macro';
 import { Section } from '@react-email/components';
 import { addMinutes, endOfDay, min, startOfDay } from 'date-fns';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { H2Title } from 'twenty-ui/display';
 import {
   CalendarChannelVisibility,
@@ -21,7 +21,7 @@ const StyledGeneralContainer = styled.div`
 `;
 
 export const SettingsAccountsCalendarChannelsGeneral = () => {
-  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+  const currentWorkspaceMember = useRecoilValueV2(currentWorkspaceMemberState);
 
   const exampleStartDate = new Date();
   const exampleEndDate = min([

--- a/packages/twenty-front/src/modules/settings/accounts/components/SettingsAccountsMessageChannelsContainer.tsx
+++ b/packages/twenty-front/src/modules/settings/accounts/components/SettingsAccountsMessageChannelsContainer.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import { useRecoilValue } from 'recoil';
 
 import { type ConnectedAccount } from '@/accounts/types/ConnectedAccount';
 import {
@@ -7,6 +6,7 @@ import {
   MessageChannelSyncStage,
 } from '@/accounts/types/MessageChannel';
 import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
 import { useGenerateDepthRecordGqlFieldsFromObject } from '@/object-record/graphql/record-gql-fields/hooks/useGenerateDepthRecordGqlFieldsFromObject';
 import { useFindManyRecords } from '@/object-record/hooks/useFindManyRecords';
@@ -30,7 +30,7 @@ export const SettingsAccountsMessageChannelsContainer = () => {
     activeTabIdComponentState,
     SETTINGS_ACCOUNT_MESSAGE_CHANNELS_TAB_LIST_COMPONENT_ID,
   );
-  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+  const currentWorkspaceMember = useRecoilValueV2(currentWorkspaceMemberState);
   const setSelectedMessageChannel = useSetRecoilStateV2(
     settingsAccountsSelectedMessageChannelStateV2,
   );

--- a/packages/twenty-front/src/modules/settings/accounts/hooks/useImapSmtpCaldavConnectionForm.ts
+++ b/packages/twenty-front/src/modules/settings/accounts/hooks/useImapSmtpCaldavConnectionForm.ts
@@ -1,9 +1,9 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useCallback, useMemo } from 'react';
 import { useForm } from 'react-hook-form';
-import { useRecoilValue } from 'recoil';
 
 import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 
 import { t } from '@lingui/core/macro';
@@ -41,7 +41,7 @@ export const useImapSmtpCaldavConnectionForm = ({
   connectedAccountId,
 }: UseConnectionFormProps = {}) => {
   const navigate = useNavigateSettings();
-  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+  const currentWorkspaceMember = useRecoilValueV2(currentWorkspaceMemberState);
 
   const formMethods = useForm<ConnectionFormData>({
     mode: 'onSubmit',

--- a/packages/twenty-front/src/modules/settings/admin-panel/components/SettingsAdminContent.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/components/SettingsAdminContent.tsx
@@ -4,11 +4,11 @@ import { SETTINGS_ADMIN_TABS } from '@/settings/admin-panel/constants/SettingsAd
 import { SETTINGS_ADMIN_TABS_ID } from '@/settings/admin-panel/constants/SettingsAdminTabsId';
 import { TabList } from '@/ui/layout/tab-list/components/TabList';
 import { t } from '@lingui/core/macro';
-import { useRecoilValue } from 'recoil';
 import { IconHeart, IconSettings2, IconVariable } from 'twenty-ui/display';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 
 export const SettingsAdminContent = () => {
-  const currentUser = useRecoilValue(currentUserState);
+  const currentUser = useRecoilValueV2(currentUserState);
 
   const canAccessFullAdminPanel = currentUser?.canAccessFullAdminPanel;
   const canImpersonate = currentUser?.canImpersonate;

--- a/packages/twenty-front/src/modules/settings/admin-panel/components/SettingsAdminGeneral.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/components/SettingsAdminGeneral.tsx
@@ -10,11 +10,11 @@ import { t } from '@lingui/core/macro';
 import { isNonEmptyString } from '@sniptt/guards';
 import { useRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilStateV2';
 import { useState } from 'react';
-import { useRecoilValue } from 'recoil';
 import { REACT_APP_SERVER_BASE_URL } from '~/config';
 import { useUserLookupAdminPanelMutation } from '~/generated-metadata/graphql';
 
 import { currentUserState } from '@/auth/states/currentUserState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { SettingsAdminTableCard } from '@/settings/admin-panel/components/SettingsAdminTableCard';
 import { SettingsAdminVersionContainer } from '@/settings/admin-panel/components/SettingsAdminVersionContainer';
 import { SETTINGS_ADMIN_USER_LOOKUP_WORKSPACE_TABS_ID } from '@/settings/admin-panel/constants/SettingsAdminUserLookupWorkspaceTabsId';
@@ -53,7 +53,7 @@ export const SettingsAdminGeneral = () => {
 
   const [userLookup] = useUserLookupAdminPanelMutation();
 
-  const currentUser = useRecoilValue(currentUserState);
+  const currentUser = useRecoilValueV2(currentUserState);
 
   const canAccessFullAdminPanel = currentUser?.canAccessFullAdminPanel;
 

--- a/packages/twenty-front/src/modules/settings/admin-panel/components/SettingsAdminGeneral.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/components/SettingsAdminGeneral.tsx
@@ -8,6 +8,7 @@ import { DEFAULT_WORKSPACE_LOGO } from '@/ui/navigation/navigation-drawer/consta
 import styled from '@emotion/styled';
 import { t } from '@lingui/core/macro';
 import { isNonEmptyString } from '@sniptt/guards';
+import { useRecoilValue } from 'recoil';
 import { useRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilStateV2';
 import { useState } from 'react';
 import { REACT_APP_SERVER_BASE_URL } from '~/config';

--- a/packages/twenty-front/src/modules/settings/admin-panel/components/SettingsAdminWorkspaceContent.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/components/SettingsAdminWorkspaceContent.tsx
@@ -1,6 +1,7 @@
 import { currentUserState } from '@/auth/states/currentUserState';
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { canManageFeatureFlagsState } from '@/client-config/states/canManageFeatureFlagsState';
+import { useRecoilValue } from 'recoil';
 import { SettingsAdminTableCard } from '@/settings/admin-panel/components/SettingsAdminTableCard';
 import { useFeatureFlagState } from '@/settings/admin-panel/hooks/useFeatureFlagState';
 import { useImpersonationAuth } from '@/settings/admin-panel/hooks/useImpersonationAuth';
@@ -20,8 +21,8 @@ import { useLingui } from '@lingui/react/macro';
 import { isNonEmptyString } from '@sniptt/guards';
 import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { useState } from 'react';
-import { useRecoilState, useRecoilValue } from 'recoil';
 import { getImageAbsoluteURI, isDefined } from 'twenty-shared/utils';
+import { useRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilStateV2';
 import { AvatarChip, Chip } from 'twenty-ui/components';
 import {
   H2Title,
@@ -60,8 +61,8 @@ export const SettingsAdminWorkspaceContent = ({
 }: SettingsAdminWorkspaceContentProps) => {
   const canManageFeatureFlags = useRecoilValue(canManageFeatureFlagsState);
   const { enqueueErrorSnackBar } = useSnackBar();
-  const [currentUser] = useRecoilState(currentUserState);
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
+  const [currentUser] = useRecoilStateV2(currentUserState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
 
   const [updateFeatureFlag] = useUpdateWorkspaceFeatureFlagMutation();
   const [isImpersonateLoading, setIsImpersonationLoading] = useState(false);

--- a/packages/twenty-front/src/modules/settings/admin-panel/hooks/useImpersonationAuth.ts
+++ b/packages/twenty-front/src/modules/settings/admin-panel/hooks/useImpersonationAuth.ts
@@ -1,12 +1,13 @@
 import { isAppEffectRedirectEnabledState } from '@/app/states/isAppEffectRedirectEnabledState';
 import { useAuth } from '@/auth/hooks/useAuth';
 import { shouldAppBeLoadingState } from '@/object-metadata/states/shouldAppBeLoadingState';
+import { useSetRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useSetRecoilStateV2';
 import { useSetRecoilState } from 'recoil';
 
 export const useImpersonationAuth = () => {
   const { getAuthTokensFromLoginToken } = useAuth();
   const setShouldAppBeLoading = useSetRecoilState(shouldAppBeLoadingState);
-  const setIsAppEffectRedirectEnabled = useSetRecoilState(
+  const setIsAppEffectRedirectEnabled = useSetRecoilStateV2(
     isAppEffectRedirectEnabledState,
   );
 

--- a/packages/twenty-front/src/modules/settings/components/SettingsItemTypeTag.tsx
+++ b/packages/twenty-front/src/modules/settings/components/SettingsItemTypeTag.tsx
@@ -2,8 +2,8 @@ import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { getItemTagInfo } from '@/settings/data-model/utils/getItemTagInfo';
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
-import { useRecoilValue } from 'recoil';
 import { Avatar } from 'twenty-ui/display';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 
 type SettingsItemTypeTagProps = {
   item: {
@@ -27,7 +27,7 @@ export const SettingsItemTypeTag = ({
   item: { isCustom, isRemote, applicationId },
 }: SettingsItemTypeTagProps) => {
   const theme = useTheme();
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
   const itemTagInfo = getItemTagInfo({
     item: { isCustom, isRemote, applicationId },
     workspaceCustomApplicationId:

--- a/packages/twenty-front/src/modules/settings/domains/components/SettingsCustomDomain.tsx
+++ b/packages/twenty-front/src/modules/settings/domains/components/SettingsCustomDomain.tsx
@@ -4,7 +4,7 @@ import { TextInput } from '@/ui/input/components/TextInput';
 import styled from '@emotion/styled';
 import { useLingui } from '@lingui/react/macro';
 import { Controller, useFormContext } from 'react-hook-form';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { H2Title, IconReload, IconTrash } from 'twenty-ui/display';
 import { Button, ButtonGroup } from 'twenty-ui/input';
 import { Section } from 'twenty-ui/layout';
@@ -43,7 +43,7 @@ export const SettingsCustomDomain = () => {
 
   const { checkCustomDomainRecords } = useCheckCustomDomainValidRecords();
 
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
 
   const { t } = useLingui();
 

--- a/packages/twenty-front/src/modules/settings/domains/components/SettingsCustomDomain.tsx
+++ b/packages/twenty-front/src/modules/settings/domains/components/SettingsCustomDomain.tsx
@@ -4,6 +4,7 @@ import { TextInput } from '@/ui/input/components/TextInput';
 import styled from '@emotion/styled';
 import { useLingui } from '@lingui/react/macro';
 import { Controller, useFormContext } from 'react-hook-form';
+import { useRecoilValue } from 'recoil';
 import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { H2Title, IconReload, IconTrash } from 'twenty-ui/display';
 import { Button, ButtonGroup } from 'twenty-ui/input';

--- a/packages/twenty-front/src/modules/settings/domains/components/SettingsDomainRecords.tsx
+++ b/packages/twenty-front/src/modules/settings/domains/components/SettingsDomainRecords.tsx
@@ -1,7 +1,6 @@
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { SettingsDnsRecordsTable } from '@/settings/components/SettingsDnsRecordsTable';
 import { t } from '@lingui/core/macro';
-import { useRecoilValue } from 'recoil';
 import { H2Title } from 'twenty-ui/display';
 import { Section } from 'twenty-ui/layout';
 import { type ThemeColor } from 'twenty-ui/theme';
@@ -9,13 +8,14 @@ import {
   type DomainRecord,
   type DomainValidRecords,
 } from '~/generated-metadata/graphql';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 
 export const SettingsDomainRecords = ({
   records,
 }: {
   records: DomainValidRecords['records'];
 }) => {
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
 
   const rowsDefinitions = [
     { name: 'Domain Setup', validationType: 'redirection' as const },

--- a/packages/twenty-front/src/modules/settings/domains/components/SettingsSubdomain.tsx
+++ b/packages/twenty-front/src/modules/settings/domains/components/SettingsSubdomain.tsx
@@ -5,10 +5,10 @@ import { Controller, useFormContext } from 'react-hook-form';
 
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { domainConfigurationState } from '@/domain-manager/states/domainConfigurationState';
-import { useRecoilValue } from 'recoil';
 import { isDefined } from 'twenty-shared/utils';
 import { H2Title } from 'twenty-ui/display';
 import { Section } from 'twenty-ui/layout';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 
 const StyledDomainFormWrapper = styled.div`
   align-items: center;
@@ -16,10 +16,10 @@ const StyledDomainFormWrapper = styled.div`
 `;
 
 export const SettingsSubdomain = () => {
-  const domainConfiguration = useRecoilValue(domainConfigurationState);
+  const domainConfiguration = useRecoilValueV2(domainConfigurationState);
   const { t } = useLingui();
 
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
 
   const { control } = useFormContext<{
     subdomain: string;

--- a/packages/twenty-front/src/modules/settings/domains/components/SettingsWorkspaceDomainCard.tsx
+++ b/packages/twenty-front/src/modules/settings/domains/components/SettingsWorkspaceDomainCard.tsx
@@ -7,11 +7,12 @@ import { SettingsPath } from 'twenty-shared/types';
 import { getSettingsPath } from 'twenty-shared/utils';
 import { IconWorld, Status } from 'twenty-ui/display';
 import { UndecoratedLink } from 'twenty-ui/navigation';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 
 export const SettingsWorkspaceDomainCard = () => {
   const { t } = useLingui();
   const isMultiWorkspaceEnabled = useRecoilValue(isMultiWorkspaceEnabledState);
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
 
   if (!isMultiWorkspaceEnabled) {
     return null;

--- a/packages/twenty-front/src/modules/settings/domains/hooks/useCheckCustomDomainValidRecords.ts
+++ b/packages/twenty-front/src/modules/settings/domains/hooks/useCheckCustomDomainValidRecords.ts
@@ -1,15 +1,16 @@
 import { useCheckCustomDomainValidRecordsMutation } from '~/generated-metadata/graphql';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilState } from 'recoil';
 import { isDefined } from 'twenty-shared/utils';
 import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { customDomainRecordsState } from '@/settings/domains/states/customDomainRecordsState';
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 
 export const useCheckCustomDomainValidRecords = () => {
   const [checkCustomDomainValidRecords] =
     useCheckCustomDomainValidRecordsMutation();
   const { enqueueErrorSnackBar } = useSnackBar();
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
 
   const [{ isLoading }, setCustomDomainRecords] = useRecoilState(
     customDomainRecordsState,

--- a/packages/twenty-front/src/modules/settings/experience/components/FormatPreferencesSettings.tsx
+++ b/packages/twenty-front/src/modules/settings/experience/components/FormatPreferencesSettings.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
-import { useRecoilValue } from 'recoil';
 
 import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { DateFormat } from '@/localization/constants/DateFormat';
 import { NumberFormat } from '@/localization/constants/NumberFormat';
 import { TimeFormat } from '@/localization/constants/TimeFormat';
@@ -26,7 +26,7 @@ const StyledContainer = styled.div`
 `;
 
 export const FormatPreferencesSettings = () => {
-  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+  const currentWorkspaceMember = useRecoilValueV2(currentWorkspaceMemberState);
   const { formatPreferences, updateFormatPreference } = useFormatPreferences();
 
   if (!isDefined(currentWorkspaceMember)) return null;

--- a/packages/twenty-front/src/modules/settings/hooks/__tests__/useSettingsNavigationItems.test.tsx
+++ b/packages/twenty-front/src/modules/settings/hooks/__tests__/useSettingsNavigationItems.test.tsx
@@ -15,8 +15,13 @@ import { currentUserState } from '@/auth/states/currentUserState';
 import { billingState } from '@/client-config/states/billingState';
 import { usePermissionFlagMap } from '@/settings/roles/hooks/usePermissionFlagMap';
 import { SnackBarComponentInstanceContext } from '@/ui/feedback/snack-bar-manager/contexts/SnackBarComponentInstanceContext';
+import {
+  jotaiStore,
+  resetJotaiStore,
+} from '@/ui/utilities/state/jotai/jotaiStore';
 import { i18n } from '@lingui/core';
 import { I18nProvider } from '@lingui/react';
+import { Provider as JotaiProvider } from 'jotai';
 import { SOURCE_LOCALE } from 'twenty-shared/translations';
 import { messages } from '~/locales/generated/en';
 
@@ -46,23 +51,26 @@ const mockBilling: Billing = {
 };
 
 const initializeState = ({ set }: MutableSnapshot) => {
-  set(currentUserState, mockCurrentUser);
+  // currentUserState is now a Jotai state, set it directly
+  jotaiStore.set(currentUserState.atom, mockCurrentUser);
   set(billingState, mockBilling);
 };
 
 const Wrapper = ({ children }: { children: ReactNode }) => (
   <MockedProvider>
-    <RecoilRoot initializeState={initializeState}>
-      <MemoryRouter>
-        <I18nProvider i18n={i18n}>
-          <SnackBarComponentInstanceContext.Provider
-            value={{ instanceId: 'test-scope-id' }}
-          >
-            {children}
-          </SnackBarComponentInstanceContext.Provider>
-        </I18nProvider>
-      </MemoryRouter>
-    </RecoilRoot>
+    <JotaiProvider store={jotaiStore}>
+      <RecoilRoot initializeState={initializeState}>
+        <MemoryRouter>
+          <I18nProvider i18n={i18n}>
+            <SnackBarComponentInstanceContext.Provider
+              value={{ instanceId: 'test-scope-id' }}
+            >
+              {children}
+            </SnackBarComponentInstanceContext.Provider>
+          </I18nProvider>
+        </MemoryRouter>
+      </RecoilRoot>
+    </JotaiProvider>
   </MockedProvider>
 );
 
@@ -71,6 +79,10 @@ jest.mock('@/settings/roles/hooks/usePermissionFlagMap', () => ({
 }));
 
 describe('useSettingsNavigationItems', () => {
+  beforeEach(() => {
+    resetJotaiStore();
+  });
+
   it('should hide workspace settings when no permissions', () => {
     (usePermissionFlagMap as jest.Mock).mockImplementation(() => ({
       [PermissionFlagType.WORKSPACE]: false,

--- a/packages/twenty-front/src/modules/settings/hooks/useSettingsNavigationItems.tsx
+++ b/packages/twenty-front/src/modules/settings/hooks/useSettingsNavigationItems.tsx
@@ -12,6 +12,7 @@ import { useIsFeatureEnabled } from '@/workspace/hooks/useIsFeatureEnabled';
 import { t } from '@lingui/core/macro';
 import { isNonEmptyString } from '@sniptt/guards';
 import { useRecoilValue } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import {
   IconApi,
   // IconApps, // TODO: Re-enable when integrations page is ready
@@ -65,10 +66,10 @@ const useSettingsNavigationItems = (): SettingsNavigationSection[] => {
   const billing = useRecoilValue(billingState);
   const { signOut } = useAuth();
   const supportChat = useRecoilValue(supportChatState);
-  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+  const currentWorkspaceMember = useRecoilValueV2(currentWorkspaceMemberState);
 
   const isBillingEnabled = billing?.isBillingEnabled ?? false;
-  const currentUser = useRecoilValue(currentUserState);
+  const currentUser = useRecoilValueV2(currentUserState);
   const isAdminEnabled =
     (currentUser?.canImpersonate || currentUser?.canAccessFullAdminPanel) ??
     false;

--- a/packages/twenty-front/src/modules/settings/lab/components/SettingsLabContent.tsx
+++ b/packages/twenty-front/src/modules/settings/lab/components/SettingsLabContent.tsx
@@ -3,9 +3,9 @@ import { SettingsOptionCardContentToggle } from '@/settings/components/SettingsO
 import { useLabPublicFeatureFlags } from '@/settings/lab/hooks/useLabPublicFeatureFlags';
 import styled from '@emotion/styled';
 import { useState } from 'react';
-import { useRecoilValue } from 'recoil';
 import { Card } from 'twenty-ui/layout';
 import { type FeatureFlagKey } from '~/generated-metadata/graphql';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 
 const StyledCardGrid = styled.div`
   display: grid;
@@ -22,7 +22,7 @@ const StyledImage = styled.img`
 `;
 
 export const SettingsLabContent = () => {
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
   const { labPublicFeatureFlags, handleLabPublicFeatureFlagUpdate } =
     useLabPublicFeatureFlags();
   const [hasImageLoadingError, setHasImageLoadingError] = useState<

--- a/packages/twenty-front/src/modules/settings/lab/hooks/useLabPublicFeatureFlags.ts
+++ b/packages/twenty-front/src/modules/settings/lab/hooks/useLabPublicFeatureFlags.ts
@@ -3,7 +3,7 @@ import { labPublicFeatureFlagsStateV2 } from '@/client-config/states/labPublicFe
 import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { t } from '@lingui/core/macro';
 import { useState } from 'react';
-import { useRecoilState } from 'recoil';
+import { useRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilStateV2';
 import { isDefined } from 'twenty-shared/utils';
 import {
   type FeatureFlagKey,
@@ -12,7 +12,7 @@ import {
 
 export const useLabPublicFeatureFlags = () => {
   const [error, setError] = useState<string | null>(null);
-  const [currentWorkspace, setCurrentWorkspace] = useRecoilState(
+  const [currentWorkspace, setCurrentWorkspace] = useRecoilStateV2(
     currentWorkspaceState,
   );
   const labPublicFeatureFlags = useRecoilValueV2(labPublicFeatureFlagsStateV2);

--- a/packages/twenty-front/src/modules/settings/profile/components/DeleteAccount.tsx
+++ b/packages/twenty-front/src/modules/settings/profile/components/DeleteAccount.tsx
@@ -1,9 +1,8 @@
-import { useRecoilValue } from 'recoil';
-
 import { useAuth } from '@/auth/hooks/useAuth';
 import { availableWorkspacesState } from '@/auth/states/availableWorkspacesState';
 import { currentUserState } from '@/auth/states/currentUserState';
 import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { countAvailableWorkspaces } from '@/auth/utils/availableWorkspacesUtils';
 import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { ConfirmationModal } from '@/ui/layout/modal/components/ConfirmationModal';
@@ -32,12 +31,12 @@ export const DeleteAccount = () => {
 
   const [deleteUserAccount] = useDeleteUserAccountMutation();
   const [deleteUserFromWorkspace] = useDeleteUserWorkspaceMutation();
-  const currentUser = useRecoilValue(currentUserState);
+  const currentUser = useRecoilValueV2(currentUserState);
   const userEmail = currentUser?.email;
-  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+  const currentWorkspaceMember = useRecoilValueV2(currentWorkspaceMemberState);
   const currentWorkspaceMemberId = currentWorkspaceMember?.id;
   const { signOut } = useAuth();
-  const availableWorkspaces = useRecoilValue(availableWorkspacesState);
+  const availableWorkspaces = useRecoilValueV2(availableWorkspacesState);
   const availableWorkspacesCount =
     countAvailableWorkspaces(availableWorkspaces);
 

--- a/packages/twenty-front/src/modules/settings/profile/components/DeleteWorkspace.tsx
+++ b/packages/twenty-front/src/modules/settings/profile/components/DeleteWorkspace.tsx
@@ -1,8 +1,8 @@
 import { Trans, useLingui } from '@lingui/react/macro';
-import { useRecoilValue } from 'recoil';
 
 import { useAuth } from '@/auth/hooks/useAuth';
 import { currentUserState } from '@/auth/states/currentUserState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { useRedirectToDefaultDomain } from '@/domain-manager/hooks/useRedirectToDefaultDomain';
 import { ConfirmationModal } from '@/ui/layout/modal/components/ConfirmationModal';
 import { useModal } from '@/ui/layout/modal/hooks/useModal';
@@ -14,7 +14,7 @@ const DELETE_WORKSPACE_MODAL_ID = 'delete-workspace-modal';
 
 export const DeleteWorkspace = () => {
   const [deleteCurrentWorkspace] = useDeleteCurrentWorkspaceMutation();
-  const currentUser = useRecoilValue(currentUserState);
+  const currentUser = useRecoilValueV2(currentUserState);
   const userEmail = currentUser?.email;
   const { t } = useLingui();
   const { openModal } = useModal();

--- a/packages/twenty-front/src/modules/settings/profile/components/EmailField.tsx
+++ b/packages/twenty-front/src/modules/settings/profile/components/EmailField.tsx
@@ -1,8 +1,8 @@
 import styled from '@emotion/styled';
 import { useState } from 'react';
-import { useRecoilValue } from 'recoil';
 
 import { currentUserState } from '@/auth/states/currentUserState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { useCanEditProfileField } from '@/settings/profile/hooks/useCanEditProfileField';
 import { useUpdateEmail } from '@/settings/profile/hooks/useUpdateEmail';
 import { SettingsTextInput } from '@/ui/input/components/SettingsTextInput';
@@ -38,7 +38,7 @@ const StyledActionButton = styled(Button)`
 `;
 
 export const EmailField = () => {
-  const currentUser = useRecoilValue(currentUserState);
+  const currentUser = useRecoilValueV2(currentUserState);
   const { canEdit } = useCanEditProfileField('email');
   const { updateEmail } = useUpdateEmail();
 

--- a/packages/twenty-front/src/modules/settings/profile/components/NameFields.tsx
+++ b/packages/twenty-front/src/modules/settings/profile/components/NameFields.tsx
@@ -1,11 +1,12 @@
 import styled from '@emotion/styled';
 import { useLingui } from '@lingui/react/macro';
 import { useEffect, useState } from 'react';
-import { useRecoilState, useRecoilValue } from 'recoil';
 import { useDebouncedCallback } from 'use-debounce';
 
 import { currentUserState } from '@/auth/states/currentUserState';
 import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
+import { useRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilStateV2';
 import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
 import { useUpdateOneRecord } from '@/object-record/hooks/useUpdateOneRecord';
 import { useCanEditProfileField } from '@/settings/profile/hooks/useCanEditProfileField';
@@ -26,8 +27,8 @@ type NameFieldsProps = {
 
 export const NameFields = ({ autoSave = true }: NameFieldsProps) => {
   const { t } = useLingui();
-  const currentUser = useRecoilValue(currentUserState);
-  const [currentWorkspaceMember, setCurrentWorkspaceMember] = useRecoilState(
+  const currentUser = useRecoilValueV2(currentUserState);
+  const [currentWorkspaceMember, setCurrentWorkspaceMember] = useRecoilStateV2(
     currentWorkspaceMemberState,
   );
   const { canEdit: canEditFirstName } = useCanEditProfileField('firstName');

--- a/packages/twenty-front/src/modules/settings/profile/components/SetOrChangePassword.tsx
+++ b/packages/twenty-front/src/modules/settings/profile/components/SetOrChangePassword.tsx
@@ -1,13 +1,13 @@
 import { useHandleResetPassword } from '@/auth/sign-in-up/hooks/useHandleResetPassword';
 import { currentUserState } from '@/auth/states/currentUserState';
 import { useLingui } from '@lingui/react/macro';
-import { useRecoilValue } from 'recoil';
 import { H2Title } from 'twenty-ui/display';
 import { Button } from 'twenty-ui/input';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 
 export const SetOrChangePassword = () => {
   const { t } = useLingui();
-  const currentUser = useRecoilValue(currentUserState);
+  const currentUser = useRecoilValueV2(currentUserState);
 
   const { handleResetPassword } = useHandleResetPassword();
 

--- a/packages/twenty-front/src/modules/settings/profile/hooks/useCanChangePassword.ts
+++ b/packages/twenty-front/src/modules/settings/profile/hooks/useCanChangePassword.ts
@@ -1,12 +1,11 @@
-import { useRecoilValue } from 'recoil';
-
 import { currentUserWorkspaceState } from '@/auth/states/currentUserWorkspaceState';
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { PermissionFlagType } from '~/generated-metadata/graphql';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 
 export const useCanChangePassword = () => {
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
-  const currentUserWorkspace = useRecoilValue(currentUserWorkspaceState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
+  const currentUserWorkspace = useRecoilValueV2(currentUserWorkspaceState);
 
   const isPasswordAuthEnabled =
     currentWorkspace?.isPasswordAuthEnabled === true;

--- a/packages/twenty-front/src/modules/settings/profile/hooks/useCanEditProfileField.ts
+++ b/packages/twenty-front/src/modules/settings/profile/hooks/useCanEditProfileField.ts
@@ -2,8 +2,8 @@ import { availableWorkspacesState } from '@/auth/states/availableWorkspacesState
 import { currentUserWorkspaceState } from '@/auth/states/currentUserWorkspaceState';
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { countAvailableWorkspaces } from '@/auth/utils/availableWorkspacesUtils';
-import { useRecoilValue } from 'recoil';
 import { PermissionFlagType } from '~/generated-metadata/graphql';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 
 export type EditableProfileField =
   | 'email'
@@ -12,9 +12,9 @@ export type EditableProfileField =
   | 'profilePicture';
 
 export const useCanEditProfileField = (field: EditableProfileField) => {
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
-  const currentUserWorkspace = useRecoilValue(currentUserWorkspaceState);
-  const availableWorkspaces = useRecoilValue(availableWorkspacesState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
+  const currentUserWorkspace = useRecoilValueV2(currentUserWorkspaceState);
+  const availableWorkspaces = useRecoilValueV2(availableWorkspacesState);
 
   if (!currentWorkspace || !currentUserWorkspace) {
     return { canEdit: false };

--- a/packages/twenty-front/src/modules/settings/profile/hooks/useUpdateEmail.ts
+++ b/packages/twenty-front/src/modules/settings/profile/hooks/useUpdateEmail.ts
@@ -1,16 +1,16 @@
 import { ApolloError } from '@apollo/client';
 
 import { t } from '@lingui/core/macro';
-import { useRecoilValue } from 'recoil';
 
 import { currentUserState } from '@/auth/states/currentUserState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { useUpdateUserEmailMutation } from '~/generated-metadata/graphql';
 
 export const useUpdateEmail = () => {
   const { enqueueErrorSnackBar, enqueueInfoSnackBar } = useSnackBar();
 
-  const currentUser = useRecoilValue(currentUserState);
+  const currentUser = useRecoilValueV2(currentUserState);
 
   const [updateUserEmail] = useUpdateUserEmailMutation();
 

--- a/packages/twenty-front/src/modules/settings/roles/components/SettingsRolesDefaultRole.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/components/SettingsRolesDefaultRole.tsx
@@ -5,7 +5,7 @@ import {
 import { SettingsOptionCardContentSelect } from '@/settings/components/SettingsOptions/SettingsOptionCardContentSelect';
 import { Select } from '@/ui/input/components/Select';
 import { t } from '@lingui/core/macro';
-import { useRecoilState } from 'recoil';
+import { useRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilStateV2';
 import { isDefined } from 'twenty-shared/utils';
 import { H2Title, IconUserPin, useIcons } from 'twenty-ui/display';
 import { Card, Section } from 'twenty-ui/layout';
@@ -24,7 +24,7 @@ export const SettingsRoleDefaultRole = ({
 }: SettingsRoleDefaultRoleProps) => {
   const [updateWorkspace] = useUpdateWorkspaceMutation();
 
-  const [currentWorkspace, setCurrentWorkspace] = useRecoilState(
+  const [currentWorkspace, setCurrentWorkspace] = useRecoilStateV2(
     currentWorkspaceState,
   );
 

--- a/packages/twenty-front/src/modules/settings/roles/components/SettingsRolesTableRow.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/components/SettingsRolesTableRow.tsx
@@ -4,7 +4,7 @@ import { TableRow } from '@/ui/layout/table/components/TableRow';
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import React from 'react';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { SettingsPath } from 'twenty-shared/types';
 import { getSettingsPath, isDefined } from 'twenty-shared/utils';
 import {
@@ -65,7 +65,9 @@ export const SettingsRolesTableRow = ({ role }: SettingsRolesTableRowProps) => {
   const { getIcon } = useIcons();
   const Icon = getIcon(role.icon ?? 'IconUser');
 
-  const currentWorkspaceMembers = useRecoilValue(currentWorkspaceMembersState);
+  const currentWorkspaceMembers = useRecoilValueV2(
+    currentWorkspaceMembersState,
+  );
 
   const enrichedWorkspaceMembers = role.workspaceMembers
     .map((workspaceMember) =>

--- a/packages/twenty-front/src/modules/settings/roles/hooks/useHasPermissionFlag.ts
+++ b/packages/twenty-front/src/modules/settings/roles/hooks/useHasPermissionFlag.ts
@@ -1,14 +1,14 @@
 import { currentUserWorkspaceState } from '@/auth/states/currentUserWorkspaceState';
-import { useRecoilValue } from 'recoil';
 import {
   WorkspaceActivationStatus,
   PermissionFlagType,
 } from '~/generated-metadata/graphql';
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 
 export const useHasPermissionFlag = (permissionFlag?: PermissionFlagType) => {
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
-  const currentUserWorkspace = useRecoilValue(currentUserWorkspaceState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
+  const currentUserWorkspace = useRecoilValueV2(currentUserWorkspaceState);
 
   if (!permissionFlag) {
     return true;

--- a/packages/twenty-front/src/modules/settings/roles/hooks/usePermissionFlagMap.ts
+++ b/packages/twenty-front/src/modules/settings/roles/hooks/usePermissionFlagMap.ts
@@ -1,10 +1,10 @@
 import { currentUserWorkspaceState } from '@/auth/states/currentUserWorkspaceState';
-import { useRecoilValue } from 'recoil';
 import { PermissionFlagType } from '~/generated-metadata/graphql';
 import { buildRecordFromKeysWithSameValue } from '~/utils/array/buildRecordFromKeysWithSameValue';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 
 export const usePermissionFlagMap = (): Record<PermissionFlagType, boolean> => {
-  const currentUserWorkspace = useRecoilValue(currentUserWorkspaceState);
+  const currentUserWorkspace = useRecoilValueV2(currentUserWorkspaceState);
 
   const currentUserWorkspaceSettingsPermissions =
     currentUserWorkspace?.permissionFlags;

--- a/packages/twenty-front/src/modules/settings/roles/role-assignment/components/SettingsRoleAssignment.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/role-assignment/components/SettingsRoleAssignment.tsx
@@ -14,6 +14,7 @@ import { useRecoilComponentValueV2 } from '@/ui/utilities/state/jotai/hooks/useR
 import { useIsFeatureEnabled } from '@/workspace/hooks/useIsFeatureEnabled';
 import { useState } from 'react';
 import { useRecoilValue } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { SettingsPath } from 'twenty-shared/types';
 import {
   useFindManyAgentsQuery,
@@ -64,8 +65,10 @@ export const SettingsRoleAssignment = ({
       null,
     );
 
-  const currentWorkspaceMembers = useRecoilValue(currentWorkspaceMembersState);
-  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+  const currentWorkspaceMembers = useRecoilValueV2(
+    currentWorkspaceMembersState,
+  );
+  const currentWorkspaceMember = useRecoilValueV2(currentWorkspaceMemberState);
   const settingsAllRoles = useRecoilValue(settingsAllRolesSelector);
 
   const roleMaps = buildRoleMaps(settingsAllRoles);

--- a/packages/twenty-front/src/modules/settings/roles/role-assignment/components/SettingsRoleAssignmentConfirmationModalSubtitle.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/role-assignment/components/SettingsRoleAssignmentConfirmationModalSubtitle.tsx
@@ -4,8 +4,8 @@ import { type SettingsRoleAssignmentConfirmationModalSelectedRoleTarget } from '
 
 import styled from '@emotion/styled';
 import { t } from '@lingui/core/macro';
-import { useRecoilValue } from 'recoil';
 import { Avatar } from 'twenty-ui/display';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 
 const StyledSettingsCardContainer = styled.div`
   margin-top: ${({ theme }) => theme.spacing(6)};
@@ -20,7 +20,9 @@ export const SettingsRoleAssignmentConfirmationModalSubtitle = ({
   selectedRoleTarget,
   onRoleClick,
 }: SettingsRoleAssignmentConfirmationModalSubtitleProps) => {
-  const currentWorkspaceMembers = useRecoilValue(currentWorkspaceMembersState);
+  const currentWorkspaceMembers = useRecoilValueV2(
+    currentWorkspaceMembersState,
+  );
 
   const enrichedSelectedWorkspaceMember = currentWorkspaceMembers.find(
     (member) => member.id === selectedRoleTarget.id,

--- a/packages/twenty-front/src/modules/settings/roles/role-assignment/components/SettingsRoleAssignmentTableRow.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/role-assignment/components/SettingsRoleAssignmentTableRow.tsx
@@ -7,6 +7,7 @@ import { t } from '@lingui/core/macro';
 import styled from '@emotion/styled';
 import { useContext } from 'react';
 import { useRecoilValue } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import {
   Avatar,
   IconKey,
@@ -55,7 +56,9 @@ export const SettingsRoleAssignmentTableRow = ({
   roleTarget,
 }: SettingsRoleAssignmentTableRowProps) => {
   const theme = useTheme();
-  const currentWorkspaceMembers = useRecoilValue(currentWorkspaceMembersState);
+  const currentWorkspaceMembers = useRecoilValueV2(
+    currentWorkspaceMembersState,
+  );
   const { getIcon } = useIcons();
   const { dateFormat, timeZone } = useContext(UserContext);
   const dateLocale = useRecoilValue(dateLocaleState);

--- a/packages/twenty-front/src/modules/settings/roles/role-assignment/components/SettingsRoleAssignmentWorkspaceMemberPickerDropdownContent.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/role-assignment/components/SettingsRoleAssignmentWorkspaceMemberPickerDropdownContent.tsx
@@ -1,10 +1,10 @@
 import { currentWorkspaceMembersState } from '@/auth/states/currentWorkspaceMembersState';
 import { t } from '@lingui/core/macro';
-import { useRecoilValue } from 'recoil';
 import { isDefined } from 'twenty-shared/utils';
 import { MenuItem, MenuItemAvatar } from 'twenty-ui/navigation';
 import { type SearchRecord } from '~/generated/graphql';
 import { type PartialWorkspaceMember } from '@/settings/roles/types/RoleWithPartialMembers';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 
 type SettingsRoleAssignmentWorkspaceMemberPickerDropdownContentProps = {
   loading: boolean;
@@ -19,7 +19,9 @@ export const SettingsRoleAssignmentWorkspaceMemberPickerDropdownContent = ({
   filteredWorkspaceMembers,
   onSelect,
 }: SettingsRoleAssignmentWorkspaceMemberPickerDropdownContentProps) => {
-  const currentWorkspaceMembers = useRecoilValue(currentWorkspaceMembersState);
+  const currentWorkspaceMembers = useRecoilValueV2(
+    currentWorkspaceMembersState,
+  );
 
   if (loading) {
     return null;

--- a/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/object-form/components/SettingsRolePermissionsObjectLevelObjectForm.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/object-form/components/SettingsRolePermissionsObjectLevelObjectForm.tsx
@@ -11,6 +11,7 @@ import { useFeatureFlagsMap } from '@/workspace/hooks/useFeatureFlagsMap';
 import { t } from '@lingui/core/macro';
 import { useSearchParams } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { SettingsPath, type ViewFilterOperand } from 'twenty-shared/types';
 import { getSettingsPath, isDefined } from 'twenty-shared/utils';
 import { Button } from 'twenty-ui/input';
@@ -33,7 +34,7 @@ export const SettingsRolePermissionsObjectLevelObjectForm = ({
   const [searchParams] = useSearchParams();
   const fromAgentId = searchParams.get('fromAgent');
 
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
 
   const settingsDraftRole = useRecoilValue(
     settingsDraftRoleFamilyState(roleId),

--- a/packages/twenty-front/src/modules/settings/security/components/SSO/SettingsSSOIdentitiesProvidersListCard.tsx
+++ b/packages/twenty-front/src/modules/settings/security/components/SSO/SettingsSSOIdentitiesProvidersListCard.tsx
@@ -13,7 +13,8 @@ import { type ApolloError } from '@apollo/client';
 import isPropValid from '@emotion/is-prop-valid';
 import styled from '@emotion/styled';
 import { useLingui } from '@lingui/react/macro';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilState } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { getSettingsPath } from 'twenty-shared/utils';
 import { IconKey } from 'twenty-ui/display';
 import { useGetSsoIdentityProvidersQuery } from '~/generated-metadata/graphql';
@@ -28,7 +29,7 @@ const StyledLink = styled(Link, {
 export const SettingsSSOIdentitiesProvidersListCard = () => {
   const { enqueueErrorSnackBar } = useSnackBar();
 
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
 
   const { t } = useLingui();
 

--- a/packages/twenty-front/src/modules/settings/security/components/SettingsSecurityAuthBypassOptionsList.tsx
+++ b/packages/twenty-front/src/modules/settings/security/components/SettingsSecurityAuthBypassOptionsList.tsx
@@ -5,7 +5,6 @@ import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { ApolloError } from '@apollo/client';
 import styled from '@emotion/styled';
 import { useLingui } from '@lingui/react/macro';
-import { useRecoilState } from 'recoil';
 import { capitalize } from 'twenty-shared/utils';
 import { IconGoogle, IconMicrosoft, IconPassword } from 'twenty-ui/display';
 import { Card } from 'twenty-ui/layout';
@@ -14,6 +13,7 @@ import {
   useUpdateWorkspaceMutation,
 } from '~/generated-metadata/graphql';
 import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
+import { useRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilStateV2';
 
 const StyledSettingsSecurityOptionsList = styled.div`
   display: flex;
@@ -27,7 +27,7 @@ export const SettingsSecurityAuthBypassOptionsList = () => {
   const { enqueueErrorSnackBar } = useSnackBar();
   const authProviders = useRecoilValueV2(authProvidersState);
 
-  const [currentWorkspace, setCurrentWorkspace] = useRecoilState(
+  const [currentWorkspace, setCurrentWorkspace] = useRecoilStateV2(
     currentWorkspaceState,
   );
 

--- a/packages/twenty-front/src/modules/settings/security/components/SettingsSecurityAuthProvidersOptionsList.tsx
+++ b/packages/twenty-front/src/modules/settings/security/components/SettingsSecurityAuthProvidersOptionsList.tsx
@@ -6,7 +6,8 @@ import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { ApolloError } from '@apollo/client';
 import styled from '@emotion/styled';
 import { useLingui } from '@lingui/react/macro';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilValue } from 'recoil';
+import { useRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilStateV2';
 import { ConnectedAccountProvider } from 'twenty-shared/types';
 import { capitalize } from 'twenty-shared/utils';
 import {
@@ -37,7 +38,7 @@ export const SettingsSecurityAuthProvidersOptionsList = () => {
   const SSOIdentitiesProviders = useRecoilValue(SSOIdentitiesProvidersState);
   const authProviders = useRecoilValueV2(authProvidersState);
 
-  const [currentWorkspace, setCurrentWorkspace] = useRecoilState(
+  const [currentWorkspace, setCurrentWorkspace] = useRecoilStateV2(
     currentWorkspaceState,
   );
 

--- a/packages/twenty-front/src/modules/settings/security/components/SettingsSecurityEditableProfileFields.tsx
+++ b/packages/twenty-front/src/modules/settings/security/components/SettingsSecurityEditableProfileFields.tsx
@@ -8,7 +8,7 @@ import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/Drop
 import { ApolloError } from '@apollo/client';
 import styled from '@emotion/styled';
 import { useLingui } from '@lingui/react/macro';
-import { useRecoilState } from 'recoil';
+import { useRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilStateV2';
 import { isDefined } from 'twenty-shared/utils';
 import {
   IconMail,
@@ -37,7 +37,7 @@ export const SettingsSecurityEditableProfileFields = () => {
   const { t } = useLingui();
   const { enqueueErrorSnackBar } = useSnackBar();
 
-  const [currentWorkspace, setCurrentWorkspace] = useRecoilState(
+  const [currentWorkspace, setCurrentWorkspace] = useRecoilStateV2(
     currentWorkspaceState,
   );
   const [updateWorkspace] = useUpdateWorkspaceMutation();

--- a/packages/twenty-front/src/modules/settings/security/components/Toggle2FA.tsx
+++ b/packages/twenty-front/src/modules/settings/security/components/Toggle2FA.tsx
@@ -1,6 +1,5 @@
-import { useRecoilState } from 'recoil';
-
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
+import { useRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilStateV2';
 import { SettingsOptionCardContentToggle } from '@/settings/components/SettingsOptions/SettingsOptionCardContentToggle';
 import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { ApolloError } from '@apollo/client';
@@ -10,7 +9,7 @@ import { useUpdateWorkspaceMutation } from '~/generated-metadata/graphql';
 
 export const Toggle2FA = () => {
   const { enqueueErrorSnackBar } = useSnackBar();
-  const [currentWorkspace, setCurrentWorkspace] = useRecoilState(
+  const [currentWorkspace, setCurrentWorkspace] = useRecoilStateV2(
     currentWorkspaceState,
   );
 

--- a/packages/twenty-front/src/modules/settings/two-factor-authentication/components/DeleteTwoFactorAuthenticationMethod.tsx
+++ b/packages/twenty-front/src/modules/settings/two-factor-authentication/components/DeleteTwoFactorAuthenticationMethod.tsx
@@ -1,7 +1,6 @@
-import { useRecoilValue } from 'recoil';
-
 import { useAuth } from '@/auth/hooks/useAuth';
 import { currentUserState } from '@/auth/states/currentUserState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { ConfirmationModal } from '@/ui/layout/modal/components/ConfirmationModal';
 import { useModal } from '@/ui/layout/modal/hooks/useModal';
@@ -28,7 +27,7 @@ export const DeleteTwoFactorAuthentication = () => {
   const { loadCurrentUser } = useLoadCurrentUser();
   const [deleteTwoFactorAuthenticationMethod] =
     useDeleteTwoFactorAuthenticationMethodMutation();
-  const currentUser = useRecoilValue(currentUserState);
+  const currentUser = useRecoilValueV2(currentUserState);
   const userEmail = currentUser?.email;
   const navigate = useNavigateSettings();
   const twoFactorAuthenticationStrategy =

--- a/packages/twenty-front/src/modules/settings/two-factor-authentication/components/TwoFactorAuthenticationSetupForSettingsEffect.tsx
+++ b/packages/twenty-front/src/modules/settings/two-factor-authentication/components/TwoFactorAuthenticationSetupForSettingsEffect.tsx
@@ -4,9 +4,9 @@ import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { gql, useMutation } from '@apollo/client';
 import { useLingui } from '@lingui/react/macro';
 import { useEffect } from 'react';
-import { useRecoilValue } from 'recoil';
 import { isDefined } from 'twenty-shared/utils';
 import { useRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilStateV2';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 
 const INITIATE_OTP_PROVISIONING_FOR_AUTHENTICATED_USER = gql`
   mutation initiateOTPProvisioningForAuthenticatedUser {
@@ -19,7 +19,7 @@ const INITIATE_OTP_PROVISIONING_FOR_AUTHENTICATED_USER = gql`
 export const TwoFactorAuthenticationSetupForSettingsEffect = () => {
   const { enqueueErrorSnackBar } = useSnackBar();
   const [qrCode, setQrCode] = useRecoilStateV2(qrCodeState);
-  const currentUser = useRecoilValue(currentUserState);
+  const currentUser = useRecoilValueV2(currentUserState);
 
   const { t } = useLingui();
 

--- a/packages/twenty-front/src/modules/settings/two-factor-authentication/hooks/useCurrentUserWorkspaceTwoFactorAuthentication.ts
+++ b/packages/twenty-front/src/modules/settings/two-factor-authentication/hooks/useCurrentUserWorkspaceTwoFactorAuthentication.ts
@@ -1,13 +1,13 @@
 import { currentUserWorkspaceState } from '@/auth/states/currentUserWorkspaceState';
 import { useMemo } from 'react';
-import { useRecoilValue } from 'recoil';
 import {
   type TwoFactorAuthenticationMethodDto,
   useInitiateOtpProvisioningMutation,
 } from '~/generated-metadata/graphql';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 
 export const useCurrentUserWorkspaceTwoFactorAuthentication = () => {
-  const currentUserWorkspace = useRecoilValue(currentUserWorkspaceState);
+  const currentUserWorkspace = useRecoilValueV2(currentUserWorkspaceState);
   const [initiateCurrentUserWorkspaceOtpProvisioning] =
     useInitiateOtpProvisioningMutation();
 

--- a/packages/twenty-front/src/modules/settings/two-factor-authentication/hooks/useWorkspaceTwoFactorAuthenticationPolicy.ts
+++ b/packages/twenty-front/src/modules/settings/two-factor-authentication/hooks/useWorkspaceTwoFactorAuthenticationPolicy.ts
@@ -1,8 +1,8 @@
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 
 export const useCurrentWorkspaceTwoFactorAuthenticationPolicy = () => {
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
 
   return {
     isEnforced: currentWorkspace?.isTwoFactorAuthenticationEnforced ?? false,

--- a/packages/twenty-front/src/modules/settings/workspace-member/components/WorkspaceMemberPictureUploader.tsx
+++ b/packages/twenty-front/src/modules/settings/workspace-member/components/WorkspaceMemberPictureUploader.tsx
@@ -1,8 +1,8 @@
 import { t } from '@lingui/core/macro';
 import { useState } from 'react';
-import { useRecoilState } from 'recoil';
 
 import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
+import { useRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilStateV2';
 import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
 import { useUpdateOneRecord } from '@/object-record/hooks/useUpdateOneRecord';
 import { useCanEditProfileField } from '@/settings/profile/hooks/useCanEditProfileField';
@@ -39,7 +39,7 @@ export const WorkspaceMemberPictureUploader = ({
   const [uploadController, setUploadController] =
     useState<AbortController | null>(null);
 
-  const [currentWorkspaceMember, setCurrentWorkspaceMember] = useRecoilState(
+  const [currentWorkspaceMember, setCurrentWorkspaceMember] = useRecoilStateV2(
     currentWorkspaceMemberState,
   );
 

--- a/packages/twenty-front/src/modules/settings/workspace/components/NameField.tsx
+++ b/packages/twenty-front/src/modules/settings/workspace/components/NameField.tsx
@@ -1,9 +1,10 @@
 import styled from '@emotion/styled';
 import { useCallback, useEffect, useState } from 'react';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { useDebouncedCallback } from 'use-debounce';
 
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
+import { useSetRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useSetRecoilStateV2';
 import { SettingsTextInput } from '@/ui/input/components/SettingsTextInput';
 import { useLingui } from '@lingui/react/macro';
 import isEmpty from 'lodash.isempty';
@@ -30,8 +31,8 @@ export const NameField = ({
   onNameUpdate,
 }: NameFieldProps) => {
   const { t } = useLingui();
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
-  const setCurrentWorkspace = useSetRecoilState(currentWorkspaceState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
+  const setCurrentWorkspace = useSetRecoilStateV2(currentWorkspaceState);
 
   const [displayName, setDisplayName] = useState(
     currentWorkspace?.displayName ?? '',

--- a/packages/twenty-front/src/modules/settings/workspace/components/ToggleImpersonate.tsx
+++ b/packages/twenty-front/src/modules/settings/workspace/components/ToggleImpersonate.tsx
@@ -1,6 +1,5 @@
-import { useRecoilState } from 'recoil';
-
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
+import { useRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilStateV2';
 import { SettingsOptionCardContentToggle } from '@/settings/components/SettingsOptions/SettingsOptionCardContentToggle';
 import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { ApolloError } from '@apollo/client';
@@ -12,7 +11,7 @@ import { useUpdateWorkspaceMutation } from '~/generated-metadata/graphql';
 export const ToggleImpersonate = () => {
   const { enqueueErrorSnackBar } = useSnackBar();
 
-  const [currentWorkspace, setCurrentWorkspace] = useRecoilState(
+  const [currentWorkspace, setCurrentWorkspace] = useRecoilStateV2(
     currentWorkspaceState,
   );
 

--- a/packages/twenty-front/src/modules/settings/workspace/components/WorkspaceLogoUploader.tsx
+++ b/packages/twenty-front/src/modules/settings/workspace/components/WorkspaceLogoUploader.tsx
@@ -1,6 +1,5 @@
-import { useRecoilState } from 'recoil';
-
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
+import { useRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilStateV2';
 import { ImageInput } from '@/ui/input/components/ImageInput';
 import { useIsFeatureEnabled } from '@/workspace/hooks/useIsFeatureEnabled';
 import { buildSignedPath } from 'twenty-shared/utils';
@@ -19,7 +18,7 @@ export const WorkspaceLogoUploader = () => {
   const [uploadLogoLegacy] = useUploadWorkspaceLogoLegacyMutation();
   const [uploadLogo] = useUploadWorkspaceLogoMutation();
   const [updateWorkspace] = useUpdateWorkspaceMutation();
-  const [currentWorkspace, setCurrentWorkspace] = useRecoilState(
+  const [currentWorkspace, setCurrentWorkspace] = useRecoilStateV2(
     currentWorkspaceState,
   );
 

--- a/packages/twenty-front/src/modules/sse-db-event/components/SSEClientEffect.tsx
+++ b/packages/twenty-front/src/modules/sse-db-event/components/SSEClientEffect.tsx
@@ -3,6 +3,7 @@ import { tokenPairState } from '@/auth/states/tokenPairState';
 import { useHandleSseClientConnectionRetry } from '@/sse-db-event/hooks/useHandleSseClientConnectionRetry';
 import { activeQueryListenersState } from '@/sse-db-event/states/activeQueryListenersState';
 import { sseClientState } from '@/sse-db-event/states/sseClientState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { getSnapshotValue } from '@/ui/utilities/state/utils/getSnapshotValue';
 import { isNonEmptyArray } from '@sniptt/guards';
 import { createClient } from 'graphql-sse';
@@ -14,7 +15,7 @@ import { REACT_APP_SERVER_BASE_URL } from '~/config';
 export const SSEClientEffect = () => {
   const isLoggedIn = useIsLogged();
   const [sseClient, setSseClient] = useRecoilState(sseClientState);
-  const [tokenPair] = useRecoilState(tokenPairState);
+  const tokenPair = useRecoilValueV2(tokenPairState);
 
   const handleSSEClientConnected = useRecoilCallback(
     ({ snapshot, set }) =>

--- a/packages/twenty-front/src/modules/sse-db-event/components/SSEEventStreamEffect.tsx
+++ b/packages/twenty-front/src/modules/sse-db-event/components/SSEEventStreamEffect.tsx
@@ -7,6 +7,7 @@ import { isCreatingSseEventStreamState } from '@/sse-db-event/states/isCreatingS
 import { isDestroyingEventStreamState } from '@/sse-db-event/states/isDestroyingEventStreamState';
 import { shouldDestroyEventStreamState } from '@/sse-db-event/states/shouldDestroyEventStreamState';
 import { sseEventStreamIdState } from '@/sse-db-event/states/sseEventStreamIdState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { useIsFeatureEnabled } from '@/workspace/hooks/useIsFeatureEnabled';
 import { isNonEmptyArray } from '@apollo/client/utilities';
 import { isNonEmptyString } from '@sniptt/guards';
@@ -31,7 +32,7 @@ export const SSEEventStreamEffect = () => {
   const isSseDbEventsEnabled = useIsFeatureEnabled(
     FeatureFlagKey.IS_SSE_DB_EVENTS_ENABLED,
   );
-  const currentUser = useRecoilValue(currentUserState);
+  const currentUser = useRecoilValueV2(currentUserState);
 
   const { triggerEventStreamCreation } = useTriggerEventStreamCreation();
   const { triggerEventStreamDestroy } = useTriggerEventStreamDestroy();

--- a/packages/twenty-front/src/modules/sse-db-event/hooks/useHandleSseClientConnectionRetry.ts
+++ b/packages/twenty-front/src/modules/sse-db-event/hooks/useHandleSseClientConnectionRetry.ts
@@ -6,11 +6,14 @@ import { shouldDestroyEventStreamState } from '@/sse-db-event/states/shouldDestr
 import { sseClientState } from '@/sse-db-event/states/sseClientState';
 import { getSnapshotValue } from '@/ui/utilities/state/utils/getSnapshotValue';
 import { useRecoilCallback } from 'recoil';
+import { useStore } from 'jotai';
 import { isDefined } from 'twenty-shared/utils';
 import { getIsDevelopmentEnvironment } from '~/utils/getIsDevelopmentEnvironment';
 import { sleep } from '~/utils/sleep';
 
 export const useHandleSseClientConnectionRetry = () => {
+  const jotaiStore = useStore();
+
   const handleSseClientConnectionRetry = useRecoilCallback(
     ({ snapshot, set }) =>
       async (retryCount: number, initialTokenForSseClient: string) => {
@@ -24,7 +27,7 @@ export const useHandleSseClientConnectionRetry = () => {
           return;
         }
 
-        const tokenPair = getSnapshotValue(snapshot, tokenPairState);
+        const tokenPair = jotaiStore.get(tokenPairState.atom);
         const currentAppToken =
           tokenPair?.accessOrWorkspaceAgnosticToken?.token;
 

--- a/packages/twenty-front/src/modules/support/hooks/useInstantiateSupportChat.ts
+++ b/packages/twenty-front/src/modules/support/hooks/useInstantiateSupportChat.ts
@@ -2,6 +2,7 @@ import { currentUserState } from '@/auth/states/currentUserState';
 import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
 import { supportChatState } from '@/client-config/states/supportChatState';
 import { useIsPrefetchLoading } from '@/prefetch/hooks/useIsPrefetchLoading';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { isNonEmptyString } from '@sniptt/guards';
 import { useCallback, useEffect, useState } from 'react';
 import { useRecoilValue } from 'recoil';
@@ -28,8 +29,8 @@ const insertScript = ({
 };
 
 export const useInstantiateSupportChat = () => {
-  const currentUser = useRecoilValue(currentUserState);
-  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+  const currentUser = useRecoilValueV2(currentUserState);
+  const currentWorkspaceMember = useRecoilValueV2(currentWorkspaceMemberState);
   const supportChat = useRecoilValue(supportChatState);
   const [isFrontChatLoaded, setIsFrontChatLoaded] = useState(false);
   const loading = useIsPrefetchLoading();

--- a/packages/twenty-front/src/modules/ui/input/components/internal/date/components/DatePicker.tsx
+++ b/packages/twenty-front/src/modules/ui/input/components/internal/date/components/DatePicker.tsx
@@ -15,9 +15,9 @@ import { useCloseDropdown } from '@/ui/layout/dropdown/hooks/useCloseDropdown';
 import { useTheme } from '@emotion/react';
 import { t } from '@lingui/core/macro';
 import 'react-datepicker/dist/react-datepicker.css';
-import { useRecoilValue } from 'recoil';
 
 import { useUserTimezone } from '@/ui/input/components/internal/date/hooks/useUserTimezone';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { Temporal } from 'temporal-polyfill';
 import { type Nullable } from 'twenty-shared/types';
 import {
@@ -356,7 +356,7 @@ export const DatePicker = ({
 
   const { closeDropdown: closeDropdownMonthSelect } = useCloseDropdown();
   const { closeDropdown: closeDropdownYearSelect } = useCloseDropdown();
-  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+  const currentWorkspaceMember = useRecoilValueV2(currentWorkspaceMemberState);
   const handleClear = () => {
     closeDropdowns();
     onClear?.();

--- a/packages/twenty-front/src/modules/ui/input/components/internal/date/components/DatePickerHeader.tsx
+++ b/packages/twenty-front/src/modules/ui/input/components/internal/date/components/DatePickerHeader.tsx
@@ -13,7 +13,7 @@ import {
 } from './DateTimePicker';
 
 import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { Temporal } from 'temporal-polyfill';
 import { SOURCE_LOCALE } from 'twenty-shared/translations';
 import { isDefined } from 'twenty-shared/utils';
@@ -57,7 +57,7 @@ export const DatePickerHeader = ({
   nextMonthButtonDisabled,
   hideInput = false,
 }: DatePickerHeaderProps) => {
-  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+  const currentWorkspaceMember = useRecoilValueV2(currentWorkspaceMemberState);
   const userLocale = currentWorkspaceMember?.locale ?? SOURCE_LOCALE;
 
   const dateParsed = isDefined(date) ? Temporal.PlainDate.from(date) : null;

--- a/packages/twenty-front/src/modules/ui/input/components/internal/date/components/DatePickerWithoutCalendar.tsx
+++ b/packages/twenty-front/src/modules/ui/input/components/internal/date/components/DatePickerWithoutCalendar.tsx
@@ -12,8 +12,8 @@ import { DatePickerHeader } from '@/ui/input/components/internal/date/components
 import { useCloseDropdown } from '@/ui/layout/dropdown/hooks/useCloseDropdown';
 import { useTheme } from '@emotion/react';
 import 'react-datepicker/dist/react-datepicker.css';
-import { useRecoilValue } from 'recoil';
 
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { Temporal } from 'temporal-polyfill';
 import { type Nullable } from 'twenty-shared/types';
 import { isDefined, turnJSDateToPlainDate } from 'twenty-shared/utils';
@@ -328,7 +328,7 @@ export const DatePickerWithoutCalendar = ({
 
   const { closeDropdown: closeDropdownMonthSelect } = useCloseDropdown();
   const { closeDropdown: closeDropdownYearSelect } = useCloseDropdown();
-  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+  const currentWorkspaceMember = useRecoilValueV2(currentWorkspaceMemberState);
 
   const closeDropdowns = () => {
     closeDropdownYearSelect(MONTH_AND_YEAR_DROPDOWN_YEAR_SELECT_ID);

--- a/packages/twenty-front/src/modules/ui/input/components/internal/date/components/DateTimePickerHeader.tsx
+++ b/packages/twenty-front/src/modules/ui/input/components/internal/date/components/DateTimePickerHeader.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
-import { useRecoilValue } from 'recoil';
 
 import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { Select } from '@/ui/input/components/Select';
 
 import { DateTimePickerInput } from '@/ui/input/components/internal/date/components/DateTimePickerInput';
@@ -61,7 +61,7 @@ export const DateTimePickerHeader = ({
   nextMonthButtonDisabled,
   hideInput = false,
 }: DateTimePickerHeaderProps) => {
-  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+  const currentWorkspaceMember = useRecoilValueV2(currentWorkspaceMemberState);
   const userLocale = currentWorkspaceMember?.locale ?? SOURCE_LOCALE;
 
   return (

--- a/packages/twenty-front/src/modules/ui/input/components/internal/date/hooks/__tests__/useUserTimezone.test.tsx
+++ b/packages/twenty-front/src/modules/ui/input/components/internal/date/hooks/__tests__/useUserTimezone.test.tsx
@@ -40,32 +40,31 @@ describe('useUserTimezone', () => {
   });
 
   it('should return system timezone when currentWorkspaceMember.timeZone is "system"', () => {
+    jotaiStore.set(currentWorkspaceMemberState.atom, {
+      id: 'workspace-member-id',
+      name: {
+        firstName: 'John',
+        lastName: 'Doe',
+      },
+      colorScheme: 'Light',
+      locale: 'en-US',
+      userEmail: 'john@example.com',
+      timeZone: 'system',
+      dateFormat: null,
+      timeFormat: null,
+      numberFormat: null,
+      calendarStartDay: null,
+    });
+
     const WrapperWithSystemTimezone = ({
       children,
     }: {
       children: React.ReactNode;
-    }) => {
-      jotaiStore.set(currentWorkspaceMemberState.atom, {
-        id: 'workspace-member-id',
-        name: {
-          firstName: 'John',
-          lastName: 'Doe',
-        },
-        colorScheme: 'Light',
-        locale: 'en-US',
-        userEmail: 'john@example.com',
-        timeZone: 'system',
-        dateFormat: null,
-        timeFormat: null,
-        numberFormat: null,
-        calendarStartDay: null,
-      });
-      return (
-        <JotaiProvider store={jotaiStore}>
-          <RecoilRoot>{children}</RecoilRoot>
-        </JotaiProvider>
-      );
-    };
+    }) => (
+      <JotaiProvider store={jotaiStore}>
+        <RecoilRoot>{children}</RecoilRoot>
+      </JotaiProvider>
+    );
 
     const { result } = renderHook(() => useUserTimezone(), {
       wrapper: WrapperWithSystemTimezone,
@@ -78,32 +77,30 @@ describe('useUserTimezone', () => {
   it('should return user-specific timezone when currentWorkspaceMember.timeZone is set', () => {
     const userTimezone = 'Europe/Paris';
 
+    jotaiStore.set(currentWorkspaceMemberState.atom, {
+      id: 'workspace-member-id',
+      name: {
+        firstName: 'John',
+        lastName: 'Doe',
+      },
+      colorScheme: 'Light',
+      locale: 'en-US',
+      userEmail: 'john@example.com',
+      timeZone: userTimezone,
+      dateFormat: null,
+      timeFormat: null,
+      numberFormat: null,
+      calendarStartDay: null,
+    });
+
     const WrapperWithUserTimezone = ({
       children,
     }: {
       children: React.ReactNode;
     }) => (
-      <RecoilRoot
-        initializeState={(snapshot) => {
-          snapshot.set(currentWorkspaceMemberState, {
-            id: 'workspace-member-id',
-            name: {
-              firstName: 'John',
-              lastName: 'Doe',
-            },
-            colorScheme: 'Light',
-            locale: 'en-US',
-            userEmail: 'john@example.com',
-            timeZone: userTimezone,
-            dateFormat: null,
-            timeFormat: null,
-            numberFormat: null,
-            calendarStartDay: null,
-          });
-        }}
-      >
-        {children}
-      </RecoilRoot>
+      <JotaiProvider store={jotaiStore}>
+        <RecoilRoot>{children}</RecoilRoot>
+      </JotaiProvider>
     );
 
     const { result } = renderHook(() => useUserTimezone(), {

--- a/packages/twenty-front/src/modules/ui/input/components/internal/date/hooks/__tests__/useUserTimezone.test.tsx
+++ b/packages/twenty-front/src/modules/ui/input/components/internal/date/hooks/__tests__/useUserTimezone.test.tsx
@@ -1,8 +1,10 @@
 import { renderHook } from '@testing-library/react';
+import { Provider as JotaiProvider } from 'jotai';
 import { RecoilRoot } from 'recoil';
 
 import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
 import { useUserTimezone } from '@/ui/input/components/internal/date/hooks/useUserTimezone';
+import { jotaiStore } from '@/ui/utilities/state/jotai/jotaiStore';
 
 describe('useUserTimezone', () => {
   const originalIntl = global.Intl;
@@ -24,7 +26,9 @@ describe('useUserTimezone', () => {
 
   it('should return system timezone when currentWorkspaceMember is null', () => {
     const Wrapper = ({ children }: { children: React.ReactNode }) => (
-      <RecoilRoot>{children}</RecoilRoot>
+      <JotaiProvider store={jotaiStore}>
+        <RecoilRoot>{children}</RecoilRoot>
+      </JotaiProvider>
     );
 
     const { result } = renderHook(() => useUserTimezone(), {
@@ -40,29 +44,28 @@ describe('useUserTimezone', () => {
       children,
     }: {
       children: React.ReactNode;
-    }) => (
-      <RecoilRoot
-        initializeState={(snapshot) => {
-          snapshot.set(currentWorkspaceMemberState, {
-            id: 'workspace-member-id',
-            name: {
-              firstName: 'John',
-              lastName: 'Doe',
-            },
-            colorScheme: 'Light',
-            locale: 'en-US',
-            userEmail: 'john@example.com',
-            timeZone: 'system',
-            dateFormat: null,
-            timeFormat: null,
-            numberFormat: null,
-            calendarStartDay: null,
-          });
-        }}
-      >
-        {children}
-      </RecoilRoot>
-    );
+    }) => {
+      jotaiStore.set(currentWorkspaceMemberState.atom, {
+        id: 'workspace-member-id',
+        name: {
+          firstName: 'John',
+          lastName: 'Doe',
+        },
+        colorScheme: 'Light',
+        locale: 'en-US',
+        userEmail: 'john@example.com',
+        timeZone: 'system',
+        dateFormat: null,
+        timeFormat: null,
+        numberFormat: null,
+        calendarStartDay: null,
+      });
+      return (
+        <JotaiProvider store={jotaiStore}>
+          <RecoilRoot>{children}</RecoilRoot>
+        </JotaiProvider>
+      );
+    };
 
     const { result } = renderHook(() => useUserTimezone(), {
       wrapper: WrapperWithSystemTimezone,

--- a/packages/twenty-front/src/modules/ui/input/components/internal/date/hooks/useUserDateFormat.ts
+++ b/packages/twenty-front/src/modules/ui/input/components/internal/date/hooks/useUserDateFormat.ts
@@ -1,9 +1,9 @@
 import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { WorkspaceMemberDateFormatEnum } from '~/generated-metadata/graphql';
 
 export const useUserDateFormat = () => {
-  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+  const currentWorkspaceMember = useRecoilValueV2(currentWorkspaceMemberState);
 
   const userDateFormat =
     currentWorkspaceMember?.dateFormat ?? WorkspaceMemberDateFormatEnum.SYSTEM;

--- a/packages/twenty-front/src/modules/ui/input/components/internal/date/hooks/useUserFirstDayOfTheWeek.ts
+++ b/packages/twenty-front/src/modules/ui/input/components/internal/date/hooks/useUserFirstDayOfTheWeek.ts
@@ -1,6 +1,6 @@
 import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
 import { detectCalendarStartDay } from '@/localization/utils/detection/detectCalendarStartDay';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { CalendarStartDay } from 'twenty-shared/constants';
 import {
   convertCalendarStartDayNonIsoNumberToFirstDayOfTheWeek,
@@ -8,7 +8,7 @@ import {
 } from 'twenty-shared/utils';
 
 export const useUserFirstDayOfTheWeek = () => {
-  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+  const currentWorkspaceMember = useRecoilValueV2(currentWorkspaceMemberState);
   const systemFirstDayOfTheWeek = detectCalendarStartDay();
 
   const isSystemFirstDayOfTheWeek =

--- a/packages/twenty-front/src/modules/ui/input/components/internal/date/hooks/useUserTimeFormat.ts
+++ b/packages/twenty-front/src/modules/ui/input/components/internal/date/hooks/useUserTimeFormat.ts
@@ -1,9 +1,9 @@
 import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { WorkspaceMemberTimeFormatEnum } from '~/generated-metadata/graphql';
 
 export const useUserTimeFormat = () => {
-  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+  const currentWorkspaceMember = useRecoilValueV2(currentWorkspaceMemberState);
 
   const userTimeFormat =
     currentWorkspaceMember?.timeFormat ?? WorkspaceMemberTimeFormatEnum.SYSTEM;

--- a/packages/twenty-front/src/modules/ui/input/components/internal/date/hooks/useUserTimezone.ts
+++ b/packages/twenty-front/src/modules/ui/input/components/internal/date/hooks/useUserTimezone.ts
@@ -1,8 +1,8 @@
 import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 
 export const useUserTimezone = () => {
-  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+  const currentWorkspaceMember = useRecoilValueV2(currentWorkspaceMemberState);
   const systemTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
   const userTimezone =

--- a/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/MultiWorkspaceDropdown/internal/MultiWorkspaceDropdownClickableComponent.tsx
+++ b/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/MultiWorkspaceDropdown/internal/MultiWorkspaceDropdownClickableComponent.tsx
@@ -6,14 +6,13 @@ import {
   StyledLabel,
 } from '@/ui/navigation/navigation-drawer/components/MultiWorkspaceDropdown/internal/MultiWorkspacesDropdownStyles';
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { useTheme } from '@emotion/react';
 import { isNavigationDrawerExpandedState } from '@/ui/navigation/states/isNavigationDrawerExpanded';
-import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { Avatar } from 'twenty-ui/display';
 
 export const MultiWorkspaceDropdownClickableComponent = () => {
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
   const theme = useTheme();
 
   const isNavigationDrawerExpanded = useRecoilValueV2(

--- a/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/MultiWorkspaceDropdown/internal/MultiWorkspaceDropdownDefaultComponents.tsx
+++ b/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/MultiWorkspaceDropdown/internal/MultiWorkspaceDropdownDefaultComponents.tsx
@@ -23,6 +23,7 @@ import { useColorScheme } from '@/ui/theme/hooks/useColorScheme';
 import { useSetRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useSetRecoilStateV2';
 import { type ApolloError } from '@apollo/client';
 import styled from '@emotion/styled';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { isNonEmptyString } from '@sniptt/guards';
 import { useLingui } from '@lingui/react/macro';
 import { useRecoilValue } from 'recoil';
@@ -56,11 +57,11 @@ const StyledDescription = styled.div`
 `;
 
 export const MultiWorkspaceDropdownDefaultComponents = () => {
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
-  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
+  const currentWorkspaceMember = useRecoilValueV2(currentWorkspaceMemberState);
   const { t } = useLingui();
   const { redirectToWorkspaceDomain } = useRedirectToWorkspaceDomain();
-  const availableWorkspaces = useRecoilValue(availableWorkspacesState);
+  const availableWorkspaces = useRecoilValueV2(availableWorkspacesState);
   const availableWorkspacesCount =
     countAvailableWorkspaces(availableWorkspaces);
   const { buildWorkspaceUrl } = useBuildWorkspaceUrl();

--- a/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/MultiWorkspaceDropdown/internal/MultiWorkspaceDropdownWorkspacesListComponents.tsx
+++ b/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/MultiWorkspaceDropdown/internal/MultiWorkspaceDropdownWorkspacesListComponents.tsx
@@ -5,9 +5,9 @@ import { DropdownMenuSearchInput } from '@/ui/layout/dropdown/components/Dropdow
 import { DropdownMenuSeparator } from '@/ui/layout/dropdown/components/DropdownMenuSeparator';
 import { multiWorkspaceDropdownStateV2 } from '@/ui/navigation/navigation-drawer/states/multiWorkspaceDropdownStateV2';
 import { useLingui } from '@lingui/react/macro';
-import { useState } from 'react';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { useSetRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useSetRecoilStateV2';
+import { useState } from 'react';
 import { IconChevronLeft } from 'twenty-ui/display';
 
 import { WorkspacesForSignIn } from './components/WorkspacesForSignIn';
@@ -17,7 +17,7 @@ import { availableWorkspacesState } from '@/auth/states/availableWorkspacesState
 export const MultiWorkspaceDropdownWorkspacesListComponents = () => {
   const { t } = useLingui();
 
-  const availableWorkspaces = useRecoilValue(availableWorkspacesState);
+  const availableWorkspaces = useRecoilValueV2(availableWorkspacesState);
 
   const setMultiWorkspaceDropdownState = useSetRecoilStateV2(
     multiWorkspaceDropdownStateV2,

--- a/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/MultiWorkspaceDropdown/internal/components/WorkspacesForSignIn.tsx
+++ b/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/MultiWorkspaceDropdown/internal/components/WorkspacesForSignIn.tsx
@@ -3,7 +3,7 @@ import { StyledDropdownMenuSubheader } from '@/ui/layout/dropdown/components/Sty
 import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/DropdownMenuItemsContainer';
 import { useFilteredAvailableWorkspaces } from '@/ui/navigation/navigation-drawer/hooks/useFilteredAvailableWorkspaces';
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { availableWorkspacesState } from '@/auth/states/availableWorkspacesState';
 import { AvailableWorkspaceItem } from '@/ui/navigation/navigation-drawer/components/MultiWorkspaceDropdown/internal/components/AvailableWorkspaceItem';
 
@@ -14,8 +14,8 @@ export const WorkspacesForSignIn = ({
 }) => {
   const { t } = useLingui();
 
-  const availableWorkspaces = useRecoilValue(availableWorkspacesState);
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
+  const availableWorkspaces = useRecoilValueV2(availableWorkspacesState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
 
   const { searchAvailableWorkspaces } = useFilteredAvailableWorkspaces();
 

--- a/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/MultiWorkspaceDropdown/internal/components/WorkspacesForSignUp.tsx
+++ b/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/MultiWorkspaceDropdown/internal/components/WorkspacesForSignUp.tsx
@@ -5,7 +5,7 @@ import { useFilteredAvailableWorkspaces } from '@/ui/navigation/navigation-drawe
 import { AvailableWorkspaceItem } from '@/ui/navigation/navigation-drawer/components/MultiWorkspaceDropdown/internal/components/AvailableWorkspaceItem';
 import { availableWorkspacesState } from '@/auth/states/availableWorkspacesState';
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 
 export const WorkspacesForSignUp = ({
   searchValue,
@@ -14,8 +14,8 @@ export const WorkspacesForSignUp = ({
 }) => {
   const { t } = useLingui();
 
-  const availableWorkspaces = useRecoilValue(availableWorkspacesState);
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
+  const availableWorkspaces = useRecoilValueV2(availableWorkspacesState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
 
   const { searchAvailableWorkspaces } = useFilteredAvailableWorkspaces();
 

--- a/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/NavigationDrawerSectionTitle.tsx
+++ b/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/NavigationDrawerSectionTitle.tsx
@@ -7,7 +7,6 @@ import { useIsMobile } from '@/ui/utilities/responsive/hooks/useIsMobile';
 import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import styled from '@emotion/styled';
 import React from 'react';
-import { useRecoilValue } from 'recoil';
 import { isDefined } from 'twenty-shared/utils';
 import { Label } from 'twenty-ui/display';
 
@@ -65,7 +64,7 @@ export const NavigationDrawerSectionTitle = ({
     isNavigationDrawerExpandedState,
   );
   const isSettingsPage = useIsSettingsPage();
-  const currentUser = useRecoilValue(currentUserState);
+  const currentUser = useRecoilValueV2(currentUserState);
   const loading = useIsPrefetchLoading();
   const handleTitleClick = (e: React.MouseEvent<HTMLDivElement>) => {
     e.stopPropagation();

--- a/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/__stories__/NavigationDrawer.stories.tsx
+++ b/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/__stories__/NavigationDrawer.stories.tsx
@@ -5,6 +5,7 @@ import { expect, within } from 'storybook/test';
 
 import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
 import { objectMetadataItemsState } from '@/object-metadata/states/objectMetadataItemsState';
+import { useSetRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useSetRecoilStateV2';
 import { SettingsPath } from 'twenty-shared/types';
 import { ComponentWithRouterDecorator } from '~/testing/decorators/ComponentWithRouterDecorator';
 import { ObjectMetadataItemsDecorator } from '~/testing/decorators/ObjectMetadataItemsDecorator';
@@ -52,7 +53,7 @@ const meta: Meta<typeof NavigationDrawer> = {
     ObjectMetadataItemsDecorator,
     PrefetchLoadedDecorator,
     (Story) => {
-      const setCurrentWorkspaceMember = useSetRecoilState(
+      const setCurrentWorkspaceMember = useSetRecoilStateV2(
         currentWorkspaceMemberState,
       );
       const setObjectMetadataItems = useSetRecoilState(

--- a/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/hooks/useFilteredAvailableWorkspaces.ts
+++ b/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/hooks/useFilteredAvailableWorkspaces.ts
@@ -1,9 +1,9 @@
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { type AvailableWorkspace } from '~/generated-metadata/graphql';
 
 export const useFilteredAvailableWorkspaces = () => {
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
 
   const searchAvailableWorkspaces = (
     searchValue: string,

--- a/packages/twenty-front/src/modules/ui/theme/hooks/__tests__/useColorScheme.test.tsx
+++ b/packages/twenty-front/src/modules/ui/theme/hooks/__tests__/useColorScheme.test.tsx
@@ -1,8 +1,11 @@
 import { act, renderHook } from '@testing-library/react';
-import { RecoilRoot, useSetRecoilState } from 'recoil';
+import { Provider as JotaiProvider } from 'jotai';
+import { RecoilRoot } from 'recoil';
 
 import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
 import { useColorScheme } from '@/ui/theme/hooks/useColorScheme';
+import { useSetRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useSetRecoilStateV2';
+import { jotaiStore } from '@/ui/utilities/state/jotai/jotaiStore';
 import { type WorkspaceMember } from '@/workspace-member/types/WorkspaceMember';
 
 const updateOneRecordMock = jest.fn();
@@ -30,11 +33,17 @@ const workspaceMember: Omit<
 
 describe('useColorScheme', () => {
   it('should update color scheme', async () => {
+    const Wrapper = ({ children }: { children: React.ReactNode }) => (
+      <JotaiProvider store={jotaiStore}>
+        <RecoilRoot>{children}</RecoilRoot>
+      </JotaiProvider>
+    );
+
     const { result } = renderHook(
       () => {
         const colorScheme = useColorScheme();
 
-        const setCurrentWorkspaceMember = useSetRecoilState(
+        const setCurrentWorkspaceMember = useSetRecoilStateV2(
           currentWorkspaceMemberState,
         );
 
@@ -43,7 +52,7 @@ describe('useColorScheme', () => {
         return colorScheme;
       },
       {
-        wrapper: RecoilRoot,
+        wrapper: Wrapper,
       },
     );
 

--- a/packages/twenty-front/src/modules/ui/theme/hooks/useColorScheme.ts
+++ b/packages/twenty-front/src/modules/ui/theme/hooks/useColorScheme.ts
@@ -1,7 +1,6 @@
-import { useCallback } from 'react';
-import { useRecoilState } from 'recoil';
-
 import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
+import { useRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilStateV2';
+import { useCallback } from 'react';
 import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
 import { useUpdateOneRecord } from '@/object-record/hooks/useUpdateOneRecord';
 import { persistedColorSchemeState } from '@/ui/theme/states/persistedColorSchemeState';
@@ -15,7 +14,7 @@ import {
 } from 'twenty-ui/display';
 
 export const useColorScheme = () => {
-  const [currentWorkspaceMember, setCurrentWorkspaceMember] = useRecoilState(
+  const [currentWorkspaceMember, setCurrentWorkspaceMember] = useRecoilStateV2(
     currentWorkspaceMemberState,
   );
 

--- a/packages/twenty-front/src/modules/ui/utilities/page-favicon/components/PageFavicon.tsx
+++ b/packages/twenty-front/src/modules/ui/utilities/page-favicon/components/PageFavicon.tsx
@@ -1,12 +1,12 @@
 import { workspacePublicDataState } from '@/auth/states/workspacePublicDataState';
 import { DEFAULT_WORKSPACE_LOGO } from '@/ui/navigation/navigation-drawer/constants/DefaultWorkspaceLogo';
 import { Helmet } from 'react-helmet-async';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { getImageAbsoluteURI } from 'twenty-shared/utils';
 import { REACT_APP_SERVER_BASE_URL } from '~/config';
 
 export const PageFavicon = () => {
-  const workspacePublicData = useRecoilValue(workspacePublicDataState);
+  const workspacePublicData = useRecoilValueV2(workspacePublicDataState);
   return (
     <Helmet>
       <link

--- a/packages/twenty-front/src/modules/ui/utilities/state/jotai/MIGRATION_PLAN.md
+++ b/packages/twenty-front/src/modules/ui/utilities/state/jotai/MIGRATION_PLAN.md
@@ -41,14 +41,14 @@ Before starting the PRs below, these Jotai V2 utilities need to be created (if n
 - [x] `createFamilyStateV2()` — global atom family
 - [x] `createSelectorV2()` — global derived atom
 - [x] `createComponentStateV2()` — instance-scoped atom
-- [ ] `createComponentFamilyStateV2()` — instance-scoped atom family
+- [x] `createComponentFamilyStateV2()` — instance-scoped atom family
 - [ ] `createComponentSelectorV2()` — instance-scoped derived atom
 - [ ] `createComponentFamilySelectorV2()` — instance-scoped derived atom family
 - [ ] `createFamilySelectorV2()` — global derived atom family (for raw selectorFamily replacements)
 
 ---
 
-## PR 1: UI Utilities — Focus, Hotkeys, Loading, Pointer Events, Scroll
+## PR 1: UI Utilities — Focus, Hotkeys, Loading, Pointer Events, Scroll ✅ DONE
 
 Low-level utilities used across the entire app. No dependencies on other app states.
 
@@ -78,7 +78,7 @@ ui/utilities/focus/states/currentGlobalHotkeysConfigSelector.ts
 
 ---
 
-## PR 2: UI Layout — Selectable List, Modal, Tab List, Table
+## PR 2: UI Layout — Selectable List, Modal, Tab List, Table ✅ DONE
 
 Core layout primitives used by record-table, record-board, and many other modules.
 
@@ -99,7 +99,7 @@ ui/layout/selectable-list/states/selectors/isSelectedItemIdComponentFamilySelect
 
 ---
 
-## PR 3: UI Navigation, Theme, Input, Feedback, Field
+## PR 3: UI Navigation, Theme, Input, Feedback, Field ✅ DONE
 
 ### States (12 files)
 ```

--- a/packages/twenty-front/src/modules/ui/utilities/state/jotai/utils/createJotaiCookieStorage.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/state/jotai/utils/createJotaiCookieStorage.ts
@@ -1,0 +1,97 @@
+import omit from 'lodash.omit';
+import { isDefined } from 'twenty-shared/utils';
+
+import { cookieStorage } from '~/utils/cookie-storage';
+
+type CookieAttributesLike = {
+  expires?: number | Date;
+  path?: string;
+  domain?: string;
+  secure?: boolean;
+};
+
+const hasCustomCookieAttributes = (
+  value: unknown,
+): value is { cookieAttributes: CookieAttributesLike } =>
+  isDefined(value) &&
+  typeof value === 'object' &&
+  value !== null &&
+  'cookieAttributes' in value &&
+  isDefined((value as Record<string, unknown>).cookieAttributes);
+
+type JotaiSyncStorage<ValueType> = {
+  getItem: (key: string, initialValue: ValueType) => ValueType;
+  setItem: (key: string, newValue: ValueType) => void;
+  removeItem: (key: string) => void;
+};
+
+export const createJotaiCookieStorage = <ValueType>({
+  cookieKey,
+  attributes,
+  validateInitFn,
+}: {
+  cookieKey: string;
+  attributes?: CookieAttributesLike;
+  validateInitFn?: (payload: NonNullable<ValueType>) => boolean;
+}): JotaiSyncStorage<ValueType> => {
+  const defaultAttributes = {
+    expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 180),
+    ...(attributes ?? {}),
+  };
+
+  return {
+    getItem: (key: string, initialValue: ValueType): ValueType => {
+      const savedValue = cookieStorage.getItem(cookieKey);
+
+      if (!isDefined(savedValue) || savedValue.length === 0) {
+        return initialValue;
+      }
+
+      try {
+        const parsed = JSON.parse(savedValue);
+
+        if (isDefined(validateInitFn) && !validateInitFn(parsed)) {
+          return initialValue;
+        }
+
+        return parsed as ValueType;
+      } catch {
+        return initialValue;
+      }
+    },
+    setItem: (key: string, newValue: ValueType): void => {
+      const cookieAttrs = {
+        ...defaultAttributes,
+        ...(hasCustomCookieAttributes(newValue)
+          ? newValue.cookieAttributes
+          : {}),
+      };
+
+      const isNullish =
+        newValue === null ||
+        newValue === undefined ||
+        (typeof newValue === 'object' &&
+          newValue !== null &&
+          Object.keys(newValue).length === 1 &&
+          hasCustomCookieAttributes(newValue));
+
+      if (isNullish) {
+        cookieStorage.removeItem(cookieKey, cookieAttrs);
+        return;
+      }
+
+      const valueToStore = hasCustomCookieAttributes(newValue)
+        ? omit(newValue, ['cookieAttributes'])
+        : newValue;
+
+      cookieStorage.setItem(
+        cookieKey,
+        JSON.stringify(valueToStore),
+        cookieAttrs,
+      );
+    },
+    removeItem: (key: string): void => {
+      cookieStorage.removeItem(cookieKey, defaultAttributes);
+    },
+  };
+};

--- a/packages/twenty-front/src/modules/ui/utilities/state/jotai/utils/createJotaiCookieStorage.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/state/jotai/utils/createJotaiCookieStorage.ts
@@ -90,7 +90,7 @@ export const createJotaiCookieStorage = <ValueType>({
         cookieAttrs,
       );
     },
-    removeItem: (key: string): void => {
+    removeItem: (_key: string): void => {
       cookieStorage.removeItem(cookieKey, defaultAttributes);
     },
   };

--- a/packages/twenty-front/src/modules/ui/utilities/state/jotai/utils/createStateV2.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/state/jotai/utils/createStateV2.ts
@@ -1,20 +1,59 @@
-import { atom } from 'jotai';
+import { atom, type WritableAtom } from 'jotai';
 import { atomWithStorage } from 'jotai/utils';
 
 import { type StateV2 } from '@/ui/utilities/state/jotai/types/StateV2';
+import { createJotaiCookieStorage } from '@/ui/utilities/state/jotai/utils/createJotaiCookieStorage';
+
+type CookieStorageConfig<ValueType> = {
+  cookieKey: string;
+  attributes?: {
+    expires?: number | Date;
+    path?: string;
+    domain?: string;
+    secure?: boolean;
+  };
+  validateInitFn?: (payload: NonNullable<ValueType>) => boolean;
+};
+
+type StateAtom<ValueType> = WritableAtom<
+  ValueType,
+  [ValueType | ((prev: ValueType) => ValueType)],
+  void
+>;
 
 export const createStateV2 = <ValueType>({
   key,
   defaultValue,
   useLocalStorage = false,
+  useCookieStorage,
 }: {
   key: string;
   defaultValue: ValueType;
   useLocalStorage?: boolean;
+  useCookieStorage?: CookieStorageConfig<ValueType>;
 }): StateV2<ValueType> => {
-  const baseAtom = useLocalStorage
-    ? atomWithStorage<ValueType>(key, defaultValue)
-    : atom(defaultValue);
+  let baseAtom: StateAtom<ValueType>;
+
+  if (useCookieStorage) {
+    const storage = createJotaiCookieStorage<ValueType>({
+      cookieKey: useCookieStorage.cookieKey,
+      attributes: useCookieStorage.attributes,
+      validateInitFn: useCookieStorage.validateInitFn,
+    });
+    baseAtom = atomWithStorage<ValueType>(
+      useCookieStorage.cookieKey,
+      defaultValue,
+      storage,
+    ) as StateAtom<ValueType>;
+  } else if (useLocalStorage) {
+    baseAtom = atomWithStorage<ValueType>(
+      key,
+      defaultValue,
+    ) as StateAtom<ValueType>;
+  } else {
+    baseAtom = atom(defaultValue);
+  }
+
   baseAtom.debugLabel = key;
 
   return {

--- a/packages/twenty-front/src/modules/ui/utilities/state/jotai/utils/createStateV2.ts
+++ b/packages/twenty-front/src/modules/ui/utilities/state/jotai/utils/createStateV2.ts
@@ -1,5 +1,6 @@
 import { atom, type WritableAtom } from 'jotai';
 import { atomWithStorage } from 'jotai/utils';
+import { isDefined } from 'twenty-shared/utils';
 
 import { type StateV2 } from '@/ui/utilities/state/jotai/types/StateV2';
 import { createJotaiCookieStorage } from '@/ui/utilities/state/jotai/utils/createJotaiCookieStorage';
@@ -34,7 +35,7 @@ export const createStateV2 = <ValueType>({
 }): StateV2<ValueType> => {
   let baseAtom: StateAtom<ValueType>;
 
-  if (useCookieStorage) {
+  if (isDefined(useCookieStorage)) {
     const storage = createJotaiCookieStorage<ValueType>({
       cookieKey: useCookieStorage.cookieKey,
       attributes: useCookieStorage.attributes,

--- a/packages/twenty-front/src/modules/users/components/MetadataProviderEffect.tsx
+++ b/packages/twenty-front/src/modules/users/components/MetadataProviderEffect.tsx
@@ -1,4 +1,4 @@
-import { useRecoilCallback, useRecoilState, useSetRecoilState } from 'recoil';
+import { useRecoilCallback, useSetRecoilState } from 'recoil';
 
 import { useIsLogged } from '@/auth/hooks/useIsLogged';
 import { availableWorkspacesState } from '@/auth/states/availableWorkspacesState';
@@ -15,6 +15,8 @@ import { type PageLayout } from '@/page-layout/types/PageLayout';
 import { transformPageLayout } from '@/page-layout/utils/transformPageLayout';
 import { logicFunctionsState } from '@/settings/logic-functions/states/logicFunctionsState';
 import { getDateFnsLocale } from '@/ui/field/display/utils/getDateFnsLocale.util';
+import { useRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilStateV2';
+import { useSetRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useSetRecoilStateV2';
 import { useStore } from 'jotai';
 import { coreViewsState } from '@/views/states/coreViewState';
 import { type CoreViewWithRelations } from '@/views/types/CoreViewWithRelations';
@@ -41,7 +43,7 @@ import { isMatchingLocation } from '~/utils/isMatchingLocation';
 export const MetadataProviderEffect = () => {
   const location = useLocation();
 
-  const [isCurrentUserLoaded, setIsCurrentUserLoaded] = useRecoilState(
+  const [isCurrentUserLoaded, setIsCurrentUserLoaded] = useRecoilStateV2(
     isCurrentUserLoadedState,
   );
 
@@ -49,10 +51,12 @@ export const MetadataProviderEffect = () => {
     useState(false);
   const [localAreViewsLoaded, setLocalAreViewsLoaded] = useState(false);
 
-  const setCurrentUser = useSetRecoilState(currentUserState);
-  const setCurrentWorkspace = useSetRecoilState(currentWorkspaceState);
-  const setCurrentUserWorkspace = useSetRecoilState(currentUserWorkspaceState);
-  const setAvailableWorkspaces = useSetRecoilState(availableWorkspacesState);
+  const setCurrentUser = useSetRecoilStateV2(currentUserState);
+  const setCurrentWorkspace = useSetRecoilStateV2(currentWorkspaceState);
+  const setCurrentUserWorkspace = useSetRecoilStateV2(
+    currentUserWorkspaceState,
+  );
+  const setAvailableWorkspaces = useSetRecoilStateV2(availableWorkspacesState);
   const setLogicFunctions = useSetRecoilState(logicFunctionsState);
   const { initializeFormatPreferences } = useInitializeFormatPreferences();
   const isLoggedIn = useIsLogged();
@@ -105,13 +109,13 @@ export const MetadataProviderEffect = () => {
     [],
   );
 
-  const setCurrentWorkspaceMember = useSetRecoilState(
+  const setCurrentWorkspaceMember = useSetRecoilStateV2(
     currentWorkspaceMemberState,
   );
-  const setCurrentWorkspaceMembers = useSetRecoilState(
+  const setCurrentWorkspaceMembers = useSetRecoilStateV2(
     currentWorkspaceMembersState,
   );
-  const setCurrentWorkspaceMembersWithDeleted = useSetRecoilState(
+  const setCurrentWorkspaceMembersWithDeleted = useSetRecoilStateV2(
     currentWorkspaceDeletedMembersState,
   );
 

--- a/packages/twenty-front/src/modules/users/components/UserProvider.tsx
+++ b/packages/twenty-front/src/modules/users/components/UserProvider.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { useRecoilValue } from 'recoil';
 
 import { isCurrentUserLoadedState } from '@/auth/states/isCurrentUserLoadedState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { useDateTimeFormat } from '@/localization/hooks/useDateTimeFormat';
 import { UserContext } from '@/users/contexts/UserContext';
 import { useLocation } from 'react-router-dom';
@@ -10,7 +10,7 @@ import { UserOrMetadataLoader } from '~/loading/components/UserOrMetadataLoader'
 import { isMatchingLocation } from '~/utils/isMatchingLocation';
 
 export const UserProvider = ({ children }: React.PropsWithChildren) => {
-  const isCurrentUserLoaded = useRecoilValue(isCurrentUserLoadedState);
+  const isCurrentUserLoaded = useRecoilValueV2(isCurrentUserLoadedState);
   const location = useLocation();
 
   const { dateFormat, timeFormat, timeZone } = useDateTimeFormat();

--- a/packages/twenty-front/src/modules/users/hooks/useLoadCurrentUser.ts
+++ b/packages/twenty-front/src/modules/users/hooks/useLoadCurrentUser.ts
@@ -8,6 +8,8 @@ import { authProvidersState } from '@/client-config/states/authProvidersState';
 import { useIsCurrentLocationOnAWorkspace } from '@/domain-manager/hooks/useIsCurrentLocationOnAWorkspace';
 import { useLastAuthenticatedWorkspaceDomain } from '@/domain-manager/hooks/useLastAuthenticatedWorkspaceDomain';
 import { useInitializeFormatPreferences } from '@/localization/hooks/useInitializeFormatPreferences';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
+import { useSetRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useSetRecoilStateV2';
 import { coreViewsState } from '@/views/states/coreViewState';
 import { workspaceAuthBypassProvidersState } from '@/workspace/states/workspaceAuthBypassProvidersState';
 import { useCallback } from 'react';
@@ -22,24 +24,25 @@ import {
 } from '~/generated-metadata/graphql';
 import { getWorkspaceUrl } from '~/utils/getWorkspaceUrl';
 import { dynamicActivate } from '~/utils/i18n/dynamicActivate';
-import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 
 export const useLoadCurrentUser = () => {
-  const setCurrentUser = useSetRecoilState(currentUserState);
-  const setAvailableWorkspaces = useSetRecoilState(availableWorkspacesState);
-  const setCurrentWorkspaceMember = useSetRecoilState(
+  const setCurrentUser = useSetRecoilStateV2(currentUserState);
+  const setAvailableWorkspaces = useSetRecoilStateV2(availableWorkspacesState);
+  const setCurrentWorkspaceMember = useSetRecoilStateV2(
     currentWorkspaceMemberState,
   );
   const { setLastAuthenticateWorkspaceDomain } =
     useLastAuthenticatedWorkspaceDomain();
-  const setCurrentUserWorkspace = useSetRecoilState(currentUserWorkspaceState);
-  const setCurrentWorkspaceMembers = useSetRecoilState(
+  const setCurrentUserWorkspace = useSetRecoilStateV2(
+    currentUserWorkspaceState,
+  );
+  const setCurrentWorkspaceMembers = useSetRecoilStateV2(
     currentWorkspaceMembersState,
   );
-  const setCurrentWorkspace = useSetRecoilState(currentWorkspaceState);
+  const setCurrentWorkspace = useSetRecoilStateV2(currentWorkspaceState);
   const { initializeFormatPreferences } = useInitializeFormatPreferences();
   const setCoreViews = useSetRecoilState(coreViewsState);
-  const setWorkspaceAuthBypassProviders = useSetRecoilState(
+  const setWorkspaceAuthBypassProviders = useSetRecoilStateV2(
     workspaceAuthBypassProvidersState,
   );
   const authProviders = useRecoilValueV2(authProvidersState);

--- a/packages/twenty-front/src/modules/workflow/hooks/useRunWorkflowVersion.tsx
+++ b/packages/twenty-front/src/modules/workflow/hooks/useRunWorkflowVersion.tsx
@@ -17,8 +17,9 @@ import { computeOptimisticCreateRecordBaseRecordInput } from '@/object-record/ut
 import { computeOptimisticRecordFromInput } from '@/object-record/utils/computeOptimisticRecordFromInput';
 import { RUN_WORKFLOW_VERSION } from '@/workflow/graphql/mutations/runWorkflowVersion';
 import { type WorkflowRun } from '@/workflow/types/Workflow';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { useMutation } from '@apollo/client';
-import { useRecoilCallback, useRecoilValue } from 'recoil';
+import { useRecoilCallback } from 'recoil';
 import { isDefined } from 'twenty-shared/utils';
 import { v4 } from 'uuid';
 import {
@@ -39,7 +40,7 @@ export const useRunWorkflowVersion = () => {
   const createOneRecordInCache = useCreateOneRecordInCache<WorkflowRun>({
     objectMetadataItem,
   });
-  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+  const currentWorkspaceMember = useRecoilValueV2(currentWorkspaceMemberState);
 
   const [mutate] = useMutation<
     RunWorkflowVersionMutation,

--- a/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/components/WorkflowEditActionEmailBase.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-steps/workflow-actions/components/WorkflowEditActionEmailBase.tsx
@@ -26,8 +26,8 @@ import { useEmailForm } from '@/workflow/workflow-steps/workflow-actions/hooks/u
 import { WorkflowVariablePicker } from '@/workflow/workflow-variables/components/WorkflowVariablePicker';
 import { useTheme } from '@emotion/react';
 import { t } from '@lingui/core/macro';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { useEffect, useState } from 'react';
-import { useRecoilValue } from 'recoil';
 import { ConnectedAccountProvider, SettingsPath } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 import { type WorkflowEmailAction } from '@/workflow/types/WorkflowEmailAction';
@@ -57,7 +57,7 @@ export const WorkflowEditActionEmailBase = ({
   actionOptions,
 }: WorkflowEditActionEmailBaseProps) => {
   const theme = useTheme();
-  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+  const currentWorkspaceMember = useRecoilValueV2(currentWorkspaceMemberState);
   const { triggerApisOAuth } = useTriggerApisOAuth();
   const { enqueueErrorSnackBar } = useSnackBar();
   const { uploadAttachmentFile } = useUploadAttachmentFile();

--- a/packages/twenty-front/src/modules/workflow/workflow-trigger/components/WorkflowEditTriggerWebhookForm.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-trigger/components/WorkflowEditTriggerWebhookForm.tsx
@@ -14,8 +14,8 @@ import { WEBHOOK_TRIGGER_HTTP_METHOD_OPTIONS } from '@/workflow/workflow-trigger
 import { getWebhookTriggerDefaultSettings } from '@/workflow/workflow-trigger/utils/getWebhookTriggerDefaultSettings';
 import { useTheme } from '@emotion/react';
 import { isNonEmptyString } from '@sniptt/guards';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { useState } from 'react';
-import { useRecoilValue } from 'recoil';
 import { isDefined } from 'twenty-shared/utils';
 import { getOutputSchemaFromValue } from 'twenty-shared/logic-function';
 import { TRIGGER_STEP_ID } from 'twenty-shared/workflow';
@@ -57,7 +57,7 @@ export const WorkflowEditTriggerWebhookForm = ({
   const workflowVisualizerWorkflowId = useRecoilComponentValue(
     workflowVisualizerWorkflowIdComponentState,
   );
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
 
   const onBlur = () => {
     setErrorMessagesVisible(true);

--- a/packages/twenty-front/src/modules/workspace/components/WorkspaceProviderEffect.tsx
+++ b/packages/twenty-front/src/modules/workspace/components/WorkspaceProviderEffect.tsx
@@ -4,6 +4,7 @@ import { isMultiWorkspaceEnabledState } from '@/client-config/states/isMultiWork
 import { useReadWorkspaceUrlFromCurrentLocation } from '@/domain-manager/hooks/useReadWorkspaceUrlFromCurrentLocation';
 import { useRedirectToWorkspaceDomain } from '@/domain-manager/hooks/useRedirectToWorkspaceDomain';
 import { lastAuthenticatedWorkspaceDomainState } from '@/domain-manager/states/lastAuthenticatedWorkspaceDomainState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { useEffect, useCallback } from 'react';
 
 import { useInitializeQueryParamState } from '@/app/hooks/useInitializeQueryParamState';
@@ -16,7 +17,7 @@ import { getWorkspaceUrl } from '~/utils/getWorkspaceUrl';
 export const WorkspaceProviderEffect = () => {
   const { data: getPublicWorkspaceData } = useGetPublicWorkspaceDataByDomain();
 
-  const lastAuthenticatedWorkspaceDomain = useRecoilValue(
+  const lastAuthenticatedWorkspaceDomain = useRecoilValueV2(
     lastAuthenticatedWorkspaceDomainState,
   );
 

--- a/packages/twenty-front/src/modules/workspace/hooks/__tests__/useSubscriptionStatus.test.ts
+++ b/packages/twenty-front/src/modules/workspace/hooks/__tests__/useSubscriptionStatus.test.ts
@@ -1,11 +1,15 @@
 import { act, renderHook } from '@testing-library/react';
-import { RecoilRoot, useSetRecoilState } from 'recoil';
+import { createElement } from 'react';
+import { Provider as JotaiProvider } from 'jotai';
+import { RecoilRoot } from 'recoil';
 import { v4 } from 'uuid';
 
 import {
   type CurrentWorkspace,
   currentWorkspaceState,
 } from '@/auth/states/currentWorkspaceState';
+import { useSetRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useSetRecoilStateV2';
+import { jotaiStore } from '@/ui/utilities/state/jotai/jotaiStore';
 import { useSubscriptionStatus } from '@/workspace/hooks/useSubscriptionStatus';
 import {
   SubscriptionStatus,
@@ -19,11 +23,18 @@ const currentWorkspace = {
   allowImpersonation: true,
 } as CurrentWorkspace;
 
+const Wrapper = ({ children }: { children: React.ReactNode }) =>
+  createElement(
+    JotaiProvider,
+    { store: jotaiStore },
+    createElement(RecoilRoot, null, children),
+  );
+
 const renderHooks = () => {
   const { result } = renderHook(
     () => {
       const subscriptionStatus = useSubscriptionStatus();
-      const setCurrentWorkspace = useSetRecoilState(currentWorkspaceState);
+      const setCurrentWorkspace = useSetRecoilStateV2(currentWorkspaceState);
 
       return {
         subscriptionStatus,
@@ -31,7 +42,7 @@ const renderHooks = () => {
       };
     },
     {
-      wrapper: RecoilRoot,
+      wrapper: Wrapper,
     },
   );
   return { result };

--- a/packages/twenty-front/src/modules/workspace/hooks/useFeatureFlagsMap.ts
+++ b/packages/twenty-front/src/modules/workspace/hooks/useFeatureFlagsMap.ts
@@ -1,10 +1,10 @@
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { extractFeatureFlagMapFromWorkspace } from '@/workspace/utils/extractFeatureFlagMapFromWorkspace';
-import { useRecoilValue } from 'recoil';
 import { type FeatureFlagKey } from '~/generated-metadata/graphql';
 
 export const useFeatureFlagsMap = (): Record<FeatureFlagKey, boolean> => {
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
 
   return extractFeatureFlagMapFromWorkspace(currentWorkspace);
 };

--- a/packages/twenty-front/src/modules/workspace/hooks/useIsFeatureEnabled.ts
+++ b/packages/twenty-front/src/modules/workspace/hooks/useIsFeatureEnabled.ts
@@ -1,10 +1,9 @@
-import { useRecoilValue } from 'recoil';
-
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { type FeatureFlagKey } from '~/generated-metadata/graphql';
 
 export const useIsFeatureEnabled = (featureKey: FeatureFlagKey | null) => {
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
 
   if (!featureKey) {
     return false;

--- a/packages/twenty-front/src/modules/workspace/hooks/useIsSomeMeteredProductCapReached.ts
+++ b/packages/twenty-front/src/modules/workspace/hooks/useIsSomeMeteredProductCapReached.ts
@@ -1,9 +1,8 @@
-import { useRecoilValue } from 'recoil';
-
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 
 export const useIsSomeMeteredProductCapReached = (): boolean => {
-  const billingSubscriptionItems = useRecoilValue(currentWorkspaceState)
+  const billingSubscriptionItems = useRecoilValueV2(currentWorkspaceState)
     ?.currentBillingSubscription?.billingSubscriptionItems;
 
   if (!billingSubscriptionItems) {

--- a/packages/twenty-front/src/modules/workspace/hooks/useIsWorkspaceActivationStatusEqualsTo.ts
+++ b/packages/twenty-front/src/modules/workspace/hooks/useIsWorkspaceActivationStatusEqualsTo.ts
@@ -1,11 +1,10 @@
-import { useRecoilValue } from 'recoil';
-
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { type WorkspaceActivationStatus } from 'twenty-shared/workspace';
 
 export const useIsWorkspaceActivationStatusEqualsTo = (
   activationStatus: WorkspaceActivationStatus,
 ): boolean => {
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
   return currentWorkspace?.activationStatus === activationStatus;
 };

--- a/packages/twenty-front/src/modules/workspace/hooks/useSubscriptionStatus.ts
+++ b/packages/twenty-front/src/modules/workspace/hooks/useSubscriptionStatus.ts
@@ -1,9 +1,8 @@
-import { useRecoilValue } from 'recoil';
-
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { type SubscriptionStatus } from '~/generated-metadata/graphql';
 
 export const useSubscriptionStatus = (): SubscriptionStatus | undefined => {
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
   return currentWorkspace?.currentBillingSubscription?.status;
 };

--- a/packages/twenty-front/src/modules/workspace/states/workspaceAuthBypassProvidersState.ts
+++ b/packages/twenty-front/src/modules/workspace/states/workspaceAuthBypassProvidersState.ts
@@ -1,8 +1,8 @@
 import { type AuthBypassProviders } from '~/generated-metadata/graphql';
-import { createState } from '@/ui/utilities/state/utils/createState';
+import { createStateV2 } from '@/ui/utilities/state/jotai/utils/createStateV2';
 
 export const workspaceAuthBypassProvidersState =
-  createState<AuthBypassProviders | null>({
+  createStateV2<AuthBypassProviders | null>({
     key: 'workspaceAuthBypassProvidersState',
     defaultValue: null,
   });

--- a/packages/twenty-front/src/modules/workspace/states/workspaceAuthProvidersState.ts
+++ b/packages/twenty-front/src/modules/workspace/states/workspaceAuthProvidersState.ts
@@ -1,7 +1,7 @@
 import { type AuthProviders } from '~/generated-metadata/graphql';
-import { createState } from '@/ui/utilities/state/utils/createState';
+import { createStateV2 } from '@/ui/utilities/state/jotai/utils/createStateV2';
 
-export const workspaceAuthProvidersState = createState<AuthProviders | null>({
+export const workspaceAuthProvidersState = createStateV2<AuthProviders | null>({
   key: 'workspaceAuthProvidersState',
   defaultValue: null,
 });

--- a/packages/twenty-front/src/modules/workspace/states/workspaceBypassModeState.ts
+++ b/packages/twenty-front/src/modules/workspace/states/workspaceBypassModeState.ts
@@ -1,6 +1,6 @@
-import { createState } from '@/ui/utilities/state/utils/createState';
+import { createStateV2 } from '@/ui/utilities/state/jotai/utils/createStateV2';
 
-export const workspaceBypassModeState = createState<boolean>({
+export const workspaceBypassModeState = createStateV2<boolean>({
   key: 'workspaceBypassModeState',
   defaultValue: false,
 });

--- a/packages/twenty-front/src/pages/auth/PasswordReset.tsx
+++ b/packages/twenty-front/src/pages/auth/PasswordReset.tsx
@@ -25,7 +25,8 @@ import { useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import Skeleton, { SkeletonTheme } from 'react-loading-skeleton';
 import { useParams } from 'react-router-dom';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
+import { useSetRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useSetRecoilStateV2';
 import { AppPath } from 'twenty-shared/types';
 import { MainButton } from 'twenty-ui/input';
 import { AnimatedEaseIn } from 'twenty-ui/utilities';
@@ -87,8 +88,8 @@ export const PasswordReset = () => {
   const { t } = useLingui();
   const { enqueueErrorSnackBar, enqueueSuccessSnackBar } = useSnackBar();
 
-  const workspacePublicData = useRecoilValue(workspacePublicDataState);
-  const setCurrentUser = useSetRecoilState(currentUserState);
+  const workspacePublicData = useRecoilValueV2(workspacePublicDataState);
+  const setCurrentUser = useSetRecoilStateV2(currentUserState);
 
   const navigate = useNavigateApp();
   const { redirect } = useRedirect();

--- a/packages/twenty-front/src/pages/auth/SignInUp.tsx
+++ b/packages/twenty-front/src/pages/auth/SignInUp.tsx
@@ -6,7 +6,9 @@ import {
 } from '@/auth/states/signInUpStepState';
 import { workspacePublicDataState } from '@/auth/states/workspacePublicDataState';
 import styled from '@emotion/styled';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilValue } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
+import { useSetRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useSetRecoilStateV2';
 
 import { Logo } from '@/auth/components/Logo';
 import { Title } from '@/auth/components/Title';
@@ -80,14 +82,14 @@ const StandardContent = ({
 
 export const SignInUp = () => {
   const { t } = useLingui();
-  const setSignInUpStep = useSetRecoilState(signInUpStepState);
+  const setSignInUpStep = useSetRecoilStateV2(signInUpStepState);
   const clientConfigApiStatus = useRecoilValue(clientConfigApiStatusState);
 
   const { form } = useSignInUpForm();
   const { signInUpStep } = useSignInUp(form);
   const { isDefaultDomain } = useIsCurrentLocationOnDefaultDomain();
   const { isOnAWorkspace } = useIsCurrentLocationOnAWorkspace();
-  const workspacePublicData = useRecoilValue(workspacePublicDataState);
+  const workspacePublicData = useRecoilValueV2(workspacePublicDataState);
   const { loading: getPublicWorkspaceDataLoading } =
     useGetPublicWorkspaceDataByDomain();
   const isMultiWorkspaceEnabled = useRecoilValue(isMultiWorkspaceEnabledState);

--- a/packages/twenty-front/src/pages/auth/__stories__/SignInUp.stories.tsx
+++ b/packages/twenty-front/src/pages/auth/__stories__/SignInUp.stories.tsx
@@ -2,10 +2,10 @@ import { getOperationName } from '@apollo/client/utilities';
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 import { HttpResponse, graphql } from 'msw';
 import { useEffect } from 'react';
-import { useSetRecoilState } from 'recoil';
 import { fireEvent, within } from 'storybook/test';
 
 import { captchaTokenState } from '@/captcha/states/captchaTokenState';
+import { useSetRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useSetRecoilStateV2';
 import { GET_CURRENT_USER } from '@/users/graphql/queries/getCurrentUser';
 import {
   PageDecorator,
@@ -17,7 +17,7 @@ import { AppPath } from 'twenty-shared/types';
 import { SignInUp } from '~/pages/auth/SignInUp';
 
 const CaptchaTokenSetterEffect = () => {
-  const setCaptchaToken = useSetRecoilState(captchaTokenState);
+  const setCaptchaToken = useSetRecoilStateV2(captchaTokenState);
 
   useEffect(() => {
     setCaptchaToken('MOCKED_CAPTCHA_TOKEN');

--- a/packages/twenty-front/src/pages/auth/__stories__/SignInUpWithInvite.stories.tsx
+++ b/packages/twenty-front/src/pages/auth/__stories__/SignInUpWithInvite.stories.tsx
@@ -2,10 +2,10 @@ import { getOperationName } from '@apollo/client/utilities';
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 import { HttpResponse, graphql } from 'msw';
 import { useEffect } from 'react';
-import { useSetRecoilState } from 'recoil';
 import { fireEvent, within } from 'storybook/test';
 
 import { captchaTokenState } from '@/captcha/states/captchaTokenState';
+import { useSetRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useSetRecoilStateV2';
 import { GET_CURRENT_USER } from '@/users/graphql/queries/getCurrentUser';
 import { GET_WORKSPACE_FROM_INVITE_HASH } from '@/workspace/graphql/queries/getWorkspaceFromInviteHash';
 import {
@@ -18,7 +18,7 @@ import { AppPath } from 'twenty-shared/types';
 import { SignInUp } from '~/pages/auth/SignInUp';
 
 const CaptchaTokenSetterEffect = () => {
-  const setCaptchaToken = useSetRecoilState(captchaTokenState);
+  const setCaptchaToken = useSetRecoilStateV2(captchaTokenState);
 
   useEffect(() => {
     setCaptchaToken('MOCKED_CAPTCHA_TOKEN');

--- a/packages/twenty-front/src/pages/onboarding/BookCall.tsx
+++ b/packages/twenty-front/src/pages/onboarding/BookCall.tsx
@@ -10,6 +10,7 @@ import { ScrollWrapper } from '@/ui/utilities/scroll/components/ScrollWrapper';
 import { useTheme } from '@emotion/react';
 import { useLingui } from '@lingui/react/macro';
 import { useRecoilValue } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { AppPath } from 'twenty-shared/types';
 import { IconChevronLeft, IconChevronRightPipe } from 'twenty-ui/display';
 import { LightButton } from 'twenty-ui/input';
@@ -39,7 +40,7 @@ export const BookCall = () => {
   const theme = useTheme();
   const calendarBookingPageId = useRecoilValue(calendarBookingPageIdState);
   const setNextOnboardingStatus = useSetNextOnboardingStatus();
-  const currentUser = useRecoilValue(currentUserState);
+  const currentUser = useRecoilValueV2(currentUserState);
   const [skipBookOnboardingStepMutation] = useSkipBookOnboardingStepMutation();
 
   const isMobile = useIsMobile();

--- a/packages/twenty-front/src/pages/onboarding/CreateProfile.tsx
+++ b/packages/twenty-front/src/pages/onboarding/CreateProfile.tsx
@@ -69,8 +69,9 @@ export const CreateProfile = () => {
   const { t } = useLingui();
   const setNextOnboardingStatus = useSetNextOnboardingStatus();
   const { enqueueErrorSnackBar } = useSnackBar();
-  const [currentWorkspaceMember, setCurrentWorkspaceMember] =
-    useRecoilStateV2(currentWorkspaceMemberState);
+  const [currentWorkspaceMember, setCurrentWorkspaceMember] = useRecoilStateV2(
+    currentWorkspaceMemberState,
+  );
   const setCurrentUser = useSetRecoilStateV2(currentUserState);
   const { updateOneRecord } = useUpdateOneRecord();
 

--- a/packages/twenty-front/src/pages/onboarding/CreateProfile.tsx
+++ b/packages/twenty-front/src/pages/onboarding/CreateProfile.tsx
@@ -2,7 +2,8 @@ import styled from '@emotion/styled';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useCallback, useState } from 'react';
 import { Controller, type SubmitHandler, useForm } from 'react-hook-form';
-import { useRecoilState, useSetRecoilState } from 'recoil';
+import { useRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilStateV2';
+import { useSetRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useSetRecoilStateV2';
 import { Key } from 'ts-key-enum';
 import { z } from 'zod';
 
@@ -68,10 +69,9 @@ export const CreateProfile = () => {
   const { t } = useLingui();
   const setNextOnboardingStatus = useSetNextOnboardingStatus();
   const { enqueueErrorSnackBar } = useSnackBar();
-  const [currentWorkspaceMember, setCurrentWorkspaceMember] = useRecoilState(
-    currentWorkspaceMemberState,
-  );
-  const setCurrentUser = useSetRecoilState(currentUserState);
+  const [currentWorkspaceMember, setCurrentWorkspaceMember] =
+    useRecoilStateV2(currentWorkspaceMemberState);
+  const setCurrentUser = useSetRecoilStateV2(currentUserState);
   const { updateOneRecord } = useUpdateOneRecord();
 
   // Form

--- a/packages/twenty-front/src/pages/onboarding/CreateWorkspace.tsx
+++ b/packages/twenty-front/src/pages/onboarding/CreateWorkspace.tsx
@@ -20,7 +20,7 @@ import { ApolloError } from '@apollo/client';
 import { Trans, useLingui } from '@lingui/react/macro';
 import { isNonEmptyString } from '@sniptt/guards';
 import { motion } from 'framer-motion';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { isDefined } from 'twenty-shared/utils';
 import { H2Title } from 'twenty-ui/display';
 import { Loader } from 'twenty-ui/feedback';
@@ -74,7 +74,7 @@ export const CreateWorkspace = () => {
   const [pendingCreationLoaderStep, setPendingCreationLoaderStep] = useState(
     PendingCreationLoaderStep.None,
   );
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
 
   const validationSchema = z
     .object({

--- a/packages/twenty-front/src/pages/onboarding/InviteTeam.tsx
+++ b/packages/twenty-front/src/pages/onboarding/InviteTeam.tsx
@@ -19,6 +19,7 @@ import {
   useForm,
 } from 'react-hook-form';
 import { useRecoilValue } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { Key } from 'ts-key-enum';
 import { isDefined } from 'twenty-shared/utils';
 import { IconCopy, SeparatorLineText } from 'twenty-ui/display';
@@ -65,7 +66,7 @@ export const InviteTeam = () => {
   const { enqueueSuccessSnackBar } = useSnackBar();
   const { sendInvitation } = useCreateWorkspaceInvitation();
   const setNextOnboardingStatus = useSetNextOnboardingStatus();
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
   const calendarBookingPageId = useRecoilValue(calendarBookingPageIdState);
   const hasCalendarBooking = isDefined(calendarBookingPageId);
 

--- a/packages/twenty-front/src/pages/onboarding/PaymentSuccess.tsx
+++ b/packages/twenty-front/src/pages/onboarding/PaymentSuccess.tsx
@@ -7,7 +7,7 @@ import { useSubscriptionStatus } from '@/workspace/hooks/useSubscriptionStatus';
 import styled from '@emotion/styled';
 import { t } from '@lingui/core/macro';
 import { useState } from 'react';
-import { useSetRecoilState } from 'recoil';
+import { useSetRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useSetRecoilStateV2';
 import { AppPath } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 import { IconCheck } from 'twenty-ui/display';
@@ -32,7 +32,7 @@ export const PaymentSuccess = () => {
   const navigate = useNavigateApp();
   const subscriptionStatus = useSubscriptionStatus();
   const [getCurrentUser] = useGetCurrentUserLazyQuery();
-  const setCurrentUser = useSetRecoilState(currentUserState);
+  const setCurrentUser = useSetRecoilStateV2(currentUserState);
   const [isLoading, setIsLoading] = useState(false);
   const navigateWithSubscriptionCheck = async () => {
     if (isLoading) return;

--- a/packages/twenty-front/src/pages/onboarding/SyncEmails.tsx
+++ b/packages/twenty-front/src/pages/onboarding/SyncEmails.tsx
@@ -1,7 +1,8 @@
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useState } from 'react';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilValue } from 'recoil';
+import { useRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilStateV2';
 import { Key } from 'ts-key-enum';
 
 import { SubTitle } from '@/auth/components/SubTitle';
@@ -58,7 +59,7 @@ export const SyncEmails = () => {
   const [visibility, setVisibility] = useState<MessageChannelVisibility>(
     MessageChannelVisibility.SHARE_EVERYTHING,
   );
-  const [lastAuthenticatedMethod] = useRecoilState(
+  const [lastAuthenticatedMethod] = useRecoilStateV2(
     lastAuthenticatedMethodState,
   );
   const [skipSyncEmailOnboardingStatusMutation] =

--- a/packages/twenty-front/src/pages/onboarding/internal/ChooseYourPlanContent.tsx
+++ b/packages/twenty-front/src/pages/onboarding/internal/ChooseYourPlanContent.tsx
@@ -12,8 +12,9 @@ import { useHandleCheckoutSession } from '@/billing/hooks/useHandleCheckoutSessi
 import { calendarBookingPageIdState } from '@/client-config/states/calendarBookingPageIdState';
 import styled from '@emotion/styled';
 import { Trans, useLingui } from '@lingui/react/macro';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilValue } from 'recoil';
 import { AppPath } from 'twenty-shared/types';
+import { useRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilStateV2';
 import { isDefined } from 'twenty-shared/utils';
 import { Loader } from 'twenty-ui/feedback';
 import { CardPicker, MainButton } from 'twenty-ui/input';
@@ -95,15 +96,14 @@ export const ChooseYourPlanContent = ({ billing }: { billing: Billing }) => {
   const { getBaseLicensedPriceByPlanKeyAndInterval } =
     useBaseLicensedPriceByPlanKeyAndInterval();
 
-  const [billingCheckoutSession, setBillingCheckoutSession] = useRecoilState(
+  const [billingCheckoutSession, setBillingCheckoutSession] = useRecoilStateV2(
     billingCheckoutSessionState,
   );
 
   const calendarBookingPageId = useRecoilValue(calendarBookingPageIdState);
 
-  const [verifyEmailRedirectPath, setVerifyEmailRedirectPath] = useRecoilState(
-    verifyEmailRedirectPathState,
-  );
+  const [verifyEmailRedirectPath, setVerifyEmailRedirectPath] =
+    useRecoilStateV2(verifyEmailRedirectPathState);
   if (isDefined(verifyEmailRedirectPath)) {
     setVerifyEmailRedirectPath(undefined);
   }

--- a/packages/twenty-front/src/pages/settings/SettingsBilling.tsx
+++ b/packages/twenty-front/src/pages/settings/SettingsBilling.tsx
@@ -1,7 +1,6 @@
 import { Trans, useLingui } from '@lingui/react/macro';
-import { useRecoilValue } from 'recoil';
-
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { SubMenuTopBarContainer } from '@/ui/layout/page/components/SubMenuTopBarContainer';
 import { SettingsBillingContent } from '@/billing/components/SettingsBillingContent';
 import { getSettingsPath } from 'twenty-shared/utils';
@@ -11,7 +10,7 @@ import { usePlans } from '@/billing/hooks/usePlans';
 export const SettingsBilling = () => {
   const { t } = useLingui();
 
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
 
   const { isPlansLoaded } = usePlans();
 

--- a/packages/twenty-front/src/pages/settings/SettingsProfile.tsx
+++ b/packages/twenty-front/src/pages/settings/SettingsProfile.tsx
@@ -10,7 +10,7 @@ import { useCanChangePassword } from '@/settings/profile/hooks/useCanChangePassw
 import { useCurrentUserWorkspaceTwoFactorAuthentication } from '@/settings/two-factor-authentication/hooks/useCurrentUserWorkspaceTwoFactorAuthentication';
 import { SubMenuTopBarContainer } from '@/ui/layout/page/components/SubMenuTopBarContainer';
 import { Trans, useLingui } from '@lingui/react/macro';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { SettingsPath } from 'twenty-shared/types';
 import { getSettingsPath } from 'twenty-shared/utils';
 import { H2Title, IconShield, Status } from 'twenty-ui/display';
@@ -19,7 +19,7 @@ import { UndecoratedLink } from 'twenty-ui/navigation';
 
 export const SettingsProfile = () => {
   const { t } = useLingui();
-  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+  const currentWorkspaceMember = useRecoilValueV2(currentWorkspaceMemberState);
 
   const { currentUserWorkspaceTwoFactorAuthenticationMethods } =
     useCurrentUserWorkspaceTwoFactorAuthentication();

--- a/packages/twenty-front/src/pages/settings/accounts/SettingsAccounts.tsx
+++ b/packages/twenty-front/src/pages/settings/accounts/SettingsAccounts.tsx
@@ -10,7 +10,7 @@ import { SettingsAccountsSettingsSection } from '@/settings/accounts/components/
 import { SettingsPageContainer } from '@/settings/components/SettingsPageContainer';
 import { SubMenuTopBarContainer } from '@/ui/layout/page/components/SubMenuTopBarContainer';
 import { useLingui } from '@lingui/react/macro';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { SettingsPath } from 'twenty-shared/types';
 import { getSettingsPath } from 'twenty-shared/utils';
 import { H2Title } from 'twenty-ui/display';
@@ -18,7 +18,7 @@ import { Section } from 'twenty-ui/layout';
 
 export const SettingsAccounts = () => {
   const { t } = useLingui();
-  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+  const currentWorkspaceMember = useRecoilValueV2(currentWorkspaceMemberState);
 
   const { recordGqlFields } = useGenerateDepthRecordGqlFieldsFromObject({
     objectNameSingular: CoreObjectNameSingular.ConnectedAccount,

--- a/packages/twenty-front/src/pages/settings/ai/SettingsAIPrompts.tsx
+++ b/packages/twenty-front/src/pages/settings/ai/SettingsAIPrompts.tsx
@@ -10,7 +10,8 @@ import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { SubMenuTopBarContainer } from '@/ui/layout/page/components/SubMenuTopBarContainer';
 import { t } from '@lingui/core/macro';
 import { useState } from 'react';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilStateV2';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { SettingsPath } from 'twenty-shared/types';
 import { getSettingsPath, isDefined } from 'twenty-shared/utils';
 import { H2Title } from 'twenty-ui/display';
@@ -38,10 +39,10 @@ const StyledTokenBadge = styled.span`
 
 export const SettingsAIPrompts = () => {
   const { enqueueErrorSnackBar } = useSnackBar();
-  const [currentWorkspace, setCurrentWorkspace] = useRecoilState(
+  const [currentWorkspace, setCurrentWorkspace] = useRecoilStateV2(
     currentWorkspaceState,
   );
-  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+  const currentWorkspaceMember = useRecoilValueV2(currentWorkspaceMemberState);
   const [updateWorkspace] = useUpdateWorkspaceMutation();
 
   const { data: previewData, loading: previewLoading } =

--- a/packages/twenty-front/src/pages/settings/ai/components/SettingsAIRouterSettings.tsx
+++ b/packages/twenty-front/src/pages/settings/ai/components/SettingsAIRouterSettings.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import { useRecoilState } from 'recoil';
 
 import { DEFAULT_FAST_MODEL } from '@/ai/constants/DefaultFastModel';
 import { DEFAULT_SMART_MODEL } from '@/ai/constants/DefaultSmartModel';
@@ -23,6 +22,7 @@ import { H2Title, IconBolt, IconBrain } from 'twenty-ui/display';
 import { Card, Section } from 'twenty-ui/layout';
 import { useUpdateWorkspaceMutation } from '~/generated-metadata/graphql';
 import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
+import { useRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilStateV2';
 
 const StyledSelectContainer = styled.div`
   justify-content: flex-end;
@@ -38,7 +38,7 @@ const StyledErrorMessage = styled.div`
 
 export const SettingsAIRouterSettings = () => {
   const { enqueueSuccessSnackBar, enqueueErrorSnackBar } = useSnackBar();
-  const [currentWorkspace, setCurrentWorkspace] = useRecoilState(
+  const [currentWorkspace, setCurrentWorkspace] = useRecoilStateV2(
     currentWorkspaceState,
   );
   const [updateWorkspace] = useUpdateWorkspaceMutation();

--- a/packages/twenty-front/src/pages/settings/applications/tabs/SettingsApplicationsCreateTab.tsx
+++ b/packages/twenty-front/src/pages/settings/applications/tabs/SettingsApplicationsCreateTab.tsx
@@ -2,7 +2,7 @@ import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMembe
 import { getDocumentationUrl } from '@/support/utils/getDocumentationUrl';
 import styled from '@emotion/styled';
 import { useLingui } from '@lingui/react/macro';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import {
   CommandBlock,
   H2Title,
@@ -20,7 +20,7 @@ const StyledButtonContainer = styled.div`
 export const SettingsApplicationsCreateTab = () => {
   const { t } = useLingui();
 
-  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+  const currentWorkspaceMember = useRecoilValueV2(currentWorkspaceMemberState);
 
   const { copyToClipboard } = useCopyToClipboard();
 

--- a/packages/twenty-front/src/pages/settings/data-model/SettingsObjectTable.tsx
+++ b/packages/twenty-front/src/pages/settings/data-model/SettingsObjectTable.tsx
@@ -21,7 +21,6 @@ import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useLingui } from '@lingui/react/macro';
 import { type ReactNode, useMemo, useState } from 'react';
-import { useRecoilValue } from 'recoil';
 import { SettingsPath } from 'twenty-shared/types';
 import { getSettingsPath } from 'twenty-shared/utils';
 import { IconArchive, IconChevronRight, IconSettings } from 'twenty-ui/display';
@@ -63,7 +62,7 @@ export const SettingsObjectTable = ({
   const { totalCountByObjectMetadataItemNamePlural } =
     useCombinedGetTotalCount();
 
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
 
   const allObjectSettingsArray = useMemo(
     () =>

--- a/packages/twenty-front/src/pages/settings/domains/SettingsDomain.tsx
+++ b/packages/twenty-front/src/pages/settings/domains/SettingsDomain.tsx
@@ -13,7 +13,8 @@ import { ApolloError } from '@apollo/client';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Trans, useLingui } from '@lingui/react/macro';
 import { FormProvider, useForm } from 'react-hook-form';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilValue } from 'recoil';
+import { useRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilStateV2';
 import { SettingsPath } from 'twenty-shared/types';
 import { getSettingsPath, isDefined } from 'twenty-shared/utils';
 import { z } from 'zod';
@@ -50,7 +51,7 @@ export const SettingsDomain = () => {
   const { redirectToWorkspaceDomain } = useRedirectToWorkspaceDomain();
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const [currentWorkspace, setCurrentWorkspace] = useRecoilState(
+  const [currentWorkspace, setCurrentWorkspace] = useRecoilStateV2(
     currentWorkspaceState,
   );
 

--- a/packages/twenty-front/src/pages/settings/logic-functions/SettingsLogicFunctionDetail.tsx
+++ b/packages/twenty-front/src/pages/settings/logic-functions/SettingsLogicFunctionDetail.tsx
@@ -21,7 +21,7 @@ import {
 } from 'twenty-ui/display';
 import { useFindOneApplicationQuery } from '~/generated-metadata/graphql';
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { SettingsLogicFunctionCodeEditorTab } from '@/settings/logic-functions/components/tabs/SettingsLogicFunctionCodeEditorTab';
 
 const LOGIC_FUNCTION_DETAIL_ID = 'logic-function-detail';
@@ -30,7 +30,7 @@ export const SettingsLogicFunctionDetail = () => {
   const { logicFunctionId = '', applicationId = '' } = useParams();
 
   const navigate = useNavigate();
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
 
   const { data, loading: applicationLoading } = useFindOneApplicationQuery({
     variables: { id: applicationId },

--- a/packages/twenty-front/src/pages/settings/members/SettingsWorkspaceMember.tsx
+++ b/packages/twenty-front/src/pages/settings/members/SettingsWorkspaceMember.tsx
@@ -15,7 +15,7 @@ import { TabList } from '@/ui/layout/tab-list/components/TabList';
 import { activeTabIdComponentState } from '@/ui/layout/tab-list/states/activeTabIdComponentState';
 import { useRecoilComponentValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilComponentValueV2';
 import { t } from '@lingui/core/macro';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { SettingsPath } from 'twenty-shared/types';
 import { getSettingsPath } from 'twenty-shared/utils';
 import { IconInfoCircle, IconLockOpen } from 'twenty-ui/display';
@@ -49,10 +49,10 @@ export const SettingsWorkspaceMember = () => {
   const navigateSettings = useNavigateSettings();
   const { enqueueErrorSnackBar, enqueueSuccessSnackBar } = useSnackBar();
   const { openModal, closeModal } = useModal();
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
   const { executeImpersonationAuth } = useImpersonationAuth();
   const [impersonate] = useImpersonateMutation();
-  const isImpersonating = useRecoilValue(isImpersonatingState);
+  const isImpersonating = useRecoilValueV2(isImpersonatingState);
   const canImpersonate =
     useHasPermissionFlag(PermissionFlagType.IMPERSONATE) && !isImpersonating;
 

--- a/packages/twenty-front/src/pages/settings/members/SettingsWorkspaceMembers.tsx
+++ b/packages/twenty-front/src/pages/settings/members/SettingsWorkspaceMembers.tsx
@@ -4,9 +4,9 @@ import { Trans, useLingui } from '@lingui/react/macro';
 import { isNonEmptyArray } from '@sniptt/guards';
 import { useMemo, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
-import { useRecoilValue } from 'recoil';
 import { useSetRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useSetRecoilStateV2';
 import { useDebounce } from 'use-debounce';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 
 import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
@@ -52,7 +52,6 @@ import { TableRow } from '@/ui/layout/table/components/TableRow';
 import { useDeleteWorkspaceInvitation } from '@/workspace-invitation/hooks/useDeleteWorkspaceInvitation';
 import { useResendWorkspaceInvitation } from '@/workspace-invitation/hooks/useResendWorkspaceInvitation';
 import { workspaceInvitationsState } from '@/workspace-invitation/states/workspaceInvitationsStates';
-import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 
 const StyledButtonContainer = styled.div`
   align-items: center;
@@ -117,7 +116,7 @@ export const SettingsWorkspaceMembers = () => {
   const navigateSettings = useNavigateSettings();
   const [isFetchingMore, setIsFetchingMore] = useState(false);
   const [searchFilter, setSearchFilter] = useState('');
-  const currentWorkspaceMember = useRecoilValue(currentWorkspaceMemberState);
+  const currentWorkspaceMember = useRecoilValueV2(currentWorkspaceMemberState);
 
   const [debouncedSearchFilter] = useDebounce(searchFilter, 300);
 
@@ -152,7 +151,7 @@ export const SettingsWorkspaceMembers = () => {
   const { resendInvitation } = useResendWorkspaceInvitation();
   const { deleteWorkspaceInvitation } = useDeleteWorkspaceInvitation();
 
-  const currentWorkspace = useRecoilValue(currentWorkspaceState);
+  const currentWorkspace = useRecoilValueV2(currentWorkspaceState);
 
   const workspaceInvitations = useRecoilValueV2(workspaceInvitationsState);
   const setWorkspaceInvitations = useSetRecoilStateV2(

--- a/packages/twenty-front/src/pages/settings/profile/appearance/components/LocalePicker.tsx
+++ b/packages/twenty-front/src/pages/settings/profile/appearance/components/LocalePicker.tsx
@@ -1,7 +1,8 @@
 import styled from '@emotion/styled';
-import { useRecoilState, useSetRecoilState } from 'recoil';
 
 import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
+import { useRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilStateV2';
+import { useSetRecoilState } from 'recoil';
 import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
 import { useUpdateOneRecord } from '@/object-record/hooks/useUpdateOneRecord';
 import { getDateFnsLocale } from '@/ui/field/display/utils/getDateFnsLocale.util';
@@ -28,7 +29,7 @@ const StyledContainer = styled.div`
 export const LocalePicker = () => {
   const { t } = useLingui();
   const store = useStore();
-  const [currentWorkspaceMember, setCurrentWorkspaceMember] = useRecoilState(
+  const [currentWorkspaceMember, setCurrentWorkspaceMember] = useRecoilStateV2(
     currentWorkspaceMemberState,
   );
   const setDateLocale = useSetRecoilState(dateLocaleState);

--- a/packages/twenty-front/src/pages/settings/security/SettingsSecurity.tsx
+++ b/packages/twenty-front/src/pages/settings/security/SettingsSecurity.tsx
@@ -21,7 +21,7 @@ import { ToggleImpersonate } from '@/settings/workspace/components/ToggleImperso
 import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { SubMenuTopBarContainer } from '@/ui/layout/page/components/SubMenuTopBarContainer';
 import { ApolloError } from '@apollo/client';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilValue } from 'recoil';
 import { SettingsPath } from 'twenty-shared/types';
 import { getSettingsPath } from 'twenty-shared/utils';
 import { Tag } from 'twenty-ui/components';
@@ -36,6 +36,7 @@ import { Button } from 'twenty-ui/input';
 import { Card, Section } from 'twenty-ui/layout';
 import { useUpdateWorkspaceMutation } from '~/generated-metadata/graphql';
 import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
+import { useRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilStateV2';
 
 const StyledContainer = styled.div`
   width: 100%;
@@ -67,7 +68,7 @@ export const SettingsSecurity = () => {
   const isClickHouseConfigured = useRecoilValue(isClickHouseConfiguredState);
   const authProviders = useRecoilValueV2(authProvidersState);
   const SSOIdentitiesProviders = useRecoilValue(SSOIdentitiesProvidersState);
-  const [currentWorkspace, setCurrentWorkspace] = useRecoilState(
+  const [currentWorkspace, setCurrentWorkspace] = useRecoilStateV2(
     currentWorkspaceState,
   );
   const [updateWorkspace] = useUpdateWorkspaceMutation();

--- a/packages/twenty-front/src/pages/settings/security/event-logs/components/EventLogFilters.tsx
+++ b/packages/twenty-front/src/pages/settings/security/event-logs/components/EventLogFilters.tsx
@@ -38,7 +38,9 @@ export const EventLogFilters = ({
   onChange,
 }: EventLogFiltersProps) => {
   const { t } = useLingui();
-  const currentWorkspaceMembers = useRecoilValueV2(currentWorkspaceMembersState);
+  const currentWorkspaceMembers = useRecoilValueV2(
+    currentWorkspaceMembersState,
+  );
   const { objectMetadataItems } = useObjectMetadataItems();
   const { getIcon } = useIcons();
 

--- a/packages/twenty-front/src/pages/settings/security/event-logs/components/EventLogFilters.tsx
+++ b/packages/twenty-front/src/pages/settings/security/event-logs/components/EventLogFilters.tsx
@@ -1,8 +1,7 @@
 import styled from '@emotion/styled';
 import { useLingui } from '@lingui/react/macro';
-import { useRecoilValue } from 'recoil';
-
 import { currentWorkspaceMembersState } from '@/auth/states/currentWorkspaceMembersState';
+import { useRecoilValueV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilValueV2';
 import { useObjectMetadataItems } from '@/object-metadata/hooks/useObjectMetadataItems';
 import { Select } from '@/ui/input/components/Select';
 import { TextInput } from '@/ui/input/components/TextInput';
@@ -39,7 +38,7 @@ export const EventLogFilters = ({
   onChange,
 }: EventLogFiltersProps) => {
   const { t } = useLingui();
-  const currentWorkspaceMembers = useRecoilValue(currentWorkspaceMembersState);
+  const currentWorkspaceMembers = useRecoilValueV2(currentWorkspaceMembersState);
   const { objectMetadataItems } = useObjectMetadataItems();
   const { getIcon } = useIcons();
 

--- a/packages/twenty-front/src/testing/decorators/ObjectMetadataItemsDecorator.tsx
+++ b/packages/twenty-front/src/testing/decorators/ObjectMetadataItemsDecorator.tsx
@@ -1,10 +1,11 @@
 import { type Decorator } from '@storybook/react-vite';
 import { useEffect } from 'react';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilValue } from 'recoil';
 
 import { currentUserState } from '@/auth/states/currentUserState';
 import { currentUserWorkspaceState } from '@/auth/states/currentUserWorkspaceState';
 import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
+import { useSetRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useSetRecoilStateV2';
 import { PreComputedChipGeneratorsProvider } from '@/object-metadata/components/PreComputedChipGeneratorsProvider';
 import { useLoadMockedObjectMetadataItems } from '@/object-metadata/hooks/useLoadMockedObjectMetadataItems';
 import { objectMetadataItemsState } from '@/object-metadata/states/objectMetadataItemsState';
@@ -13,11 +14,13 @@ import { mockWorkspaceMembers } from '~/testing/mock-data/workspace-members';
 
 export const ObjectMetadataItemsDecorator: Decorator = (Story) => {
   const objectMetadataItems = useRecoilValue(objectMetadataItemsState);
-  const setCurrentWorkspaceMember = useSetRecoilState(
+  const setCurrentWorkspaceMember = useSetRecoilStateV2(
     currentWorkspaceMemberState,
   );
-  const setCurrentUser = useSetRecoilState(currentUserState);
-  const setCurrentUserWorkspace = useSetRecoilState(currentUserWorkspaceState);
+  const setCurrentUser = useSetRecoilStateV2(currentUserState);
+  const setCurrentUserWorkspace = useSetRecoilStateV2(
+    currentUserWorkspaceState,
+  );
 
   const { loadMockedObjectMetadataItems } = useLoadMockedObjectMetadataItems();
 

--- a/packages/twenty-front/src/testing/decorators/WorkspaceDecorator.tsx
+++ b/packages/twenty-front/src/testing/decorators/WorkspaceDecorator.tsx
@@ -1,11 +1,11 @@
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
+import { useSetRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useSetRecoilStateV2';
 import { type Decorator } from '@storybook/react-vite';
 import { useEffect } from 'react';
-import { useSetRecoilState } from 'recoil';
 import { mockCurrentWorkspace } from '~/testing/mock-data/users';
 
 export const WorkspaceDecorator: Decorator = (Story) => {
-  const setCurrentWorkspace = useSetRecoilState(currentWorkspaceState);
+  const setCurrentWorkspace = useSetRecoilStateV2(currentWorkspaceState);
 
   useEffect(() => {
     setCurrentWorkspace(mockCurrentWorkspace);

--- a/packages/twenty-sdk/README.md
+++ b/packages/twenty-sdk/README.md
@@ -52,6 +52,7 @@ Commands:
   auth:switch          Switch the default workspace
   auth:list            List all configured workspaces
   app:dev              Watch and sync local application changes
+  app:typecheck        Run TypeScript type checking on the application
   app:uninstall        Uninstall application from Twenty
   entity:add           Add a new entity to your application
   function:logs        Watch application function logs
@@ -124,6 +125,8 @@ Application development commands.
 - `twenty app:dev [appPath]` — Start development mode: watch and sync local application changes.
   - Behavior: Builds your application (functions and front components), computes the manifest, syncs everything to your workspace, then watches the directory for changes and re-syncs automatically. Displays an interactive UI showing build and sync status in real time. Press Ctrl+C to stop.
 
+- `twenty app:typecheck [appPath]` — Run TypeScript type checking on the application (runs `tsc --noEmit`). Exits with code 1 if type errors are found.
+
 - `twenty app:uninstall [appPath]` — Uninstall the application from the current workspace.
 
 ### Entity
@@ -164,6 +167,9 @@ twenty app:dev
 
 # Start dev mode with a custom workspace profile
 twenty app:dev --workspace my-custom-workspace
+
+# Type check the application
+twenty app:typecheck
 
 # Add a new entity interactively
 twenty entity:add

--- a/packages/twenty-sdk/src/cli/commands/app-command.ts
+++ b/packages/twenty-sdk/src/cli/commands/app-command.ts
@@ -2,6 +2,7 @@ import { formatPath } from '@/cli/utilities/file/file-path';
 import chalk from 'chalk';
 import type { Command } from 'commander';
 import { AppDevCommand } from './app/app-dev';
+import { AppTypecheckCommand } from './app/app-typecheck';
 import { AppUninstallCommand } from './app/app-uninstall';
 import { AuthListCommand } from './auth/auth-list';
 import { AuthLoginCommand } from './auth/auth-login';
@@ -60,6 +61,7 @@ export const registerCommands = (program: Command): void => {
 
   // App commands
   const devCommand = new AppDevCommand();
+  const typecheckCommand = new AppTypecheckCommand();
   const uninstallCommand = new AppUninstallCommand();
   const addCommand = new EntityAddCommand();
   const logsCommand = new LogicFunctionLogsCommand();
@@ -70,6 +72,15 @@ export const registerCommands = (program: Command): void => {
     .description('Watch and sync local application changes')
     .action(async (appPath) => {
       await devCommand.execute({
+        appPath: formatPath(appPath),
+      });
+    });
+
+  program
+    .command('app:typecheck [appPath]')
+    .description('Run TypeScript type checking on the application')
+    .action(async (appPath) => {
+      await typecheckCommand.execute({
         appPath: formatPath(appPath),
       });
     });

--- a/packages/twenty-sdk/src/cli/commands/app/app-typecheck.ts
+++ b/packages/twenty-sdk/src/cli/commands/app/app-typecheck.ts
@@ -1,0 +1,43 @@
+import { CURRENT_EXECUTION_DIRECTORY } from '@/cli/utilities/config/current-execution-directory';
+import {
+  runTypecheck,
+  type TypecheckError,
+} from '@/cli/utilities/build/common/typecheck-plugin';
+import chalk from 'chalk';
+
+export type AppTypecheckOptions = {
+  appPath?: string;
+};
+
+const formatTypecheckError = (error: TypecheckError): string => {
+  return `${chalk.cyan(error.file)}:${chalk.yellow(String(error.line))}:${chalk.yellow(String(error.column + 1))} - ${chalk.red('error')} ${error.text}`;
+};
+
+export class AppTypecheckCommand {
+  async execute(options: AppTypecheckOptions): Promise<void> {
+    const appPath = options.appPath ?? CURRENT_EXECUTION_DIRECTORY;
+
+    console.log(chalk.blue('Running type check...'));
+    console.log(chalk.gray(`App path: ${appPath}`));
+    console.log('');
+
+    const errors = await runTypecheck(appPath);
+
+    if (errors.length === 0) {
+      console.log(chalk.green('✓ No type errors found'));
+      process.exit(0);
+    }
+
+    for (const error of errors) {
+      console.log(formatTypecheckError(error));
+    }
+
+    console.log('');
+    console.log(
+      chalk.red(
+        `✗ Found ${errors.length} type error${errors.length === 1 ? '' : 's'}`,
+      ),
+    );
+    process.exit(1);
+  }
+}

--- a/packages/twenty-sdk/src/cli/utilities/api/api-service.ts
+++ b/packages/twenty-sdk/src/cli/utilities/api/api-service.ts
@@ -356,9 +356,27 @@ export class ApiService {
         message: `Successfully synced application: ${manifest.application.displayName}`,
       };
     } catch (error) {
+      if (axios.isAxiosError(error) && error.response) {
+        const graphqlErrors = error.response.data?.errors;
+
+        if (Array.isArray(graphqlErrors) && graphqlErrors.length > 0) {
+          return {
+            success: false,
+            error: graphqlErrors[0]?.message || error.message,
+          };
+        }
+
+        return {
+          success: false,
+          error:
+            error.response.data?.message ||
+            `HTTP ${error.response.status}: ${error.message}`,
+        };
+      }
+
       return {
         success: false,
-        error,
+        error: error instanceof Error ? error.message : error,
       };
     }
   }

--- a/packages/twenty-sdk/src/cli/utilities/build/manifest/utils/get-default-object-fields.ts
+++ b/packages/twenty-sdk/src/cli/utilities/build/manifest/utils/get-default-object-fields.ts
@@ -13,7 +13,7 @@ export const getDefaultObjectFields = (
     icon: 'Icon123',
     isNullable: false,
     defaultValue: 'uuid',
-    type: FieldMetadataType.UUID,
+    type: FieldMetadataType.UUID as const,
     universalIdentifier: generateDefaultFieldUniversalIdentifier({
       objectConfig,
       fieldName: 'id',
@@ -27,7 +27,7 @@ export const getDefaultObjectFields = (
     icon: 'IconAbc',
     isNullable: true,
     defaultValue: null,
-    type: FieldMetadataType.TEXT,
+    type: FieldMetadataType.TEXT as const,
     universalIdentifier: generateDefaultFieldUniversalIdentifier({
       objectConfig,
       fieldName: 'name',
@@ -41,7 +41,7 @@ export const getDefaultObjectFields = (
     icon: 'IconCalendar',
     isNullable: false,
     defaultValue: 'now',
-    type: FieldMetadataType.DATE_TIME,
+    type: FieldMetadataType.DATE_TIME as const,
     universalIdentifier: generateDefaultFieldUniversalIdentifier({
       objectConfig,
       fieldName: 'createdAt',
@@ -55,7 +55,7 @@ export const getDefaultObjectFields = (
     icon: 'IconCalendarClock',
     isNullable: false,
     defaultValue: 'now',
-    type: FieldMetadataType.DATE_TIME,
+    type: FieldMetadataType.DATE_TIME as const,
     universalIdentifier: generateDefaultFieldUniversalIdentifier({
       objectConfig,
       fieldName: 'updatedAt',
@@ -69,7 +69,7 @@ export const getDefaultObjectFields = (
     icon: 'IconCalendarClock',
     isNullable: true,
     defaultValue: null,
-    type: FieldMetadataType.DATE_TIME,
+    type: FieldMetadataType.DATE_TIME as const,
     universalIdentifier: generateDefaultFieldUniversalIdentifier({
       objectConfig,
       fieldName: 'deletedAt',
@@ -83,7 +83,7 @@ export const getDefaultObjectFields = (
     icon: 'IconCreativeCommonsSa',
     isNullable: false,
     defaultValue: { name: "''", source: "'MANUAL'" },
-    type: FieldMetadataType.ACTOR,
+    type: FieldMetadataType.ACTOR as const,
     universalIdentifier: generateDefaultFieldUniversalIdentifier({
       objectConfig,
       fieldName: 'createdBy',
@@ -97,7 +97,7 @@ export const getDefaultObjectFields = (
     icon: 'IconUserCircle',
     isNullable: false,
     defaultValue: { name: "''", source: "'MANUAL'" },
-    type: FieldMetadataType.ACTOR,
+    type: FieldMetadataType.ACTOR as const,
     universalIdentifier: generateDefaultFieldUniversalIdentifier({
       objectConfig,
       fieldName: 'updatedBy',

--- a/packages/twenty-sdk/src/cli/utilities/dev/orchestrator/dev-mode-orchestrator-state.ts
+++ b/packages/twenty-sdk/src/cli/utilities/dev/orchestrator/dev-mode-orchestrator-state.ts
@@ -40,7 +40,8 @@ export type OrchestratorStateFileStatus =
   | 'pending'
   | 'building'
   | 'uploading'
-  | 'success';
+  | 'success'
+  | 'error';
 
 export type OrchestratorStateEntityInfo = {
   name: string;
@@ -80,10 +81,11 @@ const FILE_STATUS_TRANSITION_MATRIX: Record<
   OrchestratorStateFileStatus,
   OrchestratorStateFileStatus[]
 > = {
-  pending: ['building', 'uploading', 'success'],
-  building: ['pending', 'uploading', 'success'],
-  uploading: ['pending', 'success'],
-  success: ['pending', 'building', 'uploading'],
+  pending: ['building', 'uploading', 'success', 'error'],
+  building: ['pending', 'uploading', 'success', 'error'],
+  uploading: ['pending', 'success', 'error'],
+  success: ['pending', 'building', 'uploading', 'error'],
+  error: ['pending', 'building', 'uploading', 'success'],
 };
 
 export class OrchestratorState {

--- a/packages/twenty-sdk/src/cli/utilities/dev/orchestrator/dev-mode-orchestrator.ts
+++ b/packages/twenty-sdk/src/cli/utilities/dev/orchestrator/dev-mode-orchestrator.ts
@@ -13,6 +13,7 @@ import {
 } from '@/cli/utilities/dev/orchestrator/steps/start-watchers-orchestrator-step';
 import { SyncApplicationOrchestratorStep } from '@/cli/utilities/dev/orchestrator/steps/sync-application-orchestrator-step';
 import { UploadFilesOrchestratorStep } from '@/cli/utilities/dev/orchestrator/steps/upload-files-orchestrator-step';
+import { serializeError } from '@/cli/utilities/error/serialize-error';
 import * as fs from 'fs-extra';
 import path from 'path';
 import { OUTPUT_DIR, type Manifest } from 'twenty-shared/application';
@@ -125,10 +126,11 @@ export class DevModeOrchestrator {
       await this.runSyncPipeline();
     } catch (error) {
       this.state.addEvent({
-        message: `Sync failed with error ${JSON.stringify(error, null, 2)}`,
+        message: `Sync failed with error: ${serializeError(error)}`,
         status: 'error',
       });
       this.state.updatePipeline({ status: 'error' });
+      this.state.updateAllEntitiesStatus('error');
     } finally {
       this.state.updatePipeline({ isSyncing: false });
     }

--- a/packages/twenty-sdk/src/cli/utilities/dev/orchestrator/steps/sync-application-orchestrator-step.ts
+++ b/packages/twenty-sdk/src/cli/utilities/dev/orchestrator/steps/sync-application-orchestrator-step.ts
@@ -7,6 +7,7 @@ import {
   type OrchestratorStateStepEvent,
   type OrchestratorStateSyncStatus,
 } from '@/cli/utilities/dev/orchestrator/dev-mode-orchestrator-state';
+import { serializeError } from '@/cli/utilities/error/serialize-error';
 import { type Manifest } from 'twenty-shared/application';
 
 export type SyncApplicationOrchestratorStepOutput = {
@@ -73,12 +74,13 @@ export class SyncApplicationOrchestratorStep {
       return;
     }
 
-    const errorMessage = `Sync failed with error ${JSON.stringify(syncResult.error, null, 2)}`;
+    const errorMessage = `Sync failed with error: ${serializeError(syncResult.error)}`;
 
     events.push({ message: errorMessage, status: 'error' });
     step.output = { syncStatus: 'error', error: errorMessage };
     step.status = 'error';
     this.state.updatePipeline({ status: 'error', error: errorMessage });
+    this.state.updateAllEntitiesStatus('error');
     this.state.applyStepEvents(events);
   }
 }

--- a/packages/twenty-sdk/src/cli/utilities/dev/ui/components/dev-ui-entity-section.tsx
+++ b/packages/twenty-sdk/src/cli/utilities/dev/ui/components/dev-ui-entity-section.tsx
@@ -92,7 +92,11 @@ export const DevUiEntityLegend = (): React.ReactElement => {
         <Text color={DEV_UI_STATUS_CONFIG.done.color}>
           {DEV_UI_STATUS_CONFIG.done.icon}
         </Text>{' '}
-        success
+        success{' '}
+        <Text color={DEV_UI_STATUS_CONFIG.error.color}>
+          {DEV_UI_STATUS_CONFIG.error.icon}
+        </Text>{' '}
+        error
       </Text>
     </Box>
   );

--- a/packages/twenty-sdk/src/cli/utilities/dev/ui/dev-ui-constants.ts
+++ b/packages/twenty-sdk/src/cli/utilities/dev/ui/dev-ui-constants.ts
@@ -49,6 +49,7 @@ export const mapFileStatusToDevUiStatus = (
     building: 'in_progress',
     uploading: 'uploading',
     success: 'done',
+    error: 'error',
   };
 
   return mapping[status];
@@ -181,6 +182,7 @@ export const getPipelineRows = (
 ): DevUiPipelineRow[] => {
   const entities = [...state.entities.values()];
 
+  const hasError = entities.some((entity) => entity.status === 'error');
   const isBuilding = entities.some((entity) => entity.status === 'building');
   const allUploaded =
     entities.length > 0 &&
@@ -188,11 +190,13 @@ export const getPipelineRows = (
       (entity) => entity.status === 'uploading' || entity.status === 'success',
     );
 
-  const resourcesBuildStatus: OrchestratorStateStepStatus = isBuilding
-    ? 'in_progress'
-    : allUploaded
-      ? 'done'
-      : 'idle';
+  const resourcesBuildStatus: OrchestratorStateStepStatus = hasError
+    ? 'error'
+    : isBuilding
+      ? 'in_progress'
+      : allUploaded
+        ? 'done'
+        : 'idle';
 
   return [
     {

--- a/packages/twenty-sdk/src/cli/utilities/error/serialize-error.ts
+++ b/packages/twenty-sdk/src/cli/utilities/error/serialize-error.ts
@@ -1,0 +1,52 @@
+import axios from 'axios';
+
+export const serializeError = (error: unknown): string => {
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  if (axios.isAxiosError(error)) {
+    const parts: string[] = [];
+    const status = error.response?.status;
+    const statusText = error.response?.statusText;
+
+    if (status) {
+      parts.push(`HTTP ${status}${statusText ? ` ${statusText}` : ''}`);
+    }
+
+    const graphqlErrors = error.response?.data?.errors;
+
+    if (Array.isArray(graphqlErrors) && graphqlErrors.length > 0) {
+      const messages = graphqlErrors
+        .map(
+          (graphqlError: { message?: string }) =>
+            graphqlError.message ?? 'Unknown GraphQL error',
+        )
+        .join('; ');
+
+      parts.push(messages);
+    } else if (error.response?.data?.message) {
+      parts.push(error.response.data.message);
+    } else if (error.message) {
+      parts.push(error.message);
+    }
+
+    if (error.code) {
+      parts.push(`(${error.code})`);
+    }
+
+    return parts.join(' - ') || 'Unknown Axios error';
+  }
+
+  if (error instanceof Error) {
+    return error.message || error.toString();
+  }
+
+  const stringified = JSON.stringify(error, null, 2);
+
+  if (stringified === '{}' || stringified === undefined) {
+    return String(error);
+  }
+
+  return stringified;
+};

--- a/packages/twenty-shared/src/application/objectFieldManifest.type.ts
+++ b/packages/twenty-shared/src/application/objectFieldManifest.type.ts
@@ -1,9 +1,13 @@
 import { type FieldManifest } from '@/application/fieldManifestType';
 import type { FieldMetadataType } from '@/types';
 
+type DistributiveOmit<T, K extends keyof any> = T extends any
+  ? Omit<T, K>
+  : never;
+
 export type ObjectFieldManifest<
   T extends FieldMetadataType = Exclude<
     FieldMetadataType,
     FieldMetadataType.RELATION
   >,
-> = Omit<FieldManifest<T>, 'objectUniversalIdentifier'>;
+> = DistributiveOmit<FieldManifest<T>, 'objectUniversalIdentifier'>;


### PR DESCRIPTION
## Summary

Continue Jotai migration (PR 4 from migration plan):

- **Migrated 25 auth state files** from `createState` to `createStateV2` (including `tokenPairState` with cookie storage, `lastAuthenticatedMethodState` with local storage)
- **Created cookie storage infrastructure** for Jotai (`createJotaiCookieStorage`) to replace Recoil's `cookieStorageEffect`
- **Added cookie storage support** to `createStateV2` via `useCookieStorage` option
- **Migrated `isImpersonatingState`** from Recoil `selector` to `createSelectorV2`
- **Updated ~170 consumer files** across auth, billing, settings, domain-manager, captcha, workspace, onboarding, and other modules to use V2 hooks (`useRecoilValueV2`, `useRecoilStateV2`, `useSetRecoilStateV2`)
- **Bridged cross-cutting selectors** (`objectPermissionsFamilySelector`, `availableFieldMetadataItemsForFilterFamilySelector`) using `jotaiStore.get()` for migrated states while keeping them as Recoil selectors until their module is migrated
- **Updated test and story files** to use `jotaiStore.set()` and `JotaiProvider` for migrated state initialization

## Test plan

- [x] `npx nx typecheck twenty-front` passes with 0 errors
- [x] `npx nx lint:diff-with-main twenty-front` passes (1 pre-existing warning only)
- [ ] Manual smoke test of auth flow (login, logout, impersonation)
- [ ] Verify cookie-backed states persist across page reloads