### PR TITLE
fix: expr-eval related dependabot alerts

### DIFF
--- a/packages/twenty-shared/package.json
+++ b/packages/twenty-shared/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@sniptt/guards": "^0.2.0",
     "class-validator": "^0.14.0",
-    "expr-eval": "^2.0.2",
+    "expr-eval-fork": "3.0.3",
     "handlebars": "^4.7.8",
     "libphonenumber-js": "^1.10.26",
     "lodash.camelcase": "^4.3.0",

--- a/packages/twenty-shared/src/expr-eval-fork.d.ts
+++ b/packages/twenty-shared/src/expr-eval-fork.d.ts
@@ -1,4 +1,4 @@
-declare module 'expr-eval' {
+declare module 'expr-eval-fork' {
   export type Value =
     | number
     | string

--- a/packages/twenty-shared/src/utils/conditional-availability/__tests__/evaluateConditionalAvailabilityExpression.test.ts
+++ b/packages/twenty-shared/src/utils/conditional-availability/__tests__/evaluateConditionalAvailabilityExpression.test.ts
@@ -91,7 +91,7 @@ describe('evaluateConditionalAvailabilityExpression', () => {
       ).toBe(true);
     });
 
-    it('should reject favoriteRecordIds.length (expr-eval parses "length" as unary op)', () => {
+    it('should reject favoriteRecordIds.length (expr-eval-fork parses "length" as unary op)', () => {
       const expression = 'favoriteRecordIds.length < numberOfSelectedRecords';
       const context = buildContext({
         favoriteRecordIds: ['id-1'],

--- a/packages/twenty-shared/src/utils/conditional-availability/evaluateConditionalAvailabilityExpression.ts
+++ b/packages/twenty-shared/src/utils/conditional-availability/evaluateConditionalAvailabilityExpression.ts
@@ -4,7 +4,7 @@ import {
   isObject,
   isString,
 } from '@sniptt/guards';
-import { type EvaluationContext, Parser } from 'expr-eval';
+import { type EvaluationContext, Parser } from 'expr-eval-fork';
 
 import { isDefined } from '../validation/isDefined';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -35953,10 +35953,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expr-eval@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "expr-eval@npm:2.0.2"
-  checksum: 10c0/642f112ff28ea34574c595c3ad73ccd8e638498879a4dd28620c4dabebab2e11987a851266ba81883dae85a5800e0c93b3d06f81718b71a215f831534646e4f2
+"expr-eval-fork@npm:3.0.3":
+  version: 3.0.3
+  resolution: "expr-eval-fork@npm:3.0.3"
+  checksum: 10c0/26655b5e059d404de67ab374008ee03ff94c4b4af13904714404fca7fdfed4a27498032e48e75b5bbe5eac26cbcd360cd999eb9d5bbceb542824d9c588ab44ab
   languageName: node
   linkType: hard
 
@@ -56817,7 +56817,7 @@ __metadata:
     "@types/handlebars": "npm:^4.1.0"
     babel-plugin-module-resolver: "npm:^5.0.2"
     class-validator: "npm:^0.14.0"
-    expr-eval: "npm:^2.0.2"
+    expr-eval-fork: "npm:3.0.3"
     glob: "npm:^11.1.0"
     handlebars: "npm:^4.7.8"
     libphonenumber-js: "npm:^1.10.26"


### PR DESCRIPTION
Resolves [Dependabot Alert 593](https://github.com/twentyhq/twenty/security/dependabot/593) and [Dependabot Alert 594](https://github.com/twentyhq/twenty/security/dependabot/594).

expr-eval was last published six years ago and had changes five years ago. NPM contains a fork that published the changes from five years ago under the same name with `-fork` suffix. This PR uses that fork as suggested by Dependabot.