### PR TITLE
fix: remove add record on workflow runs/versions

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableNoRecordGroupAddNew.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/components/RecordTableNoRecordGroupAddNew.tsx
@@ -4,6 +4,7 @@ import { useUpsertRecordsInStore } from '@/object-record/record-store/hooks/useU
 import { useRecordTableContextOrThrow } from '@/object-record/record-table/contexts/RecordTableContext';
 import { useCreateNewIndexRecord } from '@/object-record/record-table/hooks/useCreateNewIndexRecord';
 import { RecordTableActionRow } from '@/object-record/record-table/record-table-row/components/RecordTableActionRow';
+import { isRecordTableCreateDisabled } from '@/object-record/record-table/utils/isRecordTableCreateDisabled';
 import { useLoadRecordsToVirtualRows } from '@/object-record/record-table/virtualization/hooks/useLoadRecordsToVirtualRows';
 import { totalNumberOfRecordsToVirtualizeComponentState } from '@/object-record/record-table/virtualization/states/totalNumberOfRecordsToVirtualizeComponentState';
 import { useAtomComponentSelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentSelectorValue';
@@ -62,6 +63,10 @@ export const RecordTableNoRecordGroupAddNew = () => {
   }
 
   if (!hasObjectUpdatePermissions) {
+    return null;
+  }
+
+  if (isRecordTableCreateDisabled(objectMetadataItem.nameSingular)) {
     return null;
   }
 

--- a/packages/twenty-front/src/modules/object-record/record-table/empty-state/components/RecordTableEmptyStateDisplay.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/empty-state/components/RecordTableEmptyStateDisplay.tsx
@@ -17,6 +17,9 @@ import {
 } from 'twenty-ui/layout';
 
 const StyledEmptyPlaceholderOuterContainer = styled.div`
+  height: 100%;
+  width: 100%;
+
   > * {
     align-items: flex-start;
   }

--- a/packages/twenty-front/src/modules/object-record/record-table/empty-state/components/RecordTableEmptyStateDisplay.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/empty-state/components/RecordTableEmptyStateDisplay.tsx
@@ -2,6 +2,7 @@ import { useObjectPermissionsForObject } from '@/object-record/hooks/useObjectPe
 import { isObjectMetadataReadOnly } from '@/object-record/read-only/utils/isObjectMetadataReadOnly';
 import { hasAnySoftDeleteFilterOnViewComponentSelector } from '@/object-record/record-filter/states/hasAnySoftDeleteFilterOnView';
 import { useRecordTableContextOrThrow } from '@/object-record/record-table/contexts/RecordTableContext';
+import { isRecordTableCreateDisabled } from '@/object-record/record-table/utils/isRecordTableCreateDisabled';
 import { useScrollWrapperHTMLElement } from '@/ui/utilities/scroll/hooks/useScrollWrapperHTMLElement';
 import { useAtomComponentSelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentSelectorValue';
 import { styled } from '@linaria/react';
@@ -80,7 +81,8 @@ export const RecordTableEmptyStateDisplay = (
         {'buttonComponent' in props && props.buttonComponent}
         {'buttonTitle' in props &&
           !isReadOnly &&
-          !hasAnySoftDeleteFilterOnView && (
+          !hasAnySoftDeleteFilterOnView &&
+          !isRecordTableCreateDisabled(objectMetadataItem.nameSingular) && (
             <Button
               Icon={props.ButtonIcon}
               title={props.buttonTitle}

--- a/packages/twenty-front/src/modules/object-record/record-table/empty-state/components/RecordTableEmptyStateNoGroupNoRecordAtAll.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/empty-state/components/RecordTableEmptyStateNoGroupNoRecordAtAll.tsx
@@ -4,6 +4,7 @@ import { RecordTableEmptyStateDisplay } from '@/object-record/record-table/empty
 import { getEmptyStateSubTitle } from '@/object-record/record-table/empty-state/utils/getEmptyStateSubTitle';
 import { getEmptyStateTitle } from '@/object-record/record-table/empty-state/utils/getEmptyStateTitle';
 import { useCreateNewIndexRecord } from '@/object-record/record-table/hooks/useCreateNewIndexRecord';
+import { isRecordTableCreateDisabled } from '@/object-record/record-table/utils/isRecordTableCreateDisabled';
 import { IconPlus } from 'twenty-ui/display';
 
 export const RecordTableEmptyStateNoGroupNoRecordAtAll = () => {
@@ -30,6 +31,17 @@ export const RecordTableEmptyStateNoGroupNoRecordAtAll = () => {
     objectMetadataItem.nameSingular,
     objectLabelSingular,
   );
+
+  if (isRecordTableCreateDisabled(objectMetadataItem.nameSingular)) {
+    return (
+      <RecordTableEmptyStateDisplay
+        subTitle={subTitle}
+        title={title}
+        animatedPlaceholderType="noRecord"
+        buttonComponent={undefined}
+      />
+    );
+  }
 
   return (
     <RecordTableEmptyStateDisplay

--- a/packages/twenty-front/src/modules/object-record/record-table/empty-state/components/RecordTableEmptyStateNoGroupNoRecordAtAll.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/empty-state/components/RecordTableEmptyStateNoGroupNoRecordAtAll.tsx
@@ -4,7 +4,6 @@ import { RecordTableEmptyStateDisplay } from '@/object-record/record-table/empty
 import { getEmptyStateSubTitle } from '@/object-record/record-table/empty-state/utils/getEmptyStateSubTitle';
 import { getEmptyStateTitle } from '@/object-record/record-table/empty-state/utils/getEmptyStateTitle';
 import { useCreateNewIndexRecord } from '@/object-record/record-table/hooks/useCreateNewIndexRecord';
-import { isRecordTableCreateDisabled } from '@/object-record/record-table/utils/isRecordTableCreateDisabled';
 import { IconPlus } from 'twenty-ui/display';
 
 export const RecordTableEmptyStateNoGroupNoRecordAtAll = () => {
@@ -31,17 +30,6 @@ export const RecordTableEmptyStateNoGroupNoRecordAtAll = () => {
     objectMetadataItem.nameSingular,
     objectLabelSingular,
   );
-
-  if (isRecordTableCreateDisabled(objectMetadataItem.nameSingular)) {
-    return (
-      <RecordTableEmptyStateDisplay
-        subTitle={subTitle}
-        title={title}
-        animatedPlaceholderType="noRecord"
-        buttonComponent={undefined}
-      />
-    );
-  }
 
   return (
     <RecordTableEmptyStateDisplay

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-header/components/RecordTableHeaderLabelIdentifierCellPlusButton.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-header/components/RecordTableHeaderLabelIdentifierCellPlusButton.tsx
@@ -2,6 +2,7 @@ import { isObjectMetadataReadOnly } from '@/object-record/read-only/utils/isObje
 import { hasAnySoftDeleteFilterOnViewComponentSelector } from '@/object-record/record-filter/states/hasAnySoftDeleteFilterOnView';
 import { useRecordTableContextOrThrow } from '@/object-record/record-table/contexts/RecordTableContext';
 import { useCreateNewIndexRecord } from '@/object-record/record-table/hooks/useCreateNewIndexRecord';
+import { isRecordTableCreateDisabled } from '@/object-record/record-table/utils/isRecordTableCreateDisabled';
 import { useAtomComponentSelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentSelectorValue';
 import { styled } from '@linaria/react';
 import { IconPlus } from 'twenty-ui/display';
@@ -45,7 +46,8 @@ export const RecordTableHeaderLabelIdentifierCellPlusButton = () => {
     !isMobile &&
     !isReadOnly &&
     hasObjectUpdatePermissions &&
-    !hasAnySoftDeleteFilterOnView && (
+    !hasAnySoftDeleteFilterOnView &&
+    !isRecordTableCreateDisabled(objectMetadataItem.nameSingular) && (
       <StyledHeaderIcon>
         <LightIconButton
           Icon={IconPlus}

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-section/components/RecordTableRecordGroupSectionAddNew.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-section/components/RecordTableRecordGroupSectionAddNew.tsx
@@ -5,6 +5,7 @@ import { recordIndexGroupFieldMetadataItemComponentState } from '@/object-record
 import { useRecordTableContextOrThrow } from '@/object-record/record-table/contexts/RecordTableContext';
 import { useCreateNewIndexRecord } from '@/object-record/record-table/hooks/useCreateNewIndexRecord';
 import { RecordTableActionRow } from '@/object-record/record-table/record-table-row/components/RecordTableActionRow';
+import { isRecordTableCreateDisabled } from '@/object-record/record-table/utils/isRecordTableCreateDisabled';
 import { useAtomFamilyStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomFamilyStateValue';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { t } from '@lingui/core/macro';
@@ -39,6 +40,10 @@ export const RecordTableRecordGroupSectionAddNew = () => {
   const hasObjectUpdatePermissions = objectPermissions.canUpdateObjectRecords;
 
   if (!hasObjectUpdatePermissions) {
+    return null;
+  }
+
+  if (isRecordTableCreateDisabled(objectMetadataItem.nameSingular)) {
     return null;
   }
 

--- a/packages/twenty-front/src/modules/object-record/record-table/utils/isRecordTableCreateDisabled.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/utils/isRecordTableCreateDisabled.ts
@@ -1,0 +1,12 @@
+import { CoreObjectNameSingular } from 'twenty-shared/types';
+
+const OBJECTS_WITHOUT_MANUAL_RECORD_CREATION: string[] = [
+  CoreObjectNameSingular.WorkflowRun,
+  CoreObjectNameSingular.WorkflowVersion,
+];
+
+export const isRecordTableCreateDisabled = (
+  objectNameSingular: string,
+): boolean => {
+  return OBJECTS_WITHOUT_MANUAL_RECORD_CREATION.includes(objectNameSingular);
+};

--- a/packages/twenty-front/src/modules/object-record/record-table/utils/isRecordTableCreateDisabled.ts
+++ b/packages/twenty-front/src/modules/object-record/record-table/utils/isRecordTableCreateDisabled.ts
@@ -1,12 +1,14 @@
 import { CoreObjectNameSingular } from 'twenty-shared/types';
 
-const OBJECTS_WITHOUT_MANUAL_RECORD_CREATION: string[] = [
-  CoreObjectNameSingular.WorkflowRun,
-  CoreObjectNameSingular.WorkflowVersion,
-];
+const OBJECTS_WITHOUT_MANUAL_RECORD_CREATION: readonly CoreObjectNameSingular[] =
+  [CoreObjectNameSingular.WorkflowRun, CoreObjectNameSingular.WorkflowVersion];
 
 export const isRecordTableCreateDisabled = (
   objectNameSingular: string,
 ): boolean => {
-  return OBJECTS_WITHOUT_MANUAL_RECORD_CREATION.includes(objectNameSingular);
+  const isDisabled = OBJECTS_WITHOUT_MANUAL_RECORD_CREATION.includes(
+    objectNameSingular as CoreObjectNameSingular,
+  );
+
+  return isDisabled;
 };


### PR DESCRIPTION
## Summary

- Disable manual record creation (add button, + header button, add new row) for **WorkflowRun** and **WorkflowVersion** objects since these are system-managed and should not be created manually
- Fix vertical centering of the record table empty state placeholder (regression from `styled(Component)` refactor in #18430 — the wrapper lost `height: 100%` / `width: 100%`)

## Test plan

- [ ] Navigate to Workflow Runs index page → empty state should show centered placeholder **without** "Add a Workflow Run" button
- [ ] Navigate to Workflow Versions index page → empty state should show centered placeholder **without** "Add a Workflow Version" button
- [ ] Navigate to any other object index page (e.g. People, Companies) → empty state should still show the "Add a ..." button and be centered
- [ ] Verify the + button in the record table header is hidden for workflow runs/versions
- [ ] Verify the "Add New" row at the bottom of the table is hidden for workflow runs/versions