### PR TITLE
fix - handle invoice.paid webhook to recover unpaid subscriptions

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/billing-webhook/billing-webhook.controller.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing-webhook/billing-webhook.controller.ts
@@ -128,8 +128,7 @@ export class BillingWebhookController {
       case BillingWebhookEvent.INVOICE_FINALIZED:
       case BillingWebhookEvent.INVOICE_PAID:
         return await this.billingWebhookInvoiceService.processStripeEvent(
-          event.data,
-          event.type,
+          event,
         );
 
       case BillingWebhookEvent.CUSTOMER_CREATED:

--- a/packages/twenty-server/src/engine/core-modules/billing-webhook/billing-webhook.controller.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing-webhook/billing-webhook.controller.ts
@@ -126,8 +126,10 @@ export class BillingWebhookController {
         );
 
       case BillingWebhookEvent.INVOICE_FINALIZED:
+      case BillingWebhookEvent.INVOICE_PAID:
         return await this.billingWebhookInvoiceService.processStripeEvent(
           event.data,
+          event.type,
         );
 
       case BillingWebhookEvent.CUSTOMER_CREATED:

--- a/packages/twenty-server/src/engine/core-modules/billing-webhook/services/billing-webhook-invoice.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing-webhook/services/billing-webhook-invoice.service.ts
@@ -148,24 +148,29 @@ export class BillingWebhookInvoiceService {
 
   private async processInvoicePaid(data: Stripe.InvoicePaidEvent.Data) {
     const stripeSubscriptionId = getSubscriptionIdFromInvoice(data.object);
-
-    if (!isDefined(stripeSubscriptionId)) {
-      return;
-    }
-
     const stripeCustomerId = data.object.customer as string | undefined;
     const paidInvoicePeriodEnd = data.object.period_end;
 
-    if (isDefined(paidInvoicePeriodEnd)) {
-      await this.finalizePastDueDraftInvoicesAfterPaidInvoice(
-        stripeSubscriptionId,
-        paidInvoicePeriodEnd,
+    if (
+      !isDefined(stripeSubscriptionId) ||
+      !isDefined(stripeCustomerId) ||
+      !isDefined(paidInvoicePeriodEnd)
+    ) {
+      throw new BillingException(
+        'Invalid invoice paid event data',
+        BillingExceptionCode.BILLING_STRIPE_ERROR,
       );
     }
 
-    if (isDefined(stripeCustomerId)) {
-      await this.delaySuspendedWorkspaceCleanup(stripeCustomerId);
-    }
+    // Paying a past-due invoice won't reactivate the subscription if Stripe
+    // already generated a draft for the next period. Finalize it so Stripe
+    // can collect payment and resume the subscription.
+    await this.finalizePastDueDraftInvoicesAfterPaidInvoice(
+      stripeSubscriptionId,
+      paidInvoicePeriodEnd,
+    );
+
+    await this.delaySuspendedWorkspaceCleanup(stripeCustomerId);
 
     return { stripeSubscriptionId };
   }

--- a/packages/twenty-server/src/engine/core-modules/billing-webhook/services/billing-webhook-invoice.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing-webhook/services/billing-webhook-invoice.service.ts
@@ -9,6 +9,10 @@ import { type Repository } from 'typeorm';
 import type Stripe from 'stripe';
 
 import { getSubscriptionIdFromInvoice } from 'src/engine/core-modules/billing-webhook/utils/get-subscription-id-from-invoice.util';
+import {
+  BillingException,
+  BillingExceptionCode,
+} from 'src/engine/core-modules/billing/billing.exception';
 import { BillingCustomerEntity } from 'src/engine/core-modules/billing/entities/billing-customer.entity';
 import { BillingSubscriptionItemEntity } from 'src/engine/core-modules/billing/entities/billing-subscription-item.entity';
 import { BillingSubscriptionEntity } from 'src/engine/core-modules/billing/entities/billing-subscription.entity';
@@ -40,16 +44,17 @@ export class BillingWebhookInvoiceService {
   ) {}
 
   async processStripeEvent(
-    data: Stripe.InvoiceFinalizedEvent.Data | Stripe.InvoicePaidEvent.Data,
-    eventType: string,
+    event: Stripe.InvoicePaidEvent | Stripe.InvoiceFinalizedEvent,
   ) {
-    if (eventType === BillingWebhookEvent.INVOICE_PAID) {
-      return this.processInvoicePaid(data as Stripe.InvoicePaidEvent.Data);
+    if (event.type === BillingWebhookEvent.INVOICE_PAID) {
+      return this.processInvoicePaid(
+        event.data as Stripe.InvoicePaidEvent.Data,
+      );
     }
 
-    if (eventType === BillingWebhookEvent.INVOICE_FINALIZED) {
+    if (event.type === BillingWebhookEvent.INVOICE_FINALIZED) {
       return this.processInvoiceFinalized(
-        data as Stripe.InvoiceFinalizedEvent.Data,
+        event.data as Stripe.InvoiceFinalizedEvent.Data,
       );
     }
   }
@@ -149,40 +154,51 @@ export class BillingWebhookInvoiceService {
     }
 
     const stripeCustomerId = data.object.customer as string | undefined;
+    const paidInvoicePeriodEnd = data.object.period_end;
 
-    await this.finalizePastDueDraftInvoices(stripeSubscriptionId);
+    if (isDefined(paidInvoicePeriodEnd)) {
+      await this.finalizePastDueDraftInvoicesAfterPaidInvoice(
+        stripeSubscriptionId,
+        paidInvoicePeriodEnd,
+      );
+    }
 
     if (isDefined(stripeCustomerId)) {
-      await this.refreshSuspendedAtIfNeeded(stripeCustomerId);
+      await this.delaySuspendedWorkspaceCleanup(stripeCustomerId);
     }
 
     return { stripeSubscriptionId };
   }
 
-  private async finalizePastDueDraftInvoices(
+  private async finalizePastDueDraftInvoicesAfterPaidInvoice(
     stripeSubscriptionId: string,
+    paidInvoicePeriodEnd: number,
   ): Promise<void> {
     const draftInvoices =
       await this.stripeInvoiceService.listDraftInvoices(stripeSubscriptionId);
 
-    const now = Date.now() / 1000;
+    const nowInSeconds = Date.now() / 1000;
 
     const pastDueDraftInvoices = draftInvoices.filter(
-      (invoice) => isDefined(invoice.period_end) && invoice.period_end < now,
+      (invoice) =>
+        isDefined(invoice.period_end) &&
+        invoice.period_end > paidInvoicePeriodEnd &&
+        invoice.period_end < nowInSeconds,
     );
 
     for (const invoice of pastDueDraftInvoices) {
       try {
         await this.stripeInvoiceService.finalizeInvoice(invoice.id);
       } catch (error) {
-        this.logger.error(
-          `Failed to finalize draft invoice ${invoice.id}: ${error instanceof Error ? error.message : String(error)}`,
+        throw new BillingException(
+          `Failed to finalize draft invoice ${invoice.id}: ${error.message}`,
+          BillingExceptionCode.BILLING_STRIPE_ERROR,
         );
       }
     }
   }
 
-  private async refreshSuspendedAtIfNeeded(
+  private async delaySuspendedWorkspaceCleanup(
     stripeCustomerId: string,
   ): Promise<void> {
     const billingCustomer = await this.billingCustomerRepository.findOne({

--- a/packages/twenty-server/src/engine/core-modules/billing-webhook/services/billing-webhook-invoice.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing-webhook/services/billing-webhook-invoice.service.ts
@@ -1,33 +1,62 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { addMonths, addYears } from 'date-fns';
 import { isDefined } from 'twenty-shared/utils';
+import { WorkspaceActivationStatus } from 'twenty-shared/workspace';
 import { type Repository } from 'typeorm';
 
 import type Stripe from 'stripe';
 
 import { getSubscriptionIdFromInvoice } from 'src/engine/core-modules/billing-webhook/utils/get-subscription-id-from-invoice.util';
+import { BillingCustomerEntity } from 'src/engine/core-modules/billing/entities/billing-customer.entity';
 import { BillingSubscriptionItemEntity } from 'src/engine/core-modules/billing/entities/billing-subscription-item.entity';
 import { BillingSubscriptionEntity } from 'src/engine/core-modules/billing/entities/billing-subscription.entity';
 import { SubscriptionInterval } from 'src/engine/core-modules/billing/enums/billing-subscription-interval.enum';
+import { BillingWebhookEvent } from 'src/engine/core-modules/billing/enums/billing-webhook-events.enum';
 import { BillingCreditRolloverService } from 'src/engine/core-modules/billing/services/billing-credit-rollover.service';
 import { BillingSubscriptionService } from 'src/engine/core-modules/billing/services/billing-subscription.service';
 import { MeteredCreditService } from 'src/engine/core-modules/billing/services/metered-credit.service';
+import { StripeInvoiceService } from 'src/engine/core-modules/billing/stripe/services/stripe-invoice.service';
+import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 
 const SUBSCRIPTION_CYCLE_BILLING_REASON = 'subscription_cycle';
 
 @Injectable()
 export class BillingWebhookInvoiceService {
+  protected readonly logger = new Logger(BillingWebhookInvoiceService.name);
+
   constructor(
     @InjectRepository(BillingSubscriptionItemEntity)
     private readonly billingSubscriptionItemRepository: Repository<BillingSubscriptionItemEntity>,
+    @InjectRepository(BillingCustomerEntity)
+    private readonly billingCustomerRepository: Repository<BillingCustomerEntity>,
+    @InjectRepository(WorkspaceEntity)
+    private readonly workspaceRepository: Repository<WorkspaceEntity>,
     private readonly billingSubscriptionService: BillingSubscriptionService,
     private readonly billingCreditRolloverService: BillingCreditRolloverService,
     private readonly meteredCreditService: MeteredCreditService,
+    private readonly stripeInvoiceService: StripeInvoiceService,
   ) {}
 
-  async processStripeEvent(data: Stripe.InvoiceFinalizedEvent.Data) {
+  async processStripeEvent(
+    data: Stripe.InvoiceFinalizedEvent.Data | Stripe.InvoicePaidEvent.Data,
+    eventType: string,
+  ) {
+    if (eventType === BillingWebhookEvent.INVOICE_PAID) {
+      return this.processInvoicePaid(data as Stripe.InvoicePaidEvent.Data);
+    }
+
+    if (eventType === BillingWebhookEvent.INVOICE_FINALIZED) {
+      return this.processInvoiceFinalized(
+        data as Stripe.InvoiceFinalizedEvent.Data,
+      );
+    }
+  }
+
+  private async processInvoiceFinalized(
+    data: Stripe.InvoiceFinalizedEvent.Data,
+  ) {
     const {
       billing_reason: billingReason,
       customer,
@@ -109,6 +138,74 @@ export class BillingWebhookInvoiceService {
       newPeriodEnd: nextPeriodEnd,
       tierQuantity: rolloverParams.tierQuantity,
       unitPriceCents: rolloverParams.unitPriceCents,
+    });
+  }
+
+  private async processInvoicePaid(data: Stripe.InvoicePaidEvent.Data) {
+    const stripeSubscriptionId = getSubscriptionIdFromInvoice(data.object);
+
+    if (!isDefined(stripeSubscriptionId)) {
+      return;
+    }
+
+    const stripeCustomerId = data.object.customer as string | undefined;
+
+    await this.finalizePastDueDraftInvoices(stripeSubscriptionId);
+
+    if (isDefined(stripeCustomerId)) {
+      await this.refreshSuspendedAtIfNeeded(stripeCustomerId);
+    }
+
+    return { stripeSubscriptionId };
+  }
+
+  private async finalizePastDueDraftInvoices(
+    stripeSubscriptionId: string,
+  ): Promise<void> {
+    const draftInvoices =
+      await this.stripeInvoiceService.listDraftInvoices(stripeSubscriptionId);
+
+    const now = Date.now() / 1000;
+
+    const pastDueDraftInvoices = draftInvoices.filter(
+      (invoice) => isDefined(invoice.period_end) && invoice.period_end < now,
+    );
+
+    for (const invoice of pastDueDraftInvoices) {
+      try {
+        await this.stripeInvoiceService.finalizeInvoice(invoice.id);
+      } catch (error) {
+        this.logger.error(
+          `Failed to finalize draft invoice ${invoice.id}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+  }
+
+  private async refreshSuspendedAtIfNeeded(
+    stripeCustomerId: string,
+  ): Promise<void> {
+    const billingCustomer = await this.billingCustomerRepository.findOne({
+      where: { stripeCustomerId },
+    });
+
+    if (!isDefined(billingCustomer)) {
+      return;
+    }
+
+    const workspace = await this.workspaceRepository.findOne({
+      where: {
+        id: billingCustomer.workspaceId,
+        activationStatus: WorkspaceActivationStatus.SUSPENDED,
+      },
+    });
+
+    if (!isDefined(workspace)) {
+      return;
+    }
+
+    await this.workspaceRepository.update(workspace.id, {
+      suspendedAt: new Date(),
     });
   }
 

--- a/packages/twenty-server/src/engine/core-modules/billing/enums/billing-webhook-events.enum.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/enums/billing-webhook-events.enum.ts
@@ -13,6 +13,7 @@ export enum BillingWebhookEvent {
   PRICE_UPDATED = 'price.updated',
   ALERT_TRIGGERED = 'billing.alert.triggered',
   INVOICE_FINALIZED = 'invoice.finalized',
+  INVOICE_PAID = 'invoice.paid',
   SUBSCRIPTION_SCHEDULE_UPDATED = 'subscription_schedule.updated',
   CREDIT_GRANT_CREATED = 'billing.credit_grant.created',
   CREDIT_GRANT_UPDATED = 'billing.credit_grant.updated',

--- a/packages/twenty-server/src/engine/core-modules/billing/stripe/services/stripe-invoice.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/stripe/services/stripe-invoice.service.ts
@@ -1,0 +1,43 @@
+/* @license Enterprise */
+
+import { Injectable, Logger } from '@nestjs/common';
+
+import type Stripe from 'stripe';
+
+import { StripeSDKService } from 'src/engine/core-modules/billing/stripe/stripe-sdk/services/stripe-sdk.service';
+import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
+
+@Injectable()
+export class StripeInvoiceService {
+  protected readonly logger = new Logger(StripeInvoiceService.name);
+  private readonly stripe: Stripe;
+
+  constructor(
+    private readonly twentyConfigService: TwentyConfigService,
+    private readonly stripeSDKService: StripeSDKService,
+  ) {
+    if (!this.twentyConfigService.get('IS_BILLING_ENABLED')) {
+      return;
+    }
+    this.stripe = this.stripeSDKService.getStripe(
+      this.twentyConfigService.get('BILLING_STRIPE_API_KEY'),
+    );
+  }
+
+  async listDraftInvoices(
+    stripeSubscriptionId: string,
+  ): Promise<Stripe.Invoice[]> {
+    const invoices = await this.stripe.invoices.list({
+      subscription: stripeSubscriptionId,
+      status: 'draft',
+    });
+
+    return invoices.data;
+  }
+
+  async finalizeInvoice(invoiceId: string): Promise<Stripe.Invoice> {
+    return this.stripe.invoices.finalizeInvoice(invoiceId, {
+      auto_advance: true,
+    });
+  }
+}

--- a/packages/twenty-server/src/engine/core-modules/billing/stripe/stripe.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/billing/stripe/stripe.module.ts
@@ -16,6 +16,7 @@ import { StripeSubscriptionScheduleService } from 'src/engine/core-modules/billi
 import { StripeSubscriptionService } from 'src/engine/core-modules/billing/stripe/services/stripe-subscription.service';
 import { StripeWebhookService } from 'src/engine/core-modules/billing/stripe/services/stripe-webhook.service';
 import { StripeCreditGrantService } from 'src/engine/core-modules/billing/stripe/services/stripe-credit-grant.service';
+import { StripeInvoiceService } from 'src/engine/core-modules/billing/stripe/services/stripe-invoice.service';
 import { StripeSDKModule } from 'src/engine/core-modules/billing/stripe/stripe-sdk/stripe-sdk.module';
 import { BillingCustomerEntity } from 'src/engine/core-modules/billing/entities/billing-customer.entity';
 import { DomainServerConfigModule } from 'src/engine/core-modules/domain/domain-server-config/domain-server-config.module';
@@ -40,6 +41,7 @@ import { DomainServerConfigModule } from 'src/engine/core-modules/domain/domain-
     StripeBillingMeterEventService,
     StripeBillingAlertService,
     StripeCreditGrantService,
+    StripeInvoiceService,
   ],
   exports: [
     StripeWebhookService,
@@ -55,6 +57,7 @@ import { DomainServerConfigModule } from 'src/engine/core-modules/domain/domain-
     StripeSubscriptionScheduleService,
     StripeBillingAlertService,
     StripeCreditGrantService,
+    StripeInvoiceService,
   ],
 })
 export class StripeModule {}


### PR DESCRIPTION
Fixes https://github.com/twentyhq/private-issues/issues/432

## Problem

When a user's invoice goes unpaid, Stripe moves their subscription to `unpaid` status, and Twenty suspends the workspace. But if the user pays that invoice while a new billing period has started, Stripe has already generated a new **draft** invoice for that period. Since the draft isn't finalized or paid, Stripe doesn't reactivate the subscription — the workspace stays suspended indefinitely.

## What was missing

- No handler for the `invoice.paid` Stripe webhook event
- No mechanism to finalize draft invoices that accumulated during the `unpaid` period
- No way to reset the workspace deletion countdown (`suspendedAt`) when a user shows payment intent

## What was added

### 1. `StripeInvoiceService` — new Stripe SDK wrapper

- `listDraftInvoices(stripeSubscriptionId)` — lists all draft invoices for a subscription
- `finalizeInvoice(invoiceId)` — finalizes a draft with `auto_advance: true` so Stripe auto-charges it

### 2. `INVOICE_PAID` enum value

Added to `BillingWebhookEvent` so the controller can route it.

### 3. `processInvoicePaid()` in `BillingWebhookInvoiceService`

New private handler that:

- Fetches all draft invoices for the subscription
- Filters to only those whose `period_end` is in the past (already overdue)
- Finalizes each one (with error handling per invoice to avoid blocking the webhook)
- If the workspace is suspended, resets `suspendedAt` to now (buys time before deletion)

### 4. Controller routing

`INVOICE_FINALIZED` and `INVOICE_PAID` are now grouped in the same switch case, both calling `processStripeEvent(data, eventType)`, which forks internally in the service.

## Expected recovery flow

User pays overdue invoice
→ Stripe fires invoice.paid
→ Handler finalizes past-due draft invoices (auto_advance: true)
→ Stripe auto-charges them
→ Subscription becomes active
→ customer.subscription.updated fires
→ Existing logic unsuspends workspace
→ suspendedAt refreshed (resets deletion countdown while payments cascade)