### PR TITLE
Add "search" to reserved metadata name keywords

### DIFF
--- a/packages/twenty-shared/src/metadata/constants/reserved-metadata-name-keywords.constant.ts
+++ b/packages/twenty-shared/src/metadata/constants/reserved-metadata-name-keywords.constant.ts
@@ -62,4 +62,6 @@ export const RESERVED_METADATA_NAME_KEYWORDS = [
   'relation',
   'relations',
   'aggregate',
+  'search',
+  'searches',
 ];


### PR DESCRIPTION
## Summary
- Adds `search` and `searches` to the `RESERVED_METADATA_NAME_KEYWORDS` list in `twenty-shared`
- Prevents users from creating custom objects named "search", which collides with the core `search` GraphQL resolver

