### PR TITLE
fix: preserve percent-encoding in URL fields during import and record transform

### DIFF
--- a/packages/twenty-shared/src/utils/url/__tests__/lowercaseUrlOriginAndRemoveTrailingSlash.test.ts
+++ b/packages/twenty-shared/src/utils/url/__tests__/lowercaseUrlOriginAndRemoveTrailingSlash.test.ts
@@ -41,7 +41,7 @@ describe('lowercaseUrlOriginAndRemoveTrailingSlash', () => {
     {
       title: 'should preserve special characters in path',
       input: 'https://test.test/edouard-ménard-22219837',
-      expected: 'https://test.test/edouard-ménard-22219837',
+      expected: 'https://test.test/edouard-m%C3%A9nard-22219837',
     },
     {
       title: 'should preserve percent-encoded characters in path',
@@ -51,7 +51,7 @@ describe('lowercaseUrlOriginAndRemoveTrailingSlash', () => {
     {
       title: 'should preserve special characters in query params',
       input: 'https://example.com/path?name=José',
-      expected: 'https://example.com/path?name=José',
+      expected: 'https://example.com/path?name=Jos%C3%A9',
     },
     {
       title:

--- a/packages/twenty-shared/src/utils/url/__tests__/lowercaseUrlOriginAndRemoveTrailingSlash.test.ts
+++ b/packages/twenty-shared/src/utils/url/__tests__/lowercaseUrlOriginAndRemoveTrailingSlash.test.ts
@@ -60,8 +60,7 @@ describe('lowercaseUrlOriginAndRemoveTrailingSlash', () => {
       expected: 'https://example.com/test%E0%A4%A',
     },
     {
-      title:
-        'should preserve double-encoded URLs as-is (no decoding)',
+      title: 'should preserve double-encoded URLs as-is (no decoding)',
       input: 'https://example.com/test%2520name',
       expected: 'https://example.com/test%2520name',
     },
@@ -76,7 +75,8 @@ describe('lowercaseUrlOriginAndRemoveTrailingSlash', () => {
       expected: 'https://example.com/path#fr%C3%A9d%C3%A9ric',
     },
     {
-      title: 'should preserve percent-encoding in path and query (e.g. %2F must not become /)',
+      title:
+        'should preserve percent-encoding in path and query (e.g. %2F must not become /)',
       input: 'https://example.com/path%2Fwith%2Fslashes?query=hello%20world',
       expected: 'https://example.com/path%2Fwith%2Fslashes?query=hello%20world',
     },

--- a/packages/twenty-shared/src/utils/url/__tests__/lowercaseUrlOriginAndRemoveTrailingSlash.test.ts
+++ b/packages/twenty-shared/src/utils/url/__tests__/lowercaseUrlOriginAndRemoveTrailingSlash.test.ts
@@ -44,9 +44,9 @@ describe('lowercaseUrlOriginAndRemoveTrailingSlash', () => {
       expected: 'https://test.test/edouard-ménard-22219837',
     },
     {
-      title: 'should decode already encoded special characters in path',
+      title: 'should preserve percent-encoded characters in path',
       input: 'https://test.test/edouard-m%C3%A9nard-22219837',
-      expected: 'https://test.test/edouard-ménard-22219837',
+      expected: 'https://test.test/edouard-m%C3%A9nard-22219837',
     },
     {
       title: 'should preserve special characters in query params',
@@ -61,9 +61,9 @@ describe('lowercaseUrlOriginAndRemoveTrailingSlash', () => {
     },
     {
       title:
-        'should preserve double-encoded URLs (encoded percent signs stay encoded once)',
+        'should preserve double-encoded URLs as-is (no decoding)',
       input: 'https://example.com/test%2520name',
-      expected: 'https://example.com/test%20name',
+      expected: 'https://example.com/test%2520name',
     },
     {
       title: 'should preserve special characters in hash fragments',
@@ -76,9 +76,14 @@ describe('lowercaseUrlOriginAndRemoveTrailingSlash', () => {
       expected: 'https://example.com/path#fr%C3%A9d%C3%A9ric',
     },
     {
-      title: 'should handle mixed encoded and non-encoded in same URL',
+      title: 'should preserve percent-encoding in path and query (e.g. %2F must not become /)',
       input: 'https://example.com/path%2Fwith%2Fslashes?query=hello%20world',
-      expected: 'https://example.com/path/with/slashes?query=hello world',
+      expected: 'https://example.com/path%2Fwith%2Fslashes?query=hello%20world',
+    },
+    {
+      title: 'should preserve Google Maps %2F data params',
+      input: 'https://www.google.com/maps/place/Test!16s%2Fg%2F1abc',
+      expected: 'https://www.google.com/maps/place/Test!16s%2Fg%2F1abc',
     },
   ])('$title', ({ input, expected }) => {
     expect(lowercaseUrlOriginAndRemoveTrailingSlash(input)).toBe(expected);

--- a/packages/twenty-shared/src/utils/url/lowercaseUrlOriginAndRemoveTrailingSlash.ts
+++ b/packages/twenty-shared/src/utils/url/lowercaseUrlOriginAndRemoveTrailingSlash.ts
@@ -1,6 +1,5 @@
 import { getURLSafely } from '@/utils/getURLSafely';
 import { isDefined } from '@/utils/validation';
-import { safeDecodeURIComponent } from './safeDecodeURIComponent';
 
 export const lowercaseUrlOriginAndRemoveTrailingSlash = (rawUrl: string) => {
   const url = getURLSafely(rawUrl);
@@ -10,10 +9,9 @@ export const lowercaseUrlOriginAndRemoveTrailingSlash = (rawUrl: string) => {
   }
 
   const lowercaseOrigin = url.origin.toLowerCase();
-  const path =
-    safeDecodeURIComponent(url.pathname) +
-    safeDecodeURIComponent(url.search) +
-    url.hash;
+  // Use pathname/search as-is to preserve percent-encoding (e.g. %2F must not
+  // become / inside Google Maps data= params or similar structured URL paths).
+  const path = url.pathname + url.search + url.hash;
 
   return (lowercaseOrigin + path).replace(/\/$/, '');
 };


### PR DESCRIPTION
## Problem

Fixes #18698

When importing records with URLs containing percent-encoded characters like `%2F`, Twenty decodes them to literal characters (`/`), breaking structured URLs such as Google Maps links.

**Broken import result:**
```
https://www.google.com/maps/...!16s/g/1ptwh8096!...   ❌ (broken)
```
**Expected:**
```
https://www.google.com/maps/...!16s%2Fg%2F1ptwh8096!... ✅
```

## Root Cause

`lowercaseUrlOriginAndRemoveTrailingSlash` was calling `safeDecodeURIComponent` on `url.pathname` and `url.search`. The `URL` object already parses and preserves encoding correctly — decoding the path/search unnecessarily broke encoded characters.

## Fix

```diff
-  const path =
-    safeDecodeURIComponent(url.pathname) +
-    safeDecodeURIComponent(url.search) +
-    url.hash;
+  const path = url.pathname + url.search + url.hash;
```

The origin is still lowercased. Trailing slash removal still works. Only the unnecessary decode is removed.