### PR TITLE
fix: show disabled file chip when file no longer exists in timeline

### DIFF
--- a/packages/twenty-front/src/modules/activities/timeline-activities/rows/main-object/components/EventFieldDiffValueEffect.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/rows/main-object/components/EventFieldDiffValueEffect.tsx
@@ -1,9 +1,13 @@
-import { useEffect } from 'react';
+import { useContext, useEffect } from 'react';
 
-import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
+import { TimelineActivityContext } from '@/activities/timeline-activities/contexts/TimelineActivityContext';
 import { type EnrichedObjectMetadataItem } from '@/object-metadata/types/EnrichedObjectMetadataItem';
+import { type FieldMetadataItem } from '@/object-metadata/types/FieldMetadataItem';
+import { type FieldFilesValue } from '@/object-record/record-field/ui/types/FieldMetadata';
 import { recordStoreFamilyState } from '@/object-record/record-store/states/recordStoreFamilyState';
+import { useAtomFamilyStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomFamilyStateValue';
 import { useSetAtomFamilyState } from '@/ui/utilities/state/jotai/hooks/useSetAtomFamilyState';
+import { FieldMetadataType } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 
 export const EventFieldDiffValueEffect = ({
@@ -22,13 +26,39 @@ export const EventFieldDiffValueEffect = ({
     diffArtificialRecordStoreId,
   );
 
+  const { recordId } = useContext(TimelineActivityContext);
+  const recordStore = useAtomFamilyStateValue(recordStoreFamilyState, recordId);
+
   useEffect(() => {
     if (!isDefined(diffRecord)) return;
+
+    let fieldValue: typeof diffRecord = diffRecord;
+
+    if (
+      fieldMetadataItem.type === FieldMetadataType.FILES &&
+      isDefined(recordStore) &&
+      Array.isArray(diffRecord)
+    ) {
+      const currentFiles = Array.isArray(recordStore[fieldMetadataItem.name])
+        ? (recordStore[fieldMetadataItem.name] as FieldFilesValue[])
+        : [];
+      const currentFileMap = new Map(
+        currentFiles.map((file) => [file.fileId, file]),
+      );
+
+      fieldValue = (diffRecord as FieldFilesValue[]).map((file) => {
+        const currentFile = currentFileMap.get(file.fileId);
+        if (isDefined(currentFile)) {
+          return currentFile;
+        }
+        return { ...file, isDeleted: true, url: undefined };
+      });
+    }
 
     const forgedObjectRecord = {
       __typename: mainObjectMetadataItem.nameSingular,
       id: diffArtificialRecordStoreId,
-      [fieldMetadataItem.name]: diffRecord,
+      [fieldMetadataItem.name]: fieldValue,
     };
 
     setRecordStore(forgedObjectRecord);
@@ -36,8 +66,10 @@ export const EventFieldDiffValueEffect = ({
     diffRecord,
     diffArtificialRecordStoreId,
     fieldMetadataItem.name,
+    fieldMetadataItem.type,
     mainObjectMetadataItem.nameSingular,
     setRecordStore,
+    recordStore,
   ]);
 
   return <></>;

--- a/packages/twenty-front/src/modules/activities/timeline-activities/rows/main-object/components/EventFieldDiffValueEffect.tsx
+++ b/packages/twenty-front/src/modules/activities/timeline-activities/rows/main-object/components/EventFieldDiffValueEffect.tsx
@@ -32,7 +32,7 @@ export const EventFieldDiffValueEffect = ({
   useEffect(() => {
     if (!isDefined(diffRecord)) return;
 
-    let fieldValue: typeof diffRecord = diffRecord;
+    let fieldValue = diffRecord;
 
     if (
       fieldMetadataItem.type === FieldMetadataType.FILES &&
@@ -49,7 +49,7 @@ export const EventFieldDiffValueEffect = ({
       fieldValue = (diffRecord as FieldFilesValue[]).map((file) => {
         const currentFile = currentFileMap.get(file.fileId);
         if (isDefined(currentFile)) {
-          return currentFile;
+          return { ...file, url: currentFile.url };
         }
         return { ...file, isDeleted: true, url: undefined };
       });

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/types/FieldMetadata.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/types/FieldMetadata.ts
@@ -335,4 +335,5 @@ export type FieldFilesValue = {
   extension?: string;
   url?: string;
   fileCategory?: FileCategory;
+  isDeleted?: boolean;
 };

--- a/packages/twenty-front/src/modules/ui/field/display/components/FileChip.tsx
+++ b/packages/twenty-front/src/modules/ui/field/display/components/FileChip.tsx
@@ -1,16 +1,35 @@
 import { styled } from '@linaria/react';
+import { t } from '@lingui/core/macro';
+import { useId, useState } from 'react';
+import { createPortal } from 'react-dom';
 
 import { FileIcon } from '@/file/components/FileIcon';
 import { type FieldFilesValue } from '@/object-record/record-field/ui/types/FieldMetadata';
 import { getFileCategoryFromExtension } from '@/object-record/record-field/ui/utils/getFileCategoryFromExtension';
 import { Chip, ChipVariant } from 'twenty-ui/components';
+import { AppTooltip, TooltipDelay, TooltipPosition } from 'twenty-ui/display';
+import { themeCssVariables } from 'twenty-ui/theme-constants';
 
 const MAX_WIDTH = 120;
 
-const StyledClickableContainer = styled.div<{ clickable: boolean }>`
-  cursor: ${({ clickable }) => (clickable ? 'pointer' : 'inherit')};
+const StyledClickableContainer = styled.div<{
+  clickable: boolean;
+  isDeleted: boolean;
+}>`
+  cursor: ${({ clickable, isDeleted }) =>
+    isDeleted ? 'not-allowed' : clickable ? 'pointer' : 'inherit'};
   display: inline-flex;
   min-width: 0;
+`;
+
+const StyledDeletedLabel = styled.span`
+  color: ${themeCssVariables.font.color.secondary};
+  font-size: inherit;
+  max-width: ${MAX_WIDTH}px;
+  overflow: hidden;
+  text-decoration: line-through;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;
 
 type FileChipProps = {
@@ -24,7 +43,11 @@ export const FileChip = ({
   onClick,
   forceDisableClick,
 }: FileChipProps) => {
-  const isClickable = forceDisableClick !== true;
+  const isDeleted = file.isDeleted === true;
+  const isClickable = forceDisableClick !== true && !isDeleted;
+  const tooltipAnchorId = useId();
+  const tooltipAnchorSelect = `[data-tooltip-anchor="${tooltipAnchorId}"]`;
+  const [shouldShowTooltip, setShouldShowTooltip] = useState(false);
 
   const handleMouseDown = (event: React.MouseEvent): void => {
     if (!isClickable) {
@@ -45,17 +68,42 @@ export const FileChip = ({
   );
 
   return (
-    <StyledClickableContainer
-      clickable={isClickable}
-      onMouseDown={handleMouseDown}
-    >
-      <Chip
-        label={file.label ?? ''}
-        maxWidth={MAX_WIDTH}
-        leftComponent={fileIcon}
-        variant={ChipVariant.Highlighted}
+    <>
+      <StyledClickableContainer
+        data-tooltip-anchor={tooltipAnchorId}
         clickable={isClickable}
-      />
-    </StyledClickableContainer>
+        isDeleted={isDeleted}
+        onMouseDown={handleMouseDown}
+        onMouseEnter={() => isDeleted && setShouldShowTooltip(true)}
+        onMouseLeave={() => setShouldShowTooltip(false)}
+      >
+        <Chip
+          label={isDeleted ? '' : (file.label ?? '')}
+          isLabelHidden={isDeleted}
+          maxWidth={isDeleted ? undefined : MAX_WIDTH}
+          leftComponent={fileIcon}
+          rightComponent={
+            isDeleted ? (
+              <StyledDeletedLabel>{file.label}</StyledDeletedLabel>
+            ) : undefined
+          }
+          variant={ChipVariant.Highlighted}
+          clickable={isClickable}
+        />
+      </StyledClickableContainer>
+      {isDeleted &&
+        shouldShowTooltip &&
+        createPortal(
+          <AppTooltip
+            anchorSelect={tooltipAnchorSelect}
+            content={t`File no longer exists`}
+            delay={TooltipDelay.shortDelay}
+            noArrow
+            place={TooltipPosition.Top}
+            positionStrategy="fixed"
+          />,
+          document.body,
+        )}
+    </>
   );
 };

--- a/packages/twenty-front/src/modules/ui/field/display/components/FileChip.tsx
+++ b/packages/twenty-front/src/modules/ui/field/display/components/FileChip.tsx
@@ -54,6 +54,7 @@ export const FileChip = ({
       >
         <Chip
           label={file.label}
+          alwaysShowTooltip={isDeleted}
           tooltipLabel={
             isDeleted ? t`File no longer exists - ${file.label}` : undefined
           }

--- a/packages/twenty-front/src/modules/ui/field/display/components/FileChip.tsx
+++ b/packages/twenty-front/src/modules/ui/field/display/components/FileChip.tsx
@@ -1,35 +1,17 @@
 import { styled } from '@linaria/react';
 import { t } from '@lingui/core/macro';
-import { useId, useState } from 'react';
-import { createPortal } from 'react-dom';
 
 import { FileIcon } from '@/file/components/FileIcon';
 import { type FieldFilesValue } from '@/object-record/record-field/ui/types/FieldMetadata';
 import { getFileCategoryFromExtension } from '@/object-record/record-field/ui/utils/getFileCategoryFromExtension';
 import { Chip, ChipVariant } from 'twenty-ui/components';
-import { AppTooltip, TooltipDelay, TooltipPosition } from 'twenty-ui/display';
-import { themeCssVariables } from 'twenty-ui/theme-constants';
 
 const MAX_WIDTH = 120;
 
-const StyledClickableContainer = styled.div<{
-  clickable: boolean;
-  isDeleted: boolean;
-}>`
-  cursor: ${({ clickable, isDeleted }) =>
-    isDeleted ? 'not-allowed' : clickable ? 'pointer' : 'inherit'};
+const StyledClickableContainer = styled.div<{ clickable: boolean }>`
+  cursor: ${({ clickable }) => (clickable ? 'pointer' : 'inherit')};
   display: inline-flex;
   min-width: 0;
-`;
-
-const StyledDeletedLabel = styled.span`
-  color: ${themeCssVariables.font.color.secondary};
-  font-size: inherit;
-  max-width: ${MAX_WIDTH}px;
-  overflow: hidden;
-  text-decoration: line-through;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 `;
 
 type FileChipProps = {
@@ -45,9 +27,6 @@ export const FileChip = ({
 }: FileChipProps) => {
   const isDeleted = file.isDeleted === true;
   const isClickable = forceDisableClick !== true && !isDeleted;
-  const tooltipAnchorId = useId();
-  const tooltipAnchorSelect = `[data-tooltip-anchor="${tooltipAnchorId}"]`;
-  const [shouldShowTooltip, setShouldShowTooltip] = useState(false);
 
   const handleMouseDown = (event: React.MouseEvent): void => {
     if (!isClickable) {
@@ -70,41 +49,21 @@ export const FileChip = ({
   return (
     <>
       <StyledClickableContainer
-        data-tooltip-anchor={tooltipAnchorId}
         clickable={isClickable}
-        isDeleted={isDeleted}
         onMouseDown={handleMouseDown}
-        onMouseEnter={() => isDeleted && setShouldShowTooltip(true)}
-        onMouseLeave={() => setShouldShowTooltip(false)}
       >
         <Chip
-          label={isDeleted ? '' : (file.label ?? '')}
-          isLabelHidden={isDeleted}
-          maxWidth={isDeleted ? undefined : MAX_WIDTH}
-          leftComponent={fileIcon}
-          rightComponent={
-            isDeleted ? (
-              <StyledDeletedLabel>{file.label}</StyledDeletedLabel>
-            ) : undefined
+          label={file.label}
+          tooltipLabel={
+            isDeleted ? t`File no longer exists - ${file.label}` : undefined
           }
-          variant={ChipVariant.Highlighted}
+          disabled={isDeleted}
+          maxWidth={MAX_WIDTH}
+          leftComponent={fileIcon}
+          variant={isDeleted ? ChipVariant.Static : ChipVariant.Highlighted}
           clickable={isClickable}
         />
       </StyledClickableContainer>
-      {isDeleted &&
-        shouldShowTooltip &&
-        createPortal(
-          <AppTooltip
-            anchorSelect={tooltipAnchorSelect}
-            content={t`File no longer exists`}
-            delay={TooltipDelay.shortDelay}
-            isOpen={true}
-            noArrow
-            place={TooltipPosition.Top}
-            positionStrategy="fixed"
-          />,
-          document.body,
-        )}
     </>
   );
 };

--- a/packages/twenty-front/src/modules/ui/field/display/components/FileChip.tsx
+++ b/packages/twenty-front/src/modules/ui/field/display/components/FileChip.tsx
@@ -98,6 +98,7 @@ export const FileChip = ({
             anchorSelect={tooltipAnchorSelect}
             content={t`File no longer exists`}
             delay={TooltipDelay.shortDelay}
+            isOpen={true}
             noArrow
             place={TooltipPosition.Top}
             positionStrategy="fixed"

--- a/packages/twenty-ui/src/components/chip/Chip.tsx
+++ b/packages/twenty-ui/src/components/chip/Chip.tsx
@@ -30,6 +30,7 @@ export type ChipProps = {
   clickable?: boolean;
   label: string;
   tooltipLabel?: string;
+  alwaysShowTooltip?: boolean;
   isLabelHidden?: boolean;
   isBold?: boolean;
   maxWidth?: number;
@@ -174,6 +175,7 @@ export const Chip = ({
   size = ChipSize.Small,
   label,
   tooltipLabel,
+  alwaysShowTooltip = false,
   isLabelHidden = false,
   isBold = false,
   disabled = false,
@@ -206,6 +208,7 @@ export const Chip = ({
           size={size}
           text={label}
           tooltipContent={tooltipLabel}
+          alwaysShowTooltip={alwaysShowTooltip}
         />
       ) : !forceEmptyText && !isLabelHidden ? (
         <StyledDiv>{emptyLabel}</StyledDiv>

--- a/packages/twenty-ui/src/components/chip/Chip.tsx
+++ b/packages/twenty-ui/src/components/chip/Chip.tsx
@@ -29,6 +29,7 @@ export type ChipProps = {
   disabled?: boolean;
   clickable?: boolean;
   label: string;
+  tooltipLabel?: string;
   isLabelHidden?: boolean;
   isBold?: boolean;
   maxWidth?: number;
@@ -172,6 +173,7 @@ const renderRightComponent = (
 export const Chip = ({
   size = ChipSize.Small,
   label,
+  tooltipLabel,
   isLabelHidden = false,
   isBold = false,
   disabled = false,
@@ -200,7 +202,11 @@ export const Chip = ({
     >
       {leftComponent}
       {!isLabelHidden && isDefined(label) && isNonEmptyString(label) ? (
-        <OverflowingTextWithTooltip size={size} text={label} />
+        <OverflowingTextWithTooltip
+          size={size}
+          text={label}
+          tooltipContent={tooltipLabel}
+        />
       ) : !forceEmptyText && !isLabelHidden ? (
         <StyledDiv>{emptyLabel}</StyledDiv>
       ) : (

--- a/packages/twenty-ui/src/display/tooltip/OverflowingTextWithTooltip.tsx
+++ b/packages/twenty-ui/src/display/tooltip/OverflowingTextWithTooltip.tsx
@@ -64,6 +64,7 @@ type OverflowingTextWithTooltipProps = {
   isTooltipMultiline?: boolean;
   displayedMaxRows?: number;
   tooltipDelay?: TooltipDelay;
+  alwaysShowTooltip?: boolean;
 } & (
   | {
       text: string | null | undefined;
@@ -82,6 +83,7 @@ export const OverflowingTextWithTooltip = ({
   displayedMaxRows,
   tooltipContent,
   tooltipDelay = TooltipDelay.mediumDelay,
+  alwaysShowTooltip = false,
 }: OverflowingTextWithTooltipProps) => {
   const textElementId = `title-id-${+new Date()}`;
 
@@ -146,7 +148,7 @@ export const OverflowingTextWithTooltip = ({
       )}
 
       {shouldRenderTooltip &&
-        isTitleOverflowing &&
+        (isTitleOverflowing || alwaysShowTooltip) &&
         isDefined(tooltipText) &&
         createPortal(
           <div onClick={handleTooltipClick}>

--- a/packages/twenty-ui/src/display/tooltip/OverflowingTextWithTooltip.tsx
+++ b/packages/twenty-ui/src/display/tooltip/OverflowingTextWithTooltip.tsx
@@ -3,8 +3,8 @@ import { type ReactNode, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 import { isNonEmptyString } from '@sniptt/guards';
-import { isDefined } from 'twenty-shared/utils';
 import { themeCssVariables } from '@ui/theme-constants';
+import { isDefined } from 'twenty-shared/utils';
 import { AppTooltip, TooltipDelay } from './AppTooltip';
 
 const spacing4 = themeCssVariables.spacing[4];


### PR DESCRIPTION
Fixes: #18943 
Follow-up pr: #19001

## Summary:                                                             
  - Timeline activity shows file upload history, but deleted files had no signed URL and were still rendered as clickable — clicking did  nothing                                                          
  - grab the fileId from properties.diff.after, look it up in the current record's files field: if present, use live signed URL; if absent, mark as deleted      
  - Deleted file chips show line-through label, not-allowed cursor, and "File no longer exists" tooltip on hover
  

https://github.com/user-attachments/assets/5df6a675-0003-4fd1-ad57-a07e4338923f

