### PR TITLE
Fix object permission override

### DIFF
--- a/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/hooks/useUpsertObjectPermission.ts
+++ b/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/hooks/useUpsertObjectPermission.ts
@@ -35,7 +35,7 @@ export const useUpsertObjectPermission = ({ roleId }: { roleId: string }) => {
       newPermissions.canReadObjectRecords = value;
     }
 
-    if (permissionKey === 'canReadObjectRecords' && !value) {
+    if (permissionKey === 'canReadObjectRecords' && value === false) {
       newPermissions.canUpdateObjectRecords = false;
       newPermissions.canSoftDeleteObjectRecords = false;
       newPermissions.canDestroyObjectRecords = false;

--- a/packages/twenty-server/src/engine/metadata-modules/object-permission/object-permission.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-permission/object-permission.service.ts
@@ -286,26 +286,34 @@ export class ObjectPermissionService {
             newObjectPermission.objectMetadataId,
         );
 
+      const resolvedCanRead =
+        newObjectPermission.canReadObjectRecords !== undefined
+          ? newObjectPermission.canReadObjectRecords
+          : existingObjectRecordPermission?.canReadObjectRecords;
       const hasReadPermissionAfterUpdate =
-        newObjectPermission.canReadObjectRecords ??
-        existingObjectRecordPermission?.canReadObjectRecords ??
-        flatRole.canReadAllObjectRecords;
+        resolvedCanRead ?? flatRole.canReadAllObjectRecords;
 
       if (hasReadPermissionAfterUpdate === false) {
+        const resolvedCanUpdate =
+          newObjectPermission.canUpdateObjectRecords !== undefined
+            ? newObjectPermission.canUpdateObjectRecords
+            : existingObjectRecordPermission?.canUpdateObjectRecords;
         const hasUpdatePermissionAfterUpdate =
-          newObjectPermission.canUpdateObjectRecords ??
-          existingObjectRecordPermission?.canUpdateObjectRecords ??
-          flatRole.canUpdateAllObjectRecords;
+          resolvedCanUpdate ?? flatRole.canUpdateAllObjectRecords;
 
+        const resolvedCanSoftDelete =
+          newObjectPermission.canSoftDeleteObjectRecords !== undefined
+            ? newObjectPermission.canSoftDeleteObjectRecords
+            : existingObjectRecordPermission?.canSoftDeleteObjectRecords;
         const hasSoftDeletePermissionAfterUpdate =
-          newObjectPermission.canSoftDeleteObjectRecords ??
-          existingObjectRecordPermission?.canSoftDeleteObjectRecords ??
-          flatRole.canSoftDeleteAllObjectRecords;
+          resolvedCanSoftDelete ?? flatRole.canSoftDeleteAllObjectRecords;
 
+        const resolvedCanDestroy =
+          newObjectPermission.canDestroyObjectRecords !== undefined
+            ? newObjectPermission.canDestroyObjectRecords
+            : existingObjectRecordPermission?.canDestroyObjectRecords;
         const hasDestroyPermissionAfterUpdate =
-          newObjectPermission.canDestroyObjectRecords ??
-          existingObjectRecordPermission?.canDestroyObjectRecords ??
-          flatRole.canDestroyAllObjectRecords;
+          resolvedCanDestroy ?? flatRole.canDestroyAllObjectRecords;
 
         if (
           hasUpdatePermissionAfterUpdate ||

--- a/packages/twenty-server/src/engine/metadata-modules/object-permission/object-permission.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-permission/object-permission.service.ts
@@ -143,14 +143,21 @@ export class ObjectPermissionService {
         );
       } else {
         const effectiveCanRead =
-          desired.canReadObjectRecords ?? current.canReadObjectRecords;
+          desired.canReadObjectRecords !== undefined
+            ? desired.canReadObjectRecords
+            : current.canReadObjectRecords;
         const effectiveCanUpdate =
-          desired.canUpdateObjectRecords ?? current.canUpdateObjectRecords;
+          desired.canUpdateObjectRecords !== undefined
+            ? desired.canUpdateObjectRecords
+            : current.canUpdateObjectRecords;
         const effectiveCanSoftDelete =
-          desired.canSoftDeleteObjectRecords ??
-          current.canSoftDeleteObjectRecords;
+          desired.canSoftDeleteObjectRecords !== undefined
+            ? desired.canSoftDeleteObjectRecords
+            : current.canSoftDeleteObjectRecords;
         const effectiveCanDestroy =
-          desired.canDestroyObjectRecords ?? current.canDestroyObjectRecords;
+          desired.canDestroyObjectRecords !== undefined
+            ? desired.canDestroyObjectRecords
+            : current.canDestroyObjectRecords;
 
         const canChanged =
           effectiveCanRead !== current.canReadObjectRecords ||


### PR DESCRIPTION
Issue: https://www.loom.com/share/dd48cd509f614e51829f6a5b58d41b6b

Bug: Unsetting a revoked object permission keeps it revoked
When a role has a global permission enabled (e.g. canReadAllObjectRecords: true) but an object-level override revokes it (canReadObjectRecords: false), clicking to remove that override had no effect — the permission stayed revoked after save.

Root cause:
Backend (object-permission.service.ts): The nullish coalescing operator (??) was used to fall back to the current DB value when the input didn't provide a value. Since ?? treats both null and undefined as nullish, sending canReadObjectRecords: null (meaning "remove override") was coalesced to the current value (false), silently discarding the reset.

Fix:
- Backend: Replaced ?? with explicit !== undefined checks, so null is preserved as a meaningful value (meaning "no override / inherit from global") while undefined (field not provided) still falls back to the current value. This also fixes the "Reset all permissions" flow which sends null for all permission fields.

Additional frontend fix: Changed !value to value === false so that only an explicit false cascades revocation to write permissions. Setting null (reset to inherit) now only affects the read permission itself.