### PR TITLE
Fix format result

### DIFF
--- a/packages/twenty-server/src/engine/twenty-orm/utils/format-result.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/format-result.util.ts
@@ -191,6 +191,23 @@ function formatResultInternal<T>(
     flatFieldMetadataMaps,
   );
 
+  const fieldMetadataItemsOfTypeDateOnly = getFlatFieldsFromFlatObjectMetadata(
+    flatObjectMetadata,
+    flatFieldMetadataMaps,
+  ).filter((field) => field.type === FieldMetadataType.DATE);
+
+  for (const dateField of fieldMetadataItemsOfTypeDateOnly) {
+    // @ts-expect-error legacy noImplicitAny
+    const rawUpdatedDate = newData[dateField.name] as string | null | undefined;
+
+    if (!isDefined(rawUpdatedDate)) {
+      continue;
+    }
+
+    // @ts-expect-error legacy noImplicitAny
+    newData[dateField.name] = rawUpdatedDate;
+  }
+
   const fieldMetadataItemsOfTypeDateTimeOnly =
     getFlatFieldsFromFlatObjectMetadata(
       flatObjectMetadata,

--- a/packages/twenty-server/src/engine/twenty-orm/utils/format-result.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/format-result.util.ts
@@ -126,16 +126,7 @@ function formatResultInternal<T>(
       : false;
 
     if (!compositePropertyArgs && !isRelation) {
-      if (isPlainObject(value)) {
-        // @ts-expect-error legacy noImplicitAny
-        newData[key] = formatResultInternal(
-          value,
-          flatObjectMetadata,
-          flatObjectMetadataMaps,
-          flatFieldMetadataMaps,
-          fieldMaps,
-        );
-      } else if (fieldMetadata) {
+      if (fieldMetadata) {
         // @ts-expect-error legacy noImplicitAny
         newData[key] = formatFieldMetadataValue(value, fieldMetadata.type);
       } else {

--- a/packages/twenty-server/src/engine/twenty-orm/utils/format-result.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/format-result.util.ts
@@ -155,6 +155,7 @@ function formatResultInternal<T>(
         flatObjectMetadataMaps,
         flatFieldMetadataMaps,
       );
+      continue;
     }
 
     if (isDefined(compositePropertyArgs)) {
@@ -178,6 +179,7 @@ function formatResultInternal<T>(
             compositeProperty.name,
             fieldMetadata,
           );
+      continue;
     }
 
     // @ts-expect-error legacy noImplicitAny

--- a/packages/twenty-server/src/engine/twenty-orm/utils/format-result.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/format-result.util.ts
@@ -121,21 +121,13 @@ function formatResultInternal<T>(
       flatEntityMaps: flatFieldMetadataMaps,
     });
 
+    if (!isDefined(fieldMetadata)) {
+      continue;
+    }
+
     const isRelation = fieldMetadata
       ? isFieldMetadataEntityOfType(fieldMetadata, FieldMetadataType.RELATION)
       : false;
-
-    if (!compositePropertyArgs && !isRelation) {
-      if (fieldMetadata) {
-        // @ts-expect-error legacy noImplicitAny
-        newData[key] = formatFieldMetadataValue(value, fieldMetadata.type);
-      } else {
-        // @ts-expect-error legacy noImplicitAny
-        newData[key] = value;
-      }
-
-      continue;
-    }
 
     if (isRelation) {
       if (!isDefined(fieldMetadata?.relationTargetObjectMetadataId)) {
@@ -164,26 +156,31 @@ function formatResultInternal<T>(
       );
     }
 
-    if (!compositePropertyArgs || !isDefined(fieldMetadata)) {
-      continue;
-    }
+    if (isDefined(compositePropertyArgs)) {
+      const { parentField, ...compositeProperty } = compositePropertyArgs;
 
-    const { parentField, ...compositeProperty } = compositePropertyArgs;
-
-    // @ts-expect-error legacy noImplicitAny
-    if (!newData[parentField]) {
       // @ts-expect-error legacy noImplicitAny
-      newData[parentField] = {};
+      if (!newData[parentField]) {
+        // @ts-expect-error legacy noImplicitAny
+        newData[parentField] = {};
+      }
+
+      // @ts-expect-error legacy noImplicitAny
+      newData[parentField][compositeProperty.name] = isNull(value)
+        ? transformCompositeFieldNullValue(
+            value,
+            compositeProperty.name,
+            fieldMetadata,
+          )
+        : formatCompositeFieldValue(
+            value,
+            compositeProperty.name,
+            fieldMetadata,
+          );
     }
 
     // @ts-expect-error legacy noImplicitAny
-    newData[parentField][compositeProperty.name] = isNull(value)
-      ? transformCompositeFieldNullValue(
-          value,
-          compositeProperty.name,
-          fieldMetadata,
-        )
-      : formatCompositeFieldValue(value, compositeProperty.name, fieldMetadata);
+    newData[key] = formatFieldMetadataValue(value, fieldMetadata.type);
   }
 
   // After assembling composite fields, handle those with missing required subfields

--- a/packages/twenty-server/src/engine/twenty-orm/utils/format-result.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/format-result.util.ts
@@ -100,7 +100,7 @@ function formatResultInternal<T>(
       flatObjectMetadata,
     );
 
-  const { fieldIdByName } = fieldMaps;
+  const { fieldIdByName, fieldIdByJoinColumnName } = fieldMaps;
 
   const compositeFieldMetadataMap = getCompositeFieldMetadataMap(
     flatObjectMetadata,
@@ -114,6 +114,7 @@ function formatResultInternal<T>(
 
     const fieldMetadataId =
       fieldIdByName[key] ||
+      fieldIdByJoinColumnName[key] ||
       fieldIdByName[compositePropertyArgs?.parentField ?? ''];
 
     const fieldMetadata = findFlatEntityByIdInFlatEntityMaps({
@@ -189,23 +190,6 @@ function formatResultInternal<T>(
     flatObjectMetadata,
     flatFieldMetadataMaps,
   );
-
-  const fieldMetadataItemsOfTypeDateOnly = getFlatFieldsFromFlatObjectMetadata(
-    flatObjectMetadata,
-    flatFieldMetadataMaps,
-  ).filter((field) => field.type === FieldMetadataType.DATE);
-
-  for (const dateField of fieldMetadataItemsOfTypeDateOnly) {
-    // @ts-expect-error legacy noImplicitAny
-    const rawUpdatedDate = newData[dateField.name] as string | null | undefined;
-
-    if (!isDefined(rawUpdatedDate)) {
-      continue;
-    }
-
-    // @ts-expect-error legacy noImplicitAny
-    newData[dateField.name] = rawUpdatedDate;
-  }
 
   const fieldMetadataItemsOfTypeDateTimeOnly =
     getFlatFieldsFromFlatObjectMetadata(


### PR DESCRIPTION
For a field that is not a relation and not a composite, there is no legitimate reason to recurse into a plain object value. 

The only cases where recursion makes sense are:
- Relations, the value is a nested entity record (handled at line 149)
- Composite fields - the value is being reassembled from flat columns (handled at line 176+)

For everything else, a plain object value is just data


#### Perf testing

Compare findManyCompanies with a jsonField having same 20-level nested value (cf quote)
- with fix
Average ≈ 75.77 ms - min 52.43 ms - max 114.99 ms.

- without
Average: ≈ 376.62 ms - Min: 194.19 ms - Max: 1183.65 ms (39 requests)

```
{
  "document": {
    "id": "doc-nested-20",
    "title": "20-level nested sample",
    "tags": ["sample", "nested", "json", "fixture", "demo"],
    "counts": [100, 200, 300, 400, 500],
    "extras": {
      "a": true,
      "b": false,
      "c": null,
      "d": 3.14159,
      "e": "unicode-测试-αβγ"
    }
  },
  "users": [
    { "id": 1, "name": "Alice", "roles": ["admin", "editor"] },
    { "id": 2, "name": "Bob", "roles": ["viewer"] },
    { "id": 3, "name": "Carol", "roles": ["editor", "viewer"] }
  ],
  "matrix": [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
  "settings": {
    "theme": "dark",
    "notifications": { "email": true, "push": false, "sms": false },
    "locale": "en-US"
  },
  "deep": {
    "level01": {
      "level02": {
        "level03": {
          "level04": {
            "level05": {
              "level06": {
                "level07": {
                  "level08": {
                    "level09": {
                      "level10": {
                        "level11": {
                          "level12": {
                            "level13": {
                              "level14": {
                                "level15": {
                                  "level16": {
                                    "level17": {
                                      "level18": {
                                        "level19": {
                                          "level20": {
                                            "leaf": true,
                                            "summary": "deepest object in this branch",
                                            "indices": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
                                            "meta": {
                                              "maxDepth": 20,
                                              "note": "Count deep.level01..level20 as 20 nested objects"
                                            }
                                          }
                                        }
                                      }
                                    }
                                  }
                                }
                              }
                            }
                          }
                        }
                      }
                    }
                  }
                }
              }
            }
          }
        }
      }
    }
  },
  "footer": {
    "checksum": "example-only-not-real",
    "generated": "2025-03-25"
  }
}
```