### PR TITLE
fix: stop event propagation when removing file in AI chat preview

### DIFF
--- a/packages/twenty-front/src/modules/ai/components/internal/AgentChatFilePreview.tsx
+++ b/packages/twenty-front/src/modules/ai/components/internal/AgentChatFilePreview.tsx
@@ -7,7 +7,7 @@ import { filePreviewState } from '@/ui/field/display/states/filePreviewState';
 import { useSetAtomState } from '@/ui/utilities/state/jotai/hooks/useSetAtomState';
 import { styled } from '@linaria/react';
 import { t } from '@lingui/core/macro';
-import { useCallback, useContext } from 'react';
+import { type MouseEvent, useCallback, useContext } from 'react';
 import { type ExtendedFileUIPart } from 'twenty-shared/ai';
 import { isDefined } from 'twenty-shared/utils';
 import { AvatarOrIcon, Chip, ChipVariant } from 'twenty-ui/components';
@@ -71,11 +71,18 @@ export const AgentChatFilePreview = ({
     />
   );
 
-  const rightComponent = onRemove ? (
+  const handleRemove = onRemove
+    ? (e: MouseEvent) => {
+        e.stopPropagation();
+        onRemove();
+      }
+    : undefined;
+
+  const rightComponent = handleRemove ? (
     <AvatarOrIcon
       Icon={IconX}
       IconColor={theme.font.color.secondary}
-      onClick={onRemove}
+      onClick={handleRemove}
     />
   ) : undefined;
 

--- a/packages/twenty-front/src/modules/ai/components/internal/AgentChatFilePreview.tsx
+++ b/packages/twenty-front/src/modules/ai/components/internal/AgentChatFilePreview.tsx
@@ -76,7 +76,7 @@ export const AgentChatFilePreview = ({
       <AvatarOrIcon
         Icon={IconX}
         IconColor={theme.font.color.secondary}
-        onClick={() => onRemove()}
+        onClick={onRemove}
       />
     </div>
   ) : undefined;

--- a/packages/twenty-front/src/modules/ai/components/internal/AgentChatFilePreview.tsx
+++ b/packages/twenty-front/src/modules/ai/components/internal/AgentChatFilePreview.tsx
@@ -7,7 +7,7 @@ import { filePreviewState } from '@/ui/field/display/states/filePreviewState';
 import { useSetAtomState } from '@/ui/utilities/state/jotai/hooks/useSetAtomState';
 import { styled } from '@linaria/react';
 import { t } from '@lingui/core/macro';
-import { type MouseEvent, useCallback, useContext } from 'react';
+import { useCallback, useContext } from 'react';
 import { type ExtendedFileUIPart } from 'twenty-shared/ai';
 import { isDefined } from 'twenty-shared/utils';
 import { AvatarOrIcon, Chip, ChipVariant } from 'twenty-ui/components';
@@ -71,19 +71,14 @@ export const AgentChatFilePreview = ({
     />
   );
 
-  const handleRemove = onRemove
-    ? (e: MouseEvent) => {
-        e.stopPropagation();
-        onRemove();
-      }
-    : undefined;
-
-  const rightComponent = handleRemove ? (
-    <AvatarOrIcon
-      Icon={IconX}
-      IconColor={theme.font.color.secondary}
-      onClick={handleRemove}
-    />
+  const rightComponent = onRemove ? (
+    <div onClick={(e) => e.stopPropagation()}>
+      <AvatarOrIcon
+        Icon={IconX}
+        IconColor={theme.font.color.secondary}
+        onClick={() => onRemove()}
+      />
+    </div>
   ) : undefined;
 
   const hasRightDivider = isDefined(onRemove);


### PR DESCRIPTION
## Summary

When clicking the ✕ button on an uploaded file in the AI chatbot context preview, the click event bubbled up to the `StyledClickableContainer` parent, which triggered `handleClick` (opening the file preview modal) instead of — or in addition to — calling `onRemove`.

**Root cause:** `StyledClickableContainer` has `onClick={handleClick}` at the div level. The `AvatarOrIcon` (X button) `onClick={onRemove}` callback didn't stop propagation, so the event continued to bubble and opened the preview.

**Fix:** Wrap `onRemove` in a `handleRemove` callback that calls `e.stopPropagation()` before invoking the original handler.

Fixes #18298