### PR TITLE
chore: trigger automerge for AI catalog sync PRs

### DIFF
--- a/.github/workflows/ci-ai-catalog-sync.yaml
+++ b/.github/workflows/ci-ai-catalog-sync.yaml
@@ -58,3 +58,11 @@ jobs:
           base: main
           labels: ai, automated
           delete-branch: true
+
+      - name: Trigger automerge
+        if: steps.changes.outputs.changed == 'true'
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.TWENTY_INFRA_TOKEN }}
+          repository: twentyhq/twenty-infra
+          event-type: automated-pr-ready


### PR DESCRIPTION
## Summary
- Adds a `repository-dispatch` step to the AI catalog sync workflow (`ci-ai-catalog-sync.yaml`) that notifies `twenty-infra` when a sync PR is created
- This allows the automerge workflow in `twenty-infra` to reactively merge the PR instead of waiting for the next cron run

## Test plan
- [ ] Verify `TWENTY_INFRA_TOKEN` secret is available (same one used by i18n workflows)
- [ ] Trigger the AI catalog sync workflow manually and confirm the dispatch fires

Made with [Cursor](https://cursor.com)