### PR TITLE
Fix cropped calendar event name

### DIFF
--- a/packages/twenty-front/src/modules/activities/calendar/components/CalendarEventRow.tsx
+++ b/packages/twenty-front/src/modules/activities/calendar/components/CalendarEventRow.tsx
@@ -26,7 +26,7 @@ type CalendarEventRowProps = {
 const StyledContainer = styled.div<{ showTitle?: boolean }>`
   align-items: center;
   cursor: ${({ showTitle }) => (showTitle ? 'pointer' : 'not-allowed')};
-  display: inline-flex;
+  display: flex;
   gap: ${themeCssVariables.spacing[3]};
   height: ${themeCssVariables.spacing[6]};
   position: relative;


### PR DESCRIPTION
## Before
<img width="3024" height="1480" alt="CleanShot 2026-03-30 at 16 17 13 2@2x" src="https://github.com/user-attachments/assets/0ec774a6-5e28-440a-93d5-1e91ea9c4c5a" />

## After
<img width="3024" height="1482" alt="CleanShot 2026-03-30 at 16 16 56@2x" src="https://github.com/user-attachments/assets/0a15a6a4-be6f-4e22-b00b-548df9e73e2d" />
