### PR TITLE
fix: remove redundant cookie write that made tokenPair a session cookie

### DIFF
--- a/packages/twenty-front/src/modules/auth/hooks/useAuth.ts
+++ b/packages/twenty-front/src/modules/auth/hooks/useAuth.ts
@@ -63,7 +63,6 @@ import { i18n } from '@lingui/core';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { SOURCE_LOCALE } from 'twenty-shared/translations';
 import { isDefined } from 'twenty-shared/utils';
-import { cookieStorage } from '~/utils/cookie-storage';
 import { getWorkspaceUrl } from '~/utils/getWorkspaceUrl';
 import { useStore } from 'jotai';
 
@@ -179,7 +178,6 @@ export const useAuth = () => {
   const handleSetAuthTokens = useCallback(
     (tokens: AuthTokenPair) => {
       setTokenPair(tokens);
-      cookieStorage.setItem('tokenPair', JSON.stringify(tokens));
     },
     [setTokenPair],
   );


### PR DESCRIPTION
## Summary

- Removes a redundant direct `cookieStorage.setItem('tokenPair', ...)` call in `handleSetAuthTokens` that was overwriting the Jotai-managed cookie (which has a 180-day expiry) with a session cookie (no expiry)
- This caused users to be logged out whenever their browser fully closed, instead of staying authenticated for 180 days

## Root cause

In April 2025 (`a7e6564017`), a direct `cookieStorage.setItem` call was added alongside `setTokenPair()` as a workaround because Recoil's `onSet` effect fired too late for the Apollo client to read the token synchronously.

In February 2026 (`674f4353cd`), `tokenPairState` was migrated from Recoil to Jotai's `atomWithStorage`, which writes the cookie **synchronously** with a 180-day `expires`. The old direct write was left in place and now runs *after* the Jotai write, overwriting the cookie without an `expires` — making it a session cookie.

## Test plan

- [ ] Log in to the app
- [ ] Inspect the `tokenPair` cookie in DevTools → Application → Cookies
- [ ] Verify the cookie has an expiration date ~180 days from now (not "Session")
- [ ] Close and reopen the browser — confirm you remain logged in


Made with [Cursor](https://cursor.com)