### PR TITLE
Skip threads with no participants in timeline formatting

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/messaging/utils/format-threads.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/messaging/utils/format-threads.util.ts
@@ -1,4 +1,5 @@
 import { FIELD_RESTRICTED_ADDITIONAL_PERMISSIONS_REQUIRED } from 'twenty-shared/constants';
+import { isDefined } from 'twenty-shared/utils';
 
 import { type TimelineThreadDTO } from 'src/engine/core-modules/messaging/dtos/timeline-thread.dto';
 import { extractParticipantSummary } from 'src/engine/core-modules/messaging/utils/extract-participant-summary.util';
@@ -21,23 +22,25 @@ export const formatThreads = (
     [key: string]: MessageChannelVisibility;
   },
 ): TimelineThreadDTO[] => {
-  return threads.map((thread) => {
-    const visibility = threadVisibilityByThreadId[thread.id];
+  return threads
+    .filter((thread) => isDefined(threadParticipantsByThreadId[thread.id]))
+    .map((thread) => {
+      const visibility = threadVisibilityByThreadId[thread.id];
 
-    return {
-      ...thread,
-      subject:
-        visibility === MessageChannelVisibility.SHARE_EVERYTHING ||
-        visibility === MessageChannelVisibility.SUBJECT
-          ? thread.subject
-          : FIELD_RESTRICTED_ADDITIONAL_PERMISSIONS_REQUIRED,
-      lastMessageBody:
-        visibility === MessageChannelVisibility.SHARE_EVERYTHING
-          ? thread.lastMessageBody
-          : FIELD_RESTRICTED_ADDITIONAL_PERMISSIONS_REQUIRED,
-      ...extractParticipantSummary(threadParticipantsByThreadId[thread.id]),
-      visibility,
-      read: true,
-    };
-  });
+      return {
+        ...thread,
+        subject:
+          visibility === MessageChannelVisibility.SHARE_EVERYTHING ||
+          visibility === MessageChannelVisibility.SUBJECT
+            ? thread.subject
+            : FIELD_RESTRICTED_ADDITIONAL_PERMISSIONS_REQUIRED,
+        lastMessageBody:
+          visibility === MessageChannelVisibility.SHARE_EVERYTHING
+            ? thread.lastMessageBody
+            : FIELD_RESTRICTED_ADDITIONAL_PERMISSIONS_REQUIRED,
+        ...extractParticipantSummary(threadParticipantsByThreadId[thread.id]),
+        visibility,
+        read: true,
+      };
+    });
 };

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/microsoft/utils/parse-microsoft-messages-import.util.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/microsoft/utils/parse-microsoft-messages-import.util.ts
@@ -12,6 +12,14 @@ export const parseMicrosoftMessagesImportError = (
   options?: { cause?: Error },
 ): MessageImportDriverException => {
   if (error.statusCode === 400) {
+    if (!error.message) {
+      return new MessageImportDriverException(
+        `Microsoft Graph API returned 400 with empty error body`,
+        MessageImportDriverExceptionCode.TEMPORARY_ERROR,
+        { cause: options?.cause },
+      );
+    }
+
     return new MessageImportDriverException(
       `Invalid request to Microsoft Graph API: ${error.message}`,
       MessageImportDriverExceptionCode.UNKNOWN,

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/microsoft/utils/parse-microsoft-messages-import.util.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/microsoft/utils/parse-microsoft-messages-import.util.ts
@@ -12,14 +12,6 @@ export const parseMicrosoftMessagesImportError = (
   options?: { cause?: Error },
 ): MessageImportDriverException => {
   if (error.statusCode === 400) {
-    if (!error.message) {
-      return new MessageImportDriverException(
-        `Microsoft Graph API returned 400 with empty error body`,
-        MessageImportDriverExceptionCode.TEMPORARY_ERROR,
-        { cause: options?.cause },
-      );
-    }
-
     return new MessageImportDriverException(
       `Invalid request to Microsoft Graph API: ${error.message}`,
       MessageImportDriverExceptionCode.UNKNOWN,


### PR DESCRIPTION
Threads with no FROM participants have no entry in the participants map, causing extractParticipantSummary to receive undefined and crash

Fixes TWENTY-SERVER-FB8