### PR TITLE
fix: replace > button with button selector in styled wrappers

### DIFF
--- a/packages/twenty-front/src/modules/settings/data-model/components/SettingsDataModelNewFieldBreadcrumbDropDown.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/components/SettingsDataModelNewFieldBreadcrumbDropDown.tsx
@@ -4,8 +4,8 @@ import { DropdownContent } from '@/ui/layout/dropdown/components/DropdownContent
 import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/DropdownMenuItemsContainer';
 import { useCloseDropdown } from '@/ui/layout/dropdown/hooks/useCloseDropdown';
 import { styled } from '@linaria/react';
-import { useContext } from 'react';
 import { t } from '@lingui/core/macro';
+import { useContext } from 'react';
 import { useLocation, useParams, useSearchParams } from 'react-router-dom';
 import { SettingsPath } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
@@ -48,7 +48,7 @@ const StyledSpan = styled.span`
 `;
 
 const StyledButtonWrapper = styled.div`
-  > button {
+  button {
     color: ${themeCssVariables.font.color.primary};
     padding-right: ${themeCssVariables.spacing[6]};
   }

--- a/packages/twenty-front/src/modules/spreadsheet-import/steps/components/ValidationStep/ValidationStep.tsx
+++ b/packages/twenty-front/src/modules/spreadsheet-import/steps/components/ValidationStep/ValidationStep.tsx
@@ -57,7 +57,7 @@ const StyledToolbar = styled.div`
 `;
 
 const StyledButtonContainer = styled.div`
-  > button {
+  button {
     height: 24px;
   }
 `;


### PR DESCRIPTION
fix CSS selector > button not reaching Button component's inner element
### Reproduce
- when you click Data model and create a new field, you will see this bug.
- When you import record and check the height of remove button in the final validation step.

### Root Reason
the Button component internally renders a wrapper div around the <button> element, so > button only reaches the intermediate div, not the actual button.

### Fix
- padding-right not applied → chevron overlapped with text
- ValidationStep: height: 24px not applied → Remove button was 32px instead of 24px

<img width="1288" height="376" alt="image" src="https://github.com/user-attachments/assets/885cd8b0-1fe2-484a-8425-70f52b784ecb" />

<img width="1001" height="291" alt="image" src="https://github.com/user-attachments/assets/0b489478-8fbc-4f7e-886a-38012eeb07ef" />

