### PR TITLE
fix: show tooltip when email edit is disabled due to multiple workspaces

### DIFF
--- a/packages/twenty-front/src/modules/settings/profile/components/EmailField.tsx
+++ b/packages/twenty-front/src/modules/settings/profile/components/EmailField.tsx
@@ -1,3 +1,4 @@
+import { t } from '@lingui/core/macro';
 import { styled } from '@linaria/react';
 import { useId, useState } from 'react';
 
@@ -9,7 +10,6 @@ import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomState
 import { AppTooltip, IconCheck, IconPencil, IconX } from 'twenty-ui/display';
 import { Button } from 'twenty-ui/input';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
-import { t } from '@lingui/core/macro';
 
 const StyledContainer = styled.div`
   display: flex;

--- a/packages/twenty-front/src/modules/settings/profile/components/EmailField.tsx
+++ b/packages/twenty-front/src/modules/settings/profile/components/EmailField.tsx
@@ -1,14 +1,15 @@
 import { styled } from '@linaria/react';
-import { useState } from 'react';
+import { useId, useState } from 'react';
 
 import { currentUserState } from '@/auth/states/currentUserState';
 import { useCanEditProfileField } from '@/settings/profile/hooks/useCanEditProfileField';
 import { useUpdateEmail } from '@/settings/profile/hooks/useUpdateEmail';
 import { SettingsTextInput } from '@/ui/input/components/SettingsTextInput';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
-import { IconCheck, IconPencil, IconX } from 'twenty-ui/display';
+import { AppTooltip, IconCheck, IconPencil, IconX } from 'twenty-ui/display';
 import { Button } from 'twenty-ui/input';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
+import { t } from '@lingui/core/macro';
 
 const StyledContainer = styled.div`
   display: flex;
@@ -40,7 +41,8 @@ const StyledActionButtonContainer = styled.div`
 
 export const EmailField = () => {
   const currentUser = useAtomStateValue(currentUserState);
-  const { canEdit } = useCanEditProfileField('email');
+  const { canEdit, disabledReason } = useCanEditProfileField('email');
+  const tooltipId = useId();
   const { updateEmail } = useUpdateEmail();
 
   const [draftEmail, setDraftEmail] = useState('');
@@ -121,14 +123,23 @@ export const EmailField = () => {
         ) : (
           <StyledActionWrapper key="view">
             <StyledActionButtonContainer>
-              <Button
-                Icon={IconPencil}
-                variant="secondary"
-                size="medium"
-                onClick={handleStartEditing}
-                disabled={!canEdit}
-                type="button"
-              />
+              <div id={disabledReason === 'multipleWorkspaces' ? tooltipId : undefined}>
+                <Button
+                  Icon={IconPencil}
+                  variant="secondary"
+                  size="medium"
+                  onClick={handleStartEditing}
+                  disabled={!canEdit}
+                  type="button"
+                />
+              </div>
+              {disabledReason === 'multipleWorkspaces' && (
+                <AppTooltip
+                  anchorSelect={`#${CSS.escape(tooltipId)}`}
+                  content={t`Email cannot be changed when you belong to multiple workspaces`}
+                  place="top"
+                />
+              )}
             </StyledActionButtonContainer>
           </StyledActionWrapper>
         )}

--- a/packages/twenty-front/src/modules/settings/profile/components/EmailField.tsx
+++ b/packages/twenty-front/src/modules/settings/profile/components/EmailField.tsx
@@ -123,7 +123,13 @@ export const EmailField = () => {
         ) : (
           <StyledActionWrapper key="view">
             <StyledActionButtonContainer>
-              <div id={disabledReason === 'multipleWorkspaces' ? tooltipId : undefined}>
+              <div
+                id={
+                  disabledReason === 'multipleWorkspaces'
+                    ? tooltipId
+                    : undefined
+                }
+              >
                 <Button
                   Icon={IconPencil}
                   variant="secondary"

--- a/packages/twenty-front/src/modules/settings/profile/hooks/useCanEditProfileField.ts
+++ b/packages/twenty-front/src/modules/settings/profile/hooks/useCanEditProfileField.ts
@@ -33,8 +33,13 @@ export const useCanEditProfileField = (field: EditableProfileField) => {
     countAvailableWorkspaces(availableWorkspaces) <= 1;
   const meetsWorkspaceLimit = !requiresSingleWorkspace || isSingleWorkspaceUser;
 
-  return {
-    canEdit:
-      workspaceAllowsField && hasProfilePermission && meetsWorkspaceLimit,
-  };
+  const canEdit =
+    workspaceAllowsField && hasProfilePermission && meetsWorkspaceLimit;
+
+  const disabledReason =
+    !canEdit && requiresSingleWorkspace && !isSingleWorkspaceUser
+      ? ('multipleWorkspaces' as const)
+      : undefined;
+
+  return { canEdit, disabledReason };
 };


### PR DESCRIPTION
## Problem

Fixes twentyhq/core-team-issues#2335

When a user belongs to multiple workspaces, the email edit pencil button is disabled with no explanation. Users have no way to discover why.

## Fix

1. `useCanEditProfileField` now returns a `disabledReason` field (`'multipleWorkspaces' | undefined`)
2. `EmailField` shows an `AppTooltip` on hover when `disabledReason === 'multipleWorkspaces'`:

> *"Email cannot be changed when you belong to multiple workspaces"*

| Scenario | Before | After |
|----------|--------|-------|
| Single workspace | Edit works | Edit works (unchanged) |
| Multiple workspaces | Button disabled, no hint | Button disabled + tooltip |