### PR TITLE
fix: respect standard object rename across all locales (Closes #18650)

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/utils/__tests__/resolve-object-metadata-standard-override.util.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/utils/__tests__/resolve-object-metadata-standard-override.util.spec.ts
@@ -319,7 +319,7 @@ describe('resolveObjectMetadataStandardOverride', () => {
       ).toBe('overridden-icon');
     });
 
-    it('should not use direct override for non-SOURCE_LOCALE', () => {
+    it('should use direct override for non-SOURCE_LOCALE', () => {
       const objectMetadata = {
         labelSingular: 'Standard Label',
         labelPlural: 'Standard Labels',
@@ -332,9 +332,6 @@ describe('resolveObjectMetadataStandardOverride', () => {
         },
       };
 
-      mockGenerateMessageId.mockReturnValue('generated-message-id');
-      mockI18n._.mockReturnValue('generated-message-id');
-
       const result = resolveObjectMetadataStandardOverride(
         objectMetadata,
         'labelSingular',
@@ -342,7 +339,7 @@ describe('resolveObjectMetadataStandardOverride', () => {
         mockI18n,
       );
 
-      expect(result).toBe('Standard Label');
+      expect(result).toBe('Overridden Label');
     });
 
     it('should not use undefined override for SOURCE_LOCALE', () => {

--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/utils/resolve-object-metadata-standard-override.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/utils/resolve-object-metadata-standard-override.util.ts
@@ -45,9 +45,7 @@ export const resolveObjectMetadataStandardOverride = (
     }
   }
 
-  if (
-  isNonEmptyString(objectMetadata.standardOverrides?.[labelKey])
-  ) {
+  if (isNonEmptyString(objectMetadata.standardOverrides?.[labelKey])) {
     return objectMetadata.standardOverrides[labelKey] ?? '';
   }
 

--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/utils/resolve-object-metadata-standard-override.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/utils/resolve-object-metadata-standard-override.util.ts
@@ -46,8 +46,7 @@ export const resolveObjectMetadataStandardOverride = (
   }
 
   if (
-    safeLocale === SOURCE_LOCALE &&
-    isNonEmptyString(objectMetadata.standardOverrides?.[labelKey])
+  isNonEmptyString(objectMetadata.standardOverrides?.[labelKey])
   ) {
     return objectMetadata.standardOverrides[labelKey] ?? '';
   }


### PR DESCRIPTION
## Fix: Standard object rename ignored when UI language is not English (Closes #18650)

### Problem
When a user renames a standard object (for example, changing **"People" → "Contacts"**), the custom name is only respected when the UI language is set to **English**.

For any other locale, the resolver ignores the user-defined override and falls back to the i18n translation of the original default label.

As a result, the custom name defined by the user is not displayed when the UI language changes.

### Root Cause
`resolveObjectMetadataStandardOverride` only applied direct overrides when the locale matched `SOURCE_LOCALE` (English):

```ts
if (
  safeLocale === SOURCE_LOCALE &&
  isNonEmptyString(objectMetadata.standardOverrides?.[labelKey])
) {
  return objectMetadata.standardOverrides[labelKey] ?? '';
}