### PR TITLE
fix: display before/after values in timeline update events

### DIFF
--- a/packages/twenty-front/src/modules/activities/timeline-activities/rows/main-object/components/EventFieldDiff.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/rows/main-object/components/EventFieldDiff.tsx
@@ -34,6 +34,10 @@ const StyledEmptyValue = styled.div`
 const StyledBeforeValue = styled.div`
   color: ${({ theme }) => theme.font.color.tertiary};
   text-decoration: line-through;
+
+  * {
+    color: inherit;
+  }
 `;
 
 export const EventFieldDiff = ({

--- a/packages/twenty-front/src/modules/activities/timeline-activities/rows/main-object/components/EventFieldDiff.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/rows/main-object/components/EventFieldDiff.tsx
@@ -9,6 +9,7 @@ import { Trans } from '@lingui/react/macro';
 
 type EventFieldDiffProps = {
   diffRecord: Record<string, any>;
+  diffBeforeRecord?: Record<string, any>;
   mainObjectMetadataItem: ObjectMetadataItem;
   fieldMetadataItem: FieldMetadataItem | undefined;
   diffArtificialRecordStoreId: string;
@@ -30,8 +31,14 @@ const StyledEmptyValue = styled.div`
   color: ${({ theme }) => theme.font.color.tertiary};
 `;
 
+const StyledBeforeValue = styled.div`
+  color: ${({ theme }) => theme.font.color.tertiary};
+  text-decoration: line-through;
+`;
+
 export const EventFieldDiff = ({
   diffRecord,
+  diffBeforeRecord,
   mainObjectMetadataItem,
   fieldMetadataItem,
   diffArtificialRecordStoreId,
@@ -52,9 +59,35 @@ export const EventFieldDiff = ({
       diffRecord !== null &&
       isObjectEmpty(diffRecord));
 
+  const isBeforeEmpty =
+    diffBeforeRecord === undefined ||
+    isValueEmpty(diffBeforeRecord) ||
+    (typeof diffBeforeRecord === 'object' &&
+      diffBeforeRecord !== null &&
+      isObjectEmpty(diffBeforeRecord));
+
+  const diffBeforeArtificialRecordStoreId =
+    diffArtificialRecordStoreId + '--before';
+
   return (
     <StyledEventFieldDiffContainer>
-      <EventFieldDiffLabel fieldMetadataItem={fieldMetadataItem} />→
+      <EventFieldDiffLabel fieldMetadataItem={fieldMetadataItem} />
+      {!isBeforeEmpty && (
+        <StyledBeforeValue>
+          <EventFieldDiffValueEffect
+            diffArtificialRecordStoreId={diffBeforeArtificialRecordStoreId}
+            mainObjectMetadataItem={mainObjectMetadataItem}
+            fieldMetadataItem={fieldMetadataItem}
+            diffRecord={diffBeforeRecord}
+          />
+          <EventFieldDiffValue
+            diffArtificialRecordStoreId={diffBeforeArtificialRecordStoreId}
+            mainObjectMetadataItem={mainObjectMetadataItem}
+            fieldMetadataItem={fieldMetadataItem}
+          />
+        </StyledBeforeValue>
+      )}
+      →
       {isUpdatedToEmpty ? (
         <StyledEmptyValue>
           <Trans>Empty</Trans>

--- a/packages/twenty-front/src/modules/activities/timeline-activities/rows/main-object/components/EventFieldDiffContainer.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/rows/main-object/components/EventFieldDiffContainer.tsx
@@ -6,6 +6,7 @@ type EventFieldDiffContainerProps = {
   mainObjectMetadataItem: ObjectMetadataItem;
   diffKey: string;
   diffValue: any;
+  diffBeforeValue?: any;
   eventId: string;
   fieldMetadataItemMap: Record<string, FieldMetadataItem>;
 };
@@ -14,6 +15,7 @@ export const EventFieldDiffContainer = ({
   mainObjectMetadataItem,
   diffKey,
   diffValue,
+  diffBeforeValue,
   eventId,
   fieldMetadataItemMap,
 }: EventFieldDiffContainerProps) => {
@@ -31,6 +33,7 @@ export const EventFieldDiffContainer = ({
     <EventFieldDiff
       key={diffArtificialRecordStoreId}
       diffRecord={diffValue}
+      diffBeforeRecord={diffBeforeValue}
       fieldMetadataItem={fieldMetadataItem}
       mainObjectMetadataItem={mainObjectMetadataItem}
       diffArtificialRecordStoreId={diffArtificialRecordStoreId}

--- a/packages/twenty-front/src/modules/activities/timeline-activities/rows/main-object/components/EventFieldDiffValueEffect.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/rows/main-object/components/EventFieldDiffValueEffect.tsx
@@ -32,6 +32,10 @@ export const EventFieldDiffValueEffect = ({
     };
 
     setRecordStore(forgedObjectRecord);
+
+    return () => {
+      setRecordStore(null);
+    };
   }, [
     diffRecord,
     diffArtificialRecordStoreId,

--- a/packages/twenty-front/src/modules/activities/timeline-activities/rows/main-object/components/EventRowMainObjectUpdated.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/rows/main-object/components/EventRowMainObjectUpdated.tsx
@@ -86,6 +86,7 @@ export const EventRowMainObjectUpdated = ({
               mainObjectMetadataItem={mainObjectMetadataItem}
               diffKey={diffEntries[0][0]}
               diffValue={diffEntries[0][1].after}
+              diffBeforeValue={diffEntries[0][1].before}
               eventId={event.id}
               fieldMetadataItemMap={fieldMetadataItemMap}
             />
@@ -107,6 +108,7 @@ export const EventRowMainObjectUpdated = ({
               mainObjectMetadataItem={mainObjectMetadataItem}
               diffKey={diffKey}
               diffValue={diffValue.after}
+              diffBeforeValue={diffValue.before}
               eventId={event.id}
               fieldMetadataItemMap={fieldMetadataItemMap}
             />


### PR DESCRIPTION
## Summary

- Timeline update events (e.g., status changes) only displayed the **new value** with an arrow (`→ New Value`), but never showed what the **previous value** was
- The diff data from the API already contains both `before` and `after` values in `event.properties.diff`, but `EventRowMainObjectUpdated` only passed `after` to child components, discarding `before`
- This change threads the `before` value through the full component chain and renders it with a line-through style before the arrow

### Before
```
Status → In Progress
```

### After  
```
Status Open → In Progress
```

## Changes

| File | Change |
|------|--------|
| `EventRowMainObjectUpdated.tsx` | Pass `diffBeforeValue` (from `diff[field].before`) to `EventFieldDiffContainer` for both single-field and multi-field updates |
| `EventFieldDiffContainer.tsx` | Accept `diffBeforeValue` prop and forward as `diffBeforeRecord` to `EventFieldDiff` |
| `EventFieldDiff.tsx` | Add `diffBeforeRecord` prop, `StyledBeforeValue` (line-through + tertiary color), empty-check logic, and render the before value using existing `EventFieldDiffValueEffect` + `EventFieldDiffValue` components |

## Test plan

- [ ] Open a record, change a field (e.g., status), verify timeline shows `OldValue → NewValue`
- [ ] Change multiple fields at once, verify all before/after values display in the expanded card
- [ ] Clear a field value, verify it still shows `→ Empty`
- [ ] Verify no regression for timeline events without `before` data (e.g., record creation)

Fixes #18284

🤖 Generated with [Claude Code](https://claude.com/claude-code)