### PR TITLE
Fix not shared chip height + hard coded border radius

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/display/components/ForbiddenFieldDisplay.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/display/components/ForbiddenFieldDisplay.tsx
@@ -8,14 +8,17 @@ const StyledContainer = styled.div`
   align-items: center;
   background: ${themeCssVariables.background.transparent.light};
 
-  border-radius: 4px;
+  border-radius: ${themeCssVariables.border.radius.sm};
   color: ${themeCssVariables.font.color.tertiary};
   display: inline-flex;
   font-size: ${themeCssVariables.font.size.md};
   font-weight: ${themeCssVariables.font.weight.regular};
   gap: ${themeCssVariables.spacing[1]};
+  height: ${themeCssVariables.spacing[3]};
+  overflow: hidden;
 
   padding: ${themeCssVariables.spacing[1]};
+  user-select: none;
 `;
 
 export const ForbiddenFieldDisplay = () => {


### PR DESCRIPTION
## Summary
- align the forbidden field "Not shared" chip with small chip dimensions in the object table
- use the shared small border radius token instead of a hardcoded value
- add `overflow: hidden` and `user-select: none` to match chip behavior more closely

## Testing
- Not run (not requested)