### PR TITLE
Avoid side panel tab overriden by show page

### DIFF
--- a/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabsRenderer.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabsRenderer.tsx
@@ -172,6 +172,7 @@ export const PageLayoutTabsRenderer = () => {
             <PageLayoutTabList
               tabs={sortedTabs}
               behaveAsLinks={!isInSidePanel && !isPageLayoutInEditMode}
+              isInSidePanel={isInSidePanel}
               componentInstanceId={tabListInstanceId}
               onAddTab={handleAddTab}
               isReorderEnabled={canEnableTabEditing}


### PR DESCRIPTION
Missing prop so layout are considered as the same