### PR TITLE
fix(admin): always open impersonation in a new tab to prevent SSE connection failure

### DIFF
--- a/packages/twenty-front/src/modules/settings/admin-panel/components/SettingsAdminWorkspaceContent.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/components/SettingsAdminWorkspaceContent.tsx
@@ -1,9 +1,7 @@
 import { currentUserState } from '@/auth/states/currentUserState';
-import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { canManageFeatureFlagsState } from '@/client-config/states/canManageFeatureFlagsState';
 import { SettingsAdminTableCard } from '@/settings/admin-panel/components/SettingsAdminTableCard';
 import { useFeatureFlagState } from '@/settings/admin-panel/hooks/useFeatureFlagState';
-import { useImpersonationAuth } from '@/settings/admin-panel/hooks/useImpersonationAuth';
 import { useImpersonationRedirect } from '@/settings/admin-panel/hooks/useImpersonationRedirect';
 import { userLookupResultState } from '@/settings/admin-panel/states/userLookupResultState';
 import { type WorkspaceInfo } from '@/settings/admin-panel/types/WorkspaceInfo';
@@ -63,11 +61,9 @@ export const SettingsAdminWorkspaceContent = ({
   const canManageFeatureFlags = useAtomStateValue(canManageFeatureFlagsState);
   const { enqueueErrorSnackBar } = useSnackBar();
   const [currentUser] = useAtomState(currentUserState);
-  const currentWorkspace = useAtomStateValue(currentWorkspaceState);
 
   const [updateFeatureFlag] = useMutation(UpdateWorkspaceFeatureFlagDocument);
   const [isImpersonateLoading, setIsImpersonationLoading] = useState(false);
-  const { executeImpersonationAuth } = useImpersonationAuth();
   const { executeImpersonationRedirect } = useImpersonationRedirect();
   const [impersonate] = useMutation(ImpersonateDocument);
 
@@ -88,12 +84,9 @@ export const SettingsAdminWorkspaceContent = ({
       variables: { userId: userLookupResult.user.id, workspaceId },
       onCompleted: async (data) => {
         const { loginToken, workspace } = data.impersonate;
-        const isCurrentWorkspace = workspace.id === currentWorkspace?.id;
-        if (isCurrentWorkspace) {
-          await executeImpersonationAuth(loginToken.token);
-          return;
-        }
-
+        // Always open in a new tab. The in-session token swap breaks the
+        // SSE event stream connection, causing "An error occurred" on any
+        // view load immediately after impersonating.
         return executeImpersonationRedirect(
           workspace.workspaceUrls,
           loginToken.token,


### PR DESCRIPTION
## Problem

When an admin impersonates a user **in the same workspace**, the current code calls `executeImpersonationAuth`, which does an in-session token swap:

```typescript
if (isCurrentWorkspace) {
  await executeImpersonationAuth(loginToken.token);  // ← breaks SSE
  return;
}
```

`executeImpersonationAuth` calls `clearSseClient()` and then `getAuthTokensFromLoginToken`, but the SSE connection is not successfully re-established under the impersonated session. The result is that **every view load immediately after impersonating shows "An error occurred"**, because the server rejects the impersonated session's attempt to subscribe to the event stream:

```
InternalServerError: You are not authorized to add a query to this event stream
  subCode: 'NOT_AUTHORIZED'
```

This makes same-workspace impersonation effectively broken for any data view.

## Fix

Remove the `isCurrentWorkspace` special case and always use `executeImpersonationRedirect` with `'_blank'`:

```typescript
// Always open in a new tab. The in-session token swap breaks the
// SSE event stream connection, causing "An error occurred" on any
// view load immediately after impersonating.
return executeImpersonationRedirect(
  workspace.workspaceUrls,
  loginToken.token,
  '_blank',
);
```

The different-workspace path was already doing this — this change unifies both. The `/verify` route handles token exchange cleanly in a new tab with no SSE state to tear down in the current session.

## What changes

- `SettingsAdminWorkspaceContent.tsx`: remove `isCurrentWorkspace` branch, remove now-unused `useImpersonationAuth` hook and `currentWorkspaceState` atom
- No behaviour change for different-workspace impersonation (was already `_blank`)
- Same-workspace impersonation now opens a clean new tab instead of trying to hot-swap tokens in the current session

## Testing

Tested on a self-hosted Twenty instance. Before this change: impersonating a same-workspace user resulted in "An error occurred" on every view. After: the new tab opens a fully functional session as the impersonated user with no errors.

## Why not fix the SSE reconnection instead?

The SSE stream is tied to the original user's auth context. Reconnecting it under the impersonated token requires deeper changes to the SSE client lifecycle. Opening a new tab is the simpler, safer, and arguably better UX — it also matches what already happens for cross-workspace impersonation, and leaves the admin's own session undisturbed.