### PR TITLE
fix(zapier): add currentWorkspace field to minimalMetadata for auth (v2)

### DIFF
--- a/packages/twenty-server/src/engine/metadata-modules/minimal-metadata/dtos/minimal-metadata.dto.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/minimal-metadata/dtos/minimal-metadata.dto.ts
@@ -1,5 +1,6 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 
+import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { CollectionHashDTO } from 'src/engine/metadata-modules/minimal-metadata/dtos/collection-hash.dto';
 import { MinimalObjectMetadataDTO } from 'src/engine/metadata-modules/minimal-metadata/dtos/minimal-object-metadata.dto';
 import { MinimalViewDTO } from 'src/engine/metadata-modules/minimal-metadata/dtos/minimal-view.dto';
@@ -14,4 +15,7 @@ export class MinimalMetadataDTO {
 
   @Field(() => [CollectionHashDTO])
   collectionHashes: CollectionHashDTO[];
+
+  @Field(() => WorkspaceEntity, { nullable: true })
+  currentWorkspace?: WorkspaceEntity;
 }

--- a/packages/twenty-server/src/engine/metadata-modules/minimal-metadata/minimal-metadata.module.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/minimal-metadata/minimal-metadata.module.ts
@@ -4,9 +4,14 @@ import { WorkspaceManyOrAllFlatEntityMapsCacheModule } from 'src/engine/metadata
 import { MinimalMetadataResolver } from 'src/engine/metadata-modules/minimal-metadata/minimal-metadata.resolver';
 import { MinimalMetadataService } from 'src/engine/metadata-modules/minimal-metadata/minimal-metadata.service';
 import { WorkspaceCacheModule } from 'src/engine/workspace-cache/workspace-cache.module';
+import { WorkspaceModule } from 'src/engine/core-modules/workspace/workspace.module';
 
 @Module({
-  imports: [WorkspaceManyOrAllFlatEntityMapsCacheModule, WorkspaceCacheModule],
+  imports: [
+    WorkspaceManyOrAllFlatEntityMapsCacheModule,
+    WorkspaceCacheModule,
+    WorkspaceModule,
+  ],
   providers: [MinimalMetadataResolver, MinimalMetadataService],
   exports: [MinimalMetadataService],
 })

--- a/packages/twenty-server/src/engine/metadata-modules/minimal-metadata/minimal-metadata.resolver.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/minimal-metadata/minimal-metadata.resolver.ts
@@ -1,10 +1,11 @@
 import { UseGuards } from '@nestjs/common';
-import { Query } from '@nestjs/graphql';
+import { Query, ResolveField } from '@nestjs/graphql';
 
 import { MetadataResolver } from 'src/engine/api/graphql/graphql-config/decorators/metadata-resolver.decorator';
-import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { AuthUserWorkspaceId } from 'src/engine/decorators/auth/auth-user-workspace-id.decorator';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
+import { WorkspaceService } from 'src/engine/core-modules/workspace/services/workspace.service';
+import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
 import { NoPermissionGuard } from 'src/engine/guards/no-permission.guard';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { MinimalMetadataDTO } from 'src/engine/metadata-modules/minimal-metadata/dtos/minimal-metadata.dto';
@@ -15,6 +16,7 @@ import { MinimalMetadataService } from 'src/engine/metadata-modules/minimal-meta
 export class MinimalMetadataResolver {
   constructor(
     private readonly minimalMetadataService: MinimalMetadataService,
+    private readonly workspaceService: WorkspaceService,
   ) {}
 
   @Query(() => MinimalMetadataDTO)
@@ -27,5 +29,18 @@ export class MinimalMetadataResolver {
       workspace.id,
       userWorkspaceId,
     );
+  }
+
+  @ResolveField(() => WorkspaceEntity)
+  async currentWorkspace(
+    @AuthWorkspace() { id }: WorkspaceEntity,
+  ): Promise<WorkspaceEntity> {
+    const workspace = await this.workspaceService.findById(id);
+
+    if (!workspace) {
+      throw new Error('Workspace not found');
+    }
+
+    return workspace;
   }
 }


### PR DESCRIPTION
Add currentWorkspace field to MinimalMetadata GraphQL type to resolve authentication failures in Zapier integration. Resolves #18311.