### PR TITLE
Fix workspace invitation email matching

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/workspace-invitation/services/workspace-invitation.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace-invitation/services/workspace-invitation.service.spec.ts
@@ -168,6 +168,30 @@ describe('WorkspaceInvitationService', () => {
       ).resolves.not.toThrow();
     });
 
+    it('should normalize the invitation email before saving it', async () => {
+      const email = 'Test@Example.com';
+      const workspace = { id: 'workspace-id' } as WorkspaceEntity;
+
+      jest.spyOn(appTokenRepository, 'createQueryBuilder').mockReturnValue({
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(null),
+      } as any);
+
+      jest.spyOn(userWorkspaceRepository, 'exists').mockResolvedValue(false);
+      const generateInvitationTokenSpy = jest
+        .spyOn(service, 'generateInvitationToken')
+        .mockResolvedValue({} as AppTokenEntity);
+
+      await service.createWorkspaceInvitation(email, workspace);
+
+      expect(generateInvitationTokenSpy).toHaveBeenCalledWith(
+        workspace.id,
+        'test@example.com',
+        undefined,
+      );
+    });
+
     it('should throw an exception if invitation already exists', async () => {
       const email = 'test@example.com';
       const workspace = { id: 'workspace-id' } as WorkspaceEntity;
@@ -181,6 +205,28 @@ describe('WorkspaceInvitationService', () => {
       await expect(
         service.createWorkspaceInvitation(email, workspace),
       ).rejects.toThrow(WorkspaceInvitationException);
+    });
+  });
+
+  describe('validatePersonalInvitation', () => {
+    it('should accept mixed-case invitation emails', async () => {
+      const workspace = { id: 'workspace-id' } as WorkspaceEntity;
+
+      jest.spyOn(appTokenRepository, 'findOne').mockResolvedValue({
+        context: { email: 'Dj@NextGen-CR.com' },
+        expiresAt: new Date(Date.now() + 60_000),
+        workspace,
+      } as AppTokenEntity);
+
+      await expect(
+        service.validatePersonalInvitation({
+          workspacePersonalInviteToken: 'token-value',
+          email: 'dj@nextgen-cr.com',
+        }),
+      ).resolves.toEqual({
+        isValid: true,
+        workspace,
+      });
     });
   });
 

--- a/packages/twenty-server/src/engine/core-modules/workspace-invitation/services/workspace-invitation.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/workspace-invitation/services/workspace-invitation.service.ts
@@ -41,6 +41,10 @@ import { CustomException } from 'src/utils/custom-exception';
 
 @Injectable()
 export class WorkspaceInvitationService {
+  private normalizeInvitationEmail(email: string) {
+    return email.trim().toLowerCase();
+  }
+
   constructor(
     @InjectRepository(AppTokenEntity)
     private readonly appTokenRepository: Repository<AppTokenEntity>,
@@ -76,7 +80,15 @@ export class WorkspaceInvitationService {
         throw new Error('Invalid invitation token');
       }
 
-      if (!appToken.context?.email || appToken.context?.email !== email) {
+      const normalizedEmail = this.normalizeInvitationEmail(email);
+      const normalizedInvitationEmail = appToken.context?.email
+        ? this.normalizeInvitationEmail(appToken.context.email)
+        : undefined;
+
+      if (
+        !normalizedInvitationEmail ||
+        normalizedInvitationEmail !== normalizedEmail
+      ) {
         throw new Error('Email does not match the invitation');
       }
 
@@ -94,13 +106,17 @@ export class WorkspaceInvitationService {
   }
 
   async findInvitationsByEmail(email: string) {
+    const normalizedEmail = this.normalizeInvitationEmail(email);
+
     return await this.appTokenRepository
       .createQueryBuilder('appToken')
       .innerJoinAndSelect('appToken.workspace', 'workspace')
       .where('"appToken".type = :type', {
         type: AppTokenType.InvitationToken,
       })
-      .andWhere('"appToken".context->>\'email\' = :email', { email })
+      .andWhere('LOWER("appToken".context->>\'email\') = :email', {
+        email: normalizedEmail,
+      })
       .andWhere('appToken.deletedAt IS NULL')
       .andWhere('appToken.expiresAt > :now', {
         now: new Date(),
@@ -109,6 +125,8 @@ export class WorkspaceInvitationService {
   }
 
   async getOneWorkspaceInvitation(workspaceId: string, email: string) {
+    const normalizedEmail = this.normalizeInvitationEmail(email);
+
     return await this.appTokenRepository
       .createQueryBuilder('appToken')
       .where('"appToken"."workspaceId" = :workspaceId', {
@@ -117,7 +135,9 @@ export class WorkspaceInvitationService {
       .andWhere('"appToken".type = :type', {
         type: AppTokenType.InvitationToken,
       })
-      .andWhere('"appToken".context->>\'email\' = :email', { email })
+      .andWhere('LOWER("appToken".context->>\'email\') = :email', {
+        email: normalizedEmail,
+      })
       .getOne();
   }
 
@@ -160,9 +180,11 @@ export class WorkspaceInvitationService {
     workspace: WorkspaceEntity,
     roleId?: string,
   ) {
+    const normalizedEmail = this.normalizeInvitationEmail(email);
+
     const maybeWorkspaceInvitation = await this.getOneWorkspaceInvitation(
       workspace.id,
-      email.toLowerCase(),
+      normalizedEmail,
     );
 
     if (maybeWorkspaceInvitation) {
@@ -191,7 +213,7 @@ export class WorkspaceInvitationService {
       );
     }
 
-    return this.generateInvitationToken(workspace.id, email, roleId);
+    return this.generateInvitationToken(workspace.id, normalizedEmail, roleId);
   }
 
   async deleteWorkspaceInvitation(appTokenId: string, workspaceId: string) {
@@ -402,6 +424,7 @@ export class WorkspaceInvitationService {
     email: string,
     roleId?: string,
   ) {
+    const normalizedEmail = this.normalizeInvitationEmail(email);
     const expiresIn = this.twentyConfigService.get(
       'INVITATION_TOKEN_EXPIRES_IN',
     );
@@ -421,7 +444,7 @@ export class WorkspaceInvitationService {
       type: AppTokenType.InvitationToken,
       value: crypto.randomBytes(32).toString('hex'),
       context: {
-        email,
+        email: normalizedEmail,
         ...(isDefined(roleId) ? { roleId } : {}),
       },
     });


### PR DESCRIPTION
## Summary
- normalize workspace invitation emails before storing them in invitation token context
- compare invitation emails case-insensitively during validation and lookup so mixed-case invites still resolve correctly
- add regression coverage for normalized storage and mixed-case invite acceptance

## Test plan
- [x] Reviewed diff against `origin/main`
- [ ] `npx nx test twenty-server --runInBand --testPathPattern=workspace-invitation.service.spec.ts` currently fails before this spec runs because `twenty-emails:build` cannot resolve `expr-eval-fork` from `twenty-shared/dist/utils.mjs`
- [ ] `npx jest packages/twenty-server/src/engine/core-modules/workspace-invitation/services/workspace-invitation.service.spec.ts --config packages/twenty-server/jest.config.mjs --runInBand` currently fails for the same unrelated `expr-eval-fork` module-resolution issue

Made with [Cursor](https://cursor.com)