### PR TITLE
fix: preserve URL encoding in lowercaseUrlOriginAndRemoveTrailingSlash

### DIFF
--- a/packages/twenty-shared/src/utils/url/__tests__/lowercaseUrlOriginAndRemoveTrailingSlash.test.ts
+++ b/packages/twenty-shared/src/utils/url/__tests__/lowercaseUrlOriginAndRemoveTrailingSlash.test.ts
@@ -44,9 +44,9 @@ describe('lowercaseUrlOriginAndRemoveTrailingSlash', () => {
       expected: 'https://test.test/edouard-ménard-22219837',
     },
     {
-      title: 'should decode already encoded special characters in path',
+      title: 'should keep already encoded special characters in path',
       input: 'https://test.test/edouard-m%C3%A9nard-22219837',
-      expected: 'https://test.test/edouard-ménard-22219837',
+      expected: 'https://test.test/edouard-m%C3%A9nard-22219837',
     },
     {
       title: 'should preserve special characters in query params',
@@ -63,12 +63,12 @@ describe('lowercaseUrlOriginAndRemoveTrailingSlash', () => {
       title:
         'should preserve double-encoded URLs (encoded percent signs stay encoded once)',
       input: 'https://example.com/test%2520name',
-      expected: 'https://example.com/test%20name',
+      expected: 'https://example.com/test%2520name',
     },
     {
       title: 'should preserve special characters in hash fragments',
       input: 'https://example.com/path#frédéric',
-      expected: 'https://example.com/path#fr%C3%A9d%C3%A9ric',
+      expected: 'https://example.com/path#frédéric',
     },
     {
       title: 'should keep encoded characters in hash fragments as-is',
@@ -78,7 +78,7 @@ describe('lowercaseUrlOriginAndRemoveTrailingSlash', () => {
     {
       title: 'should handle mixed encoded and non-encoded in same URL',
       input: 'https://example.com/path%2Fwith%2Fslashes?query=hello%20world',
-      expected: 'https://example.com/path/with/slashes?query=hello world',
+      expected: 'https://example.com/path%2Fwith%2Fslashes?query=hello%20world',
     },
   ])('$title', ({ input, expected }) => {
     expect(lowercaseUrlOriginAndRemoveTrailingSlash(input)).toBe(expected);

--- a/packages/twenty-shared/src/utils/url/lowercaseUrlOriginAndRemoveTrailingSlash.ts
+++ b/packages/twenty-shared/src/utils/url/lowercaseUrlOriginAndRemoveTrailingSlash.ts
@@ -1,6 +1,5 @@
 import { getURLSafely } from '@/utils/getURLSafely';
 import { isDefined } from '@/utils/validation';
-import { safeDecodeURIComponent } from './safeDecodeURIComponent';
 
 export const lowercaseUrlOriginAndRemoveTrailingSlash = (rawUrl: string) => {
   const url = getURLSafely(rawUrl);
@@ -10,10 +9,22 @@ export const lowercaseUrlOriginAndRemoveTrailingSlash = (rawUrl: string) => {
   }
 
   const lowercaseOrigin = url.origin.toLowerCase();
-  const path =
-    safeDecodeURIComponent(url.pathname) +
-    safeDecodeURIComponent(url.search) +
-    url.hash;
+  
+  const protocolIndex = rawUrl.indexOf('://');
+  if (protocolIndex === -1) {
+    return rawUrl;
+  }
+  
+  let endOfHost = rawUrl.length;
+  const pathStartIndex = rawUrl.indexOf('/', protocolIndex + 3);
+  const queryStartIndex = rawUrl.indexOf('?', protocolIndex + 3);
+  const hashStartIndex = rawUrl.indexOf('#', protocolIndex + 3);
+  
+  if (pathStartIndex !== -1) endOfHost = Math.min(endOfHost, pathStartIndex);
+  if (queryStartIndex !== -1) endOfHost = Math.min(endOfHost, queryStartIndex);
+  if (hashStartIndex !== -1) endOfHost = Math.min(endOfHost, hashStartIndex);
 
-  return (lowercaseOrigin + path).replace(/\/$/, '');
+  const rawPath = rawUrl.substring(endOfHost);
+
+  return (lowercaseOrigin + rawPath).replace(/\/$/, '');
 };


### PR DESCRIPTION
Closes #18698

## Summary
Fixes a URL encoding bug that breaks Google Maps links and other URLs containing percent-encoded characters (e.g., `%2F`, `%20`, `%2520`).

## Root Cause
[lowercaseUrlOriginAndRemoveTrailingSlash](cci:1://file:///d:/rocket_chat/twenty/packages/twenty-shared/src/utils/url/lowercaseUrlOriginAndRemoveTrailingSlash.ts:3:0-29:2) was using [safeDecodeURIComponent()](cci:1://file:///d:/rocket_chat/twenty/packages/twenty-shared/src/utils/url/safeDecodeURIComponent.ts:0:0-6:2) on `url.pathname` and `url.search`, which decoded `%2F` → `/`, `%20` → ` `, etc. This changed the meaning of URLs like Google Maps links where encoding is significant.

## Fix
Extract the path, query, and hash directly from the raw URL string instead of using the URL API's parsed (and auto-decoded) components. This preserves all percent-encoding exactly as the user provided it.

## Testing
- All 14 existing + updated unit tests pass
- Updated test expectations to verify encoding is preserved, not decoded
