### PR TITLE
Fix wrong uuid error on field metadata

### DIFF
--- a/packages/twenty-front/src/generated-metadata/graphql.ts
+++ b/packages/twenty-front/src/generated-metadata/graphql.ts
@@ -1770,7 +1770,7 @@ export type Field = {
   settings?: Maybe<Scalars['JSON']>;
   standardOverrides?: Maybe<StandardOverrides>;
   type: FieldMetadataType;
-  universalIdentifier: Scalars['UUID'];
+  universalIdentifier: Scalars['String'];
   updatedAt: Scalars['DateTime'];
 };
 
@@ -1803,7 +1803,6 @@ export type FieldFilter = {
   isSystem?: InputMaybe<BooleanFieldComparison>;
   isUIReadOnly?: InputMaybe<BooleanFieldComparison>;
   or?: InputMaybe<Array<FieldFilter>>;
-  universalIdentifier?: InputMaybe<UuidFilterComparison>;
 };
 
 /** Type of the field */
@@ -4992,7 +4991,7 @@ export type UpdateFieldInput = {
   name?: InputMaybe<Scalars['String']>;
   options?: InputMaybe<Scalars['JSON']>;
   settings?: InputMaybe<Scalars['JSON']>;
-  universalIdentifier?: InputMaybe<Scalars['UUID']>;
+  universalIdentifier?: InputMaybe<Scalars['String']>;
 };
 
 export type UpdateFrontComponentInput = {

--- a/packages/twenty-sdk/scripts/generate-metadata-client.ts
+++ b/packages/twenty-sdk/scripts/generate-metadata-client.ts
@@ -23,8 +23,7 @@ const main = async () => {
   );
 
   const serverUrl = process.env.TWENTY_API_URL ?? 'http://localhost:3000';
-  const token =
-    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIyMDIwMjAyMC0xYzI1LTRkMDItYmYyNS02YWVjY2Y3ZWE0MTkiLCJ0eXBlIjoiQVBJX0tFWSIsIndvcmtzcGFjZUlkIjoiMjAyMDIwMjAtMWMyNS00ZDAyLWJmMjUtNmFlY2NmN2VhNDE5IiwiaWF0IjoxNzczMzI4MDA4LCJleHAiOjQ5MjY5MjgwMDcsImp0aSI6IjVhODI0ZjQyLTRmY2MtNDBlNi1iOTk2LTA2Y2U4NzAwMjgzZCJ9.kxOEqWZKjakRwRzcHJrO5NywGYooFMgiJGdhBdaKZyc';
+  const token = process.env.TWENTY_API_KEY;
   const clientWrapperTemplateSource = await readFile(TEMPLATE_PATH, 'utf-8');
 
   const clientService = new ClientService({

--- a/packages/twenty-sdk/src/clients/generated/metadata/schema.graphql
+++ b/packages/twenty-sdk/src/clients/generated/metadata/schema.graphql
@@ -326,7 +326,7 @@ type StandardOverrides {
 
 type Field {
   id: UUID!
-  universalIdentifier: UUID!
+  universalIdentifier: String!
   type: FieldMetadataType!
   name: String!
   label: String!
@@ -534,7 +534,6 @@ input FieldFilter {
   and: [FieldFilter!]
   or: [FieldFilter!]
   id: UUIDFilterComparison
-  universalIdentifier: UUIDFilterComparison
   isCustom: BooleanFieldComparison
   isActive: BooleanFieldComparison
   isSystem: BooleanFieldComparison
@@ -4004,7 +4003,7 @@ input UpdateOneFieldMetadataInput {
 }
 
 input UpdateFieldInput {
-  universalIdentifier: UUID
+  universalIdentifier: String
   name: String
   label: String
   description: String

--- a/packages/twenty-sdk/src/clients/generated/metadata/schema.ts
+++ b/packages/twenty-sdk/src/clients/generated/metadata/schema.ts
@@ -280,7 +280,7 @@ export interface StandardOverrides {
 
 export interface Field {
     id: Scalars['UUID']
-    universalIdentifier: Scalars['UUID']
+    universalIdentifier: Scalars['String']
     type: FieldMetadataType
     name: Scalars['String']
     label: Scalars['String']
@@ -3253,7 +3253,7 @@ export interface ObjectGenqlSelection{
     __scalar?: boolean | number
 }
 
-export interface FieldFilter {and?: (FieldFilter[] | null),or?: (FieldFilter[] | null),id?: (UUIDFilterComparison | null),universalIdentifier?: (UUIDFilterComparison | null),isCustom?: (BooleanFieldComparison | null),isActive?: (BooleanFieldComparison | null),isSystem?: (BooleanFieldComparison | null),isUIReadOnly?: (BooleanFieldComparison | null)}
+export interface FieldFilter {and?: (FieldFilter[] | null),or?: (FieldFilter[] | null),id?: (UUIDFilterComparison | null),isCustom?: (BooleanFieldComparison | null),isActive?: (BooleanFieldComparison | null),isSystem?: (BooleanFieldComparison | null),isUIReadOnly?: (BooleanFieldComparison | null)}
 
 export interface IndexFilter {and?: (IndexFilter[] | null),or?: (IndexFilter[] | null),id?: (UUIDFilterComparison | null),isCustom?: (BooleanFieldComparison | null)}
 
@@ -6124,7 +6124,7 @@ id: Scalars['UUID'],
 /** The record to update */
 update: UpdateFieldInput}
 
-export interface UpdateFieldInput {universalIdentifier?: (Scalars['UUID'] | null),name?: (Scalars['String'] | null),label?: (Scalars['String'] | null),description?: (Scalars['String'] | null),icon?: (Scalars['String'] | null),isActive?: (Scalars['Boolean'] | null),isSystem?: (Scalars['Boolean'] | null),isUIReadOnly?: (Scalars['Boolean'] | null),isNullable?: (Scalars['Boolean'] | null),isUnique?: (Scalars['Boolean'] | null),defaultValue?: (Scalars['JSON'] | null),options?: (Scalars['JSON'] | null),settings?: (Scalars['JSON'] | null),isLabelSyncedWithName?: (Scalars['Boolean'] | null),morphRelationsUpdatePayload?: (Scalars['JSON'][] | null)}
+export interface UpdateFieldInput {universalIdentifier?: (Scalars['String'] | null),name?: (Scalars['String'] | null),label?: (Scalars['String'] | null),description?: (Scalars['String'] | null),icon?: (Scalars['String'] | null),isActive?: (Scalars['Boolean'] | null),isSystem?: (Scalars['Boolean'] | null),isUIReadOnly?: (Scalars['Boolean'] | null),isNullable?: (Scalars['Boolean'] | null),isUnique?: (Scalars['Boolean'] | null),defaultValue?: (Scalars['JSON'] | null),options?: (Scalars['JSON'] | null),settings?: (Scalars['JSON'] | null),isLabelSyncedWithName?: (Scalars['Boolean'] | null),morphRelationsUpdatePayload?: (Scalars['JSON'][] | null)}
 
 export interface DeleteOneFieldInput {
 /** The id of the field to delete. */

--- a/packages/twenty-sdk/src/clients/generated/metadata/types.ts
+++ b/packages/twenty-sdk/src/clients/generated/metadata/types.ts
@@ -716,7 +716,7 @@ export default {
                 3
             ],
             "universalIdentifier": [
-                3
+                1
             ],
             "type": [
                 35
@@ -1130,9 +1130,6 @@ export default {
                 47
             ],
             "id": [
-                42
-            ],
-            "universalIdentifier": [
                 42
             ],
             "isCustom": [
@@ -10154,7 +10151,7 @@ export default {
         },
         "UpdateFieldInput": {
             "universalIdentifier": [
-                3
+                1
             ],
             "name": [
                 1

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/dtos/field-metadata.dto.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/dtos/field-metadata.dto.ts
@@ -64,9 +64,8 @@ export class FieldMetadataDTO<T extends FieldMetadataType = FieldMetadataType> {
   @IDField(() => UUIDScalarType)
   id: string;
 
-  @IsUUID()
   @IsNotEmpty()
-  @IDField(() => UUIDScalarType)
+  @Field()
   universalIdentifier: string;
 
   @IsEnum(FieldMetadataType)


### PR DESCRIPTION
## Summary
- Same fix as #18590 but applied to `FieldMetadataDTO`
- Changed `universalIdentifier` from `UUID` to `String` type since field metadata universal identifiers are not necessarily valid UUIDs
- Removed `universalIdentifier` from `FieldFilter` (was using `UUIDFilterComparison`)
- Updated generated SDK and frontend types accordingly