### PR TITLE
fix navigation menu item overflow issue

### DIFF
--- a/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/NavigationDrawerItem.tsx
+++ b/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/NavigationDrawerItem.tsx
@@ -111,6 +111,7 @@ const StyledItem = styled.button<StyledItemProps>`
   height: ${themeCssVariables.spacing[7]};
   margin-top: ${({ indentationLevel }) =>
     indentationLevel === 2 ? '2px' : '0'};
+  min-width: 0;
   padding-bottom: ${themeCssVariables.spacing[1]};
   padding-left: ${themeCssVariables.spacing[1]};
   padding-right: ${({ hasRightOptions }) =>


### PR DESCRIPTION
Before
<img width="231" height="99" alt="Screenshot 2026-03-25 at 5 34 59 AM" src="https://github.com/user-attachments/assets/47980a03-b2ec-47db-be16-db0a48b122dd" />


After
<img width="220" height="96" alt="Screenshot 2026-03-25 at 5 32 44 AM" src="https://github.com/user-attachments/assets/5ad405c2-a697-407d-ac1e-450c4a0b9f62" />
