### PR TITLE
Fix double arrow

### DIFF
--- a/packages/twenty-front/src/pages/settings/applications/tabs/SettingsApplicationsDeveloperTab.tsx
+++ b/packages/twenty-front/src/pages/settings/applications/tabs/SettingsApplicationsDeveloperTab.tsx
@@ -124,13 +124,7 @@ export const SettingsApplicationsDeveloperTab = () => {
     const badgeConfig = SOURCE_TYPE_BADGE_CONFIG[item.sourceType];
 
     return (
-      <StyledRowRightContainer>
-        <Tag text={badgeConfig.label} color={badgeConfig.color} preventShrink />
-        <IconChevronRight
-          size={theme.icon.size.md}
-          stroke={theme.icon.stroke.sm}
-        />
-      </StyledRowRightContainer>
+      <Tag text={badgeConfig.label} color={badgeConfig.color} preventShrink />
     );
   };
 


### PR DESCRIPTION
## Before

<img width="1004" height="612" alt="image" src="https://github.com/user-attachments/assets/f0f832eb-d909-449f-88c1-1d30d2ec2c53" />


## after

<img width="971" height="555" alt="image" src="https://github.com/user-attachments/assets/dc751866-85e8-4a3c-8100-2cf109969970" />
