### PR TITLE
fix: board view loads all records instead of showing skeleton placeholders

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-board/components/RecordBoardFetchMoreInViewTriggerComponent.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/components/RecordBoardFetchMoreInViewTriggerComponent.tsx
@@ -1,16 +1,19 @@
 import { styled } from '@linaria/react';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useInView } from 'react-intersection-observer';
 
 import { RECORD_BOARD_COLUMN_PADDING_AND_BORDER_WIDTH } from '@/object-record/record-board/constants/RecordBoardColumnPaddingAndBorderWidth';
 
 import { RECORD_BOARD_COLUMN_WIDTH } from '@/object-record/record-board/constants/RecordBoardColumnWidth';
+import { RECORD_BOARD_QUERY_PAGE_SIZE } from '@/object-record/record-board/constants/RecordBoardQueryPageSize';
 import { recordBoardIsFetchingMoreComponentState } from '@/object-record/record-board/states/recordBoardIsFetchingMoreComponentState';
 import { recordBoardShouldFetchMoreComponentState } from '@/object-record/record-board/states/recordBoardShouldFetchMoreComponentState';
+import { visibleRecordFieldsComponentSelector } from '@/object-record/record-field/states/visibleRecordFieldsComponentSelector';
 import { visibleRecordGroupIdsComponentFamilySelector } from '@/object-record/record-group/states/selectors/visibleRecordGroupIdsComponentFamilySelector';
 import { recordIndexRecordGroupsAreInInitialLoadingComponentState } from '@/object-record/record-index/states/recordIndexRecordGroupsAreInInitialLoadingComponentState';
 import { useScrollWrapperHTMLElement } from '@/ui/utilities/scroll/hooks/useScrollWrapperHTMLElement';
 import { useAtomComponentFamilySelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentFamilySelectorValue';
+import { useAtomComponentSelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentSelectorValue';
 import { useAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useAtomComponentState';
 import { useAtomComponentStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentStateValue';
 import { ViewType } from '@/views/types/ViewType';
@@ -19,6 +22,9 @@ const StyledFetchMoreTriggerDiv = styled.div<{ width: number }>`
   max-width: ${({ width }) => width}px;
   min-width: ${({ width }) => width}px;
 `;
+
+const ESTIMATED_BOARD_CARD_HEIGHT_BASE = 60;
+const ESTIMATED_BOARD_CARD_FIELD_ROW_HEIGHT = 28;
 
 export const RecordBoardFetchMoreInViewTriggerComponent = () => {
   const [recordBoardShouldFetchMore, setRecordBoardShouldFetchMore] =
@@ -32,10 +38,24 @@ export const RecordBoardFetchMoreInViewTriggerComponent = () => {
     recordBoardIsFetchingMoreComponentState,
   );
 
+  const visibleRecordFields = useAtomComponentSelectorValue(
+    visibleRecordFieldsComponentSelector,
+  );
+
+  // Scale detection zone with card height (driven by visible field count)
+  // so the trigger fires before skeleton cards become visible to the user
+  const rootMargin = useMemo(() => {
+    const estimatedCardHeight =
+      ESTIMATED_BOARD_CARD_HEIGHT_BASE +
+      visibleRecordFields.length * ESTIMATED_BOARD_CARD_FIELD_ROW_HEIGHT;
+
+    return `${estimatedCardHeight * RECORD_BOARD_QUERY_PAGE_SIZE * 2}px`;
+  }, [visibleRecordFields.length]);
+
   const { scrollWrapperHTMLElement } = useScrollWrapperHTMLElement();
 
   const { ref, inView } = useInView({
-    rootMargin: '1600px',
+    rootMargin,
     root: scrollWrapperHTMLElement,
   });
 

--- a/packages/twenty-front/src/modules/object-record/record-board/components/RecordBoardFetchMoreInViewTriggerComponent.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/components/RecordBoardFetchMoreInViewTriggerComponent.tsx
@@ -1,7 +1,8 @@
 import { styled } from '@linaria/react';
-import { useEffect, useMemo } from 'react';
+import { useEffect } from 'react';
 import { useInView } from 'react-intersection-observer';
 
+import { SKELETON_LOADER_HEIGHT_SIZES } from '@/activities/components/SkeletonLoader';
 import { RECORD_BOARD_COLUMN_PADDING_AND_BORDER_WIDTH } from '@/object-record/record-board/constants/RecordBoardColumnPaddingAndBorderWidth';
 
 import { RECORD_BOARD_COLUMN_WIDTH } from '@/object-record/record-board/constants/RecordBoardColumnWidth';
@@ -23,8 +24,15 @@ const StyledFetchMoreTriggerDiv = styled.div<{ width: number }>`
   min-width: ${({ width }) => width}px;
 `;
 
-const ESTIMATED_BOARD_CARD_HEIGHT_BASE = 60;
-const ESTIMATED_BOARD_CARD_FIELD_ROW_HEIGHT = 28;
+// RecordCardHeaderContainer: height (24px) + padding top spacing(2) + padding bottom spacing(1)
+const BOARD_CARD_HEADER_HEIGHT = 24 + 8 + 4;
+
+// Per field row: skeleton height + RecordCardBodyContainer padding-bottom spacing(2) + StyledBodyContainer gap spacing(0.5)
+const BOARD_CARD_FIELD_ROW_HEIGHT =
+  SKELETON_LOADER_HEIGHT_SIZES.standard.s + 8 + 2;
+
+// StyledBodyContainer padding (4+4) + card border (2×1px) + StyledSkeletonCardContainer margin-bottom spacing(2)
+const BOARD_CARD_CHROME_HEIGHT = 8 + 2 + 8;
 
 export const RecordBoardFetchMoreInViewTriggerComponent = () => {
   const [recordBoardShouldFetchMore, setRecordBoardShouldFetchMore] =
@@ -42,15 +50,12 @@ export const RecordBoardFetchMoreInViewTriggerComponent = () => {
     visibleRecordFieldsComponentSelector,
   );
 
-  // Scale detection zone with card height (driven by visible field count)
-  // so the trigger fires before skeleton cards become visible to the user
-  const rootMargin = useMemo(() => {
-    const estimatedCardHeight =
-      ESTIMATED_BOARD_CARD_HEIGHT_BASE +
-      visibleRecordFields.length * ESTIMATED_BOARD_CARD_FIELD_ROW_HEIGHT;
+  const estimatedCardHeight =
+    BOARD_CARD_HEADER_HEIGHT +
+    visibleRecordFields.length * BOARD_CARD_FIELD_ROW_HEIGHT +
+    BOARD_CARD_CHROME_HEIGHT;
 
-    return `${estimatedCardHeight * RECORD_BOARD_QUERY_PAGE_SIZE * 2}px`;
-  }, [visibleRecordFields.length]);
+  const rootMargin = `${estimatedCardHeight * RECORD_BOARD_QUERY_PAGE_SIZE * 2}px`;
 
   const { scrollWrapperHTMLElement } = useScrollWrapperHTMLElement();
 

--- a/packages/twenty-front/src/modules/object-record/record-board/hooks/useTriggerRecordBoardFetchMore.ts
+++ b/packages/twenty-front/src/modules/object-record/record-board/hooks/useTriggerRecordBoardFetchMore.ts
@@ -7,6 +7,7 @@ import { RECORD_BOARD_QUERY_PAGE_SIZE } from '@/object-record/record-board/const
 
 import { recordBoardCurrentGroupByQueryOffsetComponentState } from '@/object-record/record-board/states/recordBoardCurrentGroupByQueryOffsetComponentState';
 import { recordBoardIsFetchingMoreComponentState } from '@/object-record/record-board/states/recordBoardIsFetchingMoreComponentState';
+import { recordBoardShouldFetchMoreComponentState } from '@/object-record/record-board/states/recordBoardShouldFetchMoreComponentState';
 import { recordBoardShouldFetchMoreInColumnComponentFamilyState } from '@/object-record/record-board/states/recordBoardShouldFetchMoreInColumnComponentFamilyState';
 import { recordGroupDefinitionsComponentSelector } from '@/object-record/record-group/states/selectors/recordGroupDefinitionsComponentSelector';
 import { useRecordIndexContextOrThrow } from '@/object-record/record-index/contexts/RecordIndexContext';
@@ -66,6 +67,11 @@ export const useTriggerRecordBoardFetchMore = () => {
     recordBoardIsFetchingMoreComponentState,
   );
 
+  const recordBoardShouldFetchMoreCallbackState =
+    useAtomComponentStateCallbackState(
+      recordBoardShouldFetchMoreComponentState,
+    );
+
   const triggerRecordBoardFetchMore = useCallback(async () => {
     const isAlreadyFetchingMore = store.get(recordBoardIsFetchingMore);
 
@@ -79,132 +85,144 @@ export const useTriggerRecordBoardFetchMore = () => {
 
     store.set(recordBoardIsFetchingMore, true);
 
-    const currentOffset = store.get(
-      recordBoardCurrentGroupByQueryOffsetCallbackState,
-    );
-
-    const newOffset = currentOffset + RECORD_BOARD_QUERY_PAGE_SIZE;
-
-    const recordGroupValuesThatShouldBeFetched = recordGroupDefinitions
-      .filter((recordGroupDefinition) => {
-        return store.get(
-          recordBoardShouldFetchMoreInColumnFamilyCallbackState(
-            recordGroupDefinition.id,
-          ),
-        );
-      })
-      .map((recordGroupDefinition) => recordGroupDefinition.value)
-      .filter(isDefined);
-
-    if (!isNonEmptyArray(recordGroupValuesThatShouldBeFetched)) {
-      cleanStateBeforeExit();
-
-      return;
-    }
-
-    const recordIndexGroupsRecordsGroupByLazyQueryResult =
-      await executeRecordIndexGroupsRecordsLazyGroupBy({
-        variables: {
-          offsetForRecords: newOffset,
-          filter: {
-            ...combinedFilters,
-            [recordIndexGroupFieldMetadataItem?.name ?? '']: {
-              in: [...recordGroupValuesThatShouldBeFetched],
-            },
-          },
-        },
-      });
-
-    store.set(recordBoardCurrentGroupByQueryOffsetCallbackState, newOffset);
-
-    if (!isDefined(recordIndexGroupsRecordsGroupByLazyQueryResult)) {
-      cleanStateBeforeExit();
-
-      return;
-    }
-
     const queryFieldName =
       getGroupByQueryResultGqlFieldName(objectMetadataItem);
-
-    const groups =
-      recordIndexGroupsRecordsGroupByLazyQueryResult.data?.[queryFieldName];
-
-    if (!isDefined(groups)) {
-      cleanStateBeforeExit();
-
-      return;
-    }
 
     const sortedRecordGroupDefinitions = recordGroupDefinitions.toSorted(
       sortByProperty('position'),
     );
 
-    for (const recordGroupDefinition of sortedRecordGroupDefinitions) {
-      const foundGroupInResult = groups.find(
-        (recordGroup: any) =>
-          (recordGroup.groupByDimensionValues[0] as string) ===
-          recordGroupDefinition.value,
+    let hasMorePages = true;
+
+    while (hasMorePages) {
+      const currentOffset = store.get(
+        recordBoardCurrentGroupByQueryOffsetCallbackState,
       );
 
-      if (!isDefined(foundGroupInResult)) {
-        store.set(
-          recordBoardShouldFetchMoreInColumnFamilyCallbackState(
-            recordGroupDefinition.id,
-          ),
-          false,
-        );
-        continue;
+      const newOffset = currentOffset + RECORD_BOARD_QUERY_PAGE_SIZE;
+
+      const recordGroupValuesThatShouldBeFetched = recordGroupDefinitions
+        .filter((recordGroupDefinition) => {
+          return store.get(
+            recordBoardShouldFetchMoreInColumnFamilyCallbackState(
+              recordGroupDefinition.id,
+            ),
+          );
+        })
+        .map((recordGroupDefinition) => recordGroupDefinition.value)
+        .filter(isDefined);
+
+      if (!isNonEmptyArray(recordGroupValuesThatShouldBeFetched)) {
+        hasMorePages = false;
+        break;
       }
 
-      const newRecords = getRecordsFromRecordConnection({
-        recordConnection: foundGroupInResult,
-      });
+      const recordIndexGroupsRecordsGroupByLazyQueryResult =
+        await executeRecordIndexGroupsRecordsLazyGroupBy({
+          variables: {
+            offsetForRecords: newOffset,
+            filter: {
+              ...combinedFilters,
+              [recordIndexGroupFieldMetadataItem?.name ?? '']: {
+                in: [...recordGroupValuesThatShouldBeFetched],
+              },
+            },
+          },
+        });
 
-      if (!isNonEmptyArray(newRecords)) {
-        store.set(
-          recordBoardShouldFetchMoreInColumnFamilyCallbackState(
-            recordGroupDefinition.id,
-          ),
-          false,
-        );
-        continue;
+      store.set(recordBoardCurrentGroupByQueryOffsetCallbackState, newOffset);
+
+      if (!isDefined(recordIndexGroupsRecordsGroupByLazyQueryResult)) {
+        hasMorePages = false;
+        break;
       }
 
-      const currentRecordIds = store.get(
-        recordIndexRecordIdsByGroupCallbackState(recordGroupDefinition.id),
-      ) as string[];
+      const groups =
+        recordIndexGroupsRecordsGroupByLazyQueryResult.data?.[queryFieldName];
 
-      const newRecordIds = currentRecordIds.concat(
-        newRecords.map((record) => record.id),
-      );
+      if (!isDefined(groups)) {
+        hasMorePages = false;
+        break;
+      }
 
-      store.set(
-        recordIndexRecordIdsByGroupCallbackState(recordGroupDefinition.id),
-        newRecordIds,
-      );
-
-      upsertRecordsInStore({ partialRecords: newRecords });
-
-      if (newRecords.length < RECORD_BOARD_QUERY_PAGE_SIZE) {
-        store.set(
-          recordBoardShouldFetchMoreInColumnFamilyCallbackState(
-            recordGroupDefinition.id,
-          ),
-          false,
+      for (const recordGroupDefinition of sortedRecordGroupDefinitions) {
+        const foundGroupInResult = groups.find(
+          (recordGroup: any) =>
+            (recordGroup.groupByDimensionValues[0] as string) ===
+            recordGroupDefinition.value,
         );
-      } else {
+
+        if (!isDefined(foundGroupInResult)) {
+          store.set(
+            recordBoardShouldFetchMoreInColumnFamilyCallbackState(
+              recordGroupDefinition.id,
+            ),
+            false,
+          );
+          continue;
+        }
+
+        const newRecords = getRecordsFromRecordConnection({
+          recordConnection: foundGroupInResult,
+        });
+
+        if (!isNonEmptyArray(newRecords)) {
+          store.set(
+            recordBoardShouldFetchMoreInColumnFamilyCallbackState(
+              recordGroupDefinition.id,
+            ),
+            false,
+          );
+          continue;
+        }
+
+        const currentRecordIds = store.get(
+          recordIndexRecordIdsByGroupCallbackState(recordGroupDefinition.id),
+        ) as string[];
+
+        const newRecordIds = currentRecordIds.concat(
+          newRecords.map((record) => record.id),
+        );
+
         store.set(
-          recordBoardShouldFetchMoreInColumnFamilyCallbackState(
-            recordGroupDefinition.id,
-          ),
-          true,
+          recordIndexRecordIdsByGroupCallbackState(recordGroupDefinition.id),
+          newRecordIds,
+        );
+
+        upsertRecordsInStore({ partialRecords: newRecords });
+
+        if (newRecords.length < RECORD_BOARD_QUERY_PAGE_SIZE) {
+          store.set(
+            recordBoardShouldFetchMoreInColumnFamilyCallbackState(
+              recordGroupDefinition.id,
+            ),
+            false,
+          );
+        } else {
+          store.set(
+            recordBoardShouldFetchMoreInColumnFamilyCallbackState(
+              recordGroupDefinition.id,
+            ),
+            true,
+          );
+        }
+
+        await sleep(
+          RECORD_BOARD_FETCH_MORE_THROTTLING_WAIT_TIME_IN_MILLISECONDS_TO_AVOID_REACT_FREEZE,
         );
       }
 
-      await sleep(
-        RECORD_BOARD_FETCH_MORE_THROTTLING_WAIT_TIME_IN_MILLISECONDS_TO_AVOID_REACT_FREEZE,
+      hasMorePages = recordGroupDefinitions.some(
+        (recordGroupDefinition) =>
+          store.get(
+            recordBoardShouldFetchMoreInColumnFamilyCallbackState(
+              recordGroupDefinition.id,
+            ),
+          ),
       );
     }
+
+    store.set(recordBoardShouldFetchMoreCallbackState, false);
 
     cleanStateBeforeExit();
   }, [
@@ -217,6 +235,7 @@ export const useTriggerRecordBoardFetchMore = () => {
     recordBoardIsFetchingMore,
     recordBoardCurrentGroupByQueryOffsetCallbackState,
     recordBoardShouldFetchMoreInColumnFamilyCallbackState,
+    recordBoardShouldFetchMoreCallbackState,
     combinedFilters,
     recordIndexGroupFieldMetadataItem,
   ]);

--- a/packages/twenty-front/src/modules/object-record/record-board/hooks/useTriggerRecordBoardFetchMore.ts
+++ b/packages/twenty-front/src/modules/object-record/record-board/hooks/useTriggerRecordBoardFetchMore.ts
@@ -85,144 +85,133 @@ export const useTriggerRecordBoardFetchMore = () => {
 
     store.set(recordBoardIsFetchingMore, true);
 
+    const currentOffset = store.get(
+      recordBoardCurrentGroupByQueryOffsetCallbackState,
+    );
+
+    const newOffset = currentOffset + RECORD_BOARD_QUERY_PAGE_SIZE;
+
+    const recordGroupValuesThatShouldBeFetched = recordGroupDefinitions
+      .filter((recordGroupDefinition) => {
+        return store.get(
+          recordBoardShouldFetchMoreInColumnFamilyCallbackState(
+            recordGroupDefinition.id,
+          ),
+        );
+      })
+      .map((recordGroupDefinition) => recordGroupDefinition.value)
+      .filter(isDefined);
+
+    if (!isNonEmptyArray(recordGroupValuesThatShouldBeFetched)) {
+      store.set(recordBoardShouldFetchMoreCallbackState, false);
+      cleanStateBeforeExit();
+
+      return;
+    }
+
+    const recordIndexGroupsRecordsGroupByLazyQueryResult =
+      await executeRecordIndexGroupsRecordsLazyGroupBy({
+        variables: {
+          offsetForRecords: newOffset,
+          filter: {
+            ...combinedFilters,
+            [recordIndexGroupFieldMetadataItem?.name ?? '']: {
+              in: [...recordGroupValuesThatShouldBeFetched],
+            },
+          },
+        },
+      });
+
+    store.set(recordBoardCurrentGroupByQueryOffsetCallbackState, newOffset);
+
+    if (!isDefined(recordIndexGroupsRecordsGroupByLazyQueryResult)) {
+      cleanStateBeforeExit();
+
+      return;
+    }
+
     const queryFieldName =
       getGroupByQueryResultGqlFieldName(objectMetadataItem);
+
+    const groups =
+      recordIndexGroupsRecordsGroupByLazyQueryResult.data?.[queryFieldName];
+
+    if (!isDefined(groups)) {
+      cleanStateBeforeExit();
+
+      return;
+    }
 
     const sortedRecordGroupDefinitions = recordGroupDefinitions.toSorted(
       sortByProperty('position'),
     );
 
-    let hasMorePages = true;
-
-    while (hasMorePages) {
-      const currentOffset = store.get(
-        recordBoardCurrentGroupByQueryOffsetCallbackState,
+    for (const recordGroupDefinition of sortedRecordGroupDefinitions) {
+      const foundGroupInResult = groups.find(
+        (recordGroup: any) =>
+          (recordGroup.groupByDimensionValues[0] as string) ===
+          recordGroupDefinition.value,
       );
 
-      const newOffset = currentOffset + RECORD_BOARD_QUERY_PAGE_SIZE;
-
-      const recordGroupValuesThatShouldBeFetched = recordGroupDefinitions
-        .filter((recordGroupDefinition) => {
-          return store.get(
-            recordBoardShouldFetchMoreInColumnFamilyCallbackState(
-              recordGroupDefinition.id,
-            ),
-          );
-        })
-        .map((recordGroupDefinition) => recordGroupDefinition.value)
-        .filter(isDefined);
-
-      if (!isNonEmptyArray(recordGroupValuesThatShouldBeFetched)) {
-        hasMorePages = false;
-        break;
-      }
-
-      const recordIndexGroupsRecordsGroupByLazyQueryResult =
-        await executeRecordIndexGroupsRecordsLazyGroupBy({
-          variables: {
-            offsetForRecords: newOffset,
-            filter: {
-              ...combinedFilters,
-              [recordIndexGroupFieldMetadataItem?.name ?? '']: {
-                in: [...recordGroupValuesThatShouldBeFetched],
-              },
-            },
-          },
-        });
-
-      store.set(recordBoardCurrentGroupByQueryOffsetCallbackState, newOffset);
-
-      if (!isDefined(recordIndexGroupsRecordsGroupByLazyQueryResult)) {
-        hasMorePages = false;
-        break;
-      }
-
-      const groups =
-        recordIndexGroupsRecordsGroupByLazyQueryResult.data?.[queryFieldName];
-
-      if (!isDefined(groups)) {
-        hasMorePages = false;
-        break;
-      }
-
-      for (const recordGroupDefinition of sortedRecordGroupDefinitions) {
-        const foundGroupInResult = groups.find(
-          (recordGroup: any) =>
-            (recordGroup.groupByDimensionValues[0] as string) ===
-            recordGroupDefinition.value,
-        );
-
-        if (!isDefined(foundGroupInResult)) {
-          store.set(
-            recordBoardShouldFetchMoreInColumnFamilyCallbackState(
-              recordGroupDefinition.id,
-            ),
-            false,
-          );
-          continue;
-        }
-
-        const newRecords = getRecordsFromRecordConnection({
-          recordConnection: foundGroupInResult,
-        });
-
-        if (!isNonEmptyArray(newRecords)) {
-          store.set(
-            recordBoardShouldFetchMoreInColumnFamilyCallbackState(
-              recordGroupDefinition.id,
-            ),
-            false,
-          );
-          continue;
-        }
-
-        const currentRecordIds = store.get(
-          recordIndexRecordIdsByGroupCallbackState(recordGroupDefinition.id),
-        ) as string[];
-
-        const newRecordIds = currentRecordIds.concat(
-          newRecords.map((record) => record.id),
-        );
-
+      if (!isDefined(foundGroupInResult)) {
         store.set(
-          recordIndexRecordIdsByGroupCallbackState(recordGroupDefinition.id),
-          newRecordIds,
+          recordBoardShouldFetchMoreInColumnFamilyCallbackState(
+            recordGroupDefinition.id,
+          ),
+          false,
         );
+        continue;
+      }
 
-        upsertRecordsInStore({ partialRecords: newRecords });
+      const newRecords = getRecordsFromRecordConnection({
+        recordConnection: foundGroupInResult,
+      });
 
-        if (newRecords.length < RECORD_BOARD_QUERY_PAGE_SIZE) {
-          store.set(
-            recordBoardShouldFetchMoreInColumnFamilyCallbackState(
-              recordGroupDefinition.id,
-            ),
-            false,
-          );
-        } else {
-          store.set(
-            recordBoardShouldFetchMoreInColumnFamilyCallbackState(
-              recordGroupDefinition.id,
-            ),
-            true,
-          );
-        }
+      if (!isNonEmptyArray(newRecords)) {
+        store.set(
+          recordBoardShouldFetchMoreInColumnFamilyCallbackState(
+            recordGroupDefinition.id,
+          ),
+          false,
+        );
+        continue;
+      }
 
-        await sleep(
-          RECORD_BOARD_FETCH_MORE_THROTTLING_WAIT_TIME_IN_MILLISECONDS_TO_AVOID_REACT_FREEZE,
+      const currentRecordIds = store.get(
+        recordIndexRecordIdsByGroupCallbackState(recordGroupDefinition.id),
+      ) as string[];
+
+      const newRecordIds = currentRecordIds.concat(
+        newRecords.map((record) => record.id),
+      );
+
+      store.set(
+        recordIndexRecordIdsByGroupCallbackState(recordGroupDefinition.id),
+        newRecordIds,
+      );
+
+      upsertRecordsInStore({ partialRecords: newRecords });
+
+      if (newRecords.length < RECORD_BOARD_QUERY_PAGE_SIZE) {
+        store.set(
+          recordBoardShouldFetchMoreInColumnFamilyCallbackState(
+            recordGroupDefinition.id,
+          ),
+          false,
+        );
+      } else {
+        store.set(
+          recordBoardShouldFetchMoreInColumnFamilyCallbackState(
+            recordGroupDefinition.id,
+          ),
+          true,
         );
       }
 
-      hasMorePages = recordGroupDefinitions.some(
-        (recordGroupDefinition) =>
-          store.get(
-            recordBoardShouldFetchMoreInColumnFamilyCallbackState(
-              recordGroupDefinition.id,
-            ),
-          ),
+      await sleep(
+        RECORD_BOARD_FETCH_MORE_THROTTLING_WAIT_TIME_IN_MILLISECONDS_TO_AVOID_REACT_FREEZE,
       );
     }
-
-    store.set(recordBoardShouldFetchMoreCallbackState, false);
 
     cleanStateBeforeExit();
   }, [

--- a/packages/twenty-front/src/modules/object-record/record-board/hooks/useTriggerRecordBoardInitialQuery.ts
+++ b/packages/twenty-front/src/modules/object-record/record-board/hooks/useTriggerRecordBoardInitialQuery.ts
@@ -3,6 +3,7 @@ import { RECORD_BOARD_QUERY_PAGE_SIZE } from '@/object-record/record-board/const
 import { useSetRecordIdsForColumn } from '@/object-record/record-board/hooks/useSetRecordIdsForColumn';
 import { lastRecordBoardQueryIdentifierComponentState } from '@/object-record/record-board/states/lastRecordBoardQueryIdentifierComponentState';
 import { recordBoardCurrentGroupByQueryOffsetComponentState } from '@/object-record/record-board/states/recordBoardCurrentGroupByQueryOffsetComponentState';
+import { recordBoardShouldFetchMoreComponentState } from '@/object-record/record-board/states/recordBoardShouldFetchMoreComponentState';
 import { recordBoardShouldFetchMoreInColumnComponentFamilyState } from '@/object-record/record-board/states/recordBoardShouldFetchMoreInColumnComponentFamilyState';
 import { recordGroupDefinitionsComponentSelector } from '@/object-record/record-group/states/selectors/recordGroupDefinitionsComponentSelector';
 import { useRecordIndexContextOrThrow } from '@/object-record/record-index/contexts/RecordIndexContext';
@@ -42,6 +43,11 @@ export const useTriggerRecordBoardInitialQuery = () => {
   const recordBoardShouldFetchMoreInColumnFamilyCallbackState =
     useAtomComponentFamilyStateCallbackState(
       recordBoardShouldFetchMoreInColumnComponentFamilyState,
+    );
+
+  const recordBoardShouldFetchMoreCallbackState =
+    useAtomComponentStateCallbackState(
+      recordBoardShouldFetchMoreComponentState,
     );
 
   const recordIndexRecordGroupsAreInInitialLoading =
@@ -163,6 +169,19 @@ export const useTriggerRecordBoardInitialQuery = () => {
       }
     }
 
+    const anyColumnNeedsMore = recordGroupDefinitions.some(
+      (recordGroupDefinition) =>
+        store.get(
+          recordBoardShouldFetchMoreInColumnFamilyCallbackState(
+            recordGroupDefinition.id,
+          ),
+        ),
+    );
+
+    if (anyColumnNeedsMore) {
+      store.set(recordBoardShouldFetchMoreCallbackState, true);
+    }
+
     cleanStateBeforeExit();
   }, [
     recordIndexRecordGroupsAreInInitialLoading,
@@ -177,6 +196,7 @@ export const useTriggerRecordBoardInitialQuery = () => {
     upsertRecordsInStore,
     setRecordIdsForColumn,
     recordBoardShouldFetchMoreInColumnFamilyCallbackState,
+    recordBoardShouldFetchMoreCallbackState,
   ]);
 
   return {

--- a/packages/twenty-front/src/modules/object-record/record-board/hooks/useTriggerRecordBoardInitialQuery.ts
+++ b/packages/twenty-front/src/modules/object-record/record-board/hooks/useTriggerRecordBoardInitialQuery.ts
@@ -3,7 +3,6 @@ import { RECORD_BOARD_QUERY_PAGE_SIZE } from '@/object-record/record-board/const
 import { useSetRecordIdsForColumn } from '@/object-record/record-board/hooks/useSetRecordIdsForColumn';
 import { lastRecordBoardQueryIdentifierComponentState } from '@/object-record/record-board/states/lastRecordBoardQueryIdentifierComponentState';
 import { recordBoardCurrentGroupByQueryOffsetComponentState } from '@/object-record/record-board/states/recordBoardCurrentGroupByQueryOffsetComponentState';
-import { recordBoardShouldFetchMoreComponentState } from '@/object-record/record-board/states/recordBoardShouldFetchMoreComponentState';
 import { recordBoardShouldFetchMoreInColumnComponentFamilyState } from '@/object-record/record-board/states/recordBoardShouldFetchMoreInColumnComponentFamilyState';
 import { recordGroupDefinitionsComponentSelector } from '@/object-record/record-group/states/selectors/recordGroupDefinitionsComponentSelector';
 import { useRecordIndexContextOrThrow } from '@/object-record/record-index/contexts/RecordIndexContext';
@@ -43,11 +42,6 @@ export const useTriggerRecordBoardInitialQuery = () => {
   const recordBoardShouldFetchMoreInColumnFamilyCallbackState =
     useAtomComponentFamilyStateCallbackState(
       recordBoardShouldFetchMoreInColumnComponentFamilyState,
-    );
-
-  const recordBoardShouldFetchMoreCallbackState =
-    useAtomComponentStateCallbackState(
-      recordBoardShouldFetchMoreComponentState,
     );
 
   const recordIndexRecordGroupsAreInInitialLoading =
@@ -169,19 +163,6 @@ export const useTriggerRecordBoardInitialQuery = () => {
       }
     }
 
-    const anyColumnNeedsMore = recordGroupDefinitions.some(
-      (recordGroupDefinition) =>
-        store.get(
-          recordBoardShouldFetchMoreInColumnFamilyCallbackState(
-            recordGroupDefinition.id,
-          ),
-        ),
-    );
-
-    if (anyColumnNeedsMore) {
-      store.set(recordBoardShouldFetchMoreCallbackState, true);
-    }
-
     cleanStateBeforeExit();
   }, [
     recordIndexRecordGroupsAreInInitialLoading,
@@ -196,7 +177,6 @@ export const useTriggerRecordBoardInitialQuery = () => {
     upsertRecordsInStore,
     setRecordIdsForColumn,
     recordBoardShouldFetchMoreInColumnFamilyCallbackState,
-    recordBoardShouldFetchMoreCallbackState,
   ]);
 
   return {


### PR DESCRIPTION
## Summary

- The record board (Kanban view) only loaded the first 10 records per column, then showed skeleton placeholder cards for the rest without ever fetching the remaining data
- **Root cause**: The `RecordBoardFetchMoreInViewTriggerComponent` (IntersectionObserver) is positioned at the bottom of the entire board. With 10 real cards + 10 skeleton cards per column (~3500px of content), the trigger div was pushed far beyond the 1600px `rootMargin` detection zone, so `recordBoardShouldFetchMore` never became `true` and fetch-more was never triggered
- **Fix**: The initial query now sets `recordBoardShouldFetchMore = true` when columns need more data, and `triggerRecordBoardFetchMore` uses an internal `while` loop to load all remaining pages in a single invocation — making it immune to the InView component racing to reset the flag between React render cycles

