### PR TITLE
fix: emails and phones field display overflow and missing +N chip count

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/display/components/MultiSelectFieldDisplay.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/display/components/MultiSelectFieldDisplay.tsx
@@ -1,14 +1,10 @@
-import { useFieldFocus } from '@/object-record/record-field/ui/hooks/useFieldFocus';
 import { useMultiSelectFieldDisplay } from '@/object-record/record-field/ui/meta-types/hooks/useMultiSelectFieldDisplay';
-import { MultiSelectDisplay } from '@/ui/field/display/components/MultiSelectDisplay';
 import { ExpandableList } from '@/ui/layout/expandable-list/components/ExpandableList';
 import { Tag } from 'twenty-ui/components';
 import { isDefined } from 'twenty-shared/utils';
 
 export const MultiSelectFieldDisplay = () => {
   const { fieldValue, fieldDefinition } = useMultiSelectFieldDisplay();
-
-  const { isFocused } = useFieldFocus();
 
   const selectedOptions = fieldValue
     ? fieldDefinition.metadata.options?.filter((option) =>
@@ -18,8 +14,8 @@ export const MultiSelectFieldDisplay = () => {
 
   if (!isDefined(selectedOptions)) return null;
 
-  return isFocused ? (
-    <ExpandableList isChipCountDisplayed={isFocused}>
+  return (
+    <ExpandableList>
       {selectedOptions.map((selectedOption, index) => (
         <Tag
           key={index}
@@ -28,10 +24,5 @@ export const MultiSelectFieldDisplay = () => {
         />
       ))}
     </ExpandableList>
-  ) : (
-    <MultiSelectDisplay
-      values={fieldValue}
-      options={fieldDefinition.metadata.options}
-    />
   );
 };

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/display/components/PhonesFieldDisplay.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/display/components/PhonesFieldDisplay.tsx
@@ -1,4 +1,3 @@
-import { useFieldFocus } from '@/object-record/record-field/ui/hooks/useFieldFocus';
 import { usePhonesFieldDisplay } from '@/object-record/record-field/ui/meta-types/hooks/usePhonesFieldDisplay';
 import { PhonesDisplay } from '@/ui/field/display/components/PhonesDisplay';
 import { useLingui } from '@lingui/react/macro';
@@ -9,7 +8,6 @@ import { useCopyToClipboard } from '~/hooks/useCopyToClipboard';
 export const PhonesFieldDisplay = () => {
   const { fieldValue, fieldDefinition } = usePhonesFieldDisplay();
   const { copyToClipboard } = useCopyToClipboard();
-  const { isFocused } = useFieldFocus();
 
   const { t } = useLingui();
 
@@ -28,7 +26,6 @@ export const PhonesFieldDisplay = () => {
   return (
     <PhonesDisplay
       value={fieldValue}
-      isFocused={isFocused}
       onPhoneNumberClick={handleClick}
     />
   );

--- a/packages/twenty-front/src/modules/ui/field/display/components/EmailsDisplay.tsx
+++ b/packages/twenty-front/src/modules/ui/field/display/components/EmailsDisplay.tsx
@@ -2,32 +2,16 @@ import React, { useMemo } from 'react';
 
 import { type FieldEmailsValue } from '@/object-record/record-field/ui/types/FieldMetadata';
 import { ExpandableList } from '@/ui/layout/expandable-list/components/ExpandableList';
-import { styled } from '@linaria/react';
 import { isDefined } from 'twenty-shared/utils';
 import { RoundedLink } from 'twenty-ui/navigation';
 
 type EmailsDisplayProps = {
   value?: FieldEmailsValue;
-  isFocused?: boolean;
   onEmailClick?: (email: string, event: React.MouseEvent<HTMLElement>) => void;
 };
 
-const StyledContainer = styled.div`
-  align-items: center;
-  display: flex;
-  gap: 4px;
-  justify-content: flex-start;
-
-  max-width: 100%;
-
-  overflow: hidden;
-
-  width: 100%;
-`;
-
 export const EmailsDisplay = ({
   value,
-  isFocused,
   onEmailClick,
 }: EmailsDisplayProps) => {
   const emails = useMemo(
@@ -39,8 +23,8 @@ export const EmailsDisplay = ({
     [value?.primaryEmail, value?.additionalEmails],
   );
 
-  return isFocused ? (
-    <ExpandableList isChipCountDisplayed>
+  return (
+    <ExpandableList>
       {emails.map((email, index) => (
         <RoundedLink
           key={index}
@@ -50,16 +34,5 @@ export const EmailsDisplay = ({
         />
       ))}
     </ExpandableList>
-  ) : (
-    <StyledContainer>
-      {emails.map((email, index) => (
-        <RoundedLink
-          key={index}
-          label={email}
-          href={`mailto:${email}`}
-          onClick={(event) => onEmailClick?.(email, event)}
-        />
-      ))}
-    </StyledContainer>
   );
 };

--- a/packages/twenty-front/src/modules/ui/field/display/components/PhonesDisplay.tsx
+++ b/packages/twenty-front/src/modules/ui/field/display/components/PhonesDisplay.tsx
@@ -4,7 +4,6 @@ import React, { useMemo } from 'react';
 import { type FieldPhonesValue } from '@/object-record/record-field/ui/types/FieldMetadata';
 import { ExpandableList } from '@/ui/layout/expandable-list/components/ExpandableList';
 
-import { styled } from '@linaria/react';
 import { parsePhoneNumber } from 'libphonenumber-js';
 import { isDefined } from 'twenty-shared/utils';
 import { RoundedLink } from 'twenty-ui/navigation';
@@ -12,29 +11,14 @@ import { logError } from '~/utils/logError';
 
 type PhonesDisplayProps = {
   value?: FieldPhonesValue;
-  isFocused?: boolean;
   onPhoneNumberClick?: (
     phoneNumber: string,
     event: React.MouseEvent<HTMLElement>,
   ) => void;
 };
 
-const StyledContainer = styled.div`
-  align-items: center;
-  display: flex;
-  gap: 4px;
-  justify-content: flex-start;
-
-  max-width: 100%;
-
-  overflow: hidden;
-
-  width: 100%;
-`;
-
 export const PhonesDisplay = ({
   value,
-  isFocused,
   onPhoneNumberClick,
 }: PhonesDisplayProps) => {
   const phones = useMemo(
@@ -73,8 +57,8 @@ export const PhonesDisplay = ({
     }
   };
 
-  return isFocused ? (
-    <ExpandableList isChipCountDisplayed>
+  return (
+    <ExpandableList>
       {phones.map(({ number, callingCode }, index) => {
         const { parsedPhone, invalidPhone } =
           parsePhoneNumberOrReturnInvalidValue(callingCode + number);
@@ -93,26 +77,6 @@ export const PhonesDisplay = ({
         );
       })}
     </ExpandableList>
-  ) : (
-    <StyledContainer>
-      {phones.map(({ number, callingCode }, index) => {
-        const { parsedPhone, invalidPhone } =
-          parsePhoneNumberOrReturnInvalidValue(callingCode + number);
-        const URI = parsedPhone?.getURI();
-        return (
-          <RoundedLink
-            key={index}
-            href={URI || ''}
-            label={
-              parsedPhone ? parsedPhone.formatInternational() : invalidPhone
-            }
-            onClick={(event) =>
-              onPhoneNumberClick?.(callingCode + number, event)
-            }
-          />
-        );
-      })}
-    </StyledContainer>
   );
 };
 


### PR DESCRIPTION
## Problem

In table cells, `FieldFocusStaticUnfocusedProvider` (introduced in commit `159bb9d7` for performance optimization) hardcodes `isFocused = false`. Both `EmailsDisplay` and `PhonesDisplay` had a conditional pattern:

```tsx
return isFocused ? (
  <ExpandableList isChipCountDisplayed>...</ExpandableList>
) : (
  <StyledContainer> {/* overflow: hidden, no +N count */} </StyledContainer>
);
```

Since `isFocused` is always `false` in table cells, these fields:
- Always render with `overflow: hidden` (content clipped)
- Never show the `+N` overflow chip count

Additionally, `EmailsFieldDisplay` never passed `isFocused` at all, so the bug existed even outside the table performance optimization context.

## Fix

Remove the `isFocused` conditional and always render `<ExpandableList>` without the `isChipCountDisplayed` prop. This lets `ExpandableList`'s internal mouse-hover state control the overflow chip count display — consistent with how `RelationFromManyFieldDisplay` and `MultiSelectFieldDisplay` work.

**Changes:**
- `EmailsDisplay`: remove `isFocused` prop and `StyledContainer`, always render `<ExpandableList>`
- `PhonesDisplay`: same as above, also remove unused `styled` import
- `PhonesFieldDisplay`: remove `useFieldFocus` import and `isFocused` prop pass-through

## Root cause

Same root cause as #18778 (relation chip count) and #18781 (multi-select chip count) — the `FieldFocusStaticUnfocusedProvider` performance optimization broke components that conditionally rendered based on `isFocused`.