### PR TITLE
Add Gemini 3.1 Flash Lite model to AI registry

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/constants/ai-models-types.const.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/constants/ai-models-types.const.ts
@@ -51,6 +51,7 @@ export type ModelId =
   // Google models
   | 'gemini-3.1-pro-preview'
   | 'gemini-3-flash-preview'
+  | 'gemini-3.1-flash-lite-preview'
   | 'gemini-2.5-pro'
   | 'gemini-2.5-flash'
   // Bedrock models (Anthropic via AWS)

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/constants/google-models.const.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/constants/google-models.const.ts
@@ -42,6 +42,20 @@ export const GOOGLE_MODELS: AIModelConfig[] = [
     supportedFileTypes: ['image/png', 'image/jpeg', 'image/gif', 'image/webp'],
     doesSupportThinking: true,
   },
+  {
+    modelId: 'gemini-3.1-flash-lite-preview',
+    label: 'Gemini 3.1 Flash Lite',
+    description:
+      'Ultra-low-cost Gemini model for high-volume tasks with 1M context',
+    modelFamily: ModelFamily.GOOGLE,
+    inferenceProvider: InferenceProvider.GOOGLE,
+    inputCostPerMillionTokens: 0.25,
+    outputCostPerMillionTokens: 1.5,
+    contextWindowTokens: 1048576,
+    maxOutputTokens: 65536,
+    supportedFileTypes: ['image/png', 'image/jpeg', 'image/gif', 'image/webp'],
+    doesSupportThinking: true,
+  },
 
   // Deprecated models - kept for backward compatibility with existing agents
   {


### PR DESCRIPTION
## Summary
- Adds `gemini-3.1-flash-lite-preview` to the Google AI models registry
- Ultra-low-cost Gemini model ($0.25/M input, $1.50/M output) — half the price of Gemini 3 Flash
- 1M context window, 64K max output, supports dynamic thinking
- No service code changes needed — the existing `AiModelRegistryService` auto-discovers models from constants

## Changes
- `ai-models-types.const.ts`: Added `gemini-3.1-flash-lite-preview` to the `ModelId` type union
- `google-models.const.ts`: Added model configuration with pricing, context window, and capabilities

## Test plan
- [ ] `npx nx typecheck twenty-server` passes
- [ ] `npx nx lint twenty-server` passes
- [ ] With `GOOGLE_API_KEY` set, model appears in available models list
- [ ] Existing Gemini models unaffected