### PR TITLE
feat: add activity heatmap to record timeline

### DIFF
--- a/packages/twenty-front/package.json
+++ b/packages/twenty-front/package.json
@@ -51,6 +51,7 @@
     "@mantine/hooks": "^8.3.11",
     "@mantine/utils": "^6.0.22",
     "@monaco-editor/react": "^4.7.0",
+    "@nivo/calendar": "^0.99.0",
     "@nivo/core": "^0.99.0",
     "@nivo/line": "^0.99.0",
     "@nivo/pie": "^0.99.0",

--- a/packages/twenty-front/src/modules/activities/timeline-activities/components/ActivityHeatmap.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/components/ActivityHeatmap.tsx
@@ -1,0 +1,69 @@
+import { useActivityHeatmapData } from '@/activities/timeline-activities/hooks/useActivityHeatmapData';
+import { type TimelineActivity } from '@/activities/timeline-activities/types/TimelineActivity';
+import { styled } from '@linaria/react';
+import { ResponsiveCalendar } from '@nivo/calendar';
+import { useContext } from 'react';
+import { ThemeContext, themeCssVariables } from 'twenty-ui/theme-constants';
+
+const StyledHeatmapContainer = styled.div`
+  border-bottom: 1px solid ${themeCssVariables.border.color.light};
+  height: 160px;
+  margin-bottom: ${themeCssVariables.spacing[2]};
+  padding-bottom: ${themeCssVariables.spacing[4]};
+  width: 100%;
+`;
+
+type ActivityHeatmapProps = {
+  timelineActivities: TimelineActivity[];
+};
+
+export const ActivityHeatmap = ({
+  timelineActivities,
+}: ActivityHeatmapProps) => {
+  const { theme } = useContext(ThemeContext);
+  const { data, from, to } = useActivityHeatmapData(timelineActivities);
+
+  if (data.length === 0) {
+    return null;
+  }
+
+  return (
+    <StyledHeatmapContainer>
+      <ResponsiveCalendar
+        data={data}
+        from={from}
+        to={to}
+        emptyColor={theme.background.tertiary}
+        colors={[
+          theme.color.blue3,
+          theme.color.blue5,
+          theme.color.blue7,
+          theme.color.blue9,
+        ]}
+        margin={{ top: 20, right: 20, bottom: 0, left: 20 }}
+        yearSpacing={40}
+        monthBorderColor={theme.background.primary}
+        dayBorderWidth={2}
+        dayBorderColor={theme.background.primary}
+        monthLegendOffset={10}
+        theme={{
+          labels: {
+            text: {
+              fontSize: 11,
+              fill: theme.font.color.tertiary,
+            },
+          },
+          tooltip: {
+            container: {
+              background: theme.background.primary,
+              color: theme.font.color.primary,
+              fontSize: 12,
+              borderRadius: theme.border.radius.sm,
+              boxShadow: theme.boxShadow.light,
+            },
+          },
+        }}
+      />
+    </StyledHeatmapContainer>
+  );
+};

--- a/packages/twenty-front/src/modules/activities/timeline-activities/components/TimelineCard.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/components/TimelineCard.tsx
@@ -2,6 +2,7 @@ import { styled } from '@linaria/react';
 
 import { CustomResolverFetchMoreLoader } from '@/activities/components/CustomResolverFetchMoreLoader';
 import { SkeletonLoader } from '@/activities/components/SkeletonLoader';
+import { ActivityHeatmap } from '@/activities/timeline-activities/components/ActivityHeatmap';
 import { EventList } from '@/activities/timeline-activities/components/EventList';
 import { useTimelineActivities } from '@/activities/timeline-activities/hooks/useTimelineActivities';
 import { useLayoutRenderingContext } from '@/ui/layout/contexts/LayoutRenderingContext';
@@ -86,6 +87,7 @@ export const TimelineCard = () => {
 
   return (
     <StyledMainContainer>
+      <ActivityHeatmap timelineActivities={timelineActivities} />
       <EventList
         targetableObject={targetRecord}
         title={t`All`}

--- a/packages/twenty-front/src/modules/activities/timeline-activities/hooks/useActivityHeatmapData.ts
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/hooks/useActivityHeatmapData.ts
@@ -1,0 +1,36 @@
+import { useMemo } from 'react';
+
+import { type TimelineActivity } from '@/activities/timeline-activities/types/TimelineActivity';
+
+type HeatmapDayData = {
+  day: string;
+  value: number;
+};
+
+export const useActivityHeatmapData = (
+  timelineActivities: TimelineActivity[],
+) => {
+  return useMemo(() => {
+    const countsByDay = new Map<string, number>();
+
+    for (const activity of timelineActivities) {
+      const day = activity.createdAt.substring(0, 10);
+      countsByDay.set(day, (countsByDay.get(day) ?? 0) + 1);
+    }
+
+    const data: HeatmapDayData[] = [];
+
+    for (const [day, value] of countsByDay) {
+      data.push({ day, value });
+    }
+
+    const now = new Date();
+    const oneYearAgo = new Date(now);
+    oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
+
+    const from = oneYearAgo.toISOString().substring(0, 10);
+    const to = now.toISOString().substring(0, 10);
+
+    return { data, from, to };
+  }, [timelineActivities]);
+};

--- a/packages/twenty-front/src/modules/activities/timeline-activities/hooks/useActivityHeatmapData.ts
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/hooks/useActivityHeatmapData.ts
@@ -11,10 +11,22 @@ export const useActivityHeatmapData = (
   timelineActivities: TimelineActivity[],
 ) => {
   return useMemo(() => {
+    const now = new Date();
+    const oneYearAgo = new Date(now);
+    oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
+
+    const from = oneYearAgo.toISOString().substring(0, 10);
+    const to = now.toISOString().substring(0, 10);
+
     const countsByDay = new Map<string, number>();
 
     for (const activity of timelineActivities) {
       const day = activity.createdAt.substring(0, 10);
+
+      if (day < from || day > to) {
+        continue;
+      }
+
       countsByDay.set(day, (countsByDay.get(day) ?? 0) + 1);
     }
 
@@ -23,13 +35,6 @@ export const useActivityHeatmapData = (
     for (const [day, value] of countsByDay) {
       data.push({ day, value });
     }
-
-    const now = new Date();
-    const oneYearAgo = new Date(now);
-    oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
-
-    const from = oneYearAgo.toISOString().substring(0, 10);
-    const to = now.toISOString().substring(0, 10);
 
     return { data, from, to };
   }, [timelineActivities]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -56509,6 +56509,7 @@ __metadata:
     "@mantine/hooks": "npm:^8.3.11"
     "@mantine/utils": "npm:^6.0.22"
     "@monaco-editor/react": "npm:^4.7.0"
+    "@nivo/calendar": "npm:^0.99.0"
     "@nivo/core": "npm:^0.99.0"
     "@nivo/line": "npm:^0.99.0"
     "@nivo/pie": "npm:^0.99.0"


### PR DESCRIPTION
Adds a GitHub-style calendar heatmap to the timeline tab on record pages. Shows activity density over the past year — each cell is a day, colored by how many events (creates, updates, notes, tasks) happened.

Uses @nivo/calendar which follows the same Nivo patterns already used for the line/pie/bar charts in the graph widgets. The heatmap sits above the existing event list in TimelineCard and only renders when there's activity data.

Helps answer "when was the last time we engaged with this contact?" at a glance without scrolling through the full timeline.