### PR TITLE
fix: trigger data fetch at all scroll speeds in virtualized table

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-table/virtualization/components/RecordTableVirtualizedRowTreadmillEffect.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/virtualization/components/RecordTableVirtualizedRowTreadmillEffect.tsx
@@ -195,12 +195,10 @@ export const RecordTableVirtualizedRowTreadmillEffect = () => {
           SCROLL_SPEED_THRESHOLD_IN_ROWS_PER_SECOND_TO_DEACTIVATE_LOW_DETAILS
         ) {
           deactivateLowDetailsDebounced();
-
-          triggerFetchPages();
         }
-      } else {
-        triggerFetchPages();
       }
+
+      triggerFetchPages();
     },
     [
       lastScrollMeasurementsCallbackState,


### PR DESCRIPTION
Fixes #18819

When scrolling the record table at moderate speed (roughly 50-200 rows/s), data fetching never triggers. The scroll speed thresholds that control low-details rendering mode were also gating `triggerFetchPages()`, creating a dead zone where neither the fast-scroll nor slow-scroll branch would call it.

Moved `triggerFetchPages()` outside the speed threshold branches so it always fires on scroll. The speed thresholds now only control the visual rendering mode (skeletons vs full cells), which was the original intent.

This is safe because `triggerFetchPages` is already debounced (25ms, maxWait 2s) and `triggerFetchPagesWithoutDebounce` early-returns when low-details mode is active during fast scrolling.