### PR TITLE
Fix export view

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-index/export/hooks/useRecordIndexLazyFetchRecords.ts
+++ b/packages/twenty-front/src/modules/object-record/record-index/export/hooks/useRecordIndexLazyFetchRecords.ts
@@ -92,7 +92,11 @@ export const useRecordIndexLazyFetchRecords = ({
     recordIndexId,
   );
 
-  const queryFilter = computeContextStoreFilters({
+  const isEmptySelection =
+    contextStoreTargetedRecordsRule.mode === 'selection' &&
+    contextStoreTargetedRecordsRule.selectedRecordIds.length === 0;
+
+  const contextStoreFilter = computeContextStoreFilters({
     contextStoreTargetedRecordsRule,
     contextStoreFilters,
     contextStoreFilterGroups,
@@ -100,6 +104,10 @@ export const useRecordIndexLazyFetchRecords = ({
     filterValueDependencies,
     contextStoreAnyFieldFilterValue,
   });
+
+  const queryFilter = isEmptySelection
+    ? findManyRecordsParams.filter
+    : contextStoreFilter;
 
   const visibleRecordFields = useAtomComponentSelectorValue(
     visibleRecordFieldsComponentSelector,


### PR DESCRIPTION
# PR Description

**Export view** command sent { id: { in: [] } } to the server, which rejects empty arrays. It now falls back to the view's filters instead when there is no selection, which is the intended behavior.

# Video QA

## Before

https://github.com/user-attachments/assets/3e6263f9-9c66-4f67-a81e-e0571652147d

## After

https://github.com/user-attachments/assets/977a366d-1936-457f-96a1-a5d4fb8ac98e
