### PR TITLE
fix(imap): skip getUidValidity for \Noselect folders

### DIFF
--- a/packages/twenty-server/src/modules/messaging/message-folder-manager/drivers/imap/services/imap-get-all-folders.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-folder-manager/drivers/imap/services/imap-get-all-folders.service.ts
@@ -74,9 +74,11 @@ export class ImapGetAllFoldersService implements MessageFolderDriver {
 
     if (isDefined(sentFolder)) {
       const sentMailbox = mailboxList.find((m) => m.path === sentFolder.path);
-      const uidValidity = sentMailbox
-        ? await this.getUidValidity(client, sentMailbox)
-        : null;
+      const sentIsNoselect = sentMailbox?.flags?.has('\\Noselect') ?? false;
+      const uidValidity =
+        sentMailbox && !sentIsNoselect
+          ? await this.getUidValidity(client, sentMailbox)
+          : null;
 
       const externalId = uidValidity
         ? `${sentFolder.path}:${uidValidity.toString()}`
@@ -94,7 +96,11 @@ export class ImapGetAllFoldersService implements MessageFolderDriver {
     }
 
     for (const mailbox of mailboxList) {
-      const uidValidity = await this.getUidValidity(client, mailbox);
+      // Skip getUidValidity for \Noselect folders — they don't support STATUS command
+      const isNoselect = mailbox.flags?.has('\\Noselect');
+      const uidValidity = isNoselect
+        ? null
+        : await this.getUidValidity(client, mailbox);
       const externalId = uidValidity
         ? `${mailbox.path}:${uidValidity}`
         : mailbox.path;


### PR DESCRIPTION
## Summary

Fixes twentyhq/twenty#19090 — IMAP sync fails with "Mailbox doesn't exist" for \\Noselect container folders.

## Root Cause

In `ImapGetAllFoldersService.filterAndMapFolders()`, `getUidValidity()` is called **before** checking `isValidMailbox()` for \\Noselect folders. Since \\Noselect folders don't support IMAP `STATUS`, this causes `NotFound` errors on every sync cycle for users with container-only parent folders (common with Dovecot + Thunderbird).

Introduced in PR #15526 (commit e3076328).

## Fix

1. **Main loop**: Check `mailbox.flags.has('\\Noselect')` before calling `getUidValidity()`. For \\Noselect folders, use `null` for uidValidity and set `externalId` to just the path — still correct for `pathToExternalIdMap` (needed for child folder `parentFolderId` lookups).

2. **Sent-folder branch**: Same guard applies.

## Testing

- Add unit test for \\Noselect path in `imap-get-all-folders.service.spec.ts`
- Manual: connect a Dovecot account with Thunderbird-style nested folders, trigger sync — `Mailbox doesn't exist` warning should not appear

---

/claim #19090