### PR TITLE
Fix Workflow layout show page

### DIFF
--- a/packages/twenty-front/src/modules/object-record/components/MainContainerLayoutWithSidePanel.tsx
+++ b/packages/twenty-front/src/modules/object-record/components/MainContainerLayoutWithSidePanel.tsx
@@ -20,7 +20,9 @@ const StyledMainContainerLayoutForDesktop = styled.div`
 `;
 
 const StyledPageBodyForDesktopContainer = styled.div`
+  display: flex;
   flex: 1 1 0;
+  flex-direction: column;
   min-width: 0;
   width: 0;
 
@@ -38,6 +40,11 @@ const StyledMainContainerLayoutForMobile = styled.div`
 `;
 
 const StyledPageBodyForMobileContainer = styled.div`
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+
   > * {
     padding-bottom: 0;
     padding-left: ${themeCssVariables.spacing[1]};


### PR DESCRIPTION
## Summary

Fixes the workflow show page being blank after the `styled(Component)` removal in #18430.

- PR #18430 replaced `styled(PageBody)` with a plain `div` wrapper (`StyledPageBodyForDesktopContainer`) around `PageBody`, but the wrapper defaulted to `display: block`
- `PageBody`'s internal container uses `flex: 1 1 auto` to size itself, which requires a flex parent — the block wrapper broke height propagation, causing React Flow's container to have 0 height
- Added `display: flex; flex-direction: column` to both `StyledPageBodyForDesktopContainer` and `StyledPageBodyForMobileContainer` to restore the flex chain

## Test plan

- [x] Open a workflow record show page → diagram nodes are visible
- [x] Open a company/person record show page → fields, tabs, and content render correctly
- [x] Lint and typecheck pass