### PR TITLE
fix: handle info log level alias and filter invalid levels gracefully

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/twenty-config/decorators/__tests__/cast-to-log-level-array.decorator.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/decorators/__tests__/cast-to-log-level-array.decorator.spec.ts
@@ -56,10 +56,43 @@ describe('CastToLogLevelArray Decorator', () => {
     expect(transformedClass.logLevels).toBeUndefined();
   });
 
-  it('should cast "verbose,error,toto" to undefined', () => {
+  it('should cast "verbose,error,toto" to ["verbose", "error"] filtering invalid levels', () => {
     const transformedClass = plainToClass(TestClass, {
       logLevels: 'verbose,error,toto',
     });
+
+    expect(transformedClass.logLevels).toStrictEqual(['verbose', 'error']);
+  });
+
+  it('should cast "info" to ["log"] mapping info alias', () => {
+    const transformedClass = plainToClass(TestClass, { logLevels: 'info' });
+
+    expect(transformedClass.logLevels).toStrictEqual(['log']);
+  });
+
+  it('should cast "debug,info,error,warn" to ["debug", "log", "error", "warn"]', () => {
+    const transformedClass = plainToClass(TestClass, {
+      logLevels: 'debug,info,error,warn',
+    });
+
+    expect(transformedClass.logLevels).toStrictEqual([
+      'debug',
+      'log',
+      'error',
+      'warn',
+    ]);
+  });
+
+  it('should deduplicate when alias maps to existing level', () => {
+    const transformedClass = plainToClass(TestClass, {
+      logLevels: 'log,info',
+    });
+
+    expect(transformedClass.logLevels).toStrictEqual(['log']);
+  });
+
+  it('should cast "toto" to undefined when all levels are invalid', () => {
+    const transformedClass = plainToClass(TestClass, { logLevels: 'toto' });
 
     expect(transformedClass.logLevels).toBeUndefined();
   });

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/decorators/cast-to-log-level-array.decorator.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/decorators/cast-to-log-level-array.decorator.ts
@@ -1,18 +1,28 @@
 import { Transform } from 'class-transformer';
 
+const LOG_LEVEL_ALIASES: Record<string, string> = {
+  info: 'log',
+};
+
+const VALID_LOG_LEVELS = ['log', 'error', 'warn', 'debug', 'verbose'];
+
 export const CastToLogLevelArray = () =>
   Transform(({ value }: { value: string }) => toLogLevelArray(value));
 
 // oxlint-disable-next-line @typescripttypescript/no-explicit-any
 const toLogLevelArray = (value: any) => {
   if (typeof value === 'string') {
-    const rawLogLevels = value.split(',').map((level) => level.trim());
-    const isInvalid = rawLogLevels.some(
-      (level) => !['log', 'error', 'warn', 'debug', 'verbose'].includes(level),
+    const normalizedLevels = value
+      .split(',')
+      .map((level) => level.trim())
+      .map((level) => LOG_LEVEL_ALIASES[level] ?? level);
+
+    const validLevels = normalizedLevels.filter((level) =>
+      VALID_LOG_LEVELS.includes(level),
     );
 
-    if (!isInvalid) {
-      return rawLogLevels;
+    if (validLevels.length > 0) {
+      return [...new Set(validLevels)];
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #18356

Setting `LOG_LEVELS=debug,info,error,warn` crashes the application with `TypeError: logLevels.map is not a function` because `info` is not a valid NestJS log level (NestJS uses `log` instead of `info`).

The `CastToLogLevelArray` decorator previously rejected the **entire** value when any single level was invalid, returning `undefined`. This `undefined` propagated through `ConfigService` → `loggerModuleFactory` → `ConsoleLogger.setLogLevels()`, where NestJS called `.map()` on it and crashed.

## Changes

- **Alias mapping**: common aliases like `info` are mapped to their NestJS equivalents (`log`) before validation
- **Graceful filtering**: invalid levels are filtered out instead of rejecting the entire value — `debug,info,error,toto` now resolves to `['debug', 'log', 'error']` instead of `undefined`
- **Deduplication**: prevents duplicates when an alias maps to an already-present level (e.g. `log,info` → `['log']`)
- `undefined` is only returned when **no** valid levels remain

## Test plan

- [x] Added test: `"info"` → `["log"]` (alias mapping)
- [x] Added test: `"debug,info,error,warn"` → `["debug", "log", "error", "warn"]` (exact scenario from #18356)
- [x] Added test: `"log,info"` → `["log"]` (deduplication)
- [x] Updated test: `"verbose,error,toto"` → `["verbose", "error"]` (filter instead of reject)
- [x] Existing test: `"toto"` → `undefined` (all invalid = no override)
- [x] All existing happy-path tests unchanged and passing