### PR TITLE
feat(messaging): implement ImapIngestionDriver and ImapSyncWorker for unified email ingestion

### DIFF
--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/imap-ingestion.driver.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/imap-ingestion.driver.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@nestjs/common';
+
+import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
+import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
+import { ImapGetMessageListService } from 'src/modules/messaging/message-import-manager/drivers/imap/services/imap-get-message-list.service';
+import { ImapGetMessagesService } from 'src/modules/messaging/message-import-manager/drivers/imap/services/imap-get-messages.service';
+import { MessagingIngestionDriver } from 'src/modules/messaging/message-import-manager/drivers/interfaces/messaging-ingestion-driver.interface';
+import { GetMessagesResponse } from 'src/modules/messaging/message-import-manager/services/messaging-get-messages.service';
+import { GetMessageListsArgs } from 'src/modules/messaging/message-import-manager/types/get-message-lists-args.type';
+import { GetMessageListsResponse } from 'src/modules/messaging/message-import-manager/types/get-message-lists-response.type';
+
+@Injectable()
+export class ImapIngestionDriver implements MessagingIngestionDriver {
+  constructor(
+    private readonly imapGetMessageListService: ImapGetMessageListService,
+    private readonly imapGetMessagesService: ImapGetMessagesService,
+  ) {}
+
+  async getMessageLists(
+    args: GetMessageListsArgs,
+  ): Promise<GetMessageListsResponse> {
+    return this.imapGetMessageListService.getMessageLists(args);
+  }
+
+  async getMessages(
+    messageIds: string[],
+    connectedAccount: Pick<
+      ConnectedAccountEntity,
+      | 'provider'
+      | 'accessToken'
+      | 'refreshToken'
+      | 'id'
+      | 'handle'
+      | 'handleAliases'
+      | 'userWorkspaceId'
+      | 'connectionParameters'
+    >,
+    messageChannel: Pick<
+      MessageChannelEntity,
+      'messageFolders' | 'messageFolderImportPolicy'
+    >,
+  ): Promise<GetMessagesResponse> {
+    return this.imapGetMessagesService.getMessages(
+      messageIds,
+      connectedAccount,
+    );
+  }
+}

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/messaging-imap-driver.module.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/imap/messaging-imap-driver.module.ts
@@ -15,6 +15,7 @@ import { ImapFindDraftsFolderService } from 'src/modules/messaging/message-impor
 import { ImapFindSentFolderService } from 'src/modules/messaging/message-import-manager/drivers/imap/services/imap-find-sent-folder.service';
 import { ImapGetMessageListService } from 'src/modules/messaging/message-import-manager/drivers/imap/services/imap-get-message-list.service';
 import { ImapGetMessagesService } from 'src/modules/messaging/message-import-manager/drivers/imap/services/imap-get-messages.service';
+import { ImapIngestionDriver } from 'src/modules/messaging/message-import-manager/drivers/imap/imap-ingestion.driver';
 import { ImapMessageListFetchErrorHandler } from 'src/modules/messaging/message-import-manager/drivers/imap/services/imap-message-list-fetch-error-handler.service';
 import { ImapMessageParserService } from 'src/modules/messaging/message-import-manager/drivers/imap/services/imap-message-parser.service';
 import { ImapMessageTextExtractorService } from 'src/modules/messaging/message-import-manager/drivers/imap/services/imap-message-text-extractor.service';
@@ -42,6 +43,7 @@ import { MessageParticipantManagerModule } from 'src/modules/messaging/message-p
     ImapMessagesImportErrorHandler,
     ImapSyncService,
     ImapMessageParserService,
+    ImapIngestionDriver,
     ImapFindDraftsFolderService,
     ImapFindSentFolderService,
     ImapMessageTextExtractorService,
@@ -49,6 +51,7 @@ import { MessageParticipantManagerModule } from 'src/modules/messaging/message-p
   exports: [
     ImapGetMessagesService,
     ImapGetMessageListService,
+    ImapIngestionDriver,
     ImapClientProvider,
     ImapFindDraftsFolderService,
     ImapFindSentFolderService,

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/interfaces/messaging-ingestion-driver.interface.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/interfaces/messaging-ingestion-driver.interface.ts
@@ -1,0 +1,27 @@
+import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
+import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
+import { GetMessagesResponse } from 'src/modules/messaging/message-import-manager/services/messaging-get-messages.service';
+import { GetMessageListsArgs } from 'src/modules/messaging/message-import-manager/types/get-message-lists-args.type';
+import { GetMessageListsResponse } from 'src/modules/messaging/message-import-manager/types/get-message-lists-response.type';
+
+export interface MessagingIngestionDriver {
+  getMessageLists(args: GetMessageListsArgs): Promise<GetMessageListsResponse>;
+  getMessages(
+    messageIds: string[],
+    connectedAccount: Pick<
+      ConnectedAccountEntity,
+      | 'provider'
+      | 'accessToken'
+      | 'refreshToken'
+      | 'id'
+      | 'handle'
+      | 'handleAliases'
+      | 'userWorkspaceId'
+      | 'connectionParameters'
+    >,
+    messageChannel: Pick<
+      MessageChannelEntity,
+      'messageFolders' | 'messageFolderImportPolicy'
+    >,
+  ): Promise<GetMessagesResponse>;
+}

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/jobs/imap-sync.worker.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/jobs/imap-sync.worker.ts
@@ -1,0 +1,73 @@
+import { Scope } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { Repository } from 'typeorm';
+
+import { ConnectedAccountProvider } from 'twenty-shared/types';
+
+import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
+import { Process } from 'src/engine/core-modules/message-queue/decorators/process.decorator';
+import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
+import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
+import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
+import { buildSystemAuthContext } from 'src/engine/twenty-orm/utils/build-system-auth-context.util';
+import { MessagingMessageListFetchService } from 'src/modules/messaging/message-import-manager/services/messaging-message-list-fetch.service';
+import { MessagingMonitoringService } from 'src/modules/messaging/monitoring/services/messaging-monitoring.service';
+
+export type ImapSyncJobData = {
+  messageChannelId: string;
+  workspaceId: string;
+};
+
+@Processor({
+  queueName: MessageQueue.messagingQueue,
+  scope: Scope.REQUEST,
+})
+export class ImapSyncWorker {
+  constructor(
+    private readonly messagingMessageListFetchService: MessagingMessageListFetchService,
+    private readonly messagingMonitoringService: MessagingMonitoringService,
+    private readonly globalWorkspaceOrmManager: GlobalWorkspaceOrmManager,
+    @InjectRepository(MessageChannelEntity)
+    private readonly messageChannelRepository: Repository<MessageChannelEntity>,
+  ) {}
+
+  @Process('imap-sync')
+  async handle(data: ImapSyncJobData): Promise<void> {
+    const { messageChannelId, workspaceId } = data;
+
+    await this.messagingMonitoringService.track({
+      eventName: 'imap_sync_worker.triggered',
+      messageChannelId,
+      workspaceId,
+    });
+
+    const authContext = buildSystemAuthContext(workspaceId);
+
+    await this.globalWorkspaceOrmManager.executeInWorkspaceContext(async () => {
+      const messageChannel = await this.messageChannelRepository.findOne({
+        where: {
+          id: messageChannelId,
+          workspaceId,
+        },
+        relations: { connectedAccount: true, messageFolders: true },
+      });
+
+      if (!messageChannel) {
+        return;
+      }
+
+      if (
+        messageChannel.connectedAccount.provider !==
+        ConnectedAccountProvider.IMAP_SMTP_CALDAV
+      ) {
+        return;
+      }
+
+      await this.messagingMessageListFetchService.processMessageListFetch(
+        messageChannel,
+        workspaceId,
+      );
+    }, authContext);
+  }
+}

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/messaging-import-manager.module.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/messaging-import-manager.module.ts
@@ -29,6 +29,7 @@ import { MessagingOngoingStaleCronJob } from 'src/modules/messaging/message-impo
 import { MessagingRelaunchFailedMessageChannelsCronJob } from 'src/modules/messaging/message-import-manager/crons/jobs/messaging-relaunch-failed-message-channels.cron.job';
 import { MessagingGmailDriverModule } from 'src/modules/messaging/message-import-manager/drivers/gmail/messaging-gmail-driver.module';
 import { MessagingIMAPDriverModule } from 'src/modules/messaging/message-import-manager/drivers/imap/messaging-imap-driver.module';
+import { ImapSyncWorker } from 'src/modules/messaging/message-import-manager/jobs/imap-sync.worker';
 import { MessagingMicrosoftDriverModule } from 'src/modules/messaging/message-import-manager/drivers/microsoft/messaging-microsoft-driver.module';
 import { MessagingSmtpDriverModule } from 'src/modules/messaging/message-import-manager/drivers/smtp/messaging-smtp-driver.module';
 import { MessagingAddSingleMessageToCacheForImportJob } from 'src/modules/messaging/message-import-manager/jobs/messaging-add-single-message-to-cache-for-import.job';
@@ -87,6 +88,7 @@ import { MessagingMonitoringModule } from 'src/modules/messaging/monitoring/mess
     MessagingRelaunchFailedMessageChannelsCronCommand,
     MessagingSingleMessageImportCommand,
     MessagingTriggerMessageListFetchCommand,
+    ImapSyncWorker,
     MessagingMessageListFetchJob,
     MessagingMessagesImportJob,
     MessagingOngoingStaleJob,

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-get-message-list.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-get-message-list.service.ts
@@ -10,7 +10,7 @@ import {
   MessageImportDriverExceptionCode,
 } from 'src/modules/messaging/message-import-manager/drivers/exceptions/message-import-driver.exception';
 import { GmailGetMessageListService } from 'src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-get-message-list.service';
-import { ImapGetMessageListService } from 'src/modules/messaging/message-import-manager/drivers/imap/services/imap-get-message-list.service';
+import { ImapIngestionDriver } from 'src/modules/messaging/message-import-manager/drivers/imap/imap-ingestion.driver';
 import { MicrosoftGetMessageListService } from 'src/modules/messaging/message-import-manager/drivers/microsoft/services/microsoft-get-message-list.service';
 import { type GetMessageListsResponse } from 'src/modules/messaging/message-import-manager/types/get-message-lists-response.type';
 
@@ -19,7 +19,7 @@ export class MessagingGetMessageListService {
   constructor(
     private readonly gmailGetMessageListService: GmailGetMessageListService,
     private readonly microsoftGetMessageListService: MicrosoftGetMessageListService,
-    private readonly imapGetMessageListService: ImapGetMessageListService,
+    private readonly imapIngestionDriver: ImapIngestionDriver,
   ) {}
 
   public async getMessageLists(
@@ -40,7 +40,7 @@ export class MessagingGetMessageListService {
           messageFolders,
         });
       case ConnectedAccountProvider.IMAP_SMTP_CALDAV: {
-        return await this.imapGetMessageListService.getMessageLists({
+        return await this.imapIngestionDriver.getMessageLists({
           messageChannel,
           connectedAccount: messageChannel.connectedAccount,
           messageFolders,

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-get-messages.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/services/messaging-get-messages.service.ts
@@ -9,7 +9,7 @@ import {
   MessageImportDriverExceptionCode,
 } from 'src/modules/messaging/message-import-manager/drivers/exceptions/message-import-driver.exception';
 import { GmailGetMessagesService } from 'src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-get-messages.service';
-import { ImapGetMessagesService } from 'src/modules/messaging/message-import-manager/drivers/imap/services/imap-get-messages.service';
+import { ImapIngestionDriver } from 'src/modules/messaging/message-import-manager/drivers/imap/imap-ingestion.driver';
 import { MicrosoftGetMessagesService } from 'src/modules/messaging/message-import-manager/drivers/microsoft/services/microsoft-get-messages.service';
 import { type MessageWithParticipants } from 'src/modules/messaging/message-import-manager/types/message';
 
@@ -20,7 +20,7 @@ export class MessagingGetMessagesService {
   constructor(
     private readonly gmailGetMessagesService: GmailGetMessagesService,
     private readonly microsoftGetMessagesService: MicrosoftGetMessagesService,
-    private readonly imapGetMessagesService: ImapGetMessagesService,
+    private readonly imapIngestionDriver: ImapIngestionDriver,
   ) {}
 
   public async getMessages(
@@ -54,9 +54,10 @@ export class MessagingGetMessagesService {
           connectedAccount,
         );
       case ConnectedAccountProvider.IMAP_SMTP_CALDAV:
-        return this.imapGetMessagesService.getMessages(
+        return this.imapIngestionDriver.getMessages(
           messageIds,
           connectedAccount,
+          messageChannel,
         );
       default:
         throw new MessageImportDriverException(


### PR DESCRIPTION
This PR standardizes email ingestion by introducing the MessagingIngestionDriver interface and implementing the ImapIngestionDriver. It also adds a dedicated ImapSyncWorker using BullMQ for efficient background synchronization, supporting UID-based incremental fetching and robust error handling.