### PR TITLE
fix: gate command-menu-items query behind feature flag

### DIFF
--- a/packages/twenty-front/src/modules/metadata-store/hooks/useLoadStaleMetadataEntities.ts
+++ b/packages/twenty-front/src/modules/metadata-store/hooks/useLoadStaleMetadataEntities.ts
@@ -6,11 +6,13 @@ import { splitViewWithRelated } from '@/metadata-store/utils/splitViewWithRelate
 import { FIND_MANY_OBJECT_METADATA_ITEMS } from '@/object-metadata/graphql/queries';
 import { transformPageLayout } from '@/page-layout/utils/transformPageLayout';
 import { logicFunctionsState } from '@/settings/logic-functions/states/logicFunctionsState';
+import { useIsFeatureEnabled } from '@/workspace/hooks/useIsFeatureEnabled';
 import { useApolloClient } from '@apollo/client/react';
 import { useStore } from 'jotai';
 import { useCallback } from 'react';
 import { isDefined } from 'twenty-shared/utils';
 import {
+  FeatureFlagKey,
   FindAllViewsDocument,
   FindManyCommandMenuItemsDocument,
   FindAllRecordPageLayoutsDocument,
@@ -55,6 +57,9 @@ export const useLoadStaleMetadataEntities = () => {
   const client = useApolloClient();
   const store = useStore();
   const { replaceDraft, applyChanges } = useUpdateMetadataStoreDraft();
+  const isCommandMenuItemEnabled = useIsFeatureEnabled(
+    FeatureFlagKey.IS_COMMAND_MENU_ITEM_ENABLED,
+  );
 
   const loadStaleMetadataEntities = useCallback(
     async (staleEntityKeys: MetadataEntityKey[]) => {
@@ -194,7 +199,10 @@ export const useLoadStaleMetadataEntities = () => {
         );
       }
 
-      if (staleEntityKeys.includes('commandMenuItems')) {
+      if (
+        staleEntityKeys.includes('commandMenuItems') &&
+        isCommandMenuItemEnabled
+      ) {
         fetchPromises.push(
           client
             .query({
@@ -214,7 +222,7 @@ export const useLoadStaleMetadataEntities = () => {
       await Promise.all(fetchPromises);
       applyChanges();
     },
-    [client, store, replaceDraft, applyChanges],
+    [client, store, replaceDraft, applyChanges, isCommandMenuItemEnabled],
   );
 
   return { loadStaleMetadataEntities };

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/constant/default-feature-flags.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/constant/default-feature-flags.ts
@@ -4,5 +4,4 @@ export const DEFAULT_FEATURE_FLAGS = [
   FeatureFlagKey.IS_ATTACHMENT_MIGRATED,
   FeatureFlagKey.IS_NOTE_TARGET_MIGRATED,
   FeatureFlagKey.IS_TASK_TARGET_MIGRATED,
-  FeatureFlagKey.IS_CONNECTED_ACCOUNT_MIGRATED,
 ] as const satisfies FeatureFlagKey[];


### PR DESCRIPTION
## Summary
- Gate the `FindManyCommandMenuItems` GraphQL query behind the `IS_COMMAND_MENU_ITEM_ENABLED` feature flag on the frontend, preventing an uncaught error when the flag is not enabled for a workspace
- Remove `IS_CONNECTED_ACCOUNT_MIGRATED` from the default feature flags list

