### PR TITLE
fix: infer phone country code from E.164 numbers in workflow Create Record

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/record-transformer/utils/__tests__/transform-phones-value.util.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-transformer/utils/__tests__/transform-phones-value.util.spec.ts
@@ -1,0 +1,76 @@
+import { transformPhonesValue } from '../transform-phones-value.util';
+
+describe('transformPhonesValue', () => {
+  it('should infer calling code and country code from E.164 number when they are empty strings', () => {
+    const result = transformPhonesValue({
+      input: {
+        primaryPhoneNumber: '+919999999999',
+        primaryPhoneCallingCode: '',
+        primaryPhoneCountryCode: '',
+      },
+    });
+
+    expect(result).toEqual({
+      primaryPhoneNumber: '9999999999',
+      primaryPhoneCallingCode: '+91',
+      primaryPhoneCountryCode: 'IN',
+      additionalPhones: null,
+    });
+  });
+
+  it('should infer calling code and country code from E.164 number when they are not provided', () => {
+    const result = transformPhonesValue({
+      input: {
+        primaryPhoneNumber: '+14155552671',
+      },
+    });
+
+    expect(result).toEqual({
+      primaryPhoneNumber: '4155552671',
+      primaryPhoneCallingCode: '+1',
+      primaryPhoneCountryCode: 'US',
+      additionalPhones: null,
+    });
+  });
+
+  it('should preserve explicitly provided calling code and country code', () => {
+    const result = transformPhonesValue({
+      input: {
+        primaryPhoneNumber: '9999999999',
+        primaryPhoneCallingCode: '+91',
+        primaryPhoneCountryCode: 'IN',
+      },
+    });
+
+    expect(result).toEqual({
+      primaryPhoneNumber: '9999999999',
+      primaryPhoneCallingCode: '+91',
+      primaryPhoneCountryCode: 'IN',
+      additionalPhones: null,
+    });
+  });
+
+  it('should return input as-is when input is null', () => {
+    const result = transformPhonesValue({ input: null });
+    expect(result).toBeNull();
+  });
+
+  it('should return input as-is when input is undefined', () => {
+    const result = transformPhonesValue({ input: undefined });
+    expect(result).toBeUndefined();
+  });
+
+  it('should handle empty phone number with empty calling code', () => {
+    const result = transformPhonesValue({
+      input: {
+        primaryPhoneNumber: '',
+        primaryPhoneCallingCode: '',
+        primaryPhoneCountryCode: '',
+      },
+    });
+
+    expect(result).toEqual({
+      additionalPhones: null,
+    });
+  });
+});

--- a/packages/twenty-server/src/engine/core-modules/record-transformer/utils/transform-phones-value.util.ts
+++ b/packages/twenty-server/src/engine/core-modules/record-transformer/utils/transform-phones-value.util.ts
@@ -139,9 +139,12 @@ const validateAndInferMetadataFromPrimaryPhoneNumber = ({
   }
 
   const finalPrimaryPhoneCallingCode =
-    callingCode ??
-    (`+${phone.countryCallingCode}` as undefined | CountryCallingCode);
-  const finalPrimaryPhoneCountryCode = countryCode ?? phone.country;
+    (isNonEmptyString(callingCode)
+      ? callingCode
+      : (`+${phone.countryCallingCode}` as undefined | CountryCallingCode));
+  const finalPrimaryPhoneCountryCode = isNonEmptyString(countryCode)
+    ? countryCode
+    : phone.country;
 
   return {
     countryCode: finalPrimaryPhoneCountryCode,


### PR DESCRIPTION
## Summary

- Fixes a bug where Workflow "Create Record" action drops the calling code (`+91`) and country code when a phone field is populated with an E.164 number via variable mapping (e.g. from a webhook payload)
- The root cause was that `validateAndInferMetadataFromPrimaryPhoneNumber` used the nullish coalescing operator (`??`) to decide whether to infer calling/country codes from the phone number. Since the workflow frontend sends empty strings (`''`) for unset calling code and country code sub-fields, `??` treated them as valid values and skipped inference.
- Replaced `??` with `isNonEmptyString()` checks so that empty strings are treated as "not provided", allowing `libphonenumber-js` to correctly parse and infer both calling code and country code from E.164 formatted phone numbers.
- Added unit tests for `transformPhonesValue` covering E.164 inference, explicit values, and edge cases.

## Test plan

- [ ] Verify that a Workflow with a webhook trigger mapping an E.164 phone number (e.g. `+919999999999`) to a Phone field correctly stores calling code (`+91`) and country code (`IN`)
- [ ] Verify that explicitly setting calling code and country code in the workflow form still works correctly
- [ ] Verify that API-level phone number creation still works as before
- [ ] Run `transformPhonesValue` unit tests

Fixes #17182