### PR TITLE
Fix address autocomplete duplicating city/state/country in Address 1

### DIFF
--- a/packages/twenty-front/src/modules/ui/field/input/hooks/useAddressAutocomplete.ts
+++ b/packages/twenty-front/src/modules/ui/field/input/hooks/useAddressAutocomplete.ts
@@ -79,8 +79,30 @@ export const useAddressAutocomplete = (
       const placeData = await getPlaceDetailsData(placeId, token);
       const countryName = findCountryNameByCountryCode(placeData?.country);
 
+      let cleanedStreet1 =
+        addressStreet1 || (internalValue?.addressStreet1 ?? '');
+
+      if (isDefined(addressStreet1)) {
+        const partsToRemove = [
+          placeData?.city,
+          placeData?.state,
+          placeData?.postcode,
+          countryName,
+        ].filter(isDefined);
+
+        for (const part of partsToRemove) {
+          cleanedStreet1 = cleanedStreet1.replace(part, '');
+        }
+
+        cleanedStreet1 = cleanedStreet1
+          .replace(/,\s*,/g, ',')
+          .replace(/,\s*$/, '')
+          .replace(/^\s*,/, '')
+          .trim();
+      }
+
       const updatedAddress = {
-        addressStreet1: addressStreet1 || (internalValue?.addressStreet1 ?? ''),
+        addressStreet1: cleanedStreet1,
         addressStreet2: internalValue?.addressStreet2 ?? null,
         addressCity: placeData?.city || (internalValue?.addressCity ?? null),
         addressState: placeData?.state || (internalValue?.addressState ?? null),


### PR DESCRIPTION
## Summary
- Fixes the address autocomplete behavior where selecting a suggestion would store the full address string (e.g., "123 Main St, New York, NY 10001, USA") in the Address 1 field, even though city, state, postal code, and country were already extracted into their dedicated fields
- After extracting address components from place details, the fix strips those components from the Address 1 text and cleans up leftover comma separators, so only the street address remains

Fixes #18860

## Test plan
- [ ] Open an address field and type a partial address in Address 1
- [ ] Select an autocomplete suggestion from the dropdown
- [ ] Verify that Address 1 contains only the street address (e.g., "123 Main St") and not the full string with city/state/country/zip
- [ ] Verify that City, State, Post Code, and Country fields are still correctly populated
- [ ] Test with addresses from different countries to confirm the cleanup handles various formats