### PR TITLE
Catch null workflow run typename

### DIFF
--- a/packages/twenty-shared/src/workflow/schemas/workflow-run-schema.ts
+++ b/packages/twenty-shared/src/workflow/schemas/workflow-run-schema.ts
@@ -3,7 +3,7 @@ import { workflowRunStateSchema } from './workflow-run-state-schema';
 import { workflowRunStatusSchema } from './workflow-run-status-schema';
 
 export const workflowRunSchema = z.looseObject({
-  __typename: z.literal('WorkflowRun'),
+  __typename: z.string().catch('WorkflowRun'),
   id: z.string(),
   workflowVersionId: z.string(),
   workflowId: z.string(),


### PR DESCRIPTION
When I run a workflow on twenty-main or prod, __typename is null and makes the visualizer fail