### PR TITLE
Replace align-center with padding

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormBooleanFieldToggleInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/form-types/components/FormBooleanFieldToggleInput.tsx
@@ -29,7 +29,6 @@ const StyledDescription = styled.span`
 `;
 
 const StyledToggleContainer = styled.div`
-  align-items: center;
   background-color: ${themeCssVariables.background.transparent.lighter};
   border-top: 1px solid ${themeCssVariables.border.color.medium};
   border-bottom: 1px solid ${themeCssVariables.border.color.medium};
@@ -38,6 +37,8 @@ const StyledToggleContainer = styled.div`
   border-top-right-radius: ${themeCssVariables.border.radius.sm};
   display: flex;
   padding-right: ${themeCssVariables.spacing[2]};
+  padding-top: ${themeCssVariables.spacing[2]};
+  padding-bottom: ${themeCssVariables.spacing[2]};
 `;
 
 export const FormBooleanFieldToggleInput = ({


### PR DESCRIPTION
Toggle using align-self prevents the use of align-items

Before
<img width="323" height="54" alt="Capture d’écran 2026-03-04 à 16 11 22" src="https://github.com/user-attachments/assets/08154592-7901-4cb4-84b8-d3091c7d5555" />

After
<img width="323" height="54" alt="Capture d’écran 2026-03-04 à 16 11 14" src="https://github.com/user-attachments/assets/2a6071f6-50cd-4947-85e0-0c0a5b1685cd" />
