### PR TITLE
fix: update workspace members state on profile onboarding completion

### DIFF
--- a/packages/twenty-front/src/pages/onboarding/CreateProfile.tsx
+++ b/packages/twenty-front/src/pages/onboarding/CreateProfile.tsx
@@ -11,6 +11,7 @@ import { SubTitle } from '@/auth/components/SubTitle';
 import { Title } from '@/auth/components/Title';
 import { currentUserState } from '@/auth/states/currentUserState';
 import { currentWorkspaceMemberState } from '@/auth/states/currentWorkspaceMemberState';
+import { currentWorkspaceMembersState } from '@/auth/states/currentWorkspaceMembersState';
 import { CoreObjectNameSingular } from 'twenty-shared/types';
 import { useUpdateOneRecord } from '@/object-record/hooks/useUpdateOneRecord';
 import { useSetNextOnboardingStatus } from '@/onboarding/hooks/useSetNextOnboardingStatus';
@@ -74,6 +75,9 @@ export const CreateProfile = () => {
     currentWorkspaceMemberState,
   );
   const setCurrentUser = useSetAtomState(currentUserState);
+  const setCurrentWorkspaceMembers = useSetAtomState(
+    currentWorkspaceMembersState,
+  );
   const { updateOneRecord } = useUpdateOneRecord();
 
   // Form
@@ -128,6 +132,20 @@ export const CreateProfile = () => {
           return current;
         });
 
+        setCurrentWorkspaceMembers((members) =>
+          members.map((member) =>
+            member.id === currentWorkspaceMember?.id
+              ? {
+                  ...member,
+                  name: {
+                    firstName: data.firstName,
+                    lastName: data.lastName,
+                  },
+                }
+              : member,
+          ),
+        );
+
         setCurrentUser((current) => {
           if (isDefined(current)) {
             return {
@@ -151,6 +169,7 @@ export const CreateProfile = () => {
       setNextOnboardingStatus,
       enqueueErrorSnackBar,
       setCurrentWorkspaceMember,
+      setCurrentWorkspaceMembers,
       setCurrentUser,
       updateOneRecord,
     ],


### PR DESCRIPTION
## Summary

Fixes #18610

After completing the CreateProfile onboarding step, `currentWorkspaceMembersState` (plural, used by `useActorFieldDisplay` to resolve "Created by" names) was never updated with the new name — only `currentWorkspaceMemberState` (singular) was. This caused "Created by" fields to display "Untitled" for the remainder of the session.

**Root cause analysis:**

The issue reporter attributed the bug to empty `core.user.firstName/lastName`, but `createdBy` display doesn't use `core.user` at all. The actual flow:

1. Sign-up creates workspace member with empty names (copied from empty `core.user`)
2. `GetCurrentUserDocument` loads `currentWorkspaceMembersState` with empty names
3. CreateProfile step updates workspace member in DB + `currentWorkspaceMemberState` (singular) ✓
4. `currentWorkspaceMembersState` (plural) is **never refreshed** — the query is skipped once `currentUser` exists
5. `useActorFieldDisplay` looks up from the stale plural state → empty name → "Untitled"

**Fix:** Update `currentWorkspaceMembersState` alongside `currentWorkspaceMemberState` in the CreateProfile submit handler.

