### PR TITLE
Fix sdk metadata client codegen

### DIFF
--- a/packages/twenty-sdk/scripts/generate-metadata-client.ts
+++ b/packages/twenty-sdk/scripts/generate-metadata-client.ts
@@ -23,8 +23,7 @@ const main = async () => {
   );
 
   const serverUrl = process.env.TWENTY_API_URL ?? 'http://localhost:3000';
-  const token =
-    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIyMDIwMjAyMC0xYzI1LTRkMDItYmYyNS02YWVjY2Y3ZWE0MTkiLCJ0eXBlIjoiQVBJX0tFWSIsIndvcmtzcGFjZUlkIjoiMjAyMDIwMjAtMWMyNS00ZDAyLWJmMjUtNmFlY2NmN2VhNDE5IiwiaWF0IjoxNzczMzI4MDA4LCJleHAiOjQ5MjY5MjgwMDcsImp0aSI6IjVhODI0ZjQyLTRmY2MtNDBlNi1iOTk2LTA2Y2U4NzAwMjgzZCJ9.kxOEqWZKjakRwRzcHJrO5NywGYooFMgiJGdhBdaKZyc';
+  const token = process.env.TWENTY_API_KEY;
   const clientWrapperTemplateSource = await readFile(TEMPLATE_PATH, 'utf-8');
 
   const clientService = new ClientService({


### PR DESCRIPTION
## Context
Previous token was tied to a non-existing token and codegen was failing locally due to the server throwing.
This is due to a regression introduced here https://github.com/twentyhq/twenty/pull/18590/changes#diff-848fff5d5b6f9858c8e2391212dfa9da5151cd3b1325d410df8a82250a229558L26 where a token is hardcoded instead of using the one from the ENV