### PR TITLE
fix(ai): inline $ref/$defs in tool schemas for Gemini compatibility

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/tool-provider/providers/database-tool.provider.ts
+++ b/packages/twenty-server/src/engine/core-modules/tool-provider/providers/database-tool.provider.ts
@@ -19,6 +19,7 @@ import { generateUpdateRecordInputSchema } from 'src/engine/core-modules/record-
 import { DeleteToolInputSchema } from 'src/engine/core-modules/record-crud/zod-schemas/delete-tool.zod-schema';
 import { FindOneToolInputSchema } from 'src/engine/core-modules/record-crud/zod-schemas/find-one-tool.zod-schema';
 import { generateFindToolInputSchema } from 'src/engine/core-modules/record-crud/zod-schemas/find-tool.zod-schema';
+import { sanitizeJsonSchemaForGemini } from 'src/engine/metadata-modules/ai/ai-models/utils/sanitize-tools-for-gemini.util';
 import { ToolCategory } from 'twenty-shared/ai';
 import { type ToolDescriptor } from 'src/engine/core-modules/tool-provider/types/tool-descriptor.type';
 import { type ToolIndexEntry } from 'src/engine/core-modules/tool-provider/types/tool-index-entry.type';
@@ -108,9 +109,9 @@ export class DatabaseToolProvider implements ToolProvider {
           description: `Search for ${objectMetadata.labelPlural} records using flexible filtering criteria. Supports exact matches, pattern matching, ranges, and null checks. Use limit/offset for pagination and orderBy for sorting. To find by ID, use filter: { id: { eq: "record-id" } }. Returns an array of matching records with their full data.`,
           category: ToolCategory.DATABASE_CRUD,
           ...(includeSchemas && {
-            inputSchema: z.toJSONSchema(
+            inputSchema: sanitizeJsonSchemaForGemini(z.toJSONSchema(
               generateFindToolInputSchema(objectMetadata, restrictedFields),
-            ),
+            )),
           }),
           executionRef: {
             kind: 'database_crud',
@@ -127,7 +128,7 @@ export class DatabaseToolProvider implements ToolProvider {
           description: `Retrieve a single ${objectMetadata.labelSingular} record by its unique ID. Use this when you know the exact record ID and need the complete record data. Returns the full record or an error if not found.`,
           category: ToolCategory.DATABASE_CRUD,
           ...(includeSchemas && {
-            inputSchema: z.toJSONSchema(FindOneToolInputSchema),
+            inputSchema: sanitizeJsonSchemaForGemini(z.toJSONSchema(FindOneToolInputSchema)),
           }),
           executionRef: {
             kind: 'database_crud',
@@ -146,9 +147,9 @@ export class DatabaseToolProvider implements ToolProvider {
           description: `Create a new ${objectMetadata.labelSingular} record. Provide all required fields and any optional fields you want to set. The system will automatically handle timestamps and IDs. Returns the created record with all its data.`,
           category: ToolCategory.DATABASE_CRUD,
           ...(includeSchemas && {
-            inputSchema: z.toJSONSchema(
+            inputSchema: sanitizeJsonSchemaForGemini(z.toJSONSchema(
               generateCreateRecordInputSchema(objectMetadata, restrictedFields),
-            ),
+            )),
           }),
           executionRef: {
             kind: 'database_crud',
@@ -165,12 +166,12 @@ export class DatabaseToolProvider implements ToolProvider {
           description: `Create multiple ${objectMetadata.labelPlural} records in a single call. Provide an array of records, each containing the required fields. Maximum 20 records per call. Returns the created records.`,
           category: ToolCategory.DATABASE_CRUD,
           ...(includeSchemas && {
-            inputSchema: z.toJSONSchema(
+            inputSchema: sanitizeJsonSchemaForGemini(z.toJSONSchema(
               generateCreateManyRecordInputSchema(
                 objectMetadata,
                 restrictedFields,
               ),
-            ),
+            )),
           }),
           executionRef: {
             kind: 'database_crud',
@@ -187,9 +188,9 @@ export class DatabaseToolProvider implements ToolProvider {
           description: `Update an existing ${objectMetadata.labelSingular} record. Provide the record ID and only the fields you want to change. Unspecified fields will remain unchanged. Returns the updated record with all current data.`,
           category: ToolCategory.DATABASE_CRUD,
           ...(includeSchemas && {
-            inputSchema: z.toJSONSchema(
+            inputSchema: sanitizeJsonSchemaForGemini(z.toJSONSchema(
               generateUpdateRecordInputSchema(objectMetadata, restrictedFields),
-            ),
+            )),
           }),
           executionRef: {
             kind: 'database_crud',
@@ -206,12 +207,12 @@ export class DatabaseToolProvider implements ToolProvider {
           description: `Update multiple ${objectMetadata.labelPlural} records matching a filter in a single operation. All matching records will receive the same field values. WARNING: Use specific filters to avoid unintended mass updates. Always verify the filter scope with a find query first. Returns the updated records.`,
           category: ToolCategory.DATABASE_CRUD,
           ...(includeSchemas && {
-            inputSchema: z.toJSONSchema(
+            inputSchema: sanitizeJsonSchemaForGemini(z.toJSONSchema(
               generateUpdateManyRecordInputSchema(
                 objectMetadata,
                 restrictedFields,
               ),
-            ),
+            )),
           }),
           executionRef: {
             kind: 'database_crud',
@@ -230,7 +231,7 @@ export class DatabaseToolProvider implements ToolProvider {
           description: `Delete a ${objectMetadata.labelSingular} record by marking it as deleted. The record is hidden from normal queries. This is reversible. Use this to remove records.`,
           category: ToolCategory.DATABASE_CRUD,
           ...(includeSchemas && {
-            inputSchema: z.toJSONSchema(DeleteToolInputSchema),
+            inputSchema: sanitizeJsonSchemaForGemini(z.toJSONSchema(DeleteToolInputSchema)),
           }),
           executionRef: {
             kind: 'database_crud',

--- a/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/utils/sanitize-tools-for-gemini.util.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/ai/ai-models/utils/sanitize-tools-for-gemini.util.ts
@@ -1,0 +1,60 @@
+type PlainObject = Record<string, unknown>;
+
+// Recursively resolves $ref and removes $defs from a JSON Schema.
+// Handles recursive schemas by breaking cycles with { type: "object" }.
+const inlineRefs = (
+  node: unknown,
+  defs: PlainObject,
+  resolving: Set<string>,
+): unknown => {
+  if (node === null || typeof node !== 'object') return node;
+
+  if (Array.isArray(node)) {
+    return node.map((item) => inlineRefs(item, defs, resolving));
+  }
+
+  const obj = node as PlainObject;
+
+  if (typeof obj.$ref === 'string') {
+    const name = obj.$ref.replace(/^#\/\$defs\//, '');
+
+    if (resolving.has(name)) {
+      return { type: 'object' };
+    }
+
+    const resolved = defs[name];
+
+    if (resolved === undefined) return obj;
+
+    const nextResolving = new Set(resolving);
+
+    nextResolving.add(name);
+
+    return inlineRefs(resolved, defs, nextResolving);
+  }
+
+  const localDefs: PlainObject = {
+    ...defs,
+    ...((obj.$defs as PlainObject) ?? {}),
+  };
+
+  const result: PlainObject = {};
+
+  for (const [key, value] of Object.entries(obj)) {
+    if (key === '$defs') continue;
+    result[key] = inlineRefs(value, localDefs, resolving);
+  }
+
+  return result;
+};
+
+// Removes $defs/$ref from a JSON Schema, inlining definitions.
+// Recursive references are truncated to { type: "object" }.
+export const sanitizeJsonSchemaForGemini = (
+  schema: PlainObject,
+): PlainObject => {
+  const defs = (schema.$defs as PlainObject) ?? {};
+
+  return inlineRefs(schema, defs, new Set()) as PlainObject;
+};
+


### PR DESCRIPTION
I've already discussed this issue with @FelixMalfait . My fix might not be the right way, aiming to let teams know there is this issue in gemini api.
**Related issue:** https://github.com/pydantic/pydantic-ai/issues/1598

**Reproduction**: use a Gemini API key, pick gemini-2.5-flash, ask the AI to find a contact (e.g. "find Mark Young"). The UI freezes and the backend logs errors.

## Summary:

Gemini's API does not support $ref/$defs in JSON Schema for tool definitions, causing 400 errors when using Gemini models with database CRUD tools
Added sanitizeJsonSchemaForGemini utility that recursively inlines all $ref references and removes $defs, with cycle detection for recursive schemas

## Before
<img width="463" height="759" alt="image" src="https://github.com/user-attachments/assets/6a62103b-36ed-4ffb-b9db-dc74f3d134db" />


## After
<img width="477" height="732" alt="after" src="https://github.com/user-attachments/assets/f50f3c0e-edb7-4835-bde1-58a19ba98dab" />



backend logs:
```json
[1] [Nest] 74401  - 02/04/2026, 20:52:11     LOG [ChatExecutionService] Starting chat execution with model google/gemini-2.5-flash, 4 active tools
[1] APICallError [AI_APICallError]: The referenced name `#/$defs/__schema0` in function_response.response does not match to a display_name in the function_response.parts.
[1]     at /Users/abel/Documents/Code/twenty/node_modules/@ai-sdk/provider-utils/dist/index.js:2530:14
[1]     at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
[1]     at async postToApi (/Users/abel/Documents/Code/twenty/node_modules/@ai-sdk/provider-utils/dist/index.js:2373:28)
[1]     at async GoogleGenerativeAILanguageModel.doStream (/Users/abel/Documents/Code/twenty/node_modules/@ai-sdk/google/dist/index.js:1141:50)
[1]     at async fn (/Users/abel/Documents/Code/twenty/node_modules/ai/dist/index.js:7106:27)
[1]     at async /Users/abel/Documents/Code/twenty/node_modules/ai/dist/index.js:2340:24
[1]     at async _retryWithExponentialBackoff (/Users/abel/Documents/Code/twenty/node_modules/ai/dist/index.js:2599:12)
[1]     at async streamStep (/Users/abel/Documents/Code/twenty/node_modules/ai/dist/index.js:7063:17)
[1]     at async Object.flush (/Users/abel/Documents/Code/twenty/node_modules/ai/dist/index.js:7425:25) {
[1]   cause: undefined,
[1]   url: 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse',
[1]   requestBodyValues: {
[1]     generationConfig: {
[1]       maxOutputTokens: undefined,
[1]       temperature: undefined,
[1]       topK: undefined,
[1]       topP: undefined,
[1]       frequencyPenalty: undefined,
[1]       presencePenalty: undefined,
[1]       stopSequences: undefined,
[1]       seed: undefined,
[1]       responseMimeType: undefined,
[1]       responseSchema: undefined,
[1]       responseModalities: undefined,
[1]       thinkingConfig: undefined
[1]     },
[1]     contents: [ [Object], [Object], [Object] ],
[1]     systemInstruction: { parts: [Array] },
[1]     safetySettings: undefined,
[1]     tools: [ [Object] ],
[1]     toolConfig: { functionCallingConfig: [Object] },
[1]     cachedContent: undefined,
[1]     labels: undefined
[1]   },
[1]   statusCode: 400,
[1]   responseHeaders: {
[1]     'alt-svc': 'h3=":443"; ma=2592000,h3-29=":443"; ma=2592000',
[1]     'content-length': '224',
[1]     'content-type': 'text/event-stream',
[1]     date: 'Thu, 02 Apr 2026 19:52:13 GMT',
[1]     server: 'scaffolding on HTTPServer2',
[1]     'server-timing': 'gfet4t7; dur=526',
[1]     vary: 'Origin, X-Origin, Referer',
[1]     'x-content-type-options': 'nosniff',
[1]     'x-frame-options': 'SAMEORIGIN',
[1]     'x-xss-protection': '0'
[1]   },
[1]   responseBody: '{\n' +
[1]     '  "error": {\n' +
[1]     '    "code": 400,\n' +
[1]     '    "message": "The referenced name `#/$defs/__schema0` in function_response.response does not match to a display_name in the function_response.parts.",\n' +
[1]     '    "status": "INVALID_ARGUMENT"\n' +
[1]     '  }\n' +
[1]     '}\n',
[1]   isRetryable: false,
[1]   data: {
[1]     error: {
[1]       code: 400,
[1]       message: 'The referenced name `#/$defs/__schema0` in function_response.response does not match to a display_name in the function_response.parts.',
[1]       status: 'INVALID_ARGUMENT'
[1]     }
[1]   },
[1]   Symbol(vercel.ai.error): true,
[1]   Symbol(vercel.ai.error.AI_APICallError): true
[1] }