### PR TITLE
fix: restore original migration timestamp for messaging infrastructure

### DIFF
--- a/packages/twenty-server/src/database/typeorm/core/migrations/common/1773945207801-add-messaging-infrastructure-metadata-entities.ts
+++ b/packages/twenty-server/src/database/typeorm/core/migrations/common/1773945207801-add-messaging-infrastructure-metadata-entities.ts
@@ -1,9 +1,9 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class AddMessagingInfrastructureMetadataEntities1774005903909
+export class AddMessagingInfrastructureMetadataEntities1773945207801
   implements MigrationInterface
 {
-  name = 'AddMessagingInfrastructureMetadataEntities1774005903909';
+  name = 'AddMessagingInfrastructureMetadataEntities1773945207801';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(


### PR DESCRIPTION
## Summary
- Restores the original migration timestamp (`1773945207801`) that was accidentally changed to `1774005903909` during PR #18787
- Keeps the content improvements (default column values) from that PR intact

## Test plan
- [ ] Verify migration runs correctly with `npx nx run twenty-server:database:migrate:prod`


Made with [Cursor](https://cursor.com)