### PR TITLE
Separate create draft cases op

### DIFF
--- a/packages/twenty-front/src/modules/workflow/components/OverrideWorkflowDraftConfirmationModal.tsx
+++ b/packages/twenty-front/src/modules/workflow/components/OverrideWorkflowDraftConfirmationModal.tsx
@@ -1,4 +1,3 @@
-import { CoreObjectNameSingular, AppPath } from 'twenty-shared/types';
 import {
   ConfirmationModal,
   StyledCenteredButton,
@@ -7,6 +6,7 @@ import { useModal } from '@/ui/layout/modal/hooks/useModal';
 import { OVERRIDE_WORKFLOW_DRAFT_CONFIRMATION_MODAL_ID } from '@/workflow/constants/OverrideWorkflowDraftConfirmationModalId';
 import { useCreateDraftFromWorkflowVersion } from '@/workflow/hooks/useCreateDraftFromWorkflowVersion';
 import { useLingui } from '@lingui/react/macro';
+import { AppPath, CoreObjectNameSingular } from 'twenty-shared/types';
 import { getAppPath } from 'twenty-shared/utils';
 import { useNavigateApp } from '~/hooks/useNavigateApp';
 
@@ -58,6 +58,7 @@ export const OverrideWorkflowDraftConfirmationModal = ({
             variant="secondary"
             title={t`Go to Draft`}
             fullWidth
+            justify="center"
           />
         }
       />

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version/workflow-version.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version/workflow-version.workspace-service.ts
@@ -77,44 +77,6 @@ export class WorkflowVersionWorkspaceService {
         assertWorkflowVersionTriggerIsDefined(workflowVersionToCopy);
         assertWorkflowVersionHasSteps(workflowVersionToCopy);
 
-        let draftWorkflowVersion = await workflowVersionRepository.findOne({
-          where: {
-            workflowId,
-            status: WorkflowVersionStatus.DRAFT,
-          },
-        });
-
-        if (!isDefined(draftWorkflowVersion)) {
-          const workflowVersionsCount = await workflowVersionRepository.count({
-            where: {
-              workflowId,
-            },
-          });
-
-          const position = await this.recordPositionService.buildRecordPosition(
-            {
-              value: 'first',
-              objectMetadata: {
-                isCustom: false,
-                nameSingular: 'workflowVersion',
-              },
-              workspaceId,
-            },
-          );
-
-          const insertResult = await workflowVersionRepository.insert({
-            workflowId,
-            name: `v${workflowVersionsCount + 1}`,
-            status: WorkflowVersionStatus.DRAFT,
-            position,
-          });
-
-          draftWorkflowVersion = insertResult
-            .generatedMaps[0] as WorkflowVersionWorkspaceEntity;
-        }
-
-        assertWorkflowVersionIsDraft(draftWorkflowVersion);
-
         const newWorkflowVersionTrigger = workflowVersionToCopy.trigger;
         const newWorkflowVersionSteps: WorkflowAction[] = [];
 
@@ -128,10 +90,58 @@ export class WorkflowVersionWorkspaceService {
           newWorkflowVersionSteps.push(duplicatedStep);
         }
 
-        await workflowVersionRepository.update(draftWorkflowVersion.id, {
+        const existingDraftVersion =
+          await workflowVersionRepository.findOne({
+            where: {
+              workflowId,
+              status: WorkflowVersionStatus.DRAFT,
+            },
+          });
+
+        if (isDefined(existingDraftVersion)) {
+          assertWorkflowVersionIsDraft(existingDraftVersion);
+
+          await workflowVersionRepository.update(existingDraftVersion.id, {
+            steps: newWorkflowVersionSteps,
+            trigger: newWorkflowVersionTrigger,
+          });
+
+          return {
+            ...existingDraftVersion,
+            name: existingDraftVersion.name ?? '',
+            steps: newWorkflowVersionSteps,
+            trigger: newWorkflowVersionTrigger,
+          };
+        }
+
+        const workflowVersionsCount =
+          await workflowVersionRepository.count({
+            where: {
+              workflowId,
+            },
+          });
+
+        const position =
+          await this.recordPositionService.buildRecordPosition({
+            value: 'first',
+            objectMetadata: {
+              isCustom: false,
+              nameSingular: 'workflowVersion',
+            },
+            workspaceId,
+          });
+
+        const insertResult = await workflowVersionRepository.insert({
+          workflowId,
+          name: `v${workflowVersionsCount + 1}`,
+          status: WorkflowVersionStatus.DRAFT,
           steps: newWorkflowVersionSteps,
           trigger: newWorkflowVersionTrigger,
+          position,
         });
+
+        const draftWorkflowVersion = insertResult
+          .generatedMaps[0] as WorkflowVersionWorkspaceEntity;
 
         return {
           ...draftWorkflowVersion,

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version/workflow-version.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version/workflow-version.workspace-service.ts
@@ -90,13 +90,12 @@ export class WorkflowVersionWorkspaceService {
           newWorkflowVersionSteps.push(duplicatedStep);
         }
 
-        const existingDraftVersion =
-          await workflowVersionRepository.findOne({
-            where: {
-              workflowId,
-              status: WorkflowVersionStatus.DRAFT,
-            },
-          });
+        const existingDraftVersion = await workflowVersionRepository.findOne({
+          where: {
+            workflowId,
+            status: WorkflowVersionStatus.DRAFT,
+          },
+        });
 
         if (isDefined(existingDraftVersion)) {
           assertWorkflowVersionIsDraft(existingDraftVersion);
@@ -114,22 +113,20 @@ export class WorkflowVersionWorkspaceService {
           };
         }
 
-        const workflowVersionsCount =
-          await workflowVersionRepository.count({
-            where: {
-              workflowId,
-            },
-          });
+        const workflowVersionsCount = await workflowVersionRepository.count({
+          where: {
+            workflowId,
+          },
+        });
 
-        const position =
-          await this.recordPositionService.buildRecordPosition({
-            value: 'first',
-            objectMetadata: {
-              isCustom: false,
-              nameSingular: 'workflowVersion',
-            },
-            workspaceId,
-          });
+        const position = await this.recordPositionService.buildRecordPosition({
+          value: 'first',
+          objectMetadata: {
+            isCustom: false,
+            nameSingular: 'workflowVersion',
+          },
+          workspaceId,
+        });
 
         const insertResult = await workflowVersionRepository.insert({
           workflowId,


### PR DESCRIPTION
Bug: When creating a draft from an activated workflow version, the draft row was inserted into the database without steps and trigger, then updated with them in a separate operation. The SSE create-one event fired on the INSERT, causing the frontend to refetch the draft before the UPDATE — resulting in steps: null and trigger: null, which crashed the step editor.

Fix: Reorder the operations so steps are duplicated first, then either insert a new draft or update an existing one with steps and trigger already populated. The row never exists in the database without complete data.