### PR TITLE
fix: use default Apollo client for AI chat file upload

### DIFF
--- a/packages/twenty-front/src/modules/ai/hooks/useAIChatFileUpload.ts
+++ b/packages/twenty-front/src/modules/ai/hooks/useAIChatFileUpload.ts
@@ -1,8 +1,8 @@
 import { agentChatSelectedFilesStateV2 } from '@/ai/states/agentChatSelectedFilesStateV2';
 import { agentChatUploadedFilesStateV2 } from '@/ai/states/agentChatUploadedFilesStateV2';
-import { useApolloCoreClient } from '@/object-metadata/hooks/useApolloCoreClient';
 import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { useRecoilStateV2 } from '@/ui/utilities/state/jotai/hooks/useRecoilStateV2';
+import { useApolloClient } from '@apollo/client';
 import { useLingui } from '@lingui/react/macro';
 import { type FileUIPart } from 'ai';
 import { buildSignedPath, isDefined } from 'twenty-shared/utils';
@@ -13,8 +13,8 @@ import {
 } from '~/generated-metadata/graphql';
 
 export const useAIChatFileUpload = () => {
-  const coreClient = useApolloCoreClient();
-  const [uploadFile] = useUploadFileMutation({ client: coreClient });
+  const apolloClient = useApolloClient();
+  const [uploadFile] = useUploadFileMutation({ client: apolloClient });
   const { t } = useLingui();
   const { enqueueErrorSnackBar } = useSnackBar();
   const [agentChatSelectedFiles, setAgentChatSelectedFiles] = useRecoilStateV2(


### PR DESCRIPTION
## Summary

Fix file uploads in AI chat (Agent Chat) failing with "Failed to upload file" for all file types.

## Root Cause

`useAIChatFileUpload.ts` was using `useApolloCoreClient()` which points to the `/graphql` (workspace) endpoint. However, `FileUploadResolver` is decorated with `@MetadataResolver()`, meaning `uploadFile` is only registered on the `/metadata` endpoint.

## Fix

Replace `useApolloCoreClient()` with `useApolloClient()` from `@apollo/client`, which is the default Apollo client pointing to the `/metadata` endpoint. This is consistent with how `useUploadAttachmentFile.tsx` handles file uploads.

## Changes

- Replaced `useApolloCoreClient` import with `useApolloClient` from `@apollo/client`
- Updated the client variable to use the default Apollo client
- Removed unused `useApolloCoreClient` import

Fixes #18153