### PR TITLE
Treat Microsoft Graph 400 with empty body as transient error

### DIFF
--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/microsoft/utils/parse-microsoft-messages-import.util.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/microsoft/utils/parse-microsoft-messages-import.util.ts
@@ -2,6 +2,7 @@ import {
   MessageImportDriverException,
   MessageImportDriverExceptionCode,
 } from 'src/modules/messaging/message-import-manager/drivers/exceptions/message-import-driver.exception';
+import { isDefined } from 'twenty-shared/utils';
 
 export const parseMicrosoftMessagesImportError = (
   error: {
@@ -12,6 +13,14 @@ export const parseMicrosoftMessagesImportError = (
   options?: { cause?: Error },
 ): MessageImportDriverException => {
   if (error.statusCode === 400) {
+    if (!isDefined(error.message)) {
+      return new MessageImportDriverException(
+        `Microsoft Graph API returned 400 with empty error body`,
+        MessageImportDriverExceptionCode.TEMPORARY_ERROR,
+        { cause: options?.cause },
+      );
+    }
+
     return new MessageImportDriverException(
       `Invalid request to Microsoft Graph API: ${error.message}`,
       MessageImportDriverExceptionCode.UNKNOWN,


### PR DESCRIPTION
Graph SDK occasionally returns a 400 with a null error message which is not a real bad request but a transient hiccup. 
Classify these as temporary errors so they get retried instead of flooding Sentry.

Fixes TWENTY-SERVER-D3X