### PR TITLE
fix: decouple viewPicker favorite detection from sorted navigation menu items

### DIFF
--- a/packages/twenty-front/src/modules/views/view-picker/components/ViewPickerOptionDropdown.tsx
+++ b/packages/twenty-front/src/modules/views/view-picker/components/ViewPickerOptionDropdown.tsx
@@ -1,6 +1,5 @@
 import { useCreateNavigationMenuItem } from '@/navigation-menu-item/common/hooks/useCreateNavigationMenuItem';
 import { useNavigationMenuItemsData } from '@/navigation-menu-item/display/hooks/useNavigationMenuItemsData';
-import { useSortedNavigationMenuItems } from '@/navigation-menu-item/display/hooks/useSortedNavigationMenuItems';
 import { type ObjectRecord } from '@/object-record/types/ObjectRecord';
 import { useHasPermissionFlag } from '@/settings/roles/hooks/useHasPermissionFlag';
 import { DropdownContent } from '@/ui/layout/dropdown/components/DropdownContent';
@@ -55,15 +54,15 @@ export const ViewPickerOptionDropdown = ({
   const hasViewsPermission = useHasPermissionFlag(PermissionFlagType.VIEWS);
 
   const { createNavigationMenuItem } = useCreateNavigationMenuItem();
-  const { currentWorkspaceMemberId } = useNavigationMenuItemsData();
-  const { navigationMenuItemsSorted } = useSortedNavigationMenuItems();
+  const { navigationMenuItems, currentWorkspaceMemberId } =
+    useNavigationMenuItemsData();
 
   // Users with VIEWS permission can edit all views
   // Users without VIEWS permission can only edit unlisted views (which are always their own, filtered by backend)
   const canEditView =
     hasViewsPermission || view.visibility === ViewVisibility.UNLISTED;
 
-  const isFavorite = navigationMenuItemsSorted.some(
+  const isFavorite = navigationMenuItems.some(
     (item) =>
       item.viewId === view.id &&
       item.userWorkspaceId === currentWorkspaceMemberId,


### PR DESCRIPTION
## Summary

- Reverts the `useSortedNavigationMenuItems` coupling in `ViewPickerOptionDropdown` introduced by #18791
- The viewPicker now uses `useNavigationMenuItemsData` directly for the `isFavorite` check, keeping view ordering and navigation menu item ordering independent

## Why

PR #18791 replaced `useNavigationMenuItemsData` with `useSortedNavigationMenuItems` in the viewPicker for favorite detection. While the intent was to filter out stale/orphaned navigation items, this created an unnecessary coupling: `useSortedNavigationMenuItems` subscribes to `viewsSelector` and `objectMetadataItemsSelector`, making the viewPicker transitively dependent on the navigation menu item ordering system. View ordering in the picker (driven by `view.position`) and navigation menu item ordering (driven by `navigationMenuItem.position`) should remain decorrelated.

## Test plan

- [ ] Open the viewPicker dropdown and verify views are listed in correct order
- [ ] Drag-and-drop to reorder views in the viewPicker — confirm it works
- [ ] Verify the "Add to Favorite" / "Manage favorite" label still correctly reflects favorite state
- [ ] Reorder navigation menu items in the sidebar — confirm viewPicker order is unaffected


Made with [Cursor](https://cursor.com)