### PR TITLE
fix: replace npm pkg set with node script in set-local-version target

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -141,7 +141,7 @@
       "cache": false,
       "options": {
         "cwd": "{projectRoot}",
-        "command": "npm pkg set version={args.releaseVersion}"
+        "command": "node -e \"const fs=require('fs'),p=JSON.parse(fs.readFileSync('package.json','utf8'));p.version='{args.releaseVersion}';fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n');\""
       }
     },
     "storybook:build": {


### PR DESCRIPTION
## Summary

- Replaces `npm pkg set version=X` with a direct `node -e` script in the `set-local-version` Nx target
- Fixes `CI Create App E2E minimal` workflow failures on fork PRs where `npm pkg set` fails with `EJSONPARSE: Unexpected end of JSON input while parsing empty string`

The `npm` command has unreliable `package.json` resolution in certain CI checkout contexts (shallow clones of fork PR merge refs). Using `node` directly to read/write the JSON file avoids this entirely.

