### PR TITLE
fix: resolve CODE step result variables in workflow templates

### DIFF
--- a/packages/twenty-shared/src/utils/__tests__/variable-resolver.test.ts
+++ b/packages/twenty-shared/src/utils/__tests__/variable-resolver.test.ts
@@ -130,6 +130,46 @@ describe('resolveInput', () => {
     ).toBe('{ "a": "str" }');
   });
 
+  describe('CODE step output variable resolution', () => {
+    const codeStepContext = {
+      'transform-step-001': {
+        memberName: 'Mike Chen',
+        eventName: 'Microsoft Gala',
+        result: {
+          memberName: 'Mike Chen',
+          eventName: 'Microsoft Gala',
+        },
+      },
+    };
+
+    it('should resolve CODE step output via direct path', () => {
+      expect(
+        resolveInput(
+          '{{transform-step-001.memberName}}',
+          codeStepContext,
+        ),
+      ).toBe('Mike Chen');
+    });
+
+    it('should resolve CODE step output via result path', () => {
+      expect(
+        resolveInput(
+          '{{transform-step-001.result.memberName}}',
+          codeStepContext,
+        ),
+      ).toBe('Mike Chen');
+    });
+
+    it('should resolve multiple CODE step variables in a string', () => {
+      expect(
+        resolveInput(
+          'Confirmed - {{transform-step-001.result.memberName}} for {{transform-step-001.result.eventName}}',
+          codeStepContext,
+        ),
+      ).toBe('Confirmed - Mike Chen for Microsoft Gala');
+    });
+  });
+
   describe('bracket notation for keys with special characters', () => {
     it('should resolve variables with keys containing spaces', () => {
       const contextWithSpaces = {

--- a/packages/twenty-shared/src/workflow/utils/__tests__/getWorkflowRunContext.test.ts
+++ b/packages/twenty-shared/src/workflow/utils/__tests__/getWorkflowRunContext.test.ts
@@ -17,11 +17,36 @@ describe('getWorkflowRunContext', () => {
     const context = getWorkflowRunContext(stepInfos);
 
     expect(context).toEqual({
-      step1: { res: 'value1' },
-      step2: {},
-      step4: { res: 0 },
-      step5: { res: undefined },
+      step1: { res: 'value1', result: { res: 'value1' } },
+      step2: { result: {} },
+      step4: { res: 0, result: { res: 0 } },
+      step5: { res: undefined, result: { res: undefined } },
     });
+  });
+
+  it('allows accessing step output via result property for backward compatibility', () => {
+    const stepInfos: WorkflowRunStepInfos = {
+      'code-step-001': {
+        result: { memberName: 'Mike Chen', eventName: 'Gala' },
+        status: StepStatus.SUCCESS,
+      },
+    };
+
+    const context = getWorkflowRunContext(stepInfos);
+
+    // Direct access (used by UI-generated variables)
+    expect(
+      (context['code-step-001'] as Record<string, unknown>)['memberName'],
+    ).toBe('Mike Chen');
+
+    // Access via result property (used by manually written variables)
+    expect(
+      (
+        (context['code-step-001'] as Record<string, unknown>)[
+          'result'
+        ] as Record<string, unknown>
+      )['memberName'],
+    ).toBe('Mike Chen');
   });
 
   it('returns an empty object when no step has a defined result', () => {

--- a/packages/twenty-shared/src/workflow/utils/getWorkflowRunContext.ts
+++ b/packages/twenty-shared/src/workflow/utils/getWorkflowRunContext.ts
@@ -7,6 +7,14 @@ export const getWorkflowRunContext = (
   return Object.fromEntries(
     Object.entries(stepInfos)
       .filter(([, value]) => isDefined(value?.['result']))
-      .map(([key, value]) => [key, value?.['result']]),
+      .map(([key, value]) => {
+        const result = value?.['result'];
+
+        if (typeof result === 'object' && result !== null) {
+          return [key, { ...result, result }];
+        }
+
+        return [key, result];
+      }),
   );
 };


### PR DESCRIPTION
## Summary
- Fixes workflow template variable substitution for CODE step outputs referenced via `{{step.result.field}}` path
- The `getWorkflowRunContext` function now exposes step results both at the top level (`{{step.field}}`) and under a `result` key (`{{step.result.field}}`), so both access patterns resolve correctly
- Adds tests for the new behavior in both `getWorkflowRunContext` and `variable-resolver`

## Problem
When a CODE step in a workflow produces output (e.g., `{ memberName: "Mike Chen", eventName: "Microsoft Gala" }`), subsequent steps like SEND_EMAIL that reference these values using `{{transform-step-001.result.memberName}}` get `undefined` instead of the actual value. This is because `getWorkflowRunContext` strips the `result` wrapper from step outputs, so only `{{step.field}}` works but `{{step.result.field}}` does not.

## Fix
Modified `getWorkflowRunContext` in `packages/twenty-shared/src/workflow/utils/getWorkflowRunContext.ts` to spread the result object at the top level AND include it under a `result` key. This preserves backward compatibility with existing UI-generated variables (`{{step.field}}`) while also supporting the `{{step.result.field}}` path that users naturally write based on the workflow run state structure.

## Test plan
- [ ] Verify `{{step.field}}` still resolves correctly (backward compatibility)
- [ ] Verify `{{step.result.field}}` now resolves correctly
- [ ] Verify multi-variable strings like `{{step.result.a}} and {{step.result.b}}` work
- [ ] Run existing unit tests for `getWorkflowRunContext` and `variable-resolver`

Fixes #17109

🤖 Generated with [Claude Code](https://claude.com/claude-code)