### PR TITLE
Remove try catch from generate sdk client job

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/sdk-client/jobs/generate-sdk-client.job.ts
+++ b/packages/twenty-server/src/engine/core-modules/sdk-client/jobs/generate-sdk-client.job.ts
@@ -1,5 +1,3 @@
-import { Logger } from '@nestjs/common';
-
 import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
 import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
 import { Process } from 'src/engine/core-modules/message-queue/decorators/process.decorator';
@@ -13,25 +11,16 @@ export type GenerateSdkClientJobData = {
 
 @Processor(MessageQueue.workspaceQueue)
 export class GenerateSdkClientJob {
-  private readonly logger = new Logger(GenerateSdkClientJob.name);
-
   constructor(
     private readonly sdkClientGenerationService: SdkClientGenerationService,
   ) {}
 
   @Process(GenerateSdkClientJob.name)
   async handle(data: GenerateSdkClientJobData): Promise<void> {
-    try {
-      await this.sdkClientGenerationService.generateSdkClientForApplication({
-        workspaceId: data.workspaceId,
-        applicationId: data.applicationId,
-        applicationUniversalIdentifier: data.applicationUniversalIdentifier,
-      });
-    } catch (error) {
-      this.logger.error(
-        `Failed to generate SDK client for application "${data.applicationUniversalIdentifier}" in workspace "${data.workspaceId}"`,
-        error instanceof Error ? error.stack : String(error),
-      );
-    }
+    await this.sdkClientGenerationService.generateSdkClientForApplication({
+      workspaceId: data.workspaceId,
+      applicationId: data.applicationId,
+      applicationUniversalIdentifier: data.applicationUniversalIdentifier,
+    });
   }
 }

--- a/packages/twenty-server/src/engine/core-modules/sdk-client/sdk-client-generation.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/sdk-client/sdk-client-generation.service.ts
@@ -19,7 +19,8 @@ import {
   SdkClientException,
   SdkClientExceptionCode,
 } from 'src/engine/core-modules/sdk-client/exceptions/sdk-client.exception';
-import { FlatWorkspace } from 'src/engine/core-modules/workspace/types/flat-workspace.type';
+import { fromWorkspaceEntityToFlat } from 'src/engine/core-modules/workspace/utils/from-workspace-entity-to-flat.util';
+import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 
 const SDK_CLIENT_ARCHIVE_NAME = 'twenty-client-sdk.zip';
@@ -32,6 +33,8 @@ export class SdkClientGenerationService {
     private readonly fileStorageService: FileStorageService,
     @InjectRepository(ApplicationEntity)
     private readonly applicationRepository: Repository<ApplicationEntity>,
+    @InjectRepository(WorkspaceEntity)
+    private readonly workspaceRepository: Repository<WorkspaceEntity>,
     private readonly workspaceCacheService: WorkspaceCacheService,
     private readonly workspaceSchemaFactory: WorkspaceSchemaFactory,
   ) {}
@@ -45,8 +48,11 @@ export class SdkClientGenerationService {
     applicationId: string;
     applicationUniversalIdentifier: string;
   }): Promise<Buffer> {
+    const workspaceEntity =
+      await this.workspaceRepository.findOneByOrFail({ id: workspaceId });
+
     const graphqlSchema = await this.workspaceSchemaFactory.createGraphQLSchema(
-      { id: workspaceId } as FlatWorkspace,
+      fromWorkspaceEntityToFlat(workspaceEntity),
       applicationId,
     );
 

--- a/packages/twenty-server/src/engine/core-modules/sdk-client/sdk-client-generation.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/sdk-client/sdk-client-generation.service.ts
@@ -48,8 +48,9 @@ export class SdkClientGenerationService {
     applicationId: string;
     applicationUniversalIdentifier: string;
   }): Promise<Buffer> {
-    const workspaceEntity =
-      await this.workspaceRepository.findOneByOrFail({ id: workspaceId });
+    const workspaceEntity = await this.workspaceRepository.findOneByOrFail({
+      id: workspaceId,
+    });
 
     const graphqlSchema = await this.workspaceSchemaFactory.createGraphQLSchema(
       fromWorkspaceEntityToFlat(workspaceEntity),

--- a/packages/twenty-server/src/engine/core-modules/sdk-client/sdk-client.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/sdk-client/sdk-client.module.ts
@@ -6,11 +6,12 @@ import { ApplicationEntity } from 'src/engine/core-modules/application/applicati
 import { SdkClientController } from 'src/engine/core-modules/sdk-client/controllers/sdk-client.controller';
 import { SdkClientArchiveService } from 'src/engine/core-modules/sdk-client/sdk-client-archive.service';
 import { SdkClientGenerationService } from 'src/engine/core-modules/sdk-client/sdk-client-generation.service';
+import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([ApplicationEntity]),
+    TypeOrmModule.forFeature([ApplicationEntity, WorkspaceEntity]),
     WorkspaceCacheModule,
     CoreGraphQLApiModule,
   ],


### PR DESCRIPTION
Auto merged passed to fast on https://github.com/twentyhq/twenty/pull/19271

Try catch has been added while debugging an integration test suite covering the workspace creation that would fail due to sdk generation failure

As they're run synchronously in integration tests they would stop the workspace creation process

If the proposed fix here isn't enough I'll wrapp the run sync test to be catching any unexpected issue