### PR TITLE
fix: preserve user-customized object/field names across locale changes

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/utils/__tests__/resolve-field-metadata-standard-override.util.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/utils/__tests__/resolve-field-metadata-standard-override.util.spec.ts
@@ -262,7 +262,7 @@ describe('resolveFieldMetadataStandardOverride', () => {
       ).toBe('overridden-icon');
     });
 
-    it('should not use direct override for non-SOURCE_LOCALE', () => {
+    it('should use direct override for non-SOURCE_LOCALE (preserves user customizations)', () => {
       const fieldMetadata = {
         label: 'Standard Label',
         description: 'Standard Description',
@@ -273,9 +273,6 @@ describe('resolveFieldMetadataStandardOverride', () => {
         },
       };
 
-      mockGenerateMessageId.mockReturnValue('generated-message-id');
-      mockI18n._.mockReturnValue('generated-message-id');
-
       const result = resolveFieldMetadataStandardOverride(
         fieldMetadata,
         'label',
@@ -283,7 +280,7 @@ describe('resolveFieldMetadataStandardOverride', () => {
         mockI18n,
       );
 
-      expect(result).toBe('Standard Label');
+      expect(result).toBe('Overridden Label');
     });
 
     it('should not use empty string override for SOURCE_LOCALE', () => {
@@ -386,14 +383,14 @@ describe('resolveFieldMetadataStandardOverride', () => {
   });
 
   describe('Priority order - Standard fields', () => {
-    it('should prioritize translation override over SOURCE_LOCALE override for non-SOURCE_LOCALE', () => {
+    it('should prioritize direct override over translation override for non-SOURCE_LOCALE (preserves user customizations)', () => {
       const fieldMetadata = {
         label: 'Standard Label',
         description: 'Standard Description',
         icon: 'default-icon',
         isCustom: false,
         standardOverrides: {
-          label: 'Source Override',
+          label: 'User Custom Name',
           translations: {
             'fr-FR': {
               label: 'Translation Override',
@@ -409,7 +406,7 @@ describe('resolveFieldMetadataStandardOverride', () => {
         mockI18n,
       );
 
-      expect(result).toBe('Translation Override');
+      expect(result).toBe('User Custom Name');
       expect(mockGenerateMessageId).not.toHaveBeenCalled();
       expect(mockI18n._).not.toHaveBeenCalled();
     });

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/utils/resolve-field-metadata-standard-override.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/utils/resolve-field-metadata-standard-override.util.ts
@@ -1,6 +1,6 @@
 import { type I18n } from '@lingui/core';
 import { isNonEmptyString } from '@sniptt/guards';
-import { type APP_LOCALES, SOURCE_LOCALE } from 'twenty-shared/translations';
+import { type APP_LOCALES } from 'twenty-shared/translations';
 import { isDefined } from 'twenty-shared/utils';
 
 import { generateMessageId } from 'src/engine/core-modules/i18n/utils/generateMessageId';
@@ -24,6 +24,14 @@ export const resolveFieldMetadataStandardOverride = (
     return fieldMetadata.standardOverrides.icon;
   }
 
+  // Direct standardOverrides (user customizations) take priority over
+  // locale-specific translations and auto i18n translations.
+  // This ensures that user-customized labels are preserved regardless
+  // of the active UI locale. See #18950.
+  if (isNonEmptyString(fieldMetadata.standardOverrides?.[labelKey])) {
+    return fieldMetadata.standardOverrides[labelKey] ?? '';
+  }
+
   if (
     isDefined(fieldMetadata.standardOverrides?.translations) &&
     isDefined(locale) &&
@@ -35,13 +43,6 @@ export const resolveFieldMetadataStandardOverride = (
     if (isDefined(translationValue)) {
       return translationValue;
     }
-  }
-
-  if (
-    locale === SOURCE_LOCALE &&
-    isNonEmptyString(fieldMetadata.standardOverrides?.[labelKey])
-  ) {
-    return fieldMetadata.standardOverrides[labelKey] ?? '';
   }
 
   const messageId = generateMessageId(fieldMetadata[labelKey] ?? '');

--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/utils/__tests__/resolve-object-metadata-standard-override.util.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/utils/__tests__/resolve-object-metadata-standard-override.util.spec.ts
@@ -506,7 +506,7 @@ describe('resolveObjectMetadataStandardOverride', () => {
   });
 
   describe('Priority order - Standard objects', () => {
-    it('should prioritize translation override over SOURCE_LOCALE override for non-SOURCE_LOCALE', () => {
+    it('should prioritize direct override over translation override for non-SOURCE_LOCALE (preserves user customizations)', () => {
       const objectMetadata = {
         labelSingular: 'Standard Label',
         labelPlural: 'Standard Labels',
@@ -514,8 +514,8 @@ describe('resolveObjectMetadataStandardOverride', () => {
         icon: 'default-icon',
         isCustom: false,
         standardOverrides: {
-          labelSingular: 'Source Override',
-          labelPlural: 'Source Overrides',
+          labelSingular: 'User Custom Name',
+          labelPlural: 'User Custom Names',
           translations: {
             'fr-FR': {
               labelSingular: 'Translation Override',
@@ -532,7 +532,7 @@ describe('resolveObjectMetadataStandardOverride', () => {
         mockI18n,
       );
 
-      expect(result).toBe('Translation Override');
+      expect(result).toBe('User Custom Name');
       expect(mockGenerateMessageId).not.toHaveBeenCalled();
       expect(mockI18n._).not.toHaveBeenCalled();
     });

--- a/packages/twenty-server/src/engine/metadata-modules/object-metadata/utils/resolve-object-metadata-standard-override.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/object-metadata/utils/resolve-object-metadata-standard-override.util.ts
@@ -34,6 +34,14 @@ export const resolveObjectMetadataStandardOverride = (
     return objectMetadata.standardOverrides[labelKey];
   }
 
+  // Direct standardOverrides (user customizations) take priority over
+  // locale-specific translations and auto i18n translations.
+  // This ensures that user-customized names (e.g., renaming "Company" to "ASTF")
+  // are preserved regardless of the active UI locale. See #18950.
+  if (isNonEmptyString(objectMetadata.standardOverrides?.[labelKey])) {
+    return objectMetadata.standardOverrides[labelKey] ?? '';
+  }
+
   if (
     isDefined(objectMetadata.standardOverrides?.translations) &&
     labelKey !== 'icon' &&
@@ -45,10 +53,6 @@ export const resolveObjectMetadataStandardOverride = (
     if (isDefined(translationValue)) {
       return translationValue;
     }
-  }
-
-  if (isNonEmptyString(objectMetadata.standardOverrides?.[labelKey])) {
-    return objectMetadata.standardOverrides[labelKey] ?? '';
   }
 
   const messageId = generateMessageId(objectMetadata[labelKey] ?? '');


### PR DESCRIPTION
## Summary
- Fixes user-customized Data Model object and field names being overwritten by i18n translations when the UI language is changed
- Changes the resolution priority so direct `standardOverrides` (user customizations) always take precedence over locale-specific translations and auto i18n translations
- For field metadata, removes the `SOURCE_LOCALE`-only restriction that was preventing customizations from being applied in non-English locales

## Root Cause
In `resolveObjectMetadataStandardOverride` and `resolveFieldMetadataStandardOverride`, the priority order was:
1. `standardOverrides.translations[locale]` (locale-specific translations)
2. `standardOverrides[labelKey]` (user customizations)
3. Auto i18n translation fallback

For field metadata, the direct override check (step 2) was additionally gated behind `locale === SOURCE_LOCALE`, meaning user customizations were completely ignored in non-English locales.

The fix reorders the priority to:
1. `standardOverrides[labelKey]` (user customizations) 
2. `standardOverrides.translations[locale]` (locale-specific translations)
3. Auto i18n translation fallback

This ensures that when a user renames "Company" to "ASTF", that name persists regardless of the active UI locale.

## Test plan
- [ ] Updated existing unit tests in `resolve-object-metadata-standard-override.util.spec.ts`
- [ ] Updated existing unit tests in `resolve-field-metadata-standard-override.util.spec.ts`
- [ ] Set UI language to English, rename a standard object (e.g., Company → ASTF), switch to German — ASTF should persist
- [ ] Set UI language to German, rename a standard object — the custom name should persist after refresh
- [ ] Verify that uncustomized standard objects still show translated labels in non-English locales

Fixes #18950