### PR TITLE
fix: clear navigation stack immediately in goBackFromSidePanel

### DIFF
--- a/packages/twenty-front/src/modules/side-panel/hooks/__tests__/useSidePanelHistory.test.tsx
+++ b/packages/twenty-front/src/modules/side-panel/hooks/__tests__/useSidePanelHistory.test.tsx
@@ -100,10 +100,16 @@ describe('useSidePanelHistory', () => {
 
     act(() => {
       result.current.commandMenuHistory.goBackFromSidePanel();
-      result.current.sidePanelCloseAnimationCompleteCleanup.sidePanelCloseAnimationCompleteCleanup();
     });
 
+    // Stack must be cleared immediately after goBackFromSidePanel(), without
+    // waiting for the close animation cleanup — otherwise stale entries block
+    // reopening the same record via openRecordInSidePanel.
     expect(jotaiStore.get(sidePanelNavigationStackState.atom)).toEqual([]);
+
+    act(() => {
+      result.current.sidePanelCloseAnimationCompleteCleanup.sidePanelCloseAnimationCompleteCleanup();
+    });
     expect(jotaiStore.get(sidePanelPageState.atom)).toBe(
       SidePanelPages.CommandMenuDisplay,
     );

--- a/packages/twenty-front/src/modules/side-panel/hooks/__tests__/useSidePanelHistory.test.tsx
+++ b/packages/twenty-front/src/modules/side-panel/hooks/__tests__/useSidePanelHistory.test.tsx
@@ -102,9 +102,6 @@ describe('useSidePanelHistory', () => {
       result.current.commandMenuHistory.goBackFromSidePanel();
     });
 
-    // Stack must be cleared immediately after goBackFromSidePanel(), without
-    // waiting for the close animation cleanup — otherwise stale entries block
-    // reopening the same record via openRecordInSidePanel.
     expect(jotaiStore.get(sidePanelNavigationStackState.atom)).toEqual([]);
 
     act(() => {
@@ -146,9 +143,6 @@ describe('useSidePanelHistory', () => {
       result.current.commandMenu.closeSidePanelMenu();
     });
 
-    // Stack must be cleared immediately after closeSidePanelMenu(), without
-    // waiting for the close animation cleanup — otherwise stale entries block
-    // reopening the same record via openRecordInSidePanel.
     expect(jotaiStore.get(sidePanelNavigationStackState.atom)).toEqual([]);
   });
 

--- a/packages/twenty-front/src/modules/side-panel/hooks/__tests__/useSidePanelHistory.test.tsx
+++ b/packages/twenty-front/src/modules/side-panel/hooks/__tests__/useSidePanelHistory.test.tsx
@@ -121,6 +121,37 @@ describe('useSidePanelHistory', () => {
     expect(jotaiStore.get(isSidePanelOpenedState.atom)).toBe(false);
   });
 
+  it('should clear navigation stack immediately when closeSidePanelMenu is called', () => {
+    const { result } = renderHooks();
+
+    act(() => {
+      result.current.commandMenu.navigateSidePanelMenu({
+        page: SidePanelPages.ViewRecord,
+        pageTitle: 'Company',
+        pageIcon: IconList,
+        pageId: '1',
+      });
+    });
+
+    expect(jotaiStore.get(sidePanelNavigationStackState.atom)).toEqual([
+      {
+        page: SidePanelPages.ViewRecord,
+        pageTitle: 'Company',
+        pageIcon: IconList,
+        pageId: '1',
+      },
+    ]);
+
+    act(() => {
+      result.current.commandMenu.closeSidePanelMenu();
+    });
+
+    // Stack must be cleared immediately after closeSidePanelMenu(), without
+    // waiting for the close animation cleanup — otherwise stale entries block
+    // reopening the same record via openRecordInSidePanel.
+    expect(jotaiStore.get(sidePanelNavigationStackState.atom)).toEqual([]);
+  });
+
   it('should navigate to a page in history', () => {
     const { result } = renderHooks();
 

--- a/packages/twenty-front/src/modules/side-panel/hooks/useSidePanelHistory.ts
+++ b/packages/twenty-front/src/modules/side-panel/hooks/useSidePanelHistory.ts
@@ -67,6 +67,8 @@ export const useSidePanelHistory = () => {
     const newNavigationStack = currentNavigationStack.slice(0, -1);
     const lastNavigationStackItem = newNavigationStack.at(-1);
 
+    store.set(sidePanelNavigationStackState.atom, newNavigationStack);
+
     if (!isDefined(lastNavigationStackItem)) {
       closeSidePanelMenu();
       return;
@@ -79,8 +81,6 @@ export const useSidePanelHistory = () => {
       Icon: lastNavigationStackItem.pageIcon,
       instanceId: lastNavigationStackItem.pageId,
     });
-
-    store.set(sidePanelNavigationStackState.atom, newNavigationStack);
 
     store.set(hasUserSelectedSidePanelListItemState.atom, false);
   }, [cleanupCurrentPage, closeSidePanelMenu, store]);

--- a/packages/twenty-front/src/modules/side-panel/hooks/useSidePanelMenu.ts
+++ b/packages/twenty-front/src/modules/side-panel/hooks/useSidePanelMenu.ts
@@ -3,6 +3,7 @@ import { selectedNavigationMenuItemIdInEditModeState } from '@/navigation-menu-i
 import { SIDE_PANEL_FOCUS_ID } from '@/side-panel/constants/SidePanelFocusId';
 import { useNavigateSidePanel } from '@/side-panel/hooks/useNavigateSidePanel';
 import { isSidePanelClosingState } from '@/side-panel/states/isSidePanelClosingState';
+import { sidePanelNavigationStackState } from '@/side-panel/states/sidePanelNavigationStackState';
 import { isSidePanelOpenedState } from '@/side-panel/states/isSidePanelOpenedState';
 import { sidePanelSearchObjectFilterState } from '@/side-panel/states/sidePanelSearchObjectFilterState';
 import { sidePanelSearchState } from '@/side-panel/states/sidePanelSearchState';
@@ -28,6 +29,7 @@ export const useSidePanelMenu = () => {
     const isSidePanelOpened = store.get(isSidePanelOpenedState.atom);
 
     if (isSidePanelOpened) {
+      store.set(sidePanelNavigationStackState.atom, []);
       store.set(isSidePanelOpenedState.atom, false);
       store.set(isSidePanelClosingState.atom, true);
       closeAnyOpenDropdown();


### PR DESCRIPTION
Fixes: #19152 

## Summary
goBackFromSidePanel returned early without writing the new (empty) stack to the store, leaving stale navigation state. And it caused openRecordInSidePanel to think the record was already open and skip reopening.
<img width="587" height="405" alt="image" src="https://github.com/user-attachments/assets/eb36f4c6-43ca-4c08-891a-c592ff673837" />

## Before

https://github.com/user-attachments/assets/03d1e24a-6d1e-4efc-93c1-72be0bc31a89


## After
When close the side panel with Escape, now it can be opened by clicking arrow button again.



https://github.com/user-attachments/assets/ae700d41-4f81-4d1a-af9a-f97f31f489a6

