### PR TITLE
fix(server): refine upsert matching logic for composite fields

### DIFF
--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-create-many-query-runner/utils/get-matching-record-id.util.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-create-many-query-runner/utils/get-matching-record-id.util.ts
@@ -1,4 +1,5 @@
 import { msg } from '@lingui/core/macro';
+
 import { type ObjectRecord } from 'twenty-shared/types';
 import { isDefined } from 'twenty-shared/utils';
 
@@ -20,6 +21,10 @@ export const getMatchingRecordId = (
 ): string | undefined => {
   const matchingRecordIds = conflictingFields.reduce<string[]>((acc, field) => {
     const requestFieldValue = getValueFromPath(record, field.fullPath);
+
+    if (!isDefined(requestFieldValue)) {
+      return acc;
+    }
 
     const matchingRecord = existingRecords.find((existingRecord) => {
       const existingFieldValue = getValueFromPath(


### PR DESCRIPTION
Refine upsert matching logic to correctly handle composite field types and prevent duplicate errors. Resolves #18084.