### PR TITLE
Attempt - Fix api changes report ci

### DIFF
--- a/.github/workflows/ci-breaking-changes.yaml
+++ b/.github/workflows/ci-breaking-changes.yaml
@@ -228,7 +228,6 @@ jobs:
           echo "Current branch files downloaded:"
           ls -la current-*
 
-
       - name: Preserve current branch files
         run: |
           # Create a temp directory to store current branch files
@@ -290,7 +289,7 @@ jobs:
 
           set_env_var "PG_DATABASE_URL" "postgres://postgres:postgres@localhost:5432/main_branch"
           set_env_var "NODE_PORT" "${{ env.MAIN_SERVER_PORT }}"
-          set_env_var "REDIS_URL" "redis://localhost:6379"
+          set_env_var "REDIS_URL" "redis://localhost:6379/1"
           set_env_var "CLICKHOUSE_URL" "http://default:clickhousePassword@localhost:8123/twenty"
           set_env_var "CLICKHOUSE_PASSWORD" "clickhousePassword"
 
@@ -380,7 +379,6 @@ jobs:
           echo "Main branch files downloaded:"
           ls -la main-*
 
-
       - name: Restore current branch files
         run: |
           # Move current branch files back to working directory
@@ -399,11 +397,20 @@ jobs:
           valid=true
 
           for file in main-schema-introspection.json current-schema-introspection.json \
-                      main-metadata-schema-introspection.json current-metadata-schema-introspection.json \
-                      main-rest-api.json current-rest-api.json \
-                      main-rest-metadata-api.json current-rest-metadata-api.json; do
+                      main-metadata-schema-introspection.json current-metadata-schema-introspection.json; do
             if [ ! -f "$file" ] || ! jq empty "$file" 2>/dev/null; then
               echo "::warning::Invalid or missing schema file: $file"
+              valid=false
+            elif ! jq -e '.data.__schema' "$file" > /dev/null 2>&1; then
+              echo "::warning::Schema file is not a valid GraphQL introspection response: $file"
+              valid=false
+            fi
+          done
+
+          for file in main-rest-api.json current-rest-api.json \
+                      main-rest-metadata-api.json current-rest-metadata-api.json; do
+            if [ ! -f "$file" ] || ! jq empty "$file" 2>/dev/null; then
+              echo "::warning::Invalid or missing REST API file: $file"
               valid=false
             fi
           done

--- a/packages/twenty-server/src/engine/core-modules/email-verification/dtos/resend-email-verification-token.dto.ts
+++ b/packages/twenty-server/src/engine/core-modules/email-verification/dtos/resend-email-verification-token.dto.ts
@@ -7,4 +7,7 @@ export class ResendEmailVerificationTokenDTO {
   @IsBoolean()
   @Field(() => Boolean)
   success: boolean;
+
+  @Field(() => String, { nullable: true })
+  message?: string;
 }


### PR DESCRIPTION
redis://localhost:6379/1 — main branch server uses Redis DB 1 instead of DB 0. Fixes the root cause: the current branch server wrote workspace cache data to Redis (DB 0), the main branch server read it and failed because the format may differ. Using a separate DB means each server has an isolated cache.

validate-schemas — .data.__schema check — GraphQL introspection files are now validated for actual introspection content, not just valid JSON. The server was returning {"errors": [...]} (valid JSON, but no data.__schema), which slipped through the old jq empty check and caused graphql-inspector to fail with the confusing "Not valid JSON content" error.