### PR TITLE
Fix Flow tab missing for workflow run

### DIFF
--- a/packages/twenty-front/src/modules/page-layout/components/PageLayoutRendererContent.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/PageLayoutRendererContent.tsx
@@ -116,7 +116,10 @@ export const PageLayoutRendererContent = () => {
 
   const tabsForCurrentObject = isSystemObject
     ? tabsWithVisibleWidgets.filter(
-        (tab) => tab.title === 'Home' || tab.title === 'Timeline',
+        (tab) =>
+          tab.title === 'Home' ||
+          tab.title === 'Timeline' ||
+          tab.title === 'Overview',
       )
     : tabsWithVisibleWidgets;
 

--- a/packages/twenty-front/src/modules/page-layout/components/PageLayoutRendererContent.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/PageLayoutRendererContent.tsx
@@ -114,13 +114,11 @@ export const PageLayoutRendererContent = () => {
     isEditMode: isPageLayoutInEditMode,
   });
 
+  const SYSTEM_OBJECT_TABS = ['Home', 'Timeline', 'Overview', 'Flow'];
+
   const tabsForCurrentObject = isSystemObject
-    ? tabsWithVisibleWidgets.filter(
-        (tab) =>
-          tab.title === 'Home' ||
-          tab.title === 'Timeline' ||
-          tab.title === 'Overview' ||
-          tab.title === 'Flow',
+    ? tabsWithVisibleWidgets.filter((tab) =>
+        SYSTEM_OBJECT_TABS.includes(tab.title),
       )
     : tabsWithVisibleWidgets;
 

--- a/packages/twenty-front/src/modules/page-layout/components/PageLayoutRendererContent.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/PageLayoutRendererContent.tsx
@@ -119,7 +119,8 @@ export const PageLayoutRendererContent = () => {
         (tab) =>
           tab.title === 'Home' ||
           tab.title === 'Timeline' ||
-          tab.title === 'Overview',
+          tab.title === 'Overview' ||
+          tab.title === 'Flow',
       )
     : tabsWithVisibleWidgets;
 


### PR DESCRIPTION
## Context
Conditional tab rendering was recently introduced for system objects that now have record page layouts. However Workflow run is a system object and has a specific "Flow" tab that was not displayed anymore

## Before
<img width="1191" height="640" alt="Screenshot 2026-03-12 at 18 10 03" src="https://github.com/user-attachments/assets/6f2c6319-6ddf-4906-a83c-0db8a27a8267" />

## After
<img width="1299" height="802" alt="Screenshot 2026-03-12 at 18 09 35" src="https://github.com/user-attachments/assets/35e1e356-e995-43a2-9207-adc0f67cc426" />
