### PR TITLE
refactor: consolidate database query timeout config variables

### DIFF
--- a/packages/twenty-server/src/database/typeorm/core/core.datasource.ts
+++ b/packages/twenty-server/src/database/typeorm/core/core.datasource.ts
@@ -72,7 +72,7 @@ export const typeORMCoreModuleOptions: TypeOrmModuleOptions = {
         }
       : undefined,
   extra: {
-    query_timeout: Number(process.env.DATABASE_STATEMENT_TIMEOUT_MS ?? 15000),
+    query_timeout: Number(process.env.PG_DATABASE_PRIMARY_TIMEOUT_MS ?? 10000),
   },
 };
 

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
@@ -1685,17 +1685,6 @@ export class ConfigVariables {
   @ConfigVariablesMetadata({
     group: ConfigVariablesGroup.SERVER_CONFIG,
     description:
-      'Client-side query timeout in milliseconds for the core database connection pool. Controls how long any single query can run before the driver aborts it.',
-    type: ConfigVariableType.NUMBER,
-    isEnvOnly: true,
-  })
-  @CastToPositiveNumber()
-  @IsOptional()
-  DATABASE_STATEMENT_TIMEOUT_MS: number = 15000;
-
-  @ConfigVariablesMetadata({
-    group: ConfigVariablesGroup.SERVER_CONFIG,
-    description:
       'Default npm registry URL for resolving app packages (e.g. https://registry.npmjs.org)',
     type: ConfigVariableType.STRING,
   })


### PR DESCRIPTION
## Summary

- Removes the redundant `DATABASE_STATEMENT_TIMEOUT_MS` config variable (default 15s) from `ConfigVariables`
- Updates the core TypeORM datasource to use `PG_DATABASE_PRIMARY_TIMEOUT_MS` (default 10s) for its `query_timeout`, aligning it with the workspace datasource which already uses this variable
- This consolidates two separate env vars that controlled the same concern (database query timeout) into a single one

