### PR TITLE
fix(imap): skip STATUS for Noselect folders to avoid mailbox errors

### DIFF
--- a/packages/twenty-server/src/modules/messaging/message-folder-manager/drivers/imap/services/imap-get-all-folders.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-folder-manager/drivers/imap/services/imap-get-all-folders.service.ts
@@ -94,7 +94,12 @@ export class ImapGetAllFoldersService implements MessageFolderDriver {
     }
 
     for (const mailbox of mailboxList) {
-      const uidValidity = await this.getUidValidity(client, mailbox);
+      // Skip STATUS for \Noselect folders (container-only folders with no messages).
+      // getUidValidity would fail with "Mailbox doesn't exist" on these.
+      const isNoselect = mailbox.flags?.has('\\Noselect');
+      const uidValidity = isNoselect
+        ? null
+        : await this.getUidValidity(client, mailbox);
       const externalId = uidValidity
         ? `${mailbox.path}:${uidValidity}`
         : mailbox.path;


### PR DESCRIPTION
Fix Issue #19090: IMAP sync fails with Mailbox does not exist for Noselect container folders.

When syncing IMAP folders, skip calling STATUS on folders with the Noselect flag (pure container/hierarchy folders with no message storage). STATUS fails on these with Mailbox does not exist because they have no cur/new/tmp Maildir directories.

Fix: check for Noselect before calling getUidValidity; if set, skip the call and use null uidValidity (still works for parentFolderId lookups).

Stack trace reference: ImapGetAllFoldersService.filterAndMapFolders calls getUidValidity on every mailbox including Noselect ones.