### PR TITLE
feat: allow custom app tabs on system object record pages

### DIFF
--- a/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabsRenderer.tsx
+++ b/packages/twenty-front/src/modules/page-layout/components/PageLayoutTabsRenderer.tsx
@@ -133,9 +133,16 @@ export const PageLayoutTabsRenderer = () => {
 
   const SYSTEM_OBJECT_TABS = ['Home', 'Timeline', 'Overview', 'Flow'];
 
+  const hasCustomAppWidget = (tab: { widgets: Array<{ type: string }> }) =>
+    tab.widgets.some(
+      (widget) =>
+        widget.type === 'FRONT_COMPONENT' || widget.type === 'IFRAME',
+    );
+
   const tabsForCurrentObject = isSystemObject
-    ? tabsWithVisibleWidgets.filter((tab) =>
-        SYSTEM_OBJECT_TABS.includes(tab.title),
+    ? tabsWithVisibleWidgets.filter(
+        (tab) =>
+          SYSTEM_OBJECT_TABS.includes(tab.title) || hasCustomAppWidget(tab),
       )
     : tabsWithVisibleWidgets;
 

--- a/packages/twenty-server/src/engine/metadata-modules/page-layout-widget/utils/validate-widget-configuration-input.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/page-layout-widget/utils/validate-widget-configuration-input.util.ts
@@ -138,40 +138,13 @@ export const validateWidgetConfigurationInput = ({
         PageLayoutWidgetExceptionCode.INVALID_PAGE_LAYOUT_WIDGET_DATA,
       );
     case WidgetConfigurationType.FIELDS:
-      throw new PageLayoutWidgetException(
-        'Fields configuration is not supported yet',
-        PageLayoutWidgetExceptionCode.INVALID_PAGE_LAYOUT_WIDGET_DATA,
-      );
     case WidgetConfigurationType.TIMELINE:
-      throw new PageLayoutWidgetException(
-        'Timeline configuration is not supported yet',
-        PageLayoutWidgetExceptionCode.INVALID_PAGE_LAYOUT_WIDGET_DATA,
-      );
     case WidgetConfigurationType.TASKS:
-      throw new PageLayoutWidgetException(
-        'Tasks configuration is not supported yet',
-        PageLayoutWidgetExceptionCode.INVALID_PAGE_LAYOUT_WIDGET_DATA,
-      );
     case WidgetConfigurationType.NOTES:
-      throw new PageLayoutWidgetException(
-        'Notes configuration is not supported yet',
-        PageLayoutWidgetExceptionCode.INVALID_PAGE_LAYOUT_WIDGET_DATA,
-      );
     case WidgetConfigurationType.FILES:
-      throw new PageLayoutWidgetException(
-        'Files configuration is not supported yet',
-        PageLayoutWidgetExceptionCode.INVALID_PAGE_LAYOUT_WIDGET_DATA,
-      );
     case WidgetConfigurationType.EMAILS:
-      throw new PageLayoutWidgetException(
-        'Emails configuration is not supported yet',
-        PageLayoutWidgetExceptionCode.INVALID_PAGE_LAYOUT_WIDGET_DATA,
-      );
     case WidgetConfigurationType.CALENDAR:
-      throw new PageLayoutWidgetException(
-        'Calendar configuration is not supported yet',
-        PageLayoutWidgetExceptionCode.INVALID_PAGE_LAYOUT_WIDGET_DATA,
-      );
+      break;
     case WidgetConfigurationType.FIELD_RICH_TEXT:
       throw new PageLayoutWidgetException(
         'Field rich text configuration is not supported yet',


### PR DESCRIPTION
Currently, the Page Layout SDK allows defining custom tabs with FRONT_COMPONENT or IFRAME widgets via `definePageLayout`, but two blockers prevent them from appearing on system objects (Company, Opportunity, etc.):

1. Frontend: `PageLayoutTabsRenderer` filters tabs on system objects to a hardcoded allowlist (Home, Timeline, Overview, Flow), hiding any custom app tabs. This patch extends the filter to also show tabs containing FRONT_COMPONENT or IFRAME widgets.

2. Backend: `validateWidgetConfigurationInput` throws "not supported yet" for FIELDS, TIMELINE, TASKS, NOTES, FILES, EMAILS, and CALENDAR widget types, blocking SDK apps from defining page layouts that include these standard record page widgets alongside custom components. This patch allows these types to pass validation.

These changes enable Twenty SDK apps to add custom tabs to system object record pages — a common use case for CRM extensions (e.g., deal item builders, document generators on Opportunity pages).