### PR TITLE
Standard PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,46 @@
+## Summary
+
+Describe the change in a few sentences.
+
+## Related Issue
+
+Closes #
+
+## Scope Of Change
+
+- Affected package(s):
+- Type of change:
+- User-facing impact:
+
+## How I Tested This
+
+- [ ] I tested the change locally
+- [ ] I ran the relevant lint/typecheck/test commands
+
+Commands run:
+
+```bash
+# Example:
+# npx nx lint twenty-front
+# npx nx typecheck twenty-front
+# npx jest path/to/test.test.ts --config=packages/PROJECT/jest.config.mjs
+```
+
+## Screenshots Or Recordings
+
+Include screenshots, screen recordings, or `N/A` for non-UI changes.
+
+## Checklist
+
+- [ ] I linked the related issue
+- [ ] I kept the change focused and reviewable
+- [ ] I updated documentation when needed
+- [ ] I included screenshots or recordings for UI changes
+- [ ] I generated GraphQL types if needed
+- [ ] I generated SDK metadata client changes if needed
+- [ ] I added a migration if needed
+- [ ] I understand that submitting this PR means agreeing to the CLA
+
+## Notes For Reviewers
+
+Add any extra context, tradeoffs, follow-up work, or areas that need special attention.


### PR DESCRIPTION
## **What It Is**

pull_request_template.md is a GitHub helper file. It is not code, and it is not something you “run.” Its job is to automatically pre-fill the description box when someone opens a new pull request for this repository.

So instead of a contributor seeing an empty PR description, GitHub shows the sections from this file:

- Summary
- Related Issue
- Scope Of Change
- How I Tested This
- Screenshots Or Recordings
- Checklist
- Notes For Reviewers

That makes PRs more complete and easier to review.

## **How GitHub Uses It**

Step by step:

1. A contributor makes changes in their own branch.
2. They push that branch to GitHub.
3. They click “New pull request” on GitHub.
4. GitHub checks the repository for a standard PR template file.
5. Because this repo now has .github/pull_request_template.md, GitHub automatically copies its contents into the PR description field.
6. The contributor fills in the sections before submitting the PR.
7. They submit the pull request normally.

So the file is used automatically by GitHub. Nobody manually uploads it during each PR.

## **What The Contributor Should Actually Do**

Using your template, the contributor would do this:

1. Open a new pull request on GitHub.
2. In Summary, briefly explain what changed.
3. In Related Issue, add something like Closes #123.
4. In Scope Of Change, say which package was touched and what kind of change it is.
5. In How I Tested This, list what they ran locally.
6. Add screenshots if the UI changed, or write N/A if not.
7. Tick the checklist boxes that apply.
8. Add anything important in Notes For Reviewers.
9. Submit the PR.

## **Why The Location Matters**

GitHub recognizes PR templates only when they are placed in supported locations. One of the standard locations is exactly this one:

`.github/pull_request_template.md`

Because it is in the right place, GitHub can detect and use it automatically.