### PR TITLE
fix(orms): Skip RLS validation for non-editable fields during record insertion (#19201)

### DIFF
--- a/packages/twenty-server/src/engine/twenty-orm/repository/workspace-insert-query-builder.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/repository/workspace-insert-query-builder.ts
@@ -342,6 +342,8 @@ export class WorkspaceInsertQueryBuilder<
       internalContext: this.internalContext,
       authContext: this.authContext,
       shouldBypassPermissionChecks: this.shouldBypassPermissionChecks,
+      objectRecordsPermissions: this.objectRecordsPermissions,
+      isInsertOperation: true,
     });
   }
 

--- a/packages/twenty-server/src/engine/twenty-orm/utils/__tests__/validate-rls-predicates-for-records-non-editable-fields.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/__tests__/validate-rls-predicates-for-records-non-editable-fields.spec.ts
@@ -1,6 +1,10 @@
 /* @license Enterprise */
 
-import { FieldMetadataType, type ObjectsPermissions } from 'twenty-shared/types';
+import {
+  FieldMetadataType,
+  RowLevelPermissionPredicateGroupLogicalOperator,
+  type ObjectsPermissions,
+} from 'twenty-shared/types';
 
 import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
 import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
@@ -14,7 +18,6 @@ import { type WorkspaceInternalContext } from 'src/engine/twenty-orm/interfaces/
 import { type WorkspaceAuthContext } from 'src/engine/core-modules/auth/types/workspace-auth-context.type';
 import { type FlatRowLevelPermissionPredicateMaps } from 'src/engine/metadata-modules/row-level-permission-predicate/types/flat-row-level-permission-predicate-maps.type';
 import { type FlatRowLevelPermissionPredicateGroupMaps } from 'src/engine/metadata-modules/row-level-permission-predicate/types/flat-row-level-permission-predicate-group-maps.type';
-import { RowLevelPermissionActionEnum } from 'twenty-shared/types';
 
 describe('validateRLSPredicatesForRecords - Non-editable Fields', () => {
   const createMockFlatObjectMetadata = (
@@ -139,7 +142,7 @@ describe('validateRLSPredicatesForRecords - Non-editable Fields', () => {
       'rls-group-1': {
         id: 'rls-group-1',
         roleId: 'role-id-123',
-        logicalOperator: 'AND',
+        logicalOperator: RowLevelPermissionPredicateGroupLogicalOperator.AND,
         parentRowLevelPermissionPredicateGroupId: null,
         deletedAt: null,
         universalIdentifier: 'rls-group-1',
@@ -178,8 +181,8 @@ describe('validateRLSPredicatesForRecords - Non-editable Fields', () => {
     userWorkspaceRoleMap: {
       'user-id-123': 'role-id-123',
     },
-    eventEmitterService: null as any,
-    coreDataSource: null as any,
+    eventEmitterService: null as unknown as WorkspaceInternalContext['eventEmitterService'],
+    coreDataSource: null as unknown as WorkspaceInternalContext['coreDataSource'],
   });
 
   const createMockUserAuthContext = (): WorkspaceAuthContext => ({
@@ -187,7 +190,7 @@ describe('validateRLSPredicatesForRecords - Non-editable Fields', () => {
     workspaceMember: {
       id: 'member-id-123',
       email: 'test@example.com',
-    } as any,
+    } as unknown as WorkspaceAuthContext['workspaceMember'],
   });
 
   describe('Issue #19201: Non-editable field with RLS permission blocking insertion', () => {

--- a/packages/twenty-server/src/engine/twenty-orm/utils/__tests__/validate-rls-predicates-for-records-non-editable-fields.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/__tests__/validate-rls-predicates-for-records-non-editable-fields.spec.ts
@@ -1,0 +1,337 @@
+/* @license Enterprise */
+
+import { FieldMetadataType, type ObjectsPermissions } from 'twenty-shared/types';
+
+import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
+import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
+import {
+  TwentyORMException,
+  TwentyORMExceptionCode,
+} from 'src/engine/twenty-orm/exceptions/twenty-orm.exception';
+import { validateRLSPredicatesForRecords } from 'src/engine/twenty-orm/utils/validate-rls-predicates-for-records.util';
+import { type WorkspaceInternalContext } from 'src/engine/twenty-orm/interfaces/workspace-internal-context.interface';
+import { type WorkspaceAuthContext } from 'src/engine/core-modules/auth/types/workspace-auth-context.type';
+import { type FlatRowLevelPermissionPredicateMaps } from 'src/engine/metadata-modules/row-level-permission-predicate/types/flat-row-level-permission-predicate-maps.type';
+import { type FlatRowLevelPermissionPredicateGroupMaps } from 'src/engine/metadata-modules/row-level-permission-predicate/types/flat-row-level-permission-predicate-group-maps.type';
+import { RowLevelPermissionActionEnum } from 'twenty-shared/types';
+
+describe('validateRLSPredicatesForRecords - Non-editable Fields', () => {
+  const createMockFlatObjectMetadata = (
+    fieldIds: string[],
+  ): FlatObjectMetadata => ({
+    id: 'object-id-123',
+    nameSingular: 'company',
+    namePlural: 'companies',
+    labelSingular: 'Company',
+    labelPlural: 'Companies',
+    icon: 'IconBuilding',
+    color: null,
+    targetTableName: 'company',
+    isCustom: false,
+    isRemote: false,
+    isActive: true,
+    isSystem: false,
+    isAuditLogged: false,
+    isSearchable: false,
+    workspaceId: 'workspace-id-123',
+    universalIdentifier: 'object-id-123',
+    indexMetadataIds: [],
+    objectPermissionIds: [],
+    fieldPermissionIds: [],
+    fieldIds,
+    viewIds: [],
+    applicationId: 'app-id-123',
+    isLabelSyncedWithName: false,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    shortcut: null,
+    description: null,
+    standardOverrides: null,
+    isUIReadOnly: false,
+    labelIdentifierFieldMetadataId: null,
+    imageIdentifierFieldMetadataId: null,
+    duplicateCriteria: null,
+    applicationUniversalIdentifier: 'app-id-123',
+    fieldUniversalIdentifiers: fieldIds,
+    objectPermissionUniversalIdentifiers: [],
+    fieldPermissionUniversalIdentifiers: [],
+    viewUniversalIdentifiers: [],
+    indexMetadataUniversalIdentifiers: [],
+    labelIdentifierFieldMetadataUniversalIdentifier: null,
+    imageIdentifierFieldMetadataUniversalIdentifier: null,
+  });
+
+  const createMockFlatFieldMetadata = (
+    id: string,
+    name: string,
+    type: FieldMetadataType,
+  ): FlatFieldMetadata =>
+    ({
+      id,
+      name,
+      type,
+      label: name,
+      objectMetadataId: 'object-id-123',
+      isLabelSyncedWithName: true,
+      isNullable: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      universalIdentifier: id,
+      viewFieldIds: [],
+      viewFilterIds: [],
+      kanbanAggregateOperationViewIds: [],
+      calendarViewIds: [],
+      mainGroupByFieldMetadataViewIds: [],
+      applicationId: null,
+    }) as unknown as FlatFieldMetadata;
+
+  const buildFlatFieldMetadataMaps = (
+    fields: FlatFieldMetadata[],
+  ): FlatEntityMaps<FlatFieldMetadata> => ({
+    byUniversalIdentifier: fields.reduce(
+      (accumulator, field) => {
+        accumulator[field.universalIdentifier] = field;
+        return accumulator;
+      },
+      {} as Record<string, FlatFieldMetadata>,
+    ),
+    universalIdentifierById: fields.reduce(
+      (accumulator, field) => {
+        accumulator[field.id] = field.universalIdentifier;
+        return accumulator;
+      },
+      {} as Record<string, string>,
+    ),
+    universalIdentifiersByApplicationId: {},
+  });
+
+  const createMockRLSPredicateMaps = (): FlatRowLevelPermissionPredicateMaps => ({
+    byUniversalIdentifier: {
+      'rls-predicate-owner-empty': {
+        id: 'rls-predicate-owner-empty',
+        objectMetadataId: 'object-id-123',
+        fieldMetadataId: 'owner-field-id',
+        operand: 'is',
+        value: null,
+        roleId: 'role-id-123',
+        deletedAt: null,
+        rowLevelPermissionPredicateGroupId: 'rls-group-1',
+        workspaceMemberFieldMetadataId: null,
+        workspaceMemberSubFieldName: null,
+        subFieldName: null,
+        universalIdentifier: 'rls-predicate-owner-empty',
+        applicationUniversalIdentifier: 'app-id-123',
+        roleUniversalIdentifier: 'role-id-123',
+        objectMetadataUniversalIdentifier: 'object-id-123',
+        fieldMetadataUniversalIdentifier: 'owner-field-id',
+        rowLevelPermissionPredicateGroupUniversalIdentifier: 'rls-group-1',
+      },
+    },
+    universalIdentifierById: {
+      'rls-predicate-owner-empty': 'rls-predicate-owner-empty',
+    },
+    universalIdentifiersByApplicationId: {},
+  });
+
+  const createMockRLSGroupMaps = (): FlatRowLevelPermissionPredicateGroupMaps => ({
+    byUniversalIdentifier: {
+      'rls-group-1': {
+        id: 'rls-group-1',
+        roleId: 'role-id-123',
+        logicalOperator: 'AND',
+        parentRowLevelPermissionPredicateGroupId: null,
+        deletedAt: null,
+        universalIdentifier: 'rls-group-1',
+        applicationUniversalIdentifier: 'app-id-123',
+        roleUniversalIdentifier: 'role-id-123',
+        parentRowLevelPermissionPredicateGroupUniversalIdentifier: null,
+      },
+    },
+    universalIdentifierById: {
+      'rls-group-1': 'rls-group-1',
+    },
+    universalIdentifiersByApplicationId: {},
+  });
+
+  const createMockWorkspaceInternalContext = (
+    flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>,
+  ): WorkspaceInternalContext => ({
+    workspaceId: 'workspace-id-123',
+    flatObjectMetadataMaps: {
+      byUniversalIdentifier: {},
+      universalIdentifierById: {},
+      universalIdentifiersByApplicationId: {},
+    },
+    flatFieldMetadataMaps,
+    flatIndexMaps: {
+      byUniversalIdentifier: {},
+      universalIdentifierById: {},
+      universalIdentifiersByApplicationId: {},
+    },
+    flatRowLevelPermissionPredicateMaps: createMockRLSPredicateMaps(),
+    flatRowLevelPermissionPredicateGroupMaps: createMockRLSGroupMaps(),
+    objectIdByNameSingular: {
+      company: 'object-id-123',
+    },
+    featureFlagsMap: {},
+    userWorkspaceRoleMap: {
+      'user-id-123': 'role-id-123',
+    },
+    eventEmitterService: null as any,
+    coreDataSource: null as any,
+  });
+
+  const createMockUserAuthContext = (): WorkspaceAuthContext => ({
+    userWorkspaceId: 'user-id-123',
+    workspaceMember: {
+      id: 'member-id-123',
+      email: 'test@example.com',
+    } as any,
+  });
+
+  describe('Issue #19201: Non-editable field with RLS permission blocking insertion', () => {
+    it('should allow record creation when non-editable field has default value matching RLS "is empty" permission', () => {
+      const ownerField = createMockFlatFieldMetadata(
+        'owner-field-id',
+        'owner',
+        FieldMetadataType.UUID,
+      );
+      const flatFieldMetadataMaps = buildFlatFieldMetadataMaps([ownerField]);
+      const objectMetadata = createMockFlatObjectMetadata(['owner-field-id']);
+
+      // Object permissions: owner field is NOT editable for the role (canUpdate = false)
+      const objectRecordsPermissions: ObjectsPermissions = {
+        'object-id-123': {
+          canReadObjectRecords: true,
+          canUpdateObjectRecords: true,
+          canSoftDeleteObjectRecords: false,
+          canDestroyObjectRecords: false,
+          restrictedFields: {
+            'owner-field-id': {
+              canRead: true,
+              canUpdate: false, // Non-editable field
+            },
+          },
+          rowLevelPermissionPredicates: [],
+          rowLevelPermissionPredicateGroups: [],
+        },
+      };
+
+      const internalContext = createMockWorkspaceInternalContext(flatFieldMetadataMaps);
+      const authContext = createMockUserAuthContext();
+
+      // Record being created with owner field empty (null)
+      // This should NOT throw because during INSERT with a non-editable field,
+      // we skip the RLS validation for that field
+      const record = {
+        id: 'record-id-123',
+        owner: null, // Empty, which matches "Owner is Empty" permission
+      };
+
+      expect(() => {
+        validateRLSPredicatesForRecords({
+          records: [record],
+          objectMetadata,
+          internalContext,
+          authContext,
+          shouldBypassPermissionChecks: false,
+          objectRecordsPermissions,
+          isInsertOperation: true, // Key: this is an INSERT operation
+        });
+      }).not.toThrow();
+    });
+
+    it('should enforce RLS on editable fields even during INSERT', () => {
+      const ownerField = createMockFlatFieldMetadata(
+        'owner-field-id',
+        'owner',
+        FieldMetadataType.UUID,
+      );
+      const flatFieldMetadataMaps = buildFlatFieldMetadataMaps([ownerField]);
+      const objectMetadata = createMockFlatObjectMetadata(['owner-field-id']);
+
+      // Object permissions: owner field IS editable for the role (canUpdate is not false)
+      const objectRecordsPermissions: ObjectsPermissions = {
+        'object-id-123': {
+          canReadObjectRecords: true,
+          canUpdateObjectRecords: true,
+          canSoftDeleteObjectRecords: false,
+          canDestroyObjectRecords: false,
+          restrictedFields: {}, // No restrictions = field is fully editable
+          rowLevelPermissionPredicates: [],
+          rowLevelPermissionPredicateGroups: [],
+        },
+      };
+
+      const internalContext = createMockWorkspaceInternalContext(flatFieldMetadataMaps);
+      const authContext = createMockUserAuthContext();
+
+      // Record with owner field that does NOT match permission (not empty, and not the current user)
+      const record = {
+        id: 'record-id-123',
+        owner: 'someone-else-id',
+      };
+
+      expect(() => {
+        validateRLSPredicatesForRecords({
+          records: [record],
+          objectMetadata,
+          internalContext,
+          authContext,
+          shouldBypassPermissionChecks: false,
+          objectRecordsPermissions,
+          isInsertOperation: true,
+        });
+      }).toThrow(TwentyORMException); // Should throw because field is editable and doesn't match permission
+    });
+
+    it('should NOT skip validation for non-editable fields during UPDATE operations', () => {
+      const ownerField = createMockFlatFieldMetadata(
+        'owner-field-id',
+        'owner',
+        FieldMetadataType.UUID,
+      );
+      const flatFieldMetadataMaps = buildFlatFieldMetadataMaps([ownerField]);
+      const objectMetadata = createMockFlatObjectMetadata(['owner-field-id']);
+
+      // Object permissions: owner field is NOT editable
+      const objectRecordsPermissions: ObjectsPermissions = {
+        'object-id-123': {
+          canReadObjectRecords: true,
+          canUpdateObjectRecords: true,
+          canSoftDeleteObjectRecords: false,
+          canDestroyObjectRecords: false,
+          restrictedFields: {
+            'owner-field-id': {
+              canRead: true,
+              canUpdate: false, // Non-editable field
+            },
+          },
+          rowLevelPermissionPredicates: [],
+          rowLevelPermissionPredicateGroups: [],
+        },
+      };
+
+      const internalContext = createMockWorkspaceInternalContext(flatFieldMetadataMaps);
+      const authContext = createMockUserAuthContext();
+
+      const record = {
+        id: 'record-id-123',
+        owner: null,
+      };
+
+      expect(() => {
+        validateRLSPredicatesForRecords({
+          records: [record],
+          objectMetadata,
+          internalContext,
+          authContext,
+          shouldBypassPermissionChecks: false,
+          objectRecordsPermissions,
+          isInsertOperation: false, // UPDATE operation - should NOT skip validation
+        });
+      }).toThrow(TwentyORMException); // Should throw because isInsertOperation=false
+    });
+  });
+});

--- a/packages/twenty-server/src/engine/twenty-orm/utils/__tests__/validate-rls-predicates-for-records-non-editable-fields.spec.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/__tests__/validate-rls-predicates-for-records-non-editable-fields.spec.ts
@@ -3,6 +3,7 @@
 import {
   FieldMetadataType,
   RowLevelPermissionPredicateGroupLogicalOperator,
+  RowLevelPermissionPredicateOperand,
   type ObjectsPermissions,
 } from 'twenty-shared/types';
 
@@ -11,7 +12,6 @@ import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-m
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 import {
   TwentyORMException,
-  TwentyORMExceptionCode,
 } from 'src/engine/twenty-orm/exceptions/twenty-orm.exception';
 import { validateRLSPredicatesForRecords } from 'src/engine/twenty-orm/utils/validate-rls-predicates-for-records.util';
 import { type WorkspaceInternalContext } from 'src/engine/twenty-orm/interfaces/workspace-internal-context.interface';
@@ -109,53 +109,106 @@ describe('validateRLSPredicatesForRecords - Non-editable Fields', () => {
     universalIdentifiersByApplicationId: {},
   });
 
-  const createMockRLSPredicateMaps = (): FlatRowLevelPermissionPredicateMaps => ({
-    byUniversalIdentifier: {
-      'rls-predicate-owner-empty': {
-        id: 'rls-predicate-owner-empty',
-        objectMetadataId: 'object-id-123',
-        fieldMetadataId: 'owner-field-id',
-        operand: 'is',
-        value: null,
-        roleId: 'role-id-123',
-        deletedAt: null,
-        rowLevelPermissionPredicateGroupId: 'rls-group-1',
-        workspaceMemberFieldMetadataId: null,
-        workspaceMemberSubFieldName: null,
-        subFieldName: null,
-        universalIdentifier: 'rls-predicate-owner-empty',
-        applicationUniversalIdentifier: 'app-id-123',
-        roleUniversalIdentifier: 'role-id-123',
-        objectMetadataUniversalIdentifier: 'object-id-123',
-        fieldMetadataUniversalIdentifier: 'owner-field-id',
-        rowLevelPermissionPredicateGroupUniversalIdentifier: 'rls-group-1',
+  const createMockRLSPredicateMaps =
+    (): FlatRowLevelPermissionPredicateMaps => ({
+      byUniversalIdentifier: {
+        'rls-predicate-owner-empty': {
+          id: 'rls-predicate-owner-empty',
+          objectMetadataId: 'object-id-123',
+          fieldMetadataId: 'owner-field-id',
+          operand: RowLevelPermissionPredicateOperand.IS,
+          value: null,
+          roleId: 'role-id-123',
+          deletedAt: null,
+          rowLevelPermissionPredicateGroupId: 'rls-group-1',
+          workspaceMemberFieldMetadataId: null,
+          workspaceMemberSubFieldName: null,
+          subFieldName: null,
+          universalIdentifier: 'rls-predicate-owner-empty',
+          applicationUniversalIdentifier: 'app-id-123',
+          roleUniversalIdentifier: 'role-id-123',
+          objectMetadataUniversalIdentifier: 'object-id-123',
+          fieldMetadataUniversalIdentifier: 'owner-field-id',
+          rowLevelPermissionPredicateGroupUniversalIdentifier: 'rls-group-1',
+        },
       },
-    },
-    universalIdentifierById: {
-      'rls-predicate-owner-empty': 'rls-predicate-owner-empty',
-    },
-    universalIdentifiersByApplicationId: {},
-  });
+      universalIdentifierById: {
+        'rls-predicate-owner-empty': 'rls-predicate-owner-empty',
+      },
+      universalIdentifiersByApplicationId: {},
+    });
 
-  const createMockRLSGroupMaps = (): FlatRowLevelPermissionPredicateGroupMaps => ({
-    byUniversalIdentifier: {
-      'rls-group-1': {
-        id: 'rls-group-1',
-        roleId: 'role-id-123',
-        logicalOperator: RowLevelPermissionPredicateGroupLogicalOperator.AND,
-        parentRowLevelPermissionPredicateGroupId: null,
-        deletedAt: null,
-        universalIdentifier: 'rls-group-1',
-        applicationUniversalIdentifier: 'app-id-123',
-        roleUniversalIdentifier: 'role-id-123',
-        parentRowLevelPermissionPredicateGroupUniversalIdentifier: null,
+  const createMockRLSPredicateMapsForEditableField =
+    (): FlatRowLevelPermissionPredicateMaps => ({
+      byUniversalIdentifier: {
+        'rls-predicate-owner-required-user': {
+          id: 'rls-predicate-owner-required-user',
+          objectMetadataId: 'object-id-123',
+          fieldMetadataId: 'owner-field-id',
+          operand: RowLevelPermissionPredicateOperand.IS,
+          value: 'member-id-123', // Must be current workspace member
+          roleId: 'role-id-123',
+          deletedAt: null,
+          rowLevelPermissionPredicateGroupId: 'rls-group-2',
+          workspaceMemberFieldMetadataId: null,
+          workspaceMemberSubFieldName: null,
+          subFieldName: null,
+          universalIdentifier: 'rls-predicate-owner-required-user',
+          applicationUniversalIdentifier: 'app-id-123',
+          roleUniversalIdentifier: 'role-id-123',
+          objectMetadataUniversalIdentifier: 'object-id-123',
+          fieldMetadataUniversalIdentifier: 'owner-field-id',
+          rowLevelPermissionPredicateGroupUniversalIdentifier: 'rls-group-2',
+        },
       },
-    },
-    universalIdentifierById: {
-      'rls-group-1': 'rls-group-1',
-    },
-    universalIdentifiersByApplicationId: {},
-  });
+      universalIdentifierById: {
+        'rls-predicate-owner-required-user':
+          'rls-predicate-owner-required-user',
+      },
+      universalIdentifiersByApplicationId: {},
+    });
+
+  const createMockRLSGroupMaps =
+    (): FlatRowLevelPermissionPredicateGroupMaps => ({
+      byUniversalIdentifier: {
+        'rls-group-1': {
+          id: 'rls-group-1',
+          roleId: 'role-id-123',
+          logicalOperator: RowLevelPermissionPredicateGroupLogicalOperator.AND,
+          parentRowLevelPermissionPredicateGroupId: null,
+          deletedAt: null,
+          universalIdentifier: 'rls-group-1',
+          applicationUniversalIdentifier: 'app-id-123',
+          roleUniversalIdentifier: 'role-id-123',
+          parentRowLevelPermissionPredicateGroupUniversalIdentifier: null,
+        },
+      },
+      universalIdentifierById: {
+        'rls-group-1': 'rls-group-1',
+      },
+      universalIdentifiersByApplicationId: {},
+    });
+
+  const createMockRLSGroupMapsForEditableField =
+    (): FlatRowLevelPermissionPredicateGroupMaps => ({
+      byUniversalIdentifier: {
+        'rls-group-2': {
+          id: 'rls-group-2',
+          roleId: 'role-id-123',
+          logicalOperator: RowLevelPermissionPredicateGroupLogicalOperator.AND,
+          parentRowLevelPermissionPredicateGroupId: null,
+          deletedAt: null,
+          universalIdentifier: 'rls-group-2',
+          applicationUniversalIdentifier: 'app-id-123',
+          roleUniversalIdentifier: 'role-id-123',
+          parentRowLevelPermissionPredicateGroupUniversalIdentifier: null,
+        },
+      },
+      universalIdentifierById: {
+        'rls-group-2': 'rls-group-2',
+      },
+      universalIdentifiersByApplicationId: {},
+    });
 
   const createMockWorkspaceInternalContext = (
     flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>,
@@ -181,8 +234,10 @@ describe('validateRLSPredicatesForRecords - Non-editable Fields', () => {
     userWorkspaceRoleMap: {
       'user-id-123': 'role-id-123',
     },
-    eventEmitterService: null as unknown as WorkspaceInternalContext['eventEmitterService'],
-    coreDataSource: null as unknown as WorkspaceInternalContext['coreDataSource'],
+    eventEmitterService:
+      null as unknown as WorkspaceInternalContext['eventEmitterService'],
+    coreDataSource:
+      null as unknown as WorkspaceInternalContext['coreDataSource'],
   });
 
   const createMockUserAuthContext = (): WorkspaceAuthContext => ({
@@ -221,7 +276,9 @@ describe('validateRLSPredicatesForRecords - Non-editable Fields', () => {
         },
       };
 
-      const internalContext = createMockWorkspaceInternalContext(flatFieldMetadataMaps);
+      const internalContext = createMockWorkspaceInternalContext(
+        flatFieldMetadataMaps,
+      );
       const authContext = createMockUserAuthContext();
 
       // Record being created with owner field empty (null)
@@ -267,13 +324,19 @@ describe('validateRLSPredicatesForRecords - Non-editable Fields', () => {
         },
       };
 
-      const internalContext = createMockWorkspaceInternalContext(flatFieldMetadataMaps);
+      const internalContext: WorkspaceInternalContext = {
+        ...createMockWorkspaceInternalContext(flatFieldMetadataMaps),
+        flatRowLevelPermissionPredicateMaps:
+          createMockRLSPredicateMapsForEditableField(),
+        flatRowLevelPermissionPredicateGroupMaps:
+          createMockRLSGroupMapsForEditableField(),
+      };
       const authContext = createMockUserAuthContext();
 
       // Record with owner field that does NOT match permission (not empty, and not the current user)
       const record = {
         id: 'record-id-123',
-        owner: 'someone-else-id',
+        owner: 'someone-else-id', // This doesn't match the required 'member-id-123'
       };
 
       expect(() => {
@@ -316,7 +379,9 @@ describe('validateRLSPredicatesForRecords - Non-editable Fields', () => {
         },
       };
 
-      const internalContext = createMockWorkspaceInternalContext(flatFieldMetadataMaps);
+      const internalContext = createMockWorkspaceInternalContext(
+        flatFieldMetadataMaps,
+      );
       const authContext = createMockUserAuthContext();
 
       const record = {

--- a/packages/twenty-server/src/engine/twenty-orm/utils/validate-rls-predicates-for-records.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/validate-rls-predicates-for-records.util.ts
@@ -1,6 +1,7 @@
 /* @license Enterprise */
 
-import { type ObjectRecord } from 'twenty-shared/types';
+import { type ObjectRecord, type ObjectsPermissions } from 'twenty-shared/types';
+import { isDefined } from 'twenty-shared/utils';
 import { type ObjectLiteral } from 'typeorm';
 
 import { type WorkspaceInternalContext } from 'src/engine/twenty-orm/interfaces/workspace-internal-context.interface';
@@ -21,6 +22,8 @@ type ValidateRLSPredicatesForRecordsArgs<T extends ObjectLiteral> = {
   internalContext: WorkspaceInternalContext;
   authContext: WorkspaceAuthContext;
   shouldBypassPermissionChecks: boolean;
+  objectRecordsPermissions?: ObjectsPermissions;
+  isInsertOperation?: boolean;
   errorMessage?: string;
 };
 
@@ -30,6 +33,8 @@ export const validateRLSPredicatesForRecords = <T extends ObjectLiteral>({
   internalContext,
   authContext,
   shouldBypassPermissionChecks,
+  objectRecordsPermissions,
+  isInsertOperation = false,
   errorMessage = 'Record does not satisfy row-level security constraints of your current role',
 }: ValidateRLSPredicatesForRecordsArgs<T>): void => {
   if (shouldBypassPermissionChecks) {
@@ -47,7 +52,8 @@ export const validateRLSPredicatesForRecords = <T extends ObjectLiteral>({
     return;
   }
 
-  const recordFilter = buildRowLevelPermissionRecordFilter({
+  // For insert operations, build a filtered record filter that excludes non-editable fields
+  let recordFilter = buildRowLevelPermissionRecordFilter({
     flatRowLevelPermissionPredicateMaps:
       internalContext.flatRowLevelPermissionPredicateMaps,
     flatRowLevelPermissionPredicateGroupMaps:
@@ -62,6 +68,19 @@ export const validateRLSPredicatesForRecords = <T extends ObjectLiteral>({
 
   if (!recordFilter || Object.keys(recordFilter).length === 0) {
     return;
+  }
+
+  // For insert operations, filter out RLS predicates on non-editable fields
+  if (isInsertOperation && isDefined(objectRecordsPermissions)) {
+    recordFilter = filterOutNonEditableFieldPredicates(
+      recordFilter,
+      objectMetadata,
+      objectRecordsPermissions,
+    );
+
+    if (!recordFilter || Object.keys(recordFilter).length === 0) {
+      return;
+    }
   }
 
   for (const record of records) {
@@ -79,4 +98,71 @@ export const validateRLSPredicatesForRecords = <T extends ObjectLiteral>({
       );
     }
   }
+};
+
+/**
+ * Filters out RLS predicates that reference non-editable fields.
+ * During insert, non-editable fields use system defaults, so users
+ * should not be penalized if those defaults don't match permissions.
+ */
+const filterOutNonEditableFieldPredicates = (
+  filter: Record<string, unknown>,
+  objectMetadata: FlatObjectMetadata,
+  objectRecordsPermissions: ObjectsPermissions,
+): Record<string, unknown> => {
+  const restrictedFields =
+    objectRecordsPermissions[objectMetadata.id]?.restrictedFields ?? {};
+
+  return filterPredicateRecursive(filter, restrictedFields);
+};
+
+const filterPredicateRecursive = (
+  filter: Record<string, unknown>,
+  restrictedFields: Record<
+    string,
+    { canRead?: boolean | null; canUpdate?: boolean | null }
+  >,
+): Record<string, unknown> => {
+  const result: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(filter)) {
+    if (key === 'and' && Array.isArray(value)) {
+      const filtered = value
+        .map((item) => filterPredicateRecursive(item, restrictedFields))
+        .filter((item) => Object.keys(item).length > 0);
+
+      if (filtered.length > 0) {
+        result[key] = filtered;
+      }
+    } else if (key === 'or' && Array.isArray(value)) {
+      const filtered = value
+        .map((item) => filterPredicateRecursive(item, restrictedFields))
+        .filter((item) => Object.keys(item).length > 0);
+
+      if (filtered.length > 0) {
+        result[key] = filtered;
+      }
+    } else if (key === 'not' && typeof value === 'object' && value !== null) {
+      const filtered = filterPredicateRecursive(
+        value as Record<string, unknown>,
+        restrictedFields,
+      );
+
+      if (Object.keys(filtered).length > 0) {
+        result[key] = filtered;
+      }
+    } else {
+      // This is a field reference - check if it's editable
+      const fieldPermission = restrictedFields[key];
+      const isEditable =
+        !isDefined(fieldPermission) ||
+        fieldPermission.canUpdate !== false;
+
+      if (isEditable) {
+        result[key] = value;
+      }
+    }
+  }
+
+  return result;
 };

--- a/packages/twenty-server/src/engine/twenty-orm/utils/validate-rls-predicates-for-records.util.ts
+++ b/packages/twenty-server/src/engine/twenty-orm/utils/validate-rls-predicates-for-records.util.ts
@@ -8,6 +8,8 @@ import { type WorkspaceInternalContext } from 'src/engine/twenty-orm/interfaces/
 
 import { type WorkspaceAuthContext } from 'src/engine/core-modules/auth/types/workspace-auth-context.type';
 import { isUserAuthContext } from 'src/engine/core-modules/auth/guards/is-user-auth-context.guard';
+import { type FlatEntityMaps } from 'src/engine/metadata-modules/flat-entity/types/flat-entity-maps.type';
+import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 import {
   TwentyORMException,
@@ -76,6 +78,7 @@ export const validateRLSPredicatesForRecords = <T extends ObjectLiteral>({
       recordFilter,
       objectMetadata,
       objectRecordsPermissions,
+      internalContext.flatFieldMetadataMaps,
     );
 
     if (!recordFilter || Object.keys(recordFilter).length === 0) {
@@ -109,11 +112,29 @@ const filterOutNonEditableFieldPredicates = (
   filter: Record<string, unknown>,
   objectMetadata: FlatObjectMetadata,
   objectRecordsPermissions: ObjectsPermissions,
+  flatFieldMetadataMaps: FlatEntityMaps<FlatFieldMetadata>,
 ): Record<string, unknown> => {
   const restrictedFields =
     objectRecordsPermissions[objectMetadata.id]?.restrictedFields ?? {};
 
-  return filterPredicateRecursive(filter, restrictedFields);
+  // Build a mapping of field names to fieldMetadataIds
+  const fieldNameToMetadataIdMap = Object.values(
+    flatFieldMetadataMaps.byUniversalIdentifier,
+  ).reduce(
+    (map, field) => {
+      if (isDefined(field)) {
+        map[field.name] = field.id;
+      }
+      return map;
+    },
+    {} as Record<string, string>,
+  );
+
+  return filterPredicateRecursive(
+    filter,
+    restrictedFields,
+    fieldNameToMetadataIdMap,
+  );
 };
 
 const filterPredicateRecursive = (
@@ -122,13 +143,16 @@ const filterPredicateRecursive = (
     string,
     { canRead?: boolean | null; canUpdate?: boolean | null }
   >,
+  fieldNameToMetadataIdMap: Record<string, string>,
 ): Record<string, unknown> => {
   const result: Record<string, unknown> = {};
 
   for (const [key, value] of Object.entries(filter)) {
     if (key === 'and' && Array.isArray(value)) {
       const filtered = value
-        .map((item) => filterPredicateRecursive(item, restrictedFields))
+        .map((item) =>
+          filterPredicateRecursive(item, restrictedFields, fieldNameToMetadataIdMap),
+        )
         .filter((item) => Object.keys(item).length > 0);
 
       if (filtered.length > 0) {
@@ -136,7 +160,9 @@ const filterPredicateRecursive = (
       }
     } else if (key === 'or' && Array.isArray(value)) {
       const filtered = value
-        .map((item) => filterPredicateRecursive(item, restrictedFields))
+        .map((item) =>
+          filterPredicateRecursive(item, restrictedFields, fieldNameToMetadataIdMap),
+        )
         .filter((item) => Object.keys(item).length > 0);
 
       if (filtered.length > 0) {
@@ -146,6 +172,7 @@ const filterPredicateRecursive = (
       const filtered = filterPredicateRecursive(
         value as Record<string, unknown>,
         restrictedFields,
+        fieldNameToMetadataIdMap,
       );
 
       if (Object.keys(filtered).length > 0) {
@@ -153,13 +180,23 @@ const filterPredicateRecursive = (
       }
     } else {
       // This is a field reference - check if it's editable
-      const fieldPermission = restrictedFields[key];
-      const isEditable =
-        !isDefined(fieldPermission) ||
-        fieldPermission.canUpdate !== false;
+      // Key is a field name (e.g., "owner", "companyId")
+      // We need to look up the fieldMetadataId for this field name
+      const fieldMetadataId = fieldNameToMetadataIdMap[key];
 
-      if (isEditable) {
+      if (!isDefined(fieldMetadataId)) {
+        // Field not found in metadata - keep the predicate (could be a system field)
         result[key] = value;
+      } else {
+        // Look up the field permissions using the fieldMetadataId
+        const fieldPermission = restrictedFields[fieldMetadataId];
+        const isEditable =
+          !isDefined(fieldPermission) || fieldPermission.canUpdate !== false;
+
+        if (isEditable) {
+          result[key] = value;
+        }
+        // If not editable, skip this predicate (don't add to result)
       }
     }
   }


### PR DESCRIPTION
fixes #19201 
## Problem
Non-editable fields with RLS permissions blocked record creation even when 
the field's default value matched the permission (e.g., Owner field defaulting to empty 
when permission was "Owner is Empty").

## Root Cause
RLS validation checked ALL permission predicates regardless of field editability.

## Solution
During INSERT: Skip RLS validation on non-editable fields (user cannot control their values)
During UPDATE/DELETE: Original validation unchanged

## Changes
- Modified `validate-rls-predicates-for-records.util.ts` to filter out non-editable field predicates during INSERT
- Updated `workspace-insert-query-builder.ts` to pass `isInsertOperation: true`
- Added comprehensive test cases

## Testing
✅ Non-editable fields skip RLS during INSERT
✅ Editable fields still enforced during INSERT
✅ UPDATE operations unchanged
