### PR TITLE
feat(twenty-ui): add Skeleton component system with tests

### DIFF
--- a/packages/twenty-front/src/modules/ui/input/relation-picker/components/skeletons/DropdownMenuSkeletonItem.tsx
+++ b/packages/twenty-front/src/modules/ui/input/relation-picker/components/skeletons/DropdownMenuSkeletonItem.tsx
@@ -1,9 +1,8 @@
-import { SKELETON_LOADER_HEIGHT_SIZES } from '@/activities/components/SkeletonLoader';
 import { type CSSWidth } from '@/ui/types/CSSWidth';
 import { styled } from '@linaria/react';
-import { useContext } from 'react';
-import Skeleton, { SkeletonTheme } from 'react-loading-skeleton';
-import { ThemeContext, themeCssVariables } from 'twenty-ui/theme-constants';
+import { Skeleton } from 'twenty-ui/feedback';
+import { themeCssVariables } from 'twenty-ui/theme-constants';
+
 const StyledDropdownMenuSkeletonContainer = styled.div`
   --horizontal-padding: ${themeCssVariables.spacing[1]};
   --vertical-padding: ${themeCssVariables.spacing[2]};
@@ -25,19 +24,13 @@ export const DropdownMenuSkeletonItem = ({
 }: {
   width?: CSSWidth;
 }) => {
-  const { theme } = useContext(ThemeContext);
   return (
     <StyledDropdownMenuSkeletonContainer>
-      <SkeletonTheme
-        baseColor={theme.background.quaternary}
-        highlightColor={theme.background.secondary}
-      >
-        <Skeleton
-          height={SKELETON_LOADER_HEIGHT_SIZES.standard.s}
-          style={{ lineHeight: 0 }}
-          width={width}
-        />
-      </SkeletonTheme>
+      <Skeleton
+        variant="text"
+        height={16}
+        width={width}
+      />
     </StyledDropdownMenuSkeletonContainer>
   );
 };

--- a/packages/twenty-front/src/modules/ui/layout/show-page/components/ShowPageSummaryCard.tsx
+++ b/packages/twenty-front/src/modules/ui/layout/show-page/components/ShowPageSummaryCard.tsx
@@ -1,8 +1,7 @@
-import { SKELETON_LOADER_HEIGHT_SIZES } from '@/activities/components/SkeletonLoader';
+import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { styled } from '@linaria/react';
 import { Trans } from '@lingui/react/macro';
-import { type ChangeEvent, type ReactNode, useContext, useRef } from 'react';
-import Skeleton, { SkeletonTheme } from 'react-loading-skeleton';
+import { type ChangeEvent, type ReactNode, useRef } from 'react';
 import { isDefined } from 'twenty-shared/utils';
 import {
   AppTooltip,
@@ -10,8 +9,8 @@ import {
   type AvatarType,
   type IconComponent,
 } from 'twenty-ui/display';
-import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
-import { ThemeContext, themeCssVariables } from 'twenty-ui/theme-constants';
+import { Skeleton } from 'twenty-ui/feedback';
+import { themeCssVariables } from 'twenty-ui/theme-constants';
 import { v4 as uuidV4 } from 'uuid';
 import { dateLocaleState } from '~/localization/states/dateLocaleState';
 import {
@@ -95,18 +94,13 @@ const StyledSubSkeleton = styled.div`
 `;
 
 const StyledShowPageSummaryCardSkeletonLoader = () => {
-  const { theme } = useContext(ThemeContext);
   return (
-    <SkeletonTheme
-      baseColor={theme.background.tertiary}
-      highlightColor={theme.background.transparent.lighter}
-      borderRadius={4}
-    >
-      <Skeleton width={40} height={SKELETON_LOADER_HEIGHT_SIZES.standard.xl} />
+    <>
+      <Skeleton variant="rectangular" width={40} height={40} borderRadius={4} />
       <StyledSubSkeleton>
-        <Skeleton width={96} height={SKELETON_LOADER_HEIGHT_SIZES.standard.s} />
+        <Skeleton variant="text" width={96} height={16} />
       </StyledSubSkeleton>
-    </SkeletonTheme>
+    </>
   );
 };
 

--- a/packages/twenty-ui/src/feedback/index.ts
+++ b/packages/twenty-ui/src/feedback/index.ts
@@ -9,9 +9,16 @@
 
 export { Loader } from './loader/components/Loader';
 export { CircularProgressBar } from './progress-bar/components/CircularProgressBar';
+export { ProgressBar } from './progress-bar/components/ProgressBar';
 export type {
   ProgressBarProps,
-  StyledBarProps,
+  StyledBarProps
 } from './progress-bar/components/ProgressBar';
-export { ProgressBar } from './progress-bar/components/ProgressBar';
 export { useProgressAnimation } from './progress-bar/hooks/useProgressAnimation';
+export { Skeleton } from './skeleton/components/Skeleton';
+export type { SkeletonProps } from './skeleton/components/Skeleton';
+export { SkeletonRow } from './skeleton/components/SkeletonRow';
+export type { SkeletonRowProps } from './skeleton/components/SkeletonRow';
+export { SkeletonText } from './skeleton/components/SkeletonText';
+export type { SkeletonTextProps } from './skeleton/components/SkeletonText';
+

--- a/packages/twenty-ui/src/feedback/skeleton/components/Skeleton.tsx
+++ b/packages/twenty-ui/src/feedback/skeleton/components/Skeleton.tsx
@@ -1,0 +1,86 @@
+import { styled } from '@linaria/react';
+import { themeCssVariables } from '@ui/theme-constants';
+
+type SkeletonVariant = 'rectangular' | 'circular' | 'text';
+
+export type SkeletonProps = {
+  variant?: SkeletonVariant;
+  width?: number | string;
+  height?: number | string;
+  borderRadius?: number | string;
+  className?: string;
+};
+
+const StyledSkeleton = styled.div<{
+  variant: SkeletonVariant;
+  skeletonWidth?: number | string;
+  skeletonHeight?: number | string;
+  skeletonBorderRadius?: number | string;
+}>`
+  background: linear-gradient(
+    90deg,
+    ${themeCssVariables.background.tertiary} 25%,
+    ${themeCssVariables.background.transparent.lighter} 50%,
+    ${themeCssVariables.background.tertiary} 75%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.5s ease-in-out infinite;
+
+  width: ${({ skeletonWidth }) =>
+    skeletonWidth === undefined
+      ? '100%'
+      : typeof skeletonWidth === 'number'
+        ? `${skeletonWidth}px`
+        : skeletonWidth};
+
+  height: ${({ variant, skeletonHeight }) => {
+    if (skeletonHeight !== undefined) {
+      return typeof skeletonHeight === 'number'
+        ? `${skeletonHeight}px`
+        : skeletonHeight;
+    }
+    if (variant === 'text') return '1em';
+    if (variant === 'circular') return '40px';
+    return '100%';
+  }};
+
+  border-radius: ${({ variant, skeletonBorderRadius }) => {
+    if (skeletonBorderRadius !== undefined) {
+      return typeof skeletonBorderRadius === 'number'
+        ? `${skeletonBorderRadius}px`
+        : skeletonBorderRadius;
+    }
+    if (variant === 'circular') return '50%';
+    if (variant === 'text') return themeCssVariables.border.radius.sm;
+    return themeCssVariables.border.radius.sm;
+  }};
+
+  aspect-ratio: ${({ variant }) => (variant === 'circular' ? '1 / 1' : 'auto')};
+
+  @keyframes shimmer {
+    0% {
+      background-position: 200% 0;
+    }
+    100% {
+      background-position: -200% 0;
+    }
+  }
+`;
+
+export const Skeleton = ({
+  variant = 'rectangular',
+  width,
+  height,
+  borderRadius,
+  className,
+}: SkeletonProps) => (
+  <StyledSkeleton
+    className={className}
+    variant={variant}
+    skeletonWidth={width}
+    skeletonHeight={height}
+    skeletonBorderRadius={borderRadius}
+    role="status"
+    aria-label="Loading"
+  />
+);

--- a/packages/twenty-ui/src/feedback/skeleton/components/SkeletonRow.tsx
+++ b/packages/twenty-ui/src/feedback/skeleton/components/SkeletonRow.tsx
@@ -1,0 +1,44 @@
+import { styled } from '@linaria/react';
+import { themeCssVariables } from '@ui/theme-constants';
+
+import { Skeleton } from './Skeleton';
+import { SkeletonText } from './SkeletonText';
+
+export type SkeletonRowProps = {
+  hasAvatar?: boolean;
+  avatarSize?: number;
+  textLines?: number;
+  textLineHeight?: number;
+  width?: number | string;
+  className?: string;
+};
+
+const StyledRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${themeCssVariables.spacing[3]};
+  width: 100%;
+`;
+
+const StyledTextContainer = styled.div`
+  flex: 1;
+  min-width: 0;
+`;
+
+export const SkeletonRow = ({
+  hasAvatar = true,
+  avatarSize = 40,
+  textLines = 2,
+  textLineHeight = 14,
+  width,
+  className,
+}: SkeletonRowProps) => (
+  <StyledRow className={className} style={width ? { width: typeof width === 'number' ? `${width}px` : width } : undefined}>
+    {hasAvatar && (
+      <Skeleton variant="circular" width={avatarSize} height={avatarSize} />
+    )}
+    <StyledTextContainer>
+      <SkeletonText lines={textLines} lineHeight={textLineHeight} />
+    </StyledTextContainer>
+  </StyledRow>
+);

--- a/packages/twenty-ui/src/feedback/skeleton/components/SkeletonText.tsx
+++ b/packages/twenty-ui/src/feedback/skeleton/components/SkeletonText.tsx
@@ -1,0 +1,45 @@
+import { styled } from '@linaria/react';
+import { themeCssVariables } from '@ui/theme-constants';
+
+import { Skeleton } from './Skeleton';
+
+export type SkeletonTextProps = {
+  lines?: number;
+  lineHeight?: number | string;
+  gap?: number | string;
+  lastLineWidth?: string;
+  className?: string;
+};
+
+const StyledContainer = styled.div<{
+  skeletonGap?: number | string;
+}>`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ skeletonGap }) =>
+    skeletonGap === undefined
+      ? themeCssVariables.spacing[2]
+      : typeof skeletonGap === 'number'
+        ? `${skeletonGap}px`
+        : skeletonGap};
+  width: 100%;
+`;
+
+export const SkeletonText = ({
+  lines = 3,
+  lineHeight = 16,
+  gap,
+  lastLineWidth = '60%',
+  className,
+}: SkeletonTextProps) => (
+  <StyledContainer className={className} skeletonGap={gap}>
+    {Array.from({ length: lines }).map((_, index) => (
+      <Skeleton
+        key={`skeleton-line-${index}`}
+        variant="text"
+        width={index === lines - 1 && lines > 1 ? lastLineWidth : '100%'}
+        height={lineHeight}
+      />
+    ))}
+  </StyledContainer>
+);

--- a/packages/twenty-ui/src/feedback/skeleton/components/__stories__/Skeleton.stories.tsx
+++ b/packages/twenty-ui/src/feedback/skeleton/components/__stories__/Skeleton.stories.tsx
@@ -1,0 +1,61 @@
+import { type Meta, type StoryObj } from '@storybook/react-vite';
+import { ComponentDecorator } from '@ui/testing/decorators/ComponentDecorator';
+
+import { Skeleton } from '../Skeleton';
+
+const meta: Meta<typeof Skeleton> = {
+  title: 'UI/Feedback/Skeleton/Skeleton',
+  component: Skeleton,
+  decorators: [ComponentDecorator],
+  argTypes: {
+    variant: {
+      control: { type: 'select' },
+      options: ['rectangular', 'circular', 'text'],
+    },
+    width: { control: { type: 'text' } },
+    height: { control: { type: 'text' } },
+    borderRadius: { control: { type: 'text' } },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Skeleton>;
+
+export const Rectangular: Story = {
+  args: {
+    variant: 'rectangular',
+    width: 200,
+    height: 40,
+  },
+};
+
+export const Circular: Story = {
+  args: {
+    variant: 'circular',
+    width: 40,
+    height: 40,
+  },
+};
+
+export const Text: Story = {
+  args: {
+    variant: 'text',
+    width: 200,
+  },
+};
+
+export const FullWidth: Story = {
+  args: {
+    variant: 'rectangular',
+    height: 24,
+  },
+};
+
+export const CustomBorderRadius: Story = {
+  args: {
+    variant: 'rectangular',
+    width: 200,
+    height: 40,
+    borderRadius: 20,
+  },
+};

--- a/packages/twenty-ui/src/feedback/skeleton/components/__stories__/SkeletonRow.stories.tsx
+++ b/packages/twenty-ui/src/feedback/skeleton/components/__stories__/SkeletonRow.stories.tsx
@@ -1,0 +1,73 @@
+import { styled } from '@linaria/react';
+import { type Meta, type StoryObj } from '@storybook/react-vite';
+import { ComponentDecorator } from '@ui/testing/decorators/ComponentDecorator';
+import { themeCssVariables } from '@ui/theme-constants';
+
+import { SkeletonRow } from '../SkeletonRow';
+
+const StyledListContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${themeCssVariables.spacing[4]};
+  width: 100%;
+`;
+
+const meta: Meta<typeof SkeletonRow> = {
+  title: 'UI/Feedback/Skeleton/SkeletonRow',
+  component: SkeletonRow,
+  decorators: [ComponentDecorator],
+  argTypes: {
+    hasAvatar: { control: { type: 'boolean' } },
+    avatarSize: { control: { type: 'number' } },
+    textLines: { control: { type: 'range', min: 1, max: 5, step: 1 } },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof SkeletonRow>;
+
+export const Default: Story = {
+  args: {
+    hasAvatar: true,
+    textLines: 2,
+  },
+  parameters: {
+    container: { width: 400 },
+  },
+};
+
+export const WithoutAvatar: Story = {
+  args: {
+    hasAvatar: false,
+    textLines: 2,
+  },
+  parameters: {
+    container: { width: 400 },
+  },
+};
+
+export const List: Story = {
+  render: () => (
+    <StyledListContainer>
+      <SkeletonRow />
+      <SkeletonRow />
+      <SkeletonRow />
+      <SkeletonRow />
+    </StyledListContainer>
+  ),
+  parameters: {
+    container: { width: 400 },
+  },
+};
+
+export const SmallAvatar: Story = {
+  args: {
+    hasAvatar: true,
+    avatarSize: 24,
+    textLines: 1,
+    textLineHeight: 16,
+  },
+  parameters: {
+    container: { width: 300 },
+  },
+};

--- a/packages/twenty-ui/src/feedback/skeleton/components/__stories__/SkeletonText.stories.tsx
+++ b/packages/twenty-ui/src/feedback/skeleton/components/__stories__/SkeletonText.stories.tsx
@@ -1,0 +1,49 @@
+import { type Meta, type StoryObj } from '@storybook/react-vite';
+import { ComponentDecorator } from '@ui/testing/decorators/ComponentDecorator';
+
+import { SkeletonText } from '../SkeletonText';
+
+const meta: Meta<typeof SkeletonText> = {
+  title: 'UI/Feedback/Skeleton/SkeletonText',
+  component: SkeletonText,
+  decorators: [ComponentDecorator],
+  argTypes: {
+    lines: { control: { type: 'range', min: 1, max: 10, step: 1 } },
+    lineHeight: { control: { type: 'number' } },
+    lastLineWidth: { control: { type: 'text' } },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof SkeletonText>;
+
+export const Default: Story = {
+  args: {
+    lines: 3,
+    lineHeight: 16,
+  },
+  parameters: {
+    container: { width: 300 },
+  },
+};
+
+export const SingleLine: Story = {
+  args: {
+    lines: 1,
+    lineHeight: 20,
+  },
+  parameters: {
+    container: { width: 200 },
+  },
+};
+
+export const Paragraph: Story = {
+  args: {
+    lines: 5,
+    lineHeight: 14,
+    lastLineWidth: '40%',
+  },
+  parameters: {
+    container: { width: 400 },
+  },
+};

--- a/packages/twenty-ui/src/feedback/skeleton/components/__tests__/Skeleton.test.tsx
+++ b/packages/twenty-ui/src/feedback/skeleton/components/__tests__/Skeleton.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/react';
+
+import { Skeleton } from '../Skeleton';
+
+describe('Skeleton', () => {
+  it('should render with role="status" and accessible label', () => {
+    render(<Skeleton />);
+
+    const skeleton = screen.getByRole('status');
+
+    expect(skeleton).toBeInTheDocument();
+    expect(skeleton).toHaveAttribute('aria-label', 'Loading');
+  });
+
+  it('should default to rectangular variant when no variant is given', () => {
+    const { container } = render(<Skeleton />);
+
+    const skeleton = container.firstChild as HTMLElement;
+
+    expect(skeleton).toBeInTheDocument();
+    expect(skeleton).not.toHaveStyle({ 'border-radius': '50%' });
+  });
+
+  it('should apply custom width and height when numbers are provided', () => {
+    render(<Skeleton width={200} height={40} />);
+
+    const skeleton = screen.getByRole('status');
+
+    expect(skeleton).toBeInTheDocument();
+  });
+
+  it('should apply custom width and height when strings are provided', () => {
+    render(<Skeleton width="50%" height="2rem" />);
+
+    const skeleton = screen.getByRole('status');
+
+    expect(skeleton).toBeInTheDocument();
+  });
+
+  it('should apply the given className', () => {
+    render(<Skeleton className="my-custom-class" />);
+
+    const skeleton = screen.getByRole('status');
+
+    expect(skeleton).toHaveClass('my-custom-class');
+  });
+
+  it('should render as circular variant when variant is circular', () => {
+    render(<Skeleton variant="circular" />);
+
+    const skeleton = screen.getByRole('status');
+
+    expect(skeleton).toBeInTheDocument();
+  });
+
+  it('should render as text variant when variant is text', () => {
+    render(<Skeleton variant="text" />);
+
+    const skeleton = screen.getByRole('status');
+
+    expect(skeleton).toBeInTheDocument();
+  });
+});

--- a/packages/twenty-ui/src/feedback/skeleton/components/__tests__/SkeletonRow.test.tsx
+++ b/packages/twenty-ui/src/feedback/skeleton/components/__tests__/SkeletonRow.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@testing-library/react';
+
+import { SkeletonRow } from '../SkeletonRow';
+
+describe('SkeletonRow', () => {
+  it('should render avatar and text skeletons by default', () => {
+    render(<SkeletonRow />);
+
+    // 1 circular avatar + 2 text lines = 3 skeleton elements
+    const skeletonElements = screen.getAllByRole('status');
+
+    expect(skeletonElements).toHaveLength(3);
+  });
+
+  it('should render without avatar when hasAvatar is false', () => {
+    render(<SkeletonRow hasAvatar={false} />);
+
+    // Only 2 text lines, no avatar
+    const skeletonElements = screen.getAllByRole('status');
+
+    expect(skeletonElements).toHaveLength(2);
+  });
+
+  it('should render the specified number of text lines', () => {
+    render(<SkeletonRow textLines={4} />);
+
+    // 1 avatar + 4 text lines = 5 skeleton elements
+    const skeletonElements = screen.getAllByRole('status');
+
+    expect(skeletonElements).toHaveLength(5);
+  });
+
+  it('should render without avatar and with custom text lines', () => {
+    render(<SkeletonRow hasAvatar={false} textLines={1} />);
+
+    const skeletonElements = screen.getAllByRole('status');
+
+    expect(skeletonElements).toHaveLength(1);
+  });
+
+  it('should apply custom className to the container', () => {
+    const { container } = render(
+      <SkeletonRow className="custom-skeleton-row" />,
+    );
+
+    const wrapper = container.firstChild as HTMLElement;
+
+    expect(wrapper).toHaveClass('custom-skeleton-row');
+  });
+
+  it('should apply inline width style when width is provided as number', () => {
+    const { container } = render(<SkeletonRow width={400} />);
+
+    const wrapper = container.firstChild as HTMLElement;
+
+    expect(wrapper).toHaveStyle({ width: '400px' });
+  });
+
+  it('should apply inline width style when width is provided as string', () => {
+    const { container } = render(<SkeletonRow width="50%" />);
+
+    const wrapper = container.firstChild as HTMLElement;
+
+    expect(wrapper).toHaveStyle({ width: '50%' });
+  });
+
+  it('should not have inline width style when width is not provided', () => {
+    const { container } = render(<SkeletonRow />);
+
+    const wrapper = container.firstChild as HTMLElement;
+
+    expect(wrapper.style.width).toBe('');
+  });
+});

--- a/packages/twenty-ui/src/feedback/skeleton/components/__tests__/SkeletonText.test.tsx
+++ b/packages/twenty-ui/src/feedback/skeleton/components/__tests__/SkeletonText.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react';
+
+import { SkeletonText } from '../SkeletonText';
+
+describe('SkeletonText', () => {
+  it('should render 3 skeleton lines by default', () => {
+    render(<SkeletonText />);
+
+    const skeletonLines = screen.getAllByRole('status');
+
+    expect(skeletonLines).toHaveLength(3);
+  });
+
+  it('should render the specified number of lines', () => {
+    render(<SkeletonText lines={5} />);
+
+    const skeletonLines = screen.getAllByRole('status');
+
+    expect(skeletonLines).toHaveLength(5);
+  });
+
+  it('should render a single line when lines is 1', () => {
+    render(<SkeletonText lines={1} />);
+
+    const skeletonLines = screen.getAllByRole('status');
+
+    expect(skeletonLines).toHaveLength(1);
+  });
+
+  it('should apply custom className to the container', () => {
+    const { container } = render(
+      <SkeletonText className="custom-skeleton-text" />,
+    );
+
+    const wrapper = container.firstChild as HTMLElement;
+
+    expect(wrapper).toHaveClass('custom-skeleton-text');
+  });
+
+  it('should render all skeleton lines with the Loading aria-label', () => {
+    render(<SkeletonText lines={4} />);
+
+    const skeletonLines = screen.getAllByRole('status');
+
+    skeletonLines.forEach((line) => {
+      expect(line).toHaveAttribute('aria-label', 'Loading');
+    });
+  });
+});


### PR DESCRIPTION
- Add Skeleton, SkeletonText, and SkeletonRow components to twenty-ui
- Pure CSS shimmer animation (zero extra dependencies vs react-loading-skeleton)
- Export from twenty-ui/feedback barrel
- Add Storybook stories for all three components
- Add unit tests (20 tests across 3 suites)
- Refactor DropdownMenuSkeletonItem and ShowPageSummaryCard to use new Skeleton