### PR TITLE
Fix `yarn-install-lambda` and `lambda-build` `target`

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/constants/builder/index.mjs
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/constants/builder/index.mjs
@@ -49,7 +49,7 @@ export const handler = async (event) => {
       outfile: outFilePath,
       platform: 'node',
       format: 'esm',
-      target: 'es2017',
+      target: 'es2022',
       bundle: true,
       sourcemap: true,
       packages: 'external',

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/constants/builder/index.mjs
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/constants/builder/index.mjs
@@ -49,7 +49,7 @@ export const handler = async (event) => {
       outfile: outFilePath,
       platform: 'node',
       format: 'esm',
-      target: 'es2022',
+      target: 'esnext',
       bundle: true,
       sourcemap: true,
       packages: 'external',

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/lambda.driver.ts
@@ -59,6 +59,7 @@ const YARN_INSTALL_LAMBDA_MEMORY_MB = 1024;
 const COMMON_LAYER_NAME_PREFIX = 'twenty-common-layer';
 const BUILDER_LAMBDA_TIMEOUT_SECONDS = 60;
 const BUILDER_LAMBDA_MEMORY_MB = 512;
+const LAMBDA_EPHEMERAL_STORAGE_MB = 2048;
 
 const YARN_INSTALL_HANDLER_PATH = resolve(
   __dirname,
@@ -390,6 +391,7 @@ export class LambdaDriver implements LogicFunctionDriver {
         Runtime: LogicFunctionRuntime.NODE22,
         Timeout: YARN_INSTALL_LAMBDA_TIMEOUT_SECONDS,
         MemorySize: YARN_INSTALL_LAMBDA_MEMORY_MB,
+        EphemeralStorage: { Size: LAMBDA_EPHEMERAL_STORAGE_MB },
       };
 
       await lambdaClient.send(new CreateFunctionCommand(params));
@@ -479,6 +481,7 @@ export class LambdaDriver implements LogicFunctionDriver {
         Runtime: LogicFunctionRuntime.NODE22,
         Timeout: BUILDER_LAMBDA_TIMEOUT_SECONDS,
         MemorySize: BUILDER_LAMBDA_MEMORY_MB,
+        EphemeralStorage: { Size: LAMBDA_EPHEMERAL_STORAGE_MB },
       };
 
       await lambdaClient.send(new CreateFunctionCommand(params));
@@ -934,6 +937,7 @@ export class LambdaDriver implements LogicFunctionDriver {
         Role: this.options.lambdaRole,
         Runtime: flatLogicFunction.runtime,
         Timeout: 900,
+        EphemeralStorage: { Size: LAMBDA_EPHEMERAL_STORAGE_MB },
       };
 
       const command = new CreateFunctionCommand(params);

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/local.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/local.driver.ts
@@ -151,7 +151,7 @@ export class LocalDriver implements LogicFunctionDriver {
         outfile: builtBundleFilePath,
         platform: 'node',
         format: 'esm',
-        target: 'es2022',
+        target: 'esnext',
         bundle: true,
         sourcemap: true,
         packages: 'external',

--- a/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/local.driver.ts
+++ b/packages/twenty-server/src/engine/core-modules/logic-function/logic-function-drivers/drivers/local.driver.ts
@@ -151,7 +151,7 @@ export class LocalDriver implements LogicFunctionDriver {
         outfile: builtBundleFilePath,
         platform: 'node',
         format: 'esm',
-        target: 'es2017',
+        target: 'es2022',
         bundle: true,
         sourcemap: true,
         packages: 'external',


### PR DESCRIPTION
# Size issue
```
Yarn install Lambda failed: {"errorType":"Error","errorMessage":"yarn install failed: ➤ Y/tmp/3bac8baafe6354db414389434726b02c/nodejs/node_modules/tar ENOSPC: no space left on device, write","➤ YN0000: └ Completed in 3s 57ms","➤ YN0000: · Failed with errors in 11s 684ms",""," at runYarnInstall (file:///var/task/index.mjs:48:11)"," at process.processTicksAndRejections (node:internal/process/task_queues:105:5)"," at async Runtime.handler (file:///var/task/index.mjs:119:5)"]}
```

# target esnext
setting the same target for each logic function build funnels
- sdk
- local driver
- lambda driver