### PR TITLE
docs: fix contributor docs links and typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@
 # Installation
 
 See:
-🚀 [Self-hosting](https://docs.twenty.com/developers/self-hosting/docker-compose)
-🖥️ [Local Setup](https://docs.twenty.com/developers/local-setup)
+🚀 [Self-hosting](https://docs.twenty.com/developers/self-host/capabilities/docker-compose)
+🖥️ [Local Setup](https://docs.twenty.com/developers/contribute/capabilities/local-setup)
 
 # Why Twenty
 
@@ -36,7 +36,7 @@ We built Twenty for three reasons:
 
 **A fresh start is required to build a better experience.** We can learn from past mistakes and craft a cohesive experience inspired by new UX patterns from tools like Notion, Airtable or Linear.
 
-**We believe in Open-source and community.** Hundreds of developers are already building Twenty together. Once we have plugin capabilities, a whole ecosystem will grow around it.
+**We believe in open-source and community.** Hundreds of developers are already building Twenty together. Once we have plugin capabilities, a whole ecosystem will grow around it.
 
 <br />
 

--- a/packages/twenty-docs/developers/contribute/capabilities/frontend-development/style-guide.mdx
+++ b/packages/twenty-docs/developers/contribute/capabilities/frontend-development/style-guide.mdx
@@ -9,7 +9,7 @@ The goal here is to have a consistent codebase, which is easy to read and easy t
 
 For this, it's better to be a bit more verbose than to be too concise.
 
-Always keep in mind that people read code more often than they write it, specially on an open source project, where anyone can contribute.
+Always keep in mind that people read code more often than they write it, especially on an open source project, where anyone can contribute.
 
 There are a lot of rules that are not defined here, but that are automatically checked by linters.
 
@@ -150,7 +150,7 @@ type MyType = {
 
 ### Use string literals instead of enums
 
-[String literals](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types) are the go-to way to handle enum-like values in TypeScript. They are easier to extend with Pick and Omit, and offer a better developer experience, specially with code completion.
+[String literals](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types) are the go-to way to handle enum-like values in TypeScript. They are easier to extend with Pick and Omit, and offer a better developer experience, especially with code completion.
 
 You can see why TypeScript recommends avoiding enums [here](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#enums).
 
@@ -288,4 +288,3 @@ An Oxlint rule, `typescript/consistent-type-imports`, enforces the no-type impor
 Please note that this rule specifically addresses rare edge cases where unintentional type imports occur. TypeScript itself discourages this practice, as mentioned in the [TypeScript 3.8 release notes](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html). In most situations, you should not need to use type-only imports.
 
 To ensure your code complies with this rule, make sure to run Oxlint as part of your development workflow.
-

--- a/packages/twenty-docs/developers/contribute/capabilities/local-setup.mdx
+++ b/packages/twenty-docs/developers/contribute/capabilities/local-setup.mdx
@@ -7,7 +7,7 @@ description: "The guide for contributors (or curious developers) who want to run
 ## Prerequisites
 
 <Tabs>
-<Tab title="Linux and MacOS">
+<Tab title="Linux and macOS">
 
 Before you can install and use Twenty, make sure you install the following on your computer:
 - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
@@ -31,7 +31,7 @@ wsl --install
 ```
 You should now see a prompt to restart your computer. If not, restart it manually.
 
-Upon restart, a powershell window will open and install Ubuntu. This may take up some time.
+Upon restart, a PowerShell window will open and install Ubuntu. This may take up some time.
 You'll see a prompt to create a username and password for your Ubuntu installation.
 
 2. Install and configure git
@@ -104,7 +104,7 @@ You should run all commands in the following steps from the root of the project.
 <Tabs>
   <Tab title="Linux">
     **Option 1 (preferred):** To provision your database locally:
-    Use the following link to install Postgresql on your Linux machine: [Postgresql Installation](https://www.postgresql.org/download/linux/)
+    Use the following link to install PostgreSQL on your Linux machine: [PostgreSQL Installation](https://www.postgresql.org/download/linux/)
     ```bash
       psql postgres -c "CREATE DATABASE \"default\";" -c "CREATE DATABASE test;"
     ```
@@ -131,7 +131,7 @@ You should run all commands in the following steps from the root of the project.
     ```
 
     The installer might not create the `postgres` user by default when installing
-    via Homebrew on MacOS. Instead, it creates a PostgreSQL role that matches your macOS
+    via Homebrew on macOS. Instead, it creates a PostgreSQL role that matches your macOS
     username (e.g., "john").
     To check and create the `postgres` user if necessary, follow these steps:
     ```bash
@@ -174,8 +174,8 @@ You should run all commands in the following steps from the root of the project.
   <Tab title="Windows (WSL)">
     All the following steps are to be run in the WSL terminal (within your virtual machine)
 
-    **Option 1:** To provision your Postgresql locally:
-    Use the following link to install Postgresql on your Linux virtual machine: [Postgresql Installation](https://www.postgresql.org/download/linux/)
+    **Option 1:** To provision your PostgreSQL locally:
+    Use the following link to install PostgreSQL on your Linux virtual machine: [PostgreSQL Installation](https://www.postgresql.org/download/linux/)
     ```bash
       psql postgres -c "CREATE DATABASE \"default\";" -c "CREATE DATABASE test;"
     ```
@@ -190,10 +190,10 @@ You should run all commands in the following steps from the root of the project.
   </Tab>
 </Tabs>
 
-You can now access the database at [localhost:5432](localhost:5432), with user `postgres` and password `postgres` .
+You can now access the database at `localhost:5432`, with user `postgres` and password `postgres`.
 
 ## Step 4: Set up a Redis Database (cache)
-Twenty requires a redis cache to provide the best performance
+Twenty requires a Redis cache to provide the best performance.
 
 <Tabs>
   <Tab title="Linux">
@@ -210,8 +210,10 @@ Twenty requires a redis cache to provide the best performance
     ```bash
     brew install redis
     ```
-    Start your redis server:
-    ```brew services start redis```
+    Start your Redis server:
+    ```bash
+    brew services start redis
+    ```
 
     **Option 2:** If you have docker installed:
     ```bash
@@ -229,11 +231,11 @@ Twenty requires a redis cache to provide the best performance
   </Tab>
 </Tabs>
 
-If you need a Client GUI, we recommend [redis insight](https://redis.io/insight/) (free version available)
+If you need a client GUI, we recommend [Redis Insight](https://redis.io/insight/) (free version available).
 
-## Step 5: Setup environment variables
+## Step 5: Set up environment variables
 
-Use environment variables or `.env` files to configure your project. More info [here](/developers/self-host/capabilities/setup)
+Use environment variables or `.env` files to configure your project. More info [here](/developers/self-host/capabilities/setup).
 
 Copy the `.env.example` files in `/front` and `/server`:
 ```bash

--- a/packages/twenty-docs/developers/self-host/capabilities/docker-compose.mdx
+++ b/packages/twenty-docs/developers/self-host/capabilities/docker-compose.mdx
@@ -4,7 +4,7 @@ title: 1-Click w/ Docker Compose
 
 
 <Warning>
-Docker containers are for production hosting or self-hosting, for the contribution please check the [Local Setup](/developers/contribute/capabilities/local-setup).
+Docker containers are for production hosting or self-hosting. For contributing, please check the [Local Setup](/developers/contribute/capabilities/local-setup).
 </Warning>
 
 ## Overview
@@ -13,7 +13,7 @@ This guide provides step-by-step instructions to install and configure the Twent
 
 **Important:** Only modify settings explicitly mentioned in this guide. Altering other configurations may lead to issues.
 
-See docs [Setup Environment Variables](/developers/self-host/capabilities/setup) for advanced configuration. All environment variables must be declared in the docker-compose.yml file at the server and / or worker level depending on the variable.
+See [Setup Environment Variables](/developers/self-host/capabilities/setup) for advanced configuration. All environment variables must be declared in the `docker-compose.yml` file at the server and/or worker level, depending on the variable.
 
 ## System Requirements
 
@@ -236,5 +236,4 @@ docker compose up -d
 ## Troubleshooting
 
 If you encounter any problem, check [Troubleshooting](/developers/self-host/capabilities/troubleshooting) for solutions.
-
 


### PR DESCRIPTION
## Summary

This PR fixes several small documentation issues in the contributor and setup guides:

- fixes broken docs links in the root README
- corrects multiple typos and capitalization issues in contributor docs
- fixes malformed Markdown for the Redis command in local setup
- improves wording in the Docker Compose self-hosting guide

## Changes

- updated README installation links to the current docs routes
- changed `Open-source` to `open-source`
- fixed `specially` -> `especially` in the frontend style guide
- normalized `MacOS` -> `macOS`, `powershell` -> `PowerShell`, and `Postgresql` -> `PostgreSQL`
- replaced the invalid `localhost:5432` Markdown link with inline code
- fixed the malformed fenced code block for `brew services start redis`
- cleaned up Redis naming/capitalization and a few grammar issues in the setup docs
- improved the warning and environment-variable wording in the Docker Compose guide

## Testing

- not run; docs-only changes
