### PR TITLE
feat(server): OAuth 2.0 server and application sync

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/application/application-sync.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/application-sync.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { AppRegistrationModule } from 'src/engine/core-modules/app-registration/app-registration.module';
 import { ApplicationModule } from 'src/engine/core-modules/application/application.module';
 import { ApplicationDevelopmentResolver } from 'src/engine/core-modules/application/resolvers/application-development.resolver';
 import { ApplicationResolver } from 'src/engine/core-modules/application/resolvers/application.resolver';
@@ -24,6 +25,7 @@ import { CodeStepBuildModule } from 'src/modules/workflow/workflow-builder/workf
 @Module({
   imports: [
     TypeOrmModule.forFeature([FileEntity]),
+    AppRegistrationModule,
     ApplicationModule,
     ApplicationVariableEntityModule,
     TokenModule,

--- a/packages/twenty-server/src/engine/core-modules/application/dtos/create-application.input.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/dtos/create-application.input.ts
@@ -1,6 +1,6 @@
 import { Field, InputType } from '@nestjs/graphql';
 
-import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { IsNotEmpty, IsOptional, IsString, IsUUID } from 'class-validator';
 
 @InputType()
 export class CreateApplicationInput {
@@ -28,4 +28,9 @@ export class CreateApplicationInput {
   @IsNotEmpty()
   @Field()
   sourcePath: string;
+
+  @IsUUID()
+  @IsOptional()
+  @Field({ nullable: true })
+  appRegistrationId?: string;
 }

--- a/packages/twenty-server/src/engine/core-modules/application/services/application-sync.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/services/application-sync.service.ts
@@ -5,6 +5,7 @@ import { FileFolder } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 import { PackageJson } from 'type-fest';
 
+import { AppRegistrationService } from 'src/engine/core-modules/app-registration/app-registration.service';
 import { ApplicationEntity } from 'src/engine/core-modules/application/application.entity';
 import {
   ApplicationException,
@@ -38,6 +39,7 @@ export class ApplicationSyncService {
     private readonly workspaceMigrationValidateBuildAndRunService: WorkspaceMigrationValidateBuildAndRunService,
     private readonly workspaceCacheService: WorkspaceCacheService,
     private readonly fileStorageService: FileStorageService,
+    private readonly appRegistrationService: AppRegistrationService,
   ) {}
 
   public async synchronizeFromManifest({
@@ -118,14 +120,65 @@ export class ApplicationSyncService {
       },
     );
 
-    return await this.applicationService.update(application.id, {
+    const updateData: Partial<ApplicationEntity> = {
       name,
       description: manifest.application.description,
       version: packageJson.version,
       packageJsonChecksum: manifest.application.packageJsonChecksum,
       yarnLockChecksum: manifest.application.yarnLockChecksum,
-      //availablePackages: manifest.application.availablePackages, // TODO: compute available package in dev-mode-orchestrator
+    };
+
+    let appRegistrationId = application.appRegistrationId;
+
+    const appRegistrationMetadata = {
+      name,
+      description: manifest.application.description,
+      logoUrl: manifest.application.logoUrl,
+      author: manifest.application.author,
+      websiteUrl: manifest.application.websiteUrl,
+      termsUrl: manifest.application.termsUrl,
+    };
+
+    if (!appRegistrationId) {
+      const existingRegistration =
+        await this.appRegistrationService.findOneByUniversalIdentifier(
+          manifest.application.universalIdentifier,
+        );
+
+      if (existingRegistration) {
+        appRegistrationId = existingRegistration.id;
+      } else {
+        const { appRegistration: newRegistration } =
+          await this.appRegistrationService.create(
+            {
+              ...appRegistrationMetadata,
+              universalIdentifier: manifest.application.universalIdentifier,
+            },
+            null,
+          );
+
+        appRegistrationId = newRegistration.id;
+        this.logger.log(
+          `Created app registration for ${name} (${manifest.application.universalIdentifier})`,
+        );
+      }
+
+      updateData.appRegistrationId = appRegistrationId;
+    }
+
+    await this.appRegistrationService.update({
+      id: appRegistrationId,
+      ...appRegistrationMetadata,
     });
+
+    if (manifest.application.serverVariables) {
+      await this.appRegistrationService.syncVariableSchemas(
+        appRegistrationId,
+        manifest.application.serverVariables,
+      );
+    }
+
+    return await this.applicationService.update(application.id, updateData);
   }
 
   public async uninstallApplication({

--- a/packages/twenty-server/src/engine/core-modules/application/services/marketplace.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/application/services/marketplace.service.ts
@@ -191,9 +191,8 @@ export class MarketplaceService {
     const packageJson = JSON.parse(packageJsonContent) as PackageJson;
 
     const { application } = manifest;
-    const marketplaceData = application.marketplaceData;
 
-    if (!marketplaceData?.author || !marketplaceData?.category) {
+    if (!application.author || !application.category) {
       return null;
     }
 
@@ -258,14 +257,14 @@ export class MarketplaceService {
       description: application.description ?? '',
       icon: application.icon ?? 'IconApps',
       version: packageJson.version ?? '0.1.0',
-      author: marketplaceData.author,
-      category: marketplaceData.category,
-      logo: this.resolveAssetUrl(appPath, marketplaceData.logo),
-      screenshots: this.resolveAssetUrls(appPath, marketplaceData.screenshots),
-      aboutDescription: marketplaceData.aboutDescription ?? '',
-      providers: marketplaceData.providers ?? [],
-      websiteUrl: marketplaceData.websiteUrl,
-      termsUrl: marketplaceData.termsUrl,
+      author: application.author,
+      category: application.category,
+      logo: this.resolveAssetUrl(appPath, application.logoUrl),
+      screenshots: this.resolveAssetUrls(appPath, application.screenshots),
+      aboutDescription: application.aboutDescription ?? '',
+      providers: application.providers ?? [],
+      websiteUrl: application.websiteUrl,
+      termsUrl: application.termsUrl,
       objects,
       fields,
       logicFunctions,

--- a/packages/twenty-server/src/engine/core-modules/auth/auth.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/auth.module.ts
@@ -4,6 +4,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { TypeORMModule } from 'src/database/typeorm/typeorm.module';
 import { ApiKeyEntity } from 'src/engine/core-modules/api-key/api-key.entity';
 import { ApiKeyModule } from 'src/engine/core-modules/api-key/api-key.module';
+import { AppRegistrationModule } from 'src/engine/core-modules/app-registration/app-registration.module';
 import { AppTokenEntity } from 'src/engine/core-modules/app-token/app-token.entity';
 import { AppTokenService } from 'src/engine/core-modules/app-token/services/app-token.service';
 import { ApplicationEntity } from 'src/engine/core-modules/application/application.entity';
@@ -13,6 +14,8 @@ import { GoogleAPIsAuthController } from 'src/engine/core-modules/auth/controlle
 import { GoogleAuthController } from 'src/engine/core-modules/auth/controllers/google-auth.controller';
 import { MicrosoftAPIsAuthController } from 'src/engine/core-modules/auth/controllers/microsoft-apis-auth.controller';
 import { MicrosoftAuthController } from 'src/engine/core-modules/auth/controllers/microsoft-auth.controller';
+import { OAuthDiscoveryController } from 'src/engine/core-modules/auth/controllers/oauth-discovery.controller';
+import { OAuthTokenController } from 'src/engine/core-modules/auth/controllers/oauth-token.controller';
 import { SSOAuthController } from 'src/engine/core-modules/auth/controllers/sso-auth.controller';
 import { AuthSsoService } from 'src/engine/core-modules/auth/services/auth-sso.service';
 import { CreateCalendarChannelService } from 'src/engine/core-modules/auth/services/create-calendar-channel.service';
@@ -71,6 +74,7 @@ import { MessagingFolderSyncManagerModule } from 'src/modules/messaging/message-
 import { AuthResolver } from './auth.resolver';
 
 import { AuthService } from './services/auth.service';
+import { OAuthService } from './services/oauth.service';
 import { JwtAuthStrategy } from './strategies/jwt.auth.strategy';
 
 @Module({
@@ -116,6 +120,7 @@ import { JwtAuthStrategy } from './strategies/jwt.auth.strategy';
     AuditModule,
     SubdomainManagerModule,
     DomainServerConfigModule,
+    AppRegistrationModule,
     ApplicationModule,
     WorkspaceCacheModule,
     SecureHttpClientModule,
@@ -127,6 +132,8 @@ import { JwtAuthStrategy } from './strategies/jwt.auth.strategy';
     GoogleAPIsAuthController,
     MicrosoftAPIsAuthController,
     SSOAuthController,
+    OAuthTokenController,
+    OAuthDiscoveryController,
   ],
   providers: [
     SignInUpService,
@@ -153,6 +160,7 @@ import { JwtAuthStrategy } from './strategies/jwt.auth.strategy';
     UpdateConnectedAccountOnReconnectService,
     TransientTokenService,
     AuthSsoService,
+    OAuthService,
   ],
   exports: [
     AccessTokenService,

--- a/packages/twenty-server/src/engine/core-modules/auth/controllers/oauth-discovery.controller.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/controllers/oauth-discovery.controller.ts
@@ -1,0 +1,36 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+
+import { ALL_OAUTH_SCOPES } from 'src/engine/core-modules/app-registration/constants/oauth-scopes';
+import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
+import { PublicEndpointGuard } from 'src/engine/guards/public-endpoint.guard';
+
+@Controller('.well-known')
+export class OAuthDiscoveryController {
+  constructor(
+    private readonly twentyConfigService: TwentyConfigService,
+  ) {}
+
+  @Get('oauth-authorization-server')
+  @UseGuards(PublicEndpointGuard)
+  getAuthorizationServerMetadata() {
+    const serverUrl = this.twentyConfigService.get('SERVER_URL');
+
+    return {
+      issuer: serverUrl,
+      authorization_endpoint: `${serverUrl}/authorize`,
+      token_endpoint: `${serverUrl}/oauth/token`,
+      scopes_supported: ALL_OAUTH_SCOPES,
+      response_types_supported: ['code'],
+      grant_types_supported: [
+        'authorization_code',
+        'client_credentials',
+        'refresh_token',
+      ],
+      code_challenge_methods_supported: ['S256'],
+      token_endpoint_auth_methods_supported: [
+        'client_secret_post',
+        'none',
+      ],
+    };
+  }
+}

--- a/packages/twenty-server/src/engine/core-modules/auth/controllers/oauth-token.controller.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/controllers/oauth-token.controller.ts
@@ -1,0 +1,85 @@
+import {
+  Body,
+  Controller,
+  HttpCode,
+  HttpStatus,
+  Post,
+  UseFilters,
+  UseGuards,
+} from '@nestjs/common';
+
+import { IsOptional, IsString } from 'class-validator';
+
+import { AuthRestApiExceptionFilter } from 'src/engine/core-modules/auth/filters/auth-rest-api-exception.filter';
+import { OAuthService } from 'src/engine/core-modules/auth/services/oauth.service';
+import { PublicEndpointGuard } from 'src/engine/guards/public-endpoint.guard';
+
+export class OAuthTokenRequestDto {
+  @IsString()
+  grant_type: string;
+
+  @IsOptional()
+  @IsString()
+  code?: string;
+
+  @IsOptional()
+  @IsString()
+  redirect_uri?: string;
+
+  @IsOptional()
+  @IsString()
+  client_id?: string;
+
+  @IsOptional()
+  @IsString()
+  client_secret?: string;
+
+  @IsOptional()
+  @IsString()
+  code_verifier?: string;
+
+  @IsOptional()
+  @IsString()
+  refresh_token?: string;
+}
+
+@Controller('oauth')
+@UseFilters(AuthRestApiExceptionFilter)
+export class OAuthTokenController {
+  constructor(private readonly oauthService: OAuthService) {}
+
+  @Post('token')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(PublicEndpointGuard)
+  async token(@Body() body: OAuthTokenRequestDto) {
+    switch (body.grant_type) {
+      case 'authorization_code':
+        return this.oauthService.exchangeAuthorizationCode({
+          authorizationCode: body.code ?? '',
+          clientId: body.client_id ?? '',
+          clientSecret: body.client_secret,
+          codeVerifier: body.code_verifier,
+          redirectUri: body.redirect_uri ?? '',
+        });
+
+      case 'client_credentials':
+        return this.oauthService.clientCredentialsGrant({
+          clientId: body.client_id ?? '',
+          clientSecret: body.client_secret ?? '',
+        });
+
+      case 'refresh_token':
+        return this.oauthService.refreshTokenGrant({
+          refreshToken: body.refresh_token ?? '',
+          clientId: body.client_id ?? '',
+          clientSecret: body.client_secret,
+        });
+
+      default:
+        return {
+          error: 'unsupported_grant_type',
+          error_description: `Grant type '${body.grant_type}' is not supported`,
+        };
+    }
+  }
+}

--- a/packages/twenty-server/src/engine/core-modules/auth/services/auth.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/auth.service.ts
@@ -13,8 +13,9 @@ import { AppPath } from 'twenty-shared/types';
 import { assertIsDefinedOrThrow, isDefined } from 'twenty-shared/utils';
 import { IsNull, Repository } from 'typeorm';
 
-import { NodeEnvironment } from 'src/engine/core-modules/twenty-config/interfaces/node-environment.interface';
 
+
+import { AppRegistrationService } from 'src/engine/core-modules/app-registration/app-registration.service';
 import {
   AppTokenEntity,
   AppTokenType,
@@ -94,6 +95,7 @@ export class AuthService {
     private readonly appTokenRepository: Repository<AppTokenEntity>,
     private readonly i18nService: I18nService,
     private readonly auditService: AuditService,
+    private readonly appRegistrationService: AppRegistrationService,
   ) {}
 
   private async checkAccessAndUseInvitationOrThrow(
@@ -495,40 +497,28 @@ export class AuthService {
     user: UserEntity,
     workspace: WorkspaceEntity,
   ): Promise<AuthorizeAppOutput> {
-    // TODO: replace with db call to - third party app table
-    const apps = [
-      {
-        id: 'chrome',
-        name: 'Chrome Extension',
-        redirectUrl:
-          this.twentyConfigService.get('NODE_ENV') ===
-          NodeEnvironment.DEVELOPMENT
-            ? authorizeAppInput.redirectUrl
-            : `https://${this.twentyConfigService.get(
-                'CHROME_EXTENSION_ID',
-              )}.chromiumapp.org/`,
-      },
-    ];
-
     const { clientId, codeChallenge } = authorizeAppInput;
 
-    const client = apps.find((app) => app.id === clientId);
+    const appRegistration =
+      await this.appRegistrationService.findOneByClientId(clientId);
 
-    if (!client) {
+    if (!appRegistration) {
       throw new AuthException(
         `Client not found for '${clientId}'`,
         AuthExceptionCode.CLIENT_NOT_FOUND,
       );
     }
 
-    if (!client.redirectUrl || !authorizeAppInput.redirectUrl) {
+    if (!authorizeAppInput.redirectUrl) {
       throw new AuthException(
-        `redirectUrl not found for '${clientId}'`,
+        `redirectUrl not provided for '${clientId}'`,
         AuthExceptionCode.FORBIDDEN_EXCEPTION,
       );
     }
 
-    if (client.redirectUrl !== authorizeAppInput.redirectUrl) {
+    if (
+      !appRegistration.redirectUris.includes(authorizeAppInput.redirectUrl)
+    ) {
       throw new AuthException(
         `redirectUrl mismatch for '${clientId}'`,
         AuthExceptionCode.FORBIDDEN_EXCEPTION,
@@ -570,9 +560,7 @@ export class AuthService {
       await this.appTokenRepository.save(token);
     }
 
-    const redirectUrl = `${
-      client.redirectUrl ? client.redirectUrl : authorizeAppInput.redirectUrl
-    }?authorizationCode=${authorizationCode}`;
+    const redirectUrl = `${authorizeAppInput.redirectUrl}?authorizationCode=${authorizationCode}`;
 
     return { redirectUrl };
   }

--- a/packages/twenty-server/src/engine/core-modules/auth/services/oauth.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/services/oauth.service.ts
@@ -1,157 +1,362 @@
-// import { Injectable } from '@nestjs/common';
-// import { InjectRepository } from '@nestjs/typeorm';
-//
-// import crypto from 'crypto';
-//
-// import { Repository } from 'typeorm';
-//
-// import { AppTokenEntity } from 'src/engine/core-modules/app-token/app-token.entity';
-// import {
-//   AuthException,
-//   AuthExceptionCode,
-// } from 'src/engine/core-modules/auth/auth.exception';
-// import { ExchangeAuthCode } from 'src/engine/core-modules/auth/dto/exchange-auth-code.entity';
-// import { ExchangeAuthCodeInput } from 'src/engine/core-modules/auth/dto/exchange-auth-code.input';
-// import { AccessTokenService } from 'src/engine/core-modules/auth/token/services/access-token.service';
-// import { LoginTokenService } from 'src/engine/core-modules/auth/token/services/login-token.service';
-// import { RefreshTokenService } from 'src/engine/core-modules/auth/token/services/refresh-token.service';
-// import { UserEntity } from 'src/engine/core-modules/user/user.entity';
-// import { userValidator } from 'src/engine/core-modules/user/user.validate';
-//
-// @Injectable()
-// export class OAuthService {
-//   constructor(
-//     @InjectRepository(UserEntity)
-//     private readonly userRepository: Repository<UserEntity>,
-//     @InjectRepository(AppTokenEntity)
-//     private readonly appTokenRepository: Repository<AppTokenEntity>,
-//     private readonly accessTokenService: AccessTokenService,
-//     private readonly refreshTokenService: RefreshTokenService,
-//     private readonly loginTokenService: LoginTokenService,
-//   ) {}
-//
-//   async verifyAuthorizationCode(
-//     exchangeAuthCodeInput: ExchangeAuthCodeInput,
-//   ): Promise<ExchangeAuthCode> {
-//     const { authorizationCode, codeVerifier } = exchangeAuthCodeInput;
-//
-//     if (!authorizationCode) {
-//       throw new AuthException(
-//         'Authorization code not found',
-//         AuthExceptionCode.INVALID_INPUT,
-//       );
-//     }
-//
-//     let userId = '';
-//
-//     if (codeVerifier) {
-//       const authorizationCodeAppToken = await this.appTokenRepository.findOne({
-//         where: {
-//           value: authorizationCode,
-//         },
-//       });
-//
-//       if (!authorizationCodeAppToken) {
-//         throw new AuthException(
-//           'Authorization code does not exist',
-//           AuthExceptionCode.INVALID_INPUT,
-//         );
-//       }
-//
-//       if (!(authorizationCodeAppToken.expiresAt.getTime() >= Date.now())) {
-//         throw new AuthException(
-//           'Authorization code expired.',
-//           AuthExceptionCode.FORBIDDEN_EXCEPTION,
-//         );
-//       }
-//
-//       const codeChallenge = crypto
-//         .createHash('sha256')
-//         .update(codeVerifier)
-//         .digest()
-//         .toString('base64')
-//         .replace(/\+/g, '-')
-//         .replace(/\//g, '_')
-//         .replace(/=/g, '');
-//
-//       const codeChallengeAppToken = await this.appTokenRepository.findOne({
-//         where: {
-//           value: codeChallenge,
-//         },
-//       });
-//
-//       if (!codeChallengeAppToken || !codeChallengeAppToken.userId) {
-//         throw new AuthException(
-//           'code verifier doesnt match the challenge',
-//           AuthExceptionCode.FORBIDDEN_EXCEPTION,
-//         );
-//       }
-//
-//       if (!(codeChallengeAppToken.expiresAt.getTime() >= Date.now())) {
-//         throw new AuthException(
-//           'code challenge expired.',
-//           AuthExceptionCode.FORBIDDEN_EXCEPTION,
-//         );
-//       }
-//
-//       if (codeChallengeAppToken.userId !== authorizationCodeAppToken.userId) {
-//         throw new AuthException(
-//           'authorization code / code verifier was not created by same client',
-//           AuthExceptionCode.FORBIDDEN_EXCEPTION,
-//         );
-//       }
-//
-//       if (codeChallengeAppToken.revokedAt) {
-//         throw new AuthException(
-//           'Token has been revoked.',
-//           AuthExceptionCode.FORBIDDEN_EXCEPTION,
-//         );
-//       }
-//
-//       await this.appTokenRepository.save({
-//         id: codeChallengeAppToken.id,
-//         revokedAt: new Date(),
-//       });
-//
-//       userId = codeChallengeAppToken.userId;
-//     }
-//
-//     const user = await this.userRepository.findOne({
-//       where: { id: userId },
-//       relations: ['defaultWorkspace'],
-//     });
-//
-//     userValidator.assertIsDefinedOrThrow(
-//       user,
-//       new AuthException(
-//         'User who generated the token does not exist',
-//         AuthExceptionCode.INVALID_INPUT,
-//       ),
-//     );
-//
-//     if (!user.defaultWorkspace) {
-//       throw new AuthException(
-//         'User does not have a default workspace',
-//         AuthExceptionCode.INVALID_DATA,
-//       );
-//     }
-//
-//     const accessToken = await this.accessTokenService.generateAccessToken(
-//       user.id,
-//       user.defaultWorkspaceId,
-//     );
-//     const refreshToken = await this.refreshTokenService.generateRefreshToken(
-//       user.id,
-//       user.defaultWorkspaceId,
-//     );
-//     const loginToken = await this.loginTokenService.generateLoginToken(
-//       user.email,
-//     );
-//
-//     return {
-//       accessToken,
-//       refreshToken,
-//       loginToken,
-//     };
-//   }
-// }
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import crypto from 'crypto';
+
+import { Repository } from 'typeorm';
+
+import { AppRegistrationEntity } from 'src/engine/core-modules/app-registration/app-registration.entity';
+import { AppRegistrationService } from 'src/engine/core-modules/app-registration/app-registration.service';
+import {
+  AppTokenEntity,
+  AppTokenType,
+} from 'src/engine/core-modules/app-token/app-token.entity';
+import { ApplicationEntity } from 'src/engine/core-modules/application/application.entity';
+import { ApplicationTokenService } from 'src/engine/core-modules/auth/token/services/application-token.service';
+import { UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
+
+const OAUTH_ACCESS_TOKEN_EXPIRES_IN = 1800;
+
+type OAuthTokenResponse = {
+  access_token: string;
+  token_type: string;
+  expires_in: number;
+  refresh_token?: string;
+  scope?: string;
+};
+
+type OAuthErrorResponse = {
+  error: string;
+  error_description: string;
+};
+
+@Injectable()
+export class OAuthService {
+  constructor(
+    @InjectRepository(AppTokenEntity)
+    private readonly appTokenRepository: Repository<AppTokenEntity>,
+    @InjectRepository(ApplicationEntity)
+    private readonly applicationRepository: Repository<ApplicationEntity>,
+    @InjectRepository(UserWorkspaceEntity)
+    private readonly userWorkspaceRepository: Repository<UserWorkspaceEntity>,
+    private readonly applicationTokenService: ApplicationTokenService,
+    private readonly appRegistrationService: AppRegistrationService,
+  ) {}
+
+  async exchangeAuthorizationCode(params: {
+    authorizationCode: string;
+    clientId: string;
+    clientSecret?: string;
+    codeVerifier?: string;
+    redirectUri: string;
+  }): Promise<OAuthTokenResponse | OAuthErrorResponse> {
+    const {
+      authorizationCode,
+      clientId,
+      clientSecret,
+      codeVerifier,
+      redirectUri,
+    } = params;
+
+    if (!authorizationCode) {
+      return this.errorResponse(
+        'invalid_request',
+        'Authorization code is required',
+      );
+    }
+
+    const clientValidation = await this.validateClient(clientId);
+
+    if ('error' in clientValidation) {
+      return clientValidation;
+    }
+
+    const appRegistration = clientValidation;
+
+    if (
+      redirectUri &&
+      appRegistration.redirectUris.length > 0 &&
+      !appRegistration.redirectUris.includes(redirectUri)
+    ) {
+      return this.errorResponse(
+        'invalid_grant',
+        'Redirect URI does not match any registered redirect URI',
+      );
+    }
+
+    if (clientSecret) {
+      const secretError = await this.validateClientSecret(
+        appRegistration,
+        clientSecret,
+      );
+
+      if (secretError) {
+        return secretError;
+      }
+    }
+
+    const authCodeToken = await this.appTokenRepository.findOne({
+      where: {
+        value: authorizationCode,
+        type: AppTokenType.AuthorizationCode,
+      },
+    });
+
+    if (!authCodeToken) {
+      return this.errorResponse(
+        'invalid_grant',
+        'Authorization code not found',
+      );
+    }
+
+    if (authCodeToken.expiresAt.getTime() < Date.now()) {
+      return this.errorResponse(
+        'invalid_grant',
+        'Authorization code expired',
+      );
+    }
+
+    if (codeVerifier) {
+      const pkceError = await this.validatePkce(codeVerifier, authCodeToken);
+
+      if (pkceError) {
+        return pkceError;
+      }
+    }
+
+    if (!clientSecret && !codeVerifier) {
+      return this.errorResponse(
+        'invalid_request',
+        'Either client_secret or code_verifier (PKCE) is required',
+      );
+    }
+
+    await this.appTokenRepository.update(authCodeToken.id, {
+      revokedAt: new Date(),
+    });
+
+    if (!authCodeToken.userId || !authCodeToken.workspaceId) {
+      return this.errorResponse(
+        'server_error',
+        'Authorization code is missing user or workspace context',
+      );
+    }
+
+    const application = await this.findApplicationByRegistrationAndWorkspace(
+      appRegistration.id,
+      authCodeToken.workspaceId,
+    );
+
+    if (!application) {
+      return this.errorResponse(
+        'server_error',
+        'No workspace installation found for this client',
+      );
+    }
+
+    const userWorkspace = await this.userWorkspaceRepository.findOne({
+      where: {
+        userId: authCodeToken.userId,
+        workspaceId: authCodeToken.workspaceId,
+      },
+    });
+
+    const { applicationAccessToken, applicationRefreshToken } =
+      await this.applicationTokenService.generateApplicationTokenPair({
+        workspaceId: authCodeToken.workspaceId,
+        applicationId: application.id,
+        userId: authCodeToken.userId,
+        userWorkspaceId: userWorkspace?.id,
+      });
+
+    return {
+      access_token: applicationAccessToken.token,
+      token_type: 'Bearer',
+      expires_in: OAUTH_ACCESS_TOKEN_EXPIRES_IN,
+      refresh_token: applicationRefreshToken.token,
+      scope: appRegistration.scopes.join(' '),
+    };
+  }
+
+  async clientCredentialsGrant(params: {
+    clientId: string;
+    clientSecret: string;
+  }): Promise<OAuthTokenResponse | OAuthErrorResponse> {
+    const { clientId, clientSecret } = params;
+
+    const clientValidation = await this.validateClient(clientId);
+
+    if ('error' in clientValidation) {
+      return clientValidation;
+    }
+
+    const appRegistration = clientValidation;
+
+    const secretError = await this.validateClientSecret(
+      appRegistration,
+      clientSecret,
+    );
+
+    if (secretError) {
+      return secretError;
+    }
+
+    const application = await this.applicationRepository.findOne({
+      where: { appRegistrationId: appRegistration.id },
+    });
+
+    if (!application) {
+      return this.errorResponse(
+        'server_error',
+        'No workspace installation found for this client. Install the app in a workspace first.',
+      );
+    }
+
+    const applicationAccessToken =
+      await this.applicationTokenService.generateApplicationAccessToken({
+        workspaceId: application.workspaceId,
+        applicationId: application.id,
+      });
+
+    return {
+      access_token: applicationAccessToken.token,
+      token_type: 'Bearer',
+      expires_in: OAUTH_ACCESS_TOKEN_EXPIRES_IN,
+      scope: appRegistration.scopes.join(' '),
+    };
+  }
+
+  async refreshTokenGrant(params: {
+    refreshToken: string;
+    clientId: string;
+    clientSecret?: string;
+  }): Promise<OAuthTokenResponse | OAuthErrorResponse> {
+    const { refreshToken, clientId, clientSecret } = params;
+
+    const clientValidation = await this.validateClient(clientId);
+
+    if ('error' in clientValidation) {
+      return clientValidation;
+    }
+
+    const appRegistration = clientValidation;
+
+    if (clientSecret) {
+      const secretError = await this.validateClientSecret(
+        appRegistration,
+        clientSecret,
+      );
+
+      if (secretError) {
+        return secretError;
+      }
+    }
+
+    try {
+      const payload =
+        this.applicationTokenService.validateApplicationRefreshToken(
+          refreshToken,
+        );
+
+      const { applicationAccessToken, applicationRefreshToken } =
+        await this.applicationTokenService.renewApplicationTokens(payload);
+
+      return {
+        access_token: applicationAccessToken.token,
+        token_type: 'Bearer',
+        expires_in: OAUTH_ACCESS_TOKEN_EXPIRES_IN,
+        refresh_token: applicationRefreshToken.token,
+        scope: appRegistration.scopes.join(' '),
+      };
+    } catch {
+      return this.errorResponse(
+        'invalid_grant',
+        'Invalid or expired refresh token',
+      );
+    }
+  }
+
+  private async validateClient(
+    clientId: string,
+  ): Promise<AppRegistrationEntity | OAuthErrorResponse> {
+    const appRegistration =
+      await this.appRegistrationService.findOneByClientId(clientId);
+
+    if (!appRegistration) {
+      return this.errorResponse('invalid_client', 'Client not found');
+    }
+
+    return appRegistration;
+  }
+
+  private async validateClientSecret(
+    appRegistration: AppRegistrationEntity,
+    clientSecret: string,
+  ): Promise<OAuthErrorResponse | null> {
+    const isValid = await this.appRegistrationService.verifyClientSecret(
+      appRegistration,
+      clientSecret,
+    );
+
+    if (!isValid) {
+      return this.errorResponse('invalid_client', 'Invalid client secret');
+    }
+
+    return null;
+  }
+
+  private async validatePkce(
+    codeVerifier: string,
+    authCodeToken: AppTokenEntity,
+  ): Promise<OAuthErrorResponse | null> {
+    const codeChallenge = crypto
+      .createHash('sha256')
+      .update(codeVerifier)
+      .digest()
+      .toString('base64')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=/g, '');
+
+    const challengeToken = await this.appTokenRepository.findOne({
+      where: {
+        value: codeChallenge,
+        type: AppTokenType.CodeChallenge,
+        ...(authCodeToken.userId ? { userId: authCodeToken.userId } : {}),
+      },
+    });
+
+    if (!challengeToken) {
+      return this.errorResponse(
+        'invalid_grant',
+        'Code verifier does not match the code challenge',
+      );
+    }
+
+    if (challengeToken.expiresAt.getTime() < Date.now()) {
+      return this.errorResponse('invalid_grant', 'Code challenge expired');
+    }
+
+    await this.appTokenRepository.update(challengeToken.id, {
+      revokedAt: new Date(),
+    });
+
+    return null;
+  }
+
+  private async findApplicationByRegistrationAndWorkspace(
+    appRegistrationId: string,
+    workspaceId: string,
+  ): Promise<ApplicationEntity | null> {
+    return this.applicationRepository.findOne({
+      where: { appRegistrationId, workspaceId },
+    });
+  }
+
+  private errorResponse(
+    error: string,
+    errorDescription: string,
+  ): OAuthErrorResponse {
+    return { error, error_description: errorDescription };
+  }
+}

--- a/packages/twenty-server/src/engine/core-modules/auth/strategies/jwt.auth.strategy.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/strategies/jwt.auth.strategy.ts
@@ -359,12 +359,33 @@ export class JwtAuthStrategy extends PassportStrategy(Strategy, 'jwt') {
       );
     }
 
-    // TODO: Token carries userId/userWorkspaceId but they are unused.
-    // Compute the intersection of user and application permissions instead.
-    return {
-      application,
-      workspace,
-    };
+    const context: AuthContext = { application, workspace };
+
+    // When the token carries user context (e.g. OAuth authorization code flow),
+    // populate user fields so downstream resolvers can identify the acting user.
+    if (payload.userId) {
+      const user = await this.userRepository.findOne({
+        where: { id: payload.userId },
+      });
+
+      if (isDefined(user)) {
+        context.user = user;
+      }
+    }
+
+    if (payload.userWorkspaceId) {
+      const userWorkspace = await this.userWorkspaceRepository.findOne({
+        where: { id: payload.userWorkspaceId },
+        relations: ['user', 'workspace'],
+      });
+
+      if (isDefined(userWorkspace)) {
+        context.userWorkspace = userWorkspace;
+        context.userWorkspaceId = userWorkspace.id;
+      }
+    }
+
+    return context;
   }
 
   private isLegacyApiKeyPayload(

--- a/packages/twenty-server/src/engine/core-modules/marketplace/mocks/mock-manifest.json
+++ b/packages/twenty-server/src/engine/core-modules/marketplace/mocks/mock-manifest.json
@@ -5,20 +5,18 @@
     "displayName": "Data Enrichment",
     "description": "Enrich your data easily. Choose your provider.",
     "icon": "IconSparkles",
-    "marketplaceData": {
-      "author": "Cosmos Labs",
-      "category": "Data",
-      "logo": "assets/logo.png",
-      "screenshots": [
-        "assets/screenshot-1.png",
-        "assets/screenshot-2.png",
-        "assets/screenshot-3.png"
-      ],
-      "aboutDescription": "Enhance your workspace with automated data intelligence. This app monitors your new records and automatically populates missing details such as job titles, company size, social profiles, and industry insights.",
-      "providers": ["Clearbit", "Apollo", "Hunter.io"],
-      "websiteUrl": "https://google.com",
-      "termsUrl": "https://google.com"
-    }
+    "author": "Cosmos Labs",
+    "category": "Data",
+    "logoUrl": "assets/logo.png",
+    "screenshots": [
+      "assets/screenshot-1.png",
+      "assets/screenshot-2.png",
+      "assets/screenshot-3.png"
+    ],
+    "aboutDescription": "Enhance your workspace with automated data intelligence. This app monitors your new records and automatically populates missing details such as job titles, company size, social profiles, and industry insights.",
+    "providers": ["Clearbit", "Apollo", "Hunter.io"],
+    "websiteUrl": "https://google.com",
+    "termsUrl": "https://google.com"
   },
   "entities": {
     "objects": [],


### PR DESCRIPTION
## Summary
- Adds OAuth 2.0 authorization server with three grant types:
  - **Authorization Code** with PKCE support (browser/native apps)
  - **Client Credentials** for machine-to-machine auth (no user context)
  - **Refresh Token** for token renewal
- All flows issue application-scoped tokens via `ApplicationTokenService`
- OpenID Connect discovery endpoint (`/.well-known/openid-configuration`)
- REST `/oauth/token` endpoint with proper class-validator decorators
- JWT strategy updated to optionally populate user context from application tokens
- `auth.service.ts` updated for authorization code creation during OAuth consent
- Application sync service auto-creates `AppRegistration` during manifest sync if missing
- Syncs metadata (name, description, logoUrl, author, websiteUrl, termsUrl) from manifest on every push
- Syncs server variable schemas from manifest declarations
- Marketplace service updated for flattened manifest structure
- Extracted duplicated logic in `OAuthService` into private helpers (`validateClient`, `validateClientSecret`, `validatePkce`, `errorResponse`)
- `expires_in` magic number replaced with `OAUTH_ACCESS_TOKEN_EXPIRES_IN` constant
- Redirect URI validation added to authorization code exchange

## Test plan
- [ ] Test Authorization Code flow with PKCE (browser-based)
- [ ] Test Client Credentials flow (machine-to-machine)
- [ ] Test Refresh Token flow
- [ ] Verify `/.well-known/openid-configuration` returns correct endpoints
- [ ] Run `yarn app:dev` — verify `AppRegistration` is created/updated automatically
- [ ] Verify server variables are synced from manifest

**Part 2 of 3** — Depends on PR 1 (AppRegistration entity). Frontend UI in PR 3.

Made with [Cursor](https://cursor.com)