### PR TITLE
Fix one-to-many relation attach crash on Apollo cache miss

### DIFF
--- a/packages/twenty-front/src/modules/object-record/hooks/__tests__/useRecordOneToManyFieldAttachTargetRecord.test.tsx
+++ b/packages/twenty-front/src/modules/object-record/hooks/__tests__/useRecordOneToManyFieldAttachTargetRecord.test.tsx
@@ -1,0 +1,111 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { useRecordOneToManyFieldAttachTargetRecord } from '@/object-record/hooks/useRecordOneToManyFieldAttachTargetRecord';
+import { getJestMetadataAndApolloMocksWrapper } from '~/testing/jest/getJestMetadataAndApolloMocksWrapper';
+
+const mockUpdateOneRecord = jest.fn();
+const mockGetRecordFromCache = jest.fn();
+const mockUpdateRecordFromCache = jest.fn();
+
+jest.mock('@/object-record/hooks/useUpdateOneRecord', () => ({
+  useUpdateOneRecord: () => ({
+    updateOneRecord: mockUpdateOneRecord,
+  }),
+}));
+
+jest.mock('@/object-record/cache/utils/getRecordFromCache', () => ({
+  getRecordFromCache: (...args: unknown[]) => mockGetRecordFromCache(...args),
+}));
+
+jest.mock('@/object-record/cache/utils/updateRecordFromCache', () => ({
+  updateRecordFromCache: (...args: unknown[]) =>
+    mockUpdateRecordFromCache(...args),
+}));
+
+jest.mock(
+  '@/object-record/graphql/record-gql-fields/utils/generateDepthRecordGqlFieldsFromRecord',
+  () => ({
+    generateDepthRecordGqlFieldsFromRecord: () => ({ id: true }),
+  }),
+);
+
+jest.mock('@/object-metadata/hooks/useObjectMetadataItems', () => ({
+  useObjectMetadataItems: () => ({
+    objectMetadataItems: [
+      { id: 'opportunity-id', nameSingular: 'opportunity', fields: [] },
+      { id: 'company-id', nameSingular: 'company', fields: [] },
+    ],
+  }),
+}));
+
+jest.mock('@/object-record/hooks/useObjectPermissions', () => ({
+  useObjectPermissions: () => ({
+    objectPermissionsByObjectMetadataId: {},
+  }),
+}));
+
+const Wrapper = getJestMetadataAndApolloMocksWrapper({});
+
+const attachArgs = {
+  sourceObjectNameSingular: 'company',
+  targetObjectNameSingular: 'opportunity',
+  targetGQLFieldName: 'company',
+  sourceRecordId: 'company-1',
+  targetRecordId: 'opportunity-1',
+};
+
+describe('useRecordOneToManyFieldAttachTargetRecord', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should still persist the relation when the target record is not in Apollo cache', async () => {
+    mockGetRecordFromCache.mockReturnValue(null);
+
+    const { result } = renderHook(
+      () => useRecordOneToManyFieldAttachTargetRecord(),
+      { wrapper: Wrapper },
+    );
+
+    await act(async () => {
+      await result.current.recordOneToManyFieldAttachTargetRecord(attachArgs);
+    });
+
+    expect(mockUpdateRecordFromCache).not.toHaveBeenCalled();
+    expect(mockUpdateOneRecord).toHaveBeenCalledWith({
+      objectNameSingular: 'opportunity',
+      idToUpdate: 'opportunity-1',
+      updateOneRecordInput: { companyId: 'company-1' },
+    });
+  });
+
+  it('should optimistically update the previous parent in cache when re-parenting', async () => {
+    mockGetRecordFromCache
+      .mockReturnValueOnce({ id: 'opportunity-1', companyId: 'old-company' })
+      .mockReturnValueOnce({ id: 'old-company' });
+
+    const { result } = renderHook(
+      () => useRecordOneToManyFieldAttachTargetRecord(),
+      { wrapper: Wrapper },
+    );
+
+    await act(async () => {
+      await result.current.recordOneToManyFieldAttachTargetRecord(attachArgs);
+    });
+
+    expect(mockUpdateRecordFromCache).toHaveBeenCalledTimes(1);
+    expect(mockUpdateRecordFromCache).toHaveBeenCalledWith(
+      expect.objectContaining({
+        record: expect.objectContaining({
+          id: 'opportunity-1',
+          company: { id: 'old-company' },
+        }),
+      }),
+    );
+    expect(mockUpdateOneRecord).toHaveBeenCalledWith({
+      objectNameSingular: 'opportunity',
+      idToUpdate: 'opportunity-1',
+      updateOneRecordInput: { companyId: 'company-1' },
+    });
+  });
+});

--- a/packages/twenty-front/src/modules/object-record/hooks/useRecordOneToManyFieldAttachTargetRecord.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useRecordOneToManyFieldAttachTargetRecord.ts
@@ -60,44 +60,42 @@ export const useRecordOneToManyFieldAttachTargetRecord = () => {
       objectPermissionsByObjectMetadataId,
     });
 
-    if (!cachedTargetRecord) {
-      throw new Error('Could not find cached related record');
-    }
+    if (isDefined(cachedTargetRecord)) {
+      const previousRecordId = cachedTargetRecord[`${targetGQLFieldName}Id`];
 
-    const previousRecordId = cachedTargetRecord?.[`${targetGQLFieldName}Id`];
+      if (isDefined(previousRecordId)) {
+        const previousRecord = getRecordFromCache({
+          objectMetadataItem: sourceObjectMetadataItem,
+          recordId: previousRecordId,
+          cache: apolloCoreClient.cache,
+          objectMetadataItems,
+          objectPermissionsByObjectMetadataId,
+        });
 
-    if (isDefined(previousRecordId)) {
-      const previousRecord = getRecordFromCache({
-        objectMetadataItem: sourceObjectMetadataItem,
-        recordId: previousRecordId,
-        cache: apolloCoreClient.cache,
-        objectMetadataItems,
-        objectPermissionsByObjectMetadataId,
-      });
-
-      const previousRecordWithRelation = {
-        ...cachedTargetRecord,
-        [targetGQLFieldName]: previousRecord,
-      };
-
-      const gqlFields = generateDepthRecordGqlFieldsFromRecord({
-        objectMetadataItem: targetObjectMetadataItem,
-        objectMetadataItems,
-        record: previousRecordWithRelation,
-        depth: 1,
-      });
-
-      updateRecordFromCache({
-        objectMetadataItems,
-        objectMetadataItem: targetObjectMetadataItem,
-        cache: apolloCoreClient.cache,
-        record: {
+        const previousRecordWithRelation = {
           ...cachedTargetRecord,
           [targetGQLFieldName]: previousRecord,
-        },
-        recordGqlFields: gqlFields,
-        objectPermissionsByObjectMetadataId,
-      });
+        };
+
+        const gqlFields = generateDepthRecordGqlFieldsFromRecord({
+          objectMetadataItem: targetObjectMetadataItem,
+          objectMetadataItems,
+          record: previousRecordWithRelation,
+          depth: 1,
+        });
+
+        updateRecordFromCache({
+          objectMetadataItems,
+          objectMetadataItem: targetObjectMetadataItem,
+          cache: apolloCoreClient.cache,
+          record: {
+            ...cachedTargetRecord,
+            [targetGQLFieldName]: previousRecord,
+          },
+          recordGqlFields: gqlFields,
+          objectPermissionsByObjectMetadataId,
+        });
+      }
     }
 
     await updateOneRecord({

--- a/packages/twenty-front/src/modules/object-record/hooks/useRecordOneToManyFieldAttachTargetRecord.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useRecordOneToManyFieldAttachTargetRecord.ts
@@ -88,10 +88,7 @@ export const useRecordOneToManyFieldAttachTargetRecord = () => {
           objectMetadataItems,
           objectMetadataItem: targetObjectMetadataItem,
           cache: apolloCoreClient.cache,
-          record: {
-            ...cachedTargetRecord,
-            [targetGQLFieldName]: previousRecord,
-          },
+          record: previousRecordWithRelation,
           recordGqlFields: gqlFields,
           objectPermissionsByObjectMetadataId,
         });


### PR DESCRIPTION
fixes sentry TWENTY-FRONT-4NZ

Fixes https://github.com/twentyhq/twenty/pull/18394