### PR TITLE
fix(messaging): handle ImapFlow error events to prevent server crash

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/imap-smtp-caldav-connection/services/imap-smtp-caldav-connection.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/imap-smtp-caldav-connection/services/imap-smtp-caldav-connection.service.ts
@@ -41,6 +41,12 @@ export class ImapSmtpCaldavService {
       },
     });
 
+    client.on('error', (error: Error) => {
+      this.logger.error(
+        `IMAP client error for ${handle}: ${error.message}`,
+      );
+    });
+
     try {
       await client.connect();
 

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/providers/imap-client.provider.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/providers/imap-client.provider.ts
@@ -94,6 +94,12 @@ export class ImapClientProvider {
       greetingTimeout: ImapClientProvider.GREETING_TIMEOUT_MS,
     });
 
+    client.on('error', (error: Error) => {
+      this.logger.error(
+        `IMAP client error for ${connectedAccount.handle}: ${error.message}`,
+      );
+    });
+
     try {
       await client.connect();
 


### PR DESCRIPTION
## Summary

- Add `.on('error')` event handlers to all `ImapFlow` client instances to prevent unhandled error events from crashing the Node.js process
- Affects two creation points: `ImapSmtpCaldavService.testImapConnection` (connection validation) and `ImapClientProvider.createConnection` (ongoing message sync)

## Problem

`ImapFlow` extends `EventEmitter` and emits `'error'` events asynchronously for socket timeouts and connection drops. Per Node.js semantics, an `EventEmitter` that emits `'error'` without a registered listener will throw, crashing the process.

**Reproduction steps:**
1. Add an IMAP email account in Settings > Accounts
2. IMAP connection succeeds, mailboxes are listed
3. During message channel configuration, the IMAP socket times out
4. Unhandled `'error'` event crashes the server
5. After restart, the email configuration is lost

**Server log showing the crash:**
```
[Nest] 1 - ERROR [ImapSmtpCaldavService] IMAP connection failed: Command failed
[Nest] 1 - LOG [ImapSmtpCaldavService] IMAP connection successful. Found 17 mailboxes.
[Nest] 1 - LOG [ImapClientProvider] Connected to IMAP server for user@example.com

node:events:486
      throw er; // Unhandled 'error' event
      ^
Error: Socket timeout
    at TLSSocket.<anonymous> (/app/node_modules/imapflow/lib/imap-flow.js:795:29)
Emitted 'error' event on ImapFlow instance at:
    at ImapFlow.emitError (/app/node_modules/imapflow/lib/imap-flow.js:397:14)
```

## Fix

Register `.on('error')` handlers immediately after creating each `ImapFlow` instance, before calling `client.connect()`. The handlers log the error instead of letting it crash the process.

## Test plan

- [ ] Add an IMAP email account and verify connection test works
- [ ] Verify socket timeout during sync logs an error instead of crashing the server
- [ ] Verify existing IMAP sync functionality is not affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)