### PR TITLE
Fix timeline activities + breadcrumb

### DIFF
--- a/packages/twenty-front/src/modules/activities/timeline-activities/components/EventRow.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/components/EventRow.tsx
@@ -63,11 +63,6 @@ const StyledVerticalLine = styled.div`
 `;
 
 const StyledSummary = styled.summary`
-  align-items: center;
-  display: flex;
-  flex: 1;
-  flex-direction: row;
-  gap: ${themeCssVariables.spacing[1]};
   width: 100%;
 `;
 

--- a/packages/twenty-front/src/modules/activities/timeline-activities/rows/components/EventCard.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/rows/components/EventCard.tsx
@@ -14,10 +14,11 @@ const StyledCardContainer = styled.div`
   gap: ${themeCssVariables.spacing[2]};
   padding: ${themeCssVariables.spacing[2]} 0px ${themeCssVariables.spacing[1]}
     0px;
-  width: 400px;
+  max-width: 400px;
+  width: 100%;
 
   @media (max-width: ${MOBILE_VIEWPORT}px) {
-    width: 300px;
+    max-width: 300px;
   }
 `;
 
@@ -32,6 +33,7 @@ const StyledCardInnerContainer = styled.div`
   flex-direction: column;
   gap: ${themeCssVariables.spacing[2]};
   justify-content: center;
+  overflow: hidden;
   padding: ${themeCssVariables.spacing[2]};
 `;
 

--- a/packages/twenty-front/src/modules/activities/timeline-activities/rows/components/EventCard.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/rows/components/EventCard.tsx
@@ -12,9 +12,9 @@ const StyledCardContainer = styled.div`
   flex-direction: column;
   flex-grow: 1;
   gap: ${themeCssVariables.spacing[2]};
+  max-width: 400px;
   padding: ${themeCssVariables.spacing[2]} 0px ${themeCssVariables.spacing[1]}
     0px;
-  max-width: 400px;
   width: 100%;
 
   @media (max-width: ${MOBILE_VIEWPORT}px) {

--- a/packages/twenty-front/src/modules/activities/timeline-activities/rows/message/components/EventCardMessage.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/rows/message/components/EventCardMessage.tsx
@@ -17,7 +17,8 @@ const StyledEventCardMessageContainer = styled.div<{ canOpen?: boolean }>`
   cursor: ${({ canOpen }) => (canOpen ? 'pointer' : 'not-allowed')};
   display: flex;
   flex-direction: column;
-  width: 380px;
+  max-width: 380px;
+  width: 100%;
 `;
 
 const StyledEmailContent = styled.div`

--- a/packages/twenty-front/src/pages/object-record/RecordShowPageHeader.tsx
+++ b/packages/twenty-front/src/pages/object-record/RecordShowPageHeader.tsx
@@ -26,7 +26,7 @@ export const RecordShowPageHeader = ({
         <ObjectRecordShowPageBreadcrumb
           objectNameSingular={objectNameSingular}
           objectRecordId={objectRecordId}
-          objectLabel={objectMetadataItem.labelSingular}
+          objectLabel={objectMetadataItem.labelPlural}
           labelIdentifierFieldMetadataItem={labelIdentifierFieldMetadataItem}
         />
       }


### PR DESCRIPTION
Before
<img width="412" height="223" alt="Capture d’écran 2026-03-13 à 17 42 37" src="https://github.com/user-attachments/assets/350edca5-53a3-4ff9-8c81-80d012bf2170" />

After
<img width="412" height="251" alt="Capture d’écran 2026-03-13 à 17 43 06" src="https://github.com/user-attachments/assets/75a86a10-b551-416b-9103-6db03a6ca395" />
