### PR TITLE
fix: allow arrow key cursor movement in Select field search input

### DIFF
--- a/packages/twenty-front/src/modules/ui/layout/selectable-list/hooks/internal/useSelectableListHotKeys.ts
+++ b/packages/twenty-front/src/modules/ui/layout/selectable-list/hooks/internal/useSelectableListHotKeys.ts
@@ -152,15 +152,29 @@ export const useSelectableListHotKeys = (
 
   useHotkeysOnFocusedElement({
     keys: Key.ArrowLeft,
-    callback: () => handleSelect('left'),
+    callback: (keyboardEvent) => {
+      const target = keyboardEvent.target as HTMLElement;
+      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA') {
+        return;
+      }
+      handleSelect('left');
+    },
     focusId,
     dependencies: [handleSelect],
+    options: { preventDefault: false },
   });
 
   useHotkeysOnFocusedElement({
     keys: Key.ArrowRight,
-    callback: () => handleSelect('right'),
+    callback: (keyboardEvent) => {
+      const target = keyboardEvent.target as HTMLElement;
+      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA') {
+        return;
+      }
+      handleSelect('right');
+    },
     focusId,
     dependencies: [handleSelect],
+    options: { preventDefault: false },
   });
 };


### PR DESCRIPTION
## Summary

Fixes arrow keys (left/right) not moving the cursor in Select and MultiSelect field search inputs on the record table.

**Root cause:** `useSelectableListHotKeys` registers ArrowLeft/ArrowRight handlers with `preventDefault: true` (default), which intercepts the keys before the browser can move the cursor in the search input.

**Fix:** When the event target is an `INPUT` or `TEXTAREA`, skip the selectable list navigation and let the browser handle cursor movement. Also passes `preventDefault: false` for these keys so the default text input behavior is preserved.

Fix #12847

## Test plan

- [ ] Open a record table with a Select or MultiSelect field
- [ ] Click on a Select cell to open the dropdown with search input
- [ ] Type some text in the search input
- [ ] Press Left/Right arrow keys — cursor should now move through the text
- [ ] Press Up/Down arrow keys — should still navigate through the dropdown options
- [ ] Verify arrow keys still work for list navigation when focus is NOT on an input