### PR TITLE
migrate workspace member to user workspace 1

### DIFF
--- a/packages/twenty-server/src/database/typeorm/core/migrations/common/1772544577729-migrateWorkspaceMemberToUserWorkspace.ts
+++ b/packages/twenty-server/src/database/typeorm/core/migrations/common/1772544577729-migrateWorkspaceMemberToUserWorkspace.ts
@@ -1,0 +1,93 @@
+import { type MigrationInterface, type QueryRunner } from 'typeorm';
+
+export class MigrateWorkspaceMemberToUserWorkspace1772544577729
+  implements MigrationInterface
+{
+  name = 'MigrateWorkspaceMemberToUserWorkspace1772544577729';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "core"."userWorkspace" ADD "firstName" character varying`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."userWorkspace" ADD "lastName" character varying`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."userWorkspace" ADD "avatarUrl" character varying`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "core"."userWorkspace_colorscheme_enum" AS ENUM('DARK', 'LIGHT', 'SYSTEM')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."userWorkspace" ADD "colorScheme" "core"."userWorkspace_colorscheme_enum" NOT NULL DEFAULT 'SYSTEM'`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "core"."userWorkspace_calendarstartday_enum" AS ENUM('SYSTEM', 'SUNDAY', 'MONDAY', 'SATURDAY')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."userWorkspace" ADD "calendarStartDay" "core"."userWorkspace_calendarstartday_enum" NOT NULL DEFAULT 'SYSTEM'`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."userWorkspace" ADD "timeZone" character varying`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "core"."userWorkspace_dateformat_enum" AS ENUM('SYSTEM', 'MONTH_FIRST', 'DAY_FIRST', 'YEAR_FIRST')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."userWorkspace" ADD "dateFormat" "core"."userWorkspace_dateformat_enum" NOT NULL DEFAULT 'SYSTEM'`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "core"."userWorkspace_timeformat_enum" AS ENUM('SYSTEM', 'HOUR_12', 'HOUR_24')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."userWorkspace" ADD "timeFormat" "core"."userWorkspace_timeformat_enum" NOT NULL DEFAULT 'SYSTEM'`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "core"."userWorkspace_numberformat_enum" AS ENUM('SYSTEM', 'COMMAS_AND_DOT', 'SPACES_AND_COMMA', 'DOTS_AND_COMMA', 'APOSTROPHE_AND_DOT')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."userWorkspace" ADD "numberFormat" "core"."userWorkspace_numberformat_enum" NOT NULL DEFAULT 'SYSTEM'`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "core"."userWorkspace" DROP COLUMN "numberFormat"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "core"."userWorkspace_numberformat_enum"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."userWorkspace" DROP COLUMN "timeFormat"`,
+    );
+    await queryRunner.query(`DROP TYPE "core"."userWorkspace_timeformat_enum"`);
+    await queryRunner.query(
+      `ALTER TABLE "core"."userWorkspace" DROP COLUMN "dateFormat"`,
+    );
+    await queryRunner.query(`DROP TYPE "core"."userWorkspace_dateformat_enum"`);
+    await queryRunner.query(
+      `ALTER TABLE "core"."userWorkspace" DROP COLUMN "timeZone"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."userWorkspace" DROP COLUMN "calendarStartDay"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "core"."userWorkspace_calendarstartday_enum"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."userWorkspace" DROP COLUMN "colorScheme"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "core"."userWorkspace_colorscheme_enum"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."userWorkspace" DROP COLUMN "avatarUrl"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."userWorkspace" DROP COLUMN "lastName"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."userWorkspace" DROP COLUMN "firstName"`,
+    );
+  }
+}

--- a/packages/twenty-server/src/database/typeorm/core/migrations/common/1772545262743-migrateWorkspaceMemberToUserWorkspace.ts
+++ b/packages/twenty-server/src/database/typeorm/core/migrations/common/1772545262743-migrateWorkspaceMemberToUserWorkspace.ts
@@ -1,9 +1,9 @@
 import { type MigrationInterface, type QueryRunner } from 'typeorm';
 
-export class MigrateWorkspaceMemberToUserWorkspace1772544577729
+export class MigrateWorkspaceMemberToUserWorkspace1772545262743
   implements MigrationInterface
 {
-  name = 'MigrateWorkspaceMemberToUserWorkspace1772544577729';
+  name = 'MigrateWorkspaceMemberToUserWorkspace1772545262743';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
@@ -16,6 +16,9 @@ export class MigrateWorkspaceMemberToUserWorkspace1772544577729
       `ALTER TABLE "core"."userWorkspace" ADD "avatarUrl" character varying`,
     );
     await queryRunner.query(
+      `ALTER TABLE "core"."userWorkspace" ADD "timeZone" character varying NOT NULL DEFAULT 'SYSTEM'`,
+    );
+    await queryRunner.query(
       `CREATE TYPE "core"."userWorkspace_colorscheme_enum" AS ENUM('DARK', 'LIGHT', 'SYSTEM')`,
     );
     await queryRunner.query(
@@ -26,9 +29,6 @@ export class MigrateWorkspaceMemberToUserWorkspace1772544577729
     );
     await queryRunner.query(
       `ALTER TABLE "core"."userWorkspace" ADD "calendarStartDay" "core"."userWorkspace_calendarstartday_enum" NOT NULL DEFAULT 'SYSTEM'`,
-    );
-    await queryRunner.query(
-      `ALTER TABLE "core"."userWorkspace" ADD "timeZone" character varying`,
     );
     await queryRunner.query(
       `CREATE TYPE "core"."userWorkspace_dateformat_enum" AS ENUM('SYSTEM', 'MONTH_FIRST', 'DAY_FIRST', 'YEAR_FIRST')`,
@@ -66,9 +66,6 @@ export class MigrateWorkspaceMemberToUserWorkspace1772544577729
     );
     await queryRunner.query(`DROP TYPE "core"."userWorkspace_dateformat_enum"`);
     await queryRunner.query(
-      `ALTER TABLE "core"."userWorkspace" DROP COLUMN "timeZone"`,
-    );
-    await queryRunner.query(
       `ALTER TABLE "core"."userWorkspace" DROP COLUMN "calendarStartDay"`,
     );
     await queryRunner.query(
@@ -79,6 +76,9 @@ export class MigrateWorkspaceMemberToUserWorkspace1772544577729
     );
     await queryRunner.query(
       `DROP TYPE "core"."userWorkspace_colorscheme_enum"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "core"."userWorkspace" DROP COLUMN "timeZone"`,
     );
     await queryRunner.query(
       `ALTER TABLE "core"."userWorkspace" DROP COLUMN "avatarUrl"`,

--- a/packages/twenty-server/src/engine/core-modules/user-workspace/types/calendar-start-day.enum.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-workspace/types/calendar-start-day.enum.ts
@@ -1,0 +1,13 @@
+import { registerEnumType } from '@nestjs/graphql';
+
+export enum CalendarStartDay {
+  SYSTEM = 'SYSTEM',
+  SUNDAY = 'SUNDAY',
+  MONDAY = 'MONDAY',
+  SATURDAY = 'SATURDAY',
+}
+
+registerEnumType(CalendarStartDay, {
+  name: 'CalendarStartDay',
+  description: 'Calendar start day',
+});

--- a/packages/twenty-server/src/engine/core-modules/user-workspace/types/color-scheme.enum.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-workspace/types/color-scheme.enum.ts
@@ -1,0 +1,12 @@
+import { registerEnumType } from '@nestjs/graphql';
+
+export enum ColorScheme {
+  DARK = 'DARK',
+  LIGHT = 'LIGHT',
+  SYSTEM = 'SYSTEM',
+}
+
+registerEnumType(ColorScheme, {
+  name: 'ColorScheme',
+  description: 'Color scheme',
+});

--- a/packages/twenty-server/src/engine/core-modules/user-workspace/types/date-format.enum.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-workspace/types/date-format.enum.ts
@@ -1,0 +1,13 @@
+import { registerEnumType } from '@nestjs/graphql';
+
+export enum DateFormat {
+  SYSTEM = 'SYSTEM',
+  MONTH_FIRST = 'MONTH_FIRST',
+  DAY_FIRST = 'DAY_FIRST',
+  YEAR_FIRST = 'YEAR_FIRST',
+}
+
+registerEnumType(DateFormat, {
+  name: 'DateFormat',
+  description: 'Date format',
+});

--- a/packages/twenty-server/src/engine/core-modules/user-workspace/types/number-format.enum.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-workspace/types/number-format.enum.ts
@@ -1,0 +1,14 @@
+import { registerEnumType } from '@nestjs/graphql';
+
+export enum NumberFormat {
+  SYSTEM = 'SYSTEM',
+  COMMAS_AND_DOT = 'COMMAS_AND_DOT',
+  SPACES_AND_COMMA = 'SPACES_AND_COMMA',
+  DOTS_AND_COMMA = 'DOTS_AND_COMMA',
+  APOSTROPHE_AND_DOT = 'APOSTROPHE_AND_DOT',
+}
+
+registerEnumType(NumberFormat, {
+  name: 'NumberFormat',
+  description: 'Number format',
+});

--- a/packages/twenty-server/src/engine/core-modules/user-workspace/types/time-format.enum.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-workspace/types/time-format.enum.ts
@@ -1,0 +1,12 @@
+import { registerEnumType } from '@nestjs/graphql';
+
+export enum TimeFormat {
+  SYSTEM = 'SYSTEM',
+  HOUR_12 = 'HOUR_12',
+  HOUR_24 = 'HOUR_24',
+}
+
+registerEnumType(TimeFormat, {
+  name: 'TimeFormat',
+  description: 'Time format',
+});

--- a/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.entity.ts
@@ -120,9 +120,9 @@ export class UserWorkspaceEntity extends WorkspaceRelatedEntity {
   @Column({ nullable: true })
   avatarUrl?: string;
 
-  @Field(() => String, { nullable: true })
-  @Column({ nullable: true, type: 'varchar' })
-  timeZone?: string;
+  @Field(() => String, { nullable: false })
+  @Column({ nullable: false, type: 'varchar', default: 'SYSTEM' })
+  timeZone: string;
 
   @Field(() => ColorScheme, { nullable: false })
   @Column({

--- a/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.entity.ts
@@ -1,4 +1,4 @@
-import { Field, ObjectType, registerEnumType } from '@nestjs/graphql';
+import { Field, Int, ObjectType, registerEnumType } from '@nestjs/graphql';
 
 import { IDField } from '@ptc-org/nestjs-query-graphql';
 import {
@@ -23,6 +23,11 @@ import {
 import { UUIDScalarType } from 'src/engine/api/graphql/workspace-schema-builder/graphql-types/scalars';
 import { TwoFactorAuthenticationMethodSummaryDTO } from 'src/engine/core-modules/two-factor-authentication/dto/two-factor-authentication-method.dto';
 import { TwoFactorAuthenticationMethodEntity } from 'src/engine/core-modules/two-factor-authentication/entities/two-factor-authentication-method.entity';
+import { CalendarStartDay } from 'src/engine/core-modules/user-workspace/types/calendar-start-day.enum';
+import { ColorScheme } from 'src/engine/core-modules/user-workspace/types/color-scheme.enum';
+import { DateFormat } from 'src/engine/core-modules/user-workspace/types/date-format.enum';
+import { NumberFormat } from 'src/engine/core-modules/user-workspace/types/number-format.enum';
+import { TimeFormat } from 'src/engine/core-modules/user-workspace/types/time-format.enum';
 import { UserEntity } from 'src/engine/core-modules/user/user.entity';
 import { ObjectPermissionDTO } from 'src/engine/metadata-modules/object-permission/dtos/object-permission.dto';
 import { WorkspaceRelatedEntity } from 'src/engine/workspace-manager/types/workspace-related-entity';
@@ -103,4 +108,64 @@ export class UserWorkspaceEntity extends WorkspaceRelatedEntity {
 
   @Field(() => [TwoFactorAuthenticationMethodSummaryDTO], { nullable: true })
   twoFactorAuthenticationMethodSummary?: TwoFactorAuthenticationMethodSummaryDTO[];
+
+  @Field(() => String, { nullable: true })
+  @Column({ nullable: true })
+  firstName?: string;
+
+  @Field(() => String, { nullable: true })
+  @Column({ nullable: true })
+  lastName?: string;
+
+  @Column({ nullable: true })
+  avatarUrl?: string;
+
+  @Field(() => String, { nullable: true })
+  @Column({ nullable: true, type: 'varchar' })
+  timeZone?: string;
+
+  @Field(() => ColorScheme, { nullable: false })
+  @Column({
+    nullable: false,
+    default: ColorScheme.SYSTEM,
+    type: 'enum',
+    enum: Object.values(ColorScheme),
+  })
+  colorScheme: ColorScheme;
+
+  @Field(() => Int, { nullable: false })
+  @Column({
+    nullable: false,
+    default: CalendarStartDay.SYSTEM,
+    type: 'enum',
+    enum: Object.values(CalendarStartDay),
+  })
+  calendarStartDay: CalendarStartDay;
+
+  @Field(() => DateFormat, { nullable: false })
+  @Column({
+    nullable: false,
+    default: DateFormat.SYSTEM,
+    type: 'enum',
+    enum: Object.values(DateFormat),
+  })
+  dateFormat: DateFormat;
+
+  @Field(() => TimeFormat, { nullable: false })
+  @Column({
+    nullable: false,
+    default: TimeFormat.SYSTEM,
+    type: 'enum',
+    enum: Object.values(TimeFormat),
+  })
+  timeFormat: TimeFormat;
+
+  @Field(() => NumberFormat, { nullable: false })
+  @Column({
+    nullable: false,
+    default: NumberFormat.SYSTEM,
+    type: 'enum',
+    enum: Object.values(NumberFormat),
+  })
+  numberFormat: NumberFormat;
 }


### PR DESCRIPTION
## Context
We want to move all system fields out of the workspaceMember standard object and move them into the user workspace core object.

Plan is:
- Add userWorkspace new columns (not used for now) -> This PR
- Add a new USER_WORKSPACE field type (similar to a ONE_TO_ONE RELATION field type), such fields should load and map from the cache userWorkspace and attach its fields to the associated object (ORM + CommonAPI)