### PR TITLE
fix: allow users with view-only permissions to execute workflows

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-trigger.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/workflow/resolvers/workflow-trigger.resolver.ts
@@ -26,11 +26,7 @@ import { WorkflowTriggerWorkspaceService } from 'src/modules/workflow/workflow-t
 import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
 
 @CoreResolver()
-@UseGuards(
-  WorkspaceAuthGuard,
-  UserAuthGuard,
-  SettingsPermissionGuard(PermissionFlagType.WORKFLOWS),
-)
+@UseGuards(WorkspaceAuthGuard, UserAuthGuard)
 @UsePipes(ResolverValidationPipe)
 @UseFilters(
   WorkflowTriggerGraphqlApiExceptionFilter,
@@ -44,6 +40,7 @@ export class WorkflowTriggerResolver {
   ) {}
 
   @Mutation(() => Boolean)
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.WORKFLOWS))
   async activateWorkflowVersion(
     @AuthWorkspace() workspace: WorkspaceEntity,
     @Args('workflowVersionId', { type: () => UUIDScalarType })
@@ -56,6 +53,7 @@ export class WorkflowTriggerResolver {
   }
 
   @Mutation(() => Boolean)
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.WORKFLOWS))
   async deactivateWorkflowVersion(
     @AuthWorkspace() workspace: WorkspaceEntity,
     @Args('workflowVersionId', { type: () => UUIDScalarType })
@@ -111,6 +109,7 @@ export class WorkflowTriggerResolver {
   }
 
   @Mutation(() => WorkflowRunDTO)
+  @UseGuards(SettingsPermissionGuard(PermissionFlagType.WORKFLOWS))
   async stopWorkflowRun(
     @AuthWorkspace() workspace: WorkspaceEntity,
     @Args('workflowRunId', { type: () => UUIDScalarType })


### PR DESCRIPTION
## Summary

Users with view-only permissions for workflows cannot trigger active workflows (#15231). The `SettingsPermissionGuard(PermissionFlagType.WORKFLOWS)` was applied at the class level on `WorkflowTriggerResolver`, requiring "manage workflow" permission for ALL mutations — including `runWorkflowVersion`.

## Fix

Move the WORKFLOWS permission guard from class-level to method-level on the three management mutations. `runWorkflowVersion` now only requires authentication (WorkspaceAuthGuard + UserAuthGuard).

**Before:** Class-level guard blocks all mutations for view-only users
```typescript
@UseGuards(
  WorkspaceAuthGuard,
  UserAuthGuard,
  SettingsPermissionGuard(PermissionFlagType.WORKFLOWS), // blocks everything
)
export class WorkflowTriggerResolver { ... }
```

**After:** Method-level guards on management mutations only
```typescript
@UseGuards(WorkspaceAuthGuard, UserAuthGuard) // auth only at class level

@UseGuards(SettingsPermissionGuard(PermissionFlagType.WORKFLOWS))
async activateWorkflowVersion() { ... }  // manage permission required

@UseGuards(SettingsPermissionGuard(PermissionFlagType.WORKFLOWS))
async deactivateWorkflowVersion() { ... } // manage permission required

async runWorkflowVersion() { ... }        // any authenticated user

@UseGuards(SettingsPermissionGuard(PermissionFlagType.WORKFLOWS))
async stopWorkflowRun() { ... }           // manage permission required
```

## Permission model after this change

| Mutation | Permission required |
|---|---|
| `activateWorkflowVersion` | WORKFLOWS (manage) |
| `deactivateWorkflowVersion` | WORKFLOWS (manage) |
| `stopWorkflowRun` | WORKFLOWS (manage) |
| `runWorkflowVersion` | Authentication only (view access) |

Fixes #15231