### PR TITLE
fix: pass IS_CONFIG_VARIABLES_IN_DB_ENABLED to worker in docker-compose

### DIFF
--- a/packages/twenty-docker/docker-compose.yml
+++ b/packages/twenty-docker/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       PG_DATABASE_URL: postgres://${PG_DATABASE_USER:-postgres}:${PG_DATABASE_PASSWORD:-postgres}@${PG_DATABASE_HOST:-db}:${PG_DATABASE_PORT:-5432}/default
       SERVER_URL: ${SERVER_URL}
       REDIS_URL: ${REDIS_URL:-redis://redis:6379}
+      IS_CONFIG_VARIABLES_IN_DB_ENABLED: ${IS_CONFIG_VARIABLES_IN_DB_ENABLED:-true}
       DISABLE_DB_MIGRATIONS: ${DISABLE_DB_MIGRATIONS}
       DISABLE_CRON_JOBS_REGISTRATION: ${DISABLE_CRON_JOBS_REGISTRATION}
 
@@ -66,6 +67,7 @@ services:
       PG_DATABASE_URL: postgres://${PG_DATABASE_USER:-postgres}:${PG_DATABASE_PASSWORD:-postgres}@${PG_DATABASE_HOST:-db}:${PG_DATABASE_PORT:-5432}/default
       SERVER_URL: ${SERVER_URL}
       REDIS_URL: ${REDIS_URL:-redis://redis:6379}
+      IS_CONFIG_VARIABLES_IN_DB_ENABLED: ${IS_CONFIG_VARIABLES_IN_DB_ENABLED:-true}
       DISABLE_DB_MIGRATIONS: "true" # it already runs on the server
       DISABLE_CRON_JOBS_REGISTRATION: "true" # it already runs on the server
 


### PR DESCRIPTION
## Summary
Fixes #18364

- Worker service in docker-compose didn't receive `IS_CONFIG_VARIABLES_IN_DB_ENABLED`, so database-stored config (including encrypted SMTP credentials) was never loaded by the worker
- **Root cause**: `TwentyConfigModule.forRoot()` reads `process.env.IS_CONFIG_VARIABLES_IN_DB_ENABLED` at startup — if missing from docker-compose env, it defaults to enabled but the worker may not properly initialize the database config driver
- **Fix**: Add `IS_CONFIG_VARIABLES_IN_DB_ENABLED: ${IS_CONFIG_VARIABLES_IN_DB_ENABLED:-true}` to both server and worker services

## Changes
- `docker-compose.yml`: Added env var to server (line 15) and worker (line 70) services

## Note
Users experiencing this issue should also verify that `APP_SECRET` is identical for both server and worker containers, as sensitive config values are encrypted with this key.

## Test plan
- [x] Verified `APP_SECRET` already configured identically in both services
- [x] Default value `true` matches application behavior (`!== 'false'`)