### PR TITLE
On workspace creation generate sdk client through a job

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/message-queue/jobs.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/message-queue/jobs.module.ts
@@ -30,6 +30,7 @@ import { SubscriptionsModule } from 'src/engine/subscriptions/subscriptions.modu
 import { CleanOnboardingWorkspacesJob } from 'src/engine/workspace-manager/workspace-cleaner/crons/clean-onboarding-workspaces.job';
 import { CleanSuspendedWorkspacesJob } from 'src/engine/workspace-manager/workspace-cleaner/crons/clean-suspended-workspaces.job';
 import { CleanWorkspaceDeletionWarningUserVarsJob } from 'src/engine/workspace-manager/workspace-cleaner/jobs/clean-workspace-deletion-warning-user-vars.job';
+import { SdkClientModule } from 'src/engine/core-modules/sdk-client/sdk-client.module';
 import { WorkspaceCleanerModule } from 'src/engine/workspace-manager/workspace-cleaner/workspace-cleaner.module';
 import { CalendarEventParticipantManagerModule } from 'src/modules/calendar/calendar-event-participant-manager/calendar-event-participant-manager.module';
 import { CalendarModule } from 'src/modules/calendar/calendar.module';
@@ -65,6 +66,7 @@ import { WorkflowModule } from 'src/modules/workflow/workflow.module';
     FavoriteModule,
     NavigationMenuItemModule,
     WorkspaceCleanerModule,
+    SdkClientModule,
     SubscriptionsModule,
     AuditJobModule,
     AiAgentMonitorModule,

--- a/packages/twenty-server/src/engine/core-modules/message-queue/jobs.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/message-queue/jobs.module.ts
@@ -29,8 +29,9 @@ import { WebhookJobModule } from 'src/engine/metadata-modules/webhook/jobs/webho
 import { SubscriptionsModule } from 'src/engine/subscriptions/subscriptions.module';
 import { CleanOnboardingWorkspacesJob } from 'src/engine/workspace-manager/workspace-cleaner/crons/clean-onboarding-workspaces.job';
 import { CleanSuspendedWorkspacesJob } from 'src/engine/workspace-manager/workspace-cleaner/crons/clean-suspended-workspaces.job';
-import { CleanWorkspaceDeletionWarningUserVarsJob } from 'src/engine/workspace-manager/workspace-cleaner/jobs/clean-workspace-deletion-warning-user-vars.job';
+import { GenerateSdkClientJob } from 'src/engine/core-modules/sdk-client/jobs/generate-sdk-client.job';
 import { SdkClientModule } from 'src/engine/core-modules/sdk-client/sdk-client.module';
+import { CleanWorkspaceDeletionWarningUserVarsJob } from 'src/engine/workspace-manager/workspace-cleaner/jobs/clean-workspace-deletion-warning-user-vars.job';
 import { WorkspaceCleanerModule } from 'src/engine/workspace-manager/workspace-cleaner/workspace-cleaner.module';
 import { CalendarEventParticipantManagerModule } from 'src/modules/calendar/calendar-event-participant-manager/calendar-event-participant-manager.module';
 import { CalendarModule } from 'src/modules/calendar/calendar.module';
@@ -65,8 +66,8 @@ import { WorkflowModule } from 'src/modules/workflow/workflow.module';
     WorkflowModule,
     FavoriteModule,
     NavigationMenuItemModule,
-    WorkspaceCleanerModule,
     SdkClientModule,
+    WorkspaceCleanerModule,
     SubscriptionsModule,
     AuditJobModule,
     AiAgentMonitorModule,
@@ -82,6 +83,7 @@ import { WorkflowModule } from 'src/modules/workflow/workflow.module';
     HandleWorkspaceMemberDeletedJob,
     CleanWorkspaceDeletionWarningUserVarsJob,
     UpdateWorkspaceMemberEmailJob,
+    GenerateSdkClientJob,
   ],
 })
 export class JobsModule {

--- a/packages/twenty-server/src/engine/core-modules/sdk-client/jobs/generate-sdk-client.job.ts
+++ b/packages/twenty-server/src/engine/core-modules/sdk-client/jobs/generate-sdk-client.job.ts
@@ -1,0 +1,26 @@
+import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
+import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
+import { Process } from 'src/engine/core-modules/message-queue/decorators/process.decorator';
+import { SdkClientGenerationService } from 'src/engine/core-modules/sdk-client/sdk-client-generation.service';
+
+export type GenerateSdkClientJobData = {
+  workspaceId: string;
+  applicationId: string;
+  applicationUniversalIdentifier: string;
+};
+
+@Processor(MessageQueue.workspaceQueue)
+export class GenerateSdkClientJob {
+  constructor(
+    private readonly sdkClientGenerationService: SdkClientGenerationService,
+  ) {}
+
+  @Process(GenerateSdkClientJob.name)
+  async handle(data: GenerateSdkClientJobData): Promise<void> {
+    await this.sdkClientGenerationService.generateSdkClientForApplication({
+      workspaceId: data.workspaceId,
+      applicationId: data.applicationId,
+      applicationUniversalIdentifier: data.applicationUniversalIdentifier,
+    });
+  }
+}

--- a/packages/twenty-server/src/engine/core-modules/sdk-client/jobs/generate-sdk-client.job.ts
+++ b/packages/twenty-server/src/engine/core-modules/sdk-client/jobs/generate-sdk-client.job.ts
@@ -1,3 +1,5 @@
+import { Logger } from '@nestjs/common';
+
 import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
 import { Process } from 'src/engine/core-modules/message-queue/decorators/process.decorator';
@@ -11,16 +13,25 @@ export type GenerateSdkClientJobData = {
 
 @Processor(MessageQueue.workspaceQueue)
 export class GenerateSdkClientJob {
+  private readonly logger = new Logger(GenerateSdkClientJob.name);
+
   constructor(
     private readonly sdkClientGenerationService: SdkClientGenerationService,
   ) {}
 
   @Process(GenerateSdkClientJob.name)
   async handle(data: GenerateSdkClientJobData): Promise<void> {
-    await this.sdkClientGenerationService.generateSdkClientForApplication({
-      workspaceId: data.workspaceId,
-      applicationId: data.applicationId,
-      applicationUniversalIdentifier: data.applicationUniversalIdentifier,
-    });
+    try {
+      await this.sdkClientGenerationService.generateSdkClientForApplication({
+        workspaceId: data.workspaceId,
+        applicationId: data.applicationId,
+        applicationUniversalIdentifier: data.applicationUniversalIdentifier,
+      });
+    } catch (error) {
+      this.logger.error(
+        `Failed to generate SDK client for application "${data.applicationUniversalIdentifier}" in workspace "${data.workspaceId}"`,
+        error instanceof Error ? error.stack : String(error),
+      );
+    }
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/sdk-client/sdk-client.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/sdk-client/sdk-client.module.ts
@@ -6,6 +6,7 @@ import { ApplicationEntity } from 'src/engine/core-modules/application/applicati
 import { SdkClientController } from 'src/engine/core-modules/sdk-client/controllers/sdk-client.controller';
 import { SdkClientArchiveService } from 'src/engine/core-modules/sdk-client/sdk-client-archive.service';
 import { SdkClientGenerationService } from 'src/engine/core-modules/sdk-client/sdk-client-generation.service';
+import { GenerateSdkClientJob } from 'src/engine/core-modules/sdk-client/jobs/generate-sdk-client.job';
 import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
 
 @Module({
@@ -15,7 +16,11 @@ import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache
     CoreGraphQLApiModule,
   ],
   controllers: [SdkClientController],
-  providers: [SdkClientGenerationService, SdkClientArchiveService],
+  providers: [
+    SdkClientGenerationService,
+    SdkClientArchiveService,
+    GenerateSdkClientJob,
+  ],
   exports: [SdkClientGenerationService, SdkClientArchiveService],
 })
 export class SdkClientModule {}

--- a/packages/twenty-server/src/engine/core-modules/sdk-client/sdk-client.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/sdk-client/sdk-client.module.ts
@@ -6,7 +6,6 @@ import { ApplicationEntity } from 'src/engine/core-modules/application/applicati
 import { SdkClientController } from 'src/engine/core-modules/sdk-client/controllers/sdk-client.controller';
 import { SdkClientArchiveService } from 'src/engine/core-modules/sdk-client/sdk-client-archive.service';
 import { SdkClientGenerationService } from 'src/engine/core-modules/sdk-client/sdk-client-generation.service';
-import { GenerateSdkClientJob } from 'src/engine/core-modules/sdk-client/jobs/generate-sdk-client.job';
 import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
 
 @Module({
@@ -16,11 +15,7 @@ import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache
     CoreGraphQLApiModule,
   ],
   controllers: [SdkClientController],
-  providers: [
-    SdkClientGenerationService,
-    SdkClientArchiveService,
-    GenerateSdkClientJob,
-  ],
+  providers: [SdkClientGenerationService, SdkClientArchiveService],
   exports: [SdkClientGenerationService, SdkClientArchiveService],
 })
 export class SdkClientModule {}

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-manager.module.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-manager.module.ts
@@ -3,7 +3,6 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { ApplicationModule } from 'src/engine/core-modules/application/application.module';
 import { FeatureFlagModule } from 'src/engine/core-modules/feature-flag/feature-flag.module';
-import { SdkClientModule } from 'src/engine/core-modules/sdk-client/sdk-client.module';
 import { UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AiAgentModule } from 'src/engine/metadata-modules/ai/ai-agent/ai-agent.module';
@@ -40,7 +39,6 @@ import { WorkspaceManagerService } from './workspace-manager.service';
     RoleModule,
     UserRoleModule,
     ApplicationModule,
-    SdkClientModule,
     TypeOrmModule.forFeature([
       FieldMetadataEntity,
       RoleTargetEntity,

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-manager.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-manager.service.ts
@@ -5,7 +5,13 @@ import { Repository } from 'typeorm';
 
 import { ApplicationService } from 'src/engine/core-modules/application/application.service';
 import { FlatApplication } from 'src/engine/core-modules/application/types/flat-application.type';
-import { SdkClientGenerationService } from 'src/engine/core-modules/sdk-client/sdk-client-generation.service';
+import { InjectMessageQueue } from 'src/engine/core-modules/message-queue/decorators/message-queue.decorator';
+import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
+import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
+import {
+  GenerateSdkClientJob,
+  GenerateSdkClientJobData,
+} from 'src/engine/core-modules/sdk-client/jobs/generate-sdk-client.job';
 import { UserWorkspaceEntity } from 'src/engine/core-modules/user-workspace/user-workspace.entity';
 import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { DataSourceService } from 'src/engine/metadata-modules/data-source/data-source.service';
@@ -33,7 +39,8 @@ export class WorkspaceManagerService {
     @InjectRepository(RoleEntity)
     private readonly roleRepository: Repository<RoleEntity>,
     private readonly applicationService: ApplicationService,
-    private readonly sdkClientGenerationService: SdkClientGenerationService,
+    @InjectMessageQueue(MessageQueue.workspaceQueue)
+    private readonly messageQueueService: MessageQueueService,
   ) {}
 
   public async init({
@@ -86,19 +93,25 @@ export class WorkspaceManagerService {
         },
       );
 
-    await this.sdkClientGenerationService.generateSdkClientForApplication({
-      workspaceId,
-      applicationId: twentyStandardFlatApplication.id,
-      applicationUniversalIdentifier:
-        twentyStandardFlatApplication.universalIdentifier,
-    });
+    await this.messageQueueService.add<GenerateSdkClientJobData>(
+      GenerateSdkClientJob.name,
+      {
+        workspaceId,
+        applicationId: twentyStandardFlatApplication.id,
+        applicationUniversalIdentifier:
+          twentyStandardFlatApplication.universalIdentifier,
+      },
+    );
 
-    await this.sdkClientGenerationService.generateSdkClientForApplication({
-      workspaceId,
-      applicationId: workspaceCustomFlatApplication.id,
-      applicationUniversalIdentifier:
-        workspaceCustomFlatApplication.universalIdentifier,
-    });
+    await this.messageQueueService.add<GenerateSdkClientJobData>(
+      GenerateSdkClientJob.name,
+      {
+        workspaceId,
+        applicationId: workspaceCustomFlatApplication.id,
+        applicationUniversalIdentifier:
+          workspaceCustomFlatApplication.universalIdentifier,
+      },
+    );
 
     await this.setupDefaultRoles({
       workspaceId,

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-manager.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-manager.service.ts
@@ -93,25 +93,26 @@ export class WorkspaceManagerService {
         },
       );
 
-    await this.messageQueueService.add<GenerateSdkClientJobData>(
-      GenerateSdkClientJob.name,
-      {
-        workspaceId,
-        applicationId: twentyStandardFlatApplication.id,
-        applicationUniversalIdentifier:
-          twentyStandardFlatApplication.universalIdentifier,
-      },
-    );
-
-    await this.messageQueueService.add<GenerateSdkClientJobData>(
-      GenerateSdkClientJob.name,
-      {
-        workspaceId,
-        applicationId: workspaceCustomFlatApplication.id,
-        applicationUniversalIdentifier:
-          workspaceCustomFlatApplication.universalIdentifier,
-      },
-    );
+    await Promise.all([
+      this.messageQueueService.add<GenerateSdkClientJobData>(
+        GenerateSdkClientJob.name,
+        {
+          workspaceId,
+          applicationId: twentyStandardFlatApplication.id,
+          applicationUniversalIdentifier:
+            twentyStandardFlatApplication.universalIdentifier,
+        },
+      ),
+      this.messageQueueService.add<GenerateSdkClientJobData>(
+        GenerateSdkClientJob.name,
+        {
+          workspaceId,
+          applicationId: workspaceCustomFlatApplication.id,
+          applicationUniversalIdentifier:
+            workspaceCustomFlatApplication.universalIdentifier,
+        },
+      ),
+    ]);
 
     await this.setupDefaultRoles({
       workspaceId,


### PR DESCRIPTION
Avoid overloading the workspace creation with the standard and custom app sdk generation, do through a job

```ts
[Nest] 90397  - 04/02/2026, 4:44:20 PM     LOG [CoreEntityCacheService] Cache stats: localCacheSize=0 memoizerCacheSize=0 memoizerPendingSize=0 entriesByKey={} versionsByKey={}
[Nest] 90397  - 04/02/2026, 4:45:03 PM     LOG [BullMQDriver] Processing job 4325 with name CallWebhookJobsForMetadataJob on queue webhook-queue
[Nest] 90397  - 04/02/2026, 4:45:03 PM     LOG [BullMQDriver] Processing job 1 with name GenerateSdkClientJob on queue workspace-queue
[Nest] 90397  - 04/02/2026, 4:45:03 PM     LOG [BullMQDriver] Job 1 with name GenerateSdkClientJob processed on queue workspace-queue in 0.64ms
[Nest] 90397  - 04/02/2026, 4:45:03 PM     LOG [BullMQDriver] Processing job 2 with name GenerateSdkClientJob on queue workspace-queue
[Nest] 90397  - 04/02/2026, 4:45:03 PM     LOG [BullMQDriver] Job 2 with name GenerateSdkClientJob processed on queue workspace-queue in 0.06ms
[Nest] 90397  - 04/02/2026, 4:45:03 PM     LOG [BullMQDriver] Job 4325 with name CallWebhookJobsForMetadataJob processed on queue webhook-queue in 17.47ms
[Nest] 90397  - 04/02/2026, 4:45:03 PM     LOG [BullMQDriver] Processing job 4326 with name CallWebhookJobsForMetadataJob on queue webhook-queue
```