### PR TITLE
fix: improve pre-filled address formatting

### DIFF
--- a/packages/twenty-front/src/utils/__tests__/formatAddressDisplay.test.ts
+++ b/packages/twenty-front/src/utils/__tests__/formatAddressDisplay.test.ts
@@ -29,22 +29,22 @@ describe('formatAddressDisplay', () => {
       'addressCity',
       'addressState',
     ]);
-    expect(result).toBe('123 Main St,New York,NY');
+    expect(result).toBe('123 Main St, New York, NY');
   });
 
   it('should format address with all fields when subFields is null', () => {
     const result = formatAddressDisplay(mockAddressValue, null);
-    expect(result).toBe('123 Main St,Apt 4B,New York,NY,10001,United States');
+    expect(result).toBe('123 Main St, Apt 4B, New York, NY, 10001, United States');
   });
 
   it('should format address with all fields when subFields is undefined', () => {
     const result = formatAddressDisplay(mockAddressValue, undefined);
-    expect(result).toBe('123 Main St,Apt 4B,New York,NY,10001,United States');
+    expect(result).toBe('123 Main St, Apt 4B, New York, NY, 10001, United States');
   });
 
   it('should format address with all fields when subFields is empty array', () => {
     const result = formatAddressDisplay(mockAddressValue, []);
-    expect(result).toBe('123 Main St,Apt 4B,New York,NY,10001,United States');
+    expect(result).toBe('123 Main St, Apt 4B, New York, NY, 10001, United States');
   });
 
   it('should handle address with some empty fields', () => {
@@ -66,7 +66,7 @@ describe('formatAddressDisplay', () => {
       'addressState',
       'addressPostcode',
     ]);
-    expect(result).toBe('456 Oak Ave,Boston,02101');
+    expect(result).toBe('456 Oak Ave, Boston, 02101');
   });
 
   it('should handle single field selection', () => {

--- a/packages/twenty-front/src/utils/__tests__/joinAddressFieldValues.test.ts
+++ b/packages/twenty-front/src/utils/__tests__/joinAddressFieldValues.test.ts
@@ -19,7 +19,7 @@ describe('joinAddressFieldValues', () => {
       'addressCity',
       'addressState',
     ]);
-    expect(result).toBe('123 Main St,New York,NY');
+    expect(result).toBe('123 Main St, New York, NY');
   });
 
   it('should filter out null and empty string values', () => {
@@ -42,7 +42,7 @@ describe('joinAddressFieldValues', () => {
       'addressPostcode',
       'addressCountry',
     ]);
-    expect(result).toBe('456 Oak Ave,CA,90210');
+    expect(result).toBe('456 Oak Ave, CA, 90210');
   });
 
   it('should handle empty subFields array', () => {
@@ -64,7 +64,7 @@ describe('joinAddressFieldValues', () => {
       'addressPostcode',
       'addressCountry',
     ]);
-    expect(result).toBe('123 Main St,Apt 4B,New York,NY,10001,United States');
+    expect(result).toBe('123 Main St, Apt 4B, New York, NY, 10001, United States');
   });
 
   it('should handle address with empty and null values', () => {
@@ -110,6 +110,6 @@ describe('joinAddressFieldValues', () => {
       'addressState',
       'addressPostcode',
     ]);
-    expect(result).toBe('123 Main St,New York,10001');
+    expect(result).toBe('123 Main St, New York, 10001');
   });
 });

--- a/packages/twenty-front/src/utils/joinAddressFieldValues.ts
+++ b/packages/twenty-front/src/utils/joinAddressFieldValues.ts
@@ -9,5 +9,5 @@ export const joinAddressFieldValues = (
   return subFields
     .map((subField) => fieldValue[subField])
     .filter(isNonEmptyString)
-    .join(',');
+    .join(', ');
 };


### PR DESCRIPTION
## Summary
- Changed address field separator from `","` to `", "` in `joinAddressFieldValues.ts`
- Addresses now display as `"123 Main St, New York, NY"` instead of `"123 Main St,New York,NY"`
- Updated corresponding test expectations

## Test plan
- [ ] Open a record with address fields
- [ ] Verify address displays with proper spacing after commas
- [ ] Verify editing an address field preserves formatting
- [ ] Run `joinAddressFieldValues` and `formatAddressDisplay` tests

Fixes #18860