### PR TITLE
Fix create e2e app ci set version flakiness

### DIFF
--- a/.github/workflows/ci-create-app-e2e.yaml
+++ b/.github/workflows/ci-create-app-e2e.yaml
@@ -66,7 +66,9 @@ jobs:
         run: |
           CI_VERSION="0.0.0-ci.$(date +%s)"
           echo "CI_VERSION=$CI_VERSION" >> $GITHUB_ENV
-          npx nx run-many -t set-local-version -p $PUBLISHABLE_PACKAGES --releaseVersion=$CI_VERSION
+          for pkg in $PUBLISHABLE_PACKAGES; do
+            npx nx run $pkg:set-local-version --releaseVersion=$CI_VERSION
+          done
 
       - name: Build packages
         run: |


### PR DESCRIPTION
Calling npm version in // with interdependent packages fait des chocapics

<img width="225" height="225" alt="image" src="https://github.com/user-attachments/assets/6d10e72a-87dc-4745-b078-7dd1b4706203" />
