### PR TITLE
fix(front): improve address formatting and expand kanban drop zone

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-board/components/RecordBoardColumns.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/components/RecordBoardColumns.tsx
@@ -1,11 +1,11 @@
 import { styled } from '@linaria/react';
 
+import { themeCssVariables } from 'twenty-ui/theme-constants';
+
 import { RecordBoardColumn } from '@/object-record/record-board/record-board-column/components/RecordBoardColumn';
 import { visibleRecordGroupIdsComponentFamilySelector } from '@/object-record/record-group/states/selectors/visibleRecordGroupIdsComponentFamilySelector';
 import { useAtomComponentFamilySelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentFamilySelectorValue';
 import { ViewType } from '@/views/types/ViewType';
-
-import { themeCssVariables } from 'twenty-ui/theme-constants';
 
 const StyledColumnContainer = styled.div`
   display: flex;

--- a/packages/twenty-front/src/modules/object-record/record-board/components/RecordBoardColumns.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-board/components/RecordBoardColumns.tsx
@@ -1,12 +1,16 @@
+import { styled } from '@linaria/react';
+
 import { RecordBoardColumn } from '@/object-record/record-board/record-board-column/components/RecordBoardColumn';
 import { visibleRecordGroupIdsComponentFamilySelector } from '@/object-record/record-group/states/selectors/visibleRecordGroupIdsComponentFamilySelector';
 import { useAtomComponentFamilySelectorValue } from '@/ui/utilities/state/jotai/hooks/useAtomComponentFamilySelectorValue';
 import { ViewType } from '@/views/types/ViewType';
-import { styled } from '@linaria/react';
+
 import { themeCssVariables } from 'twenty-ui/theme-constants';
 
 const StyledColumnContainer = styled.div`
   display: flex;
+  flex: 1;
+  min-height: 100%;
 
   & > *:not(:first-of-type) {
     border-left: 1px solid ${themeCssVariables.border.color.light};

--- a/packages/twenty-front/src/utils/__tests__/joinAddressFieldValues.test.ts
+++ b/packages/twenty-front/src/utils/__tests__/joinAddressFieldValues.test.ts
@@ -1,4 +1,5 @@
 import { type FieldAddressValue } from '@/object-record/record-field/ui/types/FieldMetadata';
+
 import { joinAddressFieldValues } from '~/utils/joinAddressFieldValues';
 
 describe('joinAddressFieldValues', () => {
@@ -19,7 +20,7 @@ describe('joinAddressFieldValues', () => {
       'addressCity',
       'addressState',
     ]);
-    expect(result).toBe('123 Main St,New York,NY');
+    expect(result).toBe('123 Main St, New York, NY');
   });
 
   it('should filter out null and empty string values', () => {
@@ -42,7 +43,7 @@ describe('joinAddressFieldValues', () => {
       'addressPostcode',
       'addressCountry',
     ]);
-    expect(result).toBe('456 Oak Ave,CA,90210');
+    expect(result).toBe('456 Oak Ave, CA, 90210');
   });
 
   it('should handle empty subFields array', () => {
@@ -64,7 +65,7 @@ describe('joinAddressFieldValues', () => {
       'addressPostcode',
       'addressCountry',
     ]);
-    expect(result).toBe('123 Main St,Apt 4B,New York,NY,10001,United States');
+    expect(result).toBe('123 Main St, Apt 4B, New York, NY, 10001, United States');
   });
 
   it('should handle address with empty and null values', () => {
@@ -110,6 +111,6 @@ describe('joinAddressFieldValues', () => {
       'addressState',
       'addressPostcode',
     ]);
-    expect(result).toBe('123 Main St,New York,10001');
+    expect(result).toBe('123 Main St, New York, 10001');
   });
 });

--- a/packages/twenty-front/src/utils/__tests__/joinAddressFieldValues.test.ts
+++ b/packages/twenty-front/src/utils/__tests__/joinAddressFieldValues.test.ts
@@ -1,4 +1,4 @@
-import { type FieldAddressValue } from '@/object-record/record-field/ui/types/FieldMetadata';
+import type { FieldAddressValue } from '@/object-record/record-field/ui/types/FieldMetadata';
 
 import { joinAddressFieldValues } from '~/utils/joinAddressFieldValues';
 

--- a/packages/twenty-front/src/utils/__tests__/joinAddressFieldValues.test.ts
+++ b/packages/twenty-front/src/utils/__tests__/joinAddressFieldValues.test.ts
@@ -65,7 +65,9 @@ describe('joinAddressFieldValues', () => {
       'addressPostcode',
       'addressCountry',
     ]);
-    expect(result).toBe('123 Main St, Apt 4B, New York, NY, 10001, United States');
+    expect(result).toBe(
+      '123 Main St, Apt 4B, New York, NY, 10001, United States',
+    );
   });
 
   it('should handle address with empty and null values', () => {

--- a/packages/twenty-front/src/utils/joinAddressFieldValues.ts
+++ b/packages/twenty-front/src/utils/joinAddressFieldValues.ts
@@ -1,5 +1,7 @@
-import { type FieldAddressValue } from '@/object-record/record-field/ui/types/FieldMetadata';
 import { isNonEmptyString } from '@sniptt/guards';
+
+import { type FieldAddressValue } from '@/object-record/record-field/ui/types/FieldMetadata';
+
 import { type AllowedAddressSubField } from 'twenty-shared/types';
 
 export const joinAddressFieldValues = (
@@ -9,5 +11,5 @@ export const joinAddressFieldValues = (
   return subFields
     .map((subField) => fieldValue[subField])
     .filter(isNonEmptyString)
-    .join(',');
+    .join(', ');
 };

--- a/packages/twenty-front/src/utils/joinAddressFieldValues.ts
+++ b/packages/twenty-front/src/utils/joinAddressFieldValues.ts
@@ -1,8 +1,8 @@
 import { isNonEmptyString } from '@sniptt/guards';
 
-import { type FieldAddressValue } from '@/object-record/record-field/ui/types/FieldMetadata';
+import type { FieldAddressValue } from '@/object-record/record-field/ui/types/FieldMetadata';
 
-import { type AllowedAddressSubField } from 'twenty-shared/types';
+import type { AllowedAddressSubField } from 'twenty-shared/types';
 
 export const joinAddressFieldValues = (
   fieldValue: FieldAddressValue,

--- a/packages/twenty-front/src/utils/joinAddressFieldValues.ts
+++ b/packages/twenty-front/src/utils/joinAddressFieldValues.ts
@@ -1,8 +1,8 @@
 import { isNonEmptyString } from '@sniptt/guards';
 
-import type { FieldAddressValue } from '@/object-record/record-field/ui/types/FieldMetadata';
-
 import type { AllowedAddressSubField } from 'twenty-shared/types';
+
+import type { FieldAddressValue } from '@/object-record/record-field/ui/types/FieldMetadata';
 
 export const joinAddressFieldValues = (
   fieldValue: FieldAddressValue,


### PR DESCRIPTION
Improve address formatting by adding spaces after commas and expand Kanban drop zone to 100% height. Resolves #18860 and #18842.