### PR TITLE
fix: resolve blank merge preview when selecting many records

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-merge/hooks/usePerformMergePreview.ts
+++ b/packages/twenty-front/src/modules/object-record/record-merge/hooks/usePerformMergePreview.ts
@@ -3,7 +3,7 @@ import { useMergeManyRecords } from '@/object-record/hooks/useMergeManyRecords';
 import { useMergeRecordsSelectedRecords } from '@/object-record/record-merge/hooks/useMergeRecordsSelectedRecords';
 import { useUpsertRecordsInStore } from '@/object-record/record-store/hooks/useUpsertRecordsInStore';
 import { type ObjectRecord } from '@/object-record/types/ObjectRecord';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { isMergeInProgressState } from '@/object-record/record-merge/states/mergeInProgressState';
 import { mergeSettingsState } from '@/object-record/record-merge/states/mergeSettingsState';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
@@ -18,7 +18,8 @@ export const usePerformMergePreview = ({
   const [mergePreviewRecord, setMergePreviewRecord] =
     useState<ObjectRecord | null>(null);
   const [isGeneratingPreview, setIsGeneratingPreview] = useState(false);
-  const [isInitialized, setIsInitialized] = useState(false);
+
+  const isGeneratingPreviewRef = useRef(false);
 
   const mergeSettings = useAtomStateValue(mergeSettingsState);
   const isMergeInProgress = useAtomStateValue(isMergeInProgressState);
@@ -31,21 +32,22 @@ export const usePerformMergePreview = ({
 
   const { upsertRecordsInStore } = useUpsertRecordsInStore();
 
-  useEffect(() => {
-    const fetchPreview = async () => {
-      if (
-        selectedRecords.length < 2 ||
-        isMergeInProgress ||
-        isInitialized ||
-        isGeneratingPreview
-      ) {
+  const selectedRecordIds = selectedRecords
+    .map((record) => record.id)
+    .sort()
+    .join(',');
+
+  const fetchPreview = useCallback(
+    async (records: ObjectRecord[]) => {
+      if (records.length < 2 || isGeneratingPreviewRef.current) {
         return;
       }
 
+      isGeneratingPreviewRef.current = true;
       setIsGeneratingPreview(true);
       try {
         const previewRecord = await mergeManyRecords({
-          recordIds: selectedRecords.map((record) => record.id),
+          recordIds: records.map((record) => record.id),
           mergeSettings,
           preview: true,
         });
@@ -63,23 +65,23 @@ export const usePerformMergePreview = ({
       } catch {
         setMergePreviewRecord(null);
       } finally {
+        isGeneratingPreviewRef.current = false;
         setIsGeneratingPreview(false);
-        setIsInitialized(true);
       }
-    };
+    },
+    [mergeManyRecords, mergeSettings, upsertRecordsInStore],
+  );
 
-    if (selectedRecords.length > 0 && !isMergeInProgress) {
-      fetchPreview();
+  useEffect(() => {
+    if (
+      selectedRecords.length >= 2 &&
+      !isMergeInProgress &&
+      !isGeneratingPreviewRef.current
+    ) {
+      fetchPreview(selectedRecords);
     }
-  }, [
-    selectedRecords,
-    mergeSettings,
-    isMergeInProgress,
-    isGeneratingPreview,
-    mergeManyRecords,
-    upsertRecordsInStore,
-    isInitialized,
-  ]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedRecordIds, mergeSettings, isMergeInProgress, fetchPreview]);
 
   return {
     mergePreviewRecord,


### PR DESCRIPTION
## Summary

Fixes #18214 — the "Merge preview" tab stays blank when selecting many records (e.g. 5) for merging.

**Root cause:** The `usePerformMergePreview` hook had two issues:

1. **`isInitialized` flag prevented retries** — Once set to `true` after the first fetch attempt (success or failure), the preview could never re-fetch. With many records, the `selectedRecords` array reference changes more frequently (each underlying record atom update creates a new array from the Jotai selector). If the initial fetch ran with stale/incomplete data or failed silently (the mutation uses `errorPolicy: 'ignore'`), `isInitialized` blocked all subsequent attempts.

2. **`isGeneratingPreview` as React state was subject to stale closures** — The guard check inside the effect used the state value captured at render time, not the latest value. With more records causing more frequent re-renders, concurrent effect invocations could slip past the guard.

**Fix:**
- Removed `isInitialized` entirely — replaced with a stable `selectedRecordIds` string (sorted, comma-joined IDs) as the effect dependency, so the effect only re-runs when the actual set of records changes
- Added `useRef` for `isGeneratingPreviewRef` to track in-flight fetches without stale closure issues
- Extracted `fetchPreview` into a `useCallback` that receives `selectedRecords` as a parameter to avoid stale closures
- Kept `isGeneratingPreview` state for the return value (used by `MergePreviewTab` to show loading state)

## Test plan

- [ ] Select 2 records, open command menu, click "Merge records" → merge preview tab shows preview
- [ ] Select 5 records, open command menu, click "Merge records" → merge preview tab shows preview (was blank before)
- [ ] Switch to Settings tab, change priority record, switch back to Merge preview → preview reflects updated priority
- [ ] Verify merge action still works correctly after previewing