### PR TITLE
Fix SSE event stream errors when impersonating users with limited permissions

### DIFF
--- a/packages/twenty-front/src/modules/settings/admin-panel/hooks/useImpersonationAuth.ts
+++ b/packages/twenty-front/src/modules/settings/admin-panel/hooks/useImpersonationAuth.ts
@@ -1,15 +1,18 @@
 import { isAppEffectRedirectEnabledState } from '@/app/states/isAppEffectRedirectEnabledState';
 import { useAuth } from '@/auth/hooks/useAuth';
+import { useClearSseClient } from '@/sse-db-event/hooks/useClearSseClient';
 import { useSetAtomState } from '@/ui/utilities/state/jotai/hooks/useSetAtomState';
 
 export const useImpersonationAuth = () => {
   const { getAuthTokensFromLoginToken } = useAuth();
+  const { clearSseClient } = useClearSseClient();
   const setIsAppEffectRedirectEnabled = useSetAtomState(
     isAppEffectRedirectEnabledState,
   );
 
   const executeImpersonationAuth = async (loginToken: string) => {
     setIsAppEffectRedirectEnabled(false);
+    clearSseClient();
     await getAuthTokensFromLoginToken(loginToken);
     setIsAppEffectRedirectEnabled(true);
   };

--- a/packages/twenty-front/src/modules/sse-db-event/components/SSEQuerySubscribeEffect.tsx
+++ b/packages/twenty-front/src/modules/sse-db-event/components/SSEQuerySubscribeEffect.tsx
@@ -93,6 +93,7 @@ export const SSEQuerySubscribeEffect = () => {
         const isRecoverable =
           subCode === 'EVENT_STREAM_DOES_NOT_EXIST' ||
           subCode === 'EVENT_STREAM_ALREADY_EXISTS' ||
+          subCode === 'NOT_AUTHORIZED' ||
           code === 'UNAUTHENTICATED' ||
           code === 'FORBIDDEN';
 


### PR DESCRIPTION
Clear the SSE client before swapping auth tokens during impersonation, preventing a userWorkspaceId mismatch between the existing event stream (created under the admin's identity) and the new impersonation token.
Treat NOT_AUTHORIZED event stream errors as recoverable (destroy + recreate), matching the existing behavior for EVENT_STREAM_DOES_NOT_EXIST and EVENT_STREAM_ALREADY_EXISTS.