### PR TITLE
fix: enable scroll in Fields dropdown when many fields are present

### DIFF
--- a/packages/twenty-front/src/modules/views/components/ViewFieldsHiddenDropdownSection.tsx
+++ b/packages/twenty-front/src/modules/views/components/ViewFieldsHiddenDropdownSection.tsx
@@ -52,7 +52,7 @@ export const ViewFieldsHiddenDropdownSection = () => {
 
   return (
     <>
-      <DropdownMenuItemsContainer>
+      <DropdownMenuItemsContainer hasMaxHeight>
         {availableFieldMetadataItemsToShow.length > 0 &&
           availableFieldMetadataItemsToShow.map((fieldMetadataItem) => {
             return (

--- a/packages/twenty-front/src/modules/views/components/ViewFieldsVisibleDropdownSection.tsx
+++ b/packages/twenty-front/src/modules/views/components/ViewFieldsVisibleDropdownSection.tsx
@@ -84,7 +84,7 @@ export const ViewFieldsVisibleDropdownSection = () => {
 
   return (
     <>
-      <DropdownMenuItemsContainer>
+      <DropdownMenuItemsContainer hasMaxHeight>
         {fieldMetadataItemLabelIdentifier && (
           <MenuItemDraggable
             LeftIcon={getIcon(fieldMetadataItemLabelIdentifier.icon)}


### PR DESCRIPTION
Fixes #18198

## Problem
The Fields dropdown (Options → Fields → Hidden Fields) did not scroll when there were many fields, preventing access to fields below the fold.

## Root Cause
`DropdownMenuItemsContainer` in `ViewFieldsVisibleDropdownSection` and `ViewFieldsHiddenDropdownSection` was not passing the `hasMaxHeight` prop. This meant the max-height constraint (168px) was not applied, causing the dropdown to grow beyond the viewport boundary without a scrollbar.

## Fix
Added `hasMaxHeight` prop to `DropdownMenuItemsContainer` in:

- `ViewFieldsVisibleDropdownSection.tsx`
- `ViewFieldsHiddenDropdownSection.tsx`

This ensures the dropdown respects the max-height limit and renders a scrollbar when content overflows, allowing users to access all fields.