### PR TITLE
Fix front component not opening in side panel

### DIFF
--- a/packages/twenty-front/src/modules/command-menu-item/server-items/common/hooks/useCommandMenuItemsFromBackend.tsx
+++ b/packages/twenty-front/src/modules/command-menu-item/server-items/common/hooks/useCommandMenuItemsFromBackend.tsx
@@ -152,9 +152,9 @@ export const useCommandMenuItemsFromBackend = (
     isPinned: boolean;
     typeOverride?: CommandMenuItemType;
   }): CommandMenuItemConfig | null => {
-    if (isDefined(item.engineComponentKey)) {
-      return buildCommandItemFromEngineKey({
-        item,
+    if (isDefined(item.frontComponentId)) {
+      return buildCommandMenuItemFromFrontComponent({
+        item: item as CommandMenuItemWithFrontComponent,
         type: typeOverride,
         scope,
         isPinned,
@@ -163,9 +163,9 @@ export const useCommandMenuItemsFromBackend = (
       });
     }
 
-    if (isDefined(item.frontComponentId)) {
-      return buildCommandMenuItemFromFrontComponent({
-        item: item as CommandMenuItemWithFrontComponent,
+    if (isDefined(item.engineComponentKey)) {
+      return buildCommandItemFromEngineKey({
+        item,
         type: typeOverride,
         scope,
         isPinned,


### PR DESCRIPTION
# PR Description

Fix branching priority in `useCommandMenuItemsFromBackend` so non-headless front components are routed through `FrontComponentCommandMenuItem` (which opens the side panel) instead of always going through the `HeadlessCommandMenuItem` path.

# Video QA

## Before

https://github.com/user-attachments/assets/4449b849-ae71-4ca2-b22e-0efd62ad1b1b

## After

https://github.com/user-attachments/assets/d361d1d1-83fb-4588-a5da-d1bae8747954
