### PR TITLE
fix: merge preview blank page when dry-run relation loading fails

### DIFF
--- a/packages/twenty-front/src/modules/object-record/hooks/useMergeManyRecords.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useMergeManyRecords.ts
@@ -85,10 +85,9 @@ export const useMergeManyRecords = <
             conflictPriorityIndex: mergeSettings.conflictPriorityIndex,
             dryRun: preview,
           },
-          // Prevent cache updates during dry run to avoid overwriting original record data
+          // no-cache prevents dry-run data from overwriting live records in Apollo cache
           ...(preview && {
             fetchPolicy: 'no-cache',
-            errorPolicy: 'ignore',
           }),
           refetchQueries: [
             getOperationName(findOneRecordQuery) ?? '',

--- a/packages/twenty-front/src/modules/object-record/record-merge/components/MergePreviewTab.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-merge/components/MergePreviewTab.tsx
@@ -2,7 +2,15 @@ import { usePerformMergePreview } from '@/object-record/record-merge/hooks/usePe
 import { PageLayoutSingleTabRenderer } from '@/page-layout/components/PageLayoutSingleTabRenderer';
 import { usePageLayoutIdForRecord } from '@/page-layout/hooks/usePageLayoutIdForRecord';
 import { LayoutRenderingProvider } from '@/ui/layout/contexts/LayoutRenderingContext';
+import { Trans } from '@lingui/react/macro';
 import { isDefined } from 'twenty-shared/utils';
+import {
+  AnimatedPlaceholder,
+  AnimatedPlaceholderErrorContainer,
+  AnimatedPlaceholderErrorSubTitle,
+  AnimatedPlaceholderErrorTextContainer,
+  AnimatedPlaceholderErrorTitle,
+} from 'twenty-ui/layout';
 import { PageLayoutType } from '~/generated-metadata/graphql';
 
 type MergePreviewTabProps = {
@@ -12,14 +20,33 @@ type MergePreviewTabProps = {
 export const MergePreviewTab = ({
   objectNameSingular,
 }: MergePreviewTabProps) => {
-  const { mergePreviewRecord, isGeneratingPreview } = usePerformMergePreview({
-    objectNameSingular,
-  });
+  const { mergePreviewRecord, isGeneratingPreview, previewError } =
+    usePerformMergePreview({
+      objectNameSingular,
+    });
 
   const { pageLayoutId } = usePageLayoutIdForRecord({
     id: mergePreviewRecord?.id ?? '',
     targetObjectNameSingular: objectNameSingular,
   });
+
+  if (isDefined(previewError)) {
+    return (
+      <AnimatedPlaceholderErrorContainer>
+        <AnimatedPlaceholder type="noRecord" />
+        <AnimatedPlaceholderErrorTextContainer>
+          <AnimatedPlaceholderErrorTitle>
+            <Trans>Preview unavailable</Trans>
+          </AnimatedPlaceholderErrorTitle>
+          <AnimatedPlaceholderErrorSubTitle>
+            <Trans>
+              Unable to generate a merge preview. Try again or merge directly.
+            </Trans>
+          </AnimatedPlaceholderErrorSubTitle>
+        </AnimatedPlaceholderErrorTextContainer>
+      </AnimatedPlaceholderErrorContainer>
+    );
+  }
 
   if (
     !isDefined(mergePreviewRecord) ||

--- a/packages/twenty-front/src/modules/object-record/record-merge/hooks/__tests__/usePerformMergePreview.test.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-merge/hooks/__tests__/usePerformMergePreview.test.tsx
@@ -1,0 +1,81 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+import { getJestMetadataAndApolloMocksWrapper } from '~/testing/jest/getJestMetadataAndApolloMocksWrapper';
+
+const mockMergeManyRecords = jest.fn();
+
+jest.mock('@/object-record/hooks/useMergeManyRecords', () => ({
+  useMergeManyRecords: () => ({
+    mergeManyRecords: mockMergeManyRecords,
+    loading: false,
+  }),
+}));
+
+jest.mock(
+  '@/object-record/record-merge/hooks/useMergeRecordsSelectedRecords',
+  () => ({
+    useMergeRecordsSelectedRecords: () => ({
+      selectedRecords: [
+        { id: 'rec-1', name: 'Record A' },
+        { id: 'rec-2', name: 'Record B' },
+      ],
+    }),
+  }),
+);
+
+jest.mock('@/object-record/record-store/hooks/useUpsertRecordsInStore', () => ({
+  useUpsertRecordsInStore: () => ({
+    upsertRecordsInStore: jest.fn(),
+  }),
+}));
+
+jest.mock('@/object-record/cache/utils/getRecordFromRecordNode', () => ({
+  getRecordFromRecordNode: (args: { recordNode: any }) => args.recordNode,
+}));
+
+import { usePerformMergePreview } from '@/object-record/record-merge/hooks/usePerformMergePreview';
+
+const Wrapper = getJestMetadataAndApolloMocksWrapper({
+  apolloMocks: [],
+});
+
+describe('usePerformMergePreview', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should expose previewError when mergeManyRecords rejects', async () => {
+    mockMergeManyRecords.mockRejectedValue(new Error('Server error'));
+
+    const { result } = renderHook(
+      () => usePerformMergePreview({ objectNameSingular: 'company' }),
+      { wrapper: Wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isGeneratingPreview).toBe(false);
+    });
+
+    expect(result.current.previewError).toBe('Server error');
+    expect(result.current.mergePreviewRecord).toBeNull();
+  });
+
+  it('should not have previewError when mergeManyRecords succeeds', async () => {
+    mockMergeManyRecords.mockResolvedValue({
+      id: 'preview-id',
+      name: 'Merged Record',
+    });
+
+    const { result } = renderHook(
+      () => usePerformMergePreview({ objectNameSingular: 'company' }),
+      { wrapper: Wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isGeneratingPreview).toBe(false);
+    });
+
+    expect(result.current.previewError).toBeNull();
+    expect(result.current.mergePreviewRecord).toBeDefined();
+  });
+});

--- a/packages/twenty-front/src/modules/object-record/record-merge/hooks/usePerformMergePreview.ts
+++ b/packages/twenty-front/src/modules/object-record/record-merge/hooks/usePerformMergePreview.ts
@@ -1,3 +1,4 @@
+import { extractErrorMessage } from '@/ai/utils/extractErrorMessage';
 import { getRecordFromRecordNode } from '@/object-record/cache/utils/getRecordFromRecordNode';
 import { useMergeManyRecords } from '@/object-record/hooks/useMergeManyRecords';
 import { useMergeRecordsSelectedRecords } from '@/object-record/record-merge/hooks/useMergeRecordsSelectedRecords';
@@ -19,6 +20,7 @@ export const usePerformMergePreview = ({
     useState<ObjectRecord | null>(null);
   const [isGeneratingPreview, setIsGeneratingPreview] = useState(false);
   const [isInitialized, setIsInitialized] = useState(false);
+  const [previewError, setPreviewError] = useState<string | null>(null);
 
   const mergeSettings = useAtomStateValue(mergeSettingsState);
   const isMergeInProgress = useAtomStateValue(isMergeInProgressState);
@@ -43,6 +45,7 @@ export const usePerformMergePreview = ({
       }
 
       setIsGeneratingPreview(true);
+      setPreviewError(null);
       try {
         const previewRecord = await mergeManyRecords({
           recordIds: selectedRecords.map((record) => record.id),
@@ -60,8 +63,9 @@ export const usePerformMergePreview = ({
 
         setMergePreviewRecord(transformPreviewRecord);
         upsertRecordsInStore({ partialRecords: [transformPreviewRecord] });
-      } catch {
+      } catch (error) {
         setMergePreviewRecord(null);
+        setPreviewError(extractErrorMessage(error));
       } finally {
         setIsGeneratingPreview(false);
         setIsInitialized(true);
@@ -83,6 +87,7 @@ export const usePerformMergePreview = ({
 
   return {
     mergePreviewRecord,
-    isGeneratingPreview: isGeneratingPreview,
+    isGeneratingPreview,
+    previewError,
   };
 };

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/__tests__/common-merge-many-query-runner.service.spec.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/__tests__/common-merge-many-query-runner.service.spec.ts
@@ -1,0 +1,184 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { CommonMergeManyQueryRunnerService } from 'src/engine/api/common/common-query-runners/common-merge-many-query-runner.service';
+import { ProcessNestedRelationsHelper } from 'src/engine/api/common/common-nested-relations-processor/process-nested-relations.helper';
+import { type CommonExtendedQueryRunnerContext } from 'src/engine/api/common/types/common-extended-query-runner-context.type';
+import {
+  type CommonExtendedInput,
+  type MergeManyQueryArgs,
+} from 'src/engine/api/common/types/common-query-args.type';
+import { WorkspaceQueryHookService } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/workspace-query-hook.service';
+import { QueryRunnerArgsFactory } from 'src/engine/api/common/common-args-processors/query-runner-args.factory';
+import { DataArgProcessorService } from 'src/engine/api/common/common-args-processors/data-arg-processor/data-arg-processor.service';
+import { FilterArgProcessorService } from 'src/engine/api/common/common-args-processors/filter-arg-processor/filter-arg-processor.service';
+import { GroupByArgProcessorService } from 'src/engine/api/common/common-args-processors/group-by-arg-processor/group-by-arg-processor.service';
+import { OrderByArgProcessorService } from 'src/engine/api/common/common-args-processors/order-by-arg-processor/order-by-arg-processor.service';
+import { OrderByWithGroupByArgProcessorService } from 'src/engine/api/common/common-args-processors/order-by-with-group-by-arg-processor/order-by-with-group-by-arg-processor.service';
+import { GlobalWorkspaceOrmManager } from 'src/engine/twenty-orm/global-workspace-datasource/global-workspace-orm.manager';
+import { PermissionsService } from 'src/engine/metadata-modules/permissions/permissions.service';
+import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
+import { CommonResultGettersService } from 'src/engine/api/common/common-result-getters/common-result-getters.service';
+import { ThrottlerService } from 'src/engine/core-modules/throttler/throttler.service';
+import { TwentyConfigService } from 'src/engine/core-modules/twenty-config/twenty-config.service';
+import { MetricsService } from 'src/engine/core-modules/metrics/metrics.service';
+import { FeatureFlagService } from 'src/engine/core-modules/feature-flag/services/feature-flag.service';
+
+// Mock utilities that depend on deep metadata structures irrelevant to the behavior under test
+jest.mock(
+  'src/engine/api/graphql/graphql-query-runner/utils/build-columns-to-select',
+  () => ({
+    buildColumnsToSelect: () => ({ id: true, name: true, email: true }),
+  }),
+);
+
+jest.mock(
+  'src/engine/api/graphql/graphql-query-runner/utils/build-columns-to-return',
+  () => ({
+    buildColumnsToReturn: () => ['id', 'name', 'email'],
+  }),
+);
+
+jest.mock(
+  'src/engine/metadata-modules/flat-field-metadata/utils/build-field-maps-from-flat-object-metadata.util',
+  () => ({
+    buildFieldMapsFromFlatObjectMetadata: () => ({
+      fieldIdByName: {},
+      fieldByName: {},
+    }),
+  }),
+);
+
+const stubProvider = (token: any) => ({
+  provide: token,
+  useValue: {},
+});
+
+describe('CommonMergeManyQueryRunnerService', () => {
+  let service: CommonMergeManyQueryRunnerService;
+  let processNestedRelationsHelper: jest.Mocked<ProcessNestedRelationsHelper>;
+
+  const recordA = { id: 'id-a', name: 'Acme', email: 'a@acme.com' };
+  const recordB = { id: 'id-b', name: 'Beta', email: '' };
+
+  const makeContext = (
+    repositoryRecords: any[],
+  ): CommonExtendedQueryRunnerContext =>
+    ({
+      flatObjectMetadata: {
+        id: 'obj-meta-1',
+        nameSingular: 'company',
+        namePlural: 'companies',
+        duplicateCriteria: {},
+      },
+      flatObjectMetadataMaps: { byUniversalIdentifier: {}, byId: {} },
+      flatFieldMetadataMaps: { byUniversalIdentifier: {}, byId: {} },
+      repository: {
+        find: jest.fn().mockResolvedValue(repositoryRecords),
+        createQueryBuilder: jest.fn(),
+      },
+      authContext: {},
+      workspaceDataSource: {},
+      rolePermissionConfig: {},
+      commonQueryParser: {},
+      objectIdByNameSingular: {},
+    }) as any;
+
+  const makeArgs = (
+    overrides: Partial<CommonExtendedInput<MergeManyQueryArgs>> = {},
+  ): CommonExtendedInput<MergeManyQueryArgs> =>
+    ({
+      ids: [recordA.id, recordB.id],
+      conflictPriorityIndex: 0,
+      dryRun: true,
+      selectedFieldsResult: {
+        select: { id: true, name: true, email: true },
+        relations: { company: true },
+        aggregate: {},
+      },
+      ...overrides,
+    }) as any;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CommonMergeManyQueryRunnerService,
+        {
+          provide: ProcessNestedRelationsHelper,
+          useValue: {
+            processNestedRelations: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+        stubProvider(WorkspaceQueryHookService),
+        stubProvider(QueryRunnerArgsFactory),
+        stubProvider(DataArgProcessorService),
+        stubProvider(FilterArgProcessorService),
+        stubProvider(GroupByArgProcessorService),
+        stubProvider(OrderByArgProcessorService),
+        stubProvider(OrderByWithGroupByArgProcessorService),
+        stubProvider(GlobalWorkspaceOrmManager),
+        stubProvider(PermissionsService),
+        stubProvider(WorkspaceCacheService),
+        stubProvider(CommonResultGettersService),
+        stubProvider(ThrottlerService),
+        stubProvider(TwentyConfigService),
+        stubProvider(MetricsService),
+        stubProvider(FeatureFlagService),
+      ],
+    }).compile();
+
+    service = module.get(CommonMergeManyQueryRunnerService);
+    processNestedRelationsHelper = module.get(ProcessNestedRelationsHelper);
+  });
+
+  describe('run (dry-run)', () => {
+    it('should return a merged record even when processNestedRelations throws', async () => {
+      processNestedRelationsHelper.processNestedRelations.mockRejectedValue(
+        new Error('relation loading failed'),
+      );
+
+      const context = makeContext([recordA, recordB]);
+      const args = makeArgs({ dryRun: true });
+
+      const result = await service.run(args, context);
+
+      expect(result).toBeDefined();
+      expect(result.id).toBeDefined();
+      // The dry-run record gets a new UUID (not one of the input IDs)
+      expect(result.id).not.toBe(recordA.id);
+      expect(result.id).not.toBe(recordB.id);
+      // deletedAt is set on dry-run records
+      expect(result.deletedAt).toBeDefined();
+    });
+
+    it('should log a warning when processNestedRelations fails during dry-run', async () => {
+      processNestedRelationsHelper.processNestedRelations.mockRejectedValue(
+        new Error('relation loading failed'),
+      );
+
+      const loggerSpy = jest.spyOn(service['logger'], 'warn');
+      const context = makeContext([recordA, recordB]);
+      const args = makeArgs({ dryRun: true });
+
+      await service.run(args, context);
+
+      expect(loggerSpy).toHaveBeenCalledWith(
+        expect.stringContaining('relation loading failed'),
+      );
+    });
+
+    it('should return a merged record when processNestedRelations succeeds during dry-run', async () => {
+      processNestedRelationsHelper.processNestedRelations.mockResolvedValue(
+        undefined,
+      );
+
+      const context = makeContext([recordA, recordB]);
+      const args = makeArgs({ dryRun: true });
+
+      const result = await service.run(args, context);
+
+      expect(result).toBeDefined();
+      expect(result.id).not.toBe(recordA.id);
+      expect(result.deletedAt).toBeDefined();
+    });
+  });
+});

--- a/packages/twenty-server/src/engine/api/common/common-query-runners/common-merge-many-query-runner.service.ts
+++ b/packages/twenty-server/src/engine/api/common/common-query-runners/common-merge-many-query-runner.service.ts
@@ -159,21 +159,27 @@ export class CommonMergeManyQueryRunnerService extends CommonBaseQueryRunnerServ
     const recordsToMerge = fetchedRecords;
 
     if (args.dryRun && args.selectedFieldsResult.relations) {
-      await this.processNestedRelationsHelper.processNestedRelations({
-        flatObjectMetadataMaps: context.flatObjectMetadataMaps,
-        flatFieldMetadataMaps: context.flatFieldMetadataMaps,
-        parentObjectMetadataItem: context.flatObjectMetadata,
-        parentObjectRecords: recordsToMerge,
-        relations: args.selectedFieldsResult.relations as Record<
-          string,
-          FindOptionsRelations<ObjectLiteral>
-        >,
-        limit: QUERY_MAX_RECORDS_FROM_RELATION,
-        authContext: context.authContext,
-        workspaceDataSource: context.workspaceDataSource,
-        rolePermissionConfig: context.rolePermissionConfig,
-        selectedFields: args.selectedFieldsResult.select,
-      });
+      try {
+        await this.processNestedRelationsHelper.processNestedRelations({
+          flatObjectMetadataMaps: context.flatObjectMetadataMaps,
+          flatFieldMetadataMaps: context.flatFieldMetadataMaps,
+          parentObjectMetadataItem: context.flatObjectMetadata,
+          parentObjectRecords: recordsToMerge,
+          relations: args.selectedFieldsResult.relations as Record<
+            string,
+            FindOptionsRelations<ObjectLiteral>
+          >,
+          limit: QUERY_MAX_RECORDS_FROM_RELATION,
+          authContext: context.authContext,
+          workspaceDataSource: context.workspaceDataSource,
+          rolePermissionConfig: context.rolePermissionConfig,
+          selectedFields: args.selectedFieldsResult.select,
+        });
+      } catch (error) {
+        this.logger.warn(
+          `Failed to load nested relations for dry-run merge preview: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
     }
 
     return recordsToMerge;


### PR DESCRIPTION
## Summary

Fixes #19312

- **Server**: Wrap dry-run `processNestedRelationsHelper.processNestedRelations` in try-catch so the preview returns merged field data even when nested relation queries fail
- **Frontend**: Remove `errorPolicy: 'ignore'` from dry-run mutation, add `previewError` state, render error placeholder instead of blank page