### PR TITLE
fix: Windows compatibility for build, start, and asset resolution

### DIFF
--- a/packages/twenty-sdk/vite.config.sdk.ts
+++ b/packages/twenty-sdk/vite.config.sdk.ts
@@ -3,11 +3,21 @@ import { type UserConfig, defineConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
 const isExternal = (id: string): boolean => {
-  if (id.startsWith('.') || id.startsWith('/') || id.startsWith('\0')) {
+  const normalized = id.replace(/\\/g, '/');
+
+  if (
+    normalized.startsWith('.') ||
+    normalized.startsWith('/') ||
+    normalized.startsWith('\0')
+  ) {
     return false;
   }
 
-  if (id.startsWith('src/') || id.startsWith('@/')) {
+  if (normalized.startsWith('src/') || normalized.startsWith('@/')) {
+    return false;
+  }
+
+  if (path.isAbsolute(id)) {
     return false;
   }
 

--- a/packages/twenty-server/project.json
+++ b/packages/twenty-server/project.json
@@ -13,7 +13,7 @@
         "commands": [
           "rimraf dist",
           "nest build --path ./tsconfig.build.json",
-          "mkdir -p dist/assets/twenty-client-sdk && cp ../twenty-client-sdk/package.json dist/assets/twenty-client-sdk/ && cp -r ../twenty-client-sdk/dist dist/assets/twenty-client-sdk/dist"
+          "node -e \"const fs=require('fs');const p=require('path');fs.mkdirSync(p.join('dist','assets','twenty-client-sdk','dist'),{recursive:true});fs.copyFileSync(p.join('..','twenty-client-sdk','package.json'),p.join('dist','assets','twenty-client-sdk','package.json'));const src=p.join('..','twenty-client-sdk','dist');const dst=p.join('dist','assets','twenty-client-sdk','dist');fs.cpSync(src,dst,{recursive:true});\""
         ]
       },
       "dependsOn": ["^build"]
@@ -54,7 +54,8 @@
       "dependsOn": ["^build"],
       "options": {
         "cwd": "packages/twenty-server",
-        "command": "rimraf dist && NODE_ENV=development nest start --watch"
+        "command": "rimraf dist && nest start --watch",
+        "env": { "NODE_ENV": "development" }
       }
     },
     "start:ci": {

--- a/packages/twenty-server/src/constants/assets-path.ts
+++ b/packages/twenty-server/src/constants/assets-path.ts
@@ -1,7 +1,8 @@
 import path from 'path';
 
 // If the code is built through the testing module, assets are not output to the dist/assets directory.
-const IS_BUILT_THROUGH_TESTING_MODULE = !__dirname.includes('/dist/');
+const IS_BUILT_THROUGH_TESTING_MODULE =
+  !__dirname.includes('/dist/') && !__dirname.includes('\\dist\\');
 
 export const ASSET_PATH = IS_BUILT_THROUGH_TESTING_MODULE
   ? path.resolve(__dirname, `../`)


### PR DESCRIPTION
## Motivation

Twenty's build toolchain uses Unix shell commands (`mkdir -p`, `cp -r`, inline `NODE_ENV=value`) and forward-slash-only path checks in several places. These all work fine on macOS and Linux but fail immediately on Windows, blocking Windows developers from building or running the server at all. Three small, targeted fixes make the core development loop — build, start, and sign-up — work on Windows without affecting existing Unix behavior.

## What changed

**Server build step** (`packages/twenty-server/project.json`)

The post-build command that copies `twenty-client-sdk` into `dist/assets` used `mkdir -p` and `cp -r`, which don't exist on Windows. Replaced with a Node.js one-liner using `fs.mkdirSync({recursive: true})`, `fs.copyFileSync`, and `fs.cpSync` — all cross-platform. The behavior is identical: create the target directory tree and copy the SDK package.json + dist folder into it.

**Server start target** (`packages/twenty-server/project.json`)

The `start` target set `NODE_ENV` with inline shell syntax (`NODE_ENV=development nest start`), which fails on Windows because CMD/PowerShell don't support that syntax. Moved `NODE_ENV` to the Nx executor's `env` option, which is cross-platform by design. This is the same pattern the project already uses elsewhere.

**SDK Vite build** (`packages/twenty-sdk/vite.config.sdk.ts`)

The `isExternal` function in the Rollup config checked whether module IDs started with `src/` or `@/` to keep entry modules in the bundle. On Windows, Rollup resolves entry module paths with backslashes (e.g., `C:\...\src\sdk\index.ts`), so the `src/` prefix check never matched. The entry module was incorrectly marked external, causing Rollup to throw "Entry module cannot be external." Fixed by normalizing backslashes to forward slashes before the prefix checks, and adding a `path.isAbsolute()` guard so fully-resolved Windows paths are never treated as external.

**Asset path resolution** (`packages/twenty-server/src/constants/assets-path.ts`)

The server determines whether it's running from compiled output or a test module by checking `__dirname.includes('/dist/')`. On Windows, `__dirname` uses backslashes (`C:\...\dist\...`), so this check never matched. The server thought it was in test mode and resolved asset paths to the wrong directory, causing sign-up to crash with `ENOENT` when reading seed data files. Added a parallel check for `\\dist\\`.

## Verification

All three fixes were verified on Windows 10 (19045) with Node 24.5.0:

- `npx nx build twenty-server` completes successfully (the `mkdir -p`/`cp -r` step was the only failure)
- `npx nx start twenty-server` boots, connects to PostgreSQL, and serves the API
- `npx nx start twenty-front` builds and loads in the browser
- Sign-up flow completes without ENOENT errors (asset path now resolves correctly)
- `npx nx build twenty-sdk` succeeds (no more "Entry module cannot be external")

All changes use standard Node.js APIs and platform-agnostic patterns. The behavior on macOS/Linux is unchanged — `'\\'.replace(/\\/g, '/')` is a no-op on paths that already use forward slashes, and `path.isAbsolute()` works correctly on all platforms.

## Risks and limitations

This PR fixes the three most critical blockers for Windows development. Other Windows-incompatible patterns remain in the codebase (`cp .env.example .env` in several packages, `nohup` in `start:ci-if-needed`, bash subshells in `lint:diff-with-main`, inline `NODE_ENV=` in `test:integration` and `start:debug`), but these are less critical — they affect CI-specific targets or can be worked around manually. This PR focuses on the build/start/run path that every developer needs.
