### PR TITLE
fix: use unique concurrency group per merge queue entry

### DIFF
--- a/.github/workflows/ci-merge-queue.yaml
+++ b/.github/workflows/ci-merge-queue.yaml
@@ -10,8 +10,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'merge_group' && github.event.merge_group.base_ref || github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   e2e-test:


### PR DESCRIPTION
## Summary

- Fixes merge queue PRs blocking each other by changing the concurrency group in `ci-merge-queue.yaml`
- The old concurrency group used `merge_group.base_ref` which resolves to `refs/heads/main` for every PR, causing all merge queue entries to serialize behind a single concurrency slot
- Now uses `github.ref` (unique per entry: `refs/heads/gh-readonly-queue/main/pr-NUMBER-SHA`), matching what all other CI workflows already do

## Recommended ruleset changes (in GitHub Settings > Rules > Rulesets > "CI Status Checks")

- **Grouping strategy**: Switch `ALLGREEN` to `NONE` -- each PR is still tested against the correct base (including all PRs ahead of it in the queue), but failures only affect the failing PR instead of ejecting the entire group. `max_entries_to_build: 5` still allows parallel speculative testing.
- **`min_entries_to_merge_wait_minutes`**: Reduce from 5 to 1 -- the 5-minute wait adds unnecessary latency to every merge.

## Test plan

- [ ] Enqueue 2+ PRs in the merge queue and verify both trigger e2e tests in parallel instead of one blocking the other