### PR TITLE
fix(kanban): move drag-and-drop placeholder inside innerRef container

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-board/record-board-column/components/RecordBoardColumn.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/record-board-column/components/RecordBoardColumn.tsx
@@ -65,12 +65,14 @@ export const RecordBoardColumn = ({
     >
       <Droppable droppableId={recordBoardColumnId}>
         {(droppableProvided) => (
-          <StyledColumn>
+          <StyledColumn
+            ref={droppableProvided.innerRef}
+            {...droppableProvided.droppableProps}
+          >
             <DragAndDropLibraryLegacyReRenderBreaker
               memoizationId={recordBoardColumnId}
             >
               <RecordBoardColumnCardsContainer
-                droppableProvided={droppableProvided}
                 recordBoardColumnId={recordBoardColumnId}
               />
             </DragAndDropLibraryLegacyReRenderBreaker>

--- a/packages/twenty-front/src/modules/object-record/record-board/record-board-column/components/RecordBoardColumnCardsContainer.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/record-board-column/components/RecordBoardColumnCardsContainer.tsx
@@ -1,5 +1,5 @@
 import { styled } from '@linaria/react';
-import { Draggable, type DroppableProvided } from '@hello-pangea/dnd';
+import { Draggable } from '@hello-pangea/dnd';
 import { useContext } from 'react';
 import { themeCssVariables } from 'twenty-ui/theme-constants';
 
@@ -25,12 +25,10 @@ const StyledNewButtonContainer = styled.div`
 
 type RecordBoardColumnCardsContainerProps = {
   recordBoardColumnId: string;
-  droppableProvided: DroppableProvided;
 };
 
 export const RecordBoardColumnCardsContainer = ({
   recordBoardColumnId,
-  droppableProvided,
 }: RecordBoardColumnCardsContainerProps) => {
   const { columnDefinition } = useContext(RecordBoardColumnContext);
 
@@ -45,11 +43,7 @@ export const RecordBoardColumnCardsContainer = ({
   );
 
   return (
-    <StyledColumnCardsContainer
-      ref={droppableProvided?.innerRef}
-      // oxlint-disable-next-line react/jsx-props-no-spreading
-      {...droppableProvided?.droppableProps}
-    >
+    <StyledColumnCardsContainer>
       {recordIndexRecordIdsByGroup.map((recordId, index) => (
         <RecordBoardCardDraggableContainer
           key={recordId}


### PR DESCRIPTION
fix(kanban): move drag-and-drop placeholder inside innerRef container

Fixes #18842

The Kanban drag-and-drop was only registering drops near the top of columns because the @hello-pangea/dnd placeholder was rendered outside the innerRef container, breaking the library's droppable area measurement.

## Root Cause

The library requires `droppableProvided.placeholder` to be a direct child of the element that receives `droppableProvided.innerRef`. 

**Before (broken):**
- `innerRef` was on `StyledColumnCardsContainer` (inside memo boundary)
- `placeholder` was in parent `StyledColumn` (outside memo boundary)
- Result: Library measured wrong droppable area, drops only worked at top

**After (fixed):**
- `innerRef` moved to `StyledColumn` (outside memo boundary)
- `placeholder` stays in `StyledColumn` (same parent as innerRef)
- Result: Both inside same DOM element, library measures correctly

## Changes

**RecordBoardColumn.tsx:**
- Added `ref={droppableProvided.innerRef}` to `StyledColumn`
- Added `{...droppableProvided.droppableProps}` to `StyledColumn`
- Removed `droppableProvided` from `RecordBoardColumnCardsContainer` props

**RecordBoardColumnCardsContainer.tsx:**
- Removed `droppableProvided` from component props and type
- Removed `ref` and `{...droppableProps}` from `StyledColumnCardsContainer`
- Removed unused `DroppableProvided` import

## Why This Works

The `DragAndDropLibraryLegacyReRenderBreaker` (React.memo wrapper) blocks re-renders of the card list during drag — this is the performance optimization from PR #15714. 

By lifting `innerRef` to the parent `StyledColumn`, both the memo'd cards and the placeholder live inside the innerRef DOM element, satisfying the library's requirements while preserving the performance optimization.

## Testing

Tested manually with 15+ card columns:
- ✅ Drag to top of column: works
- ✅ Drag to middle of column: works (was failing)
- ✅ Drag to bottom of column: works (was failing)
- ✅ Long columns with scroll: works

## History

- **PR #7600** (Oct 2024): Originally fixed by placing placeholder inside innerRef
- **PR #15714** (Nov 2025): Performance optimization moved placeholder outside, breaking the fix
- **This PR**: Restores correct placeholder placement while keeping performance optimization

## Credit

Root cause analysis by @sonarly (https://github.com/twentyhq/twenty/issues/18842#issuecomment-2523456789)