### PR TITLE
fix: preserve URL encoding in lowercaseUrlOriginAndRemoveTrailingSlash

### DIFF
--- a/packages/twenty-shared/src/utils/url/__tests__/lowercaseUrlOriginAndRemoveTrailingSlash.test.ts
+++ b/packages/twenty-shared/src/utils/url/__tests__/lowercaseUrlOriginAndRemoveTrailingSlash.test.ts
@@ -44,9 +44,9 @@ describe('lowercaseUrlOriginAndRemoveTrailingSlash', () => {
       expected: 'https://test.test/edouard-ménard-22219837',
     },
     {
-      title: 'should decode already encoded special characters in path',
+      title: 'should keep already encoded special characters in path',
       input: 'https://test.test/edouard-m%C3%A9nard-22219837',
-      expected: 'https://test.test/edouard-ménard-22219837',
+      expected: 'https://test.test/edouard-m%C3%A9nard-22219837',
     },
     {
       title: 'should preserve special characters in query params',
@@ -61,14 +61,14 @@ describe('lowercaseUrlOriginAndRemoveTrailingSlash', () => {
     },
     {
       title:
-        'should preserve double-encoded URLs (encoded percent signs stay encoded once)',
+        'should preserve double-encoded URLs (preserve encoded percent signs as-is)',
       input: 'https://example.com/test%2520name',
-      expected: 'https://example.com/test%20name',
+      expected: 'https://example.com/test%2520name',
     },
     {
       title: 'should preserve special characters in hash fragments',
       input: 'https://example.com/path#frédéric',
-      expected: 'https://example.com/path#fr%C3%A9d%C3%A9ric',
+      expected: 'https://example.com/path#frédéric',
     },
     {
       title: 'should keep encoded characters in hash fragments as-is',
@@ -78,7 +78,7 @@ describe('lowercaseUrlOriginAndRemoveTrailingSlash', () => {
     {
       title: 'should handle mixed encoded and non-encoded in same URL',
       input: 'https://example.com/path%2Fwith%2Fslashes?query=hello%20world',
-      expected: 'https://example.com/path/with/slashes?query=hello world',
+      expected: 'https://example.com/path%2Fwith%2Fslashes?query=hello%20world',
     },
   ])('$title', ({ input, expected }) => {
     expect(lowercaseUrlOriginAndRemoveTrailingSlash(input)).toBe(expected);

--- a/packages/twenty-shared/src/utils/url/__tests__/lowercaseUrlOriginAndRemoveTrailingSlash.test.ts
+++ b/packages/twenty-shared/src/utils/url/__tests__/lowercaseUrlOriginAndRemoveTrailingSlash.test.ts
@@ -80,6 +80,21 @@ describe('lowercaseUrlOriginAndRemoveTrailingSlash', () => {
       input: 'https://example.com/path%2Fwith%2Fslashes?query=hello%20world',
       expected: 'https://example.com/path%2Fwith%2Fslashes?query=hello%20world',
     },
+    {
+      title: 'should return non-HTTP(S) URLs unmodified',
+      input: 'data:text/html,<h1>Hello</h1>',
+      expected: 'data:text/html,<h1>Hello</h1>',
+    },
+    {
+      title: 'should preserve encoding in query-only URL without path',
+      input: 'https://example.com?x=%2F',
+      expected: 'https://example.com?x=%2F',
+    },
+    {
+      title: 'should preserve encoding in hash-only URL without path',
+      input: 'https://example.com#frag%20ment',
+      expected: 'https://example.com#frag%20ment',
+    },
   ])('$title', ({ input, expected }) => {
     expect(lowercaseUrlOriginAndRemoveTrailingSlash(input)).toBe(expected);
   });

--- a/packages/twenty-shared/src/utils/url/__tests__/lowercaseUrlOriginAndRemoveTrailingSlash.test.ts
+++ b/packages/twenty-shared/src/utils/url/__tests__/lowercaseUrlOriginAndRemoveTrailingSlash.test.ts
@@ -95,6 +95,16 @@ describe('lowercaseUrlOriginAndRemoveTrailingSlash', () => {
       input: 'https://example.com#frag%20ment',
       expected: 'https://example.com#frag%20ment',
     },
+    {
+      title: 'should preserve backslash-separated paths',
+      input: 'https://example.com\\foo\\bar',
+      expected: 'https://example.com\\foo\\bar',
+    },
+    {
+      title: 'should return blob: URLs unmodified',
+      input: 'blob:https://example.com/abc-123',
+      expected: 'blob:https://example.com/abc-123',
+    },
   ])('$title', ({ input, expected }) => {
     expect(lowercaseUrlOriginAndRemoveTrailingSlash(input)).toBe(expected);
   });

--- a/packages/twenty-shared/src/utils/url/__tests__/lowercaseUrlOriginAndRemoveTrailingSlash.test.ts
+++ b/packages/twenty-shared/src/utils/url/__tests__/lowercaseUrlOriginAndRemoveTrailingSlash.test.ts
@@ -81,7 +81,7 @@ describe('lowercaseUrlOriginAndRemoveTrailingSlash', () => {
       expected: 'https://example.com/path%2Fwith%2Fslashes?query=hello%20world',
     },
     {
-      title: 'should return non-HTTP(S) URLs unmodified',
+      title: 'should return URLs with opaque origins (e.g. data:) unmodified',
       input: 'data:text/html,<h1>Hello</h1>',
       expected: 'data:text/html,<h1>Hello</h1>',
     },

--- a/packages/twenty-shared/src/utils/url/lowercaseUrlOriginAndRemoveTrailingSlash.ts
+++ b/packages/twenty-shared/src/utils/url/lowercaseUrlOriginAndRemoveTrailingSlash.ts
@@ -15,8 +15,8 @@ export const lowercaseUrlOriginAndRemoveTrailingSlash = (rawUrl: string) => {
     return rawUrl;
   }
 
-  // Only process HTTP(S) URLs. For other schemes (e.g., blob:, file:, data:),
-  // return the original URL to avoid stripping the scheme or rewriting it.
+  // Only process HTTP(S) URLs. Other non-opaque schemes (e.g., blob:, ftp:)
+  // could have a valid origin but different URL structure, so return unmodified.
   if (url.protocol !== 'http:' && url.protocol !== 'https:') {
     return rawUrl;
   }
@@ -29,7 +29,14 @@ export const lowercaseUrlOriginAndRemoveTrailingSlash = (rawUrl: string) => {
   }
 
   let endOfHost = rawUrl.length;
-  const pathStartIndex = rawUrl.indexOf('/', protocolIndex + 3);
+  const forwardSlashIndex = rawUrl.indexOf('/', protocolIndex + 3);
+  const backslashIndex = rawUrl.indexOf('\\', protocolIndex + 3);
+  const pathStartIndex =
+    forwardSlashIndex === -1
+      ? backslashIndex
+      : backslashIndex === -1
+        ? forwardSlashIndex
+        : Math.min(forwardSlashIndex, backslashIndex);
   const queryStartIndex = rawUrl.indexOf('?', protocolIndex + 3);
   const hashStartIndex = rawUrl.indexOf('#', protocolIndex + 3);
 

--- a/packages/twenty-shared/src/utils/url/lowercaseUrlOriginAndRemoveTrailingSlash.ts
+++ b/packages/twenty-shared/src/utils/url/lowercaseUrlOriginAndRemoveTrailingSlash.ts
@@ -10,9 +10,9 @@ export const lowercaseUrlOriginAndRemoveTrailingSlash = (rawUrl: string) => {
 
   // Only HTTP(S) URLs have a meaningful origin for this transformation.
   // For other protocols (e.g., file:, data:), return the original URL
-  // with any trailing slash removed to avoid generating "null/..." URLs.
+  // unmodified to avoid generating "null/..." URLs or changing opaque URI semantics.
   if (url.protocol !== 'http:' && url.protocol !== 'https:') {
-    return rawUrl.replace(/\/$/, '');
+    return rawUrl;
   }
 
   const lowercaseOrigin = url.origin.toLowerCase();

--- a/packages/twenty-shared/src/utils/url/lowercaseUrlOriginAndRemoveTrailingSlash.ts
+++ b/packages/twenty-shared/src/utils/url/lowercaseUrlOriginAndRemoveTrailingSlash.ts
@@ -8,10 +8,10 @@ export const lowercaseUrlOriginAndRemoveTrailingSlash = (rawUrl: string) => {
     return rawUrl;
   }
 
-  // Only HTTP(S) URLs have a meaningful origin for this transformation.
-  // For other protocols (e.g., file:, data:), return the original URL
-  // unmodified to avoid generating "null/..." URLs or changing opaque URI semantics.
-  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+  // Skip URLs with opaque origins (e.g., file:, data:, mailto:), which have
+  // url.origin === "null". For these, return the original URL unmodified to
+  // avoid generating "null/..." URLs or changing opaque URI semantics.
+  if (url.origin === 'null') {
     return rawUrl;
   }
 

--- a/packages/twenty-shared/src/utils/url/lowercaseUrlOriginAndRemoveTrailingSlash.ts
+++ b/packages/twenty-shared/src/utils/url/lowercaseUrlOriginAndRemoveTrailingSlash.ts
@@ -1,6 +1,5 @@
 import { getURLSafely } from '@/utils/getURLSafely';
 import { isDefined } from '@/utils/validation';
-import { safeDecodeURIComponent } from './safeDecodeURIComponent';
 
 export const lowercaseUrlOriginAndRemoveTrailingSlash = (rawUrl: string) => {
   const url = getURLSafely(rawUrl);
@@ -9,11 +8,30 @@ export const lowercaseUrlOriginAndRemoveTrailingSlash = (rawUrl: string) => {
     return rawUrl;
   }
 
-  const lowercaseOrigin = url.origin.toLowerCase();
-  const path =
-    safeDecodeURIComponent(url.pathname) +
-    safeDecodeURIComponent(url.search) +
-    url.hash;
+  // Only HTTP(S) URLs have a meaningful origin for this transformation.
+  // For other protocols (e.g., file:, data:), return the original URL
+  // with any trailing slash removed to avoid generating "null/..." URLs.
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    return rawUrl.replace(/\/$/, '');
+  }
 
-  return (lowercaseOrigin + path).replace(/\/$/, '');
+  const lowercaseOrigin = url.origin.toLowerCase();
+
+  const protocolIndex = rawUrl.indexOf('://');
+  if (protocolIndex === -1) {
+    return rawUrl;
+  }
+
+  let endOfHost = rawUrl.length;
+  const pathStartIndex = rawUrl.indexOf('/', protocolIndex + 3);
+  const queryStartIndex = rawUrl.indexOf('?', protocolIndex + 3);
+  const hashStartIndex = rawUrl.indexOf('#', protocolIndex + 3);
+
+  if (pathStartIndex !== -1) endOfHost = Math.min(endOfHost, pathStartIndex);
+  if (queryStartIndex !== -1) endOfHost = Math.min(endOfHost, queryStartIndex);
+  if (hashStartIndex !== -1) endOfHost = Math.min(endOfHost, hashStartIndex);
+
+  const rawSuffix = rawUrl.substring(endOfHost);
+
+  return (lowercaseOrigin + rawSuffix).replace(/\/$/, '');
 };

--- a/packages/twenty-shared/src/utils/url/lowercaseUrlOriginAndRemoveTrailingSlash.ts
+++ b/packages/twenty-shared/src/utils/url/lowercaseUrlOriginAndRemoveTrailingSlash.ts
@@ -15,6 +15,12 @@ export const lowercaseUrlOriginAndRemoveTrailingSlash = (rawUrl: string) => {
     return rawUrl;
   }
 
+  // Only process HTTP(S) URLs. For other schemes (e.g., blob:, file:, data:),
+  // return the original URL to avoid stripping the scheme or rewriting it.
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    return rawUrl;
+  }
+
   const lowercaseOrigin = url.origin.toLowerCase();
 
   const protocolIndex = rawUrl.indexOf('://');


### PR DESCRIPTION
Closes #18698

## Context
My earlier PR for this issue was closed as it didn't meet quality standards — I've addressed that feedback and am resubmitting a cleaner version with all lint, formatting, and edge cases resolved.

## Problem
[lowercaseUrlOriginAndRemoveTrailingSlash](cci:1://file:///d:/rocket_chat/twenty/packages/twenty-shared/src/utils/url/lowercaseUrlOriginAndRemoveTrailingSlash.ts:3:0-36:2) uses [safeDecodeURIComponent()](cci:1://file:///d:/rocket_chat/twenty/packages/twenty-shared/src/utils/url/safeDecodeURIComponent.ts:0:0-6:2) on `url.pathname` and `url.search`, which decodes percent-encoded characters like `%2F` → `/`. This breaks Google Maps links and other URLs where encoding is significant.

**Example:**
- ✅ Original: `...!16s%2Fg%2F1ptwh8096...`
- ❌ After save: `...!16s/g/1ptwh8096...` (broken link)

## Fix
- Extract path/query/hash directly from the raw URL string instead of using the URL API's parsed (and auto-decoded) components
- Guard against non-HTTP(S) protocols (e.g., `file:`, `data:`) where `url.origin` returns `'null'`
- Remove the unused [safeDecodeURIComponent](cci:1://file:///d:/rocket_chat/twenty/packages/twenty-shared/src/utils/url/safeDecodeURIComponent.ts:0:0-6:2) import

## Testing
- All 14 unit tests pass
- Lint and Prettier formatting pass
- Updated test expectations to verify encoding is preserved, not decoded
