### PR TITLE
Prevent hovered tab to overflow

### DIFF
--- a/packages/twenty-ui/src/input/button/components/TabButton/internals/components/StyledTabBase.tsx
+++ b/packages/twenty-ui/src/input/button/components/TabButton/internals/components/StyledTabBase.tsx
@@ -72,6 +72,7 @@ export const StyledTabContainer = styled.div<{
 export const StyledTabHover = styled.span<{
   contentSize?: 'sm' | 'md';
 }>`
+  box-sizing: border-box;
   display: flex;
   gap: ${themeCssVariables.spacing[1]};
   padding: ${({ contentSize }) =>


### PR DESCRIPTION
## Before

<img width="1274" height="102" alt="image" src="https://github.com/user-attachments/assets/86088cd3-6e15-40f2-8fe4-0090e4fe9572" />

## After

https://github.com/user-attachments/assets/fb892f16-f1ca-4e02-b588-2651d5738a9b

