### PR TITLE
test(twenty-ui): add unit tests for Checkbox, Toggle, Banner, Status

### DIFF
--- a/packages/twenty-ui/src/display/banner/components/__tests__/Banner.test.tsx
+++ b/packages/twenty-ui/src/display/banner/components/__tests__/Banner.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react';
+
+import { Banner } from '../Banner';
+
+describe('Banner', () => {
+  it('renders children text', () => {
+    render(<Banner>Test banner message</Banner>);
+
+    expect(screen.getByText('Test banner message')).toBeInTheDocument();
+  });
+
+  it('renders with default variant', () => {
+    const { container } = render(<Banner>Default banner</Banner>);
+
+    expect(container.firstChild).toBeInTheDocument();
+    expect(screen.getByText('Default banner')).toBeInTheDocument();
+  });
+
+  it('renders with danger variant', () => {
+    const { container } = render(
+      <Banner variant="danger">Danger banner</Banner>,
+    );
+
+    expect(container.firstChild).toBeInTheDocument();
+    expect(screen.getByText('Danger banner')).toBeInTheDocument();
+  });
+
+  it('renders complex children', () => {
+    render(
+      <Banner>
+        <span data-testid="child-span">Complex child</span>
+      </Banner>,
+    );
+
+    expect(screen.getByTestId('child-span')).toBeInTheDocument();
+    expect(screen.getByText('Complex child')).toBeInTheDocument();
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(
+      <Banner className="custom-banner">Styled banner</Banner>,
+    );
+
+    expect(container.querySelector('.custom-banner')).toBeInTheDocument();
+  });
+
+  it('renders multiple children', () => {
+    render(
+      <Banner>
+        <span>First</span>
+        <span>Second</span>
+      </Banner>,
+    );
+
+    expect(screen.getByText('First')).toBeInTheDocument();
+    expect(screen.getByText('Second')).toBeInTheDocument();
+  });
+});

--- a/packages/twenty-ui/src/display/status/components/__tests__/Status.test.tsx
+++ b/packages/twenty-ui/src/display/status/components/__tests__/Status.test.tsx
@@ -1,0 +1,86 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { Status } from '../Status';
+
+describe('Status', () => {
+  it('renders with text', () => {
+    render(<Status color="green" text="Active" />);
+
+    expect(screen.getByText('Active')).toBeInTheDocument();
+  });
+
+  it('renders with different colors', () => {
+    const { rerender } = render(<Status color="green" text="Green" />);
+    expect(screen.getByText('Green')).toBeInTheDocument();
+
+    rerender(<Status color="red" text="Red" />);
+    expect(screen.getByText('Red')).toBeInTheDocument();
+
+    rerender(<Status color="blue" text="Blue" />);
+    expect(screen.getByText('Blue')).toBeInTheDocument();
+
+    rerender(<Status color="orange" text="Orange" />);
+    expect(screen.getByText('Orange')).toBeInTheDocument();
+  });
+
+  it('falls back to gray for unknown colors', () => {
+    const { container } = render(
+      <Status color={'unknown' as any} text="Unknown" />,
+    );
+
+    expect(container.firstChild).toBeInTheDocument();
+    expect(screen.getByText('Unknown')).toBeInTheDocument();
+  });
+
+  it('calls onClick when clicked', () => {
+    const handleClick = jest.fn();
+
+    render(<Status color="green" text="Clickable" onClick={handleClick} />);
+
+    fireEvent.click(screen.getByText('Clickable'));
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not throw when onClick is not provided', () => {
+    render(<Status color="green" text="No handler" />);
+
+    expect(() => {
+      fireEvent.click(screen.getByText('No handler'));
+    }).not.toThrow();
+  });
+
+  it('renders with regular weight by default', () => {
+    const { container } = render(
+      <Status color="green" text="Regular weight" />,
+    );
+
+    expect(container.firstChild).toBeInTheDocument();
+  });
+
+  it('renders with medium weight', () => {
+    const { container } = render(
+      <Status color="green" text="Medium weight" weight="medium" />,
+    );
+
+    expect(container.firstChild).toBeInTheDocument();
+  });
+
+  it('renders without loader by default', () => {
+    const { container } = render(
+      <Status color="green" text="No loader" />,
+    );
+
+    expect(screen.getByText('No loader')).toBeInTheDocument();
+    // Loader should not be present
+    expect(container.querySelector('[data-testid="loader"]')).toBeNull();
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(
+      <Status color="green" text="Styled" className="custom-status" />,
+    );
+
+    expect(container.querySelector('.custom-status')).toBeInTheDocument();
+  });
+});

--- a/packages/twenty-ui/src/input/components/__tests__/Checkbox.test.tsx
+++ b/packages/twenty-ui/src/input/components/__tests__/Checkbox.test.tsx
@@ -1,0 +1,137 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import {
+  Checkbox,
+  CheckboxAccent,
+  CheckboxShape,
+  CheckboxSize,
+  CheckboxVariant,
+} from '../Checkbox';
+
+describe('Checkbox', () => {
+  it('renders unchecked by default', () => {
+    render(<Checkbox checked={false} />);
+
+    const input = screen.getByTestId('input-checkbox');
+
+    expect(input).not.toBeChecked();
+  });
+
+  it('renders checked when checked prop is true', () => {
+    render(<Checkbox checked={true} />);
+
+    const input = screen.getByTestId('input-checkbox');
+
+    expect(input).toBeChecked();
+  });
+
+  it('calls onChange when clicked', () => {
+    const handleChange = jest.fn();
+
+    render(<Checkbox checked={false} onChange={handleChange} />);
+
+    const input = screen.getByTestId('input-checkbox');
+    fireEvent.click(input);
+
+    expect(handleChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onCheckedChange with the new checked value', () => {
+    const handleCheckedChange = jest.fn();
+
+    render(
+      <Checkbox checked={false} onCheckedChange={handleCheckedChange} />,
+    );
+
+    const input = screen.getByTestId('input-checkbox');
+    fireEvent.click(input);
+
+    expect(handleCheckedChange).toHaveBeenCalledWith(true);
+  });
+
+  it('renders as disabled when disabled prop is true', () => {
+    render(<Checkbox checked={false} disabled />);
+
+    const input = screen.getByTestId('input-checkbox');
+
+    expect(input).toBeDisabled();
+  });
+
+  it('renders with different variants', () => {
+    const { rerender } = render(
+      <Checkbox checked={false} variant={CheckboxVariant.Primary} />,
+    );
+    expect(screen.getByTestId('input-checkbox')).toBeInTheDocument();
+
+    rerender(
+      <Checkbox checked={false} variant={CheckboxVariant.Secondary} />,
+    );
+    expect(screen.getByTestId('input-checkbox')).toBeInTheDocument();
+
+    rerender(
+      <Checkbox checked={false} variant={CheckboxVariant.Tertiary} />,
+    );
+    expect(screen.getByTestId('input-checkbox')).toBeInTheDocument();
+  });
+
+  it('renders with different sizes', () => {
+    const { rerender } = render(
+      <Checkbox checked={false} size={CheckboxSize.Large} />,
+    );
+    expect(screen.getByTestId('input-checkbox')).toBeInTheDocument();
+
+    rerender(<Checkbox checked={false} size={CheckboxSize.Small} />);
+    expect(screen.getByTestId('input-checkbox')).toBeInTheDocument();
+  });
+
+  it('renders with different shapes', () => {
+    const { rerender } = render(
+      <Checkbox checked={false} shape={CheckboxShape.Squared} />,
+    );
+    expect(screen.getByTestId('input-checkbox')).toBeInTheDocument();
+
+    rerender(<Checkbox checked={false} shape={CheckboxShape.Rounded} />);
+    expect(screen.getByTestId('input-checkbox')).toBeInTheDocument();
+  });
+
+  it('renders with different accents', () => {
+    const { rerender } = render(
+      <Checkbox checked={true} accent={CheckboxAccent.Blue} />,
+    );
+    expect(screen.getByTestId('input-checkbox')).toBeInTheDocument();
+
+    rerender(<Checkbox checked={true} accent={CheckboxAccent.Orange} />);
+    expect(screen.getByTestId('input-checkbox')).toBeInTheDocument();
+  });
+
+  it('renders indeterminate state with minus icon', () => {
+    const { container } = render(
+      <Checkbox checked={false} indeterminate={true} />,
+    );
+
+    const svgElements = container.querySelectorAll('svg');
+
+    expect(svgElements.length).toBeGreaterThan(0);
+  });
+
+  it('toggles from unchecked to checked on click', () => {
+    const handleCheckedChange = jest.fn();
+
+    render(
+      <Checkbox checked={false} onCheckedChange={handleCheckedChange} />,
+    );
+
+    const input = screen.getByTestId('input-checkbox');
+    fireEvent.click(input);
+
+    expect(handleCheckedChange).toHaveBeenCalledWith(true);
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(
+      <Checkbox checked={false} className="custom-checkbox" />,
+    );
+
+    expect(container.querySelector('.custom-checkbox')).toBeInTheDocument();
+  });
+});

--- a/packages/twenty-ui/src/input/components/__tests__/Toggle.test.tsx
+++ b/packages/twenty-ui/src/input/components/__tests__/Toggle.test.tsx
@@ -1,0 +1,105 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { Toggle } from '../Toggle';
+
+// Mock framer-motion to avoid animation issues in tests
+jest.mock('framer-motion', () => {
+  const actual = jest.requireActual('framer-motion');
+  return {
+    ...actual,
+    motion: {
+      ...actual.motion,
+      create: (component: React.ComponentType) => component,
+    },
+  };
+});
+
+describe('Toggle', () => {
+  it('renders with default props', () => {
+    render(<Toggle />);
+
+    const input = screen.getByRole('checkbox');
+
+    expect(input).not.toBeChecked();
+  });
+
+  it('renders as checked when value is true', () => {
+    render(<Toggle value={true} />);
+
+    const input = screen.getByRole('checkbox');
+
+    expect(input).toBeChecked();
+  });
+
+  it('renders as unchecked when value is false', () => {
+    render(<Toggle value={false} />);
+
+    const input = screen.getByRole('checkbox');
+
+    expect(input).not.toBeChecked();
+  });
+
+  it('calls onChange when toggled', () => {
+    const handleChange = jest.fn();
+
+    render(<Toggle value={false} onChange={handleChange} />);
+
+    const input = screen.getByRole('checkbox');
+    fireEvent.click(input);
+
+    expect(handleChange).toHaveBeenCalledWith(true);
+  });
+
+  it('calls onChange with false when toggling off', () => {
+    const handleChange = jest.fn();
+
+    render(<Toggle value={true} onChange={handleChange} />);
+
+    const input = screen.getByRole('checkbox');
+    fireEvent.click(input);
+
+    expect(handleChange).toHaveBeenCalledWith(false);
+  });
+
+  it('renders with small size', () => {
+    const { container } = render(<Toggle toggleSize="small" />);
+
+    expect(container.firstChild).toBeInTheDocument();
+  });
+
+  it('renders with medium size', () => {
+    const { container } = render(<Toggle toggleSize="medium" />);
+
+    expect(container.firstChild).toBeInTheDocument();
+  });
+
+  it('renders disabled state', () => {
+    render(<Toggle disabled={true} />);
+
+    const input = screen.getByRole('checkbox');
+
+    expect(input).toBeDisabled();
+  });
+
+  it('renders as disabled when disabled prop is true', () => {
+    render(<Toggle value={false} disabled={true} />);
+
+    const input = screen.getByRole('checkbox');
+
+    expect(input).toBeDisabled();
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(<Toggle className="custom-toggle" />);
+
+    expect(container.querySelector('.custom-toggle')).toBeInTheDocument();
+  });
+
+  it('renders with custom id', () => {
+    render(<Toggle id="my-toggle" />);
+
+    const input = document.getElementById('my-toggle');
+
+    expect(input).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Add the first component-level unit tests for `packages/twenty-ui`, covering 4 core components (Checkbox, Toggle, Banner, Status) with 30+ test cases
- Tests cover rendering with various prop combinations, event handler invocation, disabled states, edge cases (indeterminate checkbox, unknown color fallback), and className forwarding
- Uses the existing Jest + `@testing-library/react` infrastructure that was previously only used for utility/hook tests

## Test plan

- [x] All 12 test suites pass (72 total tests, including 8 pre-existing)
- [x] Verified with `nx test twenty-ui`
- [ ] CI pipeline passes

Closes twentyhq/core-team-issues#2361