### PR TITLE
ci: replace 4-core runners with ubuntu-latest

### DIFF
--- a/.github/workflows/ci-front.yaml
+++ b/.github/workflows/ci-front.yaml
@@ -65,7 +65,7 @@ jobs:
           key: ${{ env.STORYBOOK_BUILD_CACHE_KEY_FOR_SAVE_ACTION }}
   front-sb-test:
     timeout-minutes: 30
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     needs: front-sb-build
     strategy:
       fail-fast: false

--- a/.github/workflows/ci-sdk.yaml
+++ b/.github/workflows/ci-sdk.yaml
@@ -51,7 +51,7 @@ jobs:
           tasks: ${{ matrix.task }}
   sdk-e2e-test:
     timeout-minutes: 30
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     needs: [changed-files-check, sdk-test]
     if: needs.changed-files-check.outputs.any_changed == 'true'
     services:

--- a/.github/workflows/ci-server.yaml
+++ b/.github/workflows/ci-server.yaml
@@ -32,7 +32,7 @@ jobs:
     needs: changed-files-check
     if: needs.changed-files-check.outputs.any_changed == 'true'
     timeout-minutes: 30
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     steps:
       - name: Fetch custom Github Actions and base branch history
         uses: actions/checkout@v4
@@ -60,7 +60,7 @@ jobs:
     needs: changed-files-check
     if: needs.changed-files-check.outputs.any_changed == 'true'
     timeout-minutes: 30
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     steps:
       - name: Fetch custom Github Actions and base branch history
         uses: actions/checkout@v4
@@ -79,7 +79,7 @@ jobs:
   server-validation:
     needs: server-build
     timeout-minutes: 30
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     services:
       postgres:
         image: twentycrm/twenty-postgres-spilo
@@ -179,7 +179,7 @@ jobs:
   server-test:
     needs: server-build
     timeout-minutes: 30
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     steps:
       - name: Fetch custom Github Actions and base branch history
         uses: actions/checkout@v4
@@ -201,7 +201,7 @@ jobs:
 
   server-integration-test:
     timeout-minutes: 30
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     needs: server-build
     strategy:
       fail-fast: false

--- a/.github/workflows/ci-zapier.yaml
+++ b/.github/workflows/ci-zapier.yaml
@@ -26,7 +26,7 @@ jobs:
     needs: changed-files-check
     if: needs.changed-files-check.outputs.any_changed == 'true'
     timeout-minutes: 30
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     services:
       postgres:
         image: twentycrm/twenty-postgres-spilo


### PR DESCRIPTION
## Summary

- Replace all `ubuntu-latest-4-cores` (paid larger runners) with `ubuntu-latest` across CI workflows
- The free `ubuntu-latest` runner for public repos already provides **4 vCPUs + 16 GB RAM** — identical specs to the paid 4-core larger runner
- Affects 4 workflow files: `ci-server.yaml`, `ci-front.yaml`, `ci-sdk.yaml`, `ci-zapier.yaml` (8 job definitions total, including the 10-shard integration test matrix)
- The `ubuntu-latest-8-cores` runners are intentionally **kept** for memory-heavy jobs (frontend build, storybook build, E2E tests) where the extra capacity (8 vCPUs, 32 GB RAM) is needed

