### PR TITLE
Fix Kanban drag-and-drop only registering drops near top of column

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-board/record-board-column/components/RecordBoardColumn.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/record-board-column/components/RecordBoardColumn.tsx
@@ -74,7 +74,6 @@ export const RecordBoardColumn = ({
                 recordBoardColumnId={recordBoardColumnId}
               />
             </DragAndDropLibraryLegacyReRenderBreaker>
-            {droppableProvided.placeholder}
           </StyledColumn>
         )}
       </Droppable>

--- a/packages/twenty-front/src/modules/object-record/record-board/record-board-column/components/RecordBoardColumnCardsContainer.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/record-board-column/components/RecordBoardColumnCardsContainer.tsx
@@ -73,6 +73,7 @@ export const RecordBoardColumnCardsContainer = ({
           ></div>
         )}
       </Draggable>
+      {droppableProvided?.placeholder}
       <StyledNewButtonContainer>
         <RecordBoardColumnNewRecordButton />
       </StyledNewButtonContainer>


### PR DESCRIPTION
## Summary

- Moves `droppableProvided.placeholder` back inside the `innerRef` container (`StyledColumnCardsContainer`) to fix broken drag-and-drop in Kanban view
- The placeholder was moved outside the `innerRef` element in PR #15714 as part of a performance optimization, which violated `@hello-pangea/dnd`'s API contract requiring the placeholder to be rendered inside the same DOM node that receives `innerRef`
- This caused the library's hit detection to use a shrunk bounding box, so drops only registered near the top of target columns

## Root Cause

`@hello-pangea/dnd` requires `droppableProvided.placeholder` to be rendered inside the same DOM element that receives `droppableProvided.innerRef`. In the current code, `innerRef` is on `StyledColumnCardsContainer` inside `RecordBoardColumnCardsContainer`, but the placeholder was rendered as a sibling in the parent `RecordBoardColumn`. This caused the droppable area to shrink when a card was dragged out, making drops only register near the top.

## Changes

- **`RecordBoardColumnCardsContainer.tsx`**: Added `droppableProvided.placeholder` inside the `StyledColumnCardsContainer` (the `innerRef` element)
- **`RecordBoardColumn.tsx`**: Removed the placeholder from outside the `DragAndDropLibraryLegacyReRenderBreaker` wrapper

## Test plan

- [ ] Open a Kanban view with enough cards that at least one column requires scrolling
- [ ] Drag a card from one column and drop it into the **middle** of another column — should work
- [ ] Drag a card and drop it into the **bottom** of another column — should work
- [ ] Drag a card and drop it at the **top** of a column — should still work
- [ ] Verify no regressions in card ordering after drop

Fixes #18842