### PR TITLE
feat: add regex pattern validation to custom text fields

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/TextFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/TextFieldInput.tsx
@@ -10,6 +10,8 @@ import { FieldInputContainer } from '@/ui/field/input/components/FieldInputConta
 import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
 import { useSetAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useSetAtomComponentState';
+import { isNonEmptyString } from '@sniptt/guards';
+import { useLingui } from '@lingui/react/macro';
 import { useContext } from 'react';
 import { turnIntoUndefinedIfWhitespacesOnly } from '~/utils/string/turnIntoUndefinedIfWhitespacesOnly';
 
@@ -25,32 +27,43 @@ export const TextFieldInput = () => {
   );
 
   const { enqueueErrorSnackBar } = useSnackBar();
+  const { t } = useLingui();
 
-  const setIsFieldInError = useSetAtomComponentState(
+  const setRecordFieldInputIsFieldInError = useSetAtomComponentState(
     recordFieldInputIsFieldInErrorComponentState,
   );
 
-  const validationPattern = fieldDefinition.metadata.settings?.validationPattern;
-  const validationErrorMessage =
-    fieldDefinition.metadata.settings?.validationErrorMessage ??
-    'Value does not match the required format';
+  const validationPattern =
+    fieldDefinition.metadata.settings?.validationPattern;
+  const customValidationErrorMessage =
+    fieldDefinition.metadata.settings?.validationErrorMessage;
 
-  const validate = (text: string): boolean => {
-    const trimmed = text.trim();
+  const isTextValid = (text: string) => {
+    const trimmedText = text.trim();
 
-    if (validationPattern && trimmed) {
-      const regex = new RegExp(validationPattern);
-
-      if (!regex.test(trimmed)) {
-        enqueueErrorSnackBar({ message: validationErrorMessage });
-        return false;
-      }
+    if (!isNonEmptyString(validationPattern) || trimmedText === '') {
+      return true;
     }
-    return true;
+
+    return new RegExp(validationPattern).test(trimmedText);
+  };
+
+  const validateAndNotifyOnError = (text: string) => {
+    const isValid = isTextValid(text);
+
+    if (!isValid) {
+      enqueueErrorSnackBar({
+        message: isNonEmptyString(customValidationErrorMessage)
+          ? customValidationErrorMessage
+          : t`Value does not match the required format`,
+      });
+    }
+
+    return isValid;
   };
 
   const handleEnter = (newText: string) => {
-    if (validate(newText)) {
+    if (validateAndNotifyOnError(newText)) {
       onEnter?.({ newValue: newText.trim() });
     }
   };
@@ -63,7 +76,7 @@ export const TextFieldInput = () => {
     event: MouseEvent | TouchEvent,
     newText: string,
   ) => {
-    if (validate(newText)) {
+    if (validateAndNotifyOnError(newText)) {
       onClickOutside?.({
         newValue: newText.trim(),
         event,
@@ -72,25 +85,19 @@ export const TextFieldInput = () => {
   };
 
   const handleTab = (newText: string) => {
-    if (validate(newText)) {
+    if (validateAndNotifyOnError(newText)) {
       onTab?.({ newValue: newText.trim() });
     }
   };
 
   const handleShiftTab = (newText: string) => {
-    if (validate(newText)) {
+    if (validateAndNotifyOnError(newText)) {
       onShiftTab?.({ newValue: newText.trim() });
     }
   };
 
   const handleChange = (newText: string) => {
-    if (validationPattern && newText.trim()) {
-      const regex = new RegExp(validationPattern);
-
-      setIsFieldInError(!regex.test(newText.trim()));
-    } else {
-      setIsFieldInError(false);
-    }
+    setRecordFieldInputIsFieldInError(!isTextValid(newText));
     setDraftValue(turnIntoUndefinedIfWhitespacesOnly(newText));
   };
 

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/TextFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/TextFieldInput.tsx
@@ -5,8 +5,11 @@ import { useTextField } from '@/object-record/record-field/ui/meta-types/hooks/u
 import { FieldInputEventContext } from '@/object-record/record-field/ui/contexts/FieldInputEventContext';
 import { RecordFieldComponentInstanceContext } from '@/object-record/record-field/ui/states/contexts/RecordFieldComponentInstanceContext';
 
+import { recordFieldInputIsFieldInErrorComponentState } from '@/object-record/record-field/ui/states/recordFieldInputIsFieldInErrorComponentState';
 import { FieldInputContainer } from '@/ui/field/input/components/FieldInputContainer';
+import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 import { useAvailableComponentInstanceIdOrThrow } from '@/ui/utilities/state/component-state/hooks/useAvailableComponentInstanceIdOrThrow';
+import { useSetAtomComponentState } from '@/ui/utilities/state/jotai/hooks/useSetAtomComponentState';
 import { useContext } from 'react';
 import { turnIntoUndefinedIfWhitespacesOnly } from '~/utils/string/turnIntoUndefinedIfWhitespacesOnly';
 
@@ -21,8 +24,33 @@ export const TextFieldInput = () => {
     RecordFieldComponentInstanceContext,
   );
 
+  const { enqueueErrorSnackBar } = useSnackBar();
+
+  const setIsFieldInError = useSetAtomComponentState(
+    recordFieldInputIsFieldInErrorComponentState,
+  );
+
+  const validationPattern = fieldDefinition.metadata.settings?.validationPattern;
+  const validationErrorMessage =
+    fieldDefinition.metadata.settings?.validationErrorMessage ??
+    'Value does not match the required format';
+
+  const validate = (text: string): boolean => {
+    if (validationPattern && text) {
+      const regex = new RegExp(validationPattern);
+
+      if (!regex.test(text)) {
+        enqueueErrorSnackBar({ message: validationErrorMessage });
+        return false;
+      }
+    }
+    return true;
+  };
+
   const handleEnter = (newText: string) => {
-    onEnter?.({ newValue: newText.trim() });
+    if (validate(newText)) {
+      onEnter?.({ newValue: newText.trim() });
+    }
   };
 
   const handleEscape = (newText: string) => {
@@ -33,21 +61,34 @@ export const TextFieldInput = () => {
     event: MouseEvent | TouchEvent,
     newText: string,
   ) => {
-    onClickOutside?.({
-      newValue: newText.trim(),
-      event,
-    });
+    if (validate(newText)) {
+      onClickOutside?.({
+        newValue: newText.trim(),
+        event,
+      });
+    }
   };
 
   const handleTab = (newText: string) => {
-    onTab?.({ newValue: newText.trim() });
+    if (validate(newText)) {
+      onTab?.({ newValue: newText.trim() });
+    }
   };
 
   const handleShiftTab = (newText: string) => {
-    onShiftTab?.({ newValue: newText.trim() });
+    if (validate(newText)) {
+      onShiftTab?.({ newValue: newText.trim() });
+    }
   };
 
   const handleChange = (newText: string) => {
+    if (validationPattern && newText) {
+      const regex = new RegExp(validationPattern);
+
+      setIsFieldInError(!regex.test(newText));
+    } else {
+      setIsFieldInError(false);
+    }
     setDraftValue(turnIntoUndefinedIfWhitespacesOnly(newText));
   };
 

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/TextFieldInput.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/meta-types/input/components/TextFieldInput.tsx
@@ -36,10 +36,12 @@ export const TextFieldInput = () => {
     'Value does not match the required format';
 
   const validate = (text: string): boolean => {
-    if (validationPattern && text) {
+    const trimmed = text.trim();
+
+    if (validationPattern && trimmed) {
       const regex = new RegExp(validationPattern);
 
-      if (!regex.test(text)) {
+      if (!regex.test(trimmed)) {
         enqueueErrorSnackBar({ message: validationErrorMessage });
         return false;
       }
@@ -82,10 +84,10 @@ export const TextFieldInput = () => {
   };
 
   const handleChange = (newText: string) => {
-    if (validationPattern && newText) {
+    if (validationPattern && newText.trim()) {
       const regex = new RegExp(validationPattern);
 
-      setIsFieldInError(!regex.test(newText));
+      setIsFieldInError(!regex.test(newText.trim()));
     } else {
       setIsFieldInError(false);
     }

--- a/packages/twenty-front/src/modules/object-record/record-field/ui/types/FieldMetadata.ts
+++ b/packages/twenty-front/src/modules/object-record/record-field/ui/types/FieldMetadata.ts
@@ -31,6 +31,8 @@ export type FieldTextMetadata = BaseFieldMetadata & {
   placeHolder: string;
   settings?: {
     displayedMaxRows?: number;
+    validationPattern?: string;
+    validationErrorMessage?: string;
   };
 };
 

--- a/packages/twenty-front/src/modules/settings/data-model/fields/forms/components/text/SettingsDataModelFieldTextForm.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/forms/components/text/SettingsDataModelFieldTextForm.tsx
@@ -79,8 +79,11 @@ export const SettingsDataModelFieldTextForm = ({
   const { fieldMetadataItem: existingFieldMetadataItem } =
     useFieldMetadataItemById(existingFieldMetadataId);
 
-  const { control, formState: { errors } } = useFormContext<SettingsDataModelFieldTextFormValues>();
-  const patternError = (errors as any)?.settings?.validationPattern?.message as string | undefined;
+  const {
+    control,
+    formState: { errors },
+  } = useFormContext<SettingsDataModelFieldTextFormValues>();
+  const patternError = errors.settings?.validationPattern?.message;
 
   const [validationEnabled, setValidationEnabled] = useState(
     !!existingFieldMetadataItem?.settings?.validationPattern,

--- a/packages/twenty-front/src/modules/settings/data-model/fields/forms/components/text/SettingsDataModelFieldTextForm.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/forms/components/text/SettingsDataModelFieldTextForm.tsx
@@ -1,11 +1,25 @@
 import { Controller, useFormContext } from 'react-hook-form';
 
 import { useFieldMetadataItemById } from '@/object-metadata/hooks/useFieldMetadataItemById';
+import { Separator } from '@/settings/components/Separator';
+import {
+  StyledSettingsCardContent,
+  StyledSettingsCardDescription,
+  StyledSettingsCardIcon,
+  StyledSettingsCardTextContainer,
+  StyledSettingsCardTitle,
+} from '@/settings/components/SettingsOptions/SettingsCardContentBase';
 import { SettingsOptionCardContentSelect } from '@/settings/components/SettingsOptions/SettingsOptionCardContentSelect';
+import { SettingsOptionCardContentToggle } from '@/settings/components/SettingsOptions/SettingsOptionCardContentToggle';
+import { SettingsOptionIconCustomizer } from '@/settings/components/SettingsOptions/SettingsOptionIconCustomizer';
 import { TEXT_DATA_MODEL_SELECT_OPTIONS } from '@/settings/data-model/fields/forms/components/text/constants/TextDataModelSelectOptions';
+import { TextInput } from '@/ui/input/components/TextInput';
 import { Select } from '@/ui/input/components/Select';
 import { useLingui } from '@lingui/react/macro';
-import { IconTextWrap } from 'twenty-ui/display';
+import { styled } from '@linaria/react';
+import { useState } from 'react';
+import { IconCode, IconTextWrap } from 'twenty-ui/display';
+import { themeCssVariables } from 'twenty-ui/theme-constants';
 import { z } from 'zod';
 
 type SettingsDataModelFieldTextFormProps = {
@@ -13,9 +27,25 @@ type SettingsDataModelFieldTextFormProps = {
   existingFieldMetadataId: string;
 };
 
-const textFieldDefaultValueSchema = z.object({
-  displayedMaxRows: z.number().nullable(),
-});
+const textFieldDefaultValueSchema = z
+  .object({
+    displayedMaxRows: z.number().nullable(),
+    validationPattern: z.string().optional(),
+    validationErrorMessage: z.string().optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.validationPattern) {
+      try {
+        new RegExp(data.validationPattern);
+      } catch {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['validationPattern'],
+          message: 'Invalid regular expression',
+        });
+      }
+    }
+  });
 
 export const settingsDataModelFieldTextFormSchema = z.object({
   settings: textFieldDefaultValueSchema,
@@ -24,6 +54,21 @@ export const settingsDataModelFieldTextFormSchema = z.object({
 export type SettingsDataModelFieldTextFormValues = z.infer<
   typeof settingsDataModelFieldTextFormSchema
 >;
+
+const StyledValidationContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${themeCssVariables.spacing[2]};
+  margin-top: ${themeCssVariables.spacing[2]};
+  width: 100%;
+`;
+
+const StyledInputRow = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${themeCssVariables.spacing[1]};
+  width: 100%;
+`;
 
 export const SettingsDataModelFieldTextForm = ({
   disabled,
@@ -34,36 +79,119 @@ export const SettingsDataModelFieldTextForm = ({
   const { fieldMetadataItem: existingFieldMetadataItem } =
     useFieldMetadataItemById(existingFieldMetadataId);
 
-  const { control } = useFormContext<SettingsDataModelFieldTextFormValues>();
+  const { control, formState: { errors } } = useFormContext<SettingsDataModelFieldTextFormValues>();
+  const patternError = (errors as any)?.settings?.validationPattern?.message as string | undefined;
+
+  const [validationEnabled, setValidationEnabled] = useState(
+    !!existingFieldMetadataItem?.settings?.validationPattern,
+  );
+
   return (
     <Controller
       name="settings"
       defaultValue={{
         displayedMaxRows:
           existingFieldMetadataItem?.settings?.displayedMaxRows || 0,
+        validationPattern:
+          existingFieldMetadataItem?.settings?.validationPattern ?? '',
+        validationErrorMessage:
+          existingFieldMetadataItem?.settings?.validationErrorMessage ?? '',
       }}
       control={control}
       render={({ field: { onChange, value } }) => {
         const displayedMaxRows = value?.displayedMaxRows ?? 0;
+        const validationPattern = value?.validationPattern ?? '';
+        const validationErrorMessage = value?.validationErrorMessage ?? '';
+
+        const handleToggle = (enabled: boolean) => {
+          setValidationEnabled(enabled);
+          if (!enabled) {
+            onChange({
+              ...value,
+              validationPattern: '',
+              validationErrorMessage: '',
+            });
+          }
+        };
 
         return (
-          <SettingsOptionCardContentSelect
-            Icon={IconTextWrap}
-            title={t`Wrap on record pages`}
-            description={t`Display text on multiple lines`}
-          >
-            <Select<number>
-              dropdownId="text-wrap"
-              value={displayedMaxRows}
-              onChange={(value) => onChange({ displayedMaxRows: value })}
+          <>
+            <SettingsOptionCardContentSelect
+              Icon={IconTextWrap}
+              title={t`Wrap on record pages`}
+              description={t`Display text on multiple lines`}
+            >
+              <Select<number>
+                dropdownId="text-wrap"
+                value={displayedMaxRows}
+                onChange={(newValue) =>
+                  onChange({
+                    ...value,
+                    displayedMaxRows: newValue,
+                  })
+                }
+                disabled={disabled}
+                options={TEXT_DATA_MODEL_SELECT_OPTIONS.map((option) => ({
+                  ...option,
+                  label: t(option.label),
+                }))}
+                selectSizeVariant="small"
+              />
+            </SettingsOptionCardContentSelect>
+            <Separator />
+            <SettingsOptionCardContentToggle
+              Icon={IconCode}
+              title={t`Validation pattern`}
+              description={t`Require values to match a regex`}
+              checked={validationEnabled}
+              onChange={handleToggle}
               disabled={disabled}
-              options={TEXT_DATA_MODEL_SELECT_OPTIONS.map((option) => ({
-                ...option,
-                label: t(option.label),
-              }))}
-              selectSizeVariant="small"
             />
-          </SettingsOptionCardContentSelect>
+            {validationEnabled && (
+              <StyledSettingsCardContent alignItems="flex-start">
+                <StyledSettingsCardIcon>
+                  <SettingsOptionIconCustomizer Icon={IconCode} />
+                </StyledSettingsCardIcon>
+                <StyledSettingsCardTextContainer>
+                  <StyledSettingsCardTitle>{t`Pattern & error message`}</StyledSettingsCardTitle>
+                  <StyledSettingsCardDescription>
+                    {t`Regex the field value must match`}
+                  </StyledSettingsCardDescription>
+                  <StyledValidationContainer>
+                    <StyledInputRow>
+                      <TextInput
+                        value={validationPattern}
+                        onChange={(newValue) =>
+                          onChange({
+                            ...value,
+                            validationPattern: newValue,
+                          })
+                        }
+                        placeholder="^[A-Z0-9]+$"
+                        disabled={disabled}
+                        error={patternError}
+                        fullWidth
+                      />
+                    </StyledInputRow>
+                    <StyledInputRow>
+                      <TextInput
+                        value={validationErrorMessage}
+                        onChange={(newValue) =>
+                          onChange({
+                            ...value,
+                            validationErrorMessage: newValue,
+                          })
+                        }
+                        placeholder={t`Custom error message (optional)`}
+                        disabled={disabled}
+                        fullWidth
+                      />
+                    </StyledInputRow>
+                  </StyledValidationContainer>
+                </StyledSettingsCardTextContainer>
+              </StyledSettingsCardContent>
+            )}
+          </>
         );
       }}
     />

--- a/packages/twenty-server/src/engine/api/common/common-args-processors/data-arg-processor/data-arg-processor.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-args-processors/data-arg-processor/data-arg-processor.service.ts
@@ -189,7 +189,11 @@ export class DataArgProcessorService {
         return validateNumberFieldOrThrow(value, key);
       }
       case FieldMetadataType.TEXT: {
-        const validatedValue = validateTextFieldOrThrow(value, key);
+        const validatedValue = validateTextFieldOrThrow(
+          value,
+          key,
+          fieldMetadata.settings as FieldMetadataSettingsMapping[FieldMetadataType.TEXT],
+        );
 
         return transformTextField(validatedValue);
       }

--- a/packages/twenty-server/src/engine/api/common/common-args-processors/data-arg-processor/validator-utils/__tests__/validate-text-field-or-throw.util.spec.ts
+++ b/packages/twenty-server/src/engine/api/common/common-args-processors/data-arg-processor/validator-utils/__tests__/validate-text-field-or-throw.util.spec.ts
@@ -19,6 +19,38 @@ describe('validateTextFieldOrThrow', () => {
 
       expect(result).toBe('hello world');
     });
+
+    it('should return the string when it matches the validation pattern', () => {
+      const result = validateTextFieldOrThrow('ABC123', 'testField', {
+        validationPattern: '^[A-Z]{3}[0-9]{3}$',
+      });
+
+      expect(result).toBe('ABC123');
+    });
+
+    it('should not enforce the pattern when value is an empty string', () => {
+      const result = validateTextFieldOrThrow('', 'testField', {
+        validationPattern: '^[A-Z]{3}[0-9]{3}$',
+      });
+
+      expect(result).toBe('');
+    });
+
+    it('should not enforce the pattern when value is whitespace only', () => {
+      const result = validateTextFieldOrThrow('   ', 'testField', {
+        validationPattern: '^[A-Z]{3}[0-9]{3}$',
+      });
+
+      expect(result).toBe('   ');
+    });
+
+    it('should not enforce the pattern when validationPattern is an empty string', () => {
+      const result = validateTextFieldOrThrow('anything', 'testField', {
+        validationPattern: '',
+      });
+
+      expect(result).toBe('anything');
+    });
   });
 
   describe('invalid inputs', () => {
@@ -63,6 +95,16 @@ describe('validateTextFieldOrThrow', () => {
         validateTextFieldOrThrow({ key: 'value' }, 'testField'),
       ).toThrow(
         'Invalid string value { key: \'value\' } for text field "testField"',
+      );
+    });
+
+    it('should throw when value does not match the validation pattern', () => {
+      expect(() =>
+        validateTextFieldOrThrow('not-a-match', 'testField', {
+          validationPattern: '^[A-Z]{3}[0-9]{3}$',
+        }),
+      ).toThrow(
+        'Field "testField" value does not match pattern ^[A-Z]{3}[0-9]{3}$',
       );
     });
   });

--- a/packages/twenty-server/src/engine/api/common/common-args-processors/data-arg-processor/validator-utils/validate-text-field-or-throw.util.ts
+++ b/packages/twenty-server/src/engine/api/common/common-args-processors/data-arg-processor/validator-utils/validate-text-field-or-throw.util.ts
@@ -1,9 +1,11 @@
 import { inspect } from 'util';
 
 import { msg } from '@lingui/core/macro';
-import { isNull } from '@sniptt/guards';
-import { type FieldMetadataSettingsMapping } from 'twenty-shared/types';
-import { FieldMetadataType } from 'twenty-shared/types';
+import { isNonEmptyString, isNull } from '@sniptt/guards';
+import {
+  type FieldMetadataSettingsMapping,
+  type FieldMetadataType,
+} from 'twenty-shared/types';
 
 import {
   CommonQueryRunnerException,
@@ -26,23 +28,29 @@ export const validateTextFieldOrThrow = (
   }
 
   if (
-    typeof value === 'string' &&
-    value.trim() !== '' &&
-    settings?.validationPattern
+    typeof value !== 'string' ||
+    value.trim() === '' ||
+    !isNonEmptyString(settings?.validationPattern)
   ) {
-    const regex = new RegExp(settings.validationPattern);
+    return value;
+  }
 
-    if (!regex.test(value)) {
-      const errorMessage =
-        settings.validationErrorMessage ??
-        `Value does not match required pattern`;
+  const doesValueMatchPattern = new RegExp(settings.validationPattern).test(
+    value,
+  );
 
-      throw new CommonQueryRunnerException(
-        `Field "${fieldName}" value does not match pattern ${settings.validationPattern}`,
-        CommonQueryRunnerExceptionCode.INVALID_ARGS_DATA,
-        { userFriendlyMessage: msg`${errorMessage}` },
-      );
-    }
+  if (!doesValueMatchPattern) {
+    const customErrorMessage = settings.validationErrorMessage;
+
+    throw new CommonQueryRunnerException(
+      `Field "${fieldName}" value does not match pattern ${settings.validationPattern}`,
+      CommonQueryRunnerExceptionCode.INVALID_ARGS_DATA,
+      {
+        userFriendlyMessage: isNonEmptyString(customErrorMessage)
+          ? msg`${customErrorMessage}`
+          : msg`Value does not match the required format`,
+      },
+    );
   }
 
   return value;

--- a/packages/twenty-server/src/engine/api/common/common-args-processors/data-arg-processor/validator-utils/validate-text-field-or-throw.util.ts
+++ b/packages/twenty-server/src/engine/api/common/common-args-processors/data-arg-processor/validator-utils/validate-text-field-or-throw.util.ts
@@ -27,6 +27,7 @@ export const validateTextFieldOrThrow = (
 
   if (
     typeof value === 'string' &&
+    value.trim() !== '' &&
     settings?.validationPattern
   ) {
     const regex = new RegExp(settings.validationPattern);

--- a/packages/twenty-server/src/engine/api/common/common-args-processors/data-arg-processor/validator-utils/validate-text-field-or-throw.util.ts
+++ b/packages/twenty-server/src/engine/api/common/common-args-processors/data-arg-processor/validator-utils/validate-text-field-or-throw.util.ts
@@ -2,6 +2,8 @@ import { inspect } from 'util';
 
 import { msg } from '@lingui/core/macro';
 import { isNull } from '@sniptt/guards';
+import { type FieldMetadataSettingsMapping } from 'twenty-shared/types';
+import { FieldMetadataType } from 'twenty-shared/types';
 
 import {
   CommonQueryRunnerException,
@@ -11,6 +13,7 @@ import {
 export const validateTextFieldOrThrow = (
   value: unknown,
   fieldName: string,
+  settings?: FieldMetadataSettingsMapping[FieldMetadataType.TEXT] | null,
 ): string | null => {
   if (typeof value !== 'string' && !isNull(value)) {
     const inspectedValue = inspect(value);
@@ -20,6 +23,25 @@ export const validateTextFieldOrThrow = (
       CommonQueryRunnerExceptionCode.INVALID_ARGS_DATA,
       { userFriendlyMessage: msg`Invalid value: "${inspectedValue}"` },
     );
+  }
+
+  if (
+    typeof value === 'string' &&
+    settings?.validationPattern
+  ) {
+    const regex = new RegExp(settings.validationPattern);
+
+    if (!regex.test(value)) {
+      const errorMessage =
+        settings.validationErrorMessage ??
+        `Value does not match required pattern`;
+
+      throw new CommonQueryRunnerException(
+        `Field "${fieldName}" value does not match pattern ${settings.validationPattern}`,
+        CommonQueryRunnerExceptionCode.INVALID_ARGS_DATA,
+        { userFriendlyMessage: msg`${errorMessage}` },
+      );
+    }
   }
 
   return value;

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/services/flat-field-metadata-type-validator.service.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/services/flat-field-metadata-type-validator.service.ts
@@ -15,6 +15,7 @@ import { validateFilesFlatFieldMetadata } from 'src/engine/metadata-modules/flat
 import { validateMorphOrRelationFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-morph-or-relation-flat-field-metadata.util';
 import { validateMorphRelationFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-morph-relation-flat-field-metadata.util';
 import { validatePositionFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-position-flat-field-metadata.util';
+import { validateTextFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-text-flat-field-metadata.util';
 import { validateTsVectorFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-ts-vector-flat-field-metadata.util';
 
 const DEFAULT_NO_VALIDATION = (): FlatFieldMetadataValidationError[] => [];
@@ -72,7 +73,7 @@ export class FlatFieldMetadataTypeValidatorService {
       POSITION: validatePositionFlatFieldMetadata,
       RAW_JSON: DEFAULT_NO_VALIDATION,
       RICH_TEXT: DEFAULT_NO_VALIDATION,
-      TEXT: DEFAULT_NO_VALIDATION,
+      TEXT: validateTextFlatFieldMetadata,
       TS_VECTOR: validateTsVectorFlatFieldMetadata,
       UUID: DEFAULT_NO_VALIDATION,
       MORPH_RELATION: validateMorphRelationFlatFieldMetadata,

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/validators/utils/__tests__/validate-text-flat-field-metadata.util.spec.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/validators/utils/__tests__/validate-text-flat-field-metadata.util.spec.ts
@@ -1,0 +1,72 @@
+import { FieldMetadataType } from 'twenty-shared/types';
+
+import { type FlatFieldMetadataValidationError } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata-validation-error.type';
+import { validateTextFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-text-flat-field-metadata.util';
+import { type UniversalFlatFieldMetadata } from 'src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/universal-flat-field-metadata.type';
+
+const createFlatEntityToValidate = (
+  overrides: Partial<UniversalFlatFieldMetadata<FieldMetadataType.TEXT>> = {},
+): UniversalFlatFieldMetadata<FieldMetadataType.TEXT> =>
+  ({
+    type: FieldMetadataType.TEXT,
+    name: 'testTextField',
+    label: 'Test Text Field',
+    universalSettings: {},
+    isUnique: false,
+    ...overrides,
+  }) as UniversalFlatFieldMetadata<FieldMetadataType.TEXT>;
+
+const callValidator = (
+  flatEntityToValidate: UniversalFlatFieldMetadata<FieldMetadataType.TEXT>,
+) =>
+  validateTextFlatFieldMetadata({
+    flatEntityToValidate,
+  } as Parameters<typeof validateTextFlatFieldMetadata>[0]);
+
+const stripUserFriendlyMessage = (errors: FlatFieldMetadataValidationError[]) =>
+  errors.map(({ userFriendlyMessage: _, ...rest }) => rest);
+
+describe('validateTextFlatFieldMetadata', () => {
+  it('should return no errors when no validation pattern is set', () => {
+    const errors = callValidator(createFlatEntityToValidate());
+
+    expect(errors).toMatchInlineSnapshot('[]');
+  });
+
+  it('should return no errors for a valid validation pattern', () => {
+    const errors = callValidator(
+      createFlatEntityToValidate({
+        universalSettings: { validationPattern: '^[A-Z]{3}[0-9]{3}$' },
+      }),
+    );
+
+    expect(errors).toMatchInlineSnapshot('[]');
+  });
+
+  it('should return no errors when the validation pattern is an empty string', () => {
+    const errors = callValidator(
+      createFlatEntityToValidate({
+        universalSettings: { validationPattern: '' },
+      }),
+    );
+
+    expect(errors).toMatchInlineSnapshot('[]');
+  });
+
+  it('should return an error when the validation pattern is not a valid regular expression', () => {
+    const errors = callValidator(
+      createFlatEntityToValidate({
+        universalSettings: { validationPattern: '[unclosed' },
+      }),
+    );
+
+    expect(stripUserFriendlyMessage(errors)).toMatchInlineSnapshot(`
+[
+  {
+    "code": "INVALID_FIELD_INPUT",
+    "message": "validationPattern is not a valid regular expression: [unclosed",
+  },
+]
+`);
+  });
+});

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-text-flat-field-metadata.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-text-flat-field-metadata.util.ts
@@ -1,4 +1,5 @@
 import { msg } from '@lingui/core/macro';
+import { isNonEmptyString } from '@sniptt/guards';
 import { type FieldMetadataType } from 'twenty-shared/types';
 
 import { FieldMetadataExceptionCode } from 'src/engine/metadata-modules/field-metadata/field-metadata.exception';
@@ -10,10 +11,9 @@ export const validateTextFlatFieldMetadata = ({
 }: FlatFieldMetadataTypeValidationArgs<FieldMetadataType.TEXT>): FlatFieldMetadataValidationError[] => {
   const errors: FlatFieldMetadataValidationError[] = [];
 
-  const pattern =
-    flatEntityToValidate?.universalSettings?.validationPattern;
+  const pattern = flatEntityToValidate?.universalSettings?.validationPattern;
 
-  if (pattern != null) {
+  if (isNonEmptyString(pattern)) {
     try {
       new RegExp(pattern);
     } catch {

--- a/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-text-flat-field-metadata.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/flat-field-metadata/validators/utils/validate-text-flat-field-metadata.util.ts
@@ -1,0 +1,29 @@
+import { msg } from '@lingui/core/macro';
+import { type FieldMetadataType } from 'twenty-shared/types';
+
+import { FieldMetadataExceptionCode } from 'src/engine/metadata-modules/field-metadata/field-metadata.exception';
+import { type FlatFieldMetadataTypeValidationArgs } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata-type-validator.type';
+import { type FlatFieldMetadataValidationError } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata-validation-error.type';
+
+export const validateTextFlatFieldMetadata = ({
+  flatEntityToValidate,
+}: FlatFieldMetadataTypeValidationArgs<FieldMetadataType.TEXT>): FlatFieldMetadataValidationError[] => {
+  const errors: FlatFieldMetadataValidationError[] = [];
+
+  const pattern =
+    flatEntityToValidate?.universalSettings?.validationPattern;
+
+  if (pattern != null) {
+    try {
+      new RegExp(pattern);
+    } catch {
+      errors.push({
+        code: FieldMetadataExceptionCode.INVALID_FIELD_INPUT,
+        message: `validationPattern is not a valid regular expression: ${pattern}`,
+        userFriendlyMessage: msg`The validation pattern is not a valid regular expression`,
+      });
+    }
+  }
+
+  return errors;
+};

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/__tests__/universal-flat-field-metadata.test-type.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-migration/universal-flat-entity/types/__tests__/universal-flat-field-metadata.test-type.ts
@@ -127,6 +127,8 @@ type SettingsExpectedResult =
     }
   | {
       displayedMaxRows?: number | undefined;
+      validationPattern?: string | undefined;
+      validationErrorMessage?: string | undefined;
       __JsonbPropertyBrand__?: undefined;
     }
   | null;

--- a/packages/twenty-shared/src/types/FieldMetadataSettings.ts
+++ b/packages/twenty-shared/src/types/FieldMetadataSettings.ts
@@ -28,6 +28,8 @@ type FieldMetadataNumberSettings = {
 
 type FieldMetadataTextSettings = {
   displayedMaxRows?: number;
+  validationPattern?: string;
+  validationErrorMessage?: string;
 };
 
 type FieldMetadataDateSettings = {


### PR DESCRIPTION
Closes #18655

## Summary

Implements regex pattern validation for custom `TEXT` fields, as requested in #18655. Admins can configure a pattern and optional error message per field; values are validated on both the client and server.

## Changes

**`twenty-shared`**
- `FieldMetadataSettings.ts` — added `validationPattern` and `validationErrorMessage` to `FieldMetadataTextSettings`

**`twenty-server`**
- `validate-text-flat-field-metadata.util.ts` *(new)* — validates the regex is syntactically valid when a field is created/updated
- `flat-field-metadata-type-validator.service.ts` — wired `TEXT` to the new validator
- `validate-text-field-or-throw.util.ts` — enforces the pattern when a record value is saved
- `data-arg-processor.service.ts` — passes `settings` to the text validator for the `TEXT` case

**`twenty-front`**
- `FieldMetadata.ts` — extended `FieldTextMetadata` with `validationPattern` and `validationErrorMessage`
- `SettingsDataModelFieldTextForm.tsx` — toggle in the "Customize" card that reveals pattern + error message inputs; Zod validates regex syntax client-side before saving the field
- `TextFieldInput.tsx` — red border live feedback via `recordFieldInputIsFieldInErrorComponentState` + snackbar error that blocks save on invalid values

## How it works

**Configuring the pattern (admin)**

In Settings → Data model → [Object] → [Text field], a new "Validation pattern" toggle appears in the Customize card. Enabling it reveals:
1. A regex input (e.g. `^BE0[0-9]{9}$`) with inline syntax error if the expression is invalid
2. An optional custom error message shown to users (e.g. `Not a valid Belgian VAT number`)

**Runtime validation (end user)**

- Typing an invalid value shows a red border on the cell (same as URL/phone/email fields)
- Pressing Enter, Tab, or clicking outside blocks the save and shows a snackbar with the custom error message
- Server-side validation also rejects invalid values via the GraphQL API

## Test plan

- [ ] Create a custom text field, enable the validation toggle, set pattern `^BE0[0-9]{9}$` and error message `Not a valid Belgian VAT number`
- [ ] On a record, click the field — type an invalid value (`kkk`) — red border should appear
- [ ] Press Enter — save is blocked, snackbar shows the custom error message
- [ ] Type a valid value (`BE0123456789`) — border clears, Enter saves successfully
- [ ] Disable the toggle — pattern is cleared, field accepts any value again
- [ ] Via GraphQL mutation, attempt to set an invalid value — server should return the custom error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)