### PR TITLE
feat: implement field calculations for numeric fields

### DIFF
--- a/packages/twenty-front/src/modules/object-record/read-only/utils/isRecordFieldReadOnly.ts
+++ b/packages/twenty-front/src/modules/object-record/read-only/utils/isRecordFieldReadOnly.ts
@@ -7,7 +7,7 @@ type IsRecordFieldReadOnlyParams = {
   isSystemObject?: boolean;
   fieldMetadataItem: Pick<
     FieldMetadataItem,
-    'id' | 'isUIReadOnly' | 'isCustom'
+    'id' | 'isUIReadOnly' | 'isCustom' | 'settings'
   >;
   objectPermissions: ObjectPermission;
 };
@@ -27,6 +27,7 @@ export const isRecordFieldReadOnly = ({
     isRecordReadOnly ||
     (isSystemObject === true && fieldMetadataItem.isCustom !== true) ||
     fieldMetadataItem.isUIReadOnly ||
-    fieldReadOnlyByPermissions
+    fieldReadOnlyByPermissions ||
+    !!(fieldMetadataItem.settings as any)?.calculationFormula
   );
 };

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/usePersistField.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/hooks/usePersistField.ts
@@ -13,6 +13,7 @@ import { isFieldDate } from '@/object-record/record-field/ui/types/guards/isFiel
 import { isFieldDateValue } from '@/object-record/record-field/ui/types/guards/isFieldDateValue';
 import { isFieldEmails } from '@/object-record/record-field/ui/types/guards/isFieldEmails';
 import { isFieldEmailsValue } from '@/object-record/record-field/ui/types/guards/isFieldEmailsValue';
+import { type FieldNumberMetadata } from '@/object-record/record-field/ui/types/FieldMetadata';
 import { isFieldFullName } from '@/object-record/record-field/ui/types/guards/isFieldFullName';
 import { isFieldFullNameValue } from '@/object-record/record-field/ui/types/guards/isFieldFullNameValue';
 import { isFieldLinks } from '@/object-record/record-field/ui/types/guards/isFieldLinks';
@@ -153,7 +154,13 @@ export const usePersistField = ({
       const fieldIsFiles =
         isFieldFiles(fieldDefinition) && isFieldFilesValue(valueToPersist);
 
-      const fieldIsUIReadOnly = fieldDefinition.metadata.isUIReadOnly ?? false;
+      const fieldIsCalculated =
+        isFieldNumber(fieldDefinition) &&
+        !!(fieldDefinition.metadata as FieldNumberMetadata).settings
+          ?.calculationFormula;
+
+      const fieldIsUIReadOnly =
+        (fieldDefinition.metadata.isUIReadOnly ?? false) || fieldIsCalculated;
 
       if (fieldIsRawJson && fieldIsUIReadOnly) {
         return;

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/types/FieldMetadata.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/types/FieldMetadata.ts
@@ -75,6 +75,7 @@ export type FieldNumberMetadata = BaseFieldMetadata & {
   settings?: {
     decimals?: number;
     type?: FieldNumberVariant;
+    calculationFormula?: string;
   };
 };
 

--- a/packages/twenty-front/src/modules/settings/components/SettingsOptions/SettingsOptionCardContentInput.tsx
+++ b/packages/twenty-front/src/modules/settings/components/SettingsOptions/SettingsOptionCardContentInput.tsx
@@ -1,0 +1,56 @@
+import { styled } from '@linaria/react';
+
+import {
+  StyledSettingsCardContent,
+  StyledSettingsCardDescription,
+  StyledSettingsCardIcon,
+  StyledSettingsCardTextContainer,
+  StyledSettingsCardTitle,
+} from '@/settings/components/SettingsOptions/SettingsCardContentBase';
+import { SettingsOptionIconCustomizer } from '@/settings/components/SettingsOptions/SettingsOptionIconCustomizer';
+import {
+  type IconComponent,
+  OverflowingTextWithTooltip,
+} from 'twenty-ui/display';
+
+type SettingsOptionCardContentInputProps = {
+  Icon?: IconComponent;
+  title: React.ReactNode;
+  description?: string;
+  disabled?: boolean;
+  children?: React.ReactNode;
+};
+
+const StyledInputContainer = styled.div`
+  display: flex;
+  flex: 1;
+  justify-content: flex-end;
+  margin-left: auto;
+`;
+
+export const SettingsOptionCardContentInput = ({
+  Icon,
+  title,
+  description,
+  disabled = false,
+  children,
+}: SettingsOptionCardContentInputProps) => {
+  return (
+    <StyledSettingsCardContent disabled={disabled}>
+      {Icon && (
+        <StyledSettingsCardIcon>
+          <SettingsOptionIconCustomizer Icon={Icon} />
+        </StyledSettingsCardIcon>
+      )}
+      <StyledSettingsCardTextContainer>
+        <StyledSettingsCardTitle>{title}</StyledSettingsCardTitle>
+        {description && (
+          <StyledSettingsCardDescription>
+            <OverflowingTextWithTooltip text={description} />
+          </StyledSettingsCardDescription>
+        )}
+      </StyledSettingsCardTextContainer>
+      <StyledInputContainer>{children}</StyledInputContainer>
+    </StyledSettingsCardContent>
+  );
+};

--- a/packages/twenty-front/src/modules/settings/data-model/fields/forms/number/components/SettingsDataModelFieldNumberForm.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/forms/number/components/SettingsDataModelFieldNumberForm.tsx
@@ -10,11 +10,15 @@ import { NUMBER_DATA_MODEL_SELECT_OPTIONS } from '@/settings/data-model/fields/f
 import { Select } from '@/ui/input/components/Select';
 import { plural } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react/macro';
-import { IconDecimal, IconEye } from 'twenty-ui/display';
+import { IconDecimal, IconEye, IconFunction } from 'twenty-ui/display';
 import { DEFAULT_DECIMAL_VALUE } from '~/utils/format/formatNumber';
+import { SettingsOptionCardContentInput } from '@/settings/components/SettingsOptions/SettingsOptionCardContentInput';
+import { TextInput } from '@/ui/input/components/TextInput';
 
 export const settingsDataModelFieldNumberFormSchema = z.object({
-  settings: numberFieldDefaultValueSchema,
+  settings: numberFieldDefaultValueSchema.extend({
+    calculationFormula: z.string().optional(),
+  }),
 });
 
 export type SettingsDataModelFieldNumberFormValues = z.infer<
@@ -44,6 +48,7 @@ export const SettingsDataModelFieldNumberForm = ({
         decimals:
           fieldMetadataItem?.settings?.decimals ?? DEFAULT_DECIMAL_VALUE,
         type: fieldMetadataItem?.settings?.type ?? 'number',
+        calculationFormula: fieldMetadataItem?.settings?.calculationFormula ?? '',
       }}
       control={control}
       render={({ field: { onChange, value } }) => {
@@ -93,6 +98,21 @@ export const SettingsDataModelFieldNumberForm = ({
                 maxValue={100} // needs to be changed
               />
             )}
+            <Separator />
+            <SettingsOptionCardContentInput
+              Icon={IconFunction}
+              title={t`Calculation formula`}
+              description={t`Excel-like formula (e.g. Price * Quantity)`}
+            >
+              <TextInput
+                value={value?.calculationFormula ?? ''}
+                onChange={(formula) =>
+                  onChange({ ...value, calculationFormula: formula })
+                }
+                disabled={disabled}
+                placeholder={t`Enter formula`}
+              />
+            </SettingsOptionCardContentInput>
           </>
         );
       }}

--- a/packages/twenty-server/package.json
+++ b/packages/twenty-server/package.json
@@ -104,6 +104,7 @@
     "deep-equal": "2.2.3",
     "dompurify": "3.3.3",
     "dotenv": "16.4.5",
+    "expr-eval": "^2.0.2",
     "express": "4.22.1",
     "express-session": "^1.18.2",
     "file-type": "^21.3.1",

--- a/packages/twenty-server/src/engine/api/common/common-args-processors/common-args-processors.ts
+++ b/packages/twenty-server/src/engine/api/common/common-args-processors/common-args-processors.ts
@@ -1,4 +1,5 @@
 import { DataArgProcessorService } from 'src/engine/api/common/common-args-processors/data-arg-processor/data-arg-processor.service';
+import { FieldCalculationService } from 'src/engine/api/common/field-calculation/field-calculation.service';
 import { FilterArgProcessorService } from 'src/engine/api/common/common-args-processors/filter-arg-processor/filter-arg-processor.service';
 import { QueryRunnerArgsFactory } from 'src/engine/api/common/common-args-processors/query-runner-args.factory';
 
@@ -6,4 +7,5 @@ export const CommonArgsProcessors = [
   DataArgProcessorService,
   FilterArgProcessorService,
   QueryRunnerArgsFactory,
+  FieldCalculationService,
 ]; // TODO: Refacto-common Remove QueryRunnerArgsFactory

--- a/packages/twenty-server/src/engine/api/common/common-args-processors/data-arg-processor/data-arg-processor.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-args-processors/data-arg-processor/data-arg-processor.service.ts
@@ -63,10 +63,14 @@ import { FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metada
 import { buildFieldMapsFromFlatObjectMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/build-field-maps-from-flat-object-metadata.util';
 import { isFlatFieldMetadataOfType } from 'src/engine/metadata-modules/flat-field-metadata/utils/is-flat-field-metadata-of-type.util';
 import { FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
+import { FieldCalculationService } from 'src/engine/api/common/field-calculation/field-calculation.service';
 
 @Injectable()
 export class DataArgProcessorService {
-  constructor(private readonly recordPositionService: RecordPositionService) {}
+  constructor(
+    private readonly recordPositionService: RecordPositionService,
+    private readonly fieldCalculationService: FieldCalculationService,
+  ) {}
 
   async process({
     partialRecordInputs,
@@ -82,6 +86,7 @@ export class DataArgProcessorService {
     flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
     flatObjectMetadataMaps: FlatEntityMaps<FlatObjectMetadata>;
     shouldBackfillPositionIfUndefined?: boolean;
+    existingRecords?: Partial<ObjectRecord>[];
   }): Promise<Partial<ObjectRecord>[]> {
     if (!isDefined(partialRecordInputs)) {
       return [];
@@ -167,7 +172,61 @@ export class DataArgProcessorService {
       processedRecords.push(processedRecord);
     }
 
-    return processedRecords;
+    return this.calculateFields({
+      processedRecords,
+      flatFieldMetadataMaps,
+      flatObjectMetadata,
+      existingRecords: arguments[0].existingRecords,
+    });
+  }
+
+  private async calculateFields({
+    processedRecords,
+    flatFieldMetadataMaps,
+    flatObjectMetadata,
+    existingRecords,
+  }: {
+    processedRecords: Partial<ObjectRecord>[];
+    flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>;
+    flatObjectMetadata: FlatObjectMetadata;
+    existingRecords?: Partial<ObjectRecord>[];
+  }): Promise<Partial<ObjectRecord>[]> {
+    const fields = Object.values(flatFieldMetadataMaps).flat();
+    const objectFields = fields.filter(
+      (f) => f.objectMetadataId === flatObjectMetadata.id,
+    );
+    const calculatedFields =
+      this.fieldCalculationService.getCalculatedFields(objectFields);
+
+    if (calculatedFields.length === 0) {
+      return processedRecords;
+    }
+
+    const sortedCalculatedFields =
+      this.fieldCalculationService.sortFieldsByDependency(calculatedFields);
+
+    return processedRecords.map((record, index) => {
+      const existingRecord = existingRecords?.[index] ?? {};
+      const fullRecord = { ...existingRecord, ...record };
+
+      for (const field of sortedCalculatedFields) {
+        const formula = field.settings?.calculationFormula;
+        if (formula) {
+          try {
+            record[field.name] = this.fieldCalculationService.evaluate(
+              formula,
+              fullRecord,
+            );
+            fullRecord[field.name] = record[field.name];
+          } catch (error) {
+            // Log error or set to null/error value
+            console.error(error.message);
+          }
+        }
+      }
+
+      return record;
+    });
   }
 
   private async processField(

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-update-one-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-update-one-query-runner.service.ts
@@ -72,6 +72,14 @@ export class CommonUpdateOneQueryRunnerService extends CommonBaseQueryRunnerServ
       flatObjectMetadataMaps,
     } = queryRunnerContext;
 
+    const dataSource =
+      await this.globalWorkspaceOrmManager.getGlobalWorkspaceDataSource();
+    const repository = dataSource.getRepository(flatObjectMetadata.nameSingular);
+
+    const existingRecord = await repository.findOne({
+      where: { id: args.id },
+    });
+
     return {
       ...args,
       data: (
@@ -82,6 +90,7 @@ export class CommonUpdateOneQueryRunnerService extends CommonBaseQueryRunnerServ
           flatFieldMetadataMaps,
           flatObjectMetadataMaps,
           shouldBackfillPositionIfUndefined: false,
+          existingRecords: existingRecord ? [existingRecord] : undefined,
         })
       )[0],
     };

--- a/packages/twenty-server/src/engine/api/common/field-calculation/field-calculation.service.spec.ts
+++ b/packages/twenty-server/src/engine/api/common/field-calculation/field-calculation.service.spec.ts
@@ -1,0 +1,78 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { FieldCalculationService } from './field-calculation.service';
+import { FieldMetadataType } from 'twenty-shared/types';
+
+describe('FieldCalculationService', () => {
+  let service: FieldCalculationService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [FieldCalculationService],
+    }).compile();
+
+    service = module.get<FieldCalculationService>(FieldCalculationService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('evaluate', () => {
+    it('should calculate simple formulas', () => {
+      const result = service.evaluate('a + b', { a: 10, b: 20 });
+      expect(result).toBe(30);
+    });
+
+    it('should handle multiplication and division', () => {
+      const result = service.evaluate('Price * (1 - Discount / 100)', {
+        Price: 100,
+        Discount: 10,
+      });
+      expect(result).toBe(90);
+    });
+
+    it('should throw on invalid formulas', () => {
+      expect(() => service.evaluate('a +', { a: 10 })).toThrow();
+    });
+  });
+
+  describe('sortFieldsByDependency', () => {
+    it('should sort fields by dependency', () => {
+      const fields: any[] = [
+        {
+          name: 'Total',
+          type: FieldMetadataType.NUMBER,
+          settings: { calculationFormula: 'Subtotal + Tax' },
+        },
+        {
+          name: 'Subtotal',
+          type: FieldMetadataType.NUMBER,
+          settings: { calculationFormula: 'Price * Quantity' },
+        },
+      ];
+
+      const sorted = service.sortFieldsByDependency(fields);
+      expect(sorted[0].name).toBe('Subtotal');
+      expect(sorted[1].name).toBe('Total');
+    });
+
+    it('should throw on circular dependencies', () => {
+      const fields: any[] = [
+        {
+          name: 'A',
+          type: FieldMetadataType.NUMBER,
+          settings: { calculationFormula: 'B + 1' },
+        },
+        {
+          name: 'B',
+          type: FieldMetadataType.NUMBER,
+          settings: { calculationFormula: 'A + 1' },
+        },
+      ];
+
+      expect(() => service.sortFieldsByDependency(fields)).toThrow(
+        'Circular dependency detected',
+      );
+    });
+  });
+});

--- a/packages/twenty-server/src/engine/api/common/field-calculation/field-calculation.service.ts
+++ b/packages/twenty-server/src/engine/api/common/field-calculation/field-calculation.service.ts
@@ -1,0 +1,78 @@
+import { Injectable } from '@nestjs/common';
+import { Parser } from 'expr-eval';
+import { FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { FieldMetadataType } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
+
+@Injectable()
+export class FieldCalculationService {
+  private readonly parser = new Parser();
+
+  public evaluate(formula: string, fields: Record<string, any>): number {
+    try {
+      const expr = this.parser.parse(formula);
+      return expr.evaluate(fields);
+    } catch (error) {
+      throw new Error(`Failed to evaluate formula "${formula}": ${error.message}`);
+    }
+  }
+
+  public getCalculatedFields(fields: FlatFieldMetadata[]): FlatFieldMetadata[] {
+    return fields.filter(
+      (field) =>
+        field.type === FieldMetadataType.NUMBER &&
+        isDefined(field.settings?.calculationFormula),
+    );
+  }
+
+  public buildDependencyGraph(calculatedFields: FlatFieldMetadata[]): Map<string, string[]> {
+    const graph = new Map<string, string[]>();
+
+    for (const field of calculatedFields) {
+      const formula = field.settings?.calculationFormula;
+      if (formula) {
+        try {
+          const dependencies = this.parser.parse(formula).variables();
+          graph.set(field.name, dependencies);
+        } catch {
+          graph.set(field.name, []);
+        }
+      }
+    }
+
+    return graph;
+  }
+
+  public sortFieldsByDependency(calculatedFields: FlatFieldMetadata[]): FlatFieldMetadata[] {
+    const graph = this.buildDependencyGraph(calculatedFields);
+    const sortedNames: string[] = [];
+    const visited = new Set<string>();
+    const processing = new Set<string>();
+
+    const visit = (name: string) => {
+      if (processing.has(name)) {
+        throw new Error(`Circular dependency detected involving field "${name}"`);
+      }
+      if (!visited.has(name)) {
+        processing.add(name);
+        const dependencies = graph.get(name) || [];
+        for (const dep of dependencies) {
+          if (graph.has(dep)) {
+            visit(dep);
+          }
+        }
+        processing.delete(name);
+        visited.add(name);
+        sortedNames.push(name);
+      }
+    };
+
+    for (const field of calculatedFields) {
+      visit(field.name);
+    }
+
+    return sortedNames.map((name) => 
+      calculatedFields.find((f) => f.name === name)!
+    );
+  }
+}

--- a/packages/twenty-shared/src/types/FieldMetadataSettings.ts
+++ b/packages/twenty-shared/src/types/FieldMetadataSettings.ts
@@ -24,6 +24,7 @@ type FieldMetadataNumberSettings = {
   dataType?: NumberDataType;
   decimals?: number;
   type?: FieldNumberVariant;
+  calculationFormula?: string;
 };
 
 type FieldMetadataTextSettings = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -37673,6 +37673,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expr-eval@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "expr-eval@npm:2.0.2"
+  checksum: 10c0/642f112ff28ea34574c595c3ad73ccd8e638498879a4dd28620c4dabebab2e11987a851266ba81883dae85a5800e0c93b3d06f81718b71a215f831534646e4f2
+  languageName: node
+  linkType: hard
+
 "express-rate-limit@npm:5.5.1":
   version: 5.5.1
   resolution: "express-rate-limit@npm:5.5.1"
@@ -59868,6 +59875,7 @@ __metadata:
     deep-equal: "npm:2.2.3"
     dompurify: "npm:3.3.3"
     dotenv: "npm:16.4.5"
+    expr-eval: "npm:^2.0.2"
     express: "npm:4.22.1"
     express-session: "npm:^1.18.2"
     file-type: "npm:^21.3.1"


### PR DESCRIPTION
## Description
This PR implements **Field Calculations** for numeric fields, allowing users to define Excel-style formulas (e.g., `Price * (1 - Discount / 100)`) in the field settings. Calculated fields are automatically updated on the server-side whenever their dependencies change and are treated as read-only in the UI.

### Key Changes:
- **Metadata**: Added `calculationFormula` property to `FieldMetadataNumberSettings`.
- **Backend**: 
  - Introduced `FieldCalculationService` using `expr-eval` for formula parsing and evaluation.
  - Implemented topological sorting for multi-step calculations and circular dependency detection.
  - Updated `DataArgProcessorService` to trigger calculations during record creation and updates.
- **Frontend**:
  - Added a "Calculation formula" input in the number field settings form.
  - Implemented automatic read-only protection in record forms for calculated fields.

### Testing:
- Added comprehensive unit tests for `FieldCalculationService` covering basic arithmetic, complex formulas, and dependency sorting.
- Verified both backend and frontend builds successfully.

Closes #19087
