### PR TITLE
Fix migration crash: agent.modelId NOT NULL violation

### DIFF
--- a/packages/twenty-server/src/database/typeorm/core/migrations/common/1773900000000-migrate-model-ids-to-composite-format.ts
+++ b/packages/twenty-server/src/database/typeorm/core/migrations/common/1773900000000-migrate-model-ids-to-composite-format.ts
@@ -25,14 +25,15 @@ export class MigrateModelIdsToCompositeFormat1773900000000
           OR array_length("enabledAiModelIds", 1) > 0`,
     );
 
-    // Clear agent-specific model IDs so they fall back to workspace defaults
+    // Reset agent model IDs to the sentinel so they fall back to workspace defaults
     await queryRunner.query(
-      `UPDATE "core"."agent" SET "modelId" = NULL WHERE "modelId" IS NOT NULL`,
+      `UPDATE "core"."agent"
+       SET "modelId" = 'default-smart-model'
+       WHERE "modelId" != 'default-smart-model'`,
     );
   }
 
   public async down(_queryRunner: QueryRunner): Promise<void> {
-    // No reversal needed — sentinel defaults and NULLed agent modelIds
-    // are safe to leave in place.
+    // No reversal needed — sentinel defaults are safe to leave in place.
   }
 }


### PR DESCRIPTION
## Summary

- The `MigrateModelIdsToCompositeFormat` migration was setting `agent.modelId = NULL`, but the column has a `NOT NULL` constraint — causing the migration to fail on deploy.
- Fixed by setting `modelId` to the `'default-smart-model'` sentinel value instead of NULL. The runtime already resolves this sentinel dynamically via `getEffectiveModelConfig` / `isDefaultModelSentinel`, so agents correctly fall back to the admin-configured smart model.

## Test plan

- [ ] Run `npx nx run twenty-server:database:migrate:prod` — migration should complete without errors
- [ ] Verify agents still resolve to the correct model at runtime (sentinel → `getDefaultPerformanceModel()`)


Made with [Cursor](https://cursor.com)