### PR TITLE
fix(messaging): create messageThread.subject field metadata + column in 1-21 backfill

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-upgrade-version-command.module.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-upgrade-version-command.module.ts
@@ -22,6 +22,7 @@ import { CalendarChannelEntity } from 'src/engine/metadata-modules/calendar-chan
 import { ConnectedAccountEntity } from 'src/engine/metadata-modules/connected-account/entities/connected-account.entity';
 import { DataSourceEntity } from 'src/engine/metadata-modules/data-source/data-source.entity';
 import { DataSourceModule } from 'src/engine/metadata-modules/data-source/data-source.module';
+import { FieldMetadataModule } from 'src/engine/metadata-modules/field-metadata/field-metadata.module';
 import { MessageChannelEntity } from 'src/engine/metadata-modules/message-channel/entities/message-channel.entity';
 import { MessageFolderEntity } from 'src/engine/metadata-modules/message-folder/entities/message-folder.entity';
 import { WorkspaceSchemaManagerModule } from 'src/engine/twenty-orm/workspace-schema-manager/workspace-schema-manager.module';
@@ -40,6 +41,7 @@ import { WorkspaceMigrationModule } from 'src/engine/workspace-manager/workspace
       UserWorkspaceEntity,
     ]),
     DataSourceModule,
+    FieldMetadataModule,
     WorkspaceCacheModule,
     ApplicationModule,
     WorkspaceMigrationModule,

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-backfill-message-thread-subject.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-backfill-message-thread-subject.command.ts
@@ -1,18 +1,31 @@
 import { Command } from 'nest-commander';
+import { isDefined } from 'twenty-shared/utils';
+import { v4 } from 'uuid';
 
 import { ActiveOrSuspendedWorkspaceCommandRunner } from 'src/database/commands/command-runners/active-or-suspended-workspace.command-runner';
 import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
 import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspace.command-runner';
+import { ApplicationService } from 'src/engine/core-modules/application/application.service';
+import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 import { getWorkspaceSchemaName } from 'src/engine/workspace-datasource/utils/get-workspace-schema-name.util';
+import { computeTwentyStandardApplicationAllFlatEntityMaps } from 'src/engine/workspace-manager/twenty-standard-application/utils/twenty-standard-application-all-flat-entity-maps.constant';
+import { WorkspaceMigrationValidateBuildAndRunService } from 'src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service';
+
+const MESSAGE_THREAD_OBJECT_NAME_SINGULAR = 'messageThread';
+const SUBJECT_FIELD_NAME = 'subject';
 
 @Command({
   name: 'upgrade:1-21:backfill-message-thread-subject',
   description:
-    'Backfill messageThread.subject from the most recently received message in each thread',
+    'Create the messageThread.subject field metadata and column if missing, then backfill subject from the most recently received message in each thread',
 })
 export class BackfillMessageThreadSubjectCommand extends ActiveOrSuspendedWorkspaceCommandRunner {
   constructor(
     protected readonly workspaceIteratorService: WorkspaceIteratorService,
+    private readonly applicationService: ApplicationService,
+    private readonly workspaceCacheService: WorkspaceCacheService,
+    private readonly workspaceMigrationValidateBuildAndRunService: WorkspaceMigrationValidateBuildAndRunService,
   ) {
     super(workspaceIteratorService);
   }
@@ -28,9 +41,11 @@ export class BackfillMessageThreadSubjectCommand extends ActiveOrSuspendedWorksp
       return;
     }
 
-    const schemaName = getWorkspaceSchemaName(workspaceId);
+    const isDryRun = options.dryRun ?? false;
 
-    if (options.dryRun) {
+    await this.ensureSubjectFieldExists({ workspaceId, isDryRun });
+
+    if (isDryRun) {
       this.logger.log(
         `[DRY RUN] Would backfill messageThread.subject for workspace ${workspaceId}`,
       );
@@ -38,23 +53,7 @@ export class BackfillMessageThreadSubjectCommand extends ActiveOrSuspendedWorksp
       return;
     }
 
-    const columnExists = await dataSource.query(
-      `SELECT 1 FROM information_schema.columns
-       WHERE table_schema = $1
-         AND table_name = 'messageThread'
-         AND column_name = 'subject'`,
-      [schemaName],
-      undefined,
-      { shouldBypassPermissionChecks: true },
-    );
-
-    if (columnExists.length === 0) {
-      this.logger.log(
-        `Column "subject" does not exist yet on messageThread for workspace ${workspaceId}, skipping (will be created by sync-metadata)`,
-      );
-
-      return;
-    }
+    const schemaName = getWorkspaceSchemaName(workspaceId);
 
     const result = await dataSource.query(
       `UPDATE "${schemaName}"."messageThread" mt
@@ -73,6 +72,127 @@ export class BackfillMessageThreadSubjectCommand extends ActiveOrSuspendedWorksp
 
     this.logger.log(
       `Backfilled subject for ${result?.[1] ?? 0} message threads in workspace ${workspaceId}`,
+    );
+  }
+
+  private async ensureSubjectFieldExists({
+    workspaceId,
+    isDryRun,
+  }: {
+    workspaceId: string;
+    isDryRun: boolean;
+  }): Promise<void> {
+    const { flatObjectMetadataMaps, flatFieldMetadataMaps } =
+      await this.workspaceCacheService.getOrRecompute(workspaceId, [
+        'flatObjectMetadataMaps',
+        'flatFieldMetadataMaps',
+      ]);
+
+    const messageThreadObject = Object.values(
+      flatObjectMetadataMaps.byUniversalIdentifier,
+    )
+      .filter(isDefined)
+      .find(
+        (object) =>
+          object.nameSingular === MESSAGE_THREAD_OBJECT_NAME_SINGULAR,
+      );
+
+    if (!isDefined(messageThreadObject)) {
+      this.logger.warn(
+        `messageThread object metadata not found for workspace ${workspaceId}, skipping`,
+      );
+
+      return;
+    }
+
+    const existingSubjectField = Object.values(
+      flatFieldMetadataMaps.byUniversalIdentifier,
+    )
+      .filter(isDefined)
+      .find(
+        (field) =>
+          field.objectMetadataId === messageThreadObject.id &&
+          field.name === SUBJECT_FIELD_NAME,
+      );
+
+    if (isDefined(existingSubjectField)) {
+      return;
+    }
+
+    const { twentyStandardFlatApplication } =
+      await this.applicationService.findWorkspaceTwentyStandardAndCustomApplicationOrThrow(
+        { workspaceId },
+      );
+
+    const { allFlatEntityMaps: standardAllFlatEntityMaps } =
+      computeTwentyStandardApplicationAllFlatEntityMaps({
+        shouldIncludeRecordPageLayouts: false,
+        now: new Date().toISOString(),
+        workspaceId,
+        twentyStandardApplicationId: twentyStandardFlatApplication.id,
+      });
+
+    const standardSubjectField = Object.values(
+      standardAllFlatEntityMaps.flatFieldMetadataMaps.byUniversalIdentifier,
+    )
+      .filter(isDefined)
+      .find(
+        (field) =>
+          field.objectMetadataUniversalIdentifier ===
+            messageThreadObject.universalIdentifier &&
+          field.name === SUBJECT_FIELD_NAME,
+      );
+
+    if (!isDefined(standardSubjectField)) {
+      this.logger.warn(
+        `Standard messageThread.subject field not found in twenty-standard application, skipping workspace ${workspaceId}`,
+      );
+
+      return;
+    }
+
+    if (isDryRun) {
+      this.logger.log(
+        `[DRY RUN] Would create messageThread.subject field metadata and column for workspace ${workspaceId}`,
+      );
+
+      return;
+    }
+
+    const fieldToCreate: FlatFieldMetadata = {
+      ...standardSubjectField,
+      id: v4(),
+      objectMetadataId: messageThreadObject.id,
+    };
+
+    const validateAndBuildResult =
+      await this.workspaceMigrationValidateBuildAndRunService.validateBuildAndRunWorkspaceMigration(
+        {
+          allFlatEntityOperationByMetadataName: {
+            fieldMetadata: {
+              flatEntityToCreate: [fieldToCreate],
+              flatEntityToDelete: [],
+              flatEntityToUpdate: [],
+            },
+          },
+          workspaceId,
+          applicationUniversalIdentifier:
+            twentyStandardFlatApplication.universalIdentifier,
+        },
+      );
+
+    if (validateAndBuildResult.status === 'fail') {
+      this.logger.error(
+        `Failed to create messageThread.subject field for workspace ${workspaceId}:\n${JSON.stringify(validateAndBuildResult, null, 2)}`,
+      );
+
+      throw new Error(
+        `Failed to create messageThread.subject field for workspace ${workspaceId}`,
+      );
+    }
+
+    this.logger.log(
+      `Created messageThread.subject field metadata and column for workspace ${workspaceId}`,
     );
   }
 }

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-backfill-message-thread-subject.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-backfill-message-thread-subject.command.ts
@@ -1,31 +1,28 @@
 import { Command } from 'nest-commander';
-import { isDefined } from 'twenty-shared/utils';
-import { v4 } from 'uuid';
+import { STANDARD_OBJECTS } from 'twenty-shared/metadata';
+import { FieldMetadataType } from 'twenty-shared/types';
 
 import { ActiveOrSuspendedWorkspaceCommandRunner } from 'src/database/commands/command-runners/active-or-suspended-workspace.command-runner';
 import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
 import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspace.command-runner';
 import { ApplicationService } from 'src/engine/core-modules/application/application.service';
-import { type FlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/types/flat-field-metadata.type';
+import { FieldMetadataService } from 'src/engine/metadata-modules/field-metadata/services/field-metadata.service';
+import { findFlatEntityByUniversalIdentifier } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier.util';
+import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 import { getWorkspaceSchemaName } from 'src/engine/workspace-datasource/utils/get-workspace-schema-name.util';
-import { computeTwentyStandardApplicationAllFlatEntityMaps } from 'src/engine/workspace-manager/twenty-standard-application/utils/twenty-standard-application-all-flat-entity-maps.constant';
-import { WorkspaceMigrationValidateBuildAndRunService } from 'src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service';
-
-const MESSAGE_THREAD_OBJECT_NAME_SINGULAR = 'messageThread';
-const SUBJECT_FIELD_NAME = 'subject';
 
 @Command({
   name: 'upgrade:1-21:backfill-message-thread-subject',
   description:
-    'Create the messageThread.subject field metadata and column if missing, then backfill subject from the most recently received message in each thread',
+    'Create the messageThread.subject standard field if missing and backfill it from the most recently received message in each thread',
 })
 export class BackfillMessageThreadSubjectCommand extends ActiveOrSuspendedWorkspaceCommandRunner {
   constructor(
     protected readonly workspaceIteratorService: WorkspaceIteratorService,
     private readonly applicationService: ApplicationService,
+    private readonly fieldMetadataService: FieldMetadataService,
     private readonly workspaceCacheService: WorkspaceCacheService,
-    private readonly workspaceMigrationValidateBuildAndRunService: WorkspaceMigrationValidateBuildAndRunService,
   ) {
     super(workspaceIteratorService);
   }
@@ -41,11 +38,9 @@ export class BackfillMessageThreadSubjectCommand extends ActiveOrSuspendedWorksp
       return;
     }
 
-    const isDryRun = options.dryRun ?? false;
+    await this.ensureSubjectFieldExists({ workspaceId, isDryRun: !!options.dryRun });
 
-    await this.ensureSubjectFieldExists({ workspaceId, isDryRun });
-
-    if (isDryRun) {
+    if (options.dryRun) {
       this.logger.log(
         `[DRY RUN] Would backfill messageThread.subject for workspace ${workspaceId}`,
       );
@@ -88,34 +83,36 @@ export class BackfillMessageThreadSubjectCommand extends ActiveOrSuspendedWorksp
         'flatFieldMetadataMaps',
       ]);
 
-    const messageThreadObject = Object.values(
-      flatObjectMetadataMaps.byUniversalIdentifier,
-    )
-      .filter(isDefined)
-      .find(
-        (object) =>
-          object.nameSingular === MESSAGE_THREAD_OBJECT_NAME_SINGULAR,
-      );
+    const messageThreadObjectMetadata =
+      findFlatEntityByUniversalIdentifier<FlatObjectMetadata>({
+        flatEntityMaps: flatObjectMetadataMaps,
+        universalIdentifier:
+          STANDARD_OBJECTS.messageThread.universalIdentifier,
+      });
 
-    if (!isDefined(messageThreadObject)) {
-      this.logger.warn(
+    if (!messageThreadObjectMetadata) {
+      this.logger.log(
         `messageThread object metadata not found for workspace ${workspaceId}, skipping`,
       );
 
       return;
     }
 
-    const existingSubjectField = Object.values(
-      flatFieldMetadataMaps.byUniversalIdentifier,
-    )
-      .filter(isDefined)
-      .find(
-        (field) =>
-          field.objectMetadataId === messageThreadObject.id &&
-          field.name === SUBJECT_FIELD_NAME,
+    const existingField = findFlatEntityByUniversalIdentifier({
+      flatEntityMaps: flatFieldMetadataMaps,
+      universalIdentifier:
+        STANDARD_OBJECTS.messageThread.fields.subject.universalIdentifier,
+    });
+
+    if (existingField) {
+      return;
+    }
+
+    if (isDryRun) {
+      this.logger.log(
+        `[DRY RUN] Would create messageThread.subject field for workspace ${workspaceId}`,
       );
 
-    if (isDefined(existingSubjectField)) {
       return;
     }
 
@@ -124,75 +121,25 @@ export class BackfillMessageThreadSubjectCommand extends ActiveOrSuspendedWorksp
         { workspaceId },
       );
 
-    const { allFlatEntityMaps: standardAllFlatEntityMaps } =
-      computeTwentyStandardApplicationAllFlatEntityMaps({
-        shouldIncludeRecordPageLayouts: false,
-        now: new Date().toISOString(),
-        workspaceId,
-        twentyStandardApplicationId: twentyStandardFlatApplication.id,
-      });
-
-    const standardSubjectField = Object.values(
-      standardAllFlatEntityMaps.flatFieldMetadataMaps.byUniversalIdentifier,
-    )
-      .filter(isDefined)
-      .find(
-        (field) =>
-          field.objectMetadataUniversalIdentifier ===
-            messageThreadObject.universalIdentifier &&
-          field.name === SUBJECT_FIELD_NAME,
-      );
-
-    if (!isDefined(standardSubjectField)) {
-      this.logger.warn(
-        `Standard messageThread.subject field not found in twenty-standard application, skipping workspace ${workspaceId}`,
-      );
-
-      return;
-    }
-
-    if (isDryRun) {
-      this.logger.log(
-        `[DRY RUN] Would create messageThread.subject field metadata and column for workspace ${workspaceId}`,
-      );
-
-      return;
-    }
-
-    const fieldToCreate: FlatFieldMetadata = {
-      ...standardSubjectField,
-      id: v4(),
-      objectMetadataId: messageThreadObject.id,
-    };
-
-    const validateAndBuildResult =
-      await this.workspaceMigrationValidateBuildAndRunService.validateBuildAndRunWorkspaceMigration(
-        {
-          allFlatEntityOperationByMetadataName: {
-            fieldMetadata: {
-              flatEntityToCreate: [fieldToCreate],
-              flatEntityToDelete: [],
-              flatEntityToUpdate: [],
-            },
-          },
-          workspaceId,
-          applicationUniversalIdentifier:
-            twentyStandardFlatApplication.universalIdentifier,
-        },
-      );
-
-    if (validateAndBuildResult.status === 'fail') {
-      this.logger.error(
-        `Failed to create messageThread.subject field for workspace ${workspaceId}:\n${JSON.stringify(validateAndBuildResult, null, 2)}`,
-      );
-
-      throw new Error(
-        `Failed to create messageThread.subject field for workspace ${workspaceId}`,
-      );
-    }
+    await this.fieldMetadataService.createOneField({
+      createFieldInput: {
+        name: 'subject',
+        type: FieldMetadataType.TEXT,
+        label: 'Subject',
+        description: 'Subject',
+        icon: 'IconMessage',
+        isNullable: true,
+        isUIReadOnly: true,
+        objectMetadataId: messageThreadObjectMetadata.id,
+        universalIdentifier:
+          STANDARD_OBJECTS.messageThread.fields.subject.universalIdentifier,
+      },
+      workspaceId,
+      ownerFlatApplication: twentyStandardFlatApplication,
+    });
 
     this.logger.log(
-      `Created messageThread.subject field metadata and column for workspace ${workspaceId}`,
+      `Created messageThread.subject field for workspace ${workspaceId}`,
     );
   }
 }

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-backfill-message-thread-subject.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-backfill-message-thread-subject.command.ts
@@ -38,7 +38,10 @@ export class BackfillMessageThreadSubjectCommand extends ActiveOrSuspendedWorksp
       return;
     }
 
-    await this.ensureSubjectFieldExists({ workspaceId, isDryRun: !!options.dryRun });
+    await this.ensureSubjectFieldExists({
+      workspaceId,
+      isDryRun: !!options.dryRun,
+    });
 
     if (options.dryRun) {
       this.logger.log(
@@ -86,8 +89,7 @@ export class BackfillMessageThreadSubjectCommand extends ActiveOrSuspendedWorksp
     const messageThreadObjectMetadata =
       findFlatEntityByUniversalIdentifier<FlatObjectMetadata>({
         flatEntityMaps: flatObjectMetadataMaps,
-        universalIdentifier:
-          STANDARD_OBJECTS.messageThread.universalIdentifier,
+        universalIdentifier: STANDARD_OBJECTS.messageThread.universalIdentifier,
       });
 
     if (!messageThreadObjectMetadata) {

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-backfill-message-thread-subject.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-backfill-message-thread-subject.command.ts
@@ -6,11 +6,12 @@ import { ActiveOrSuspendedWorkspaceCommandRunner } from 'src/database/commands/c
 import { WorkspaceIteratorService } from 'src/database/commands/command-runners/workspace-iterator.service';
 import { type RunOnWorkspaceArgs } from 'src/database/commands/command-runners/workspace.command-runner';
 import { ApplicationService } from 'src/engine/core-modules/application/application.service';
-import { FieldMetadataService } from 'src/engine/metadata-modules/field-metadata/services/field-metadata.service';
 import { findFlatEntityByUniversalIdentifier } from 'src/engine/metadata-modules/flat-entity/utils/find-flat-entity-by-universal-identifier.util';
+import { getDefaultFlatFieldMetadata } from 'src/engine/metadata-modules/flat-field-metadata/utils/get-default-flat-field-metadata-from-create-field-input.util';
 import { type FlatObjectMetadata } from 'src/engine/metadata-modules/flat-object-metadata/types/flat-object-metadata.type';
 import { WorkspaceCacheService } from 'src/engine/workspace-cache/services/workspace-cache.service';
 import { getWorkspaceSchemaName } from 'src/engine/workspace-datasource/utils/get-workspace-schema-name.util';
+import { WorkspaceMigrationValidateBuildAndRunService } from 'src/engine/workspace-manager/workspace-migration/services/workspace-migration-validate-build-and-run-service';
 
 @Command({
   name: 'upgrade:1-21:backfill-message-thread-subject',
@@ -21,8 +22,8 @@ export class BackfillMessageThreadSubjectCommand extends ActiveOrSuspendedWorksp
   constructor(
     protected readonly workspaceIteratorService: WorkspaceIteratorService,
     private readonly applicationService: ApplicationService,
-    private readonly fieldMetadataService: FieldMetadataService,
     private readonly workspaceCacheService: WorkspaceCacheService,
+    private readonly workspaceMigrationValidateBuildAndRunService: WorkspaceMigrationValidateBuildAndRunService,
   ) {
     super(workspaceIteratorService);
   }
@@ -123,7 +124,7 @@ export class BackfillMessageThreadSubjectCommand extends ActiveOrSuspendedWorksp
         { workspaceId },
       );
 
-    await this.fieldMetadataService.createOneField({
+    const flatFieldMetadataToCreate = getDefaultFlatFieldMetadata({
       createFieldInput: {
         name: 'subject',
         type: FieldMetadataType.TEXT,
@@ -132,13 +133,39 @@ export class BackfillMessageThreadSubjectCommand extends ActiveOrSuspendedWorksp
         icon: 'IconMessage',
         isNullable: true,
         isUIReadOnly: true,
-        objectMetadataId: messageThreadObjectMetadata.id,
         universalIdentifier:
           STANDARD_OBJECTS.messageThread.fields.subject.universalIdentifier,
       },
-      workspaceId,
-      ownerFlatApplication: twentyStandardFlatApplication,
+      flatApplication: twentyStandardFlatApplication,
+      objectMetadataUniversalIdentifier:
+        messageThreadObjectMetadata.universalIdentifier,
     });
+
+    const validateAndBuildResult =
+      await this.workspaceMigrationValidateBuildAndRunService.validateBuildAndRunWorkspaceMigration(
+        {
+          allFlatEntityOperationByMetadataName: {
+            fieldMetadata: {
+              flatEntityToCreate: [flatFieldMetadataToCreate],
+              flatEntityToDelete: [],
+              flatEntityToUpdate: [],
+            },
+          },
+          workspaceId,
+          applicationUniversalIdentifier:
+            twentyStandardFlatApplication.universalIdentifier,
+        },
+      );
+
+    if (validateAndBuildResult.status === 'fail') {
+      this.logger.error(
+        `Failed to create messageThread.subject field for workspace ${workspaceId}:\n${JSON.stringify(validateAndBuildResult, null, 2)}`,
+      );
+
+      throw new Error(
+        `Failed to create messageThread.subject field for workspace ${workspaceId}`,
+      );
+    }
 
     this.logger.log(
       `Created messageThread.subject field for workspace ${workspaceId}`,

--- a/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-backfill-message-thread-subject.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/1-21/1-21-workspace-command-backfill-message-thread-subject.command.ts
@@ -124,22 +124,25 @@ export class BackfillMessageThreadSubjectCommand extends ActiveOrSuspendedWorksp
         { workspaceId },
       );
 
-    const flatFieldMetadataToCreate = getDefaultFlatFieldMetadata({
-      createFieldInput: {
-        name: 'subject',
-        type: FieldMetadataType.TEXT,
-        label: 'Subject',
-        description: 'Subject',
-        icon: 'IconMessage',
-        isNullable: true,
-        isUIReadOnly: true,
-        universalIdentifier:
-          STANDARD_OBJECTS.messageThread.fields.subject.universalIdentifier,
-      },
-      flatApplication: twentyStandardFlatApplication,
-      objectMetadataUniversalIdentifier:
-        messageThreadObjectMetadata.universalIdentifier,
-    });
+    const flatFieldMetadataToCreate = {
+      ...getDefaultFlatFieldMetadata({
+        createFieldInput: {
+          name: 'subject',
+          type: FieldMetadataType.TEXT,
+          label: 'Subject',
+          description: 'Subject',
+          icon: 'IconMessage',
+          isNullable: true,
+          isUIReadOnly: true,
+          universalIdentifier:
+            STANDARD_OBJECTS.messageThread.fields.subject.universalIdentifier,
+        },
+        flatApplication: twentyStandardFlatApplication,
+        objectMetadataUniversalIdentifier:
+          messageThreadObjectMetadata.universalIdentifier,
+      }),
+      isCustom: false,
+    };
 
     const validateAndBuildResult =
       await this.workspaceMigrationValidateBuildAndRunService.validateBuildAndRunWorkspaceMigration(


### PR DESCRIPTION
## Summary
- The 1-21 \`upgrade:1-21:backfill-message-thread-subject\` command assumed the legacy \`sync-metadata\` flow would create the new \`messageThread.subject\` field metadata and column on existing workspaces. That sync was removed, so the column was never added and the backfill silently skipped.
- The command now ensures the field exists by computing the standard \`messageThread.subject\` flat field from the twenty-standard application and running it through \`WorkspaceMigrationValidateBuildAndRunService\` (same pattern used by the page-layout / command-menu-item backfills). This creates both the field metadata row and the workspace schema column.
- After ensuring the field, the existing \`UPDATE messageThread SET subject = ...\` runs as before.

## Test plan
- [ ] On a workspace with no \`subject\` column on \`messageThread\`, run \`yarn command:prod upgrade:1-21:backfill-message-thread-subject\` and confirm:
  - the field metadata row is created in \`core.\"fieldMetadata\"\`
  - the \`subject\` column is created on \`workspace_<id>.messageThread\`
  - existing message threads are backfilled from the most recent message
- [ ] Re-run on the same workspace and confirm it is a no-op (field already exists, no rows to update)
- [ ] Run on a workspace that already has the column but \`NULL\` subjects and confirm only the backfill runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)