### PR TITLE
fix: FIND_RECORDS RELATION IS filter should return 0 results when variable resolves to null

### DIFF
--- a/packages/twenty-shared/src/utils/filter/turnRecordFilterIntoGqlOperationFilter.ts
+++ b/packages/twenty-shared/src/utils/filter/turnRecordFilterIntoGqlOperationFilter.ts
@@ -532,7 +532,18 @@ export const turnRecordFilterIntoRecordGqlOperationFilter = ({
           ]
         : selectedRecordIds;
 
-      if (!isDefined(recordIds) || recordIds.length === 0) return;
+      if (!isDefined(recordIds) || recordIds.length === 0) {
+        // When the filter value is empty (e.g. a variable resolved to null),
+        // IS should match nothing rather than being silently dropped.
+        if (recordFilter.operand === RecordFilterOperand.IS) {
+          return {
+            [correspondingFieldMetadataItem.name + 'Id']: {
+              in: [],
+            } as RelationFilter,
+          };
+        }
+        return;
+      }
 
       switch (recordFilter.operand) {
         case RecordFilterOperand.IS:


### PR DESCRIPTION
## Problem

Fixes #18744

**Critical bug**: When a `FIND_RECORDS` workflow step uses a variable reference (e.g. `{{previousStep.first.id}}`) in a `RELATION IS` filter, and that variable resolves to `null` at runtime, the filter is **silently dropped** — causing the step to return ALL matching records instead of zero. This is a data leak.

| Run | Variable value | Expected | Actual (before fix) |
|-----|----------------|----------|---------------------|
| Previous step found a record | Valid UUID | Matching records | ✅ Correct |
| Previous step returned empty | `null` | 0 records | ❌ ALL records (filter dropped) |

## Root Cause

`arrayOfUuidOrVariableSchema.parse(null)` returns `[]` (via `.catch([])`). The code then hit:

```typescript
if (!isDefined(recordIds) || recordIds.length === 0) return; // ← drops filter
```

Returning `undefined` caused the caller to treat the filter as if it didn't exist.

## Fix

When `recordIds` is empty and operand is `IS`, return a match-nothing filter (`in: []`) instead of `undefined`:

```typescript
if (!isDefined(recordIds) || recordIds.length === 0) {
  if (recordFilter.operand === RecordFilterOperand.IS) {
    return {
      [correspondingFieldMetadataItem.name + 'Id']: { in: [] },
    };
  }
  return; // IS_NOT with no IDs: drop is correct (exclude nothing = all)
}
```