### PR TITLE
Fix: Hide object from Opened section when it already has a workspace nav item

### DIFF
--- a/packages/twenty-front/src/modules/navigation-menu-item/display/hooks/useWorkspaceNavigationMenuItems.ts
+++ b/packages/twenty-front/src/modules/navigation-menu-item/display/hooks/useWorkspaceNavigationMenuItems.ts
@@ -1,5 +1,3 @@
-import { useMemo } from 'react';
-
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { viewsSelector } from '@/views/states/selectors/viewsSelector';
 
@@ -13,32 +11,20 @@ export const useWorkspaceNavigationMenuItems = (): {
     useNavigationMenuItemsData();
   const views = useAtomStateValue(viewsSelector);
 
-  const allWorkspaceNavigationMenuItemViewIds = useMemo(
-    () =>
-      new Set(
-        rawWorkspaceNavigationMenuItems
-          .map((item) => item.viewId)
-          .filter((viewId) => isDefined(viewId)),
-      ),
-    [rawWorkspaceNavigationMenuItems],
+  const workspaceNavViewIds = new Set(
+    rawWorkspaceNavigationMenuItems
+      .map((item) => item.viewId)
+      .filter((viewId) => isDefined(viewId)),
   );
 
-  const objectMetadataIdsInWorkspaceNav = useMemo(
-    () =>
-      new Set([
-        ...views
-          .filter((view) => allWorkspaceNavigationMenuItemViewIds.has(view.id))
-          .map((view) => view.objectMetadataId),
-        ...rawWorkspaceNavigationMenuItems
-          .map((item) => item.targetObjectMetadataId)
-          .filter((objectMetadataId) => isDefined(objectMetadataId)),
-      ]),
-    [
-      views,
-      allWorkspaceNavigationMenuItemViewIds,
-      rawWorkspaceNavigationMenuItems,
-    ],
-  );
+  const objectMetadataIdsInWorkspaceNav = new Set([
+    ...views
+      .filter((view) => workspaceNavViewIds.has(view.id))
+      .map((view) => view.objectMetadataId),
+    ...rawWorkspaceNavigationMenuItems
+      .map((item) => item.targetObjectMetadataId)
+      .filter((objectMetadataId) => isDefined(objectMetadataId)),
+  ]);
 
   return {
     objectMetadataIdsInWorkspaceNav,

--- a/packages/twenty-front/src/modules/navigation-menu-item/display/hooks/useWorkspaceNavigationMenuItems.ts
+++ b/packages/twenty-front/src/modules/navigation-menu-item/display/hooks/useWorkspaceNavigationMenuItems.ts
@@ -1,8 +1,5 @@
 import { useMemo } from 'react';
 
-import { isNavigationMenuItemFolder } from '@/navigation-menu-item/common/utils/isNavigationMenuItemFolder';
-import { useFilteredObjectMetadataItems } from '@/object-metadata/hooks/useFilteredObjectMetadataItems';
-import { type ObjectMetadataItem } from '@/object-metadata/types/ObjectMetadataItem';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { viewsSelector } from '@/views/states/selectors/viewsSelector';
 
@@ -10,68 +7,40 @@ import { isDefined } from 'twenty-shared/utils';
 import { useNavigationMenuItemsData } from './useNavigationMenuItemsData';
 
 export const useWorkspaceNavigationMenuItems = (): {
-  workspaceNavigationMenuItemsObjectMetadataItems: ObjectMetadataItem[];
+  objectMetadataIdsInWorkspaceNav: Set<string>;
 } => {
   const { workspaceNavigationMenuItems: rawWorkspaceNavigationMenuItems } =
     useNavigationMenuItemsData();
   const views = useAtomStateValue(viewsSelector);
 
-  const workspaceFolderIds = useMemo(
+  const allWorkspaceNavigationMenuItemViewIds = useMemo(
     () =>
       new Set(
         rawWorkspaceNavigationMenuItems
-          .filter(isNavigationMenuItemFolder)
-          .map((item) => item.id),
+          .map((item) => item.viewId)
+          .filter((viewId) => isDefined(viewId)),
       ),
     [rawWorkspaceNavigationMenuItems],
   );
 
-  const workspaceNavigationMenuItemsIncludingFolderItems = useMemo(
+  const objectMetadataIdsInWorkspaceNav = useMemo(
     () =>
-      rawWorkspaceNavigationMenuItems.filter(
-        (item) =>
-          !isDefined(item.folderId) ||
-          (isDefined(item.folderId) && workspaceFolderIds.has(item.folderId)),
-      ),
-    [rawWorkspaceNavigationMenuItems, workspaceFolderIds],
+      new Set([
+        ...views
+          .filter((view) => allWorkspaceNavigationMenuItemViewIds.has(view.id))
+          .map((view) => view.objectMetadataId),
+        ...rawWorkspaceNavigationMenuItems
+          .map((item) => item.targetObjectMetadataId)
+          .filter((objectMetadataId) => isDefined(objectMetadataId)),
+      ]),
+    [
+      views,
+      allWorkspaceNavigationMenuItemViewIds,
+      rawWorkspaceNavigationMenuItems,
+    ],
   );
-
-  const workspaceNavigationMenuItemViewIds = new Set(
-    workspaceNavigationMenuItemsIncludingFolderItems
-      .map((item) => item.viewId)
-      .filter((viewId) => isDefined(viewId)),
-  );
-
-  const navigationMenuItemViewObjectMetadataIds = new Set(
-    views.reduce<string[]>((acc, view) => {
-      if (workspaceNavigationMenuItemViewIds.has(view.id)) {
-        acc.push(view.objectMetadataId);
-      }
-      return acc;
-    }, []),
-  );
-
-  const navigationMenuItemRecordObjectMetadataIds = new Set(
-    workspaceNavigationMenuItemsIncludingFolderItems
-      .map((item) => item.targetObjectMetadataId)
-      .filter((objectMetadataId) => isDefined(objectMetadataId)),
-  );
-
-  const allNavigationMenuItemObjectMetadataIds = new Set([
-    ...navigationMenuItemViewObjectMetadataIds,
-    ...navigationMenuItemRecordObjectMetadataIds,
-  ]);
-
-  const { activeNonSystemObjectMetadataItems } =
-    useFilteredObjectMetadataItems();
-
-  const activeNonSystemObjectMetadataItemsInWorkspaceNavigationMenuItems: ObjectMetadataItem[] =
-    activeNonSystemObjectMetadataItems.filter((item: ObjectMetadataItem) =>
-      allNavigationMenuItemObjectMetadataIds.has(item.id),
-    );
 
   return {
-    workspaceNavigationMenuItemsObjectMetadataItems:
-      activeNonSystemObjectMetadataItemsInWorkspaceNavigationMenuItems,
+    objectMetadataIdsInWorkspaceNav,
   };
 };

--- a/packages/twenty-front/src/modules/navigation-menu-item/display/sections/components/NavigationDrawerOpenedSection.tsx
+++ b/packages/twenty-front/src/modules/navigation-menu-item/display/sections/components/NavigationDrawerOpenedSection.tsx
@@ -3,14 +3,7 @@ import { useParams } from 'react-router-dom';
 import { useWorkspaceNavigationMenuItems } from '@/navigation-menu-item/display/hooks/useWorkspaceNavigationMenuItems';
 import { NavigationDrawerSectionForObjectMetadataItems } from '@/object-metadata/components/NavigationDrawerSectionForObjectMetadataItems';
 import { useFilteredObjectMetadataItems } from '@/object-metadata/hooks/useFilteredObjectMetadataItems';
-import { CoreObjectNameSingular } from 'twenty-shared/types';
 import { useLingui } from '@lingui/react/macro';
-
-const WORKFLOW_OBJECTS_IN_SIDEBAR = [
-  CoreObjectNameSingular.Workflow,
-  CoreObjectNameSingular.WorkflowRun,
-  CoreObjectNameSingular.WorkflowVersion,
-];
 
 export const NavigationDrawerOpenedSection = () => {
   const { t } = useLingui();
@@ -19,8 +12,7 @@ export const NavigationDrawerOpenedSection = () => {
   const filteredActiveNonSystemObjectMetadataItems =
     activeObjectMetadataItems.filter((item) => !item.isRemote);
 
-  const { workspaceNavigationMenuItemsObjectMetadataItems } =
-    useWorkspaceNavigationMenuItems();
+  const { objectMetadataIdsInWorkspaceNav } = useWorkspaceNavigationMenuItems();
 
   const {
     objectNamePlural: currentObjectNamePlural,
@@ -41,18 +33,12 @@ export const NavigationDrawerOpenedSection = () => {
     return;
   }
 
-  const isWorkflowObjectInSidebar = WORKFLOW_OBJECTS_IN_SIDEBAR.includes(
-    objectMetadataItem.nameSingular as CoreObjectNameSingular,
+  const isObjectAlreadyInNav = objectMetadataIdsInWorkspaceNav.has(
+    objectMetadataItem.id,
   );
 
-  const shouldDisplayObjectInOpenedSection =
-    !isWorkflowObjectInSidebar &&
-    !workspaceNavigationMenuItemsObjectMetadataItems
-      .map((item) => item.id)
-      .includes(objectMetadataItem.id);
-
   return (
-    shouldDisplayObjectInOpenedSection && (
+    !isObjectAlreadyInNav && (
       <NavigationDrawerSectionForObjectMetadataItems
         sectionTitle={t`Opened`}
         objectMetadataItems={[objectMetadataItem]}

--- a/packages/twenty-front/src/modules/navigation-menu-item/display/sections/components/NavigationDrawerOpenedSection.tsx
+++ b/packages/twenty-front/src/modules/navigation-menu-item/display/sections/components/NavigationDrawerOpenedSection.tsx
@@ -33,12 +33,12 @@ export const NavigationDrawerOpenedSection = () => {
     return;
   }
 
-  const isObjectAlreadyInNav = objectMetadataIdsInWorkspaceNav.has(
+  const isObjectAlreadyInNavbar = objectMetadataIdsInWorkspaceNav.has(
     objectMetadataItem.id,
   );
 
   return (
-    !isObjectAlreadyInNav && (
+    !isObjectAlreadyInNavbar && (
       <NavigationDrawerSectionForObjectMetadataItems
         sectionTitle={t`Opened`}
         objectMetadataItems={[objectMetadataItem]}


### PR DESCRIPTION
Previously, the Opened section was always hidden for all workflow objects. We now base the “in nav” check on the full set of object metadata IDs that have a workspace nav item, instead of only active non-system objects. So: if an object has a nav item (e.g. workflow runs), it no longer appears under Opened; if it doesn’t, it can appear there. The hook was simplified to only expose `objectMetadataIdsInWorkspaceNav`, and the unused return value was removed.