### PR TITLE
[FIx]: using the dynamic {objectLabelPlural} instead of hardcoded name

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-attachment-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-attachment-views.util.ts
@@ -15,7 +15,7 @@ export const computeStandardAttachmentViews = (
       objectName: 'attachment',
       context: {
         viewName: 'allAttachments',
-        name: 'All Attachments',
+        name: 'All {objectLabelPlural}',
         type: ViewType.TABLE,
         key: ViewKey.INDEX,
         position: 0,

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-blocklist-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-blocklist-views.util.ts
@@ -15,7 +15,7 @@ export const computeStandardBlocklistViews = (
       objectName: 'blocklist',
       context: {
         viewName: 'allBlocklists',
-        name: 'All Blocklists',
+        name: 'All {objectLabelPlural}',
         type: ViewType.TABLE,
         key: ViewKey.INDEX,
         position: 0,

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-calendar-channel-event-association-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-calendar-channel-event-association-views.util.ts
@@ -18,7 +18,7 @@ export const computeStandardCalendarChannelEventAssociationViews = (
       objectName: 'calendarChannelEventAssociation',
       context: {
         viewName: 'allCalendarChannelEventAssociations',
-        name: 'All Calendar Channel Event Associations',
+        name: 'All {objectLabelPlural}',
         type: ViewType.TABLE,
         key: ViewKey.INDEX,
         position: 0,

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-calendar-channel-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-calendar-channel-views.util.ts
@@ -15,7 +15,7 @@ export const computeStandardCalendarChannelViews = (
       objectName: 'calendarChannel',
       context: {
         viewName: 'allCalendarChannels',
-        name: 'All Calendar Channels',
+        name: 'All {objectLabelPlural}',
         type: ViewType.TABLE,
         key: ViewKey.INDEX,
         position: 0,

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-calendar-event-participant-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-calendar-event-participant-views.util.ts
@@ -15,7 +15,7 @@ export const computeStandardCalendarEventParticipantViews = (
       objectName: 'calendarEventParticipant',
       context: {
         viewName: 'allCalendarEventParticipants',
-        name: 'All Calendar Event Participants',
+        name: 'All {objectLabelPlural}',
         type: ViewType.TABLE,
         key: ViewKey.INDEX,
         position: 0,

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-calendar-event-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-calendar-event-views.util.ts
@@ -15,7 +15,7 @@ export const computeStandardCalendarEventViews = (
       objectName: 'calendarEvent',
       context: {
         viewName: 'allCalendarEvents',
-        name: 'All Calendar Events',
+        name: 'All {objectLabelPlural}',
         type: ViewType.TABLE,
         key: ViewKey.INDEX,
         position: 0,

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-company-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-company-views.util.ts
@@ -16,7 +16,7 @@ export const computeStandardCompanyViews = (
       objectName: 'company',
       context: {
         viewName: 'allCompanies',
-        name: 'All Companies',
+        name: 'All {objectLabelPlural}',
         type: ViewType.TABLE,
         key: ViewKey.INDEX,
         position: 0,

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-connected-account-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-connected-account-views.util.ts
@@ -15,7 +15,7 @@ export const computeStandardConnectedAccountViews = (
       objectName: 'connectedAccount',
       context: {
         viewName: 'allConnectedAccounts',
-        name: 'All Connected Accounts',
+        name: 'All {objectLabelPlural}',
         type: ViewType.TABLE,
         key: ViewKey.INDEX,
         position: 0,

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-dashboard-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-dashboard-views.util.ts
@@ -15,7 +15,7 @@ export const computeStandardDashboardViews = (
       objectName: 'dashboard',
       context: {
         viewName: 'allDashboards',
-        name: 'All Dashboards',
+        name: 'All {objectLabelPlural}',
         type: ViewType.TABLE,
         key: ViewKey.INDEX,
         position: 0,

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-favorite-folder-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-favorite-folder-views.util.ts
@@ -15,7 +15,7 @@ export const computeStandardFavoriteFolderViews = (
       objectName: 'favoriteFolder',
       context: {
         viewName: 'allFavoriteFolders',
-        name: 'All Favorite Folders',
+        name: 'All {objectLabelPlural}',
         type: ViewType.TABLE,
         key: ViewKey.INDEX,
         position: 0,

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-favorite-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-favorite-views.util.ts
@@ -15,7 +15,7 @@ export const computeStandardFavoriteViews = (
       objectName: 'favorite',
       context: {
         viewName: 'allFavorites',
-        name: 'All Favorites',
+        name: 'All {objectLabelPlural}',
         type: ViewType.TABLE,
         key: ViewKey.INDEX,
         position: 0,

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-message-channel-message-association-message-folder-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-message-channel-message-association-message-folder-views.util.ts
@@ -20,7 +20,7 @@ export const computeStandardMessageChannelMessageAssociationMessageFolderViews =
           objectName: 'messageChannelMessageAssociationMessageFolder',
           context: {
             viewName: 'allMessageChannelMessageAssociationMessageFolders',
-            name: 'All Message Channel Message Association Message Folders',
+            name: 'All {objectLabelPlural}',
             type: ViewType.TABLE,
             key: ViewKey.INDEX,
             position: 0,

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-message-channel-message-association-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-message-channel-message-association-views.util.ts
@@ -18,7 +18,7 @@ export const computeStandardMessageChannelMessageAssociationViews = (
       objectName: 'messageChannelMessageAssociation',
       context: {
         viewName: 'allMessageChannelMessageAssociations',
-        name: 'All Message Channel Message Associations',
+        name: 'All {objectLabelPlural}',
         type: ViewType.TABLE,
         key: ViewKey.INDEX,
         position: 0,

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-message-channel-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-message-channel-views.util.ts
@@ -15,7 +15,7 @@ export const computeStandardMessageChannelViews = (
       objectName: 'messageChannel',
       context: {
         viewName: 'allMessageChannels',
-        name: 'All Message Channels',
+        name: 'All {objectLabelPlural}',
         type: ViewType.TABLE,
         key: ViewKey.INDEX,
         position: 0,

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-message-folder-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-message-folder-views.util.ts
@@ -15,7 +15,7 @@ export const computeStandardMessageFolderViews = (
       objectName: 'messageFolder',
       context: {
         viewName: 'allMessageFolders',
-        name: 'All Message Folders',
+        name: 'All {objectLabelPlural}',
         type: ViewType.TABLE,
         key: ViewKey.INDEX,
         position: 0,

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-message-participant-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-message-participant-views.util.ts
@@ -15,7 +15,7 @@ export const computeStandardMessageParticipantViews = (
       objectName: 'messageParticipant',
       context: {
         viewName: 'allMessageParticipants',
-        name: 'All Message Participants',
+        name: 'All {objectLabelPlural}',
         type: ViewType.TABLE,
         key: ViewKey.INDEX,
         position: 0,

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-message-thread-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-message-thread-views.util.ts
@@ -15,7 +15,7 @@ export const computeStandardMessageThreadViews = (
       objectName: 'messageThread',
       context: {
         viewName: 'allMessageThreads',
-        name: 'All Message Threads',
+        name: 'All {objectLabelPlural}',
         type: ViewType.TABLE,
         key: ViewKey.INDEX,
         position: 0,

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-message-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-message-views.util.ts
@@ -15,7 +15,7 @@ export const computeStandardMessageViews = (
       objectName: 'message',
       context: {
         viewName: 'allMessages',
-        name: 'All Messages',
+        name: 'All {objectLabelPlural}',
         type: ViewType.TABLE,
         key: ViewKey.INDEX,
         position: 0,

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-note-target-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-note-target-views.util.ts
@@ -15,7 +15,7 @@ export const computeStandardNoteTargetViews = (
       objectName: 'noteTarget',
       context: {
         viewName: 'allNoteTargets',
-        name: 'All Note Targets',
+        name: 'All {objectLabelPlural}',
         type: ViewType.TABLE,
         key: ViewKey.INDEX,
         position: 0,

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-note-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-note-views.util.ts
@@ -15,7 +15,7 @@ export const computeStandardNoteViews = (
       objectName: 'note',
       context: {
         viewName: 'allNotes',
-        name: 'All Notes',
+        name: 'All {objectLabelPlural}',
         type: ViewType.TABLE,
         key: ViewKey.INDEX,
         position: 0,

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-opportunity-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-opportunity-views.util.ts
@@ -16,7 +16,7 @@ export const computeStandardOpportunityViews = (
       objectName: 'opportunity',
       context: {
         viewName: 'allOpportunities',
-        name: 'All Opportunities',
+        name: 'All {objectLabelPlural}',
         type: ViewType.TABLE,
         key: ViewKey.INDEX,
         position: 0,

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-person-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-person-views.util.ts
@@ -15,7 +15,7 @@ export const computeStandardPersonViews = (
       objectName: 'person',
       context: {
         viewName: 'allPeople',
-        name: 'All People',
+        name: 'All {objectLabelPlural}',
         type: ViewType.TABLE,
         key: ViewKey.INDEX,
         position: 0,

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-task-target-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-task-target-views.util.ts
@@ -15,7 +15,7 @@ export const computeStandardTaskTargetViews = (
       objectName: 'taskTarget',
       context: {
         viewName: 'allTaskTargets',
-        name: 'All Task Targets',
+        name: 'All {objectLabelPlural}',
         type: ViewType.TABLE,
         key: ViewKey.INDEX,
         position: 0,

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-task-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-task-views.util.ts
@@ -16,7 +16,7 @@ export const computeStandardTaskViews = (
       objectName: 'task',
       context: {
         viewName: 'allTasks',
-        name: 'All Tasks',
+        name: 'All {objectLabelPlural}',
         type: ViewType.TABLE,
         key: ViewKey.INDEX,
         position: 0,

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-timeline-activity-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-timeline-activity-views.util.ts
@@ -16,7 +16,7 @@ export const computeStandardTimelineActivityViews = (
       objectName: 'timelineActivity',
       context: {
         viewName: 'allTimelineActivities',
-        name: 'All Timeline Activities',
+        name: 'All {objectLabelPlural}',
         type: ViewType.TABLE,
         key: ViewKey.INDEX,
         position: 0,

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-workflow-automated-trigger-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-workflow-automated-trigger-views.util.ts
@@ -15,7 +15,7 @@ export const computeStandardWorkflowAutomatedTriggerViews = (
       objectName: 'workflowAutomatedTrigger',
       context: {
         viewName: 'allWorkflowAutomatedTriggers',
-        name: 'All Workflow Automated Triggers',
+        name: 'All {objectLabelPlural}',
         type: ViewType.TABLE,
         key: ViewKey.INDEX,
         position: 0,

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-workflow-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-workflow-views.util.ts
@@ -16,7 +16,7 @@ export const computeStandardWorkflowViews = (
       objectName: 'workflow',
       context: {
         viewName: 'allWorkflows',
-        name: 'All Workflows',
+        name: 'All {objectLabelPlural}',
         type: ViewType.TABLE,
         key: ViewKey.INDEX,
         position: 0,

--- a/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-workspace-member-views.util.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/twenty-standard-application/utils/view/compute-standard-workspace-member-views.util.ts
@@ -16,7 +16,7 @@ export const computeStandardWorkspaceMemberViews = (
       objectName: 'workspaceMember',
       context: {
         viewName: 'allWorkspaceMembers',
-        name: 'All Workspace Members',
+        name: 'All {objectLabelPlural}',
         type: ViewType.TABLE,
         key: ViewKey.INDEX,
         position: 0,


### PR DESCRIPTION
Fixes #18607 

So previously i followed the frontend approach which led to architectural mismatch.


- We already have the correct things implemented in the `processViewNameWithTemplate` and in object metadata service. Found that the seeder files had the hardcoded names instead of {objectLabelPlural}. So changed all the hardcoded string to contain {objectLabelPlural} to seed the new workspaces accurately.



- it will have a follow up PR for typeORM migration to migrate the existing workspaces




https://github.com/user-attachments/assets/3b460f9f-c59d-49d1-8baa-17322d696ecc



I hope i am correct this time :)
