### PR TITLE
Fix workflow nodes color in dark mode

### DIFF
--- a/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasBase.tsx
+++ b/packages/twenty-front/src/modules/workflow/workflow-diagram/components/WorkflowDiagramCanvasBase.tsx
@@ -164,7 +164,7 @@ export const WorkflowDiagramCanvasBase = ({
     event: MouseEvent | React.MouseEvent<Element, MouseEvent>;
   }) => void;
 }) => {
-  const { theme } = useContext(ThemeContext);
+  const { theme, colorScheme } = useContext(ThemeContext);
   const store = useStore();
   const reactflow = useReactFlow();
 
@@ -623,6 +623,7 @@ export const WorkflowDiagramCanvasBase = ({
         preventScrolling={true}
         connectionLineComponent={WorkflowDiagramConnection}
         connectionRadius={0}
+        colorMode={colorScheme}
       >
         <Background color={theme.border.color.medium} size={2} />
 


### PR DESCRIPTION
## Why
  `ThemeProvider` already exposes `colorScheme` (`'light' | 'dark'`) via  `ThemeContext`, but `WorkflowDiagramCanvasBase` was only extracting`theme` and never passing `colorMode` to `ReactFlow`.
Fix: #18453 

## Before
<img width="1384" height="745" alt="image" src="https://github.com/user-attachments/assets/e50db287-c27b-4157-a5c6-59f2d6eab656" />

## After

<img width="1413" height="747" alt="image" src="https://github.com/user-attachments/assets/db98f048-29fd-41bc-a3ae-cec7435dc93b" />
