### PR TITLE
Fix docker installer startup ordering and tag alignment

### DIFF
--- a/packages/twenty-docker/scripts/install.sh
+++ b/packages/twenty-docker/scripts/install.sh
@@ -43,9 +43,11 @@ function on_exit {
 }
 trap on_exit EXIT
 
-# Use environment variables VERSION and BRANCH, with defaults if not set
+# Use environment variables VERSION and BRANCH, with defaults if not set.
+# By default, keep the Docker image tag and GitHub tag aligned to avoid
+# fetching compose/env files from a different release than the image itself.
 version=${VERSION:-$(curl -s "https://hub.docker.com/v2/repositories/twentycrm/twenty/tags" | grep -o '"name":"[^"]*"' | grep -v 'latest' | cut -d'"' -f4 | sort -V | tail -n1)}
-branch=${BRANCH:-$(curl -s https://api.github.com/repos/twentyhq/twenty/tags | grep '"name":' | head -n 1 | cut -d '"' -f 4)}
+branch=${BRANCH:-$version}
 
 echo "🚀 Using docker version $version and Github branch $branch"
 
@@ -126,7 +128,10 @@ if [ "$answer" = "n" ]; then
   exit 0
 else
   echo "🐳 Starting Docker containers..."
-  docker compose up -d
+  # Start the server dependencies first. On newer Docker Compose versions,
+  # bringing up the worker at the same time can fail the whole command while
+  # the server is still performing first-boot migrations and upgrades.
+  docker compose up -d db redis server
   # Check if port is listening
   echo "Waiting for server to be healthy, it might take a few minutes while we initialize the database..."
   # Tail logs of the server until it's ready
@@ -136,6 +141,7 @@ else
     sleep 1
   done
   kill $pid
+  docker compose up -d worker
   echo ""
   echo "✅ Server is up and running"
 fi


### PR DESCRIPTION
## Summary
- keep the installer's Docker image tag and GitHub tag aligned by default
- start `db`, `redis`, and `server` first, then wait for server health before starting `worker`

## Why
On this host, the first boot spends several minutes in the server image entrypoint running database initialization, cache flushes, upgrades, and cron registration before `exec node dist/main`.

With current Docker Compose behavior, `docker compose up -d` for the whole stack fails early because `worker` depends on `server` being healthy. The installer exits before the server finishes first-boot initialization even though the server eventually becomes healthy if left running.

The installer also currently resolves the Docker image tag and GitHub branch independently, which can produce mismatched releases (for example `v1.19.1` image with `v1.19.13` compose/env files).

## Validation
- reproduced the install failure on a fresh self-hosted setup
- verified the server eventually reaches healthy state when started without the worker race
- syntax checked the updated installer with `bash -n packages/twenty-docker/scripts/install.sh`
