### PR TITLE
Bugfix/nodemailer upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,6 +177,7 @@
   "name": "twenty",
   "packageManager": "yarn@4.13.0",
   "resolutions": {
+    "nodemailer": "8.0.4",
     "graphql": "16.8.1",
     "type-fest": "4.10.1",
     "typescript": "5.9.2",

--- a/package.json
+++ b/package.json
@@ -177,7 +177,6 @@
   "name": "twenty",
   "packageManager": "yarn@4.13.0",
   "resolutions": {
-    "nodemailer": "8.0.4",
     "graphql": "16.8.1",
     "type-fest": "4.10.1",
     "typescript": "5.9.2",

--- a/packages/twenty-server/package.json
+++ b/packages/twenty-server/package.json
@@ -150,7 +150,7 @@
     "ms": "2.1.3",
     "nest-commander": "^3.19.1",
     "node-ical": "^0.20.1",
-    "nodemailer": "^7.0.11",
+    "nodemailer": "8.0.4",
     "openapi-types": "12.1.3",
     "openid-client": "^5.7.0",
     "otplib": "^12.0.1",

--- a/packages/twenty-server/package.json
+++ b/packages/twenty-server/package.json
@@ -150,7 +150,7 @@
     "ms": "2.1.3",
     "nest-commander": "^3.19.1",
     "node-ical": "^0.20.1",
-    "nodemailer": "8.0.4",
+    "nodemailer": "^8.0.4",
     "openapi-types": "12.1.3",
     "openid-client": "^5.7.0",
     "otplib": "^12.0.1",

--- a/packages/twenty-server/src/engine/core-modules/application/application-package/constants/seed-dependencies/package.json
+++ b/packages/twenty-server/src/engine/core-modules/application/application-package/constants/seed-dependencies/package.json
@@ -37,7 +37,7 @@
     "lodash.pickby": "^4.6.0",
     "lodash.snakecase": "^4.1.1",
     "lodash.upperfirst": "^4.3.1",
-    "nodemailer": "^7.0.11",
+    "nodemailer": "^8.0.4",
     "sharp": "^0.34.5",
     "uuid": "^10.0.0",
     "winston": "^3.14.2"

--- a/packages/twenty-server/src/engine/core-modules/application/application-package/constants/seed-dependencies/yarn.lock
+++ b/packages/twenty-server/src/engine/core-modules/application/application-package/constants/seed-dependencies/yarn.lock
@@ -2195,10 +2195,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nodemailer@npm:^7.0.11":
-  version: 7.0.11
-  resolution: "nodemailer@npm:7.0.11"
-  checksum: 10c0/208f108fdb4c5dd0e3a2f013578d53dad505cf1b9c7a084f6d22fc9d6f3912daafb4a23793ca568ff848afc35f15f4eb24382d3f6f9fb8ede4a8410d4ca63618
+"nodemailer@npm:^8.0.4":
+  version: 8.0.4
+  resolution: "nodemailer@npm:8.0.4"
+  checksum: 10c0/5fb6fa72645b541c18b84b861de46f4740449e1d7c987b4d9ef715d815d613f93262225bc319e217df6215d6f123efadb9a412dcf937fe0a41cbecf279dfb2a0
   languageName: node
   linkType: hard
 
@@ -2510,7 +2510,7 @@ __metadata:
     lodash.pickby: "npm:^4.6.0"
     lodash.snakecase: "npm:^4.1.1"
     lodash.upperfirst: "npm:^4.3.1"
-    nodemailer: "npm:^7.0.11"
+    nodemailer: "npm:^8.0.4"
     sharp: "npm:^0.34.5"
     uuid: "npm:^10.0.0"
     winston: "npm:^3.14.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -41517,7 +41517,7 @@ __metadata:
     libbase64: "npm:1.3.0"
     libmime: "npm:5.3.7"
     libqp: "npm:2.1.1"
-    nodemailer: "npm:8.0.4"
+    nodemailer: "npm:7.0.11"
     pino: "npm:10.1.0"
     socks: "npm:2.8.7"
   checksum: 10c0/dc3bef59dc2c9a6c27938de4c53e69ed5734d91da8a79cd2552fe90942667d7456dec557f1f0f2c7f61dfc459d0495c8420d754e84fa17b6a88be9caaa553113
@@ -46480,7 +46480,7 @@ __metadata:
     iconv-lite: "npm:0.7.2"
     libmime: "npm:5.3.7"
     linkify-it: "npm:5.0.0"
-    nodemailer: "npm:8.0.4"
+    nodemailer: "npm:7.0.13"
     punycode.js: "npm:2.3.1"
     tlds: "npm:1.261.0"
   checksum: 10c0/da62c7cd977867da8be0dd1e6cf3b137821258e0d1e0976a00d3ec17bbd8a92bbefbccc7b0ec1dd33bc5ccd28dc5d51bbae723fac8ca05be843e88b7d579c751
@@ -49302,7 +49302,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nodemailer@npm:8.0.4":
+"nodemailer@npm:7.0.11":
+  version: 7.0.11
+  resolution: "nodemailer@npm:7.0.11"
+  checksum: 10c0/208f108fdb4c5dd0e3a2f013578d53dad505cf1b9c7a084f6d22fc9d6f3912daafb4a23793ca568ff848afc35f15f4eb24382d3f6f9fb8ede4a8410d4ca63618
+  languageName: node
+  linkType: hard
+
+"nodemailer@npm:7.0.13":
+  version: 7.0.13
+  resolution: "nodemailer@npm:7.0.13"
+  checksum: 10c0/b26aa5b9fa4a033bbc1e1c16ef75ee2a9c8641fd290c00a8361d6a251b3c1b8bad545a23efa627f59cb266340a448891ea8aa49d8a9307c767b8505219d95079
+  languageName: node
+  linkType: hard
+
+"nodemailer@npm:^8.0.4":
   version: 8.0.4
   resolution: "nodemailer@npm:8.0.4"
   checksum: 10c0/5fb6fa72645b541c18b84b861de46f4740449e1d7c987b4d9ef715d815d613f93262225bc319e217df6215d6f123efadb9a412dcf937fe0a41cbecf279dfb2a0
@@ -59907,7 +59921,7 @@ __metadata:
     ms: "npm:2.1.3"
     nest-commander: "npm:^3.19.1"
     node-ical: "npm:^0.20.1"
-    nodemailer: "npm:8.0.4"
+    nodemailer: "npm:^8.0.4"
     openapi-types: "npm:12.1.3"
     openid-client: "npm:^5.7.0"
     otplib: "npm:^12.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -41517,7 +41517,7 @@ __metadata:
     libbase64: "npm:1.3.0"
     libmime: "npm:5.3.7"
     libqp: "npm:2.1.1"
-    nodemailer: "npm:7.0.11"
+    nodemailer: "npm:8.0.4"
     pino: "npm:10.1.0"
     socks: "npm:2.8.7"
   checksum: 10c0/dc3bef59dc2c9a6c27938de4c53e69ed5734d91da8a79cd2552fe90942667d7456dec557f1f0f2c7f61dfc459d0495c8420d754e84fa17b6a88be9caaa553113
@@ -46480,7 +46480,7 @@ __metadata:
     iconv-lite: "npm:0.7.2"
     libmime: "npm:5.3.7"
     linkify-it: "npm:5.0.0"
-    nodemailer: "npm:7.0.13"
+    nodemailer: "npm:8.0.4"
     punycode.js: "npm:2.3.1"
     tlds: "npm:1.261.0"
   checksum: 10c0/da62c7cd977867da8be0dd1e6cf3b137821258e0d1e0976a00d3ec17bbd8a92bbefbccc7b0ec1dd33bc5ccd28dc5d51bbae723fac8ca05be843e88b7d579c751
@@ -49302,17 +49302,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nodemailer@npm:7.0.11":
-  version: 7.0.11
-  resolution: "nodemailer@npm:7.0.11"
-  checksum: 10c0/208f108fdb4c5dd0e3a2f013578d53dad505cf1b9c7a084f6d22fc9d6f3912daafb4a23793ca568ff848afc35f15f4eb24382d3f6f9fb8ede4a8410d4ca63618
-  languageName: node
-  linkType: hard
-
-"nodemailer@npm:7.0.13, nodemailer@npm:^7.0.11":
-  version: 7.0.13
-  resolution: "nodemailer@npm:7.0.13"
-  checksum: 10c0/b26aa5b9fa4a033bbc1e1c16ef75ee2a9c8641fd290c00a8361d6a251b3c1b8bad545a23efa627f59cb266340a448891ea8aa49d8a9307c767b8505219d95079
+"nodemailer@npm:8.0.4":
+  version: 8.0.4
+  resolution: "nodemailer@npm:8.0.4"
+  checksum: 10c0/5fb6fa72645b541c18b84b861de46f4740449e1d7c987b4d9ef715d815d613f93262225bc319e217df6215d6f123efadb9a412dcf937fe0a41cbecf279dfb2a0
   languageName: node
   linkType: hard
 
@@ -59914,7 +59907,7 @@ __metadata:
     ms: "npm:2.1.3"
     nest-commander: "npm:^3.19.1"
     node-ical: "npm:^0.20.1"
-    nodemailer: "npm:^7.0.11"
+    nodemailer: "npm:8.0.4"
     openapi-types: "npm:12.1.3"
     openid-client: "npm:^5.7.0"
     otplib: "npm:^12.0.1"


### PR DESCRIPTION
## Summary

This PR upgrades `nodemailer` to `8.0.4` to address
`GHSA-c7w3-x93f-qmm8` (SMTP command injection via unsanitized `envelope.size`).

## What Changed

- Updated `packages/twenty-server/package.json`
  - `nodemailer` from `^7.0.11` to `8.0.4`
- Updated seed dependencies:
  - `packages/twenty-server/src/engine/core-modules/application/application-package/constants/seed-dependencies/package.json`
  - `nodemailer` from `^7.0.11` to `^8.0.4`
- Updated lockfiles:
  - `yarn.lock`
  - `packages/twenty-server/src/engine/core-modules/application/application-package/constants/seed-dependencies/yarn.lock`
- Added root resolution to ensure transitive dependency graph also resolves to `nodemailer@8.0.4`:
  - `package.json` -> `"resolutions": { "nodemailer": "8.0.4", ... }`

## Security Context

The vulnerable 7.x range allowed CRLF injection through SMTP `MAIL FROM` `SIZE=...`
handling. Moving to `8.0.4` applies the upstream fix.

## Compatibility Notes

`nodemailer` 8 introduces an error code rename (`NoAuth` -> `ENOAUTH`).
No explicit usage of these literals was found in the touched server paths.

## Testing / Validation

- Dependency manifests and lockfiles now resolve `nodemailer` to `8.0.4`
  for `twenty-server` and seed dependencies.
- Local `yarn up` encountered Windows `EBUSY` temp-file locking issues in this environment,
  but committed manifest + lockfile state reflects the intended secure resolution.