### PR TITLE
Restore missing workflow code step migration (#18296)

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-18/1-18-migrate-workflow-code-steps.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-18/1-18-migrate-workflow-code-steps.command.ts
@@ -1,0 +1,134 @@
+import { Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { Command } from 'nest-commander';
+import { isDefined } from 'twenty-shared/utils';
+import { In, Repository } from 'typeorm';
+
+import { ActiveOrSuspendedWorkspacesMigrationCommandRunner } from 'src/database/commands/command-runners/active-or-suspended-workspaces-migration.command-runner';
+import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspaces-migration.command-runner';
+import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
+import { DataSourceService } from 'src/engine/metadata-modules/data-source/data-source.service';
+import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
+import {
+  WorkflowVersionStatus,
+  type WorkflowVersionWorkspaceEntity,
+} from 'src/modules/workflow/common/standard-objects/workflow-version.workspace-entity';
+import { type WorkflowAction } from 'src/modules/workflow/workflow-executor/workflow-actions/types/workflow-action.type';
+
+type LegacyCodeStepInput = {
+  serverlessFunctionId: string;
+  serverlessFunctionVersion?: string;
+  serverlessFunctionInput?: Record<string, unknown>;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type UntypedStep = Record<string, any>;
+
+const isLegacyCodeStep = (step: UntypedStep): boolean => {
+  return (
+    step.type === 'CODE' &&
+    isDefined(step.settings?.input?.serverlessFunctionId)
+  );
+};
+
+@Command({
+  name: 'upgrade:1-18:migrate-workflow-code-steps',
+  description:
+    'Migrate workflow CODE steps from legacy serverlessFunction fields to logicFunction fields',
+})
+export class MigrateWorkflowCodeStepsCommand extends ActiveOrSuspendedWorkspacesMigrationCommandRunner {
+  protected readonly logger = new Logger(MigrateWorkflowCodeStepsCommand.name);
+
+  constructor(
+    @InjectRepository(WorkspaceEntity)
+    protected readonly workspaceRepository: Repository<WorkspaceEntity>,
+    protected readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    protected readonly dataSourceService: DataSourceService,
+  ) {
+    super(workspaceRepository, globalWorkspaceOrmManager, dataSourceService);
+  }
+
+  override async runOnWorkspace({
+    workspaceId,
+    options,
+  }: RunOnWorkspaceArgs): Promise<void> {
+    const isDryRun = options.dryRun ?? false;
+
+    this.logger.log(
+      `${isDryRun ? '[DRY RUN] ' : ''}Running MigrateWorkflowCodeStepsCommand for workspace ${workspaceId}`,
+    );
+
+    const workflowVersionRepository =
+      await this.globalWorkspaceOrmManager.getRepository<WorkflowVersionWorkspaceEntity>(
+        workspaceId,
+        'workflowVersion',
+        { shouldBypassPermissionChecks: true },
+      );
+
+    const workflowVersions = await workflowVersionRepository.find({
+      select: ['id', 'steps', 'status'],
+      where: {
+        status: In([
+          WorkflowVersionStatus.DRAFT,
+          WorkflowVersionStatus.ACTIVE,
+          WorkflowVersionStatus.DEACTIVATED,
+        ]),
+      },
+    });
+
+    let migratedCount = 0;
+
+    for (const version of workflowVersions) {
+      const steps = version.steps;
+
+      if (!isDefined(steps) || !Array.isArray(steps) || steps.length === 0) {
+        continue;
+      }
+
+      const untypedSteps = steps as UntypedStep[];
+      const hasLegacySteps = untypedSteps.some(isLegacyCodeStep);
+
+      if (!hasLegacySteps) {
+        continue;
+      }
+
+      const migratedSteps = untypedSteps.map((step) => {
+        if (!isLegacyCodeStep(step)) {
+          return step;
+        }
+
+        const legacyInput = step.settings.input as LegacyCodeStepInput;
+
+        this.logger.log(
+          `${isDryRun ? '[DRY RUN] ' : ''}Migrating CODE step ${step.id} in workflow version ${version.id}: ` +
+            `serverlessFunctionId=${legacyInput.serverlessFunctionId} → logicFunctionId`,
+        );
+
+        return {
+          ...step,
+          settings: {
+            ...step.settings,
+            input: {
+              logicFunctionId: legacyInput.serverlessFunctionId,
+              logicFunctionInput: legacyInput.serverlessFunctionInput ?? {},
+            },
+          },
+        };
+      }) as WorkflowAction[];
+
+      if (!isDryRun) {
+        await workflowVersionRepository.update(
+          { id: version.id },
+          { steps: migratedSteps },
+        );
+      }
+
+      migratedCount++;
+    }
+
+    this.logger.log(
+      `${isDryRun ? '[DRY RUN] ' : ''}Migrated ${migratedCount} workflow version(s) in workspace ${workspaceId}`,
+    );
+  }
+}

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-18/1-18-upgrade-version-command.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-18/1-18-upgrade-version-command.module.ts
@@ -9,6 +9,7 @@ import { MigrateActivityRichTextAttachmentFileIdsCommand } from 'src/database/co
 import { MigrateAttachmentFilesCommand } from 'src/database/commands/upgrade-version-command/1-18/1-18-migrate-attachment-files.command';
 import { MigrateFavoritesToNavigationMenuItemsCommand } from 'src/database/commands/upgrade-version-command/1-18/1-18-migrate-favorites-to-navigation-menu-items.command';
 import { MigratePersonAvatarFilesCommand } from 'src/database/commands/upgrade-version-command/1-18/1-18-migrate-person-avatar-files.command';
+import { MigrateWorkflowCodeStepsCommand } from 'src/database/commands/upgrade-version-command/1-18/1-18-migrate-workflow-code-steps.command';
 import { MigrateWorkflowSendEmailAttachmentsCommand } from 'src/database/commands/upgrade-version-command/1-18/1-18-migrate-workflow-send-email-attachments.command';
 import { MigrateWorkspacePicturesCommand } from 'src/database/commands/upgrade-version-command/1-18/1-18-migrate-workspace-pictures.command';
 import { ApplicationModule } from 'src/engine/core-modules/application/application.module';
@@ -65,6 +66,7 @@ import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/sta
     MigrateActivityRichTextAttachmentFileIdsCommand,
     BackfillMessageChannelThrottleRetryAfterCommand,
     BackfillStandardViewsAndFieldMetadataCommand,
+    MigrateWorkflowCodeStepsCommand,
     MigrateWorkflowSendEmailAttachmentsCommand,
   ],
   exports: [
@@ -76,6 +78,7 @@ import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/sta
     BackfillMessageChannelThrottleRetryAfterCommand,
     BackfillStandardViewsAndFieldMetadataCommand,
     MigrateWorkspacePicturesCommand,
+    MigrateWorkflowCodeStepsCommand,
     MigrateWorkflowSendEmailAttachmentsCommand,
     BackfillFileSizeAndMimeTypeCommand,
   ],

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/upgrade.command.ts
@@ -25,6 +25,7 @@ import { MigrateActivityRichTextAttachmentFileIdsCommand } from 'src/database/co
 import { MigrateAttachmentFilesCommand } from 'src/database/commands/upgrade-version-command/1-18/1-18-migrate-attachment-files.command';
 import { MigrateFavoritesToNavigationMenuItemsCommand } from 'src/database/commands/upgrade-version-command/1-18/1-18-migrate-favorites-to-navigation-menu-items.command';
 import { MigratePersonAvatarFilesCommand } from 'src/database/commands/upgrade-version-command/1-18/1-18-migrate-person-avatar-files.command';
+import { MigrateWorkflowCodeStepsCommand } from 'src/database/commands/upgrade-version-command/1-18/1-18-migrate-workflow-code-steps.command';
 import { MigrateWorkflowSendEmailAttachmentsCommand } from 'src/database/commands/upgrade-version-command/1-18/1-18-migrate-workflow-send-email-attachments.command';
 import { MigrateWorkspacePicturesCommand } from 'src/database/commands/upgrade-version-command/1-18/1-18-migrate-workspace-pictures.command';
 import { AddMissingSystemFieldsToStandardObjectsCommand } from 'src/database/commands/upgrade-version-command/1-19/1-19-add-missing-system-fields-to-standard-objects.command';
@@ -81,6 +82,7 @@ export class UpgradeCommand extends UpgradeCommandRunner {
     protected readonly backfillMessageChannelThrottleRetryAfterCommand: BackfillMessageChannelThrottleRetryAfterCommand,
     protected readonly backfillStandardViewsAndFieldMetadataCommand: BackfillStandardViewsAndFieldMetadataCommand,
     protected readonly migrateWorkspacePicturesCommand: MigrateWorkspacePicturesCommand,
+    protected readonly migrateWorkflowCodeStepsCommand: MigrateWorkflowCodeStepsCommand,
     protected readonly migrateWorkflowSendEmailAttachmentsCommand: MigrateWorkflowSendEmailAttachmentsCommand,
 
     // 1.19 Commands
@@ -131,6 +133,7 @@ export class UpgradeCommand extends UpgradeCommandRunner {
       this.migrateAttachmentFilesCommand,
       this.migrateActivityRichTextAttachmentFileIdsCommand,
       this.migrateWorkspacePicturesCommand,
+      this.migrateWorkflowCodeStepsCommand,
       this.migrateWorkflowSendEmailAttachmentsCommand,
       this.backfillFileSizeAndMimeTypeCommand,
       this.backfillMessageChannelThrottleRetryAfterCommand,


### PR DESCRIPTION
The upgrade command that migrates CODE step JSONB fields from serverlessFunctionId to logicFunctionId was deleted in #18074, breaking self-hosted instances upgrading from v1.16 to v1.18+.