### PR TITLE
fix: prevent empty array `id.in` filter in single record picker

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-picker/single-record-picker/hooks/useSingleRecordPickerPerformSearch.ts
+++ b/packages/twenty-front/src/modules/object-record/record-picker/single-record-picker/hooks/useSingleRecordPickerPerformSearch.ts
@@ -34,13 +34,16 @@ export const useSingleRecordPickerPerformSearch = ({
 
   const { objectMetadataItems } = useObjectMetadataItems();
 
-  const selectedIdsFilter = { id: { in: selectedIds } };
+  const hasSelectedIds = selectedIds.length > 0;
+  const selectedIdsFilter = hasSelectedIds
+    ? { id: { in: selectedIds } }
+    : undefined;
 
   const { loading: selectedRecordsLoading, searchRecords: selectedRecords } =
     useObjectRecordSearchRecords({
       objectNameSingulars,
       filter: selectedIdsFilter,
-      skip: !selectedIds.length,
+      skip: !hasSelectedIds,
       searchInput: '',
     });
 
@@ -50,7 +53,7 @@ export const useSingleRecordPickerPerformSearch = ({
   } = useObjectRecordSearchRecords({
     objectNameSingulars,
     filter: selectedIdsFilter,
-    skip: !selectedIds.length,
+    skip: !hasSelectedIds,
     searchInput: searchFilter,
   });
 


### PR DESCRIPTION
## Summary

- Fixes intermittent `INVALID_QUERY_INPUT` errors (152 occurrences / 2 users in Sentry) caused by the single record picker sending `{ id: { in: [] } }` to the Search query when no records are selected
- The `skip` guard is logically correct but Apollo Client v4 can briefly fire queries during React 18 render transitions before processing the skip flag
- Makes `selectedIdsFilter` conditional on `hasSelectedIds`, so variables contain a safe empty filter `{}` regardless of skip behavior — matching the existing defensive pattern used by the third query's `notFilter`

## Test plan

- [ ] Open a relation field picker (e.g., Person on an Opportunity) with no existing value — search should load without errors
- [ ] Open a relation field picker with an existing value — selected record should appear and search should work
- [ ] Clear a selected relation and reopen the picker — no console errors


Made with [Cursor](https://cursor.com)