### PR TITLE
fix: restore overflow +N count for multi-select chips in table cells

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/display/components/MultiSelectFieldDisplay.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/display/components/MultiSelectFieldDisplay.tsx
@@ -1,14 +1,10 @@
-import { useFieldFocus } from '@/object-record/record-field/ui/hooks/useFieldFocus';
 import { useMultiSelectFieldDisplay } from '@/object-record/record-field/ui/meta-types/hooks/useMultiSelectFieldDisplay';
-import { MultiSelectDisplay } from '@/ui/field/display/components/MultiSelectDisplay';
 import { ExpandableList } from '@/ui/layout/expandable-list/components/ExpandableList';
 import { Tag } from 'twenty-ui/components';
 import { isDefined } from 'twenty-shared/utils';
 
 export const MultiSelectFieldDisplay = () => {
   const { fieldValue, fieldDefinition } = useMultiSelectFieldDisplay();
-
-  const { isFocused } = useFieldFocus();
 
   const selectedOptions = fieldValue
     ? fieldDefinition.metadata.options?.filter((option) =>
@@ -18,8 +14,8 @@ export const MultiSelectFieldDisplay = () => {
 
   if (!isDefined(selectedOptions)) return null;
 
-  return isFocused ? (
-    <ExpandableList isChipCountDisplayed={isFocused}>
+  return (
+    <ExpandableList>
       {selectedOptions.map((selectedOption, index) => (
         <Tag
           key={index}
@@ -28,10 +24,5 @@ export const MultiSelectFieldDisplay = () => {
         />
       ))}
     </ExpandableList>
-  ) : (
-    <MultiSelectDisplay
-      values={fieldValue}
-      options={fieldDefinition.metadata.options}
-    />
   );
 };


### PR DESCRIPTION
## Problem

Fixes #18729 (multi-select aspect)

The table performance optimization (commit `159bb9d7`, [#18304](https://github.com/twentyhq/twenty/pull/18304)) replaced `FieldFocusContextProvider` with `FieldFocusStaticUnfocusedProvider`, which hardcodes `isFocused = false` in all table cells.

`MultiSelectFieldDisplay` used `isFocused` to conditionally render:
- **When focused (hovered):** `<ExpandableList isChipCountDisplayed={isFocused}>` — shows +N overflow badge  
- **When unfocused (default):** `<MultiSelectDisplay>` — `overflow: hidden` with no overflow indicator

Since `isFocused` is **always `false`** after the perf optimization, the `ExpandableList` was never rendered. Overflowing tags were silently hidden with no visual indicator of how many values are missing.

## Root Cause

Same as [#18778](https://github.com/twentyhq/twenty/pull/18778) for relation-to-many fields:
- `ExpandableList` has two modes: props-controlled (`isChipCountDisplayed` prop) and internal mouse-hover
- Passing `isChipCountDisplayed={false}` **disables** the internal hover fallback entirely
- Since `isFocused` is always false, the +N badge never appeared

## Fix

Always render `<ExpandableList>` without `isChipCountDisplayed` prop, letting it use its own internal mouse-hover state to show the overflow count badge.

Remove the now-unused `useFieldFocus` import and `MultiSelectDisplay` fallback (which was only needed for the unfocused case).

## Before / After

| State | Before | After |
|-------|--------|-------|
| Normal (unfocused) | Tags clipped with no count | Tags shown with +N badge on hover |
| Hovered | ExpandableList shown (never reached) | ExpandableList with +N badge |