### PR TITLE
fix: bypass permission checks in 1.21 backfill-message-thread-subject command

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-backfill-message-thread-subject.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-backfill-message-thread-subject.command.ts
@@ -44,6 +44,8 @@ export class BackfillMessageThreadSubjectCommand extends ActiveOrSuspendedWorksp
          AND table_name = 'messageThread'
          AND column_name = 'subject'`,
       [schemaName],
+      undefined,
+      { shouldBypassPermissionChecks: true },
     );
 
     if (columnExists.length === 0) {
@@ -64,6 +66,9 @@ export class BackfillMessageThreadSubjectCommand extends ActiveOrSuspendedWorksp
        ) sub
        WHERE mt.id = sub."messageThreadId"
          AND mt."subject" IS NULL`,
+      undefined,
+      undefined,
+      { shouldBypassPermissionChecks: true },
     );
 
     this.logger.log(


### PR DESCRIPTION
## Summary
- `upgrade:1-21:backfill-message-thread-subject` was failing on every workspace with `Method not allowed because permissions are not implemented at datasource level`.
- The global workspace datasource gates raw `query()` calls behind `shouldBypassPermissionChecks`. Both the column-existence probe and the UPDATE in this command now pass that flag, matching the pattern used by the other 1.20/1.21 upgrade commands.

## Test plan
- [ ] Re-run `yarn command:prod upgrade:1-21:backfill-message-thread-subject` and confirm all workspaces complete without the permissions error
- [ ] Spot-check a workspace to confirm `messageThread.subject` is backfilled from the most recent message

🤖 Generated with [Claude Code](https://claude.com/claude-code)