### PR TITLE
Fixed board no value column not fetching more

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-board/hooks/useTriggerRecordBoardFetchMore.ts
+++ b/packages/twenty-front/src/modules/object-record/record-board/hooks/useTriggerRecordBoardFetchMore.ts
@@ -23,6 +23,7 @@ import { useAtomComponentFamilyStateCallbackState } from '@/ui/utilities/state/j
 import { useAtomComponentSelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentSelectorValue';
 import { isNonEmptyArray } from '@sniptt/guards';
 import { isDefined } from 'twenty-shared/utils';
+import { computeRecordGroupOptionsFilter } from '@/object-record/record-group/utils/computeRecordGroupOptionsFilter';
 import { sortByProperty } from '~/utils/array/sortByProperty';
 import { sleep } from '~/utils/sleep';
 
@@ -99,8 +100,7 @@ export const useTriggerRecordBoardFetchMore = () => {
           ),
         );
       })
-      .map((recordGroupDefinition) => recordGroupDefinition.value)
-      .filter(isDefined);
+      .map((recordGroupDefinition) => recordGroupDefinition.value);
 
     if (!isNonEmptyArray(recordGroupValuesThatShouldBeFetched)) {
       store.set(recordBoardShouldFetchMoreCallbackState, false);
@@ -109,15 +109,18 @@ export const useTriggerRecordBoardFetchMore = () => {
       return;
     }
 
+    const recordGroupOptionsFilter = computeRecordGroupOptionsFilter({
+      recordGroupFieldMetadata: recordIndexGroupFieldMetadataItem,
+      recordGroupValues: recordGroupValuesThatShouldBeFetched,
+    });
+
     const recordIndexGroupsRecordsGroupByLazyQueryResult =
       await executeRecordIndexGroupsRecordsLazyGroupBy({
         variables: {
           offsetForRecords: newOffset,
           filter: {
             ...combinedFilters,
-            [recordIndexGroupFieldMetadataItem?.name ?? '']: {
-              in: [...recordGroupValuesThatShouldBeFetched],
-            },
+            ...recordGroupOptionsFilter,
           },
         },
       });


### PR DESCRIPTION
Fixes https://github.com/twentyhq/twenty/issues/18148

## Problem
- Scrolling down in the "no value" kanban column never loads additional records when it's the only column that needs pagination
- `useTriggerRecordBoardFetchMore` — `.filter(isDefined)` removes `null` from the list of group values to fetch, and `null` is the value used by "no value" columns, causing early exit
- `useTriggerRecordBoardFetchMore` — the inline `{ in: [...values] }` filter cannot express a NULL match, so even without the early exit the query would be wrong

## Fix
- "No value" column now triggers pagination correctly — `useTriggerRecordBoardFetchMore` (removed `.filter(isDefined)` so `null` values pass through)
- Query filter correctly matches NULL field values — `useTriggerRecordBoardFetchMore` (replaced inline `{ in: [...] }` with `computeRecordGroupOptionsFilter` which generates `{ is: 'NULL' }` for null values and `{ in: [...] }` for non-null values)
