### PR TITLE
clean paddings in favorites section

### DIFF
--- a/packages/twenty-front/src/modules/navigation-menu-item/display/sections/favorites/components/FavoritesSection.tsx
+++ b/packages/twenty-front/src/modules/navigation-menu-item/display/sections/favorites/components/FavoritesSection.tsx
@@ -32,7 +32,6 @@ const StyledList = styled.div`
   display: flex;
   flex-direction: column;
   gap: ${themeCssVariables.betweenSiblingsGap};
-  padding-top: ${themeCssVariables.betweenSiblingsGap};
 `;
 
 const StyledListItemRow = styled.div`

--- a/packages/twenty-front/src/modules/navigation-menu-item/display/sections/favorites/components/FavoritesSectionDispatcher.tsx
+++ b/packages/twenty-front/src/modules/navigation-menu-item/display/sections/favorites/components/FavoritesSectionDispatcher.tsx
@@ -1,14 +1,28 @@
 import { isLayoutCustomizationModeEnabledState } from '@/layout-customization/states/isLayoutCustomizationModeEnabledState';
 import { NavigationSections } from '@/navigation-menu-item/common/constants/NavigationSections.constants';
+import { isNavigationMenuItemFolderCreatingState } from '@/navigation-menu-item/common/states/isNavigationMenuItemFolderCreatingState';
 import { NavigationMenuItemDndKitProvider } from '@/navigation-menu-item/display/dnd/providers/NavigationMenuItemDndKitProvider';
+import { useSortedNavigationMenuItems } from '@/navigation-menu-item/display/hooks/useSortedNavigationMenuItems';
 import { FavoritesSection } from '@/navigation-menu-item/display/sections/favorites/components/FavoritesSection';
 import { useAtomStateValue } from '@/ui/utilities/state/jotai/hooks/useAtomStateValue';
 import { AnimatedEaseInOut } from 'twenty-ui/utilities';
 
 export const FavoritesSectionDispatcher = () => {
+  const { navigationMenuItemsSorted } = useSortedNavigationMenuItems();
   const isLayoutCustomizationModeEnabled = useAtomStateValue(
     isLayoutCustomizationModeEnabledState,
   );
+  const isNavigationMenuItemFolderCreating = useAtomStateValue(
+    isNavigationMenuItemFolderCreatingState,
+  );
+
+  const hasFavoritesSectionContent =
+    isNavigationMenuItemFolderCreating ||
+    navigationMenuItemsSorted.some((item) => !item.folderId);
+
+  if (!hasFavoritesSectionContent) {
+    return null;
+  }
 
   return (
     <AnimatedEaseInOut isOpen={!isLayoutCustomizationModeEnabled} initial>


### PR DESCRIPTION
## Summary
- hide the Favorites section wrapper when there are no top-level favorites and no folder creation in progress
- remove the extra top padding from the Favorites list so the section title-to-content gap matches other navigation sections
- prevent the empty animated container from adding stray space in the navbar

## screens

Before
<img width="926" height="820" alt="CleanShot 2026-03-30 at 12 02 11@2x" src="https://github.com/user-attachments/assets/eac53f86-1108-42ac-986f-328327fbe947" />

<img width="1602" height="1168" alt="CleanShot 2026-03-30 at 12 02 29@2x" src="https://github.com/user-attachments/assets/6249c7f9-9ac5-46c8-a709-dfc1904b37c7" />

(arrows = paddings too big)

After
<img width="1270" height="1074" alt="CleanShot 2026-03-30 at 12 01 24@2x" src="https://github.com/user-attachments/assets/16e4155a-5591-4387-9675-f5c7be58ce32" />

