### PR TITLE
send X-Schema-Version header when metadataVersion is 0

### DIFF
--- a/packages/twenty-front/src/modules/apollo/services/apollo.factory.ts
+++ b/packages/twenty-front/src/modules/apollo/services/apollo.factory.ts
@@ -132,7 +132,7 @@ export class ApolloFactory implements ApolloManager {
             ...optionHeaders,
             authorization: token ? `Bearer ${token}` : '',
             'x-locale': locale,
-            ...(this.currentWorkspace?.metadataVersion && {
+            ...(isDefined(this.currentWorkspace?.metadataVersion) && {
               'X-Schema-Version': `${this.currentWorkspace.metadataVersion}`,
             }),
             ...(this.appVersion && { 'X-App-Version': this.appVersion }),

--- a/packages/twenty-server/src/engine/core-modules/graphql/hooks/use-graphql-error-handler.hook.ts
+++ b/packages/twenty-server/src/engine/core-modules/graphql/hooks/use-graphql-error-handler.hook.ts
@@ -291,8 +291,8 @@ export const useGraphQLErrorHandlerHook = <
         }
 
         if (
-          !frontEndAppVersion ||
-          !backendAppVersion ||
+          !isDefined(frontEndAppVersion) ||
+          !isDefined(backendAppVersion) ||
           !semver.valid(frontEndAppVersion) ||
           !semver.valid(backendAppVersion)
         ) {


### PR DESCRIPTION
Fixes https://github.com/twentyhq/twenty/issues/13103

Newly created workspaces start with metadataVersion = 0. The truthy check this.currentWorkspace?.metadataVersion && {…} treated 0 as falsy, so the X-Schema-Version header was never sent. Without this header, the backend's schema mismatch detection is bypassed and raw validation errors leak to Sentry. Replaced with isDefined() check.

Also replaced bare negation checks with isDefined() in the backend validation hook for consistency.