### PR TITLE
Handle SSE token expiration silently to avoid Sentry noise

### DIFF
--- a/packages/twenty-front/src/modules/sse-db-event/hooks/useTriggerEventStreamCreation.ts
+++ b/packages/twenty-front/src/modules/sse-db-event/hooks/useTriggerEventStreamCreation.ts
@@ -115,6 +115,19 @@ export const useTriggerEventStreamCreation = () => {
           dispatchMetadataEventsFromSseToBrowserEvents(metadataEvents);
         },
         error: (error) => {
+          const isTokenExpiredError =
+            (error instanceof Error &&
+              (error.message.includes('401') ||
+                error.message.includes('UNAUTHENTICATED') ||
+                error.message.includes('Unauthorized'))) ||
+            ('status' in error && (error as { status: number }).status === 401);
+
+          if (isTokenExpiredError) {
+            store.set(shouldDestroyEventStreamState.atom, true);
+
+            return;
+          }
+
           captureException(error);
         },
         complete: () => {},


### PR DESCRIPTION
## Summary
- Fixes the SSE client error handler in `useTriggerEventStreamCreation` to detect token expiration errors (401/UNAUTHENTICATED) and handle them silently by triggering event stream reconnection
- Non-token-expiration errors continue to be reported to Sentry as before
- This prevents excessive Sentry error logs caused by normal idle session token expiry, which is a standard reconnection scenario

Fixes #18077

## Test plan
- [ ] Verify that when a session goes idle and the token expires, no error is sent to Sentry
- [ ] Verify that the SSE client reconnects normally after token expiration
- [ ] Verify that genuine SSE errors (non-auth) are still captured in Sentry