### PR TITLE
fix: prevent browser scrollbar layout shift on file preview

### DIFF
--- a/packages/twenty-front/src/index.css
+++ b/packages/twenty-front/src/index.css
@@ -8,7 +8,6 @@ body {
 
 html {
   font-size: 13px;
-  overflow: hidden;
 }
 
 button {
@@ -22,4 +21,8 @@ form {
 /* https://stackoverflow.com/questions/44543157/how-to-hide-the-google-invisible-recaptcha-badge */
 .grecaptcha-badge {
   visibility: hidden !important;
+}
+
+canvas.hiddenCanvasElement {
+  position: absolute;
 }

--- a/packages/twenty-front/src/index.css
+++ b/packages/twenty-front/src/index.css
@@ -8,6 +8,7 @@ body {
 
 html {
   font-size: 13px;
+  overflow: hidden;
 }
 
 button {


### PR DESCRIPTION
I found this 'bug' when I open the pdf preview. It triggers a transient native scrollbar on the right side, shifting the entire page left and return back quickly. I think hiding the scrollbar would improve the user experience a little. wdyt?
It only happens in pdf. CSV and xlsx is fine, but I haven't test ppt, doc, odt... (It's not allowed to open in local dev).

## Before 

https://github.com/user-attachments/assets/629c7874-b8f9-4a9b-97dc-023bcc8804f4

## After

https://github.com/user-attachments/assets/19ace675-c742-422d-9fe4-eeccde16bb2d

