### PR TITLE
Fix: Cannot create two workflow agent nodes because these have the same name

### DIFF
--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version-step/workflow-version-step-operations.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version-step/workflow-version-step-operations.workspace-service.ts
@@ -704,8 +704,7 @@ export class WorkflowVersionStepOperationsWorkspaceService {
 
         const clonedAgent = await this.agentService.createOneAgent(
           {
-            label:
-              existingAgent.label + ' ' + clonedStepId.substring(0, 4),
+            label: existingAgent.label + ' ' + clonedStepId.substring(0, 4),
             icon: existingAgent.icon ?? undefined,
             description: existingAgent.description ?? undefined,
             prompt: existingAgent.prompt,

--- a/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version-step/workflow-version-step-operations.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/workflow-builder/workflow-version-step/workflow-version-step-operations.workspace-service.ts
@@ -432,16 +432,9 @@ export class WorkflowVersionStepOperationsWorkspaceService {
         };
       }
       case WorkflowActionType.AI_AGENT: {
-        const workflowVersion =
-          await this.workflowCommonWorkspaceService.getWorkflowVersionOrFail({
-            workflowVersionId,
-            workspaceId,
-          });
-
         const newAgent = await this.agentService.createOneAgent(
           {
-            label:
-              'Workflow Agent' + workflowVersion.workflowId.substring(0, 4),
+            label: 'Workflow Agent ' + baseStep.id.substring(0, 4),
             icon: 'IconRobot',
             description: '',
             prompt:
@@ -707,9 +700,12 @@ export class WorkflowVersionStepOperationsWorkspaceService {
           workspaceId,
         });
 
+        const clonedStepId = v4();
+
         const clonedAgent = await this.agentService.createOneAgent(
           {
-            label: existingAgent.label,
+            label:
+              existingAgent.label + ' ' + clonedStepId.substring(0, 4),
             icon: existingAgent.icon ?? undefined,
             description: existingAgent.description ?? undefined,
             prompt: existingAgent.prompt,
@@ -723,7 +719,7 @@ export class WorkflowVersionStepOperationsWorkspaceService {
 
         return {
           ...step,
-          id: v4(),
+          id: clonedStepId,
           nextStepIds: [],
           position: duplicatedStepPosition,
           settings: {


### PR DESCRIPTION
Currently, when trying to create a second step agent, we get the error agent already exists because the name is using workflow id. Using step id instead.