### PR TITLE
fix: add Windows platform compatibility for local development

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "@yarnpkg/types": "^4.0.0",
     "chromatic": "^6.18.0",
     "concurrently": "^8.2.2",
+    "cross-env": "^10.1.0",
     "danger": "^13.0.4",
     "dotenv-cli": "^7.4.4",
     "esbuild": "^0.25.10",

--- a/packages/twenty-sdk/vite.config.sdk.ts
+++ b/packages/twenty-sdk/vite.config.sdk.ts
@@ -11,6 +11,16 @@ const isExternal = (id: string): boolean => {
     return false;
   }
 
+  // Workspace packages must be bundled, not externalized
+  if (id.startsWith('twenty-shared') || id.startsWith('twenty-ui')) {
+    return false;
+  }
+
+  // On Windows, absolute paths with drive letters (e.g. D:\...) should not be external
+  if (/^[a-zA-Z]:/.test(id)) {
+    return false;
+  }
+
   return true;
 };
 

--- a/packages/twenty-server/project.json
+++ b/packages/twenty-server/project.json
@@ -50,14 +50,14 @@
       "dependsOn": ["^build"],
       "options": {
         "cwd": "packages/twenty-server",
-        "command": "rimraf dist && NODE_ENV=development nest start --watch"
+        "command": "rimraf dist && cross-env NODE_ENV=development nest start --watch"
       }
     },
     "start:ci": {
       "executor": "nx:run-commands",
       "options": {
         "cwd": "packages/twenty-server",
-        "command": "NODE_ENV=development nest start"
+        "command": "cross-env NODE_ENV=development nest start"
       }
     },
     "start:ci-if-needed": {
@@ -73,7 +73,7 @@
       "dependsOn": ["^build"],
       "options": {
         "cwd": "packages/twenty-server",
-        "command": "rimraf dist && NODE_ENV=development nest start --watch --debug"
+        "command": "rimraf dist && cross-env NODE_ENV=development nest start --watch --debug"
       }
     },
     "reset:env": {

--- a/packages/twenty-server/project.json
+++ b/packages/twenty-server/project.json
@@ -19,7 +19,7 @@
       "options": {
         "cwd": "packages/twenty-server",
         "commands": [
-          "NODE_ENV=test NODE_OPTIONS=\"--max-old-space-size=12288 --import tsx/esm\" nx jest --config ./jest-integration.config.ts"
+          "cross-env NODE_ENV=test NODE_OPTIONS=\"--max-old-space-size=12288 --import tsx/esm\" nx jest --config ./jest-integration.config.ts"
         ]
       },
       "parallel": false,
@@ -27,7 +27,7 @@
         "with-db-reset": {
           "cwd": "packages/twenty-server",
           "commands": [
-            "NODE_ENV=test NODE_OPTIONS=\"--max-old-space-size=12288 --import tsx/esm\" nx database:reset > reset-logs.log && NODE_ENV=test NODE_OPTIONS=\"--max-old-space-size=12288 --import tsx/esm\" nx jest --config ./jest-integration.config.ts"
+            "cross-env NODE_ENV=test NODE_OPTIONS=\"--max-old-space-size=12288 --import tsx/esm\" nx database:reset > reset-logs.log && cross-env NODE_ENV=test NODE_OPTIONS=\"--max-old-space-size=12288 --import tsx/esm\" nx jest --config ./jest-integration.config.ts"
           ]
         }
       }

--- a/packages/twenty-server/src/constants/assets-path.ts
+++ b/packages/twenty-server/src/constants/assets-path.ts
@@ -1,8 +1,10 @@
 import path from 'path';
 
 // If the code is built through the testing module, assets are not output to the dist/assets directory.
-const IS_BUILT_THROUGH_TESTING_MODULE =
-  !__dirname.includes('/dist/') && !__dirname.includes('\\dist\\');
+const normalizedDir = path.normalize(__dirname);
+const IS_BUILT_THROUGH_TESTING_MODULE = !normalizedDir.includes(
+  `${path.sep}dist${path.sep}`,
+);
 
 export const ASSET_PATH = IS_BUILT_THROUGH_TESTING_MODULE
   ? path.resolve(__dirname, `../`)

--- a/packages/twenty-server/src/constants/assets-path.ts
+++ b/packages/twenty-server/src/constants/assets-path.ts
@@ -1,7 +1,8 @@
 import path from 'path';
 
 // If the code is built through the testing module, assets are not output to the dist/assets directory.
-const IS_BUILT_THROUGH_TESTING_MODULE = !__dirname.includes('/dist/');
+const IS_BUILT_THROUGH_TESTING_MODULE =
+  !__dirname.includes('/dist/') && !__dirname.includes('\\dist\\');
 
 export const ASSET_PATH = IS_BUILT_THROUGH_TESTING_MODULE
   ? path.resolve(__dirname, `../`)

--- a/yarn.lock
+++ b/yarn.lock
@@ -4593,6 +4593,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@epic-web/invariant@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@epic-web/invariant@npm:1.0.0"
+  checksum: 10c0/72dbeb026e4e4eb3bc9c65739b91408ca77ab7d603a2494fa2eff3790ec22892c4caba751cffdf30f5ccf0e7ba79c1e9c96cf0a357404b9432bf1365baac23ca
+  languageName: node
+  linkType: hard
+
 "@esbuild-kit/core-utils@npm:^3.3.2":
   version: 3.3.2
   resolution: "@esbuild-kit/core-utils@npm:3.3.2"
@@ -32467,6 +32474,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cross-env@npm:^10.1.0":
+  version: 10.1.0
+  resolution: "cross-env@npm:10.1.0"
+  dependencies:
+    "@epic-web/invariant": "npm:^1.0.0"
+    cross-spawn: "npm:^7.0.6"
+  bin:
+    cross-env: dist/bin/cross-env.js
+    cross-env-shell: dist/bin/cross-env-shell.js
+  checksum: 10c0/834a862db456ba1fedf6c6da43436b123ae38f514fa286d6f0937c14fa83f13469f77f70f2812db041ae2d84f82bac627040b8686030aca27fbdf113dfa38b63
+  languageName: node
+  linkType: hard
+
 "cross-fetch@npm:4.1.0":
   version: 4.1.0
   resolution: "cross-fetch@npm:4.1.0"
@@ -57029,6 +57049,7 @@ __metadata:
     archiver: "npm:^7.0.1"
     chromatic: "npm:^6.18.0"
     concurrently: "npm:^8.2.2"
+    cross-env: "npm:^10.1.0"
     danger: "npm:^13.0.4"
     danger-plugin-todos: "npm:^1.3.1"
     date-fns: "npm:^2.30.0"


### PR DESCRIPTION
## Summary
Fixes cross-platform compatibility issues that prevent Twenty from building and running on Windows environments.

Closes #18470

## Changes

### 1. Fix asset path resolution on Windows ([assets-path.ts](cci:7://file:///d:/rocket_chat/twenty/packages/twenty-server/src/constants/assets-path.ts:0:0-0:0))
The `IS_BUILT_THROUGH_TESTING_MODULE` check only looked for `/dist/` (Unix paths). On Windows, `__dirname` uses backslashes (`D:\...\dist\...`), so the check always returned `true`, causing ENOENT errors during signup when the server couldn't find seed dependency files.

### 2. Fix SDK build externalization on Windows ([vite.config.sdk.ts](cci:7://file:///d:/rocket_chat/twenty/packages/twenty-sdk/vite.config.sdk.ts:0:0-0:0))
The [isExternal](cci:1://file:///d:/rocket_chat/twenty/packages/twenty-sdk/vite.config.sdk.ts:4:0-24:2) function didn't account for:
- Windows absolute paths (e.g., `D:\...`) being passed as module IDs by Rollup
- Workspace packages (`twenty-shared`, `twenty-ui`) needing to be bundled

This caused "Entry module cannot be external" build failures.

### 3. Use cross-env for NODE_ENV in server commands (`project.json`)
PowerShell/CMD doesn't support `VAR=value command` inline syntax. Using `cross-env` makes environment variable setting cross-platform.

## Testing
- [x] Backend builds and starts successfully on Windows
- [x] Frontend builds and starts successfully on Windows
- [x] User signup works without ENOENT errors
- [x] Health check returns 200 OK at localhost:3000/healthz
- [x] Frontend loads correctly at localhost:3001