### PR TITLE
Enable update when record not in cache

### DIFF
--- a/packages/twenty-front/src/modules/object-record/hooks/useRecordOneToManyFieldAttachTargetRecord.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useRecordOneToManyFieldAttachTargetRecord.ts
@@ -60,44 +60,43 @@ export const useRecordOneToManyFieldAttachTargetRecord = () => {
       objectPermissionsByObjectMetadataId,
     });
 
-    if (!cachedTargetRecord) {
-      throw new Error('Could not find cached related record');
-    }
+    if (cachedTargetRecord) {
+      const previousRecordId =
+        cachedTargetRecord[`${targetGQLFieldName}Id`];
 
-    const previousRecordId = cachedTargetRecord?.[`${targetGQLFieldName}Id`];
+      if (isDefined(previousRecordId)) {
+        const previousRecord = getRecordFromCache({
+          objectMetadataItem: sourceObjectMetadataItem,
+          recordId: previousRecordId,
+          cache: apolloCoreClient.cache,
+          objectMetadataItems,
+          objectPermissionsByObjectMetadataId,
+        });
 
-    if (isDefined(previousRecordId)) {
-      const previousRecord = getRecordFromCache({
-        objectMetadataItem: sourceObjectMetadataItem,
-        recordId: previousRecordId,
-        cache: apolloCoreClient.cache,
-        objectMetadataItems,
-        objectPermissionsByObjectMetadataId,
-      });
-
-      const previousRecordWithRelation = {
-        ...cachedTargetRecord,
-        [targetGQLFieldName]: previousRecord,
-      };
-
-      const gqlFields = generateDepthRecordGqlFieldsFromRecord({
-        objectMetadataItem: targetObjectMetadataItem,
-        objectMetadataItems,
-        record: previousRecordWithRelation,
-        depth: 1,
-      });
-
-      updateRecordFromCache({
-        objectMetadataItems,
-        objectMetadataItem: targetObjectMetadataItem,
-        cache: apolloCoreClient.cache,
-        record: {
+        const previousRecordWithRelation = {
           ...cachedTargetRecord,
           [targetGQLFieldName]: previousRecord,
-        },
-        recordGqlFields: gqlFields,
-        objectPermissionsByObjectMetadataId,
-      });
+        };
+
+        const gqlFields = generateDepthRecordGqlFieldsFromRecord({
+          objectMetadataItem: targetObjectMetadataItem,
+          objectMetadataItems,
+          record: previousRecordWithRelation,
+          depth: 1,
+        });
+
+        updateRecordFromCache({
+          objectMetadataItems,
+          objectMetadataItem: targetObjectMetadataItem,
+          cache: apolloCoreClient.cache,
+          record: {
+            ...cachedTargetRecord,
+            [targetGQLFieldName]: previousRecord,
+          },
+          recordGqlFields: gqlFields,
+          objectPermissionsByObjectMetadataId,
+        });
+      }
     }
 
     await updateOneRecord({


### PR DESCRIPTION
Fixes https://github.com/twentyhq/twenty/issues/17669

I may be wrong but I don't get why we absolutely need the cache to perform the update