### PR TITLE
Fix E2E tests broken by redesigned navigation menu

### DIFF
--- a/packages/twenty-e2e-testing/lib/pom/leftMenu.ts
+++ b/packages/twenty-e2e-testing/lib/pom/leftMenu.ts
@@ -22,7 +22,7 @@ export class LeftMenu {
     this.workspaceDropdown = page.getByTestId('workspace-dropdown');
     this.leftMenu = page.getByRole('button').first();
     this.searchSubTab = page.getByText('Search');
-    this.settingsTab = page.getByRole('link', { name: 'Settings' });
+    this.settingsTab = page.getByRole('button', { name: 'Settings' });
     this.peopleTab = page.getByRole('link', { name: 'People' });
     this.companiesTab = page.getByRole('link', { name: 'Companies' });
     this.opportunitiesTab = page.getByRole('link', { name: 'Opportunities' });

--- a/packages/twenty-e2e-testing/tests/authentication/signup_invite_email.spec.ts
+++ b/packages/twenty-e2e-testing/tests/authentication/signup_invite_email.spec.ts
@@ -45,7 +45,7 @@ test('Sign up with invite link via email', async ({
   });
 
   await test.step('Delete account from workspace', async () => {
-    await page.waitForLoadState('networkidle');
+    await expect(page.getByRole('button', { name: 'Settings' })).toBeVisible();
     await leftMenu.goToSettings();
     await settingsPage.goToProfileSection();
     await profileSection.deleteAccount();

--- a/packages/twenty-e2e-testing/tests/authentication/signup_invite_email.spec.ts
+++ b/packages/twenty-e2e-testing/tests/authentication/signup_invite_email.spec.ts
@@ -45,6 +45,7 @@ test('Sign up with invite link via email', async ({
   });
 
   await test.step('Delete account from workspace', async () => {
+    await page.waitForLoadState('networkidle');
     await leftMenu.goToSettings();
     await settingsPage.goToProfileSection();
     await profileSection.deleteAccount();

--- a/packages/twenty-e2e-testing/tests/create-kanban-view.spec.ts
+++ b/packages/twenty-e2e-testing/tests/create-kanban-view.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '../lib/fixtures/screenshot';
 test.describe.serial('Create Kanban View', () => {
 test('Create Industry Select Field', async ({ page }) => {
-    await page.getByRole('link', { name: 'Settings' }).click();
+    await page.getByRole('button', { name: 'Settings' }).click();
     await page.getByRole('link', { name: 'Data model' }).click();
     await page.getByRole('link', { name: 'Opportunities' }).click();
     await expect(page.getByRole('button', { name: 'New Field' })).toBeVisible();

--- a/packages/twenty-e2e-testing/tests/create-record.spec.ts
+++ b/packages/twenty-e2e-testing/tests/create-record.spec.ts
@@ -80,6 +80,7 @@ test('Create and update record', async ({ page }) => {
     await page.getByPlaceholder('Intro').press('Enter');
 
     // Fill URL
+    await recordFieldList.getByText('Linkedin').first().click();
     const urlInput = recordFieldList.getByText('Linkedin').nth(1);
     await expect(urlInput).toBeVisible();
     await urlInput.click({ force: true });

--- a/packages/twenty-e2e-testing/tests/create-record.spec.ts
+++ b/packages/twenty-e2e-testing/tests/create-record.spec.ts
@@ -93,6 +93,7 @@ test('Create and update record', async ({ page }) => {
     await ratingContainer.locator('svg').nth(3).click({force: true});
 
     // Fill phone field
+    await recordFieldList.getByText('Phones').first().click();
     const phoneInput = recordFieldList.getByText('Phones').nth(1);
     await expect(phoneInput).toBeVisible();
     await phoneInput.click({ force: true });

--- a/packages/twenty-e2e-testing/tests/create-record.spec.ts
+++ b/packages/twenty-e2e-testing/tests/create-record.spec.ts
@@ -88,7 +88,7 @@ test('Create and update record', async ({ page }) => {
     await page.getByPlaceholder('URL').press('Enter');
 
     // Click on 4th star to rate
-    recordFieldList.getByText('Performance Rating').first().click({ force: true });
+    await recordFieldList.getByText('Performance Rating').first().click({ force: true });
     const ratingContainer = recordFieldList.locator('div[aria-label="Rating"]');
     await ratingContainer.locator('svg').nth(3).click({force: true});
 


### PR DESCRIPTION
## Summary
- **Settings selector**: The Settings navigation item is now rendered as a `<button>` (via `NavigationDrawerItem` with `onClick`) instead of an `<a>` link (with `to`). Updated `leftMenu.ts` POM and `create-kanban-view.spec.ts` to use `getByRole('button', { name: 'Settings' })`.
- **create-record URL field**: The Linkedin field interaction was missing an initial label click to trigger the hover portal rendering. Added `recordFieldList.getByText('Linkedin').first().click()` before the value click, matching the pattern used by the working Emails field.

## Test plan
- [ ] E2E `signup_invite_email.spec.ts` passes (uses `leftMenu.goToSettings()`)
- [ ] E2E `create-kanban-view.spec.ts` passes (uses Settings click directly)
- [ ] E2E `create-record.spec.ts` passes (Linkedin URL field interaction)
- [ ] Existing passing E2E tests remain green


Made with [Cursor](https://cursor.com)