### PR TITLE
chore: add CD workflow template and point spawn action to main

### DIFF
--- a/packages/create-twenty-app/src/constants/template/github/actions/deploy/action.yml
+++ b/packages/create-twenty-app/src/constants/template/github/actions/deploy/action.yml
@@ -1,0 +1,46 @@
+name: Deploy Twenty App
+description: Build and deploy a Twenty app to a remote instance
+
+inputs:
+  api-url:
+    description: Base URL of the target Twenty instance (e.g. https://my.twenty.instance)
+    required: true
+  api-key:
+    description: API key or access token for the target instance
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Enable Corepack
+      shell: bash
+      run: corepack enable
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version-file: '.nvmrc'
+        cache: yarn
+
+    - name: Install dependencies
+      shell: bash
+      run: yarn install --immutable
+
+    - name: Configure remote
+      shell: bash
+      run: |
+        mkdir -p ~/.twenty
+        node -e "
+          const fs = require('fs'), path = require('path'), os = require('os');
+          fs.writeFileSync(path.join(os.homedir(), '.twenty', 'config.json'), JSON.stringify({
+            version: 1,
+            remotes: { target: { apiUrl: process.env.API_URL, apiKey: process.env.API_KEY } }
+          }, null, 2));
+        "
+      env:
+        API_URL: ${{ inputs.api-url }}
+        API_KEY: ${{ inputs.api-key }}
+
+    - name: Deploy
+      shell: bash
+      run: yarn twenty deploy --remote target

--- a/packages/create-twenty-app/src/constants/template/github/actions/install/action.yml
+++ b/packages/create-twenty-app/src/constants/template/github/actions/install/action.yml
@@ -1,0 +1,46 @@
+name: Install Twenty App
+description: Install (or upgrade) a Twenty app on a specific workspace
+
+inputs:
+  api-url:
+    description: Base URL of the target Twenty instance (e.g. https://my.twenty.instance)
+    required: true
+  api-key:
+    description: API key or access token for the target workspace
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Enable Corepack
+      shell: bash
+      run: corepack enable
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version-file: '.nvmrc'
+        cache: yarn
+
+    - name: Install dependencies
+      shell: bash
+      run: yarn install --immutable
+
+    - name: Configure remote
+      shell: bash
+      run: |
+        mkdir -p ~/.twenty
+        node -e "
+          const fs = require('fs'), path = require('path'), os = require('os');
+          fs.writeFileSync(path.join(os.homedir(), '.twenty', 'config.json'), JSON.stringify({
+            version: 1,
+            remotes: { target: { apiUrl: process.env.API_URL, apiKey: process.env.API_KEY } }
+          }, null, 2));
+        "
+      env:
+        API_URL: ${{ inputs.api-url }}
+        API_KEY: ${{ inputs.api-key }}
+
+    - name: Install
+      shell: bash
+      run: yarn twenty install --remote target

--- a/packages/create-twenty-app/src/constants/template/github/workflows/cd.yml
+++ b/packages/create-twenty-app/src/constants/template/github/workflows/cd.yml
@@ -1,0 +1,61 @@
+name: CD
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: read
+
+env:
+  TWENTY_DEPLOY_URL: http://localhost:3000
+
+concurrency:
+  group: cd-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && github.event.label.name == 'deploy')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Configure remote
+        run: |
+          mkdir -p ~/.twenty
+          node -e "
+            const path = require('path'), os = require('os'), fs = require('fs');
+            fs.writeFileSync(path.join(os.homedir(), '.twenty', 'config.json'), JSON.stringify({
+              version: 1,
+              remotes: { prod: { apiUrl: process.env.TWENTY_DEPLOY_URL, apiKey: process.env.TWENTY_DEPLOY_API_KEY } }
+            }, null, 2));
+          "
+        env:
+          TWENTY_DEPLOY_API_KEY: ${{ secrets.TWENTY_DEPLOY_API_KEY }}
+
+      - name: Deploy
+        run: yarn twenty deploy --remote prod
+
+      - name: Install
+        run: yarn twenty install --remote prod

--- a/packages/create-twenty-app/src/constants/template/github/workflows/cd.yml
+++ b/packages/create-twenty-app/src/constants/template/github/workflows/cd.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  deploy:
+  deploy-and-install:
     if: >-
       github.event_name == 'push' ||
       (github.event_name == 'pull_request' && github.event.label.name == 'deploy')
@@ -29,33 +29,14 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-          cache: yarn
-
-      - name: Install dependencies
-        run: yarn install --immutable
-
-      - name: Configure remote
-        run: |
-          mkdir -p ~/.twenty
-          node -e "
-            const path = require('path'), os = require('os'), fs = require('fs');
-            fs.writeFileSync(path.join(os.homedir(), '.twenty', 'config.json'), JSON.stringify({
-              version: 1,
-              remotes: { prod: { apiUrl: process.env.TWENTY_DEPLOY_URL, apiKey: process.env.TWENTY_DEPLOY_API_KEY } }
-            }, null, 2));
-          "
-        env:
-          TWENTY_DEPLOY_API_KEY: ${{ secrets.TWENTY_DEPLOY_API_KEY }}
-
       - name: Deploy
-        run: yarn twenty deploy --remote prod
+        uses: ./.github/actions/deploy
+        with:
+          api-url: ${{ env.TWENTY_DEPLOY_URL }}
+          api-key: ${{ secrets.TWENTY_DEPLOY_API_KEY }}
 
       - name: Install
-        run: yarn twenty install --remote prod
+        uses: ./.github/actions/install
+        with:
+          api-url: ${{ env.TWENTY_DEPLOY_URL }}
+          api-key: ${{ secrets.TWENTY_DEPLOY_API_KEY }}

--- a/packages/create-twenty-app/src/constants/template/github/workflows/ci.yml
+++ b/packages/create-twenty-app/src/constants/template/github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Spawn Twenty test instance
         id: twenty
-        uses: twentyhq/twenty/.github/actions/spawn-twenty-app-dev-test@feature/sdk-config-file-source-of-truth
+        uses: twentyhq/twenty/.github/actions/spawn-twenty-app-dev-test@main
         with:
           twenty-version: ${{ env.TWENTY_VERSION }}
 

--- a/packages/twenty-apps/examples/hello-world/.github/actions/deploy/action.yml
+++ b/packages/twenty-apps/examples/hello-world/.github/actions/deploy/action.yml
@@ -1,0 +1,46 @@
+name: Deploy Twenty App
+description: Build and deploy a Twenty app to a remote instance
+
+inputs:
+  api-url:
+    description: Base URL of the target Twenty instance (e.g. https://my.twenty.instance)
+    required: true
+  api-key:
+    description: API key or access token for the target instance
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Enable Corepack
+      shell: bash
+      run: corepack enable
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version-file: '.nvmrc'
+        cache: yarn
+
+    - name: Install dependencies
+      shell: bash
+      run: yarn install --immutable
+
+    - name: Configure remote
+      shell: bash
+      run: |
+        mkdir -p ~/.twenty
+        node -e "
+          const fs = require('fs'), path = require('path'), os = require('os');
+          fs.writeFileSync(path.join(os.homedir(), '.twenty', 'config.json'), JSON.stringify({
+            version: 1,
+            remotes: { target: { apiUrl: process.env.API_URL, apiKey: process.env.API_KEY } }
+          }, null, 2));
+        "
+      env:
+        API_URL: ${{ inputs.api-url }}
+        API_KEY: ${{ inputs.api-key }}
+
+    - name: Deploy
+      shell: bash
+      run: yarn twenty deploy --remote target

--- a/packages/twenty-apps/examples/hello-world/.github/actions/install/action.yml
+++ b/packages/twenty-apps/examples/hello-world/.github/actions/install/action.yml
@@ -1,0 +1,46 @@
+name: Install Twenty App
+description: Install (or upgrade) a Twenty app on a specific workspace
+
+inputs:
+  api-url:
+    description: Base URL of the target Twenty instance (e.g. https://my.twenty.instance)
+    required: true
+  api-key:
+    description: API key or access token for the target workspace
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Enable Corepack
+      shell: bash
+      run: corepack enable
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version-file: '.nvmrc'
+        cache: yarn
+
+    - name: Install dependencies
+      shell: bash
+      run: yarn install --immutable
+
+    - name: Configure remote
+      shell: bash
+      run: |
+        mkdir -p ~/.twenty
+        node -e "
+          const fs = require('fs'), path = require('path'), os = require('os');
+          fs.writeFileSync(path.join(os.homedir(), '.twenty', 'config.json'), JSON.stringify({
+            version: 1,
+            remotes: { target: { apiUrl: process.env.API_URL, apiKey: process.env.API_KEY } }
+          }, null, 2));
+        "
+      env:
+        API_URL: ${{ inputs.api-url }}
+        API_KEY: ${{ inputs.api-key }}
+
+    - name: Install
+      shell: bash
+      run: yarn twenty install --remote target

--- a/packages/twenty-apps/examples/hello-world/.github/workflows/cd.yml
+++ b/packages/twenty-apps/examples/hello-world/.github/workflows/cd.yml
@@ -1,0 +1,61 @@
+name: CD
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: read
+
+env:
+  TWENTY_DEPLOY_URL: http://localhost:3000
+
+concurrency:
+  group: cd-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && github.event.label.name == 'deploy')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Configure remote
+        run: |
+          mkdir -p ~/.twenty
+          node -e "
+            const path = require('path'), os = require('os'), fs = require('fs');
+            fs.writeFileSync(path.join(os.homedir(), '.twenty', 'config.json'), JSON.stringify({
+              version: 1,
+              remotes: { prod: { apiUrl: process.env.TWENTY_DEPLOY_URL, apiKey: process.env.TWENTY_DEPLOY_API_KEY } }
+            }, null, 2));
+          "
+        env:
+          TWENTY_DEPLOY_API_KEY: ${{ secrets.TWENTY_DEPLOY_API_KEY }}
+
+      - name: Deploy
+        run: yarn twenty deploy --remote prod
+
+      - name: Install
+        run: yarn twenty install --remote prod

--- a/packages/twenty-apps/examples/hello-world/.github/workflows/cd.yml
+++ b/packages/twenty-apps/examples/hello-world/.github/workflows/cd.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  deploy:
+  deploy-and-install:
     if: >-
       github.event_name == 'push' ||
       (github.event_name == 'pull_request' && github.event.label.name == 'deploy')
@@ -29,33 +29,14 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-          cache: yarn
-
-      - name: Install dependencies
-        run: yarn install --immutable
-
-      - name: Configure remote
-        run: |
-          mkdir -p ~/.twenty
-          node -e "
-            const path = require('path'), os = require('os'), fs = require('fs');
-            fs.writeFileSync(path.join(os.homedir(), '.twenty', 'config.json'), JSON.stringify({
-              version: 1,
-              remotes: { prod: { apiUrl: process.env.TWENTY_DEPLOY_URL, apiKey: process.env.TWENTY_DEPLOY_API_KEY } }
-            }, null, 2));
-          "
-        env:
-          TWENTY_DEPLOY_API_KEY: ${{ secrets.TWENTY_DEPLOY_API_KEY }}
-
       - name: Deploy
-        run: yarn twenty deploy --remote prod
+        uses: ./.github/actions/deploy
+        with:
+          api-url: ${{ env.TWENTY_DEPLOY_URL }}
+          api-key: ${{ secrets.TWENTY_DEPLOY_API_KEY }}
 
       - name: Install
-        run: yarn twenty install --remote prod
+        uses: ./.github/actions/install
+        with:
+          api-url: ${{ env.TWENTY_DEPLOY_URL }}
+          api-key: ${{ secrets.TWENTY_DEPLOY_API_KEY }}

--- a/packages/twenty-apps/examples/hello-world/.github/workflows/ci.yml
+++ b/packages/twenty-apps/examples/hello-world/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Spawn Twenty test instance
         id: twenty
-        uses: twentyhq/twenty/.github/actions/spawn-twenty-app-dev-test@feature/sdk-config-file-source-of-truth
+        uses: twentyhq/twenty/.github/actions/spawn-twenty-app-dev-test@main
         with:
           twenty-version: ${{ env.TWENTY_VERSION }}
 

--- a/packages/twenty-apps/examples/postcard/.github/actions/deploy/action.yml
+++ b/packages/twenty-apps/examples/postcard/.github/actions/deploy/action.yml
@@ -1,0 +1,46 @@
+name: Deploy Twenty App
+description: Build and deploy a Twenty app to a remote instance
+
+inputs:
+  api-url:
+    description: Base URL of the target Twenty instance (e.g. https://my.twenty.instance)
+    required: true
+  api-key:
+    description: API key or access token for the target instance
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Enable Corepack
+      shell: bash
+      run: corepack enable
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version-file: '.nvmrc'
+        cache: yarn
+
+    - name: Install dependencies
+      shell: bash
+      run: yarn install --immutable
+
+    - name: Configure remote
+      shell: bash
+      run: |
+        mkdir -p ~/.twenty
+        node -e "
+          const fs = require('fs'), path = require('path'), os = require('os');
+          fs.writeFileSync(path.join(os.homedir(), '.twenty', 'config.json'), JSON.stringify({
+            version: 1,
+            remotes: { target: { apiUrl: process.env.API_URL, apiKey: process.env.API_KEY } }
+          }, null, 2));
+        "
+      env:
+        API_URL: ${{ inputs.api-url }}
+        API_KEY: ${{ inputs.api-key }}
+
+    - name: Deploy
+      shell: bash
+      run: yarn twenty deploy --remote target

--- a/packages/twenty-apps/examples/postcard/.github/actions/install/action.yml
+++ b/packages/twenty-apps/examples/postcard/.github/actions/install/action.yml
@@ -1,0 +1,46 @@
+name: Install Twenty App
+description: Install (or upgrade) a Twenty app on a specific workspace
+
+inputs:
+  api-url:
+    description: Base URL of the target Twenty instance (e.g. https://my.twenty.instance)
+    required: true
+  api-key:
+    description: API key or access token for the target workspace
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Enable Corepack
+      shell: bash
+      run: corepack enable
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version-file: '.nvmrc'
+        cache: yarn
+
+    - name: Install dependencies
+      shell: bash
+      run: yarn install --immutable
+
+    - name: Configure remote
+      shell: bash
+      run: |
+        mkdir -p ~/.twenty
+        node -e "
+          const fs = require('fs'), path = require('path'), os = require('os');
+          fs.writeFileSync(path.join(os.homedir(), '.twenty', 'config.json'), JSON.stringify({
+            version: 1,
+            remotes: { target: { apiUrl: process.env.API_URL, apiKey: process.env.API_KEY } }
+          }, null, 2));
+        "
+      env:
+        API_URL: ${{ inputs.api-url }}
+        API_KEY: ${{ inputs.api-key }}
+
+    - name: Install
+      shell: bash
+      run: yarn twenty install --remote target

--- a/packages/twenty-apps/examples/postcard/.github/workflows/cd.yml
+++ b/packages/twenty-apps/examples/postcard/.github/workflows/cd.yml
@@ -1,0 +1,61 @@
+name: CD
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: read
+
+env:
+  TWENTY_DEPLOY_URL: http://localhost:3000
+
+concurrency:
+  group: cd-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && github.event.label.name == 'deploy')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Configure remote
+        run: |
+          mkdir -p ~/.twenty
+          node -e "
+            const path = require('path'), os = require('os'), fs = require('fs');
+            fs.writeFileSync(path.join(os.homedir(), '.twenty', 'config.json'), JSON.stringify({
+              version: 1,
+              remotes: { prod: { apiUrl: process.env.TWENTY_DEPLOY_URL, apiKey: process.env.TWENTY_DEPLOY_API_KEY } }
+            }, null, 2));
+          "
+        env:
+          TWENTY_DEPLOY_API_KEY: ${{ secrets.TWENTY_DEPLOY_API_KEY }}
+
+      - name: Deploy
+        run: yarn twenty deploy --remote prod
+
+      - name: Install
+        run: yarn twenty install --remote prod

--- a/packages/twenty-apps/examples/postcard/.github/workflows/cd.yml
+++ b/packages/twenty-apps/examples/postcard/.github/workflows/cd.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  deploy:
+  deploy-and-install:
     if: >-
       github.event_name == 'push' ||
       (github.event_name == 'pull_request' && github.event.label.name == 'deploy')
@@ -29,33 +29,14 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-          cache: yarn
-
-      - name: Install dependencies
-        run: yarn install --immutable
-
-      - name: Configure remote
-        run: |
-          mkdir -p ~/.twenty
-          node -e "
-            const path = require('path'), os = require('os'), fs = require('fs');
-            fs.writeFileSync(path.join(os.homedir(), '.twenty', 'config.json'), JSON.stringify({
-              version: 1,
-              remotes: { prod: { apiUrl: process.env.TWENTY_DEPLOY_URL, apiKey: process.env.TWENTY_DEPLOY_API_KEY } }
-            }, null, 2));
-          "
-        env:
-          TWENTY_DEPLOY_API_KEY: ${{ secrets.TWENTY_DEPLOY_API_KEY }}
-
       - name: Deploy
-        run: yarn twenty deploy --remote prod
+        uses: ./.github/actions/deploy
+        with:
+          api-url: ${{ env.TWENTY_DEPLOY_URL }}
+          api-key: ${{ secrets.TWENTY_DEPLOY_API_KEY }}
 
       - name: Install
-        run: yarn twenty install --remote prod
+        uses: ./.github/actions/install
+        with:
+          api-url: ${{ env.TWENTY_DEPLOY_URL }}
+          api-key: ${{ secrets.TWENTY_DEPLOY_API_KEY }}

--- a/packages/twenty-apps/examples/postcard/.github/workflows/ci.yml
+++ b/packages/twenty-apps/examples/postcard/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Spawn Twenty test instance
         id: twenty
-        uses: twentyhq/twenty/.github/actions/spawn-twenty-app-dev-test@feature/sdk-config-file-source-of-truth
+        uses: twentyhq/twenty/.github/actions/spawn-twenty-app-dev-test@main
         with:
           twenty-version: ${{ env.TWENTY_VERSION }}
 


### PR DESCRIPTION
## Summary

- Adds reusable composite GitHub Actions for Twenty app deployment:
  - `.github/actions/deploy` — builds and deploys to a remote instance (`api-url`, `api-key` inputs)
  - `.github/actions/install` — installs/upgrades on a specific workspace (`api-url`, `api-key` inputs)
- Adds a `cd.yml` CD workflow that calls both actions in sequence. The workflow:
  - Deploys on push to `main`
  - Can be triggered from a PR by adding a `deploy` label
  - Configures a named remote via `TWENTY_DEPLOY_URL` env var and `TWENTY_DEPLOY_API_KEY` secret
- Applied to: `create-twenty-app` template, `postcard` example, `hello-world` example
- Updates the `spawn-twenty-app-dev-test` action ref from `@feature/sdk-config-file-source-of-truth` to `@main` in all `ci.yml` files